### PR TITLE
 Suppress assets messages for Clean target.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ obj/
 # Visual Studio
 ###############################################################################
 .vs/
+
+# OS X Device Services Store
+.DS_Store

--- a/sdk.sln
+++ b/sdk.sln
@@ -107,9 +107,13 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Common", "Common", "{529365
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.NET.Build.Tests", "src\Tests\Microsoft.NET.Build.Tests\Microsoft.NET.Build.Tests.csproj", "{52CB4546-DD2D-4207-B6E1-494C9506D1C1}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.NET.Clean.Tests", "src\Tests\Microsoft.NET.Clean.Tests\Microsoft.NET.Clean.Tests.csproj", "{5CBFF0EE-71EA-49CC-8369-34A9A62C8116}"
+EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.NET.Pack.Tests", "src\Tests\Microsoft.NET.Pack.Tests\Microsoft.NET.Pack.Tests.csproj", "{8746DC05-3035-4F24-9F2C-BAAAB5B50FD3}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.NET.Publish.Tests", "src\Tests\Microsoft.NET.Publish.Tests\Microsoft.NET.Publish.Tests.csproj", "{5B3E6EC9-AD8D-4F68-A9F8-C60CF11F4753}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.NET.Rebuild.Tests", "src\Tests\Microsoft.NET.Rebuild.Tests\Microsoft.NET.Rebuild.Tests.csproj", "{8283544E-9704-40C5-BEC2-2781413AA3CF}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.NET.Restore.Tests", "src\Tests\Microsoft.NET.Restore.Tests\Microsoft.NET.Restore.Tests.csproj", "{112668D7-322D-4F83-A6CE-B814C25AD3BF}"
 EndProject
@@ -168,6 +172,14 @@ Global
 		{6F72FAA2-4E46-4382-940A-4F0290E070E2}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6F72FAA2-4E46-4382-940A-4F0290E070E2}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6F72FAA2-4E46-4382-940A-4F0290E070E2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5CBFF0EE-71EA-49CC-8369-34A9A62C8116}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5CBFF0EE-71EA-49CC-8369-34A9A62C8116}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5CBFF0EE-71EA-49CC-8369-34A9A62C8116}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5CBFF0EE-71EA-49CC-8369-34A9A62C8116}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8283544E-9704-40C5-BEC2-2781413AA3CF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8283544E-9704-40C5-BEC2-2781413AA3CF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8283544E-9704-40C5-BEC2-2781413AA3CF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8283544E-9704-40C5-BEC2-2781413AA3CF}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -191,6 +203,8 @@ Global
 		{CAF71BDC-7B7D-4A43-AB8C-E440A1E4F108} = {580D1AE7-AA8F-4912-8B76-105594E00B3B}
 		{7C6A88D0-DBCC-4933-A92D-A0AC133DD5FC} = {5293658E-96D2-421F-A789-D0B6BA129570}
 		{6F72FAA2-4E46-4382-940A-4F0290E070E2} = {580D1AE7-AA8F-4912-8B76-105594E00B3B}
+		{5CBFF0EE-71EA-49CC-8369-34A9A62C8116} = {580D1AE7-AA8F-4912-8B76-105594E00B3B}
+		{8283544E-9704-40C5-BEC2-2781413AA3CF} = {580D1AE7-AA8F-4912-8B76-105594E00B3B}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {FB8F26CE-4DE6-433F-B32A-79183020BBD6}

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.targets
@@ -90,6 +90,20 @@ Copyright (c) .NET Foundation. All rights reserved.
     </CoreBuildDependsOn>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <CoreCleanDependsOn>
+      SuppressAssetsLogMessages;
+      $(CoreCleanDependsOn)
+    </CoreCleanDependsOn>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <RebuildDependsOn>
+      UnsuppressAssetsLogMessages;
+      $(RebuildDependsOn)
+    </RebuildDependsOn>
+  </PropertyGroup>
+
   <!--
     ============================================================
                                         GenerateBuildDependencyFile
@@ -182,6 +196,32 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ItemGroup>
       <BuiltProjectOutputGroupOutput Include="$(ProjectRuntimeConfigFilePath)" FinalOutputPath="$(ProjectRuntimeConfigFilePath)" />
     </ItemGroup>
+  </Target>
+
+  <!--
+    ============================================================
+                                        SuppressAssetsLogMessages
+
+    Suppresses log messages from an existing project assets file.
+    ============================================================
+    -->
+  <Target Name="SuppressAssetsLogMessages" Condition="'$(UnsuppressAssetsLogMessages)' != 'true'">
+    <PropertyGroup>
+      <EmitAssetsLogMessages>false</EmitAssetsLogMessages>
+    </PropertyGroup>
+  </Target>
+
+  <!--
+    ============================================================
+                                        UnsuppressAssetsLogMessages
+
+    Unsuppresses log messages from an existing project assets file.
+    ============================================================
+    -->
+  <Target Name="UnsuppressAssetsLogMessages">
+    <PropertyGroup>
+      <UnsuppressAssetsLogMessages>true</UnsuppressAssetsLogMessages>
+    </PropertyGroup>
   </Target>
 
   <!--

--- a/src/Tests/Microsoft.NET.Clean.Tests/GivenThatWeWantToCleanAProject.cs
+++ b/src/Tests/Microsoft.NET.Clean.Tests/GivenThatWeWantToCleanAProject.cs
@@ -1,0 +1,57 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Xml.Linq;
+using Microsoft.NET.TestFramework;
+using Microsoft.NET.TestFramework.Assertions;
+using Microsoft.NET.TestFramework.Commands;
+using FluentAssertions;
+using NuGet.Common;
+using NuGet.ProjectModel;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.NET.Clean.Tests
+{
+    public class GivenThatWeWantToCleanAHelloWorldProject : SdkTest
+    {
+        public GivenThatWeWantToCleanAHelloWorldProject(ITestOutputHelper log) : base(log)
+        {
+        }
+
+        [Fact]
+        public void It_cleans_without_logging_assets_message()
+        {
+            var testAsset = _testAssetsManager
+                .CopyTestAsset("HelloWorld", "CleanHelloWorld")
+                .WithSource()
+                .Restore(Log);
+
+            var lockFilePath = Path.Combine(testAsset.TestRoot, "obj", "project.assets.json");
+            LockFile lockFile = LockFileUtilities.GetLockFile(lockFilePath, NullLogger.Instance);
+
+            lockFile.LogMessages.Add(
+                new AssetsLogMessage(
+                    LogLevel.Warning,
+                    NuGetLogCode.NU1500,
+                    "a test warning",
+                    null));
+
+            new LockFileFormat().Write(lockFilePath, lockFile);
+
+            var cleanCommand = new CleanCommand(Log, testAsset.TestRoot);
+
+            cleanCommand
+                .Execute()
+                .Should()
+                .Pass()
+                .And
+                .NotHaveStdOutContaining("warning");
+        }
+    }
+}

--- a/src/Tests/Microsoft.NET.Clean.Tests/Microsoft.NET.Clean.Tests.csproj
+++ b/src/Tests/Microsoft.NET.Clean.Tests/Microsoft.NET.Clean.Tests.csproj
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the MIT license. See License.txt in the project root for full license information. -->
+<Project>
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <EnableDefaultItems>false</EnableDefaultItems>
+    <OutDirName>Tests\$(MSBuildProjectName)</OutDirName>
+  </PropertyGroup>
+
+  <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
+
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
+    <PackageReference Include="Microsoft.DotNet.Cli.Utils" Version="$(MicrosoftDotNetCliUtilsVersion)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Microsoft.NET.TestFramework\Microsoft.NET.TestFramework.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="**\*.cs" Exclude="$(GlobalExclude)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="**\*.resx" Exclude="$(GlobalExclude)" />
+  </ItemGroup>
+
+  <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
+
+</Project>

--- a/src/Tests/Microsoft.NET.Rebuild.Tests/GivenThatWeWantToRebuildAProject.cs
+++ b/src/Tests/Microsoft.NET.Rebuild.Tests/GivenThatWeWantToRebuildAProject.cs
@@ -1,0 +1,57 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Xml.Linq;
+using Microsoft.NET.TestFramework;
+using Microsoft.NET.TestFramework.Assertions;
+using Microsoft.NET.TestFramework.Commands;
+using FluentAssertions;
+using NuGet.Common;
+using NuGet.ProjectModel;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.NET.Rebuild.Tests
+{
+    public class GivenThatWeWantToRebuildAHelloWorldProject : SdkTest
+    {
+        public GivenThatWeWantToRebuildAHelloWorldProject(ITestOutputHelper log) : base(log)
+        {
+        }
+
+        [Fact]
+        public void It_rebuilds_with_logging_assets_message()
+        {
+            var testAsset = _testAssetsManager
+                .CopyTestAsset("HelloWorld", "RebuildHelloWorld")
+                .WithSource()
+                .Restore(Log);
+
+            var lockFilePath = Path.Combine(testAsset.TestRoot, "obj", "project.assets.json");
+            LockFile lockFile = LockFileUtilities.GetLockFile(lockFilePath, NullLogger.Instance);
+
+            lockFile.LogMessages.Add(
+                new AssetsLogMessage(
+                    LogLevel.Warning,
+                    NuGetLogCode.NU1500,
+                    "a test warning",
+                    null));
+
+            new LockFileFormat().Write(lockFilePath, lockFile);
+
+            var rebuildCommand = new RebuildCommand(Log, testAsset.TestRoot);
+
+            rebuildCommand
+                .Execute()
+                .Should()
+                .Pass()
+                .And
+                .HaveStdOutContaining("warning");
+        }
+    }
+}

--- a/src/Tests/Microsoft.NET.Rebuild.Tests/Microsoft.NET.Rebuild.Tests.csproj
+++ b/src/Tests/Microsoft.NET.Rebuild.Tests/Microsoft.NET.Rebuild.Tests.csproj
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the MIT license. See License.txt in the project root for full license information. -->
+<Project>
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <EnableDefaultItems>false</EnableDefaultItems>
+    <OutDirName>Tests\$(MSBuildProjectName)</OutDirName>
+  </PropertyGroup>
+
+  <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
+
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
+    <PackageReference Include="Microsoft.DotNet.Cli.Utils" Version="$(MicrosoftDotNetCliUtilsVersion)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Microsoft.NET.TestFramework\Microsoft.NET.TestFramework.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="**\*.cs" Exclude="$(GlobalExclude)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="**\*.resx" Exclude="$(GlobalExclude)" />
+  </ItemGroup>
+
+  <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
+
+</Project>

--- a/src/Tests/Microsoft.NET.TestFramework/Commands/CleanCommand.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/Commands/CleanCommand.cs
@@ -1,0 +1,19 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Linq;
+using Microsoft.DotNet.Cli.Utils;
+using System.IO;
+using Xunit.Abstractions;
+
+namespace Microsoft.NET.TestFramework.Commands
+{
+    public sealed class CleanCommand : MSBuildCommand
+    {
+        public CleanCommand(ITestOutputHelper log, string projectPath, string relativePathToProject = null)
+            : base(log, "Clean", projectPath, relativePathToProject)
+        {
+        }
+    }
+}

--- a/src/Tests/Microsoft.NET.TestFramework/Commands/RebuildCommand.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/Commands/RebuildCommand.cs
@@ -1,0 +1,19 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Linq;
+using Microsoft.DotNet.Cli.Utils;
+using System.IO;
+using Xunit.Abstractions;
+
+namespace Microsoft.NET.TestFramework.Commands
+{
+    public sealed class RebuildCommand : MSBuildCommand
+    {
+        public RebuildCommand(ITestOutputHelper log, string projectPath, string relativePathToProject = null)
+            : base(log, "Rebuild", projectPath, relativePathToProject)
+        {
+        }
+    }
+}


### PR DESCRIPTION
This commit ensures that messages from `project.assets.json` aren't logged for
the `Clean` target.  If a project is cleaned that has diagnostic messages
stored from a previous restore operation, the Clean target would previously
log the messages via the `ReportAssetsLogMessages` target.

Since a clean operation does not perform a restore, this is confusing to users.
The fix is to set the `EmitAssetsLogMessages` property to `false` for the
`Clean` target.

Fixes dotnet/cli#8027.