### PR TITLE
Fix build break by ensuring the version prerelease always starts with an alpha character

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,8 +17,9 @@
     <VersionPrefix Condition="'$(VersionPrefix)' == ''">1.0.0</VersionPrefix>
     <VersionPrereleasePrefix Condition="'$(VersionPrereleasePrefix)' == ''">alpha</VersionPrereleasePrefix>
     <!-- When running on VSO (for official builds) use a real number. -->
-    <BUILD_BUILDNUMBER Condition="'$(BUILD_BUILDNUMBER)' == ''">00001</BUILD_BUILDNUMBER>
-    <VersionSuffix Condition="'$(VersionSuffix)' == ''">$(VersionPrereleasePrefix)-$(BUILD_BUILDNUMBER)</VersionSuffix>
+    <BuildNumber Condition="'$(BuildNumber)' == ''">$(BUILD_BUILDNUMBER)</BuildNumber>
+    <BuildNumber Condition="'$(BuildNumber)' == ''">00000001-01</BuildNumber>
+    <VersionSuffix Condition="'$(VersionSuffix)' == ''">$(VersionPrereleasePrefix)-$(BuildNumber)</VersionSuffix>
     <Version Condition="'$(Version)' == ''">$(VersionPrefix)-$(VersionSuffix)</Version>
 
     <DotNet_Install_Dir Condition=" '$(DotNet_Install_Dir)' == ''">$(RepositoryRootDirectory).dotnet_cli\</DotNet_Install_Dir>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -15,9 +15,10 @@
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)' == ''">$([System.IO.Path]::GetFullPath('$(RepositoryRootDirectory)bin\obj\$(MSBuildProjectName)'))\</BaseIntermediateOutputPath>
 
     <VersionPrefix Condition="'$(VersionPrefix)' == ''">1.0.0</VersionPrefix>
+    <VersionPrereleasePrefix Condition="'$(VersionPrereleasePrefix)' == ''">alpha</VersionPrereleasePrefix>
     <!-- When running on VSO (for official builds) use a real number. -->
-    <VersionSuffix Condition="'$(VersionSuffix)' == ''">$(BUILD_BUILDNUMBER)</VersionSuffix>
-    <VersionSuffix Condition="'$(VersionSuffix)' == ''">alpha-00001</VersionSuffix>
+    <BUILD_BUILDNUMBER Condition="'$(BUILD_BUILDNUMBER)' == ''">00001</BUILD_BUILDNUMBER>
+    <VersionSuffix Condition="'$(VersionSuffix)' == ''">$(VersionPrereleasePrefix)-$(BUILD_BUILDNUMBER)</VersionSuffix>
     <Version Condition="'$(Version)' == ''">$(VersionPrefix)-$(VersionSuffix)</Version>
 
     <DotNet_Install_Dir Condition=" '$(DotNet_Install_Dir)' == ''">$(RepositoryRootDirectory).dotnet_cli\</DotNet_Install_Dir>


### PR DESCRIPTION
@333fred 

@livarcocc @brthor @piotrpMSFT @dotnet/project-system 
