### PR TITLE
Use dotnet msbuild in build.sh so targets can be supplied

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -77,4 +77,4 @@ export PATH="$DOTNET_INSTALL_DIR:$PATH"
 # Disable first run since we want to control all package sources
 export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
 
-dotnet build $REPOROOT/build/build.proj /m:1 /nologo /p:Configuration=$CONFIGURATION /p:Platform="$PLATFORM" "${args[@]}"
+dotnet msbuild $REPOROOT/build/build.proj /m:1 /nologo /p:Configuration=$CONFIGURATION /p:Platform="$PLATFORM" "${args[@]}"


### PR DESCRIPTION
This matches what `build.ps1` does.

`dotnet build` is an alias for `dotnet msbuild /t:Build`. If a user does `dotnet build /t:Foo`, dotnet ends up calling  ~~`dotnet msbuild /t:Build`,ignoring `Foo` completely and unexpectedly~~. `dotnet msbuild /t:Build /t:Foo`, which may not be what the user wants. See https://github.com/dotnet/cli/issues/4815 for more information.

So switch to running `dotnet msbuild` so user can supply targets to `build.sh` and it will just work.

As an example:

    ./build.sh /t:BuildWithoutTesting

Before this patch, this still ends up running `/t:Build`. After this patch it ends up running `/t:BuildWithoutTesting` as expected, without any surprises.