### PR TITLE
Simplify scheduling of ConflictResolution/NETStandard injection

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Extensions.Tasks/msbuildExtensions/Microsoft.NET.Build.Extensions/Microsoft.NET.Build.Extensions.ConflictResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Extensions.Tasks/msbuildExtensions/Microsoft.NET.Build.Extensions/Microsoft.NET.Build.Extensions.ConflictResolution.targets
@@ -3,29 +3,27 @@
   <Choose>
     <!-- Allow completely disabling the conflict resolution targets -->
     <When Condition="'$(DisableHandlePackageFileConflicts)' == 'true'" />
-    <!-- SDK projects have built in conflict resolution that understands assets/deps file -->
-    <When Condition="'$(UsingMicrosoftNETSdk)' == 'true'" />
     <When Condition="'$(ResolveNuGetPackages)' == 'true' and Exists('$(ProjectLockFile)')">
       <!-- Non-SDK using project.json or PackageReference, run after references are read from the lock/assets file -->
       <PropertyGroup>
-        <HandlePackageFileConflictsAfter>ResolveNuGetPackageAssets</HandlePackageFileConflictsAfter>
+        <_HandlePackageFileConflictsAfter>ResolveNuGetPackageAssets</_HandlePackageFileConflictsAfter>
       </PropertyGroup>
     </When>
     <Otherwise>
       <!-- No specific NuGet targets to sequence after, run before targets that consume references -->
       <PropertyGroup>
-        <ResolveAssemblyReferencesDependsOn>$(ResolveAssemblyReferencesDependsOn);HandlePackageFileConflicts</ResolveAssemblyReferencesDependsOn>
-        <PrepareResourcesDependsOn>HandlePackageFileConflicts;$(PrepareResourcesDependsOn)</PrepareResourcesDependsOn>
+        <ResolveAssemblyReferencesDependsOn>$(ResolveAssemblyReferencesDependsOn);_HandlePackageFileConflicts</ResolveAssemblyReferencesDependsOn>
+        <PrepareResourcesDependsOn>_HandlePackageFileConflicts;$(PrepareResourcesDependsOn)</PrepareResourcesDependsOn>
       </PropertyGroup>
     </Otherwise>
   </Choose>
   
   <UsingTask TaskName="ResolvePackageFileConflicts" AssemblyFile="$(MicrosoftNETBuildExtensionsTasksAssembly)" />
-  <Target Name="HandlePackageFileConflicts" AfterTargets="$(HandlePackageFileConflictsAfter)" DependsOnTargets="$(HandlePackageFileConflictsDependsOn)">
+  <Target Name="_HandlePackageFileConflicts" AfterTargets="$(_HandlePackageFileConflictsAfter)">
     <ResolvePackageFileConflicts References="@(Reference)"
-                                ReferenceCopyLocalPaths="@(ReferenceCopyLocalPaths)"
-                                PlatformManifests="@(PackageConflictPlatformManifests)"
-                                PreferredPackages="$(PackageConflictPreferredPackages)">
+                                 ReferenceCopyLocalPaths="@(ReferenceCopyLocalPaths)"
+                                 PlatformManifests="@(PackageConflictPlatformManifests)"
+                                 PreferredPackages="$(PackageConflictPreferredPackages)">
       <Output TaskParameter="ReferencesWithoutConflicts" ItemName="_ReferencesWithoutConflicts" />
       <Output TaskParameter="ReferenceCopyLocalPathsWithoutConflicts" ItemName="_ReferenceCopyLocalPathsWithoutConflicts" />
       <Output TaskParameter="Conflicts" ItemName="_ConflictPackageFiles" />

--- a/src/Tasks/Microsoft.NET.Build.Extensions.Tasks/msbuildExtensions/Microsoft.NET.Build.Extensions/Microsoft.NET.Build.Extensions.NETFramework.targets
+++ b/src/Tasks/Microsoft.NET.Build.Extensions.Tasks/msbuildExtensions/Microsoft.NET.Build.Extensions/Microsoft.NET.Build.Extensions.NETFramework.targets
@@ -5,39 +5,11 @@
     <ImplicitlyExpandNETStandardFacades Condition="'$(ImplicitlyExpandNETStandardFacades)' == '' AND '$(_TargetFrameworkVersionWithoutV)' &gt;= '4.6.1'">true</ImplicitlyExpandNETStandardFacades>
   </PropertyGroup>
 
-  <Choose>
-    <!-- Allow completely disabling the conflict resolution targets-->
-    <When Condition="'$(ImplicitlyExpandNETStandardFacades)' != 'true'" />
-    <When Condition="'$(UsingMicrosoftNETSdk)' == 'true' OR '$(TargetFramework)' != '' OR '$(TargetFrameworks)' != ''">
-      <!-- .NET SDK: Run after references are resolved -->
-      <PropertyGroup>
-        <ImplicitlyExpandNETStandardFacadesAfter>ResolveLockFileReferences</ImplicitlyExpandNETStandardFacadesAfter>
-      </PropertyGroup>
-    </When>
-    <When Condition="'$(ResolveNuGetPackages)' == 'true' and Exists('$(ProjectLockFile)')">
-      <!-- Non-SDK using project.json or PackageReference, run after references are read from the lock/assets file -->
-      <PropertyGroup>
-        <ImplicitlyExpandNETStandardFacadesAfter>ResolveNuGetPackageAssets</ImplicitlyExpandNETStandardFacadesAfter>
-      </PropertyGroup>
-    </When>
-    <Otherwise>
-      <!-- No specific NuGet targets to sequence after, run before targets that consume references -->
-      <PropertyGroup>
-        <ResolveAssemblyReferencesDependsOn>ImplicitlyExpandNETStandardFacades;$(ResolveAssemblyReferencesDependsOn)</ResolveAssemblyReferencesDependsOn>
-        <PrepareResourcesDependsOn>ImplicitlyExpandNETStandardFacades;$(PrepareResourcesDependsOn)</PrepareResourcesDependsOn>
-      </PropertyGroup>
-    </Otherwise>
-  </Choose>
-
-  <PropertyGroup Condition="'$(ImplicitlyExpandNETStandardFacades)' == 'true'">
-    <!-- Ensure this runs before conflict resolution since the added files may cause conflicts -->
-    <HandlePackageFileConflictsDependsOn>ImplicitlyExpandNETStandardFacades;$(HandlePackageFileConflictsDependsOn)</HandlePackageFileConflictsDependsOn>
-  </PropertyGroup>
-
   <UsingTask TaskName="GetDependsOnNETStandard" AssemblyFile="$(MicrosoftNETBuildExtensionsTasksAssembly)" />
   <UsingTask TaskName="NETBuildExtensionsError" AssemblyFile="$(MicrosoftNETBuildExtensionsTasksAssembly)" />
   <Target Name="ImplicitlyExpandNETStandardFacades"
-          AfterTargets="$(ImplicitlyExpandNETStandardFacadesAfter)">
+          Condition="'$(ImplicitlyExpandNETStandardFacades)' == 'true'"
+          BeforeTargets="_HandlePackageFileConflicts;ResolveAssemblyReferences">
 
     <ItemGroup>
       <_CandidateNETStandardReferences Include="@(Reference);@(_ResolvedProjectReferencePaths)" />

--- a/src/Tasks/Microsoft.NET.Build.Extensions.Tasks/msbuildExtensions/Microsoft.NET.Build.Extensions/Microsoft.NET.Build.Extensions.targets
+++ b/src/Tasks/Microsoft.NET.Build.Extensions.Tasks/msbuildExtensions/Microsoft.NET.Build.Extensions/Microsoft.NET.Build.Extensions.targets
@@ -8,10 +8,11 @@
     <MicrosoftNETBuildExtensionsTasksAssembly Condition="'$(MicrosoftNETBuildExtensionsTasksAssembly)' == ''">$(MSBuildThisFileDirectory)\tools\net46\Microsoft.NET.Build.Extensions.Tasks.dll</MicrosoftNETBuildExtensionsTasksAssembly>
 
     <!-- Include conflict resolution targets for NETFramework and allow other frameworks to opt-in -->
-    <ResolveAssemblyConflicts Condition="'$(ResolveAssemblyConflicts)' == '' AND '$(TargetFrameworkIdentifier)' == '.NETFramework' AND '$(UsingMicrosoftNETSdk)' != 'true'">true</ResolveAssemblyConflicts>
+    <ResolveAssemblyConflicts Condition="'$(ResolveAssemblyConflicts)' == '' AND '$(TargetFrameworkIdentifier)' == '.NETFramework'">true</ResolveAssemblyConflicts>
   </PropertyGroup>
 
   <Import Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'" Project="Microsoft.NET.Build.Extensions.NETFramework.targets"/>
 
-  <Import Condition="'$(ResolveAssemblyConflicts)' == 'true'" Project="Microsoft.NET.Build.Extensions.ConflictResolution.targets"/>
+  <!-- Only import ConflictResolution targets for non-SDK projects, SDK projects have ConflictResolution built in -->
+  <Import Condition="'$(ResolveAssemblyConflicts)' == 'true' AND '$(UsingMicrosoftNETSdk)' != 'true'" Project="Microsoft.NET.Build.Extensions.ConflictResolution.targets"/>
 </Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.PackageDependencyResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.PackageDependencyResolution.targets
@@ -64,10 +64,12 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ResolveAssemblyReferencesDependsOn>
       $(ResolveAssemblyReferencesDependsOn);
       ResolvePackageDependenciesForBuild;
+      _HandlePackageFileConflicts;
     </ResolveAssemblyReferencesDependsOn>
 
     <PrepareResourcesDependsOn>
       ResolvePackageDependenciesForBuild;
+      _HandlePackageFileConflicts;
       $(PrepareResourcesDependsOn)
     </PrepareResourcesDependsOn>
   </PropertyGroup>
@@ -121,8 +123,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       ResolveLockFileReferences;
       ResolveLockFileAnalyzers;
       ResolveLockFileCopyLocalProjectDeps;
-      IncludeTransitiveProjectReferences;
-      _HandlePackageFileConflicts
+      IncludeTransitiveProjectReferences
     </ResolvePackageDependenciesForBuildDependsOn>
   </PropertyGroup>
   <Target Name="ResolvePackageDependenciesForBuild"


### PR DESCRIPTION
SDK projects were running conflict-resolution too early, before ResolveProjectReferences.  Fix this by moving conflict resolution out of
ResolvePackageDependenciesForBuildDependsOn and moving it later as
a dependency of ResolveAssemblyReferences.

ImplicitlyExpandNETStandardFacades was previously trying to run as early as possible
which introduced problems in differing build sequences and complexity around handling
those.  Instead, run this as late as possible.  This is better because this target really
needs a full picture of all references to do its job.  I've scheduled it to run before
_HandlePackageFileConflicts and ResolveAssemblyReferences, just in case someone disables
_HandlePackageFileConflicts.

I've also renamed the extension conflict resolution target _HandlePackageFileConflicts
to match the SDK and made sure that it will never be brought into an SDK project.
This helped in the simplification of scheduling of ImplicitlyExpandNETStandardFacades.

Fixes #1311

/cc @eerhardt @dsplaisted @nguerrera 