### PR TITLE
Fix path too long errors in signed build

### DIFF
--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantAllResourcesInSatellite.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantAllResourcesInSatellite.cs
@@ -16,19 +16,17 @@ using System.Runtime.CompilerServices;
 
 namespace Microsoft.NET.Build.Tests
 {
-    public class GivenThatWeWantAllResourcesInSatellite
+    public class GivenThatWeWantAllResourcesInSatellite : SdkTest
     {
-        private TestAssetsManager _testAssetsManager = TestAssetsManager.TestProjectsAssetsManager;
-
         [Fact]
         public void It_retrieves_strings_successfully()
         {
-            TestSatelliteResources();
+            TestSatelliteResources(_testAssetsManager);
         }
 
-        public void TestSatelliteResources(Action<XDocument> projectChanges = null, Action<BuildCommand> setup = null, [CallerMemberName] string callingMethod = null)
+        public static void TestSatelliteResources(TestAssetsManager testAssetsManager, Action<XDocument> projectChanges = null, Action<BuildCommand> setup = null, [CallerMemberName] string callingMethod = null)
         {
-            var testAsset = _testAssetsManager
+            var testAsset = testAssetsManager
                 .CopyTestAsset("AllResourcesInSatellite", callingMethod)
                 .WithSource();
 

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildACrossTargetedLibrary.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildACrossTargetedLibrary.cs
@@ -11,10 +11,8 @@ using static Microsoft.NET.TestFramework.Commands.MSBuildTest;
 
 namespace Microsoft.NET.Build.Tests
 {
-    public class GivenThatWeWantToBuildACrossTargetedLibrary
+    public class GivenThatWeWantToBuildACrossTargetedLibrary : SdkTest
     {
-        private TestAssetsManager _testAssetsManager = TestAssetsManager.TestProjectsAssetsManager;
-
         [Fact]
         public void It_builds_nondesktop_library_successfully_on_all_platforms()
         {

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildADesktopExe.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildADesktopExe.cs
@@ -13,10 +13,8 @@ using Microsoft.NET.TestFramework.ProjectConstruction;
 
 namespace Microsoft.NET.Build.Tests
 {
-    public class GivenThatWeWantToBuildADesktopExe
+    public class GivenThatWeWantToBuildADesktopExe : SdkTest
     {
-        private TestAssetsManager _testAssetsManager = TestAssetsManager.TestProjectsAssetsManager;
-
         [Fact]
         public void It_fails_to_build_if_no_rid_is_set()
         {

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildALibrary.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildALibrary.cs
@@ -18,10 +18,8 @@ using System.Runtime.CompilerServices;
 
 namespace Microsoft.NET.Build.Tests
 {
-    public class GivenThatWeWantToBuildALibrary
+    public class GivenThatWeWantToBuildALibrary : SdkTest
     {
-        private TestAssetsManager _testAssetsManager = TestAssetsManager.TestProjectsAssetsManager;
-
        [Fact]
         public void It_builds_the_library_successfully()
         {

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildASolutionWithNonAnyCPUPlatform.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildASolutionWithNonAnyCPUPlatform.cs
@@ -11,10 +11,8 @@ using static Microsoft.NET.TestFramework.Commands.MSBuildTest;
 
 namespace Microsoft.NET.Build.Tests
 {
-    public class GivenThatWeWantToBuildASolutionWithNonAnyCPUPlatform
+    public class GivenThatWeWantToBuildASolutionWithNonAnyCPUPlatform : SdkTest
     {
-        private TestAssetsManager _testAssetsManager = TestAssetsManager.TestProjectsAssetsManager;
-
         [Fact]
         public void It_builds_solusuccessfully()
         {

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAnAppWithLibrary.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAnAppWithLibrary.cs
@@ -18,10 +18,8 @@ using System;
 
 namespace Microsoft.NET.Build.Tests
 {
-    public class GivenThatWeWantToBuildAnAppWithLibrary
+    public class GivenThatWeWantToBuildAnAppWithLibrary : SdkTest
     {
-        private TestAssetsManager _testAssetsManager = TestAssetsManager.TestProjectsAssetsManager;
-
         [Fact]
         public void It_builds_the_project_successfully()
         {

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAnAppWithTransitiveProjectRefs.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAnAppWithTransitiveProjectRefs.cs
@@ -18,10 +18,8 @@ using System;
 
 namespace Microsoft.NET.Build.Tests
 {
-    public class GivenThatWeWantToBuildAnAppWithTransitiveProjectRefs
+    public class GivenThatWeWantToBuildAnAppWithTransitiveProjectRefs : SdkTest
     {
-        private TestAssetsManager _testAssetsManager = TestAssetsManager.TestProjectsAssetsManager;
-
         [Fact]
         public void It_builds_the_project_successfully()
         {

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAppsWithFrameworkRefs.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAppsWithFrameworkRefs.cs
@@ -16,10 +16,8 @@ using static Microsoft.NET.TestFramework.Commands.MSBuildTest;
 
 namespace Microsoft.NET.Build.Tests
 {
-    public class GivenThatWeWantToBuildAppsWithFrameworkRefs
+    public class GivenThatWeWantToBuildAppsWithFrameworkRefs : SdkTest
     {
-        private TestAssetsManager _testAssetsManager = TestAssetsManager.TestProjectsAssetsManager;
-
         [Fact]
         public void It_builds_the_projects_successfully()
         {

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToControlGeneratedAssemblyInfo.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToControlGeneratedAssemblyInfo.cs
@@ -12,10 +12,8 @@ using static Microsoft.NET.TestFramework.Commands.MSBuildTest;
 
 namespace Microsoft.NET.Build.Tests
 {
-    public class GivenThatWeWantToControlGeneratedAssemblyInfo
+    public class GivenThatWeWantToControlGeneratedAssemblyInfo : SdkTest
     {
-        private TestAssetsManager _testAssetsManager = TestAssetsManager.TestProjectsAssetsManager;
-
         [Theory]
         [InlineData("AssemblyInformationVersionAttribute")]
         [InlineData("AssemblyFileVersionAttribute")]

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToReferenceAProject.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToReferenceAProject.cs
@@ -14,10 +14,8 @@ using System.Linq;
 
 namespace Microsoft.NET.Build.Tests
 {
-    public class GivenThatWeWantToReferenceAProject
+    public class GivenThatWeWantToReferenceAProject : SdkTest
     {
-        private TestAssetsManager _testAssetsManager = TestAssetsManager.TestProjectsAssetsManager;
-
         //  Different types of projects which should form the test matrix:
 
         //  Desktop (non-SDK) project

--- a/test/Microsoft.NET.Build.Tests/GivenThereAreDefaultItems.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThereAreDefaultItems.cs
@@ -17,10 +17,8 @@ using static Microsoft.NET.TestFramework.Commands.MSBuildTest;
 
 namespace Microsoft.NET.Build.Tests
 {
-    public class GivenThereAreDefaultItems
+    public class GivenThereAreDefaultItems : SdkTest
     {
-        private TestAssetsManager _testAssetsManager = TestAssetsManager.TestProjectsAssetsManager;
-
         [Fact]
         public void It_ignores_excluded_folders()
         {
@@ -351,8 +349,7 @@ namespace Microsoft.NET.Build.Tests
                     "!InvalidCSharp!");
             };
 
-            new GivenThatWeWantAllResourcesInSatellite()
-                .TestSatelliteResources(projectChanges, setup);
+            GivenThatWeWantAllResourcesInSatellite.TestSatelliteResources(_testAssetsManager, projectChanges, setup, "ExplicitCompileDefaultEmbeddedResource");
         }
 
         void RemoveGeneratedCompileItems(List<string> compileItems)

--- a/test/Microsoft.NET.Pack.Tests/GivenThatWeWantToPackACrossTargetedLibrary.cs
+++ b/test/Microsoft.NET.Pack.Tests/GivenThatWeWantToPackACrossTargetedLibrary.cs
@@ -13,10 +13,8 @@ using static Microsoft.NET.TestFramework.Commands.MSBuildTest;
 
 namespace Microsoft.NET.Pack.Tests
 {
-    public class GivenThatWeWantToPackACrossTargetedLibrary
+    public class GivenThatWeWantToPackACrossTargetedLibrary : SdkTest
     {
-        private TestAssetsManager _testAssetsManager = TestAssetsManager.TestProjectsAssetsManager;
-
         [Fact]
         public void It_packs_nondesktop_library_successfully_on_all_platforms()
         {

--- a/test/Microsoft.NET.Pack.Tests/GivenThatWeWantToPackASimpleLibrary.cs
+++ b/test/Microsoft.NET.Pack.Tests/GivenThatWeWantToPackASimpleLibrary.cs
@@ -13,10 +13,8 @@ using static Microsoft.NET.TestFramework.Commands.MSBuildTest;
 
 namespace Microsoft.NET.Pack.Tests
 {
-    public class GivenThatWeWantToPackASimpleLibrary
+    public class GivenThatWeWantToPackASimpleLibrary : SdkTest
     {
-        private TestAssetsManager _testAssetsManager = TestAssetsManager.TestProjectsAssetsManager;
-
         [Fact]
         public void It_packs_successfully()
         {

--- a/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPreserveCompilationContext.cs
+++ b/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPreserveCompilationContext.cs
@@ -16,10 +16,8 @@ using System.Xml.Linq;
 
 namespace Microsoft.NET.Publish.Tests
 {
-    public class GivenThatWeWantToPreserveCompilationContext
+    public class GivenThatWeWantToPreserveCompilationContext : SdkTest
     {
-        private TestAssetsManager _testAssetsManager = TestAssetsManager.TestProjectsAssetsManager;
-
         [Fact]
         public void It_publishes_the_project_with_a_refs_folder_and_correct_deps_file()
         {

--- a/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAHelloWorldProject.cs
+++ b/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAHelloWorldProject.cs
@@ -13,15 +13,8 @@ using static Microsoft.NET.TestFramework.Commands.MSBuildTest;
 
 namespace Microsoft.NET.Publish.Tests
 {
-    public class GivenThatWeWantToPublishAHelloWorldProject
+    public class GivenThatWeWantToPublishAHelloWorldProject : SdkTest
     {
-        private TestAssetsManager _testAssetsManager;
-
-        public GivenThatWeWantToPublishAHelloWorldProject()
-        {
-            _testAssetsManager = TestAssetsManager.TestProjectsAssetsManager;
-        }
-
         [Fact]
         public void It_publishes_portable_apps_to_the_publish_folder_and_the_app_should_run()
         {

--- a/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAProjectWithAllFeatures.cs
+++ b/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAProjectWithAllFeatures.cs
@@ -15,10 +15,8 @@ using static Microsoft.NET.TestFramework.Commands.MSBuildTest;
 
 namespace Microsoft.NET.Publish.Tests
 {
-    public class GivenThatWeWantToPublishAProjectWithAllFeatures
+    public class GivenThatWeWantToPublishAProjectWithAllFeatures : SdkTest
     {
-        private TestAssetsManager _testAssetsManager = TestAssetsManager.TestProjectsAssetsManager;
-
         [Fact]
         public void It_publishes_the_project_correctly()
         {

--- a/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAProjectWithDependencies.cs
+++ b/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAProjectWithDependencies.cs
@@ -12,15 +12,8 @@ using System.Runtime.InteropServices;
 
 namespace Microsoft.NET.Publish.Tests
 {
-    public class GivenThatWeWantToPublishAProjectWithDependencies
+    public class GivenThatWeWantToPublishAProjectWithDependencies : SdkTest
     {
-        private TestAssetsManager _testAssetsManager;
-
-        public GivenThatWeWantToPublishAProjectWithDependencies()
-        {
-            _testAssetsManager = TestAssetsManager.TestProjectsAssetsManager;
-        }
-
         [Fact]
         public void It_publishes_projects_with_simple_dependencies()
         {

--- a/test/Microsoft.NET.TestFramework/SdkTest.cs
+++ b/test/Microsoft.NET.TestFramework/SdkTest.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.NET.TestFramework
+{
+    public class SdkTest : IDisposable
+    {
+        protected TestAssetsManager _testAssetsManager = new TestAssetsManager();
+
+        public void Dispose()
+        {
+            _testAssetsManager.ValidateDestinationDirectories();
+        }
+    }
+}


### PR DESCRIPTION
Also add validation to try to catch this when tests are run on any machine in the future.

FWIW, the following powershell command is useful for finding the longest path under a folder:

```powershell
Get-ChildItem -Recurse | % { $_.FullName } | Sort-Object -Descending -Property Length > longpaths.txt
```