### PR TITLE
update NuGet in SDK to 4.0.0.2048

### DIFF
--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -8,7 +8,7 @@
     
     <MsBuildPackagesVersion>0.1.0-preview-00028-160627</MsBuildPackagesVersion>
     <CoreSetupVersion>1.0.1-beta-000933</CoreSetupVersion>
-    <NuGetVersion>4.0.0-rc-2037</NuGetVersion>
+    <NuGetVersion>4.0.0-rc-2048</NuGetVersion>
     <RoslynVersion>2.0.0-beta6-60922-08</RoslynVersion>
   </PropertyGroup>
 

--- a/build/Nuget/Microsoft.NET.Sdk.nuspec
+++ b/build/Nuget/Microsoft.NET.Sdk.nuspec
@@ -11,7 +11,7 @@
     <authors>dotnet</authors>
     <projectUrl>http://dot.net</projectUrl>
     <dependencies>
-        <dependency id="Nuget.Build.Tasks.Pack" version="4.0.0-rc-2037" />
+        <dependency id="Nuget.Build.Tasks.Pack" version="4.0.0-rc-2048" />
     </dependencies>
   </metadata>
   <files>


### PR DESCRIPTION
updating NuGet in SDK to 4.0.0.2048

It may fail w/o the new CLI update.
If so, please feel free to push to this branch/pr with that extra delta.

@piotrpMSFT @livarcocc @nguerrera @joelverhagen 