### PR TITLE
CreatePDB doesn't work without DiaSymReader on the path

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.CrossGen.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.CrossGen.targets
@@ -73,8 +73,19 @@ Copyright (c) .NET Foundation. All rights reserved.
                  ResourceName="UnableToFindResolvedPath"
                  FormatArguments="$(Crossgen)" />
 
+    <!-- Copy crossgen into the netcoreapp folder to ensure it can load Microsoft.DiaSymReader.Native when creating PDBs -->
+    <Copy SourceFiles="$(Crossgen)"
+          DestinationFolder="$(_NetCoreRefDir)"
+          OverwriteReadOnlyFiles="$(OverwriteReadOnlyFiles)"
+          Retries="$(CopyRetryCount)"
+          RetryDelayMilliseconds="$(CopyRetryDelayMilliseconds)"
+          UseHardlinksIfPossible="$(CreateHardLinksForPublishFilesIfPossible)"
+          UseSymboliclinksIfPossible="$(CreateSymbolicLinksForPublishFilesIfPossible)">
+      <Output TaskParameter="DestinationFiles" ItemName="FileWrites"/>
+    </Copy>
+    
     <PropertyGroup>
-      <Crossgen> $([System.IO.Path]::GetFullPath($(Crossgen)))</Crossgen>
+      <Crossgen>$([System.IO.Path]::GetFullPath($([System.IO.Path]::Combine($(_NetCoreRefDir), $([System.IO.Path]::GetFileName($(Crossgen)))))))</Crossgen>
     </PropertyGroup>
   </Target>
   

--- a/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToStoreAProjectWithDependencies.cs
+++ b/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToStoreAProjectWithDependencies.cs
@@ -235,7 +235,16 @@ namespace Microsoft.NET.Publish.Tests
             var outputFolder = Path.Combine(targetManifestsAsset.TestRoot, "o");
             var workingDir = Path.Combine(targetManifestsAsset.TestRoot, "w");
 
-            new ComposeStoreCommand(Log, targetManifestsAsset.TestRoot, "NewtonsoftFilterProfile.xml")
+            var composeStore = new ComposeStoreCommand(Log, targetManifestsAsset.TestRoot, "NewtonsoftFilterProfile.xml");
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                // clear the PATH on windows to ensure creating .ni.pdbs works without 
+                // being in a VS developer command prompt
+                composeStore.WithEnvironmentVariable("PATH", string.Empty);
+            }
+            
+            composeStore
                 .Execute(
                     $"/p:RuntimeIdentifier={_runtimeRid}",
                     "/p:TargetFramework=netcoreapp2.0",

--- a/test/Microsoft.NET.TestFramework/Commands/TestCommand.cs
+++ b/test/Microsoft.NET.TestFramework/Commands/TestCommand.cs
@@ -2,14 +2,15 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.DotNet.Cli.Utils;
+using System.Collections.Generic;
 using Xunit.Abstractions;
 
 namespace Microsoft.NET.TestFramework.Commands
 {
-
-
     public abstract class TestCommand
     {
+        private Dictionary<string, string> _environment = new Dictionary<string, string>();
+
         public ITestOutputHelper Log { get; }
 
         protected TestCommand(ITestOutputHelper log)
@@ -19,12 +20,24 @@ namespace Microsoft.NET.TestFramework.Commands
 
         protected abstract ICommand CreateCommand(string[] args);
 
+        public TestCommand WithEnvironmentVariable(string name, string value)
+        {
+            _environment[name] = value;
+            return this;
+        }
+
         public CommandResult Execute(params string[] args)
         {
-            var result = CreateCommand(args)
+            var command = CreateCommand(args)
                 .CaptureStdOut()
-                .CaptureStdErr()
-                .Execute();
+                .CaptureStdErr();
+
+            foreach (var variable in _environment)
+            {
+                command.EnvironmentVariable(variable.Key, variable.Value);
+            }
+
+            var result = command.Execute();
 
             Log.WriteLine($"> {result.StartInfo.FileName} {result.StartInfo.Arguments}");
             Log.WriteLine(result.StdOut);


### PR DESCRIPTION
To fix this, copy crossgen to the netcoreapp folder that has DiaSymReader in it, and invoke crossgen from there.

Fix https://github.com/dotnet/cli/issues/6778

/cc @gkhanna79