### PR TITLE
Making package downgrade warnings an error by default.

### DIFF
--- a/TestAssets/TestProjects/NetCoreApp11WithP2P/App/App.csproj
+++ b/TestAssets/TestProjects/NetCoreApp11WithP2P/App/App.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp1.1</TargetFramework>
-    <RuntimeFrameworkVersion>1.1.0</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>1.1.2</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.CSharp.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.CSharp.props
@@ -15,6 +15,9 @@ Copyright (c) .NET Foundation. All rights reserved.
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
     <WarningLevel Condition=" '$(WarningLevel)' == '' ">4</WarningLevel>
     <NoWarn Condition=" '$(NoWarn)' == '' ">1701;1702;1705</NoWarn>
+
+    <!-- Remove the line below once https://github.com/Microsoft/visualfsharp/issues/3207 gets fixed -->
+    <WarningsAsErrors Condition=" '$(WarningsAsErrors)' == '' ">NU1605</WarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup>
     <DefineConstants Condition=" '$(DefineConstants)' != '' ">$(DefineConstants);</DefineConstants>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.VisualBasic.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.VisualBasic.props
@@ -20,6 +20,9 @@ Copyright (c) .NET Foundation. All rights reserved.
     <OptionCompare Condition=" '$(OptionCompare)' == '' ">Binary</OptionCompare>
     <OptionStrict Condition=" '$(OptionStrict)' == '' ">Off</OptionStrict>
     <OptionInfer Condition=" '$(OptionInfer)' == '' ">On</OptionInfer>
+
+    <!-- Remove the line below once https://github.com/Microsoft/visualfsharp/issues/3207 gets fixed -->
+    <WarningsAsErrors Condition=" '$(WarningsAsErrors)' == '' ">NU1605</WarningsAsErrors>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.props
@@ -103,7 +103,8 @@ Copyright (c) .NET Foundation. All rights reserved.
     <DebugSymbols Condition="'$(DebugSymbols)'==''">false</DebugSymbols>
     <CheckForOverflowUnderflow Condition="'$(CheckForOverflowUnderflow)'==''">false</CheckForOverflowUnderflow>
 
-    <WarningsAsErrors Condition=" '$(WarningsAsErrors)' == '' ">NU1605</WarningsAsErrors>
+    <!-- Uncomment this once https://github.com/Microsoft/visualfsharp/issues/3207 gets fixed -->
+    <!-- <WarningsAsErrors Condition=" '$(WarningsAsErrors)' == '' ">NU1605</WarningsAsErrors> -->
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.props
@@ -102,6 +102,8 @@ Copyright (c) .NET Foundation. All rights reserved.
     <PackageRequireLicenseAcceptance Condition="'$(PackageRequireLicenseAcceptance)'==''">false</PackageRequireLicenseAcceptance>
     <DebugSymbols Condition="'$(DebugSymbols)'==''">false</DebugSymbols>
     <CheckForOverflowUnderflow Condition="'$(CheckForOverflowUnderflow)'==''">false</CheckForOverflowUnderflow>
+
+    <WarningsAsErrors>NU1605</WarningsAsErrors>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.props
@@ -103,7 +103,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <DebugSymbols Condition="'$(DebugSymbols)'==''">false</DebugSymbols>
     <CheckForOverflowUnderflow Condition="'$(CheckForOverflowUnderflow)'==''">false</CheckForOverflowUnderflow>
 
-    <WarningsAsErrors>NU1605</WarningsAsErrors>
+    <WarningsAsErrors Condition=" '$(WarningsAsErrors)' == '' ">NU1605</WarningsAsErrors>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/test/Microsoft.NET.Restore.Tests/GivenThatWeWantToRestoreProjectsUsingNuGetConfigProperties.cs
+++ b/test/Microsoft.NET.Restore.Tests/GivenThatWeWantToRestoreProjectsUsingNuGetConfigProperties.cs
@@ -14,7 +14,7 @@ using System.Threading;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace Microsoft.NET.Build.Tests
+namespace Microsoft.NET.Restore.Tests
 {
     public class GivenThatWeWantToRestoreProjectsUsingNuGetConfigProperties : SdkTest
     {

--- a/test/Microsoft.NET.Restore.Tests/GivenThatWeWantToRestoreProjectsWithPackageDowngrades.cs
+++ b/test/Microsoft.NET.Restore.Tests/GivenThatWeWantToRestoreProjectsWithPackageDowngrades.cs
@@ -1,0 +1,76 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using FluentAssertions;
+using Microsoft.NET.TestFramework;
+using Microsoft.NET.TestFramework.Assertions;
+using Microsoft.NET.TestFramework.Commands;
+using Microsoft.NET.TestFramework.ProjectConstruction;
+using NuGet.Common;
+using NuGet.Packaging;
+using NuGet.Packaging.Core;
+using System.IO;
+using System.Threading;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.NET.Restore.Tests
+{
+    public class GivenThatWeWantToRestoreProjectsWithPackageDowngrades : SdkTest
+    {
+        public GivenThatWeWantToRestoreProjectsWithPackageDowngrades(ITestOutputHelper log) : base(log)
+        {
+        }
+
+        // https://github.com/dotnet/sdk/issues/1327
+        [CoreMSBuildOnlyFact]
+        public void DowngradeWarningsAreErrorsByDefault()
+        {
+            const string testProjectName = "ProjectWithDowngradeWarning";
+            var testProject = new TestProject()
+            {
+                Name = testProjectName,
+                TargetFrameworks = "netstandard2.0",
+                IsSdkProject = true
+            };
+
+            testProject.PackageReferences.Add(new TestPackageReference("NuGet.Packaging", "3.5.0", null));
+            testProject.PackageReferences.Add(new TestPackageReference("NuGet.Commands", "4.0.0", null));
+
+            var testAsset = _testAssetsManager.CreateTestProject(testProject);
+
+            var packagesFolder = Path.Combine(RepoInfo.TestsFolder, "packages", testProjectName);
+
+            var restoreCommand = testAsset.GetRestoreCommand(Log, relativePath: testProjectName);
+            restoreCommand
+                .Execute($"/p:RestorePackagesPath={packagesFolder}")
+                .Should().Fail()
+                .And.HaveStdOutContaining("MSBUILD : error NU1605: Detected package downgrade");
+        }
+
+        [CoreMSBuildOnlyFact]
+        public void ItIsPossibleToTurnOffDowngradeWarningsAsErrors()
+        {
+            const string testProjectName = "ProjectWithDowngradeWarning";
+            var testProject = new TestProject()
+            {
+                Name = testProjectName,
+                TargetFrameworks = "netstandard2.0",
+                IsSdkProject = true
+            };
+
+            testProject.AdditionalProperties.Add("WarningsAsErrors", string.Empty);
+            testProject.PackageReferences.Add(new TestPackageReference("NuGet.Packaging", "3.5.0", null));
+            testProject.PackageReferences.Add(new TestPackageReference("NuGet.Commands", "4.0.0", null));
+
+            var testAsset = _testAssetsManager.CreateTestProject(testProject);
+
+            var packagesFolder = Path.Combine(RepoInfo.TestsFolder, "packages", testProjectName);
+
+            var restoreCommand = testAsset.GetRestoreCommand(Log, relativePath: testProjectName);
+            restoreCommand
+                .Execute($"/p:RestorePackagesPath={packagesFolder}")
+                .Should().Pass();;
+        }
+    }
+}

--- a/test/Microsoft.NET.Restore.Tests/GivenThatWeWantToRestoreProjectsWithPackageDowngrades.cs
+++ b/test/Microsoft.NET.Restore.Tests/GivenThatWeWantToRestoreProjectsWithPackageDowngrades.cs
@@ -45,7 +45,7 @@ namespace Microsoft.NET.Restore.Tests
             restoreCommand
                 .Execute($"/p:RestorePackagesPath={packagesFolder}")
                 .Should().Fail()
-                .And.HaveStdOutContaining("MSBUILD : error NU1605: Detected package downgrade");
+                .And.HaveStdOutContaining("NU1605");
         }
 
         [CoreMSBuildOnlyFact]


### PR DESCRIPTION
@dotnet/dotnet-cli @srivatsn 

@MattGertz for approval

**Customer scenario**

Making package downgrade warnings an error by default. This is being done in the SDK because we want this behavior for SDK based projects only.

**Bugs this fixes:** 

https://github.com/dotnet/sdk/issues/1310

**Workarounds, if any**

User can set this property themselves in their project file.

**Risk**

Low.

**Performance impact**

N/A

**Is this a regression from a previous update?**

N/A

**Root cause analysis:**

N/A

**How was the bug found?**

Planned feature.