### PR TITLE
Move reference manager capabilities from the project system and remov…

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.targets
@@ -241,6 +241,14 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ProjectCapability Include="CrossPlatformExecutable" />
   </ItemGroup>
 
+  <!-- Reference Manager capabilities -->
+  <ItemGroup>
+    <ProjectCapability Include="AssemblyReferences" />
+    <ProjectCapability Include="ProjectReferences" />
+    <ProjectCapability Include="PackageReferences" />
+    <ProjectCapability Include="SharedProjectReferences" />
+  </ItemGroup>
+
   <Import Project="$(MSBuildThisFileDirecotry)Microsoft.NET.DisableStandardFrameworkResolution.targets" Condition="'$(DisableStandardFrameworkResolution)' == 'true'" />
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.NET.GenerateAssemblyInfo.targets" />
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.NET.Publish.targets" />


### PR DESCRIPTION
Related to these issues in the project system repo:

https://github.com/dotnet/roslyn-project-system/issues/399
https://github.com/dotnet/roslyn-project-system/issues/400

The capabilities that control this should be at the SDK layer not at the project system layer as different projects will need to define different capabilities to enable the type of references they want. There will be a matching PR on that repo to remove the capabilities from the design time targets.

@dsplaisted I just looked at moving the other capability in here but decided against it since that one is following the rest of the xml doc comments settings so it made more sense to have those all in the same place as opposed to keeping all of the capabilities in the same file.