### PR TITLE
Test updates

### DIFF
--- a/test/Microsoft.NET.TestFramework/Commands/MSBuildTest.cs
+++ b/test/Microsoft.NET.TestFramework/Commands/MSBuildTest.cs
@@ -29,10 +29,21 @@ namespace Microsoft.NET.TestFramework.Commands
 
         private ICommand CreateCommand(params string[] args)
         {
-            var newArgs = args.ToList();
-            newArgs.Insert(0, $"msbuild");
+            ICommand command;
 
-            ICommand command = Command.Create(DotNetHostPath, newArgs);
+            //  Run tests on full framework MSBuild if environment variable is set pointing to it
+            string msbuildPath = Environment.GetEnvironmentVariable("DOTNET_SDK_TEST_MSBUILD_PATH");
+            if (!string.IsNullOrEmpty(msbuildPath))
+            {
+                command = Command.Create(msbuildPath, args);
+            }
+            else
+            {
+                var newArgs = args.ToList();
+                newArgs.Insert(0, $"msbuild");
+
+                command = Command.Create(DotNetHostPath, newArgs);
+            }
 
             //  Set NUGET_PACKAGES environment variable to match value from build.ps1
             command = command.EnvironmentVariable("NUGET_PACKAGES", Path.Combine(RepoInfo.RepoRoot, "packages"));

--- a/test/Microsoft.NET.TestFramework/SdkTest.cs
+++ b/test/Microsoft.NET.TestFramework/SdkTest.cs
@@ -7,15 +7,26 @@ namespace Microsoft.NET.TestFramework
     public class SdkTest : IDisposable
     {
         protected TestAssetsManager _testAssetsManager = new TestAssetsManager();
+        bool _shouldValidateDirectories;
 
         public SdkTest()
         {
             Environment.SetEnvironmentVariable("DOTNET_SKIP_FIRST_TIME_EXPERIENCE", "1");
+
+            string msbuildPath = Environment.GetEnvironmentVariable("DOTNET_SDK_TEST_MSBUILD_PATH");
+
+            //  Skip path length validation if running on full framework MSBuild.  We do the path length validation
+            //  to avoid getting path to long errors when copying the test drop in our build infrastructure.  However,
+            //  those builds are only built with .NET Core MSBuild.
+            _shouldValidateDirectories = string.IsNullOrEmpty(msbuildPath);
         }
 
         public void Dispose()
         {
-            _testAssetsManager.ValidateDestinationDirectories();
+            if (_shouldValidateDirectories)
+            {
+                _testAssetsManager.ValidateDestinationDirectories();
+            }
         }
     }
 }

--- a/test/Microsoft.NET.TestFramework/SdkTest.cs
+++ b/test/Microsoft.NET.TestFramework/SdkTest.cs
@@ -8,6 +8,11 @@ namespace Microsoft.NET.TestFramework
     {
         protected TestAssetsManager _testAssetsManager = new TestAssetsManager();
 
+        public SdkTest()
+        {
+            Environment.SetEnvironmentVariable("DOTNET_SKIP_FIRST_TIME_EXPERIENCE", "1");
+        }
+
         public void Dispose()
         {
             _testAssetsManager.ValidateDestinationDirectories();


### PR DESCRIPTION
- Suppress .NET CLI first run experience in Visual Studio
- Support environment variable to run tests using full framework MSBuild instead of .NET Core version