### PR TITLE
Fix ResolveLockFileReferences to work with a default console app.

### DIFF
--- a/src/Tasks/Microsoft.DotNet.Core.Build.Tasks/Microsoft.PackageDependencyResolution.targets
+++ b/src/Tasks/Microsoft.DotNet.Core.Build.Tasks/Microsoft.PackageDependencyResolution.targets
@@ -40,8 +40,8 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <!-- Target Moniker + RID-->
   <PropertyGroup Condition="'$(_NugetTargetMonikerAndRID)' == ''">
-    <_NugetTargetMonikerAndRID Condition="'$(NuGetRuntimeIdentifier)' == ''">$(NuGetTargetMoniker)</_NugetTargetMonikerAndRID>
-    <_NugetTargetMonikerAndRID Condition="'$(NuGetRuntimeIdentifier)' != ''">$(NuGetTargetMoniker)/$(NuGetRuntimeIdentifier)</_NugetTargetMonikerAndRID>
+    <_NugetTargetMonikerAndRID Condition="'$(RuntimeIdentifier)' == ''">$(NuGetTargetMoniker)</_NugetTargetMonikerAndRID>
+    <_NugetTargetMonikerAndRID Condition="'$(RuntimeIdentifier)' != ''">$(NuGetTargetMoniker)/$(RuntimeIdentifier)</_NugetTargetMonikerAndRID>
   </PropertyGroup>
 
   <!--
@@ -154,7 +154,7 @@ Copyright (c) .NET Foundation. All rights reserved.
           Returns="ResolvedCompileFileDefinitions">
     <ItemGroup>
       <TFMFileItems Include="@(FileDependencies->WithMetadataValue('ParentTarget', '$(_NugetTargetMonikerAndRID)'))" />
-      <_CompileFileItems Include="@(TFMFileItems->WithMetadataValue('FileGroup', 'CompileAssembly'))" />
+      <_CompileFileItems Include="@(TFMFileItems->WithMetadataValue('FileGroup', 'CompileTimeAssembly'))" />
       
       <!-- Get corresponding file definitions -->
       <__CompileFileDefinitions Include="@(FileDefinitions)" Exclude="@(_CompileFileItems)" />


### PR DESCRIPTION
- Fix the enum name used in the .targets to match the C# enum.
- Remove the reference to $(NuGetRuntimeIdentifier), and instead use the $(RuntimeIdentifier) property. $(NuGetRuntimeIdentifier) is always defaulted to a value if it isn't set.  But the RID can be empty for portable apps and libraries.

@natidea 

/cc @dotnet/project-system @livarcocc @brthor @piotrpMSFT 
