### PR TITLE
Set the runtime framework version based on the target framework version

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.BeforeCommon.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.BeforeCommon.targets
@@ -111,13 +111,20 @@ Copyright (c) .NET Foundation. All rights reserved.
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(NetCoreAppImplicitPackageVersion)' == ''" >
+    <NetCoreAppImplicitPackageVersion>1.1.0</NetCoreAppImplicitPackageVersion>
+  </PropertyGroup>
+
+  <!-- Set the version of the framework runtime to use (which will be written to the runtimeconfig.json file -->
+  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(RuntimeFrameworkVersion)' == ''" >
+    <!-- When the TFM is .NET Core 1.0, target version 1.0.3 of the framework runtime-->
+    <RuntimeFrameworkVersion Condition=" '$(_TargetFrameworkVersionWithoutV)' == '1.0' ">1.0.3</RuntimeFrameworkVersion>
     
-    <!-- For Microsoft.NETCore.App, default to using the version of the package that matches the target framework version -->
-    <NetCoreAppImplicitPackageVersion>$(_TargetFrameworkVersionWithoutV)</NetCoreAppImplicitPackageVersion>
-    
-    <!-- When the TFM is .NET Core 1.0, use version 1.0.3 of the Microsoft.NETCore.App package -->
-    <NetCoreAppImplicitPackageVersion Condition=" '$(_TargetFrameworkVersionWithoutV)' == '1.0' ">1.0.3</NetCoreAppImplicitPackageVersion>
-    
+    <!-- Otherwise, use the version of the framework runtime matching the target framework version-->
+    <RuntimeFrameworkVersion Condition=" '$(RuntimeFrameworkVersion)' == '' ">$(_TargetFrameworkVersionWithoutV)</RuntimeFrameworkVersion>
+
+    <!-- Normalize RuntimeFrameworkVersion to 3 digits -->
+    <RuntimeFrameworkVersion Condition=" $(RuntimeFrameworkVersion.Split('.').Length) == 1">$(RuntimeFrameworkVersion).0.0</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion Condition=" $(RuntimeFrameworkVersion.Split('.').Length) == 2">$(RuntimeFrameworkVersion).0</RuntimeFrameworkVersion>
   </PropertyGroup>
 
 

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildANetCoreApp.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildANetCoreApp.cs
@@ -1,0 +1,66 @@
+﻿using FluentAssertions;
+using Microsoft.NET.TestFramework;
+using Microsoft.NET.TestFramework.Assertions;
+using Microsoft.NET.TestFramework.Commands;
+using Microsoft.NET.TestFramework.ProjectConstruction;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Xml.Linq;
+using Xunit;
+using static Microsoft.NET.TestFramework.Commands.MSBuildTest;
+
+namespace Microsoft.NET.Build.Tests
+{
+    public class GivenThatWeWantToBuildANetCoreApp : SdkTest
+    {
+        [Theory]
+        [InlineData("netcoreapp1.0", null, "1.0.3")]
+        [InlineData("netcoreapp1.1", null, "1.1.0")]
+        [InlineData("netcoreapp1.0", "1.1.0", "1.0.3")]
+        public void It_targets_the_right_shared_framework(string targetFramework, string netCoreAppPackageVersion, string expectedRuntimeVersion)
+        {
+            var testProject = new TestProject()
+            {
+                Name = "SharedFrameworkTest",
+                TargetFrameworks = targetFramework,
+                IsSdkProject = true,
+                IsExe = true
+            };
+
+            string testIdentifier = string.Join("_", targetFramework, netCoreAppPackageVersion ?? "null");
+
+            var testAsset = _testAssetsManager.CreateTestProject(testProject, nameof(It_targets_the_right_shared_framework), testIdentifier);
+
+            if (netCoreAppPackageVersion != null)
+            {
+                testAsset = testAsset.WithProjectChanges(project =>
+                {
+                    var ns = project.Root.Name.Namespace;
+                    var propertyGroup = new XElement(ns + "PropertyGroup");
+                    project.Root.Add(propertyGroup);
+                    propertyGroup.Add(new XElement(ns + "NetCoreAppImplicitPackageVersion", netCoreAppPackageVersion));
+                });
+            }
+
+            testAsset = testAsset.Restore(testProject.Name);
+
+            var buildCommand = new BuildCommand(Stage0MSBuild, Path.Combine(testAsset.TestRoot, testProject.Name));
+
+            buildCommand
+                .Execute()
+                .Should()
+                .Pass();
+
+            var outputDirectory = buildCommand.GetOutputDirectory(targetFramework);
+            string runtimeConfigFile = Path.Combine(outputDirectory.FullName, testProject.Name + ".runtimeconfig.json");
+            string runtimeConfigContents = File.ReadAllText(runtimeConfigFile);
+            JObject runtimeConfig = JObject.Parse(runtimeConfigContents);
+
+            string runtimeFrameworkVersion = ((JValue)runtimeConfig["runtimeOptions"]["framework"]["version"]).Value<string>();
+            runtimeFrameworkVersion.Should().Be(expectedRuntimeVersion);
+        }
+    }
+}

--- a/test/Microsoft.NET.TestFramework/TestAsset.cs
+++ b/test/Microsoft.NET.TestFramework/TestAsset.cs
@@ -42,8 +42,7 @@ namespace Microsoft.NET.TestFramework
         {
             _projectFiles = new List<string>();
 
-            var files = Directory.GetFiles(base.Path, "*.*", SearchOption.AllDirectories)
-                .Where(file => !IsInBinOrObjFolder(file));
+            var files = Directory.GetFiles(base.Path, "*.*", SearchOption.AllDirectories);
 
             foreach (string file in files)
             {


### PR DESCRIPTION
...instead of defaulting to the version of the Microsoft.NETCore.App package reference

Some of the changes in #450 were based on the belief that a `PackageReference` could be set as `ReadOnly` to prevent the UI from offering updates to it.  I am not sure how I got the impression that this had been finished, as right now it is still only a feature proposal: https://github.com/NuGet/Home/issues/4044

This means that currently updates for the Microsoft.NETCore.App package reference will be offered in the package manager UI, and if an app targets netcoreapp1.0 but updates to use version 1.1.0 of the package, that the app will compile against .NET Core 1.0 but declare a dependency on .NET Core 1.1 in its runtimeconfig.json file.  This PR:

- Sets the runtime framework version based on the target framework version instead of the version of the Microsoft.NETCore.App package that is referenced
- References version 1.1.0 of the Microsoft.NETCore.App package by default for all projects.  This means that updates won't be offered for new projects, hopefully reducing confusion about the difference between the target framework version and the version of the package referenced.