### PR TITLE
Use the NuGetPackageResolver to get the package directory path instead of using the environment variables ourselves.

### DIFF
--- a/Test/Microsoft.DotNet.TestFramework/Commands/RestoreCommand.cs
+++ b/Test/Microsoft.DotNet.TestFramework/Commands/RestoreCommand.cs
@@ -20,7 +20,6 @@ namespace Microsoft.DotNet.TestFramework.Commands
             //newArgs.Insert(0, FullPathProjectFile);
             //var command = MSBuild.CreateCommandForTarget("restore", newArgs.ToArray());
 
-            newArgs.Insert(0, "--legacy-packages-directory");
             newArgs.Insert(0, ProjectRootPath);
             newArgs.Insert(0, "restore");
             var command = Command.Create(RepoInfo.DotNetHostPath, newArgs);

--- a/src/Tasks/Microsoft.DotNet.Core.Build.Tasks/build/netstandard1.0/Microsoft.PackageDependencyResolution.targets
+++ b/src/Tasks/Microsoft.DotNet.Core.Build.Tasks/build/netstandard1.0/Microsoft.PackageDependencyResolution.targets
@@ -130,6 +130,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     -->
   <Target Name="RunResolvePackageDependencies">
     <ResolvePackageDependencies
+      ProjectPath="$(MSBuildProjectFullPath)"
       ProjectLockFile="$(ProjectLockFile)">
 
       <Output TaskParameter="TargetDefinitions" ItemName="TargetDefinitions" />


### PR DESCRIPTION
Fix #24
Fix #76

@brthor @natidea 
