### PR TITLE
Change sort order and default names of templates

### DIFF
--- a/src/Templates/ProjectTemplates/CSharp/.NETCore/CSharpClassLibrary/ClassLibrary.vstemplate
+++ b/src/Templates/ProjectTemplates/CSharp/.NETCore/CSharpClassLibrary/ClassLibrary.vstemplate
@@ -6,7 +6,7 @@
     <Icon Package="{FAE04EC1-301F-11d3-BF4B-00C04F79EFBC}" ID="4547" />
     <ProjectType>CSharp</ProjectType>
     <RequiredFrameworkVersion>2.0</RequiredFrameworkVersion>
-    <SortOrder>21</SortOrder>
+    <SortOrder>15</SortOrder>
     <NumberOfParentCategoriesToRollUp>1</NumberOfParentCategoriesToRollUp>
     <TemplateID>Microsoft.CSharp.NETCore.ClassLibrary</TemplateID>
     <CreateNewFolder>true</CreateNewFolder>

--- a/src/Templates/ProjectTemplates/CSharp/.NETCore/CSharpConsoleApplication/ConsoleApplication.vstemplate
+++ b/src/Templates/ProjectTemplates/CSharp/.NETCore/CSharpConsoleApplication/ConsoleApplication.vstemplate
@@ -11,7 +11,7 @@
     <TemplateID>Microsoft.CSharp.NETCore.ConsoleApplication</TemplateID>
     <CreateNewFolder>true</CreateNewFolder>
     <CreateInPlace>true</CreateInPlace>
-    <DefaultName>ConsoleApplication</DefaultName>
+    <DefaultName>ConsoleApp</DefaultName>
     <ProvideDefaultName>true</ProvideDefaultName>
     <PromptForSaveOnCreation>true</PromptForSaveOnCreation>
   </TemplateData>

--- a/src/Templates/ProjectTemplates/VisualBasic/.NETCore/VisualBasicClassLibrary/ClassLibrary.vstemplate
+++ b/src/Templates/ProjectTemplates/VisualBasic/.NETCore/VisualBasicClassLibrary/ClassLibrary.vstemplate
@@ -6,7 +6,7 @@
     <Icon Package="{164B10B9-B200-11D0-8C61-00A0C91E29D5}" ID="4500" />
     <ProjectType>VisualBasic</ProjectType>
     <RequiredFrameworkVersion>2.0</RequiredFrameworkVersion>
-    <SortOrder>21</SortOrder>
+    <SortOrder>15</SortOrder>
     <NumberOfParentCategoriesToRollUp>1</NumberOfParentCategoriesToRollUp>
     <TemplateID>Microsoft.VisualBasic.NETCore.ClassLibrary</TemplateID>
     <CreateNewFolder>true</CreateNewFolder>

--- a/src/Templates/ProjectTemplates/VisualBasic/.NETCore/VisualBasicConsoleApplication/ConsoleApplication.vstemplate
+++ b/src/Templates/ProjectTemplates/VisualBasic/.NETCore/VisualBasicConsoleApplication/ConsoleApplication.vstemplate
@@ -6,12 +6,12 @@
     <Icon>ConsoleApplication.png</Icon>
     <ProjectType>VisualBasic</ProjectType>
     <RequiredFrameworkVersion>2.0</RequiredFrameworkVersion>
-    <SortOrder>1</SortOrder>
+    <SortOrder>13</SortOrder>
     <NumberOfParentCategoriesToRollUp>1</NumberOfParentCategoriesToRollUp>
     <TemplateID>Microsoft.VisualBasic.NETCore.ConsoleApplication</TemplateID>
     <CreateNewFolder>true</CreateNewFolder>
     <CreateInPlace>true</CreateInPlace>
-    <DefaultName>ConsoleApplication</DefaultName>
+    <DefaultName>ConsoleApp</DefaultName>
     <ProvideDefaultName>true</ProvideDefaultName>
     <PromptForSaveOnCreation>true</PromptForSaveOnCreation>
   </TemplateData>


### PR DESCRIPTION
This is so they are sorted and named according to https://github.com/dotnet/roslyn-project-system/issues/409.

tag @dotnet/project-system 
