### PR TITLE
Update testplatform to v15.0.0-preview-20170123-02.

### DIFF
--- a/src/Templates/ProjectTemplates/CSharp/.NETCore/CSharpUnitTest/ProjectTemplate.csproj
+++ b/src/Templates/ProjectTemplates/CSharp/.NETCore/CSharpUnitTest/ProjectTemplate.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0-preview-20170113-02" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0-preview-20170123-02" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.1.8-rc" />
     <PackageReference Include="MSTest.TestFramework" Version="1.0.8-rc" />
   </ItemGroup>

--- a/src/Templates/ProjectTemplates/CSharp/.NETCore/CSharpXUnitTest/ProjectTemplate.csproj
+++ b/src/Templates/ProjectTemplates/CSharp/.NETCore/CSharpXUnitTest/ProjectTemplate.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0-preview-20170113-02" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0-preview-20170123-02" />
     <PackageReference Include="xunit" Version="2.2.0-beta5-build3474" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0-beta5-build1225" />
   </ItemGroup>


### PR DESCRIPTION
Fixes part of this release:
* Allow multiple test properties with same key [#239](https://github.com/Microsoft/vstest/issues/239), [#358](https://github.com/Microsoft/vstest/issues/358)
* Localization for testplatform vsix package [#146](https://github.com/Microsoft/vstest/issues/146)
* Working directory should be set to test source parent directory [#311](https://github.com/Microsoft/vstest/issues/311)
* Allow relative source paths to vstest.console [#331](https://github.com/Microsoft/vstest/issues/331)
* Stacktrace and error message should be in context of failed test [#285](https://github.com/Microsoft/vstest/issues/285)