### PR TITLE
Removing Nuget.Build.Tasks.Pack dependency from Microsoft.NET.Sdk.nuspec

### DIFF
--- a/build/Nuget/Microsoft.NET.Sdk.nuspec
+++ b/build/Nuget/Microsoft.NET.Sdk.nuspec
@@ -10,9 +10,6 @@
     <version>$version$</version>
     <authors>dotnet</authors>
     <projectUrl>http://dot.net</projectUrl>
-    <dependencies>
-        <dependency id="Nuget.Build.Tasks.Pack" version="4.0.0-rtm-2323" />
-    </dependencies>
   </metadata>
   <files>
     <file src="PackagesLayout\**" />


### PR DESCRIPTION
Removing Nuget.Build.Tasks.Pack dependency from Microsoft.NET.Sdk.nuspec

This should no longer be needed. 

https://github.com/dotnet/sdk/pull/1032#issuecomment-288545438