### PR TITLE
Finish localization of SDK

### DIFF
--- a/Common.props
+++ b/Common.props
@@ -14,7 +14,7 @@
     <OutputPath>$([System.IO.Path]::GetFullPath('$(RepositoryRootDirectory)bin\$(Configuration)'))\</OutputPath>
     <OutDir>$(OutputPath)</OutDir>
     <RootOutDir>$(OutDir)</RootOutDir>
-    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)' == ''">$([System.IO.Path]::GetFullPath('$(RepositoryRootDirectory)bin\obj\$(MSBuildProjectName)'))\</BaseIntermediateOutputPath>
+    <BaseIntermediateOutputPath>$([System.IO.Path]::GetFullPath('$(RepositoryRootDirectory)bin\obj\$(MSBuildProjectName)'))\</BaseIntermediateOutputPath>
     <RawOutDir>$(OutDir)Raw\</RawOutDir>
     <PackagesLayoutDir>$(OutDir)PackagesLayout\</PackagesLayoutDir>
     <PackagesLayoutToolsDir>$(PackagesLayoutDir)tools\</PackagesLayoutToolsDir>

--- a/Common.props
+++ b/Common.props
@@ -13,7 +13,9 @@
 
     <OutputPath>$([System.IO.Path]::GetFullPath('$(RepositoryRootDirectory)bin\$(Configuration)'))\</OutputPath>
     <OutDir>$(OutputPath)</OutDir>
+    <RootOutDir>$(OutDir)</RootOutDir>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)' == ''">$([System.IO.Path]::GetFullPath('$(RepositoryRootDirectory)bin\obj\$(MSBuildProjectName)'))\</BaseIntermediateOutputPath>
+    <RawOutDir>$(OutDir)Raw\</RawOutDir>
     <PackagesLayoutDir>$(OutDir)PackagesLayout\</PackagesLayoutDir>
     <PackagesLayoutToolsDir>$(PackagesLayoutDir)tools\</PackagesLayoutToolsDir>
     <PackagesLayoutToolsNet46Dir>$(PackagesLayoutToolsDir)net46\</PackagesLayoutToolsNet46Dir>

--- a/build.ps1
+++ b/build.ps1
@@ -72,7 +72,7 @@ if ($SkipTests) {
     $buildTarget = 'BuildWithoutTesting'
 }
 
-$commonBuildArgs = echo $RepoRoot\build\build.proj /t:$buildTarget /m /nologo /p:Configuration=$Configuration /p:Platform=$Platform /p:SignType=$signType /verbosity:$Verbosity
+$commonBuildArgs = echo $RepoRoot\build\build.proj /t:$buildTarget /m:1 /nologo /p:Configuration=$Configuration /p:Platform=$Platform /p:SignType=$signType /verbosity:$Verbosity
 
 # NET Core Build 
 $msbuildSummaryLog = Join-Path -path $logPath -childPath "sdk.log"

--- a/build.sh
+++ b/build.sh
@@ -77,4 +77,4 @@ export PATH="$DOTNET_INSTALL_DIR:$PATH"
 # Disable first run since we want to control all package sources
 export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
 
-dotnet build $REPOROOT/build/build.proj /m /nologo /p:Configuration=$CONFIGURATION /p:Platform="$PLATFORM" "${args[@]}"
+dotnet build $REPOROOT/build/build.proj /m:1 /nologo /p:Configuration=$CONFIGURATION /p:Platform="$PLATFORM" "${args[@]}"

--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -3,9 +3,6 @@
   <!-- This file is imported by all projects at the beginning of the project files -->
 
   <PropertyGroup>
-    <!-- SdkStage0Version is the version of the Microsoft.NET.Sdk we use to build ourselves -->
-    <SdkStage0Version>1.0.0-alpha-20161012-3</SdkStage0Version>
-    
     <MsBuildPackagesVersion>0.1.0-preview-00028-160627</MsBuildPackagesVersion>
     <CoreSetupVersion>1.0.1-beta-000933</CoreSetupVersion>
     <NuGetVersion>4.0.0-rc3</NuGetVersion>

--- a/build/Nuget/Microsoft.NET.Nuget.proj
+++ b/build/Nuget/Microsoft.NET.Nuget.proj
@@ -4,6 +4,7 @@
 
   <PropertyGroup>
     <NuGetOutDir>$(OutDir)Packages\</NuGetOutDir>
+    <OutDir>$(OutDir)Raw\</OutDir>
   </PropertyGroup>
 
   <ItemGroup>
@@ -45,7 +46,7 @@
       Command="$(NuGetDownloadCommand)"
       />
 
-    <Exec Command="$(NuGetTool) Pack &quot;$(MSBuildProjectDirectory)\%(NuSpec.Identity)&quot; -verbosity quiet -basepath &quot;$(OutDir.TrimEnd('\'))&quot; -outputdirectory &quot;$(NuGetOutDir.TrimEnd('\'))&quot; %(NuSpec.NuGetArguments)" 
+    <Exec Command="$(NuGetTool) Pack &quot;$(MSBuildProjectDirectory)\%(NuSpec.Identity)&quot; -verbosity quiet -basepath &quot;$(RootOutDir.TrimEnd('\'))&quot; -outputdirectory &quot;$(NuGetOutDir.TrimEnd('\'))&quot; %(NuSpec.NuGetArguments)" 
           Condition="'$(OS)' == 'Windows_NT'"/>
   </Target>
 

--- a/build/Nuget/Microsoft.NET.Sdk.Nuget.targets
+++ b/build/Nuget/Microsoft.NET.Sdk.Nuget.targets
@@ -105,8 +105,19 @@
         <RelativePath>Sdk\%(RecursiveDir)</RelativePath>
       </CopyLocalSdkFile>
 
+      <CopyLocalSatelliteAssembly Include="$(OutDir)\**\Microsoft.NET.Build.Tasks.resources.dll">
+        <RelativePath>tools\net46\</RelativePath>
+      </CopyLocalSatelliteAssembly>
+      <CopyLocalSatelliteAssembly  Include="$(OutDir)\**\Microsoft.NET.Build.Tasks.resources.dll">
+        <RelativePath>tools\netcoreapp1.0\</RelativePath>
+      </CopyLocalSatelliteAssembly>
+      <CopyLocalSatelliteAssembly>
+        <RelativePath>%(RelativePath)%(RecursiveDir)</RelativePath>
+      </CopyLocalSatelliteAssembly>
+
       <CopyLocalBuildFile Include="@(CopyLocalBuildCrossTargetingFile)" />
       <CopyLocalBuildFile Include="@(CopyLocalSdkFile)" />
+      <CopyLocalBuildFile Include="@(CopyLocalSatelliteAssembly)" />
     </ItemGroup>
 
     <Copy SourceFiles="%(Net46CopyLocalAssembly.FullFilePath)"

--- a/build/Signing/SignToolConfig.json
+++ b/build/Signing/SignToolConfig.json
@@ -4,7 +4,20 @@
             "certificate": "Microsoft402",
             "strongName": "MsSharedLib72",
             "values": [
-                "Microsoft.NET.Build.Tasks.dll"
+                "Raw/Microsoft.NET.Build.Tasks.dll",
+                "Raw/cs/Microsoft.NET.Build.Tasks.resources.dll",
+                "Raw/de/Microsoft.NET.Build.Tasks.resources.dll",
+                "Raw/es/Microsoft.NET.Build.Tasks.resources.dll",
+                "Raw/fr/Microsoft.NET.Build.Tasks.resources.dll",
+                "Raw/it/Microsoft.NET.Build.Tasks.resources.dll",
+                "Raw/ja/Microsoft.NET.Build.Tasks.resources.dll",
+                "Raw/ko/Microsoft.NET.Build.Tasks.resources.dll",
+                "Raw/pl/Microsoft.NET.Build.Tasks.resources.dll",
+                "Raw/pt-BR/Microsoft.NET.Build.Tasks.resources.dll",
+                "Raw/ru/Microsoft.NET.Build.Tasks.resources.dll",
+                "Raw/tr/Microsoft.NET.Build.Tasks.resources.dll",
+                "Raw/zh-Hans/Microsoft.NET.Build.Tasks.resources.dll",
+                "Raw/zh-Hant/Microsoft.NET.Build.Tasks.resources.dll"
             ]
         }
     ]

--- a/build/Targets/Signing.Imports.targets
+++ b/build/Targets/Signing.Imports.targets
@@ -76,5 +76,21 @@
       <DelaySign>true</DelaySign>
     </PropertyGroup>
   </Target>
+  
+   <!--
+    Workaround https://github.com/Microsoft/msbuild/issues/1490 (lack of support for public-signing satellites) by 
+    delay-signing satellite assemblies when main assembly is public-signed.
+   -->
+  <Target Name="PrepareToDelaySignSatelliteAssemblies" BeforeTargets="GenerateSatelliteAssemblies">
+    <PropertyGroup>
+      <_DelaySignMainAssembly>$(DelaySign)</_DelaySignMainAssembly>
+      <DelaySign Condition="'$(PublicSign)' == 'true'">true</DelaySign>
+    </PropertyGroup>
+  </Target>
+  <Target Name="CleanupAfterDelaySigningSatelliteAssemblies" AfterTargets="GenerateSatelliteAssemblies">
+    <PropertyGroup>
+      <DelaySign>$(_DelaySignMainAssembly)</DelaySign>
+    </PropertyGroup>
+  </Target>
 
 </Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/Microsoft.NET.Build.Tasks.UnitTests.csproj
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/Microsoft.NET.Build.Tasks.UnitTests.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'Common.props'))\Common.props" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -15,6 +15,7 @@
     <OutDir>$(OutDir)Tests\</OutDir>
     <GenerateDependencyFile>false</GenerateDependencyFile>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <EnableDefaultItems>false</EnableDefaultItems>
     <NonShipping>true</NonShipping>
     <StartAction>Program</StartAction>
     <StartProgram>$(DotNetTool).exe</StartProgram>
@@ -23,10 +24,6 @@
     <DebugEngines>{2E36F1D4-B23C-435D-AB41-18E608940038}</DebugEngines>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>$(SdkStage0Version)</Version>
-      <PrivateAssets>All</PrivateAssets>
-    </PackageReference>
     <PackageReference Include="NuGet.ProjectModel">
       <Version>$(NuGetVersion)</Version>
     </PackageReference>
@@ -101,8 +98,7 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="..\..\..\build\Targets\Signing.Imports.targets" />
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Target Name="AfterBuild">
+  <Target Name="CustomAfterBuild" AfterTargets="Build">
     <ItemGroup>
       <CopyLocalAssembly Include="Microsoft.Build.Framework">
         <Version>$(MsBuildPackagesVersion)</Version>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Microsoft.NET.Build.Tasks.csproj
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Microsoft.NET.Build.Tasks.csproj
@@ -153,6 +153,9 @@
       <LastGenOutput>Strings.Designer.cs</LastGenOutput>
       <CustomToolNamespace>Microsoft.NET.Build.Tasks</CustomToolNamespace>
     </EmbeddedResource>
+    <EmbeddedResource Include="Resources\Strings.*.resx">
+      <DependentUpon>Strings.resx</DependentUpon>
+    </EmbeddedResource>
   </ItemGroup>
   <Import Project="..\..\..\build\Targets\Signing.Imports.targets" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Microsoft.NET.Build.Tasks.csproj
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Microsoft.NET.Build.Tasks.csproj
@@ -1,7 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'Common.props'))\Common.props" />
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
     <ProjectGuid>{DF7D2697-B3B4-45C2-8297-27245F528A99}</ProjectGuid>
@@ -14,11 +13,9 @@
     <TargetFramework>netstandard1.3</TargetFramework>
     <GenerateDependencyFile>false</GenerateDependencyFile>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>$(SdkStage0Version)</Version>
-    </PackageReference>
     <PackageReference Include="NuGet.ProjectModel">
       <Version>$(NuGetVersion)</Version>
     </PackageReference>
@@ -159,5 +156,4 @@
     </EmbeddedResource>
   </ItemGroup>
   <Import Project="..\..\..\build\Targets\Signing.Imports.targets" />
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Microsoft.NET.Build.Tasks.csproj
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Microsoft.NET.Build.Tasks.csproj
@@ -6,6 +6,7 @@
     <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
     <ProjectGuid>{DF7D2697-B3B4-45C2-8297-27245F528A99}</ProjectGuid>
     <OutputType>Library</OutputType>
+    <OutDir>$(RawOutDir)</OutDir>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.NET.Build.Tasks</RootNamespace>
     <AssemblyName>Microsoft.NET.Build.Tasks</AssemblyName>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.cs.resx
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.cs.resx
@@ -1,0 +1,228 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="AtLeastOneTargetFrameworkMustBeSpecified" xml:space="preserve">
+    <value>Je potřeba zadat alespoň jednu možnou cílovou platformu</value>
+  </data>
+  <data name="NoCompatibleTargetFramework" xml:space="preserve">
+    <value>Cílová platforma projektu {0} není kompatibilní s {1}.</value>
+  </data>
+  <data name="InvalidFrameworkName" xml:space="preserve">
+    <value>Neplatný název platformy: {0}</value>
+  </data>
+  <data name="AssetsFileNotFound" xml:space="preserve">
+    <value>Soubor prostředků {0} se nenašel. Pokud chcete tento soubor vygenerovat, spusťte obnovení balíčku NuGet.</value>
+  </data>
+  <data name="AssetsFileMissingTarget" xml:space="preserve">
+    <value>Soubor prostředků {0} nemá cíl pro {1}. Ověřte, že jste projekt obnovili pro hodnoty TargetFramework={2} a RuntimeIdentifier={3}.</value>
+  </data>
+  <data name="AssetsFilePathNotRooted" xml:space="preserve">
+    <value>Cesta k souboru prostředků {0} není uvedena od kořene. Podporované jsou jen celé cesty.</value>
+  </data>
+  <data name="CannotFindProjectInfo" xml:space="preserve">
+    <value>Nelze najít informace o projektu pro {0}. Může to znamenat chybějící odkaz na projekt.</value>
+  </data>
+  <data name="ContentFileDoesNotContainExpectedParentPackageInformation" xml:space="preserve">
+    <value>V souboru obsahu {0} nejsou očekávané informace o nadřízeném balíčku.</value>
+  </data>
+  <data name="MissingItemMetadata" xml:space="preserve">
+    <value>Chybí metadata {0} o {1} položky {2}.</value>
+  </data>
+  <data name="UnrecognizedPreprocessorToken" xml:space="preserve">
+    <value>Nerozpoznaný token preprocesoru {0} v {1}.</value>
+  </data>
+  <data name="ContentPreproccessorParameterRequired" xml:space="preserve">
+    <value>Úloha {0} musí mít hodnotu parametru {1}, aby mohla použít předem zpracovaný obsah.</value>
+  </data>
+  <data name="ProjectAssetsConsumedWithoutMSBuildProjectPath" xml:space="preserve">
+    <value>Prostředky se použijí z projektu {0}, ale v {1} se nenašla odpovídající cesta k projektu MSBuildu.</value>
+  </data>
+  <data name="UnexpectedFileType" xml:space="preserve">
+    <value>Nečekaný typ souboru {0}. Typ je {1} i {2}.</value>
+  </data>
+  <data name="CannotInferTargetFrameworkIdentiferAndVersion" xml:space="preserve">
+    <value>Z údaje TargetFramework={0} nejde odvodit hodnota TargetFrameworkIdentifier ani hodnota TargetFrameworkVersion. Musí být výslovně zadané.</value>
+  </data>
+  <data name="ContentItemDoesNotProvideOutputPath" xml:space="preserve">
+    <value>Položka obsahu pro {0} nastaví {1}, ale neposkytuje {2} ani {3}.</value>
+  </data>
+  <data name="DuplicatePreprocessorToken" xml:space="preserve">
+    <value>Token preprocesoru {0} získal víc hodnot než jednu. Volba hodnoty {1}.</value>
+  </data>
+  <data name="ErrorsOccurredWhenEmittingSatelliteAssembly" xml:space="preserve">
+    <value>Při generování satelitního sestavení {0} došlo k chybám.</value>
+  </data>
+  <data name="UnableToFindResolvedPath" xml:space="preserve">
+    <value>Nepodařilo se najít vyhodnocenou cestu pro {0}.</value>
+  </data>
+  <data name="UnexpectedDependencyWithNoVersionNumber" xml:space="preserve">
+    <value>Nečekaná závislost {0} bez čísla verze.</value>
+  </data>
+  <data name="RuntimeIdentifierMustBeSetForNETFramework" xml:space="preserve">
+    <value>Hodnota RuntimeIdentifier musí být nastavena pro spustitelné soubory .NET Frameworku. Můžete použít hodnotu RuntimeIdentifier=win7-x86 nebo RuntimeIdentifier=win7-x64.</value>
+  </data>
+  <data name="AssetPreprocessorMustBeConfigured" xml:space="preserve">
+    <value>Před zpracováním prostředků je potřeba nakonfigurovat preprocesor prostředků.</value>
+  </data>
+  <data name="InvalidNuGetVersionString" xml:space="preserve">
+    <value>Neplatný řetězec verze NuGet: {0}</value>
+  </data>
+  <data name="DOTNET1011" xml:space="preserve">
+    <value>Nenainstalovaná platforma: {0} v {1}</value>
+  </data>
+  <data name="DOTNET1012" xml:space="preserve">
+    <value>Není zadaný adresář referenčních sestavení. K nastavení umístění použijte proměnnou prostředí DOTNET_REFERENCE_ASSEMBLIES_PATH.</value>
+  </data>
+  <data name="DOTNET1013" xml:space="preserve">
+    <value>Následující závislosti jsou označené typem „platform“, ale tento typ může mít jenom jedna závislost: {0}</value>
+  </data>
+  <data name="DOTNET1014" xml:space="preserve">
+    <value>Soubor zámku se nedá přečíst.</value>
+  </data>
+  <data name="DOTNET1017" xml:space="preserve">
+    <value>Soubor projektu neexistuje {0}.</value>
+  </data>
+  <data name="NU1001" xml:space="preserve">
+    <value>Závislost {0} se nepodařilo vyřešit.</value>
+  </data>
+  <data name="NU1002" xml:space="preserve">
+    <value>Závislost {0} v projektu {1} nepodporuje platformu {2}.</value>
+  </data>
+  <data name="NU1006" xml:space="preserve">
+    <value>{0}. Ke generování nového souboru prostředků prosím použijte příkaz „dotnet restore“.</value>
+  </data>
+  <data name="NU1007" xml:space="preserve">
+    <value>Zadaná závislost byla {0}, ale skončila s {1}.</value>
+  </data>
+  <data name="NU1008" xml:space="preserve">
+    <value>{0} není podporovaná platforma.</value>
+  </data>
+  <data name="NU1009" xml:space="preserve">
+    <value>Očekávaný soubor prostředků neexistuje. Ke generování nového souboru prostředků prosím použijte příkaz „dotnet restore“.</value>
+  </data>
+  <data name="NU1010" xml:space="preserve">
+    <value>Typ závislosti se změnil.</value>
+  </data>
+  <data name="NU1011" xml:space="preserve">
+    <value>Cíl závislosti {0} není podporovaný.</value>
+  </data>
+  <data name="NU1012" xml:space="preserve">
+    <value>Konflikt závislostí. {0} očekával {1}, ale přijal {2}.</value>
+  </data>
+</root>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.de.resx
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.de.resx
@@ -1,0 +1,228 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="AtLeastOneTargetFrameworkMustBeSpecified" xml:space="preserve">
+    <value>Geben Sie mindestens ein mögliches Zielframework an.</value>
+  </data>
+  <data name="NoCompatibleTargetFramework" xml:space="preserve">
+    <value>Für das Projekt "{0}" ist kein mit "{1}" kompatibles Framework vorhanden.</value>
+  </data>
+  <data name="InvalidFrameworkName" xml:space="preserve">
+    <value>Ungültiger Frameworkname: {0}.</value>
+  </data>
+  <data name="AssetsFileNotFound" xml:space="preserve">
+    <value>Die Ressourcendatei "{0}" wurde nicht gefunden. Führen Sie eine NuGet-Paketwiederherstellung aus, um diese Datei zu generieren.</value>
+  </data>
+  <data name="AssetsFileMissingTarget" xml:space="preserve">
+    <value>Die Ressourcendatei "{0}" hat kein Ziel für "{1}". Vergewissern Sie sich, dass Sie dieses Projekt für das Zielframework "{2}" und die Laufzeit-ID "{3}" wiederhergestellt haben.</value>
+  </data>
+  <data name="AssetsFilePathNotRooted" xml:space="preserve">
+    <value>Der Ressourcendateipfad "{0}" hat keinen Stamm. Nur vollständige Pfade werden unterstützt.</value>
+  </data>
+  <data name="CannotFindProjectInfo" xml:space="preserve">
+    <value>Die Projektinformationen für "{0}" wurden nicht gefunden. Dies ist möglicherweise auf einen fehlenden Projektverweis zurückzuführen.</value>
+  </data>
+  <data name="ContentFileDoesNotContainExpectedParentPackageInformation" xml:space="preserve">
+    <value>Die Inhaltsdatei "{0}" enthält nicht die erwarteten Informationen zum übergeordneten Paket.</value>
+  </data>
+  <data name="MissingItemMetadata" xml:space="preserve">
+    <value>Die Metadaten "{0}" für das Element "{2}" vom Typ "{1}" sind nicht vorhanden.</value>
+  </data>
+  <data name="UnrecognizedPreprocessorToken" xml:space="preserve">
+    <value>Unbekanntes Präprozessortoken "{0}" in "{1}".</value>
+  </data>
+  <data name="ContentPreproccessorParameterRequired" xml:space="preserve">
+    <value>Die Aufgabe "{0}" muss für die Nutzung vorverarbeiteter Inhalte mit einem Wert für den Parameter "{1}" versehen werden.</value>
+  </data>
+  <data name="ProjectAssetsConsumedWithoutMSBuildProjectPath" xml:space="preserve">
+    <value>Es werden Ressourcen aus dem Projekt "{0}" genutzt, in "{1}" wurde jedoch kein entsprechender MSBuild-Projektpfad gefunden.</value>
+  </data>
+  <data name="UnexpectedFileType" xml:space="preserve">
+    <value>Unerwarteter Dateityp für "{0}". Der Typ ist sowohl "{1}" als auch "{2}".</value>
+  </data>
+  <data name="CannotInferTargetFrameworkIdentiferAndVersion" xml:space="preserve">
+    <value>"TargetFrameworkIdentifier" und/oder "TargetFrameworkVersion" kann nicht von "TargetFramework='{0}'" abgeleitet werden. Sie müssen explizit angegeben werden.</value>
+  </data>
+  <data name="ContentItemDoesNotProvideOutputPath" xml:space="preserve">
+    <value>Das Inhaltselement für "{0}" legt "{1}" fest, gibt aber "{2}" oder "{3}" nicht an.</value>
+  </data>
+  <data name="DuplicatePreprocessorToken" xml:space="preserve">
+    <value>Das Präprozessortoken "{0}" wurde mit mehreren Werten versehen. "{1}" wird als Wert ausgewählt.</value>
+  </data>
+  <data name="ErrorsOccurredWhenEmittingSatelliteAssembly" xml:space="preserve">
+    <value>Fehler beim Ausgeben der Satellitenassembly "{0}".</value>
+  </data>
+  <data name="UnableToFindResolvedPath" xml:space="preserve">
+    <value>Der aufgelöste Pfad für "{0}" wurde nicht gefunden.</value>
+  </data>
+  <data name="UnexpectedDependencyWithNoVersionNumber" xml:space="preserve">
+    <value>Unerwartete Abhängigkeit "{0}" ohne Versionsnummer.</value>
+  </data>
+  <data name="RuntimeIdentifierMustBeSetForNETFramework" xml:space="preserve">
+    <value>"RuntimeIdentifier" muss für ausführbare .NETFramework-Dateien festgelegt werden. Verwenden Sie ggf. "RuntimeIdentifier=win7-x86" oder "RuntimeIdentifier=win7-x64".</value>
+  </data>
+  <data name="AssetPreprocessorMustBeConfigured" xml:space="preserve">
+    <value>Der Ressourcenpräprozessor muss konfiguriert werden, bevor Ressourcen verarbeitet werden.</value>
+  </data>
+  <data name="InvalidNuGetVersionString" xml:space="preserve">
+    <value>Ungültige NuGet-Versionszeichenfolge: {0}.</value>
+  </data>
+  <data name="DOTNET1011" xml:space="preserve">
+    <value>Framework nicht installiert: {0} in {1}</value>
+  </data>
+  <data name="DOTNET1012" xml:space="preserve">
+    <value>Das Verweisassemblysverzeichnis wurde nicht angegeben. Sie können den Speicherort mit der Umgebungsvariablen DOTNET_REFERENCE_ASSEMBLIES_PATH festlegen.</value>
+  </data>
+  <data name="DOTNET1013" xml:space="preserve">
+    <value>Die folgenden Abhängigkeiten sind mit dem Typ „platform“ gekennzeichnet, doch nur eine Abhängigkeit kann diesen Typ haben: {0}</value>
+  </data>
+  <data name="DOTNET1014" xml:space="preserve">
+    <value>Fehler beim Lesen der Sperrdatei.</value>
+  </data>
+  <data name="DOTNET1017" xml:space="preserve">
+    <value>Die Projektdatei ist nicht vorhanden: „{0}“.</value>
+  </data>
+  <data name="NU1001" xml:space="preserve">
+    <value>Die Abhängigkeit „{0}“ konnte nicht aufgelöst werden.</value>
+  </data>
+  <data name="NU1002" xml:space="preserve">
+    <value>Die Abhängigkeit „{0}“ in Projekt „{1}“ unterstützt nicht Framework „{2}“.</value>
+  </data>
+  <data name="NU1006" xml:space="preserve">
+    <value>{0}. Bitte führen Sie „dotnet restore“ aus, um eine neue Ressourcendatei zu erzeugen.</value>
+  </data>
+  <data name="NU1007" xml:space="preserve">
+    <value>Die angegebene Abhängigkeit war „{0}“, aber es endete mit „{1}“.</value>
+  </data>
+  <data name="NU1008" xml:space="preserve">
+    <value>{0} ist ein nicht unterstütztes Framework.</value>
+  </data>
+  <data name="NU1009" xml:space="preserve">
+    <value>Die erwartete Ressourcendatei ist nicht vorhanden. Bitte führen Sie „dotnet restore“ aus, um eine neue Ressourcendatei zu erzeugen.</value>
+  </data>
+  <data name="NU1010" xml:space="preserve">
+    <value>Der Abhängigkeitstyp wurde geändert.</value>
+  </data>
+  <data name="NU1011" xml:space="preserve">
+    <value>Das Abhängigkeitsziel „{0}“ wird nicht unterstützt.</value>
+  </data>
+  <data name="NU1012" xml:space="preserve">
+    <value>Abhängigkeitskonflikt. „{0}“ erwartete „{1}“, empfing jedoch „{2}“.</value>
+  </data>
+</root>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.es.resx
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.es.resx
@@ -1,0 +1,228 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="AtLeastOneTargetFrameworkMustBeSpecified" xml:space="preserve">
+    <value>Debe especificarse al menos una plataforma de destino posible.</value>
+  </data>
+  <data name="NoCompatibleTargetFramework" xml:space="preserve">
+    <value>El proyecto '{0}' no tiene una plataforma de destino compatible con '{1}'.</value>
+  </data>
+  <data name="InvalidFrameworkName" xml:space="preserve">
+    <value>Nombre de plataforma no válido: '{0}'.</value>
+  </data>
+  <data name="AssetsFileNotFound" xml:space="preserve">
+    <value>No se encuentra el archivo de recursos '{0}'. Ejecute una restauración de paquetes NuGet para generar el archivo.</value>
+  </data>
+  <data name="AssetsFileMissingTarget" xml:space="preserve">
+    <value>El archivo de recursos '{0}' no tiene un destino para '{1}'. Asegúrese de que ha restaurado el proyecto para TargetFramework='{2}' y RuntimeIdentifier='{3}'.</value>
+  </data>
+  <data name="AssetsFilePathNotRooted" xml:space="preserve">
+    <value>La ruta de acceso del archivo de recursos '{0}' no tiene raíz. Solo se admiten rutas de acceso completas.</value>
+  </data>
+  <data name="CannotFindProjectInfo" xml:space="preserve">
+    <value>No se encuentra la información de proyecto de '{0}'. Esto puede indicar que falta una referencia de proyecto.</value>
+  </data>
+  <data name="ContentFileDoesNotContainExpectedParentPackageInformation" xml:space="preserve">
+    <value>El archivo de contenido '{0}' no tiene la información de paquete primario que se esperaba.</value>
+  </data>
+  <data name="MissingItemMetadata" xml:space="preserve">
+    <value>Faltan los metadatos de '{0}' en el elemento de '{1}' '{2}'.</value>
+  </data>
+  <data name="UnrecognizedPreprocessorToken" xml:space="preserve">
+    <value>Token de preprocesador no reconocido '{0}' en '{1}'.</value>
+  </data>
+  <data name="ContentPreproccessorParameterRequired" xml:space="preserve">
+    <value>Debe darse un valor al parámetro '{1}' de la tarea '{0}' para poder consumir contenido preprocesado.</value>
+  </data>
+  <data name="ProjectAssetsConsumedWithoutMSBuildProjectPath" xml:space="preserve">
+    <value>Los recursos se consumen desde el proyecto '{0}', pero no se ha encontrado la ruta de acceso de proyecto de MSBuild correspondiente en '{1}'.</value>
+  </data>
+  <data name="UnexpectedFileType" xml:space="preserve">
+    <value>Tipo de archivo no esperado para '{0}'. El tipo es tanto '{1}' como '{2}'.</value>
+  </data>
+  <data name="CannotInferTargetFrameworkIdentiferAndVersion" xml:space="preserve">
+    <value>No se puede inferir TargetFrameworkIdentifier y/o TargetFrameworkVersion de TargetFramework='{0}'. Deben especificarse de forma explícita.</value>
+  </data>
+  <data name="ContentItemDoesNotProvideOutputPath" xml:space="preserve">
+    <value>El elemento de contenido de '{0}' establece '{1}', pero no proporciona '{2}' ni '{3}'.</value>
+  </data>
+  <data name="DuplicatePreprocessorToken" xml:space="preserve">
+    <value>Se han dado varios valores para el token de preprocesador '{0}'. Se va a elegir '{1}' como valor.</value>
+  </data>
+  <data name="ErrorsOccurredWhenEmittingSatelliteAssembly" xml:space="preserve">
+    <value>Se han producido errores al emitir el ensamblado satélite '{0}'.</value>
+  </data>
+  <data name="UnableToFindResolvedPath" xml:space="preserve">
+    <value>No se encuentra la ruta de acceso resuelta para '{0}'.</value>
+  </data>
+  <data name="UnexpectedDependencyWithNoVersionNumber" xml:space="preserve">
+    <value>Dependencia '{0}' sin número de versión no esperada.</value>
+  </data>
+  <data name="RuntimeIdentifierMustBeSetForNETFramework" xml:space="preserve">
+    <value>RuntimeIdentifier debe establecerse para archivos ejecutables de .NET Framework. Considere usar RuntimeIdentifier=win7-x86 o RuntimeIdentifier=win7-x64.</value>
+  </data>
+  <data name="AssetPreprocessorMustBeConfigured" xml:space="preserve">
+    <value>Debe configurarse el preprocesador de recursos antes de que se procesen los recursos.</value>
+  </data>
+  <data name="InvalidNuGetVersionString" xml:space="preserve">
+    <value>Cadena de versión de NuGet no válida: '{0}'.</value>
+  </data>
+  <data name="DOTNET1011" xml:space="preserve">
+    <value>Plataforma no instalada: {0} en {1}</value>
+  </data>
+  <data name="DOTNET1012" xml:space="preserve">
+    <value>No se especificó el directorio de ensamblados de referencia. Puede establecer la ubicación mediante la variable de entorno DOTNET_REFERENCE_ASSEMBLIES_PATH.</value>
+  </data>
+  <data name="DOTNET1013" xml:space="preserve">
+    <value>Las dependencias siguientes están marcadas con el tipo "plataforma"; sin embargo, solo una dependencia puede tener este tipo: {0}</value>
+  </data>
+  <data name="DOTNET1014" xml:space="preserve">
+    <value>No se pudo leer el archivo de bloqueo</value>
+  </data>
+  <data name="DOTNET1017" xml:space="preserve">
+    <value>El archivo de proyecto no existe "{0}".</value>
+  </data>
+  <data name="NU1001" xml:space="preserve">
+    <value>No se pudo resolver la dependencia "{0}".</value>
+  </data>
+  <data name="NU1002" xml:space="preserve">
+    <value>La dependencia "{0}" del proyecto "{1}" no es compatible con la plataforma "{2}".</value>
+  </data>
+  <data name="NU1006" xml:space="preserve">
+    <value>{0}. Ejecute "dotnet restore" para generar un nuevo archivo de recurso.</value>
+  </data>
+  <data name="NU1007" xml:space="preserve">
+    <value>La dependencia especificada era "{0}", pero finalizaba con "{1}".</value>
+  </data>
+  <data name="NU1008" xml:space="preserve">
+    <value>{0} es una plataforma no compatible.</value>
+  </data>
+  <data name="NU1009" xml:space="preserve">
+    <value>El archivo de recurso esperado no existe. Ejecute "dotnet restore" para generar un nuevo archivo de recurso.</value>
+  </data>
+  <data name="NU1010" xml:space="preserve">
+    <value>El tipo de dependencia cambió</value>
+  </data>
+  <data name="NU1011" xml:space="preserve">
+    <value>El destino de dependencia"{0}" no es compatible.</value>
+  </data>
+  <data name="NU1012" xml:space="preserve">
+    <value>Conflicto de dependencia. "{0}" esperaba "{1}", pero recibió "{2}"</value>
+  </data>
+</root>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.fr.resx
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.fr.resx
@@ -1,0 +1,228 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="AtLeastOneTargetFrameworkMustBeSpecified" xml:space="preserve">
+    <value>Au moins un framework cible doit être spécifié.</value>
+  </data>
+  <data name="NoCompatibleTargetFramework" xml:space="preserve">
+    <value>Le projet '{0}' n'a aucun framework cible compatible avec '{1}'.</value>
+  </data>
+  <data name="InvalidFrameworkName" xml:space="preserve">
+    <value>Nom de framework non valide : '{0}'.</value>
+  </data>
+  <data name="AssetsFileNotFound" xml:space="preserve">
+    <value>Fichier de composants '{0}' introuvable. Exécutez une restauration de package NuGet pour générer ce fichier.</value>
+  </data>
+  <data name="AssetsFileMissingTarget" xml:space="preserve">
+    <value>Le fichier de composant '{0}' n'a pas de cible pour '{1}'. Vérifiez que vous avez restauré ce projet pour TargetFramework='{2}' et RuntimeIdentifier='{3}'.</value>
+  </data>
+  <data name="AssetsFilePathNotRooted" xml:space="preserve">
+    <value>Le chemin du fichier de composant '{0}' n'est pas associé à une racine. Seuls les chemins complets sont pris en charge.</value>
+  </data>
+  <data name="CannotFindProjectInfo" xml:space="preserve">
+    <value>Informations sur le projet introuvables pour '{0}'. Ceci peut indiquer une référence de projet manquante.</value>
+  </data>
+  <data name="ContentFileDoesNotContainExpectedParentPackageInformation" xml:space="preserve">
+    <value>Le fichier de contenu '{0}' ne contient pas les informations attendues sur le package parent.</value>
+  </data>
+  <data name="MissingItemMetadata" xml:space="preserve">
+    <value>Métadonnées '{0}' manquantes sur l'élément '{1}' '{2}'.</value>
+  </data>
+  <data name="UnrecognizedPreprocessorToken" xml:space="preserve">
+    <value>Jeton de préprocesseur '{0}' non reconnu dans '{1}'.</value>
+  </data>
+  <data name="ContentPreproccessorParameterRequired" xml:space="preserve">
+    <value>La tâche '{0}' doit recevoir une valeur pour le paramètre '{1}' pour pouvoir consommer du contenu prétraité.</value>
+  </data>
+  <data name="ProjectAssetsConsumedWithoutMSBuildProjectPath" xml:space="preserve">
+    <value>Les composants sont consommés à partir du projet '{0}', mais aucun chemin de projet MSBuild correspondant n'a été trouvé dans '{1}'.</value>
+  </data>
+  <data name="UnexpectedFileType" xml:space="preserve">
+    <value>Type de fichier inattendu pour '{0}'. Le type est à la fois '{1}' et '{2}'.</value>
+  </data>
+  <data name="CannotInferTargetFrameworkIdentiferAndVersion" xml:space="preserve">
+    <value>Impossible de déduire TargetFrameworkIdentifier et/ou TargetFrameworkVersion à partir de TargetFramework='{0}'. Ils doivent être spécifiés explicitement.</value>
+  </data>
+  <data name="ContentItemDoesNotProvideOutputPath" xml:space="preserve">
+    <value>L'élément de contenu pour '{0}' définit '{1}', mais ne fournit ni '{2}' ni '{3}'.</value>
+  </data>
+  <data name="DuplicatePreprocessorToken" xml:space="preserve">
+    <value>Plusieurs valeurs ont été affectées au jeton de préprocesseur '{0}'. La valeur choisie est '{1}'.</value>
+  </data>
+  <data name="ErrorsOccurredWhenEmittingSatelliteAssembly" xml:space="preserve">
+    <value>Des erreurs se sont produites pendant l'émission de l'assembly satellite '{0}'.</value>
+  </data>
+  <data name="UnableToFindResolvedPath" xml:space="preserve">
+    <value>Chemin résolu introuvable pour '{0}'.</value>
+  </data>
+  <data name="UnexpectedDependencyWithNoVersionNumber" xml:space="preserve">
+    <value>Dépendance '{0}' sans numéro de version inattendue.</value>
+  </data>
+  <data name="RuntimeIdentifierMustBeSetForNETFramework" xml:space="preserve">
+    <value>RuntimeIdentifier doit être défini pour les exécutables .NET Framework. Considérez RuntimeIdentifier=win7-x86 ou RuntimeIdentifier=win7-x64.</value>
+  </data>
+  <data name="AssetPreprocessorMustBeConfigured" xml:space="preserve">
+    <value>Le préprocesseur de composants doit être configuré avant que les composants ne soient traités.</value>
+  </data>
+  <data name="InvalidNuGetVersionString" xml:space="preserve">
+    <value>Chaîne de version NuGet non valide : '{0}'.</value>
+  </data>
+  <data name="DOTNET1011" xml:space="preserve">
+    <value>Framework non installé : {0} dans {1}</value>
+  </data>
+  <data name="DOTNET1012" xml:space="preserve">
+    <value>Le répertoire des assemblys de référence n'a pas été spécifié. Vous pouvez définir l'emplacement à l'aide de la variable d'environnement DOTNET_REFERENCE_ASSEMBLIES_PATH.</value>
+  </data>
+  <data name="DOTNET1013" xml:space="preserve">
+    <value>Les dépendances suivantes sont marquées avec le type 'platform'. Toutefois, une seule dépendance peut avoir ce type : {0}</value>
+  </data>
+  <data name="DOTNET1014" xml:space="preserve">
+    <value>Échec de la lecture du fichier de verrouillage</value>
+  </data>
+  <data name="DOTNET1017" xml:space="preserve">
+    <value>Le fichier projet n'existe pas : '{0}'.</value>
+  </data>
+  <data name="NU1001" xml:space="preserve">
+    <value>Impossible de résoudre la dépendance '{0}'.</value>
+  </data>
+  <data name="NU1002" xml:space="preserve">
+    <value>La dépendance '{0}' du projet '{1}' ne prend pas en charge le framework '{2}'.</value>
+  </data>
+  <data name="NU1006" xml:space="preserve">
+    <value>{0}. Exécutez 'dotnet restore' pour générer un nouveau fichier de composants.</value>
+  </data>
+  <data name="NU1007" xml:space="preserve">
+    <value>La dépendance spécifiée était '{0}' mais se terminait par '{1}'.</value>
+  </data>
+  <data name="NU1008" xml:space="preserve">
+    <value>{0} est un framework non pris en charge.</value>
+  </data>
+  <data name="NU1009" xml:space="preserve">
+    <value>Le fichier de composants attendu n'existe pas. Exécutez 'dotnet restore' pour générer un nouveau fichier de composants.</value>
+  </data>
+  <data name="NU1010" xml:space="preserve">
+    <value>Le type de dépendance a été changé</value>
+  </data>
+  <data name="NU1011" xml:space="preserve">
+    <value>La cible de dépendance '{0}' n'est pas prise en charge.</value>
+  </data>
+  <data name="NU1012" xml:space="preserve">
+    <value>Conflit de dépendances. '{0}' attendait '{1}' mais a reçu '{2}'</value>
+  </data>
+</root>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.it.resx
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.it.resx
@@ -1,0 +1,228 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="AtLeastOneTargetFrameworkMustBeSpecified" xml:space="preserve">
+    <value>È necessario specificare almeno un framework di destinazione possibile.</value>
+  </data>
+  <data name="NoCompatibleTargetFramework" xml:space="preserve">
+    <value>Per il progetto '{0}' non esiste alcun framework di destinazione compatibile con '{1}'.</value>
+  </data>
+  <data name="InvalidFrameworkName" xml:space="preserve">
+    <value>Nome di framework non valido: '{0}'.</value>
+  </data>
+  <data name="AssetsFileNotFound" xml:space="preserve">
+    <value>Il file di risorse '{0}' non è stato trovato. Per generare questo file, eseguire un ripristino del pacchetto NuGet.</value>
+  </data>
+  <data name="AssetsFileMissingTarget" xml:space="preserve">
+    <value>Il file di risorse '{0}' non contiene una destinazione per '{1}'. Assicurarsi di aver ripristinato questo progetto per TargetFramework='{2}' e RuntimeIdentifier='{3}'.</value>
+  </data>
+  <data name="AssetsFilePathNotRooted" xml:space="preserve">
+    <value>Il percorso dei file di risorse '{0}' non contiene una radice. Sono supportati solo percorsi completi.</value>
+  </data>
+  <data name="CannotFindProjectInfo" xml:space="preserve">
+    <value>Le informazioni del progetto per '{0}' non sono state trovate. Questo errore può indicare la mancanza di un riferimento al progetto.</value>
+  </data>
+  <data name="ContentFileDoesNotContainExpectedParentPackageInformation" xml:space="preserve">
+    <value>Il file di contenuto '{0}' non contiene le informazioni previste sul pacchetto padre.</value>
+  </data>
+  <data name="MissingItemMetadata" xml:space="preserve">
+    <value>Mancano i metadati di '{0}' sull'elemento '{2}' di '{1}'.</value>
+  </data>
+  <data name="UnrecognizedPreprocessorToken" xml:space="preserve">
+    <value>Token di preprocessore '{0}' non riconosciuto in '{1}'.</value>
+  </data>
+  <data name="ContentPreproccessorParameterRequired" xml:space="preserve">
+    <value>Per poter utilizzare il contenuto pre-elaborato, è necessario assegnare un valore per il parametro '{1}' nell'attività '{0}'.</value>
+  </data>
+  <data name="ProjectAssetsConsumedWithoutMSBuildProjectPath" xml:space="preserve">
+    <value>Le risorse vengono utilizzate dal progetto '{0}', ma non è stato trovato alcun percorso di progetto MSBuild corrispondente in '{1}'.</value>
+  </data>
+  <data name="UnexpectedFileType" xml:space="preserve">
+    <value>Tipo di file imprevisto per '{0}'. Il tipo è sia '{1}' che '{2}'.</value>
+  </data>
+  <data name="CannotInferTargetFrameworkIdentiferAndVersion" xml:space="preserve">
+    <value>Non è possibile dedurre TargetFrameworkIdentifier e/o TargetFrameworkVersion da TargetFramework='{0}'. Devono essere specificati in modo esplicito.</value>
+  </data>
+  <data name="ContentItemDoesNotProvideOutputPath" xml:space="preserve">
+    <value>L'elemento di contenuto per '{0}' imposta '{1}', ma non fornisce '{2}' o '{3}'.</value>
+  </data>
+  <data name="DuplicatePreprocessorToken" xml:space="preserve">
+    <value>Al token di preprocessore '{0}' è stato assegnato più di un valore. Come valore verrà scelto '{1}'.</value>
+  </data>
+  <data name="ErrorsOccurredWhenEmittingSatelliteAssembly" xml:space="preserve">
+    <value>Si sono verificati errori durante la creazione dell'assembly satellite '{0}'.</value>
+  </data>
+  <data name="UnableToFindResolvedPath" xml:space="preserve">
+    <value>Il percorso risolto per '{0}' non è stato trovato.</value>
+  </data>
+  <data name="UnexpectedDependencyWithNoVersionNumber" xml:space="preserve">
+    <value>La dipendenza '{0}' è imprevista e non ha numero di versione.</value>
+  </data>
+  <data name="RuntimeIdentifierMustBeSetForNETFramework" xml:space="preserve">
+    <value>Per gli eseguibili di .NET Framework è necessario impostare RuntimeIdentifier. Provare a specificare RuntimeIdentifier=win7-x86 o RuntimeIdentifier=win7-x64.</value>
+  </data>
+  <data name="AssetPreprocessorMustBeConfigured" xml:space="preserve">
+    <value>Prima di elaborare le risorse, è necessario configurare il preprocessore di risorse.</value>
+  </data>
+  <data name="InvalidNuGetVersionString" xml:space="preserve">
+    <value>La stringa di versione '{0}' di NuGet non è valida.</value>
+  </data>
+  <data name="DOTNET1011" xml:space="preserve">
+    <value>Framework non installato: {0} in {1}</value>
+  </data>
+  <data name="DOTNET1012" xml:space="preserve">
+    <value>La directory degli assembly di riferimento non è stata specificata. È possibile impostare il percorso con la variabile di ambiente DOTNET_REFERENCE_ASSEMBLIES_PATH.</value>
+  </data>
+  <data name="DOTNET1013" xml:space="preserve">
+    <value>Le dipendenze seguenti sono contrassegnate dal tipo 'platform', tuttavia questo tipo può essere assegnato a una sola dipendenza: {0}</value>
+  </data>
+  <data name="DOTNET1014" xml:space="preserve">
+    <value>Non è stato possibile leggere il file di blocco</value>
+  </data>
+  <data name="DOTNET1017" xml:space="preserve">
+    <value>Il file di progetto '{0}' non esiste.</value>
+  </data>
+  <data name="NU1001" xml:space="preserve">
+    <value>Non è stato possibile risolvere la dipendenza '{0}'.</value>
+  </data>
+  <data name="NU1002" xml:space="preserve">
+    <value>La dipendenza '{0}' nel progetto '{1}' non supporta il framework '{2}'.</value>
+  </data>
+  <data name="NU1006" xml:space="preserve">
+    <value>{0}. Per generare un nuovo file di risorse, eseguire 'dotnet restore'.</value>
+  </data>
+  <data name="NU1007" xml:space="preserve">
+    <value>La dipendenza specificata era '{0}' ma è risultata essere '{1}'.</value>
+  </data>
+  <data name="NU1008" xml:space="preserve">
+    <value>{0} è un framework non supportato.</value>
+  </data>
+  <data name="NU1009" xml:space="preserve">
+    <value>Il file di risorse previsto non esiste. Per generare un nuovo file di risorse, eseguire 'dotnet restore'.</value>
+  </data>
+  <data name="NU1010" xml:space="preserve">
+    <value>Il tipo di dipendenza è cambiato</value>
+  </data>
+  <data name="NU1011" xml:space="preserve">
+    <value>La destinazione '{0}' della dipendenza non è supportata.</value>
+  </data>
+  <data name="NU1012" xml:space="preserve">
+    <value>Conflitto di dipendenze. In '{0}' è previsto '{1}', ma è stato ricevuto '{2}'</value>
+  </data>
+</root>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.ja.resx
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.ja.resx
@@ -1,0 +1,228 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="AtLeastOneTargetFrameworkMustBeSpecified" xml:space="preserve">
+    <value>可能性のあるターゲット フレームワークを少なくとも 1 つ指定する必要があります。</value>
+  </data>
+  <data name="NoCompatibleTargetFramework" xml:space="preserve">
+    <value>プロジェクト '{0}' には、'{1}' と互換性のあるターゲット フレームワークがありません。</value>
+  </data>
+  <data name="InvalidFrameworkName" xml:space="preserve">
+    <value>無効なフレームワーク名: '{0}'。</value>
+  </data>
+  <data name="AssetsFileNotFound" xml:space="preserve">
+    <value>資産ファイル '{0}' が見つかりません。NuGet パッケージの復元を実行して、このファイルを生成してください。</value>
+  </data>
+  <data name="AssetsFileMissingTarget" xml:space="preserve">
+    <value>資産ファイル '{0}' に '{1}' のターゲットがありません。TargetFramework='{2}' および RuntimeIdentifier='{3}' のこのプロジェクトを復元したことを確認してください。</value>
+  </data>
+  <data name="AssetsFilePathNotRooted" xml:space="preserve">
+    <value>資産ファイル パス '{0}' にルートが指定されていません。完全パスのみがサポートされます。</value>
+  </data>
+  <data name="CannotFindProjectInfo" xml:space="preserve">
+    <value>'{0}' のプロジェクト情報が見つかりません。これは、プロジェクト参照がないことを示している可能性があります。</value>
+  </data>
+  <data name="ContentFileDoesNotContainExpectedParentPackageInformation" xml:space="preserve">
+    <value>予期される親パッケージ情報がコンテンツ ファイル '{0}' に入っていません。</value>
+  </data>
+  <data name="MissingItemMetadata" xml:space="preserve">
+    <value>'{1}' 項目 '{2}' の '{0}' メタデータがありません。</value>
+  </data>
+  <data name="UnrecognizedPreprocessorToken" xml:space="preserve">
+    <value>認識されないプリプロセッサ トークン '{0}' が '{1}' に存在します。</value>
+  </data>
+  <data name="ContentPreproccessorParameterRequired" xml:space="preserve">
+    <value>前処理されたコンテンツを使用するためには、パラメーター '{1}' の値を '{0}' タスクに指定する必要があります。</value>
+  </data>
+  <data name="ProjectAssetsConsumedWithoutMSBuildProjectPath" xml:space="preserve">
+    <value>プロジェクト '{0}' の資産が使用されますが、対応する MSBuild プロジェクト パスが '{1}' で見つかりませんでした。</value>
+  </data>
+  <data name="UnexpectedFileType" xml:space="preserve">
+    <value>'{0}' のファイルの種類が正しくありません。種類は '{1}' と '{2}' の両方です。</value>
+  </data>
+  <data name="CannotInferTargetFrameworkIdentiferAndVersion" xml:space="preserve">
+    <value>TargetFrameworkIdentifier または TargetFrameworkVersion あるいはその両方を TargetFramework='{0}' から推論できません。それらは明示的に指定する必要があります。</value>
+  </data>
+  <data name="ContentItemDoesNotProvideOutputPath" xml:space="preserve">
+    <value>'{0}' のコンテンツ項目で '{1}' が設定されますが、'{2}' または '{3}' は指定されません。</value>
+  </data>
+  <data name="DuplicatePreprocessorToken" xml:space="preserve">
+    <value>プリプロセッサ トークン '{0}' に複数の値が指定されています。値として '{1}' を選択します。</value>
+  </data>
+  <data name="ErrorsOccurredWhenEmittingSatelliteAssembly" xml:space="preserve">
+    <value>サテライト アセンブリ '{0}' を出力しているときに、エラーが発生しました。</value>
+  </data>
+  <data name="UnableToFindResolvedPath" xml:space="preserve">
+    <value>解決された '{0}' のパスが見つかりません。</value>
+  </data>
+  <data name="UnexpectedDependencyWithNoVersionNumber" xml:space="preserve">
+    <value>バージョン番号のない予期しない依存関係 '{0}' です。</value>
+  </data>
+  <data name="RuntimeIdentifierMustBeSetForNETFramework" xml:space="preserve">
+    <value>.NETFramework 実行可能ファイルの RuntimeIdentifier を設定する必要があります。RuntimeIdentifier=win7-x86 または RuntimeIdentifier=win7-x64 を検討してください。</value>
+  </data>
+  <data name="AssetPreprocessorMustBeConfigured" xml:space="preserve">
+    <value>資産を処理する前に、資産プリプロセッサを構成する必要があります。</value>
+  </data>
+  <data name="InvalidNuGetVersionString" xml:space="preserve">
+    <value>無効な NuGet バージョン文字列: '{0}'。</value>
+  </data>
+  <data name="DOTNET1011" xml:space="preserve">
+    <value>{1} にフレームワーク {0} がインストールされていません</value>
+  </data>
+  <data name="DOTNET1012" xml:space="preserve">
+    <value>参照アセンブリのディレクトリが指定されていません。DOTNET_REFERENCE_ASSEMBLIES_PATH 環境変数を使用して、場所を設定できます。</value>
+  </data>
+  <data name="DOTNET1013" xml:space="preserve">
+    <value>次の依存関係は型 'platform' でマークされています。ただし、この型 {0} を持つことができる依存関係は 1 つのみです</value>
+  </data>
+  <data name="DOTNET1014" xml:space="preserve">
+    <value>ロック ファイルの読み取りに失敗しました</value>
+  </data>
+  <data name="DOTNET1017" xml:space="preserve">
+    <value>プロジェクト ファイルが存在しません: '{0}'。</value>
+  </data>
+  <data name="NU1001" xml:space="preserve">
+    <value>依存関係 '{0}' を解決できませんでした。</value>
+  </data>
+  <data name="NU1002" xml:space="preserve">
+    <value>プロジェクト '{1}' の依存関係 '{0}' は、フレームワーク '{2}' をサポートしません。</value>
+  </data>
+  <data name="NU1006" xml:space="preserve">
+    <value>{0}。'dotnet restore' を実行して、新しい資産ファイルを生成してください。</value>
+  </data>
+  <data name="NU1007" xml:space="preserve">
+    <value>指定した依存関係は '{0}' ですが、'{1}' が見つかりました。</value>
+  </data>
+  <data name="NU1008" xml:space="preserve">
+    <value>{0} は、サポートされていないフレームワークです。</value>
+  </data>
+  <data name="NU1009" xml:space="preserve">
+    <value>必要な資産ファイルが存在しません。'dotnet restore' を実行して、新しい資産ファイルを生成してください。</value>
+  </data>
+  <data name="NU1010" xml:space="preserve">
+    <value>依存関係の種類が変更されました</value>
+  </data>
+  <data name="NU1011" xml:space="preserve">
+    <value>依存関係ターゲット '{0}' はサポートされていません。</value>
+  </data>
+  <data name="NU1012" xml:space="preserve">
+    <value>依存関係の競合。'{0}' には '{1}' が必要ですが、'{2}' を受信しました。</value>
+  </data>
+</root>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.ko.resx
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.ko.resx
@@ -1,0 +1,228 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="AtLeastOneTargetFrameworkMustBeSpecified" xml:space="preserve">
+    <value>가능한 대상 프레임워크를 하나 이상 지정해야 합니다.</value>
+  </data>
+  <data name="NoCompatibleTargetFramework" xml:space="preserve">
+    <value>'{0}' 프로젝트에 '{1}'과(와) 호환되는 대상 프레임워크가 없습니다.</value>
+  </data>
+  <data name="InvalidFrameworkName" xml:space="preserve">
+    <value>프레임워크 이름 '{0}'이(가) 잘못되었습니다.</value>
+  </data>
+  <data name="AssetsFileNotFound" xml:space="preserve">
+    <value>자산 파일 `{0}`을(를) 찾을 수 없습니다. NuGet 패키지 복원을 실행하여 이 파일을 생성하세요.</value>
+  </data>
+  <data name="AssetsFileMissingTarget" xml:space="preserve">
+    <value>자산 파일 '{0}'에 '{1}'의 대상이 없습니다. TargetFramework='{2}' 및 RuntimeIdentifier='{3}'에 대해 이 프로젝트를 복원했는지 확인하세요.</value>
+  </data>
+  <data name="AssetsFilePathNotRooted" xml:space="preserve">
+    <value>자산 파일 경로 '{0}'이(가) 루트에서 시작하지 않습니다. 전체 경로만 지원됩니다.</value>
+  </data>
+  <data name="CannotFindProjectInfo" xml:space="preserve">
+    <value>'{0}'에 대한 프로젝트 정보를 찾을 수 없습니다. 프로젝트 참조가 없음을 나타낼 수 있습니다.</value>
+  </data>
+  <data name="ContentFileDoesNotContainExpectedParentPackageInformation" xml:space="preserve">
+    <value>콘텐츠 파일 '{0}'에 필요한 패키지 정보가 없습니다.</value>
+  </data>
+  <data name="MissingItemMetadata" xml:space="preserve">
+    <value>'{1}' 항목 '{2}'에 '{0}' 메타데이터가 없습니다.</value>
+  </data>
+  <data name="UnrecognizedPreprocessorToken" xml:space="preserve">
+    <value>'{1}'에서 전처리기 토큰 '{0}'을(를) 인식할 수 없습니다.</value>
+  </data>
+  <data name="ContentPreproccessorParameterRequired" xml:space="preserve">
+    <value>전처리된 콘텐츠를 사용하려면 '{0}' 작업에서 '{1}' 매개 변수의 값을 지정해야 합니다.</value>
+  </data>
+  <data name="ProjectAssetsConsumedWithoutMSBuildProjectPath" xml:space="preserve">
+    <value>'{0}' 프로젝트의 자산이 사용되었지만, '{1}'에서 해당 MSBuild 프로젝트 경로를 찾을 수 없습니다.</value>
+  </data>
+  <data name="UnexpectedFileType" xml:space="preserve">
+    <value>'{0}'에 대해 예기치 않은 파일 형식입니다. 형식이 '{1}'인 동시에 '{2}'입니다.</value>
+  </data>
+  <data name="CannotInferTargetFrameworkIdentiferAndVersion" xml:space="preserve">
+    <value>TargetFramework='{0}'에서 TargetFrameworkIdentifier 및/또는 TargetFrameworkVersion을 유추할 수 없습니다. 명시적으로 지정해야 합니다.</value>
+  </data>
+  <data name="ContentItemDoesNotProvideOutputPath" xml:space="preserve">
+    <value>{0}'의 콘텐츠 항목이 '{1}'을(를) 설정하지만, '{2}' 또는 '{3}'을(를) 제공하지 않습니다.</value>
+  </data>
+  <data name="DuplicatePreprocessorToken" xml:space="preserve">
+    <value>전처리기 토큰 '{0}'의 값이 두 개 이상 지정되었습니다. '{1}'을(를) 값으로 선택합니다.</value>
+  </data>
+  <data name="ErrorsOccurredWhenEmittingSatelliteAssembly" xml:space="preserve">
+    <value>위성 어셈블리 '{0}'을(를) 내보내는 동안 오류가 발생했습니다.</value>
+  </data>
+  <data name="UnableToFindResolvedPath" xml:space="preserve">
+    <value>'{0}'에 대해 확인된 경로를 찾을 수 없습니다.</value>
+  </data>
+  <data name="UnexpectedDependencyWithNoVersionNumber" xml:space="preserve">
+    <value>버전 번호가 없는 예기치 않은 종속성 '{0}'입니다.</value>
+  </data>
+  <data name="RuntimeIdentifierMustBeSetForNETFramework" xml:space="preserve">
+    <value>.NET Framework 실행 파일에는 RuntimeIdentifier를 설정해야 합니다. RuntimeIdentifier=win7-x86 또는 RuntimeIdentifier=win7-x64를 사용해 보세요.</value>
+  </data>
+  <data name="AssetPreprocessorMustBeConfigured" xml:space="preserve">
+    <value>자산을 처리하려면 먼저 자산 전처리기를 구성해야 합니다.</value>
+  </data>
+  <data name="InvalidNuGetVersionString" xml:space="preserve">
+    <value>NuGet 버전 문자열 '{0}'이(가) 잘못되었습니다.</value>
+  </data>
+  <data name="DOTNET1011" xml:space="preserve">
+    <value>{0} 프레임워크가 {1}에 설치되지 않았습니다.</value>
+  </data>
+  <data name="DOTNET1012" xml:space="preserve">
+    <value>참조 어셈블리 디렉터리가 지정되지 않았습니다. DOTNET_REFERENCE_ASSEMBLIES_PATH 환경 변수를 사용하여 위치를 설정할 수 있습니다.</value>
+  </data>
+  <data name="DOTNET1013" xml:space="preserve">
+    <value>다음 종속성이 '플랫폼' 유형으로 표시되었지만, 하나의 종속성만 이 유형을 가질 수 있습니다. {0}</value>
+  </data>
+  <data name="DOTNET1014" xml:space="preserve">
+    <value>잠금 파일 읽기 실패</value>
+  </data>
+  <data name="DOTNET1017" xml:space="preserve">
+    <value>프로젝트 파일에 '{0}'이(가) 없습니다.</value>
+  </data>
+  <data name="NU1001" xml:space="preserve">
+    <value>'{0}' 종속성을 확인할 수 없습니다.</value>
+  </data>
+  <data name="NU1002" xml:space="preserve">
+    <value>'{1}' 프로젝트의 '{0}' 종속성이 '{2}' 프레임워크를 지원하지 않습니다.</value>
+  </data>
+  <data name="NU1006" xml:space="preserve">
+    <value>{0}. 새 자산 파일을 생성하려면 'dotnet restore'를 실행하세요.</value>
+  </data>
+  <data name="NU1007" xml:space="preserve">
+    <value>지정된 종속성은 '{0}'인데 '{1}'(으)로 끝납니다.</value>
+  </data>
+  <data name="NU1008" xml:space="preserve">
+    <value>{0}은(는) 지원되지 않는 프레임워크입니다.</value>
+  </data>
+  <data name="NU1009" xml:space="preserve">
+    <value>예상되는 자산 파일이 없습니다. 새 자산 파일을 생성하려면 'dotnet restore'를 실행하세요.</value>
+  </data>
+  <data name="NU1010" xml:space="preserve">
+    <value>종속성 유형이 변경되었습니다.</value>
+  </data>
+  <data name="NU1011" xml:space="preserve">
+    <value>'{0}' 종속성 대상은 지원되지 않습니다.</value>
+  </data>
+  <data name="NU1012" xml:space="preserve">
+    <value>종속성 충돌. '{0}'에서 '{1}'을(를) 예상했지만 '{2}'을(를) 수신했습니다.</value>
+  </data>
+</root>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.pl.resx
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.pl.resx
@@ -1,0 +1,228 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="AtLeastOneTargetFrameworkMustBeSpecified" xml:space="preserve">
+    <value>Należy określić co najmniej jedną możliwą platformę docelową.</value>
+  </data>
+  <data name="NoCompatibleTargetFramework" xml:space="preserve">
+    <value>Projekt „{0}” nie ma platformy docelowej kompatybilnej z „{1}”.</value>
+  </data>
+  <data name="InvalidFrameworkName" xml:space="preserve">
+    <value>Nieprawidłowa nazwa platformy: „{0}”.</value>
+  </data>
+  <data name="AssetsFileNotFound" xml:space="preserve">
+    <value>Nie odnaleziono pliku zasobów „{0}”. Uruchom przywracanie pakietu NuGet, aby wygenerować ten plik.</value>
+  </data>
+  <data name="AssetsFileMissingTarget" xml:space="preserve">
+    <value>Plik zasobów „{0}” nie ma obiektu docelowego dla „{1}”. Upewnij się, że projekt został przywrócony dla elementu TargetFramework=„{2}” i RuntimeIdentifier=„{3}”.</value>
+  </data>
+  <data name="AssetsFilePathNotRooted" xml:space="preserve">
+    <value>Ścieżka pliku zasobów „{0}” nie prowadzi do katalogu głównego. Tylko pełne ścieżki są obsługiwane.</value>
+  </data>
+  <data name="CannotFindProjectInfo" xml:space="preserve">
+    <value>Nie odnaleziono informacji o projekcie dla elementu „{0}”. Może to wskazywać na brakujące odwołanie do projektu.</value>
+  </data>
+  <data name="ContentFileDoesNotContainExpectedParentPackageInformation" xml:space="preserve">
+    <value>Plik zawartości „{0}” nie zawiera oczekiwanych informacji o pakiecie nadrzędnym.</value>
+  </data>
+  <data name="MissingItemMetadata" xml:space="preserve">
+    <value>Brak metadanych „{0}” w elemencie „{1}” „{2}”.</value>
+  </data>
+  <data name="UnrecognizedPreprocessorToken" xml:space="preserve">
+    <value>Nierozpoznany token preprocesora „{0}” w elemencie „{1}”.</value>
+  </data>
+  <data name="ContentPreproccessorParameterRequired" xml:space="preserve">
+    <value>Dla zadania „{0}” musi zostać podana wartość parametru „{1}” w celu użycia wstępnie przetworzonej zawartości.</value>
+  </data>
+  <data name="ProjectAssetsConsumedWithoutMSBuildProjectPath" xml:space="preserve">
+    <value>Zasoby są używane z projektu „{0}”, ale w elemencie „{1}” nie odnaleziono odpowiadającej ścieżki projektu MSBuild.</value>
+  </data>
+  <data name="UnexpectedFileType" xml:space="preserve">
+    <value>Nieoczekiwany typ pliku dla „{0}”. Typ to „{1}” oraz „{2}”.</value>
+  </data>
+  <data name="CannotInferTargetFrameworkIdentiferAndVersion" xml:space="preserve">
+    <value>Nie można wywnioskować elementu TargetFrameworkIdentifier i/lub TargetFrameworkVersion z elementu TargetFramework=„{0}”. Należy jawnie je określić.</value>
+  </data>
+  <data name="ContentItemDoesNotProvideOutputPath" xml:space="preserve">
+    <value>Element zawartości dla elementu „{0}” ustawia „{1}”, ale nie zapewnia „{2}” ani „{3}”.</value>
+  </data>
+  <data name="DuplicatePreprocessorToken" xml:space="preserve">
+    <value>Dla tokenu preprocesora „{0}” podano więcej niż jedną wartość. Wybieranie elementu „{1}” jako wartości.</value>
+  </data>
+  <data name="ErrorsOccurredWhenEmittingSatelliteAssembly" xml:space="preserve">
+    <value>Podczas emitowania zestawu satelickiego „{0}” wystąpiły błędy.</value>
+  </data>
+  <data name="UnableToFindResolvedPath" xml:space="preserve">
+    <value>Nie można odnaleźć rozpoznanej ścieżki dla elementu „{0}”.</value>
+  </data>
+  <data name="UnexpectedDependencyWithNoVersionNumber" xml:space="preserve">
+    <value>Nieoczekiwana zależność „{0}” bez numeru wersji.</value>
+  </data>
+  <data name="RuntimeIdentifierMustBeSetForNETFramework" xml:space="preserve">
+    <value>Element RuntimeIdentifier musi być ustawiony dla plików wykonywalnych programu .NETFramework. Rozważ element RuntimeIdentifier=win7-x86 lub RuntimeIdentifier=win7-x64.</value>
+  </data>
+  <data name="AssetPreprocessorMustBeConfigured" xml:space="preserve">
+    <value>Preprocesor zasobów musi być skonfigurowany przed przetworzeniem zasobów.</value>
+  </data>
+  <data name="InvalidNuGetVersionString" xml:space="preserve">
+    <value>Nieprawidłowy ciąg wersji NuGet: „{0}”.</value>
+  </data>
+  <data name="DOTNET1011" xml:space="preserve">
+    <value>Nie zainstalowano platformy: {0} w lokalizacji {1}</value>
+  </data>
+  <data name="DOTNET1012" xml:space="preserve">
+    <value>Nie określono katalogu zestawów referencyjnych. Aby ustawić jego lokalizację, użyj zmiennej środowiskowej DOTNET_REFERENCE_ASSEMBLIES_PATH.</value>
+  </data>
+  <data name="DOTNET1013" xml:space="preserve">
+    <value>Następujące zależności oznaczono za pomocą typu „platform”, jednak tylko jedna zależność może mieć ten typ: {0}</value>
+  </data>
+  <data name="DOTNET1014" xml:space="preserve">
+    <value>Nie można odczytać pliku blokady</value>
+  </data>
+  <data name="DOTNET1017" xml:space="preserve">
+    <value>Plik projektu nie istnieje „{0}”.</value>
+  </data>
+  <data name="NU1001" xml:space="preserve">
+    <value>Nie można rozpoznać zależności „{0}”.</value>
+  </data>
+  <data name="NU1002" xml:space="preserve">
+    <value>Zależność „{0}” w projekcie „{1}” nie obsługuje platformy „{2}”.</value>
+  </data>
+  <data name="NU1006" xml:space="preserve">
+    <value>{0}. Uruchom polecenie „dotnet restore”, aby wygenerować nowy plik zasobów.</value>
+  </data>
+  <data name="NU1007" xml:space="preserve">
+    <value>Określono zależność „{0}”, ale ostatecznie otrzymano zależność „{1}”.</value>
+  </data>
+  <data name="NU1008" xml:space="preserve">
+    <value>{0} to nieobsługiwana platforma.</value>
+  </data>
+  <data name="NU1009" xml:space="preserve">
+    <value>Oczekiwany plik zasobów nie istnieje. Uruchom polecenie „dotnet restore”, aby wygenerować nowy plik zasobów.</value>
+  </data>
+  <data name="NU1010" xml:space="preserve">
+    <value>Zmieniono typ zależności</value>
+  </data>
+  <data name="NU1011" xml:space="preserve">
+    <value>Element docelowy zależności „{0}” jest nieobsługiwany.</value>
+  </data>
+  <data name="NU1012" xml:space="preserve">
+    <value>Konflikt zależności. Element „{0}” oczekiwał elementu „{1}”, ale otrzymał element „{2}”</value>
+  </data>
+</root>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.pt-BR.resx
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.pt-BR.resx
@@ -1,0 +1,228 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="AtLeastOneTargetFrameworkMustBeSpecified" xml:space="preserve">
+    <value>É necessário especificar pelo menos uma estrutura de destino possível.</value>
+  </data>
+  <data name="NoCompatibleTargetFramework" xml:space="preserve">
+    <value>O projeto '{0}' não tem nenhuma estrutura de destino compatível com '{1}'.</value>
+  </data>
+  <data name="InvalidFrameworkName" xml:space="preserve">
+    <value>Nome de estrutura inválido: '{0}'.</value>
+  </data>
+  <data name="AssetsFileNotFound" xml:space="preserve">
+    <value>Arquivo de ativos '{0}' não encontrado. Execute uma restauração de pacote NuGet para gerar esse arquivo.</value>
+  </data>
+  <data name="AssetsFileMissingTarget" xml:space="preserve">
+    <value>O arquivo de ativos '{0}' não tem um destino para '{1}'. Certifique-se de ter restaurado esse projeto para TargetFramework='{2}' e RuntimeIdentifier='{3}'.</value>
+  </data>
+  <data name="AssetsFilePathNotRooted" xml:space="preserve">
+    <value>O caminho de arquivo de ativos '{0}' não tem raiz. Apenas caminhos completos têm suporte.</value>
+  </data>
+  <data name="CannotFindProjectInfo" xml:space="preserve">
+    <value>Não é possível localizar informações de projeto para '{0}'. Isso pode indicar uma referência de projeto ausente.</value>
+  </data>
+  <data name="ContentFileDoesNotContainExpectedParentPackageInformation" xml:space="preserve">
+    <value>O arquivo de conteúdo '{0}' não contém as informações de pacote pai esperadas.</value>
+  </data>
+  <data name="MissingItemMetadata" xml:space="preserve">
+    <value>Metadados '{0}' ausentes no item '{1}' '{2}'.</value>
+  </data>
+  <data name="UnrecognizedPreprocessorToken" xml:space="preserve">
+    <value>Token de pré-processador não reconhecido '{0}' no '{1}'.</value>
+  </data>
+  <data name="ContentPreproccessorParameterRequired" xml:space="preserve">
+    <value>A tarefa '{0}' deve receber um valor para o parâmetro '{1}' para consumir o conteúdo pré-processado.</value>
+  </data>
+  <data name="ProjectAssetsConsumedWithoutMSBuildProjectPath" xml:space="preserve">
+    <value>Os ativos são consumidos de um projeto '{0}', mas não foi encontrado nenhum caminho de projeto do MSBuild correspondente em '{1}'.</value>
+  </data>
+  <data name="UnexpectedFileType" xml:space="preserve">
+    <value>Tipo de arquivo inesperado para '{0}'. O tipo é '{1}' e '{2}'.</value>
+  </data>
+  <data name="CannotInferTargetFrameworkIdentiferAndVersion" xml:space="preserve">
+    <value>Não é possível inferir TargetFrameworkIdentifier e/ou TargetFrameworkVersion de TargetFramework='{0}'. Eles devem ser especificados explicitamente.</value>
+  </data>
+  <data name="ContentItemDoesNotProvideOutputPath" xml:space="preserve">
+    <value>O item de conteúdo para '{0}' define '{1}', mas não fornece '{2}' ou '{3}'.</value>
+  </data>
+  <data name="DuplicatePreprocessorToken" xml:space="preserve">
+    <value>O token de pré-processador '{0}' recebeu mais de um valor. Escolhendo '{1}' como o valor.</value>
+  </data>
+  <data name="ErrorsOccurredWhenEmittingSatelliteAssembly" xml:space="preserve">
+    <value>Ocorreram erros ao emitir o assembly satélite '{0}'.</value>
+  </data>
+  <data name="UnableToFindResolvedPath" xml:space="preserve">
+    <value>Não foi possível localizar o caminho resolvido para '{0}'.</value>
+  </data>
+  <data name="UnexpectedDependencyWithNoVersionNumber" xml:space="preserve">
+    <value>Dependência inesperada '{0}' sem número de versão.</value>
+  </data>
+  <data name="RuntimeIdentifierMustBeSetForNETFramework" xml:space="preserve">
+    <value>O RuntimeIdentifier deve ser definido para executáveis .NETFramework. Considere o RuntimeIdentifier=win7-x86 ou RuntimeIdentifier=win7-x64.</value>
+  </data>
+  <data name="AssetPreprocessorMustBeConfigured" xml:space="preserve">
+    <value>O pré-processador de ativos deve ser configurado antes de os ativos serem processados.</value>
+  </data>
+  <data name="InvalidNuGetVersionString" xml:space="preserve">
+    <value>Cadeia de caracteres de versão do NuGet inválida: '{0}'.</value>
+  </data>
+  <data name="DOTNET1011" xml:space="preserve">
+    <value>Estrutura não instalada: {0} em {1}</value>
+  </data>
+  <data name="DOTNET1012" xml:space="preserve">
+    <value>O diretório de assemblies de referência não foi especificado. É possível definir o local usando a variável de ambiente DOTNET_REFERENCE_ASSEMBLIES_PATH.</value>
+  </data>
+  <data name="DOTNET1013" xml:space="preserve">
+    <value>As seguintes dependências estão marcadas com o tipo 'platform'; no entanto, apenas uma dependência pode ter esse tipo: {0}</value>
+  </data>
+  <data name="DOTNET1014" xml:space="preserve">
+    <value>Falha ao ler arquivo de bloqueio</value>
+  </data>
+  <data name="DOTNET1017" xml:space="preserve">
+    <value>O arquivo de projeto não existe: '{0}'.</value>
+  </data>
+  <data name="NU1001" xml:space="preserve">
+    <value>A dependência '{0}' não pôde ser resolvida.</value>
+  </data>
+  <data name="NU1002" xml:space="preserve">
+    <value>A dependência '{0}' do projeto '{1}' não dá suporte à estrutura '{2}'.</value>
+  </data>
+  <data name="NU1006" xml:space="preserve">
+    <value>{0}. Execute 'dotnet restore' para gerar um novo arquivo de ativo.</value>
+  </data>
+  <data name="NU1007" xml:space="preserve">
+    <value>A dependência especificada era '{0}', mas terminou com '{1}'.</value>
+  </data>
+  <data name="NU1008" xml:space="preserve">
+    <value>{0} é uma estrutura sem suporte.</value>
+  </data>
+  <data name="NU1009" xml:space="preserve">
+    <value>O arquivo de ativo esperado não existe. Execute 'dotnet restore' para gerar um novo arquivo de ativo.</value>
+  </data>
+  <data name="NU1010" xml:space="preserve">
+    <value>O tipo de dependência foi alterado</value>
+  </data>
+  <data name="NU1011" xml:space="preserve">
+    <value>Não há suporte para o destino de dependência '{0}'.</value>
+  </data>
+  <data name="NU1012" xml:space="preserve">
+    <value>Conflito de dependência. '{0}' esperava '{1}', mas recebeu '{2\}'</value>
+  </data>
+</root>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.ru.resx
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.ru.resx
@@ -1,0 +1,228 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="AtLeastOneTargetFrameworkMustBeSpecified" xml:space="preserve">
+    <value>Необходимо указать хотя бы одну целевую платформу.</value>
+  </data>
+  <data name="NoCompatibleTargetFramework" xml:space="preserve">
+    <value>Проект "{0}" не содержит целевую платформу, совместимую с "{1}".</value>
+  </data>
+  <data name="InvalidFrameworkName" xml:space="preserve">
+    <value>Недопустимое имя платформы: "{0}".</value>
+  </data>
+  <data name="AssetsFileNotFound" xml:space="preserve">
+    <value>Файл ресурсов "{0}" не найден. Выполните восстановление пакета NuGet, чтобы создать этот файл.</value>
+  </data>
+  <data name="AssetsFileMissingTarget" xml:space="preserve">
+    <value>Файл ресурсов "{0}" не имеет целевого объекта для "{1}". Убедитесь, что выполнено восстановление этого проекта для TargetFramework="{2}" и RuntimeIdentifier="{3}".</value>
+  </data>
+  <data name="AssetsFilePathNotRooted" xml:space="preserve">
+    <value>Путь к файлу ресурсов "{0}" должен содержать корневой каталог. Поддерживаются только полные пути.</value>
+  </data>
+  <data name="CannotFindProjectInfo" xml:space="preserve">
+    <value>Невозможно найти сведения о проекте для "{0}". Возможно, отсутствует ссылка на проект.</value>
+  </data>
+  <data name="ContentFileDoesNotContainExpectedParentPackageInformation" xml:space="preserve">
+    <value>Файл содержимого "{0}" не содержит ожидаемые сведения о родительском пакете.</value>
+  </data>
+  <data name="MissingItemMetadata" xml:space="preserve">
+    <value>Отсутствуют метаданные "{0}" для элемента "{2}" "{1}".</value>
+  </data>
+  <data name="UnrecognizedPreprocessorToken" xml:space="preserve">
+    <value>Нераспознанный маркер препроцессора "{0}" в "{1}".</value>
+  </data>
+  <data name="ContentPreproccessorParameterRequired" xml:space="preserve">
+    <value>В задачу "{0}" необходимо передать значение для параметра "{1}" для использования предварительно обработанного содержимого.</value>
+  </data>
+  <data name="ProjectAssetsConsumedWithoutMSBuildProjectPath" xml:space="preserve">
+    <value>Ресурсы используются из проекта "{0}", однако соответствующий путь к проекту MSBuild не найден в "{1}".</value>
+  </data>
+  <data name="UnexpectedFileType" xml:space="preserve">
+    <value>Непредвиденный тип файла для "{0}". Тип является "{1}" и "{2}".</value>
+  </data>
+  <data name="CannotInferTargetFrameworkIdentiferAndVersion" xml:space="preserve">
+    <value>Невозможно определить TargetFrameworkIdentifier и (или) TargetFrameworkVersion на основе TargetFramework="{0}". Они должны быть указаны явно.</value>
+  </data>
+  <data name="ContentItemDoesNotProvideOutputPath" xml:space="preserve">
+    <value>Элемент содержимого для "{0}" задает "{1}", но не предоставляет "{2}" или "{3}".</value>
+  </data>
+  <data name="DuplicatePreprocessorToken" xml:space="preserve">
+    <value>Для маркера препроцессора "{0}" задано несколько значений. Выбор "{1}" в качестве значения.</value>
+  </data>
+  <data name="ErrorsOccurredWhenEmittingSatelliteAssembly" xml:space="preserve">
+    <value>При выпуске вспомогательной сборки "{0}" возникли ошибки.</value>
+  </data>
+  <data name="UnableToFindResolvedPath" xml:space="preserve">
+    <value>Не удается найти разрешенный путь для "{0}".</value>
+  </data>
+  <data name="UnexpectedDependencyWithNoVersionNumber" xml:space="preserve">
+    <value>Непредвиденная зависимость "{0}" без номера версии.</value>
+  </data>
+  <data name="RuntimeIdentifierMustBeSetForNETFramework" xml:space="preserve">
+    <value>RuntimeIdentifier необходимо задать для исполняемых файлов .NETFramework. Рекомендуется RuntimeIdentifier=win7-x86 или RuntimeIdentifier=win7-x64.</value>
+  </data>
+  <data name="AssetPreprocessorMustBeConfigured" xml:space="preserve">
+    <value>Препроцессор ресурсов необходимо настроить перед обработкой ресурсов.</value>
+  </data>
+  <data name="InvalidNuGetVersionString" xml:space="preserve">
+    <value>Недопустимая строка версии Invalid NuGet: "{0}".</value>
+  </data>
+  <data name="DOTNET1011" xml:space="preserve">
+    <value>Платформа не установлена: {0} в {1}</value>
+  </data>
+  <data name="DOTNET1012" xml:space="preserve">
+    <value>Не указан каталог ссылочной сборки. Вы можете задать это расположение с помощью переменной среды DOTNET_REFERENCE_ASSEMBLIES_PATH.</value>
+  </data>
+  <data name="DOTNET1013" xml:space="preserve">
+    <value>Следующие зависимости помечены с типом "platform", но всего одна зависимость может иметь этот тип: {0}.</value>
+  </data>
+  <data name="DOTNET1014" xml:space="preserve">
+    <value>Не удалось считать файл блокировки.</value>
+  </data>
+  <data name="DOTNET1017" xml:space="preserve">
+    <value>Файл проекта не существует: "{0}".</value>
+  </data>
+  <data name="NU1001" xml:space="preserve">
+    <value>Не удалось разрешить зависимость "{0}".</value>
+  </data>
+  <data name="NU1002" xml:space="preserve">
+    <value>Зависимость "{0}" в проекте "{1}" не поддерживает платформу "{2}".</value>
+  </data>
+  <data name="NU1006" xml:space="preserve">
+    <value>{0}. Выполните команду "dotnet restore" для создания нового файла активов.</value>
+  </data>
+  <data name="NU1007" xml:space="preserve">
+    <value>Была указана зависимость "{0}", но в конце стоит "{1}".</value>
+  </data>
+  <data name="NU1008" xml:space="preserve">
+    <value>Платформа {0} не поддерживается.</value>
+  </data>
+  <data name="NU1009" xml:space="preserve">
+    <value>Ожидаемый файл активов не существует. Выполните команду "dotnet restore" для создания нового файла активов.</value>
+  </data>
+  <data name="NU1010" xml:space="preserve">
+    <value>Тип зависимости был изменен.</value>
+  </data>
+  <data name="NU1011" xml:space="preserve">
+    <value>Целевой объект зависимости "{0}" не поддерживается.</value>
+  </data>
+  <data name="NU1012" xml:space="preserve">
+    <value>Конфликт зависимостей. "{0}" ожидал "{1}", но получил "{2}".</value>
+  </data>
+</root>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.tr.resx
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.tr.resx
@@ -1,0 +1,228 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="AtLeastOneTargetFrameworkMustBeSpecified" xml:space="preserve">
+    <value>En az bir olası hedef çerçeve belirtilmelidir.</value>
+  </data>
+  <data name="NoCompatibleTargetFramework" xml:space="preserve">
+    <value>'{0}' projesinde '{1}' ile uyumlu bir hedef çerçeve yok.</value>
+  </data>
+  <data name="InvalidFrameworkName" xml:space="preserve">
+    <value>Geçersiz çerçeve adı: '{0}'.</value>
+  </data>
+  <data name="AssetsFileNotFound" xml:space="preserve">
+    <value>'{0}' varlık dosyası bulunamadı. Bu dosyayı oluşturmak için, NuGet paketi geri yükleme işlemi gerçekleştirin.</value>
+  </data>
+  <data name="AssetsFileMissingTarget" xml:space="preserve">
+    <value>'{0}' varlık dosyasında '{1}' için hedef yok. TargetFramework='{2}' ve RuntimeIdentifier='{3}' için bu projeyi geri yüklediğinizden emin olun.</value>
+  </data>
+  <data name="AssetsFilePathNotRooted" xml:space="preserve">
+    <value>'{0}' varlık dosya yolunun kökü belirtilmemiş. Yalnızca tam yollar desteklenir.</value>
+  </data>
+  <data name="CannotFindProjectInfo" xml:space="preserve">
+    <value>'{0}' için proje bilgisi bulunamıyor. Bu durum, eksik bir proje başvurusu olduğunu gösteriyor olabilie.</value>
+  </data>
+  <data name="ContentFileDoesNotContainExpectedParentPackageInformation" xml:space="preserve">
+    <value>'{0}' içerik dosyası beklenen üst paket bilgilerini içermiyor.</value>
+  </data>
+  <data name="MissingItemMetadata" xml:space="preserve">
+    <value>'{1}' öğesi '{2}' üzerinde '{0}' meta verileri eksik.</value>
+  </data>
+  <data name="UnrecognizedPreprocessorToken" xml:space="preserve">
+    <value>'{1}' içinde tanınmayan ön işlemci belirteci: '{0}'.</value>
+  </data>
+  <data name="ContentPreproccessorParameterRequired" xml:space="preserve">
+    <value>Önceden işlenen içeriği kullanabilmesi için '{0}' görevine, '{1}' parametresine ilişkin bir değer verilmelidir.</value>
+  </data>
+  <data name="ProjectAssetsConsumedWithoutMSBuildProjectPath" xml:space="preserve">
+    <value>'{0}' projesindeki varlıklar kullanılıyor, ancak '{1}' içinde karşılık gelen bir MSBuild projesi bulunamadı.</value>
+  </data>
+  <data name="UnexpectedFileType" xml:space="preserve">
+    <value>'{0}' için beklenmeyen dosya türü. Tür, hem '{1}' hem de '{2}'.</value>
+  </data>
+  <data name="CannotInferTargetFrameworkIdentiferAndVersion" xml:space="preserve">
+    <value>TargetFrameworkIdentifier ve/veya TargetFrameworkVersion, TargetFramework='{0}' içinden çıkarsanamıyor. Bunlar açıkça belirtilmelidir.</value>
+  </data>
+  <data name="ContentItemDoesNotProvideOutputPath" xml:space="preserve">
+    <value>'{0}' için içerik öğesi, '{1}' değerini ayarlıyor ancak '{2}' veya '{3}' sağlamıyor.</value>
+  </data>
+  <data name="DuplicatePreprocessorToken" xml:space="preserve">
+    <value>'{0}' ön işlemci belirtecine birden fazla değer verildi. Değer olarak '{1}' seçiliyor.</value>
+  </data>
+  <data name="ErrorsOccurredWhenEmittingSatelliteAssembly" xml:space="preserve">
+    <value>'{0}' uydu bütünleştirilmiş kodu yayılırken hatalar oluştu.</value>
+  </data>
+  <data name="UnableToFindResolvedPath" xml:space="preserve">
+    <value>'{0}' için çözümlenmiş yol bulunamıyor.</value>
+  </data>
+  <data name="UnexpectedDependencyWithNoVersionNumber" xml:space="preserve">
+    <value>Sürüm numarası olmayan, beklenmeyen bağımlılık: '{0}'.</value>
+  </data>
+  <data name="RuntimeIdentifierMustBeSetForNETFramework" xml:space="preserve">
+    <value>.NETFramework yürütülebilir dosyaları için RuntimeIdentifier ayarlanmalıdır. RuntimeIdentifier=win7-x86 veya RuntimeIdentifier=win7-x64 ayarlanabilir.</value>
+  </data>
+  <data name="AssetPreprocessorMustBeConfigured" xml:space="preserve">
+    <value>Varlıkların işlenebilmesi için varlık ön işlemcisi yapılandırılmalıdır.</value>
+  </data>
+  <data name="InvalidNuGetVersionString" xml:space="preserve">
+    <value>Geçersiz NuGet sürüm dizesi: '{0}'.</value>
+  </data>
+  <data name="DOTNET1011" xml:space="preserve">
+    <value>Çerçeve yüklenmedi: {1} içinde {0}</value>
+  </data>
+  <data name="DOTNET1012" xml:space="preserve">
+    <value>Başvuru bütünleştirilmiş kodları dizini belirtilmedi. DOTNET_REFERENCE_ASSEMBLIES_PATH ortam değişkenini kullanarak konumu ayarlayabilirsiniz.</value>
+  </data>
+  <data name="DOTNET1013" xml:space="preserve">
+    <value>Aşağıdaki bağımlılıklar 'platform' türüyle işaretlendi ancak yalnızca bir bağımlılık bu türe sahip olabilir: {0}</value>
+  </data>
+  <data name="DOTNET1014" xml:space="preserve">
+    <value>Kilit dosyası okunamadı</value>
+  </data>
+  <data name="DOTNET1017" xml:space="preserve">
+    <value>Proje dosyası yok: '{0}'.</value>
+  </data>
+  <data name="NU1001" xml:space="preserve">
+    <value>'{0}' bağımlılığı çözülemedi.</value>
+  </data>
+  <data name="NU1002" xml:space="preserve">
+    <value>'{1}' projesi içindeki '{0}' bağımlılığı '{2}' çerçevesini desteklemiyor.</value>
+  </data>
+  <data name="NU1006" xml:space="preserve">
+    <value>{0}. Yeni bir varlık dosyası oluşturmak için 'dotnet restore' çalıştırın.</value>
+  </data>
+  <data name="NU1007" xml:space="preserve">
+    <value>Belirtilen bağımlılık '{0}' ancak '{1}' alındı.</value>
+  </data>
+  <data name="NU1008" xml:space="preserve">
+    <value>{0} çerçevesi desteklenmiyor.</value>
+  </data>
+  <data name="NU1009" xml:space="preserve">
+    <value>Beklenen varlık dosyası yok.Yeni bir varlık dosyası oluşturmak için 'dotnet restore' çalıştırın.</value>
+  </data>
+  <data name="NU1010" xml:space="preserve">
+    <value>Bağımlılık türü değiştirildi</value>
+  </data>
+  <data name="NU1011" xml:space="preserve">
+    <value>Bağımlılık hedefi ('{0}') desteklenmiyor.</value>
+  </data>
+  <data name="NU1012" xml:space="preserve">
+    <value>Bağımlılık çakışması. '{0}' '{1}' bekliyordu ancak '{2}' alındı</value>
+  </data>
+</root>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.zh-Hans.resx
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.zh-Hans.resx
@@ -1,0 +1,228 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="AtLeastOneTargetFrameworkMustBeSpecified" xml:space="preserve">
+    <value>必须指定至少一个可能的目标框架。</value>
+  </data>
+  <data name="NoCompatibleTargetFramework" xml:space="preserve">
+    <value>项目“{0}”没有与“{1}”兼容的目标框架。</value>
+  </data>
+  <data name="InvalidFrameworkName" xml:space="preserve">
+    <value>无效的框架名称:“{0}”。</value>
+  </data>
+  <data name="AssetsFileNotFound" xml:space="preserve">
+    <value>找不到资产文件“{0}”。运行 NuGet 程序包还原以生成此文件。</value>
+  </data>
+  <data name="AssetsFileMissingTarget" xml:space="preserve">
+    <value>资产文件“{0}”没有“{1}”的目标。确保已针对 TargetFramework=“{2}”和 RuntimeIdentifier=“{3}”还原此项目。</value>
+  </data>
+  <data name="AssetsFilePathNotRooted" xml:space="preserve">
+    <value>资产文件路径“{0}”不是根路径。仅支持完整路径。</value>
+  </data>
+  <data name="CannotFindProjectInfo" xml:space="preserve">
+    <value>找不到“{0}”的项目信息。这可以指示缺少一个项目引用。</value>
+  </data>
+  <data name="ContentFileDoesNotContainExpectedParentPackageInformation" xml:space="preserve">
+    <value>内容文件“{0}”不包含预期的父包信息。</value>
+  </data>
+  <data name="MissingItemMetadata" xml:space="preserve">
+    <value>在“{1}”项“{2}”上缺少“{0}”元数据。</value>
+  </data>
+  <data name="UnrecognizedPreprocessorToken" xml:space="preserve">
+    <value>“{1}”中无法识别的预处理器标记“{0}”。</value>
+  </data>
+  <data name="ContentPreproccessorParameterRequired" xml:space="preserve">
+    <value>必须向“{0}”任务提供参数“{1}”的值以便使用预处理的内容。</value>
+  </data>
+  <data name="ProjectAssetsConsumedWithoutMSBuildProjectPath" xml:space="preserve">
+    <value>从项目“{0}”消耗资产，但在“{1}”中找不到相应的 MSBuild 项目路径。</value>
+  </data>
+  <data name="UnexpectedFileType" xml:space="preserve">
+    <value>“{0}”的意外文件类型。类型是“{1}”和“{2}”。</value>
+  </data>
+  <data name="CannotInferTargetFrameworkIdentiferAndVersion" xml:space="preserve">
+    <value>无法从 TargetFramework=“{0}”推断 TargetFrameworkIdentifier 和/或 TargetFrameworkVersion。必须显式指定这两项。</value>
+  </data>
+  <data name="ContentItemDoesNotProvideOutputPath" xml:space="preserve">
+    <value>“{0}”的内容项设置“{1}”，但不提供“{2}”或“{3}”。</value>
+  </data>
+  <data name="DuplicatePreprocessorToken" xml:space="preserve">
+    <value>已向预处理器标记“{0}”提供多个值。选择“{1}”作为值。</value>
+  </data>
+  <data name="ErrorsOccurredWhenEmittingSatelliteAssembly" xml:space="preserve">
+    <value>发出附属程序集“{0}”时出错。</value>
+  </data>
+  <data name="UnableToFindResolvedPath" xml:space="preserve">
+    <value>找不到“{0}”的已解析路径。</value>
+  </data>
+  <data name="UnexpectedDependencyWithNoVersionNumber" xml:space="preserve">
+    <value>不具有版本号的意外依赖项“{0}”。</value>
+  </data>
+  <data name="RuntimeIdentifierMustBeSetForNETFramework" xml:space="preserve">
+    <value>必须为 .NETFramework 可执行文件设置 RuntimeIdentifier。请考虑 RuntimeIdentifier=win7-x86 或 RuntimeIdentifier=win7-x64。</value>
+  </data>
+  <data name="AssetPreprocessorMustBeConfigured" xml:space="preserve">
+    <value>必须在处理资产之前配置资产预处理器。</value>
+  </data>
+  <data name="InvalidNuGetVersionString" xml:space="preserve">
+    <value>无效的 NuGet 版本字符串:“{0}”。</value>
+  </data>
+  <data name="DOTNET1011" xml:space="preserve">
+    <value>未安装的框架: {1} 中的 {0}</value>
+  </data>
+  <data name="DOTNET1012" xml:space="preserve">
+    <value>未指定引用程序集目录。可以使用 DOTNET_REFERENCE_ASSEMBLIES_PATH 环境变量设置位置。</value>
+  </data>
+  <data name="DOTNET1013" xml:space="preserve">
+    <value>以下依赖项使用类型“platform”标记，但只有一个依赖项可以具有此类型: {0}</value>
+  </data>
+  <data name="DOTNET1014" xml:space="preserve">
+    <value>未能读取锁定文件</value>
+  </data>
+  <data name="DOTNET1017" xml:space="preserve">
+    <value>项目文件不存在“{0}”。</value>
+  </data>
+  <data name="NU1001" xml:space="preserve">
+    <value>无法解析依赖项“{0}”。</value>
+  </data>
+  <data name="NU1002" xml:space="preserve">
+    <value>项目“{1}”中的依赖项“{0}”不支持框架“{2}”。</value>
+  </data>
+  <data name="NU1006" xml:space="preserve">
+    <value>{0}。请运行“dotnet restore”以生成新的资产文件。</value>
+  </data>
+  <data name="NU1007" xml:space="preserve">
+    <value>指定的依赖项为“{0}”，但以“'{1}”结尾。</value>
+  </data>
+  <data name="NU1008" xml:space="preserve">
+    <value>{0} 是不受支持的框架。</value>
+  </data>
+  <data name="NU1009" xml:space="preserve">
+    <value>预期资产文件不存在。请运行“dotnet restore”以生成新的资产文件。</value>
+  </data>
+  <data name="NU1010" xml:space="preserve">
+    <value>依赖项类型已更改</value>
+  </data>
+  <data name="NU1011" xml:space="preserve">
+    <value>不支持依赖项目标“{0}”。</value>
+  </data>
+  <data name="NU1012" xml:space="preserve">
+    <value>依赖项冲突。“{0}”预期“'{1}”，但接收到“{2}”</value>
+  </data>
+</root>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.zh-Hant.resx
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.zh-Hant.resx
@@ -1,0 +1,228 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="AtLeastOneTargetFrameworkMustBeSpecified" xml:space="preserve">
+    <value>必須指定至少一個可能的目標 Framework。</value>
+  </data>
+  <data name="NoCompatibleTargetFramework" xml:space="preserve">
+    <value>專案 '{0}' 沒有與 '{1}' 相容的目標 Framework。</value>
+  </data>
+  <data name="InvalidFrameworkName" xml:space="preserve">
+    <value>無效的架構名稱: '{0}'。</value>
+  </data>
+  <data name="AssetsFileNotFound" xml:space="preserve">
+    <value>找不到資產檔案 '{0}'。執行 NuGet 套件還原以產生此檔案。</value>
+  </data>
+  <data name="AssetsFileMissingTarget" xml:space="preserve">
+    <value>資產檔案 '{0}' 沒有 '{1}' 的目標。請確定您已還原此專案 (TargetFramework='{2}' 且 RuntimeIdentifier='{3}')。</value>
+  </data>
+  <data name="AssetsFilePathNotRooted" xml:space="preserve">
+    <value>資產檔案路徑 '{0}' 不是根目錄。僅支援完整路徑。</value>
+  </data>
+  <data name="CannotFindProjectInfo" xml:space="preserve">
+    <value>找不到 '{0}' 的專案資訊。這可能表示遺漏專案參考。</value>
+  </data>
+  <data name="ContentFileDoesNotContainExpectedParentPackageInformation" xml:space="preserve">
+    <value>內容檔案 '{0}' 未包含必要的父套件資訊。</value>
+  </data>
+  <data name="MissingItemMetadata" xml:space="preserve">
+    <value>'{1}' 項目 '{2}' 上遺漏 '{0}' 中繼資料。</value>
+  </data>
+  <data name="UnrecognizedPreprocessorToken" xml:space="preserve">
+    <value>'{1}' 中的前置處理器 Token '{0}' 無法辨識。</value>
+  </data>
+  <data name="ContentPreproccessorParameterRequired" xml:space="preserve">
+    <value>必須為 '{0}' 工作指定參數 '{1}' 的值，才能取用前置處理過的內容。</value>
+  </data>
+  <data name="ProjectAssetsConsumedWithoutMSBuildProjectPath" xml:space="preserve">
+    <value>已從專案 '{0}' 取用資產，但在 '{1}' 中找不到對應的 MSBuild 專案路徑。</value>
+  </data>
+  <data name="UnexpectedFileType" xml:space="preserve">
+    <value>'{0}' 屬於未預期的檔案類型類型同時為 '{1}' 和 '{2}'。</value>
+  </data>
+  <data name="CannotInferTargetFrameworkIdentiferAndVersion" xml:space="preserve">
+    <value>無法從 TargetFramework='{0}' 推斷 TargetFrameworkIdentifier 及/或 TargetFrameworkVersion。您必須明確加以指定。</value>
+  </data>
+  <data name="ContentItemDoesNotProvideOutputPath" xml:space="preserve">
+    <value>'{0}' 的內容項目設定 '{1}'，但未提供 '{2}' 或 '{3}'。</value>
+  </data>
+  <data name="DuplicatePreprocessorToken" xml:space="preserve">
+    <value>已為前置處理器 Token '{0}' 指定多個值。正在選擇 '{1}' 作為值。</value>
+  </data>
+  <data name="ErrorsOccurredWhenEmittingSatelliteAssembly" xml:space="preserve">
+    <value>發出附屬組件 '{0}' 時發生錯誤。</value>
+  </data>
+  <data name="UnableToFindResolvedPath" xml:space="preserve">
+    <value>找不到 '{0}' 的解析路徑。</value>
+  </data>
+  <data name="UnexpectedDependencyWithNoVersionNumber" xml:space="preserve">
+    <value>未預期的相依性 '{0}'，沒有版本號碼。</value>
+  </data>
+  <data name="RuntimeIdentifierMustBeSetForNETFramework" xml:space="preserve">
+    <value>必須為 .NETFramework 可執行檔設定 RuntimeIdentifier。請考慮使用 RuntimeIdentifier=win7-x86 或 RuntimeIdentifier=win7-x64。</value>
+  </data>
+  <data name="AssetPreprocessorMustBeConfigured" xml:space="preserve">
+    <value>必須設定資產前置處理器，才能處理資產。</value>
+  </data>
+  <data name="InvalidNuGetVersionString" xml:space="preserve">
+    <value>無效的 NuGet 版本字串: '{0}'。</value>
+  </data>
+  <data name="DOTNET1011" xml:space="preserve">
+    <value>未安裝架構: {0} (在 {1} 中)</value>
+  </data>
+  <data name="DOTNET1012" xml:space="preserve">
+    <value>未指定參考組件目錄。您可使用 DOTNET_REFERENCE_ASSEMBLIES_PATH 環境變數設定位置。</value>
+  </data>
+  <data name="DOTNET1013" xml:space="preserve">
+    <value>下列相依性以類型 'platform' 標記，但只有一個相依性可具備此類型: {0}</value>
+  </data>
+  <data name="DOTNET1014" xml:space="preserve">
+    <value>無法讀取鎖定檔案</value>
+  </data>
+  <data name="DOTNET1017" xml:space="preserve">
+    <value>專案檔不存在 '{0}'。</value>
+  </data>
+  <data name="NU1001" xml:space="preserve">
+    <value>無法解析相依性 '{0}'。</value>
+  </data>
+  <data name="NU1002" xml:space="preserve">
+    <value>專案 '{1}' 中的相依性 '{0}' 不支援架構 '{2}'。</value>
+  </data>
+  <data name="NU1006" xml:space="preserve">
+    <value>{0}。請執行 'dotnet restore' 產生新的資產檔案。</value>
+  </data>
+  <data name="NU1007" xml:space="preserve">
+    <value>指定的相依性為 '{0}' 但最終為 '{1}'。</value>
+  </data>
+  <data name="NU1008" xml:space="preserve">
+    <value>{0} 為不受支援的架構。</value>
+  </data>
+  <data name="NU1009" xml:space="preserve">
+    <value>所需的資產檔案不存在。請執行 'dotnet restore' 產生新的資產檔案。</value>
+  </data>
+  <data name="NU1010" xml:space="preserve">
+    <value>相依性類型已變更</value>
+  </data>
+  <data name="NU1011" xml:space="preserve">
+    <value>相依性目標 '{0}' 不受支援。</value>
+  </data>
+  <data name="NU1012" xml:space="preserve">
+    <value>相依性衝突。'{0}' 需要 '{1}' 但收到 '{2}'</value>
+  </data>
+</root>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.de.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.resx">
     <body>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.xlf
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.xlf
@@ -93,59 +93,59 @@
       </trans-unit>
       <trans-unit id="DOTNET1011">
         <source>Framework not installed: {0} in {1}</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="DOTNET1012">
         <source>The reference assemblies directory was not specified. You can set the location using the DOTNET_REFERENCE_ASSEMBLIES_PATH environment variable.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="DOTNET1013">
         <source>The following dependencies are marked with type 'platform', however only one dependency can have this type: {0}</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="DOTNET1014">
         <source>Failed to read lock file</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="DOTNET1017">
         <source>Project file does not exist '{0}'.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="NU1001">
         <source>The dependency '{0}' could not be resolved.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="NU1002">
         <source>The dependency '{0}' in project '{1}' does not support framework '{2}'.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="NU1006">
         <source>{0}. Please run 'dotnet restore' to generate a new asset file.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="NU1007">
         <source>Dependency specified was '{0}' but ended up with '{1}'.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="NU1008">
         <source>{0} is an unsupported framework.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="NU1009">
         <source>The expected asset file does not exist. Please run 'dotnet restore' to generate a new asset file.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="NU1010">
         <source>The dependency type was changed</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="NU1011">
         <source>The dependency target '{0}' is unsupported.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="NU1012">
         <source>Dependency conflict. '{0}' expected '{1}' but received '{2}'</source>
-        <note></note>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/VsixV3/Microsoft.Net.Sdk.swr
+++ b/src/VsixV3/Microsoft.Net.Sdk.swr
@@ -59,6 +59,45 @@ folder "InstallDir:MSBuild\Sdks\Microsoft.NET.Sdk\tools\net46"
   file source="$(OutputPath)PackagesLayout\tools\net46\System.Security.Cryptography.Algorithms.dll"
   file source="$(OutputPath)PackagesLayout\tools\net46\System.Security.Cryptography.Primitives.dll"
   file source="$(OutputPath)PackagesLayout\tools\net46\System.Threading.Thread.dll"
+  
+folder "InstallDir:MSBuild\Sdks\Microsoft.NET.Sdk\tools\net46\cs"  
+  file source="$(OutputPath)PackagesLayout\tools\net46\cs\Microsoft.NET.Build.Tasks.resources.dll"
+
+folder "InstallDir:MSBuild\Sdks\Microsoft.NET.Sdk\tools\net46\de"  
+  file source="$(OutputPath)PackagesLayout\tools\net46\de\Microsoft.NET.Build.Tasks.resources.dll"
+
+folder "InstallDir:MSBuild\Sdks\Microsoft.NET.Sdk\tools\net46\es"  
+  file source="$(OutputPath)PackagesLayout\tools\net46\es\Microsoft.NET.Build.Tasks.resources.dll"  
+
+folder "InstallDir:MSBuild\Sdks\Microsoft.NET.Sdk\tools\net46\fr"  
+  file source="$(OutputPath)PackagesLayout\tools\net46\fr\Microsoft.NET.Build.Tasks.resources.dll"
+  
+folder "InstallDir:MSBuild\Sdks\Microsoft.NET.Sdk\tools\net46\it"  
+  file source="$(OutputPath)PackagesLayout\tools\net46\it\Microsoft.NET.Build.Tasks.resources.dll"
+
+folder "InstallDir:MSBuild\Sdks\Microsoft.NET.Sdk\tools\net46\ja"  
+  file source="$(OutputPath)PackagesLayout\tools\net46\ja\Microsoft.NET.Build.Tasks.resources.dll"
+
+folder "InstallDir:MSBuild\Sdks\Microsoft.NET.Sdk\tools\net46\ko"  
+  file source="$(OutputPath)PackagesLayout\tools\net46\ko\Microsoft.NET.Build.Tasks.resources.dll"
+
+folder "InstallDir:MSBuild\Sdks\Microsoft.NET.Sdk\tools\net46\pl"  
+  file source="$(OutputPath)PackagesLayout\tools\net46\pl\Microsoft.NET.Build.Tasks.resources.dll"
+
+folder "InstallDir:MSBuild\Sdks\Microsoft.NET.Sdk\tools\net46\pt-BR"  
+  file source="$(OutputPath)PackagesLayout\tools\net46\pt-BR\Microsoft.NET.Build.Tasks.resources.dll"
+
+folder "InstallDir:MSBuild\Sdks\Microsoft.NET.Sdk\tools\net46\ru"  
+  file source="$(OutputPath)PackagesLayout\tools\net46\ru\Microsoft.NET.Build.Tasks.resources.dll"
+
+folder "InstallDir:MSBuild\Sdks\Microsoft.NET.Sdk\tools\net46\tr"  
+  file source="$(OutputPath)PackagesLayout\tools\net46\tr\Microsoft.NET.Build.Tasks.resources.dll"
+
+folder "InstallDir:MSBuild\Sdks\Microsoft.NET.Sdk\tools\net46\zh-Hans"  
+  file source="$(OutputPath)PackagesLayout\tools\net46\zh-Hans\Microsoft.NET.Build.Tasks.resources.dll"
+  
+folder "InstallDir:MSBuild\Sdks\Microsoft.NET.Sdk\tools\net46\zh-Hant"  
+  file source="$(OutputPath)PackagesLayout\tools\net46\zh-Hant\Microsoft.NET.Build.Tasks.resources.dll"
 
 folder "InstallDir:MSBuild\Sdks\Microsoft.NET.Sdk\tools\netcoreapp1.0"
   file source="$(OutputPath)PackagesLayout\tools\netcoreapp1.0\Microsoft.DotNet.PlatformAbstractions.dll"
@@ -80,3 +119,42 @@ folder "InstallDir:MSBuild\Sdks\Microsoft.NET.Sdk\tools\netcoreapp1.0"
   file source="$(OutputPath)PackagesLayout\tools\netcoreapp1.0\NuGet.RuntimeModel.dll"
   file source="$(OutputPath)PackagesLayout\tools\netcoreapp1.0\NuGet.Versioning.dll"
   file source="$(OutputPath)PackagesLayout\tools\netcoreapp1.0\System.Runtime.Serialization.Primitives.dll"
+
+folder "InstallDir:MSBuild\Sdks\Microsoft.NET.Sdk\tools\netcoreapp1.0\cs"  
+  file source="$(OutputPath)PackagesLayout\tools\netcoreapp1.0\cs\Microsoft.NET.Build.Tasks.resources.dll"
+
+folder "InstallDir:MSBuild\Sdks\Microsoft.NET.Sdk\tools\netcoreapp1.0\de"  
+  file source="$(OutputPath)PackagesLayout\tools\netcoreapp1.0\de\Microsoft.NET.Build.Tasks.resources.dll"
+
+folder "InstallDir:MSBuild\Sdks\Microsoft.NET.Sdk\tools\netcoreapp1.0\es"  
+  file source="$(OutputPath)PackagesLayout\tools\netcoreapp1.0\es\Microsoft.NET.Build.Tasks.resources.dll"  
+
+folder "InstallDir:MSBuild\Sdks\Microsoft.NET.Sdk\tools\netcoreapp1.0\fr"  
+  file source="$(OutputPath)PackagesLayout\tools\netcoreapp1.0\fr\Microsoft.NET.Build.Tasks.resources.dll"
+  
+folder "InstallDir:MSBuild\Sdks\Microsoft.NET.Sdk\tools\netcoreapp1.0\it"  
+  file source="$(OutputPath)PackagesLayout\tools\netcoreapp1.0\it\Microsoft.NET.Build.Tasks.resources.dll"
+
+folder "InstallDir:MSBuild\Sdks\Microsoft.NET.Sdk\tools\netcoreapp1.0\ja"  
+  file source="$(OutputPath)PackagesLayout\tools\netcoreapp1.0\ja\Microsoft.NET.Build.Tasks.resources.dll"
+
+folder "InstallDir:MSBuild\Sdks\Microsoft.NET.Sdk\tools\netcoreapp1.0\ko"  
+  file source="$(OutputPath)PackagesLayout\tools\netcoreapp1.0\ko\Microsoft.NET.Build.Tasks.resources.dll"
+
+folder "InstallDir:MSBuild\Sdks\Microsoft.NET.Sdk\tools\netcoreapp1.0\pl"  
+  file source="$(OutputPath)PackagesLayout\tools\netcoreapp1.0\pl\Microsoft.NET.Build.Tasks.resources.dll"
+
+folder "InstallDir:MSBuild\Sdks\Microsoft.NET.Sdk\tools\netcoreapp1.0\pt-BR"  
+  file source="$(OutputPath)PackagesLayout\tools\netcoreapp1.0\pt-BR\Microsoft.NET.Build.Tasks.resources.dll"
+
+folder "InstallDir:MSBuild\Sdks\Microsoft.NET.Sdk\tools\netcoreapp1.0\ru"  
+  file source="$(OutputPath)PackagesLayout\tools\netcoreapp1.0\ru\Microsoft.NET.Build.Tasks.resources.dll"
+
+folder "InstallDir:MSBuild\Sdks\Microsoft.NET.Sdk\tools\netcoreapp1.0\tr"  
+  file source="$(OutputPath)PackagesLayout\tools\netcoreapp1.0\tr\Microsoft.NET.Build.Tasks.resources.dll"
+
+folder "InstallDir:MSBuild\Sdks\Microsoft.NET.Sdk\tools\netcoreapp1.0\zh-Hans"  
+  file source="$(OutputPath)PackagesLayout\tools\netcoreapp1.0\zh-Hans\Microsoft.NET.Build.Tasks.resources.dll"
+  
+folder "InstallDir:MSBuild\Sdks\Microsoft.NET.Sdk\tools\netcoreapp1.0\zh-Hant"  
+  file source="$(OutputPath)PackagesLayout\tools\netcoreapp1.0\zh-Hant\Microsoft.NET.Build.Tasks.resources.dll"

--- a/test/Microsoft.NET.Build.Tests/Microsoft.NET.Build.Tests.csproj
+++ b/test/Microsoft.NET.Build.Tests/Microsoft.NET.Build.Tests.csproj
@@ -1,7 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'Common.props'))\Common.props" />
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
     <ProjectGuid>{EC640B7E-332E-40A2-BB6E-5B7EC788F315}</ProjectGuid>
@@ -13,6 +12,7 @@
     <OutDir>$(OutDir)Tests\</OutDir>
     <GenerateDependencyFile>false</GenerateDependencyFile>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <EnableDefaultItems>false</EnableDefaultItems>
     <NonShipping>true</NonShipping>
     <StartAction>Program</StartAction>
     <StartProgram>$(DotNetTool).exe</StartProgram>
@@ -21,10 +21,6 @@
     <DebugEngines>{2E36F1D4-B23C-435D-AB41-18E608940038}</DebugEngines>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>$(SdkStage0Version)</Version>
-      <PrivateAssets>All</PrivateAssets>
-    </PackageReference>
     <PackageReference Include="Microsoft.DotNet.Cli.Utils">
       <Version>$(DotNetCliUtilsVersion)</Version>
     </PackageReference>
@@ -49,5 +45,4 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="..\..\build\Targets\Signing.Imports.targets" />
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/test/Microsoft.NET.Pack.Tests/Microsoft.NET.Pack.Tests.csproj
+++ b/test/Microsoft.NET.Pack.Tests/Microsoft.NET.Pack.Tests.csproj
@@ -1,7 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'Common.props'))\Common.props" />
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
     <ProjectGuid>{588516D7-96AD-4447-A1EB-244D737A3C87}</ProjectGuid>
@@ -13,6 +12,7 @@
     <OutDir>$(OutDir)Tests\</OutDir>
     <GenerateDependencyFile>false</GenerateDependencyFile>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <EnableDefaultItems>false</EnableDefaultItems>
     <NonShipping>true</NonShipping>
     <StartAction>Program</StartAction>
     <StartProgram>$(DotNetTool).exe</StartProgram>
@@ -21,10 +21,6 @@
     <DebugEngines>{2E36F1D4-B23C-435D-AB41-18E608940038}</DebugEngines>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>$(SdkStage0Version)</Version>
-      <PrivateAssets>All</PrivateAssets>
-    </PackageReference>
     <PackageReference Include="Microsoft.DotNet.Cli.Utils">
       <Version>$(DotNetCliUtilsVersion)</Version>
     </PackageReference>
@@ -47,5 +43,4 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="..\..\build\Targets\Signing.Imports.targets" />
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/test/Microsoft.NET.Publish.Tests/Microsoft.NET.Publish.Tests.csproj
+++ b/test/Microsoft.NET.Publish.Tests/Microsoft.NET.Publish.Tests.csproj
@@ -1,7 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'Common.props'))\Common.props" />
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
     <ProjectGuid>{7F31F2C6-6395-400C-ABE3-5A1CEF208096}</ProjectGuid>
@@ -13,6 +12,7 @@
     <OutDir>$(OutDir)Tests\</OutDir>
     <GenerateDependencyFile>false</GenerateDependencyFile>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <EnableDefaultItems>false</EnableDefaultItems>
     <NonShipping>true</NonShipping>
     <StartAction>Program</StartAction>
     <StartProgram>$(DotNetTool).exe</StartProgram>
@@ -21,10 +21,6 @@
     <DebugEngines>{2E36F1D4-B23C-435D-AB41-18E608940038}</DebugEngines>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>$(SdkStage0Version)</Version>
-      <PrivateAssets>All</PrivateAssets>
-    </PackageReference>
     <PackageReference Include="Microsoft.DotNet.Cli.Utils">
       <Version>$(DotNetCliUtilsVersion)</Version>
     </PackageReference>
@@ -46,5 +42,4 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="..\..\build\Targets\Signing.Imports.targets" />
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/test/Microsoft.NET.TestFramework/Microsoft.NET.TestFramework.csproj
+++ b/test/Microsoft.NET.TestFramework/Microsoft.NET.TestFramework.csproj
@@ -1,7 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'Common.props'))\Common.props" />
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
     <ProjectGuid>{A33548A0-F3B0-40C3-8C4D-AD2F00596CD6}</ProjectGuid>
@@ -16,13 +15,10 @@
     <GenerateDependencyFile>false</GenerateDependencyFile>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <NonShipping>true</NonShipping>
+    <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>$(SdkStage0Version)</Version>
-      <PrivateAssets>All</PrivateAssets>
-    </PackageReference>
     <PackageReference Include="Microsoft.DotNet.Cli.Utils">
       <Version>$(DotNetCliUtilsVersion)</Version>
     </PackageReference>
@@ -50,8 +46,8 @@
   </Target>
 
   <Import Project="..\..\build\Targets\Signing.Imports.targets"/>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Target Name="AfterBuild">
+
+  <Target Name="CustomAfterBuild" AfterTargets="Build">
     <ItemGroup>
       <CopyLocalAssembly Include="Microsoft.DotNet.Cli.Utils">
         <Version>$(DotNetCliUtilsVersion)</Version>


### PR DESCRIPTION
Build and deploy satellites from translations

The satellites are still not being picked up correctly by core MSBuild, but they work with desktop MSBuild. I am still investigating but I believe this is due to https://github.com/Microsoft/msbuild/issues/1476.

Change the target SatelliteDllsProjectOutputGroup to SatelliteDllsProjectOutputGroupWithFinalOutputPath, which will include the resources from the final output path rather than the intermediate path and hence will include the signed satellite assemblies

**Customer scenario**
Build messages from the SDK will not be localized without this change

**Bugs this fixes:**
SDK portion of [VSO 279745](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/279745)
(The project system portion was already completed before entering escrow)

**Workarounds, if any**
None

**Risk**
Low

**Performance impact**
None for English. Only the required small impact of loading satellite assembly for non-English languages.

**Is this a regression from a previous update?**
No. This was feature work approved to be done by RC3.

**How was this bug found?**
N/A. This was known work that wasn't done until now.

@srivatsn @dotnet/project-system 