### PR TITLE
Produce Only Preprocessor Files in ProduceContentAssets

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/ProduceContentAssets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ProduceContentAssets.cs
@@ -18,6 +18,7 @@ namespace Microsoft.NET.Build.Tasks
     /// </summary>
     public sealed class ProduceContentAssets : TaskBase
     {
+        private const string PPOutputPathKey = "ppOutputPath";
         private readonly Dictionary<string, string> _resolvedPaths = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         private readonly List<ITaskItem> _contentItems = new List<ITaskItem>();
         private readonly List<ITaskItem> _fileWrites = new List<ITaskItem>();
@@ -84,6 +85,14 @@ namespace Microsoft.NET.Build.Tasks
         /// Optional the Project Language (E.g. C#, VB)
         /// </summary>
         public string ProjectLanguage
+        {
+            get; set;
+        }
+
+        /// <summary>
+        /// Optionally filter the operation of this task to just preprocessor files
+        /// </summary>
+        public bool ProduceOnlyPreprocessorFiles
         {
             get; set;
         }
@@ -161,7 +170,9 @@ namespace Microsoft.NET.Build.Tasks
             }
 
             var contentFileDeps = ContentFileDependencies ?? Enumerable.Empty<ITaskItem>();
-            var contentFileGroups = contentFileDeps.GroupBy(t => t.GetMetadata(MetadataKeys.ParentPackage));
+            var contentFileGroups = contentFileDeps
+                .Where(f => !ProduceOnlyPreprocessorFiles || IsPreprocessorFile(f))
+                .GroupBy(t => t.GetMetadata(MetadataKeys.ParentPackage));
             foreach (var grouping in contentFileGroups)
             {
                 // Is there an asset with our exact language? If so, we use that. Otherwise we'll simply collect "any" assets.
@@ -202,6 +213,9 @@ namespace Microsoft.NET.Build.Tasks
             }
         }
 
+        private bool IsPreprocessorFile(ITaskItem contentFile) =>
+            contentFile.GetMetadata(PPOutputPathKey) != null;
+
         private void ProduceContentAsset(ITaskItem contentFile)
         {
             string resolvedPath;
@@ -212,7 +226,7 @@ namespace Microsoft.NET.Build.Tasks
             }
 
             string pathToFinalAsset = resolvedPath;
-            string ppOutputPath = contentFile.GetMetadata("ppOutputPath");
+            string ppOutputPath = contentFile.GetMetadata(PPOutputPathKey);
             string parentPackage = contentFile.GetMetadata(MetadataKeys.ParentPackage);
 
             if (ppOutputPath != null)
@@ -249,7 +263,7 @@ namespace Microsoft.NET.Build.Tasks
                 }
                 else
                 {
-                    Log.LogWarning(Strings.ContentItemDoesNotProvideOutputPath, pathToFinalAsset, "copyToOutput", "outputPath", "ppOutputPath");
+                    Log.LogWarning(Strings.ContentItemDoesNotProvideOutputPath, pathToFinalAsset, "copyToOutput", "outputPath", PPOutputPathKey);
                 }
             }
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.PackageDependencyResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.PackageDependencyResolution.targets
@@ -38,6 +38,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <CopyLocalLockFileAssemblies Condition="'$(CopyLocalLockFileAssemblies)' == ''">true</CopyLocalLockFileAssemblies>
 
     <ContentPreprocessorOutputDirectory Condition="'$(ContentPreprocessorOutputDirectory)' == ''">$(IntermediateOutputPath)NuGet\</ContentPreprocessorOutputDirectory>
+    <ProduceOnlyPreprocessorFilesInBuildTask Condition="'$(ProduceOnlyPreprocessorFilesInBuildTask)' == ''">true</ProduceOnlyPreprocessorFilesInBuildTask>
 
     <UseTargetPlatformAsNuGetTargetMoniker Condition="'$(UseTargetPlatformAsNuGetTargetMoniker)' == '' AND '$(TargetFrameworkMoniker)' == '.NETCore,Version=v5.0'">true</UseTargetPlatformAsNuGetTargetMoniker>
     <NuGetTargetMoniker Condition="'$(NuGetTargetMoniker)' == '' AND '$(UseTargetPlatformAsNuGetTargetMoniker)' == 'true'">$(TargetPlatformIdentifier),Version=v$([System.Version]::Parse('$(TargetPlatformMinVersion)').ToString(3))</NuGetTargetMoniker>
@@ -209,6 +210,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       ContentFileDependencies="@(_ContentFileDeps)"
       ContentPreprocessorValues="@(PreprocessorValue)"
       ContentPreprocessorOutputDirectory="$(ContentPreprocessorOutputDirectory)"
+      ProduceOnlyPreprocessorFiles="$(ProduceOnlyPreprocessorFilesInBuildTask)"
       ProjectLanguage="$(Language)">
 
       <Output TaskParameter="CopyLocalItems" ItemName="_ContentCopyLocalItems" />


### PR DESCRIPTION
Adds mode to produce only preprocessor files in ProduceContentAssets. Preprocessor files are items with `ppOutputPath` metadata set. This mode can be turned on since NuGet produces the remaining content files.

Fixes #577 

/cc @emgarten @dsplaisted @nguerrera @srivatsn 