### PR TITLE
Set PublishDir after TargetFramework sub-folder is established

### DIFF
--- a/src/Tasks/Microsoft.NETCore.Build.Tasks/build/netstandard1.0/Microsoft.NETCore.Sdk.BeforeCommon.targets
+++ b/src/Tasks/Microsoft.NETCore.Build.Tasks/build/netstandard1.0/Microsoft.NETCore.Sdk.BeforeCommon.targets
@@ -11,19 +11,34 @@ Copyright (c) .NET Foundation. All rights reserved.
 -->
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <!-- Set PublishDir here, before Microsoft.Common.targets, to avoid a competing default there. -->
+  <!--
+     Apply the same defaults as Microsoft.Common.targets now since we're running before them,
+     but need to adjust them and/or make decisions in terms of them.
+   -->
   <PropertyGroup>
-
-    <!-- Since Microsoft.Common.targets hasn't be loaded yet, need to handle $(OutputPath) without a trailing slash -->
-    <_TempOutputPath>$(OutputPath)</_TempOutputPath>
-    <_TempOutputPath Condition="!HasTrailingSlash('$(_TempOutputPath)')">$(_TempOutputPath)\</_TempOutputPath>
-
-    <PublishDirName Condition="'$(PublishDirName)' == ''">publish</PublishDirName>
-    <PublishDir Condition="'$(PublishDir)' == '' and '$(RuntimeIdentifier)' != ''">$(_TempOutputPath)$(RuntimeIdentifier)\$(PublishDirName)\</PublishDir>
-    <PublishDir Condition="'$(PublishDir)' == ''">$(_TempOutputPath)$(PublishDirName)\</PublishDir>
+    <Platform Condition="'$(Platform)'==''">AnyCPU</Platform>
+    <PlatformName Condition="'$(PlatformName)' == ''">$(Platform)</PlatformName>
+    <Configuration Condition="'$(Configuration)'==''">Debug</Configuration>
+    <ConfigurationName Condition="'$(ConfigurationName)' == ''">$(Configuration)</ConfigurationName>
+    <OutputPath Condition="'$(OutputPath)' != '' and !HasTrailingSlash('$(OutputPath)')">$(OutputPath)\</OutputPath>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)' == ''">obj\</BaseIntermediateOutputPath>
+    <BaseIntermediateOutputPath Condition="!HasTrailingSlash('$(BaseIntermediateOutputPath)')">$(BaseIntermediateOutputPath)\</BaseIntermediateOutputPath>
+    <IntermediateOutputPath Condition=" $(IntermediateOutputPath) == '' and '$(PlatformName)' == 'AnyCPU' ">$(BaseIntermediateOutputPath)$(Configuration)\</IntermediateOutputPath>
+    <IntermediateOutputPath Condition=" $(IntermediateOutputPath) == '' and '$(PlatformName)' != 'AnyCPU' ">$(BaseIntermediateOutputPath)$(PlatformName)\$(Configuration)\</IntermediateOutputPath>
   </PropertyGroup>
 
+  <!-- 
+    Expand TargetFramework (if set) to TargetFrameworkIdentifier and TargetFrameworkVersion,
+    and adjust intermediate and output paths to include it.
+  -->
   <Import Condition="'$(TargetFramework)' != ''"
-          Project="$(MSBuildThisFileDirectory)Microsoft.NETCore.TargetFrameworkInference.targets" />
+        Project="$(MSBuildThisFileDirectory)Microsoft.NETCore.TargetFrameworkInference.targets" />
+
+  <!-- Set PublishDir here, before Microsoft.Common.targets, to avoid a competing default there. -->
+  <PropertyGroup>
+    <PublishDirName Condition="'$(PublishDirName)' == ''">publish</PublishDirName>
+    <PublishDir Condition="'$(PublishDir)' == '' and '$(RuntimeIdentifier)' != ''">$(OutputPath)$(RuntimeIdentifier)\$(PublishDirName)\</PublishDir>
+    <PublishDir Condition="'$(PublishDir)' == ''">$(OutputPath)$(PublishDirName)\</PublishDir>
+  </PropertyGroup>
 
 </Project>

--- a/src/Tasks/Microsoft.NETCore.Build.Tasks/build/netstandard1.0/Microsoft.NETCore.TargetFrameworkInference.targets
+++ b/src/Tasks/Microsoft.NETCore.Build.Tasks/build/netstandard1.0/Microsoft.NETCore.TargetFrameworkInference.targets
@@ -77,22 +77,6 @@ Copyright (c) .NET Foundation. All rights reserved.
   </Target>
 
   <!--
-     Apply the same defaults as common targets now since we're running before them, but need to respect defaults
-     in our override of intermediate and output paths below.
-   -->
-  <PropertyGroup>
-    <Platform Condition="'$(Platform)'==''">AnyCPU</Platform>
-    <PlatformName Condition="'$(PlatformName)' == ''">$(Platform)</PlatformName>
-    <Configuration Condition="'$(Configuration)'==''">Debug</Configuration>
-    <ConfigurationName Condition="'$(ConfigurationName)' == ''">$(Configuration)</ConfigurationName>
-    <OutputPath Condition="'$(OutputPath)' != '' and !HasTrailingSlash('$(OutputPath)')">$(OutputPath)\</OutputPath>
-    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)' == ''">obj\</BaseIntermediateOutputPath>
-    <BaseIntermediateOutputPath Condition="!HasTrailingSlash('$(BaseIntermediateOutputPath)')">$(BaseIntermediateOutputPath)\</BaseIntermediateOutputPath>
-    <IntermediateOutputPath Condition=" $(IntermediateOutputPath) == '' and '$(PlatformName)' == 'AnyCPU' ">$(BaseIntermediateOutputPath)$(Configuration)\</IntermediateOutputPath>
-    <IntermediateOutputPath Condition=" $(IntermediateOutputPath) == '' and '$(PlatformName)' != 'AnyCPU' ">$(BaseIntermediateOutputPath)$(PlatformName)\$(Configuration)\</IntermediateOutputPath>
-  </PropertyGroup>
-
-  <!--
     Append $(TargetFramework) directory to output and intermediate paths to prevent bin clashes between
     targets. However, we must leave OutputPath unset if it's not already as common targets use this to 
     detect an invalid configuration or platform.


### PR DESCRIPTION
Also move defaults to the very beginning of BeforeCommon.targets
and apply them unconditionally.

Fix #168

@eerhardt @dotnet/project-system 
