### PR TITLE
Create profiling symbols by default.

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.ComposeStore.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.ComposeStore.targets
@@ -244,9 +244,13 @@ Copyright (c) .NET Foundation. All rights reserved.
       <RestoreProj>$([System.IO.Path]::Combine($(ComposeWorkingDir),"Restore.csproj"))</RestoreProj>          <!-- To minimize parsing huge input files during restore stage for packages -->
       <!-- Ensure any PublishDir has a trailing slash, so it can be concatenated -->
       <PublishDir Condition="!HasTrailingSlash('$(PublishDir)')">$(PublishDir)\</PublishDir>
-      <CreateProfilingSymbols Condition="'$(CreateProfilingSymbols)' == ''">false</CreateProfilingSymbols>
     </PropertyGroup>
-
+    
+    <PropertyGroup Condition="'$(CreateProfilingSymbols)' == ''">
+      <!-- There is no support for profiling symbols on OSX -->
+      <CreateProfilingSymbols Condition="$(RuntimeIdentifier.StartsWith('osx'))">false</CreateProfilingSymbols>
+      <CreateProfilingSymbols Condition="'$(CreateProfilingSymbols)' == ''">true</CreateProfilingSymbols>
+    </PropertyGroup>
 
     <NETSdkError Condition="Exists($(ComposeWorkingDir))"
                  ResourceName="FolderAlreadyExists"


### PR DESCRIPTION
@gkhanna79 @ramarag 

/cc @nguerrera 

Note: the tests needed to turn this option off because they are using `netcoreapp1.0`, which errors out when generating profiling pdbs.  We don't support `dotnet store` for `netcoreapp1.0`, so it makes sense to shut off profiling symbols in those tests. (which is what we were doing before this change)