### PR TITLE
adding arch to user profile store

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.ComposeStore.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.ComposeStore.targets
@@ -230,8 +230,8 @@ Copyright (c) .NET Foundation. All rights reserved.
       <ProfilingSymbolsDir Condition="'$(DoNotDecorateComposeDir)' != 'true'">$([System.IO.Path]::Combine($(ProfilingSymbolsDir), $(_TFM)))</ProfilingSymbolsDir>
       <ProfilingSymbolsDir Condition="!HasTrailingSlash('$(ProfilingSymbolsDir)')">$(ProfilingSymbolsDir)\</ProfilingSymbolsDir>
 
-      <ComposeDir Condition="'$(ComposeDir)' != '' and '$(DoNotDecorateComposeDir)' != 'true'">$([System.IO.Path]::Combine($(ComposeDir), $(PlatformTarget)))</ComposeDir>
       <ComposeDir Condition="'$(ComposeDir)' == ''">$(DefaultComposeDir)</ComposeDir>
+      <ComposeDir Condition="'$(DoNotDecorateComposeDir)' != 'true'">$([System.IO.Path]::Combine($(ComposeDir), $(PlatformTarget)))</ComposeDir>
       <ComposeDir Condition="'$(DoNotDecorateComposeDir)' != 'true'">$([System.IO.Path]::Combine($(ComposeDir), $(_TFM)))</ComposeDir>
       <StoreArtifactXml>$([System.IO.Path]::Combine($(ComposeDir),"artifact.xml"))</StoreArtifactXml>
       <PublishDir>$([System.IO.Path]::GetFullPath($(ComposeDir)))</PublishDir>


### PR DESCRIPTION
this is to reflect changes in https://github.com/dotnet/core-setup/pull/2314

@eerhardt @gkhanna79 PTAL

cc @livarcocc this behavior should not be activated for preview1 but should be there for preview2
is this the correct time and branch ?

FYI @JunTaoLuo  User profiles store will start to be in  $HOME/.dotnet/{arch}/store/arch/tfm or %USERPROFILE%\.dotnet\<arch>\store\<arch>\<tfm> from preview2 on wards