### PR TITLE
Rename $(ProjectLockFile) to $(ProjectAssetsFile).

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAResolvePackageDependenciesTask.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAResolvePackageDependenciesTask.cs
@@ -519,7 +519,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             LockFile lockFile = TestLockFiles.CreateLockFile(lockFileContent);
             var task = new ResolvePackageDependencies(lockFile, new MockPackageResolver())
             {
-                ProjectLockFile = lockFile.Path,
+                ProjectAssetsFile = lockFile.Path,
                 ProjectPath = null,
                 ProjectLanguage = projectLanguage // set language
             };
@@ -603,7 +603,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             LockFile lockFile = TestLockFiles.CreateLockFile(lockFileContent);
             var task = new ResolvePackageDependencies(lockFile, new MockPackageResolver())
             {
-                ProjectLockFile = lockFile.Path,
+                ProjectAssetsFile = lockFile.Path,
                 ProjectPath = null,
                 ProjectLanguage = projectLanguage // set language
             };
@@ -723,7 +723,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
 
             var task = new ResolvePackageDependencies(lockFile, resolver)
             {
-                ProjectLockFile = lockFile.Path,
+                ProjectAssetsFile = lockFile.Path,
                 ProjectPath = null,
                 ProjectLanguage = null
             };

--- a/src/Tasks/Microsoft.NET.Build.Tasks/GenerateDepsFile.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/GenerateDepsFile.cs
@@ -21,7 +21,7 @@ namespace Microsoft.NET.Build.Tasks
         public string ProjectPath { get; set; }
 
         [Required]
-        public string LockFilePath { get; set; }
+        public string AssetsFilePath { get; set; }
 
         [Required]
         public string DepsFilePath { get; set; }
@@ -46,7 +46,7 @@ namespace Microsoft.NET.Build.Tasks
 
         public override bool Execute()
         {
-            LockFile lockFile = new LockFileCache(BuildEngine4).GetLockFile(LockFilePath);
+            LockFile lockFile = new LockFileCache(BuildEngine4).GetLockFile(AssetsFilePath);
             CompilationOptions compilationOptions = CompilationOptionsConverter.ConvertFrom(CompilerOptions);
             SingleProjectInfo mainProject = SingleProjectInfo.Create(ProjectPath, AssemblyName, AssemblyVersion, AssemblySatelliteAssemblies);
             IEnumerable<string> privateAssets = PackageReferenceConverter.GetPackageIds(PrivateAssetsPackageReferences);

--- a/src/Tasks/Microsoft.NET.Build.Tasks/GenerateRuntimeConfigurationFiles.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/GenerateRuntimeConfigurationFiles.cs
@@ -21,7 +21,7 @@ namespace Microsoft.NET.Build.Tasks
     public class GenerateRuntimeConfigurationFiles : Task
     {
         [Required]
-        public string LockFilePath { get; set; }
+        public string AssetsFilePath { get; set; }
 
         [Required]
         public string RuntimeConfigPath { get; set; }
@@ -38,7 +38,7 @@ namespace Microsoft.NET.Build.Tasks
 
         public override bool Execute()
         {
-            LockFile = new LockFileCache(BuildEngine4).GetLockFile(LockFilePath);
+            LockFile = new LockFileCache(BuildEngine4).GetLockFile(AssetsFilePath);
 
             WriteRuntimeConfig();
 
@@ -91,7 +91,7 @@ namespace Microsoft.NET.Build.Tasks
             }
 
             var rawRuntimeOptions = File.ReadAllText(UserRuntimeConfig);
-            
+
             var runtimeOptionsFromProject = JObject.Parse(rawRuntimeOptions);
             foreach (var runtimeOption in runtimeOptionsFromProject)
             {

--- a/src/Tasks/Microsoft.NET.Build.Tasks/LockFileCache.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/LockFileCache.cs
@@ -52,6 +52,11 @@ namespace Microsoft.NET.Build.Tasks
 
         private LockFile LoadLockFile(string path)
         {
+            if (!File.Exists(path))
+            {
+                throw new Exception($"Assets file '{path}' couldn't be found. Run a NuGet package restore to generate this file.");
+            }
+
             // TODO - https://github.com/dotnet/sdk/issues/18 adapt task logger to Nuget Logger
             return LockFileUtilities.GetLockFile(path, NullLogger.Instance);
         }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageDependencies.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageDependencies.cs
@@ -92,10 +92,10 @@ namespace Microsoft.NET.Build.Tasks
         }
 
         /// <summary>
-        /// The lock file to process
+        /// The assets file to process
         /// </summary>
         [Required]
-        public string ProjectLockFile
+        public string ProjectAssetsFile
         {
             get; set;
         }
@@ -145,12 +145,7 @@ namespace Microsoft.NET.Build.Tasks
             {
                 if (_lockFile == null)
                 {
-                    if (!File.Exists(ProjectLockFile))
-                    {
-                        ReportException($"Lock file {ProjectLockFile} couldn't be found. Run a NuGet package restore to generate this file.");
-                    }
-
-                    _lockFile = new LockFileCache(BuildEngine4).GetLockFile(ProjectLockFile);
+                    _lockFile = new LockFileCache(BuildEngine4).GetLockFile(ProjectAssetsFile);
                 }
 
                 return _lockFile;
@@ -448,7 +443,7 @@ namespace Microsoft.NET.Build.Tasks
 
         private string GetAbsolutePathFromProjectRelativePath(string path)
         {
-            return Path.GetFullPath(Path.Combine(Path.GetDirectoryName(Path.GetFullPath(ProjectLockFile)), path));
+            return Path.GetFullPath(Path.Combine(Path.GetDirectoryName(Path.GetFullPath(ProjectAssetsFile)), path));
         }
 
         private void ReportException(string message)

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePublishAssemblies.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePublishAssemblies.cs
@@ -22,7 +22,7 @@ namespace Microsoft.NET.Build.Tasks
         public string ProjectPath { get; set; }
 
         [Required]
-        public string LockFilePath { get; set; }
+        public string AssetsFilePath { get; set; }
 
         [Required]
         public string TargetFramework { get; set; }
@@ -42,7 +42,7 @@ namespace Microsoft.NET.Build.Tasks
 
         public override bool Execute()
         {
-            LockFile lockFile = new LockFileCache(BuildEngine4).GetLockFile(LockFilePath);
+            LockFile lockFile = new LockFileCache(BuildEngine4).GetLockFile(AssetsFilePath);
             NuGetFramework framework = TargetFramework == null ? null : NuGetFramework.Parse(TargetFramework);
             NuGetPathContext nugetPathContext = NuGetPathContext.Create(Path.GetDirectoryName(ProjectPath));
             IEnumerable<string> privateAssetsPackageIds = PackageReferenceConverter.GetPackageIds(PrivateAssetsPackageReferences);

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/netstandard1.0/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/netstandard1.0/Microsoft.NET.Publish.targets
@@ -221,7 +221,7 @@ Copyright (c) .NET Foundation. All rights reserved.
           DependsOnTargets="ComputePrivateAssetsPackageReferences">
 
     <ResolvePublishAssemblies ProjectPath="$(MSBuildProjectFullPath)"
-                              LockFilePath="$(ProjectLockFile)"
+                              AssetsFilePath="$(ProjectAssetsFile)"
                               TargetFramework="$(TargetFrameworkIdentifier),Version=$(TargetFrameworkVersion)"
                               RuntimeIdentifier="$(RuntimeIdentifier)"
                               PrivateAssetsPackageReferences="@(PrivateAssetsPackageReference)">
@@ -430,7 +430,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     </PropertyGroup>
 
     <GenerateDepsFile ProjectPath="$(MSBuildProjectFullPath)"
-                      LockFilePath="$(ProjectLockFile)"
+                      AssetsFilePath="$(ProjectAssetsFile)"
                       DepsFilePath="$(_PublishDepsFilePath)"
                       TargetFramework="$(TargetFrameworkIdentifier),Version=$(TargetFrameworkVersion)"
                       AssemblyName="$(AssemblyName)"
@@ -480,7 +480,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       <_PublishRuntimeConfigFilePath Condition=" '$(_PublishRuntimeConfigFilePath)' == '' ">$(PublishDir)$(_ProjectRuntimeConfigFileName)</_PublishRuntimeConfigFilePath>
     </PropertyGroup>
 
-    <GenerateRuntimeConfigurationFiles LockFilePath="$(ProjectLockFile)"
+    <GenerateRuntimeConfigurationFiles AssetsFilePath="$(ProjectAssetsFile)"
                                        RuntimeConfigPath="$(_PublishRuntimeConfigFilePath)"
                                        RuntimeIdentifier="$(RuntimeIdentifier)"
                                        UserRuntimeConfig="$(UserRuntimeConfig)" />

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/netstandard1.0/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/netstandard1.0/Microsoft.NET.Sdk.targets
@@ -66,7 +66,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <Target Name="GenerateBuildDependencyFile"
           Condition=" '$(GenerateDependencyFile)' == 'true'"
-          Inputs="$(ProjectLockFile)"
+          Inputs="$(ProjectAssetsFile)"
           Outputs="$(_ProjectDepsFilePath)">
 
     <!-- 
@@ -74,7 +74,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     should be included during 'Build'.  They are only excluded on 'Publish'.
     -->
     <GenerateDepsFile ProjectPath="$(MSBuildProjectFullPath)"
-                      LockFilePath="$(ProjectLockFile)"
+                      AssetsFilePath="$(ProjectAssetsFile)"
                       DepsFilePath="$(_ProjectDepsFilePath)"
                       TargetFramework="$(TargetFrameworkIdentifier),Version=$(TargetFrameworkVersion)"
                       AssemblyName="$(AssemblyName)"
@@ -95,10 +95,10 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <Target Name="GenerateBuildRuntimeConfigurationFiles"
           Condition=" '$(GenerateRuntimeConfigurationFiles)' == 'true'"
-          Inputs="$(ProjectLockFile);$(UserRuntimeConfig)"
+          Inputs="$(ProjectAssetsFile);$(UserRuntimeConfig)"
           Outputs="$(_ProjectRuntimeConfigFilePath);$(_ProjectRuntimeConfigDevFilePath)">
 
-    <GenerateRuntimeConfigurationFiles LockFilePath="$(ProjectLockFile)"
+    <GenerateRuntimeConfigurationFiles AssetsFilePath="$(ProjectAssetsFile)"
                                        RuntimeConfigPath="$(_ProjectRuntimeConfigFilePath)"
                                        RuntimeConfigDevPath="$(_ProjectRuntimeConfigDevFilePath)"
                                        RuntimeIdentifier="$(RuntimeIdentifier)"

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/netstandard1.0/Microsoft.PackageDependencyResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/netstandard1.0/Microsoft.PackageDependencyResolution.targets
@@ -25,22 +25,14 @@ Copyright (c) .NET Foundation. All rights reserved.
       Condition="'$(EnableResolvePackageDependencies)' == ''">true</EnableResolvePackageDependencies>
   </PropertyGroup>
 
-  <!-- Project Lock File -->
-  <PropertyGroup Condition="'$(ProjectLockFile)' == ''">
-    <_ProjectSpecificProjectJsonFile>$(MSBuildProjectName).project.json</_ProjectSpecificProjectJsonFile>
-    <ProjectLockFile Condition="Exists('$(_ProjectSpecificProjectJsonFile)')">$(MSBuildProjectDirectory)/$(MSBuildProjectName).project.lock.json</ProjectLockFile>
-    <ProjectLockFile Condition="!Exists('$(_ProjectSpecificProjectJsonFile)')">$(MSBuildProjectDirectory)/project.lock.json</ProjectLockFile>
-  </PropertyGroup>
-  
-  <!-- For .NET Core projects the lock file will be in the obj folder. NuGet is currently using the presence of the TargetFrameworks property to determine that.
-       This will likely change when PackageReferences for UWP lights up-->
+  <!-- Project Assets File -->
   <PropertyGroup>
-    <ProjectLockFile Condition="'$(TargetFrameworks)' != ''">$(BaseIntermediateOutputPath)/project.assets.json</ProjectLockFile>
+    <ProjectAssetsFile Condition="'$(ProjectAssetsFile)' == ''">$(BaseIntermediateOutputPath)/project.assets.json</ProjectAssetsFile>
   </PropertyGroup>
 
   <PropertyGroup>
-    <!-- Ensure $(ProjectLockFile) is a full path -->
-    <ProjectLockFile Condition="'$([System.IO.Path]::IsPathRooted($(ProjectLockFile)))' != 'true'">$([System.IO.Path]::GetFullPath('$(MSBuildProjectDirectory)/$(ProjectLockFile)'))</ProjectLockFile>
+    <!-- Ensure $(ProjectAssetsFile) is a full path -->
+    <ProjectAssetsFile Condition="'$([System.IO.Path]::IsPathRooted($(ProjectAssetsFile)))' != 'true'">$([System.IO.Path]::GetFullPath('$(MSBuildProjectDirectory)/$(ProjectAssetsFile)'))</ProjectAssetsFile>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -121,7 +113,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     </ResolvePackageDependenciesForBuildDependsOn>
   </PropertyGroup>
   <Target Name="ResolvePackageDependenciesForBuild"
-          Condition="'$(ResolvePackageDependenciesForBuild)' == 'true' and '$(EnableResolvePackageDependencies)' == 'true' and Exists('$(ProjectLockFile)')"
+          Condition="'$(ResolvePackageDependenciesForBuild)' == 'true' and '$(EnableResolvePackageDependencies)' == 'true' and Exists('$(ProjectAssetsFile)')"
           DependsOnTargets="$(ResolvePackageDependenciesForBuildDependsOn)" />
 
   <!--
@@ -145,7 +137,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <Target Name="RunResolvePackageDependencies">
     <ResolvePackageDependencies
       ProjectPath="$(MSBuildProjectFullPath)"
-      ProjectLockFile="$(ProjectLockFile)"
+      ProjectAssetsFile="$(ProjectAssetsFile)"
       ProjectLanguage="$(Language)">
 
       <Output TaskParameter="TargetDefinitions" ItemName="TargetDefinitions" />


### PR DESCRIPTION
A few reasons:
1. it is no longer called a "lock file".
2. the current property name conflicts with Microsoft.NuGet.targets and they fight each other.
3. Currently, the Sdk only overwrites $(ProjectLockFile) if the multiple $(TargetFrameworks) property is set.

@nguerrera @natidea 

/cc @dotnet/project-system 

NOTE: this gets us one more step closer to moving our templates to single-TFM support by default.  We are still blocked by https://github.com/NuGet/Home/issues/3588
