### PR TITLE
Prepare localization handoff by running xlf converter

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.cs.resx
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.cs.resx
@@ -237,9 +237,6 @@
   <data name="FolderAlreadyExists" xml:space="preserve">
     <value>Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</value>
   </data>
-  <data name="IncorrectFilterFormat" xml:space="preserve">
-    <value>The filter profile {0} provided is of not the correct format</value>
-  </data>
   <data name="ParsingFiles" xml:space="preserve">
     <value>Parsing the Files : '{0}'</value>
   </data>
@@ -248,5 +245,53 @@
   </data>
   <data name="RuntimeIdentifierWasNotSpecified" xml:space="preserve">
     <value>Specify a RuntimeIdentifier</value>
+  </data>
+  <data name="IncorrectTargetFormat" xml:space="preserve">
+    <value>The target manifest {0} provided is of not the correct format</value>
+  </data>
+  <data name="AppHostHasBeenModified" xml:space="preserve">
+    <value>Unable to use '{0}' as application host executable as it does not contain the expected placeholder byte sequence '{1}' that would mark where the application name would be written.</value>
+  </data>
+  <data name="FileNameIsTooLong" xml:space="preserve">
+    <value>Given file name '{0}' is longer than 1024 bytes</value>
+  </data>
+  <data name="CannotHaveSelfContainedWithoutRuntimeIdentifier" xml:space="preserve">
+    <value>It is not supported to build or publish a self-contained application without specifying a RuntimeIdentifier.  Please either specify a RuntimeIdentifier or set SelfContained to false.</value>
+  </data>
+  <data name="ChoosingAssemblyVersion" xml:space="preserve">
+    <value>Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</value>
+  </data>
+  <data name="ChoosingFileVersion" xml:space="preserve">
+    <value>Choosing '{0}' because file version '{1}' is greater than '{2}'.</value>
+  </data>
+  <data name="ChoosingPlatformItem" xml:space="preserve">
+    <value>Choosing '{0}' because it is a platform item.</value>
+  </data>
+  <data name="ChoosingPreferredPackage" xml:space="preserve">
+    <value>Choosing '{0}' because it comes from a package that is preferred.</value>
+  </data>
+  <data name="ConflictCouldNotDetermineWinner" xml:space="preserve">
+    <value>Could not determine winner due to equal file and assembly versions.</value>
+  </data>
+  <data name="CouldNotDetermineWinner_DoesntExist" xml:space="preserve">
+    <value>Could not determine winner because '{0}' does not exist.</value>
+  </data>
+  <data name="CouldNotDetermineWinner_FileVersion" xml:space="preserve">
+    <value>Could not determine a winner because '{0}' has no file version.</value>
+  </data>
+  <data name="CouldNotDetermineWinner_NotAnAssembly" xml:space="preserve">
+    <value>Could not determine a winner because '{0}' is not an assembly.</value>
+  </data>
+  <data name="EncounteredConflict" xml:space="preserve">
+    <value>Encountered conflict between '{0}' and '{1}'.</value>
+  </data>
+  <data name="CouldNotLoadPlatformManifest" xml:space="preserve">
+    <value>Could not load PlatformManifest from '{0}' because it did not exist.</value>
+  </data>
+  <data name="ErrorParsingPlatformManifest" xml:space="preserve">
+    <value>Error parsing PlatformManifest from '{0}' line {1}.  Lines must have the format {2}.</value>
+  </data>
+  <data name="ErrorParsingPlatformManifestInvalidValue" xml:space="preserve">
+    <value>Error parsing PlatformManifest from '{0}' line {1}.  {2} '{3}' was invalid.</value>
   </data>
 </root>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.de.resx
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.de.resx
@@ -237,9 +237,6 @@
   <data name="FolderAlreadyExists" xml:space="preserve">
     <value>Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</value>
   </data>
-  <data name="IncorrectFilterFormat" xml:space="preserve">
-    <value>The filter profile {0} provided is of not the correct format</value>
-  </data>
   <data name="ParsingFiles" xml:space="preserve">
     <value>Parsing the Files : '{0}'</value>
   </data>
@@ -248,5 +245,53 @@
   </data>
   <data name="RuntimeIdentifierWasNotSpecified" xml:space="preserve">
     <value>Specify a RuntimeIdentifier</value>
+  </data>
+  <data name="IncorrectTargetFormat" xml:space="preserve">
+    <value>The target manifest {0} provided is of not the correct format</value>
+  </data>
+  <data name="AppHostHasBeenModified" xml:space="preserve">
+    <value>Unable to use '{0}' as application host executable as it does not contain the expected placeholder byte sequence '{1}' that would mark where the application name would be written.</value>
+  </data>
+  <data name="FileNameIsTooLong" xml:space="preserve">
+    <value>Given file name '{0}' is longer than 1024 bytes</value>
+  </data>
+  <data name="CannotHaveSelfContainedWithoutRuntimeIdentifier" xml:space="preserve">
+    <value>It is not supported to build or publish a self-contained application without specifying a RuntimeIdentifier.  Please either specify a RuntimeIdentifier or set SelfContained to false.</value>
+  </data>
+  <data name="ChoosingAssemblyVersion" xml:space="preserve">
+    <value>Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</value>
+  </data>
+  <data name="ChoosingFileVersion" xml:space="preserve">
+    <value>Choosing '{0}' because file version '{1}' is greater than '{2}'.</value>
+  </data>
+  <data name="ChoosingPlatformItem" xml:space="preserve">
+    <value>Choosing '{0}' because it is a platform item.</value>
+  </data>
+  <data name="ChoosingPreferredPackage" xml:space="preserve">
+    <value>Choosing '{0}' because it comes from a package that is preferred.</value>
+  </data>
+  <data name="ConflictCouldNotDetermineWinner" xml:space="preserve">
+    <value>Could not determine winner due to equal file and assembly versions.</value>
+  </data>
+  <data name="CouldNotDetermineWinner_DoesntExist" xml:space="preserve">
+    <value>Could not determine winner because '{0}' does not exist.</value>
+  </data>
+  <data name="CouldNotDetermineWinner_FileVersion" xml:space="preserve">
+    <value>Could not determine a winner because '{0}' has no file version.</value>
+  </data>
+  <data name="CouldNotDetermineWinner_NotAnAssembly" xml:space="preserve">
+    <value>Could not determine a winner because '{0}' is not an assembly.</value>
+  </data>
+  <data name="EncounteredConflict" xml:space="preserve">
+    <value>Encountered conflict between '{0}' and '{1}'.</value>
+  </data>
+  <data name="CouldNotLoadPlatformManifest" xml:space="preserve">
+    <value>Could not load PlatformManifest from '{0}' because it did not exist.</value>
+  </data>
+  <data name="ErrorParsingPlatformManifest" xml:space="preserve">
+    <value>Error parsing PlatformManifest from '{0}' line {1}.  Lines must have the format {2}.</value>
+  </data>
+  <data name="ErrorParsingPlatformManifestInvalidValue" xml:space="preserve">
+    <value>Error parsing PlatformManifest from '{0}' line {1}.  {2} '{3}' was invalid.</value>
   </data>
 </root>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.es.resx
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.es.resx
@@ -237,9 +237,6 @@
   <data name="FolderAlreadyExists" xml:space="preserve">
     <value>Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</value>
   </data>
-  <data name="IncorrectFilterFormat" xml:space="preserve">
-    <value>The filter profile {0} provided is of not the correct format</value>
-  </data>
   <data name="ParsingFiles" xml:space="preserve">
     <value>Parsing the Files : '{0}'</value>
   </data>
@@ -248,5 +245,53 @@
   </data>
   <data name="RuntimeIdentifierWasNotSpecified" xml:space="preserve">
     <value>Specify a RuntimeIdentifier</value>
+  </data>
+  <data name="IncorrectTargetFormat" xml:space="preserve">
+    <value>The target manifest {0} provided is of not the correct format</value>
+  </data>
+  <data name="AppHostHasBeenModified" xml:space="preserve">
+    <value>Unable to use '{0}' as application host executable as it does not contain the expected placeholder byte sequence '{1}' that would mark where the application name would be written.</value>
+  </data>
+  <data name="FileNameIsTooLong" xml:space="preserve">
+    <value>Given file name '{0}' is longer than 1024 bytes</value>
+  </data>
+  <data name="CannotHaveSelfContainedWithoutRuntimeIdentifier" xml:space="preserve">
+    <value>It is not supported to build or publish a self-contained application without specifying a RuntimeIdentifier.  Please either specify a RuntimeIdentifier or set SelfContained to false.</value>
+  </data>
+  <data name="ChoosingAssemblyVersion" xml:space="preserve">
+    <value>Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</value>
+  </data>
+  <data name="ChoosingFileVersion" xml:space="preserve">
+    <value>Choosing '{0}' because file version '{1}' is greater than '{2}'.</value>
+  </data>
+  <data name="ChoosingPlatformItem" xml:space="preserve">
+    <value>Choosing '{0}' because it is a platform item.</value>
+  </data>
+  <data name="ChoosingPreferredPackage" xml:space="preserve">
+    <value>Choosing '{0}' because it comes from a package that is preferred.</value>
+  </data>
+  <data name="ConflictCouldNotDetermineWinner" xml:space="preserve">
+    <value>Could not determine winner due to equal file and assembly versions.</value>
+  </data>
+  <data name="CouldNotDetermineWinner_DoesntExist" xml:space="preserve">
+    <value>Could not determine winner because '{0}' does not exist.</value>
+  </data>
+  <data name="CouldNotDetermineWinner_FileVersion" xml:space="preserve">
+    <value>Could not determine a winner because '{0}' has no file version.</value>
+  </data>
+  <data name="CouldNotDetermineWinner_NotAnAssembly" xml:space="preserve">
+    <value>Could not determine a winner because '{0}' is not an assembly.</value>
+  </data>
+  <data name="EncounteredConflict" xml:space="preserve">
+    <value>Encountered conflict between '{0}' and '{1}'.</value>
+  </data>
+  <data name="CouldNotLoadPlatformManifest" xml:space="preserve">
+    <value>Could not load PlatformManifest from '{0}' because it did not exist.</value>
+  </data>
+  <data name="ErrorParsingPlatformManifest" xml:space="preserve">
+    <value>Error parsing PlatformManifest from '{0}' line {1}.  Lines must have the format {2}.</value>
+  </data>
+  <data name="ErrorParsingPlatformManifestInvalidValue" xml:space="preserve">
+    <value>Error parsing PlatformManifest from '{0}' line {1}.  {2} '{3}' was invalid.</value>
   </data>
 </root>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.fr.resx
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.fr.resx
@@ -237,9 +237,6 @@
   <data name="FolderAlreadyExists" xml:space="preserve">
     <value>Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</value>
   </data>
-  <data name="IncorrectFilterFormat" xml:space="preserve">
-    <value>The filter profile {0} provided is of not the correct format</value>
-  </data>
   <data name="ParsingFiles" xml:space="preserve">
     <value>Parsing the Files : '{0}'</value>
   </data>
@@ -248,5 +245,53 @@
   </data>
   <data name="RuntimeIdentifierWasNotSpecified" xml:space="preserve">
     <value>Specify a RuntimeIdentifier</value>
+  </data>
+  <data name="IncorrectTargetFormat" xml:space="preserve">
+    <value>The target manifest {0} provided is of not the correct format</value>
+  </data>
+  <data name="AppHostHasBeenModified" xml:space="preserve">
+    <value>Unable to use '{0}' as application host executable as it does not contain the expected placeholder byte sequence '{1}' that would mark where the application name would be written.</value>
+  </data>
+  <data name="FileNameIsTooLong" xml:space="preserve">
+    <value>Given file name '{0}' is longer than 1024 bytes</value>
+  </data>
+  <data name="CannotHaveSelfContainedWithoutRuntimeIdentifier" xml:space="preserve">
+    <value>It is not supported to build or publish a self-contained application without specifying a RuntimeIdentifier.  Please either specify a RuntimeIdentifier or set SelfContained to false.</value>
+  </data>
+  <data name="ChoosingAssemblyVersion" xml:space="preserve">
+    <value>Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</value>
+  </data>
+  <data name="ChoosingFileVersion" xml:space="preserve">
+    <value>Choosing '{0}' because file version '{1}' is greater than '{2}'.</value>
+  </data>
+  <data name="ChoosingPlatformItem" xml:space="preserve">
+    <value>Choosing '{0}' because it is a platform item.</value>
+  </data>
+  <data name="ChoosingPreferredPackage" xml:space="preserve">
+    <value>Choosing '{0}' because it comes from a package that is preferred.</value>
+  </data>
+  <data name="ConflictCouldNotDetermineWinner" xml:space="preserve">
+    <value>Could not determine winner due to equal file and assembly versions.</value>
+  </data>
+  <data name="CouldNotDetermineWinner_DoesntExist" xml:space="preserve">
+    <value>Could not determine winner because '{0}' does not exist.</value>
+  </data>
+  <data name="CouldNotDetermineWinner_FileVersion" xml:space="preserve">
+    <value>Could not determine a winner because '{0}' has no file version.</value>
+  </data>
+  <data name="CouldNotDetermineWinner_NotAnAssembly" xml:space="preserve">
+    <value>Could not determine a winner because '{0}' is not an assembly.</value>
+  </data>
+  <data name="EncounteredConflict" xml:space="preserve">
+    <value>Encountered conflict between '{0}' and '{1}'.</value>
+  </data>
+  <data name="CouldNotLoadPlatformManifest" xml:space="preserve">
+    <value>Could not load PlatformManifest from '{0}' because it did not exist.</value>
+  </data>
+  <data name="ErrorParsingPlatformManifest" xml:space="preserve">
+    <value>Error parsing PlatformManifest from '{0}' line {1}.  Lines must have the format {2}.</value>
+  </data>
+  <data name="ErrorParsingPlatformManifestInvalidValue" xml:space="preserve">
+    <value>Error parsing PlatformManifest from '{0}' line {1}.  {2} '{3}' was invalid.</value>
   </data>
 </root>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.it.resx
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.it.resx
@@ -237,9 +237,6 @@
   <data name="FolderAlreadyExists" xml:space="preserve">
     <value>Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</value>
   </data>
-  <data name="IncorrectFilterFormat" xml:space="preserve">
-    <value>The filter profile {0} provided is of not the correct format</value>
-  </data>
   <data name="ParsingFiles" xml:space="preserve">
     <value>Parsing the Files : '{0}'</value>
   </data>
@@ -248,5 +245,53 @@
   </data>
   <data name="RuntimeIdentifierWasNotSpecified" xml:space="preserve">
     <value>Specify a RuntimeIdentifier</value>
+  </data>
+  <data name="IncorrectTargetFormat" xml:space="preserve">
+    <value>The target manifest {0} provided is of not the correct format</value>
+  </data>
+  <data name="AppHostHasBeenModified" xml:space="preserve">
+    <value>Unable to use '{0}' as application host executable as it does not contain the expected placeholder byte sequence '{1}' that would mark where the application name would be written.</value>
+  </data>
+  <data name="FileNameIsTooLong" xml:space="preserve">
+    <value>Given file name '{0}' is longer than 1024 bytes</value>
+  </data>
+  <data name="CannotHaveSelfContainedWithoutRuntimeIdentifier" xml:space="preserve">
+    <value>It is not supported to build or publish a self-contained application without specifying a RuntimeIdentifier.  Please either specify a RuntimeIdentifier or set SelfContained to false.</value>
+  </data>
+  <data name="ChoosingAssemblyVersion" xml:space="preserve">
+    <value>Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</value>
+  </data>
+  <data name="ChoosingFileVersion" xml:space="preserve">
+    <value>Choosing '{0}' because file version '{1}' is greater than '{2}'.</value>
+  </data>
+  <data name="ChoosingPlatformItem" xml:space="preserve">
+    <value>Choosing '{0}' because it is a platform item.</value>
+  </data>
+  <data name="ChoosingPreferredPackage" xml:space="preserve">
+    <value>Choosing '{0}' because it comes from a package that is preferred.</value>
+  </data>
+  <data name="ConflictCouldNotDetermineWinner" xml:space="preserve">
+    <value>Could not determine winner due to equal file and assembly versions.</value>
+  </data>
+  <data name="CouldNotDetermineWinner_DoesntExist" xml:space="preserve">
+    <value>Could not determine winner because '{0}' does not exist.</value>
+  </data>
+  <data name="CouldNotDetermineWinner_FileVersion" xml:space="preserve">
+    <value>Could not determine a winner because '{0}' has no file version.</value>
+  </data>
+  <data name="CouldNotDetermineWinner_NotAnAssembly" xml:space="preserve">
+    <value>Could not determine a winner because '{0}' is not an assembly.</value>
+  </data>
+  <data name="EncounteredConflict" xml:space="preserve">
+    <value>Encountered conflict between '{0}' and '{1}'.</value>
+  </data>
+  <data name="CouldNotLoadPlatformManifest" xml:space="preserve">
+    <value>Could not load PlatformManifest from '{0}' because it did not exist.</value>
+  </data>
+  <data name="ErrorParsingPlatformManifest" xml:space="preserve">
+    <value>Error parsing PlatformManifest from '{0}' line {1}.  Lines must have the format {2}.</value>
+  </data>
+  <data name="ErrorParsingPlatformManifestInvalidValue" xml:space="preserve">
+    <value>Error parsing PlatformManifest from '{0}' line {1}.  {2} '{3}' was invalid.</value>
   </data>
 </root>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.ja.resx
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.ja.resx
@@ -237,9 +237,6 @@
   <data name="FolderAlreadyExists" xml:space="preserve">
     <value>Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</value>
   </data>
-  <data name="IncorrectFilterFormat" xml:space="preserve">
-    <value>The filter profile {0} provided is of not the correct format</value>
-  </data>
   <data name="ParsingFiles" xml:space="preserve">
     <value>Parsing the Files : '{0}'</value>
   </data>
@@ -248,5 +245,53 @@
   </data>
   <data name="RuntimeIdentifierWasNotSpecified" xml:space="preserve">
     <value>Specify a RuntimeIdentifier</value>
+  </data>
+  <data name="IncorrectTargetFormat" xml:space="preserve">
+    <value>The target manifest {0} provided is of not the correct format</value>
+  </data>
+  <data name="AppHostHasBeenModified" xml:space="preserve">
+    <value>Unable to use '{0}' as application host executable as it does not contain the expected placeholder byte sequence '{1}' that would mark where the application name would be written.</value>
+  </data>
+  <data name="FileNameIsTooLong" xml:space="preserve">
+    <value>Given file name '{0}' is longer than 1024 bytes</value>
+  </data>
+  <data name="CannotHaveSelfContainedWithoutRuntimeIdentifier" xml:space="preserve">
+    <value>It is not supported to build or publish a self-contained application without specifying a RuntimeIdentifier.  Please either specify a RuntimeIdentifier or set SelfContained to false.</value>
+  </data>
+  <data name="ChoosingAssemblyVersion" xml:space="preserve">
+    <value>Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</value>
+  </data>
+  <data name="ChoosingFileVersion" xml:space="preserve">
+    <value>Choosing '{0}' because file version '{1}' is greater than '{2}'.</value>
+  </data>
+  <data name="ChoosingPlatformItem" xml:space="preserve">
+    <value>Choosing '{0}' because it is a platform item.</value>
+  </data>
+  <data name="ChoosingPreferredPackage" xml:space="preserve">
+    <value>Choosing '{0}' because it comes from a package that is preferred.</value>
+  </data>
+  <data name="ConflictCouldNotDetermineWinner" xml:space="preserve">
+    <value>Could not determine winner due to equal file and assembly versions.</value>
+  </data>
+  <data name="CouldNotDetermineWinner_DoesntExist" xml:space="preserve">
+    <value>Could not determine winner because '{0}' does not exist.</value>
+  </data>
+  <data name="CouldNotDetermineWinner_FileVersion" xml:space="preserve">
+    <value>Could not determine a winner because '{0}' has no file version.</value>
+  </data>
+  <data name="CouldNotDetermineWinner_NotAnAssembly" xml:space="preserve">
+    <value>Could not determine a winner because '{0}' is not an assembly.</value>
+  </data>
+  <data name="EncounteredConflict" xml:space="preserve">
+    <value>Encountered conflict between '{0}' and '{1}'.</value>
+  </data>
+  <data name="CouldNotLoadPlatformManifest" xml:space="preserve">
+    <value>Could not load PlatformManifest from '{0}' because it did not exist.</value>
+  </data>
+  <data name="ErrorParsingPlatformManifest" xml:space="preserve">
+    <value>Error parsing PlatformManifest from '{0}' line {1}.  Lines must have the format {2}.</value>
+  </data>
+  <data name="ErrorParsingPlatformManifestInvalidValue" xml:space="preserve">
+    <value>Error parsing PlatformManifest from '{0}' line {1}.  {2} '{3}' was invalid.</value>
   </data>
 </root>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.ko.resx
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.ko.resx
@@ -237,9 +237,6 @@
   <data name="FolderAlreadyExists" xml:space="preserve">
     <value>Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</value>
   </data>
-  <data name="IncorrectFilterFormat" xml:space="preserve">
-    <value>The filter profile {0} provided is of not the correct format</value>
-  </data>
   <data name="ParsingFiles" xml:space="preserve">
     <value>Parsing the Files : '{0}'</value>
   </data>
@@ -248,5 +245,53 @@
   </data>
   <data name="RuntimeIdentifierWasNotSpecified" xml:space="preserve">
     <value>Specify a RuntimeIdentifier</value>
+  </data>
+  <data name="IncorrectTargetFormat" xml:space="preserve">
+    <value>The target manifest {0} provided is of not the correct format</value>
+  </data>
+  <data name="AppHostHasBeenModified" xml:space="preserve">
+    <value>Unable to use '{0}' as application host executable as it does not contain the expected placeholder byte sequence '{1}' that would mark where the application name would be written.</value>
+  </data>
+  <data name="FileNameIsTooLong" xml:space="preserve">
+    <value>Given file name '{0}' is longer than 1024 bytes</value>
+  </data>
+  <data name="CannotHaveSelfContainedWithoutRuntimeIdentifier" xml:space="preserve">
+    <value>It is not supported to build or publish a self-contained application without specifying a RuntimeIdentifier.  Please either specify a RuntimeIdentifier or set SelfContained to false.</value>
+  </data>
+  <data name="ChoosingAssemblyVersion" xml:space="preserve">
+    <value>Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</value>
+  </data>
+  <data name="ChoosingFileVersion" xml:space="preserve">
+    <value>Choosing '{0}' because file version '{1}' is greater than '{2}'.</value>
+  </data>
+  <data name="ChoosingPlatformItem" xml:space="preserve">
+    <value>Choosing '{0}' because it is a platform item.</value>
+  </data>
+  <data name="ChoosingPreferredPackage" xml:space="preserve">
+    <value>Choosing '{0}' because it comes from a package that is preferred.</value>
+  </data>
+  <data name="ConflictCouldNotDetermineWinner" xml:space="preserve">
+    <value>Could not determine winner due to equal file and assembly versions.</value>
+  </data>
+  <data name="CouldNotDetermineWinner_DoesntExist" xml:space="preserve">
+    <value>Could not determine winner because '{0}' does not exist.</value>
+  </data>
+  <data name="CouldNotDetermineWinner_FileVersion" xml:space="preserve">
+    <value>Could not determine a winner because '{0}' has no file version.</value>
+  </data>
+  <data name="CouldNotDetermineWinner_NotAnAssembly" xml:space="preserve">
+    <value>Could not determine a winner because '{0}' is not an assembly.</value>
+  </data>
+  <data name="EncounteredConflict" xml:space="preserve">
+    <value>Encountered conflict between '{0}' and '{1}'.</value>
+  </data>
+  <data name="CouldNotLoadPlatformManifest" xml:space="preserve">
+    <value>Could not load PlatformManifest from '{0}' because it did not exist.</value>
+  </data>
+  <data name="ErrorParsingPlatformManifest" xml:space="preserve">
+    <value>Error parsing PlatformManifest from '{0}' line {1}.  Lines must have the format {2}.</value>
+  </data>
+  <data name="ErrorParsingPlatformManifestInvalidValue" xml:space="preserve">
+    <value>Error parsing PlatformManifest from '{0}' line {1}.  {2} '{3}' was invalid.</value>
   </data>
 </root>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.pl.resx
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.pl.resx
@@ -237,9 +237,6 @@
   <data name="FolderAlreadyExists" xml:space="preserve">
     <value>Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</value>
   </data>
-  <data name="IncorrectFilterFormat" xml:space="preserve">
-    <value>The filter profile {0} provided is of not the correct format</value>
-  </data>
   <data name="ParsingFiles" xml:space="preserve">
     <value>Parsing the Files : '{0}'</value>
   </data>
@@ -248,5 +245,53 @@
   </data>
   <data name="RuntimeIdentifierWasNotSpecified" xml:space="preserve">
     <value>Specify a RuntimeIdentifier</value>
+  </data>
+  <data name="IncorrectTargetFormat" xml:space="preserve">
+    <value>The target manifest {0} provided is of not the correct format</value>
+  </data>
+  <data name="AppHostHasBeenModified" xml:space="preserve">
+    <value>Unable to use '{0}' as application host executable as it does not contain the expected placeholder byte sequence '{1}' that would mark where the application name would be written.</value>
+  </data>
+  <data name="FileNameIsTooLong" xml:space="preserve">
+    <value>Given file name '{0}' is longer than 1024 bytes</value>
+  </data>
+  <data name="CannotHaveSelfContainedWithoutRuntimeIdentifier" xml:space="preserve">
+    <value>It is not supported to build or publish a self-contained application without specifying a RuntimeIdentifier.  Please either specify a RuntimeIdentifier or set SelfContained to false.</value>
+  </data>
+  <data name="ChoosingAssemblyVersion" xml:space="preserve">
+    <value>Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</value>
+  </data>
+  <data name="ChoosingFileVersion" xml:space="preserve">
+    <value>Choosing '{0}' because file version '{1}' is greater than '{2}'.</value>
+  </data>
+  <data name="ChoosingPlatformItem" xml:space="preserve">
+    <value>Choosing '{0}' because it is a platform item.</value>
+  </data>
+  <data name="ChoosingPreferredPackage" xml:space="preserve">
+    <value>Choosing '{0}' because it comes from a package that is preferred.</value>
+  </data>
+  <data name="ConflictCouldNotDetermineWinner" xml:space="preserve">
+    <value>Could not determine winner due to equal file and assembly versions.</value>
+  </data>
+  <data name="CouldNotDetermineWinner_DoesntExist" xml:space="preserve">
+    <value>Could not determine winner because '{0}' does not exist.</value>
+  </data>
+  <data name="CouldNotDetermineWinner_FileVersion" xml:space="preserve">
+    <value>Could not determine a winner because '{0}' has no file version.</value>
+  </data>
+  <data name="CouldNotDetermineWinner_NotAnAssembly" xml:space="preserve">
+    <value>Could not determine a winner because '{0}' is not an assembly.</value>
+  </data>
+  <data name="EncounteredConflict" xml:space="preserve">
+    <value>Encountered conflict between '{0}' and '{1}'.</value>
+  </data>
+  <data name="CouldNotLoadPlatformManifest" xml:space="preserve">
+    <value>Could not load PlatformManifest from '{0}' because it did not exist.</value>
+  </data>
+  <data name="ErrorParsingPlatformManifest" xml:space="preserve">
+    <value>Error parsing PlatformManifest from '{0}' line {1}.  Lines must have the format {2}.</value>
+  </data>
+  <data name="ErrorParsingPlatformManifestInvalidValue" xml:space="preserve">
+    <value>Error parsing PlatformManifest from '{0}' line {1}.  {2} '{3}' was invalid.</value>
   </data>
 </root>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.pt-BR.resx
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.pt-BR.resx
@@ -237,9 +237,6 @@
   <data name="FolderAlreadyExists" xml:space="preserve">
     <value>Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</value>
   </data>
-  <data name="IncorrectFilterFormat" xml:space="preserve">
-    <value>The filter profile {0} provided is of not the correct format</value>
-  </data>
   <data name="ParsingFiles" xml:space="preserve">
     <value>Parsing the Files : '{0}'</value>
   </data>
@@ -248,5 +245,53 @@
   </data>
   <data name="RuntimeIdentifierWasNotSpecified" xml:space="preserve">
     <value>Specify a RuntimeIdentifier</value>
+  </data>
+  <data name="IncorrectTargetFormat" xml:space="preserve">
+    <value>The target manifest {0} provided is of not the correct format</value>
+  </data>
+  <data name="AppHostHasBeenModified" xml:space="preserve">
+    <value>Unable to use '{0}' as application host executable as it does not contain the expected placeholder byte sequence '{1}' that would mark where the application name would be written.</value>
+  </data>
+  <data name="FileNameIsTooLong" xml:space="preserve">
+    <value>Given file name '{0}' is longer than 1024 bytes</value>
+  </data>
+  <data name="CannotHaveSelfContainedWithoutRuntimeIdentifier" xml:space="preserve">
+    <value>It is not supported to build or publish a self-contained application without specifying a RuntimeIdentifier.  Please either specify a RuntimeIdentifier or set SelfContained to false.</value>
+  </data>
+  <data name="ChoosingAssemblyVersion" xml:space="preserve">
+    <value>Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</value>
+  </data>
+  <data name="ChoosingFileVersion" xml:space="preserve">
+    <value>Choosing '{0}' because file version '{1}' is greater than '{2}'.</value>
+  </data>
+  <data name="ChoosingPlatformItem" xml:space="preserve">
+    <value>Choosing '{0}' because it is a platform item.</value>
+  </data>
+  <data name="ChoosingPreferredPackage" xml:space="preserve">
+    <value>Choosing '{0}' because it comes from a package that is preferred.</value>
+  </data>
+  <data name="ConflictCouldNotDetermineWinner" xml:space="preserve">
+    <value>Could not determine winner due to equal file and assembly versions.</value>
+  </data>
+  <data name="CouldNotDetermineWinner_DoesntExist" xml:space="preserve">
+    <value>Could not determine winner because '{0}' does not exist.</value>
+  </data>
+  <data name="CouldNotDetermineWinner_FileVersion" xml:space="preserve">
+    <value>Could not determine a winner because '{0}' has no file version.</value>
+  </data>
+  <data name="CouldNotDetermineWinner_NotAnAssembly" xml:space="preserve">
+    <value>Could not determine a winner because '{0}' is not an assembly.</value>
+  </data>
+  <data name="EncounteredConflict" xml:space="preserve">
+    <value>Encountered conflict between '{0}' and '{1}'.</value>
+  </data>
+  <data name="CouldNotLoadPlatformManifest" xml:space="preserve">
+    <value>Could not load PlatformManifest from '{0}' because it did not exist.</value>
+  </data>
+  <data name="ErrorParsingPlatformManifest" xml:space="preserve">
+    <value>Error parsing PlatformManifest from '{0}' line {1}.  Lines must have the format {2}.</value>
+  </data>
+  <data name="ErrorParsingPlatformManifestInvalidValue" xml:space="preserve">
+    <value>Error parsing PlatformManifest from '{0}' line {1}.  {2} '{3}' was invalid.</value>
   </data>
 </root>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.ru.resx
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.ru.resx
@@ -237,9 +237,6 @@
   <data name="FolderAlreadyExists" xml:space="preserve">
     <value>Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</value>
   </data>
-  <data name="IncorrectFilterFormat" xml:space="preserve">
-    <value>The filter profile {0} provided is of not the correct format</value>
-  </data>
   <data name="ParsingFiles" xml:space="preserve">
     <value>Parsing the Files : '{0}'</value>
   </data>
@@ -248,5 +245,53 @@
   </data>
   <data name="RuntimeIdentifierWasNotSpecified" xml:space="preserve">
     <value>Specify a RuntimeIdentifier</value>
+  </data>
+  <data name="IncorrectTargetFormat" xml:space="preserve">
+    <value>The target manifest {0} provided is of not the correct format</value>
+  </data>
+  <data name="AppHostHasBeenModified" xml:space="preserve">
+    <value>Unable to use '{0}' as application host executable as it does not contain the expected placeholder byte sequence '{1}' that would mark where the application name would be written.</value>
+  </data>
+  <data name="FileNameIsTooLong" xml:space="preserve">
+    <value>Given file name '{0}' is longer than 1024 bytes</value>
+  </data>
+  <data name="CannotHaveSelfContainedWithoutRuntimeIdentifier" xml:space="preserve">
+    <value>It is not supported to build or publish a self-contained application without specifying a RuntimeIdentifier.  Please either specify a RuntimeIdentifier or set SelfContained to false.</value>
+  </data>
+  <data name="ChoosingAssemblyVersion" xml:space="preserve">
+    <value>Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</value>
+  </data>
+  <data name="ChoosingFileVersion" xml:space="preserve">
+    <value>Choosing '{0}' because file version '{1}' is greater than '{2}'.</value>
+  </data>
+  <data name="ChoosingPlatformItem" xml:space="preserve">
+    <value>Choosing '{0}' because it is a platform item.</value>
+  </data>
+  <data name="ChoosingPreferredPackage" xml:space="preserve">
+    <value>Choosing '{0}' because it comes from a package that is preferred.</value>
+  </data>
+  <data name="ConflictCouldNotDetermineWinner" xml:space="preserve">
+    <value>Could not determine winner due to equal file and assembly versions.</value>
+  </data>
+  <data name="CouldNotDetermineWinner_DoesntExist" xml:space="preserve">
+    <value>Could not determine winner because '{0}' does not exist.</value>
+  </data>
+  <data name="CouldNotDetermineWinner_FileVersion" xml:space="preserve">
+    <value>Could not determine a winner because '{0}' has no file version.</value>
+  </data>
+  <data name="CouldNotDetermineWinner_NotAnAssembly" xml:space="preserve">
+    <value>Could not determine a winner because '{0}' is not an assembly.</value>
+  </data>
+  <data name="EncounteredConflict" xml:space="preserve">
+    <value>Encountered conflict between '{0}' and '{1}'.</value>
+  </data>
+  <data name="CouldNotLoadPlatformManifest" xml:space="preserve">
+    <value>Could not load PlatformManifest from '{0}' because it did not exist.</value>
+  </data>
+  <data name="ErrorParsingPlatformManifest" xml:space="preserve">
+    <value>Error parsing PlatformManifest from '{0}' line {1}.  Lines must have the format {2}.</value>
+  </data>
+  <data name="ErrorParsingPlatformManifestInvalidValue" xml:space="preserve">
+    <value>Error parsing PlatformManifest from '{0}' line {1}.  {2} '{3}' was invalid.</value>
   </data>
 </root>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.tr.resx
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.tr.resx
@@ -237,9 +237,6 @@
   <data name="FolderAlreadyExists" xml:space="preserve">
     <value>Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</value>
   </data>
-  <data name="IncorrectFilterFormat" xml:space="preserve">
-    <value>The filter profile {0} provided is of not the correct format</value>
-  </data>
   <data name="ParsingFiles" xml:space="preserve">
     <value>Parsing the Files : '{0}'</value>
   </data>
@@ -248,5 +245,53 @@
   </data>
   <data name="RuntimeIdentifierWasNotSpecified" xml:space="preserve">
     <value>Specify a RuntimeIdentifier</value>
+  </data>
+  <data name="IncorrectTargetFormat" xml:space="preserve">
+    <value>The target manifest {0} provided is of not the correct format</value>
+  </data>
+  <data name="AppHostHasBeenModified" xml:space="preserve">
+    <value>Unable to use '{0}' as application host executable as it does not contain the expected placeholder byte sequence '{1}' that would mark where the application name would be written.</value>
+  </data>
+  <data name="FileNameIsTooLong" xml:space="preserve">
+    <value>Given file name '{0}' is longer than 1024 bytes</value>
+  </data>
+  <data name="CannotHaveSelfContainedWithoutRuntimeIdentifier" xml:space="preserve">
+    <value>It is not supported to build or publish a self-contained application without specifying a RuntimeIdentifier.  Please either specify a RuntimeIdentifier or set SelfContained to false.</value>
+  </data>
+  <data name="ChoosingAssemblyVersion" xml:space="preserve">
+    <value>Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</value>
+  </data>
+  <data name="ChoosingFileVersion" xml:space="preserve">
+    <value>Choosing '{0}' because file version '{1}' is greater than '{2}'.</value>
+  </data>
+  <data name="ChoosingPlatformItem" xml:space="preserve">
+    <value>Choosing '{0}' because it is a platform item.</value>
+  </data>
+  <data name="ChoosingPreferredPackage" xml:space="preserve">
+    <value>Choosing '{0}' because it comes from a package that is preferred.</value>
+  </data>
+  <data name="ConflictCouldNotDetermineWinner" xml:space="preserve">
+    <value>Could not determine winner due to equal file and assembly versions.</value>
+  </data>
+  <data name="CouldNotDetermineWinner_DoesntExist" xml:space="preserve">
+    <value>Could not determine winner because '{0}' does not exist.</value>
+  </data>
+  <data name="CouldNotDetermineWinner_FileVersion" xml:space="preserve">
+    <value>Could not determine a winner because '{0}' has no file version.</value>
+  </data>
+  <data name="CouldNotDetermineWinner_NotAnAssembly" xml:space="preserve">
+    <value>Could not determine a winner because '{0}' is not an assembly.</value>
+  </data>
+  <data name="EncounteredConflict" xml:space="preserve">
+    <value>Encountered conflict between '{0}' and '{1}'.</value>
+  </data>
+  <data name="CouldNotLoadPlatformManifest" xml:space="preserve">
+    <value>Could not load PlatformManifest from '{0}' because it did not exist.</value>
+  </data>
+  <data name="ErrorParsingPlatformManifest" xml:space="preserve">
+    <value>Error parsing PlatformManifest from '{0}' line {1}.  Lines must have the format {2}.</value>
+  </data>
+  <data name="ErrorParsingPlatformManifestInvalidValue" xml:space="preserve">
+    <value>Error parsing PlatformManifest from '{0}' line {1}.  {2} '{3}' was invalid.</value>
   </data>
 </root>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.zh-Hans.resx
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.zh-Hans.resx
@@ -237,9 +237,6 @@
   <data name="FolderAlreadyExists" xml:space="preserve">
     <value>Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</value>
   </data>
-  <data name="IncorrectFilterFormat" xml:space="preserve">
-    <value>The filter profile {0} provided is of not the correct format</value>
-  </data>
   <data name="ParsingFiles" xml:space="preserve">
     <value>Parsing the Files : '{0}'</value>
   </data>
@@ -248,5 +245,53 @@
   </data>
   <data name="RuntimeIdentifierWasNotSpecified" xml:space="preserve">
     <value>Specify a RuntimeIdentifier</value>
+  </data>
+  <data name="IncorrectTargetFormat" xml:space="preserve">
+    <value>The target manifest {0} provided is of not the correct format</value>
+  </data>
+  <data name="AppHostHasBeenModified" xml:space="preserve">
+    <value>Unable to use '{0}' as application host executable as it does not contain the expected placeholder byte sequence '{1}' that would mark where the application name would be written.</value>
+  </data>
+  <data name="FileNameIsTooLong" xml:space="preserve">
+    <value>Given file name '{0}' is longer than 1024 bytes</value>
+  </data>
+  <data name="CannotHaveSelfContainedWithoutRuntimeIdentifier" xml:space="preserve">
+    <value>It is not supported to build or publish a self-contained application without specifying a RuntimeIdentifier.  Please either specify a RuntimeIdentifier or set SelfContained to false.</value>
+  </data>
+  <data name="ChoosingAssemblyVersion" xml:space="preserve">
+    <value>Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</value>
+  </data>
+  <data name="ChoosingFileVersion" xml:space="preserve">
+    <value>Choosing '{0}' because file version '{1}' is greater than '{2}'.</value>
+  </data>
+  <data name="ChoosingPlatformItem" xml:space="preserve">
+    <value>Choosing '{0}' because it is a platform item.</value>
+  </data>
+  <data name="ChoosingPreferredPackage" xml:space="preserve">
+    <value>Choosing '{0}' because it comes from a package that is preferred.</value>
+  </data>
+  <data name="ConflictCouldNotDetermineWinner" xml:space="preserve">
+    <value>Could not determine winner due to equal file and assembly versions.</value>
+  </data>
+  <data name="CouldNotDetermineWinner_DoesntExist" xml:space="preserve">
+    <value>Could not determine winner because '{0}' does not exist.</value>
+  </data>
+  <data name="CouldNotDetermineWinner_FileVersion" xml:space="preserve">
+    <value>Could not determine a winner because '{0}' has no file version.</value>
+  </data>
+  <data name="CouldNotDetermineWinner_NotAnAssembly" xml:space="preserve">
+    <value>Could not determine a winner because '{0}' is not an assembly.</value>
+  </data>
+  <data name="EncounteredConflict" xml:space="preserve">
+    <value>Encountered conflict between '{0}' and '{1}'.</value>
+  </data>
+  <data name="CouldNotLoadPlatformManifest" xml:space="preserve">
+    <value>Could not load PlatformManifest from '{0}' because it did not exist.</value>
+  </data>
+  <data name="ErrorParsingPlatformManifest" xml:space="preserve">
+    <value>Error parsing PlatformManifest from '{0}' line {1}.  Lines must have the format {2}.</value>
+  </data>
+  <data name="ErrorParsingPlatformManifestInvalidValue" xml:space="preserve">
+    <value>Error parsing PlatformManifest from '{0}' line {1}.  {2} '{3}' was invalid.</value>
   </data>
 </root>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.zh-Hant.resx
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.zh-Hant.resx
@@ -237,9 +237,6 @@
   <data name="FolderAlreadyExists" xml:space="preserve">
     <value>Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</value>
   </data>
-  <data name="IncorrectFilterFormat" xml:space="preserve">
-    <value>The filter profile {0} provided is of not the correct format</value>
-  </data>
   <data name="ParsingFiles" xml:space="preserve">
     <value>Parsing the Files : '{0}'</value>
   </data>
@@ -248,5 +245,53 @@
   </data>
   <data name="RuntimeIdentifierWasNotSpecified" xml:space="preserve">
     <value>Specify a RuntimeIdentifier</value>
+  </data>
+  <data name="IncorrectTargetFormat" xml:space="preserve">
+    <value>The target manifest {0} provided is of not the correct format</value>
+  </data>
+  <data name="AppHostHasBeenModified" xml:space="preserve">
+    <value>Unable to use '{0}' as application host executable as it does not contain the expected placeholder byte sequence '{1}' that would mark where the application name would be written.</value>
+  </data>
+  <data name="FileNameIsTooLong" xml:space="preserve">
+    <value>Given file name '{0}' is longer than 1024 bytes</value>
+  </data>
+  <data name="CannotHaveSelfContainedWithoutRuntimeIdentifier" xml:space="preserve">
+    <value>It is not supported to build or publish a self-contained application without specifying a RuntimeIdentifier.  Please either specify a RuntimeIdentifier or set SelfContained to false.</value>
+  </data>
+  <data name="ChoosingAssemblyVersion" xml:space="preserve">
+    <value>Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</value>
+  </data>
+  <data name="ChoosingFileVersion" xml:space="preserve">
+    <value>Choosing '{0}' because file version '{1}' is greater than '{2}'.</value>
+  </data>
+  <data name="ChoosingPlatformItem" xml:space="preserve">
+    <value>Choosing '{0}' because it is a platform item.</value>
+  </data>
+  <data name="ChoosingPreferredPackage" xml:space="preserve">
+    <value>Choosing '{0}' because it comes from a package that is preferred.</value>
+  </data>
+  <data name="ConflictCouldNotDetermineWinner" xml:space="preserve">
+    <value>Could not determine winner due to equal file and assembly versions.</value>
+  </data>
+  <data name="CouldNotDetermineWinner_DoesntExist" xml:space="preserve">
+    <value>Could not determine winner because '{0}' does not exist.</value>
+  </data>
+  <data name="CouldNotDetermineWinner_FileVersion" xml:space="preserve">
+    <value>Could not determine a winner because '{0}' has no file version.</value>
+  </data>
+  <data name="CouldNotDetermineWinner_NotAnAssembly" xml:space="preserve">
+    <value>Could not determine a winner because '{0}' is not an assembly.</value>
+  </data>
+  <data name="EncounteredConflict" xml:space="preserve">
+    <value>Encountered conflict between '{0}' and '{1}'.</value>
+  </data>
+  <data name="CouldNotLoadPlatformManifest" xml:space="preserve">
+    <value>Could not load PlatformManifest from '{0}' because it did not exist.</value>
+  </data>
+  <data name="ErrorParsingPlatformManifest" xml:space="preserve">
+    <value>Error parsing PlatformManifest from '{0}' line {1}.  Lines must have the format {2}.</value>
+  </data>
+  <data name="ErrorParsingPlatformManifestInvalidValue" xml:space="preserve">
+    <value>Error parsing PlatformManifest from '{0}' line {1}.  {2} '{3}' was invalid.</value>
   </data>
 </root>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.cs.xlf
@@ -203,11 +203,6 @@
         <target state="new">Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</target>
         <note></note>
       </trans-unit>
-      <trans-unit id="IncorrectFilterFormat">
-        <source>The filter profile {0} provided is of not the correct format</source>
-        <target state="new">The filter profile {0} provided is of not the correct format</target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="ParsingFiles">
         <source>Parsing the Files : '{0}'</source>
         <target state="new">Parsing the Files : '{0}'</target>
@@ -221,6 +216,86 @@
       <trans-unit id="RuntimeIdentifierWasNotSpecified">
         <source>Specify a RuntimeIdentifier</source>
         <target state="new">Specify a RuntimeIdentifier</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="IncorrectTargetFormat">
+        <source>The target manifest {0} provided is of not the correct format</source>
+        <target state="new">The target manifest {0} provided is of not the correct format</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AppHostHasBeenModified">
+        <source>Unable to use '{0}' as application host executable as it does not contain the expected placeholder byte sequence '{1}' that would mark where the application name would be written.</source>
+        <target state="new">Unable to use '{0}' as application host executable as it does not contain the expected placeholder byte sequence '{1}' that would mark where the application name would be written.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FileNameIsTooLong">
+        <source>Given file name '{0}' is longer than 1024 bytes</source>
+        <target state="new">Given file name '{0}' is longer than 1024 bytes</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CannotHaveSelfContainedWithoutRuntimeIdentifier">
+        <source>It is not supported to build or publish a self-contained application without specifying a RuntimeIdentifier.  Please either specify a RuntimeIdentifier or set SelfContained to false.</source>
+        <target state="new">It is not supported to build or publish a self-contained application without specifying a RuntimeIdentifier.  Please either specify a RuntimeIdentifier or set SelfContained to false.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ChoosingAssemblyVersion">
+        <source>Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</source>
+        <target state="new">Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ChoosingFileVersion">
+        <source>Choosing '{0}' because file version '{1}' is greater than '{2}'.</source>
+        <target state="new">Choosing '{0}' because file version '{1}' is greater than '{2}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ChoosingPlatformItem">
+        <source>Choosing '{0}' because it is a platform item.</source>
+        <target state="new">Choosing '{0}' because it is a platform item.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ChoosingPreferredPackage">
+        <source>Choosing '{0}' because it comes from a package that is preferred.</source>
+        <target state="new">Choosing '{0}' because it comes from a package that is preferred.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ConflictCouldNotDetermineWinner">
+        <source>Could not determine winner due to equal file and assembly versions.</source>
+        <target state="new">Could not determine winner due to equal file and assembly versions.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CouldNotDetermineWinner_DoesntExist">
+        <source>Could not determine winner because '{0}' does not exist.</source>
+        <target state="new">Could not determine winner because '{0}' does not exist.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CouldNotDetermineWinner_FileVersion">
+        <source>Could not determine a winner because '{0}' has no file version.</source>
+        <target state="new">Could not determine a winner because '{0}' has no file version.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CouldNotDetermineWinner_NotAnAssembly">
+        <source>Could not determine a winner because '{0}' is not an assembly.</source>
+        <target state="new">Could not determine a winner because '{0}' is not an assembly.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="EncounteredConflict">
+        <source>Encountered conflict between '{0}' and '{1}'.</source>
+        <target state="new">Encountered conflict between '{0}' and '{1}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CouldNotLoadPlatformManifest">
+        <source>Could not load PlatformManifest from '{0}' because it did not exist.</source>
+        <target state="new">Could not load PlatformManifest from '{0}' because it did not exist.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ErrorParsingPlatformManifest">
+        <source>Error parsing PlatformManifest from '{0}' line {1}.  Lines must have the format {2}.</source>
+        <target state="new">Error parsing PlatformManifest from '{0}' line {1}.  Lines must have the format {2}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ErrorParsingPlatformManifestInvalidValue">
+        <source>Error parsing PlatformManifest from '{0}' line {1}.  {2} '{3}' was invalid.</source>
+        <target state="new">Error parsing PlatformManifest from '{0}' line {1}.  {2} '{3}' was invalid.</target>
         <note></note>
       </trans-unit>
     </body>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.de.xlf
@@ -203,11 +203,6 @@
         <target state="new">Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</target>
         <note></note>
       </trans-unit>
-      <trans-unit id="IncorrectFilterFormat">
-        <source>The filter profile {0} provided is of not the correct format</source>
-        <target state="new">The filter profile {0} provided is of not the correct format</target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="ParsingFiles">
         <source>Parsing the Files : '{0}'</source>
         <target state="new">Parsing the Files : '{0}'</target>
@@ -221,6 +216,86 @@
       <trans-unit id="RuntimeIdentifierWasNotSpecified">
         <source>Specify a RuntimeIdentifier</source>
         <target state="new">Specify a RuntimeIdentifier</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="IncorrectTargetFormat">
+        <source>The target manifest {0} provided is of not the correct format</source>
+        <target state="new">The target manifest {0} provided is of not the correct format</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AppHostHasBeenModified">
+        <source>Unable to use '{0}' as application host executable as it does not contain the expected placeholder byte sequence '{1}' that would mark where the application name would be written.</source>
+        <target state="new">Unable to use '{0}' as application host executable as it does not contain the expected placeholder byte sequence '{1}' that would mark where the application name would be written.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FileNameIsTooLong">
+        <source>Given file name '{0}' is longer than 1024 bytes</source>
+        <target state="new">Given file name '{0}' is longer than 1024 bytes</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CannotHaveSelfContainedWithoutRuntimeIdentifier">
+        <source>It is not supported to build or publish a self-contained application without specifying a RuntimeIdentifier.  Please either specify a RuntimeIdentifier or set SelfContained to false.</source>
+        <target state="new">It is not supported to build or publish a self-contained application without specifying a RuntimeIdentifier.  Please either specify a RuntimeIdentifier or set SelfContained to false.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ChoosingAssemblyVersion">
+        <source>Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</source>
+        <target state="new">Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ChoosingFileVersion">
+        <source>Choosing '{0}' because file version '{1}' is greater than '{2}'.</source>
+        <target state="new">Choosing '{0}' because file version '{1}' is greater than '{2}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ChoosingPlatformItem">
+        <source>Choosing '{0}' because it is a platform item.</source>
+        <target state="new">Choosing '{0}' because it is a platform item.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ChoosingPreferredPackage">
+        <source>Choosing '{0}' because it comes from a package that is preferred.</source>
+        <target state="new">Choosing '{0}' because it comes from a package that is preferred.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ConflictCouldNotDetermineWinner">
+        <source>Could not determine winner due to equal file and assembly versions.</source>
+        <target state="new">Could not determine winner due to equal file and assembly versions.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CouldNotDetermineWinner_DoesntExist">
+        <source>Could not determine winner because '{0}' does not exist.</source>
+        <target state="new">Could not determine winner because '{0}' does not exist.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CouldNotDetermineWinner_FileVersion">
+        <source>Could not determine a winner because '{0}' has no file version.</source>
+        <target state="new">Could not determine a winner because '{0}' has no file version.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CouldNotDetermineWinner_NotAnAssembly">
+        <source>Could not determine a winner because '{0}' is not an assembly.</source>
+        <target state="new">Could not determine a winner because '{0}' is not an assembly.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="EncounteredConflict">
+        <source>Encountered conflict between '{0}' and '{1}'.</source>
+        <target state="new">Encountered conflict between '{0}' and '{1}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CouldNotLoadPlatformManifest">
+        <source>Could not load PlatformManifest from '{0}' because it did not exist.</source>
+        <target state="new">Could not load PlatformManifest from '{0}' because it did not exist.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ErrorParsingPlatformManifest">
+        <source>Error parsing PlatformManifest from '{0}' line {1}.  Lines must have the format {2}.</source>
+        <target state="new">Error parsing PlatformManifest from '{0}' line {1}.  Lines must have the format {2}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ErrorParsingPlatformManifestInvalidValue">
+        <source>Error parsing PlatformManifest from '{0}' line {1}.  {2} '{3}' was invalid.</source>
+        <target state="new">Error parsing PlatformManifest from '{0}' line {1}.  {2} '{3}' was invalid.</target>
         <note></note>
       </trans-unit>
     </body>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.es.xlf
@@ -203,11 +203,6 @@
         <target state="new">Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</target>
         <note></note>
       </trans-unit>
-      <trans-unit id="IncorrectFilterFormat">
-        <source>The filter profile {0} provided is of not the correct format</source>
-        <target state="new">The filter profile {0} provided is of not the correct format</target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="ParsingFiles">
         <source>Parsing the Files : '{0}'</source>
         <target state="new">Parsing the Files : '{0}'</target>
@@ -221,6 +216,86 @@
       <trans-unit id="RuntimeIdentifierWasNotSpecified">
         <source>Specify a RuntimeIdentifier</source>
         <target state="new">Specify a RuntimeIdentifier</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="IncorrectTargetFormat">
+        <source>The target manifest {0} provided is of not the correct format</source>
+        <target state="new">The target manifest {0} provided is of not the correct format</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AppHostHasBeenModified">
+        <source>Unable to use '{0}' as application host executable as it does not contain the expected placeholder byte sequence '{1}' that would mark where the application name would be written.</source>
+        <target state="new">Unable to use '{0}' as application host executable as it does not contain the expected placeholder byte sequence '{1}' that would mark where the application name would be written.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FileNameIsTooLong">
+        <source>Given file name '{0}' is longer than 1024 bytes</source>
+        <target state="new">Given file name '{0}' is longer than 1024 bytes</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CannotHaveSelfContainedWithoutRuntimeIdentifier">
+        <source>It is not supported to build or publish a self-contained application without specifying a RuntimeIdentifier.  Please either specify a RuntimeIdentifier or set SelfContained to false.</source>
+        <target state="new">It is not supported to build or publish a self-contained application without specifying a RuntimeIdentifier.  Please either specify a RuntimeIdentifier or set SelfContained to false.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ChoosingAssemblyVersion">
+        <source>Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</source>
+        <target state="new">Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ChoosingFileVersion">
+        <source>Choosing '{0}' because file version '{1}' is greater than '{2}'.</source>
+        <target state="new">Choosing '{0}' because file version '{1}' is greater than '{2}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ChoosingPlatformItem">
+        <source>Choosing '{0}' because it is a platform item.</source>
+        <target state="new">Choosing '{0}' because it is a platform item.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ChoosingPreferredPackage">
+        <source>Choosing '{0}' because it comes from a package that is preferred.</source>
+        <target state="new">Choosing '{0}' because it comes from a package that is preferred.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ConflictCouldNotDetermineWinner">
+        <source>Could not determine winner due to equal file and assembly versions.</source>
+        <target state="new">Could not determine winner due to equal file and assembly versions.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CouldNotDetermineWinner_DoesntExist">
+        <source>Could not determine winner because '{0}' does not exist.</source>
+        <target state="new">Could not determine winner because '{0}' does not exist.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CouldNotDetermineWinner_FileVersion">
+        <source>Could not determine a winner because '{0}' has no file version.</source>
+        <target state="new">Could not determine a winner because '{0}' has no file version.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CouldNotDetermineWinner_NotAnAssembly">
+        <source>Could not determine a winner because '{0}' is not an assembly.</source>
+        <target state="new">Could not determine a winner because '{0}' is not an assembly.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="EncounteredConflict">
+        <source>Encountered conflict between '{0}' and '{1}'.</source>
+        <target state="new">Encountered conflict between '{0}' and '{1}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CouldNotLoadPlatformManifest">
+        <source>Could not load PlatformManifest from '{0}' because it did not exist.</source>
+        <target state="new">Could not load PlatformManifest from '{0}' because it did not exist.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ErrorParsingPlatformManifest">
+        <source>Error parsing PlatformManifest from '{0}' line {1}.  Lines must have the format {2}.</source>
+        <target state="new">Error parsing PlatformManifest from '{0}' line {1}.  Lines must have the format {2}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ErrorParsingPlatformManifestInvalidValue">
+        <source>Error parsing PlatformManifest from '{0}' line {1}.  {2} '{3}' was invalid.</source>
+        <target state="new">Error parsing PlatformManifest from '{0}' line {1}.  {2} '{3}' was invalid.</target>
         <note></note>
       </trans-unit>
     </body>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.fr.xlf
@@ -203,11 +203,6 @@
         <target state="new">Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</target>
         <note></note>
       </trans-unit>
-      <trans-unit id="IncorrectFilterFormat">
-        <source>The filter profile {0} provided is of not the correct format</source>
-        <target state="new">The filter profile {0} provided is of not the correct format</target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="ParsingFiles">
         <source>Parsing the Files : '{0}'</source>
         <target state="new">Parsing the Files : '{0}'</target>
@@ -221,6 +216,86 @@
       <trans-unit id="RuntimeIdentifierWasNotSpecified">
         <source>Specify a RuntimeIdentifier</source>
         <target state="new">Specify a RuntimeIdentifier</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="IncorrectTargetFormat">
+        <source>The target manifest {0} provided is of not the correct format</source>
+        <target state="new">The target manifest {0} provided is of not the correct format</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AppHostHasBeenModified">
+        <source>Unable to use '{0}' as application host executable as it does not contain the expected placeholder byte sequence '{1}' that would mark where the application name would be written.</source>
+        <target state="new">Unable to use '{0}' as application host executable as it does not contain the expected placeholder byte sequence '{1}' that would mark where the application name would be written.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FileNameIsTooLong">
+        <source>Given file name '{0}' is longer than 1024 bytes</source>
+        <target state="new">Given file name '{0}' is longer than 1024 bytes</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CannotHaveSelfContainedWithoutRuntimeIdentifier">
+        <source>It is not supported to build or publish a self-contained application without specifying a RuntimeIdentifier.  Please either specify a RuntimeIdentifier or set SelfContained to false.</source>
+        <target state="new">It is not supported to build or publish a self-contained application without specifying a RuntimeIdentifier.  Please either specify a RuntimeIdentifier or set SelfContained to false.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ChoosingAssemblyVersion">
+        <source>Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</source>
+        <target state="new">Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ChoosingFileVersion">
+        <source>Choosing '{0}' because file version '{1}' is greater than '{2}'.</source>
+        <target state="new">Choosing '{0}' because file version '{1}' is greater than '{2}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ChoosingPlatformItem">
+        <source>Choosing '{0}' because it is a platform item.</source>
+        <target state="new">Choosing '{0}' because it is a platform item.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ChoosingPreferredPackage">
+        <source>Choosing '{0}' because it comes from a package that is preferred.</source>
+        <target state="new">Choosing '{0}' because it comes from a package that is preferred.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ConflictCouldNotDetermineWinner">
+        <source>Could not determine winner due to equal file and assembly versions.</source>
+        <target state="new">Could not determine winner due to equal file and assembly versions.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CouldNotDetermineWinner_DoesntExist">
+        <source>Could not determine winner because '{0}' does not exist.</source>
+        <target state="new">Could not determine winner because '{0}' does not exist.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CouldNotDetermineWinner_FileVersion">
+        <source>Could not determine a winner because '{0}' has no file version.</source>
+        <target state="new">Could not determine a winner because '{0}' has no file version.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CouldNotDetermineWinner_NotAnAssembly">
+        <source>Could not determine a winner because '{0}' is not an assembly.</source>
+        <target state="new">Could not determine a winner because '{0}' is not an assembly.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="EncounteredConflict">
+        <source>Encountered conflict between '{0}' and '{1}'.</source>
+        <target state="new">Encountered conflict between '{0}' and '{1}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CouldNotLoadPlatformManifest">
+        <source>Could not load PlatformManifest from '{0}' because it did not exist.</source>
+        <target state="new">Could not load PlatformManifest from '{0}' because it did not exist.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ErrorParsingPlatformManifest">
+        <source>Error parsing PlatformManifest from '{0}' line {1}.  Lines must have the format {2}.</source>
+        <target state="new">Error parsing PlatformManifest from '{0}' line {1}.  Lines must have the format {2}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ErrorParsingPlatformManifestInvalidValue">
+        <source>Error parsing PlatformManifest from '{0}' line {1}.  {2} '{3}' was invalid.</source>
+        <target state="new">Error parsing PlatformManifest from '{0}' line {1}.  {2} '{3}' was invalid.</target>
         <note></note>
       </trans-unit>
     </body>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.it.xlf
@@ -203,11 +203,6 @@
         <target state="new">Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</target>
         <note></note>
       </trans-unit>
-      <trans-unit id="IncorrectFilterFormat">
-        <source>The filter profile {0} provided is of not the correct format</source>
-        <target state="new">The filter profile {0} provided is of not the correct format</target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="ParsingFiles">
         <source>Parsing the Files : '{0}'</source>
         <target state="new">Parsing the Files : '{0}'</target>
@@ -221,6 +216,86 @@
       <trans-unit id="RuntimeIdentifierWasNotSpecified">
         <source>Specify a RuntimeIdentifier</source>
         <target state="new">Specify a RuntimeIdentifier</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="IncorrectTargetFormat">
+        <source>The target manifest {0} provided is of not the correct format</source>
+        <target state="new">The target manifest {0} provided is of not the correct format</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AppHostHasBeenModified">
+        <source>Unable to use '{0}' as application host executable as it does not contain the expected placeholder byte sequence '{1}' that would mark where the application name would be written.</source>
+        <target state="new">Unable to use '{0}' as application host executable as it does not contain the expected placeholder byte sequence '{1}' that would mark where the application name would be written.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FileNameIsTooLong">
+        <source>Given file name '{0}' is longer than 1024 bytes</source>
+        <target state="new">Given file name '{0}' is longer than 1024 bytes</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CannotHaveSelfContainedWithoutRuntimeIdentifier">
+        <source>It is not supported to build or publish a self-contained application without specifying a RuntimeIdentifier.  Please either specify a RuntimeIdentifier or set SelfContained to false.</source>
+        <target state="new">It is not supported to build or publish a self-contained application without specifying a RuntimeIdentifier.  Please either specify a RuntimeIdentifier or set SelfContained to false.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ChoosingAssemblyVersion">
+        <source>Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</source>
+        <target state="new">Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ChoosingFileVersion">
+        <source>Choosing '{0}' because file version '{1}' is greater than '{2}'.</source>
+        <target state="new">Choosing '{0}' because file version '{1}' is greater than '{2}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ChoosingPlatformItem">
+        <source>Choosing '{0}' because it is a platform item.</source>
+        <target state="new">Choosing '{0}' because it is a platform item.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ChoosingPreferredPackage">
+        <source>Choosing '{0}' because it comes from a package that is preferred.</source>
+        <target state="new">Choosing '{0}' because it comes from a package that is preferred.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ConflictCouldNotDetermineWinner">
+        <source>Could not determine winner due to equal file and assembly versions.</source>
+        <target state="new">Could not determine winner due to equal file and assembly versions.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CouldNotDetermineWinner_DoesntExist">
+        <source>Could not determine winner because '{0}' does not exist.</source>
+        <target state="new">Could not determine winner because '{0}' does not exist.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CouldNotDetermineWinner_FileVersion">
+        <source>Could not determine a winner because '{0}' has no file version.</source>
+        <target state="new">Could not determine a winner because '{0}' has no file version.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CouldNotDetermineWinner_NotAnAssembly">
+        <source>Could not determine a winner because '{0}' is not an assembly.</source>
+        <target state="new">Could not determine a winner because '{0}' is not an assembly.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="EncounteredConflict">
+        <source>Encountered conflict between '{0}' and '{1}'.</source>
+        <target state="new">Encountered conflict between '{0}' and '{1}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CouldNotLoadPlatformManifest">
+        <source>Could not load PlatformManifest from '{0}' because it did not exist.</source>
+        <target state="new">Could not load PlatformManifest from '{0}' because it did not exist.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ErrorParsingPlatformManifest">
+        <source>Error parsing PlatformManifest from '{0}' line {1}.  Lines must have the format {2}.</source>
+        <target state="new">Error parsing PlatformManifest from '{0}' line {1}.  Lines must have the format {2}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ErrorParsingPlatformManifestInvalidValue">
+        <source>Error parsing PlatformManifest from '{0}' line {1}.  {2} '{3}' was invalid.</source>
+        <target state="new">Error parsing PlatformManifest from '{0}' line {1}.  {2} '{3}' was invalid.</target>
         <note></note>
       </trans-unit>
     </body>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.ja.xlf
@@ -203,11 +203,6 @@
         <target state="new">Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</target>
         <note></note>
       </trans-unit>
-      <trans-unit id="IncorrectFilterFormat">
-        <source>The filter profile {0} provided is of not the correct format</source>
-        <target state="new">The filter profile {0} provided is of not the correct format</target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="ParsingFiles">
         <source>Parsing the Files : '{0}'</source>
         <target state="new">Parsing the Files : '{0}'</target>
@@ -221,6 +216,86 @@
       <trans-unit id="RuntimeIdentifierWasNotSpecified">
         <source>Specify a RuntimeIdentifier</source>
         <target state="new">Specify a RuntimeIdentifier</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="IncorrectTargetFormat">
+        <source>The target manifest {0} provided is of not the correct format</source>
+        <target state="new">The target manifest {0} provided is of not the correct format</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AppHostHasBeenModified">
+        <source>Unable to use '{0}' as application host executable as it does not contain the expected placeholder byte sequence '{1}' that would mark where the application name would be written.</source>
+        <target state="new">Unable to use '{0}' as application host executable as it does not contain the expected placeholder byte sequence '{1}' that would mark where the application name would be written.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FileNameIsTooLong">
+        <source>Given file name '{0}' is longer than 1024 bytes</source>
+        <target state="new">Given file name '{0}' is longer than 1024 bytes</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CannotHaveSelfContainedWithoutRuntimeIdentifier">
+        <source>It is not supported to build or publish a self-contained application without specifying a RuntimeIdentifier.  Please either specify a RuntimeIdentifier or set SelfContained to false.</source>
+        <target state="new">It is not supported to build or publish a self-contained application without specifying a RuntimeIdentifier.  Please either specify a RuntimeIdentifier or set SelfContained to false.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ChoosingAssemblyVersion">
+        <source>Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</source>
+        <target state="new">Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ChoosingFileVersion">
+        <source>Choosing '{0}' because file version '{1}' is greater than '{2}'.</source>
+        <target state="new">Choosing '{0}' because file version '{1}' is greater than '{2}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ChoosingPlatformItem">
+        <source>Choosing '{0}' because it is a platform item.</source>
+        <target state="new">Choosing '{0}' because it is a platform item.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ChoosingPreferredPackage">
+        <source>Choosing '{0}' because it comes from a package that is preferred.</source>
+        <target state="new">Choosing '{0}' because it comes from a package that is preferred.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ConflictCouldNotDetermineWinner">
+        <source>Could not determine winner due to equal file and assembly versions.</source>
+        <target state="new">Could not determine winner due to equal file and assembly versions.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CouldNotDetermineWinner_DoesntExist">
+        <source>Could not determine winner because '{0}' does not exist.</source>
+        <target state="new">Could not determine winner because '{0}' does not exist.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CouldNotDetermineWinner_FileVersion">
+        <source>Could not determine a winner because '{0}' has no file version.</source>
+        <target state="new">Could not determine a winner because '{0}' has no file version.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CouldNotDetermineWinner_NotAnAssembly">
+        <source>Could not determine a winner because '{0}' is not an assembly.</source>
+        <target state="new">Could not determine a winner because '{0}' is not an assembly.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="EncounteredConflict">
+        <source>Encountered conflict between '{0}' and '{1}'.</source>
+        <target state="new">Encountered conflict between '{0}' and '{1}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CouldNotLoadPlatformManifest">
+        <source>Could not load PlatformManifest from '{0}' because it did not exist.</source>
+        <target state="new">Could not load PlatformManifest from '{0}' because it did not exist.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ErrorParsingPlatformManifest">
+        <source>Error parsing PlatformManifest from '{0}' line {1}.  Lines must have the format {2}.</source>
+        <target state="new">Error parsing PlatformManifest from '{0}' line {1}.  Lines must have the format {2}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ErrorParsingPlatformManifestInvalidValue">
+        <source>Error parsing PlatformManifest from '{0}' line {1}.  {2} '{3}' was invalid.</source>
+        <target state="new">Error parsing PlatformManifest from '{0}' line {1}.  {2} '{3}' was invalid.</target>
         <note></note>
       </trans-unit>
     </body>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.ko.xlf
@@ -203,11 +203,6 @@
         <target state="new">Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</target>
         <note></note>
       </trans-unit>
-      <trans-unit id="IncorrectFilterFormat">
-        <source>The filter profile {0} provided is of not the correct format</source>
-        <target state="new">The filter profile {0} provided is of not the correct format</target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="ParsingFiles">
         <source>Parsing the Files : '{0}'</source>
         <target state="new">Parsing the Files : '{0}'</target>
@@ -221,6 +216,86 @@
       <trans-unit id="RuntimeIdentifierWasNotSpecified">
         <source>Specify a RuntimeIdentifier</source>
         <target state="new">Specify a RuntimeIdentifier</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="IncorrectTargetFormat">
+        <source>The target manifest {0} provided is of not the correct format</source>
+        <target state="new">The target manifest {0} provided is of not the correct format</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AppHostHasBeenModified">
+        <source>Unable to use '{0}' as application host executable as it does not contain the expected placeholder byte sequence '{1}' that would mark where the application name would be written.</source>
+        <target state="new">Unable to use '{0}' as application host executable as it does not contain the expected placeholder byte sequence '{1}' that would mark where the application name would be written.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FileNameIsTooLong">
+        <source>Given file name '{0}' is longer than 1024 bytes</source>
+        <target state="new">Given file name '{0}' is longer than 1024 bytes</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CannotHaveSelfContainedWithoutRuntimeIdentifier">
+        <source>It is not supported to build or publish a self-contained application without specifying a RuntimeIdentifier.  Please either specify a RuntimeIdentifier or set SelfContained to false.</source>
+        <target state="new">It is not supported to build or publish a self-contained application without specifying a RuntimeIdentifier.  Please either specify a RuntimeIdentifier or set SelfContained to false.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ChoosingAssemblyVersion">
+        <source>Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</source>
+        <target state="new">Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ChoosingFileVersion">
+        <source>Choosing '{0}' because file version '{1}' is greater than '{2}'.</source>
+        <target state="new">Choosing '{0}' because file version '{1}' is greater than '{2}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ChoosingPlatformItem">
+        <source>Choosing '{0}' because it is a platform item.</source>
+        <target state="new">Choosing '{0}' because it is a platform item.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ChoosingPreferredPackage">
+        <source>Choosing '{0}' because it comes from a package that is preferred.</source>
+        <target state="new">Choosing '{0}' because it comes from a package that is preferred.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ConflictCouldNotDetermineWinner">
+        <source>Could not determine winner due to equal file and assembly versions.</source>
+        <target state="new">Could not determine winner due to equal file and assembly versions.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CouldNotDetermineWinner_DoesntExist">
+        <source>Could not determine winner because '{0}' does not exist.</source>
+        <target state="new">Could not determine winner because '{0}' does not exist.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CouldNotDetermineWinner_FileVersion">
+        <source>Could not determine a winner because '{0}' has no file version.</source>
+        <target state="new">Could not determine a winner because '{0}' has no file version.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CouldNotDetermineWinner_NotAnAssembly">
+        <source>Could not determine a winner because '{0}' is not an assembly.</source>
+        <target state="new">Could not determine a winner because '{0}' is not an assembly.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="EncounteredConflict">
+        <source>Encountered conflict between '{0}' and '{1}'.</source>
+        <target state="new">Encountered conflict between '{0}' and '{1}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CouldNotLoadPlatformManifest">
+        <source>Could not load PlatformManifest from '{0}' because it did not exist.</source>
+        <target state="new">Could not load PlatformManifest from '{0}' because it did not exist.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ErrorParsingPlatformManifest">
+        <source>Error parsing PlatformManifest from '{0}' line {1}.  Lines must have the format {2}.</source>
+        <target state="new">Error parsing PlatformManifest from '{0}' line {1}.  Lines must have the format {2}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ErrorParsingPlatformManifestInvalidValue">
+        <source>Error parsing PlatformManifest from '{0}' line {1}.  {2} '{3}' was invalid.</source>
+        <target state="new">Error parsing PlatformManifest from '{0}' line {1}.  {2} '{3}' was invalid.</target>
         <note></note>
       </trans-unit>
     </body>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.pl.xlf
@@ -203,11 +203,6 @@
         <target state="new">Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</target>
         <note></note>
       </trans-unit>
-      <trans-unit id="IncorrectFilterFormat">
-        <source>The filter profile {0} provided is of not the correct format</source>
-        <target state="new">The filter profile {0} provided is of not the correct format</target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="ParsingFiles">
         <source>Parsing the Files : '{0}'</source>
         <target state="new">Parsing the Files : '{0}'</target>
@@ -221,6 +216,86 @@
       <trans-unit id="RuntimeIdentifierWasNotSpecified">
         <source>Specify a RuntimeIdentifier</source>
         <target state="new">Specify a RuntimeIdentifier</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="IncorrectTargetFormat">
+        <source>The target manifest {0} provided is of not the correct format</source>
+        <target state="new">The target manifest {0} provided is of not the correct format</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AppHostHasBeenModified">
+        <source>Unable to use '{0}' as application host executable as it does not contain the expected placeholder byte sequence '{1}' that would mark where the application name would be written.</source>
+        <target state="new">Unable to use '{0}' as application host executable as it does not contain the expected placeholder byte sequence '{1}' that would mark where the application name would be written.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FileNameIsTooLong">
+        <source>Given file name '{0}' is longer than 1024 bytes</source>
+        <target state="new">Given file name '{0}' is longer than 1024 bytes</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CannotHaveSelfContainedWithoutRuntimeIdentifier">
+        <source>It is not supported to build or publish a self-contained application without specifying a RuntimeIdentifier.  Please either specify a RuntimeIdentifier or set SelfContained to false.</source>
+        <target state="new">It is not supported to build or publish a self-contained application without specifying a RuntimeIdentifier.  Please either specify a RuntimeIdentifier or set SelfContained to false.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ChoosingAssemblyVersion">
+        <source>Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</source>
+        <target state="new">Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ChoosingFileVersion">
+        <source>Choosing '{0}' because file version '{1}' is greater than '{2}'.</source>
+        <target state="new">Choosing '{0}' because file version '{1}' is greater than '{2}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ChoosingPlatformItem">
+        <source>Choosing '{0}' because it is a platform item.</source>
+        <target state="new">Choosing '{0}' because it is a platform item.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ChoosingPreferredPackage">
+        <source>Choosing '{0}' because it comes from a package that is preferred.</source>
+        <target state="new">Choosing '{0}' because it comes from a package that is preferred.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ConflictCouldNotDetermineWinner">
+        <source>Could not determine winner due to equal file and assembly versions.</source>
+        <target state="new">Could not determine winner due to equal file and assembly versions.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CouldNotDetermineWinner_DoesntExist">
+        <source>Could not determine winner because '{0}' does not exist.</source>
+        <target state="new">Could not determine winner because '{0}' does not exist.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CouldNotDetermineWinner_FileVersion">
+        <source>Could not determine a winner because '{0}' has no file version.</source>
+        <target state="new">Could not determine a winner because '{0}' has no file version.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CouldNotDetermineWinner_NotAnAssembly">
+        <source>Could not determine a winner because '{0}' is not an assembly.</source>
+        <target state="new">Could not determine a winner because '{0}' is not an assembly.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="EncounteredConflict">
+        <source>Encountered conflict between '{0}' and '{1}'.</source>
+        <target state="new">Encountered conflict between '{0}' and '{1}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CouldNotLoadPlatformManifest">
+        <source>Could not load PlatformManifest from '{0}' because it did not exist.</source>
+        <target state="new">Could not load PlatformManifest from '{0}' because it did not exist.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ErrorParsingPlatformManifest">
+        <source>Error parsing PlatformManifest from '{0}' line {1}.  Lines must have the format {2}.</source>
+        <target state="new">Error parsing PlatformManifest from '{0}' line {1}.  Lines must have the format {2}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ErrorParsingPlatformManifestInvalidValue">
+        <source>Error parsing PlatformManifest from '{0}' line {1}.  {2} '{3}' was invalid.</source>
+        <target state="new">Error parsing PlatformManifest from '{0}' line {1}.  {2} '{3}' was invalid.</target>
         <note></note>
       </trans-unit>
     </body>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.pt-BR.xlf
@@ -203,11 +203,6 @@
         <target state="new">Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</target>
         <note></note>
       </trans-unit>
-      <trans-unit id="IncorrectFilterFormat">
-        <source>The filter profile {0} provided is of not the correct format</source>
-        <target state="new">The filter profile {0} provided is of not the correct format</target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="ParsingFiles">
         <source>Parsing the Files : '{0}'</source>
         <target state="new">Parsing the Files : '{0}'</target>
@@ -221,6 +216,86 @@
       <trans-unit id="RuntimeIdentifierWasNotSpecified">
         <source>Specify a RuntimeIdentifier</source>
         <target state="new">Specify a RuntimeIdentifier</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="IncorrectTargetFormat">
+        <source>The target manifest {0} provided is of not the correct format</source>
+        <target state="new">The target manifest {0} provided is of not the correct format</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AppHostHasBeenModified">
+        <source>Unable to use '{0}' as application host executable as it does not contain the expected placeholder byte sequence '{1}' that would mark where the application name would be written.</source>
+        <target state="new">Unable to use '{0}' as application host executable as it does not contain the expected placeholder byte sequence '{1}' that would mark where the application name would be written.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FileNameIsTooLong">
+        <source>Given file name '{0}' is longer than 1024 bytes</source>
+        <target state="new">Given file name '{0}' is longer than 1024 bytes</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CannotHaveSelfContainedWithoutRuntimeIdentifier">
+        <source>It is not supported to build or publish a self-contained application without specifying a RuntimeIdentifier.  Please either specify a RuntimeIdentifier or set SelfContained to false.</source>
+        <target state="new">It is not supported to build or publish a self-contained application without specifying a RuntimeIdentifier.  Please either specify a RuntimeIdentifier or set SelfContained to false.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ChoosingAssemblyVersion">
+        <source>Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</source>
+        <target state="new">Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ChoosingFileVersion">
+        <source>Choosing '{0}' because file version '{1}' is greater than '{2}'.</source>
+        <target state="new">Choosing '{0}' because file version '{1}' is greater than '{2}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ChoosingPlatformItem">
+        <source>Choosing '{0}' because it is a platform item.</source>
+        <target state="new">Choosing '{0}' because it is a platform item.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ChoosingPreferredPackage">
+        <source>Choosing '{0}' because it comes from a package that is preferred.</source>
+        <target state="new">Choosing '{0}' because it comes from a package that is preferred.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ConflictCouldNotDetermineWinner">
+        <source>Could not determine winner due to equal file and assembly versions.</source>
+        <target state="new">Could not determine winner due to equal file and assembly versions.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CouldNotDetermineWinner_DoesntExist">
+        <source>Could not determine winner because '{0}' does not exist.</source>
+        <target state="new">Could not determine winner because '{0}' does not exist.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CouldNotDetermineWinner_FileVersion">
+        <source>Could not determine a winner because '{0}' has no file version.</source>
+        <target state="new">Could not determine a winner because '{0}' has no file version.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CouldNotDetermineWinner_NotAnAssembly">
+        <source>Could not determine a winner because '{0}' is not an assembly.</source>
+        <target state="new">Could not determine a winner because '{0}' is not an assembly.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="EncounteredConflict">
+        <source>Encountered conflict between '{0}' and '{1}'.</source>
+        <target state="new">Encountered conflict between '{0}' and '{1}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CouldNotLoadPlatformManifest">
+        <source>Could not load PlatformManifest from '{0}' because it did not exist.</source>
+        <target state="new">Could not load PlatformManifest from '{0}' because it did not exist.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ErrorParsingPlatformManifest">
+        <source>Error parsing PlatformManifest from '{0}' line {1}.  Lines must have the format {2}.</source>
+        <target state="new">Error parsing PlatformManifest from '{0}' line {1}.  Lines must have the format {2}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ErrorParsingPlatformManifestInvalidValue">
+        <source>Error parsing PlatformManifest from '{0}' line {1}.  {2} '{3}' was invalid.</source>
+        <target state="new">Error parsing PlatformManifest from '{0}' line {1}.  {2} '{3}' was invalid.</target>
         <note></note>
       </trans-unit>
     </body>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.ru.xlf
@@ -203,11 +203,6 @@
         <target state="new">Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</target>
         <note></note>
       </trans-unit>
-      <trans-unit id="IncorrectFilterFormat">
-        <source>The filter profile {0} provided is of not the correct format</source>
-        <target state="new">The filter profile {0} provided is of not the correct format</target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="ParsingFiles">
         <source>Parsing the Files : '{0}'</source>
         <target state="new">Parsing the Files : '{0}'</target>
@@ -221,6 +216,86 @@
       <trans-unit id="RuntimeIdentifierWasNotSpecified">
         <source>Specify a RuntimeIdentifier</source>
         <target state="new">Specify a RuntimeIdentifier</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="IncorrectTargetFormat">
+        <source>The target manifest {0} provided is of not the correct format</source>
+        <target state="new">The target manifest {0} provided is of not the correct format</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AppHostHasBeenModified">
+        <source>Unable to use '{0}' as application host executable as it does not contain the expected placeholder byte sequence '{1}' that would mark where the application name would be written.</source>
+        <target state="new">Unable to use '{0}' as application host executable as it does not contain the expected placeholder byte sequence '{1}' that would mark where the application name would be written.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FileNameIsTooLong">
+        <source>Given file name '{0}' is longer than 1024 bytes</source>
+        <target state="new">Given file name '{0}' is longer than 1024 bytes</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CannotHaveSelfContainedWithoutRuntimeIdentifier">
+        <source>It is not supported to build or publish a self-contained application without specifying a RuntimeIdentifier.  Please either specify a RuntimeIdentifier or set SelfContained to false.</source>
+        <target state="new">It is not supported to build or publish a self-contained application without specifying a RuntimeIdentifier.  Please either specify a RuntimeIdentifier or set SelfContained to false.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ChoosingAssemblyVersion">
+        <source>Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</source>
+        <target state="new">Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ChoosingFileVersion">
+        <source>Choosing '{0}' because file version '{1}' is greater than '{2}'.</source>
+        <target state="new">Choosing '{0}' because file version '{1}' is greater than '{2}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ChoosingPlatformItem">
+        <source>Choosing '{0}' because it is a platform item.</source>
+        <target state="new">Choosing '{0}' because it is a platform item.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ChoosingPreferredPackage">
+        <source>Choosing '{0}' because it comes from a package that is preferred.</source>
+        <target state="new">Choosing '{0}' because it comes from a package that is preferred.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ConflictCouldNotDetermineWinner">
+        <source>Could not determine winner due to equal file and assembly versions.</source>
+        <target state="new">Could not determine winner due to equal file and assembly versions.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CouldNotDetermineWinner_DoesntExist">
+        <source>Could not determine winner because '{0}' does not exist.</source>
+        <target state="new">Could not determine winner because '{0}' does not exist.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CouldNotDetermineWinner_FileVersion">
+        <source>Could not determine a winner because '{0}' has no file version.</source>
+        <target state="new">Could not determine a winner because '{0}' has no file version.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CouldNotDetermineWinner_NotAnAssembly">
+        <source>Could not determine a winner because '{0}' is not an assembly.</source>
+        <target state="new">Could not determine a winner because '{0}' is not an assembly.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="EncounteredConflict">
+        <source>Encountered conflict between '{0}' and '{1}'.</source>
+        <target state="new">Encountered conflict between '{0}' and '{1}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CouldNotLoadPlatformManifest">
+        <source>Could not load PlatformManifest from '{0}' because it did not exist.</source>
+        <target state="new">Could not load PlatformManifest from '{0}' because it did not exist.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ErrorParsingPlatformManifest">
+        <source>Error parsing PlatformManifest from '{0}' line {1}.  Lines must have the format {2}.</source>
+        <target state="new">Error parsing PlatformManifest from '{0}' line {1}.  Lines must have the format {2}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ErrorParsingPlatformManifestInvalidValue">
+        <source>Error parsing PlatformManifest from '{0}' line {1}.  {2} '{3}' was invalid.</source>
+        <target state="new">Error parsing PlatformManifest from '{0}' line {1}.  {2} '{3}' was invalid.</target>
         <note></note>
       </trans-unit>
     </body>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.tr.xlf
@@ -203,11 +203,6 @@
         <target state="new">Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</target>
         <note></note>
       </trans-unit>
-      <trans-unit id="IncorrectFilterFormat">
-        <source>The filter profile {0} provided is of not the correct format</source>
-        <target state="new">The filter profile {0} provided is of not the correct format</target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="ParsingFiles">
         <source>Parsing the Files : '{0}'</source>
         <target state="new">Parsing the Files : '{0}'</target>
@@ -221,6 +216,86 @@
       <trans-unit id="RuntimeIdentifierWasNotSpecified">
         <source>Specify a RuntimeIdentifier</source>
         <target state="new">Specify a RuntimeIdentifier</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="IncorrectTargetFormat">
+        <source>The target manifest {0} provided is of not the correct format</source>
+        <target state="new">The target manifest {0} provided is of not the correct format</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AppHostHasBeenModified">
+        <source>Unable to use '{0}' as application host executable as it does not contain the expected placeholder byte sequence '{1}' that would mark where the application name would be written.</source>
+        <target state="new">Unable to use '{0}' as application host executable as it does not contain the expected placeholder byte sequence '{1}' that would mark where the application name would be written.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FileNameIsTooLong">
+        <source>Given file name '{0}' is longer than 1024 bytes</source>
+        <target state="new">Given file name '{0}' is longer than 1024 bytes</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CannotHaveSelfContainedWithoutRuntimeIdentifier">
+        <source>It is not supported to build or publish a self-contained application without specifying a RuntimeIdentifier.  Please either specify a RuntimeIdentifier or set SelfContained to false.</source>
+        <target state="new">It is not supported to build or publish a self-contained application without specifying a RuntimeIdentifier.  Please either specify a RuntimeIdentifier or set SelfContained to false.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ChoosingAssemblyVersion">
+        <source>Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</source>
+        <target state="new">Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ChoosingFileVersion">
+        <source>Choosing '{0}' because file version '{1}' is greater than '{2}'.</source>
+        <target state="new">Choosing '{0}' because file version '{1}' is greater than '{2}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ChoosingPlatformItem">
+        <source>Choosing '{0}' because it is a platform item.</source>
+        <target state="new">Choosing '{0}' because it is a platform item.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ChoosingPreferredPackage">
+        <source>Choosing '{0}' because it comes from a package that is preferred.</source>
+        <target state="new">Choosing '{0}' because it comes from a package that is preferred.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ConflictCouldNotDetermineWinner">
+        <source>Could not determine winner due to equal file and assembly versions.</source>
+        <target state="new">Could not determine winner due to equal file and assembly versions.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CouldNotDetermineWinner_DoesntExist">
+        <source>Could not determine winner because '{0}' does not exist.</source>
+        <target state="new">Could not determine winner because '{0}' does not exist.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CouldNotDetermineWinner_FileVersion">
+        <source>Could not determine a winner because '{0}' has no file version.</source>
+        <target state="new">Could not determine a winner because '{0}' has no file version.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CouldNotDetermineWinner_NotAnAssembly">
+        <source>Could not determine a winner because '{0}' is not an assembly.</source>
+        <target state="new">Could not determine a winner because '{0}' is not an assembly.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="EncounteredConflict">
+        <source>Encountered conflict between '{0}' and '{1}'.</source>
+        <target state="new">Encountered conflict between '{0}' and '{1}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CouldNotLoadPlatformManifest">
+        <source>Could not load PlatformManifest from '{0}' because it did not exist.</source>
+        <target state="new">Could not load PlatformManifest from '{0}' because it did not exist.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ErrorParsingPlatformManifest">
+        <source>Error parsing PlatformManifest from '{0}' line {1}.  Lines must have the format {2}.</source>
+        <target state="new">Error parsing PlatformManifest from '{0}' line {1}.  Lines must have the format {2}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ErrorParsingPlatformManifestInvalidValue">
+        <source>Error parsing PlatformManifest from '{0}' line {1}.  {2} '{3}' was invalid.</source>
+        <target state="new">Error parsing PlatformManifest from '{0}' line {1}.  {2} '{3}' was invalid.</target>
         <note></note>
       </trans-unit>
     </body>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.xlf
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.xlf
@@ -163,10 +163,6 @@
         <source>Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</source>
         <note></note>
       </trans-unit>
-      <trans-unit id="IncorrectFilterFormat">
-        <source>The filter profile {0} provided is of not the correct format</source>
-        <note></note>
-      </trans-unit>
       <trans-unit id="ParsingFiles">
         <source>Parsing the Files : '{0}'</source>
         <note></note>
@@ -177,6 +173,70 @@
       </trans-unit>
       <trans-unit id="RuntimeIdentifierWasNotSpecified">
         <source>Specify a RuntimeIdentifier</source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="IncorrectTargetFormat">
+        <source>The target manifest {0} provided is of not the correct format</source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AppHostHasBeenModified">
+        <source>Unable to use '{0}' as application host executable as it does not contain the expected placeholder byte sequence '{1}' that would mark where the application name would be written.</source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FileNameIsTooLong">
+        <source>Given file name '{0}' is longer than 1024 bytes</source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CannotHaveSelfContainedWithoutRuntimeIdentifier">
+        <source>It is not supported to build or publish a self-contained application without specifying a RuntimeIdentifier.  Please either specify a RuntimeIdentifier or set SelfContained to false.</source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ChoosingAssemblyVersion">
+        <source>Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ChoosingFileVersion">
+        <source>Choosing '{0}' because file version '{1}' is greater than '{2}'.</source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ChoosingPlatformItem">
+        <source>Choosing '{0}' because it is a platform item.</source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ChoosingPreferredPackage">
+        <source>Choosing '{0}' because it comes from a package that is preferred.</source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ConflictCouldNotDetermineWinner">
+        <source>Could not determine winner due to equal file and assembly versions.</source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CouldNotDetermineWinner_DoesntExist">
+        <source>Could not determine winner because '{0}' does not exist.</source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CouldNotDetermineWinner_FileVersion">
+        <source>Could not determine a winner because '{0}' has no file version.</source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CouldNotDetermineWinner_NotAnAssembly">
+        <source>Could not determine a winner because '{0}' is not an assembly.</source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="EncounteredConflict">
+        <source>Encountered conflict between '{0}' and '{1}'.</source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CouldNotLoadPlatformManifest">
+        <source>Could not load PlatformManifest from '{0}' because it did not exist.</source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ErrorParsingPlatformManifest">
+        <source>Error parsing PlatformManifest from '{0}' line {1}.  Lines must have the format {2}.</source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ErrorParsingPlatformManifestInvalidValue">
+        <source>Error parsing PlatformManifest from '{0}' line {1}.  {2} '{3}' was invalid.</source>
         <note></note>
       </trans-unit>
     </body>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.zh-Hans.xlf
@@ -203,11 +203,6 @@
         <target state="new">Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</target>
         <note></note>
       </trans-unit>
-      <trans-unit id="IncorrectFilterFormat">
-        <source>The filter profile {0} provided is of not the correct format</source>
-        <target state="new">The filter profile {0} provided is of not the correct format</target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="ParsingFiles">
         <source>Parsing the Files : '{0}'</source>
         <target state="new">Parsing the Files : '{0}'</target>
@@ -221,6 +216,86 @@
       <trans-unit id="RuntimeIdentifierWasNotSpecified">
         <source>Specify a RuntimeIdentifier</source>
         <target state="new">Specify a RuntimeIdentifier</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="IncorrectTargetFormat">
+        <source>The target manifest {0} provided is of not the correct format</source>
+        <target state="new">The target manifest {0} provided is of not the correct format</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AppHostHasBeenModified">
+        <source>Unable to use '{0}' as application host executable as it does not contain the expected placeholder byte sequence '{1}' that would mark where the application name would be written.</source>
+        <target state="new">Unable to use '{0}' as application host executable as it does not contain the expected placeholder byte sequence '{1}' that would mark where the application name would be written.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FileNameIsTooLong">
+        <source>Given file name '{0}' is longer than 1024 bytes</source>
+        <target state="new">Given file name '{0}' is longer than 1024 bytes</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CannotHaveSelfContainedWithoutRuntimeIdentifier">
+        <source>It is not supported to build or publish a self-contained application without specifying a RuntimeIdentifier.  Please either specify a RuntimeIdentifier or set SelfContained to false.</source>
+        <target state="new">It is not supported to build or publish a self-contained application without specifying a RuntimeIdentifier.  Please either specify a RuntimeIdentifier or set SelfContained to false.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ChoosingAssemblyVersion">
+        <source>Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</source>
+        <target state="new">Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ChoosingFileVersion">
+        <source>Choosing '{0}' because file version '{1}' is greater than '{2}'.</source>
+        <target state="new">Choosing '{0}' because file version '{1}' is greater than '{2}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ChoosingPlatformItem">
+        <source>Choosing '{0}' because it is a platform item.</source>
+        <target state="new">Choosing '{0}' because it is a platform item.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ChoosingPreferredPackage">
+        <source>Choosing '{0}' because it comes from a package that is preferred.</source>
+        <target state="new">Choosing '{0}' because it comes from a package that is preferred.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ConflictCouldNotDetermineWinner">
+        <source>Could not determine winner due to equal file and assembly versions.</source>
+        <target state="new">Could not determine winner due to equal file and assembly versions.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CouldNotDetermineWinner_DoesntExist">
+        <source>Could not determine winner because '{0}' does not exist.</source>
+        <target state="new">Could not determine winner because '{0}' does not exist.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CouldNotDetermineWinner_FileVersion">
+        <source>Could not determine a winner because '{0}' has no file version.</source>
+        <target state="new">Could not determine a winner because '{0}' has no file version.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CouldNotDetermineWinner_NotAnAssembly">
+        <source>Could not determine a winner because '{0}' is not an assembly.</source>
+        <target state="new">Could not determine a winner because '{0}' is not an assembly.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="EncounteredConflict">
+        <source>Encountered conflict between '{0}' and '{1}'.</source>
+        <target state="new">Encountered conflict between '{0}' and '{1}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CouldNotLoadPlatformManifest">
+        <source>Could not load PlatformManifest from '{0}' because it did not exist.</source>
+        <target state="new">Could not load PlatformManifest from '{0}' because it did not exist.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ErrorParsingPlatformManifest">
+        <source>Error parsing PlatformManifest from '{0}' line {1}.  Lines must have the format {2}.</source>
+        <target state="new">Error parsing PlatformManifest from '{0}' line {1}.  Lines must have the format {2}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ErrorParsingPlatformManifestInvalidValue">
+        <source>Error parsing PlatformManifest from '{0}' line {1}.  {2} '{3}' was invalid.</source>
+        <target state="new">Error parsing PlatformManifest from '{0}' line {1}.  {2} '{3}' was invalid.</target>
         <note></note>
       </trans-unit>
     </body>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/xlf/Strings.zh-Hant.xlf
@@ -203,11 +203,6 @@
         <target state="new">Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</target>
         <note></note>
       </trans-unit>
-      <trans-unit id="IncorrectFilterFormat">
-        <source>The filter profile {0} provided is of not the correct format</source>
-        <target state="new">The filter profile {0} provided is of not the correct format</target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="ParsingFiles">
         <source>Parsing the Files : '{0}'</source>
         <target state="new">Parsing the Files : '{0}'</target>
@@ -221,6 +216,86 @@
       <trans-unit id="RuntimeIdentifierWasNotSpecified">
         <source>Specify a RuntimeIdentifier</source>
         <target state="new">Specify a RuntimeIdentifier</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="IncorrectTargetFormat">
+        <source>The target manifest {0} provided is of not the correct format</source>
+        <target state="new">The target manifest {0} provided is of not the correct format</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AppHostHasBeenModified">
+        <source>Unable to use '{0}' as application host executable as it does not contain the expected placeholder byte sequence '{1}' that would mark where the application name would be written.</source>
+        <target state="new">Unable to use '{0}' as application host executable as it does not contain the expected placeholder byte sequence '{1}' that would mark where the application name would be written.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FileNameIsTooLong">
+        <source>Given file name '{0}' is longer than 1024 bytes</source>
+        <target state="new">Given file name '{0}' is longer than 1024 bytes</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CannotHaveSelfContainedWithoutRuntimeIdentifier">
+        <source>It is not supported to build or publish a self-contained application without specifying a RuntimeIdentifier.  Please either specify a RuntimeIdentifier or set SelfContained to false.</source>
+        <target state="new">It is not supported to build or publish a self-contained application without specifying a RuntimeIdentifier.  Please either specify a RuntimeIdentifier or set SelfContained to false.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ChoosingAssemblyVersion">
+        <source>Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</source>
+        <target state="new">Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ChoosingFileVersion">
+        <source>Choosing '{0}' because file version '{1}' is greater than '{2}'.</source>
+        <target state="new">Choosing '{0}' because file version '{1}' is greater than '{2}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ChoosingPlatformItem">
+        <source>Choosing '{0}' because it is a platform item.</source>
+        <target state="new">Choosing '{0}' because it is a platform item.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ChoosingPreferredPackage">
+        <source>Choosing '{0}' because it comes from a package that is preferred.</source>
+        <target state="new">Choosing '{0}' because it comes from a package that is preferred.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ConflictCouldNotDetermineWinner">
+        <source>Could not determine winner due to equal file and assembly versions.</source>
+        <target state="new">Could not determine winner due to equal file and assembly versions.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CouldNotDetermineWinner_DoesntExist">
+        <source>Could not determine winner because '{0}' does not exist.</source>
+        <target state="new">Could not determine winner because '{0}' does not exist.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CouldNotDetermineWinner_FileVersion">
+        <source>Could not determine a winner because '{0}' has no file version.</source>
+        <target state="new">Could not determine a winner because '{0}' has no file version.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CouldNotDetermineWinner_NotAnAssembly">
+        <source>Could not determine a winner because '{0}' is not an assembly.</source>
+        <target state="new">Could not determine a winner because '{0}' is not an assembly.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="EncounteredConflict">
+        <source>Encountered conflict between '{0}' and '{1}'.</source>
+        <target state="new">Encountered conflict between '{0}' and '{1}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CouldNotLoadPlatformManifest">
+        <source>Could not load PlatformManifest from '{0}' because it did not exist.</source>
+        <target state="new">Could not load PlatformManifest from '{0}' because it did not exist.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ErrorParsingPlatformManifest">
+        <source>Error parsing PlatformManifest from '{0}' line {1}.  Lines must have the format {2}.</source>
+        <target state="new">Error parsing PlatformManifest from '{0}' line {1}.  Lines must have the format {2}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ErrorParsingPlatformManifestInvalidValue">
+        <source>Error parsing PlatformManifest from '{0}' line {1}.  {2} '{3}' was invalid.</source>
+        <target state="new">Error parsing PlatformManifest from '{0}' line {1}.  {2} '{3}' was invalid.</target>
         <note></note>
       </trans-unit>
     </body>


### PR DESCRIPTION
@dsplaisted @livarcocc  @dotnet/dotnet-cli 

@MattGertz This is a required step to handoff new 2.0 SDK strings to loc team. It will not impact the product until the loc team submits the translations back.


