### PR TITLE
Incremental build improvements for generated AssemblyInfo.cs using inputs cache

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.GenerateAssemblyInfo.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.GenerateAssemblyInfo.targets
@@ -48,10 +48,7 @@ Copyright (c) .NET Foundation. All rights reserved.
           DependsOnTargets="PrepareForBuild;GetAssemblyVersion;CoreGenerateAssemblyInfo"
           Condition="'$(GenerateAssemblyInfo)' == 'true'" />
 
-  <Target Name="CoreGenerateAssemblyInfo"
-          Condition="'$(Language)'=='VB' or '$(Language)'=='C#'"
-          Inputs="$(MSBuildAllProjects)"
-          Outputs="$(GeneratedAssemblyInfoFile)">
+  <Target Name="_CalculateAssemblyAttributes">
     <ItemGroup>
       <AssemblyAttribute Include="System.Reflection.AssemblyCompanyAttribute" Condition="'$(Company)' != '' and '$(GenerateAssemblyCompanyAttribute)' == 'true'">
         <_Parameter1>$(Company)</_Parameter1>
@@ -84,7 +81,35 @@ Copyright (c) .NET Foundation. All rights reserved.
         <_Parameter1>$(NeutralLanguage)</_Parameter1>
       </AssemblyAttribute>
     </ItemGroup>
+  </Target>
 
+  <!-- 
+    To allow version changes to be respected on incremental builds (e.g. through CLI parameters),
+    create a hash of all assembly attributes so that the lock file name will change with the calculated
+    assembly attribute values and msbuild will then execute CoreGenerateAssembly to generate a new file.
+  -->
+  <Target Name="_CreateGeneratedAssemblyInfoInputsCacheFile"
+          DependsOnTargets="_CalculateAssemblyAttributes"
+          BeforeTargets="CoreGenerateAssemblyInfo">
+    <PropertyGroup>
+      <GeneratedAssemblyInfoInputsCacheFile>$(IntermediateOutputPath)$(MSBuildProjectName).AssemblyInfoInputs.cache</GeneratedAssemblyInfoInputsCacheFile>
+    </PropertyGroup>
+
+    <Hash ItemsToHash="@(AssemblyAttribute->'%(Identity)%(_Parameter1)')">
+      <Output TaskParameter="HashResult" PropertyName="_AssemblyAttributesHash" />
+    </Hash>
+
+    <WriteLinesToFile Lines="$(_AssemblyAttributesHash)" File="$(GeneratedAssemblyInfoInputsCacheFile)" Overwrite="True" WriteOnlyWhenDifferent="True" />
+    
+    <ItemGroup>
+      <FileWrites Include="$(GeneratedAssemblyInfoInputsCacheFile)" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="CoreGenerateAssemblyInfo"
+          Condition="'$(Language)'=='VB' or '$(Language)'=='C#'"
+          Inputs="$(MSBuildAllProjects);$(GeneratedAssemblyInfoInputsCacheFile)"
+          Outputs="$(GeneratedAssemblyInfoFile)">
     <ItemGroup>
       <!-- Ensure the generated assemblyinfo file is not already part of the Compile sources, as a workaround for https://github.com/dotnet/sdk/issues/114 -->
       <Compile Remove="$(GeneratedAssemblyInfoFile)" />

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.GenerateAssemblyInfo.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.GenerateAssemblyInfo.targets
@@ -45,10 +45,11 @@ Copyright (c) .NET Foundation. All rights reserved.
    -->
   <Target Name="GenerateAssemblyInfo"
           BeforeTargets="CoreCompile"
-          DependsOnTargets="PrepareForBuild;GetAssemblyVersion;CoreGenerateAssemblyInfo"
+          DependsOnTargets="PrepareForBuild;CoreGenerateAssemblyInfo"
           Condition="'$(GenerateAssemblyInfo)' == 'true'" />
 
-  <Target Name="_CalculateAssemblyAttributes">
+  <Target Name="GetAssemblyAttributes"
+          DependsOnTargets="GetAssemblyVersion">
     <ItemGroup>
       <AssemblyAttribute Include="System.Reflection.AssemblyCompanyAttribute" Condition="'$(Company)' != '' and '$(GenerateAssemblyCompanyAttribute)' == 'true'">
         <_Parameter1>$(Company)</_Parameter1>
@@ -85,12 +86,11 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <!-- 
     To allow version changes to be respected on incremental builds (e.g. through CLI parameters),
-    create a hash of all assembly attributes so that the lock file name will change with the calculated
+    create a hash of all assembly attributes so that the cache file will change with the calculated
     assembly attribute values and msbuild will then execute CoreGenerateAssembly to generate a new file.
   -->
-  <Target Name="_CreateGeneratedAssemblyInfoInputsCacheFile"
-          DependsOnTargets="_CalculateAssemblyAttributes"
-          BeforeTargets="CoreGenerateAssemblyInfo">
+  <Target Name="CreateGeneratedAssemblyInfoInputsCacheFile"
+          DependsOnTargets="GetAssemblyAttributes">
     <PropertyGroup>
       <GeneratedAssemblyInfoInputsCacheFile>$(IntermediateOutputPath)$(MSBuildProjectName).AssemblyInfoInputs.cache</GeneratedAssemblyInfoInputsCacheFile>
     </PropertyGroup>
@@ -108,7 +108,8 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <Target Name="CoreGenerateAssemblyInfo"
           Condition="'$(Language)'=='VB' or '$(Language)'=='C#'"
-          Inputs="$(MSBuildAllProjects);$(GeneratedAssemblyInfoInputsCacheFile)"
+          DependsOnTargets="CreateGeneratedAssemblyInfoInputsCacheFile"
+          Inputs="$(GeneratedAssemblyInfoInputsCacheFile)"
           Outputs="$(GeneratedAssemblyInfoFile)">
     <ItemGroup>
       <!-- Ensure the generated assemblyinfo file is not already part of the Compile sources, as a workaround for https://github.com/dotnet/sdk/issues/114 -->

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToControlGeneratedAssemblyInfo.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToControlGeneratedAssemblyInfo.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
+using System.Linq;
 using System.IO;
 using Microsoft.NET.TestFramework;
 using Microsoft.NET.TestFramework.Assertions;
@@ -116,6 +117,41 @@ namespace Microsoft.NET.Build.Tests
             info["AssemblyVersionAttribute"].Should().Be("1.2.3.0");
             info["AssemblyFileVersionAttribute"].Should().Be("1.2.3.0");
             info["AssemblyInformationalVersionAttribute"].Should().Be("1.2.3");
+        }
+
+        [Theory]
+        [InlineData("netcoreapp1.1")]
+        [InlineData("net45")]
+        public void It_respects_version_changes_on_incremental_build(string targetFramework)
+        {
+            if (targetFramework == "net45" && !RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return;
+            }
+
+            // Given a project that has already been built
+            var testAsset = _testAssetsManager
+                .CopyTestAsset("HelloWorld", identifier: targetFramework)
+                .WithSource()
+                .Restore(Log, "", $"/p:OutputType=Library;TargetFramework={targetFramework}");
+            BuildProject(versionPrefix: "1.2.3");
+
+            // When the same project is built again using a different VersionPrefix proeprty
+            var incrementalBuildCommand = BuildProject(versionPrefix: "1.2.4");
+
+            // Then the version of the built assembly shall match the provided VersionPrefix
+            var assemblyPath = Path.Combine(incrementalBuildCommand.GetOutputDirectory(targetFramework).FullName, "HelloWorld.dll");
+            var info = AssemblyInfo.Get(assemblyPath);
+            info["AssemblyVersionAttribute"].Should().Be("1.2.4.0");
+
+            BuildCommand BuildProject(string versionPrefix)
+            {
+                var command = new BuildCommand(Log, testAsset.TestRoot);
+                command.Execute($"/p:OutputType=Library;TargetFramework={targetFramework};VersionPrefix={versionPrefix}")
+                       .Should()
+                       .Pass();
+                return command;
+            }
         }
     }
 }


### PR DESCRIPTION
Alternative to #1007 (fixes #967) using a mechanism similar to `CoreCompileInputs.cache`:

Splits `CoreGenerateAssemblyInfo` into:

1. `GetAssemblyAttributes` which creates all `AssemblyAttribute` items.
2. `CreateGeneratedAssemblyInfoInputsCacheFile` creates an `obj/tfm/projectname.AssemblyInfoInputs.cache` file containing the hash of all `AssemblyAttribute` items. This filename is available as `$(GeneratedAssemblyInfoInputsCacheFile)`. The target uses msbuild 15's `WriteOnlyWhenDifferent="True"` feature for `WriteLinesToFile` so the file doesn't change unnecessarily.
3. `CoreGenerateAssemblyInfo` which generates the `projectname.AssemblyInfo.cs` file, using the cache file as input for incremental build.

cc @nguerrera @dsplaisted @rainersigwald 

Also cc @enricosada @KevinRansom  who want to use the refactor to overwrite `CoreGenerateAssemblyInfo` in F# specific targets (https://github.com/Microsoft/visualfsharp/issues/3113)