### PR TITLE
Matching fix in SDK for 1456, add a new property with hardcoded list of implicit packages

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenUnresolvedSDKProjectItemsAndImplicitPackages.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenUnresolvedSDKProjectItemsAndImplicitPackages.cs
@@ -53,7 +53,14 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                     { MetadataKeys.IsImplicitlyDefined, "False" },
                     { MetadataKeys.Version, "1.0.1" }
                 });
-            
+            var defaultImplicitPackage1 = new MockTaskItem(
+                itemSpec: "DefaultImplicitPackage1",
+                metadata: new Dictionary<string, string>
+                {
+                    { MetadataKeys.SDKPackageItemSpec, "" },
+                    { MetadataKeys.Name, "DefaultImplicitPackage1" }
+                });
+
             var task = new CollectSDKReferencesDesignTime();
             task.SdkReferences = new[] {
                 sdkReference1,
@@ -62,26 +69,29 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             task.PackageReferences = new ITaskItem[] {
                 packageReference1,
                 packageReference2,
-                packageReference3
+                packageReference3,
+                defaultImplicitPackage1
             };
+            task.DefaultImplicitPackages = "DefaultImplicitPackage1;SomeOtherImplicitPackage";
 
             // Act
             var result = task.Execute();
 
             // Assert
             result.Should().BeTrue();
-            task.SDKReferencesDesignTime.Count().Should().Be(3);
+            task.SDKReferencesDesignTime.Count().Should().Be(4);
 
             VerifyTaskItem(sdkReference1, task.SDKReferencesDesignTime[0]);
             VerifyTaskItem(sdkReference2, task.SDKReferencesDesignTime[1]);
             VerifyTaskItem(packageReference1, task.SDKReferencesDesignTime[2]);
+            VerifyTaskItem(defaultImplicitPackage1, task.SDKReferencesDesignTime[3]);
         }
 
         private void VerifyTaskItem(ITaskItem input, ITaskItem output)
         {
             // remove unnecessary metadata to keep only ones that would be in result task items
             var removeMetadata = new[] { MetadataKeys.IsImplicitlyDefined };
-            foreach(var rm in removeMetadata)
+            foreach (var rm in removeMetadata)
             {
                 output.RemoveMetadata(rm);
                 input.RemoveMetadata(rm);

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.Common.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.Common.targets
@@ -20,6 +20,12 @@ Copyright (c) .NET Foundation. All rights reserved.
     <MicrosoftNETBuildTasksTFM Condition=" '$(MicrosoftNETBuildTasksTFM)' == ''">net46</MicrosoftNETBuildTasksTFM>
     <MicrosoftNETBuildTasksDirectory>$(MicrosoftNETBuildTasksDirectoryRoot)$(MicrosoftNETBuildTasksTFM)/</MicrosoftNETBuildTasksDirectory>
     <MicrosoftNETBuildTasksAssembly>$(MicrosoftNETBuildTasksDirectory)Microsoft.NET.Build.Tasks.dll</MicrosoftNETBuildTasksAssembly>
+    
+    <!-- 
+          Hardcoded list of known implicit packges that are added to project from default SDK targets implicitly.
+          Should be re-visited when multiple TFM support is added to Dependencies logic.
+    -->
+    <DefaultImplicitPackages>Microsoft.NETCore.App;NETStandard.Library</DefaultImplicitPackages>
   </PropertyGroup>
 
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.PackageDependencyResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.PackageDependencyResolution.targets
@@ -189,7 +189,7 @@ Copyright (c) .NET Foundation. All rights reserved.
           FileDefinitions="@(FileDefinitions)"
           PackageDependencies="@(PackageDependencies)"
           FileDependencies="@(FileDependencies)"
-          PackageReferences="@(PackageReference)"
+          DefaultImplicitPackages="$(DefaultImplicitPackages)"
           InputDiagnosticMessages="@(DiagnosticMessages)">
 
       <Output TaskParameter="DependenciesDesignTime" ItemName="_DependenciesDesignTime" />
@@ -201,22 +201,23 @@ Copyright (c) .NET Foundation. All rights reserved.
                      CollectSDKReferencesDesignTime
 
     Aggregates the sdk specified as project items and implicit
-    packages raferences.
+    packages references.
     ============================================================
     -->
-
-  <UsingTask TaskName="Microsoft.NET.Build.Tasks.CollectSDKReferencesDesignTime"
+  <UsingTask TaskName="Microsoft.NET.Build.Tasks.CollectResolvedSDKReferencesDesignTime"
              AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
-
+  
   <Target Name="CollectSDKReferencesDesignTime"
-          Returns="@(_SDKReference)">
+          Returns="@(_SDKReference)"
+          DependsOnTargets="ResolvePackageDependenciesDesignTime">
 
-    <CollectSDKReferencesDesignTime
-          SdkReferences="@(SDKReference)"
-          PackageReferences="@(PackageReference)" >
+    <CollectResolvedSDKReferencesDesignTime
+          ResolvedSdkReferences="@(SdkReference)"
+          DependenciesDesignTime="@(_DependenciesDesignTime)">
 
-      <Output TaskParameter="SDKReferencesDesignTime" ItemName="_SDKReference" />
-    </CollectSDKReferencesDesignTime>
+      <Output TaskParameter="ResolvedSDKReferencesDesignTime" ItemName="_SDKReference" />
+
+    </CollectResolvedSDKReferencesDesignTime>
   </Target>
           
   <!--
@@ -228,16 +229,13 @@ Copyright (c) .NET Foundation. All rights reserved.
     ============================================================
     -->
 
-  <UsingTask TaskName="Microsoft.NET.Build.Tasks.CollectResolvedSDKReferencesDesignTime"
-             AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
-
   <Target Name="CollectResolvedSDKReferencesDesignTime"
           Returns="@(_ResolvedSDKReference)"
           DependsOnTargets="ResolveSDKReferencesDesignTime;ResolvePackageDependenciesDesignTime">
 
     <CollectResolvedSDKReferencesDesignTime
           ResolvedSdkReferences="@(ResolvedSdkReference)"
-          DependenciesDesignTime="@(_DependenciesDesignTime)" >
+          DependenciesDesignTime="@(_DependenciesDesignTime)">
 
       <Output TaskParameter="ResolvedSDKReferencesDesignTime" ItemName="_ResolvedSDKReference" />
     </CollectResolvedSDKReferencesDesignTime>


### PR DESCRIPTION
This is a matching change for this https://github.com/dotnet/roslyn-project-system/pull/1513 which fixes this issue: https://github.com/dotnet/roslyn-project-system/issues/1456. 

@natidea @srivatsn @dotnet/project-system 