### PR TITLE
Build with VS 15 dev tools

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -6,7 +6,7 @@ if "%ERRORLEVEL%" == "0" (
     goto :SkipDeveloperSetup
 )
 
-set DeveloperCommandPrompt=%VS140COMNTOOLS%\VsDevCmd.bat
+set DeveloperCommandPrompt=%VS150COMNTOOLS%\VsDevCmd.bat
 
 if not exist "%DeveloperCommandPrompt%" (
   echo In order to build this repository, you either need 'msbuild' on the path or Visual Studio 2015 installed.

--- a/netci.groovy
+++ b/netci.groovy
@@ -3,8 +3,8 @@
 
 // Import the utility functionality.
 
+import jobs.generation.ArchivalSettings;
 import jobs.generation.Utilities;
-import jobs.generation.InternalUtilities;
 
 def project = GithubProject
 def branch = GithubBranchName
@@ -53,8 +53,14 @@ ${buildCommand}""")
             }
         }
 
-        Utilities.setMachineAffinity(newJob, osBase, 'latest-or-auto-internal')
-        InternalUtilities.standardJobSetup(newJob, project, isPR, "*/${branch}")
+        def archiveSettings = new ArchivalSettings()
+        archiveSettings.addFiles("bin/**/*")
+        archiveSettings.excludeFiles("bin/obj/*")
+        archiveSettings.setFailIfNothingArchived()
+        archiveSettings.setArchiveOnFailure()
+        Utilities.addArchival(newJob, archiveSettings)
+        Utilities.setMachineAffinity(newJob, osBase, 'latest-or-auto')
+        Utilities.standardJobSetup(newJob, project, isPR, "*/${branch}")
         Utilities.addXUnitDotNETResults(newJob, "bin/$config/Tests/TestResults.xml", false)
         Utilities.addGithubPRTriggerForBranch(newJob, branch, "$os $config")
     }

--- a/netci.groovy
+++ b/netci.groovy
@@ -41,7 +41,10 @@ osList.each { os ->
             steps {
                 if (osBase == 'Windows_NT') {
                     // Batch
-                    batchFile(buildCommand)
+                    batchFile("""SET VS150COMNTOOLS=%ProgramFiles(x86)%\\Microsoft Visual Studio\\2017\\Enterprise\\Common7\\Tools\\
+SET VSSDK150Install=%ProgramFiles(x86)%\\Microsoft Visual Studio\\2017\\Enterprise\\VSSDK\\
+SET VSSDKInstall=%ProgramFiles(x86)%\\Microsoft Visual Studio\\2017\\Enterprise\\VSSDK\\
+${buildCommand}""")
                 }
                 else {
                     // Shell

--- a/netci.groovy
+++ b/netci.groovy
@@ -24,6 +24,7 @@ osList.each { os ->
         def buildCommand = '';
 
         def osBase = os
+        def machineAffinity = 'latest-or-auto'
 
         // Calculate the build command
         if (os == 'Windows_NT') {
@@ -31,6 +32,7 @@ osList.each { os ->
         } else if (os == 'Windows_NT_FullFramework') {
             buildCommand = ".\\build.cmd -Configuration $config -FullMSBuild"
             osBase = 'Windows_NT'
+            machineAffinity = 'latest-or-auto-dev15-rc'
         } else {
             // Jenkins non-Ubuntu CI machines don't have docker
             buildCommand = "./build.sh --configuration $config"
@@ -59,7 +61,7 @@ ${buildCommand}""")
         archiveSettings.setFailIfNothingArchived()
         archiveSettings.setArchiveOnFailure()
         Utilities.addArchival(newJob, archiveSettings)
-        Utilities.setMachineAffinity(newJob, osBase, 'latest-or-auto')
+        Utilities.setMachineAffinity(newJob, osBase, machineAffinity)
         Utilities.standardJobSetup(newJob, project, isPR, "*/${branch}")
         Utilities.addXUnitDotNETResults(newJob, "bin/$config/Tests/TestResults.xml", false)
         Utilities.addGithubPRTriggerForBranch(newJob, branch, "$os $config")

--- a/netci.groovy
+++ b/netci.groovy
@@ -44,8 +44,6 @@ osList.each { os ->
                 if (osBase == 'Windows_NT') {
                     // Batch
                     batchFile("""SET VS150COMNTOOLS=%ProgramFiles(x86)%\\Microsoft Visual Studio\\2017\\Enterprise\\Common7\\Tools\\
-SET VSSDK150Install=%ProgramFiles(x86)%\\Microsoft Visual Studio\\2017\\Enterprise\\VSSDK\\
-SET VSSDKInstall=%ProgramFiles(x86)%\\Microsoft Visual Studio\\2017\\Enterprise\\VSSDK\\
 ${buildCommand}""")
                 }
                 else {


### PR DESCRIPTION
This will hopefully fix the full framework CI runs.

It looks like they were failing because the tests had the wrong MSBuild path, which was probably because the path was using the VS 14 install folder instead of VS 15.