### PR TITLE
Deploy copy-local package satellites correctly

### DIFF
--- a/TestAssets/TestProjects/DesktopUsingPackageWithSatellites/DesktopUsingPackageWithSatellites.csproj
+++ b/TestAssets/TestProjects/DesktopUsingPackageWithSatellites/DesktopUsingPackageWithSatellites.csproj
@@ -1,0 +1,12 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net46</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FluentValidation" Version="5.5.0" />
+  </ItemGroup>
+
+</Project>

--- a/TestAssets/TestProjects/DesktopUsingPackageWithSatellites/Program.cs
+++ b/TestAssets/TestProjects/DesktopUsingPackageWithSatellites/Program.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace TestApp
+{
+    class Program
+    {
+        static void Main()
+        {
+            Console.WriteLine("Hello World");
+        }
+    }
+}

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.PackageDependencyResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.PackageDependencyResolution.targets
@@ -494,7 +494,10 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <!-- Add the copy local items -->
     <ItemGroup>
-      <ReferenceCopyLocalPaths Include="@(AllCopyLocalItems)" />
+      <ReferenceCopyLocalPaths Include="@(AllCopyLocalItems)" Exclude="@(ResourceCopyLocalItems)" />
+      <ReferenceCopyLocalPaths Include="@(ResourceCopyLocalItems)" Condition="'@(ResourceCopyLocalItems)' != ''">
+        <DestinationSubDirectory>$([System.IO.Directory]::GetParent(%(ResourceCopyLocalItems.FullPath)).get_Name())\</DestinationSubDirectory>
+      </ReferenceCopyLocalPaths>
     </ItemGroup>
 
   </Target>

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildADesktopExe.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildADesktopExe.cs
@@ -377,5 +377,24 @@ namespace DefaultReferences
                 "DesktopNeedsBindingRedirects.exe.config"
             });
         }
+
+        [WindowsOnlyFact]
+        public void It_places_package_satellites_correctly()
+        {
+            var testAsset = _testAssetsManager
+              .CopyTestAsset("DesktopUsingPackageWithSatellites")
+              .WithSource()
+              .Restore(Log);
+
+            var buildCommand = new BuildCommand(Log, testAsset.TestRoot);
+            buildCommand
+                .Execute()
+                .Should()
+                .Pass();
+
+            var outputDirectory = buildCommand.GetOutputDirectory("net46");
+            outputDirectory.Should().NotHaveFile("FluentValidation.resources.dll");
+            outputDirectory.Should().HaveFile(@"fr\FluentValidation.resources.dll");
+        }
     }
 }

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildADesktopExe.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildADesktopExe.cs
@@ -378,13 +378,28 @@ namespace DefaultReferences
             });
         }
 
-        [WindowsOnlyFact]
-        public void It_places_package_satellites_correctly()
+        [WindowsOnlyTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void It_places_package_satellites_correctly(bool crossTarget)
         {
             var testAsset = _testAssetsManager
-              .CopyTestAsset("DesktopUsingPackageWithSatellites")
-              .WithSource()
-              .Restore(Log);
+              .CopyTestAsset(
+                  "DesktopUsingPackageWithSatellites", 
+                  identifier: crossTarget ? "_cross" : "")
+              .WithSource();
+
+            if (crossTarget)
+            {
+                 testAsset = testAsset.WithProjectChanges(project =>
+                 {
+                     var ns = project.Root.Name.Namespace;
+                     var propertyGroup = project.Root.Elements(ns + "PropertyGroup").First();
+                     propertyGroup.Element(ns + "TargetFramework").Name += "s";
+                 });
+            }
+
+            testAsset.Restore(Log);
 
             var buildCommand = new BuildCommand(Log, testAsset.TestRoot);
             buildCommand


### PR DESCRIPTION
**Customer scenario**

Targeting desktop and consuming any package containing satellite assemblies. The satellite assemblies were not deployed to the correct location (on build, publish was OK) and so they simply do not load as expected.

**Bugs this fixes**

#1006 

**Workarounds, if any**

None.

**Risk**

Low. The change is scoped to the case that is failing.

**Performance impact**

Minimal. Some additional path computation is done, but only in the case that is currently broken.

**Root cause analysis**

Lack of test coverage for intersection of desktop-targeting and packages with satellite assemblies. Test gap is closed along with the change.

**How was the bug found?**

Customer reported and identified as blocking on several email threads with customers and partners.

@dsplaisted @dotnet/dotnet-cli