### PR TITLE
Incrementality for CoreGenerateAssemblyInfo

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/netstandard1.0/Microsoft.NET.GenerateAssemblyInfo.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/netstandard1.0/Microsoft.NET.GenerateAssemblyInfo.targets
@@ -33,9 +33,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <Target Name="GenerateAssemblyInfo"
           BeforeTargets="CoreCompile"
           DependsOnTargets="PrepareForBuild;GetAssemblyVersion;CoreGenerateAssemblyInfo"
-          Condition="'$(GenerateAssemblyInfo)' == 'true'"
-          Inputs="$(MSBuildAllProjects)"
-          Outputs="$(GeneratedAssemblyInfoFile)" />
+          Condition="'$(GenerateAssemblyInfo)' == 'true'" />
 
   <Target Name="CoreGenerateAssemblyInfo"
           Condition="'$(Language)'=='VB' or '$(Language)'=='C#'"

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/netstandard1.0/Microsoft.NET.GenerateAssemblyInfo.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/netstandard1.0/Microsoft.NET.GenerateAssemblyInfo.targets
@@ -18,6 +18,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     ============================================================
     -->
   <PropertyGroup>
+    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
     <GeneratedAssemblyInfoFile  Condition="'$(GeneratedAssemblyInfoFile)' ==''">$(IntermediateOutputPath)$(MSBuildProjectName).AssemblyInfo$(DefaultLanguageSourceExtension)</GeneratedAssemblyInfoFile>
     <GenerateAssemblyInfo Condition="'$(GenerateAssemblyInfo)' == ''">true</GenerateAssemblyInfo>
   </PropertyGroup>
@@ -37,7 +38,9 @@ Copyright (c) .NET Foundation. All rights reserved.
           Outputs="$(GeneratedAssemblyInfoFile)" />
 
   <Target Name="CoreGenerateAssemblyInfo"
-          Condition="'$(Language)'=='VB' or '$(Language)'=='C#'">
+          Condition="'$(Language)'=='VB' or '$(Language)'=='C#'"
+          Inputs="$(MSBuildAllProjects)"
+          Outputs="$(GeneratedAssemblyInfoFile)">
     <ItemGroup>
       <AssemblyAttribute Include="System.Reflection.AssemblyCompanyAttribute" Condition="'$(Authors)' != ''">
         <_Parameter1>$(Authors)</_Parameter1>


### PR DESCRIPTION
Fixes (the first part of) #275.

The CoreGenerateAssemblyInfo target was always executing and always
writing code to the assemblyinfo source file, causing unnecessary
rebuilds.

Since this solution adopts the standard "all relevant imported projects"
approach to did-a-property-change, I also made sure the
GenerateAssemblyInfo.targets file used that pattern--but I did not check
for that pattern elsewhere.
