### PR TITLE
Make build.cmd work if only Dev15 is installed.

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -28,7 +28,8 @@ if($Help)
 }
 
 $RepoRoot = "$PSScriptRoot"
-$env:NUGET_PACKAGES = "$RepoRoot\packages"
+$PackagesPath = "$RepoRoot\packages"
+$env:NUGET_PACKAGES = $PackagesPath
 $DotnetCLIVersion = Get-Content "$RepoRoot\DotnetCLIVersion.txt"
 
 # Use a repo-local install directory (but not the bin directory because that gets cleaned a lot)
@@ -94,21 +95,7 @@ $msbuildSummaryLog = Join-Path -path $logPath -childPath "templates.log"
 $msbuildWarningLog = Join-Path -path $logPath -childPath "templates.wrn"
 $msbuildFailureLog = Join-Path -path $logPath -childPath "templates.err"
 
-# TODO: https://github.com/dotnet/sdk/issues/342: convert Templates\* from project.json to PackageReference 
-# In the meantime, use Windows nuget.exe v3.4.4 to restore packages for the templates solution.
-$nugetDir = "$RepoRoot\.nuget"
-if (!(Test-Path $nugetDir))
-{
-    mkdir $nugetDir
-}
-
-$nuget = "$nugetDir\nuget.exe"
-if (!(Test-Path $nuget))
-{
-    Invoke-WebRequest "https://dist.nuget.org/win-x86-commandline/v3.4.4/NuGet.exe" -OutFile $nuget
-}
-
-& $nuget restore $RepoRoot\sdk-templates.sln
+msbuild /t:restore /p:RestorePackagesPath=$PackagesPath $RepoRoot\sdk-templates.sln /verbosity:$Verbosity
 if($LASTEXITCODE -ne 0) { throw "Failed to restore nuget packages for templates" }
 
 msbuild $commonBuildArgs /nr:false /p:BuildTemplates=true /flp1:Summary`;Verbosity=diagnostic`;Encoding=UTF-8`;LogFile=$msbuildSummaryLog /flp2:WarningsOnly`;Verbosity=diagnostic`;Encoding=UTF-8`;LogFile=$msbuildWarningLog /flp3:ErrorsOnly`;Verbosity=diagnostic`;Encoding=UTF-8`;LogFile=$msbuildFailureLog


### PR DESCRIPTION
Currently it doesn't because build.cmd tries to restore the Templates solution using NuGet 3.4.4 which looks for a machine-wide msbuild and on a Dev15-only machine it find 4.0 and fails miserably.

A newer NuGet.exe would presumably work but instead changing the script to just invoke msbuild /t:restore.