### PR TITLE
Update SDK projects to use MSBuild Sdk attribute, and hence the version of the Sdk that ships with the CLI or VS

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/Microsoft.NET.Build.Tasks.UnitTests.csproj
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/Microsoft.NET.Build.Tasks.UnitTests.csproj
@@ -1,14 +1,7 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'Common.props'))\Common.props" />
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
-    <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
-    <ProjectGuid>{6A698C1D-F604-4295-B6FC-7FC726F9FE5F}</ProjectGuid>
-    <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>Microsoft.NET.Build.Tasks.UnitTests</RootNamespace>
-    <AssemblyName>Microsoft.NET.Build.Tasks.UnitTests</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetFramework>netstandard1.3</TargetFramework>
     <PackageTargetFallback>dotnet5.4;portable-net451+win8</PackageTargetFallback>
@@ -23,10 +16,6 @@
     <DebugEngines>{2E36F1D4-B23C-435D-AB41-18E608940038}</DebugEngines>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>$(SdkStage0Version)</Version>
-      <PrivateAssets>All</PrivateAssets>
-    </PackageReference>
     <PackageReference Include="NuGet.ProjectModel">
       <Version>$(NuGetVersion)</Version>
     </PackageReference>
@@ -47,62 +36,42 @@
     </PackageReference>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="GivenAProjectContext.cs" />
-    <Compile Include="GivenACompilationOptionsConverter.cs" />
-    <Compile Include="GivenAProduceContentsAssetsTask.cs" />
-    <Compile Include="GivenAResolvePackageDependenciesTask.cs" />
-    <Compile Include="LockFileSnippets.cs" />
-    <Compile Include="Mocks\MockContentAssetPreprocessor.cs" />
-    <Compile Include="Mocks\MockPackageResolver.cs" />
-    <Compile Include="Mocks\MockTaskItem.cs" />
-    <Compile Include="GivenThatWeWantToGetDependenciesViaDesignTimeBuild.cs" />
-    <Compile Include="GivenAPublishAssembliesResolver.cs" />
-    <Compile Include="GivenADependencyContextBuilder.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="Constants.cs" />
-    <Compile Include="TestLockFiles.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="all.asset.types.portable.deps.json">
+    <None Update="all.asset.types.portable.deps.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Include="all.asset.types.osx.deps.json">
+    <None Update="all.asset.types.osx.deps.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Include="dotnet.new.resources.deps.json">
+    <None Update="dotnet.new.resources.deps.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Include="dotnet.new.deps.json">
+    <None Update="dotnet.new.deps.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Include="LockFiles\all.asset.types.project.lock.json">
+    <None Update="LockFiles\all.asset.types.project.lock.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Include="LockFiles\dependencies.withgraphs.project.lock.json">
+    <None Update="LockFiles\dependencies.withgraphs.project.lock.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Include="LockFiles\dotnet.new.project.lock.json">
+    <None Update="LockFiles\dotnet.new.project.lock.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Include="simple.dependencies.compilerOptions.deps.json">
+    <None Update="simple.dependencies.compilerOptions.deps.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Include="simple.dependencies.deps.json">
+    <None Update="simple.dependencies.deps.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Include="LockFiles\simple.dependencies.project.lock.json">
+    <None Update="LockFiles\simple.dependencies.project.lock.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\Microsoft.NET.Build.Tasks\Microsoft.NET.Build.Tasks.csproj">
-      <Project>{df7d2697-b3b4-45c2-8297-27245f528a99}</Project>
-      <Name>Microsoft.NET.Build.Tasks</Name>
-    </ProjectReference>
+    <ProjectReference Include="..\Microsoft.NET.Build.Tasks\Microsoft.NET.Build.Tasks.csproj" />
   </ItemGroup>
   <Import Project="..\..\..\build\Targets\Signing.Imports.targets" />
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Target Name="AfterBuild">
+  <Target Name="MyAfterBuild" AfterTargets="AfterBuild">
     <ItemGroup>
       <CopyLocalAssembly Include="Microsoft.Build.Framework">
         <Version>$(MsBuildPackagesVersion)</Version>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Microsoft.NET.Build.Tasks.csproj
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Microsoft.NET.Build.Tasks.csproj
@@ -1,23 +1,14 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'Common.props'))\Common.props" />
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
-    <ProjectGuid>{DF7D2697-B3B4-45C2-8297-27245F528A99}</ProjectGuid>
-    <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>Microsoft.NET.Build.Tasks</RootNamespace>
-    <AssemblyName>Microsoft.NET.Build.Tasks</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetFramework>netstandard1.3</TargetFramework>
     <GenerateDependencyFile>false</GenerateDependencyFile>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>$(SdkStage0Version)</Version>
-    </PackageReference>
     <PackageReference Include="NuGet.ProjectModel">
       <Version>$(NuGetVersion)</Version>
     </PackageReference>
@@ -35,127 +26,23 @@
     </PackageReference>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="CheckForDuplicateItems.cs" />
-    <Compile Include="CheckForImplicitPackageReferenceOverrides.cs" />
-    <Compile Include="DiagnosticMessageSeverity.cs" />
-    <Compile Include="DiagnosticsHelper.cs" />
-    <Compile Include="NETSdkError.cs" />
-    <Compile Include="LockFileLookup.cs" />
-    <Compile Include="FrameworkReferenceResolver.cs" />
-    <Compile Include="BuildErrorException.cs" />
-    <Compile Include="ReferenceInfo.cs" />
-    <Compile Include="Resources\Strings.Designer.cs">
+    <Compile Update="Resources\Strings.Designer.cs">
       <DesignTime>True</DesignTime>
       <AutoGen>True</AutoGen>
       <DependentUpon>Strings.resx</DependentUpon>
     </Compile>
-    <Compile Include="TaskBase.cs" />
-    <Compile Include="PackageReferenceConverter.cs" />
-    <Compile Include="NugetContentAssetPreprocessor.cs" />
-    <Compile Include="IContentAssetPreprocessor.cs" />
-    <Compile Include="ProduceContentAssets.cs" />
-    <Compile Include="GetNearestTargetFramework.cs" />
-    <Compile Include="ITaskItemExtensions.cs" />
-    <Compile Include="CompilationOptionsConverter.cs" />
-    <Compile Include="NuGetUtils.cs" />
-    <Compile Include="GetAssemblyVersion.cs" />
-    <Compile Include="GenerateSatelliteAssemblies.cs" />
-    <Compile Include="ResourceAssemblyInfo.cs" />
-    <Compile Include="SingleProjectInfo.cs" />
-    <Compile Include="ProjectContext.cs" />
-    <Compile Include="NuGetPackageResolver.cs" />
-    <Compile Include="IPackageResolver.cs" />
-    <Compile Include="ResolvedFile.cs" />
-    <Compile Include="PublishAssembliesResolver.cs" />
-    <Compile Include="LockFileExtensions.cs" />
-    <Compile Include="ResolvePublishAssemblies.cs" />
-    <Compile Include="DependencyType.cs" />
-    <Compile Include="PreprocessPackageDependenciesDesignTime.cs" />
-    <Compile Include="RuntimeConfig.cs" />
-    <Compile Include="RuntimeConfigFramework.cs" />
-    <Compile Include="RuntimeOptions.cs" />
-    <None Include="buildCrossTargeting\Microsoft.NET.Sdk.targets">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="build\Microsoft.NET.DefaultOutputPaths.targets">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="build\Microsoft.NET.RuntimeIdentifierInference.targets">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="build\Microsoft.NET.DisableStandardFrameworkResolution.targets">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="build\Microsoft.NET.PreserveCompilationContext.targets">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="build\Microsoft.NET.GenerateAssemblyInfo.targets">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="build\Microsoft.NET.Sdk.BeforeCommonCrossTargeting.targets">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="build\Microsoft.NET.Sdk.DefaultItems.props">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="build\Microsoft.NET.Sdk.DefaultItems.targets">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="build\Microsoft.NET.Sdk.VisualBasic.props">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="build\Microsoft.NET.Sdk.CSharp.props">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="build\Microsoft.NET.Sdk.VisualBasic.targets">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="build\Microsoft.NET.Sdk.BeforeCommon.targets">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="build\Microsoft.NET.Sdk.Common.targets">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="build\Microsoft.NET.Sdk.CSharp.targets">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="build\Microsoft.NET.Sdk.targets">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="build\Microsoft.NET.Sdk.props">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="build\Microsoft.NET.Publish.targets">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="build\Microsoft.NET.TargetFrameworkInference.targets">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="build\Microsoft.PackageDependencyResolution.targets">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="sdk\Sdk.props">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="sdk\Sdk.targets">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <Compile Include="DependencyContextBuilder.cs" />
-    <Compile Include="GenerateDepsFile.cs" />
-    <Compile Include="GenerateRuntimeConfigurationFiles.cs" />
-    <Compile Include="LockFileCache.cs" />
-    <Compile Include="FileGroup.cs" />
-    <Compile Include="MetadataKeys.cs" />
-    <Compile Include="ResolvePackageDependencies.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
+
+    <None Update="buildCrossTargeting\**" CopyToOutputDirectory="PreserveNewest" />
+    <None Update="build\**" CopyToOutputDirectory="PreserveNewest" />
+    <None Update="sdk\**" CopyToOutputDirectory="PreserveNewest" />
+
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="Resources\Strings.resx">
+    <EmbeddedResource Update="Resources\Strings.resx">
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Strings.Designer.cs</LastGenOutput>
       <CustomToolNamespace>Microsoft.NET.Build.Tasks</CustomToolNamespace>
     </EmbeddedResource>
   </ItemGroup>
   <Import Project="..\..\..\build\Targets\Signing.Imports.targets" />
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/test/Microsoft.NET.Build.Tests/Microsoft.NET.Build.Tests.csproj
+++ b/test/Microsoft.NET.Build.Tests/Microsoft.NET.Build.Tests.csproj
@@ -1,11 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'Common.props'))\Common.props" />
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
-    <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
-    <ProjectGuid>{EC640B7E-332E-40A2-BB6E-5B7EC788F315}</ProjectGuid>
-    <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetFramework>netstandard1.6</TargetFramework>
@@ -21,10 +16,6 @@
     <DebugEngines>{2E36F1D4-B23C-435D-AB41-18E608940038}</DebugEngines>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>$(SdkStage0Version)</Version>
-      <PrivateAssets>All</PrivateAssets>
-    </PackageReference>
     <PackageReference Include="Microsoft.DotNet.Cli.Utils">
       <Version>$(DotNetCliUtilsVersion)</Version>
     </PackageReference>
@@ -39,15 +30,7 @@
     </PackageReference>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="**\*.cs" Exclude="$(GlobalExclude)" />
-    <EmbeddedResource Include="**\*.resx" Exclude="$(GlobalExclude)" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\Microsoft.NET.TestFramework\Microsoft.NET.TestFramework.csproj">
-      <Project>{a33548a0-f3b0-40c3-8c4d-ad2f00596cd6}</Project>
-      <Name>Microsoft.NET.TestFramework</Name>
-    </ProjectReference>
+    <ProjectReference Include="..\Microsoft.NET.TestFramework\Microsoft.NET.TestFramework.csproj" />
   </ItemGroup>
   <Import Project="..\..\build\Targets\Signing.Imports.targets" />
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/test/Microsoft.NET.Pack.Tests/Microsoft.NET.Pack.Tests.csproj
+++ b/test/Microsoft.NET.Pack.Tests/Microsoft.NET.Pack.Tests.csproj
@@ -1,11 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'Common.props'))\Common.props" />
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
-    <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
-    <ProjectGuid>{588516D7-96AD-4447-A1EB-244D737A3C87}</ProjectGuid>
-    <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetFramework>netstandard1.6</TargetFramework>
@@ -21,10 +16,6 @@
     <DebugEngines>{2E36F1D4-B23C-435D-AB41-18E608940038}</DebugEngines>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>$(SdkStage0Version)</Version>
-      <PrivateAssets>All</PrivateAssets>
-    </PackageReference>
     <PackageReference Include="Microsoft.DotNet.Cli.Utils">
       <Version>$(DotNetCliUtilsVersion)</Version>
     </PackageReference>
@@ -36,16 +27,7 @@
     </PackageReference>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="GivenThatWeWantToPackASimpleLibrary.cs" />
-    <Compile Include="GivenThatWeWantToPackACrossTargetedLibrary.cs" />
-    <EmbeddedResource Include="**\*.resx" Exclude="$(GlobalExclude)" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\Microsoft.NET.TestFramework\Microsoft.NET.TestFramework.csproj">
-      <Project>{a33548a0-f3b0-40c3-8c4d-ad2f00596cd6}</Project>
-      <Name>Microsoft.NET.TestFramework</Name>
-    </ProjectReference>
+    <ProjectReference Include="..\Microsoft.NET.TestFramework\Microsoft.NET.TestFramework.csproj" />
   </ItemGroup>
   <Import Project="..\..\build\Targets\Signing.Imports.targets" />
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/test/Microsoft.NET.Publish.Tests/Microsoft.NET.Publish.Tests.csproj
+++ b/test/Microsoft.NET.Publish.Tests/Microsoft.NET.Publish.Tests.csproj
@@ -1,11 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'Common.props'))\Common.props" />
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
-    <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
-    <ProjectGuid>{7F31F2C6-6395-400C-ABE3-5A1CEF208096}</ProjectGuid>
-    <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetFramework>netstandard1.6</TargetFramework>
@@ -21,10 +16,6 @@
     <DebugEngines>{2E36F1D4-B23C-435D-AB41-18E608940038}</DebugEngines>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>$(SdkStage0Version)</Version>
-      <PrivateAssets>All</PrivateAssets>
-    </PackageReference>
     <PackageReference Include="Microsoft.DotNet.Cli.Utils">
       <Version>$(DotNetCliUtilsVersion)</Version>
     </PackageReference>
@@ -36,15 +27,7 @@
     </PackageReference>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="**\*.cs" Exclude="$(GlobalExclude)" />
-    <EmbeddedResource Include="**\*.resx" Exclude="$(GlobalExclude)" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\Microsoft.NET.TestFramework\Microsoft.NET.TestFramework.csproj">
-      <Project>{a33548a0-f3b0-40c3-8c4d-ad2f00596cd6}</Project>
-      <Name>Microsoft.NET.TestFramework</Name>
-    </ProjectReference>
+    <ProjectReference Include="..\Microsoft.NET.TestFramework\Microsoft.NET.TestFramework.csproj" />
   </ItemGroup>
   <Import Project="..\..\build\Targets\Signing.Imports.targets" />
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/test/Microsoft.NET.TestFramework/Microsoft.NET.TestFramework.csproj
+++ b/test/Microsoft.NET.TestFramework/Microsoft.NET.TestFramework.csproj
@@ -1,14 +1,7 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'Common.props'))\Common.props" />
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
-    <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
-    <ProjectGuid>{A33548A0-F3B0-40C3-8C4D-AD2F00596CD6}</ProjectGuid>
-    <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>Microsoft.NET.TestFramework</RootNamespace>
-    <AssemblyName>Microsoft.NET.TestFramework</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetFramework>netstandard1.6</TargetFramework>
     <PackageTargetFallback>dotnet5.4;portable-net451+win8</PackageTargetFallback>
@@ -19,10 +12,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>$(SdkStage0Version)</Version>
-      <PrivateAssets>All</PrivateAssets>
-    </PackageReference>
     <PackageReference Include="Microsoft.DotNet.Cli.Utils">
       <Version>$(DotNetCliUtilsVersion)</Version>
     </PackageReference>
@@ -37,11 +26,6 @@
     </PackageReference>
   </ItemGroup>
 
-  <ItemGroup>
-    <Compile Include="**\*.cs" Exclude="$(GlobalExclude)" />
-    <EmbeddedResource Include="**\*.resx" Exclude="$(GlobalExclude)" />
-  </ItemGroup>
-
   <Target Name="GenerateVersionFile"
           BeforeTargets="Build">
     <WriteLinesToFile File="$(RepositoryRootDirectory)\TestAssets\buildVersion.txt"
@@ -50,8 +34,7 @@
   </Target>
 
   <Import Project="..\..\build\Targets\Signing.Imports.targets"/>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Target Name="AfterBuild">
+  <Target Name="MyAfterBuild" AfterTargets="AfterBuild">
     <ItemGroup>
       <CopyLocalAssembly Include="Microsoft.DotNet.Cli.Utils">
         <Version>$(DotNetCliUtilsVersion)</Version>


### PR DESCRIPTION
In addition to cleaning our project files up and dogfooding a recent version of the SDK, this fixes the design-time build and hence intellisense in VS for me on the latest builds of VS.