### PR TITLE
Implement version cap for .NET Standard and .NET Core

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.Designer.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.Designer.cs
@@ -20,7 +20,7 @@ namespace Microsoft.NET.Build.Tasks {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Strings {
@@ -589,6 +589,15 @@ namespace Microsoft.NET.Build.Tasks {
         internal static string UnrecognizedPreprocessorToken {
             get {
                 return ResourceManager.GetString("UnrecognizedPreprocessorToken", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The current .NET SDK does not support targeting {0} {1}.  Either target {0} {2} or lower, or use a version of the .NET SDK that supports {0} {1}..
+        /// </summary>
+        internal static string UnsupportedTargetFrameworkVersion {
+            get {
+                return ResourceManager.GetString("UnsupportedTargetFrameworkVersion", resourceCulture);
             }
         }
     }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.resx
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.resx
@@ -294,4 +294,7 @@
   <data name="ErrorParsingPlatformManifestInvalidValue" xml:space="preserve">
     <value>Error parsing PlatformManifest from '{0}' line {1}.  {2} '{3}' was invalid.</value>
   </data>
+  <data name="UnsupportedTargetFrameworkVersion" xml:space="preserve">
+    <value>The current .NET SDK does not support targeting {0} {1}.  Either target {0} {2} or lower, or use a version of the .NET SDK that supports {0} {1}.</value>
+  </data>
 </root>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.TargetFrameworkInference.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.TargetFrameworkInference.targets
@@ -96,6 +96,36 @@ Copyright (c) .NET Foundation. All rights reserved.
   <PropertyGroup Condition="'$(TargetFrameworkVersion)' == ''">
     <TargetFrameworkVersion >v0.0</TargetFrameworkVersion>
   </PropertyGroup>
+  
+  <!--
+    Trigger an error if targeting a higher version of .NET Core or .NET Standard than is supported by the current SDK.
+  -->
+
+  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(NETCoreAppMaximumVersion)' == ''">
+    <NETCoreAppMaximumVersion>$(BundledNETCoreAppTargetFrameworkVersion)</NETCoreAppMaximumVersion>
+  </PropertyGroup>
+    
+  <Target Name="_CheckForUnsupportedNETCoreVersion" BeforeTargets="_CheckForInvalidConfigurationAndPlatform;Restore;CollectPackageReferences"
+          Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
+
+    <NETSdkError Condition="'$(_TargetFrameworkVersionWithoutV)' > '$(NETCoreAppMaximumVersion)'"
+                 ResourceName="UnsupportedTargetFrameworkVersion"
+                 FormatArguments=".NET Core;$(_TargetFrameworkVersionWithoutV);$(NETCoreAppMaximumVersion)"
+      />
+  </Target>
+
+  <PropertyGroup  Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard' And '$(NETStandardMaximumVersion)' == ''">
+    <NETStandardMaximumVersion>$(BundledNETStandardTargetFrameworkVersion)</NETStandardMaximumVersion>
+  </PropertyGroup>
+
+  <Target Name="_CheckForUnsupportedNETStandardVersion" BeforeTargets="_CheckForInvalidConfigurationAndPlatform;Restore;CollectPackageReferences"
+          Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard'">
+
+    <NETSdkError Condition="'$(_TargetFrameworkVersionWithoutV)' > '$(NETStandardMaximumVersion)'"
+                 ResourceName="UnsupportedTargetFrameworkVersion"
+                 FormatArguments=".NET Standard;$(_TargetFrameworkVersionWithoutV);$(NETStandardMaximumVersion)"
+      />    
+  </Target>
 
 
   <!-- Exclude files from OutputPath and IntermediateOutputPath from default item globs.  Use the value


### PR DESCRIPTION
Generate an error if targeting a version of .NET Core or .NET Standard higher than the current SDK supports

Fixes #1194

