### PR TITLE
Import Microsoft.Common.Props before Microsoft.NET.Sdk.props

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.CSharp.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.CSharp.props
@@ -13,11 +13,11 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <PropertyGroup>
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
-    <WarningLevel>4</WarningLevel>
-    <NoWarn>1701;1702;1705</NoWarn>
+    <WarningLevel Condition=" '$(WarningLevel)' == '' ">4</WarningLevel>
+    <NoWarn Condition=" '$(NoWarn)' == '' ">1701;1702;1705</NoWarn>
   </PropertyGroup>
   <PropertyGroup>
-    <DefineConstants>TRACE</DefineConstants>
+    <DefineConstants>$(DefineConstants);TRACE</DefineConstants>
   </PropertyGroup>
 
 </Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.CSharp.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.CSharp.props
@@ -17,7 +17,8 @@ Copyright (c) .NET Foundation. All rights reserved.
     <NoWarn Condition=" '$(NoWarn)' == '' ">1701;1702;1705</NoWarn>
   </PropertyGroup>
   <PropertyGroup>
-    <DefineConstants>$(DefineConstants);TRACE</DefineConstants>
+    <DefineConstants Condition=" '$(DefineConstants)' != '' ">$(DefineConstants);</DefineConstants>
+    <DefineConstants>$(DefineConstants)TRACE</DefineConstants>
   </PropertyGroup>
 
 </Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.VisualBasic.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.VisualBasic.props
@@ -12,15 +12,15 @@ Copyright (c) .NET Foundation. All rights reserved.
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
-    <VBRuntime>Embed</VBRuntime>
+    <VBRuntime Condition=" '$(VBRuntime)' == '' ">Embed</VBRuntime>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
-    <DefineDebug>true</DefineDebug>
-    <DefineTrace>true</DefineTrace>
+    <DefineDebug Condition=" '$(DefineDebug)' == '' ">true</DefineDebug>
+    <DefineTrace Condition=" '$(DefineTrace)' == '' ">true</DefineTrace>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
-    <DefineTrace>true</DefineTrace>
+    <DefineTrace Condition=" '$(DefineTrace)' == '' ">true</DefineTrace>
   </PropertyGroup>
 
 </Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.props
@@ -84,7 +84,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <DebugType Condition=" '$(DebugType)' == '' ">portable</DebugType>
 
     <!-- This will turn off the base UWP-specific 'ResolveNuGetPackages' target -->
-    <ResolveNuGetPackages >false</ResolveNuGetPackages>
+    <ResolveNuGetPackages>false</ResolveNuGetPackages>
 
     <!-- Skip import of Microsoft.NuGet.props and Microsoft.NuGet.targets -->
     <SkipImportNuGetProps>true</SkipImportNuGetProps>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.props
@@ -34,22 +34,22 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <!-- User-facing configuration-agnostic defaults -->
   <PropertyGroup>
-    <OutputType>Library</OutputType>
-    <FileAlignment>512</FileAlignment>
-    <ErrorReport>prompt</ErrorReport>
-    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
-    <RootNamespace>$(MSBuildProjectName)</RootNamespace>
-    <Deterministic>true</Deterministic>
+    <OutputType Condition=" '$(OutputType)' == '' ">Library</OutputType>
+    <FileAlignment Condition=" '$(FileAlignment)' == '' ">512</FileAlignment>
+    <ErrorReport Condition=" '$(ErrorReport)' == '' ">prompt</ErrorReport>
+    <AssemblyName Condition=" '$(AssemblyName)' == '' ">$(MSBuildProjectName)</AssemblyName>
+    <RootNamespace Condition=" '$(RootNamespace)' == '' ">$(MSBuildProjectName)</RootNamespace>
+    <Deterministic Condition=" '$(Deterministic)' == '' ">true</Deterministic>
   </PropertyGroup>
 
   <!-- User-facing configuration-specific defaults -->
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
-    <DebugSymbols>true</DebugSymbols>
-    <Optimize>false</Optimize>
+    <DebugSymbols Condition=" '$(DebugSymbols)' == '' ">true</DebugSymbols>
+    <Optimize Condition=" '$(Optimize)' == '' ">false</Optimize>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
-    <Optimize>true</Optimize>
+    <Optimize Condition=" '$(Optimize)' == '' ">true</Optimize>
   </PropertyGroup>
 
   <!-- User-facing platform-specific defaults -->
@@ -70,21 +70,21 @@ Copyright (c) .NET Foundation. All rights reserved.
     <_PlatformWithoutConfigurationInference>$(Platform)</_PlatformWithoutConfigurationInference>
   </PropertyGroup>  
   <PropertyGroup Condition=" '$(_PlatformWithoutConfigurationInference)' == 'x64' ">
-    <PlatformTarget>x64</PlatformTarget>
+    <PlatformTarget Condition=" '$(PlatformTarget)' == '' ">x64</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(_PlatformWithoutConfigurationInference)' == 'x86' ">
-    <PlatformTarget>x86</PlatformTarget>
+    <PlatformTarget Condition=" '$(PlatformTarget)' == '' ">x86</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(_PlatformWithoutConfigurationInference)' == 'ARM' ">
-    <PlatformTarget>ARM</PlatformTarget>
+    <PlatformTarget Condition=" '$(PlatformTarget)' == '' ">ARM</PlatformTarget>
   </PropertyGroup>
 
   <!-- Default settings for all projects built with this Sdk package -->
   <PropertyGroup>
-    <DebugType>portable</DebugType>
+    <DebugType Condition=" '$(DebugType)' == '' ">portable</DebugType>
 
     <!-- This will turn off the base UWP-specific 'ResolveNuGetPackages' target -->
-    <ResolveNuGetPackages>false</ResolveNuGetPackages>
+    <ResolveNuGetPackages >false</ResolveNuGetPackages>
 
     <!-- Skip import of Microsoft.NuGet.props and Microsoft.NuGet.targets -->
     <SkipImportNuGetProps>true</SkipImportNuGetProps>
@@ -96,8 +96,8 @@ Copyright (c) .NET Foundation. All rights reserved.
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
     
     <!-- Exclude GAC, registry, output directory from search paths. -->
-    <AssemblySearchPaths>{CandidateAssemblyFiles};{HintPathFromItem};{TargetFrameworkDirectory};{RawFileName}</AssemblySearchPaths>
-    <DesignTimeAssemblySearchPaths>$(AssemblySearchPaths)</DesignTimeAssemblySearchPaths>
+    <AssemblySearchPaths Condition=" '$(AssemblySearchPaths)' == '' ">{CandidateAssemblyFiles};{HintPathFromItem};{TargetFrameworkDirectory};{RawFileName}</AssemblySearchPaths>
+    <DesignTimeAssemblySearchPaths Condition=" '$(DesignTimeAssemblySearchPaths)' == '' ">$(AssemblySearchPaths)</DesignTimeAssemblySearchPaths>
 
     <AllowUnsafeBlocks Condition="'$(AllowUnsafeBlocks)'==''">false</AllowUnsafeBlocks>
     <TreatWarningsAsErrors Condition="'$(TreatWarningsAsErrors)'==''">false</TreatWarningsAsErrors>
@@ -116,7 +116,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <!-- Temporary workarounds -->
   <PropertyGroup>
     <!-- Workaround: https://github.com/dotnet/roslyn/issues/12167 -->
-    <NoLogo>true</NoLogo>
+    <NoLogo Condition=" '$(NoLogo)' == '' ">true</NoLogo>
 
     <!-- Workaround: https://github.com/Microsoft/msbuild/issues/720 -->
     <OverrideToolHost Condition=" '$(DotnetHostPath)' != '' and '$(OverrideToolHost)' == ''">$(DotnetHostPath)</OverrideToolHost>
@@ -124,8 +124,8 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <!-- Workaround: https://github.com/Microsoft/msbuild/issues/1293 -->
   <PropertyGroup Condition="'$(MSBuildRuntimeType)' == 'Core'"> 
-    <GenerateResourceMSBuildArchitecture>CurrentArchitecture</GenerateResourceMSBuildArchitecture>
-    <GenerateResourceMSBuildRuntime>CurrentRuntime</GenerateResourceMSBuildRuntime>
+    <GenerateResourceMSBuildArchitecture Condition=" '$(GenerateResourceMSBuildArchitecture)' == '' ">CurrentArchitecture</GenerateResourceMSBuildArchitecture>
+    <GenerateResourceMSBuildRuntime Condition=" '$(GenerateResourceMSBuildRuntime)' == '' ">CurrentRuntime</GenerateResourceMSBuildRuntime>
   </PropertyGroup>
 
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.NET.Sdk.CSharp.props" Condition="'$(MSBuildProjectExtension)' == '.csproj'" />

--- a/src/Tasks/Microsoft.NET.Build.Tasks/sdk/Sdk.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/sdk/Sdk.props
@@ -15,6 +15,6 @@ Copyright (c) .NET Foundation. All rights reserved.
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
   </PropertyGroup>
 
-  <Import Project="$(MSBuildThisFileDirectory)..\build\Microsoft.NET.Sdk.props"  />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" />
+  <Import Project="$(MSBuildThisFileDirectory)..\build\Microsoft.NET.Sdk.props"  />  
 </Project>

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToSetPropertiesInDirectoryBuildProps.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToSetPropertiesInDirectoryBuildProps.cs
@@ -15,7 +15,6 @@ namespace Microsoft.NET.Build.Tests
 {
     public class GivenThatWeWantToSetPropertiesInDirectoryBuildProps : SdkTest
     {
-
         [Fact]
         public void The_default_configuration_can_be_set_to_release()
         {

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToSetPropertiesInDirectoryBuildProps.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToSetPropertiesInDirectoryBuildProps.cs
@@ -1,0 +1,82 @@
+﻿using FluentAssertions;
+using Microsoft.NET.TestFramework;
+using Microsoft.NET.TestFramework.Assertions;
+using Microsoft.NET.TestFramework.ProjectConstruction;
+using Microsoft.NET.TestFramework.Commands;
+using static Microsoft.NET.TestFramework.Commands.MSBuildTest;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Xml.Linq;
+using Xunit;
+
+namespace Microsoft.NET.Build.Tests
+{
+    public class GivenThatWeWantToSetPropertiesInDirectoryBuildProps : SdkTest
+    {
+
+        [Fact]
+        public void The_default_configuration_can_be_set_to_release()
+        {
+            TestProject project = new TestProject()
+            {
+                Name = "DirectoryBuildPropsTest",
+                TargetFrameworks = "netstandard1.4",
+                IsSdkProject = true
+            };
+
+            var testAsset = _testAssetsManager.CreateTestProject(project);
+
+            string directoryBuildPropsPath = Path.Combine(testAsset.Path, "Directory.Build.props");
+            
+            var directoryBuildPropsContent = @"
+<Project>
+  <PropertyGroup>
+    <Configuration Condition="" '$(Configuration)' == '' "">Release</Configuration>
+  </PropertyGroup>
+</Project>
+";
+
+            File.WriteAllText(directoryBuildPropsPath, directoryBuildPropsContent);
+
+            var restoreCommand = testAsset.GetRestoreCommand(project.Name);
+
+            restoreCommand
+                .Execute()
+                .Should()
+                .Pass();
+
+            string projectFolder = Path.Combine(testAsset.Path, project.Name);
+
+            var buildCommand = new BuildCommand(Stage0MSBuild, projectFolder);
+
+            buildCommand
+                .Execute()
+                .Should()
+                .Pass();
+
+            string GetPropertyValue(string propertyName)
+            {
+                var getValuesCommand = new GetValuesCommand(Stage0MSBuild, projectFolder,
+                    project.TargetFrameworks, propertyName, GetValuesCommand.ValueType.Property)
+                {
+                    Configuration = "Release"
+                };
+
+                getValuesCommand
+                    .Execute()
+                    .Should()
+                    .Pass();
+
+                var values = getValuesCommand.GetValues();
+                values.Count.Should().Be(1);
+                return values[0];
+            }
+
+            GetPropertyValue("Configuration").Should().Be("Release");
+            GetPropertyValue("Optimize").Should().Be("true");
+        }
+
+    }
+}

--- a/test/Microsoft.NET.TestFramework/Commands/GetValuesCommand.cs
+++ b/test/Microsoft.NET.TestFramework/Commands/GetValuesCommand.cs
@@ -87,10 +87,6 @@ namespace Microsoft.NET.TestFramework.Commands
             string outputFilename = $"{_valueName}Values.txt";
             var outputDirectory = GetOutputDirectory(_targetFramework, Configuration ?? "Debug");
 
-            outputDirectory.Should().OnlyHaveFiles(new[] {
-                outputFilename,
-            });
-
             return File.ReadAllLines(Path.Combine(outputDirectory.FullName, outputFilename))
                 .Select(line => line.Trim())
                 .Where(line => !string.IsNullOrEmpty(line))


### PR DESCRIPTION
We had some discussion in #924 about how we might import Directory.Build.props files before the .NET SDK's .props files.  I've realized that there may be a simpler solution to this: simply import Microsoft.Common.props before Microsoft.NET.Sdk.props.

I've looked at this a bit and it doesn't look like there is any specific reason that we were importing the SDK .props first.  The main thing that I noted with this change is that .props files from NuGet packages would be imported before the defaults from Microsoft.NET.Sdk.props were set.

We would probably want to add a test to cover this, but I wanted to get this PR out there to start getting feedback on this approach to solving the problem.

@nguerrera @rainersigwald @eerhardt @jeffkl