### PR TITLE
Hide assemblies with Facade metadata in the dependencies tree and generalize reparenting.

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenThatWeWantToGetDependenciesViaDesignTimeBuild.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenThatWeWantToGetDependenciesViaDesignTimeBuild.cs
@@ -71,6 +71,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             task.FileDependencies = new ITaskItem[] { };
             task.References = new ITaskItem[] { };
             task.DefaultImplicitPackages = string.Empty;
+            task.TargetFrameworkMoniker = string.Empty;
 
             // Act
             var result = task.Execute();
@@ -148,6 +149,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             task.FileDependencies = new ITaskItem[] { };
             task.References = new ITaskItem[] { };
             task.DefaultImplicitPackages = string.Empty;
+            task.TargetFrameworkMoniker = string.Empty;
 
             // Act
             var result = task.Execute();
@@ -207,6 +209,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             task.FileDependencies = new ITaskItem[] { };
             task.References = new ITaskItem[] { };
             task.DefaultImplicitPackages = string.Empty;
+            task.TargetFrameworkMoniker = string.Empty;
 
             // Act
             var result = task.Execute();
@@ -420,6 +423,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             task.FileDependencies = new ITaskItem[] { };
             task.References = new ITaskItem[] { };
             task.DefaultImplicitPackages = string.Empty;
+            task.TargetFrameworkMoniker = string.Empty;
 
             // Act
             var result = task.Execute();
@@ -556,6 +560,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             task.FileDependencies = new ITaskItem[] { };
             task.References = new ITaskItem[] { };
             task.DefaultImplicitPackages = string.Empty;
+            task.TargetFrameworkMoniker = string.Empty;
 
             // Act
             var result = task.Execute();
@@ -767,6 +772,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             };
             task.References = new ITaskItem[] { };
             task.DefaultImplicitPackages = string.Empty;
+            task.TargetFrameworkMoniker = string.Empty;
 
             // Act
             var result = task.Execute();
@@ -944,6 +950,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             };
             task.References = new ITaskItem[] { };
             task.DefaultImplicitPackages = "Package3;Package4";
+            task.TargetFrameworkMoniker = string.Empty;
 
             // Act
             var result = task.Execute();
@@ -1073,6 +1080,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             task.FileDependencies = new ITaskItem[] { };
             task.References = new ITaskItem[] { };
             task.DefaultImplicitPackages = string.Empty;
+            task.TargetFrameworkMoniker = string.Empty;
 
             // Act
             var result = task.Execute();
@@ -1103,7 +1111,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
         }
 
         [Fact]
-        public void ItShouldCreateDependenciesForNetStandardLibraryReferences()
+        public void ItShouldCreateDependenciesForReferencesWithNuGetMetadata()
         {
             // Arrange
             // target definitions
@@ -1119,43 +1127,48 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 });
 
             // package definitions
-            var netStandardLibraryPackage = new MockTaskItem(
-                itemSpec: "NETStandard.Library/2.0.0",
+            var myPackage = new MockTaskItem(
+                itemSpec: "MyPackage/1.5.0",
                 metadata: new Dictionary<string, string>
                 {
-                    { MetadataKeys.Name, "NETStandard.Library" },
-                    { MetadataKeys.Version, "2.0.0" },
-                    { MetadataKeys.Path, "MyPackages\\NETStandard.Library\\2.0.0" },
+                    { MetadataKeys.Name, "MyPackage" },
+                    { MetadataKeys.Version, "1.5.0" },
+                    { MetadataKeys.Path, "Packages\\MyPackage\\1.5.0" },
                     { MetadataKeys.ResolvedPath, "" },
                     { MetadataKeys.Type, "Package" },
                     { PreprocessPackageDependenciesDesignTime.ResolvedMetadata, "True" }
                 });
 
             // package dependencies
-            var netStandardLibraryPackageDependency = new MockTaskItem(
-                itemSpec: "NETStandard.Library/2.0.0",
+            var myPackageDependency = new MockTaskItem(
+                itemSpec: "MyPackage/1.5.0",
                 metadata: new Dictionary<string, string>
                 {
                     { MetadataKeys.ParentTarget, ".NETStandard,Version=v2.0" }
                 });
 
             // references
-            var mockReference = new MockTaskItem(
-                itemSpec: "MyPackages\\NETStandard.Library\\2.0.0\\AnAssembly.dll",
+            var referenceWithMetadata = new MockTaskItem(
+                itemSpec: "Packages\\MyPackage\\1.5.0\\AnAssembly.dll",
                 metadata: new Dictionary<string, string>
                 {
-                    { "NuGetPackageId", "NETStandard.Library" },
-                    { "NuGetPackageVersion", "2.0.0" }
+                    { "NuGetPackageId", "MyPackage" },
+                    { "NuGetPackageVersion", "1.5.0" }
                 });
+
+            var referenceWithoutMetadata = new MockTaskItem(
+                itemSpec: "Packages\\MyPackage\\1.5.0\\AnotherAssembly.dll",
+                metadata: new Dictionary<string, string>());
 
             var task = new PreprocessPackageDependenciesDesignTime();
             task.TargetDefinitions = new[] { netStandard20Target };
-            task.PackageDefinitions = new ITaskItem[] { netStandardLibraryPackage };
+            task.PackageDefinitions = new ITaskItem[] { myPackage };
             task.FileDefinitions = new ITaskItem[] {  };
-            task.PackageDependencies = new ITaskItem[] { netStandardLibraryPackageDependency };
+            task.PackageDependencies = new ITaskItem[] { myPackageDependency };
             task.FileDependencies = new ITaskItem[] { };
-            task.References = new ITaskItem[] { mockReference };
+            task.References = new ITaskItem[] { referenceWithMetadata, referenceWithoutMetadata };
             task.DefaultImplicitPackages = string.Empty;
+            task.TargetFrameworkMoniker = ".NETStandard,Version=v2.0";
 
             // Act
             var result = task.Execute();
@@ -1164,11 +1177,11 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             result.Should().BeTrue();
             task.DependenciesDesignTime.Count().Should().Be(3);
 
-            var resultPackage1 = task.DependenciesDesignTime
-                .Where(x => x.ItemSpec.Equals(".NETStandard,Version=v2.0/NETStandard.Library/2.0.0")).ToArray();
-            resultPackage1.Length.Should().Be(1);
-            resultPackage1[0].GetMetadata(PreprocessPackageDependenciesDesignTime.DependenciesMetadata)
-                             .Should().Be("NETStandard.Library/2.0.0/AnAssembly.dll");
+            var resultPackage = task.DependenciesDesignTime
+                .Where(x => x.ItemSpec.Equals(".NETStandard,Version=v2.0/MyPackage/1.5.0")).ToArray();
+            resultPackage.Length.Should().Be(1);
+            resultPackage[0].GetMetadata(PreprocessPackageDependenciesDesignTime.DependenciesMetadata)
+                            .Should().Be("MyPackage/1.5.0/AnAssembly.dll");
         }
 
         private void VerifyTargetTaskItem(DependencyType type, ITaskItem input, ITaskItem output)

--- a/src/Tasks/Microsoft.NET.Build.Tasks/PreprocessPackageDependenciesDesignTime.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/PreprocessPackageDependenciesDesignTime.cs
@@ -636,7 +636,7 @@ namespace Microsoft.NET.Build.Tasks
             public PreResolvedNetStandardAssemblyDependency(string itemSpec, string parentPackage)
             {
                 ItemSpec = itemSpec;
-                _metadata[MetadataKeys.FileGroup] = "CompileTimeAssembly";
+                _metadata[MetadataKeys.FileGroup] = CompileTimeAssemblyMetadata;
                 _metadata[MetadataKeys.ParentTarget] = ".NETStandard,Version=v2.0";
                 _metadata[MetadataKeys.ParentPackage] = parentPackage;
             }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.PackageDependencyResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.PackageDependencyResolution.targets
@@ -208,7 +208,7 @@ Copyright (c) .NET Foundation. All rights reserved.
           References="@(Reference)"
           DefaultImplicitPackages="$(DefaultImplicitPackages)"
           InputDiagnosticMessages="@(DiagnosticMessages)"
-          TargetFrameworkMoniker="$(TargetFrameworkMoniker)">
+          TargetFrameworkMoniker="$(NuGetTargetMoniker)">
 
       <Output TaskParameter="DependenciesDesignTime" ItemName="_DependenciesDesignTime" />
     </PreprocessPackageDependenciesDesignTime>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.PackageDependencyResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.PackageDependencyResolution.targets
@@ -207,7 +207,8 @@ Copyright (c) .NET Foundation. All rights reserved.
           FileDependencies="@(FileDependencies)"
           References="@(Reference)"
           DefaultImplicitPackages="$(DefaultImplicitPackages)"
-          InputDiagnosticMessages="@(DiagnosticMessages)">
+          InputDiagnosticMessages="@(DiagnosticMessages)"
+          TargetFrameworkMoniker="$(TargetFrameworkMoniker)">
 
       <Output TaskParameter="DependenciesDesignTime" ItemName="_DependenciesDesignTime" />
     </PreprocessPackageDependenciesDesignTime>


### PR DESCRIPTION
Make it possible for packages other than NETStandard.Library to reparent `Reference` items under the package as though they were resolved from the assets/lock file.

Also hide reparented assemblies marked with the "Façade" metadata.

**Customer scenario**

A package author needs to include assembly references but can't depend on the normal package handling, and instead explicitly includes them as `Reference` items. Currently these `Reference` items show up under the Assemblies node, rather than under the appropriate package under the SDK or NuGet nodes.

**Bugs this fixes:** 

Related to https://github.com/dotnet/project-system/issues/2132 and https://github.com/dotnet/project-system/issues/2320.

**Workarounds, if any**

None.

**Risk**

Low.

**Performance impact**

Low, and limited to certain design-time builds. When computing the dependencies graph we now need to examine the set of `Reference` items, and create new `FileDependency` items for the ones that need to be reparented.

**Is this a regression from a previous update?**

No.

**Root cause analysis:**

N/A; this is a new issues to .NET Standard 2.0 support.

**How was the bug found?**

Ad hoc testing.
