### PR TITLE
Unblock having non-anycpu configurations by always setting output path

### DIFF
--- a/TestAssets/TestProjects/x64SolutionBuild/Program.cs
+++ b/TestAssets/TestProjects/x64SolutionBuild/Program.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace ConsoleApplication
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            Console.WriteLine("Hello World!");
+        }
+    }
+}

--- a/TestAssets/TestProjects/x64SolutionBuild/x64SolutionBuild.csproj
+++ b/TestAssets/TestProjects/x64SolutionBuild/x64SolutionBuild.csproj
@@ -1,0 +1,31 @@
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" />
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'" />
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="**\*.cs" />
+    <EmbeddedResource Include="**\*.resx" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NETCore.App">
+      <Version>1.0.1</Version>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Sdk">
+      <Version>0.0.0</Version>
+    </PackageReference>	
+  </ItemGroup>
+
+  <Target Name="CheckPlatform" BeforeTargets="Build">
+    <Error Condition="'$(Platform)' != 'x64'" Text="This test project expects to be built via solution and have Platform=x64" />
+  </Target>
+
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/TestAssets/TestProjects/x64SolutionBuild/x64SolutionBuild.sln
+++ b/TestAssets/TestProjects/x64SolutionBuild/x64SolutionBuild.sln
@@ -1,0 +1,21 @@
+﻿Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.25827.1
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "x64SolutionBuild", "x64SolutionBuild.csproj", "{544B615E-491F-4C80-9918-B10A6FB4B3CD}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
+		Release|x64 = Release|x64
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{544B615E-491F-4C80-9918-B10A6FB4B3CD}.Debug|x64.ActiveCfg = Debug|x64
+		{544B615E-491F-4C80-9918-B10A6FB4B3CD}.Debug|x64.Build.0 = Debug|x64
+		{544B615E-491F-4C80-9918-B10A6FB4B3CD}.Release|x64.ActiveCfg = Release|Any CPU
+		{544B615E-491F-4C80-9918-B10A6FB4B3CD}.Release|x64.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Microsoft.NET.Build.Tasks.csproj
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Microsoft.NET.Build.Tasks.csproj
@@ -71,6 +71,9 @@
     <None Include="buildCrossTargeting\Microsoft.NET.Sdk.targets">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="build\Microsoft.NET.DefaultOutputPaths.targets">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="build\Microsoft.NET.RuntimeIdentifierInference.targets">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
@@ -81,6 +84,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="build\Microsoft.NET.GenerateAssemblyInfo.targets">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="build\Microsoft.NET.Sdk.BeforeCommonCrossTargeting.targets">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="build\Microsoft.NET.Sdk.VisualBasic.props">

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.DefaultOutputPaths.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.DefaultOutputPaths.targets
@@ -1,0 +1,49 @@
+<!--
+***********************************************************************************************
+Microsoft.NET.DefaultOutputPaths.targets
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+          created a backup copy.  Incorrect changes to this file will make it
+          impossible to load or build your projects from the command-line or the IDE.
+
+Copyright (c) .NET Foundation. All rights reserved. 
+***********************************************************************************************
+-->
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+   <!--
+    Apply the same default output paths as Microsoft.Common.targets now since we're running before them,
+    but need to adjust them and/or make decisions in terms of them.
+
+    Also note that common targets only set a default OutputPath if neither configuration nor 
+    platform were set by the user. This was used to validate that a valid configuration is passed, 
+    assuming the convention maintained by VS that every Configuration|Platform combination had 
+    an explicit OutputPath. Since we now want to support leaner project files with less 
+    duplication and more automatic defaults, we always set a default OutputPath and can no
+    longer depend on that convention for validation. Getting validation re-enabled with a 
+    different mechanism is tracked by https://github.com/dotnet/sdk/issues/350
+   -->
+  <PropertyGroup>
+    <Configuration Condition="'$(Configuration)'==''">Debug</Configuration>
+    <Platform Condition="'$(Platform)'==''">AnyCPU</Platform>
+    <PlatformName Condition="'$(PlatformName)' == ''">$(Platform)</PlatformName>
+    
+    <BaseOutputPath Condition="'$(BaseOutputPath)' == ''">bin\</BaseOutputPath>
+    <BaseOutputPath Condition="!HasTrailingSlash('$(BaseOutputPath)')">$(BaseOutputPath)\</BaseOutputPath>
+    <OutputPath Condition="'$(OutputPath)' == '' and '$(PlatformName)' == 'AnyCPU'">$(BaseOutputPath)$(Configuration)\</OutputPath>
+    <OutputPath Condition="'$(OutputPath)' == '' and '$(PlatformName)' != 'AnyCPU'">$(BaseOutputPath)$(PlatformName)\$(Configuration)\</OutputPath>
+    <OutputPath Condition="!HasTrailingSlash('$(OutputPath)')">$(OutputPath)\</OutputPath>
+
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)' == ''">obj\</BaseIntermediateOutputPath>
+    <BaseIntermediateOutputPath Condition="!HasTrailingSlash('$(BaseIntermediateOutputPath)')">$(BaseIntermediateOutputPath)\</BaseIntermediateOutputPath>
+    <IntermediateOutputPath Condition=" $(IntermediateOutputPath) == '' and '$(PlatformName)' == 'AnyCPU' ">$(BaseIntermediateOutputPath)$(Configuration)\</IntermediateOutputPath>
+    <IntermediateOutputPath Condition=" $(IntermediateOutputPath) == '' and '$(PlatformName)' != 'AnyCPU' ">$(BaseIntermediateOutputPath)$(PlatformName)\$(Configuration)\</IntermediateOutputPath>
+    <IntermediateOutputPath Condition="!HasTrailingSlash('$(IntermediateOutputPath)')">$(IntermediateOutputPath)\</IntermediateOutputPath>
+  </PropertyGroup>
+  
+  <!-- Set the package output path (for nuget pack target) now, before the TargetFramework is appended -->
+  <PropertyGroup>
+    <PackageOutputPath Condition="'$(PackageOutputPath)' == ''">$(OutputPath)</PackageOutputPath>
+  </PropertyGroup>
+  
+</Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.BeforeCommon.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.BeforeCommon.targets
@@ -11,21 +11,9 @@ Copyright (c) .NET Foundation. All rights reserved.
 -->
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <!--
-     Apply the same defaults as Microsoft.Common.targets now since we're running before them,
-     but need to adjust them and/or make decisions in terms of them.
-   -->
-  <PropertyGroup>
-    <Platform Condition="'$(Platform)'==''">AnyCPU</Platform>
-    <PlatformName Condition="'$(PlatformName)' == ''">$(Platform)</PlatformName>
-    <Configuration Condition="'$(Configuration)'==''">Debug</Configuration>
-    <OutputPath Condition="'$(OutputPath)' != '' and !HasTrailingSlash('$(OutputPath)')">$(OutputPath)\</OutputPath>
-    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)' == ''">obj\</BaseIntermediateOutputPath>
-    <BaseIntermediateOutputPath Condition="!HasTrailingSlash('$(BaseIntermediateOutputPath)')">$(BaseIntermediateOutputPath)\</BaseIntermediateOutputPath>
-    <IntermediateOutputPath Condition=" $(IntermediateOutputPath) == '' and '$(PlatformName)' == 'AnyCPU' ">$(BaseIntermediateOutputPath)$(Configuration)\</IntermediateOutputPath>
-    <IntermediateOutputPath Condition=" $(IntermediateOutputPath) == '' and '$(PlatformName)' != 'AnyCPU' ">$(BaseIntermediateOutputPath)$(PlatformName)\$(Configuration)\</IntermediateOutputPath>
-  </PropertyGroup>
-
+  <!-- Set default intermediate and output paths -->
+  <Import Project="$(MSBuildThisFileDirectory)Microsoft.NET.DefaultOutputPaths.targets" />
+  
   <!-- 
     Expand TargetFramework (if set) to TargetFrameworkIdentifier and TargetFrameworkVersion,
     and adjust intermediate and output paths to include it.
@@ -35,7 +23,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <!--
     Use RuntimeIdentifier to determine PlatformTarget.
-    Also, enforce that RuntimeIdentifier always be specified for .NETFramework executables.
+    Also, enforce that RuntimeIdentifier is always specified for .NETFramework executables.
   -->
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.NET.RuntimeIdentifierInference.targets" />
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.BeforeCommonCrossTargeting.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.BeforeCommonCrossTargeting.targets
@@ -1,6 +1,6 @@
 <!--
 ***********************************************************************************************
-Microsoft.NET.Sdk.CSharp.props
+Microsoft.NET.Sdk.BeforeCommonCrossTargeting.targets
 
 WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
           created a backup copy.  Incorrect changes to this file will make it
@@ -9,17 +9,8 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
 Copyright (c) .NET Foundation. All rights reserved. 
 ***********************************************************************************************
 -->
-<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <PropertyGroup>
-    <WarningLevel>4</WarningLevel>
-    <NoWarn>1701;1702;1705</NoWarn>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
-    <DefineConstants>TRACE</DefineConstants>
-  </PropertyGroup>
-
+  <Import Project="$(MSBuildThisFileDirectory)Microsoft.NET.DefaultOutputPaths.targets" />
+  
 </Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.VisualBasic.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.VisualBasic.props
@@ -15,11 +15,11 @@ Copyright (c) .NET Foundation. All rights reserved.
     <VBRuntime>Embed</VBRuntime>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
     <DefineDebug>true</DefineDebug>
     <DefineTrace>true</DefineTrace>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <DefineTrace>true</DefineTrace>
   </PropertyGroup>
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.props
@@ -15,11 +15,26 @@ Copyright (c) .NET Foundation. All rights reserved.
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
   </PropertyGroup>
 
+  <!-- Default configuration and platform to Debug|AnyCPU--> 
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+  </PropertyGroup>
+
+  <!--
+    Ensure VS sees two default configurations: Debug|AnyCPU and Release|AnyCPU
+
+    This is temproary until we have designed and implemented a new configuration management scheme,
+    which is tracked by https://github.com/dotnet/sdk/issues/350. In the meantime, one consequence of
+    defining these defaults here with the old inference-from-usage scheme here is that the user cannot
+    remove or rename them.
+  -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "/>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' "/>
+
   <!-- User-facing configuration-agnostic defaults -->
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform>AnyCPU</Platform>
     <FileAlignment>512</FileAlignment>
     <ErrorReport>prompt</ErrorReport>
     <AssemblyName>$(MSBuildProjectName)</AssemblyName>
@@ -28,14 +43,19 @@ Copyright (c) .NET Foundation. All rights reserved.
   </PropertyGroup>
 
   <!-- User-facing configuration-specific defaults -->
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+
+  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
     <DebugSymbols>true</DebugSymbols>
     <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Platform)' == 'x64' ">
+    <PlatformTarget>x64</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Platform)' == 'x86' ">
+    <PlatformTarget>x86</PlatformTarget>
   </PropertyGroup>
 
   <!-- Default settings for all projects built with this Sdk package -->
@@ -60,6 +80,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <!-- Temp Hack: https://github.com/Microsoft/msbuild/issues/1045: This is the only before common targets hook available to us, but using it is hijacking a hook that should belong to the user. -->
     <CustomBeforeMicrosoftCommonTargets>$(MSBuildThisFileDirectory)Microsoft.NET.Sdk.BeforeCommon.targets</CustomBeforeMicrosoftCommonTargets>
+    <CustomBeforeMicrosoftCommonCrossTargetingTargets>$(MSBuildThisFileDirectory)Microsoft.NET.Sdk.BeforeCommonCrossTargeting.targets</CustomBeforeMicrosoftCommonCrossTargetingTargets>
   </PropertyGroup>
 
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.NET.Sdk.CSharp.props" Condition="'$(MSBuildProjectExtension)' == '.csproj'" />

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.TargetFrameworkInference.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.TargetFrameworkInference.targets
@@ -78,12 +78,11 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <!--
     Append $(TargetFramework) directory to output and intermediate paths to prevent bin clashes between
-    targets. However, we must leave OutputPath unset if it's not already as common targets use this to 
-    detect an invalid configuration or platform.
+    targets.
    -->
   <PropertyGroup>
     <IntermediateOutputPath>$(IntermediateOutputPath)$(TargetFramework)\</IntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)' != ''">$(OutputPath)$(TargetFramework)\</OutputPath>
+    <OutputPath>$(OutputPath)$(TargetFramework)\</OutputPath>
   </PropertyGroup>
 
 </Project>

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildASolutionWithNonAnyCPUPlatform.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildASolutionWithNonAnyCPUPlatform.cs
@@ -30,7 +30,7 @@ namespace Microsoft.NET.Build.Tests
                 .Should()
                 .Pass();
 
-            buildCommand.GetOutputDirectory("netcoreapp1.0", @"x64\Debug")
+            buildCommand.GetOutputDirectory("netcoreapp1.0", Path.Combine("x64", "Debug"))
                 .Should()
                 .OnlyHaveFiles(new[] {
                     "x64SolutionBuild.runtimeconfig.dev.json",

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildASolutionWithNonAnyCPUPlatform.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildASolutionWithNonAnyCPUPlatform.cs
@@ -1,0 +1,44 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.IO;
+using System.Runtime.InteropServices;
+using Microsoft.NET.TestFramework;
+using Microsoft.NET.TestFramework.Assertions;
+using Microsoft.NET.TestFramework.Commands;
+using Xunit;
+using static Microsoft.NET.TestFramework.Commands.MSBuildTest;
+
+namespace Microsoft.NET.Build.Tests
+{
+    public class GivenThatWeWantToBuildASolutionWithNonAnyCPUPlatform
+    {
+        private TestAssetsManager _testAssetsManager = TestAssetsManager.TestProjectsAssetsManager;
+
+        [Fact]
+        public void It_builds_solusuccessfully()
+        {
+            var testAsset = _testAssetsManager
+                .CopyTestAsset("x64SolutionBuild")
+                .WithSource()
+                .Restore();
+
+
+            var buildCommand = new BuildCommand(Stage0MSBuild, testAsset.TestRoot, "x64SolutionBuild.sln");
+            buildCommand
+                .Execute()
+                .Should()
+                .Pass();
+
+            buildCommand.GetOutputDirectory("netcoreapp1.0", @"x64\Debug")
+                .Should()
+                .OnlyHaveFiles(new[] {
+                    "x64SolutionBuild.runtimeconfig.dev.json",
+                    "x64SolutionBuild.runtimeconfig.json",
+                    "x64SolutionBuild.deps.json",
+                    "x64SolutionBuild.dll",
+                    "x64SolutionBuild.pdb"
+                });
+        }
+    }
+}

--- a/test/Microsoft.NET.Pack.Tests/GivenThatWeWantToPackASimpleLibrary.cs
+++ b/test/Microsoft.NET.Pack.Tests/GivenThatWeWantToPackASimpleLibrary.cs
@@ -1,0 +1,44 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.IO;
+using System.Runtime.InteropServices;
+using Microsoft.DotNet.Cli.Utils;
+using Microsoft.DotNet.InternalAbstractions;
+using Microsoft.NET.TestFramework;
+using Microsoft.NET.TestFramework.Assertions;
+using Microsoft.NET.TestFramework.Commands;
+using Xunit;
+using static Microsoft.NET.TestFramework.Commands.MSBuildTest;
+
+namespace Microsoft.NET.Pack.Tests
+{
+    public class GivenThatWeWantToPackASimpleLibrary
+    {
+        private TestAssetsManager _testAssetsManager = TestAssetsManager.TestProjectsAssetsManager;
+
+        [Fact]
+        public void It_packs_successfully()
+        {
+            var testAsset = _testAssetsManager
+                .CopyTestAsset("HelloWorld")
+                .WithSource()
+                .Restore();
+
+            new PackCommand(Stage0MSBuild, testAsset.TestRoot)
+                .Execute()
+                .Should()
+                .Pass();
+
+            var outputDirectory = new DirectoryInfo(Path.Combine(testAsset.TestRoot, "bin", "Debug"));
+            outputDirectory.Should().OnlyHaveFiles(new[] {
+                "HelloWorld.1.0.0.nupkg",
+                "netcoreapp1.0/HelloWorld.dll",
+                "netcoreapp1.0/HelloWorld.pdb",
+                "netcoreapp1.0/HelloWorld.deps.json",
+                "netcoreapp1.0/HelloWorld.runtimeconfig.json",
+                "netcoreapp1.0/HelloWorld.runtimeconfig.dev.json",
+            });
+        }
+    }
+}

--- a/test/Microsoft.NET.Pack.Tests/Microsoft.NET.Pack.Tests.csproj
+++ b/test/Microsoft.NET.Pack.Tests/Microsoft.NET.Pack.Tests.csproj
@@ -36,6 +36,7 @@
     </PackageReference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="GivenThatWeWantToPackASimpleLibrary.cs" />
     <Compile Include="GivenThatWeWantToPackACrossTargetedLibrary.cs" />
     <EmbeddedResource Include="**\*.resx" Exclude="$(GlobalExclude)" />
   </ItemGroup>

--- a/test/Microsoft.NET.TestFramework/Commands/BuildCommand.cs
+++ b/test/Microsoft.NET.TestFramework/Commands/BuildCommand.cs
@@ -11,8 +11,8 @@ namespace Microsoft.NET.TestFramework.Commands
 {
     public sealed class BuildCommand : TestCommand
     {
-        public BuildCommand(MSBuildTest msbuild, string projectPath)
-            : base(msbuild, projectPath)
+        public BuildCommand(MSBuildTest msbuild, string projectRootPath, string relativePathToProject = null)
+            : base(msbuild, projectRootPath, relativePathToProject)
         {
         }
 

--- a/test/Microsoft.NET.TestFramework/Commands/TestCommand.cs
+++ b/test/Microsoft.NET.TestFramework/Commands/TestCommand.cs
@@ -17,21 +17,22 @@ namespace Microsoft.NET.TestFramework.Commands
 
         public string FullPathProjectFile => Path.Combine(ProjectRootPath, ProjectFile);
 
-        protected TestCommand(MSBuildTest msBuild, string projectRootPath, bool skipResolvingProjectFile = false)
+        protected TestCommand(MSBuildTest msBuild, string projectRootPath, string relativePathToProject = null)
         {
             MSBuild = msBuild;
             ProjectRootPath = projectRootPath;
-
-            if (!skipResolvingProjectFile)
-            {
-                ProjectFile = FindProjectFile();
-            }
+            ProjectFile = FindProjectFile(relativePathToProject);
         }
 
         public abstract CommandResult Execute(params string[] args);
 
-        private string FindProjectFile()
+        private string FindProjectFile(string relativePathToProject)
         {
+            if (!string.IsNullOrEmpty(relativePathToProject))
+            {
+                return Path.Combine(ProjectRootPath, relativePathToProject);
+            }
+
             var buildProjectFiles = Directory.GetFiles(ProjectRootPath, "*.csproj");
 
             if(buildProjectFiles.Length != 1)


### PR DESCRIPTION
Also, set PlatformTarget to match Platform for x86 and x64 as VS would
do for classic projects.

This is enough to close all of the following:
* Fix https://github.com/dotnet/sdk/issues/328
* Fix https://github.com/dotnet/sdk/issues/203
* Fix https://github.com/dotnet/sdk/issues/318
* Fix https://github.com/dotnet/roslyn-project-system/issues/527


But there is remaining work to manage (add/remove/rename) configurations and platforms, which is now tracked by:
* https://github.com/dotnet/sdk/issues/350
* https://github.com/dotnet/roslyn-project-system/issues/694

