### PR TITLE
Show publish directory in minimal verbosity output

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Publish.targets
@@ -42,7 +42,13 @@ Copyright (c) .NET Foundation. All rights reserved.
                             PrepareForPublish;
                             ComputeAndCopyFilesToPublishDirectory;
                             GeneratePublishDependencyFile;
-                            GeneratePublishRuntimeConfigurationFile" />
+                            GeneratePublishRuntimeConfigurationFile">
+
+    <!-- Ensure there is minimal verbosity output pointing to the publish directory and not just the
+         build step's minimal output. Otherwise there is no indication at minimal verbosity of where
+         the published assets were copied. -->
+    <Message Importance="High" Text="$(MSBuildProjectName) -&gt; $([System.IO.Path]::GetFullPath('$(PublishDir)'))" />
+  </Target>
 
   <!--
     ============================================================


### PR DESCRIPTION
Fix #801 

The output is now:
```
> dotnet publish
Microsoft (R) Build Engine version 15.2.47.30403
Copyright (C) Microsoft Corporation. All rights reserved.

  tmp -> D:\Src\sdk\tmp\bin\Debug\netcoreapp2.0\tmp.dll
  tmp -> D:\Src\sdk\tmp\bin\Debug\netcoreapp2.0\publish\
```

We still have the output from [CopyFilesToOutputDirectory](https://github.com/Microsoft/msbuild/blob/eeecf7bd7fb7af9be893b019828a3d9e28f9158d/src/Tasks/Microsoft.Common.CurrentVersion.targets#L4010) because publish runs a build first, but we follow it up with another line showing the publish directory in the same style. 

Note that I've just indicated the publish directory and not the path to the app exe in the publish directory, because the factoring of CopyFilesToOutputDirectory makes that a bit mroe complicated to mirror.

@eerhardt @Petermarcu @dsplaisted @livarcocc 