### PR TITLE
Allow our Build.Tasks.dll to load successfully by packaging its dependent assemblies along side of it.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -15,5 +15,7 @@
     
     <DotNet_Install_Dir Condition=" '$(DotNet_Install_Dir)' == ''">$(RepositoryRootDirectory).dotnet_cli\</DotNet_Install_Dir>
     <DotNetTool>$(DotNet_Install_Dir)\dotnet</DotNetTool>
+
+    <NuGet_Packages Condition=" '$(NuGet_Packages)' == ''">$(RepositoryRootDirectory)packages\</NuGet_Packages>
   </PropertyGroup>
 </Project>

--- a/build/Nuget/Microsoft.DotNet.Core.Sdk.nuspec
+++ b/build/Nuget/Microsoft.DotNet.Core.Sdk.nuspec
@@ -13,6 +13,25 @@
   </metadata>
   <files>
     <file src="Microsoft.DotNet.Core.Build.Tasks.dll" target="tools\netstandard1.3" />
+
+    <file src="Microsoft.Extensions.DependencyModel.dll" target="tools\netstandard1.3" />
+    <file src="Microsoft.DotNet.PlatformAbstractions.dll" target="tools\netstandard1.3" />
+
+    <file src="NuGet.ProjectModel.dll" target="tools\netstandard1.3" />
+    <file src="NuGet.DependencyResolver.Core.dll" target="tools\netstandard1.3" />
+    <file src="NuGet.LibraryModel.dll" target="tools\netstandard1.3" />
+    <file src="NuGet.Frameworks.dll" target="tools\netstandard1.3" />
+    <file src="NuGet.Protocol.Core.v3.dll" target="tools\netstandard1.3" />
+    <file src="NuGet.Repositories.dll" target="tools\netstandard1.3" />
+    <file src="NuGet.RuntimeModel.dll" target="tools\netstandard1.3" />
+    <file src="NuGet.Common.dll" target="tools\netstandard1.3" />
+    <file src="NuGet.Packaging.dll" target="tools\netstandard1.3" />
+    <file src="NuGet.Protocol.Core.Types.dll" target="tools\netstandard1.3" />
+    <file src="NuGet.Packaging.Core.Types.dll" target="tools\netstandard1.3" />
+    <file src="NuGet.Versioning.dll" target="tools\netstandard1.3" />
+
+    <file src="Newtonsoft.Json.dll" target="tools\netstandard1.3" />
+
     <file src="Microsoft.DotNet.Core.Sdk.props" target="build\netstandard1.0" />
     <file src="Microsoft.DotNet.Core.Sdk.targets" target="build\netstandard1.0" />
   </files>

--- a/src/Tasks/Microsoft.DotNet.Core.Build.Tasks/Microsoft.DotNet.Core.Build.Tasks.csproj
+++ b/src/Tasks/Microsoft.DotNet.Core.Build.Tasks/Microsoft.DotNet.Core.Build.Tasks.csproj
@@ -35,4 +35,53 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="Microsoft.DotNet.Core.Sdk.targets" />
+  
+  <Target Name="AfterBuild">
+    <PropertyGroup>
+      <CoreSetupVersion>1.0.1-beta-000914</CoreSetupVersion>
+      <NuGetVersion>3.5.0-rc1-1697</NuGetVersion>
+    </PropertyGroup>
+    <ItemGroup>
+      <NuGetCopyLocalAssembly Include="NuGet.ProjectModel" />
+      <NuGetCopyLocalAssembly Include="NuGet.DependencyResolver.Core" />
+      <NuGetCopyLocalAssembly Include="NuGet.LibraryModel" />
+      <NuGetCopyLocalAssembly Include="NuGet.Frameworks" />
+      <NuGetCopyLocalAssembly Include="NuGet.Protocol.Core.v3" />
+      <NuGetCopyLocalAssembly Include="NuGet.Repositories" />
+      <NuGetCopyLocalAssembly Include="NuGet.RuntimeModel" />
+      <NuGetCopyLocalAssembly Include="NuGet.Common" />
+      <NuGetCopyLocalAssembly Include="NuGet.Packaging" />
+      <NuGetCopyLocalAssembly Include="NuGet.Protocol.Core.Types" />
+      <NuGetCopyLocalAssembly Include="NuGet.Packaging.Core.Types" />
+      <CopyLocalAssembly Include="@(NuGetCopyLocalAssembly)">
+        <Version>$(NuGetVersion)</Version>
+        <TFM>netstandard1.3</TFM>
+      </CopyLocalAssembly>
+      <CopyLocalAssembly Include="NuGet.Versioning">
+        <Version>$(NuGetVersion)</Version>
+        <TFM>netstandard1.0</TFM>
+      </CopyLocalAssembly>
+
+      <CopyLocalAssembly Include="Microsoft.Extensions.DependencyModel">
+        <Version>$(CoreSetupVersion)</Version>
+        <TFM>netstandard1.3</TFM>
+      </CopyLocalAssembly>
+      <CopyLocalAssembly Include="Microsoft.DotNet.PlatformAbstractions">
+        <Version>$(CoreSetupVersion)</Version>
+        <TFM>netstandard1.3</TFM>
+      </CopyLocalAssembly>
+      
+      <CopyLocalAssembly Include="Newtonsoft.Json">
+        <Version>9.0.1</Version>
+        <TFM>netstandard1.0</TFM>
+      </CopyLocalAssembly>
+
+      <CopyLocalAssembly>
+        <FullFilePath>$(NuGet_Packages)\%(CopyLocalAssembly.Identity)\%(CopyLocalAssembly.Version)\lib\%(CopyLocalAssembly.TFM)\%(CopyLocalAssembly.Identity).dll</FullFilePath>
+      </CopyLocalAssembly>
+    </ItemGroup>
+    
+    <Copy SourceFiles="%(CopyLocalAssembly.FullFilePath)" DestinationFolder="$(OutDir)" />
+  </Target>
+  
 </Project>

--- a/src/Tasks/Microsoft.DotNet.Core.Build.Tasks/Microsoft.DotNet.Core.Sdk.props
+++ b/src/Tasks/Microsoft.DotNet.Core.Build.Tasks/Microsoft.DotNet.Core.Sdk.props
@@ -26,8 +26,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <!-- User-facing configuration-specific defaults -->
   <PropertyGroup>
-    <!-- TODO: This property can't be set in the CLI since ResolveNuGetPackageAssets needs an exact RID from the project.json, and the RID is made up of the PlatformTarget -->
-    <!--<PlatformTarget>AnyCPU</PlatformTarget>-->
+    <PlatformTarget>AnyCPU</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <NoWarn>$(NoWarn);1701</NoWarn>


### PR DESCRIPTION
Our Build.Tasks.dll fails to load when building in VS 2015.  This is because it can't find the assemblies we depend on.  (Also, because I had commented out the property that sets the $(PlatformTarget) to AnyCPU.)

To fix this, I am packaging all our dependent assemblies along with our build tasks library.

In order to make our assembly (which targets netstandard1.3) load in VS 2015, I also needed to copy 3 .NET Framework libraries as well.  I have an email out asking if we need to support VS 2015 or not.  If we do, the correct fix will be to multi-target our Build.Tasks.dll to both net451 and netstandard1.3.

@davkean @natidea @srivatsn @333fred @piotrpMSFT @livarcocc @brthor 
