### PR TITLE
Fix Reference and PackageReference name collision

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/DependencyContextBuilder.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/DependencyContextBuilder.cs
@@ -55,8 +55,9 @@ namespace Microsoft.NET.Build.Tasks
             {
                 if (_usedLibraryNames == null)
                 {
-                    _usedLibraryNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-                    _usedLibraryNames.AddRange(_projectContext.LockFile.Libraries.Select(l => l.Name));
+                    _usedLibraryNames = new HashSet<string>(
+                        _projectContext.LockFile.Libraries.Select(l => l.Name),
+                        StringComparer.OrdinalIgnoreCase);
                 }
 
                 return _usedLibraryNames;

--- a/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPreserveCompilationContext.cs
+++ b/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPreserveCompilationContext.cs
@@ -119,7 +119,7 @@ namespace Microsoft.NET.Publish.Tests
 
                         var systemCollectionsLibrary = dependencyContext
                             .CompileLibraries
-                            .FirstOrDefault(l => string.Equals(l.Name, "system.collections", StringComparison.OrdinalIgnoreCase));
+                            .FirstOrDefault(l => string.Equals(l.Name, "system.collections.reference", StringComparison.OrdinalIgnoreCase));
                         systemCollectionsLibrary.Assemblies.Count.Should().Be(1);
                         systemCollectionsLibrary.Assemblies[0].Should().Be(".NETFramework/v4.6/Facades/System.Collections.dll");
                     }


### PR DESCRIPTION
When building a DependencyContext, it is possible for
Reference names and PackageReference names to collide. We need
to ensure the DependencyContext libraries that are created have
unique names.

Also, when PreserveCompilationContext is false, we shouldn't be
creating Dependency objects for referenceassembly libraries, since
they won't be in the context.  They are only used for compilation.

Fix #1289

/cc @livarcocc 