### PR TITLE
Move Simple Name Reference Remove Statement

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.PackageDependencyResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.PackageDependencyResolution.targets
@@ -304,13 +304,15 @@ Copyright (c) .NET Foundation. All rights reserved.
   <Target Name="ResolveLockFileReferences"
           DependsOnTargets="_ComputeLockFileReferences;_ComputeLockFileFrameworks">
     <ItemGroup>
-      <!-- Remove simple name references if we're directly providing a reference assembly to the compiler. For example,
-           consider a project with an Reference Include="System", and some NuGet package is providing System.dll -->
-      <Reference Remove="%(ResolvedCompileFileDefinitions.FileName)" />
-      
       <!-- Add the references we computed -->
       <Reference Include="@(ResolvedCompileFileDefinitions)" />
       <Reference Include="@(ResolvedFrameworkAssemblies)" />
+
+      <!-- Remove simple name references if we're directly providing a reference assembly to the compiler. For example,
+           consider a project with an Reference Include="System", and some NuGet package is providing System.dll.
+           Simple references can also come from NuGet framework assemblies, hence this statement should occur after
+           including all computed references. -->
+      <Reference Remove="%(ResolvedCompileFileDefinitions.FileName)" />
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
Fixes #514

Move removing simple name references after included all computed references so that simple name references are removed from framework assemblies added by NuGet. This updates the fix #662 to account for more cases, specifically the case where the simple name reference comes from NuGet. 

/cc @srivatsn @MattGertz @nguerrera @dsplaisted 

**Customer scenario**: if the user has a sdk-based desktop project and they reference httpclient and some netstandard library then they'll get spurious build warnings.

**Bugs this fixes:**: #514 

**Workarounds, if any**: N/A

**Risk**: Low. 

**Performance impact**: None

**Is this a regression from a previous update?**: No

**Root cause analysis:** Incomplete port of [logic from the NuGet.BuildTasks](https://github.com/NuGet/NuGet.BuildTasks/blob/cb9b1a1559efac311b84aacc5f605004ad9e8562/src/Microsoft.NuGet.Build.Tasks/Microsoft.NuGet.targets#L216-L218)

**How was the bug found?**: Dogfooding