### PR TITLE
VB-specific DocumentationFile generation.

### DIFF
--- a/src/Assets/TestProjects/AppWithLibraryVB/TestApp/Program.vb
+++ b/src/Assets/TestProjects/AppWithLibraryVB/TestApp/Program.vb
@@ -1,0 +1,16 @@
+' Copyright (c) .NET Foundation and contributors. All rights reserved.
+' Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+Imports System
+
+Namespace TestApp
+
+    Module Program
+
+        Sub Main(args As String())
+            Console.WriteLine(TestLibrary.Helper.GetMessage())
+        End Sub
+
+    End Module
+
+End Namespace

--- a/src/Assets/TestProjects/AppWithLibraryVB/TestApp/TestApp.vbproj
+++ b/src/Assets/TestProjects/AppWithLibraryVB/TestApp/TestApp.vbproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Version>1.2.3-beta</Version>
+    <Authors>Test Authors</Authors>
+    <Product>Test Product</Product>
+    <AssemblyTitle>Test AssemblyTitle</AssemblyTitle>
+    <Copyright>Copyright (c) Test Authors</Copyright>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../TestLibrary/TestLibrary.vbproj" />
+  </ItemGroup>
+</Project>

--- a/src/Assets/TestProjects/AppWithLibraryVB/TestLibrary/Helper.vb
+++ b/src/Assets/TestProjects/AppWithLibraryVB/TestLibrary/Helper.vb
@@ -1,0 +1,18 @@
+' Copyright (c) .NET Foundation and contributors. All rights reserved.
+' Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+Namespace TestLibrary
+
+    Public Class Helper
+
+        Public Shared Function GetMessage() As String
+            Return "This string came from the test library!"
+        End Function
+
+        Public Sub SayHi()
+            Console.WriteLine("Hello there!")
+        End Sub
+
+    End Class
+
+End Namespace

--- a/src/Assets/TestProjects/AppWithLibraryVB/TestLibrary/TestLibrary.vbproj
+++ b/src/Assets/TestProjects/AppWithLibraryVB/TestLibrary/TestLibrary.vbproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Version>42.43.44.45-alpha</Version>
+    <OutputType>Library</OutputType>
+    <TargetFramework>netstandard1.5</TargetFramework>
+  </PropertyGroup>
+</Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.BeforeCommon.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.BeforeCommon.targets
@@ -165,7 +165,8 @@ Copyright (c) .NET Foundation. All rights reserved.
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(GenerateDocumentationFile)' == 'true' and '$(DocumentationFile)' == ''">
-    <DocumentationFile>$(IntermediateOutputPath)$(AssemblyName).xml</DocumentationFile>
+    <DocumentationFile Condition="'$(MSBuildProjectExtension)' == '.vbproj'">$(AssemblyName).xml</DocumentationFile>
+    <DocumentationFile Condition="'$(MSBuildProjectExtension)' != '.vbproj'">$(IntermediateOutputPath)$(AssemblyName).xml</DocumentationFile>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(GenerateDocumentationFile)' != 'true'">

--- a/src/Tests/Microsoft.NET.TestFramework/Commands/MSBuildCommand.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/Commands/MSBuildCommand.cs
@@ -51,11 +51,11 @@ namespace Microsoft.NET.TestFramework.Commands
                 }
             }
 
-            var buildProjectFiles = Directory.GetFiles(projectRootPath, "*.csproj");
+            var buildProjectFiles = Directory.GetFiles(projectRootPath, "*.*proj");
 
             if (buildProjectFiles.Length != 1)
             {
-                var errorMsg = $"Found {buildProjectFiles.Length} .csproj files under {projectRootPath} instead of just 1.";
+                var errorMsg = $"Found {buildProjectFiles.Length} project files under {projectRootPath} instead of just 1.";
                 throw new ArgumentException(errorMsg);
             }
 


### PR DESCRIPTION
Fixes #1598

VB targets already include `$(IntermediateOutputPath)`, so don't add it for `GenerateDocumentationFile`.