### PR TITLE
Add PrivateAssets=All to the Sdk PackageReference in the templates.

### DIFF
--- a/src/Templates/ProjectTemplates/CSharp/.NETCore/CSharpClassLibrary/ProjectTemplate.csproj
+++ b/src/Templates/ProjectTemplates/CSharp/.NETCore/CSharpClassLibrary/ProjectTemplate.csproj
@@ -16,6 +16,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.Sdk">
       <Version>$$buildversion$$</Version>
+      <PrivateAssets>All</PrivateAssets>
     </PackageReference>
   </ItemGroup>
 

--- a/src/Templates/ProjectTemplates/CSharp/.NETCore/CSharpConsoleApplication/ProjectTemplate.csproj
+++ b/src/Templates/ProjectTemplates/CSharp/.NETCore/CSharpConsoleApplication/ProjectTemplate.csproj
@@ -17,6 +17,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.Sdk">
       <Version>$$buildversion$$</Version>
+      <PrivateAssets>All</PrivateAssets>
     </PackageReference>
   </ItemGroup>
   

--- a/src/Templates/ProjectTemplates/CSharp/.NETCore/CSharpUnitTest/ProjectTemplate.csproj
+++ b/src/Templates/ProjectTemplates/CSharp/.NETCore/CSharpUnitTest/ProjectTemplate.csproj
@@ -17,6 +17,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.Sdk">
       <Version>$$buildversion$$</Version>
+      <PrivateAssets>All</PrivateAssets>
     </PackageReference>
   <PackageReference Include="Microsoft.TestPlatform.TestHost">
       <Version>15.0.0-preview-20161005-01</Version>

--- a/src/Templates/ProjectTemplates/CSharp/Web/EmptyWeb/ProjectTemplate.csproj
+++ b/src/Templates/ProjectTemplates/CSharp/Web/EmptyWeb/ProjectTemplate.csproj
@@ -28,6 +28,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.Sdk.Web">
       <Version>$$buildversion$$</Version>
+      <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics">
       <Version>1.0.0</Version>

--- a/src/Templates/ProjectTemplates/VisualBasic/.NETCore/VisualBasicClassLibrary/ProjectTemplate.vbproj
+++ b/src/Templates/ProjectTemplates/VisualBasic/.NETCore/VisualBasicClassLibrary/ProjectTemplate.vbproj
@@ -16,6 +16,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.Sdk">
       <Version>$$buildversion$$</Version>
+      <PrivateAssets>All</PrivateAssets>
     </PackageReference>
   </ItemGroup>
 

--- a/src/Templates/ProjectTemplates/VisualBasic/.NETCore/VisualBasicConsoleApplication/ProjectTemplate.vbproj
+++ b/src/Templates/ProjectTemplates/VisualBasic/.NETCore/VisualBasicConsoleApplication/ProjectTemplate.vbproj
@@ -17,6 +17,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.Sdk">
       <Version>$$buildversion$$</Version>
+      <PrivateAssets>All</PrivateAssets>
     </PackageReference>
   </ItemGroup>
 


### PR DESCRIPTION
@natidea @srivatsn 

@piotrpMSFT  - we should do the same in the CLI templates.

/cc @dotnet/project-system @brthor @livarcocc 
