### PR TITLE
Fixing a small coding error in GetNearestTargetFramework

### DIFF
--- a/src/Tasks/Microsoft.NETCore.Build.Tasks/GetNearestTargetFramework.cs
+++ b/src/Tasks/Microsoft.NETCore.Build.Tasks/GetNearestTargetFramework.cs
@@ -67,7 +67,7 @@ namespace Microsoft.DotNet.Core.Build.Tasks
             // in a condition that compares against $(TargetFramework).
             int indexOfNearestFramework = possibleNuGetFrameworks.IndexOf(nearestNuGetFramework);
             NearestTargetFramework = PossibleTargetFrameworks[indexOfNearestFramework];
-            return Log.HasLoggedErrors;
+            return !Log.HasLoggedErrors;
         }
 
         private NuGetFramework ParseFramework(string name)


### PR DESCRIPTION
Need to return !Log.HasLoggedErrors from Execute, so the task returns whether it has failed or not correctly.

@nguerrera 
