### PR TITLE
Force current runtime and arch for GenerateResources on Core msbuild

### DIFF
--- a/TestAssets/TestProjects/DesktopMinusRid/DesktopMinusRid.csproj
+++ b/TestAssets/TestProjects/DesktopMinusRid/DesktopMinusRid.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="**\*.cs" />
+    <EmbeddedResource Include="**\*.resx" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Sdk">

--- a/TestAssets/TestProjects/DesktopMinusRid/Strings.resx
+++ b/TestAssets/TestProjects/DesktopMinusRid/Strings.resx
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Hello" xml:space="preserve">
+    <value>Hello!</value>
+  </data>
+</root>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.props
@@ -50,16 +50,22 @@ Copyright (c) .NET Foundation. All rights reserved.
     <DesignTimeAssemblySearchPaths>$(AssemblySearchPaths)</DesignTimeAssemblySearchPaths>
   </PropertyGroup>
 
-  <!-- Temporary hacks to work around bugs -->
+  <!-- Temporary workarounds -->
   <PropertyGroup>
-    <!-- Temp Hack: https://github.com/dotnet/roslyn/issues/12167 -->
+    <!-- Workaround: https://github.com/dotnet/roslyn/issues/12167 -->
     <NoLogo>true</NoLogo>
 
-    <!-- Temp Hack: https://github.com/Microsoft/msbuild/issues/720 -->
+    <!-- Workaround: https://github.com/Microsoft/msbuild/issues/720 -->
     <OverrideToolHost Condition=" '$(DotnetHostPath)' != '' and '$(OverrideToolHost)' == ''">$(DotnetHostPath)</OverrideToolHost>
 
-    <!-- Temp Hack: https://github.com/Microsoft/msbuild/issues/1045: This is the only before common targets hook available to us, but using it is hijacking a hook that should belong to the user. -->
+    <!-- Workaround: https://github.com/Microsoft/msbuild/issues/1045: This is the only before common targets hook available to us, but using it is hijacking a hook that should belong to the user. -->
     <CustomBeforeMicrosoftCommonTargets>$(MSBuildThisFileDirectory)Microsoft.NET.Sdk.BeforeCommon.targets</CustomBeforeMicrosoftCommonTargets>
+  </PropertyGroup>
+
+  <!-- Workaround: https://github.com/Microsoft/msbuild/issues/1293 -->
+  <PropertyGroup Condition="'$(MSBuildRuntimeType)' == 'Core'"> 
+    <GenerateResourceMSBuildArchitecture>CurrentArchitecture</GenerateResourceMSBuildArchitecture>
+    <GenerateResourceMSBuildRuntime>CurrentRuntime</GenerateResourceMSBuildRuntime>
   </PropertyGroup>
 
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.NET.Sdk.CSharp.props" Condition="'$(MSBuildProjectExtension)' == '.csproj'" />


### PR DESCRIPTION
Fix #346 with a workaround for Microsoft/msbuild#1293

Also cleaning up the nearby usage 'hack' to just 'workaround' ;)

@srivatsn @rainersigwald @NTaylorMullen @dotnet/project-system 