### PR TITLE
Support for running tests in Visual Studio

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/Properties/launchSettings.json
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/Properties/launchSettings.json
@@ -1,0 +1,10 @@
+{
+  "profiles": {
+    "Microsoft.NET.Build.Tests": {
+      "commandName": "Executable",
+      "executablePath": "$(RunCommand)",
+      "commandLineArgs": "\"$(OutDir)xunit.console.netcore.exe\" \"$(OutDir)$(AssemblyName).dll\" -wait",
+      "workingDirectory": "$(OutDir)"
+    }
+  }
+}

--- a/test/Microsoft.NET.Build.Tests/Properties/launchSettings.json
+++ b/test/Microsoft.NET.Build.Tests/Properties/launchSettings.json
@@ -1,0 +1,10 @@
+{
+  "profiles": {
+    "Microsoft.NET.Build.Tests": {
+      "commandName": "Executable",
+      "executablePath": "$(RunCommand)",
+      "commandLineArgs": "\"$(OutDir)xunit.console.netcore.exe\" \"$(OutDir)$(AssemblyName).dll\" -wait",
+      "workingDirectory": "$(OutDir)"
+    }
+  }
+}

--- a/test/Microsoft.NET.Pack.Tests/Properties/launchSettings.json
+++ b/test/Microsoft.NET.Pack.Tests/Properties/launchSettings.json
@@ -1,0 +1,10 @@
+{
+  "profiles": {
+    "Microsoft.NET.Build.Tests": {
+      "commandName": "Executable",
+      "executablePath": "$(RunCommand)",
+      "commandLineArgs": "\"$(OutDir)xunit.console.netcore.exe\" \"$(OutDir)$(AssemblyName).dll\" -wait",
+      "workingDirectory": "$(OutDir)"
+    }
+  }
+}

--- a/test/Microsoft.NET.Publish.Tests/Properties/launchSettings.json
+++ b/test/Microsoft.NET.Publish.Tests/Properties/launchSettings.json
@@ -1,0 +1,10 @@
+{
+  "profiles": {
+    "Microsoft.NET.Build.Tests": {
+      "commandName": "Executable",
+      "executablePath": "$(RunCommand)",
+      "commandLineArgs": "\"$(OutDir)xunit.console.netcore.exe\" \"$(OutDir)$(AssemblyName).dll\" -wait",
+      "workingDirectory": "$(OutDir)"
+    }
+  }
+}

--- a/test/Microsoft.NET.TestFramework/Commands/MSBuildTest.cs
+++ b/test/Microsoft.NET.TestFramework/Commands/MSBuildTest.cs
@@ -19,7 +19,7 @@ namespace Microsoft.NET.TestFramework.Commands
             DotNetHostPath = dotNetHostPath;
         }
 
-        public Command CreateCommandForTarget(string target, params string[] args)
+        public ICommand CreateCommandForTarget(string target, params string[] args)
         {
             var newArgs = args.ToList();
             newArgs.Insert(0, $"/t:{target}");
@@ -27,12 +27,17 @@ namespace Microsoft.NET.TestFramework.Commands
             return CreateCommand(newArgs.ToArray());
         }
 
-        private Command CreateCommand(params string[] args)
+        private ICommand CreateCommand(params string[] args)
         {
             var newArgs = args.ToList();
             newArgs.Insert(0, $"msbuild");
 
-            return Command.Create(DotNetHostPath, newArgs);
+            ICommand command = Command.Create(DotNetHostPath, newArgs);
+
+            //  Set NUGET_PACKAGES environment variable to match value from build.ps1
+            command = command.EnvironmentVariable("NUGET_PACKAGES", RepoInfo.PackagesPath);
+
+            return command;
         }
     }
 }


### PR DESCRIPTION
- Adds launchSettings.json files to test projects to support running tests with F5
- Set NUGET_PACKAGES environment variable when running MSBuild commands, to match the value set by `build.ps1` when launching tests from VS

With the changes from dotnet/roslyn-project-system#658, this will let you launch tests from VS.  You can add `-class` or `-method` to the arguments to specify which tests to run.
