### PR TITLE
Use TreatWarningsAsErrors instead of WarningsAsErrors for PreserveCom…

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenACompilationOptionsConverter.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenACompilationOptionsConverter.cs
@@ -40,7 +40,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                             { "LangVersion", "6" },
                             { "PlatformTarget", "x64" },
                             { "AllowUnsafeBlocks", "true" },
-                            { "WarningsAsErrors", "false" },
+                            { "TreatWarningsAsErrors", "false" },
                             //{ "Optimize", "" }, Explicitly not setting Optmize
                             { "AssemblyOriginatorKeyFile", "../keyfile.snk" },
                             { "DelaySign", "" },

--- a/src/Tasks/Microsoft.NET.Build.Tasks/CompilationOptionsConverter.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/CompilationOptionsConverter.cs
@@ -21,7 +21,7 @@ namespace Microsoft.NET.Build.Tasks
                 compilerOptionsItem.GetMetadata("LangVersion"),
                 compilerOptionsItem.GetMetadata("PlatformTarget"),
                 compilerOptionsItem.GetBooleanMetadata("AllowUnsafeBlocks"),
-                compilerOptionsItem.GetBooleanMetadata("WarningsAsErrors"),
+                compilerOptionsItem.GetBooleanMetadata("TreatWarningsAsErrors"),
                 compilerOptionsItem.GetBooleanMetadata("Optimize"),
                 compilerOptionsItem.GetMetadata("AssemblyOriginatorKeyFile"),
                 compilerOptionsItem.GetBooleanMetadata("DelaySign"),

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.PreserveCompilationContext.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.PreserveCompilationContext.targets
@@ -28,7 +28,7 @@ Copyright (c) .NET Foundation. All rights reserved.
         <LangVersion>$(LangVersion)</LangVersion>
         <PlatformTarget>$(PlatformTarget)</PlatformTarget>
         <AllowUnsafeBlocks>$(AllowUnsafeBlocks)</AllowUnsafeBlocks>
-        <WarningsAsErrors>$(WarningsAsErrors)</WarningsAsErrors>
+        <TreatWarningsAsErrors>$(TreatWarningsAsErrors)</TreatWarningsAsErrors>
         <Optimize>$(Optimize)</Optimize>
         <AssemblyOriginatorKeyFile>$(AssemblyOriginatorKeyFile)</AssemblyOriginatorKeyFile>
         <DelaySign>$(DelaySign)</DelaySign>


### PR DESCRIPTION
…pilationContext targets.

TreatWarningsAsErrors controls warning as error behavior for the entire compilation, while WarningsAsErrors is a string of set of diagnostic IDs that need to be treated as errors.

Fixes #756