### PR TITLE
Updated return of matching TF and RID instructions

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.Common.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.Common.targets
@@ -103,5 +103,28 @@ Copyright (c) .NET Foundation. All rights reserved.
       </ProjectBuildInstructions>
     </ItemGroup>
   </Target>
-  
+
+  <!-- This target is a compat shim, allowing the SDK to continue to function with older common targets that haven't switched to GetReferenceProperties.
+
+       TODO: After the SDK has picked up an MSBuild with https://github.com/Microsoft/msbuild/pull/1866, it should be deleted. -->
+  <Target Name="GetTargetFrameworkProperties" Returns="TargetFramework=$(NearestTargetFramework);ProjectHasSingleTargetFramework=$(_HasSingleTargetFramework);ProjectIsRidAgnostic=$(_IsRidAgnostic)"
+          DependsOnTargets="ShouldQueryForProperties">
+
+    <PropertyGroup>
+      <!-- If a ReferringTargetFramework was not specified, and we only have one TargetFramework, then don't try to check compatibility -->
+      <_SkipNearestTargetFrameworkResolution Condition="'$(TargetFramework)' != '' and '$(ReferringTargetFramework)' == ''">true</_SkipNearestTargetFrameworkResolution>
+      <NearestTargetFramework Condition="'$(_SkipNearestTargetFrameworkResolution)' == 'true'">$(TargetFramework)</NearestTargetFramework>
+
+      <_PossibleTargetFrameworks Condition="'$(TargetFramework)' != ''">$(TargetFramework)</_PossibleTargetFrameworks>
+      <_PossibleTargetFrameworks Condition="'$(TargetFramework)' == ''">$(TargetFrameworks)</_PossibleTargetFrameworks>
+    </PropertyGroup>
+
+    <GetNearestTargetFramework ReferringTargetFramework="$(ReferringTargetFramework)"
+                               PossibleTargetFrameworks="$(_PossibleTargetFrameworks)"
+                               ProjectFilePath="$(MSBuildProjectFullPath)"
+                               Condition="'$(_SkipNearestTargetFrameworkResolution)' != 'true'">
+      <Output PropertyName="NearestTargetFramework" TaskParameter="NearestTargetFramework" />
+    </GetNearestTargetFramework>
+  </Target>
+
 </Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.Common.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.Common.targets
@@ -37,11 +37,11 @@ Copyright (c) .NET Foundation. All rights reserved.
                                         ShouldQueryForProperties
 
     Indicate that this project cross-targets, so before building
-    it, a referring project must call GetReferenceProperties
+    it, a referring project must call GetDesiredProperties
     to get the matching TargetFramework to specify.
   -->
   <Target Name="ShouldQueryForProperties"
-          Returns="$(_ReferringProjectShouldCallGetReferenceProperties)">
+          Returns="$(_ReferringProjectShouldCallGetDesiredProperties)">
     <PropertyGroup>
       <!-- indicate to caller that project is RID agnostic so that a global property RuntimeIdentifier value can be removed -->
       <_IsRidAgnostic>false</_IsRidAgnostic>
@@ -51,14 +51,14 @@ Copyright (c) .NET Foundation. All rights reserved.
       <_HasSingleTargetFramework Condition="'$(IsCrossTargetingBuild)' != 'true'">true</_HasSingleTargetFramework>
       <_HasSingleTargetFramework Condition="'$(_HasSingleTargetFramework)' == ''">false</_HasSingleTargetFramework>
 
-      <_ReferringProjectShouldCallGetReferenceProperties>true</_ReferringProjectShouldCallGetReferenceProperties>
-      <_ReferringProjectShouldCallGetReferenceProperties Condition="$(_HasSingleTargetFramework) and $(_IsRidAgnostic)">false</_ReferringProjectShouldCallGetReferenceProperties>
+      <_ReferringProjectShouldCallGetDesiredProperties>true</_ReferringProjectShouldCallGetDesiredProperties>
+      <_ReferringProjectShouldCallGetDesiredProperties Condition="$(_HasSingleTargetFramework) and $(_IsRidAgnostic)">false</_ReferringProjectShouldCallGetDesiredProperties>
     </PropertyGroup>
   </Target>
 
   <!--
   ============================================================
-                              GetReferenceProperties
+                              GetDesiredProperties
 
     Invoked by common targets to return the set of properties 
     (in the form  "key1=value1;...keyN=valueN") needed to build 
@@ -75,7 +75,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     with the referencing project's target framework.
   ============================================================
    -->
-  <Target Name="GetReferenceProperties"
+  <Target Name="GetDesiredProperties"
           DependsOnTargets="ShouldQueryForProperties"
           Returns="@(ProjectBuildInstructions)">
 
@@ -104,7 +104,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     </ItemGroup>
   </Target>
 
-  <!-- This target is a compat shim, allowing the SDK to continue to function with older common targets that haven't switched to GetReferenceProperties.
+  <!-- This target is a compat shim, allowing the SDK to continue to function with older common targets that haven't switched to GetDesiredProperties.
 
        TODO: After the SDK has picked up an MSBuild with https://github.com/Microsoft/msbuild/pull/1866, it should be deleted. -->
   <Target Name="GetTargetFrameworkProperties" Returns="TargetFramework=$(NearestTargetFramework);ProjectHasSingleTargetFramework=$(_HasSingleTargetFramework);ProjectIsRidAgnostic=$(_IsRidAgnostic)"

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.Common.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.Common.targets
@@ -33,8 +33,32 @@ Copyright (c) .NET Foundation. All rights reserved.
   <UsingTask TaskName="NETSdkError" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
   
   <!--
+    ============================================================
+                                        ShouldQueryForProperties
+
+    Indicate that this project cross-targets, so before building
+    it, a referring project must call GetReferenceProperties
+    to get the matching TargetFramework to specify.
+  -->
+  <Target Name="ShouldQueryForProperties"
+          Returns="$(_ReferringProjectShouldCallGetReferenceProperties)">
+    <PropertyGroup>
+      <!-- indicate to caller that project is RID agnostic so that a global property RuntimeIdentifier value can be removed -->
+      <_IsRidAgnostic>false</_IsRidAgnostic>
+      <_IsRidAgnostic Condition=" '$(RuntimeIdentifier)' == '' and '$(RuntimeIdentifiers)' == '' ">true</_IsRidAgnostic>
+
+      <!-- A project can only have more than one output if the current global properties are such that the current build is a cross-targeting one. -->
+      <_HasSingleTargetFramework Condition="'$(IsCrossTargetingBuild)' != 'true'">true</_HasSingleTargetFramework>
+      <_HasSingleTargetFramework Condition="'$(_HasSingleTargetFramework)' == ''">false</_HasSingleTargetFramework>
+
+      <_ReferringProjectShouldCallGetReferenceProperties>true</_ReferringProjectShouldCallGetReferenceProperties>
+      <_ReferringProjectShouldCallGetReferenceProperties Condition="$(_HasSingleTargetFramework) and $(_IsRidAgnostic)">false</_ReferringProjectShouldCallGetReferenceProperties>
+    </PropertyGroup>
+  </Target>
+
+  <!--
   ============================================================
-                              GetTargetFrameworkProperties
+                              GetReferenceProperties
 
     Invoked by common targets to return the set of properties 
     (in the form  "key1=value1;...keyN=valueN") needed to build 
@@ -51,20 +75,14 @@ Copyright (c) .NET Foundation. All rights reserved.
     with the referencing project's target framework.
   ============================================================
    -->
-  <Target Name="GetTargetFrameworkProperties" Returns="@(ProjectBuildInstructions)">
+  <Target Name="GetReferenceProperties"
+          DependsOnTargets="ShouldQueryForProperties"
+          Returns="@(ProjectBuildInstructions)">
 
     <PropertyGroup>
-      <!-- indicate to caller that project is RID agnostic so that a global property RuntimeIdentifier value can be removed -->
-      <_IsRidAgnostic>false</_IsRidAgnostic>
-      <_IsRidAgnostic Condition=" '$(RuntimeIdentifier)' == '' and '$(RuntimeIdentifiers)' == '' ">true</_IsRidAgnostic>
-
       <!-- If a ReferringTargetFramework was not specified, and we only have one TargetFramework, then don't try to check compatibility -->
       <_SkipNearestTargetFrameworkResolution Condition="'$(TargetFramework)' != '' and '$(ReferringTargetFramework)' == ''">true</_SkipNearestTargetFrameworkResolution>
       <NearestTargetFramework Condition="'$(_SkipNearestTargetFrameworkResolution)' == 'true'">$(TargetFramework)</NearestTargetFramework>
-
-      <!-- A project can only have more than one output if the current global properties are such that the current build is a cross-targeting one. -->
-      <_HasSingleTargetFramework Condition="'$(IsCrossTargetingBuild)' != 'true'">true</_HasSingleTargetFramework>
-      <_HasSingleTargetFramework Condition="'$(_HasSingleTargetFramework)' == ''">false</_HasSingleTargetFramework>
 
       <_PossibleTargetFrameworks Condition="'$(TargetFramework)' != ''">$(TargetFramework)</_PossibleTargetFrameworks>
       <_PossibleTargetFrameworks Condition="'$(TargetFramework)' == ''">$(TargetFrameworks)</_PossibleTargetFrameworks>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.Common.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.Common.targets
@@ -31,53 +31,64 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <UsingTask TaskName="GetNearestTargetFramework" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
   <UsingTask TaskName="NETSdkError" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
-  
+
   <!--
     ============================================================
                                         ShouldQueryForProperties
 
-    Indicate that this project cross-targets, so before building
-    it, a referring project must call GetDesiredProperties
-    to get the matching TargetFramework to specify.
+    Indicate whether this project cross-targets, so before
+    building it, a referring project must call
+    GetDesiredProperties to get the matching TargetFramework to
+    specify.
+
+    If this project only has a single TF and a single RID,
+    return UndefineProperties to allow the referring project
+    to build it directly without a subsequent query.
   -->
   <Target Name="ShouldQueryForProperties"
-          Returns="$(_ReferringProjectShouldCallGetDesiredProperties)">
+          Returns="@(_ShouldQueryForPropertiesResult)">
     <PropertyGroup>
       <!-- indicate to caller that project is RID agnostic so that a global property RuntimeIdentifier value can be removed -->
       <_IsRidAgnostic>false</_IsRidAgnostic>
       <_IsRidAgnostic Condition=" '$(RuntimeIdentifier)' == '' and '$(RuntimeIdentifiers)' == '' ">true</_IsRidAgnostic>
 
+      <_DesiredRemovedProperties Condition="'$(_IsRidAgnostic)' == 'true'">$(_DesiredRemovedProperties);RuntimeIdentifier</_DesiredRemovedProperties>
+
       <!-- A project can only have more than one output if the current global properties are such that the current build is a cross-targeting one. -->
       <_HasSingleTargetFramework Condition="'$(IsCrossTargetingBuild)' != 'true'">true</_HasSingleTargetFramework>
       <_HasSingleTargetFramework Condition="'$(_HasSingleTargetFramework)' == ''">false</_HasSingleTargetFramework>
 
+      <_DesiredRemovedProperties Condition="'$(_HasSingleTargetFramework)' == 'true'">$(_DesiredRemovedProperties);TargetFramework</_DesiredRemovedProperties>
+
       <_ReferringProjectShouldCallGetDesiredProperties>true</_ReferringProjectShouldCallGetDesiredProperties>
       <_ReferringProjectShouldCallGetDesiredProperties Condition="$(_HasSingleTargetFramework) and $(_IsRidAgnostic)">false</_ReferringProjectShouldCallGetDesiredProperties>
     </PropertyGroup>
+
+    <ItemGroup>
+      <_ShouldQueryForPropertiesResult Include="$(MSBuildProjectFullPath)">
+        <QueryForProperties>$(_ReferringProjectShouldCallGetDesiredProperties)</QueryForProperties>
+        <UndefineProperties Condition="'$(_ReferringProjectShouldCallGetDesiredProperties)' == 'false'">$(_DesiredRemovedProperties)</UndefineProperties>
+      </_ShouldQueryForPropertiesResult>
+    </ItemGroup>
   </Target>
 
   <!--
   ============================================================
                               GetDesiredProperties
 
-    Invoked by common targets to return the set of properties 
-    (in the form  "key1=value1;...keyN=valueN") needed to build 
-    against the target framework that best matches the referring
-    project's target framework.
+    Invoked by common targets to return the set of properties
+    (in the metadatum SetDesiredProperties` in the form
+    "key1=value1;...keyN=valueN") needed to build against the
+    target framework that best matches the referring project's
+    target framework.
 
-    The referring project's $(TargetFrameworkMoniker) is passed 
+    The referring project's $(TargetFrameworkMoniker) is passed
     in as $(ReferringTargetFramework).
-
-    This is in the common targets so that it will apply to both
-    cross-targeted and single-targeted projects.  It is run
-    for single-targeted projects so that an error will be
-    generated if the referenced project is not compatible
-    with the referencing project's target framework.
   ============================================================
    -->
   <Target Name="GetDesiredProperties"
           DependsOnTargets="ShouldQueryForProperties"
-          Returns="@(ProjectBuildInstructions)">
+          Returns="@(_ProjectBuildInstructions)">
 
     <PropertyGroup>
       <!-- If a ReferringTargetFramework was not specified, and we only have one TargetFramework, then don't try to check compatibility -->
@@ -88,7 +99,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       <_PossibleTargetFrameworks Condition="'$(TargetFramework)' == ''">$(TargetFrameworks)</_PossibleTargetFrameworks>
     </PropertyGroup>
 
-    <GetNearestTargetFramework ReferringTargetFramework="$(ReferringTargetFramework)" 
+    <GetNearestTargetFramework ReferringTargetFramework="$(ReferringTargetFramework)"
                                PossibleTargetFrameworks="$(_PossibleTargetFrameworks)"
                                ProjectFilePath="$(MSBuildProjectFullPath)"
                                Condition="'$(_SkipNearestTargetFrameworkResolution)' != 'true'">
@@ -96,11 +107,10 @@ Copyright (c) .NET Foundation. All rights reserved.
     </GetNearestTargetFramework>
 
     <ItemGroup>
-      <ProjectBuildInstructions Include="$(MSBuildProjectFullPath)">
-        <DesiredTargetFrameworkProperties>TargetFramework=$(NearestTargetFramework)</DesiredTargetFrameworkProperties>
-        <HasSingleTargetFramework>$(_HasSingleTargetFramework)</HasSingleTargetFramework>
-        <IsRidAgnostic>$(_IsRidAgnostic)</IsRidAgnostic>
-      </ProjectBuildInstructions>
+      <_ProjectBuildInstructions Include="$(MSBuildProjectFullPath)">
+        <SetDesiredProperties>TargetFramework=$(NearestTargetFramework)</SetDesiredProperties>
+        <UndefineProperties>$(_DesiredRemovedProperties)</UndefineProperties>
+      </_ProjectBuildInstructions>
     </ItemGroup>
   </Target>
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.Common.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.Common.targets
@@ -51,7 +51,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     with the referencing project's target framework.
   ============================================================
    -->
-  <Target Name="GetTargetFrameworkProperties" Returns="TargetFramework=$(NearestTargetFramework);ProjectHasSingleTargetFramework=$(_HasSingleTargetFramework);ProjectIsRidAgnostic=$(_IsRidAgnostic)">
+  <Target Name="GetTargetFrameworkProperties" Returns="@(ProjectBuildInstructions)">
 
     <PropertyGroup>
       <!-- indicate to caller that project is RID agnostic so that a global property RuntimeIdentifier value can be removed -->
@@ -76,6 +76,14 @@ Copyright (c) .NET Foundation. All rights reserved.
                                Condition="'$(_SkipNearestTargetFrameworkResolution)' != 'true'">
       <Output PropertyName="NearestTargetFramework" TaskParameter="NearestTargetFramework" />
     </GetNearestTargetFramework>
+
+    <ItemGroup>
+      <ProjectBuildInstructions Include="$(MSBuildProjectFullPath)">
+        <DesiredTargetFrameworkProperties>TargetFramework=$(NearestTargetFramework)</DesiredTargetFrameworkProperties>
+        <HasSingleTargetFramework>$(_HasSingleTargetFramework)</HasSingleTargetFramework>
+        <IsRidAgnostic>$(_IsRidAgnostic)</IsRidAgnostic>
+      </ProjectBuildInstructions>
+    </ItemGroup>
   </Target>
   
 </Project>


### PR DESCRIPTION
Instead of returning a semicolon-delimited string, which must be parsed
on the receiving end and cannot be easily converted to an item (with
relevant metadata like which project it's associated with), return
structured data in the only way MSBuild can: as an item with metadata.

Metadata includes the closest matching TargetFramework and whether or
not the project should have TargetFramework and/or RuntimeIdentifier
stripped before calling it.

Consumed by Microsoft.Common.CurrentVersion.targets in the coordinated
change Microsoft/msbuild#1866.