### PR TITLE
Revert "Update support libraries to those that are only lib."

### DIFF
--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -13,7 +13,7 @@
     <NuGetVersion>4.4.0-preview3-4475</NuGetVersion>
     <NewtonsoftJsonVersion>9.0.1</NewtonsoftJsonVersion>
     <SystemReflectionMetadataVersion>1.4.2</SystemReflectionMetadataVersion>
-    <NETStandardLibraryNETFrameworkVersion>2.0.1-servicing-25708-01</NETStandardLibraryNETFrameworkVersion>
+    <NETStandardLibraryNETFrameworkVersion>2.0.0-preview2-25405-01</NETStandardLibraryNETFrameworkVersion>
     <XliffTasksVersion>0.2.0-beta-000042</XliffTasksVersion>
   </PropertyGroup>
 

--- a/src/Tasks/Microsoft.NET.Build.Extensions.Tasks/msbuildExtensions/Microsoft/Microsoft.NET.Build.Extensions/Microsoft.NET.Build.Extensions.NETFramework.targets
+++ b/src/Tasks/Microsoft.NET.Build.Extensions.Tasks/msbuildExtensions/Microsoft/Microsoft.NET.Build.Extensions/Microsoft.NET.Build.Extensions.NETFramework.targets
@@ -59,6 +59,15 @@ Copyright (c) .NET Foundation. All rights reserved.
     
     <!-- if any reference depends on netstandard and it is not inbox, add references and implementation assemblies for netstandard2.0  -->
     <ItemGroup Condition="'$(DependsOnNETStandard)' == 'true' AND '$(NETStandardInbox)' != 'true'">
+      <_NETStandardLibraryNETFrameworkReference Condition="'$(_TargetFrameworkVersionWithoutV)' &gt;= '4.7'"
+                                                Include="$(MSBuildThisFileDirectory)\net47\ref\*.dll" />
+      <_NETStandardLibraryNETFrameworkReference Condition="'$(_TargetFrameworkVersionWithoutV)' &gt;= '4.6.2'"
+                                                Include="$(MSBuildThisFileDirectory)\net462\ref\*.dll"
+                                                Exclude="@(_NETStandardLibraryNETFrameworkReference->'$(MSBuildThisFileDirectory)\net462\ref\%(FileName).dll')" />
+      <_NETStandardLibraryNETFrameworkReference Condition="'$(_TargetFrameworkVersionWithoutV)' &gt;= '4.6.1'"
+                                                Include="$(MSBuildThisFileDirectory)\net461\ref\*.dll"
+                                                Exclude="@(_NETStandardLibraryNETFrameworkReference->'$(MSBuildThisFileDirectory)\net461\ref\%(FileName).dll')" />
+
       <_NETStandardLibraryNETFrameworkLib Condition="'$(_TargetFrameworkVersionWithoutV)' &gt;= '4.7'"
                                           Include="$(MSBuildThisFileDirectory)\net47\lib\*.dll" />
       <_NETStandardLibraryNETFrameworkLib Condition="'$(_TargetFrameworkVersionWithoutV)' &gt;= '4.6.2'"
@@ -74,12 +83,15 @@ Copyright (c) .NET Foundation. All rights reserved.
            Simple references can also come from NuGet framework assemblies, hence this statement should occur after
            including all computed references, thus this target is scheduled after references have been raised by NuGet
            targets. -->
-      <Reference Remove="%(_NETStandardLibraryNETFrameworkLib.FileName)" />
+      <Reference Remove="%(_NETStandardLibraryNETFrameworkReference.FileName)" />
 
-      <Reference Include="@(_NETStandardLibraryNETFrameworkLib)">
-        <!-- netfx.force.conflicts is only needed at compile time. -->
-        <Private Condition="'%(FileName)' == 'netfx.force.conflicts'">false</Private>
+      <Reference Include="@(_NETStandardLibraryNETFrameworkReference)">
+        <Private>false</Private>
       </Reference>
+
+      <ReferenceCopyLocalPaths Include="@(_NETStandardLibraryNETFrameworkLib)">
+        <Private>false</Private>
+      </ReferenceCopyLocalPaths>
     </ItemGroup>
   </Target>
 </Project>

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildADesktopExeWtihNetStandardLib.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildADesktopExeWtihNetStandardLib.cs
@@ -287,7 +287,7 @@ namespace Microsoft.NET.Build.Tests
                         // Add a target that replaces the facade folder with the set of netstandard support assemblies
                         // this can be replaced by targeting the version of .NETFramework that includes netstandard inbox,
                         // once available
-                        var facadesDir = Path.Combine(RepoInfo.BuildExtensionsMSBuildPath, "net461", "lib\\");
+                        var facadesDir = Path.Combine(RepoInfo.BuildExtensionsMSBuildPath, "net461", "ref\\");
                         var ns = project.Root.Name.Namespace;
                         var target = new XElement(ns + "Target",
                             new XAttribute("Name", "ReplaceDesignTimeFacadeDirectories"),


### PR DESCRIPTION
Reverts dotnet/sdk#1582, which broke ASP.NET Core web apps running on .NET Framework.

A description of the issue, thanks to @eerhardt:

Previously we used to reference both the “ref assembly” to compile and the “runtime assembly” to run.  Now, we are no longer referencing the “ref assembly” at compile time.  We are compiling and running solely against the “runtime assembly”.

This changed the way the .deps.json file is created.  For the assembly it is looking for “Microsoft.Win32.Primitives”, the deps.json file changed from:

```
"Microsoft.Win32.Primitives/4.0.3.0": {
      "type": "referenceassembly",
```

In the old file to 

```
    "Microsoft.Win32.Primitives/4.0.3.0": {
      "type": "reference",
```

We have a pretty well-known bug in the 2.0.0 version of the DependencyModel library that was fixed in 2.0.1 - https://github.com/dotnet/core-setup/issues/2981.  Basically, the DependencyModel doesn’t resolve “type: reference” libraries correctly.
