### PR TITLE
Add ResolvePackageDependeciesDesignTime target

### DIFF
--- a/src/Tasks/Microsoft.NETCore.Build.Tasks/build/netstandard1.0/Microsoft.PackageDependencyResolution.targets
+++ b/src/Tasks/Microsoft.NETCore.Build.Tasks/build/netstandard1.0/Microsoft.PackageDependencyResolution.targets
@@ -144,6 +144,33 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <!--
     ============================================================
+                     ResolvePackageDependenciesDesignTime
+
+    Aggregate the dependencies produced by ResolvePackageDependencies to a form
+    that's consumable by an IDE to display package dependencies.
+    ============================================================
+    -->
+
+  <UsingTask TaskName="Microsoft.DotNet.Core.Build.Tasks.PreprocessPackageDependenciesDesignTime"
+             AssemblyFile="$(MicrosoftDotNetCoreBuildTasksAssembly)" />
+  
+  <Target Name="ResolvePackageDependenciesDesignTime"
+          Returns="@(_DependenciesDesignTime)"
+          DependsOnTargets="ResolveAssemblyReferencesDesignTime;RunResolvePackageDependencies">
+
+    <PreprocessPackageDependenciesDesignTime  
+                               TargetDefinitions="@(TargetDefinitions)"
+                               PackageDefinitions="@(PackageDefinitions)"
+                               FileDefinitions="@(FileDefinitions)"
+                               PackageDependencies="@(PackageDependencies)"
+                               FileDependencies="@(FileDependencies)">
+
+      <Output TaskParameter="DependenciesDesignTime" ItemName="_DependenciesDesignTime" />
+    </PreprocessPackageDependenciesDesignTime>
+  </Target>
+
+  <!--
+    ============================================================
     Reference Targets: For populating References based on lock file
     - _ComputeLockFileReferences
     - ResolveLockFileReferences

--- a/src/Tasks/Microsoft.NETCore.Build.Tasks/build/netstandard1.0/Microsoft.PackageDependencyResolution.targets
+++ b/src/Tasks/Microsoft.NETCore.Build.Tasks/build/netstandard1.0/Microsoft.PackageDependencyResolution.targets
@@ -151,19 +151,19 @@ Copyright (c) .NET Foundation. All rights reserved.
     ============================================================
     -->
 
-  <UsingTask TaskName="Microsoft.DotNet.Core.Build.Tasks.PreprocessPackageDependenciesDesignTime"
-             AssemblyFile="$(MicrosoftDotNetCoreBuildTasksAssembly)" />
+  <UsingTask TaskName="Microsoft.NETCore.Build.Tasks.PreprocessPackageDependenciesDesignTime"
+             AssemblyFile="$(MicrosoftNETCoreBuildTasksAssembly)" />
   
   <Target Name="ResolvePackageDependenciesDesignTime"
           Returns="@(_DependenciesDesignTime)"
           DependsOnTargets="ResolveAssemblyReferencesDesignTime;RunResolvePackageDependencies">
 
-    <PreprocessPackageDependenciesDesignTime  
-                               TargetDefinitions="@(TargetDefinitions)"
-                               PackageDefinitions="@(PackageDefinitions)"
-                               FileDefinitions="@(FileDefinitions)"
-                               PackageDependencies="@(PackageDependencies)"
-                               FileDependencies="@(FileDependencies)">
+    <PreprocessPackageDependenciesDesignTime
+          TargetDefinitions="@(TargetDefinitions)"
+          PackageDefinitions="@(PackageDefinitions)"
+          FileDefinitions="@(FileDefinitions)"
+          PackageDependencies="@(PackageDependencies)"
+          FileDependencies="@(FileDependencies)">
 
       <Output TaskParameter="DependenciesDesignTime" ItemName="_DependenciesDesignTime" />
     </PreprocessPackageDependenciesDesignTime>


### PR DESCRIPTION
This is a target that calls @abpiskunov's new PreprocessPackageDependenciesDesignTime task. This target will be called by the project system for getting the package information to show in VS's soln explorer.

@abpiskunov @natidea  @dotnet/project-system 
