### PR TITLE
Generate a nupkg for Microsoft.DotNet.Core.Sdk.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,6 +9,10 @@
     <OutDir Condition="'$(OutDir)' == ''">$([System.IO.Path]::GetFullPath('$(RepositoryRootDirectory)bin\$(Configuration)'))\</OutDir>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)' == ''">$([System.IO.Path]::GetFullPath('$(RepositoryRootDirectory)bin\obj\$(MSBuildProjectName)'))\</BaseIntermediateOutputPath>
 
+    <VersionPrefix Condition="'$(VersionPrefix)' == ''">1.0.0</VersionPrefix>
+    <VersionSuffix Condition="'$(VersionSuffix)' == ''">alpha-00001</VersionSuffix>
+    <Version Condition="'$(Version)' == ''">$(VersionPrefix)-$(VersionSuffix)</Version>
+    
     <DotNet_Install_Dir Condition=" '$(DotNet_Install_Dir)' == ''">$(RepositoryRootDirectory).dotnet_cli\</DotNet_Install_Dir>
     <DotNetTool>$(DotNet_Install_Dir)\dotnet</DotNetTool>
   </PropertyGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,15 @@
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" TreatAsLocalProperty="OutDir;Configuration">
+  <!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
+  <!-- This file is imported by all projects at the beginning of the project files -->
+
+  <PropertyGroup>
+    <RepositoryRootDirectory>$(MSBuildThisFileDirectory)</RepositoryRootDirectory>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+
+    <OutDir Condition="'$(OutDir)' == ''">$([System.IO.Path]::GetFullPath('$(RepositoryRootDirectory)bin\$(Configuration)'))\</OutDir>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)' == ''">$([System.IO.Path]::GetFullPath('$(RepositoryRootDirectory)bin\obj\$(MSBuildProjectName)'))\</BaseIntermediateOutputPath>
+
+    <DotNet_Install_Dir Condition=" '$(DotNet_Install_Dir)' == ''">$(RepositoryRootDirectory).dotnet_cli\</DotNet_Install_Dir>
+    <DotNetTool>$(DotNet_Install_Dir)\dotnet</DotNetTool>
+  </PropertyGroup>
+</Project>

--- a/build.ps1
+++ b/build.ps1
@@ -47,9 +47,6 @@ $env:PATH = "$env:DOTNET_INSTALL_DIR;$env:PATH"
 # Disable first run since we want to control all package sources
 $env:DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
 
-dotnet restore $RepoRoot
-if($LASTEXITCODE -ne 0) { throw "Failed to restore" }
-
 # TODO: https://github.com/dotnet/sdk/issues/13 add back `/m` when the MSBuild hang is fixed
-dotnet build3 $RepoRoot\core-sdk.sln /nologo /p:Configuration=$Configuration /p:Platform=$Platform
+dotnet build3 $RepoRoot\build\build.proj /nologo /p:Configuration=$Configuration /p:Platform=$Platform
 if($LASTEXITCODE -ne 0) { throw "Failed to build" }

--- a/build/Nuget/Microsoft.DotNet.Core.Nuget.proj
+++ b/build/Nuget/Microsoft.DotNet.Core.Nuget.proj
@@ -4,7 +4,6 @@
 
   <PropertyGroup>
     <NuGetOutDir>$(OutDir)Packages\</NuGetOutDir>
-    <Version>1.0.0</Version>
   </PropertyGroup>
 
   <ItemGroup>
@@ -29,7 +28,7 @@
 
     <PropertyGroup>
       <DotNetSdkPath>$(DotNet_Install_Dir)\sdk\@(CLIVersion)\</DotNetSdkPath>
-      <NuGetTool>$(DotNetTool) exec --runtimeconfig $(DotNetSdkPath)\dotnet.runtimeconfig.json $(DotNetSdkPath)\NuGet.CommandLine.XPlat.dll</NuGetTool>
+      <NuGetTool>$(DotNetTool) exec --runtimeconfig $(DotNetSdkPath)\dotnet.runtimeconfig.json --depsfile $(DotNetSdkPath)\dotnet.deps.json $(DotNetSdkPath)\NuGet.CommandLine.XPlat.dll</NuGetTool>
     </PropertyGroup>
 
     <MakeDir Directories="$(NuGetOutDir)" />

--- a/build/Nuget/Microsoft.DotNet.Core.Nuget.proj
+++ b/build/Nuget/Microsoft.DotNet.Core.Nuget.proj
@@ -1,17 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-  </PropertyGroup>
-
-  <ImportGroup>
-    <Import Project="..\Targets\Settings.targets" />
-  </ImportGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'Directory.Build.props'))\Directory.Build.props" />
 
   <PropertyGroup>
-    <RepoRoot>$(MSBuildThisFileDirectory)..\..\</RepoRoot>
-    <DOTNET_INSTALL_DIR Condition=" '$(DOTNET_INSTALL_DIR)' == ''">$(RepositoryRootDirectory)\.dotnet_cli\</DOTNET_INSTALL_DIR>
-    <DotNetTool>$(DOTNET_INSTALL_DIR)dotnet</DotNetTool>
     <NuGetOutDir>$(OutDir)Packages\</NuGetOutDir>
     <Version>1.0.0</Version>
   </PropertyGroup>
@@ -32,12 +23,12 @@
 
   <Target Name="Build" Inputs="@(NuSpec);@(PackageAssets)" Outputs="@(NuSpec->'%(NuPkgOutput)')" DependsOnTargets="LogOutput">
 
-    <ReadLinesFromFile File="$(RepoRoot)DotnetCLIVersion.txt">
+    <ReadLinesFromFile File="$(RepositoryRootDirectory)DotnetCLIVersion.txt">
       <Output TaskParameter="Lines" ItemName="CLIVersion" />
     </ReadLinesFromFile>
 
     <PropertyGroup>
-      <DotNetSdkPath>$(DOTNET_INSTALL_DIR)sdk\@(CLIVersion)\</DotNetSdkPath>
+      <DotNetSdkPath>$(DotNet_Install_Dir)\sdk\@(CLIVersion)\</DotNetSdkPath>
       <NuGetTool>$(DotNetTool) exec --runtimeconfig $(DotNetSdkPath)\dotnet.runtimeconfig.json $(DotNetSdkPath)\NuGet.CommandLine.XPlat.dll</NuGetTool>
     </PropertyGroup>
 

--- a/build/Nuget/Microsoft.DotNet.Core.Nuget.proj
+++ b/build/Nuget/Microsoft.DotNet.Core.Nuget.proj
@@ -10,8 +10,8 @@
 
   <PropertyGroup>
     <RepoRoot>$(MSBuildThisFileDirectory)..\..\</RepoRoot>
-    <DotNetPath>$(RepoRoot).dotnet_cli\</DotNetPath>
-    <DotNetTool>$(DotNetPath)dotnet</DotNetTool>
+    <DOTNET_INSTALL_DIR Condition=" '$(DOTNET_INSTALL_DIR)' == ''">$(RepositoryRootDirectory)\.dotnet_cli\</DOTNET_INSTALL_DIR>
+    <DotNetTool>$(DOTNET_INSTALL_DIR)dotnet</DotNetTool>
     <NuGetOutDir>$(OutDir)Packages\</NuGetOutDir>
     <Version>1.0.0</Version>
   </PropertyGroup>
@@ -37,7 +37,7 @@
     </ReadLinesFromFile>
 
     <PropertyGroup>
-      <DotNetSdkPath>$(DotNetPath)sdk\@(CLIVersion)\</DotNetSdkPath>
+      <DotNetSdkPath>$(DOTNET_INSTALL_DIR)sdk\@(CLIVersion)\</DotNetSdkPath>
       <NuGetTool>$(DotNetTool) exec --runtimeconfig $(DotNetSdkPath)\dotnet.runtimeconfig.json $(DotNetSdkPath)\NuGet.CommandLine.XPlat.dll</NuGetTool>
     </PropertyGroup>
 

--- a/build/Nuget/Microsoft.DotNet.Core.Nuget.proj
+++ b/build/Nuget/Microsoft.DotNet.Core.Nuget.proj
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+  </PropertyGroup>
+
+  <ImportGroup>
+    <Import Project="..\Targets\Settings.targets" />
+  </ImportGroup>
+
+  <PropertyGroup>
+    <RepoRoot>$(MSBuildThisFileDirectory)..\..\</RepoRoot>
+    <DotNetPath>$(RepoRoot).dotnet_cli\</DotNetPath>
+    <DotNetTool>$(DotNetPath)dotnet</DotNetTool>
+    <NuGetOutDir>$(OutDir)Packages\</NuGetOutDir>
+    <Version>1.0.0</Version>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <NuSpec Include="Microsoft.DotNet.Core.Sdk.nuspec">
+      <NuPkgOutput>$(NuGetOutDir)%(FileName).$(Version).nupkg</NuPkgOutput>
+      <NuGetArguments>--version "$(Version)"</NuGetArguments>
+    </NuSpec>
+
+    <!-- Make note, without actually knowing what's included in the NuSpec, 
+         we just assume that everything in the output dir is, and treat them
+         as inputs so that we rerun packaging if they change. 
+         Long term we'll want to use a packaging project, such as NuProj where 
+         the NuSpec is auto-generated based on the inputs. -->
+    <PackageAssets Include="$(OutDir)\*.*" Exclude="*.log" />
+  </ItemGroup>
+
+  <Target Name="Build" Inputs="@(NuSpec);@(PackageAssets)" Outputs="@(NuSpec->'%(NuPkgOutput)')" DependsOnTargets="LogOutput">
+
+    <ReadLinesFromFile File="$(RepoRoot)DotnetCLIVersion.txt">
+      <Output TaskParameter="Lines" ItemName="CLIVersion" />
+    </ReadLinesFromFile>
+
+    <PropertyGroup>
+      <DotNetSdkPath>$(DotNetPath)sdk\@(CLIVersion)\</DotNetSdkPath>
+      <NuGetTool>$(DotNetTool) exec --runtimeconfig $(DotNetSdkPath)\dotnet.runtimeconfig.json $(DotNetSdkPath)\NuGet.CommandLine.XPlat.dll</NuGetTool>
+    </PropertyGroup>
+
+    <MakeDir Directories="$(NuGetOutDir)" />
+
+    <Exec Command="$(NuGetTool) Pack &quot;$(MSBuildProjectDirectory)\%(NuSpec.Identity)&quot; --verbosity quiet --base-path &quot;$(OutDir.TrimEnd('\'))&quot; --output-directory &quot;$(NuGetOutDir.TrimEnd('\'))&quot; %(NuSpec.NuGetArguments)" />
+  </Target>
+
+  <Target Name="Clean">
+    <Delete Files="%(NuSpec.NuPkgOutput)" />
+  </Target>
+
+  <Target Name="Rebuild" DependsOnTargets="Clean;Build" />
+
+  <Target Name="LogOutput">
+    <Message Importance="High" Text="%(NuSpec.Identity) -> %(NuSpec.NuPkgOutput)'" />
+  </Target>
+
+</Project>

--- a/build/Nuget/Microsoft.DotNet.Core.Sdk.nuspec
+++ b/build/Nuget/Microsoft.DotNet.Core.Sdk.nuspec
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
+  <metadata>
+    <id>Microsoft.DotNet.Core.Sdk</id>
+    <summary>The MSBuild targets and properties for building .NET Core projects.</summary>
+    <description>
+      The MSBuild targets and properties for building .NET Core projects.
+    </description>
+    <language>en-US</language>
+    <version>1.0.0</version>
+    <authors>dotnet</authors>
+    <projectUrl>http://dot.net</projectUrl>
+  </metadata>
+  <files>
+    <file src="Microsoft.DotNet.Core.Build.Tasks.dll" target="tools\netstandard1.3" />
+    <file src="Microsoft.DotNet.Core.Sdk.props" target="build\netstandard1.0" />
+    <file src="Microsoft.DotNet.Core.Sdk.targets" target="build\netstandard1.0" />
+  </files>
+</package>

--- a/build/Nuget/Microsoft.DotNet.Core.Sdk.nuspec
+++ b/build/Nuget/Microsoft.DotNet.Core.Sdk.nuspec
@@ -7,7 +7,7 @@
       The MSBuild targets and properties for building .NET Core projects.
     </description>
     <language>en-US</language>
-    <version>1.0.0</version>
+    <version>$version$</version>
     <authors>dotnet</authors>
     <projectUrl>http://dot.net</projectUrl>
   </metadata>

--- a/build/Targets/Settings.targets
+++ b/build/Targets/Settings.targets
@@ -1,9 +1,0 @@
-<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" TreatAsLocalProperty="OutDir;Configuration">
-  <!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
-  <!-- This file is imported by all projects at the beginning of the project files -->
-
-  <PropertyGroup>
-    <OutDir Condition="'$(OutDir)' == ''">$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)\..\..\bin\$(Configuration)'))\</OutDir>
-    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)' == ''">$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)\..\..\bin\obj\$(MSBuildProjectName)'))\</BaseIntermediateOutputPath>
-  </PropertyGroup>
-</Project>

--- a/build/build.proj
+++ b/build/build.proj
@@ -1,0 +1,73 @@
+<Project
+  xmlns="http://schemas.microsoft.com/developer/msbuild/2003"
+  DefaultTargets="Build"
+  ToolsVersion="14.0">
+
+  <PropertyGroup>
+    <RepositoryRootDirectory>$(MSBuildThisFileDirectory)..\</RepositoryRootDirectory>
+    <DOTNET_INSTALL_DIR Condition=" '$(DOTNET_INSTALL_DIR)' == ''">$(RepositoryRootDirectory)\.dotnet_cli\</DOTNET_INSTALL_DIR>
+    <DotNetTool>$(DOTNET_INSTALL_DIR)dotnet</DotNetTool>
+
+    <CommonMSBuildGlobalProperties>
+      Configuration=$(Configuration);
+    </CommonMSBuildGlobalProperties>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <SolutionFile Include="$(RepositoryRootDirectory)core-sdk.sln" />
+    <NuGetProjectFile Include="$(RepositoryRootDirectory)build\Nuget\Microsoft.DotNet.Core.Nuget.proj" />
+  </ItemGroup>
+
+  <Target Name="RestorePackages">
+
+    <Message Text="Restoring packages for %(SolutionFile.Filename)" Importance="high" />
+    
+    <Exec Command="$(DotNetTool) restore --verbosity Minimal"
+          WorkingDirectory="$(RepositoryRootDirectory)"
+          />
+  </Target>
+
+  <Target Name="BuildSolution">
+
+    <Message Text="Building %(SolutionFile.Filename) [$(Configuration)]" Importance="high" />
+    
+    <MSBuild BuildInParallel="true"
+             Projects="@(SolutionFile)"
+             Targets="Build"
+             Properties="$(CommonMSBuildGlobalProperties)"
+             />
+  </Target>
+
+  <Target Name="RebuildSolution">
+
+    <Message Text="Rebuilding %(SolutionFile.Filename) [$(Configuration)]" Importance="high" />
+
+    <MSBuild BuildInParallel="true"
+             Projects="@(SolutionFile)"
+             Targets="Rebuild"
+             Properties="$(CommonMSBuildGlobalProperties)"
+             />
+  </Target>
+  
+  <Target Name="BuildNuGetPackages">
+
+    <MSBuild BuildInParallel="true"
+             Projects="@(NuGetProjectFile)"
+             Targets="Build"
+             Properties="$(CommonMSBuildGlobalProperties)"
+             />
+  </Target>
+
+  <Target Name="RebuildNuGetPackages">
+
+    <MSBuild BuildInParallel="true"
+             Projects="@(NuGetProjectFile)"
+             Targets="Rebuild"
+             Properties="$(CommonMSBuildGlobalProperties)"
+             />
+  </Target>
+
+  <Target Name="Build" DependsOnTargets="RestorePackages;BuildSolution;BuildNuGetPackages" />
+  <Target Name="Rebuild" DependsOnTargets="RestorePackages;RebuildSolution;RebuildNuGetPackages" />
+
+</Project>

--- a/build/build.proj
+++ b/build/build.proj
@@ -2,12 +2,9 @@
   xmlns="http://schemas.microsoft.com/developer/msbuild/2003"
   DefaultTargets="Build"
   ToolsVersion="14.0">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'Directory.Build.props'))\Directory.Build.props" />
 
   <PropertyGroup>
-    <RepositoryRootDirectory>$(MSBuildThisFileDirectory)..\</RepositoryRootDirectory>
-    <DOTNET_INSTALL_DIR Condition=" '$(DOTNET_INSTALL_DIR)' == ''">$(RepositoryRootDirectory)\.dotnet_cli\</DOTNET_INSTALL_DIR>
-    <DotNetTool>$(DOTNET_INSTALL_DIR)dotnet</DotNetTool>
-
     <CommonMSBuildGlobalProperties>
       Configuration=$(Configuration);
     </CommonMSBuildGlobalProperties>

--- a/core-sdk.sln
+++ b/core-sdk.sln
@@ -14,6 +14,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build", "build", "{50A89C27-BA35-44B2-AC57-E54551791C64}"
+	ProjectSection(SolutionItems) = preProject
+		build\build.proj = build\build.proj
+	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Nuget", "Nuget", "{13EE1E3C-D7F4-48D3-87AE-94CBCCF574E9}"
 	ProjectSection(SolutionItems) = preProject

--- a/core-sdk.sln
+++ b/core-sdk.sln
@@ -11,6 +11,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	ProjectSection(SolutionItems) = preProject
 		build.cmd = build.cmd
 		build.ps1 = build.ps1
+		Directory.Build.props = Directory.Build.props
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build", "build", "{50A89C27-BA35-44B2-AC57-E54551791C64}"

--- a/core-sdk.sln
+++ b/core-sdk.sln
@@ -13,6 +13,14 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		build.ps1 = build.ps1
 	EndProjectSection
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build", "build", "{50A89C27-BA35-44B2-AC57-E54551791C64}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Nuget", "Nuget", "{13EE1E3C-D7F4-48D3-87AE-94CBCCF574E9}"
+	ProjectSection(SolutionItems) = preProject
+		build\Nuget\Microsoft.DotNet.Core.Nuget.proj = build\Nuget\Microsoft.DotNet.Core.Nuget.proj
+		build\Nuget\Microsoft.DotNet.Core.Sdk.nuspec = build\Nuget\Microsoft.DotNet.Core.Sdk.nuspec
+	EndProjectSection
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.DotNet.Core.Build.Tasks.UnitTests", "src\Tasks\Microsoft.DotNet.Core.Build.Tasks.UnitTests\Microsoft.DotNet.Core.Build.Tasks.UnitTests.csproj", "{6A698C1D-F604-4295-B6FC-7FC726F9FE5F}"
 EndProject
 Global
@@ -35,6 +43,7 @@ Global
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{DF7D2697-B3B4-45C2-8297-27245F528A99} = {1FEED16D-E07D-47C1-BB4C-56CD9F42B53B}
+		{13EE1E3C-D7F4-48D3-87AE-94CBCCF574E9} = {50A89C27-BA35-44B2-AC57-E54551791C64}
 		{6A698C1D-F604-4295-B6FC-7FC726F9FE5F} = {1FEED16D-E07D-47C1-BB4C-56CD9F42B53B}
 	EndGlobalSection
 EndGlobal

--- a/src/Tasks/Microsoft.DotNet.Core.Build.Tasks.UnitTests/Microsoft.DotNet.Core.Build.Tasks.UnitTests.csproj
+++ b/src/Tasks/Microsoft.DotNet.Core.Build.Tasks.UnitTests/Microsoft.DotNet.Core.Build.Tasks.UnitTests.csproj
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'Directory.Build.props'))\Directory.Build.props" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <Import Project="..\Microsoft.DotNet.Core.Build.Tasks\Microsoft.DotNet.Core.Sdk.props" />
-  <Import Project="..\..\..\build\Targets\Settings.targets" />
   <PropertyGroup>
     <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
     <ProjectGuid>{6A698C1D-F604-4295-B6FC-7FC726F9FE5F}</ProjectGuid>

--- a/src/Tasks/Microsoft.DotNet.Core.Build.Tasks/Microsoft.DotNet.Core.Build.Tasks.csproj
+++ b/src/Tasks/Microsoft.DotNet.Core.Build.Tasks/Microsoft.DotNet.Core.Build.Tasks.csproj
@@ -19,8 +19,12 @@
     <Compile Include="RuntimeConfig.cs" />
     <Compile Include="RuntimeConfigFramework.cs" />
     <Compile Include="RuntimeOptions.cs" />
-    <None Include="Microsoft.DotNet.Core.Sdk.targets" />
-    <None Include="Microsoft.DotNet.Core.Sdk.props" />
+    <None Include="Microsoft.DotNet.Core.Sdk.targets">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Microsoft.DotNet.Core.Sdk.props">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="project.json" />
     <Compile Include="DependencyContextBuilder.cs" />
     <Compile Include="GenerateDepsFile.cs" />

--- a/src/Tasks/Microsoft.DotNet.Core.Build.Tasks/Microsoft.DotNet.Core.Build.Tasks.csproj
+++ b/src/Tasks/Microsoft.DotNet.Core.Build.Tasks/Microsoft.DotNet.Core.Build.Tasks.csproj
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'Directory.Build.props'))\Directory.Build.props" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <Import Project="Microsoft.DotNet.Core.Sdk.props" />
-  <Import Project="..\..\..\build\Targets\Settings.targets" />
   <PropertyGroup>
     <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
     <ProjectGuid>{DF7D2697-B3B4-45C2-8297-27245F528A99}</ProjectGuid>


### PR DESCRIPTION
This adds a project that will generate .nupkgs for us.  I copied some stuff from the roslyn-project-system.  Some I made up (ex. using XPlat NuGet to pack the nuspec).

@davkean @natidea @333fred @brthor @livarcocc @piotrpMSFT
