### PR TITLE
Revert implicit package references

### DIFF
--- a/TestAssets/TestProjects/AllResourcesInSatellite/AllResourcesInSatellite.csproj
+++ b/TestAssets/TestProjects/AllResourcesInSatellite/AllResourcesInSatellite.csproj
@@ -22,4 +22,8 @@
     <RuntimeIdentifier>win7-x86</RuntimeIdentifier>
   </PropertyGroup>
   
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp1.0'">
+    <PackageReference Include="Microsoft.NETCore.App" Version="1.0.1" />
+  </ItemGroup>
+  
 </Project>

--- a/TestAssets/TestProjects/AppWithLibrary/TestApp/TestApp.csproj
+++ b/TestAssets/TestProjects/AppWithLibrary/TestApp/TestApp.csproj
@@ -11,4 +11,9 @@
   <ItemGroup>
     <ProjectReference Include="../TestLibrary/TestLibrary.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NETCore.App">
+      <Version>1.0.1</Version>
+    </PackageReference>
+  </ItemGroup>
 </Project>

--- a/TestAssets/TestProjects/AppWithLibrary/TestLibrary/TestLibrary.csproj
+++ b/TestAssets/TestProjects/AppWithLibrary/TestLibrary/TestLibrary.csproj
@@ -4,4 +4,9 @@
     <OutputType>Library</OutputType>
     <TargetFramework>netstandard1.5</TargetFramework>
   </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="NETStandard.Library">
+      <Version>1.6.0</Version>
+    </PackageReference>
+  </ItemGroup>
 </Project>

--- a/TestAssets/TestProjects/AppWithTransitiveProjectRefs/AuxLibrary/AuxLibrary.csproj
+++ b/TestAssets/TestProjects/AppWithTransitiveProjectRefs/AuxLibrary/AuxLibrary.csproj
@@ -5,4 +5,8 @@
     <TargetFramework>netstandard1.4</TargetFramework>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="NETStandard.Library" Version="1.6" />
+  </ItemGroup>
+
 </Project>

--- a/TestAssets/TestProjects/AppWithTransitiveProjectRefs/MainLibrary/MainLibrary.csproj
+++ b/TestAssets/TestProjects/AppWithTransitiveProjectRefs/MainLibrary/MainLibrary.csproj
@@ -4,6 +4,9 @@
     <TargetFramework>netstandard1.4</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="NETStandard.Library" Version="1.6" />
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="..\AuxLibrary\AuxLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/TestAssets/TestProjects/AppWithTransitiveProjectRefs/TestApp/TestApp.csproj
+++ b/TestAssets/TestProjects/AppWithTransitiveProjectRefs/TestApp/TestApp.csproj
@@ -4,6 +4,9 @@
     <TargetFramework>netcoreapp1.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.NETCore.App" Version="1.0.1" />
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="..\MainLibrary\MainLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/TestAssets/TestProjects/CompilationContext/TestApp/TestApp.csproj
+++ b/TestAssets/TestProjects/CompilationContext/TestApp/TestApp.csproj
@@ -8,6 +8,11 @@
   <ItemGroup>
     <ProjectReference Include="../TestLibrary/TestLibrary.csproj" />
   </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp1.0'">
+    <PackageReference Include="Microsoft.NETCore.App">
+      <Version>1.0.1</Version>
+    </PackageReference>
+  </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
   </ItemGroup>

--- a/TestAssets/TestProjects/CompilationContext/TestLibrary/TestLibrary.csproj
+++ b/TestAssets/TestProjects/CompilationContext/TestLibrary/TestLibrary.csproj
@@ -3,4 +3,9 @@
     <OutputType>Library</OutputType>
     <TargetFramework>netstandard1.3</TargetFramework>
   </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="NETStandard.Library">
+      <Version>1.6.1</Version>
+    </PackageReference>
+  </ItemGroup>
 </Project>

--- a/TestAssets/TestProjects/CrossTargeting/DesktopAndNetStandard/DesktopAndNetStandard.csproj
+++ b/TestAssets/TestProjects/CrossTargeting/DesktopAndNetStandard/DesktopAndNetStandard.csproj
@@ -18,5 +18,8 @@
   </ItemGroup>  
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.5'">
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+    <PackageReference Include="NETStandard.Library">
+      <Version>1.6.0</Version>
+    </PackageReference>
   </ItemGroup>
 </Project>

--- a/TestAssets/TestProjects/CrossTargeting/NetStandardAndNetCoreApp/NetStandardAndNetCoreApp.csproj
+++ b/TestAssets/TestProjects/CrossTargeting/NetStandardAndNetCoreApp/NetStandardAndNetCoreApp.csproj
@@ -9,8 +9,14 @@
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp1.0'">
     <PackageReference Include="Newtonsoft.Json" Version="7.0.1" />
+    <PackageReference Include="Microsoft.NETCore.App">
+      <Version>1.0.1</Version>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.5'">
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+    <PackageReference Include="NETStandard.Library">
+      <Version>1.6.0</Version>
+    </PackageReference>
   </ItemGroup>
 </Project>

--- a/TestAssets/TestProjects/DeployProjectReferencingSdkProject/HelloWorld/HelloWorld.csproj
+++ b/TestAssets/TestProjects/DeployProjectReferencingSdkProject/HelloWorld/HelloWorld.csproj
@@ -5,4 +5,10 @@
     <TargetFramework>netcoreapp1.0</TargetFramework>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NETCore.App">
+      <Version>1.0.1</Version>
+    </PackageReference>
+  </ItemGroup>
+
 </Project>

--- a/TestAssets/TestProjects/HelloWorld/HelloWorld.csproj
+++ b/TestAssets/TestProjects/HelloWorld/HelloWorld.csproj
@@ -5,4 +5,10 @@
     <TargetFramework>netcoreapp1.0</TargetFramework>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NETCore.App">
+      <Version>1.0.1</Version>
+    </PackageReference>
+  </ItemGroup>
+
 </Project>

--- a/TestAssets/TestProjects/KitchenSink/TestApp/TestApp.csproj
+++ b/TestAssets/TestProjects/KitchenSink/TestApp/TestApp.csproj
@@ -45,6 +45,7 @@
     <ProjectReference Include="../TestLibrary/TestLibrary.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.NETCore.App" Version="1.0.1" />
 	<!-- 
 	  The TestLibrary has a hard dependency on Newtonsoft.Json.
 	  The TestApp has a PrivateAssets=All dependency on Microsoft.Extensions.DependencyModel.

--- a/TestAssets/TestProjects/KitchenSink/TestLibrary/TestLibrary.csproj
+++ b/TestAssets/TestProjects/KitchenSink/TestLibrary/TestLibrary.csproj
@@ -11,5 +11,8 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+    <PackageReference Include="NETStandard.Library">
+      <Version>1.6.1</Version>
+    </PackageReference>
   </ItemGroup>
 </Project>

--- a/TestAssets/TestProjects/SimpleDependencies/SimpleDependencies.csproj
+++ b/TestAssets/TestProjects/SimpleDependencies/SimpleDependencies.csproj
@@ -6,6 +6,9 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.NETCore.App">
+      <Version>1.0.1</Version>
+    </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
       <Version>9.0.1</Version>
     </PackageReference>

--- a/TestAssets/TestProjects/x64SolutionBuild/x64SolutionBuild.csproj
+++ b/TestAssets/TestProjects/x64SolutionBuild/x64SolutionBuild.csproj
@@ -8,6 +8,12 @@
     <TargetFramework>netcoreapp1.0</TargetFramework>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NETCore.App">
+      <Version>1.0.1</Version>
+    </PackageReference>	
+  </ItemGroup>
+
   <Target Name="CheckPlatform" BeforeTargets="Build">
     <Error Condition="'$(Platform)' != 'x64'" Text="This test project expects to be built via solution and have Platform=x64" />
   </Target>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.BeforeCommon.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.BeforeCommon.targets
@@ -103,24 +103,6 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   </ItemGroup>
 
-  <!-- Set the default versions of the NETStandard.Library or Microsoft.NETCore.App packages to reference.
-       The implicit package references themselves are defined in Microsoft.NET.Sdk.props, so that they can be overridden
-       in the project file. -->
-  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard' And '$(NetStandardImplicitPackageVersion)' == ''">
-    <NetStandardImplicitPackageVersion>1.6.1</NetStandardImplicitPackageVersion>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(NetCoreAppImplicitPackageVersion)' == ''" >
-    
-    <!-- For Microsoft.NETCore.App, default to using the version of the package that matches the target framework version -->
-    <NetCoreAppImplicitPackageVersion>$(_TargetFrameworkVersionWithoutV)</NetCoreAppImplicitPackageVersion>
-    
-    <!-- When the TFM is .NET Core 1.0, use version 1.0.3 of the Microsoft.NETCore.App package -->
-    <NetCoreAppImplicitPackageVersion Condition=" '$(_TargetFrameworkVersionWithoutV)' == '1.0' ">1.0.3</NetCoreAppImplicitPackageVersion>
-    
-  </PropertyGroup>
-
-
   <!-- Add conditional compilation symbols for the target framework (for example NET461, NETSTANDARD2_0, NETCOREAPP1_0) -->
   <PropertyGroup Condition=" '$(DisableImplicitFrameworkDefines)' != 'true' and '$(TargetFrameworkIdentifier)' != '.NETPortable'">
     <_FrameworkIdentifierForImplicitDefine>$(TargetFrameworkIdentifier.Replace('.', '').ToUpperInvariant())</_FrameworkIdentifierForImplicitDefine>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.props
@@ -86,19 +86,6 @@ Copyright (c) .NET Foundation. All rights reserved.
   <!-- Default glob settings -->
   <Import Project="Microsoft.NET.Sdk.DefaultItems.props" />
   
-  <!-- Automatically reference NETStandard.Library or Microsoft.NETCore.App package if targeting the corresponding target framework.
-      We can refer here in the .props file to properties set in the .targets files because items and their conditions are
-      evaluated in the second pass of evaluation, after all properties have been evaluated. -->
-  <ItemGroup Condition=" '$(DisableImplicitFrameworkReferences)' != 'true' and '$(TargetFrameworkIdentifier)' == '.NETStandard'">
-    <PackageReference Include="NETStandard.Library" Version="$(NetStandardImplicitPackageVersion)"/>
-  </ItemGroup>
-
-  <!-- The reference to the Microsoft.NETCore.App currently needs to match the target framework version.  So mark it as
-       ReadOnly so it won't show updates to the package in the package manager UI. -->
-  <ItemGroup Condition=" '$(DisableImplicitFrameworkReferences)' != 'true' and '$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
-    <PackageReference Include="Microsoft.NETCore.App" Version="$(NetCoreAppImplicitPackageVersion)" ReadOnly="true" />
-  </ItemGroup>
-
   <!-- Temporary workarounds -->
   <PropertyGroup>
     <!-- Workaround: https://github.com/dotnet/roslyn/issues/12167 -->

--- a/src/Templates/ProjectTemplates/CSharp/.NETCore/CSharpClassLibrary/ProjectTemplate.csproj
+++ b/src/Templates/ProjectTemplates/CSharp/.NETCore/CSharpClassLibrary/ProjectTemplate.csproj
@@ -4,4 +4,8 @@
     <TargetFramework>netcoreapp1.0</TargetFramework>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NETCore.App" Version="1.0.1" />
+  </ItemGroup>
+
 </Project>

--- a/src/Templates/ProjectTemplates/CSharp/.NETCore/CSharpConsoleApplication/ProjectTemplate.csproj
+++ b/src/Templates/ProjectTemplates/CSharp/.NETCore/CSharpConsoleApplication/ProjectTemplate.csproj
@@ -5,4 +5,8 @@
     <TargetFramework>netcoreapp1.0</TargetFramework>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NETCore.App" Version="1.0.1" />
+  </ItemGroup>
+
 </Project>

--- a/src/Templates/ProjectTemplates/CSharp/.NETCore/CSharpUnitTest/ProjectTemplate.csproj
+++ b/src/Templates/ProjectTemplates/CSharp/.NETCore/CSharpUnitTest/ProjectTemplate.csproj
@@ -6,6 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0-preview-20170106-08" />
+    <PackageReference Include="Microsoft.NETCore.App" Version="1.0.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.1.8-rc" />
     <PackageReference Include="MSTest.TestFramework" Version="1.0.8-rc" />
   </ItemGroup>

--- a/src/Templates/ProjectTemplates/CSharp/.NETCore/CSharpXUnitTest/ProjectTemplate.csproj
+++ b/src/Templates/ProjectTemplates/CSharp/.NETCore/CSharpXUnitTest/ProjectTemplate.csproj
@@ -8,6 +8,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0-preview-20170106-08" />
     <PackageReference Include="xunit" Version="2.2.0-beta5-build3474" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0-beta5-build1225" />
+    <PackageReference Include="Microsoft.NETCore.App" Version="1.0.1" />
   </ItemGroup>
 
 </Project>

--- a/src/Templates/ProjectTemplates/CSharp/.NETStandard/CSharpNetStandardClassLibrary/ProjectTemplate.csproj
+++ b/src/Templates/ProjectTemplates/CSharp/.NETStandard/CSharpNetStandardClassLibrary/ProjectTemplate.csproj
@@ -4,4 +4,8 @@
     <TargetFramework>netstandard1.4</TargetFramework>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="NETStandard.Library" Version="1.6" />
+  </ItemGroup>
+
 </Project>

--- a/src/Templates/ProjectTemplates/VisualBasic/.NETCore/VisualBasicClassLibrary/ProjectTemplate.vbproj
+++ b/src/Templates/ProjectTemplates/VisualBasic/.NETCore/VisualBasicClassLibrary/ProjectTemplate.vbproj
@@ -9,4 +9,8 @@
     <EmbeddedResource Include="**\*.resx" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NETCore.App" Version="1.0.1" />
+  </ItemGroup>
+
 </Project>

--- a/src/Templates/ProjectTemplates/VisualBasic/.NETCore/VisualBasicConsoleApplication/ProjectTemplate.vbproj
+++ b/src/Templates/ProjectTemplates/VisualBasic/.NETCore/VisualBasicConsoleApplication/ProjectTemplate.vbproj
@@ -10,4 +10,8 @@
     <EmbeddedResource Include="**\*.resx" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NETCore.App" Version="1.0.1" />
+  </ItemGroup>
+
 </Project>

--- a/src/Templates/ProjectTemplates/VisualBasic/.NETStandard/VisualBasicNetStandardClassLibrary/ProjectTemplate.vbproj
+++ b/src/Templates/ProjectTemplates/VisualBasic/.NETStandard/VisualBasicNetStandardClassLibrary/ProjectTemplate.vbproj
@@ -9,4 +9,8 @@
     <EmbeddedResource Include="**\*.resx" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="NETStandard.Library" Version="1.6" />
+  </ItemGroup>
+
 </Project>

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildALibrary.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildALibrary.cs
@@ -447,6 +447,7 @@ namespace Microsoft.NET.Build.Tests
         [InlineData(".NETStandard,Version=v1.0", new[] { "NETSTANDARD1_0" }, false)]
         [InlineData("netstandard1.3", new[] { "NETSTANDARD1_3" }, false)]
         [InlineData("netstandard1.6", new[] { "NETSTANDARD1_6" }, false)]
+        [InlineData("netstandard20", new[] { "NETSTANDARD2_0" }, false)]
         [InlineData("net45", new[] { "NET45" }, true)]
         [InlineData("net461", new[] { "NET461" }, true)]
         [InlineData("netcoreapp1.0", new[] { "NETCOREAPP1_0" }, false)]

--- a/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAProjectWithAllFeatures.cs
+++ b/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAProjectWithAllFeatures.cs
@@ -33,6 +33,16 @@ namespace Microsoft.NET.Publish.Tests
 
                         var targetFrameworkElement = project.Root.Elements(ns + "PropertyGroup").Elements(ns + "TargetFramework").Single();
                         targetFrameworkElement.SetValue(targetFramework);
+
+                        if (targetFramework == "netcoreapp1.1")
+                        {
+                            var netcoreAppReference = project.Root.Elements(ns + "ItemGroup").Elements(ns + "PackageReference")
+                                .Where(element => element.Attribute("Include").Value == "Microsoft.NETCore.App")
+                                .Single();
+
+                            netcoreAppReference.Attribute("Version").SetValue("1.1.0");
+                        }
+                        
                     }
                 });
 

--- a/test/Microsoft.NET.TestFramework/ProjectConstruction/TestProject.cs
+++ b/test/Microsoft.NET.TestFramework/ProjectConstruction/TestProject.cs
@@ -129,6 +129,52 @@ namespace Microsoft.NET.TestFramework.ProjectConstruction
                     propertyGroup.Add(new XElement(ns + "TargetFramework", this.TargetFrameworks));
                 }
 
+                //  If there are any targets that aren't .NET Framework, add appropriate package reference
+                if (targetFrameworks.Any(identifier => !GetShortTargetFrameworkIdentifier(identifier).Equals("net", StringComparison.OrdinalIgnoreCase)))
+                {
+                    XElement packageReference;
+                    if (this.IsExe)
+                    {
+                        packageReference = new XElement(ns + "PackageReference",
+                                new XAttribute("Include", "Microsoft.NETCore.App"),
+                                new XAttribute("Version", "1.0.1")
+                            );
+                    }
+                    else
+                    {
+                        packageReference = new XElement(ns + "PackageReference",
+                                new XAttribute("Include", "NETStandard.Library"),
+                                new XAttribute("Version", "1.6.0")
+                            );
+                    }
+
+                    if (targetFrameworks.Any(identifier => GetShortTargetFrameworkIdentifier(identifier).Equals("net", StringComparison.OrdinalIgnoreCase)))
+                    {
+                        string condition = null;
+
+                        foreach (var target in targetFrameworks)
+                        {
+                            if (!GetShortTargetFrameworkIdentifier(target).Equals("net", StringComparison.OrdinalIgnoreCase))
+                            {
+                                if (condition == null)
+                                {
+                                    condition = "";
+                                }
+                                else
+                                {
+                                    condition += " Or ";
+                                }
+
+                                condition += $"'$(TargetFramework)' == '{target}'";
+                            }
+                        }
+
+                        packageReference.SetAttributeValue("Condition", condition);
+                    }
+
+                    packageReferenceItemGroup.Add(packageReference);
+                }
+
                 if (this.IsExe && targetFrameworks.Any(identifier => GetShortTargetFrameworkIdentifier(identifier).Equals("net", StringComparison.OrdinalIgnoreCase)))
                 {
                     propertyGroup.Add(new XElement(ns + "RuntimeIdentifier", "win7-x86"));


### PR DESCRIPTION
Back out most of the changes from #450

In order to move forward with this, we need to make sure we understand all the places where we will need to react to this change.  What I can think of is:

- ASP.NET templates
- Templates in .NET CLI
- Dotnet Migrate command

Other repos that build using the SDK will also need to update their projects to add the references back (I think this doesn't apply to the .NET CLI as they disabled the implicit package references).

Is there anything I'm missing?

Fixes #596