### PR TITLE
Make CoreGenerateSatelliteAssemblies work for VB

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.targets
@@ -421,7 +421,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       </SatelliteAssemblyAttribute>
     </ItemGroup>
 
-    <WriteCodeFragment AssemblyAttributes="@(SatelliteAssemblyAttribute)" Language="$(Language)" OutputFile="$(_AssemblyInfoFile)">
+    <WriteCodeFragment AssemblyAttributes="@(SatelliteAssemblyAttribute)" Language="C#" OutputFile="$(_AssemblyInfoFile)">
       <Output TaskParameter="OutputFile" ItemName="FileWrites" />
     </WriteCodeFragment>
 


### PR DESCRIPTION
Fixes #1748.

The `CoreGenerateSatelliteAssemblies` task first calls the
`WriteCodeFragment` task to write a bunch of attributes to a .cs file,
and then calls the `Csc` task to compile it (along with the .resource
files, of course).

However, the call to `WriteCodeFragment` will use the project's language
to generate the source file. This means that in a VB project we'll end
up generating VB code into a .cs file which we then try to compile with
csc.exe. That doesn't end well.

The fix here is to always pass "C#" as the language to
`WriteCodeFragment`.