### PR TITLE
Fix build warnings on MacOS and Linux

### DIFF
--- a/build/build.proj
+++ b/build/build.proj
@@ -40,8 +40,8 @@
       <ProjectToRestore3 Include="test\Microsoft.NET.Publish.Tests\Microsoft.NET.Publish.Tests.csproj" />
     </ItemGroup>
 
-    <!-- work around https://github.com/dotnet/sdk/issues/203 by passing in /p:SkipInvalidConfigurations=true;_InvalidConfigurationWarning=false -->
-    <Exec Command="$(DotNetTool) restore3 %(ProjectToRestore3.Identity) /v:minimal /p:SkipInvalidConfigurations=true;_InvalidConfigurationWarning=false"
+    <!-- work around https://github.com/dotnet/sdk/issues/203 by passing in /p:SkipInvalidConfigurations=true /p:_InvalidConfigurationWarning=false -->
+    <Exec Command="$(DotNetTool) restore3 %(ProjectToRestore3.Identity) /v:minimal /p:SkipInvalidConfigurations=true /p:_InvalidConfigurationWarning=false"
           Condition="'$(BuildTemplates)' != 'true'"
           WorkingDirectory="$(RepositoryRootDirectory)"
           />


### PR DESCRIPTION
The workaround to silence false invalid configuration warnings was effectively only half applied on Unix-based platforms. The issue is that a semicolon is treated by the shell as a command line separator so `dotnet msbuild /p:X=Y;Z=W` runs `dotnet msbuild /p:X=Y` then `Z=W`. The second command is valid and just sets the shell variable Z to W. 

:trollface: 

@dotnet/project-system for review

@piotrpMSFT @livarcocc FYI, this may lead to some support issues for folks passing semicolon-delimited msbuild properties to dotnet commands (if it hasn't already). There's nothing the CLI can do since the commands are separated by the shell. The user has to use multiple independent /p args or add quotes.
