### PR TITLE
Add a list of supported TFMs that can be used by hosts to display.

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/Microsoft.NET.Build.Tasks.csproj
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Microsoft.NET.Build.Tasks.csproj
@@ -159,6 +159,9 @@
     <None Include="build\Microsoft.NET.CrossGen.targets">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="build\Microsoft.NET.SupportedTargetFrameworks.props">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="build\Microsoft.NET.TargetFrameworkInference.targets">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.props
@@ -107,6 +107,9 @@ Copyright (c) .NET Foundation. All rights reserved.
   <!-- Default item includes (globs and implicit references) -->
   <Import Project="Microsoft.NET.Sdk.DefaultItems.props" />
   
+  <!-- List of supported .NET Core and .NET Standard TFMs -->
+  <Import Project="Microsoft.NET.SupportedTargetFrameworks.props" />
+  
   <!-- Temporary workarounds -->
   <PropertyGroup>
     <!-- Workaround: https://github.com/dotnet/roslyn/issues/12167 -->

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.SupportedTargetFrameworks.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.SupportedTargetFrameworks.props
@@ -13,6 +13,10 @@ Copyright (c) .NET Foundation. All rights reserved.
 <!-- This file contains a list of the TFMs that are supported by this SDK for .NET Core and .NET Standard.
      This is used by VS to show the list of frameworks to which projects can be retargeted. -->
 <Project>
+    <PropertyGroup>
+        <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+    </PropertyGroup>
+
     <!-- .NET Core -->
     <ItemGroup>
         <SupportedTargetFramework Include=".NETCoreApp,Version=v1.0" DisplayName=".NET Core 1.0" />

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.SupportedTargetFrameworks.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.SupportedTargetFrameworks.props
@@ -1,0 +1,34 @@
+<!--
+***********************************************************************************************
+Microsoft.NET.SupportedTargetFrameworks.targets
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+          created a backup copy.  Incorrect changes to this file will make it
+          impossible to load or build your projects from the command-line or the IDE.
+
+Copyright (c) .NET Foundation. All rights reserved. 
+***********************************************************************************************
+-->
+
+<!-- This file contains a list of the TFMs that are supported by this SDK for .NET Core and .NET Standard.
+     This is used by VS to show the list of frameworks to which projects can be retargeted. -->
+<Project>
+    <!-- .NET Core -->
+    <ItemGroup>
+        <SupportedTargetFramework Include=".NETCoreApp,Version=v1.0" DisplayName=".NET Core 1.0" />
+        <SupportedTargetFramework Include=".NETCoreApp,Version=v1.1" DisplayName=".NET Core 1.1" />
+        <SupportedTargetFramework Include=".NETCoreApp,Version=v2.0" DisplayName=".NET Core 2.0" />
+    </ItemGroup>
+
+    <!-- .NET Standard -->
+    <ItemGroup>
+        <SupportedTargetFramework Include=".NETStandard,Version=v1.0" DisplayName=".NET Standard 1.0" />
+        <SupportedTargetFramework Include=".NETStandard,Version=v1.1" DisplayName=".NET Standard 1.1" />
+        <SupportedTargetFramework Include=".NETStandard,Version=v1.2" DisplayName=".NET Standard 1.2" />
+        <SupportedTargetFramework Include=".NETStandard,Version=v1.3" DisplayName=".NET Standard 1.3" />
+        <SupportedTargetFramework Include=".NETStandard,Version=v1.4" DisplayName=".NET Standard 1.4" />
+        <SupportedTargetFramework Include=".NETStandard,Version=v1.5" DisplayName=".NET Standard 1.5" />
+        <SupportedTargetFramework Include=".NETStandard,Version=v1.6" DisplayName=".NET Standard 1.6" />
+        <SupportedTargetFramework Include=".NETStandard,Version=v2.0" DisplayName=".NET Standard 2.0" />
+    </ItemGroup>
+</Project>


### PR DESCRIPTION
This will be used by VS to show the list of Targetframworks in the application page. This make it so that new SDKs can easily add new targets without having to update VS.

@panopticoncentral @nguerrera @dsplaisted @livarcocc @dotnet/project-system 