### PR TITLE
Fix incorrect itemspec for references from ImplicitlyExpandNETStandardFacades

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -3,6 +3,7 @@
   <packageSources>
     <!--To inherit the global NuGet package sources remove the <clear/> line below -->
     <clear />
+    <add key="TransportFeed" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/packages/index.json" />
     <add key="nugetbuild" value="https://www.myget.org/F/nugetbuild/api/v3/index.json" />
     <add key="msbuild" value="https://dotnet.myget.org/F/msbuild/api/v3/index.json" />
     <add key="dotnet-buildtools" value="https://dotnet.myget.org/F/dotnet-buildtools/api/v3/index.json" />

--- a/build.ps1
+++ b/build.ps1
@@ -58,14 +58,6 @@ Invoke-WebRequest $DOTNET_INSTALL_SCRIPT_URL -OutFile "$env:DOTNET_INSTALL_DIR\d
 & "$env:DOTNET_INSTALL_DIR\dotnet-install.ps1" -Version $DotnetCLIVersion $dotnetInstallVerbosity
 if($LASTEXITCODE -ne 0) { throw "Failed to install stage0" }
 
-# This is a hack to prevent this target from being imported twice. We want to import the one that is build in the repo. If anyone knows
-# of a better way to do this, let licavalc known and I will immediatelly fix it.
-$NETBuildExtensionsTargets = "$env:DOTNET_INSTALL_DIR\sdk\$DotnetCLIVersion\15.0\Microsoft.Common.targets\ImportAfter\Microsoft.NET.Build.Extensions.targets"
-if (Test-Path $NETBuildExtensionsTargets)
-{
-    Remove-Item $NETBuildExtensionsTargets
-}
-
 # Install 1.0.4 shared framework
 if (!(Test-Path "$env:DOTNET_INSTALL_DIR\shared\Microsoft.NETCore.App\1.0.5"))
 {

--- a/build/sdk-test-env.bat
+++ b/build/sdk-test-env.bat
@@ -17,6 +17,5 @@ set DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
 set MSBuildSDKsPath=%SDK_REPO_ROOT%bin\Debug\Sdks
 set DOTNET_MSBUILD_SDK_RESOLVER_SDKS_DIR=%SDK_REPO_ROOT%bin\Debug\Sdks
 set NETCoreSdkBundledVersionsProps=%SDK_REPO_ROOT%.dotnet_cli\sdk\%SDK_CLI_VERSION%\Microsoft.NETCoreSdk.BundledVersions.props
-set CustomAfterMicrosoftCommonTargets=%SDK_REPO_ROOT%bin\Debug\Sdks\Microsoft.NET.Build.Extensions\msbuildExtensions-ver\Microsoft.Common.Targets\ImportAfter\Microsoft.NET.Build.Extensions.targets
 set MicrosoftNETBuildExtensionsTargets=%SDK_REPO_ROOT%bin\Debug\Sdks\Microsoft.NET.Build.Extensions\msbuildExtensions\Microsoft\Microsoft.NET.Build.Extensions\Microsoft.NET.Build.Extensions.targets
 rem You also need to add https://dotnet.myget.org/F/dotnet-core/api/v3/index.json to your NuGet feeds if building projects outside the SDK cone

--- a/src/Tasks/Microsoft.NET.Build.Extensions.Tasks/msbuildExtensions/Microsoft/Microsoft.NET.Build.Extensions/Microsoft.NET.Build.Extensions.NETFramework.targets
+++ b/src/Tasks/Microsoft.NET.Build.Extensions.Tasks/msbuildExtensions/Microsoft/Microsoft.NET.Build.Extensions/Microsoft.NET.Build.Extensions.NETFramework.targets
@@ -60,13 +60,13 @@ Copyright (c) .NET Foundation. All rights reserved.
     <!-- if any reference depends on netstandard and it is not inbox, add references and implementation assemblies for netstandard2.0  -->
     <ItemGroup Condition="'$(DependsOnNETStandard)' == 'true' AND '$(NETStandardInbox)' != 'true'">
       <_NETStandardLibraryNETFrameworkLib Condition="'$(_TargetFrameworkVersionWithoutV)' &gt;= '4.7'"
-                                          Include="$(MSBuildThisFileDirectory)\net47\lib\*.dll" />
+                                          Include="$(MSBuildThisFileDirectory)net47\lib\*.dll" />
       <_NETStandardLibraryNETFrameworkLib Condition="'$(_TargetFrameworkVersionWithoutV)' &gt;= '4.6.2'"
-                                          Include="$(MSBuildThisFileDirectory)\net462\lib\*.dll"
-                                          Exclude="@(_NETStandardLibraryNETFrameworkLib->'$(MSBuildThisFileDirectory)\net462\lib\%(FileName).dll')" />
+                                          Include="$(MSBuildThisFileDirectory)net462\lib\*.dll"
+                                          Exclude="@(_NETStandardLibraryNETFrameworkLib->'$(MSBuildThisFileDirectory)net462\lib\%(FileName).dll')" />
       <_NETStandardLibraryNETFrameworkLib Condition="'$(_TargetFrameworkVersionWithoutV)' &gt;= '4.6.1'"
-                                          Include="$(MSBuildThisFileDirectory)\net461\lib\*.dll"
-                                          Exclude="@(_NETStandardLibraryNETFrameworkLib->'$(MSBuildThisFileDirectory)\net461\lib\%(FileName).dll')" />
+                                          Include="$(MSBuildThisFileDirectory)net461\lib\*.dll"
+                                          Exclude="@(_NETStandardLibraryNETFrameworkLib->'$(MSBuildThisFileDirectory)net461\lib\%(FileName).dll')" />
 
       <!-- Remove simple name references if we're directly providing a reference assembly to the compiler. For example,
            consider a project with a Reference Include="System.Net.Http" or "System.IO.Compression", which are both in 

--- a/src/Tasks/Microsoft.NET.Build.Extensions.Tasks/msbuildExtensions/Microsoft/Microsoft.NET.Build.Extensions/Microsoft.NET.Build.Extensions.NETFramework.targets
+++ b/src/Tasks/Microsoft.NET.Build.Extensions.Tasks/msbuildExtensions/Microsoft/Microsoft.NET.Build.Extensions/Microsoft.NET.Build.Extensions.NETFramework.targets
@@ -90,7 +90,7 @@ Copyright (c) .NET Foundation. All rights reserved.
            and VS won't show a warning icon on the reference.  See https://github.com/dotnet/sdk/issues/1499
            -->
       
-      <Reference Include="@(_NETStandardLibraryNETFrameworkLib.FileName)">
+      <Reference Include="%(_NETStandardLibraryNETFrameworkLib.FileName)">
         <HintPath>%(_NETStandardLibraryNETFrameworkLib.Identity)</HintPath>
         <Private>false</Private>
       </Reference>

--- a/test/Microsoft.NET.TestFramework/RepoInfo.cs
+++ b/test/Microsoft.NET.TestFramework/RepoInfo.cs
@@ -166,9 +166,12 @@ namespace Microsoft.NET.TestFramework
 
             command = command.EnvironmentVariable("NETCoreSdkBundledVersionsProps", Path.Combine(RepoInfo.CliSdkPath, "Microsoft.NETCoreSdk.BundledVersions.props"));
 
-            // The following line can be removed once this file is integrated into MSBuild
-            command = command.EnvironmentVariable("CustomAfterMicrosoftCommonTargets", Path.Combine(RepoInfo.BuildExtensionsSdkPath, 
-                "msbuildExtensions-ver", "Microsoft.Common.targets", "ImportAfter", "Microsoft.NET.Build.Extensions.targets"));
+            if (UsingFullMSBuildWithoutExtensionsTargets())
+            {
+                command = command.EnvironmentVariable("CustomAfterMicrosoftCommonTargets", Path.Combine(RepoInfo.BuildExtensionsSdkPath,
+                    "msbuildExtensions-ver", "Microsoft.Common.targets", "ImportAfter", "Microsoft.NET.Build.Extensions.targets"));
+            }
+
             command = command.EnvironmentVariable("MicrosoftNETBuildExtensionsTargets", Path.Combine(RepoInfo.BuildExtensionsMSBuildPath, "Microsoft.NET.Build.Extensions.targets"));
 
             command = command
@@ -177,6 +180,19 @@ namespace Microsoft.NET.TestFramework
                 .EnvironmentVariable(nameof(ImplicitRuntimeFrameworkVersionForSelfContainedNetCoreApp2_0), ImplicitRuntimeFrameworkVersionForSelfContainedNetCoreApp2_0);
 
             return command;
+        }
+
+        private static bool UsingFullMSBuildWithoutExtensionsTargets()
+        {
+            string fullMSBuildPath = Environment.GetEnvironmentVariable("DOTNET_SDK_TEST_MSBUILD_PATH");
+            if (string.IsNullOrEmpty(fullMSBuildPath))
+            {
+                return false;
+            }
+
+            string fullMSBuildDirectory = Path.GetDirectoryName(fullMSBuildPath);
+            string extensionsImportAfterPath = Path.Combine(fullMSBuildDirectory, "..", "Microsoft.Common.targets", "ImportAfter", "Microsoft.NET.Build.Extensions.targets");
+            return !File.Exists(extensionsImportAfterPath);
         }
     }
 }


### PR DESCRIPTION
- Merge release/2.0.0 into release/15.5 (in order to pick up fix from #1644)
- Fix #1499, which I expected to be fixed by #1454 except there was a mistake in the XML
- Added test case to cover the broken scenario