### PR TITLE
Sort .NET Core Console template with .NET Framework

### DIFF
--- a/src/Templates/ProjectTemplates/CSharp/.NETCore/ConsoleApplication/ConsoleApplication.vstemplate
+++ b/src/Templates/ProjectTemplates/CSharp/.NETCore/ConsoleApplication/ConsoleApplication.vstemplate
@@ -6,7 +6,7 @@
     <Icon>ConsoleApplication.png</Icon>
     <ProjectType>CSharp</ProjectType>
     <RequiredFrameworkVersion>2.0</RequiredFrameworkVersion>
-    <SortOrder>1</SortOrder>
+    <SortOrder>12</SortOrder>
     <NumberOfParentCategoriesToRollUp>1</NumberOfParentCategoriesToRollUp>
     <TemplateID>Microsoft.CSharp.NETCore.ConsoleApplication</TemplateID>
     <CreateNewFolder>true</CreateNewFolder>


### PR DESCRIPTION
This puts the template with the .NET Framework version, instead at top of all templates.
