### PR TITLE
Add analyzers to designtime dependencies collection

### DIFF
--- a/src/Tasks/Microsoft.NETCore.Build.Tasks/DependencyType.cs
+++ b/src/Tasks/Microsoft.NETCore.Build.Tasks/DependencyType.cs
@@ -11,6 +11,7 @@ namespace Microsoft.NETCore.Build.Tasks
         Package,
         Assembly,
         FrameworkAssembly,
+        AnalyzerAssembly,
         Content,
         Project,
         ExternalProject,

--- a/src/Tasks/Microsoft.NETCore.Build.Tasks/ITaskItemExtensions.cs
+++ b/src/Tasks/Microsoft.NETCore.Build.Tasks/ITaskItemExtensions.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Build.Framework;
+
+namespace Microsoft.NETCore.Build.Tasks
+{
+    internal static class ITaskItemExtensions
+    {
+        public static bool IsAnalyzer(this ITaskItem item)
+        {
+            var isAnalyzer = false;
+            var analyzerString = item.GetMetadata(MetadataKeys.Analyzer);
+            return bool.TryParse(analyzerString, out isAnalyzer) && isAnalyzer;
+        }
+    }
+}

--- a/src/Tasks/Microsoft.NETCore.Build.Tasks/Microsoft.NETCore.Build.Tasks.csproj
+++ b/src/Tasks/Microsoft.NETCore.Build.Tasks/Microsoft.NETCore.Build.Tasks.csproj
@@ -18,6 +18,7 @@
     <ResolveNuGetPackages>true</ResolveNuGetPackages>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="ITaskItemExtensions.cs" />
     <Compile Include="ProjectContext.cs" />
     <Compile Include="NuGetPackageResolver.cs" />
     <Compile Include="IPackageResolver.cs" />


### PR DESCRIPTION
Add a new dependency type AnalyzerAssembly and add analyzers to DesignTime dependencies collection, to allow Nuget sub-tree provider to display them as package dependencies.
