### PR TITLE
Don't require global Powershell execution policy change

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -14,7 +14,7 @@ if not exist "%DeveloperCommandPrompt%" (
 
 call "%DeveloperCommandPrompt%" || goto :BuildFailed
 
-powershell -NoProfile -NoLogo -Command "& \"%~dp0build.ps1\" %*; exit $LastExitCode;"
+powershell -NoProfile -NoLogo -ExecutionPolicy Bypass -Command "& \"%~dp0build.ps1\" %*; exit $LastExitCode;"
 exit /b %ERRORLEVEL%
 
 :BuildFailed


### PR DESCRIPTION
Makes it so I can run build.cmd without any global changes to my box.

@srivatsn @davkean 
