### PR TITLE
Fix spelling of 'overridden'

### DIFF
--- a/src/Tasks/Common/ConflictResolution/PackageOverride.cs
+++ b/src/Tasks/Common/ConflictResolution/PackageOverride.cs
@@ -19,42 +19,42 @@ namespace Microsoft.NET.Build.Tasks.ConflictResolution
     internal class PackageOverride
     {
         public string PackageName { get; }
-        public Dictionary<string, Version> OverridenPackages { get; }
+        public Dictionary<string, Version> OverriddenPackages { get; }
 
-        private PackageOverride(string packageName, IEnumerable<Tuple<string, Version>> overridenPackages)
+        private PackageOverride(string packageName, IEnumerable<Tuple<string, Version>> overriddenPackages)
         {
             PackageName = packageName;
 
-            OverridenPackages = new Dictionary<string, Version>(StringComparer.OrdinalIgnoreCase);
-            foreach (Tuple<string, Version> package in overridenPackages)
+            OverriddenPackages = new Dictionary<string, Version>(StringComparer.OrdinalIgnoreCase);
+            foreach (Tuple<string, Version> package in overriddenPackages)
             {
-                OverridenPackages[package.Item1] = package.Item2;
+                OverriddenPackages[package.Item1] = package.Item2;
             }
         }
 
         public static PackageOverride Create(ITaskItem packageOverrideItem)
         {
             string packageName = packageOverrideItem.ItemSpec;
-            string overridenPackagesString = packageOverrideItem.GetMetadata(MetadataKeys.OverridenPackages);
+            string overriddenPackagesString = packageOverrideItem.GetMetadata(MetadataKeys.OverriddenPackages);
 
-            return new PackageOverride(packageName, CreateOverridenPackages(overridenPackagesString));
+            return new PackageOverride(packageName, CreateOverriddenPackages(overriddenPackagesString));
         }
 
-        private static IEnumerable<Tuple<string, Version>> CreateOverridenPackages(string overridenPackagesString)
+        private static IEnumerable<Tuple<string, Version>> CreateOverriddenPackages(string overriddenPackagesString)
         {
-            if (!string.IsNullOrEmpty(overridenPackagesString))
+            if (!string.IsNullOrEmpty(overriddenPackagesString))
             {
-                overridenPackagesString = overridenPackagesString.Trim();
-                string[] overridenPackagesAndVersions = overridenPackagesString.Split(new char[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
-                foreach (string overridenPackagesAndVersion in overridenPackagesAndVersions)
+                overriddenPackagesString = overriddenPackagesString.Trim();
+                string[] overriddenPackagesAndVersions = overriddenPackagesString.Split(new char[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
+                foreach (string overriddenPackagesAndVersion in overriddenPackagesAndVersions)
                 {
-                    string trimmedOverridenPackagesAndVersion = overridenPackagesAndVersion.Trim();
-                    int separatorIndex = trimmedOverridenPackagesAndVersion.IndexOf('|');
+                    string trimmedOverriddenPackagesAndVersion = overriddenPackagesAndVersion.Trim();
+                    int separatorIndex = trimmedOverriddenPackagesAndVersion.IndexOf('|');
                     if (separatorIndex != -1)
                     {
-                        if (Version.TryParse(trimmedOverridenPackagesAndVersion.Substring(separatorIndex + 1), out Version version))
+                        if (Version.TryParse(trimmedOverriddenPackagesAndVersion.Substring(separatorIndex + 1), out Version version))
                         {
-                            yield return Tuple.Create(trimmedOverridenPackagesAndVersion.Substring(0, separatorIndex), version);
+                            yield return Tuple.Create(trimmedOverriddenPackagesAndVersion.Substring(0, separatorIndex), version);
                         }
                     }
                 }

--- a/src/Tasks/Common/ConflictResolution/PackageOverrideResolver.cs
+++ b/src/Tasks/Common/ConflictResolution/PackageOverrideResolver.cs
@@ -55,23 +55,23 @@ namespace Microsoft.NET.Build.Tasks.ConflictResolution
         }
 
         /// <summary>
-        /// Merges newPackageOverride into existingPackageOverride by adding all the new overriden packages
-        /// and taking the highest version when they both contain the same overriden package.
+        /// Merges newPackageOverride into existingPackageOverride by adding all the new overridden packages
+        /// and taking the highest version when they both contain the same overridden package.
         /// </summary>
         private static void MergePackageOverrides(PackageOverride newPackageOverride, PackageOverride existingPackageOverride)
         {
-            foreach (KeyValuePair<string, Version> newOverride in newPackageOverride.OverridenPackages)
+            foreach (KeyValuePair<string, Version> newOverride in newPackageOverride.OverriddenPackages)
             {
-                if (existingPackageOverride.OverridenPackages.TryGetValue(newOverride.Key, out Version existingOverrideVersion))
+                if (existingPackageOverride.OverriddenPackages.TryGetValue(newOverride.Key, out Version existingOverrideVersion))
                 {
                     if (existingOverrideVersion < newOverride.Value)
                     {
-                        existingPackageOverride.OverridenPackages[newOverride.Key] = newOverride.Value;
+                        existingPackageOverride.OverriddenPackages[newOverride.Key] = newOverride.Value;
                     }
                 }
                 else
                 {
-                    existingPackageOverride.OverridenPackages[newOverride.Key] = newOverride.Value;
+                    existingPackageOverride.OverriddenPackages[newOverride.Key] = newOverride.Value;
                 }
             }
         }
@@ -84,7 +84,7 @@ namespace Microsoft.NET.Build.Tasks.ConflictResolution
                 Version version;
                 if (item1.PackageId != null
                     && PackageOverrides.TryGetValue(item1.PackageId, out packageOverride)
-                    && packageOverride.OverridenPackages.TryGetValue(item2.PackageId, out version)
+                    && packageOverride.OverriddenPackages.TryGetValue(item2.PackageId, out version)
                     && item2.PackageVersion != null
                     && item2.PackageVersion <= version)
                 {
@@ -92,7 +92,7 @@ namespace Microsoft.NET.Build.Tasks.ConflictResolution
                 }
                 else if (item2.PackageId != null
                     && PackageOverrides.TryGetValue(item2.PackageId, out packageOverride)
-                    && packageOverride.OverridenPackages.TryGetValue(item1.PackageId, out version)
+                    && packageOverride.OverriddenPackages.TryGetValue(item1.PackageId, out version)
                     && item1.PackageVersion != null
                     && item1.PackageVersion <= version)
                 {

--- a/src/Tasks/Common/ConflictResolution/ResolvePackageFileConflicts.cs
+++ b/src/Tasks/Common/ConflictResolution/ResolvePackageFileConflicts.cs
@@ -32,7 +32,7 @@ namespace Microsoft.NET.Build.Tasks.ConflictResolution
         public string[] PreferredPackages { get; set; }
 
         /// <summary>
-        /// A collection of items that contain information of which packages get overriden
+        /// A collection of items that contain information of which packages get overridden
         /// by which packages before doing any other conflict resolution.
         /// </summary>
         /// <remarks>

--- a/src/Tasks/Common/MetadataKeys.cs
+++ b/src/Tasks/Common/MetadataKeys.cs
@@ -52,6 +52,6 @@ namespace Microsoft.NET.Build.Tasks
         public const string RuntimeStoreManifestNames = "RuntimeStoreManifestNames";
 
         // Conflict Resolution
-        public const string OverridenPackages = "OverridenPackages";
+        public const string OverriddenPackages = "OverriddenPackages";
     }
 }

--- a/src/Tasks/Common/build/Microsoft.NET.DefaultPackageConflictOverrides.targets
+++ b/src/Tasks/Common/build/Microsoft.NET.DefaultPackageConflictOverrides.targets
@@ -17,7 +17,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <ItemGroup Condition="'$(DisableDefaultPackageConflictOverrides)' != 'true'">
     <PackageConflictOverrides Include="Microsoft.NETCore.App">
-      <OverridenPackages>
+      <OverriddenPackages>
         Microsoft.CSharp|4.4.0;
         Microsoft.Win32.Primitives|4.3.0;
         Microsoft.Win32.Registry|4.4.0;
@@ -132,10 +132,10 @@ Copyright (c) .NET Foundation. All rights reserved.
         System.Xml.XmlSerializer|4.3.0;
         System.Xml.XPath|4.3.0;
         System.Xml.XPath.XDocument|4.3.0;
-      </OverridenPackages>
+      </OverriddenPackages>
     </PackageConflictOverrides>
     <PackageConflictOverrides Include="NETStandard.Library">
-      <OverridenPackages>
+      <OverriddenPackages>
         Microsoft.Win32.Primitives|4.3.0;
         System.AppContext|4.3.0;
         System.Collections|4.3.0;
@@ -231,7 +231,7 @@ Copyright (c) .NET Foundation. All rights reserved.
         System.Xml.XmlSerializer|4.3.0;
         System.Xml.XPath|4.3.0;
         System.Xml.XPath.XDocument|4.3.0;
-      </OverridenPackages>
+      </OverriddenPackages>
     </PackageConflictOverrides>
   </ItemGroup>
 </Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAConflictResolver.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAConflictResolver.cs
@@ -331,7 +331,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 new[] {
                     new MockTaskItem("Platform", new Dictionary<string, string>
                     {
-                        { MetadataKeys.OverridenPackages, "System.Ben|4.3.0;System.Immo|4.3.0;System.Dave|4.3.0" },
+                        { MetadataKeys.OverriddenPackages, "System.Ben|4.3.0;System.Immo|4.3.0;System.Dave|4.3.0" },
                     })
                 });
 
@@ -362,7 +362,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 new[] {
                     new MockTaskItem("Platform", new Dictionary<string, string>
                     {
-                        { MetadataKeys.OverridenPackages, "System.Ben|4.3.0;System.Immo|4.3.0;System.Dave|4.3.0" },
+                        { MetadataKeys.OverriddenPackages, "System.Ben|4.3.0;System.Immo|4.3.0;System.Dave|4.3.0" },
                     })
                 });
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAPackageOverrideResolver.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAPackageOverrideResolver.cs
@@ -19,11 +19,11 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             {
                 new MockTaskItem("Platform", new Dictionary<string, string>
                 {
-                    { MetadataKeys.OverridenPackages, "System.Ben|4.2.0;System.Immo|4.2.0;System.Livar|4.3.0;System.Dave|4.2.0" }
+                    { MetadataKeys.OverriddenPackages, "System.Ben|4.2.0;System.Immo|4.2.0;System.Livar|4.3.0;System.Dave|4.2.0" }
                 }),
                 new MockTaskItem("Platform", new Dictionary<string, string>
                 {
-                    { MetadataKeys.OverridenPackages, "System.Ben|4.2.0;System.Immo|4.3.0;System.Livar|4.2.0;System.Nick|4.2.0" }
+                    { MetadataKeys.OverriddenPackages, "System.Ben|4.2.0;System.Immo|4.3.0;System.Livar|4.2.0;System.Nick|4.2.0" }
                 })
             };
 
@@ -32,12 +32,12 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             Assert.Single(resolver.PackageOverrides);
 
             PackageOverride packageOverride = resolver.PackageOverrides["Platform"];
-            Assert.Equal(5, packageOverride.OverridenPackages.Count);
-            Assert.Equal(new Version(4, 2, 0), packageOverride.OverridenPackages["System.Ben"]);
-            Assert.Equal(new Version(4, 3, 0), packageOverride.OverridenPackages["System.Immo"]);
-            Assert.Equal(new Version(4, 3, 0), packageOverride.OverridenPackages["System.Livar"]);
-            Assert.Equal(new Version(4, 2, 0), packageOverride.OverridenPackages["System.Dave"]);
-            Assert.Equal(new Version(4, 2, 0), packageOverride.OverridenPackages["System.Nick"]);
+            Assert.Equal(5, packageOverride.OverriddenPackages.Count);
+            Assert.Equal(new Version(4, 2, 0), packageOverride.OverriddenPackages["System.Ben"]);
+            Assert.Equal(new Version(4, 3, 0), packageOverride.OverriddenPackages["System.Immo"]);
+            Assert.Equal(new Version(4, 3, 0), packageOverride.OverriddenPackages["System.Livar"]);
+            Assert.Equal(new Version(4, 2, 0), packageOverride.OverriddenPackages["System.Dave"]);
+            Assert.Equal(new Version(4, 2, 0), packageOverride.OverriddenPackages["System.Nick"]);
         }
 
         [Fact]


### PR DESCRIPTION
This typo fix affects msbuild metadata, but it is non-breaking because it was just introduced with #1805 and hasn't shipped.