### PR TITLE
Multitarget SDK tasks to .NET 4.6 as well as .NET Standard in order to use earlier version of NewtonSoft.Json on .NET Framework

### DIFF
--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -18,6 +18,7 @@
     <FluentAssertionsVersion>4.0.0</FluentAssertionsVersion>
     <FluentAssertionsJsonVersion>4.12.0</FluentAssertionsJsonVersion>
     <NewtonsoftJsonVersion>9.0.1</NewtonsoftJsonVersion>
+    <NewtonsoftJsonOnNetFrameworkVersion>6.0.4</NewtonsoftJsonOnNetFrameworkVersion>
     <DotNetCliUtilsVersion>1.0.0-preview2-003121</DotNetCliUtilsVersion>
   </PropertyGroup>
   

--- a/build/Nuget/Microsoft.NET.Sdk.Nuget.targets
+++ b/build/Nuget/Microsoft.NET.Sdk.Nuget.targets
@@ -19,29 +19,29 @@
       <CopyLocalAssembly Include="@(NuGetCopyLocalAssembly)">
         <Version>$(NuGetVersion)</Version>
         <TFM>netstandard1.3</TFM>
-        <DestinationTFM>net46;netcoreapp1.0</DestinationTFM>
+        <DestinationTFM>netcoreapp1.0</DestinationTFM>
       </CopyLocalAssembly>
       <CopyLocalAssembly Include="NuGet.Versioning">
         <Version>$(NuGetVersion)</Version>
         <TFM>netstandard1.0</TFM>
-        <DestinationTFM>net46;netcoreapp1.0</DestinationTFM>
+        <DestinationTFM>netcoreapp1.0</DestinationTFM>
       </CopyLocalAssembly>
 
       <CopyLocalAssembly Include="Microsoft.Extensions.DependencyModel">
         <Version>$(CoreSetupVersion)</Version>
         <TFM>netstandard1.3</TFM>
-        <DestinationTFM>net46;netcoreapp1.0</DestinationTFM>
+        <DestinationTFM>netcoreapp1.0</DestinationTFM>
       </CopyLocalAssembly>
       <CopyLocalAssembly Include="Microsoft.DotNet.PlatformAbstractions">
         <Version>$(CoreSetupVersion)</Version>
         <TFM>netstandard1.3</TFM>
-        <DestinationTFM>net46;netcoreapp1.0</DestinationTFM>
+        <DestinationTFM>netcoreapp1.0</DestinationTFM>
       </CopyLocalAssembly>
 
       <CopyLocalAssembly Include="Newtonsoft.Json">
         <Version>9.0.1</Version>
         <TFM>netstandard1.0</TFM>
-        <DestinationTFM>net46;netcoreapp1.0</DestinationTFM>
+        <DestinationTFM>netcoreapp1.0</DestinationTFM>
       </CopyLocalAssembly>
 
       <CopyLocalAssembly Include="System.Runtime.Serialization.Primitives">
@@ -49,79 +49,9 @@
         <TFM>netstandard1.3</TFM>
         <DestinationTFM>netcoreapp1.0</DestinationTFM>
       </CopyLocalAssembly>
-
-      <CopyLocalAssembly Include="System.Runtime.InteropServices.RuntimeInformation">
-        <Version>4.0.0</Version>
-        <TFM>net45</TFM>
-        <DestinationTFM>net46</DestinationTFM>
-      </CopyLocalAssembly>
-      <CopyLocalAssembly Include="System.Security.Cryptography.Algorithms">
-        <Version>4.2.0</Version>
-        <TFM>net46</TFM>
-        <DestinationTFM>net46</DestinationTFM>
-      </CopyLocalAssembly>
-      <CopyLocalAssembly Include="System.Security.Cryptography.Primitives">
-        <Version>4.0.0</Version>
-        <TFM>net46</TFM>
-        <DestinationTFM>net46</DestinationTFM>
-      </CopyLocalAssembly>
-      <CopyLocalAssembly Include="System.Threading.Thread">
-        <Version>4.0.0</Version>
-        <TFM>net46</TFM>
-        <DestinationTFM>net46</DestinationTFM>
-      </CopyLocalAssembly>
-      <CopyLocalAssembly Include="System.IO.FileSystem">
-        <Version>4.0.1</Version>
-        <TFM>net46</TFM>
-        <DestinationTFM>net46</DestinationTFM>
-      </CopyLocalAssembly>
-      <CopyLocalAssembly Include="System.AppContext">
-        <Version>4.1.0</Version>
-        <TFM>net46</TFM>
-        <DestinationTFM>net46</DestinationTFM>
-      </CopyLocalAssembly>
-      <CopyLocalAssembly Include="System.Console">
-        <Version>4.0.0</Version>
-        <TFM>net46</TFM>
-        <DestinationTFM>net46</DestinationTFM>
-      </CopyLocalAssembly>
-      <CopyLocalAssembly Include="System.Diagnostics.FileVersionInfo">
-        <Version>4.0.0</Version>
-        <TFM>net46</TFM>
-        <DestinationTFM>net46</DestinationTFM>
-      </CopyLocalAssembly>
-      <CopyLocalAssembly Include="System.Diagnostics.Process">
-        <Version>4.1.0</Version>
-        <TFM>net46</TFM>
-        <DestinationTFM>net46</DestinationTFM>
-      </CopyLocalAssembly>
-      <CopyLocalAssembly Include="System.Diagnostics.StackTrace">
-        <Version>4.0.1</Version>
-        <TFM>net46</TFM>
-        <DestinationTFM>net46</DestinationTFM>
-      </CopyLocalAssembly>
-      <CopyLocalAssembly Include="System.IO.Compression">
-        <Version>4.1.0</Version>
-        <TFM>net46</TFM>
-        <DestinationTFM>net46</DestinationTFM>
-      </CopyLocalAssembly>
-      <CopyLocalAssembly Include="System.IO.FileSystem.Primitives">
-        <Version>4.0.1</Version>
-        <TFM>net46</TFM>
-        <DestinationTFM>net46</DestinationTFM>
-      </CopyLocalAssembly>
+      
       <CopyLocalAssembly Include="System.Security.Claims">
         <Version>4.0.1</Version>
-        <TFM>net46</TFM>
-        <DestinationTFM>net46</DestinationTFM>
-      </CopyLocalAssembly>
-      <CopyLocalAssembly Include="System.Security.Cryptography.Encoding">
-        <Version>4.0.0</Version>
-        <TFM>net46</TFM>
-        <DestinationTFM>net46</DestinationTFM>
-      </CopyLocalAssembly>
-      <CopyLocalAssembly Include="System.Security.Cryptography.X509Certificates">
-        <Version>4.1.0</Version>
         <TFM>net46</TFM>
         <DestinationTFM>net46</DestinationTFM>
       </CopyLocalAssembly>
@@ -130,31 +60,12 @@
         <TFM>net46</TFM>
         <DestinationTFM>net46</DestinationTFM>
       </CopyLocalAssembly>
-      <CopyLocalAssembly Include="System.Text.Encoding.CodePages">
-        <Version>4.0.1</Version>
-        <TFM>net46</TFM>
-        <DestinationTFM>net46</DestinationTFM>
-      </CopyLocalAssembly>
       <CopyLocalAssembly Include="System.Xml.ReaderWriter">
         <Version>4.0.11</Version>
         <TFM>netstandard1.3</TFM>
         <DestinationTFM>net46</DestinationTFM>
       </CopyLocalAssembly>
-      <CopyLocalAssembly Include="System.Xml.XmlDocument">
-        <Version>4.0.1</Version>
-        <TFM>net46</TFM>
-        <DestinationTFM>net46</DestinationTFM>
-      </CopyLocalAssembly>
-      <CopyLocalAssembly Include="System.Xml.XPath">
-        <Version>4.0.1</Version>
-        <TFM>net46</TFM>
-        <DestinationTFM>net46</DestinationTFM>
-      </CopyLocalAssembly>
-      <CopyLocalAssembly Include="System.Xml.XPath.XDocument">
-        <Version>4.0.1</Version>
-        <TFM>net46</TFM>
-        <DestinationTFM>net46</DestinationTFM>
-      </CopyLocalAssembly>
+
 
       <CopyLocalAssembly>
         <PackageRelativePath>$([System.String]::Copy('%(Identity)\%(Version)').ToLowerInvariant())</PackageRelativePath>
@@ -192,10 +103,36 @@
 
       <CopyLocalBuildFile Include="@(CopyLocalBuildCrossTargetingFile)" />
       <CopyLocalBuildFile Include="@(CopyLocalSdkFile)" />
+
+      <!-- Use the contents of the output directory of the net46 build of the SDK tasks, except
+           for MSBuild and Roslyn DLLs and their dependencies-->
+      <Net46OutputAssembly Include="$(OutDir)net46\*.dll" />
+      
+      <!-- Use the versions of these that come with MSBuild -->
+      <Net46OutputAssembly Remove="$(OutDir)net46\Microsoft.Build.Framework.dll" />
+      <Net46OutputAssembly Remove="$(OutDir)net46\Microsoft.Build.Utilities.Core.dll" />
+
+      <!-- This is a dependency of Microsoft.Build.Utilities.Core -->
+      <Net46OutputAssembly Remove="$(OutDir)net46\Microsoft.Win32.Primitives.dll" />
+      
+      <!-- Use versions of Roslyn that come with MSBuild / the CLI -->
+      <Net46OutputAssembly Remove="$(OutDir)net46\Microsoft.CodeAnalysis.CSharp.dll" />
+      <Net46OutputAssembly Remove="$(OutDir)net46\Microsoft.CodeAnalysis.dll" />
+      
+      <!-- These should be dependencies of Roslyn -->
+      <Net46OutputAssembly Remove="$(OutDir)net46\System.Collections.Immutable.dll" />
+      <Net46OutputAssembly Remove="$(OutDir)net46\System.Collections.NonGeneric.dll" />
+      <Net46OutputAssembly Remove="$(OutDir)net46\System.Diagnostics.TraceSource.dll" />
+      <Net46OutputAssembly Remove="$(OutDir)net46\System.Reflection.Metadata.dll" />
+      <Net46OutputAssembly Remove="$(OutDir)net46\System.Reflection.TypeExtensions.dll" />
+
     </ItemGroup>
 
     <Copy SourceFiles="%(Net46CopyLocalAssembly.FullFilePath)"
           DestinationFolder="$(PackagesLayoutToolsNet46Dir)" />
+
+    <Copy SourceFiles="@(Net46OutputAssembly)"
+      DestinationFolder="$(PackagesLayoutToolsNet46Dir)" />
 
     <Copy SourceFiles="%(NetCoreAppCopyLocalAssembly.FullFilePath)"
           DestinationFolder="$(PackagesLayoutToolsNetCoreAppDir)" />

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Microsoft.NET.Build.Tasks.csproj
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Microsoft.NET.Build.Tasks.csproj
@@ -10,9 +10,12 @@
     <RootNamespace>Microsoft.NET.Build.Tasks</RootNamespace>
     <AssemblyName>Microsoft.NET.Build.Tasks</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
-    <TargetFramework>netstandard1.3</TargetFramework>
+    <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
     <GenerateDependencyFile>false</GenerateDependencyFile>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net46'">
+    <OutDir>$(OutDir)net46\</OutDir>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Sdk">
@@ -33,6 +36,13 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp">
       <Version>$(RoslynVersion)</Version>
     </PackageReference>
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net46'">
+    <Reference Include="System" />
+
+    <!-- Downgrade NewtonSoft.Json reference to the version NuGet uses for .NET Framework,
+         even though Microsoft.Extensions.DependencyModel depends on version 9.0.1 -->
+    <PackageReference Include="NewtonSoft.Json" Version="$(NewtonsoftJsonOnNetFrameworkVersion)" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CheckForDuplicateItems.cs" />
@@ -74,6 +84,16 @@
     <Compile Include="RuntimeConfig.cs" />
     <Compile Include="RuntimeConfigFramework.cs" />
     <Compile Include="RuntimeOptions.cs" />
+    <Compile Include="DependencyContextBuilder.cs" />
+    <Compile Include="GenerateDepsFile.cs" />
+    <Compile Include="GenerateRuntimeConfigurationFiles.cs" />
+    <Compile Include="LockFileCache.cs" />
+    <Compile Include="FileGroup.cs" />
+    <Compile Include="MetadataKeys.cs" />
+    <Compile Include="ResolvePackageDependencies.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' != 'net46'">
     <None Include="buildCrossTargeting\Microsoft.NET.Sdk.targets">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
@@ -140,14 +160,6 @@
     <None Include="sdk\Sdk.targets">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <Compile Include="DependencyContextBuilder.cs" />
-    <Compile Include="GenerateDepsFile.cs" />
-    <Compile Include="GenerateRuntimeConfigurationFiles.cs" />
-    <Compile Include="LockFileCache.cs" />
-    <Compile Include="FileGroup.cs" />
-    <Compile Include="MetadataKeys.cs" />
-    <Compile Include="ResolvePackageDependencies.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Resources\Strings.resx">

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Microsoft.NET.Build.Tasks.csproj
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Microsoft.NET.Build.Tasks.csproj
@@ -10,7 +10,8 @@
     <RootNamespace>Microsoft.NET.Build.Tasks</RootNamespace>
     <AssemblyName>Microsoft.NET.Build.Tasks</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
-    <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netstandard1.3</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">netstandard1.3;net46</TargetFrameworks>
     <GenerateDependencyFile>false</GenerateDependencyFile>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>


### PR DESCRIPTION
Prior to this PR, we were compiling our tasks once for .NET Standard, and (transitively) referencing NewtonSoft.Json 9.0.1.

However, the current version of NewtonSoft.Json in Visual Studio is 8.0.x, which was causing conflicts where multiple versions of the assembly were loaded.

This change switches to multi-targeting the tasks assembly to .NET Standard 1.3 and .NET Framework 4.6.  The .NET Framework version references NewtonSoft.Json 6.0.4, which is the same as the NuGet libraries do for their .NET Framework versions.  The tasks assembly still depends on Microsoft.Extensions.DependencyModel, which depends on NewtonSoft.Json 9.0.1, so we are explicitly downgrading that reference.

With this change, we are also relying on NuGet and the build process to copy the dependencies of the task assembly to the net46 output folder, and including them in the tools\net46 folder of the NuGet package, instead of explicitly listing each DLL to be copied in Microsoft.NET.Sdk.Nuget.targets.