### PR TITLE
Fix build break due to successful, but bad merge

### DIFF
--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildANetCoreApp.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildANetCoreApp.cs
@@ -291,9 +291,9 @@ public static class Program
             string[] extraArgs = new[] { "/p:TargetFramework=NETCOREAPP1.1" };
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject, testProject.Name)
-                .Restore(testProject.Name, extraArgs);
+                .Restore(Log, testProject.Name, extraArgs);
 
-            var buildCommand = new BuildCommand(Stage0MSBuild, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
 
             buildCommand
                 .Execute(extraArgs)

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToVerifyNuGetReferenceCompat.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToVerifyNuGetReferenceCompat.cs
@@ -176,7 +176,6 @@ namespace Microsoft.NET.Build.Tests
 
             var restoreCommand = testProjectTestAsset.GetRestoreCommand(Log, relativePath: testProjectName);
             restoreCommand.AddSource(Path.GetDirectoryName(_net461PackageReference.NupkgPath));
-            restoreCommand.CaptureStdOut();
             restoreCommand.Execute().Should().Fail();
         }
 
@@ -192,7 +191,6 @@ namespace Microsoft.NET.Build.Tests
 
             var restoreCommand = testProjectTestAsset.GetRestoreCommand(Log, relativePath: testProjectName);
             restoreCommand.AddSource(Path.GetDirectoryName(_net461PackageReference.NupkgPath));
-            restoreCommand.CaptureStdOut();
             restoreCommand.Execute().Should().Fail();
         }
 


### PR DESCRIPTION
Jenkins edge case: two changes that were green on their own produced a failing build when merged together even though there was no textual conflict.

@livarcocc @dsplaisted @eerhardt @dotnet/dotnet-cli 