### PR TITLE
Refactor _CopySourceItemsToPublishDirectory target into ComputeFilesToPublish and CopyFilesToPublishDirectory

### DIFF
--- a/src/Tasks/Microsoft.NETCore.Build.Tasks/build/netstandard1.0/Microsoft.NETCore.PreserveCompilationContext.targets
+++ b/src/Tasks/Microsoft.NETCore.Build.Tasks/build/netstandard1.0/Microsoft.NETCore.PreserveCompilationContext.targets
@@ -49,9 +49,9 @@ Copyright (c) .NET Foundation. All rights reserved.
       Don't copy a compilation assembly if it's also a runtime assembly. There is no need to copy the same
       assembly to the 'refs' folder, if it is already in the publish directory.
       -->
-      <ResolvedFilesToPublish Include="@(ReferencePath)" Exclude="@(ResolvedAssembliesToPublish->'%(FullPath)')">
+      <ResolvedFileToPublish Include="@(ReferencePath)" Exclude="@(ResolvedAssembliesToPublish->'%(FullPath)')">
         <RelativePath>$(RefAssembliesFolderName)\%(Filename)%(Extension)</RelativePath>
-      </ResolvedFilesToPublish>
+      </ResolvedFileToPublish>
     </ItemGroup>
 
   </Target>

--- a/src/Tasks/Microsoft.NETCore.Build.Tasks/build/netstandard1.0/Microsoft.NETCore.Publish.targets
+++ b/src/Tasks/Microsoft.NETCore.Build.Tasks/build/netstandard1.0/Microsoft.NETCore.Publish.targets
@@ -26,10 +26,16 @@ Copyright (c) .NET Foundation. All rights reserved.
     <RenamePublishedHost Condition=" '$(RenamePublishedHost)' == '' and '$(OutputType)' == 'Exe' and '$(RuntimeIdentifier)' != ''">true</RenamePublishedHost>
   </PropertyGroup>
 
+  <ItemDefinitionGroup>
+    <ResolvedFilesToPublish>
+      <CopyToPublishDirectory>Always</CopyToPublishDirectory>
+    </ResolvedFilesToPublish>
+  </ItemDefinitionGroup>
+
   <Target Name="Publish"
           DependsOnTargets="Build;
                             PrepareForPublish;
-                            CopyFilesToPublishDirectory;
+                            ComputeAndCopyFilesToPublishDirectory;
                             GeneratePublishDependencyFile;
                             GeneratePublishRuntimeConfigurationFile" />
 
@@ -53,22 +59,48 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <!--
     ============================================================
+                                        ComputeAndCopyFilesToPublishDirectory
+
+    Computes the list of all files to copy to the publish directory and then publishes them.
+    ============================================================
+    -->
+  <Target Name="ComputeAndCopyFilesToPublishDirectory"
+          DependsOnTargets="ComputeFilesToPublish;
+                            CopyFilesToPublishDirectory" />
+
+  <!--
+    ============================================================
                                         CopyFilesToPublishDirectory
 
     Copy all build outputs, satellites and other necessary files to the publish directory.
     ============================================================
     -->
   <Target Name="CopyFilesToPublishDirectory"
-          DependsOnTargets="ComputeFilesToPublish;
-                            RenamePublishedHost;
-                            _CopySourceItemsToPublishDirectory">
+          DependsOnTargets="_CopyResolvedFilesToPublishPreserveNewest;
+                            _CopyResolvedFilesToPublishAlways" />
 
-    <Copy SourceFiles="@(ResolvedFilesToPublish)"
-          DestinationFiles="$(PublishDir)%(ResolvedFilesToPublish.RelativePath)"
-          SkipUnchangedFiles="$(SkipCopyUnchangedFiles)"
+  <!--
+    ============================================================
+                                        _CopyResolvedFilesToPublishPreserveNewest
+
+    Copy _ResolvedFilesToPublishPreserveNewest items to the publish directory.
+    ============================================================
+    -->
+  <Target Name="_CopyResolvedFilesToPublishPreserveNewest"
+          DependsOnTargets="_ComputeResolvedFilesToPublishTypes"
+          Inputs="@(_ResolvedFilesToPublishPreserveNewest)"
+          Outputs="@(_ResolvedFilesToPublishPreserveNewest->'$(PublishDir)%(RelativePath)')">
+
+    <!--
+        Not using SkipUnchangedFiles="true" because the application may want to change
+        one of these files and not have an incremental build replace it.
+        -->
+    <Copy SourceFiles = "@(_ResolvedFilesToPublishPreserveNewest)"
+          DestinationFiles="$(PublishDir)%(_ResolvedFilesToPublishPreserveNewest.RelativePath)"
           OverwriteReadOnlyFiles="$(OverwriteReadOnlyFiles)"
           Retries="$(CopyRetryCount)"
-          RetryDelayMilliseconds="$(CopyRetryDelayMilliseconds)">
+          RetryDelayMilliseconds="$(CopyRetryDelayMilliseconds)"
+          UseHardlinksIfPossible="$(CreateHardLinksForAdditionalFilesIfPossible)">
 
       <Output TaskParameter="DestinationFiles" ItemName="FileWrites"/>
 
@@ -78,14 +110,59 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <!--
     ============================================================
+                                        _CopyResolvedFilesToPublishAlways
+
+    Copy _ResolvedFilesToPublishAlways items to the publish directory.
+    ============================================================
+    -->
+  <Target Name="_CopyResolvedFilesToPublishAlways"
+          DependsOnTargets="_ComputeResolvedFilesToPublishTypes">
+
+    <!--
+        Not using SkipUnchangedFiles="true" because the application may want to change
+        one of these files and not have an incremental build replace it.
+        -->
+    <Copy SourceFiles = "@(_ResolvedFilesToPublishAlways)"
+          DestinationFiles="$(PublishDir)%(_ResolvedFilesToPublishAlways.RelativePath)"
+          OverwriteReadOnlyFiles="$(OverwriteReadOnlyFiles)"
+          Retries="$(CopyRetryCount)"
+          RetryDelayMilliseconds="$(CopyRetryDelayMilliseconds)"
+          UseHardlinksIfPossible="$(CreateHardLinksForAdditionalFilesIfPossible)">
+
+      <Output TaskParameter="DestinationFiles" ItemName="FileWrites"/>
+
+    </Copy>
+
+  </Target>
+
+  <!--
+    ============================================================
+                                        _ComputeResolvedFilesToPublishTypes
+
+    Splits ResolvedFilesToPublish items into 'PreserveNewest' and 'Always' buckets.
+    ============================================================
+    -->
+  <Target Name="_ComputeResolvedFilesToPublishTypes">
+    <ItemGroup>
+      <_ResolvedFilesToPublishPreserveNewest Include="@(ResolvedFilesToPublish)"
+                                             Condition="'%(ResolvedFilesToPublish.CopyToPublishDirectory)'=='PreserveNewest'" />
+
+      <_ResolvedFilesToPublishAlways Include="@(ResolvedFilesToPublish)"
+                                     Condition="'%(ResolvedFilesToPublish.CopyToPublishDirectory)'=='Always'" />
+    </ItemGroup>
+  </Target>
+
+
+  <!--
+    ============================================================
                                         ComputeFilesToPublish
 
     Gathers all the files that need to be copied to the publish directory.
     ============================================================
     -->
   <Target Name="ComputeFilesToPublish"
-          DependsOnTargets="_ComputeNetCorePublishAssets"
-          Returns="ResolvedFilesToPublish">
+          DependsOnTargets="_ComputeNetCorePublishAssets;
+                            _ComputeCopyToPublishDirectoryItems">
 
     <PropertyGroup>
       <CopyBuildOutputToPublishDirectory Condition="'$(CopyBuildOutputToPublishDirectory)'==''">true</CopyBuildOutputToPublishDirectory>
@@ -153,13 +230,25 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <!--
     ============================================================
-                                        _CopySourceItemsToPublishDirectory
+                                        _ComputeCopyToPublishDirectoryItems
     ============================================================
     -->
-  <Target Name="_CopySourceItemsToPublishDirectory"
-          DependsOnTargets="GetCopyToPublishDirectoryItems;
-                            _CopyOutOfDateSourceItemsToPublishDirectory;
-                            _CopyOutOfDateSourceItemsToPublishDirectoryAlways"/>
+  <Target Name="_ComputeCopyToPublishDirectoryItems"
+          DependsOnTargets="GetCopyToPublishDirectoryItems">
+
+    <ItemGroup>
+      <ResolvedFilesToPublish Include="@(_SourceItemsToCopyToPublishDirectoryAlways)">
+        <RelativePath>%(_SourceItemsToCopyToPublishDirectoryAlways.TargetPath)</RelativePath>
+        <CopyToPublishDirectory>Always</CopyToPublishDirectory>
+      </ResolvedFilesToPublish>
+
+      <ResolvedFilesToPublish Include="@(_SourceItemsToCopyToPublishDirectory)">
+        <RelativePath>%(_SourceItemsToCopyToPublishDirectory.TargetPath)</RelativePath>
+        <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+      </ResolvedFilesToPublish>
+    </ItemGroup>
+
+  </Target>
 
   <!--
     ============================================================
@@ -322,62 +411,6 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <!--
     ============================================================
-                                        _CopyOutOfDateSourceItemsToPublishDirectory
-
-    Copy files that have the CopyToPublishDirectory attribute set to 'PreserveNewest'.
-    ============================================================
-    -->
-  <Target Name="_CopyOutOfDateSourceItemsToPublishDirectory"
-          Condition=" '@(_SourceItemsToCopyToPublishDirectory)' != '' "
-          Inputs="@(_SourceItemsToCopyToPublishDirectory)"
-          Outputs="@(_SourceItemsToCopyToPublishDirectory->'$(PublishDir)%(TargetPath)')">
-
-    <!--
-        Not using SkipUnchangedFiles="true" because the application may want to change
-        one of these files and not have an incremental build replace it.
-        -->
-    <Copy SourceFiles = "@(_SourceItemsToCopyToPublishDirectory)"
-          DestinationFiles = "@(_SourceItemsToCopyToPublishDirectory->'$(PublishDir)%(TargetPath)')"
-          OverwriteReadOnlyFiles="$(OverwriteReadOnlyFiles)"
-          Retries="$(CopyRetryCount)"
-          RetryDelayMilliseconds="$(CopyRetryDelayMilliseconds)"
-          UseHardlinksIfPossible="$(CreateHardLinksForAdditionalFilesIfPossible)">
-
-      <Output TaskParameter="DestinationFiles" ItemName="FileWrites"/>
-
-    </Copy>
-
-  </Target>
-
-  <!--
-    ============================================================
-                                        _CopyOutOfDateSourceItemsToPublishDirectoryAlways
-
-    Copy files that have the CopyToPublishDirectory attribute set to 'Always'.
-    ============================================================
-    -->
-  <Target Name="_CopyOutOfDateSourceItemsToPublishDirectoryAlways"
-          Condition=" '@(_SourceItemsToCopyToPublishDirectoryAlways)' != '' ">
-
-    <!--
-        Not using SkipUnchangedFiles="true" because the application may want to change
-        one of these files and not have an incremental build replace it.
-        -->
-    <Copy SourceFiles = "@(_SourceItemsToCopyToPublishDirectoryAlways)"
-          DestinationFiles = "@(_SourceItemsToCopyToPublishDirectoryAlways->'$(PublishDir)%(TargetPath)')"
-          OverwriteReadOnlyFiles="$(OverwriteReadOnlyFiles)"
-          Retries="$(CopyRetryCount)"
-          RetryDelayMilliseconds="$(CopyRetryDelayMilliseconds)"
-          UseHardlinksIfPossible="$(CreateHardLinksForAdditionalFilesIfPossible)">
-
-      <Output TaskParameter="DestinationFiles" ItemName="FileWrites"/>
-
-    </Copy>
-
-  </Target>
-
-  <!--
-    ============================================================
                                         GeneratePublishDependencyFile
 
     Generates the $(project).deps.json file for a published app
@@ -431,6 +464,8 @@ Copyright (c) .NET Foundation. All rights reserved.
     -->
 
   <Target Name="RenamePublishedHost"
+          AfterTargets="ComputeFilesToPublish"
+          BeforeTargets="CopyFilesToPublishDirectory"
           Condition="'$(RenamePublishedHost)' == 'true'">
 
     <PropertyGroup>

--- a/src/Tasks/Microsoft.NETCore.Build.Tasks/build/netstandard1.0/Microsoft.NETCore.Publish.targets
+++ b/src/Tasks/Microsoft.NETCore.Build.Tasks/build/netstandard1.0/Microsoft.NETCore.Publish.targets
@@ -27,9 +27,9 @@ Copyright (c) .NET Foundation. All rights reserved.
   </PropertyGroup>
 
   <ItemDefinitionGroup>
-    <ResolvedFilesToPublish>
+    <ResolvedFileToPublish>
       <CopyToPublishDirectory>Always</CopyToPublishDirectory>
-    </ResolvedFilesToPublish>
+    </ResolvedFileToPublish>
   </ItemDefinitionGroup>
 
   <Target Name="Publish"
@@ -83,24 +83,25 @@ Copyright (c) .NET Foundation. All rights reserved.
     ============================================================
                                         _CopyResolvedFilesToPublishPreserveNewest
 
-    Copy _ResolvedFilesToPublishPreserveNewest items to the publish directory.
+    Copy _ResolvedFileToPublishPreserveNewest items to the publish directory.
     ============================================================
     -->
   <Target Name="_CopyResolvedFilesToPublishPreserveNewest"
           DependsOnTargets="_ComputeResolvedFilesToPublishTypes"
-          Inputs="@(_ResolvedFilesToPublishPreserveNewest)"
-          Outputs="@(_ResolvedFilesToPublishPreserveNewest->'$(PublishDir)%(RelativePath)')">
+          Inputs="@(_ResolvedFileToPublishPreserveNewest)"
+          Outputs="@(_ResolvedFileToPublishPreserveNewest->'$(PublishDir)%(RelativePath)')">
 
     <!--
         Not using SkipUnchangedFiles="true" because the application may want to change
         one of these files and not have an incremental build replace it.
         -->
-    <Copy SourceFiles = "@(_ResolvedFilesToPublishPreserveNewest)"
-          DestinationFiles="$(PublishDir)%(_ResolvedFilesToPublishPreserveNewest.RelativePath)"
+    <Copy SourceFiles = "@(_ResolvedFileToPublishPreserveNewest)"
+          DestinationFiles="$(PublishDir)%(_ResolvedFileToPublishPreserveNewest.RelativePath)"
           OverwriteReadOnlyFiles="$(OverwriteReadOnlyFiles)"
           Retries="$(CopyRetryCount)"
           RetryDelayMilliseconds="$(CopyRetryDelayMilliseconds)"
-          UseHardlinksIfPossible="$(CreateHardLinksForAdditionalFilesIfPossible)">
+          UseHardlinksIfPossible="$(CreateHardLinksForPublishFilesIfPossible)"
+          UseSymboliclinksIfPossible="$(CreateSymbolicLinksForPublishFilesIfPossible)">
 
       <Output TaskParameter="DestinationFiles" ItemName="FileWrites"/>
 
@@ -112,7 +113,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     ============================================================
                                         _CopyResolvedFilesToPublishAlways
 
-    Copy _ResolvedFilesToPublishAlways items to the publish directory.
+    Copy _ResolvedFileToPublishAlways items to the publish directory.
     ============================================================
     -->
   <Target Name="_CopyResolvedFilesToPublishAlways"
@@ -122,12 +123,13 @@ Copyright (c) .NET Foundation. All rights reserved.
         Not using SkipUnchangedFiles="true" because the application may want to change
         one of these files and not have an incremental build replace it.
         -->
-    <Copy SourceFiles = "@(_ResolvedFilesToPublishAlways)"
-          DestinationFiles="$(PublishDir)%(_ResolvedFilesToPublishAlways.RelativePath)"
+    <Copy SourceFiles = "@(_ResolvedFileToPublishAlways)"
+          DestinationFiles="$(PublishDir)%(_ResolvedFileToPublishAlways.RelativePath)"
           OverwriteReadOnlyFiles="$(OverwriteReadOnlyFiles)"
           Retries="$(CopyRetryCount)"
           RetryDelayMilliseconds="$(CopyRetryDelayMilliseconds)"
-          UseHardlinksIfPossible="$(CreateHardLinksForAdditionalFilesIfPossible)">
+          UseHardlinksIfPossible="$(CreateHardLinksForPublishFilesIfPossible)"
+          UseSymboliclinksIfPossible="$(CreateSymbolicLinksForPublishFilesIfPossible)">
 
       <Output TaskParameter="DestinationFiles" ItemName="FileWrites"/>
 
@@ -139,16 +141,16 @@ Copyright (c) .NET Foundation. All rights reserved.
     ============================================================
                                         _ComputeResolvedFilesToPublishTypes
 
-    Splits ResolvedFilesToPublish items into 'PreserveNewest' and 'Always' buckets.
+    Splits ResolvedFileToPublish items into 'PreserveNewest' and 'Always' buckets.
     ============================================================
     -->
   <Target Name="_ComputeResolvedFilesToPublishTypes">
     <ItemGroup>
-      <_ResolvedFilesToPublishPreserveNewest Include="@(ResolvedFilesToPublish)"
-                                             Condition="'%(ResolvedFilesToPublish.CopyToPublishDirectory)'=='PreserveNewest'" />
+      <_ResolvedFileToPublishPreserveNewest Include="@(ResolvedFileToPublish)"
+                                             Condition="'%(ResolvedFileToPublish.CopyToPublishDirectory)'=='PreserveNewest'" />
 
-      <_ResolvedFilesToPublishAlways Include="@(ResolvedFilesToPublish)"
-                                     Condition="'%(ResolvedFilesToPublish.CopyToPublishDirectory)'=='Always'" />
+      <_ResolvedFileToPublishAlways Include="@(ResolvedFileToPublish)"
+                                     Condition="'%(ResolvedFileToPublish.CopyToPublishDirectory)'=='Always'" />
     </ItemGroup>
   </Target>
 
@@ -171,26 +173,26 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <ItemGroup>
       <!-- Copy the build product (.dll or .exe). -->
-      <ResolvedFilesToPublish Include="@(IntermediateAssembly)"
+      <ResolvedFileToPublish Include="@(IntermediateAssembly)"
                               Condition="'$(CopyBuildOutputToPublishDirectory)' == 'true'">
         <RelativePath>@(IntermediateAssembly->'%(Filename)%(Extension)')</RelativePath>
-      </ResolvedFilesToPublish>
+      </ResolvedFileToPublish>
 
       <!-- Copy the debug information file (.pdb), if any -->
-      <ResolvedFilesToPublish Include="@(_DebugSymbolsIntermediatePath)"
+      <ResolvedFileToPublish Include="@(_DebugSymbolsIntermediatePath)"
                               Condition="'$(_DebugSymbolsProduced)'=='true' and '$(CopyOutputSymbolsToPublishDirectory)'=='true'">
         <RelativePath>@(_DebugSymbolsIntermediatePath->'%(Filename)%(Extension)')</RelativePath>
-      </ResolvedFilesToPublish>
+      </ResolvedFileToPublish>
 
       <!-- Copy satellite assemblies. -->
-      <ResolvedFilesToPublish Include="@(IntermediateSatelliteAssembliesWithTargetPath)">
+      <ResolvedFileToPublish Include="@(IntermediateSatelliteAssembliesWithTargetPath)">
         <RelativePath>%(IntermediateSatelliteAssembliesWithTargetPath.Culture)\%(Filename)%(Extension)</RelativePath>
-      </ResolvedFilesToPublish>
+      </ResolvedFileToPublish>
 
       <!-- Copy all the assemblies -->
-      <ResolvedFilesToPublish Include="@(ResolvedAssembliesToPublish)">
+      <ResolvedFileToPublish Include="@(ResolvedAssembliesToPublish)">
         <RelativePath>%(ResolvedAssembliesToPublish.DestinationSubPath)</RelativePath>
-      </ResolvedFilesToPublish>
+      </ResolvedFileToPublish>
     </ItemGroup>
 
   </Target>
@@ -237,15 +239,15 @@ Copyright (c) .NET Foundation. All rights reserved.
           DependsOnTargets="GetCopyToPublishDirectoryItems">
 
     <ItemGroup>
-      <ResolvedFilesToPublish Include="@(_SourceItemsToCopyToPublishDirectoryAlways)">
+      <ResolvedFileToPublish Include="@(_SourceItemsToCopyToPublishDirectoryAlways)">
         <RelativePath>%(_SourceItemsToCopyToPublishDirectoryAlways.TargetPath)</RelativePath>
         <CopyToPublishDirectory>Always</CopyToPublishDirectory>
-      </ResolvedFilesToPublish>
+      </ResolvedFileToPublish>
 
-      <ResolvedFilesToPublish Include="@(_SourceItemsToCopyToPublishDirectory)">
+      <ResolvedFileToPublish Include="@(_SourceItemsToCopyToPublishDirectory)">
         <RelativePath>%(_SourceItemsToCopyToPublishDirectory.TargetPath)</RelativePath>
         <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
-      </ResolvedFilesToPublish>
+      </ResolvedFileToPublish>
     </ItemGroup>
 
   </Target>
@@ -475,9 +477,9 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <ItemGroup>
 
-      <ResolvedFilesToPublish Condition="'%(ResolvedFilesToPublish.RelativePath)' == '$(_DotNetHostExecutableName)'">
-        <RelativePath>$(AssemblyName)%(ResolvedFilesToPublish.Extension)</RelativePath>
-      </ResolvedFilesToPublish>
+      <ResolvedFileToPublish Condition="'%(ResolvedFileToPublish.RelativePath)' == '$(_DotNetHostExecutableName)'">
+        <RelativePath>$(AssemblyName)%(ResolvedFileToPublish.Extension)</RelativePath>
+      </ResolvedFileToPublish>
 
     </ItemGroup>
 


### PR DESCRIPTION
We should have a single place where consumers can extend publish to add and remove files to be published.  With this change, all files to be copied are computed during `ComputeFilesToPublish` and then they are copied to the publish directory in `CopyFilesToPublishDirectory`.  Users can put a target between those two targets to add/update/remove files from @(ResolvedFilesToPublish).

Fix #170

@brthor @livarcocc @nguerrera 

/cc @dotnet/project-system 
