### PR TITLE
Changes to the msbuild extensions targets that will enable copying the shims for net471 case

### DIFF
--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -13,7 +13,7 @@
     <NuGetVersion>4.5.0-preview2-4529</NuGetVersion>
     <NewtonsoftJsonVersion>9.0.1</NewtonsoftJsonVersion>
     <SystemReflectionMetadataVersion>1.4.2</SystemReflectionMetadataVersion>
-    <NETStandardLibraryNETFrameworkVersion>2.0.1-servicing-25708-01</NETStandardLibraryNETFrameworkVersion>
+    <NETStandardLibraryNETFrameworkVersion>2.0.1-servicing-25708-01</NETStandardLibraryNETFrameworkVersion> <!-- Once we have a new version of this package available, this version will have to be updated -->
     <XliffTasksVersion>0.2.0-beta-000042</XliffTasksVersion>
   </PropertyGroup>
 

--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -13,7 +13,7 @@
     <NuGetVersion>4.5.0-preview2-4529</NuGetVersion>
     <NewtonsoftJsonVersion>9.0.1</NewtonsoftJsonVersion>
     <SystemReflectionMetadataVersion>1.4.2</SystemReflectionMetadataVersion>
-    <NETStandardLibraryNETFrameworkVersion>2.0.1-servicing-25708-01</NETStandardLibraryNETFrameworkVersion> <!-- Once we have a new version of this package available, this version will have to be updated -->
+    <NETStandardLibraryNETFrameworkVersion>2.0.1-servicing-25908-02</NETStandardLibraryNETFrameworkVersion>
     <XliffTasksVersion>0.2.0-beta-000042</XliffTasksVersion>
   </PropertyGroup>
 

--- a/src/Tasks/Microsoft.NET.Build.Extensions.Tasks/msbuildExtensions/Microsoft/Microsoft.NET.Build.Extensions/Microsoft.NET.Build.Extensions.NETFramework.targets
+++ b/src/Tasks/Microsoft.NET.Build.Extensions.Tasks/msbuildExtensions/Microsoft/Microsoft.NET.Build.Extensions/Microsoft.NET.Build.Extensions.NETFramework.targets
@@ -67,9 +67,8 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <!--
       .NET 4.7.1 has support for .NET Standard 2.0 built-in, so most of the facades aren't necessary.  However, the assembly versions of a few set of assemblies
-      do not yet match the ones shipped by the support package.  This means that the versions from the contract NuGet packages would be preferred to the in-box 
-      version (which is newer).  So if there is a dependency on netstandard.dll, we use the 4.2.0.0 version of the DLLs from the .NET Standard 2.0 "facades".
-      (Though these DLLs are not actually facades, they contain the implementation.)
+      do not yet match the ones shipped in the support package for .NET Standard 2.0 on .NET 4.7 and below. This means that .NET 4.7 or lower libraries might have
+      references to higher versions of these assemblies than are available in-box in .NET 4.7, leading to assembly loading errors.
       -->
     <ItemGroup Condition="'$(_TargetFrameworkVersionWithoutV)' == '4.7.1'">
       <_NETStandardLibraryNETFrameworkLib Include="$(MSBuildThisFileDirectory)\net471\lib\*.dll" Condition="'$(DependsOnNETStandard)' == 'true'"/>

--- a/src/Tasks/Microsoft.NET.Build.Extensions.Tasks/msbuildExtensions/Microsoft/Microsoft.NET.Build.Extensions/Microsoft.NET.Build.Extensions.NETFramework.targets
+++ b/src/Tasks/Microsoft.NET.Build.Extensions.Tasks/msbuildExtensions/Microsoft/Microsoft.NET.Build.Extensions/Microsoft.NET.Build.Extensions.NETFramework.targets
@@ -76,7 +76,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     </ItemGroup>
     
     <!-- if any reference depends on netstandard and it is not inbox, add references and implementation assemblies for netstandard2.0  -->
-    <ItemGroup Condition="'$(DependsOnNETStandard)' == 'true' AND '$(NETStandardInbox)' != 'true' AND '$(_TargetFrameworkVersionWithoutV)' != '4.7.1'">
+    <ItemGroup Condition="'$(DependsOnNETStandard)' == 'true' AND '$(NETStandardInbox)' != 'true' AND '$(_TargetFrameworkVersionWithoutV)' &lt; '4.7.1'">
       <_NETStandardLibraryNETFrameworkLib Condition="'$(_TargetFrameworkVersionWithoutV)' &gt;= '4.7'"
                                           Include="$(MSBuildThisFileDirectory)net47\lib\*.dll" />
       <_NETStandardLibraryNETFrameworkLib Condition="'$(_TargetFrameworkVersionWithoutV)' &gt;= '4.6.2'"

--- a/src/Tasks/Microsoft.NET.Build.Extensions.Tasks/msbuildExtensions/Microsoft/Microsoft.NET.Build.Extensions/Microsoft.NET.Build.Extensions.NETFramework.targets
+++ b/src/Tasks/Microsoft.NET.Build.Extensions.Tasks/msbuildExtensions/Microsoft/Microsoft.NET.Build.Extensions/Microsoft.NET.Build.Extensions.NETFramework.targets
@@ -44,8 +44,16 @@ Copyright (c) .NET Foundation. All rights reserved.
     <PropertyGroup Condition="'$(DependsOnNETStandard)' == '' AND '$(NETStandardInbox)' != 'true'">
       <DependsOnNETStandard Condition="('%(_ResolvedProjectReferencePaths.TargetFrameworkIdentifier)' == '.NETStandard') And ('%(_ResolvedProjectReferencePaths.TargetFrameworkVersion)' >= '1.5')">true</DependsOnNETStandard>
     </PropertyGroup>
+
+    <PropertyGroup Condition="'@(_CandidateNETStandardReferences)' != ''">
+      <!-- Use an intermediate property to simplify condition.  Run GetDependsOnNETStandard if either: -->
+      <!-- 1. The .NET Standard 2.0 support need to be injected -->
+      <_RunGetDependsOnNETStandard Condition="'$(DependsOnNETStandard)' == '' AND '$(NETStandardInbox)' != 'true'">true</_RunGetDependsOnNETStandard>
+      <!-- 2. The target framework is .NET 4.7.1, which needs to special case some shims -->
+      <_RunGetDependsOnNETStandard Condition="'$(_TargetFrameworkVersionWithoutV)' == '4.7.1'">true</_RunGetDependsOnNETStandard>
+    </PropertyGroup>
     
-    <GetDependsOnNETStandard Condition="'$(DependsOnNETStandard)' == '' AND '$(NETStandardInbox)' != 'true' AND '@(_CandidateNETStandardReferences)' != ''" 
+    <GetDependsOnNETStandard Condition="'$(_RunGetDependsOnNETStandard)' == 'true'"
                              References="@(_CandidateNETStandardReferences)">
       <Output TaskParameter="DependsOnNETStandard" PropertyName="DependsOnNETStandard" />
     </GetDependsOnNETStandard>
@@ -56,9 +64,19 @@ Copyright (c) .NET Foundation. All rights reserved.
     </PropertyGroup>
     <NETBuildExtensionsError Condition="'$(DependsOnNETStandard)' == 'true' AND '$(NETStandardInbox)' != 'true' AND '$(_UsingOldSDK)' == 'true'"
                              ResourceName="UnsupportedSDKVersionForNetStandard20"/>
+
+    <!--
+      .NET 4.7.1 has support for .NET Standard 2.0 built-in, so most of the facades aren't necessary.  However, the assembly versions of a few set of assemblies
+      do not yet match the ones shipped by the support package.  This means that the versions from the contract NuGet packages would be preferred to the in-box 
+      version (which is newer).  So if there is a dependency on netstandard.dll, we use the 4.2.0.0 version of the DLLs from the .NET Standard 2.0 "facades".
+      (Though these DLLs are not actually facades, they contain the implementation.)
+      -->
+    <ItemGroup Condition="'$(_TargetFrameworkVersionWithoutV)' == '4.7.1'">
+      <_NETStandardLibraryNETFrameworkLib Include="$(MSBuildThisFileDirectory)\net471\lib\*.dll" Condition="'$(DependsOnNETStandard)' == 'true'"/>
+    </ItemGroup>
     
     <!-- if any reference depends on netstandard and it is not inbox, add references and implementation assemblies for netstandard2.0  -->
-    <ItemGroup Condition="'$(DependsOnNETStandard)' == 'true' AND '$(NETStandardInbox)' != 'true'">
+    <ItemGroup Condition="'$(DependsOnNETStandard)' == 'true' AND '$(NETStandardInbox)' != 'true' AND '$(_TargetFrameworkVersionWithoutV)' != '4.7.1'">
       <_NETStandardLibraryNETFrameworkLib Condition="'$(_TargetFrameworkVersionWithoutV)' &gt;= '4.7'"
                                           Include="$(MSBuildThisFileDirectory)net47\lib\*.dll" />
       <_NETStandardLibraryNETFrameworkLib Condition="'$(_TargetFrameworkVersionWithoutV)' &gt;= '4.6.2'"
@@ -67,7 +85,9 @@ Copyright (c) .NET Foundation. All rights reserved.
       <_NETStandardLibraryNETFrameworkLib Condition="'$(_TargetFrameworkVersionWithoutV)' &gt;= '4.6.1'"
                                           Include="$(MSBuildThisFileDirectory)net461\lib\*.dll"
                                           Exclude="@(_NETStandardLibraryNETFrameworkLib->'$(MSBuildThisFileDirectory)net461\lib\%(FileName).dll')" />
+    </ItemGroup>
 
+    <ItemGroup Condition="'@(_NETStandardLibraryNETFrameworkLib)' != ''">
       <!-- Remove simple name references if we're directly providing a reference assembly to the compiler. For example,
            consider a project with a Reference Include="System.Net.Http" or "System.IO.Compression", which are both in 
            _NETStandardLibraryNETFrameworkReference.

--- a/src/Tasks/Microsoft.NET.Build.Extensions.Tasks/msbuildExtensions/Microsoft/Microsoft.NET.Build.Extensions/Microsoft.NET.Build.Extensions.NETFramework.targets
+++ b/src/Tasks/Microsoft.NET.Build.Extensions.Tasks/msbuildExtensions/Microsoft/Microsoft.NET.Build.Extensions/Microsoft.NET.Build.Extensions.NETFramework.targets
@@ -68,7 +68,8 @@ Copyright (c) .NET Foundation. All rights reserved.
     <!--
       .NET 4.7.1 has support for .NET Standard 2.0 built-in, so most of the facades aren't necessary.  However, the assembly versions of a few set of assemblies
       do not yet match the ones shipped in the support package for .NET Standard 2.0 on .NET 4.7 and below. This means that .NET 4.7 or lower libraries might have
-      references to higher versions of these assemblies than are available in-box in .NET 4.7, leading to assembly loading errors.
+      references to higher versions of these assemblies than are available in-box in .NET 4.7, leading to assembly loading errors. So if there is a dependency on 
+      netstandard.dll, we include DLLs for .NET 4.7.1 from the support package to avoid these errors.
       -->
     <ItemGroup Condition="'$(_TargetFrameworkVersionWithoutV)' == '4.7.1'">
       <_NETStandardLibraryNETFrameworkLib Include="$(MSBuildThisFileDirectory)\net471\lib\*.dll" Condition="'$(DependsOnNETStandard)' == 'true'"/>

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToTargetNet471.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToTargetNet471.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using FluentAssertions;
+using Microsoft.Build.Utilities;
 using Microsoft.NET.TestFramework;
 using Microsoft.NET.TestFramework.Assertions;
 using Microsoft.NET.TestFramework.Commands;
@@ -24,9 +25,30 @@ namespace Microsoft.NET.Build.Tests
         {
         }
 
-        [WindowsOnlyFact(Skip = "https://github.com/dotnet/sdk/issues/1625")]
+        string[] net471Shims =
+        {
+            "System.Data.Common.dll",
+            "System.Diagnostics.StackTrace.dll",
+            "System.Diagnostics.Tracing.dll",
+            "System.Globalization.Extensions.dll",
+            "System.IO.Compression.dll",
+            "System.Net.Http.dll",
+            "System.Net.Sockets.dll",
+            "System.Runtime.Serialization.Primitives.dll",
+            "System.Security.Cryptography.Algorithms.dll",
+            "System.Security.SecureString.dll",
+            "System.Threading.Overlapped.dll",
+            "System.Xml.XPath.XDocument.dll"
+        };
+
+        [Fact]
         public void It_builds_a_net471_app()
         {
+            //  https://github.com/dotnet/sdk/issues/1625
+            if (!Net471ReferenceAssembliesAreInstalled())
+            {
+                return;
+            }
             var testProject = new TestProject()
             {
                 Name = "Net471App",
@@ -55,9 +77,14 @@ namespace Microsoft.NET.Build.Tests
             });
         }
 
-        [WindowsOnlyFact(Skip = "https://github.com/dotnet/sdk/issues/1625")]
+        [Fact]
         public void It_builds_a_net471_app_referencing_netstandard20()
         {
+            //  https://github.com/dotnet/sdk/issues/1625
+            if (!Net471ReferenceAssembliesAreInstalled())
+            {
+                return;
+            }
             var testProject = new TestProject()
             {
                 Name = "Net471App_Referencing_NetStandard20",
@@ -94,12 +121,17 @@ namespace Microsoft.NET.Build.Tests
                 $"{testProject.Name}.pdb",
                 $"{netStandardProject.Name}.dll",
                 $"{netStandardProject.Name}.pdb",
-            });
+            }.Concat(net471Shims));
         }
 
-        [WindowsOnlyFact(Skip = "https://github.com/dotnet/sdk/issues/1625")]
+        [Fact]
         public void It_does_not_include_facades_from_nuget_packages()
         {
+            //  https://github.com/dotnet/sdk/issues/1625
+            if (!Net471ReferenceAssembliesAreInstalled())
+            {
+                return;
+            }
             var testProject = new TestProject()
             {
                 Name = "Net471_NuGetFacades",
@@ -127,14 +159,120 @@ namespace Microsoft.NET.Build.Tests
             outputDirectory.Should().OnlyHaveFiles(new[] {
                 $"{testProject.Name}.exe",
                 $"{testProject.Name}.pdb",
-
-                //  Remove these two once https://github.com/dotnet/sdk/issues/1647 is fixed
+                
                 "System.Net.Http.dll",
                 "System.IO.Compression.dll",
 
                 //  This is an implementation dependency of the System.Net.Http package, which won't get conflict resolved out
                 "System.Diagnostics.DiagnosticSource.dll",
             });
+        }
+
+        [Fact]
+        public void It_includes_shims_when_net471_app_references_netstandard16()
+        {
+            //  https://github.com/dotnet/sdk/issues/1625
+            if (!Net471ReferenceAssembliesAreInstalled())
+            {
+                return;
+            }
+            var testProject = new TestProject()
+            {
+                Name = "Net471App_Referencing_NetStandard16",
+                TargetFrameworks = "net471",
+                IsSdkProject = true,
+                IsExe = true
+            };
+
+            var netStandardProject = new TestProject()
+            {
+                Name = "NetStandard16_Library",
+                TargetFrameworks = "netstandard1.6",
+                IsSdkProject = true
+            };
+
+            testProject.ReferencedProjects.Add(netStandardProject);
+
+            var testAsset = _testAssetsManager.CreateTestProject(testProject, "net471_ref_ns16")
+                .Restore(Log, testProject.Name);
+
+            var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+
+            buildCommand
+                .Execute("/v:normal")
+                .Should()
+                .Pass()
+                .And.NotHaveStdOutContaining("MSB3277") // MSB3277: Found conflicts between different versions of the same dependent assembly that could not be resolved.
+                .And.NotHaveStdOutContaining("Could not determine");
+
+            var outputDirectory = buildCommand.GetOutputDirectory(testProject.TargetFrameworks);
+
+            outputDirectory.Should().OnlyHaveFiles(new[] {
+                $"{testProject.Name}.exe",
+                $"{testProject.Name}.pdb",
+                $"{netStandardProject.Name}.dll",
+                $"{netStandardProject.Name}.pdb",
+                "System.Diagnostics.DiagnosticSource.dll" // This library will get pulled in as part of the closure of the ns16 project and will be copyied because it's not inbox.
+            }.Concat(net471Shims));
+        }
+
+        [Fact]
+        public void It_does_not_include_shims_when_app_references_471_library()
+        {
+            //  https://github.com/dotnet/sdk/issues/1625
+            if (!Net471ReferenceAssembliesAreInstalled())
+            {
+                return;
+            }
+            var testProject = new TestProject()
+            {
+                Name = "Net471App_Referencing_Net471Library",
+                TargetFrameworks = "net471",
+                IsSdkProject = true,
+                IsExe = true
+            };
+
+            var net471library = new TestProject()
+            {
+                Name = "Net471_Library",
+                TargetFrameworks = "net471",
+                IsSdkProject = true
+            };
+
+            testProject.ReferencedProjects.Add(net471library);
+
+            var testAsset = _testAssetsManager.CreateTestProject(testProject, "net471_ref_net471")
+                .Restore(Log, testProject.Name);
+
+            var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+
+            buildCommand
+                .Execute("/v:normal")
+                .Should()
+                .Pass()
+                .And.NotHaveStdOutContaining("MSB3277") // MSB3277: Found conflicts between different versions of the same dependent assembly that could not be resolved.
+                .And.NotHaveStdOutContaining("Could not determine");
+
+            var outputDirectory = buildCommand.GetOutputDirectory(testProject.TargetFrameworks);
+
+            outputDirectory.Should().OnlyHaveFiles(new[] {
+                $"{testProject.Name}.exe",
+                $"{testProject.Name}.pdb",
+                $"{net471library.Name}.dll",
+                $"{net471library.Name}.pdb",
+            });
+        }
+
+        static bool Net471ReferenceAssembliesAreInstalled()
+        {
+            var net461referenceAssemblies = ToolLocationHelper.GetPathToDotNetFrameworkReferenceAssemblies(TargetDotNetFrameworkVersion.Version461);
+            if (net461referenceAssemblies == null)
+            {
+                //  4.6.1 reference assemblies not found, assume that 4.7.1 isn't available either
+                return false;
+            }
+            var net471referenceAssemblies = Path.Combine(new DirectoryInfo(net461referenceAssemblies).Parent.FullName, "v4.7.1");
+            return Directory.Exists(net471referenceAssemblies);
         }
     }
 }


### PR DESCRIPTION
cc: @AlexGhiondea @weshaggard @dsplaisted @livarcocc 

These are the required changes for copying the required shims in order to run a net471 app that contains assets that were built using the support package. An example of a case that is currently broken is the following:

- A is a netstandard based library (could be ns1.5+)
- B is a net461 library that has a dependency to A. It also uses the type HttpClient. (HttpClient is in one of the affected assemblies, there are 12 affected assemblies in total)
- C is a net471 app that consumes B. When trying to run the app on net471, it will crash since it won't be able to find System.Net.Http.dll version 4.2.0.0.

The reason behind it is that since the net461 library depends on a NS1.5+ library, it will be built against the shims contained in the support package. These shims, have in some cases a higher assembly version than the one we have inbox on net471 (in 12 cases as I mentioned above). That means that your net461 library, will depend on a higher assembly version of a library than the ones present inbox on net471, which will cause a missing assembly error.