### PR TITLE
Stop duplicating default setting of $(ConfigurationName)

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.BeforeCommon.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.BeforeCommon.targets
@@ -19,7 +19,6 @@ Copyright (c) .NET Foundation. All rights reserved.
     <Platform Condition="'$(Platform)'==''">AnyCPU</Platform>
     <PlatformName Condition="'$(PlatformName)' == ''">$(Platform)</PlatformName>
     <Configuration Condition="'$(Configuration)'==''">Debug</Configuration>
-    <ConfigurationName Condition="'$(ConfigurationName)' == ''">$(Configuration)</ConfigurationName>
     <OutputPath Condition="'$(OutputPath)' != '' and !HasTrailingSlash('$(OutputPath)')">$(OutputPath)\</OutputPath>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)' == ''">obj\</BaseIntermediateOutputPath>
     <BaseIntermediateOutputPath Condition="!HasTrailingSlash('$(BaseIntermediateOutputPath)')">$(BaseIntermediateOutputPath)\</BaseIntermediateOutputPath>


### PR DESCRIPTION
We don't use it so there's no need to repeat that line of logic from  Microsoft.Common.CurrentVersion.targets.

@eerhardt Just following up on something we spotted on our call. The common targets do not use ConfigurationName in IntermediateOutputPath either. That part is transcribed correctly using PlatformName and Configuration. As such, we don't actually need ConfigurationName to be set this early, so we can let Microsoft.Common.targets do it later and duplicate one less thing here.
