### PR TITLE
Use RID less targets to obtain compile assets

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.PackageDependencyResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.PackageDependencyResolution.targets
@@ -306,11 +306,11 @@ Copyright (c) .NET Foundation. All rights reserved.
     </ItemGroup>
   </Target>
 
-  <Target Name="_ComputeRIDLessTFMFileDependencies"
+  <Target Name="_ComputeTFMOnlyFileDependencies"
           DependsOnTargets="RunResolvePackageDependencies"
-          Returns="_RIDLessTFMFileDependencies">
+          Returns="_TFMOnlyFileDependencies">
     <ItemGroup>
-      <_RIDLessTFMFileDependencies Include="@(FileDependencies->WithMetadataValue('ParentTarget', '$(NuGetTargetMoniker)'))" />
+      <_TFMOnlyFileDependencies Include="@(FileDependencies->WithMetadataValue('ParentTarget', '$(NuGetTargetMoniker)'))" />
     </ItemGroup>
   </Target>
 
@@ -324,10 +324,10 @@ Copyright (c) .NET Foundation. All rights reserved.
     -->
 
   <Target Name="_ComputeLockFileReferences"
-          DependsOnTargets="_ComputeRIDLessTFMFileDependencies"
+          DependsOnTargets="_ComputeTFMOnlyFileDependencies"
           Returns="ResolvedCompileFileDefinitions">
     <ItemGroup>
-      <_CompileFileItems Include="@(_RIDLessTFMFileDependencies->WithMetadataValue('FileGroup', 'CompileTimeAssembly'))" />
+      <_CompileFileItems Include="@(_TFMOnlyFileDependencies->WithMetadataValue('FileGroup', 'CompileTimeAssembly'))" />
 
       <!-- Get corresponding file definitions -->
       <__CompileFileDefinitions Include="@(FileDefinitions)" Exclude="@(_CompileFileItems)" />
@@ -344,10 +344,10 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <Target Name="_ComputeLockFileFrameworks"
           Condition="'$(DisableLockFileFrameworks)' != 'true'"
-          DependsOnTargets="_ComputeRIDLessTFMFileDependencies"
+          DependsOnTargets="_ComputeTFMOnlyFileDependencies"
           Returns="ResolvedFrameworkAssemblies">
     <ItemGroup>
-      <_FrameworkAssemblies Include="@(_RIDLessTFMFileDependencies->WithMetadataValue('FileGroup', 'FrameworkAssembly'))" />
+      <_FrameworkAssemblies Include="@(_TFMOnlyFileDependencies->WithMetadataValue('FileGroup', 'FrameworkAssembly'))" />
 
       <ResolvedFrameworkAssemblies Include="%(_FrameworkAssemblies.FrameworkAssembly)">
         <Private>false</Private>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.PackageDependencyResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.PackageDependencyResolution.targets
@@ -306,6 +306,14 @@ Copyright (c) .NET Foundation. All rights reserved.
     </ItemGroup>
   </Target>
 
+  <Target Name="_ComputeRIDLessTFMFileDependencies"
+          DependsOnTargets="RunResolvePackageDependencies"
+          Returns="_RIDLessTFMFileDependencies">
+    <ItemGroup>
+      <_RIDLessTFMFileDependencies Include="@(FileDependencies->WithMetadataValue('ParentTarget', '$(NuGetTargetMoniker)'))" />
+    </ItemGroup>
+  </Target>
+
   <!--
     ============================================================
     Reference Targets: For populating References based on lock file
@@ -316,10 +324,10 @@ Copyright (c) .NET Foundation. All rights reserved.
     -->
 
   <Target Name="_ComputeLockFileReferences"
-          DependsOnTargets="_ComputeActiveTFMFileDependencies"
+          DependsOnTargets="_ComputeRIDLessTFMFileDependencies"
           Returns="ResolvedCompileFileDefinitions">
     <ItemGroup>
-      <_CompileFileItems Include="@(_ActiveTFMFileDependencies->WithMetadataValue('FileGroup', 'CompileTimeAssembly'))" />
+      <_CompileFileItems Include="@(_RIDLessTFMFileDependencies->WithMetadataValue('FileGroup', 'CompileTimeAssembly'))" />
 
       <!-- Get corresponding file definitions -->
       <__CompileFileDefinitions Include="@(FileDefinitions)" Exclude="@(_CompileFileItems)" />
@@ -336,10 +344,10 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <Target Name="_ComputeLockFileFrameworks"
           Condition="'$(DisableLockFileFrameworks)' != 'true'"
-          DependsOnTargets="_ComputeActiveTFMFileDependencies"
+          DependsOnTargets="_ComputeRIDLessTFMFileDependencies"
           Returns="ResolvedFrameworkAssemblies">
     <ItemGroup>
-      <_FrameworkAssemblies Include="@(_ActiveTFMFileDependencies->WithMetadataValue('FileGroup', 'FrameworkAssembly'))" />
+      <_FrameworkAssemblies Include="@(_RIDLessTFMFileDependencies->WithMetadataValue('FileGroup', 'FrameworkAssembly'))" />
 
       <ResolvedFrameworkAssemblies Include="%(_FrameworkAssemblies.FrameworkAssembly)">
         <Private>false</Private>

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildALibrary.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildALibrary.cs
@@ -555,5 +555,27 @@ namespace Microsoft.NET.Build.Tests
                 .And.HaveStdOutContaining("TargetFramework=''") // new deliberate error
                 .And.NotHaveStdOutContaining(">="); // old error about comparing empty string to version
         }
+
+        [Fact]
+        public void It_passes_ridless_target_to_compiler()
+        {
+            var testAsset = _testAssetsManager
+                .CopyTestAsset("AppWithLibrary", "RidlessLib")
+                .WithSource()
+                .Restore(relativePath: "TestLibrary");
+
+            var libraryProjectDirectory = Path.Combine(testAsset.TestRoot, "TestLibrary");
+            var fullPathProjectFile = new BuildCommand(Stage0MSBuild, libraryProjectDirectory).FullPathProjectFile;
+
+            // compile should still pass with unknown RID because references are always pulled 
+            // from RIDLess target
+            var buildCommand = Stage0MSBuild.CreateCommandForTarget(
+                "Compile", fullPathProjectFile, "/p:RuntimeIdentifier=unknownrid");
+
+            buildCommand
+                .Execute()
+                .Should()
+                .Pass();
+        }
     }
 }


### PR DESCRIPTION
https://github.com/NuGet/Home/issues/4207 reports that NuGet is incorrectly including runtime assemblies in the "compile" assets for RID-specific targets. This is compounded by the fact that this SDK populates References using compile assets from RID-specific targets, but these compile assets should be independent of RID, and come from the RID-less targets.

This change derives `ResolvedCompileFileDefinitions` and `ResolvedFrameworkAssemblies` from file dependencies with parent target equal to `NuGetTargetMoniker` (i.e. excluding the RID if one exists)

A fix for the NuGet issue is available (https://github.com/NuGet/NuGet.Client/pull/1103) but is not currently targeting RTW because of risk. My fix may also carry some risk for any scenarios where builds were previously working by accident because we were pulling in runtime assets. But making this available for consideration in case we decide to take it.

Fixes #592

/cc @emgarten @dsplaisted @srivatsn @nguerrera @ericstj 