### PR TITLE
Don't include implicit package references as dependencies in package when project is packed in most cases

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -10,7 +10,9 @@ param(
     [switch]$SkipTests,
     [switch]$FullMSBuild,
     [switch]$RealSign,
-    [switch]$Help)
+    [switch]$Help,
+    [Parameter(Position=0, ValueFromRemainingArguments=$true)]
+    $ExtraParameters)
 
 if($Help)
 {
@@ -100,8 +102,9 @@ $commonBuildArgs = echo $RepoRoot\build\build.proj /m:1 /nologo /p:Configuration
 $msbuildSummaryLog = Join-Path -path $logPath -childPath "sdk.log"
 $msbuildWarningLog = Join-Path -path $logPath -childPath "sdk.wrn"
 $msbuildFailureLog = Join-Path -path $logPath -childPath "sdk.err"
+$msbuildBinLog = Join-Path -path $logPath -childPath "sdk.binlog"
 
-dotnet msbuild /t:$buildTarget $commonBuildArgs /flp1:Summary`;Verbosity=diagnostic`;Encoding=UTF-8`;LogFile=$msbuildSummaryLog /flp2:WarningsOnly`;Verbosity=diagnostic`;Encoding=UTF-8`;LogFile=$msbuildWarningLog /flp3:ErrorsOnly`;Verbosity=diagnostic`;Encoding=UTF-8`;LogFile=$msbuildFailureLog
+dotnet msbuild /t:$buildTarget $commonBuildArgs /flp1:Summary`;Verbosity=diagnostic`;Encoding=UTF-8`;LogFile=$msbuildSummaryLog /flp2:WarningsOnly`;Verbosity=diagnostic`;Encoding=UTF-8`;LogFile=$msbuildWarningLog /flp3:ErrorsOnly`;Verbosity=diagnostic`;Encoding=UTF-8`;LogFile=$msbuildFailureLog /bl:$msbuildBinLog $ExtraParameters
 if($LASTEXITCODE -ne 0) { throw "Failed to build" }
 
 msbuild  /t:$buildTarget $commonBuildArgs /nr:false /p:BuildTemplates=true /flp1:Summary`;Verbosity=diagnostic`;Encoding=UTF-8`;LogFile=$msbuildSummaryLog /flp2:WarningsOnly`;Verbosity=diagnostic`;Encoding=UTF-8`;LogFile=$msbuildWarningLog /flp3:ErrorsOnly`;Verbosity=diagnostic`;Encoding=UTF-8`;LogFile=$msbuildFailureLog

--- a/build.ps1
+++ b/build.ps1
@@ -26,6 +26,8 @@ if($Help)
     Write-Host "  -FullMSBuild                       Run tests with the full .NET Framework version of MSBuild instead of the .NET Core version"
     Write-Host "  -RealSign                          Sign the output DLLs"
     Write-Host "  -Help                              Display this help message"
+    Write-Host ""
+    Write-Host "Any additional parameters will be passed through to the main invocation of MSBuild"
     exit 0
 }
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAProjectContext.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAProjectContext.cs
@@ -15,7 +15,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
     public class GivenAProjectContext
     {
         [Fact]
-        public void ItComputesPrivateAssetsExclusionList()
+        public void ItComputesExcludeFromPublishList()
         {
             LockFile lockFile = TestLockFiles.GetLockFile("dependencies.withgraphs");
             ProjectContext projectContext = lockFile.CreateProjectContext(
@@ -24,7 +24,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                Constants.DefaultPlatformLibrary,
                isSelfContained: false);
 
-            IEnumerable<string> privateAssetPackageIds = new[] { "Microsoft.Extensions.Logging.Abstractions" };
+            IEnumerable<string> excludeFromPublishPackageIds = new[] { "Microsoft.Extensions.Logging.Abstractions" };
             IDictionary<string, LockFileTargetLibrary> libraryLookup =
                 projectContext
                     .LockFileTarget
@@ -32,7 +32,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                     .ToDictionary(e => e.Name, StringComparer.OrdinalIgnoreCase);
 
             HashSet<string> exclusionList =
-                projectContext.GetPrivateAssetsExclusionList(privateAssetPackageIds, libraryLookup);
+                projectContext.GetExcludeFromPublishList(excludeFromPublishPackageIds, libraryLookup);
             
             HashSet<string> expectedExclusions = new HashSet<string>()
             {

--- a/src/Tasks/Microsoft.NET.Build.Tasks/DependencyContextBuilder.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/DependencyContextBuilder.cs
@@ -23,7 +23,7 @@ namespace Microsoft.NET.Build.Tasks
         private IEnumerable<ReferenceInfo> _frameworkReferences;
         private IEnumerable<ReferenceInfo> _directReferences;
         private Dictionary<string, SingleProjectInfo> _referenceProjectInfos;
-        private IEnumerable<string> _privateAssetPackageIds;
+        private IEnumerable<string> _excludeFromPublishPackageIds;
         private CompilationOptions _compilationOptions;
         private string _referenceAssembliesPath;
         private Dictionary<PackageIdentity, StringBuilder> _filteredPackages;
@@ -64,9 +64,9 @@ namespace Microsoft.NET.Build.Tasks
             return this;
         }
 
-        public DependencyContextBuilder WithPrivateAssets(IEnumerable<string> privateAssetPackageIds)
+        public DependencyContextBuilder WithExcludeFromPublishAssets(IEnumerable<string> excludeFromPublishPackageIds)
         {
-            _privateAssetPackageIds = privateAssetPackageIds;
+            _excludeFromPublishPackageIds = excludeFromPublishPackageIds;
             return this;
         }
 
@@ -92,10 +92,10 @@ namespace Microsoft.NET.Build.Tasks
         {
             bool includeCompilationLibraries = _compilationOptions != null;
 
-            IEnumerable<LockFileTargetLibrary> runtimeExports = _projectContext.GetRuntimeLibraries(_privateAssetPackageIds);
+            IEnumerable<LockFileTargetLibrary> runtimeExports = _projectContext.GetRuntimeLibraries(_excludeFromPublishPackageIds);
             IEnumerable<LockFileTargetLibrary> compilationExports =
                 includeCompilationLibraries ?
-                    _projectContext.GetCompileLibraries(_privateAssetPackageIds) :
+                    _projectContext.GetCompileLibraries(_excludeFromPublishPackageIds) :
                     Enumerable.Empty<LockFileTargetLibrary>();
 
             var dependencyLookup = compilationExports

--- a/src/Tasks/Microsoft.NET.Build.Tasks/GenerateDepsFile.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/GenerateDepsFile.cs
@@ -63,7 +63,7 @@ namespace Microsoft.NET.Build.Tasks
 
         public ITaskItem CompilerOptions { get; set; }
 
-        public ITaskItem[] PrivateAssetsPackageReferences { get; set; }
+        public ITaskItem[] ExcludeFromPublishPackageReferences { get; set; }
 
         public string[] TargetManifestFileList { get; set; }
 
@@ -136,7 +136,7 @@ namespace Microsoft.NET.Build.Tasks
                 ReferencePaths,
                 ReferenceSatellitePaths);
 
-            IEnumerable<string> privateAssets = PackageReferenceConverter.GetPackageIds(PrivateAssetsPackageReferences);
+            IEnumerable<string> excludeFromPublishAssets = PackageReferenceConverter.GetPackageIds(ExcludeFromPublishPackageReferences);
 
             ProjectContext projectContext = lockFile.CreateProjectContext(
                 NuGetUtils.ParseFrameworkName(TargetFramework),
@@ -149,7 +149,7 @@ namespace Microsoft.NET.Build.Tasks
                 .WithFrameworkReferences(frameworkReferences)
                 .WithDirectReferences(directReferences)
                 .WithReferenceProjectInfos(referenceProjects)
-                .WithPrivateAssets(privateAssets)
+                .WithExcludeFromPublishAssets(excludeFromPublishAssets)
                 .WithCompilationOptions(compilationOptions)
                 .WithReferenceAssembliesPath(FrameworkReferenceResolver.GetDefaultReferenceAssembliesPath())
                 .WithPackagesThatWhereFiltered(GetFilteredPackages())

--- a/src/Tasks/Microsoft.NET.Build.Tasks/PublishAssembliesResolver.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/PublishAssembliesResolver.cs
@@ -14,7 +14,7 @@ namespace Microsoft.NET.Build.Tasks
     {
         private  HashSet<PackageIdentity> _allResolvedPackages = new HashSet<PackageIdentity>();
         private readonly IPackageResolver _packageResolver;
-        private IEnumerable<string> _privateAssetPackageIds;
+        private IEnumerable<string> _excludeFromPublishPackageIds;
         private bool _preserveStoreLayout;
 
         public PublishAssembliesResolver(IPackageResolver packageResolver)
@@ -22,9 +22,9 @@ namespace Microsoft.NET.Build.Tasks
             _packageResolver = packageResolver;
         }
 
-        public PublishAssembliesResolver WithPrivateAssets(IEnumerable<string> privateAssetPackageIds)
+        public PublishAssembliesResolver WithExcludeFromPublish(IEnumerable<string> excludeFromPublishPackageIds)
         {
-            _privateAssetPackageIds = privateAssetPackageIds;
+            _excludeFromPublishPackageIds = excludeFromPublishPackageIds;
             return this;
         }
         public PublishAssembliesResolver WithPreserveStoreLayout(bool preserveStoreLayout)
@@ -36,7 +36,7 @@ namespace Microsoft.NET.Build.Tasks
         {
             List<ResolvedFile> results = new List<ResolvedFile>();
 
-            foreach (LockFileTargetLibrary targetLibrary in projectContext.GetRuntimeLibraries(_privateAssetPackageIds))
+            foreach (LockFileTargetLibrary targetLibrary in projectContext.GetRuntimeLibraries(_excludeFromPublishPackageIds))
             {
                 if (targetLibrary.Type != "package")
                 {

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePublishAssemblies.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePublishAssemblies.cs
@@ -31,7 +31,7 @@ namespace Microsoft.NET.Build.Tasks
 
         public string PlatformLibraryName { get; set; }
 
-        public ITaskItem[] PrivateAssetsPackageReferences { get; set; }
+        public ITaskItem[] ExcludeFromPublishPackageReferences { get; set; }
 
         public bool PreserveStoreLayout { get; set; }
 
@@ -59,7 +59,7 @@ namespace Microsoft.NET.Build.Tasks
         {
             var lockFileCache = new LockFileCache(BuildEngine4);
             LockFile lockFile = lockFileCache.GetLockFile(AssetsFilePath);
-            IEnumerable<string> privateAssetsPackageIds = PackageReferenceConverter.GetPackageIds(PrivateAssetsPackageReferences);
+            IEnumerable<string> excludeFromPublishPackageIds = PackageReferenceConverter.GetPackageIds(ExcludeFromPublishPackageReferences);
             IPackageResolver packageResolver = NuGetPackageResolver.CreateResolver(lockFile, ProjectPath);
             HashSet<PackageIdentity> packagestoBeFiltered = null;
 
@@ -89,7 +89,7 @@ namespace Microsoft.NET.Build.Tasks
 
             var assemblyResolver =
                 new PublishAssembliesResolver(packageResolver)
-                    .WithPrivateAssets(privateAssetsPackageIds)
+                    .WithExcludeFromPublish(excludeFromPublishPackageIds)
                     .WithPreserveStoreLayout(PreserveStoreLayout);
 
             IEnumerable<ResolvedFile> resolvedAssemblies = assemblyResolver.Resolve(projectContext);

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.CrossGen.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.CrossGen.targets
@@ -315,7 +315,7 @@ Restores netcoreapp and publishes it to a temp directory
                               TargetFramework="$(_TFM)"
                               RuntimeIdentifier="$(RuntimeIdentifier)"
                               PlatformLibraryName="$(MicrosoftNETPlatformLibrary)"
-                              PrivateAssetsPackageReferences="@(PrivateAssetsPackageReference)"
+                              ExcludeFromPublishPackageReferences="@(ExcludeFromPublishPackageReference)"
                               PreserveStoreLayout="false">
 
       <Output TaskParameter="AssembliesToPublish" ItemName="CrossgenResolvedAssembliesToPublish" />

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.CrossGen.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.CrossGen.targets
@@ -315,7 +315,7 @@ Restores netcoreapp and publishes it to a temp directory
                               TargetFramework="$(_TFM)"
                               RuntimeIdentifier="$(RuntimeIdentifier)"
                               PlatformLibraryName="$(MicrosoftNETPlatformLibrary)"
-                              ExcludeFromPublishPackageReferences="@(ExcludeFromPublishPackageReference)"
+                              ExcludeFromPublishPackageReferences="@(_ExcludeFromPublishPackageReference)"
                               PreserveStoreLayout="false">
 
       <Output TaskParameter="AssembliesToPublish" ItemName="CrossgenResolvedAssembliesToPublish" />

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Publish.targets
@@ -507,8 +507,14 @@ Copyright (c) .NET Foundation. All rights reserved.
           Condition="'$(ComputeExcludeFromPublishPackageReferences)' == 'true'">
 
     <ItemGroup>
+      
+      <!-- PrivateAssets="All" means exclude from publish, unless ExcludeFromPublish metadata is specified separately -->
+      <PackageReference Update="@(PackageReference)" 
+                        Publish="false"
+                        Condition="('%(PackageReference.PrivateAssets)' == 'All') And ('%(PackageReference.Publish)' == '')"/>
+      
       <ExcludeFromPublishPackageReference Include="@(PackageReference)"
-                                          Condition="(('%(PackageReference.PrivateAssets)' == 'All') And ('%(PackageReference.ExcludeFromPublish)' != 'false')) Or ('%(PackageReference.ExcludeFromPublish)' == 'true')" />
+                                          Condition="('%(PackageReference.Publish)' == 'false')" />
     </ItemGroup>
 
   </Target>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Publish.targets
@@ -247,14 +247,14 @@ Copyright (c) .NET Foundation. All rights reserved.
     -->
   <UsingTask TaskName="ResolvePublishAssemblies" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
   <Target Name="RunResolvePublishAssemblies"
-          DependsOnTargets="ComputePrivateAssetsPackageReferences;
+          DependsOnTargets="ComputeExcludeFromPublishPackageReferences;
                             _DefaultMicrosoftNETPlatformLibrary">
     <ResolvePublishAssemblies ProjectPath="$(MSBuildProjectFullPath)"
                               AssetsFilePath="$(ProjectAssetsFile)"
                               TargetFramework="$(TargetFrameworkMoniker)"
                               RuntimeIdentifier="$(RuntimeIdentifier)"
                               PlatformLibraryName="$(MicrosoftNETPlatformLibrary)"
-                              PrivateAssetsPackageReferences="@(PrivateAssetsPackageReference)"
+                              ExcludeFromPublishPackageReferences="@(ExcludeFromPublishPackageReference)"
                               TargetManifestFiles="@(TargetManifestFileList)"
                               PreserveStoreLayout="$(PreserveStoreLayout)"
                               IsSelfContained="$(SelfContained)" >
@@ -460,7 +460,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     ============================================================
     -->
   <Target Name="GeneratePublishDependencyFile"
-          DependsOnTargets="ComputePrivateAssetsPackageReferences;
+          DependsOnTargets="ComputeExcludeFromPublishPackageReferences;
                             _DefaultMicrosoftNETPlatformLibrary;
                             _HandlePackageFileConflicts;
                             _HandlePublishFileConflicts"
@@ -485,7 +485,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                       PlatformLibraryName="$(MicrosoftNETPlatformLibrary)"
                       FilesToSkip="@(_ConflictPackageFiles);@(_PublishConflictPackageFiles)"
                       CompilerOptions="@(DependencyFileCompilerOptions)"
-                      PrivateAssetsPackageReferences="@(PrivateAssetsPackageReference)"
+                      ExcludeFromPublishPackageReferences="@(ExcludeFromPublishPackageReference)"
                       TargetManifestFileList="@(TargetManifestFileList)"
                       IsSelfContained="$(SelfContained)" />
 
@@ -493,22 +493,22 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <!--
     ============================================================
-                                        ComputePrivateAssetsPackageReferences
+                                        ComputeExcludeFromPublishPackageReferences
 
-    Builds up the @(PrivateAssetsPackageReference) item by looking for @(PackageReference) items with 
+    Builds up the @(ExcludeFromPublishPackageReference) item by looking for @(PackageReference) items with 
     <PrivateAssets> metadata.
     ============================================================
     -->
   <PropertyGroup>
-    <ComputePrivateAssetsPackageReferences Condition="'$(ComputePrivateAssetsPackageReferences)' == ''">true</ComputePrivateAssetsPackageReferences>
+    <ComputeExcludeFromPublishPackageReferences Condition="'$(ComputeExcludeFromPublishPackageReferences)' == ''">true</ComputeExcludeFromPublishPackageReferences>
   </PropertyGroup>
 
-  <Target Name="ComputePrivateAssetsPackageReferences"
-          Condition="'$(ComputePrivateAssetsPackageReferences)' == 'true'">
+  <Target Name="ComputeExcludeFromPublishPackageReferences"
+          Condition="'$(ComputeExcludeFromPublishPackageReferences)' == 'true'">
 
     <ItemGroup>
-      <PrivateAssetsPackageReference Include="@(PackageReference)"
-                                     Condition="'%(PackageReference.PrivateAssets)' == 'All'" />
+      <ExcludeFromPublishPackageReference Include="@(PackageReference)"
+                                          Condition="'%(PackageReference.PrivateAssets)' == 'All'" />
     </ItemGroup>
 
   </Target>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Publish.targets
@@ -247,14 +247,14 @@ Copyright (c) .NET Foundation. All rights reserved.
     -->
   <UsingTask TaskName="ResolvePublishAssemblies" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
   <Target Name="RunResolvePublishAssemblies"
-          DependsOnTargets="ComputeExcludeFromPublishPackageReferences;
+          DependsOnTargets="_ComputeExcludeFromPublishPackageReferences;
                             _DefaultMicrosoftNETPlatformLibrary">
     <ResolvePublishAssemblies ProjectPath="$(MSBuildProjectFullPath)"
                               AssetsFilePath="$(ProjectAssetsFile)"
                               TargetFramework="$(TargetFrameworkMoniker)"
                               RuntimeIdentifier="$(RuntimeIdentifier)"
                               PlatformLibraryName="$(MicrosoftNETPlatformLibrary)"
-                              ExcludeFromPublishPackageReferences="@(ExcludeFromPublishPackageReference)"
+                              ExcludeFromPublishPackageReferences="@(_ExcludeFromPublishPackageReference)"
                               TargetManifestFiles="@(TargetManifestFileList)"
                               PreserveStoreLayout="$(PreserveStoreLayout)"
                               IsSelfContained="$(SelfContained)" >
@@ -460,7 +460,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     ============================================================
     -->
   <Target Name="GeneratePublishDependencyFile"
-          DependsOnTargets="ComputeExcludeFromPublishPackageReferences;
+          DependsOnTargets="_ComputeExcludeFromPublishPackageReferences;
                             _DefaultMicrosoftNETPlatformLibrary;
                             _HandlePackageFileConflicts;
                             _HandlePublishFileConflicts"
@@ -485,7 +485,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                       PlatformLibraryName="$(MicrosoftNETPlatformLibrary)"
                       FilesToSkip="@(_ConflictPackageFiles);@(_PublishConflictPackageFiles)"
                       CompilerOptions="@(DependencyFileCompilerOptions)"
-                      ExcludeFromPublishPackageReferences="@(ExcludeFromPublishPackageReference)"
+                      ExcludeFromPublishPackageReferences="@(_ExcludeFromPublishPackageReference)"
                       TargetManifestFileList="@(TargetManifestFileList)"
                       IsSelfContained="$(SelfContained)" />
 
@@ -493,27 +493,26 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <!--
     ============================================================
-                                        ComputeExcludeFromPublishPackageReferences
+                                        _ComputeExcludeFromPublishPackageReferences
 
-    Builds up the @(ExcludeFromPublishPackageReference) item by looking for @(PackageReference) items with 
-    <PrivateAssets> metadata.
+    Builds up the @(_ExcludeFromPublishPackageReference) item by looking for @(PackageReference) items where
+    that have Publish=false metadata, or that have PrivateAssets=All and don't specify Publish
     ============================================================
     -->
   <PropertyGroup>
-    <ComputeExcludeFromPublishPackageReferences Condition="'$(ComputeExcludeFromPublishPackageReferences)' == ''">true</ComputeExcludeFromPublishPackageReferences>
+    <_ComputeExcludeFromPublishPackageReferences Condition="'$(_ComputeExcludeFromPublishPackageReferences)' == ''">true</_ComputeExcludeFromPublishPackageReferences>
   </PropertyGroup>
 
-  <Target Name="ComputeExcludeFromPublishPackageReferences"
-          Condition="'$(ComputeExcludeFromPublishPackageReferences)' == 'true'">
+  <Target Name="_ComputeExcludeFromPublishPackageReferences"
+          Condition="'$(_ComputeExcludeFromPublishPackageReferences)' == 'true'">
 
     <ItemGroup>
       
-      <!-- PrivateAssets="All" means exclude from publish, unless ExcludeFromPublish metadata is specified separately -->
-      <PackageReference Update="@(PackageReference)" 
-                        Publish="false"
+      <!-- PrivateAssets="All" means exclude from publish, unless Publish metadata is specified separately -->
+      <PackageReference Publish="false"
                         Condition="('%(PackageReference.PrivateAssets)' == 'All') And ('%(PackageReference.Publish)' == '')"/>
       
-      <ExcludeFromPublishPackageReference Include="@(PackageReference)"
+      <_ExcludeFromPublishPackageReference Include="@(PackageReference)"
                                           Condition="('%(PackageReference.Publish)' == 'false')" />
     </ItemGroup>
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Publish.targets
@@ -508,7 +508,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <ItemGroup>
       <ExcludeFromPublishPackageReference Include="@(PackageReference)"
-                                          Condition="'%(PackageReference.PrivateAssets)' == 'All'" />
+                                          Condition="(('%(PackageReference.PrivateAssets)' == 'All') And ('%(PackageReference.ExcludeFromPublish)' != 'false')) Or ('%(PackageReference.ExcludeFromPublish)' == 'true')" />
     </ItemGroup>
 
   </Target>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.DefaultItems.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.DefaultItems.props
@@ -37,17 +37,19 @@ Copyright (c) .NET Foundation. All rights reserved.
     <!-- If targeting .NET Standard 2.0 or higher, then don't include a dependency on NETStandard.Library in the package produced by pack -->
     <PackageReference Update="NETStandard.Library"
                       Condition=" '$(_TargetFrameworkVersionWithoutV)' >= '2.0' "
-                      PrivateAssets="All" Publish="true" />
+                      PrivateAssets="All" 
+                      Publish="true" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(DisableImplicitFrameworkReferences)' != 'true' and '$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
     <PackageReference Include="Microsoft.NETCore.App" Version="$(RuntimeFrameworkVersion)" IsImplicitlyDefined="true" />
 
-    <!-- For libraries targeting .NET Core 2.0 or higher, don't include a dependency on NETStandard.Library in the package produced by pack.
+    <!-- For libraries targeting .NET Core 2.0 or higher, don't include a dependency on Microsoft.NETCore.App in the package produced by pack.
          Packing an app (for example a .NET CLI tool) should include the Microsoft.NETCore.App package dependency. -->
     <PackageReference Update="Microsoft.NETCore.App"
                       Condition="('$(OutputType)' != 'Exe') And ('$(_TargetFrameworkVersionWithoutV)' >= '2.0')"
-                      PrivateAssets="All" Publish="true" />    
+                      PrivateAssets="All"
+                      Publish="true" />    
   </ItemGroup>
 
 </Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.DefaultItems.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.DefaultItems.props
@@ -37,7 +37,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <!-- If targeting .NET Standard 2.0 or higher, then don't include a dependency on NETStandard.Library in the package produced by pack -->
     <PackageReference Update="NETStandard.Library"
                       Condition=" '$(_TargetFrameworkVersionWithoutV)' >= '2.0' "
-                      PrivateAssets="All" ExcludeFromPublish="false" />
+                      PrivateAssets="All" Publish="true" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(DisableImplicitFrameworkReferences)' != 'true' and '$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
@@ -47,7 +47,7 @@ Copyright (c) .NET Foundation. All rights reserved.
          Packing an app (for example a .NET CLI tool) should include the Microsoft.NETCore.App package dependency. -->
     <PackageReference Update="Microsoft.NETCore.App"
                       Condition="('$(OutputType)' != 'Exe') And ('$(_TargetFrameworkVersionWithoutV)' >= '2.0')"
-                      PrivateAssets="All" ExcludeFromPublish="false" />    
+                      PrivateAssets="All" Publish="true" />    
   </ItemGroup>
 
 </Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.DefaultItems.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.DefaultItems.props
@@ -33,10 +33,21 @@ Copyright (c) .NET Foundation. All rights reserved.
       evaluated in the second pass of evaluation, after all properties have been evaluated. -->
   <ItemGroup Condition=" '$(DisableImplicitFrameworkReferences)' != 'true' and '$(TargetFrameworkIdentifier)' == '.NETStandard'">
     <PackageReference Include="NETStandard.Library" Version="$(NETStandardImplicitPackageVersion)" IsImplicitlyDefined="true" />
+
+    <!-- If targeting .NET Standard 2.0 or higher, then don't include a dependency on NETStandard.Library in the package produced by pack -->
+    <PackageReference Update="NETStandard.Library"
+                      Condition=" '$(_TargetFrameworkVersionWithoutV)' >= '2.0' "
+                      PrivateAssets="All" ExcludeFromPublish="false" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(DisableImplicitFrameworkReferences)' != 'true' and '$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
     <PackageReference Include="Microsoft.NETCore.App" Version="$(RuntimeFrameworkVersion)" IsImplicitlyDefined="true" />
+
+    <!-- For libraries targeting .NET Core 2.0 or higher, don't include a dependency on NETStandard.Library in the package produced by pack.
+         Packing an app (for example a .NET CLI tool) should include the Microsoft.NETCore.App package dependency. -->
+    <PackageReference Update="Microsoft.NETCore.App"
+                      Condition="('$(OutputType)' != 'Exe') And ('$(_TargetFrameworkVersionWithoutV)' >= '2.0')"
+                      PrivateAssets="All" ExcludeFromPublish="false" />    
   </ItemGroup>
 
 </Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.DefaultItems.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.DefaultItems.targets
@@ -54,7 +54,12 @@ Copyright (c) .NET Foundation. All rights reserved.
     <!-- If targeting the same release that is bundled with the .NET Core SDK, use the bundled package version provided by Microsoft.NETCoreSdk.BundledVersions.props -->
     <NETStandardImplicitPackageVersion Condition="'$(NETStandardImplicitPackageVersion)' =='' And '$(_TargetFrameworkVersionWithoutV)' == '$(BundledNETStandardTargetFrameworkVersion)'">$(BundledNETStandardPackageVersion)</NETStandardImplicitPackageVersion>
 
-    <!-- Default to use v1.6.1 (latest stable release) -->
+    <!-- If targeting .NET Standard 1.x, use version 1.6.1 of the package.  This is so that when projects are packed, the dependency on the package produced won't change when
+         updating to the 2.0 or higher SDK.  When targeting .NET Standard 2.0 or higher, the NETStandard.Library reference won't show up as a dependency of the package
+         produced, so we will roll forward to the latest version. -->
+    <NETStandardImplicitPackageVersion Condition="'$(NETStandardImplicitPackageVersion)' =='' And '$(_TargetFrameworkVersionWithoutV)' &lt; '2.0'">1.6.1</NETStandardImplicitPackageVersion>
+    
+    <!-- Default to use th latest stable release.  Currently this is the same as the previous clause, but when we have a stable 2.0 package this should change. -->
     <NETStandardImplicitPackageVersion Condition="'$(NETStandardImplicitPackageVersion)' ==''">1.6.1</NETStandardImplicitPackageVersion>
   </PropertyGroup>
   

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.DefaultItems.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.DefaultItems.targets
@@ -59,7 +59,7 @@ Copyright (c) .NET Foundation. All rights reserved.
          produced, so we will roll forward to the latest version. -->
     <NETStandardImplicitPackageVersion Condition="'$(NETStandardImplicitPackageVersion)' =='' And '$(_TargetFrameworkVersionWithoutV)' &lt; '2.0'">1.6.1</NETStandardImplicitPackageVersion>
     
-    <!-- Default to use th latest stable release.  Currently this is the same as the previous clause, but when we have a stable 2.0 package this should change. -->
+    <!-- Default to use the latest stable release.  Currently this is the same as the previous clause, but when we have a stable 2.0 package this should change. -->
     <NETStandardImplicitPackageVersion Condition="'$(NETStandardImplicitPackageVersion)' ==''">1.6.1</NETStandardImplicitPackageVersion>
   </PropertyGroup>
   

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.targets
@@ -88,7 +88,7 @@ Copyright (c) .NET Foundation. All rights reserved.
           Outputs="$(ProjectDepsFilePath)">
 
     <!-- 
-    Explicitly not passing any PrivateAssets information during 'Build', since these dependencies
+    Explicitly not passing any ExcludeFromPublishPackageReferences information during 'Build', since these dependencies
     should be included during 'Build'.  They are only excluded on 'Publish'.
     -->
     <GenerateDepsFile ProjectPath="$(MSBuildProjectFullPath)"

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToExcludeTheMainProjectFromTheDepsFile.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToExcludeTheMainProjectFromTheDepsFile.cs
@@ -1,4 +1,7 @@
-﻿using FluentAssertions;
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using FluentAssertions;
 using Microsoft.NET.TestFramework;
 using Microsoft.NET.TestFramework.Assertions;
 using Microsoft.NET.TestFramework.Commands;

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToGenerateADepsFileForATool.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToGenerateADepsFileForATool.cs
@@ -1,4 +1,7 @@
-﻿using FluentAssertions;
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using FluentAssertions;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.NET.TestFramework;
 using Microsoft.NET.TestFramework.Assertions;

--- a/test/Microsoft.NET.Pack.Tests/GivenThatThereAreImplicitPackageReferences.cs
+++ b/test/Microsoft.NET.Pack.Tests/GivenThatThereAreImplicitPackageReferences.cs
@@ -77,16 +77,11 @@ namespace Microsoft.NET.Pack.Tests
                 .Should().StartWith("1.1.");
         }
 
-        [Fact]
+        //  Disabled on full framework MSBuild until CI machines have VS with bundled .NET Core / .NET Standard versions
+        //  See https://github.com/dotnet/sdk/issues/1077
+        [CoreMSBuildOnlyFact]
         public void Packing_a_netcoreapp_2_0_library_does_not_include_the_implicit_dependency()
         {
-            if (UsingFullFrameworkMSBuild)
-            {
-                //  Disabled on full framework MSBuild until CI machines have VS with bundled .NET Core / .NET Standard versions
-                //  See https://github.com/dotnet/sdk/issues/1077
-                return;
-            }
-
             TestProject testProject = new TestProject()
             {
                 Name = "PackNetCoreApp20Library",
@@ -122,16 +117,11 @@ namespace Microsoft.NET.Pack.Tests
                 .Should().StartWith("1.1.");
         }
 
-        [Fact]
+        //  Disabled on full framework MSBuild until CI machines have VS with bundled .NET Core / .NET Standard versions
+        //  See https://github.com/dotnet/sdk/issues/1077
+        [CoreMSBuildOnlyFact]
         public void Packing_a_netcoreapp_2_0_app_includes_the_implicit_dependency()
         {
-            if (UsingFullFrameworkMSBuild)
-            {
-                //  Disabled on full framework MSBuild until CI machines have VS with bundled .NET Core / .NET Standard versions
-                //  See https://github.com/dotnet/sdk/issues/1077
-                return;
-            }
-
             TestProject testProject = new TestProject()
             {
                 Name = "PackNetCoreApp20App",
@@ -151,16 +141,11 @@ namespace Microsoft.NET.Pack.Tests
                 .Should().StartWith("2.0.");
         }
 
-        [Fact]
+        //  Disabled on full framework MSBuild until CI machines have VS with bundled .NET Core / .NET Standard versions
+        //  See https://github.com/dotnet/sdk/issues/1077
+        [CoreMSBuildOnlyFact]
         public void Packing_a_multitargeted_library_includes_implicit_dependencies_when_appropriate()
         {
-            if (UsingFullFrameworkMSBuild)
-            {
-                //  Disabled on full framework MSBuild until CI machines have VS with bundled .NET Core / .NET Standard versions
-                //  See https://github.com/dotnet/sdk/issues/1077
-                return;
-            }
-
             TestProject testProject = new TestProject()
             {
                 Name = "PackMultiTargetedLibrary",

--- a/test/Microsoft.NET.Pack.Tests/GivenThatThereAreImplicitPackageReferences.cs
+++ b/test/Microsoft.NET.Pack.Tests/GivenThatThereAreImplicitPackageReferences.cs
@@ -1,0 +1,216 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.NET.TestFramework;
+using Microsoft.NET.TestFramework.Assertions;
+using Microsoft.NET.TestFramework.Commands;
+using Xunit;
+using static Microsoft.NET.TestFramework.Commands.MSBuildTest;
+using Microsoft.NET.TestFramework.ProjectConstruction;
+using System.Xml.Linq;
+using System.Linq;
+using FluentAssertions;
+
+namespace Microsoft.NET.Pack.Tests
+{
+    public class GivenThatThereAreImplicitPackageReferences : SdkTest
+    {
+        [Fact]
+        public void Packing_a_netstandard_1_x_library_includes_the_implicit_dependency()
+        {
+            TestProject testProject = new TestProject()
+            {
+                Name = "PackNetStandard1x",
+                IsSdkProject = true,
+                TargetFrameworks = "netstandard1.4",
+                IsExe = false
+            };
+
+            var dependencies = PackAndGetDependencies(testProject);
+
+            dependencies.Count().Should().Be(1);
+            dependencies.Single().Attribute("id").Value
+                .Should().Be("NETStandard.Library");
+            dependencies.Single().Attribute("version").Value
+                .Should().Be("1.6.1");
+        }
+
+        [Fact]
+        public void Packing_a_netstandard_2_0_library_does_not_include_the_implicit_dependency()
+        {
+            TestProject testProject = new TestProject()
+            {
+                Name = "PackNetStandard20",
+                IsSdkProject = true,
+                TargetFrameworks = "netstandard2.0",
+                IsExe = false
+            };
+
+            var dependencies = PackAndGetDependencies(testProject);
+
+            dependencies.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void Packing_a_netcoreapp_1_1_library_includes_the_implicit_dependency()
+        {
+            TestProject testProject = new TestProject()
+            {
+                Name = "PackNetCoreApp11Library",
+                IsSdkProject = true,
+                TargetFrameworks = "netcoreapp1.1",
+                IsExe = false
+            };
+
+            var dependencies = PackAndGetDependencies(testProject);
+
+            dependencies.Count().Should().Be(1);
+            dependencies.Single().Attribute("id").Value
+                .Should().Be("Microsoft.NETCore.App");
+
+            //  Don't check the exact version so that the test doesn't break if we roll forward to new patch versions of the package
+            dependencies.Single().Attribute("version").Value
+                .Should().StartWith("1.1.");
+        }
+
+        [Fact]
+        public void Packing_a_netcoreapp_2_0_library_does_not_include_the_implicit_dependency()
+        {
+            TestProject testProject = new TestProject()
+            {
+                Name = "PackNetCoreApp20Library",
+                IsSdkProject = true,
+                TargetFrameworks = "netcoreapp2.0",
+                IsExe = false
+            };
+
+            var dependencies = PackAndGetDependencies(testProject);
+
+            dependencies.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void Packing_a_netcoreapp_1_1_app_includes_the_implicit_dependency()
+        {
+            TestProject testProject = new TestProject()
+            {
+                Name = "PackNetCoreApp11App",
+                IsSdkProject = true,
+                TargetFrameworks = "netcoreapp1.1",
+                IsExe = true
+            };
+
+            var dependencies = PackAndGetDependencies(testProject);
+
+            dependencies.Count().Should().Be(1);
+            dependencies.Single().Attribute("id").Value
+                .Should().Be("Microsoft.NETCore.App");
+
+            //  Don't check the exact version so that the test doesn't break if we roll forward to new patch versions of the package
+            dependencies.Single().Attribute("version").Value
+                .Should().StartWith("1.1.");
+        }
+
+        [Fact]
+        public void Packing_a_netcoreapp_2_0_app_includes_the_implicit_dependency()
+        {
+            TestProject testProject = new TestProject()
+            {
+                Name = "PackNetCoreApp20App",
+                IsSdkProject = true,
+                TargetFrameworks = "netcoreapp2.0",
+                IsExe = true
+            };
+
+            var dependencies = PackAndGetDependencies(testProject);
+
+            dependencies.Count().Should().Be(1);
+            dependencies.Single().Attribute("id").Value
+                .Should().Be("Microsoft.NETCore.App");
+
+            //  Don't check the exact version so that the test doesn't break if we roll forward to new patch versions of the package
+            dependencies.Single().Attribute("version").Value
+                .Should().StartWith("2.0.");
+        }
+
+        [Fact]
+        public void Packing_a_multitargeted_library_includes_implicit_dependencies_when_appropriate()
+        {
+            TestProject testProject = new TestProject()
+            {
+                Name = "PackMultiTargetedLibrary",
+                IsSdkProject = true,
+                TargetFrameworks = "netstandard1.1;netstandard2.0;netcoreapp1.1;netcoreapp2.0;net461",
+                IsExe = false
+            };
+
+            var dependencyGroups = PackAndGetDependencyGroups(testProject, out var ns);
+
+            void ExpectDependencyGroup(string targetFramework, string dependencyId)
+            {
+                var matchingGroups = dependencyGroups.Where(dg => dg.Attribute("targetFramework").Value == targetFramework).ToList();
+                matchingGroups.Count().Should().Be(1);
+
+                var dependencies = matchingGroups.Single().Elements(ns + "dependency");
+                if (dependencyId == null)
+                {
+                    dependencies.Should().BeEmpty();
+                }
+                else
+                {
+                    dependencies.Count().Should().Be(1);
+                    dependencies.Single().Attribute("id").Value
+                        .Should().Be(dependencyId);
+                }
+            }
+
+            ExpectDependencyGroup(".NETStandard1.1", "NETStandard.Library");
+            ExpectDependencyGroup(".NETStandard2.0", null);
+            ExpectDependencyGroup(".NETCoreApp1.1", "Microsoft.NETCore.App");
+            ExpectDependencyGroup(".NETCoreApp2.0", null);
+            ExpectDependencyGroup(".NETFramework4.6.1", null);
+        }
+
+        List<XElement> PackAndGetDependencyGroups(TestProject testProject, out XNamespace ns)
+        {
+            var testProjectInstance = _testAssetsManager.CreateTestProject(testProject, testProject.Name)
+                .Restore(testProject.Name);
+
+            var packCommand = new PackCommand(Stage0MSBuild, testProjectInstance.TestRoot, testProject.Name);
+
+            packCommand.Execute()
+                .Should()
+                .Pass();
+
+            string nuspecPath = packCommand.GetIntermediateNuspecPath();
+            var nuspec = XDocument.Load(nuspecPath);
+            ns = nuspec.Root.Name.Namespace;
+
+            var dependencyGroups = nuspec.Root
+                .Element(ns + "metadata")
+                .Element(ns + "dependencies")
+                .Elements()
+                .ToList();
+
+            return dependencyGroups;
+        }
+
+        List<XElement> PackAndGetDependencies(TestProject testProject)
+        {
+            var dependencyGroups = PackAndGetDependencyGroups(testProject, out var ns);
+
+            //  There should be only one dependency group for these tests
+            dependencyGroups.Count().Should().Be(1);
+
+            //  It should have the right element name
+            dependencyGroups.Single().Name.Should().Be(ns + "group");
+
+            var dependencies = dependencyGroups.Single().Elements(ns + "dependency").ToList();
+
+            return dependencies;
+        }
+    }
+}

--- a/test/Microsoft.NET.Pack.Tests/GivenThatWeWantToPackAHelloWorldProject.cs
+++ b/test/Microsoft.NET.Pack.Tests/GivenThatWeWantToPackAHelloWorldProject.cs
@@ -23,14 +23,16 @@ namespace Microsoft.NET.Pack.Tests
                 .WithSource()
                 .Restore();
 
-            new PackCommand(Stage0MSBuild, helloWorldAsset.TestRoot)
+            var packCommand = new PackCommand(Stage0MSBuild, helloWorldAsset.TestRoot);
+
+            packCommand
                 .Execute()
                 .Should()
                 .Pass();
 
             //  Validate the contents of the NuGet package by looking at the generated .nuspec file, as that's simpler
             //  than unzipping and inspecting the .nupkg
-            string nuspecPath = Path.Combine(helloWorldAsset.TestRoot, "obj", "HelloWorld.1.0.0.nuspec");
+            string nuspecPath = packCommand.GetIntermediateNuspecPath();
             var nuspec = XDocument.Load(nuspecPath);
 
             var ns = nuspec.Root.Name.Namespace;

--- a/test/Microsoft.NET.Pack.Tests/Microsoft.NET.Pack.Tests.csproj
+++ b/test/Microsoft.NET.Pack.Tests/Microsoft.NET.Pack.Tests.csproj
@@ -30,6 +30,7 @@
     </PackageReference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="GivenThatThereAreImplicitPackageReferences.cs" />
     <Compile Include="GivenThatWeWantToPackAHelloWorldProject.cs" />
     <Compile Include="GivenThatWeWantToPackASimpleLibrary.cs" />
     <Compile Include="GivenThatWeWantToPackACrossTargetedLibrary.cs" />

--- a/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToExcludeAPackageFromPublish.cs
+++ b/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToExcludeAPackageFromPublish.cs
@@ -50,5 +50,76 @@ namespace Microsoft.NET.Publish.Tests
                 "HelloWorld.runtimeconfig.json"
             });
         }
+
+        [Fact]
+        public void It_does_not_publish_a_PackageReference_with_Publish_false()
+        {
+            var helloWorldAsset = _testAssetsManager
+                .CopyTestAsset("HelloWorld", "PublishPackagePublishFalse")
+                .WithSource()
+                .WithProjectChanges(project =>
+                {
+                    var ns = project.Root.Name.Namespace;
+
+                    var itemGroup = new XElement(ns + "ItemGroup");
+                    project.Root.Add(itemGroup);
+
+                    itemGroup.Add(new XElement(ns + "PackageReference", new XAttribute("Include", "Newtonsoft.Json"),
+                                                                        new XAttribute("Version", "9.0.1"),
+                                                                        new XAttribute("Publish", "false")));
+                })
+                .Restore();
+
+            var publishCommand = new PublishCommand(Stage0MSBuild, helloWorldAsset.TestRoot);
+            var publishResult = publishCommand.Execute();
+
+            publishResult.Should().Pass();
+
+            var publishDirectory = publishCommand.GetOutputDirectory();
+
+            publishDirectory.Should().OnlyHaveFiles(new[] {
+                "HelloWorld.dll",
+                "HelloWorld.pdb",
+                "HelloWorld.deps.json",
+                "HelloWorld.runtimeconfig.json"
+            });
+        }
+
+        [Fact]
+        public void It_publishes_a_PackageReference_with_PrivateAssets_All_and_Publish_true()
+        {
+            var helloWorldAsset = _testAssetsManager
+                .CopyTestAsset("HelloWorld", "PublishPrivateAssets")
+                .WithSource()
+                .WithProjectChanges(project =>
+                {
+                    var ns = project.Root.Name.Namespace;
+
+                    var itemGroup = new XElement(ns + "ItemGroup");
+                    project.Root.Add(itemGroup);
+
+                    itemGroup.Add(new XElement(ns + "PackageReference", new XAttribute("Include", "Newtonsoft.Json"),
+                                                                        new XAttribute("Version", "9.0.1"),
+                                                                        new XAttribute("PrivateAssets", "All"),
+                                                                        new XAttribute("Publish", "true")));
+                })
+                .Restore();
+
+            var publishCommand = new PublishCommand(Stage0MSBuild, helloWorldAsset.TestRoot);
+            var publishResult = publishCommand.Execute();
+
+            publishResult.Should().Pass();
+
+            var publishDirectory = publishCommand.GetOutputDirectory();
+
+            publishDirectory.Should().OnlyHaveFiles(new[] {
+                "HelloWorld.dll",
+                "HelloWorld.pdb",
+                "HelloWorld.deps.json",
+                "HelloWorld.runtimeconfig.json",
+                "Newtonsoft.Json.dll",
+                "System.Runtime.Serialization.Primitives.dll"
+            });
+        }
     }
 }

--- a/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAHelloWorldProject.cs
+++ b/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAHelloWorldProject.cs
@@ -345,7 +345,7 @@ public static class Program
                 .WithSource()
                 .Restore(relativePath: "HelloWorld", args: $"/p:RuntimeIdentifiers={rid}");
 
-            var buildCommand = new BuildCommand(Stage0MSBuild, helloWorldAsset.TestRoot, @"DeployProj\Deploy.proj");
+            var buildCommand = new BuildCommand(Stage0MSBuild, helloWorldAsset.TestRoot, Path.Combine("DeployProj", "Deploy.proj"));
 
             buildCommand
                 .Execute()

--- a/test/Microsoft.NET.TestFramework/Commands/PackCommand.cs
+++ b/test/Microsoft.NET.TestFramework/Commands/PackCommand.cs
@@ -4,13 +4,14 @@
 using System;
 using System.Linq;
 using Microsoft.DotNet.Cli.Utils;
+using System.IO;
 
 namespace Microsoft.NET.TestFramework.Commands
 {
     public sealed class PackCommand : TestCommand
     {
-        public PackCommand(MSBuildTest msbuild, string projectPath)
-            : base(msbuild, projectPath)
+        public PackCommand(MSBuildTest msbuild, string projectPath, string relativePathToProject = null)
+            : base(msbuild, projectPath, relativePathToProject)
         {
         }
 
@@ -22,6 +23,16 @@ namespace Microsoft.NET.TestFramework.Commands
             var command = MSBuild.CreateCommandForTarget("pack", newArgs.ToArray());
 
             return command.Execute();
+        }
+
+        public string GetIntermediateNuspecPath(string packageId = null, string packageVersion = "1.0.0")
+        {
+            if (packageId == null)
+            {
+                packageId = Path.GetFileNameWithoutExtension(ProjectFile);
+            }
+
+            return Path.Combine(GetBaseIntermediateDirectory().FullName, $"{packageId}.{packageVersion}.nuspec");
         }
     }
 }


### PR DESCRIPTION
Fixes #992

Change metadata on implicit package references to NETStandard.Library and Microsoft.NETCore.App so that the package won't be a dependency of the package produced when packing the project in the following cases:

- The project is targeting .NET Standard 2.0 or higher
- The project is targeting .NET Core 2.0 or higher and the output type is not `Exe`

The implicit package reference will still be included when targeting 1.x so that updating to the 2.0 tools doesn't change the result of building or packing the project.  And it will still be included when targeting .NET Core and the output type is `Exe` as this is needed to make DotNetCliToolReferences work.

This PR also makes it explicit that even after there is a non-prerelease version of the NETStandard.Library 2.0 package, that projects targeting .NET Standard 1.x should still implicitly reference the 1.6.1 version of the package.  This is again so that the output of a project doesn't change when updating to the 2.0 tools.

I've also updated the build script to automatically create a binary log for the main SDK build.

Tests are still to come.