### PR TITLE
Fix the ASP.NET MVC on Desktop

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/DependencyContextBuilder.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/DependencyContextBuilder.cs
@@ -20,7 +20,7 @@ namespace Microsoft.NET.Build.Tasks
         private readonly VersionFolderPathResolver _versionFolderPathResolver;
         private readonly SingleProjectInfo _mainProjectInfo;
         private readonly ProjectContext _projectContext;
-        private IEnumerable<ReferenceInfo> _frameworkReferences;
+        private IEnumerable<ReferenceInfo> _referenceAssemblyReferences;
         private IEnumerable<ReferenceInfo> _directReferences;
         private Dictionary<string, SingleProjectInfo> _referenceProjectInfos;
         private IEnumerable<string> _excludeFromPublishPackageIds;
@@ -44,11 +44,11 @@ namespace Microsoft.NET.Build.Tasks
             return this;
         }
 
-        public DependencyContextBuilder WithFrameworkReferences(IEnumerable<ReferenceInfo> frameworkReferences)
+        public DependencyContextBuilder WithReferenceAssemblyReferences(IEnumerable<ReferenceInfo> referenceAssemblyReferences)
         {
-            // note: Framework libraries only export compile-time stuff
+            // note: ReferenceAssembly libraries only export compile-time stuff
             // since they assume the runtime library is present already
-            _frameworkReferences = frameworkReferences;
+            _referenceAssemblyReferences = referenceAssemblyReferences;
             return this;
         }
 
@@ -138,7 +138,7 @@ namespace Microsoft.NET.Build.Tasks
                 }
 
                 compilationLibraries = compilationLibraries
-                    .Concat(GetFrameworkLibraries())
+                    .Concat(GetReferenceAssemblyLibraries())
                     .Concat(GetLibraries(compilationExports, libraryLookup, dependencyLookup, runtime: false).Cast<CompilationLibrary>())
                     .Concat(GetDirectReferenceCompilationLibraries());
             }
@@ -197,7 +197,7 @@ namespace Microsoft.NET.Build.Tasks
             }
 
             var referenceInfos = Enumerable.Concat(
-                _frameworkReferences ?? Enumerable.Empty<ReferenceInfo>(),
+                _referenceAssemblyReferences ?? Enumerable.Empty<ReferenceInfo>(),
                 _directReferences ?? Enumerable.Empty<ReferenceInfo>());
 
             foreach (ReferenceInfo referenceInfo in referenceInfos)
@@ -452,9 +452,9 @@ namespace Microsoft.NET.Build.Tasks
             }
         }
 
-        private IEnumerable<CompilationLibrary> GetFrameworkLibraries()
+        private IEnumerable<CompilationLibrary> GetReferenceAssemblyLibraries()
         {
-            return _frameworkReferences
+            return _referenceAssemblyReferences
                 ?.Select(r => new CompilationLibrary(
                     type: "referenceassembly",
                     name: r.Name,

--- a/src/Tasks/Microsoft.NET.Build.Tasks/DependencyContextBuilder.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/DependencyContextBuilder.cs
@@ -20,7 +20,7 @@ namespace Microsoft.NET.Build.Tasks
         private readonly VersionFolderPathResolver _versionFolderPathResolver;
         private readonly SingleProjectInfo _mainProjectInfo;
         private readonly ProjectContext _projectContext;
-        private IEnumerable<ReferenceInfo> _referenceAssemblyReferences;
+        private IEnumerable<ReferenceInfo> _referenceAssemblies;
         private IEnumerable<ReferenceInfo> _directReferences;
         private Dictionary<string, SingleProjectInfo> _referenceProjectInfos;
         private IEnumerable<string> _excludeFromPublishPackageIds;
@@ -44,11 +44,11 @@ namespace Microsoft.NET.Build.Tasks
             return this;
         }
 
-        public DependencyContextBuilder WithReferenceAssemblyReferences(IEnumerable<ReferenceInfo> referenceAssemblyReferences)
+        public DependencyContextBuilder WithReferenceAssemblies(IEnumerable<ReferenceInfo> referenceAssemblies)
         {
             // note: ReferenceAssembly libraries only export compile-time stuff
             // since they assume the runtime library is present already
-            _referenceAssemblyReferences = referenceAssemblyReferences;
+            _referenceAssemblies = referenceAssemblies;
             return this;
         }
 
@@ -197,7 +197,7 @@ namespace Microsoft.NET.Build.Tasks
             }
 
             var referenceInfos = Enumerable.Concat(
-                _referenceAssemblyReferences ?? Enumerable.Empty<ReferenceInfo>(),
+                _referenceAssemblies ?? Enumerable.Empty<ReferenceInfo>(),
                 _directReferences ?? Enumerable.Empty<ReferenceInfo>());
 
             foreach (ReferenceInfo referenceInfo in referenceInfos)
@@ -454,7 +454,7 @@ namespace Microsoft.NET.Build.Tasks
 
         private IEnumerable<CompilationLibrary> GetReferenceAssemblyLibraries()
         {
-            return _referenceAssemblyReferences
+            return _referenceAssemblies
                 ?.Select(r => new CompilationLibrary(
                     type: "referenceassembly",
                     name: r.Name,

--- a/src/Tasks/Microsoft.NET.Build.Tasks/GenerateDepsFile.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/GenerateDepsFile.cs
@@ -114,7 +114,7 @@ namespace Microsoft.NET.Build.Tasks
                     AssemblyVersion,
                     AssemblySatelliteAssemblies);            
 
-            IEnumerable<ReferenceInfo> referenceAssemblyReferences =
+            IEnumerable<ReferenceInfo> referenceAssemblyInfos =
                 ReferenceInfo.CreateReferenceInfos(ReferenceAssemblies);
 
             IEnumerable<ReferenceInfo> directReferences =
@@ -134,7 +134,7 @@ namespace Microsoft.NET.Build.Tasks
 
             DependencyContext dependencyContext = new DependencyContextBuilder(mainProject, projectContext)
                 .WithMainProjectInDepsFile(IncludeMainProject)
-                .WithReferenceAssemblyReferences(referenceAssemblyReferences)
+                .WithReferenceAssemblies(referenceAssemblyInfos)
                 .WithDirectReferences(directReferences)
                 .WithReferenceProjectInfos(referenceProjects)
                 .WithExcludeFromPublishAssets(excludeFromPublishAssets)

--- a/src/Tasks/Microsoft.NET.Build.Tasks/GenerateDepsFile.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/GenerateDepsFile.cs
@@ -58,6 +58,9 @@ namespace Microsoft.NET.Build.Tasks
         public ITaskItem[] ReferenceSatellitePaths { get; set; }
 
         [Required]
+        public ITaskItem[] ReferenceAssemblies { get; set; }
+
+        [Required]
         public ITaskItem[] FilesToSkip { get; set; }
 
         public ITaskItem CompilerOptions { get; set; }
@@ -111,8 +114,8 @@ namespace Microsoft.NET.Build.Tasks
                     AssemblyVersion,
                     AssemblySatelliteAssemblies);            
 
-            IEnumerable<ReferenceInfo> frameworkReferences =
-                ReferenceInfo.CreateFrameworkReferenceInfos(ReferencePaths);
+            IEnumerable<ReferenceInfo> referenceAssemblyReferences =
+                ReferenceInfo.CreateReferenceInfos(ReferenceAssemblies);
 
             IEnumerable<ReferenceInfo> directReferences =
                 ReferenceInfo.CreateDirectReferenceInfos(ReferencePaths, ReferenceSatellitePaths);
@@ -131,7 +134,7 @@ namespace Microsoft.NET.Build.Tasks
 
             DependencyContext dependencyContext = new DependencyContextBuilder(mainProject, projectContext)
                 .WithMainProjectInDepsFile(IncludeMainProject)
-                .WithFrameworkReferences(frameworkReferences)
+                .WithReferenceAssemblyReferences(referenceAssemblyReferences)
                 .WithDirectReferences(directReferences)
                 .WithReferenceProjectInfos(referenceProjects)
                 .WithExcludeFromPublishAssets(excludeFromPublishAssets)

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ReferenceInfo.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ReferenceInfo.cs
@@ -31,19 +31,15 @@ namespace Microsoft.NET.Build.Tasks
             _resourceAssemblies = new List<ResourceAssemblyInfo>();
         }
 
-        public static IEnumerable<ReferenceInfo> CreateFrameworkReferenceInfos(IEnumerable<ITaskItem> referencePaths)
+        public static IEnumerable<ReferenceInfo> CreateReferenceInfos(IEnumerable<ITaskItem> referencePaths)
         {
-            IEnumerable<ITaskItem> frameworkReferencePaths = referencePaths
-                .Where(r => r.GetBooleanMetadata("FrameworkFile") == true ||
-                            r.GetMetadata("ResolvedFrom") == "ImplicitlyExpandDesignTimeFacades");
-
-            List<ReferenceInfo> frameworkReferences = new List<ReferenceInfo>();
-            foreach (ITaskItem frameworkReferencePath in frameworkReferencePaths)
+            List<ReferenceInfo> referenceInfos = new List<ReferenceInfo>();
+            foreach (ITaskItem referencePath in referencePaths)
             {
-                frameworkReferences.Add(CreateReferenceInfo(frameworkReferencePath));
+                referenceInfos.Add(CreateReferenceInfo(referencePath));
             }
 
-            return frameworkReferences;
+            return referenceInfos;
         }
 
         public static IEnumerable<ReferenceInfo> CreateDirectReferenceInfos(

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.PreserveCompilationContext.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.PreserveCompilationContext.targets
@@ -13,14 +13,14 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <PropertyGroup>
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
-    
+
     <RefAssembliesFolderName Condition="'$(RefAssembliesFolderName)' == ''">refs</RefAssembliesFolderName>
   </PropertyGroup>
 
   <Target Name="ComputeDependencyFileCompilerOptions"
-        Condition="'$(PreserveCompilationContext)' == 'true'"
-        BeforeTargets="GenerateBuildDependencyFile;
-                       GeneratePublishDependencyFile">
+          Condition="'$(PreserveCompilationContext)' == 'true'"
+          BeforeTargets="GenerateBuildDependencyFile;
+                         GeneratePublishDependencyFile">
 
     <ItemGroup>
       <DependencyFileCompilerOptions Include="CompilerOptions">
@@ -53,7 +53,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                            Packages="@(RuntimeStorePackages)">
       <Output TaskParameter="ItemsFromPackages" ItemName="_RuntimeItemsInRuntimeStore"/>
     </FindItemsFromPackages>
-    
+
     <ItemGroup>
       <!--
       Don't copy a compilation assembly if it's also a runtime assembly. There is no need to copy the same
@@ -70,6 +70,34 @@ Copyright (c) .NET Foundation. All rights reserved.
         <RelativePath>$(RefAssembliesFolderName)\%(Filename)%(Extension)</RelativePath>
       </ResolvedFileToPublish>
     </ItemGroup>
+
+  </Target>
+
+  <!--
+    ============================================================
+                                        _CopyReferenceOnlyAssembliesForBuild
+
+    Copies reference assemblies that normally can't be resolved at runtime to the 'refs' folder in the build output.
+    This is necessary in order for the running app to resolve these reference assemblies.
+    ============================================================
+    -->
+  <Target Name="_CopyReferenceOnlyAssembliesForBuild"
+          Condition="'$(PreserveCompilationContext)' == 'true'"
+          DependsOnTargets="_ComputeReferenceAssemblies"
+          AfterTargets="CopyFilesToOutputDirectory">
+
+    <Copy SourceFiles="@(_ReferenceOnlyAssemblies)"
+          DestinationFolder="$(OutDir)$(RefAssembliesFolderName)"
+          SkipUnchangedFiles="$(SkipCopyUnchangedFiles)"
+          OverwriteReadOnlyFiles="$(OverwriteReadOnlyFiles)"
+          Retries="$(CopyRetryCount)"
+          RetryDelayMilliseconds="$(CopyRetryDelayMilliseconds)"
+          UseHardlinksIfPossible="$(CreateHardLinksForCopyFilesToOutputDirectoryIfPossible)"
+          UseSymboliclinksIfPossible="$(CreateSymbolicLinksForCopyFilesToOutputDirectoryIfPossible)">
+
+      <Output TaskParameter="DestinationFiles" ItemName="FileWrites"/>
+
+    </Copy>
 
   </Target>
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Publish.targets
@@ -461,7 +461,8 @@ Copyright (c) .NET Foundation. All rights reserved.
                             _ParseTargetManifestFiles;
                             _DefaultMicrosoftNETPlatformLibrary;
                             _HandlePackageFileConflicts;
-                            _HandlePublishFileConflicts"
+                            _HandlePublishFileConflicts;
+                            _ComputeReferenceAssemblies"
           Condition="'$(GenerateDependencyFile)' == 'true'">
 
     <PropertyGroup>
@@ -478,6 +479,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                       AssemblySatelliteAssemblies="@(IntermediateSatelliteAssembliesWithTargetPath)"
                       ReferencePaths="@(ReferencePath)"
                       ReferenceSatellitePaths="@(ReferenceSatellitePaths)"
+                      ReferenceAssemblies="@(_ReferenceAssemblies)"
                       IncludeMainProject="$(IncludeMainProjectInDepsFile)"
                       RuntimeIdentifier="$(RuntimeIdentifier)"
                       PlatformLibraryName="$(MicrosoftNETPlatformLibrary)"

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.targets
@@ -280,7 +280,8 @@ Copyright (c) .NET Foundation. All rights reserved.
     Computes references that are only used at compile-time.
     ============================================================
     -->
-  <Target Name="_ComputeReferenceAssemblies">
+  <Target Name="_ComputeReferenceAssemblies"
+          DependsOnTargets="ResolveAssemblyReferences">
 
     <ItemGroup>
       <_FrameworkReferenceAssemblies Include="@(ReferencePath)"

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.targets
@@ -81,7 +81,9 @@ Copyright (c) .NET Foundation. All rights reserved.
     -->
 
   <Target Name="GenerateBuildDependencyFile"
-          DependsOnTargets="_DefaultMicrosoftNETPlatformLibrary;_HandlePackageFileConflicts"
+          DependsOnTargets="_DefaultMicrosoftNETPlatformLibrary;
+                            _HandlePackageFileConflicts;
+                            _ComputeReferenceAssemblies"
           BeforeTargets="CopyFilesToOutputDirectory"
           Condition=" '$(GenerateDependencyFile)' == 'true'"
           Inputs="$(ProjectAssetsFile)"
@@ -101,6 +103,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                       AssemblySatelliteAssemblies="@(IntermediateSatelliteAssembliesWithTargetPath)"
                       ReferencePaths="@(ReferencePath)"
                       ReferenceSatellitePaths="@(ReferenceSatellitePaths)"
+                      ReferenceAssemblies="@(_ReferenceAssemblies)"
                       IncludeMainProject="$(IncludeMainProjectInDepsFile)"
                       RuntimeIdentifier="$(RuntimeIdentifier)"
                       PlatformLibraryName="$(MicrosoftNETPlatformLibrary)"
@@ -266,6 +269,39 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ItemGroup>
       <!-- Use 'None' so we can rename files using the 'Link' metadata as necessary -->
       <None Include="@(AllNETCoreCopyLocalItems)" />
+    </ItemGroup>
+
+  </Target>
+
+  <!--
+    ============================================================
+                                        _ComputeReferenceAssemblies
+
+    Computes references that are only used at compile-time.
+    ============================================================
+    -->
+  <Target Name="_ComputeReferenceAssemblies">
+
+    <ItemGroup>
+      <_FrameworkReferenceAssemblies Include="@(ReferencePath)"
+                                     Condition="%(ReferencePath.FrameworkFile) == 'true' or
+                                                %(ReferencePath.ResolvedFrom) == 'ImplicitlyExpandDesignTimeFacades'" />
+      
+      <!--
+      "ReferenceOnly" assemblies are assemblies that are only used at compile-time, and they can't be resolved
+      by the normal compile-assembly resolvers at runtime:
+      1. App local
+      2. NuGet/Package layout
+      3. ProgramFiles\Reference Assemblies
+      These assemblies need to be copied to the 'refs' folder for both build and publish.
+      -->
+      <_ReferenceOnlyAssemblies Include="@(ReferencePath)"
+                                Exclude="@(_FrameworkReferenceAssemblies)"
+                                Condition="%(ReferencePath.CopyLocal) != 'true' and 
+                                           %(ReferencePath.NuGetSourceType) == ''" />
+
+      <_ReferenceAssemblies Include="@(_FrameworkReferenceAssemblies)" />
+      <_ReferenceAssemblies Include="@(_ReferenceOnlyAssemblies)" />
     </ItemGroup>
 
   </Target>

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToPreserveCompilationContextForBuild.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToPreserveCompilationContextForBuild.cs
@@ -1,0 +1,192 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using System.Linq;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyModel;
+using Microsoft.NET.TestFramework;
+using Microsoft.NET.TestFramework.Assertions;
+using Microsoft.NET.TestFramework.Commands;
+using Microsoft.NET.TestFramework.ProjectConstruction;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.NET.Build.Tests
+{
+    public class GivenThatWeWantToPreserveCompilationContextForBuild : SdkTest
+    {
+        public GivenThatWeWantToPreserveCompilationContextForBuild(ITestOutputHelper log) : base(log)
+        {
+        }
+
+        [WindowsOnlyFact]
+        public void It_supports_copylocal_false_references()
+        {
+            var testProject = new TestProject()
+            {
+                Name = "CopyLocalFalseReferences",
+                TargetFrameworks = "net461",
+                IsSdkProject = true,
+                IsExe = true
+            };
+
+            testProject.AdditionalProperties.Add("PreserveCompilationContext", "true");
+            testProject.PackageReferences.Add(new TestPackageReference("NETStandard.Library.NETFramework", "2.0.0-preview2-25330-01", null));
+
+            var testAsset = _testAssetsManager.CreateTestProject(testProject)
+                .Restore(Log, testProject.Name);
+
+            var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+
+            buildCommand
+                .Execute()
+                .Should()
+                .Pass();
+
+            var outputDirectory = buildCommand.GetOutputDirectory(testProject.TargetFrameworks);
+
+            // The "_ReferenceOnlyAssemblies" should be copied to the 'refs' directory, so they can be resolved at runtime
+            outputDirectory.Sub("refs")
+                .Should().OnlyHaveFiles(Net461ReferenceOnlyAssemblies);
+
+            using (var depsJsonFileStream = File.OpenRead(Path.Combine(outputDirectory.FullName, $"{testProject.Name}.deps.json")))
+            {
+                var dependencyContext = new DependencyContextJsonReader().Read(depsJsonFileStream);
+
+                var compileLibraryAssemblyNames = dependencyContext.CompileLibraries.SelectMany(cl => cl.Assemblies)
+                    .Select(a => a.Split('/').Last())
+                    .ToList();
+
+                compileLibraryAssemblyNames.Should().BeEquivalentTo(Net461CompileAssemblies);
+            }
+        }
+
+        private static readonly string[] Net461ReferenceOnlyAssemblies = new []
+        {
+            "Microsoft.Win32.Primitives.dll",
+            "netfx.force.conflicts.dll",
+            "netstandard.dll",
+            "System.AppContext.dll",
+            "System.Collections.Concurrent.dll",
+            "System.Collections.dll",
+            "System.Collections.NonGeneric.dll",
+            "System.Collections.Specialized.dll",
+            "System.ComponentModel.dll",
+            "System.ComponentModel.EventBasedAsync.dll",
+            "System.ComponentModel.Primitives.dll",
+            "System.ComponentModel.TypeConverter.dll",
+            "System.Console.dll",
+            "System.Data.Common.dll",
+            "System.Diagnostics.Contracts.dll",
+            "System.Diagnostics.Debug.dll",
+            "System.Diagnostics.FileVersionInfo.dll",
+            "System.Diagnostics.Process.dll",
+            "System.Diagnostics.StackTrace.dll",
+            "System.Diagnostics.TextWriterTraceListener.dll",
+            "System.Diagnostics.Tools.dll",
+            "System.Diagnostics.TraceSource.dll",
+            "System.Diagnostics.Tracing.dll",
+            "System.Drawing.Primitives.dll",
+            "System.Dynamic.Runtime.dll",
+            "System.Globalization.Calendars.dll",
+            "System.Globalization.dll",
+            "System.Globalization.Extensions.dll",
+            "System.IO.Compression.dll",
+            "System.IO.Compression.ZipFile.dll",
+            "System.IO.dll",
+            "System.IO.FileSystem.dll",
+            "System.IO.FileSystem.DriveInfo.dll",
+            "System.IO.FileSystem.Primitives.dll",
+            "System.IO.FileSystem.Watcher.dll",
+            "System.IO.IsolatedStorage.dll",
+            "System.IO.MemoryMappedFiles.dll",
+            "System.IO.Pipes.dll",
+            "System.IO.UnmanagedMemoryStream.dll",
+            "System.Linq.dll",
+            "System.Linq.Expressions.dll",
+            "System.Linq.Parallel.dll",
+            "System.Linq.Queryable.dll",
+            "System.Net.Http.dll",
+            "System.Net.NameResolution.dll",
+            "System.Net.NetworkInformation.dll",
+            "System.Net.Ping.dll",
+            "System.Net.Primitives.dll",
+            "System.Net.Requests.dll",
+            "System.Net.Security.dll",
+            "System.Net.Sockets.dll",
+            "System.Net.WebHeaderCollection.dll",
+            "System.Net.WebSockets.Client.dll",
+            "System.Net.WebSockets.dll",
+            "System.ObjectModel.dll",
+            "System.Reflection.dll",
+            "System.Reflection.Extensions.dll",
+            "System.Reflection.Primitives.dll",
+            "System.Resources.Reader.dll",
+            "System.Resources.ResourceManager.dll",
+            "System.Resources.Writer.dll",
+            "System.Runtime.CompilerServices.VisualC.dll",
+            "System.Runtime.dll",
+            "System.Runtime.Extensions.dll",
+            "System.Runtime.Handles.dll",
+            "System.Runtime.InteropServices.dll",
+            "System.Runtime.InteropServices.RuntimeInformation.dll",
+            "System.Runtime.Numerics.dll",
+            "System.Runtime.Serialization.Formatters.dll",
+            "System.Runtime.Serialization.Json.dll",
+            "System.Runtime.Serialization.Primitives.dll",
+            "System.Runtime.Serialization.Xml.dll",
+            "System.Security.Claims.dll",
+            "System.Security.Cryptography.Algorithms.dll",
+            "System.Security.Cryptography.Csp.dll",
+            "System.Security.Cryptography.Encoding.dll",
+            "System.Security.Cryptography.Primitives.dll",
+            "System.Security.Cryptography.X509Certificates.dll",
+            "System.Security.Principal.dll",
+            "System.Security.SecureString.dll",
+            "System.Text.Encoding.dll",
+            "System.Text.Encoding.Extensions.dll",
+            "System.Text.RegularExpressions.dll",
+            "System.Threading.dll",
+            "System.Threading.Overlapped.dll",
+            "System.Threading.Tasks.dll",
+            "System.Threading.Tasks.Parallel.dll",
+            "System.Threading.Thread.dll",
+            "System.Threading.ThreadPool.dll",
+            "System.Threading.Timer.dll",
+            "System.ValueTuple.dll",
+            "System.Xml.ReaderWriter.dll",
+            "System.Xml.XDocument.dll",
+            "System.Xml.XmlDocument.dll",
+            "System.Xml.XmlSerializer.dll",
+            "System.Xml.XPath.dll",
+            "System.Xml.XPath.XDocument.dll",
+        };
+
+        private static readonly string[] Net461CompileAssemblies = Net461ReferenceOnlyAssemblies.Concat(new[]
+        {
+            "CopyLocalFalseReferences.exe",
+            "mscorlib.dll",
+            "System.ComponentModel.Annotations.dll",
+            "System.Core.dll",
+            "System.Data.dll",
+            "System.dll",
+            "System.Drawing.dll",
+            "System.IO.Compression.FileSystem.dll",
+            "System.Numerics.dll",
+            "System.Reflection.Emit.dll",
+            "System.Reflection.Emit.ILGeneration.dll",
+            "System.Reflection.Emit.Lightweight.dll",
+            "System.Runtime.InteropServices.WindowsRuntime.dll",
+            "System.Runtime.Serialization.dll",
+            "System.ServiceModel.Duplex.dll",
+            "System.ServiceModel.Http.dll",
+            "System.ServiceModel.NetTcp.dll",
+            "System.ServiceModel.Primitives.dll",
+            "System.ServiceModel.Security.dll",
+            "System.Xml.dll",
+            "System.Xml.Linq.dll",
+        }).ToArray();
+    }
+}


### PR DESCRIPTION
Fix the following issues with PreserveCompilationContext

- Add all non-NuGet, CopyLocal=false References to deps.json file.
- Copy any Reference that can't be resolved at runtime to the build output "refs" folder.

Fix #1259

/cc @ericstj @livarcocc @muratg @NTaylorMullen @pranavkm 