### PR TITLE
Add CrossPlatformExecutable project capability for .NETCoreApp

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.targets
@@ -214,7 +214,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   ============================================================
   -->
 
-  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' and '$(OutputType)' == 'Exe'">
     <ProjectCapability Include="CrossPlatformExecutable" />
   </ItemGroup>
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.targets
@@ -208,6 +208,16 @@ Copyright (c) .NET Foundation. All rights reserved.
   -->
   <Target Name="GetTargetFrameworkProperties" Returns="TargetFramework=$(TargetFramework)" />
 
+  <!--
+  ============================================================
+                                         Project Capabilities
+  ============================================================
+  -->
+
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
+    <ProjectCapability Include="CrossPlatformExecutable" />
+  </ItemGroup>
+
   <Import Project="$(MSBuildThisFileDirecotry)Microsoft.NET.DisableStandardFrameworkResolution.targets" Condition="'$(DisableStandardFrameworkResolution)' == 'true'" />
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.NET.GenerateAssemblyInfo.targets" />
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.NET.Publish.targets" />


### PR DESCRIPTION
@srivatsn 

Fix #245 but adds it to targets and does not follow #246, which wants to have nuget folders per TFM and these in props. I have several unresolved concerns about the latter and we're getting indication that having the capability defined at all is urgent.
