### PR TITLE
Support generating a documentation file with GenerateDocumentationFile property

### DIFF
--- a/TestAssets/TestProjects/AppWithLibrary/TestLibrary/TestLibrary.csproj
+++ b/TestAssets/TestProjects/AppWithLibrary/TestLibrary/TestLibrary.csproj
@@ -3,7 +3,6 @@
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" />  
   <PropertyGroup>
     <Version>42.43.44.45-alpha</Version>
-    <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <OutputType>Library</OutputType>
     <TargetFramework>netstandard1.5</TargetFramework>
   </PropertyGroup>

--- a/TestAssets/TestProjects/CompilationContext/TestLibrary/TestLibrary.csproj
+++ b/TestAssets/TestProjects/CompilationContext/TestLibrary/TestLibrary.csproj
@@ -2,7 +2,6 @@
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" />
   <PropertyGroup>
-    <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <OutputType>Library</OutputType>
     <TargetFramework>netstandard1.3</TargetFramework>
   </PropertyGroup>

--- a/TestAssets/TestProjects/KitchenSink/TestLibrary/TestLibrary.csproj
+++ b/TestAssets/TestProjects/KitchenSink/TestLibrary/TestLibrary.csproj
@@ -2,7 +2,6 @@
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" />
   <PropertyGroup>
-    <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <OutputType>Library</OutputType>
     <TargetFramework>netstandard1.5</TargetFramework>
     <ProjectGuid>{BB691360-49BC-46EB-8BA9-6A69A54CD4B0}</ProjectGuid>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.BeforeCommon.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.BeforeCommon.targets
@@ -65,6 +65,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <PublishDir Condition="'$(PublishDir)' == ''">$(OutputPath)$(PublishDirName)\</PublishDir>
   </PropertyGroup>
 
+  <!-- Add conditional compilation symbols for the target framework (for example NET461, NETSTANDARD2_0, NETCOREAPP1_0) -->
   <PropertyGroup Condition=" '$(DisableImplicitFrameworkDefines)' != 'true' and '$(TargetFrameworkIdentifier)' != '.NETPortable'">
     <_FrameworkIdentifierForImplicitDefine>$(TargetFrameworkIdentifier.Replace('.', '').ToUpperInvariant())</_FrameworkIdentifierForImplicitDefine>
     <_FrameworkIdentifierForImplicitDefine Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework'">NET</_FrameworkIdentifierForImplicitDefine>
@@ -78,5 +79,21 @@ Copyright (c) .NET Foundation. All rights reserved.
     
     <DefineConstants>$(DefineConstants);$(_FrameworkIdentifierForImplicitDefine)$(_FrameworkVersionForImplicitDefine)</DefineConstants>
   </PropertyGroup>
+
+  <!-- Handle XML documentation file settings -->
+  <PropertyGroup Condition="'$(GenerateDocumentationFile)' == 'true' and '$(DocumentationFile)' == ''">
+    <DocumentationFile>$(IntermediateOutputPath)\$(AssemblyName).xml</DocumentationFile>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(GenerateDocumentationFile)' == 'false' and '$(DocumentationFile)' != ''">
+    <_InvalidDocumentationFileSettingsError>GenerateDocumentationFile is false but DocumentationFile is '$(DocumentationFile)', which is an invalid combination.  Either set GenerateDocumentationFile to true (or leave it unset), or leave DocumentationFile unset.</_InvalidDocumentationFileSettingsError>
+  </PropertyGroup>
+  <Target Name="_CheckForInvalidDocumentationFileSettings" BeforeTargets="_CheckForInvalidConfigurationAndPlatform">
+    <Error Condition="'$(_InvalidDocumentationFileSettingsError)' != ''" Text="$(_InvalidDocumentationFileSettingsError)" />
+  </Target>
+
+  <!-- Add a project capability so that the project properties in the IDE can show the option to generate an XML documentation file without specifying the filename -->
+  <ItemGroup>
+    <ProjectCapability Include="GenerateDocumentationFile" />
+  </ItemGroup>
 
 </Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.BeforeCommon.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.BeforeCommon.targets
@@ -81,15 +81,18 @@ Copyright (c) .NET Foundation. All rights reserved.
   </PropertyGroup>
 
   <!-- Handle XML documentation file settings -->
+  <PropertyGroup Condition="'$(GenerateDocumentationFile)' == ''">
+    <GenerateDocumentationFile Condition="'$(DocumentationFile)' == ''">false</GenerateDocumentationFile>
+    <GenerateDocumentationFile Condition="'$(DocumentationFile)' != ''">true</GenerateDocumentationFile>
+  </PropertyGroup>
+
   <PropertyGroup Condition="'$(GenerateDocumentationFile)' == 'true' and '$(DocumentationFile)' == ''">
-    <DocumentationFile>$(IntermediateOutputPath)\$(AssemblyName).xml</DocumentationFile>
+    <DocumentationFile>$(IntermediateOutputPath)$(AssemblyName).xml</DocumentationFile>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(GenerateDocumentationFile)' == 'false' and '$(DocumentationFile)' != ''">
-    <_InvalidDocumentationFileSettingsError>GenerateDocumentationFile is false but DocumentationFile is '$(DocumentationFile)', which is an invalid combination.  Either set GenerateDocumentationFile to true (or leave it unset), or leave DocumentationFile unset.</_InvalidDocumentationFileSettingsError>
+
+  <PropertyGroup Condition="'$(GenerateDocumentationFile)' != 'true'">
+    <DocumentationFile />
   </PropertyGroup>
-  <Target Name="_CheckForInvalidDocumentationFileSettings" BeforeTargets="_CheckForInvalidConfigurationAndPlatform">
-    <Error Condition="'$(_InvalidDocumentationFileSettingsError)' != ''" Text="$(_InvalidDocumentationFileSettingsError)" />
-  </Target>
 
   <!-- Add a project capability so that the project properties in the IDE can show the option to generate an XML documentation file without specifying the filename -->
   <ItemGroup>

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildALibrary.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildALibrary.cs
@@ -186,7 +186,7 @@ namespace Microsoft.NET.Build.Tests
         {
             string genDocFileIdentifier = generateDocumentationFile == null ? "null" : generateDocumentationFile.Value.ToString();
             string docFileIdentifier = documentationFile == null ? "null" : Path.GetFileName(documentationFile);
-            string identifier = $"genDoc={genDocFileIdentifier}, docFile={Path.GetFileName(docFileIdentifier)}";
+            string identifier = $"-genDoc={genDocFileIdentifier}, docFile={Path.GetFileName(docFileIdentifier)}";
 
             var testAsset = _testAssetsManager
                 .CopyTestAsset("AppWithLibrary", callingMethod, identifier)
@@ -248,7 +248,7 @@ namespace Microsoft.NET.Build.Tests
         [InlineData(false)]
         public void It_allows_us_to_override_the_documentation_file_name(bool setGenerateDocumentationFileProperty)
         {
-            var testAsset = CreateDocumentationFileLibraryAsset(setGenerateDocumentationFileProperty ? (bool?)true : null, "TestLibraryDocumentation.xml");
+            var testAsset = CreateDocumentationFileLibraryAsset(setGenerateDocumentationFileProperty ? (bool?)true : null, "TestLibDoc.xml", "OverrideDocFileName");
 
             var libraryProjectDirectory = Path.Combine(testAsset.TestRoot, "TestLibrary");
 
@@ -267,7 +267,7 @@ namespace Microsoft.NET.Build.Tests
                 "TestLibrary.dll",
                 "TestLibrary.pdb",
                 "TestLibrary.deps.json",
-                "TestLibraryDocumentation.xml"
+                "TestLibDoc.xml"
             });
 
             //  Due to the way the DocumentationFile works, if you specify an unrooted filename, then the documentation file will be generated in that
@@ -276,7 +276,7 @@ namespace Microsoft.NET.Build.Tests
             {
                 "Helper.cs",
                 "TestLibrary.csproj",
-                "TestLibraryDocumentation.xml"
+                "TestLibDoc.xml"
             }, SearchOption.TopDirectoryOnly);
         }
 
@@ -285,7 +285,7 @@ namespace Microsoft.NET.Build.Tests
         [InlineData(false)]
         public void It_does_not_create_a_documentation_file_if_GenerateDocumentationFile_property_is_false(bool setDocumentationFileProperty)
         {
-            var testAsset = CreateDocumentationFileLibraryAsset(false, setDocumentationFileProperty ? "TestLibraryDocumentation.xml" : null);
+            var testAsset = CreateDocumentationFileLibraryAsset(false, setDocumentationFileProperty ? "TestLibDoc.xml" : null, "DoesntCreateDocFile");
 
             var libraryProjectDirectory = Path.Combine(testAsset.TestRoot, "TestLibrary");
 

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildALibrary.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildALibrary.cs
@@ -294,6 +294,7 @@ namespace Microsoft.NET.Build.Tests
             var buildCommand = new BuildCommand(Stage0MSBuild, libraryProjectDirectory);
 
             buildCommand
+                .CaptureStdOut()
                 .Execute()
                 .Should()
                 .Fail();

--- a/test/Microsoft.NET.TestFramework/Assertions/DirectoryInfoAssertions.cs
+++ b/test/Microsoft.NET.TestFramework/Assertions/DirectoryInfoAssertions.cs
@@ -75,9 +75,9 @@ namespace Microsoft.NET.TestFramework.Assertions
             return new AndConstraint<DirectoryInfoAssertions>(new DirectoryInfoAssertions(dir));
         }
 
-        public AndConstraint<DirectoryInfoAssertions> OnlyHaveFiles(IEnumerable<string> expectedFiles)
+        public AndConstraint<DirectoryInfoAssertions> OnlyHaveFiles(IEnumerable<string> expectedFiles, SearchOption searchOption = SearchOption.AllDirectories)
         {
-            var actualFiles = _dirInfo.EnumerateFiles("*", SearchOption.AllDirectories)
+            var actualFiles = _dirInfo.EnumerateFiles("*", searchOption)
                               .Select(f => f.FullName.Substring(_dirInfo.FullName.Length + 1) // make relative to _dirInfo
                               .Replace("\\", "/")); // normalize separator
 

--- a/test/Microsoft.NET.TestFramework/Commands/BuildCommand.cs
+++ b/test/Microsoft.NET.TestFramework/Commands/BuildCommand.cs
@@ -11,9 +11,17 @@ namespace Microsoft.NET.TestFramework.Commands
 {
     public sealed class BuildCommand : TestCommand
     {
+        bool _captureStdOut;
+
         public BuildCommand(MSBuildTest msbuild, string projectRootPath, string relativePathToProject = null)
             : base(msbuild, projectRootPath, relativePathToProject)
         {
+        }
+
+        public BuildCommand CaptureStdOut()
+        {
+            _captureStdOut = true;
+            return this;
         }
 
         public override CommandResult Execute(params string[] args)
@@ -22,6 +30,11 @@ namespace Microsoft.NET.TestFramework.Commands
             newArgs.Insert(0, FullPathProjectFile);
 
             var command = MSBuild.CreateCommandForTarget("build", newArgs.ToArray());
+
+            if (_captureStdOut)
+            {
+                command = command.CaptureStdOut();
+            }
 
             return command.Execute();
         }


### PR DESCRIPTION
Fixes #193, by automatically setting the `DocumentationFile` property if `GenerateDocumentationFile` is true.

Follow-up bugs to file once this is merged:
- Update the compilation context preservation process to correctly handle the documentation file options (or ignore them entirely if we don't need them).
- Don't set OutputPath in the props files for the Sdk. If we're just going to be modifying it in the targets, then setting it to something in the props files can lead to unexpected behavior when the value is used in the project but doesn't represent the final value of the property.
- In [dotnet/roslyn-project-system](https://github.com/dotnet/roslyn-project-system): Update the "Build" property page so that you can check a box to generate an Xml documentation file without specifying the filename. This should set `GenerateDocumentationFile` to true in the project file instead of setting the `DocumentationFile` property. This behavior should light up based on the `GenerateDocumentationFile` capability so that projects that don't use the Sdk still get the old behavior.