### PR TITLE
[2.0] Import nuget pack targets via relative path.

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/sdk/Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/sdk/Sdk.targets
@@ -46,8 +46,8 @@ Copyright (c) .NET Foundation. All rights reserved.
   
   <!-- Import targets from NuGet.Build.Tasks.Pack package/Sdk -->
   <PropertyGroup>
-    <NuGetBuildTasksPackTargets Condition="'$(NuGetBuildTasksPackTargets)' == '' And '$(IsCrossTargetingBuild)' == 'true'">$(MSBuildSDKsPath)\NuGet.Build.Tasks.Pack\buildCrossTargeting\NuGet.Build.Tasks.Pack.targets</NuGetBuildTasksPackTargets>
-    <NuGetBuildTasksPackTargets Condition="'$(NuGetBuildTasksPackTargets)' == '' And '$(IsCrossTargetingBuild)' != 'true'">$(MSBuildSDKsPath)\NuGet.Build.Tasks.Pack\build\NuGet.Build.Tasks.Pack.targets</NuGetBuildTasksPackTargets>
+    <NuGetBuildTasksPackTargets Condition="'$(NuGetBuildTasksPackTargets)' == '' And '$(IsCrossTargetingBuild)' == 'true'">$(MSBuildThisFileDirectory)..\..\NuGet.Build.Tasks.Pack\buildCrossTargeting\NuGet.Build.Tasks.Pack.targets</NuGetBuildTasksPackTargets>
+    <NuGetBuildTasksPackTargets Condition="'$(NuGetBuildTasksPackTargets)' == '' And '$(IsCrossTargetingBuild)' != 'true'">$(MSBuildThisFileDirectory)..\..\NuGet.Build.Tasks.Pack\build\NuGet.Build.Tasks.Pack.targets</NuGetBuildTasksPackTargets>
   </PropertyGroup>
   
   <Import Project="$(NuGetBuildTasksPackTargets)"


### PR DESCRIPTION
Note that we cannot use `<Import Sdk="...">` because NuGet.Build.Tasks.Pack does not have an Sdk folder.

@livarcocc @dsplaisted 