### PR TITLE
Make HasRuntimeOutput change compatible with existing test sdk versions

### DIFF
--- a/TestAssets/TestProjects/XUnitTestProject/UnitTest1.cs
+++ b/TestAssets/TestProjects/XUnitTestProject/UnitTest1.cs
@@ -1,0 +1,14 @@
+using System;
+using Xunit;
+
+namespace XUnitTestProject1
+{
+    public class UnitTest1
+    {
+        [Fact]
+        public void Test1()
+        {
+
+        }
+    }
+}

--- a/TestAssets/TestProjects/XUnitTestProject/XUnitTestProject.csproj
+++ b/TestAssets/TestProjects/XUnitTestProject/XUnitTestProject.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
+    <PackageReference Include="xunit" Version="2.2.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+  </ItemGroup>
+
+</Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.BeforeCommon.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.BeforeCommon.targets
@@ -13,9 +13,12 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <PropertyGroup>
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
-    <_IsExecutable Condition="'$(_IsExecutable)' == '' and '$(OutputType)'=='Exe'">true</_IsExecutable>
-    <_IsExecutable Condition="'$(_IsExecutable)' == '' and '$(OutputType)'=='WinExe'">true</_IsExecutable>
-    <HasRuntimeOutput Condition="'$(HasRuntimeOutput)' == ''">$(_IsExecutable)</HasRuntimeOutput>
+    <_IsExecutable Condition="'$(OutputType)' == 'Exe' or '$(OutputType)'=='WinExe'">true</_IsExecutable>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(HasRuntimeOutput)' == ''">
+    <HasRuntimeOutput>$(_IsExecutable)</HasRuntimeOutput>
+    <_UsingDefaultForHasRuntimeOutput>true</_UsingDefaultForHasRuntimeOutput>
   </PropertyGroup>
 
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.NET.DefaultAssemblyInfo.targets" />

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.Common.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.Common.targets
@@ -28,6 +28,16 @@ Copyright (c) .NET Foundation. All rights reserved.
     <DefaultImplicitPackages>Microsoft.NETCore.App;NETStandard.Library</DefaultImplicitPackages>
   </PropertyGroup>
 
+  <!--
+     Some versions of Microsoft.NET.Test.Sdk.targets change the OutputType after we've set _IsExecutable and
+     HasRuntimeOutput default in Microsfot.NET.Sdk.BeforeCommon.targets. Refresh these value here for backwards
+     compatibilty with that.
+   -->
+  <PropertyGroup>
+    <_IsExecutable Condition="'$(OutputType)' == 'Exe' or '$(OutputType)'=='WinExe'">true</_IsExecutable>
+    <HasRuntimeOutput Condition="'$(_UsingDefaultForHasRuntimeOutput)' == 'true'">$(_IsExecutable)</HasRuntimeOutput>
+  </PropertyGroup>
+
   <PropertyGroup Condition="'$(DotnetCliToolTargetFramework)' == '' And '$(BundledNETCoreAppTargetFrameworkVersion)' != ''">
     <!-- Set the TFM used to restore .NET CLI tools to match the version of .NET Core bundled in the CLI -->
     <DotnetCliToolTargetFramework>netcoreapp$(BundledNETCoreAppTargetFrameworkVersion)</DotnetCliToolTargetFramework>

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAUnitTestProject.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAUnitTestProject.cs
@@ -1,0 +1,37 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.NET.TestFramework;
+using Microsoft.NET.TestFramework.Assertions;
+using Microsoft.NET.TestFramework.Commands;
+using Xunit;
+using FluentAssertions;
+using Xunit.Abstractions;
+
+namespace Microsoft.NET.Build.Tests
+{
+    public class GivenThatWeWantToBuildAUnitTestProject : SdkTest
+    {
+        public GivenThatWeWantToBuildAUnitTestProject(ITestOutputHelper log) : base(log)
+        {
+        }
+
+        [Fact]
+        public void It_generates_runtime_config()
+        {
+            var testAsset = _testAssetsManager
+                .CopyTestAsset("XUnitTestProject")
+                .WithSource()
+                .Restore(Log);
+
+            var buildCommand = new BuildCommand(Log, testAsset.TestRoot);
+            buildCommand
+                .Execute()
+                .Should()
+                .Pass();
+
+            var outputDirectory = buildCommand.GetOutputDirectory("netcoreapp2.0");
+            outputDirectory.Should().HaveFile(@"XUnitTestProject.runtimeconfig.json");
+        }
+    }
+}


### PR DESCRIPTION
#1178 caused projects using existing test SDK to break.  Caught by dotnet test coverage in CLI repo.

The problem is that the test SDK changes the OutputType in targets after we've already set some variables based on it.

This is blocking the ingestion of a new dotnet/SDK into dotnet/CLI


**Customer scenario**

Using a unit test project that references a version of the test sdk that has not yet implemented https://github.com/Microsoft/vstest/issues/792 (which at this time is all versions of the test sdk because the feature isn't implemented yet.

**Bugs this fixes:** 

None filed because it was found during ingestion of dotnet/sdk to dotnet/cli so nobody was impacted by it yet.

**Workarounds, if any**

None. 

**Risk**

Low. 

**Performance impact**

Low.

**Is this a regression from a previous update?**

It is a regression in this repo, but it never saw the light of day because we caught it in CLI repo on its way to the outside world.

**Root cause analysis:**

Lack of test coverage in sdk repo, relying on CLI tests to catch it. I've added a test in this repo to prevent the long turn around on finding another similar regression.

**How was the bug found?**

Automated testing


