### PR TITLE
Fix build.proj to fail whenever xunit returns a non-zero exit code.

### DIFF
--- a/build/build.proj
+++ b/build/build.proj
@@ -104,7 +104,7 @@
       <Output TaskParameter="ExitCode" PropertyName="ExitCode" />
     </Exec>
 
-    <Error Text="There were test failures, for full log see %(XmlTestFile.FullPath)" Condition="$(ExitCode) == 1" />
+    <Error Text="There were test failures, for full log see %(XmlTestFile.FullPath)" Condition="$(ExitCode) != 0" />
 
   </Target>
 


### PR DESCRIPTION
@333fred @livarcocc 

/cc @dotnet/project-system 
