### PR TITLE
Fix #1435 - calculation of ResolvedPath for project references

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageDependencies.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageDependencies.cs
@@ -460,7 +460,7 @@ namespace Microsoft.NET.Build.Tasks
 
         private string GetAbsolutePathFromProjectRelativePath(string path)
         {
-            return Path.GetFullPath(Path.Combine(Path.GetDirectoryName(Path.GetFullPath(ProjectAssetsFile)), path));
+            return Path.GetFullPath(Path.Combine(Path.GetDirectoryName(ProjectPath)), path));
         }
     }
 }


### PR DESCRIPTION
See #1435 for error description and analysis of the problem.

Questions:
 - Is it actually the desired outcome that ResolvedPath points to the csproj file? Or should it point to the output directory of that project?
 - Is ProjectPath always passed in as full path? (otherwise it needs to be enclosed by a `Path.GetFullPath`)