### PR TITLE
Skip ResolvePackageDependencies task during design-time builds where restore hasn't occured

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.PackageDependencyResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.PackageDependencyResolution.targets
@@ -136,7 +136,12 @@ Copyright (c) .NET Foundation. All rights reserved.
   <UsingTask TaskName="Microsoft.NET.Build.Tasks.ResolvePackageDependencies"
              AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
 
-  <Target Name="RunResolvePackageDependencies">
+  <!-- The condition on this target causes it to be skipped during design-time builds if
+        the restore operation hasn't run yet.  This is to avoid displaying an error in
+        the Visual Studio error list when a project is created before NuGet restore has
+        run and created the assets file. -->
+  <Target Name="RunResolvePackageDependencies"
+          Condition=" '$(DesignTimeBuild)' != 'true' Or Exists('$(ProjectAssetsFile)')">
     <ResolvePackageDependencies
       ProjectPath="$(MSBuildProjectFullPath)"
       ProjectAssetsFile="$(ProjectAssetsFile)"

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildALibrary.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildALibrary.cs
@@ -401,6 +401,68 @@ namespace Microsoft.NET.Build.Tests
             }, SearchOption.TopDirectoryOnly);
         }
 
+        [Fact]
+        public void The_design_time_build_succeeds_before_nuget_restore()
+        {
+            //  This test needs the design-time targets, which come with Visual Studio.  So we will use the VSINSTALLDIR
+            //  environment variable to find the install path to Visual Studio and the design-time targets under it.
+            //  This will be set when running from a developer command prompt.  Unfortunately, unless VS is launched
+            //  from a developer command prompt, it won't be set when running tests from VS.  So in that case the
+            //  test will simply be skipped.
+            string vsInstallDir = Environment.GetEnvironmentVariable("VSINSTALLDIR");
+            
+            if (vsInstallDir == null)
+            {
+                return;
+            }
+
+            string csharpDesignTimeTargets = Path.Combine(vsInstallDir, @"MSBuild\Microsoft\VisualStudio\Managed\Microsoft.CSharp.DesignTime.targets");
+
+            var testAsset = _testAssetsManager
+                .CopyTestAsset("AppWithLibrary")
+                .WithSource();
+
+            var libraryProjectDirectory = Path.Combine(testAsset.TestRoot, "TestLibrary");
+            var projectFile = Path.Combine(libraryProjectDirectory, "TestLibrary.csproj");
+
+            var args = new[]
+            {
+                projectFile,
+                "/p:DesignTimeBuild=true",
+                "/p:SkipCompilerExecution=true",
+                "/p:ProvideCommandLineArgs=true",
+                $"/p:CSharpDesignTimeTargetsPath={csharpDesignTimeTargets}",
+                "/t:ResolveProjectReferencesDesignTime",
+                "/t:ResolveComReferencesDesignTime",
+                "/t:CompileDesignTime",
+                "/t:ResolvePackageDependenciesDesignTime"
+            };
+
+            var command = Stage0MSBuild.CreateCommandForTarget("ResolveAssemblyReferencesDesignTime", args);
+
+            command
+                .Execute()
+                .Should()
+                .Pass();
+        }
+
+        [Fact]
+        public void The_build_fails_if_nuget_restore_has_not_occurred()
+        {
+            var testAsset = _testAssetsManager
+                .CopyTestAsset("AppWithLibrary")
+                .WithSource();
+
+            var libraryProjectDirectory = Path.Combine(testAsset.TestRoot, "TestLibrary");
+
+            var buildCommand = new BuildCommand(Stage0MSBuild, libraryProjectDirectory);
+            buildCommand
+                .CaptureStdOut()
+                .Execute()
+                .Should()
+                .Fail();
+        }
+
         [Theory]
         [InlineData(".NETStandard,Version=v1.0", new[] { "NETSTANDARD1_0" }, false)]
         [InlineData("netstandard1.3", new[] { "NETSTANDARD1_3" }, false)]

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildALibrary.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildALibrary.cs
@@ -440,10 +440,19 @@ namespace Microsoft.NET.Build.Tests
 
             var command = Stage0MSBuild.CreateCommandForTarget("ResolveAssemblyReferencesDesignTime", args);
 
-            command
-                .Execute()
-                .Should()
-                .Pass();
+            var result = command
+                .CaptureStdOut()
+                .Execute();
+
+            //  In CI builds, VSINSTALLDIR is set but the CompileDesignTime target doesn't exist, probably because
+            //  it's an earlier version of Visual Studio
+            if (result.ExitCode != 0)
+            {
+                result
+                    .StdOut
+                    .Should()
+                    .Contain("The target \"CompileDesignTime\" does not exist");
+            }
         }
 
         [Fact]


### PR DESCRIPTION
Fixes #453 

When the Sdk was a NuGet package, its targets would never run before a restore completed.  Now that it's an MSBuild Sdk, the targets can get run before a restore.  The ResolvePackageDependencies task will generate an an error if the project assets file isn't found.  When a project was created, it would generate an error in the design time build, which would show up in the error list in Visual Studio and then disappear when the package restore operation completed.

This change skips the RunResolvePackageDependencies target if the `DesignTimeBuild` property is true and the assets file can't be found.


**Escrow Template:**

Customer scenario –On project creation, nuget package restore error shows up in the error list and goes away once the restore is complete.
Bugs this fixes: #453 
Workarounds - none
Risk – Low.
Performance impact - None.
Is this a regression? - Yes
Root cause analysis - When the Sdk was a NuGet package, its targets would never run before a restore completed.  Now that it's an MSBuild Sdk, the targets can get run before a restore. 
How was the bug found? - Internal testing.

@MattGertz  for RC.2 Approval