### PR TITLE
Skip import of Microsoft.NuGet.props and Microsoft.NuGet.targets

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.props
@@ -85,6 +85,10 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <!-- This will turn off the base UWP-specific 'ResolveNuGetPackages' target -->
     <ResolveNuGetPackages>false</ResolveNuGetPackages>
+
+    <!-- Skip import of Microsoft.NuGet.props and Microsoft.NuGet.targets -->
+    <SkipImportNuGetProps>true</SkipImportNuGetProps>
+    <SkipImportNuGetBuildTargets>true</SkipImportNuGetBuildTargets>
     
     <!-- NuGet should always restore .NET SDK projects with "PackageReference" style restore.  Setting this property will
          cause the right thing to happen even if there aren't any PackageReference items in the project, such as when

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildALibrary.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildALibrary.cs
@@ -577,5 +577,15 @@ namespace Microsoft.NET.Build.Tests
                 .Should()
                 .Pass();
         }
+
+        [Fact]
+        public void It_restores_only_ridless_tfm()
+        {
+            // When RuntimeIdentifier is not specified, the assets file
+            // should only contain one target with no RIDs
+            var targetDefs = GetValuesFromTestLibrary(_testAssetsManager, "TargetDefinitions");
+            targetDefs.Count.Should().Be(1);
+            targetDefs.Should().Contain(".NETStandard,Version=v1.5");
+        }
     }
 }

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildALibrary.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildALibrary.cs
@@ -577,15 +577,5 @@ namespace Microsoft.NET.Build.Tests
                 .Should()
                 .Pass();
         }
-
-        [Fact]
-        public void It_restores_only_ridless_tfm()
-        {
-            // When RuntimeIdentifier is not specified, the assets file
-            // should only contain one target with no RIDs
-            var targetDefs = GetValuesFromTestLibrary(_testAssetsManager, "TargetDefinitions");
-            targetDefs.Count.Should().Be(1);
-            targetDefs.Should().Contain(".NETStandard,Version=v1.5");
-        }
     }
 }

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildANetCoreApp.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildANetCoreApp.cs
@@ -76,5 +76,28 @@ namespace Microsoft.NET.Build.Tests
             var netCoreAppLibrary = target.Libraries.Single(l => l.Name == "Microsoft.NETCore.App");
             netCoreAppLibrary.Version.ToString().Should().Be(expectedPackageVersion);
         }
+
+        [Fact]
+        public void It_restores_only_ridless_tfm()
+        {
+            var testAsset = _testAssetsManager
+                .CopyTestAsset("HelloWorld")
+                .WithSource()
+                .Restore();
+
+            var getValuesCommand = new GetValuesCommand(Stage0MSBuild, testAsset.TestRoot,
+                "netcoreapp1.0", "TargetDefinitions", GetValuesCommand.ValueType.Item);
+
+            getValuesCommand
+                .Execute()
+                .Should()
+                .Pass();
+
+            // When RuntimeIdentifier is not specified, the assets file
+            // should only contain one target with no RIDs
+            var targetDefs = getValuesCommand.GetValues();
+            targetDefs.Count.Should().Be(1);
+            targetDefs.Should().Contain(".NETCoreApp,Version=v1.0");
+        }
     }
 }

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildANetCoreApp.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildANetCoreApp.cs
@@ -77,7 +77,7 @@ namespace Microsoft.NET.Build.Tests
             netCoreAppLibrary.Version.ToString().Should().Be(expectedPackageVersion);
         }
 
-        [Fact]
+        //[Fact(Skip = "https://github.com/dotnet/sdk/issues/874")]
         public void It_restores_only_ridless_tfm()
         {
             var testAsset = _testAssetsManager

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildANetCoreApp.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildANetCoreApp.cs
@@ -77,9 +77,17 @@ namespace Microsoft.NET.Build.Tests
             netCoreAppLibrary.Version.ToString().Should().Be(expectedPackageVersion);
         }
 
-        //[Fact(Skip = "https://github.com/dotnet/sdk/issues/874")]
+        [Fact]
         public void It_restores_only_ridless_tfm()
         {
+            //  Disable this test when using full Framework MSBuild, until MSBuild is updated 
+            //  to provide conditions in NuGet ImportBefore/ImportAfter props/targets
+            //  https://github.com/dotnet/sdk/issues/874
+            if (UsingFullFrameworkMSBuild)
+            {
+                return;
+            }
+
             var testAsset = _testAssetsManager
                 .CopyTestAsset("HelloWorld")
                 .WithSource()


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn-project-system/issues/1474 and https://github.com/dotnet/roslyn-project-system/issues/1508

**Customer scenario**

Customers restoring projects with reference to certain packages (e.g. System.ValueTuple) will see hundreds of downgrade warnings, when they restore from Visual Studio. However they don't see those same warnings when restoring from the CLI.

The root cause is that the VS targets automatically import Microsoft.NuGet.targets, which contains legacy properties and targets associated with project.json. This targets file is specified as an automatic "ImportAfter" Microsoft.Common.targets for all project types. Other errors are sometimes reported because of the inclusion of this file (https://github.com/dotnet/roslyn-project-system/issues/1508). The downgrade warnings occur because more RIDs are restored than are specified because of this property in Microsoft.NuGet.targets: 
```xml
<RuntimeIdentifiers>win;win-x86;win-x64</RuntimeIdentifiers>
```

The CLI dropped this file from their version of ImportAfter, however VS cannot drop it since it is used by other project types. This change adds some conditions allowing us to skip importing this file in .NET Core projects.

There are two parts to this fix:
- a VS side change which adds conditions to the imports: [PR 57278](https://devdiv.visualstudio.com/DefaultCollection/DevDiv/Default/_git/VS/pullrequest/57278)
- this SDK PR sets the properties for .NET Core projects

**Bugs this fixes:**

https://github.com/dotnet/roslyn-project-system/issues/1474 and https://github.com/dotnet/roslyn-project-system/issues/1508

**Risk**

Low. The risk may come from us accidentally depending on properties defined in Microsoft.NuGet.targets but all relevant properties have already been copied over to our targets. Furthermore the CLI has been operating without a dependency on this for some time so this ensures parity between the VS and CLI experience.

**Performance impact**

None

**Is this a regression from a previous update?**

No

**How was the bug found?**

Dogfooding

/cc @srivatsn @dsplaisted @nguerrera 