### PR TITLE
Make templates show up under a .NET Core group in VS. 

### DIFF
--- a/src/Templates/ProjectTemplates/CSharp/.NETCore/CSharpClassLibrary/CSharpClassLibrary.csproj
+++ b/src/Templates/ProjectTemplates/CSharp/.NETCore/CSharpClassLibrary/CSharpClassLibrary.csproj
@@ -52,6 +52,7 @@
   <ItemGroup>
     <VSTemplate Include="ClassLibrary.vstemplate">
       <SubType>Designer</SubType>
+      <OutputSubPath>.NET Core</OutputSubPath>
     </VSTemplate>
   </ItemGroup>
   <ItemGroup>

--- a/src/Templates/ProjectTemplates/CSharp/.NETCore/CSharpClassLibrary/ClassLibrary.vstemplate
+++ b/src/Templates/ProjectTemplates/CSharp/.NETCore/CSharpClassLibrary/ClassLibrary.vstemplate
@@ -6,7 +6,7 @@
     <Icon Package="{FAE04EC1-301F-11d3-BF4B-00C04F79EFBC}" ID="4547" />
     <ProjectType>CSharp</ProjectType>
     <RequiredFrameworkVersion>2.0</RequiredFrameworkVersion>
-    <SortOrder>15</SortOrder>
+    <SortOrder>14</SortOrder>
     <NumberOfParentCategoriesToRollUp>1</NumberOfParentCategoriesToRollUp>
     <TemplateID>Microsoft.CSharp.NETCore.ClassLibrary</TemplateID>
     <CreateNewFolder>true</CreateNewFolder>

--- a/src/Templates/ProjectTemplates/CSharp/.NETCore/CSharpConsoleApplication/CSharpConsoleApplication.csproj
+++ b/src/Templates/ProjectTemplates/CSharp/.NETCore/CSharpConsoleApplication/CSharpConsoleApplication.csproj
@@ -53,6 +53,7 @@
   <ItemGroup>
     <VSTemplate Include="ConsoleApplication.vstemplate">
       <SubType>Designer</SubType>
+      <OutputSubPath>.NET Core</OutputSubPath>
     </VSTemplate>
   </ItemGroup>
   <ItemGroup>

--- a/src/Templates/ProjectTemplates/CSharp/.NETCore/CSharpUnitTest/CSharpUnitTest.csproj
+++ b/src/Templates/ProjectTemplates/CSharp/.NETCore/CSharpUnitTest/CSharpUnitTest.csproj
@@ -53,6 +53,7 @@
   <ItemGroup>
     <VSTemplate Include="UnitTest.vstemplate">
       <SubType>Designer</SubType>
+      <OutputSubPath>.NET Core</OutputSubPath>
     </VSTemplate>
   </ItemGroup>
   <ItemGroup>

--- a/src/Templates/ProjectTemplates/CSharp/.NETCore/CSharpUnitTest/UnitTest.vstemplate
+++ b/src/Templates/ProjectTemplates/CSharp/.NETCore/CSharpUnitTest/UnitTest.vstemplate
@@ -7,7 +7,6 @@
     <ProjectType>CSharp</ProjectType>
     <RequiredFrameworkVersion>2.0</RequiredFrameworkVersion>
     <SortOrder>12</SortOrder>
-    <NumberOfParentCategoriesToRollUp>1</NumberOfParentCategoriesToRollUp>
     <TemplateID>Microsoft.CSharp.NETCore.UnitTest</TemplateID>
     <CreateNewFolder>true</CreateNewFolder>
     <CreateInPlace>true</CreateInPlace>

--- a/src/Templates/ProjectTemplates/VisualBasic/.NETCore/VisualBasicClassLibrary/ClassLibrary.vstemplate
+++ b/src/Templates/ProjectTemplates/VisualBasic/.NETCore/VisualBasicClassLibrary/ClassLibrary.vstemplate
@@ -6,7 +6,7 @@
     <Icon Package="{164B10B9-B200-11D0-8C61-00A0C91E29D5}" ID="4500" />
     <ProjectType>VisualBasic</ProjectType>
     <RequiredFrameworkVersion>2.0</RequiredFrameworkVersion>
-    <SortOrder>15</SortOrder>
+    <SortOrder>14</SortOrder>
     <NumberOfParentCategoriesToRollUp>1</NumberOfParentCategoriesToRollUp>
     <TemplateID>Microsoft.VisualBasic.NETCore.ClassLibrary</TemplateID>
     <CreateNewFolder>true</CreateNewFolder>

--- a/src/Templates/ProjectTemplates/VisualBasic/.NETCore/VisualBasicClassLibrary/VisualBasicClassLibrary.csproj
+++ b/src/Templates/ProjectTemplates/VisualBasic/.NETCore/VisualBasicClassLibrary/VisualBasicClassLibrary.csproj
@@ -53,6 +53,7 @@
   <ItemGroup>
     <VSTemplate Include="ClassLibrary.vstemplate">
       <SubType>Designer</SubType>
+      <OutputSubPath>.NET Core</OutputSubPath>      
     </VSTemplate>
   </ItemGroup>
   <ItemGroup>

--- a/src/Templates/ProjectTemplates/VisualBasic/.NETCore/VisualBasicConsoleApplication/VisualBasicConsoleApplication.csproj
+++ b/src/Templates/ProjectTemplates/VisualBasic/.NETCore/VisualBasicConsoleApplication/VisualBasicConsoleApplication.csproj
@@ -53,6 +53,7 @@
   <ItemGroup>
     <VSTemplate Include="ConsoleApplication.vstemplate">
       <SubType>Designer</SubType>
+      <OutputSubPath>.NET Core</OutputSubPath>      
     </VSTemplate>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Also ensure that unit test projects don't roll up and that NETStandard template shows up higher than the framework class library template in the rollup.

@dotnet/project-system 

Fixes #230
