### PR TITLE
Add new strings to xlf

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.cs.xlf
@@ -183,6 +183,16 @@
         <target state="translated">Konflikt závislostí. {0} očekával {1}, ale přijal {2}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DuplicateItemsError">
+        <source>Duplicate '{0}' items were included. The .NET SDK includes '{0}' items from your project directory by default. You can either remove these items from your project file, or set the '{1}' property to '{2}' if you want to explicitly include them in your project file. The duplicate items were: {3}</source>
+        <target state="new">Duplicate '{0}' items were included. The .NET SDK includes '{0}' items from your project directory by default. You can either remove these items from your project file, or set the '{1}' property to '{2}' if you want to explicitly include them in your project file. The duplicate items were: {3}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PackageReferenceOverrideWarning">
+        <source>A PackageReference for '{0}' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see {1}</source>
+        <target state="new">A PackageReference for '{0}' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see {1}</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.de.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.resx">
     <body>
@@ -181,6 +181,16 @@
       <trans-unit id="NU1012">
         <source>Dependency conflict. '{0}' expected '{1}' but received '{2}'</source>
         <target state="new">Abhängigkeitskonflikt. „{0}“ erwartete „{1}“, empfing jedoch „{2}“.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DuplicateItemsError">
+        <source>Duplicate '{0}' items were included. The .NET SDK includes '{0}' items from your project directory by default. You can either remove these items from your project file, or set the '{1}' property to '{2}' if you want to explicitly include them in your project file. The duplicate items were: {3}</source>
+        <target state="new">Duplicate '{0}' items were included. The .NET SDK includes '{0}' items from your project directory by default. You can either remove these items from your project file, or set the '{1}' property to '{2}' if you want to explicitly include them in your project file. The duplicate items were: {3}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PackageReferenceOverrideWarning">
+        <source>A PackageReference for '{0}' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see {1}</source>
+        <target state="new">A PackageReference for '{0}' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see {1}</target>
         <note></note>
       </trans-unit>
     </body>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.es.xlf
@@ -183,6 +183,16 @@
         <target state="translated">Conflicto de dependencia. "{0}" esperaba "{1}", pero recibió "{2}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="DuplicateItemsError">
+        <source>Duplicate '{0}' items were included. The .NET SDK includes '{0}' items from your project directory by default. You can either remove these items from your project file, or set the '{1}' property to '{2}' if you want to explicitly include them in your project file. The duplicate items were: {3}</source>
+        <target state="new">Duplicate '{0}' items were included. The .NET SDK includes '{0}' items from your project directory by default. You can either remove these items from your project file, or set the '{1}' property to '{2}' if you want to explicitly include them in your project file. The duplicate items were: {3}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PackageReferenceOverrideWarning">
+        <source>A PackageReference for '{0}' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see {1}</source>
+        <target state="new">A PackageReference for '{0}' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see {1}</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.fr.xlf
@@ -183,6 +183,16 @@
         <target state="translated">Conflit de dépendances. '{0}' attendait '{1}' mais a reçu '{2}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="DuplicateItemsError">
+        <source>Duplicate '{0}' items were included. The .NET SDK includes '{0}' items from your project directory by default. You can either remove these items from your project file, or set the '{1}' property to '{2}' if you want to explicitly include them in your project file. The duplicate items were: {3}</source>
+        <target state="new">Duplicate '{0}' items were included. The .NET SDK includes '{0}' items from your project directory by default. You can either remove these items from your project file, or set the '{1}' property to '{2}' if you want to explicitly include them in your project file. The duplicate items were: {3}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PackageReferenceOverrideWarning">
+        <source>A PackageReference for '{0}' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see {1}</source>
+        <target state="new">A PackageReference for '{0}' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see {1}</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.it.xlf
@@ -183,6 +183,16 @@
         <target state="translated">Conflitto di dipendenze. In '{0}' è previsto '{1}', ma è stato ricevuto '{2}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="DuplicateItemsError">
+        <source>Duplicate '{0}' items were included. The .NET SDK includes '{0}' items from your project directory by default. You can either remove these items from your project file, or set the '{1}' property to '{2}' if you want to explicitly include them in your project file. The duplicate items were: {3}</source>
+        <target state="new">Duplicate '{0}' items were included. The .NET SDK includes '{0}' items from your project directory by default. You can either remove these items from your project file, or set the '{1}' property to '{2}' if you want to explicitly include them in your project file. The duplicate items were: {3}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PackageReferenceOverrideWarning">
+        <source>A PackageReference for '{0}' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see {1}</source>
+        <target state="new">A PackageReference for '{0}' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see {1}</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.ja.xlf
@@ -183,6 +183,16 @@
         <target state="translated">依存関係の競合。'{0}' には '{1}' が必要ですが、'{2}' を受信しました。</target>
         <note />
       </trans-unit>
+      <trans-unit id="DuplicateItemsError">
+        <source>Duplicate '{0}' items were included. The .NET SDK includes '{0}' items from your project directory by default. You can either remove these items from your project file, or set the '{1}' property to '{2}' if you want to explicitly include them in your project file. The duplicate items were: {3}</source>
+        <target state="new">Duplicate '{0}' items were included. The .NET SDK includes '{0}' items from your project directory by default. You can either remove these items from your project file, or set the '{1}' property to '{2}' if you want to explicitly include them in your project file. The duplicate items were: {3}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PackageReferenceOverrideWarning">
+        <source>A PackageReference for '{0}' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see {1}</source>
+        <target state="new">A PackageReference for '{0}' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see {1}</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.ko.xlf
@@ -183,6 +183,16 @@
         <target state="translated">종속성 충돌. '{0}'에서 '{1}'을(를) 예상했지만 '{2}'을(를) 수신했습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DuplicateItemsError">
+        <source>Duplicate '{0}' items were included. The .NET SDK includes '{0}' items from your project directory by default. You can either remove these items from your project file, or set the '{1}' property to '{2}' if you want to explicitly include them in your project file. The duplicate items were: {3}</source>
+        <target state="new">Duplicate '{0}' items were included. The .NET SDK includes '{0}' items from your project directory by default. You can either remove these items from your project file, or set the '{1}' property to '{2}' if you want to explicitly include them in your project file. The duplicate items were: {3}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PackageReferenceOverrideWarning">
+        <source>A PackageReference for '{0}' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see {1}</source>
+        <target state="new">A PackageReference for '{0}' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see {1}</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.pl.xlf
@@ -183,6 +183,16 @@
         <target state="translated">Konflikt zależności. Element „{0}” oczekiwał elementu „{1}”, ale otrzymał element „{2}”</target>
         <note />
       </trans-unit>
+      <trans-unit id="DuplicateItemsError">
+        <source>Duplicate '{0}' items were included. The .NET SDK includes '{0}' items from your project directory by default. You can either remove these items from your project file, or set the '{1}' property to '{2}' if you want to explicitly include them in your project file. The duplicate items were: {3}</source>
+        <target state="new">Duplicate '{0}' items were included. The .NET SDK includes '{0}' items from your project directory by default. You can either remove these items from your project file, or set the '{1}' property to '{2}' if you want to explicitly include them in your project file. The duplicate items were: {3}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PackageReferenceOverrideWarning">
+        <source>A PackageReference for '{0}' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see {1}</source>
+        <target state="new">A PackageReference for '{0}' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see {1}</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.pt-BR.xlf
@@ -183,6 +183,16 @@
         <target state="translated">Conflito de dependência. '{0}' esperava '{1}', mas recebeu '{2\}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="DuplicateItemsError">
+        <source>Duplicate '{0}' items were included. The .NET SDK includes '{0}' items from your project directory by default. You can either remove these items from your project file, or set the '{1}' property to '{2}' if you want to explicitly include them in your project file. The duplicate items were: {3}</source>
+        <target state="new">Duplicate '{0}' items were included. The .NET SDK includes '{0}' items from your project directory by default. You can either remove these items from your project file, or set the '{1}' property to '{2}' if you want to explicitly include them in your project file. The duplicate items were: {3}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PackageReferenceOverrideWarning">
+        <source>A PackageReference for '{0}' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see {1}</source>
+        <target state="new">A PackageReference for '{0}' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see {1}</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.ru.xlf
@@ -183,6 +183,16 @@
         <target state="translated">Конфликт зависимостей. "{0}" ожидал "{1}", но получил "{2}".</target>
         <note />
       </trans-unit>
+      <trans-unit id="DuplicateItemsError">
+        <source>Duplicate '{0}' items were included. The .NET SDK includes '{0}' items from your project directory by default. You can either remove these items from your project file, or set the '{1}' property to '{2}' if you want to explicitly include them in your project file. The duplicate items were: {3}</source>
+        <target state="new">Duplicate '{0}' items were included. The .NET SDK includes '{0}' items from your project directory by default. You can either remove these items from your project file, or set the '{1}' property to '{2}' if you want to explicitly include them in your project file. The duplicate items were: {3}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PackageReferenceOverrideWarning">
+        <source>A PackageReference for '{0}' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see {1}</source>
+        <target state="new">A PackageReference for '{0}' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see {1}</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.tr.xlf
@@ -183,6 +183,16 @@
         <target state="translated">Bağımlılık çakışması. '{0}' '{1}' bekliyordu ancak '{2}' alındı</target>
         <note />
       </trans-unit>
+      <trans-unit id="DuplicateItemsError">
+        <source>Duplicate '{0}' items were included. The .NET SDK includes '{0}' items from your project directory by default. You can either remove these items from your project file, or set the '{1}' property to '{2}' if you want to explicitly include them in your project file. The duplicate items were: {3}</source>
+        <target state="new">Duplicate '{0}' items were included. The .NET SDK includes '{0}' items from your project directory by default. You can either remove these items from your project file, or set the '{1}' property to '{2}' if you want to explicitly include them in your project file. The duplicate items were: {3}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PackageReferenceOverrideWarning">
+        <source>A PackageReference for '{0}' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see {1}</source>
+        <target state="new">A PackageReference for '{0}' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see {1}</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.xlf
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.xlf
@@ -93,58 +93,66 @@
       </trans-unit>
       <trans-unit id="DOTNET1011">
         <source>Framework not installed: {0} in {1}</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="DOTNET1012">
         <source>The reference assemblies directory was not specified. You can set the location using the DOTNET_REFERENCE_ASSEMBLIES_PATH environment variable.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="DOTNET1013">
         <source>The following dependencies are marked with type 'platform', however only one dependency can have this type: {0}</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="DOTNET1014">
         <source>Failed to read lock file</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="DOTNET1017">
         <source>Project file does not exist '{0}'.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="NU1001">
         <source>The dependency '{0}' could not be resolved.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="NU1002">
         <source>The dependency '{0}' in project '{1}' does not support framework '{2}'.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="NU1006">
         <source>{0}. Please run 'dotnet restore' to generate a new asset file.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="NU1007">
         <source>Dependency specified was '{0}' but ended up with '{1}'.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="NU1008">
         <source>{0} is an unsupported framework.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="NU1009">
         <source>The expected asset file does not exist. Please run 'dotnet restore' to generate a new asset file.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="NU1010">
         <source>The dependency type was changed</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="NU1011">
         <source>The dependency target '{0}' is unsupported.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="NU1012">
         <source>Dependency conflict. '{0}' expected '{1}' but received '{2}'</source>
+        <note />
+      </trans-unit>
+      <trans-unit id="DuplicateItemsError">
+        <source>Duplicate '{0}' items were included. The .NET SDK includes '{0}' items from your project directory by default. You can either remove these items from your project file, or set the '{1}' property to '{2}' if you want to explicitly include them in your project file. The duplicate items were: {3}</source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PackageReferenceOverrideWarning">
+        <source>A PackageReference for '{0}' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see {1}</source>
         <note></note>
       </trans-unit>
     </body>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.zh-Hans.xlf
@@ -183,6 +183,16 @@
         <target state="translated">依赖项冲突。“{0}”预期“'{1}”，但接收到“{2}”</target>
         <note />
       </trans-unit>
+      <trans-unit id="DuplicateItemsError">
+        <source>Duplicate '{0}' items were included. The .NET SDK includes '{0}' items from your project directory by default. You can either remove these items from your project file, or set the '{1}' property to '{2}' if you want to explicitly include them in your project file. The duplicate items were: {3}</source>
+        <target state="new">Duplicate '{0}' items were included. The .NET SDK includes '{0}' items from your project directory by default. You can either remove these items from your project file, or set the '{1}' property to '{2}' if you want to explicitly include them in your project file. The duplicate items were: {3}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PackageReferenceOverrideWarning">
+        <source>A PackageReference for '{0}' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see {1}</source>
+        <target state="new">A PackageReference for '{0}' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see {1}</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.zh-Hant.xlf
@@ -183,6 +183,16 @@
         <target state="translated">相依性衝突。'{0}' 需要 '{1}' 但收到 '{2}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="DuplicateItemsError">
+        <source>Duplicate '{0}' items were included. The .NET SDK includes '{0}' items from your project directory by default. You can either remove these items from your project file, or set the '{1}' property to '{2}' if you want to explicitly include them in your project file. The duplicate items were: {3}</source>
+        <target state="new">Duplicate '{0}' items were included. The .NET SDK includes '{0}' items from your project directory by default. You can either remove these items from your project file, or set the '{1}' property to '{2}' if you want to explicitly include them in your project file. The duplicate items were: {3}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PackageReferenceOverrideWarning">
+        <source>A PackageReference for '{0}' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see {1}</source>
+        <target state="new">A PackageReference for '{0}' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see {1}</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>


### PR DESCRIPTION
**Customer scenario**

Some strings are still not translated as they were added after last handback

**Bugs this fixes:**

[VSO 370234](https://devdiv.visualstudio.com/DevDiv/_workitems?id=370234&_a=edit)

**Workarounds, if any**

None

**Risk**

Low, small number of new strings are now translated.

**Performance impact**

None

**Is this a regression from a previous update?**

No. The strings are new.

**Root cause analysis:**

We didn't miss anything. Strings were added after last handback.

**How was the bug found?**

N/A


@srivatsn @dotnet/project-system Needed for next handoff ASAP