### PR TITLE
Add more net46 assemblies to our sdk.nupkg

### DIFF
--- a/build/Nuget/Microsoft.DotNet.Core.Sdk.Nuget.targets
+++ b/build/Nuget/Microsoft.DotNet.Core.Sdk.Nuget.targets
@@ -55,12 +55,22 @@
         <DestinationTFM>netcoreapp1.0</DestinationTFM>
       </CopyLocalAssembly>
 
+      <CopyLocalAssembly Include="System.Runtime.InteropServices.RuntimeInformation">
+        <Version>4.0.0</Version>
+        <TFM>net45</TFM>
+        <DestinationTFM>net46</DestinationTFM>
+      </CopyLocalAssembly>
       <CopyLocalAssembly Include="System.Security.Cryptography.Algorithms">
         <Version>4.2.0</Version>
         <TFM>net46</TFM>
         <DestinationTFM>net46</DestinationTFM>
       </CopyLocalAssembly>
       <CopyLocalAssembly Include="System.Security.Cryptography.Primitives">
+        <Version>4.0.0</Version>
+        <TFM>net46</TFM>
+        <DestinationTFM>net46</DestinationTFM>
+      </CopyLocalAssembly>
+      <CopyLocalAssembly Include="System.Threading.Thread">
         <Version>4.0.0</Version>
         <TFM>net46</TFM>
         <DestinationTFM>net46</DestinationTFM>


### PR DESCRIPTION
Add System.Runtime.InteropServices.RuntimeInformation and System.Threading.Thread to the net46 assemblies in our .nupkg so the build tasks can be loaded in desktop MSBuild.

@natidea @srivatsn 

/cc @dotnet/project-system @brthor @livarcocc @piotrpMSFT 
