### PR TITLE
remove Compile items from None, if EnableDefaultCompileItems is false

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.DefaultItems.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.DefaultItems.targets
@@ -22,6 +22,10 @@ Copyright (c) .NET Foundation. All rights reserved.
     <EnableDefaultNoneItems Condition=" '$(EnableDefaultNoneItems)' == '' ">true</EnableDefaultNoneItems>
   </PropertyGroup>
 
+  <ItemGroup>
+    <None Remove="@(Compile)" Condition=" '$(EnableDefaultCompileItems)' != 'true' And '$(EnableDefaultNoneItems)' == 'true' " />
+  </ItemGroup>
+
   <PropertyGroup>    
     <!-- Set DefaultItemExcludes property for items that should be excluded from the default Compile, etc items.
          This is in the .targets because it needs to come after the final BaseOutputPath has been evaluated. -->


### PR DESCRIPTION
When wilcard include of None items is enabled ( `EnableDefaultNoneItems` ), all files are added
to `None` items.
if `EnableDefaultCompileItems` is disabled, the `Compile` items are not removed from
the `None` items, because these `Compile` are defined later in the project file.

So we need to remove the `Compile` items after are defined (so in the .targets file)

ref and more info in https://github.com/dotnet/netcorecli-fsc/issues/94
