### PR TITLE
Fix for Unit Test Template localization

### DIFF
--- a/src/Templates/ProjectTemplates/CSharp/.NETCore/CSharpUnitTest/UnitTest.vstemplate
+++ b/src/Templates/ProjectTemplates/CSharp/.NETCore/CSharpUnitTest/UnitTest.vstemplate
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <VSTemplate Version="3.0.0" Type="Project" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" xmlns:sdk="http://schemas.microsoft.com/developer/vstemplate-sdkextension/2010">
   <TemplateData>
-    <Name>Unit Test Project (.NET Core)</Name>
-    <Description>A project that contains unit tests that can run on .NET Core on Windows, Linux and MacOS</Description>
+    <Name Package="{52CBD135-1F97-2580-011F-C7CD052E44DE}" ID="521"/>
+    <Description Package="{52CBD135-1F97-2580-011F-C7CD052E44DE}" ID="522"/>
     <Icon Package="{52CBD135-1F97-2580-011F-C7CD052E44DE}" ID="531"/>
     <ProjectType>CSharp</ProjectType>
     <RequiredFrameworkVersion>2.0</RequiredFrameworkVersion>


### PR DESCRIPTION
Fixing the name and description for the Unit Test template for .Net Core.
Consumed the localized strings from the package instead.

Validations:
Validated on the loc machine.
Screenshot with the fix:
![loc fix](https://cloud.githubusercontent.com/assets/18569990/22198625/5052aafc-e17d-11e6-93a2-0fa9b3378347.png)
