### PR TITLE
Fix regression vs. MSBuild.Sdk.Extras additional TFM support

### DIFF
--- a/TestAssets/TestProjects/UwpUsingSdkExtras/Class1.cs
+++ b/TestAssets/TestProjects/UwpUsingSdkExtras/Class1.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace UwpUsingSdkExtras
+{
+    public class Class1
+    {
+    }
+}

--- a/TestAssets/TestProjects/UwpUsingSdkExtras/UwpUsingSdkExtras.csproj
+++ b/TestAssets/TestProjects/UwpUsingSdkExtras/UwpUsingSdkExtras.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="MSBuild.Sdk.Extras" Version="1.0.2" PrivateAssets="All" />
+    <PackageReference Include="MSBuild.Sdk.Extras" Version="1.0.3" PrivateAssets="All" />
   </ItemGroup>
   
   <ItemGroup Condition=" '$(TargetFramework)' == 'uap10.0' ">

--- a/TestAssets/TestProjects/UwpUsingSdkExtras/UwpUsingSdkExtras.csproj
+++ b/TestAssets/TestProjects/UwpUsingSdkExtras/UwpUsingSdkExtras.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0;uap10.0</TargetFrameworks>
+  </PropertyGroup>
+  
+  <ItemGroup>
+    <PackageReference Include="MSBuild.Sdk.Extras" Version="1.0.2" PrivateAssets="All" />
+  </ItemGroup>
+  
+  <ItemGroup Condition=" '$(TargetFramework)' == 'uap10.0' ">
+    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform " Version="5.2.2" />
+  </ItemGroup>
+  
+  <Import Project="$(MSBuildSDKExtrasTargets)" Condition="Exists('$(MSBuildSDKExtrasTargets)')" />
+  
+  <!-- Force default language targets so that we can test on machines without UWP workload installed and on core msbuild -->
+  <PropertyGroup>
+    <LanguageTargets />
+    <_ExtrasMissingLangTargets>false</_ExtrasMissingLangTargets>
+    <DisableStandardFrameworkResolution>true</DisableStandardFrameworkResolution>
+  </PropertyGroup>
+  
+</Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.BeforeCommon.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.BeforeCommon.targets
@@ -141,7 +141,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   </PropertyGroup>
 
   <!-- Add conditional compilation symbols for the target framework (for example NET461, NETSTANDARD2_0, NETCOREAPP1_0) -->
-  <PropertyGroup Condition=" '$(DisableImplicitFrameworkDefines)' != 'true' and '$(TargetFrameworkIdentifier)' != '.NETPortable'">
+  <PropertyGroup Condition=" '$(DisableImplicitFrameworkDefines)' != 'true' and '$(TargetFrameworkIdentifier)' != '.NETPortable' and '$(TargetFrameworkIdentifier)' != ''">
     <_FrameworkIdentifierForImplicitDefine>$(TargetFrameworkIdentifier.Replace('.', '').ToUpperInvariant())</_FrameworkIdentifierForImplicitDefine>
     <_FrameworkIdentifierForImplicitDefine Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework'">NET</_FrameworkIdentifierForImplicitDefine>
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.TargetFrameworkInference.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.TargetFrameworkInference.targets
@@ -80,8 +80,17 @@ Copyright (c) .NET Foundation. All rights reserved.
   <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '' or '$(TargetFrameworkVersion)' == ''">
     <_UnsupportedTargetFrameworkError>true</_UnsupportedTargetFrameworkError>
   </PropertyGroup>
+
+  <!--
+    NOTE: We must not validate the TFM before restore target runs as it prevents adding additional TFM 
+          support from being provided by a nuget package such as MSBuild.Sdk.Extras.
+
+          We run before RunResolvePackageDependencies and GetReferenceAssemblyPaths so that design-time builds
+          which do not currently invoke _CheckForInvalidConfigurationAndPlatform, will not trigger spurious 
+          errors that are only consequences of the root cause identified here.
+  -->
   <Target Name="_CheckForUnsupportedTargetFramework"
-          BeforeTargets="_CheckForInvalidConfigurationAndPlatform;_GenerateRestoreProjectSpec;CollectPackageReferences"
+          BeforeTargets="_CheckForInvalidConfigurationAndPlatform;RunResolvePackageDependencies;GetReferenceAssemblyPaths"
           Condition="'$(_UnsupportedTargetFrameworkError)' == 'true'"
           >
     <NETSdkError Condition="!$(TargetFramework.Contains(';'))"
@@ -98,10 +107,14 @@ Copyright (c) .NET Foundation. All rights reserved.
     but we need this to be a valid version so that our error message does not get pre-empted by failure to interpret
     version comparison expressions, which is currently unrecoverable in VS.
 
-    This is also an extra safeguard to ensure we never end up with common targets default of .NetFramework,Version=v4.0
+    Also don't leave TargetFrameworkIdentifier unset as it will be defaulted to .NETFramework by common targets, which
+    can cause restore (which we cannot block, see above) to silently succeed for empty TargetFramework.
   -->
   <PropertyGroup Condition="'$(TargetFrameworkVersion)' == ''">
     <TargetFrameworkVersion >v0.0</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == ''">
+    <TargetFrameworkIdentifier>_</TargetFrameworkIdentifier>
   </PropertyGroup>
   
   <!--

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.PackageDependencyResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.PackageDependencyResolution.targets
@@ -164,7 +164,7 @@ Copyright (c) .NET Foundation. All rights reserved.
          compile errors. -->
     <CheckForTargetInAssetsFile
       AssetsFilePath="$(ProjectAssetsFile)"
-      TargetFrameworkMoniker="$(TargetFrameworkMoniker)"
+      TargetFrameworkMoniker="$(NuGetTargetMoniker)"
       RuntimeIdentifier="$(RuntimeIdentifier)" />
 
     <ResolvePackageDependencies


### PR DESCRIPTION
**Customer scenario**
Using MSBuild.Sdk.Extras community package to build libraries cross-targeting to UWP/Xamarin/PLIB. Popular libraries like Rx.NET cannot build with 2.0 Preview 2 SDK without this.

**Bugs this fixes:**
#1335 

**Workarounds, if any**
None

**Risk**
Low.

**Performance impact**
Low

**Is this a regression from a previous update?**
Yes

**Root cause analysis:**
Missing test coverage for scenario (added)

**How was the bug found?**
Customer reported

--

I have verified that I can build Rx.NET. 

There were in fact two issues:

1. Not respecting NuGetTargetMoniker over TargetFrameworkMoniker in assets file check
2. Running unsupported TFM check in front of restore, which prevents MSBuild.Sdk.Extras from being restored and handling TFMs that we do not

(2) means some compromise on recent work to clean up the error messages in the invalid target framework cases. Restore has a sub-optimal message that can mask our better error message in build when build is not run after failed restore, which is often the case. I've filed https://github.com/NuGet/Home/issues/5413 to get a better error message from restore. Our better error still shows up nicely in the IDE and I've taken care to make sure that we don't regress other design-time noise that (2) fixed while still getting out of restore's way. 

@onovotny @dotnet/dotnet-cli 

