### PR TITLE
Raise Log Messages in assets file to MSBuild items

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenThatWeReportAssetsLogMessages.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenThatWeReportAssetsLogMessages.cs
@@ -108,8 +108,28 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             item.GetMetadata(MetadataKeys.ParentPackage).Should().Be(expectedPackage);
         }
 
-        // MultiTFM - Only one logged, 
-        // Converts LogLevel to Error/Warning/Info
+        [Fact]
+        public void ItHandlesInfoLogLevels()
+        {
+            var log = new MockLog();
+            string lockFileContent = CreateDefaultLockFileSnippet(
+                logs: new string[] {
+                    CreateLog(NuGetLogCode.NU1000, LogLevel.Information, "Sample message"),
+                    CreateLog(NuGetLogCode.NU1000, LogLevel.Minimal, "Sample message"),
+                    CreateLog(NuGetLogCode.NU1000, LogLevel.Verbose, "Sample message"),
+                    CreateLog(NuGetLogCode.NU1000, LogLevel.Debug, "Sample message"),
+                }
+            );
+
+            var task = GetExecutedTaskFromContents(lockFileContent, log);
+
+            log.Messages.Should().HaveCount(4);
+            task.DiagnosticMessages.Should().HaveCount(4);
+
+            task.DiagnosticMessages
+                    .Select(item => item.GetMetadata(MetadataKeys.Severity))
+                    .Should().OnlyContain(s => s == "Info");
+        }
 
         private static string CreateDefaultLockFileSnippet(string[] logs = null) => 
             CreateLockFileSnippet(

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenThatWeReportAssetsLogMessages.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenThatWeReportAssetsLogMessages.cs
@@ -1,0 +1,145 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using FluentAssertions;
+using NuGet.Common;
+using NuGet.ProjectModel;
+using System;
+using System.Linq;
+using Xunit;
+using static Microsoft.NET.Build.Tasks.UnitTests.LockFileSnippets;
+
+namespace Microsoft.NET.Build.Tasks.UnitTests
+{
+    public class GivenThatWeReportAssetsLogMessages
+    {
+        [Fact]
+        public void ItReportsDiagnosticsWithNoPackage()
+        {
+            var log = new MockLog();
+            string lockFileContent = CreateDefaultLockFileSnippet(
+                logs: new string[] {
+                    CreateLog(NuGetLogCode.NU1000, LogLevel.Warning, "Sample warning")
+                }
+            );
+
+            var task = GetExecutedTaskFromContents(lockFileContent, log);
+
+            task.DiagnosticMessages.Should().HaveCount(1);
+            log.Messages.Should().HaveCount(1);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData(new object[] { new string[0] })]
+        public void ItReportsZeroDiagnosticsWithNoLogs(string [] logsJson)
+        {
+            var log = new MockLog();
+            string lockFileContent = CreateDefaultLockFileSnippet(logsJson);
+
+            var task = GetExecutedTaskFromContents(lockFileContent, log);
+            
+            task.DiagnosticMessages.Should().BeEmpty();
+            log.Messages.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void ItReportsDiagnosticsMetadataWithLogs()
+        {
+            var log = new MockLog();
+            string lockFileContent = CreateDefaultLockFileSnippet(
+                logs: new string[] {
+                    CreateLog(NuGetLogCode.NU1000, LogLevel.Error, "Sample error",
+                        filePath: "path/to/project.csproj",
+                        libraryId: "LibA",
+                        targetGraphs: new string[]{ ".NETCoreApp,Version=v1.0" }),
+                    CreateLog(NuGetLogCode.NU1001, LogLevel.Warning, "Sample warning",
+                        libraryId: "LibB",
+                        targetGraphs: new string[]{ ".NETCoreApp,Version=v1.0" })
+                }
+            );
+
+            var task = GetExecutedTaskFromContents(lockFileContent, log);
+
+            log.Messages.Should().HaveCount(2);
+            task.DiagnosticMessages.Should().HaveCount(2);
+
+            Action<string,string,string> checkMetadata = (key, val1, val2) => {
+                task.DiagnosticMessages
+                    .Select(item => item.GetMetadata(key))
+                    .Should().Contain(new string[] { val1, val2 });
+            };
+
+            checkMetadata(MetadataKeys.DiagnosticCode, "NU1000", "NU1001");
+            checkMetadata(MetadataKeys.Severity, "Error", "Warning");
+            checkMetadata(MetadataKeys.Message, "Sample error", "Sample warning");
+            checkMetadata(MetadataKeys.FilePath, "", "path/to/project.csproj");
+            checkMetadata(MetadataKeys.ParentTarget, ".NETCoreApp,Version=v1.0", ".NETCoreApp,Version=v1.0");
+            checkMetadata(MetadataKeys.ParentPackage, "LibA/1.2.3", "LibB/1.2.3");
+        }
+
+        [Theory]
+        [InlineData(null, null)]
+        [InlineData(new string[] { ".NETCoreApp,Version=v1.0" }, null)]
+        [InlineData(null, "LibA")]
+        [InlineData(new string[] { ".NETCoreApp,Version=v1.0" }, "LibA")]
+        public void ItReportsDiagnosticsWithAllTargetLibraryCases(string[] targetGraphs, string libraryId)
+        {
+            var log = new MockLog();
+            string lockFileContent = CreateDefaultLockFileSnippet(
+                logs: new string[] {
+                    CreateLog(NuGetLogCode.NU1000, LogLevel.Warning, "Sample warning", 
+                        filePath: "path/to/project.csproj",
+                        libraryId: libraryId,
+                        targetGraphs: targetGraphs)
+                }
+            );
+
+            var task = GetExecutedTaskFromContents(lockFileContent, log);
+
+            log.Messages.Should().HaveCount(1);
+            task.DiagnosticMessages.Should().HaveCount(1);
+            var item = task.DiagnosticMessages.First();
+
+            string expectedTarget = targetGraphs != null ? targetGraphs[0] : string.Empty;
+            string expectedPackage = libraryId != null && targetGraphs != null ? "LibA/1.2.3" : string.Empty;
+
+            item.GetMetadata(MetadataKeys.ParentTarget).Should().Be(expectedTarget);
+            item.GetMetadata(MetadataKeys.ParentPackage).Should().Be(expectedPackage);
+        }
+
+        // MultiTFM - Only one logged, 
+        // Converts LogLevel to Error/Warning/Info
+
+        private static string CreateDefaultLockFileSnippet(string[] logs = null) => 
+            CreateLockFileSnippet(
+                targets: new string[] {
+                    CreateTarget(".NETCoreApp,Version=v1.0", TargetLibA, TargetLibB, TargetLibC),
+                },
+                libraries: new string[] { LibADefn, LibBDefn, LibCDefn },
+                projectFileDependencyGroups: new string[] {
+                    CreateProjectFileDependencyGroup("", "LibA >= 1.2.3"), // ==> Top Level Dependency
+                    NETCoreGroup
+                },
+                logs: logs
+            );
+
+        private ReportAssetsLogMessages GetExecutedTaskFromContents(string lockFileContents, MockLog logger)
+        {
+            var lockFile = TestLockFiles.CreateLockFile(lockFileContents);
+            return GetExecutedTask(lockFile, logger);
+        }
+
+        private ReportAssetsLogMessages GetExecutedTask(LockFile lockFile, MockLog logger)
+        {
+            var task = new ReportAssetsLogMessages(lockFile, logger)
+            {
+                ProjectAssetsFile = lockFile.Path,
+            };
+
+            task.Execute().Should().BeTrue();
+
+            return task;
+        }
+    }
+}

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenThatWeReportAssetsLogMessages.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenThatWeReportAssetsLogMessages.cs
@@ -14,7 +14,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
     public class GivenThatWeReportAssetsLogMessages
     {
         [Fact]
-        public void ItReportsDiagnosticsWithNoPackage()
+        public void ItReportsDiagnosticsWithMinimumData()
         {
             var log = new MockLog();
             string lockFileContent = CreateDefaultLockFileSnippet(
@@ -79,11 +79,11 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
         }
 
         [Theory]
-        [InlineData(null, null)]
-        [InlineData(new string[] { ".NETCoreApp,Version=v1.0" }, null)]
-        [InlineData(null, "LibA")]
-        [InlineData(new string[] { ".NETCoreApp,Version=v1.0" }, "LibA")]
-        public void ItReportsDiagnosticsWithAllTargetLibraryCases(string[] targetGraphs, string libraryId)
+        [InlineData(null, null, "", "")]
+        [InlineData(new string[] { ".NETCoreApp,Version=v1.0" }, null, ".NETCoreApp,Version=v1.0", "")]
+        [InlineData(null, "LibA", "", "")]
+        [InlineData(new string[] { ".NETCoreApp,Version=v1.0" }, "LibA", ".NETCoreApp,Version=v1.0", "LibA/1.2.3")]
+        public void ItReportsDiagnosticsWithAllTargetLibraryCases(string[] targetGraphs, string libraryId, string expectedTarget, string expectedPackage)
         {
             var log = new MockLog();
             string lockFileContent = CreateDefaultLockFileSnippet(
@@ -100,9 +100,6 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             log.Messages.Should().HaveCount(1);
             task.DiagnosticMessages.Should().HaveCount(1);
             var item = task.DiagnosticMessages.First();
-
-            string expectedTarget = targetGraphs != null ? targetGraphs[0] : string.Empty;
-            string expectedPackage = libraryId != null && targetGraphs != null ? "LibA/1.2.3" : string.Empty;
 
             item.GetMetadata(MetadataKeys.ParentTarget).Should().Be(expectedTarget);
             item.GetMetadata(MetadataKeys.ParentPackage).Should().Be(expectedPackage);
@@ -131,6 +128,68 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                     .Should().OnlyContain(s => s == "Info");
         }
 
+        [Theory]
+        [InlineData(new string[] { ".NETCoreApp,Version=v1.0", ".NETFramework,Version=v4.6.1" }, "LibA")]
+        [InlineData(new string[] { ".NETCoreApp,Version=v1.0" }, "LibA")]
+        public void ItHandlesMultiTFMScenarios(string[] targetGraphs, string libraryId)
+        {
+            var log = new MockLog();
+            string lockFileContent = CreateLockFileSnippet(
+                targets: new string[] {
+                    CreateTarget(".NETCoreApp,Version=v1.0", TargetLibA, TargetLibB, TargetLibC),
+                    CreateTarget(".NETFramework,Version=v4.6.1", TargetLibA, TargetLibB, TargetLibC),
+                },
+                libraries: new string[] { LibADefn, LibBDefn, LibCDefn },
+                projectFileDependencyGroups: new string[] {
+                    ProjectGroup, NETCoreGroup, NET461Group
+                },
+                logs: new string[] {
+                    CreateLog(NuGetLogCode.NU1000, LogLevel.Warning, "Sample warning",
+                        filePath: "path/to/project.csproj",
+                        libraryId: libraryId,
+                        targetGraphs: targetGraphs)
+                }
+            );            
+
+            var task = GetExecutedTaskFromContents(lockFileContent, log);
+
+            // a diagnostic for each target graph...
+            task.DiagnosticMessages.Should().HaveCount(targetGraphs.Length);
+
+            // ...but only one is logged
+            log.Messages.Should().HaveCount(1);
+
+            task.DiagnosticMessages
+                    .Select(item => item.GetMetadata(MetadataKeys.ParentTarget))
+                    .Should().Contain(targetGraphs);
+
+            task.DiagnosticMessages
+                    .Select(item => item.GetMetadata(MetadataKeys.ParentPackage))
+                    .Should().OnlyContain(v => v.StartsWith(libraryId));
+        }
+
+        [Fact]
+        public void ItSkipsInvalidEntries()
+        {
+            var log = new MockLog();
+            string lockFileContent = CreateDefaultLockFileSnippet(
+                logs: new string[] {
+                    CreateLog(NuGetLogCode.NU1000, LogLevel.Error, "Sample error that will be invalid"),
+                    CreateLog(NuGetLogCode.NU1001, LogLevel.Warning, "Sample warning"),
+                }
+            );
+            lockFileContent = lockFileContent.Replace("NU1000", "CA1000");
+
+            var task = GetExecutedTaskFromContents(lockFileContent, log);
+
+            log.Messages.Should().HaveCount(1);
+            task.DiagnosticMessages.Should().HaveCount(1);
+
+            task.DiagnosticMessages
+                    .Select(item => item.GetMetadata(MetadataKeys.DiagnosticCode))
+                    .Should().OnlyContain(v => v == "NU1001");
+        }
+
         private static string CreateDefaultLockFileSnippet(string[] logs = null) => 
             CreateLockFileSnippet(
                 targets: new string[] {
@@ -138,8 +197,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 },
                 libraries: new string[] { LibADefn, LibBDefn, LibCDefn },
                 projectFileDependencyGroups: new string[] {
-                    CreateProjectFileDependencyGroup("", "LibA >= 1.2.3"), // ==> Top Level Dependency
-                    NETCoreGroup
+                    ProjectGroup, NETCoreGroup
                 },
                 logs: logs
             );

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/LockFileSnippets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/LockFileSnippets.cs
@@ -147,6 +147,9 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
         public static readonly string NETCoreOsxGroup =
             CreateProjectFileDependencyGroup(".NETCoreApp,Version=v1.0/osx.10.11-x64");
 
+        public static readonly string NET461Group =
+            CreateProjectFileDependencyGroup(".NETFramework,Version=v4.6.1");
+
         public static readonly string LibADefn =
             CreateLibrary("LibA/1.2.3", "package", "lib/file/A.dll", "lib/file/B.dll", "lib/file/C.dll");
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/LockFileSnippets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/LockFileSnippets.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System;
 using System.Linq;
+using NuGet.Common;
 
 namespace Microsoft.NET.Build.Tasks.UnitTests
 {
@@ -14,16 +15,21 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
         public static string CreateLockFileSnippet(
             string[] targets,
             string[] libraries,
-            string[] projectFileDependencyGroups)
-        {
+            string[] projectFileDependencyGroups,
+            string[] logs = null)
+        {            
             return $@"{{
-              ""locked"": false,
-              ""version"": 2,
+              ""version"": 3,
               ""targets"": {{{string.Join(",", targets)}}},
               ""libraries"": {{{string.Join(",", libraries)}}},
+              {GetLogsPart(logs)}
               ""projectFileDependencyGroups"": {{{string.Join(",", projectFileDependencyGroups)}}}
+              
             }}";
         }
+
+        private static string GetLogsPart(string[] logs) 
+            => logs == null ? string.Empty : $@" ""logs"": [{string.Join(",", logs)}], ";
 
         public static string CreateLibrary(string nameVer, string type = "package", params string[] members)
         {
@@ -99,6 +105,28 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
         public static string CreateProjectFileDependencyGroup(string tfm, params string[] dependencies)
         {
             return $"\"{tfm}\": [{ToStringList(dependencies)}]";
+        }
+
+        public static string CreateLog(NuGetLogCode code, LogLevel level, string message,
+            string filePath = null,
+            string libraryId = null,
+            string warningLevel = "0",
+            string[] targetGraphs = null)
+        {
+            List<string> parts = new List<string>();
+
+            parts.Add($"\"code\": \"{code}\"");
+            parts.Add($"\"level\": \"{level}\"");
+            parts.Add($"\"message\": \"{message}\"");
+            parts.Add($"\"warningLevel\": \"{warningLevel}\"");
+
+            if (filePath != null) parts.Add($"\"filePath\": \"{filePath}\"");
+            if (libraryId != null) parts.Add($"\"libraryId\": \"{libraryId}\"");
+            if (targetGraphs != null) parts.Add($"\"targetGraphs\": [{ToStringList(targetGraphs)}]");
+
+            return $@"{{
+                {string.Join(",", parts)}
+            }}";
         }
 
         private static string ToStringList(params string[] members)

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/Microsoft.NET.Build.Tasks.UnitTests.csproj
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/Microsoft.NET.Build.Tasks.UnitTests.csproj
@@ -46,8 +46,10 @@
     <Compile Include="GivenACompilationOptionsConverter.cs" />
     <Compile Include="GivenAProduceContentsAssetsTask.cs" />
     <Compile Include="GivenAResolvePackageDependenciesTask.cs" />
+    <Compile Include="GivenThatWeReportAssetsLogMessages.cs" />
     <Compile Include="GivenUnresolvedSDKProjectItemsAndImplicitPackages.cs" />
     <Compile Include="LockFileSnippets.cs" />
+    <Compile Include="Mocks\MockLog.cs" />
     <Compile Include="Mocks\MockContentAssetPreprocessor.cs" />
     <Compile Include="Mocks\MockPackageResolver.cs" />
     <Compile Include="Mocks\MockTaskItem.cs" />

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/Mocks/MockLog.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/Mocks/MockLog.cs
@@ -1,0 +1,84 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Build.Framework;
+using System.Collections.Generic;
+
+namespace Microsoft.NET.Build.Tasks.UnitTests
+{
+    public class MockLog : ILog
+    {
+        public const string ErrorPrefix = "[ERROR]";
+        public const string WarningPrefix = "[WARNING]";
+        public const string MessagePrefix = "[MESSAGE]";
+
+        // track unformatted messages
+        public List<string> Messages { get; } = new List<string>();
+
+        public void LogError(string message, params object[] messageArgs)
+        {
+            Messages.Add($"{ErrorPrefix}: {message}");
+        }
+
+        public void LogMessage(string message, params object[] messageArgs)
+        {
+            Messages.Add($"{MessagePrefix}: {message}");
+        }
+
+        public void LogMessage(LogImportance importance, string message, params object[] messageArgs)
+        {
+            Messages.Add($"{MessagePrefix}: {message}");
+        }
+
+        public void LogWarning(string message, params object[] messageArgs)
+        {
+            Messages.Add($"{WarningPrefix}: {message}");
+        }
+
+        public void LogError(
+            string subcategory,
+            string errorCode,
+            string helpKeyword,
+            string file,
+            int lineNumber,
+            int columnNumber,
+            int endLineNumber,
+            int endColumnNumber,
+            string message,
+            params object[] messageArgs)
+        {
+            Messages.Add($"{ErrorPrefix}: {message}");
+        }
+
+        public void LogWarning(
+            string subcategory,
+            string warningCode,
+            string helpKeyword,
+            string file,
+            int lineNumber,
+            int columnNumber,
+            int endLineNumber,
+            int endColumnNumber,
+            string message,
+            params object[] messageArgs)
+        {
+            Messages.Add($"{WarningPrefix}: {message}");
+        }
+
+        public void LogMessage(
+            string subcategory,
+            string code,
+            string helpKeyword,
+            string file,
+            int lineNumber,
+            int columnNumber,
+            int endLineNumber,
+            int endColumnNumber,
+            MessageImportance importance,
+            string message,
+            params object[] messageArgs)
+        {
+            Messages.Add($"{MessagePrefix}: {message}");
+        }
+    }
+}

--- a/src/Tasks/Microsoft.NET.Build.Tasks/DiagnosticsHelper.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/DiagnosticsHelper.cs
@@ -14,9 +14,9 @@ namespace Microsoft.NET.Build.Tasks
     public sealed class DiagnosticsHelper
     {
         private readonly List<ITaskItem> _diagnosticMessages = new List<ITaskItem>();
-        private readonly TaskLoggingHelper _log;
+        private readonly ILog _log;
 
-        public DiagnosticsHelper(TaskLoggingHelper log)
+        public DiagnosticsHelper(ILog log)
         {
             _log = log;
         }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ILog.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ILog.cs
@@ -1,0 +1,132 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Build.Framework;
+
+namespace Microsoft.NET.Build.Tasks
+{
+    public enum LogImportance
+    {
+        Low = MessageImportance.Low,
+        Normal = MessageImportance.Normal,
+        High = MessageImportance.High
+    }
+
+
+    public interface ILog
+    {
+        //
+        // Summary:
+        //     Logs an error with the specified message.
+        //
+        // Parameters:
+        //   message:
+        //     The message.
+        //
+        //   messageArgs:
+        //     Optional arguments for formatting the message string.
+        //
+        // Exceptions:
+        //   T:System.ArgumentNullException:
+        //     message is null.
+        void LogError(string message, params object[] messageArgs);
+
+        //
+        // Summary:
+        //     Logs a message with the specified string.
+        //
+        // Parameters:
+        //   message:
+        //     The message.
+        //
+        //   messageArgs:
+        //     The arguments for formatting the message.
+        //
+        // Exceptions:
+        //   T:System.ArgumentNullException:
+        //     message is null.
+        void LogMessage(string message, params object[] messageArgs);
+
+        //
+        // Summary:
+        //     Logs a message with the specified string and importance.
+        //
+        // Parameters:
+        //   importance:
+        //     One of the enumeration values that specifies the importance of the message.
+        //
+        //   message:
+        //     The message.
+        //
+        //   messageArgs:
+        //     The arguments for formatting the message.
+        //
+        // Exceptions:
+        //   T:System.ArgumentNullException:
+        //     message is null.
+        void LogMessage(LogImportance importance, string message, params object[] messageArgs);
+
+        //
+        // Summary:
+        //     Logs a warning with the specified message.
+        //
+        // Parameters:
+        //   message:
+        //     The message.
+        //
+        //   messageArgs:
+        //     Optional arguments for formatting the message string.
+        //
+        // Exceptions:
+        //   T:System.ArgumentNullException:
+        //     message is null.
+        void LogWarning(string message, params object[] messageArgs);
+
+        /// <summary>
+        /// Logs an error using the specified string and other error details.
+        /// </summary>
+        void LogError(
+            string subcategory,
+            string errorCode,
+            string helpKeyword,
+            string file,
+            int lineNumber,
+            int columnNumber,
+            int endLineNumber,
+            int endColumnNumber,
+            string message,
+            params object[] messageArgs);
+
+        /// <summary>
+        /// Logs a warning using the specified string and other warning details.
+        /// </summary>
+        void LogWarning(
+            string subcategory,
+            string warningCode,
+            string helpKeyword,
+            string file,
+            int lineNumber,
+            int columnNumber,
+            int endLineNumber,
+            int endColumnNumber,
+            string message,
+            params object[] messageArgs);
+
+        /// <summary>
+        /// Logs a message using the specified string and other message details.
+        /// </summary>
+        void LogMessage(
+            string subcategory,
+            string code,
+            string helpKeyword,
+            string file,
+            int lineNumber,
+            int columnNumber,
+            int endLineNumber,
+            int endColumnNumber,
+            MessageImportance importance,
+            string message,
+            params object[] messageArgs);
+
+    }
+}

--- a/src/Tasks/Microsoft.NET.Build.Tasks/MSBuildLog.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/MSBuildLog.cs
@@ -1,0 +1,116 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+namespace Microsoft.NET.Build.Tasks
+{
+    internal class MSBuildLog : ILog
+    {
+        private readonly TaskLoggingHelper _logger;
+
+        public MSBuildLog(TaskLoggingHelper logger)
+        {
+            _logger = logger;
+        }
+
+        public void LogError(string message, params object[] messageArgs)
+        {
+            _logger.LogError(message, messageArgs);
+        }
+
+        public void LogMessage(string message, params object[] messageArgs)
+        {
+            _logger.LogMessage(message, messageArgs);
+        }
+
+        public void LogMessage(LogImportance importance, string message, params object[] messageArgs)
+        {
+            _logger.LogMessage((MessageImportance)importance, message, messageArgs);
+        }
+
+        public void LogWarning(string message, params object[] messageArgs)
+        {
+            _logger.LogWarning(message, messageArgs);
+        }
+
+        public void LogError(
+            string subcategory,
+            string errorCode,
+            string helpKeyword,
+            string file,
+            int lineNumber,
+            int columnNumber,
+            int endLineNumber,
+            int endColumnNumber,
+            string message,
+            params object[] messageArgs)
+        {
+            _logger.LogError(
+                subcategory,
+                errorCode,
+                helpKeyword,
+                file,
+                lineNumber,
+                columnNumber,
+                endLineNumber,
+                endColumnNumber,
+                message,
+                messageArgs);
+        }
+
+        public void LogWarning(
+            string subcategory,
+            string warningCode,
+            string helpKeyword,
+            string file,
+            int lineNumber,
+            int columnNumber,
+            int endLineNumber,
+            int endColumnNumber,
+            string message,
+            params object[] messageArgs)
+        {
+            _logger.LogWarning(
+                subcategory,
+                warningCode,
+                helpKeyword,
+                file,
+                lineNumber,
+                columnNumber,
+                endLineNumber,
+                endColumnNumber,
+                message,
+                messageArgs);
+        }
+
+        public void LogMessage(
+            string subcategory,
+            string code,
+            string helpKeyword,
+            string file,
+            int lineNumber,
+            int columnNumber,
+            int endLineNumber,
+            int endColumnNumber,
+            MessageImportance importance,
+            string message,
+            params object[] messageArgs)
+        {
+            _logger.LogMessage(
+                subcategory,
+                code,
+                helpKeyword,
+                file,
+                lineNumber,
+                columnNumber,
+                endLineNumber,
+                endColumnNumber,
+                importance,
+                message,
+                messageArgs);
+        }
+    }
+}

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Microsoft.NET.Build.Tasks.csproj
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Microsoft.NET.Build.Tasks.csproj
@@ -41,6 +41,8 @@
     <Compile Include="CheckForImplicitPackageReferenceOverrides.cs" />
     <Compile Include="DiagnosticMessageSeverity.cs" />
     <Compile Include="DiagnosticsHelper.cs" />
+    <Compile Include="ILog.cs" />
+    <Compile Include="MSBuildLog.cs" />
     <Compile Include="NETSdkError.cs" />
     <Compile Include="LockFileLookup.cs" />
     <Compile Include="FrameworkReferenceResolver.cs" />

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Microsoft.NET.Build.Tasks.csproj
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Microsoft.NET.Build.Tasks.csproj
@@ -47,6 +47,7 @@
     <Compile Include="BuildErrorException.cs" />
     <Compile Include="CollectSDKReferencesDesignTime.cs" />
     <Compile Include="ReferenceInfo.cs" />
+    <Compile Include="ReportAssetsLogMessages.cs" />
     <Compile Include="Resources\Strings.Designer.cs">
       <DesignTime>True</DesignTime>
       <AutoGen>True</AutoGen>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ReportAssetsLogMessages.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ReportAssetsLogMessages.cs
@@ -2,13 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Build.Framework;
-using Microsoft.Build.Utilities;
 using NuGet.Common;
 using NuGet.ProjectModel;
-using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 
 namespace Microsoft.NET.Build.Tasks
 {

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ReportAssetsLogMessages.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ReportAssetsLogMessages.cs
@@ -1,0 +1,125 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using NuGet.Common;
+using NuGet.ProjectModel;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Microsoft.NET.Build.Tasks
+{
+    /// <summary>
+    /// Report Log Messages in the assets file to MSBuild and raise them as 
+    /// DiagnosticMessage items that can be consumed downstream (e.g. by the
+    /// dependency node in the solution explorer)
+    /// </summary>
+    public sealed class ReportAssetsLogMessages : TaskBase
+    {
+        private LockFile _lockFile;
+
+        #region Outputs
+
+        // Only output is 'DiagnosticMessages' which is in the base class TaskBase
+
+        #endregion
+
+        #region Inputs
+
+        /// <summary>
+        /// The assets file to process
+        /// </summary>
+        [Required]
+        public string ProjectAssetsFile
+        {
+            get; set;
+        }
+
+        #endregion
+
+        public ReportAssetsLogMessages()
+        {
+        }
+
+        #region Test Support
+
+        internal ReportAssetsLogMessages(LockFile lockFile, ILog logger)
+            : base(logger)
+        {
+            _lockFile = lockFile;
+        }
+
+        #endregion
+
+        private LockFile LockFile
+        {
+            get
+            {
+                if (_lockFile == null)
+                {
+                    _lockFile = new LockFileCache(BuildEngine4).GetLockFile(ProjectAssetsFile);
+                }
+
+                return _lockFile;
+            }
+        }
+
+        protected override void ExecuteCore()
+        {
+            foreach (var message in LockFile.LogMessages)
+            {
+                AddMessage(message);
+            }
+        }
+
+        private void AddMessage(IAssetsLogMessage message)
+        {
+            var logToMsBuild = true;
+            var targetGraphs = message.GetTargetGraphs(LockFile);
+
+            targetGraphs = targetGraphs.Any() ? targetGraphs : new LockFileTarget[] { null };
+
+            foreach (var target in targetGraphs)
+            {
+                var targetLib = message.LibraryId == null ? null : target?.GetTargetLibrary(message.LibraryId);
+
+                Diagnostics.Add(
+                    message.Code.ToString(),
+                    message.Message,
+                    message.FilePath,
+                    FromLogLevel(message.Level),
+                    message.StartLineNumber,
+                    message.StartColumnNumber,
+                    message.EndLineNumber,
+                    message.EndColumnNumber,
+                    target?.Name,
+                    targetLib == null ? null : $"{targetLib.Name}/{targetLib.Version.ToNormalizedString()}",
+                    logToMsBuild);
+
+                logToMsBuild = false; // only write first instance of this diagnostic to msbuild
+            }
+        }
+
+        private static DiagnosticMessageSeverity FromLogLevel(LogLevel level)
+        {
+            switch (level)
+            {
+                case LogLevel.Error:
+                    return DiagnosticMessageSeverity.Error;
+
+                case LogLevel.Warning:
+                    return DiagnosticMessageSeverity.Warning;
+
+                case LogLevel.Debug:
+                case LogLevel.Verbose:
+                case LogLevel.Information:
+                case LogLevel.Minimal:
+                default:
+                    return DiagnosticMessageSeverity.Info;
+            }
+        }
+    }
+}

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ReportAssetsLogMessages.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ReportAssetsLogMessages.cs
@@ -42,7 +42,7 @@ namespace Microsoft.NET.Build.Tasks
 
         #region Test Support
 
-        internal ReportAssetsLogMessages(LockFile lockFile, ILog logger)
+        public ReportAssetsLogMessages(LockFile lockFile, ILog logger)
             : base(logger)
         {
             _lockFile = lockFile;

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageDependencies.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageDependencies.cs
@@ -163,7 +163,6 @@ namespace Microsoft.NET.Build.Tasks
             ReadProjectFileDependencies();
             RaiseLockFileTargets();
             GetPackageAndFileDefinitions();
-            GetDependencyDiagnostics();
         }
 
         private void ReadProjectFileDependencies()
@@ -399,64 +398,6 @@ namespace Microsoft.NET.Build.Tasks
 
                     // map each file key to a Type metadata value
                     SaveFileKeyType(fileKey, fileGroup);
-                }
-            }
-        }
-
-        private void GetDependencyDiagnostics()
-        {
-            Dictionary<string, string> projectDeps = LockFile.GetProjectFileDependencies();
-
-            // Temporarily suppress MSBuild logging because these diagnostics are also 
-            // reported by NuGet. This will no longer be necessary when NuGet moves 
-            // these diagnostics into the lockfile: 
-            // - https://github.com/NuGet/Home/issues/1599
-            // - https://github.com/dotnet/sdk/issues/585
-            bool logToMsBuild = false;
-
-            // if a project dependency is not in the list of libs, then it is an unresolved reference
-            var unresolvedDeps = projectDeps.Where(dep =>
-                null == LockFile.Libraries.FirstOrDefault(lib =>
-                    string.Equals(lib.Name, dep.Key, StringComparison.OrdinalIgnoreCase)));
-
-            foreach (var target in LockFile.Targets)
-            {
-                foreach (var dep in unresolvedDeps)
-                {
-                    string packageId = dep.Key;
-                    packageId += dep.Value == null ? string.Empty : $"/{dep.Value}";
-
-                    Diagnostics.Add(nameof(Strings.NU1001),
-                        string.Format(CultureInfo.CurrentCulture, Strings.NU1001, packageId),
-                        ProjectPath,
-                        DiagnosticMessageSeverity.Warning,
-                        1, 0,
-                        target.Name,
-                        packageId,
-                        logToMSBuild: logToMsBuild
-                        );
-                }
-
-                // report diagnostic if project dependency version does not match library version
-                foreach (var dep in projectDeps)
-                {
-                    var library = target.Libraries.FirstOrDefault(lib =>
-                        string.Equals(lib.Name, dep.Key, StringComparison.OrdinalIgnoreCase));
-                    var libraryVersion = library?.Version?.ToNormalizedString();
-
-                    if (libraryVersion != null && dep.Value != null &&
-                        !string.Equals(libraryVersion, dep.Value, StringComparison.OrdinalIgnoreCase))
-                    {
-                        Diagnostics.Add(nameof(Strings.NU1012),
-                            string.Format(CultureInfo.CurrentCulture, Strings.NU1012, library.Name, dep.Value, libraryVersion),
-                            ProjectPath,
-                            DiagnosticMessageSeverity.Warning,
-                            1, 0,
-                            target.Name,
-                            $"{library.Name}/{libraryVersion}", 
-                            logToMSBuild: logToMsBuild
-                            );
-                    }
                 }
             }
         }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageDependencies.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageDependencies.cs
@@ -340,7 +340,6 @@ namespace Microsoft.NET.Build.Tasks
                 string version;
                 if (!resolvedPackageVersions.TryGetValue(deps.Id, out version))
                 {
-                    Log.LogError(Strings.UnexpectedDependencyWithNoVersionNumber, deps.Id);
                     continue;
                 }
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/TaskBase.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/TaskBase.cs
@@ -49,8 +49,17 @@ namespace Microsoft.NET.Build.Tasks
         // no reason for outside classes to derive from this class.
         internal TaskBase()
         {
-            _diagnostics = new DiagnosticsHelper(Log);
+            _diagnostics = new DiagnosticsHelper(new MSBuildLog(Log));
         }
+
+        #region Test Support
+
+        internal TaskBase(ILog logger)
+        {
+            _diagnostics = new DiagnosticsHelper(logger ?? new MSBuildLog(Log));
+        }
+
+        #endregion
 
         public override bool Execute()
         {

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.PackageDependencyResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.PackageDependencyResolution.targets
@@ -43,6 +43,8 @@ Copyright (c) .NET Foundation. All rights reserved.
     <UseTargetPlatformAsNuGetTargetMoniker Condition="'$(UseTargetPlatformAsNuGetTargetMoniker)' == '' AND '$(TargetFrameworkMoniker)' == '.NETCore,Version=v5.0'">true</UseTargetPlatformAsNuGetTargetMoniker>
     <NuGetTargetMoniker Condition="'$(NuGetTargetMoniker)' == '' AND '$(UseTargetPlatformAsNuGetTargetMoniker)' == 'true'">$(TargetPlatformIdentifier),Version=v$([System.Version]::Parse('$(TargetPlatformMinVersion)').ToString(3))</NuGetTargetMoniker>
     <NuGetTargetMoniker Condition="'$(NuGetTargetMoniker)' == '' AND '$(UseTargetPlatformAsNuGetTargetMoniker)' != 'true'">$(TargetFrameworkMoniker)</NuGetTargetMoniker>
+
+    <EmitAssetsLogMessages Condition="'$(EmitAssetsLogMessages)' == ''">false</EmitAssetsLogMessages>
   </PropertyGroup>
 
   <!-- Target Moniker + RID-->
@@ -150,7 +152,8 @@ Copyright (c) .NET Foundation. All rights reserved.
         the Visual Studio error list when a project is created before NuGet restore has
         run and created the assets file. -->
   <Target Name="RunResolvePackageDependencies"
-          Condition=" '$(DesignTimeBuild)' != 'true' Or Exists('$(ProjectAssetsFile)')">
+          Condition=" '$(DesignTimeBuild)' != 'true' Or Exists('$(ProjectAssetsFile)')"
+          DependsOnTargets="ReportAssetsLogMessages">
     <ResolvePackageDependencies
       ProjectPath="$(MSBuildProjectFullPath)"
       ProjectAssetsFile="$(ProjectAssetsFile)"
@@ -282,6 +285,42 @@ Copyright (c) .NET Foundation. All rights reserved.
     </CreateItem>
   </Target>
 
+  <!--
+    ============================================================
+                     ReportAssetsLogMessages
+
+    Report Log Messages in the assets file to MSBuild and raise them as 
+    DiagnosticMessage items that can be consumed downstream (e.g. by the
+    dependency node in the solution explorer)
+    ============================================================
+    -->
+
+  <UsingTask TaskName="Microsoft.NET.Build.Tasks.ReportAssetsLogMessages"
+             AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
+
+  <!-- The condition on this target causes it to be skipped during design-time builds if
+        the restore operation hasn't run yet.  This is to avoid displaying an error in
+        the Visual Studio error list when a project is created before NuGet restore has
+        run and created the assets file. -->
+  <Target Name="ReportAssetsLogMessages"
+          Condition="'$(EmitAssetsLogMessages)' == 'true' And ('$(DesignTimeBuild)' != 'true' Or Exists('$(ProjectAssetsFile)'))">
+    
+    <ReportAssetsLogMessages
+      ProjectAssetsFile="$(ProjectAssetsFile)"
+      ContinueOnError="ErrorAndContinue">
+
+      <Output TaskParameter="DiagnosticMessages" ItemName="DiagnosticMessages" />
+    </ReportAssetsLogMessages>
+    
+  </Target>
+
+  <PropertyGroup>
+    <EmitsDependencyDiagnosticMessages>
+      ReportAssetsLogMessages;
+      $(EmitsDependencyDiagnosticMessages)
+    </EmitsDependencyDiagnosticMessages>
+  </PropertyGroup>
+  
   <!--
     ============================================================
     HELPERS: Get Package and File Dependencies matching active TFM and RID

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.PackageDependencyResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.PackageDependencyResolution.targets
@@ -44,7 +44,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <NuGetTargetMoniker Condition="'$(NuGetTargetMoniker)' == '' AND '$(UseTargetPlatformAsNuGetTargetMoniker)' == 'true'">$(TargetPlatformIdentifier),Version=v$([System.Version]::Parse('$(TargetPlatformMinVersion)').ToString(3))</NuGetTargetMoniker>
     <NuGetTargetMoniker Condition="'$(NuGetTargetMoniker)' == '' AND '$(UseTargetPlatformAsNuGetTargetMoniker)' != 'true'">$(TargetFrameworkMoniker)</NuGetTargetMoniker>
 
-    <EmitAssetsLogMessages Condition="'$(EmitAssetsLogMessages)' == ''">false</EmitAssetsLogMessages>
+    <EmitAssetsLogMessages Condition="'$(EmitAssetsLogMessages)' == ''">true</EmitAssetsLogMessages>
   </PropertyGroup>
 
   <!-- Target Moniker + RID-->


### PR DESCRIPTION
Report Log Messages in the assets file to MSBuild and raise them as DiagnosticMessage items that can be consumed downstream (e.g. by the dependency node in the solution explorer). This PR adds new ReportAssetsLogMessages task/target, but initially disables it until NuGet stops sending duplicate warnings to error list. (Also E2E tests fail when this is enabled because the CLI used to run tests needs an updated NuGet)

**Customer scenario**

Currently, NuGet warnings are written directly to the error list, and do not appear in the solution explorer. NuGet has done some work to clean up error messages, and place them in the assets file. More details at: https://github.com/NuGet/Home/wiki/Restore-errors-and-warnings
Raising these errors will enable us to take advantage of improved messages, and ensures there is just one source providing diagnostics for the error list. 

**Bugs this fixes:** 

Fixes #585 
Fixes https://github.com/dotnet/sdk/issues/1026
Fixes https://github.com/dotnet/project-system/issues/774
https://github.com/dotnet/project-system/issues/1660

**Workarounds, if any**

N/A

**Risk**

Low. This change uses the existing DiagnosticsHelper to raise and log messages in the assets file

**Performance impact**

Low, since the lockfile is cached and read once.

**Is this a regression from a previous update?**
Not from RTW

**Root cause analysis:**
Planned Feature

**How was the bug found?**
Planned Feature

/cc @dsplaisted @livarcocc 
/cc @dotnet/project-system
/cc @emgarten  