### PR TITLE
Filter out System files during caching step

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.ComposeCache.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.ComposeCache.targets
@@ -42,6 +42,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       <SkipOptimization Condition="'$(RuntimeIdentifier)' == ''">true</SkipOptimization>
       <_TFM Condition="'$(_TFM)' == ''">$(TargetFramework)</_TFM>
       <PathSeparator>$([System.IO.Path]::PathSeparator)</PathSeparator>
+      <DirectorySeparatorChar>$([System.IO.Path]::DirectorySeparatorChar)</DirectorySeparatorChar>
     </PropertyGroup>
 
     <NETSdkError Condition="'$(RuntimeIdentifier)' =='' and '$(_PureManagedAssets)' == ''"

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.CrossGen.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.CrossGen.targets
@@ -24,8 +24,8 @@ Copyright (c) .NET Foundation. All rights reserved.
   <Target Name="_RunOptimizer"
           DependsOnTargets="_ComputeResolvedFilesToCacheTypes;
                             _GenerateCrossgenProj;
-                            _SetupCrossgenStage;
-                            _RestoreCrossgen"
+                            _RestoreCrossgen;
+                            _SetupCrossgenStage"
           Condition="$(SkipOptimization) != 'true' ">
     <!-- Get the coreclr path -->
     <ItemGroup>
@@ -71,8 +71,8 @@ Copyright (c) .NET Foundation. All rights reserved.
     </PropertyGroup>
 
     <NETSdkError Condition="!Exists($(_Crossgen))"
-    ResourceName="UnableToFindResolvedPath"
-    FormatArguments="$(_Crossgen)" />
+                 ResourceName="UnableToFindResolvedPath"
+                 FormatArguments="$(_Crossgen)" />
 
     <PropertyGroup>
       <_Crossgen> $([System.IO.Path]::GetFullPath($(_Crossgen)))</_Crossgen>
@@ -92,7 +92,8 @@ Copyright (c) .NET Foundation. All rights reserved.
                              _CGenJit=$(_JitPath);
                              _CGenInputAssembly=%(_AssembliestoCrossGen.Fullpath);
                              _CGenOutputAssembly=$([System.IO.Path]::Combine($(_RuntimeOptimizedDir),%(RecursiveDir)%(Filename)%(Extension)));
-                             _CGenPlatformAssembliesPath=$(_NetCoreRefDir)$(PathSeparator)$(_RuntimeRefDir);" />
+                             _CGenPlatformAssembliesPath=$(_RuntimeRefDir)$(PathSeparator)$(_NetCoreRefDir);"
+                 Condition="'@(_AssembliestoCrossGen)' != ''"/>
 
 
     <!-- Copy by proxy the directory structure to PublishDir-->
@@ -165,10 +166,12 @@ Copyright (c) .NET Foundation. All rights reserved.
                                         _SetupCrossgenStage
     ============================================================
     -->
-  <Target Name="_SetupCrossgenStage">
+  <Target Name="_SetupCrossgenStage"
+          DependsOnTargets="_FilterOutFXFromResolvedCandidates;_PoulateUnFilteredResolvedCandidates">
+
     <!-- Copy managed files to temp directory maintaining the structure -->
-    <Copy SourceFiles = "@(_ManagedResolvedFileToPublishCandidates)"
-          DestinationFiles="$(_RuntimeDir)\%(_ManagedResolvedFileToPublishCandidates.DestinationSubPath)"
+    <Copy SourceFiles = "@(_ManagedResolvedFilesToOptimize)"
+          DestinationFiles="$(_RuntimeDir)\%(_ManagedResolvedFilesToOptimize.DestinationSubPath)"
           OverwriteReadOnlyFiles="$(OverwriteReadOnlyFiles)"
           Retries="$(CopyRetryCount)"
           RetryDelayMilliseconds="$(CopyRetryDelayMilliseconds)"
@@ -179,7 +182,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     </Copy>
 
     <!-- Copy managed files to  a flat temp directory for passing it as ref -->
-    <Copy SourceFiles = "@(_ManagedResolvedFileToPublishCandidates)"
+    <Copy SourceFiles = "@(_ManagedResolvedFilesToOptimize)"
           DestinationFolder="$(_RuntimeRefDir)"
           OverwriteReadOnlyFiles="$(OverwriteReadOnlyFiles)"
           Retries="$(CopyRetryCount)"
@@ -191,6 +194,34 @@ Copyright (c) .NET Foundation. All rights reserved.
     </Copy>
 
   </Target>
+
+  <!--
+    ============================================================
+                                        _FilterOutFXFromResolvedCandidates
+    ============================================================
+    -->
+  <Target Name="_FilterOutFXFromResolvedCandidates"
+          DependsOnTargets="_RestoreCrossgen"
+          Condition="$(SkipRemovingSystemFiles) != 'true' ">
+
+    <ItemGroup>
+      <_ManagedResolvedFilesToOptimize Include="@(_ManagedResolvedFileToPublishCandidates)" Condition="!Exists('$(_NetCoreRefDir)$(DirectorySeparatorChar)%(FileName)%(Extension)')"/>
+    </ItemGroup>
+  </Target>
+
+  <!--
+    ============================================================
+                                        _PoulateUnFilteredResolvedCandidates
+    ============================================================
+    -->
+  <Target Name="_PoulateUnFilteredResolvedCandidates"
+          Condition="$(SkipRemovingSystemFiles) == 'true' ">
+
+   <ItemGroup>
+      <_ManagedResolvedFilesToOptimize Include="@(_ManagedResolvedFileToPublishCandidates)" />
+    </ItemGroup>
+  </Target>
+
   <!--
     ============================================================
                                         _RestoreCrossgen


### PR DESCRIPTION
This prevents crossgen errors with incompatible corefx files
Also the shared framework is supposed to carry them

Typical crossgen error is like 

```
F:\git\cli\.nuget\packages\runtime.win7-x64.microsoft.netcore.app\2.0.0-beta-001507-00\tools\crossgen.exe -readytorun -in F:\temp\out2\Optimize\runtime\runtime.any.system.collections\4.0.11\lib\netstandard1.3\System.Collections.dll -out F:\temp\out2\Optimize\runtimopt\runtime.any.system.collections\4.0.11\lib\netstandard1.3\System.Collections.dll -jitpath F:\git\cli\.nuget\packages\runtime.win7-x64.microsoft.netcore.app\2.0.0-beta-001507-00\runtimes\win7-x64\native\clrjit.dll -platform_assemblies_paths F:\temp\out2\Optimize\netcoreapp;F:\temp\out2\Optimize\runtimeref

ERROR: Native images generated against multiple versions of assembly System.Collections. while compiling method StructuralComparer.Compare
ERROR: Native images generated against multiple versions of assembly System.Collections. while compiling method HashSet`1..ctor
ERROR: Native images generated against multiple versions of assembly System.Collections. while compiling method HashSet`1..ctor
ERROR: Native images generated against multiple versions of assembly System.Collections. while compiling method HashSet`1..ctor
ERROR: Native images generated against multiple versions of assembly System.Collections. while compiling method LinkedList`1.Find
ERROR: Native images generated against multiple versions of assembly System.Collections. while compiling method LinkedList`1.FindLast
ERROR: Native images generated against multiple versions of assembly System.Collections. while compiling method Queue`1.Contains
ERROR: Native images generated against multiple versions of assembly System.Collections. while compiling method SortedDictionary`2..ctor```