### PR TITLE
Merge master to restore3

### DIFF
--- a/TestAssets/TestProjects/CrossTargeting/TestLibrary/Helper.cs
+++ b/TestAssets/TestProjects/CrossTargeting/TestLibrary/Helper.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace TestLibrary
+{
+    public static class Helper
+    {
+        /// <summary>
+        /// Gets the message from the helper. This comment is here to help test XML documentation file generation, please do not remove it.
+        /// </summary>
+        /// <returns>A message</returns>
+        public static string GetMessage()
+        {
+            return "This string came from the test library!";
+        }
+
+        public static void SayHi()
+        {
+            Console.WriteLine("Hello there!");
+        }
+    }
+}

--- a/TestAssets/TestProjects/CrossTargeting/TestLibrary/TestLibrary.csproj
+++ b/TestAssets/TestProjects/CrossTargeting/TestLibrary/TestLibrary.csproj
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" />  
+  <PropertyGroup>
+    <Version>42.43.44.45-alpha</Version>
+    <GenerateDocumentationFile>True</GenerateDocumentationFile>
+    <OutputType>Library</OutputType>
+    <TargetFrameworks>netstandard1.4;netstandard1.5</TargetFrameworks>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="**\*.cs" Exclude="$(GlobalExclude)" />
+    <EmbeddedResource Include="**\*.resx" Exclude="$(GlobalExclude)" />
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/TestAssets/TestProjects/CrossTargeting/TestLibrary/project.json
+++ b/TestAssets/TestProjects/CrossTargeting/TestLibrary/project.json
@@ -1,0 +1,10 @@
+{
+  "dependencies": {
+    "NETStandard.Library": "1.6.0",
+    "Microsoft.NETCore.Sdk": "1.0.0-alpha-00000001-01"
+  },
+  "frameworks": {
+    "netstandard1.4": {},
+    "netstandard1.5": {}
+  }
+}

--- a/src/Tasks/Microsoft.NETCore.Build.Tasks.UnitTests/GivenACompilationOptionsConverter.cs
+++ b/src/Tasks/Microsoft.NETCore.Build.Tasks.UnitTests/GivenACompilationOptionsConverter.cs
@@ -68,7 +68,7 @@ namespace Microsoft.NETCore.Build.Tasks.UnitTests
                 yield return new object[]
                 {
                     null,
-                    CompilationOptions.Default
+                    null
                 };
             }
         }

--- a/src/Tasks/Microsoft.NETCore.Build.Tasks/CompilationOptionsConverter.cs
+++ b/src/Tasks/Microsoft.NETCore.Build.Tasks/CompilationOptionsConverter.cs
@@ -13,7 +13,7 @@ namespace Microsoft.NETCore.Build.Tasks
         {
             if (compilerOptionsItem == null)
             {
-                return CompilationOptions.Default;
+                return null;
             }
 
             return new CompilationOptions(

--- a/src/Tasks/Microsoft.NETCore.Build.Tasks/GetNearestTargetFramework.cs
+++ b/src/Tasks/Microsoft.NETCore.Build.Tasks/GetNearestTargetFramework.cs
@@ -55,6 +55,7 @@ namespace Microsoft.DotNet.Core.Build.Tasks
             {
                 // TODO: localize: https://github.com/dotnet/sdk/issues/33
                 Log.LogError($"Project has no no target framework compatible with '{ReferringTargetFramework}'");
+                return false;
             }
 
             // Note that there can be more than one spelling of the same target framework (e.g. net45 and net4.5) and 

--- a/src/Tasks/Microsoft.NETCore.Build.Tasks/GetNearestTargetFramework.cs
+++ b/src/Tasks/Microsoft.NETCore.Build.Tasks/GetNearestTargetFramework.cs
@@ -1,0 +1,81 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Newtonsoft.Json;
+using NuGet.Versioning;
+using System.Diagnostics;
+using NuGet.Frameworks;
+using System.Runtime.Versioning;
+using System.Linq;
+
+namespace Microsoft.DotNet.Core.Build.Tasks
+{
+    /// <summary>
+    /// Gets the "nearest" framework
+    /// </summary>
+    public class GetNearestTargetFramework : Task
+    {
+        /// <summary>
+        /// The target framework of the referring project (in short form or full TFM)
+        /// </summary>
+        [Required]
+        public string ReferringTargetFramework { get; set; }
+
+        /// <summary>
+        /// The target frameworks supported by the project being referenced (in short form or full TFM).
+        /// </summary>
+        [Required]
+        public string[] PossibleTargetFrameworks { get; set; }
+
+        /// <summary>
+        /// The entry in <see cref="PossibleTargetFrameworks"/> that is "nearest" to <see cref="ReferringTargetFramework" />.
+        /// If none of the possible frameworks are compatible with the referring framework.
+        /// </summary>
+        [Output]
+        public string NearestTargetFramework { get; private set; }
+
+        public override bool Execute()
+        {
+            if (PossibleTargetFrameworks.Length < 1)
+            {
+                // TODO: localize: https://github.com/dotnet/sdk/issues/33
+                Log.LogError("At least one possible target framework must be specified.");
+                return false;
+            }
+
+            var referringNuGetFramework = ParseFramework(ReferringTargetFramework);
+            var possibleNuGetFrameworks = PossibleTargetFrameworks.Select(framework => ParseFramework(framework)).ToList(); // ToList() to force enumeration and error logging.
+
+            if (Log.HasLoggedErrors)
+            {
+                return false;
+            }
+
+            var nearestNuGetFramework = new FrameworkReducer().GetNearest(referringNuGetFramework, possibleNuGetFrameworks);
+            if (nearestNuGetFramework == null)
+            {
+                // TODO: localize: https://github.com/dotnet/sdk/issues/33
+                Log.LogError($"Project has no no target framework compatible with '{ReferringTargetFramework}'");
+            }
+
+            NearestTargetFramework = PossibleTargetFrameworks[possibleNuGetFrameworks.IndexOf(nearestNuGetFramework)];
+            return true;
+        }
+
+        private NuGetFramework ParseFramework(string name)
+        {
+            var framework = NuGetFramework.Parse(name);
+
+            if (framework == null)
+            {
+                // TODO: localize: https://github.com/dotnet/sdk/issues/33
+                Log.LogError($"Invalid framework name: '{framework}'.");
+            }
+
+            return framework;
+        }
+    }
+}

--- a/src/Tasks/Microsoft.NETCore.Build.Tasks/GetNearestTargetFramework.cs
+++ b/src/Tasks/Microsoft.NETCore.Build.Tasks/GetNearestTargetFramework.cs
@@ -1,14 +1,10 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using Newtonsoft.Json;
-using NuGet.Versioning;
-using System.Diagnostics;
 using NuGet.Frameworks;
-using System.Runtime.Versioning;
 using System.Linq;
 
 namespace Microsoft.DotNet.Core.Build.Tasks
@@ -61,7 +57,15 @@ namespace Microsoft.DotNet.Core.Build.Tasks
                 Log.LogError($"Project has no no target framework compatible with '{ReferringTargetFramework}'");
             }
 
-            NearestTargetFramework = PossibleTargetFrameworks[possibleNuGetFrameworks.IndexOf(nearestNuGetFramework)];
+            // Note that there can be more than one spelling of the same target framework (e.g. net45 and net4.5) and 
+            // we must return a value that is spelled exactly the same way as the PossibleTargetFrameworks input. To 
+            // achieve this, we find the index of the returned framework among the set we passed to nuget and use that
+            // to retrive a value at the same position in the input.
+            //
+            // This is required to guarantee that a project can use whatever spelling appears in $(TargetFrameworks)
+            // in a condition that compares against $(TargetFramework).
+            int indexOfNearestFramework = possibleNuGetFrameworks.IndexOf(nearestNuGetFramework);
+            NearestTargetFramework = PossibleTargetFrameworks[indexOfNearestFramework];
             return true;
         }
 

--- a/src/Tasks/Microsoft.NETCore.Build.Tasks/GetNearestTargetFramework.cs
+++ b/src/Tasks/Microsoft.NETCore.Build.Tasks/GetNearestTargetFramework.cs
@@ -67,7 +67,7 @@ namespace Microsoft.DotNet.Core.Build.Tasks
             // in a condition that compares against $(TargetFramework).
             int indexOfNearestFramework = possibleNuGetFrameworks.IndexOf(nearestNuGetFramework);
             NearestTargetFramework = PossibleTargetFrameworks[indexOfNearestFramework];
-            return true;
+            return Log.HasLoggedErrors;
         }
 
         private NuGetFramework ParseFramework(string name)

--- a/src/Tasks/Microsoft.NETCore.Build.Tasks/Microsoft.NETCore.Build.Tasks.csproj
+++ b/src/Tasks/Microsoft.NETCore.Build.Tasks/Microsoft.NETCore.Build.Tasks.csproj
@@ -19,6 +19,7 @@
     <ResolveNuGetPackages>true</ResolveNuGetPackages>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="GetNearestTargetFramework.cs" />
     <Compile Include="ITaskItemExtensions.cs" />
     <Compile Include="CompilationOptionsConverter.cs" />
     <Compile Include="NuGetUtils.cs" />
@@ -42,6 +43,9 @@
     <None Include="build\netstandard1.0\Microsoft.NETCore.GenerateAssemblyInfo.targets">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="build\cross\Microsoft.NETCore.Sdk.targets">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="build\netstandard1.0\Microsoft.NETCore.Sdk.VisualBasic.props">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
@@ -49,6 +53,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="build\netstandard1.0\Microsoft.NETCore.Sdk.VisualBasic.targets">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="build\netstandard1.0\Microsoft.NETCore.Sdk.BeforeCommon.targets">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="build\netstandard1.0\Microsoft.NETCore.Sdk.CSharp.targets">
@@ -61,6 +68,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="build\netstandard1.0\Microsoft.NETCore.Publish.targets">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="build\netstandard1.0\Microsoft.NETCore.TargetFrameworkInference.targets">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="build\netstandard1.0\Microsoft.PackageDependencyResolution.targets">

--- a/src/Tasks/Microsoft.NETCore.Build.Tasks/NuGetUtils.cs
+++ b/src/Tasks/Microsoft.NETCore.Build.Tasks/NuGetUtils.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using NuGet.Packaging.Core;
+using NuGet.ProjectModel;
 
 namespace Microsoft.NETCore.Build.Tasks
 {
@@ -19,6 +20,11 @@ namespace Microsoft.NETCore.Build.Tasks
         public static IEnumerable<string> FilterPlaceHolderFiles(this IEnumerable<string> files)
         {
             return files.Where(f => !IsPlaceholderFile(f));
+        }
+
+        public static IEnumerable<LockFileItem> FilterPlaceHolderFiles(this IEnumerable<LockFileItem> files)
+        {
+            return files.Where(f => !IsPlaceholderFile(f.Path));
         }
     }
 }

--- a/src/Tasks/Microsoft.NETCore.Build.Tasks/PublishAssembliesResolver.cs
+++ b/src/Tasks/Microsoft.NETCore.Build.Tasks/PublishAssembliesResolver.cs
@@ -35,7 +35,7 @@ namespace Microsoft.NETCore.Build.Tasks
                 results.AddRange(GetResolvedFiles(targetLibrary.RuntimeAssemblies, libraryPath));
                 results.AddRange(GetResolvedFiles(targetLibrary.NativeLibraries, libraryPath));
 
-                foreach (LockFileRuntimeTarget runtimeTarget in targetLibrary.RuntimeTargets)
+                foreach (LockFileRuntimeTarget runtimeTarget in targetLibrary.RuntimeTargets.FilterPlaceHolderFiles())
                 {
                     if (string.Equals(runtimeTarget.AssetType, "native", StringComparison.OrdinalIgnoreCase) ||
                         string.Equals(runtimeTarget.AssetType, "runtime", StringComparison.OrdinalIgnoreCase))
@@ -47,7 +47,7 @@ namespace Microsoft.NETCore.Build.Tasks
                     }
                 }
 
-                foreach (LockFileItem resourceAssembly in targetLibrary.ResourceAssemblies)
+                foreach (LockFileItem resourceAssembly in targetLibrary.ResourceAssemblies.FilterPlaceHolderFiles())
                 {
                     string locale;
                     if (!resourceAssembly.Properties.TryGetValue("locale", out locale))
@@ -67,7 +67,7 @@ namespace Microsoft.NETCore.Build.Tasks
 
         private static IEnumerable<ResolvedFile> GetResolvedFiles(IEnumerable<LockFileItem> items, string libraryPath)
         {
-            foreach (LockFileItem item in items)
+            foreach (LockFileItem item in items.FilterPlaceHolderFiles())
             {
                 yield return new ResolvedFile(
                     sourcePath: Path.Combine(libraryPath, item.Path),

--- a/src/Tasks/Microsoft.NETCore.Build.Tasks/build/cross/Microsoft.NETCore.Sdk.targets
+++ b/src/Tasks/Microsoft.NETCore.Build.Tasks/build/cross/Microsoft.NETCore.Sdk.targets
@@ -1,0 +1,59 @@
+<!--
+***********************************************************************************************
+cross/Microsoft.NETCore.Sdk.targets
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+          created a backup copy.  Incorrect changes to this file will make it
+          impossible to load or build your projects from the command-line or the IDE.
+
+Copyright (c) .NET Foundation. All rights reserved. 
+***********************************************************************************************
+-->
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <!-- ================================================================================== -->
+  <!--  TODO: Move everything in this section to Microsoft.Commmon.CrossTargeting.targets -->
+  <!--  https://github.com/dotnet/sdk/issues/145                                          -->
+  <!-- ================================================================================== -->
+  <ItemGroup>
+    <TargetFramework Include="$(TargetFrameworks)" />
+  </ItemGroup>
+
+  <Target Name="Build" Returns="@(InnerOutput)">
+    <PropertyGroup  Condition="'$(InnerTargets)' == ''">
+      <InnerTargets>Build</InnerTargets>
+    </PropertyGroup>
+
+    <MSBuild Projects="$(MSBuildProjectFile)"
+             Condition="'$(TargetFrameworks)' != '' "
+             Targets="$(InnerTargets)"
+             Properties="TargetFramework=%(TargetFramework.Identity)">
+      <Output ItemName="InnerOutput" TaskParameter="TargetOutputs" />
+    </MSBuild>
+  </Target>
+
+  <Target Name="Clean" DependsOnTargets="_SetCleanInnerTarget;Build" />
+  <Target Name="_SetCleanInnerTarget">
+    <PropertyGroup>
+      <InnerTargets>Clean</InnerTargets>
+    </PropertyGroup>
+  </Target>
+
+  <Target Name="Rebuild" DependsOnTargets="_SetRebuildInnerTarget;Build" />
+  <Target Name="_SetRebuildInnerTarget">
+    <PropertyGroup>
+      <InnerTargets>Rebuild</InnerTargets>
+    </PropertyGroup>
+  </Target>
+
+  <!-- ===================================================================================== -->
+  <!-- End of what should be moved to Microsoft.Common.CrossTargeting.targets                -->
+  <!-- ===================================================================================== -->
+
+  <UsingTask TaskName="GetNearestTargetFramework" AssemblyFile="$(MicrosoftNETCoreBuildTasksAssembly)" />
+
+  <Target Name="GetTargetFrameworkProperties" Returns="TargetFramework=$(NearestTargetFramework)">
+    <GetNearestTargetFramework ReferringTargetFramework="$(ReferringTargetFramework)" PossibleTargetFrameworks="@(TargetFramework)">
+      <Output PropertyName="NearestTargetFramework" TaskParameter="NearestTargetFramework" />
+    </GetNearestTargetFramework>
+  </Target>
+</Project>

--- a/src/Tasks/Microsoft.NETCore.Build.Tasks/build/cross/Microsoft.NETCore.Sdk.targets
+++ b/src/Tasks/Microsoft.NETCore.Build.Tasks/build/cross/Microsoft.NETCore.Sdk.targets
@@ -1,6 +1,6 @@
 <!--
 ***********************************************************************************************
-cross/Microsoft.NETCore.Sdk.targets
+Microsoft.NETCore.Sdk.targets
 
 WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
           created a backup copy.  Incorrect changes to this file will make it
@@ -14,31 +14,85 @@ Copyright (c) .NET Foundation. All rights reserved.
   <!--  TODO: Move everything in this section to Microsoft.Commmon.CrossTargeting.targets -->
   <!--  https://github.com/dotnet/sdk/issues/145                                          -->
   <!-- ================================================================================== -->
-  <ItemGroup>
-    <TargetFramework Include="$(TargetFrameworks)" />
-  </ItemGroup>
 
-  <Target Name="Build" Returns="@(InnerOutput)">
-    <PropertyGroup  Condition="'$(InnerTargets)' == ''">
-      <InnerTargets>Build</InnerTargets>
-    </PropertyGroup>
+  <!--
+  ============================================================
+                                       DispatchToInnerBuilds
 
+     Builds this project with /t:$(InnerTarget) /p:TargetFramework=X for each
+     value X in $(TargetFrameworks)
+
+     [IN]
+     $(TargetFrameworks) - Semicolon delimited list of target frameworks.
+     $(InnerTargets) - The targets to build for each target framework
+     
+     [OUT]
+     @(InnerOutput) - The combined output items of the inner targets across
+                      all target frameworks..
+  ============================================================
+  -->
+  <Target Name="DispatchToInnerBuilds" Returns="@(InnerOutput)">
+    <ItemGroup>
+      <_TargetFramework Include="$(TargetFrameworks)" />
+    </ItemGroup>
     <MSBuild Projects="$(MSBuildProjectFile)"
              Condition="'$(TargetFrameworks)' != '' "
              Targets="$(InnerTargets)"
-             Properties="TargetFramework=%(TargetFramework.Identity)">
+             Properties="TargetFramework=%(_TargetFramework.Identity)">
       <Output ItemName="InnerOutput" TaskParameter="TargetOutputs" />
     </MSBuild>
   </Target>
 
-  <Target Name="Clean" DependsOnTargets="_SetCleanInnerTarget;Build" />
+  <!--
+  ============================================================
+                                       Build
+
+   Cross-targeting version of Build.
+
+   [IN]
+   $(TargetFrameworks) - Semicolon delimited list of target frameworks.
+
+   $(InnerTargets)     - The targets to build for each target framework. Defaults
+                         to 'Build' if unset, but allows override to support
+                         `msbuild /p:InnerTargets=X;Y;Z` which will build X, Y, 
+                         and Z targets for each target framework.
+
+   [OUT]
+   @(InnerOutput) - The combined output items of the inner targets across
+                    all builds.
+  ============================================================
+  -->
+  <Target Name="Build" DependsOnTargets="_SetBuildInnerTarget;DispatchToInnerBuilds" />
+  
+  <Target Name="_SetBuildInnerTarget" Returns="@(InnerOutput)">
+    <PropertyGroup  Condition="'$(InnerTargets)' == ''">
+      <InnerTargets>Build</InnerTargets>
+    </PropertyGroup>
+  </Target>
+
+
+  <!--
+  ============================================================
+                                       Clean
+
+   Cross-targeting version of clean.
+  ============================================================
+  -->
+  <Target Name="Clean" DependsOnTargets="_SetCleanInnerTarget;DispatchToInnerBuilds" />
   <Target Name="_SetCleanInnerTarget">
     <PropertyGroup>
       <InnerTargets>Clean</InnerTargets>
     </PropertyGroup>
   </Target>
 
-  <Target Name="Rebuild" DependsOnTargets="_SetRebuildInnerTarget;Build" />
+  <!--
+  ============================================================
+                                       Rebuild
+
+   Cross-targeting version of rebuild.
+  ============================================================
+  -->
+  <Target Name="Rebuild" DependsOnTargets="_SetRebuildInnerTarget;DispatchToInnerBuilds" />
   <Target Name="_SetRebuildInnerTarget">
     <PropertyGroup>
       <InnerTargets>Rebuild</InnerTargets>
@@ -51,9 +105,23 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <UsingTask TaskName="GetNearestTargetFramework" AssemblyFile="$(MicrosoftNETCoreBuildTasksAssembly)" />
 
+  <!--
+  ============================================================
+                              GetTargetFrameworkProperties
+
+    Invoked by common targets to return the set of properties 
+    (in the form  "key1=value1;...keyN=valueN") needed to build 
+    against the target framework that best matches the referring
+    project's target framework.
+
+    The referring project's $(TargetFrameworkMoniker) is passed 
+    in as $(ReferringTargetFramework).
+  ============================================================
+   -->
   <Target Name="GetTargetFrameworkProperties" Returns="TargetFramework=$(NearestTargetFramework)">
     <GetNearestTargetFramework ReferringTargetFramework="$(ReferringTargetFramework)" PossibleTargetFrameworks="@(TargetFramework)">
       <Output PropertyName="NearestTargetFramework" TaskParameter="NearestTargetFramework" />
     </GetNearestTargetFramework>
   </Target>
+
 </Project>

--- a/src/Tasks/Microsoft.NETCore.Build.Tasks/build/netstandard1.0/Microsoft.NETCore.Publish.targets
+++ b/src/Tasks/Microsoft.NETCore.Build.Tasks/build/netstandard1.0/Microsoft.NETCore.Publish.targets
@@ -442,7 +442,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <PropertyGroup>
       <_DotNetHostExecutableName>dotnet</_DotNetHostExecutableName>
-      <_DotNetHostExecutableName Condition="'$(OS)'=='Windows_NT'">$(_DotNetHostExecutableName).exe</_DotNetHostExecutableName>
+      <_DotNetHostExecutableName Condition="$(RuntimeIdentifier.StartsWith('win'))">$(_DotNetHostExecutableName).exe</_DotNetHostExecutableName>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Tasks/Microsoft.NETCore.Build.Tasks/build/netstandard1.0/Microsoft.NETCore.Publish.targets
+++ b/src/Tasks/Microsoft.NETCore.Build.Tasks/build/netstandard1.0/Microsoft.NETCore.Publish.targets
@@ -19,9 +19,18 @@ Copyright (c) .NET Foundation. All rights reserved.
     ============================================================
     -->
   <PropertyGroup>
-    <PublishDir Condition=" '$(PublishDir)' == '' ">$(OutDir)publish\</PublishDir>
+    <_PublishDirName Condition=" '$(_PublishDirName)' == '' ">publish</_PublishDirName>
+
+    <!-- TODO: https://github.com/dotnet/sdk/issues/143 - find a way to default $(PublishDir) before Microsoft.Common.CurrentVersion.targets defaults it -->
+    <_ShouldSetPublishDir Condition=" '$(PublishDir)' == '' or '$(PublishDir)' == '$(OutputPath)app.publish\'">true</_ShouldSetPublishDir>
+    <PublishDir Condition=" '$(_ShouldSetPublishDir)' == 'true' ">$(OutDir)$(_PublishDirName)\</PublishDir>
+    <PublishDir Condition=" '$(_ShouldSetPublishDir)' == 'true' and '$(RuntimeIdentifier)' != ''  ">$(OutDir)$(RuntimeIdentifier)\$(_PublishDirName)\</PublishDir>
+
     <DefaultCopyToPublishDirectoryMetadata Condition="'$(DefaultCopyToPublishDirectoryMetadata)' == ''">true</DefaultCopyToPublishDirectoryMetadata>
     <_GetChildProjectCopyToPublishDirectoryItems Condition="'$(_GetChildProjectCopyToPublishDirectoryItems)' == ''">true</_GetChildProjectCopyToPublishDirectoryItems>
+
+    <!-- publishing self-contained apps should publish the native host as $(AssemblyName).exe -->
+    <RenamePublishedHost Condition=" '$(RenamePublishedHost)' == '' and '$(OutputType)' == 'Exe' and '$(RuntimeIdentifier)' != ''">true</RenamePublishedHost>
   </PropertyGroup>
 
   <Target Name="Publish"
@@ -58,6 +67,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     -->
   <Target Name="CopyFilesToPublishDirectory"
           DependsOnTargets="ComputeFilesToPublish;
+                            RenamePublishedHost;
                             _CopySourceItemsToPublishDirectory">
 
     <Copy SourceFiles="@(ResolvedFilesToPublish)"
@@ -416,6 +426,32 @@ Copyright (c) .NET Foundation. All rights reserved.
                                        RuntimeConfigPath="$(_PublishRuntimeConfigFilePath)"
                                        RuntimeIdentifier="$(RuntimeIdentifier)"
                                        UserRuntimeConfig="$(UserRuntimeConfig)" />
+
+  </Target>
+
+  <!--
+    ============================================================
+                                        RenamePublishedHost
+
+    Renames the dotnet native host to match the application's name.
+    ============================================================
+    -->
+
+  <Target Name="RenamePublishedHost"
+          Condition="'$(RenamePublishedHost)' == 'true'">
+
+    <PropertyGroup>
+      <_DotNetHostExecutableName>dotnet</_DotNetHostExecutableName>
+      <_DotNetHostExecutableName Condition="'$(OS)'=='Windows_NT'">$(_DotNetHostExecutableName).exe</_DotNetHostExecutableName>
+    </PropertyGroup>
+
+    <ItemGroup>
+
+      <ResolvedFilesToPublish Condition="'%(ResolvedFilesToPublish.RelativePath)' == '$(_DotNetHostExecutableName)'">
+        <RelativePath>$(AssemblyName)%(ResolvedFilesToPublish.Extension)</RelativePath>
+      </ResolvedFilesToPublish>
+
+    </ItemGroup>
 
   </Target>
 

--- a/src/Tasks/Microsoft.NETCore.Build.Tasks/build/netstandard1.0/Microsoft.NETCore.Sdk.BeforeCommon.targets
+++ b/src/Tasks/Microsoft.NETCore.Build.Tasks/build/netstandard1.0/Microsoft.NETCore.Sdk.BeforeCommon.targets
@@ -1,0 +1,18 @@
+<!--
+***********************************************************************************************
+Microsoft.NETCore.Sdk.BeforeCommon.targets
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+          created a backup copy.  Incorrect changes to this file will make it
+          impossible to load or build your projects from the command-line or the IDE.
+
+Copyright (c) .NET Foundation. All rights reserved. 
+***********************************************************************************************
+-->
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <Import Condition="'$(TargetFramework)' != ''"
+          Project="$(MSBuildThisFileDirectory)Microsoft.NETCore.TargetFrameworkInference.targets" />
+
+  </Project>
+

--- a/src/Tasks/Microsoft.NETCore.Build.Tasks/build/netstandard1.0/Microsoft.NETCore.Sdk.BeforeCommon.targets
+++ b/src/Tasks/Microsoft.NETCore.Build.Tasks/build/netstandard1.0/Microsoft.NETCore.Sdk.BeforeCommon.targets
@@ -14,5 +14,4 @@ Copyright (c) .NET Foundation. All rights reserved.
   <Import Condition="'$(TargetFramework)' != ''"
           Project="$(MSBuildThisFileDirectory)Microsoft.NETCore.TargetFrameworkInference.targets" />
 
-  </Project>
-
+</Project>

--- a/src/Tasks/Microsoft.NETCore.Build.Tasks/build/netstandard1.0/Microsoft.NETCore.Sdk.props
+++ b/src/Tasks/Microsoft.NETCore.Build.Tasks/build/netstandard1.0/Microsoft.NETCore.Sdk.props
@@ -60,6 +60,15 @@ Copyright (c) .NET Foundation. All rights reserved.
     <CopyLocalLockFileAssemblies>false</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 
+  <!-- Shared properties between cross-targeting and inner build targets. -->
+  <PropertyGroup>
+    <MicrosoftNETCoreBuildTasksDirectoryRoot>$(MSBuildThisFileDirectory)../../tools/</MicrosoftNETCoreBuildTasksDirectoryRoot>
+    <MicrosoftNETCoreBuildTasksTFM Condition=" '$(MSBuildRuntimeType)' == 'Core'">netcoreapp1.0</MicrosoftNETCoreBuildTasksTFM>
+    <MicrosoftNETCoreBuildTasksTFM Condition=" '$(MicrosoftNETCoreBuildTasksTFM)' == ''">net46</MicrosoftNETCoreBuildTasksTFM>
+    <MicrosoftNETCoreBuildTasksDirectory>$(MicrosoftNETCoreBuildTasksDirectoryRoot)$(MicrosoftNETCoreBuildTasksTFM)/</MicrosoftNETCoreBuildTasksDirectory>
+    <MicrosoftNETCoreBuildTasksAssembly>$(MicrosoftNETCoreBuildTasksDirectory)Microsoft.NETCore.Build.Tasks.dll</MicrosoftNETCoreBuildTasksAssembly>
+  </PropertyGroup>
+
   <!-- Temporary hacks to work around bugs -->
   <PropertyGroup>
     <!-- Temp Hack: https://github.com/dotnet/roslyn/issues/12167 -->
@@ -75,15 +84,6 @@ Copyright (c) .NET Foundation. All rights reserved.
     <CustomBeforeMicrosoftCommonTargets>$(MSBuildThisFileDirectory)Microsoft.NETCore.Sdk.BeforeCommon.targets</CustomBeforeMicrosoftCommonTargets>
   </PropertyGroup>
   
-  <!-- Shared properties between cross-targeting and inner build targets. -->
-  <PropertyGroup>
-    <MicrosoftNETCoreBuildTasksDirectoryRoot>$(MSBuildThisFileDirectory)../../tools/</MicrosoftNETCoreBuildTasksDirectoryRoot>
-    <MicrosoftNETCoreBuildTasksTFM Condition=" '$(MSBuildRuntimeType)' == 'Core'">netcoreapp1.0</MicrosoftNETCoreBuildTasksTFM>
-    <MicrosoftNETCoreBuildTasksTFM Condition=" '$(MicrosoftNETCoreBuildTasksTFM)' == ''">net46</MicrosoftNETCoreBuildTasksTFM>
-    <MicrosoftNETCoreBuildTasksDirectory>$(MicrosoftNETCoreBuildTasksDirectoryRoot)$(MicrosoftNETCoreBuildTasksTFM)/</MicrosoftNETCoreBuildTasksDirectory>
-    <MicrosoftNETCoreBuildTasksAssembly>$(MicrosoftNETCoreBuildTasksDirectory)Microsoft.NETCore.Build.Tasks.dll</MicrosoftNETCoreBuildTasksAssembly>
-  </PropertyGroup>
-
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.NETCore.Sdk.CSharp.props" Condition="'$(MSBuildProjectExtension)' == '.csproj'" />
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.NETCore.Sdk.VisualBasic.props" Condition="'$(MSBuildProjectExtension)' == '.vbproj'" />
 </Project>

--- a/src/Tasks/Microsoft.NETCore.Build.Tasks/build/netstandard1.0/Microsoft.NETCore.Sdk.props
+++ b/src/Tasks/Microsoft.NETCore.Build.Tasks/build/netstandard1.0/Microsoft.NETCore.Sdk.props
@@ -67,8 +67,23 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <!-- Temp Hack: https://github.com/Microsoft/msbuild/issues/720 -->
     <OverrideToolHost Condition=" '$(DotnetHostPath)' != '' and '$(OverrideToolHost)' == ''">$(DotnetHostPath)</OverrideToolHost>
+
+    <!-- Temp Hack: https://github.com/Microsoft/msbuild/issues/1046: Temporary bootstrapping mechanism before cross-targeting participation is extensible just as inner build is. -->
+    <CoreCrossTargetingTargetsPath>$(MSBuildThisFileDirectory)..\cross\Microsoft.NETCore.Sdk.targets</CoreCrossTargetingTargetsPath>
+    
+    <!-- Temp Hack: https://github.com/Microsoft/msbuild/issues/1045: This is the only before common targets hook available to us, but using it is hijacking a hook that should belong to the user. -->
+    <CustomBeforeMicrosoftCommonTargets>$(MSBuildThisFileDirectory)Microsoft.NETCore.Sdk.BeforeCommon.targets</CustomBeforeMicrosoftCommonTargets>
   </PropertyGroup>
   
+  <!-- Shared properties between cross-targeting and inner build targets. -->
+  <PropertyGroup>
+    <MicrosoftNETCoreBuildTasksDirectoryRoot>$(MSBuildThisFileDirectory)../../tools/</MicrosoftNETCoreBuildTasksDirectoryRoot>
+    <MicrosoftNETCoreBuildTasksTFM Condition=" '$(MSBuildRuntimeType)' == 'Core'">netcoreapp1.0</MicrosoftNETCoreBuildTasksTFM>
+    <MicrosoftNETCoreBuildTasksTFM Condition=" '$(MicrosoftNETCoreBuildTasksTFM)' == ''">net46</MicrosoftNETCoreBuildTasksTFM>
+    <MicrosoftNETCoreBuildTasksDirectory>$(MicrosoftNETCoreBuildTasksDirectoryRoot)$(MicrosoftNETCoreBuildTasksTFM)/</MicrosoftNETCoreBuildTasksDirectory>
+    <MicrosoftNETCoreBuildTasksAssembly>$(MicrosoftNETCoreBuildTasksDirectory)Microsoft.NETCore.Build.Tasks.dll</MicrosoftNETCoreBuildTasksAssembly>
+  </PropertyGroup>
+
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.NETCore.Sdk.CSharp.props" Condition="'$(MSBuildProjectExtension)' == '.csproj'" />
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.NETCore.Sdk.VisualBasic.props" Condition="'$(MSBuildProjectExtension)' == '.vbproj'" />
 </Project>

--- a/src/Tasks/Microsoft.NETCore.Build.Tasks/build/netstandard1.0/Microsoft.NETCore.Sdk.props
+++ b/src/Tasks/Microsoft.NETCore.Build.Tasks/build/netstandard1.0/Microsoft.NETCore.Sdk.props
@@ -25,6 +25,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ErrorReport>prompt</ErrorReport>
     <AssemblyName>$(MSBuildProjectName)</AssemblyName>
     <RootNamespace>$(MSBuildProjectName)</RootNamespace>
+    <Deterministic>true</Deterministic>
   </PropertyGroup>
 
   <!-- User-facing configuration-specific defaults -->

--- a/src/Tasks/Microsoft.NETCore.Build.Tasks/build/netstandard1.0/Microsoft.NETCore.Sdk.targets
+++ b/src/Tasks/Microsoft.NETCore.Build.Tasks/build/netstandard1.0/Microsoft.NETCore.Sdk.targets
@@ -1,6 +1,6 @@
 <!--
 ***********************************************************************************************
-Microsoft.NETCore.Sdk.targets
+netstandard1.0/Microsoft.NETCore.Sdk.targets
 
 WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
           created a backup copy.  Incorrect changes to this file will make it
@@ -10,13 +10,6 @@ Copyright (c) .NET Foundation. All rights reserved.
 ***********************************************************************************************
 -->
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup>
-    <MicrosoftNETCoreBuildTasksDirectoryRoot>$(MSBuildThisFileDirectory)../../tools/</MicrosoftNETCoreBuildTasksDirectoryRoot>
-    <MicrosoftNETCoreBuildTasksTFM Condition=" '$(MSBuildRuntimeType)' == 'Core'">netcoreapp1.0</MicrosoftNETCoreBuildTasksTFM>
-    <MicrosoftNETCoreBuildTasksTFM Condition=" '$(MicrosoftNETCoreBuildTasksTFM)' == ''">net46</MicrosoftNETCoreBuildTasksTFM>
-    <MicrosoftNETCoreBuildTasksDirectory>$(MicrosoftNETCoreBuildTasksDirectoryRoot)$(MicrosoftNETCoreBuildTasksTFM)/</MicrosoftNETCoreBuildTasksDirectory>
-    <MicrosoftNETCoreBuildTasksAssembly>$(MicrosoftNETCoreBuildTasksDirectory)Microsoft.NETCore.Build.Tasks.dll</MicrosoftNETCoreBuildTasksAssembly>
-  </PropertyGroup>
 
   <ImportGroup>
     <Import Project="$(MSBuildThisFileDirectory)Microsoft.PackageDependencyResolution.targets" Condition="Exists('$(MSBuildThisFileDirectory)Microsoft.PackageDependencyResolution.targets')" />

--- a/src/Tasks/Microsoft.NETCore.Build.Tasks/build/netstandard1.0/Microsoft.NETCore.Sdk.targets
+++ b/src/Tasks/Microsoft.NETCore.Build.Tasks/build/netstandard1.0/Microsoft.NETCore.Sdk.targets
@@ -96,11 +96,6 @@ Copyright (c) .NET Foundation. All rights reserved.
                       RuntimeIdentifier="$(RuntimeIdentifier)"
                       CompilerOptions="@(DependencyFileCompilerOptions)" />
 
-    <!--
-    TODO: https://github.com/dotnet/sdk/issues/21
-    When OutputType == 'exe' and !IsPortable, we need to verify CoreClr is present in the deps graph, and copy in a host to the output
-    See https://github.com/dotnet/cli/blob/6b54ae0bcc5c63e7c989ac19d851f234f9172bea/src/Microsoft.DotNet.Compiler.Common/Executable.cs#L102-L107
-    -->
   </Target>
 
   <!--

--- a/src/Tasks/Microsoft.NETCore.Build.Tasks/build/netstandard1.0/Microsoft.NETCore.Sdk.targets
+++ b/src/Tasks/Microsoft.NETCore.Build.Tasks/build/netstandard1.0/Microsoft.NETCore.Sdk.targets
@@ -1,6 +1,6 @@
 <!--
 ***********************************************************************************************
-netstandard1.0/Microsoft.NETCore.Sdk.targets
+Microsoft.NETCore.Sdk.targets
 
 WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
           created a backup copy.  Incorrect changes to this file will make it

--- a/src/Tasks/Microsoft.NETCore.Build.Tasks/build/netstandard1.0/Microsoft.NETCore.TargetFrameworkInference.targets
+++ b/src/Tasks/Microsoft.NETCore.Build.Tasks/build/netstandard1.0/Microsoft.NETCore.TargetFrameworkInference.targets
@@ -1,0 +1,105 @@
+<!--
+***********************************************************************************************
+Microsoft.NETCore.TargetFrameworkInference.props
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+          created a backup copy.  Incorrect changes to this file will make it
+          impossible to load or build your projects from the command-line or the IDE.
+
+Copyright (c) .NET Foundation. All rights reserved. 
+***********************************************************************************************
+-->
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <!-- 
+    Note that this file is only included when $(TargetFramework) is set and so we do not need to check that here.
+
+    Common targets require that $(TargetFrameworkIdentifier) and $(TargetFrameworkVersion) are set by static evaluation
+    before they are imported. In common cases (currently netstandard, netcoreapp, or net), we infer them from the short
+    names given via TargetFramework to allow for terseness and lack of duplication in project files.
+
+    For other cases, the user must supply them manually.
+
+    For cases where inference is supported, the user need only specify the targets in TargetFrameworks, e.g:
+      <PropertyGroup>
+        <TargetFrameworks>net45;netstandard1.0</TargetFrameworks>
+      </PropertyGroup>
+
+    For cases where inference is not supported, identifier, version and profile can be specified explicitly as follows:
+       <PropertyGroup>
+         <TargetFrameworks>net451+win81;xyz1.0</TargetFrameworks>
+       <PropertyGroup>
+       <PropertyGroup Condition="'$(TargetFramework)' == 'net451+win81'">
+         <TargetFrameworkIdentifier>.NETPortable</TargetFrameworkIdentifier>
+         <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+         <TargetFrameworkProfile>Profile44</TargetFrameworkProfile>
+       </PropertyGroup>
+       <PropertyGroup Condition="'$(TargetFramework)' == 'xyz1.0'">
+         <TargetFrameworkIdentifier>Xyz</TargetFrameworkVersion>
+       <PropertyGroup>
+
+    Note in the xyz1.0 case, which is meant to demonstrate a framework we don't yet recognize, we can still
+    infer the version of 1.0. The user can also override it as always we honor a TargetFrameworkIdentifier
+    or TargetFrameworkVersion that is already set.
+   -->
+
+  <!-- Split $(TargetFramework) (e.g. net45) into short identifier and short version (e.g. 'net' and '45'). -->
+  <PropertyGroup Condition="!$(TargetFramework.Contains(',')) and !$(TargetFramework.Contains('+'))">
+   <_ShortFrameworkIdentifier>$(TargetFramework.TrimEnd('.0123456789'))</_ShortFrameworkIdentifier>
+   <_ShortFrameworkVersion>$(TargetFramework.Substring($(_ShortFrameworkIdentifier.Length)))</_ShortFrameworkVersion>
+  </PropertyGroup>
+
+  <!-- Map short name to long name. See earlier comment for example of how to work with identifiers that are not recognized here. -->
+  <PropertyGroup Condition="$(TargetFrameworkIdentifier) == ''">
+    <TargetFrameworkIdentifier Condition="'$(_ShortFrameworkIdentifier)' == 'netstandard'">.NETStandard</TargetFrameworkIdentifier>
+    <TargetFrameworkIdentifier Condition="'$(_ShortFrameworkIdentifier)' == 'netcoreapp'">.NETCoreApp</TargetFrameworkIdentifier>
+    <TargetFrameworkIdentifier Condition="'$(_ShortFrameworkIdentifier)' == 'net'">.NETFramework</TargetFrameworkIdentifier>
+  </PropertyGroup>
+
+  <!-- Versions with dots are taken as is and just given leading 'v'. -->
+  <PropertyGroup Condition="'$(TargetFrameworkVersion)' == '' and '$(_ShortFrameworkVersion)' != '' and $(_ShortFrameworkVersion.Contains('.'))">
+    <TargetFrameworkVersion>v$(_ShortFrameworkVersion)</TargetFrameworkVersion>
+  </PropertyGroup>
+
+  <!-- Versions with no dots and up to 3 characters get leading 'v' and implicit dots between characters. -->
+  <PropertyGroup Condition="'$(TargetFrameworkVersion)' == '' and '$(_ShortFrameworkVersion)' != ''">
+    <TargetFrameworkVersion Condition="$(_ShortFrameworkVersion.Length) == 1">v$(_ShortFrameworkVersion[0]).0</TargetFrameworkVersion>
+    <TargetFrameworkVersion Condition="$(_ShortFrameworkVersion.Length) == 2">v$(_ShortFrameworkVersion[0]).$(_ShortFrameworkVersion[1])"</TargetFrameworkVersion>
+    <TargetFrameworkVersion Condition="$(_ShortFrameworkVersion.Length) == 3">v$(_ShortFrameworkVersion[0]).$(_ShortFrameworkVersion[1]).$(_ShortFrameworkVersion[2])</TargetFrameworkVersion>
+  </PropertyGroup>
+
+  <!-- Trigger an error if we're unable to infer the framework identifier and version. -->
+  <PropertyGroup Condition="$(TargetFrameworkIdentifier) == '' or $(TargetFrameworkVersion) == ''">
+    <_UnsupportedTargetFrameworkError>Cannot infer TargetFrameworkIdentifier and/or TargetFrameworkVersion from TargetFramework='$(TargetFramework)'. See comment in $(MSBuildThisFileFullPath) showing how to specify them explicitly.</_UnsupportedTargetFrameworkError>
+  </PropertyGroup>
+  <Target Name="_CheckForUnsupportedTargetFramework" BeforeTargets="_CheckForInvalidConfigurationAndPlatform">
+    <Error Condition="'$(_UnsupportedTargetFrameworkError)' != ''" Text="$(_UnsupportedTargetFrameworkError)" />
+  </Target>
+
+  <!--
+     Apply the same defaults as common targets now since we're rnning before them, but need to respect defaults
+     in our override of intermediate and output paths below.
+   -->
+  <PropertyGroup>
+    <Platform Condition="'$(Platform)'==''">AnyCPU</Platform>
+    <PlatformName Condition="'$(PlatformName)' == ''">$(Platform)</PlatformName>
+    <Configuration Condition="'$(Configuration)'==''">Debug</Configuration>
+    <ConfigurationName Condition="'$(ConfigurationName)' == ''">$(Configuration)</ConfigurationName>
+    <OutputPath Condition="'$(OutputPath)' != '' and !HasTrailingSlash('$(OutputPath)')">$(OutputPath)\</OutputPath>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)' == ''">obj\</BaseIntermediateOutputPath>
+    <BaseIntermediateOutputPath Condition="!HasTrailingSlash('$(BaseIntermediateOutputPath)')">$(BaseIntermediateOutputPath)\</BaseIntermediateOutputPath>
+    <IntermediateOutputPath Condition=" $(IntermediateOutputPath) == '' and '$(PlatformName)' == 'AnyCPU' ">$(BaseIntermediateOutputPath)$(Configuration)\</IntermediateOutputPath>
+    <IntermediateOutputPath Condition=" $(IntermediateOutputPath) == '' and '$(PlatformName)' != 'AnyCPU' ">$(BaseIntermediateOutputPath)$(PlatformName)\$(Configuration)\</IntermediateOutputPath>
+  </PropertyGroup>
+
+  <!--
+    Append $(TargetFramework) directory to output and intermediate paths to prevent bin clashes between
+    targets. However, we must leave OutputPath unset if it's not already as common targets use this to 
+    detect an invalid configuration or platform.
+   -->
+  <PropertyGroup>
+    <IntermediateOutputPath>$(IntermediateOutputPath)$(TargetFramework)\</IntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)' != ''">$(OutputPath)$(TargetFramework)\</OutputPath>
+  </PropertyGroup>
+
+</Project>

--- a/src/Tasks/Microsoft.NETCore.Build.Tasks/build/netstandard1.0/Microsoft.NETCore.TargetFrameworkInference.targets
+++ b/src/Tasks/Microsoft.NETCore.Build.Tasks/build/netstandard1.0/Microsoft.NETCore.TargetFrameworkInference.targets
@@ -1,6 +1,6 @@
 <!--
 ***********************************************************************************************
-Microsoft.NETCore.TargetFrameworkInference.props
+Microsoft.NETCore.TargetFrameworkInference.targets
 
 WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
           created a backup copy.  Incorrect changes to this file will make it
@@ -77,7 +77,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   </Target>
 
   <!--
-     Apply the same defaults as common targets now since we're rnning before them, but need to respect defaults
+     Apply the same defaults as common targets now since we're running before them, but need to respect defaults
      in our override of intermediate and output paths below.
    -->
   <PropertyGroup>

--- a/test/Microsoft.NETCore.Build.Tests/GivenThatWeWantToBuildACrossTargetedLibrary.cs
+++ b/test/Microsoft.NETCore.Build.Tests/GivenThatWeWantToBuildACrossTargetedLibrary.cs
@@ -1,0 +1,45 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.IO;
+using Microsoft.NETCore.TestFramework;
+using Microsoft.NETCore.TestFramework.Assertions;
+using Microsoft.NETCore.TestFramework.Commands;
+using Xunit;
+using static Microsoft.NETCore.TestFramework.Commands.MSBuildTest;
+
+namespace Microsoft.NETCore.Build.Tests
+{
+    public class GivenThatWeWantToBuildACrossTargetedLibrary
+    {
+        private TestAssetsManager _testAssetsManager = TestAssetsManager.TestProjectsAssetsManager;
+
+        [Fact]
+        public void It_builds_the_library_successfully()
+        {
+            var testAsset = _testAssetsManager
+                .CopyTestAsset("CrossTargeting")
+                .WithSource()
+                .Restore("--fallbacksource", $"{RepoInfo.PackagesPath}");
+
+            var libraryProjectDirectory = Path.Combine(testAsset.TestRoot, "TestLibrary");
+
+            var buildCommand = new BuildCommand(Stage0MSBuild, libraryProjectDirectory);
+            buildCommand
+                .Execute()
+                .Should()
+                .Pass();
+
+            var outputDirectory = buildCommand.GetOutputDirectory();
+            var targetFrameworks = new[] { "netstandard1.4", "netstandard1.5" };
+            outputDirectory.Should().OnlyHaveFiles(new[] {
+                "netstandard1.4/TestLibrary.dll",
+                "netstandard1.4/TestLibrary.pdb",
+                "netstandard1.4/TestLibrary.deps.json",
+                "netstandard1.5/TestLibrary.dll",
+                "netstandard1.5/TestLibrary.pdb",
+                "netstandard1.5/TestLibrary.deps.json"
+            }, SearchOption.AllDirectories);
+        }
+    }
+}

--- a/test/Microsoft.NETCore.Publish.Tests/GivenThatWeWantToPublishAHelloWorldProject.cs
+++ b/test/Microsoft.NETCore.Publish.Tests/GivenThatWeWantToPublishAHelloWorldProject.cs
@@ -2,7 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.IO;
+using System.Runtime.InteropServices;
 using Microsoft.DotNet.Cli.Utils;
+using Microsoft.DotNet.InternalAbstractions;
 using Microsoft.NETCore.TestFramework;
 using Microsoft.NETCore.TestFramework.Assertions;
 using Microsoft.NETCore.TestFramework.Commands;
@@ -21,7 +23,7 @@ namespace Microsoft.NETCore.Publish.Tests
         }
 
         [Fact]
-        public void It_publishes_the_project_to_the_publish_folder_and_the_app_should_run()
+        public void It_publishes_portable_apps_to_the_publish_folder_and_the_app_should_run()
         {
             var helloWorldAsset = _testAssetsManager
                 .CopyTestAsset("HelloWorld")
@@ -35,7 +37,7 @@ namespace Microsoft.NETCore.Publish.Tests
 
             var publishDirectory = publishCommand.GetOutputDirectory();
 
-            publishDirectory.Should().OnlyHaveFiles(new [] {
+            publishDirectory.Should().OnlyHaveFiles(new[] {
                 "HelloWorld.dll",
                 "HelloWorld.pdb",
                 "HelloWorld.deps.json",
@@ -43,6 +45,47 @@ namespace Microsoft.NETCore.Publish.Tests
             });
 
             Command.Create(RepoInfo.DotNetHostPath, new[] { Path.Combine(publishDirectory.FullName, "HelloWorld.dll") })
+                .CaptureStdOut()
+                .Execute()
+                .Should()
+                .Pass()
+                .And
+                .HaveStdOutContaining("Hello World!");
+        }
+
+        [Fact]
+        public void It_publishes_self_contained_apps_to_the_publish_folder_and_the_app_should_run()
+        {
+            var helloWorldAsset = _testAssetsManager
+                .CopyTestAsset("HelloWorld")
+                .WithSource()
+                .AsSelfContained()
+                .Restore("--fallbacksource", $"{RepoInfo.PackagesPath}");
+
+            var publishCommand = new PublishCommand(Stage0MSBuild, helloWorldAsset.TestRoot);
+            var publishResult = publishCommand.Execute($"/p:RuntimeIdentifier={RuntimeEnvironment.GetRuntimeIdentifier()}");
+
+            publishResult.Should().Pass();
+
+            var publishDirectory = publishCommand.GetOutputDirectory(selfContained: true);
+            var selfContainedExecutable = $"HelloWorld{Constants.ExeSuffix}";
+
+            var libPrefix = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "" : "lib";
+
+            publishDirectory.Should().HaveFiles(new[] {
+                selfContainedExecutable,
+                "HelloWorld.dll",
+                "HelloWorld.pdb",
+                "HelloWorld.deps.json",
+                "HelloWorld.runtimeconfig.json",
+                $"{libPrefix}coreclr{Constants.DynamicLibSuffix}",
+                $"{libPrefix}hostfxr{Constants.DynamicLibSuffix}",
+                $"{libPrefix}hostpolicy{Constants.DynamicLibSuffix}",
+                $"mscorlib.dll",
+                $"System.Private.CoreLib.dll",
+            });
+
+            Command.Create(Path.Combine(publishDirectory.FullName, selfContainedExecutable), new string[] { })
                 .CaptureStdOut()
                 .Execute()
                 .Should()

--- a/test/Microsoft.NETCore.TestFramework/Assertions/DirectoryInfoAssertions.cs
+++ b/test/Microsoft.NETCore.TestFramework/Assertions/DirectoryInfoAssertions.cs
@@ -75,9 +75,12 @@ namespace Microsoft.NETCore.TestFramework.Assertions
             return new AndConstraint<DirectoryInfoAssertions>(new DirectoryInfoAssertions(dir));
         }
 
-        public AndConstraint<DirectoryInfoAssertions> OnlyHaveFiles(IEnumerable<string> expectedFiles)
+        public AndConstraint<DirectoryInfoAssertions> OnlyHaveFiles(IEnumerable<string> expectedFiles, SearchOption searchOption = SearchOption.TopDirectoryOnly)
         {
-            var actualFiles = _dirInfo.EnumerateFiles("*", SearchOption.TopDirectoryOnly).Select(f => f.Name);
+            var actualFiles = _dirInfo.EnumerateFiles("*", searchOption)
+                              .Select(f => f.FullName.Substring(_dirInfo.FullName.Length + 1) // make relative to _dirInfo
+                              .Replace("\\", "/")); // normalize separator
+
             var missingFiles = Enumerable.Except(expectedFiles, actualFiles);
             var extraFiles = Enumerable.Except(actualFiles, expectedFiles);
             var nl = Environment.NewLine;

--- a/test/Microsoft.NETCore.TestFramework/Commands/PublishCommand.cs
+++ b/test/Microsoft.NETCore.TestFramework/Commands/PublishCommand.cs
@@ -6,12 +6,13 @@ using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
 using Microsoft.DotNet.Cli.Utils;
+using Microsoft.DotNet.InternalAbstractions;
 
 namespace Microsoft.NETCore.TestFramework.Commands
 {
     public sealed class PublishCommand : TestCommand
     {
-        private const string PublishSubfolderName = "app.publish";
+        private const string PublishSubfolderName = "publish";
 
         public PublishCommand(MSBuildTest msbuild, string projectPath)
             : base(msbuild, projectPath)
@@ -28,9 +29,9 @@ namespace Microsoft.NETCore.TestFramework.Commands
             return command.Execute();
         }
 
-        public DirectoryInfo GetOutputDirectory()
+        public DirectoryInfo GetOutputDirectory(bool selfContained = false)
         {
-            string output = Path.Combine(ProjectRootPath, "bin", BuildRelativeOutputPath());
+            string output = Path.Combine(ProjectRootPath, "bin", BuildRelativeOutputPath(selfContained));
             return new DirectoryInfo(output);
         }
 
@@ -39,9 +40,11 @@ namespace Microsoft.NETCore.TestFramework.Commands
             return Path.Combine(GetOutputDirectory().FullName, $"{appName}.dll");
         }
 
-        private string BuildRelativeOutputPath()
+        private string BuildRelativeOutputPath(bool selfContained)
         {
-            return Path.Combine("Debug", "", PublishSubfolderName);
+            return selfContained ?
+                Path.Combine("Debug", RuntimeEnvironment.GetRuntimeIdentifier(), PublishSubfolderName) :
+                Path.Combine("Debug", PublishSubfolderName);
         }
     }
 }


### PR DESCRIPTION
No conflicts, will merge if green.

FYI @srivatsn, @dotnet/project-system To get cross-targeting targets in to restore3. I was limited in what I could test due to old restore not working with P2P refs to cross-targeted projects. It's likely that the new restore doesn't yet work for that scenario either, but let's get all of the latest bits in to restore3, and add more tests there.
