### PR TITLE
Add bug reference to web inner-build simulation workaround

### DIFF
--- a/src/Templates/ProjectTemplates/CSharp/Web/EmptyWeb/ProjectTemplate.csproj
+++ b/src/Templates/ProjectTemplates/CSharp/Web/EmptyWeb/ProjectTemplate.csproj
@@ -1,6 +1,11 @@
 ﻿<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <!-- Temporarily simulate an inner build until cross-targeting support for VS is checked in. This needs to be
-       above the import of the props because the SDK.props will only get imported if the TargetFramework is set.-->
+  <!-- 
+    https://github.com/dotnet/sdk/issues/210
+  
+    Temporarily simulate an inner build until web projects work correctly with cross-targeting. 
+    This needs to be above the import of the props because the SDK.props will only get imported 
+    if the TargetFramework is set.
+  -->
   <PropertyGroup>
     <TargetFramework>netcoreapp1.0</TargetFramework>
   </PropertyGroup>


### PR DESCRIPTION
The reverted comment referred to work that was already done, so making sure there's a distinct issue tracking getting cross-targeting and web working well together and referencing it in the comment associated with the workaround.

@abpiskunov @srivatsn 
