### PR TITLE
Report decent error message when LockFileTarget cannot be found.

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/GenerateDepsFile.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/GenerateDepsFile.cs
@@ -15,7 +15,7 @@ namespace Microsoft.NET.Build.Tasks
     /// <summary>
     /// Generates the $(project).deps.json file.
     /// </summary>
-    public class GenerateDepsFile : Task
+    public class GenerateDepsFile : TaskBase
     {
         [Required]
         public string ProjectPath { get; set; }
@@ -39,12 +39,12 @@ namespace Microsoft.NET.Build.Tasks
 
         [Required]
         public ITaskItem[] AssemblySatelliteAssemblies { get; set; }
-        
+
         public ITaskItem CompilerOptions { get; set; }
 
         public ITaskItem[] PrivateAssetsPackageReferences { get; set; }
 
-        public override bool Execute()
+        protected override void ExecuteCore()
         {
             LockFile lockFile = new LockFileCache(BuildEngine4).GetLockFile(AssetsFilePath);
             CompilationOptions compilationOptions = CompilationOptionsConverter.ConvertFrom(CompilerOptions);
@@ -65,8 +65,6 @@ namespace Microsoft.NET.Build.Tasks
             {
                 writer.Write(dependencyContext, fileStream);
             }
-
-            return true;
         }
     }
 }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/GenerateRuntimeConfigurationFiles.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/GenerateRuntimeConfigurationFiles.cs
@@ -18,7 +18,7 @@ namespace Microsoft.NET.Build.Tasks
     /// Generates the $(project).runtimeconfig.json and optionally $(project).runtimeconfig.dev.json files
     /// for a project.
     /// </summary>
-    public class GenerateRuntimeConfigurationFiles : Task
+    public class GenerateRuntimeConfigurationFiles : TaskBase
     {
         [Required]
         public string AssetsFilePath { get; set; }
@@ -36,7 +36,7 @@ namespace Microsoft.NET.Build.Tasks
 
         private bool IsPortable => string.IsNullOrEmpty(RuntimeIdentifier);
 
-        public override bool Execute()
+        protected override void ExecuteCore()
         {
             LockFile = new LockFileCache(BuildEngine4).GetLockFile(AssetsFilePath);
 
@@ -46,8 +46,6 @@ namespace Microsoft.NET.Build.Tasks
             {
                 WriteDevRuntimeConfig();
             }
-
-            return true;
         }
 
         private void WriteRuntimeConfig()

--- a/src/Tasks/Microsoft.NET.Build.Tasks/GenerateSatelliteAssemblies.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/GenerateSatelliteAssemblies.cs
@@ -17,7 +17,7 @@ namespace Microsoft.NET.Build.Tasks
     /// <summary>
     /// Generates Satellite Assemblies
     /// </summary>
-    public class GenerateSatelliteAssemblies : Task
+    public class GenerateSatelliteAssemblies : TaskBase
     {
         [Required]
         public ITaskItem[] EmbedResources { get; set; }
@@ -32,7 +32,7 @@ namespace Microsoft.NET.Build.Tasks
         [Required]
         public string AssemblyInfoFile { get; set; }
 
-        public override bool Execute()
+        protected override void ExecuteCore()
         {
             var resourceDescriptions = new List<ResourceDescription>();
 
@@ -71,8 +71,6 @@ namespace Microsoft.NET.Build.Tasks
                     }
                 }
             }
-
-            return !Log.HasLoggedErrors;
         }
     }
 }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/GetAssemblyVersion.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/GetAssemblyVersion.cs
@@ -8,12 +8,12 @@ using Newtonsoft.Json;
 using NuGet.Versioning;
 using System.Diagnostics;
 
-namespace Microsoft.DotNet.Core.Build.Tasks
+namespace Microsoft.NET.Build.Tasks
 {
     /// <summary>
     /// Determines the assembly version to use for a given semantic version.
     /// </summary>
-    public class GetAssemblyVersion : Task
+    public class GetAssemblyVersion : TaskBase
     {
         /// <summary>
         /// The nuget version from which to get an assembly version portion.
@@ -27,18 +27,16 @@ namespace Microsoft.DotNet.Core.Build.Tasks
         [Output]
         public string AssemblyVersion { get; set; }
 
-        public override bool Execute()
+        protected override void ExecuteCore()
         {
             // Using try/catch instead of TryParse so that we don't need to maintain our own error message here.
             try
             {
                 AssemblyVersion = NuGet.Versioning.NuGetVersion.Parse(NuGetVersion).Version.ToString();
-                return true;
             }
             catch (ArgumentException ex)
             {
                 Log.LogError(ex.Message);
-                return false;
             }
         }
     }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/GetNearestTargetFramework.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/GetNearestTargetFramework.cs
@@ -7,12 +7,12 @@ using Newtonsoft.Json;
 using NuGet.Frameworks;
 using System.Linq;
 
-namespace Microsoft.DotNet.Core.Build.Tasks
+namespace Microsoft.NET.Build.Tasks
 {
     /// <summary>
     /// Gets the "nearest" framework
     /// </summary>
-    public class GetNearestTargetFramework : Task
+    public class GetNearestTargetFramework : TaskBase
     {
         /// <summary>
         /// The target framework of the referring project (in short form or full TFM)
@@ -33,13 +33,13 @@ namespace Microsoft.DotNet.Core.Build.Tasks
         [Output]
         public string NearestTargetFramework { get; private set; }
 
-        public override bool Execute()
+        protected override void ExecuteCore()
         {
             if (PossibleTargetFrameworks.Length < 1)
             {
                 // TODO: localize: https://github.com/dotnet/sdk/issues/33
                 Log.LogError("At least one possible target framework must be specified.");
-                return false;
+                return;
             }
 
             var referringNuGetFramework = ParseFramework(ReferringTargetFramework);
@@ -47,7 +47,7 @@ namespace Microsoft.DotNet.Core.Build.Tasks
 
             if (Log.HasLoggedErrors)
             {
-                return false;
+                return;
             }
 
             var nearestNuGetFramework = new FrameworkReducer().GetNearest(referringNuGetFramework, possibleNuGetFrameworks);
@@ -55,7 +55,7 @@ namespace Microsoft.DotNet.Core.Build.Tasks
             {
                 // TODO: localize: https://github.com/dotnet/sdk/issues/33
                 Log.LogError($"Project has no no target framework compatible with '{ReferringTargetFramework}'");
-                return false;
+                return;
             }
 
             // Note that there can be more than one spelling of the same target framework (e.g. net45 and net4.5) and 
@@ -67,7 +67,6 @@ namespace Microsoft.DotNet.Core.Build.Tasks
             // in a condition that compares against $(TargetFramework).
             int indexOfNearestFramework = possibleNuGetFrameworks.IndexOf(nearestNuGetFramework);
             NearestTargetFramework = PossibleTargetFrameworks[indexOfNearestFramework];
-            return !Log.HasLoggedErrors;
         }
 
         private NuGetFramework ParseFramework(string name)

--- a/src/Tasks/Microsoft.NET.Build.Tasks/LockFileCache.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/LockFileCache.cs
@@ -54,7 +54,7 @@ namespace Microsoft.NET.Build.Tasks
         {
             if (!File.Exists(path))
             {
-                throw new Exception($"Assets file '{path}' couldn't be found. Run a NuGet package restore to generate this file.");
+                throw new ReportUserErrorException($"Assets file '{path}' couldn't be found. Run a NuGet package restore to generate this file.");
             }
 
             // TODO - https://github.com/dotnet/sdk/issues/18 adapt task logger to Nuget Logger

--- a/src/Tasks/Microsoft.NET.Build.Tasks/LockFileExtensions.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/LockFileExtensions.cs
@@ -36,7 +36,7 @@ namespace Microsoft.NET.Build.Tasks
                     frameworkString :
                     $"{frameworkString}/{runtime}";
 
-                throw new Exception($"Assets file '{lockFile.Path}' doesn't have a target for '{targetMoniker}'." +
+                throw new ReportUserErrorException($"Assets file '{lockFile.Path}' doesn't have a target for '{targetMoniker}'." +
                     $" Ensure you have restored this project for TargetFramework='{framework.GetShortFolderName()}'" +
                     $" and RuntimeIdentifier='{runtime}'.");
             }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/LockFileExtensions.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/LockFileExtensions.cs
@@ -18,7 +18,28 @@ namespace Microsoft.NET.Build.Tasks
             NuGetFramework framework, 
             string runtime)
         {
+            if (lockFile == null)
+            {
+                throw new ArgumentNullException(nameof(lockFile));
+            }
+            if (framework == null)
+            {
+                throw new ArgumentNullException(nameof(framework));
+            }
+
             LockFileTarget lockFileTarget = lockFile.GetTarget(framework, runtime);
+
+            if (lockFileTarget == null)
+            {
+                string frameworkString = framework.DotNetFrameworkName;
+                string targetMoniker = string.IsNullOrEmpty(runtime) ?
+                    frameworkString :
+                    $"{frameworkString}/{runtime}";
+
+                throw new Exception($"Assets file '{lockFile.Path}' doesn't have a target for '{targetMoniker}'." +
+                    $" Ensure you have restored this project for TargetFramework='{framework.GetShortFolderName()}'" +
+                    $" and RuntimeIdentifier='{runtime}'.");
+            }
 
             return new ProjectContext(projectPath, lockFile, lockFileTarget);
         }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Microsoft.NET.Build.Tasks.csproj
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Microsoft.NET.Build.Tasks.csproj
@@ -35,6 +35,7 @@
     </PackageReference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="TaskBase.cs" />
     <Compile Include="PackageReferenceConverter.cs" />
     <Compile Include="NugetContentAssetPreprocessor.cs" />
     <Compile Include="IContentAssetPreprocessor.cs" />

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Microsoft.NET.Build.Tasks.csproj
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Microsoft.NET.Build.Tasks.csproj
@@ -35,6 +35,7 @@
     </PackageReference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ReportUserErrorException.cs" />
     <Compile Include="TaskBase.cs" />
     <Compile Include="PackageReferenceConverter.cs" />
     <Compile Include="NugetContentAssetPreprocessor.cs" />

--- a/src/Tasks/Microsoft.NET.Build.Tasks/PreprocessPackageDependenciesDesignTime.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/PreprocessPackageDependenciesDesignTime.cs
@@ -19,7 +19,7 @@ namespace Microsoft.NET.Build.Tasks
     /// 
     /// TODO: Add support for diagnostics, related issue https://github.com/dotnet/sdk/issues/26
     /// </summary>
-    public class PreprocessPackageDependenciesDesignTime : Task
+    public class PreprocessPackageDependenciesDesignTime : TaskBase
     {
         public const string DependenciesMetadata = "Dependencies";
         public const string CompileTimeAssemblyMetadata = "CompileTimeAssembly";
@@ -55,7 +55,7 @@ namespace Microsoft.NET.Build.Tasks
         private Dictionary<string, ItemMetadata> DependenciesWorld { get; set; }
                     = new Dictionary<string, ItemMetadata>(StringComparer.OrdinalIgnoreCase);
 
-        public override bool Execute()
+        protected override void ExecuteCore()
         {
             PopulateTargets();
 
@@ -91,8 +91,6 @@ namespace Microsoft.NET.Build.Tasks
 
                 return newTaskItem;
             }).ToArray();
-
-            return true;
         }
 
         /// <summary>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ProduceContentAssets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ProduceContentAssets.cs
@@ -16,7 +16,7 @@ namespace Microsoft.NET.Build.Tasks
     /// other filtering on content assets, including whether they match the active 
     /// project language.
     /// </summary>
-    public sealed class ProduceContentAssets : Task
+    public sealed class ProduceContentAssets : TaskBase
     {
         private readonly Dictionary<string, string> _resolvedPaths = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         private readonly List<ITaskItem> _contentItems = new List<ITaskItem>();
@@ -119,21 +119,7 @@ namespace Microsoft.NET.Build.Tasks
             }
         }
 
-        public override bool Execute()
-        {
-            try
-            {
-                ExecuteCore();
-                return true;
-            }
-            catch (Exception e)
-            {
-                Log.LogErrorFromException(e, showStackTrace: true);
-                return false;
-            }
-        }
-
-        private void ExecuteCore()
+        protected override void ExecuteCore()
         {
             MapContentFileDefinitions();
             ProcessContentFileInputs();

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ReportUserErrorException.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ReportUserErrorException.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace Microsoft.NET.Build.Tasks
+{
+    internal class ReportUserErrorException : Exception
+    {
+        public ReportUserErrorException()
+        {
+        }
+
+        public ReportUserErrorException(string message) : base(message)
+        {
+        }
+
+        public ReportUserErrorException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+    }
+}

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageDependencies.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageDependencies.cs
@@ -16,7 +16,7 @@ namespace Microsoft.NET.Build.Tasks
     /// Raises Nuget LockFile representation to MSBuild items and resolves
     /// assets specified in the lock file.
     /// </summary>
-    public sealed class ResolvePackageDependencies : Task
+    public sealed class ResolvePackageDependencies : TaskBase
     {
         private readonly Dictionary<string, string> _fileTypes = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         private readonly HashSet<string> _projectFileDependencies = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -155,21 +155,7 @@ namespace Microsoft.NET.Build.Tasks
         /// <summary>
         /// Raise Nuget LockFile representation to MSBuild items
         /// </summary>
-        public override bool Execute()
-        {
-            try
-            {
-                ExecuteCore();
-                return true;
-            }
-            catch (Exception e)
-            {
-                Log.LogErrorFromException(e, showStackTrace: true);
-                return false;
-            }
-        }
-
-        private void ExecuteCore()
+        protected override void ExecuteCore()
         {
             ReadProjectFileDependencies();
             RaiseLockFileTargets();

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageDependencies.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageDependencies.cs
@@ -402,7 +402,7 @@ namespace Microsoft.NET.Build.Tasks
 
                 if (string.IsNullOrEmpty(relativeMSBuildProjectPath))
                 {
-                    ReportException($"Your project is consuming assets from the project but no MSBuild project is found in the project.lock.json.");
+                    ReportException($"Your project is consuming assets from the project but no MSBuild project is found in '{ProjectAssetsFile}'");
                 }
 
                 return GetAbsolutePathFromProjectRelativePath(relativeMSBuildProjectPath);
@@ -434,7 +434,7 @@ namespace Microsoft.NET.Build.Tasks
 
         private void ReportException(string message)
         {
-            throw new Exception(message);
+            throw new ReportUserErrorException(message);
         }
     }
 }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePublishAssemblies.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePublishAssemblies.cs
@@ -14,7 +14,7 @@ namespace Microsoft.NET.Build.Tasks
     /// <summary>
     /// Resolves the assemblies to be published for a .NET app.
     /// </summary>
-    public class ResolvePublishAssemblies : Task
+    public class ResolvePublishAssemblies : TaskBase
     {
         private readonly List<ITaskItem> _assembliesToPublish = new List<ITaskItem>();
 
@@ -40,7 +40,7 @@ namespace Microsoft.NET.Build.Tasks
             get { return _assembliesToPublish.ToArray(); }
         }
 
-        public override bool Execute()
+        protected override void ExecuteCore()
         {
             LockFile lockFile = new LockFileCache(BuildEngine4).GetLockFile(AssetsFilePath);
             NuGetFramework framework = TargetFramework == null ? null : NuGetFramework.Parse(TargetFramework);
@@ -61,8 +61,6 @@ namespace Microsoft.NET.Build.Tasks
 
                 _assembliesToPublish.Add(item);
             }
-
-            return true;
         }
     }
 }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/TaskBase.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/TaskBase.cs
@@ -19,9 +19,9 @@ namespace Microsoft.NET.Build.Tasks
             {
                 ExecuteCore();
             }
-            catch (Exception e)
+            catch (ReportUserErrorException e)
             {
-                Log.LogErrorFromException(e, showStackTrace: true);
+                Log.LogErrorFromException(e);
             }
 
             return !Log.HasLoggedErrors;

--- a/src/Tasks/Microsoft.NET.Build.Tasks/TaskBase.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/TaskBase.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using Microsoft.Build.Utilities;
+
+namespace Microsoft.NET.Build.Tasks
+{
+    public abstract class TaskBase : Task
+    {
+        // no reason for outside classes to derive from this class.
+        internal TaskBase()
+        {
+        }
+
+        public override bool Execute()
+        {
+            try
+            {
+                ExecuteCore();
+            }
+            catch (Exception e)
+            {
+                Log.LogErrorFromException(e, showStackTrace: true);
+            }
+
+            return !Log.HasLoggedErrors;
+        }
+
+        protected abstract void ExecuteCore();
+    }
+}


### PR DESCRIPTION
Report decent error message when LockFileTarget cannot be found because the project wasn't restored for the correct TFM/RID configuration.

I also refactored our error reporting in general to have less code duplication.

Fix #233

@nguerrera @natidea 

/cc @dotnet/project-system 
