### PR TITLE
Fix Sort Order for UnitTest templates

### DIFF
--- a/src/Templates/ProjectTemplates/CSharp/.NETCore/CSharpUnitTest/UnitTest.vstemplate
+++ b/src/Templates/ProjectTemplates/CSharp/.NETCore/CSharpUnitTest/UnitTest.vstemplate
@@ -6,7 +6,7 @@
     <Icon Package="{52CBD135-1F97-2580-011F-C7CD052E44DE}" ID="531"/>
     <ProjectType>CSharp</ProjectType>
     <RequiredFrameworkVersion>2.0</RequiredFrameworkVersion>
-    <SortOrder>12</SortOrder>
+    <SortOrder>15</SortOrder>
     <TemplateID>Microsoft.CSharp.NETCore.UnitTest</TemplateID>
     <CreateNewFolder>true</CreateNewFolder>
     <CreateInPlace>true</CreateInPlace>

--- a/src/Templates/ProjectTemplates/CSharp/.NETCore/CSharpXUnitTest/XUnitTest.vstemplate
+++ b/src/Templates/ProjectTemplates/CSharp/.NETCore/CSharpXUnitTest/XUnitTest.vstemplate
@@ -6,7 +6,7 @@
     <Icon Package="{52CBD135-1F97-2580-011F-C7CD052E44DE}" ID="531"/>
     <ProjectType>CSharp</ProjectType>
     <RequiredFrameworkVersion>2.0</RequiredFrameworkVersion>
-    <SortOrder>13</SortOrder>
+    <SortOrder>16</SortOrder>
     <TemplateID>Microsoft.CSharp.NETCore.XUnitTest</TemplateID>
     <CreateNewFolder>true</CreateNewFolder>
     <CreateInPlace>true</CreateInPlace>


### PR DESCRIPTION
Changing the sort order for UnitTest templates to make them appear after Console App and Class Lib.