### PR TITLE
When publishing a project that has an $(OutputPath) without a trailing slash, the publish directory is incorrect.

### DIFF
--- a/src/Tasks/Microsoft.NETCore.Build.Tasks/build/netstandard1.0/Microsoft.NETCore.Sdk.BeforeCommon.targets
+++ b/src/Tasks/Microsoft.NETCore.Build.Tasks/build/netstandard1.0/Microsoft.NETCore.Sdk.BeforeCommon.targets
@@ -13,9 +13,14 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <!-- Set PublishDir here, before Microsoft.Common.targets, to avoid a competing default there. -->
   <PropertyGroup>
+
+    <!-- Since Microsoft.Common.targets hasn't be loaded yet, need to handle $(OutputPath) without a trailing slash -->
+    <_TempOutputPath>$(OutputPath)</_TempOutputPath>
+    <_TempOutputPath Condition="!HasTrailingSlash('$(_TempOutputPath)')">$(_TempOutputPath)\</_TempOutputPath>
+
     <PublishDirName Condition="'$(PublishDirName)' == ''">publish</PublishDirName>
-    <PublishDir Condition="'$(PublishDir)' == '' and '$(RuntimeIdentifier)' != ''">$(OutputPath)$(RuntimeIdentifier)\$(PublishDirName)\</PublishDir>
-    <PublishDir Condition="'$(PublishDir)' == ''">$(OutputPath)$(PublishDirName)\</PublishDir>
+    <PublishDir Condition="'$(PublishDir)' == '' and '$(RuntimeIdentifier)' != ''">$(_TempOutputPath)$(RuntimeIdentifier)\$(PublishDirName)\</PublishDir>
+    <PublishDir Condition="'$(PublishDir)' == ''">$(_TempOutputPath)$(PublishDirName)\</PublishDir>
   </PropertyGroup>
 
   <Import Condition="'$(TargetFramework)' != ''"


### PR DESCRIPTION
I wasn't sure if I should have just overwritten $(OutputPath) or not.  I didn't feel like it was my place to add the trailing slash...

@nguerrera @brthor @livarcocc 

/cc @dotnet/project-system 
