### PR TITLE
Turn on deterministic builds by default for core projects

### DIFF
--- a/src/Tasks/Microsoft.NETCore.Build.Tasks/build/netstandard1.0/Microsoft.NETCore.Sdk.props
+++ b/src/Tasks/Microsoft.NETCore.Build.Tasks/build/netstandard1.0/Microsoft.NETCore.Sdk.props
@@ -25,6 +25,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ErrorReport>prompt</ErrorReport>
     <AssemblyName>$(MSBuildProjectName)</AssemblyName>
     <RootNamespace>$(MSBuildProjectName)</RootNamespace>
+    <Deterministic>true</Deterministic>
   </PropertyGroup>
 
   <!-- User-facing configuration-specific defaults -->


### PR DESCRIPTION
Fix #1 

@dotnet/project-system @eerhardt @brthor @livarcocc @jaredpar 
