### PR TITLE
Add default VB properties for nowarn, warninglevel and msbuildAllProjects

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.VisualBasic.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.VisualBasic.props
@@ -13,6 +13,9 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <PropertyGroup>
     <VBRuntime>Embed</VBRuntime>
+    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+    <WarningLevel Condition=" '$(WarningLevel)' == '' ">1</WarningLevel>
+    <NoWarn Condition=" '$(NoWarn)' == '' ">41999,42016,42017,42018,42019,42020,42021,42022,42032,42036</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.VisualBasic.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.VisualBasic.props
@@ -16,6 +16,10 @@ Copyright (c) .NET Foundation. All rights reserved.
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
     <WarningLevel Condition=" '$(WarningLevel)' == '' ">1</WarningLevel>
     <NoWarn Condition=" '$(NoWarn)' == '' ">41999,42016,42017,42018,42019,42020,42021,42022,42032,42036</NoWarn>
+    <OptionExplicit>On</OptionExplicit>
+    <OptionCompare>Binary</OptionCompare>
+    <OptionStrict>Off</OptionStrict>
+    <OptionInfer>On</OptionInfer>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.VisualBasic.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.VisualBasic.targets
@@ -17,4 +17,15 @@ Copyright (c) .NET Foundation. All rights reserved.
   <PropertyGroup>
     <DefineConstants>$(DefineConstants),$(ImplicitFrameworkDefine)</DefineConstants>
   </PropertyGroup>
+  <ItemGroup>
+    <Import Include="Microsoft.VisualBasic" />
+    <Import Include="System" />
+    <Import Include="System.Collections" />
+    <Import Include="System.Collections.Generic" />
+    <Import Include="System.Data" />
+    <Import Include="System.Diagnostics" />
+    <Import Include="System.Linq" />
+    <Import Include="System.Xml.Linq" />
+    <Import Include="System.Threading.Tasks" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
This change adds default value for VB msbuild properties that are required to light up the compile page. The corresponding change in Project system is [project-system/2004](https://github.com/dotnet/project-system/pull/2004)

This change should go into the Dev15.3 Preview1 branch and not the alpha pack branch. I will retarget the branch once @livarcocc creates the Dev15.3 Preview1 branch.

@davkean @srivatsn @dotnet/project-system for review

**Customer scenario**

Enables the VB Compile Property page by providing the default VB values

**Bugs this fixes:** 

#346

**Workarounds, if any**

None

**Risk**

Low risk - since this just affects that page and adds new properties

**Performance impact**

None - since this just adds some properties

**Is this a regression from a previous update?** N/A

**Root cause analysis:** N/A

**How was the bug found?** N/A