### PR TITLE
Import the VSSDK targets from the build tools package instead of VS

### DIFF
--- a/build/Targets/Templates.Imports.targets
+++ b/build/Targets/Templates.Imports.targets
@@ -67,7 +67,7 @@
     <NoWarn>$(NoWarn);2008</NoWarn>
   </PropertyGroup>
 
-  <Import Project="$(VsSDKInstall)\Microsoft.VsSDK.targets" Condition="'$(VsSDKInstall)' != ''" />
+  <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="Exists('$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets')" /> 
   <Import Project="Signing.Imports.targets"/>
 
 </Project>


### PR DESCRIPTION
The VSSDK build tools package sets a property called VSToolsPath to point to the folder containing the VSSDK targets.

@mavasani @dotnet/project-system 