### PR TITLE
Include pre-restored project.assets.json in project templates

### DIFF
--- a/build/Targets/Templates.Imports.targets
+++ b/build/Targets/Templates.Imports.targets
@@ -59,6 +59,54 @@
 
   </Target>
 
+  <!-- RewriteToken Task: Deletes all lines from a file that contain the specified string  -->
+  <UsingTask TaskName="DeleteLinesFromFile"
+             TaskFactory="CodeTaskFactory"
+             AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.v12.0.dll">
+    <ParameterGroup>
+      <FilePath ParameterType="System.String" Required="true" />
+      <LineContents ParameterType="System.String" Required="true" />
+    </ParameterGroup>
+      
+    <Task>
+      <Code Type="Fragment" Language="cs"><![CDATA[
+        string[] lines = File.ReadAllLines(FilePath);
+        System.Text.StringBuilder content = new StringBuilder();
+        foreach (string line in lines)
+        {
+            if (!line.Contains(LineContents))
+            {
+                content.AppendLine(line);
+            }
+        }
+        File.WriteAllText(FilePath, content.ToString());
+      ]]></Code>
+    </Task>
+  </UsingTask>
+    
+  <!-- _RestoreTemplateProject Target: Run "dotnet restore" on the project file to create the project.assets.json,
+        then remove the "packageFolders" value from the file (as that is machine-specific). -->
+  <Target Name="_RestoreTemplateProject" BeforeTargets="GetZipFilesFromVSTemplates" DependsOnTargets="_UpdateNETCoreSdkVersion">
+      <PropertyGroup>
+        <__NewLine><![CDATA[
+]]></__NewLine>
+        <__SetMSBuildSdksPath>set MSBuildSDKsPath=$(RepositoryRootDirectory)bin\$(Configuration)\Sdks</__SetMSBuildSdksPath>
+    </PropertyGroup>
+    
+    <Exec Command="$(__SetMSBuildSdksPath)$(__NewLine)$(DotNetTool) restore %(ProjectTemplate.TargetPath)" />
+
+    <PropertyGroup>
+      <_PackagesFolderToReplace>$(NUGET_PACKAGES)</_PackagesFolderToReplace>
+      <_PackagesFolderToReplace>$(_PackagesFolderToReplace.Replace('\', '\\'))</_PackagesFolderToReplace>
+      <_TemplateProjectAssetsFile>$(MSBuildProjectDirectory)\obj\project.assets.json</_TemplateProjectAssetsFile>
+    </PropertyGroup>
+      <DeleteLinesFromFile 
+        FilePath="$(_TemplateProjectAssetsFile)"
+        LineContents="$(_PackagesFolderToReplace)"
+        Condition="Exists($(_TemplateProjectAssetsFile))"
+        />
+  </Target>
+
   <!-- Returns the current build version. Used in .vsixmanifests to substitute our build version into them -->
   <Target Name="GetBuildVersion" Outputs="$(VsixVersion)" />
 

--- a/src/Templates/ProjectTemplates/CSharp/.NETCore/CSharpClassLibrary/ClassLibrary.vstemplate
+++ b/src/Templates/ProjectTemplates/CSharp/.NETCore/CSharpClassLibrary/ClassLibrary.vstemplate
@@ -18,6 +18,7 @@
   <TemplateContent>
     <Project File="Project.csproj" ReplaceParameters="true">
       <ProjectItem ReplaceParameters="true" OpenInEditor="true">Class1.cs</ProjectItem>
+      <ProjectItem>obj\project.assets.json</ProjectItem>
     </Project>
   </TemplateContent>
 </VSTemplate>

--- a/src/Templates/ProjectTemplates/CSharp/.NETCore/CSharpConsoleApplication/ConsoleApplication.vstemplate
+++ b/src/Templates/ProjectTemplates/CSharp/.NETCore/CSharpConsoleApplication/ConsoleApplication.vstemplate
@@ -17,7 +17,8 @@
   </TemplateData>
   <TemplateContent>
     <Project File="Project.csproj" ReplaceParameters="true">
-      <ProjectItem ReplaceParameters="true" OpenInEditor="true">Program.cs</ProjectItem>      
+      <ProjectItem ReplaceParameters="true" OpenInEditor="true">Program.cs</ProjectItem>
+      <ProjectItem>obj\project.assets.json</ProjectItem>      
     </Project>
   </TemplateContent>
 </VSTemplate>

--- a/src/Templates/ProjectTemplates/CSharp/.NETCore/CSharpUnitTest/UnitTest.vstemplate
+++ b/src/Templates/ProjectTemplates/CSharp/.NETCore/CSharpUnitTest/UnitTest.vstemplate
@@ -17,6 +17,7 @@
   <TemplateContent>
     <Project File="Project.csproj" ReplaceParameters="true">
       <ProjectItem ReplaceParameters="true" OpenInEditor="true">UnitTest1.cs</ProjectItem>
+      <ProjectItem>obj\project.assets.json</ProjectItem>
     </Project>
   </TemplateContent>
 </VSTemplate>

--- a/src/Templates/ProjectTemplates/CSharp/.NETCore/CSharpXUnitTest/XUnitTest.vstemplate
+++ b/src/Templates/ProjectTemplates/CSharp/.NETCore/CSharpXUnitTest/XUnitTest.vstemplate
@@ -17,6 +17,7 @@
   <TemplateContent>
     <Project File="Project.csproj" ReplaceParameters="true">
       <ProjectItem ReplaceParameters="true" OpenInEditor="true">UnitTest1.cs</ProjectItem>
+      <ProjectItem>obj\project.assets.json</ProjectItem>
     </Project>
   </TemplateContent>
 </VSTemplate>


### PR DESCRIPTION
This PR adds a "pre-restored" project.assets.json file to the project templates.  This means that when the project is created, but before the restore operation completes, the project will be functional.  Without this change, the project will not have the right references, so there will be design-time build errors, and intellisense won't show any .NET APIs.

This depends on the packages being available in the user's NuGet package cache folder, so the first time a project is created on a machine, the errors will still show up until package restore completes.

**Escrow Template**:

Customer scenario –On project creation, nuget package restore error shows up in the error list and goes away once the restore is complete.
Bugs this fixes: not filed
Workarounds - wait for restore to complete
Risk – Medium: when creating the templates, the build process deletes a line from project.assets.json that has the value for `packageFolders`, as this is machine-specific.  NuGet (or its tasks, etc) may not expect that to be missing from the assets file.
Performance impact - None.
Is this a regression? - No
Root cause analysis - After #453 is fixed with PR #457, the design-time "build" succeeds.  But the design-time invocation of the build doesn't compile anything (as I understand it), it merely gathers the parameters needed to pass to the compiler.  So the compilation is now failing because there are no references to the .NET Framework APIs from NuGet packages until after the restore completes.
How was the bug found? - Internal testing.