### PR TITLE
Allow NuGetBuildTasksPackTargets to be overrideable

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/sdk/Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/sdk/Sdk.targets
@@ -46,8 +46,8 @@ Copyright (c) .NET Foundation. All rights reserved.
   
   <!-- Import targets from NuGet.Build.Tasks.Pack package/Sdk -->
   <PropertyGroup>
-    <NuGetBuildTasksPackTargets Condition="'$(IsCrossTargetingBuild)' == 'true'">$(MSBuildSDKsPath)\NuGet.Build.Tasks.Pack\buildCrossTargeting\NuGet.Build.Tasks.Pack.targets</NuGetBuildTasksPackTargets>
-    <NuGetBuildTasksPackTargets Condition="'$(IsCrossTargetingBuild)' != 'true'">$(MSBuildSDKsPath)\NuGet.Build.Tasks.Pack\build\NuGet.Build.Tasks.Pack.targets</NuGetBuildTasksPackTargets>
+    <NuGetBuildTasksPackTargets Condition="'$(NuGetBuildTasksPackTargets)' == '' And '$(IsCrossTargetingBuild)' == 'true'">$(MSBuildSDKsPath)\NuGet.Build.Tasks.Pack\buildCrossTargeting\NuGet.Build.Tasks.Pack.targets</NuGetBuildTasksPackTargets>
+    <NuGetBuildTasksPackTargets Condition="'$(NuGetBuildTasksPackTargets)' == '' And '$(IsCrossTargetingBuild)' != 'true'">$(MSBuildSDKsPath)\NuGet.Build.Tasks.Pack\build\NuGet.Build.Tasks.Pack.targets</NuGetBuildTasksPackTargets>
   </PropertyGroup>
   
   <Import Project="$(NuGetBuildTasksPackTargets)"


### PR DESCRIPTION
Fixes #888