### PR TITLE
Allow .NET Core 2.0 projects to reference assemblies on disk

### DIFF
--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -11,6 +11,7 @@
 
   <!-- Dependencies from test projects -->
   <PropertyGroup>
+    <MicrosoftNETCoreApp20Version>2.0.0-beta-001509-00</MicrosoftNETCoreApp20Version>
     <xunitVersion>2.1.0</xunitVersion>
     <FluentAssertionsVersion>4.0.0</FluentAssertionsVersion>
     <FluentAssertionsJsonVersion>4.12.0</FluentAssertionsJsonVersion>

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/Microsoft.NET.Build.Tasks.UnitTests.csproj
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/Microsoft.NET.Build.Tasks.UnitTests.csproj
@@ -81,6 +81,9 @@
     <None Include="LockFiles\dotnet.new.project.lock.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="simple.dependencies.directReference.deps.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="simple.dependencies.compilerOptions.deps.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/simple.dependencies.directReference.deps.json
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/simple.dependencies.directReference.deps.json
@@ -1,0 +1,2516 @@
+{
+  "runtimeTarget": {
+    "name": ".NETCoreApp,Version=v1.0",
+    "signature": "a813617eb7d3bb5d69fa51d48f64bc6455d8ca5f"
+  },
+  "compilationOptions": {
+    "defines": [
+      "DEBUG",
+      "TRACE"
+    ],
+    "languageVersion": "6",
+    "platform": "x64",
+    "allowUnsafe": true,
+    "warningsAsErrors": false,
+    "keyFile": "../keyfile.snk",
+    "emitEntryPoint": true,
+    "xmlDoc": true,
+    "debugType": "portable"
+  },
+  "targets": {
+    ".NETCoreApp,Version=v1.0": {
+      "simple.dependencies/1.0.0": {
+        "dependencies": {
+          "Newtonsoft.Json": "9.0.1",
+          "Microsoft.NETCore.App": "1.0.0",
+          "System.Collections.NonGeneric": "4.0.1",
+          "RandomLooseLibrary": "1.2.0.4"
+        },
+        "runtime": {
+          "simple.dependencies.dll": {}
+        },
+        "compile": {
+          "simple.dependencies.dll": {}
+        }
+      },
+      "newtonsoft.json/9.0.1": {
+        "dependencies": {
+          "Microsoft.CSharp": "4.0.1",
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Dynamic.Runtime": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.IO": "4.1.0",
+          "System.Linq": "4.1.0",
+          "System.Linq.Expressions": "4.1.0",
+          "System.ObjectModel": "4.0.12",
+          "System.Reflection": "4.1.0",
+          "System.Reflection.Extensions": "4.0.1",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.Serialization.Primitives": "4.1.1",
+          "System.Text.Encoding": "4.0.11",
+          "System.Text.Encoding.Extensions": "4.0.11",
+          "System.Text.RegularExpressions": "4.1.0",
+          "System.Threading": "4.0.11",
+          "System.Threading.Tasks": "4.0.11",
+          "System.Xml.ReaderWriter": "4.0.11",
+          "System.Xml.XDocument": "4.0.11"
+        },
+        "runtime": {
+          "lib/netstandard1.0/Newtonsoft.Json.dll": {}
+        },
+        "compile": {
+          "lib/netstandard1.0/Newtonsoft.Json.dll": {}
+        }
+      },
+      "system.collections.nongeneric/4.0.1": {
+        "dependencies": {
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Threading": "4.0.11"
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Collections.NonGeneric.dll": {}
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Collections.NonGeneric.dll": {}
+        }
+      },
+      "system.runtime.serialization.primitives/4.1.1": {
+        "dependencies": {
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0"
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Runtime.Serialization.Primitives.dll": {}
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Runtime.Serialization.Primitives.dll": {}
+        }
+      },
+      "randomlooselibrary/1.2.0.4": {
+        "runtime": {
+          "RandomLooseLibrary.dll": {}
+        },
+        "resources": {
+          "fr/RandomLooseLibrary.resources.dll": {
+            "locale": "fr"
+          }
+        },
+        "compile": {
+          "RandomLooseLibrary.dll": {}
+        }
+      },
+      "libuv/1.9.0": {
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1"
+        },
+        "compileOnly": true
+      },
+      "microsoft.codeanalysis.analyzers/1.1.0": {
+        "compileOnly": true
+      },
+      "microsoft.codeanalysis.common/1.3.0": {
+        "dependencies": {
+          "Microsoft.CodeAnalysis.Analyzers": "1.1.0",
+          "System.AppContext": "4.1.0",
+          "System.Collections": "4.0.11",
+          "System.Collections.Concurrent": "4.0.12",
+          "System.Collections.Immutable": "1.2.0",
+          "System.Console": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Diagnostics.FileVersionInfo": "4.0.0",
+          "System.Diagnostics.StackTrace": "4.0.1",
+          "System.Diagnostics.Tools": "4.0.1",
+          "System.Dynamic.Runtime": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.IO.FileSystem": "4.0.1",
+          "System.IO.FileSystem.Primitives": "4.0.1",
+          "System.Linq": "4.1.0",
+          "System.Linq.Expressions": "4.1.0",
+          "System.Reflection": "4.1.0",
+          "System.Reflection.Metadata": "1.3.0",
+          "System.Reflection.Primitives": "4.0.1",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.Handles": "4.0.1",
+          "System.Runtime.InteropServices": "4.1.0",
+          "System.Runtime.Numerics": "4.0.1",
+          "System.Security.Cryptography.Algorithms": "4.2.0",
+          "System.Security.Cryptography.Encoding": "4.0.0",
+          "System.Security.Cryptography.X509Certificates": "4.1.0",
+          "System.Text.Encoding": "4.0.11",
+          "System.Text.Encoding.CodePages": "4.0.1",
+          "System.Text.Encoding.Extensions": "4.0.11",
+          "System.Threading": "4.0.11",
+          "System.Threading.Tasks": "4.0.11",
+          "System.Threading.Tasks.Parallel": "4.0.1",
+          "System.Threading.Thread": "4.0.0",
+          "System.Xml.ReaderWriter": "4.0.11",
+          "System.Xml.XDocument": "4.0.11",
+          "System.Xml.XPath.XDocument": "4.0.1",
+          "System.Xml.XmlDocument": "4.0.1"
+        },
+        "compileOnly": true
+      },
+      "microsoft.codeanalysis.csharp/1.3.0": {
+        "dependencies": {
+          "Microsoft.CodeAnalysis.Common": "1.3.0"
+        },
+        "compileOnly": true
+      },
+      "microsoft.codeanalysis.visualbasic/1.3.0": {
+        "dependencies": {
+          "Microsoft.CodeAnalysis.Common": "1.3.0"
+        },
+        "compileOnly": true
+      },
+      "microsoft.csharp/4.0.1": {
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Dynamic.Runtime": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.Linq": "4.1.0",
+          "System.Linq.Expressions": "4.1.0",
+          "System.ObjectModel": "4.0.12",
+          "System.Reflection": "4.1.0",
+          "System.Reflection.Extensions": "4.0.1",
+          "System.Reflection.Primitives": "4.0.1",
+          "System.Reflection.TypeExtensions": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.InteropServices": "4.1.0",
+          "System.Threading": "4.0.11"
+        },
+        "compile": {
+          "ref/netstandard1.0/Microsoft.CSharp.dll": {}
+        },
+        "compileOnly": true
+      },
+      "microsoft.netcore.app/1.0.0": {
+        "dependencies": {
+          "Libuv": "1.9.0",
+          "Microsoft.CSharp": "4.0.1",
+          "Microsoft.CodeAnalysis.CSharp": "1.3.0",
+          "Microsoft.CodeAnalysis.VisualBasic": "1.3.0",
+          "Microsoft.NETCore.DotNetHostPolicy": "1.0.1",
+          "Microsoft.NETCore.Runtime.CoreCLR": "1.0.2",
+          "Microsoft.VisualBasic": "10.0.1",
+          "NETStandard.Library": "1.6.0",
+          "System.Buffers": "4.0.0",
+          "System.Collections.Immutable": "1.2.0",
+          "System.ComponentModel": "4.0.1",
+          "System.ComponentModel.Annotations": "4.1.0",
+          "System.Diagnostics.DiagnosticSource": "4.0.0",
+          "System.Diagnostics.Process": "4.1.0",
+          "System.Dynamic.Runtime": "4.0.11",
+          "System.Globalization.Extensions": "4.0.1",
+          "System.IO.FileSystem.Watcher": "4.0.0",
+          "System.IO.MemoryMappedFiles": "4.0.0",
+          "System.IO.UnmanagedMemoryStream": "4.0.1",
+          "System.Linq.Expressions": "4.1.0",
+          "System.Linq.Parallel": "4.0.1",
+          "System.Linq.Queryable": "4.0.1",
+          "System.Net.NameResolution": "4.0.0",
+          "System.Net.Requests": "4.0.11",
+          "System.Net.Security": "4.0.0",
+          "System.Net.WebHeaderCollection": "4.0.1",
+          "System.Numerics.Vectors": "4.1.1",
+          "System.Reflection.DispatchProxy": "4.0.1",
+          "System.Reflection.Metadata": "1.3.0",
+          "System.Reflection.TypeExtensions": "4.1.0",
+          "System.Resources.Reader": "4.0.0",
+          "System.Runtime.Loader": "4.0.0",
+          "System.Security.Cryptography.Algorithms": "4.2.0",
+          "System.Security.Cryptography.Encoding": "4.0.0",
+          "System.Security.Cryptography.Primitives": "4.0.0",
+          "System.Security.Cryptography.X509Certificates": "4.1.0",
+          "System.Threading.Tasks.Dataflow": "4.6.0",
+          "System.Threading.Tasks.Extensions": "4.0.0",
+          "System.Threading.Tasks.Parallel": "4.0.1",
+          "System.Threading.Thread": "4.0.0",
+          "System.Threading.ThreadPool": "4.0.10"
+        },
+        "compileOnly": true
+      },
+      "microsoft.netcore.dotnethost/1.0.1": {
+        "compileOnly": true
+      },
+      "microsoft.netcore.dotnethostpolicy/1.0.1": {
+        "dependencies": {
+          "Microsoft.NETCore.DotNetHostResolver": "1.0.1"
+        },
+        "compileOnly": true
+      },
+      "microsoft.netcore.dotnethostresolver/1.0.1": {
+        "dependencies": {
+          "Microsoft.NETCore.DotNetHost": "1.0.1"
+        },
+        "compileOnly": true
+      },
+      "microsoft.netcore.jit/1.0.2": {
+        "compileOnly": true
+      },
+      "microsoft.netcore.platforms/1.0.1": {
+        "compileOnly": true
+      },
+      "microsoft.netcore.runtime.coreclr/1.0.2": {
+        "dependencies": {
+          "Microsoft.NETCore.Jit": "1.0.2",
+          "Microsoft.NETCore.Windows.ApiSets": "1.0.1"
+        },
+        "compileOnly": true
+      },
+      "microsoft.netcore.targets/1.0.1": {
+        "compileOnly": true
+      },
+      "microsoft.netcore.windows.apisets/1.0.1": {
+        "compileOnly": true
+      },
+      "microsoft.visualbasic/10.0.1": {
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Dynamic.Runtime": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.Linq": "4.1.0",
+          "System.Linq.Expressions": "4.1.0",
+          "System.ObjectModel": "4.0.12",
+          "System.Reflection": "4.1.0",
+          "System.Reflection.Extensions": "4.0.1",
+          "System.Reflection.Primitives": "4.0.1",
+          "System.Reflection.TypeExtensions": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.InteropServices": "4.1.0",
+          "System.Threading": "4.0.11"
+        },
+        "compile": {
+          "ref/netstandard1.1/Microsoft.VisualBasic.dll": {}
+        },
+        "compileOnly": true
+      },
+      "microsoft.win32.primitives/4.0.1": {
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1",
+          "System.Runtime": "4.1.0"
+        },
+        "compile": {
+          "ref/netstandard1.3/Microsoft.Win32.Primitives.dll": {}
+        },
+        "compileOnly": true
+      },
+      "microsoft.win32.registry/4.0.0": {
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "System.Collections": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.Handles": "4.0.1",
+          "System.Runtime.InteropServices": "4.1.0"
+        },
+        "compileOnly": true
+      },
+      "netstandard.library/1.6.0": {
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.Win32.Primitives": "4.0.1",
+          "System.AppContext": "4.1.0",
+          "System.Collections": "4.0.11",
+          "System.Collections.Concurrent": "4.0.12",
+          "System.Console": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Diagnostics.Tools": "4.0.1",
+          "System.Diagnostics.Tracing": "4.1.0",
+          "System.Globalization": "4.0.11",
+          "System.Globalization.Calendars": "4.0.1",
+          "System.IO": "4.1.0",
+          "System.IO.Compression": "4.1.0",
+          "System.IO.Compression.ZipFile": "4.0.1",
+          "System.IO.FileSystem": "4.0.1",
+          "System.IO.FileSystem.Primitives": "4.0.1",
+          "System.Linq": "4.1.0",
+          "System.Linq.Expressions": "4.1.0",
+          "System.Net.Http": "4.1.0",
+          "System.Net.Primitives": "4.0.11",
+          "System.Net.Sockets": "4.1.0",
+          "System.ObjectModel": "4.0.12",
+          "System.Reflection": "4.1.0",
+          "System.Reflection.Extensions": "4.0.1",
+          "System.Reflection.Primitives": "4.0.1",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.Handles": "4.0.1",
+          "System.Runtime.InteropServices": "4.1.0",
+          "System.Runtime.InteropServices.RuntimeInformation": "4.0.0",
+          "System.Runtime.Numerics": "4.0.1",
+          "System.Security.Cryptography.Algorithms": "4.2.0",
+          "System.Security.Cryptography.Encoding": "4.0.0",
+          "System.Security.Cryptography.Primitives": "4.0.0",
+          "System.Security.Cryptography.X509Certificates": "4.1.0",
+          "System.Text.Encoding": "4.0.11",
+          "System.Text.Encoding.Extensions": "4.0.11",
+          "System.Text.RegularExpressions": "4.1.0",
+          "System.Threading": "4.0.11",
+          "System.Threading.Tasks": "4.0.11",
+          "System.Threading.Timer": "4.0.1",
+          "System.Xml.ReaderWriter": "4.0.11",
+          "System.Xml.XDocument": "4.0.11"
+        },
+        "compileOnly": true
+      },
+      "runtime.native.system/4.0.0": {
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1"
+        },
+        "compileOnly": true
+      },
+      "runtime.native.system.io.compression/4.1.0": {
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1"
+        },
+        "compileOnly": true
+      },
+      "runtime.native.system.net.http/4.0.1": {
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1"
+        },
+        "compileOnly": true
+      },
+      "runtime.native.system.net.security/4.0.1": {
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1"
+        },
+        "compileOnly": true
+      },
+      "runtime.native.system.security.cryptography/4.0.0": {
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1"
+        },
+        "compileOnly": true
+      },
+      "system.appcontext/4.1.0": {
+        "dependencies": {
+          "System.Runtime": "4.1.0"
+        },
+        "compile": {
+          "ref/netstandard1.6/System.AppContext.dll": {}
+        },
+        "compileOnly": true
+      },
+      "system.buffers/4.0.0": {
+        "dependencies": {
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Diagnostics.Tracing": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Threading": "4.0.11"
+        },
+        "compile": {
+          "lib/netstandard1.1/System.Buffers.dll": {}
+        },
+        "compileOnly": true
+      },
+      "system.collections/4.0.11": {
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1",
+          "System.Runtime": "4.1.0"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Collections.dll": {}
+        },
+        "compileOnly": true
+      },
+      "system.collections.concurrent/4.0.12": {
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Diagnostics.Tracing": "4.1.0",
+          "System.Globalization": "4.0.11",
+          "System.Reflection": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Threading": "4.0.11",
+          "System.Threading.Tasks": "4.0.11"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Collections.Concurrent.dll": {}
+        },
+        "compileOnly": true
+      },
+      "system.collections.immutable/1.2.0": {
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.Linq": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Threading": "4.0.11"
+        },
+        "compile": {
+          "lib/netstandard1.0/System.Collections.Immutable.dll": {}
+        },
+        "compileOnly": true
+      },
+      "system.componentmodel/4.0.1": {
+        "dependencies": {
+          "System.Runtime": "4.1.0"
+        },
+        "compile": {
+          "ref/netstandard1.0/System.ComponentModel.dll": {}
+        },
+        "compileOnly": true
+      },
+      "system.componentmodel.annotations/4.1.0": {
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.ComponentModel": "4.0.1",
+          "System.Globalization": "4.0.11",
+          "System.Linq": "4.1.0",
+          "System.Reflection": "4.1.0",
+          "System.Reflection.Extensions": "4.0.1",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Text.RegularExpressions": "4.1.0",
+          "System.Threading": "4.0.11"
+        },
+        "compile": {
+          "ref/netstandard1.4/System.ComponentModel.Annotations.dll": {}
+        },
+        "compileOnly": true
+      },
+      "system.console/4.0.0": {
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1",
+          "System.IO": "4.1.0",
+          "System.Runtime": "4.1.0",
+          "System.Text.Encoding": "4.0.11"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Console.dll": {}
+        },
+        "compileOnly": true
+      },
+      "system.diagnostics.debug/4.0.11": {
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1",
+          "System.Runtime": "4.1.0"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Diagnostics.Debug.dll": {}
+        },
+        "compileOnly": true
+      },
+      "system.diagnostics.diagnosticsource/4.0.0": {
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Tracing": "4.1.0",
+          "System.Reflection": "4.1.0",
+          "System.Runtime": "4.1.0",
+          "System.Threading": "4.0.11"
+        },
+        "compile": {
+          "lib/netstandard1.3/System.Diagnostics.DiagnosticSource.dll": {}
+        },
+        "compileOnly": true
+      },
+      "system.diagnostics.fileversioninfo/4.0.0": {
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "System.Globalization": "4.0.11",
+          "System.IO": "4.1.0",
+          "System.IO.FileSystem": "4.0.1",
+          "System.IO.FileSystem.Primitives": "4.0.1",
+          "System.Reflection.Metadata": "1.3.0",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.InteropServices": "4.1.0"
+        },
+        "compileOnly": true
+      },
+      "system.diagnostics.process/4.1.0": {
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.Win32.Primitives": "4.0.1",
+          "Microsoft.Win32.Registry": "4.0.0",
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.IO": "4.1.0",
+          "System.IO.FileSystem": "4.0.1",
+          "System.IO.FileSystem.Primitives": "4.0.1",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.Handles": "4.0.1",
+          "System.Runtime.InteropServices": "4.1.0",
+          "System.Text.Encoding": "4.0.11",
+          "System.Text.Encoding.Extensions": "4.0.11",
+          "System.Threading": "4.0.11",
+          "System.Threading.Tasks": "4.0.11",
+          "System.Threading.Thread": "4.0.0",
+          "System.Threading.ThreadPool": "4.0.10",
+          "runtime.native.System": "4.0.0"
+        },
+        "compile": {
+          "ref/netstandard1.4/System.Diagnostics.Process.dll": {}
+        },
+        "compileOnly": true
+      },
+      "system.diagnostics.stacktrace/4.0.1": {
+        "dependencies": {
+          "System.Collections.Immutable": "1.2.0",
+          "System.IO.FileSystem": "4.0.1",
+          "System.Reflection": "4.1.0",
+          "System.Reflection.Metadata": "1.3.0",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0"
+        },
+        "compileOnly": true
+      },
+      "system.diagnostics.tools/4.0.1": {
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1",
+          "System.Runtime": "4.1.0"
+        },
+        "compile": {
+          "ref/netstandard1.0/System.Diagnostics.Tools.dll": {}
+        },
+        "compileOnly": true
+      },
+      "system.diagnostics.tracing/4.1.0": {
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1",
+          "System.Runtime": "4.1.0"
+        },
+        "compile": {
+          "ref/netstandard1.5/System.Diagnostics.Tracing.dll": {}
+        },
+        "compileOnly": true
+      },
+      "system.dynamic.runtime/4.0.11": {
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.Linq": "4.1.0",
+          "System.Linq.Expressions": "4.1.0",
+          "System.ObjectModel": "4.0.12",
+          "System.Reflection": "4.1.0",
+          "System.Reflection.Emit": "4.0.1",
+          "System.Reflection.Emit.ILGeneration": "4.0.1",
+          "System.Reflection.Primitives": "4.0.1",
+          "System.Reflection.TypeExtensions": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Threading": "4.0.11"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Dynamic.Runtime.dll": {}
+        },
+        "compileOnly": true
+      },
+      "system.globalization/4.0.11": {
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1",
+          "System.Runtime": "4.1.0"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Globalization.dll": {}
+        },
+        "compileOnly": true
+      },
+      "system.globalization.calendars/4.0.1": {
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1",
+          "System.Globalization": "4.0.11",
+          "System.Runtime": "4.1.0"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Globalization.Calendars.dll": {}
+        },
+        "compileOnly": true
+      },
+      "system.globalization.extensions/4.0.1": {
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "System.Globalization": "4.0.11",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.InteropServices": "4.1.0"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Globalization.Extensions.dll": {}
+        },
+        "compileOnly": true
+      },
+      "system.io/4.1.0": {
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Text.Encoding": "4.0.11",
+          "System.Threading.Tasks": "4.0.11"
+        },
+        "compile": {
+          "ref/netstandard1.5/System.IO.dll": {}
+        },
+        "compileOnly": true
+      },
+      "system.io.compression/4.1.0": {
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.IO": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.Handles": "4.0.1",
+          "System.Runtime.InteropServices": "4.1.0",
+          "System.Text.Encoding": "4.0.11",
+          "System.Threading": "4.0.11",
+          "System.Threading.Tasks": "4.0.11",
+          "runtime.native.System": "4.0.0",
+          "runtime.native.System.IO.Compression": "4.1.0"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.IO.Compression.dll": {}
+        },
+        "compileOnly": true
+      },
+      "system.io.compression.zipfile/4.0.1": {
+        "dependencies": {
+          "System.Buffers": "4.0.0",
+          "System.IO": "4.1.0",
+          "System.IO.Compression": "4.1.0",
+          "System.IO.FileSystem": "4.0.1",
+          "System.IO.FileSystem.Primitives": "4.0.1",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Text.Encoding": "4.0.11"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.IO.Compression.ZipFile.dll": {}
+        },
+        "compileOnly": true
+      },
+      "system.io.filesystem/4.0.1": {
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1",
+          "System.IO": "4.1.0",
+          "System.IO.FileSystem.Primitives": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Handles": "4.0.1",
+          "System.Text.Encoding": "4.0.11",
+          "System.Threading.Tasks": "4.0.11"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.IO.FileSystem.dll": {}
+        },
+        "compileOnly": true
+      },
+      "system.io.filesystem.primitives/4.0.1": {
+        "dependencies": {
+          "System.Runtime": "4.1.0"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.IO.FileSystem.Primitives.dll": {}
+        },
+        "compileOnly": true
+      },
+      "system.io.filesystem.watcher/4.0.0": {
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.Win32.Primitives": "4.0.1",
+          "System.Collections": "4.0.11",
+          "System.IO.FileSystem": "4.0.1",
+          "System.IO.FileSystem.Primitives": "4.0.1",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.Handles": "4.0.1",
+          "System.Runtime.InteropServices": "4.1.0",
+          "System.Text.Encoding": "4.0.11",
+          "System.Threading": "4.0.11",
+          "System.Threading.Overlapped": "4.0.1",
+          "System.Threading.Tasks": "4.0.11",
+          "System.Threading.Thread": "4.0.0",
+          "runtime.native.System": "4.0.0"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.IO.FileSystem.Watcher.dll": {}
+        },
+        "compileOnly": true
+      },
+      "system.io.memorymappedfiles/4.0.0": {
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "System.IO": "4.1.0",
+          "System.IO.FileSystem": "4.0.1",
+          "System.IO.FileSystem.Primitives": "4.0.1",
+          "System.IO.UnmanagedMemoryStream": "4.0.1",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.Handles": "4.0.1",
+          "System.Runtime.InteropServices": "4.1.0",
+          "System.Threading": "4.0.11",
+          "System.Threading.Tasks": "4.0.11",
+          "runtime.native.System": "4.0.0"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.IO.MemoryMappedFiles.dll": {}
+        },
+        "compileOnly": true
+      },
+      "system.io.unmanagedmemorystream/4.0.1": {
+        "dependencies": {
+          "System.IO": "4.1.0",
+          "System.IO.FileSystem.Primitives": "4.0.1",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.InteropServices": "4.1.0",
+          "System.Threading": "4.0.11",
+          "System.Threading.Tasks": "4.0.11"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.IO.UnmanagedMemoryStream.dll": {}
+        },
+        "compileOnly": true
+      },
+      "system.linq/4.1.0": {
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0"
+        },
+        "compile": {
+          "ref/netstandard1.6/System.Linq.dll": {}
+        },
+        "compileOnly": true
+      },
+      "system.linq.expressions/4.1.0": {
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.IO": "4.1.0",
+          "System.Linq": "4.1.0",
+          "System.ObjectModel": "4.0.12",
+          "System.Reflection": "4.1.0",
+          "System.Reflection.Emit": "4.0.1",
+          "System.Reflection.Emit.ILGeneration": "4.0.1",
+          "System.Reflection.Emit.Lightweight": "4.0.1",
+          "System.Reflection.Extensions": "4.0.1",
+          "System.Reflection.Primitives": "4.0.1",
+          "System.Reflection.TypeExtensions": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Threading": "4.0.11"
+        },
+        "compile": {
+          "ref/netstandard1.6/System.Linq.Expressions.dll": {}
+        },
+        "compileOnly": true
+      },
+      "system.linq.parallel/4.0.1": {
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Collections.Concurrent": "4.0.12",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Diagnostics.Tracing": "4.1.0",
+          "System.Linq": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Threading": "4.0.11",
+          "System.Threading.Tasks": "4.0.11"
+        },
+        "compile": {
+          "ref/netstandard1.1/System.Linq.Parallel.dll": {}
+        },
+        "compileOnly": true
+      },
+      "system.linq.queryable/4.0.1": {
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Linq": "4.1.0",
+          "System.Linq.Expressions": "4.1.0",
+          "System.Reflection": "4.1.0",
+          "System.Reflection.Extensions": "4.0.1",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0"
+        },
+        "compile": {
+          "ref/netstandard1.0/System.Linq.Queryable.dll": {}
+        },
+        "compileOnly": true
+      },
+      "system.net.http/4.1.0": {
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Diagnostics.DiagnosticSource": "4.0.0",
+          "System.Diagnostics.Tracing": "4.1.0",
+          "System.Globalization": "4.0.11",
+          "System.Globalization.Extensions": "4.0.1",
+          "System.IO": "4.1.0",
+          "System.IO.FileSystem": "4.0.1",
+          "System.Net.Primitives": "4.0.11",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.Handles": "4.0.1",
+          "System.Runtime.InteropServices": "4.1.0",
+          "System.Security.Cryptography.Algorithms": "4.2.0",
+          "System.Security.Cryptography.Encoding": "4.0.0",
+          "System.Security.Cryptography.OpenSsl": "4.0.0",
+          "System.Security.Cryptography.Primitives": "4.0.0",
+          "System.Security.Cryptography.X509Certificates": "4.1.0",
+          "System.Text.Encoding": "4.0.11",
+          "System.Threading": "4.0.11",
+          "System.Threading.Tasks": "4.0.11",
+          "runtime.native.System": "4.0.0",
+          "runtime.native.System.Net.Http": "4.0.1",
+          "runtime.native.System.Security.Cryptography": "4.0.0"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Net.Http.dll": {}
+        },
+        "compileOnly": true
+      },
+      "system.net.nameresolution/4.0.0": {
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Tracing": "4.1.0",
+          "System.Globalization": "4.0.11",
+          "System.Net.Primitives": "4.0.11",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.Handles": "4.0.1",
+          "System.Runtime.InteropServices": "4.1.0",
+          "System.Security.Principal.Windows": "4.0.0",
+          "System.Threading": "4.0.11",
+          "System.Threading.Tasks": "4.0.11",
+          "runtime.native.System": "4.0.0"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Net.NameResolution.dll": {}
+        },
+        "compileOnly": true
+      },
+      "system.net.primitives/4.0.11": {
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Handles": "4.0.1"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Net.Primitives.dll": {}
+        },
+        "compileOnly": true
+      },
+      "system.net.requests/4.0.11": {
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Diagnostics.Tracing": "4.1.0",
+          "System.Globalization": "4.0.11",
+          "System.IO": "4.1.0",
+          "System.Net.Http": "4.1.0",
+          "System.Net.Primitives": "4.0.11",
+          "System.Net.WebHeaderCollection": "4.0.1",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Threading": "4.0.11",
+          "System.Threading.Tasks": "4.0.11"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Net.Requests.dll": {}
+        },
+        "compileOnly": true
+      },
+      "system.net.security/4.0.0": {
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.Win32.Primitives": "4.0.1",
+          "System.Collections": "4.0.11",
+          "System.Collections.Concurrent": "4.0.12",
+          "System.Diagnostics.Tracing": "4.1.0",
+          "System.Globalization": "4.0.11",
+          "System.Globalization.Extensions": "4.0.1",
+          "System.IO": "4.1.0",
+          "System.Net.Primitives": "4.0.11",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.Handles": "4.0.1",
+          "System.Runtime.InteropServices": "4.1.0",
+          "System.Security.Claims": "4.0.1",
+          "System.Security.Cryptography.Algorithms": "4.2.0",
+          "System.Security.Cryptography.Encoding": "4.0.0",
+          "System.Security.Cryptography.OpenSsl": "4.0.0",
+          "System.Security.Cryptography.Primitives": "4.0.0",
+          "System.Security.Cryptography.X509Certificates": "4.1.0",
+          "System.Security.Principal": "4.0.1",
+          "System.Text.Encoding": "4.0.11",
+          "System.Threading": "4.0.11",
+          "System.Threading.Tasks": "4.0.11",
+          "System.Threading.ThreadPool": "4.0.10",
+          "runtime.native.System": "4.0.0",
+          "runtime.native.System.Net.Security": "4.0.1",
+          "runtime.native.System.Security.Cryptography": "4.0.0"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Net.Security.dll": {}
+        },
+        "compileOnly": true
+      },
+      "system.net.sockets/4.1.0": {
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1",
+          "System.IO": "4.1.0",
+          "System.Net.Primitives": "4.0.11",
+          "System.Runtime": "4.1.0",
+          "System.Threading.Tasks": "4.0.11"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Net.Sockets.dll": {}
+        },
+        "compileOnly": true
+      },
+      "system.net.webheadercollection/4.0.1": {
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Net.WebHeaderCollection.dll": {}
+        },
+        "compileOnly": true
+      },
+      "system.numerics.vectors/4.1.1": {
+        "dependencies": {
+          "System.Globalization": "4.0.11",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0"
+        },
+        "compile": {
+          "ref/netstandard1.0/System.Numerics.Vectors.dll": {}
+        },
+        "compileOnly": true
+      },
+      "system.objectmodel/4.0.12": {
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Threading": "4.0.11"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.ObjectModel.dll": {}
+        },
+        "compileOnly": true
+      },
+      "system.reflection/4.1.0": {
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1",
+          "System.IO": "4.1.0",
+          "System.Reflection.Primitives": "4.0.1",
+          "System.Runtime": "4.1.0"
+        },
+        "compile": {
+          "ref/netstandard1.5/System.Reflection.dll": {}
+        },
+        "compileOnly": true
+      },
+      "system.reflection.dispatchproxy/4.0.1": {
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Linq": "4.1.0",
+          "System.Reflection": "4.1.0",
+          "System.Reflection.Emit": "4.0.1",
+          "System.Reflection.Emit.ILGeneration": "4.0.1",
+          "System.Reflection.Extensions": "4.0.1",
+          "System.Reflection.Primitives": "4.0.1",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Threading": "4.0.11"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Reflection.DispatchProxy.dll": {}
+        },
+        "compileOnly": true
+      },
+      "system.reflection.emit/4.0.1": {
+        "dependencies": {
+          "System.IO": "4.1.0",
+          "System.Reflection": "4.1.0",
+          "System.Reflection.Emit.ILGeneration": "4.0.1",
+          "System.Reflection.Primitives": "4.0.1",
+          "System.Runtime": "4.1.0"
+        },
+        "compileOnly": true
+      },
+      "system.reflection.emit.ilgeneration/4.0.1": {
+        "dependencies": {
+          "System.Reflection": "4.1.0",
+          "System.Reflection.Primitives": "4.0.1",
+          "System.Runtime": "4.1.0"
+        },
+        "compileOnly": true
+      },
+      "system.reflection.emit.lightweight/4.0.1": {
+        "dependencies": {
+          "System.Reflection": "4.1.0",
+          "System.Reflection.Emit.ILGeneration": "4.0.1",
+          "System.Reflection.Primitives": "4.0.1",
+          "System.Runtime": "4.1.0"
+        },
+        "compileOnly": true
+      },
+      "system.reflection.extensions/4.0.1": {
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1",
+          "System.Reflection": "4.1.0",
+          "System.Runtime": "4.1.0"
+        },
+        "compile": {
+          "ref/netstandard1.0/System.Reflection.Extensions.dll": {}
+        },
+        "compileOnly": true
+      },
+      "system.reflection.metadata/1.3.0": {
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Collections.Immutable": "1.2.0",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.IO": "4.1.0",
+          "System.Linq": "4.1.0",
+          "System.Reflection": "4.1.0",
+          "System.Reflection.Extensions": "4.0.1",
+          "System.Reflection.Primitives": "4.0.1",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.InteropServices": "4.1.0",
+          "System.Text.Encoding": "4.0.11",
+          "System.Text.Encoding.Extensions": "4.0.11",
+          "System.Threading": "4.0.11"
+        },
+        "compile": {
+          "lib/netstandard1.1/System.Reflection.Metadata.dll": {}
+        },
+        "compileOnly": true
+      },
+      "system.reflection.primitives/4.0.1": {
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1",
+          "System.Runtime": "4.1.0"
+        },
+        "compile": {
+          "ref/netstandard1.0/System.Reflection.Primitives.dll": {}
+        },
+        "compileOnly": true
+      },
+      "system.reflection.typeextensions/4.1.0": {
+        "dependencies": {
+          "System.Reflection": "4.1.0",
+          "System.Runtime": "4.1.0"
+        },
+        "compile": {
+          "ref/netstandard1.5/System.Reflection.TypeExtensions.dll": {}
+        },
+        "compileOnly": true
+      },
+      "system.resources.reader/4.0.0": {
+        "dependencies": {
+          "System.IO": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Text.Encoding": "4.0.11",
+          "System.Threading": "4.0.11"
+        },
+        "compile": {
+          "lib/netstandard1.0/System.Resources.Reader.dll": {}
+        },
+        "compileOnly": true
+      },
+      "system.resources.resourcemanager/4.0.1": {
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1",
+          "System.Globalization": "4.0.11",
+          "System.Reflection": "4.1.0",
+          "System.Runtime": "4.1.0"
+        },
+        "compile": {
+          "ref/netstandard1.0/System.Resources.ResourceManager.dll": {}
+        },
+        "compileOnly": true
+      },
+      "system.runtime/4.1.0": {
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1"
+        },
+        "compile": {
+          "ref/netstandard1.5/System.Runtime.dll": {}
+        },
+        "compileOnly": true
+      },
+      "system.runtime.extensions/4.1.0": {
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1",
+          "System.Runtime": "4.1.0"
+        },
+        "compile": {
+          "ref/netstandard1.5/System.Runtime.Extensions.dll": {}
+        },
+        "compileOnly": true
+      },
+      "system.runtime.handles/4.0.1": {
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1",
+          "System.Runtime": "4.1.0"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Runtime.Handles.dll": {}
+        },
+        "compileOnly": true
+      },
+      "system.runtime.interopservices/4.1.0": {
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1",
+          "System.Reflection": "4.1.0",
+          "System.Reflection.Primitives": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Handles": "4.0.1"
+        },
+        "compile": {
+          "ref/netstandard1.5/System.Runtime.InteropServices.dll": {}
+        },
+        "compileOnly": true
+      },
+      "system.runtime.interopservices.runtimeinformation/4.0.0": {
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "System.Reflection": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.InteropServices": "4.1.0",
+          "System.Threading": "4.0.11",
+          "runtime.native.System": "4.0.0"
+        },
+        "compile": {
+          "ref/netstandard1.1/System.Runtime.InteropServices.RuntimeInformation.dll": {}
+        },
+        "compileOnly": true
+      },
+      "system.runtime.loader/4.0.0": {
+        "dependencies": {
+          "System.IO": "4.1.0",
+          "System.Reflection": "4.1.0",
+          "System.Runtime": "4.1.0"
+        },
+        "compileOnly": true
+      },
+      "system.runtime.numerics/4.0.1": {
+        "dependencies": {
+          "System.Globalization": "4.0.11",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0"
+        },
+        "compile": {
+          "ref/netstandard1.1/System.Runtime.Numerics.dll": {}
+        },
+        "compileOnly": true
+      },
+      "system.security.claims/4.0.1": {
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.IO": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Security.Principal": "4.0.1"
+        },
+        "compileOnly": true
+      },
+      "system.security.cryptography.algorithms/4.2.0": {
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "System.Collections": "4.0.11",
+          "System.IO": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.Handles": "4.0.1",
+          "System.Runtime.InteropServices": "4.1.0",
+          "System.Runtime.Numerics": "4.0.1",
+          "System.Security.Cryptography.Encoding": "4.0.0",
+          "System.Security.Cryptography.Primitives": "4.0.0",
+          "System.Text.Encoding": "4.0.11",
+          "runtime.native.System.Security.Cryptography": "4.0.0"
+        },
+        "compile": {
+          "ref/netstandard1.6/System.Security.Cryptography.Algorithms.dll": {}
+        },
+        "compileOnly": true
+      },
+      "system.security.cryptography.cng/4.2.0": {
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "System.IO": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.Handles": "4.0.1",
+          "System.Runtime.InteropServices": "4.1.0",
+          "System.Security.Cryptography.Algorithms": "4.2.0",
+          "System.Security.Cryptography.Encoding": "4.0.0",
+          "System.Security.Cryptography.Primitives": "4.0.0",
+          "System.Text.Encoding": "4.0.11"
+        },
+        "compileOnly": true
+      },
+      "system.security.cryptography.csp/4.0.0": {
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "System.IO": "4.1.0",
+          "System.Reflection": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.Handles": "4.0.1",
+          "System.Runtime.InteropServices": "4.1.0",
+          "System.Security.Cryptography.Algorithms": "4.2.0",
+          "System.Security.Cryptography.Encoding": "4.0.0",
+          "System.Security.Cryptography.Primitives": "4.0.0",
+          "System.Text.Encoding": "4.0.11",
+          "System.Threading": "4.0.11"
+        },
+        "compileOnly": true
+      },
+      "system.security.cryptography.encoding/4.0.0": {
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "System.Collections": "4.0.11",
+          "System.Collections.Concurrent": "4.0.12",
+          "System.Linq": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.Handles": "4.0.1",
+          "System.Runtime.InteropServices": "4.1.0",
+          "System.Security.Cryptography.Primitives": "4.0.0",
+          "System.Text.Encoding": "4.0.11",
+          "runtime.native.System.Security.Cryptography": "4.0.0"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Security.Cryptography.Encoding.dll": {}
+        },
+        "compileOnly": true
+      },
+      "system.security.cryptography.openssl/4.0.0": {
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.IO": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.Handles": "4.0.1",
+          "System.Runtime.InteropServices": "4.1.0",
+          "System.Runtime.Numerics": "4.0.1",
+          "System.Security.Cryptography.Algorithms": "4.2.0",
+          "System.Security.Cryptography.Encoding": "4.0.0",
+          "System.Security.Cryptography.Primitives": "4.0.0",
+          "System.Text.Encoding": "4.0.11",
+          "runtime.native.System.Security.Cryptography": "4.0.0"
+        },
+        "compileOnly": true
+      },
+      "system.security.cryptography.primitives/4.0.0": {
+        "dependencies": {
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.IO": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Threading": "4.0.11",
+          "System.Threading.Tasks": "4.0.11"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Security.Cryptography.Primitives.dll": {}
+        },
+        "compileOnly": true
+      },
+      "system.security.cryptography.x509certificates/4.1.0": {
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.Globalization.Calendars": "4.0.1",
+          "System.IO": "4.1.0",
+          "System.IO.FileSystem": "4.0.1",
+          "System.IO.FileSystem.Primitives": "4.0.1",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.Handles": "4.0.1",
+          "System.Runtime.InteropServices": "4.1.0",
+          "System.Runtime.Numerics": "4.0.1",
+          "System.Security.Cryptography.Algorithms": "4.2.0",
+          "System.Security.Cryptography.Cng": "4.2.0",
+          "System.Security.Cryptography.Csp": "4.0.0",
+          "System.Security.Cryptography.Encoding": "4.0.0",
+          "System.Security.Cryptography.OpenSsl": "4.0.0",
+          "System.Security.Cryptography.Primitives": "4.0.0",
+          "System.Text.Encoding": "4.0.11",
+          "System.Threading": "4.0.11",
+          "runtime.native.System": "4.0.0",
+          "runtime.native.System.Net.Http": "4.0.1",
+          "runtime.native.System.Security.Cryptography": "4.0.0"
+        },
+        "compile": {
+          "ref/netstandard1.4/System.Security.Cryptography.X509Certificates.dll": {}
+        },
+        "compileOnly": true
+      },
+      "system.security.principal/4.0.1": {
+        "dependencies": {
+          "System.Runtime": "4.1.0"
+        },
+        "compile": {
+          "ref/netstandard1.0/System.Security.Principal.dll": {}
+        },
+        "compileOnly": true
+      },
+      "system.security.principal.windows/4.0.0": {
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.Win32.Primitives": "4.0.1",
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Reflection": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.Handles": "4.0.1",
+          "System.Runtime.InteropServices": "4.1.0",
+          "System.Security.Claims": "4.0.1",
+          "System.Security.Principal": "4.0.1",
+          "System.Text.Encoding": "4.0.11",
+          "System.Threading": "4.0.11"
+        },
+        "compileOnly": true
+      },
+      "system.text.encoding/4.0.11": {
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1",
+          "System.Runtime": "4.1.0"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Text.Encoding.dll": {}
+        },
+        "compileOnly": true
+      },
+      "system.text.encoding.codepages/4.0.1": {
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "System.Collections": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.IO": "4.1.0",
+          "System.Reflection": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.Handles": "4.0.1",
+          "System.Runtime.InteropServices": "4.1.0",
+          "System.Text.Encoding": "4.0.11",
+          "System.Threading": "4.0.11"
+        },
+        "compileOnly": true
+      },
+      "system.text.encoding.extensions/4.0.11": {
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Text.Encoding": "4.0.11"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Text.Encoding.Extensions.dll": {}
+        },
+        "compileOnly": true
+      },
+      "system.text.regularexpressions/4.1.0": {
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Threading": "4.0.11"
+        },
+        "compile": {
+          "ref/netstandard1.6/System.Text.RegularExpressions.dll": {}
+        },
+        "compileOnly": true
+      },
+      "system.threading/4.0.11": {
+        "dependencies": {
+          "System.Runtime": "4.1.0",
+          "System.Threading.Tasks": "4.0.11"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Threading.dll": {}
+        },
+        "compileOnly": true
+      },
+      "system.threading.overlapped/4.0.1": {
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Handles": "4.0.1"
+        },
+        "compileOnly": true
+      },
+      "system.threading.tasks/4.0.11": {
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1",
+          "System.Runtime": "4.1.0"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Threading.Tasks.dll": {}
+        },
+        "compileOnly": true
+      },
+      "system.threading.tasks.dataflow/4.6.0": {
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Collections.Concurrent": "4.0.12",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Diagnostics.Tracing": "4.1.0",
+          "System.Dynamic.Runtime": "4.0.11",
+          "System.Linq": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Threading": "4.0.11",
+          "System.Threading.Tasks": "4.0.11"
+        },
+        "compile": {
+          "lib/netstandard1.1/System.Threading.Tasks.Dataflow.dll": {}
+        },
+        "compileOnly": true
+      },
+      "system.threading.tasks.extensions/4.0.0": {
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Runtime": "4.1.0",
+          "System.Threading.Tasks": "4.0.11"
+        },
+        "compile": {
+          "lib/netstandard1.0/System.Threading.Tasks.Extensions.dll": {}
+        },
+        "compileOnly": true
+      },
+      "system.threading.tasks.parallel/4.0.1": {
+        "dependencies": {
+          "System.Collections.Concurrent": "4.0.12",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Diagnostics.Tracing": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Threading": "4.0.11",
+          "System.Threading.Tasks": "4.0.11"
+        },
+        "compile": {
+          "ref/netstandard1.1/System.Threading.Tasks.Parallel.dll": {}
+        },
+        "compileOnly": true
+      },
+      "system.threading.thread/4.0.0": {
+        "dependencies": {
+          "System.Runtime": "4.1.0"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Threading.Thread.dll": {}
+        },
+        "compileOnly": true
+      },
+      "system.threading.threadpool/4.0.10": {
+        "dependencies": {
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Handles": "4.0.1"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Threading.ThreadPool.dll": {}
+        },
+        "compileOnly": true
+      },
+      "system.threading.timer/4.0.1": {
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1",
+          "System.Runtime": "4.1.0"
+        },
+        "compile": {
+          "ref/netstandard1.2/System.Threading.Timer.dll": {}
+        },
+        "compileOnly": true
+      },
+      "system.xml.readerwriter/4.0.11": {
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.IO": "4.1.0",
+          "System.IO.FileSystem": "4.0.1",
+          "System.IO.FileSystem.Primitives": "4.0.1",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.InteropServices": "4.1.0",
+          "System.Text.Encoding": "4.0.11",
+          "System.Text.Encoding.Extensions": "4.0.11",
+          "System.Text.RegularExpressions": "4.1.0",
+          "System.Threading.Tasks": "4.0.11",
+          "System.Threading.Tasks.Extensions": "4.0.0"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Xml.ReaderWriter.dll": {}
+        },
+        "compileOnly": true
+      },
+      "system.xml.xdocument/4.0.11": {
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Diagnostics.Tools": "4.0.1",
+          "System.Globalization": "4.0.11",
+          "System.IO": "4.1.0",
+          "System.Reflection": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Text.Encoding": "4.0.11",
+          "System.Threading": "4.0.11",
+          "System.Xml.ReaderWriter": "4.0.11"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Xml.XDocument.dll": {}
+        },
+        "compileOnly": true
+      },
+      "system.xml.xmldocument/4.0.1": {
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.IO": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Text.Encoding": "4.0.11",
+          "System.Threading": "4.0.11",
+          "System.Xml.ReaderWriter": "4.0.11"
+        },
+        "compileOnly": true
+      },
+      "system.xml.xpath/4.0.1": {
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.IO": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Threading": "4.0.11",
+          "System.Xml.ReaderWriter": "4.0.11"
+        },
+        "compileOnly": true
+      },
+      "system.xml.xpath.xdocument/4.0.1": {
+        "dependencies": {
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Linq": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Threading": "4.0.11",
+          "System.Xml.ReaderWriter": "4.0.11",
+          "System.Xml.XDocument": "4.0.11",
+          "System.Xml.XPath": "4.0.1"
+        },
+        "compileOnly": true
+      }
+    }
+  },
+  "libraries": {
+    "simple.dependencies/1.0.0": {
+      "type": "project",
+      "serviceable": false,
+      "sha512": ""
+    },
+    "newtonsoft.json/9.0.1": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-U82mHQSKaIk+lpSVCbWYKNavmNH1i5xrExDEquU1i6I5pV6UMOqRnJRSlKO3cMPfcpp0RgDY+8jUXHdQ4IfXvw==",
+      "path": "Newtonsoft.Json/9.0.1",
+      "hashPath": "newtonsoft.json.9.0.1.nupkg.sha512"
+    },
+    "system.collections.nongeneric/4.0.1": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-hMxFT2RhhlffyCdKLDXjx8WEC5JfCvNozAZxCablAuFRH74SCV4AgzE8yJCh/73bFnEoZgJ9MJmkjQ0dJmnKqA==",
+      "path": "System.Collections.NonGeneric/4.0.1",
+      "hashPath": "system.collections.nongeneric.4.0.1.nupkg.sha512"
+    },
+    "system.runtime.serialization.primitives/4.1.1": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-HZ6Du5QrTG8MNJbf4e4qMO3JRAkIboGT5Fk804uZtg3Gq516S7hAqTm2UZKUHa7/6HUGdVy3AqMQKbns06G/cg==",
+      "path": "System.Runtime.Serialization.Primitives/4.1.1",
+      "hashPath": "system.runtime.serialization.primitives.4.1.1.nupkg.sha512"
+    },
+    "randomlooselibrary/1.2.0.4": {
+      "type": "reference",
+      "serviceable": false,
+      "sha512": ""
+    },
+    "libuv/1.9.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-R8WOXQyvM/qtpss3OOAAHrvTAXjk3sU2Jycpn9b4o0d/V64odAveBG8iQBKv4Rn6y7IRsQj68TftGMO9mUducg==",
+      "path": "Libuv/1.9.0",
+      "hashPath": "libuv.1.9.0.nupkg.sha512"
+    },
+    "microsoft.codeanalysis.analyzers/1.1.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-DQBn3skrfcDH4k7D0U7Iy0p19Rgh9G5iVsSLwb2wKVXmVNNMerg62paMsbXvbPoAXmo/mswV81kFu3t233iqzg==",
+      "path": "Microsoft.CodeAnalysis.Analyzers/1.1.0",
+      "hashPath": "microsoft.codeanalysis.analyzers.1.1.0.nupkg.sha512"
+    },
+    "microsoft.codeanalysis.common/1.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-c4MpVNVkXkeJbHAvrAtpZti8R7Fit7PL+Wxq6wZyudsZ/cUEp/h6owq1SgU6mlmEpkUjIkX5bK6z4VHeV4DfKA==",
+      "path": "Microsoft.CodeAnalysis.Common/1.3.0",
+      "hashPath": "microsoft.codeanalysis.common.1.3.0.nupkg.sha512"
+    },
+    "microsoft.codeanalysis.csharp/1.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-l8wItUjeoiCQ4yNh3LAfmFUe1oZ/c+JhUSSGDw50HURu1c1Pvjt8rNJ7Mu4mwN7GiIHS/o+zVLiuBxs/fzI19A==",
+      "path": "Microsoft.CodeAnalysis.CSharp/1.3.0",
+      "hashPath": "microsoft.codeanalysis.csharp.1.3.0.nupkg.sha512"
+    },
+    "microsoft.codeanalysis.visualbasic/1.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-1e7G/c5WBVvXurbiyO5Xh7/9JVu4JfnuvmGe2IcsIdryvKfWnhLk36p84dEZwxQ2FCbch6JWn/xGUzTXXhVz0Q==",
+      "path": "Microsoft.CodeAnalysis.VisualBasic/1.3.0",
+      "hashPath": "microsoft.codeanalysis.visualbasic.1.3.0.nupkg.sha512"
+    },
+    "microsoft.csharp/4.0.1": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-XaADFLAIOncVa+cCzhZjnAmqUpiDlkcAl5e/rlHqmJkcqiYn+WYyZrtM2nWdhodNs+evRyg4wXSnvs1vkoleMQ==",
+      "path": "Microsoft.CSharp/4.0.1",
+      "hashPath": "microsoft.csharp.4.0.1.nupkg.sha512"
+    },
+    "microsoft.netcore.app/1.0.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-wCaPr6INGtw/mrBld2b6tKZoVtMnXBJoRHPjDf0lyBVvT37IG+oN2bSgbQgexp+sd+QHtzJ3mu3pxng0CEuv9g==",
+      "path": "Microsoft.NETCore.App/1.0.0",
+      "hashPath": "microsoft.netcore.app.1.0.0.nupkg.sha512"
+    },
+    "microsoft.netcore.dotnethost/1.0.1": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-drmQROPm5utHQJfaIT0TFwQOuMop7hAJfXHQQ7EIZeVFninr6Iu4/UB3eKLPlODa2qjAWMsUUfiswXo0wBjO+g==",
+      "path": "Microsoft.NETCore.DotNetHost/1.0.1",
+      "hashPath": "microsoft.netcore.dotnethost.1.0.1.nupkg.sha512"
+    },
+    "microsoft.netcore.dotnethostpolicy/1.0.1": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-0NdjfuteMXC+qBQyNysrSFVJ8r29boAjlvlMnLYql1X4QTfcYmWCUgFWWWGogtx/MC1RWH2riPgJ77enNm1QWw==",
+      "path": "Microsoft.NETCore.DotNetHostPolicy/1.0.1",
+      "hashPath": "microsoft.netcore.dotnethostpolicy.1.0.1.nupkg.sha512"
+    },
+    "microsoft.netcore.dotnethostresolver/1.0.1": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-LhPQ2NH748RVJaI9sxA8UzS0fKYoaezTbkft6PGpsocqqsejyvHYi5CAul+2F/rgBpTASUH0JzpjVnkiHnFA0Q==",
+      "path": "Microsoft.NETCore.DotNetHostResolver/1.0.1",
+      "hashPath": "microsoft.netcore.dotnethostresolver.1.0.1.nupkg.sha512"
+    },
+    "microsoft.netcore.jit/1.0.2": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-DSP5BlZ/Fu7Cfhkd2CtAt6EZOiOlaRwcPYKkYElN9LBLr1h5bxf7BbMOnLGXFwBBtEFiKjmHK8/tsZAG8Sn/fg==",
+      "path": "Microsoft.NETCore.Jit/1.0.2",
+      "hashPath": "microsoft.netcore.jit.1.0.2.nupkg.sha512"
+    },
+    "microsoft.netcore.platforms/1.0.1": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-T/LgCB0BL7RK71g1sMvqsofDUPWD5tUrLCl6S/a9u5iYKeUkBJlwHNXVrjF0meoUI4/3dtfDYuIPh9UrBlgmOw==",
+      "path": "Microsoft.NETCore.Platforms/1.0.1",
+      "hashPath": "microsoft.netcore.platforms.1.0.1.nupkg.sha512"
+    },
+    "microsoft.netcore.runtime.coreclr/1.0.2": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-rU8ccMrcxuZ4BiJ7DBuzDI4blsg27p7ulP6cgydILvlGTjaKs1+vaIxr29gtQIThQsJ70H/lxjiGG4K6Mt/7CA==",
+      "path": "Microsoft.NETCore.Runtime.CoreCLR/1.0.2",
+      "hashPath": "microsoft.netcore.runtime.coreclr.1.0.2.nupkg.sha512"
+    },
+    "microsoft.netcore.targets/1.0.1": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-ciEwIQjtqSFLbNh+Cg4Rbi5saNjbRFy7bxi8gY7kPDHnr4Z8xVFgtBTOY24cfxx7FJYZ0MPRMc4Qhn8rFJIx0A==",
+      "path": "Microsoft.NETCore.Targets/1.0.1",
+      "hashPath": "microsoft.netcore.targets.1.0.1.nupkg.sha512"
+    },
+    "microsoft.netcore.windows.apisets/1.0.1": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-WM1T+WUvi1UbFGHzP7Z1t7SlhCMaOPaknL5BCtUqwM3FPiQdhy+dZzm/vvE6E/1vC/M3Ea/rNiWV9yfVgM9mgQ==",
+      "path": "Microsoft.NETCore.Windows.ApiSets/1.0.1",
+      "hashPath": "microsoft.netcore.windows.apisets.1.0.1.nupkg.sha512"
+    },
+    "microsoft.visualbasic/10.0.1": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-K1mxxLGUicXpzTPSkEqxdglBem5v4NmqTqeg03gpxdzsfI/I0BaWYtc9JBD0mIOfRGp6uM9M5utgZiYJqAxyoA==",
+      "path": "Microsoft.VisualBasic/10.0.1",
+      "hashPath": "microsoft.visualbasic.10.0.1.nupkg.sha512"
+    },
+    "microsoft.win32.primitives/4.0.1": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-l0ZrqK6NAJ/PBt6NPSloZ772BusAC6o0qJyI3PL9s8M+649hvuK++aEJ/KYZ7gtMjmWphrdhYoL6AhUVw/qCpQ==",
+      "path": "Microsoft.Win32.Primitives/4.0.1",
+      "hashPath": "microsoft.win32.primitives.4.0.1.nupkg.sha512"
+    },
+    "microsoft.win32.registry/4.0.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-QZQsMYyHWyeeNHSqn6YZVprctxbhZ6QnK9os0kRHxm1LTdFPnw+u21Kj6+H5CLW9WCEnkTZxvrnNTuFLkQ4c1Q==",
+      "path": "Microsoft.Win32.Registry/4.0.0",
+      "hashPath": "microsoft.win32.registry.4.0.0.nupkg.sha512"
+    },
+    "netstandard.library/1.6.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-Jbpa0wLmcErrrp3TjO7uS/Bxwft6HWlL9wC8+LxwC8tHw/pcdDQVvND/9lLiX8Rn0kY+s1/EOz9yWie2TQ5gAQ==",
+      "path": "NETStandard.Library/1.6.0",
+      "hashPath": "netstandard.library.1.6.0.nupkg.sha512"
+    },
+    "runtime.native.system/4.0.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-41x2lcS1kEVczKU1ryUZykYDyw3CMCdTeUOwt6A1/FJGjWHSxPQm0U/JU4fC9bqmnD7vA4q3uWEaJ1IzrmyJPw==",
+      "path": "runtime.native.System/4.0.0",
+      "hashPath": "runtime.native.system.4.0.0.nupkg.sha512"
+    },
+    "runtime.native.system.io.compression/4.1.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-L9gcA8G8BREAHoWcOstDugB4/UVbTuQ38UV/Ju4b9IuwVqK80tE1pgy/+LeSnIiF9ws1KW3XQEwl3vb3KSEXXA==",
+      "path": "runtime.native.System.IO.Compression/4.1.0",
+      "hashPath": "runtime.native.system.io.compression.4.1.0.nupkg.sha512"
+    },
+    "runtime.native.system.net.http/4.0.1": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-MTLNQABiRAiyju80+M+kZUMUlTRP/V0ofcD6vdRzZS1I5ffr0KSxi//21lAS3hLEJfJ623Zi0btO4fR8dnPKPg==",
+      "path": "runtime.native.System.Net.Http/4.0.1",
+      "hashPath": "runtime.native.system.net.http.4.0.1.nupkg.sha512"
+    },
+    "runtime.native.system.net.security/4.0.1": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-d3QUrmQ8fg3qLxAVYwS6B7rizx3+mmf6CbN3+6x43yYwUp27f74BwDPc2jLIgKPPwTzitangLWi+9YqqiES88g==",
+      "path": "runtime.native.System.Net.Security/4.0.1",
+      "hashPath": "runtime.native.system.net.security.4.0.1.nupkg.sha512"
+    },
+    "runtime.native.system.security.cryptography/4.0.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-6gLQEjlZ2e8AmNlH0YDd102/hZVICNe1folF5RenqK25X852P/IQ/llAwCJVoAKUQlpa8KDrLVuzhjX3JPawRA==",
+      "path": "runtime.native.System.Security.Cryptography/4.0.0",
+      "hashPath": "runtime.native.system.security.cryptography.4.0.0.nupkg.sha512"
+    },
+    "system.appcontext/4.1.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-kTXEWzCijc7u4XmD2zfHYmyyrxqc0eqBHeuFMIlwNikCqFJC6AiHfEIZYlZk8HbVTc2A8UWLTBOpBPMFflrqpw==",
+      "path": "System.AppContext/4.1.0",
+      "hashPath": "system.appcontext.4.1.0.nupkg.sha512"
+    },
+    "system.buffers/4.0.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-6hah3sqjZCX6Ba37GRGUY8vslT+KKqLwRom33XExKPh+yYFTA4X2w6fjMVD2wdOuahNr1M/R4Z6I+ogEyciHGQ==",
+      "path": "System.Buffers/4.0.0",
+      "hashPath": "system.buffers.4.0.0.nupkg.sha512"
+    },
+    "system.collections/4.0.11": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-GetjWwFh14cMNU77nbTHe4Zx49WxFc78Bpwh/JkyQBmDVpLlwnUJQGHe2F1tdDaJMlj9stL1UHTFN/6bcjVv0A==",
+      "path": "System.Collections/4.0.11",
+      "hashPath": "system.collections.4.0.11.nupkg.sha512"
+    },
+    "system.collections.concurrent/4.0.12": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-s6klY8LSbB2bOLGUAaEd1uuKgSk+uBRVknh9CnsXEIgHrEV66SAjZyC0IivkCxdsOUD4PcpgWvTpH/+p0SeyJA==",
+      "path": "System.Collections.Concurrent/4.0.12",
+      "hashPath": "system.collections.concurrent.4.0.12.nupkg.sha512"
+    },
+    "system.collections.immutable/1.2.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-NJM6bLtu0XMTIL1tbu4YvePct9oytxbrXGpKDkSBTowmWXtjw+UgK8duC/5QUZ4KP7sgJ82wWj0zJ7o/EiyQiQ==",
+      "path": "System.Collections.Immutable/1.2.0",
+      "hashPath": "system.collections.immutable.1.2.0.nupkg.sha512"
+    },
+    "system.componentmodel/4.0.1": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-+WQW/7ThcXEyOmX48xzbn6k9wgpZUWFKal7lPaansIGp5KNt0Sqs4yAn48Hk+KSineDpmjRIfFyr9x7p7IX+WQ==",
+      "path": "System.ComponentModel/4.0.1",
+      "hashPath": "system.componentmodel.4.0.1.nupkg.sha512"
+    },
+    "system.componentmodel.annotations/4.1.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-7e7YTOa1lmKn/SBiIH9OTwdt1gzvw57OleO8J1lDF3Mk4VjEmtBcao6ER3ESvsRYoZ/U9YiHj2g1mhX+fw556Q==",
+      "path": "System.ComponentModel.Annotations/4.1.0",
+      "hashPath": "system.componentmodel.annotations.4.1.0.nupkg.sha512"
+    },
+    "system.console/4.0.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-mDEy6iQe09abm2HpuCjSfeJMt8k4Bu7wnqqvfvpNn87A42NyjCbmJ3v1gF/P2M1NoyyoEcMyS9MO8rxeZF761Q==",
+      "path": "System.Console/4.0.0",
+      "hashPath": "system.console.4.0.0.nupkg.sha512"
+    },
+    "system.diagnostics.debug/4.0.11": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-GOUwHInyMvSBKENMfKGgL+trlGq27LOUqiggBMC69GntL/k0G4/3Dh7qqyp9aVZyraja5jy+YLs5R+5w3JZXeg==",
+      "path": "System.Diagnostics.Debug/4.0.11",
+      "hashPath": "system.diagnostics.debug.4.0.11.nupkg.sha512"
+    },
+    "system.diagnostics.diagnosticsource/4.0.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-gqW2/wPdjw/O0c23ck8JUDWHsa57MqxE4yaqaL01KpLHoaC6IabRV3wLSJBsl6tnCDS4EJExIk5gSMvBJT9L8g==",
+      "path": "System.Diagnostics.DiagnosticSource/4.0.0",
+      "hashPath": "system.diagnostics.diagnosticsource.4.0.0.nupkg.sha512"
+    },
+    "system.diagnostics.fileversioninfo/4.0.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-/kVXI1j/fWw8bumaMmoA2Actx/pJGOrFucfEXcLBI5aRatSH5Mqk1hS49Q5REypcV32rbOI0agg/14cEWKpz2Q==",
+      "path": "System.Diagnostics.FileVersionInfo/4.0.0",
+      "hashPath": "system.diagnostics.fileversioninfo.4.0.0.nupkg.sha512"
+    },
+    "system.diagnostics.process/4.1.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-2aYQppWQviG/0OKXTwe7FOnHDZLdCCvjN3u6zUw40lxrNzhRhlrz95uPcX/xSHxcxRpomqLhPKsp2R47yuWiQw==",
+      "path": "System.Diagnostics.Process/4.1.0",
+      "hashPath": "system.diagnostics.process.4.1.0.nupkg.sha512"
+    },
+    "system.diagnostics.stacktrace/4.0.1": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-ZnFIBpSe/Uulh7R7nXorTnkL2POzkaFUL22YXBjthPeLyZSbXm8BMtDgCx1btgMFPF9oVQOS/nmzt4gJSM5z0A==",
+      "path": "System.Diagnostics.StackTrace/4.0.1",
+      "hashPath": "system.diagnostics.stacktrace.4.0.1.nupkg.sha512"
+    },
+    "system.diagnostics.tools/4.0.1": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-oFPexUie0mHe3sVWqdvmmvszsm+FikNSeZToJc9lQ412eILHMF3f1WzXlqKJayUC9klA8WNsREtTnk1A5P+Ggg==",
+      "path": "System.Diagnostics.Tools/4.0.1",
+      "hashPath": "system.diagnostics.tools.4.0.1.nupkg.sha512"
+    },
+    "system.diagnostics.tracing/4.1.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-vXwGhvfM0beIjP18dKIMPgx0L9mW06JwMwaY82ZQY6DlZrrR9mWyyOHW2u7ntm5A24yxOhGU60Ylo/Eu6DPoqw==",
+      "path": "System.Diagnostics.Tracing/4.1.0",
+      "hashPath": "system.diagnostics.tracing.4.1.0.nupkg.sha512"
+    },
+    "system.dynamic.runtime/4.0.11": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-arcukY36dVZoxQD9tPqAC7qSn1khD5anIUMxIAsLFTKdy/il5yxXIw/gELCCIojxE5WDSiL54c5ENjxemLvY1A==",
+      "path": "System.Dynamic.Runtime/4.0.11",
+      "hashPath": "system.dynamic.runtime.4.0.11.nupkg.sha512"
+    },
+    "system.globalization/4.0.11": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-93EFhs2UoueVm5ZbDtoNv+gjlZgfV1FR1N9JS1XzFfe0VWfYEpi2zDRbavv71VtNKRpS7L19JGvkWXVaSUlKTQ==",
+      "path": "System.Globalization/4.0.11",
+      "hashPath": "system.globalization.4.0.11.nupkg.sha512"
+    },
+    "system.globalization.calendars/4.0.1": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-ZPoYOVSNSTbaSR/lDaYZdAtxMu5xsOSsu46LpNPlPgLc2mAbo/nLmkyU8S0A90XthMhhP0CT4GBYn8StVA1Hlw==",
+      "path": "System.Globalization.Calendars/4.0.1",
+      "hashPath": "system.globalization.calendars.4.0.1.nupkg.sha512"
+    },
+    "system.globalization.extensions/4.0.1": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-f6x3H/Lpw6K1MBGbC741p6y6BuVqVG2m0mCTF+XVCZOxxIOVS1NvUal6jukvRt339kt/XFvPI8FiPrMCB+35KA==",
+      "path": "System.Globalization.Extensions/4.0.1",
+      "hashPath": "system.globalization.extensions.4.0.1.nupkg.sha512"
+    },
+    "system.io/4.1.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-JrXp07/ss3zp+XxstCDw0+nZ/br7btoR5atmKTm1KpbOjsWg/QLwGS8G06hwPSuGi2Gg72aT87XkmJPGTi/sDw==",
+      "path": "System.IO/4.1.0",
+      "hashPath": "system.io.4.1.0.nupkg.sha512"
+    },
+    "system.io.compression/4.1.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-eBdkXbRWXGtZq60g4xfAtHaMRrMls+V7kMZANCGq4lYVKiDhpa9T8UP/DgmAnm3sXQ7H0bwdj9CpIIq4+ap5Iw==",
+      "path": "System.IO.Compression/4.1.0",
+      "hashPath": "system.io.compression.4.1.0.nupkg.sha512"
+    },
+    "system.io.compression.zipfile/4.0.1": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-gww8ubYRDaNbdObTWjxm3282U5n1IwWdefVsJDYY0GXjfoKaHaKdY9QAawe+EFoQLFcOMb2XKYj2SLrWNI+Uig==",
+      "path": "System.IO.Compression.ZipFile/4.0.1",
+      "hashPath": "system.io.compression.zipfile.4.0.1.nupkg.sha512"
+    },
+    "system.io.filesystem/4.0.1": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-Yu1IGorsj0jZuIj2iAqlvR1bJ4ONT1vK77jaD0npgzTP3owP2PXZFoVekMMtkO2TO/0e/zXBVOmDCC4GhIpysg==",
+      "path": "System.IO.FileSystem/4.0.1",
+      "hashPath": "system.io.filesystem.4.0.1.nupkg.sha512"
+    },
+    "system.io.filesystem.primitives/4.0.1": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-XhOqbO9JWdHU+d6ZkILXA96Yz3+XTwznJ78uyhtCgXharLT4mkhlBNNt2eZ8ynV9ChvyQusD7grQvA4H2lC+1Q==",
+      "path": "System.IO.FileSystem.Primitives/4.0.1",
+      "hashPath": "system.io.filesystem.primitives.4.0.1.nupkg.sha512"
+    },
+    "system.io.filesystem.watcher/4.0.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-1Ai0CkKSOIuei9Ht04Ug5e/MHa4wuRDgl+yJDZcz8IrDclLDHodqr+lA9ziUncuHT5JbizLzMWEcM9KZW6jbJw==",
+      "path": "System.IO.FileSystem.Watcher/4.0.0",
+      "hashPath": "system.io.filesystem.watcher.4.0.0.nupkg.sha512"
+    },
+    "system.io.memorymappedfiles/4.0.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-I6FvO5VWpPw/VW1DEuME9+jY7EnU3EiPvsfQILWWT7GQ7xirNg3rDOB+w1eWyAs8i8uJTQmt+wiMU1CJH8WF5w==",
+      "path": "System.IO.MemoryMappedFiles/4.0.0",
+      "hashPath": "system.io.memorymappedfiles.4.0.0.nupkg.sha512"
+    },
+    "system.io.unmanagedmemorystream/4.0.1": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-C/q7XR1nJq4vk6rdnlR3nMRcIpWSP9M8vpfTQ8lTTMW586c0MwXUVpvthGzazELKRr+uY+juJVRfcJCiq8i1Rw==",
+      "path": "System.IO.UnmanagedMemoryStream/4.0.1",
+      "hashPath": "system.io.unmanagedmemorystream.4.0.1.nupkg.sha512"
+    },
+    "system.linq/4.1.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-AvDpmWdu5s2MdyCmrHjyeHed10zGSLLq7kjaZPDcdGz3HPOwRfG6mNcK6jL0XTGFbNfH6C4/5H6c9CuVkV2xqg==",
+      "path": "System.Linq/4.1.0",
+      "hashPath": "system.linq.4.1.0.nupkg.sha512"
+    },
+    "system.linq.expressions/4.1.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-xSoEkwQSrkEx+kgs6maYU4Zn3Rkb0o/FvRyjDSgFsbKU/QPUlhhvAt2zc46WAqTqIaK3M/rYO5mdGAMAyPnQRw==",
+      "path": "System.Linq.Expressions/4.1.0",
+      "hashPath": "system.linq.expressions.4.1.0.nupkg.sha512"
+    },
+    "system.linq.parallel/4.0.1": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-J7R9tTmkEIjuqh6pieeSmXf7m/8evxvHDAWZ2al/p74EHHeQRa3zTOaWi5UpOzCoKGB20QjFd+9hV6iM3CypTw==",
+      "path": "System.Linq.Parallel/4.0.1",
+      "hashPath": "system.linq.parallel.4.0.1.nupkg.sha512"
+    },
+    "system.linq.queryable/4.0.1": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-D07uaRFTD+jLHZ91sVDFcZU0WivI3QrSishVDAHhQeC/m+dax+XD3XqC0OGpdAz7zEMunj5trg5HrmAHuRd+Yw==",
+      "path": "System.Linq.Queryable/4.0.1",
+      "hashPath": "system.linq.queryable.4.0.1.nupkg.sha512"
+    },
+    "system.net.http/4.1.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-BkAwb17jMBDijqtrjf8Tp8gtVK76nJWmMOgCC8vGP7PHIstlrGADxZH5AP1h0C6xeTGXrsztXVXasjb2A9QWjg==",
+      "path": "System.Net.Http/4.1.0",
+      "hashPath": "system.net.http.4.1.0.nupkg.sha512"
+    },
+    "system.net.nameresolution/4.0.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-jkERvZB3hT+eNXFJVAeAmro+AqWcHWdvt+ud0ymHtRn5goyuQ6gRGYj+J64QfuJ18hp6blmWaLDHAuyg3WVLcQ==",
+      "path": "System.Net.NameResolution/4.0.0",
+      "hashPath": "system.net.nameresolution.4.0.0.nupkg.sha512"
+    },
+    "system.net.primitives/4.0.11": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-0W1rJnR7bkg/kLU2BnHOLOdvJe9eWkzwd27yoR0zqwk5JjQTDJXFVgzr0joQMqffzCr8GAhOmsQ2Ic49VnXytw==",
+      "path": "System.Net.Primitives/4.0.11",
+      "hashPath": "system.net.primitives.4.0.11.nupkg.sha512"
+    },
+    "system.net.requests/4.0.11": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-xbqbJz9ulEo77Trphha4CBiolIki7Go2xp2oEVBoSAzM+O4jf1yqAct9KxC0XPchBcywAB2szLCY74DlizAYXg==",
+      "path": "System.Net.Requests/4.0.11",
+      "hashPath": "system.net.requests.4.0.11.nupkg.sha512"
+    },
+    "system.net.security/4.0.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-DAdMigsDUPudVlFUpXuLmIpPixoWF2qg3nWwYPfh03xOdrK+pI2+PudxuxBC8hJJPCED53W/kelFItMT2lgcXQ==",
+      "path": "System.Net.Security/4.0.0",
+      "hashPath": "system.net.security.4.0.0.nupkg.sha512"
+    },
+    "system.net.sockets/4.1.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-Vr4Zun+nSboRmNHxw1Caanhrbawsl/bYqUOmCkRleLny3OdsSU+/Heo5C6DVI9sPAzq2cCWi4FmNzkqVst70mg==",
+      "path": "System.Net.Sockets/4.1.0",
+      "hashPath": "system.net.sockets.4.1.0.nupkg.sha512"
+    },
+    "system.net.webheadercollection/4.0.1": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-PWVHl0iPXu3k16tkKPtcbb+I84QMm0G9WDXX5ax5re33RGpNluW8nSiM+qz+gGunHavDELXZWw8Iqwr+mkoaLw==",
+      "path": "System.Net.WebHeaderCollection/4.0.1",
+      "hashPath": "system.net.webheadercollection.4.0.1.nupkg.sha512"
+    },
+    "system.numerics.vectors/4.1.1": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-pXF7egIi6aKokRdt8O5P4tC9b/3i9VnOZKLEsHj6fj6v1TMqtICfhwom3bcQJpVK6X5TOZTHKOZLcROnr+cjjQ==",
+      "path": "System.Numerics.Vectors/4.1.1",
+      "hashPath": "system.numerics.vectors.4.1.1.nupkg.sha512"
+    },
+    "system.objectmodel/4.0.12": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-O+q402luZF3nRK51XkyePYiBi6WVQeiPriESLWlcMK1NJaR6Afffh0WONmTQTwcka+Z6iiNgQzePli4Gl0oUdg==",
+      "path": "System.ObjectModel/4.0.12",
+      "hashPath": "system.objectmodel.4.0.12.nupkg.sha512"
+    },
+    "system.reflection/4.1.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-hnsgRmEC7EQ4r920kkr4njHfM0PbHSmISiM8uWj0xh/tfj2QfBFVQbRY6jzDMIJI9NM180ztaAyu6xXFqJgbiw==",
+      "path": "System.Reflection/4.1.0",
+      "hashPath": "system.reflection.4.1.0.nupkg.sha512"
+    },
+    "system.reflection.dispatchproxy/4.0.1": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-uc8ys/hjDLRbF3Dgq/h3yOu/scjXwfbA53GZvD5lrJyfMVnjW5I3kW+ohYA8jpiHtuX/qiyymNahHVMjWQ//og==",
+      "path": "System.Reflection.DispatchProxy/4.0.1",
+      "hashPath": "system.reflection.dispatchproxy.4.0.1.nupkg.sha512"
+    },
+    "system.reflection.emit/4.0.1": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-LY/uzPD3sRNysXaZKMXD+WG5AF3VxDybEcwVQVqHEurO2fRj8lLGhXH3GwubeXbadEiYQ0eE2PeR0auXNtx6HA==",
+      "path": "System.Reflection.Emit/4.0.1",
+      "hashPath": "system.reflection.emit.4.0.1.nupkg.sha512"
+    },
+    "system.reflection.emit.ilgeneration/4.0.1": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-XfE7FOBbXdtD5uOrRkR6zd6hKLRBp1fpL3HQZbZ0QJW2ZNe7ELHvVZCspBpISMvm3Z7s5vw7hZ9w/yyeFtBEOg==",
+      "path": "System.Reflection.Emit.ILGeneration/4.0.1",
+      "hashPath": "system.reflection.emit.ilgeneration.4.0.1.nupkg.sha512"
+    },
+    "system.reflection.emit.lightweight/4.0.1": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-pOsk7aQYUH90F0fTqnUUUIZJfRBRd+J0ixAdQ593TFY1ISzL7xwKvZxWzEoeA9/elOf9eZawYaN2DdII1RMlqg==",
+      "path": "System.Reflection.Emit.Lightweight/4.0.1",
+      "hashPath": "system.reflection.emit.lightweight.4.0.1.nupkg.sha512"
+    },
+    "system.reflection.extensions/4.0.1": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-IfbmuGxvcwpWuHgvg15l4YAWc/0CPcsFFI+cMhF1Z00Q1ZtnyRYSW677KJIq5x7Oh4U3C6RM0UBbw+IbtD8Ntg==",
+      "path": "System.Reflection.Extensions/4.0.1",
+      "hashPath": "system.reflection.extensions.4.0.1.nupkg.sha512"
+    },
+    "system.reflection.metadata/1.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-AqzJhKDLd5GV+McOb4nw1E4z6PaDzIdxIpb0QBIjAf4thoTqbg84CxFAfxTB3kzbVSLU9C4NYQyd9R/lU1YIMA==",
+      "path": "System.Reflection.Metadata/1.3.0",
+      "hashPath": "system.reflection.metadata.1.3.0.nupkg.sha512"
+    },
+    "system.reflection.primitives/4.0.1": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-jrEPZZ9lhfNsWYmubLHDHfLA/h/5H0dpq9mLfF8DEL2HwGoysd1QG36Szxt9N0D+NbXSftFQV4rCl7Me+QQGRQ==",
+      "path": "System.Reflection.Primitives/4.0.1",
+      "hashPath": "system.reflection.primitives.4.0.1.nupkg.sha512"
+    },
+    "system.reflection.typeextensions/4.1.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-oi2XhaXLryqd8IM+rrYAyI0z+ZLBXKBHXQ2pTkW53U0nHeavANuVcSUlKP/gBuyTdLKTtqDex2ZXps/L9oKVzQ==",
+      "path": "System.Reflection.TypeExtensions/4.1.0",
+      "hashPath": "system.reflection.typeextensions.4.1.0.nupkg.sha512"
+    },
+    "system.resources.reader/4.0.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-nzI6DUrQKAwSNN7y4PjvpblOXt+4aTcogUV+EwkgeiuWjToUW2m4epup65N8FaLJeQybBpTEDiOhSis3qTC1QQ==",
+      "path": "System.Resources.Reader/4.0.0",
+      "hashPath": "system.resources.reader.4.0.0.nupkg.sha512"
+    },
+    "system.resources.resourcemanager/4.0.1": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-R73oCHfarGDuS724tGXmJsVGzQfk00OGW8JpiAYt/MMzfPu5T/5yYko/sSM97+sy8VMhP2y8083UzshyujageA==",
+      "path": "System.Resources.ResourceManager/4.0.1",
+      "hashPath": "system.resources.resourcemanager.4.0.1.nupkg.sha512"
+    },
+    "system.runtime/4.1.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-16wNLsqfhKCTcyWxq3EkWbfnCY/maOUqGLq35UOV2EGz99S5te9xgrqCqBkXwL1BnK62mqpxlK/tWt2Zjqp0Eg==",
+      "path": "System.Runtime/4.1.0",
+      "hashPath": "system.runtime.4.1.0.nupkg.sha512"
+    },
+    "system.runtime.extensions/4.1.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-t6l7jZsg/NcRHxg+276A+nqmJv/RvqsWTSl8LP3ullxyKu7ZK6rvlrsP10fMdDXuQOiusK7+7fOW3ePwbPXbVQ==",
+      "path": "System.Runtime.Extensions/4.1.0",
+      "hashPath": "system.runtime.extensions.4.1.0.nupkg.sha512"
+    },
+    "system.runtime.handles/4.0.1": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-DrLy26SE00IJfn7X+7c09nibQXNP/XExX9+P03Ldu8NoN0b4Qa0x2wt6Ljok8XT6C+O9ucA+e9ZAe7YTDjFr9A==",
+      "path": "System.Runtime.Handles/4.0.1",
+      "hashPath": "system.runtime.handles.4.0.1.nupkg.sha512"
+    },
+    "system.runtime.interopservices/4.1.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-AEz9Rp0bTyJZwQJLtLQtuAUFAo2y4Z/Hec4NmSPT1ySrpPsGGElSV87DI3jM9VBQv6JDPDzNH2JE9h19wxq5IA==",
+      "path": "System.Runtime.InteropServices/4.1.0",
+      "hashPath": "system.runtime.interopservices.4.1.0.nupkg.sha512"
+    },
+    "system.runtime.interopservices.runtimeinformation/4.0.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-uEdRRdxU5zCgv1H0bxo/vRHhdc8JFHeZtz8i35go4McrHMBT5n8va8ycyTYWrZSQ8bgLvD7ix8dw5k/bx6B2iQ==",
+      "path": "System.Runtime.InteropServices.RuntimeInformation/4.0.0",
+      "hashPath": "system.runtime.interopservices.runtimeinformation.4.0.0.nupkg.sha512"
+    },
+    "system.runtime.loader/4.0.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-BOuixOICsGb5WsnmiVaBYSuptC1KApl1vzlRBfQU7Y3ltsszsUNwfMHdNse/yT1knz1Q2cCSXTnq2lfXvm9PFg==",
+      "path": "System.Runtime.Loader/4.0.0",
+      "hashPath": "system.runtime.loader.4.0.0.nupkg.sha512"
+    },
+    "system.runtime.numerics/4.0.1": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-1gKGhH7nUFf7C1gr+bBoMvsBQ2/H4b9B/R+ZBVTVR+sEml+rns+PZF+GECpuCqs7bbNDXj8k7DtWgaBBFqglLQ==",
+      "path": "System.Runtime.Numerics/4.0.1",
+      "hashPath": "system.runtime.numerics.4.0.1.nupkg.sha512"
+    },
+    "system.security.claims/4.0.1": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-Uj4YL2pPL4HjGJV8NczP2Q66UVYjTTQLIi3uROiAwwJkRP2vPQgaZwaeAugciNZgNNZkqHzdvozJAV+Ec/0N/w==",
+      "path": "System.Security.Claims/4.0.1",
+      "hashPath": "system.security.claims.4.0.1.nupkg.sha512"
+    },
+    "system.security.cryptography.algorithms/4.2.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-nfDTD7z58eF8+OUt9R7UCNqRSzTgFfAH4q2Fbt3yHMP/+15Tu6uZEdUPu+/yE1vUY4PfozxaQ5a78isG/Ha5IA==",
+      "path": "System.Security.Cryptography.Algorithms/4.2.0",
+      "hashPath": "system.security.cryptography.algorithms.4.2.0.nupkg.sha512"
+    },
+    "system.security.cryptography.cng/4.2.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-qJ9pnGGae9+LnViB7xjeFAouF0OViIf6MqgqF4PEtNtjze+yDbXakzZcj4+9Acrw80uqhOsKN/Xu48SUuuerpA==",
+      "path": "System.Security.Cryptography.Cng/4.2.0",
+      "hashPath": "system.security.cryptography.cng.4.2.0.nupkg.sha512"
+    },
+    "system.security.cryptography.csp/4.0.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-NVEnNApnW+5UAQg96yfGX6bAihbemBQTkJT+wmEyxNe+0JUcvATBJhF15Dh/Z04/sJPTPBfeC2k3QbE0O7zGkw==",
+      "path": "System.Security.Cryptography.Csp/4.0.0",
+      "hashPath": "system.security.cryptography.csp.4.0.0.nupkg.sha512"
+    },
+    "system.security.cryptography.encoding/4.0.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-Ym5NRRQ1ZcHi+s/bME47Q9KuakimP/sJXfkY+dfHGu67hgBdrLcB0xs1LbKKVip1kGukZpS40qCpFm37KO/h+A==",
+      "path": "System.Security.Cryptography.Encoding/4.0.0",
+      "hashPath": "system.security.cryptography.encoding.4.0.0.nupkg.sha512"
+    },
+    "system.security.cryptography.openssl/4.0.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-pcPHa9ffsgALcBW/IpZSoHdKLuK8L1W1Rls9D32vKzbSYtBcZZacGb+tQLjgGX4TTK4BWsIN8c+RyTvnjly5Xw==",
+      "path": "System.Security.Cryptography.OpenSsl/4.0.0",
+      "hashPath": "system.security.cryptography.openssl.4.0.0.nupkg.sha512"
+    },
+    "system.security.cryptography.primitives/4.0.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-NoZUZptChcNKOUu6DEJjlBDMPoFvw4QnoHN5wlddmi9idGe0a9wXcRqLANsfsdwPR9wFCMC3B2DhwlN5XP/mug==",
+      "path": "System.Security.Cryptography.Primitives/4.0.0",
+      "hashPath": "system.security.cryptography.primitives.4.0.0.nupkg.sha512"
+    },
+    "system.security.cryptography.x509certificates/4.1.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-3e5jXb54vQuItYXB/KBMsqUw645c/JQjz1MoJ5uaco3mu+fLpscUeR0rQwcctjVAIMDEF6pGEa8falmDvyCIPg==",
+      "path": "System.Security.Cryptography.X509Certificates/4.1.0",
+      "hashPath": "system.security.cryptography.x509certificates.4.1.0.nupkg.sha512"
+    },
+    "system.security.principal/4.0.1": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-awQM/V57TinvUv04eNBkuZfpZpS3TykQmw457uQIfb1c1NUb8s0WloI8F+8OefgMKFUArZqS/CTIo1MaxzI41A==",
+      "path": "System.Security.Principal/4.0.1",
+      "hashPath": "system.security.principal.4.0.1.nupkg.sha512"
+    },
+    "system.security.principal.windows/4.0.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-6AjgoFpkgOXi6ff/QA8X7ptSzHgxfdDGFzXBrgtCuYWp7yZEA5UpgYXTUz+BRN0ghptF0QiT7XMks1VFWjdkPA==",
+      "path": "System.Security.Principal.Windows/4.0.0",
+      "hashPath": "system.security.principal.windows.4.0.0.nupkg.sha512"
+    },
+    "system.text.encoding/4.0.11": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-qNhrsRyOiAJEebUgu4u8j0KKwVxE6ToQXD7SVI1ZEzDjBANJqWuGmJkCGyPavi/L5oW5c3nfZd+SWYy3gHpeQw==",
+      "path": "System.Text.Encoding/4.0.11",
+      "hashPath": "system.text.encoding.4.0.11.nupkg.sha512"
+    },
+    "system.text.encoding.codepages/4.0.1": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-SPSEk/+yGF/8671SF4otT/7Ccy0v96cUfHIzxhTvzkttd7ilIUKXnFNi2pR0No9w0mN37FOZeWH/1anvUpvwLg==",
+      "path": "System.Text.Encoding.CodePages/4.0.1",
+      "hashPath": "system.text.encoding.codepages.4.0.1.nupkg.sha512"
+    },
+    "system.text.encoding.extensions/4.0.11": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-riSwTArdagYKjrp/DzoyVuK9wh6d3F+rHzR5/eyEb83VTIToGreYlnC/cDF/H1llhZhykBr7CG0gkxnUKTGtGA==",
+      "path": "System.Text.Encoding.Extensions/4.0.11",
+      "hashPath": "system.text.encoding.extensions.4.0.11.nupkg.sha512"
+    },
+    "system.text.regularexpressions/4.1.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-kyy6kxns6bAysPO9m29a/lIgPthlAOl4AHuN55etAos2laoFdaWo6U/4OdyoBnJO+Bxh5FlFO7fpP5A69T0KLg==",
+      "path": "System.Text.RegularExpressions/4.1.0",
+      "hashPath": "system.text.regularexpressions.4.1.0.nupkg.sha512"
+    },
+    "system.threading/4.0.11": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-dsJUbvClITs+Pznqq3N//aMDJNneTRYMoEsVKDmAHGh8EPjDB4FvAmcHMeoj4xyO3fZTpk5/7xcZBSG7PXb7kA==",
+      "path": "System.Threading/4.0.11",
+      "hashPath": "system.threading.4.0.11.nupkg.sha512"
+    },
+    "system.threading.overlapped/4.0.1": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-41i+EAxyCW+/evnvXSKj0IHfUiMwHZohxyq7dalgZfO58o7ep5qll81/aLr5cvtPfS/91iHkFp5MGLED/ry7Dw==",
+      "path": "System.Threading.Overlapped/4.0.1",
+      "hashPath": "system.threading.overlapped.4.0.1.nupkg.sha512"
+    },
+    "system.threading.tasks/4.0.11": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-TtdCvO0IIheiswtc9Ngly7J9QBkap5X23ujGaaUSBPuKqKl7U7JYtcRfIsQMwyZ+O91uyMradQPZGwCsMzeATw==",
+      "path": "System.Threading.Tasks/4.0.11",
+      "hashPath": "system.threading.tasks.4.0.11.nupkg.sha512"
+    },
+    "system.threading.tasks.dataflow/4.6.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-OK7OxIJ9u4tpQ7K2rkal+qHqipIQ576CgHHm6nNlwMymqCPdihtFLhb1TV+MSSMWyeOTA3fT3eQNLlnBBlrQ5A==",
+      "path": "System.Threading.Tasks.Dataflow/4.6.0",
+      "hashPath": "system.threading.tasks.dataflow.4.6.0.nupkg.sha512"
+    },
+    "system.threading.tasks.extensions/4.0.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-tNrguBmbHTG/UsTJPlgZhlb2iAGJQVguY/amgbR4z36eB4bDelHSLl5/S5qxBVL/rzbAwWhlGntc6x1LiM3t8w==",
+      "path": "System.Threading.Tasks.Extensions/4.0.0",
+      "hashPath": "system.threading.tasks.extensions.4.0.0.nupkg.sha512"
+    },
+    "system.threading.tasks.parallel/4.0.1": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-Hck6r2cP4010W10GHj0T+2aC4BlwfR5Jryo66LuKneqWYv8woLvkB33wms+u99zkHowvrMyH5GyAn+3Xy/oNYQ==",
+      "path": "System.Threading.Tasks.Parallel/4.0.1",
+      "hashPath": "system.threading.tasks.parallel.4.0.1.nupkg.sha512"
+    },
+    "system.threading.thread/4.0.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-bZZ1sPwuEgP+ldGNxjznhbr6l43j/FshRA5B79FEPK7JuRXfzywYijLVx7xwRWp6JspbjTJ6vyxCewU0SudBIQ==",
+      "path": "System.Threading.Thread/4.0.0",
+      "hashPath": "system.threading.thread.4.0.0.nupkg.sha512"
+    },
+    "system.threading.threadpool/4.0.10": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-XsayrwW56AZOeZODMbycHoip7UvhWo4gvP+lQuPWiRLoBmf5544Y7u1OqLCtyHpyVKfdwgUhvjmwnt2nDvOSJw==",
+      "path": "System.Threading.ThreadPool/4.0.10",
+      "hashPath": "system.threading.threadpool.4.0.10.nupkg.sha512"
+    },
+    "system.threading.timer/4.0.1": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-IGPz3ncIsWGzTI31Ew6LF9vUfT9IbGLuaA7sZNT8HiJ5icwmQP4dZB1Iquvyyr5+6IshhyBZAYL+PT7WvW26HQ==",
+      "path": "System.Threading.Timer/4.0.1",
+      "hashPath": "system.threading.timer.4.0.1.nupkg.sha512"
+    },
+    "system.xml.readerwriter/4.0.11": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-hmEjrB85NCiD50cw9JkQvzHGAZ+I9guEg2zGLYKSZdjzPDYdg25mmGehf86zfJwZdW5XBi7owJpLZWRU5QDH2Q==",
+      "path": "System.Xml.ReaderWriter/4.0.11",
+      "hashPath": "system.xml.readerwriter.4.0.11.nupkg.sha512"
+    },
+    "system.xml.xdocument/4.0.11": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-Kg0Ca0bBCniaLGY2EnmJ+GTZlrQswzd530hIiRi0Zm4iMdDdxV67Fv73B5gwh+sMGHqaW/Q917waIqmSFxTaOg==",
+      "path": "System.Xml.XDocument/4.0.11",
+      "hashPath": "system.xml.xdocument.4.0.11.nupkg.sha512"
+    },
+    "system.xml.xmldocument/4.0.1": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-5fyjMTXJNcbDv4aCJN1RyNzu3/xObqJlfzX8OVgJ3DXHeapmjj7zkt1YoGiEzqamG1DPZ9epRVLsf+SxBjf5hQ==",
+      "path": "System.Xml.XmlDocument/4.0.1",
+      "hashPath": "system.xml.xmldocument.4.0.1.nupkg.sha512"
+    },
+    "system.xml.xpath/4.0.1": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-HoPTx0vnO+b3F3/CbyERk+DTFTOQjYvie4wPgwdtRXmDa1zo4qzIUCT3FWFeRh9Bg/V5hhm6pHxY9arJD56SLA==",
+      "path": "System.Xml.XPath/4.0.1",
+      "hashPath": "system.xml.xpath.4.0.1.nupkg.sha512"
+    },
+    "system.xml.xpath.xdocument/4.0.1": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-dgXOf8OwZhN7XEQxU3goBEad6DvEZB3GoGXMdqu8XEG5HX1sJ8tIYIedsjJWqAsEHnbYnPDd82Y9gagu0jyVqQ==",
+      "path": "System.Xml.XPath.XDocument/4.0.1",
+      "hashPath": "system.xml.xpath.xdocument.4.0.1.nupkg.sha512"
+    }
+  }
+}

--- a/src/Tasks/Microsoft.NET.Build.Tasks/DependencyContextBuilder.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/DependencyContextBuilder.cs
@@ -21,6 +21,7 @@ namespace Microsoft.NET.Build.Tasks
         private readonly SingleProjectInfo _mainProjectInfo;
         private readonly ProjectContext _projectContext;
         private IEnumerable<ReferenceInfo> _frameworkReferences;
+        private IEnumerable<ReferenceInfo> _directReferences;
         private Dictionary<string, SingleProjectInfo> _referenceProjectInfos;
         private IEnumerable<string> _privateAssetPackageIds;
         private CompilationOptions _compilationOptions;
@@ -40,6 +41,12 @@ namespace Microsoft.NET.Build.Tasks
             // note: Framework libraries only export compile-time stuff
             // since they assume the runtime library is present already
             _frameworkReferences = frameworkReferences;
+            return this;
+        }
+
+        public DependencyContextBuilder WithDirectReferences(IEnumerable<ReferenceInfo> directReferences)
+        {
+            _directReferences = directReferences;
             return this;
         }
 
@@ -93,7 +100,8 @@ namespace Microsoft.NET.Build.Tasks
                 dependencyLookup);
             IEnumerable<RuntimeLibrary> runtimeLibraries =
                 new[] { projectRuntimeLibrary }
-                .Concat(GetLibraries(runtimeExports, libraryLookup, dependencyLookup, runtime: true).Cast<RuntimeLibrary>());
+                .Concat(GetLibraries(runtimeExports, libraryLookup, dependencyLookup, runtime: true).Cast<RuntimeLibrary>())
+                .Concat(GetDirectReferenceRuntimeLibraries());
 
             IEnumerable<CompilationLibrary> compilationLibraries;
             if (includeCompilationLibraries)
@@ -105,7 +113,8 @@ namespace Microsoft.NET.Build.Tasks
                 compilationLibraries =
                     new[] { projectCompilationLibrary }
                     .Concat(GetFrameworkLibraries())
-                    .Concat(GetLibraries(compilationExports, libraryLookup, dependencyLookup, runtime: false).Cast<CompilationLibrary>());
+                    .Concat(GetLibraries(compilationExports, libraryLookup, dependencyLookup, runtime: false).Cast<CompilationLibrary>())
+                    .Concat(GetDirectReferenceCompilationLibraries());
             }
             else
             {
@@ -173,15 +182,9 @@ namespace Microsoft.NET.Build.Tasks
             ProjectContext projectContext,
             Dictionary<string, Dependency> dependencyLookup)
         {
-
             RuntimeAssetGroup[] runtimeAssemblyGroups = new[] { new RuntimeAssetGroup(string.Empty, projectInfo.OutputName) };
 
             List<Dependency> dependencies = GetProjectDependencies(projectContext, dependencyLookup);
-
-            ResourceAssembly[] resourceAssemblies = projectInfo
-                .ResourceAssemblies
-                .Select(r => new ResourceAssembly(r.RelativePath, r.Culture))
-                .ToArray();
 
             return new RuntimeLibrary(
                 type: "project",
@@ -190,7 +193,7 @@ namespace Microsoft.NET.Build.Tasks
                 hash: string.Empty,
                 runtimeAssemblyGroups: runtimeAssemblyGroups,
                 nativeLibraryGroups: new RuntimeAssetGroup[] { },
-                resourceAssemblies: resourceAssemblies,
+                resourceAssemblies: CreateResourceAssemblies(projectInfo.ResourceAssemblies),
                 dependencies: dependencies.ToArray(),
                 serviceable: false);
         }
@@ -352,9 +355,7 @@ namespace Microsoft.NET.Build.Tasks
             if (targetLibrary.Type == "project")
             {
                 EnsureProjectInfo(referenceProjectInfo, targetLibrary.Name);
-                return referenceProjectInfo
-                    .ResourceAssemblies
-                    .Select(r => new ResourceAssembly(r.RelativePath, r.Culture));
+                return CreateResourceAssemblies(referenceProjectInfo.ResourceAssemblies);
             }
             else
             {
@@ -415,6 +416,44 @@ namespace Microsoft.NET.Build.Tasks
             }
 
             return Path.GetFileName(fullPath);
+        }
+
+        private IEnumerable<RuntimeLibrary> GetDirectReferenceRuntimeLibraries()
+        {
+            return _directReferences
+                ?.Select(r => new RuntimeLibrary(
+                    type: "reference",
+                    name: r.Name,
+                    version: r.Version,
+                    hash: string.Empty,
+                    runtimeAssemblyGroups: new[] { new RuntimeAssetGroup(string.Empty, r.FileName) },
+                    nativeLibraryGroups: new RuntimeAssetGroup[] { },
+                    resourceAssemblies: CreateResourceAssemblies(r.ResourceAssemblies),
+                    dependencies: Enumerable.Empty<Dependency>(),
+                    serviceable: false))
+                ??
+                Enumerable.Empty<RuntimeLibrary>();
+        }
+
+        private IEnumerable<CompilationLibrary> GetDirectReferenceCompilationLibraries()
+        {
+            return _directReferences
+                ?.Select(r => new CompilationLibrary(
+                    type: "reference",
+                    name: r.Name,
+                    version: r.Version,
+                    hash: string.Empty,
+                    assemblies: new[] { r.FileName },
+                    dependencies: Enumerable.Empty<Dependency>(),
+                    serviceable: false))
+                ??
+                Enumerable.Empty<CompilationLibrary>();
+        }
+
+        private static IEnumerable<ResourceAssembly> CreateResourceAssemblies(IEnumerable<ResourceAssemblyInfo> resourceAssemblyInfos)
+        {
+            return resourceAssemblyInfos
+                .Select(r => new ResourceAssembly(r.RelativePath, r.Culture));
         }
 
         private static void EnsureProjectInfo(SingleProjectInfo referenceProjectInfo, string libraryName)

--- a/src/Tasks/Microsoft.NET.Build.Tasks/DependencyContextBuilder.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/DependencyContextBuilder.cs
@@ -174,6 +174,15 @@ namespace Microsoft.NET.Build.Tasks
                 }
             }
 
+            var referenceInfos = Enumerable.Concat(
+                _frameworkReferences ?? Enumerable.Empty<ReferenceInfo>(),
+                _directReferences ?? Enumerable.Empty<ReferenceInfo>());
+
+            foreach (ReferenceInfo referenceInfo in referenceInfos)
+            {
+                dependencies.Add(new Dependency(referenceInfo.Name, referenceInfo.Version));
+            }
+
             return dependencies;
         }
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/GenerateDepsFile.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/GenerateDepsFile.cs
@@ -78,6 +78,9 @@ namespace Microsoft.NET.Build.Tasks
             IEnumerable<ReferenceInfo> frameworkReferences =
                 ReferenceInfo.CreateFrameworkReferenceInfos(ReferencePaths);
 
+            IEnumerable<ReferenceInfo> directReferences =
+                ReferenceInfo.CreateDirectReferenceInfos(ReferencePaths, ReferenceSatellitePaths);
+
             Dictionary<string, SingleProjectInfo> referenceProjects = SingleProjectInfo.CreateProjectReferenceInfos(
                 ReferencePaths,
                 ReferenceSatellitePaths);
@@ -91,6 +94,7 @@ namespace Microsoft.NET.Build.Tasks
 
             DependencyContext dependencyContext = new DependencyContextBuilder(mainProject, projectContext)
                 .WithFrameworkReferences(frameworkReferences)
+                .WithDirectReferences(directReferences)
                 .WithReferenceProjectInfos(referenceProjects)
                 .WithPrivateAssets(privateAssets)
                 .WithCompilationOptions(compilationOptions)

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ITaskItemExtensions.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ITaskItemExtensions.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using Microsoft.Build.Framework;
 
 namespace Microsoft.NET.Build.Tasks
@@ -19,6 +20,13 @@ namespace Microsoft.NET.Build.Tasks
             }
 
             return result;
+        }
+
+        public static bool HasMetadataValue(this ITaskItem item, string name, string expectedValue)
+        {
+            string value = item.GetMetadata(name);
+
+            return string.Equals(value, expectedValue, StringComparison.OrdinalIgnoreCase);
         }
     }
 }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ReferenceInfo.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ReferenceInfo.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using Microsoft.Build.Framework;
 
 namespace Microsoft.NET.Build.Tasks
@@ -13,12 +14,21 @@ namespace Microsoft.NET.Build.Tasks
         public string Name { get; }
         public string Version { get; }
         public string FullPath { get; }
+        public string FileName => Path.GetFileName(FullPath);
+
+        private List<ResourceAssemblyInfo> _resourceAssemblies;
+        public IEnumerable<ResourceAssemblyInfo> ResourceAssemblies
+        {
+            get { return _resourceAssemblies; }
+        }
 
         private ReferenceInfo(string name, string version, string fullPath)
         {
             Name = name;
             Version = version;
             FullPath = fullPath;
+
+            _resourceAssemblies = new List<ResourceAssemblyInfo>();
         }
 
         public static IEnumerable<ReferenceInfo> CreateFrameworkReferenceInfos(IEnumerable<ITaskItem> referencePaths)
@@ -30,21 +40,77 @@ namespace Microsoft.NET.Build.Tasks
             List<ReferenceInfo> frameworkReferences = new List<ReferenceInfo>();
             foreach (ITaskItem frameworkReferencePath in frameworkReferencePaths)
             {
-                string fullPath = frameworkReferencePath.ItemSpec;
-                string name = Path.GetFileNameWithoutExtension(fullPath);
-                string version = frameworkReferencePath.GetMetadata("Version");
-
-                if (string.IsNullOrEmpty(version))
-                {
-                    // ImplicitlyExpandDesignTimeFacades adds straight to reference path
-                    // without setting version metadata. Use 0.0.0.0 as placeholder.
-                    version = "0.0.0.0";
-                }
-
-                frameworkReferences.Add(new ReferenceInfo(name, version, fullPath));
+                frameworkReferences.Add(CreateReferenceInfo(frameworkReferencePath));
             }
 
             return frameworkReferences;
+        }
+
+        public static IEnumerable<ReferenceInfo> CreateDirectReferenceInfos(
+            IEnumerable<ITaskItem> referencePaths,
+            IEnumerable<ITaskItem> referenceSatellitePaths)
+        {
+            IEnumerable<ITaskItem> directReferencePaths = referencePaths
+                .Where(r => r.HasMetadataValue("CopyLocal", "true") &&
+                            r.HasMetadataValue("ReferenceSourceTarget", "ResolveAssemblyReference") &&
+                            string.IsNullOrEmpty(r.GetMetadata("NuGetSourceType")));
+
+            Dictionary<string, ReferenceInfo> directReferences = new Dictionary<string, ReferenceInfo>();
+            foreach (ITaskItem directReferencePath in directReferencePaths)
+            {
+                ReferenceInfo referenceInfo = CreateReferenceInfo(directReferencePath);
+                directReferences.Add(referenceInfo.FullPath, referenceInfo);
+            }
+
+            foreach (ITaskItem referenceSatellitePath in referenceSatellitePaths)
+            {
+                string originalItemSpec = referenceSatellitePath.GetMetadata("OriginalItemSpec");
+                if (!string.IsNullOrEmpty(originalItemSpec))
+                {
+                    ReferenceInfo referenceInfo;
+                    if (directReferences.TryGetValue(originalItemSpec, out referenceInfo))
+                    {
+                        ResourceAssemblyInfo resourceAssemblyInfo =
+                            ResourceAssemblyInfo.CreateFromReferenceSatellitePath(referenceSatellitePath);
+                        referenceInfo._resourceAssemblies.Add(resourceAssemblyInfo);
+                    }
+                }
+            }
+
+            return directReferences.Values;
+        }
+
+        private static ReferenceInfo CreateReferenceInfo(ITaskItem referencePath)
+        {
+            string fullPath = referencePath.ItemSpec;
+            string name = Path.GetFileNameWithoutExtension(fullPath);
+            string version = GetVersion(referencePath);
+
+            return new ReferenceInfo(name, version, fullPath);
+        }
+
+        private static string GetVersion(ITaskItem referencePath)
+        {
+            string version = referencePath.GetMetadata("Version");
+
+            if (string.IsNullOrEmpty(version))
+            {
+                string fusionName = referencePath.GetMetadata("FusionName");
+                if (!string.IsNullOrEmpty(fusionName))
+                {
+                    AssemblyName assemblyName = new AssemblyName(fusionName);
+                    version = assemblyName.Version.ToString();
+                }
+
+                if (string.IsNullOrEmpty(version))
+                {
+                    // Use 0.0.0.0 as placeholder, if we can't find a version any
+                    // other way
+                    version = "0.0.0.0";
+                }
+            }
+
+            return version;
         }
     }
 }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResourceAssemblyInfo.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResourceAssemblyInfo.cs
@@ -1,6 +1,9 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.IO;
+using Microsoft.Build.Framework;
+
 namespace Microsoft.NET.Build.Tasks
 {
     public class ResourceAssemblyInfo
@@ -12,6 +15,16 @@ namespace Microsoft.NET.Build.Tasks
         {
             Culture = culture;
             RelativePath = relativePath;
+        }
+
+        public static ResourceAssemblyInfo CreateFromReferenceSatellitePath(ITaskItem referenceSatellitePath)
+        {
+            string destinationSubDirectory = referenceSatellitePath.GetMetadata("DestinationSubDirectory");
+
+            string culture = destinationSubDirectory.Trim('\\', '/');
+            string relativePath = Path.Combine(destinationSubDirectory, Path.GetFileName(referenceSatellitePath.ItemSpec));
+
+            return new ResourceAssemblyInfo(culture, relativePath);
         }
     }
 }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/SingleProjectInfo.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/SingleProjectInfo.cs
@@ -92,12 +92,9 @@ namespace Microsoft.NET.Build.Tasks
                 SingleProjectInfo referenceProjectInfo;
                 if (projectReferences.TryGetValue(sourceProjectFile, out referenceProjectInfo))
                 {
-                    string destinationSubDirectory = projectReferenceSatellitePath.GetMetadata("DestinationSubDirectory");
-
-                    string culture = destinationSubDirectory.Trim('\\', '/');
-                    string relativePath = Path.Combine(destinationSubDirectory, Path.GetFileName(projectReferenceSatellitePath.ItemSpec));
-
-                    referenceProjectInfo._resourceAssemblies.Add(new ResourceAssemblyInfo(culture, relativePath));
+                    ResourceAssemblyInfo resourceAssemblyInfo =
+                        ResourceAssemblyInfo.CreateFromReferenceSatellitePath(projectReferenceSatellitePath);
+                    referenceProjectInfo._resourceAssemblies.Add(resourceAssemblyInfo);
                 }
             }
 

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildANetCoreApp.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildANetCoreApp.cs
@@ -35,27 +35,15 @@ namespace Microsoft.NET.Build.Tests
             {
                 Name = "SharedFrameworkTest",
                 TargetFrameworks = targetFramework,
+                RuntimeFrameworkVersion = runtimeFrameworkVersion,
                 IsSdkProject = true,
                 IsExe = true
             };
 
             string testIdentifier = string.Join("_", targetFramework, runtimeFrameworkVersion ?? "null");
 
-            var testAsset = _testAssetsManager.CreateTestProject(testProject, nameof(It_targets_the_right_shared_framework), testIdentifier);
-
-            testAsset = testAsset.WithProjectChanges(project =>
-            {
-                var ns = project.Root.Name.Namespace;
-                var propertyGroup = new XElement(ns + "PropertyGroup");
-                project.Root.Add(propertyGroup);
-
-                if (runtimeFrameworkVersion != null)
-                {
-                    propertyGroup.Add(new XElement(ns + "RuntimeFrameworkVersion", runtimeFrameworkVersion));
-                }
-            });
-
-            testAsset = testAsset.Restore(testProject.Name);
+            var testAsset = _testAssetsManager.CreateTestProject(testProject, nameof(It_targets_the_right_shared_framework), testIdentifier)
+                .Restore(testProject.Name);
 
             var buildCommand = new BuildCommand(Stage0MSBuild, Path.Combine(testAsset.TestRoot, testProject.Name));
 

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToReferenceAnAssembly.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToReferenceAnAssembly.cs
@@ -1,0 +1,104 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using FluentAssertions;
+using Microsoft.DotNet.Cli.Utils;
+using Microsoft.NET.TestFramework;
+using Microsoft.NET.TestFramework.Assertions;
+using Microsoft.NET.TestFramework.Commands;
+using Microsoft.NET.TestFramework.ProjectConstruction;
+using static Microsoft.NET.TestFramework.Commands.MSBuildTest;
+using Xunit;
+
+namespace Microsoft.NET.Build.Tests
+{
+    public class GivenThatWeWantToReferenceAnAssembly : SdkTest
+    {
+        [Theory]
+        [InlineData("netcoreapp2.0", "net40")]
+        [InlineData("netcoreapp2.0", "netstandard1.5")]
+        [InlineData("netcoreapp2.0", "netcoreapp1.0")]
+        public void ItRunsAppsDirectlyReferencingAssemblies(
+            string referencerTarget, 
+            string dependencyTarget)
+        {
+            string identifier = referencerTarget.ToString() + "_" + dependencyTarget.ToString();
+
+            TestProject dependencyProject = new TestProject()
+            {
+                Name = "Dependency",
+                IsSdkProject = true,
+                TargetFrameworks = dependencyTarget,
+            };
+
+            //  Skip running test if not running on Windows
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !dependencyProject.BuildsOnNonWindows)
+            {
+                return;
+            }
+
+            dependencyProject.SourceFiles["Class1.cs"] = @"
+public class Class1
+{
+    public static string GetMessage()
+    {
+        return ""Hello from a direct reference."";
+    }
+}
+";
+
+            var dependencyAsset = _testAssetsManager.CreateTestProject(dependencyProject, identifier: identifier);
+            string dependencyAssemblyPath = RestoreAndBuild(dependencyAsset, dependencyProject);
+
+            TestProject referencerProject = new TestProject()
+            {
+                Name = "Referencer",
+                IsSdkProject = true,
+                TargetFrameworks = referencerTarget,
+                RuntimeFrameworkVersion = RepoInfo.NetCoreApp20Version,
+                // Need to use a self-contained app for now because we don't use a CLI that has a "2.0" shared framework
+                RuntimeIdentifier = EnvironmentInfo.GetCompatibleRid(referencerTarget),
+                IsExe = true,
+            };
+            referencerProject.References.Add(dependencyAssemblyPath);
+
+            referencerProject.SourceFiles["Program.cs"] = @"
+using System;
+public static class Program
+{
+    public static void Main()
+    {
+        Console.WriteLine(Class1.GetMessage());
+    }
+}
+";
+
+            var referencerAsset = _testAssetsManager.CreateTestProject(referencerProject,  identifier: identifier);
+            string applicationPath = RestoreAndBuild(referencerAsset, referencerProject);
+
+            Command.Create(RepoInfo.DotNetHostPath, new[] { applicationPath })
+                .CaptureStdOut()
+                .Execute()
+                .Should().Pass()
+                .And.HaveStdOutContaining("Hello from a direct reference.");
+        }
+
+        private static string RestoreAndBuild(TestAsset testAsset, TestProject testProject)
+        {
+            testAsset.Restore(testProject.Name);
+
+            var buildCommand = new BuildCommand(Stage0MSBuild, Path.Combine(testAsset.TestRoot, testProject.Name));
+
+            buildCommand.Execute()
+                .Should()
+                .Pass();
+
+            var outputDirectory = buildCommand.GetOutputDirectory(testProject.TargetFrameworks);
+            return Path.Combine(outputDirectory.FullName, testProject.Name + ".dll");
+        }
+    }
+}

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToReferenceAnAssembly.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToReferenceAnAssembly.cs
@@ -23,7 +23,7 @@ namespace Microsoft.NET.Build.Tests
         [InlineData("netcoreapp2.0", "netstandard1.5")]
         [InlineData("netcoreapp2.0", "netcoreapp1.0")]
         public void ItRunsAppsDirectlyReferencingAssemblies(
-            string referencerTarget, 
+            string referencerTarget,
             string dependencyTarget)
         {
             string identifier = referencerTarget.ToString() + "_" + dependencyTarget.ToString();
@@ -77,7 +77,7 @@ public static class Program
 }
 ";
 
-            var referencerAsset = _testAssetsManager.CreateTestProject(referencerProject,  identifier: identifier);
+            var referencerAsset = _testAssetsManager.CreateTestProject(referencerProject, identifier: identifier);
             string applicationPath = RestoreAndBuild(referencerAsset, referencerProject);
 
             Command.Create(RepoInfo.DotNetHostPath, new[] { applicationPath })
@@ -97,7 +97,9 @@ public static class Program
                 .Should()
                 .Pass();
 
-            var outputDirectory = buildCommand.GetOutputDirectory(testProject.TargetFrameworks);
+            var outputDirectory = buildCommand.GetOutputDirectory(
+                testProject.TargetFrameworks,
+                runtimeIdentifier: testProject.RuntimeIdentifier);
             return Path.Combine(outputDirectory.FullName, testProject.Name + ".dll");
         }
     }

--- a/test/Microsoft.NET.Build.Tests/Microsoft.NET.Build.Tests.csproj
+++ b/test/Microsoft.NET.Build.Tests/Microsoft.NET.Build.Tests.csproj
@@ -6,6 +6,7 @@
     <ProjectGuid>{EC640B7E-332E-40A2-BB6E-5B7EC788F315}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
+    <AssemblyName>Microsoft.NET.Build.Tests</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetFramework>netstandard1.6</TargetFramework>
     <PackageTargetFallback>dotnet5.4;portable-net451+win8</PackageTargetFallback>

--- a/test/Microsoft.NET.TestFramework/Commands/TestCommand.cs
+++ b/test/Microsoft.NET.TestFramework/Commands/TestCommand.cs
@@ -46,6 +46,10 @@ namespace Microsoft.NET.TestFramework.Commands
 
         public virtual DirectoryInfo GetOutputDirectory(string targetFramework, string configuration = "Debug", string runtimeIdentifier = "")
         {
+            targetFramework = targetFramework ?? string.Empty;
+            configuration = configuration ?? string.Empty;
+            runtimeIdentifier = runtimeIdentifier ?? string.Empty;
+
             string output = Path.Combine(ProjectRootPath, "bin", configuration, targetFramework, runtimeIdentifier);
             return new DirectoryInfo(output);
         }

--- a/test/Microsoft.NET.TestFramework/ProjectConstruction/TestProject.cs
+++ b/test/Microsoft.NET.TestFramework/ProjectConstruction/TestProject.cs
@@ -18,10 +18,16 @@ namespace Microsoft.NET.TestFramework.ProjectConstruction
         //  Applies to SDK Projects
         public string TargetFrameworks { get; set; }
 
+        public string RuntimeFrameworkVersion { get; set; }
+
+        public string RuntimeIdentifier { get; set; }
+
         //  TargetFrameworkVersion applies to non-SDK projects
         public string TargetFrameworkVersion { get; set; }
 
         public List<TestProject> ReferencedProjects { get; } = new List<TestProject>();
+
+        public List<string> References { get; } = new List<string>();
 
         public Dictionary<string, string> SourceFiles { get; } = new Dictionary<string, string>();
 
@@ -129,6 +135,16 @@ namespace Microsoft.NET.TestFramework.ProjectConstruction
                     propertyGroup.Add(new XElement(ns + "TargetFramework", this.TargetFrameworks));
                 }
 
+                if (!string.IsNullOrEmpty(this.RuntimeFrameworkVersion))
+                {
+                    propertyGroup.Add(new XElement(ns + "RuntimeFrameworkVersion", this.RuntimeFrameworkVersion));
+                }
+
+                if (!string.IsNullOrEmpty(this.RuntimeIdentifier))
+                {
+                    propertyGroup.Add(new XElement(ns + "RuntimeIdentifier", this.RuntimeIdentifier));
+                }
+
                 if (this.IsExe && targetFrameworks.Any(identifier => GetShortTargetFrameworkIdentifier(identifier).Equals("net", StringComparison.OrdinalIgnoreCase)))
                 {
                     propertyGroup.Add(new XElement(ns + "RuntimeIdentifier", "win7-x86"));
@@ -163,6 +179,23 @@ namespace Microsoft.NET.TestFramework.ProjectConstruction
                 {
                     projectReferenceItemGroup.Add(new XElement(ns + "ProjectReference",
                         new XAttribute("Include", $"../{referencedProject.Name}/{referencedProject.Name}.csproj")));
+                }
+            }
+
+            if (this.References.Any())
+            {
+                var referenceItemGroup = projectXml.Root.Elements(ns + "ItemGroup")
+                    .FirstOrDefault(itemGroup => itemGroup.Elements(ns + "Reference").Count() > 0);
+                if (referenceItemGroup == null)
+                {
+                    referenceItemGroup = new XElement(ns + "ItemGroup");
+                    packageReferenceItemGroup.AddBeforeSelf(referenceItemGroup);
+                }
+
+                foreach (var reference in References)
+                {
+                    referenceItemGroup.Add(new XElement(ns + "Reference",
+                        new XAttribute("Include", reference)));
                 }
             }
 

--- a/test/Microsoft.NET.TestFramework/RepoInfo.cs
+++ b/test/Microsoft.NET.TestFramework/RepoInfo.cs
@@ -3,6 +3,8 @@
 
 using System;
 using System.IO;
+using System.Linq;
+using System.Xml.Linq;
 using Microsoft.DotNet.Cli.Utils;
 
 namespace Microsoft.NET.TestFramework
@@ -76,6 +78,28 @@ namespace Microsoft.NET.TestFramework
             {
                 return Path.Combine(RepoRoot, ".dotnet_cli", $"dotnet{Constants.ExeSuffix}");
             }
+        }
+
+        public static string NetCoreApp20Version { get; } = ReadNetCoreApp20Version();
+
+        private static string ReadNetCoreApp20Version()
+        {
+            var dependencyVersionsPath = Path.Combine(RepoRoot, "build", "DependencyVersions.props");
+            var root = XDocument.Load(dependencyVersionsPath).Root;
+            var ns = root.Name.Namespace;
+
+            var version = root
+                .Elements(ns + "PropertyGroup")
+                .Elements(ns + "MicrosoftNETCoreApp20Version")
+                .FirstOrDefault()
+                ?.Value;
+
+            if (string.IsNullOrEmpty(version))
+            {
+                throw new InvalidOperationException($"Could not find a property named 'MicrosoftNETCoreApp20Version' in {dependencyVersionsPath}");
+            }
+
+            return version;
         }
 
         private static string FindConfigurationInBasePath()


### PR DESCRIPTION
Fix #120 

The necessary change to the product is to generate the correct .deps.json file.  We were already copying the reference assembly and supporting files into the build/publish folder.

Note this doesn't attempt to fix 'dotnet pack' for this scenario.  That will be up to the NuGet team.

@nguerrera @dsplaisted @srivatsn 

/cc @terrajobst 