### PR TITLE
Add default configs to be consumed by the new schema

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.props
@@ -119,7 +119,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <GenerateResourceMSBuildRuntime>CurrentRuntime</GenerateResourceMSBuildRuntime>
   </PropertyGroup>
 
-  <!-- Workaround: https://github.com/Microsoft/msbuild/issues/1878 -->
+  <!-- Workaround: https://github.com/dotnet/sdk/issues/1001 -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "/>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' "/>
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.props
@@ -119,6 +119,10 @@ Copyright (c) .NET Foundation. All rights reserved.
     <GenerateResourceMSBuildRuntime>CurrentRuntime</GenerateResourceMSBuildRuntime>
   </PropertyGroup>
 
+  <!-- Workaround: https://github.com/Microsoft/msbuild/issues/1878 -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "/>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' "/>
+
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.NET.Sdk.CSharp.props" Condition="'$(MSBuildProjectExtension)' == '.csproj'" />
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.NET.Sdk.VisualBasic.props" Condition="'$(MSBuildProjectExtension)' == '.vbproj'" />
 </Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.props
@@ -17,20 +17,11 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <!-- Default configuration and platform to Debug|AnyCPU--> 
   <PropertyGroup>
+    <Configurations Condition=" '$(Configurations)' == '' ">Debug;Release</Configurations>
+    <Platforms Condition=" '$(Platforms)' == '' ">AnyCPU</Platforms>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
   </PropertyGroup>
-
-  <!--
-    Ensure VS sees two default configurations: Debug|AnyCPU and Release|AnyCPU
-
-    This is temporary until we have designed and implemented a new configuration management scheme,
-    which is tracked by https://github.com/dotnet/sdk/issues/350. In the meantime, one consequence of
-    defining these defaults here with the old inference-from-usage scheme here is that the user cannot
-    remove or rename them.
-  -->
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "/>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' "/>
 
   <!-- User-facing configuration-agnostic defaults -->
   <PropertyGroup>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.targets
@@ -434,11 +434,4 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   </Target>
 
-
-  <!-- Remove the ProjectConfigurationsInferredFromUsage included in the C#/VB targets so that it doesn't
-       collides with ProjectConfigurationsDeclaredDimensions. This should be removed from those targets
-       directly but those come from a different repo so until all changes meet remove the capability here-->
-  <ItemGroup>
-    <ProjectCapability Remove="ProjectConfigurationsInferredFromUsage" />
-  </ItemGroup>
 </Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.targets
@@ -433,5 +433,12 @@ Copyright (c) .NET Foundation. All rights reserved.
     <Message Importance="Low" Text="Including @(ReferencePath)" Condition="'%(ReferencePath.ResolvedFrom)' == 'ImplicitlyExpandDesignTimeFacades'" />
 
   </Target>
-  
+
+
+  <!-- Remove the ProjectConfigurationsInferredFromUsage included in the C#/VB targets so that it doesn't
+       collides with ProjectConfigurationsDeclaredDimensions. This should be removed from those targets
+       directly but those come from a different repo so until all changes meet remove the capability here-->
+  <ItemGroup>
+    <ProjectCapability Remove="ProjectConfigurationsInferredFromUsage" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
Add defaults using the new Configs and Platforms properties.

Note: This depends on https://github.com/dotnet/roslyn-project-system/pull/1591 which in turns depends on a CPS insertion happening sometime this week.