### PR TITLE
Set AppDesignerFolder property

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.CSharp.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.CSharp.targets
@@ -12,6 +12,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+    <AppDesignerFolder Condition="'$(AppDesignerFolder)' == ''">Properties</AppDesignerFolder>
   </PropertyGroup>
   <PropertyGroup Condition="'$(DisableImplicitConfigurationDefines)' != 'true'">
     <ImplicitConfigurationDefine>$(Configuration.ToUpperInvariant())</ImplicitConfigurationDefine>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.VisualBasic.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.VisualBasic.targets
@@ -12,6 +12,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+    <AppDesignerFolder Condition="'$(AppDesignerFolder)' == ''">My Project</AppDesignerFolder>
   </PropertyGroup>
   <PropertyGroup>
     <DefineConstants>$(DefineConstants),$(ImplicitFrameworkDefine)</DefineConstants>


### PR DESCRIPTION
The Web SDK uses the `AppDesignerFolder` property to [exclude launchSettings.json files from publish](https://github.com/aspnet/websdk/blob/75184cba7a7a59c580caf60a74fac247a29d807b/src/Web/Microsoft.NET.Sdk.Web.ProjectSystem.Targets/netstandard1.0/Microsoft.NET.Sdk.Web.ProjectSystem.props#L28):

```xml
    <!-- Set CopyToPublishDirectory to Never for items under AppDesignerFolder ("Properties", by default) to avoid publishing launchSettings.json -->
    <Content Update="$(AppDesignerFolder)/**" CopyToPublishDirectory="Never" Condition="'$(AppDesignerFolder)' != ''"/>
```

However, the `AppDesignerFolder` property is currently only set in the designtime targets, which means that during a normal build it's not set.  This change adds default values for the property to the .NET SDK

Fixes (half of) #631.  The other half of that bug should be fixed by changes going into the Web SDK.

@srivatsn @davkean @nguerrera @natidea for review.

Escrow template:

#### Scenario

Publish a ASP.NET Core project.  The Properties\launchSettings.json file should not be included in the published output

#### Bug

#631 

#### Workarounds

Add the following to a PropertyGroup in your project:

```xml
<AppDesignerFolder>Properties</AppDesignerFolder>
```

#### Risk

Low - This is adding one additional property definition which was already part of the DesignTime targets

#### Performance Impact

Low - One additional property in MSBuild evaluation

#### Regression Analysis

This was part of the implicit item includes changes.  Probably there are not tests covering this scenario, as the json file will only be created when you modify the debug properties of a project in VS
