### PR TITLE
Re-design "type: platform" for MSBuild.

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/Constants.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/Constants.cs
@@ -1,0 +1,10 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.NET.Build.Tasks.UnitTests
+{
+    internal static class Constants
+    {
+        public const string DefaultPlatformLibrary = "Microsoft.NETCore.App";
+    }
+}

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenADependencyContextBuilder.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenADependencyContextBuilder.cs
@@ -31,18 +31,22 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             ITaskItem[] satelliteAssemblies)
         {
             LockFile lockFile = TestLockFiles.GetLockFile(mainProjectName);
+
             SingleProjectInfo mainProject = SingleProjectInfo.Create(
                 "/usr/Path",
                 mainProjectName,
                 mainProjectVersion,
                 satelliteAssemblies ?? new ITaskItem[] { });
 
+            ProjectContext projectContext = lockFile.CreateProjectContext(
+                FrameworkConstants.CommonFrameworks.NetCoreApp10,
+                runtime,
+                Constants.DefaultPlatformLibrary);
+
             DependencyContext dependencyContext = new DependencyContextBuilder().Build(
                 mainProject,
-                compilationOptions,
-                lockFile,
-                FrameworkConstants.CommonFrameworks.NetCoreApp10,
-                runtime);
+                projectContext,
+                compilationOptions);
 
             JObject result = Save(dependencyContext);
             JObject baseline = ReadJson($"{baselineFileName}.deps.json");

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAProjectContext.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAProjectContext.cs
@@ -20,7 +20,8 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             LockFile lockFile = TestLockFiles.GetLockFile("dependencies.withgraphs");
             ProjectContext projectContext = lockFile.CreateProjectContext(
                FrameworkConstants.CommonFrameworks.NetStandard16,
-               null);
+               null,
+               Constants.DefaultPlatformLibrary);
 
             IEnumerable<string> privateAssetPackageIds = new[] { "Microsoft.Extensions.Logging.Abstractions" };
             IDictionary<string, LockFileTargetLibrary> libraryLookup =

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAPublishAssembliesResolver.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAPublishAssembliesResolver.cs
@@ -23,7 +23,8 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             LockFile lockFile = TestLockFiles.GetLockFile(projectName);
             ProjectContext projectContext = lockFile.CreateProjectContext(
                 FrameworkConstants.CommonFrameworks.NetCoreApp10,
-                runtime);
+                runtime,
+                Constants.DefaultPlatformLibrary);
 
             IEnumerable<ResolvedFile> resolvedFiles = new PublishAssembliesResolver(new MockPackageResolver())
                 .Resolve(projectContext);

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/Microsoft.NET.Build.Tasks.UnitTests.csproj
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/Microsoft.NET.Build.Tasks.UnitTests.csproj
@@ -59,6 +59,7 @@
     <Compile Include="GivenAPublishAssembliesResolver.cs" />
     <Compile Include="GivenADependencyContextBuilder.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Constants.cs" />
     <Compile Include="TestLockFiles.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/GenerateDepsFile.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/GenerateDepsFile.cs
@@ -31,6 +31,8 @@ namespace Microsoft.NET.Build.Tasks
 
         public string RuntimeIdentifier { get; set; }
 
+        public string PlatformLibraryName { get; set; }
+
         [Required]
         public string AssemblyName { get; set; }
 
@@ -50,15 +52,17 @@ namespace Microsoft.NET.Build.Tasks
             CompilationOptions compilationOptions = CompilationOptionsConverter.ConvertFrom(CompilerOptions);
             SingleProjectInfo mainProject = SingleProjectInfo.Create(ProjectPath, AssemblyName, AssemblyVersion, AssemblySatelliteAssemblies);
             IEnumerable<string> privateAssets = PackageReferenceConverter.GetPackageIds(PrivateAssetsPackageReferences);
+            ProjectContext projectContext = lockFile.CreateProjectContext(
+                NuGetUtils.ParseFrameworkName(TargetFramework),
+                RuntimeIdentifier,
+                PlatformLibraryName);
 
             DependencyContext dependencyContext = new DependencyContextBuilder()
                 .WithPrivateAssets(privateAssets)
                 .Build(
                     mainProject,
-                    compilationOptions,
-                    lockFile,
-                    NuGetUtils.ParseFrameworkName(TargetFramework),
-                    RuntimeIdentifier);
+                    projectContext,
+                    compilationOptions);
 
             var writer = new DependencyContextWriter();
             using (var fileStream = File.Create(DepsFilePath))

--- a/src/Tasks/Microsoft.NET.Build.Tasks/GenerateRuntimeConfigurationFiles.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/GenerateRuntimeConfigurationFiles.cs
@@ -34,6 +34,8 @@ namespace Microsoft.NET.Build.Tasks
 
         public string RuntimeIdentifier { get; set; }
 
+        public string PlatformLibraryName { get; set; }
+
         public string UserRuntimeConfig { get; set; }
 
         protected override void ExecuteCore()
@@ -41,7 +43,8 @@ namespace Microsoft.NET.Build.Tasks
             LockFile lockFile = new LockFileCache(BuildEngine4).GetLockFile(AssetsFilePath);
             ProjectContext projectContext = lockFile.CreateProjectContext(
                 NuGetUtils.ParseFrameworkName(TargetFramework),
-                RuntimeIdentifier);
+                RuntimeIdentifier,
+                PlatformLibraryName);
 
             WriteRuntimeConfig(projectContext);
 
@@ -66,8 +69,7 @@ namespace Microsoft.NET.Build.Tasks
         {
             if (projectContext.IsPortable)
             {
-                var platformLibrary = projectContext.LockFileTarget.GetPlatformLibrary();
-
+                var platformLibrary = projectContext.PlatformLibrary;
                 if (platformLibrary != null)
                 {
                     RuntimeConfigFramework framework = new RuntimeConfigFramework();

--- a/src/Tasks/Microsoft.NET.Build.Tasks/LockFileExtensions.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/LockFileExtensions.cs
@@ -13,9 +13,10 @@ namespace Microsoft.NET.Build.Tasks
     public static class LockFileExtensions
     {
         public static ProjectContext CreateProjectContext(
-            this LockFile lockFile, 
-            NuGetFramework framework, 
-            string runtime)
+            this LockFile lockFile,
+            NuGetFramework framework,
+            string runtime,
+            string platformLibraryName)
         {
             if (lockFile == null)
             {
@@ -40,31 +41,26 @@ namespace Microsoft.NET.Build.Tasks
                     $" and RuntimeIdentifier='{runtime}'.");
             }
 
-            return new ProjectContext(lockFile, lockFileTarget);
+            return new ProjectContext(lockFile, lockFileTarget, platformLibraryName);
         }
 
-        public static bool IsPortable(this LockFileTarget lockFileTarget)
+        public static LockFileTargetLibrary GetLibrary(this LockFileTarget lockFileTarget, string libraryName)
         {
-            return string.IsNullOrEmpty(lockFileTarget.RuntimeIdentifier) &&
-                lockFileTarget.GetPlatformLibrary() != null;
-        }
+            if (string.IsNullOrEmpty(libraryName))
+            {
+                return null;
+            }
 
-        public static LockFileTargetLibrary GetPlatformLibrary(this LockFileTarget lockFileTarget)
-        {
-            // TODO: https://github.com/dotnet/sdk/issues/17 get this from the lock file
-            var platformPackageName = "Microsoft.NETCore.App";
-            var platformLibrary = lockFileTarget
+            return lockFileTarget
                 .Libraries
-                .FirstOrDefault(e => e.Name.Equals(platformPackageName, StringComparison.OrdinalIgnoreCase));
-
-            return platformLibrary;
+                .FirstOrDefault(e => e.Name.Equals(libraryName, StringComparison.OrdinalIgnoreCase));
         }
 
         public static HashSet<string> GetPlatformExclusionList(
             this LockFileTarget lockFileTarget,
+            LockFileTargetLibrary platformLibrary,
             IDictionary<string, LockFileTargetLibrary> libraryLookup)
         {
-            var platformLibrary = lockFileTarget.GetPlatformLibrary();
             var exclusionList = new HashSet<string>();
 
             exclusionList.Add(platformLibrary.Name);

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ProjectContext.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ProjectContext.cs
@@ -13,18 +13,22 @@ namespace Microsoft.NET.Build.Tasks
     {
         private readonly LockFile _lockFile;
         private readonly LockFileTarget _lockFileTarget;
+        private readonly string _platformLibraryName;
 
         public bool IsPortable { get; }
+        public LockFileTargetLibrary PlatformLibrary { get; }
 
         public LockFile LockFile => _lockFile;
         public LockFileTarget LockFileTarget => _lockFileTarget;
 
-        public ProjectContext(LockFile lockFile, LockFileTarget lockFileTarget)
+        public ProjectContext(LockFile lockFile, LockFileTarget lockFileTarget, string platformLibraryName)
         {
             _lockFile = lockFile;
             _lockFileTarget = lockFileTarget;
+            _platformLibraryName = platformLibraryName;
 
-            IsPortable = _lockFileTarget.IsPortable();
+            PlatformLibrary = _lockFileTarget.GetLibrary(_platformLibraryName);
+            IsPortable = PlatformLibrary != null && string.IsNullOrEmpty(_lockFileTarget.RuntimeIdentifier);
         }
 
         public IEnumerable<LockFileTargetLibrary> GetRuntimeLibraries(IEnumerable<string> privateAssetPackageIds)
@@ -37,7 +41,7 @@ namespace Microsoft.NET.Build.Tasks
 
             if (IsPortable)
             {
-                allExclusionList.UnionWith(_lockFileTarget.GetPlatformExclusionList(libraryLookup));
+                allExclusionList.UnionWith(_lockFileTarget.GetPlatformExclusionList(PlatformLibrary, libraryLookup));
             }
 
             if (privateAssetPackageIds?.Any() == true)

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePublishAssemblies.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePublishAssemblies.cs
@@ -29,6 +29,8 @@ namespace Microsoft.NET.Build.Tasks
 
         public string RuntimeIdentifier { get; set; }
 
+        public string PlatformLibraryName { get; set; }
+
         public ITaskItem[] PrivateAssetsPackageReferences { get; set; }
 
         /// <summary>
@@ -48,7 +50,8 @@ namespace Microsoft.NET.Build.Tasks
 
             ProjectContext projectContext = lockFile.CreateProjectContext(
                 NuGetUtils.ParseFrameworkName(TargetFramework),
-                RuntimeIdentifier);
+                RuntimeIdentifier,
+                PlatformLibraryName);
 
             IEnumerable<ResolvedFile> resolvedAssemblies = 
                 new PublishAssembliesResolver(new NuGetPackageResolver(nugetPathContext))

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Publish.targets
@@ -218,12 +218,14 @@ Copyright (c) .NET Foundation. All rights reserved.
     -->
   <UsingTask TaskName="ResolvePublishAssemblies" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
   <Target Name="RunResolvePublishAssemblies"
-          DependsOnTargets="ComputePrivateAssetsPackageReferences">
+          DependsOnTargets="ComputePrivateAssetsPackageReferences;
+                            _DefaultMicrosoftNETPlatformLibrary">
 
     <ResolvePublishAssemblies ProjectPath="$(MSBuildProjectFullPath)"
                               AssetsFilePath="$(ProjectAssetsFile)"
                               TargetFramework="$(TargetFrameworkMoniker)"
                               RuntimeIdentifier="$(RuntimeIdentifier)"
+                              PlatformLibraryName="$(MicrosoftNETPlatformLibrary)"
                               PrivateAssetsPackageReferences="@(PrivateAssetsPackageReference)">
 
       <Output TaskParameter="AssembliesToPublish" ItemName="ResolvedAssembliesToPublish" />
@@ -422,7 +424,8 @@ Copyright (c) .NET Foundation. All rights reserved.
     ============================================================
     -->
   <Target Name="GeneratePublishDependencyFile"
-          DependsOnTargets="ComputePrivateAssetsPackageReferences"
+          DependsOnTargets="ComputePrivateAssetsPackageReferences;
+                            _DefaultMicrosoftNETPlatformLibrary"
           Condition="'$(GenerateDependencyFile)' == 'true'">
 
     <PropertyGroup>
@@ -437,6 +440,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                       AssemblyVersion="$(Version)"
                       AssemblySatelliteAssemblies="@(IntermediateSatelliteAssembliesWithTargetPath)"
                       RuntimeIdentifier="$(RuntimeIdentifier)"
+                      PlatformLibraryName="$(MicrosoftNETPlatformLibrary)"
                       CompilerOptions="@(DependencyFileCompilerOptions)"
                       PrivateAssetsPackageReferences="@(PrivateAssetsPackageReference)" />
 
@@ -474,6 +478,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     -->
 
   <Target Name="GeneratePublishRuntimeConfigurationFile"
+          DependsOnTargets="_DefaultMicrosoftNETPlatformLibrary"
           Condition="'$(GenerateRuntimeConfigurationFiles)' == 'true'">
 
     <PropertyGroup>
@@ -484,6 +489,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                                        TargetFramework="$(TargetFrameworkMoniker)"
                                        RuntimeConfigPath="$(PublishRuntimeConfigFilePath)"
                                        RuntimeIdentifier="$(RuntimeIdentifier)"
+                                       PlatformLibraryName="$(MicrosoftNETPlatformLibrary)"
                                        UserRuntimeConfig="$(UserRuntimeConfig)" />
 
   </Target>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.targets
@@ -65,6 +65,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     -->
 
   <Target Name="GenerateBuildDependencyFile"
+          DependsOnTargets="_DefaultMicrosoftNETPlatformLibrary"
           Condition=" '$(GenerateDependencyFile)' == 'true'"
           Inputs="$(ProjectAssetsFile)"
           Outputs="$(ProjectDepsFilePath)">
@@ -81,6 +82,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                       AssemblyVersion="$(Version)"
                       AssemblySatelliteAssemblies="@(IntermediateSatelliteAssembliesWithTargetPath)"
                       RuntimeIdentifier="$(RuntimeIdentifier)"
+                      PlatformLibraryName="$(MicrosoftNETPlatformLibrary)"
                       CompilerOptions="@(DependencyFileCompilerOptions)" />
 
   </Target>
@@ -94,6 +96,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     -->
 
   <Target Name="GenerateBuildRuntimeConfigurationFiles"
+          DependsOnTargets="_DefaultMicrosoftNETPlatformLibrary"
           Condition=" '$(GenerateRuntimeConfigurationFiles)' == 'true'"
           Inputs="$(ProjectAssetsFile);$(UserRuntimeConfig)"
           Outputs="$(ProjectRuntimeConfigFilePath);$(ProjectRuntimeConfigDevFilePath)">
@@ -103,6 +106,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                                        RuntimeConfigPath="$(ProjectRuntimeConfigFilePath)"
                                        RuntimeConfigDevPath="$(ProjectRuntimeConfigDevFilePath)"
                                        RuntimeIdentifier="$(RuntimeIdentifier)"
+                                       PlatformLibraryName="$(MicrosoftNETPlatformLibrary)"
                                        UserRuntimeConfig="$(UserRuntimeConfig)" />
 
   </Target>
@@ -149,18 +153,17 @@ Copyright (c) .NET Foundation. All rights reserved.
     </When>
   </Choose>
 
+  <!--
+    ============================================================
+                    CoreGenerateSatelliteAssemblies
+    ============================================================
+    -->
   <PropertyGroup>
     <CreateSatelliteAssembliesDependsOn>
       $(CreateSatelliteAssembliesDependsOn);
       CoreGenerateSatelliteAssemblies
     </CreateSatelliteAssembliesDependsOn>
   </PropertyGroup>
-
-  <!--
-    ============================================================
-                    CoreGenerateSatelliteAssemblies
-    ============================================================
--->
 
   <Target Name="CoreGenerateSatelliteAssemblies"
           Inputs="$(MSBuildAllProjects);@(_SatelliteAssemblyResourceInputs);$(IntermediateOutputPath)$(TargetName)$(TargetExt)"
@@ -193,7 +196,24 @@ Copyright (c) .NET Foundation. All rights reserved.
       <Output TaskParameter="OutputAssembly" ItemName="FileWrites"/>
     </GenerateSatelliteAssemblies>
   </Target>
-  
+
+  <!--
+  ============================================================
+                           _DefaultMicrosoftNETPlatformLibrary
+
+  .NET Core apps can have shared frameworks that are pre-installed on the target machine, thus the app is "portable"
+  to any machine that already has the shared framework installed. In order to enable this, a "platform" library
+  has to be declared. The platform library and its dependencies will be excluded from the runtime assemblies.
+  ============================================================
+  -->
+  <Target Name="_DefaultMicrosoftNETPlatformLibrary">
+    
+    <PropertyGroup Condition="'$(MicrosoftNETPlatformLibrary)' == ''">
+      <MicrosoftNETPlatformLibrary Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">Microsoft.NETCore.App</MicrosoftNETPlatformLibrary>
+    </PropertyGroup>
+    
+  </Target>
+
   <!--
   ============================================================
                                  GetTargetFrameworkProperties


### PR DESCRIPTION
Instead of relying on a library being marked as "type: platform", we now have an MSBuild property that gives the name of the platform library.

By default, .NET Core projects use 'Microsoft.NETCore.App' for the platform library, but users or other nupkgs can set the property, if necessary.

Fix #17 

@nguerrera @livarcocc @piotrpMSFT 

/cc @dotnet/project-system 
