### PR TITLE
Separate out static MSBuild property invocation into a separate variable

### DIFF
--- a/Common.props
+++ b/Common.props
@@ -29,7 +29,8 @@
          Additionally, in order ensure the value fits in the 16-bit PE header fields, we will only take the last five digits of the BuildNumber, so
          in the case of 20160615, we will set BuildNumberFiveDigitDateStamp to 60615. Unfortunately for releases in 2017 we can't go any higher, so
          we will continue the month counting instead: the build after 61231 is 61301. -->
-    <BuildNumberFiveDigitDateStamp Condition="'$(BuildNumber)' != ''">$([MSBuild]::Subtract($(BuildNumber.Split('.')[0].Substring(3).Trim()), 8800))</BuildNumberFiveDigitDateStamp>
+    <BuildNumberPart1 Condition="'$(BuildNumber)' != ''">$(BuildNumber.Split('.')[0].Substring(3).Trim())</BuildNumberPart1>
+    <BuildNumberFiveDigitDateStamp Condition="'$(BuildNumber)' != ''">$([MSBuild]::Subtract($(BuildNumberPart1), 8800))</BuildNumberFiveDigitDateStamp>
     <BuildNumberBuildOfTheDayPadded Condition="('$(BuildNumber)' != '') AND ($(BuildNumber.Split('.').Length) == 2)">$(BuildNumber.Split('.')[1].PadLeft(2,'0'))</BuildNumberBuildOfTheDayPadded>
 
     <VersionPrefix Condition="'$(VersionPrefix)' == ''">1.0.0</VersionPrefix>

--- a/netci.groovy
+++ b/netci.groovy
@@ -45,7 +45,7 @@ osList.each { os ->
             }
         }
 
-        Utilities.setMachineAffinity(newJob, os, 'latest-or-auto-internal')
+        Utilities.setMachineAffinity(newJob, os, 'latest-or-auto-dev15-rc')
         InternalUtilities.standardJobSetup(newJob, project, isPR, "*/${branch}")
         Utilities.addXUnitDotNETResults(newJob, "bin/$config/Tests/TestResults.xml", false)
         Utilities.addGithubPRTriggerForBranch(newJob, branch, "$os $config")

--- a/src/Tasks/Microsoft.NET.Build.Tasks/DependencyContextBuilder.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/DependencyContextBuilder.cs
@@ -32,7 +32,7 @@ namespace Microsoft.NET.Build.Tasks
             _projectContext = projectContext;
 
             // This resolver is only used for building file names, so that base path is not required.
-            _versionFolderPathResolver = new VersionFolderPathResolver(path: null);
+            _versionFolderPathResolver = new VersionFolderPathResolver(rootPath: null);
         }
 
         public DependencyContextBuilder WithFrameworkReferences(IEnumerable<ReferenceInfo> frameworkReferences)


### PR DESCRIPTION
Microbuild broke with my previous change to compute build version, it gives the following error:

```
2017-01-10T01:15:24.2998766Z E:\A\_work\15\s\Common.props(32,5): error MSB4186: Invalid static method invocation syntax: "[MSBuild]::Subtract($(BuildNumber.Split('.')[0].Substring(3).Trim()), 8800)". Input string was not in a correct format. Static method invocation should be of the form: $([FullTypeName]::Method()), e.g. $([System.IO.Path]::Combine(`a`, `b`)).  [E:\A\_work\15\s\build\build.proj]
2017-01-10T01:15:24.4717498Z Failed to build
2017-01-10T01:15:24.4717498Z At E:\A\_work\15\s\build.ps1:83 char:27
2017-01-10T01:15:24.4717498Z + if($LASTEXITCODE -ne 0) { throw "Failed to build" }
```

Attempt to separate out the property function invocation into a separate variable to fix the build break.