### PR TITLE
Handle packagerefs with satellite assemblies

### DIFF
--- a/TestAssets/TestProjects/KitchenSink/TestApp/TestApp.csproj
+++ b/TestAssets/TestProjects/KitchenSink/TestApp/TestApp.csproj
@@ -5,6 +5,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp1.0</TargetFramework>
     <ProjectGuid>{C91F7F4C-47ED-4D1C-8990-B2E886B0FAD9}</ProjectGuid>
+    <PackageTargetFallback>portable-net45+wp8+win8+wpa</PackageTargetFallback>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Program.cs" />
@@ -61,6 +62,11 @@
     <PackageReference Include="Microsoft.NET.Sdk">
       <Version>0.0</Version>
       <PrivateAssets>All</PrivateAssets>
+    </PackageReference>
+
+    <!-- Has satellite assembly -->
+    <PackageReference Include="System.Spatial">
+      <Version>5.7.0</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/Tasks/Microsoft.NET.Build.Tasks/GenerateDepsFile.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/GenerateDepsFile.cs
@@ -49,7 +49,7 @@ namespace Microsoft.NET.Build.Tasks
         public ITaskItem[] ReferencePaths { get; set; }
 
         [Required]
-        public ITaskItem[] ProjectReferenceSatellitePaths { get; set; }
+        public ITaskItem[] ReferenceSatellitePaths { get; set; }
 
         public ITaskItem CompilerOptions { get; set; }
 
@@ -72,7 +72,7 @@ namespace Microsoft.NET.Build.Tasks
 
             Dictionary<string, SingleProjectInfo> referenceProjects = SingleProjectInfo.CreateProjectReferenceInfos(
                 ReferencePaths,
-                ProjectReferenceSatellitePaths);
+                ReferenceSatellitePaths);
 
             IEnumerable<string> privateAssets = PackageReferenceConverter.GetPackageIds(PrivateAssetsPackageReferences);
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/SingleProjectInfo.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/SingleProjectInfo.cs
@@ -49,7 +49,7 @@ namespace Microsoft.NET.Build.Tasks
 
         public static Dictionary<string, SingleProjectInfo> CreateProjectReferenceInfos(
             IEnumerable<ITaskItem> referencePaths,
-            IEnumerable<ITaskItem> projectReferenceSatellitePaths)
+            IEnumerable<ITaskItem> referenceSatellitePaths)
         {
             Dictionary<string, SingleProjectInfo> projectReferences = new Dictionary<string, SingleProjectInfo>();
 
@@ -76,6 +76,9 @@ namespace Microsoft.NET.Build.Tasks
                     sourceProjectFile,
                     new SingleProjectInfo(sourceProjectFile, name, version, outputName, resourceAssemblies));
             }
+
+            IEnumerable<ITaskItem> projectReferenceSatellitePaths = referenceSatellitePaths
+                .Where(r => string.Equals(r.GetMetadata("ReferenceSourceTarget"), "ProjectReference", StringComparison.OrdinalIgnoreCase));
 
             foreach (ITaskItem projectReferenceSatellitePath in projectReferenceSatellitePaths)
             {

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Publish.targets
@@ -441,7 +441,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                       AssemblyVersion="$(Version)"
                       AssemblySatelliteAssemblies="@(IntermediateSatelliteAssembliesWithTargetPath)"
                       ReferencePaths="@(ReferencePath)"
-                      ProjectReferenceSatellitePaths="@(ReferenceSatellitePaths)"
+                      ReferenceSatellitePaths="@(ReferenceSatellitePaths)"
                       RuntimeIdentifier="$(RuntimeIdentifier)"
                       PlatformLibraryName="$(MicrosoftNETPlatformLibrary)"
                       CompilerOptions="@(DependencyFileCompilerOptions)"

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.targets
@@ -83,7 +83,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                       AssemblyVersion="$(Version)"
                       AssemblySatelliteAssemblies="@(IntermediateSatelliteAssembliesWithTargetPath)"
                       ReferencePaths="@(ReferencePath)"
-                      ProjectReferenceSatellitePaths="@(ReferenceSatellitePaths)"
+                      ReferenceSatellitePaths="@(ReferenceSatellitePaths)"
                       RuntimeIdentifier="$(RuntimeIdentifier)"
                       PlatformLibraryName="$(MicrosoftNETPlatformLibrary)"
                       CompilerOptions="@(DependencyFileCompilerOptions)" />

--- a/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAProjectWithAllFeatures.cs
+++ b/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAProjectWithAllFeatures.cs
@@ -61,6 +61,16 @@ namespace Microsoft.NET.Publish.Tests
                 "de/TestLibrary.resources.dll",
                 "fr/TestApp.resources.dll",
                 "fr/TestLibrary.resources.dll",
+                "System.Spatial.dll",
+                "de/System.Spatial.resources.dll",
+                "es/System.Spatial.resources.dll",
+                "fr/System.Spatial.resources.dll",
+                "it/System.Spatial.resources.dll",
+                "ja/System.Spatial.resources.dll",
+                "ko/System.Spatial.resources.dll",
+                "ru/System.Spatial.resources.dll",
+                "zh-Hans/System.Spatial.resources.dll",
+                "zh-Hant/System.Spatial.resources.dll"
             });
 
             using (var depsJsonFileStream = File.OpenRead(Path.Combine(publishDirectory.FullName, "TestApp.deps.json")))
@@ -71,38 +81,39 @@ namespace Microsoft.NET.Publish.Tests
                 // TestLibrary has a hard dependency on Newtonsoft.Json.
                 // TestApp has a PrivateAssets=All dependency on Microsoft.Extensions.DependencyModel, which depends on Newtonsoft.Json.
                 // This verifies that P2P references get walked correctly when doing PrivateAssets exclusion.
-                dependencyContext
-                    .RuntimeLibraries
-                    .FirstOrDefault(l => string.Equals(l.Name, "newtonsoft.json", StringComparison.OrdinalIgnoreCase))
-                    .Should()
-                    .NotBeNull();
+                VerifyDependency(dependencyContext, "Newtonsoft.Json", "lib/netstandard1.0/");
 
                 // Verify P2P references get created correctly in the .deps.json file.
-                var testLibrary = dependencyContext
-                    .RuntimeLibraries
-                    .FirstOrDefault(l => string.Equals(l.Name, "testlibrary", StringComparison.OrdinalIgnoreCase));
+                VerifyDependency(dependencyContext, "TestLibrary", "",
+                    "da", "de", "fr");
 
-                testLibrary.RuntimeAssemblyGroups.Count.Should().Be(1);
-                testLibrary.RuntimeAssemblyGroups[0].Runtime.Should().Be(string.Empty);
-                testLibrary.RuntimeAssemblyGroups[0].AssetPaths.Count.Should().Be(1);
-                testLibrary.RuntimeAssemblyGroups[0].AssetPaths[0].Should().Be("TestLibrary.dll");
+                // Verify package reference with satellites gets created correctly in the .deps.json file
+                VerifyDependency(dependencyContext, "System.Spatial", "lib/portable-net45+wp8+win8+wpa/",
+                    "de", "es", "fr", "it", "ja", "ko", "ru", "zh-Hans", "zh-Hant");
+            }
+        }
 
-                testLibrary.ResourceAssemblies.Count.Should().Be(3);
-                testLibrary
-                    .ResourceAssemblies
-                    .FirstOrDefault(r => r.Locale == "da" && r.Path == "da/TestLibrary.resources.dll")
-                    .Should()
-                    .NotBeNull();
-                testLibrary
-                    .ResourceAssemblies
-                    .FirstOrDefault(r => r.Locale == "de" && r.Path == "de/TestLibrary.resources.dll")
-                    .Should()
-                    .NotBeNull();
-                testLibrary
-                    .ResourceAssemblies
-                    .FirstOrDefault(r => r.Locale == "fr" && r.Path == "fr/TestLibrary.resources.dll")
-                    .Should()
-                    .NotBeNull();
+        private static void VerifyDependency(DependencyContext dependencyContext, string name, string path, params string[] locales)
+        {
+            var library = dependencyContext
+                .RuntimeLibraries
+                .FirstOrDefault(l => string.Equals(l.Name, name, StringComparison.OrdinalIgnoreCase));
+
+            library.Should().NotBeNull();
+            library.RuntimeAssemblyGroups.Count.Should().Be(1);
+            library.RuntimeAssemblyGroups[0].Runtime.Should().Be(string.Empty);
+            library.RuntimeAssemblyGroups[0].AssetPaths.Count.Should().Be(1);
+            library.RuntimeAssemblyGroups[0].AssetPaths[0].Should().Be($"{path}{name}.dll");
+
+            library.ResourceAssemblies.Count.Should().Be(locales.Length);
+
+            foreach (string locale in locales)
+            {
+                library
+                   .ResourceAssemblies
+                   .FirstOrDefault(r => r.Locale == locale && r.Path == $"{path}{locale}/{name}.resources.dll")
+                   .Should()
+                   .NotBeNull();
             }
         }
     }


### PR DESCRIPTION
Fix #338 

@srivatsn @livarcocc @dotnet/project-system 

@MattGertz for approval. This is blocking the CLI team and would prevent customer publishing if any package with a satellite assembly is referenced.
