### PR TITLE
Re-enable disabled full framework test coverage

### DIFF
--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildANetCoreApp.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildANetCoreApp.cs
@@ -118,14 +118,6 @@ namespace Microsoft.NET.Build.Tests
         [Fact]
         public void It_restores_only_ridless_tfm()
         {
-            //  Disable this test when using full Framework MSBuild, until MSBuild is updated 
-            //  to provide conditions in NuGet ImportBefore/ImportAfter props/targets
-            //  https://github.com/dotnet/sdk/issues/874
-            if (UsingFullFrameworkMSBuild)
-            {
-                return;
-            }
-
             var testAsset = _testAssetsManager
                 .CopyTestAsset("HelloWorld")
                 .WithSource()
@@ -172,13 +164,6 @@ namespace Microsoft.NET.Build.Tests
 
         private void RunAppFromOutputFolder(string testName, bool useRid, bool includeConflicts)
         {
-            if (UsingFullFrameworkMSBuild)
-            {
-                //  Disabled on full framework MSBuild until CI machines have VS with bundled .NET Core / .NET Standard versions
-                //  See https://github.com/dotnet/sdk/issues/1077
-                return;
-            }
-
             var targetFramework = "netcoreapp2.0";
             var runtimeIdentifier = useRid ? EnvironmentInfo.GetCompatibleRid(targetFramework) : null;
 
@@ -249,13 +234,6 @@ public static class Program
         [Fact]
         public void It_trims_conflicts_from_the_deps_file()
         {
-            if (UsingFullFrameworkMSBuild)
-            {
-                //  Disabled on full framework MSBuild until CI machines have VS with bundled .NET Core / .NET Standard versions
-                //  See https://github.com/dotnet/sdk/issues/1077
-                return;
-            }
-
             TestProject project = new TestProject()
             {
                 Name = "NetCore2App",

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAnAppWithLibrariesAndRid.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAnAppWithLibrariesAndRid.cs
@@ -23,14 +23,6 @@ namespace Microsoft.NET.Build.Tests
         [Fact]
         public void It_builds_a_RID_specific_runnable_output()
         {
-            if (UsingFullFrameworkMSBuild)
-            {
-                //  Disable this test on full framework, as the current build won't have access to 
-                //  https://github.com/Microsoft/msbuild/pull/1674
-                //  See https://github.com/dotnet/sdk/issues/877
-                return;
-            }
-
             var runtimeIdentifier = RuntimeEnvironment.GetRuntimeIdentifier();
             var testAsset = _testAssetsManager
                 .CopyTestAsset("AppWithLibraryAndRid")
@@ -70,14 +62,6 @@ namespace Microsoft.NET.Build.Tests
         [Fact]
         public void It_builds_a_framework_dependent_RID_specific_runnable_output()
         {
-            if (UsingFullFrameworkMSBuild)
-            {
-                //  Disable this test on full framework, as the current build won't have access to 
-                //  https://github.com/Microsoft/msbuild/pull/1674
-                //  See https://github.com/dotnet/sdk/issues/877
-                return;
-            }
-
             var runtimeIdentifier = RuntimeEnvironment.GetRuntimeIdentifier();
             var testAsset = _testAssetsManager
                 .CopyTestAsset("AppWithLibraryAndRid", "BuildFrameworkDependentRIDSpecific")

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAnAppWithLibrary.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAnAppWithLibrary.cs
@@ -102,9 +102,7 @@ namespace Microsoft.NET.Build.Tests
             libInfo.ProductVersion.Should().Be("42.43.44.45-alpha");
         }
 
-        //  Disabled on full framework MSBuild until CI machines have VS with bundled .NET Core / .NET Standard versions
-        //  See https://github.com/dotnet/sdk/issues/1077
-        [CoreMSBuildOnlyFact]
+        [Fact]
         public void It_generates_satellite_assemblies()
         {
             var testAsset = _testAssetsManager

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToExcludeTheMainProjectFromTheDepsFile.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToExcludeTheMainProjectFromTheDepsFile.cs
@@ -27,16 +27,6 @@ namespace Microsoft.NET.Build.Tests
         [Fact]
         public void It_builds_successfully()
         {
-            if (UsingFullFrameworkMSBuild)
-            {
-                //  Fullframework NuGet versioning on Jenkins infrastructure issue
-                //        https://github.com/dotnet/sdk/issues/1041
-
-                //  Disabled on full framework MSBuild until CI machines have VS with bundled .NET Core / .NET Standard versions
-                //  See https://github.com/dotnet/sdk/issues/1077
-                return;
-            }
-
             TestProject testProject = new TestProject()
             {
                 Name = "ExcludeMainProjectFromDeps",

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToGenerateADepsFileForATool.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToGenerateADepsFileForATool.cs
@@ -31,16 +31,6 @@ namespace Microsoft.NET.Build.Tests
         [Fact]
         public void It_creates_a_deps_file_for_the_tool_and_the_tool_runs()
         {
-            if (UsingFullFrameworkMSBuild)
-            {
-                //  Fullframework NuGet versioning on Jenkins infrastructure issue
-                //        https://github.com/dotnet/sdk/issues/1041
-
-                //  Disabled on full framework MSBuild until CI machines have VS with bundled .NET Core / .NET Standard versions
-                //  See https://github.com/dotnet/sdk/issues/1077
-                return;
-            }
-
             TestProject toolProject = new TestProject()
             {
                 Name = "TestTool",
@@ -58,16 +48,6 @@ namespace Microsoft.NET.Build.Tests
         [Fact]
         public void It_handles_conflicts_when_creating_a_tool_deps_file()
         {
-            if (UsingFullFrameworkMSBuild)
-            {
-                //  Fullframework NuGet versioning on Jenkins infrastructure issue
-                //        https://github.com/dotnet/sdk/issues/1041
-
-                //  Disabled on full framework MSBuild until CI machines have VS with bundled .NET Core / .NET Standard versions
-                //  See https://github.com/dotnet/sdk/issues/1077
-                return;
-            }
-
             TestProject toolProject = new TestProject()
             {
                 Name = "DependencyContextTool",

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToGenerateADepsFileForATool.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToGenerateADepsFileForATool.cs
@@ -28,7 +28,8 @@ namespace Microsoft.NET.Build.Tests
         {
         }
 
-        [Fact]
+        //  Disabled on full Framework MSBuild due to https://github.com/dotnet/sdk/issues/1293
+        [CoreMSBuildOnlyFact]
         public void It_creates_a_deps_file_for_the_tool_and_the_tool_runs()
         {
             TestProject toolProject = new TestProject()
@@ -45,7 +46,8 @@ namespace Microsoft.NET.Build.Tests
                 .And.HaveStdOutContaining("Hello World!");
         }
 
-        [Fact]
+        //  Disabled on full Framework MSBuild due to https://github.com/dotnet/sdk/issues/1293
+        [CoreMSBuildOnlyFact]
         public void It_handles_conflicts_when_creating_a_tool_deps_file()
         {
             TestProject toolProject = new TestProject()

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToIncludeItemsOutsideTheProjectFolder.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToIncludeItemsOutsideTheProjectFolder.cs
@@ -23,9 +23,7 @@ namespace Microsoft.NET.Build.Tests
         {
         }
 
-        //  Disabled on full framework MSBuild until CI machines have VS with bundled .NET Core / .NET Standard versions
-        //  See https://github.com/dotnet/sdk/issues/1077
-        [CoreMSBuildOnlyTheory]
+        [Theory]
         [InlineData(false, false)]
         [InlineData(false, true)]
         [InlineData(true, false)]

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToReferenceAnAssembly.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToReferenceAnAssembly.cs
@@ -31,13 +31,6 @@ namespace Microsoft.NET.Build.Tests
             string referencerTarget,
             string dependencyTarget)
         {
-            if (UsingFullFrameworkMSBuild)
-            {
-                //  Disabled on full framework MSBuild until CI machines have VS with bundled .NET Core / .NET Standard versions
-                //  See https://github.com/dotnet/sdk/issues/1077
-                return;
-            }
-
             string identifier = referencerTarget.ToString() + "_" + dependencyTarget.ToString();
 
             TestProject dependencyProject = new TestProject()

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToVerifyNuGetReferenceCompat.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToVerifyNuGetReferenceCompat.cs
@@ -29,11 +29,8 @@ namespace Microsoft.NET.Build.Tests
         [InlineData("net46", "Full", "netstandard1.0 netstandard1.1 netstandard1.2 netstandard1.3 net45 net451 net46", true, true)]
         [InlineData("net461", "PartM3", "netstandard1.0 netstandard1.1 netstandard1.2 netstandard1.3 netstandard1.4 net45 net451 net46 net461", true, true)]
         [InlineData("net462", "PartM2", "netstandard1.0 netstandard1.1 netstandard1.2 netstandard1.3 netstandard1.4 netstandard1.5 net45 net451 net46 net461", true, true)]
-        //  Fullframework NuGet versioning on Jenkins infrastructure issue
-        //        https://github.com/dotnet/sdk/issues/1041
-        //[InlineData("net461", "Full", "netstandard1.0 netstandard1.1 netstandard1.2 netstandard1.3 netstandard1.4 netstandard1.5 netstandard1.6 netstandard2.0 net45 net451 net46 net461", true, true)]
-        //[InlineData("net462", "Full", "netstandard1.0 netstandard1.1 netstandard1.2 netstandard1.3 netstandard1.4 netstandard1.5 netstandard1.6 netstandard2.0 net45 net451 net46 net461", true, true)]
-
+        [InlineData("net461", "Full", "netstandard1.0 netstandard1.1 netstandard1.2 netstandard1.3 netstandard1.4 netstandard1.5 netstandard1.6 netstandard2.0 net45 net451 net46 net461", true, true)]
+        [InlineData("net462", "Full", "netstandard1.0 netstandard1.1 netstandard1.2 netstandard1.3 netstandard1.4 netstandard1.5 netstandard1.6 netstandard2.0 net45 net451 net46 net461", true, true)]
         [InlineData("netstandard1.0", "Full", "netstandard1.0", true, true)]
         [InlineData("netstandard1.1", "Full", "netstandard1.0 netstandard1.1", true, true)]
         [InlineData("netstandard1.2", "Full", "netstandard1.0 netstandard1.1 netstandard1.2", true, true)]
@@ -47,25 +44,12 @@ namespace Microsoft.NET.Build.Tests
         [InlineData("netcoreapp2.0", "PartM1", "netstandard1.0 netstandard1.1 netstandard1.2 netstandard1.3 netstandard1.4 netstandard1.5 netstandard1.6 netcoreapp1.0 netcoreapp1.1 netcoreapp2.0", true, true)]
         [InlineData("netcoreapp2.0", "Full", "netstandard1.0 netstandard1.1 netstandard1.2 netstandard1.3 netstandard1.4 netstandard1.5 netstandard1.6 netstandard2.0 netcoreapp1.0 netcoreapp1.1 netcoreapp2.0", true, true)]
 
-        //  OptIn matrix throws an exception for each permutation
-        //        https://github.com/dotnet/sdk/issues/1025
-        //[InlineData("netstandard2.0", "OptIn", "net45 net451 net46 net461", true, true)]
-        //[InlineData("netcoreapp2.0", "OptIn", "net45 net451 net46 net461", true, true)]
+        [InlineData("netstandard2.0", "OptIn", "net45 net451 net46 net461", true, true)]
+        [InlineData("netcoreapp2.0", "OptIn", "net45 net451 net46 net461", true, true)]
 
         public void Nuget_reference_compat(string referencerTarget, string testDescription, string rawDependencyTargets,
                 bool restoreSucceeds, bool buildSucceeds)
         {
-            if (UsingFullFrameworkMSBuild &&
-                (referencerTarget == "netcoreapp2.0" || referencerTarget == "netstandard2.0"))
-            {
-                //  Fullframework NuGet versioning on Jenkins infrastructure issue
-                //        https://github.com/dotnet/sdk/issues/1041
-
-                //  Disabled on full framework MSBuild until CI machines have VS with bundled .NET Core / .NET Standard versions
-                //  See https://github.com/dotnet/sdk/issues/1077
-                return;
-            }
-
             string referencerDirectoryNamePostfix = "_" + referencerTarget + "_" + testDescription;
 
             TestProject referencerProject = GetTestProject(ConstantStringValues.ReferencerDirectoryName, referencerTarget, true);
@@ -146,7 +130,7 @@ namespace Microsoft.NET.Build.Tests
             }
         }
 
-        [CoreMSBuildAndWindowsOnlyTheory]
+        [WindowsOnlyTheory]
         [InlineData("netstandard2.0")]
         [InlineData("netcoreapp2.0")]
         public void Net461_is_implicit_for_Netstandard_and_Netcore_20(string targetFramework)
@@ -179,7 +163,7 @@ namespace Microsoft.NET.Build.Tests
             restoreCommand.Execute().Should().Fail();
         }
 
-        [CoreMSBuildAndWindowsOnlyFact]
+        [WindowsOnlyFact]
         public void It_is_possible_to_disabled_net461_implicit_package_target_fallback()
         {
             const string testProjectName = "netstandard20_disabled_ptf";

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToVerifyProjectReferenceCompat.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToVerifyProjectReferenceCompat.cs
@@ -27,11 +27,8 @@ namespace Microsoft.NET.Build.Tests
         [InlineData("net46", "FullMatrix", "netstandard1.0 netstandard1.1 netstandard1.2 netstandard1.3 net45 net451 net46", true, true)]
         [InlineData("net461", "PartialM3", "netstandard1.0 netstandard1.1 netstandard1.2 netstandard1.3 netstandard1.4 net45 net451 net46 net461", true, true)]
         [InlineData("net462", "PartialM2", "netstandard1.0 netstandard1.1 netstandard1.2 netstandard1.3 netstandard1.4 netstandard1.5 net45 net451 net46 net461", true, true)]
-        //  Fullframework NuGet versioning on Jenkins infrastructure issue
-        //        https://github.com/dotnet/sdk/issues/1041
-        //[InlineData("net461", "FullMatrix", "netstandard1.0 netstandard1.1 netstandard1.2 netstandard1.3 netstandard1.4 netstandard1.5 netstandard1.6 netstandard2.0 net45 net451 net46 net461", true, true)]
-        //[InlineData("net462", "FullMatrix", "netstandard1.0 netstandard1.1 netstandard1.2 netstandard1.3 netstandard1.4 netstandard1.5 netstandard1.6 netstandard2.0 net45 net451 net46 net461", true, true)]
-
+        [InlineData("net461", "FullMatrix", "netstandard1.0 netstandard1.1 netstandard1.2 netstandard1.3 netstandard1.4 netstandard1.5 netstandard1.6 netstandard2.0 net45 net451 net46 net461", true, true)]
+        [InlineData("net462", "FullMatrix", "netstandard1.0 netstandard1.1 netstandard1.2 netstandard1.3 netstandard1.4 netstandard1.5 netstandard1.6 netstandard2.0 net45 net451 net46 net461", true, true)]
         [InlineData("netstandard1.0", "FullMatrix", "netstandard1.0", true, true)]
         [InlineData("netstandard1.1", "FullMatrix", "netstandard1.0 netstandard1.1", true, true)]
         [InlineData("netstandard1.2", "FullMatrix", "netstandard1.0 netstandard1.1 netstandard1.2", true, true)]
@@ -48,16 +45,6 @@ namespace Microsoft.NET.Build.Tests
         public void Project_reference_compat(string referencerTarget, string testIDPostFix, string rawDependencyTargets, 
                 bool restoreSucceeds, bool buildSucceeds)
         {
-            if (UsingFullFrameworkMSBuild && referencerTarget == "netcoreapp2.0")
-            {
-                //  Fullframework NuGet versioning on Jenkins infrastructure issue
-                //        https://github.com/dotnet/sdk/issues/1041
-
-                //  Disabled on full framework MSBuild until CI machines have VS with bundled .NET Core / .NET Standard versions
-                //  See https://github.com/dotnet/sdk/issues/1077
-                return;
-            }
-
             string identifier = "_TestID_" + referencerTarget + "_" + testIDPostFix;
 
             TestProject referencerProject = GetTestProject("Referencer", referencerTarget, true);

--- a/test/Microsoft.NET.Pack.Tests/GivenThatThereAreImplicitPackageReferences.cs
+++ b/test/Microsoft.NET.Pack.Tests/GivenThatThereAreImplicitPackageReferences.cs
@@ -82,9 +82,7 @@ namespace Microsoft.NET.Pack.Tests
                 .Should().StartWith("1.1.");
         }
 
-        //  Disabled on full framework MSBuild until CI machines have VS with bundled .NET Core / .NET Standard versions
-        //  See https://github.com/dotnet/sdk/issues/1077
-        [CoreMSBuildOnlyFact]
+        [Fact]
         public void Packing_a_netcoreapp_2_0_library_does_not_include_the_implicit_dependency()
         {
             TestProject testProject = new TestProject()
@@ -122,9 +120,7 @@ namespace Microsoft.NET.Pack.Tests
                 .Should().StartWith("1.1.");
         }
 
-        //  Disabled on full framework MSBuild until CI machines have VS with bundled .NET Core / .NET Standard versions
-        //  See https://github.com/dotnet/sdk/issues/1077
-        [CoreMSBuildOnlyFact]
+        [Fact]
         public void Packing_a_netcoreapp_2_0_app_includes_the_implicit_dependency()
         {
             TestProject testProject = new TestProject()
@@ -146,9 +142,7 @@ namespace Microsoft.NET.Pack.Tests
                 .Should().StartWith("2.0.");
         }
 
-        //  Disabled on full framework MSBuild until CI machines have VS with bundled .NET Core / .NET Standard versions
-        //  See https://github.com/dotnet/sdk/issues/1077
-        [CoreMSBuildOnlyFact]
+        [Fact]
         public void Packing_a_multitargeted_library_includes_implicit_dependencies_when_appropriate()
         {
             TestProject testProject = new TestProject()

--- a/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAHelloWorldProject.cs
+++ b/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAHelloWorldProject.cs
@@ -107,13 +107,6 @@ namespace Microsoft.NET.Publish.Tests
         [Fact]
         public void Publish_standalone_post_netcoreapp2_app_and_it_should_run()
         {
-            if (UsingFullFrameworkMSBuild)
-            {
-                //  Disabled on full framework MSBuild until CI machines have VS with bundled .NET Core / .NET Standard versions
-                //  See https://github.com/dotnet/sdk/issues/1077
-                return;
-            }
-
             var targetFramework = "netcoreapp2.0";
             var rid = EnvironmentInfo.GetCompatibleRid(targetFramework);
 
@@ -196,13 +189,6 @@ public static class Program
 
         void Conflicts_are_resolved_when_publishing(bool selfContained, bool ridSpecific, [CallerMemberName] string callingMethod = "")
         {
-            if (UsingFullFrameworkMSBuild)
-            {
-                //  Disabled on full framework MSBuild until CI machines have VS with bundled .NET Core / .NET Standard versions
-                //  See https://github.com/dotnet/sdk/issues/1077
-                return;
-            }
-
             if (selfContained && !ridSpecific)
             {
                 throw new ArgumentException("Self-contained apps must be rid specific");

--- a/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAProjectWithDependencies.cs
+++ b/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAProjectWithDependencies.cs
@@ -200,9 +200,7 @@ namespace Microsoft.NET.Publish.Tests
 //TODO: Enable testing the run once dotnet host has the notion of looking up shared packages
         }
 
-        //  Disabled on full framework MSBuild until CI machines have VS with bundled .NET Core / .NET Standard versions
-        //  See https://github.com/dotnet/sdk/issues/1077
-        [CoreMSBuildOnlyTheory]
+        [Theory]
         [InlineData("GenerateDocumentationFile=true", true, true)]
         [InlineData("GenerateDocumentationFile=true;PublishDocumentationFile=false", false, true)]
         [InlineData("GenerateDocumentationFile=true;PublishReferencesDocumentationFiles=false", true, false)]
@@ -245,13 +243,6 @@ namespace Microsoft.NET.Publish.Tests
         [InlineData("PublishReferencesDocumentationFiles=true", true)]
         public void It_publishes_referenced_assembly_documentation(string property, bool expectAssemblyDocumentationFilePublished)
         {
-            if (UsingFullFrameworkMSBuild)
-            {
-                //  Disabled on full framework MSBuild until CI machines have VS with bundled .NET Core / .NET Standard versions
-                //  See https://github.com/dotnet/sdk/issues/1077
-                return;
-            }
-
             var identifier = property.Replace("=", "");
 
             var libProject = new TestProject

--- a/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAnAppWithLibrariesAndRid.cs
+++ b/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAnAppWithLibrariesAndRid.cs
@@ -23,14 +23,6 @@ namespace Microsoft.NET.Publish.Tests
         [Fact]
         public void It_publishes_a_self_contained_runnable_output()
         {
-            if (UsingFullFrameworkMSBuild)
-            {
-                //  Disable this test on full framework, as the current build won't have access to 
-                //  https://github.com/Microsoft/msbuild/pull/1674
-                //  See https://github.com/dotnet/sdk/issues/877
-                return;
-            }
-
             PublishAppWithLibraryAndRid(true,
                 out var publishDirectory,
                 out var runtimeIdentifier);
@@ -67,14 +59,6 @@ namespace Microsoft.NET.Publish.Tests
         [Fact]
         public void It_publishes_a_framework_dependent_RID_specific_runnable_output()
         {
-            if (UsingFullFrameworkMSBuild)
-            {
-                //  Disable this test on full framework, as the current build won't have access to 
-                //  https://github.com/Microsoft/msbuild/pull/1674
-                //  See https://github.com/dotnet/sdk/issues/877
-                return;
-            }
-
             PublishAppWithLibraryAndRid(false,
                 out var publishDirectory,
                 out var runtimeIdentifier);

--- a/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToStoreAProjectWithDependencies.cs
+++ b/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToStoreAProjectWithDependencies.cs
@@ -308,13 +308,6 @@ namespace Microsoft.NET.Publish.Tests
         [Fact]
         public void It_creates_profiling_symbols()
         {
-            if (UsingFullFrameworkMSBuild)
-            {
-                //  Disabled on full framework MSBuild until CI machines have VS with bundled .NET Core / .NET Standard versions
-                //  See https://github.com/dotnet/sdk/issues/1077
-                return;
-            }
-
             TestAsset targetManifestsAsset = _testAssetsManager
                 .CopyTestAsset("TargetManifests")
                 .WithSource();

--- a/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToStoreAProjectWithDependencies.cs
+++ b/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToStoreAProjectWithDependencies.cs
@@ -63,7 +63,7 @@ namespace Microsoft.NET.Publish.Tests
         {
         }
 
-        [Fact]
+        [CoreMSBuildOnlyFact]
         public void compose_dependencies()
         {
             TestAsset simpleDependenciesAsset = _testAssetsManager
@@ -121,7 +121,7 @@ namespace Microsoft.NET.Publish.Tests
             }
 
         }
-        [Fact]
+        [CoreMSBuildOnlyFact]
         public void compose_with_fxfiles()
         {
             TestAsset simpleDependenciesAsset = _testAssetsManager
@@ -155,7 +155,7 @@ namespace Microsoft.NET.Publish.Tests
             storeDirectory.Should().OnlyHaveFiles(files_on_disk);
         }
 
-        [Fact]
+        [CoreMSBuildOnlyFact]
         public void compose_dependencies_noopt()
         {
             TestAsset simpleDependenciesAsset = _testAssetsManager
@@ -191,7 +191,7 @@ namespace Microsoft.NET.Publish.Tests
             storeDirectory.Should().OnlyHaveFiles(files_on_disk);
         }
 
-        [Fact]
+        [CoreMSBuildOnlyFact]
         public void store_nativeonlyassets()
         {
             TestAsset simpleDependenciesAsset = _testAssetsManager
@@ -218,7 +218,7 @@ namespace Microsoft.NET.Publish.Tests
             storeDirectory.Should().OnlyHaveFiles(files_on_disk);
         }
 
-        [Fact]
+        [CoreMSBuildOnlyFact]
         public void compose_multifile()
         {
             TestAsset simpleDependenciesAsset = _testAssetsManager
@@ -264,7 +264,7 @@ namespace Microsoft.NET.Publish.Tests
             }
         }
 
-        [Fact]
+        [CoreMSBuildOnlyFact]
         public void It_uses_star_versions_correctly()
         {
             TestAsset targetManifestsAsset = _testAssetsManager
@@ -305,7 +305,7 @@ namespace Microsoft.NET.Publish.Tests
             }
         }
 
-        [Fact]
+        [CoreMSBuildOnlyFact]
         public void It_creates_profiling_symbols()
         {
             TestAsset targetManifestsAsset = _testAssetsManager

--- a/test/Microsoft.NET.TestFramework/RepoInfo.cs
+++ b/test/Microsoft.NET.TestFramework/RepoInfo.cs
@@ -117,6 +117,7 @@ namespace Microsoft.NET.TestFramework
             command = command.EnvironmentVariable("NUGET_PACKAGES", RepoInfo.NuGetCachePath);
 
             command = command.EnvironmentVariable("MSBuildSDKsPath", RepoInfo.SdksPath);
+            command = command.EnvironmentVariable("DOTNET_MSBUILD_SDK_RESOLVER_SDKS_DIR", RepoInfo.SdksPath);
 
             command = command.EnvironmentVariable("NETCoreSdkBundledVersionsProps", Path.Combine(RepoInfo.CliSdkPath, "Microsoft.NETCoreSdk.BundledVersions.props"));
 


### PR DESCRIPTION
Now that we've updated to use Jenkins machines with recent builds of VS 15.3 in #1278, we should be able to re-enable the full framework coverage that was disabled.