### PR TITLE
.NET Core Class Library template should not appear in root

### DIFF
--- a/src/Templates/ProjectTemplates/CSharp/.NETCore/CSharpClassLibrary/ClassLibrary.vstemplate
+++ b/src/Templates/ProjectTemplates/CSharp/.NETCore/CSharpClassLibrary/ClassLibrary.vstemplate
@@ -7,7 +7,7 @@
     <ProjectType>CSharp</ProjectType>
     <RequiredFrameworkVersion>2.0</RequiredFrameworkVersion>
     <SortOrder>14</SortOrder>
-    <NumberOfParentCategoriesToRollUp>1</NumberOfParentCategoriesToRollUp>
+    <NumberOfParentCategoriesToRollUp>0</NumberOfParentCategoriesToRollUp>
     <TemplateID>Microsoft.CSharp.NETCore.ClassLibrary</TemplateID>
     <CreateNewFolder>true</CreateNewFolder>
     <CreateInPlace>true</CreateInPlace>


### PR DESCRIPTION
fixes #564