### PR TITLE
Add a flag to control build script verbosity and unit tests

### DIFF
--- a/build/build.proj
+++ b/build/build.proj
@@ -151,7 +151,7 @@
     
   </Target>
 
-  <Target Name="Test" Condition="'$(BuildTemplates)' != 'true'">
+  <Target Name="Test" Condition="'$(BuildTemplates)' != 'true' and '$(RunTests)' != 'false'">
 
     <ItemGroup>
       <TestAssembly Include="$(TestsDirectory)*Tests.dll" />

--- a/build/build.proj
+++ b/build/build.proj
@@ -151,7 +151,7 @@
     
   </Target>
 
-  <Target Name="Test" Condition="'$(BuildTemplates)' != 'true' and '$(RunTests)' != 'false'">
+  <Target Name="Test" Condition="'$(BuildTemplates)' != 'true'">
 
     <ItemGroup>
       <TestAssembly Include="$(TestsDirectory)*Tests.dll" />


### PR DESCRIPTION
The output is still too verbose for `/Verbosity minimal`, but considerably smaller.