### PR TITLE
Don't generate deps or runtimeconfig files when build has failed but _CleanRecordFileWrites is being run

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.targets
@@ -82,7 +82,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <Target Name="GenerateBuildDependencyFile"
           DependsOnTargets="_DefaultMicrosoftNETPlatformLibrary;_HandlePackageFileConflicts"
-          BeforeTargets="_CheckForCompileOutputs"
+          BeforeTargets="CopyFilesToOutputDirectory"
           Condition=" '$(GenerateDependencyFile)' == 'true'"
           Inputs="$(ProjectAssetsFile)"
           Outputs="$(ProjectDepsFilePath)">
@@ -126,7 +126,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <Target Name="GenerateBuildRuntimeConfigurationFiles"
           DependsOnTargets="_DefaultMicrosoftNETPlatformLibrary"
-          BeforeTargets="_CheckForCompileOutputs"
+          BeforeTargets="CopyFilesToOutputDirectory"
           Condition=" '$(GenerateRuntimeConfigurationFiles)' == 'true'"
           Inputs="$(ProjectAssetsFile);$(UserRuntimeConfig)"
           Outputs="$(ProjectRuntimeConfigFilePath);$(ProjectRuntimeConfigDevFilePath)">

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildADesktopExe.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildADesktopExe.cs
@@ -335,7 +335,8 @@ namespace DefaultReferences
 
             var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
 
-            var result = buildCommand.Execute();
+            //  Pass "/clp:summary" so that we can check output for string "1 Error(s)"
+            var result = buildCommand.Execute("/clp:summary");
 
             result.Should().Fail();
 
@@ -345,7 +346,8 @@ namespace DefaultReferences
             //  Error code for exception generated from task
             result.StdOut.Should().NotContain("MSB4018");
 
-            Regex.Matches(result.StdOut, "error").Count.Should().Be(1);
+            //  Ensure no other errors are generated
+            result.StdOut.Should().Contain("1 Error(s)");
         }
 
         [Fact]


### PR DESCRIPTION
Fixes #1234

The `GenerateBuildRuntimeConfigurationFiles` runs before `_CheckForCompileOutputs`, so that the `FileWrites` items it adds will be picked up by `_CleanGetCurrentAndPriorFileWrites`, and incremental builds and cleans will work correctly.  (See some discussion of this on #381)

However, the `CoreBuild` target invokes the `_CleanRecordFileWrites` target [when it errors](https://github.com/Microsoft/msbuild/blob/a8a025b9751461feaedc0a78cd28c226f5872bdf/src/Tasks/Microsoft.Common.CurrentVersion.targets#L838):

```xml
  <Target
      Name="CoreBuild"
      DependsOnTargets="$(CoreBuildDependsOn)">

    <OnError ExecuteTargets="_TimeStampAfterCompile;PostBuildEvent" Condition="'$(RunPostBuildEvent)'=='Always' or '$(RunPostBuildEvent)'=='OnOutputUpdated'"/>
    <OnError ExecuteTargets="_CleanRecordFileWrites"/>

  </Target>
```

This means that even if there is a previous build error, we are trying to generate the runtime config files.  In the case of #1234, the output path where we would write them hasn't been created, so the task throws an exception.

This PR adds a condition to only run the task if the folder it's going to write to exists.  This feels like a band-aid solution though.  Is there a better way to structure this which would add the correct `FileWrites` items when needed, but not even run the target if `GetReferenceAssemblyPaths` or some other target before-hand has failed?

@rainersigwald @AndyGerlicher @nguerrera