### PR TITLE
Add validation that referenced project target framework is compatible with current target

### DIFF
--- a/TestAssets/TestProjects/ProjectConstruction/SdkProject/SdkProject.csproj
+++ b/TestAssets/TestProjects/ProjectConstruction/SdkProject/SdkProject.csproj
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" />  
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="**\*.cs" />
+    <EmbeddedResource Include="**\*.resx" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Sdk">
+      <Version>0.0</Version>
+      <PrivateAssets>All</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.Common.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.Common.targets
@@ -32,5 +32,40 @@ Copyright (c) .NET Foundation. All rights reserved.
     <Product Condition="'$(Product)' == ''">$(AssemblyName)</Product>
     <NeutralLanguage Condition="'$(NeutralLanguage)' == ''">en</NeutralLanguage>
   </PropertyGroup>
+
+  <UsingTask TaskName="GetNearestTargetFramework" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
+
+  <!--
+  ============================================================
+                              GetTargetFrameworkProperties
+
+    Invoked by common targets to return the set of properties 
+    (in the form  "key1=value1;...keyN=valueN") needed to build 
+    against the target framework that best matches the referring
+    project's target framework.
+
+    The referring project's $(TargetFrameworkMoniker) is passed 
+    in as $(ReferringTargetFramework).
+
+    This is in the common targets so that it will apply to both
+    cross-targeted and single-targeted projects.  It is run
+    for single-targeted projects so that an error will be
+    generated if the referenced project is not compatible
+    with the referencing project's target framework.
+  ============================================================
+   -->
+  <Target Name="GetTargetFrameworkProperties" Returns="TargetFramework=$(NearestTargetFramework)">
+
+    <PropertyGroup>
+      <_PossibleTargetFrameworks Condition="'$($TargetFramework)' != ''">$(TargetFramework)</_PossibleTargetFrameworks>
+      <_PossibleTargetFrameworks Condition="'$($TargetFramework)' == ''">$(TargetFrameworks)</_PossibleTargetFrameworks>
+    </PropertyGroup>
+
+    <GetNearestTargetFramework ReferringTargetFramework="$(ReferringTargetFramework)" 
+                               PossibleTargetFrameworks="$(_PossibleTargetFrameworks)"
+                               ProjectFilePath="$(MSBuildProjectFullPath)">
+      <Output PropertyName="NearestTargetFramework" TaskParameter="NearestTargetFramework" />
+    </GetNearestTargetFramework>
+  </Target>
   
 </Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.Common.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.Common.targets
@@ -57,8 +57,8 @@ Copyright (c) .NET Foundation. All rights reserved.
   <Target Name="GetTargetFrameworkProperties" Returns="TargetFramework=$(NearestTargetFramework)">
 
     <PropertyGroup>
-      <_PossibleTargetFrameworks Condition="'$($TargetFramework)' != ''">$(TargetFramework)</_PossibleTargetFrameworks>
-      <_PossibleTargetFrameworks Condition="'$($TargetFramework)' == ''">$(TargetFrameworks)</_PossibleTargetFrameworks>
+      <_PossibleTargetFrameworks Condition="'$(TargetFramework)' != ''">$(TargetFramework)</_PossibleTargetFrameworks>
+      <_PossibleTargetFrameworks Condition="'$(TargetFramework)' == ''">$(TargetFrameworks)</_PossibleTargetFrameworks>
     </PropertyGroup>
 
     <GetNearestTargetFramework ReferringTargetFramework="$(ReferringTargetFramework)" 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.targets
@@ -221,20 +221,6 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <!--
   ============================================================
-                                 GetTargetFrameworkProperties
-
-  This target is called to assign properties that invoke the
-  correct inner build for a given referring framework. This 
-  override handles the non-cross-targeting project case, where
-  we simply return 'TargetFramework=$(TargetFramework)' to ensure
-  that global /p:TargetFramework=X passed to referring project 
-  doesn't flow to us.
-  ============================================================
-  -->
-  <Target Name="GetTargetFrameworkProperties" Returns="TargetFramework=$(TargetFramework)" />
-
-  <!--
-  ============================================================
                                          Project Capabilities
   ============================================================
   -->

--- a/src/Tasks/Microsoft.NET.Build.Tasks/buildCrossTargeting/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/buildCrossTargeting/Microsoft.NET.Sdk.targets
@@ -17,29 +17,6 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <Import Project="..\build\Microsoft.NET.Sdk.Common.targets"/>
 
-  <UsingTask TaskName="GetNearestTargetFramework" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
-
-  <!--
-  ============================================================
-                              GetTargetFrameworkProperties
-
-    Invoked by common targets to return the set of properties 
-    (in the form  "key1=value1;...keyN=valueN") needed to build 
-    against the target framework that best matches the referring
-    project's target framework.
-
-    The referring project's $(TargetFrameworkMoniker) is passed 
-    in as $(ReferringTargetFramework).
-  ============================================================
-   -->
-  <Target Name="GetTargetFrameworkProperties" Returns="TargetFramework=$(NearestTargetFramework)">
-    <GetNearestTargetFramework ReferringTargetFramework="$(ReferringTargetFramework)" 
-                               PossibleTargetFrameworks="$(TargetFrameworks)"
-                               ProjectFilePath="$(MSBuildProjectFullPath)">
-      <Output PropertyName="NearestTargetFramework" TaskParameter="NearestTargetFramework" />
-    </GetNearestTargetFramework>
-  </Target>
-
   <!--
   ============================================================
                               Publish

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToReferenceAProject.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToReferenceAProject.cs
@@ -1,0 +1,130 @@
+﻿using Microsoft.NET.TestFramework;
+using Microsoft.NET.TestFramework.Assertions;
+using Microsoft.NET.TestFramework.Commands;
+using Microsoft.NET.TestFramework.ProjectConstruction;
+using static Microsoft.NET.TestFramework.Commands.MSBuildTest;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using Xunit;
+using FluentAssertions;
+
+namespace Microsoft.NET.Build.Tests
+{
+    public class GivenThatWeWantToReferenceAProject
+    {
+        private TestAssetsManager _testAssetsManager = TestAssetsManager.TestProjectsAssetsManager;
+
+        //  Different types of projects which should form the test matrix:
+
+        //  Desktop (non-SDK) project
+        //  Single-targeted SDK project
+        //  Multi-targeted SDK project
+        //  PCL
+
+        //  Compatible
+        //  Incompatible
+
+        //  Exe
+        //  Library
+
+        //  .NET Core
+        //  .NET Standard
+        //  .NET Framework (SDK and non-SDK)
+
+        public enum ReferenceBuildResult
+        {
+            BuildSucceeds,
+            FailsRestore,
+            FailsBuild
+        }
+
+        [Theory]
+        [InlineData("netcoreapp1.0", "netstandard1.5", true, true)]
+        [InlineData("netstandard1.2", "netstandard1.5", false, false)]
+        [InlineData("netcoreapp1.0", "net45;netstandard1.5", true, true)]
+        [InlineData("netcoreapp1.0", "net45;net46", false, false)]
+        [InlineData("netcoreapp1.0;net461", "netstandard1.4", true, true)]
+        [InlineData("netcoreapp1.0;net45", "netstandard1.4", false, false)]
+        [InlineData("netcoreapp1.0;net46", "net45;netstandard1.6", true, true)]
+        [InlineData("netcoreapp1.0;net45", "net46;netstandard1.6", false, false)]
+        public void It_checks_for_valid_references(string referencerTarget, string dependencyTarget, bool restoreSucceeds, bool buildSucceeds)
+        {
+            string identifier = referencerTarget.ToString() + " " + dependencyTarget.ToString();
+
+            TestProject referencerProject = new TestProject()
+            {
+                Name = "Referencer",
+                IsSdkProject = true,
+            };
+
+            TestProject dependencyProject = new TestProject()
+            {
+                Name = "Dependency",
+                IsSdkProject = true
+            };
+
+            if (referencerTarget.Contains(";"))
+            {
+                referencerProject.TargetFrameworks = referencerTarget;
+            }
+            else
+            {
+                referencerProject.TargetFramework = referencerTarget;
+            }
+
+            if (dependencyTarget.Contains(";"))
+            {
+                dependencyProject.TargetFrameworks = dependencyTarget;
+            }
+            else
+            {
+                dependencyProject.TargetFramework = dependencyTarget;
+            }
+
+            referencerProject.ReferencedProjects.Add(dependencyProject);
+
+            var testAsset = _testAssetsManager.CreateTestProject(referencerProject, nameof(It_checks_for_valid_references), identifier);
+
+            var restoreCommand = testAsset.GetRestoreCommand(relativePath: "Referencer");
+
+            if (restoreSucceeds)
+            {
+                restoreCommand
+                    .Execute()
+                    .Should()
+                    .Pass();
+            }
+            else
+            {
+                restoreCommand
+                    .CaptureStdOut()
+                    .Execute()
+                    .Should()
+                    .Fail();
+            }
+
+            var appProjectDirectory = Path.Combine(testAsset.TestRoot, "Referencer");
+
+            var buildCommand = new BuildCommand(Stage0MSBuild, appProjectDirectory);
+
+            if (!buildSucceeds)
+            {
+                buildCommand = buildCommand.CaptureStdOut();
+            }
+
+            var result = buildCommand.Execute();
+
+            if (buildSucceeds)
+            {
+                result.Should().Pass();
+            }
+            else
+            {
+                result.Should().Fail()
+                    .And.HaveStdOutContaining("has no target framework compatible with");
+            }
+        }
+    }
+}

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToReferenceAProject.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToReferenceAProject.cs
@@ -9,6 +9,7 @@ using System.IO;
 using System.Text;
 using Xunit;
 using FluentAssertions;
+using System.Runtime.InteropServices;
 
 namespace Microsoft.NET.Build.Tests
 {
@@ -84,6 +85,15 @@ namespace Microsoft.NET.Build.Tests
             }
 
             referencerProject.ReferencedProjects.Add(dependencyProject);
+
+            //  Skip running test if not running on Windows
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                if (!referencerProject.BuildsOnNonWindows || !dependencyProject.BuildsOnNonWindows)
+                {
+                    return;
+                }
+            }
 
             var testAsset = _testAssetsManager.CreateTestProject(referencerProject, nameof(It_checks_for_valid_references), identifier);
 

--- a/test/Microsoft.NET.TestFramework/Commands/RestoreCommand.cs
+++ b/test/Microsoft.NET.TestFramework/Commands/RestoreCommand.cs
@@ -12,6 +12,7 @@ namespace Microsoft.NET.TestFramework.Commands
     public sealed class RestoreCommand : TestCommand
     {
         private List<string> _sources = new List<string>();
+        private bool _captureStdOut;
 
         public RestoreCommand(MSBuildTest msbuild, string projectPath)
             : base(msbuild, projectPath)
@@ -37,6 +38,12 @@ namespace Microsoft.NET.TestFramework.Commands
             return this;
         }
 
+        public RestoreCommand CaptureStdOut()
+        {
+            _captureStdOut = true;
+            return this;
+        }
+
         public override CommandResult Execute(params string[] args)
         {
             var newArgs = new List<string>();
@@ -51,6 +58,11 @@ namespace Microsoft.NET.TestFramework.Commands
             newArgs.AddRange(args);
 
             var command = MSBuild.CreateCommandForTarget("restore", newArgs.ToArray());
+
+            if (_captureStdOut)
+            {
+                command = command.CaptureStdOut();
+            }
 
             return command.Execute();
         }

--- a/test/Microsoft.NET.TestFramework/ProjectConstruction/TestProject.cs
+++ b/test/Microsoft.NET.TestFramework/ProjectConstruction/TestProject.cs
@@ -22,8 +22,38 @@ namespace Microsoft.NET.TestFramework.ProjectConstruction
         //  TargetFrameworkVersion applies to non-SDK projects
         public string TargetFrameworkVersion { get; set; }
 
-
         public List<TestProject> ReferencedProjects { get; } = new List<TestProject>();
+
+        public bool BuildsOnNonWindows
+        {
+            get
+            {
+                if (!IsSdkProject)
+                {
+                    return false;
+                }
+
+                //  Currently can't build projects targeting .NET Framework on non-Windows: https://github.com/dotnet/sdk/issues/335
+                foreach (var target in TargetFrameworks?.Split(';') ?? new[] { TargetFramework })
+                {
+                    int identifierLength = 0;
+                    for (; identifierLength < target.Length; identifierLength++)
+                    {
+                        if (!char.IsLetter(target[identifierLength]))
+                        {
+                            break;
+                        }
+                    }
+
+                    string identifier = target.Substring(0, identifierLength);
+                    if (identifier.Equals("net", StringComparison.OrdinalIgnoreCase))
+                    {
+                        return false;
+                    }
+                }
+                return true;
+            }
+        }
 
         //  TODO: Source files
 

--- a/test/Microsoft.NET.TestFramework/ProjectConstruction/TestProject.cs
+++ b/test/Microsoft.NET.TestFramework/ProjectConstruction/TestProject.cs
@@ -116,7 +116,7 @@ namespace Microsoft.NET.TestFramework.ProjectConstruction
 
         public override string ToString()
         {
-            StringBuilder ret = new StringBuilder();
+            var ret = new StringBuilder();
             if (!string.IsNullOrEmpty(Name))
             {
                 ret.Append(Name);

--- a/test/Microsoft.NET.TestFramework/ProjectConstruction/TestProject.cs
+++ b/test/Microsoft.NET.TestFramework/ProjectConstruction/TestProject.cs
@@ -1,0 +1,147 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Xml.Linq;
+
+namespace Microsoft.NET.TestFramework.ProjectConstruction
+{
+    public class TestProject
+    {
+        public string Name { get; set; }
+
+        public bool IsSdkProject { get; set; }
+
+        public bool IsExe { get; set; }
+
+        //  Apply to SDK Projects
+        public string TargetFramework { get; set; }
+        public string TargetFrameworks { get; set; }
+
+        //  TargetFrameworkVersion applies to non-SDK projects
+        public string TargetFrameworkVersion { get; set; }
+
+
+        public List<TestProject> ReferencedProjects { get; } = new List<TestProject>();
+
+        //  TODO: Source files
+
+        internal void Create(TestAsset targetTestAsset, string testProjectsSourceFolder)
+        {
+            string targetFolder = Path.Combine(targetTestAsset.Path, this.Name);
+            Directory.CreateDirectory(targetFolder);
+
+            string targetProjectPath = Path.Combine(targetFolder, this.Name + ".csproj");
+
+            string sourceProject;
+            string sourceProjectBase = Path.Combine(testProjectsSourceFolder, "ProjectConstruction");
+            if (IsSdkProject)
+            {
+                sourceProject = Path.Combine(sourceProjectBase, "SdkProject", "SdkProject.csproj");
+            }
+            else
+            {
+                throw new NotImplementedException("Non-SDK project generation not yet supported");
+            }
+
+            var projectXml = XDocument.Load(sourceProject);
+
+            var ns = XNamespace.Get("http://schemas.microsoft.com/developer/msbuild/2003");
+
+            var propertyGroup = projectXml.Root.Elements(ns + "PropertyGroup").First();
+
+            var packageReferenceItemGroup = projectXml.Root.Elements(ns + "ItemGroup")
+                .FirstOrDefault(itemGroup => itemGroup.Elements(ns + "PackageReference").Count() > 0);
+            if (packageReferenceItemGroup == null)
+            {
+                packageReferenceItemGroup = projectXml.Root.Elements(ns + "ItemGroup")
+                    .First();
+            }
+
+            if (IsSdkProject)
+            {
+                if (this.TargetFramework != null)
+                {
+                    propertyGroup.Add(new XElement(ns + "TargetFramework", this.TargetFramework));
+                }
+                if (this.TargetFrameworks != null)
+                {
+                    propertyGroup.Add(new XElement(ns + "TargetFrameworks", this.TargetFrameworks));
+                }
+
+                if (this.IsExe)
+                {
+                    packageReferenceItemGroup.Add(new XElement(ns + "PackageReference",
+                            new XAttribute("Include", "Microsoft.NETCore.App"),
+                            new XAttribute("Version", "1.0.1")
+                        ));
+                }
+                else
+                {
+                    packageReferenceItemGroup.Add(new XElement(ns + "PackageReference",
+                            new XAttribute("Include", "NETStandard.Library"),
+                            new XAttribute("Version", "1.6.0")
+                        ));
+                }
+
+                projectXml.Descendants(ns +"PackageReference")
+                        .FirstOrDefault(pr => pr.Attribute("Include")?.Value == "Microsoft.NET.Sdk")
+                        ?.Element(ns + "Version")
+                        ?.SetValue('[' + targetTestAsset.BuildVersion + ']');
+            }
+
+            if (this.ReferencedProjects.Any())
+            {
+                var projectReferenceItemGroup = projectXml.Root.Elements(ns + "ItemGroup")
+                    .FirstOrDefault(itemGroup => itemGroup.Elements(ns + "ProjectReference").Count() > 0);
+                if (projectReferenceItemGroup == null)
+                {
+                    projectReferenceItemGroup = new XElement(ns + "ItemGroup");
+                    packageReferenceItemGroup.AddBeforeSelf(projectReferenceItemGroup);
+                }
+
+                foreach (var referencedProject in ReferencedProjects)
+                {
+                    projectReferenceItemGroup.Add(new XElement(ns + "ProjectReference",
+                        new XAttribute("Include", $"../{referencedProject.Name}/{referencedProject.Name}.csproj")));
+                }
+            }
+
+            using (var file = File.CreateText(targetProjectPath))
+            {
+                projectXml.Save(file);
+            }
+        }
+
+        public override string ToString()
+        {
+            StringBuilder ret = new StringBuilder();
+            if (!string.IsNullOrEmpty(Name))
+            {
+                ret.Append(Name);
+            }
+            if (IsSdkProject)
+            {
+                ret.Append("Sdk");
+            }
+            if (IsExe)
+            {
+                ret.Append("Exe");
+            }
+            if (!string.IsNullOrEmpty(TargetFramework))
+            {
+                ret.Append(TargetFramework);
+            }
+            if (!string.IsNullOrEmpty(TargetFrameworks))
+            {
+                ret.Append("(" + TargetFramework + ")");
+            }
+            if (!string.IsNullOrEmpty(TargetFrameworkVersion))
+            {
+                ret.Append(TargetFrameworkVersion);
+            }
+            return ret.ToString();
+        }
+    }
+}

--- a/test/Microsoft.NET.TestFramework/TestAsset.cs
+++ b/test/Microsoft.NET.TestFramework/TestAsset.cs
@@ -84,7 +84,7 @@ namespace Microsoft.NET.TestFramework
                         .Descendants(XName.Get("PackageReference", "http://schemas.microsoft.com/developer/msbuild/2003"))
                         .FirstOrDefault(pr => pr.Attribute("Include")?.Value == "Microsoft.NET.Sdk")
                         ?.Element(XName.Get("Version", "http://schemas.microsoft.com/developer/msbuild/2003"))
-                        ?.SetValue('[' +BuildVersion + ']');
+                        ?.SetValue($"[{BuildVersion}]");
 
                     using (var file = File.CreateText(destFile))
                     {


### PR DESCRIPTION
This fixes #264 for the case where both projects use the .NET SDK.