### PR TITLE
Put project path in P2P target framework incompatibility error

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/GetNearestTargetFramework.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/GetNearestTargetFramework.cs
@@ -27,6 +27,12 @@ namespace Microsoft.NET.Build.Tasks
         public string[] PossibleTargetFrameworks { get; set; }
 
         /// <summary>
+        /// The full path to the project with the given possible target frameworks. 
+        /// </summary>
+        [Required]
+        public string ProjectFilePath { get; set; }
+
+        /// <summary>
         /// The entry in <see cref="PossibleTargetFrameworks"/> that is "nearest" to <see cref="ReferringTargetFramework" />.
         /// If none of the possible frameworks are compatible with the referring framework.
         /// </summary>
@@ -54,7 +60,7 @@ namespace Microsoft.NET.Build.Tasks
             if (nearestNuGetFramework == null)
             {
                 // TODO: localize: https://github.com/dotnet/sdk/issues/33
-                Log.LogError($"Project has no no target framework compatible with '{ReferringTargetFramework}'");
+                Log.LogError($"Project '{ProjectFilePath}' has no target framework compatible with '{ReferringTargetFramework}'.");
                 return;
             }
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/buildCrossTargeting/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/buildCrossTargeting/Microsoft.NET.Sdk.targets
@@ -44,7 +44,9 @@ Copyright (c) .NET Foundation. All rights reserved.
   ============================================================
    -->
   <Target Name="GetTargetFrameworkProperties" Returns="TargetFramework=$(NearestTargetFramework)">
-    <GetNearestTargetFramework ReferringTargetFramework="$(ReferringTargetFramework)" PossibleTargetFrameworks="$(TargetFrameworks)">
+    <GetNearestTargetFramework ReferringTargetFramework="$(ReferringTargetFramework)" 
+                               PossibleTargetFrameworks="$(TargetFrameworks)"
+                               ProjectFilePath="$(MSBuildProjectFullPath)">
       <Output PropertyName="NearestTargetFramework" TaskParameter="NearestTargetFramework" />
     </GetNearestTargetFramework>
   </Target>


### PR DESCRIPTION
Also remove duplicate 'no' and add a period.

Fix #265 

I am not 100% sure if this is the right fix. MSBuild already puts the project file path in square brackets, but VS seems to drop this even if it is not the same as what will show in the project column of error list (since there's a nested MSBuild invocation).

On the command-line, we now have:

```
D:\Z\TestApp>msbuild /nologo /v:minimal
d:\src\sdk\packages\microsoft.net.sdk\1.0.0-alpha-00000001-01\buildCrossTargeting\Microsoft.NET.Sdk.targets(47,5): error : Project 'D:\Z\TestLibrary\TestLibrary.csproj'
has  no target framework compatible with '.NETFramework,Version=v4.6'. [D:\Z\TestLibrary\TestLibrary.csproj]
```

Notice how D:\Z\TestLibrary\TestLibrary.csproj is shown twice...

@davkean @dotnet/project-system 
