### PR TITLE
Avoid boxing List<T> enumerable

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/PreprocessPackageDependenciesDesignTime.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/PreprocessPackageDependenciesDesignTime.cs
@@ -284,7 +284,7 @@ namespace Microsoft.NET.Build.Tasks
             /// A list of name/version strings to specify dependency identities.
             /// Note: identity here is just a "name/version" and does not have TFM part in front.
             /// </summary>
-            public IList<string> Dependencies { get; }
+            public List<string> Dependencies { get; }
 
             /// <summary>
             /// Returns name/value pairs for metadata specific to given item type's implementation.


### PR DESCRIPTION
This was allocating 0.2% of all memory during some design-time builds.

![image](https://user-images.githubusercontent.com/1103906/28867242-b851146e-77b8-11e7-862d-ea48df063ecb.png)
