### PR TITLE
Add cross-targeting Publish target with nice error message.

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/buildCrossTargeting/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/buildCrossTargeting/Microsoft.NET.Sdk.targets
@@ -34,4 +34,18 @@ Copyright (c) .NET Foundation. All rights reserved.
     </GetNearestTargetFramework>
   </Target>
 
+  <!--
+  ============================================================
+                              Publish
+
+   This is the Publish target for cross-targeting.
+   Currently it is unsupported to publish for multiple target frameworks
+   because users can specify the $(PublishDir), and publish would put
+   multiple published applications in a single directory.
+  ============================================================
+   -->
+  <Target Name="Publish">
+    <Error Text="The 'Publish' target is not supported without specifying a target framework. The current project targets multiple frameworks, please specify the framework for the published application." />
+  </Target>
+  
 </Project>

--- a/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAHelloWorldProject.cs
+++ b/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAHelloWorldProject.cs
@@ -54,18 +54,19 @@ namespace Microsoft.NET.Publish.Tests
                 .HaveStdOutContaining("Hello World!");
         }
 
-        // https://github.com/dotnet/sdk/issues/116 - need to support self-contained apps in msbuild /t:restore
-        //[Fact]
+        [Fact]
         public void It_publishes_self_contained_apps_to_the_publish_folder_and_the_app_should_run()
         {
+            var rid = RuntimeEnvironment.GetRuntimeIdentifier();
+
             var helloWorldAsset = _testAssetsManager
                 .CopyTestAsset("HelloWorld")
                 .WithSource()
-                //.AsSelfContained()
-                .Restore();
+                .Restore(relativePath: "", args: $"/p:RuntimeIdentifiers={rid}");
 
             var publishCommand = new PublishCommand(Stage0MSBuild, helloWorldAsset.TestRoot);
-            var publishResult = publishCommand.Execute($"/p:RuntimeIdentifier={RuntimeEnvironment.GetRuntimeIdentifier()}");
+            // Temporarily pass in the TFM to publish until https://github.com/dotnet/sdk/issues/175 is addressed
+            var publishResult = publishCommand.Execute("/p:TargetFramework=netcoreapp1.0", $"/p:RuntimeIdentifier={rid}");
 
             publishResult.Should().Pass();
 


### PR DESCRIPTION
I also took the liberty of re-enabling the self-contained publish test, since I was looking at this publish test.

@nguerrera @livarcocc 

/cc @dotnet/project-system 
