### PR TITLE
Use windows PDB for symweb compat

### DIFF
--- a/Common.props
+++ b/Common.props
@@ -22,6 +22,9 @@
     <PackagesLayoutToolsNet46Dir>$(PackagesLayoutToolsDir)net46\</PackagesLayoutToolsNet46Dir>
     <PackagesLayoutToolsNetCoreAppDir>$(PackagesLayoutToolsDir)netcoreapp1.0\</PackagesLayoutToolsNetCoreAppDir>
 
+    <!-- We must use Windows PDB format (overriding SDK default) in order to send symbols to symweb -->
+    <DebugType>full</DebugType>
+
     <!-- Reset $(BuildEpoch) whenever $(VersionPrefix) increments. We subtract this from YYYYMMDD portion of build
          number below to obtain the fourth part of file version that must fit in 16 bits. We can produce builds 
          for seven years from every epoch reset. -->


### PR DESCRIPTION
**Customer scenario**

Symbols for the SDK tasks dll are not on symweb. And they are currently in incompatible portable format. Without this, we may have difficulty locating appropriate symbols to diagnose customer-reported issues.

**Bugs this fixes:**

#897 (there also need to be build definition changes to automate the uploading)

**Workarounds, if any**

Go locate the portable PDB manually from the raw build drop when debugging. 

**Risk**

Low. Only PDB is changed. No product code is affected.

**Performance impact**

None. Again, only PDB is impacted.

**Is this a regression from a previous update?**

No. We may have built with windows PDB prior to self-hosting SDK build on SDK but that started quite a while ago. Regardless, the build definition has never uploaded symbols to symweb.

**Root cause analysis:**

We did not consider the symweb impact of using SDK defaults, which we are dogfooding.

**How was the bug found?**

Dogfooding

@srivatsn @tmat @333fred 