### PR TITLE
Revert "Enable deploying templates to RoslynDev hive during build"

### DIFF
--- a/Common.props
+++ b/Common.props
@@ -19,70 +19,19 @@
     <PackagesLayoutToolsNet46Dir>$(PackagesLayoutToolsDir)net46\</PackagesLayoutToolsNet46Dir>
     <PackagesLayoutToolsNetCoreAppDir>$(PackagesLayoutToolsDir)netcoreapp1.0\</PackagesLayoutToolsNetCoreAppDir>
     
+    <VersionPrefix Condition="'$(VersionPrefix)' == ''">1.0.0</VersionPrefix>
+    <VersionPrereleasePrefix Condition="'$(VersionPrereleasePrefix)' == ''">alpha</VersionPrereleasePrefix>
     <!-- When running on VSO (for official builds) use a real number. -->
     <BuildNumber Condition="'$(BuildNumber)' == ''">$(BUILD_BUILDNUMBER)</BuildNumber>
-    <!-- Split the build parts out from the BuildNumber which is given to us by MicroBuild in the format of yyyymmdd.nn
-         where BuildNumberFiveDigitDateStamp is mmmdd (such as 60615) and BuildNumberBuildOfTheDay is nn (which represents the nth build
-         started that day). So the first build of the day, 20160615.1, will produce something similar to BuildNumberFiveDigitDateStamp: 60615,
-         BuildNumberBuildOfTheDayPadded: 01;and the 12th build of the day, 20160615.12, will produce BuildNumberFiveDigitDateStamp: 60615, BuildNumberBuildOfTheDay: 12
-
-         Additionally, in order ensure the value fits in the 16-bit PE header fields, we will only take the last five digits of the BuildNumber, so
-         in the case of 20160615, we will set BuildNumberFiveDigitDateStamp to 60615. Unfortunately for releases in 2017 we can't go any higher, so
-         we will continue the month counting instead: the build after 61231 is 61301. -->
-    <BuildNumberFiveDigitDateStamp Condition="'$(BuildNumber)' != ''">$([MSBuild]::Subtract($(BuildNumber.Split('.')[0].Substring(3).Trim()), 8800))</BuildNumberFiveDigitDateStamp>
-    <BuildNumberBuildOfTheDayPadded Condition="('$(BuildNumber)' != '') AND ($(BuildNumber.Split('.').Length) == 2)">$(BuildNumber.Split('.')[1].PadLeft(2,'0'))</BuildNumberBuildOfTheDayPadded>
-
-    <VersionPrefix Condition="'$(VersionPrefix)' == ''">1.0.0</VersionPrefix>
-    <VersionSuffix Condition="'$(VersionSuffix)' == ''">alpha</VersionSuffix>
+    <BuildNumber Condition="'$(BuildNumber)' == ''">00000001-01</BuildNumber>
+    <VersionSuffix Condition="'$(VersionSuffix)' == ''">$(VersionPrereleasePrefix)-$(BuildNumber)</VersionSuffix>
     <Version Condition="'$(Version)' == ''">$(VersionPrefix)-$(VersionSuffix)</Version>
-    <Version Condition="'$(BuildNumberFiveDigitDateStamp)' != '' AND '$(BuildNumberBuildOfTheDayPadded)' != ''">$(Version)-$(BuildNumberFiveDigitDateStamp.Trim())-$(BuildNumberBuildOfTheDayPadded.Trim())</Version>
-  </PropertyGroup>
-  
-  <!-- Prepare Version number used in template builds -->
-  <Choose>
-    <When Condition="'$(BuildVersion)' != ''">
-      <!-- The user specified a build version number. In that case, we'll use their version number
-        for the file version, and force the assembly version to $(VersionPrefix).0.  That way
-        day-to-day upgrades don't break assembly references to other installed apps. -->
-      <PropertyGroup>
-        <AssemblyVersion>$(VersionPrefix).0</AssemblyVersion>
-        <VsixVersion>$(BuildVersion)</VsixVersion>
-      </PropertyGroup>
-    </When>
 
-    <When Condition="('$(BuildNumber)' != '') AND ('$(BuildNumberFiveDigitDateStamp)' != '') AND ('$(BuildNumberBuildOfTheDayPadded)' != '')">
-      <!-- The user specified a build number, so we should use that. -->
-      <PropertyGroup>
-        <AssemblyVersion>$(VersionPrefix).0</AssemblyVersion>
-        <BuildVersion>$(VersionPrefix).$(BuildNumberFiveDigitDateStamp)</BuildVersion>
-        <VsixVersion>$(VersionPrefix).$(BuildNumberFiveDigitDateStamp)$(BuildNumberBuildOfTheDayPadded)</VsixVersion>
-      </PropertyGroup>
-    </When>
+    <!-- Prepare Version number used in template builds -->
+    <BuildNumberPart1>$(BuildNumber.Split('-')[0])</BuildNumberPart1>
+    <BuildNumberPart2>$(BuildNumber.Split('-')[1].PadLeft(2,'0'))</BuildNumberPart2>
+    <VsixVersion Condition="'$(VsixVersion)' == ''">$(VersionPrefix).$(BuildNumberPart1)$(BuildNumberPart2)</VsixVersion>
 
-    <When Condition="'$(OfficialBuild)' == 'true' OR '$(RealSignBuild)' == 'true' OR '$(SignType)' == 'real'">
-      <!-- We're creating an official or real-signed build, but don't have a build number. Just use the VersionPrefix.
-        This happens if the build template does not pass BuildNumber down to MSBuild. -->
-      <PropertyGroup>
-        <AssemblyVersion>$(VersionPrefix).0</AssemblyVersion>
-        <BuildVersion>$(VersionPrefix).$(BuildNumberFiveDigitDateStamp)</BuildVersion>
-        <VsixVersion>$(VersionPrefix).$(BuildNumberFiveDigitDateStamp)$(BuildNumberBuildOfTheDayPadded)</VsixVersion>
-      </PropertyGroup>
-    </When>
-
-    <Otherwise>
-      <!-- No build version was supplied.  We'll use a special version, higher than anything
-        installed, so that the assembly identity is different.  This will allows us to
-        have a build with an actual number installed, but then build and F5 a build with
-        this number.  -->
-      <PropertyGroup>
-        <AssemblyVersion>42.42.42.42</AssemblyVersion>
-        <BuildVersion>42.42.42.42</BuildVersion>
-        <VsixVersion>42.42.42.42</VsixVersion>
-      </PropertyGroup>
-    </Otherwise>
-  </Choose>
-
-  <PropertyGroup>
     <!-- Unfortunately we have already shipped template manifests with version 2.0.0.0 (matching
          the version for the NETCore Project System.) Changing this version to match $(VsixVersion) 
          which is 1.0.0.xxx may create upgrade problems for users doing B2B or Preview 5 upgrades. 
@@ -90,7 +39,7 @@
          number. This conforms to the dependencies specified in the ManagedDesktop workload [2.0.0.0,3.0.0.0).
          We can get rid of this, and references to it, when we bump Microsoft.NET.Sdk version to 2.0.0.
       -->
-    <ProjectSystemVsixVersion Condition="'$(ProjectSystemVsixVersion)' == ''">2.0.0.$(BuildNumberFiveDigitDateStamp)$(BuildNumberBuildOfTheDayPadded)</ProjectSystemVsixVersion>
+    <ProjectSystemVsixVersion Condition="'$(ProjectSystemVsixVersion)' == ''">2.0.0.$(BuildNumberPart1)$(BuildNumberPart2)</ProjectSystemVsixVersion>
 
     <DotNet_Install_Dir Condition=" '$(DotNet_Install_Dir)' == ''">$(RepositoryRootDirectory).dotnet_cli\</DotNet_Install_Dir>
     <DotNetTool>$(DotNet_Install_Dir)\dotnet</DotNetTool>

--- a/build/Targets/Templates.Imports.targets
+++ b/build/Targets/Templates.Imports.targets
@@ -63,8 +63,7 @@
   <Target Name="GetBuildVersion" Outputs="$(VsixVersion)" />
 
   <PropertyGroup>
-    <DeployExtension Condition="'$(DeployExtension)' == ''">true</DeployExtension>
-    <VSSDKTargetPlatformRegRootSuffix Condition="'$(VSSDKTargetPlatformRegRootSuffix)' == '' And '$(DeployExtension)' == 'true'">RoslynDev</VSSDKTargetPlatformRegRootSuffix>
+    <DeployExtension>false</DeployExtension>
     <NoWarn>$(NoWarn);2008</NoWarn>
   </PropertyGroup>
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/DependencyContextBuilder.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/DependencyContextBuilder.cs
@@ -32,7 +32,7 @@ namespace Microsoft.NET.Build.Tasks
             _projectContext = projectContext;
 
             // This resolver is only used for building file names, so that base path is not required.
-            _versionFolderPathResolver = new VersionFolderPathResolver(path: null);
+            _versionFolderPathResolver = new VersionFolderPathResolver(rootPath: null);
         }
 
         public DependencyContextBuilder WithFrameworkReferences(IEnumerable<ReferenceInfo> frameworkReferences)

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageDependencies.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageDependencies.cs
@@ -172,7 +172,7 @@ namespace Microsoft.NET.Build.Tasks
             {
                 foreach (var dep in group.Dependencies)
                 {
-                    // Get package name from e.g. Microsoft.VSSDK.BuildTools >= 15.0.25929-RC2
+                    // Get package name from e.g. Microsoft.VSSDK.BuildTools >= 15.0.25604-Preview4
                     _projectFileDependencies.Add(dep.Split()[0].Trim());
                 }
             }

--- a/src/Templates/CSharpNetStandardTemplatesSetup/project.json
+++ b/src/Templates/CSharpNetStandardTemplatesSetup/project.json
@@ -3,7 +3,7 @@
     "net46": { }
   },
   "dependencies": {
-    "Microsoft.VSSDK.BuildTools": "15.0.25929-RC2"
+    "Microsoft.VSSDK.BuildTools": "15.0.25604-Preview4"
   },
   "runtimes": {
     "win": { }

--- a/src/Templates/CSharpNetStandardTemplatesSetup/source.extension.vsixmanifest
+++ b/src/Templates/CSharpNetStandardTemplatesSetup/source.extension.vsixmanifest
@@ -12,9 +12,6 @@
     <InstallationTarget Version="[15.0,]" Id="Microsoft.VisualStudio.VWDExpress" />
     <InstallationTarget Version="[15.0,]" Id="Microsoft.VisualStudio.VSWinExpress" />
   </Installation>
-  <Prerequisites>
-    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
-  </Prerequisites>
   <Dependencies>
     <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.6,)" />
   </Dependencies>

--- a/src/Templates/CSharpTemplatesSetup/project.json
+++ b/src/Templates/CSharpTemplatesSetup/project.json
@@ -3,7 +3,7 @@
     "net46": { }
   },
   "dependencies": {
-    "Microsoft.VSSDK.BuildTools": "15.0.25929-RC2"
+    "Microsoft.VSSDK.BuildTools": "15.0.25604-Preview4"
   },
   "runtimes": {
     "win": { }

--- a/src/Templates/CSharpTemplatesSetup/source.extension.vsixmanifest
+++ b/src/Templates/CSharpTemplatesSetup/source.extension.vsixmanifest
@@ -12,9 +12,6 @@
     <InstallationTarget Version="[15.0,]" Id="Microsoft.VisualStudio.VWDExpress" />
     <InstallationTarget Version="[15.0,]" Id="Microsoft.VisualStudio.VSWinExpress" />
   </Installation>
-  <Prerequisites>
-    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
-  </Prerequisites>
   <Dependencies>
     <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.6,)" />
   </Dependencies>

--- a/src/Templates/ProjectTemplates/CSharp/.NETCore/CSharpClassLibrary/project.json
+++ b/src/Templates/ProjectTemplates/CSharp/.NETCore/CSharpClassLibrary/project.json
@@ -3,7 +3,7 @@
     "net46": {}
   },
   "dependencies": {
-    "Microsoft.VSSDK.BuildTools": "15.0.25929-RC2"
+    "Microsoft.VSSDK.BuildTools": "15.0.25604-Preview4"
   },
   "runtimes": {
     "win": { }

--- a/src/Templates/ProjectTemplates/CSharp/.NETCore/CSharpConsoleApplication/project.json
+++ b/src/Templates/ProjectTemplates/CSharp/.NETCore/CSharpConsoleApplication/project.json
@@ -3,7 +3,7 @@
     "net46": {}
   },
   "dependencies": {
-    "Microsoft.VSSDK.BuildTools": "15.0.25929-RC2"
+    "Microsoft.VSSDK.BuildTools": "15.0.25604-Preview4"
   },
   "runtimes": {
     "win": { }

--- a/src/Templates/ProjectTemplates/CSharp/.NETCore/CSharpUnitTest/project.json
+++ b/src/Templates/ProjectTemplates/CSharp/.NETCore/CSharpUnitTest/project.json
@@ -3,7 +3,7 @@
     "net46": {}
   },
   "dependencies": {
-    "Microsoft.VSSDK.BuildTools": "15.0.25929-RC2"
+    "Microsoft.VSSDK.BuildTools": "15.0.25604-Preview4"
   },
   "runtimes": {
     "win": { }

--- a/src/Templates/ProjectTemplates/CSharp/.NETCore/CSharpXUnitTest/project.json
+++ b/src/Templates/ProjectTemplates/CSharp/.NETCore/CSharpXUnitTest/project.json
@@ -3,7 +3,7 @@
     "net46": {}
   },
   "dependencies": {
-    "Microsoft.VSSDK.BuildTools": "15.0.25929-RC2"
+    "Microsoft.VSSDK.BuildTools": "15.0.25604-Preview4"
   },
   "runtimes": {
     "win": { }

--- a/src/Templates/ProjectTemplates/CSharp/.NETStandard/CSharpNetStandardClassLibrary/project.json
+++ b/src/Templates/ProjectTemplates/CSharp/.NETStandard/CSharpNetStandardClassLibrary/project.json
@@ -3,7 +3,7 @@
     "net46": {}
   },
   "dependencies": {
-    "Microsoft.VSSDK.BuildTools": "15.0.25929-RC2"
+    "Microsoft.VSSDK.BuildTools": "15.0.25604-Preview4"
   },
   "runtimes": {
     "win": { }

--- a/src/Templates/ProjectTemplates/VisualBasic/.NETCore/VisualBasicClassLibrary/project.json
+++ b/src/Templates/ProjectTemplates/VisualBasic/.NETCore/VisualBasicClassLibrary/project.json
@@ -3,7 +3,7 @@
     "net46": {}
   },
   "dependencies": {
-    "Microsoft.VSSDK.BuildTools": "15.0.25929-RC2"
+    "Microsoft.VSSDK.BuildTools": "15.0.25604-Preview4"
   },
   "runtimes": {
     "win": { }

--- a/src/Templates/ProjectTemplates/VisualBasic/.NETCore/VisualBasicConsoleApplication/project.json
+++ b/src/Templates/ProjectTemplates/VisualBasic/.NETCore/VisualBasicConsoleApplication/project.json
@@ -3,7 +3,7 @@
     "net46": {}
   },
   "dependencies": {
-    "Microsoft.VSSDK.BuildTools": "15.0.25929-RC2"
+    "Microsoft.VSSDK.BuildTools": "15.0.25604-Preview4"
   },
   "runtimes": {
     "win": { }

--- a/src/Templates/ProjectTemplates/VisualBasic/.NETStandard/VisualBasicNetStandardClassLibrary/project.json
+++ b/src/Templates/ProjectTemplates/VisualBasic/.NETStandard/VisualBasicNetStandardClassLibrary/project.json
@@ -3,7 +3,7 @@
     "net46": {}
   },
   "dependencies": {
-    "Microsoft.VSSDK.BuildTools": "15.0.25929-RC2"
+    "Microsoft.VSSDK.BuildTools": "15.0.25604-Preview4"
   },
   "runtimes": {
     "win": { }

--- a/src/Templates/VisualBasicNetStandardTemplatesSetup/project.json
+++ b/src/Templates/VisualBasicNetStandardTemplatesSetup/project.json
@@ -3,7 +3,7 @@
     "net46": { }
   },
   "dependencies": {
-    "Microsoft.VSSDK.BuildTools": "15.0.25929-RC2"
+    "Microsoft.VSSDK.BuildTools": "15.0.25604-Preview4"
   },
   "runtimes": {
     "win": { }

--- a/src/Templates/VisualBasicNetStandardTemplatesSetup/source.extension.vsixmanifest
+++ b/src/Templates/VisualBasicNetStandardTemplatesSetup/source.extension.vsixmanifest
@@ -12,9 +12,6 @@
     <InstallationTarget Version="[15.0,]" Id="Microsoft.VisualStudio.VWDExpress" />
     <InstallationTarget Version="[15.0,]" Id="Microsoft.VisualStudio.VSWinExpress" />
   </Installation>
-  <Prerequisites>
-    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
-  </Prerequisites>
   <Dependencies>
     <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.6,)" />
   </Dependencies>

--- a/src/Templates/VisualBasicTemplatesSetup/project.json
+++ b/src/Templates/VisualBasicTemplatesSetup/project.json
@@ -3,7 +3,7 @@
     "net46": { }
   },
   "dependencies": {
-    "Microsoft.VSSDK.BuildTools": "15.0.25929-RC2"
+    "Microsoft.VSSDK.BuildTools": "15.0.25604-Preview4"
   },
   "runtimes": {
     "win": { }

--- a/src/Templates/VisualBasicTemplatesSetup/source.extension.vsixmanifest
+++ b/src/Templates/VisualBasicTemplatesSetup/source.extension.vsixmanifest
@@ -12,9 +12,6 @@
     <InstallationTarget Version="[15.0,]" Id="Microsoft.VisualStudio.VWDExpress" />
     <InstallationTarget Version="[15.0,]" Id="Microsoft.VisualStudio.VSWinExpress" />
   </Installation>
-  <Prerequisites>
-    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
-  </Prerequisites>
   <Dependencies>
     <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.6,)" />
   </Dependencies>


### PR DESCRIPTION
Reverts dotnet/sdk#616

This change caused a bunch of downstream issues:

1. Microbuilds are broken with the below error:

```
2017-01-10T01:15:24.2998766Z E:\A\_work\15\s\Common.props(32,5): error MSB4186: Invalid static method invocation syntax: "[MSBuild]::Subtract($(BuildNumber.Split('.')[0].Substring(3).Trim()), 8800)". Input string was not in a correct format. Static method invocation should be of the form: $([FullTypeName]::Method()), e.g. $([System.IO.Path]::Combine(`a`, `b`)).  [E:\A\_work\15\s\build\build.proj]
2017-01-10T01:15:24.4717498Z Failed to build
2017-01-10T01:15:24.4717498Z At E:\A\_work\15\s\build.ps1:83 char:27
2017-01-10T01:15:24.4717498Z + if($LASTEXITCODE -ne 0) { throw "Failed to build" }
```

2. Deploying the template VSIXes during build requires RC.2 VS SDK tools, but Jenkins for this repo seems to be on pre-RC machines. When I attempted to move to RC machine, the build fails with:

```
21:26:48 D:\j\workspace\debug_windows---2a22f01d>.\build.cmd -Configuration Debug 
21:26:49 In order to build this repository, you either need 'msbuild' on the path or Visual Studio 2015 installed.
21:26:49 
```

At this point I am going to revert this change, and let the SDK repo experts deal with these issues before enabling building the VSIXes by default in the repo.