### PR TITLE
Giving more information on 'No compatiblity target frameowrk' failure

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/GetNearestTargetFramework.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/GetNearestTargetFramework.cs
@@ -58,7 +58,7 @@ namespace Microsoft.NET.Build.Tasks
             var nearestNuGetFramework = new FrameworkReducer().GetNearest(referringNuGetFramework, possibleNuGetFrameworks);
             if (nearestNuGetFramework == null)
             {
-                Log.LogError(Strings.NoCompatibleTargetFramework, ProjectFilePath, ReferringTargetFramework);
+                Log.LogError(Strings.NoCompatibleTargetFramework, ProjectFilePath, ReferringTargetFramework, string.Join("; ", possibleNuGetFrameworks));
                 return;
             }
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.resx
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.resx
@@ -121,7 +121,7 @@
     <value>At least one possible target framework must be specified.</value>
   </data>
   <data name="NoCompatibleTargetFramework" xml:space="preserve">
-    <value>Project '{0}' has no target framework compatible with '{1}'.</value>
+    <value>Project '{0}' targets '{2}'. It cannot be referenced by a project that targets '{1}'.</value>
   </data>
   <data name="InvalidFrameworkName" xml:space="preserve">
     <value>Invalid framework name: '{0}'.</value>

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToReferenceAProject.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToReferenceAProject.cs
@@ -128,7 +128,7 @@ namespace Microsoft.NET.Build.Tests
             else
             {
                 result.Should().Fail()
-                    .And.HaveStdOutContaining("has no target framework compatible with");
+                    .And.HaveStdOutContaining("It cannot be referenced by a project that targets");
             }
         }
 


### PR DESCRIPTION
fixes #788 

Message was 
```
C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\MSBuild\Sdks\Microsoft.NET.Sdk\build\Microsoft.NET.Sdk.Common.targets(69,5): error : Project 'c:\users\billhie\documents\visual studio 2017\Projects\WebApplication2\WebApplication2\WebApplication2.csproj' has no target framework compatible with '.NETCoreApp,Version=v1.0'.
Done building project "WebApplication2.csproj" -- FAILED.
```

New Message 

```
4>C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\MSBuild\Sdks\Microsoft.NET.Sdk\build\Microsoft.NET.Sdk.Common.targets(69,5): error : Project 'C:\Users\jinuj\documents\visual studio 2017\Projects\WebApplication1\WebApplication1\WebApplication1.csproj' targets '.NETCoreApp,Version=v1.1'. It cannot be referenced by a project that targets '.NETCoreApp,Version=v1.0'.
4>Done building project "WebApplication1.csproj" -- FAILED.
```

@srivatsn @nguerrera 