### PR TITLE
Rename 'packages' folder to 'store'

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.ComposeStore.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.ComposeStore.targets
@@ -204,7 +204,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <PropertyGroup>
       <DefaultComposeDir>$(HOME)</DefaultComposeDir>
       <DefaultComposeDir Condition="'$(OS)' == 'Windows_NT'">$(USERPROFILE)</DefaultComposeDir>
-      <DefaultComposeDir>$([System.IO.Path]::Combine($(DefaultComposeDir), '.dotnet', $(PlatformTarget), 'packages'))</DefaultComposeDir>
+      <DefaultComposeDir>$([System.IO.Path]::Combine($(DefaultComposeDir), '.dotnet', $(PlatformTarget), 'store'))</DefaultComposeDir>
       <ComposeDir Condition="'$(ComposeDir)' != '' and '$(DoNotDecorateComposeDir)' != 'true'">$([System.IO.Path]::Combine($(ComposeDir), $(PlatformTarget)))</ComposeDir>
       <ComposeDir Condition="'$(ComposeDir)' == ''">$(DefaultComposeDir)</ComposeDir>
       <ComposeDir Condition="'$(DoNotDecorateComposeDir)' != 'true'">$([System.IO.Path]::Combine($(ComposeDir), $(_TFM)))</ComposeDir>


### PR DESCRIPTION
This is a follow up to https://github.com/dotnet/core-setup/pull/2017, which renamed the folder where the host finds the runtime store directory from 'packages' to 'store'.  The ComposeStore command should be writing to this new location by default.

@ramarag 

@livarcocc and @MattGertz for approval.  This is necessary for our `dotnet store` command to work correctly out of the box.