### PR TITLE
Ensure all properties are set when cloning Libraries.

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/GenerateDepsFile.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/GenerateDepsFile.cs
@@ -77,7 +77,7 @@ namespace Microsoft.NET.Build.Tasks
         private Dictionary<string, HashSet<string>> compileFilesToSkip = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase);
         private Dictionary<string, HashSet<string>> runtimeFilesToSkip = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase);
 
-        private Dictionary<PackageIdentity, StringBuilder>  GetFilteredPackages()
+        private Dictionary<PackageIdentity, StringBuilder> GetFilteredPackages()
         {
             Dictionary<PackageIdentity, StringBuilder> filteredPackages = null;
 
@@ -214,7 +214,10 @@ namespace Microsoft.NET.Build.Tasks
                                               TrimAssetGroups(runtimeLibrary.NativeLibraryGroups, filesToSkip).ToArray(),
                                               TrimResourceAssemblies(runtimeLibrary.ResourceAssemblies, filesToSkip),
                                               runtimeLibrary.Dependencies,
-                                              runtimeLibrary.Serviceable);
+                                              runtimeLibrary.Serviceable,
+                                              runtimeLibrary.Path,
+                                              runtimeLibrary.HashPath,
+                                              runtimeLibrary.RuntimeStoreManifestName);
                 }
                 else
                 {
@@ -255,7 +258,9 @@ namespace Microsoft.NET.Build.Tasks
                                               compileLibrary.Hash,
                                               TrimAssemblies(compileLibrary.Assemblies, filesToSkip),
                                               compileLibrary.Dependencies,
-                                              compileLibrary.Serviceable);
+                                              compileLibrary.Serviceable,
+                                              compileLibrary.Path,
+                                              compileLibrary.HashPath);
                 }
                 else
                 {

--- a/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAHelloWorldProject.cs
+++ b/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAHelloWorldProject.cs
@@ -275,7 +275,9 @@ public static class Program
             dependencyContext.Should()
                 .HaveNoDuplicateRuntimeAssemblies(rid ?? "")
                 .And
-                .HaveNoDuplicateNativeAssets(rid ?? "");
+                .HaveNoDuplicateNativeAssets(rid ?? "")
+                .And
+                .OnlyHavePackagesWithPathProperties();
 
             ICommand runCommand;
 

--- a/test/Microsoft.NET.TestFramework/Assertions/DependencyContextAssertions.cs
+++ b/test/Microsoft.NET.TestFramework/Assertions/DependencyContextAssertions.cs
@@ -83,5 +83,20 @@ namespace Microsoft.NET.TestFramework.Assertions
 
             return new AndConstraint<DependencyContextAssertions>(this);
         }
+
+        public AndConstraint<DependencyContextAssertions> OnlyHavePackagesWithPathProperties()
+        {
+            var packageLibraries = _dependencyContext.RuntimeLibraries
+                .Union<Library>(_dependencyContext.CompileLibraries)
+                .Where(l => string.Equals(l.Type, "package", StringComparison.OrdinalIgnoreCase));
+
+            foreach (var packageLibrary in packageLibraries)
+            {
+                packageLibrary.Path.Should().NotBeNullOrEmpty($"Every Library with Type='package' should have a Path, but {packageLibrary.Name} does not.");
+                packageLibrary.HashPath.Should().NotBeNullOrEmpty($"Every Library with Type='package' should have a HashPath, but {packageLibrary.Name} does not.");
+            }
+
+            return new AndConstraint<DependencyContextAssertions>(this);
+        }
     }
 }


### PR DESCRIPTION
When we are trimming runtime and compilation libraries in the .deps.json file, we are losing information such as "Path".  This ensures this information is not lost.

Fix #1130 

@livarcocc @dsplaisted @nguerrera 

/cc @mikeharder 