### PR TITLE
Enable publishing XML documentation

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Publish.targets
@@ -201,6 +201,12 @@ Copyright (c) .NET Foundation. All rights reserved.
       <ResolvedFileToPublish Include="@(ResolvedAssembliesToPublish)">
         <RelativePath>%(ResolvedAssembliesToPublish.DestinationSubPath)</RelativePath>
       </ResolvedFileToPublish>
+
+      <!-- Copy the xml documentation (if enabled) -->
+      <ResolvedFileToPublish Include="@(FinalDocFile)"
+                              Condition="'$(PublishDocumentationFile)' == 'true'">
+        <RelativePath>@(FinalDocFile->'%(Filename)%(Extension)')</RelativePath>
+      </ResolvedFileToPublish>
     </ItemGroup>
 
   </Target>
@@ -211,7 +217,9 @@ Copyright (c) .NET Foundation. All rights reserved.
     <!-- TODO perform any preprocess transforms on the files -->
 
     <ItemGroup>
-      <ResolvedAssembliesToPublish Include="@(ReferenceCopyLocalPaths)" Exclude="@(ResolvedAssembliesToPublish)">
+      <ResolvedAssembliesToPublish Include="@(ReferenceCopyLocalPaths)"
+                                   Exclude="@(ResolvedAssembliesToPublish)"
+                                   Condition="'$(PublishProjectReferenceDocumentationFiles)' == 'true' or '%(Extension)' != '.xml'">
         <DestinationSubPath>%(ReferenceCopyLocalPaths.DestinationSubDirectory)%(Filename)%(Extension)</DestinationSubPath>
       </ResolvedAssembliesToPublish>
     </ItemGroup>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Publish.targets
@@ -219,7 +219,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ItemGroup>
       <ResolvedAssembliesToPublish Include="@(ReferenceCopyLocalPaths)"
                                    Exclude="@(ResolvedAssembliesToPublish)"
-                                   Condition="'$(PublishProjectReferenceDocumentationFiles)' == 'true' or '%(Extension)' != '.xml'">
+                                   Condition="'$(PublishReferencesDocumentationFiles)' == 'true' or '%(Extension)' != '.xml'">
         <DestinationSubPath>%(ReferenceCopyLocalPaths.DestinationSubDirectory)%(Filename)%(Extension)</DestinationSubPath>
       </ResolvedAssembliesToPublish>
     </ItemGroup>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.BeforeCommon.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.BeforeCommon.targets
@@ -137,6 +137,12 @@ Copyright (c) .NET Foundation. All rights reserved.
     <DocumentationFile />
   </PropertyGroup>
 
+  <PropertyGroup>
+    <PublishDocumentationFiles Condition="'$(PublishDocumentationFiles)' == ''">true</PublishDocumentationFiles>
+    <PublishDocumentationFile Condition="'$(PublishDocumentationFile)' == '' and '$(PublishDocumentationFiles)' == 'true'">true</PublishDocumentationFile>
+    <PublishProjectReferenceDocumentationFiles Condition="'$(PublishProjectReferenceDocumentationFiles)' == '' and '$(PublishDocumentationFiles)' == 'true'">true</PublishProjectReferenceDocumentationFiles>
+  </PropertyGroup>
+
   <!-- Add a project capability so that the project properties in the IDE can show the option to generate an XML documentation file without specifying the filename -->
   <ItemGroup>
     <ProjectCapability Include="GenerateDocumentationFile" />

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.BeforeCommon.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.BeforeCommon.targets
@@ -140,7 +140,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <PropertyGroup>
     <PublishDocumentationFiles Condition="'$(PublishDocumentationFiles)' == ''">true</PublishDocumentationFiles>
     <PublishDocumentationFile Condition="'$(PublishDocumentationFile)' == '' and '$(PublishDocumentationFiles)' == 'true'">true</PublishDocumentationFile>
-    <PublishProjectReferenceDocumentationFiles Condition="'$(PublishProjectReferenceDocumentationFiles)' == '' and '$(PublishDocumentationFiles)' == 'true'">true</PublishProjectReferenceDocumentationFiles>
+    <PublishReferencesDocumentationFiles Condition="'$(PublishReferencesDocumentationFiles)' == '' and '$(PublishDocumentationFiles)' == 'true'">true</PublishReferencesDocumentationFiles>
   </PropertyGroup>
 
   <!-- Add a project capability so that the project properties in the IDE can show the option to generate an XML documentation file without specifying the filename -->

--- a/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAProjectWithDependencies.cs
+++ b/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAProjectWithDependencies.cs
@@ -14,6 +14,7 @@ using System.Runtime.InteropServices;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System.Collections.Generic;
+using Microsoft.NET.TestFramework.ProjectConstruction;
 
 namespace Microsoft.NET.Publish.Tests
 {
@@ -199,16 +200,19 @@ namespace Microsoft.NET.Publish.Tests
 
 
         [Theory]
-        [MemberData(nameof(PublishDocumentationExpectations))]
-        public void It_publishes_documentation_files(string properties, bool expectAppDocPublished, bool expectLibDocPublished)
+        [InlineData("GenerateDocumentationFile=true", true, true)]
+        [InlineData("GenerateDocumentationFile=true;PublishDocumentationFile=false", false, true)]
+        [InlineData("GenerateDocumentationFile=true;PublishReferencesDocumentationFiles=false", true, false)]
+        [InlineData("GenerateDocumentationFile=true;PublishDocumentationFiles=false", false, false)]
+        public void It_publishes_documentation_files(string properties, bool expectAppDocPublished, bool expectLibProjectDocPublished)
         {
             var kitchenSinkAsset = _testAssetsManager
-                .CopyTestAsset("KitchenSink")
+                .CopyTestAsset("KitchenSink", identifier: $"{expectAppDocPublished}_{expectLibProjectDocPublished}")
                 .WithSource();
             kitchenSinkAsset.Restore("TestApp");
-
+            
             var publishCommand = new PublishCommand(Stage0MSBuild, Path.Combine(kitchenSinkAsset.TestRoot, "TestApp"));
-            var publishResult = publishCommand.Execute(properties);
+            var publishResult = publishCommand.Execute("/p:" + properties);
 
             publishResult.Should().Pass();
 
@@ -223,7 +227,7 @@ namespace Microsoft.NET.Publish.Tests
                 publishDirectory.Should().NotHaveFile("TestApp.xml");
             }
 
-            if (expectLibDocPublished)
+            if (expectLibProjectDocPublished)
             {
                 publishDirectory.Should().HaveFile("TestLibrary.xml");
             }
@@ -233,14 +237,55 @@ namespace Microsoft.NET.Publish.Tests
             }
         }
 
-        public static IEnumerable<object[]> PublishDocumentationExpectations
+        [Theory]
+        [InlineData("PublishReferencesDocumentationFiles=false", false)]
+        [InlineData("PublishReferencesDocumentationFiles=true", true)]
+        public void It_publishes_referenced_assembly_documentation(string property, bool expectAssemblyDocumentationFilePublished)
         {
-            get
+            var identifier = property.Replace("=", "");
+
+            var libProject = new TestProject
             {
-                yield return new object[] { "/p:GenerateDocumentationFile=true", true, true };
-                yield return new object[] { "/p:GenerateDocumentationFile=true;PublishDocumentationFile=false", false, true };
-                yield return new object[] { "/p:GenerateDocumentationFile=true;PublishProjectReferenceDocumentationFiles=false", true, false };
-                yield return new object[] { "/p:GenerateDocumentationFile=true;PublishDocumentationFiles=false", false, false };
+                Name = "NetStdLib",
+                IsSdkProject = true,
+                TargetFrameworks = "netstandard1.0"
+            };
+
+            var libAsset = _testAssetsManager.CreateTestProject(libProject, identifier: identifier)
+                .Restore("NetStdLib");
+
+            var libPublishCommand = new PublishCommand(Stage0MSBuild, Path.Combine(libAsset.TestRoot, "NetStdLib"));
+            var libPublishResult = libPublishCommand.Execute("/t:Publish", "/p:GenerateDocumentationFile=true");
+            libPublishResult.Should().Pass();
+            var publishedLibPath = Path.Combine(libPublishCommand.GetOutputDirectory("netstandard1.0").FullName, "NetStdLib.dll");
+
+            var appProject = new TestProject
+            {
+                Name = "TestApp",
+                IsSdkProject = true,
+                IsExe = true,
+                TargetFrameworks = "netcoreapp2.0",
+                RuntimeFrameworkVersion = RepoInfo.NetCoreApp20Version,
+                References = { publishedLibPath }
+            };
+
+            var appAsset = _testAssetsManager.CreateTestProject(appProject, identifier: identifier);
+            var appSourcePath  = Path.Combine(appAsset.TestRoot, "TestApp");
+
+            new RestoreCommand(Stage0MSBuild, appSourcePath).Execute().Should().Pass();
+            var appPublishCommand = new PublishCommand(Stage0MSBuild, appSourcePath);
+            var appPublishResult = appPublishCommand.Execute("/p:" + property);
+            appPublishResult.Should().Pass();
+
+            var appPublishDirectory = appPublishCommand.GetOutputDirectory("netcoreapp2.0");
+
+            if (expectAssemblyDocumentationFilePublished)
+            {
+                appPublishDirectory.Should().HaveFile("NetStdLib.xml");
+            }
+            else
+            {
+                appPublishDirectory.Should().NotHaveFile("NetStdLib.xml");
             }
         }
 


### PR DESCRIPTION
Fixes #795 by publishing the XML documentation by default when documentation generation is enabled unless `PublishDocumentationFile` is set to `false`.

Edit:
Note that documentation files of project references are already included in the published output.

Update:

1. Property `PublishDocumentationFiles` can be set to `false` to opt out of publishing own documentation *and* documentation of project references. (Sets `PublishDocumentationFile` and `PublishProjectReferenceDocumentationFiles` to false)
2. Property `PublishDocumentationFile` can be set individually to opt out of publishing own documentation file.
3. Property `PublishReferencesDocumentationFiles` can be set individually to opt out of publishing documentation files of project and assembly references.

cc @eerhardt @nguerrera 