### PR TITLE
Fix for project sstem issue 2069, to specify correct metadata for package for different targets…

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenThatWeWantToGetDependenciesViaDesignTimeBuild.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenThatWeWantToGetDependenciesViaDesignTimeBuild.cs
@@ -981,6 +981,119 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             VerifyTargetTaskItem(DependencyType.AnalyzerAssembly, mockChildAnalyzerAssembly, resultChildAnalyzerAssembly[0]);
         }
 
+        [Fact]
+        public void ItShouldReturnCorrectPackagesForCorrespondingTarget()
+        {
+            // Arrange 
+            // target definitions 
+            var mockTarget = new MockTaskItem(
+                itemSpec: ".Net Framework,Version=v4.5",
+                metadata: new Dictionary<string, string>
+                {
+                    { MetadataKeys.RuntimeIdentifier, "net45" },
+                    { MetadataKeys.TargetFrameworkMoniker, ".Net Framework,Version=v4.5" },
+                    { MetadataKeys.FrameworkName, ".Net Framework" },
+                    { MetadataKeys.FrameworkVersion, "4.5" },
+                    { MetadataKeys.Type, "Target" }
+                });
+
+            var mockTarget2 = new MockTaskItem(
+                itemSpec: ".Net Framework,Version=v4.6",
+                metadata: new Dictionary<string, string>
+                {
+                    { MetadataKeys.RuntimeIdentifier, "net46" },
+                    { MetadataKeys.TargetFrameworkMoniker, ".Net Framework,Version=v4.6" },
+                    { MetadataKeys.FrameworkName, ".Net Framework" },
+                    { MetadataKeys.FrameworkVersion, "4.6" },
+                    { MetadataKeys.Type, "Target" }
+                });
+
+            // package definitions
+            var mockPackage1 = new MockTaskItem(
+                itemSpec: "Package1/1.0.0",
+                metadata: new Dictionary<string, string>
+                {
+                    { MetadataKeys.Name, "Package1" },
+                    { MetadataKeys.Version, "1.0.0" },
+                    { MetadataKeys.Path, "some path" },
+                    { MetadataKeys.ResolvedPath, "" },
+                    { MetadataKeys.Type, "Package" },
+                    { PreprocessPackageDependenciesDesignTime.ResolvedMetadata, "True" }
+                });
+
+            var mockChildPackage1 = new MockTaskItem(
+                itemSpec: "ChildPackage1/1.0.0",
+                metadata: new Dictionary<string, string>
+                {
+                    { MetadataKeys.Name, "ChildPackage1" },
+                    { MetadataKeys.Version, "1.0.0" },
+                    { MetadataKeys.Path, "some path" },
+                    { MetadataKeys.ResolvedPath, "some resolved path" },
+                    { MetadataKeys.Type, "Package" },
+                    { PreprocessPackageDependenciesDesignTime.ResolvedMetadata, "True" },
+                    { MetadataKeys.IsTopLevelDependency, "False" }
+                });
+
+            // package dependencies
+            var mockPackageDep1 = new MockTaskItem(
+                itemSpec: "Package1/1.0.0",
+                metadata: new Dictionary<string, string>
+                {
+                    { MetadataKeys.ParentTarget, ".Net Framework,Version=v4.5" }
+                });
+
+            var mockChildPackageDep1 = new MockTaskItem(
+                itemSpec: "ChildPackage1/1.0.0",
+                metadata: new Dictionary<string, string>
+                {
+                    { MetadataKeys.ParentTarget, ".Net Framework,Version=v4.5" },
+                    { MetadataKeys.ParentPackage, "Package1/1.0.0" }
+                });
+
+            var mockPackageDep2 = new MockTaskItem(
+                itemSpec: "Package1/1.0.0",
+                metadata: new Dictionary<string, string>
+                {
+                    { MetadataKeys.ParentTarget, ".Net Framework,Version=v4.6" }
+                });
+
+
+            var task = new PreprocessPackageDependenciesDesignTime();
+            task.TargetDefinitions = new[] { mockTarget, mockTarget2 };
+            task.PackageDefinitions = new ITaskItem[] { mockPackage1, mockChildPackage1 };
+            task.FileDefinitions = new ITaskItem[] { };
+            task.PackageDependencies = new ITaskItem[] { mockPackageDep1, mockPackageDep2, mockChildPackageDep1 };
+            task.FileDependencies = new ITaskItem[] { };
+            task.DefaultImplicitPackages = string.Empty;
+
+            // Act
+            var result = task.Execute();
+
+            // Assert
+            result.Should().BeTrue();
+            task.DependenciesDesignTime.Count().Should().Be(5);
+
+            var resultTargets = task.DependenciesDesignTime
+                                    .Where(x => x.ItemSpec.Equals(".Net Framework,Version=v4.5")).ToArray();
+            resultTargets.Length.Should().Be(1);
+
+            resultTargets = task.DependenciesDesignTime
+                                .Where(x => x.ItemSpec.Equals(".Net Framework,Version=v4.6")).ToArray();
+            resultTargets.Length.Should().Be(1);
+
+            var resultPackage1 = task.DependenciesDesignTime
+                .Where(x => x.ItemSpec.Equals(".Net Framework,Version=v4.5/Package1/1.0.0")).ToArray();
+            resultPackage1.Length.Should().Be(1);
+            resultPackage1[0].GetMetadata(PreprocessPackageDependenciesDesignTime.DependenciesMetadata)
+                             .Should().Be("ChildPackage1/1.0.0");
+
+            resultPackage1 = task.DependenciesDesignTime
+                .Where(x => x.ItemSpec.Equals(".Net Framework,Version=v4.6/Package1/1.0.0")).ToArray();
+            resultPackage1.Length.Should().Be(1);
+            resultPackage1[0].GetMetadata(PreprocessPackageDependenciesDesignTime.DependenciesMetadata)
+                             .Should().Be("");
+        }
+
         private void VerifyTargetTaskItem(DependencyType type, ITaskItem input, ITaskItem output)
         {
             type.ToString().Should().Be(output.GetMetadata(MetadataKeys.Type));

--- a/src/Tasks/Microsoft.NET.Build.Tasks/PreprocessPackageDependenciesDesignTime.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/PreprocessPackageDependenciesDesignTime.cs
@@ -236,7 +236,7 @@ namespace Microsoft.NET.Build.Tasks
 
                 var currentPackageUniqueId = $"{parentTargetId}/{currentItemId}";
                 // add current package to dependencies world
-                var currentItem = items[currentItemId].Clone();
+                var currentItem = GetItem(items, currentItemId);
                 DependenciesWorld[currentPackageUniqueId] = currentItem;
 
                 // update parent
@@ -255,11 +255,11 @@ namespace Microsoft.NET.Build.Tasks
                     // Update parent's Dependencies count and make sure parent is in the dependencies world
                     if (!string.IsNullOrEmpty(parentPackageId))
                     {
-                        parentDependency = Packages[parentPackageId].Clone();
+                        parentDependency = GetItem(Packages, parentPackageId);
                     }
                     else
                     {
-                        parentDependency = Targets[parentTargetId].Clone();
+                        parentDependency = GetItem(Targets, parentTargetId);
                         currentItem.IsTopLevelDependency = true;
                     }
 
@@ -267,6 +267,11 @@ namespace Microsoft.NET.Build.Tasks
                     DependenciesWorld[parentDependencyId] = parentDependency;
                 }
             }
+        }
+
+        private ItemMetadata GetItem(Dictionary<string, ItemMetadata> items, string id)
+        {
+            return Targets.Count > 1 ? items[id].Clone() : items[id];
         }
 
         private abstract class ItemMetadata

--- a/src/Tasks/Microsoft.NET.Build.Tasks/PreprocessPackageDependenciesDesignTime.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/PreprocessPackageDependenciesDesignTime.cs
@@ -236,7 +236,7 @@ namespace Microsoft.NET.Build.Tasks
 
                 var currentPackageUniqueId = $"{parentTargetId}/{currentItemId}";
                 // add current package to dependencies world
-                var currentItem = items[currentItemId];
+                var currentItem = items[currentItemId].Clone();
                 DependenciesWorld[currentPackageUniqueId] = currentItem;
 
                 // update parent
@@ -255,11 +255,11 @@ namespace Microsoft.NET.Build.Tasks
                     // Update parent's Dependencies count and make sure parent is in the dependencies world
                     if (!string.IsNullOrEmpty(parentPackageId))
                     {
-                        parentDependency = Packages[parentPackageId];
+                        parentDependency = Packages[parentPackageId].Clone();
                     }
                     else
                     {
-                        parentDependency = Targets[parentTargetId];
+                        parentDependency = Targets[parentTargetId].Clone();
                         currentItem.IsTopLevelDependency = true;
                     }
 
@@ -271,10 +271,11 @@ namespace Microsoft.NET.Build.Tasks
 
         private abstract class ItemMetadata
         {
-            public ItemMetadata(DependencyType type)
+            public ItemMetadata(DependencyType type, IList<string> dependencies = null, bool isTopLevelDependency = false)
             {
                 Type = type;
-                Dependencies = new List<string>();
+                Dependencies = dependencies == null ? new List<string>() : new List<string>(dependencies);
+                IsTopLevelDependency = isTopLevelDependency;
             }
 
             public DependencyType Type { get; protected set; }
@@ -291,6 +292,11 @@ namespace Microsoft.NET.Build.Tasks
             /// </summary>
             /// <returns></returns>
             public abstract IDictionary<string, string> ToDictionary();
+
+            /// <summary>
+            /// Creates a copy of the item
+            /// </summary>
+            public abstract ItemMetadata Clone();
         }
 
         private class TargetMetadata : ItemMetadata
@@ -302,6 +308,22 @@ namespace Microsoft.NET.Build.Tasks
                 TargetFrameworkMoniker = item.GetMetadata(MetadataKeys.TargetFrameworkMoniker) ?? string.Empty;
                 FrameworkName = item.GetMetadata(MetadataKeys.FrameworkName) ?? string.Empty;
                 FrameworkVersion = item.GetMetadata(MetadataKeys.FrameworkVersion) ?? string.Empty;
+            }
+
+            private TargetMetadata(
+                DependencyType type, 
+                IList<string> dependencies, 
+                bool isTopLevelDependency,
+                string runtimeIdentifier,
+                string targetFrameworkMoniker,
+                string frameworkName,
+                string frameworkVersion)
+                : base(type, dependencies, isTopLevelDependency)
+            {
+                RuntimeIdentifier = runtimeIdentifier;
+                TargetFrameworkMoniker = targetFrameworkMoniker;
+                FrameworkName = frameworkName;
+                FrameworkVersion = frameworkVersion;
             }
 
             public string RuntimeIdentifier { get; }
@@ -321,6 +343,18 @@ namespace Microsoft.NET.Build.Tasks
                     { DependenciesMetadata, string.Join(";", Dependencies) }
                 };
             }
+
+            public override ItemMetadata Clone()
+            {
+                return new TargetMetadata(
+                    Type, 
+                    Dependencies, 
+                    IsTopLevelDependency, 
+                    RuntimeIdentifier, 
+                    TargetFrameworkMoniker, 
+                    FrameworkName, 
+                    FrameworkVersion);
+            }
         }
 
         private class PackageMetadata : ItemMetadata
@@ -334,6 +368,24 @@ namespace Microsoft.NET.Build.Tasks
                 Path = (Resolved
                         ? item.GetMetadata(MetadataKeys.ResolvedPath)
                         : item.GetMetadata(MetadataKeys.Path)) ?? string.Empty;
+            }
+
+            private PackageMetadata(
+                DependencyType type,
+                IList<string> dependencies,
+                bool isTopLevelDependency,
+                string name,
+                string version,
+                string path,
+                bool resolved,
+                bool isImplicitlyDefined)
+                : base(type, dependencies, isTopLevelDependency)
+            {
+                Name = name;
+                Version = version;
+                Path = path;
+                Resolved = resolved;
+                IsImplicitlyDefined = isImplicitlyDefined;
             }
 
             public string Name { get; protected set; }
@@ -355,6 +407,19 @@ namespace Microsoft.NET.Build.Tasks
                     { ResolvedMetadata, Resolved.ToString() },
                     { DependenciesMetadata, string.Join(";", Dependencies) }
                 };
+            }
+
+            public override ItemMetadata Clone()
+            {
+                return new PackageMetadata(
+                    Type,
+                    Dependencies,
+                    IsTopLevelDependency,
+                    Name,
+                    Version,
+                    Path,
+                    Resolved,
+                    IsImplicitlyDefined);
             }
         }
 
@@ -385,6 +450,30 @@ namespace Microsoft.NET.Build.Tasks
                 EndColumn = item.GetMetadata(MetadataKeys.EndColumn) ?? string.Empty;
             }
 
+            private DiagnosticMetadata(
+                DependencyType type,
+                IList<string> dependencies,
+                bool isTopLevelDependency,
+                string diagnosticCode,
+                string message,
+                string filePath,
+                string severity,
+                string startLine,
+                string startColumn,
+                string endLine,
+                string endColumn)                
+                : base(type, dependencies, isTopLevelDependency)
+            {
+                DiagnosticCode = diagnosticCode;
+                Message = message;
+                FilePath = filePath;
+                Severity = severity;
+                StartLine = startLine;
+                StartColumn = startColumn;
+                EndLine = endLine;
+                EndColumn = endColumn;
+            }
+
             public string DiagnosticCode { get; }
             public string Message { get; }
             public string FilePath { get; }
@@ -410,6 +499,22 @@ namespace Microsoft.NET.Build.Tasks
                     { MetadataKeys.Type, Type.ToString() },
                     { DependenciesMetadata, string.Join(";", Dependencies) }
                 };
+            }
+
+            public override ItemMetadata Clone()
+            {
+                return new DiagnosticMetadata(
+                    Type,
+                    Dependencies,
+                    IsTopLevelDependency,
+                    DiagnosticCode,
+                    Message,
+                    FilePath,
+                    Severity,
+                    StartLine,
+                    StartColumn,
+                    EndLine,
+                    EndColumn);
             }
         }
 


### PR DESCRIPTION
We reused item object for packages across targets instead of cloning them and it caused all package items for all targets to have dependencyIDs property updated.

Fix for https://github.com/dotnet/project-system/issues/2069