### PR TITLE
Fix SelfContained error on libraries.

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.RuntimeIdentifierInference.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.RuntimeIdentifierInference.targets
@@ -104,14 +104,18 @@ Copyright (c) .NET Foundation. All rights reserved.
     Default SelfContained based on the RuntimeIdentifier, so projects don't have to explicitly set SelfContained.
     This avoids a breaking change from 1.0 behavior.
     -->
-  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' and '$(SelfContained)' == ''">
+  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' and '$(OutputType)' == 'Exe' and '$(SelfContained)' == ''">
     <SelfContained Condition="'$(RuntimeIdentifier)' == ''">false</SelfContained>
     <SelfContained Condition="'$(RuntimeIdentifier)' != ''">true</SelfContained>
   </PropertyGroup>
 
-  <Target Name="_CheckForUnsupportedSelfContained" BeforeTargets="_CheckForInvalidConfigurationAndPlatform">
+  <Target Name="_CheckForUnsupportedSelfContained"
+          BeforeTargets="_CheckForInvalidConfigurationAndPlatform"
+          Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' and '$(OutputType)' == 'Exe'">
+    
     <NETSdkError Condition="'$(SelfContained)' == 'true' and '$(RuntimeIdentifier)' == ''"
                  ResourceName="CannotHaveSelfContainedWithoutRuntimeIdentifier" />
+    
   </Target>
 
   <PropertyGroup>

--- a/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAnAppWithLibrariesAndRid.cs
+++ b/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAnAppWithLibrariesAndRid.cs
@@ -16,6 +16,49 @@ namespace Microsoft.NET.Publish.Tests
     public class GivenThatWeWantToPublishAnAppWithLibrariesAndRid : SdkTest
     {
         [Fact]
+        public void It_publishes_a_self_contained_runnable_output()
+        {
+            if (UsingFullFrameworkMSBuild)
+            {
+                //  Disable this test on full framework, as the current build won't have access to 
+                //  https://github.com/Microsoft/msbuild/pull/1674
+                //  See https://github.com/dotnet/sdk/issues/877
+                return;
+            }
+
+            PublishAppWithLibraryAndRid(true,
+                out var publishDirectory,
+                out var runtimeIdentifier);
+
+            var selfContainedExecutable = $"App{Constants.ExeSuffix}";
+
+            publishDirectory.Should().NotHaveSubDirectories();
+            publishDirectory.Should().HaveFiles(new[] {
+                selfContainedExecutable,
+                "App.dll",
+                "App.pdb",
+                "App.deps.json",
+                "App.runtimeconfig.json",
+                "LibraryWithoutRid.dll",
+                "LibraryWithoutRid.pdb",
+                "LibraryWithRid.dll",
+                "LibraryWithRid.pdb",
+                "LibraryWithRids.dll",
+                "LibraryWithRids.pdb",
+                $"{FileConstants.DynamicLibPrefix}sqlite3{Constants.DynamicLibSuffix}",
+                $"{FileConstants.DynamicLibPrefix}coreclr{Constants.DynamicLibSuffix}",
+                $"{FileConstants.DynamicLibPrefix}hostfxr{Constants.DynamicLibSuffix}",
+                $"{FileConstants.DynamicLibPrefix}hostpolicy{Constants.DynamicLibSuffix}",
+            });
+
+            Command.Create(Path.Combine(publishDirectory.FullName, selfContainedExecutable), new string[] { })
+                .CaptureStdOut()
+                .Execute()
+                .Should().Pass()
+                .And.HaveStdOutContaining($"3.13.0 '{runtimeIdentifier}' 3.13.0 '{runtimeIdentifier}' Hello World");
+        }
+
+        [Fact]
         public void It_publishes_a_framework_dependent_RID_specific_runnable_output()
         {
             if (UsingFullFrameworkMSBuild)
@@ -26,26 +69,9 @@ namespace Microsoft.NET.Publish.Tests
                 return;
             }
 
-            var runtimeIdentifier = RuntimeEnvironment.GetRuntimeIdentifier();
-            var testAsset = _testAssetsManager
-                .CopyTestAsset("AppWithLibraryAndRid", "PublishFrameworkDependentRIDSpecific")
-                .WithSource();
-
-            var projectPath = Path.Combine(testAsset.TestRoot, "App");
-
-            var restoreCommand = new RestoreCommand(Stage0MSBuild, projectPath, "App.csproj");
-            restoreCommand
-                .Execute($"/p:TestRuntimeIdentifier={runtimeIdentifier}")
-                .Should()
-                .Pass();
-
-            var publishCommand = new PublishCommand(Stage0MSBuild, projectPath);
-
-            publishCommand
-                .Execute($"/p:RuntimeIdentifier={runtimeIdentifier}", $"/p:TestRuntimeIdentifier={runtimeIdentifier}", "/p:SelfContained=false")
-                .Should().Pass();
-
-            var publishDirectory = publishCommand.GetOutputDirectory("netcoreapp1.1", runtimeIdentifier: runtimeIdentifier);
+            PublishAppWithLibraryAndRid(false,
+                out var publishDirectory,
+                out var runtimeIdentifier);
 
             publishDirectory.Should().NotHaveSubDirectories();
             publishDirectory.Should().OnlyHaveFiles(new[] {
@@ -67,6 +93,33 @@ namespace Microsoft.NET.Publish.Tests
                 .Execute()
                 .Should().Pass()
                 .And.HaveStdOutContaining($"3.13.0 '{runtimeIdentifier}' 3.13.0 '{runtimeIdentifier}' Hello World");
+        }
+
+        private void PublishAppWithLibraryAndRid(bool selfContained, out DirectoryInfo publishDirectory, out string runtimeIdentifier)
+        {
+            runtimeIdentifier = RuntimeEnvironment.GetRuntimeIdentifier();
+            var testAsset = _testAssetsManager
+                .CopyTestAsset("AppWithLibraryAndRid", $"PublishAppWithLibraryAndRid{selfContained}")
+                .WithSource();
+
+            var projectPath = Path.Combine(testAsset.TestRoot, "App");
+
+            var restoreCommand = new RestoreCommand(Stage0MSBuild, projectPath, "App.csproj");
+            restoreCommand
+                .Execute($"/p:TestRuntimeIdentifier={runtimeIdentifier}")
+                .Should()
+                .Pass();
+
+            var publishCommand = new PublishCommand(Stage0MSBuild, projectPath);
+
+            publishCommand
+                .Execute(
+                    $"/p:RuntimeIdentifier={runtimeIdentifier}", 
+                    $"/p:TestRuntimeIdentifier={runtimeIdentifier}", 
+                    $"/p:SelfContained={selfContained}")
+                .Should().Pass();
+
+            publishDirectory = publishCommand.GetOutputDirectory("netcoreapp1.1", runtimeIdentifier: runtimeIdentifier);
         }
     }
 }

--- a/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAnAppWithLibrariesAndRid.cs
+++ b/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAnAppWithLibrariesAndRid.cs
@@ -52,6 +52,7 @@ namespace Microsoft.NET.Publish.Tests
             });
 
             Command.Create(Path.Combine(publishDirectory.FullName, selfContainedExecutable), new string[] { })
+                .EnsureExecutable()
                 .CaptureStdOut()
                 .Execute()
                 .Should().Pass()


### PR DESCRIPTION
When publishing an app with a library and using --self-contained, the libraries are throwing an error saying it is not supported to have SelfContained without setting a RID.  We need to skip this error for libraries, since it doesn't make any sense.

@livarcocc @nguerrera @dsplaisted 