### PR TITLE
Add a unit test for ARM projects to verify correct files are generated

### DIFF
--- a/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAHelloWorldProject.cs
+++ b/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAHelloWorldProject.cs
@@ -168,6 +168,72 @@ public static class Program
                 .And
                 .HaveStdOutContaining("Hello from a netcoreapp2.0.!");
         }
+		
+		//Note: Pre Netcoreapp2.0 standalone activation uses renamed dotnet.exe
+        //      While Post 2.0 we are shifting to using apphost.exe, so both publish needs to be validated
+        [CoreMSBuildOnlyTheory]
+        [InlineData("win-arm")]
+        [InlineData("win8-arm")]
+        [InlineData("win81-arm")]
+        [InlineData("win10-arm")]
+        [InlineData("win10-arm64")]
+        public void Publish_standalone_post_netcoreapp2_arm_app(string runtimeIdentifier)
+        {
+            // Tests for existence of expected files when publishing an ARM project
+            // See https://github.com/dotnet/sdk/issues/1239
+
+            var targetFramework = "netcoreapp2.0";
+
+            TestProject testProject = new TestProject()
+            {
+                Name = "Hello",
+                IsSdkProject = true,
+                TargetFrameworks = targetFramework,
+                RuntimeIdentifier = runtimeIdentifier,
+                IsExe = true,
+            };
+            
+            testProject.SourceFiles["Program.cs"] = @"
+using System;
+public static class Program
+{
+    public static void Main()
+    {
+        Console.WriteLine(""Hello from an arm netcoreapp2.0 app!"");
+    }
+}
+";
+            var testProjectInstance = _testAssetsManager.CreateTestProject(testProject);
+
+            testProjectInstance.Restore(Log, testProject.Name);
+            var publishCommand = new PublishCommand(Log, Path.Combine(testProjectInstance.TestRoot, testProject.Name));
+            var publishResult = publishCommand.Execute();
+
+            publishResult.Should().Pass();
+
+            var publishDirectory = publishCommand.GetOutputDirectory(
+                targetFramework: targetFramework,
+                runtimeIdentifier: runtimeIdentifier);
+            
+            // The name of the self contained executable depends on the runtime identifier.
+            // For Windows family ARM publishing, it'll always be Hello.exe.
+            // We shouldn't use "Constants.ExeSuffix" for the suffix here because that changes
+            // depending on the RuntimeInformation
+            var selfContainedExecutable = "Hello.exe";
+
+            publishDirectory.Should().HaveFiles(new[] {
+                selfContainedExecutable,
+                "Hello.dll",
+                "Hello.pdb",
+                "Hello.deps.json",
+                "Hello.runtimeconfig.json",
+                "coreclr.dll",
+                "hostfxr.dll",
+                "hostpolicy.dll",
+                "mscorlib.dll",
+                "System.Private.CoreLib.dll",
+            });
+        }
 
         [Fact]
         public void Conflicts_are_resolved_when_publishing_a_portable_app()


### PR DESCRIPTION
This adds a unit test to cover [issue #1239](https://github.com/dotnet/sdk/issues/1239) - this checks that the correct files are generated for self contained projects which target ARM runtimes.

Quick note for clarity - this request is just a unit test - the original fix was submitted by @eerhardt in [PR #20187](https://github.com/dotnet/corefx/pull/20187).

[PR #1251](https://github.com/dotnet/sdk/pull/1251) was opened for this previously but closed after merge conflicts.

@ericstj @nguerrera @eerhardt 