### PR TITLE
Don't pack implicit references as framework references

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.BeforeCommon.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.BeforeCommon.targets
@@ -89,30 +89,45 @@ Copyright (c) .NET Foundation. All rights reserved.
   
   <ItemGroup Condition=" '$(DisableImplicitFrameworkReferences)' != 'true' and '$(TargetFrameworkIdentifier)' == '.NETFramework'">
 
-    <Reference Include="System"/>
-    <Reference Include="System.Data"/>
-    <Reference Include="System.Drawing"/>
-    <Reference Include="System.Xml"/>
+    <_SDKImplicitReference Include="System"/>
+    <_SDKImplicitReference Include="System.Data"/>
+    <_SDKImplicitReference Include="System.Drawing"/>
+    <_SDKImplicitReference Include="System.Xml"/>
 
     <!-- When doing greater than/less than comparisons between strings, MSBuild will try to parse the strings as Version objects and compare them as
          such if the parse succeeds. -->
     
     <!-- Framework assemblies introduced in .NET 3.5 -->
-    <Reference Include="System.Core" Condition=" '$(_TargetFrameworkVersionWithoutV)' >= '3.5' "/>
-    <Reference Include="System.Runtime.Serialization" Condition=" '$(_TargetFrameworkVersionWithoutV)' >= '3.5' "/>
-    <Reference Include="System.Xml.Linq" Condition=" '$(_TargetFrameworkVersionWithoutV)' >= '3.5' "/>
+    <_SDKImplicitReference Include="System.Core" Condition=" '$(_TargetFrameworkVersionWithoutV)' >= '3.5' "/>
+    <_SDKImplicitReference Include="System.Runtime.Serialization" Condition=" '$(_TargetFrameworkVersionWithoutV)' >= '3.5' "/>
+    <_SDKImplicitReference Include="System.Xml.Linq" Condition=" '$(_TargetFrameworkVersionWithoutV)' >= '3.5' "/>
 
     <!-- Framework assemblies introduced in .NET 4.0 -->
-    <Reference Include="System.Numerics" Condition=" '$(_TargetFrameworkVersionWithoutV)' >= '4.0' "/>
+    <_SDKImplicitReference Include="System.Numerics" Condition=" '$(_TargetFrameworkVersionWithoutV)' >= '4.0' "/>
 
     <!-- Framework assemblies introduced in .NET 4.5 -->
-    <Reference Include="System.IO.Compression.FileSystem" Condition=" '$(_TargetFrameworkVersionWithoutV)' >= '4.5' "/>
+    <_SDKImplicitReference Include="System.IO.Compression.FileSystem" Condition=" '$(_TargetFrameworkVersionWithoutV)' >= '4.5' "/>
     
     <!-- Don't automatically reference System.IO.Compression or System.Net.Http to help avoid hitting https://github.com/Microsoft/msbuild/issues/1329. -->
     <!--<Reference Include="System.IO.Compression" Condition=" '$(_TargetFrameworkVersionWithoutV)' >= '4.5' "/>
-    <Reference Include="System.Net.Http" Condition=" '$(_TargetFrameworkVersionWithoutV)' >= '4.5' "/>-->
+    <_SDKImplicitReference Include="System.Net.Http" Condition=" '$(_TargetFrameworkVersionWithoutV)' >= '4.5' "/>-->
 
+    <!-- Set Pack=false on implicit references so they don't get added to NuGet packages as framework assemblies -->
+    <_SDKImplicitReference Update="@(_SDKImplicitReference)"
+                           Pack="false" />
+
+    <!-- Don't duplicate any references that are explicit in the project file.  This means that if you do want to include a framework assembly in your
+         NuGet package, you can just add the Reference to your project file. -->
+    <_SDKImplicitReference Remove="@(Reference)" />
+
+    <!-- Add the implicit references to @(Reference) -->
+    <Reference Include="@(_SDKImplicitReference)" />
   </ItemGroup>
+
+  <PropertyGroup>
+    <!-- Prevent System.Core reference from being added separately (see Microsoft.NETFramework.CurrentVersion.props) -->
+    <AddAdditionalExplicitAssemblyReferences>false</AddAdditionalExplicitAssemblyReferences>
+  </PropertyGroup>
 
   <PropertyGroup Condition="'$(DisableImplicitPackageTargetFallback)' != 'true' and '$(_IsNETCoreOrNETStandard)' == 'true' and '$(_TargetFrameworkVersionWithoutV)' >= '2.0'">
     <PackageTargetFallback>$(PackageTargetFallback);net461</PackageTargetFallback>    

--- a/test/Microsoft.NET.Pack.Tests/GivenThatThereAreImplicitPackageReferences.cs
+++ b/test/Microsoft.NET.Pack.Tests/GivenThatThereAreImplicitPackageReferences.cs
@@ -188,7 +188,7 @@ namespace Microsoft.NET.Pack.Tests
             }
         }
 
-        List<XElement> PackAndGetDependencyGroups(TestProject testProject, out XNamespace ns)
+        private List<XElement> PackAndGetDependencyGroups(TestProject testProject, out XNamespace ns)
         {
             var testProjectInstance = _testAssetsManager.CreateTestProject(testProject, testProject.Name)
                 .Restore(Log, testProject.Name);
@@ -212,7 +212,7 @@ namespace Microsoft.NET.Pack.Tests
             return dependencyGroups;
         }
 
-        List<XElement> PackAndGetDependencies(TestProject testProject)
+        private List<XElement> PackAndGetDependencies(TestProject testProject)
         {
             var dependencyGroups = PackAndGetDependencyGroups(testProject, out var ns);
 

--- a/test/Microsoft.NET.Pack.Tests/GivenThatWeWantToPackANetFrameworkLibrary.cs
+++ b/test/Microsoft.NET.Pack.Tests/GivenThatWeWantToPackANetFrameworkLibrary.cs
@@ -24,7 +24,7 @@ namespace Microsoft.NET.Pack.Tests
         {
         }
 
-        [Fact]
+        [WindowsOnlyFact]
         public void ImplicitReferencesAreNotIncludedAsFrameworkReferences()
         {
             TestProject testProject = new TestProject()
@@ -47,7 +47,7 @@ namespace Microsoft.NET.Pack.Tests
             frameworkAssemblies.Should().BeNull();
         }
 
-        [Fact]
+        [WindowsOnlyFact]
         public void ExplicitReferencesAreIncludedAsFrameworkReferences()
         {
             TestProject testProject = new TestProject()

--- a/test/Microsoft.NET.Pack.Tests/GivenThatWeWantToPackANetFrameworkLibrary.cs
+++ b/test/Microsoft.NET.Pack.Tests/GivenThatWeWantToPackANetFrameworkLibrary.cs
@@ -1,0 +1,106 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.NET.TestFramework;
+using Microsoft.NET.TestFramework.Assertions;
+using Microsoft.NET.TestFramework.Commands;
+using Xunit;
+using static Microsoft.NET.TestFramework.Commands.MSBuildTest;
+using Microsoft.NET.TestFramework.ProjectConstruction;
+using System.Xml.Linq;
+using System.Linq;
+using FluentAssertions;
+using System.Runtime.InteropServices;
+using Xunit.Abstractions;
+
+namespace Microsoft.NET.Pack.Tests
+{
+    public class GivenThatWeWantToPackANetFrameworkLibrary : SdkTest
+    {
+        public GivenThatWeWantToPackANetFrameworkLibrary(ITestOutputHelper log) : base(log)
+        {
+        }
+
+        [Fact]
+        public void ImplicitReferencesAreNotIncludedAsFrameworkReferences()
+        {
+            TestProject testProject = new TestProject()
+            {
+                Name = "PackImplicitReferences",
+                IsSdkProject = true,
+                TargetFrameworks = "net461",
+                IsExe = false
+            };
+
+            var nuspecPath = PackAndGetNuspecPath(testProject);
+
+            var nuspec = XDocument.Load(nuspecPath);
+            var ns = nuspec.Root.Name.Namespace;
+
+            var frameworkAssemblies = nuspec.Root
+                .Element(ns + "metadata")
+                .Element(ns + "frameworkAssemblies");
+
+            frameworkAssemblies.Should().BeNull();
+        }
+
+        [Fact]
+        public void ExplicitReferencesAreIncludedAsFrameworkReferences()
+        {
+            TestProject testProject = new TestProject()
+            {
+                Name = "PackImplicitReferences",
+                IsSdkProject = true,
+                TargetFrameworks = "net461",
+                IsExe = false
+            };
+
+            var nuspecPath = PackAndGetNuspecPath(testProject,
+                p =>
+                {
+                    var pns = p.Root.Name.Namespace;
+
+                    p.Root.Add(new XElement(pns + "ItemGroup",
+                        new XElement(pns + "Reference", new XAttribute("Include", "System")),
+                        new XElement(pns + "Reference", new XAttribute("Include", "System.Xml.Linq"))));
+                });
+
+            var nuspec = XDocument.Load(nuspecPath);
+            var ns = nuspec.Root.Name.Namespace;
+
+            var frameworkAssemblies = nuspec.Root
+                .Element(ns + "metadata")
+                .Element(ns + "frameworkAssemblies")
+                .Elements(ns + "frameworkAssembly");
+
+            frameworkAssemblies.Count().Should().Be(2);
+            frameworkAssemblies.Should().Contain(i => i.Attribute("assemblyName").Value == "System");
+            frameworkAssemblies.Should().Contain(i => i.Attribute("assemblyName").Value == "System.Xml.Linq");
+        }
+
+        private string PackAndGetNuspecPath(TestProject testProject, Action<XDocument> xmlAction = null)
+        {
+            var testProjectInstance = _testAssetsManager.CreateTestProject(testProject, testProject.Name);
+
+            if (xmlAction != null)
+            {
+                testProjectInstance = testProjectInstance.WithProjectChanges(xmlAction);
+            }
+
+            testProjectInstance = testProjectInstance.Restore(Log, testProject.Name);
+
+            var packCommand = new PackCommand(Log, testProjectInstance.TestRoot, testProject.Name);
+
+            packCommand.Execute()
+                .Should()
+                .Pass();
+
+            string nuspecPath = packCommand.GetIntermediateNuspecPath();
+            return nuspecPath;
+           
+        }
+    }
+}

--- a/test/Microsoft.NET.Pack.Tests/Microsoft.NET.Pack.Tests.csproj
+++ b/test/Microsoft.NET.Pack.Tests/Microsoft.NET.Pack.Tests.csproj
@@ -17,6 +17,7 @@
   <ItemGroup>
     <Compile Include="GivenThatThereAreImplicitPackageReferences.cs" />
     <Compile Include="GivenThatWeWantToPackAHelloWorldProject.cs" />
+    <Compile Include="GivenThatWeWantToPackANetFrameworkLibrary.cs" />
     <Compile Include="GivenThatWeWantToPackASimpleLibrary.cs" />
     <Compile Include="GivenThatWeWantToPackACrossTargetedLibrary.cs" />
     <EmbeddedResource Include="**\*.resx" Exclude="$(GlobalExclude)" />


### PR DESCRIPTION
- Add Pack=false metadata to implicit framework references for .NET Framework projects
- Don't add implicit references that are already explicitly referenced

Fixes #1179

Note that this updates to a version of NuGet that has the framework reference support in the pack command.  So that update may need to be coordinated across the SDK and CLI repos.