### PR TITLE
Lock down public surface

### DIFF
--- a/Common.props
+++ b/Common.props
@@ -67,8 +67,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <!-- Assembly signing isn't supported by non-Windows MSBuild. Disable until supported. See #55 (https://github.com/dotnet/sdk/issues/55) -->
-    <SignAssembly Condition="'$(OS)'=='Windows_NT'">true</SignAssembly>
+    <SignAssembly>true</SignAssembly>
   </PropertyGroup>
 
   <Import Project="build\DependencyVersions.props" />

--- a/build/Targets/Signing.Imports.targets
+++ b/build/Targets/Signing.Imports.targets
@@ -54,6 +54,8 @@
         <!-- Non-shipping binaries are simply signed with the Roslyn internal key. -->
         <Otherwise>
           <PropertyGroup>
+            <!-- Public sign on non-Windows as full signing isn't currently supported (https://github.com/dotnet/roslyn/issues/8210) -->
+            <PublicSign Condition="'$(OS)' != 'Windows_NT'">true</PublicSign>
             <AssemblyOriginatorKeyFile>$(BuildDirPath)Strong Name Keys\RoslynInternalKey.Private.snk</AssemblyOriginatorKeyFile>
             <DelaySign>false</DelaySign>
             <PublicKey>$(RoslynInternalKey)</PublicKey>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/CacheArtifactParser.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/CacheArtifactParser.cs
@@ -10,9 +10,7 @@ using System.Xml.Linq;
 using NuGet.Versioning;
 using NuGet.Packaging.Core;
 
-#if PRODUCT
 using Microsoft.Build.Framework;
-#endif
 
 namespace Microsoft.NET.Build.Tasks
 {
@@ -26,12 +24,12 @@ namespace Microsoft.NET.Build.Tasks
             var listofPackages = new HashSet<PackageIdentity>();
             var doc = XDocument.Load(filterFile);
             var rootName = doc.Root.Name;
-#if PRODUCT
+
             if (!rootName.LocalName.Equals("CacheArtifacts"))
             {
                 throw new BuildErrorException(Strings.IncorrectFilterFormat, filterFile);
             }
-#endif
+
             var ns = rootName.Namespace;
 
             foreach (var pkginfo in doc.Root.Elements(ns + "Package"))

--- a/src/Tasks/Microsoft.NET.Build.Tasks/DependencyContextBuilder.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/DependencyContextBuilder.cs
@@ -15,7 +15,7 @@ using NuGet.ProjectModel;
 
 namespace Microsoft.NET.Build.Tasks
 {
-    public class DependencyContextBuilder
+    internal class DependencyContextBuilder
     {
         private readonly VersionFolderPathResolver _versionFolderPathResolver;
         private readonly SingleProjectInfo _mainProjectInfo;

--- a/src/Tasks/Microsoft.NET.Build.Tasks/DependencyType.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/DependencyType.cs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.NET.Build.Tasks
 {
-    public enum DependencyType
+    internal enum DependencyType
     {
         Unknown,
         Target,

--- a/src/Tasks/Microsoft.NET.Build.Tasks/DiagnosticMessageSeverity.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/DiagnosticMessageSeverity.cs
@@ -6,7 +6,7 @@ namespace Microsoft.NET.Build.Tasks
     /// <summary>
     /// Specifies the severity of Diagnostic Messages
     /// </summary>
-    public enum DiagnosticMessageSeverity
+    internal enum DiagnosticMessageSeverity
     {
         Info,
         Warning,

--- a/src/Tasks/Microsoft.NET.Build.Tasks/DiagnosticsHelper.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/DiagnosticsHelper.cs
@@ -11,7 +11,7 @@ namespace Microsoft.NET.Build.Tasks
     /// Writes diagnostic messages to the task log and creates diagnostic task items 
     /// that can be returned from a task
     /// </summary>
-    public sealed class DiagnosticsHelper
+    internal sealed class DiagnosticsHelper
     {
         private readonly List<ITaskItem> _diagnosticMessages = new List<ITaskItem>();
         private readonly TaskLoggingHelper _log;

--- a/src/Tasks/Microsoft.NET.Build.Tasks/FileGroup.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/FileGroup.cs
@@ -13,7 +13,7 @@ namespace Microsoft.NET.Build.Tasks
     /// <summary>
     /// Values for File Group Metadata corresponding to the groups in a target library
     /// </summary>
-    public enum FileGroup
+    internal enum FileGroup
     {
         CompileTimeAssembly,
         RuntimeAssembly,
@@ -24,7 +24,7 @@ namespace Microsoft.NET.Build.Tasks
         FrameworkAssembly
     }
 
-    public static class FileGroupExtensions
+    internal static class FileGroupExtensions
     {
         private static readonly IDictionary<string, string> _emptyProperties = new Dictionary<string, string>();
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/IContentAssetPreprocessor.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/IContentAssetPreprocessor.cs
@@ -8,7 +8,7 @@ namespace Microsoft.NET.Build.Tasks
     /// <summary>
     /// Resource for reading, processing and writing content assets
     /// </summary>
-    public interface IContentAssetPreprocessor
+    internal interface IContentAssetPreprocessor
     {
         /// <summary>
         /// Configure the preprocessor with a base outputDirectory and the tokens/value 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/IPackageResolver.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/IPackageResolver.cs
@@ -5,7 +5,7 @@ using NuGet.Versioning;
 
 namespace Microsoft.NET.Build.Tasks
 {
-    public interface IPackageResolver
+    internal interface IPackageResolver
     {
         string GetPackageDirectory(string packageId, NuGetVersion version);
         string GetPackageDirectory(string packageId, NuGetVersion version, out string packageRoot);

--- a/src/Tasks/Microsoft.NET.Build.Tasks/LockFileExtensions.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/LockFileExtensions.cs
@@ -10,7 +10,7 @@ using NuGet.ProjectModel;
 
 namespace Microsoft.NET.Build.Tasks
 {
-    public static class LockFileExtensions
+    internal static class LockFileExtensions
     {
         public static ProjectContext CreateProjectContext(
             this LockFile lockFile,

--- a/src/Tasks/Microsoft.NET.Build.Tasks/MetadataKeys.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/MetadataKeys.cs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.NET.Build.Tasks
 {
-    public static class MetadataKeys
+    internal static class MetadataKeys
     {
         // General Metadata
         public const string Name = "Name";

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Microsoft.NET.Build.Tasks.csproj
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Microsoft.NET.Build.Tasks.csproj
@@ -15,7 +15,6 @@
     <GenerateDependencyFile>false</GenerateDependencyFile>
     <EnableDefaultItems>false</EnableDefaultItems>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-    <DefineConstants>$(DefineConstants);PRODUCT</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'net46'">
     <OutDir>$(OutDir)net46\</OutDir>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ProduceContentAssets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ProduceContentAssets.cs
@@ -105,7 +105,7 @@ namespace Microsoft.NET.Build.Tasks
         {
         }
 
-        public ProduceContentAssets(IContentAssetPreprocessor assetPreprocessor)
+        internal ProduceContentAssets(IContentAssetPreprocessor assetPreprocessor)
             : this()
         {
             _assetPreprocessor = assetPreprocessor;
@@ -116,7 +116,7 @@ namespace Microsoft.NET.Build.Tasks
         /// <summary>
         /// Resource for reading, processing and writing content assets
         /// </summary>
-        public IContentAssetPreprocessor AssetPreprocessor
+        internal IContentAssetPreprocessor AssetPreprocessor
         {
             get
             {

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ProduceContentAssets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ProduceContentAssets.cs
@@ -99,11 +99,11 @@ namespace Microsoft.NET.Build.Tasks
 
         #endregion
 
-        #region Test Support
-
         public ProduceContentAssets()
         {
         }
+
+        #region Test Support
 
         internal ProduceContentAssets(IContentAssetPreprocessor assetPreprocessor)
             : this()

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ProjectContext.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ProjectContext.cs
@@ -12,7 +12,7 @@ using Microsoft.Build.Utilities;
 
 namespace Microsoft.NET.Build.Tasks
 {
-    public class ProjectContext
+    internal class ProjectContext
     {
         private readonly LockFile _lockFile;
         private readonly LockFileTarget _lockFileTarget;

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Properties/AssemblyInfo.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Properties/AssemblyInfo.cs
@@ -1,3 +1,6 @@
 ﻿using System.Resources;
+using System.Runtime.CompilerServices;
 
 [assembly: NeutralResourcesLanguage("en")]
+
+[assembly: InternalsVisibleTo("Microsoft.NET.Build.Tasks.UnitTests, PublicKey=002400000480000094000000060200000024000052534131000400000100010055e0217eb635f69281051f9a823e0c7edd90f28063eb6c7a742a19b4f6139778ee0af438f47aed3b6e9f99838aa8dba689c7a71ddb860c96d923830b57bbd5cd6119406ddb9b002cf1c723bf272d6acbb7129e9d6dd5a5309c94e0ff4b2c884d45a55f475cd7dba59198086f61f5a8c8b5e601c0edbf269733f6f578fc8579c2")]

--- a/src/Tasks/Microsoft.NET.Build.Tasks/PublishAssembliesResolver.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/PublishAssembliesResolver.cs
@@ -10,7 +10,7 @@ using NuGet.Packaging.Core;
 
 namespace Microsoft.NET.Build.Tasks
 {
-    public class PublishAssembliesResolver
+    internal class PublishAssembliesResolver
     {
         private  HashSet<PackageIdentity> _allResolvedPackages = new HashSet<PackageIdentity>();
         private readonly IPackageResolver _packageResolver;

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ReferenceInfo.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ReferenceInfo.cs
@@ -9,7 +9,7 @@ using Microsoft.Build.Framework;
 
 namespace Microsoft.NET.Build.Tasks
 {
-    public class ReferenceInfo
+    internal class ReferenceInfo
     {
         public string Name { get; }
         public string Version { get; }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageDependencies.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageDependencies.cs
@@ -114,11 +114,11 @@ namespace Microsoft.NET.Build.Tasks
 
         #endregion
 
-        #region Test Support
-
         public ResolvePackageDependencies()
         {
         }
+
+        #region Test Support
 
         internal ResolvePackageDependencies(LockFile lockFile, IPackageResolver packageResolver)
             : this()

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageDependencies.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageDependencies.cs
@@ -120,7 +120,7 @@ namespace Microsoft.NET.Build.Tasks
         {
         }
 
-        public ResolvePackageDependencies(LockFile lockFile, IPackageResolver packageResolver)
+        internal ResolvePackageDependencies(LockFile lockFile, IPackageResolver packageResolver)
             : this()
         {
             _lockFile = lockFile;

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolvedFile.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolvedFile.cs
@@ -5,7 +5,7 @@ using System.IO;
 using System;
 namespace Microsoft.NET.Build.Tasks
 {
-    public enum AssetType
+    internal enum AssetType
     {
         None,
         Runtime,
@@ -13,7 +13,7 @@ namespace Microsoft.NET.Build.Tasks
         Resources
     }
 
-    public class ResolvedFile
+    internal class ResolvedFile
     {
         public string SourcePath { get; }
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResourceAssemblyInfo.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResourceAssemblyInfo.cs
@@ -6,7 +6,7 @@ using Microsoft.Build.Framework;
 
 namespace Microsoft.NET.Build.Tasks
 {
-    public class ResourceAssemblyInfo
+    internal class ResourceAssemblyInfo
     {
         public string Culture { get; }
         public string RelativePath { get; }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/SingleProjectInfo.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/SingleProjectInfo.cs
@@ -9,7 +9,7 @@ using Microsoft.Build.Framework;
 
 namespace Microsoft.NET.Build.Tasks
 {
-    public class SingleProjectInfo
+    internal class SingleProjectInfo
     {
         public string ProjectPath { get; }
         public string Name { get; }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/TaskBase.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/TaskBase.cs
@@ -35,7 +35,7 @@ namespace Microsoft.NET.Build.Tasks
 
         private readonly DiagnosticsHelper _diagnostics;
 
-        public DiagnosticsHelper Diagnostics
+        internal DiagnosticsHelper Diagnostics
         {
             get { return _diagnostics; }
         }

--- a/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToCacheAProjectWithDependencies.cs
+++ b/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToCacheAProjectWithDependencies.cs
@@ -3,6 +3,8 @@
 
 using System.IO;
 using System.Collections.Generic;
+using System.Linq;
+using System.Xml.Linq;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.NET.TestFramework;
 using Microsoft.NET.TestFramework.Assertions;
@@ -11,7 +13,6 @@ using Xunit;
 using static Microsoft.NET.TestFramework.Commands.MSBuildTest;
 using System.Runtime.InteropServices;
 using Microsoft.DotNet.InternalAbstractions;
-using Microsoft.NET.Build.Tasks;
 using FluentAssertions;
 using NuGet.Versioning;
 using NuGet.Packaging.Core;
@@ -94,7 +95,7 @@ namespace Microsoft.NET.Publish.Tests
             }
 
             var artifact = Path.Combine(OutputFolder, "artifact.xml");
-            var packagescomposed = CacheArtifactParser.Parse(artifact);
+            HashSet<PackageIdentity> packagescomposed = ParseCacheArtifacts(artifact);
 
             packagescomposed.Count.Should().Be(knownpackage.Count);
 
@@ -237,7 +238,7 @@ namespace Microsoft.NET.Publish.Tests
             knownpackage.Add(new PackageIdentity("FluentAssertions.Json", NuGetVersion.Parse("4.12.0")));
 
             var artifact = Path.Combine(OutputFolder, "artifact.xml");
-            var packagescomposed = CacheArtifactParser.Parse(artifact);
+            var packagescomposed = ParseCacheArtifacts(artifact);
 
             packagescomposed.Count.Should().BeGreaterThan(0);
 
@@ -245,6 +246,15 @@ namespace Microsoft.NET.Publish.Tests
             {
                 packagescomposed.Should().Contain(elem => elem.Equals(pkg), "package {0}, version {1} was not expected to be cached", pkg.Id, pkg.Version);
             }
+        }
+
+        private static HashSet<PackageIdentity> ParseCacheArtifacts(string path)
+        {
+            return new HashSet<PackageIdentity>(
+                from element in XDocument.Load(path).Root.Elements("Package")
+                select new PackageIdentity(
+                    element.Attribute("Id").Value,
+                    NuGetVersion.Parse(element.Attribute("Version").Value)));
         }
     }
 }

--- a/test/Microsoft.NET.Publish.Tests/Microsoft.NET.Publish.Tests.csproj
+++ b/test/Microsoft.NET.Publish.Tests/Microsoft.NET.Publish.Tests.csproj
@@ -32,7 +32,6 @@
     </PackageReference>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="$(RepositoryRootDirectory)src\Tasks\Microsoft.NET.Build.Tasks\CacheArtifactParser.cs" Exclude="$(GlobalExclude)" />
     <Compile Include="**\*.cs" Exclude="$(GlobalExclude)" />
     <EmbeddedResource Include="**\*.resx" Exclude="$(GlobalExclude)" />
   </ItemGroup>


### PR DESCRIPTION
Fix #55 - We now public-sign on non-Windows builds instead of leaving assemblies unsigned there
Fix #656 - Limit public surface to Tasks and use InternalsVisibleTo(tests) for other things that were public only for test purposes and being blocked by #55

Also, get rid of the #if PRODUCT and special handling of CacheArtifactParser.cs. I had intended to make this go through IVTA too, but then found that this level of tests do not reference the build tasks, but merely execute them via msbuild, and I didn't want to break that layering. I just wrote the trivial parsing from scratch in to the test using an XLinq query. This is intentionally different from the product code. If the format changes, the tests will break, but I consider that a feature.

@eerhardt @ramarag @333fred @dsplaisted 

