### PR TITLE
Don't run CheckForImplicitPackageReferenceOverrides before NuGet restore

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.DefaultItems.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.DefaultItems.targets
@@ -112,6 +112,41 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   </Target>
 
+  <!-- Running an SDK task before the NuGet restore task causes issues when running on .NET Framework because it causes the
+      .NET Standard NuGet DLLs to be loaded from the SDK path rather than the .NET Framework versions from the NuGet targets
+      path.  To avoid this, we create a separate target to run before NuGet restore which deduplicates the items without
+      causing the SDK tasks to be loaded (but doesn't generate a warning message, because we need to load the tasks for that). -->
+  <PropertyGroup Condition="'$(DisableImplicitFrameworkReferences)' != 'true'">
+    <_ImplicitPackageName Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard'">NETStandard.Library</_ImplicitPackageName>
+    <_ImplicitPackageName Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">Microsoft.NETCore.App</_ImplicitPackageName>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(_ImplicitPackageName)' != ''">
+    <!-- Filter PackageReference to items where the ItemSpec matches the implicit package name, and add IsImplicitlyDefined metadata
+         for items that don't have it-->
+    <_ImplicitPackageReferenceCheck
+        Include="@(PackageReference->WithMetadataValue('Identity', '$(_ImplicitPackageName)'))">
+      <IsImplicitlyDefined Condition="'%(IsImplicitlyDefined)' != 'true' ">false</IsImplicitlyDefined>
+    </_ImplicitPackageReferenceCheck>
+
+    <!-- Now filter down to an item with just the implicit reference and another one with just the overriding reference -->
+    <_ImplicitPackageReference Include="@(_ImplicitPackageReferenceCheck->WithMetadataValue('IsImplicitlyDefined', 'true'))"/>
+    <_OverridingPackageReference Include="@(_ImplicitPackageReferenceCheck->WithMetadataValue('IsImplicitlyDefined', 'false'))"/>
+  </ItemGroup>
+
+  <Target Name="CheckForImplicitPackageReferenceOverridesBeforeRestore" BeforeTargets="_GetRestoreProjectStyle">
+    <ItemGroup>
+      <!-- Remove both the implicit and the override item, if there was both an implicit and an override item -->
+      <PackageReference Remove="@(PackageReference->WithMetadataValue('Identity', '$(_ImplicitPackageName)'))"
+                        Condition="'@(_ImplicitPackageReference)' != '' And '@(_OverridingPackageReference)' != ''"
+                      />
+
+      <!-- Add the override item back -->
+      <PackageReference Include="@(_OverridingPackageReference)"
+                        Condition="'@(_ImplicitPackageReference)' != '' And '@(_OverridingPackageReference)' != ''" />
+    </ItemGroup>
+  </Target>
+
   <UsingTask TaskName="CheckForDuplicateItems" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
 
   <Target Name="CheckForDuplicateItems" BeforeTargets="_CheckForInvalidConfigurationAndPlatform;CoreCompile">

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.DefaultItems.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.DefaultItems.targets
@@ -93,7 +93,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <UsingTask TaskName="CheckForImplicitPackageReferenceOverrides" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
 
   <!-- Remove package references with metadata IsImplicitlyDefined = true, if there are other PackageReference items with the same identity -->
-  <Target Name="CheckForImplicitPackageReferenceOverrides" BeforeTargets="_GetRestoreProjectStyle;_CheckForInvalidConfigurationAndPlatform;CollectPackageReferences">
+  <Target Name="CheckForImplicitPackageReferenceOverrides" BeforeTargets="_CheckForInvalidConfigurationAndPlatform;CollectPackageReferences">
     <PropertyGroup>
       <ImplicitPackageReferenceInformationLink>https://aka.ms/sdkimplicitrefs</ImplicitPackageReferenceInformationLink>
     </PropertyGroup>


### PR DESCRIPTION
This should help avoid assembly loading ordering issues, where the some of the (.NET Standard) NuGet assemblies were being loaded from the .NET SDK instead of the (.NET Framework) versions from the NuGet tasks