### PR TITLE
Fixing self-contained tests on OSX Sierra

### DIFF
--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildASelfContainedApp.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildASelfContainedApp.cs
@@ -22,7 +22,8 @@ namespace Microsoft.NET.Build.Tests
         [Fact]
         public void It_builds_a_runnable_output()
         {
-            var runtimeIdentifier = RuntimeEnvironment.GetRuntimeIdentifier();
+            var targetFramework = "netcoreapp1.0";
+            var runtimeIdentifier = EnvironmentInfo.GetCompatibleRid(targetFramework);
             var testAsset = _testAssetsManager
                 .CopyTestAsset("HelloWorld")
                 .WithSource()
@@ -43,7 +44,7 @@ namespace Microsoft.NET.Build.Tests
                 .Should()
                 .Pass();
 
-            var outputDirectory = buildCommand.GetOutputDirectory("netcoreapp1.0", runtimeIdentifier: runtimeIdentifier);
+            var outputDirectory = buildCommand.GetOutputDirectory(targetFramework, runtimeIdentifier: runtimeIdentifier);
             var selfContainedExecutable = $"HelloWorld{Constants.ExeSuffix}";
 
             var libPrefix = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "" : "lib";

--- a/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAHelloWorldProject.cs
+++ b/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAHelloWorldProject.cs
@@ -49,7 +49,8 @@ namespace Microsoft.NET.Publish.Tests
         [Fact]
         public void It_publishes_self_contained_apps_to_the_publish_folder_and_the_app_should_run()
         {
-            var rid = RuntimeEnvironment.GetRuntimeIdentifier();
+            var targetFramework = "netcoreapp1.0";
+            var rid = EnvironmentInfo.GetCompatibleRid(targetFramework);
 
             var helloWorldAsset = _testAssetsManager
                 .CopyTestAsset("HelloWorld", "SelfContained")
@@ -61,7 +62,9 @@ namespace Microsoft.NET.Publish.Tests
 
             publishResult.Should().Pass();
 
-            var publishDirectory = publishCommand.GetOutputDirectory(selfContained: true);
+            var publishDirectory = publishCommand.GetOutputDirectory(
+                targetFramework: targetFramework,
+                runtimeIdentifier: rid);
             var selfContainedExecutable = $"HelloWorld{Constants.ExeSuffix}";
 
             var libPrefix = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "" : "lib";

--- a/test/Microsoft.NET.TestFramework/Commands/PublishCommand.cs
+++ b/test/Microsoft.NET.TestFramework/Commands/PublishCommand.cs
@@ -29,25 +29,15 @@ namespace Microsoft.NET.TestFramework.Commands
             return command.Execute();
         }
 
-        public DirectoryInfo GetOutputDirectory(string targetFramework = "netcoreapp1.0", string configuration = "Debug", string runtimeIdentifier = "", bool selfContained = false)
+        public DirectoryInfo GetOutputDirectory(string targetFramework = "netcoreapp1.0", string configuration = "Debug", string runtimeIdentifier = "")
         {
-            string output = Path.Combine(ProjectRootPath, "bin", BuildRelativeOutputPath(targetFramework, configuration, runtimeIdentifier, selfContained));
+            string output = Path.Combine(ProjectRootPath, "bin", configuration, targetFramework, runtimeIdentifier, PublishSubfolderName);
             return new DirectoryInfo(output);
         }
 
         public string GetPublishedAppPath(string appName)
         {
             return Path.Combine(GetOutputDirectory().FullName, $"{appName}.dll");
-        }
-
-        private string BuildRelativeOutputPath(string targetFramework, string configuration, string runtimeIdentifier, bool selfContained)
-        {
-            if (runtimeIdentifier.Length == 0 && selfContained)
-            {
-                runtimeIdentifier = RuntimeEnvironment.GetRuntimeIdentifier();
-            }
-			
-            return Path.Combine(configuration, targetFramework, runtimeIdentifier, PublishSubfolderName);
         }
     }
 }

--- a/test/Microsoft.NET.TestFramework/EnvironmentInfo.cs
+++ b/test/Microsoft.NET.TestFramework/EnvironmentInfo.cs
@@ -1,0 +1,34 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using Microsoft.DotNet.InternalAbstractions;
+
+namespace Microsoft.NET.TestFramework
+{
+    public static class EnvironmentInfo
+    {
+        public static string GetCompatibleRid(string targetFramework)
+        {
+            string rid = RuntimeEnvironment.GetRuntimeIdentifier();
+
+            if (string.Equals(targetFramework, "netcoreapp1.0", StringComparison.OrdinalIgnoreCase))
+            {
+                // netcoreapp1.0 only supports osx.10.10 and osx.10.11
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+                {
+                    Version osVersion;
+                    if (Version.TryParse(RuntimeEnvironment.OperatingSystemVersion, out osVersion) &&
+                        osVersion > new Version(10, 11))
+                    {
+                        rid = "osx.10.11-x64";
+                    }
+                }
+            }
+
+            return rid;
+        }
+    }
+}


### PR DESCRIPTION
Our self-contained tests use netcoreapp1.0 and the current machine's RID.  When building/running on OSX Sierra this is a problem because netcoreapp1.0 only supported the previous 2 OSX versions.

The fix is to check if we are running on a newer OSX machine than what was supported, and downgrade the RID to a supported RID.

Fix #834 

/cc @wjk