### PR TITLE
Port NuGetTargetMoniker from Microsoft.NuGet.Targets

### DIFF
--- a/src/Tasks/Microsoft.NETCore.Build.Tasks/build/netstandard1.0/Microsoft.PackageDependencyResolution.targets
+++ b/src/Tasks/Microsoft.NETCore.Build.Tasks/build/netstandard1.0/Microsoft.PackageDependencyResolution.targets
@@ -48,6 +48,10 @@ Copyright (c) .NET Foundation. All rights reserved.
     <CopyLocalLockFileAssemblies Condition="'$(CopyLocalLockFileAssemblies)' == ''">true</CopyLocalLockFileAssemblies>
 
     <ContentPreprocessorOutputDirectory Condition="'$(ContentPreprocessorOutputDirectory)' == ''">$(IntermediateOutputPath)NuGet\</ContentPreprocessorOutputDirectory>
+
+    <UseTargetPlatformAsNuGetTargetMoniker Condition="'$(UseTargetPlatformAsNuGetTargetMoniker)' == '' AND '$(TargetFrameworkMoniker)' == '.NETCore,Version=v5.0'">true</UseTargetPlatformAsNuGetTargetMoniker>
+    <NuGetTargetMoniker Condition="'$(NuGetTargetMoniker)' == '' AND '$(UseTargetPlatformAsNuGetTargetMoniker)' == 'true'">$(TargetPlatformIdentifier),Version=v$([System.Version]::Parse('$(TargetPlatformMinVersion)').ToString(3))</NuGetTargetMoniker>
+    <NuGetTargetMoniker Condition="'$(NuGetTargetMoniker)' == '' AND '$(UseTargetPlatformAsNuGetTargetMoniker)' != 'true'">$(TargetFrameworkMoniker)</NuGetTargetMoniker>
   </PropertyGroup>
 
   <!-- Target Moniker + RID-->


### PR DESCRIPTION
This variable was being pulled in from Microsoft.NuGet.Targets and we don't want to have to take a dependency on this being present.  Microsoft.NuGet.Targets is being removed from the CLI. Doing further investigation to determine if we are accidentally depending on other variables.

/cc @livarcocc @dotnet/project-system 
