### PR TITLE
Prevent ignored error in appx -> cross-targeted case

### DIFF
--- a/TestAssets/TestProjects/AppxReferencingCrossTargeting/Appx/Appx.csproj
+++ b/TestAssets/TestProjects/AppxReferencingCrossTargeting/Appx/Appx.csproj
@@ -9,8 +9,14 @@
     <ProjectReference Include="../CrossTargeted/CrossTargeted.csproj" />
   </ItemGroup>
  
-  <!-- Mimic enough of Microsoft.AppxPackage.targets to get regression coverage
-       for the scenario without OS or VS workload dependencies -->
+  <!--
+    Mimic enough of Microsoft.AppxPackage.targets to get regression coverage
+    for the scenario without OS or VS workload dependencies. One important
+    distinction between this mock implementation and the real implementation
+    is that we never continue on error here, which allows the correspodning
+    unit test to check for successful binding to GetPackagingOutputs as simply
+    build pass vs. fail.
+  -->
   <Target Name="GetPackagingOutputsOfProjectReferences" 
           AfterTargets="Build"
           DependsOnTargets="AssignProjectConfiguration;_SplitProjectReferencesByFileExistence">

--- a/TestAssets/TestProjects/AppxReferencingCrossTargeting/Appx/Appx.csproj
+++ b/TestAssets/TestProjects/AppxReferencingCrossTargeting/Appx/Appx.csproj
@@ -1,0 +1,28 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../CrossTargeted/CrossTargeted.csproj" />
+  </ItemGroup>
+ 
+  <!-- Mimic enough of Microsoft.AppxPackage.targets to get regression coverage
+       for the scenario without OS or VS workload dependencies -->
+  <Target Name="GetPackagingOutputsOfProjectReferences" 
+          AfterTargets="Build"
+          DependsOnTargets="AssignProjectConfiguration;_SplitProjectReferencesByFileExistence">
+    <MSBuild
+      Projects="@(ProjectReferenceWithConfiguration)"
+      Targets="GetPackagingOutputs"
+      BuildInParallel="$(BuildInParallel)"
+      Properties="%(ProjectReferenceWithConfiguration.SetConfiguration); %(ProjectReferenceWithConfiguration.SetPlatform)"
+      Condition="'@(ProjectReferenceWithConfiguration)' != ''
+                 and '%(ProjectReferenceWithConfiguration.BuildReference)' == 'true' 
+                 and '%(ProjectReferenceWithConfiguration.ReferenceOutputAssembly)' == 'true'">
+      <Output TaskParameter="TargetOutputs" ItemName="_PackagingOutputsFromOtherProjects" />
+    </MSBuild>
+  </Target>
+</Project>

--- a/TestAssets/TestProjects/AppxReferencingCrossTargeting/Appx/Program.cs
+++ b/TestAssets/TestProjects/AppxReferencingCrossTargeting/Appx/Program.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace ConsoleApplication
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            Console.WriteLine(CrossTargeted.Class.Hello);
+        }
+    }
+}

--- a/TestAssets/TestProjects/AppxReferencingCrossTargeting/CrossTargeted/CrossTargeted.cs
+++ b/TestAssets/TestProjects/AppxReferencingCrossTargeting/CrossTargeted/CrossTargeted.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace CrossTargeted
+{
+    public class Class
+    {
+        public static string Hello => "Hello";
+    }
+}

--- a/TestAssets/TestProjects/AppxReferencingCrossTargeting/CrossTargeted/CrossTargeted.csproj
+++ b/TestAssets/TestProjects/AppxReferencingCrossTargeting/CrossTargeted/CrossTargeted.csproj
@@ -1,0 +1,5 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp1.0;netstandard1.4</TargetFrameworks>
+  </PropertyGroup>
+</Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/buildCrossTargeting/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/buildCrossTargeting/Microsoft.NET.Sdk.targets
@@ -98,11 +98,11 @@ Copyright (c) .NET Foundation. All rights reserved.
   Furthermore, the appx targets currently use continue-on-error
   such that even without this, clean builds succeed but log an 
   error and incremental builds silently succeed. As such, this 
-  simplyr emoves a confounding error from successful clean
+  simply removes a confounding error from successful clean
   builds.
 
   ============================================================
   -->
-<Target Name="GetPackagingOutputs" />
+  <Target Name="GetPackagingOutputs" />
 
 </Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/buildCrossTargeting/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/buildCrossTargeting/Microsoft.NET.Sdk.targets
@@ -73,4 +73,36 @@ Copyright (c) .NET Foundation. All rights reserved.
     </PropertyGroup>
   </Target>
 
+  <!--
+  ============================================================
+                       GetPackagingOutputs
+
+  Stub cross-targeting implementation of GetPackagingOutputs 
+  to allow project references from from projects that pull in 
+  Microsoft.AppxPackage.targets (UWP, PCL) to cross-targeted
+  projects.
+
+  Ultimately, the appx targets should be modified to use the
+  same P2P TFM negotiation protocol as Microsoft.Common.targets
+  so that they can forward to the TFM-specific GetPackagingOutputs
+  of the appropriate inner build. This stub would not have any
+  bad interaction with that change, which would happily bypass
+  this implementation altogether.
+
+  An empty GetPackagingOutputs is sufficient for the common
+  case of a library with no special assets to contribute to
+  the appx and is also equivalent to what is present in the
+  single-targeted case unless WindowsAppContainer is not set 
+  to true.
+
+  Furthermore, the appx targets currently use continue-on-error
+  such that even without this, clean builds succeed but log an 
+  error and incremental builds silently succeed. As such, this 
+  simplyr emoves a confounding error from successful clean
+  builds.
+
+  ============================================================
+  -->
+<Target Name="GetPackagingOutputs" />
+
 </Project>

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAnAppWithLibrary.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAnAppWithLibrary.cs
@@ -201,5 +201,21 @@ namespace Microsoft.NET.Build.Tests
             outputDirectory.Should().OnlyHaveFiles(Array.Empty<string>());
 
         }
+
+        [Fact]
+        public void An_appx_app_can_reference_a_cross_targeted_library()
+        {
+            var asset = _testAssetsManager
+                .CopyTestAsset("AppxReferencingCrossTargeting")
+                .WithSource()
+                .Restore("Appx");
+
+            var buildCommand = new BuildCommand(Stage0MSBuild, Path.Combine(asset.TestRoot, "Appx"));
+
+            buildCommand
+                .Execute()
+                .Should()
+                .Pass();
+        }
     }
 }


### PR DESCRIPTION
**Customer scenario**

Referencing cross-targeted project from PCL or UWP app. An error is logged in output/error list, but build succeeds and F5 works.

**Bugs this fixes:**

https://github.com/dotnet/sdk/issues/707

**Workarounds, if any**

* Add the empty target to the cross-targeted project manually.

**Risk**

Low. This change is scoped to cross-targeted projects only and merely stubs out target that would not otherwise be defined. It unblocks the basic Appx -> Cross-targeted lib scenarios. There are other scenarios involving contributing content and more than one level of P2P interdependency that would rely on a full-fledged GetPackagingOutputs. Those would need work in appx target projects for cross-targeting case (filed internal bugs for that) and require user to set WindowsAppContainer=true manually even in single-targeted case. Those can be worked around and are out of scope for RTM, but this change at least prevents a confounding error in a successful build that runs and packages fine in common cases.


**Performance impact**

None.

**Is this a regression from a previous update?**

No

**Root cause analysis:**

The fact that the build succeeded with an error logged, but then incremental build passed let this go undetected longer than it should have been.


**How was the bug found?**

Customer reported
