### PR TITLE
Support setting Server GC and other properties from runtimeconfig.json via MSBuild properties

### DIFF
--- a/TestAssets/TestProjects/KitchenSink/TestApp/TestApp.csproj
+++ b/TestAssets/TestProjects/KitchenSink/TestApp/TestApp.csproj
@@ -6,6 +6,16 @@
     <PackageTargetFallback>portable-net45+wp8+win8+wpa</PackageTargetFallback>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
+
+  <!-- Host configuration properties -->
+  <PropertyGroup>
+    <ConcurrentGarbageCollection>false</ConcurrentGarbageCollection>
+    <ServerGarbageCollection>true</ServerGarbageCollection>
+    <RetainVMGarbageCollection>false</RetainVMGarbageCollection>
+    <ThreadPoolMinThreads>2</ThreadPoolMinThreads>
+    <ThreadPoolMaxThreads>9</ThreadPoolMaxThreads>
+  </PropertyGroup>
+
   <ItemGroup>
     <Compile Include="Program.cs" />
     <Compile Include="CompileCopyToOutput.cs">

--- a/TestAssets/TestProjects/KitchenSink/TestApp/runtimeconfig.template.json
+++ b/TestAssets/TestProjects/KitchenSink/TestApp/runtimeconfig.template.json
@@ -1,0 +1,7 @@
+{
+    "configProperties": {
+        "System.GC.Concurrent": true,
+        "extraProperty": true
+    },
+    "applyPatches": true
+}

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Publish.targets
@@ -502,7 +502,8 @@ Copyright (c) .NET Foundation. All rights reserved.
                                        RuntimeIdentifier="$(RuntimeIdentifier)"
                                        PlatformLibraryName="$(MicrosoftNETPlatformLibrary)"
                                        RuntimeFrameworkVersion="$(RuntimeFrameworkVersion)"
-                                       UserRuntimeConfig="$(UserRuntimeConfig)" />
+                                       UserRuntimeConfig="$(UserRuntimeConfig)"
+                                       HostConfigurationOptions="@(RuntimeHostConfigurationOption)" />
 
   </Target>
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.targets
@@ -117,7 +117,8 @@ Copyright (c) .NET Foundation. All rights reserved.
                                        RuntimeIdentifier="$(RuntimeIdentifier)"
                                        PlatformLibraryName="$(MicrosoftNETPlatformLibrary)"
                                        RuntimeFrameworkVersion="$(RuntimeFrameworkVersion)"
-                                       UserRuntimeConfig="$(UserRuntimeConfig)">
+                                       UserRuntimeConfig="$(UserRuntimeConfig)"
+                                       HostConfigurationOptions="@(RuntimeHostConfigurationOption)">
       
     </GenerateRuntimeConfigurationFiles>
     
@@ -130,6 +131,36 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   </Target>
 
+  <!--
+    ============================================================
+                                        DefaultRuntimeHostConfigurationOptions
+
+    Defaults @(RuntimeHostConfigurationOption) items based on MSBuild properties.
+    ============================================================
+    -->
+
+  <ItemGroup>
+    <RuntimeHostConfigurationOption Include="System.GC.Concurrent"
+                                    Condition="'$(ConcurrentGarbageCollection)' != ''"
+                                    Value="$(ConcurrentGarbageCollection)" />
+    
+    <RuntimeHostConfigurationOption Include="System.GC.Server"
+                                    Condition="'$(ServerGarbageCollection)' != ''"
+                                    Value="$(ServerGarbageCollection)" />
+    
+    <RuntimeHostConfigurationOption Include="System.GC.RetainVM"
+                                    Condition="'$(RetainVMGarbageCollection)' != ''"
+                                    Value="$(RetainVMGarbageCollection)" />
+    
+    <RuntimeHostConfigurationOption Include="System.Threading.ThreadPool.MinThreads"
+                                    Condition="'$(ThreadPoolMinThreads)' != ''"
+                                    Value="$(ThreadPoolMinThreads)" />
+    
+    <RuntimeHostConfigurationOption Include="System.Threading.ThreadPool.MaxThreads"
+                                    Condition="'$(ThreadPoolMaxThreads)' != ''"
+                                    Value="$(ThreadPoolMaxThreads)" />
+  </ItemGroup>
+  
   <!--
     ============================================================
                                         Run Information

--- a/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAProjectWithAllFeatures.cs
+++ b/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAProjectWithAllFeatures.cs
@@ -6,10 +6,12 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using FluentAssertions;
+using FluentAssertions.Json;
 using Microsoft.Extensions.DependencyModel;
 using Microsoft.NET.TestFramework;
 using Microsoft.NET.TestFramework.Assertions;
 using Microsoft.NET.TestFramework.Commands;
+using Newtonsoft.Json.Linq;
 using Xunit;
 using static Microsoft.NET.TestFramework.Commands.MSBuildTest;
 using System.Xml.Linq;
@@ -69,6 +71,33 @@ namespace Microsoft.NET.Publish.Tests
                 VerifyDependency(dependencyContext, "System.Spatial", "lib/portable-net45+wp8+win8+wpa/",
                     "de", "es", "fr", "it", "ja", "ko", "ru", "zh-Hans", "zh-Hant");
             }
+
+            var runtimeConfigJsonContents = File.ReadAllText(Path.Combine(publishDirectory.FullName, "TestApp.runtimeconfig.json"));
+            var runtimeConfigJsonObject = JObject.Parse(runtimeConfigJsonContents);
+
+            var baselineConfigJsonObject = JObject.Parse(@"{
+    ""runtimeOptions"": {
+        ""configProperties"": {
+            ""System.GC.Concurrent"": false,
+            ""System.GC.Server"": true,
+            ""System.GC.RetainVM"": false,
+            ""System.Threading.ThreadPool.MinThreads"": 2,
+            ""System.Threading.ThreadPool.MaxThreads"": 9,
+            ""extraProperty"": true
+        },
+        ""framework"": {
+            ""name"": ""Microsoft.NETCore.App"",
+            ""version"": ""set below""
+        },
+        ""applyPatches"": true
+    }
+}");
+            baselineConfigJsonObject["runtimeOptions"]["framework"]["version"] = 
+                targetFramework == "netcoreapp1.0" ? "1.0.0" : "1.1.0";
+
+            runtimeConfigJsonObject
+                .Should()
+                .BeEquivalentTo(baselineConfigJsonObject);
         }
 
         private static void VerifyDependency(DependencyContext dependencyContext, string name, string path, params string[] locales)

--- a/test/Microsoft.NET.Publish.Tests/Microsoft.NET.Publish.Tests.csproj
+++ b/test/Microsoft.NET.Publish.Tests/Microsoft.NET.Publish.Tests.csproj
@@ -28,8 +28,8 @@
     <PackageReference Include="Microsoft.DotNet.Cli.Utils">
       <Version>$(DotNetCliUtilsVersion)</Version>
     </PackageReference>
-    <PackageReference Include="FluentAssertions">
-      <Version>$(FluentAssertionsVersion)</Version>
+    <PackageReference Include="FluentAssertions.Json">
+      <Version>$(FluentAssertionsJsonVersion)</Version>
     </PackageReference>
     <PackageReference Include="xunit">
       <Version>$(xunitVersion)</Version>


### PR DESCRIPTION
@nguerrera @dsplaisted @srivatsn 

/cc @davidfowl @mlorbetske @DamianEdwards 

With this change the Web.Sdk can default `<ServerGarbageCollection>true</ServerGarbageCollection>` in their .props file, and server GC will be turned on for .NET Core apps.

Fix #474 