### PR TITLE
Check the targetext to determine if a framework project can be run on F5

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.targets
@@ -269,7 +269,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       </PropertyGroup>
     </When>
     
-    <When Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework' and '$(OutputType)' == 'Exe'">
+    <When Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework' and '$(TargetExt)' == '.exe'">
       <PropertyGroup>
         <RunCommand Condition="'$(RunCommand)' == ''">$(TargetPath)</RunCommand>
         <RunArguments Condition="'$(RunArguments)' == ''">$(StartArguments)</RunArguments>


### PR DESCRIPTION
We should be able to run both Console Application and Windows Application on F5 for Framework Projects

This is to address the issue [project-system/2033](https://github.com/dotnet/project-system/issues/2033)

Tagging @dotnet/project-system @srivatsn @davkean for review

P.S: This PR will not be merged until Preview1 is done.