### PR TITLE
Add DisableImplicitTransitiveReferences

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.PackageDependencyResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.PackageDependencyResolution.targets
@@ -462,6 +462,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     -->
 
   <Target Name="_ComputeTransitiveProjectReferences"
+          Condition="'$(DisableImplicitTransitiveReferences)' != 'true'"
           DependsOnTargets="_ComputeActiveTFMPackageDependencies"
           Returns="_TransitiveProjectReferences">
     <ItemGroup>
@@ -479,6 +480,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   </Target>
 
   <Target Name="IncludeTransitiveProjectReferences"
+          Condition="'$(DisableImplicitTransitiveReferences)' != 'true'"
           DependsOnTargets="_ComputeTransitiveProjectReferences" >
     <ItemGroup>
       <!-- Add the references we computed -->

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.PackageDependencyResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.PackageDependencyResolution.targets
@@ -462,7 +462,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     -->
 
   <Target Name="_ComputeTransitiveProjectReferences"
-          Condition="'$(DisableImplicitTransitiveReferences)' != 'true'"
+          Condition="'$(DisableTransitiveProjectReferences)' != 'true'"
           DependsOnTargets="_ComputeActiveTFMPackageDependencies"
           Returns="_TransitiveProjectReferences">
     <ItemGroup>
@@ -480,7 +480,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   </Target>
 
   <Target Name="IncludeTransitiveProjectReferences"
-          Condition="'$(DisableImplicitTransitiveReferences)' != 'true'"
+          Condition="'$(DisableTransitiveProjectReferences)' != 'true'"
           DependsOnTargets="_ComputeTransitiveProjectReferences" >
     <ItemGroup>
       <!-- Add the references we computed -->

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAnAppWithTransitiveProjectRefs.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAnAppWithTransitiveProjectRefs.cs
@@ -122,5 +122,28 @@ namespace Microsoft.NET.Build.Tests
 
             outputDirectory.Should().OnlyHaveFiles(Array.Empty<string>());
         }
+
+        [Fact]
+        public void It_does_not_build_the_project_successfully()
+        {
+            // NOTE the project dependencies in AppWithTransitiveProjectRefs:
+            // TestApp --depends on--> MainLibrary --depends on--> AuxLibrary
+            // (TestApp transitively depends on AuxLibrary)
+
+            var testAsset = _testAssetsManager
+                .CopyTestAsset("AppWithTransitiveProjectRefs", "BuildAppWithTransitiveProjectRefDisabled")
+                .WithSource();
+
+            testAsset.Restore(Log, "TestApp");
+            testAsset.Restore(Log, "MainLibrary");
+            testAsset.Restore(Log, "AuxLibrary");
+
+            var appProjectDirectory = Path.Combine(testAsset.TestRoot, "TestApp");
+            var buildCommand = new BuildCommand(Log, appProjectDirectory);
+            buildCommand
+                .Execute("/p:DisableImplicitTransitiveReferences=true")
+                .Should()
+                .Fail();
+        }
     }
 }

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAnAppWithTransitiveProjectRefs.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAnAppWithTransitiveProjectRefs.cs
@@ -141,7 +141,7 @@ namespace Microsoft.NET.Build.Tests
             var appProjectDirectory = Path.Combine(testAsset.TestRoot, "TestApp");
             var buildCommand = new BuildCommand(Log, appProjectDirectory);
             buildCommand
-                .Execute("/p:DisableImplicitTransitiveReferences=true")
+                .Execute("/p:DisableTransitiveProjectReferences=true")
                 .Should()
                 .Fail();
         }


### PR DESCRIPTION
This implements the feature described in #1750. It provides projects with a way to
explicitly opt-out of implicit transitive refernces by setting the
DisableImplicitTransitiveReferences property to `'true'`.

closes #1750