### PR TITLE
Use a better error message when TargetFramework property has a semicolon in it

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.Designer.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.Designer.cs
@@ -134,7 +134,7 @@ namespace Microsoft.NET.Build.Tasks {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Cannot infer TargetFrameworkIdentifier and/or TargetFrameworkVersion from TargetFramework=&apos;{0}&apos;. They must be specified explicitly..
+        ///   Looks up a localized string similar to The TargetFramework value &apos;{0}&apos; was not recognized. It may be misspelled. If not, then the TargetFrameworkIdentifier and/or TargetFrameworkVersion properties must be specified explicitly..
         /// </summary>
         internal static string CannotInferTargetFrameworkIdentiferAndVersion {
             get {
@@ -557,7 +557,7 @@ namespace Microsoft.NET.Build.Tasks {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; is not a valid value for the &apos;TargetFramework&apos; property. To multi-target, use the &apos;TargetFrameworks&apos; property instead..
+        ///   Looks up a localized string similar to The TargetFramework value &apos;{0}&apos; is not valid. To multi-target, use the &apos;TargetFrameworks&apos; property instead..
         /// </summary>
         internal static string TargetFrameworkWithSemicolon {
             get {

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.Designer.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.Designer.cs
@@ -557,6 +557,15 @@ namespace Microsoft.NET.Build.Tasks {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to &apos;{0}&apos; is not a valid value for the &apos;TargetFramework&apos; property. To multi-target, use the &apos;TargetFrameworks&apos; property instead..
+        /// </summary>
+        internal static string TargetFrameworkWithSemicolon {
+            get {
+                return ResourceManager.GetString("TargetFrameworkWithSemicolon", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Unable to find resolved path for &apos;{0}&apos;..
         /// </summary>
         internal static string UnableToFindResolvedPath {

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.resx
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.resx
@@ -157,7 +157,7 @@
     <value>Unexpected file type for '{0}'. Type is both '{1}' and '{2}'.</value>
   </data>
   <data name="CannotInferTargetFrameworkIdentiferAndVersion" xml:space="preserve">
-    <value>Cannot infer TargetFrameworkIdentifier and/or TargetFrameworkVersion from TargetFramework='{0}'. They must be specified explicitly.</value>
+    <value>The TargetFramework value '{0}' was not recognized. It may be misspelled. If not, then the TargetFrameworkIdentifier and/or TargetFrameworkVersion properties must be specified explicitly.</value>
   </data>
   <data name="ContentItemDoesNotProvideOutputPath" xml:space="preserve">
     <value>Content item for '{0}' sets '{1}', but does not provide  '{2}' or '{3}'.</value>
@@ -298,6 +298,6 @@
     <value>The current .NET SDK does not support targeting {0} {1}.  Either target {0} {2} or lower, or use a version of the .NET SDK that supports {0} {1}.</value>
   </data>
   <data name="TargetFrameworkWithSemicolon" xml:space="preserve">
-    <value>'{0}' is not a valid value for the 'TargetFramework' property. To multi-target, use the 'TargetFrameworks' property instead.</value>
+    <value>The TargetFramework value '{0}' is not valid. To multi-target, use the 'TargetFrameworks' property instead.</value>
   </data>
 </root>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.resx
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.resx
@@ -297,4 +297,7 @@
   <data name="UnsupportedTargetFrameworkVersion" xml:space="preserve">
     <value>The current .NET SDK does not support targeting {0} {1}.  Either target {0} {2} or lower, or use a version of the .NET SDK that supports {0} {1}.</value>
   </data>
+  <data name="TargetFrameworkWithSemicolon" xml:space="preserve">
+    <value>'{0}' is not a valid value for the 'TargetFramework' property. To multi-target, use the 'TargetFrameworks' property instead.</value>
+  </data>
 </root>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.TargetFrameworkInference.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.TargetFrameworkInference.targets
@@ -81,7 +81,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <_UnsupportedTargetFrameworkError>true</_UnsupportedTargetFrameworkError>
   </PropertyGroup>
   <Target Name="_CheckForUnsupportedTargetFramework"
-          BeforeTargets="_CheckForInvalidConfigurationAndPlatform;Restore;CollectPackageReferences"
+          BeforeTargets="_CheckForInvalidConfigurationAndPlatform;_GenerateRestoreProjectSpec;CollectPackageReferences"
           Condition="'$(_UnsupportedTargetFrameworkError)' == 'true'"
           >
     <NETSdkError Condition="!$(TargetFramework.Contains(';'))"

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.TargetFrameworkInference.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.TargetFrameworkInference.targets
@@ -81,7 +81,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <_UnsupportedTargetFrameworkError>true</_UnsupportedTargetFrameworkError>
   </PropertyGroup>
   <Target Name="_CheckForUnsupportedTargetFramework"
-          BeforeTargets="_CheckForInvalidConfigurationAndPlatform"
+          BeforeTargets="_CheckForInvalidConfigurationAndPlatform;Restore;CollectPackageReferences"
           Condition="'$(_UnsupportedTargetFrameworkError)' == 'true'"
           >
     <NETSdkError Condition="!$(TargetFramework.Contains(';'))"

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.TargetFrameworkInference.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.TargetFrameworkInference.targets
@@ -80,9 +80,16 @@ Copyright (c) .NET Foundation. All rights reserved.
   <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '' or '$(TargetFrameworkVersion)' == ''">
     <_UnsupportedTargetFrameworkError>true</_UnsupportedTargetFrameworkError>
   </PropertyGroup>
-  <Target Name="_CheckForUnsupportedTargetFramework" BeforeTargets="_CheckForInvalidConfigurationAndPlatform">
-    <NETSdkError Condition="'$(_UnsupportedTargetFrameworkError)' == 'true'" 
+  <Target Name="_CheckForUnsupportedTargetFramework"
+          BeforeTargets="_CheckForInvalidConfigurationAndPlatform"
+          Condition="'$(_UnsupportedTargetFrameworkError)' == 'true'"
+          >
+    <NETSdkError Condition="!$(TargetFramework.Contains(';'))"
                  ResourceName="CannotInferTargetFrameworkIdentiferAndVersion"
+                 FormatArguments="$([MSBuild]::Escape('$(TargetFramework)'))" />
+    
+    <NETSdkError Condition="$(TargetFramework.Contains(';'))"
+                 ResourceName="TargetFrameworkWithSemicolon"
                  FormatArguments="$([MSBuild]::Escape('$(TargetFramework)'))" />
   </Target>
 

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildALibrary.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildALibrary.cs
@@ -51,7 +51,7 @@ namespace Microsoft.NET.Build.Tests
             });
         }
 
-       [Fact]
+        [Fact]
         public void It_builds_the_library_twice_in_a_row()
         {
             var testAsset = _testAssetsManager
@@ -530,35 +530,105 @@ namespace Microsoft.NET.Build.Tests
             definedConstants.Should().BeEquivalentTo(new[] { "DEBUG", "TRACE" }.Concat(expectedDefines).ToArray());
         }
 
-        [Fact]
-        public void It_fails_gracefully_if_targetframework_is_empty()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void It_fails_gracefully_if_targetframework_is_empty(bool useSolution)
         {
-            var testAsset = _testAssetsManager
-                .CopyTestAsset("AppWithLibrary", "EmptyTargetFramework")
-                .WithSource()
-                .WithProjectChanges(project =>
-                {
-                    project.Root
-                        .Elements("PropertyGroup")
-                        .Elements("TargetFramework")
-                        .Single()
-                        .SetValue("");
-                });
+            string targetFramework = "";
+            TestInvalidTargetFramework("EmptyTargetFramework", targetFramework, useSolution,
+                $"The TargetFramework value '{targetFramework}' was not recognized");
+        }
 
-            var restoreCommand = testAsset.GetRestoreCommand(Log, "TestLibrary");
-            
-            var libraryProjectDirectory = Path.Combine(testAsset.TestRoot, "TestLibrary");
-            var buildCommand = new BuildCommand(Log, libraryProjectDirectory);
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void It_fails_gracefully_if_targetframework_is_invalid(bool useSolution)
+        {
+            string targetFramework = "notaframework";
+            TestInvalidTargetFramework("InvalidTargetFramework", targetFramework, useSolution,
+                $"The TargetFramework value '{targetFramework}' was not recognized");
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void It_fails_gracefully_if_targetframework_should_be_targetframeworks(bool useSolution)
+        {
+            string targetFramework = "netcoreapp2.0;net461";
+            TestInvalidTargetFramework("InvalidTargetFramework", targetFramework, useSolution,
+                $"The TargetFramework value '{targetFramework}' is not valid. To multi-target, use the 'TargetFrameworks' property instead");
+        }
+
+        private void TestInvalidTargetFramework(string testName, string targetFramework, bool useSolution, string expectedOutput)
+        {
+            var testProject = new TestProject()
+            {
+                Name = testName,
+                TargetFrameworks = targetFramework,
+                IsSdkProject = true
+            };
+
+            string identifier = useSolution ? "_Solution" : "";
+            var testAsset = _testAssetsManager.CreateTestProject(testProject, testProject.Name, identifier);
+
+            if (targetFramework.Contains(";"))
+            {
+                //  The TestProject class doesn't differentiate between TargetFramework and TargetFrameworks, and helpfully selects
+                //  which property to use based on whether there's a semicolon.
+                //  For this test, we need to override this behavior
+                testAsset = testAsset.WithProjectChanges(project =>
+                {
+                    var ns = project.Root.Name.Namespace;
+
+                    project.Root.Element(ns + "PropertyGroup")
+                        .Element(ns + "TargetFrameworks")
+                        .Name = ns + "TargetFramework";
+                });
+            }
+
+            TestCommand restoreCommand;
+            TestCommand buildCommand;
+
+            if (useSolution)
+            {
+                var dotnetCommand = new DotnetCommand(Log)
+                {
+                    WorkingDirectory = testAsset.TestRoot
+                };
+
+                dotnetCommand.Execute("new", "sln")
+                    .Should()
+                    .Pass();
+
+                var relativePathToProject = Path.Combine(testProject.Name, testProject.Name + ".csproj");
+                dotnetCommand.Execute($"sln", "add", relativePathToProject)
+                    .Should()
+                    .Pass();
+
+                var relativePathToSln = testProject.Name + identifier + ".sln";
+
+                restoreCommand = testAsset.GetRestoreCommand(Log, relativePathToSln);
+                buildCommand = new BuildCommand(Log, testAsset.TestRoot, relativePathToSln);
+            }
+            else
+            {
+                restoreCommand = testAsset.GetRestoreCommand(Log, testProject.Name);
+                buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            }
 
             foreach (var command in new TestCommand[] { restoreCommand, buildCommand })
             {
+                //  Set RestoreContinueOnError=ErrorAndContinue to force failure on error
+                //  See https://github.com/NuGet/Home/issues/5309
                 command
-                    .Execute()
+                    .Execute("/p:RestoreContinueOnError=ErrorAndContinue")
                     .Should()
                     .Fail()
-                    .And.HaveStdOutContaining("The TargetFramework value ''") // new deliberate error
-                    .And.NotHaveStdOutContaining(">="); // old error about comparing empty string to version
-            }                
+                    .And
+                    .HaveStdOutContaining(expectedOutput)
+                    .And.NotHaveStdOutContaining(">="); // old error about comparing empty string to version when TargetFramework was blank;
+            }
         }
 
         [Theory]

--- a/test/Microsoft.NET.TestFramework/Commands/DotnetCommand.cs
+++ b/test/Microsoft.NET.TestFramework/Commands/DotnetCommand.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.DotNet.Cli.Utils;
+using Xunit.Abstractions;
+
+namespace Microsoft.NET.TestFramework.Commands
+{
+    public class DotnetCommand : TestCommand
+    {
+        public string WorkingDirectory { get; set; }
+
+        public DotnetCommand(ITestOutputHelper log) : base(log)
+        {
+        }
+
+        protected override ICommand CreateCommand(string[] args)
+        {
+            ICommand ret = Command.Create(RepoInfo.DotNetHostPath, args);
+            if (!string.IsNullOrEmpty(WorkingDirectory))
+            {
+                ret = ret.WorkingDirectory(WorkingDirectory);
+            }
+
+            return ret;
+        }
+    }
+}

--- a/test/Microsoft.NET.TestFramework/TestAsset.cs
+++ b/test/Microsoft.NET.TestFramework/TestAsset.cs
@@ -137,7 +137,7 @@ namespace Microsoft.NET.TestFramework
 
         }
 
-        public RestoreCommand GetRestoreCommand(ITestOutputHelper log, string relativePath = "", params string[] args)
+        public RestoreCommand GetRestoreCommand(ITestOutputHelper log, string relativePath = "")
         {
             return new RestoreCommand(log, System.IO.Path.Combine(TestRoot, relativePath))
                 .AddSourcesFromCurrentConfig()
@@ -146,7 +146,7 @@ namespace Microsoft.NET.TestFramework
 
         public TestAsset Restore(ITestOutputHelper log, string relativePath = "", params string[] args)
         {
-            var commandResult = GetRestoreCommand(log, relativePath, args)
+            var commandResult = GetRestoreCommand(log, relativePath)
                 .Execute(args);
 
             commandResult.Should().Pass();


### PR DESCRIPTION
Fixes #385

For checking for a TargetFramework value with a semicolon in it, this reuses the existing check that TargetFrameworkIdentifier or TargetFrameworkVersion couldn't be inferred, but uses a different error message:

> The TargetFramework value 'netcoreapp2.0;net46' is not valid. To multi-target, use the 'TargetFrameworks' property instead.

Fixes #1015 

Updates the error message in the case where there isn't a semicolon in `TargetFramework` to:

> The TargetFramework value 'foo45' was not recognized. It may be misspelled. If not, then the TargetFrameworkIdentifier and/or TargetFrameworkVersion properties must be specified explicitly.

This PR also updates the `_CheckForUnsupportedTargetFramework` target to run before Restore, since a valid target framework is necessary in order to restore.