### PR TITLE
Add runtimeconfig.json to BuiltProjectOutputGroupOutput

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.targets
@@ -131,6 +131,16 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   </Target>
 
+  <!-- Add runtimeconfig.json file to BuiltProjectOutputGroupOutput, so that it will get included in the NuGet package by the Pack target -->
+  <Target Name="AddRuntimeConfigFileToBuiltProjectOutputGroupOutput"
+          Condition=" '$(GenerateRuntimeConfigurationFiles)' == 'true'"
+          BeforeTargets="BuiltProjectOutputGroup"
+          DependsOnTargets="GenerateBuildRuntimeConfigurationFiles">
+    <ItemGroup>
+      <BuiltProjectOutputGroupOutput Include="$(ProjectRuntimeConfigFilePath)" FinalOutputPath="$(ProjectRuntimeConfigFilePath)" />
+    </ItemGroup>
+  </Target>
+
   <!--
     ============================================================
                                         DefaultRuntimeHostConfigurationOptions

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.targets
@@ -134,8 +134,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <!-- Add runtimeconfig.json file to BuiltProjectOutputGroupOutput, so that it will get included in the NuGet package by the Pack target -->
   <Target Name="AddRuntimeConfigFileToBuiltProjectOutputGroupOutput"
           Condition=" '$(GenerateRuntimeConfigurationFiles)' == 'true'"
-          BeforeTargets="BuiltProjectOutputGroup"
-          DependsOnTargets="GenerateBuildRuntimeConfigurationFiles">
+          BeforeTargets="BuiltProjectOutputGroup">
     <ItemGroup>
       <BuiltProjectOutputGroupOutput Include="$(ProjectRuntimeConfigFilePath)" FinalOutputPath="$(ProjectRuntimeConfigFilePath)" />
     </ItemGroup>

--- a/test/Microsoft.NET.Pack.Tests/GivenThatWeWantToPackAHelloWorldProject.cs
+++ b/test/Microsoft.NET.Pack.Tests/GivenThatWeWantToPackAHelloWorldProject.cs
@@ -37,10 +37,14 @@ namespace Microsoft.NET.Pack.Tests
             XElement filesSection = nuspec.Root.Element(ns + "files");
 
             var fileTargets = filesSection.Elements().Select(files => files.Attribute("target").Value).ToList();
-            fileTargets.Should().BeEquivalentTo(
+
+            var expectedFileTargets = new[]
+            {
                 @"lib\netcoreapp1.0\HelloWorld.runtimeconfig.json",
                 @"lib\netcoreapp1.0\HelloWorld.dll"
-                );
+            }.Select(p => p.Replace('\\', Path.DirectorySeparatorChar));
+
+            fileTargets.Should().BeEquivalentTo(expectedFileTargets);
         }
     }
 }

--- a/test/Microsoft.NET.Pack.Tests/GivenThatWeWantToPackAHelloWorldProject.cs
+++ b/test/Microsoft.NET.Pack.Tests/GivenThatWeWantToPackAHelloWorldProject.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Xml.Linq;
+using Microsoft.NET.TestFramework;
+using Microsoft.NET.TestFramework.Assertions;
+using Microsoft.NET.TestFramework.Commands;
+using FluentAssertions;
+using Xunit;
+using static Microsoft.NET.TestFramework.Commands.MSBuildTest;
+
+namespace Microsoft.NET.Pack.Tests
+{
+    public class GivenThatWeWantToPackAHelloWorldProject : SdkTest
+    {
+        [Fact]
+        public void It_packs_successfully()
+        {
+            var helloWorldAsset = _testAssetsManager
+                .CopyTestAsset("HelloWorld", "PackHelloWorld")
+                .WithSource()
+                .Restore();
+
+            new PackCommand(Stage0MSBuild, helloWorldAsset.TestRoot)
+                .Execute()
+                .Should()
+                .Pass();
+
+            //  Validate the contents of the NuGet package by looking at the generated .nuspec file, as that's simpler
+            //  than unzipping and inspecting the .nupkg
+            string nuspecPath = Path.Combine(helloWorldAsset.TestRoot, "obj", "HelloWorld.1.0.0.nuspec");
+            var nuspec = XDocument.Load(nuspecPath);
+
+            var ns = nuspec.Root.Name.Namespace;
+            XElement filesSection = nuspec.Root.Element(ns + "files");
+
+            var fileTargets = filesSection.Elements().Select(files => files.Attribute("target").Value).ToList();
+            fileTargets.Should().BeEquivalentTo(
+                @"lib\netcoreapp1.0\HelloWorld.runtimeconfig.json",
+                @"lib\netcoreapp1.0\HelloWorld.dll"
+                );
+        }
+    }
+}

--- a/test/Microsoft.NET.Pack.Tests/Microsoft.NET.Pack.Tests.csproj
+++ b/test/Microsoft.NET.Pack.Tests/Microsoft.NET.Pack.Tests.csproj
@@ -36,6 +36,7 @@
     </PackageReference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="GivenThatWeWantToPackAHelloWorldProject.cs" />
     <Compile Include="GivenThatWeWantToPackASimpleLibrary.cs" />
     <Compile Include="GivenThatWeWantToPackACrossTargetedLibrary.cs" />
     <EmbeddedResource Include="**\*.resx" Exclude="$(GlobalExclude)" />


### PR DESCRIPTION
Adds runtimeconfig.json to BuiltProjectOutputGroupOutput item. This will cause it to be included in the NuGet package if an application project is packed.

Fixes #472 