### PR TITLE
light up pack3 

### DIFF
--- a/build/Nuget/Microsoft.NETCore.Sdk.Nuget.targets
+++ b/build/Nuget/Microsoft.NETCore.Sdk.Nuget.targets
@@ -4,7 +4,7 @@
   <Target Name="LayoutSdkPackage">
     <PropertyGroup>
       <CoreSetupVersion>1.0.1-beta-000933</CoreSetupVersion>
-      <NuGetVersion>3.6.0-beta.1.msbuild.7</NuGetVersion>
+      <NuGetVersion>3.6.0-beta.1.msbuild.15</NuGetVersion>
     </PropertyGroup>
     
     <ItemGroup>

--- a/build/Nuget/Microsoft.NETCore.Sdk.nuspec
+++ b/build/Nuget/Microsoft.NETCore.Sdk.nuspec
@@ -10,6 +10,9 @@
     <version>$version$</version>
     <authors>dotnet</authors>
     <projectUrl>http://dot.net</projectUrl>
+    <dependencies>
+        <dependency id="Nuget.Build.Tasks.Pack" version="3.6.0-beta.1.msbuild.15" />
+    </dependencies>
   </metadata>
   <files>
     <file src="PackagesLayout\**" />

--- a/src/Tasks/Microsoft.NETCore.Build.Tasks.UnitTests/project.json
+++ b/src/Tasks/Microsoft.NETCore.Build.Tasks.UnitTests/project.json
@@ -1,6 +1,6 @@
 ﻿{
   "dependencies": {
-    "NuGet.ProjectModel": "3.6.0-beta.1.msbuild.7",
+    "NuGet.ProjectModel": "3.6.0-beta.1.msbuild.15",
     "Microsoft.Extensions.DependencyModel": "1.0.1-beta-000933",
     "Microsoft.Build.Framework": "0.1.0-preview-00028-160627",
     "Microsoft.Build.Utilities.Core": "0.1.0-preview-00028-160627",

--- a/src/Tasks/Microsoft.NETCore.Build.Tasks/project.json
+++ b/src/Tasks/Microsoft.NETCore.Build.Tasks/project.json
@@ -1,6 +1,6 @@
 ﻿{
   "dependencies": {
-    "NuGet.ProjectModel": "3.6.0-beta.1.msbuild.7",
+    "NuGet.ProjectModel": "3.6.0-beta.1.msbuild.15",
     "Microsoft.Extensions.DependencyModel": "1.0.1-beta-000933",
     "Microsoft.Build.Framework": "0.1.0-preview-00028-160627",
     "Microsoft.Build.Utilities.Core": "0.1.0-preview-00028-160627",

--- a/test/Microsoft.NETCore.Publish.Tests/GivenThatWeWantToPreserveCompilationContext.cs
+++ b/test/Microsoft.NETCore.Publish.Tests/GivenThatWeWantToPreserveCompilationContext.cs
@@ -59,7 +59,7 @@ namespace Microsoft.NETCore.Publish.Tests
                 dependencyContext.CompilationOptions.EmitEntryPoint.Should().Be(true);
                 dependencyContext.CompilationOptions.DebugType.Should().Be("portable");
 
-                dependencyContext.CompileLibraries.Count.Should().Be(114);
+                dependencyContext.CompileLibraries.Count.Should().Be(115);
             }
         }
     }


### PR DESCRIPTION
this PR does the necessary plumbing to light up pack3 in any dotnet core project that references the microsoft.netcore.sdk 

CC: @srivatsn @eerhardt @natidea @rrelyea 
