### PR TITLE
Match Microsoft.NETCore.App package version to runtime version, and allow it to float

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/GenerateRuntimeConfigurationFiles.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/GenerateRuntimeConfigurationFiles.cs
@@ -40,7 +40,7 @@ namespace Microsoft.NET.Build.Tasks
         /// The version of the shared framework that should be used.  If not specified, it will
         /// be the package version of the <see cref="PlatformLibraryName"/> package.
         /// </summary>
-        public string RuntimeFrameworkVersion { get; set; }
+        public string FrameworkVersion { get; set; }
 
         public string UserRuntimeConfig { get; set; }
 
@@ -96,9 +96,9 @@ namespace Microsoft.NET.Build.Tasks
                 {
                     RuntimeConfigFramework framework = new RuntimeConfigFramework();
                     framework.Name = platformLibrary.Name;
-                    if (!string.IsNullOrEmpty(RuntimeFrameworkVersion))
+                    if (!string.IsNullOrEmpty(FrameworkVersion))
                     {
-                        framework.Version = RuntimeFrameworkVersion;
+                        framework.Version = FrameworkVersion;
                     }
                     else
                     {

--- a/src/Tasks/Microsoft.NET.Build.Tasks/GenerateRuntimeConfigurationFiles.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/GenerateRuntimeConfigurationFiles.cs
@@ -36,12 +36,6 @@ namespace Microsoft.NET.Build.Tasks
 
         public string PlatformLibraryName { get; set; }
 
-        /// <summary>
-        /// The version of the shared framework that should be used.  If not specified, it will
-        /// be the package version of the <see cref="PlatformLibraryName"/> package.
-        /// </summary>
-        public string FrameworkVersion { get; set; }
-
         public string UserRuntimeConfig { get; set; }
 
         public ITaskItem[] HostConfigurationOptions { get; set; }
@@ -96,14 +90,7 @@ namespace Microsoft.NET.Build.Tasks
                 {
                     RuntimeConfigFramework framework = new RuntimeConfigFramework();
                     framework.Name = platformLibrary.Name;
-                    if (!string.IsNullOrEmpty(FrameworkVersion))
-                    {
-                        framework.Version = FrameworkVersion;
-                    }
-                    else
-                    {
-                        framework.Version = platformLibrary.Version.ToNormalizedString();
-                    }
+                    framework.Version = platformLibrary.Version.ToNormalizedString();
 
                     runtimeOptions.Framework = framework;
                 }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Publish.targets
@@ -501,7 +501,6 @@ Copyright (c) .NET Foundation. All rights reserved.
                                        RuntimeConfigPath="$(PublishRuntimeConfigFilePath)"
                                        RuntimeIdentifier="$(RuntimeIdentifier)"
                                        PlatformLibraryName="$(MicrosoftNETPlatformLibrary)"
-                                       RuntimeFrameworkVersion="$(RuntimeFrameworkVersion)"
                                        UserRuntimeConfig="$(UserRuntimeConfig)"
                                        HostConfigurationOptions="@(RuntimeHostConfigurationOption)" />
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.DefaultItems.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.DefaultItems.props
@@ -34,7 +34,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   </ItemGroup>
 
   <ItemGroup Condition=" '$(DisableImplicitFrameworkReferences)' != 'true' and '$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
-    <PackageReference Include="Microsoft.NETCore.App" Version="$(NetCoreAppImplicitPackageVersion)" IsImplicitlyDefined="true" />
+    <PackageReference Include="Microsoft.NETCore.App" Version="$(RuntimeFrameworkVersion)" IsImplicitlyDefined="true" />
   </ItemGroup>
 
 </Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.DefaultItems.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.DefaultItems.targets
@@ -54,41 +54,25 @@ Copyright (c) .NET Foundation. All rights reserved.
     <NetStandardImplicitPackageVersion>1.6.0</NetStandardImplicitPackageVersion>
   </PropertyGroup>
   
-  <!--
-    Determine the NetCoreImplicitPackageVersion and RuntimeFrameworkVersion
+  <!--  
+    Determine the NetCoreImplicitPackageVersion and RuntimeFrameworkVersion when targeting .NET Core
     
-    The RuntimeFrameworkVersion is the version that is written to the runtimeconfig.json, and is the version of the runtime
-    that the app should run on.
+    When targeting .NET Core, the TargetFramework is generally used to specify which version of the runtime to use.
     
-    If RuntimeFrameworkVersion is not set, then derive the RuntimeFrameworkVersion from the TargetFrameworkVersion,
-    and use the latest known version of Microsoft.NETCore.App as the NetCoreAppImplicitPackageVersion, unless that
-    property is already set.
+    In order to target a specific patch version, or to float the version number (2.0-*), the RuntimeFrameworkVersion
+    property can be used.
     
-    If RuntimeFrameworkVersion is set, then use that version for the NetCoreAppImplicitPackageVersion, unless
-    NetCoreAppImplicitPackageVersion is already set.
-    
+    The framework version that is written to the runtimeconfig.json file is based on the actual resolved package version
+    of Microsoft.NETCore.App.  This is to allow floating the verion number.
+  
   -->
 
-  <Choose>
-    <When Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(RuntimeFrameworkVersion)' == ''">
-      <PropertyGroup>
-        <!-- Use the version of the framework runtime matching the target framework version-->
-        <RuntimeFrameworkVersion>$(_TargetFrameworkVersionWithoutV)</RuntimeFrameworkVersion>
-      
-        <!-- Normalize RuntimeFrameworkVersion to 3 digits -->
-        <RuntimeFrameworkVersion Condition=" $(RuntimeFrameworkVersion.Split('.').Length) == 1">$(RuntimeFrameworkVersion).0.0</RuntimeFrameworkVersion>
-        <RuntimeFrameworkVersion Condition=" $(RuntimeFrameworkVersion.Split('.').Length) == 2">$(RuntimeFrameworkVersion).0</RuntimeFrameworkVersion>
+  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
+    <!-- Default to use the version of the framework runtime matching the target framework version-->
+    <RuntimeFrameworkVersion Condition="'$(RuntimeFrameworkVersion)' == ''">$(_TargetFrameworkVersionWithoutV)</RuntimeFrameworkVersion>
 
-        <NetCoreAppImplicitPackageVersion Condition="'$(NetCoreAppImplicitPackageVersion)' == ''">1.1.0</NetCoreAppImplicitPackageVersion>
-      </PropertyGroup>
-    </When>
-    
-    <When Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(RuntimeFrameworkVersion)' != ''">
-      <PropertyGroup>
-        <NetCoreAppImplicitPackageVersion Condition="'$(NetCoreAppImplicitPackageVersion)' == ''">$(RuntimeFrameworkVersion)</NetCoreAppImplicitPackageVersion>
-      </PropertyGroup>
-    </When>
-  </Choose>
+    <NetCoreAppImplicitPackageVersion Condition="'$(NetCoreAppImplicitPackageVersion)' == ''">$(RuntimeFrameworkVersion)</NetCoreAppImplicitPackageVersion>
+  </PropertyGroup>
 
   <UsingTask TaskName="CheckForImplicitPackageReferenceOverrides" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.DefaultItems.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.DefaultItems.targets
@@ -70,8 +70,6 @@ Copyright (c) .NET Foundation. All rights reserved.
   <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
     <!-- Default to use the version of the framework runtime matching the target framework version-->
     <RuntimeFrameworkVersion Condition="'$(RuntimeFrameworkVersion)' == ''">$(_TargetFrameworkVersionWithoutV)</RuntimeFrameworkVersion>
-
-    <NetCoreAppImplicitPackageVersion Condition="'$(NetCoreAppImplicitPackageVersion)' == ''">$(RuntimeFrameworkVersion)</NetCoreAppImplicitPackageVersion>
   </PropertyGroup>
 
   <UsingTask TaskName="CheckForImplicitPackageReferenceOverrides" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.targets
@@ -132,7 +132,6 @@ Copyright (c) .NET Foundation. All rights reserved.
                                        RuntimeConfigDevPath="$(ProjectRuntimeConfigDevFilePath)"
                                        RuntimeIdentifier="$(RuntimeIdentifier)"
                                        PlatformLibraryName="$(MicrosoftNETPlatformLibrary)"
-                                       RuntimeFrameworkVersion="$(RuntimeFrameworkVersion)"
                                        UserRuntimeConfig="$(UserRuntimeConfig)"
                                        HostConfigurationOptions="@(RuntimeHostConfigurationOption)">
       

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildANetCoreApp.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildANetCoreApp.cs
@@ -21,13 +21,12 @@ namespace Microsoft.NET.Build.Tests
     public class GivenThatWeWantToBuildANetCoreApp : SdkTest
     {
         [Theory]
-        //  TargetFramework, RuntimeFrameworkVersion, NETCoreAppPackageVersion, ExpectedPackageVersion, ExpectedRuntimeFrameworkVersion
-        [InlineData("netcoreapp1.0", null, null, "1.0.0", "1.0.0")]
-        [InlineData("netcoreapp1.1", null, null, "1.1.0", "1.1.0")]
-        [InlineData("netcoreapp1.0", null, "1.0.3", "1.0.3", "1.0.3")]
-        [InlineData("netcoreapp1.0", "1.0.1", null, "1.0.1", "1.0.1")]
-        [InlineData("netcoreapp1.0", "1.0.1", "1.0.3", "1.0.3", "1.0.3")]
-        public void It_targets_the_right_shared_framework(string targetFramework, string runtimeFrameworkVersion, string netCoreAppPackageVersion, 
+        //  TargetFramework, RuntimeFrameworkVersion, ExpectedPackageVersion, ExpectedRuntimeFrameworkVersion
+        [InlineData("netcoreapp1.0", null, "1.0.0", "1.0.0")]
+        [InlineData("netcoreapp1.1", null, "1.1.0", "1.1.0")]
+        [InlineData("netcoreapp1.0", "1.0.1", "1.0.1", "1.0.1")]
+        [InlineData("netcoreapp1.0", "1.0.3", "1.0.3", "1.0.3")]
+        public void It_targets_the_right_shared_framework(string targetFramework, string runtimeFrameworkVersion,
             string expectedPackageVersion, string expectedRuntimeVersion)
         {
             var testProject = new TestProject()
@@ -38,7 +37,7 @@ namespace Microsoft.NET.Build.Tests
                 IsExe = true
             };
 
-            string testIdentifier = string.Join("_", targetFramework, runtimeFrameworkVersion ?? "null", netCoreAppPackageVersion ?? "null");
+            string testIdentifier = string.Join("_", targetFramework, runtimeFrameworkVersion ?? "null");
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject, nameof(It_targets_the_right_shared_framework), testIdentifier);
 
@@ -51,11 +50,6 @@ namespace Microsoft.NET.Build.Tests
                 if (runtimeFrameworkVersion != null)
                 {
                     propertyGroup.Add(new XElement(ns + "RuntimeFrameworkVersion", runtimeFrameworkVersion));
-                }
-
-                if (netCoreAppPackageVersion != null)
-                {
-                    propertyGroup.Add(new XElement(ns + "NetCoreAppImplicitPackageVersion", netCoreAppPackageVersion));
                 }
             });
 

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildANetCoreApp.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildANetCoreApp.cs
@@ -22,11 +22,11 @@ namespace Microsoft.NET.Build.Tests
     {
         [Theory]
         //  TargetFramework, RuntimeFrameworkVersion, NETCoreAppPackageVersion, ExpectedPackageVersion, ExpectedRuntimeFrameworkVersion
-        [InlineData("netcoreapp1.0", null, null, "1.1.0", "1.0.0")]
+        [InlineData("netcoreapp1.0", null, null, "1.0.0", "1.0.0")]
         [InlineData("netcoreapp1.1", null, null, "1.1.0", "1.1.0")]
-        [InlineData("netcoreapp1.0", null, "1.0.3", "1.0.3", "1.0.0")]
+        [InlineData("netcoreapp1.0", null, "1.0.3", "1.0.3", "1.0.3")]
         [InlineData("netcoreapp1.0", "1.0.1", null, "1.0.1", "1.0.1")]
-        [InlineData("netcoreapp1.0", "1.0.1", "1.0.3", "1.0.3", "1.0.1")]
+        [InlineData("netcoreapp1.0", "1.0.1", "1.0.3", "1.0.3", "1.0.3")]
         public void It_targets_the_right_shared_framework(string targetFramework, string runtimeFrameworkVersion, string netCoreAppPackageVersion, 
             string expectedPackageVersion, string expectedRuntimeVersion)
         {


### PR DESCRIPTION
Fixes #686

This PR modifies how the runtime framework version is handled.  The following is still true (ie unaffected with this PR):

- There isn't a `PackageReference` to Microsoft.NETCore.App explicitly in your project file
- You specify the version of .NET Core to target via the `TargetFramework` attribute, ie netcoreapp1.0 or netcoreapp1.1
- If you want to target a specific patch version, or a prerelease version, you do that by setting the `RuntimeFrameworkVersion` property

The changes in this PR are:

- If you don't specify a `RuntimeFrameworkVersion`, the package version of Microsoft.NETCore.App will match the version in the `TargetFramework` property.  So if the project targets netcoreapp1.0, then version 1.0.0 of Microsoft.NETCore.App will be used, instead of version 1.1 as was previously the case
- The resolved version of the Microsoft.NETCore.App package will be used as the framework version in the runtimeconfig.json file, instead of using the `RuntimeFrameworkVersion` property directly.  This allows floating versions (for example `2.0-*`) to be specified in the `RuntimeFrameworkVersion` property.

@nguerrera @srivatsn @eerhardt @natemcmaster