### PR TITLE
Incremental build improvements for generated AssemblyInfo.cs

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.GenerateAssemblyInfo.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.GenerateAssemblyInfo.targets
@@ -19,7 +19,6 @@ Copyright (c) .NET Foundation. All rights reserved.
     -->
   <PropertyGroup>
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
-    <GeneratedAssemblyInfoFile Condition="'$(GeneratedAssemblyInfoFile)' ==''">$(IntermediateOutputPath)$(MSBuildProjectName).AssemblyInfo$(DefaultLanguageSourceExtension)</GeneratedAssemblyInfoFile>
     <GenerateAssemblyInfo Condition="'$(GenerateAssemblyInfo)' == ''">true</GenerateAssemblyInfo>
   </PropertyGroup>
 
@@ -48,10 +47,7 @@ Copyright (c) .NET Foundation. All rights reserved.
           DependsOnTargets="PrepareForBuild;GetAssemblyVersion;CoreGenerateAssemblyInfo"
           Condition="'$(GenerateAssemblyInfo)' == 'true'" />
 
-  <Target Name="CoreGenerateAssemblyInfo"
-          Condition="'$(Language)'=='VB' or '$(Language)'=='C#'"
-          Inputs="$(MSBuildAllProjects)"
-          Outputs="$(GeneratedAssemblyInfoFile)">
+  <Target Name="_CalculateAssemblyAttributes">
     <ItemGroup>
       <AssemblyAttribute Include="System.Reflection.AssemblyCompanyAttribute" Condition="'$(Company)' != '' and '$(GenerateAssemblyCompanyAttribute)' == 'true'">
         <_Parameter1>$(Company)</_Parameter1>
@@ -84,7 +80,29 @@ Copyright (c) .NET Foundation. All rights reserved.
         <_Parameter1>$(NeutralLanguage)</_Parameter1>
       </AssemblyAttribute>
     </ItemGroup>
+  </Target>
 
+  <!-- 
+    To allow version changes to be respected on incremental builds (e.g. through CLI parameters),
+    create a hash of all assembly attributes so that the output file name will change with the calculated
+    assembly attribute values and msbuild will then execute CoreGenerateAssembly to generate the new file.
+  -->
+  <Target Name="_CalculateGeneratedAssemblyInfoFileName" DependsOnTargets="_CalculateAssemblyAttributes">
+    <Hash ItemsToHash="@(AssemblyAttribute->'%(Identity)%(_Parameter1)')">
+      <Output TaskParameter="HashResult" PropertyName="_AssemblyAttributeContentHash" />
+    </Hash>
+
+    <PropertyGroup>
+      <GeneratedAssemblyInfoFile Condition=" '$(_AssemblyAttributeContentHash)' != '' ">$(IntermediateOutputPath)$(MSBuildProjectName).AssemblyInfo.$(_AssemblyAttributeContentHash.SubString(0,6))$(DefaultLanguageSourceExtension)</GeneratedAssemblyInfoFile>
+      <GeneratedAssemblyInfoFile Condition=" '$(GeneratedAssemblyInfoFile)' == '' ">$(IntermediateOutputPath)$(MSBuildProjectName).AssemblyInfo$(DefaultLanguageSourceExtension)</GeneratedAssemblyInfoFile>
+    </PropertyGroup>
+  </Target>
+
+  <Target Name="CoreGenerateAssemblyInfo"
+          Condition="'$(Language)'=='VB' or '$(Language)'=='C#'"
+          DependsOnTargets="_CalculateAssemblyAttributes;_CalculateGeneratedAssemblyInfoFileName"
+          Inputs="$(MSBuildAllProjects)"
+          Outputs="$(GeneratedAssemblyInfoFile)">
     <ItemGroup>
       <!-- Ensure the generated assemblyinfo file is not already part of the Compile sources, as a workaround for https://github.com/dotnet/sdk/issues/114 -->
       <Compile Remove="$(GeneratedAssemblyInfoFile)" />

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToControlGeneratedAssemblyInfo.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToControlGeneratedAssemblyInfo.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
+using System.Linq;
 using System.IO;
 using Microsoft.NET.TestFramework;
 using Microsoft.NET.TestFramework.Assertions;
@@ -111,6 +112,57 @@ namespace Microsoft.NET.Build.Tests
             info["AssemblyVersionAttribute"].Should().Be("1.2.3.0");
             info["AssemblyFileVersionAttribute"].Should().Be("1.2.3.0");
             info["AssemblyInformationalVersionAttribute"].Should().Be("1.2.3");
+        }
+
+        [Theory]
+        [InlineData("netcoreapp1.1")]
+        [InlineData("net45")]
+        public void It_respects_version_changes_on_incremental_build(string targetFramework)
+        {
+            if (targetFramework == "net45" && !RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return;
+            }
+
+            // Given a project that has already been built
+            var testAsset = _testAssetsManager
+                .CopyTestAsset("HelloWorld", identifier: targetFramework)
+                .WithSource()
+                .Restore("", $"/p:OutputType=Library;TargetFramework={targetFramework}");
+            BuildProject(versionPrefix: "1.2.3");
+            var fullBuildAssemblyInfo = FindAssemblyInfo();
+
+            // When the same project is built again using a different VersionPrefix proeprty
+            var incrementalBuildCommand = BuildProject(versionPrefix: "1.2.4");
+            var incrementalBuildAssemblyInfo = FindAssemblyInfo();
+
+            // Then the version of the built assembly shall match the provided VersionPrefix
+            var assemblyPath = Path.Combine(incrementalBuildCommand.GetOutputDirectory(targetFramework).FullName, "HelloWorld.dll");
+            var info = AssemblyInfo.Get(assemblyPath);
+            info["AssemblyVersionAttribute"].Should().Be("1.2.4.0");
+
+            // And the assembly info filename must have changed
+            incrementalBuildAssemblyInfo.Should().NotBe(fullBuildAssemblyInfo);
+
+            // And the previous assembly info must have been deleted (by IncrementalClean)
+            File.Exists(fullBuildAssemblyInfo).Should().BeFalse();
+
+            BuildCommand BuildProject(string versionPrefix)
+            {
+                var command = new BuildCommand(Stage0MSBuild, testAsset.TestRoot);
+                command.Execute($"/p:OutputType=Library;TargetFramework={targetFramework};VersionPrefix={versionPrefix}")
+                       .Should()
+                       .Pass();
+                return command;
+            }
+
+            string FindAssemblyInfo()
+            {
+                var expectedAssemblyInfoLocation = Path.Combine(testAsset.TestRoot, "obj", "Debug", targetFramework);
+                var matches = Directory.EnumerateFiles(expectedAssemblyInfoLocation, "*AssemblyInfo*.cs", SearchOption.TopDirectoryOnly).ToList();
+                matches.Count.Should().Be(1, "only a single assembly info file should exist");
+                return matches[0];
+            }
         }
     }
 }

--- a/test/Microsoft.NET.Build.Tests/GivenThereAreDefaultItems.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThereAreDefaultItems.cs
@@ -11,6 +11,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Xml.Linq;
 using Xunit;
 using static Microsoft.NET.TestFramework.Commands.MSBuildTest;
@@ -561,7 +562,7 @@ namespace Microsoft.NET.Build.Tests
             //      { AssemblyName}.AssemblyInfo.cs in the intermediate output path
             var itemsToRemove = compileItems.Where(i =>
                     i.EndsWith("AssemblyAttributes.cs", System.StringComparison.OrdinalIgnoreCase) ||
-                    i.EndsWith("AssemblyInfo.cs", StringComparison.OrdinalIgnoreCase))
+                    Regex.IsMatch(i, ".*AssemblyInfo(.[0-9a-z]{6})?.cs$"))
                 .ToList();
 
             foreach (var itemToRemove in itemsToRemove)


### PR DESCRIPTION
Addresses #967 by:
1. Splitting `CoreGenerateAssemblyInfo` into:
  * `_CalculateAssemblyAttributes` which produces `AssemblyAttribute` items.
  * `_CalculateGeneratedAssemblyInfoFileName` which uses the present `AssemblyAttribute` items to product the name of the generated assembly info file, using the `Hash` task introduced in https://github.com/Microsoft/msbuild/pull/1328:
    * `VersionPrefix=1.0.0` => `obj/Debug/netstandard2.0/lib1.AssemblyInfo.e32ef0.cs`
    * `VersionPrefix=1.0.1` => `obj/Debug/netstandard2.0/lib1.AssemblyInfo.5be252.cs`
    *  All `Generate*AssemblyAttribute` set to `false` => `obj/Debug/netstandard2.0/lib1.AssemblyInfo.cs`
2. `CoreGenerateAssemblyInfo` then uses the generated file name as `Outputs` and is executed on incremental builds only when any of the `AssemblyAttribute` items change (even custom ones not generated by the SDK).