### PR TITLE
Remove old workarounds that are no longer necessary.

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.props
@@ -118,19 +118,6 @@ Copyright (c) .NET Foundation. All rights reserved.
   <!-- List of supported .NET Core and .NET Standard TFMs -->
   <Import Project="Microsoft.NET.SupportedTargetFrameworks.props" />
 
-  <!-- Temporary workarounds -->
-  <PropertyGroup>
-    <!-- Workaround: https://github.com/dotnet/roslyn/issues/12167 -->
-    <NoLogo Condition=" '$(NoLogo)' == '' ">true</NoLogo>
-
-    <!-- Workaround: https://github.com/Microsoft/msbuild/issues/720 -->
-    <OverrideToolHost Condition=" '$(DotnetHostPath)' != '' and '$(OverrideToolHost)' == ''">$(DotnetHostPath)</OverrideToolHost>
-  </PropertyGroup>
-
-  <!-- Workaround: https://github.com/dotnet/sdk/issues/1001 -->
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "/>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' "/>
-
   <!-- Workaround: https://github.com/dotnet/sdk/issues/1001 -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "/>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' "/>


### PR DESCRIPTION
Also, fix a merge issue where a group of code got duplicated unnecessarily.

https://github.com/Microsoft/msbuild/issues/720 has been closed for a long time.

https://github.com/dotnet/roslyn/issues/12167 is about to be closed since the issue no longer repos with the latest .NET Core SDK.