### PR TITLE
First version of DesignTime task for dependencies tree

### DIFF
--- a/src/Tasks/Microsoft.DotNet.Core.Build.Tasks.UnitTests/GivenThatWeWantToGetDependenciesViaDesignTimeBuild.cs
+++ b/src/Tasks/Microsoft.DotNet.Core.Build.Tasks.UnitTests/GivenThatWeWantToGetDependenciesViaDesignTimeBuild.cs
@@ -3,15 +3,16 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using FluentAssertions;
 using Microsoft.Build.Framework;
 using Xunit;
 
 namespace Microsoft.DotNet.Core.Build.Tasks.UnitTests
 {
-    public class PreprocessPackageDependenciesDesignTimeTests
+    public class GivenThatWeWantToGetDependenciesViaDesignTimeBuild
     {
         [Fact]
-        public void PreprocessPackageDependenciesDesignTime_Targets()
+        public void ItShouldReturnOnlyValidTargetsWithoutRIDs()
         {
             // Arrange 
             // target definitions 
@@ -73,18 +74,17 @@ namespace Microsoft.DotNet.Core.Build.Tasks.UnitTests
             var result = task.Execute();
 
             // Assert
-            Assert.True(result);
-            Assert.Equal(1, task.DependenciesDesignTime.Count());
+            result.Should().BeTrue();
+            task.DependenciesDesignTime.Count().Should().Be(1);
 
-            // Target with type
             var resultTargetsWithType = task.DependenciesDesignTime
                                                 .Where(x => x.ItemSpec.Equals(".Net Framework,Version=v4.5")).ToArray();
-            Assert.Equal(1, resultTargetsWithType.Length);
+            resultTargetsWithType.Length.Should().Be(1);
             VerifyTargetTaskItem(DependencyType.Target, mockTargetWithType, resultTargetsWithType[0]);
         }
 
         [Fact]
-        public void PreprocessPackageDependenciesDesignTime_Packages_Unknown()
+        public void ItShouldNotReturnPackagesWithUnknownTypes()
         {
             // Arrange 
             // target definitions 
@@ -149,18 +149,17 @@ namespace Microsoft.DotNet.Core.Build.Tasks.UnitTests
             var result = task.Execute();
 
             // Assert
-            Assert.True(result);
-            Assert.Equal(1, task.DependenciesDesignTime.Count());
+            result.Should().BeTrue();
+            task.DependenciesDesignTime.Count().Should().Be(1);
 
-            // Target with type
             var resultTargets = task.DependenciesDesignTime
                                                 .Where(x => x.ItemSpec.Equals(".Net Framework,Version=v4.5")).ToArray();
-            Assert.Equal(1, resultTargets.Length);
+            resultTargets.Length.Should().Be(1);
             VerifyTargetTaskItem(DependencyType.Target, mockTarget, resultTargets[0]);
         }
 
         [Fact]
-        public void PreprocessPackageDependenciesDesignTime_Packages_Unresolved()
+        public void ItShouldReturnUnresolvedPackageDependenciesWithTypePackage()
         {
             // Arrange 
             // target definitions 
@@ -207,24 +206,22 @@ namespace Microsoft.DotNet.Core.Build.Tasks.UnitTests
             var result = task.Execute();
 
             // Assert
-            Assert.True(result);
-            Assert.Equal(2, task.DependenciesDesignTime.Count());
+            result.Should().BeTrue();
+            task.DependenciesDesignTime.Count().Should().Be(2);
 
-            // Target with type
             var resultTargets = task.DependenciesDesignTime
                                                 .Where(x => x.ItemSpec.Equals(".Net Framework,Version=v4.5")).ToArray();
-            Assert.Equal(1, resultTargets.Length);
+            resultTargets.Length.Should().Be(1);
             VerifyTargetTaskItem(DependencyType.Target, mockTarget, resultTargets[0]);
 
-            // Package unknown Resolved = false
             var resultPackageUnresolved = task.DependenciesDesignTime
                 .Where(x => x.ItemSpec.Equals(".Net Framework,Version=v4.5/mockPackageUnresolved/1.0.0")).ToArray();
-            Assert.Equal(1, resultPackageUnresolved.Length);
+            resultPackageUnresolved.Length.Should().Be(1);
             VerifyTargetTaskItem(DependencyType.Package, mockPackageUnresolved, resultPackageUnresolved[0]);
         }
 
         [Fact]
-        public void PreprocessPackageDependenciesDesignTime_Packages_WhenTypeIsNotPackageOrUnresolved()
+        public void ItShouldIgnoreAllDependenciesWithTypeNotEqualToPackageOrUnresolved()
         {
             // Arrange 
             // target definitions 
@@ -393,7 +390,6 @@ namespace Microsoft.DotNet.Core.Build.Tasks.UnitTests
                     { MetadataKeys.ParentTarget, ".Net Framework,Version=v4.5" }
                 });
 
-
             var task = new PreprocessPackageDependenciesDesignTime();
             task.TargetDefinitions = new[] { mockTarget };
             task.PackageDefinitions = new ITaskItem[] {
@@ -421,18 +417,18 @@ namespace Microsoft.DotNet.Core.Build.Tasks.UnitTests
             var result = task.Execute();
 
             // Assert
-            Assert.True(result);
-            Assert.Equal(1, task.DependenciesDesignTime.Count());
+            result.Should().BeTrue();
+            task.DependenciesDesignTime.Count().Should().Be(1);
 
             // Target with type
             var resultTargets = task.DependenciesDesignTime
                                                 .Where(x => x.ItemSpec.Equals(".Net Framework,Version=v4.5")).ToArray();
-            Assert.Equal(1, resultTargets.Length);
+            resultTargets.Length.Should().Be(1);
             VerifyTargetTaskItem(DependencyType.Target, mockTarget, resultTargets[0]);
         }
 
         [Fact]
-        public void PreprocessPackageDependenciesDesignTime_Packages_ChildPackages()
+        public void ItReturnsCorrectHierarchyOfDependenciesThatHaveChildren()
         {
             // Arrange 
             // target definitions 
@@ -447,6 +443,7 @@ namespace Microsoft.DotNet.Core.Build.Tasks.UnitTests
                     { MetadataKeys.Type, "Target" }
                 });
 
+            // package definitions
             var mockPackage = new MockTaskItem(
                 itemSpec: "Package3/1.0.0",
                 metadata: new Dictionary<string, string>
@@ -497,6 +494,7 @@ namespace Microsoft.DotNet.Core.Build.Tasks.UnitTests
                     { PreprocessPackageDependenciesDesignTime.ResolvedMetadata, "True" }
                 });
 
+            // package dependencies
             var mockPackageDep = new MockTaskItem(
                             itemSpec: "Package3/1.0.0",
                             metadata: new Dictionary<string, string>
@@ -548,46 +546,41 @@ namespace Microsoft.DotNet.Core.Build.Tasks.UnitTests
             var result = task.Execute();
 
             // Assert
-            Assert.True(result);
-            Assert.Equal(5, task.DependenciesDesignTime.Count());
+            result.Should().BeTrue();
+            task.DependenciesDesignTime.Count().Should().Be(5);
 
-            // Target with type
             var resultTargets = task.DependenciesDesignTime
                                                 .Where(x => x.ItemSpec.Equals(".Net Framework,Version=v4.5")).ToArray();
-            Assert.Equal(1, resultTargets.Length);
+            resultTargets.Length.Should().Be(1);
             VerifyTargetTaskItem(DependencyType.Target, mockTarget, resultTargets[0]);
 
-            // Package3/1.0.0
             mockPackage.SetMetadata(MetadataKeys.Path, mockPackage.GetMetadata(MetadataKeys.ResolvedPath));
             var resultPackage = task.DependenciesDesignTime
                 .Where(x => x.ItemSpec.Equals(".Net Framework,Version=v4.5/Package3/1.0.0")).ToArray();
-            Assert.Equal(1, resultPackage.Length);
+            resultPackage.Length.Should().Be(1);
             VerifyTargetTaskItem(DependencyType.Package, mockPackage, resultPackage[0]);
 
-            // ChildPackage1/1.0.0
             mockChildPackage1.SetMetadata(MetadataKeys.Path, mockChildPackage1.GetMetadata(MetadataKeys.ResolvedPath));
             var resultChildPackage1 = task.DependenciesDesignTime
                 .Where(x => x.ItemSpec.Equals(".Net Framework,Version=v4.5/ChildPackage1/1.0.0")).ToArray();
-            Assert.Equal(1, resultChildPackage1.Length);
+            resultChildPackage1.Length.Should().Be(1);
             VerifyTargetTaskItem(DependencyType.Package, mockChildPackage1, resultChildPackage1[0]);
 
-            // ChildPackage11/1.0.0
             mockChildPackage11.SetMetadata(MetadataKeys.Path, mockChildPackage11.GetMetadata(MetadataKeys.ResolvedPath));
             var resultChildPackage11 = task.DependenciesDesignTime
                 .Where(x => x.ItemSpec.Equals(".Net Framework,Version=v4.5/ChildPackage11/1.0.0")).ToArray();
-            Assert.Equal(1, resultChildPackage11.Length);
+            resultChildPackage11.Length.Should().Be(1);
             VerifyTargetTaskItem(DependencyType.Package, mockChildPackage11, resultChildPackage11[0]);
 
-            // ChildPackage2/3.0.0
             mockChildPackage2.SetMetadata(MetadataKeys.Path, mockChildPackage2.GetMetadata(MetadataKeys.ResolvedPath));
             var resultChildPackage2 = task.DependenciesDesignTime
                 .Where(x => x.ItemSpec.Equals(".Net Framework,Version=v4.5/ChildPackage2/2.0.0")).ToArray();
-            Assert.Equal(1, resultChildPackage2.Length);
+            resultChildPackage2.Length.Should().Be(1);
             VerifyTargetTaskItem(DependencyType.Package, mockChildPackage2, resultChildPackage2[0]);
         }
 
         [Fact]
-        public void PreprocessPackageDependenciesDesignTime_Assemblies_WhenTypeIsNotAssembly()
+        public void ItShouldIgnoreFileDependenciesThatAre_NotAssemblies_And_DontBelongToCompileTimeAssemblyGroup()
         {
             // Arrange 
             // target definitions 
@@ -762,18 +755,18 @@ namespace Microsoft.DotNet.Core.Build.Tasks.UnitTests
             var result = task.Execute();
 
             // Assert
-            Assert.True(result);
-            Assert.Equal(1, task.DependenciesDesignTime.Count());
+            result.Should().BeTrue();
+            task.DependenciesDesignTime.Count().Should().Be(1);
 
             // Target with type
             var resultTargets = task.DependenciesDesignTime
                                                 .Where(x => x.ItemSpec.Equals(".Net Framework,Version=v4.5")).ToArray();
-            Assert.Equal(1, resultTargets.Length);
+            resultTargets.Length.Should().Be(1);
             VerifyTargetTaskItem(DependencyType.Target, mockTarget, resultTargets[0]);
         }
 
         [Fact]
-        public void PreprocessPackageDependenciesDesignTime_Assemblies_ChildAssemblies()
+        public void ItShouldReturnCorrectHierarchyWhenPackageHasChildAssemblyDependencies()
         {
             // Arrange 
             // target definitions 
@@ -788,6 +781,7 @@ namespace Microsoft.DotNet.Core.Build.Tasks.UnitTests
                     { MetadataKeys.Type, "Target" }
                 });
 
+            // package definitions
             var mockPackage = new MockTaskItem(
                 itemSpec: "Package3/1.0.0",
                 metadata: new Dictionary<string, string>
@@ -835,6 +829,7 @@ namespace Microsoft.DotNet.Core.Build.Tasks.UnitTests
                     { PreprocessPackageDependenciesDesignTime.ResolvedMetadata, "True" }
                 });
 
+            // package dependencies
             var mockPackageDep = new MockTaskItem(
                 itemSpec: "Package3/1.0.0",
                 metadata: new Dictionary<string, string>
@@ -891,41 +886,36 @@ namespace Microsoft.DotNet.Core.Build.Tasks.UnitTests
             var result = task.Execute();
 
             // Assert
-            Assert.True(result);
-            Assert.Equal(4, task.DependenciesDesignTime.Count());
+            result.Should().BeTrue();
+            task.DependenciesDesignTime.Count().Should().Be(4);
 
-            // Target with type
             var resultTargets = task.DependenciesDesignTime
                                                 .Where(x => x.ItemSpec.Equals(".Net Framework,Version=v4.5")).ToArray();
-            Assert.Equal(1, resultTargets.Length);
+            resultTargets.Length.Should().Be(1);
             VerifyTargetTaskItem(DependencyType.Target, mockTarget, resultTargets[0]);
 
-            // Package3/1.0.0
             mockPackage.SetMetadata(MetadataKeys.Path, mockPackage.GetMetadata(MetadataKeys.ResolvedPath));
             var resultPackage = task.DependenciesDesignTime
                 .Where(x => x.ItemSpec.Equals(".Net Framework,Version=v4.5/Package3/1.0.0")).ToArray();
-            Assert.Equal(1, resultPackage.Length);
+            resultPackage.Length.Should().Be(1);
             VerifyTargetTaskItem(DependencyType.Package, mockPackage, resultPackage[0]);
 
-            // ChildAssembly1/1.0.0
             mockChildAssembly1.SetMetadata(MetadataKeys.Path, mockChildAssembly1.GetMetadata(MetadataKeys.ResolvedPath));
             var resultChildAssembly1 = task.DependenciesDesignTime
                 .Where(x => x.ItemSpec.Equals(".Net Framework,Version=v4.5/mockChildAssembly1")).ToArray();
-            Assert.Equal(1, resultChildAssembly1.Length);
+            resultChildAssembly1.Length.Should().Be(1);
             VerifyTargetTaskItem(DependencyType.Assembly, mockChildAssembly1, resultChildAssembly1[0]);
 
-            // ChildAssembly2/1.0.0
             mockChildAssembly2.SetMetadata(MetadataKeys.Path, mockChildAssembly2.GetMetadata(MetadataKeys.ResolvedPath));
             var resultChildAssembly2 = task.DependenciesDesignTime
                 .Where(x => x.ItemSpec.Equals(".Net Framework,Version=v4.5/somepath/mockChildAssembly2")).ToArray();
-            Assert.Equal(1, resultChildAssembly2.Length);
+            resultChildAssembly2.Length.Should().Be(1);
             VerifyTargetTaskItem(DependencyType.FrameworkAssembly, mockChildAssembly2, resultChildAssembly2[0]);
         }
 
         private void VerifyTargetTaskItem(DependencyType type, ITaskItem input, ITaskItem output)
         {
-            Assert.Equal(type.ToString(),
-                         output.GetMetadata(MetadataKeys.Type));
+            type.ToString().Should().Be(output.GetMetadata(MetadataKeys.Type));
 
             // remove unnecessary metadata to keep only ones that would be in result task items
             var removeMetadata = new[] { MetadataKeys.Type, MetadataKeys.ResolvedPath };
@@ -938,7 +928,7 @@ namespace Microsoft.DotNet.Core.Build.Tasks.UnitTests
 
             foreach (var metadata in input.MetadataNames)
             {
-                Assert.Equal(input.GetMetadata(metadata.ToString()), output.GetMetadata(metadata.ToString()));
+                input.GetMetadata(metadata.ToString()).Should().Be(output.GetMetadata(metadata.ToString()));
             }
         }
     }

--- a/src/Tasks/Microsoft.DotNet.Core.Build.Tasks.UnitTests/Microsoft.DotNet.Core.Build.Tasks.UnitTests.csproj
+++ b/src/Tasks/Microsoft.DotNet.Core.Build.Tasks.UnitTests/Microsoft.DotNet.Core.Build.Tasks.UnitTests.csproj
@@ -20,6 +20,8 @@
     <ResolveNuGetPackages>true</ResolveNuGetPackages>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="Mocks\MockTaskItem.cs" />
+    <Compile Include="PreprocessPackageDependenciesDesignTimeTests.cs" />
     <Compile Include="GivenADependencyContextBuilder.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
@@ -47,4 +49,23 @@
   <Import Project="..\..\..\build\Targets\Signing.Imports.targets"/>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\Microsoft.DotNet.Core.Build.Tasks\build\netstandard1.0\Microsoft.DotNet.Core.Sdk.targets" />
+  <Target Name="AfterBuild">
+    <PropertyGroup>
+      <MsBuildPackagesVersion>0.1.0-preview-00028-160627</MsBuildPackagesVersion>
+    </PropertyGroup>
+    <ItemGroup>
+      <CopyLocalAssembly Include="Microsoft.Build.Framework">
+        <Version>$(MsBuildPackagesVersion)</Version>
+        <TFM>netstandard1.3</TFM>
+      </CopyLocalAssembly>
+      <CopyLocalAssembly Include="Microsoft.Build.Utilities.Core">
+        <Version>$(MsBuildPackagesVersion)</Version>
+        <TFM>netstandard1.3</TFM>
+      </CopyLocalAssembly>
+      <CopyLocalAssembly>
+        <FullFilePath>$(NuGet_Packages)\%(CopyLocalAssembly.Identity)\%(CopyLocalAssembly.Version)\lib\%(CopyLocalAssembly.TFM)\%(CopyLocalAssembly.Identity).dll</FullFilePath>
+      </CopyLocalAssembly>
+    </ItemGroup>
+    <Copy SourceFiles="%(CopyLocalAssembly.FullFilePath)" DestinationFolder="$(OutDir)" />
+  </Target>
 </Project>

--- a/src/Tasks/Microsoft.DotNet.Core.Build.Tasks.UnitTests/Microsoft.DotNet.Core.Build.Tasks.UnitTests.csproj
+++ b/src/Tasks/Microsoft.DotNet.Core.Build.Tasks.UnitTests/Microsoft.DotNet.Core.Build.Tasks.UnitTests.csproj
@@ -21,7 +21,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Mocks\MockTaskItem.cs" />
-    <Compile Include="PreprocessPackageDependenciesDesignTimeTests.cs" />
+    <Compile Include="GivenThatWeWantToGetDependenciesViaDesignTimeBuild.cs" />
     <Compile Include="GivenADependencyContextBuilder.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
@@ -46,7 +46,7 @@
       <Name>Microsoft.DotNet.Core.Build.Tasks</Name>
     </ProjectReference>
   </ItemGroup>
-  <Import Project="..\..\..\build\Targets\Signing.Imports.targets"/>
+  <Import Project="..\..\..\build\Targets\Signing.Imports.targets" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\Microsoft.DotNet.Core.Build.Tasks\build\netstandard1.0\Microsoft.DotNet.Core.Sdk.targets" />
   <Target Name="AfterBuild">

--- a/src/Tasks/Microsoft.DotNet.Core.Build.Tasks.UnitTests/Mocks/MockTaskItem.cs
+++ b/src/Tasks/Microsoft.DotNet.Core.Build.Tasks.UnitTests/Mocks/MockTaskItem.cs
@@ -1,0 +1,81 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using Microsoft.Build.Framework;
+
+namespace Microsoft.DotNet.Core.Build.Tasks.UnitTests
+{
+    public class MockTaskItem : ITaskItem
+    {
+        private Dictionary<string, string> _metadata = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        public MockTaskItem()
+        {
+        }
+
+        public MockTaskItem(string itemSpec, Dictionary<string, string> metadata)
+        {
+            ItemSpec = itemSpec;
+            foreach(var m in metadata)
+            {
+                _metadata.Add(m.Key, m.Value);
+            }
+        }
+
+        public string ItemSpec { get; set; }
+
+        public int MetadataCount
+        {
+            get
+            {
+                return _metadata.Count;
+            }
+        }
+
+        public ICollection MetadataNames
+        {
+            get
+            {
+                return _metadata.Keys;
+            }
+        }
+
+        public IDictionary CloneCustomMetadata()
+        {
+            throw new NotImplementedException();
+        }
+
+        public void CopyMetadataTo(ITaskItem destinationItem)
+        {
+            throw new NotImplementedException();
+        }
+
+        public string GetMetadata(string metadataName)
+        {
+            string metadatValue = null;
+            if (_metadata.TryGetValue(metadataName, out metadatValue))
+            {
+                return metadatValue;
+            }
+
+            return null;
+        }
+
+        public void RemoveMetadata(string metadataName)
+        {
+            string metadatValue = null;
+            if (_metadata.TryGetValue(metadataName, out metadatValue))
+            {
+                _metadata.Remove(metadataName);
+            }
+        }
+
+        public void SetMetadata(string metadataName, string metadataValue)
+        {
+            _metadata[metadataName] = metadataValue;
+        }
+    }
+}

--- a/src/Tasks/Microsoft.DotNet.Core.Build.Tasks.UnitTests/PreprocessPackageDependenciesDesignTimeTests.cs
+++ b/src/Tasks/Microsoft.DotNet.Core.Build.Tasks.UnitTests/PreprocessPackageDependenciesDesignTimeTests.cs
@@ -1,0 +1,893 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Build.Framework;
+using Xunit;
+
+namespace Microsoft.DotNet.Core.Build.Tasks.UnitTests
+{
+    public class PreprocessPackageDependenciesDesignTimeTests
+    {
+        [Fact]
+        public void PreprocessPackageDependenciesDesignTime_Targets()
+        {
+            // Arrange 
+            // target definitions 
+            var mockTargetWithType = new MockTaskItem(
+                itemSpec: ".Net Framework,Version=v4.5",
+                metadata: new Dictionary<string, string>
+                {
+                    { MetadataKeys.RuntimeIdentifier, "net45" },
+                    { MetadataKeys.TargetFrameworkMoniker, ".Net Framework,Version=v4.5" },
+                    { MetadataKeys.FrameworkName, ".Net Framework" },
+                    { MetadataKeys.FrameworkVersion, "4.5" },
+                    { MetadataKeys.Type, "target" } // lower case just in case
+                });
+
+            var mockTargetWithRidToBeSkipped = new MockTaskItem(
+                itemSpec: ".Net Framework,Version=v4.5/win7x86",
+                metadata: new Dictionary<string, string>
+                {
+                    { MetadataKeys.RuntimeIdentifier, "" },
+                    { MetadataKeys.TargetFrameworkMoniker, "" },
+                    { MetadataKeys.FrameworkName, "" },
+                    { MetadataKeys.FrameworkVersion, "" },
+                    { MetadataKeys.Type, ""}
+                });
+
+            var mockTargetWithoutType = new MockTaskItem(
+                itemSpec: ".Net Framework,Version=v4.6",
+                metadata: new Dictionary<string, string>
+                {
+                    { MetadataKeys.RuntimeIdentifier, "net46" },
+                    { MetadataKeys.TargetFrameworkMoniker, ".Net Framework,Version=v4.6" },
+                    { MetadataKeys.FrameworkName, ".Net Framework" },
+                    { MetadataKeys.FrameworkVersion, "4.6" },
+                });
+
+            var mockTargetWithEmptyItemSpecToBeSkipped = new MockTaskItem(
+                itemSpec: "",
+                metadata: new Dictionary<string, string>
+                {
+                    { MetadataKeys.RuntimeIdentifier, "" },
+                    { MetadataKeys.TargetFrameworkMoniker, "" },
+                    { MetadataKeys.FrameworkName, "" },
+                    { MetadataKeys.FrameworkVersion, "" }
+                });
+
+            var task = new PreprocessPackageDependenciesDesignTime();
+            task.TargetDefinitions = new[] {
+                mockTargetWithType,
+                mockTargetWithRidToBeSkipped,
+                mockTargetWithoutType,
+                mockTargetWithEmptyItemSpecToBeSkipped
+            };
+            task.PackageDefinitions = new ITaskItem[] { };
+            task.FileDefinitions = new ITaskItem[] { };
+            task.PackageDependencies = new ITaskItem[] { };
+            task.FileDependencies = new ITaskItem[] { };
+
+            // Act
+            var result = task.Execute();
+
+            // Assert
+            Assert.True(result);
+            Assert.Equal(1, task.DependenciesDesignTime.Count());
+
+            // Target with type
+            var resultTargetsWithType = task.DependenciesDesignTime
+                                                .Where(x => x.ItemSpec.Equals(".Net Framework,Version=v4.5")).ToArray();
+            Assert.Equal(1, resultTargetsWithType.Length);
+            VerifyTargetTaskItem(DependencyType.Target, mockTargetWithType, resultTargetsWithType[0]);
+        }
+
+        [Fact]
+        public void PreprocessPackageDependenciesDesignTime_Packages_Unknown()
+        {
+            // Arrange 
+            // target definitions 
+            var mockTarget = new MockTaskItem(
+                itemSpec: ".Net Framework,Version=v4.5",
+                metadata: new Dictionary<string, string>
+                {
+                    { MetadataKeys.RuntimeIdentifier, "net45" },
+                    { MetadataKeys.TargetFrameworkMoniker, ".Net Framework,Version=v4.5" },
+                    { MetadataKeys.FrameworkName, ".Net Framework" },
+                    { MetadataKeys.FrameworkVersion, "4.5" },
+                    { MetadataKeys.Type, "Target" }
+                });
+
+            // package definitions
+            var mockPackageNoType = new MockTaskItem(
+                itemSpec: "mockPackageNoType/1.0.0",
+                metadata: new Dictionary<string, string>
+                {
+                    { MetadataKeys.Name, "mockPackageNoType" },
+                    { MetadataKeys.Version, "1.0.0" },
+                    { MetadataKeys.Path, "some path" },
+                    { MetadataKeys.ResolvedPath, "some path" },
+                    { PreprocessPackageDependenciesDesignTime.ResolvedMetadata, "False" }
+                });
+
+            var mockPackageUnknown = new MockTaskItem(
+                itemSpec: "mockPackageUnknown/1.0.0",
+                metadata: new Dictionary<string, string>
+                {
+                    { MetadataKeys.Name, "mockPackageUnknown" },
+                    { MetadataKeys.Version, "1.0.0" },
+                    { MetadataKeys.Path, "some path" },
+                    { MetadataKeys.ResolvedPath, "some resolved path" },
+                    { MetadataKeys.Type, "qqqq" },
+                    { PreprocessPackageDependenciesDesignTime.ResolvedMetadata, "False" }
+                });
+
+            // package dependencies
+            var mockPackageDepNoType = new MockTaskItem(
+                itemSpec: "mockPackageNoType/1.0.0",
+                metadata: new Dictionary<string, string>
+                {
+                    { MetadataKeys.ParentTarget, ".Net Framework,Version=v4.5" }
+                });
+
+            var mockPackageDepUnknown = new MockTaskItem(
+                itemSpec: "mockPackageUnknown/1.0.0",
+                metadata: new Dictionary<string, string>
+                {
+                    { MetadataKeys.ParentTarget, ".Net Framework,Version=v4.5" }
+                });
+
+            var task = new PreprocessPackageDependenciesDesignTime();
+            task.TargetDefinitions = new[] { mockTarget };
+            task.PackageDefinitions = new ITaskItem[] { mockPackageNoType, mockPackageUnknown };
+            task.FileDefinitions = new ITaskItem[] { };
+            task.PackageDependencies = new ITaskItem[] { mockPackageDepNoType, mockPackageDepUnknown };
+            task.FileDependencies = new ITaskItem[] { };
+
+            // Act
+            var result = task.Execute();
+
+            // Assert
+            Assert.True(result);
+            Assert.Equal(3, task.DependenciesDesignTime.Count());
+
+            // Target with type
+            var resultTargets = task.DependenciesDesignTime
+                                                .Where(x => x.ItemSpec.Equals(".Net Framework,Version=v4.5")).ToArray();
+            Assert.Equal(1, resultTargets.Length);
+            VerifyTargetTaskItem(DependencyType.Target, mockTarget, resultTargets[0]);
+
+            // package unknown, no Type, Resolved = false
+            var resultPackageNoType = task.DependenciesDesignTime
+                    .Where(x => x.ItemSpec.Equals(".Net Framework,Version=v4.5/mockPackageNoType/1.0.0")).ToArray();
+            Assert.Equal(1, resultPackageNoType.Length);
+            VerifyTargetTaskItem(DependencyType.Unknown, mockPackageNoType, resultPackageNoType[0]);
+
+            // Package unknown Resolved = false
+            var resultPackageUnknown = task.DependenciesDesignTime
+                .Where(x => x.ItemSpec.Equals(".Net Framework,Version=v4.5/mockPackageUnknown/1.0.0")).ToArray();
+            Assert.Equal(1, resultPackageUnknown.Length);
+            VerifyTargetTaskItem(DependencyType.Unknown, mockPackageUnknown, resultPackageUnknown[0]);
+        }
+
+        [Fact]
+        public void PreprocessPackageDependenciesDesignTime_Packages_WhenTypeIsNotPackageOrUnknown()
+        {
+            // Arrange 
+            // target definitions 
+            var mockTarget = new MockTaskItem(
+                itemSpec: ".Net Framework,Version=v4.5",
+                metadata: new Dictionary<string, string>
+                {
+                    { MetadataKeys.RuntimeIdentifier, "net45" },
+                    { MetadataKeys.TargetFrameworkMoniker, ".Net Framework,Version=v4.5" },
+                    { MetadataKeys.FrameworkName, ".Net Framework" },
+                    { MetadataKeys.FrameworkVersion, "4.5" },
+                    { MetadataKeys.Type, "Target" }
+                });
+
+            // package definitions
+            var mockPackageExternalProject = new MockTaskItem(
+                itemSpec: "mockPackageExternalProject/1.0.0",
+                metadata: new Dictionary<string, string>
+                {
+                    { MetadataKeys.Name, "mockPackageExternalProject" },
+                    { MetadataKeys.Version, "1.0.0" },
+                    { MetadataKeys.Path, "some path" },
+                    { MetadataKeys.ResolvedPath, "some path" },
+                    { MetadataKeys.Type, "ExternalProject" },
+                    { PreprocessPackageDependenciesDesignTime.ResolvedMetadata, "False" }
+                });
+
+            var mockPackageProject = new MockTaskItem(
+                itemSpec: "mockPackageProject/1.0.0",
+                metadata: new Dictionary<string, string>
+                {
+                    { MetadataKeys.Name, "mockPackageProject" },
+                    { MetadataKeys.Version, "1.0.0" },
+                    { MetadataKeys.Path, "some path" },
+                    { MetadataKeys.ResolvedPath, "some resolved path" },
+                    { MetadataKeys.Type, "Project" },
+                    { PreprocessPackageDependenciesDesignTime.ResolvedMetadata, "False" }
+                });
+
+            var mockPackageContent = new MockTaskItem(
+                itemSpec: "mockPackageContent/1.0.0",
+                metadata: new Dictionary<string, string>
+                {
+                    { MetadataKeys.Name, "mockPackageContent" },
+                    { MetadataKeys.Version, "1.0.0" },
+                    { MetadataKeys.Path, "some path" },
+                    { MetadataKeys.ResolvedPath, "some resolved path" },
+                    { MetadataKeys.Type, "Content" },
+                    { PreprocessPackageDependenciesDesignTime.ResolvedMetadata, "False" }
+                });
+
+            var mockPackageAssembly = new MockTaskItem(
+                itemSpec: "mockPackageAssembly/1.0.0",
+                metadata: new Dictionary<string, string>
+                {
+                    { MetadataKeys.Name, "mockPackageAssembly" },
+                    { MetadataKeys.Version, "1.0.0" },
+                    { MetadataKeys.Path, "some path" },
+                    { MetadataKeys.ResolvedPath, "some resolved path" },
+                    { MetadataKeys.Type, "Assembly" },
+                    { PreprocessPackageDependenciesDesignTime.ResolvedMetadata, "False" }
+                });
+
+            var mockPackageFrameworkAssembly = new MockTaskItem(
+                itemSpec: "mockPackageFrameworkAssembly/1.0.0",
+                metadata: new Dictionary<string, string>
+                {
+                    { MetadataKeys.Name, "mockPackageFrameworkAssembly" },
+                    { MetadataKeys.Version, "1.0.0" },
+                    { MetadataKeys.Path, "some path" },
+                    { MetadataKeys.ResolvedPath, "some resolved path" },
+                    { MetadataKeys.Type, "FrameworkAssembly" },
+                    { PreprocessPackageDependenciesDesignTime.ResolvedMetadata, "False" }
+                });
+
+            var mockPackageDiagnostic = new MockTaskItem(
+                itemSpec: "mockPackageDiagnostic/1.0.0",
+                metadata: new Dictionary<string, string>
+                {
+                    { MetadataKeys.Name, "mockPackageDiagnostic" },
+                    { MetadataKeys.Version, "1.0.0" },
+                    { MetadataKeys.Path, "some path" },
+                    { MetadataKeys.ResolvedPath, "some resolved path" },
+                    { MetadataKeys.Type, "Diagnostic" },
+                    { PreprocessPackageDependenciesDesignTime.ResolvedMetadata, "False" }
+                });
+
+            var mockPackageWinmd = new MockTaskItem(
+                itemSpec: "mockPackageWinmd/1.0.0",
+                metadata: new Dictionary<string, string>
+                {
+                    { MetadataKeys.Name, "mockPackageWinmd" },
+                    { MetadataKeys.Version, "1.0.0" },
+                    { MetadataKeys.Path, "some path" },
+                    { MetadataKeys.ResolvedPath, "some resolved path" },
+                    { MetadataKeys.Type, "Winmd" },
+                    { PreprocessPackageDependenciesDesignTime.ResolvedMetadata, "False" }
+                });
+
+            var mockPackageReference = new MockTaskItem(
+                itemSpec: "mockPackageReference/1.0.0",
+                metadata: new Dictionary<string, string>
+                {
+                    { MetadataKeys.Name, "mockPackageReference" },
+                    { MetadataKeys.Version, "1.0.0" },
+                    { MetadataKeys.Path, "some path" },
+                    { MetadataKeys.ResolvedPath, "some resolved path" },
+                    { MetadataKeys.Type, "Reference" },
+                    { PreprocessPackageDependenciesDesignTime.ResolvedMetadata, "False" }
+                });
+
+            // package dependencies
+            var mockPackageExternalProjectDep = new MockTaskItem(
+                itemSpec: "mockPackageExternalProject/1.0.0",
+                metadata: new Dictionary<string, string>
+                {
+                    { MetadataKeys.ParentTarget, ".Net Framework,Version=v4.5" }
+                });
+
+            var mockPackageProjectDep = new MockTaskItem(
+                itemSpec: "mockPackageProject/1.0.0",
+                metadata: new Dictionary<string, string>
+                {
+                    { MetadataKeys.ParentTarget, ".Net Framework,Version=v4.5" }
+                });
+
+            var mockPackageContentDep = new MockTaskItem(
+                itemSpec: "mockPackageContent/1.0.0",
+                metadata: new Dictionary<string, string>
+                {
+                    { MetadataKeys.ParentTarget, ".Net Framework,Version=v4.5" }
+                });
+
+            var mockPackageAssemblyDep = new MockTaskItem(
+                itemSpec: "mockPackageAssembly/1.0.0",
+                metadata: new Dictionary<string, string>
+                {
+                    { MetadataKeys.ParentTarget, ".Net Framework,Version=v4.5" }
+                });
+
+            var mockPackageFrameworkAssemblyDep = new MockTaskItem(
+                itemSpec: "mockPackageFrameworkAssembly/1.0.0",
+                metadata: new Dictionary<string, string>
+                {
+                    { MetadataKeys.ParentTarget, ".Net Framework,Version=v4.5" }
+                });
+
+            var mockPackageDiagnosticDep = new MockTaskItem(
+                itemSpec: "mockPackageDiagnostic/1.0.0",
+                metadata: new Dictionary<string, string>
+                {
+                    { MetadataKeys.ParentTarget, ".Net Framework,Version=v4.5" }
+                });
+
+            var mockPackageWinmdDep = new MockTaskItem(
+                itemSpec: "mockPackageWinmd/1.0.0",
+                metadata: new Dictionary<string, string>
+                {
+                    { MetadataKeys.ParentTarget, ".Net Framework,Version=v4.5" }
+                });
+
+            var mockPackageReferenceDep = new MockTaskItem(
+                itemSpec: "mockPackageReference/1.0.0",
+                metadata: new Dictionary<string, string>
+                {
+                    { MetadataKeys.ParentTarget, ".Net Framework,Version=v4.5" }
+                });
+
+
+            var task = new PreprocessPackageDependenciesDesignTime();
+            task.TargetDefinitions = new[] { mockTarget };
+            task.PackageDefinitions = new ITaskItem[] {
+                mockPackageExternalProject,
+                mockPackageProject,
+                mockPackageContent,
+                mockPackageAssembly,
+                mockPackageFrameworkAssembly,
+                mockPackageWinmd,
+                mockPackageReference
+            };
+            task.FileDefinitions = new ITaskItem[] { };
+            task.PackageDependencies = new ITaskItem[] {
+                mockPackageExternalProjectDep,
+                mockPackageProjectDep,
+                mockPackageContentDep,
+                mockPackageAssemblyDep,
+                mockPackageFrameworkAssemblyDep,
+                mockPackageWinmdDep,
+                mockPackageReferenceDep
+            };
+            task.FileDependencies = new ITaskItem[] { };
+
+            // Act
+            var result = task.Execute();
+
+            // Assert
+            Assert.True(result);
+            Assert.Equal(1, task.DependenciesDesignTime.Count());
+
+            // Target with type
+            var resultTargets = task.DependenciesDesignTime
+                                                .Where(x => x.ItemSpec.Equals(".Net Framework,Version=v4.5")).ToArray();
+            Assert.Equal(1, resultTargets.Length);
+            VerifyTargetTaskItem(DependencyType.Target, mockTarget, resultTargets[0]);
+        }
+
+        [Fact]
+        public void PreprocessPackageDependenciesDesignTime_Packages_ChildPackages()
+        {
+            // Arrange 
+            // target definitions 
+            var mockTarget = new MockTaskItem(
+                itemSpec: ".Net Framework,Version=v4.5",
+                metadata: new Dictionary<string, string>
+                {
+                    { MetadataKeys.RuntimeIdentifier, "net45" },
+                    { MetadataKeys.TargetFrameworkMoniker, ".Net Framework,Version=v4.5" },
+                    { MetadataKeys.FrameworkName, ".Net Framework" },
+                    { MetadataKeys.FrameworkVersion, "4.5" },
+                    { MetadataKeys.Type, "Target" }
+                });
+
+            var mockPackage = new MockTaskItem(
+                itemSpec: "Package3/1.0.0",
+                metadata: new Dictionary<string, string>
+                {
+                    { MetadataKeys.Name, "Package3" },
+                    { MetadataKeys.Version, "1.0.0" },
+                    { MetadataKeys.Path, "some path" },
+                    { MetadataKeys.ResolvedPath, "some resolved path" },
+                    { MetadataKeys.Type, "Package" },
+                    { PreprocessPackageDependenciesDesignTime.ResolvedMetadata, "True" },
+                    { PreprocessPackageDependenciesDesignTime.DependenciesMetadata, "ChildPackage1/1.0.0;ChildPackage2/2.0.0" }
+                });
+
+            var mockChildPackage1 = new MockTaskItem(
+                itemSpec: "ChildPackage1/1.0.0",
+                metadata: new Dictionary<string, string>
+                {
+                    { MetadataKeys.Name, "ChildPackage1" },
+                    { MetadataKeys.Version, "1.0.0" },
+                    { MetadataKeys.Path, "some path" },
+                    { MetadataKeys.ResolvedPath, "some resolved path" },
+                    { MetadataKeys.Type, "Package" },
+                    { PreprocessPackageDependenciesDesignTime.ResolvedMetadata, "True" },
+                    { PreprocessPackageDependenciesDesignTime.DependenciesMetadata, "ChildPackage11/1.0.0" }
+                });
+
+            var mockChildPackage11 = new MockTaskItem(
+                itemSpec: "ChildPackage11/1.0.0",
+                metadata: new Dictionary<string, string>
+                {
+                    { MetadataKeys.Name, "ChildPackage11" },
+                    { MetadataKeys.Version, "1.0.0" },
+                    { MetadataKeys.Path, "some path" },
+                    { MetadataKeys.ResolvedPath, "some resolved path" },
+                    { MetadataKeys.Type, "Package" },
+                    { PreprocessPackageDependenciesDesignTime.ResolvedMetadata, "True" }
+                });
+
+            var mockChildPackage2 = new MockTaskItem(
+                itemSpec: "ChildPackage2/2.0.0",
+                metadata: new Dictionary<string, string>
+                {
+                    { MetadataKeys.Name, "ChildPackage2" },
+                    { MetadataKeys.Version, "2.0.0" },
+                    { MetadataKeys.Path, "some path" },
+                    { MetadataKeys.ResolvedPath, "some resolved path" },
+                    { MetadataKeys.Type, "Package" },
+                    { PreprocessPackageDependenciesDesignTime.ResolvedMetadata, "True" }
+                });
+
+            var mockPackageDep = new MockTaskItem(
+                            itemSpec: "Package3/1.0.0",
+                            metadata: new Dictionary<string, string>
+                            {
+                                { MetadataKeys.ParentTarget, ".Net Framework,Version=v4.5" }
+                            });
+
+            var mockChildPackageDep1 = new MockTaskItem(
+                itemSpec: "ChildPackage1/1.0.0",
+                metadata: new Dictionary<string, string>
+                {
+                    { MetadataKeys.ParentTarget, ".Net Framework,Version=v4.5" },
+                    { MetadataKeys.ParentPackage, "Package3/1.0.0" }
+                });
+
+            var mockChildPackageDep11 = new MockTaskItem(
+                itemSpec: "ChildPackage11/1.0.0",
+                metadata: new Dictionary<string, string>
+                {
+                    { MetadataKeys.ParentTarget, ".Net Framework,Version=v4.5" },
+                    { MetadataKeys.ParentPackage, "ChildPackage1/1.0.0" }
+                });
+
+            var mockChildPackageDep2 = new MockTaskItem(
+                itemSpec: "ChildPackage2/2.0.0",
+                metadata: new Dictionary<string, string>
+                {
+                    { MetadataKeys.ParentTarget, ".Net Framework,Version=v4.5" },
+                    { MetadataKeys.ParentPackage, "Package3/1.0.0" }
+                });
+            var task = new PreprocessPackageDependenciesDesignTime();
+            task.TargetDefinitions = new[] { mockTarget };
+            task.PackageDefinitions = new ITaskItem[] {
+                mockPackage,
+                mockChildPackage1,
+                mockChildPackage11,
+                mockChildPackage2
+            };
+            task.FileDefinitions = new ITaskItem[] { };
+            task.PackageDependencies = new ITaskItem[] {
+                mockPackageDep,
+                mockChildPackageDep1,
+                mockChildPackageDep11,
+                mockChildPackageDep2
+            };
+            task.FileDependencies = new ITaskItem[] { };
+
+            // Act
+            var result = task.Execute();
+
+            // Assert
+            Assert.True(result);
+            Assert.Equal(5, task.DependenciesDesignTime.Count());
+
+            // Target with type
+            var resultTargets = task.DependenciesDesignTime
+                                                .Where(x => x.ItemSpec.Equals(".Net Framework,Version=v4.5")).ToArray();
+            Assert.Equal(1, resultTargets.Length);
+            VerifyTargetTaskItem(DependencyType.Target, mockTarget, resultTargets[0]);
+
+            // Package3/1.0.0
+            mockPackage.SetMetadata(MetadataKeys.Path, mockPackage.GetMetadata(MetadataKeys.ResolvedPath));
+            var resultPackage = task.DependenciesDesignTime
+                .Where(x => x.ItemSpec.Equals(".Net Framework,Version=v4.5/Package3/1.0.0")).ToArray();
+            Assert.Equal(1, resultPackage.Length);
+            VerifyTargetTaskItem(DependencyType.Package, mockPackage, resultPackage[0]);
+
+            // ChildPackage1/1.0.0
+            mockChildPackage1.SetMetadata(MetadataKeys.Path, mockChildPackage1.GetMetadata(MetadataKeys.ResolvedPath));
+            var resultChildPackage1 = task.DependenciesDesignTime
+                .Where(x => x.ItemSpec.Equals(".Net Framework,Version=v4.5/ChildPackage1/1.0.0")).ToArray();
+            Assert.Equal(1, resultChildPackage1.Length);
+            VerifyTargetTaskItem(DependencyType.Package, mockChildPackage1, resultChildPackage1[0]);
+
+            // ChildPackage11/1.0.0
+            mockChildPackage11.SetMetadata(MetadataKeys.Path, mockChildPackage11.GetMetadata(MetadataKeys.ResolvedPath));
+            var resultChildPackage11 = task.DependenciesDesignTime
+                .Where(x => x.ItemSpec.Equals(".Net Framework,Version=v4.5/ChildPackage11/1.0.0")).ToArray();
+            Assert.Equal(1, resultChildPackage11.Length);
+            VerifyTargetTaskItem(DependencyType.Package, mockChildPackage11, resultChildPackage11[0]);
+
+            // ChildPackage2/3.0.0
+            mockChildPackage2.SetMetadata(MetadataKeys.Path, mockChildPackage2.GetMetadata(MetadataKeys.ResolvedPath));
+            var resultChildPackage2 = task.DependenciesDesignTime
+                .Where(x => x.ItemSpec.Equals(".Net Framework,Version=v4.5/ChildPackage2/2.0.0")).ToArray();
+            Assert.Equal(1, resultChildPackage2.Length);
+            VerifyTargetTaskItem(DependencyType.Package, mockChildPackage2, resultChildPackage2[0]);
+        }
+
+        [Fact]
+        public void PreprocessPackageDependenciesDesignTime_Assemblies_WhenTypeIsNotAssembly()
+        {
+            // Arrange 
+            // target definitions 
+            var mockTarget = new MockTaskItem(
+                itemSpec: ".Net Framework,Version=v4.5",
+                metadata: new Dictionary<string, string>
+                {
+                    { MetadataKeys.RuntimeIdentifier, "net45" },
+                    { MetadataKeys.TargetFrameworkMoniker, ".Net Framework,Version=v4.5" },
+                    { MetadataKeys.FrameworkName, ".Net Framework" },
+                    { MetadataKeys.FrameworkVersion, "4.5" },
+                    { MetadataKeys.Type, "Target" }
+                });
+
+            // package definitions
+            var mockExternalProject = new MockTaskItem(
+                itemSpec: "mockExternalProject/1.0.0",
+                metadata: new Dictionary<string, string>
+                {
+                    { MetadataKeys.Name, "mockExternalProject" },
+                    { MetadataKeys.Version, "1.0.0" },
+                    { MetadataKeys.Path, "some path" },
+                    { MetadataKeys.ResolvedPath, "some path" },
+                    { MetadataKeys.Type, "ExternalProject" },
+                    { PreprocessPackageDependenciesDesignTime.ResolvedMetadata, "False" }
+                });
+
+            var mockProject = new MockTaskItem(
+                itemSpec: "mockProject/1.0.0",
+                metadata: new Dictionary<string, string>
+                {
+                    { MetadataKeys.Name, "mockProject" },
+                    { MetadataKeys.Version, "1.0.0" },
+                    { MetadataKeys.Path, "some path" },
+                    { MetadataKeys.ResolvedPath, "some resolved path" },
+                    { MetadataKeys.Type, "Project" },
+                    { PreprocessPackageDependenciesDesignTime.ResolvedMetadata, "False" }
+                });
+
+            var mockContent = new MockTaskItem(
+                itemSpec: "mockContent/1.0.0",
+                metadata: new Dictionary<string, string>
+                {
+                    { MetadataKeys.Name, "mockContent" },
+                    { MetadataKeys.Version, "1.0.0" },
+                    { MetadataKeys.Path, "some path" },
+                    { MetadataKeys.ResolvedPath, "some resolved path" },
+                    { MetadataKeys.Type, "Content" },
+                    { PreprocessPackageDependenciesDesignTime.ResolvedMetadata, "False" }
+                });
+
+            var mockPackage = new MockTaskItem(
+                itemSpec: "mockPackage/1.0.0",
+                metadata: new Dictionary<string, string>
+                {
+                    { MetadataKeys.Name, "mockAssembly" },
+                    { MetadataKeys.Version, "1.0.0" },
+                    { MetadataKeys.Path, "some path" },
+                    { MetadataKeys.ResolvedPath, "some resolved path" },
+                    { MetadataKeys.Type, "Assembly" },
+                    { PreprocessPackageDependenciesDesignTime.ResolvedMetadata, "False" }
+                });
+
+            var mockDiagnostic = new MockTaskItem(
+                itemSpec: "mockDiagnostic/1.0.0",
+                metadata: new Dictionary<string, string>
+                {
+                    { MetadataKeys.Name, "mockDiagnostic" },
+                    { MetadataKeys.Version, "1.0.0" },
+                    { MetadataKeys.Path, "some path" },
+                    { MetadataKeys.ResolvedPath, "some resolved path" },
+                    { MetadataKeys.Type, "Diagnostic" },
+                    { PreprocessPackageDependenciesDesignTime.ResolvedMetadata, "False" }
+                });
+
+            var mockWinmd = new MockTaskItem(
+                itemSpec: "mockWinmd/1.0.0",
+                metadata: new Dictionary<string, string>
+                {
+                    { MetadataKeys.Name, "mockWinmd" },
+                    { MetadataKeys.Version, "1.0.0" },
+                    { MetadataKeys.Path, "some path" },
+                    { MetadataKeys.ResolvedPath, "some resolved path" },
+                    { MetadataKeys.Type, "Winmd" },
+                    { PreprocessPackageDependenciesDesignTime.ResolvedMetadata, "False" }
+                });
+
+            var mockReference = new MockTaskItem(
+                itemSpec: "mockReference/1.0.0",
+                metadata: new Dictionary<string, string>
+                {
+                    { MetadataKeys.Name, "mockReference" },
+                    { MetadataKeys.Version, "1.0.0" },
+                    { MetadataKeys.Path, "some path" },
+                    { MetadataKeys.ResolvedPath, "some resolved path" },
+                    { MetadataKeys.Type, "Reference" },
+                    { PreprocessPackageDependenciesDesignTime.ResolvedMetadata, "False" }
+                });
+
+            // package dependencies
+            var mockExternalProjectDep = new MockTaskItem(
+                itemSpec: "mockExternalProject/1.0.0",
+                metadata: new Dictionary<string, string>
+                {
+                    { MetadataKeys.ParentTarget, ".Net Framework,Version=v4.5" }
+                });
+
+            var mockProjectDep = new MockTaskItem(
+                itemSpec: "mockProject/1.0.0",
+                metadata: new Dictionary<string, string>
+                {
+                    { MetadataKeys.ParentTarget, ".Net Framework,Version=v4.5" }
+                });
+
+            var mockContentDep = new MockTaskItem(
+                itemSpec: "mockContent/1.0.0",
+                metadata: new Dictionary<string, string>
+                {
+                    { MetadataKeys.ParentTarget, ".Net Framework,Version=v4.5" }
+                });
+
+            var mockPackageDep = new MockTaskItem(
+                itemSpec: "mockPackage/1.0.0",
+                metadata: new Dictionary<string, string>
+                {
+                    { MetadataKeys.ParentTarget, ".Net Framework,Version=v4.5" }
+                });
+
+            var mockDiagnosticDep = new MockTaskItem(
+                itemSpec: "mockDiagnostic/1.0.0",
+                metadata: new Dictionary<string, string>
+                {
+                    { MetadataKeys.ParentTarget, ".Net Framework,Version=v4.5" }
+                });
+
+            var mockWinmdDep = new MockTaskItem(
+                itemSpec: "mockWinmd/1.0.0",
+                metadata: new Dictionary<string, string>
+                {
+                    { MetadataKeys.ParentTarget, ".Net Framework,Version=v4.5" }
+                });
+
+            var mockReferenceDep = new MockTaskItem(
+                itemSpec: "mockReference/1.0.0",
+                metadata: new Dictionary<string, string>
+                {
+                    { MetadataKeys.ParentTarget, ".Net Framework,Version=v4.5" }
+                });
+
+            var task = new PreprocessPackageDependenciesDesignTime();
+            task.TargetDefinitions = new[] { mockTarget };
+            task.PackageDefinitions = new ITaskItem[] { };
+            task.FileDefinitions = new ITaskItem[] {
+                mockExternalProject,
+                mockProject,
+                mockContent,
+                mockPackage,
+                mockWinmd,
+                mockReference
+            };
+            task.PackageDependencies = new ITaskItem[] { };
+            task.FileDependencies = new ITaskItem[] {
+                mockExternalProjectDep,
+                mockProjectDep,
+                mockContentDep,
+                mockPackageDep,
+                mockWinmdDep,
+                mockReferenceDep
+            };
+
+            // Act
+            var result = task.Execute();
+
+            // Assert
+            Assert.True(result);
+            Assert.Equal(1, task.DependenciesDesignTime.Count());
+
+            // Target with type
+            var resultTargets = task.DependenciesDesignTime
+                                                .Where(x => x.ItemSpec.Equals(".Net Framework,Version=v4.5")).ToArray();
+            Assert.Equal(1, resultTargets.Length);
+            VerifyTargetTaskItem(DependencyType.Target, mockTarget, resultTargets[0]);
+        }
+
+        [Fact]
+        public void PreprocessPackageDependenciesDesignTime_Assemblies_ChildAssemblies()
+        {
+            // Arrange 
+            // target definitions 
+            var mockTarget = new MockTaskItem(
+                itemSpec: ".Net Framework,Version=v4.5",
+                metadata: new Dictionary<string, string>
+                {
+                    { MetadataKeys.RuntimeIdentifier, "net45" },
+                    { MetadataKeys.TargetFrameworkMoniker, ".Net Framework,Version=v4.5" },
+                    { MetadataKeys.FrameworkName, ".Net Framework" },
+                    { MetadataKeys.FrameworkVersion, "4.5" },
+                    { MetadataKeys.Type, "Target" }
+                });
+
+            var mockPackage = new MockTaskItem(
+                itemSpec: "Package3/1.0.0",
+                metadata: new Dictionary<string, string>
+                {
+                    { MetadataKeys.Name, "Package3" },
+                    { MetadataKeys.Version, "1.0.0" },
+                    { MetadataKeys.Path, "some path" },
+                    { MetadataKeys.ResolvedPath, "some resolved path" },
+                    { MetadataKeys.Type, "Package" },
+                    { PreprocessPackageDependenciesDesignTime.ResolvedMetadata, "True" },
+                    { PreprocessPackageDependenciesDesignTime.DependenciesMetadata,
+                      @"mockChildAssembly1;somepath/mockChildAssembly2" }
+                });
+
+            var mockChildAssembly1 = new MockTaskItem(
+                itemSpec: @"mockChildAssembly1",
+                metadata: new Dictionary<string, string>
+                {
+                    { MetadataKeys.Name, "mockChildAssembly1" },
+                    { MetadataKeys.Path, "some path" },
+                    { MetadataKeys.ResolvedPath, "some resolved path" },
+                    { MetadataKeys.Type, "Assembly" },
+                    { PreprocessPackageDependenciesDesignTime.ResolvedMetadata, "True" }                   
+                });
+
+            var mockChildAssembly2 = new MockTaskItem(
+                itemSpec: @"somepath/mockChildAssembly2",
+                metadata: new Dictionary<string, string>
+                {
+                    { MetadataKeys.Name, "mockChildAssembly2" },
+                    { MetadataKeys.Path, "some path" },
+                    { MetadataKeys.ResolvedPath, "some resolved path" },
+                    { MetadataKeys.Type, "FrameworkAssembly" },
+                    { PreprocessPackageDependenciesDesignTime.ResolvedMetadata, "True" }
+                });
+
+            var mockChildAssemblyNoCompileMetadata = new MockTaskItem(
+                itemSpec: @"somepath/mockChildAssemblyNoCompileMetadata",
+                metadata: new Dictionary<string, string>
+                {
+                    { MetadataKeys.Name, "mockChildAssemblyNoCompileMetadata" },
+                    { MetadataKeys.Path, "some path" },
+                    { MetadataKeys.ResolvedPath, "some resolved path" },
+                    { MetadataKeys.Type, "Assembly" },
+                    { PreprocessPackageDependenciesDesignTime.ResolvedMetadata, "True" }
+                });
+
+            var mockPackageDep = new MockTaskItem(
+                itemSpec: "Package3/1.0.0",
+                metadata: new Dictionary<string, string>
+                {
+                    { MetadataKeys.ParentTarget, ".Net Framework,Version=v4.5" }
+                });
+
+            var mockChildAssemblyDep1 = new MockTaskItem(
+                itemSpec: "mockChildAssembly1",
+                metadata: new Dictionary<string, string>
+                {
+                    { MetadataKeys.ParentTarget, ".Net Framework,Version=v4.5" },
+                    { MetadataKeys.ParentPackage, "Package3/1.0.0" },
+                    { MetadataKeys.FileGroup, PreprocessPackageDependenciesDesignTime.CompileTimeAssemblyMetadata }
+                });
+
+            var mockChildAssemblyDep2 = new MockTaskItem(
+                itemSpec: @"somepath/mockChildAssembly2",
+                metadata: new Dictionary<string, string>
+                {
+                    { MetadataKeys.ParentTarget, ".Net Framework,Version=v4.5" },
+                    { MetadataKeys.ParentPackage, "Package3/1.0.0" },
+                    { MetadataKeys.FileGroup, PreprocessPackageDependenciesDesignTime.CompileTimeAssemblyMetadata }
+                });
+
+            var mockChildAssemblyNoCompileMetadataDep = new MockTaskItem(
+                itemSpec: "mockChildAssemblyNoCompileMetadata/2.0.0",
+                metadata: new Dictionary<string, string>
+                {
+                    { MetadataKeys.ParentTarget, ".Net Framework,Version=v4.5" },
+                    { MetadataKeys.ParentPackage, "Package3/1.0.0" }
+                });
+
+            var task = new PreprocessPackageDependenciesDesignTime();
+            task.TargetDefinitions = new[] { mockTarget };
+            task.PackageDefinitions = new ITaskItem[] {
+                mockPackage
+            };
+            task.FileDefinitions = new ITaskItem[] {
+                mockChildAssembly1,
+                mockChildAssembly2,
+                mockChildAssemblyNoCompileMetadata
+            };
+            task.PackageDependencies = new ITaskItem[] {
+                mockPackageDep
+            };
+            task.FileDependencies = new ITaskItem[] {
+                mockChildAssemblyDep1,
+                mockChildAssemblyDep2,
+                mockChildAssemblyNoCompileMetadataDep
+            };
+
+            // Act
+            var result = task.Execute();
+
+            // Assert
+            Assert.True(result);
+            Assert.Equal(4, task.DependenciesDesignTime.Count());
+
+            // Target with type
+            var resultTargets = task.DependenciesDesignTime
+                                                .Where(x => x.ItemSpec.Equals(".Net Framework,Version=v4.5")).ToArray();
+            Assert.Equal(1, resultTargets.Length);
+            VerifyTargetTaskItem(DependencyType.Target, mockTarget, resultTargets[0]);
+
+            // Package3/1.0.0
+            mockPackage.SetMetadata(MetadataKeys.Path, mockPackage.GetMetadata(MetadataKeys.ResolvedPath));
+            var resultPackage = task.DependenciesDesignTime
+                .Where(x => x.ItemSpec.Equals(".Net Framework,Version=v4.5/Package3/1.0.0")).ToArray();
+            Assert.Equal(1, resultPackage.Length);
+            VerifyTargetTaskItem(DependencyType.Package, mockPackage, resultPackage[0]);
+
+            // ChildAssembly1/1.0.0
+            mockChildAssembly1.SetMetadata(MetadataKeys.Path, mockChildAssembly1.GetMetadata(MetadataKeys.ResolvedPath));
+            var resultChildAssembly1 = task.DependenciesDesignTime
+                .Where(x => x.ItemSpec.Equals(".Net Framework,Version=v4.5/mockChildAssembly1")).ToArray();
+            Assert.Equal(1, resultChildAssembly1.Length);
+            VerifyTargetTaskItem(DependencyType.Assembly, mockChildAssembly1, resultChildAssembly1[0]);
+
+            // ChildAssembly2/1.0.0
+            mockChildAssembly2.SetMetadata(MetadataKeys.Path, mockChildAssembly2.GetMetadata(MetadataKeys.ResolvedPath));
+            var resultChildAssembly2 = task.DependenciesDesignTime
+                .Where(x => x.ItemSpec.Equals(".Net Framework,Version=v4.5/somepath/mockChildAssembly2")).ToArray();
+            Assert.Equal(1, resultChildAssembly2.Length);
+            VerifyTargetTaskItem(DependencyType.FrameworkAssembly, mockChildAssembly2, resultChildAssembly2[0]);
+        }
+
+        private void VerifyTargetTaskItem(DependencyType type, ITaskItem input, ITaskItem output)
+        {
+            Assert.Equal(type.ToString(),
+                         output.GetMetadata(MetadataKeys.Type));
+
+            // remove unnecessary metadata to keep only ones that would be in result task items
+            var removeMetadata = new[] { MetadataKeys.Type, MetadataKeys.ResolvedPath };
+
+            foreach(var rm in removeMetadata)
+            {
+                output.RemoveMetadata(rm);
+                input.RemoveMetadata(rm);
+            }
+
+            foreach (var metadata in input.MetadataNames)
+            {
+                Assert.Equal(input.GetMetadata(metadata.ToString()), output.GetMetadata(metadata.ToString()));
+            }
+        }
+    }
+}

--- a/src/Tasks/Microsoft.DotNet.Core.Build.Tasks/DependencyType.cs
+++ b/src/Tasks/Microsoft.DotNet.Core.Build.Tasks/DependencyType.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.DotNet.Core.Build.Tasks
+{
+    public enum DependencyType
+    {
+        Unknown,
+        Target,
+        Diagnostic,
+        Package,
+        Assembly,
+        FrameworkAssembly,
+        Content,
+        Project,
+        ExternalProject,
+        Reference,
+        Winmd
+    }
+}

--- a/src/Tasks/Microsoft.DotNet.Core.Build.Tasks/DependencyType.cs
+++ b/src/Tasks/Microsoft.DotNet.Core.Build.Tasks/DependencyType.cs
@@ -15,6 +15,7 @@ namespace Microsoft.DotNet.Core.Build.Tasks
         Project,
         ExternalProject,
         Reference,
-        Winmd
+        Winmd,
+        Unresolved
     }
 }

--- a/src/Tasks/Microsoft.DotNet.Core.Build.Tasks/MetadataKeys.cs
+++ b/src/Tasks/Microsoft.DotNet.Core.Build.Tasks/MetadataKeys.cs
@@ -3,29 +3,29 @@
 
 namespace Microsoft.DotNet.Core.Build.Tasks
 {
-    internal static class MetadataKeys
+    public static class MetadataKeys
     {
         // General Metadata
-        internal const string Name = "Name";
-        internal const string Type = "Type";
-        internal const string Version = "Version";
-        internal const string FileGroup = "FileGroup";
-        internal const string Path = "Path";
-        internal const string ResolvedPath = "ResolvedPath";
+        public const string Name = "Name";
+        public const string Type = "Type";
+        public const string Version = "Version";
+        public const string FileGroup = "FileGroup";
+        public const string Path = "Path";
+        public const string ResolvedPath = "ResolvedPath";
 
         // Target Metadata
-        internal const string RuntimeIdentifier = "RuntimeIdentifier";
-        internal const string TargetFrameworkMoniker = "TargetFrameworkMoniker";
-        internal const string FrameworkName = "FrameworkName";
-        internal const string FrameworkVersion = "FrameworkVersion";
+        public const string RuntimeIdentifier = "RuntimeIdentifier";
+        public const string TargetFrameworkMoniker = "TargetFrameworkMoniker";
+        public const string FrameworkName = "FrameworkName";
+        public const string FrameworkVersion = "FrameworkVersion";
 
         // Foreign Keys
-        internal const string ParentTarget = "ParentTarget";
-        internal const string ParentTargetLibrary = "ParentTargetLibrary";
-        internal const string ParentPackage = "ParentPackage";
+        public const string ParentTarget = "ParentTarget";
+        public const string ParentTargetLibrary = "ParentTargetLibrary";
+        public const string ParentPackage = "ParentPackage";
 
         // Tags
-        internal const string Analyzer = "Analyzer";
-        internal const string AnalyzerLanguage = "AnalyzerLanguage";
+        public const string Analyzer = "Analyzer";
+        public const string AnalyzerLanguage = "AnalyzerLanguage";
     }
 }

--- a/src/Tasks/Microsoft.DotNet.Core.Build.Tasks/Microsoft.DotNet.Core.Build.Tasks.csproj
+++ b/src/Tasks/Microsoft.DotNet.Core.Build.Tasks/Microsoft.DotNet.Core.Build.Tasks.csproj
@@ -19,6 +19,8 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="LockFileTargetExtensions.cs" />
+    <Compile Include="DependencyType.cs" />
+    <Compile Include="PreprocessPackageDependenciesDesignTime.cs" />
     <Compile Include="RuntimeConfig.cs" />
     <Compile Include="RuntimeConfigFramework.cs" />
     <Compile Include="RuntimeOptions.cs" />

--- a/src/Tasks/Microsoft.DotNet.Core.Build.Tasks/PreprocessPackageDependenciesDesignTime.cs
+++ b/src/Tasks/Microsoft.DotNet.Core.Build.Tasks/PreprocessPackageDependenciesDesignTime.cs
@@ -14,7 +14,7 @@ namespace Microsoft.DotNet.Core.Build.Tasks
     /// Task combines data returned from ResolvePackageDependencies into single items collection
     /// that can be consumed by DesignTime build and contains all info needed to expand packages
     /// dependency graph.
-    /// If any changes made here, make sure corresponding changes are made to NuGetDependenciesSubTreeProvider
+    /// If any changes are made here, make sure corresponding changes are made to NuGetDependenciesSubTreeProvider
     /// in roslyn-project-system repo and corresponding tests.
     /// 
     /// TODO: Add support for diagnostics, related issue https://github.com/dotnet/sdk/issues/26
@@ -43,17 +43,17 @@ namespace Microsoft.DotNet.Core.Build.Tasks
         [Output]
         public ITaskItem[] DependenciesDesignTime { get; set; }
 
-        private Dictionary<string, DependencyMetadata> Targets { get; set; }
-                    = new Dictionary<string, DependencyMetadata>(StringComparer.OrdinalIgnoreCase);
+        private Dictionary<string, ItemMetadata> Targets { get; set; }
+                    = new Dictionary<string, ItemMetadata>(StringComparer.OrdinalIgnoreCase);
 
-        private Dictionary<string, DependencyMetadata> Packages { get; set; }
-                    = new Dictionary<string, DependencyMetadata>(StringComparer.OrdinalIgnoreCase);
+        private Dictionary<string, ItemMetadata> Packages { get; set; }
+                    = new Dictionary<string, ItemMetadata>(StringComparer.OrdinalIgnoreCase);
 
-        private Dictionary<string, DependencyMetadata> Assemblies { get; set; }
-                    = new Dictionary<string, DependencyMetadata>(StringComparer.OrdinalIgnoreCase);
+        private Dictionary<string, ItemMetadata> Assemblies { get; set; }
+                    = new Dictionary<string, ItemMetadata>(StringComparer.OrdinalIgnoreCase);
 
-        private Dictionary<string, DependencyMetadata> DependenciesWorld { get; set; }
-                    = new Dictionary<string, DependencyMetadata>(StringComparer.OrdinalIgnoreCase);
+        private Dictionary<string, ItemMetadata> DependenciesWorld { get; set; }
+                    = new Dictionary<string, ItemMetadata>(StringComparer.OrdinalIgnoreCase);
 
         public override bool Execute()
         {
@@ -71,20 +71,14 @@ namespace Microsoft.DotNet.Core.Build.Tasks
                 return string.IsNullOrEmpty(fileGroup) || !fileGroup.Equals(CompileTimeAssemblyMetadata);
             });
 
-            // prepare output collection
-            DependenciesDesignTime = DependenciesWorld.Select(kvp =>
+            // prepare output collection: add corresponding metadata to ITaskItem based in item type
+            DependenciesDesignTime = DependenciesWorld.Select(itemKvp =>
             {
-                var newTaskItem = new TaskItem(kvp.Key);
-                newTaskItem.SetMetadata(MetadataKeys.RuntimeIdentifier, kvp.Value.RuntimeIdentifier);
-                newTaskItem.SetMetadata(MetadataKeys.TargetFrameworkMoniker, kvp.Value.TargetFrameworkMoniker);
-                newTaskItem.SetMetadata(MetadataKeys.FrameworkName, kvp.Value.FrameworkName);
-                newTaskItem.SetMetadata(MetadataKeys.FrameworkVersion, kvp.Value.FrameworkVersion);
-                newTaskItem.SetMetadata(MetadataKeys.Name, kvp.Value.Name);
-                newTaskItem.SetMetadata(MetadataKeys.Version, kvp.Value.Version);
-                newTaskItem.SetMetadata(MetadataKeys.Path, kvp.Value.Path);
-                newTaskItem.SetMetadata(MetadataKeys.Type, kvp.Value.DependencyType.ToString());
-                newTaskItem.SetMetadata(ResolvedMetadata, kvp.Value.Resolved.ToString());
-                newTaskItem.SetMetadata(DependenciesMetadata, string.Join(";", kvp.Value.Dependencies));
+                var newTaskItem = new TaskItem(itemKvp.Key);
+                foreach(var metadataKvp in itemKvp.Value.ToDictionary())
+                {
+                    newTaskItem.SetMetadata(metadataKvp.Key, metadataKvp.Value);
+                }
 
                 return newTaskItem;
             }).ToArray();
@@ -92,6 +86,9 @@ namespace Microsoft.DotNet.Core.Build.Tasks
             return true;
         }
 
+        /// <summary>
+        /// Adds targets from TargetDefinitions to dependencies world collection
+        /// </summary>
         private void PopulateTargets()
         {
             foreach (var targetDef in TargetDefinitions)
@@ -109,33 +106,20 @@ namespace Microsoft.DotNet.Core.Build.Tasks
                     continue;
                 }
 
-                var target = new DependencyMetadata(
-                                runtimeIdentifier: targetDef.GetMetadata(MetadataKeys.RuntimeIdentifier),
-                                targetFrameworkMoniker: targetDef.GetMetadata(MetadataKeys.TargetFrameworkMoniker),
-                                frameworkName: targetDef.GetMetadata(MetadataKeys.FrameworkName),
-                                frameworkVersion: targetDef.GetMetadata(MetadataKeys.FrameworkVersion),
-                                type: dependencyType);
+                var target = new TargetMetadata(targetDef);
+                                
                 Targets[targetDef.ItemSpec] = target;
 
                 // add target to the world now, since it does not have parents
                 DependenciesWorld[targetDef.ItemSpec] = target;
             }
         }
-        
-        private DependencyType GetDependencyType(string dependencyTypeString)
-        {
-            var dependencyType = DependencyType.Unknown;
-            if (!string.IsNullOrEmpty(dependencyTypeString))
-            {
-                Enum.TryParse(dependencyTypeString, /* ignoreCase */ true, out dependencyType);
-            }
 
-            return dependencyType;
-        }
-
+        /// <summary>
+        /// Adds packages from PackageDefinitions to the dependencies world dictionary.
+        /// </summary>
         private void PopulatePackages()
         {
-            // populate unique packages 
             foreach (var packageDef in PackageDefinitions)
             {
                 var dependencyType = GetDependencyType(packageDef.GetMetadata(MetadataKeys.Type));
@@ -148,18 +132,16 @@ namespace Microsoft.DotNet.Core.Build.Tasks
                     continue;
                 }
 
-                var dependency = new DependencyMetadata(name: packageDef.GetMetadata(MetadataKeys.Name),
-                                                        version: packageDef.GetMetadata(MetadataKeys.Version),
-                                                        type: DependencyType.Package,
-                                                        path: packageDef.GetMetadata(MetadataKeys.Path),
-                                                        resolvedPath: packageDef.GetMetadata(MetadataKeys.ResolvedPath));
+                var dependency = new PackageMetadata(packageDef);
                 Packages[packageDef.ItemSpec] = dependency;
             }
         }
 
+        /// <summary>
+        /// Adds assemblies and framework assemblies form FileDefinitons to dependencies world dictionary.
+        /// </summary>
         private void PopulateAssemblies()
         {
-            // populate unique assembly files 
             foreach (var fileDef in FileDefinitions)
             {
                 var dependencyType = GetDependencyType(fileDef.GetMetadata(MetadataKeys.Type));
@@ -170,15 +152,23 @@ namespace Microsoft.DotNet.Core.Build.Tasks
                 }
 
                 var name = Path.GetFileName(fileDef.ItemSpec);
-                var assembly = new DependencyMetadata(name: name,
-                                                      type: dependencyType,
-                                                      path: fileDef.GetMetadata(MetadataKeys.Path),
-                                                      resolvedPath: fileDef.GetMetadata(MetadataKeys.ResolvedPath));
+                var assembly = new AssemblyMetadata(dependencyType, fileDef, name);
                 Assemblies[fileDef.ItemSpec] = assembly;
             }
         }
 
-        private void AddDependenciesToTheWorld(Dictionary<string, DependencyMetadata> items,
+        private DependencyType GetDependencyType(string dependencyTypeString)
+        {
+            var dependencyType = DependencyType.Unknown;
+            if (!string.IsNullOrEmpty(dependencyTypeString))
+            {
+                Enum.TryParse(dependencyTypeString, /* ignoreCase */ true, out dependencyType);
+            }
+
+            return dependencyType;
+        }
+
+        private void AddDependenciesToTheWorld(Dictionary<string, ItemMetadata> items,
                                                ITaskItem[] itemDependencies,
                                                Func<ITaskItem, bool> shouldSkipItemCheck = null)
         {
@@ -191,7 +181,7 @@ namespace Microsoft.DotNet.Core.Build.Tasks
                     continue;
                 }
 
-                if (shouldSkipItemCheck != null && shouldSkipItemCheck.Invoke(dependency))
+                if (shouldSkipItemCheck != null && shouldSkipItemCheck(dependency))
                 {
                     continue;
                 }
@@ -216,7 +206,7 @@ namespace Microsoft.DotNet.Core.Build.Tasks
 
                 // update parent
                 var parentDependencyId = $"{parentTargetId}/{parentPackageId}".Trim('/');
-                DependencyMetadata parentDependency = null;
+                ItemMetadata parentDependency = null;
                 if (DependenciesWorld.TryGetValue(parentDependencyId, out parentDependency))
                 {
 
@@ -224,7 +214,7 @@ namespace Microsoft.DotNet.Core.Build.Tasks
                 }
                 else
                 {
-                    // create new parent
+                    // Update parent's Dependencies count and make sure parent is in the dependencies world
                     if (!string.IsNullOrEmpty(parentPackageId))
                     {
                         parentDependency = Packages[parentPackageId];
@@ -240,53 +230,101 @@ namespace Microsoft.DotNet.Core.Build.Tasks
             }
         }
 
-        private class DependencyMetadata
+        private abstract class ItemMetadata
         {
-            public DependencyMetadata(string name = null,
-                                      string version = null,
-                                      DependencyType type = DependencyType.Unknown,
-                                      string path = null,
-                                      string resolvedPath = null,
-                                      string runtimeIdentifier = null,
-                                      string targetFrameworkMoniker = null,
-                                      string frameworkName = null,
-                                      string frameworkVersion = null)
+            public ItemMetadata(DependencyType type)
             {
-                Name = name ?? string.Empty;
-                Version = version ?? string.Empty;
-                DependencyType = type;
-
-                Resolved = DependencyType != DependencyType.Unknown && !string.IsNullOrEmpty(resolvedPath);
-
-                Path = Resolved 
-                        ? resolvedPath
-                        : path ?? string.Empty;
-
-                RuntimeIdentifier = runtimeIdentifier ?? string.Empty;
-                TargetFrameworkMoniker = targetFrameworkMoniker ?? string.Empty;
-                FrameworkName = frameworkName ?? string.Empty;
-                FrameworkVersion = frameworkVersion ?? string.Empty;
-
+                Type = type;
                 Dependencies = new List<string>();
             }
 
-            // dependency properties
-            public string Name { get; private set; }
-            public string Version { get; private set; }
-            public DependencyType DependencyType { get; private set; }
-            public string Path { get; private set; }
-            public bool Resolved { get; private set; }
-
-            // target framework properties
-            public string RuntimeIdentifier { get; private set; }
-            public string TargetFrameworkMoniker { get; private set; }
-            public string FrameworkName { get; private set; }
-            public string FrameworkVersion { get; private set; }
+            public DependencyType Type { get; protected set; }
 
             /// <summary>
-            /// a list of name/version strings to specify dependencies identities
+            /// A list of name/version strings to specify dependency identities.
+            /// Note: identity here is just a "name/version" and does not have TFM part in front.
             /// </summary>
-            public IList<string> Dependencies { get; private set; }
+            public IList<string> Dependencies { get; }
+
+            /// <summary>
+            /// Returns name/value pairs for metadata specific to given item type's implementation.
+            /// </summary>
+            /// <returns></returns>
+            public abstract IDictionary<string, string> ToDictionary();
+        }
+
+        private class TargetMetadata : ItemMetadata
+        {
+            public TargetMetadata(ITaskItem item)
+                :base(DependencyType.Target)
+            {
+                RuntimeIdentifier = item.GetMetadata(MetadataKeys.RuntimeIdentifier) ?? string.Empty;
+                TargetFrameworkMoniker = item.GetMetadata(MetadataKeys.TargetFrameworkMoniker) ?? string.Empty;
+                FrameworkName = item.GetMetadata(MetadataKeys.FrameworkName) ?? string.Empty;
+                FrameworkVersion = item.GetMetadata(MetadataKeys.FrameworkVersion) ?? string.Empty;
+            }
+
+            public string RuntimeIdentifier { get; }
+            public string TargetFrameworkMoniker { get; }
+            public string FrameworkName { get; }
+            public string FrameworkVersion { get; }
+
+            public override IDictionary<string, string> ToDictionary()
+            {
+                return new Dictionary<string, string>
+                {
+                    { MetadataKeys.RuntimeIdentifier, RuntimeIdentifier },
+                    { MetadataKeys.TargetFrameworkMoniker, TargetFrameworkMoniker },
+                    { MetadataKeys.FrameworkName, FrameworkName },
+                    { MetadataKeys.FrameworkVersion, FrameworkVersion },
+                    { MetadataKeys.Type, Type.ToString() },
+                    { DependenciesMetadata, string.Join(";", Dependencies) }
+                };
+            }
+        }
+
+        private class PackageMetadata : ItemMetadata
+        {
+            public PackageMetadata(ITaskItem item)
+                : base(DependencyType.Package)
+            {
+                Name = item.GetMetadata(MetadataKeys.Name) ?? string.Empty;
+                Version = item.GetMetadata(MetadataKeys.Version) ?? string.Empty;
+                Resolved = Type != DependencyType.Unknown && !string.IsNullOrEmpty(item.GetMetadata(MetadataKeys.ResolvedPath));
+                Path = (Resolved
+                        ? item.GetMetadata(MetadataKeys.ResolvedPath)
+                        : item.GetMetadata(MetadataKeys.Path)) ?? string.Empty;
+            }
+
+            public string Name { get; protected set; }
+            public string Version { get; }
+            public string Path { get; }
+            public bool Resolved { get; }
+
+            public override IDictionary<string, string> ToDictionary()
+            {
+                return new Dictionary<string, string>
+                {
+                    { MetadataKeys.Name, Name },
+                    { MetadataKeys.Version, Version },
+                    { MetadataKeys.Path, Path },
+                    { MetadataKeys.Type, Type.ToString() },
+                    { ResolvedMetadata, ResolvedMetadata.ToString() },
+                    { DependenciesMetadata, string.Join(";", Dependencies) }
+                };
+            }
+        }
+
+        private class AssemblyMetadata : PackageMetadata
+        {
+            public AssemblyMetadata(DependencyType type,
+                                    ITaskItem item,
+                                    string name)
+                : base(item)
+            {
+                Name = name ?? string.Empty;
+                Type = type;
+            }
         }
     }
 }

--- a/src/Tasks/Microsoft.DotNet.Core.Build.Tasks/PreprocessPackageDependenciesDesignTime.cs
+++ b/src/Tasks/Microsoft.DotNet.Core.Build.Tasks/PreprocessPackageDependenciesDesignTime.cs
@@ -209,7 +209,6 @@ namespace Microsoft.DotNet.Core.Build.Tasks
                 ItemMetadata parentDependency = null;
                 if (DependenciesWorld.TryGetValue(parentDependencyId, out parentDependency))
                 {
-
                     parentDependency.Dependencies.Add(currentItemId);
                 }
                 else

--- a/src/Tasks/Microsoft.DotNet.Core.Build.Tasks/PreprocessPackageDependenciesDesignTime.cs
+++ b/src/Tasks/Microsoft.DotNet.Core.Build.Tasks/PreprocessPackageDependenciesDesignTime.cs
@@ -140,7 +140,7 @@ namespace Microsoft.DotNet.Core.Build.Tasks
             {
                 var dependencyType = GetDependencyType(packageDef.GetMetadata(MetadataKeys.Type));
                 if (dependencyType != DependencyType.Package &&
-                    dependencyType != DependencyType.Unknown)
+                    dependencyType != DependencyType.Unresolved)
                 {
                     // we ignore all other dependency types since 
                     //      - assemblies we handle separatelly below 
@@ -150,7 +150,7 @@ namespace Microsoft.DotNet.Core.Build.Tasks
 
                 var dependency = new DependencyMetadata(name: packageDef.GetMetadata(MetadataKeys.Name),
                                                         version: packageDef.GetMetadata(MetadataKeys.Version),
-                                                        type: dependencyType,
+                                                        type: DependencyType.Package,
                                                         path: packageDef.GetMetadata(MetadataKeys.Path),
                                                         resolvedPath: packageDef.GetMetadata(MetadataKeys.ResolvedPath));
                 Packages[packageDef.ItemSpec] = dependency;

--- a/src/Tasks/Microsoft.DotNet.Core.Build.Tasks/PreprocessPackageDependenciesDesignTime.cs
+++ b/src/Tasks/Microsoft.DotNet.Core.Build.Tasks/PreprocessPackageDependenciesDesignTime.cs
@@ -87,7 +87,7 @@ namespace Microsoft.DotNet.Core.Build.Tasks
         }
 
         /// <summary>
-        /// Adds targets from TargetDefinitions to dependencies world collection
+        /// Adds targets from TargetDefinitions to dependencies world dictionary
         /// </summary>
         private void PopulateTargets()
         {
@@ -138,7 +138,7 @@ namespace Microsoft.DotNet.Core.Build.Tasks
         }
 
         /// <summary>
-        /// Adds assemblies and framework assemblies form FileDefinitons to dependencies world dictionary.
+        /// Adds assemblies and framework assemblies from FileDefinitons to dependencies world dictionary.
         /// </summary>
         private void PopulateAssemblies()
         {
@@ -309,7 +309,7 @@ namespace Microsoft.DotNet.Core.Build.Tasks
                     { MetadataKeys.Version, Version },
                     { MetadataKeys.Path, Path },
                     { MetadataKeys.Type, Type.ToString() },
-                    { ResolvedMetadata, ResolvedMetadata.ToString() },
+                    { ResolvedMetadata, Resolved.ToString() },
                     { DependenciesMetadata, string.Join(";", Dependencies) }
                 };
             }

--- a/src/Tasks/Microsoft.DotNet.Core.Build.Tasks/PreprocessPackageDependenciesDesignTime.cs
+++ b/src/Tasks/Microsoft.DotNet.Core.Build.Tasks/PreprocessPackageDependenciesDesignTime.cs
@@ -1,0 +1,292 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+namespace Microsoft.DotNet.Core.Build.Tasks
+{
+    /// <summary>
+    /// Task combines data returned from ResolvePackageDependencies into single items collection
+    /// that can be consumed by DesignTime build and contains all info needed to expand packages
+    /// dependency graph.
+    /// If any changes made here, make sure corresponding changes are made to NuGetDependenciesSubTreeProvider
+    /// in roslyn-project-system repo and corresponding tests.
+    /// 
+    /// TODO: Add support for diagnostics, related issue https://github.com/dotnet/sdk/issues/26
+    /// </summary>
+    public class PreprocessPackageDependenciesDesignTime : Task
+    {
+        public const string DependenciesMetadata = "Dependencies";
+        public const string CompileTimeAssemblyMetadata = "CompileTimeAssembly";
+        public const string ResolvedMetadata = "Resolved";
+
+        [Required]
+        public ITaskItem[] TargetDefinitions { get; set; }
+
+        [Required]
+        public ITaskItem[] PackageDefinitions { get; set; }
+
+        [Required]
+        public ITaskItem[] FileDefinitions { get; set; }
+
+        [Required]
+        public ITaskItem[] PackageDependencies { get; set; }
+
+        [Required]
+        public ITaskItem[] FileDependencies { get; set; }
+
+        [Output]
+        public ITaskItem[] DependenciesDesignTime { get; set; }
+
+        private Dictionary<string, DependencyMetadata> Targets { get; set; }
+                    = new Dictionary<string, DependencyMetadata>(StringComparer.OrdinalIgnoreCase);
+
+        private Dictionary<string, DependencyMetadata> Packages { get; set; }
+                    = new Dictionary<string, DependencyMetadata>(StringComparer.OrdinalIgnoreCase);
+
+        private Dictionary<string, DependencyMetadata> Assemblies { get; set; }
+                    = new Dictionary<string, DependencyMetadata>(StringComparer.OrdinalIgnoreCase);
+
+        private Dictionary<string, DependencyMetadata> DependenciesWorld { get; set; }
+                    = new Dictionary<string, DependencyMetadata>(StringComparer.OrdinalIgnoreCase);
+
+        public override bool Execute()
+        {
+            PopulateTargets();
+
+            PopulatePackages();
+
+            PopulateAssemblies();
+
+            AddDependenciesToTheWorld(Packages, PackageDependencies);
+
+            AddDependenciesToTheWorld(Assemblies, FileDependencies, (item) =>
+            {
+                var fileGroup = item.GetMetadata(MetadataKeys.FileGroup);
+                return string.IsNullOrEmpty(fileGroup) || !fileGroup.Equals(CompileTimeAssemblyMetadata);
+            });
+
+            // prepare output collection
+            DependenciesDesignTime = DependenciesWorld.Select(kvp =>
+            {
+                var newTaskItem = new TaskItem(kvp.Key);
+                newTaskItem.SetMetadata(MetadataKeys.RuntimeIdentifier, kvp.Value.RuntimeIdentifier);
+                newTaskItem.SetMetadata(MetadataKeys.TargetFrameworkMoniker, kvp.Value.TargetFrameworkMoniker);
+                newTaskItem.SetMetadata(MetadataKeys.FrameworkName, kvp.Value.FrameworkName);
+                newTaskItem.SetMetadata(MetadataKeys.FrameworkVersion, kvp.Value.FrameworkVersion);
+                newTaskItem.SetMetadata(MetadataKeys.Name, kvp.Value.Name);
+                newTaskItem.SetMetadata(MetadataKeys.Version, kvp.Value.Version);
+                newTaskItem.SetMetadata(MetadataKeys.Path, kvp.Value.Path);
+                newTaskItem.SetMetadata(MetadataKeys.Type, kvp.Value.DependencyType.ToString());
+                newTaskItem.SetMetadata(ResolvedMetadata, kvp.Value.Resolved.ToString());
+                newTaskItem.SetMetadata(DependenciesMetadata, string.Join(";", kvp.Value.Dependencies));
+
+                return newTaskItem;
+            }).ToArray();
+
+            return true;
+        }
+
+        private void PopulateTargets()
+        {
+            foreach (var targetDef in TargetDefinitions)
+            {
+                if (string.IsNullOrEmpty(targetDef.ItemSpec) || targetDef.ItemSpec.Contains("/"))
+                {
+                    // skip "target/rid"s and only consume actual targets
+                    continue;
+                }
+
+                var dependencyType = GetDependencyType(targetDef.GetMetadata(MetadataKeys.Type));
+                if (dependencyType != DependencyType.Target)
+                {
+                    // keep only targets here
+                    continue;
+                }
+
+                var target = new DependencyMetadata(
+                                runtimeIdentifier: targetDef.GetMetadata(MetadataKeys.RuntimeIdentifier),
+                                targetFrameworkMoniker: targetDef.GetMetadata(MetadataKeys.TargetFrameworkMoniker),
+                                frameworkName: targetDef.GetMetadata(MetadataKeys.FrameworkName),
+                                frameworkVersion: targetDef.GetMetadata(MetadataKeys.FrameworkVersion),
+                                type: dependencyType);
+                Targets[targetDef.ItemSpec] = target;
+
+                // add target to the world now, since it does not have parents
+                DependenciesWorld[targetDef.ItemSpec] = target;
+            }
+        }
+        
+        private DependencyType GetDependencyType(string dependencyTypeString)
+        {
+            var dependencyType = DependencyType.Unknown;
+            if (!string.IsNullOrEmpty(dependencyTypeString))
+            {
+                Enum.TryParse(dependencyTypeString, /* ignoreCase */ true, out dependencyType);
+            }
+
+            return dependencyType;
+        }
+
+        private void PopulatePackages()
+        {
+            // populate unique packages 
+            foreach (var packageDef in PackageDefinitions)
+            {
+                var dependencyType = GetDependencyType(packageDef.GetMetadata(MetadataKeys.Type));
+                if (dependencyType != DependencyType.Package &&
+                    dependencyType != DependencyType.Unknown)
+                {
+                    // we ignore all other dependency types since 
+                    //      - assemblies we handle separatelly below 
+                    //      - projects we don't care here, since they are sent to project system via other route
+                    continue;
+                }
+
+                var dependency = new DependencyMetadata(name: packageDef.GetMetadata(MetadataKeys.Name),
+                                                        version: packageDef.GetMetadata(MetadataKeys.Version),
+                                                        type: dependencyType,
+                                                        path: packageDef.GetMetadata(MetadataKeys.Path),
+                                                        resolvedPath: packageDef.GetMetadata(MetadataKeys.ResolvedPath));
+                Packages[packageDef.ItemSpec] = dependency;
+            }
+        }
+
+        private void PopulateAssemblies()
+        {
+            // populate unique assembly files 
+            foreach (var fileDef in FileDefinitions)
+            {
+                var dependencyType = GetDependencyType(fileDef.GetMetadata(MetadataKeys.Type));
+                if (dependencyType != DependencyType.Assembly &&
+                    dependencyType != DependencyType.FrameworkAssembly)
+                {
+                    continue;
+                }
+
+                var name = Path.GetFileName(fileDef.ItemSpec);
+                var assembly = new DependencyMetadata(name: name,
+                                                      type: dependencyType,
+                                                      path: fileDef.GetMetadata(MetadataKeys.Path),
+                                                      resolvedPath: fileDef.GetMetadata(MetadataKeys.ResolvedPath));
+                Assemblies[fileDef.ItemSpec] = assembly;
+            }
+        }
+
+        private void AddDependenciesToTheWorld(Dictionary<string, DependencyMetadata> items,
+                                               ITaskItem[] itemDependencies,
+                                               Func<ITaskItem, bool> shouldSkipItemCheck = null)
+        {
+            foreach (var dependency in itemDependencies)
+            {
+                var currentItemId = dependency.ItemSpec;
+                if (!items.Keys.Contains(currentItemId))
+                {
+                    // if this package definition does not even exist - skip it
+                    continue;
+                }
+
+                if (shouldSkipItemCheck != null && shouldSkipItemCheck.Invoke(dependency))
+                {
+                    continue;
+                }
+
+                var parentTargetId = dependency.GetMetadata(MetadataKeys.ParentTarget);
+                if (parentTargetId.Contains("/") || !Targets.Keys.Contains(parentTargetId))
+                {
+                    // skip "target/rid"s and only consume actual targets and ignore non-existent parent targets
+                    continue;
+                }
+
+                var parentPackageId = dependency.GetMetadata(MetadataKeys.ParentPackage);
+                if (!string.IsNullOrEmpty(parentPackageId) && !Packages.Keys.Contains(parentPackageId))
+                {
+                    // ignore non-existent parent packages
+                    continue;
+                }
+
+                var currentPackageUniqueId = $"{parentTargetId}/{currentItemId}";
+                // add current package to dependencies world
+                DependenciesWorld[currentPackageUniqueId] = items[currentItemId];
+
+                // update parent
+                var parentDependencyId = $"{parentTargetId}/{parentPackageId}".Trim('/');
+                DependencyMetadata parentDependency = null;
+                if (DependenciesWorld.TryGetValue(parentDependencyId, out parentDependency))
+                {
+
+                    parentDependency.Dependencies.Add(currentItemId);
+                }
+                else
+                {
+                    // create new parent
+                    if (!string.IsNullOrEmpty(parentPackageId))
+                    {
+                        parentDependency = Packages[parentPackageId];
+                    }
+                    else
+                    {
+                        parentDependency = Targets[parentTargetId];
+                    }
+
+                    parentDependency.Dependencies.Add(currentItemId);
+                    DependenciesWorld[parentDependencyId] = parentDependency;
+                }
+            }
+        }
+
+        private class DependencyMetadata
+        {
+            public DependencyMetadata(string name = null,
+                                      string version = null,
+                                      DependencyType type = DependencyType.Unknown,
+                                      string path = null,
+                                      string resolvedPath = null,
+                                      string runtimeIdentifier = null,
+                                      string targetFrameworkMoniker = null,
+                                      string frameworkName = null,
+                                      string frameworkVersion = null)
+            {
+                Name = name ?? string.Empty;
+                Version = version ?? string.Empty;
+                DependencyType = type;
+
+                Resolved = DependencyType != DependencyType.Unknown && !string.IsNullOrEmpty(resolvedPath);
+
+                Path = Resolved 
+                        ? resolvedPath
+                        : path ?? string.Empty;
+
+                RuntimeIdentifier = runtimeIdentifier ?? string.Empty;
+                TargetFrameworkMoniker = targetFrameworkMoniker ?? string.Empty;
+                FrameworkName = frameworkName ?? string.Empty;
+                FrameworkVersion = frameworkVersion ?? string.Empty;
+
+                Dependencies = new List<string>();
+            }
+
+            // dependency properties
+            public string Name { get; private set; }
+            public string Version { get; private set; }
+            public DependencyType DependencyType { get; private set; }
+            public string Path { get; private set; }
+            public bool Resolved { get; private set; }
+
+            // target framework properties
+            public string RuntimeIdentifier { get; private set; }
+            public string TargetFrameworkMoniker { get; private set; }
+            public string FrameworkName { get; private set; }
+            public string FrameworkVersion { get; private set; }
+
+            /// <summary>
+            /// a list of name/version strings to specify dependencies identities
+            /// </summary>
+            public IList<string> Dependencies { get; private set; }
+        }
+    }
+}


### PR DESCRIPTION
Task that converts project.lock.json data provided by ResolvePackageDependencies to the format that can be consumed by DesignTime build for Dependencies tree Nuget node
