### PR TITLE
Add reference metadata to indicate that RAR can skip dependency searching

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Extensions.Tasks/Microsoft.NET.Build.Extensions.Tasks.csproj
+++ b/src/Tasks/Microsoft.NET.Build.Extensions.Tasks/Microsoft.NET.Build.Extensions.Tasks.csproj
@@ -195,7 +195,7 @@
 
   <!-- Remove files from copy local that would not be published as they are provided by the platform package -->
   <!-- https://github.com/dotnet/sdk/issues/933 tracks a first class feature for this -->
-  <Target Name="FilterCopyLocal" DependsOnTargets="RunResolvePublishAssemblies" BeforeTargets="ResolveLockFileCopyLocalProjectDeps">
+  <Target Name="FilterCopyLocal" DependsOnTargets="GetFrameworkPaths;GetReferenceAssemblyPaths;RunResolvePublishAssemblies" BeforeTargets="ResolveLockFileCopyLocalProjectDeps">
     <ItemGroup>
       <_CopyLocalButNotPublished Include="@(AllCopyLocalItems)" Exclude="@(ResolvedAssembliesToPublish)" />
       <AllCopyLocalItems Remove="@(_CopyLocalButNotPublished)" />

--- a/src/Tasks/Microsoft.NET.Build.Extensions.Tasks/msbuildExtensions/Microsoft/Microsoft.NET.Build.Extensions/Microsoft.NET.Build.Extensions.NETFramework.targets
+++ b/src/Tasks/Microsoft.NET.Build.Extensions.Tasks/msbuildExtensions/Microsoft/Microsoft.NET.Build.Extensions/Microsoft.NET.Build.Extensions.NETFramework.targets
@@ -66,6 +66,14 @@ Copyright (c) .NET Foundation. All rights reserved.
                              ResourceName="UnsupportedSDKVersionForNetStandard20"/>
 
     <!--
+      Just like references from packages, RAR should not waste time finding dependencies and related files for libraries added by this
+      extension. See related MarkPackageReferencesAsExternallyResolved in Microsoft.PackageDependencyResolution.targets.
+      -->
+    <PropertyGroup Condition="'$(MarkNETFrameworkExtensionAssembliesAsExternallyResolved)' == ''">
+      <MarkNETFrameworkExtensionAssembliesAsExternallyResolved>true</MarkNETFrameworkExtensionAssembliesAsExternallyResolved>
+    </PropertyGroup>
+
+    <!--
       .NET 4.7.1 has support for .NET Standard 2.0 built-in, so most of the facades aren't necessary.  However, the assembly versions of a few set of assemblies
       do not yet match the ones shipped in the support package for .NET Standard 2.0 on .NET 4.7 and below. This means that .NET 4.7 or lower libraries might have
       references to higher versions of these assemblies than are available in-box in .NET 4.7, leading to assembly loading errors. So if there is a dependency on 
@@ -113,6 +121,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       <Reference Include="%(_NETStandardLibraryNETFrameworkLib.FileName)">
         <HintPath>%(_NETStandardLibraryNETFrameworkLib.Identity)</HintPath>
         <Private>false</Private>
+        <ExternallyResolved>$(MarkNETFrameworkExtensionAssembliesAsExternallyResolved)</ExternallyResolved>
       </Reference>
       
       <ReferenceCopyLocalPaths Include="@(_NETStandardLibraryNETFrameworkLib)" Condition="'%(FileName)' != 'netfx.force.conflicts'">

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Microsoft.NET.Build.Tasks.csproj
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Microsoft.NET.Build.Tasks.csproj
@@ -89,7 +89,7 @@
 
   <!-- Remove files from copy local that would not be published as they are provided by the platform package -->
   <!-- https://github.com/dotnet/sdk/issues/933 tracks a first class feature for this -->
-  <Target Name="FilterCopyLocal" DependsOnTargets="RunResolvePublishAssemblies" BeforeTargets="ResolveLockFileCopyLocalProjectDeps">
+  <Target Name="FilterCopyLocal" DependsOnTargets="GetFrameworkPaths;GetReferenceAssemblyPaths;RunResolvePublishAssemblies" BeforeTargets="ResolveLockFileCopyLocalProjectDeps">
     <ItemGroup>
       <_CopyLocalButNotPublished Include="@(AllCopyLocalItems)" Exclude="@(ResolvedAssembliesToPublish)" />
       <AllCopyLocalItems Remove="@(_CopyLocalButNotPublished)" />

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.PackageDependencyResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.PackageDependencyResolution.targets
@@ -103,6 +103,16 @@ Copyright (c) .NET Foundation. All rights reserved.
   </ItemGroup>
 
   <!--
+    This will prevent RAR from spending time locating dependencies and related files for assemblies
+    that came from packages. PackageReference should already be promoted to a closure of Reference
+    items and we are responsible for adding package relates files to CopyLocal items, not RAR. This
+    is only configurable as a compat opt-out in case skipping the slow RAR code breaks something.
+  -->
+  <PropertyGroup Condition="'$(MarkPackageReferencesAsExternallyResolved)' == ''">
+    <MarkPackageReferencesAsExternallyResolved>true</MarkPackageReferencesAsExternallyResolved>
+  </PropertyGroup>
+
+  <!--
     *************************************
     3. BUILD TARGETS
     - Override the Depends-On properties, or the individual targets
@@ -424,12 +434,22 @@ Copyright (c) .NET Foundation. All rights reserved.
           DependsOnTargets="_ComputeLockFileReferences;_ComputeLockFileFrameworks">
 
     <ItemGroup>
+      <!--
+        Update Reference items with NuGetPackageId metadata to set ExternallyResolved appropriately.
+        NetStandard.Library adds its assets in targets this way and not in the standard way that
+        would get ExternallyResolved set in ResolvedCompileFileDefinitions below.
+       -->
+      <Reference Condition="'%(Reference.NuGetPackageId)' != ''">
+        <ExternallyResolved>$(MarkPackageReferencesAsExternallyResolved)</ExternallyResolved>
+      </Reference>
+
       <!-- Add framework references from NuGet packages here, so that if there is also a matching reference from a NuGet package,
            it will be treated the same as a reference from the project file. -->
       <Reference Include="@(ResolvedFrameworkAssemblies)" />
       
       <ResolvedCompileFileDefinitions Update="@(ResolvedCompileFileDefinitions)">
         <HintPath>%(FullPath)</HintPath>
+        <ExternallyResolved>$(MarkPackageReferencesAsExternallyResolved)</ExternallyResolved>
       </ResolvedCompileFileDefinitions>
     </ItemGroup>
     


### PR DESCRIPTION
MSBuild half: https://github.com/Microsoft/msbuild/pull/2716

On .NET Core, I'm seeing 2.5-3X improvement in RAR and about 0.5 seconds shaved off of full and incremental builds.

```
Before (dotnet new mvc - first build)
       68 ms  ResolvePackageFileConflicts                1 calls
       81 ms  ResolvePackageDependencies                 1 calls
      101 ms  GenerateDepsFile                           1 calls
      168 ms  MsBuild                                   10 calls
      724 ms  ResolveAssemblyReference                   1 calls
      795 ms  Csc                                        1 calls
     1125 ms  RestoreTask                                1 calls

     Time Elapsed 00:00:03.80

Before (dotnet new mvc - no changes):
       70 ms  ResolvePackageFileConflicts                1 calls
       95 ms  ResolvePackageDependencies                 1 calls
      167 ms  MsBuild                                   10 calls
      172 ms  RestoreTask                                1 calls
      729 ms  ResolveAssemblyReference                   1 calls

      Time Elapsed 00:00:01.88


After (dotnet new mvc - first build):
       75 ms  ResolvePackageFileConflicts                1 calls
       98 ms  GenerateDepsFile                           1 calls
       98 ms  ResolvePackageDependencies                 1 calls
      173 ms  MsBuild                                   10 calls
      260 ms  ResolveAssemblyReference                   1 calls
      810 ms  Csc                                        1 calls
     1092 ms  RestoreTask                                1 calls

     Time Elapsed 00:00:03.16

After (dotnet new mvc - no changes):
       76 ms  ResolvePackageFileConflicts                1 calls
      105 ms  ResolvePackageDependencies                 1 calls
      183 ms  MsBuild                                   10 calls
      187 ms  RestoreTask                                1 calls
      287 ms  ResolveAssemblyReference                   1 calls

      Time Elapsed 00:00:01.40
```