### PR TITLE
Use Dev15 CI machines for Windows builds

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -29,6 +29,7 @@ osList.each { os ->
         // Calculate the build command
         if (os == 'Windows_NT') {
             buildCommand = ".\\build.cmd -Configuration $config"
+            machineAffinity = 'latest-or-auto-dev15-rc'
         } else if (os == 'Windows_NT_FullFramework') {
             buildCommand = ".\\build.cmd -Configuration $config -FullMSBuild"
             osBase = 'Windows_NT'


### PR DESCRIPTION
In #737, I updated the build script to use Dev15 tools, but only selected the Dev15 CI machines for the Full Framework runs.  This change uses the Dev15 CI machines for all Windows builds, which should fix the .NET Core CI runs.

@333fred 