### PR TITLE
Fix Publish failing when an app targets netcoreapp1.1 and a P2P to a project that targets netcoreapp1.1

### DIFF
--- a/TestAssets/TestProjects/NetCoreApp11WithP2P/App/App.csproj
+++ b/TestAssets/TestProjects/NetCoreApp11WithP2P/App/App.csproj
@@ -1,0 +1,16 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Library\Library.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NETCore.App" Version="1.1.0" />
+  </ItemGroup>
+
+</Project>

--- a/TestAssets/TestProjects/NetCoreApp11WithP2P/App/Program.cs
+++ b/TestAssets/TestProjects/NetCoreApp11WithP2P/App/Program.cs
@@ -1,0 +1,9 @@
+using System;
+
+class Program
+{
+    static void Main(string[] args)
+    {
+        Console.WriteLine("Hello World!");
+    }
+}

--- a/TestAssets/TestProjects/NetCoreApp11WithP2P/Library/Class1.cs
+++ b/TestAssets/TestProjects/NetCoreApp11WithP2P/Library/Class1.cs
@@ -1,0 +1,8 @@
+﻿using System;
+
+namespace ClassLibrary
+{
+    public class Class1
+    {
+    }
+}

--- a/TestAssets/TestProjects/NetCoreApp11WithP2P/Library/Library.csproj
+++ b/TestAssets/TestProjects/NetCoreApp11WithP2P/Library/Library.csproj
@@ -1,0 +1,11 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NETCore.App" Version="1.1.0" />
+  </ItemGroup>
+
+</Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Publish.targets
@@ -98,7 +98,7 @@ Copyright (c) .NET Foundation. All rights reserved.
         one of these files and not have an incremental build replace it.
         -->
     <Copy SourceFiles = "@(_ResolvedFileToPublishPreserveNewest)"
-          DestinationFiles="$(PublishDir)%(_ResolvedFileToPublishPreserveNewest.RelativePath)"
+          DestinationFiles="@(_ResolvedFileToPublishPreserveNewest->'$(PublishDir)%(RelativePath)')"
           OverwriteReadOnlyFiles="$(OverwriteReadOnlyFiles)"
           Retries="$(CopyRetryCount)"
           RetryDelayMilliseconds="$(CopyRetryDelayMilliseconds)"
@@ -126,7 +126,7 @@ Copyright (c) .NET Foundation. All rights reserved.
         one of these files and not have an incremental build replace it.
         -->
     <Copy SourceFiles = "@(_ResolvedFileToPublishAlways)"
-          DestinationFiles="$(PublishDir)%(_ResolvedFileToPublishAlways.RelativePath)"
+          DestinationFiles="@(_ResolvedFileToPublishAlways->'$(PublishDir)%(RelativePath)')"
           OverwriteReadOnlyFiles="$(OverwriteReadOnlyFiles)"
           Retries="$(CopyRetryCount)"
           RetryDelayMilliseconds="$(CopyRetryDelayMilliseconds)"

--- a/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAProjectWithDependencies.cs
+++ b/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAProjectWithDependencies.cs
@@ -88,5 +88,26 @@ namespace Microsoft.NET.Publish.Tests
                 "DesktopNeedsBindingRedirects.exe.config"
             });
         }
+
+        [Fact]
+        public void It_publishes_projects_targeting_netcoreapp11_with_p2p_targeting_netcoreapp11()
+        {
+            // Microsoft.NETCore.App 1.1.0 added a dependency on Microsoft.DiaSymReader.Native.
+            // Microsoft.DiaSymReader.Native package adds a "Content" item for its native assemblies,
+            // which means an App project will get duplicate "Content" items for each P2P it references
+            // that targets netcoreapp1.1.  Ensure Publish works correctly with these duplicate Content items.
+
+            var testAsset = _testAssetsManager
+                .CopyTestAsset("NetCoreApp11WithP2P")
+                .WithSource()
+                .Restore("App");
+
+            var appProjectDirectory = Path.Combine(testAsset.TestRoot, "App");
+            PublishCommand publishCommand = new PublishCommand(Stage0MSBuild, appProjectDirectory);
+            publishCommand
+                .Execute()
+                .Should()
+                .Pass();
+        }
     }
 }


### PR DESCRIPTION
The issue is that NETCore.App 1.1.0 now references DiaSymReader.Native nuget package and DiaSymReader.Native includes a "Content" item for the native assemblies.  So the app gets duplicate "Content" items, one from the app project and one from the P2P project.  When you have 2 duplicate Content items publish fails with:

"error MSB3094: "DestinationFiles" refers to 1 item(s), and "SourceFiles" refers to 2 item(s). They must have the same number of items."

Attached is a project that repros the issue with `dotnet restore` and `dotnet publish` the App project.

[DiaSymTest.zip](https://github.com/dotnet/sdk/files/685464/DiaSymTest.zip)