### PR TITLE
Version cap 11

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.Designer.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.Designer.cs
@@ -10,9 +10,8 @@
 
 namespace Microsoft.NET.Build.Tasks {
     using System;
-    using System.Reflection;
-
-        
+    
+    
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
     /// </summary>
@@ -20,7 +19,7 @@ namespace Microsoft.NET.Build.Tasks {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Strings {
@@ -40,7 +39,7 @@ namespace Microsoft.NET.Build.Tasks {
         internal static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
-                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Microsoft.NET.Build.Tasks.Resources.Strings", typeof(Strings).GetTypeInfo().Assembly);
+                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Microsoft.NET.Build.Tasks.Resources.Strings", typeof(Strings).Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;
@@ -197,7 +196,7 @@ namespace Microsoft.NET.Build.Tasks {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Duplicate {0} items were included. The .NET SDK includes {0} items from your project directory by default. You can either remove these items from your project file, or set the &apos;{1}&apos; property to &apos;{2}&apos; if you want to explicitly include them in your project file. The duplicate items were: {3}.
+        ///   Looks up a localized string similar to Duplicate &apos;{0}&apos; items were included. The .NET SDK includes &apos;{0}&apos; items from your project directory by default. You can either remove these items from your project file, or set the &apos;{1}&apos; property to &apos;{2}&apos; if you want to explicitly include them in your project file. For more information, see {4}. The duplicate items were: {3}.
         /// </summary>
         internal static string DuplicateItemsError {
             get {
@@ -251,7 +250,7 @@ namespace Microsoft.NET.Build.Tasks {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Project &apos;{0}&apos; has no target framework compatible with &apos;{1}&apos;..
+        ///   Looks up a localized string similar to Project &apos;{0}&apos; targets &apos;{2}&apos;. It cannot be referenced by a project that targets &apos;{1}&apos;..
         /// </summary>
         internal static string NoCompatibleTargetFramework {
             get {
@@ -355,15 +354,6 @@ namespace Microsoft.NET.Build.Tasks {
         internal static string ProjectAssetsConsumedWithoutMSBuildProjectPath {
             get {
                 return ResourceManager.GetString("ProjectAssetsConsumedWithoutMSBuildProjectPath", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to RuntimeIdentifier must be set for .NETFramework executables. Consider RuntimeIdentifier=win7-x86 or RuntimeIdentifier=win7-x64..
-        /// </summary>
-        internal static string RuntimeIdentifierMustBeSetForNETFramework {
-            get {
-                return ResourceManager.GetString("RuntimeIdentifierMustBeSetForNETFramework", resourceCulture);
             }
         }
         

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.Designer.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.Designer.cs
@@ -10,7 +10,7 @@
 
 namespace Microsoft.NET.Build.Tasks {
     using System;
-    
+    using System.Reflection;
     
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
@@ -39,7 +39,7 @@ namespace Microsoft.NET.Build.Tasks {
         internal static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
-                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Microsoft.NET.Build.Tasks.Resources.Strings", typeof(Strings).Assembly);
+                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Microsoft.NET.Build.Tasks.Resources.Strings",  typeof(Strings).GetTypeInfo().Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.Designer.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.Designer.cs
@@ -20,7 +20,7 @@ namespace Microsoft.NET.Build.Tasks {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Strings {
@@ -400,6 +400,15 @@ namespace Microsoft.NET.Build.Tasks {
         internal static string UnrecognizedPreprocessorToken {
             get {
                 return ResourceManager.GetString("UnrecognizedPreprocessorToken", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The current .NET SDK does not support targeting {0} {1}.  Either target {0} {2} or lower, or use a version of the .NET SDK that supports {0} {1}..
+        /// </summary>
+        internal static string UnsupportedTargetFrameworkVersion {
+            get {
+                return ResourceManager.GetString("UnsupportedTargetFrameworkVersion", resourceCulture);
             }
         }
     }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.resx
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Resources/Strings.resx
@@ -228,4 +228,7 @@
   <data name="PackageReferenceOverrideWarning" xml:space="preserve">
     <value>A PackageReference for '{0}' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see {1}</value>
   </data>
+  <data name="UnsupportedTargetFrameworkVersion" xml:space="preserve">
+    <value>The current .NET SDK does not support targeting {0} {1}.  Either target {0} {2} or lower, or use a version of the .NET SDK that supports {0} {1}.</value>
+  </data>
 </root>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.TargetFrameworkInference.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.TargetFrameworkInference.targets
@@ -101,29 +101,31 @@ Copyright (c) .NET Foundation. All rights reserved.
     Trigger an error if targeting a higher version of .NET Core or .NET Standard than is supported by the current SDK.
   -->
 
-  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(NETCoreAppMaximumVersion)' == ''">
-    <NETCoreAppMaximumVersion>$(BundledNETCoreAppTargetFrameworkVersion)</NETCoreAppMaximumVersion>
+  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(NETCoreAppMaximumVersionExclusive)' == ''">
+    <NETCoreAppMaximumVersionExclusive>1.2</NETCoreAppMaximumVersionExclusive>
+    <NETCoreAppMaximumVersionHumanReadable>1.1</NETCoreAppMaximumVersionHumanReadable>
   </PropertyGroup>
     
   <Target Name="_CheckForUnsupportedNETCoreVersion" BeforeTargets="_CheckForInvalidConfigurationAndPlatform;Restore;CollectPackageReferences"
-          Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
+          Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(NETCoreAppMaximumVersionExclusive)' != ''">
 
-    <NETSdkError Condition="'$(_TargetFrameworkVersionWithoutV)' > '$(NETCoreAppMaximumVersion)'"
+    <NETSdkError Condition="'$(_TargetFrameworkVersionWithoutV)' >= '$(NETCoreAppMaximumVersionExclusive)'"
                  ResourceName="UnsupportedTargetFrameworkVersion"
-                 FormatArguments=".NET Core;$(_TargetFrameworkVersionWithoutV);$(NETCoreAppMaximumVersion)"
+                 FormatArguments=".NET Core;$(_TargetFrameworkVersionWithoutV);$(NETCoreAppMaximumVersionHumanReadable)"
       />
   </Target>
 
-  <PropertyGroup  Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard' And '$(NETStandardMaximumVersion)' == ''">
-    <NETStandardMaximumVersion>$(BundledNETStandardTargetFrameworkVersion)</NETStandardMaximumVersion>
+  <PropertyGroup  Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard' And '$(NETStandardMaximumVersionExclusive)' == ''">
+    <NETStandardMaximumVersionExclusive>1.7</NETStandardMaximumVersionExclusive>
+    <NETStandardMaximumVersionHumanReadable>1.6</NETStandardMaximumVersionHumanReadable>
   </PropertyGroup>
 
   <Target Name="_CheckForUnsupportedNETStandardVersion" BeforeTargets="_CheckForInvalidConfigurationAndPlatform;Restore;CollectPackageReferences"
-          Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard'">
+          Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard' And '$(NETStandardMaximumVersionExclusive)' != ''">
 
-    <NETSdkError Condition="'$(_TargetFrameworkVersionWithoutV)' > '$(NETStandardMaximumVersion)'"
+    <NETSdkError Condition="'$(_TargetFrameworkVersionWithoutV)' >= '$(NETStandardMaximumVersionExclusive)'"
                  ResourceName="UnsupportedTargetFrameworkVersion"
-                 FormatArguments=".NET Standard;$(_TargetFrameworkVersionWithoutV);$(NETStandardMaximumVersion)"
+                 FormatArguments=".NET Standard;$(_TargetFrameworkVersionWithoutV);$(NETStandardMaximumVersionHumanReadable)"
       />    
   </Target>
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.TargetFrameworkInference.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.TargetFrameworkInference.targets
@@ -96,6 +96,36 @@ Copyright (c) .NET Foundation. All rights reserved.
   <PropertyGroup Condition="'$(TargetFrameworkVersion)' == ''">
     <TargetFrameworkVersion >v0.0</TargetFrameworkVersion>
   </PropertyGroup>
+  
+  <!--
+    Trigger an error if targeting a higher version of .NET Core or .NET Standard than is supported by the current SDK.
+  -->
+
+  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(NETCoreAppMaximumVersion)' == ''">
+    <NETCoreAppMaximumVersion>$(BundledNETCoreAppTargetFrameworkVersion)</NETCoreAppMaximumVersion>
+  </PropertyGroup>
+    
+  <Target Name="_CheckForUnsupportedNETCoreVersion" BeforeTargets="_CheckForInvalidConfigurationAndPlatform;Restore;CollectPackageReferences"
+          Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
+
+    <NETSdkError Condition="'$(_TargetFrameworkVersionWithoutV)' > '$(NETCoreAppMaximumVersion)'"
+                 ResourceName="UnsupportedTargetFrameworkVersion"
+                 FormatArguments=".NET Core;$(_TargetFrameworkVersionWithoutV);$(NETCoreAppMaximumVersion)"
+      />
+  </Target>
+
+  <PropertyGroup  Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard' And '$(NETStandardMaximumVersion)' == ''">
+    <NETStandardMaximumVersion>$(BundledNETStandardTargetFrameworkVersion)</NETStandardMaximumVersion>
+  </PropertyGroup>
+
+  <Target Name="_CheckForUnsupportedNETStandardVersion" BeforeTargets="_CheckForInvalidConfigurationAndPlatform;Restore;CollectPackageReferences"
+          Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard'">
+
+    <NETSdkError Condition="'$(_TargetFrameworkVersionWithoutV)' > '$(NETStandardMaximumVersion)'"
+                 ResourceName="UnsupportedTargetFrameworkVersion"
+                 FormatArguments=".NET Standard;$(_TargetFrameworkVersionWithoutV);$(NETStandardMaximumVersion)"
+      />    
+  </Target>
 
 
   <!-- Exclude files from OutputPath and IntermediateOutputPath from default item globs.  Use the value

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildALibrary.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildALibrary.cs
@@ -15,7 +15,6 @@ using System.Runtime.InteropServices;
 using System.Collections.Generic;
 using System;
 using System.Runtime.CompilerServices;
-using Xunit.Abstractions;
 using Microsoft.NET.TestFramework.ProjectConstruction;
 
 namespace Microsoft.NET.Build.Tests
@@ -559,9 +558,9 @@ namespace Microsoft.NET.Build.Tests
         }
 
         [Theory]
-        [InlineData("netcoreapp2.1")]
-        [InlineData("netstandard2.1")]
-        public void It_fails_to_build_if_targeting_a_higher_framework_than_is_supported(string targetFramework)
+        [InlineData("netcoreapp2.0", ".NET Core 1.1")]
+        [InlineData("netstandard2.0", ".NET Standard 1.6")]
+        public void It_fails_to_build_if_targeting_a_higher_framework_than_is_supported(string targetFramework, string errorMessageExpectVersion)
         {
             var testProject = new TestProject()
             {
@@ -572,21 +571,59 @@ namespace Microsoft.NET.Build.Tests
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject, testProject.Name, targetFramework);
 
-            var restoreCommand = testAsset.GetRestoreCommand(Log, relativePath: testProject.Name);
+            var restoreCommand = testAsset.GetRestoreCommand(relativePath: testProject.Name);
 
             restoreCommand
+                .CaptureStdOut()
                 .Execute()
                 .Should()
                 .Fail()
-                .And.HaveStdOutContaining("The current .NET SDK does not support targeting");
+                .And.HaveStdOutContaining("The current .NET SDK does not support targeting")
+                .And.HaveStdOutContaining($"Either target {errorMessageExpectVersion} or lower");
 
-            var buildCommand = new BuildCommand(Log, testAsset.TestRoot, testProject.Name);
+            var buildCommand = new BuildCommand(Stage0MSBuild, testAsset.TestRoot, testProject.Name);
 
             buildCommand
+                .CaptureStdOut()
                 .Execute()
                 .Should()
                 .Fail()
-                .And.HaveStdOutContaining("The current .NET SDK does not support targeting");
+                .And.HaveStdOutContaining("The current .NET SDK does not support targeting")
+                .And.HaveStdOutContaining($"Either target {errorMessageExpectVersion} or lower");
+        }
+
+        [Theory]
+        [InlineData("netcoreapp1.1")]
+        [InlineData("netcoreapp1.1.1")]
+        [InlineData("netstandard1.6")]
+        [InlineData("netstandard1.6.1")]
+        public void It_is_able_to_build_if_targeting_a_lower_framework_than_is_supported_including_11X_16X(
+            string targetFramework)
+        {
+            var testProject = new TestProject()
+            {
+                Name = "TargetFrameworkVersionCap",
+                TargetFrameworks = targetFramework,
+                IsSdkProject = true
+            };
+
+            var testAsset = _testAssetsManager.CreateTestProject(testProject, testProject.Name, targetFramework);
+
+            var restoreCommand = testAsset.GetRestoreCommand(relativePath: testProject.Name);
+
+            restoreCommand
+                .CaptureStdOut()
+                .Execute()
+                .Should()
+                .Pass();
+
+            var buildCommand = new BuildCommand(Stage0MSBuild, testAsset.TestRoot, testProject.Name);
+
+            buildCommand
+                .CaptureStdOut()
+                .Execute()
+                .Should()
+                .Pass();
         }
 
         [Fact]

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildALibrary.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildALibrary.cs
@@ -15,6 +15,8 @@ using System.Runtime.InteropServices;
 using System.Collections.Generic;
 using System;
 using System.Runtime.CompilerServices;
+using Xunit.Abstractions;
+using Microsoft.NET.TestFramework.ProjectConstruction;
 
 namespace Microsoft.NET.Build.Tests
 {
@@ -554,6 +556,37 @@ namespace Microsoft.NET.Build.Tests
                 .Fail()
                 .And.HaveStdOutContaining("TargetFramework=''") // new deliberate error
                 .And.NotHaveStdOutContaining(">="); // old error about comparing empty string to version
+        }
+
+        [Theory]
+        [InlineData("netcoreapp2.1")]
+        [InlineData("netstandard2.1")]
+        public void It_fails_to_build_if_targeting_a_higher_framework_than_is_supported(string targetFramework)
+        {
+            var testProject = new TestProject()
+            {
+                Name = "TargetFrameworkVersionCap",
+                TargetFrameworks = targetFramework,
+                IsSdkProject = true
+            };
+
+            var testAsset = _testAssetsManager.CreateTestProject(testProject, testProject.Name, targetFramework);
+
+            var restoreCommand = testAsset.GetRestoreCommand(Log, relativePath: testProject.Name);
+
+            restoreCommand
+                .Execute()
+                .Should()
+                .Fail()
+                .And.HaveStdOutContaining("The current .NET SDK does not support targeting");
+
+            var buildCommand = new BuildCommand(Log, testAsset.TestRoot, testProject.Name);
+
+            buildCommand
+                .Execute()
+                .Should()
+                .Fail()
+                .And.HaveStdOutContaining("The current .NET SDK does not support targeting");
         }
 
         [Fact]


### PR DESCRIPTION
cherry pick and adjust from release/2.0.0 commit

https://github.com/dotnet/sdk/issues/1325

**Customer scenario**

This change is in release/2.0.0 now porting it to 1.1

Opening a project that targets a higher version of .NET Core or .NET Standard than the current SDK supports. This PR will generate an error message like the following:

> The .NET 1.1 SDK does not support targeting .NET Core 2.0. Either target .NET Core 1.1 or lower, or use a version of the .NET SDK that supports .NET Core 2.0.

**Bugs this fixes**

https://github.com/dotnet/sdk/issues/1325

**Workarounds, if any**

n/a - without this change, projects targeting newer target frameworks would fail in much less helpful ways.

**Risk**

Low.

**Performance impact**

Low - a few additional checks during the build

**Root cause analysis**

n/a

**How was the bug found?**

n/a - this is a feature for 2.0 now porting to 1.1
