### PR TITLE
Track unexpected dependencies so we only report missing dependencies once

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageDependencies.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageDependencies.cs
@@ -525,7 +525,7 @@ namespace Microsoft.NET.Build.Tasks
         }
 
         private string GetAbsolutePathFromProjectRelativePath(string path)
-        {            
+        {
             return Path.GetFullPath(Path.Combine(Path.GetDirectoryName(Path.GetFullPath(ProjectAssetsFile)), path));
         }
     }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageDependencies.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageDependencies.cs
@@ -350,7 +350,7 @@ namespace Microsoft.NET.Build.Tasks
                 if (!resolvedPackageVersions.TryGetValue(deps.Id, out version) &&
                     !unexpectedDeps.Contains(deps.Id))
                 {
-                    Log.LogError(Strings.UnexpectedDependencyWithNoVersionNumber, deps.Id);
+                    Log.LogError(Strings.UnexpectedPackageDependency, deps.Id, packageId);
                     unexpectedDeps.Add(deps.Id);
                     continue;
                 }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageDependencies.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageDependencies.cs
@@ -302,6 +302,8 @@ namespace Microsoft.NET.Build.Tasks
                     .Where(lib => IsTransitiveProjectReference(lib))
                     .Select(pkg => pkg.Name), 
                 StringComparer.OrdinalIgnoreCase);
+
+            var unexpectedDeps = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             
             TaskItem item;
             foreach (var package in target.Libraries)
@@ -318,7 +320,8 @@ namespace Microsoft.NET.Build.Tasks
                 }
 
                 // get sub package dependencies
-                GetPackageDependencies(package, target.Name, resolvedPackageVersions, transitiveProjectRefs);
+                GetPackageDependencies(package, target.Name, resolvedPackageVersions, 
+                    transitiveProjectRefs, unexpectedDeps);
 
                 // get file dependencies on this package
                 GetFileDependencies(package, target.Name);
@@ -336,16 +339,19 @@ namespace Microsoft.NET.Build.Tasks
             LockFileTargetLibrary package, 
             string targetName, 
             Dictionary<string, string> resolvedPackageVersions,
-            HashSet<string> transitiveProjectRefs)
+            HashSet<string> transitiveProjectRefs,
+            HashSet<string> unexpectedDeps)
         {
             string packageId = $"{package.Name}/{package.Version.ToNormalizedString()}";
             TaskItem item;
             foreach (var deps in package.Dependencies)
             {
                 string version;
-                if (!resolvedPackageVersions.TryGetValue(deps.Id, out version))
+                if (!resolvedPackageVersions.TryGetValue(deps.Id, out version) &&
+                    !unexpectedDeps.Contains(deps.Id))
                 {
                     Log.LogError(Strings.UnexpectedDependencyWithNoVersionNumber, deps.Id);
+                    unexpectedDeps.Add(deps.Id);
                     continue;
                 }
 
@@ -519,7 +525,7 @@ namespace Microsoft.NET.Build.Tasks
         }
 
         private string GetAbsolutePathFromProjectRelativePath(string path)
-        {
+        {            
             return Path.GetFullPath(Path.Combine(Path.GetDirectoryName(Path.GetFullPath(ProjectAssetsFile)), path));
         }
     }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.Designer.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.Designer.cs
@@ -434,11 +434,11 @@ namespace Microsoft.NET.Build.Tasks {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Unexpected dependency &apos;{0}&apos; with no version number..
+        ///   Looks up a localized string similar to Unexpected dependency &apos;{0}&apos; in package &apos;{1}&apos;..
         /// </summary>
-        internal static string UnexpectedDependencyWithNoVersionNumber {
+        internal static string UnexpectedPackageDependency {
             get {
-                return ResourceManager.GetString("UnexpectedDependencyWithNoVersionNumber", resourceCulture);
+                return ResourceManager.GetString("UnexpectedPackageDependency", resourceCulture);
             }
         }
         

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.cs.resx
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.cs.resx
@@ -171,9 +171,6 @@
   <data name="UnableToFindResolvedPath" xml:space="preserve">
     <value>Nepodařilo se najít vyhodnocenou cestu pro {0}.</value>
   </data>
-  <data name="UnexpectedDependencyWithNoVersionNumber" xml:space="preserve">
-    <value>Nečekaná závislost {0} bez čísla verze.</value>
-  </data>
   <data name="AssetPreprocessorMustBeConfigured" xml:space="preserve">
     <value>Před zpracováním prostředků je potřeba nakonfigurovat preprocesor prostředků.</value>
   </data>
@@ -248,5 +245,8 @@
   </data>
   <data name="RuntimeIdentifierWasNotSpecified" xml:space="preserve">
     <value>Specify a RuntimeIdentifier</value>
+  </data>
+  <data name="UnexpectedPackageDependency" xml:space="preserve">
+    <value>Unexpected dependency '{0}' in package '{1}'.</value>
   </data>
 </root>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.de.resx
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.de.resx
@@ -171,9 +171,6 @@
   <data name="UnableToFindResolvedPath" xml:space="preserve">
     <value>Der aufgelöste Pfad für "{0}" wurde nicht gefunden.</value>
   </data>
-  <data name="UnexpectedDependencyWithNoVersionNumber" xml:space="preserve">
-    <value>Unerwartete Abhängigkeit "{0}" ohne Versionsnummer.</value>
-  </data>
   <data name="AssetPreprocessorMustBeConfigured" xml:space="preserve">
     <value>Der Ressourcenpräprozessor muss konfiguriert werden, bevor Ressourcen verarbeitet werden.</value>
   </data>
@@ -248,5 +245,8 @@
   </data>
   <data name="RuntimeIdentifierWasNotSpecified" xml:space="preserve">
     <value>Specify a RuntimeIdentifier</value>
+  </data>
+  <data name="UnexpectedPackageDependency" xml:space="preserve">
+    <value>Unexpected dependency '{0}' in package '{1}'.</value>
   </data>
 </root>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.es.resx
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.es.resx
@@ -171,9 +171,6 @@
   <data name="UnableToFindResolvedPath" xml:space="preserve">
     <value>No se encuentra la ruta de acceso resuelta para '{0}'.</value>
   </data>
-  <data name="UnexpectedDependencyWithNoVersionNumber" xml:space="preserve">
-    <value>Dependencia '{0}' sin número de versión no esperada.</value>
-  </data>
   <data name="AssetPreprocessorMustBeConfigured" xml:space="preserve">
     <value>Debe configurarse el preprocesador de recursos antes de que se procesen los recursos.</value>
   </data>
@@ -248,5 +245,8 @@
   </data>
   <data name="RuntimeIdentifierWasNotSpecified" xml:space="preserve">
     <value>Specify a RuntimeIdentifier</value>
+  </data>
+  <data name="UnexpectedPackageDependency" xml:space="preserve">
+    <value>Unexpected dependency '{0}' in package '{1}'.</value>
   </data>
 </root>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.fr.resx
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.fr.resx
@@ -171,9 +171,6 @@
   <data name="UnableToFindResolvedPath" xml:space="preserve">
     <value>Chemin résolu introuvable pour '{0}'.</value>
   </data>
-  <data name="UnexpectedDependencyWithNoVersionNumber" xml:space="preserve">
-    <value>Dépendance '{0}' sans numéro de version inattendue.</value>
-  </data>
   <data name="AssetPreprocessorMustBeConfigured" xml:space="preserve">
     <value>Le préprocesseur de composants doit être configuré avant que les composants ne soient traités.</value>
   </data>
@@ -248,5 +245,8 @@
   </data>
   <data name="RuntimeIdentifierWasNotSpecified" xml:space="preserve">
     <value>Specify a RuntimeIdentifier</value>
+  </data>
+  <data name="UnexpectedPackageDependency" xml:space="preserve">
+    <value>Unexpected dependency '{0}' in package '{1}'.</value>
   </data>
 </root>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.it.resx
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.it.resx
@@ -171,9 +171,6 @@
   <data name="UnableToFindResolvedPath" xml:space="preserve">
     <value>Il percorso risolto per '{0}' non è stato trovato.</value>
   </data>
-  <data name="UnexpectedDependencyWithNoVersionNumber" xml:space="preserve">
-    <value>La dipendenza '{0}' è imprevista e non ha numero di versione.</value>
-  </data>
   <data name="AssetPreprocessorMustBeConfigured" xml:space="preserve">
     <value>Prima di elaborare le risorse, è necessario configurare il preprocessore di risorse.</value>
   </data>
@@ -248,5 +245,8 @@
   </data>
   <data name="RuntimeIdentifierWasNotSpecified" xml:space="preserve">
     <value>Specify a RuntimeIdentifier</value>
+  </data>
+  <data name="UnexpectedPackageDependency" xml:space="preserve">
+    <value>Unexpected dependency '{0}' in package '{1}'.</value>
   </data>
 </root>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.ja.resx
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.ja.resx
@@ -171,9 +171,6 @@
   <data name="UnableToFindResolvedPath" xml:space="preserve">
     <value>解決された '{0}' のパスが見つかりません。</value>
   </data>
-  <data name="UnexpectedDependencyWithNoVersionNumber" xml:space="preserve">
-    <value>バージョン番号のない予期しない依存関係 '{0}' です。</value>
-  </data>
   <data name="AssetPreprocessorMustBeConfigured" xml:space="preserve">
     <value>資産を処理する前に、資産プリプロセッサを構成する必要があります。</value>
   </data>
@@ -248,5 +245,8 @@
   </data>
   <data name="RuntimeIdentifierWasNotSpecified" xml:space="preserve">
     <value>Specify a RuntimeIdentifier</value>
+  </data>
+  <data name="UnexpectedPackageDependency" xml:space="preserve">
+    <value>Unexpected dependency '{0}' in package '{1}'.</value>
   </data>
 </root>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.ko.resx
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.ko.resx
@@ -171,9 +171,6 @@
   <data name="UnableToFindResolvedPath" xml:space="preserve">
     <value>'{0}'에 대해 확인된 경로를 찾을 수 없습니다.</value>
   </data>
-  <data name="UnexpectedDependencyWithNoVersionNumber" xml:space="preserve">
-    <value>버전 번호가 없는 예기치 않은 종속성 '{0}'입니다.</value>
-  </data>
   <data name="AssetPreprocessorMustBeConfigured" xml:space="preserve">
     <value>자산을 처리하려면 먼저 자산 전처리기를 구성해야 합니다.</value>
   </data>
@@ -248,5 +245,8 @@
   </data>
   <data name="RuntimeIdentifierWasNotSpecified" xml:space="preserve">
     <value>Specify a RuntimeIdentifier</value>
+  </data>
+  <data name="UnexpectedPackageDependency" xml:space="preserve">
+    <value>Unexpected dependency '{0}' in package '{1}'.</value>
   </data>
 </root>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.pl.resx
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.pl.resx
@@ -171,9 +171,6 @@
   <data name="UnableToFindResolvedPath" xml:space="preserve">
     <value>Nie można odnaleźć rozpoznanej ścieżki dla elementu „{0}”.</value>
   </data>
-  <data name="UnexpectedDependencyWithNoVersionNumber" xml:space="preserve">
-    <value>Nieoczekiwana zależność „{0}” bez numeru wersji.</value>
-  </data>
   <data name="AssetPreprocessorMustBeConfigured" xml:space="preserve">
     <value>Preprocesor zasobów musi być skonfigurowany przed przetworzeniem zasobów.</value>
   </data>
@@ -248,5 +245,8 @@
   </data>
   <data name="RuntimeIdentifierWasNotSpecified" xml:space="preserve">
     <value>Specify a RuntimeIdentifier</value>
+  </data>
+  <data name="UnexpectedPackageDependency" xml:space="preserve">
+    <value>Unexpected dependency '{0}' in package '{1}'.</value>
   </data>
 </root>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.pt-BR.resx
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.pt-BR.resx
@@ -171,9 +171,6 @@
   <data name="UnableToFindResolvedPath" xml:space="preserve">
     <value>Não foi possível localizar o caminho resolvido para '{0}'.</value>
   </data>
-  <data name="UnexpectedDependencyWithNoVersionNumber" xml:space="preserve">
-    <value>Dependência inesperada '{0}' sem número de versão.</value>
-  </data>
   <data name="AssetPreprocessorMustBeConfigured" xml:space="preserve">
     <value>O pré-processador de ativos deve ser configurado antes de os ativos serem processados.</value>
   </data>
@@ -248,5 +245,8 @@
   </data>
   <data name="RuntimeIdentifierWasNotSpecified" xml:space="preserve">
     <value>Specify a RuntimeIdentifier</value>
+  </data>
+  <data name="UnexpectedPackageDependency" xml:space="preserve">
+    <value>Unexpected dependency '{0}' in package '{1}'.</value>
   </data>
 </root>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.resx
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.resx
@@ -171,8 +171,8 @@
   <data name="UnableToFindResolvedPath" xml:space="preserve">
     <value>Unable to find resolved path for '{0}'.</value>
   </data>
-  <data name="UnexpectedDependencyWithNoVersionNumber" xml:space="preserve">
-    <value>Unexpected dependency '{0}' with no version number.</value>
+  <data name="UnexpectedPackageDependency" xml:space="preserve">
+    <value>Unexpected dependency '{0}' in package '{1}'.</value>
   </data>
   <data name="AssetPreprocessorMustBeConfigured" xml:space="preserve">
     <value>Asset preprocessor must be configured before assets are processed.</value>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.ru.resx
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.ru.resx
@@ -171,9 +171,6 @@
   <data name="UnableToFindResolvedPath" xml:space="preserve">
     <value>Не удается найти разрешенный путь для "{0}".</value>
   </data>
-  <data name="UnexpectedDependencyWithNoVersionNumber" xml:space="preserve">
-    <value>Непредвиденная зависимость "{0}" без номера версии.</value>
-  </data>
   <data name="AssetPreprocessorMustBeConfigured" xml:space="preserve">
     <value>Препроцессор ресурсов необходимо настроить перед обработкой ресурсов.</value>
   </data>
@@ -248,5 +245,8 @@
   </data>
   <data name="RuntimeIdentifierWasNotSpecified" xml:space="preserve">
     <value>Specify a RuntimeIdentifier</value>
+  </data>
+  <data name="UnexpectedPackageDependency" xml:space="preserve">
+    <value>Unexpected dependency '{0}' in package '{1}'.</value>
   </data>
 </root>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.tr.resx
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.tr.resx
@@ -171,9 +171,6 @@
   <data name="UnableToFindResolvedPath" xml:space="preserve">
     <value>'{0}' için çözümlenmiş yol bulunamıyor.</value>
   </data>
-  <data name="UnexpectedDependencyWithNoVersionNumber" xml:space="preserve">
-    <value>Sürüm numarası olmayan, beklenmeyen bağımlılık: '{0}'.</value>
-  </data>
   <data name="AssetPreprocessorMustBeConfigured" xml:space="preserve">
     <value>Varlıkların işlenebilmesi için varlık ön işlemcisi yapılandırılmalıdır.</value>
   </data>
@@ -248,5 +245,8 @@
   </data>
   <data name="RuntimeIdentifierWasNotSpecified" xml:space="preserve">
     <value>Specify a RuntimeIdentifier</value>
+  </data>
+  <data name="UnexpectedPackageDependency" xml:space="preserve">
+    <value>Unexpected dependency '{0}' in package '{1}'.</value>
   </data>
 </root>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.zh-Hans.resx
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.zh-Hans.resx
@@ -171,9 +171,6 @@
   <data name="UnableToFindResolvedPath" xml:space="preserve">
     <value>找不到“{0}”的已解析路径。</value>
   </data>
-  <data name="UnexpectedDependencyWithNoVersionNumber" xml:space="preserve">
-    <value>不具有版本号的意外依赖项“{0}”。</value>
-  </data>
   <data name="AssetPreprocessorMustBeConfigured" xml:space="preserve">
     <value>必须在处理资产之前配置资产预处理器。</value>
   </data>
@@ -248,5 +245,8 @@
   </data>
   <data name="RuntimeIdentifierWasNotSpecified" xml:space="preserve">
     <value>Specify a RuntimeIdentifier</value>
+  </data>
+  <data name="UnexpectedPackageDependency" xml:space="preserve">
+    <value>Unexpected dependency '{0}' in package '{1}'.</value>
   </data>
 </root>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.zh-Hant.resx
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.zh-Hant.resx
@@ -171,9 +171,6 @@
   <data name="UnableToFindResolvedPath" xml:space="preserve">
     <value>找不到 '{0}' 的解析路徑。</value>
   </data>
-  <data name="UnexpectedDependencyWithNoVersionNumber" xml:space="preserve">
-    <value>未預期的相依性 '{0}'，沒有版本號碼。</value>
-  </data>
   <data name="AssetPreprocessorMustBeConfigured" xml:space="preserve">
     <value>必須設定資產前置處理器，才能處理資產。</value>
   </data>
@@ -248,5 +245,8 @@
   </data>
   <data name="RuntimeIdentifierWasNotSpecified" xml:space="preserve">
     <value>Specify a RuntimeIdentifier</value>
+  </data>
+  <data name="UnexpectedPackageDependency" xml:space="preserve">
+    <value>Unexpected dependency '{0}' in package '{1}'.</value>
   </data>
 </root>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.cs.xlf
@@ -93,11 +93,6 @@
         <target state="translated">Nepodařilo se najít vyhodnocenou cestu pro {0}.</target>
         <note />
       </trans-unit>
-      <trans-unit id="UnexpectedDependencyWithNoVersionNumber">
-        <source>Unexpected dependency '{0}' with no version number.</source>
-        <target state="translated">Nečekaná závislost {0} bez čísla verze.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AssetPreprocessorMustBeConfigured">
         <source>Asset preprocessor must be configured before assets are processed.</source>
         <target state="translated">Před zpracováním prostředků je potřeba nakonfigurovat preprocesor prostředků.</target>
@@ -221,6 +216,11 @@
       <trans-unit id="RuntimeIdentifierWasNotSpecified">
         <source>Specify a RuntimeIdentifier</source>
         <target state="new">Specify a RuntimeIdentifier</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UnexpectedPackageDependency">
+        <source>Unexpected dependency '{0}' in package '{1}'.</source>
+        <target state="new">Unexpected dependency '{0}' in package '{1}'.</target>
         <note></note>
       </trans-unit>
     </body>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.de.xlf
@@ -93,11 +93,6 @@
         <target state="translated">Der aufgelöste Pfad für "{0}" wurde nicht gefunden.</target>
         <note />
       </trans-unit>
-      <trans-unit id="UnexpectedDependencyWithNoVersionNumber">
-        <source>Unexpected dependency '{0}' with no version number.</source>
-        <target state="translated">Unerwartete Abhängigkeit "{0}" ohne Versionsnummer.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AssetPreprocessorMustBeConfigured">
         <source>Asset preprocessor must be configured before assets are processed.</source>
         <target state="translated">Der Ressourcenpräprozessor muss konfiguriert werden, bevor Ressourcen verarbeitet werden.</target>
@@ -221,6 +216,11 @@
       <trans-unit id="RuntimeIdentifierWasNotSpecified">
         <source>Specify a RuntimeIdentifier</source>
         <target state="new">Specify a RuntimeIdentifier</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UnexpectedPackageDependency">
+        <source>Unexpected dependency '{0}' in package '{1}'.</source>
+        <target state="new">Unexpected dependency '{0}' in package '{1}'.</target>
         <note></note>
       </trans-unit>
     </body>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.es.xlf
@@ -93,11 +93,6 @@
         <target state="translated">No se encuentra la ruta de acceso resuelta para '{0}'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="UnexpectedDependencyWithNoVersionNumber">
-        <source>Unexpected dependency '{0}' with no version number.</source>
-        <target state="translated">Dependencia '{0}' sin número de versión no esperada.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AssetPreprocessorMustBeConfigured">
         <source>Asset preprocessor must be configured before assets are processed.</source>
         <target state="translated">Debe configurarse el preprocesador de recursos antes de que se procesen los recursos.</target>
@@ -221,6 +216,11 @@
       <trans-unit id="RuntimeIdentifierWasNotSpecified">
         <source>Specify a RuntimeIdentifier</source>
         <target state="new">Specify a RuntimeIdentifier</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UnexpectedPackageDependency">
+        <source>Unexpected dependency '{0}' in package '{1}'.</source>
+        <target state="new">Unexpected dependency '{0}' in package '{1}'.</target>
         <note></note>
       </trans-unit>
     </body>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.fr.xlf
@@ -93,11 +93,6 @@
         <target state="translated">Chemin résolu introuvable pour '{0}'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="UnexpectedDependencyWithNoVersionNumber">
-        <source>Unexpected dependency '{0}' with no version number.</source>
-        <target state="translated">Dépendance '{0}' sans numéro de version inattendue.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AssetPreprocessorMustBeConfigured">
         <source>Asset preprocessor must be configured before assets are processed.</source>
         <target state="translated">Le préprocesseur de composants doit être configuré avant que les composants ne soient traités.</target>
@@ -221,6 +216,11 @@
       <trans-unit id="RuntimeIdentifierWasNotSpecified">
         <source>Specify a RuntimeIdentifier</source>
         <target state="new">Specify a RuntimeIdentifier</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UnexpectedPackageDependency">
+        <source>Unexpected dependency '{0}' in package '{1}'.</source>
+        <target state="new">Unexpected dependency '{0}' in package '{1}'.</target>
         <note></note>
       </trans-unit>
     </body>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.it.xlf
@@ -93,11 +93,6 @@
         <target state="translated">Il percorso risolto per '{0}' non è stato trovato.</target>
         <note />
       </trans-unit>
-      <trans-unit id="UnexpectedDependencyWithNoVersionNumber">
-        <source>Unexpected dependency '{0}' with no version number.</source>
-        <target state="translated">La dipendenza '{0}' è imprevista e non ha numero di versione.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AssetPreprocessorMustBeConfigured">
         <source>Asset preprocessor must be configured before assets are processed.</source>
         <target state="translated">Prima di elaborare le risorse, è necessario configurare il preprocessore di risorse.</target>
@@ -221,6 +216,11 @@
       <trans-unit id="RuntimeIdentifierWasNotSpecified">
         <source>Specify a RuntimeIdentifier</source>
         <target state="new">Specify a RuntimeIdentifier</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UnexpectedPackageDependency">
+        <source>Unexpected dependency '{0}' in package '{1}'.</source>
+        <target state="new">Unexpected dependency '{0}' in package '{1}'.</target>
         <note></note>
       </trans-unit>
     </body>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.ja.xlf
@@ -93,11 +93,6 @@
         <target state="translated">解決された '{0}' のパスが見つかりません。</target>
         <note />
       </trans-unit>
-      <trans-unit id="UnexpectedDependencyWithNoVersionNumber">
-        <source>Unexpected dependency '{0}' with no version number.</source>
-        <target state="translated">バージョン番号のない予期しない依存関係 '{0}' です。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AssetPreprocessorMustBeConfigured">
         <source>Asset preprocessor must be configured before assets are processed.</source>
         <target state="translated">資産を処理する前に、資産プリプロセッサを構成する必要があります。</target>
@@ -221,6 +216,11 @@
       <trans-unit id="RuntimeIdentifierWasNotSpecified">
         <source>Specify a RuntimeIdentifier</source>
         <target state="new">Specify a RuntimeIdentifier</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UnexpectedPackageDependency">
+        <source>Unexpected dependency '{0}' in package '{1}'.</source>
+        <target state="new">Unexpected dependency '{0}' in package '{1}'.</target>
         <note></note>
       </trans-unit>
     </body>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.ko.xlf
@@ -93,11 +93,6 @@
         <target state="translated">'{0}'에 대해 확인된 경로를 찾을 수 없습니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="UnexpectedDependencyWithNoVersionNumber">
-        <source>Unexpected dependency '{0}' with no version number.</source>
-        <target state="translated">버전 번호가 없는 예기치 않은 종속성 '{0}'입니다.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AssetPreprocessorMustBeConfigured">
         <source>Asset preprocessor must be configured before assets are processed.</source>
         <target state="translated">자산을 처리하려면 먼저 자산 전처리기를 구성해야 합니다.</target>
@@ -221,6 +216,11 @@
       <trans-unit id="RuntimeIdentifierWasNotSpecified">
         <source>Specify a RuntimeIdentifier</source>
         <target state="new">Specify a RuntimeIdentifier</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UnexpectedPackageDependency">
+        <source>Unexpected dependency '{0}' in package '{1}'.</source>
+        <target state="new">Unexpected dependency '{0}' in package '{1}'.</target>
         <note></note>
       </trans-unit>
     </body>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.pl.xlf
@@ -93,11 +93,6 @@
         <target state="translated">Nie można odnaleźć rozpoznanej ścieżki dla elementu „{0}”.</target>
         <note />
       </trans-unit>
-      <trans-unit id="UnexpectedDependencyWithNoVersionNumber">
-        <source>Unexpected dependency '{0}' with no version number.</source>
-        <target state="translated">Nieoczekiwana zależność „{0}” bez numeru wersji.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AssetPreprocessorMustBeConfigured">
         <source>Asset preprocessor must be configured before assets are processed.</source>
         <target state="translated">Preprocesor zasobów musi być skonfigurowany przed przetworzeniem zasobów.</target>
@@ -221,6 +216,11 @@
       <trans-unit id="RuntimeIdentifierWasNotSpecified">
         <source>Specify a RuntimeIdentifier</source>
         <target state="new">Specify a RuntimeIdentifier</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UnexpectedPackageDependency">
+        <source>Unexpected dependency '{0}' in package '{1}'.</source>
+        <target state="new">Unexpected dependency '{0}' in package '{1}'.</target>
         <note></note>
       </trans-unit>
     </body>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.pt-BR.xlf
@@ -93,11 +93,6 @@
         <target state="translated">Não foi possível localizar o caminho resolvido para '{0}'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="UnexpectedDependencyWithNoVersionNumber">
-        <source>Unexpected dependency '{0}' with no version number.</source>
-        <target state="translated">Dependência inesperada '{0}' sem número de versão.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AssetPreprocessorMustBeConfigured">
         <source>Asset preprocessor must be configured before assets are processed.</source>
         <target state="translated">O pré-processador de ativos deve ser configurado antes de os ativos serem processados.</target>
@@ -221,6 +216,11 @@
       <trans-unit id="RuntimeIdentifierWasNotSpecified">
         <source>Specify a RuntimeIdentifier</source>
         <target state="new">Specify a RuntimeIdentifier</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UnexpectedPackageDependency">
+        <source>Unexpected dependency '{0}' in package '{1}'.</source>
+        <target state="new">Unexpected dependency '{0}' in package '{1}'.</target>
         <note></note>
       </trans-unit>
     </body>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.ru.xlf
@@ -93,11 +93,6 @@
         <target state="translated">Не удается найти разрешенный путь для "{0}".</target>
         <note />
       </trans-unit>
-      <trans-unit id="UnexpectedDependencyWithNoVersionNumber">
-        <source>Unexpected dependency '{0}' with no version number.</source>
-        <target state="translated">Непредвиденная зависимость "{0}" без номера версии.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AssetPreprocessorMustBeConfigured">
         <source>Asset preprocessor must be configured before assets are processed.</source>
         <target state="translated">Препроцессор ресурсов необходимо настроить перед обработкой ресурсов.</target>
@@ -221,6 +216,11 @@
       <trans-unit id="RuntimeIdentifierWasNotSpecified">
         <source>Specify a RuntimeIdentifier</source>
         <target state="new">Specify a RuntimeIdentifier</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UnexpectedPackageDependency">
+        <source>Unexpected dependency '{0}' in package '{1}'.</source>
+        <target state="new">Unexpected dependency '{0}' in package '{1}'.</target>
         <note></note>
       </trans-unit>
     </body>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.tr.xlf
@@ -93,11 +93,6 @@
         <target state="translated">'{0}' için çözümlenmiş yol bulunamıyor.</target>
         <note />
       </trans-unit>
-      <trans-unit id="UnexpectedDependencyWithNoVersionNumber">
-        <source>Unexpected dependency '{0}' with no version number.</source>
-        <target state="translated">Sürüm numarası olmayan, beklenmeyen bağımlılık: '{0}'.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AssetPreprocessorMustBeConfigured">
         <source>Asset preprocessor must be configured before assets are processed.</source>
         <target state="translated">Varlıkların işlenebilmesi için varlık ön işlemcisi yapılandırılmalıdır.</target>
@@ -221,6 +216,11 @@
       <trans-unit id="RuntimeIdentifierWasNotSpecified">
         <source>Specify a RuntimeIdentifier</source>
         <target state="new">Specify a RuntimeIdentifier</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UnexpectedPackageDependency">
+        <source>Unexpected dependency '{0}' in package '{1}'.</source>
+        <target state="new">Unexpected dependency '{0}' in package '{1}'.</target>
         <note></note>
       </trans-unit>
     </body>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.xlf
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.xlf
@@ -75,10 +75,6 @@
         <source>Unable to find resolved path for '{0}'.</source>
         <note />
       </trans-unit>
-      <trans-unit id="UnexpectedDependencyWithNoVersionNumber">
-        <source>Unexpected dependency '{0}' with no version number.</source>
-        <note />
-      </trans-unit>
       <trans-unit id="AssetPreprocessorMustBeConfigured">
         <source>Asset preprocessor must be configured before assets are processed.</source>
         <note />
@@ -177,6 +173,10 @@
       </trans-unit>
       <trans-unit id="RuntimeIdentifierWasNotSpecified">
         <source>Specify a RuntimeIdentifier</source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UnexpectedPackageDependency">
+        <source>Unexpected dependency '{0}' in package '{1}'.</source>
         <note></note>
       </trans-unit>
     </body>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.zh-Hans.xlf
@@ -93,11 +93,6 @@
         <target state="translated">找不到“{0}”的已解析路径。</target>
         <note />
       </trans-unit>
-      <trans-unit id="UnexpectedDependencyWithNoVersionNumber">
-        <source>Unexpected dependency '{0}' with no version number.</source>
-        <target state="translated">不具有版本号的意外依赖项“{0}”。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AssetPreprocessorMustBeConfigured">
         <source>Asset preprocessor must be configured before assets are processed.</source>
         <target state="translated">必须在处理资产之前配置资产预处理器。</target>
@@ -221,6 +216,11 @@
       <trans-unit id="RuntimeIdentifierWasNotSpecified">
         <source>Specify a RuntimeIdentifier</source>
         <target state="new">Specify a RuntimeIdentifier</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UnexpectedPackageDependency">
+        <source>Unexpected dependency '{0}' in package '{1}'.</source>
+        <target state="new">Unexpected dependency '{0}' in package '{1}'.</target>
         <note></note>
       </trans-unit>
     </body>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.zh-Hant.xlf
@@ -93,11 +93,6 @@
         <target state="translated">找不到 '{0}' 的解析路徑。</target>
         <note />
       </trans-unit>
-      <trans-unit id="UnexpectedDependencyWithNoVersionNumber">
-        <source>Unexpected dependency '{0}' with no version number.</source>
-        <target state="translated">未預期的相依性 '{0}'，沒有版本號碼。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AssetPreprocessorMustBeConfigured">
         <source>Asset preprocessor must be configured before assets are processed.</source>
         <target state="translated">必須設定資產前置處理器，才能處理資產。</target>
@@ -221,6 +216,11 @@
       <trans-unit id="RuntimeIdentifierWasNotSpecified">
         <source>Specify a RuntimeIdentifier</source>
         <target state="new">Specify a RuntimeIdentifier</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UnexpectedPackageDependency">
+        <source>Unexpected dependency '{0}' in package '{1}'.</source>
+        <target state="new">Unexpected dependency '{0}' in package '{1}'.</target>
         <note></note>
       </trans-unit>
     </body>


### PR DESCRIPTION
Partially addresses https://github.com/NuGet/Home/issues/4724
(Part of series in https://github.com/dotnet/roslyn-project-system/issues/1660)

An error about unexpected dependencies is reported by the SDK when a project is unloaded (and in other situations that result in a dependency that does not appear in the asset file's "library" section).

Long term, we should move this validation of the assets file to the NuGet client, and add any problems found to project.assets.json from whence it can be raised to an MSBuild error by this SDK task (as requested in https://github.com/NuGet/Home/issues/1599).

But this is a minor change to clean up this error so it is only reported once per project, removing all the duplicate errors reported in https://github.com/NuGet/Home/issues/4724. (Also reworded the error since it has nothing to do with missing version numbers.)

/cc @davkean @nguerrera @dsplaisted @dotnet/project-system 
/cc @emgarten as fyi