### PR TITLE
Fix NUGET_PACKAGES folder when running tests.

### DIFF
--- a/test/Microsoft.NET.TestFramework/Commands/MSBuildTest.cs
+++ b/test/Microsoft.NET.TestFramework/Commands/MSBuildTest.cs
@@ -35,7 +35,7 @@ namespace Microsoft.NET.TestFramework.Commands
             ICommand command = Command.Create(DotNetHostPath, newArgs);
 
             //  Set NUGET_PACKAGES environment variable to match value from build.ps1
-            command = command.EnvironmentVariable("NUGET_PACKAGES", RepoInfo.PackagesPath);
+            command = command.EnvironmentVariable("NUGET_PACKAGES", Path.Combine(RepoInfo.RepoRoot, "packages"));
 
             return command;
         }


### PR DESCRIPTION
The tests use $(OutDir)\Packages for the package folder, so we need to clean it up from there to ensure tests are run with the latest changes to the SDK.