### PR TITLE
Revert self-contained implicit versions to 1.0.5/1.1.2/2.0.0

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.DefaultItems.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.DefaultItems.targets
@@ -90,11 +90,11 @@ Copyright (c) .NET Foundation. All rights reserved.
        builds are available. -->
   <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(RuntimeFrameworkVersion)' == ''"> 
     <ImplicitRuntimeFrameworkVersionForSelfContainedNetCoreApp1_0
-      Condition="'$(ImplicitRuntimeFrameworkVersionForSelfContainedNetCoreApp1_0)' == ''">1.0.6</ImplicitRuntimeFrameworkVersionForSelfContainedNetCoreApp1_0>
+      Condition="'$(ImplicitRuntimeFrameworkVersionForSelfContainedNetCoreApp1_0)' == ''">1.0.5</ImplicitRuntimeFrameworkVersionForSelfContainedNetCoreApp1_0>
     <ImplicitRuntimeFrameworkVersionForSelfContainedNetCoreApp1_1
-      Condition="'$(ImplicitRuntimeFrameworkVersionForSelfContainedNetCoreApp1_1)' == ''">1.1.3</ImplicitRuntimeFrameworkVersionForSelfContainedNetCoreApp1_1>
+      Condition="'$(ImplicitRuntimeFrameworkVersionForSelfContainedNetCoreApp1_1)' == ''">1.1.2</ImplicitRuntimeFrameworkVersionForSelfContainedNetCoreApp1_1>
     <ImplicitRuntimeFrameworkVersionForSelfContainedNetCoreApp2_0
-      Condition="'$(ImplicitRuntimeFrameworkVersionForSelfContainedNetCoreApp2_0)' == ''">2.0.1</ImplicitRuntimeFrameworkVersionForSelfContainedNetCoreApp2_0>
+      Condition="'$(ImplicitRuntimeFrameworkVersionForSelfContainedNetCoreApp2_0)' == ''">2.0.0</ImplicitRuntimeFrameworkVersionForSelfContainedNetCoreApp2_0>
   </PropertyGroup>
 
   <!-- Select implicit runtime framework versions -->


### PR DESCRIPTION
NOTE: This just bumps the versions back down with reverting the whole commit because

1. We need a fix in that commit to actually use 2.0.0 instead of the bundled version for framework-dependent apps
2. There's test cleanup that allows these versions to be changed and test to pass that we should keep.