### PR TITLE
update nuget to 4.0.0-rc2 version 2067

### DIFF
--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -8,7 +8,7 @@
     
     <MsBuildPackagesVersion>0.1.0-preview-00028-160627</MsBuildPackagesVersion>
     <CoreSetupVersion>1.0.1-beta-000933</CoreSetupVersion>
-    <NuGetVersion>4.0.0-rc-2048</NuGetVersion>
+    <NuGetVersion>4.0.0-rc2</NuGetVersion>
     <RoslynVersion>2.0.0-beta6-60922-08</RoslynVersion>
   </PropertyGroup>
 

--- a/build/Nuget/Microsoft.NET.Sdk.nuspec
+++ b/build/Nuget/Microsoft.NET.Sdk.nuspec
@@ -11,7 +11,7 @@
     <authors>dotnet</authors>
     <projectUrl>http://dot.net</projectUrl>
     <dependencies>
-        <dependency id="Nuget.Build.Tasks.Pack" version="4.0.0-rc-2048" />
+        <dependency id="Nuget.Build.Tasks.Pack" version="4.0.0-rc2" />
     </dependencies>
   </metadata>
   <files>


### PR DESCRIPTION
Integrate 4.0.0.2067 which has 3 important pack fixes, but doesn’t have the API changes that have made this more difficult to integrate.
NuGet-build feed on dotnet already has 4.0.0-rc2 packages of version 4.0.0.2067

@rrelyea @livarcocc @eerhardt @srivatsn 