### PR TITLE
Add strings for expected diagnostics

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.Designer.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.Designer.cs
@@ -12,7 +12,7 @@ namespace Microsoft.NET.Build.Tasks {
     using System;
     using System.Reflection;
 
-
+        
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
     /// </summary>
@@ -152,6 +152,51 @@ namespace Microsoft.NET.Build.Tasks {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Framework not installed: {0} in {1}.
+        /// </summary>
+        internal static string DOTNET1011 {
+            get {
+                return ResourceManager.GetString("DOTNET1011", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The reference assemblies directory was not specified. You can set the location using the DOTNET_REFERENCE_ASSEMBLIES_PATH environment variable..
+        /// </summary>
+        internal static string DOTNET1012 {
+            get {
+                return ResourceManager.GetString("DOTNET1012", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The following dependencies are marked with type &apos;platform&apos;, however only one dependency can have this type: {0}.
+        /// </summary>
+        internal static string DOTNET1013 {
+            get {
+                return ResourceManager.GetString("DOTNET1013", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Failed to read lock file.
+        /// </summary>
+        internal static string DOTNET1014 {
+            get {
+                return ResourceManager.GetString("DOTNET1014", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Project file does not exist &apos;{0}&apos;..
+        /// </summary>
+        internal static string DOTNET1017 {
+            get {
+                return ResourceManager.GetString("DOTNET1017", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The preprocessor token &apos;{0}&apos; has been given more than one value. Choosing &apos;{1}&apos; as the value..
         /// </summary>
         internal static string DuplicatePreprocessorToken {
@@ -202,6 +247,87 @@ namespace Microsoft.NET.Build.Tasks {
         internal static string NoCompatibleTargetFramework {
             get {
                 return ResourceManager.GetString("NoCompatibleTargetFramework", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The dependency &apos;{0}&apos; could not be resolved..
+        /// </summary>
+        internal static string NU1001 {
+            get {
+                return ResourceManager.GetString("NU1001", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The dependency &apos;{0}&apos; in project &apos;{1}&apos; does not support framework &apos;{2}&apos;..
+        /// </summary>
+        internal static string NU1002 {
+            get {
+                return ResourceManager.GetString("NU1002", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {0}. Please run &apos;dotnet restore&apos; to generate a new asset file..
+        /// </summary>
+        internal static string NU1006 {
+            get {
+                return ResourceManager.GetString("NU1006", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Dependency specified was &apos;{0}&apos; but ended up with &apos;{1}&apos;..
+        /// </summary>
+        internal static string NU1007 {
+            get {
+                return ResourceManager.GetString("NU1007", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {0} is an unsupported framework..
+        /// </summary>
+        internal static string NU1008 {
+            get {
+                return ResourceManager.GetString("NU1008", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The expected asset file does not exist. Please run &apos;dotnet restore&apos; to generate a new asset file..
+        /// </summary>
+        internal static string NU1009 {
+            get {
+                return ResourceManager.GetString("NU1009", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The dependency type was changed.
+        /// </summary>
+        internal static string NU1010 {
+            get {
+                return ResourceManager.GetString("NU1010", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The dependency target &apos;{0}&apos; is unsupported..
+        /// </summary>
+        internal static string NU1011 {
+            get {
+                return ResourceManager.GetString("NU1011", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Dependency conflict. &apos;{0}&apos; expected &apos;{1}&apos; but received &apos;{2}&apos;.
+        /// </summary>
+        internal static string NU1012 {
+            get {
+                return ResourceManager.GetString("NU1012", resourceCulture);
             }
         }
         

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.resx
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.resx
@@ -183,4 +183,46 @@
   <data name="InvalidNuGetVersionString" xml:space="preserve">
     <value>Invalid NuGet version string: '{0}'.</value>
   </data>
+  <data name="DOTNET1011" xml:space="preserve">
+    <value>Framework not installed: {0} in {1}</value>
+  </data>
+  <data name="DOTNET1012" xml:space="preserve">
+    <value>The reference assemblies directory was not specified. You can set the location using the DOTNET_REFERENCE_ASSEMBLIES_PATH environment variable.</value>
+  </data>
+  <data name="DOTNET1013" xml:space="preserve">
+    <value>The following dependencies are marked with type 'platform', however only one dependency can have this type: {0}</value>
+  </data>
+  <data name="DOTNET1014" xml:space="preserve">
+    <value>Failed to read lock file</value>
+  </data>
+  <data name="DOTNET1017" xml:space="preserve">
+    <value>Project file does not exist '{0}'.</value>
+  </data>
+  <data name="NU1001" xml:space="preserve">
+    <value>The dependency '{0}' could not be resolved.</value>
+  </data>
+  <data name="NU1002" xml:space="preserve">
+    <value>The dependency '{0}' in project '{1}' does not support framework '{2}'.</value>
+  </data>
+  <data name="NU1006" xml:space="preserve">
+    <value>{0}. Please run 'dotnet restore' to generate a new asset file.</value>
+  </data>
+  <data name="NU1007" xml:space="preserve">
+    <value>Dependency specified was '{0}' but ended up with '{1}'.</value>
+  </data>
+  <data name="NU1008" xml:space="preserve">
+    <value>{0} is an unsupported framework.</value>
+  </data>
+  <data name="NU1009" xml:space="preserve">
+    <value>The expected asset file does not exist. Please run 'dotnet restore' to generate a new asset file.</value>
+  </data>
+  <data name="NU1010" xml:space="preserve">
+    <value>The dependency type was changed</value>
+  </data>
+  <data name="NU1011" xml:space="preserve">
+    <value>The dependency target '{0}' is unsupported.</value>
+  </data>
+  <data name="NU1012" xml:space="preserve">
+    <value>Dependency conflict. '{0}' expected '{1}' but received '{2}'</value>
+  </data>
 </root>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.cs.xlf
@@ -113,6 +113,76 @@
         <target state="translated">Neplatný řetězec verze NuGet: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="DOTNET1011">
+        <source>Framework not installed: {0} in {1}</source>
+        <target state="new">Framework not installed: {0} in {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DOTNET1012">
+        <source>The reference assemblies directory was not specified. You can set the location using the DOTNET_REFERENCE_ASSEMBLIES_PATH environment variable.</source>
+        <target state="new">The reference assemblies directory was not specified. You can set the location using the DOTNET_REFERENCE_ASSEMBLIES_PATH environment variable.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DOTNET1013">
+        <source>The following dependencies are marked with type 'platform', however only one dependency can have this type: {0}</source>
+        <target state="new">The following dependencies are marked with type 'platform', however only one dependency can have this type: {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DOTNET1014">
+        <source>Failed to read lock file</source>
+        <target state="new">Failed to read lock file</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DOTNET1017">
+        <source>Project file does not exist '{0}'.</source>
+        <target state="new">Project file does not exist '{0}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1001">
+        <source>The dependency '{0}' could not be resolved.</source>
+        <target state="new">The dependency '{0}' could not be resolved.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1002">
+        <source>The dependency '{0}' in project '{1}' does not support framework '{2}'.</source>
+        <target state="new">The dependency '{0}' in project '{1}' does not support framework '{2}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1006">
+        <source>{0}. Please run 'dotnet restore' to generate a new asset file.</source>
+        <target state="new">{0}. Please run 'dotnet restore' to generate a new asset file.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1007">
+        <source>Dependency specified was '{0}' but ended up with '{1}'.</source>
+        <target state="new">Dependency specified was '{0}' but ended up with '{1}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1008">
+        <source>{0} is an unsupported framework.</source>
+        <target state="new">{0} is an unsupported framework.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1009">
+        <source>The expected asset file does not exist. Please run 'dotnet restore' to generate a new asset file.</source>
+        <target state="new">The expected asset file does not exist. Please run 'dotnet restore' to generate a new asset file.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1010">
+        <source>The dependency type was changed</source>
+        <target state="new">The dependency type was changed</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1011">
+        <source>The dependency target '{0}' is unsupported.</source>
+        <target state="new">The dependency target '{0}' is unsupported.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1012">
+        <source>Dependency conflict. '{0}' expected '{1}' but received '{2}'</source>
+        <target state="new">Dependency conflict. '{0}' expected '{1}' but received '{2}'</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.de.xlf
@@ -113,6 +113,76 @@
         <target state="translated">Ungültige NuGet-Versionszeichenfolge: {0}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DOTNET1011">
+        <source>Framework not installed: {0} in {1}</source>
+        <target state="new">Framework not installed: {0} in {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DOTNET1012">
+        <source>The reference assemblies directory was not specified. You can set the location using the DOTNET_REFERENCE_ASSEMBLIES_PATH environment variable.</source>
+        <target state="new">The reference assemblies directory was not specified. You can set the location using the DOTNET_REFERENCE_ASSEMBLIES_PATH environment variable.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DOTNET1013">
+        <source>The following dependencies are marked with type 'platform', however only one dependency can have this type: {0}</source>
+        <target state="new">The following dependencies are marked with type 'platform', however only one dependency can have this type: {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DOTNET1014">
+        <source>Failed to read lock file</source>
+        <target state="new">Failed to read lock file</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DOTNET1017">
+        <source>Project file does not exist '{0}'.</source>
+        <target state="new">Project file does not exist '{0}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1001">
+        <source>The dependency '{0}' could not be resolved.</source>
+        <target state="new">The dependency '{0}' could not be resolved.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1002">
+        <source>The dependency '{0}' in project '{1}' does not support framework '{2}'.</source>
+        <target state="new">The dependency '{0}' in project '{1}' does not support framework '{2}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1006">
+        <source>{0}. Please run 'dotnet restore' to generate a new asset file.</source>
+        <target state="new">{0}. Please run 'dotnet restore' to generate a new asset file.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1007">
+        <source>Dependency specified was '{0}' but ended up with '{1}'.</source>
+        <target state="new">Dependency specified was '{0}' but ended up with '{1}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1008">
+        <source>{0} is an unsupported framework.</source>
+        <target state="new">{0} is an unsupported framework.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1009">
+        <source>The expected asset file does not exist. Please run 'dotnet restore' to generate a new asset file.</source>
+        <target state="new">The expected asset file does not exist. Please run 'dotnet restore' to generate a new asset file.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1010">
+        <source>The dependency type was changed</source>
+        <target state="new">The dependency type was changed</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1011">
+        <source>The dependency target '{0}' is unsupported.</source>
+        <target state="new">The dependency target '{0}' is unsupported.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1012">
+        <source>Dependency conflict. '{0}' expected '{1}' but received '{2}'</source>
+        <target state="new">Dependency conflict. '{0}' expected '{1}' but received '{2}'</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.es.xlf
@@ -113,6 +113,76 @@
         <target state="translated">Cadena de versión de NuGet no válida: '{0}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DOTNET1011">
+        <source>Framework not installed: {0} in {1}</source>
+        <target state="new">Framework not installed: {0} in {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DOTNET1012">
+        <source>The reference assemblies directory was not specified. You can set the location using the DOTNET_REFERENCE_ASSEMBLIES_PATH environment variable.</source>
+        <target state="new">The reference assemblies directory was not specified. You can set the location using the DOTNET_REFERENCE_ASSEMBLIES_PATH environment variable.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DOTNET1013">
+        <source>The following dependencies are marked with type 'platform', however only one dependency can have this type: {0}</source>
+        <target state="new">The following dependencies are marked with type 'platform', however only one dependency can have this type: {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DOTNET1014">
+        <source>Failed to read lock file</source>
+        <target state="new">Failed to read lock file</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DOTNET1017">
+        <source>Project file does not exist '{0}'.</source>
+        <target state="new">Project file does not exist '{0}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1001">
+        <source>The dependency '{0}' could not be resolved.</source>
+        <target state="new">The dependency '{0}' could not be resolved.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1002">
+        <source>The dependency '{0}' in project '{1}' does not support framework '{2}'.</source>
+        <target state="new">The dependency '{0}' in project '{1}' does not support framework '{2}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1006">
+        <source>{0}. Please run 'dotnet restore' to generate a new asset file.</source>
+        <target state="new">{0}. Please run 'dotnet restore' to generate a new asset file.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1007">
+        <source>Dependency specified was '{0}' but ended up with '{1}'.</source>
+        <target state="new">Dependency specified was '{0}' but ended up with '{1}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1008">
+        <source>{0} is an unsupported framework.</source>
+        <target state="new">{0} is an unsupported framework.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1009">
+        <source>The expected asset file does not exist. Please run 'dotnet restore' to generate a new asset file.</source>
+        <target state="new">The expected asset file does not exist. Please run 'dotnet restore' to generate a new asset file.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1010">
+        <source>The dependency type was changed</source>
+        <target state="new">The dependency type was changed</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1011">
+        <source>The dependency target '{0}' is unsupported.</source>
+        <target state="new">The dependency target '{0}' is unsupported.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1012">
+        <source>Dependency conflict. '{0}' expected '{1}' but received '{2}'</source>
+        <target state="new">Dependency conflict. '{0}' expected '{1}' but received '{2}'</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.fr.xlf
@@ -113,6 +113,76 @@
         <target state="translated">Chaîne de version NuGet non valide : '{0}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DOTNET1011">
+        <source>Framework not installed: {0} in {1}</source>
+        <target state="new">Framework not installed: {0} in {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DOTNET1012">
+        <source>The reference assemblies directory was not specified. You can set the location using the DOTNET_REFERENCE_ASSEMBLIES_PATH environment variable.</source>
+        <target state="new">The reference assemblies directory was not specified. You can set the location using the DOTNET_REFERENCE_ASSEMBLIES_PATH environment variable.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DOTNET1013">
+        <source>The following dependencies are marked with type 'platform', however only one dependency can have this type: {0}</source>
+        <target state="new">The following dependencies are marked with type 'platform', however only one dependency can have this type: {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DOTNET1014">
+        <source>Failed to read lock file</source>
+        <target state="new">Failed to read lock file</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DOTNET1017">
+        <source>Project file does not exist '{0}'.</source>
+        <target state="new">Project file does not exist '{0}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1001">
+        <source>The dependency '{0}' could not be resolved.</source>
+        <target state="new">The dependency '{0}' could not be resolved.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1002">
+        <source>The dependency '{0}' in project '{1}' does not support framework '{2}'.</source>
+        <target state="new">The dependency '{0}' in project '{1}' does not support framework '{2}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1006">
+        <source>{0}. Please run 'dotnet restore' to generate a new asset file.</source>
+        <target state="new">{0}. Please run 'dotnet restore' to generate a new asset file.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1007">
+        <source>Dependency specified was '{0}' but ended up with '{1}'.</source>
+        <target state="new">Dependency specified was '{0}' but ended up with '{1}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1008">
+        <source>{0} is an unsupported framework.</source>
+        <target state="new">{0} is an unsupported framework.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1009">
+        <source>The expected asset file does not exist. Please run 'dotnet restore' to generate a new asset file.</source>
+        <target state="new">The expected asset file does not exist. Please run 'dotnet restore' to generate a new asset file.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1010">
+        <source>The dependency type was changed</source>
+        <target state="new">The dependency type was changed</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1011">
+        <source>The dependency target '{0}' is unsupported.</source>
+        <target state="new">The dependency target '{0}' is unsupported.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1012">
+        <source>Dependency conflict. '{0}' expected '{1}' but received '{2}'</source>
+        <target state="new">Dependency conflict. '{0}' expected '{1}' but received '{2}'</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.it.xlf
@@ -113,6 +113,76 @@
         <target state="translated">La stringa di versione '{0}' di NuGet non è valida.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DOTNET1011">
+        <source>Framework not installed: {0} in {1}</source>
+        <target state="new">Framework not installed: {0} in {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DOTNET1012">
+        <source>The reference assemblies directory was not specified. You can set the location using the DOTNET_REFERENCE_ASSEMBLIES_PATH environment variable.</source>
+        <target state="new">The reference assemblies directory was not specified. You can set the location using the DOTNET_REFERENCE_ASSEMBLIES_PATH environment variable.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DOTNET1013">
+        <source>The following dependencies are marked with type 'platform', however only one dependency can have this type: {0}</source>
+        <target state="new">The following dependencies are marked with type 'platform', however only one dependency can have this type: {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DOTNET1014">
+        <source>Failed to read lock file</source>
+        <target state="new">Failed to read lock file</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DOTNET1017">
+        <source>Project file does not exist '{0}'.</source>
+        <target state="new">Project file does not exist '{0}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1001">
+        <source>The dependency '{0}' could not be resolved.</source>
+        <target state="new">The dependency '{0}' could not be resolved.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1002">
+        <source>The dependency '{0}' in project '{1}' does not support framework '{2}'.</source>
+        <target state="new">The dependency '{0}' in project '{1}' does not support framework '{2}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1006">
+        <source>{0}. Please run 'dotnet restore' to generate a new asset file.</source>
+        <target state="new">{0}. Please run 'dotnet restore' to generate a new asset file.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1007">
+        <source>Dependency specified was '{0}' but ended up with '{1}'.</source>
+        <target state="new">Dependency specified was '{0}' but ended up with '{1}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1008">
+        <source>{0} is an unsupported framework.</source>
+        <target state="new">{0} is an unsupported framework.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1009">
+        <source>The expected asset file does not exist. Please run 'dotnet restore' to generate a new asset file.</source>
+        <target state="new">The expected asset file does not exist. Please run 'dotnet restore' to generate a new asset file.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1010">
+        <source>The dependency type was changed</source>
+        <target state="new">The dependency type was changed</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1011">
+        <source>The dependency target '{0}' is unsupported.</source>
+        <target state="new">The dependency target '{0}' is unsupported.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1012">
+        <source>Dependency conflict. '{0}' expected '{1}' but received '{2}'</source>
+        <target state="new">Dependency conflict. '{0}' expected '{1}' but received '{2}'</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.ja.xlf
@@ -113,6 +113,76 @@
         <target state="translated">無効な NuGet バージョン文字列: '{0}'。</target>
         <note />
       </trans-unit>
+      <trans-unit id="DOTNET1011">
+        <source>Framework not installed: {0} in {1}</source>
+        <target state="new">Framework not installed: {0} in {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DOTNET1012">
+        <source>The reference assemblies directory was not specified. You can set the location using the DOTNET_REFERENCE_ASSEMBLIES_PATH environment variable.</source>
+        <target state="new">The reference assemblies directory was not specified. You can set the location using the DOTNET_REFERENCE_ASSEMBLIES_PATH environment variable.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DOTNET1013">
+        <source>The following dependencies are marked with type 'platform', however only one dependency can have this type: {0}</source>
+        <target state="new">The following dependencies are marked with type 'platform', however only one dependency can have this type: {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DOTNET1014">
+        <source>Failed to read lock file</source>
+        <target state="new">Failed to read lock file</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DOTNET1017">
+        <source>Project file does not exist '{0}'.</source>
+        <target state="new">Project file does not exist '{0}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1001">
+        <source>The dependency '{0}' could not be resolved.</source>
+        <target state="new">The dependency '{0}' could not be resolved.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1002">
+        <source>The dependency '{0}' in project '{1}' does not support framework '{2}'.</source>
+        <target state="new">The dependency '{0}' in project '{1}' does not support framework '{2}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1006">
+        <source>{0}. Please run 'dotnet restore' to generate a new asset file.</source>
+        <target state="new">{0}. Please run 'dotnet restore' to generate a new asset file.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1007">
+        <source>Dependency specified was '{0}' but ended up with '{1}'.</source>
+        <target state="new">Dependency specified was '{0}' but ended up with '{1}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1008">
+        <source>{0} is an unsupported framework.</source>
+        <target state="new">{0} is an unsupported framework.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1009">
+        <source>The expected asset file does not exist. Please run 'dotnet restore' to generate a new asset file.</source>
+        <target state="new">The expected asset file does not exist. Please run 'dotnet restore' to generate a new asset file.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1010">
+        <source>The dependency type was changed</source>
+        <target state="new">The dependency type was changed</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1011">
+        <source>The dependency target '{0}' is unsupported.</source>
+        <target state="new">The dependency target '{0}' is unsupported.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1012">
+        <source>Dependency conflict. '{0}' expected '{1}' but received '{2}'</source>
+        <target state="new">Dependency conflict. '{0}' expected '{1}' but received '{2}'</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.ko.xlf
@@ -113,6 +113,76 @@
         <target state="translated">NuGet 버전 문자열 '{0}'이(가) 잘못되었습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DOTNET1011">
+        <source>Framework not installed: {0} in {1}</source>
+        <target state="new">Framework not installed: {0} in {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DOTNET1012">
+        <source>The reference assemblies directory was not specified. You can set the location using the DOTNET_REFERENCE_ASSEMBLIES_PATH environment variable.</source>
+        <target state="new">The reference assemblies directory was not specified. You can set the location using the DOTNET_REFERENCE_ASSEMBLIES_PATH environment variable.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DOTNET1013">
+        <source>The following dependencies are marked with type 'platform', however only one dependency can have this type: {0}</source>
+        <target state="new">The following dependencies are marked with type 'platform', however only one dependency can have this type: {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DOTNET1014">
+        <source>Failed to read lock file</source>
+        <target state="new">Failed to read lock file</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DOTNET1017">
+        <source>Project file does not exist '{0}'.</source>
+        <target state="new">Project file does not exist '{0}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1001">
+        <source>The dependency '{0}' could not be resolved.</source>
+        <target state="new">The dependency '{0}' could not be resolved.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1002">
+        <source>The dependency '{0}' in project '{1}' does not support framework '{2}'.</source>
+        <target state="new">The dependency '{0}' in project '{1}' does not support framework '{2}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1006">
+        <source>{0}. Please run 'dotnet restore' to generate a new asset file.</source>
+        <target state="new">{0}. Please run 'dotnet restore' to generate a new asset file.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1007">
+        <source>Dependency specified was '{0}' but ended up with '{1}'.</source>
+        <target state="new">Dependency specified was '{0}' but ended up with '{1}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1008">
+        <source>{0} is an unsupported framework.</source>
+        <target state="new">{0} is an unsupported framework.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1009">
+        <source>The expected asset file does not exist. Please run 'dotnet restore' to generate a new asset file.</source>
+        <target state="new">The expected asset file does not exist. Please run 'dotnet restore' to generate a new asset file.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1010">
+        <source>The dependency type was changed</source>
+        <target state="new">The dependency type was changed</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1011">
+        <source>The dependency target '{0}' is unsupported.</source>
+        <target state="new">The dependency target '{0}' is unsupported.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1012">
+        <source>Dependency conflict. '{0}' expected '{1}' but received '{2}'</source>
+        <target state="new">Dependency conflict. '{0}' expected '{1}' but received '{2}'</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.pl.xlf
@@ -113,6 +113,76 @@
         <target state="translated">Nieprawidłowy ciąg wersji NuGet: „{0}”.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DOTNET1011">
+        <source>Framework not installed: {0} in {1}</source>
+        <target state="new">Framework not installed: {0} in {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DOTNET1012">
+        <source>The reference assemblies directory was not specified. You can set the location using the DOTNET_REFERENCE_ASSEMBLIES_PATH environment variable.</source>
+        <target state="new">The reference assemblies directory was not specified. You can set the location using the DOTNET_REFERENCE_ASSEMBLIES_PATH environment variable.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DOTNET1013">
+        <source>The following dependencies are marked with type 'platform', however only one dependency can have this type: {0}</source>
+        <target state="new">The following dependencies are marked with type 'platform', however only one dependency can have this type: {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DOTNET1014">
+        <source>Failed to read lock file</source>
+        <target state="new">Failed to read lock file</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DOTNET1017">
+        <source>Project file does not exist '{0}'.</source>
+        <target state="new">Project file does not exist '{0}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1001">
+        <source>The dependency '{0}' could not be resolved.</source>
+        <target state="new">The dependency '{0}' could not be resolved.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1002">
+        <source>The dependency '{0}' in project '{1}' does not support framework '{2}'.</source>
+        <target state="new">The dependency '{0}' in project '{1}' does not support framework '{2}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1006">
+        <source>{0}. Please run 'dotnet restore' to generate a new asset file.</source>
+        <target state="new">{0}. Please run 'dotnet restore' to generate a new asset file.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1007">
+        <source>Dependency specified was '{0}' but ended up with '{1}'.</source>
+        <target state="new">Dependency specified was '{0}' but ended up with '{1}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1008">
+        <source>{0} is an unsupported framework.</source>
+        <target state="new">{0} is an unsupported framework.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1009">
+        <source>The expected asset file does not exist. Please run 'dotnet restore' to generate a new asset file.</source>
+        <target state="new">The expected asset file does not exist. Please run 'dotnet restore' to generate a new asset file.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1010">
+        <source>The dependency type was changed</source>
+        <target state="new">The dependency type was changed</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1011">
+        <source>The dependency target '{0}' is unsupported.</source>
+        <target state="new">The dependency target '{0}' is unsupported.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1012">
+        <source>Dependency conflict. '{0}' expected '{1}' but received '{2}'</source>
+        <target state="new">Dependency conflict. '{0}' expected '{1}' but received '{2}'</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.pt-BR.xlf
@@ -113,6 +113,76 @@
         <target state="translated">Cadeia de caracteres de versão do NuGet inválida: '{0}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DOTNET1011">
+        <source>Framework not installed: {0} in {1}</source>
+        <target state="new">Framework not installed: {0} in {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DOTNET1012">
+        <source>The reference assemblies directory was not specified. You can set the location using the DOTNET_REFERENCE_ASSEMBLIES_PATH environment variable.</source>
+        <target state="new">The reference assemblies directory was not specified. You can set the location using the DOTNET_REFERENCE_ASSEMBLIES_PATH environment variable.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DOTNET1013">
+        <source>The following dependencies are marked with type 'platform', however only one dependency can have this type: {0}</source>
+        <target state="new">The following dependencies are marked with type 'platform', however only one dependency can have this type: {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DOTNET1014">
+        <source>Failed to read lock file</source>
+        <target state="new">Failed to read lock file</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DOTNET1017">
+        <source>Project file does not exist '{0}'.</source>
+        <target state="new">Project file does not exist '{0}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1001">
+        <source>The dependency '{0}' could not be resolved.</source>
+        <target state="new">The dependency '{0}' could not be resolved.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1002">
+        <source>The dependency '{0}' in project '{1}' does not support framework '{2}'.</source>
+        <target state="new">The dependency '{0}' in project '{1}' does not support framework '{2}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1006">
+        <source>{0}. Please run 'dotnet restore' to generate a new asset file.</source>
+        <target state="new">{0}. Please run 'dotnet restore' to generate a new asset file.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1007">
+        <source>Dependency specified was '{0}' but ended up with '{1}'.</source>
+        <target state="new">Dependency specified was '{0}' but ended up with '{1}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1008">
+        <source>{0} is an unsupported framework.</source>
+        <target state="new">{0} is an unsupported framework.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1009">
+        <source>The expected asset file does not exist. Please run 'dotnet restore' to generate a new asset file.</source>
+        <target state="new">The expected asset file does not exist. Please run 'dotnet restore' to generate a new asset file.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1010">
+        <source>The dependency type was changed</source>
+        <target state="new">The dependency type was changed</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1011">
+        <source>The dependency target '{0}' is unsupported.</source>
+        <target state="new">The dependency target '{0}' is unsupported.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1012">
+        <source>Dependency conflict. '{0}' expected '{1}' but received '{2}'</source>
+        <target state="new">Dependency conflict. '{0}' expected '{1}' but received '{2}'</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.ru.xlf
@@ -113,6 +113,76 @@
         <target state="translated">Недопустимая строка версии Invalid NuGet: "{0}".</target>
         <note />
       </trans-unit>
+      <trans-unit id="DOTNET1011">
+        <source>Framework not installed: {0} in {1}</source>
+        <target state="new">Framework not installed: {0} in {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DOTNET1012">
+        <source>The reference assemblies directory was not specified. You can set the location using the DOTNET_REFERENCE_ASSEMBLIES_PATH environment variable.</source>
+        <target state="new">The reference assemblies directory was not specified. You can set the location using the DOTNET_REFERENCE_ASSEMBLIES_PATH environment variable.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DOTNET1013">
+        <source>The following dependencies are marked with type 'platform', however only one dependency can have this type: {0}</source>
+        <target state="new">The following dependencies are marked with type 'platform', however only one dependency can have this type: {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DOTNET1014">
+        <source>Failed to read lock file</source>
+        <target state="new">Failed to read lock file</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DOTNET1017">
+        <source>Project file does not exist '{0}'.</source>
+        <target state="new">Project file does not exist '{0}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1001">
+        <source>The dependency '{0}' could not be resolved.</source>
+        <target state="new">The dependency '{0}' could not be resolved.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1002">
+        <source>The dependency '{0}' in project '{1}' does not support framework '{2}'.</source>
+        <target state="new">The dependency '{0}' in project '{1}' does not support framework '{2}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1006">
+        <source>{0}. Please run 'dotnet restore' to generate a new asset file.</source>
+        <target state="new">{0}. Please run 'dotnet restore' to generate a new asset file.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1007">
+        <source>Dependency specified was '{0}' but ended up with '{1}'.</source>
+        <target state="new">Dependency specified was '{0}' but ended up with '{1}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1008">
+        <source>{0} is an unsupported framework.</source>
+        <target state="new">{0} is an unsupported framework.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1009">
+        <source>The expected asset file does not exist. Please run 'dotnet restore' to generate a new asset file.</source>
+        <target state="new">The expected asset file does not exist. Please run 'dotnet restore' to generate a new asset file.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1010">
+        <source>The dependency type was changed</source>
+        <target state="new">The dependency type was changed</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1011">
+        <source>The dependency target '{0}' is unsupported.</source>
+        <target state="new">The dependency target '{0}' is unsupported.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1012">
+        <source>Dependency conflict. '{0}' expected '{1}' but received '{2}'</source>
+        <target state="new">Dependency conflict. '{0}' expected '{1}' but received '{2}'</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.tr.xlf
@@ -113,6 +113,76 @@
         <target state="translated">Geçersiz NuGet sürüm dizesi: '{0}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DOTNET1011">
+        <source>Framework not installed: {0} in {1}</source>
+        <target state="new">Framework not installed: {0} in {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DOTNET1012">
+        <source>The reference assemblies directory was not specified. You can set the location using the DOTNET_REFERENCE_ASSEMBLIES_PATH environment variable.</source>
+        <target state="new">The reference assemblies directory was not specified. You can set the location using the DOTNET_REFERENCE_ASSEMBLIES_PATH environment variable.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DOTNET1013">
+        <source>The following dependencies are marked with type 'platform', however only one dependency can have this type: {0}</source>
+        <target state="new">The following dependencies are marked with type 'platform', however only one dependency can have this type: {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DOTNET1014">
+        <source>Failed to read lock file</source>
+        <target state="new">Failed to read lock file</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DOTNET1017">
+        <source>Project file does not exist '{0}'.</source>
+        <target state="new">Project file does not exist '{0}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1001">
+        <source>The dependency '{0}' could not be resolved.</source>
+        <target state="new">The dependency '{0}' could not be resolved.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1002">
+        <source>The dependency '{0}' in project '{1}' does not support framework '{2}'.</source>
+        <target state="new">The dependency '{0}' in project '{1}' does not support framework '{2}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1006">
+        <source>{0}. Please run 'dotnet restore' to generate a new asset file.</source>
+        <target state="new">{0}. Please run 'dotnet restore' to generate a new asset file.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1007">
+        <source>Dependency specified was '{0}' but ended up with '{1}'.</source>
+        <target state="new">Dependency specified was '{0}' but ended up with '{1}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1008">
+        <source>{0} is an unsupported framework.</source>
+        <target state="new">{0} is an unsupported framework.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1009">
+        <source>The expected asset file does not exist. Please run 'dotnet restore' to generate a new asset file.</source>
+        <target state="new">The expected asset file does not exist. Please run 'dotnet restore' to generate a new asset file.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1010">
+        <source>The dependency type was changed</source>
+        <target state="new">The dependency type was changed</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1011">
+        <source>The dependency target '{0}' is unsupported.</source>
+        <target state="new">The dependency target '{0}' is unsupported.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1012">
+        <source>Dependency conflict. '{0}' expected '{1}' but received '{2}'</source>
+        <target state="new">Dependency conflict. '{0}' expected '{1}' but received '{2}'</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.xlf
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.xlf
@@ -5,90 +5,146 @@
       <group id="src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.resx" />
       <trans-unit id="AtLeastOneTargetFrameworkMustBeSpecified">
         <source>At least one possible target framework must be specified.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="NoCompatibleTargetFramework">
         <source>Project '{0}' has no target framework compatible with '{1}'.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="InvalidFrameworkName">
         <source>Invalid framework name: '{0}'.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="AssetsFileNotFound">
         <source>Assets file '{0}' not found. Run a NuGet package restore to generate this file.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="AssetsFileMissingTarget">
         <source>Assets file '{0}' doesn't have a target for '{1}'. Ensure you have restored this project for TargetFramework='{2}' and RuntimeIdentifier='{3}'.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="AssetsFilePathNotRooted">
         <source>Assets file path '{0}' is not rooted. Only full paths are supported.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="CannotFindProjectInfo">
         <source>Cannot find project info for '{0}'. This can indicate a missing project reference.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="ContentFileDoesNotContainExpectedParentPackageInformation">
         <source>Content file '{0}' does not contain expected parent package information.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="MissingItemMetadata">
         <source>Missing '{0}' metadata on '{1}' item '{2}'.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="UnrecognizedPreprocessorToken">
         <source>Unrecognized preprocessor token '{0}' in '{1}'.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="ContentPreproccessorParameterRequired">
         <source>The '{0}' task must be given a value for parameter '{1}' in order to consume preprocessed content.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="ProjectAssetsConsumedWithoutMSBuildProjectPath">
         <source>Assets are consumed from project '{0}', but no corresponding MSBuild project path was  found in '{1}'.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="UnexpectedFileType">
         <source>Unexpected file type for '{0}'. Type is both '{1}' and '{2}'.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="CannotInferTargetFrameworkIdentiferAndVersion">
         <source>Cannot infer TargetFrameworkIdentifier and/or TargetFrameworkVersion from TargetFramework='{0}'. They must be specified explicitly.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="ContentItemDoesNotProvideOutputPath">
         <source>Content item for '{0}' sets '{1}', but does not provide  '{2}' or '{3}'.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="DuplicatePreprocessorToken">
         <source>The preprocessor token '{0}' has been given more than one value. Choosing '{1}' as the value.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="ErrorsOccurredWhenEmittingSatelliteAssembly">
         <source>Errors occured when emitting satellite assembly '{0}'.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="UnableToFindResolvedPath">
         <source>Unable to find resolved path for '{0}'.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="UnexpectedDependencyWithNoVersionNumber">
         <source>Unexpected dependency '{0}' with no version number.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="RuntimeIdentifierMustBeSetForNETFramework">
         <source>RuntimeIdentifier must be set for .NETFramework executables. Consider RuntimeIdentifier=win7-x86 or RuntimeIdentifier=win7-x64.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="AssetPreprocessorMustBeConfigured">
         <source>Asset preprocessor must be configured before assets are processed.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="InvalidNuGetVersionString">
         <source>Invalid NuGet version string: '{0}'.</source>
+        <note />
+      </trans-unit>
+      <trans-unit id="DOTNET1011">
+        <source>Framework not installed: {0} in {1}</source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DOTNET1012">
+        <source>The reference assemblies directory was not specified. You can set the location using the DOTNET_REFERENCE_ASSEMBLIES_PATH environment variable.</source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DOTNET1013">
+        <source>The following dependencies are marked with type 'platform', however only one dependency can have this type: {0}</source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DOTNET1014">
+        <source>Failed to read lock file</source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DOTNET1017">
+        <source>Project file does not exist '{0}'.</source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1001">
+        <source>The dependency '{0}' could not be resolved.</source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1002">
+        <source>The dependency '{0}' in project '{1}' does not support framework '{2}'.</source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1006">
+        <source>{0}. Please run 'dotnet restore' to generate a new asset file.</source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1007">
+        <source>Dependency specified was '{0}' but ended up with '{1}'.</source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1008">
+        <source>{0} is an unsupported framework.</source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1009">
+        <source>The expected asset file does not exist. Please run 'dotnet restore' to generate a new asset file.</source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1010">
+        <source>The dependency type was changed</source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1011">
+        <source>The dependency target '{0}' is unsupported.</source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1012">
+        <source>Dependency conflict. '{0}' expected '{1}' but received '{2}'</source>
         <note></note>
       </trans-unit>
     </body>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.zh-Hans.xlf
@@ -113,6 +113,76 @@
         <target state="translated">无效的 NuGet 版本字符串:“{0}”。</target>
         <note />
       </trans-unit>
+      <trans-unit id="DOTNET1011">
+        <source>Framework not installed: {0} in {1}</source>
+        <target state="new">Framework not installed: {0} in {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DOTNET1012">
+        <source>The reference assemblies directory was not specified. You can set the location using the DOTNET_REFERENCE_ASSEMBLIES_PATH environment variable.</source>
+        <target state="new">The reference assemblies directory was not specified. You can set the location using the DOTNET_REFERENCE_ASSEMBLIES_PATH environment variable.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DOTNET1013">
+        <source>The following dependencies are marked with type 'platform', however only one dependency can have this type: {0}</source>
+        <target state="new">The following dependencies are marked with type 'platform', however only one dependency can have this type: {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DOTNET1014">
+        <source>Failed to read lock file</source>
+        <target state="new">Failed to read lock file</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DOTNET1017">
+        <source>Project file does not exist '{0}'.</source>
+        <target state="new">Project file does not exist '{0}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1001">
+        <source>The dependency '{0}' could not be resolved.</source>
+        <target state="new">The dependency '{0}' could not be resolved.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1002">
+        <source>The dependency '{0}' in project '{1}' does not support framework '{2}'.</source>
+        <target state="new">The dependency '{0}' in project '{1}' does not support framework '{2}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1006">
+        <source>{0}. Please run 'dotnet restore' to generate a new asset file.</source>
+        <target state="new">{0}. Please run 'dotnet restore' to generate a new asset file.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1007">
+        <source>Dependency specified was '{0}' but ended up with '{1}'.</source>
+        <target state="new">Dependency specified was '{0}' but ended up with '{1}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1008">
+        <source>{0} is an unsupported framework.</source>
+        <target state="new">{0} is an unsupported framework.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1009">
+        <source>The expected asset file does not exist. Please run 'dotnet restore' to generate a new asset file.</source>
+        <target state="new">The expected asset file does not exist. Please run 'dotnet restore' to generate a new asset file.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1010">
+        <source>The dependency type was changed</source>
+        <target state="new">The dependency type was changed</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1011">
+        <source>The dependency target '{0}' is unsupported.</source>
+        <target state="new">The dependency target '{0}' is unsupported.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1012">
+        <source>Dependency conflict. '{0}' expected '{1}' but received '{2}'</source>
+        <target state="new">Dependency conflict. '{0}' expected '{1}' but received '{2}'</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.zh-Hant.xlf
@@ -113,6 +113,76 @@
         <target state="translated">無效的 NuGet 版本字串: '{0}'。</target>
         <note />
       </trans-unit>
+      <trans-unit id="DOTNET1011">
+        <source>Framework not installed: {0} in {1}</source>
+        <target state="new">Framework not installed: {0} in {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DOTNET1012">
+        <source>The reference assemblies directory was not specified. You can set the location using the DOTNET_REFERENCE_ASSEMBLIES_PATH environment variable.</source>
+        <target state="new">The reference assemblies directory was not specified. You can set the location using the DOTNET_REFERENCE_ASSEMBLIES_PATH environment variable.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DOTNET1013">
+        <source>The following dependencies are marked with type 'platform', however only one dependency can have this type: {0}</source>
+        <target state="new">The following dependencies are marked with type 'platform', however only one dependency can have this type: {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DOTNET1014">
+        <source>Failed to read lock file</source>
+        <target state="new">Failed to read lock file</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DOTNET1017">
+        <source>Project file does not exist '{0}'.</source>
+        <target state="new">Project file does not exist '{0}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1001">
+        <source>The dependency '{0}' could not be resolved.</source>
+        <target state="new">The dependency '{0}' could not be resolved.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1002">
+        <source>The dependency '{0}' in project '{1}' does not support framework '{2}'.</source>
+        <target state="new">The dependency '{0}' in project '{1}' does not support framework '{2}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1006">
+        <source>{0}. Please run 'dotnet restore' to generate a new asset file.</source>
+        <target state="new">{0}. Please run 'dotnet restore' to generate a new asset file.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1007">
+        <source>Dependency specified was '{0}' but ended up with '{1}'.</source>
+        <target state="new">Dependency specified was '{0}' but ended up with '{1}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1008">
+        <source>{0} is an unsupported framework.</source>
+        <target state="new">{0} is an unsupported framework.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1009">
+        <source>The expected asset file does not exist. Please run 'dotnet restore' to generate a new asset file.</source>
+        <target state="new">The expected asset file does not exist. Please run 'dotnet restore' to generate a new asset file.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1010">
+        <source>The dependency type was changed</source>
+        <target state="new">The dependency type was changed</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1011">
+        <source>The dependency target '{0}' is unsupported.</source>
+        <target state="new">The dependency target '{0}' is unsupported.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NU1012">
+        <source>Dependency conflict. '{0}' expected '{1}' but received '{2}'</source>
+        <target state="new">Dependency conflict. '{0}' expected '{1}' but received '{2}'</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>


### PR DESCRIPTION
This PR adds the strings we anticipate when we implement diagnostics. Preparing this early to catch the next localization drop. I also generated the XLF files.

/cc @srivatsn @nguerrera 