### PR TITLE
Include the new Vsixes in the signing template

### DIFF
--- a/build/Signing/SignToolTemplateConfig.json
+++ b/build/Signing/SignToolTemplateConfig.json
@@ -5,7 +5,9 @@
             "strongName": null,
             "values": [
                 "Microsoft.VisualStudio.ProjectSystem.CSharp.Templates.vsix",
-                "Microsoft.VisualStudio.ProjectSystem.VisualBasic.Templates.vsix"
+                "Microsoft.VisualStudio.ProjectSystem.CSharp.NetStandard.Templates.vsix",
+                "Microsoft.VisualStudio.ProjectSystem.VisualBasic.Templates.vsix",
+                "Microsoft.VisualStudio.ProjectSystem.VisualBasic.NetStandard.Templates.vsix"
             ]
         }
     ]


### PR DESCRIPTION
Include the new vsixes, `Microsoft.VisualStudio.ProjectSystem.CSharp.NetStandard.Templates.vsix` and `Microsoft.VisualStudio.ProjectSystem.VisualBasic.NetStandard.Templates.vsix` in the Sign tool template

@srivatsn @dotnet/project-system for review