### PR TITLE
Filter ProduceContentAssets to active TFM 

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/ProduceContentAssets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ProduceContentAssets.cs
@@ -214,7 +214,7 @@ namespace Microsoft.NET.Build.Tasks
         }
 
         private bool IsPreprocessorFile(ITaskItem contentFile) =>
-            contentFile.GetMetadata(PPOutputPathKey) != null;
+            !string.IsNullOrEmpty(contentFile.GetMetadata(PPOutputPathKey));
 
         private void ProduceContentAsset(ITaskItem contentFile)
         {
@@ -229,7 +229,7 @@ namespace Microsoft.NET.Build.Tasks
             string ppOutputPath = contentFile.GetMetadata(PPOutputPathKey);
             string parentPackage = contentFile.GetMetadata(MetadataKeys.ParentPackage);
 
-            if (ppOutputPath != null)
+            if (!string.IsNullOrEmpty(ppOutputPath))
             {
                 if (string.IsNullOrEmpty(ContentPreprocessorOutputDirectory))
                 {
@@ -251,9 +251,10 @@ namespace Microsoft.NET.Build.Tasks
 
             if (contentFile.GetBooleanMetadata("copyToOutput") == true)
             {
-                string outputPath = contentFile.GetMetadata("outputPath") ?? ppOutputPath;
+                string outputPath = contentFile.GetMetadata("outputPath");
+                outputPath = string.IsNullOrEmpty(outputPath) ? ppOutputPath : outputPath;
 
-                if (outputPath != null)
+                if (!string.IsNullOrEmpty(outputPath))
                 {
                     var item = new TaskItem(pathToFinalAsset);
                     item.SetMetadata("TargetPath", outputPath);

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.PackageDependencyResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.PackageDependencyResolution.targets
@@ -208,9 +208,9 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <Target Name="RunProduceContentAssets"
           Returns="_ContentCopyLocalItems;FileWrites"
-          DependsOnTargets="RunResolvePackageDependencies">
+          DependsOnTargets="_ComputeActiveTFMFileDependencies">
     <ItemGroup>
-      <_ContentFileDeps Include="@(FileDependencies->WithMetadataValue('FileGroup', 'ContentFile'))" />
+      <_ContentFileDeps Include="@(_ActiveTFMFileDependencies->WithMetadataValue('FileGroup', 'ContentFile'))" />
       <__ContentFileDefs Include="@(FileDefinitions)" Exclude="@(_ContentFileDeps)" />
       <_ContentFileDefs Include="@(FileDefinitions)" Exclude="@(__ContentFileDefs)" />
     </ItemGroup>


### PR DESCRIPTION
Fixes #495 
Fixes #372 

ProduceContentAssets was not properly filtering to the active tfm, causing the same content file to be reported twice in some cross targeting projects. For `buildAction=Compile`, this causes a compilation error.

Additionally, the idiom `item.GetMetadata() != null` is incorrect as GetMetadata can return string.Empty.

/cc @srivatsn @nguerrera @dsplaisted 
/cc @emgarten @rohit21agrawal since NuGet now handles non-pp content files, please verify it is properly filtering to active TFM as well.
