### PR TITLE
Modify .Net Core templates to mention Package Reference Version as At…

### DIFF
--- a/src/Templates/ProjectTemplates/CSharp/.NETCore/CSharpClassLibrary/ProjectTemplate.csproj
+++ b/src/Templates/ProjectTemplates/CSharp/.NETCore/CSharpClassLibrary/ProjectTemplate.csproj
@@ -1,6 +1,6 @@
-﻿<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project ToolsVersion="15.0">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" />
-  
+
   <PropertyGroup>
     <TargetFramework>netstandard1.4</TargetFramework>
   </PropertyGroup>
@@ -11,11 +11,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NETStandard.Library">
-      <Version>1.6</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>$$buildversion$$</Version>
+    <PackageReference Include="NETStandard.Library" Version="1.6" />
+    <PackageReference Include="Microsoft.NET.Sdk" Version="$$buildversion$$">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
   </ItemGroup>

--- a/src/Templates/ProjectTemplates/CSharp/.NETCore/CSharpConsoleApplication/ProjectTemplate.csproj
+++ b/src/Templates/ProjectTemplates/CSharp/.NETCore/CSharpConsoleApplication/ProjectTemplate.csproj
@@ -1,6 +1,6 @@
-﻿<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project ToolsVersion="15.0">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" />
-  
+
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp1.0</TargetFramework>
@@ -12,14 +12,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NETCore.App">
-      <Version>1.0.1</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>$$buildversion$$</Version>
+    <PackageReference Include="Microsoft.NETCore.App" Version="1.0.1" />
+    <PackageReference Include="Microsoft.NET.Sdk" Version="$$buildversion$$">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
   </ItemGroup>
-  
+
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/src/Templates/ProjectTemplates/CSharp/.NETCore/CSharpUnitTest/ProjectTemplate.csproj
+++ b/src/Templates/ProjectTemplates/CSharp/.NETCore/CSharpUnitTest/ProjectTemplate.csproj
@@ -1,6 +1,6 @@
-﻿<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project ToolsVersion="15.0">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" />
-  
+
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp1.0</TargetFramework>
@@ -12,23 +12,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NETCore.App">
-      <Version>1.0.1</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>$$buildversion$$</Version>
+    <PackageReference Include="Microsoft.NETCore.App" Version="1.0.1" />
+    <PackageReference Include="Microsoft.NET.Sdk" Version="$$buildversion$$">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-  <PackageReference Include="Microsoft.NET.Test.Sdk">
-      <Version>15.0.0-preview-20161109-01</Version>
-    </PackageReference>
-  <PackageReference Include="MSTest.TestAdapter">
-      <Version>1.1.5-preview</Version>
-    </PackageReference>
-  <PackageReference Include="MSTest.TestFramework">
-      <Version>1.0.6-preview</Version>
-    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0-preview-20161109-01" />
+    <PackageReference Include="MSTest.TestAdapter" Version="1.1.5-preview" />
+    <PackageReference Include="MSTest.TestFramework" Version="1.0.6-preview" />
   </ItemGroup>
-  
+
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/src/Templates/ProjectTemplates/CSharp/.NETCore/CSharpXUnitTest/ProjectTemplate.csproj
+++ b/src/Templates/ProjectTemplates/CSharp/.NETCore/CSharpXUnitTest/ProjectTemplate.csproj
@@ -1,4 +1,4 @@
-﻿<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project ToolsVersion="15.0">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" />
 
   <PropertyGroup>
@@ -12,22 +12,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NETCore.App">
-      <Version>1.0.1</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>$$buildversion$$</Version>
+    <PackageReference Include="Microsoft.NETCore.App" Version="1.0.1" />
+    <PackageReference Include="Microsoft.NET.Sdk" Version="$$buildversion$$">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk">
-      <Version>15.0.0-preview-20161109-01</Version>
-    </PackageReference>
-    <PackageReference Include="xunit">
-      <Version>2.2.0-beta4-build3444</Version>
-    </PackageReference>
-    <PackageReference Include="xunit.runner.visualstudio">
-      <Version>2.2.0-beta4-build1194</Version>
-    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0-preview-20161109-01" />
+    <PackageReference Include="xunit" Version="2.2.0-beta4-build3444" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0-beta4-build1194" />
   </ItemGroup>
 
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/Templates/ProjectTemplates/VisualBasic/.NETCore/VisualBasicClassLibrary/ProjectTemplate.vbproj
+++ b/src/Templates/ProjectTemplates/VisualBasic/.NETCore/VisualBasicClassLibrary/ProjectTemplate.vbproj
@@ -1,6 +1,6 @@
-﻿<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project ToolsVersion="15.0">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" />
-  
+
   <PropertyGroup>
     <TargetFramework>netstandard1.4</TargetFramework>
   </PropertyGroup>
@@ -11,11 +11,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NETStandard.Library">
-      <Version>1.6</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>$$buildversion$$</Version>
+    <PackageReference Include="NETStandard.Library" Version="1.6" />
+    <PackageReference Include="Microsoft.NET.Sdk" Version="$$buildversion$$">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
   </ItemGroup>

--- a/src/Templates/ProjectTemplates/VisualBasic/.NETCore/VisualBasicConsoleApplication/ProjectTemplate.vbproj
+++ b/src/Templates/ProjectTemplates/VisualBasic/.NETCore/VisualBasicConsoleApplication/ProjectTemplate.vbproj
@@ -1,6 +1,6 @@
-﻿<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project ToolsVersion="15.0">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" />
-  
+
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp1.0</TargetFramework>
@@ -12,11 +12,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NETCore.App">
-      <Version>1.0.1</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>$$buildversion$$</Version>
+    <PackageReference Include="Microsoft.NETCore.App" Version="1.0.1" />
+    <PackageReference Include="Microsoft.NET.Sdk" Version="$$buildversion$$">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
   </ItemGroup>


### PR DESCRIPTION
…tribute

This change modifies the template of the .Net Core Projects to mention
the version of the package references as an attribute rather than a
metadata since Msbuild supports it now.

Also we are removing the xmlns attribute from the templates.

Adding @dotnet/project-system @srivatsn for review