### PR TITLE
Update Microsoft.PackageDependencyResolution.targets to allow lock file override

### DIFF
--- a/src/Tasks/Microsoft.NETCore.Build.Tasks/build/netstandard1.0/Microsoft.PackageDependencyResolution.targets
+++ b/src/Tasks/Microsoft.NETCore.Build.Tasks/build/netstandard1.0/Microsoft.PackageDependencyResolution.targets
@@ -24,18 +24,18 @@ Copyright (c) .NET Foundation. All rights reserved.
     <EnableResolvePackageDependencies
       Condition="'$(EnableResolvePackageDependencies)' == ''">true</EnableResolvePackageDependencies>
   </PropertyGroup>
-
+  
+    <!-- For .NET Core projects the lock file will be in the obj folder. NuGet is currently using the presence of the TargetFrameworks property to determine that.
+       This will likely change when PackageReferences for UWP lights up-->
+  <PropertyGroup Condition="'$(ProjectLockFile)' == ''">
+    <ProjectLockFile Condition="'$(TargetFrameworks)' != ''">$(BaseIntermediateOutputPath)/project.assets.json</ProjectLockFile>
+  </PropertyGroup>
+          
   <!-- Project Lock File -->
   <PropertyGroup Condition="'$(ProjectLockFile)' == ''">
     <_ProjectSpecificProjectJsonFile>$(MSBuildProjectName).project.json</_ProjectSpecificProjectJsonFile>
     <ProjectLockFile Condition="Exists('$(_ProjectSpecificProjectJsonFile)')">$(MSBuildProjectDirectory)/$(MSBuildProjectName).project.lock.json</ProjectLockFile>
     <ProjectLockFile Condition="!Exists('$(_ProjectSpecificProjectJsonFile)')">$(MSBuildProjectDirectory)/project.lock.json</ProjectLockFile>
-  </PropertyGroup>
-  
-  <!-- For .NET Core projects the lock file will be in the obj folder. NuGet is currently using the presence of the TargetFrameworks property to determine that.
-       This will likely change when PackageReferences for UWP lights up-->
-  <PropertyGroup>
-    <ProjectLockFile Condition="'$(TargetFrameworks)' != ''">$(BaseIntermediateOutputPath)/project.assets.json</ProjectLockFile>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
This change allows the lock file to be overridden in the user's project. 

The behavior should be unchanged otherwise. 

@nguerrera @natidea @eerhardt @livarcocc 
