### PR TITLE
Stop defaulting NeutralLanguage

### DIFF
--- a/TestAssets/TestProjects/AllResourcesInSatellite/AllResourcesInSatellite.csproj
+++ b/TestAssets/TestProjects/AllResourcesInSatellite/AllResourcesInSatellite.csproj
@@ -1,0 +1,11 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="**\*.cs" />
+    <EmbeddedResource Include="**\*.resx" />
+    <PackageReference Include="Microsoft.NETCore.App" Version="1.0.1" />
+  </ItemGroup>
+</Project>

--- a/TestAssets/TestProjects/AllResourcesInSatellite/Program.cs
+++ b/TestAssets/TestProjects/AllResourcesInSatellite/Program.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Globalization;
+using System.Reflection;
+using System.Resources;
+
+namespace AllResourcesInSatellite
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            CultureInfo.CurrentUICulture = new CultureInfo("en-US");
+
+            var resources = new ResourceManager("AllResourcesInSatellite.Strings", typeof(Program).GetTypeInfo().Assembly);
+
+            Console.WriteLine(resources.GetString("HelloWorld"));
+        }
+    }
+}

--- a/TestAssets/TestProjects/AllResourcesInSatellite/Strings.en.resx
+++ b/TestAssets/TestProjects/AllResourcesInSatellite/Strings.en.resx
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <data name="HelloWorld" xml:space="preserve">
+    <value>Hello World from en satellite assembly</value>
+  </data>
+</root>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.GenerateAssemblyInfo.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.GenerateAssemblyInfo.targets
@@ -80,7 +80,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       <AssemblyAttribute Include="System.Reflection.AssemblyVersionAttribute" Condition="'$(AssemblyVersion)' != '' and '$(GenerateAssemblyVersionAttribute)' == 'true'">
         <_Parameter1>$(AssemblyVersion)</_Parameter1>
       </AssemblyAttribute>
-      <AssemblyAttribute Include="System.Resources.NeutralResourcesLanguageAttribute" Condition="'$(NeutralLanguage)' != '' and '$(GenerateNeutralResourcesLanguageAttribute)'">
+      <AssemblyAttribute Include="System.Resources.NeutralResourcesLanguageAttribute" Condition="'$(NeutralLanguage)' != '' and '$(GenerateNeutralResourcesLanguageAttribute)' == 'true'">
         <_Parameter1>$(NeutralLanguage)</_Parameter1>
       </AssemblyAttribute>
     </ItemGroup>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.Common.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.Common.targets
@@ -31,7 +31,6 @@ Copyright (c) .NET Foundation. All rights reserved.
     <Company Condition=" '$(Company)'=='' ">$(Authors)</Company>
     <AssemblyTitle Condition="'$(AssemblyTitle)' == ''">$(AssemblyName)</AssemblyTitle>
     <Product Condition="'$(Product)' == ''">$(AssemblyName)</Product>
-    <NeutralLanguage Condition="'$(NeutralLanguage)' == ''">en</NeutralLanguage>
   </PropertyGroup>
 
   <UsingTask TaskName="GetNearestTargetFramework" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantAllResourcesInSatellite.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantAllResourcesInSatellite.cs
@@ -1,0 +1,52 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.IO;
+using System.Runtime.InteropServices;
+using Microsoft.NET.TestFramework;
+using Microsoft.NET.TestFramework.Assertions;
+using Microsoft.NET.TestFramework.Commands;
+using Xunit;
+using static Microsoft.NET.TestFramework.Commands.MSBuildTest;
+using Microsoft.DotNet.Cli.Utils;
+
+namespace Microsoft.NET.Build.Tests
+{
+    public class GivenThatWeWantAllResourcesInSatellite
+    {
+        private TestAssetsManager _testAssetsManager = TestAssetsManager.TestProjectsAssetsManager;
+
+        [Fact]
+        public void It_retrieves_strings_successfully()
+        {
+            var testAsset = _testAssetsManager
+                .CopyTestAsset("AllResourcesInSatellite")
+                .WithSource()
+                .Restore();
+
+            var buildCommand = new BuildCommand(Stage0MSBuild, testAsset.TestRoot);
+            buildCommand
+                .Execute()
+                .Should()
+                .Pass();
+
+            var outputDirectory = buildCommand.GetOutputDirectory(targetFramework: "netcoreapp1.0");
+            outputDirectory.Should().OnlyHaveFiles(new[] {
+                "AllResourcesInSatellite.dll",
+                "AllResourcesInSatellite.pdb",
+                "AllResourcesInSatellite.runtimeconfig.json",
+                "AllResourcesInSatellite.runtimeconfig.dev.json",
+                "AllResourcesInSatellite.deps.json",
+                "en/AllResourcesInSatellite.resources.dll",
+            });
+
+            Command.Create(RepoInfo.DotNetHostPath, new[] { Path.Combine(outputDirectory.FullName, "AllResourcesInSatellite.dll") })
+                .CaptureStdOut()
+                .Execute()
+                .Should()
+                .Pass()
+                .And
+                .HaveStdOutContaining("Hello World from en satellite assembly");
+        }
+    }
+}


### PR DESCRIPTION
This can cause MissingManifestException if project doesn't have English neutral resources in main assembly, or incorrectly displaying non-English neutral resources to English end-user.

Fix #382
Fix #410 

@srivatsn @dsplaisted @davkean