### PR TITLE
Fix ArgumentNullException when no reference assemblies are installed on the machine

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/DependencyContextBuilder.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/DependencyContextBuilder.cs
@@ -453,13 +453,8 @@ namespace Microsoft.NET.Build.Tasks
 
         private static string EnsureTrailingCharacter(string path, char trailingCharacter)
         {
-            if (path == null)
-            {
-                throw new ArgumentNullException(nameof(path));
-            }
-
             // if the path is empty, we want to return the original string instead of a single trailing character.
-            if (path.Length == 0 || path[path.Length - 1] == trailingCharacter)
+            if (string.IsNullOrEmpty(path) || path[path.Length - 1] == trailingCharacter)
             {
                 return path;
             }


### PR DESCRIPTION
Needed to fix Docker scenarios.

@nguerrera @dsplaisted 

/cc @dotnet/project-system @stevelasker
