### PR TITLE
Automatically add references to core framework assemblies when targeting .NET Framework

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.BeforeCommon.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.BeforeCommon.targets
@@ -68,20 +68,21 @@ Copyright (c) .NET Foundation. All rights reserved.
   <!-- For .NET Framework, reference core assemblies -->
 
   <PropertyGroup>
-    <_TargetFrameworkVersionSegmentCount>$(TargetFrameworkVersion.Split('.').Length)</_TargetFrameworkVersionSegmentCount>
-    <_TargetFrameworkMajorVersion>$(TargetFrameworkVersion.Split('.')[0])</_TargetFrameworkMajorVersion>
-    <_TargetFrameworkMajorVersion Condition="$(_TargetFrameworkMajorVersion.StartsWith('v'))">$(TargetFrameworkVersion.Substring(1))</_TargetFrameworkMajorVersion>
-    <_TargetFrameworkMinorVersion Condition="$(_TargetFrameworkVersionSegmentCount) > 1">$(TargetFrameworkVersion.Split('.')[1])</_TargetFrameworkMinorVersion>
+    <_TargetFrameworkVersionWithoutV>$(TargetFrameworkVersion)</_TargetFrameworkVersionWithoutV>
+    <_TargetFrameworkVersionWithoutV Condition="$(TargetFrameworkVersion.StartsWith('v'))">$(TargetFrameworkVersion.Substring(1))</_TargetFrameworkVersionWithoutV>
   </PropertyGroup>
   
   <ItemGroup Condition=" '$(DisableImplicitFrameworkReferences)' != 'true' and '$(TargetFrameworkIdentifier)' == '.NETFramework'">
     <Reference Include="System"/>
     <Reference Include="System.Core"/>
-    <Reference Include="System.Xml.Linq"/>
-    <Reference Include="System.Data.DataSetExtensions"/>
-    <Reference Include="Microsoft.CSharp"/>
     <Reference Include="System.Data"/>
-    <Reference Include="System.Net.Http" Condition="($(_TargetFrameworkMajorVersion) > 4) Or ($(_TargetFrameworkMajorVersion) == 4 And $(_TargetFrameworkMinorVersion) >= 5)"/>
+    <Reference Include="System.Drawing"/>
+    <Reference Include="System.IO.Compression.FileSystem" Condition=" '$(_TargetFrameworkVersionWithoutV)' >= '4.5' "/>
+    <Reference Include="System.IO.Compression" Condition=" '$(_TargetFrameworkVersionWithoutV)' >= '4.5' "/>
+    <Reference Include="System.Net.Http" Condition=" '$(_TargetFrameworkVersionWithoutV)' >= '4.5' "/>
+    <Reference Include="System.Numerics" Condition=" '$(_TargetFrameworkVersionWithoutV)' >= '4.0' "/>
+    <Reference Include="System.Runtime.Serialization"/>
+    <Reference Include="System.Xml.Linq"/>
     <Reference Include="System.Xml"/>
   </ItemGroup>
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.BeforeCommon.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.BeforeCommon.targets
@@ -77,6 +77,8 @@ Copyright (c) .NET Foundation. All rights reserved.
     <Reference Include="System.Core"/>
     <Reference Include="System.Data"/>
     <Reference Include="System.Drawing"/>
+    <!-- When doing greater than/less than comparisons between strings, MSBuild will try to parse the strings as Version objects and compare them as
+         such if the parse succeeds. -->
     <Reference Include="System.IO.Compression.FileSystem" Condition=" '$(_TargetFrameworkVersionWithoutV)' >= '4.5' "/>
     <Reference Include="System.IO.Compression" Condition=" '$(_TargetFrameworkVersionWithoutV)' >= '4.5' "/>
     <Reference Include="System.Net.Http" Condition=" '$(_TargetFrameworkVersionWithoutV)' >= '4.5' "/>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.BeforeCommon.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.BeforeCommon.targets
@@ -65,6 +65,26 @@ Copyright (c) .NET Foundation. All rights reserved.
     <PublishDir Condition="'$(PublishDir)' == ''">$(OutputPath)$(PublishDirName)\</PublishDir>
   </PropertyGroup>
 
+  <!-- For .NET Framework, reference core assemblies -->
+
+  <PropertyGroup>
+    <_TargetFrameworkVersionSegmentCount>$(TargetFrameworkVersion.Split('.').Length)</_TargetFrameworkVersionSegmentCount>
+    <_TargetFrameworkMajorVersion>$(TargetFrameworkVersion.Split('.')[0])</_TargetFrameworkMajorVersion>
+    <_TargetFrameworkMajorVersion Condition="$(_TargetFrameworkMajorVersion.StartsWith('v'))">$(TargetFrameworkVersion.Substring(1))</_TargetFrameworkMajorVersion>
+    <_TargetFrameworkMinorVersion Condition="$(_TargetFrameworkVersionSegmentCount) > 1">$(TargetFrameworkVersion.Split('.')[1])</_TargetFrameworkMinorVersion>
+  </PropertyGroup>
+  
+  <ItemGroup Condition=" '$(DisableImplicitFrameworkReferences)' != 'true' and '$(TargetFrameworkIdentifier)' == '.NETFramework'">
+    <Reference Include="System"/>
+    <Reference Include="System.Core"/>
+    <Reference Include="System.Xml.Linq"/>
+    <Reference Include="System.Data.DataSetExtensions"/>
+    <Reference Include="Microsoft.CSharp"/>
+    <Reference Include="System.Data"/>
+    <Reference Include="System.Net.Http" Condition="($(_TargetFrameworkMajorVersion) > 4) Or ($(_TargetFrameworkMajorVersion) == 4 And $(_TargetFrameworkMinorVersion) >= 5)"/>
+    <Reference Include="System.Xml"/>
+  </ItemGroup>
+
   <!-- Add conditional compilation symbols for the target framework (for example NET461, NETSTANDARD2_0, NETCOREAPP1_0) -->
   <PropertyGroup Condition=" '$(DisableImplicitFrameworkDefines)' != 'true' and '$(TargetFrameworkIdentifier)' != '.NETPortable'">
     <_FrameworkIdentifierForImplicitDefine>$(TargetFrameworkIdentifier.Replace('.', '').ToUpperInvariant())</_FrameworkIdentifierForImplicitDefine>

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildADesktopExe.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildADesktopExe.cs
@@ -122,7 +122,8 @@ namespace Microsoft.NET.Build.Tests
             var testProject = new TestProject()
             {
                 Name = "DefaultReferences",
-                TargetFrameworks = "net461",
+                //  TODO: Add net35 to the TargetFrameworks list once https://github.com/Microsoft/msbuild/issues/1333 is fixed
+                TargetFrameworks = "net40;net45;net461",
                 IsSdkProject = true,
                 IsExe = true
             };
@@ -149,9 +150,12 @@ namespace DefaultReferences
             var buildCommand = new BuildCommand(Stage0MSBuild, Path.Combine(testAsset.TestRoot, "DefaultReferences"));
 
             buildCommand
+                .CaptureStdOut()
                 .Execute()
                 .Should()
-                .Pass();
+                .Pass()
+                .And
+                .NotHaveStdOutMatching("Could not resolve this reference", System.Text.RegularExpressions.RegexOptions.CultureInvariant | System.Text.RegularExpressions.RegexOptions.IgnoreCase);
 
         }
 

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToReferenceAProject.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToReferenceAProject.cs
@@ -119,6 +119,12 @@ namespace Microsoft.NET.Build.Tests
                 buildCommand = buildCommand.CaptureStdOut();
             }
 
+            //  Suppress ResolveAssemblyReference warning output due to https://github.com/Microsoft/msbuild/issues/1329
+            if (buildSucceeds && referencerProject.IsExe && referencerProject.ShortTargetFrameworkIdentifiers.Contains("net"))
+            {
+                buildCommand = buildCommand.CaptureStdOut();
+            }
+
             var result = buildCommand.Execute();
 
             if (buildSucceeds)

--- a/test/Microsoft.NET.TestFramework/Assertions/CommandResultAssertions.cs
+++ b/test/Microsoft.NET.TestFramework/Assertions/CommandResultAssertions.cs
@@ -74,6 +74,13 @@ namespace Microsoft.NET.TestFramework.Assertions
             return new AndConstraint<CommandResultAssertions>(this);
         }
 
+        public AndConstraint<CommandResultAssertions> NotHaveStdOutMatching(string pattern, RegexOptions options = RegexOptions.None)
+        {
+            Execute.Assertion.ForCondition(!Regex.Match(_commandResult.StdOut, pattern, options).Success)
+                .FailWith(AppendDiagnosticsTo($"The command output matched a pattern it should not have. Pattern: {pattern}{Environment.NewLine}"));
+            return new AndConstraint<CommandResultAssertions>(this);
+        }
+
         public AndConstraint<CommandResultAssertions> HaveStdErr()
         {
             Execute.Assertion.ForCondition(!string.IsNullOrEmpty(_commandResult.StdErr))

--- a/test/Microsoft.NET.TestFramework/ProjectConstruction/TestProject.cs
+++ b/test/Microsoft.NET.TestFramework/ProjectConstruction/TestProject.cs
@@ -23,6 +23,8 @@ namespace Microsoft.NET.TestFramework.ProjectConstruction
 
         public List<TestProject> ReferencedProjects { get; } = new List<TestProject>();
 
+        public Dictionary<string, string> SourceFiles { get; } = new Dictionary<string, string>();
+
         private static string GetShortTargetFrameworkIdentifier(string targetFramework)
         {
             int identifierLength = 0;
@@ -212,12 +214,14 @@ namespace Microsoft.NET.TestFramework.ProjectConstruction
                 projectXml.Save(file);
             }
 
-            string source;
-
-            if (this.IsExe)
+            if (SourceFiles.Count == 0)
             {
-                source =
-@"using System;
+                string source;
+
+                if (this.IsExe)
+                {
+                    source =
+    @"using System;
 
 class Program
 {
@@ -226,19 +230,19 @@ class Program
         Console.WriteLine(""Hello World!"");
 ";
 
-                foreach (var dependency in this.ReferencedProjects)
-                {
-                    source += $"        Console.WriteLine({dependency.Name}.{dependency.Name}Class.Name);" + Environment.NewLine;
-                }
+                    foreach (var dependency in this.ReferencedProjects)
+                    {
+                        source += $"        Console.WriteLine({dependency.Name}.{dependency.Name}Class.Name);" + Environment.NewLine;
+                    }
 
-                source +=
-@"    }
+                    source +=
+    @"    }
 }";
-            }
-            else
-            {
-                source =
-$@"using System;
+                }
+                else
+                {
+                    source =
+    $@"using System;
 
 namespace {this.Name}
 {{
@@ -247,10 +251,18 @@ namespace {this.Name}
         public static string Name {{ get {{ return ""{this.Name}""; }} }}
     }}
 }}";
-            }
-            string sourcePath = Path.Combine(targetFolder, this.Name + ".cs");
+                }
+                string sourcePath = Path.Combine(targetFolder, this.Name + ".cs");
 
-            File.WriteAllText(sourcePath, source);
+                File.WriteAllText(sourcePath, source);
+            }
+            else
+            {
+                foreach (var kvp in SourceFiles)
+                {
+                    File.WriteAllText(Path.Combine(targetFolder, kvp.Key), kvp.Value);
+                }
+            }
         }
 
         public override string ToString()


### PR DESCRIPTION
Right now, if you create an ASP.NET Core application targeting .NET Framework, you won't get references to any framework assemblies except mscorlib.  This means a bunch of types (`Uri`, Linq, etc) won't be available to you.

We could add these to the templates, but in the interest of keeping the `.csproj` files concise I think it's better to reference them automatically in the SDK targets.  That's what this PR does.

The list of assemblies comes from what you get by default when creating a new .NET Framework Class Library.  For parity with .NET Standard and .NET Core projects, I'd suggest we should reference all assemblies that contain types that are in .NET Standard 2.0.  @weshaggard @ericstj @terrajobst can you provide a list of assemblies you would need to reference in .NET Framework to get all the types that are in .NET Standard 2.0?