### PR TITLE
Fix VS experience

### DIFF
--- a/Common.props
+++ b/Common.props
@@ -18,7 +18,6 @@
     <PackagesLayoutToolsDir>$(PackagesLayoutDir)tools\</PackagesLayoutToolsDir>
     <PackagesLayoutToolsNet46Dir>$(PackagesLayoutToolsDir)net46\</PackagesLayoutToolsNet46Dir>
     <PackagesLayoutToolsNetCoreAppDir>$(PackagesLayoutToolsDir)netcoreapp1.0\</PackagesLayoutToolsNetCoreAppDir>
-    <WebPackagesLayoutDir>$(OutDir)WebPackagesLayout\</WebPackagesLayoutDir>
     
     <VersionPrefix Condition="'$(VersionPrefix)' == ''">1.0.0</VersionPrefix>
     <VersionPrereleasePrefix Condition="'$(VersionPrereleasePrefix)' == ''">alpha</VersionPrereleasePrefix>

--- a/Common.props
+++ b/Common.props
@@ -11,13 +11,14 @@
     <RepositoryRootDirectory>$(MSBuildThisFileDirectory)</RepositoryRootDirectory>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
 
-    <OutDir Condition="'$(OutDir)' == ''">$([System.IO.Path]::GetFullPath('$(RepositoryRootDirectory)bin\$(Configuration)'))\</OutDir>
+    <OutputPath>$([System.IO.Path]::GetFullPath('$(RepositoryRootDirectory)bin\$(Configuration)'))\</OutputPath>
+    <OutDir>$(OutputPath)</OutDir>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)' == ''">$([System.IO.Path]::GetFullPath('$(RepositoryRootDirectory)bin\obj\$(MSBuildProjectName)'))\</BaseIntermediateOutputPath>
-    <PackagesLayoutDir>$(OutDir)\PackagesLayout\</PackagesLayoutDir>
+    <PackagesLayoutDir>$(OutDir)PackagesLayout\</PackagesLayoutDir>
     <PackagesLayoutToolsDir>$(PackagesLayoutDir)tools\</PackagesLayoutToolsDir>
     <PackagesLayoutToolsNet46Dir>$(PackagesLayoutToolsDir)net46\</PackagesLayoutToolsNet46Dir>
     <PackagesLayoutToolsNetCoreAppDir>$(PackagesLayoutToolsDir)netcoreapp1.0\</PackagesLayoutToolsNetCoreAppDir>
-    <WebPackagesLayoutDir>$(OutDir)\WebPackagesLayout\</WebPackagesLayoutDir>
+    <WebPackagesLayoutDir>$(OutDir)WebPackagesLayout\</WebPackagesLayoutDir>
     
     <VersionPrefix Condition="'$(VersionPrefix)' == ''">1.0.0</VersionPrefix>
     <VersionPrereleasePrefix Condition="'$(VersionPrereleasePrefix)' == ''">alpha</VersionPrereleasePrefix>
@@ -45,6 +46,7 @@
     <DotNetTool>$(DotNet_Install_Dir)\dotnet</DotNetTool>
 
     <NuGet_Packages Condition=" '$(NuGet_Packages)' == ''">$(RepositoryRootDirectory)packages\</NuGet_Packages>
+    <NuGetPackageRoot Condition=" '$(NuGetPackageRoot)' == ''">$(NuGet_Packages)</NuGetPackageRoot>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/NuGet.config
+++ b/NuGet.config
@@ -10,4 +10,7 @@
     <add key="roslyn-tools" value="https://dotnet.myget.org/F/roslyn-tools/api/v3/index.json" />
     <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
+  <config>
+    <add key="repositoryPath" value="packages" />
+  </config>
 </configuration>

--- a/build/Targets/ProducesNoOutput.Imports.props
+++ b/build/Targets/ProducesNoOutput.Imports.props
@@ -22,5 +22,7 @@
   <Target Name="CoreCompile" />                               <!-- Prevent Csc from being called -->
   <Target Name="GenerateTargetFrameworkMonikerAttribute" />   <!-- Don't generate TFM attribute -->
   <Target Name="RuntimeImplementationProjectOutputGroup" />   <!-- Group always attempts resolve runtime, regardless of <CopyNuGetImplementations>-->
+  <Target Name="GetReferenceAssemblyPaths" />                 <!-- Don't go looking for framewoek reference assemblies-->
+  <Target Name="GetFrameworkPaths"  />                        <!-- ^ -->
 
 </Project>

--- a/build/Targets/ProducesNoOutput.Settings.props
+++ b/build/Targets/ProducesNoOutput.Settings.props
@@ -11,5 +11,6 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <ResolvePackageDependenciesForBuild>false</ResolvePackageDependenciesForBuild>
     <NonShipping>true</NonShipping>
+    <NoStdLib>true</NoStdLib>
   </PropertyGroup>
 </Project>

--- a/src/Dependencies/xUnit.net/project.json
+++ b/src/Dependencies/xUnit.net/project.json
@@ -1,7 +1,8 @@
 {
   "dependencies": {
     "xunit.console.netcore": "1.0.3-prerelease-00607-01",
-    "xunit.runner.reporters": "2.1.0"
+    "xunit.runner.reporters": "2.1.0",
+    "system.text.regularexpressions": "4.1.0"
   },
   "frameworks": {
     "netcoreapp1.0": {


### PR DESCRIPTION
1. Make sure to set OutputPath and not just OutDir
2. Use NuGet.config setting to ensure same packages dir for command line and VS
3. Prevent reference assembly searches for 'no output' projects
4. Eliminate package downgrade warning about System.Text.RegularExpressions

IntelliSense works without workarounds now, and you can alternate between command line and VS without issue. 🎉 

@dsplaisted @srivatsn @dotnet/project-system 
