### PR TITLE
Provide a flag to indicate that Microsoft.NET.Sdk is used

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/sdk/Sdk.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/sdk/Sdk.props
@@ -13,6 +13,17 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <PropertyGroup>
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+
+    <!--
+      Indicate to other targets that Microsoft.NET.Sdk is being used.
+
+      This must be set here (as early as possible, before Microsoft.Common.props)
+      so that everything that follows can depend on it.
+
+      In particular, Directory.Build.props and nuget package props need to be able
+      to use this flag and they are imported by Microsoft.Common.props.
+    -->
+    <UsingMicrosoftNETSdk>true</UsingMicrosoftNETSdk>
   </PropertyGroup>
 
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" />


### PR DESCRIPTION
**Customer scenario**

Partner and ecosystem features need to be able to adjust themselves based on whether or not the project they're working with uses Microsoft.NET.Sdk. This has been identified as blocking corefx for preview2.

**Bugs this fixes:** 

#534

**Workarounds, if any**

None. There were some unsupported things you could sniff, but all of them were defined too late for use in corefx's scenario. This gives an official, supported property that is set as early as possible.

**Risk**

Low. 

**Performance impact**

None.

**Is this a regression from a previous update?**

No

**Root cause analysis:**

N/A


**How was the bug found?**

N/A

@MattGertz for approval