### PR TITLE
Update TestPlatform to v15.0.0-preview-20170222-09.

### DIFF
--- a/src/Templates/ProjectTemplates/CSharp/.NETCore/CSharpUnitTest/ProjectTemplate.csproj
+++ b/src/Templates/ProjectTemplates/CSharp/.NETCore/CSharpUnitTest/ProjectTemplate.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0-preview-20170217-05" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0-preview-20170222-09" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.1.11" />
     <PackageReference Include="MSTest.TestFramework" Version="1.1.11" />
   </ItemGroup>

--- a/src/Templates/ProjectTemplates/CSharp/.NETCore/CSharpXUnitTest/ProjectTemplate.csproj
+++ b/src/Templates/ProjectTemplates/CSharp/.NETCore/CSharpXUnitTest/ProjectTemplate.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0-preview-20170217-05" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0-preview-20170222-09" />
     <PackageReference Include="xunit" Version="2.2.0-rc2-build3523" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0-rc2-build1249" />
   </ItemGroup>


### PR DESCRIPTION
Fixes included in this release:
- Performance: provide `DeisgnMode` flag for adapters to distinguish IDE and CLI runs (Microsoft/vstest#349)
- If test code uses TypeDescriptors, string[] are not converted as expected (Microsoft/vstest#427)
- Navigation to test from test explorer is broken if user has new roslyn based test project targeting desktop (Microsoft/vstest#523)

Ask mode template: [Bug 387252](https://devdiv.visualstudio.com/DevDiv/VS.in%20Agile%20Testing%20IDE/_workitems?id=387252&_a=edit)

These fixes are required for RTW, pending shiproom approval of above bug.