### PR TITLE
Allow cache projects to use star versions in PackageDependency.

### DIFF
--- a/TestAssets/TestProjects/ProfileLists/StarVersion.xml
+++ b/TestAssets/TestProjects/ProfileLists/StarVersion.xml
@@ -1,0 +1,5 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <PackageReference Include="NuGet.Common" Version="4.0.0-*" />
+  </ItemGroup>
+</Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.ComposeCache.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.ComposeCache.targets
@@ -248,8 +248,8 @@ Copyright (c) .NET Foundation. All rights reserved.
   <Target Name="PrepforRestoreForComposeCache">
 
     <PropertyGroup>
-      <CachePackageVersion>$(CachePackageVersion.Replace('*','-'))</CachePackageVersion>
-      <CacheWorkerWorkingDir>$([System.IO.Path]::Combine($(ComposeWorkingDir),"$(CachePackageName)_$(CachePackageVersion)"))</CacheWorkerWorkingDir>
+      <CachePackageVersionForFolderName>$(CachePackageVersion.Replace('*','-'))</CachePackageVersionForFolderName>
+      <CacheWorkerWorkingDir>$([System.IO.Path]::Combine($(ComposeWorkingDir),"$(CachePackageName)_$(CachePackageVersionForFolderName)"))</CacheWorkerWorkingDir>
       <_PackageProjFile>$([System.IO.Path]::Combine($(CacheWorkerWorkingDir), "Package.csproj"))</_PackageProjFile>
       <ProjectAssetsFile>$(CacheWorkerWorkingDir)\project.assets.json</ProjectAssetsFile>
       <_PackageProjContent>

--- a/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToCacheAProjectWithDependencies.cs
+++ b/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToCacheAProjectWithDependencies.cs
@@ -290,11 +290,19 @@ namespace Microsoft.NET.Publish.Tests
             // 4.0.0-rtm-2265
             // 4.0.0-rc3
             // 4.0.0-rc2
+            // 4.0.0-rc-2048
             //
             // and the StarVersion.xml uses Version="4.0.0-*", 
             // so we expect a version greater than 4.0.0-rc2, since there is
             // a higher version on the feed that meets the criteria
             nugetPackage.Version.Should().BeGreaterThan(NuGetVersion.Parse("4.0.0-rc2"));
+
+            // work around https://github.com/dotnet/sdk/issues/1045. The unnecessary assets getting
+            // put in the cache folder cause long path issues, so delete them
+            foreach (var runtimeFolder in new DirectoryInfo(outputFolder).GetDirectories("runtime.*"))
+            {
+                runtimeFolder.Delete(true);
+            }
         }
 
         private static HashSet<PackageIdentity> ParseCacheArtifacts(string path)


### PR DESCRIPTION
@ramarag @nguerrera @dsplaisted @livarcocc 