### PR TITLE
Eliminate all 20 remaining build warnings

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/ProduceContentAssets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ProduceContentAssets.cs
@@ -155,8 +155,8 @@ namespace Microsoft.NET.Build.Tasks
                 foreach (var duplicatedPreprocessorKey in duplicatedPreprocessorKeys)
                 {
                     Log.LogWarning(
-                        $"The preprocessor token &apos;{duplicatedPreprocessorKey}&apos; has been given more than one value." + 
-                        $" Choosing &apos;{preprocessorValues[duplicatedPreprocessorKey]}&apos; as the value.");
+                        $"The preprocessor token '{duplicatedPreprocessorKey}' has been given more than one value." +
+                        $" Choosing '{preprocessorValues[duplicatedPreprocessorKey]}' as the value.");
                 }
 
                 AssetPreprocessor.ConfigurePreprocessor(ContentPreprocessorOutputDirectory, preprocessorValues);

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/netstandard1.0/Microsoft.PackageDependencyResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/netstandard1.0/Microsoft.PackageDependencyResolution.targets
@@ -73,7 +73,6 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <!-- Common tokens used in preprocessed content files -->
   <ItemGroup>
-    <PreprocessorValue Include="@(NuGetPreprocessorValue)" Condition="'@(NuGetPreprocessorValue)' != ''"/>
     <PreprocessorValue Include="rootnamespace">
       <Value>$(RootNamespace)</Value>
     </PreprocessorValue>
@@ -89,6 +88,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <PreprocessorValue Include="filename">
       <Value>$(MSBuildProjectFile)</Value>
     </PreprocessorValue>
+    <PreprocessorValue Include="@(NuGetPreprocessorValue)" Exclude="@(PreprocessorValue)" />
   </ItemGroup>
 
   <!--


### PR DESCRIPTION
We were getting the same values out of @(NuGetPreprocessorValue) as our @(PreprocessorValue).

@natidea @dotnet/project-system 
