### PR TITLE
Prevent GenerateRuntimeConfigurationFiles from running on every build

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.targets
@@ -45,6 +45,11 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ComputeNETCoreBuildOutputFiles Condition=" '$(ComputeNETCoreBuildOutputFiles)' == '' and '$(TargetFrameworkIdentifier)' == '.NETCoreApp'">true</ComputeNETCoreBuildOutputFiles>
   </PropertyGroup>
 
+  <ItemGroup>
+    <GenerateRuntimeConfigurationFilesInputs Include="$(ProjectAssetsFile)" />
+    <GenerateRuntimeConfigurationFilesInputs Include="$(UserRuntimeConfig)" Condition=" Exists($(UserRuntimeConfig)) " />
+  </ItemGroup>
+
   <PropertyGroup>
     <ProjectDepsFileName Condition="'$(ProjectDepsFileName)' == ''">$(AssemblyName).deps.json</ProjectDepsFileName>
     <ProjectDepsFilePath Condition="'$(ProjectDepsFilePath)' == ''">$(TargetDir)$(ProjectDepsFileName)</ProjectDepsFilePath>
@@ -144,7 +149,7 @@ Copyright (c) .NET Foundation. All rights reserved.
           DependsOnTargets="_DefaultMicrosoftNETPlatformLibrary"
           BeforeTargets="CopyFilesToOutputDirectory"
           Condition=" '$(GenerateRuntimeConfigurationFiles)' == 'true'"
-          Inputs="$(ProjectAssetsFile);$(UserRuntimeConfig)"
+          Inputs="@(GenerateRuntimeConfigurationFilesInputs)"
           Outputs="$(ProjectRuntimeConfigFilePath);$(ProjectRuntimeConfigDevFilePath)">
 
     <GenerateRuntimeConfigurationFiles AssetsFilePath="$(ProjectAssetsFile)"

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantBuildsToBeIncremental.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantBuildsToBeIncremental.cs
@@ -1,0 +1,43 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using FluentAssertions;
+using Microsoft.NET.TestFramework;
+using Microsoft.NET.TestFramework.Assertions;
+using Microsoft.NET.TestFramework.Commands;
+using Microsoft.NET.TestFramework.ProjectConstruction;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.NET.Build.Tests
+{
+    public class GivenThatWeWantBuildsToBeIncremental : SdkTest
+    {
+        public GivenThatWeWantBuildsToBeIncremental(ITestOutputHelper log) : base(log)
+        {
+        }
+
+        [Fact]
+        public void GenerateBuildRuntimeConfigurationFiles_runs_incrementaly()
+        {
+            var testAsset = _testAssetsManager
+                .CopyTestAsset("HelloWorld")
+                .WithSource()
+                .Restore(Log);
+
+            var buildCommand = new BuildCommand(Log, testAsset.TestRoot);
+            var outputDirectory = buildCommand.GetOutputDirectory("netcoreapp1.1").FullName;
+            var runtimeConfigDevJsonPath = Path.Combine(outputDirectory, "HelloWorld.runtimeconfig.dev.json");
+
+            buildCommand.Execute().Should().Pass();
+            DateTime runtimeConfigDevJsonFirstModifiedTime = new FileInfo(runtimeConfigDevJsonPath).LastWriteTime;
+
+            buildCommand.Execute().Should().Pass();
+            DateTime runtimeConfigDevJsonSecondModifiedTime = new FileInfo(runtimeConfigDevJsonPath).LastWriteTime;
+
+            runtimeConfigDevJsonSecondModifiedTime.Should().Be(runtimeConfigDevJsonFirstModifiedTime);
+        }
+    }
+}


### PR DESCRIPTION
**Customer scenario**

Without this, we will have a target that will run all the time, even when it is not needed and a file that will keep getting re-generated. We were setting runtimeconfig.dev.json as an input to the target even when the file did not exist, causing the target to run every time and ignore incremental compilation. The fix is to only use runtimeconfig.dev.json as an input to GenerateRuntimeConfigurationFiles if it exists, thus preventing the task from running every time.

**Bugs this fixes:** 

Fixes https://github.com/dotnet/sdk/issues/496

**Workarounds, if any**

None.

**Risk**

Low.

**Performance impact**

No.

**Is this a regression from a previous update?**

No.

**Root cause analysis:**

We were setting runtimeconfig.dev.json as an input to the target even when the file did not exist, causing the target to run every time and ignore incremental compilation.

**How was the bug found?**

Code review.

@dotnet/dotnet-cli for review

@MattGertz for approval
