### PR TITLE
Handle empty target framework more gracefully

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/NETSdkError.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/NETSdkError.cs
@@ -26,11 +26,21 @@ namespace Microsoft.NET.Build.Tasks
 
         public bool WarningOnly { get; set; }
 
+        private static readonly string[] EmptyArguments = new[] { "" };
+
         protected override void ExecuteCore()
         {
+            if (FormatArguments == null || FormatArguments.Length == 0)
+            {
+                // We use a single-item array with one empty string in this case so that
+                // it is possible to interpret FormatArguments="$(EmptyVariable)" as a request
+                // to pass an empty string on to string.Format. Note if there are not placeholders
+                // in the string, then the empty string arg will be ignored.
+                FormatArguments = EmptyArguments;
+            }
+
             string format = Strings.ResourceManager.GetString(ResourceName, Strings.Culture);
-            string[] arguments = FormatArguments ?? Array.Empty<string>();
-            string message = string.Format(CultureInfo.CurrentCulture, format, arguments);
+            string message = string.Format(CultureInfo.CurrentCulture, format, FormatArguments);
 
             if (WarningOnly)
             {

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.BeforeCommon.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.BeforeCommon.targets
@@ -19,11 +19,10 @@ Copyright (c) .NET Foundation. All rights reserved.
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.NET.DefaultOutputPaths.targets" />
   
   <!-- 
-    Expand TargetFramework (if set) to TargetFrameworkIdentifier and TargetFrameworkVersion,
+    Expand TargetFramework to TargetFrameworkIdentifier and TargetFrameworkVersion,
     and adjust intermediate and output paths to include it.
   -->
-  <Import Condition="'$(TargetFramework)' != ''"
-        Project="$(MSBuildThisFileDirectory)Microsoft.NET.TargetFrameworkInference.targets" />
+  <Import Project="$(MSBuildThisFileDirectory)Microsoft.NET.TargetFrameworkInference.targets" />
 
   <!--
     Use RuntimeIdentifier to determine PlatformTarget.

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.TargetFrameworkInference.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.TargetFrameworkInference.targets
@@ -47,7 +47,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   </PropertyGroup>
 
   <!-- Split $(TargetFramework) (e.g. net45) into short identifier and short version (e.g. 'net' and '45'). -->
-  <PropertyGroup Condition="!$(TargetFramework.Contains(',')) and !$(TargetFramework.Contains('+'))">
+  <PropertyGroup Condition="'$(TargetFramework)' != '' and !$(TargetFramework.Contains(',')) and !$(TargetFramework.Contains('+'))">
    <_ShortFrameworkIdentifier>$(TargetFramework.TrimEnd('.0123456789'))</_ShortFrameworkIdentifier>
    <_ShortFrameworkVersion>$(TargetFramework.Substring($(_ShortFrameworkIdentifier.Length)))</_ShortFrameworkVersion>
   </PropertyGroup>
@@ -86,11 +86,22 @@ Copyright (c) .NET Foundation. All rights reserved.
                  FormatArguments="$(TargetFramework)" />
   </Target>
 
+  <!-- 
+    Don't leave TargetFrameworkVersion empty if it still hasn't been determined. We will trigger the error above,
+    but we need this to be a valid version so that our error message does not get pre-empted by failure to interpret
+    version comparison expressions, which is currently unrecoverable in VS.
+
+    This is also an extra safeguard to ensure we never end up with common targets default of .NetFramework,Version=v4.0
+  -->
+  <PropertyGroup Condition="'$(TargetFrameworkVersion)' == ''">
+    <TargetFrameworkVersion >v0.0</TargetFrameworkVersion>
+  </PropertyGroup>
+
   <!--
     Append $(TargetFramework) directory to output and intermediate paths to prevent bin clashes between
     targets.
    -->
-  <PropertyGroup Condition="'$(_UnsupportedTargetFrameworkError)' != 'true'">
+  <PropertyGroup Condition="'$(TargetFramework)' != '' and '$(_UnsupportedTargetFrameworkError)' != 'true'">
     <IntermediateOutputPath>$(IntermediateOutputPath)$(TargetFramework)\</IntermediateOutputPath>
     <OutputPath>$(OutputPath)$(TargetFramework)\</OutputPath>
   </PropertyGroup>

--- a/test/Microsoft.NET.TestFramework/Assertions/CommandResultAssertions.cs
+++ b/test/Microsoft.NET.TestFramework/Assertions/CommandResultAssertions.cs
@@ -59,6 +59,13 @@ namespace Microsoft.NET.TestFramework.Assertions
                 .FailWith(AppendDiagnosticsTo($"The command output did not contain expected result: {pattern}{Environment.NewLine}"));
             return new AndConstraint<CommandResultAssertions>(this);
         }
+        
+        public AndConstraint<CommandResultAssertions> NotHaveStdOutContaining(string pattern)
+        {
+            Execute.Assertion.ForCondition(!_commandResult.StdOut.Contains(pattern))
+                .FailWith(AppendDiagnosticsTo($"The command output contained a result it should not have contained: {pattern}{Environment.NewLine}"));
+            return new AndConstraint<CommandResultAssertions>(this);
+        }
 
         public AndConstraint<CommandResultAssertions> HaveStdOutContainingIgnoreCase(string pattern)
         {


### PR DESCRIPTION
#### Scenario

Editing your project file in VS and saving at a point in time where TargetFramework is empty will cause VS to crash

#### Bug

#684

#### Workarounds

Be very careful not to ever make TargetFramework empty, but there's really no telling from the pop-up that precedes the crash that this is the cause.

#### Risk

Low

#### Performance Impact

Negligible. Just a few more conditions to evaluate to avoid the crash

#### Regression Analysis

Not a regression


@srivatsn @dsplaisted @dotnet/project-system 