### PR TITLE
Make publish work for desktop projects

### DIFF
--- a/TestAssets/TestProjects/CompilationContext/TestApp/TestApp.csproj
+++ b/TestAssets/TestProjects/CompilationContext/TestApp/TestApp.csproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp1.0</TargetFrameworks>
+    <TargetFrameworks>net46;netcoreapp1.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="**\*.cs" />
@@ -13,10 +13,12 @@
   <ItemGroup>
     <ProjectReference Include="../TestLibrary/TestLibrary.csproj" />
   </ItemGroup>
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp1.0'">
     <PackageReference Include="Microsoft.NETCore.App">
       <Version>1.0.1</Version>
     </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="Microsoft.NET.Sdk">
       <Version>0.0</Version>
     </PackageReference>

--- a/TestAssets/TestProjects/CompilationContext/TestLibrary/TestLibrary.csproj
+++ b/TestAssets/TestProjects/CompilationContext/TestLibrary/TestLibrary.csproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <OutputType>Library</OutputType>
-    <TargetFrameworks>netstandard1.5</TargetFrameworks>
+    <TargetFrameworks>netstandard1.3</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="**\*.cs" />

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolvedFile.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolvedFile.cs
@@ -28,7 +28,7 @@ namespace Microsoft.NET.Build.Tasks
 
         public ResolvedFile(string sourcePath, string destinationSubDirectory)
         {
-            SourcePath = sourcePath;
+            SourcePath = Path.GetFullPath(sourcePath);
             DestinationSubDirectory = destinationSubDirectory;
         }
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/netstandard1.0/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/netstandard1.0/Microsoft.NET.Publish.targets
@@ -203,7 +203,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <!-- TODO perform any preprocess transforms on the files -->
 
     <ItemGroup>
-      <ResolvedAssembliesToPublish Include="@(ReferenceCopyLocalPaths)">
+      <ResolvedAssembliesToPublish Include="@(ReferenceCopyLocalPaths)" Exclude="@(ResolvedAssembliesToPublish)">
         <DestinationSubPath>%(ReferenceCopyLocalPaths.DestinationSubDirectory)%(Filename)%(Extension)</DestinationSubPath>
       </ResolvedAssembliesToPublish>
     </ItemGroup>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/netstandard1.0/Microsoft.NET.Sdk.BeforeCommon.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/netstandard1.0/Microsoft.NET.Sdk.BeforeCommon.targets
@@ -52,6 +52,11 @@ Copyright (c) .NET Foundation. All rights reserved.
     <!-- dependencies coming from the package manager lock file should not be copied locally for .NET Core and .NETStandard projects -->
     <CopyLocalLockFileAssemblies Condition="'$(CopyLocalLockFileAssemblies)' == ''">false</CopyLocalLockFileAssemblies>
   </PropertyGroup>
+  
+  <!-- Regardless of platform, enable dependency file generation if PreserveCompilatioContext is set. -->
+  <PropertyGroup>
+    <GenerateDependencyFile Condition="'$(GenerateDependencyFile)' == ''">$(PreserveCompilationContext)</GenerateDependencyFile>
+  </PropertyGroup>
 
   <!-- Set PublishDir here, before Microsoft.Common.targets, to avoid a competing default there. -->
   <PropertyGroup>


### PR DESCRIPTION
- Always generate deps file if PreserveCompilationContext=true

This is where we're hoping to land,, but it's still different from the embedded desktop file used in project.json builds. We should decide today with the MVC folks if we're going to match the old behavior or stick with the new approach, which is more consistent across platforms. I'll follow up with a separate change once we make a final decision on this.

Fix #111
Fix #119
- Normalize and dedup paths to publish

This is a workaround for an issue where we were trying to copy the same file passed twice in Copy Task SourceFiles to one DestinationFile. I think it's fine to be defensive because it's really easy to end up with duplicates in the half dozen or so different items that can end up in this list.

With that said, I think I finally found the root cause of the duplication just now so I could likely get away with fixing only that and reverting the normalization and deduping. My preference, however. would be to keep the deduping regardless.

@eerhardt @dotnet/project-system 
