### PR TITLE
'dotnet run' doesn't work on self-contained apps

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Publish.targets
@@ -520,11 +520,6 @@ Copyright (c) .NET Foundation. All rights reserved.
           BeforeTargets="CopyFilesToPublishDirectory"
           Condition="'$(RenamePublishedHost)' == 'true'">
 
-    <PropertyGroup>
-      <_DotNetHostExecutableName>dotnet</_DotNetHostExecutableName>
-      <_DotNetHostExecutableName Condition="$(RuntimeIdentifier.StartsWith('win'))">$(_DotNetHostExecutableName).exe</_DotNetHostExecutableName>
-    </PropertyGroup>
-
     <ItemGroup>
 
       <ResolvedFileToPublish Condition="'%(ResolvedFileToPublish.RelativePath)' == '$(_DotNetHostExecutableName)'">

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.RuntimeIdentifierInference.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.RuntimeIdentifierInference.targets
@@ -45,11 +45,17 @@ Copyright (c) .NET Foundation. All rights reserved.
     </Otherwise>
   </Choose>
 
+  <PropertyGroup>
+    <!-- AppendRuntimeIdentifierToOutputPath defaults to false since it is a breaking change to change the output path -->
+    <!-- Projects that build for multiple RIDs can set this to true to get a RID folder in their output path -->
+    <AppendRuntimeIdentifierToOutputPath Condition="'$(AppendRuntimeIdentifierToOutputPath)' == ''">false</AppendRuntimeIdentifierToOutputPath>
+  </PropertyGroup>
+
   <!--
     Append $(RuntimeIdentifier) directory to output and intermediate paths to prevent bin clashes between
     targets.
    -->
-  <PropertyGroup Condition="'$(RuntimeIdentifier)' != ''">
+  <PropertyGroup Condition="'$(AppendRuntimeIdentifierToOutputPath)' == 'true' and '$(RuntimeIdentifier)' != ''">
     <IntermediateOutputPath>$(IntermediateOutputPath)$(RuntimeIdentifier)\</IntermediateOutputPath>
     <OutputPath>$(OutputPath)$(RuntimeIdentifier)\</OutputPath>
   </PropertyGroup>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.RuntimeIdentifierInference.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.RuntimeIdentifierInference.targets
@@ -45,6 +45,15 @@ Copyright (c) .NET Foundation. All rights reserved.
     </Otherwise>
   </Choose>
 
+  <!--
+    Append $(RuntimeIdentifier) directory to output and intermediate paths to prevent bin clashes between
+    targets.
+   -->
+  <PropertyGroup Condition="'$(RuntimeIdentifier)' != ''">
+    <IntermediateOutputPath>$(IntermediateOutputPath)$(RuntimeIdentifier)\</IntermediateOutputPath>
+    <OutputPath>$(OutputPath)$(RuntimeIdentifier)\</OutputPath>
+  </PropertyGroup>
+
   <Target Name="_CheckRuntimeIdentifier" BeforeTargets="_CheckForInvalidConfigurationAndPlatform">
     <NetSdkError Condition="'$(RuntimeIdentifier)' == '' and '$(TargetFrameworkIdentifier)' == '.NETFramework' and '$(OutputType)' == 'Exe'"
                  ResourceName="RuntimeIdentifierMustBeSetForNETFramework" />

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.BeforeCommon.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.BeforeCommon.targets
@@ -64,6 +64,10 @@ Copyright (c) .NET Foundation. All rights reserved.
   <!-- Set PublishDir here, before Microsoft.Common.targets, to avoid a competing default there. -->
   <PropertyGroup>
     <PublishDirName Condition="'$(PublishDirName)' == ''">publish</PublishDirName>
+    <!-- ensure the PublishDir is RID specific-->
+    <PublishDir Condition="'$(PublishDir)' == '' and
+                           '$(AppendRuntimeIdentifierToOutputPath)' != 'true' and
+                           '$(RuntimeIdentifier)' != ''">$(OutputPath)$(RuntimeIdentifier)\$(PublishDirName)\</PublishDir>
     <PublishDir Condition="'$(PublishDir)' == ''">$(OutputPath)$(PublishDirName)\</PublishDir>
   </PropertyGroup>
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.BeforeCommon.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.BeforeCommon.targets
@@ -64,7 +64,6 @@ Copyright (c) .NET Foundation. All rights reserved.
   <!-- Set PublishDir here, before Microsoft.Common.targets, to avoid a competing default there. -->
   <PropertyGroup>
     <PublishDirName Condition="'$(PublishDirName)' == ''">publish</PublishDirName>
-    <PublishDir Condition="'$(PublishDir)' == '' and '$(RuntimeIdentifier)' != ''">$(OutputPath)$(RuntimeIdentifier)\$(PublishDirName)\</PublishDir>
     <PublishDir Condition="'$(PublishDir)' == ''">$(OutputPath)$(PublishDirName)\</PublishDir>
   </PropertyGroup>
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.targets
@@ -200,7 +200,12 @@ Copyright (c) .NET Foundation. All rights reserved.
           BeforeTargets="AssignTargetPaths"
           Condition="'$(ComputeNETCoreBuildOutputFiles)' == 'true'">
 
-    <!-- Adds the host assemblies for self-contained apps -->
+    <!--
+    During "build" and "run" of .NET Core projects, the assemblies coming from NuGet packages
+    are loaded from the NuGet cache. But, in order for a self-contained app to be runnable,
+    it requires a host in the output directory to load the app.
+    During "publish", all required assets are copied to the publish directory.
+    -->
     <ItemGroup Condition="'$(RuntimeIdentifier)' != '' and '$(OutputType)' == 'Exe'">
       <_NETCoreNativeFileItems Include="@(_ActiveTFMFileDependencies->WithMetadataValue('FileGroup', 'NativeLibrary'))" />
       <__NETCoreNativeItems Include="@(FileDefinitions)" Exclude="@(_NETCoreNativeFileItems)" />

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.targets
@@ -36,6 +36,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <GenerateRuntimeConfigurationFiles Condition=" '$(GenerateRuntimeConfigurationFiles)' == '' and '$(OutputType)' == 'exe' ">true</GenerateRuntimeConfigurationFiles>
     <UserRuntimeConfig Condition=" '$(UserRuntimeConfig)' == '' ">$(MSBuildProjectDirectory)/runtimeconfig.template.json</UserRuntimeConfig>
     <GenerateSatelliteAssembliesForCore Condition=" '$(GenerateSatelliteAssembliesForCore)' == '' and '$(MSBuildRuntimeType)' == 'Core' ">true</GenerateSatelliteAssembliesForCore>
+    <ComputeNETCoreBuildOutputFiles Condition=" '$(ComputeNETCoreBuildOutputFiles)' == '' and '$(TargetFrameworkIdentifier)' == '.NETCoreApp'">true</ComputeNETCoreBuildOutputFiles>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -44,6 +45,21 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ProjectRuntimeConfigFileName Condition="'$(ProjectRuntimeConfigFileName)' == ''">$(AssemblyName).runtimeconfig.json</ProjectRuntimeConfigFileName>
     <ProjectRuntimeConfigFilePath Condition="'$(ProjectRuntimeConfigFilePath)' == ''">$(TargetDir)$(ProjectRuntimeConfigFileName)</ProjectRuntimeConfigFilePath>
     <ProjectRuntimeConfigDevFilePath Condition="'$(ProjectRuntimeConfigDevFilePath)' == ''">$(TargetDir)$(AssemblyName).runtimeconfig.dev.json</ProjectRuntimeConfigDevFilePath>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <_NativeLibraryPrefix Condition="'$(_NativeLibraryPrefix)' == '' and !$(RuntimeIdentifier.StartsWith('win'))">lib</_NativeLibraryPrefix>
+
+    <_NativeLibraryExtension Condition="'$(_NativeLibraryExtension)' == '' and $(RuntimeIdentifier.StartsWith('win'))">.dll</_NativeLibraryExtension>
+    <_NativeLibraryExtension Condition="'$(_NativeLibraryExtension)' == '' and $(RuntimeIdentifier.StartsWith('osx'))">.dylib</_NativeLibraryExtension>
+    <_NativeLibraryExtension Condition="'$(_NativeLibraryExtension)' == ''">.so</_NativeLibraryExtension>
+
+    <_NativeExecutableExtension Condition="'$(_NativeExecutableExtension)' == '' and $(RuntimeIdentifier.StartsWith('win'))">.exe</_NativeExecutableExtension>
+
+    <_DotNetHostExecutableName>dotnet$(_NativeExecutableExtension)</_DotNetHostExecutableName>
+
+    <_DotNetHostPolicyLibraryName>$(_NativeLibraryPrefix)hostpolicy$(_NativeLibraryExtension)</_DotNetHostPolicyLibraryName>
+    <_DotNetHostFxrLibraryName>$(_NativeLibraryPrefix)hostfxr$(_NativeLibraryExtension)</_DotNetHostFxrLibraryName>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -169,7 +185,50 @@ Copyright (c) .NET Foundation. All rights reserved.
                                     Condition="'$(ThreadPoolMaxThreads)' != ''"
                                     Value="$(ThreadPoolMaxThreads)" />
   </ItemGroup>
-  
+
+  <!--
+    ============================================================
+                                        _ComputeNETCoreBuildOutputFiles
+
+    Computes any files that need to be copied to the build output folder for .NET Core.
+    ============================================================
+    -->
+
+  <Target Name="_ComputeNETCoreBuildOutputFiles"
+          DependsOnTargets="_ComputeActiveTFMFileDependencies"
+          AfterTargets="ResolveReferences"
+          BeforeTargets="AssignTargetPaths"
+          Condition="'$(ComputeNETCoreBuildOutputFiles)' == 'true'">
+
+    <!-- Adds the host assemblies for self-contained apps -->
+    <ItemGroup Condition="'$(RuntimeIdentifier)' != '' and '$(OutputType)' == 'Exe'">
+      <_NETCoreNativeFileItems Include="@(_ActiveTFMFileDependencies->WithMetadataValue('FileGroup', 'NativeLibrary'))" />
+      <__NETCoreNativeItems Include="@(FileDefinitions)" Exclude="@(_NETCoreNativeFileItems)" />
+      <_NETCoreNativeItems Include="@(FileDefinitions)" Exclude="@(__NETCoreNativeItems)" />
+
+      <NativeNETCoreCopyLocalItems Include="%(_NETCoreNativeItems.ResolvedPath)"
+                                   Condition="'%(_NETCoreNativeItems.FileName)%(_NETCoreNativeItems.Extension)' == '$(_DotNetHostPolicyLibraryName)' or
+                                              '%(_NETCoreNativeItems.FileName)%(_NETCoreNativeItems.Extension)' == '$(_DotNetHostFxrLibraryName)'" />
+
+      <NativeNETCoreCopyLocalItems Include="%(_NETCoreNativeItems.ResolvedPath)"
+                                   Condition="'%(_NETCoreNativeItems.FileName)%(_NETCoreNativeItems.Extension)' == '$(_DotNetHostExecutableName)'">
+        <!-- Rename the host executable to the app's name -->
+        <Link>$(AssemblyName)%(_NETCoreNativeItems.Extension)</Link>
+      </NativeNETCoreCopyLocalItems>
+
+      <AllNETCoreCopyLocalItems Include="@(NativeNETCoreCopyLocalItems)">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        <CopyToPublishDirectory>Never</CopyToPublishDirectory>
+      </AllNETCoreCopyLocalItems>
+    </ItemGroup>
+
+    <ItemGroup>
+      <!-- Use 'None' so we can rename files using the 'Link' metadata as necessary -->
+      <None Include="@(AllNETCoreCopyLocalItems)" />
+    </ItemGroup>
+
+  </Target>
+
   <!--
     ============================================================
                                         Run Information
@@ -191,13 +250,18 @@ Copyright (c) .NET Foundation. All rights reserved.
     </When>
     
     <When Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' and '$(OutputType)' == 'Exe'">
-      <PropertyGroup>
+      <PropertyGroup Condition="'$(RuntimeIdentifier)' == ''">
         <!-- TODO: https://github.com/dotnet/sdk/issues/20 Need to get the DotNetHost path from MSBuild -->
         <RunCommand Condition="'$(RunCommand)' == ''">dotnet</RunCommand>
 
         <_NetCoreRunArguments>exec &quot;$(TargetPath)&quot;</_NetCoreRunArguments>
         <RunArguments Condition="'$(RunArguments)' == '' and '$(StartArguments)' != ''">$(_NetCoreRunArguments) $(StartArguments)</RunArguments>
         <RunArguments Condition="'$(RunArguments)' == ''">$(_NetCoreRunArguments)</RunArguments>
+      </PropertyGroup>
+
+      <PropertyGroup Condition="'$(RuntimeIdentifier)' != ''">
+        <RunCommand Condition="'$(RunCommand)' == ''">$(TargetDir)$(AssemblyName)$(_NativeExecutableExtension)</RunCommand>
+        <RunArguments Condition="'$(RunArguments)' == ''">$(StartArguments)</RunArguments>
       </PropertyGroup>
     </When>
     

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.TargetFrameworkInference.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.TargetFrameworkInference.targets
@@ -109,12 +109,16 @@ Copyright (c) .NET Foundation. All rights reserved.
     <DefaultItemExcludes>$(DefaultItemExcludes);$(OutputPath)/**</DefaultItemExcludes>
     <DefaultItemExcludes>$(DefaultItemExcludes);$(IntermediateOutputPath)/**</DefaultItemExcludes>
   </PropertyGroup>
-  
+
+  <PropertyGroup>
+    <AppendTargetFrameworkToOutputPath Condition="'$(AppendTargetFrameworkToOutputPath)' == ''">true</AppendTargetFrameworkToOutputPath>
+  </PropertyGroup>
+
   <!--
     Append $(TargetFramework) directory to output and intermediate paths to prevent bin clashes between
     targets.
    -->
-  <PropertyGroup Condition="'$(TargetFramework)' != '' and '$(_UnsupportedTargetFrameworkError)' != 'true'">
+  <PropertyGroup Condition="'$(AppendTargetFrameworkToOutputPath)' == 'true' and '$(TargetFramework)' != '' and '$(_UnsupportedTargetFrameworkError)' != 'true'">
     <IntermediateOutputPath>$(IntermediateOutputPath)$(TargetFramework)\</IntermediateOutputPath>
     <OutputPath>$(OutputPath)$(TargetFramework)\</OutputPath>
   </PropertyGroup>

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildASelfContainedApp.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildASelfContainedApp.cs
@@ -1,0 +1,69 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using FluentAssertions;
+using Microsoft.DotNet.Cli.Utils;
+using Microsoft.DotNet.InternalAbstractions;
+using Microsoft.NET.TestFramework;
+using Microsoft.NET.TestFramework.Commands;
+using Microsoft.NET.TestFramework.Assertions;
+using System;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Xml.Linq;
+using Xunit;
+using static Microsoft.NET.TestFramework.Commands.MSBuildTest;
+
+namespace Microsoft.NET.Build.Tests
+{
+    public class GivenThatWeWantToBuildASelfContainedApp : SdkTest
+    {
+        [Fact]
+        public void It_builds_a_runnable_output()
+        {
+            var runtimeIdentifier = RuntimeEnvironment.GetRuntimeIdentifier();
+            var testAsset = _testAssetsManager
+                .CopyTestAsset("HelloWorld")
+                .WithSource()
+                .WithProjectChanges(project =>
+                {
+                    var ns = project.Root.Name.Namespace;
+                    var propertyGroup = project.Root.Elements(ns + "PropertyGroup").First();
+                    propertyGroup.Add(new XElement(ns + "RuntimeIdentifier", runtimeIdentifier));
+                })
+                .Restore();
+
+            var buildCommand = new BuildCommand(Stage0MSBuild, Path.Combine(testAsset.TestRoot));
+
+            buildCommand
+                .Execute()
+                .Should()
+                .Pass();
+
+            var outputDirectory = buildCommand.GetOutputDirectory("netcoreapp1.0", runtimeIdentifier: runtimeIdentifier);
+            var selfContainedExecutable = $"HelloWorld{Constants.ExeSuffix}";
+
+            var libPrefix = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "" : "lib";
+
+            outputDirectory.Should().OnlyHaveFiles(new[] {
+                selfContainedExecutable,
+                "HelloWorld.dll",
+                "HelloWorld.pdb",
+                "HelloWorld.deps.json",
+                "HelloWorld.runtimeconfig.dev.json",
+                "HelloWorld.runtimeconfig.json",
+                $"{libPrefix}hostfxr{Constants.DynamicLibSuffix}",
+                $"{libPrefix}hostpolicy{Constants.DynamicLibSuffix}",
+            });
+
+            Command.Create(Path.Combine(outputDirectory.FullName, selfContainedExecutable), new string[] { })
+                .CaptureStdOut()
+                .Execute()
+                .Should()
+                .Pass()
+                .And
+                .HaveStdOutContaining("Hello World!");
+        }
+    }
+}

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildASelfContainedApp.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildASelfContainedApp.cs
@@ -31,6 +31,8 @@ namespace Microsoft.NET.Build.Tests
                     var ns = project.Root.Name.Namespace;
                     var propertyGroup = project.Root.Elements(ns + "PropertyGroup").First();
                     propertyGroup.Add(new XElement(ns + "RuntimeIdentifier", runtimeIdentifier));
+
+                    propertyGroup.Add(new XElement(ns + "AppendRuntimeIdentifierToOutputPath", "true"));
                 })
                 .Restore();
 

--- a/test/Microsoft.NET.TestFramework/Commands/TestCommand.cs
+++ b/test/Microsoft.NET.TestFramework/Commands/TestCommand.cs
@@ -35,7 +35,7 @@ namespace Microsoft.NET.TestFramework.Commands
 
             var buildProjectFiles = Directory.GetFiles(ProjectRootPath, "*.csproj");
 
-            if(buildProjectFiles.Length != 1)
+            if (buildProjectFiles.Length != 1)
             {
                 var errorMsg = $"Found {buildProjectFiles.Length} csproj files under {ProjectRootPath} instead of just 1.";
                 throw new ArgumentException(errorMsg);
@@ -44,9 +44,9 @@ namespace Microsoft.NET.TestFramework.Commands
             return buildProjectFiles[0];
         }
 
-        public DirectoryInfo GetOutputDirectory(string targetFramework, string configuration = "Debug")
+        public DirectoryInfo GetOutputDirectory(string targetFramework, string configuration = "Debug", string runtimeIdentifier = "")
         {
-            string output = Path.Combine(ProjectRootPath, "bin", configuration, targetFramework);
+            string output = Path.Combine(ProjectRootPath, "bin", configuration, targetFramework, runtimeIdentifier);
             return new DirectoryInfo(output);
         }
 


### PR DESCRIPTION
Fixing the build output of self-contained applications to be runnable.  Also making 'dotnet run' and Visual Studio F5 work on self-contained applications.

This change also adds an option to append the $(RuntimeIdentifier) to the build output, since the output changes between RIDs.  This would be a breaking change, so the option is defaulted to "off".

@davkean - can you check the usage of the `<None>` item.  It is being used because `<ReferenceCopyLocalPaths>` won't let me rename the file (which is needed for the host executable).  These items shouldn't show up in VS since they are added by a Target, right?

Fix #527

/cc @srivatsn 


## Scenario

When a user sets the `<RuntimeIdentifier>` property in their project, or does a build with `dotnet build -r RID`, the build output is not runnable.  When calling `dotnet run` they get errors like:

```
A fatal error was encountered. The library 'hostpolicy.dll' required to execute the application was not found in 'F:\DotNetTest\DependencyTest\bin\Debug\netcoreapp2.0\'.
```

## Bugs

#527 #791 

## Workarounds

Publish the self-contained app, and then you can run it.

## Risk

~The change to the OutputPath is risky this late.  But @nguerrera said he needed this change for some desktop work as well.  This change makes the output consistent with the output for project.json projects when a RuntimeIdentifier was set.~

By default, there is no change to the OutputPath now.

This change only affects self-contained .NET Core apps during build/run and allows run to work.

## Performance Impact

Minimal, a few more files are being copied to the output folder during build of a self-contained app.

## Regression Analysis

This was a regression from project.json-based projects.