### PR TITLE
Don't delete Stage0 version of .NET SDK NuGet package from cache

### DIFF
--- a/build/Nuget/Microsoft.NET.Nuget.proj
+++ b/build/Nuget/Microsoft.NET.Nuget.proj
@@ -50,7 +50,7 @@
   <Target Name="InvalidateNuGetCache">
     <!-- Ensure the sha512 files are deleted, which will invalidate all the cache entries, even if the RemoveDir fails -->
     <Delete Files="$(NuGet_Packages)\%(NuSpec.FileName)\**\*.sha512" />
-    <RemoveDir ContinueOnError="true" Directories="$(NuGet_Packages)\%(NuSpec.FileName)\$(Version)" />
+    <RemoveDir Directories="$(NuGet_Packages)\%(NuSpec.FileName)\$(Version)" />
   </Target>
 
   <Target Name="Clean">

--- a/build/Nuget/Microsoft.NET.Nuget.proj
+++ b/build/Nuget/Microsoft.NET.Nuget.proj
@@ -50,7 +50,7 @@
   <Target Name="InvalidateNuGetCache">
     <!-- Ensure the sha512 files are deleted, which will invalidate all the cache entries, even if the RemoveDir fails -->
     <Delete Files="$(NuGet_Packages)\%(NuSpec.FileName)\**\*.sha512" />
-    <RemoveDir ContinueOnError="true" Directories="$(NuGet_Packages)\%(NuSpec.FileName)" />
+    <RemoveDir ContinueOnError="true" Directories="$(NuGet_Packages)\%(NuSpec.FileName)\$(Version)" />
   </Target>
 
   <Target Name="Clean">

--- a/test/Microsoft.NET.TestFramework/TestAsset.cs
+++ b/test/Microsoft.NET.TestFramework/TestAsset.cs
@@ -57,7 +57,7 @@ namespace Microsoft.NET.TestFramework
                         .Descendants(XName.Get("PackageReference", "http://schemas.microsoft.com/developer/msbuild/2003"))
                         .FirstOrDefault(pr => pr.Attribute("Include")?.Value == "Microsoft.NET.Sdk")
                         ?.Element(XName.Get("Version", "http://schemas.microsoft.com/developer/msbuild/2003"))
-                        ?.SetValue(_buildVersion);
+                        ?.SetValue('[' +_buildVersion + ']');
 
                     using (var file = File.CreateText(destFile))
                     {


### PR DESCRIPTION
This fixes #281 and should make the solution work better in Visual Studio when you do a command-line build.

There's an outstanding question of whether we need to surround the version in brackets when we [set it for the test projects](https://github.com/dotnet/sdk/blob/0708a4f3587c7f8feae778ef6af4441777a9ca55/test/Microsoft.NET.TestFramework/TestAsset.cs#L60) in order to be sure that NuGet doesn't pick a different version.

An alternate solution would be to put something like the following in `Common.props`:

``` xml
<NuGetPackageRoot Condition="'$(BuildingInsideVisualStudio)' == 'true'">$(UserProfile)\.nuget\packages\</NuGetPackageRoot>
```

This would get evaluated before the generated NuGet props, and would ensure that the build in Visual Studio always uses the user's package cache, even when a command-line build restores in a context that uses the repo`s packages folder.

I've also included a commit in this PR to update the GUIDs in SDK.sln so that the projects will be loaded with CPS.  This isn't necessary with a change @jinujoseph made last week, but it shouldn't hurt and makes it easier to use the solution until that change makes its way to a build of VS we start using.
