### PR TITLE
Continue on Error in ResolvePackageDependencies

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.PackageDependencyResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.PackageDependencyResolution.targets
@@ -154,7 +154,8 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ResolvePackageDependencies
       ProjectPath="$(MSBuildProjectFullPath)"
       ProjectAssetsFile="$(ProjectAssetsFile)"
-      ProjectLanguage="$(Language)">
+      ProjectLanguage="$(Language)"
+      ContinueOnError="ErrorAndContinue">
 
       <Output TaskParameter="TargetDefinitions" ItemName="TargetDefinitions" />
       <Output TaskParameter="PackageDefinitions" ItemName="PackageDefinitions" />


### PR DESCRIPTION
**Customer scenario**

A customer with one project containing a broken dependency may observe all the other projects in the solution have unresolved NuGet packages. Specifically, projects which transitively depend on the broken project contain unresolved package references after reloading the solution. This experience is confusing for users since it suggests all their projects are broken, when in fact just one is broken.

**Bugs this fixes:**

#717 

**Workarounds, if any**

Fix the broken project reference, assuming user can root cause the problem

**Risk**

Low

**Performance impact**

None

**Is this a regression from a previous update?**

No

**Root cause analysis:**

This occurs because the broken project reference produces an error upstream in all the dependent projects, and this error forces the ResolvePackageDependencies to terminate prematurely. The fix is to allow the task to continue when it encounters errors since the errors do not prevent the task from performing its duties including emitting resolved package references.

**How was the bug found?**

Dogfooding

/cc @nguerrera @dsplaisted @srivatsn @rainersigwald 
