### PR TITLE
Fix handling of ProjectName.deps.json file in incremental builds

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.targets
@@ -92,10 +92,13 @@ Copyright (c) .NET Foundation. All rights reserved.
                       RuntimeIdentifier="$(RuntimeIdentifier)"
                       PlatformLibraryName="$(MicrosoftNETPlatformLibrary)"
                       CompilerOptions="@(DependencyFileCompilerOptions)">
-
-      <Output TaskParameter="FilesWritten" ItemName="FileWrites" />
     </GenerateDepsFile>
 
+    <ItemGroup>
+      <!-- Do this in an ItemGroup instead of as an output parameter of the GenerateDepsFile task so that it still gets added to the item set
+           during incremental builds when the task is skipped -->
+      <FileWrites Include="$(ProjectDepsFilePath)" Condition="Exists('$(ProjectDepsFilePath)')"/>
+    </ItemGroup>
   </Target>
 
   <!--

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAnAppWithLibrary.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAnAppWithLibrary.cs
@@ -32,15 +32,37 @@ namespace Microsoft.NET.Build.Tests
             testAsset.Restore("TestApp");
             testAsset.Restore("TestLibrary");
 
+            VerifyAppBuilds(testAsset);
+        }
+
+        [Fact]
+        public void It_builds_the_project_successfully_twice()
+        {
+            var testAsset = _testAssetsManager
+                .CopyTestAsset("AppWithLibrary")
+                .WithSource();
+
+            testAsset.Restore("TestApp");
+            testAsset.Restore("TestLibrary");
+
+
+            for (int i = 0; i < 2; i++)
+            {
+                VerifyAppBuilds(testAsset);
+            }
+        }
+
+        void VerifyAppBuilds(TestAsset testAsset)
+        {
             var appProjectDirectory = Path.Combine(testAsset.TestRoot, "TestApp");
 
             var buildCommand = new BuildCommand(Stage0MSBuild, appProjectDirectory);
+            var outputDirectory = buildCommand.GetOutputDirectory("netcoreapp1.0");
+
             buildCommand
                 .Execute()
                 .Should()
                 .Pass();
-
-            var outputDirectory = buildCommand.GetOutputDirectory("netcoreapp1.0");
 
             outputDirectory.Should().OnlyHaveFiles(new[] {
                 "TestApp.dll",


### PR DESCRIPTION
Fixes #408

The issue was that if the ProjectName.deps.json file was up to date, then the `GenerateDepsFile` target would be skipped and the deps.json file would not be included in the `FileWrites` item group, causing it to get deleted by `IncrementalClean`.  This change adds a separate target which always runs which adds the deps.json file to the `FileWrites` group even if `GenerateDepsFile` isn't run.