### PR TITLE
Remove simple name references matching references that come from NuGet packages

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.PackageDependencyResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.PackageDependencyResolution.targets
@@ -304,6 +304,10 @@ Copyright (c) .NET Foundation. All rights reserved.
   <Target Name="ResolveLockFileReferences"
           DependsOnTargets="_ComputeLockFileReferences;_ComputeLockFileFrameworks">
     <ItemGroup>
+      <!-- Remove simple name references if we're directly providing a reference assembly to the compiler. For example,
+           consider a project with an Reference Include="System", and some NuGet package is providing System.dll -->
+      <Reference Remove="%(ResolvedCompileFileDefinitions.FileName)" />
+      
       <!-- Add the references we computed -->
       <Reference Include="@(ResolvedCompileFileDefinitions)" />
       <Reference Include="@(ResolvedFrameworkAssemblies)" />

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildADesktopLibrary.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildADesktopLibrary.cs
@@ -6,6 +6,7 @@ using Microsoft.NET.TestFramework.ProjectConstruction;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Xml.Linq;
 using Xunit;
@@ -17,6 +18,11 @@ namespace Microsoft.NET.Build.Tests
         [Fact]
         public void It_can_use_HttpClient_and_exchange_the_type_with_a_NETStandard_library()
         {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return;
+            }
+
             var netStandardLibrary = new TestProject()
             {
                 Name = "NETStandardLibrary",

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildADesktopLibrary.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildADesktopLibrary.cs
@@ -1,0 +1,82 @@
+﻿using FluentAssertions;
+using Microsoft.NET.TestFramework;
+using Microsoft.NET.TestFramework.Assertions;
+using Microsoft.NET.TestFramework.Commands;
+using Microsoft.NET.TestFramework.ProjectConstruction;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Xml.Linq;
+using Xunit;
+
+namespace Microsoft.NET.Build.Tests
+{
+    public class GivenThatWeWantToBuildADesktopLibrary : SdkTest
+    {
+        [Fact]
+        public void It_can_use_HttpClient_and_exchange_the_type_with_a_NETStandard_library()
+        {
+            var netStandardLibrary = new TestProject()
+            {
+                Name = "NETStandardLibrary",
+                TargetFrameworks = "netstandard1.4",
+                IsSdkProject = true
+            };
+
+            netStandardLibrary.SourceFiles["NETStandard.cs"] = @"
+using System.Net.Http;
+public class NETStandard
+{
+    public static HttpClient GetHttpClient()
+    {
+        return new HttpClient();
+    }
+}
+";
+
+            var netFrameworkLibrary = new TestProject()
+            {
+                Name = "NETFrameworkLibrary",
+                TargetFrameworks = "net461",
+                IsSdkProject = true
+            };
+
+            netFrameworkLibrary.ReferencedProjects.Add(netStandardLibrary);
+
+            netFrameworkLibrary.SourceFiles["NETFramework.cs"] = @"
+using System.Net.Http;
+public class NETFramework
+{
+    public void Method1()
+    {
+        System.Net.Http.HttpClient client = NETStandard.GetHttpClient();
+    }
+}
+";
+
+            var testAsset = _testAssetsManager.CreateTestProject(netFrameworkLibrary, "ExchangeHttpClient")
+                .WithProjectChanges((projectPath, project) =>
+                {
+                    if (Path.GetFileName(projectPath).Equals(netFrameworkLibrary.Name + ".csproj", StringComparison.OrdinalIgnoreCase))
+                    {
+                        var ns = project.Root.Name.Namespace;
+
+                        var itemGroup = new XElement(ns + "ItemGroup");
+                        project.Root.Add(itemGroup);
+
+                        itemGroup.Add(new XElement(ns + "Reference", new XAttribute("Include", "System.Net.Http")));
+                    }
+                })
+                .Restore(netFrameworkLibrary.Name);
+
+            var buildCommand = new BuildCommand(MSBuildTest.Stage0MSBuild, Path.Combine(testAsset.TestRoot, netFrameworkLibrary.Name));
+
+            buildCommand
+                .Execute()
+                .Should()
+                .Pass();
+
+        }
+    }
+}


### PR DESCRIPTION
This change matches [logic from the NuGet.BuildTasks](https://github.com/NuGet/NuGet.BuildTasks/blob/cb9b1a1559efac311b84aacc5f605004ad9e8562/src/Microsoft.NuGet.Build.Tasks/Microsoft.NuGet.targets#L216-L218) which @ericstj pointed out, which removes simple name references for which there is a matching reference coming from a NuGet package.

Fixes #514