### PR TITLE
Try and fix compilation warnings from satellite resources

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.targets
@@ -428,6 +428,10 @@ Copyright (c) .NET Foundation. All rights reserved.
          PublicSign="$(PublicSign)"
          DelaySign="$(DelaySign)"
          Deterministic="$(Deterministic)"
+         DisabledWarnings="$(DisabledWarnings)"
+         WarningLevel="$(WarningLevel)"
+         WarningsAsErrors="$(WarningsAsErrors)"
+         WarningsNotAsErrors="$(WarningsNotAsErrors)"
          TargetType="Library"
          ToolExe="$(CscToolExe)"
          ToolPath="$(CscToolPath)">


### PR DESCRIPTION
Attempt to fix compilation warnings emitted during compilation of satellite resource files due to warning settings not being forwarded to CSC.

I've worked on the basis that the comment in the issue description about the warnings not being forwarded to `csc.exe` in the MSBuild task is all that is required.

Is that assumption correct? Are any additional tests required to this beyond what is already in this repo's build process? If so, what's the best approach to go about adding a test to replicate the problem and show it is resolved?

Relates to #954.