### PR TITLE
Don't generate runtimeconfig files for desktop.

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.targets
@@ -39,7 +39,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   </PropertyGroup>
 
   <PropertyGroup>
-    <GenerateRuntimeConfigurationFiles Condition=" '$(GenerateRuntimeConfigurationFiles)' == '' and '$(HasRuntimeOutput)' == 'true' ">true</GenerateRuntimeConfigurationFiles>
+    <GenerateRuntimeConfigurationFiles Condition=" '$(GenerateRuntimeConfigurationFiles)' == '' and '$(TargetFrameworkIdentifier)' == '.NETCoreApp' and '$(HasRuntimeOutput)' == 'true' ">true</GenerateRuntimeConfigurationFiles>
     <UserRuntimeConfig Condition=" '$(UserRuntimeConfig)' == '' ">$(MSBuildProjectDirectory)/runtimeconfig.template.json</UserRuntimeConfig>
     <GenerateSatelliteAssembliesForCore Condition=" '$(GenerateSatelliteAssembliesForCore)' == '' and '$(MSBuildRuntimeType)' == 'Core' ">true</GenerateSatelliteAssembliesForCore>
     <ComputeNETCoreBuildOutputFiles Condition=" '$(ComputeNETCoreBuildOutputFiles)' == '' and '$(TargetFrameworkIdentifier)' == '.NETCoreApp'">true</ComputeNETCoreBuildOutputFiles>

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantAllResourcesInSatellite.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantAllResourcesInSatellite.cs
@@ -78,8 +78,6 @@ namespace Microsoft.NET.Build.Tests
                 var outputFiles = new List<string>
                 {
                     "AllResourcesInSatellite.pdb",
-                    "AllResourcesInSatellite.runtimeconfig.json",
-                    "AllResourcesInSatellite.runtimeconfig.dev.json",
                     "en/AllResourcesInSatellite.resources.dll"
                 };
 
@@ -93,11 +91,12 @@ namespace Microsoft.NET.Build.Tests
                 {
                     outputFiles.Add("AllResourcesInSatellite.dll");
                     outputFiles.Add("AllResourcesInSatellite.deps.json");
+                    outputFiles.Add("AllResourcesInSatellite.runtimeconfig.json");
+                    outputFiles.Add("AllResourcesInSatellite.runtimeconfig.dev.json");
                     command = Command.Create(RepoInfo.DotNetHostPath, new[] { Path.Combine(outputDirectory.FullName, "AllResourcesInSatellite.dll") });
                 }
 
                 outputDirectory.Should().OnlyHaveFiles(outputFiles);
-
 
                 command
                     .CaptureStdOut()

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildADesktopExe.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildADesktopExe.cs
@@ -62,7 +62,6 @@ namespace Microsoft.NET.Build.Tests
             });
         }
 
-
         [Theory]
 
         // If we don't set platformTarget and don't use native dependency, we get working AnyCPU app.

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildADesktopExe.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildADesktopExe.cs
@@ -28,6 +28,41 @@ namespace Microsoft.NET.Build.Tests
         {
         }
 
+        [Fact]
+        public void It_builds_a_simple_desktop_app()
+        {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return;
+            }
+
+            var targetFramework = "net45";
+            var testAsset = _testAssetsManager
+                .CopyTestAsset("HelloWorld")
+                .WithSource()
+                .WithProjectChanges(project =>
+                {
+                    var ns = project.Root.Name.Namespace;
+                    var propertyGroup = project.Root.Elements(ns + "PropertyGroup").First();
+                    propertyGroup.Element(ns + "TargetFramework").SetValue(targetFramework);
+                })
+                .Restore(Log);
+
+            var buildCommand = new BuildCommand(Log, testAsset.TestRoot);
+            buildCommand
+                .Execute()
+                .Should()
+                .Pass();
+
+            var outputDirectory = buildCommand.GetOutputDirectory(targetFramework);
+
+            outputDirectory.Should().OnlyHaveFiles(new[] {
+                "HelloWorld.exe",
+                "HelloWorld.pdb",
+            });
+        }
+
+
         [Theory]
 
         // If we don't set platformTarget and don't use native dependency, we get working AnyCPU app.

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAppsWithFrameworkRefs.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAppsWithFrameworkRefs.cs
@@ -67,9 +67,7 @@ namespace Microsoft.NET.Build.Tests
 
             VerifyBuild(testAsset, "EntityFrameworkApp", "net451", "win7-x86", buildArgs,
                 "EntityFrameworkApp.exe",
-                "EntityFrameworkApp.pdb",
-                "EntityFrameworkApp.runtimeconfig.dev.json",
-                "EntityFrameworkApp.runtimeconfig.json");
+                "EntityFrameworkApp.pdb");
 
             // Try running EntityFrameworkApp.exe
             var appProjectDirectory = Path.Combine(testAsset.TestRoot, "EntityFrameworkApp");
@@ -123,9 +121,7 @@ namespace Microsoft.NET.Build.Tests
 
             VerifyClean(testAsset, "EntityFrameworkApp", "net451", "win7-x86",
                 "EntityFrameworkApp.exe",
-                "EntityFrameworkApp.pdb",
-                "EntityFrameworkApp.runtimeconfig.dev.json",
-                "EntityFrameworkApp.runtimeconfig.json");
+                "EntityFrameworkApp.pdb");
         }
 
         private void VerifyClean(TestAsset testAsset, string project, string targetFramework, string runtimeIdentifier,


### PR DESCRIPTION
Runtimeconfig.json files are .NET Core specific.  We don't need to generate them for other TFMs.

Fix #404 

/cc @livarcocc @basoundr 