### PR TITLE
Adding one more condition so that we can override adding shims for net471 in case they are required

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Extensions.Tasks/msbuildExtensions/Microsoft/Microsoft.NET.Build.Extensions/Microsoft.NET.Build.Extensions.NETFramework.targets
+++ b/src/Tasks/Microsoft.NET.Build.Extensions.Tasks/msbuildExtensions/Microsoft/Microsoft.NET.Build.Extensions/Microsoft.NET.Build.Extensions.NETFramework.targets
@@ -50,7 +50,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       <!-- 1. The .NET Standard 2.0 support need to be injected -->
       <_RunGetDependsOnNETStandard Condition="'$(DependsOnNETStandard)' == '' AND '$(NETStandardInbox)' != 'true'">true</_RunGetDependsOnNETStandard>
       <!-- 2. The target framework is .NET 4.7.1, which needs to special case some shims -->
-      <_RunGetDependsOnNETStandard Condition="'$(_TargetFrameworkVersionWithoutV)' == '4.7.1'">true</_RunGetDependsOnNETStandard>
+      <_RunGetDependsOnNETStandard Condition="'$(DependsOnNETStandard)' == '' AND '$(_TargetFrameworkVersionWithoutV)' == '4.7.1'">true</_RunGetDependsOnNETStandard>
     </PropertyGroup>
     
     <GetDependsOnNETStandard Condition="'$(_RunGetDependsOnNETStandard)' == 'true'"


### PR DESCRIPTION
cc: @livarcocc @AlexGhiondea @weshaggard @dsplaisted 

During my testing I found one more thing that we can improve with the current targets. The problem to solve, is that in the case your app is in a state where we don't automatically detect that you need the shims (for example if you don't directly reference a netstandard based library but one of your dependencies does) and you are targeting .NET 4.7.1, there is no quick property that you can set in order to force the shims to be deployed with the app. The only current workaround for that, would be to add a direct reference to a netstandard based component directly, so that our logic kicks in. I don't think that this is a good behavior, which is why I would like to try to squish this change in, so that if users need to deploy the shims for 4.7.1, they can simpy set property `<DependsOnNETStandard>true</DependsOnNETStandard>` in order to accomplish that.