### PR TITLE
PreserveCompilationContext should take into account runtime store assemblies

### DIFF
--- a/TestAssets/TestProjects/CompilationContext/TestApp/TestApp.csproj
+++ b/TestAssets/TestProjects/CompilationContext/TestApp/TestApp.csproj
@@ -10,5 +10,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.3.0" />
   </ItemGroup>
 </Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/DependencyContextBuilder.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/DependencyContextBuilder.cs
@@ -26,7 +26,7 @@ namespace Microsoft.NET.Build.Tasks
         private IEnumerable<string> _excludeFromPublishPackageIds;
         private CompilationOptions _compilationOptions;
         private string _referenceAssembliesPath;
-        private Dictionary<PackageIdentity, StringBuilder> _filteredPackages;
+        private Dictionary<PackageIdentity, string> _filteredPackages;
         private bool _includeMainProjectInDepsFile = true;
 
         public DependencyContextBuilder(SingleProjectInfo mainProjectInfo, ProjectContext projectContext)
@@ -82,7 +82,7 @@ namespace Microsoft.NET.Build.Tasks
             return this;
         }
 
-        public DependencyContextBuilder WithPackagesThatWhereFiltered(Dictionary<PackageIdentity, StringBuilder> packagesThatWhereFiltered)
+        public DependencyContextBuilder WithPackagesThatWhereFiltered(Dictionary<PackageIdentity, string> packagesThatWhereFiltered)
         {
             _filteredPackages = packagesThatWhereFiltered;
             return this;
@@ -223,11 +223,7 @@ namespace Microsoft.NET.Build.Tasks
         {
             string runtimeStoreManifestName = null;
             var pkg = new PackageIdentity(name, NuGetVersion.Parse(version));
-            StringBuilder listofManifests = null;
-            if (_filteredPackages?.TryGetValue(pkg, out listofManifests) == true)
-            {
-                runtimeStoreManifestName = listofManifests.ToString();
-            }
+            _filteredPackages?.TryGetValue(pkg, out runtimeStoreManifestName);
 
             return new RuntimeLibrary(
                 type,

--- a/src/Tasks/Microsoft.NET.Build.Tasks/FindItemsFromPackages.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/FindItemsFromPackages.cs
@@ -18,8 +18,6 @@ namespace Microsoft.NET.Build.Tasks
     /// </remarks>
     public sealed class FindItemsFromPackages : TaskBase
     {
-        private readonly List<ITaskItem> _itemsFromPackages = new List<ITaskItem>();
-
         [Required]
         public ITaskItem[] Items { get; set; }
 
@@ -27,24 +25,24 @@ namespace Microsoft.NET.Build.Tasks
         public ITaskItem[] Packages { get; set; }
 
         [Output]
-        public ITaskItem[] ItemsFromPackages
-        {
-            get { return _itemsFromPackages.ToArray(); }
-        }
+        public ITaskItem[] ItemsFromPackages { get; private set; }
 
         protected override void ExecuteCore()
         {
-            HashSet<PackageIdentity> packageIdentities = new HashSet<PackageIdentity>(
+            var packageIdentities = new HashSet<PackageIdentity>(
                 Packages.Select(p => ItemUtilities.GetPackageIdentity(p)));
-            
+
+            var itemsFromPackages = new List<ITaskItem>();
             foreach (ITaskItem item in Items)
             {
                 PackageIdentity identity = ItemUtilities.GetPackageIdentity(item);
                 if (identity != null && packageIdentities.Contains(identity))
                 {
-                    _itemsFromPackages.Add(item);
+                    itemsFromPackages.Add(item);
                 }
             }
+
+            ItemsFromPackages = itemsFromPackages.ToArray();
         }
     }
 }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/FindItemsFromPackages.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/FindItemsFromPackages.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Build.Framework;
+using NuGet.Packaging.Core;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.NET.Build.Tasks
+{
+    /// <summary>
+    /// Returns the ITaskItem values in Items that were resolved from the specified
+    /// set of Packages.
+    /// </summary>
+    /// <remarks>
+    /// Both Items and Packages are expected to have 'PackageName' and 'PackageVersion' 
+    /// metadata properties to use for the matching.
+    /// </remarks>
+    public sealed class FindItemsFromPackages : TaskBase
+    {
+        private readonly List<ITaskItem> _itemsFromPackages = new List<ITaskItem>();
+
+        [Required]
+        public ITaskItem[] Items { get; set; }
+
+        [Required]
+        public ITaskItem[] Packages { get; set; }
+
+        [Output]
+        public ITaskItem[] ItemsFromPackages
+        {
+            get { return _itemsFromPackages.ToArray(); }
+        }
+
+        protected override void ExecuteCore()
+        {
+            HashSet<PackageIdentity> packageIdentities = new HashSet<PackageIdentity>(
+                Packages.Select(p => ItemUtilities.GetPackageIdentity(p)));
+            
+            foreach (ITaskItem item in Items)
+            {
+                PackageIdentity identity = ItemUtilities.GetPackageIdentity(item);
+                if (identity != null && packageIdentities.Contains(identity))
+                {
+                    _itemsFromPackages.Add(item);
+                }
+            }
+        }
+    }
+}

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ItemUtilities.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ItemUtilities.cs
@@ -137,9 +137,17 @@ namespace Microsoft.NET.Build.Tasks
 
         public static PackageIdentity GetPackageIdentity(ITaskItem item)
         {
+            string packageName = item.GetMetadata(MetadataKeys.PackageName);
+            string packageVersion = item.GetMetadata(MetadataKeys.PackageVersion);
+
+            if (string.IsNullOrEmpty(packageName) || string.IsNullOrEmpty(packageVersion))
+            {
+                return null;
+            }
+
             return new PackageIdentity(
-                item.GetMetadata(MetadataKeys.PackageName),
-                NuGetVersion.Parse(item.GetMetadata(MetadataKeys.PackageVersion)));
+                packageName,
+                NuGetVersion.Parse(packageVersion));
         }
     }
 }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ItemUtilities.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ItemUtilities.cs
@@ -1,9 +1,11 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using Microsoft.Build.Framework;
 using Microsoft.NET.Build.Tasks.ConflictResolution;
+using NuGet.Packaging.Core;
+using NuGet.Versioning;
+using System;
 using System.IO;
 
 namespace Microsoft.NET.Build.Tasks
@@ -131,6 +133,13 @@ namespace Microsoft.NET.Build.Tasks
             var sourcePath = GetSourcePath(item);
 
             return Path.GetFileName(sourcePath);
+        }
+
+        public static PackageIdentity GetPackageIdentity(ITaskItem item)
+        {
+            return new PackageIdentity(
+                item.GetMetadata(MetadataKeys.PackageName),
+                NuGetVersion.Parse(item.GetMetadata(MetadataKeys.PackageVersion)));
         }
     }
 }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/MetadataKeys.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/MetadataKeys.cs
@@ -47,5 +47,8 @@ namespace Microsoft.NET.Build.Tasks
         public const string StartColumn = "StartColumn";
         public const string EndLine = "EndLine";
         public const string EndColumn = "EndColumn";
+
+        // Publish Target Manifest
+        public const string RuntimeStoreManifestNames = "RuntimeStoreManifestNames";
     }
 }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ParseTargetManifests.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ParseTargetManifests.cs
@@ -1,0 +1,73 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using NuGet.Packaging.Core;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Text;
+
+namespace Microsoft.NET.Build.Tasks
+{
+    /// <summary>
+    /// Parses the target manifest files into MSBuild Items.
+    /// </summary>
+    public sealed class ParseTargetManifests : TaskBase
+    {
+        private readonly List<ITaskItem> _runtimeStorePackages = new List<ITaskItem>();
+
+        public string TargetManifestFiles { get; set; }
+
+        [Output]
+        public ITaskItem[] RuntimeStorePackages
+        {
+            get { return _runtimeStorePackages.ToArray(); }
+        }
+
+        protected override void ExecuteCore()
+        {
+            string[] targetManifestFileList = TargetManifestFiles?.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
+
+            if (targetManifestFileList != null && targetManifestFileList.Length > 0)
+            {
+                var runtimeStorePackages = new Dictionary<PackageIdentity, StringBuilder>();
+                foreach (var manifestFile in targetManifestFileList)
+                {
+                    Log.LogMessage(MessageImportance.Low, string.Format(CultureInfo.CurrentCulture, Strings.ParsingFiles, manifestFile));
+                    var packagesSpecified = StoreArtifactParser.Parse(manifestFile);
+                    var targetManifestFileName = Path.GetFileName(manifestFile);
+
+                    foreach (var pkg in packagesSpecified)
+                    {
+                        Log.LogMessage(MessageImportance.Low, string.Format(CultureInfo.CurrentCulture, Strings.PackageInfoLog, pkg.Id, pkg.Version));
+                        StringBuilder fileList;
+                        if (runtimeStorePackages.TryGetValue(pkg, out fileList))
+                        {
+                            fileList.Append($";{targetManifestFileName}");
+                        }
+                        else
+                        {
+                            runtimeStorePackages.Add(pkg, new StringBuilder(targetManifestFileName));
+                        }
+                    }
+                }
+
+                foreach (var storeEntry in runtimeStorePackages)
+                {
+                    string packageName = storeEntry.Key.Id;
+                    string packageVersion = storeEntry.Key.Version.ToNormalizedString();
+
+                    TaskItem item = new TaskItem($"{packageName}/{packageVersion}");
+                    item.SetMetadata(MetadataKeys.PackageName, packageName);
+                    item.SetMetadata(MetadataKeys.PackageVersion, packageVersion);
+                    item.SetMetadata(MetadataKeys.RuntimeStoreManifestNames, storeEntry.Value.ToString());
+
+                    _runtimeStorePackages.Add(item);
+                }
+            }
+        }
+    }
+}

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ParseTargetManifests.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ParseTargetManifests.cs
@@ -17,15 +17,10 @@ namespace Microsoft.NET.Build.Tasks
     /// </summary>
     public sealed class ParseTargetManifests : TaskBase
     {
-        private readonly List<ITaskItem> _runtimeStorePackages = new List<ITaskItem>();
-
         public string TargetManifestFiles { get; set; }
 
         [Output]
-        public ITaskItem[] RuntimeStorePackages
-        {
-            get { return _runtimeStorePackages.ToArray(); }
-        }
+        public ITaskItem[] RuntimeStorePackages { get; private set; }
 
         protected override void ExecuteCore()
         {
@@ -55,6 +50,7 @@ namespace Microsoft.NET.Build.Tasks
                     }
                 }
 
+                var resultPackages = new List<ITaskItem>();
                 foreach (var storeEntry in runtimeStorePackages)
                 {
                     string packageName = storeEntry.Key.Id;
@@ -65,8 +61,10 @@ namespace Microsoft.NET.Build.Tasks
                     item.SetMetadata(MetadataKeys.PackageVersion, packageVersion);
                     item.SetMetadata(MetadataKeys.RuntimeStoreManifestNames, storeEntry.Value.ToString());
 
-                    _runtimeStorePackages.Add(item);
+                    resultPackages.Add(item);
                 }
+
+                RuntimeStorePackages = resultPackages.ToArray();
             }
         }
     }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.PreserveCompilationContext.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.PreserveCompilationContext.targets
@@ -41,17 +41,32 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   </Target>
 
+  <UsingTask TaskName="FindItemsFromPackages" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
   <Target Name="ComputeRefAssembliesToPublish"
           Condition="'$(PreserveCompilationContext)' == 'true'"
+          DependsOnTargets="_ComputeLockFileCopyLocal;
+                            _ParseTargetManifestFiles"
           AfterTargets="ComputeFilesToPublish"
           BeforeTargets="CopyFilesToPublishDirectory">
 
+    <FindItemsFromPackages Items="@(_RuntimeCopyLocalItems)"
+                           Packages="@(RuntimeStorePackages)">
+      <Output TaskParameter="ItemsFromPackages" ItemName="_RuntimeItemsInRuntimeStore"/>
+    </FindItemsFromPackages>
+    
     <ItemGroup>
       <!--
       Don't copy a compilation assembly if it's also a runtime assembly. There is no need to copy the same
       assembly to the 'refs' folder, if it is already in the publish directory.
       -->
-      <ResolvedFileToPublish Include="@(ReferencePath)" Exclude="@(ResolvedAssembliesToPublish->'%(FullPath)')">
+      <_RefAssembliesToExclude Include="@(ResolvedAssembliesToPublish->'%(FullPath)')" />
+      <!--
+      Similarly, don't copy a compilation assembly if it's also a runtime assembly that is in a runtime store.
+      It will be resolved from the runtime store directory at runtime.
+      -->
+      <_RefAssembliesToExclude Include="@(_RuntimeItemsInRuntimeStore->'%(ResolvedPath)')" />
+
+      <ResolvedFileToPublish Include="@(ReferencePath)" Exclude="@(_RefAssembliesToExclude)">
         <RelativePath>$(RefAssembliesFolderName)\%(Filename)%(Extension)</RelativePath>
       </ResolvedFileToPublish>
     </ItemGroup>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Publish.targets
@@ -29,10 +29,6 @@ Copyright (c) .NET Foundation. All rights reserved.
     </ResolvedFileToPublish>
   </ItemDefinitionGroup>
 
-  <ItemGroup>
-    <TargetManifestFileList Include="$(TargetManifestFiles.Split('%3B'))"/>
-  </ItemGroup>
-
   <!--
     ============================================================
                                         Publish
@@ -248,6 +244,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <UsingTask TaskName="ResolvePublishAssemblies" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
   <Target Name="RunResolvePublishAssemblies"
           DependsOnTargets="_ComputeExcludeFromPublishPackageReferences;
+                            _ParseTargetManifestFiles;
                             _DefaultMicrosoftNETPlatformLibrary">
     <ResolvePublishAssemblies ProjectPath="$(MSBuildProjectFullPath)"
                               AssetsFilePath="$(ProjectAssetsFile)"
@@ -255,7 +252,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                               RuntimeIdentifier="$(RuntimeIdentifier)"
                               PlatformLibraryName="$(MicrosoftNETPlatformLibrary)"
                               ExcludeFromPublishPackageReferences="@(_ExcludeFromPublishPackageReference)"
-                              TargetManifestFiles="@(TargetManifestFileList)"
+                              RuntimeStorePackages="@(RuntimeStorePackages)"
                               PreserveStoreLayout="$(PreserveStoreLayout)"
                               IsSelfContained="$(SelfContained)" >
 
@@ -461,6 +458,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     -->
   <Target Name="GeneratePublishDependencyFile"
           DependsOnTargets="_ComputeExcludeFromPublishPackageReferences;
+                            _ParseTargetManifestFiles;
                             _DefaultMicrosoftNETPlatformLibrary;
                             _HandlePackageFileConflicts;
                             _HandlePublishFileConflicts"
@@ -486,7 +484,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                       FilesToSkip="@(_ConflictPackageFiles);@(_PublishConflictPackageFiles)"
                       CompilerOptions="@(DependencyFileCompilerOptions)"
                       ExcludeFromPublishPackageReferences="@(_ExcludeFromPublishPackageReference)"
-                      TargetManifestFileList="@(TargetManifestFileList)"
+                      RuntimeStorePackages="@(RuntimeStorePackages)"
                       IsSelfContained="$(SelfContained)" />
 
   </Target>
@@ -515,6 +513,25 @@ Copyright (c) .NET Foundation. All rights reserved.
       <_ExcludeFromPublishPackageReference Include="@(PackageReference)"
                                           Condition="('%(PackageReference.Publish)' == 'false')" />
     </ItemGroup>
+
+  </Target>
+
+  <!--
+    ============================================================
+                                        _ParseTargetManifestFiles
+
+    Parses the $(TargetManifestFiles) which contains a list of files into @(RuntimeStorePackages) items
+    which describes which packages should be excluded from publish since they are contained in the runtime store.
+    ============================================================
+    -->
+  <UsingTask TaskName="ParseTargetManifests" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
+  <Target Name="_ParseTargetManifestFiles"
+          Condition="'$(TargetManifestFiles)' != ''"
+          Returns="@(RuntimeStorePackages)">
+
+    <ParseTargetManifests TargetManifestFiles="$(TargetManifestFiles)">
+      <Output TaskParameter="RuntimeStorePackages" ItemName="RuntimeStorePackages"/>
+    </ParseTargetManifests>
 
   </Target>
 

--- a/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPreserveCompilationContext.cs
+++ b/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPreserveCompilationContext.cs
@@ -19,6 +19,10 @@ namespace Microsoft.NET.Publish.Tests
 {
     public class GivenThatWeWantToPreserveCompilationContext : SdkTest
     {
+        public GivenThatWeWantToPreserveCompilationContext(ITestOutputHelper log) : base(log)
+        {
+        }
+
         [Fact]
         public void It_publishes_the_project_with_a_refs_folder_and_correct_deps_file()
         {
@@ -123,11 +127,65 @@ namespace Microsoft.NET.Publish.Tests
             }
         }
 
+        [Fact]
+        public void It_excludes_runtime_store_packages_from_the_refs_folder()
+        {
+            var testAsset = _testAssetsManager
+                .CopyTestAsset("CompilationContext", "PreserveCompilationContextRefs")
+                .WithSource()
+                .Restore(Log, "TestApp");
+
+            var manifestFile = Path.Combine(testAsset.TestRoot, "manifest.xml");
+
+            File.WriteAllLines(manifestFile, new[]
+            {
+                "<StoreArtifacts>",
+                @"  <Package Id=""Newtonsoft.Json"" Version=""9.0.1"" />",
+                @"  <Package Id=""System.Data.Common"" Version=""4.3.0"" />",
+                @"  <Package Id=""System.Data.SqlClient"" Version=""4.3.0"" />",
+                "</StoreArtifacts>",
+            });
+
+            var appProjectDirectory = Path.Combine(testAsset.TestRoot, "TestApp");
+
+            var targetFramework = "netcoreapp1.1";
+            var publishCommand = new PublishCommand(Log, appProjectDirectory);
+            publishCommand
+                .Execute($"/p:TargetFramework={targetFramework}", $"/p:TargetManifestFiles={manifestFile}")
+                .Should()
+                .Pass();
+
+            var publishDirectory = publishCommand.GetOutputDirectory(targetFramework, runtimeIdentifier: "win7-x86");
+
+            publishDirectory.Should().HaveFiles(new[] {
+                "TestApp.dll",
+                "TestLibrary.dll"});
+
+            // excluded through TargetManifestFiles
+            publishDirectory.Should().NotHaveFile("Newtonsoft.Json.dll");
+            publishDirectory.Should().NotHaveFile("System.Data.Common.dll");
+            publishDirectory.Should().NotHaveFile("System.Data.SqlClient.dll");
+
+            var refsDirectory = new DirectoryInfo(Path.Combine(publishDirectory.FullName, "refs"));
+            // Should have compilation time assemblies
+            refsDirectory.Should().HaveFile("System.IO.dll");
+            // System.Data.Common|SqlClient have separate compile and runtime assemblies, so the compile assembly
+            // should be copied to refs even though the runtime assembly is listed in TargetManifestFiles
+            refsDirectory.Should().HaveFile("System.Data.Common.dll");
+            refsDirectory.Should().HaveFile("System.Data.SqlClient.dll");
+
+            // Libraries in which lib==ref should be deduped
+            refsDirectory.Should().NotHaveFile("TestLibrary.dll");
+            refsDirectory.Should().NotHaveFile("Newtonsoft.Json.dll");
+        }
+
         string[] Net46CompileLibraryNames = @"TestApp.exe
 mscorlib.dll
 System.ComponentModel.Composition.dll
 System.Core.dll
+System.Data.Common.dll
 System.Data.dll
+System.Data.SqlClient.dll
 System.dll
 System.Drawing.dll
 System.IO.Compression.FileSystem.dll
@@ -206,7 +264,7 @@ System.Security.Cryptography.X509Certificates.dll
 System.Xml.ReaderWriter.dll
 TestLibrary.dll".Split(new char[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
 
-        string [] NetCoreAppCompileLibraryNames = @"TestApp.dll
+        string[] NetCoreAppCompileLibraryNames = @"TestApp.dll
 Microsoft.CSharp.dll
 Microsoft.VisualBasic.dll
 Microsoft.Win32.Primitives.dll
@@ -219,6 +277,8 @@ System.Collections.Immutable.dll
 System.ComponentModel.dll
 System.ComponentModel.Annotations.dll
 System.Console.dll
+System.Data.Common.dll
+System.Data.SqlClient.dll
 System.Diagnostics.Debug.dll
 System.Diagnostics.DiagnosticSource.dll
 System.Diagnostics.Process.dll
@@ -286,9 +346,5 @@ System.Threading.Timer.dll
 System.Xml.ReaderWriter.dll
 System.Xml.XDocument.dll
 TestLibrary.dll".Split(new char[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
-
-        public GivenThatWeWantToPreserveCompilationContext(ITestOutputHelper log) : base(log)
-        {
-        }
     }
 }


### PR DESCRIPTION
When PreserveCompilationContext is set to `true`, runtime assemblies that are already in the runtime store shouldn't be copied to the `refs` folder.  Instead, they should be resolved from the runtime store at runtime.

Fix https://github.com/dotnet/sdk/issues/1216

End-to-end scenario is blocked by https://github.com/dotnet/core-setup/pull/2498