### PR TITLE
Import common targets if LanguageTargets property isn't set.

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/sdk/Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/sdk/Sdk.targets
@@ -28,10 +28,13 @@ Copyright (c) .NET Foundation. All rights reserved.
   <PropertyGroup Condition="'$(LanguageTargets)' == ''">
     <LanguageTargets Condition="'$(MSBuildProjectExtension)' == '.csproj'">$(MSBuildToolsPath)\Microsoft.CSharp.targets</LanguageTargets>
     <LanguageTargets Condition="'$(MSBuildProjectExtension)' == '.vbproj'">$(MSBuildToolsPath)\Microsoft.VisualBasic.targets</LanguageTargets>
+    
+    <!-- If LanguageTargets isn't otherwise set, then just import the common targets.  This should allow the restore target to run,
+         which could bring in NuGet packages that set the LanguageTargets to something else.  This means support for different
+         languages could either be supplied via an SDK or via a NuGet package. -->
+    <LanguageTargets Condition="'$(LanguageTargets)' == ''">$(MSBuildToolsPath)\Microsoft.Common.CurrentVersion.targets</LanguageTargets>
   </PropertyGroup>
-  
-  <!-- TODO: Generate error if LanguageTargets property isn't set here.  This would happen, for example if an .fsproj referenced the .NET Sdk 
-              but not the FSharp one.  See https://github.com/dotnet/sdk/issues/448 -->
+
   <!-- REMARK: Dont remove/rename, the LanguageTargets property is used by F# to hook inside the project's sdk 
                using Sdk attribute (from .NET Core Sdk 1.0.0-preview4) -->
   <Import Project="$(LanguageTargets)"/>

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildALibrary.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildALibrary.cs
@@ -472,6 +472,28 @@ namespace Microsoft.NET.Build.Tests
                 .Fail();
         }
 
+        [Fact]
+        public void Restore_succeeds_even_if_the_project_extension_is_for_a_different_language()
+        {
+            var testAsset = _testAssetsManager
+                .CopyTestAsset("AppWithLibrary")
+                .WithSource();
+
+            var libraryProjectDirectory = Path.Combine(testAsset.TestRoot, "TestLibrary");
+
+            var oldProjectFile = Path.Combine(libraryProjectDirectory, "TestLibrary.csproj");
+            var newProjectFile = Path.Combine(libraryProjectDirectory, "TestLibrary.fsproj");
+
+            File.Move(oldProjectFile, newProjectFile);
+
+            var restoreCommand = new RestoreCommand(Stage0MSBuild, libraryProjectDirectory, "TestLibrary.fsproj");
+
+            restoreCommand
+                .Execute()
+                .Should()
+                .Pass();
+        }
+
         [Theory]
         [InlineData(".NETStandard,Version=v1.0", new[] { "NETSTANDARD1_0" }, false)]
         [InlineData("netstandard1.3", new[] { "NETSTANDARD1_3" }, false)]

--- a/test/Microsoft.NET.TestFramework/Commands/RestoreCommand.cs
+++ b/test/Microsoft.NET.TestFramework/Commands/RestoreCommand.cs
@@ -14,8 +14,8 @@ namespace Microsoft.NET.TestFramework.Commands
         private List<string> _sources = new List<string>();
         private bool _captureStdOut;
 
-        public RestoreCommand(MSBuildTest msbuild, string projectPath)
-            : base(msbuild, projectPath)
+        public RestoreCommand(MSBuildTest msbuild, string projectPath, string relativePathToProject = null)
+            : base(msbuild, projectPath, relativePathToProject)
         {
         }
 


### PR DESCRIPTION
This will allow restore to succeed.  Fixes #448. Fixes #373 

Rather than generating an error (as specified in #448), this PR imports the common targets if the `LanguageTargets` property isn't set.  This means that restore can succeed even if the language targets aren't otherwise set, which means that F# or another language could be provided solely as a NuGet package instead of an MSBuild SDK.

@enricosada How does this look to you?  Once it is possible to have third party SDKs (see https://github.com/Microsoft/msbuild/issues/1493), you may still prefer to use an SDK for F# over a NuGet package.  It would make the project files more succinct and might avoid the project showing up differently in solution explorer when you create or open a project before the restore completes.