### PR TITLE
Don't try testing whether targeting unsupported .NET Core or .NET Standard versions if the maximum version isn't set

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.TargetFrameworkInference.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.TargetFrameworkInference.targets
@@ -106,7 +106,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   </PropertyGroup>
     
   <Target Name="_CheckForUnsupportedNETCoreVersion" BeforeTargets="_CheckForInvalidConfigurationAndPlatform;Restore;CollectPackageReferences"
-          Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
+          Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(NETCoreAppMaximumVersion)' != ''">
 
     <NETSdkError Condition="'$(_TargetFrameworkVersionWithoutV)' > '$(NETCoreAppMaximumVersion)'"
                  ResourceName="UnsupportedTargetFrameworkVersion"
@@ -119,7 +119,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   </PropertyGroup>
 
   <Target Name="_CheckForUnsupportedNETStandardVersion" BeforeTargets="_CheckForInvalidConfigurationAndPlatform;Restore;CollectPackageReferences"
-          Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard'">
+          Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard' And '$(NETStandardMaximumVersion)' != ''">
 
     <NETSdkError Condition="'$(_TargetFrameworkVersionWithoutV)' > '$(NETStandardMaximumVersion)'"
                  ResourceName="UnsupportedTargetFrameworkVersion"


### PR DESCRIPTION
This PR fixes an issue where if you don't have the bundled versions .prpos file imported, you'll get an error like:

> A numeric comparison was attempted on "$(NETStandardMaximumVersion)" that evaluates to "" instead of a number, in condition "'$(_TargetFrameworkVersionWithoutV)' > '$(NETStandardMaximumVersion)'".  

This shouldn't happen in normal product uses, but does happen if you're trying to test updates to the SDK by setting `MSBuildSDKsPath` but haven't also set `NETCoreSdkBundledVersionsProps`.