### PR TITLE
Use shared compiler in CoreGenerateSatelliteAssemblies

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.targets
@@ -425,6 +425,10 @@ Copyright (c) .NET Foundation. All rights reserved.
       <Output TaskParameter="OutputFile" ItemName="FileWrites" />
     </WriteCodeFragment>
 
+    <PropertyGroup Condition="'$(UseSharedCompilation)' == ''">
+      <UseSharedCompilation>true</UseSharedCompilation>
+    </PropertyGroup>
+
     <Csc Resources="@(_SatelliteAssemblyResourceInputs)"
          Sources="$(_AssemblyInfoFile)"
          OutputAssembly="$(_OutputAssembly)"
@@ -443,7 +447,8 @@ Copyright (c) .NET Foundation. All rights reserved.
          WarningsNotAsErrors="$(WarningsNotAsErrors)"
          TargetType="Library"
          ToolExe="$(CscToolExe)"
-         ToolPath="$(CscToolPath)">
+         ToolPath="$(CscToolPath)"
+         UseSharedCompilation="$(UseSharedCompilation)">
 
       <Output TaskParameter="OutputAssembly" ItemName="FileWrites"/>
     </Csc>


### PR DESCRIPTION
The `CoreGenerateSatelliteAssemblies` target uses the `Csc` task to
create satellite assemblies. We can greatly speed up the creation of
these assemblies by telling `Csc` to use the shared compiler server if
it is available, rather than spinning up a new copy of csc.exe for every
satellite.