### PR TITLE
Copy App-Host for a self-contained app with extension only on windows

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Publish.targets
@@ -579,7 +579,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       <ResolvedFileToPublish Remove ="%(ResolvedFileToRemove.Identity)"/>
 
       <ResolvedFileToPublish Include="%(NativeAppHostNETCore.Identity)">
-        <RelativePath>$(AssemblyName)%(Extension)</RelativePath>
+        <RelativePath>$(AssemblyName)$(_NativeExecutableExtension)</RelativePath>
       </ResolvedFileToPublish>
       
 


### PR DESCRIPTION
**Customer scenario**

Publishing self-contained apps that have a "." in their name ends up publishing an executable with the wrong name.

When copying the App-Host for a self-contained app, only use the extension when publishing for windows. Otherwise, for apps with a . in the name, the part that comes after the . ends up being used as an extension and the executable has a duplicated last piece of the name, like sample.console.console, instead of sample.console.


**Bugs this fixes:** 

Fixes https://github.com/dotnet/cli/issues/6397

**Workarounds, if any**

Change the name of your application or hack some msbuild to change the file name after it is copied. It is bad.

**Risk**

Low

**Performance impact**

None

**Is this a regression from a previous update?**

Yes.

**Root cause analysis:**

Lack of test coverage.

**How was the bug found?**

Reported by the community.

@livarcocc @dotnet/dotnet-cli for review

@MattGertz for approval