### PR TITLE
Expand .NET Standard facades during design-time builds when referencing a .NET Standard project that hasn't been built yet

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Extensions.Tasks/msbuildExtensions/Microsoft/Microsoft.NET.Build.Extensions/Microsoft.NET.Build.Extensions.NETFramework.targets
+++ b/src/Tasks/Microsoft.NET.Build.Extensions.Tasks/msbuildExtensions/Microsoft/Microsoft.NET.Build.Extensions/Microsoft.NET.Build.Extensions.NETFramework.targets
@@ -35,6 +35,16 @@ Copyright (c) .NET Foundation. All rights reserved.
     </PropertyGroup>
 
     <!-- determine if any references depend on NETStandard -->
+
+    <!-- Check metadata of _ResolvedProjectReferencePaths items.  This handles the case where we are doing a design-time build and a referenced project
+         hasn't been built yet, so there is no corresponding assembly on disk for the GetDependsOnNETStandard task to examine.
+         
+         More context: https://github.com/dotnet/sdk/issues/1403
+         -->
+    <PropertyGroup Condition="'$(DependsOnNETStandard)' == '' AND '$(NETStandardInbox)' != 'true'">
+      <DependsOnNETStandard Condition="('%(_ResolvedProjectReferencePaths.TargetFrameworkIdentifier)' == '.NETStandard') And ('%(_ResolvedProjectReferencePaths.TargetFrameworkVersion)' >= '1.5')">true</DependsOnNETStandard>
+    </PropertyGroup>
+    
     <GetDependsOnNETStandard Condition="'$(DependsOnNETStandard)' == '' AND '$(NETStandardInbox)' != 'true' AND '@(_CandidateNETStandardReferences)' != ''" 
                              References="@(_CandidateNETStandardReferences)">
       <Output TaskParameter="DependsOnNETStandard" PropertyName="DependsOnNETStandard" />

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.targets
@@ -483,20 +483,13 @@ Copyright (c) .NET Foundation. All rights reserved.
   See https://github.com/dotnet/sdk/issues/1403 for more context
   ============================================================
   -->
-  
-  <Target Name="InjectTargetPathMetadata"
-        BeforeTargets="GetTargetPath"
-        DependsOnTargets="GetTargetPathWithTargetPlatformMoniker">
 
-    <ItemGroup>
-      <TargetPathWithTargetPlatformMoniker>
-        <TargetFrameworkIdentifier>$(TargetFrameworkIdentifier)</TargetFrameworkIdentifier>
-        <TargetFrameworkVersion>$(_TargetFrameworkVersionWithoutV)</TargetFrameworkVersion>
-      </TargetPathWithTargetPlatformMoniker>
-    </ItemGroup>
-    
-  </Target>
-  
+  <ItemDefinitionGroup>
+    <TargetPathWithTargetPlatformMoniker>
+      <TargetFrameworkIdentifier>$(TargetFrameworkIdentifier)</TargetFrameworkIdentifier>
+      <TargetFrameworkVersion>$(_TargetFrameworkVersionWithoutV)</TargetFrameworkVersion>
+    </TargetPathWithTargetPlatformMoniker>
+  </ItemDefinitionGroup>
   
   <!--
   ============================================================

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.targets
@@ -488,12 +488,12 @@ Copyright (c) .NET Foundation. All rights reserved.
         BeforeTargets="GetTargetPath"
         DependsOnTargets="GetTargetPathWithTargetPlatformMoniker">
 
-    <PropertyGroup>
+    <ItemGroup>
       <TargetPathWithTargetPlatformMoniker>
         <TargetFrameworkIdentifier>$(TargetFrameworkIdentifier)</TargetFrameworkIdentifier>
         <TargetFrameworkVersion>$(_TargetFrameworkVersionWithoutV)</TargetFrameworkVersion>
       </TargetPathWithTargetPlatformMoniker>
-    </PropertyGroup>
+    </ItemGroup>
     
   </Target>
   

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.targets
@@ -472,6 +472,34 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <!--
   ============================================================
+                                      InjectTargetPathMetadata
+  
+  Update TargetPathWithTargetPlatformMoniker with target framework
+  identifier and version metadata.  This is so that the
+  ImplicitlyExpandNETStandardFacades target can determine if a
+  referenced project needs the .NET Standard facades even if
+  the project hasn't been compiled to disk yet.
+  
+  See https://github.com/dotnet/sdk/issues/1403 for more context
+  ============================================================
+  -->
+  
+  <Target Name="InjectTargetPathMetadata"
+        BeforeTargets="GetTargetPath"
+        DependsOnTargets="GetTargetPathWithTargetPlatformMoniker">
+
+    <PropertyGroup>
+      <TargetPathWithTargetPlatformMoniker>
+        <TargetFrameworkIdentifier>$(TargetFrameworkIdentifier)</TargetFrameworkIdentifier>
+        <TargetFrameworkVersion>$(_TargetFrameworkVersionWithoutV)</TargetFrameworkVersion>
+      </TargetPathWithTargetPlatformMoniker>
+    </PropertyGroup>
+    
+  </Target>
+  
+  
+  <!--
+  ============================================================
                                          Project Capabilities
   ============================================================
   -->

--- a/test/Microsoft.NET.TestFramework/FullMSBuildOnlyFactAttribute.cs
+++ b/test/Microsoft.NET.TestFramework/FullMSBuildOnlyFactAttribute.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+
+namespace Microsoft.NET.TestFramework
+{
+    public class FullMSBuildOnlyFactAttribute : FactAttribute
+    {
+        public FullMSBuildOnlyFactAttribute()
+        {
+            string msbuildPath = Environment.GetEnvironmentVariable("DOTNET_SDK_TEST_MSBUILD_PATH");
+            bool usingFullFrameworkMSBuild = !string.IsNullOrEmpty(msbuildPath);
+            if (!usingFullFrameworkMSBuild)
+            {
+                this.Skip = "This test requires Full MSBuild to run";
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #1403

I would like to fix #1393 together with this, which is a similar bug for .NET Standard 1.x projects.  However, I'm still assessing the risk of doing so by changing the TargetPlatformIdentifier from `Windows` to `Portable` for .NET Standard projects.