### PR TITLE
Fixing the generation of binding redirects when targeting 4.7.1

### DIFF
--- a/build/Versions.props
+++ b/build/Versions.props
@@ -30,7 +30,7 @@
     <MicrosoftBuildFrameworkVersion>15.4.8</MicrosoftBuildFrameworkVersion>
     <MicrosoftBuildUtilitiesCoreVersion>15.4.8</MicrosoftBuildUtilitiesCoreVersion>
     <MicrosoftExtensionsDependencyModelVersion>2.0.0</MicrosoftExtensionsDependencyModelVersion>
-    <NETStandardLibraryNETFrameworkVersion>2.0.1-servicing-25908-02</NETStandardLibraryNETFrameworkVersion>
+    <NETStandardLibraryNETFrameworkVersion>2.0.1-servicing-26011-01</NETStandardLibraryNETFrameworkVersion>
     <NewtonsoftJsonVersion>9.0.1</NewtonsoftJsonVersion>
     <NuGetBuildTasksPackVersion>4.5.0-preview2-4529</NuGetBuildTasksPackVersion>
     <NuGetPackagingVersion>4.5.0-preview2-4529</NuGetPackagingVersion>

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToTargetNet471.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToTargetNet471.cs
@@ -121,6 +121,7 @@ namespace Microsoft.NET.Build.Tests
                 $"{testProject.Name}.pdb",
                 $"{netStandardProject.Name}.dll",
                 $"{netStandardProject.Name}.pdb",
+                $"{testProject.Name}.exe.config", // We have now added binding redirects so we should expect a config flag to be dropped to the output directory.
             }.Concat(net471Shims));
         }
 
@@ -213,6 +214,7 @@ namespace Microsoft.NET.Build.Tests
                 $"{testProject.Name}.pdb",
                 $"{netStandardProject.Name}.dll",
                 $"{netStandardProject.Name}.pdb",
+                $"{testProject.Name}.exe.config", // We have now added binding redirects so we should expect a config flag to be dropped to the output directory.
                 "System.Diagnostics.DiagnosticSource.dll" //  This is an implementation dependency of the System.Net.Http package, which won't get conflict resolved out
             }.Concat(net471Shims));
         }
@@ -309,6 +311,7 @@ namespace Microsoft.NET.Build.Tests
             outputDirectory.Should().OnlyHaveFiles(new[] {
                 $"{testProject.Name}.exe",
                 $"{testProject.Name}.pdb",
+                $"{testProject.Name}.exe.config", // We have now added binding redirects so we should expect a config flag to be dropped to the output directory.
             }.Concat(net471Shims));
         }
 


### PR DESCRIPTION
@dotnet/dotnet-cli 