### PR TITLE
Fixing the generation of binding redirects when targeting 4.7.1

### DIFF
--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -13,7 +13,7 @@
     <NuGetVersion>4.5.0-preview2-4529</NuGetVersion>
     <NewtonsoftJsonVersion>9.0.1</NewtonsoftJsonVersion>
     <SystemReflectionMetadataVersion>1.4.2</SystemReflectionMetadataVersion>
-    <NETStandardLibraryNETFrameworkVersion>2.0.1-servicing-25908-02</NETStandardLibraryNETFrameworkVersion>
+    <NETStandardLibraryNETFrameworkVersion>2.0.1-servicing-26011-01</NETStandardLibraryNETFrameworkVersion>
     <XliffTasksVersion>0.2.0-beta-000042</XliffTasksVersion>
   </PropertyGroup>
 

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToTargetNet471.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToTargetNet471.cs
@@ -121,6 +121,7 @@ namespace Microsoft.NET.Build.Tests
                 $"{testProject.Name}.pdb",
                 $"{netStandardProject.Name}.dll",
                 $"{netStandardProject.Name}.pdb",
+                $"{testProject.Name}.exe.config", // We have now added binding redirects so we should expect a config flag to be dropped to the output directory.
             }.Concat(net471Shims));
         }
 
@@ -213,6 +214,7 @@ namespace Microsoft.NET.Build.Tests
                 $"{testProject.Name}.pdb",
                 $"{netStandardProject.Name}.dll",
                 $"{netStandardProject.Name}.pdb",
+                $"{testProject.Name}.exe.config", // We have now added binding redirects so we should expect a config flag to be dropped to the output directory.
                 "System.Diagnostics.DiagnosticSource.dll" //  This is an implementation dependency of the System.Net.Http package, which won't get conflict resolved out
             }.Concat(net471Shims));
         }
@@ -309,6 +311,7 @@ namespace Microsoft.NET.Build.Tests
             outputDirectory.Should().OnlyHaveFiles(new[] {
                 $"{testProject.Name}.exe",
                 $"{testProject.Name}.pdb",
+                $"{testProject.Name}.exe.config", // We have now added binding redirects so we should expect a config flag to be dropped to the output directory.
             }.Concat(net471Shims));
         }
 


### PR DESCRIPTION
cc: @livarcocc @weshaggard @AlexGhiondea

Inserting the new support package to the SDK that will fix the binding redirects for 4.7.1.