### PR TITLE
Fix-#1521 Output the file path in warning message

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -9,7 +9,7 @@ if "%ERRORLEVEL%" == "0" (
 set DeveloperCommandPrompt=%VS150COMNTOOLS%\VsDevCmd.bat
 
 if not exist "%DeveloperCommandPrompt%" (
-  echo In order to build this repository, you either need 'msbuild' on the path or Visual Studio 2015 installed.
+  echo In order to build this repository, you either need 'msbuild' on the path or Visual Studio 2017 installed.
   echo.
   echo Visit this page to download:
   echo.

--- a/src/Tasks/Common/Resources/Strings.resx
+++ b/src/Tasks/Common/Resources/Strings.resx
@@ -310,7 +310,7 @@
     <value>'AdditionalProbingPaths' were specified for GenerateRuntimeConfigurationFiles, but are being skipped because 'RuntimeConfigDevPath' is empty.</value>
   </data>
   <data name="GetDependsOnNETStandardFailedWithException" xml:space="preserve">
-    <value>Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0} [{1}]</value>
+    <value>Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0} {1}</value>
   </data>
   <data name="UnsupportedSDKVersionForNetStandard20" xml:space="preserve">
     <value>The version of Microsoft.NET.Sdk used by this project is insufficient to support .NET Standard 2.0 which is required by this project's references.  Please install version 2.0 or higher of the .NET Core SDK.</value>

--- a/src/Tasks/Common/Resources/Strings.resx
+++ b/src/Tasks/Common/Resources/Strings.resx
@@ -310,7 +310,7 @@
     <value>'AdditionalProbingPaths' were specified for GenerateRuntimeConfigurationFiles, but are being skipped because 'RuntimeConfigDevPath' is empty.</value>
   </data>
   <data name="GetDependsOnNETStandardFailedWithException" xml:space="preserve">
-    <value>Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0}</value>
+    <value>Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0} [{1}]</value>
   </data>
   <data name="UnsupportedSDKVersionForNetStandard20" xml:space="preserve">
     <value>The version of Microsoft.NET.Sdk used by this project is insufficient to support .NET Standard 2.0 which is required by this project's references.  Please install version 2.0 or higher of the .NET Core SDK.</value>

--- a/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
@@ -313,8 +313,8 @@
         <note />
       </trans-unit>
       <trans-unit id="GetDependsOnNETStandardFailedWithException">
-        <source>Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0}</source>
-        <target state="translated">Přeložený soubor má nesprávnou image, nemá žádná metadata nebo je jiným způsobem nedostupný. {0}</target>
+        <source>Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0} [{1}]</source>
+        <target state="translated">Přeložený soubor má nesprávnou image, nemá žádná metadata nebo je jiným způsobem nedostupný. {0} [{1}]</target>
         <note />
       </trans-unit>
       <trans-unit id="UnsupportedSDKVersionForNetStandard20">

--- a/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
@@ -313,8 +313,8 @@
         <note />
       </trans-unit>
       <trans-unit id="GetDependsOnNETStandardFailedWithException">
-        <source>Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0} [{1}]</source>
-        <target state="translated">Přeložený soubor má nesprávnou image, nemá žádná metadata nebo je jiným způsobem nedostupný. {0} [{1}]</target>
+        <source>Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0} {1}</source>
+        <target state="needs-review-translation">Přeložený soubor má nesprávnou image, nemá žádná metadata nebo je jiným způsobem nedostupný. {0} {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="UnsupportedSDKVersionForNetStandard20">

--- a/src/Tasks/Common/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.de.xlf
@@ -318,8 +318,8 @@
         <note />
       </trans-unit>
       <trans-unit id="GetDependsOnNETStandardFailedWithException">
-        <source>Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0} [{1}]</source>
-        <target state="translated">Die aufgelöste Datei enthält ein fehlerhaftes Image oder keine Metadaten, oder der Zugriff ist aus anderen Gründen nicht möglich. {0} [{1}]</target>
+        <source>Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0} {1}</source>
+        <target state="needs-review-translation">Die aufgelöste Datei enthält ein fehlerhaftes Image oder keine Metadaten, oder der Zugriff ist aus anderen Gründen nicht möglich. {0} {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="UnsupportedSDKVersionForNetStandard20">

--- a/src/Tasks/Common/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.de.xlf
@@ -318,8 +318,8 @@
         <note />
       </trans-unit>
       <trans-unit id="GetDependsOnNETStandardFailedWithException">
-        <source>Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0}</source>
-        <target state="translated">Die aufgelöste Datei enthält ein fehlerhaftes Image oder keine Metadaten, oder der Zugriff ist aus anderen Gründen nicht möglich. {0}</target>
+        <source>Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0} [{1}]</source>
+        <target state="translated">Die aufgelöste Datei enthält ein fehlerhaftes Image oder keine Metadaten, oder der Zugriff ist aus anderen Gründen nicht möglich. {0} [{1}]</target>
         <note />
       </trans-unit>
       <trans-unit id="UnsupportedSDKVersionForNetStandard20">

--- a/src/Tasks/Common/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.es.xlf
@@ -318,8 +318,8 @@
         <note />
       </trans-unit>
       <trans-unit id="GetDependsOnNETStandardFailedWithException">
-        <source>Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0} [{1}]</source>
-        <target state="translated">El archivo resuelto tiene una imagen incorrecta, no tiene metadatos o no es posible su acceso. {0} [{1}]</target>
+        <source>Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0} {1}</source>
+        <target state="needs-review-translation">El archivo resuelto tiene una imagen incorrecta, no tiene metadatos o no es posible su acceso. {0} {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="UnsupportedSDKVersionForNetStandard20">

--- a/src/Tasks/Common/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.es.xlf
@@ -318,8 +318,8 @@
         <note />
       </trans-unit>
       <trans-unit id="GetDependsOnNETStandardFailedWithException">
-        <source>Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0}</source>
-        <target state="translated">El archivo resuelto tiene una imagen incorrecta, no tiene metadatos o no es posible su acceso. {0}</target>
+        <source>Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0} [{1}]</source>
+        <target state="translated">El archivo resuelto tiene una imagen incorrecta, no tiene metadatos o no es posible su acceso. {0} [{1}]</target>
         <note />
       </trans-unit>
       <trans-unit id="UnsupportedSDKVersionForNetStandard20">

--- a/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
@@ -318,8 +318,8 @@
         <note />
       </trans-unit>
       <trans-unit id="GetDependsOnNETStandardFailedWithException">
-        <source>Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0}</source>
-        <target state="translated">Le fichier résolu a une image incorrecte, ne comporte pas de métadonnées ou n'est pas accessible. {0}</target>
+        <source>Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0} [{1}]</source>
+        <target state="translated">Le fichier résolu a une image incorrecte, ne comporte pas de métadonnées ou n'est pas accessible. {0} [{1}]</target>
         <note />
       </trans-unit>
       <trans-unit id="UnsupportedSDKVersionForNetStandard20">

--- a/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
@@ -318,8 +318,8 @@
         <note />
       </trans-unit>
       <trans-unit id="GetDependsOnNETStandardFailedWithException">
-        <source>Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0} [{1}]</source>
-        <target state="translated">Le fichier résolu a une image incorrecte, ne comporte pas de métadonnées ou n'est pas accessible. {0} [{1}]</target>
+        <source>Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0} {1}</source>
+        <target state="needs-review-translation">Le fichier résolu a une image incorrecte, ne comporte pas de métadonnées ou n'est pas accessible. {0} {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="UnsupportedSDKVersionForNetStandard20">

--- a/src/Tasks/Common/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.it.xlf
@@ -318,8 +318,8 @@
         <note />
       </trans-unit>
       <trans-unit id="GetDependsOnNETStandardFailedWithException">
-        <source>Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0} [{1}]</source>
-        <target state="translated">Il file risolto contiene un'immagine danneggiata, non contiene metadati o è inaccessibile per altri motivi. {0} [{1}]</target>
+        <source>Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0} {1}</source>
+        <target state="needs-review-translation">Il file risolto contiene un'immagine danneggiata, non contiene metadati o è inaccessibile per altri motivi. {0} {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="UnsupportedSDKVersionForNetStandard20">

--- a/src/Tasks/Common/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.it.xlf
@@ -318,8 +318,8 @@
         <note />
       </trans-unit>
       <trans-unit id="GetDependsOnNETStandardFailedWithException">
-        <source>Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0}</source>
-        <target state="translated">Il file risolto contiene un'immagine danneggiata, non contiene metadati o è inaccessibile per altri motivi. {0}</target>
+        <source>Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0} [{1}]</source>
+        <target state="translated">Il file risolto contiene un'immagine danneggiata, non contiene metadati o è inaccessibile per altri motivi. {0} [{1}]</target>
         <note />
       </trans-unit>
       <trans-unit id="UnsupportedSDKVersionForNetStandard20">

--- a/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
@@ -318,8 +318,8 @@
         <note />
       </trans-unit>
       <trans-unit id="GetDependsOnNETStandardFailedWithException">
-        <source>Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0}</source>
-        <target state="translated">解決されたファイルには、無効なイメージが含まれているか、メタデータが存在しないか、またはアクセスできません。{0}</target>
+        <source>Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0} [{1}]</source>
+        <target state="translated">解決されたファイルには、無効なイメージが含まれているか、メタデータが存在しないか、またはアクセスできません。{0} [{1}]</target>
         <note />
       </trans-unit>
       <trans-unit id="UnsupportedSDKVersionForNetStandard20">

--- a/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
@@ -318,8 +318,8 @@
         <note />
       </trans-unit>
       <trans-unit id="GetDependsOnNETStandardFailedWithException">
-        <source>Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0} [{1}]</source>
-        <target state="translated">解決されたファイルには、無効なイメージが含まれているか、メタデータが存在しないか、またはアクセスできません。{0} [{1}]</target>
+        <source>Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0} {1}</source>
+        <target state="needs-review-translation">解決されたファイルには、無効なイメージが含まれているか、メタデータが存在しないか、またはアクセスできません。{0} {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="UnsupportedSDKVersionForNetStandard20">

--- a/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
@@ -318,8 +318,8 @@
         <note />
       </trans-unit>
       <trans-unit id="GetDependsOnNETStandardFailedWithException">
-        <source>Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0} [{1}]</source>
-        <target state="translated">확인된 파일의 이미지가 잘못되었거나, 메타데이터가 없거나, 파일 자체에 액세스할 수 없습니다. {0} [{1}]</target>
+        <source>Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0} {1}</source>
+        <target state="needs-review-translation">확인된 파일의 이미지가 잘못되었거나, 메타데이터가 없거나, 파일 자체에 액세스할 수 없습니다. {0} {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="UnsupportedSDKVersionForNetStandard20">

--- a/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
@@ -318,8 +318,8 @@
         <note />
       </trans-unit>
       <trans-unit id="GetDependsOnNETStandardFailedWithException">
-        <source>Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0}</source>
-        <target state="translated">확인된 파일의 이미지가 잘못되었거나, 메타데이터가 없거나, 파일 자체에 액세스할 수 없습니다. {0}</target>
+        <source>Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0} [{1}]</source>
+        <target state="translated">확인된 파일의 이미지가 잘못되었거나, 메타데이터가 없거나, 파일 자체에 액세스할 수 없습니다. {0} [{1}]</target>
         <note />
       </trans-unit>
       <trans-unit id="UnsupportedSDKVersionForNetStandard20">

--- a/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
@@ -318,8 +318,8 @@
         <note />
       </trans-unit>
       <trans-unit id="GetDependsOnNETStandardFailedWithException">
-        <source>Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0}</source>
-        <target state="translated">Rozpoznany plik ma zły obraz, nie ma metadanych lub jest w inny sposób niedostępny. {0}</target>
+        <source>Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0} [{1}]</source>
+        <target state="translated">Rozpoznany plik ma zły obraz, nie ma metadanych lub jest w inny sposób niedostępny. {0} [{1}]</target>
         <note />
       </trans-unit>
       <trans-unit id="UnsupportedSDKVersionForNetStandard20">

--- a/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
@@ -318,8 +318,8 @@
         <note />
       </trans-unit>
       <trans-unit id="GetDependsOnNETStandardFailedWithException">
-        <source>Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0} [{1}]</source>
-        <target state="translated">Rozpoznany plik ma zły obraz, nie ma metadanych lub jest w inny sposób niedostępny. {0} [{1}]</target>
+        <source>Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0} {1}</source>
+        <target state="needs-review-translation">Rozpoznany plik ma zły obraz, nie ma metadanych lub jest w inny sposób niedostępny. {0} {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="UnsupportedSDKVersionForNetStandard20">

--- a/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
@@ -318,8 +318,8 @@
         <note />
       </trans-unit>
       <trans-unit id="GetDependsOnNETStandardFailedWithException">
-        <source>Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0} [{1}]</source>
-        <target state="translated">O arquivo resolvido tem uma imagem inválida, não tem metadados ou está inacessível. {0} [{1}]</target>
+        <source>Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0} {1}</source>
+        <target state="needs-review-translation">O arquivo resolvido tem uma imagem inválida, não tem metadados ou está inacessível. {0} {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="UnsupportedSDKVersionForNetStandard20">

--- a/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
@@ -318,8 +318,8 @@
         <note />
       </trans-unit>
       <trans-unit id="GetDependsOnNETStandardFailedWithException">
-        <source>Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0}</source>
-        <target state="translated">O arquivo resolvido tem uma imagem inválida, não tem metadados ou está inacessível. {0}</target>
+        <source>Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0} [{1}]</source>
+        <target state="translated">O arquivo resolvido tem uma imagem inválida, não tem metadados ou está inacessível. {0} [{1}]</target>
         <note />
       </trans-unit>
       <trans-unit id="UnsupportedSDKVersionForNetStandard20">

--- a/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
@@ -318,8 +318,8 @@
         <note />
       </trans-unit>
       <trans-unit id="GetDependsOnNETStandardFailedWithException">
-        <source>Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0}</source>
-        <target state="translated">Найденный файл имеет неправильный образ, не имеет метаданных или недоступен по другим причинам. {0}</target>
+        <source>Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0} [{1}]</source>
+        <target state="translated">Найденный файл имеет неправильный образ, не имеет метаданных или недоступен по другим причинам. {0} [{1}]</target>
         <note />
       </trans-unit>
       <trans-unit id="UnsupportedSDKVersionForNetStandard20">

--- a/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
@@ -318,8 +318,8 @@
         <note />
       </trans-unit>
       <trans-unit id="GetDependsOnNETStandardFailedWithException">
-        <source>Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0} [{1}]</source>
-        <target state="translated">Найденный файл имеет неправильный образ, не имеет метаданных или недоступен по другим причинам. {0} [{1}]</target>
+        <source>Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0} {1}</source>
+        <target state="needs-review-translation">Найденный файл имеет неправильный образ, не имеет метаданных или недоступен по другим причинам. {0} {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="UnsupportedSDKVersionForNetStandard20">

--- a/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
@@ -318,8 +318,8 @@
         <note />
       </trans-unit>
       <trans-unit id="GetDependsOnNETStandardFailedWithException">
-        <source>Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0}</source>
-        <target state="translated">Çözümlenen dosyada hatalı görüntü var, meta veri yok veya dosya erişilemez durumda. {0}</target>
+        <source>Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0} [{1}]</source>
+        <target state="translated">Çözümlenen dosyada hatalı görüntü var, meta veri yok veya dosya erişilemez durumda. {0} [{1}]</target>
         <note />
       </trans-unit>
       <trans-unit id="UnsupportedSDKVersionForNetStandard20">

--- a/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
@@ -318,8 +318,8 @@
         <note />
       </trans-unit>
       <trans-unit id="GetDependsOnNETStandardFailedWithException">
-        <source>Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0} [{1}]</source>
-        <target state="translated">Çözümlenen dosyada hatalı görüntü var, meta veri yok veya dosya erişilemez durumda. {0} [{1}]</target>
+        <source>Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0} {1}</source>
+        <target state="needs-review-translation">Çözümlenen dosyada hatalı görüntü var, meta veri yok veya dosya erişilemez durumda. {0} {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="UnsupportedSDKVersionForNetStandard20">

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
@@ -318,8 +318,8 @@
         <note />
       </trans-unit>
       <trans-unit id="GetDependsOnNETStandardFailedWithException">
-        <source>Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0}</source>
-        <target state="translated">解析的文件包含错误图像、无元数据或不可访问。{0}</target>
+        <source>Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0} [{1}]</source>
+        <target state="translated">解析的文件包含错误图像、无元数据或不可访问。{0} [{1}]</target>
         <note />
       </trans-unit>
       <trans-unit id="UnsupportedSDKVersionForNetStandard20">

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
@@ -318,8 +318,8 @@
         <note />
       </trans-unit>
       <trans-unit id="GetDependsOnNETStandardFailedWithException">
-        <source>Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0} [{1}]</source>
-        <target state="translated">解析的文件包含错误图像、无元数据或不可访问。{0} [{1}]</target>
+        <source>Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0} {1}</source>
+        <target state="needs-review-translation">解析的文件包含错误图像、无元数据或不可访问。{0} {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="UnsupportedSDKVersionForNetStandard20">

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
@@ -318,8 +318,8 @@
         <note />
       </trans-unit>
       <trans-unit id="GetDependsOnNETStandardFailedWithException">
-        <source>Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0}</source>
-        <target state="translated">解析的檔案含有毀損的映像、沒有中繼資料，或是無法存取。{0}</target>
+        <source>Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0} [{1}]</source>
+        <target state="translated">解析的檔案含有毀損的映像、沒有中繼資料，或是無法存取。{0} [{1}]</target>
         <note />
       </trans-unit>
       <trans-unit id="UnsupportedSDKVersionForNetStandard20">

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
@@ -318,8 +318,8 @@
         <note />
       </trans-unit>
       <trans-unit id="GetDependsOnNETStandardFailedWithException">
-        <source>Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0} [{1}]</source>
-        <target state="translated">解析的檔案含有毀損的映像、沒有中繼資料，或是無法存取。{0} [{1}]</target>
+        <source>Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0} {1}</source>
+        <target state="needs-review-translation">解析的檔案含有毀損的映像、沒有中繼資料，或是無法存取。{0} {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="UnsupportedSDKVersionForNetStandard20">

--- a/src/Tasks/Microsoft.NET.Build.Extensions.Tasks/GetDependsOnNETStandard.cs
+++ b/src/Tasks/Microsoft.NET.Build.Extensions.Tasks/GetDependsOnNETStandard.cs
@@ -57,7 +57,7 @@ namespace Microsoft.NET.Build.Tasks
                     catch (Exception e) when (IsReferenceException(e))
                     {
                         // ResolveAssemblyReference treats all of these exceptions as warnings so we'll do the same
-                        Log.LogWarning(Strings.GetDependsOnNETStandardFailedWithException, e.Message);
+                        Log.LogWarning(Strings.GetDependsOnNETStandardFailedWithException, e.Message, referenceSourcePath);
                     }
                 }
             }


### PR DESCRIPTION
This PR only enriches the log message with the file path which caused the warning, but it doesn't provide the approach to allow the user to ignore these kind of warnings. Please refer to the issue #1521 