### PR TITLE
Fix publishing with project references, re-enable tests

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/DependencyContextBuilder.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/DependencyContextBuilder.cs
@@ -32,7 +32,7 @@ namespace Microsoft.NET.Build.Tasks
             _projectContext = projectContext;
 
             // This resolver is only used for building file names, so that base path is not required.
-            _versionFolderPathResolver = new VersionFolderPathResolver(path: null);
+            _versionFolderPathResolver = new VersionFolderPathResolver(rootPath: null);
         }
 
         public DependencyContextBuilder WithFrameworkReferences(IEnumerable<ReferenceInfo> frameworkReferences)

--- a/src/Tasks/Microsoft.NET.Build.Tasks/PublishAssembliesResolver.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/PublishAssembliesResolver.cs
@@ -31,6 +31,11 @@ namespace Microsoft.NET.Build.Tasks
 
             foreach (LockFileTargetLibrary targetLibrary in projectContext.GetRuntimeLibraries(_privateAssetPackageIds))
             {
+                if (targetLibrary.Type == "project")
+                {
+                    continue;
+                }
+
                 string libraryPath = _packageResolver.GetPackageDirectory(targetLibrary.Name, targetLibrary.Version);
 
                 results.AddRange(GetResolvedFiles(targetLibrary.RuntimeAssemblies, libraryPath));

--- a/src/Tasks/Microsoft.NET.Build.Tasks/PublishAssembliesResolver.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/PublishAssembliesResolver.cs
@@ -31,7 +31,7 @@ namespace Microsoft.NET.Build.Tasks
 
             foreach (LockFileTargetLibrary targetLibrary in projectContext.GetRuntimeLibraries(_privateAssetPackageIds))
             {
-                if (targetLibrary.Type == "project")
+                if (targetLibrary.Type != "package")
                 {
                     continue;
                 }

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAnAppWithTransitiveProjectRefs.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAnAppWithTransitiveProjectRefs.cs
@@ -28,7 +28,7 @@ namespace Microsoft.NET.Build.Tests
             // (TestApp transitively depends on AuxLibrary)
 
             var testAsset = _testAssetsManager
-                .CopyTestAsset("AppWithTransitiveProjectRefs")
+                .CopyTestAsset("AppWithTransitiveProjectRefs", "BuildAppWithTransitiveProjectRef")
                 .WithSource();
 
             testAsset.Restore("TestApp");

--- a/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPreserveCompilationContext.cs
+++ b/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPreserveCompilationContext.cs
@@ -18,7 +18,7 @@ namespace Microsoft.NET.Publish.Tests
 {
     public class GivenThatWeWantToPreserveCompilationContext : SdkTest
     {
-        //[Fact]
+        [Fact]
         public void It_publishes_the_project_with_a_refs_folder_and_correct_deps_file()
         {
             var testAsset = _testAssetsManager

--- a/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAProjectWithAllFeatures.cs
+++ b/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAProjectWithAllFeatures.cs
@@ -18,7 +18,7 @@ namespace Microsoft.NET.Publish.Tests
 {
     public class GivenThatWeWantToPublishAProjectWithAllFeatures : SdkTest
     {
-        //[Theory]
+        [Theory]
         [MemberData("PublishData")]
         public void It_publishes_the_project_correctly(string targetFramework, string [] expectedPublishFiles)
         {

--- a/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAProjectWithDependencies.cs
+++ b/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAProjectWithDependencies.cs
@@ -89,7 +89,7 @@ namespace Microsoft.NET.Publish.Tests
             });
         }
 
-        //[Fact]
+        [Fact]
         public void It_publishes_projects_targeting_netcoreapp11_with_p2p_targeting_netcoreapp11()
         {
             // Microsoft.NETCore.App 1.1.0 added a dependency on Microsoft.DiaSymReader.Native.


### PR DESCRIPTION
https://github.com/NuGet/NuGet.Client/pull/1072, adde files under project entries in the assets file, such as the following, under `compile` and `runtime`:

```json
      "MainLibrary/1.0.0": {
        "type": "project",
        "framework": ".NETStandard,Version=v1.4",
        "dependencies": {
          "AuxLibrary": "1.0.0",
          "NETStandard.Library": "1.6.1"
        },
        "compile": {
          "bin/placeholder/netstandard1.4/MainLibrary.dll": {}
        },
        "runtime": {
          "bin/placeholder/netstandard1.4/MainLibrary.dll": {}
        }
      }
```

The `PublishAssembliesResolver` was trying to process the runtime files and getting a null reference because the package directory returned from the resolver was null.  I believe the right thing to do is to skip these projects entirely in `PublishAssembliesResolver.Resolve`, as the runtime and native assets from those projects should already have come in via the `ProjectReference` process.

@natidea @emgarten @eerhardt for review