### PR TITLE
Prevent VS from generating non-AnyCPU configurations by default

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.props
@@ -51,11 +51,32 @@ Copyright (c) .NET Foundation. All rights reserved.
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <Optimize>true</Optimize>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Platform)' == 'x64' ">
+
+  <!-- User-facing platform-specific defaults -->
+
+  <!-- 
+    NOTE:
+    
+     * We cannot compare against $(Platform) directly as that will give VS cause to instantiate extra 
+       configurations, for each combination, which leads to performance problems and clutter in the sln
+       in the common AnyCPU-only case.
+
+     * We cannot just set $(PlatformTarget) to $(Platform) here because $(Platform) can be set to anything
+       at the solution level, but there are a fixed set valid $(PlatformTarget) values that can be passed
+       to the compiler. It is up to the user to explicitly set PlatformTarget to non-AnyCPU (if desired)
+       outside the 1:1 defaults below.
+  -->
+  <PropertyGroup>
+    <_PlatformWithoutConfigurationInference>$(Platform)</_PlatformWithoutConfigurationInference>
+  </PropertyGroup>  
+  <PropertyGroup Condition=" '$(_PlatformWithoutConfigurationInference)' == 'x64' ">
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Platform)' == 'x86' ">
+  <PropertyGroup Condition=" '$(_PlatformWithoutConfigurationInference)' == 'x86' ">
     <PlatformTarget>x86</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(_PlatformWithoutConfigurationInference)' == 'ARM' ">
+    <PlatformTarget>ARM</PlatformTarget>
   </PropertyGroup>
 
   <!-- Default settings for all projects built with this Sdk package -->


### PR DESCRIPTION
**Customer scenario**
* Perf: CPS is doing bookkeeping for 6 platform/configuration combinations instead of just 2.
* Annoyance: Sln file is cluttered with x86 and x64 configurations that the user does not need
* Can cause sln build to build libraries intended to always be AnyCPU as x86/x64 depending on how careful you are in configuration manager
* Also led to [NuGet restore issues](https://github.com/NuGet/Home/issues/4316). Those were fixed separately, but it demonstrates risk associated with extra configurations that the user did not request.

**Bugs this fixes:**
Fixes https://github.com/dotnet/roslyn-project-system/issues/1458 

**Workarounds, if any**
None for perf overhead of the extra configurations.
You can hand remove the extra solution configs for the rest, but VS will often add them back.

**Risk**
Low

**Performance impact**
Should improve performance since there are fewer configurations being tracked by CPS.

**Is this a regression from a previous update?**
Yes, introduced by https://github.com/dotnet/sdk/commit/e84a17d3257499293971ef4ae9aabf7b8692c65a

**Root cause analysis**
Lack of test coverage for expected # of configurations on File -> New Project. 

**How was the bug found**
Customer reported.

@davkean @dsplaisted @srivatsn @dotnet/project-system 