### PR TITLE
Create dependencies for NETStandard.Library facades

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/PreprocessPackageDependenciesDesignTime.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/PreprocessPackageDependenciesDesignTime.cs
@@ -215,7 +215,7 @@ namespace Microsoft.NET.Build.Tasks
                 }
 
                 // This is meant only as a workaround for an issue in NETStandard.Library 2.0.*.
-                if (packageName != "NETStandard.Library")
+                if (!packageName.Equals("NETStandard.Library", StringComparison.OrdinalIgnoreCase))
                 {
                     continue;
                 }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/PreprocessPackageDependenciesDesignTime.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/PreprocessPackageDependenciesDesignTime.cs
@@ -198,8 +198,7 @@ namespace Microsoft.NET.Build.Tasks
         /// Explorer, rather than just under the "Assemblies" node.
         ///
         /// This is not meant to be a general mechanism for injecting files that can't be handled
-        /// through the normal NuGet package mechanisms. For that, package authors should be
-        /// creating FileDefinition and FileDependency items instead of Reference items.
+        /// through the normal NuGet package mechanisms.
         /// </summary>
         private void PopulatePreResolvedNetStandardAssemblies()
         {

--- a/src/Tasks/Microsoft.NET.Build.Tasks/PreprocessPackageDependenciesDesignTime.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/PreprocessPackageDependenciesDesignTime.cs
@@ -215,8 +215,6 @@ namespace Microsoft.NET.Build.Tasks
                 }
 
                 // This is meant only as a workaround for an issue in NETStandard.Library 2.0.*.
-                // Other packages should use the more general mechanism of creating
-                // FileDefinition and FileDependency items rather than Reference items.
                 if (packageName != "NETStandard.Library")
                 {
                     continue;

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.PackageDependencyResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.PackageDependencyResolution.targets
@@ -205,6 +205,7 @@ Copyright (c) .NET Foundation. All rights reserved.
           FileDefinitions="@(FileDefinitions)"
           PackageDependencies="@(PackageDependencies)"
           FileDependencies="@(FileDependencies)"
+          References="@(Reference)"
           DefaultImplicitPackages="$(DefaultImplicitPackages)"
           InputDiagnosticMessages="@(DiagnosticMessages)">
 


### PR DESCRIPTION
The NETStandard.Library package (starting from version 2.0) adds
references to most assemblies via a .targets file rather than going
through the normal process to resolve assemblies from packages. This
causes the assemblies to show up under the Assemblies node in Solution
Explorer, rather than under the NETStandard.Library package where they
logically belong.

To surface these assemblies under the package we need to update the
existing `FileDefinition` items for the assemblies, and create new
`FileDependency` items linking them to the package.

Note that this change does nothing to hide the items under the
Assemblies node; that will need to occur as a separate change in the
project system. This is also a targeted at the NETStandard.Library, and is
not a general mechanism that other packages could use to do the same
thing. If that is desired, we will need to design and implement it
separately.

**Customer scenario**

Customer creates a project targeting .NET Standard 2.0 and then starts looking through the Dependencies node in Solution Explorer. The references brought in by the NETStandard.Library package appear under the "Assemblies" node rather than under the "SDK\NETStandard.Library" node as expected.

**Bugs this fixes:** 

Partial fix for https://github.com/dotnet/project-system/issues/2320.

**Workarounds, if any**

None

**Risk**

Low.

**Performance impact**

This will reduce UI delays and reduce the number of active threads.

**Is this a regression from a previous update?**

Yes, in the sense that it doesn't occur with lower versions of .NET Standard.

**Root cause analysis:**

We only want to bring in the references from NETStandard.Library 2.0.0 if the project is actually targeting .NET Standard v2.0; if we're targeting something compatible with .NET Standard v2.0 then that target is responsible for providing the proper assembly references. Hence the NETStandard.Library package uses a custom .targets file to supply the `Reference` items rather than letting them be resolved from the package contents as you would normally expect. This causes them to show up in the wrong place in Solution Explorer.

**How was the bug found?**

Ad hoc testing.
