### PR TITLE
Remove COM and Framework capabilities which will hide those tabs in the reference manager dialog in VS.

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.targets
@@ -252,6 +252,12 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ProjectCapability Include="CrossPlatformExecutable" />
   </ItemGroup>
 
+  <!-- Reference Manager capabilities -->
+  <ItemGroup>
+    <ProjectCapability Remove="ReferenceManagerAssemblies" />
+    <ProjectCapability Remove="ReferenceManagerCOM" />
+  </ItemGroup>
+
   <Import Project="$(MSBuildThisFileDirecotry)Microsoft.NET.DisableStandardFrameworkResolution.targets" Condition="'$(DisableStandardFrameworkResolution)' == 'true'" />
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.NET.GenerateAssemblyInfo.targets" />
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.NET.Publish.targets" />

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.targets
@@ -253,7 +253,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   </ItemGroup>
 
   <!-- Reference Manager capabilities -->
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
     <ProjectCapability Remove="ReferenceManagerAssemblies" />
     <ProjectCapability Remove="ReferenceManagerCOM" />
   </ItemGroup>


### PR DESCRIPTION
This consumed the project system changes from this PR https://github.com/dotnet/roslyn-project-system/pull/876 and addresses

https://github.com/dotnet/roslyn-project-system/issues/399
https://github.com/dotnet/roslyn-project-system/issues/400