### PR TITLE
Bump default versions for self-contained apps

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -94,6 +94,9 @@ $env:PATH = "$env:DOTNET_INSTALL_DIR;$env:PATH"
 # Disable first run since we want to control all package sources
 $env:DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
 
+# Don't resolve runtime, shared framework, or SDK from other locations
+$env:DOTNET_MULTILEVEL_LOOKUP=0
+
 $logPath = "$RepoRoot\bin\log"
 if (!(Test-Path -Path $logPath)) {
     New-Item -Path $logPath -Force -ItemType 'Directory' | Out-Null

--- a/build.sh
+++ b/build.sh
@@ -92,4 +92,7 @@ export PATH="$DOTNET_INSTALL_DIR:$PATH"
 # Disable first run since we want to control all package sources
 export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
 
+# Don't resolve runtime, shared framework, or SDK from global locations
+export DOTNET_MULTILEVEL_LOOKUP=0
+
 dotnet msbuild $REPOROOT/build/build.proj /m:1 /nologo /p:Configuration=$CONFIGURATION /p:Platform="$PLATFORM" "${args[@]}" /warnaserror

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.DefaultItems.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.DefaultItems.targets
@@ -76,29 +76,25 @@ Copyright (c) .NET Foundation. All rights reserved.
     
     If RuntimeFrameworkVersion is not specified, the following logic applies:
     
-    - When targeting .NET Core 2.0 or higher, Framework-dependent apps use the target framework version with a ".0" patch version
-    - When targeting .NET Core 2.0 or higher, Self-contained apps use the latest patch version (from when the SDK shipped) for
-      the specified major.minor version of .NET Core
-    - When targeting .NET Core 1.x, the latest patch version (from when the SDK shipped) is used for both Framework-dependent and
-      Self-contained apps.  This is to preserve the same behavior between 1.x and 2.0 SDKs.  If we ship further patch versions
-      after 1.0.5 and 1.1.2, we may choose to apply the Framework-dependent / Self-contained split to 1.x for those versions.  
+    - Self-contained apps use the latest corrsesponding patch version (from when the SDK shipped)
+
+    - When targeting .NET Core 2.0 or higher:
+      - Framework-dependent apps use the target framework version with a ".0" patch version
+
+    - When targeting .NET Core 1.0 and 1.1
+      - Framework-dependent apps use 1.0.5 and 1.1.2, respectively.
+      - This is done for compatibility with previous releases that bumped the self-contained and framework-dependent versions together.
   -->
 
-  <!-- These properties are mainly here as a test hook, as at the time we're implementing the logic which will choose
-       different versions depending on whether an app is self-contained or not, there aren't any patch versions of
-       .NET Core 2.0.  So these properties allow us to apply the new behavior to .NET Core 1.x by overriding them.
-       
-       Once there is a patch version of .NET Core, we may want to remove these properties and just put the version
-       numbers directly inside the <Choose> element below. -->
+  <!-- These properties are here as a test hook so that we can test with the versions bumped before the actual framework
+       builds are available. -->
   <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(RuntimeFrameworkVersion)' == ''"> 
-    <ImplicitRuntimeFrameworkVersionForFrameworkDependentNetCoreApp1_0
-      Condition="'$(ImplicitRuntimeFrameworkVersionForFrameworkDependentNetCoreApp1_0)' == ''">1.0.5</ImplicitRuntimeFrameworkVersionForFrameworkDependentNetCoreApp1_0>
     <ImplicitRuntimeFrameworkVersionForSelfContainedNetCoreApp1_0
-      Condition="'$(ImplicitRuntimeFrameworkVersionForSelfContainedNetCoreApp1_0)' == ''">1.0.5</ImplicitRuntimeFrameworkVersionForSelfContainedNetCoreApp1_0>
-    <ImplicitRuntimeFrameworkVersionForFrameworkDependentNetCoreApp1_1
-      Condition="'$(ImplicitRuntimeFrameworkVersionForFrameworkDependentNetCoreApp1_1)' == ''">1.1.2</ImplicitRuntimeFrameworkVersionForFrameworkDependentNetCoreApp1_1>
+      Condition="'$(ImplicitRuntimeFrameworkVersionForSelfContainedNetCoreApp1_0)' == ''">1.0.6</ImplicitRuntimeFrameworkVersionForSelfContainedNetCoreApp1_0>
     <ImplicitRuntimeFrameworkVersionForSelfContainedNetCoreApp1_1
-      Condition="'$(ImplicitRuntimeFrameworkVersionForSelfContainedNetCoreApp1_1)' == ''">1.1.2</ImplicitRuntimeFrameworkVersionForSelfContainedNetCoreApp1_1>    
+      Condition="'$(ImplicitRuntimeFrameworkVersionForSelfContainedNetCoreApp1_1)' == ''">1.1.3</ImplicitRuntimeFrameworkVersionForSelfContainedNetCoreApp1_1>
+    <ImplicitRuntimeFrameworkVersionForSelfContainedNetCoreApp2_0
+      Condition="'$(ImplicitRuntimeFrameworkVersionForSelfContainedNetCoreApp2_0)' == ''">2.0.1</ImplicitRuntimeFrameworkVersionForSelfContainedNetCoreApp2_0>
   </PropertyGroup>
 
   <!-- Select implicit runtime framework versions -->
@@ -108,18 +104,24 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <When Condition="'$(_TargetFrameworkVersionWithoutV)' == '1.0'">
       <PropertyGroup>
-        <ImplicitRuntimeFrameworkVersionForFrameworkDependentApp>$(ImplicitRuntimeFrameworkVersionForFrameworkDependentNetCoreApp1_0)</ImplicitRuntimeFrameworkVersionForFrameworkDependentApp>
+        <ImplicitRuntimeFrameworkVersionForFrameworkDependentApp>1.0.5</ImplicitRuntimeFrameworkVersionForFrameworkDependentApp>
         <ImplicitRuntimeFrameworkVersionForSelfContainedApp>$(ImplicitRuntimeFrameworkVersionForSelfContainedNetCoreApp1_0)</ImplicitRuntimeFrameworkVersionForSelfContainedApp>
       </PropertyGroup>
     </When>
     <When Condition="'$(_TargetFrameworkVersionWithoutV)' == '1.1'">
       <PropertyGroup>
-        <ImplicitRuntimeFrameworkVersionForFrameworkDependentApp>$(ImplicitRuntimeFrameworkVersionForFrameworkDependentNetCoreApp1_1)</ImplicitRuntimeFrameworkVersionForFrameworkDependentApp>
+        <ImplicitRuntimeFrameworkVersionForFrameworkDependentApp>1.1.2</ImplicitRuntimeFrameworkVersionForFrameworkDependentApp>
         <ImplicitRuntimeFrameworkVersionForSelfContainedApp>$(ImplicitRuntimeFrameworkVersionForSelfContainedNetCoreApp1_1)</ImplicitRuntimeFrameworkVersionForSelfContainedApp>
       </PropertyGroup>
     </When>
+    <When Condition="'$(_TargetFrameworkVersionWithoutV)' == '2.0'">
+      <PropertyGroup>
+        <ImplicitRuntimeFrameworkVersionForFrameworkDependentApp>2.0</ImplicitRuntimeFrameworkVersionForFrameworkDependentApp>
+        <ImplicitRuntimeFrameworkVersionForSelfContainedApp>$(ImplicitRuntimeFrameworkVersionForSelfContainedNetCoreApp2_0)</ImplicitRuntimeFrameworkVersionForSelfContainedApp>
+      </PropertyGroup>
+    </When>
 
-    <!-- If targeting the same release that is bundled with the .NET Core SDK, use the bundled package version provided by Microsoft.NETCoreSdk.BundledVersions.props -->
+    <!-- If targeting the same pre-release that is bundled with the .NET Core SDK, use the bundled package version provided by Microsoft.NETCoreSdk.BundledVersions.props -->
     <When Condition="'$(_TargetFrameworkVersionWithoutV)' == '$(BundledNETCoreAppTargetFrameworkVersion)'">
       <PropertyGroup>
         <ImplicitRuntimeFrameworkVersionForFrameworkDependentApp>$(BundledNETCoreAppPackageVersion)</ImplicitRuntimeFrameworkVersionForFrameworkDependentApp>

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildANetCoreApp.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildANetCoreApp.cs
@@ -48,15 +48,20 @@ namespace Microsoft.NET.Build.Tests
 
         //  Test behavior when implicit version differs for framework-dependent and self-contained apps
         [Theory]
-        [InlineData(false, true, "1.1.1")]
-        [InlineData(true, true, "1.1.2")]
-        [InlineData(false, false, "1.1.1")]
-        public void It_targets_the_right_framework_depending_on_output_type(bool selfContained, bool isExe, string expectedFrameworkVersion)
+        [InlineData("netcoreapp1.0", false, true, "1.0.5")]
+        [InlineData("netcoreapp1.0", true, true, RepoInfo.ImplicitRuntimeFrameworkVersionForSelfContainedNetCoreApp1_0)]
+        [InlineData("netcoreapp1.0", false, false, "1.0.5")]
+        [InlineData("netcoreapp1.1", false, true, "1.1.2")]
+        [InlineData("netcoreapp1.1", true, true, RepoInfo.ImplicitRuntimeFrameworkVersionForSelfContainedNetCoreApp1_1)]
+        [InlineData("netcoreapp1.1", false, false, "1.1.2")]
+        [InlineData("netcoreapp2.0", false, true, "2.0.0")]
+        [InlineData("netcoreapp2.0", true, true, RepoInfo.ImplicitRuntimeFrameworkVersionForSelfContainedNetCoreApp2_0)]
+        [InlineData("netcoreapp2.0", false, false, "2.0.0")]
+        public void It_targets_the_right_framework_depending_on_output_type(string targetFramework, bool selfContained, bool isExe, string expectedFrameworkVersion)
         {
             string testIdentifier = "Framework_targeting_" + (isExe ? "App_" : "Lib_") + (selfContained ? "SelfContained" : "FrameworkDependent");
 
-            It_targets_the_right_framework(testIdentifier, "netcoreapp1.1", null, selfContained, isExe, expectedFrameworkVersion, expectedFrameworkVersion,
-                "/p:ImplicitRuntimeFrameworkVersionForFrameworkDependentNetCoreApp1_1=1.1.1");
+            It_targets_the_right_framework(testIdentifier, targetFramework, null, selfContained, isExe, expectedFrameworkVersion, expectedFrameworkVersion);
         }
 
         private void It_targets_the_right_framework(

--- a/test/Microsoft.NET.TestFramework/RepoInfo.cs
+++ b/test/Microsoft.NET.TestFramework/RepoInfo.cs
@@ -134,6 +134,15 @@ namespace Microsoft.NET.TestFramework
             return new DirectoryInfo(GetBaseDirectory()).Parent.Name;
         }
 
+        // For test purposes, override the implicit .NETCoreApp version for self-contained apps that to builds thare 
+        //  (1) different from the fixed framework-dependent defaults (1.0.5, 1.1.2, 2.0.0)
+        //  (2) currently available on nuget.org
+        //
+        // This allows bumping the versions before builds without causing tests to fail.
+        public const string ImplicitRuntimeFrameworkVersionForSelfContainedNetCoreApp1_0 = "1.0.4";
+        public const string ImplicitRuntimeFrameworkVersionForSelfContainedNetCoreApp1_1 = "1.1.1";
+        public const string ImplicitRuntimeFrameworkVersionForSelfContainedNetCoreApp2_0 = "2.0.0-preview2-25407-01";
+
         public static string GetBaseDirectory()
         {
 #if NET451
@@ -159,6 +168,11 @@ namespace Microsoft.NET.TestFramework
             command = command.EnvironmentVariable("CustomAfterMicrosoftCommonTargets", Path.Combine(RepoInfo.BuildExtensionsSdkPath, 
                 "msbuildExtensions-ver", "Microsoft.Common.targets", "ImportAfter", "Microsoft.NET.Build.Extensions.targets"));
             command = command.EnvironmentVariable("MicrosoftNETBuildExtensionsTargets", Path.Combine(RepoInfo.BuildExtensionsMSBuildPath, "Microsoft.NET.Build.Extensions.targets"));
+
+            command = command
+                .EnvironmentVariable(nameof(ImplicitRuntimeFrameworkVersionForSelfContainedNetCoreApp1_0), ImplicitRuntimeFrameworkVersionForSelfContainedNetCoreApp1_0)
+                .EnvironmentVariable(nameof(ImplicitRuntimeFrameworkVersionForSelfContainedNetCoreApp1_1), ImplicitRuntimeFrameworkVersionForSelfContainedNetCoreApp1_1)
+                .EnvironmentVariable(nameof(ImplicitRuntimeFrameworkVersionForSelfContainedNetCoreApp2_0), ImplicitRuntimeFrameworkVersionForSelfContainedNetCoreApp2_0);
 
             return command;
         }


### PR DESCRIPTION
Also, prevent multilevel lookup from interfering with builds.