### PR TITLE
Update build script switch defaults for log, restore, and test to true

### DIFF
--- a/build/build.ps1
+++ b/build/build.ps1
@@ -6,14 +6,14 @@ Param(
   [switch] $deploy,
   [switch] $fullMSBuild,
   [switch] $help,
-  [switch] $log,
+  [switch] $log = $True,
   [switch] $pack,
   [switch] $prepareMachine,
   [switch] $rebuild,
-  [switch] $restore,
+  [switch] $restore = $True,
   [switch] $sign,
   [string] $solution = "",
-  [switch] $test,
+  [switch] $test = $True,
   [string] $verbosity = "minimal",
   [Parameter(ValueFromRemainingArguments=$true)][String[]]$properties
 )


### PR DESCRIPTION
With these changes, you can simply run `build` on a clean copy of the repo and you'll get a successful build, tests will run, and a binary log will be created for investigation in case anything goes wrong.

To build with one of these options disabled, do this: `build -Test:$False`