### PR TITLE
Dependency's framework assembly should not be hoist

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.PackageDependencyResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.PackageDependencyResolution.targets
@@ -405,6 +405,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
       <ResolvedFrameworkAssemblies Include="@(_FrameworkAssemblies->'%(FrameworkAssembly)')">
         <Private>false</Private>
+        <Pack>false</Pack>
         <NuGetIsFrameworkReference>true</NuGetIsFrameworkReference>
         <NuGetSourceType>Package</NuGetSourceType>
         <NuGetPackageId>%(PackageName)</NuGetPackageId>


### PR DESCRIPTION
**Customer scenario**

Customer use pack target to create NuGet packages, if there is a framework assembly dependency of a dependency, it will be hoisted to nuspec. However, it should not. 

**Bugs this fixes**

https://github.com/dotnet/sdk/issues/1179

**Workarounds, if any**

No

**Risk**

An bug could lead to an invalid nuspec

**Performance impact**

low

**Root cause analysis**

Missing an case on implicit framework references task

**How was the bug found?**

Issue filed from Github
