### PR TITLE
Remove duplicate import

### DIFF
--- a/build/Targets/ProducesNoOutput.Settings.props
+++ b/build/Targets/ProducesNoOutput.Settings.props
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'Common.props'))\Common.props" />
   <PropertyGroup>
     <TargetFrameworkIdentifier>.NETCoreApp</TargetFrameworkIdentifier>
     <TargetFrameworkVersion>v1.0</TargetFrameworkVersion>


### PR DESCRIPTION
Common.props is already pulled in by Directory.build.props, which is triggering a build warning.

@dsplaisted 