### PR TITLE
Remove unnecessary CLI nuget feed

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -8,7 +8,6 @@
     <add key="dotnet-core" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
     <add key="roslyn-master-nightly" value="https://dotnet.myget.org/F/roslyn-master-nightly/api/v3/index.json" />
     <add key="roslyn-tools" value="https://dotnet.myget.org/F/roslyn-tools/api/v3/index.json" />
-    <add key="dotnet-cli" value="https://dotnet.myget.org/F/dotnet-cli/api/v3/index.json" />
     <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
There had been a bad package on this feed and we shouldn't even need it.

I'm still seeing another failure locally with or without this change, so I'm also wanting to see where we stand with Jenkins.

@srivatsn @dotnet/project-system 
