### PR TITLE
Enable deploying templates to RoslynDev hive during build

### DIFF
--- a/Common.props
+++ b/Common.props
@@ -19,8 +19,6 @@
     <PackagesLayoutToolsNet46Dir>$(PackagesLayoutToolsDir)net46\</PackagesLayoutToolsNet46Dir>
     <PackagesLayoutToolsNetCoreAppDir>$(PackagesLayoutToolsDir)netcoreapp1.0\</PackagesLayoutToolsNetCoreAppDir>
     
-    <VersionPrefix Condition="'$(VersionPrefix)' == ''">1.0.0</VersionPrefix>
-    <VersionPrereleasePrefix Condition="'$(VersionPrereleasePrefix)' == ''">alpha</VersionPrereleasePrefix>
     <!-- When running on VSO (for official builds) use a real number. -->
     <BuildNumber Condition="'$(BuildNumber)' == ''">$(BUILD_BUILDNUMBER)</BuildNumber>
     <!-- Split the build parts out from the BuildNumber which is given to us by MicroBuild in the format of yyyymmdd.nn
@@ -33,8 +31,11 @@
          we will continue the month counting instead: the build after 61231 is 61301. -->
     <BuildNumberFiveDigitDateStamp Condition="'$(BuildNumber)' != ''">$([MSBuild]::Subtract($(BuildNumber.Split('.')[0].Substring(3).Trim()), 8800))</BuildNumberFiveDigitDateStamp>
     <BuildNumberBuildOfTheDayPadded Condition="('$(BuildNumber)' != '') AND ($(BuildNumber.Split('.').Length) == 2)">$(BuildNumber.Split('.')[1].PadLeft(2,'0'))</BuildNumberBuildOfTheDayPadded>
-    <VersionSuffix Condition="'$(VersionSuffix)' == ''">$(VersionPrereleasePrefix)-$(BuildNumber)</VersionSuffix>
+
+    <VersionPrefix Condition="'$(VersionPrefix)' == ''">1.0.0</VersionPrefix>
+    <VersionSuffix Condition="'$(VersionSuffix)' == ''">alpha</VersionSuffix>
     <Version Condition="'$(Version)' == ''">$(VersionPrefix)-$(VersionSuffix)</Version>
+    <Version Condition="'$(BuildNumberFiveDigitDateStamp)' != '' AND '$(BuildNumberBuildOfTheDayPadded)' != ''">$(Version)-$(BuildNumberFiveDigitDateStamp.Trim())-$(BuildNumberBuildOfTheDayPadded.Trim())</Version>
   </PropertyGroup>
   
   <!-- Prepare Version number used in template builds -->
@@ -45,6 +46,7 @@
         day-to-day upgrades don't break assembly references to other installed apps. -->
       <PropertyGroup>
         <AssemblyVersion>$(VersionPrefix).0</AssemblyVersion>
+        <VsixVersion>$(BuildVersion)</VsixVersion>
       </PropertyGroup>
     </When>
 
@@ -53,7 +55,7 @@
       <PropertyGroup>
         <AssemblyVersion>$(VersionPrefix).0</AssemblyVersion>
         <BuildVersion>$(VersionPrefix).$(BuildNumberFiveDigitDateStamp)</BuildVersion>
-        <VsixVersion>$(VersionPrefix).$(BuildNumberFiveDigitDateStamp)-$(BuildNumberBuildOfTheDayPadded)</VsixVersion>
+        <VsixVersion>$(VersionPrefix).$(BuildNumberFiveDigitDateStamp)$(BuildNumberBuildOfTheDayPadded)</VsixVersion>
       </PropertyGroup>
     </When>
 
@@ -63,7 +65,7 @@
       <PropertyGroup>
         <AssemblyVersion>$(VersionPrefix).0</AssemblyVersion>
         <BuildVersion>$(VersionPrefix).$(BuildNumberFiveDigitDateStamp)</BuildVersion>
-        <VsixVersion>$(VersionPrefix).$(BuildNumberFiveDigitDateStamp)-$(BuildNumberBuildOfTheDayPadded)</VsixVersion>
+        <VsixVersion>$(VersionPrefix).$(BuildNumberFiveDigitDateStamp)$(BuildNumberBuildOfTheDayPadded)</VsixVersion>
       </PropertyGroup>
     </When>
 
@@ -73,8 +75,8 @@
         have a build with an actual number installed, but then build and F5 a build with
         this number.  -->
       <PropertyGroup>
-        <BuildVersion>42.42.42.42</BuildVersion>
         <AssemblyVersion>42.42.42.42</AssemblyVersion>
+        <BuildVersion>42.42.42.42</BuildVersion>
         <VsixVersion>42.42.42.42</VsixVersion>
       </PropertyGroup>
     </Otherwise>
@@ -88,7 +90,7 @@
          number. This conforms to the dependencies specified in the ManagedDesktop workload [2.0.0.0,3.0.0.0).
          We can get rid of this, and references to it, when we bump Microsoft.NET.Sdk version to 2.0.0.
       -->
-    <ProjectSystemVsixVersion Condition="'$(ProjectSystemVsixVersion)' == ''">2.0.0.$(BuildNumberFiveDigitDateStamp)</ProjectSystemVsixVersion>
+    <ProjectSystemVsixVersion Condition="'$(ProjectSystemVsixVersion)' == ''">2.0.0.$(BuildNumberFiveDigitDateStamp)$(BuildNumberBuildOfTheDayPadded)</ProjectSystemVsixVersion>
 
     <DotNet_Install_Dir Condition=" '$(DotNet_Install_Dir)' == ''">$(RepositoryRootDirectory).dotnet_cli\</DotNet_Install_Dir>
     <DotNetTool>$(DotNet_Install_Dir)\dotnet</DotNetTool>

--- a/Common.props
+++ b/Common.props
@@ -23,15 +23,64 @@
     <VersionPrereleasePrefix Condition="'$(VersionPrereleasePrefix)' == ''">alpha</VersionPrereleasePrefix>
     <!-- When running on VSO (for official builds) use a real number. -->
     <BuildNumber Condition="'$(BuildNumber)' == ''">$(BUILD_BUILDNUMBER)</BuildNumber>
-    <BuildNumber Condition="'$(BuildNumber)' == ''">00000001-01</BuildNumber>
+    <!-- Split the build parts out from the BuildNumber which is given to us by MicroBuild in the format of yyyymmdd.nn
+         where BuildNumberFiveDigitDateStamp is mmmdd (such as 60615) and BuildNumberBuildOfTheDay is nn (which represents the nth build
+         started that day). So the first build of the day, 20160615.1, will produce something similar to BuildNumberFiveDigitDateStamp: 60615,
+         BuildNumberBuildOfTheDayPadded: 01;and the 12th build of the day, 20160615.12, will produce BuildNumberFiveDigitDateStamp: 60615, BuildNumberBuildOfTheDay: 12
+
+         Additionally, in order ensure the value fits in the 16-bit PE header fields, we will only take the last five digits of the BuildNumber, so
+         in the case of 20160615, we will set BuildNumberFiveDigitDateStamp to 60615. Unfortunately for releases in 2017 we can't go any higher, so
+         we will continue the month counting instead: the build after 61231 is 61301. -->
+    <BuildNumberFiveDigitDateStamp Condition="'$(BuildNumber)' != ''">$([MSBuild]::Subtract($(BuildNumber.Split('.')[0].Substring(3).Trim()), 8800))</BuildNumberFiveDigitDateStamp>
+    <BuildNumberBuildOfTheDayPadded Condition="('$(BuildNumber)' != '') AND ($(BuildNumber.Split('.').Length) == 2)">$(BuildNumber.Split('.')[1].PadLeft(2,'0'))</BuildNumberBuildOfTheDayPadded>
     <VersionSuffix Condition="'$(VersionSuffix)' == ''">$(VersionPrereleasePrefix)-$(BuildNumber)</VersionSuffix>
     <Version Condition="'$(Version)' == ''">$(VersionPrefix)-$(VersionSuffix)</Version>
+  </PropertyGroup>
+  
+  <!-- Prepare Version number used in template builds -->
+  <Choose>
+    <When Condition="'$(BuildVersion)' != ''">
+      <!-- The user specified a build version number. In that case, we'll use their version number
+        for the file version, and force the assembly version to $(VersionPrefix).0.  That way
+        day-to-day upgrades don't break assembly references to other installed apps. -->
+      <PropertyGroup>
+        <AssemblyVersion>$(VersionPrefix).0</AssemblyVersion>
+      </PropertyGroup>
+    </When>
 
-    <!-- Prepare Version number used in template builds -->
-    <BuildNumberPart1>$(BuildNumber.Split('-')[0])</BuildNumberPart1>
-    <BuildNumberPart2>$(BuildNumber.Split('-')[1].PadLeft(2,'0'))</BuildNumberPart2>
-    <VsixVersion Condition="'$(VsixVersion)' == ''">$(VersionPrefix).$(BuildNumberPart1)$(BuildNumberPart2)</VsixVersion>
+    <When Condition="('$(BuildNumber)' != '') AND ('$(BuildNumberFiveDigitDateStamp)' != '') AND ('$(BuildNumberBuildOfTheDayPadded)' != '')">
+      <!-- The user specified a build number, so we should use that. -->
+      <PropertyGroup>
+        <AssemblyVersion>$(VersionPrefix).0</AssemblyVersion>
+        <BuildVersion>$(VersionPrefix).$(BuildNumberFiveDigitDateStamp)</BuildVersion>
+        <VsixVersion>$(VersionPrefix).$(BuildNumberFiveDigitDateStamp)-$(BuildNumberBuildOfTheDayPadded)</VsixVersion>
+      </PropertyGroup>
+    </When>
 
+    <When Condition="'$(OfficialBuild)' == 'true' OR '$(RealSignBuild)' == 'true' OR '$(SignType)' == 'real'">
+      <!-- We're creating an official or real-signed build, but don't have a build number. Just use the VersionPrefix.
+        This happens if the build template does not pass BuildNumber down to MSBuild. -->
+      <PropertyGroup>
+        <AssemblyVersion>$(VersionPrefix).0</AssemblyVersion>
+        <BuildVersion>$(VersionPrefix).$(BuildNumberFiveDigitDateStamp)</BuildVersion>
+        <VsixVersion>$(VersionPrefix).$(BuildNumberFiveDigitDateStamp)-$(BuildNumberBuildOfTheDayPadded)</VsixVersion>
+      </PropertyGroup>
+    </When>
+
+    <Otherwise>
+      <!-- No build version was supplied.  We'll use a special version, higher than anything
+        installed, so that the assembly identity is different.  This will allows us to
+        have a build with an actual number installed, but then build and F5 a build with
+        this number.  -->
+      <PropertyGroup>
+        <BuildVersion>42.42.42.42</BuildVersion>
+        <AssemblyVersion>42.42.42.42</AssemblyVersion>
+        <VsixVersion>42.42.42.42</VsixVersion>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
+
+  <PropertyGroup>
     <!-- Unfortunately we have already shipped template manifests with version 2.0.0.0 (matching
          the version for the NETCore Project System.) Changing this version to match $(VsixVersion) 
          which is 1.0.0.xxx may create upgrade problems for users doing B2B or Preview 5 upgrades. 
@@ -39,7 +88,7 @@
          number. This conforms to the dependencies specified in the ManagedDesktop workload [2.0.0.0,3.0.0.0).
          We can get rid of this, and references to it, when we bump Microsoft.NET.Sdk version to 2.0.0.
       -->
-    <ProjectSystemVsixVersion Condition="'$(ProjectSystemVsixVersion)' == ''">2.0.0.$(BuildNumberPart1)$(BuildNumberPart2)</ProjectSystemVsixVersion>
+    <ProjectSystemVsixVersion Condition="'$(ProjectSystemVsixVersion)' == ''">2.0.0.$(BuildNumberFiveDigitDateStamp)</ProjectSystemVsixVersion>
 
     <DotNet_Install_Dir Condition=" '$(DotNet_Install_Dir)' == ''">$(RepositoryRootDirectory).dotnet_cli\</DotNet_Install_Dir>
     <DotNetTool>$(DotNet_Install_Dir)\dotnet</DotNetTool>

--- a/build/Targets/Templates.Imports.targets
+++ b/build/Targets/Templates.Imports.targets
@@ -63,7 +63,8 @@
   <Target Name="GetBuildVersion" Outputs="$(VsixVersion)" />
 
   <PropertyGroup>
-    <DeployExtension>false</DeployExtension>
+    <DeployExtension Condition="'$(DeployExtension)' == ''">true</DeployExtension>
+    <VSSDKTargetPlatformRegRootSuffix Condition="'$(VSSDKTargetPlatformRegRootSuffix)' == '' And '$(DeployExtension)' == 'true'">RoslynDev</VSSDKTargetPlatformRegRootSuffix>
     <NoWarn>$(NoWarn);2008</NoWarn>
   </PropertyGroup>
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageDependencies.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageDependencies.cs
@@ -172,7 +172,7 @@ namespace Microsoft.NET.Build.Tasks
             {
                 foreach (var dep in group.Dependencies)
                 {
-                    // Get package name from e.g. Microsoft.VSSDK.BuildTools >= 15.0.25604-Preview4
+                    // Get package name from e.g. Microsoft.VSSDK.BuildTools >= 15.0.25929-RC2
                     _projectFileDependencies.Add(dep.Split()[0].Trim());
                 }
             }

--- a/src/Templates/CSharpNetStandardTemplatesSetup/project.json
+++ b/src/Templates/CSharpNetStandardTemplatesSetup/project.json
@@ -3,7 +3,7 @@
     "net46": { }
   },
   "dependencies": {
-    "Microsoft.VSSDK.BuildTools": "15.0.25604-Preview4"
+    "Microsoft.VSSDK.BuildTools": "15.0.25929-RC2"
   },
   "runtimes": {
     "win": { }

--- a/src/Templates/CSharpNetStandardTemplatesSetup/source.extension.vsixmanifest
+++ b/src/Templates/CSharpNetStandardTemplatesSetup/source.extension.vsixmanifest
@@ -12,6 +12,9 @@
     <InstallationTarget Version="[15.0,]" Id="Microsoft.VisualStudio.VWDExpress" />
     <InstallationTarget Version="[15.0,]" Id="Microsoft.VisualStudio.VSWinExpress" />
   </Installation>
+  <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
+  </Prerequisites>
   <Dependencies>
     <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.6,)" />
   </Dependencies>

--- a/src/Templates/CSharpTemplatesSetup/project.json
+++ b/src/Templates/CSharpTemplatesSetup/project.json
@@ -3,7 +3,7 @@
     "net46": { }
   },
   "dependencies": {
-    "Microsoft.VSSDK.BuildTools": "15.0.25604-Preview4"
+    "Microsoft.VSSDK.BuildTools": "15.0.25929-RC2"
   },
   "runtimes": {
     "win": { }

--- a/src/Templates/CSharpTemplatesSetup/source.extension.vsixmanifest
+++ b/src/Templates/CSharpTemplatesSetup/source.extension.vsixmanifest
@@ -12,6 +12,9 @@
     <InstallationTarget Version="[15.0,]" Id="Microsoft.VisualStudio.VWDExpress" />
     <InstallationTarget Version="[15.0,]" Id="Microsoft.VisualStudio.VSWinExpress" />
   </Installation>
+  <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
+  </Prerequisites>
   <Dependencies>
     <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.6,)" />
   </Dependencies>

--- a/src/Templates/ProjectTemplates/CSharp/.NETCore/CSharpClassLibrary/project.json
+++ b/src/Templates/ProjectTemplates/CSharp/.NETCore/CSharpClassLibrary/project.json
@@ -3,7 +3,7 @@
     "net46": {}
   },
   "dependencies": {
-    "Microsoft.VSSDK.BuildTools": "15.0.25604-Preview4"
+    "Microsoft.VSSDK.BuildTools": "15.0.25929-RC2"
   },
   "runtimes": {
     "win": { }

--- a/src/Templates/ProjectTemplates/CSharp/.NETCore/CSharpConsoleApplication/project.json
+++ b/src/Templates/ProjectTemplates/CSharp/.NETCore/CSharpConsoleApplication/project.json
@@ -3,7 +3,7 @@
     "net46": {}
   },
   "dependencies": {
-    "Microsoft.VSSDK.BuildTools": "15.0.25604-Preview4"
+    "Microsoft.VSSDK.BuildTools": "15.0.25929-RC2"
   },
   "runtimes": {
     "win": { }

--- a/src/Templates/ProjectTemplates/CSharp/.NETCore/CSharpUnitTest/project.json
+++ b/src/Templates/ProjectTemplates/CSharp/.NETCore/CSharpUnitTest/project.json
@@ -3,7 +3,7 @@
     "net46": {}
   },
   "dependencies": {
-    "Microsoft.VSSDK.BuildTools": "15.0.25604-Preview4"
+    "Microsoft.VSSDK.BuildTools": "15.0.25929-RC2"
   },
   "runtimes": {
     "win": { }

--- a/src/Templates/ProjectTemplates/CSharp/.NETCore/CSharpXUnitTest/project.json
+++ b/src/Templates/ProjectTemplates/CSharp/.NETCore/CSharpXUnitTest/project.json
@@ -3,7 +3,7 @@
     "net46": {}
   },
   "dependencies": {
-    "Microsoft.VSSDK.BuildTools": "15.0.25604-Preview4"
+    "Microsoft.VSSDK.BuildTools": "15.0.25929-RC2"
   },
   "runtimes": {
     "win": { }

--- a/src/Templates/ProjectTemplates/CSharp/.NETStandard/CSharpNetStandardClassLibrary/project.json
+++ b/src/Templates/ProjectTemplates/CSharp/.NETStandard/CSharpNetStandardClassLibrary/project.json
@@ -3,7 +3,7 @@
     "net46": {}
   },
   "dependencies": {
-    "Microsoft.VSSDK.BuildTools": "15.0.25604-Preview4"
+    "Microsoft.VSSDK.BuildTools": "15.0.25929-RC2"
   },
   "runtimes": {
     "win": { }

--- a/src/Templates/ProjectTemplates/VisualBasic/.NETCore/VisualBasicClassLibrary/project.json
+++ b/src/Templates/ProjectTemplates/VisualBasic/.NETCore/VisualBasicClassLibrary/project.json
@@ -3,7 +3,7 @@
     "net46": {}
   },
   "dependencies": {
-    "Microsoft.VSSDK.BuildTools": "15.0.25604-Preview4"
+    "Microsoft.VSSDK.BuildTools": "15.0.25929-RC2"
   },
   "runtimes": {
     "win": { }

--- a/src/Templates/ProjectTemplates/VisualBasic/.NETCore/VisualBasicConsoleApplication/project.json
+++ b/src/Templates/ProjectTemplates/VisualBasic/.NETCore/VisualBasicConsoleApplication/project.json
@@ -3,7 +3,7 @@
     "net46": {}
   },
   "dependencies": {
-    "Microsoft.VSSDK.BuildTools": "15.0.25604-Preview4"
+    "Microsoft.VSSDK.BuildTools": "15.0.25929-RC2"
   },
   "runtimes": {
     "win": { }

--- a/src/Templates/ProjectTemplates/VisualBasic/.NETStandard/VisualBasicNetStandardClassLibrary/project.json
+++ b/src/Templates/ProjectTemplates/VisualBasic/.NETStandard/VisualBasicNetStandardClassLibrary/project.json
@@ -3,7 +3,7 @@
     "net46": {}
   },
   "dependencies": {
-    "Microsoft.VSSDK.BuildTools": "15.0.25604-Preview4"
+    "Microsoft.VSSDK.BuildTools": "15.0.25929-RC2"
   },
   "runtimes": {
     "win": { }

--- a/src/Templates/VisualBasicNetStandardTemplatesSetup/project.json
+++ b/src/Templates/VisualBasicNetStandardTemplatesSetup/project.json
@@ -3,7 +3,7 @@
     "net46": { }
   },
   "dependencies": {
-    "Microsoft.VSSDK.BuildTools": "15.0.25604-Preview4"
+    "Microsoft.VSSDK.BuildTools": "15.0.25929-RC2"
   },
   "runtimes": {
     "win": { }

--- a/src/Templates/VisualBasicNetStandardTemplatesSetup/source.extension.vsixmanifest
+++ b/src/Templates/VisualBasicNetStandardTemplatesSetup/source.extension.vsixmanifest
@@ -12,6 +12,9 @@
     <InstallationTarget Version="[15.0,]" Id="Microsoft.VisualStudio.VWDExpress" />
     <InstallationTarget Version="[15.0,]" Id="Microsoft.VisualStudio.VSWinExpress" />
   </Installation>
+  <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
+  </Prerequisites>
   <Dependencies>
     <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.6,)" />
   </Dependencies>

--- a/src/Templates/VisualBasicTemplatesSetup/project.json
+++ b/src/Templates/VisualBasicTemplatesSetup/project.json
@@ -3,7 +3,7 @@
     "net46": { }
   },
   "dependencies": {
-    "Microsoft.VSSDK.BuildTools": "15.0.25604-Preview4"
+    "Microsoft.VSSDK.BuildTools": "15.0.25929-RC2"
   },
   "runtimes": {
     "win": { }

--- a/src/Templates/VisualBasicTemplatesSetup/source.extension.vsixmanifest
+++ b/src/Templates/VisualBasicTemplatesSetup/source.extension.vsixmanifest
@@ -12,6 +12,9 @@
     <InstallationTarget Version="[15.0,]" Id="Microsoft.VisualStudio.VWDExpress" />
     <InstallationTarget Version="[15.0,]" Id="Microsoft.VisualStudio.VSWinExpress" />
   </Installation>
+  <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
+  </Prerequisites>
   <Dependencies>
     <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.6,)" />
   </Dependencies>


### PR DESCRIPTION
Apart from making the core change to set `DeployExtension = true`, I had to make couple of additional changes:

1. Fix the AssemblyVersion, BuildVersion and VSIXVersion computation in the target. We ended up defaulting these to 1.0.0.0000101, which prevented locally built VSIXes from installing into the Dev hive due to it being lower then existing version. Now we default the versions to 42.42.42.42 when doing non-official builds.

2. Move to RC.2 VS SDK build tools - The preview4 build tools were crashing intermittently when deploying the VSIX during build.