### PR TITLE
Use dotnet-install from cli's master branch

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -48,7 +48,7 @@ if ($Verbosity -eq 'diagnostic') {
 }
 
 # Install a stage 0
-$DOTNET_INSTALL_SCRIPT_URL="https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/dotnet-install.ps1"
+$DOTNET_INSTALL_SCRIPT_URL="https://raw.githubusercontent.com/dotnet/cli/master/scripts/obtain/dotnet-install.ps1"
 Invoke-WebRequest $DOTNET_INSTALL_SCRIPT_URL -OutFile "$env:DOTNET_INSTALL_DIR\dotnet-install.ps1"
 
 & "$env:DOTNET_INSTALL_DIR\dotnet-install.ps1" -Version $DotnetCLIVersion $dotnetInstallVerbosity

--- a/build.sh
+++ b/build.sh
@@ -68,7 +68,7 @@ export NUGET_PACKAGES="$REPOROOT/packages"
 [ -d "$DOTNET_INSTALL_DIR" ] || mkdir -p $DOTNET_INSTALL_DIR
 
 # Install a stage 0
-DOTNET_INSTALL_SCRIPT_URL="https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/dotnet-install.sh"
+DOTNET_INSTALL_SCRIPT_URL="https://raw.githubusercontent.com/dotnet/cli/master/scripts/obtain/dotnet-install.sh"
 curl -sSL "$DOTNET_INSTALL_SCRIPT_URL" | bash /dev/stdin  --version $DOTNET_CLI_VERSION --verbose
 
 # Put stage 0 on the PATH


### PR DESCRIPTION
This verison of dotnet-install supports more operating systems and lets us install a working dotnet cli that supports building sdk on more operating systems and versions.

As an example, currently this gets us a working cli on RHEL 7.3, which isn't possible with the dotnet-install script on the cli's rel/1.0.0 branch.

I am also making related changes in other repos, including cli: https://github.com/dotnet/cli/pull/5686