### PR TITLE
Add netstandard support facades when ns1.5+ libraries are referenced

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Extensions.Tasks.UnitTests/GivenAGetDependsOnNETStandardTask.cs
+++ b/src/Tasks/Microsoft.NET.Build.Extensions.Tasks.UnitTests/GivenAGetDependsOnNETStandardTask.cs
@@ -28,8 +28,8 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             };
             task.Execute().Should().BeTrue();
 
-            // this test happens to compile against System.Runtime, update if the test TFM changes to netstandard2.x
-            task.DependsOnNETStandard.Should().BeFalse();
+            // this test compiles against a sufficiently high System.Runtime
+            task.DependsOnNETStandard.Should().BeTrue();
         }
 
         [Fact]
@@ -51,8 +51,8 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             };
             task.Execute().Should().BeTrue();
 
-            // this test happens to compile against System.Runtime, update if the test TFM changes to netstandard2.x
-            task.DependsOnNETStandard.Should().BeFalse();
+            // this test compiles against a sufficiently high System.Runtime
+            task.DependsOnNETStandard.Should().BeTrue();
         }
 
 

--- a/src/Tasks/Microsoft.NET.Build.Extensions.Tasks/GetDependsOnNETStandard.cs
+++ b/src/Tasks/Microsoft.NET.Build.Extensions.Tasks/GetDependsOnNETStandard.cs
@@ -14,6 +14,14 @@ namespace Microsoft.NET.Build.Tasks
     public partial class GetDependsOnNETStandard : TaskBase
     {
         private const string NetStandardAssemblyName = "netstandard";
+
+        // System.Runtime from netstandard1.5
+        // We also treat this as depending on netstandard so that we can provide netstandard1.5 and netstandard1.6 compatible 
+        // facades since net461 was previously only compatible with netstandard1.4 and thus packages only provided netstandard1.4
+        // compatible facades.
+        private const string SystemRuntimeAssemblyName = "System.Runtime";
+        private static readonly Version SystemRuntimeMinVersion = new Version(4, 1, 0, 0);
+
         /// <summary>
         /// Set of reference items to analyze.
         /// </summary>

--- a/src/Tasks/Microsoft.NET.Build.Extensions.Tasks/GetDependsOnNETStandard.netstandard.cs
+++ b/src/Tasks/Microsoft.NET.Build.Extensions.Tasks/GetDependsOnNETStandard.netstandard.cs
@@ -29,6 +29,12 @@ namespace Microsoft.NET.Build.Tasks
                             {
                                 return true;
                             }
+                            
+                            if (reader.StringComparer.Equals(reference.Name, SystemRuntimeAssemblyName) &&
+                                reference.Version >= SystemRuntimeMinVersion)
+                            {
+                                return true;
+                            }
                         }
                     }
                 }

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildADesktopExeWtihNetStandardLib.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildADesktopExeWtihNetStandardLib.cs
@@ -294,7 +294,7 @@ namespace Microsoft.NET.Build.Tests
         [WindowsOnlyTheory]
         [InlineData(true)]
         [InlineData(false)]
-        public void It_does_not_include_netstandard_when_libary_targets_netstandard1(bool isSdk)
+        public void It_does_not_include_netstandard_when_libary_targets_netstandard14(bool isSdk)
         {
             var testAsset = _testAssetsManager
                 .CopyTestAsset(GetTemplateName(isSdk))
@@ -311,7 +311,7 @@ namespace Microsoft.NET.Build.Tests
                         var ns = project.Root.Name.Namespace;
                         var propertyGroup = project.Root.Elements(ns + "PropertyGroup").First();
                         var targetFrameworkProperty = propertyGroup.Element(ns + "TargetFramework");
-                        targetFrameworkProperty.Value = "netstandard1.6";
+                        targetFrameworkProperty.Value = "netstandard1.4";
                     }
                 });
 
@@ -328,6 +328,52 @@ namespace Microsoft.NET.Build.Tests
                 buildCommand.GetNonSDKOutputDirectory();
 
             outputDirectory.Should().NotHaveFile("netstandard.dll");
+        }
+
+
+        [WindowsOnlyTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void It_includes_netstandard_when_libary_targets_netstandard15(bool isSdk)
+        {
+            var testAsset = _testAssetsManager
+                .CopyTestAsset(GetTemplateName(isSdk))
+                .WithSource()
+                .WithProjectChanges((projectPath, project) =>
+                {
+                    if (IsAppProject(projectPath))
+                    {
+                        AddReferenceToLibrary(project, ReferenceScenario.ProjectReference);
+                    }
+
+                    if (IsLibraryProject(projectPath))
+                    {
+                        var ns = project.Root.Name.Namespace;
+                        var propertyGroup = project.Root.Elements(ns + "PropertyGroup").First();
+                        var targetFrameworkProperty = propertyGroup.Element(ns + "TargetFramework");
+                        targetFrameworkProperty.Value = "netstandard1.5";
+                    }
+                });
+
+            testAsset.Restore(Log, relativePath: AppName);
+
+            var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot, AppName));
+            buildCommand
+                .Execute()
+                .Should()
+                .Pass();
+
+            var outputDirectory = isSdk ?
+                buildCommand.GetOutputDirectory("net461") :
+                buildCommand.GetNonSDKOutputDirectory();
+
+            // NET461 didn't originally support netstandard2.0, (nor netstandard1.5 or netstandard1.6)
+            // Since support was added after we need to ensure we apply the shims for netstandard1.5 projects as well.
+
+            outputDirectory.Should().HaveFiles(new[] {
+                "netstandard.dll",
+                $"{AppName}.exe.config"
+            });
         }
 
     }


### PR DESCRIPTION
Previously we only added the netstandard2.0 facades when a netstandard2.0 library
was referenced.

This will also apply them if a netstandard1.5 or greater library is referenced.

This addresses the case where packages (like System.Runtime) are broken after NuGet
remapped net461 from netstandard1.4 to netstandard2.0.

Fixes #1386 

/cc @livarcocc @dsplaisted 