### PR TITLE
Support well-known 'Publish' target extensions

### DIFF
--- a/TestAssets/TestProjects/PublishTargets/PublishTargets.csproj
+++ b/TestAssets/TestProjects/PublishTargets/PublishTargets.csproj
@@ -1,0 +1,41 @@
+<Project ToolsVersion="15.0">
+  <Import Project="$(MSBuildSdksPath)\Microsoft.NET.Sdk\Sdk\Sdk.props" />
+
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <TargetFramework>netstandard1.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NETStandard.Library" Version="1.6.0" />
+  </ItemGroup>
+
+  <Import Project="$(MSBuildSdksPath)\Microsoft.NET.Sdk\Sdk\Sdk.targets" />
+
+  <!-- common, well-known targets for user to override must be defined after Microsoft.Common.targets is imported -->
+
+  <Target Name="AfterPublish">
+      <WriteLinesToFile File="$(PublishDir)afterpublish.txt"
+            Lines="$(PublishTimestamp)"
+            Overwrite="true" />
+  </Target>
+
+  <Target Name="BeforePublish" DependsOnTargets="PrepareForPublish">
+      <WriteLinesToFile File="$(PublishDir)beforepublish.txt"
+            Lines="$(PublishTimestamp)"
+            Overwrite="true" />
+  </Target>
+
+  <!-- chaining into PublishDependsOn -->
+
+  <PropertyGroup>
+    <PublishDependsOn>$(PublishDependsOn);CustomAfterPublishDependsOn</PublishDependsOn>
+  </PropertyGroup>
+
+  <Target Name="CustomAfterPublishDependsOn">
+    <WriteLinesToFile File="$(PublishDir)publishdependson.txt"
+            Lines="$(PublishTimestamp)"
+            Overwrite="true" />
+  </Target>
+
+</Project>

--- a/TestAssets/TestProjects/PublishTargets/obj/PublishTargets.csproj.tool.g.targets
+++ b/TestAssets/TestProjects/PublishTargets/obj/PublishTargets.csproj.tool.g.targets
@@ -1,0 +1,14 @@
+<!-- A tool (e.g. NuGet) may import targets via MSBuildProjectExtensionsPath -->
+<Project ToolsVersion="15.0">
+
+  <PropertyGroup>
+    <PublishDependsOn>$(PublishDependsOn);ImportedPublishDependsOn</PublishDependsOn>
+  </PropertyGroup>
+
+  <Target Name="ImportedPublishDependsOn">
+    <WriteLinesToFile File="$(PublishDir)importedpublishdependson.txt"
+            Lines="$(PublishTimestamp)"
+            Overwrite="true" />
+  </Target>
+
+</Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Publish.targets
@@ -6,7 +6,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
           created a backup copy.  Incorrect changes to this file will make it
           impossible to load or build your projects from the command-line or the IDE.
 
-Copyright (c) .NET Foundation. All rights reserved. 
+Copyright (c) .NET Foundation. All rights reserved.
 ***********************************************************************************************
 -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
@@ -14,13 +14,13 @@ Copyright (c) .NET Foundation. All rights reserved.
   <!--
     ============================================================
                                         Publish
- 
+
     The main publish entry point.
     ============================================================
     -->
   <PropertyGroup>
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
-    
+
     <DefaultCopyToPublishDirectoryMetadata Condition="'$(DefaultCopyToPublishDirectoryMetadata)' == ''">true</DefaultCopyToPublishDirectoryMetadata>
     <_GetChildProjectCopyToPublishDirectoryItems Condition="'$(_GetChildProjectCopyToPublishDirectoryItems)' == ''">true</_GetChildProjectCopyToPublishDirectoryItems>
 
@@ -34,12 +34,27 @@ Copyright (c) .NET Foundation. All rights reserved.
     </ResolvedFileToPublish>
   </ItemDefinitionGroup>
 
+  <ItemGroup>
+    <!-- remove ClickOnce targets imported from Microsoft.Common.targets -->
+    <_FilteredPublishDependsOn Include="$(PublishDependsOn)"
+                               Exclude="Build;SetGenerateManifests;PublishOnly;_DeploymentUnpublishable" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <_PublishDependsOn>
+      Build;
+      BeforePublish;
+      PrepareForPublish;
+      ComputeAndCopyFilesToPublishDirectory;
+      GeneratePublishDependencyFile;
+      GeneratePublishRuntimeConfigurationFile;
+      @(_FilteredPublishDependsOn);
+      AfterPublish;
+    </_PublishDependsOn>
+  </PropertyGroup>
+
   <Target Name="Publish"
-          DependsOnTargets="Build;
-                            PrepareForPublish;
-                            ComputeAndCopyFilesToPublishDirectory;
-                            GeneratePublishDependencyFile;
-                            GeneratePublishRuntimeConfigurationFile" />
+          DependsOnTargets="$(_PublishDependsOn)" />
 
   <!--
     ============================================================
@@ -179,7 +194,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                               Condition="'$(CopyBuildOutputToPublishDirectory)' == 'true'">
         <RelativePath>@(IntermediateAssembly->'%(Filename)%(Extension)')</RelativePath>
       </ResolvedFileToPublish>
-      
+
       <!-- Copy the app.config (if any) -->
       <ResolvedFileToPublish Include="@(AppConfigWithTargetPath)"
                               Condition="'$(CopyBuildOutputToPublishDirectory)' == 'true'">
@@ -272,8 +287,8 @@ Copyright (c) .NET Foundation. All rights reserved.
     This includes baggage items from transitively referenced projects. It would appear
     that this target computes full transitive closure of content items for all referenced
     projects; however that is not the case. It only collects the content items from its
-    immediate children and not children of children. 
-    
+    immediate children and not children of children.
+
     See comment on GetCopyToOutputDirectoryItems, from which this logic was taken.
     ============================================================
     -->
@@ -461,7 +476,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     ============================================================
                                         ComputePrivateAssetsPackageReferences
 
-    Builds up the @(PrivateAssetsPackageReference) item by looking for @(PackageReference) items with 
+    Builds up the @(PrivateAssetsPackageReference) item by looking for @(PackageReference) items with
     <PrivateAssets> metadata.
     ============================================================
     -->

--- a/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishWithCommonPublishTargets.cs
+++ b/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishWithCommonPublishTargets.cs
@@ -1,0 +1,69 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using System.Linq;
+using FluentAssertions;
+using Microsoft.DotNet.Cli.Utils;
+using Microsoft.NET.TestFramework;
+using Microsoft.NET.TestFramework.Assertions;
+using Microsoft.NET.TestFramework.Commands;
+using Xunit;
+using static Microsoft.NET.TestFramework.Commands.MSBuildTest;
+
+namespace Microsoft.NET.Publish.Tests
+{
+    public class GivenThatWeWantToPublishAProjectWithPublishTargets
+    {
+        private TestAssetsManager _testAssetsManager;
+
+        public GivenThatWeWantToPublishAProjectWithPublishTargets()
+        {
+            _testAssetsManager = TestAssetsManager.TestProjectsAssetsManager;
+        }
+
+        [Fact]
+        public void It_executes_targets_that_extend_publish_target()
+        {
+            var publishTargetsAsset = _testAssetsManager
+                .CopyTestAsset("PublishTargets")
+                .WithSource()
+                .Restore();
+
+            File.Copy(
+                Path.Combine(publishTargetsAsset.SourceRoot, "obj", "PublishTargets.csproj.tool.g.targets"),
+                Path.Combine(publishTargetsAsset.TestRoot, "obj", "PublishTargets.csproj.tool.g.targets"));
+
+            var publishCommand = new PublishCommand(Stage0MSBuild, publishTargetsAsset.TestRoot);
+            var timestamp = DateTime.UtcNow.ToString();
+            var publishResult = publishCommand.Execute("/p:PublishTimestamp=" + timestamp);
+
+            publishResult.Should().Pass();
+
+            var publishDirectory = publishCommand.GetOutputDirectory("netstandard1.0");
+
+            var publishTargetFiles = new []
+            {
+                "afterpublish.txt",
+                "beforepublish.txt",
+                "publishdependson.txt",
+                "importedpublishdependson.txt"
+            };
+
+            publishDirectory.Should().OnlyHaveFiles(new[]
+            {
+                "PublishTargets.dll",
+                "PublishTargets.pdb",
+                "PublishTargets.deps.json",
+            }.Concat(publishTargetFiles));
+
+            foreach (var file in publishTargetFiles)
+            {
+                var path = Path.Combine(publishDirectory.FullName, file);
+                File.ReadAllText(path)?.Trim()
+                    .Should().Be(timestamp);
+            }
+        }
+    }
+}

--- a/test/Microsoft.NET.TestFramework/TestAsset.cs
+++ b/test/Microsoft.NET.TestFramework/TestAsset.cs
@@ -22,6 +22,8 @@ namespace Microsoft.NET.TestFramework
 
         public string TestRoot => Path;
 
+        public string SourceRoot => _testAssetRoot;
+
         internal TestAsset(string testDestination, string buildVersion) : base(testDestination)
         {
             BuildVersion = buildVersion;
@@ -117,7 +119,7 @@ namespace Microsoft.NET.TestFramework
                 }
             }
             return this;
-            
+
         }
 
         public void SetSdkVersion(XDocument project)


### PR DESCRIPTION
Current implementation of 'Publish' target tramples on the well-known targets/properties from Microsoft.Common.targets. This adds support for extending publish via:

 - Adding to the 'PublishDependsOn' property
 - Implementing custom 'AfterPublish' and 'BeforePublish' targets

