### PR TITLE
Run xliffconverter to pick up new strings

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.cs.resx
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.cs.resx
@@ -228,4 +228,25 @@
   <data name="PackageReferenceOverrideWarning" xml:space="preserve">
     <value>Do projektu byl zahrnut odkaz na balíček pro {0}. Na tento balíček implicitně odkazuje sada .NET SDK, takže na něj zpravidla nemusíte odkazovat z projektu. Další informace najdete na adrese {1}.</value>
   </data>
+  <data name="IncorrectPackageRoot" xml:space="preserve">
+    <value>Package Root {0} was incorrectly given for Resolved library {1}</value>
+  </data>
+  <data name="MultipleFilesResolved" xml:space="preserve">
+    <value>More than one file found for {0}</value>
+  </data>
+  <data name="FolderAlreadyExists" xml:space="preserve">
+    <value>Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</value>
+  </data>
+  <data name="IncorrectFilterFormat" xml:space="preserve">
+    <value>The filter profile {0} provided is of not the correct format</value>
+  </data>
+  <data name="ParsingFiles" xml:space="preserve">
+    <value>Parsing the Files : '{0}'</value>
+  </data>
+  <data name="PackageInfoLog" xml:space="preserve">
+    <value>Package Name='{0}', Version='{1}' was parsed</value>
+  </data>
+  <data name="RuntimeIdentifierWasNotSpecified" xml:space="preserve">
+    <value>Specify a RuntimeIdentifier</value>
+  </data>
 </root>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.de.resx
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.de.resx
@@ -205,7 +205,7 @@
     <value>{0}. Bitte führen Sie "dotnet restore" aus, um eine neue Ressourcendatei zu erzeugen.</value>
   </data>
   <data name="NU1007" xml:space="preserve">
-    <value>Die angegebene Abhängigkeit war "{0}", das Ende war jedoch "{1}".</value>
+    <value>Angegeben war Abhängigkeit "{0}", die tatsächliche Abhängigkeit war aber "{1}".</value>
   </data>
   <data name="NU1008" xml:space="preserve">
     <value>{0} ist ein nicht unterstütztes Framework.</value>
@@ -227,5 +227,26 @@
   </data>
   <data name="PackageReferenceOverrideWarning" xml:space="preserve">
     <value>Ein Paketverweis für "{0}" war in Ihrem Projekt vorhanden. Auf dieses Paket wird vom .NET SDK implizit verwiesen, und Sie müssen in der Regel nicht von Ihrem Projekt aus darauf verweisen. Weitere Informationen finden Sie unter {1}.</value>
+  </data>
+  <data name="IncorrectPackageRoot" xml:space="preserve">
+    <value>Package Root {0} was incorrectly given for Resolved library {1}</value>
+  </data>
+  <data name="MultipleFilesResolved" xml:space="preserve">
+    <value>More than one file found for {0}</value>
+  </data>
+  <data name="FolderAlreadyExists" xml:space="preserve">
+    <value>Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</value>
+  </data>
+  <data name="IncorrectFilterFormat" xml:space="preserve">
+    <value>The filter profile {0} provided is of not the correct format</value>
+  </data>
+  <data name="ParsingFiles" xml:space="preserve">
+    <value>Parsing the Files : '{0}'</value>
+  </data>
+  <data name="PackageInfoLog" xml:space="preserve">
+    <value>Package Name='{0}', Version='{1}' was parsed</value>
+  </data>
+  <data name="RuntimeIdentifierWasNotSpecified" xml:space="preserve">
+    <value>Specify a RuntimeIdentifier</value>
   </data>
 </root>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.es.resx
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.es.resx
@@ -228,4 +228,25 @@
   <data name="PackageReferenceOverrideWarning" xml:space="preserve">
     <value>Se incluyó un elemento PackageReference para "{0}" en su proyecto. El SDK de .NET hace referencia implícita a este paquete y normalmente no tiene que hacer referencia a él desde su proyecto. Para obtener más información, consulte {1}</value>
   </data>
+  <data name="IncorrectPackageRoot" xml:space="preserve">
+    <value>Package Root {0} was incorrectly given for Resolved library {1}</value>
+  </data>
+  <data name="MultipleFilesResolved" xml:space="preserve">
+    <value>More than one file found for {0}</value>
+  </data>
+  <data name="FolderAlreadyExists" xml:space="preserve">
+    <value>Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</value>
+  </data>
+  <data name="IncorrectFilterFormat" xml:space="preserve">
+    <value>The filter profile {0} provided is of not the correct format</value>
+  </data>
+  <data name="ParsingFiles" xml:space="preserve">
+    <value>Parsing the Files : '{0}'</value>
+  </data>
+  <data name="PackageInfoLog" xml:space="preserve">
+    <value>Package Name='{0}', Version='{1}' was parsed</value>
+  </data>
+  <data name="RuntimeIdentifierWasNotSpecified" xml:space="preserve">
+    <value>Specify a RuntimeIdentifier</value>
+  </data>
 </root>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.fr.resx
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.fr.resx
@@ -228,4 +228,25 @@
   <data name="PackageReferenceOverrideWarning" xml:space="preserve">
     <value>Un PackageReference pour '{0}' a été inclus dans votre projet. Comme ce package est implicitement référencé par le SDK .NET, vous n'avez généralement pas besoin de le référencer à partir de votre projet. Pour plus d'informations, consultez {1}</value>
   </data>
+  <data name="IncorrectPackageRoot" xml:space="preserve">
+    <value>Package Root {0} was incorrectly given for Resolved library {1}</value>
+  </data>
+  <data name="MultipleFilesResolved" xml:space="preserve">
+    <value>More than one file found for {0}</value>
+  </data>
+  <data name="FolderAlreadyExists" xml:space="preserve">
+    <value>Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</value>
+  </data>
+  <data name="IncorrectFilterFormat" xml:space="preserve">
+    <value>The filter profile {0} provided is of not the correct format</value>
+  </data>
+  <data name="ParsingFiles" xml:space="preserve">
+    <value>Parsing the Files : '{0}'</value>
+  </data>
+  <data name="PackageInfoLog" xml:space="preserve">
+    <value>Package Name='{0}', Version='{1}' was parsed</value>
+  </data>
+  <data name="RuntimeIdentifierWasNotSpecified" xml:space="preserve">
+    <value>Specify a RuntimeIdentifier</value>
+  </data>
 </root>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.it.resx
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.it.resx
@@ -228,4 +228,25 @@
   <data name="PackageReferenceOverrideWarning" xml:space="preserve">
     <value>Nel progetto è stato incluso un riferimento al pacchetto per '{0}'. Questo pacchetto viene usato come riferimento implicito da .NET SDK e non è in genere necessario farvi riferimento dal progetto. Per altre informazioni, vedere {1}</value>
   </data>
+  <data name="IncorrectPackageRoot" xml:space="preserve">
+    <value>Package Root {0} was incorrectly given for Resolved library {1}</value>
+  </data>
+  <data name="MultipleFilesResolved" xml:space="preserve">
+    <value>More than one file found for {0}</value>
+  </data>
+  <data name="FolderAlreadyExists" xml:space="preserve">
+    <value>Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</value>
+  </data>
+  <data name="IncorrectFilterFormat" xml:space="preserve">
+    <value>The filter profile {0} provided is of not the correct format</value>
+  </data>
+  <data name="ParsingFiles" xml:space="preserve">
+    <value>Parsing the Files : '{0}'</value>
+  </data>
+  <data name="PackageInfoLog" xml:space="preserve">
+    <value>Package Name='{0}', Version='{1}' was parsed</value>
+  </data>
+  <data name="RuntimeIdentifierWasNotSpecified" xml:space="preserve">
+    <value>Specify a RuntimeIdentifier</value>
+  </data>
 </root>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.ja.resx
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.ja.resx
@@ -228,4 +228,25 @@
   <data name="PackageReferenceOverrideWarning" xml:space="preserve">
     <value>'{0}' の PackageReference がプロジェクトに含められました。このパッケージは .NET SDK によって暗黙的に参照されるため、通常はプロジェクトから参照する必要がありません。詳細については、{1} をご覧ください。</value>
   </data>
+  <data name="IncorrectPackageRoot" xml:space="preserve">
+    <value>Package Root {0} was incorrectly given for Resolved library {1}</value>
+  </data>
+  <data name="MultipleFilesResolved" xml:space="preserve">
+    <value>More than one file found for {0}</value>
+  </data>
+  <data name="FolderAlreadyExists" xml:space="preserve">
+    <value>Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</value>
+  </data>
+  <data name="IncorrectFilterFormat" xml:space="preserve">
+    <value>The filter profile {0} provided is of not the correct format</value>
+  </data>
+  <data name="ParsingFiles" xml:space="preserve">
+    <value>Parsing the Files : '{0}'</value>
+  </data>
+  <data name="PackageInfoLog" xml:space="preserve">
+    <value>Package Name='{0}', Version='{1}' was parsed</value>
+  </data>
+  <data name="RuntimeIdentifierWasNotSpecified" xml:space="preserve">
+    <value>Specify a RuntimeIdentifier</value>
+  </data>
 </root>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.ko.resx
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.ko.resx
@@ -228,4 +228,25 @@
   <data name="PackageReferenceOverrideWarning" xml:space="preserve">
     <value>'{0}'에 대한 PackageReference가 프로젝트에 포함되어 있습니다. 이 패키지는 .NET SDK에서 암시적으로 참조되며, 일반적으로 사용자가 프로젝트에서 참조할 필요가 없습니다. 자세한 내용은 {1}을(를) 참조하세요.</value>
   </data>
+  <data name="IncorrectPackageRoot" xml:space="preserve">
+    <value>Package Root {0} was incorrectly given for Resolved library {1}</value>
+  </data>
+  <data name="MultipleFilesResolved" xml:space="preserve">
+    <value>More than one file found for {0}</value>
+  </data>
+  <data name="FolderAlreadyExists" xml:space="preserve">
+    <value>Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</value>
+  </data>
+  <data name="IncorrectFilterFormat" xml:space="preserve">
+    <value>The filter profile {0} provided is of not the correct format</value>
+  </data>
+  <data name="ParsingFiles" xml:space="preserve">
+    <value>Parsing the Files : '{0}'</value>
+  </data>
+  <data name="PackageInfoLog" xml:space="preserve">
+    <value>Package Name='{0}', Version='{1}' was parsed</value>
+  </data>
+  <data name="RuntimeIdentifierWasNotSpecified" xml:space="preserve">
+    <value>Specify a RuntimeIdentifier</value>
+  </data>
 </root>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.pl.resx
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.pl.resx
@@ -228,4 +228,25 @@
   <data name="PackageReferenceOverrideWarning" xml:space="preserve">
     <value>Odwołanie do pakietu dla „{0}” zostało uwzględnione w projekcie. Ten pakiet jest jawnie przywoływany przez zestaw .NET SDK i zwykle nie ma potrzeby tworzenia odwołania do niego z projektu. Aby uzyskać więcej informacji, zobacz {1}</value>
   </data>
+  <data name="IncorrectPackageRoot" xml:space="preserve">
+    <value>Package Root {0} was incorrectly given for Resolved library {1}</value>
+  </data>
+  <data name="MultipleFilesResolved" xml:space="preserve">
+    <value>More than one file found for {0}</value>
+  </data>
+  <data name="FolderAlreadyExists" xml:space="preserve">
+    <value>Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</value>
+  </data>
+  <data name="IncorrectFilterFormat" xml:space="preserve">
+    <value>The filter profile {0} provided is of not the correct format</value>
+  </data>
+  <data name="ParsingFiles" xml:space="preserve">
+    <value>Parsing the Files : '{0}'</value>
+  </data>
+  <data name="PackageInfoLog" xml:space="preserve">
+    <value>Package Name='{0}', Version='{1}' was parsed</value>
+  </data>
+  <data name="RuntimeIdentifierWasNotSpecified" xml:space="preserve">
+    <value>Specify a RuntimeIdentifier</value>
+  </data>
 </root>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.pt-BR.resx
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.pt-BR.resx
@@ -228,4 +228,25 @@
   <data name="PackageReferenceOverrideWarning" xml:space="preserve">
     <value>Um PackageReference para '{0}' foi incluído no seu projeto. Esse pacote é referenciado implicitamente pelo .NET SDK e normalmente você não precisa referenciá-lo no seu projeto. Para obter mais informações, consulte {1}</value>
   </data>
+  <data name="IncorrectPackageRoot" xml:space="preserve">
+    <value>Package Root {0} was incorrectly given for Resolved library {1}</value>
+  </data>
+  <data name="MultipleFilesResolved" xml:space="preserve">
+    <value>More than one file found for {0}</value>
+  </data>
+  <data name="FolderAlreadyExists" xml:space="preserve">
+    <value>Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</value>
+  </data>
+  <data name="IncorrectFilterFormat" xml:space="preserve">
+    <value>The filter profile {0} provided is of not the correct format</value>
+  </data>
+  <data name="ParsingFiles" xml:space="preserve">
+    <value>Parsing the Files : '{0}'</value>
+  </data>
+  <data name="PackageInfoLog" xml:space="preserve">
+    <value>Package Name='{0}', Version='{1}' was parsed</value>
+  </data>
+  <data name="RuntimeIdentifierWasNotSpecified" xml:space="preserve">
+    <value>Specify a RuntimeIdentifier</value>
+  </data>
 </root>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.ru.resx
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.ru.resx
@@ -228,4 +228,25 @@
   <data name="PackageReferenceOverrideWarning" xml:space="preserve">
     <value>PackageReference для "{0}" был включен в проект. На этот пакет неявно указывает пакет .NET SDK и обычно не нужно ссылаться на него из проекта. Дополнительные сведения: {1}</value>
   </data>
+  <data name="IncorrectPackageRoot" xml:space="preserve">
+    <value>Package Root {0} was incorrectly given for Resolved library {1}</value>
+  </data>
+  <data name="MultipleFilesResolved" xml:space="preserve">
+    <value>More than one file found for {0}</value>
+  </data>
+  <data name="FolderAlreadyExists" xml:space="preserve">
+    <value>Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</value>
+  </data>
+  <data name="IncorrectFilterFormat" xml:space="preserve">
+    <value>The filter profile {0} provided is of not the correct format</value>
+  </data>
+  <data name="ParsingFiles" xml:space="preserve">
+    <value>Parsing the Files : '{0}'</value>
+  </data>
+  <data name="PackageInfoLog" xml:space="preserve">
+    <value>Package Name='{0}', Version='{1}' was parsed</value>
+  </data>
+  <data name="RuntimeIdentifierWasNotSpecified" xml:space="preserve">
+    <value>Specify a RuntimeIdentifier</value>
+  </data>
 </root>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.tr.resx
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.tr.resx
@@ -228,4 +228,25 @@
   <data name="PackageReferenceOverrideWarning" xml:space="preserve">
     <value>Projenize '{0}' için bir paket başvurusu eklendi. .NET SDK bu pakete örtük olarak başvuruyor; buna projenizden başvurmanız genellikle gerekli değildir. Daha fazla bilgi için bkz. {1}</value>
   </data>
+  <data name="IncorrectPackageRoot" xml:space="preserve">
+    <value>Package Root {0} was incorrectly given for Resolved library {1}</value>
+  </data>
+  <data name="MultipleFilesResolved" xml:space="preserve">
+    <value>More than one file found for {0}</value>
+  </data>
+  <data name="FolderAlreadyExists" xml:space="preserve">
+    <value>Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</value>
+  </data>
+  <data name="IncorrectFilterFormat" xml:space="preserve">
+    <value>The filter profile {0} provided is of not the correct format</value>
+  </data>
+  <data name="ParsingFiles" xml:space="preserve">
+    <value>Parsing the Files : '{0}'</value>
+  </data>
+  <data name="PackageInfoLog" xml:space="preserve">
+    <value>Package Name='{0}', Version='{1}' was parsed</value>
+  </data>
+  <data name="RuntimeIdentifierWasNotSpecified" xml:space="preserve">
+    <value>Specify a RuntimeIdentifier</value>
+  </data>
 </root>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.zh-Hans.resx
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.zh-Hans.resx
@@ -228,4 +228,25 @@
   <data name="PackageReferenceOverrideWarning" xml:space="preserve">
     <value>项目中包含了“{0}”的 PackageReference。此包由 .NET SDK 隐式引用，且通常情况下你无需从项目中对其进行引用。有关详细信息，请参阅 {1}</value>
   </data>
+  <data name="IncorrectPackageRoot" xml:space="preserve">
+    <value>Package Root {0} was incorrectly given for Resolved library {1}</value>
+  </data>
+  <data name="MultipleFilesResolved" xml:space="preserve">
+    <value>More than one file found for {0}</value>
+  </data>
+  <data name="FolderAlreadyExists" xml:space="preserve">
+    <value>Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</value>
+  </data>
+  <data name="IncorrectFilterFormat" xml:space="preserve">
+    <value>The filter profile {0} provided is of not the correct format</value>
+  </data>
+  <data name="ParsingFiles" xml:space="preserve">
+    <value>Parsing the Files : '{0}'</value>
+  </data>
+  <data name="PackageInfoLog" xml:space="preserve">
+    <value>Package Name='{0}', Version='{1}' was parsed</value>
+  </data>
+  <data name="RuntimeIdentifierWasNotSpecified" xml:space="preserve">
+    <value>Specify a RuntimeIdentifier</value>
+  </data>
 </root>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.zh-Hant.resx
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.zh-Hant.resx
@@ -228,4 +228,25 @@
   <data name="PackageReferenceOverrideWarning" xml:space="preserve">
     <value>您的專案中包含 '{0}' 的 PackageReference。.NET SDK 會隱含參考此套件，您通常不需要從專案加以參考。如需詳細資訊，請參閱 {1}</value>
   </data>
+  <data name="IncorrectPackageRoot" xml:space="preserve">
+    <value>Package Root {0} was incorrectly given for Resolved library {1}</value>
+  </data>
+  <data name="MultipleFilesResolved" xml:space="preserve">
+    <value>More than one file found for {0}</value>
+  </data>
+  <data name="FolderAlreadyExists" xml:space="preserve">
+    <value>Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</value>
+  </data>
+  <data name="IncorrectFilterFormat" xml:space="preserve">
+    <value>The filter profile {0} provided is of not the correct format</value>
+  </data>
+  <data name="ParsingFiles" xml:space="preserve">
+    <value>Parsing the Files : '{0}'</value>
+  </data>
+  <data name="PackageInfoLog" xml:space="preserve">
+    <value>Package Name='{0}', Version='{1}' was parsed</value>
+  </data>
+  <data name="RuntimeIdentifierWasNotSpecified" xml:space="preserve">
+    <value>Specify a RuntimeIdentifier</value>
+  </data>
 </root>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.cs.xlf
@@ -188,6 +188,41 @@
         <target state="translated">Do projektu byl zahrnut odkaz na balíček pro {0}. Na tento balíček implicitně odkazuje sada .NET SDK, takže na něj zpravidla nemusíte odkazovat z projektu. Další informace najdete na adrese {1}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="IncorrectPackageRoot">
+        <source>Package Root {0} was incorrectly given for Resolved library {1}</source>
+        <target state="new">Package Root {0} was incorrectly given for Resolved library {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="MultipleFilesResolved">
+        <source>More than one file found for {0}</source>
+        <target state="new">More than one file found for {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FolderAlreadyExists">
+        <source>Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</source>
+        <target state="new">Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="IncorrectFilterFormat">
+        <source>The filter profile {0} provided is of not the correct format</source>
+        <target state="new">The filter profile {0} provided is of not the correct format</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ParsingFiles">
+        <source>Parsing the Files : '{0}'</source>
+        <target state="new">Parsing the Files : '{0}'</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PackageInfoLog">
+        <source>Package Name='{0}', Version='{1}' was parsed</source>
+        <target state="new">Package Name='{0}', Version='{1}' was parsed</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="RuntimeIdentifierWasNotSpecified">
+        <source>Specify a RuntimeIdentifier</source>
+        <target state="new">Specify a RuntimeIdentifier</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.de.xlf
@@ -188,6 +188,41 @@
         <target state="translated">Ein Paketverweis für "{0}" war in Ihrem Projekt vorhanden. Auf dieses Paket wird vom .NET SDK implizit verwiesen, und Sie müssen in der Regel nicht von Ihrem Projekt aus darauf verweisen. Weitere Informationen finden Sie unter {1}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="IncorrectPackageRoot">
+        <source>Package Root {0} was incorrectly given for Resolved library {1}</source>
+        <target state="new">Package Root {0} was incorrectly given for Resolved library {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="MultipleFilesResolved">
+        <source>More than one file found for {0}</source>
+        <target state="new">More than one file found for {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FolderAlreadyExists">
+        <source>Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</source>
+        <target state="new">Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="IncorrectFilterFormat">
+        <source>The filter profile {0} provided is of not the correct format</source>
+        <target state="new">The filter profile {0} provided is of not the correct format</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ParsingFiles">
+        <source>Parsing the Files : '{0}'</source>
+        <target state="new">Parsing the Files : '{0}'</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PackageInfoLog">
+        <source>Package Name='{0}', Version='{1}' was parsed</source>
+        <target state="new">Package Name='{0}', Version='{1}' was parsed</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="RuntimeIdentifierWasNotSpecified">
+        <source>Specify a RuntimeIdentifier</source>
+        <target state="new">Specify a RuntimeIdentifier</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.es.xlf
@@ -188,6 +188,41 @@
         <target state="translated">Se incluyó un elemento PackageReference para "{0}" en su proyecto. El SDK de .NET hace referencia implícita a este paquete y normalmente no tiene que hacer referencia a él desde su proyecto. Para obtener más información, consulte {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="IncorrectPackageRoot">
+        <source>Package Root {0} was incorrectly given for Resolved library {1}</source>
+        <target state="new">Package Root {0} was incorrectly given for Resolved library {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="MultipleFilesResolved">
+        <source>More than one file found for {0}</source>
+        <target state="new">More than one file found for {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FolderAlreadyExists">
+        <source>Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</source>
+        <target state="new">Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="IncorrectFilterFormat">
+        <source>The filter profile {0} provided is of not the correct format</source>
+        <target state="new">The filter profile {0} provided is of not the correct format</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ParsingFiles">
+        <source>Parsing the Files : '{0}'</source>
+        <target state="new">Parsing the Files : '{0}'</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PackageInfoLog">
+        <source>Package Name='{0}', Version='{1}' was parsed</source>
+        <target state="new">Package Name='{0}', Version='{1}' was parsed</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="RuntimeIdentifierWasNotSpecified">
+        <source>Specify a RuntimeIdentifier</source>
+        <target state="new">Specify a RuntimeIdentifier</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.fr.xlf
@@ -188,6 +188,41 @@
         <target state="translated">Un PackageReference pour '{0}' a été inclus dans votre projet. Comme ce package est implicitement référencé par le SDK .NET, vous n'avez généralement pas besoin de le référencer à partir de votre projet. Pour plus d'informations, consultez {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="IncorrectPackageRoot">
+        <source>Package Root {0} was incorrectly given for Resolved library {1}</source>
+        <target state="new">Package Root {0} was incorrectly given for Resolved library {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="MultipleFilesResolved">
+        <source>More than one file found for {0}</source>
+        <target state="new">More than one file found for {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FolderAlreadyExists">
+        <source>Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</source>
+        <target state="new">Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="IncorrectFilterFormat">
+        <source>The filter profile {0} provided is of not the correct format</source>
+        <target state="new">The filter profile {0} provided is of not the correct format</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ParsingFiles">
+        <source>Parsing the Files : '{0}'</source>
+        <target state="new">Parsing the Files : '{0}'</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PackageInfoLog">
+        <source>Package Name='{0}', Version='{1}' was parsed</source>
+        <target state="new">Package Name='{0}', Version='{1}' was parsed</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="RuntimeIdentifierWasNotSpecified">
+        <source>Specify a RuntimeIdentifier</source>
+        <target state="new">Specify a RuntimeIdentifier</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.it.xlf
@@ -188,6 +188,41 @@
         <target state="translated">Nel progetto è stato incluso un riferimento al pacchetto per '{0}'. Questo pacchetto viene usato come riferimento implicito da .NET SDK e non è in genere necessario farvi riferimento dal progetto. Per altre informazioni, vedere {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="IncorrectPackageRoot">
+        <source>Package Root {0} was incorrectly given for Resolved library {1}</source>
+        <target state="new">Package Root {0} was incorrectly given for Resolved library {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="MultipleFilesResolved">
+        <source>More than one file found for {0}</source>
+        <target state="new">More than one file found for {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FolderAlreadyExists">
+        <source>Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</source>
+        <target state="new">Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="IncorrectFilterFormat">
+        <source>The filter profile {0} provided is of not the correct format</source>
+        <target state="new">The filter profile {0} provided is of not the correct format</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ParsingFiles">
+        <source>Parsing the Files : '{0}'</source>
+        <target state="new">Parsing the Files : '{0}'</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PackageInfoLog">
+        <source>Package Name='{0}', Version='{1}' was parsed</source>
+        <target state="new">Package Name='{0}', Version='{1}' was parsed</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="RuntimeIdentifierWasNotSpecified">
+        <source>Specify a RuntimeIdentifier</source>
+        <target state="new">Specify a RuntimeIdentifier</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.ja.xlf
@@ -188,6 +188,41 @@
         <target state="translated">'{0}' の PackageReference がプロジェクトに含められました。このパッケージは .NET SDK によって暗黙的に参照されるため、通常はプロジェクトから参照する必要がありません。詳細については、{1} をご覧ください。</target>
         <note />
       </trans-unit>
+      <trans-unit id="IncorrectPackageRoot">
+        <source>Package Root {0} was incorrectly given for Resolved library {1}</source>
+        <target state="new">Package Root {0} was incorrectly given for Resolved library {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="MultipleFilesResolved">
+        <source>More than one file found for {0}</source>
+        <target state="new">More than one file found for {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FolderAlreadyExists">
+        <source>Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</source>
+        <target state="new">Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="IncorrectFilterFormat">
+        <source>The filter profile {0} provided is of not the correct format</source>
+        <target state="new">The filter profile {0} provided is of not the correct format</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ParsingFiles">
+        <source>Parsing the Files : '{0}'</source>
+        <target state="new">Parsing the Files : '{0}'</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PackageInfoLog">
+        <source>Package Name='{0}', Version='{1}' was parsed</source>
+        <target state="new">Package Name='{0}', Version='{1}' was parsed</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="RuntimeIdentifierWasNotSpecified">
+        <source>Specify a RuntimeIdentifier</source>
+        <target state="new">Specify a RuntimeIdentifier</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.ko.xlf
@@ -188,6 +188,41 @@
         <target state="translated">'{0}'에 대한 PackageReference가 프로젝트에 포함되어 있습니다. 이 패키지는 .NET SDK에서 암시적으로 참조되며, 일반적으로 사용자가 프로젝트에서 참조할 필요가 없습니다. 자세한 내용은 {1}을(를) 참조하세요.</target>
         <note />
       </trans-unit>
+      <trans-unit id="IncorrectPackageRoot">
+        <source>Package Root {0} was incorrectly given for Resolved library {1}</source>
+        <target state="new">Package Root {0} was incorrectly given for Resolved library {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="MultipleFilesResolved">
+        <source>More than one file found for {0}</source>
+        <target state="new">More than one file found for {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FolderAlreadyExists">
+        <source>Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</source>
+        <target state="new">Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="IncorrectFilterFormat">
+        <source>The filter profile {0} provided is of not the correct format</source>
+        <target state="new">The filter profile {0} provided is of not the correct format</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ParsingFiles">
+        <source>Parsing the Files : '{0}'</source>
+        <target state="new">Parsing the Files : '{0}'</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PackageInfoLog">
+        <source>Package Name='{0}', Version='{1}' was parsed</source>
+        <target state="new">Package Name='{0}', Version='{1}' was parsed</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="RuntimeIdentifierWasNotSpecified">
+        <source>Specify a RuntimeIdentifier</source>
+        <target state="new">Specify a RuntimeIdentifier</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.pl.xlf
@@ -188,6 +188,41 @@
         <target state="translated">Odwołanie do pakietu dla „{0}” zostało uwzględnione w projekcie. Ten pakiet jest jawnie przywoływany przez zestaw .NET SDK i zwykle nie ma potrzeby tworzenia odwołania do niego z projektu. Aby uzyskać więcej informacji, zobacz {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="IncorrectPackageRoot">
+        <source>Package Root {0} was incorrectly given for Resolved library {1}</source>
+        <target state="new">Package Root {0} was incorrectly given for Resolved library {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="MultipleFilesResolved">
+        <source>More than one file found for {0}</source>
+        <target state="new">More than one file found for {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FolderAlreadyExists">
+        <source>Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</source>
+        <target state="new">Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="IncorrectFilterFormat">
+        <source>The filter profile {0} provided is of not the correct format</source>
+        <target state="new">The filter profile {0} provided is of not the correct format</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ParsingFiles">
+        <source>Parsing the Files : '{0}'</source>
+        <target state="new">Parsing the Files : '{0}'</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PackageInfoLog">
+        <source>Package Name='{0}', Version='{1}' was parsed</source>
+        <target state="new">Package Name='{0}', Version='{1}' was parsed</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="RuntimeIdentifierWasNotSpecified">
+        <source>Specify a RuntimeIdentifier</source>
+        <target state="new">Specify a RuntimeIdentifier</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.pt-BR.xlf
@@ -188,6 +188,41 @@
         <target state="translated">Um PackageReference para '{0}' foi incluído no seu projeto. Esse pacote é referenciado implicitamente pelo .NET SDK e normalmente você não precisa referenciá-lo no seu projeto. Para obter mais informações, consulte {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="IncorrectPackageRoot">
+        <source>Package Root {0} was incorrectly given for Resolved library {1}</source>
+        <target state="new">Package Root {0} was incorrectly given for Resolved library {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="MultipleFilesResolved">
+        <source>More than one file found for {0}</source>
+        <target state="new">More than one file found for {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FolderAlreadyExists">
+        <source>Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</source>
+        <target state="new">Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="IncorrectFilterFormat">
+        <source>The filter profile {0} provided is of not the correct format</source>
+        <target state="new">The filter profile {0} provided is of not the correct format</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ParsingFiles">
+        <source>Parsing the Files : '{0}'</source>
+        <target state="new">Parsing the Files : '{0}'</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PackageInfoLog">
+        <source>Package Name='{0}', Version='{1}' was parsed</source>
+        <target state="new">Package Name='{0}', Version='{1}' was parsed</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="RuntimeIdentifierWasNotSpecified">
+        <source>Specify a RuntimeIdentifier</source>
+        <target state="new">Specify a RuntimeIdentifier</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.ru.xlf
@@ -188,6 +188,41 @@
         <target state="translated">PackageReference для "{0}" был включен в проект. На этот пакет неявно указывает пакет .NET SDK и обычно не нужно ссылаться на него из проекта. Дополнительные сведения: {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="IncorrectPackageRoot">
+        <source>Package Root {0} was incorrectly given for Resolved library {1}</source>
+        <target state="new">Package Root {0} was incorrectly given for Resolved library {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="MultipleFilesResolved">
+        <source>More than one file found for {0}</source>
+        <target state="new">More than one file found for {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FolderAlreadyExists">
+        <source>Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</source>
+        <target state="new">Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="IncorrectFilterFormat">
+        <source>The filter profile {0} provided is of not the correct format</source>
+        <target state="new">The filter profile {0} provided is of not the correct format</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ParsingFiles">
+        <source>Parsing the Files : '{0}'</source>
+        <target state="new">Parsing the Files : '{0}'</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PackageInfoLog">
+        <source>Package Name='{0}', Version='{1}' was parsed</source>
+        <target state="new">Package Name='{0}', Version='{1}' was parsed</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="RuntimeIdentifierWasNotSpecified">
+        <source>Specify a RuntimeIdentifier</source>
+        <target state="new">Specify a RuntimeIdentifier</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.tr.xlf
@@ -188,6 +188,41 @@
         <target state="translated">Projenize '{0}' için bir paket başvurusu eklendi. .NET SDK bu pakete örtük olarak başvuruyor; buna projenizden başvurmanız genellikle gerekli değildir. Daha fazla bilgi için bkz. {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="IncorrectPackageRoot">
+        <source>Package Root {0} was incorrectly given for Resolved library {1}</source>
+        <target state="new">Package Root {0} was incorrectly given for Resolved library {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="MultipleFilesResolved">
+        <source>More than one file found for {0}</source>
+        <target state="new">More than one file found for {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FolderAlreadyExists">
+        <source>Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</source>
+        <target state="new">Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="IncorrectFilterFormat">
+        <source>The filter profile {0} provided is of not the correct format</source>
+        <target state="new">The filter profile {0} provided is of not the correct format</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ParsingFiles">
+        <source>Parsing the Files : '{0}'</source>
+        <target state="new">Parsing the Files : '{0}'</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PackageInfoLog">
+        <source>Package Name='{0}', Version='{1}' was parsed</source>
+        <target state="new">Package Name='{0}', Version='{1}' was parsed</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="RuntimeIdentifierWasNotSpecified">
+        <source>Specify a RuntimeIdentifier</source>
+        <target state="new">Specify a RuntimeIdentifier</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.xlf
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.xlf
@@ -151,6 +151,34 @@
         <source>A PackageReference for '{0}' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see {1}</source>
         <note />
       </trans-unit>
+      <trans-unit id="IncorrectPackageRoot">
+        <source>Package Root {0} was incorrectly given for Resolved library {1}</source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="MultipleFilesResolved">
+        <source>More than one file found for {0}</source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FolderAlreadyExists">
+        <source>Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="IncorrectFilterFormat">
+        <source>The filter profile {0} provided is of not the correct format</source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ParsingFiles">
+        <source>Parsing the Files : '{0}'</source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PackageInfoLog">
+        <source>Package Name='{0}', Version='{1}' was parsed</source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="RuntimeIdentifierWasNotSpecified">
+        <source>Specify a RuntimeIdentifier</source>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.zh-Hans.xlf
@@ -188,6 +188,41 @@
         <target state="translated">项目中包含了“{0}”的 PackageReference。此包由 .NET SDK 隐式引用，且通常情况下你无需从项目中对其进行引用。有关详细信息，请参阅 {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="IncorrectPackageRoot">
+        <source>Package Root {0} was incorrectly given for Resolved library {1}</source>
+        <target state="new">Package Root {0} was incorrectly given for Resolved library {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="MultipleFilesResolved">
+        <source>More than one file found for {0}</source>
+        <target state="new">More than one file found for {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FolderAlreadyExists">
+        <source>Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</source>
+        <target state="new">Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="IncorrectFilterFormat">
+        <source>The filter profile {0} provided is of not the correct format</source>
+        <target state="new">The filter profile {0} provided is of not the correct format</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ParsingFiles">
+        <source>Parsing the Files : '{0}'</source>
+        <target state="new">Parsing the Files : '{0}'</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PackageInfoLog">
+        <source>Package Name='{0}', Version='{1}' was parsed</source>
+        <target state="new">Package Name='{0}', Version='{1}' was parsed</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="RuntimeIdentifierWasNotSpecified">
+        <source>Specify a RuntimeIdentifier</source>
+        <target state="new">Specify a RuntimeIdentifier</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.zh-Hant.xlf
@@ -188,6 +188,41 @@
         <target state="translated">您的專案中包含 '{0}' 的 PackageReference。.NET SDK 會隱含參考此套件，您通常不需要從專案加以參考。如需詳細資訊，請參閱 {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="IncorrectPackageRoot">
+        <source>Package Root {0} was incorrectly given for Resolved library {1}</source>
+        <target state="new">Package Root {0} was incorrectly given for Resolved library {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="MultipleFilesResolved">
+        <source>More than one file found for {0}</source>
+        <target state="new">More than one file found for {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FolderAlreadyExists">
+        <source>Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</source>
+        <target state="new">Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="IncorrectFilterFormat">
+        <source>The filter profile {0} provided is of not the correct format</source>
+        <target state="new">The filter profile {0} provided is of not the correct format</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ParsingFiles">
+        <source>Parsing the Files : '{0}'</source>
+        <target state="new">Parsing the Files : '{0}'</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PackageInfoLog">
+        <source>Package Name='{0}', Version='{1}' was parsed</source>
+        <target state="new">Package Name='{0}', Version='{1}' was parsed</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="RuntimeIdentifierWasNotSpecified">
+        <source>Specify a RuntimeIdentifier</source>
+        <target state="new">Specify a RuntimeIdentifier</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>


### PR DESCRIPTION
I have another experimental change that updates strings and it pulls in additional because it appears xliffconverter has not been run in a while.

This change only runs `xliffconverter.exe --two-way` on a fresh repo -- it does not add any new strings.

/cc @nguerrera @dsplaisted @livarcocc 