### PR TITLE
Improve error messages when project hasn't been restored for the right target framework or runtime identifier

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/CheckForTargetInAssetsFile.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/CheckForTargetInAssetsFile.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Build.Framework;
+using NuGet.ProjectModel;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.NET.Build.Tasks
+{
+    public class CheckForTargetInAssetsFile : TaskBase
+    {
+        [Required]
+        public string AssetsFilePath { get; set; }
+
+        [Required]
+        public string TargetFrameworkMoniker { get; set; }
+
+        public string RuntimeIdentifier { get; set; }
+
+
+        protected override void ExecuteCore()
+        {
+            LockFile lockFile = new LockFileCache(BuildEngine4).GetLockFile(AssetsFilePath);
+
+            var nugetFramework = NuGetUtils.ParseFrameworkName(TargetFrameworkMoniker);
+
+            lockFile.GetTargetAndThrowIfNotFound(nugetFramework, RuntimeIdentifier);
+        }
+    }
+}

--- a/src/Tasks/Microsoft.NET.Build.Tasks/LockFileExtensions.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/LockFileExtensions.cs
@@ -23,10 +23,14 @@ namespace Microsoft.NET.Build.Tasks
                     frameworkString :
                     $"{frameworkString}/{runtime}";
 
-                string message = string.Format(Strings.AssetsFileMissingTarget, lockFile.Path, targetMoniker, framework.GetShortFolderName());
-                if (!string.IsNullOrEmpty(runtime))
+                string message;
+                if (string.IsNullOrEmpty(runtime))
                 {
-                    message += " " + string.Format(Strings.AssetsFileMissingRuntimeIdentifier, runtime);
+                    message = string.Format(Strings.AssetsFileMissingTarget, lockFile.Path, targetMoniker, framework.GetShortFolderName());
+                }
+                else
+                {
+                    message = string.Format(Strings.AssetsFileMissingRuntimeIdentifier, lockFile.Path, targetMoniker, framework.GetShortFolderName(), runtime);
                 }
 
                 throw new BuildErrorException(message);

--- a/src/Tasks/Microsoft.NET.Build.Tasks/LockFileExtensions.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/LockFileExtensions.cs
@@ -37,7 +37,13 @@ namespace Microsoft.NET.Build.Tasks
                     frameworkString :
                     $"{frameworkString}/{runtime}";
 
-                throw new BuildErrorException(Strings.AssetsFileMissingTarget, lockFile.Path, targetMoniker, framework.GetShortFolderName(), runtime);
+                string message = string.Format(Strings.AssetsFileMissingTarget, lockFile.Path, targetMoniker, framework.GetShortFolderName());
+                if (!string.IsNullOrEmpty(runtime))
+                {
+                    message += " " + string.Format(Strings.AssetsFileMissingRuntimeIdentifier, runtime);
+                }
+
+                throw new BuildErrorException(message);
             }
 
             LockFileTargetLibrary platformLibrary = lockFileTarget.GetLibrary(platformLibraryName);

--- a/src/Tasks/Microsoft.NET.Build.Tasks/LockFileExtensions.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/LockFileExtensions.cs
@@ -12,22 +12,8 @@ namespace Microsoft.NET.Build.Tasks
 {
     internal static class LockFileExtensions
     {
-        public static ProjectContext CreateProjectContext(
-            this LockFile lockFile,
-            NuGetFramework framework,
-            string runtime,
-            string platformLibraryName,
-            bool isSelfContained)
+        public static LockFileTarget GetTargetAndThrowIfNotFound(this LockFile lockFile, NuGetFramework framework, string runtime)
         {
-            if (lockFile == null)
-            {
-                throw new ArgumentNullException(nameof(lockFile));
-            }
-            if (framework == null)
-            {
-                throw new ArgumentNullException(nameof(framework));
-            }
-
             LockFileTarget lockFileTarget = lockFile.GetTarget(framework, runtime);
 
             if (lockFileTarget == null)
@@ -45,6 +31,27 @@ namespace Microsoft.NET.Build.Tasks
 
                 throw new BuildErrorException(message);
             }
+
+            return lockFileTarget;
+        }
+
+        public static ProjectContext CreateProjectContext(
+            this LockFile lockFile,
+            NuGetFramework framework,
+            string runtime,
+            string platformLibraryName,
+            bool isSelfContained)
+        {
+            if (lockFile == null)
+            {
+                throw new ArgumentNullException(nameof(lockFile));
+            }
+            if (framework == null)
+            {
+                throw new ArgumentNullException(nameof(framework));
+            }
+
+            var lockFileTarget = lockFile.GetTargetAndThrowIfNotFound(framework, runtime);
 
             LockFileTargetLibrary platformLibrary = lockFileTarget.GetLibrary(platformLibraryName);
             bool isFrameworkDependent = platformLibrary != null && (!isSelfContained || string.IsNullOrEmpty(lockFileTarget.RuntimeIdentifier));

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Microsoft.NET.Build.Tasks.csproj
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Microsoft.NET.Build.Tasks.csproj
@@ -47,8 +47,8 @@
       <DependentUpon>Strings.resx</DependentUpon>
     </EmbeddedResource>
     <Compile Update="Resources\Strings.Designer.cs">
-      <DesignTime>true</DesignTime>
-      <AutoGen>true</AutoGen>
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
       <DependentUpon>Strings.resx</DependentUpon>
     </Compile>
   </ItemGroup>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.Designer.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.Designer.cs
@@ -80,7 +80,7 @@ namespace Microsoft.NET.Build.Tasks {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to You may also need to include &apos;{0}&apos; in your project&apos;s RuntimeIdentifiers..
+        ///   Looks up a localized string similar to Assets file &apos;{0}&apos; doesn&apos;t have a target for &apos;{1}&apos;. Ensure you have included &apos;{2}&apos; in the TargetFrameworks for your project. You may also need to include &apos;{3}&apos; in your project&apos;s RuntimeIdentifiers..
         /// </summary>
         internal static string AssetsFileMissingRuntimeIdentifier {
             get {

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.Designer.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.Designer.cs
@@ -80,7 +80,16 @@ namespace Microsoft.NET.Build.Tasks {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Assets file &apos;{0}&apos; doesn&apos;t have a target for &apos;{1}&apos;. Ensure you have restored this project for TargetFramework=&apos;{2}&apos; and RuntimeIdentifier=&apos;{3}&apos;..
+        ///   Looks up a localized string similar to You may also need to include &apos;{0}&apos; in your project&apos;s RuntimeIdentifiers..
+        /// </summary>
+        internal static string AssetsFileMissingRuntimeIdentifier {
+            get {
+                return ResourceManager.GetString("AssetsFileMissingRuntimeIdentifier", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Assets file &apos;{0}&apos; doesn&apos;t have a target for &apos;{1}&apos;. Ensure you have included &apos;{2}&apos; in the TargetFrameworks for your project..
         /// </summary>
         internal static string AssetsFileMissingTarget {
             get {

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.resx
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.resx
@@ -130,7 +130,7 @@
     <value>Assets file '{0}' not found. Run a NuGet package restore to generate this file.</value>
   </data>
   <data name="AssetsFileMissingTarget" xml:space="preserve">
-    <value>Assets file '{0}' doesn't have a target for '{1}'. Ensure you have restored this project for TargetFramework='{2}' and RuntimeIdentifier='{3}'.</value>
+    <value>Assets file '{0}' doesn't have a target for '{1}'. Ensure you have included '{2}' in the TargetFrameworks for your project.</value>
   </data>
   <data name="AssetsFilePathNotRooted" xml:space="preserve">
     <value>Assets file path '{0}' is not rooted. Only full paths are supported.</value>
@@ -296,5 +296,8 @@
   </data>
   <data name="UnsupportedTargetFrameworkVersion" xml:space="preserve">
     <value>The current .NET SDK does not support targeting {0} {1}.  Either target {0} {2} or lower, or use a version of the .NET SDK that supports {0} {1}.</value>
+  </data>
+  <data name="AssetsFileMissingRuntimeIdentifier" xml:space="preserve">
+    <value>You may also need to include '{0}' in your project's RuntimeIdentifiers.</value>
   </data>
 </root>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.resx
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.resx
@@ -298,6 +298,6 @@
     <value>The current .NET SDK does not support targeting {0} {1}.  Either target {0} {2} or lower, or use a version of the .NET SDK that supports {0} {1}.</value>
   </data>
   <data name="AssetsFileMissingRuntimeIdentifier" xml:space="preserve">
-    <value>You may also need to include '{0}' in your project's RuntimeIdentifiers.</value>
+    <value>Assets file '{0}' doesn't have a target for '{1}'. Ensure you have included '{2}' in the TargetFrameworks for your project. You may also need to include '{3}' in your project's RuntimeIdentifiers.</value>
   </data>
 </root>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.PackageDependencyResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.PackageDependencyResolution.targets
@@ -157,14 +157,11 @@ Copyright (c) .NET Foundation. All rights reserved.
     
     <!-- Verify that the assets file has a target for the right framework.  Otherwise, if we restored for the
          wrong framework, we'd end up finding no references to pass to the compiler, and we'd get a ton of
-         compile errors.
-         
-         The RuntimeIdentifier isn't used to select references to pass to the compiler, so we don't include
-         it here. -->
+         compile errors. -->
     <CheckForTargetInAssetsFile
       AssetsFilePath="$(ProjectAssetsFile)"
       TargetFrameworkMoniker="$(TargetFrameworkMoniker)"
-      RuntimeIdentifier="" />
+      RuntimeIdentifier="$(RuntimeIdentifier)" />
     
     <ResolvePackageDependencies
       ProjectPath="$(MSBuildProjectFullPath)"

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.PackageDependencyResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.PackageDependencyResolution.targets
@@ -145,6 +145,8 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <UsingTask TaskName="Microsoft.NET.Build.Tasks.ResolvePackageDependencies"
              AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
+  <UsingTask TaskName="Microsoft.NET.Build.Tasks.CheckForTargetInAssetsFile"
+           AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
 
   <!-- The condition on this target causes it to be skipped during design-time builds if
         the restore operation hasn't run yet.  This is to avoid displaying an error in
@@ -152,6 +154,13 @@ Copyright (c) .NET Foundation. All rights reserved.
         run and created the assets file. -->
   <Target Name="RunResolvePackageDependencies"
           Condition=" '$(DesignTimeBuild)' != 'true' Or Exists('$(ProjectAssetsFile)')">
+    
+    <!-- Verify that the assets file has a target for the right framework and runtime -->
+    <CheckForTargetInAssetsFile
+      AssetsFilePath="$(ProjectAssetsFile)"
+      TargetFrameworkMoniker="$(TargetFrameworkMoniker)"
+      RuntimeIdentifier="$(RuntimeIdentifier)" />
+    
     <ResolvePackageDependencies
       ProjectPath="$(MSBuildProjectFullPath)"
       ProjectAssetsFile="$(ProjectAssetsFile)"

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.PackageDependencyResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.PackageDependencyResolution.targets
@@ -155,11 +155,16 @@ Copyright (c) .NET Foundation. All rights reserved.
   <Target Name="RunResolvePackageDependencies"
           Condition=" '$(DesignTimeBuild)' != 'true' Or Exists('$(ProjectAssetsFile)')">
     
-    <!-- Verify that the assets file has a target for the right framework and runtime -->
+    <!-- Verify that the assets file has a target for the right framework.  Otherwise, if we restored for the
+         wrong framework, we'd end up finding no references to pass to the compiler, and we'd get a ton of
+         compile errors.
+         
+         The RuntimeIdentifier isn't used to select references to pass to the compiler, so we don't include
+         it here. -->
     <CheckForTargetInAssetsFile
       AssetsFilePath="$(ProjectAssetsFile)"
       TargetFrameworkMoniker="$(TargetFrameworkMoniker)"
-      RuntimeIdentifier="$(RuntimeIdentifier)" />
+      RuntimeIdentifier="" />
     
     <ResolvePackageDependencies
       ProjectPath="$(MSBuildProjectFullPath)"

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildALibrary.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildALibrary.cs
@@ -17,6 +17,9 @@ using System;
 using System.Runtime.CompilerServices;
 using Xunit.Abstractions;
 using Microsoft.NET.TestFramework.ProjectConstruction;
+using NuGet.ProjectModel;
+using NuGet.Common;
+using Newtonsoft.Json.Linq;
 
 namespace Microsoft.NET.Build.Tests
 {
@@ -591,19 +594,46 @@ namespace Microsoft.NET.Build.Tests
         [Fact]
         public void It_passes_ridless_target_to_compiler()
         {
-            var testAsset = _testAssetsManager
-                .CopyTestAsset("AppWithLibrary", "RidlessLib")
-                .WithSource()
-                .Restore(Log, relativePath: "TestLibrary");
+            var runtimeIdentifier = EnvironmentInfo.GetCompatibleRid("netcoreapp2.0");
 
-            var libraryProjectDirectory = Path.Combine(testAsset.TestRoot, "TestLibrary");
-            var fullPathProjectFile = new BuildCommand(Log, libraryProjectDirectory).FullPathProjectFile;
+            var testProject = new TestProject()
+            {
+                Name = "CompileDoesntUseRid",
+                TargetFrameworks = "netcoreapp2.0",
+                RuntimeIdentifier = runtimeIdentifier,
+                IsSdkProject = true
+            };
 
-            // compile should still pass with unknown RID because references are always pulled 
-            // from RIDLess target
-            var buildCommand = new MSBuildCommand(Log, "Compile", fullPathProjectFile);
+            var testAsset = _testAssetsManager.CreateTestProject(testProject, testProject.Name)
+                .WithProjectChanges(project =>
+                {
+                    //  Set property to disable logic in Microsoft.NETCore.App package that will otherwise cause a failure
+                    //  when we remove everything under the rid-specific targets in the assets file
+                    var ns = project.Root.Name.Namespace;
+                    project.Root.Element(ns + "PropertyGroup")
+                        .Add(new XElement(ns + "EnsureNETCoreAppRuntime", false));
+                })
+                .Restore(Log, testProject.Name);
+
+            var buildCommand = new BuildCommand(Log, testAsset.TestRoot, testProject.Name);
+
+            //  Test that compilation doesn't depend on any rid-specific assets by removing them from the assets file after it's been restored
+            var assetsFilePath = Path.Combine(buildCommand.GetBaseIntermediateDirectory().FullName, "project.assets.json");
+
+            JObject assetsContents = JObject.Parse(File.ReadAllText(assetsFilePath));
+            foreach (JProperty target in assetsContents["targets"])
+            {
+                if (target.Name.Contains("/"))
+                {
+                    //  This is a target element with a RID specified, so remove all its contents
+                    target.Value = new JObject();
+                }
+            }
+            string newContents = assetsContents.ToString();
+            File.WriteAllText(assetsFilePath, newContents);
+
             buildCommand
-                .Execute("/p:RuntimeIdentifier=unkownrid")
+                .Execute()
                 .Should()
                 .Pass();
         }


### PR DESCRIPTION
Fixes #648 

Changes error from:

> Assets file 'C:\git\dotnet-sdk\bin\repro\WrongFramework\obj\project.assets.json' doesn't have a target for '.NETFramework,Version=v4.6.1/win7-x86'. Ensure you have restored this project for TargetFramework='net461' and RuntimeIdentifier='win7-x86'.

To either this (if RuntimeIdentifier is empty):

> Assets file 'C:\git\dotnet-sdk\bin\repro\WrongFramework\obj\project.assets.json' doesn't have a target for '.NETCoreApp,Version=v1.1'. Ensure you have included 'netcoreapp1.1' in the TargetFrameworks for your project.

Or this (if there is a RuntimeIdentifier):

> Assets file 'C:\git\dotnet-sdk\bin\repro\WrongFramework\obj\project.assets.json' doesn't have a target for '.NETFramework,Version=v4.6.1/win7-x86'. Ensure you have included 'net461' in the TargetFrameworks for your project. You may also need to include 'win7-x86' in your project's RuntimeIdentifiers.

This PR also adds an explicit check in the `RunResolvePackageDependencies` target that the right target exists in the assets file.  Previously, it was happening incidentally in the `GenerateBuildRuntimeConfigurationFiles` target, which runs after the compiler is called.  So the error would likely either not be noticed among all the compile errors, or after #1257 wouldn't be generated at all.