### PR TITLE
Add SDK support for generating deps.json files for .NET CLI Tools

### DIFF
--- a/build/Nuget/Microsoft.NET.Sdk.Nuget.targets
+++ b/build/Nuget/Microsoft.NET.Sdk.Nuget.targets
@@ -48,6 +48,10 @@ vs.localizedResources
       <SdkSwrLines Include='$(SdkSwrBlankLine)folder "InstallDir:MSBuild\Sdks\Microsoft.NET.Sdk\build"' />
       <SdkSwrLines Include='%20%20file source="%24(OutputPath)PackagesLayout\build\%(LaidOutSdk_BuildFiles.Filename)%(LaidOutSdk_BuildFiles.Extension)"' />
 
+      <LaidOutSdk_BuildGenerateDepsFiles Include="$(PackagesLayoutDir)build\GenerateDeps\*" />
+      <SdkSwrLines Include='$(SdkSwrBlankLine)folder "InstallDir:MSBuild\Sdks\Microsoft.NET.Sdk\build\GenerateDeps"' />
+      <SdkSwrLines Include='%20%20file source="%24(OutputPath)PackagesLayout\build\GenerateDeps\%(LaidOutSdk_BuildGenerateDepsFiles.Filename)%(LaidOutSdk_BuildGenerateDepsFiles.Extension)"' />
+
       <LaidOutSdk_BuildCrossTargetingFiles Include="$(PackagesLayoutDir)buildCrossTargeting\*" />
       <SdkSwrLines Include='$(SdkSwrBlankLine)folder "InstallDir:MSBuild\Sdks\Microsoft.NET.Sdk\buildCrossTargeting"' />
       <SdkSwrLines Include='%20%20file source="%24(OutputPath)PackagesLayout\buildCrossTargeting\%(LaidOutSdk_BuildCrossTargetingFiles.Filename)%(LaidOutSdk_BuildCrossTargetingFiles.Extension)"' />      

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenADependencyContextBuilder.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenADependencyContextBuilder.cs
@@ -52,7 +52,8 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 Constants.DefaultPlatformLibrary,
                 isSelfContained: !string.IsNullOrEmpty(runtime));
 
-            DependencyContext dependencyContext = new DependencyContextBuilder(mainProject, projectContext)
+            DependencyContext dependencyContext = new DependencyContextBuilder(projectContext)
+                .WithMainProject(mainProject)
                 .WithDirectReferences(directReferences)
                 .WithCompilationOptions(compilationOptions)
                 .Build();

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenADependencyContextBuilder.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenADependencyContextBuilder.cs
@@ -52,8 +52,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 Constants.DefaultPlatformLibrary,
                 isSelfContained: !string.IsNullOrEmpty(runtime));
 
-            DependencyContext dependencyContext = new DependencyContextBuilder(projectContext)
-                .WithMainProject(mainProject)
+            DependencyContext dependencyContext = new DependencyContextBuilder(mainProject, projectContext)
                 .WithDirectReferences(directReferences)
                 .WithCompilationOptions(compilationOptions)
                 .Build();

--- a/src/Tasks/Microsoft.NET.Build.Tasks/GenerateDepsFile.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/GenerateDepsFile.cs
@@ -50,6 +50,9 @@ namespace Microsoft.NET.Build.Tasks
         public ITaskItem[] AssemblySatelliteAssemblies { get; set; }
 
         [Required]
+        public bool IncludeMainProject { get; set; }
+
+        [Required]
         public ITaskItem[] ReferencePaths { get; set; }
 
         [Required]
@@ -116,12 +119,17 @@ namespace Microsoft.NET.Build.Tasks
             LockFile lockFile = new LockFileCache(BuildEngine4).GetLockFile(AssetsFilePath);
             CompilationOptions compilationOptions = CompilationOptionsConverter.ConvertFrom(CompilerOptions);
 
-            SingleProjectInfo mainProject = SingleProjectInfo.Create(
-                ProjectPath,
-                AssemblyName,
-                AssemblyExtension,
-                AssemblyVersion,
-                AssemblySatelliteAssemblies);
+            SingleProjectInfo mainProject = null;
+
+            if (IncludeMainProject)
+            {
+                mainProject = SingleProjectInfo.Create(
+                    ProjectPath,
+                    AssemblyName,
+                    AssemblyExtension,
+                    AssemblyVersion,
+                    AssemblySatelliteAssemblies);
+            }
 
             IEnumerable<ReferenceInfo> frameworkReferences =
                 ReferenceInfo.CreateFrameworkReferenceInfos(ReferencePaths);
@@ -141,7 +149,8 @@ namespace Microsoft.NET.Build.Tasks
                 PlatformLibraryName,
                 IsSelfContained);
 
-            DependencyContext dependencyContext = new DependencyContextBuilder(mainProject, projectContext)
+            DependencyContext dependencyContext = new DependencyContextBuilder(projectContext)
+                .WithMainProject(mainProject)
                 .WithFrameworkReferences(frameworkReferences)
                 .WithDirectReferences(directReferences)
                 .WithReferenceProjectInfos(referenceProjects)

--- a/src/Tasks/Microsoft.NET.Build.Tasks/GenerateDepsFile.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/GenerateDepsFile.cs
@@ -119,17 +119,12 @@ namespace Microsoft.NET.Build.Tasks
             LockFile lockFile = new LockFileCache(BuildEngine4).GetLockFile(AssetsFilePath);
             CompilationOptions compilationOptions = CompilationOptionsConverter.ConvertFrom(CompilerOptions);
 
-            SingleProjectInfo mainProject = null;
-
-            if (IncludeMainProject)
-            {
-                mainProject = SingleProjectInfo.Create(
+            SingleProjectInfo mainProject = SingleProjectInfo.Create(
                     ProjectPath,
                     AssemblyName,
                     AssemblyExtension,
                     AssemblyVersion,
-                    AssemblySatelliteAssemblies);
-            }
+                    AssemblySatelliteAssemblies);            
 
             IEnumerable<ReferenceInfo> frameworkReferences =
                 ReferenceInfo.CreateFrameworkReferenceInfos(ReferencePaths);
@@ -149,8 +144,8 @@ namespace Microsoft.NET.Build.Tasks
                 PlatformLibraryName,
                 IsSelfContained);
 
-            DependencyContext dependencyContext = new DependencyContextBuilder(projectContext)
-                .WithMainProject(mainProject)
+            DependencyContext dependencyContext = new DependencyContextBuilder(mainProject, projectContext)
+                .WithMainProjectInDepsFile(IncludeMainProject)
                 .WithFrameworkReferences(frameworkReferences)
                 .WithDirectReferences(directReferences)
                 .WithReferenceProjectInfos(referenceProjects)

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Microsoft.NET.Build.Tasks.csproj
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Microsoft.NET.Build.Tasks.csproj
@@ -189,7 +189,9 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <None Include="build\GenerateDeps\GenerateDeps.proj" />
+    <None Include="build\GenerateDeps\GenerateDeps.proj">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <!-- Remove files from copy local that would not be published as they are provided by the platform package -->
   <!-- https://github.com/dotnet/sdk/issues/933 tracks a first class feature for this -->

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Microsoft.NET.Build.Tasks.csproj
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Microsoft.NET.Build.Tasks.csproj
@@ -188,6 +188,9 @@
       <DependentUpon>Strings.resx</DependentUpon>
     </EmbeddedResource>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="build\GenerateDeps\GenerateDeps.proj" />
+  </ItemGroup>
   <!-- Remove files from copy local that would not be published as they are provided by the platform package -->
   <!-- https://github.com/dotnet/sdk/issues/933 tracks a first class feature for this -->
   <Target Name="FilterCopyLocal" DependsOnTargets="RunResolvePublishAssemblies" BeforeTargets="ResolveLockFileCopyLocalProjectDeps">

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/GenerateDeps/GenerateDeps.proj
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/GenerateDeps/GenerateDeps.proj
@@ -29,7 +29,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <TargetFramework>netcoreapp$(BundledNETCoreAppTargetFrameworkVersion)</TargetFramework>
 
     <ToolFolder>$([System.IO.Path]::GetDirectoryName($(ProjectAssetsFile)))</ToolFolder>
-    <ProjectDepsFilePath>$(ToolFolder)\$(ToolName).deps.json</ProjectDepsFilePath>
+    <ProjectDepsFilePath Condition="'$(ProjectDepsFilePath)' == ''">$(ToolFolder)\$(ToolName).deps.json</ProjectDepsFilePath>
     
     <OutputType>Exe</OutputType>
     <IncludeMainProjectInDepsFile>false</IncludeMainProjectInDepsFile>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/GenerateDeps/GenerateDeps.proj
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/GenerateDeps/GenerateDeps.proj
@@ -1,0 +1,44 @@
+﻿<Project Sdk="Microsoft.NET.Sdk" DefaultTargets="BuildDepsJson">
+  <!--
+***********************************************************************************************
+GenerateDeps.proj
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+          created a backup copy.  Incorrect changes to this file will make it
+          impossible to load or build your projects from the command-line or the IDE.
+
+Copyright (c) .NET Foundation. All rights reserved. 
+***********************************************************************************************
+-->
+  
+  <!--
+    This project is built by the .NET CLI in order to create .deps.json files for .NET CLI tools.
+    Properties to be passed in by the .NET CLI:
+      - ProjectAssetsFile: Full path to the project.assets.json file for the tool under the NuGet .tools folder
+      - ToolName: The simple name of the tool DLL, for example, "dotnet-mytool"
+      - AdditionalImport: The full path to the .props file from the platform package which will be imported, which
+        should include the PackageConflictPlatformManifests file.      
+        This is a workaround until NuGet can generate .props and .targets files for imports from packages referenced
+        by tools, which is tracked by https://github.com/NuGet/Home/issues/5037.
+  -->
+
+  <Import Project="$(AdditionalImport)"
+          Condition=" '$(AdditionalImport)' != '' And Exists($(AdditionalImport))" />
+  
+  <PropertyGroup>
+    <TargetFramework>netcoreapp$(BundledNETCoreAppTargetFrameworkVersion)</TargetFramework>
+
+    <ToolFolder>$([System.IO.Path]::GetDirectoryName($(ProjectAssetsFile)))</ToolFolder>
+    <ProjectDepsFilePath>$(ToolFolder)\$(ToolName).deps.json</ProjectDepsFilePath>
+    
+    <OutputType>Exe</OutputType>
+    <IncludeMainProjectInDepsFile>false</IncludeMainProjectInDepsFile>
+  </PropertyGroup>
+
+  <Target Name="BuildDepsJson" DependsOnTargets="$(ResolvePackageDependenciesForBuildDependsOn);GenerateBuildDependencyFile" />
+
+  <Target Name="DontRestore" BeforeTargets="Restore">
+    <Error Text="This project should not be restored" />
+  </Target>
+
+</Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/GenerateDeps/GenerateDeps.proj
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/GenerateDeps/GenerateDeps.proj
@@ -26,8 +26,6 @@ Copyright (c) .NET Foundation. All rights reserved.
           Condition=" '$(AdditionalImport)' != '' And Exists($(AdditionalImport))" />
   
   <PropertyGroup>
-    <TargetFramework>netcoreapp$(BundledNETCoreAppTargetFrameworkVersion)</TargetFramework>
-
     <ToolFolder>$([System.IO.Path]::GetDirectoryName($(ProjectAssetsFile)))</ToolFolder>
     <ProjectDepsFilePath Condition="'$(ProjectDepsFilePath)' == ''">$(ToolFolder)\$(ToolName).deps.json</ProjectDepsFilePath>
     

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Publish.targets
@@ -468,7 +468,6 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <PropertyGroup>
       <PublishDepsFilePath Condition=" '$(PublishDepsFilePath)' == '' ">$(PublishDir)$(ProjectDepsFileName)</PublishDepsFilePath>
-      <IncludeMainProjectInDepsFile Condition=" '$(IncludeMainProjectInDepsFile)' == '' ">true</IncludeMainProjectInDepsFile>
     </PropertyGroup>
 
     <GenerateDepsFile ProjectPath="$(MSBuildProjectFullPath)"

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Publish.targets
@@ -468,6 +468,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <PropertyGroup>
       <PublishDepsFilePath Condition=" '$(PublishDepsFilePath)' == '' ">$(PublishDir)$(ProjectDepsFileName)</PublishDepsFilePath>
+      <IncludeMainProjectInDepsFile Condition=" '$(IncludeMainProjectInDepsFile)' == '' ">true</IncludeMainProjectInDepsFile>
     </PropertyGroup>
 
     <GenerateDepsFile ProjectPath="$(MSBuildProjectFullPath)"
@@ -480,6 +481,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                       AssemblySatelliteAssemblies="@(IntermediateSatelliteAssembliesWithTargetPath)"
                       ReferencePaths="@(ReferencePath)"
                       ReferenceSatellitePaths="@(ReferenceSatellitePaths)"
+                      IncludeMainProject="$(IncludeMainProjectInDepsFile)"
                       RuntimeIdentifier="$(RuntimeIdentifier)"
                       PlatformLibraryName="$(MicrosoftNETPlatformLibrary)"
                       FilesToSkip="@(_ConflictPackageFiles);@(_PublishConflictPackageFiles)"

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.Common.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.Common.targets
@@ -28,6 +28,10 @@ Copyright (c) .NET Foundation. All rights reserved.
     <DefaultImplicitPackages>Microsoft.NETCore.App;NETStandard.Library</DefaultImplicitPackages>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(DotnetCliToolTargetFramework)' == '' And '$(BundledNETCoreAppTargetFrameworkVersion)' != ''">
+    <!-- Set the TFM used to restore .NET CLI tools to match the version of .NET Core bundled in the CLI -->
+    <DotnetCliToolTargetFramework>netcoreapp$(BundledNETCoreAppTargetFrameworkVersion)</DotnetCliToolTargetFramework>
+  </PropertyGroup>
 
   <UsingTask TaskName="GetNearestTargetFramework" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
   <UsingTask TaskName="NETSdkError" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.props
@@ -103,6 +103,11 @@ Copyright (c) .NET Foundation. All rights reserved.
     <DebugSymbols Condition="'$(DebugSymbols)'==''">false</DebugSymbols>
     <CheckForOverflowUnderflow Condition="'$(CheckForOverflowUnderflow)'==''">false</CheckForOverflowUnderflow>
   </PropertyGroup>
+
+  <PropertyGroup>
+    <!-- Path to project that the .NET CLI will build in order to generate deps.json files for .NET CLI tools -->
+    <ToolDepsJsonGeneratorProject>$(MSBuildThisFileDirectory)GenerateDeps\GenerateDeps.proj</ToolDepsJsonGeneratorProject>
+  </PropertyGroup>
   
   <!-- Default item includes (globs and implicit references) -->
   <Import Project="Microsoft.NET.Sdk.DefaultItems.props" />

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.targets
@@ -63,11 +63,6 @@ Copyright (c) .NET Foundation. All rights reserved.
     <_DotNetHostFxrLibraryName>$(_NativeLibraryPrefix)hostfxr$(_NativeLibraryExtension)</_DotNetHostFxrLibraryName>
   </PropertyGroup>
   
-  <PropertyGroup Condition="'$(DotnetCliToolTargetFramework)' == '' And '$(BundledNETCoreAppTargetFrameworkVersion)' != ''">
-    <!-- Set the TFM used to restore .NET CLI tools to match the version of .NET Core bundled in the CLI -->
-    <DotnetCliToolTargetFramework>netcoreapp$(BundledNETCoreAppTargetFrameworkVersion)</DotnetCliToolTargetFramework>
-  </PropertyGroup>
-
   <PropertyGroup>
     <CoreBuildDependsOn>
       $(CoreBuildDependsOn);

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.targets
@@ -62,6 +62,11 @@ Copyright (c) .NET Foundation. All rights reserved.
     <_DotNetHostPolicyLibraryName>$(_NativeLibraryPrefix)hostpolicy$(_NativeLibraryExtension)</_DotNetHostPolicyLibraryName>
     <_DotNetHostFxrLibraryName>$(_NativeLibraryPrefix)hostfxr$(_NativeLibraryExtension)</_DotNetHostFxrLibraryName>
   </PropertyGroup>
+  
+  <PropertyGroup Condition="'$(DotnetCliToolTargetFramework)' == '' And '$(BundledNETCoreAppTargetFrameworkVersion)' != ''">
+    <!-- Set the TFM used to restore .NET CLI tools to match the version of .NET Core bundled in the CLI -->
+    <DotnetCliToolTargetFramework>netcoreapp$(BundledNETCoreAppTargetFrameworkVersion)</DotnetCliToolTargetFramework>
+  </PropertyGroup>
 
   <PropertyGroup>
     <CoreBuildDependsOn>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.targets
@@ -45,6 +45,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ProjectRuntimeConfigFileName Condition="'$(ProjectRuntimeConfigFileName)' == ''">$(AssemblyName).runtimeconfig.json</ProjectRuntimeConfigFileName>
     <ProjectRuntimeConfigFilePath Condition="'$(ProjectRuntimeConfigFilePath)' == ''">$(TargetDir)$(ProjectRuntimeConfigFileName)</ProjectRuntimeConfigFilePath>
     <ProjectRuntimeConfigDevFilePath Condition="'$(ProjectRuntimeConfigDevFilePath)' == ''">$(TargetDir)$(AssemblyName).runtimeconfig.dev.json</ProjectRuntimeConfigDevFilePath>
+    <IncludeMainProjectInDepsFile Condition=" '$(IncludeMainProjectInDepsFile)' == '' ">true</IncludeMainProjectInDepsFile>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -86,10 +87,6 @@ Copyright (c) .NET Foundation. All rights reserved.
           Inputs="$(ProjectAssetsFile)"
           Outputs="$(ProjectDepsFilePath)">
 
-    <PropertyGroup>
-      <IncludeMainProjectInDepsFile Condition=" '$(IncludeMainProjectInDepsFile)' == '' ">true</IncludeMainProjectInDepsFile>
-    </PropertyGroup>
-    
     <!-- 
     Explicitly not passing any PrivateAssets information during 'Build', since these dependencies
     should be included during 'Build'.  They are only excluded on 'Publish'.

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.targets
@@ -86,6 +86,10 @@ Copyright (c) .NET Foundation. All rights reserved.
           Inputs="$(ProjectAssetsFile)"
           Outputs="$(ProjectDepsFilePath)">
 
+    <PropertyGroup>
+      <IncludeMainProjectInDepsFile Condition=" '$(IncludeMainProjectInDepsFile)' == '' ">true</IncludeMainProjectInDepsFile>
+    </PropertyGroup>
+    
     <!-- 
     Explicitly not passing any PrivateAssets information during 'Build', since these dependencies
     should be included during 'Build'.  They are only excluded on 'Publish'.
@@ -100,6 +104,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                       AssemblySatelliteAssemblies="@(IntermediateSatelliteAssembliesWithTargetPath)"
                       ReferencePaths="@(ReferencePath)"
                       ReferenceSatellitePaths="@(ReferenceSatellitePaths)"
+                      IncludeMainProject="$(IncludeMainProjectInDepsFile)"
                       RuntimeIdentifier="$(RuntimeIdentifier)"
                       PlatformLibraryName="$(MicrosoftNETPlatformLibrary)"
                       FilesToSkip="@(_ConflictPackageFiles)"

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToExcludeTheMainProjectFromTheDepsFile.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToExcludeTheMainProjectFromTheDepsFile.cs
@@ -19,6 +19,16 @@ namespace Microsoft.NET.Build.Tests
         [Fact]
         public void It_builds_successfully()
         {
+            if (UsingFullFrameworkMSBuild)
+            {
+                //  Fullframework NuGet versioning on Jenkins infrastructure issue
+                //        https://github.com/dotnet/sdk/issues/1041
+
+                //  Disabled on full framework MSBuild until CI machines have VS with bundled .NET Core / .NET Standard versions
+                //  See https://github.com/dotnet/sdk/issues/1077
+                return;
+            }
+
             TestProject testProject = new TestProject()
             {
                 Name = "ExcludeMainProjectFromDeps",

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToExcludeTheMainProjectFromTheDepsFile.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToExcludeTheMainProjectFromTheDepsFile.cs
@@ -1,0 +1,62 @@
+﻿using FluentAssertions;
+using Microsoft.NET.TestFramework;
+using Microsoft.NET.TestFramework.Assertions;
+using Microsoft.NET.TestFramework.Commands;
+using Microsoft.NET.TestFramework.ProjectConstruction;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Xml.Linq;
+using Xunit;
+
+using static Microsoft.NET.TestFramework.Commands.MSBuildTest;
+
+namespace Microsoft.NET.Build.Tests
+{
+    public class GivenThatWeWantToExcludeTheMainProjectFromTheDepsFile : SdkTest
+    {
+        [Fact]
+        public void It_builds_successfully()
+        {
+            TestProject testProject = new TestProject()
+            {
+                Name = "ExcludeMainProjectFromDeps",
+                IsSdkProject = true,
+                TargetFrameworks = "netcoreapp2.0",
+                IsExe = true,
+            };
+
+            TestProject referencedProject = new TestProject()
+            {
+                Name = "ReferencedProject",
+                IsSdkProject = true,
+                TargetFrameworks = "netstandard2.0",
+                IsExe = false
+            };
+
+            testProject.ReferencedProjects.Add(referencedProject);
+
+            var testProjectInstance = _testAssetsManager.CreateTestProject(testProject, testProject.Name)
+                .WithProjectChanges((path, project) =>
+                {
+                    if (Path.GetFileNameWithoutExtension(path) == testProject.Name)
+                    {
+                        var ns = project.Root.Name.Namespace;
+
+                        var propertyGroup = new XElement(ns + "PropertyGroup");
+                        project.Root.Add(propertyGroup);
+
+                        propertyGroup.Add(new XElement(ns + "IncludeMainProjectInDepsFile", "false"));
+                    }
+                })
+                .Restore(testProject.Name);
+
+            var buildCommand = new BuildCommand(Stage0MSBuild, testProjectInstance.TestRoot, testProject.Name);
+
+            buildCommand.Execute()
+                .Should()
+                .Pass();
+        }
+    }
+}

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToGenerateADepsFileForATool.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToGenerateADepsFileForATool.cs
@@ -23,6 +23,16 @@ namespace Microsoft.NET.Build.Tests
         [Fact]
         public void It_creates_a_deps_file_for_the_tool_and_the_tool_runs()
         {
+            if (UsingFullFrameworkMSBuild)
+            {
+                //  Fullframework NuGet versioning on Jenkins infrastructure issue
+                //        https://github.com/dotnet/sdk/issues/1041
+
+                //  Disabled on full framework MSBuild until CI machines have VS with bundled .NET Core / .NET Standard versions
+                //  See https://github.com/dotnet/sdk/issues/1077
+                return;
+            }
+
             TestProject toolProject = new TestProject()
             {
                 Name = "TestTool",
@@ -40,6 +50,16 @@ namespace Microsoft.NET.Build.Tests
         [Fact]
         public void It_handles_conflicts_when_creating_a_tool_deps_file()
         {
+            if (UsingFullFrameworkMSBuild)
+            {
+                //  Fullframework NuGet versioning on Jenkins infrastructure issue
+                //        https://github.com/dotnet/sdk/issues/1041
+
+                //  Disabled on full framework MSBuild until CI machines have VS with bundled .NET Core / .NET Standard versions
+                //  See https://github.com/dotnet/sdk/issues/1077
+                return;
+            }
+
             TestProject toolProject = new TestProject()
             {
                 Name = "DependencyContextTool",

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToGenerateADepsFileForATool.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToGenerateADepsFileForATool.cs
@@ -119,7 +119,7 @@ class Program
             restoreCommand.AddSource(nupkgPath);
             restoreCommand.Execute().Should().Pass();
 
-            string toolAssetsFilePath = Path.Combine(RepoInfo.NuGetCachePath, ".tools", toolProject.Name, "1.0.0", toolProject.TargetFrameworks, "project.assets.json");
+            string toolAssetsFilePath = Path.Combine(RepoInfo.NuGetCachePath, ".tools", toolProject.Name.ToLowerInvariant(), "1.0.0", toolProject.TargetFrameworks, "project.assets.json");
             var toolAssetsFile = new LockFileFormat().Read(toolAssetsFilePath);
 
             var args = new List<string>();

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToGenerateADepsFileForATool.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToGenerateADepsFileForATool.cs
@@ -68,7 +68,7 @@ namespace Microsoft.NET.Build.Tests
                 IsExe = true
             };
 
-            toolProject.PackageReferences.Add(new TestPackageReference("Microsoft.Extensions.DependencyModel", "2.0.0-preview1-002022", null));
+            toolProject.PackageReferences.Add(new TestPackageReference("Microsoft.Extensions.DependencyModel", "1.1.0", null));
 
             string toolSource = @"
 using System;

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToGenerateADepsFileForATool.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToGenerateADepsFileForATool.cs
@@ -1,0 +1,239 @@
+﻿using FluentAssertions;
+using Microsoft.DotNet.Cli.Utils;
+using Microsoft.NET.TestFramework;
+using Microsoft.NET.TestFramework.Assertions;
+using Microsoft.NET.TestFramework.Commands;
+using Microsoft.NET.TestFramework.ProjectConstruction;
+using NuGet.Packaging;
+using NuGet.ProjectModel;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Xml.Linq;
+using Xunit;
+using static Microsoft.NET.TestFramework.Commands.MSBuildTest;
+
+namespace Microsoft.NET.Build.Tests
+{
+    public class GivenThatWeWantToGenerateADepsFileForATool : SdkTest
+    {
+        [Fact]
+        public void It_creates_a_deps_file_for_the_tool_and_the_tool_runs()
+        {
+            TestProject toolProject = new TestProject()
+            {
+                Name = "TestTool",
+                IsSdkProject = true,
+                TargetFrameworks = "netcoreapp2.0",
+                IsExe = true
+            };
+
+            GenerateDepsAndRunTool(toolProject)
+                .Should()
+                .Pass()
+                .And.HaveStdOutContaining("Hello World!");
+        }
+
+        [Fact]
+        public void It_handles_conflicts_when_creating_a_tool_deps_file()
+        {
+            TestProject toolProject = new TestProject()
+            {
+                Name = "DependencyContextTool",
+                IsSdkProject = true,
+                TargetFrameworks = "netcoreapp2.0",
+                IsExe = true
+            };
+
+            toolProject.PackageReferences.Add(new TestPackageReference("Microsoft.Extensions.DependencyModel", "2.0.0-preview1-002022", null));
+
+            string toolSource = @"
+using System;
+using System.Linq;
+using Microsoft.Extensions.DependencyModel;
+
+class Program
+{
+    static void Main(string[] args)
+    {
+        if(DependencyContext.Default?.RuntimeGraph?.Any() == true)
+        {
+            Console.WriteLine(""Successfully loaded runtime graph"");
+        }
+        else
+        {
+            Console.WriteLine(""Couldn't load runtime graph"");
+        }
+    }
+}";
+
+            toolProject.SourceFiles.Add("Program.cs", toolSource);
+
+            GenerateDepsAndRunTool(toolProject, "ToolConflictResolution")
+                .Should()
+                .Pass()
+                .And.HaveStdOutContaining("Successfully loaded runtime graph");
+        }
+
+        //  This method duplicates a lot of logic from the CLI in order to test generating deps files for tools in the SDK repo
+        private CommandResult GenerateDepsAndRunTool(TestProject toolProject, [CallerMemberName] string callingMethod = "")
+        {
+            DeleteFolder(Path.Combine(RepoInfo.NuGetCachePath, toolProject.Name.ToLowerInvariant()));
+            DeleteFolder(Path.Combine(RepoInfo.NuGetCachePath, ".tools", toolProject.Name.ToLowerInvariant()));
+
+            var toolProjectInstance = _testAssetsManager.CreateTestProject(toolProject, callingMethod, identifier: toolProject.Name)
+                .Restore(toolProject.Name);
+
+            var packCommand = new PackCommand(Stage0MSBuild, Path.Combine(toolProjectInstance.TestRoot, toolProject.Name));
+
+            packCommand.Execute()
+                .Should()
+                .Pass();
+
+            string nupkgPath = Path.Combine(packCommand.ProjectRootPath, "bin", "Debug");
+
+            TestProject toolReferencer = new TestProject()
+            {
+                Name = "ToolReferencer",
+                IsSdkProject = true,
+                TargetFrameworks = "netcoreapp2.0"
+            };
+
+            var toolReferencerInstance = _testAssetsManager.CreateTestProject(toolReferencer, callingMethod, identifier: toolReferencer.Name)
+                .WithProjectChanges(project =>
+                {
+                    var ns = project.Root.Name.Namespace;
+
+                    var itemGroup = new XElement(ns + "ItemGroup");
+                    project.Root.Add(itemGroup);
+
+                    itemGroup.Add(new XElement(ns + "DotNetCliToolReference",
+                        new XAttribute("Include", toolProject.Name),
+                        new XAttribute("Version", "1.0.0")));
+                });
+
+            var restoreCommand = toolReferencerInstance.GetRestoreCommand(toolReferencer.Name);
+            restoreCommand.AddSource(nupkgPath);
+            restoreCommand.Execute().Should().Pass();
+
+            string toolAssetsFilePath = Path.Combine(RepoInfo.NuGetCachePath, ".tools", toolProject.Name, "1.0.0", toolProject.TargetFrameworks, "project.assets.json");
+            var toolAssetsFile = new LockFileFormat().Read(toolAssetsFilePath);
+
+            var args = new List<string>();
+
+            string generateDepsProjectPath = Path.Combine(RepoInfo.SdksPath, "Microsoft.NET.Sdk", "build", "GenerateDeps", "GenerateDeps.proj");
+            args.Add(generateDepsProjectPath);
+            
+            args.Add($"/p:ProjectAssetsFile=\"{toolAssetsFilePath}\"");
+
+            args.Add($"/p:ToolName={toolProject.Name}");
+
+            string depsFilePath = Path.Combine(Path.GetDirectoryName(toolAssetsFilePath), toolProject.Name + ".deps.json");
+            args.Add($"/p:ProjectDepsFilePath={depsFilePath}");
+
+            var toolTargetFramework = toolAssetsFile.Targets.First().TargetFramework.GetShortFolderName();
+            args.Add($"/p:TargetFramework={toolProject.TargetFrameworks}");
+
+            //  Look for the .props file in the Microsoft.NETCore.App package, until NuGet
+            //  generates .props and .targets files for tool restores (https://github.com/NuGet/Home/issues/5037)
+            var platformLibrary = toolAssetsFile.Targets
+                .Single()
+                .Libraries
+                .FirstOrDefault(e => e.Name.Equals("Microsoft.NETCore.App", StringComparison.OrdinalIgnoreCase));
+
+            if (platformLibrary != null)
+            {
+                string buildRelativePath = platformLibrary.Build.FirstOrDefault()?.Path;
+
+                var platformLibraryPath = GetPackageDirectory(toolAssetsFile, platformLibrary);
+
+                if (platformLibraryPath != null && buildRelativePath != null)
+                {
+                    //  Get rid of "_._" filename
+                    buildRelativePath = Path.GetDirectoryName(buildRelativePath);
+
+                    string platformLibraryBuildFolderPath = Path.Combine(platformLibraryPath, buildRelativePath);
+                    var platformLibraryPropsFile = Directory.GetFiles(platformLibraryBuildFolderPath, "*.props").FirstOrDefault();
+
+                    if (platformLibraryPropsFile != null)
+                    {
+                        args.Add($"/p:AdditionalImport={platformLibraryPropsFile}");
+                    }
+                }
+            }
+
+            var generateDepsCommand = Stage0MSBuild.CreateCommandForTarget("BuildDepsJson", args.ToArray());
+
+            generateDepsCommand.Execute()
+                .Should()
+                .Pass();
+
+            var toolLibrary = toolAssetsFile.Targets
+                .Single()
+                .Libraries.FirstOrDefault(
+                    l => StringComparer.OrdinalIgnoreCase.Equals(l.Name, toolProject.Name));
+
+            var toolAssembly = toolLibrary?.RuntimeAssemblies
+                .FirstOrDefault(r => Path.GetFileNameWithoutExtension(r.Path) == toolProject.Name);
+
+            var toolPackageDirectory = GetPackageDirectory(toolAssetsFile, toolLibrary);
+
+            var toolAssemblyPath = Path.Combine(
+                toolPackageDirectory,
+                toolAssembly.Path);
+
+            var dotnetArgs = new List<string>();
+            dotnetArgs.Add("exec");
+
+            dotnetArgs.Add("--depsfile");
+            dotnetArgs.Add(depsFilePath);
+
+            foreach (var packageFolder in GetNormalizedPackageFolders(toolAssetsFile))
+            {
+                dotnetArgs.Add("--additionalprobingpath");
+                dotnetArgs.Add(packageFolder);
+            }
+
+            dotnetArgs.Add(toolAssemblyPath);
+
+            ICommand toolCommand = Command.Create(RepoInfo.DotNetHostPath, dotnetArgs)
+                .CaptureStdOut();
+            toolCommand = RepoInfo.AddTestEnvironmentVariables(toolCommand);
+
+
+            var toolResult = toolCommand.Execute();
+
+            return toolResult;
+        }
+
+        private static void DeleteFolder(string path)
+        {
+            if (Directory.Exists(path))
+            {
+                Directory.Delete(path, true);
+            }
+        }
+
+        private static IEnumerable<string> GetNormalizedPackageFolders(LockFile lockFile)
+        {
+            return lockFile.PackageFolders.Select(pf => pf.Path.TrimEnd(Path.DirectorySeparatorChar));
+        }
+
+        private static string GetPackageDirectory(LockFile lockFile, LockFileTargetLibrary library)
+        {
+            var packageFolders = GetNormalizedPackageFolders(lockFile);
+
+            var packageFoldersCount = packageFolders.Count();
+            var userPackageFolder = packageFoldersCount == 1 ? string.Empty : packageFolders.First();
+            var fallbackPackageFolders = packageFoldersCount > 1 ? packageFolders.Skip(1) : packageFolders;
+
+            var packageDirectory = new FallbackPackagePathResolver(userPackageFolder, fallbackPackageFolders)
+                .GetPackageDirectory(library.Name, library.Version);
+
+            return packageDirectory;
+        }
+    }
+}

--- a/test/Microsoft.NET.TestFramework/Commands/MSBuildTest.cs
+++ b/test/Microsoft.NET.TestFramework/Commands/MSBuildTest.cs
@@ -45,10 +45,7 @@ namespace Microsoft.NET.TestFramework.Commands
                 command = Command.Create(DotNetHostPath, newArgs);
             }
 
-            //  Set NUGET_PACKAGES environment variable to match value from build.ps1
-            command = command.EnvironmentVariable("NUGET_PACKAGES", Path.Combine(RepoInfo.RepoRoot, "packages"));
-
-            command = command.EnvironmentVariable("MSBuildSDKsPath", RepoInfo.SdksPath);
+            command = RepoInfo.AddTestEnvironmentVariables(command);
 
             return command;
         }

--- a/test/Microsoft.NET.TestFramework/RepoInfo.cs
+++ b/test/Microsoft.NET.TestFramework/RepoInfo.cs
@@ -69,7 +69,7 @@ namespace Microsoft.NET.TestFramework
 
         public static string NuGetCachePath
         {
-            get { return Path.Combine(RepoRoot, "Packages"); }
+            get { return Path.Combine(RepoRoot, "packages"); }
         }
 
 
@@ -101,6 +101,16 @@ namespace Microsoft.NET.TestFramework
 #endif
 
             return directory;
+        }
+
+        public static ICommand AddTestEnvironmentVariables(ICommand command)
+        {
+            //  Set NUGET_PACKAGES environment variable to match value from build.ps1
+            command = command.EnvironmentVariable("NUGET_PACKAGES", Path.Combine(RepoInfo.RepoRoot, "packages"));
+
+            command = command.EnvironmentVariable("MSBuildSDKsPath", RepoInfo.SdksPath);
+
+            return command;
         }
     }
 }

--- a/test/Microsoft.NET.TestFramework/RepoInfo.cs
+++ b/test/Microsoft.NET.TestFramework/RepoInfo.cs
@@ -106,7 +106,7 @@ namespace Microsoft.NET.TestFramework
         public static ICommand AddTestEnvironmentVariables(ICommand command)
         {
             //  Set NUGET_PACKAGES environment variable to match value from build.ps1
-            command = command.EnvironmentVariable("NUGET_PACKAGES", Path.Combine(RepoInfo.RepoRoot, "packages"));
+            command = command.EnvironmentVariable("NUGET_PACKAGES", RepoInfo.NuGetCachePath);
 
             command = command.EnvironmentVariable("MSBuildSDKsPath", RepoInfo.SdksPath);
 


### PR DESCRIPTION
This is an SDK-side change which will be part of fixing https://github.com/dotnet/cli/issues/6087.  There will be a corresponding CLI change which will take advantage of it.  We should probably wait to merge this change until I have the CLI change ready, but I think this change can be reviewed as is.

The idea is that when the CLI is going to run a tool, it will check to see if there is a deps.json file next to the project.assets.json under the NuGet .tools folder.  If not, it will generate the deps file by building the new GenerateDeps.proj file which is inside the CLI, passing in necessary information such as the path to the assets file.

This will allow the same logic to be used to generate the .deps.json files for tools as is used when apps are built.  It will include the conflict resolution logic, which will fix #6087.