### PR TITLE
Enable running tests on full .NET Framework version of MSBuild

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -76,8 +76,7 @@ if ($SkipTests) {
 
 if ($FullMSBuild)
 {
-    $msbuildPath = join-path $env:vs150comntools "..\..\MSBuild\15.0\bin\MSBuild.exe"
-    $env:DOTNET_SDK_TEST_MSBUILD_PATH = [System.IO.Path]::GetFullPath($msbuildPath)
+    $env:DOTNET_SDK_TEST_MSBUILD_PATH = join-path $env:VSInstallDir "MSBuild\15.0\bin\MSBuild.exe"
 }
 
 $commonBuildArgs = echo $RepoRoot\build\build.proj /t:$buildTarget /m /nologo /p:Configuration=$Configuration /p:Platform=$Platform /p:SignType=$signType /verbosity:$Verbosity

--- a/build.ps1
+++ b/build.ps1
@@ -8,6 +8,7 @@ param(
     [string]$Platform="Any CPU",
     [string]$Verbosity="minimal",
     [switch]$SkipTests,
+    [switch]$FullMSBuild,
     [switch]$RealSign,
     [switch]$Help)
 
@@ -20,6 +21,7 @@ if($Help)
     Write-Host "  -Platform <PLATFORM>               Build the specified Platform (Any CPU)"
     Write-Host "  -Verbosity <VERBOSITY>             Build console output verbosity (minimal or diagnostic, default: minimal)"
     Write-Host "  -SkipTests                         Skip executing unit tests"
+    Write-Host "  -FullMSBuild                       Run tests with the full .NET Framework version of MSBuild instead of the .NET Core version"
     Write-Host "  -RealSign                          Sign the output DLLs"
     Write-Host "  -Help                              Display this help message"
     exit 0
@@ -70,6 +72,12 @@ if ($RealSign) {
 $buildTarget = 'Build'
 if ($SkipTests) {
     $buildTarget = 'BuildWithoutTesting'
+}
+
+if ($FullMSBuild)
+{
+    $msbuildPath = join-path $env:vs150comntools "..\..\MSBuild\15.0\bin\MSBuild.exe"
+    $env:DOTNET_SDK_TEST_MSBUILD_PATH = [System.IO.Path]::GetFullPath($msbuildPath)
 }
 
 $commonBuildArgs = echo $RepoRoot\build\build.proj /t:$buildTarget /m /nologo /p:Configuration=$Configuration /p:Platform=$Platform /p:SignType=$signType /verbosity:$Verbosity

--- a/netci.groovy
+++ b/netci.groovy
@@ -10,7 +10,7 @@ def project = GithubProject
 def branch = GithubBranchName
 def isPR = true
 
-def osList = ['Windows_NT', 'Ubuntu14.04']
+def osList = ['Windows_NT', 'Windows_NT_FullFramework', 'Ubuntu14.04']
 def configList = ['Release', 'Debug']
 
 def static getBuildJobName(def configuration, def os) {
@@ -26,6 +26,8 @@ osList.each { os ->
         // Calculate the build command
         if (os == 'Windows_NT') {
             buildCommand = ".\\build.cmd -Configuration $config"
+        } else if (os == 'Windows_NT_FullFramework') {
+            buildCommand = ".\\build.cmd -Configuration $config -FullMSBuild"
         } else {
             // Jenkins non-Ubuntu CI machines don't have docker
             buildCommand = "./build.sh --configuration $config"

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantAllResourcesInSatellite.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantAllResourcesInSatellite.cs
@@ -21,6 +21,13 @@ namespace Microsoft.NET.Build.Tests
         [Fact]
         public void It_retrieves_strings_successfully()
         {
+            if (UsingFullFrameworkMSBuild)
+            {
+                //  Disable this test on full framework, as generating strong named satellite assemblies with AL.exe requires Admin permissions
+                //  See https://github.com/dotnet/sdk/issues/732
+                return;
+            }
+
             TestSatelliteResources(_testAssetsManager);
         }
 

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildALibrary.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildALibrary.cs
@@ -76,6 +76,12 @@ namespace Microsoft.NET.Build.Tests
                 return;
             }
 
+            //  Disable this test when using full Framework MSBuild, as the paths to the props and targets are different
+            if (UsingFullFrameworkMSBuild)
+            {
+                return;
+            }
+
             List<string> expectedAllProjects = new List<string>();
             string baseIntermediateDirectory = null;
 

--- a/test/Microsoft.NET.Build.Tests/GivenThereAreDefaultItems.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThereAreDefaultItems.cs
@@ -370,6 +370,13 @@ namespace Microsoft.NET.Build.Tests
         [Fact]
         public void Compile_items_can_be_explicitly_specified_while_default_EmbeddedResource_items_are_used()
         {
+            if (UsingFullFrameworkMSBuild)
+            {
+                //  Disable this test on full framework, as generating strong named satellite assemblies with AL.exe requires Admin permissions
+                //  See https://github.com/dotnet/sdk/issues/732
+                return;
+            }
+
             Action<XDocument> projectChanges = project =>
             {
                 var ns = project.Root.Name.Namespace;

--- a/test/Microsoft.NET.TestFramework/SdkTest.cs
+++ b/test/Microsoft.NET.TestFramework/SdkTest.cs
@@ -7,23 +7,23 @@ namespace Microsoft.NET.TestFramework
     public class SdkTest : IDisposable
     {
         protected TestAssetsManager _testAssetsManager = new TestAssetsManager();
-        bool _shouldValidateDirectories;
+
+        protected bool UsingFullFrameworkMSBuild { get; private set; }
 
         public SdkTest()
         {
             Environment.SetEnvironmentVariable("DOTNET_SKIP_FIRST_TIME_EXPERIENCE", "1");
 
             string msbuildPath = Environment.GetEnvironmentVariable("DOTNET_SDK_TEST_MSBUILD_PATH");
-
-            //  Skip path length validation if running on full framework MSBuild.  We do the path length validation
-            //  to avoid getting path to long errors when copying the test drop in our build infrastructure.  However,
-            //  those builds are only built with .NET Core MSBuild.
-            _shouldValidateDirectories = string.IsNullOrEmpty(msbuildPath);
+            UsingFullFrameworkMSBuild = !string.IsNullOrEmpty(msbuildPath);
         }
 
         public void Dispose()
         {
-            if (_shouldValidateDirectories)
+            //  Skip path length validation if running on full framework MSBuild.  We do the path length validation
+            //  to avoid getting path to long errors when copying the test drop in our build infrastructure.  However,
+            //  those builds are only built with .NET Core MSBuild.
+            if (!UsingFullFrameworkMSBuild)
             {
                 _testAssetsManager.ValidateDestinationDirectories();
             }


### PR DESCRIPTION
- Add `-FullMSBuild` build switch to run tests using full MSBuild
- Add CI configuratons to include full MSBuild runs