### PR TITLE
Include log files in Jenkins archive

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -56,6 +56,7 @@ ${buildCommand}""")
 
         def archiveSettings = new ArchivalSettings()
         archiveSettings.addFiles("bin/**/*")
+        archiveSettings.addFiles("bin/log/**/*")
         archiveSettings.excludeFiles("bin/obj/*")
         archiveSettings.setFailIfNothingArchived()
         archiveSettings.setArchiveOnFailure()


### PR DESCRIPTION
This will include the structured log of the build in the Jenkins archive which will be helpful diagnosing build issues.