### PR TITLE
This change is to allow to hide implicit packages form Nuget tree subnode and show them under SDK sub node instead. There are 2 new design time tasks and 2 targets to combine SDKReference items from project with implicit package references for resolved and unresolved items.

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenResolvedSDKProjectItemsAndImplicitPackages.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenResolvedSDKProjectItemsAndImplicitPackages.cs
@@ -1,0 +1,174 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using Microsoft.Build.Framework;
+using Xunit;
+
+namespace Microsoft.NET.Build.Tasks.UnitTests
+{
+    public class GivenResolvedSDKProjectItemsAndImplicitPackages
+    {
+        [Fact]
+        public void ItShouldCombineSdkReferencesWithImplicitPackageReferences()
+        {
+            // Arrange 
+            var sdkReference1 = new MockTaskItem(
+                itemSpec: "SdkReference1",
+                metadata: new Dictionary<string, string>
+                {
+                    { MetadataKeys.Version, "2.0.1" }
+                });
+
+            var sdkReference2 = new MockTaskItem(
+                itemSpec: "SdkReference2",
+                metadata: new Dictionary<string, string>
+                {
+                    { MetadataKeys.Version, "1.0.1" }
+                });
+
+            var packageReference1 = new MockTaskItem(
+                itemSpec: "tfm1/PackageReference1/3.0.1",
+                metadata: new Dictionary<string, string>
+                {
+                    { MetadataKeys.Type, "Package" },
+                    { MetadataKeys.IsTopLevelDependency, "True" },
+                    { MetadataKeys.IsImplicitlyDefined, "True" },
+                    { MetadataKeys.SDKPackageItemSpec, "tfm1/PackageReference1/3.0.1" },
+                    { MetadataKeys.Name, "PackageReference1" },
+                    { MetadataKeys.OriginalItemSpec, "PackageReference1" },
+                    { MetadataKeys.Path, @"x:\folder\subfolder" },
+                    { MetadataKeys.Version, @"3.0.1" }
+
+                });
+
+            var packageReference1_otherTFM = new MockTaskItem(
+                itemSpec: "tfm2/PackageReference1/3.0.1",
+                metadata: new Dictionary<string, string>
+                {
+                    { MetadataKeys.Type, "Package" },
+                    { MetadataKeys.IsTopLevelDependency, "True" },
+                    { MetadataKeys.IsImplicitlyDefined, "True" },
+                    { MetadataKeys.SDKPackageItemSpec, "tfm2/PackageReference1/3.0.1" },
+                    { MetadataKeys.Name, "PackageReference1" },
+                    { MetadataKeys.OriginalItemSpec, "PackageReference1" },
+                    { MetadataKeys.Path, @"x:\folder\subfolder\tfm2" }
+
+                });
+
+            var packageReference_Target = new MockTaskItem(
+                itemSpec: "packageReference_Target",
+                metadata: new Dictionary<string, string>
+                {
+                    { MetadataKeys.Type, "Target" },
+                    { MetadataKeys.IsTopLevelDependency, "True" },
+                    { MetadataKeys.IsImplicitlyDefined, "True" },
+                    { MetadataKeys.Name, "packageReference_Target" }
+                });
+
+            var packageReference_Unknown = new MockTaskItem(
+                itemSpec: "packageReference_Unknown",
+                metadata: new Dictionary<string, string>
+                {
+                    { MetadataKeys.Type, "Xxx" },
+                    { MetadataKeys.IsTopLevelDependency, "True" },
+                    { MetadataKeys.IsImplicitlyDefined, "True" },
+                    { MetadataKeys.Name, "packageReference_Unknown" }
+                });
+
+            var packageReference_NotTopLevel = new MockTaskItem(
+                itemSpec: "packageReference_NotTopLevel",
+                metadata: new Dictionary<string, string>
+                {
+                    { MetadataKeys.Type, "Package" },
+                    { MetadataKeys.IsTopLevelDependency, "False" },
+                    { MetadataKeys.IsImplicitlyDefined, "True" },
+                    { MetadataKeys.Name, "packageReference_NotTopLevel" }
+                });
+
+            var packageReference_NotTopLevel2 = new MockTaskItem(
+                itemSpec: "packageReference_NotTopLevel2",
+                metadata: new Dictionary<string, string>
+                {
+                    { MetadataKeys.Type, "Package" },
+                    { MetadataKeys.IsTopLevelDependency, "xxxx" },
+                    { MetadataKeys.IsImplicitlyDefined, "True" },
+                    { MetadataKeys.Name, "packageReference_NotTopLevel2" }
+                });
+
+            var packageReference_NotImplicit = new MockTaskItem(
+                itemSpec: "packageReference_NotImplicit",
+                metadata: new Dictionary<string, string>
+                {
+                    { MetadataKeys.Type, "Package" },
+                    { MetadataKeys.IsTopLevelDependency, "True" },
+                    { MetadataKeys.IsImplicitlyDefined, "False" },
+                    { MetadataKeys.Name, "packageReference_NotImplicit" }
+                });
+
+            var packageReference_NotImplicit2 = new MockTaskItem(
+                itemSpec: "packageReference_NotImplicit2",
+                metadata: new Dictionary<string, string>
+                {
+                    { MetadataKeys.Type, "Package" },
+                    { MetadataKeys.IsTopLevelDependency, "True" },
+                    { MetadataKeys.IsImplicitlyDefined, "Xxxx" },
+                    { MetadataKeys.Name, "packageReference_NotImplicit2" }
+                });
+
+            var task = new CollectResolvedSDKReferencesDesignTime();
+            task.ResolvedSdkReferences = new[] {
+                sdkReference1,
+                sdkReference2
+            };
+            task.DependenciesDesignTime = new ITaskItem[] {
+                packageReference1,
+                packageReference1_otherTFM,
+                packageReference_Target,
+                packageReference_Unknown,
+                packageReference_NotTopLevel,
+                packageReference_NotTopLevel2,
+                packageReference_NotImplicit,
+                packageReference_NotImplicit2
+            };
+
+            // Act
+            var result = task.Execute();
+
+            // Assert
+            result.Should().BeTrue();
+            task.ResolvedSDKReferencesDesignTime.Count().Should().Be(3);
+
+            VerifyTaskItem(sdkReference1, task.ResolvedSDKReferencesDesignTime[0]);
+            VerifyTaskItem(sdkReference2, task.ResolvedSDKReferencesDesignTime[1]);
+            VerifyTaskItem(packageReference1, task.ResolvedSDKReferencesDesignTime[2], "PackageReference1");
+        }
+
+        private void VerifyTaskItem(ITaskItem input, ITaskItem output, string expectedItemSpec = null)
+        {
+            // remove unnecessary metadata to keep only ones that would be in result task items
+            var removeMetadata = new[] {
+                MetadataKeys.IsImplicitlyDefined,
+                MetadataKeys.IsTopLevelDependency,
+                MetadataKeys.Type
+            };
+
+            foreach(var rm in removeMetadata)
+            {
+                output.RemoveMetadata(rm);
+                input.RemoveMetadata(rm);
+            }
+            if (expectedItemSpec != null)
+            {
+                expectedItemSpec.Should().Be(output.ItemSpec);
+            }
+
+            foreach (var metadata in input.MetadataNames)
+            {
+                input.GetMetadata(metadata.ToString()).Should().Be(output.GetMetadata(metadata.ToString()));
+            }
+        }
+    }
+}

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenResolvedSDKProjectItemsAndImplicitPackages.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenResolvedSDKProjectItemsAndImplicitPackages.cs
@@ -143,6 +143,10 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
 
             VerifyTaskItem(sdkReference1, task.ResolvedSDKReferencesDesignTime[0]);
             VerifyTaskItem(sdkReference2, task.ResolvedSDKReferencesDesignTime[1]);
+
+            var path = packageReference1.GetMetadata(MetadataKeys.Path);
+            packageReference1.RemoveMetadata(MetadataKeys.Path);
+            packageReference1.SetMetadata(MetadataKeys.SDKRootFolder, path);
             VerifyTaskItem(packageReference1, task.ResolvedSDKReferencesDesignTime[2], "PackageReference1");
         }
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenThatWeWantToGetDependenciesViaDesignTimeBuild.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenThatWeWantToGetDependenciesViaDesignTimeBuild.cs
@@ -458,7 +458,8 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                     { MetadataKeys.ResolvedPath, "some resolved path" },
                     { MetadataKeys.Type, "Package" },
                     { PreprocessPackageDependenciesDesignTime.ResolvedMetadata, "True" },
-                    { PreprocessPackageDependenciesDesignTime.DependenciesMetadata, "ChildPackage1/1.0.0;ChildPackage2/2.0.0" }
+                    { PreprocessPackageDependenciesDesignTime.DependenciesMetadata, "ChildPackage1/1.0.0;ChildPackage2/2.0.0" },
+                    { MetadataKeys.IsTopLevelDependency, "True" }
                 });
 
             var mockChildPackage1 = new MockTaskItem(
@@ -471,7 +472,8 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                     { MetadataKeys.ResolvedPath, "some resolved path" },
                     { MetadataKeys.Type, "Package" },
                     { PreprocessPackageDependenciesDesignTime.ResolvedMetadata, "True" },
-                    { PreprocessPackageDependenciesDesignTime.DependenciesMetadata, "ChildPackage11/1.0.0" }
+                    { PreprocessPackageDependenciesDesignTime.DependenciesMetadata, "ChildPackage11/1.0.0" },
+                    { MetadataKeys.IsTopLevelDependency, "False" }
                 });
 
             var mockChildPackage11 = new MockTaskItem(
@@ -483,7 +485,8 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                     { MetadataKeys.Path, "some path" },
                     { MetadataKeys.ResolvedPath, "some resolved path" },
                     { MetadataKeys.Type, "Package" },
-                    { PreprocessPackageDependenciesDesignTime.ResolvedMetadata, "True" }
+                    { PreprocessPackageDependenciesDesignTime.ResolvedMetadata, "True" },
+                    { MetadataKeys.IsTopLevelDependency, "False" }
                 });
 
             var mockChildPackage2 = new MockTaskItem(
@@ -495,7 +498,8 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                     { MetadataKeys.Path, "some path" },
                     { MetadataKeys.ResolvedPath, "some resolved path" },
                     { MetadataKeys.Type, "Package" },
-                    { PreprocessPackageDependenciesDesignTime.ResolvedMetadata, "True" }
+                    { PreprocessPackageDependenciesDesignTime.ResolvedMetadata, "True" },
+                    { MetadataKeys.IsTopLevelDependency, "False" }
                 });
 
             // package dependencies
@@ -529,6 +533,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                     { MetadataKeys.ParentTarget, ".Net Framework,Version=v4.5" },
                     { MetadataKeys.ParentPackage, "Package3/1.0.0" }
                 });
+
             var task = new PreprocessPackageDependenciesDesignTime();
             task.TargetDefinitions = new[] { mockTarget };
             task.PackageDefinitions = new ITaskItem[] {

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenThatWeWantToGetDependenciesViaDesignTimeBuild.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenThatWeWantToGetDependenciesViaDesignTimeBuild.cs
@@ -69,6 +69,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             task.FileDefinitions = new ITaskItem[] { };
             task.PackageDependencies = new ITaskItem[] { };
             task.FileDependencies = new ITaskItem[] { };
+            task.PackageReferences = new ITaskItem[] { };
 
             // Act
             var result = task.Execute();
@@ -144,6 +145,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             task.FileDefinitions = new ITaskItem[] { };
             task.PackageDependencies = new ITaskItem[] { mockPackageDepNoType, mockPackageDepUnknown };
             task.FileDependencies = new ITaskItem[] { };
+            task.PackageReferences = new ITaskItem[] { };
 
             // Act
             var result = task.Execute();
@@ -201,6 +203,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             task.FileDefinitions = new ITaskItem[] { };
             task.PackageDependencies = new ITaskItem[] { mockPackageDepUnresolved };
             task.FileDependencies = new ITaskItem[] { };
+            task.PackageReferences = new ITaskItem[] { };
 
             // Act
             var result = task.Execute();
@@ -412,6 +415,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 mockPackageReferenceDep
             };
             task.FileDependencies = new ITaskItem[] { };
+            task.PackageReferences = new ITaskItem[] { };
 
             // Act
             var result = task.Execute();
@@ -541,6 +545,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 mockChildPackageDep2
             };
             task.FileDependencies = new ITaskItem[] { };
+            task.PackageReferences = new ITaskItem[] { };
 
             // Act
             var result = task.Execute();
@@ -750,6 +755,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 mockWinmdDep,
                 mockReferenceDep
             };
+            task.PackageReferences = new ITaskItem[] { };
 
             // Act
             var result = task.Execute();
@@ -793,7 +799,8 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                     { MetadataKeys.Type, "Package" },
                     { PreprocessPackageDependenciesDesignTime.ResolvedMetadata, "True" },
                     { PreprocessPackageDependenciesDesignTime.DependenciesMetadata,
-                      @"mockChildAssembly1;somepath/mockChildAssembly2;somepath/mockChildAnalyzerAssembly" }
+                      @"mockChildAssembly1;somepath/mockChildAssembly2;somepath/mockChildAnalyzerAssembly" },
+                    { MetadataKeys.IsImplicitlyDefined, "True" }
                 });
 
             var mockChildAssembly1 = new MockTaskItem(
@@ -845,7 +852,8 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 itemSpec: "Package3/1.0.0",
                 metadata: new Dictionary<string, string>
                 {
-                    { MetadataKeys.ParentTarget, ".Net Framework,Version=v4.5" }
+                    { MetadataKeys.ParentTarget, ".Net Framework,Version=v4.5" },
+                    { MetadataKeys.IsImplicitlyDefined, "True" }
                 });
 
             var mockChildAssemblyDep1 = new MockTaskItem(
@@ -901,6 +909,13 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 mockChildAssemblyDep2,
                 mockChildAssemblyNoCompileMetadataDep,
                 mockChildAnalyzerAssemblyDep
+            };
+            task.PackageReferences = new ITaskItem[] { new MockTaskItem(
+                itemSpec: "Package3",
+                metadata: new Dictionary<string, string>
+                {
+                    { MetadataKeys.IsImplicitlyDefined, "True" }
+                })
             };
 
             // Act

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/Microsoft.NET.Build.Tasks.UnitTests.csproj
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/Microsoft.NET.Build.Tasks.UnitTests.csproj
@@ -51,6 +51,8 @@
     <Compile Include="GivenACompilationOptionsConverter.cs" />
     <Compile Include="GivenAProduceContentsAssetsTask.cs" />
     <Compile Include="GivenAResolvePackageDependenciesTask.cs" />
+    <Compile Include="GivenResolvedSDKProjectItemsAndImplicitPackages.cs" />
+    <Compile Include="GivenUnresolvedSDKProjectItemsAndImplicitPackages.cs" />
     <Compile Include="LockFileSnippets.cs" />
     <Compile Include="Mocks\MockContentAssetPreprocessor.cs" />
     <Compile Include="Mocks\MockPackageResolver.cs" />

--- a/src/Tasks/Microsoft.NET.Build.Tasks/CollectResolvedSDKReferencesDesignTime.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/CollectResolvedSDKReferencesDesignTime.cs
@@ -58,7 +58,7 @@ namespace Microsoft.NET.Build.Tasks
                 newTaskItem.SetMetadata(MetadataKeys.SDKPackageItemSpec, dependencyItem.ItemSpec);
                 newTaskItem.SetMetadata(MetadataKeys.Name, itemName);
                 newTaskItem.SetMetadata(MetadataKeys.Version, dependencyItem.GetMetadata(MetadataKeys.Version));
-                newTaskItem.SetMetadata(MetadataKeys.Path, dependencyItem.GetMetadata(MetadataKeys.Path));
+                newTaskItem.SetMetadata(MetadataKeys.SDKRootFolder, dependencyItem.GetMetadata(MetadataKeys.Path));
                 newTaskItem.SetMetadata(MetadataKeys.OriginalItemSpec, itemName);
                 
                 topLevelPackages.Add(newTaskItem);

--- a/src/Tasks/Microsoft.NET.Build.Tasks/CollectResolvedSDKReferencesDesignTime.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/CollectResolvedSDKReferencesDesignTime.cs
@@ -1,0 +1,96 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+namespace Microsoft.NET.Build.Tasks
+{
+    /// <summary>
+    /// Aggregates the sdk specified as project items and implicit
+    /// packages produced by ResolvePackageDependencies.
+    /// </summary>
+    public class CollectResolvedSDKReferencesDesignTime : TaskBase
+    {
+        [Required]
+        public ITaskItem[] ResolvedSdkReferences { get; set; }
+
+        [Required]
+        public ITaskItem[] DependenciesDesignTime { get; set; }
+
+        [Output]
+        public ITaskItem[] ResolvedSDKReferencesDesignTime { get; set; }
+
+        protected override void ExecuteCore()
+        {
+            var sdkDesignTimeList = new List<ITaskItem>(ResolvedSdkReferences);
+            sdkDesignTimeList.AddRange(GetTopLevelImplicitPackageDependencies());
+
+            ResolvedSDKReferencesDesignTime = sdkDesignTimeList.ToArray();
+        }
+
+        private IEnumerable<ITaskItem> GetTopLevelImplicitPackageDependencies()
+        {
+            var uniqueTopLevelPackages = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var topLevelPackages = new List<ITaskItem>();
+            foreach (var dependencyItem in DependenciesDesignTime)
+            {
+                var dependencyItemWrapper = new DependencyItemWrapper(dependencyItem);
+                if (!(dependencyItemWrapper.Type == DependencyType.Package &&
+                      dependencyItemWrapper.IsTopLevelDependency &&
+                      dependencyItemWrapper.IsImplicitlyDefined))
+                {
+                    continue;
+                }
+
+                var itemName = dependencyItem.GetMetadata(MetadataKeys.Name);
+                if (uniqueTopLevelPackages.Contains(itemName))
+                {
+                    continue;
+                }
+
+                uniqueTopLevelPackages.Add(itemName);
+
+                var newTaskItem = new TaskItem(itemName);
+                newTaskItem.SetMetadata(MetadataKeys.SDKPackageItemSpec, dependencyItem.ItemSpec);
+                newTaskItem.SetMetadata(MetadataKeys.Name, itemName);
+                newTaskItem.SetMetadata(MetadataKeys.Version, dependencyItem.GetMetadata(MetadataKeys.Version));
+                newTaskItem.SetMetadata(MetadataKeys.Path, dependencyItem.GetMetadata(MetadataKeys.Path));
+                newTaskItem.SetMetadata(MetadataKeys.OriginalItemSpec, itemName);
+                
+                topLevelPackages.Add(newTaskItem);
+            }
+
+            return topLevelPackages;
+        }
+
+        private class DependencyItemWrapper
+        {
+            public DependencyItemWrapper(ITaskItem item)
+            {
+                var dependencyTypeString = item.GetMetadata(MetadataKeys.Type) ?? string.Empty;
+                if (Enum.TryParse(dependencyTypeString ?? string.Empty, /*ignoreCase */ true, out DependencyType dependencyType))
+                {
+                    Type = dependencyType;
+                }
+                else
+                {
+                    Type = DependencyType.Unknown;
+                }
+
+                bool.TryParse(item.GetMetadata(MetadataKeys.IsTopLevelDependency) ?? string.Empty, out bool isTopLevelDependency);
+                IsTopLevelDependency = isTopLevelDependency;
+
+                bool.TryParse(item.GetMetadata(MetadataKeys.IsImplicitlyDefined) ?? string.Empty, out bool isImplicitlyDefined);
+                IsImplicitlyDefined = isImplicitlyDefined;
+            }
+
+            public DependencyType Type { get; }
+            public bool IsTopLevelDependency { get; }
+            public bool IsImplicitlyDefined { get; }
+        }
+    }
+}

--- a/src/Tasks/Microsoft.NET.Build.Tasks/CollectSDKReferencesDesignTime.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/CollectSDKReferencesDesignTime.cs
@@ -1,0 +1,62 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+namespace Microsoft.NET.Build.Tasks
+{
+    /// <summary>
+    /// Aggregates the sdk specified as project items and implicit packages raferences.
+    /// </summary>
+    public class CollectSDKReferencesDesignTime : TaskBase
+    {
+        [Required]
+        public ITaskItem[] SdkReferences { get; set; }
+
+        [Required]
+        public ITaskItem[] PackageReferences { get; set; }
+
+        [Output]
+        public ITaskItem[] SDKReferencesDesignTime { get; set; }
+
+        protected override void ExecuteCore()
+        {
+            var sdkDesignTimeList = new List<ITaskItem>(SdkReferences);
+            sdkDesignTimeList.AddRange(GetImplicitPackageReferences());
+
+            SDKReferencesDesignTime = sdkDesignTimeList.ToArray();
+        }
+
+        private IEnumerable<ITaskItem> GetImplicitPackageReferences()
+        {
+            var implicitPackages = new List<ITaskItem>();
+            foreach (var packageReference in PackageReferences)
+            {
+                var isImplicitlyDefinedString = packageReference.GetMetadata(MetadataKeys.IsImplicitlyDefined);
+                if (string.IsNullOrEmpty(isImplicitlyDefinedString))
+                {
+                    continue;
+                }
+
+                bool isImplicitlyDefined;
+                if (!Boolean.TryParse(isImplicitlyDefinedString, out isImplicitlyDefined)
+                    || !isImplicitlyDefined)
+                {
+                    continue;
+                }
+
+                var newTaskItem = new TaskItem(packageReference.ItemSpec);
+                newTaskItem.SetMetadata(MetadataKeys.SDKPackageItemSpec, string.Empty);
+                newTaskItem.SetMetadata(MetadataKeys.Name, packageReference.ItemSpec);
+
+                implicitPackages.Add(newTaskItem);
+            }
+
+            return implicitPackages;
+        }
+    }
+}

--- a/src/Tasks/Microsoft.NET.Build.Tasks/MetadataKeys.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/MetadataKeys.cs
@@ -24,6 +24,7 @@ namespace Microsoft.NET.Build.Tasks
         // SDK Metadata
         public const string SDKPackageItemSpec = "SDKPackageItemSpec";
         public const string OriginalItemSpec = "OriginalItemSpec";
+        public const string SDKRootFolder = "SDKRootFolder";
 
         // Foreign Keys
         public const string ParentTarget = "ParentTarget";

--- a/src/Tasks/Microsoft.NET.Build.Tasks/MetadataKeys.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/MetadataKeys.cs
@@ -12,12 +12,18 @@ namespace Microsoft.NET.Build.Tasks
         public const string FileGroup = "FileGroup";
         public const string Path = "Path";
         public const string ResolvedPath = "ResolvedPath";
+        public const string IsImplicitlyDefined = "IsImplicitlyDefined";
+        public const string IsTopLevelDependency = "IsTopLevelDependency";
 
         // Target Metadata
         public const string RuntimeIdentifier = "RuntimeIdentifier";
         public const string TargetFrameworkMoniker = "TargetFrameworkMoniker";
         public const string FrameworkName = "FrameworkName";
         public const string FrameworkVersion = "FrameworkVersion";
+
+        // SDK Metadata
+        public const string SDKPackageItemSpec = "SDKPackageItemSpec";
+        public const string OriginalItemSpec = "OriginalItemSpec";
 
         // Foreign Keys
         public const string ParentTarget = "ParentTarget";

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Microsoft.NET.Build.Tasks.csproj
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Microsoft.NET.Build.Tasks.csproj
@@ -40,6 +40,8 @@
     <Compile Include="LockFileLookup.cs" />
     <Compile Include="FrameworkReferenceResolver.cs" />
     <Compile Include="BuildErrorException.cs" />
+    <Compile Include="CollectSDKReferencesDesignTime.cs" />
+    <Compile Include="CollectResolvedSDKReferencesDesignTime.cs" />
     <Compile Include="ReferenceInfo.cs" />
     <Compile Include="Resources\Strings.Designer.cs">
       <DesignTime>True</DesignTime>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.PackageDependencyResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.PackageDependencyResolution.targets
@@ -188,12 +188,60 @@ Copyright (c) .NET Foundation. All rights reserved.
           FileDefinitions="@(FileDefinitions)"
           PackageDependencies="@(PackageDependencies)"
           FileDependencies="@(FileDependencies)"
+          PackageReferences="@(PackageReference)"
           InputDiagnosticMessages="@(DiagnosticMessages)">
 
       <Output TaskParameter="DependenciesDesignTime" ItemName="_DependenciesDesignTime" />
     </PreprocessPackageDependenciesDesignTime>
   </Target>
+    
+  <!--
+    ============================================================
+                     CollectSDKReferencesDesignTime
 
+    Aggregates the sdk specified as project items and implicit
+    packages raferences.
+    ============================================================
+    -->
+
+  <UsingTask TaskName="Microsoft.NET.Build.Tasks.CollectSDKReferencesDesignTime"
+             AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
+
+  <Target Name="CollectSDKReferencesDesignTime"
+          Returns="@(_SDKReference)">
+
+    <CollectSDKReferencesDesignTime
+          SdkReferences="@(SDKReference)"
+          PackageReferences="@(PackageReference)" >
+
+      <Output TaskParameter="SDKReferencesDesignTime" ItemName="_SDKReference" />
+    </CollectSDKReferencesDesignTime>
+  </Target>
+          
+  <!--
+    ============================================================
+                     CollectResolvedSDKReferencesDesignTime
+
+    Aggregates the sdk specified as project items and implicit
+    packages produced by ResolvePackageDependencies.
+    ============================================================
+    -->
+
+  <UsingTask TaskName="Microsoft.NET.Build.Tasks.CollectResolvedSDKReferencesDesignTime"
+             AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
+
+  <Target Name="CollectResolvedSDKReferencesDesignTime"
+          Returns="@(_ResolvedSDKReference)"
+          DependsOnTargets="ResolveSDKReferencesDesignTime;ResolvePackageDependenciesDesignTime">
+
+    <CollectResolvedSDKReferencesDesignTime
+          ResolvedSdkReferences="@(ResolvedSdkReference)"
+          DependenciesDesignTime="@(_DependenciesDesignTime)" >
+
+      <Output TaskParameter="ResolvedSDKReferencesDesignTime" ItemName="_ResolvedSDKReference" />
+    </CollectResolvedSDKReferencesDesignTime>
+  </Target>
+  
   <!--
     ============================================================
                      RunProduceContentAssets


### PR DESCRIPTION
This change is to allow to hide implicit packages form Nuget tree subnode and show them under SDK sub node instead. There are 2 new design time tasks and 2 targets to combine SDKReference items from project with implicit package references for resolved and unresolved items.

Tests for new tasks are in progress code changes are under review.