### PR TITLE
Remove some obstacles from desktop targeting

### DIFF
--- a/src/Tasks/Microsoft.NETCore.Build.Tasks/Microsoft.NETCore.Build.Tasks.csproj
+++ b/src/Tasks/Microsoft.NETCore.Build.Tasks/Microsoft.NETCore.Build.Tasks.csproj
@@ -48,6 +48,9 @@
     <None Include="buildCrossTargeting\Microsoft.NETCore.Sdk.targets">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="build\netstandard1.0\Microsoft.NETCore.DisableStandardFrameworkResolution.targets">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="build\netstandard1.0\Microsoft.NETCore.PreserveCompilationContext.targets">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/src/Tasks/Microsoft.NETCore.Build.Tasks/build/netstandard1.0/Microsoft.NETCore.DisableStandardFrameworkResolution.targets
+++ b/src/Tasks/Microsoft.NETCore.Build.Tasks/build/netstandard1.0/Microsoft.NETCore.DisableStandardFrameworkResolution.targets
@@ -1,0 +1,23 @@
+<!--
+***********************************************************************************************
+Microsoft.NETCore.DisableStandardFrameworkResolution.targets
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+          created a backup copy.  Incorrect changes to this file will make it
+          impossible to load or build your projects from the command-line or the IDE.
+
+Copyright (c) .NET Foundation. All rights reserved. 
+***********************************************************************************************
+-->
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <Target Name="GetReferenceAssemblyPaths" />
+  <Target Name="GetFrameworkPaths" />
+
+  <PropertyGroup>
+    <_TargetFrameworkDirectories />
+    <FrameworkPathOverride />
+    <TargetFrameworkDirectory />
+  </PropertyGroup>
+
+</Project>

--- a/src/Tasks/Microsoft.NETCore.Build.Tasks/build/netstandard1.0/Microsoft.NETCore.Sdk.props
+++ b/src/Tasks/Microsoft.NETCore.Build.Tasks/build/netstandard1.0/Microsoft.NETCore.Sdk.props
@@ -58,6 +58,10 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <!-- dependencies coming from the package manager lock file should not be copied locally for .NET Core projects -->
     <CopyLocalLockFileAssemblies>false</CopyLocalLockFileAssemblies>
+
+    <!-- Exclude GAC, registry, output directory from search paths. -->
+    <AssemblySearchPaths>{CandidateAssemblyFiles};{HintPathFromItem};{TargetFrameworkDirectory};{RawFileName}</AssemblySearchPaths>
+    <DesignTimeAssemblySearchPaths>$(AssemblySearchPaths)</DesignTimeAssemblySearchPaths>
   </PropertyGroup>
 
   <!-- Shared properties between cross-targeting and inner build targets. -->

--- a/src/Tasks/Microsoft.NETCore.Build.Tasks/build/netstandard1.0/Microsoft.NETCore.Sdk.targets
+++ b/src/Tasks/Microsoft.NETCore.Build.Tasks/build/netstandard1.0/Microsoft.NETCore.Sdk.targets
@@ -28,13 +28,9 @@ Copyright (c) .NET Foundation. All rights reserved.
   <UsingTask TaskName="GetAssemblyVersion" AssemblyFile="$(MicrosoftNETCoreBuildTasksAssembly)" />
   <UsingTask TaskName="GenerateSatelliteAssemblies" AssemblyFile="$(MicrosoftNETCoreBuildTasksAssembly)" />
 
-  <PropertyGroup>
-    <!-- We don't use any of MSBuild's resolution logic for resolving the framework, so just set these two
-              properties to any folder that exists to skip the GetReferenceAssemblyPaths task (not target) and
-              to prevent it from outputting a warning (MSB3644).
-          -->
-    <_TargetFrameworkDirectories>$(MSBuildThisFileDirectory)</_TargetFrameworkDirectories>
-    <_FullFrameworkReferenceAssemblyPaths>$(MSBuildThisFileDirectory)</_FullFrameworkReferenceAssemblyPaths>
+  <PropertyGroup Condition="'$(DisableStandardFrameworkResolution)' == ''">
+     <DisableStandardFrameworkResolution Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">true</DisableStandardFrameworkResolution>
+     <DisableStandardFrameworkResolution Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard'">true</DisableStandardFrameworkResolution>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -200,9 +196,10 @@ Copyright (c) .NET Foundation. All rights reserved.
     </GenerateSatelliteAssemblies>
   </Target>
 
-  <Import Project="$(MSBuildThisFileDirectory)Microsoft.NETCore.GenerateAssemblyInfo.targets" Condition="Exists('$(MSBuildThisFileDirectory)Microsoft.NETCore.GenerateAssemblyInfo.targets')" />
-  <Import Project="$(MSBuildThisFileDirectory)Microsoft.NETCore.Publish.targets" Condition="Exists('$(MSBuildThisFileDirectory)Microsoft.NETCore.Publish.targets')" />
-  <Import Project="$(MSBuildThisFileDirectory)Microsoft.NETCore.PreserveCompilationContext.targets" Condition="Exists('$(MSBuildThisFileDirectory)Microsoft.NETCore.PreserveCompilationContext.targets')" />
+  <Import Project="$(MSBuildThisFileDirecotry)Microsoft.NETCore.DisableStandardFrameworkResolution.targets" Condition="'$(DisableStandardFrameworkResolution)' == 'true'" />
+  <Import Project="$(MSBuildThisFileDirectory)Microsoft.NETCore.GenerateAssemblyInfo.targets" />
+  <Import Project="$(MSBuildThisFileDirectory)Microsoft.NETCore.Publish.targets" />
+  <Import Project="$(MSBuildThisFileDirectory)Microsoft.NETCore.PreserveCompilationContext.targets" />
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.NETCore.Sdk.CSharp.targets" Condition="'$(Language)' == 'C#'" />
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.NETCore.Sdk.VisualBasic.targets" Condition="'$(Language)' == 'VB'" />
 </Project>


### PR DESCRIPTION
This lets msbuild resolve framework assemblies as usual if Target is not netcoreapp or netstandard.

I can now _compile_ using desktop msbuild and TargetFramework=net45, but GenerateDepsFile is blowing up, but that might be due to not having things in place to restore properly on my box at the moment. Core MSBuild is also not up to the task yet.

Still, this is a step forward, so I thought I'd send it out for review now.

@srivatsn @eerhardt @dotnet/project-system 
