### PR TITLE
Remove workaround in tests for Windows RuntimeIdentifier that's no longer needed

### DIFF
--- a/test/Microsoft.NET.TestFramework/ProjectConstruction/TestProject.cs
+++ b/test/Microsoft.NET.TestFramework/ProjectConstruction/TestProject.cs
@@ -155,11 +155,6 @@ namespace Microsoft.NET.TestFramework.ProjectConstruction
                     propertyGroup.Add(new XElement(ns + "RuntimeIdentifier", this.RuntimeIdentifier));
                 }
 
-                if (this.IsExe && targetFrameworks.Any(identifier => GetShortTargetFrameworkIdentifier(identifier).Equals("net", StringComparison.OrdinalIgnoreCase)))
-                {
-                    propertyGroup.Add(new XElement(ns + "RuntimeIdentifier", "win7-x86"));
-                }
-
                 //  Update SDK reference to the version under test
                 targetTestAsset.SetSdkVersion(projectXml);
                 


### PR DESCRIPTION
This removes a workaround in tests for an issue that has since been fixed.