### PR TITLE
Use LockFile.PackageFolders instead of NuGetPathContext

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/NuGetPackageResolver.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/NuGetPackageResolver.cs
@@ -2,8 +2,13 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using NuGet.Common;
+using NuGet.Configuration;
 using NuGet.Packaging;
+using NuGet.ProjectModel;
 using NuGet.Versioning;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 
 namespace Microsoft.NET.Build.Tasks
 {
@@ -16,9 +21,33 @@ namespace Microsoft.NET.Build.Tasks
             _packagePathResolver = new FallbackPackagePathResolver(pathContext);
         }
 
+        public NuGetPackageResolver(string userPackageFolder, IEnumerable<string> fallbackPackageFolders)
+        {
+            _packagePathResolver = new FallbackPackagePathResolver(userPackageFolder, fallbackPackageFolders);
+        }
+
         public string GetPackageDirectory(string packageId, NuGetVersion version)
         {
             return _packagePathResolver.GetPackageDirectory(packageId, version);
+        }
+
+        public static NuGetPackageResolver CreateResolver(LockFile lockFile, string projectPath)
+        {
+            NuGetPackageResolver packageResolver;
+
+            string userPackageFolder = lockFile.PackageFolders.FirstOrDefault()?.Path;
+            if (userPackageFolder != null)
+            {
+                var fallBackFolders = lockFile.PackageFolders.Skip(1).Select(f => f.Path);
+                packageResolver = new NuGetPackageResolver(userPackageFolder, fallBackFolders);
+            }
+            else
+            {
+                NuGetPathContext nugetPathContext = NuGetPathContext.Create(Path.GetDirectoryName(projectPath));
+                packageResolver = new NuGetPackageResolver(nugetPathContext);
+            }
+
+            return packageResolver;
         }
     }
 }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageDependencies.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageDependencies.cs
@@ -131,8 +131,7 @@ namespace Microsoft.NET.Build.Tasks
             {
                 if (_packageResolver == null)
                 {
-                    NuGetPathContext nugetPathContext = NuGetPathContext.Create(Path.GetDirectoryName(ProjectPath));
-                    _packageResolver = new NuGetPackageResolver(nugetPathContext);
+                    _packageResolver = NuGetPackageResolver.CreateResolver(LockFile, ProjectPath);
                 }
 
                 return _packageResolver;

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePublishAssemblies.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePublishAssemblies.cs
@@ -2,11 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
-using System.IO;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
-using NuGet.Configuration;
-using NuGet.Frameworks;
 using NuGet.ProjectModel;
 
 namespace Microsoft.NET.Build.Tasks
@@ -44,9 +41,9 @@ namespace Microsoft.NET.Build.Tasks
 
         protected override void ExecuteCore()
         {
-            LockFile lockFile = new LockFileCache(BuildEngine4).GetLockFile(AssetsFilePath);
-            NuGetPathContext nugetPathContext = NuGetPathContext.Create(Path.GetDirectoryName(ProjectPath));
+            LockFile lockFile = new LockFileCache(BuildEngine4).GetLockFile(AssetsFilePath);            
             IEnumerable<string> privateAssetsPackageIds = PackageReferenceConverter.GetPackageIds(PrivateAssetsPackageReferences);
+            IPackageResolver packageResolver = NuGetPackageResolver.CreateResolver(lockFile, ProjectPath);
 
             ProjectContext projectContext = lockFile.CreateProjectContext(
                 NuGetUtils.ParseFrameworkName(TargetFramework),
@@ -54,7 +51,7 @@ namespace Microsoft.NET.Build.Tasks
                 PlatformLibraryName);
 
             IEnumerable<ResolvedFile> resolvedAssemblies = 
-                new PublishAssembliesResolver(new NuGetPackageResolver(nugetPathContext))
+                new PublishAssembliesResolver(packageResolver)
                     .WithPrivateAssets(privateAssetsPackageIds)
                     .Resolve(projectContext);
 


### PR DESCRIPTION
Use LockFile.PackageFolders instead of NuGetPathContext when it is available 

Fixes #361

/cc @dotnet/project-system @emgarten 