### PR TITLE
Fix store tests

### DIFF
--- a/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAProjectWithDependencies.cs
+++ b/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAProjectWithDependencies.cs
@@ -1,19 +1,19 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.IO;
-using Microsoft.DotNet.Cli.Utils;
 using FluentAssertions;
+using Microsoft.DotNet.Cli.Utils;
 using Microsoft.NET.TestFramework;
 using Microsoft.NET.TestFramework.Assertions;
 using Microsoft.NET.TestFramework.Commands;
-using Xunit;
-using static Microsoft.NET.TestFramework.Commands.MSBuildTest;
-using System.Runtime.InteropServices;
+using Microsoft.NET.TestFramework.ProjectConstruction;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-using System.Collections.Generic;
-using Microsoft.NET.TestFramework.ProjectConstruction;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Xml.Linq;
+using Xunit;
 using Xunit.Abstractions;
 
 namespace Microsoft.NET.Publish.Tests
@@ -124,10 +124,18 @@ namespace Microsoft.NET.Publish.Tests
         public void It_publishes_projects_with_simple_dependencies_with_filter_profile()
         {
             string project = "SimpleDependencies";
+            string targetFramework = "netcoreapp2.0";
 
             TestAsset simpleDependenciesAsset = _testAssetsManager
                 .CopyTestAsset(project)
                 .WithSource()
+                .WithProjectChanges(projectFile =>
+                {
+                    var ns = projectFile.Root.Name.Namespace;
+
+                    var targetFrameworkElement = projectFile.Root.Elements(ns + "PropertyGroup").Elements(ns + "TargetFramework").Single();
+                    targetFrameworkElement.SetValue(targetFramework);
+                })
                 .Restore(Log);
 
             string filterProjDir = _testAssetsManager.GetAndValidateTestProjectDirectory("StoreManifests");
@@ -138,42 +146,53 @@ namespace Microsoft.NET.Publish.Tests
 
             PublishCommand publishCommand = new PublishCommand(Log, simpleDependenciesAsset.TestRoot);
             publishCommand
-                .Execute( $"/p:TargetManifestFiles={manifestFile1}%3b{manifestFile2}")
+                .Execute($"/p:TargetManifestFiles={manifestFile1}%3b{manifestFile2}")
                 .Should()
                 .Pass();
 
-            DirectoryInfo publishDirectory = publishCommand.GetOutputDirectory();
+            DirectoryInfo publishDirectory = publishCommand.GetOutputDirectory(targetFramework);
 
             publishDirectory.Should().OnlyHaveFiles(new[] {
                 $"{project}.dll",
                 $"{project}.pdb",
                 $"{project}.deps.json",
                 $"{project}.runtimeconfig.json",
-                "System.Collections.NonGeneric.dll"
             });
 
-           var runtimeConfig = ReadJson(System.IO.Path.Combine(publishDirectory.ToString(), $"{project}.runtimeconfig.json"));
-           runtimeConfig["runtimeOptions"]["tfm"].ToString().Should().Be("netcoreapp1.1");
+            var runtimeConfig = ReadJson(Path.Combine(publishDirectory.FullName, $"{project}.runtimeconfig.json"));
+            runtimeConfig["runtimeOptions"]["tfm"].ToString().Should().Be(targetFramework);
 
-            var depsJson = ReadJson(System.IO.Path.Combine(publishDirectory.ToString(), $"{project}.deps.json"));
+            var depsJson = ReadJson(Path.Combine(publishDirectory.FullName, $"{project}.deps.json"));
             depsJson["libraries"]["Newtonsoft.Json/9.0.1"]["runtimeStoreManifestName"].ToString().Should().Be($"{manifestFileName1};{manifestFileName2}");
 
-//TODO: Enable testing the run once dotnet host has the notion of looking up shared packages
+            // The end-to-end test of running the published app happens in the dotnet/cli repo.
+            // See https://github.com/dotnet/cli/blob/358568b07f16749108dd33e7fea2f2c84ccf4563/test/dotnet-store.Tests/GivenDotnetStoresAndPublishesProjects.cs
         }
 
         [Fact]
         public void It_publishes_projects_with_filter_and_rid()
         {
             string project = "SimpleDependencies";
+            string targetFramework = "netcoreapp2.0";
             var rid = Microsoft.DotNet.PlatformAbstractions.RuntimeEnvironment.GetRuntimeIdentifier();
             TestAsset simpleDependenciesAsset = _testAssetsManager
                 .CopyTestAsset(project)
                 .WithSource()
+                .WithProjectChanges(projectFile =>
+                {
+                    var ns = projectFile.Root.Name.Namespace;
+
+                    var targetFrameworkElement = projectFile.Root.Elements(ns + "PropertyGroup").Elements(ns + "TargetFramework").Single();
+                    targetFrameworkElement.SetValue(targetFramework);
+                })
                 .Restore(Log, "", $"/p:RuntimeIdentifier={rid}");
 
             string filterProjDir = _testAssetsManager.GetAndValidateTestProjectDirectory("StoreManifests");
             string manifestFile = Path.Combine(filterProjDir, "NewtonsoftFilterProfile.xml");
-            
+
+            // According to https://github.com/dotnet/sdk/issues/1362 publish should throw an error
+            // since this scenario is not supported. Running the published app doesn't work currently.
+            // This test should be updated when that bug is fixed.
 
             PublishCommand publishCommand = new PublishCommand(Log, simpleDependenciesAsset.TestRoot);
             publishCommand
@@ -181,7 +200,7 @@ namespace Microsoft.NET.Publish.Tests
                 .Should()
                 .Pass();
 
-            DirectoryInfo publishDirectory = publishCommand.GetOutputDirectory(runtimeIdentifier: rid);
+            DirectoryInfo publishDirectory = publishCommand.GetOutputDirectory(targetFramework, runtimeIdentifier: rid);
 
             publishDirectory.Should().HaveFiles(new[] {
                 $"{project}.dll",
@@ -194,10 +213,7 @@ namespace Microsoft.NET.Publish.Tests
 
             publishDirectory.Should().NotHaveFiles(new[] {
                 "Newtonsoft.Json.dll",
-                "System.Runtime.Serialization.Primitives.dll"
             });
-
-//TODO: Enable testing the run once dotnet host has the notion of looking up shared packages
         }
 
         [Theory]

--- a/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToStoreAProjectWithDependencies.cs
+++ b/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToStoreAProjectWithDependencies.cs
@@ -84,7 +84,7 @@ namespace Microsoft.NET.Publish.Tests
                };
 
            
-            storeDirectory.Should().HaveFiles(files_on_disk);
+            storeDirectory.Should().OnlyHaveFiles(files_on_disk);
         }
 
         [CoreMSBuildOnlyFact]
@@ -114,8 +114,7 @@ namespace Microsoft.NET.Publish.Tests
                };
 
            
-            storeDirectory.Should().HaveFiles(files_on_disk);
-
+            storeDirectory.Should().OnlyHaveFiles(files_on_disk);
         }
 
         [CoreMSBuildOnlyFact]
@@ -167,18 +166,21 @@ namespace Microsoft.NET.Publish.Tests
 
             List<string> files_on_disk = new List<string> {
                "artifact.xml",
-               @"newtonsoft.json/9.0.2-beta2/lib/netstandard1.1/Newtonsoft.Json.dll",
-               @"newtonsoft.json/9.0.1/lib/netstandard1.0/Newtonsoft.Json.dll",
-               @"fluentassertions.json/4.12.0/lib/netstandard1.3/FluentAssertions.Json.dll"
+               "newtonsoft.json/9.0.2-beta2/lib/netstandard1.1/Newtonsoft.Json.dll",
+               "newtonsoft.json/9.0.1/lib/netstandard1.0/Newtonsoft.Json.dll",
+               "fluentassertions/4.12.0/lib/netstandard1.3/FluentAssertions.Core.dll",
+               "fluentassertions/4.12.0/lib/netstandard1.3/FluentAssertions.dll",
+               "fluentassertions.json/4.12.0/lib/netstandard1.3/FluentAssertions.Json.dll",
                };
 
-            storeDirectory.Should().HaveFiles(files_on_disk);
+            storeDirectory.Should().OnlyHaveFiles(files_on_disk);
 
-            var knownpackage = new HashSet<PackageIdentity>();
-
-            knownpackage.Add(new PackageIdentity("Newtonsoft.Json", NuGetVersion.Parse("9.0.1")));
-            knownpackage.Add(new PackageIdentity("Newtonsoft.Json", NuGetVersion.Parse("9.0.2-beta2")));
-            knownpackage.Add(new PackageIdentity("FluentAssertions.Json", NuGetVersion.Parse("4.12.0")));
+            var knownpackage = new HashSet<PackageIdentity>
+            {
+                new PackageIdentity("Newtonsoft.Json", NuGetVersion.Parse("9.0.1")),
+                new PackageIdentity("Newtonsoft.Json", NuGetVersion.Parse("9.0.2-beta2")),
+                new PackageIdentity("FluentAssertions.Json", NuGetVersion.Parse("4.12.0"))
+            };
 
             var artifact = Path.Combine(OutputFolder, "artifact.xml");
             var packagescomposed = ParseStoreArtifacts(artifact);

--- a/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToStoreAProjectWithDependencies.cs
+++ b/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToStoreAProjectWithDependencies.cs
@@ -77,13 +77,18 @@ namespace Microsoft.NET.Publish.Tests
 
             List<string> files_on_disk = new List<string> {
                "artifact.xml",
-               @"newtonsoft.json/9.0.1/lib/netstandard1.0/Newtonsoft.Json.dll",
-               @"fluentassertions/4.12.0/lib/netstandard1.3/FluentAssertions.Core.dll",
-               @"fluentassertions/4.12.0/lib/netstandard1.3/FluentAssertions.dll",
-               @"fluentassertions.json/4.12.0/lib/netstandard1.3/FluentAssertions.Json.dll"
+               "newtonsoft.json/9.0.1/lib/netstandard1.0/Newtonsoft.Json.dll",
+               "fluentassertions/4.12.0/lib/netstandard1.3/FluentAssertions.Core.dll",
+               "fluentassertions/4.12.0/lib/netstandard1.3/FluentAssertions.dll",
+               "fluentassertions.json/4.12.0/lib/netstandard1.3/FluentAssertions.Json.dll"
                };
 
-           
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                // https://github.com/dotnet/core-setup/issues/2716 - an unintended native shim is getting published to the runtime store
+                files_on_disk.Add($"runtime.{_runtimeRid}.runtime.native.system.security.cryptography/1.0.1/runtimes/{_runtimeRid}/native/System.Security.Cryptography.Native{FileConstants.DynamicLibSuffix}");
+            }
+
             storeDirectory.Should().OnlyHaveFiles(files_on_disk);
         }
 
@@ -107,13 +112,18 @@ namespace Microsoft.NET.Publish.Tests
 
             List<string> files_on_disk = new List<string> {
                "artifact.xml",
-               @"newtonsoft.json/9.0.1/lib/netstandard1.0/Newtonsoft.Json.dll",
-               @"fluentassertions/4.12.0/lib/netstandard1.3/FluentAssertions.Core.dll",
-               @"fluentassertions/4.12.0/lib/netstandard1.3/FluentAssertions.dll",
-               @"fluentassertions.json/4.12.0/lib/netstandard1.3/FluentAssertions.Json.dll"
+               "newtonsoft.json/9.0.1/lib/netstandard1.0/Newtonsoft.Json.dll",
+               "fluentassertions/4.12.0/lib/netstandard1.3/FluentAssertions.Core.dll",
+               "fluentassertions/4.12.0/lib/netstandard1.3/FluentAssertions.dll",
+               "fluentassertions.json/4.12.0/lib/netstandard1.3/FluentAssertions.Json.dll"
                };
 
-           
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                // https://github.com/dotnet/core-setup/issues/2716 - an unintended native shim is getting published to the runtime store
+                files_on_disk.Add($"runtime.{_runtimeRid}.runtime.native.system.security.cryptography/1.0.1/runtimes/{_runtimeRid}/native/System.Security.Cryptography.Native{FileConstants.DynamicLibSuffix}");
+            }
+
             storeDirectory.Should().OnlyHaveFiles(files_on_disk);
         }
 
@@ -172,6 +182,12 @@ namespace Microsoft.NET.Publish.Tests
                "fluentassertions/4.12.0/lib/netstandard1.3/FluentAssertions.dll",
                "fluentassertions.json/4.12.0/lib/netstandard1.3/FluentAssertions.Json.dll",
                };
+
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                // https://github.com/dotnet/core-setup/issues/2716 - an unintended native shim is getting published to the runtime store
+                files_on_disk.Add($"runtime.{_runtimeRid}.runtime.native.system.security.cryptography/1.0.1/runtimes/{_runtimeRid}/native/System.Security.Cryptography.Native{FileConstants.DynamicLibSuffix}");
+            }
 
             storeDirectory.Should().OnlyHaveFiles(files_on_disk);
 


### PR DESCRIPTION
Use OnlyHaveFiles instead of HaveFiles for better test coverage.
Update publish --manifest tests to use netcoreapp2.0 and resolve remaining TODOs.

Fix #1036 

@livarcocc @nguerrera 

FYI @MattGertz - test only change