### PR TITLE
Fix official build "path too long" error by shortening the TestAsset path.

### DIFF
--- a/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAHelloWorldProject.cs
+++ b/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAHelloWorldProject.cs
@@ -59,7 +59,7 @@ namespace Microsoft.NET.Publish.Tests
             var rid = RuntimeEnvironment.GetRuntimeIdentifier();
 
             var helloWorldAsset = _testAssetsManager
-                .CopyTestAsset("HelloWorld")
+                .CopyTestAsset("HelloWorld", "SelfContained")
                 .WithSource()
                 .Restore(relativePath: "", args: $"/p:RuntimeIdentifiers={rid}");
 


### PR DESCRIPTION
Our official build is currently broken.

@nguerrera @srivatsn @333fred 

/cc @dotnet/project-system 
