### PR TITLE
Don't require VS 2015 to build if 'msbuild' is on the path.

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -1,19 +1,25 @@
 @echo off
 setlocal enabledelayedexpansion
 
+where /q msbuild
+if "%ERRORLEVEL%" == "0" (
+    goto :SkipDeveloperSetup
+)
+
 set DeveloperCommandPrompt=%VS140COMNTOOLS%\VsDevCmd.bat
 
 if not exist "%DeveloperCommandPrompt%" (
-  echo In order to build this repository, you need Visual Studio 2015 installed.
+  echo In order to build this repository, you either need 'msbuild' on the path or Visual Studio 2015 installed.
   echo.
   echo Visit this page to download:
   echo.
-  echo https://go.microsoft.com/fwlink/?LinkId=691978&clcid=0x409
+  echo https://go.microsoft.com/fwlink/?LinkId=691978^&clcid=0x409
   exit /b 1
 )
 
 call "%DeveloperCommandPrompt%" || goto :BuildFailed
 
+:SkipDeveloperSetup
 powershell -NoProfile -NoLogo -ExecutionPolicy Bypass -Command "& \"%~dp0build.ps1\" %*; exit $LastExitCode;"
 exit /b %ERRORLEVEL%
 


### PR DESCRIPTION
We don't need VS 2015 installed on the machine, if we can find 'msbuild'.  For example, if the machine just has Dev15 and we are using a developer command prompt.

@333fred 

/cc @dotnet/project-system @nguerrera 
