### PR TITLE
avoid warning for importing pack targets twice

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/sdk/Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/sdk/Sdk.targets
@@ -45,11 +45,12 @@ Copyright (c) .NET Foundation. All rights reserved.
           Condition="'$(IsCrossTargetingBuild)' != 'true'"/>
   
   <!-- Import targets from NuGet.Build.Tasks.Pack package/Sdk -->
-  <PropertyGroup>
-    <NuGetBuildTasksPackTargets Condition="'$(NuGetBuildTasksPackTargets)' == '' And '$(IsCrossTargetingBuild)' == 'true'">$(MSBuildThisFileDirectory)..\..\NuGet.Build.Tasks.Pack\buildCrossTargeting\NuGet.Build.Tasks.Pack.targets</NuGetBuildTasksPackTargets>
-    <NuGetBuildTasksPackTargets Condition="'$(NuGetBuildTasksPackTargets)' == '' And '$(IsCrossTargetingBuild)' != 'true'">$(MSBuildThisFileDirectory)..\..\NuGet.Build.Tasks.Pack\build\NuGet.Build.Tasks.Pack.targets</NuGetBuildTasksPackTargets>
+  <PropertyGroup Condition="'$(NuGetBuildTasksPackTargets)' == '' AND '$(ImportNuGetBuildTasksPackTargetsFromSdk' != 'false'">
+    <NuGetBuildTasksPackTargets Condition="'$(IsCrossTargetingBuild)' == 'true'">$(MSBuildThisFileDirectory)..\..\NuGet.Build.Tasks.Pack\buildCrossTargeting\NuGet.Build.Tasks.Pack.targets</NuGetBuildTasksPackTargets>
+    <NuGetBuildTasksPackTargets Condition="'$(IsCrossTargetingBuild)' != 'true'">$(MSBuildThisFileDirectory)..\..\NuGet.Build.Tasks.Pack\build\NuGet.Build.Tasks.Pack.targets</NuGetBuildTasksPackTargets>
+    <ImportNuGetBuildTasksPackTargetsFromSdk>true</ImportNuGetBuildTasksPackTargetsFromSdk>
   </PropertyGroup>
   
   <Import Project="$(NuGetBuildTasksPackTargets)"
-          Condition="Exists('$(NuGetBuildTasksPackTargets)')"/>  
+          Condition="Exists('$(NuGetBuildTasksPackTargets)') AND '$(ImportNuGetBuildTasksPackTargetsFromSdk)' == 'true'"/>  
 </Project>


### PR DESCRIPTION
The fix for https://github.com/dotnet/sdk/issues/888 was incomplete in the sense that if $(NuGetBuildTasksPackTargets) is defined in a target contained via the nupkg, it is already imported as a result of restore. SDK shouldn't be trying to import those targets again.

@dsplaisted @nguerrera 

CC: @kzu to make sure it doesn't break nugetizer's behavior since he did the original fix.