### PR TITLE
[Workaround] Fallback folder workaround for multi tfm

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.NuGetOfflineCache.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.NuGetOfflineCache.targets
@@ -1,0 +1,29 @@
+<!--
+***********************************************************************************************
+Microsoft.NET.NuGetOfflineCache.targets
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+          created a backup copy.  Incorrect changes to this file will make it
+          impossible to load or build your projects from the command-line or the IDE.
+
+Copyright (c) .NET Foundation. All rights reserved.
+***********************************************************************************************
+-->
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <PropertyGroup>
+    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <_NugetFallbackFolder>$(MSBuildThisFileDirectory)..\..\..\..\NuGetFallbackFolder</_NugetFallbackFolder>
+    <_IsNETCoreOrNETStandard1x Condition=" '$(_IsNETCoreOrNETStandard)' == 'true' and '$(_TargetFrameworkVersionWithoutV)' &lt; '2.0' ">true</_IsNETCoreOrNETStandard1x>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(DisableImplicitNuGetFallbackFolder)' != 'true' and Exists($(_NugetFallbackFolder)) ">
+    <RestoreAdditionalProjectSources Condition=" '$(_IsNETCoreOrNETStandard1x)' == 'true' ">$(RestoreAdditionalProjectSources);$(_NugetFallbackFolder)</RestoreAdditionalProjectSources>
+    <RestoreAdditionalProjectFallbackFoldersExcludes Condition=" '$(_IsNETCoreOrNETStandard1x)' == 'true' ">$(RestoreAdditionalProjectFallbackFoldersExcludes);$(_NugetFallbackFolder)</RestoreAdditionalProjectFallbackFoldersExcludes>
+
+    <RestoreAdditionalProjectFallbackFolders Condition=" '$(_IsNETCoreOrNETStandard1x)' != 'true' ">$(RestoreAdditionalProjectFallbackFolders);$(_NugetFallbackFolder)</RestoreAdditionalProjectFallbackFolders>
+  </PropertyGroup>
+</Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.NuGetOfflineCache.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.NuGetOfflineCache.targets
@@ -9,6 +9,9 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
 Copyright (c) .NET Foundation. All rights reserved.
 ***********************************************************************************************
 -->
+<!-- https://github.com/NuGet/Home/issues/5596 and https://github.com/dotnet/project-system/issues/2605 -->
+<!-- Remove the second _IsNETCore1x property below, uncomment the RestoreAdditionalProjectFallbackFoldersExcludes line
+     below and remove the NuGetOfflineCache import from Microsoft.NET.Sdk.targets in crossbuilding -->
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
@@ -17,13 +20,14 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <PropertyGroup>
     <_NugetFallbackFolder>$(MSBuildThisFileDirectory)..\..\..\..\NuGetFallbackFolder</_NugetFallbackFolder>
-    <_IsNETCoreOrNETStandard1x Condition=" '$(_IsNETCoreOrNETStandard)' == 'true' and '$(_TargetFrameworkVersionWithoutV)' &lt; '2.0' ">true</_IsNETCoreOrNETStandard1x>
+    <_IsNETCore1x Condition=" '$(TargetFrameworkIdentifier)' == '.NETCoreApp' and '$(_TargetFrameworkVersionWithoutV)' &lt; '2.0' ">true</_IsNETCore1x>
+    <_IsNETCore1x Condition=" '$(_IsNETCore1x)' != 'true' And $(TargetFrameworks.ToUpper().Contains('NETCOREAPP1')) ">true</_IsNETCore1x>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(DisableImplicitNuGetFallbackFolder)' != 'true' and Exists($(_NugetFallbackFolder)) ">
-    <RestoreAdditionalProjectSources Condition=" '$(_IsNETCoreOrNETStandard1x)' == 'true' ">$(RestoreAdditionalProjectSources);$(_NugetFallbackFolder)</RestoreAdditionalProjectSources>
-    <RestoreAdditionalProjectFallbackFoldersExcludes Condition=" '$(_IsNETCoreOrNETStandard1x)' == 'true' ">$(RestoreAdditionalProjectFallbackFoldersExcludes);$(_NugetFallbackFolder)</RestoreAdditionalProjectFallbackFoldersExcludes>
+    <RestoreAdditionalProjectSources Condition=" '$(_IsNETCore1x)' == 'true' ">$(RestoreAdditionalProjectSources);$(_NugetFallbackFolder)</RestoreAdditionalProjectSources>
+    <!-- RestoreAdditionalProjectFallbackFoldersExcludes Condition=" '$(_IsNETCore1x)' == 'true' ">$(RestoreAdditionalProjectFallbackFoldersExcludes);$(_NugetFallbackFolder)</RestoreAdditionalProjectFallbackFoldersExcludes -->
 
-    <RestoreAdditionalProjectFallbackFolders Condition=" '$(_IsNETCoreOrNETStandard1x)' != 'true' ">$(RestoreAdditionalProjectFallbackFolders);$(_NugetFallbackFolder)</RestoreAdditionalProjectFallbackFolders>
+    <RestoreAdditionalProjectFallbackFolders Condition=" '$(_IsNETCore1x)' != 'true' ">$(RestoreAdditionalProjectFallbackFolders);$(_NugetFallbackFolder)</RestoreAdditionalProjectFallbackFolders>
   </PropertyGroup>
 </Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.BeforeCommon.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.BeforeCommon.targets
@@ -14,7 +14,6 @@ Copyright (c) .NET Foundation. All rights reserved.
   <PropertyGroup>
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
     <_IsExecutable Condition="'$(OutputType)' == 'Exe' or '$(OutputType)'=='WinExe'">true</_IsExecutable>
-    <_NugetFallbackFolder>$(MSBuildThisFileDirectory)..\..\..\..\NuGetFallbackFolder</_NugetFallbackFolder>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(HasRuntimeOutput)' == ''">
@@ -88,11 +87,11 @@ Copyright (c) .NET Foundation. All rights reserved.
     <_TargetFrameworkVersionWithoutV Condition="$(TargetFrameworkVersion.StartsWith('v'))">$(TargetFrameworkVersion.Substring(1))</_TargetFrameworkVersionWithoutV>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(DisableImplicitNuGetFallbackFolder)' != 'true' and '$(_IsNETCoreOrNETStandard)' == 'true' and Exists($(_NugetFallbackFolder)) ">
-    <RestoreAdditionalProjectSources Condition=" '$(_TargetFrameworkVersionWithoutV)' &lt; '2.0' ">$(RestoreAdditionalProjectSources);$(_NugetFallbackFolder)</RestoreAdditionalProjectSources>
-
-    <RestoreAdditionalProjectFallbackFolders Condition=" '$(_TargetFrameworkVersionWithoutV)' >= '2.0' ">$(RestoreAdditionalProjectFallbackFolders);$(_NugetFallbackFolder)</RestoreAdditionalProjectFallbackFolders>
-  </PropertyGroup>
+  <!--
+    Sets RestoreAdditionalProjectSources or RestoreAdditionalProjectFallbackFolders to the SDK Offline Cache based
+    on the TargetFramework.
+  -->
+  <Import Project="$(MSBuildThisFileDirectory)Microsoft.NET.NuGetOfflineCache.targets" />
   
   <ItemGroup Condition=" '$(DisableImplicitFrameworkReferences)' != 'true' and '$(TargetFrameworkIdentifier)' == '.NETFramework'">
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/buildCrossTargeting/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/buildCrossTargeting/Microsoft.NET.Sdk.targets
@@ -16,6 +16,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   </PropertyGroup>
 
   <Import Project="..\build\Microsoft.NET.Sdk.Common.targets"/>
+  <Import Project="..\build\Microsoft.NET.NuGetOfflineCache.targets"/>
 
   <!--
   ============================================================

--- a/test/Microsoft.NET.Restore.Tests/GivenThatWeWantToRestoreProjectsUsingNuGetConfigProperties.cs
+++ b/test/Microsoft.NET.Restore.Tests/GivenThatWeWantToRestoreProjectsUsingNuGetConfigProperties.cs
@@ -29,13 +29,17 @@ namespace Microsoft.NET.Restore.Tests
         [InlineData("netcoreapp1.1", "1.1", true)]
         [InlineData("netstandard2.0", "2.0", false)]
         [InlineData("netcoreapp2.0", "2.0app", false)]
+        [InlineData("net461", "461app", false)]
+        // https://github.com/NuGet/Home/issues/5596 and https://github.com/dotnet/project-system/issues/2605
+        //[InlineData("netcoreapp2.0;net461", "multiTFM20app", false)]
+        //[InlineData("netcoreapp1.0;netcoreapp2.0", "multiTFM1020app", true)]
         public void I_can_restore_a_project_with_implicit_msbuild_nuget_config(
-            string framework,
+            string frameworks,
             string projectPrefix,
             bool fileExists)
         {
             string testProjectName = $"{projectPrefix}Fallback";
-            TestAsset testProjectTestAsset = CreateTestAsset(testProjectName, framework);
+            TestAsset testProjectTestAsset = CreateTestAsset(testProjectName, frameworks);
 
             var packagesFolder = Path.Combine(RepoInfo.TestsFolder, "packages", testProjectName);
 
@@ -56,16 +60,16 @@ namespace Microsoft.NET.Restore.Tests
         [InlineData("netcoreapp1.1", "1.1")]
         [InlineData("netstandard2.0", "2.0")]
         [InlineData("netcoreapp2.0", "2.0app")]
-        public void I_can_disable_implicit_msbuild_nuget_config(string framework, string projectPrefix)
+        public void I_can_disable_implicit_msbuild_nuget_config(string frameworks, string projectPrefix)
         {
             string testProjectName = $"{projectPrefix}DisabledFallback";
-            TestAsset testProjectTestAsset = CreateTestAsset(testProjectName, framework);
+            TestAsset testProjectTestAsset = CreateTestAsset(testProjectName, frameworks);
 
             var restoreCommand = testProjectTestAsset.GetRestoreCommand(Log, relativePath: testProjectName);
             restoreCommand.Execute($"/p:DisableImplicitNuGetFallbackFolder=true").Should().Fail();
         }
 
-        private TestAsset CreateTestAsset(string testProjectName, string framework)
+        private TestAsset CreateTestAsset(string testProjectName, string frameworks)
         {
             var packageInNuGetFallbackFolder = CreatePackageInNuGetFallbackFolder();
 
@@ -73,7 +77,7 @@ namespace Microsoft.NET.Restore.Tests
                 new TestProject
                 {
                     Name = testProjectName,
-                    TargetFrameworks = framework,
+                    TargetFrameworks = frameworks,
                     IsSdkProject = true
                 };
 

--- a/test/Microsoft.NET.Restore.Tests/GivenThatWeWantToRestoreProjectsUsingNuGetConfigProperties.cs
+++ b/test/Microsoft.NET.Restore.Tests/GivenThatWeWantToRestoreProjectsUsingNuGetConfigProperties.cs
@@ -24,15 +24,15 @@ namespace Microsoft.NET.Restore.Tests
 
         // https://github.com/dotnet/sdk/issues/1327
         [CoreMSBuildOnlyTheory]
-        [InlineData("netstandard1.3", "1.3", true)]
+        [InlineData("netstandard1.3", "1.3", false)]
         [InlineData("netcoreapp1.0", "1.0", true)]
         [InlineData("netcoreapp1.1", "1.1", true)]
         [InlineData("netstandard2.0", "2.0", false)]
         [InlineData("netcoreapp2.0", "2.0app", false)]
         [InlineData("net461", "461app", false)]
-        // https://github.com/NuGet/Home/issues/5596 and https://github.com/dotnet/project-system/issues/2605
-        //[InlineData("netcoreapp2.0;net461", "multiTFM20app", false)]
-        //[InlineData("netcoreapp1.0;netcoreapp2.0", "multiTFM1020app", true)]
+        [InlineData("netcoreapp2.0;net461", "multiTFM20app", false)]
+        [InlineData("netcoreapp1.0;netcoreapp2.0", "multiTFM1020app", true)]
+        [InlineData("netcoreapp1.0;net461", "multiTFM1046app", true)]
         public void I_can_restore_a_project_with_implicit_msbuild_nuget_config(
             string frameworks,
             string projectPrefix,


### PR DESCRIPTION
**Customer scenario**

Fallback folders were not being set for full framework projects nor multi-tfm projects. Adds fallback folder for full framework projects by removing the condition on the project being netstandard or netcore. Also, as a workaround for a fix we need from NuGet, use the TargetFrameworks to set the NuGet configuration, thus enabling fallback folders for multi-tfm projects.

**Bugs this fixes:** 

Fixes https://github.com/dotnet/sdk/issues/1389

**Workarounds, if any**

Don't use the offline cache. Instead, we will hit the web during restore for Multi-tfm projects.

**Risk**

Low

**Performance impact**

None.

**Is this a regression from a previous update?**

Yes.

**Root cause analysis:**

We were only setting the property for NuGet in the inner-loop.

**How was the bug found?**

Partner team.

@dotnet/dotnet-cli for review

@srivatsn for approval
