### PR TITLE
[Won't pass CI] Updating the implicit package versions to 1.0.5 and 1.1.1.

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.DefaultItems.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.DefaultItems.targets
@@ -83,8 +83,8 @@ Copyright (c) .NET Foundation. All rights reserved.
       the exact version of the runtime to use with the RuntimeFrameworkVersion property.    
     -->
     <!-- If targeting netcoreapp1.1, and RuntimeFrameworkVersion is not specified, use version 1.1.1 -->
-    <RuntimeFrameworkVersion Condition="'$(RuntimeFrameworkVersion)' == '' And '$(_TargetFrameworkVersionWithoutV)' == '1.0'">1.0.4</RuntimeFrameworkVersion>
-    <RuntimeFrameworkVersion Condition="'$(RuntimeFrameworkVersion)' == '' And '$(_TargetFrameworkVersionWithoutV)' == '1.1'">1.1.1</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion Condition="'$(RuntimeFrameworkVersion)' == '' And '$(_TargetFrameworkVersionWithoutV)' == '1.0'">1.0.5</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion Condition="'$(RuntimeFrameworkVersion)' == '' And '$(_TargetFrameworkVersionWithoutV)' == '1.1'">1.1.2</RuntimeFrameworkVersion>
     
     <!-- Default to use the version of the framework runtime matching the target framework version-->
     <RuntimeFrameworkVersion Condition="'$(RuntimeFrameworkVersion)' == ''">$(_TargetFrameworkVersionWithoutV)</RuntimeFrameworkVersion>

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildANetCoreApp.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildANetCoreApp.cs
@@ -22,10 +22,10 @@ namespace Microsoft.NET.Build.Tests
     {
         [Theory]
         //  TargetFramework, RuntimeFrameworkVersion, ExpectedPackageVersion, ExpectedRuntimeFrameworkVersion
-        [InlineData("netcoreapp1.0", null, "1.0.4", "1.0.4")]
+        [InlineData("netcoreapp1.0", null, "1.0.5", "1.0.5")]
         [InlineData("netcoreapp1.0", "1.0.0", "1.0.0", "1.0.0")]
         [InlineData("netcoreapp1.0", "1.0.3", "1.0.3", "1.0.3")]
-        [InlineData("netcoreapp1.1", null, "1.1.1", "1.1.1")]
+        [InlineData("netcoreapp1.1", null, "1.1.2", "1.1.2")]
         [InlineData("netcoreapp1.1", "1.1.0", "1.1.0", "1.1.0")]
         [InlineData("netcoreapp1.1.1", null, "1.1.1", "1.1.1")]
         public void It_targets_the_right_shared_framework(string targetFramework, string runtimeFrameworkVersion,

--- a/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAProjectWithAllFeatures.cs
+++ b/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAProjectWithAllFeatures.cs
@@ -93,7 +93,7 @@ namespace Microsoft.NET.Publish.Tests
     }
 }");
             baselineConfigJsonObject["runtimeOptions"]["framework"]["version"] = 
-                targetFramework == "netcoreapp1.0" ? "1.0.4" : "1.1.1";
+                targetFramework == "netcoreapp1.0" ? "1.0.5" : "1.1.2";
 
             runtimeConfigJsonObject
                 .Should()


### PR DESCRIPTION
@dsplaisted @eerhardt @weshaggard

This will fail CI, we will have to merge it like that. I have run tests on OSX and Windows.