### PR TITLE
Add Version metadata to SDK references

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenUnresolvedSDKProjectItemsAndImplicitPackages.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenUnresolvedSDKProjectItemsAndImplicitPackages.cs
@@ -58,7 +58,8 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 metadata: new Dictionary<string, string>
                 {
                     { MetadataKeys.SDKPackageItemSpec, "" },
-                    { MetadataKeys.Name, "DefaultImplicitPackage1" }
+                    { MetadataKeys.Name, "DefaultImplicitPackage1" },
+                    { MetadataKeys.Version, "1.2.3" }
                 });
 
             var task = new CollectSDKReferencesDesignTime();

--- a/src/Tasks/Microsoft.NET.Build.Tasks/CollectSDKReferencesDesignTime.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/CollectSDKReferencesDesignTime.cs
@@ -65,6 +65,7 @@ namespace Microsoft.NET.Build.Tasks
                     newTaskItem.SetMetadata(MetadataKeys.SDKPackageItemSpec, string.Empty);
                     newTaskItem.SetMetadata(MetadataKeys.Name, packageReference.ItemSpec);
                     newTaskItem.SetMetadata(MetadataKeys.IsImplicitlyDefined, "True");
+                    newTaskItem.SetMetadata(MetadataKeys.Version, packageReference.GetMetadata(MetadataKeys.Version));
 
                     implicitPackages.Add(newTaskItem);
                 }


### PR DESCRIPTION
Related to https://github.com/dotnet/project-system/issues/2248.

When generating MSBuild items representing SDK references make sure to pass along the Version metadata. This way we can display it in Solution Explorer and the Properties window.