### PR TITLE
replace project-level Common.props imports with Directory.Build.props

### DIFF
--- a/TestAssets/TestProjects/ProjectConstruction/NetFrameworkProject/NetFrameworkProject.csproj
+++ b/TestAssets/TestProjects/ProjectConstruction/NetFrameworkProject/NetFrameworkProject.csproj
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>

--- a/TestAssets/TestProjects/ProjectConstruction/NetFrameworkProject/NetFrameworkProject.csproj
+++ b/TestAssets/TestProjects/ProjectConstruction/NetFrameworkProject/NetFrameworkProject.csproj
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,0 +1,5 @@
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+     <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'Common.props'))\Common.props" />
+
+</Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,5 +1,3 @@
-<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-
-     <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'Common.props'))\Common.props" />
-
+<Project>
+     <Import Project="$([MSBuild]::GetPathOfFileAbove('Common.props'))" />
 </Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/Microsoft.NET.Build.Tasks.UnitTests.csproj
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/Microsoft.NET.Build.Tasks.UnitTests.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'Common.props'))\Common.props" />
+
   <PropertyGroup>
     <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
     <ProjectGuid>{6A698C1D-F604-4295-B6FC-7FC726F9FE5F}</ProjectGuid>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Microsoft.NET.Build.Tasks.csproj
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Microsoft.NET.Build.Tasks.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'Common.props'))\Common.props" />
+
   <PropertyGroup>
     <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
     <ProjectGuid>{DF7D2697-B3B4-45C2-8297-27245F528A99}</ProjectGuid>

--- a/src/Templates/CSharpNetStandardTemplatesSetup/CSharpNetStandardTemplatesSetup.csproj
+++ b/src/Templates/CSharpNetStandardTemplatesSetup/CSharpNetStandardTemplatesSetup.csproj
@@ -5,7 +5,6 @@
     <MinimumVisualStudioVersion>15.0</MinimumVisualStudioVersion>
     <ProjectRootDir>$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'Common.props'))\</ProjectRootDir>
   </PropertyGroup>
-  <Import Project="$(ProjectRootDir)Common.props" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>

--- a/src/Templates/CSharpTemplatesSetup/CSharpTemplatesSetup.csproj
+++ b/src/Templates/CSharpTemplatesSetup/CSharpTemplatesSetup.csproj
@@ -5,7 +5,6 @@
     <MinimumVisualStudioVersion>15.0</MinimumVisualStudioVersion>
     <ProjectRootDir>$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'Common.props'))\</ProjectRootDir>
   </PropertyGroup>
-  <Import Project="$(ProjectRootDir)Common.props" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>

--- a/src/Templates/ProjectTemplates/CSharp/.NETCore/CSharpClassLibrary/CSharpClassLibrary.csproj
+++ b/src/Templates/ProjectTemplates/CSharp/.NETCore/CSharpClassLibrary/CSharpClassLibrary.csproj
@@ -5,7 +5,6 @@
     <MinimumVisualStudioVersion>15.0</MinimumVisualStudioVersion>
     <ProjectRootDir>$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'Common.props'))\</ProjectRootDir>
   </PropertyGroup>
-  <Import Project="$(ProjectRootDir)Common.props" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>

--- a/src/Templates/ProjectTemplates/CSharp/.NETCore/CSharpConsoleApplication/CSharpConsoleApplication.csproj
+++ b/src/Templates/ProjectTemplates/CSharp/.NETCore/CSharpConsoleApplication/CSharpConsoleApplication.csproj
@@ -5,7 +5,6 @@
     <MinimumVisualStudioVersion>15.0</MinimumVisualStudioVersion>
     <ProjectRootDir>$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'Common.props'))\</ProjectRootDir>
   </PropertyGroup>
-  <Import Project="$(ProjectRootDir)Common.props" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>

--- a/src/Templates/ProjectTemplates/CSharp/.NETCore/CSharpUnitTest/CSharpUnitTest.csproj
+++ b/src/Templates/ProjectTemplates/CSharp/.NETCore/CSharpUnitTest/CSharpUnitTest.csproj
@@ -5,7 +5,6 @@
     <MinimumVisualStudioVersion>15.0</MinimumVisualStudioVersion>
     <ProjectRootDir>$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'Common.props'))\</ProjectRootDir>
   </PropertyGroup>
-  <Import Project="$(ProjectRootDir)Common.props" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>

--- a/src/Templates/ProjectTemplates/CSharp/.NETCore/CSharpXUnitTest/CSharpXUnitTest.csproj
+++ b/src/Templates/ProjectTemplates/CSharp/.NETCore/CSharpXUnitTest/CSharpXUnitTest.csproj
@@ -5,7 +5,6 @@
     <MinimumVisualStudioVersion>15.0</MinimumVisualStudioVersion>
     <ProjectRootDir>$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'Common.props'))\</ProjectRootDir>
   </PropertyGroup>
-  <Import Project="$(ProjectRootDir)Common.props" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>

--- a/src/Templates/ProjectTemplates/CSharp/.NETStandard/CSharpNetStandardClassLibrary/CSharpNetStandardClassLibrary.csproj
+++ b/src/Templates/ProjectTemplates/CSharp/.NETStandard/CSharpNetStandardClassLibrary/CSharpNetStandardClassLibrary.csproj
@@ -5,7 +5,6 @@
     <MinimumVisualStudioVersion>15.0</MinimumVisualStudioVersion>
     <ProjectRootDir>$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'Common.props'))\</ProjectRootDir>
   </PropertyGroup>
-  <Import Project="$(ProjectRootDir)Common.props" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>

--- a/src/Templates/ProjectTemplates/VisualBasic/.NETCore/VisualBasicClassLibrary/VisualBasicClassLibrary.csproj
+++ b/src/Templates/ProjectTemplates/VisualBasic/.NETCore/VisualBasicClassLibrary/VisualBasicClassLibrary.csproj
@@ -5,7 +5,6 @@
     <MinimumVisualStudioVersion>15.0</MinimumVisualStudioVersion>
     <ProjectRootDir>$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'Common.props'))\</ProjectRootDir>
   </PropertyGroup>
-  <Import Project="$(ProjectRootDir)Common.props" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>

--- a/src/Templates/ProjectTemplates/VisualBasic/.NETCore/VisualBasicConsoleApplication/VisualBasicConsoleApplication.csproj
+++ b/src/Templates/ProjectTemplates/VisualBasic/.NETCore/VisualBasicConsoleApplication/VisualBasicConsoleApplication.csproj
@@ -5,7 +5,6 @@
     <MinimumVisualStudioVersion>15.0</MinimumVisualStudioVersion>
     <ProjectRootDir>$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'Common.props'))\</ProjectRootDir>
   </PropertyGroup>
-  <Import Project="$(ProjectRootDir)Common.props" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>

--- a/src/Templates/ProjectTemplates/VisualBasic/.NETStandard/VisualBasicNetStandardClassLibrary/VisualBasicNetStandardClassLibrary.csproj
+++ b/src/Templates/ProjectTemplates/VisualBasic/.NETStandard/VisualBasicNetStandardClassLibrary/VisualBasicNetStandardClassLibrary.csproj
@@ -5,7 +5,6 @@
     <MinimumVisualStudioVersion>15.0</MinimumVisualStudioVersion>
     <ProjectRootDir>$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'Common.props'))\</ProjectRootDir>
   </PropertyGroup>
-  <Import Project="$(ProjectRootDir)Common.props" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>

--- a/src/Templates/VisualBasicNetStandardTemplatesSetup/VisualBasicNetStandardTemplatesSetup.csproj
+++ b/src/Templates/VisualBasicNetStandardTemplatesSetup/VisualBasicNetStandardTemplatesSetup.csproj
@@ -5,7 +5,6 @@
     <MinimumVisualStudioVersion>15.0</MinimumVisualStudioVersion>
     <ProjectRootDir>$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'Common.props'))\</ProjectRootDir>
   </PropertyGroup>
-  <Import Project="$(ProjectRootDir)Common.props" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>

--- a/src/Templates/VisualBasicTemplatesSetup/VisualBasicTemplatesSetup.csproj
+++ b/src/Templates/VisualBasicTemplatesSetup/VisualBasicTemplatesSetup.csproj
@@ -5,7 +5,6 @@
     <MinimumVisualStudioVersion>15.0</MinimumVisualStudioVersion>
     <ProjectRootDir>$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'Common.props'))\</ProjectRootDir>
   </PropertyGroup>
-  <Import Project="$(ProjectRootDir)Common.props" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -1,0 +1,5 @@
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+     <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'Common.props'))\Common.props" />
+
+</Project>

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -1,5 +1,3 @@
-<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-
-     <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'Common.props'))\Common.props" />
-
+<Project>
+     <Import Project="$([MSBuild]::GetPathOfFileAbove('Common.props'))" />
 </Project>

--- a/test/Microsoft.NET.Build.Tests/Microsoft.NET.Build.Tests.csproj
+++ b/test/Microsoft.NET.Build.Tests/Microsoft.NET.Build.Tests.csproj
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'Common.props'))\Common.props" />
   <PropertyGroup>
     <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
     <ProjectGuid>{EC640B7E-332E-40A2-BB6E-5B7EC788F315}</ProjectGuid>

--- a/test/Microsoft.NET.Pack.Tests/Microsoft.NET.Pack.Tests.csproj
+++ b/test/Microsoft.NET.Pack.Tests/Microsoft.NET.Pack.Tests.csproj
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'Common.props'))\Common.props" />
   <PropertyGroup>
     <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
     <ProjectGuid>{588516D7-96AD-4447-A1EB-244D737A3C87}</ProjectGuid>

--- a/test/Microsoft.NET.Publish.Tests/Microsoft.NET.Publish.Tests.csproj
+++ b/test/Microsoft.NET.Publish.Tests/Microsoft.NET.Publish.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'Common.props'))\Common.props" />
+  
   <PropertyGroup>
     <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
     <ProjectGuid>{7F31F2C6-6395-400C-ABE3-5A1CEF208096}</ProjectGuid>

--- a/test/Microsoft.NET.TestFramework/Microsoft.NET.TestFramework.csproj
+++ b/test/Microsoft.NET.TestFramework/Microsoft.NET.TestFramework.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'Common.props'))\Common.props" />
+ 
   <PropertyGroup>
     <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
     <ProjectGuid>{A33548A0-F3B0-40C3-8C4D-AD2F00596CD6}</ProjectGuid>


### PR DESCRIPTION
This removes the Common.props imports from the projects under /test and /src and replaces them with Directory.Build.props.

This addresses #802.