### PR TITLE
Removing Program.cs from Unit Test template for .NET core.

### DIFF
--- a/src/Templates/ProjectTemplates/CSharp/.NETCore/CSharpUnitTest/CSharpUnitTest.csproj
+++ b/src/Templates/ProjectTemplates/CSharp/.NETCore/CSharpUnitTest/CSharpUnitTest.csproj
@@ -58,7 +58,6 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="UnitTest1.cs" />
-    <None Include="Program.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />

--- a/src/Templates/ProjectTemplates/CSharp/.NETCore/CSharpUnitTest/Program.cs
+++ b/src/Templates/ProjectTemplates/CSharp/.NETCore/CSharpUnitTest/Program.cs
@@ -1,9 +1,0 @@
-﻿using System;
-
-class Program
-{
-    static void Main(string[] args)
-    {
-        Console.WriteLine("Hello World!");
-    }
-}

--- a/src/Templates/ProjectTemplates/CSharp/.NETCore/CSharpUnitTest/ProjectTemplate.csproj
+++ b/src/Templates/ProjectTemplates/CSharp/.NETCore/CSharpUnitTest/ProjectTemplate.csproj
@@ -19,8 +19,8 @@
       <Version>$$buildversion$$</Version>
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-  <PackageReference Include="Microsoft.TestPlatform.TestHost">
-      <Version>15.0.0-preview-20161012-02</Version>
+  <PackageReference Include="Microsoft.NET.Test.Sdk">
+      <Version>15.0.0-preview-20161024-02</Version>
     </PackageReference>
   <PackageReference Include="MSTest.TestAdapter">
       <Version>1.1.3-preview</Version>

--- a/src/Templates/ProjectTemplates/CSharp/.NETCore/CSharpUnitTest/UnitTest.vstemplate
+++ b/src/Templates/ProjectTemplates/CSharp/.NETCore/CSharpUnitTest/UnitTest.vstemplate
@@ -16,8 +16,7 @@
   </TemplateData>
   <TemplateContent>
     <Project File="Project.csproj" ReplaceParameters="true">
-      <ProjectItem ReplaceParameters="true" OpenInEditor="true">UnitTest1.cs</ProjectItem> 
-      <ProjectItem ReplaceParameters="true" OpenInEditor="false">Program.cs</ProjectItem>      
+      <ProjectItem ReplaceParameters="true" OpenInEditor="true">UnitTest1.cs</ProjectItem>
     </Project>
   </TemplateContent>
 </VSTemplate>


### PR DESCRIPTION
1. Removing the Program.cs from the Unit Test template for .NET core for CSharp.
2. Updating the reference to Microsoft.NET.Test.Sdk package which brings in the targets for auto-generating the Program.cs.
