### PR TITLE
Infer PlatformTarget from RuntimeIdentifier

### DIFF
--- a/TestAssets/TestProjects/CompilationContext/TestApp/TestApp.csproj
+++ b/TestAssets/TestProjects/CompilationContext/TestApp/TestApp.csproj
@@ -5,6 +5,7 @@
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net46;netcoreapp1.0</TargetFrameworks>
+    <RuntimeIdentifier>win7-x86</RuntimeIdentifier>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="**\*.cs" />

--- a/TestAssets/TestProjects/DesktopMinusRid/DesktopMinusRid.csproj
+++ b/TestAssets/TestProjects/DesktopMinusRid/DesktopMinusRid.csproj
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" />
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net46</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="**\*.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Sdk">
+      <Version>0.0</Version>
+    </PackageReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  
+  <!-- So we can check if PlatformTarget was inferred via AssemblyDescription -->
+  <PropertyGroup>
+     <Description>PlatformTarget=$(PlatformTarget)</Description>
+  </PropertyGroup>
+</Project>

--- a/TestAssets/TestProjects/DesktopMinusRid/Program.cs
+++ b/TestAssets/TestProjects/DesktopMinusRid/Program.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Diagnostics;
+
+namespace TestApp
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+        }
+    }
+}

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Microsoft.NET.Build.Tasks.csproj
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Microsoft.NET.Build.Tasks.csproj
@@ -71,6 +71,9 @@
     <None Include="buildCrossTargeting\Microsoft.NET.Sdk.targets">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="build\Microsoft.NET.RuntimeIdentifierInference.targets">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="build\Microsoft.NET.DisableStandardFrameworkResolution.targets">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.RuntimeIdentifierInference.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.RuntimeIdentifierInference.targets
@@ -1,0 +1,50 @@
+<!--
+***********************************************************************************************
+Microsoft.NET.RuntimeIdentifierInference.targets
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+          created a backup copy.  Incorrect changes to this file will make it
+          impossible to load or build your projects from the command-line or the IDE.
+
+Copyright (c) .NET Foundation. All rights reserved. 
+***********************************************************************************************
+-->
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" InitialTargets="CheckRuntimeIdentifier">
+
+  <!-- Determine PlatformTarget (if not already set) from runtime identifier. -->
+  <Choose>
+    <When Condition="'$(PlatformTarget)' != '' or '$(RuntimeIdentifier)' == ''" />
+
+    <When Condition="$(RuntimeIdentifier.EndsWith('-x86')) or $(RuntimeIdentifier.Contains('-x86-'))">
+      <PropertyGroup>
+        <PlatformTarget>x86</PlatformTarget>
+      </PropertyGroup>
+    </When>
+
+    <When Condition="$(RuntimeIdentifier.EndsWith('-x64')) or $(RuntimeIdentifier.Contains('-x64-'))">
+      <PropertyGroup>
+        <PlatformTarget>x64</PlatformTarget>
+      </PropertyGroup>
+    </When>
+
+    <When Condition="$(RuntimeIdentifier.EndsWith('-arm')) or $(RuntimeIdentifier.Contains('-arm-'))">
+      <PropertyGroup>
+        <PlatformTarget>arm</PlatformTarget>
+      </PropertyGroup>
+    </When>
+
+    <!-- NOTE: PlatformTarget=arm64 is not currently supported and therefore no inference of that here. -->
+    <Otherwise>
+      <PropertyGroup>
+        <PlatformTarget>AnyCPU</PlatformTarget>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
+
+  <Target Name="CheckRuntimeIdentifier">
+    <Error Condition="'$(RuntimeIdentifier)' == '' and 
+                      '$(TargetFrameworkIdentifier)' == '.NETFramework' and '$(OutputType)' == 'Exe'"
+           Text="RuntimeIdentifier must be set for .NETFramework executables. Consider RuntimeIdentifier=win7-x86 or RuntimeIdentifier=win7-x64." />
+  </Target>
+
+</Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.BeforeCommon.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.BeforeCommon.targets
@@ -33,6 +33,12 @@ Copyright (c) .NET Foundation. All rights reserved.
   <Import Condition="'$(TargetFramework)' != ''"
         Project="$(MSBuildThisFileDirectory)Microsoft.NET.TargetFrameworkInference.targets" />
 
+  <!--
+    Use RuntimeIdentifier to determine PlatformTarget.
+    Also, enforce that RuntimeIdentifier always be specified for .NETFramework executables.
+  -->
+  <Import Project="$(MSBuildThisFileDirectory)Microsoft.NET.RuntimeIdentifierInference.targets" />
+
   <PropertyGroup Condition="'$(_IsNETCoreOrNETStandard)' == ''">
     <_IsNETCoreOrNETStandard Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">true</_IsNETCoreOrNETStandard>
     <_IsNETCoreOrNETStandard Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard'">true</_IsNETCoreOrNETStandard>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.props
@@ -21,7 +21,6 @@ Copyright (c) .NET Foundation. All rights reserved.
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform>AnyCPU</Platform>
     <FileAlignment>512</FileAlignment>
-    <PlatformTarget>AnyCPU</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
     <AssemblyName>$(MSBuildProjectName)</AssemblyName>
     <RootNamespace>$(MSBuildProjectName)</RootNamespace>

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildADesktopExe.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildADesktopExe.cs
@@ -19,6 +19,11 @@ namespace Microsoft.NET.Build.Tests
         [Fact]
         public void It_fails_to_build_if_no_rid_is_set()
         {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return;
+            }
+
             var testAsset = _testAssetsManager
                 .CopyTestAsset("DesktopMinusRid")
                 .WithSource()
@@ -52,6 +57,11 @@ namespace Microsoft.NET.Build.Tests
         [InlineData("arm-something", "AnyCPU")]
         public void It_builds_with_inferred_platform_target(string runtimeIdentifier, string expectedPlatformTarget)
         {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return;
+            }
+
             var testAsset = _testAssetsManager
                 .CopyTestAsset("DesktopMinusRid", identifier: Path.DirectorySeparatorChar + runtimeIdentifier)
                 .WithSource()
@@ -75,6 +85,11 @@ namespace Microsoft.NET.Build.Tests
         [Fact]
         public void It_respects_explicit_platform_target()
         {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return;
+            }
+
             var testAsset = _testAssetsManager
                 .CopyTestAsset("DesktopMinusRid")
                 .WithSource()

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildADesktopExe.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildADesktopExe.cs
@@ -1,0 +1,98 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.IO;
+using System.Runtime.InteropServices;
+using Microsoft.NET.TestFramework;
+using Microsoft.NET.TestFramework.Assertions;
+using Microsoft.NET.TestFramework.Commands;
+using Xunit;
+using FluentAssertions;
+using static Microsoft.NET.TestFramework.Commands.MSBuildTest;
+
+namespace Microsoft.NET.Build.Tests
+{
+    public class GivenThatWeWantToBuildADesktopExe
+    {
+        private TestAssetsManager _testAssetsManager = TestAssetsManager.TestProjectsAssetsManager;
+
+        [Fact]
+        public void It_fails_to_build_if_no_rid_is_set()
+        {
+            var testAsset = _testAssetsManager
+                .CopyTestAsset("DesktopMinusRid")
+                .WithSource()
+                .Restore();
+
+            var buildCommand = new BuildCommand(Stage0MSBuild, testAsset.TestRoot);
+            buildCommand
+                .MSBuild
+                .CreateCommandForTarget("build", buildCommand.FullPathProjectFile)
+                .CaptureStdOut()
+                .Execute()
+                .Should()
+                .Fail()
+                .And
+                .HaveStdOutContaining("RuntimeIdentifier must be set");
+        }
+
+        [Theory]
+        [InlineData("win7-x86", "x86")]
+        [InlineData("win8-x86-aot", "x86")]
+        [InlineData("win7-x64", "x64")]
+        [InlineData("win8-x64-aot", "x64")]
+        [InlineData("win10-arm", "arm")]
+        [InlineData("win10-arm-aot", "arm")]
+        //PlatformTarget=arm64 is not supported and never inferred
+        [InlineData("win10-arm64", "AnyCPU")]
+        [InlineData("win10-arm64-aot", "AnyCPU")]
+        // cpu architecture is never expected at the front
+        [InlineData("x86-something", "AnyCPU")]
+        [InlineData("x64-something", "AnyCPU")]
+        [InlineData("arm-something", "AnyCPU")]
+        public void It_builds_with_inferred_platform_target(string runtimeIdentifier, string expectedPlatformTarget)
+        {
+            var testAsset = _testAssetsManager
+                .CopyTestAsset("DesktopMinusRid", identifier: Path.DirectorySeparatorChar + runtimeIdentifier)
+                .WithSource()
+                .Restore("", $"/p:RuntimeIdentifier={runtimeIdentifier}");
+
+            var buildCommand = new BuildCommand(Stage0MSBuild, testAsset.TestRoot);
+            buildCommand
+                .Execute($"/p:RuntimeIdentifier={runtimeIdentifier}")
+                .Should()
+                .Pass();
+
+            var assemblyPath = Path.Combine(buildCommand.GetOutputDirectory("net46").FullName, "DesktopMinusRid.exe");
+            var assemblyInfo = AssemblyInfo.Get(assemblyPath);
+            assemblyInfo
+                .Should()
+                .Contain(
+                    "AssemblyDescriptionAttribute",
+                    $"PlatformTarget={expectedPlatformTarget}");
+        }
+
+        [Fact]
+        public void It_respects_explicit_platform_target()
+        {
+            var testAsset = _testAssetsManager
+                .CopyTestAsset("DesktopMinusRid")
+                .WithSource()
+                .Restore("", $"/p:RuntimeIdentifier=win7-x86");
+
+            var buildCommand = new BuildCommand(Stage0MSBuild, testAsset.TestRoot);
+            buildCommand
+                .Execute($"/p:RuntimeIdentifier=win7-x86", "/p:PlatformTarget=x64")
+                .Should()
+                .Pass();
+
+            var assemblyPath = Path.Combine(buildCommand.GetOutputDirectory("net46").FullName, "DesktopMinusRid.exe");
+            var assemblyInfo = AssemblyInfo.Get(assemblyPath);
+            assemblyInfo
+                .Should()
+                .Contain(
+                    "AssemblyDescriptionAttribute",
+                    $"PlatformTarget=x64");
+        }
+    }
+}

--- a/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPreserveCompilationContext.cs
+++ b/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPreserveCompilationContext.cs
@@ -45,7 +45,7 @@ namespace Microsoft.NET.Publish.Tests
                     .Should()
                     .Pass();
 
-                var publishDirectory = publishCommand.GetOutputDirectory(targetFramework);
+                var publishDirectory = publishCommand.GetOutputDirectory(targetFramework, runtimeIdentifier: "win7-x86");
 
                 publishDirectory.Should().HaveFiles(new[] {
                     targetFramework == "net46" ? "TestApp.exe" : "TestApp.dll",
@@ -75,13 +75,13 @@ namespace Microsoft.NET.Publish.Tests
 
                     dependencyContext.CompilationOptions.Defines.Should().BeEquivalentTo(expectedDefines);
                     dependencyContext.CompilationOptions.LanguageVersion.Should().Be("");
-                    dependencyContext.CompilationOptions.Platform.Should().Be("AnyCPU");
+                    dependencyContext.CompilationOptions.Platform.Should().Be("x86");
                     dependencyContext.CompilationOptions.Optimize.Should().Be(false);
                     dependencyContext.CompilationOptions.KeyFile.Should().Be("");
                     dependencyContext.CompilationOptions.EmitEntryPoint.Should().Be(true);
                     dependencyContext.CompilationOptions.DebugType.Should().Be("portable");
 
-                    dependencyContext.CompileLibraries.Count.Should().Be(targetFramework == "net46" ? 53 : 116);
+                    dependencyContext.CompileLibraries.Count.Should().Be(targetFramework == "net46" ? 53 : 149);
 
                     // Ensure P2P references are specified correctly
                     var testLibrary = dependencyContext

--- a/test/Microsoft.NET.TestFramework/Commands/PublishCommand.cs
+++ b/test/Microsoft.NET.TestFramework/Commands/PublishCommand.cs
@@ -29,9 +29,9 @@ namespace Microsoft.NET.TestFramework.Commands
             return command.Execute();
         }
 
-        public DirectoryInfo GetOutputDirectory(string targetFramework = "netcoreapp1.0", bool selfContained = false)
+        public DirectoryInfo GetOutputDirectory(string targetFramework = "netcoreapp1.0", string configuration = "Debug", string runtimeIdentifier = "", bool selfContained = false)
         {
-            string output = Path.Combine(ProjectRootPath, "bin", BuildRelativeOutputPath(targetFramework, selfContained));
+            string output = Path.Combine(ProjectRootPath, "bin", BuildRelativeOutputPath(targetFramework, configuration, runtimeIdentifier, selfContained));
             return new DirectoryInfo(output);
         }
 
@@ -40,11 +40,14 @@ namespace Microsoft.NET.TestFramework.Commands
             return Path.Combine(GetOutputDirectory().FullName, $"{appName}.dll");
         }
 
-        private string BuildRelativeOutputPath(string targetFramework, bool selfContained)
+        private string BuildRelativeOutputPath(string targetFramework, string configuration, string runtimeIdentifier, bool selfContained)
         {
-            return selfContained ?
-                Path.Combine("Debug", targetFramework, RuntimeEnvironment.GetRuntimeIdentifier(), PublishSubfolderName) :
-                Path.Combine("Debug", targetFramework, PublishSubfolderName);
+            if (runtimeIdentifier.Length == 0 && selfContained)
+            {
+                runtimeIdentifier = RuntimeEnvironment.GetRuntimeIdentifier();
+            }
+			
+            return Path.Combine(configuration, targetFramework, runtimeIdentifier, PublishSubfolderName);
         }
     }
 }


### PR DESCRIPTION
Also, require RID for .NETFramework exes

@srivatsn @eerhardt Working on a test, but given urgency, would be good to get review started in parallel. 

Finally, I ran into test issues with redirecting the build output path to have the RID so I reverted that for now. I'm thinking that can wait.
