### PR TITLE
Adding implicit nuget properties to control restore source and fallback folder.

### DIFF
--- a/sdk.sln
+++ b/sdk.sln
@@ -63,18 +63,12 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.NET.Build.Extensi
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.NET.Build.Extensions.Tasks.UnitTests", "src\Tasks\Microsoft.NET.Build.Extensions.Tasks.UnitTests\Microsoft.NET.Build.Extensions.Tasks.UnitTests.csproj", "{0E11CA1E-D64F-48E9-BE86-B040D9E8EBF8}"
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{4A305861-DAB7-455A-8A0F-27F82D79D971}"
-EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.NET.Restore.Tests", "test\Microsoft.NET.Restore.Tests\Microsoft.NET.Restore.Tests.csproj", "{73F52EAA-A435-4D7B-8E1E-F82E9A25BA98}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
-		Debug|x64 = Debug|x64
-		Debug|x86 = Debug|x86
-		Release|x64 = Release|x64
-		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{DF7D2697-B3B4-45C2-8297-27245F528A99}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -115,16 +109,8 @@ Global
 		{0E11CA1E-D64F-48E9-BE86-B040D9E8EBF8}.Release|Any CPU.Build.0 = Release|Any CPU
 		{73F52EAA-A435-4D7B-8E1E-F82E9A25BA98}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{73F52EAA-A435-4D7B-8E1E-F82E9A25BA98}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{73F52EAA-A435-4D7B-8E1E-F82E9A25BA98}.Debug|x64.ActiveCfg = Debug|x64
-		{73F52EAA-A435-4D7B-8E1E-F82E9A25BA98}.Debug|x64.Build.0 = Debug|x64
-		{73F52EAA-A435-4D7B-8E1E-F82E9A25BA98}.Debug|x86.ActiveCfg = Debug|x86
-		{73F52EAA-A435-4D7B-8E1E-F82E9A25BA98}.Debug|x86.Build.0 = Debug|x86
 		{73F52EAA-A435-4D7B-8E1E-F82E9A25BA98}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{73F52EAA-A435-4D7B-8E1E-F82E9A25BA98}.Release|Any CPU.Build.0 = Release|Any CPU
-		{73F52EAA-A435-4D7B-8E1E-F82E9A25BA98}.Release|x64.ActiveCfg = Release|x64
-		{73F52EAA-A435-4D7B-8E1E-F82E9A25BA98}.Release|x64.Build.0 = Release|x64
-		{73F52EAA-A435-4D7B-8E1E-F82E9A25BA98}.Release|x86.ActiveCfg = Release|x86
-		{73F52EAA-A435-4D7B-8E1E-F82E9A25BA98}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -142,6 +128,6 @@ Global
 		{588516D7-96AD-4447-A1EB-244D737A3C87} = {580D1AE7-AA8F-4912-8B76-105594E00B3B}
 		{88723307-6BFA-4CB5-A518-2FFD5F91B891} = {1FEED16D-E07D-47C1-BB4C-56CD9F42B53B}
 		{0E11CA1E-D64F-48E9-BE86-B040D9E8EBF8} = {1FEED16D-E07D-47C1-BB4C-56CD9F42B53B}
-		{73F52EAA-A435-4D7B-8E1E-F82E9A25BA98} = {4A305861-DAB7-455A-8A0F-27F82D79D971}
+		{73F52EAA-A435-4D7B-8E1E-F82E9A25BA98} = {580D1AE7-AA8F-4912-8B76-105594E00B3B}
 	EndGlobalSection
 EndGlobal

--- a/sdk.sln
+++ b/sdk.sln
@@ -1,4 +1,4 @@
-﻿
+
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.26531.4
@@ -63,10 +63,18 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.NET.Build.Extensi
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.NET.Build.Extensions.Tasks.UnitTests", "src\Tasks\Microsoft.NET.Build.Extensions.Tasks.UnitTests\Microsoft.NET.Build.Extensions.Tasks.UnitTests.csproj", "{0E11CA1E-D64F-48E9-BE86-B040D9E8EBF8}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{4A305861-DAB7-455A-8A0F-27F82D79D971}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.NET.Restore.Tests", "test\Microsoft.NET.Restore.Tests\Microsoft.NET.Restore.Tests.csproj", "{73F52EAA-A435-4D7B-8E1E-F82E9A25BA98}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{DF7D2697-B3B4-45C2-8297-27245F528A99}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -105,6 +113,18 @@ Global
 		{0E11CA1E-D64F-48E9-BE86-B040D9E8EBF8}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0E11CA1E-D64F-48E9-BE86-B040D9E8EBF8}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0E11CA1E-D64F-48E9-BE86-B040D9E8EBF8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{73F52EAA-A435-4D7B-8E1E-F82E9A25BA98}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{73F52EAA-A435-4D7B-8E1E-F82E9A25BA98}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{73F52EAA-A435-4D7B-8E1E-F82E9A25BA98}.Debug|x64.ActiveCfg = Debug|x64
+		{73F52EAA-A435-4D7B-8E1E-F82E9A25BA98}.Debug|x64.Build.0 = Debug|x64
+		{73F52EAA-A435-4D7B-8E1E-F82E9A25BA98}.Debug|x86.ActiveCfg = Debug|x86
+		{73F52EAA-A435-4D7B-8E1E-F82E9A25BA98}.Debug|x86.Build.0 = Debug|x86
+		{73F52EAA-A435-4D7B-8E1E-F82E9A25BA98}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{73F52EAA-A435-4D7B-8E1E-F82E9A25BA98}.Release|Any CPU.Build.0 = Release|Any CPU
+		{73F52EAA-A435-4D7B-8E1E-F82E9A25BA98}.Release|x64.ActiveCfg = Release|x64
+		{73F52EAA-A435-4D7B-8E1E-F82E9A25BA98}.Release|x64.Build.0 = Release|x64
+		{73F52EAA-A435-4D7B-8E1E-F82E9A25BA98}.Release|x86.ActiveCfg = Release|x86
+		{73F52EAA-A435-4D7B-8E1E-F82E9A25BA98}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -122,5 +142,6 @@ Global
 		{588516D7-96AD-4447-A1EB-244D737A3C87} = {580D1AE7-AA8F-4912-8B76-105594E00B3B}
 		{88723307-6BFA-4CB5-A518-2FFD5F91B891} = {1FEED16D-E07D-47C1-BB4C-56CD9F42B53B}
 		{0E11CA1E-D64F-48E9-BE86-B040D9E8EBF8} = {1FEED16D-E07D-47C1-BB4C-56CD9F42B53B}
+		{73F52EAA-A435-4D7B-8E1E-F82E9A25BA98} = {4A305861-DAB7-455A-8A0F-27F82D79D971}
 	EndGlobalSection
 EndGlobal

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.BeforeCommon.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.BeforeCommon.targets
@@ -89,9 +89,9 @@ Copyright (c) .NET Foundation. All rights reserved.
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(DisableImplicitNuGetFallbackFolder)' != 'true' and '$(_IsNETCoreOrNETStandard)' == 'true' and Exists($(_NugetFallbackFolder)) ">
-    <RestoreAdditionalProjectSources Condition=" '$(_TargetFrameworkVersionWithoutV)' &lt; '2.0' ">$(RestoreSources);$(_NugetFallbackFolder)</RestoreAdditionalProjectSources>
+    <RestoreAdditionalProjectSources Condition=" '$(_TargetFrameworkVersionWithoutV)' &lt; '2.0' ">$(RestoreAdditionalProjectSources);$(_NugetFallbackFolder)</RestoreAdditionalProjectSources>
 
-    <RestoreAdditionalProjectFallbackFolders Condition=" '$(_TargetFrameworkVersionWithoutV)' >= '2.0' ">$(RestoreFallbackFolders);$(_NugetFallbackFolder)</RestoreAdditionalProjectFallbackFolders>
+    <RestoreAdditionalProjectFallbackFolders Condition=" '$(_TargetFrameworkVersionWithoutV)' >= '2.0' ">$(RestoreAdditionalProjectFallbackFolders);$(_NugetFallbackFolder)</RestoreAdditionalProjectFallbackFolders>
   </PropertyGroup>
   
   <ItemGroup Condition=" '$(DisableImplicitFrameworkReferences)' != 'true' and '$(TargetFrameworkIdentifier)' == '.NETFramework'">

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.BeforeCommon.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.BeforeCommon.targets
@@ -14,6 +14,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <PropertyGroup>
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
     <_IsExecutable Condition="'$(OutputType)' == 'Exe' or '$(OutputType)'=='WinExe'">true</_IsExecutable>
+    <_NugetFallbackFolder>$(MSBuildThisFileDirectory)..\..\..\..\NuGetFallbackFolder</_NugetFallbackFolder>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(HasRuntimeOutput)' == ''">
@@ -85,6 +86,12 @@ Copyright (c) .NET Foundation. All rights reserved.
   <PropertyGroup>
     <_TargetFrameworkVersionWithoutV>$(TargetFrameworkVersion)</_TargetFrameworkVersionWithoutV>
     <_TargetFrameworkVersionWithoutV Condition="$(TargetFrameworkVersion.StartsWith('v'))">$(TargetFrameworkVersion.Substring(1))</_TargetFrameworkVersionWithoutV>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(DisableImplicitNuGetFallbackFolder)' != 'true' and '$(_IsNETCoreOrNETStandard)' == 'true' and Exists($(_NugetFallbackFolder)) ">
+    <RestoreAdditionalProjectSources Condition=" '$(_TargetFrameworkVersionWithoutV)' &lt; '2.0' ">$(RestoreSources);$(_NugetFallbackFolder)</RestoreAdditionalProjectSources>
+
+    <RestoreAdditionalProjectFallbackFolders Condition=" '$(_TargetFrameworkVersionWithoutV)' >= '2.0' ">$(RestoreFallbackFolders);$(_NugetFallbackFolder)</RestoreAdditionalProjectFallbackFolders>
   </PropertyGroup>
   
   <ItemGroup Condition=" '$(DisableImplicitFrameworkReferences)' != 'true' and '$(TargetFrameworkIdentifier)' == '.NETFramework'">

--- a/test/Microsoft.NET.Restore.Tests/GivenThatWeWantToRestoreProjectsUsingNuGetConfigProperties.cs
+++ b/test/Microsoft.NET.Restore.Tests/GivenThatWeWantToRestoreProjectsUsingNuGetConfigProperties.cs
@@ -22,18 +22,22 @@ namespace Microsoft.NET.Build.Tests
         {
         }
 
-        [Theory]
-        [InlineData("netstandard1.3", true)]
-        [InlineData("netcoreapp1.0", true)]
-        [InlineData("netcoreapp1.1", true)]
-        [InlineData("netstandard2.0", false)]
-        [InlineData("netcoreapp2.0", false)]
-        public void I_can_restore_a_project_with_implicit_msbuild_nuget_config(string framework, bool fileExists)
+        // https://github.com/dotnet/sdk/issues/1327
+        [CoreMSBuildOnlyTheory]
+        [InlineData("netstandard1.3", "1.3", true)]
+        [InlineData("netcoreapp1.0", "1.0", true)]
+        [InlineData("netcoreapp1.1", "1.1", true)]
+        [InlineData("netstandard2.0", "2.0", false)]
+        [InlineData("netcoreapp2.0", "2.0app", false)]
+        public void I_can_restore_a_project_with_implicit_msbuild_nuget_config(
+            string framework,
+            string projectPrefix,
+            bool fileExists)
         {
-            string testProjectName = framework.Replace(".", "") + "ProjectWithFallbackFolderReference";   
+            string testProjectName = $"{projectPrefix}Fallback";
             TestAsset testProjectTestAsset = CreateTestAsset(testProjectName, framework);
 
-            var packagesFolder = Path.Combine(testProjectTestAsset.Path, "packages");
+            var packagesFolder = Path.Combine(RepoInfo.TestsFolder, "packages", testProjectName);
 
             var restoreCommand = testProjectTestAsset.GetRestoreCommand(Log, relativePath: testProjectName);
             restoreCommand.Execute($"/p:RestorePackagesPath={packagesFolder}").Should().Pass();
@@ -45,15 +49,16 @@ namespace Microsoft.NET.Build.Tests
                 "projectinfallbackfolder.1.0.0.nupkg")).Should().Be(fileExists);
         }
 
-        [Theory]
-        [InlineData("netstandard1.3")]
-        [InlineData("netcoreapp1.0")]
-        [InlineData("netcoreapp1.1")]
-        [InlineData("netstandard2.0")]
-        [InlineData("netcoreapp2.0")]
-        public void I_can_disable_implicit_msbuild_nuget_config(string framework)
+        // https://github.com/dotnet/sdk/issues/1327
+        [CoreMSBuildOnlyTheory]
+        [InlineData("netstandard1.3", "1.3")]
+        [InlineData("netcoreapp1.0", "1.0")]
+        [InlineData("netcoreapp1.1", "1.1")]
+        [InlineData("netstandard2.0", "2.0")]
+        [InlineData("netcoreapp2.0", "2.0app")]
+        public void I_can_disable_implicit_msbuild_nuget_config(string framework, string projectPrefix)
         {
-            string testProjectName = framework.Replace(".", "") + "ProjectWithDisabledFallbackFolder";   
+            string testProjectName = $"{projectPrefix}DisabledFallback";
             TestAsset testProjectTestAsset = CreateTestAsset(testProjectName, framework);
 
             var restoreCommand = testProjectTestAsset.GetRestoreCommand(Log, relativePath: testProjectName);

--- a/test/Microsoft.NET.Restore.Tests/GivenThatWeWantToRestoreProjectsUsingNuGetConfigProperties.cs
+++ b/test/Microsoft.NET.Restore.Tests/GivenThatWeWantToRestoreProjectsUsingNuGetConfigProperties.cs
@@ -1,0 +1,151 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using FluentAssertions;
+using Microsoft.NET.TestFramework;
+using Microsoft.NET.TestFramework.Assertions;
+using Microsoft.NET.TestFramework.Commands;
+using Microsoft.NET.TestFramework.ProjectConstruction;
+using NuGet.Common;
+using NuGet.Packaging;
+using NuGet.Packaging.Core;
+using System.IO;
+using System.Threading;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.NET.Build.Tests
+{
+    public class GivenThatWeWantToRestoreProjectsUsingNuGetConfigProperties : SdkTest
+    {
+        public GivenThatWeWantToRestoreProjectsUsingNuGetConfigProperties(ITestOutputHelper log) : base(log)
+        {
+        }
+
+        [Theory]
+        [InlineData("netstandard1.3", true)]
+        [InlineData("netcoreapp1.0", true)]
+        [InlineData("netcoreapp1.1", true)]
+        [InlineData("netstandard2.0", false)]
+        [InlineData("netcoreapp2.0", false)]
+        public void I_can_restore_a_project_with_implicit_msbuild_nuget_config(string framework, bool fileExists)
+        {
+            string testProjectName = framework.Replace(".", "") + "ProjectWithFallbackFolderReference";   
+            TestAsset testProjectTestAsset = CreateTestAsset(testProjectName, framework);
+
+            var packagesFolder = Path.Combine(testProjectTestAsset.Path, "packages");
+
+            var restoreCommand = testProjectTestAsset.GetRestoreCommand(Log, relativePath: testProjectName);
+            restoreCommand.Execute($"/p:RestorePackagesPath={packagesFolder}").Should().Pass();
+
+            File.Exists(Path.Combine(
+                packagesFolder,
+                "projectinfallbackfolder",
+                "1.0.0",
+                "projectinfallbackfolder.1.0.0.nupkg")).Should().Be(fileExists);
+        }
+
+        [Theory]
+        [InlineData("netstandard1.3")]
+        [InlineData("netcoreapp1.0")]
+        [InlineData("netcoreapp1.1")]
+        [InlineData("netstandard2.0")]
+        [InlineData("netcoreapp2.0")]
+        public void I_can_disable_implicit_msbuild_nuget_config(string framework)
+        {
+            string testProjectName = framework.Replace(".", "") + "ProjectWithDisabledFallbackFolder";   
+            TestAsset testProjectTestAsset = CreateTestAsset(testProjectName, framework);
+
+            var restoreCommand = testProjectTestAsset.GetRestoreCommand(Log, relativePath: testProjectName);
+            restoreCommand.Execute($"/p:DisableImplicitNuGetFallbackFolder=true").Should().Fail();
+        }
+
+        private TestAsset CreateTestAsset(string testProjectName, string framework)
+        {
+            var packageInNuGetFallbackFolder = CreatePackageInNuGetFallbackFolder();
+
+            var testProject =
+                new TestProject
+                {
+                    Name = testProjectName,
+                    TargetFrameworks = framework,
+                    IsSdkProject = true
+                };
+
+            testProject.PackageReferences.Add(packageInNuGetFallbackFolder);
+
+            var testProjectTestAsset = _testAssetsManager.CreateTestProject(
+                testProject,
+                string.Empty,
+                testProjectName);
+
+            return testProjectTestAsset;
+        }
+
+        private TestPackageReference CreatePackageInNuGetFallbackFolder()
+        {
+            var projectInNuGetFallbackFolder =
+                new TestProject
+                {
+                    Name = $"ProjectInFallbackFolder",
+                    TargetFrameworks = "netstandard1.3",
+                    IsSdkProject = true
+                };
+
+            var projectInNuGetFallbackFolderPackageReference =
+                new TestPackageReference(
+                    projectInNuGetFallbackFolder.Name,
+                    "1.0.0",
+                    RepoInfo.NuGetFallbackFolder);
+
+            if (!projectInNuGetFallbackFolderPackageReference.NuGetPackageExists())
+            {
+                var projectInNuGetFallbackFolderTestAsset =
+                    _testAssetsManager.CreateTestProject(projectInNuGetFallbackFolder);
+                var packageRestoreCommand = projectInNuGetFallbackFolderTestAsset.GetRestoreCommand(
+                    Log,
+                    relativePath: projectInNuGetFallbackFolder.Name).Execute().Should().Pass();
+                var dependencyProjectDirectory = Path.Combine(
+                    projectInNuGetFallbackFolderTestAsset.TestRoot,
+                    projectInNuGetFallbackFolder.Name);
+                var packagePackCommand =
+                    new PackCommand(Log, dependencyProjectDirectory)
+                    .Execute($"/p:PackageOutputPath={RepoInfo.NuGetFallbackFolder}").Should().Pass();
+
+                ExtractNupkg(
+                    RepoInfo.NuGetFallbackFolder,
+                    Path.Combine(RepoInfo.NuGetFallbackFolder, $"{projectInNuGetFallbackFolder.Name}.1.0.0.nupkg"));
+            }
+
+            return projectInNuGetFallbackFolderPackageReference;
+        }
+
+        private void ExtractNupkg(string nugetCache, string nupkg)
+        {
+            var pathResolver = new VersionFolderPathResolver(nugetCache);
+
+            PackageIdentity identity = null;
+
+            using (var reader = new PackageArchiveReader(File.OpenRead(nupkg)))
+            {
+                identity = reader.GetIdentity();
+            }
+
+            if (!File.Exists(pathResolver.GetHashPath(identity.Id, identity.Version)))
+            {
+                using (var fileStream = File.OpenRead(nupkg))
+                {
+                    PackageExtractor.InstallFromSourceAsync((stream) =>
+                        fileStream.CopyToAsync(stream, 4096, CancellationToken.None),
+                        new VersionFolderPathContext(
+                            identity,
+                            nugetCache,
+                            NullLogger.Instance,
+                            PackageSaveMode.Defaultv3,
+                            XmlDocFileSaveMode.None),
+                        CancellationToken.None).Wait();
+                }
+            }
+        }
+    }
+}

--- a/test/Microsoft.NET.Restore.Tests/Microsoft.NET.Restore.Tests.csproj
+++ b/test/Microsoft.NET.Restore.Tests/Microsoft.NET.Restore.Tests.csproj
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <EnableDefaultItems>false</EnableDefaultItems>
+    <NonShipping>true</NonShipping>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
+    <PackageReference Include="NuGet.Packaging" Version="$(NuGetVersion)" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="**\*.cs" Exclude="$(GlobalExclude)" />
+    <EmbeddedResource Include="**\*.resx" Exclude="$(GlobalExclude)" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Microsoft.NET.TestFramework\Microsoft.NET.TestFramework.csproj" />
+  </ItemGroup>
+  <Import Project="..\..\build\Targets\Signing.Imports.targets" />
+</Project>

--- a/test/Microsoft.NET.TestFramework/RepoInfo.cs
+++ b/test/Microsoft.NET.TestFramework/RepoInfo.cs
@@ -62,6 +62,14 @@ namespace Microsoft.NET.TestFramework
             }
         }
 
+        public static string NuGetFallbackFolder
+        {
+            get
+            {
+                return Path.Combine(BinPath, "NuGetFallbackFolder");
+            }
+        }
+
         public static string PackagesPath
         {
             get { return Path.Combine(BinPath, Configuration, "Packages"); }

--- a/test/Microsoft.NET.TestFramework/RepoInfo.cs
+++ b/test/Microsoft.NET.TestFramework/RepoInfo.cs
@@ -70,6 +70,14 @@ namespace Microsoft.NET.TestFramework
             }
         }
 
+        public static string TestsFolder
+        {
+            get
+            {
+                return Path.Combine(BinPath, Configuration, "Tests");
+            }
+        }
+
         public static string PackagesPath
         {
             get { return Path.Combine(BinPath, Configuration, "Packages"); }


### PR DESCRIPTION
@dotnet/dotnet-cli 

@MattGertz for approval

**Customer scenario**

Enables the offline SDK cache to change between fallback folder for 2.0 projects and package source for 1.0 projects. This is a required change to support fallback folder in 2.0.

**Bugs this fixes:** 

https://github.com/dotnet/cli/issues/6507

**Workarounds, if any**

N/A

**Risk**

Low.

**Performance impact**

This should actually improve performance given that we will use fallback folders for 2.0 apps.

**Is this a regression from a previous update?**

N/A

**Root cause analysis:**

N/A

**How was the bug found?**

Planned feature.