### PR TITLE
Avoid errors in conditions when MSBuild is evaluating for design time

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.DefaultItems.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.DefaultItems.props
@@ -36,7 +36,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <!-- If targeting .NET Standard 2.0 or higher, then don't include a dependency on NETStandard.Library in the package produced by pack -->
     <PackageReference Update="NETStandard.Library"
-                      Condition=" '$(_TargetFrameworkVersionWithoutV)' >= '2.0' "
+                      Condition=" ('$(_TargetFrameworkVersionWithoutV)' != '') And ('$(_TargetFrameworkVersionWithoutV)' >= '2.0') "
                       PrivateAssets="All" 
                       Publish="true" />
   </ItemGroup>
@@ -47,7 +47,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <!-- For libraries targeting .NET Core 2.0 or higher, don't include a dependency on Microsoft.NETCore.App in the package produced by pack.
          Packing an app (for example a .NET CLI tool) should include the Microsoft.NETCore.App package dependency. -->
     <PackageReference Update="Microsoft.NETCore.App"
-                      Condition="('$(OutputType)' != 'Exe') And ('$(_TargetFrameworkVersionWithoutV)' >= '2.0')"
+                      Condition="('$(OutputType)' != 'Exe') And ('$(_TargetFrameworkVersionWithoutV)' != '') And ('$(_TargetFrameworkVersionWithoutV)' >= '2.0')"
                       PrivateAssets="All"
                       Publish="true" />    
   </ItemGroup>


### PR DESCRIPTION
When evaluating for design time, MSBuild will evaluate items even when they have a condition that is false.  So in a cross-targeting build, even though the target framework identifier won't be set, it will still evaluate the items in these item groups.  So we need to have a defense against trying to do a version comparison against an empty version in these conditions themselves.

This was regressed in #1171