### PR TITLE
Disable multilevel lookup in build/test to prevent accidental machine dependencies

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -94,6 +94,9 @@ $env:PATH = "$env:DOTNET_INSTALL_DIR;$env:PATH"
 # Disable first run since we want to control all package sources
 $env:DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
 
+# Don't resolve runtime, shared framework, or SDK from other locations
+$env:DOTNET_MULTILEVEL_LOOKUP=0
+
 $logPath = "$RepoRoot\bin\log"
 if (!(Test-Path -Path $logPath)) {
     New-Item -Path $logPath -Force -ItemType 'Directory' | Out-Null

--- a/build.sh
+++ b/build.sh
@@ -92,4 +92,7 @@ export PATH="$DOTNET_INSTALL_DIR:$PATH"
 # Disable first run since we want to control all package sources
 export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
 
+# Don't resolve runtime, shared framework, or SDK from global locations
+export DOTNET_MULTILEVEL_LOOKUP=0
+
 dotnet msbuild $REPOROOT/build/build.proj /m:1 /nologo /p:Configuration=$CONFIGURATION /p:Platform="$PLATFORM" "${args[@]}" /warnaserror


### PR DESCRIPTION
Cherry-picked multi-level lookup fix from #1519 for master