### PR TITLE
Fixing Desktop build default properties.

### DIFF
--- a/TestAssets/TestProjects/CrossTargeting/DesktopAndNetStandard/DesktopAndNetStandard.csproj
+++ b/TestAssets/TestProjects/CrossTargeting/DesktopAndNetStandard/DesktopAndNetStandard.csproj
@@ -13,7 +13,6 @@
     <EmbeddedResource Include="**\*.resx" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net45'">
-    <Reference Include="mscorlib" />
     <Reference Include="System.Windows.Forms" />
   </ItemGroup>  
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.5'">

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/netstandard1.0/Microsoft.NET.DisableStandardFrameworkResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/netstandard1.0/Microsoft.NET.DisableStandardFrameworkResolution.targets
@@ -18,6 +18,9 @@ Copyright (c) .NET Foundation. All rights reserved.
     <_TargetFrameworkDirectories />
     <FrameworkPathOverride />
     <TargetFrameworkDirectory />
+
+    <!-- all references (even the StdLib) come from packages -->
+    <NoStdLib Condition="'$(NoStdLib)' == ''">true</NoStdLib>
   </PropertyGroup>
 
 </Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/netstandard1.0/Microsoft.NET.DisableStandardFrameworkResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/netstandard1.0/Microsoft.NET.DisableStandardFrameworkResolution.targets
@@ -20,7 +20,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <TargetFrameworkDirectory />
 
     <!-- all references (even the StdLib) come from packages -->
-    <NoStdLib Condition="'$(NoStdLib)' == ''">true</NoStdLib>
+    <NoStdLib>true</NoStdLib>
   </PropertyGroup>
 
 </Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/netstandard1.0/Microsoft.NET.Sdk.BeforeCommon.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/netstandard1.0/Microsoft.NET.Sdk.BeforeCommon.targets
@@ -34,9 +34,31 @@ Copyright (c) .NET Foundation. All rights reserved.
   <Import Condition="'$(TargetFramework)' != ''"
         Project="$(MSBuildThisFileDirectory)Microsoft.NET.TargetFrameworkInference.targets" />
 
-  <!-- Force .dll extension for .NETCoreApp projects even if output type is exe. -->
-  <PropertyGroup>
-    <TargetExt Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">.dll</TargetExt>
+  <PropertyGroup Condition="'$(_IsNETCoreOrNETStandard)' == ''">
+    <_IsNETCoreOrNETStandard Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">true</_IsNETCoreOrNETStandard>
+    <_IsNETCoreOrNETStandard Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard'">true</_IsNETCoreOrNETStandard>
+  </PropertyGroup>
+
+  <!-- Default settings for .NET Core and .NET Standard build logic -->
+  <PropertyGroup Condition="'$(_IsNETCoreOrNETStandard)' == 'true'">
+    <DebugType Condition="'$(DebugType)' == ''">portable</DebugType>
+    <AutoUnifyAssemblyReferences Condition="'$(AutoUnifyAssemblyReferences)' == ''">true</AutoUnifyAssemblyReferences>
+    <DesignTimeAutoUnify Condition="'$(DesignTimeAutoUnify)' == ''">true</DesignTimeAutoUnify>
+
+    <GenerateDependencyFile Condition=" '$(GenerateDependencyFile)' == '' ">true</GenerateDependencyFile>
+
+    <!-- all references (even the StdLib) come from packages -->
+    <NoStdLib Condition="'$(NoStdLib)' == ''">true</NoStdLib>
+
+    <!-- Force .dll extension for .NETCoreApp and .NETStandard projects even if output type is exe. -->
+    <TargetExt Condition="'$(TargetExt)' == ''">.dll</TargetExt>
+
+    <!-- dependencies coming from the package manager lock file should not be copied locally for .NET Core and .NETStandard projects -->
+    <CopyLocalLockFileAssemblies Condition="'$(CopyLocalLockFileAssemblies)' == ''">false</CopyLocalLockFileAssemblies>
+
+    <!-- Exclude GAC, registry, output directory from search paths. -->
+    <AssemblySearchPaths Condition="'$(AssemblySearchPaths)' == ''">{CandidateAssemblyFiles};{HintPathFromItem};{TargetFrameworkDirectory};{RawFileName}</AssemblySearchPaths>
+    <DesignTimeAssemblySearchPaths Condition="'$(DesignTimeAssemblySearchPaths)' == ''">$(AssemblySearchPaths)</DesignTimeAssemblySearchPaths>
   </PropertyGroup>
 
   <!-- Set PublishDir here, before Microsoft.Common.targets, to avoid a competing default there. -->

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/netstandard1.0/Microsoft.NET.Sdk.BeforeCommon.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/netstandard1.0/Microsoft.NET.Sdk.BeforeCommon.targets
@@ -41,24 +41,16 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <!-- Default settings for .NET Core and .NET Standard build logic -->
   <PropertyGroup Condition="'$(_IsNETCoreOrNETStandard)' == 'true'">
-    <DebugType Condition="'$(DebugType)' == ''">portable</DebugType>
     <AutoUnifyAssemblyReferences Condition="'$(AutoUnifyAssemblyReferences)' == ''">true</AutoUnifyAssemblyReferences>
     <DesignTimeAutoUnify Condition="'$(DesignTimeAutoUnify)' == ''">true</DesignTimeAutoUnify>
 
     <GenerateDependencyFile Condition=" '$(GenerateDependencyFile)' == '' ">true</GenerateDependencyFile>
-
-    <!-- all references (even the StdLib) come from packages -->
-    <NoStdLib Condition="'$(NoStdLib)' == ''">true</NoStdLib>
 
     <!-- Force .dll extension for .NETCoreApp and .NETStandard projects even if output type is exe. -->
     <TargetExt Condition="'$(TargetExt)' == ''">.dll</TargetExt>
 
     <!-- dependencies coming from the package manager lock file should not be copied locally for .NET Core and .NETStandard projects -->
     <CopyLocalLockFileAssemblies Condition="'$(CopyLocalLockFileAssemblies)' == ''">false</CopyLocalLockFileAssemblies>
-
-    <!-- Exclude GAC, registry, output directory from search paths. -->
-    <AssemblySearchPaths Condition="'$(AssemblySearchPaths)' == ''">{CandidateAssemblyFiles};{HintPathFromItem};{TargetFrameworkDirectory};{RawFileName}</AssemblySearchPaths>
-    <DesignTimeAssemblySearchPaths Condition="'$(DesignTimeAssemblySearchPaths)' == ''">$(AssemblySearchPaths)</DesignTimeAssemblySearchPaths>
   </PropertyGroup>
 
   <!-- Set PublishDir here, before Microsoft.Common.targets, to avoid a competing default there. -->

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/netstandard1.0/Microsoft.NET.Sdk.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/netstandard1.0/Microsoft.NET.Sdk.props
@@ -39,26 +39,10 @@ Copyright (c) .NET Foundation. All rights reserved.
     <OutputPath>bin\Release\</OutputPath>
   </PropertyGroup>
 
-  <!-- Default settings for .NET Core build logic -->
+  <!-- Default settings for all projects built with this Sdk package -->
   <PropertyGroup>
-    <DebugType>portable</DebugType>
-    <AutoUnifyAssemblyReferences>true</AutoUnifyAssemblyReferences>
-    <DesignTimeAutoUnify>true</DesignTimeAutoUnify>
-    
-    <GenerateDependencyFile Condition=" '$(GenerateDependencyFile)' == '' ">true</GenerateDependencyFile>
-
-    <!-- all references (even the StdLib) come from packages -->
-    <NoStdLib>true</NoStdLib>
-
     <!-- This will turn off the base UWP-specific 'ResolveNuGetPackages' target -->
     <ResolveNuGetPackages>false</ResolveNuGetPackages>
-
-    <!-- dependencies coming from the package manager lock file should not be copied locally for .NET Core projects -->
-    <CopyLocalLockFileAssemblies>false</CopyLocalLockFileAssemblies>
-
-    <!-- Exclude GAC, registry, output directory from search paths. -->
-    <AssemblySearchPaths>{CandidateAssemblyFiles};{HintPathFromItem};{TargetFrameworkDirectory};{RawFileName}</AssemblySearchPaths>
-    <DesignTimeAssemblySearchPaths>$(AssemblySearchPaths)</DesignTimeAssemblySearchPaths>
   </PropertyGroup>
 
   <!-- Temporary hacks to work around bugs -->
@@ -72,7 +56,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <!-- Temp Hack: https://github.com/Microsoft/msbuild/issues/1045: This is the only before common targets hook available to us, but using it is hijacking a hook that should belong to the user. -->
     <CustomBeforeMicrosoftCommonTargets>$(MSBuildThisFileDirectory)Microsoft.NET.Sdk.BeforeCommon.targets</CustomBeforeMicrosoftCommonTargets>
   </PropertyGroup>
-  
+
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.NET.Sdk.CSharp.props" Condition="'$(MSBuildProjectExtension)' == '.csproj'" />
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.NET.Sdk.VisualBasic.props" Condition="'$(MSBuildProjectExtension)' == '.vbproj'" />
 </Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/netstandard1.0/Microsoft.NET.Sdk.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/netstandard1.0/Microsoft.NET.Sdk.props
@@ -41,8 +41,14 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <!-- Default settings for all projects built with this Sdk package -->
   <PropertyGroup>
+    <DebugType>portable</DebugType>
+
     <!-- This will turn off the base UWP-specific 'ResolveNuGetPackages' target -->
     <ResolveNuGetPackages>false</ResolveNuGetPackages>
+
+    <!-- Exclude GAC, registry, output directory from search paths. -->
+    <AssemblySearchPaths>{CandidateAssemblyFiles};{HintPathFromItem};{TargetFrameworkDirectory};{RawFileName}</AssemblySearchPaths>
+    <DesignTimeAssemblySearchPaths>$(AssemblySearchPaths)</DesignTimeAssemblySearchPaths>
   </PropertyGroup>
 
   <!-- Temporary hacks to work around bugs -->

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/netstandard1.0/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/netstandard1.0/Microsoft.NET.Sdk.targets
@@ -30,9 +30,8 @@ Copyright (c) .NET Foundation. All rights reserved.
   <UsingTask TaskName="GetAssemblyVersion" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
   <UsingTask TaskName="GenerateSatelliteAssemblies" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
 
-  <PropertyGroup Condition="'$(DisableStandardFrameworkResolution)' == ''">
-    <DisableStandardFrameworkResolution Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">true</DisableStandardFrameworkResolution>
-    <DisableStandardFrameworkResolution Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard'">true</DisableStandardFrameworkResolution>
+  <PropertyGroup>
+    <DisableStandardFrameworkResolution Condition="'$(DisableStandardFrameworkResolution)' == ''">$(_IsNETCoreOrNETStandard)</DisableStandardFrameworkResolution>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildACrossTargetedLibrary.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildACrossTargetedLibrary.cs
@@ -69,7 +69,6 @@ namespace Microsoft.NET.Build.Tests
             outputDirectory.Should().OnlyHaveFiles(new[] {
                 "net45/DesktopAndNetStandard.dll",
                 "net45/DesktopAndNetStandard.pdb",
-                "net45/DesktopAndNetStandard.deps.json",
                 "netstandard1.5/DesktopAndNetStandard.dll",
                 "netstandard1.5/DesktopAndNetStandard.pdb",
                 "netstandard1.5/DesktopAndNetStandard.deps.json"


### PR DESCRIPTION
Some of the properties that were set unconditionally should not be set on desktop projects.

Fix https://github.com/dotnet/cli/issues/4334

I'm looking for a better name than `$(_IsNETCoreOrNETStandard)` if anyone has one.

@nguerrera @davkean @srivatsn 

/cc @dotnet/project-system @brthor @livarcocc 
