### PR TITLE
Replacing PackageTargetFallback with AssetTargetFallback

### DIFF
--- a/TestAssets/TestProjects/CrossTargeting/NetStandardAndNetCoreApp/NetStandardAndNetCoreApp.csproj
+++ b/TestAssets/TestProjects/CrossTargeting/NetStandardAndNetCoreApp/NetStandardAndNetCoreApp.csproj
@@ -5,7 +5,7 @@
   <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp1.1'">
     <OutputType>exe</OutputType>
     <DefineConstants>NETCOREAPP;$(DefineConstants)</DefineConstants>
-    <PackageTargetFallback>dnxcore50</PackageTargetFallback>
+    <AssetTargetFallback>dnxcore50</AssetTargetFallback>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp1.1'">
     <PackageReference Include="Newtonsoft.Json" Version="7.0.1" />

--- a/TestAssets/TestProjects/KitchenSink/TestApp/TestApp.csproj
+++ b/TestAssets/TestProjects/KitchenSink/TestApp/TestApp.csproj
@@ -3,7 +3,6 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <ProjectGuid>{C91F7F4C-47ED-4D1C-8990-B2E886B0FAD9}</ProjectGuid>
-    <AssetTargetFallback>portable-net45+wp8+win8+wpa</AssetTargetFallback>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 
@@ -64,6 +63,6 @@
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="1.0.0" PrivateAssets="All" />
 
     <!-- Has satellite assembly -->
-    <PackageReference Include="System.Spatial" Version="5.7.0" />
+    <PackageReference Include="Humanizer" Version="2.2.0" />
   </ItemGroup>
 </Project>

--- a/TestAssets/TestProjects/KitchenSink/TestApp/TestApp.csproj
+++ b/TestAssets/TestProjects/KitchenSink/TestApp/TestApp.csproj
@@ -3,7 +3,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <ProjectGuid>{C91F7F4C-47ED-4D1C-8990-B2E886B0FAD9}</ProjectGuid>
-    <PackageTargetFallback>portable-net45+wp8+win8+wpa</PackageTargetFallback>
+    <AssetTargetFallback>portable-net45+wp8+win8+wpa</AssetTargetFallback>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.BeforeCommon.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.BeforeCommon.targets
@@ -136,8 +136,8 @@ Copyright (c) .NET Foundation. All rights reserved.
     <AddAdditionalExplicitAssemblyReferences>false</AddAdditionalExplicitAssemblyReferences>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(DisableImplicitPackageTargetFallback)' != 'true' and '$(_IsNETCoreOrNETStandard)' == 'true' and '$(_TargetFrameworkVersionWithoutV)' >= '2.0'">
-    <PackageTargetFallback>$(PackageTargetFallback);net461</PackageTargetFallback>    
+  <PropertyGroup Condition="'$(DisableImplicitAssetTargetFallback)' != 'true' and '$(_IsNETCoreOrNETStandard)' == 'true' and '$(_TargetFrameworkVersionWithoutV)' >= '2.0'">
+    <AssetTargetFallback>$(AssetTargetFallback);net461</AssetTargetFallback>
   </PropertyGroup>
 
   <!-- Add conditional compilation symbols for the target framework (for example NET461, NETSTANDARD2_0, NETCOREAPP1_0) -->

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildACrossTargetedLibrary.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildACrossTargetedLibrary.cs
@@ -21,7 +21,8 @@ namespace Microsoft.NET.Build.Tests
         {
         }
 
-        [Fact]
+        // https://github.com/dotnet/sdk/issues/1327
+        [CoreMSBuildOnlyFact]
         public void It_builds_nondesktop_library_successfully_on_all_platforms()
         {
             var testAsset = _testAssetsManager

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAnAppWithLibrary.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAnAppWithLibrary.cs
@@ -102,7 +102,8 @@ namespace Microsoft.NET.Build.Tests
             libInfo.ProductVersion.Should().Be("42.43.44.45-alpha");
         }
 
-        [Fact]
+        // https://github.com/dotnet/sdk/issues/1327
+        [CoreMSBuildOnlyFact]
         public void It_generates_satellite_assemblies()
         {
             var testAsset = _testAssetsManager

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAnAppWithLibrary.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAnAppWithLibrary.cs
@@ -102,8 +102,7 @@ namespace Microsoft.NET.Build.Tests
             libInfo.ProductVersion.Should().Be("42.43.44.45-alpha");
         }
 
-        // https://github.com/dotnet/sdk/issues/1327
-        [CoreMSBuildOnlyFact]
+        [Fact]
         public void It_generates_satellite_assemblies()
         {
             var testAsset = _testAssetsManager

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToVerifyNuGetReferenceCompat.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToVerifyNuGetReferenceCompat.cs
@@ -23,6 +23,25 @@ namespace Microsoft.NET.Build.Tests
         {
         }
 
+        // https://github.com/dotnet/sdk/issues/1327
+        [CoreMSBuildOnlyTheory]
+        [InlineData("netstandard2.0", "OptIn", "net45 net451 net46 net461", true, true)]
+        [InlineData("netcoreapp2.0", "OptIn", "net45 net451 net46 net461", true, true)]
+        public void Nuget_reference_compat_core_only(
+            string referencerTarget,
+            string testDescription,
+            string rawDependencyTargets,
+            bool restoreSucceeds,
+            bool buildSucceeds)
+        {
+            Nuget_reference_compat(
+                referencerTarget,
+                testDescription,
+                rawDependencyTargets,
+                restoreSucceeds,
+                buildSucceeds);
+        }
+
         [Theory]
         [InlineData("net45", "Full", "netstandard1.0 netstandard1.1 net45", true, true)]
         [InlineData("net451", "Full", "netstandard1.0 netstandard1.1 netstandard1.2 net45 net451", true, true)]
@@ -43,10 +62,6 @@ namespace Microsoft.NET.Build.Tests
         [InlineData("netcoreapp1.1", "Full", "netstandard1.0 netstandard1.1 netstandard1.2 netstandard1.3 netstandard1.4 netstandard1.5 netstandard1.6 netcoreapp1.0 netcoreapp1.1", true, true)]
         [InlineData("netcoreapp2.0", "PartM1", "netstandard1.0 netstandard1.1 netstandard1.2 netstandard1.3 netstandard1.4 netstandard1.5 netstandard1.6 netcoreapp1.0 netcoreapp1.1 netcoreapp2.0", true, true)]
         [InlineData("netcoreapp2.0", "Full", "netstandard1.0 netstandard1.1 netstandard1.2 netstandard1.3 netstandard1.4 netstandard1.5 netstandard1.6 netstandard2.0 netcoreapp1.0 netcoreapp1.1 netcoreapp2.0", true, true)]
-
-        [InlineData("netstandard2.0", "OptIn", "net45 net451 net46 net461", true, true)]
-        [InlineData("netcoreapp2.0", "OptIn", "net45 net451 net46 net461", true, true)]
-
         public void Nuget_reference_compat(string referencerTarget, string testDescription, string rawDependencyTargets,
                 bool restoreSucceeds, bool buildSucceeds)
         {
@@ -130,7 +145,8 @@ namespace Microsoft.NET.Build.Tests
             }
         }
 
-        [WindowsOnlyTheory]
+        // https://github.com/dotnet/sdk/issues/1327
+        [CoreMSBuildAndWindowsOnlyTheory]
         [InlineData("netstandard2.0")]
         [InlineData("netcoreapp2.0")]
         public void Net461_is_implicit_for_Netstandard_and_Netcore_20(string targetFramework)

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToVerifyNuGetReferenceCompat.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToVerifyNuGetReferenceCompat.cs
@@ -171,7 +171,7 @@ namespace Microsoft.NET.Build.Tests
             var testProjectTestAsset = CreateTestAsset(
                 testProjectName,
                 "netstandard2.0",
-                new Dictionary<string, string> { {"DisableImplicitPackageTargetFallback", "true" } });
+                new Dictionary<string, string> { {"DisableImplicitAssetTargetFallback", "true" } });
 
             var restoreCommand = testProjectTestAsset.GetRestoreCommand(Log, relativePath: testProjectName);
             restoreCommand.AddSource(Path.GetDirectoryName(_net461PackageReference.NupkgPath));

--- a/test/Microsoft.NET.Pack.Tests/GivenThatWeWantToPackACrossTargetedLibrary.cs
+++ b/test/Microsoft.NET.Pack.Tests/GivenThatWeWantToPackACrossTargetedLibrary.cs
@@ -20,7 +20,8 @@ namespace Microsoft.NET.Pack.Tests
         {
         }
 
-        [Fact]
+        // https://github.com/dotnet/sdk/issues/1327
+        [CoreMSBuildOnlyFact]
         public void It_packs_nondesktop_library_successfully_on_all_platforms()
         {
             var testAsset = _testAssetsManager


### PR DESCRIPTION
@dotnet/dotnet-cli 

@MattGertz for approval

**Customer scenario**

Replaces PackageTargetFallback with AssetTargetFallback. this is a new way from Nuget to do fallback between TFMs. This is the SDK reacting to that.

**Bugs this fixes:** 

https://github.com/dotnet/sdk/issues/1271

**Workarounds, if any**

N/A

**Risk**

Low.

**Performance impact**

N/A

**Is this a regression from a previous update?**

N/A

**Root cause analysis:**

N/A

**How was the bug found?**

Planned feature.