### PR TITLE
Add assemblyname, rootnamespace. Remove GlobalExclude. Add AutoUnify.

### DIFF
--- a/src/Tasks/Microsoft.NETCore.Build.Tasks/build/netstandard1.0/Microsoft.NETCore.Sdk.VisualBasic.targets
+++ b/src/Tasks/Microsoft.NETCore.Build.Tasks/build/netstandard1.0/Microsoft.NETCore.Sdk.VisualBasic.targets
@@ -17,7 +17,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     https://github.com/dotnet/roslyn/issues/13681 tracks the compiler bug.
     -->
   <PropertyGroup>
-    <TargetsTriggeredByCompilation Condition="'($OutputType)' == 'exe'">ChangeExtensionOfOutputAssembly;$(TargetsTriggeredByCompilation)</TargetsTriggeredByCompilation>
+    <TargetsTriggeredByCompilation Condition="'$(OutputType)' == 'exe'">ChangeExtensionOfOutputAssembly;$(TargetsTriggeredByCompilation)</TargetsTriggeredByCompilation>
   </PropertyGroup>
 
   <Target Name="ChangeExtensionOfOutputAssembly">

--- a/src/Tasks/Microsoft.NETCore.Build.Tasks/build/netstandard1.0/Microsoft.NETCore.Sdk.props
+++ b/src/Tasks/Microsoft.NETCore.Build.Tasks/build/netstandard1.0/Microsoft.NETCore.Sdk.props
@@ -20,12 +20,11 @@ Copyright (c) .NET Foundation. All rights reserved.
     <OutputType>Library</OutputType>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform>AnyCPU</Platform>
-
     <FileAlignment>512</FileAlignment>
-    <GlobalExclude>bin\**;obj\**;</GlobalExclude>
-
     <PlatformTarget>AnyCPU</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <RootNamespace>$(MSBuildProjectName)</RootNamespace>
   </PropertyGroup>
 
   <!-- User-facing configuration-specific defaults -->
@@ -42,7 +41,9 @@ Copyright (c) .NET Foundation. All rights reserved.
   <!-- Default settings for .NET Core build logic -->
   <PropertyGroup>
     <DebugType>portable</DebugType>
-
+    <AutoUnifyAssemblyReferences>true</AutoUnifyAssemblyReferences>
+    <DesignTimeAutoUnify>true</DesignTimeAutoUnify>
+    
     <GenerateDependencyFile Condition=" '$(GenerateDependencyFile)' == '' ">true</GenerateDependencyFile>
 
     <!-- all references (even the StdLib) come from packages -->

--- a/src/Tasks/Microsoft.NETCore.Build.Tasks/build/netstandard1.0/Microsoft.NETCore.Sdk.targets
+++ b/src/Tasks/Microsoft.NETCore.Build.Tasks/build/netstandard1.0/Microsoft.NETCore.Sdk.targets
@@ -22,6 +22,11 @@ Copyright (c) .NET Foundation. All rights reserved.
     <Import Project="$(MSBuildThisFileDirectory)Microsoft.PackageDependencyResolution.targets" Condition="Exists('$(MSBuildThisFileDirectory)Microsoft.PackageDependencyResolution.targets')" />
   </ImportGroup>
 
+  <ItemGroup>
+    <Compile Remove="bin\**;obj\**" />
+    <EmbeddedResource Remove="bin\**;obj\**" />
+  </ItemGroup>
+  
   <UsingTask TaskName="GenerateDepsFile" AssemblyFile="$(MicrosoftNETCoreBuildTasksAssembly)" />
   <UsingTask TaskName="GenerateRuntimeConfigurationFiles" AssemblyFile="$(MicrosoftNETCoreBuildTasksAssembly)" />
   <UsingTask TaskName="GetAssemblyVersion" AssemblyFile="$(MicrosoftNETCoreBuildTasksAssembly)" />

--- a/src/Tasks/Microsoft.NETCore.Build.Tasks/build/netstandard1.0/Microsoft.NETCore.Sdk.targets
+++ b/src/Tasks/Microsoft.NETCore.Build.Tasks/build/netstandard1.0/Microsoft.NETCore.Sdk.targets
@@ -22,9 +22,12 @@ Copyright (c) .NET Foundation. All rights reserved.
     <Import Project="$(MSBuildThisFileDirectory)Microsoft.PackageDependencyResolution.targets" Condition="Exists('$(MSBuildThisFileDirectory)Microsoft.PackageDependencyResolution.targets')" />
   </ImportGroup>
 
+  <PropertyGroup>
+    <DefaultExcludes>bin\**;obj\**</DefaultExcludes>
+  </PropertyGroup>
   <ItemGroup>
-    <Compile Remove="bin\**;obj\**" />
-    <EmbeddedResource Remove="bin\**;obj\**" />
+    <Compile Remove="$(DefaultExcludes)" />
+    <EmbeddedResource Remove="$(DefaultExcludes)" />
   </ItemGroup>
   
   <UsingTask TaskName="GenerateDepsFile" AssemblyFile="$(MicrosoftNETCoreBuildTasksAssembly)" />

--- a/src/Templates/ProjectTemplates/CSharp/.NETCore/CSharpClassLibrary/ProjectTemplate.csproj
+++ b/src/Templates/ProjectTemplates/CSharp/.NETCore/CSharpClassLibrary/ProjectTemplate.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="**\*.cs" Exclude="$(GlobalExclude)" />
-    <EmbeddedResource Include="**\*.resx" Exclude="$(GlobalExclude)" />
+    <Compile Include="**\*.cs" />
+    <EmbeddedResource Include="**\*.resx" />
     <None Include="project.json" />
   </ItemGroup>
   

--- a/src/Templates/ProjectTemplates/CSharp/.NETCore/CSharpConsoleApplication/ProjectTemplate.csproj
+++ b/src/Templates/ProjectTemplates/CSharp/.NETCore/CSharpConsoleApplication/ProjectTemplate.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="**\*.cs" Exclude="$(GlobalExclude)" />
-    <EmbeddedResource Include="**\*.resx" Exclude="$(GlobalExclude)" />
+    <Compile Include="**\*.cs" />
+    <EmbeddedResource Include="**\*.resx" />
     <None Include="project.json" />
   </ItemGroup>
   

--- a/src/Templates/ProjectTemplates/CSharp/Web/EmptyWeb/ProjectTemplate.csproj
+++ b/src/Templates/ProjectTemplates/CSharp/Web/EmptyWeb/ProjectTemplate.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="**\*.cs" Exclude="$(GlobalExclude)" />
-    <EmbeddedResource Include="**\*.resx" Exclude="$(GlobalExclude)" />
+    <Compile Include="**\*.cs" />
+    <EmbeddedResource Include="**\*.resx" />
     <None Include="project.json" />
   </ItemGroup>
 

--- a/src/Templates/ProjectTemplates/VisualBasic/.NETCore/VisualBasicClassLibrary/ProjectTemplate.vbproj
+++ b/src/Templates/ProjectTemplates/VisualBasic/.NETCore/VisualBasicClassLibrary/ProjectTemplate.vbproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="**\*.vb" Exclude="$(GlobalExclude)" />
-    <EmbeddedResource Include="**\*.resx" Exclude="$(GlobalExclude)" />
+    <Compile Include="**\*.vb" />
+    <EmbeddedResource Include="**\*.resx" />
     <None Include="project.json" />
   </ItemGroup>
   

--- a/src/Templates/ProjectTemplates/VisualBasic/.NETCore/VisualBasicConsoleApplication/ProjectTemplate.vbproj
+++ b/src/Templates/ProjectTemplates/VisualBasic/.NETCore/VisualBasicConsoleApplication/ProjectTemplate.vbproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="**\*.vb" Exclude="$(GlobalExclude)" />
-    <EmbeddedResource Include="**\*.resx" Exclude="$(GlobalExclude)" />
+    <Compile Include="**\*.vb" />
+    <EmbeddedResource Include="**\*.resx" />
     <None Include="project.json" />
   </ItemGroup>
   


### PR DESCRIPTION
- Fixes #106 (Assembly Name and Root Namespace need to be defaulted in props). Verified that DefaultNamespace is passed to VB compiler as well.
- Remove the GlobalExclude property and instead use the Remove syntax.
- Partial fix for #73 (References should be unified in .NET Core). We set the AutoUnifyAssemblyReferences property in the props. To fix it completely requires a MSBuild with this change - https://github.com/Microsoft/msbuild/pull/1019 to respect the property being set.
- Fix a typo that broke VB console apps.

@dotnet/project-system @eerhardt @brthor 
