### PR TITLE
Fix ubuntu 16 properly

### DIFF
--- a/TestAssets/TestProjects/SimpleCache/SimpleCache.xml
+++ b/TestAssets/TestProjects/SimpleCache/SimpleCache.xml
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
     <ItemGroup>
         <PackageReference Include="System.Private.Uri" Version="4.4.0-beta-24821-02" />
-        <PackageReference Include="Microsoft.NETCore.DotNetAppHost" Version="1.2.0-beta-001304-00" />
+        <PackageReference Include="Microsoft.NETCore.CoreDisTools" Version="1.0.1-prerelease-00001" />
   </ItemGroup>
 
 </Project>

--- a/TestAssets/TestProjects/UnmanagedCache/UnmanagedCache.csproj
+++ b/TestAssets/TestProjects/UnmanagedCache/UnmanagedCache.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
     <ItemGroup>
-        <PackageReference Include="Microsoft.NETCore.DotNetAppHost" Version="1.2.0-beta-001304-00" />
+        <PackageReference Include="Microsoft.NETCore.CoreDisTools" Version="1.0.1-prerelease-00001" />
   </ItemGroup>
 
 </Project>

--- a/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToCacheAProjectWithDependencies.cs
+++ b/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToCacheAProjectWithDependencies.cs
@@ -21,6 +21,7 @@ namespace Microsoft.NET.Publish.Tests
 {
     public class GivenThatWeWantToCacheAProjectWithDependencies : SdkTest
     {
+        private static string _libPrefix;
         private static string _runtimeOs;
         private static string _runtimeLibOs;
         private static string _runtimeRid;
@@ -32,6 +33,7 @@ namespace Microsoft.NET.Publish.Tests
             var rid = RuntimeEnvironment.GetRuntimeIdentifier();
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
+                _libPrefix = "";
                 _runtimeOs = "win7";
                 _runtimeLibOs = "win";
                 _testArch = rid.Substring(rid.LastIndexOf("-") + 1);
@@ -39,12 +41,13 @@ namespace Microsoft.NET.Publish.Tests
             }
             else
             {
+                _libPrefix = "lib";
                 _runtimeOs = "unix";
                 _runtimeLibOs = "unix";
 
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
                 {
-                    // microsoft.netcore.dotnetapphost  has assets  only for osx.10.10
+                    // microsoft.netcore.coredistools only has assets for osx.10.10
                     _runtimeRid = "osx.10.10-x64";
                 }
                 else
@@ -74,7 +77,8 @@ namespace Microsoft.NET.Publish.Tests
 
             List<string> files_on_disk = new List < string > {
                "artifact.xml",
-               $"runtime.{_runtimeRid}.microsoft.netcore.dotnetapphost/1.2.0-beta-001304-00/runtimes/{_runtimeRid}/native/apphost{Constants.ExeSuffix}",
+               $"runtime.{_runtimeRid}.microsoft.netcore.coredistools/1.0.1-prerelease-00001/runtimes/{_runtimeRid}/native/{_libPrefix}coredistools{Constants.DynamicLibSuffix}",
+               $"runtime.{_runtimeRid}.microsoft.netcore.coredistools/1.0.1-prerelease-00001/runtimes/{_runtimeRid}/native/coredistools.h"
                };
 
             if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && _testArch != "x86")
@@ -89,10 +93,10 @@ namespace Microsoft.NET.Publish.Tests
 
             knownpackage.Add(new PackageIdentity("Microsoft.NETCore.Targets", NuGetVersion.Parse("1.2.0-beta-24821-02")));
             knownpackage.Add(new PackageIdentity("System.Private.Uri", NuGetVersion.Parse("4.4.0-beta-24821-02")));
-            knownpackage.Add(new PackageIdentity("Microsoft.NETCore.DotNetAppHost", NuGetVersion.Parse("1.2.0-beta-001304-00")));
+            knownpackage.Add(new PackageIdentity("Microsoft.NETCore.CoreDisTools", NuGetVersion.Parse("1.0.1-prerelease-00001")));
             knownpackage.Add(new PackageIdentity($"runtime.{_runtimeOs}.System.Private.Uri", NuGetVersion.Parse("4.4.0-beta-24821-02")));
             knownpackage.Add(new PackageIdentity("Microsoft.NETCore.Platforms", NuGetVersion.Parse("1.2.0-beta-24821-02")));
-            knownpackage.Add(new PackageIdentity($"runtime.{_runtimeRid}.Microsoft.NETCore.DotNetAppHost", NuGetVersion.Parse("1.2.0-beta-001304-00")));
+            knownpackage.Add(new PackageIdentity($"runtime.{_runtimeRid}.Microsoft.NETCore.CoreDisTools", NuGetVersion.Parse("1.0.1-prerelease-00001")));
 
             if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && _testArch != "x86")
             {
@@ -111,7 +115,6 @@ namespace Microsoft.NET.Publish.Tests
             }
             
         }
-
         [Fact]
         public void compose_with_fxfiles()
         {
@@ -133,7 +136,8 @@ namespace Microsoft.NET.Publish.Tests
             DirectoryInfo cacheDirectory = new DirectoryInfo(OutputFolder);
             List<string> files_on_disk = new List<string> {
                "artifact.xml",
-               $"runtime.{_runtimeRid}.microsoft.netcore.dotnetapphost/1.2.0-beta-001304-00/runtimes/{_runtimeRid}/native/apphost{Constants.ExeSuffix}",
+               $"runtime.{_runtimeRid}.microsoft.netcore.coredistools/1.0.1-prerelease-00001/runtimes/{_runtimeRid}/native/{_libPrefix}coredistools{Constants.DynamicLibSuffix}",
+               $"runtime.{_runtimeRid}.microsoft.netcore.coredistools/1.0.1-prerelease-00001/runtimes/{_runtimeRid}/native/coredistools.h",
                $"runtime.{_runtimeOs}.system.private.uri/4.4.0-beta-24821-02/runtimes/{_runtimeLibOs}/lib/netstandard1.0/System.Private.Uri.dll"
                };
 
@@ -167,7 +171,8 @@ namespace Microsoft.NET.Publish.Tests
 
             List<string> files_on_disk = new List<string> {
                "artifact.xml",
-               $"runtime.{_runtimeRid}.microsoft.netcore.dotnetapphost/1.2.0-beta-001304-00/runtimes/{_runtimeRid}/native/apphost{Constants.ExeSuffix}",
+               $"runtime.{_runtimeRid}.microsoft.netcore.coredistools/1.0.1-prerelease-00001/runtimes/{_runtimeRid}/native/{_libPrefix}coredistools{Constants.DynamicLibSuffix}",
+               $"runtime.{_runtimeRid}.microsoft.netcore.coredistools/1.0.1-prerelease-00001/runtimes/{_runtimeRid}/native/coredistools.h",
                $"runtime.{_runtimeOs}.system.private.uri/4.4.0-beta-24821-02/runtimes/{_runtimeLibOs}/lib/netstandard1.0/System.Private.Uri.dll"
                };
 
@@ -200,7 +205,8 @@ namespace Microsoft.NET.Publish.Tests
 
             List<string> files_on_disk = new List<string> {
                "artifact.xml",
-               $"runtime.{_runtimeRid}.microsoft.netcore.dotnetapphost/1.2.0-beta-001304-00/runtimes/{_runtimeRid}/native/apphost{Constants.ExeSuffix}"
+               $"runtime.{_runtimeRid}.microsoft.netcore.coredistools/1.0.1-prerelease-00001/runtimes/{_runtimeRid}/native/{_libPrefix}coredistools{Constants.DynamicLibSuffix}",
+               $"runtime.{_runtimeRid}.microsoft.netcore.coredistools/1.0.1-prerelease-00001/runtimes/{_runtimeRid}/native/coredistools.h"
                };
 
             cacheDirectory.Should().OnlyHaveFiles(files_on_disk);

--- a/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToCacheAProjectWithDependencies.cs
+++ b/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToCacheAProjectWithDependencies.cs
@@ -50,6 +50,11 @@ namespace Microsoft.NET.Publish.Tests
                     // microsoft.netcore.coredistools only has assets for osx.10.10
                     _runtimeRid = "osx.10.10-x64";
                 }
+                else if (rid.Contains("ubuntu"))
+                {
+                    // microsoft.netcore.coredistools only has assets for ubuntu.14.04-x64
+                    _runtimeRid = "ubuntu.14.04-x64";
+                }
                 else
                 {
                     _runtimeRid = rid;                    


### PR DESCRIPTION
With the apphost.exe being used for standalone apps scenario, they will by default will be filtered from the publish step and will not be a good candidate for testing the cache feature. So i am rolling back the fix