### PR TITLE
Updating the implicit Microsoft.NETCore.App version from 2.0 to 2.0.0 for 15.5

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.DefaultItems.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.DefaultItems.targets
@@ -113,7 +113,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     </When>
     <When Condition="'$(_TargetFrameworkVersionWithoutV)' == '2.0'">
       <PropertyGroup>
-        <ImplicitRuntimeFrameworkVersionForFrameworkDependentApp>2.0</ImplicitRuntimeFrameworkVersionForFrameworkDependentApp>
+        <ImplicitRuntimeFrameworkVersionForFrameworkDependentApp>2.0.0</ImplicitRuntimeFrameworkVersionForFrameworkDependentApp>
         <ImplicitRuntimeFrameworkVersionForSelfContainedApp>$(ImplicitRuntimeFrameworkVersionForSelfContainedNetCoreApp2_0)</ImplicitRuntimeFrameworkVersionForSelfContainedApp>
       </PropertyGroup>
     </When>


### PR DESCRIPTION
Updating the implicit Microsoft.NETCore.App version from 2.0 to 2.0.0. This will make sure that when evaluating RuntimeFrameworkVersion we will get a 3 digit number.

Test coming.

Part one of the fix to https://github.com/dotnet/cli/issues/7901. This needs to be fixed in both 2.0 and 2.1