### PR TITLE
Revert ".NET Standard template should not have it's own node"

### DIFF
--- a/src/Templates/ProjectTemplates/CSharp/.NETStandard/CSharpNetStandardClassLibrary/CSharpNetStandardClassLibrary.csproj
+++ b/src/Templates/ProjectTemplates/CSharp/.NETStandard/CSharpNetStandardClassLibrary/CSharpNetStandardClassLibrary.csproj
@@ -52,6 +52,7 @@
   <ItemGroup>
     <VSTemplate Include="ClassLibrary.vstemplate">
       <SubType>Designer</SubType>
+      <OutputSubPath>.NET Standard</OutputSubPath>
     </VSTemplate>
   </ItemGroup>
   <ItemGroup>

--- a/src/Templates/ProjectTemplates/VisualBasic/.NETStandard/VisualBasicNetStandardClassLibrary/VisualBasicNetStandardClassLibrary.csproj
+++ b/src/Templates/ProjectTemplates/VisualBasic/.NETStandard/VisualBasicNetStandardClassLibrary/VisualBasicNetStandardClassLibrary.csproj
@@ -53,6 +53,7 @@
   <ItemGroup>
     <VSTemplate Include="ClassLibrary.vstemplate">
       <SubType>Designer</SubType>
+      <OutputSubPath>.NET Standard</OutputSubPath>
     </VSTemplate>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
While this was originally done so that we could have common templates in the top group, the addition of the .NET Core class library template has caused a lot of user confusion. So bringing back the .NET Standard node so as to avoid confusion.

@dotnet/project-system 