### PR TITLE
Update framework references from NuGet packages with HintPath if there's also a matching DLL from NuGet

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.PackageDependencyResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.PackageDependencyResolution.targets
@@ -424,6 +424,10 @@ Copyright (c) .NET Foundation. All rights reserved.
           DependsOnTargets="_ComputeLockFileReferences;_ComputeLockFileFrameworks">
 
     <ItemGroup>
+      <!-- Add framework references from NuGet packages here, so that if there is also a matching reference from a NuGet package,
+           it will be treated the same as a reference from the project file. -->
+      <Reference Include="@(ResolvedFrameworkAssemblies)" />
+      
       <ResolvedCompileFileDefinitions Update="@(ResolvedCompileFileDefinitions)">
         <HintPath>%(FullPath)</HintPath>
       </ResolvedCompileFileDefinitions>
@@ -445,8 +449,6 @@ Copyright (c) .NET Foundation. All rights reserved.
       
       <!-- Add the references we computed -->
       <Reference Include="@(ResolvedCompileFileDefinitionsToAdd)" />
-      <Reference Include="@(ResolvedFrameworkAssemblies)" />
-      
     </ItemGroup>
   </Target>
 

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildADesktopExe.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildADesktopExe.cs
@@ -462,6 +462,38 @@ namespace DefaultReferences
                 .NotHaveStdOutMatching("Encountered conflict", System.Text.RegularExpressions.RegexOptions.CultureInvariant | System.Text.RegularExpressions.RegexOptions.IgnoreCase);
         }
 
+        [Fact]
+        public void It_does_not_report_conflicts_when_with_http_4_1_package()
+        {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return;
+            }
+
+            var testProject = new TestProject()
+            {
+                Name = "DesktopConflictsHttp4_1",
+                TargetFrameworks = "net461",
+                IsSdkProject = true,
+                IsExe = true
+            };
+
+            testProject.PackageReferences.Add(new TestPackageReference("System.Net.Http", "4.1.0"));
+
+            var testAsset = _testAssetsManager.CreateTestProject(testProject, testProject.Name)
+                .Restore(Log, testProject.Name);
+
+            var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+
+            //  Verify that ResolveAssemblyReference doesn't generate any conflicts
+            buildCommand
+                .Execute("/v:normal")
+                .Should()
+                .Pass()
+                .And
+                .NotHaveStdOutMatching("MSB3243", System.Text.RegularExpressions.RegexOptions.CultureInvariant | System.Text.RegularExpressions.RegexOptions.IgnoreCase);
+        }
+
         [WindowsOnlyFact]
         public void It_does_not_report_conflicts_with_runtime_specific_items()
         {


### PR DESCRIPTION
Applies the fix from #1454 to framework references that come from NuGet packages