### PR TITLE
Stop removing items that were included in the project file

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.DefaultItems.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.DefaultItems.props
@@ -17,11 +17,11 @@ Copyright (c) .NET Foundation. All rights reserved.
 
 
   <ItemGroup Condition=" '$(EnableDefaultItems)' == 'true' ">
-    <Compile Include="**/*$(DefaultLanguageSourceExtension)" Exclude="$(DefaultExcludesInProjectFolder)" Condition=" '$(EnableDefaultCompileItems)' == 'true' " />
-    <EmbeddedResource Include="**/*.resx" Exclude="$(DefaultExcludesInProjectFolder)" Condition=" '$(EnableDefaultEmbeddedResourceItems)' == 'true' " />
+    <Compile Include="**/*$(DefaultLanguageSourceExtension)" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" Condition=" '$(EnableDefaultCompileItems)' == 'true' " />
+    <EmbeddedResource Include="**/*.resx" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" Condition=" '$(EnableDefaultEmbeddedResourceItems)' == 'true' " />
   </ItemGroup>
   <ItemGroup Condition=" '$(EnableDefaultItems)' == 'true' And '$(EnableDefaultNoneItems)' == 'true' ">
-    <None Include="**/*" Exclude="$(DefaultExcludesInProjectFolder)" />
+    <None Include="**/*" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
     <None Remove="**/*$(DefaultLanguageSourceExtension)" Condition=" '$(EnableDefaultCompileItems)' == 'true' "/>
     <None Remove="**/*.resx" Condition=" '$(EnableDefaultEmbeddedResourceItems)' == 'true' "/>
   </ItemGroup>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.DefaultItems.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.DefaultItems.targets
@@ -42,6 +42,9 @@ Copyright (c) .NET Foundation. All rights reserved.
          relative path outside the project folder (for example "..\Shared\Shared.cs").  So be sure only to apply it to items
          that are in the project folder. -->
     <DefaultItemExcludesInProjectFolder>$(DefaultItemExcludesInProjectFolder);**/.*/**</DefaultItemExcludesInProjectFolder>
+
+    <!-- TODO: Verify why this was originally added and whether we really need it -->
+    <DefaultItemExcludes>$(DefaultItemExcludes);packages/**</DefaultItemExcludes>
     
   </PropertyGroup>
   

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.DefaultItems.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.DefaultItems.targets
@@ -23,33 +23,26 @@ Copyright (c) .NET Foundation. All rights reserved.
   </PropertyGroup>
 
   <PropertyGroup>
+    
+    <!-- Set DefaultItemExcludes property for items that should be excluded from the default Compile, etc items.
+         This is in the .targets because it needs to come after the final BaseOutputPath has been evaluated. -->
+    
     <!-- bin folder, by default -->
-    <DefaultRemoves>$(DefaultRemoves);$(BaseOutputPath)/**</DefaultRemoves>
+    <DefaultItemExcludes>$(DefaultItemExcludes);$(BaseOutputPath)/**</DefaultItemExcludes>
     <!-- obj folder, by default -->
-    <DefaultRemoves>$(DefaultRemoves);$(BaseIntermediateOutputPath)/**</DefaultRemoves>
+    <DefaultItemExcludes>$(DefaultItemExcludes);$(BaseIntermediateOutputPath)/**</DefaultItemExcludes>
 
     <!-- Various files that should generally always be ignored -->
-    <DefaultRemoves>$(DefaultRemoves);**/*.user</DefaultRemoves>
-    <DefaultRemoves>$(DefaultRemoves);**/*.*proj</DefaultRemoves>
-    <DefaultRemoves>$(DefaultRemoves);**/*.sln</DefaultRemoves>
-    <DefaultRemoves>$(DefaultRemoves);**/*.vssscc</DefaultRemoves>
+    <DefaultItemExcludes>$(DefaultItemExcludes);**/*.user</DefaultItemExcludes>
+    <DefaultItemExcludes>$(DefaultItemExcludes);**/*.*proj</DefaultItemExcludes>
+    <DefaultItemExcludes>$(DefaultItemExcludes);**/*.sln</DefaultItemExcludes>
+    <DefaultItemExcludes>$(DefaultItemExcludes);**/*.vssscc</DefaultItemExcludes>
     
-    <!-- This pattern is supposed to ignore folders such as .git and .vs, but it would also match items included with a relative path
-         outside the project folder (for example "..\Shared\Shared.cs").  So instead of using it to remove from the Compile,
-         EmbeddedResource, and Content items in this .targets file, it will be used in the Exclude attribute for the default
-         patterns which include files in these items (which happens in Microsoft.NET.Sdk.DefaultItems.props). -->
-    <DefaultExcludesInProjectFolder>$(DefaultExcludesInProjectFolder);**/.*/**</DefaultExcludesInProjectFolder>
-
-    <!-- TODO: Verify why this was originally added and whether we really need it -->
-    <DefaultRemoves>$(DefaultRemoves);packages/**</DefaultRemoves>
+    <!-- WARNING: This pattern is there to ignore folders such as .git and .vs, but it will also match items included with a
+         relative path outside the project folder (for example "..\Shared\Shared.cs").  So be sure only to apply it to items
+         that are in the project folder. -->
+    <DefaultItemExcludesInProjectFolder>$(DefaultItemExcludesInProjectFolder);**/.*/**</DefaultItemExcludesInProjectFolder>
     
   </PropertyGroup>
   
-  <ItemGroup Condition="'$(DisableDefaultRemoves)' != 'true'">
-    <Compile Remove="$(DefaultRemoves)" />
-    <EmbeddedResource Remove="$(DefaultRemoves)" />
-    <None Remove="$(DefaultRemoves)" />
-    <Content Remove="$(DefaultRemoves)" />
-  </ItemGroup>
-
 </Project>

--- a/test/Microsoft.NET.Build.Tests/GivenThereAreDefaultItems.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThereAreDefaultItems.cs
@@ -24,7 +24,7 @@ namespace Microsoft.NET.Build.Tests
         {
             Action<GetValuesCommand> setup = getValuesCommand =>
             {
-                foreach (string folder in new[] { "bin", "obj" })
+                foreach (string folder in new[] { "bin", "obj", "packages" })
                 {
                     WriteFile(Path.Combine(getValuesCommand.ProjectRootPath, folder, "source.cs"),
                         "!InvalidCSharp!");

--- a/test/Microsoft.NET.Build.Tests/GivenThereAreDefaultItems.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThereAreDefaultItems.cs
@@ -24,7 +24,7 @@ namespace Microsoft.NET.Build.Tests
         {
             Action<GetValuesCommand> setup = getValuesCommand =>
             {
-                foreach (string folder in new[] { "bin", "obj", "packages" })
+                foreach (string folder in new[] { "bin", "obj" })
                 {
                     WriteFile(Path.Combine(getValuesCommand.ProjectRootPath, folder, "source.cs"),
                         "!InvalidCSharp!");

--- a/test/Microsoft.NET.Build.Tests/GivenThereAreDefaultItems.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThereAreDefaultItems.cs
@@ -169,6 +169,44 @@ namespace Microsoft.NET.Build.Tests
         }
 
         [Fact]
+        public void It_allows_files_in_the_obj_folder_to_be_explicitly_included()
+        {
+            Action<GetValuesCommand> setup = getValuesCommand =>
+            {
+                WriteFile(Path.Combine(getValuesCommand.ProjectRootPath, "Code", "Class1.cs"),
+                    "public class Class1 {}");
+                WriteFile(Path.Combine(getValuesCommand.ProjectRootPath, "obj", "Class2.cs"),
+                    "public class Class2 {}");
+                WriteFile(Path.Combine(getValuesCommand.ProjectRootPath, "obj", "Excluded.cs"),
+                    "!InvalidCSharp!");
+            };
+
+            Action<XDocument> projectChanges = project =>
+            {
+                var ns = project.Root.Name.Namespace;
+
+                XElement itemGroup = new XElement(ns + "ItemGroup");
+                project.Root.Add(itemGroup);
+                itemGroup.Add(new XElement(ns + "Compile", new XAttribute("Include", "obj\\Class2.cs")));
+            };
+
+            var compileItems = GivenThatWeWantToBuildALibrary.GetValuesFromTestLibrary(_testAssetsManager, "Compile", setup, projectChanges: projectChanges);
+
+            RemoveGeneratedCompileItems(compileItems);
+
+            var expectedItems = new[]
+            {
+                "Helper.cs",
+                @"Code\Class1.cs",
+                @"obj\Class2.cs"
+            }
+            .Select(item => item.Replace('\\', Path.DirectorySeparatorChar))
+            .ToArray();
+
+            compileItems.Should().BeEquivalentTo(expectedItems);
+        }
+
+        [Fact]
         public void It_allows_a_CSharp_file_to_be_used_as_an_EmbeddedResource()
         {
             Action<GetValuesCommand> setup = getValuesCommand =>


### PR DESCRIPTION
Instead, only apply the patterns that used to be called DefaultRemoves to the items that are implicitly included.  If someone adds an include for a file to their project file, we should respect that.

Fixes #623
Fixes #588

The `DefaultRemoves` property was originally used so that when you had wildcard includes in your project file, you wouldn't have to specifically exclude the `bin`, `obj`, etc. folders.  When we switched to implicit includes, I left it in with the idea that it would help you have a cleaner project file if you did want to explicitly see a wildcard include in your project, and it would help protect you from accidentally including items that you "shouldn't" from the output folders.

However, it's become apparent that it comes with two huge downsides:
 - If you actually want items that would match the patterns in `DefaultRemoves`, you will include them in the project file, and that won't work, and you will have absolutely no idea why and there's no good way to debug / figure it out
 - If you do manage to figure out why the items aren't being included, there's no good way to override the behavior to let you include a file.  You have to turn off the `DefaultRemoves` entirely, which then means your implicit globs will suddenly pick up a bunch of files that they shouldn't, unless you jump through even more hoops in your project file.

This PR makes it so that if you put an item in your project file, it will be respected.  The items that will be included implicitly remain the same as before.

This PR also takes the opportunity to remove the `packages` folder from the list of folders that the default includes don't apply to.  It's unclear why this was originally [added in the CLI](https://github.com/dotnet/cli/commit/94bafb17).  @davidfowl [had this to say about it](https://github.com/aspnet/websdk/pull/88/files/621bb3d2a625ceab3b2123b1a11dd69357eb79bd):

> It was likely because of a mix of older packages folder (nuget v2) and xproj. Though that should only have been at the solution level...

Removing this exclusion will make default items in projects with code or other assets in a "packages" folder work as people will expect.

This change will need to be made together with a change to the Web SDK, as now it will be its responsibility to remove these items from its default includes.  I will also submit a PR for that.
