### PR TITLE
Use resolved versions for package dependencies 

### DIFF
--- a/src/Tasks/Microsoft.NETCore.Build.Tasks.UnitTests/GivenAResolvePackageDependenciesTask.cs
+++ b/src/Tasks/Microsoft.NETCore.Build.Tasks.UnitTests/GivenAResolvePackageDependenciesTask.cs
@@ -611,51 +611,46 @@ namespace Microsoft.NETCore.Build.Tasks.UnitTests
         }
 
         [Fact]
-        public void ItUsesMinVersionFromPackageDependencyRanges()
+        public void ItUsesResolvedPackageVersionFromSameTarget()
         {
             string targetLibC = CreateTargetLibrary("LibC/1.2.3", "package",
                 dependencies: new string[] {
-                    "\"Dep.Lib.Alpha\": \"4.0.0\"",
-                    "\"Dep.Lib.Beta\": \"[4.0.0]\"",
                     "\"Dep.Lib.Chi\": \"[4.0.0, 5.0.0)\"",
-                    "\"Dep.Lib.Delta\": \"[4.0.0)\"",
                 });
+
+            string targetLibChi1 = CreateTargetLibrary("Dep.Lib.Chi/4.0.0", "package");
+            string targetLibChi2 = CreateTargetLibrary("Dep.Lib.Chi/4.1.0", "package");
 
             string lockFileContent = CreateLockFileSnippet(
                 targets: new string[] {
-                    CreateTarget(".NETCoreApp,Version=v1.0", TargetLibA, TargetLibB, targetLibC),
+                    CreateTarget(".NETCoreApp,Version=v1.0", TargetLibA, TargetLibB, targetLibC, targetLibChi1),
+                    CreateTarget(".NETCoreApp,Version=v1.0/osx.10.11-x64", TargetLibA, TargetLibB, targetLibC, targetLibChi2),
                 },
                 libraries: new string[] {
                     LibADefn, LibBDefn, LibCDefn,
-                    CreateLibrary("Dep.Lib.Alpha/4.0.0", "package", "lib/file/Alpha.dll"),
-                    CreateLibrary("Dep.Lib.Beta/4.0.0",  "package", "lib/file/Beta.dll"),
                     CreateLibrary("Dep.Lib.Chi/4.0.0",   "package", "lib/file/Chi.dll"),
-                    CreateLibrary("Dep.Lib.Delta/4.0.0", "package", "lib/file/Delta.dll"),
+                    CreateLibrary("Dep.Lib.Chi/4.1.0",   "package", "lib/file/Chi.dll"),
                 },
                 projectFileDependencyGroups: new string[] { ProjectGroup, NETCoreGroup, NETCoreOsxGroup }
             );
 
             var task = GetExecutedTaskFromContents(lockFileContent);
 
-            task.PackageDependencies
-                .Where(t => t.ItemSpec.StartsWith("Dep.Lib."))
-                .Count().Should().Be(4);
+            var chiDeps = task.PackageDependencies
+                .Where(t => t.ItemSpec.StartsWith("Dep.Lib.Chi"));
 
-            task.PackageDependencies
-                .Any(t => t.ItemSpec == "Dep.Lib.Alpha/4.0.0")
-                .Should().BeTrue();
+            chiDeps.Count().Should().Be(2);
 
-            task.PackageDependencies
-                .Any(t => t.ItemSpec == "Dep.Lib.Beta/4.0.0")
-                .Should().BeTrue();
+            // Dep.Lib.Chi has version range [4.0.0, 5.0.0), but the version assigned 
+            // is that of the library in the same target
 
-            task.PackageDependencies
-                .Any(t => t.ItemSpec == "Dep.Lib.Chi/4.0.0")
-                .Should().BeTrue();
+            chiDeps.Where(t => t.GetMetadata(MetadataKeys.ParentTarget) == ".NETCoreApp,Version=v1.0")
+                .Select(t => t.ItemSpec)
+                .First().Should().Be("Dep.Lib.Chi/4.0.0");
 
-            task.PackageDependencies
-                .Any(t => t.ItemSpec == "Dep.Lib.Delta/4.0.0")
-                .Should().BeTrue();
+            chiDeps.Where(t => t.GetMetadata(MetadataKeys.ParentTarget) == ".NETCoreApp,Version=v1.0/osx.10.11-x64")
+                .Select(t => t.ItemSpec)
+                .First().Should().Be("Dep.Lib.Chi/4.1.0");
         }
 
         private ResolvePackageDependencies GetExecutedTaskFromPrefix(string lockFilePrefix)

--- a/src/Tasks/Microsoft.NETCore.Build.Tasks.UnitTests/GivenAResolvePackageDependenciesTask.cs
+++ b/src/Tasks/Microsoft.NETCore.Build.Tasks.UnitTests/GivenAResolvePackageDependenciesTask.cs
@@ -73,7 +73,7 @@ namespace Microsoft.NETCore.Build.Tasks.UnitTests
 
             // set of valid targets and packages
             HashSet<string> validTargets = new HashSet<string>(lockFile.Targets.Select(x => x.Name));
-            HashSet<string> validPackages = new HashSet<string>(lockFile.Libraries.Select(x => $"{x.Name}/{x.Version.ToString()}"));
+            HashSet<string> validPackages = new HashSet<string>(lockFile.Libraries.Select(x => $"{x.Name}/{x.Version.ToNormalizedString()}"));
 
             Func<ITaskItem[], bool> allValidParentTarget =
                 (items) => items.All(x => validTargets.Contains(x.GetMetadata(MetadataKeys.ParentTarget)));

--- a/src/Tasks/Microsoft.NETCore.Build.Tasks/ResolvePackageDependencies.cs
+++ b/src/Tasks/Microsoft.NETCore.Build.Tasks/ResolvePackageDependencies.cs
@@ -18,9 +18,8 @@ namespace Microsoft.NETCore.Build.Tasks
     /// </summary>
     public sealed class ResolvePackageDependencies : Task
     {
-        private readonly List<string> _packageFolders = new List<string>();
-        private readonly Dictionary<string, string> _fileTypes = new Dictionary<string, string>();
-        private readonly HashSet<string> _projectFileDependencies = new HashSet<string>();
+        private readonly Dictionary<string, string> _fileTypes = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        private readonly HashSet<string> _projectFileDependencies = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         private IPackageResolver _packageResolver;
         private LockFile _lockFile;
 
@@ -200,11 +199,11 @@ namespace Microsoft.NETCore.Build.Tasks
             TaskItem item;
             foreach (var package in LockFile.Libraries)
             {
-                string packageId = $"{package.Name}/{package.Version.ToString()}";
+                string packageId = $"{package.Name}/{package.Version.ToNormalizedString()}";
                 item = new TaskItem(packageId);
                 item.SetMetadata(MetadataKeys.Name, package.Name);
                 item.SetMetadata(MetadataKeys.Type, package.Type);
-                item.SetMetadata(MetadataKeys.Version, package.Version.ToString());
+                item.SetMetadata(MetadataKeys.Version, package.Version.ToNormalizedString());
 
                 item.SetMetadata(MetadataKeys.Path, package.Path ?? string.Empty);
 
@@ -317,12 +316,12 @@ namespace Microsoft.NETCore.Build.Tasks
         private void GetPackageAndFileDependencies(LockFileTarget target)
         {
             var resolvedPackageVersions = target.Libraries
-                .ToDictionary(pkg => pkg.Name, pkg => pkg.Version.ToString());
+                .ToDictionary(pkg => pkg.Name, pkg => pkg.Version.ToNormalizedString(), StringComparer.OrdinalIgnoreCase);
 
             TaskItem item;
             foreach (var package in target.Libraries)
             {
-                string packageId = $"{package.Name}/{package.Version.ToString()}";
+                string packageId = $"{package.Name}/{package.Version.ToNormalizedString()}";
 
                 if (_projectFileDependencies.Contains(package.Name))
                 {
@@ -346,7 +345,7 @@ namespace Microsoft.NETCore.Build.Tasks
             string targetName, 
             Dictionary<string, string> resolvedPackageVersions)
         {
-            string packageId = $"{package.Name}/{package.Version.ToString()}";
+            string packageId = $"{package.Name}/{package.Version.ToNormalizedString()}";
             TaskItem item;
             foreach (var deps in package.Dependencies)
             {
@@ -369,7 +368,7 @@ namespace Microsoft.NETCore.Build.Tasks
 
         private void GetFileDependencies(LockFileTargetLibrary package, string targetName)
         {
-            string packageId = $"{package.Name}/{package.Version.ToString()}";
+            string packageId = $"{package.Name}/{package.Version.ToNormalizedString()}";
             TaskItem item;
 
             // for each type of file group


### PR DESCRIPTION
Use resolved versions for package dependencies, instead of the MinVersion returned by the package dependency version range.

Fixes #25 and #144  
