### PR TITLE
Rename DepsJson and RuntimeConfig FilePath properties to be "public".

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Publish.targets
@@ -426,12 +426,12 @@ Copyright (c) .NET Foundation. All rights reserved.
           Condition="'$(GenerateDependencyFile)' == 'true'">
 
     <PropertyGroup>
-      <_PublishDepsFilePath Condition=" '$(_PublishDepsFilePath)' == '' ">$(PublishDir)$(_ProjectDepsFileName)</_PublishDepsFilePath>
+      <PublishDepsFilePath Condition=" '$(PublishDepsFilePath)' == '' ">$(PublishDir)$(ProjectDepsFileName)</PublishDepsFilePath>
     </PropertyGroup>
 
     <GenerateDepsFile ProjectPath="$(MSBuildProjectFullPath)"
                       AssetsFilePath="$(ProjectAssetsFile)"
-                      DepsFilePath="$(_PublishDepsFilePath)"
+                      DepsFilePath="$(PublishDepsFilePath)"
                       TargetFramework="$(TargetFrameworkIdentifier),Version=$(TargetFrameworkVersion)"
                       AssemblyName="$(AssemblyName)"
                       AssemblyVersion="$(Version)"
@@ -477,11 +477,11 @@ Copyright (c) .NET Foundation. All rights reserved.
           Condition="'$(GenerateRuntimeConfigurationFiles)' == 'true'">
 
     <PropertyGroup>
-      <_PublishRuntimeConfigFilePath Condition=" '$(_PublishRuntimeConfigFilePath)' == '' ">$(PublishDir)$(_ProjectRuntimeConfigFileName)</_PublishRuntimeConfigFilePath>
+      <PublishRuntimeConfigFilePath Condition=" '$(PublishRuntimeConfigFilePath)' == '' ">$(PublishDir)$(ProjectRuntimeConfigFileName)</PublishRuntimeConfigFilePath>
     </PropertyGroup>
 
     <GenerateRuntimeConfigurationFiles AssetsFilePath="$(ProjectAssetsFile)"
-                                       RuntimeConfigPath="$(_PublishRuntimeConfigFilePath)"
+                                       RuntimeConfigPath="$(PublishRuntimeConfigFilePath)"
                                        RuntimeIdentifier="$(RuntimeIdentifier)"
                                        UserRuntimeConfig="$(UserRuntimeConfig)" />
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.targets
@@ -41,11 +41,11 @@ Copyright (c) .NET Foundation. All rights reserved.
   </PropertyGroup>
 
   <PropertyGroup>
-    <_ProjectDepsFileName>$(AssemblyName).deps.json</_ProjectDepsFileName>
-    <_ProjectDepsFilePath>$(TargetDir)$(_ProjectDepsFileName)</_ProjectDepsFilePath>
-    <_ProjectRuntimeConfigFileName>$(AssemblyName).runtimeconfig.json</_ProjectRuntimeConfigFileName>
-    <_ProjectRuntimeConfigFilePath>$(TargetDir)$(_ProjectRuntimeConfigFileName)</_ProjectRuntimeConfigFilePath>
-    <_ProjectRuntimeConfigDevFilePath>$(TargetDir)$(AssemblyName).runtimeconfig.dev.json</_ProjectRuntimeConfigDevFilePath>
+    <ProjectDepsFileName Condition="'$(ProjectDepsFileName)' == ''">$(AssemblyName).deps.json</ProjectDepsFileName>
+    <ProjectDepsFilePath Condition="'$(ProjectDepsFilePath)' == ''">$(TargetDir)$(ProjectDepsFileName)</ProjectDepsFilePath>
+    <ProjectRuntimeConfigFileName Condition="'$(ProjectRuntimeConfigFileName)' == ''">$(AssemblyName).runtimeconfig.json</ProjectRuntimeConfigFileName>
+    <ProjectRuntimeConfigFilePath Condition="'$(ProjectRuntimeConfigFilePath)' == ''">$(TargetDir)$(ProjectRuntimeConfigFileName)</ProjectRuntimeConfigFilePath>
+    <ProjectRuntimeConfigDevFilePath Condition="'$(ProjectRuntimeConfigDevFilePath)' == ''">$(TargetDir)$(AssemblyName).runtimeconfig.dev.json</ProjectRuntimeConfigDevFilePath>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -67,7 +67,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <Target Name="GenerateBuildDependencyFile"
           Condition=" '$(GenerateDependencyFile)' == 'true'"
           Inputs="$(ProjectAssetsFile)"
-          Outputs="$(_ProjectDepsFilePath)">
+          Outputs="$(ProjectDepsFilePath)">
 
     <!-- 
     Explicitly not passing any PrivateAssets information during 'Build', since these dependencies
@@ -75,7 +75,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     -->
     <GenerateDepsFile ProjectPath="$(MSBuildProjectFullPath)"
                       AssetsFilePath="$(ProjectAssetsFile)"
-                      DepsFilePath="$(_ProjectDepsFilePath)"
+                      DepsFilePath="$(ProjectDepsFilePath)"
                       TargetFramework="$(TargetFrameworkIdentifier),Version=$(TargetFrameworkVersion)"
                       AssemblyName="$(AssemblyName)"
                       AssemblyVersion="$(Version)"
@@ -96,11 +96,11 @@ Copyright (c) .NET Foundation. All rights reserved.
   <Target Name="GenerateBuildRuntimeConfigurationFiles"
           Condition=" '$(GenerateRuntimeConfigurationFiles)' == 'true'"
           Inputs="$(ProjectAssetsFile);$(UserRuntimeConfig)"
-          Outputs="$(_ProjectRuntimeConfigFilePath);$(_ProjectRuntimeConfigDevFilePath)">
+          Outputs="$(ProjectRuntimeConfigFilePath);$(ProjectRuntimeConfigDevFilePath)">
 
     <GenerateRuntimeConfigurationFiles AssetsFilePath="$(ProjectAssetsFile)"
-                                       RuntimeConfigPath="$(_ProjectRuntimeConfigFilePath)"
-                                       RuntimeConfigDevPath="$(_ProjectRuntimeConfigDevFilePath)"
+                                       RuntimeConfigPath="$(ProjectRuntimeConfigFilePath)"
+                                       RuntimeConfigDevPath="$(ProjectRuntimeConfigDevFilePath)"
                                        RuntimeIdentifier="$(RuntimeIdentifier)"
                                        UserRuntimeConfig="$(UserRuntimeConfig)" />
 


### PR DESCRIPTION
The CLI needs to inspect these properties in order to invoke dependency tools.

@livarcocc @nguerrera 

/cc @dotnet/project-system 

@livarcocc - when the CLI takes the new version of the SDK, you will have to remember to use the new property names.
