### PR TITLE
Add Framework Assemblies from project assets file to compiler references

### DIFF
--- a/TestAssets/TestProjects/AppsWithFrameworkReferences/EntityFrameworkApp/EntityFrameworkApp.csproj
+++ b/TestAssets/TestProjects/AppsWithFrameworkReferences/EntityFrameworkApp/EntityFrameworkApp.csproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net451</TargetFramework>
+    <RuntimeIdentifier>win7-x86</RuntimeIdentifier>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="**\*.cs" />
+    <EmbeddedResource Include="**\*.resx" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="1.0.0" />
+  </ItemGroup>
+
+</Project>

--- a/TestAssets/TestProjects/AppsWithFrameworkReferences/EntityFrameworkApp/Program.cs
+++ b/TestAssets/TestProjects/AppsWithFrameworkReferences/EntityFrameworkApp/Program.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.ComponentModel.DataAnnotations;
+
+class Program
+{
+    static void Main(string[] args)
+    {
+        var b = new VerifyCodeViewModel
+        {
+            Provider = "Required Test Provider"
+        };
+        Console.WriteLine(b.Provider);
+    }
+
+    public class VerifyCodeViewModel
+    {
+        [Required]
+        public string Provider { get; set; }
+    }
+}

--- a/TestAssets/TestProjects/AppsWithFrameworkReferences/StopwatchLib/Helper.cs
+++ b/TestAssets/TestProjects/AppsWithFrameworkReferences/StopwatchLib/Helper.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics;
+
+namespace StopwatchLib
+{
+    public static class Helper
+    {
+        public static Stopwatch StartWatch()
+        {
+            return Stopwatch.StartNew();
+        }
+    }
+}

--- a/TestAssets/TestProjects/AppsWithFrameworkReferences/StopwatchLib/StopwatchLib.csproj
+++ b/TestAssets/TestProjects/AppsWithFrameworkReferences/StopwatchLib/StopwatchLib.csproj
@@ -1,0 +1,16 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net45</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="**\*.cs" />
+    <EmbeddedResource Include="**\*.resx" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NETStandard.Library" Version="1.6" />
+  </ItemGroup>
+
+</Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageDependencies.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageDependencies.cs
@@ -361,6 +361,11 @@ namespace Microsoft.NET.Build.Tasks
                     item.SetMetadata(MetadataKeys.ParentTarget, targetName); // Foreign Key
                     item.SetMetadata(MetadataKeys.ParentPackage, packageId); // Foreign Key
 
+                    if (fileGroup == FileGroup.FrameworkAssembly)
+                    {
+                        item.SetMetadata("FrameworkAssembly", filePath);
+                    }
+
                     foreach (var property in properties)
                     {
                         item.SetMetadata(property.Key, property.Value);

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageDependencies.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageDependencies.cs
@@ -363,6 +363,7 @@ namespace Microsoft.NET.Build.Tasks
 
                     if (fileGroup == FileGroup.FrameworkAssembly)
                     {
+                        // NOTE: the path provided for framework assemblies is the name of the framework reference
                         item.SetMetadata("FrameworkAssembly", filePath);
                     }
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.PackageDependencyResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.PackageDependencyResolution.targets
@@ -225,18 +225,32 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <!--
     ============================================================
+    HELPER: Get File Dependencies matching active TFM and RID
+    ============================================================
+    -->
+
+  <Target Name="_ComputeActiveTFMFileDependencies"
+          DependsOnTargets="RunResolvePackageDependencies"
+          Returns="_ActiveTFMFileDependencies">
+    <ItemGroup>
+      <_ActiveTFMFileDependencies Include="@(FileDependencies->WithMetadataValue('ParentTarget', '$(_NugetTargetMonikerAndRID)'))" />
+    </ItemGroup>
+  </Target>
+
+  <!--
+    ============================================================
     Reference Targets: For populating References based on lock file
     - _ComputeLockFileReferences
+    - _ComputeLockFileFrameworks
     - ResolveLockFileReferences
     ============================================================
     -->
 
   <Target Name="_ComputeLockFileReferences"
-          DependsOnTargets="RunResolvePackageDependencies"
+          DependsOnTargets="_ComputeActiveTFMFileDependencies"
           Returns="ResolvedCompileFileDefinitions">
     <ItemGroup>
-      <TFMFileItems Include="@(FileDependencies->WithMetadataValue('ParentTarget', '$(_NugetTargetMonikerAndRID)'))" />
-      <_CompileFileItems Include="@(TFMFileItems->WithMetadataValue('FileGroup', 'CompileTimeAssembly'))" />
+      <_CompileFileItems Include="@(_ActiveTFMFileDependencies->WithMetadataValue('FileGroup', 'CompileTimeAssembly'))" />
 
       <!-- Get corresponding file definitions -->
       <__CompileFileDefinitions Include="@(FileDefinitions)" Exclude="@(_CompileFileItems)" />
@@ -251,11 +265,28 @@ Copyright (c) .NET Foundation. All rights reserved.
     </ItemGroup>
   </Target>
 
+  <Target Name="_ComputeLockFileFrameworks"
+          Condition="'$(DisableLockFileFrameworks)' != 'true'"
+          DependsOnTargets="_ComputeActiveTFMFileDependencies"
+          Returns="ResolvedFrameworkAssemblies">
+    <ItemGroup>
+      <_FrameworkAssemblies Include="@(_ActiveTFMFileDependencies->WithMetadataValue('FileGroup', 'FrameworkAssembly'))" />
+
+      <ResolvedFrameworkAssemblies Include="%(_FrameworkAssemblies.FrameworkAssembly)">
+        <Private>false</Private>
+        <NuGetIsFrameworkReference>true</NuGetIsFrameworkReference>
+        <NuGetSourceType>Package</NuGetSourceType>
+      </ResolvedFrameworkAssemblies>
+
+    </ItemGroup>
+  </Target>
+
   <Target Name="ResolveLockFileReferences"
-          DependsOnTargets="_ComputeLockFileReferences">
+          DependsOnTargets="_ComputeLockFileReferences;_ComputeLockFileFrameworks">
     <ItemGroup>
       <!-- Add the references we computed -->
       <Reference Include="@(ResolvedCompileFileDefinitions)" />
+      <Reference Include="@(ResolvedFrameworkAssemblies)" />
     </ItemGroup>
   </Target>
 
@@ -295,25 +326,23 @@ Copyright (c) .NET Foundation. All rights reserved.
     -->
 
   <Target Name="_ComputeLockFileCopyLocal"
-        DependsOnTargets="RunResolvePackageDependencies;RunProduceContentAssets"
+        DependsOnTargets="_ComputeActiveTFMFileDependencies;RunProduceContentAssets"
         Returns="NativeCopyLocalItems;RuntimeCopyLocalItems;ResourceCopyLocalItems;AllCopyLocalItems">
     <ItemGroup>
-      <TFMFileItems Include="@(FileDependencies->WithMetadataValue('ParentTarget', '$(_NugetTargetMonikerAndRID)'))" />
-
       <!--NativeLibrary-->
-      <_NativeFileItems Include="@(TFMFileItems->WithMetadataValue('FileGroup', 'NativeLibrary'))" />
+      <_NativeFileItems Include="@(_ActiveTFMFileDependencies->WithMetadataValue('FileGroup', 'NativeLibrary'))" />
       <__NativeCopyLocalItems Include="@(FileDefinitions)" Exclude="@(_NativeFileItems)" />
       <_NativeCopyLocalItems Include="@(FileDefinitions)" Exclude="@(__NativeCopyLocalItems)" />
       <NativeCopyLocalItems Include="%(_NativeCopyLocalItems.ResolvedPath)" />
 
       <!--RuntimeAssembly-->
-      <_RuntimeFileItems Include="@(TFMFileItems->WithMetadataValue('FileGroup', 'RuntimeAssembly'))" />
+      <_RuntimeFileItems Include="@(_ActiveTFMFileDependencies->WithMetadataValue('FileGroup', 'RuntimeAssembly'))" />
       <__RuntimeCopyLocalItems Include="@(FileDefinitions)" Exclude="@(_RuntimeFileItems)" />
       <_RuntimeCopyLocalItems Include="@(FileDefinitions)" Exclude="@(__RuntimeCopyLocalItems)" />
       <RuntimeCopyLocalItems Include="%(_RuntimeCopyLocalItems.ResolvedPath)" />
 
       <!--ResourceAssembly-->
-      <_ResourceFileItems Include="@(TFMFileItems->WithMetadataValue('FileGroup', 'ResourceAssembly'))" />
+      <_ResourceFileItems Include="@(_ActiveTFMFileDependencies->WithMetadataValue('FileGroup', 'ResourceAssembly'))" />
       <__ResourceCopyLocalItems Include="@(FileDefinitions)" Exclude="@(_ResourceFileItems)" />
       <_ResourceCopyLocalItems Include="@(FileDefinitions)" Exclude="@(__ResourceCopyLocalItems)" />
       <ResourceCopyLocalItems Include="%(_ResourceCopyLocalItems.ResolvedPath)" />

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAppsWithFrameworkRefs.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAppsWithFrameworkRefs.cs
@@ -23,6 +23,11 @@ namespace Microsoft.NET.Build.Tests
         [Fact]
         public void It_builds_the_projects_successfully()
         {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return;
+            }
+
             var testAsset = _testAssetsManager
                 .CopyTestAsset("AppsWithFrameworkReferences")
                 .WithSource();
@@ -36,6 +41,11 @@ namespace Microsoft.NET.Build.Tests
         [Fact]
         public void It_builds_with_disable_implicit_frameworkRefs()
         {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return;
+            }
+
             var testAsset = _testAssetsManager
                 .CopyTestAsset("AppsWithFrameworkReferences")
                 .WithSource()
@@ -61,6 +71,11 @@ namespace Microsoft.NET.Build.Tests
         [Fact]
         public void It_builds_the_projects_successfully_twice()
         {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return;
+            }
+
             var testAsset = _testAssetsManager
                 .CopyTestAsset("AppsWithFrameworkReferences")
                 .WithSource();

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAppsWithFrameworkRefs.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAppsWithFrameworkRefs.cs
@@ -1,0 +1,170 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using FluentAssertions;
+using Microsoft.DotNet.Cli.Utils;
+using Microsoft.NET.TestFramework;
+using Microsoft.NET.TestFramework.Assertions;
+using Microsoft.NET.TestFramework.Commands;
+using System;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Xml.Linq;
+using Xunit;
+using static Microsoft.NET.TestFramework.Commands.MSBuildTest;
+
+namespace Microsoft.NET.Build.Tests
+{
+    public class GivenThatWeWantToBuildAppsWithFrameworkRefs
+    {
+        private TestAssetsManager _testAssetsManager = TestAssetsManager.TestProjectsAssetsManager;
+
+        [Fact]
+        public void It_builds_the_projects_successfully()
+        {
+            var testAsset = _testAssetsManager
+                .CopyTestAsset("AppsWithFrameworkReferences")
+                .WithSource();
+
+            testAsset.Restore("EntityFrameworkApp");
+            testAsset.Restore("StopwatchLib");
+
+            VerifyProjectsBuild(testAsset);
+        }
+
+        [Fact]
+        public void It_builds_with_disable_implicit_frameworkRefs()
+        {
+            var testAsset = _testAssetsManager
+                .CopyTestAsset("AppsWithFrameworkReferences")
+                .WithSource()
+                .WithProjectChanges(project =>
+                {
+                    // Some framework references may be provided implicitly.
+                    // Turn off this implicit addition to verify that references are
+                    // provided in this scenario by project assets file
+
+                    var ns = project.Root.Name.Namespace;
+                    var propertyGroup = project.Root.Elements(ns + "PropertyGroup").FirstOrDefault();
+                    propertyGroup.Should().NotBeNull();
+
+                    propertyGroup.Add(new XElement(ns + "DisableImplicitFrameworkReferences", "true"));
+                });
+
+            testAsset.Restore("EntityFrameworkApp");
+            testAsset.Restore("StopwatchLib");
+
+            VerifyProjectsBuild(testAsset);
+        }
+
+        [Fact]
+        public void It_builds_the_projects_successfully_twice()
+        {
+            var testAsset = _testAssetsManager
+                .CopyTestAsset("AppsWithFrameworkReferences")
+                .WithSource();
+
+            testAsset.Restore("EntityFrameworkApp");
+            testAsset.Restore("StopwatchLib");
+
+            for (int i = 0; i < 2; i++)
+            {
+                VerifyProjectsBuild(testAsset);
+            }
+        }
+
+        void VerifyProjectsBuild(TestAsset testAsset)
+        {
+            VerifyBuild(testAsset, "StopwatchLib", "net45",
+                "StopwatchLib.dll",
+                "StopwatchLib.pdb");
+
+            VerifyBuild(testAsset, "EntityFrameworkApp", "net451",
+                "EntityFrameworkApp.exe",
+                "EntityFrameworkApp.pdb",
+                "EntityFrameworkApp.runtimeconfig.dev.json",
+                "EntityFrameworkApp.runtimeconfig.json");
+
+            // Try running EntityFrameworkApp.exe
+            var appProjectDirectory = Path.Combine(testAsset.TestRoot, "EntityFrameworkApp");
+            var buildCommand = new BuildCommand(Stage0MSBuild, appProjectDirectory);
+            var outputDirectory = buildCommand.GetOutputDirectory("net451");
+
+            Command.Create(Path.Combine(outputDirectory.FullName, "EntityFrameworkApp.exe"), Enumerable.Empty<string>())
+                .CaptureStdOut()
+                .Execute()
+                .Should()
+                .Pass()
+                .And
+                .HaveStdOutContaining("Required Test Provider");
+        }
+
+        private void VerifyBuild(TestAsset testAsset, string project, string targetFramework, 
+            params string [] expectedFiles)
+        {
+            var appProjectDirectory = Path.Combine(testAsset.TestRoot, project);
+
+            var buildCommand = new BuildCommand(Stage0MSBuild, appProjectDirectory);
+            var outputDirectory = buildCommand.GetOutputDirectory(targetFramework);
+
+            buildCommand
+                .Execute()
+                .Should()
+                .Pass();
+
+            outputDirectory.Should().HaveFiles(expectedFiles);
+        }
+
+        [Fact]
+        public void The_clean_target_removes_all_files_from_the_output_folder()
+        {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return;
+            }
+
+            var testAsset = _testAssetsManager
+                .CopyTestAsset("AppsWithFrameworkReferences")
+                .WithSource();
+
+            testAsset.Restore("EntityFrameworkApp");
+            testAsset.Restore("StopwatchLib");
+
+            VerifyClean(testAsset, "StopwatchLib", "net45",
+                "StopwatchLib.dll",
+                "StopwatchLib.pdb");
+
+            VerifyClean(testAsset, "EntityFrameworkApp", "net451",
+                "EntityFrameworkApp.exe",
+                "EntityFrameworkApp.pdb",
+                "EntityFrameworkApp.runtimeconfig.dev.json",
+                "EntityFrameworkApp.runtimeconfig.json");
+        }
+
+        private void VerifyClean(TestAsset testAsset, string project, string targetFramework,
+            params string[] expectedFiles)
+        {
+            var appProjectDirectory = Path.Combine(testAsset.TestRoot, project);
+
+            var buildCommand = new BuildCommand(Stage0MSBuild, appProjectDirectory);
+            var outputDirectory = buildCommand.GetOutputDirectory(targetFramework);
+
+            buildCommand
+                .Execute()
+                .Should()
+                .Pass();
+
+            outputDirectory.Should().HaveFiles(expectedFiles);
+
+            var cleanCommand = Stage0MSBuild.CreateCommandForTarget("Clean", buildCommand.FullPathProjectFile);
+
+            cleanCommand
+                .Execute()
+                .Should()
+                .Pass();
+
+            outputDirectory.Should().OnlyHaveFiles(Array.Empty<string>());
+        }
+    }
+}

--- a/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPreserveCompilationContext.cs
+++ b/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPreserveCompilationContext.cs
@@ -35,6 +35,7 @@ namespace Microsoft.NET.Publish.Tests
                     propertyGroup.Should().NotBeNull();
 
                     propertyGroup.Add(new XElement(ns + "DisableImplicitFrameworkReferences", "true"));
+                    propertyGroup.Add(new XElement(ns + "DisableLockFileFrameworks", "true"));
                 });
 
             testAsset.Restore("TestApp");

--- a/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPreserveCompilationContext.cs
+++ b/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPreserveCompilationContext.cs
@@ -25,18 +25,7 @@ namespace Microsoft.NET.Publish.Tests
         {
             var testAsset = _testAssetsManager
                 .CopyTestAsset("CompilationContext", "PreserveCompilationContext")
-                .WithSource()
-                .WithProjectChanges(project =>
-                {
-                    //  Workaround for https://github.com/dotnet/sdk/issues/367
-
-                    var ns = project.Root.Name.Namespace;
-                    var propertyGroup = project.Root.Elements(ns + "PropertyGroup").FirstOrDefault();
-                    propertyGroup.Should().NotBeNull();
-
-                    propertyGroup.Add(new XElement(ns + "DisableImplicitFrameworkReferences", "true"));
-                    propertyGroup.Add(new XElement(ns + "DisableLockFileFrameworks", "true"));
-                });
+                .WithSource();
 
             testAsset.Restore("TestApp");
             testAsset.Restore("TestLibrary");
@@ -53,7 +42,12 @@ namespace Microsoft.NET.Publish.Tests
                 }
 
                 publishCommand
-                    .Execute($"/p:TargetFramework={targetFramework}")
+                    .Execute(
+                        $"/p:TargetFramework={targetFramework}",
+
+                        //  Additional properties to workaround https://github.com/Microsoft/msbuild/issues/1345
+                        "/p:DisableImplicitFrameworkReferences=true",
+                        "/p:DisableLockFileFrameworks=true")
                     .Should()
                     .Pass();
 


### PR DESCRIPTION
Add Framework Assemblies raised from project assets file to compiler references. Previously, we were not doing anything with this information.

Fixes #365 and #409. Note that the scenario in #409 is already addressed by [implicit framework references](https://github.com/dotnet/sdk/blob/0908e3556df08d9ba308291b4d9fe4fb2154c0fc/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.BeforeCommon.targets#L79) because the scenario only relies on 'System'.

To workaround a failure in a preexisting test due to https://github.com/Microsoft/msbuild/issues/1345, I added the ability to disable the new targets but they are on by default.