### PR TITLE
Fix #1435 - calculation of ResolvedPath for project references

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAResolvePackageDependenciesTask.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAResolvePackageDependenciesTask.cs
@@ -16,6 +16,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
     public class GivenAResolvePackageDependenciesTask
     {
         private static readonly string _packageRoot = "\\root\\packages".Replace('\\', Path.DirectorySeparatorChar);
+        private static readonly string _projectPath = "\\root\\anypath\\solutiondirectory\\myprojectdir\\myproject.csproj".Replace('\\', Path.DirectorySeparatorChar);
 
         [Theory]
         [MemberData(nameof(ItemCounts))]
@@ -254,8 +255,8 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                     package.GetMetadata(MetadataKeys.Type).Should().Be("project");
                     package.GetMetadata(MetadataKeys.Path).Should().Be($"../ClassLibP/project.json");
 
-                    var resolvedPath = Path.GetDirectoryName(Path.GetFullPath(lockFile.Path));
-                    resolvedPath = Path.GetFullPath(Path.Combine(resolvedPath, "../ClassLibP/ClassLibP.csproj"));
+                    var projectDirectoryPath = Path.GetDirectoryName(Path.GetFullPath(_projectPath));
+                    var resolvedPath = Path.GetFullPath(Path.Combine(projectDirectoryPath, "../ClassLibP/ClassLibP.csproj"));
                     package.GetMetadata(MetadataKeys.ResolvedPath).Should().Be(resolvedPath);
                 }
                 else
@@ -796,7 +797,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             var task = new ResolvePackageDependencies(lockFile, resolver)
             {
                 ProjectAssetsFile = lockFile.Path,
-                ProjectPath = null,
+                ProjectPath = _projectPath,
                 ProjectLanguage = null
             };
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageDependencies.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageDependencies.cs
@@ -460,7 +460,7 @@ namespace Microsoft.NET.Build.Tasks
 
         private string GetAbsolutePathFromProjectRelativePath(string path)
         {
-            return Path.GetFullPath(Path.Combine(Path.GetDirectoryName(Path.GetFullPath(ProjectAssetsFile)), path));
+            return Path.GetFullPath(Path.Combine(Path.GetDirectoryName(ProjectPath), path));
         }
     }
 }


### PR DESCRIPTION
See #479 and #1435 for error description and analysis of the problem. In short:

The old implementation combined the relative `<ProjectReference Include="..." />` path with the directory of the `ProjectAssetFile`.
Corrected this to combine the relative project reference with the current's project path.

Questions:
 - Is it actually the desired outcome that ResolvedPath points to the csproj file? Or should it point to the output directory of that project?
 - Is ProjectPath always passed in as full path? (otherwise it needs to be enclosed by a `Path.GetFullPath`)