### PR TITLE
Allow control of AssemblyInformationVersion specifically

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.GenerateAssemblyInfo.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.GenerateAssemblyInfo.targets
@@ -68,8 +68,8 @@ Copyright (c) .NET Foundation. All rights reserved.
       <AssemblyAttribute Include="System.Reflection.AssemblyFileVersionAttribute" Condition="'$(FileVersion)' != '' and '$(GenerateAssemblyFileVersionAttribute)' == 'true'">
         <_Parameter1>$(FileVersion)</_Parameter1>
       </AssemblyAttribute>
-      <AssemblyAttribute Include="System.Reflection.AssemblyInformationalVersionAttribute" Condition="'$(Version)' != '' and '$(GenerateAssemblyInformationalVersionAttribute)' == 'true'">
-        <_Parameter1>$(Version)</_Parameter1>
+      <AssemblyAttribute Include="System.Reflection.AssemblyInformationalVersionAttribute" Condition="'$(InformationalVersion)' != '' and '$(GenerateAssemblyInformationalVersionAttribute)' == 'true'">
+        <_Parameter1>$(InformationalVersion)</_Parameter1>
       </AssemblyAttribute>
       <AssemblyAttribute Include="System.Reflection.AssemblyProductAttribute" Condition="'$(Product)' != '' and '$(GenerateAssemblyProductAttribute)' == 'true'">
         <_Parameter1>$(Product)</_Parameter1>
@@ -123,6 +123,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     
     <PropertyGroup>
       <FileVersion Condition="'$(FileVersion)' == ''">$(AssemblyVersion)</FileVersion>
+      <InformationalVersion Condition="'$(InformationalVersion)' == ''">$(Version)</InformationalVersion>
     </PropertyGroup>
   </Target>
 


### PR DESCRIPTION
The [Nerdbank.GitVersioning](https://github.com/aarnott/nerdbank.gitversioning) package sets a bunch of assembly version information including the git commit ID in the AssemblyInformationVersion attribute. This fixes the build authoring so that this attribute's value in particular can be customized rather than being set only to the same value as the nuget package.