### PR TITLE
Execute the unit tests during the build.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,6 +2,11 @@
   <!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
   <!-- This file is imported by all projects at the beginning of the project files -->
 
+  <!-- Project language -->
+  <PropertyGroup Condition="'$(ProjectLanguage)' == ''">
+    <ProjectLanguage Condition="'$(MSBuildProjectExtension)' == '.csproj' OR '$(Language)' == 'C#'">CSharp</ProjectLanguage>
+  </PropertyGroup>
+  
   <PropertyGroup>
     <RepositoryRootDirectory>$(MSBuildThisFileDirectory)</RepositoryRootDirectory>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>

--- a/build/Nuget/Microsoft.DotNet.Core.Sdk.nuspec
+++ b/build/Nuget/Microsoft.DotNet.Core.Sdk.nuspec
@@ -32,6 +32,8 @@
 
     <file src="Newtonsoft.Json.dll" target="tools\netstandard1.3" />
 
+    <file src="System.Runtime.Serialization.Primitives.dll" target="tools\netstandard1.3" />
+
     <file src="Microsoft.DotNet.Core.Sdk.props" target="build\netstandard1.0" />
     <file src="Microsoft.DotNet.Core.Sdk.targets" target="build\netstandard1.0" />
   </files>

--- a/build/Targets/ProducesNoOutput.Imports.targets
+++ b/build/Targets/ProducesNoOutput.Imports.targets
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Choose>
+    <When Condition="'$(ProjectLanguage)' == 'CSharp'">
+      <PropertyGroup>
+        <MSBuildTargetsLanguageName>CSharp</MSBuildTargetsLanguageName>
+      </PropertyGroup>
+    </When>
+  </Choose>
+
+  <PropertyGroup>
+    <MSBuildTargetsFilePath>$(MSBuildToolsPath)\Microsoft.$(MSBuildTargetsLanguageName).targets</MSBuildTargetsFilePath>
+  </PropertyGroup>
+
+  <Import Project="$(MSBuildTargetsFilePath)" />
+
+  <PropertyGroup>
+    <TargetPath></TargetPath>    <!-- Prevent projects referencing this from trying to pass us to the compiler -->
+  </PropertyGroup>
+
+  <Target Name="CoreCompile" />                               <!-- Prevent Csc from being called -->
+  <Target Name="GenerateTargetFrameworkMonikerAttribute" />   <!-- Don't generate TFM attribute -->
+  <Target Name="RuntimeImplementationProjectOutputGroup" />   <!-- Group always attempts resolve runtime, regardless of <CopyNuGetImplementations>-->
+
+</Project>

--- a/build/build.proj
+++ b/build/build.proj
@@ -5,6 +5,8 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'Directory.Build.props'))\Directory.Build.props" />
 
   <PropertyGroup>
+    <TestsDirectory>$(RepositoryRootDirectory)bin\$(Configuration)\Tests\</TestsDirectory>
+
     <CommonMSBuildGlobalProperties>
       Configuration=$(Configuration);
     </CommonMSBuildGlobalProperties>
@@ -64,7 +66,37 @@
              />
   </Target>
 
-  <Target Name="Build" DependsOnTargets="RestorePackages;BuildSolution;BuildNuGetPackages" />
-  <Target Name="Rebuild" DependsOnTargets="RestorePackages;RebuildSolution;RebuildNuGetPackages" />
+  <Target Name="Test">
+
+    <ItemGroup>
+      <TestAssembly Include="$(TestsDirectory)*Tests.dll" />
+      <XmlTestFile Include="$(TestsDirectory)TestResults.xml" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProductAssets Include="$(OutDir)\*" />
+    </ItemGroup>
+    
+    <Message Text="Running tests for %(SolutionFile.Filename) [$(Configuration)]" Importance="high" />
+
+    <!-- Copy all the product assemblies to the test directory, so the tests can load them. -->
+    <Copy SourceFiles="@(ProductAssets)"
+          DestinationFolder="$(TestsDirectory)"
+          />
+    
+    <Exec Command="$(DotNetTool) &quot;$(TestsDirectory)\xunit.console.netcore.exe&quot; &quot;@(TestAssembly, '&quot; &quot;')&quot; -xml &quot;@(XmlTestFile)&quot;"
+          LogStandardErrorAsError="true"
+          WorkingDirectory="$(TestsDirectory)"
+          IgnoreExitCode="true"
+          >
+      <Output TaskParameter="ExitCode" PropertyName="ExitCode" />
+    </Exec>
+
+    <Error Text="There were test failures, for full log see %(XmlTestFile.FullPath)" Condition="$(ExitCode) == 1" />
+
+  </Target>
+
+  <Target Name="Build" DependsOnTargets="RestorePackages;BuildSolution;BuildNuGetPackages;Test" />
+  <Target Name="Rebuild" DependsOnTargets="RestorePackages;RebuildSolution;RebuildNuGetPackages;Test" />
 
 </Project>

--- a/core-sdk.sln
+++ b/core-sdk.sln
@@ -27,6 +27,15 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Nuget", "Nuget", "{13EE1E3C
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.DotNet.Core.Build.Tasks.UnitTests", "src\Tasks\Microsoft.DotNet.Core.Build.Tasks.UnitTests\Microsoft.DotNet.Core.Build.Tasks.UnitTests.csproj", "{6A698C1D-F604-4295-B6FC-7FC726F9FE5F}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Dependencies", "Dependencies", "{3B295650-6CBF-486F-9E25-F96EE03B7CAE}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "xUnit.net", "src\Dependencies\xUnit.net\xUnit.net.csproj", "{94F9B889-635A-48A7-A0CB-BAE5D6C9A91A}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Targets", "Targets", "{0C1312C0-0A29-4EB2-8294-6D1C54D78F61}"
+	ProjectSection(SolutionItems) = preProject
+		build\Targets\ProducesNoOutput.Imports.targets = build\Targets\ProducesNoOutput.Imports.targets
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -41,6 +50,10 @@ Global
 		{6A698C1D-F604-4295-B6FC-7FC726F9FE5F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6A698C1D-F604-4295-B6FC-7FC726F9FE5F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6A698C1D-F604-4295-B6FC-7FC726F9FE5F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{94F9B889-635A-48A7-A0CB-BAE5D6C9A91A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{94F9B889-635A-48A7-A0CB-BAE5D6C9A91A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{94F9B889-635A-48A7-A0CB-BAE5D6C9A91A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{94F9B889-635A-48A7-A0CB-BAE5D6C9A91A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -49,5 +62,7 @@ Global
 		{DF7D2697-B3B4-45C2-8297-27245F528A99} = {1FEED16D-E07D-47C1-BB4C-56CD9F42B53B}
 		{13EE1E3C-D7F4-48D3-87AE-94CBCCF574E9} = {50A89C27-BA35-44B2-AC57-E54551791C64}
 		{6A698C1D-F604-4295-B6FC-7FC726F9FE5F} = {1FEED16D-E07D-47C1-BB4C-56CD9F42B53B}
+		{94F9B889-635A-48A7-A0CB-BAE5D6C9A91A} = {3B295650-6CBF-486F-9E25-F96EE03B7CAE}
+		{0C1312C0-0A29-4EB2-8294-6D1C54D78F61} = {50A89C27-BA35-44B2-AC57-E54551791C64}
 	EndGlobalSection
 EndGlobal

--- a/src/Dependencies/xUnit.net/project.json
+++ b/src/Dependencies/xUnit.net/project.json
@@ -1,0 +1,14 @@
+{
+  "dependencies": {
+    "xunit.console.netcore": "1.0.3-prerelease-00607-01",
+    "xunit.runner.reporters": "2.1.0"
+  },
+  "frameworks": {
+    "netcoreapp1.0": {
+      "imports": [
+        "dotnet5.4",
+        "portable-net451+win8"
+      ]
+    }
+  }
+}

--- a/src/Dependencies/xUnit.net/xUnit.net.csproj
+++ b/src/Dependencies/xUnit.net/xUnit.net.csproj
@@ -1,0 +1,64 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'Directory.Build.props'))\Directory.Build.props" />
+  <Import Project="..\..\Tasks\Microsoft.DotNet.Core.Build.Tasks\Microsoft.DotNet.Core.Sdk.props" />
+  <PropertyGroup>
+    <ProjectGuid>{94F9B889-635A-48A7-A0CB-BAE5D6C9A91A}</ProjectGuid>
+    <ProjectTypeGuids>{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <TargetFrameworkIdentifier>.NETCoreApp</TargetFrameworkIdentifier>
+    <TargetFrameworkVersion>v1.0</TargetFrameworkVersion>
+    <OutDir>$(OutDir)Tests\</OutDir>
+    <CopyBuildOutputToOutputDirectory>false</CopyBuildOutputToOutputDirectory>
+    <CopyOutputSymbolsToOutputDirectory>false</CopyOutputSymbolsToOutputDirectory>
+    <OutputType>Library</OutputType>
+    <GenerateDependencyFile>false</GenerateDependencyFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+    <!-- Write a runtimeconfig.json file for xunit.console.netcore.exe, so it runs against the shared framework. -->
+    <None Include="xunit.console.netcore.runtimeconfig.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+  <Import Project="..\..\..\build\Targets\ProducesNoOutput.Imports.targets" />
+  <Import Project="..\..\Tasks\Microsoft.DotNet.Core.Build.Tasks\Microsoft.DotNet.Core.Sdk.targets" />
+
+  <Target Name="AfterBuild">
+    <PropertyGroup>
+      <XUnitVersion>2.1.0</XUnitVersion>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <CopyLocalAssembly Include="xunit.console.netcore">
+        <RelativePath>xunit.console.netcore\1.0.3-prerelease-00607-01\runtimes\any\native\xunit.console.netcore.exe</RelativePath>
+      </CopyLocalAssembly>
+      <CopyLocalAssembly Include="xunit.abstractions">
+        <RelativePath>xunit.abstractions\2.0.0\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.abstractions.dll</RelativePath>
+      </CopyLocalAssembly>
+      <CopyLocalAssembly Include="xunit.assert">
+        <RelativePath>xunit.assert\$(XUnitVersion)\lib\dotnet\xunit.assert.dll</RelativePath>
+      </CopyLocalAssembly>
+      <CopyLocalAssembly Include="xunit.core">
+        <RelativePath>xunit.extensibility.core\$(XUnitVersion)\lib\portable-net45+win8+wp8+wpa81\xunit.core.dll</RelativePath>
+      </CopyLocalAssembly>
+      <CopyLocalAssembly Include="xunit.execution.dotnet">
+        <RelativePath>xunit.extensibility.execution\$(XUnitVersion)\lib\dotnet\xunit.execution.dotnet.dll</RelativePath>
+      </CopyLocalAssembly>
+      <CopyLocalAssembly Include="xunit.runner.reporters.dotnet">
+        <RelativePath>xunit.runner.reporters\$(XUnitVersion)\lib\dotnet\xunit.runner.reporters.dotnet.dll</RelativePath>
+      </CopyLocalAssembly>
+      <CopyLocalAssembly Include="xunit.runner.utility.dotnet">
+        <RelativePath>xunit.runner.utility\$(XUnitVersion)\lib\dotnet\xunit.runner.utility.dotnet.dll</RelativePath>
+      </CopyLocalAssembly>
+      
+      <TestCopyLocalAssembly Include="$(NuGet_Packages)\%(CopyLocalAssembly.RelativePath)" />
+
+      <FluentAssertionsPackage Include="fluentassertions" />
+      <FluentAssertionsPackage Include="fluentassertions.json" />
+
+      <TestCopyLocalAssembly Include="$(NuGet_Packages)\%(FluentAssertionsPackage.Identity)\4.12.0\lib\netstandard1.3\*.dll" />
+    </ItemGroup>
+
+    <Copy SourceFiles="%(TestCopyLocalAssembly.FullPath)" DestinationFolder="$(OutDir)" />
+  </Target>
+</Project>

--- a/src/Dependencies/xUnit.net/xunit.console.netcore.runtimeconfig.json
+++ b/src/Dependencies/xUnit.net/xunit.console.netcore.runtimeconfig.json
@@ -1,0 +1,8 @@
+{
+  "runtimeOptions": {
+    "framework": {
+      "name": "Microsoft.NETCore.App",
+      "version": "1.0.0"
+    }
+  }
+}

--- a/src/Tasks/Microsoft.DotNet.Core.Build.Tasks/Microsoft.DotNet.Core.Build.Tasks.csproj
+++ b/src/Tasks/Microsoft.DotNet.Core.Build.Tasks/Microsoft.DotNet.Core.Build.Tasks.csproj
@@ -76,6 +76,11 @@
         <TFM>netstandard1.0</TFM>
       </CopyLocalAssembly>
 
+      <CopyLocalAssembly Include="System.Runtime.Serialization.Primitives">
+        <Version>4.1.1</Version>
+        <TFM>netstandard1.3</TFM>
+      </CopyLocalAssembly>
+
       <CopyLocalAssembly>
         <FullFilePath>$(NuGet_Packages)\%(CopyLocalAssembly.Identity)\%(CopyLocalAssembly.Version)\lib\%(CopyLocalAssembly.TFM)\%(CopyLocalAssembly.Identity).dll</FullFilePath>
       </CopyLocalAssembly>


### PR DESCRIPTION
This change executes our unit tests during the build.

Basically the approach is that we have a `src\Dependencies\xUnit.net` project that ensures the xunit assemblies are placed into the tests directory.  The tests are executed by the build.proj, just like it is in [dotnet\roslyn-project-system's build.proj](https://github.com/dotnet/roslyn-project-system/blob/master/build/build.proj#L87-L106).

I had to copy a little bit of infrastructure from @333fred's PR: https://github.com/dotnet/sdk/pull/7

@natidea @333fred @davkean @livarcocc @piotrpMSFT @brthor 
