### PR TITLE
GenerateDepsFile fails for desktop libraries referencing NS.Library.

### DIFF
--- a/TestAssets/TestProjects/DesktopReferencingNetStandardLibrary/Class1.cs
+++ b/TestAssets/TestProjects/DesktopReferencingNetStandardLibrary/Class1.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace DesktopReferencingNetStandardLibrary
+{
+    public class Class1
+    {
+        public string GetMessage()
+        {
+            return "Hello";
+        }
+    }
+}

--- a/TestAssets/TestProjects/DesktopReferencingNetStandardLibrary/Library.csproj
+++ b/TestAssets/TestProjects/DesktopReferencingNetStandardLibrary/Library.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net46</TargetFramework>
+    <PreserveCompilationContext>true</PreserveCompilationContext>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NETStandard.Library" Version="1.6.1" />
+  </ItemGroup>
+
+</Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/DependencyContextBuilder.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/DependencyContextBuilder.cs
@@ -124,9 +124,7 @@ namespace Microsoft.NET.Build.Tasks
                 _projectContext.LockFileTarget.TargetFramework.DotNetFrameworkName,
                 _projectContext.LockFileTarget.RuntimeIdentifier,
                 runtimeSignature,
-                // DependencyContext's IsPortable strictly means it doesn't have a runtime dependency,
-                // not whether it is FrameworkDependent or !SelfContained.
-                isPortable: string.IsNullOrEmpty(_projectContext.LockFileTarget.RuntimeIdentifier));
+                _projectContext.IsPortable);
 
             return new DependencyContext(
                 targetInfo,

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ProjectContext.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ProjectContext.cs
@@ -25,6 +25,10 @@ namespace Microsoft.NET.Build.Tasks
         /// <summary>
         /// A value indicating that this project is portable across operating systems, processor architectures, etc.
         /// </summary>
+        /// <remarks>
+        /// Returns <c>true</c> for projects running on shared frameworks (<see cref="IsFrameworkDependent" />)
+        /// that do not target a specific RID.
+        /// </remarks>
         public bool IsPortable => IsFrameworkDependent && string.IsNullOrEmpty(_lockFileTarget.RuntimeIdentifier);
 
         public LockFileTargetLibrary PlatformLibrary { get; }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ProjectContext.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ProjectContext.cs
@@ -16,7 +16,17 @@ namespace Microsoft.NET.Build.Tasks
         private readonly LockFileTarget _lockFileTarget;
         internal HashSet<PackageIdentity> PackagesToBeFiltered { get; set; }
 
+        /// <summary>
+        /// A value indicating that this project runs on a shared system-wide framework.
+        /// (ex. Microsoft.NETCore.App for .NET Core)
+        /// </summary>
         public bool IsFrameworkDependent { get; }
+
+        /// <summary>
+        /// A value indicating that this project is portable across operating systems, processor architectures, etc.
+        /// </summary>
+        public bool IsPortable => IsFrameworkDependent && string.IsNullOrEmpty(_lockFileTarget.RuntimeIdentifier);
+
         public LockFileTargetLibrary PlatformLibrary { get; }
 
         public LockFile LockFile => _lockFile;


### PR DESCRIPTION
When generating the deps.json file, we were incorrectly assuming "IsPortable" meant an empty RID.  But for desktop apps, they aren't portable, but still have an empty RID.

The fix is to truly use "IsPortable" when creating the DependencyContext.

Fix https://github.com/dotnet/cli/issues/6245

@dsplaisted @livarcocc @nguerrera 

/cc @pakrym 