### PR TITLE
Bump dependency versions to RTM

### DIFF
--- a/TestAssets/TestProjects/AppWithLibraryAndRid/App/App.csproj
+++ b/TestAssets/TestProjects/AppWithLibraryAndRid/App/App.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp1.1</TargetFramework>
-    <RuntimeIdentifiers>osx.10.11-x64;ubuntu.16.04-x64;ubuntu.14.04-x64;win10-x64;win81-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>osx.10.11-x64;osx.10.12-x64;ubuntu.16.04-x64;ubuntu.14.04-x64;win10-x64;win81-x64</RuntimeIdentifiers>
   </PropertyGroup>
 
   <ItemGroup>

--- a/TestAssets/TestProjects/AppWithLibraryAndRid/LibraryWithRid/NativeCode.cs
+++ b/TestAssets/TestProjects/AppWithLibraryAndRid/LibraryWithRid/NativeCode.cs
@@ -14,6 +14,7 @@ namespace LibraryWithRid
                 case "'ubuntu.14.04-x64'":
                     return Marshal.PtrToStringAnsi(LinuxNativeMethods.sqlite3_libversion());
                 case "'osx.10.11-x64'": 
+                case "'osx.10.12-x64'":
                     return Marshal.PtrToStringAnsi(MacNativeMethods.sqlite3_libversion());
                 case "'win10-x64'":
                 case "'win81-x64'":

--- a/TestAssets/TestProjects/AppWithLibraryAndRid/LibraryWithRids/LibraryWithRids.csproj
+++ b/TestAssets/TestProjects/AppWithLibraryAndRid/LibraryWithRids/LibraryWithRids.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard1.4</TargetFramework>
-    <RuntimeIdentifiers>osx.10.11-x64;ubuntu.16.04-x64;ubuntu.14.04-x64;win10-x64;win81-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>osx.10.11-x64;osx.10.12-x64;ubuntu.16.04-x64;ubuntu.14.04-x64;win10-x64;win81-x64</RuntimeIdentifiers>
     <Description>'$(RuntimeIdentifier)'</Description>
   </PropertyGroup>
   <ItemGroup>

--- a/TestAssets/TestProjects/AppWithLibraryAndRid/LibraryWithRids/NativeCode.cs
+++ b/TestAssets/TestProjects/AppWithLibraryAndRid/LibraryWithRids/NativeCode.cs
@@ -14,6 +14,7 @@ namespace LibraryWithRids
                 case "'ubuntu.14.04-x64'":
                     return Marshal.PtrToStringAnsi(LinuxNativeMethods.sqlite3_libversion());
                 case "'osx.10.11-x64'": 
+                case "'osx.10.12-x64'":
                     return Marshal.PtrToStringAnsi(MacNativeMethods.sqlite3_libversion());
                 case "'win10-x64'":
                 case "'win81-x64'":

--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -3,7 +3,7 @@
   <!-- This file is imported by all projects at the beginning of the project files -->
 
   <PropertyGroup>
-    <MsBuildPackagesVersion>0.1.0-preview-00028-160627</MsBuildPackagesVersion>
+    <MsBuildPackagesVersion>15.1.548</MsBuildPackagesVersion>
     <DependencyModelVersion>1.0.3</DependencyModelVersion>
     <PlatformAbstractionsVersion>1.0.3</PlatformAbstractionsVersion>
     <NuGetVersion>4.3.0-beta1-2342</NuGetVersion>
@@ -13,11 +13,11 @@
   <PropertyGroup>
     <MicrosoftNETCoreApp20Version>2.0.0-beta-001509-00</MicrosoftNETCoreApp20Version>
     <xunitVersion>2.1.0</xunitVersion>
-    <FluentAssertionsVersion>4.0.0</FluentAssertionsVersion>
-    <FluentAssertionsJsonVersion>4.12.0</FluentAssertionsJsonVersion>
+    <FluentAssertionsVersion>4.19.2</FluentAssertionsVersion>
+    <FluentAssertionsJsonVersion>4.19.0</FluentAssertionsJsonVersion>
     <NewtonsoftJsonVersion>9.0.1</NewtonsoftJsonVersion>
     <NewtonsoftJsonOnNetFrameworkVersion>6.0.4</NewtonsoftJsonOnNetFrameworkVersion>
-    <DotNetCliUtilsVersion>1.0.0-preview2-003121</DotNetCliUtilsVersion>
+    <DotNetCliUtilsVersion>1.0.1</DotNetCliUtilsVersion>
   </PropertyGroup>
   
 </Project>

--- a/build/Nuget/Microsoft.NET.Sdk.Nuget.targets
+++ b/build/Nuget/Microsoft.NET.Sdk.Nuget.targets
@@ -8,7 +8,7 @@
       <PackageFile Include="$(OutDir)build\**\*.*" Folder="build" />
       <PackageFile Include="$(OutDir)buildCrossTargeting\**\*.*" Folder="buildCrossTargeting" />
       <PackageFile Include="$(OutDir)sdk\**\*.*" Folder="Sdk" />
-      <PackageFile Include="$(NuGet_Packages)\newtonsoft.json\6.0.4\lib\net45\Newtonsoft.Json.dll" Folder="tools\net46\Newtonsoft.Json.6.0.4" />
+      <PackageFile Include="$(NuGet_Packages)\newtonsoft.json\$(NewtonsoftJsonOnNetFrameworkVersion)\lib\net45\Newtonsoft.Json.dll" Folder="tools\net46\Newtonsoft.Json.6.0.4" Condition="'$(OS)' == 'Windows_NT'" />
     </ItemGroup>
 
     <Copy SourceFiles="@(PackageFile)" 

--- a/src/Dependencies/xUnit.net/xUnit.net.csproj
+++ b/src/Dependencies/xUnit.net/xUnit.net.csproj
@@ -44,13 +44,17 @@
       <CopyLocalAssembly Include="xunit.runner.utility.dotnet">
         <RelativePath>xunit.runner.utility\$(XUnitVersion)\lib\dotnet\xunit.runner.utility.dotnet.dll</RelativePath>
       </CopyLocalAssembly>
+      <CopyLocalAssembly Include="fluentassertions">
+        <RelativePath>fluentassertions\$(FluentAssertionsVersion)\lib\netstandard1.3\FluentAssertions.dll</RelativePath>
+      </CopyLocalAssembly>
+      <CopyLocalAssembly Include="fluentassertions.core">
+        <RelativePath>fluentassertions\$(FluentAssertionsVersion)\lib\netstandard1.3\FluentAssertions.Core.dll</RelativePath>
+      </CopyLocalAssembly>
+      <CopyLocalAssembly Include="fluentassertions.json">
+        <RelativePath>fluentassertions.json\$(FluentAssertionsJsonVersion)\lib\netstandard1.3\FluentAssertions.Json.dll</RelativePath>
+      </CopyLocalAssembly>
 
       <TestCopyLocalAssembly Include="$(NuGet_Packages)\%(CopyLocalAssembly.RelativePath)" />
-
-      <FluentAssertionsPackage Include="fluentassertions" />
-      <FluentAssertionsPackage Include="fluentassertions.json" />
-
-      <TestCopyLocalAssembly Include="$(NuGet_Packages)\%(FluentAssertionsPackage.Identity)\4.12.0\lib\netstandard1.3\*.dll" />
     </ItemGroup>
 
     <Copy SourceFiles="%(TestCopyLocalAssembly.FullPath)" DestinationFolder="$(OutDir)" />

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildASelfContainedApp.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildASelfContainedApp.cs
@@ -3,7 +3,7 @@
 
 using FluentAssertions;
 using Microsoft.DotNet.Cli.Utils;
-using Microsoft.DotNet.InternalAbstractions;
+using Microsoft.DotNet.PlatformAbstractions;
 using Microsoft.NET.TestFramework;
 using Microsoft.NET.TestFramework.Commands;
 using Microsoft.NET.TestFramework.Assertions;

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildASelfContainedAppWithRid.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildASelfContainedAppWithRid.cs
@@ -3,7 +3,7 @@
 
 using FluentAssertions;
 using Microsoft.DotNet.Cli.Utils;
-using Microsoft.DotNet.InternalAbstractions;
+using Microsoft.DotNet.PlatformAbstractions;
 using Microsoft.NET.TestFramework;
 using Microsoft.NET.TestFramework.Commands;
 using Microsoft.NET.TestFramework.Assertions;

--- a/test/Microsoft.NET.Pack.Tests/GivenThatWeWantToPackACrossTargetedLibrary.cs
+++ b/test/Microsoft.NET.Pack.Tests/GivenThatWeWantToPackACrossTargetedLibrary.cs
@@ -4,7 +4,7 @@
 using System.IO;
 using System.Runtime.InteropServices;
 using Microsoft.DotNet.Cli.Utils;
-using Microsoft.DotNet.InternalAbstractions;
+using Microsoft.DotNet.PlatformAbstractions;
 using Microsoft.NET.TestFramework;
 using Microsoft.NET.TestFramework.Assertions;
 using Microsoft.NET.TestFramework.Commands;

--- a/test/Microsoft.NET.Pack.Tests/GivenThatWeWantToPackASimpleLibrary.cs
+++ b/test/Microsoft.NET.Pack.Tests/GivenThatWeWantToPackASimpleLibrary.cs
@@ -4,7 +4,7 @@
 using System.IO;
 using System.Runtime.InteropServices;
 using Microsoft.DotNet.Cli.Utils;
-using Microsoft.DotNet.InternalAbstractions;
+using Microsoft.DotNet.PlatformAbstractions;
 using Microsoft.NET.TestFramework;
 using Microsoft.NET.TestFramework.Assertions;
 using Microsoft.NET.TestFramework.Commands;

--- a/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToCacheAProjectWithDependencies.cs
+++ b/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToCacheAProjectWithDependencies.cs
@@ -10,7 +10,7 @@ using Microsoft.NET.TestFramework.Commands;
 using Xunit;
 using static Microsoft.NET.TestFramework.Commands.MSBuildTest;
 using System.Runtime.InteropServices;
-using Microsoft.DotNet.InternalAbstractions;
+using Microsoft.DotNet.PlatformAbstractions;
 using Microsoft.NET.Build.Tasks;
 using FluentAssertions;
 using NuGet.Versioning;

--- a/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToExcludeAPackageFromPublish.cs
+++ b/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToExcludeAPackageFromPublish.cs
@@ -4,7 +4,7 @@
 using System.IO;
 using System.Runtime.InteropServices;
 using Microsoft.DotNet.Cli.Utils;
-using Microsoft.DotNet.InternalAbstractions;
+using Microsoft.DotNet.PlatformAbstractions;
 using Microsoft.NET.TestFramework;
 using Microsoft.NET.TestFramework.Assertions;
 using Microsoft.NET.TestFramework.Commands;

--- a/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAHelloWorldProject.cs
+++ b/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAHelloWorldProject.cs
@@ -4,7 +4,7 @@
 using System.IO;
 using System.Runtime.InteropServices;
 using Microsoft.DotNet.Cli.Utils;
-using Microsoft.DotNet.InternalAbstractions;
+using Microsoft.DotNet.PlatformAbstractions;
 using Microsoft.NET.TestFramework;
 using Microsoft.NET.TestFramework.Assertions;
 using Microsoft.NET.TestFramework.Commands;

--- a/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAProjectWithDependencies.cs
+++ b/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAProjectWithDependencies.cs
@@ -9,7 +9,7 @@ using Microsoft.NET.TestFramework.Assertions;
 using Microsoft.NET.TestFramework.Commands;
 using Xunit;
 using static Microsoft.NET.TestFramework.Commands.MSBuildTest;
-using Microsoft.DotNet.InternalAbstractions;
+using Microsoft.DotNet.PlatformAbstractions;
 using System.Runtime.InteropServices;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;

--- a/test/Microsoft.NET.TestFramework/Commands/ComposeCache.cs
+++ b/test/Microsoft.NET.TestFramework/Commands/ComposeCache.cs
@@ -6,7 +6,7 @@ using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
 using Microsoft.DotNet.Cli.Utils;
-using Microsoft.DotNet.InternalAbstractions;
+using Microsoft.DotNet.PlatformAbstractions;
 
 namespace Microsoft.NET.TestFramework.Commands
 {

--- a/test/Microsoft.NET.TestFramework/Commands/PublishCommand.cs
+++ b/test/Microsoft.NET.TestFramework/Commands/PublishCommand.cs
@@ -6,7 +6,7 @@ using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
 using Microsoft.DotNet.Cli.Utils;
-using Microsoft.DotNet.InternalAbstractions;
+using Microsoft.DotNet.PlatformAbstractions;
 
 namespace Microsoft.NET.TestFramework.Commands
 {

--- a/test/Microsoft.NET.TestFramework/EnvironmentInfo.cs
+++ b/test/Microsoft.NET.TestFramework/EnvironmentInfo.cs
@@ -4,7 +4,7 @@
 using System;
 using System.IO;
 using System.Runtime.InteropServices;
-using Microsoft.DotNet.InternalAbstractions;
+using Microsoft.DotNet.PlatformAbstractions;
 
 namespace Microsoft.NET.TestFramework
 {

--- a/test/Microsoft.NET.TestFramework/Microsoft.NET.TestFramework.csproj
+++ b/test/Microsoft.NET.TestFramework/Microsoft.NET.TestFramework.csproj
@@ -50,14 +50,10 @@
     <ItemGroup>
       <CopyLocalAssembly Include="Microsoft.DotNet.Cli.Utils">
         <Version>$(DotNetCliUtilsVersion)</Version>
-        <TFM>netstandard1.6</TFM>
+        <TFM>netstandard1.5</TFM>
       </CopyLocalAssembly>
-      <CopyLocalAssembly Include="Microsoft.DotNet.ProjectModel">
-        <Version>1.0.0-rc3-003121</Version>
-        <TFM>netstandard1.6</TFM>
-      </CopyLocalAssembly>
-      <CopyLocalAssembly Include="Microsoft.DotNet.InternalAbstractions">
-        <Version>1.0.0</Version>
+      <CopyLocalAssembly Include="Microsoft.DotNet.PlatformAbstractions">
+        <Version>$(PlatformAbstractionsVersion)</Version>
         <TFM>netstandard1.3</TFM>
       </CopyLocalAssembly>
       <CopyLocalAssembly>

--- a/test/Microsoft.NET.TestFramework/Microsoft.NET.TestFramework.csproj
+++ b/test/Microsoft.NET.TestFramework/Microsoft.NET.TestFramework.csproj
@@ -52,6 +52,10 @@
         <Version>$(DotNetCliUtilsVersion)</Version>
         <TFM>netstandard1.5</TFM>
       </CopyLocalAssembly>
+      <CopyLocalAssembly Include="Microsoft.Build">
+        <Version>$(MSBuildPackagesVersion)</Version>
+        <TFM>netstandard1.5</TFM>
+      </CopyLocalAssembly>
       <CopyLocalAssembly Include="Microsoft.DotNet.PlatformAbstractions">
         <Version>$(PlatformAbstractionsVersion)</Version>
         <TFM>netstandard1.3</TFM>


### PR DESCRIPTION
Also bumped FluentAssertions versions to latest.

I am still working to get rid of the remaining manual copying, but separating the package upgrades from that here.

@eerhardt @dsplaisted @livarcocc 