### PR TITLE
fix F# project loading

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.FSharp.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.FSharp.targets
@@ -45,11 +45,11 @@ Copyright (c) .NET Foundation. All rights reserved.
        Import design time targets for Roslyn Project System. These are only available if Visual Studio is installed.
        Import design time targets before the common crosstargeting targets, which import targets from Nuget.
        *************************************************************************************************************** -->
-  <PropertyGroup Condition=" '$(IsCrossTargetingBuild)' == 'true' " >
+  <PropertyGroup>
      <FSharpDesignTimeTargetsPath>$(MSBuildExtensionsPath)\Microsoft\VisualStudio\Managed\Microsoft.FSharp.DesignTime.targets</FSharpDesignTimeTargetsPath>
   </PropertyGroup>
   <Import Project="$(FSharpDesignTimeTargetsPath)" 
-          Condition=" '$(UseBundledFSharpTargets)' == 'true' and '$(IsCrossTargetingBuild)' == 'true' and '$(FSharpDesignTimeTargetsPath)' != '' and Exists('$(FSharpDesignTimeTargetsPath)') " />
+          Condition=" '$(UseBundledFSharpTargets)' == 'true' and '$(FSharpDesignTimeTargetsPath)' != '' and Exists('$(FSharpDesignTimeTargetsPath)') " />
   <Import Project="$(MSBuildToolsPath)\Microsoft.Common.CrossTargeting.targets"
           Condition=" '$(UseBundledFSharpTargets)' == 'true' and '$(IsCrossTargetingBuild)' == 'true' "/>
 


### PR DESCRIPTION
fix https://github.com/Microsoft/visualfsharp/issues/3263 (project loading)
fix https://github.com/Microsoft/visualfsharp/issues/3262 (debugging)


to test it locally, change `C:\Program Files\dotnet\sdk\2.0.0-preview2-006502\Sdks\Microsoft.NET.Sdk\build\Microsoft.NET.Sdk.FSharp.targets` to apply the PR changes

before:

![image](https://user-images.githubusercontent.com/147243/27599606-940986ec-5b69-11e7-9d57-37024c9921d6.png)

after:

![image](https://user-images.githubusercontent.com/147243/27598643-6b295a16-5b66-11e7-9a7a-dfc66780046e.png)
