### PR TITLE
Make DirectoryInfoAssertions.OnlyHaveFiles always recursive

### DIFF
--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildACrossTargetedLibrary.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildACrossTargetedLibrary.cs
@@ -41,7 +41,7 @@ namespace Microsoft.NET.Build.Tests
                 "netstandard1.5/NetStandardAndNetCoreApp.dll",
                 "netstandard1.5/NetStandardAndNetCoreApp.pdb",
                 "netstandard1.5/NetStandardAndNetCoreApp.deps.json"
-            }, SearchOption.AllDirectories);
+            });
         }
 
         [Fact]
@@ -72,7 +72,7 @@ namespace Microsoft.NET.Build.Tests
                 "netstandard1.5/DesktopAndNetStandard.dll",
                 "netstandard1.5/DesktopAndNetStandard.pdb",
                 "netstandard1.5/DesktopAndNetStandard.deps.json"
-            }, SearchOption.AllDirectories);
+            });
         }
     }
 }

--- a/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAProjectWithAllFeatures.cs
+++ b/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAProjectWithAllFeatures.cs
@@ -55,17 +55,13 @@ namespace Microsoft.NET.Publish.Tests
                 "NoneCopyOutputAlways.txt",
                 "NoneCopyOutputPreserveNewest.txt",
                 "CopyToOutputFromProjectReference.txt",
+                "da/TestApp.resources.dll",
+                "da/TestLibrary.resources.dll",
+                "de/TestApp.resources.dll",
+                "de/TestLibrary.resources.dll",
+                "fr/TestApp.resources.dll",
+                "fr/TestLibrary.resources.dll",
             });
-
-            var cultures = new List<string>() { "da", "de", "fr" };
-
-            foreach (var culture in cultures)
-            {
-                var cultureDir = new DirectoryInfo(Path.Combine(publishDirectory.FullName, culture));
-                cultureDir.Should().Exist();
-                cultureDir.Should().HaveFile("TestApp.resources.dll");
-                cultureDir.Should().HaveFile("TestLibrary.resources.dll");
-            }
 
             // Ensure Newtonsoft.Json doesn't get excluded from the deps.json file.
             // TestLibrary has a hard dependency on Newtonsoft.Json.

--- a/test/Microsoft.NET.TestFramework/Assertions/DirectoryInfoAssertions.cs
+++ b/test/Microsoft.NET.TestFramework/Assertions/DirectoryInfoAssertions.cs
@@ -75,9 +75,9 @@ namespace Microsoft.NET.TestFramework.Assertions
             return new AndConstraint<DirectoryInfoAssertions>(new DirectoryInfoAssertions(dir));
         }
 
-        public AndConstraint<DirectoryInfoAssertions> OnlyHaveFiles(IEnumerable<string> expectedFiles, SearchOption searchOption = SearchOption.TopDirectoryOnly)
+        public AndConstraint<DirectoryInfoAssertions> OnlyHaveFiles(IEnumerable<string> expectedFiles)
         {
-            var actualFiles = _dirInfo.EnumerateFiles("*", searchOption)
+            var actualFiles = _dirInfo.EnumerateFiles("*", SearchOption.AllDirectories)
                               .Select(f => f.FullName.Substring(_dirInfo.FullName.Length + 1) // make relative to _dirInfo
                               .Replace("\\", "/")); // normalize separator
 


### PR DESCRIPTION
Not being recursive let the satellite assembly on *nix bug linger for a while. Making it opt-in was a workaround while that bug was getting fixed. Now that it's fixed, prevent similar bugs from getting left undetected.

Fix #156 

@eerhardt @dotnet/project-system 
