### PR TITLE
Bump default versions for self-contained apps (for 1.1.x)

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.DefaultItems.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.DefaultItems.targets
@@ -55,7 +55,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   </PropertyGroup>
   
   <!--  
-    Determine the NetCoreImplicitPackageVersion and RuntimeFrameworkVersion when targeting .NET Core
+    Determine the RuntimeFrameworkVersion when targeting .NET Core
     
     When targeting .NET Core, the TargetFramework is generally used to specify which version of the runtime to use.
     
@@ -64,30 +64,51 @@ Copyright (c) .NET Foundation. All rights reserved.
     
     The framework version that is written to the runtimeconfig.json file is based on the actual resolved package version
     of Microsoft.NETCore.App.  This is to allow floating the verion number.
-  
-  -->
+    
+    If RuntimeFrameworkVersion is not specified, the following logic applies
 
-  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
-    <!-- If targeting .NET Core, and the RuntimeFrameworkVersion is not specified, use the latest patch version of that runtime that we know about.
-    
-      This ensures that if a self-contained app is published where RuntimeFrameworkVersion is not specified, the latest patch
-      version of the runtime (that the SDK knew about when it shipped) will be used.
-      
-      This also will fix an issue where Microsoft.NETCore.App 1.1.0 included a version of the Microsoft.DiaSymReader.Native package
-      that was authored in such a way that Microsoft.DiaSymReader.Native.amd64.dll and Microsoft.DiaSymReader.Native.x86.dll would
-      be copied to the output folder.  Using Microsoft.NETCore.App 1.1.1 fixes this, as it references an updated version of the
-      DiaSymReader package with the issue fixed.  (See https://github.com/dotnet/corefx/issues/14627)
-      
-      Using the latest patch version that the SDK knows about does mean that an update to the SDK could change the version of
-      the runtime that a project targets.  In general, this should be OK.  If a project wants to opt out of this, it can specify
-      the exact version of the runtime to use with the RuntimeFrameworkVersion property.    
-    -->
-    <!-- If targeting netcoreapp1.1, and RuntimeFrameworkVersion is not specified, use version 1.1.1 -->
-    <RuntimeFrameworkVersion Condition="'$(RuntimeFrameworkVersion)' == '' And '$(_TargetFrameworkVersionWithoutV)' == '1.0'">1.0.5</RuntimeFrameworkVersion>
-    <RuntimeFrameworkVersion Condition="'$(RuntimeFrameworkVersion)' == '' And '$(_TargetFrameworkVersionWithoutV)' == '1.1'">1.1.2</RuntimeFrameworkVersion>
-    
-    <!-- Default to use the version of the framework runtime matching the target framework version-->
-    <RuntimeFrameworkVersion Condition="'$(RuntimeFrameworkVersion)' == ''">$(_TargetFrameworkVersionWithoutV)</RuntimeFrameworkVersion>
+    - Self-contained apps use the latest corresponding patch version (from when the SDK shipped)
+    - Framework-dependent app targeting netcoreapp1.0 and netcoreapp1.1 use v1.0.5 and v1.1.2, respectively
+        - This is done for compatibility with previous releases that bumped the self-contained and framework-dependent versions together.
+  -->
+  <!-- These properties are here as a test hook so that we can test with the versions bumped before the actual framework
+       builds are available. -->
+  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(RuntimeFrameworkVersion)' == ''"> 
+    <ImplicitRuntimeFrameworkVersionForSelfContainedNetCoreApp1_0
+      Condition="'$(ImplicitRuntimeFrameworkVersionForSelfContainedNetCoreApp1_0)' == ''">1.0.6</ImplicitRuntimeFrameworkVersionForSelfContainedNetCoreApp1_0>
+    <ImplicitRuntimeFrameworkVersionForSelfContainedNetCoreApp1_1
+      Condition="'$(ImplicitRuntimeFrameworkVersionForSelfContainedNetCoreApp1_1)' == ''">1.1.3</ImplicitRuntimeFrameworkVersionForSelfContainedNetCoreApp1_1>
+  </PropertyGroup>
+
+  <!-- Select implicit runtime framework versions -->
+  <Choose>
+    <!-- If not targeting .NET Core, or if RuntimeFrameworkVersion is already set, do nothing -->
+    <When Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp' Or '$(RuntimeFrameworkVersion)' != ''" />
+
+    <When Condition="'$(_TargetFrameworkVersionWithoutV)' == '1.0'">
+      <PropertyGroup>
+        <ImplicitRuntimeFrameworkVersionForFrameworkDependentApp>1.0.5</ImplicitRuntimeFrameworkVersionForFrameworkDependentApp>
+        <ImplicitRuntimeFrameworkVersionForSelfContainedApp>$(ImplicitRuntimeFrameworkVersionForSelfContainedNetCoreApp1_0)</ImplicitRuntimeFrameworkVersionForSelfContainedApp>
+      </PropertyGroup>
+    </When>
+    <When Condition="'$(_TargetFrameworkVersionWithoutV)' == '1.1'">
+      <PropertyGroup>
+        <ImplicitRuntimeFrameworkVersionForFrameworkDependentApp>1.1.2</ImplicitRuntimeFrameworkVersionForFrameworkDependentApp>
+        <ImplicitRuntimeFrameworkVersionForSelfContainedApp>$(ImplicitRuntimeFrameworkVersionForSelfContainedNetCoreApp1_1)</ImplicitRuntimeFrameworkVersionForSelfContainedApp>
+      </PropertyGroup>
+    </When>
+
+    <!-- If not covered by the previous cases, use the target framework version for the implicit RuntimeFrameworkVersions -->
+    <Otherwise>
+      <PropertyGroup>
+        <ImplicitRuntimeFrameworkVersionForFrameworkDependentApp>$(_TargetFrameworkVersionWithoutV)</ImplicitRuntimeFrameworkVersionForFrameworkDependentApp>
+        <ImplicitRuntimeFrameworkVersionForSelfContainedApp>$(_TargetFrameworkVersionWithoutV)</ImplicitRuntimeFrameworkVersionForSelfContainedApp>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
+  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(RuntimeFrameworkVersion)' == ''">
+    <RuntimeFrameworkVersion Condition="'$(RuntimeIdentifier)' != '' ">$(ImplicitRuntimeFrameworkVersionForSelfContainedApp)</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion Condition="'$(RuntimeIdentifier)' == '' ">$(ImplicitRuntimeFrameworkVersionForFrameworkDependentApp)</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <UsingTask TaskName="CheckForImplicitPackageReferenceOverrides" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />

--- a/test/Microsoft.NET.TestFramework/Commands/MSBuildTest.cs
+++ b/test/Microsoft.NET.TestFramework/Commands/MSBuildTest.cs
@@ -50,6 +50,10 @@ namespace Microsoft.NET.TestFramework.Commands
 
             command = command.EnvironmentVariable("MSBuildSDKsPath", RepoInfo.SdksPath);
 
+            command = command
+                .EnvironmentVariable(nameof(RepoInfo.ImplicitRuntimeFrameworkVersionForSelfContainedNetCoreApp1_0), RepoInfo.ImplicitRuntimeFrameworkVersionForSelfContainedNetCoreApp1_0)
+                .EnvironmentVariable(nameof(RepoInfo.ImplicitRuntimeFrameworkVersionForSelfContainedNetCoreApp1_1), RepoInfo.ImplicitRuntimeFrameworkVersionForSelfContainedNetCoreApp1_1);
+
             return command;
         }
     }

--- a/test/Microsoft.NET.TestFramework/Commands/TestCommand.cs
+++ b/test/Microsoft.NET.TestFramework/Commands/TestCommand.cs
@@ -46,6 +46,7 @@ namespace Microsoft.NET.TestFramework.Commands
 
         public virtual DirectoryInfo GetOutputDirectory(string targetFramework, string configuration = "Debug", string runtimeIdentifier = "")
         {
+            runtimeIdentifier = runtimeIdentifier ?? "";
             string output = Path.Combine(ProjectRootPath, "bin", configuration, targetFramework, runtimeIdentifier);
             return new DirectoryInfo(output);
         }

--- a/test/Microsoft.NET.TestFramework/ProjectConstruction/TestProject.cs
+++ b/test/Microsoft.NET.TestFramework/ProjectConstruction/TestProject.cs
@@ -18,6 +18,10 @@ namespace Microsoft.NET.TestFramework.ProjectConstruction
         //  Applies to SDK Projects
         public string TargetFrameworks { get; set; }
 
+        public string RuntimeFrameworkVersion { get; set; }
+
+        public string RuntimeIdentifier { get; set; }
+
         //  TargetFrameworkVersion applies to non-SDK projects
         public string TargetFrameworkVersion { get; set; }
 
@@ -129,9 +133,14 @@ namespace Microsoft.NET.TestFramework.ProjectConstruction
                     propertyGroup.Add(new XElement(ns + "TargetFramework", this.TargetFrameworks));
                 }
 
-                if (this.IsExe && targetFrameworks.Any(identifier => GetShortTargetFrameworkIdentifier(identifier).Equals("net", StringComparison.OrdinalIgnoreCase)))
+                if (!string.IsNullOrEmpty(this.RuntimeFrameworkVersion))
                 {
-                    propertyGroup.Add(new XElement(ns + "RuntimeIdentifier", "win7-x86"));
+                    propertyGroup.Add(new XElement(ns + "RuntimeFrameworkVersion", this.RuntimeFrameworkVersion));
+                }
+
+                if (!string.IsNullOrEmpty(this.RuntimeIdentifier))
+                {
+                    propertyGroup.Add(new XElement(ns + "RuntimeIdentifier", this.RuntimeIdentifier));
                 }
 
                 //  Update SDK reference to the version under test

--- a/test/Microsoft.NET.TestFramework/RepoInfo.cs
+++ b/test/Microsoft.NET.TestFramework/RepoInfo.cs
@@ -84,6 +84,14 @@ namespace Microsoft.NET.TestFramework
             return new DirectoryInfo(GetBaseDirectory()).Parent.Name;
         }
 
+        // For test purposes, override the implicit .NETCoreApp version for self-contained apps that to builds thare 
+        //  (1) different from the fixed framework-dependent defaults (1.0.5, 1.1.2, 2.0.0)
+        //  (2) currently available on nuget.org
+        //
+        // This allows bumping the versions before builds without causing tests to fail.
+        public const string ImplicitRuntimeFrameworkVersionForSelfContainedNetCoreApp1_0 = "1.0.4";
+        public const string ImplicitRuntimeFrameworkVersionForSelfContainedNetCoreApp1_1 = "1.1.1";
+
         private static string GetBaseDirectory()
         {
 #if NET451


### PR DESCRIPTION
Ported along with corresponding tests from https://github.com/dotnet/sdk/pull/1519 from 2.0.x to 1.1.x