### PR TITLE
Update CLI to 1.0.0-featmsbuild-003408.

### DIFF
--- a/DotnetCLIVersion.txt
+++ b/DotnetCLIVersion.txt
@@ -1,1 +1,1 @@
-1.0.0-featmsbuild-003384
+1.0.0-featmsbuild-003408

--- a/build.ps1
+++ b/build.ps1
@@ -47,6 +47,5 @@ $env:PATH = "$env:DOTNET_INSTALL_DIR;$env:PATH"
 # Disable first run since we want to control all package sources
 $env:DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
 
-# TODO: https://github.com/dotnet/sdk/issues/13 add back `/m` when the MSBuild hang is fixed
-dotnet build3 $RepoRoot\build\build.proj /nologo /p:Configuration=$Configuration /p:Platform=$Platform
+dotnet build3 $RepoRoot\build\build.proj /m /nologo /p:Configuration=$Configuration /p:Platform=$Platform
 if($LASTEXITCODE -ne 0) { throw "Failed to build" }

--- a/src/Dependencies/xUnit.net/xUnit.net.csproj
+++ b/src/Dependencies/xUnit.net/xUnit.net.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'Directory.Build.props'))\Directory.Build.props" />
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <Import Project="..\..\Tasks\Microsoft.DotNet.Core.Build.Tasks\Microsoft.DotNet.Core.Sdk.props" />
   <PropertyGroup>
     <ProjectGuid>{94F9B889-635A-48A7-A0CB-BAE5D6C9A91A}</ProjectGuid>

--- a/src/Tasks/Microsoft.DotNet.Core.Build.Tasks.UnitTests/Microsoft.DotNet.Core.Build.Tasks.UnitTests.csproj
+++ b/src/Tasks/Microsoft.DotNet.Core.Build.Tasks.UnitTests/Microsoft.DotNet.Core.Build.Tasks.UnitTests.csproj
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'Directory.Build.props'))\Directory.Build.props" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <Import Project="..\Microsoft.DotNet.Core.Build.Tasks\Microsoft.DotNet.Core.Sdk.props" />
   <PropertyGroup>

--- a/src/Tasks/Microsoft.DotNet.Core.Build.Tasks/Microsoft.DotNet.Core.Build.Tasks.csproj
+++ b/src/Tasks/Microsoft.DotNet.Core.Build.Tasks/Microsoft.DotNet.Core.Build.Tasks.csproj
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'Directory.Build.props'))\Directory.Build.props" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <Import Project="Microsoft.DotNet.Core.Sdk.props" />
   <PropertyGroup>


### PR DESCRIPTION
This brings in the latest MSBuild version as well, which allows us to use `/m` during the build.

Fix #13

Also, the latest MSBuild imports the `Directory.Build.props` file above the current directory automatically, so our explicit imports can now be removed.
