### PR TITLE
Append TargetFramework to the OutputPath only if we were able to succ…

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.TargetFrameworkInference.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.TargetFrameworkInference.targets
@@ -90,7 +90,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     Append $(TargetFramework) directory to output and intermediate paths to prevent bin clashes between
     targets.
    -->
-  <PropertyGroup>
+  <PropertyGroup Condition="'$(_UnsupportedTargetFrameworkError)' != 'true'">
     <IntermediateOutputPath>$(IntermediateOutputPath)$(TargetFramework)\</IntermediateOutputPath>
     <OutputPath>$(OutputPath)$(TargetFramework)\</OutputPath>
   </PropertyGroup>


### PR DESCRIPTION
…essfully parse the TargetFramework

**Customer scenario**

Visual Studio crashes if you add multiple target frameworks to `TargetFramework` element. This is a very common mistake when user tries to change their project from single targeting to multi-targeting project, but forgets to change the property name to `TargetFrameworks`.

**Bugs this fixes:**

Fixes https://github.com/dotnet/sdk/issues/657

**Workarounds, if any**

None.

**Risk**

Minimal, we are just adding a check to avoid appending TargetFramework to output path when the TargetFramework inference fails.

**Performance impact**

None

**Is this a regression from a previous update?**

No.

**Root cause analysis:**

We probably did not test this code path.

**How was the bug found?**

Dogfooding.