### PR TITLE
Update property name for exclude pattern in project folder to match where it's consumed

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.DefaultItems.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.DefaultItems.targets
@@ -40,7 +40,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <!-- WARNING: This pattern is there to ignore folders such as .git and .vs, but it will also match items included with a
          relative path outside the project folder (for example "..\Shared\Shared.cs").  So be sure only to apply it to items
          that are in the project folder. -->
-    <DefaultItemExcludesInProjectFolder>$(DefaultItemExcludesInProjectFolder);**/.*/**</DefaultItemExcludesInProjectFolder>
+    <DefaultExcludesInProjectFolder>$(DefaultItemExcludesInProjectFolder);**/.*/**</DefaultExcludesInProjectFolder>
 
     <!-- TODO: Verify why this was originally added and whether we really need it -->
     <DefaultItemExcludes>$(DefaultItemExcludes);packages/**</DefaultItemExcludes>

--- a/test/Microsoft.NET.Build.Tests/GivenThereAreDefaultItems.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThereAreDefaultItems.cs
@@ -25,7 +25,7 @@ namespace Microsoft.NET.Build.Tests
         {
             Action<GetValuesCommand> setup = getValuesCommand =>
             {
-                foreach (string folder in new[] { "bin", "obj", "packages" })
+                foreach (string folder in new[] { "bin", "obj", "packages", ".vscode" })
                 {
                     WriteFile(Path.Combine(getValuesCommand.ProjectRootPath, folder, "source.cs"),
                         "!InvalidCSharp!");


### PR DESCRIPTION
Fixes #631 

#### Scenario

Build or publish a project using the .NET SDK that has a .vscode, .git, or other folder starting with "." in the project folder.  Without this fix files in these folders that match the right extensions (.json, .cs, etc.) will be included in the project and, in the case of Web SDK projects, the .json files will be included in the publish output.

#### Bug

#631

#### Workarounds

Add the following property to the project file, or otherwise explicitly exclude the unwanted folder from the items:

```xml
<DefaultExcludesInProjectFolder>$(DefaultItemExcludesInProjectFolder);**/.*/**</DefaultExcludesInProjectFolder>
```

#### Risk

Low

#### Performance Impact

Low

#### Regression Analysis

This was introduced in #630, where I accidentally renamed a property where it was defined, but not where it was consumed.