### PR TITLE
Ensure incremental build works on AssemblyAttribute items with multiple parameters

### DIFF
--- a/TestAssets/TestProjects/KitchenSink/TestLibrary/TestLibrary.csproj
+++ b/TestAssets/TestProjects/KitchenSink/TestLibrary/TestLibrary.csproj
@@ -5,6 +5,10 @@
     <ProjectGuid>{BB691360-49BC-46EB-8BA9-6A69A54CD4B0}</ProjectGuid>
   </PropertyGroup>
   <ItemGroup>
+    <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute" Condition="'$(BuildNumber)' != ''">
+      <_Parameter1>BuildNumber</_Parameter1>
+      <_Parameter2>$(BuildNumber)</_Parameter2>
+    </AssemblyAttribute>
     <Content Include="CopyToOutputFromProjectReference.txt" CopyToOutputDirectory="Always" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.GenerateAssemblyInfo.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.GenerateAssemblyInfo.targets
@@ -95,7 +95,8 @@ Copyright (c) .NET Foundation. All rights reserved.
       <GeneratedAssemblyInfoInputsCacheFile>$(IntermediateOutputPath)$(MSBuildProjectName).AssemblyInfoInputs.cache</GeneratedAssemblyInfoInputsCacheFile>
     </PropertyGroup>
 
-    <Hash ItemsToHash="@(AssemblyAttribute->'%(Identity)%(_Parameter1)')">
+    <!-- We only use up to _Parameter1 for most attributes, but other targets may add additional assembly attributes with multiple parameters. -->
+    <Hash ItemsToHash="@(AssemblyAttribute->'%(Identity)%(_Parameter1)%(_Parameter2)%(_Parameter3)%(_Parameter4)%(_Parameter5)%(_Parameter6)%(_Parameter7)%(_Parameter8)')">
       <Output TaskParameter="HashResult" PropertyName="_AssemblyAttributesHash" />
     </Hash>
 

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToControlGeneratedAssemblyInfo.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToControlGeneratedAssemblyInfo.cs
@@ -153,5 +153,45 @@ namespace Microsoft.NET.Build.Tests
                 return command;
             }
         }
+
+        [Fact]
+        public void It_respects_custom_assembly_atrribute_items_on_incremental_build()
+        {
+            var targetFramework = "netstandard1.5";
+            var testAsset = _testAssetsManager
+                .CopyTestAsset("KitchenSink", identifier: targetFramework)
+                .WithSource()
+                .Restore(Log, "TestLibrary");
+
+            var firstBuildCommand = BuildProject(buildNumber: "1");
+            var assemblyPath = Path.Combine(firstBuildCommand.GetOutputDirectory(targetFramework).FullName, "TestLibrary.dll");
+            AssemblyInfo.Get(assemblyPath)["AssemblyMetadataAttribute"].Should().Be("BuildNumber:1");
+
+            var firstWriteTime = File.GetLastWriteTimeUtc(assemblyPath);
+
+            // When rebuilding with the same value
+            BuildProject(buildNumber: "1");
+
+            // the build should no-op.
+            File.GetLastWriteTimeUtc(assemblyPath).Should().Be(firstWriteTime);
+
+            // When the same project is built again using a different build number
+            BuildProject(buildNumber: "2");
+
+            // the file should change
+            File.GetLastWriteTimeUtc(assemblyPath).Should().NotBe(firstWriteTime);
+
+            // and the custom assembly should be generated with the updated value.
+            AssemblyInfo.Get(assemblyPath)["AssemblyMetadataAttribute"].Should().Be("BuildNumber:2");
+
+            BuildCommand BuildProject(string buildNumber)
+            {
+                var command = new BuildCommand(Log, Path.Combine(testAsset.TestRoot, "TestLibrary"));
+                command.Execute($"/p:BuildNumber={buildNumber}")
+                       .Should()
+                       .Pass();
+                return command;
+            }
+        }
     }
 }


### PR DESCRIPTION
I want to use the `<AssemblyAttribute>` item to generate AssemblyMetadataAttribute with build numbers and commit hashes. This ensures that the generated attributes file will re-generate when attributes with multiple parameters are included.