### PR TITLE
Implicitly define compilation constants for target framework

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.BeforeCommon.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.BeforeCommon.targets
@@ -64,4 +64,18 @@ Copyright (c) .NET Foundation. All rights reserved.
     <PublishDir Condition="'$(PublishDir)' == ''">$(OutputPath)$(PublishDirName)\</PublishDir>
   </PropertyGroup>
 
+  <PropertyGroup Condition=" '$(DisableImplicitFrameworkDefines)' != 'true' and '$(TargetFrameworkIdentifier)' != '.NETPortable'">
+    <_FrameworkIdentifierForImplicitDefine>$(TargetFrameworkIdentifier.Replace('.', '').ToUpper())</_FrameworkIdentifierForImplicitDefine>
+    <_FrameworkIdentifierForImplicitDefine Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework'">NET</_FrameworkIdentifierForImplicitDefine>
+
+    <_FrameworkVersionForImplicitDefine Condition="$(TargetFrameworkVersion.StartsWith('v'))">$(TargetFrameworkVersion.SubString(1))</_FrameworkVersionForImplicitDefine>
+    <_FrameworkVersionForImplicitDefine Condition="!$(TargetFrameworkVersion.StartsWith('v'))">$(TargetFrameworkVersion)</_FrameworkVersionForImplicitDefine>
+
+    <_FrameworkVersionForImplicitDefine>$(_FrameworkVersionForImplicitDefine.Replace('.', '_'))</_FrameworkVersionForImplicitDefine>
+    
+    <_FrameworkVersionForImplicitDefine Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework'">$(_FrameworkVersionForImplicitDefine.Replace('_', ''))</_FrameworkVersionForImplicitDefine>
+    
+    <DefineConstants>$(DefineConstants);$(_FrameworkIdentifierForImplicitDefine)$(_FrameworkVersionForImplicitDefine)</DefineConstants>
+  </PropertyGroup>
+
 </Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.BeforeCommon.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.BeforeCommon.targets
@@ -65,7 +65,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(DisableImplicitFrameworkDefines)' != 'true' and '$(TargetFrameworkIdentifier)' != '.NETPortable'">
-    <_FrameworkIdentifierForImplicitDefine>$(TargetFrameworkIdentifier.Replace('.', '').ToUpper())</_FrameworkIdentifierForImplicitDefine>
+    <_FrameworkIdentifierForImplicitDefine>$(TargetFrameworkIdentifier.Replace('.', '').ToUpperInvariant())</_FrameworkIdentifierForImplicitDefine>
     <_FrameworkIdentifierForImplicitDefine Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework'">NET</_FrameworkIdentifierForImplicitDefine>
 
     <_FrameworkVersionForImplicitDefine Condition="$(TargetFrameworkVersion.StartsWith('v'))">$(TargetFrameworkVersion.SubString(1))</_FrameworkVersionForImplicitDefine>

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildALibrary.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildALibrary.cs
@@ -7,6 +7,10 @@ using Microsoft.NET.TestFramework.Assertions;
 using Microsoft.NET.TestFramework.Commands;
 using Xunit;
 using static Microsoft.NET.TestFramework.Commands.MSBuildTest;
+using System.Linq;
+using FluentAssertions;
+using System.Xml.Linq;
+using System.Runtime.Versioning;
 
 namespace Microsoft.NET.Build.Tests
 {
@@ -59,6 +63,116 @@ namespace Microsoft.NET.Build.Tests
                 .Execute()
                 .Should()
                 .Pass();
+        }
+
+        [Theory]
+        [InlineData(".NETStandard,Version=v1.0", new[] { "NETSTANDARD1_0" })]
+        [InlineData("netstandard1.3", new[] { "NETSTANDARD1_3" })]
+        [InlineData("netstandard1.6", new[] { "NETSTANDARD1_6" })]
+        [InlineData("netstandard20", new[] { "NETSTANDARD2_0" })]
+        [InlineData("net45", new[] { "NET45" })]
+        [InlineData("net461", new[] { "NET461" })]
+        [InlineData("netcoreapp1.0", new[] { "NETCOREAPP1_0" })]
+        [InlineData(".NETPortable,Version=v4.5,Profile=Profile78", new string[] { })]
+        [InlineData(".NETFramework,Version=v4.0,Profile=Client", new string[] { "NET40" })]
+        [InlineData("Xamarin.iOS,Version=v1.0", new string[] { "XAMARINIOS1_0" })]
+        [InlineData("UnknownFramework,Version=v3.14", new string[] { "UNKNOWNFRAMEWORK3_14" })]
+        public void It_implicitly_defines_compilation_constants_for_the_target_framework(string targetFramework, string[] expectedDefines)
+        {
+            var testAsset = _testAssetsManager
+                .CopyTestAsset("AppWithLibrary", "ImplicitFrameworkConstants", targetFramework)
+                .WithSource();
+
+            var libraryProjectDirectory = Path.Combine(testAsset.TestRoot, "TestLibrary");
+
+            var buildCommand = new BuildCommand(Stage0MSBuild, libraryProjectDirectory);
+
+            //  Update target framework in project
+            var ns = XNamespace.Get("http://schemas.microsoft.com/developer/msbuild/2003");
+            var project = XDocument.Load(buildCommand.FullPathProjectFile);
+
+            var targetFrameworkProperties = project.Root
+                .Elements(ns + "PropertyGroup")
+                .Elements(ns + "TargetFramework")
+                .ToList();
+
+            targetFrameworkProperties.Count.Should().Be(1);
+
+            bool shouldCompile;
+
+            if (targetFramework.Contains(",Version="))
+            {
+                //  We use the full TFM for frameworks we don't have built-in support for targeting, so we don't want to run the Compile target
+                shouldCompile = false;
+
+                var frameworkName = new FrameworkName(targetFramework);
+
+                var targetFrameworkProperty = targetFrameworkProperties.Single();
+                targetFrameworkProperty.AddBeforeSelf(new XElement(ns + "TargetFrameworkIdentifier", frameworkName.Identifier));
+                targetFrameworkProperty.AddBeforeSelf(new XElement(ns + "TargetFrameworkVersion", "v" + frameworkName.Version.ToString()));
+                if (!string.IsNullOrEmpty(frameworkName.Profile))
+                {
+                    targetFrameworkProperty.AddBeforeSelf(new XElement(ns + "TargetFrameworkProfile", frameworkName.Profile));
+                }
+
+                //  For the NuGet restore task to work with package references, it needs the TargetFramework property to be set.
+                //  Otherwise we would just remove the property.
+                targetFrameworkProperty.SetValue(targetFramework);
+            }
+            else
+            {
+                shouldCompile = true;
+                targetFrameworkProperties.Single().SetValue(targetFramework);
+            }
+
+            using (var file = File.CreateText(buildCommand.FullPathProjectFile))
+            {
+                project.Save(file);
+            }
+
+            testAsset.Restore(relativePath: "TestLibrary");
+
+            //  Override build target to write out DefineConstants value to a file in the output directory
+            Directory.CreateDirectory(buildCommand.GetBaseIntermediateDirectory().FullName);
+            string injectTargetPath = Path.Combine(
+                buildCommand.GetBaseIntermediateDirectory().FullName,
+                Path.GetFileName(buildCommand.ProjectFile) + ".WriteDefinedConstants.g.targets");
+
+            string injectTargetContents =
+@"<Project ToolsVersion=`14.0` xmlns=`http://schemas.microsoft.com/developer/msbuild/2003`>
+  <Target Name=`Build` " + (shouldCompile ? "DependsOnTargets=`Compile`" : "") + @">
+    <WriteLinesToFile
+      File=`$(OutputPath)\DefinedConstants.txt`
+      Lines=`$(DefineConstants)`
+      Overwrite=`true`
+      Encoding=`Unicode`
+      />
+  </Target>
+</Project>";
+            injectTargetContents = injectTargetContents.Replace('`', '"');
+
+            File.WriteAllText(injectTargetPath, injectTargetContents);
+
+            //  Build project
+            var outputDirectory = buildCommand.GetOutputDirectory(targetFramework);
+            outputDirectory.Create();
+
+            buildCommand
+                .Execute()
+                .Should()
+                .Pass();
+
+            //  Verify expected DefineConstants
+            outputDirectory.Should().OnlyHaveFiles(new[] {
+                "DefinedConstants.txt",
+            });
+
+            var definedConstants = File.ReadAllLines(Path.Combine(outputDirectory.FullName, "DefinedConstants.txt"))
+                .Select(line => line.Trim())
+                .Where(line => !string.IsNullOrEmpty(line))
+                .ToList();
+
+            definedConstants.Should().BeEquivalentTo(new[] { "DEBUG", "TRACE" }.Concat(expectedDefines).ToArray());
         }
     }
 }

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildALibrary.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildALibrary.cs
@@ -78,7 +78,7 @@ namespace Microsoft.NET.Build.Tests
         [InlineData(".NETFramework,Version=v4.0,Profile=Client", new string[] { "NET40" }, false)]
         [InlineData("Xamarin.iOS,Version=v1.0", new string[] { "XAMARINIOS1_0" }, false)]
         [InlineData("UnknownFramework,Version=v3.14", new string[] { "UNKNOWNFRAMEWORK3_14" }, false)]
-        public void It_implicitly_defines_compilation_constants_for_the_target_framework(string targetFramework, string[] expectedDefines, bool buildOnlyOnWindows = false)
+        public void It_implicitly_defines_compilation_constants_for_the_target_framework(string targetFramework, string[] expectedDefines, bool buildOnlyOnWindows)
         {
             var testAsset = _testAssetsManager
                 .CopyTestAsset("AppWithLibrary", "ImplicitFrameworkConstants", targetFramework)

--- a/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPreserveCompilationContext.cs
+++ b/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPreserveCompilationContext.cs
@@ -61,7 +61,17 @@ namespace Microsoft.NET.Publish.Tests
                 {
                     var dependencyContext = new DependencyContextJsonReader().Read(depsJsonFileStream);
 
-                    dependencyContext.CompilationOptions.Defines.Should().BeEquivalentTo(new[] { "DEBUG", "TRACE" });
+                    string[] expectedDefines;
+                    if (targetFramework == "net46")
+                    {
+                        expectedDefines = new[] { "DEBUG", "TRACE", "NET46" };
+                    }
+                    else
+                    {
+                        expectedDefines = new[] { "DEBUG", "TRACE", "NETCOREAPP1_0" };
+                    }
+
+                    dependencyContext.CompilationOptions.Defines.Should().BeEquivalentTo(expectedDefines);
                     dependencyContext.CompilationOptions.LanguageVersion.Should().Be("");
                     dependencyContext.CompilationOptions.Platform.Should().Be("AnyCPU");
                     dependencyContext.CompilationOptions.Optimize.Should().Be(false);

--- a/test/Microsoft.NET.TestFramework/Commands/BuildCommand.cs
+++ b/test/Microsoft.NET.TestFramework/Commands/BuildCommand.cs
@@ -31,5 +31,11 @@ namespace Microsoft.NET.TestFramework.Commands
             string output = Path.Combine(ProjectRootPath, "bin", "Debug", targetFramework);
             return new DirectoryInfo(output);
         }
+
+        public DirectoryInfo GetBaseIntermediateDirectory()
+        {
+            string output = Path.Combine(ProjectRootPath, "obj");
+            return new DirectoryInfo(output);
+        }
     }
 }


### PR DESCRIPTION
Fixes #195

The project.json based .NET CLI tooling puts underscores in place of periods in the version numbers for some framework identifiers (`NETSTANDARD1_3`), but not others (`NETCORE45`).  It also uses `NET` as an abbreviation for `.NETFRAMEWORK`.

Here I've simply defined all possibilities, so a library targeting .NET 4.6.1 will have these defines: `NET461`, `NETFRAMEWORK461`, and `NETFRAMEWORK4_6_1`.  A library targeting .NET Standard 2.0 will have `NETSTANDARD20` and `NETSTANDARD2_0` defined.

I also haven't yet figured out a good way to test this.  It gets tested incidentally as part of the preserve compilation context tests.  To directly test it I'd like to be able to build a project and get the list of compilation constants that were used.  Possible ways of doing this could be to parse the log file (ugh!) or to evaluate the project with the MSBuild APIs and get the value of the `DefineConstants` property.
