### PR TITLE
Support publishing self-contained applications.

### DIFF
--- a/src/Tasks/Microsoft.NETCore.Build.Tasks.UnitTests/GivenACompilationOptionsConverter.cs
+++ b/src/Tasks/Microsoft.NETCore.Build.Tasks.UnitTests/GivenACompilationOptionsConverter.cs
@@ -68,7 +68,7 @@ namespace Microsoft.NETCore.Build.Tasks.UnitTests
                 yield return new object[]
                 {
                     null,
-                    CompilationOptions.Default
+                    null
                 };
             }
         }

--- a/src/Tasks/Microsoft.NETCore.Build.Tasks/CompilationOptionsConverter.cs
+++ b/src/Tasks/Microsoft.NETCore.Build.Tasks/CompilationOptionsConverter.cs
@@ -13,7 +13,7 @@ namespace Microsoft.NETCore.Build.Tasks
         {
             if (compilerOptionsItem == null)
             {
-                return CompilationOptions.Default;
+                return null;
             }
 
             return new CompilationOptions(

--- a/src/Tasks/Microsoft.NETCore.Build.Tasks/NuGetUtils.cs
+++ b/src/Tasks/Microsoft.NETCore.Build.Tasks/NuGetUtils.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using NuGet.Packaging.Core;
+using NuGet.ProjectModel;
 
 namespace Microsoft.NETCore.Build.Tasks
 {
@@ -19,6 +20,11 @@ namespace Microsoft.NETCore.Build.Tasks
         public static IEnumerable<string> FilterPlaceHolderFiles(this IEnumerable<string> files)
         {
             return files.Where(f => !IsPlaceholderFile(f));
+        }
+
+        public static IEnumerable<LockFileItem> FilterPlaceHolderFiles(this IEnumerable<LockFileItem> files)
+        {
+            return files.Where(f => !IsPlaceholderFile(f.Path));
         }
     }
 }

--- a/src/Tasks/Microsoft.NETCore.Build.Tasks/PublishAssembliesResolver.cs
+++ b/src/Tasks/Microsoft.NETCore.Build.Tasks/PublishAssembliesResolver.cs
@@ -35,7 +35,7 @@ namespace Microsoft.NETCore.Build.Tasks
                 results.AddRange(GetResolvedFiles(targetLibrary.RuntimeAssemblies, libraryPath));
                 results.AddRange(GetResolvedFiles(targetLibrary.NativeLibraries, libraryPath));
 
-                foreach (LockFileRuntimeTarget runtimeTarget in targetLibrary.RuntimeTargets)
+                foreach (LockFileRuntimeTarget runtimeTarget in targetLibrary.RuntimeTargets.FilterPlaceHolderFiles())
                 {
                     if (string.Equals(runtimeTarget.AssetType, "native", StringComparison.OrdinalIgnoreCase) ||
                         string.Equals(runtimeTarget.AssetType, "runtime", StringComparison.OrdinalIgnoreCase))
@@ -47,7 +47,7 @@ namespace Microsoft.NETCore.Build.Tasks
                     }
                 }
 
-                foreach (LockFileItem resourceAssembly in targetLibrary.ResourceAssemblies)
+                foreach (LockFileItem resourceAssembly in targetLibrary.ResourceAssemblies.FilterPlaceHolderFiles())
                 {
                     string locale;
                     if (!resourceAssembly.Properties.TryGetValue("locale", out locale))
@@ -67,7 +67,7 @@ namespace Microsoft.NETCore.Build.Tasks
 
         private static IEnumerable<ResolvedFile> GetResolvedFiles(IEnumerable<LockFileItem> items, string libraryPath)
         {
-            foreach (LockFileItem item in items)
+            foreach (LockFileItem item in items.FilterPlaceHolderFiles())
             {
                 yield return new ResolvedFile(
                     sourcePath: Path.Combine(libraryPath, item.Path),

--- a/src/Tasks/Microsoft.NETCore.Build.Tasks/build/netstandard1.0/Microsoft.NETCore.Publish.targets
+++ b/src/Tasks/Microsoft.NETCore.Build.Tasks/build/netstandard1.0/Microsoft.NETCore.Publish.targets
@@ -442,7 +442,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <PropertyGroup>
       <_DotNetHostExecutableName>dotnet</_DotNetHostExecutableName>
-      <_DotNetHostExecutableName Condition="'$(OS)'=='Windows_NT'">$(_DotNetHostExecutableName).exe</_DotNetHostExecutableName>
+      <_DotNetHostExecutableName Condition="$(RuntimeIdentifier.StartsWith('win'))">$(_DotNetHostExecutableName).exe</_DotNetHostExecutableName>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Tasks/Microsoft.NETCore.Build.Tasks/build/netstandard1.0/Microsoft.NETCore.Publish.targets
+++ b/src/Tasks/Microsoft.NETCore.Build.Tasks/build/netstandard1.0/Microsoft.NETCore.Publish.targets
@@ -19,9 +19,18 @@ Copyright (c) .NET Foundation. All rights reserved.
     ============================================================
     -->
   <PropertyGroup>
-    <PublishDir Condition=" '$(PublishDir)' == '' ">$(OutDir)publish\</PublishDir>
+    <_PublishDirName Condition=" '$(_PublishDirName)' == '' ">publish</_PublishDirName>
+
+    <!-- TODO: https://github.com/dotnet/sdk/issues/143 - find a way to default $(PublishDir) before Microsoft.Common.CurrentVersion.targets defaults it -->
+    <_ShouldSetPublishDir Condition=" '$(PublishDir)' == '' or '$(PublishDir)' == '$(OutputPath)app.publish\'">true</_ShouldSetPublishDir>
+    <PublishDir Condition=" '$(_ShouldSetPublishDir)' == 'true' ">$(OutDir)$(_PublishDirName)\</PublishDir>
+    <PublishDir Condition=" '$(_ShouldSetPublishDir)' == 'true' and '$(RuntimeIdentifier)' != ''  ">$(OutDir)$(RuntimeIdentifier)\$(_PublishDirName)\</PublishDir>
+
     <DefaultCopyToPublishDirectoryMetadata Condition="'$(DefaultCopyToPublishDirectoryMetadata)' == ''">true</DefaultCopyToPublishDirectoryMetadata>
     <_GetChildProjectCopyToPublishDirectoryItems Condition="'$(_GetChildProjectCopyToPublishDirectoryItems)' == ''">true</_GetChildProjectCopyToPublishDirectoryItems>
+
+    <!-- publishing self-contained apps should publish the native host as $(AssemblyName).exe -->
+    <RenamePublishedHost Condition=" '$(RenamePublishedHost)' == '' and '$(OutputType)' == 'Exe' and '$(RuntimeIdentifier)' != ''">true</RenamePublishedHost>
   </PropertyGroup>
 
   <Target Name="Publish"
@@ -58,6 +67,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     -->
   <Target Name="CopyFilesToPublishDirectory"
           DependsOnTargets="ComputeFilesToPublish;
+                            RenamePublishedHost;
                             _CopySourceItemsToPublishDirectory">
 
     <Copy SourceFiles="@(ResolvedFilesToPublish)"
@@ -416,6 +426,32 @@ Copyright (c) .NET Foundation. All rights reserved.
                                        RuntimeConfigPath="$(_PublishRuntimeConfigFilePath)"
                                        RuntimeIdentifier="$(RuntimeIdentifier)"
                                        UserRuntimeConfig="$(UserRuntimeConfig)" />
+
+  </Target>
+
+  <!--
+    ============================================================
+                                        RenamePublishedHost
+
+    Renames the dotnet native host to match the application's name.
+    ============================================================
+    -->
+
+  <Target Name="RenamePublishedHost"
+          Condition="'$(RenamePublishedHost)' == 'true'">
+
+    <PropertyGroup>
+      <_DotNetHostExecutableName>dotnet</_DotNetHostExecutableName>
+      <_DotNetHostExecutableName Condition="'$(OS)'=='Windows_NT'">$(_DotNetHostExecutableName).exe</_DotNetHostExecutableName>
+    </PropertyGroup>
+
+    <ItemGroup>
+
+      <ResolvedFilesToPublish Condition="'%(ResolvedFilesToPublish.RelativePath)' == '$(_DotNetHostExecutableName)'">
+        <RelativePath>$(AssemblyName)%(ResolvedFilesToPublish.Extension)</RelativePath>
+      </ResolvedFilesToPublish>
+
+    </ItemGroup>
 
   </Target>
 

--- a/src/Tasks/Microsoft.NETCore.Build.Tasks/build/netstandard1.0/Microsoft.NETCore.Sdk.targets
+++ b/src/Tasks/Microsoft.NETCore.Build.Tasks/build/netstandard1.0/Microsoft.NETCore.Sdk.targets
@@ -96,11 +96,6 @@ Copyright (c) .NET Foundation. All rights reserved.
                       RuntimeIdentifier="$(RuntimeIdentifier)"
                       CompilerOptions="@(DependencyFileCompilerOptions)" />
 
-    <!--
-    TODO: https://github.com/dotnet/sdk/issues/21
-    When OutputType == 'exe' and !IsPortable, we need to verify CoreClr is present in the deps graph, and copy in a host to the output
-    See https://github.com/dotnet/cli/blob/6b54ae0bcc5c63e7c989ac19d851f234f9172bea/src/Microsoft.DotNet.Compiler.Common/Executable.cs#L102-L107
-    -->
   </Target>
 
   <!--

--- a/test/Microsoft.NETCore.Publish.Tests/GivenThatWeWantToPublishAHelloWorldProject.cs
+++ b/test/Microsoft.NETCore.Publish.Tests/GivenThatWeWantToPublishAHelloWorldProject.cs
@@ -2,7 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.IO;
+using System.Runtime.InteropServices;
 using Microsoft.DotNet.Cli.Utils;
+using Microsoft.DotNet.InternalAbstractions;
 using Microsoft.NETCore.TestFramework;
 using Microsoft.NETCore.TestFramework.Assertions;
 using Microsoft.NETCore.TestFramework.Commands;
@@ -21,7 +23,7 @@ namespace Microsoft.NETCore.Publish.Tests
         }
 
         [Fact]
-        public void It_publishes_the_project_to_the_publish_folder_and_the_app_should_run()
+        public void It_publishes_portable_apps_to_the_publish_folder_and_the_app_should_run()
         {
             var helloWorldAsset = _testAssetsManager
                 .CopyTestAsset("HelloWorld")
@@ -35,7 +37,7 @@ namespace Microsoft.NETCore.Publish.Tests
 
             var publishDirectory = publishCommand.GetOutputDirectory();
 
-            publishDirectory.Should().OnlyHaveFiles(new [] {
+            publishDirectory.Should().OnlyHaveFiles(new[] {
                 "HelloWorld.dll",
                 "HelloWorld.pdb",
                 "HelloWorld.deps.json",
@@ -43,6 +45,47 @@ namespace Microsoft.NETCore.Publish.Tests
             });
 
             Command.Create(RepoInfo.DotNetHostPath, new[] { Path.Combine(publishDirectory.FullName, "HelloWorld.dll") })
+                .CaptureStdOut()
+                .Execute()
+                .Should()
+                .Pass()
+                .And
+                .HaveStdOutContaining("Hello World!");
+        }
+
+        [Fact]
+        public void It_publishes_self_contained_apps_to_the_publish_folder_and_the_app_should_run()
+        {
+            var helloWorldAsset = _testAssetsManager
+                .CopyTestAsset("HelloWorld")
+                .WithSource()
+                .AsSelfContained()
+                .Restore("--fallbacksource", $"{RepoInfo.PackagesPath}");
+
+            var publishCommand = new PublishCommand(Stage0MSBuild, helloWorldAsset.TestRoot);
+            var publishResult = publishCommand.Execute($"/p:RuntimeIdentifier={RuntimeEnvironment.GetRuntimeIdentifier()}");
+
+            publishResult.Should().Pass();
+
+            var publishDirectory = publishCommand.GetOutputDirectory(selfContained: true);
+            var selfContainedExecutable = $"HelloWorld{Constants.ExeSuffix}";
+
+            var libPrefix = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "" : "lib";
+
+            publishDirectory.Should().HaveFiles(new[] {
+                selfContainedExecutable,
+                "HelloWorld.dll",
+                "HelloWorld.pdb",
+                "HelloWorld.deps.json",
+                "HelloWorld.runtimeconfig.json",
+                $"{libPrefix}coreclr{Constants.DynamicLibSuffix}",
+                $"{libPrefix}hostfxr{Constants.DynamicLibSuffix}",
+                $"{libPrefix}hostpolicy{Constants.DynamicLibSuffix}",
+                $"mscorlib.dll",
+                $"System.Private.CoreLib.dll",
+            });
+
+            Command.Create(Path.Combine(publishDirectory.FullName, selfContainedExecutable), new string[] { })
                 .CaptureStdOut()
                 .Execute()
                 .Should()

--- a/test/Microsoft.NETCore.TestFramework/Commands/PublishCommand.cs
+++ b/test/Microsoft.NETCore.TestFramework/Commands/PublishCommand.cs
@@ -6,12 +6,13 @@ using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
 using Microsoft.DotNet.Cli.Utils;
+using Microsoft.DotNet.InternalAbstractions;
 
 namespace Microsoft.NETCore.TestFramework.Commands
 {
     public sealed class PublishCommand : TestCommand
     {
-        private const string PublishSubfolderName = "app.publish";
+        private const string PublishSubfolderName = "publish";
 
         public PublishCommand(MSBuildTest msbuild, string projectPath)
             : base(msbuild, projectPath)
@@ -28,9 +29,9 @@ namespace Microsoft.NETCore.TestFramework.Commands
             return command.Execute();
         }
 
-        public DirectoryInfo GetOutputDirectory()
+        public DirectoryInfo GetOutputDirectory(bool selfContained = false)
         {
-            string output = Path.Combine(ProjectRootPath, "bin", BuildRelativeOutputPath());
+            string output = Path.Combine(ProjectRootPath, "bin", BuildRelativeOutputPath(selfContained));
             return new DirectoryInfo(output);
         }
 
@@ -39,9 +40,11 @@ namespace Microsoft.NETCore.TestFramework.Commands
             return Path.Combine(GetOutputDirectory().FullName, $"{appName}.dll");
         }
 
-        private string BuildRelativeOutputPath()
+        private string BuildRelativeOutputPath(bool selfContained)
         {
-            return Path.Combine("Debug", "", PublishSubfolderName);
+            return selfContained ?
+                Path.Combine("Debug", RuntimeEnvironment.GetRuntimeIdentifier(), PublishSubfolderName) :
+                Path.Combine("Debug", PublishSubfolderName);
         }
     }
 }


### PR DESCRIPTION
I also fixed a minor issue where we were always writing the compile assemblies into the published deps.json file.

Fix #21 - There is nothing to do for "self-contained" apps at build time, since it is a publish time decision.

@brthor @livarcocc @nguerrera 

/cc @dotnet/project-system 
