### PR TITLE
Update DependencyModel to the official package and add dotnet-core feed to the NuGet.config

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -5,8 +5,7 @@
     <clear />
     <add key="nugetbuild" value="https://www.myget.org/F/nugetbuild/api/v3/index.json" />
     <add key="dotnet-buildtools" value="https://dotnet.myget.org/F/dotnet-buildtools/api/v3/index.json" />
-    <!-- TODO: https://github.com/dotnet/sdk/issues/14 dotnet-core-test needs to be changed to dotnet-core once the netstandard1.3 DependencyModel package is available -->
-    <add key="dotnet-core-test" value="https://dotnet.myget.org/F/dotnet-core-test/api/v3/index.json" />
+    <add key="dotnet-core" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
     <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
 </configuration>

--- a/src/Tasks/Microsoft.DotNet.Core.Build.Tasks.UnitTests/project.json
+++ b/src/Tasks/Microsoft.DotNet.Core.Build.Tasks.UnitTests/project.json
@@ -1,7 +1,7 @@
 ﻿{
   "dependencies": {
     "NuGet.ProjectModel": "3.5.0-rc1-1697",
-    "Microsoft.Extensions.DependencyModel": "1.0.1-beta-003393",
+    "Microsoft.Extensions.DependencyModel": "1.0.1-beta-000914",
     "Microsoft.Build.Framework": "0.1.0-preview-00028-160627",
     "Microsoft.Build.Utilities.Core": "0.1.0-preview-00028-160627",
     "xunit": "2.1.0",

--- a/src/Tasks/Microsoft.DotNet.Core.Build.Tasks/project.json
+++ b/src/Tasks/Microsoft.DotNet.Core.Build.Tasks/project.json
@@ -1,7 +1,7 @@
 ﻿{
   "dependencies": {
     "NuGet.ProjectModel": "3.5.0-rc1-1697",
-    "Microsoft.Extensions.DependencyModel": "1.0.1-beta-003393",
+    "Microsoft.Extensions.DependencyModel": "1.0.1-beta-000914",
     "Microsoft.Build.Framework": "0.1.0-preview-00028-160627",
     "Microsoft.Build.Utilities.Core": "0.1.0-preview-00028-160627"
   },


### PR DESCRIPTION
Fix #14.

@brthor @333fred @livarcocc 

Notes: 
1. This looks like a "downgrade" in versions.  This occurred because the library was moved from the CLI to core-setup and the CLI has a higher commit count.  Thus a higher pre-release version.
