### PR TITLE
Remove requirement for specifying a RID in desktop exe projects

### DIFF
--- a/TestAssets/TestProjects/AllResourcesInSatellite/AllResourcesInSatellite.csproj
+++ b/TestAssets/TestProjects/AllResourcesInSatellite/AllResourcesInSatellite.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp1.0</TargetFrameworks>
-    <RuntimeIdentifiers>win7-x86</RuntimeIdentifiers>
     <OutputType>Exe</OutputType>
     <AssemblyOriginatorKeyFile>test.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
@@ -19,7 +18,6 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net46'">
-    <RuntimeIdentifier>win7-x86</RuntimeIdentifier>
     <PublicSign>false</PublicSign>
   </PropertyGroup>
   

--- a/TestAssets/TestProjects/DesktopMinusRid/DesktopMinusRid.csproj
+++ b/TestAssets/TestProjects/DesktopMinusRid/DesktopMinusRid.csproj
@@ -3,4 +3,10 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net46</TargetFramework>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(UseNativeCode)' == 'true'">
+     <DefineConstants>$(DefineConstants);USE_NATIVE_CODE</DefineConstants>
+  </PropertyGroup>
+  <ItemGroup Condition="'$(UseNativeCode)' == 'true'">
+    <PackageReference Include="Libuv" Version="1.9.1" />
+  </ItemGroup>
 </Project>

--- a/TestAssets/TestProjects/DesktopMinusRid/Program.cs
+++ b/TestAssets/TestProjects/DesktopMinusRid/Program.cs
@@ -2,14 +2,41 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Diagnostics;
+using System.Reflection;
+using System.Runtime.InteropServices;
 
 namespace TestApp
 {
-    public class Program
+    class Program
     {
-        public static void Main(string[] args)
+        static void Main()
         {
+            // Prevent libuv on path from interfering with test
+            Environment.SetEnvironmentVariable("PATH", "");
+
+#if USE_NATIVE_CODE
+            try
+            {
+                uv_loop_size();
+                Console.WriteLine($"Native code was used ({GetProcessorArchitecture()})");
+            }
+            catch (DllNotFoundException)
+            {
+                Console.WriteLine($"Native code failed ({GetProcessorArchitecture()})");
+            }
+#else      
+            Console.WriteLine($"Native code was not used ({GetProcessorArchitecture()})");
+#endif  
+        }
+
+#if USE_NATIVE_CODE
+        [DllImport("libuv", CallingConvention = CallingConvention.Cdecl)]
+        static extern int uv_loop_size();
+#endif
+
+        static ProcessorArchitecture GetProcessorArchitecture()
+        {
+            return AssemblyName.GetAssemblyName(Assembly.GetExecutingAssembly().Location).ProcessorArchitecture;
         }
     }
 }

--- a/TestAssets/TestProjects/DesktopMinusRid/Program.cs
+++ b/TestAssets/TestProjects/DesktopMinusRid/Program.cs
@@ -18,14 +18,14 @@ namespace TestApp
             try
             {
                 uv_loop_size();
-                Console.WriteLine($"Native code was used ({GetProcessorArchitecture()})");
+                Console.WriteLine($"Native code was used ({GetCurrentAssemblyProcessorArchitecture()})");
             }
             catch (DllNotFoundException)
             {
-                Console.WriteLine($"Native code failed ({GetProcessorArchitecture()})");
+                Console.WriteLine($"Native code failed ({GetCurrentAssemblyProcessorArchitecture()})");
             }
 #else      
-            Console.WriteLine($"Native code was not used ({GetProcessorArchitecture()})");
+            Console.WriteLine($"Native code was not used ({GetCurrentAssemblyProcessorArchitecture()})");
 #endif  
         }
 
@@ -34,9 +34,9 @@ namespace TestApp
         static extern int uv_loop_size();
 #endif
 
-        static ProcessorArchitecture GetProcessorArchitecture()
+        static ProcessorArchitecture GetCurrentAssemblyProcessorArchitecture()
         {
-            return AssemblyName.GetAssemblyName(Assembly.GetExecutingAssembly().Location).ProcessorArchitecture;
+            return AssemblyName.GetAssemblyName(typeof(Program).Assembly.Location).ProcessorArchitecture;
         }
     }
 }

--- a/TestAssets/TestProjects/DesktopMinusRid/Program.cs
+++ b/TestAssets/TestProjects/DesktopMinusRid/Program.cs
@@ -36,7 +36,11 @@ namespace TestApp
 
         static ProcessorArchitecture GetCurrentAssemblyProcessorArchitecture()
         {
+#if NET46
             return AssemblyName.GetAssemblyName(typeof(Program).Assembly.Location).ProcessorArchitecture;
+#else
+            throw new PlatformNotSupportedException();
+#endif
         }
     }
 }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.cs.resx
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.cs.resx
@@ -174,9 +174,6 @@
   <data name="UnexpectedDependencyWithNoVersionNumber" xml:space="preserve">
     <value>Nečekaná závislost {0} bez čísla verze.</value>
   </data>
-  <data name="RuntimeIdentifierMustBeSetForNETFramework" xml:space="preserve">
-    <value>Hodnota RuntimeIdentifier musí být nastavena pro spustitelné soubory .NET Frameworku. Můžete použít hodnotu RuntimeIdentifier=win7-x86 nebo RuntimeIdentifier=win7-x64.</value>
-  </data>
   <data name="AssetPreprocessorMustBeConfigured" xml:space="preserve">
     <value>Před zpracováním prostředků je potřeba nakonfigurovat preprocesor prostředků.</value>
   </data>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.de.resx
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.de.resx
@@ -174,9 +174,6 @@
   <data name="UnexpectedDependencyWithNoVersionNumber" xml:space="preserve">
     <value>Unerwartete Abhängigkeit "{0}" ohne Versionsnummer.</value>
   </data>
-  <data name="RuntimeIdentifierMustBeSetForNETFramework" xml:space="preserve">
-    <value>"RuntimeIdentifier" muss für ausführbare .NETFramework-Dateien festgelegt werden. Verwenden Sie ggf. "RuntimeIdentifier=win7-x86" oder "RuntimeIdentifier=win7-x64".</value>
-  </data>
   <data name="AssetPreprocessorMustBeConfigured" xml:space="preserve">
     <value>Der Ressourcenpräprozessor muss konfiguriert werden, bevor Ressourcen verarbeitet werden.</value>
   </data>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.es.resx
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.es.resx
@@ -174,9 +174,6 @@
   <data name="UnexpectedDependencyWithNoVersionNumber" xml:space="preserve">
     <value>Dependencia '{0}' sin número de versión no esperada.</value>
   </data>
-  <data name="RuntimeIdentifierMustBeSetForNETFramework" xml:space="preserve">
-    <value>RuntimeIdentifier debe establecerse para archivos ejecutables de .NET Framework. Considere usar RuntimeIdentifier=win7-x86 o RuntimeIdentifier=win7-x64.</value>
-  </data>
   <data name="AssetPreprocessorMustBeConfigured" xml:space="preserve">
     <value>Debe configurarse el preprocesador de recursos antes de que se procesen los recursos.</value>
   </data>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.fr.resx
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.fr.resx
@@ -174,9 +174,6 @@
   <data name="UnexpectedDependencyWithNoVersionNumber" xml:space="preserve">
     <value>Dépendance '{0}' sans numéro de version inattendue.</value>
   </data>
-  <data name="RuntimeIdentifierMustBeSetForNETFramework" xml:space="preserve">
-    <value>RuntimeIdentifier doit être défini pour les exécutables .NET Framework. Considérez RuntimeIdentifier=win7-x86 ou RuntimeIdentifier=win7-x64.</value>
-  </data>
   <data name="AssetPreprocessorMustBeConfigured" xml:space="preserve">
     <value>Le préprocesseur de composants doit être configuré avant que les composants ne soient traités.</value>
   </data>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.it.resx
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.it.resx
@@ -174,9 +174,6 @@
   <data name="UnexpectedDependencyWithNoVersionNumber" xml:space="preserve">
     <value>La dipendenza '{0}' è imprevista e non ha numero di versione.</value>
   </data>
-  <data name="RuntimeIdentifierMustBeSetForNETFramework" xml:space="preserve">
-    <value>Per gli eseguibili di .NET Framework è necessario impostare RuntimeIdentifier. Provare a specificare RuntimeIdentifier=win7-x86 o RuntimeIdentifier=win7-x64.</value>
-  </data>
   <data name="AssetPreprocessorMustBeConfigured" xml:space="preserve">
     <value>Prima di elaborare le risorse, è necessario configurare il preprocessore di risorse.</value>
   </data>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.ja.resx
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.ja.resx
@@ -174,9 +174,6 @@
   <data name="UnexpectedDependencyWithNoVersionNumber" xml:space="preserve">
     <value>バージョン番号のない予期しない依存関係 '{0}' です。</value>
   </data>
-  <data name="RuntimeIdentifierMustBeSetForNETFramework" xml:space="preserve">
-    <value>.NETFramework 実行可能ファイルの RuntimeIdentifier を設定する必要があります。RuntimeIdentifier=win7-x86 または RuntimeIdentifier=win7-x64 を検討してください。</value>
-  </data>
   <data name="AssetPreprocessorMustBeConfigured" xml:space="preserve">
     <value>資産を処理する前に、資産プリプロセッサを構成する必要があります。</value>
   </data>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.ko.resx
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.ko.resx
@@ -174,9 +174,6 @@
   <data name="UnexpectedDependencyWithNoVersionNumber" xml:space="preserve">
     <value>버전 번호가 없는 예기치 않은 종속성 '{0}'입니다.</value>
   </data>
-  <data name="RuntimeIdentifierMustBeSetForNETFramework" xml:space="preserve">
-    <value>.NET Framework 실행 파일에는 RuntimeIdentifier를 설정해야 합니다. RuntimeIdentifier=win7-x86 또는 RuntimeIdentifier=win7-x64를 사용해 보세요.</value>
-  </data>
   <data name="AssetPreprocessorMustBeConfigured" xml:space="preserve">
     <value>자산을 처리하려면 먼저 자산 전처리기를 구성해야 합니다.</value>
   </data>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.pl.resx
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.pl.resx
@@ -174,9 +174,6 @@
   <data name="UnexpectedDependencyWithNoVersionNumber" xml:space="preserve">
     <value>Nieoczekiwana zależność „{0}” bez numeru wersji.</value>
   </data>
-  <data name="RuntimeIdentifierMustBeSetForNETFramework" xml:space="preserve">
-    <value>Element RuntimeIdentifier musi być ustawiony dla plików wykonywalnych programu .NETFramework. Rozważ element RuntimeIdentifier=win7-x86 lub RuntimeIdentifier=win7-x64.</value>
-  </data>
   <data name="AssetPreprocessorMustBeConfigured" xml:space="preserve">
     <value>Preprocesor zasobów musi być skonfigurowany przed przetworzeniem zasobów.</value>
   </data>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.pt-BR.resx
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.pt-BR.resx
@@ -174,9 +174,6 @@
   <data name="UnexpectedDependencyWithNoVersionNumber" xml:space="preserve">
     <value>Dependência inesperada '{0}' sem número de versão.</value>
   </data>
-  <data name="RuntimeIdentifierMustBeSetForNETFramework" xml:space="preserve">
-    <value>O RuntimeIdentifier deve ser definido para executáveis .NETFramework. Considere o RuntimeIdentifier=win7-x86 ou RuntimeIdentifier=win7-x64.</value>
-  </data>
   <data name="AssetPreprocessorMustBeConfigured" xml:space="preserve">
     <value>O pré-processador de ativos deve ser configurado antes de os ativos serem processados.</value>
   </data>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.resx
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.resx
@@ -174,9 +174,6 @@
   <data name="UnexpectedDependencyWithNoVersionNumber" xml:space="preserve">
     <value>Unexpected dependency '{0}' with no version number.</value>
   </data>
-  <data name="RuntimeIdentifierMustBeSetForNETFramework" xml:space="preserve">
-    <value>RuntimeIdentifier must be set for .NETFramework executables. Consider RuntimeIdentifier=win7-x86 or RuntimeIdentifier=win7-x64.</value>
-  </data>
   <data name="AssetPreprocessorMustBeConfigured" xml:space="preserve">
     <value>Asset preprocessor must be configured before assets are processed.</value>
   </data>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.ru.resx
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.ru.resx
@@ -174,9 +174,6 @@
   <data name="UnexpectedDependencyWithNoVersionNumber" xml:space="preserve">
     <value>Непредвиденная зависимость "{0}" без номера версии.</value>
   </data>
-  <data name="RuntimeIdentifierMustBeSetForNETFramework" xml:space="preserve">
-    <value>RuntimeIdentifier необходимо задать для исполняемых файлов .NETFramework. Рекомендуется RuntimeIdentifier=win7-x86 или RuntimeIdentifier=win7-x64.</value>
-  </data>
   <data name="AssetPreprocessorMustBeConfigured" xml:space="preserve">
     <value>Препроцессор ресурсов необходимо настроить перед обработкой ресурсов.</value>
   </data>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.tr.resx
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.tr.resx
@@ -174,9 +174,6 @@
   <data name="UnexpectedDependencyWithNoVersionNumber" xml:space="preserve">
     <value>Sürüm numarası olmayan, beklenmeyen bağımlılık: '{0}'.</value>
   </data>
-  <data name="RuntimeIdentifierMustBeSetForNETFramework" xml:space="preserve">
-    <value>.NETFramework yürütülebilir dosyaları için RuntimeIdentifier ayarlanmalıdır. RuntimeIdentifier=win7-x86 veya RuntimeIdentifier=win7-x64 ayarlanabilir.</value>
-  </data>
   <data name="AssetPreprocessorMustBeConfigured" xml:space="preserve">
     <value>Varlıkların işlenebilmesi için varlık ön işlemcisi yapılandırılmalıdır.</value>
   </data>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.zh-Hans.resx
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.zh-Hans.resx
@@ -174,9 +174,6 @@
   <data name="UnexpectedDependencyWithNoVersionNumber" xml:space="preserve">
     <value>不具有版本号的意外依赖项“{0}”。</value>
   </data>
-  <data name="RuntimeIdentifierMustBeSetForNETFramework" xml:space="preserve">
-    <value>必须为 .NETFramework 可执行文件设置 RuntimeIdentifier。请考虑 RuntimeIdentifier=win7-x86 或 RuntimeIdentifier=win7-x64。</value>
-  </data>
   <data name="AssetPreprocessorMustBeConfigured" xml:space="preserve">
     <value>必须在处理资产之前配置资产预处理器。</value>
   </data>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.zh-Hant.resx
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.zh-Hant.resx
@@ -174,9 +174,6 @@
   <data name="UnexpectedDependencyWithNoVersionNumber" xml:space="preserve">
     <value>未預期的相依性 '{0}'，沒有版本號碼。</value>
   </data>
-  <data name="RuntimeIdentifierMustBeSetForNETFramework" xml:space="preserve">
-    <value>必須為 .NETFramework 可執行檔設定 RuntimeIdentifier。請考慮使用 RuntimeIdentifier=win7-x86 或 RuntimeIdentifier=win7-x64。</value>
-  </data>
   <data name="AssetPreprocessorMustBeConfigured" xml:space="preserve">
     <value>必須設定資產前置處理器，才能處理資產。</value>
   </data>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.cs.xlf
@@ -9,9 +9,9 @@
         <note />
       </trans-unit>
       <trans-unit id="NoCompatibleTargetFramework">
-        <source>Project '{0}' has no target framework compatible with '{1}'.</source>
-        <target state="translated">Cílová platforma projektu {0} není kompatibilní s {1}.</target>
-        <note />
+        <source>Project '{0}' targets '{2}'. It cannot be referenced by a project that targets '{1}'.</source>
+        <target state="needs-review-translation">Cílová platforma projektu {0} není kompatibilní s {1}.</target>
+        <note></note>
       </trans-unit>
       <trans-unit id="InvalidFrameworkName">
         <source>Invalid framework name: '{0}'.</source>
@@ -96,11 +96,6 @@
       <trans-unit id="UnexpectedDependencyWithNoVersionNumber">
         <source>Unexpected dependency '{0}' with no version number.</source>
         <target state="translated">Nečekaná závislost {0} bez čísla verze.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="RuntimeIdentifierMustBeSetForNETFramework">
-        <source>RuntimeIdentifier must be set for .NETFramework executables. Consider RuntimeIdentifier=win7-x86 or RuntimeIdentifier=win7-x64.</source>
-        <target state="translated">Hodnota RuntimeIdentifier musí být nastavena pro spustitelné soubory .NET Frameworku. Můžete použít hodnotu RuntimeIdentifier=win7-x86 nebo RuntimeIdentifier=win7-x64.</target>
         <note />
       </trans-unit>
       <trans-unit id="AssetPreprocessorMustBeConfigured">

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.de.xlf
@@ -9,9 +9,9 @@
         <note />
       </trans-unit>
       <trans-unit id="NoCompatibleTargetFramework">
-        <source>Project '{0}' has no target framework compatible with '{1}'.</source>
-        <target state="translated">Für das Projekt "{0}" ist kein mit "{1}" kompatibles Framework vorhanden.</target>
-        <note />
+        <source>Project '{0}' targets '{2}'. It cannot be referenced by a project that targets '{1}'.</source>
+        <target state="needs-review-translation">Für das Projekt "{0}" ist kein mit "{1}" kompatibles Framework vorhanden.</target>
+        <note></note>
       </trans-unit>
       <trans-unit id="InvalidFrameworkName">
         <source>Invalid framework name: '{0}'.</source>
@@ -96,11 +96,6 @@
       <trans-unit id="UnexpectedDependencyWithNoVersionNumber">
         <source>Unexpected dependency '{0}' with no version number.</source>
         <target state="translated">Unerwartete Abhängigkeit "{0}" ohne Versionsnummer.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="RuntimeIdentifierMustBeSetForNETFramework">
-        <source>RuntimeIdentifier must be set for .NETFramework executables. Consider RuntimeIdentifier=win7-x86 or RuntimeIdentifier=win7-x64.</source>
-        <target state="translated">"RuntimeIdentifier" muss für ausführbare .NETFramework-Dateien festgelegt werden. Verwenden Sie ggf. "RuntimeIdentifier=win7-x86" oder "RuntimeIdentifier=win7-x64".</target>
         <note />
       </trans-unit>
       <trans-unit id="AssetPreprocessorMustBeConfigured">

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.es.xlf
@@ -9,9 +9,9 @@
         <note />
       </trans-unit>
       <trans-unit id="NoCompatibleTargetFramework">
-        <source>Project '{0}' has no target framework compatible with '{1}'.</source>
-        <target state="translated">El proyecto '{0}' no tiene una plataforma de destino compatible con '{1}'.</target>
-        <note />
+        <source>Project '{0}' targets '{2}'. It cannot be referenced by a project that targets '{1}'.</source>
+        <target state="needs-review-translation">El proyecto '{0}' no tiene una plataforma de destino compatible con '{1}'.</target>
+        <note></note>
       </trans-unit>
       <trans-unit id="InvalidFrameworkName">
         <source>Invalid framework name: '{0}'.</source>
@@ -96,11 +96,6 @@
       <trans-unit id="UnexpectedDependencyWithNoVersionNumber">
         <source>Unexpected dependency '{0}' with no version number.</source>
         <target state="translated">Dependencia '{0}' sin número de versión no esperada.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="RuntimeIdentifierMustBeSetForNETFramework">
-        <source>RuntimeIdentifier must be set for .NETFramework executables. Consider RuntimeIdentifier=win7-x86 or RuntimeIdentifier=win7-x64.</source>
-        <target state="translated">RuntimeIdentifier debe establecerse para archivos ejecutables de .NET Framework. Considere usar RuntimeIdentifier=win7-x86 o RuntimeIdentifier=win7-x64.</target>
         <note />
       </trans-unit>
       <trans-unit id="AssetPreprocessorMustBeConfigured">

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.fr.xlf
@@ -9,9 +9,9 @@
         <note />
       </trans-unit>
       <trans-unit id="NoCompatibleTargetFramework">
-        <source>Project '{0}' has no target framework compatible with '{1}'.</source>
-        <target state="translated">Le projet '{0}' n'a aucun framework cible compatible avec '{1}'.</target>
-        <note />
+        <source>Project '{0}' targets '{2}'. It cannot be referenced by a project that targets '{1}'.</source>
+        <target state="needs-review-translation">Le projet '{0}' n'a aucun framework cible compatible avec '{1}'.</target>
+        <note></note>
       </trans-unit>
       <trans-unit id="InvalidFrameworkName">
         <source>Invalid framework name: '{0}'.</source>
@@ -96,11 +96,6 @@
       <trans-unit id="UnexpectedDependencyWithNoVersionNumber">
         <source>Unexpected dependency '{0}' with no version number.</source>
         <target state="translated">Dépendance '{0}' sans numéro de version inattendue.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="RuntimeIdentifierMustBeSetForNETFramework">
-        <source>RuntimeIdentifier must be set for .NETFramework executables. Consider RuntimeIdentifier=win7-x86 or RuntimeIdentifier=win7-x64.</source>
-        <target state="translated">RuntimeIdentifier doit être défini pour les exécutables .NET Framework. Considérez RuntimeIdentifier=win7-x86 ou RuntimeIdentifier=win7-x64.</target>
         <note />
       </trans-unit>
       <trans-unit id="AssetPreprocessorMustBeConfigured">

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.it.xlf
@@ -9,9 +9,9 @@
         <note />
       </trans-unit>
       <trans-unit id="NoCompatibleTargetFramework">
-        <source>Project '{0}' has no target framework compatible with '{1}'.</source>
-        <target state="translated">Per il progetto '{0}' non esiste alcun framework di destinazione compatibile con '{1}'.</target>
-        <note />
+        <source>Project '{0}' targets '{2}'. It cannot be referenced by a project that targets '{1}'.</source>
+        <target state="needs-review-translation">Per il progetto '{0}' non esiste alcun framework di destinazione compatibile con '{1}'.</target>
+        <note></note>
       </trans-unit>
       <trans-unit id="InvalidFrameworkName">
         <source>Invalid framework name: '{0}'.</source>
@@ -96,11 +96,6 @@
       <trans-unit id="UnexpectedDependencyWithNoVersionNumber">
         <source>Unexpected dependency '{0}' with no version number.</source>
         <target state="translated">La dipendenza '{0}' è imprevista e non ha numero di versione.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="RuntimeIdentifierMustBeSetForNETFramework">
-        <source>RuntimeIdentifier must be set for .NETFramework executables. Consider RuntimeIdentifier=win7-x86 or RuntimeIdentifier=win7-x64.</source>
-        <target state="translated">Per gli eseguibili di .NET Framework è necessario impostare RuntimeIdentifier. Provare a specificare RuntimeIdentifier=win7-x86 o RuntimeIdentifier=win7-x64.</target>
         <note />
       </trans-unit>
       <trans-unit id="AssetPreprocessorMustBeConfigured">

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.ja.xlf
@@ -9,9 +9,9 @@
         <note />
       </trans-unit>
       <trans-unit id="NoCompatibleTargetFramework">
-        <source>Project '{0}' has no target framework compatible with '{1}'.</source>
-        <target state="translated">プロジェクト '{0}' には、'{1}' と互換性のあるターゲット フレームワークがありません。</target>
-        <note />
+        <source>Project '{0}' targets '{2}'. It cannot be referenced by a project that targets '{1}'.</source>
+        <target state="needs-review-translation">プロジェクト '{0}' には、'{1}' と互換性のあるターゲット フレームワークがありません。</target>
+        <note></note>
       </trans-unit>
       <trans-unit id="InvalidFrameworkName">
         <source>Invalid framework name: '{0}'.</source>
@@ -96,11 +96,6 @@
       <trans-unit id="UnexpectedDependencyWithNoVersionNumber">
         <source>Unexpected dependency '{0}' with no version number.</source>
         <target state="translated">バージョン番号のない予期しない依存関係 '{0}' です。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="RuntimeIdentifierMustBeSetForNETFramework">
-        <source>RuntimeIdentifier must be set for .NETFramework executables. Consider RuntimeIdentifier=win7-x86 or RuntimeIdentifier=win7-x64.</source>
-        <target state="translated">.NETFramework 実行可能ファイルの RuntimeIdentifier を設定する必要があります。RuntimeIdentifier=win7-x86 または RuntimeIdentifier=win7-x64 を検討してください。</target>
         <note />
       </trans-unit>
       <trans-unit id="AssetPreprocessorMustBeConfigured">

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.ko.xlf
@@ -9,9 +9,9 @@
         <note />
       </trans-unit>
       <trans-unit id="NoCompatibleTargetFramework">
-        <source>Project '{0}' has no target framework compatible with '{1}'.</source>
-        <target state="translated">'{0}' 프로젝트에 '{1}'과(와) 호환되는 대상 프레임워크가 없습니다.</target>
-        <note />
+        <source>Project '{0}' targets '{2}'. It cannot be referenced by a project that targets '{1}'.</source>
+        <target state="needs-review-translation">'{0}' 프로젝트에 '{1}'과(와) 호환되는 대상 프레임워크가 없습니다.</target>
+        <note></note>
       </trans-unit>
       <trans-unit id="InvalidFrameworkName">
         <source>Invalid framework name: '{0}'.</source>
@@ -96,11 +96,6 @@
       <trans-unit id="UnexpectedDependencyWithNoVersionNumber">
         <source>Unexpected dependency '{0}' with no version number.</source>
         <target state="translated">버전 번호가 없는 예기치 않은 종속성 '{0}'입니다.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="RuntimeIdentifierMustBeSetForNETFramework">
-        <source>RuntimeIdentifier must be set for .NETFramework executables. Consider RuntimeIdentifier=win7-x86 or RuntimeIdentifier=win7-x64.</source>
-        <target state="translated">.NET Framework 실행 파일에는 RuntimeIdentifier를 설정해야 합니다. RuntimeIdentifier=win7-x86 또는 RuntimeIdentifier=win7-x64를 사용해 보세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="AssetPreprocessorMustBeConfigured">

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.pl.xlf
@@ -9,9 +9,9 @@
         <note />
       </trans-unit>
       <trans-unit id="NoCompatibleTargetFramework">
-        <source>Project '{0}' has no target framework compatible with '{1}'.</source>
-        <target state="translated">Projekt „{0}” nie ma platformy docelowej kompatybilnej z „{1}”.</target>
-        <note />
+        <source>Project '{0}' targets '{2}'. It cannot be referenced by a project that targets '{1}'.</source>
+        <target state="needs-review-translation">Projekt „{0}” nie ma platformy docelowej kompatybilnej z „{1}”.</target>
+        <note></note>
       </trans-unit>
       <trans-unit id="InvalidFrameworkName">
         <source>Invalid framework name: '{0}'.</source>
@@ -96,11 +96,6 @@
       <trans-unit id="UnexpectedDependencyWithNoVersionNumber">
         <source>Unexpected dependency '{0}' with no version number.</source>
         <target state="translated">Nieoczekiwana zależność „{0}” bez numeru wersji.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="RuntimeIdentifierMustBeSetForNETFramework">
-        <source>RuntimeIdentifier must be set for .NETFramework executables. Consider RuntimeIdentifier=win7-x86 or RuntimeIdentifier=win7-x64.</source>
-        <target state="translated">Element RuntimeIdentifier musi być ustawiony dla plików wykonywalnych programu .NETFramework. Rozważ element RuntimeIdentifier=win7-x86 lub RuntimeIdentifier=win7-x64.</target>
         <note />
       </trans-unit>
       <trans-unit id="AssetPreprocessorMustBeConfigured">

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.pt-BR.xlf
@@ -9,9 +9,9 @@
         <note />
       </trans-unit>
       <trans-unit id="NoCompatibleTargetFramework">
-        <source>Project '{0}' has no target framework compatible with '{1}'.</source>
-        <target state="translated">O projeto '{0}' não tem nenhuma estrutura de destino compatível com '{1}'.</target>
-        <note />
+        <source>Project '{0}' targets '{2}'. It cannot be referenced by a project that targets '{1}'.</source>
+        <target state="needs-review-translation">O projeto '{0}' não tem nenhuma estrutura de destino compatível com '{1}'.</target>
+        <note></note>
       </trans-unit>
       <trans-unit id="InvalidFrameworkName">
         <source>Invalid framework name: '{0}'.</source>
@@ -96,11 +96,6 @@
       <trans-unit id="UnexpectedDependencyWithNoVersionNumber">
         <source>Unexpected dependency '{0}' with no version number.</source>
         <target state="translated">Dependência inesperada '{0}' sem número de versão.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="RuntimeIdentifierMustBeSetForNETFramework">
-        <source>RuntimeIdentifier must be set for .NETFramework executables. Consider RuntimeIdentifier=win7-x86 or RuntimeIdentifier=win7-x64.</source>
-        <target state="translated">O RuntimeIdentifier deve ser definido para executáveis .NETFramework. Considere o RuntimeIdentifier=win7-x86 ou RuntimeIdentifier=win7-x64.</target>
         <note />
       </trans-unit>
       <trans-unit id="AssetPreprocessorMustBeConfigured">

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.ru.xlf
@@ -9,9 +9,9 @@
         <note />
       </trans-unit>
       <trans-unit id="NoCompatibleTargetFramework">
-        <source>Project '{0}' has no target framework compatible with '{1}'.</source>
-        <target state="translated">Проект "{0}" не содержит целевую платформу, совместимую с "{1}".</target>
-        <note />
+        <source>Project '{0}' targets '{2}'. It cannot be referenced by a project that targets '{1}'.</source>
+        <target state="needs-review-translation">Проект "{0}" не содержит целевую платформу, совместимую с "{1}".</target>
+        <note></note>
       </trans-unit>
       <trans-unit id="InvalidFrameworkName">
         <source>Invalid framework name: '{0}'.</source>
@@ -96,11 +96,6 @@
       <trans-unit id="UnexpectedDependencyWithNoVersionNumber">
         <source>Unexpected dependency '{0}' with no version number.</source>
         <target state="translated">Непредвиденная зависимость "{0}" без номера версии.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="RuntimeIdentifierMustBeSetForNETFramework">
-        <source>RuntimeIdentifier must be set for .NETFramework executables. Consider RuntimeIdentifier=win7-x86 or RuntimeIdentifier=win7-x64.</source>
-        <target state="translated">RuntimeIdentifier необходимо задать для исполняемых файлов .NETFramework. Рекомендуется RuntimeIdentifier=win7-x86 или RuntimeIdentifier=win7-x64.</target>
         <note />
       </trans-unit>
       <trans-unit id="AssetPreprocessorMustBeConfigured">

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.tr.xlf
@@ -9,9 +9,9 @@
         <note />
       </trans-unit>
       <trans-unit id="NoCompatibleTargetFramework">
-        <source>Project '{0}' has no target framework compatible with '{1}'.</source>
-        <target state="translated">'{0}' projesinde '{1}' ile uyumlu bir hedef çerçeve yok.</target>
-        <note />
+        <source>Project '{0}' targets '{2}'. It cannot be referenced by a project that targets '{1}'.</source>
+        <target state="needs-review-translation">'{0}' projesinde '{1}' ile uyumlu bir hedef çerçeve yok.</target>
+        <note></note>
       </trans-unit>
       <trans-unit id="InvalidFrameworkName">
         <source>Invalid framework name: '{0}'.</source>
@@ -96,11 +96,6 @@
       <trans-unit id="UnexpectedDependencyWithNoVersionNumber">
         <source>Unexpected dependency '{0}' with no version number.</source>
         <target state="translated">Sürüm numarası olmayan, beklenmeyen bağımlılık: '{0}'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="RuntimeIdentifierMustBeSetForNETFramework">
-        <source>RuntimeIdentifier must be set for .NETFramework executables. Consider RuntimeIdentifier=win7-x86 or RuntimeIdentifier=win7-x64.</source>
-        <target state="translated">.NETFramework yürütülebilir dosyaları için RuntimeIdentifier ayarlanmalıdır. RuntimeIdentifier=win7-x86 veya RuntimeIdentifier=win7-x64 ayarlanabilir.</target>
         <note />
       </trans-unit>
       <trans-unit id="AssetPreprocessorMustBeConfigured">

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.xlf
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="NoCompatibleTargetFramework">
-        <source>Project '{0}' has no target framework compatible with '{1}'.</source>
-        <note />
+        <source>Project '{0}' targets '{2}'. It cannot be referenced by a project that targets '{1}'.</source>
+        <note></note>
       </trans-unit>
       <trans-unit id="InvalidFrameworkName">
         <source>Invalid framework name: '{0}'.</source>
@@ -77,10 +77,6 @@
       </trans-unit>
       <trans-unit id="UnexpectedDependencyWithNoVersionNumber">
         <source>Unexpected dependency '{0}' with no version number.</source>
-        <note />
-      </trans-unit>
-      <trans-unit id="RuntimeIdentifierMustBeSetForNETFramework">
-        <source>RuntimeIdentifier must be set for .NETFramework executables. Consider RuntimeIdentifier=win7-x86 or RuntimeIdentifier=win7-x64.</source>
         <note />
       </trans-unit>
       <trans-unit id="AssetPreprocessorMustBeConfigured">

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.zh-Hans.xlf
@@ -9,9 +9,9 @@
         <note />
       </trans-unit>
       <trans-unit id="NoCompatibleTargetFramework">
-        <source>Project '{0}' has no target framework compatible with '{1}'.</source>
-        <target state="translated">项目“{0}”没有与“{1}”兼容的目标框架。</target>
-        <note />
+        <source>Project '{0}' targets '{2}'. It cannot be referenced by a project that targets '{1}'.</source>
+        <target state="needs-review-translation">项目“{0}”没有与“{1}”兼容的目标框架。</target>
+        <note></note>
       </trans-unit>
       <trans-unit id="InvalidFrameworkName">
         <source>Invalid framework name: '{0}'.</source>
@@ -96,11 +96,6 @@
       <trans-unit id="UnexpectedDependencyWithNoVersionNumber">
         <source>Unexpected dependency '{0}' with no version number.</source>
         <target state="translated">不具有版本号的意外依赖项“{0}”。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="RuntimeIdentifierMustBeSetForNETFramework">
-        <source>RuntimeIdentifier must be set for .NETFramework executables. Consider RuntimeIdentifier=win7-x86 or RuntimeIdentifier=win7-x64.</source>
-        <target state="translated">必须为 .NETFramework 可执行文件设置 RuntimeIdentifier。请考虑 RuntimeIdentifier=win7-x86 或 RuntimeIdentifier=win7-x64。</target>
         <note />
       </trans-unit>
       <trans-unit id="AssetPreprocessorMustBeConfigured">

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.zh-Hant.xlf
@@ -9,9 +9,9 @@
         <note />
       </trans-unit>
       <trans-unit id="NoCompatibleTargetFramework">
-        <source>Project '{0}' has no target framework compatible with '{1}'.</source>
-        <target state="translated">專案 '{0}' 沒有與 '{1}' 相容的目標 Framework。</target>
-        <note />
+        <source>Project '{0}' targets '{2}'. It cannot be referenced by a project that targets '{1}'.</source>
+        <target state="needs-review-translation">專案 '{0}' 沒有與 '{1}' 相容的目標 Framework。</target>
+        <note></note>
       </trans-unit>
       <trans-unit id="InvalidFrameworkName">
         <source>Invalid framework name: '{0}'.</source>
@@ -96,11 +96,6 @@
       <trans-unit id="UnexpectedDependencyWithNoVersionNumber">
         <source>Unexpected dependency '{0}' with no version number.</source>
         <target state="translated">未預期的相依性 '{0}'，沒有版本號碼。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="RuntimeIdentifierMustBeSetForNETFramework">
-        <source>RuntimeIdentifier must be set for .NETFramework executables. Consider RuntimeIdentifier=win7-x86 or RuntimeIdentifier=win7-x64.</source>
-        <target state="translated">必須為 .NETFramework 可執行檔設定 RuntimeIdentifier。請考慮使用 RuntimeIdentifier=win7-x86 或 RuntimeIdentifier=win7-x64。</target>
         <note />
       </trans-unit>
       <trans-unit id="AssetPreprocessorMustBeConfigured">

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.RuntimeIdentifierInference.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.RuntimeIdentifierInference.targets
@@ -107,9 +107,12 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <!--
     Append $(RuntimeIdentifier) directory to output and intermediate paths to prevent bin clashes between
-    targets.
+    targets. 
+
+    But do not append the implicit default runtime identifier for .NET Framework apps as that would 
+    append a RID the user never mentioned in the path and do so even in the AnyCPU case.
    -->
-  <PropertyGroup Condition="'$(AppendRuntimeIdentifierToOutputPath)' == 'true' and '$(RuntimeIdentifier)' != ''">
+  <PropertyGroup Condition="'$(AppendRuntimeIdentifierToOutputPath)' == 'true' and '$(RuntimeIdentifier)' != '' and '$(_UsingDefaultRuntimeIdentifier)' != 'true'">
     <IntermediateOutputPath>$(IntermediateOutputPath)$(RuntimeIdentifier)\</IntermediateOutputPath>
     <OutputPath>$(OutputPath)$(RuntimeIdentifier)\</OutputPath>
   </PropertyGroup>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.RuntimeIdentifierInference.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.RuntimeIdentifierInference.targets
@@ -39,7 +39,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
       2. Building an x86 or x64 NETFramework application on and for
          Windows with native NuGet dependencies that do not require
-         greater thanwin7.
+         greater than win7.
 
      However, any other combination of host operating system, CPU
      architecture, and minimum Windows version will require some

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.RuntimeIdentifierInference.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.RuntimeIdentifierInference.targets
@@ -14,7 +14,61 @@ Copyright (c) .NET Foundation. All rights reserved.
   <PropertyGroup>
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
   </PropertyGroup>
-  
+
+  <!--
+    .NETFramework cannot load native package dependencies dynamically
+    based on the current architecture.  We have must have a RID to
+    resolve and copy native dependencies to the output directory.
+
+     When building a .NETFramework exe on Windows and not given a RID,
+     we'll pick either win7-x64 or win7-x86 (based on PlatformTarget)
+     if we're not given an explicit RID. However, if after resolving
+     NuGet assets we find no copy-local native dependencies, we will
+     emit the binary as AnyCPU.
+
+     Note that we must set the RID here early (to be seen during NuGet
+     restore) in order for the project.assets.json to include the
+     native dependencies that will let us make the final call on
+     AnyCPU or platform-specific.
+
+     This allows these common cases to work without requiring mention
+     of RuntimeIdentifier in the user project PlatformTarget:
+
+      1. Building an AnyCPU .NETFramework application on any host OS
+         with no native NuGet dependencies. (*)
+
+      2. Building an x86 or x64 NETFramework application on and for
+         Windows with native NuGet dependencies that do not require
+         greater thanwin7.
+
+     However, any other combination of host operating system, CPU
+     architecture, and minimum Windows version will require some
+     manual intervention in the project file to set up the right
+     RID. (**)
+
+     (*) Building NET4x from non-Windows is still not fully supported:
+         https://github.com/dotnet/sdk/issues/335) The point above is
+         that this code would not have to change to make the first
+         scenario work on non-Windows hosts.
+
+     (**) https://github.com/dotnet/sdk/issues/840 tracks improving
+          the default RID selection here to make more non-AnyCPU scenarios
+          work without user intervention. The current static evaluation
+          requirement limits us.
+   -->
+  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework' and 
+                            '$(OutputType)' == 'Exe' and 
+                            '$(OS)' == 'Windows_NT' and
+                            '$(RuntimeIdentifier)' == ''">
+    <_UsingDefaultRuntimeIdentifier>true</_UsingDefaultRuntimeIdentifier>
+    <RuntimeIdentifier Condition="'$(PlatformTarget)' == 'x64'">win7-x64</RuntimeIdentifier>
+    <RuntimeIdentifier Condition="'$(PlatformTarget)' == 'x86' or '$(PlatformTarget)' == ''">win7-x86</RuntimeIdentifier>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(PlatformTarget)' == ''">
+    <_UsingDefaultPlatformTarget>true</_UsingDefaultPlatformTarget>
+  </PropertyGroup>
+
   <!-- Determine PlatformTarget (if not already set) from runtime identifier. -->
   <Choose>
     <When Condition="'$(PlatformTarget)' != '' or '$(RuntimeIdentifier)' == ''" />
@@ -60,9 +114,19 @@ Copyright (c) .NET Foundation. All rights reserved.
     <OutputPath>$(OutputPath)$(RuntimeIdentifier)\</OutputPath>
   </PropertyGroup>
 
-  <Target Name="_CheckRuntimeIdentifier" BeforeTargets="_CheckForInvalidConfigurationAndPlatform">
-    <NetSdkError Condition="'$(RuntimeIdentifier)' == '' and '$(TargetFrameworkIdentifier)' == '.NETFramework' and '$(OutputType)' == 'Exe'"
-                 ResourceName="RuntimeIdentifierMustBeSetForNETFramework" />
+  <!-- 
+    Switch our default .NETFramework CPU architecture choice back to AnyCPU before 
+    compiling the exe if no copy-local native dependencies were resolved from NuGet 
+  -->
+  <Target Name="AdjustDefaultPlatformTargetForNetFrameworkExeWithNoNativeCopyLocalItems"
+          DependsOnTargets="ResolvePackageDependenciesForBuild"
+          BeforeTargets="CoreCompile"
+          Condition="'$(_UsingDefaultPlatformTarget)' == 'true' and
+                     '$(_UsingDefaultRuntimeIdentifier)' == 'true' and 
+                     '@(NativeCopyLocalItems)' == ''">
+    <PropertyGroup>
+      <PlatformTarget>AnyCPU</PlatformTarget>
+    </PropertyGroup>
   </Target>
 
 </Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.RuntimeIdentifierInference.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.RuntimeIdentifierInference.targets
@@ -122,7 +122,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     compiling the exe if no copy-local native dependencies were resolved from NuGet 
   -->
   <Target Name="AdjustDefaultPlatformTargetForNetFrameworkExeWithNoNativeCopyLocalItems"
-          DependsOnTargets="ResolvePackageDependenciesForBuild"
+          AfterTargets="ResolvePackageDependenciesForBuild"
           BeforeTargets="CoreCompile"
           Condition="'$(_UsingDefaultPlatformTarget)' == 'true' and
                      '$(_UsingDefaultRuntimeIdentifier)' == 'true' and 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.BeforeCommon.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.BeforeCommon.targets
@@ -69,7 +69,8 @@ Copyright (c) .NET Foundation. All rights reserved.
     <!-- ensure the PublishDir is RID specific-->
     <PublishDir Condition="'$(PublishDir)' == '' and
                            '$(AppendRuntimeIdentifierToOutputPath)' != 'true' and
-                           '$(RuntimeIdentifier)' != ''">$(OutputPath)$(RuntimeIdentifier)\$(PublishDirName)\</PublishDir>
+                           '$(RuntimeIdentifier)' != '' and
+                           '$(_UsingDefaultRuntimeIdentifier)' != 'true'">$(OutputPath)$(RuntimeIdentifier)\$(PublishDirName)\</PublishDir>
     <PublishDir Condition="'$(PublishDir)' == ''">$(OutputPath)$(PublishDirName)\</PublishDir>
   </PropertyGroup>
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.targets
@@ -354,6 +354,14 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <!--
   ============================================================
+                                      GetAllRuntimeIdentifiers
+  ============================================================
+  -->
+  <Target Name="GetAllRuntimeIdentifiers" 
+          Returns="$(RuntimeIdentifiers);$(RuntimeIdentifier)" />
+
+  <!--
+  ============================================================
                                          Project Capabilities
   ============================================================
   -->

--- a/src/Tasks/Microsoft.NET.Build.Tasks/buildCrossTargeting/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/buildCrossTargeting/Microsoft.NET.Sdk.targets
@@ -63,7 +63,6 @@ Copyright (c) .NET Foundation. All rights reserved.
     </ItemGroup>
 
     <MSBuild Projects="$(MSBuildProjectFile)"
-             Condition="'$(TargetFrameworks)' != ''"
              Targets="GetAllRuntimeIdentifiers"
              Properties="TargetFramework=%(_GetAllRuntimeIdentifiersTargetFrameworks.Identity)">
       <Output ItemName="_AllRuntimeIdentifiers" TaskParameter="TargetOutputs" />

--- a/src/Tasks/Microsoft.NET.Build.Tasks/buildCrossTargeting/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/buildCrossTargeting/Microsoft.NET.Sdk.targets
@@ -30,5 +30,48 @@ Copyright (c) .NET Foundation. All rights reserved.
   <Target Name="Publish">
     <Error Text="The 'Publish' target is not supported without specifying a target framework. The current project targets multiple frameworks, please specify the framework for the published application." />
   </Target>
+
+  <!--
+  ============================================================
+                                      GetAllRuntimeIdentifiers
+
+  Outer build implementation of GetAllRuntimeIdentifiers returns
+  a union of all runtime identifiers used across inner and outer
+  build evaluations.
+
+  It is further set to run before '_GenerateRestoreProjecSpec' 
+  (note that running only 'Restore' is too late and will not work
+  with solution level restore). This ensures that any conditioning
+  of runtime  identifiers against TargetFramework does not prevent
+  restore from providing  the necessary RID-specific assets for all
+  inner builds.
   
+  It also brings parity to VS vs. command line behavior in this
+  scenario because VS passes all of the information from each
+  configured inner build to restore, whereas command-line restore
+  without this target would only use the runtime identifiers that
+  are statically set in the outer evaluation.
+  ============================================================
+  -->
+  <Target Name="GetAllRuntimeIdentifiers" 
+          Returns="$(RuntimeIdentifiers)"
+          BeforeTargets="_GenerateRestoreProjectSpec">
+
+    <ItemGroup>
+      <_GetAllRuntimeIdentifiersTargetFrameworks Include="$(TargetFrameworks)" />
+      <_AllRuntimeIdentifiers Include="$(RuntimeIdentifiers);$(RuntimeIdentifier)" />
+    </ItemGroup>
+
+    <MSBuild Projects="$(MSBuildProjectFile)"
+             Condition="'$(TargetFrameworks)' != ''"
+             Targets="GetAllRuntimeIdentifiers"
+             Properties="TargetFramework=%(_GetAllRuntimeIdentifiersTargetFrameworks.Identity)">
+      <Output ItemName="_AllRuntimeIdentifiers" TaskParameter="TargetOutputs" />
+    </MSBuild>
+
+    <PropertyGroup>
+      <RuntimeIdentifiers>@(_AllRuntimeIdentifiers->Distinct())</RuntimeIdentifiers>
+    </PropertyGroup>
+  </Target>
+
 </Project>

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildADesktopExe.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildADesktopExe.cs
@@ -1,22 +1,58 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.IO;
+using System.Linq;
 using System.Runtime.InteropServices;
+using System.Xml.Linq;
+
+using Microsoft.DotNet.Cli.Utils;
 using Microsoft.NET.TestFramework;
 using Microsoft.NET.TestFramework.Assertions;
 using Microsoft.NET.TestFramework.Commands;
-using Xunit;
-using FluentAssertions;
-using static Microsoft.NET.TestFramework.Commands.MSBuildTest;
 using Microsoft.NET.TestFramework.ProjectConstruction;
+
+using FluentAssertions;
+using Xunit;
+
+using static Microsoft.NET.TestFramework.Commands.MSBuildTest;
 
 namespace Microsoft.NET.Build.Tests
 {
     public class GivenThatWeWantToBuildADesktopExe : SdkTest
     {
-        [Fact]
-        public void It_fails_to_build_if_no_rid_is_set()
+        [Theory]
+
+        // If we don't set platformTarget and don't use native dependency, we get working AnyCPU app.
+        [InlineData("defaults", null, false, "Native code was not used (MSIL)")]
+
+        // If we don't set platformTarget and do use native dependency, we get working x86 app.
+        [InlineData("defaultsNative", null, true, "Native code was used (X86)")]
+
+        // If we set x86 and don't use native dependency, we get working x86 app.
+        [InlineData("x86", "x86", false, "Native code was not used (X86)")]
+
+        // If we set x86 and do use native dependency, we get working x86 app.
+        [InlineData("x86Native", "x86", true, "Native code was used (X86)")]
+
+        // If we set x64 and don't use native dependency, we get working x64 app.
+        [InlineData("x64", "x64", false, "Native code was not used (Amd64)")]
+
+        // If we set x64 and do use native dependency, we get working x64 app.
+        [InlineData("x64Native", "x64", true, "Native code was used (Amd64)")]
+
+        // If we set AnyCPU and don't use native dependency, we get working  AnyCPU app.
+        [InlineData("AnyCPU", "AnyCPU", false, "Native code was not used (MSIL)")]
+
+        // If we set AnyCPU and do use native dependency, we get any CPU app that can't find its native dependency.
+        // Tests current behavior, but ideally we'd also raise a build diagnostic in this case: https://github.com/dotnet/sdk/issues/843
+        [InlineData("AnyCPUNative", "AnyCPU", true, "Native code failed (MSIL)")]
+        public void It_handles_native_depdencies_and_platform_target(
+             string identifier,
+             string platformTarget,
+             bool useNativeCode,
+             string expectedProgramOutput)
         {
             if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
@@ -24,20 +60,36 @@ namespace Microsoft.NET.Build.Tests
             }
 
             var testAsset = _testAssetsManager
-                .CopyTestAsset("DesktopMinusRid")
-                .WithSource()
-                .Restore();
+               .CopyTestAsset("DesktopMinusRid", identifier: Path.DirectorySeparatorChar + identifier)
+               .WithSource()
+               .WithProjectChanges(project =>
+               {
+                   var ns = project.Root.Name.Namespace;
+                   var propertyGroup = project.Root.Elements(ns + "PropertyGroup").First();
+                   propertyGroup.Add(new XElement(ns + "UseNativeCode", useNativeCode));
+
+                   if (platformTarget != null)
+                   {
+                       propertyGroup.Add(new XElement(ns + "PlatformTarget", platformTarget));
+                   }
+               })
+              .Restore();
 
             var buildCommand = new BuildCommand(Stage0MSBuild, testAsset.TestRoot);
             buildCommand
-                .MSBuild
-                .CreateCommandForTarget("build", buildCommand.FullPathProjectFile)
+                .Execute()
+                .Should()
+                .Pass();
+
+            var exe = Path.Combine(buildCommand.GetOutputDirectory("net46").FullName, "DesktopMinusRid.exe");
+            var runCommand = Command.Create(exe, Array.Empty<string>());
+            runCommand
                 .CaptureStdOut()
                 .Execute()
                 .Should()
-                .Fail()
+                .Pass()
                 .And
-                .HaveStdOutContaining("RuntimeIdentifier must be set");
+                .HaveStdOutContaining(expectedProgramOutput);
         }
 
         [Theory]

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildADesktopExe.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildADesktopExe.cs
@@ -173,6 +173,33 @@ namespace Microsoft.NET.Build.Tests
             }
         }
 
+        [Fact]
+        public void It_builds_multitargeted_with_default_rid()
+        {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return;
+            }
+
+            var testAsset = _testAssetsManager
+                .CopyTestAsset("HelloWorld")
+                .WithSource()
+                .WithProjectChanges(project =>
+                {
+                    var ns = project.Root.Name.Namespace;
+                    var propertyGroup = project.Root.Elements(ns + "PropertyGroup").First();
+                    propertyGroup.Element(ns + "TargetFramework").Remove();
+                    propertyGroup.Add(new XElement(ns + "TargetFrameworks", "net46;netcoreapp1.1"));
+                })
+                .Restore();
+
+            var buildCommand = new BuildCommand(Stage0MSBuild, testAsset.TestRoot);
+            buildCommand
+                .Execute()
+                .Should()
+                .Pass();
+        }
+
         [Theory]
         [InlineData("win7-x86", "x86")]
         [InlineData("win8-x86-aot", "x86")]

--- a/test/Microsoft.NET.TestFramework/Commands/GetValuesCommand.cs
+++ b/test/Microsoft.NET.TestFramework/Commands/GetValuesCommand.cs
@@ -24,6 +24,8 @@ namespace Microsoft.NET.TestFramework.Commands
 
         public bool ShouldCompile { get; set; } = true;
 
+        public string DependsOnTargets { get; set; } = "Compile";
+
         public string Configuration { get; set; }
 
         public GetValuesCommand(MSBuildTest msbuild, string projectPath, string targetFramework,
@@ -58,7 +60,7 @@ namespace Microsoft.NET.TestFramework.Commands
   <PropertyGroup>
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
   </PropertyGroup>
-  <Target Name=`WriteValuesToFile` " + (ShouldCompile ? "DependsOnTargets=`Compile`" : "") + $@">
+  <Target Name=`WriteValuesToFile` " + (ShouldCompile ? $"DependsOnTargets=`{DependsOnTargets}`" : "") + $@">
     <WriteLinesToFile
       File=`bin\$(Configuration)\$(TargetFramework)\{_valueName}Values.txt`
       {linesAttribute}


### PR DESCRIPTION
**Customer scenario**
* Cannot build AnyCPU desktop app (common case) using SDK/new project system without applying a cumbersome and hard-to-understand workaround.
* Cannot build desktop app with native nuget dependencies without making a RID choice.

The approach taken is scoped to address these two common cases:

1. Building AnyCPU desktop application
2. Building win7+ desktop applications with native dependencies

Both of the above will happen automatically and F5 successfully without any mention of RuntimeIdentifier or PlatformTarget in the project. Other scenarios will still require adjusting the RID and PlatformTarget to resolve the native dependencies correctly and stamp the resulting binary correctly.

Follow-ups to improve the experience outside these cases:

* https://github.com/dotnet/sdk/issues/840
* https://github.com/dotnet/sdk/issues/843

**Bugs this fixes:**
Fix #396 and its myriad of duplicates/consequences.

**Workarounds, if any**
Specify dummy runtime identifier for AnyCPU app, and explicitly let PlatformTarget to AnyCPU.
Always pick a RID whenever taking native nuget dependencies from a desktop app.

**Risk**
Low. We address two common cases with new defaults. Specifying PlatformTarget and RuntimeIdentifier explicitly shuts off these defaults and gives the user the same control they had before. We simply make it so that this control needn't be used for the most common cases.

**Performance impact**
Minimal. A few extra checks are needed in msbuild evaluation.

**Is this a regression from a previous update?**
No.

**Root cause analysis**
N/A since we are amending a deliberate design decision in response to significant customer and partner feedback.

**How was the bug found**
Customer and partner reported.

@srivatsn @dsplaisted @eerhardt @dotnet/project-system 




