### PR TITLE
Fix error message when TargetFramework contains semicolons.

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.TargetFrameworkInference.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.TargetFrameworkInference.targets
@@ -83,7 +83,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <Target Name="_CheckForUnsupportedTargetFramework" BeforeTargets="_CheckForInvalidConfigurationAndPlatform">
     <NETSdkError Condition="'$(_UnsupportedTargetFrameworkError)' == 'true'" 
                  ResourceName="CannotInferTargetFrameworkIdentiferAndVersion"
-                 FormatArguments="$(TargetFramework)" />
+                 FormatArguments="$([MSBuild]::Escape('$(TargetFramework)'))" />
   </Target>
 
   <!-- 


### PR DESCRIPTION
When you want to change a single-tfm project to target multiple TFMs, you tend to forget to change the property name (plural `s`).
The error message in this case isn't very helpful and is problematic to debug. E.g. this [SO question](http://stackoverflow.com/questions/43763180/dotnet-pack-targeting-multiple-frameworks) has
```xml
<TargetFramework>netcoreapp1.0;net45</TargetFramework>
```
The resulting error message says:
```
Cannot infer TargetFrameworkIdentifier and/or TargetFrameworkVersion from TargetFramework='netcoreapp1.0'. They must be specified explicitly.
```
With this change, the error message will change from `TargetFramework='netcoreapp1.0'` to `TargetFramework='netcoreapp1.0;net45'.` as the semicolon caused the format arguments to be split.