### PR TITLE
Copy execute permissions for apphost for non-Windows

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/EmbedAppNameInHost.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/EmbedAppNameInHost.cs
@@ -59,7 +59,15 @@ namespace Microsoft.NET.Build.Tasks
             {
                 Directory.CreateDirectory(destinationDirectory);
             }
-            File.WriteAllBytes(ModifiedAppHostPath, array);
+
+            // Copy AppHostSourcePath to ModifiedAppHostPath so it inherits the same attributes\permissions.
+            File.Copy(AppHostSourcePath, ModifiedAppHostPath);
+
+            // Re-write ModifiedAppHostPath with the proper contents.
+            using (FileStream fs = new FileStream(ModifiedAppHostPath, FileMode.Truncate, FileAccess.ReadWrite, FileShare.Read))
+            {
+                fs.Write(array, 0, array.Length);
+            }
         }
 
         // See: https://en.wikipedia.org/wiki/Knuth%E2%80%93Morris%E2%80%93Pratt_algorithm

--- a/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAHelloWorldProject.cs
+++ b/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAHelloWorldProject.cs
@@ -160,7 +160,6 @@ public static class Program
             });
 
             Command.Create(selfContainedExecutableFullPath, new string[] { })
-                .EnsureExecutable()
                 .CaptureStdOut()
                 .Execute()
                 .Should()
@@ -364,8 +363,7 @@ public static class Program
                     .And
                     .OnlyHaveNativeAssembliesWhichAreInFolder(rid, publishDirectory.FullName, testProject.Name);
 
-                runCommand = Command.Create(selfContainedExecutableFullPath, new string[] { })
-                    .EnsureExecutable();
+                runCommand = Command.Create(selfContainedExecutableFullPath, new string[] { });
             }
             else
             {


### PR DESCRIPTION
@dotnet/dotnet-cli

@MattGertz for approval

**Customer scenario**
The executable generated from `dotnet publish -r{RID}` doesn't have the "x" (execute) permission for non-Windows and thus when attempting to execute, a `Permission denied` error is returned from the OS. This means the standalone + RID scenario is broken for non-Windows.

The fix is to do a File.Copy from the source apphost to the destination (modified apphost) so the execute permission will be copied with that. Then the file is updated to have the proper contents.

**Bugs this fixes:**
https://github.com/dotnet/sdk/issues/1331

**Workarounds, if any**
The developer would need to do a manual chmod, such as `chmod +x myConsoleApp`

**Risk**
Low.

**Performance impact**
Minor; extra copy of ~77K apphost file. Created issue https://github.com/dotnet/sdk/issues/1339 to address in future.

**Is this a regression from a previous update?**
No

**Root cause analysis:**
The underlying issue has been masked for a long time by a NuGet issue which didn't restore executable files with the "x" permission.

**How was the bug found?**
Going through a core developer scenario on non-Windows.