### PR TITLE
RunWorkingDirectory no longer has a default. By default, it is up to …

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.targets
@@ -142,8 +142,6 @@ Copyright (c) .NET Foundation. All rights reserved.
         <_NetCoreRunArguments>exec &quot;$(TargetPath)&quot;</_NetCoreRunArguments>
         <RunArguments Condition="'$(RunArguments)' == '' and '$(StartArguments)' != ''">$(_NetCoreRunArguments) $(StartArguments)</RunArguments>
         <RunArguments Condition="'$(RunArguments)' == ''">$(_NetCoreRunArguments)</RunArguments>
-
-        <RunWorkingDirectory Condition="'$(RunWorkingDirectory)' == ''">$(TargetDir)</RunWorkingDirectory>
       </PropertyGroup>
     </When>
     
@@ -151,7 +149,6 @@ Copyright (c) .NET Foundation. All rights reserved.
       <PropertyGroup>
         <RunCommand Condition="'$(RunCommand)' == ''">$(TargetPath)</RunCommand>
         <RunArguments Condition="'$(RunArguments)' == ''">$(StartArguments)</RunArguments>
-        <RunWorkingDirectory Condition="'$(RunWorkingDirectory)' == ''">$(TargetDir)</RunWorkingDirectory>
       </PropertyGroup>
     </When>
   </Choose>


### PR DESCRIPTION
By default, it is up to the caller (dotnet/cli, VS, VS Code) to decide how best to run the project.

Fix https://github.com/dotnet/cli/issues/4473

@nguerrera @dsplaisted 

@BillHiebert - this is a breaking change that VS will need to react to.

/cc @dotnet/project-system @natemcmaster 
