### PR TITLE
Multitarget SDK tasks to .NET 4.6 as well as .NET Standard, and load different versions of NewtonSoft.Json side-by-side

### DIFF
--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -17,6 +17,7 @@
     <FluentAssertionsVersion>4.0.0</FluentAssertionsVersion>
     <FluentAssertionsJsonVersion>4.12.0</FluentAssertionsJsonVersion>
     <NewtonsoftJsonVersion>9.0.1</NewtonsoftJsonVersion>
+    <NewtonsoftJsonOnNetFrameworkVersion>6.0.4</NewtonsoftJsonOnNetFrameworkVersion>
     <DotNetCliUtilsVersion>1.0.0-preview2-003121</DotNetCliUtilsVersion>
   </PropertyGroup>
   

--- a/build/Nuget/Microsoft.NET.Sdk.Nuget.targets
+++ b/build/Nuget/Microsoft.NET.Sdk.Nuget.targets
@@ -19,29 +19,29 @@
       <CopyLocalAssembly Include="@(NuGetCopyLocalAssembly)">
         <Version>$(NuGetVersion)</Version>
         <TFM>netstandard1.3</TFM>
-        <DestinationTFM>net46;netcoreapp1.0</DestinationTFM>
+        <DestinationTFM>netcoreapp1.0</DestinationTFM>
       </CopyLocalAssembly>
       <CopyLocalAssembly Include="NuGet.Versioning">
         <Version>$(NuGetVersion)</Version>
         <TFM>netstandard1.0</TFM>
-        <DestinationTFM>net46;netcoreapp1.0</DestinationTFM>
+        <DestinationTFM>netcoreapp1.0</DestinationTFM>
       </CopyLocalAssembly>
 
       <CopyLocalAssembly Include="Microsoft.Extensions.DependencyModel">
         <Version>$(CoreSetupVersion)</Version>
         <TFM>netstandard1.3</TFM>
-        <DestinationTFM>net46;netcoreapp1.0</DestinationTFM>
+        <DestinationTFM>netcoreapp1.0</DestinationTFM>
       </CopyLocalAssembly>
       <CopyLocalAssembly Include="Microsoft.DotNet.PlatformAbstractions">
         <Version>$(CoreSetupVersion)</Version>
         <TFM>netstandard1.3</TFM>
-        <DestinationTFM>net46;netcoreapp1.0</DestinationTFM>
+        <DestinationTFM>netcoreapp1.0</DestinationTFM>
       </CopyLocalAssembly>
 
       <CopyLocalAssembly Include="Newtonsoft.Json">
         <Version>9.0.1</Version>
         <TFM>netstandard1.0</TFM>
-        <DestinationTFM>net46;netcoreapp1.0</DestinationTFM>
+        <DestinationTFM>netcoreapp1.0</DestinationTFM>
       </CopyLocalAssembly>
 
       <CopyLocalAssembly Include="System.Runtime.Serialization.Primitives">
@@ -49,79 +49,9 @@
         <TFM>netstandard1.3</TFM>
         <DestinationTFM>netcoreapp1.0</DestinationTFM>
       </CopyLocalAssembly>
-
-      <CopyLocalAssembly Include="System.Runtime.InteropServices.RuntimeInformation">
-        <Version>4.0.0</Version>
-        <TFM>net45</TFM>
-        <DestinationTFM>net46</DestinationTFM>
-      </CopyLocalAssembly>
-      <CopyLocalAssembly Include="System.Security.Cryptography.Algorithms">
-        <Version>4.2.0</Version>
-        <TFM>net46</TFM>
-        <DestinationTFM>net46</DestinationTFM>
-      </CopyLocalAssembly>
-      <CopyLocalAssembly Include="System.Security.Cryptography.Primitives">
-        <Version>4.0.0</Version>
-        <TFM>net46</TFM>
-        <DestinationTFM>net46</DestinationTFM>
-      </CopyLocalAssembly>
-      <CopyLocalAssembly Include="System.Threading.Thread">
-        <Version>4.0.0</Version>
-        <TFM>net46</TFM>
-        <DestinationTFM>net46</DestinationTFM>
-      </CopyLocalAssembly>
-      <CopyLocalAssembly Include="System.IO.FileSystem">
-        <Version>4.0.1</Version>
-        <TFM>net46</TFM>
-        <DestinationTFM>net46</DestinationTFM>
-      </CopyLocalAssembly>
-      <CopyLocalAssembly Include="System.AppContext">
-        <Version>4.1.0</Version>
-        <TFM>net46</TFM>
-        <DestinationTFM>net46</DestinationTFM>
-      </CopyLocalAssembly>
-      <CopyLocalAssembly Include="System.Console">
-        <Version>4.0.0</Version>
-        <TFM>net46</TFM>
-        <DestinationTFM>net46</DestinationTFM>
-      </CopyLocalAssembly>
-      <CopyLocalAssembly Include="System.Diagnostics.FileVersionInfo">
-        <Version>4.0.0</Version>
-        <TFM>net46</TFM>
-        <DestinationTFM>net46</DestinationTFM>
-      </CopyLocalAssembly>
-      <CopyLocalAssembly Include="System.Diagnostics.Process">
-        <Version>4.1.0</Version>
-        <TFM>net46</TFM>
-        <DestinationTFM>net46</DestinationTFM>
-      </CopyLocalAssembly>
-      <CopyLocalAssembly Include="System.Diagnostics.StackTrace">
-        <Version>4.0.1</Version>
-        <TFM>net46</TFM>
-        <DestinationTFM>net46</DestinationTFM>
-      </CopyLocalAssembly>
-      <CopyLocalAssembly Include="System.IO.Compression">
-        <Version>4.1.0</Version>
-        <TFM>net46</TFM>
-        <DestinationTFM>net46</DestinationTFM>
-      </CopyLocalAssembly>
-      <CopyLocalAssembly Include="System.IO.FileSystem.Primitives">
-        <Version>4.0.1</Version>
-        <TFM>net46</TFM>
-        <DestinationTFM>net46</DestinationTFM>
-      </CopyLocalAssembly>
+      
       <CopyLocalAssembly Include="System.Security.Claims">
         <Version>4.0.1</Version>
-        <TFM>net46</TFM>
-        <DestinationTFM>net46</DestinationTFM>
-      </CopyLocalAssembly>
-      <CopyLocalAssembly Include="System.Security.Cryptography.Encoding">
-        <Version>4.0.0</Version>
-        <TFM>net46</TFM>
-        <DestinationTFM>net46</DestinationTFM>
-      </CopyLocalAssembly>
-      <CopyLocalAssembly Include="System.Security.Cryptography.X509Certificates">
-        <Version>4.1.0</Version>
         <TFM>net46</TFM>
         <DestinationTFM>net46</DestinationTFM>
       </CopyLocalAssembly>
@@ -130,31 +60,12 @@
         <TFM>net46</TFM>
         <DestinationTFM>net46</DestinationTFM>
       </CopyLocalAssembly>
-      <CopyLocalAssembly Include="System.Text.Encoding.CodePages">
-        <Version>4.0.1</Version>
-        <TFM>net46</TFM>
-        <DestinationTFM>net46</DestinationTFM>
-      </CopyLocalAssembly>
       <CopyLocalAssembly Include="System.Xml.ReaderWriter">
         <Version>4.0.11</Version>
         <TFM>netstandard1.3</TFM>
         <DestinationTFM>net46</DestinationTFM>
       </CopyLocalAssembly>
-      <CopyLocalAssembly Include="System.Xml.XmlDocument">
-        <Version>4.0.1</Version>
-        <TFM>net46</TFM>
-        <DestinationTFM>net46</DestinationTFM>
-      </CopyLocalAssembly>
-      <CopyLocalAssembly Include="System.Xml.XPath">
-        <Version>4.0.1</Version>
-        <TFM>net46</TFM>
-        <DestinationTFM>net46</DestinationTFM>
-      </CopyLocalAssembly>
-      <CopyLocalAssembly Include="System.Xml.XPath.XDocument">
-        <Version>4.0.1</Version>
-        <TFM>net46</TFM>
-        <DestinationTFM>net46</DestinationTFM>
-      </CopyLocalAssembly>
+
 
       <CopyLocalAssembly>
         <PackageRelativePath>$([System.String]::Copy('%(Identity)\%(Version)').ToLowerInvariant())</PackageRelativePath>
@@ -192,10 +103,36 @@
 
       <CopyLocalBuildFile Include="@(CopyLocalBuildCrossTargetingFile)" />
       <CopyLocalBuildFile Include="@(CopyLocalSdkFile)" />
+
+      <!-- Use the contents of the output directory of the net46 build of the SDK tasks, except
+           for MSBuild and Roslyn DLLs and their dependencies-->
+      <Net46OutputAssembly Include="$(OutDir)net46\*.dll" />
+      
+      <!-- Use the versions of these that come with MSBuild -->
+      <Net46OutputAssembly Remove="$(OutDir)net46\Microsoft.Build.Framework.dll" />
+      <Net46OutputAssembly Remove="$(OutDir)net46\Microsoft.Build.Utilities.Core.dll" />
+
+      <!-- This is a dependency of Microsoft.Build.Utilities.Core -->
+      <Net46OutputAssembly Remove="$(OutDir)net46\Microsoft.Win32.Primitives.dll" />
+      
+      <!-- Use versions of Roslyn that come with MSBuild / the CLI -->
+      <Net46OutputAssembly Remove="$(OutDir)net46\Microsoft.CodeAnalysis.CSharp.dll" />
+      <Net46OutputAssembly Remove="$(OutDir)net46\Microsoft.CodeAnalysis.dll" />
+      
+      <!-- These should be dependencies of Roslyn -->
+      <Net46OutputAssembly Remove="$(OutDir)net46\System.Collections.Immutable.dll" />
+      <Net46OutputAssembly Remove="$(OutDir)net46\System.Collections.NonGeneric.dll" />
+      <Net46OutputAssembly Remove="$(OutDir)net46\System.Diagnostics.TraceSource.dll" />
+      <Net46OutputAssembly Remove="$(OutDir)net46\System.Reflection.Metadata.dll" />
+      <Net46OutputAssembly Remove="$(OutDir)net46\System.Reflection.TypeExtensions.dll" />
+
     </ItemGroup>
 
     <Copy SourceFiles="%(Net46CopyLocalAssembly.FullFilePath)"
           DestinationFolder="$(PackagesLayoutToolsNet46Dir)" />
+
+    <Copy SourceFiles="@(Net46OutputAssembly)"
+      DestinationFolder="$(PackagesLayoutToolsNet46Dir)" />
 
     <Copy SourceFiles="%(NetCoreAppCopyLocalAssembly.FullFilePath)"
           DestinationFolder="$(PackagesLayoutToolsNetCoreAppDir)" />

--- a/build/Nuget/Microsoft.NET.Sdk.Nuget.targets
+++ b/build/Nuget/Microsoft.NET.Sdk.Nuget.targets
@@ -134,8 +134,8 @@
     <Copy SourceFiles="@(Net46OutputAssembly)"
       DestinationFolder="$(PackagesLayoutToolsNet46Dir)" />
 
-    <Copy SourceFiles="$(NuGet_Packages)\newtonsoft.json\6.0.4\lib\net45\NewtonSoft.Json.dll"
-          DestinationFolder="$(PackagesLayoutToolsNet46Dir)NewtonSoft.Json.6.0.4"/>
+    <Copy SourceFiles="$(NuGet_Packages)\newtonsoft.json\6.0.4\lib\net45\Newtonsoft.Json.dll"
+          DestinationFolder="$(PackagesLayoutToolsNet46Dir)Newtonsoft.Json.6.0.4"/>
 
     <Copy SourceFiles="%(NetCoreAppCopyLocalAssembly.FullFilePath)"
           DestinationFolder="$(PackagesLayoutToolsNetCoreAppDir)" />

--- a/build/Nuget/Microsoft.NET.Sdk.Nuget.targets
+++ b/build/Nuget/Microsoft.NET.Sdk.Nuget.targets
@@ -134,6 +134,9 @@
     <Copy SourceFiles="@(Net46OutputAssembly)"
       DestinationFolder="$(PackagesLayoutToolsNet46Dir)" />
 
+    <Copy SourceFiles="$(NuGet_Packages)\newtonsoft.json\6.0.4\lib\net45\NewtonSoft.Json.dll"
+          DestinationFolder="$(PackagesLayoutToolsNet46Dir)NewtonSoft.Json.6.0.4"/>
+
     <Copy SourceFiles="%(NetCoreAppCopyLocalAssembly.FullFilePath)"
           DestinationFolder="$(PackagesLayoutToolsNetCoreAppDir)" />
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Microsoft.NET.Build.Tasks.csproj
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Microsoft.NET.Build.Tasks.csproj
@@ -10,7 +10,8 @@
     <RootNamespace>Microsoft.NET.Build.Tasks</RootNamespace>
     <AssemblyName>Microsoft.NET.Build.Tasks</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
-    <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netstandard1.3</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">netstandard1.3;net46</TargetFrameworks>
     <GenerateDependencyFile>false</GenerateDependencyFile>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Microsoft.NET.Build.Tasks.csproj
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Microsoft.NET.Build.Tasks.csproj
@@ -17,6 +17,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'net46'">
     <OutDir>$(OutDir)net46\</OutDir>
+    <DefineConstants>$(DefineConstants);NET46</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Sdk">
@@ -37,10 +38,6 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net46'">
     <Reference Include="System" />
-
-    <!-- Downgrade NewtonSoft.Json reference to the version NuGet uses for .NET Framework,
-         even though Microsoft.Extensions.DependencyModel depends on version 9.0.1 -->
-    <PackageReference Include="NewtonSoft.Json" Version="$(NewtonsoftJsonOnNetFrameworkVersion)" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CheckForDuplicateItems.cs" />

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Microsoft.NET.Build.Tasks.csproj
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Microsoft.NET.Build.Tasks.csproj
@@ -10,9 +10,12 @@
     <RootNamespace>Microsoft.NET.Build.Tasks</RootNamespace>
     <AssemblyName>Microsoft.NET.Build.Tasks</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
-    <TargetFramework>netstandard1.3</TargetFramework>
+    <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
     <GenerateDependencyFile>false</GenerateDependencyFile>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net46'">
+    <OutDir>$(OutDir)net46\</OutDir>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Sdk">
@@ -30,6 +33,13 @@
     <PackageReference Include="Microsoft.Build.Utilities.Core">
       <Version>$(MsBuildPackagesVersion)</Version>
     </PackageReference>
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net46'">
+    <Reference Include="System" />
+
+    <!-- Downgrade NewtonSoft.Json reference to the version NuGet uses for .NET Framework,
+         even though Microsoft.Extensions.DependencyModel depends on version 9.0.1 -->
+    <PackageReference Include="NewtonSoft.Json" Version="$(NewtonsoftJsonOnNetFrameworkVersion)" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CheckForDuplicateItems.cs" />
@@ -72,6 +82,16 @@
     <Compile Include="RuntimeConfig.cs" />
     <Compile Include="RuntimeConfigFramework.cs" />
     <Compile Include="RuntimeOptions.cs" />
+    <Compile Include="DependencyContextBuilder.cs" />
+    <Compile Include="GenerateDepsFile.cs" />
+    <Compile Include="GenerateRuntimeConfigurationFiles.cs" />
+    <Compile Include="LockFileCache.cs" />
+    <Compile Include="FileGroup.cs" />
+    <Compile Include="MetadataKeys.cs" />
+    <Compile Include="ResolvePackageDependencies.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' != 'net46'">
     <None Include="buildCrossTargeting\Microsoft.NET.Sdk.targets">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
@@ -138,14 +158,6 @@
     <None Include="sdk\Sdk.targets">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <Compile Include="DependencyContextBuilder.cs" />
-    <Compile Include="GenerateDepsFile.cs" />
-    <Compile Include="GenerateRuntimeConfigurationFiles.cs" />
-    <Compile Include="LockFileCache.cs" />
-    <Compile Include="FileGroup.cs" />
-    <Compile Include="MetadataKeys.cs" />
-    <Compile Include="ResolvePackageDependencies.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Resources\Strings.resx">

--- a/src/Tasks/Microsoft.NET.Build.Tasks/TaskBase.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/TaskBase.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.IO;
+using System.Reflection;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 
@@ -8,6 +10,30 @@ namespace Microsoft.NET.Build.Tasks
 {
     public abstract class TaskBase : Task
     {
+        //  Our tasks depend on both the NuGet APIs and Microsoft.Extensions.DependencyModel
+        //  For .NET Framework, the NuGet APIs depend on version 6.0.4 of NewtonSoft.Json.
+        //  However, Microsoft.Extensions.DependencyModel depends on version 9.0.1.
+        //  This is a problem because MSBuild tasks can't supply binding redirects, so we
+        //  can't redirect the reference that the NuGet APIs have on version 6.0.4 of
+        //  NewtonSoft.Json to a higher version.
+        //
+        //  To fix this issue, we ship version 6.0.4 of NewtonSoft.Json in a subfolder and
+        //  explicitly load it from there before any of the NuGet APIs are used.  This means
+        //  that when the framework tries to bind the NuGet API references to NewtonSoft.Json,
+        //  it will resolve to the 6.0.4 version that has already been loaded, instead of trying
+        //  to load the 9.0.1 version that is in the base tasks folder and failing due to a version
+        //  mismatch.  So the 9.0.1 and 6.0.4 versions will load side-by-side, and everything
+        //  should work as long as we don't try to exchange types between the two.
+#if NET46
+        static TaskBase()
+        {
+            string assemblyFolder = Path.GetDirectoryName(typeof(TaskBase).Assembly.Location);
+            string newtonSoft604Path = Path.Combine(assemblyFolder, "NewtonSoft.Json.6.0.4", "NewtonSoft.Json.dll");
+            Assembly.LoadFrom(newtonSoft604Path);
+            //System.Reflection.Assembly.LoadFrom(@"C:\git\dotnet-sdk\bin\Debug\Sdks\Microsoft.NET.Sdk\tools\net46\NewtonSoft.Json.6.0.4\NewtonSoft.Json.dll");
+        }
+#endif
+
         private readonly DiagnosticsHelper _diagnostics;
 
         public DiagnosticsHelper Diagnostics

--- a/src/Tasks/Microsoft.NET.Build.Tasks/TaskBase.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/TaskBase.cs
@@ -11,15 +11,15 @@ namespace Microsoft.NET.Build.Tasks
     public abstract class TaskBase : Task
     {
         //  Our tasks depend on both the NuGet APIs and Microsoft.Extensions.DependencyModel
-        //  For .NET Framework, the NuGet APIs depend on version 6.0.4 of NewtonSoft.Json.
+        //  For .NET Framework, the NuGet APIs depend on version 6.0.4 of Newtonsoft.Json.
         //  However, Microsoft.Extensions.DependencyModel depends on version 9.0.1.
         //  This is a problem because MSBuild tasks can't supply binding redirects, so we
         //  can't redirect the reference that the NuGet APIs have on version 6.0.4 of
-        //  NewtonSoft.Json to a higher version.
+        //  Newtonsoft.Json to a higher version.
         //
-        //  To fix this issue, we ship version 6.0.4 of NewtonSoft.Json in a subfolder and
+        //  To fix this issue, we ship version 6.0.4 of Newtonsoft.Json in a subfolder and
         //  explicitly load it from there before any of the NuGet APIs are used.  This means
-        //  that when the framework tries to bind the NuGet API references to NewtonSoft.Json,
+        //  that when the framework tries to bind the NuGet API references to Newtonsoft.Json,
         //  it will resolve to the 6.0.4 version that has already been loaded, instead of trying
         //  to load the 9.0.1 version that is in the base tasks folder and failing due to a version
         //  mismatch.  So the 9.0.1 and 6.0.4 versions will load side-by-side, and everything
@@ -28,9 +28,8 @@ namespace Microsoft.NET.Build.Tasks
         static TaskBase()
         {
             string assemblyFolder = Path.GetDirectoryName(typeof(TaskBase).Assembly.Location);
-            string newtonSoft604Path = Path.Combine(assemblyFolder, "NewtonSoft.Json.6.0.4", "NewtonSoft.Json.dll");
+            string newtonSoft604Path = Path.Combine(assemblyFolder, "Newtonsoft.Json.6.0.4", "Newtonsoft.Json.dll");
             Assembly.LoadFrom(newtonSoft604Path);
-            //System.Reflection.Assembly.LoadFrom(@"C:\git\dotnet-sdk\bin\Debug\Sdks\Microsoft.NET.Sdk\tools\net46\NewtonSoft.Json.6.0.4\NewtonSoft.Json.dll");
         }
 #endif
 


### PR DESCRIPTION
Fixes #745 

Prior to this PR, we were compiling our tasks once for .NET Standard.  We ship the dependencies of our tasks together with the tasks, and these dependencies include the NuGet API DLLs as well as Microsoft.Extensions.DependencyModel.

The NuGet DLLs are multitargeted to .NET Framework and .NET Standard.  The .NET Standard versions of the DLLs depend on NewtonSoft.Json 9.0.1, while the .NET Framework versions depend on version 6.0.4.  Using the .NET Standard versions of the NuGet DLLs on .NET Framework ended up causing problems, as the .NET Framework versions of those are shipped together with the NuGet restore tasks.  So if an SDK task ran first, it would load the .NET Standard version of a NuGet DLL from the SDK task folder, while if the NuGet restore task ran first, it would load the .NET Framework version of NuGet DLLs from the NuGet tasks folder.  The SDK task would not load all the NuGet DLLs, however, so if an SDK task ran first, there would be a mix of .NET Standard and .NET Framework targeted NuGet DLLs, which in turn depended on different versions of NewtonSoft.Json.  When they tried to exchange types from NewtonSoft.Json, it would fail with the message `Method not found: 'NuGet.RuntimeModel.RuntimeGraph NuGet.RuntimeModel.JsonRuntimeFormat.ReadRuntimeGraph(Newtonsoft.Json.Linq.JToken)'.`

We mitigated this in #699 by avoiding running any of our tasks before the NuGet restore task runs.  However, if a non-CPS project references a .NET SDK project, then the build can run in-process in Visual Studio, and load the SDK tasks into VS.  Depending on timing, this can happen before the .NET Framework versions of the NuGet DLLs have been otherwise loaded, resulting in the same error: #745 

This PR attempts to provide a "real" fix to the problem, by switching the build of the tasks assembly to multitargeting .NET Standard 1.3 and .NET Framework 4.6, and to ship the .NET Framework versions of the NuGet DLLs with the .NET Framework version of the SDK tasks.  This way, it won't matter where the NuGet DLLs are loaded from first, as both places will have the exact same DLLs.

However, switching to the .NET Framework versions of the NuGet DLLs means that we have the NuGet DLLs which depend on version 6.0.4 of NewtonSoft.Json, as well as Microsoft.Extensions.DependencyModel which still depends on version 9.0.1.  Generally in targeting .NET Framework you would use binding redirects to unify different versions of diamond dependencies to a single version.  However, binding redirects are not supported for MSBuild tasks.  To resolve this issue, this PR includes NewtonSoft.Json in a subfolder, and uses `Assembly.LoadFrom` to load that DLL before any NuGet APIs are used.  Thus, when the framework tries to bind the references from the NuGet DLLs to NewtonSoft.Json 6.0.4, it will use the already-loaded 6.0.4 version, instead of trying to load the 9.0.1 version that is in the base tasks folder and failing due to a version mismatch.  So the 9.0.1 and 6.0.4 versions will load side-by-side, and everything should work as long as we don't try to exchange types between the two.

With this change, we are also relying on NuGet and the build process to copy the dependencies of the task assembly to the net46 output folder, and including them in the tools\net46 folder of the NuGet package, instead of explicitly listing each DLL to be copied in Microsoft.NET.Sdk.Nuget.targets.