### PR TITLE
Adding the Runtime Identifier and PlatformTarget to the error message

### DIFF
--- a/src/Tasks/Common/Resources/Strings.resx
+++ b/src/Tasks/Common/Resources/Strings.resx
@@ -259,7 +259,7 @@
     <value>It is not supported to build or publish a self-contained application without specifying a RuntimeIdentifier.  Please either specify a RuntimeIdentifier or set SelfContained to false.</value>
   </data>
   <data name="CannotHaveRuntimeIdentifierPlatformMismatchPlatformTarget" xml:space="preserve">
-    <value>The RuntimeIdentifier platform and the PlatformTarget must match.</value>
+    <value>The RuntimeIdentifier platform '{0}' and the PlatformTarget '{1}' must be compatible.</value>
   </data>
   <data name="ChoosingAssemblyVersion" xml:space="preserve">
     <value>Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</value>

--- a/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
@@ -328,8 +328,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CannotHaveRuntimeIdentifierPlatformMismatchPlatformTarget">
-        <source>The RuntimeIdentifier platform and the PlatformTarget must match.</source>
-        <target state="translated">Platforma RuntimeIdentifier a PlatformTarget se musí shodovat.</target>
+        <source>The RuntimeIdentifier platform '{0}' and the PlatformTarget '{1}' must be compatible.</source>
+        <target state="needs-review-translation">Platforma RuntimeIdentifier a PlatformTarget se musí shodovat.</target>
         <note />
       </trans-unit>
       <trans-unit id="ErrorParsingFrameworkListInvalidValue">

--- a/src/Tasks/Common/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.de.xlf
@@ -328,8 +328,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CannotHaveRuntimeIdentifierPlatformMismatchPlatformTarget">
-        <source>The RuntimeIdentifier platform and the PlatformTarget must match.</source>
-        <target state="translated">Die RuntimeIdentifier-Plattform und PlatformTarget müssen übereinstimmen.</target>
+        <source>The RuntimeIdentifier platform '{0}' and the PlatformTarget '{1}' must be compatible.</source>
+        <target state="needs-review-translation">Die RuntimeIdentifier-Plattform und PlatformTarget müssen übereinstimmen.</target>
         <note />
       </trans-unit>
       <trans-unit id="ErrorParsingFrameworkListInvalidValue">

--- a/src/Tasks/Common/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.es.xlf
@@ -328,8 +328,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CannotHaveRuntimeIdentifierPlatformMismatchPlatformTarget">
-        <source>The RuntimeIdentifier platform and the PlatformTarget must match.</source>
-        <target state="translated">Las plataformas RuntimeIdentifier y PlatformTarget deben coincidir.</target>
+        <source>The RuntimeIdentifier platform '{0}' and the PlatformTarget '{1}' must be compatible.</source>
+        <target state="needs-review-translation">Las plataformas RuntimeIdentifier y PlatformTarget deben coincidir.</target>
         <note />
       </trans-unit>
       <trans-unit id="ErrorParsingFrameworkListInvalidValue">

--- a/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
@@ -328,8 +328,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CannotHaveRuntimeIdentifierPlatformMismatchPlatformTarget">
-        <source>The RuntimeIdentifier platform and the PlatformTarget must match.</source>
-        <target state="translated">La plateforme RuntimeIdentifier et la PlatformTarget doivent correspondre.</target>
+        <source>The RuntimeIdentifier platform '{0}' and the PlatformTarget '{1}' must be compatible.</source>
+        <target state="needs-review-translation">La plateforme RuntimeIdentifier et la PlatformTarget doivent correspondre.</target>
         <note />
       </trans-unit>
       <trans-unit id="ErrorParsingFrameworkListInvalidValue">

--- a/src/Tasks/Common/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.it.xlf
@@ -328,8 +328,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CannotHaveRuntimeIdentifierPlatformMismatchPlatformTarget">
-        <source>The RuntimeIdentifier platform and the PlatformTarget must match.</source>
-        <target state="translated">La piattaforma di RuntimeIdentifier e quella di PlatformTarget devono corrispondere.</target>
+        <source>The RuntimeIdentifier platform '{0}' and the PlatformTarget '{1}' must be compatible.</source>
+        <target state="needs-review-translation">La piattaforma di RuntimeIdentifier e quella di PlatformTarget devono corrispondere.</target>
         <note />
       </trans-unit>
       <trans-unit id="ErrorParsingFrameworkListInvalidValue">

--- a/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
@@ -328,8 +328,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CannotHaveRuntimeIdentifierPlatformMismatchPlatformTarget">
-        <source>The RuntimeIdentifier platform and the PlatformTarget must match.</source>
-        <target state="translated">RuntimeIdentifier プラットフォームと PlatformTarget は一致している必要があります。</target>
+        <source>The RuntimeIdentifier platform '{0}' and the PlatformTarget '{1}' must be compatible.</source>
+        <target state="needs-review-translation">RuntimeIdentifier プラットフォームと PlatformTarget は一致している必要があります。</target>
         <note />
       </trans-unit>
       <trans-unit id="ErrorParsingFrameworkListInvalidValue">

--- a/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
@@ -328,8 +328,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CannotHaveRuntimeIdentifierPlatformMismatchPlatformTarget">
-        <source>The RuntimeIdentifier platform and the PlatformTarget must match.</source>
-        <target state="translated">RuntimeIdentifier 플랫폼과 PlatformTarget은 일치해야 합니다.</target>
+        <source>The RuntimeIdentifier platform '{0}' and the PlatformTarget '{1}' must be compatible.</source>
+        <target state="needs-review-translation">RuntimeIdentifier 플랫폼과 PlatformTarget은 일치해야 합니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="ErrorParsingFrameworkListInvalidValue">

--- a/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
@@ -328,8 +328,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CannotHaveRuntimeIdentifierPlatformMismatchPlatformTarget">
-        <source>The RuntimeIdentifier platform and the PlatformTarget must match.</source>
-        <target state="translated">Platforma RuntimeIdentifier i wartość PlatformTarget muszą być zgodne.</target>
+        <source>The RuntimeIdentifier platform '{0}' and the PlatformTarget '{1}' must be compatible.</source>
+        <target state="needs-review-translation">Platforma RuntimeIdentifier i wartość PlatformTarget muszą być zgodne.</target>
         <note />
       </trans-unit>
       <trans-unit id="ErrorParsingFrameworkListInvalidValue">

--- a/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
@@ -328,8 +328,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CannotHaveRuntimeIdentifierPlatformMismatchPlatformTarget">
-        <source>The RuntimeIdentifier platform and the PlatformTarget must match.</source>
-        <target state="translated">A plataforma RuntimeIdentifier e a PlatformTarget devem corresponder.</target>
+        <source>The RuntimeIdentifier platform '{0}' and the PlatformTarget '{1}' must be compatible.</source>
+        <target state="needs-review-translation">A plataforma RuntimeIdentifier e a PlatformTarget devem corresponder.</target>
         <note />
       </trans-unit>
       <trans-unit id="ErrorParsingFrameworkListInvalidValue">

--- a/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
@@ -328,8 +328,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CannotHaveRuntimeIdentifierPlatformMismatchPlatformTarget">
-        <source>The RuntimeIdentifier platform and the PlatformTarget must match.</source>
-        <target state="translated">Платформа RuntimeIdentifier и PlatformTarget должны совпадать.</target>
+        <source>The RuntimeIdentifier platform '{0}' and the PlatformTarget '{1}' must be compatible.</source>
+        <target state="needs-review-translation">Платформа RuntimeIdentifier и PlatformTarget должны совпадать.</target>
         <note />
       </trans-unit>
       <trans-unit id="ErrorParsingFrameworkListInvalidValue">

--- a/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
@@ -328,8 +328,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CannotHaveRuntimeIdentifierPlatformMismatchPlatformTarget">
-        <source>The RuntimeIdentifier platform and the PlatformTarget must match.</source>
-        <target state="translated">RuntimeIdentifier platformu ile PlatformTarget eşleşmelidir.</target>
+        <source>The RuntimeIdentifier platform '{0}' and the PlatformTarget '{1}' must be compatible.</source>
+        <target state="needs-review-translation">RuntimeIdentifier platformu ile PlatformTarget eşleşmelidir.</target>
         <note />
       </trans-unit>
       <trans-unit id="ErrorParsingFrameworkListInvalidValue">

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
@@ -328,8 +328,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CannotHaveRuntimeIdentifierPlatformMismatchPlatformTarget">
-        <source>The RuntimeIdentifier platform and the PlatformTarget must match.</source>
-        <target state="translated">RuntimeIdentifier 平台和 PlatformTarget 必须匹配。</target>
+        <source>The RuntimeIdentifier platform '{0}' and the PlatformTarget '{1}' must be compatible.</source>
+        <target state="needs-review-translation">RuntimeIdentifier 平台和 PlatformTarget 必须匹配。</target>
         <note />
       </trans-unit>
       <trans-unit id="ErrorParsingFrameworkListInvalidValue">

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
@@ -328,8 +328,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CannotHaveRuntimeIdentifierPlatformMismatchPlatformTarget">
-        <source>The RuntimeIdentifier platform and the PlatformTarget must match.</source>
-        <target state="translated">RuntimeIdentifier 平台必須與 PlatformTarget 相符。</target>
+        <source>The RuntimeIdentifier platform '{0}' and the PlatformTarget '{1}' must be compatible.</source>
+        <target state="needs-review-translation">RuntimeIdentifier 平台必須與 PlatformTarget 相符。</target>
         <note />
       </trans-unit>
       <trans-unit id="ErrorParsingFrameworkListInvalidValue">

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Microsoft.NET.Build.Tasks.csproj
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Microsoft.NET.Build.Tasks.csproj
@@ -70,6 +70,7 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.NET.Build.Tasks.UnitTests" />
+    <InternalsVisibleTo Include="Microsoft.NET.Build.Tests" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.RuntimeIdentifierInference.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.RuntimeIdentifierInference.targets
@@ -123,7 +123,8 @@ Copyright (c) .NET Foundation. All rights reserved.
           Condition="'$(RuntimeIdentifier)' != '' and '$(PlatformTarget)' != ''">
 
     <NETSdkError Condition="'$(PlatformTarget)' != 'AnyCPU' and !$(RuntimeIdentifier.ToUpper().Contains($(PlatformTarget.ToUpper())))"
-                 ResourceName="CannotHaveRuntimeIdentifierPlatformMismatchPlatformTarget" />
+                 ResourceName="CannotHaveRuntimeIdentifierPlatformMismatchPlatformTarget"
+                 FormatArguments="$(RuntimeIdentifier);$(PlatformTarget)" />
 
   </Target>
 

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildASelfContainedApp.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildASelfContainedApp.cs
@@ -3,6 +3,7 @@
 
 using FluentAssertions;
 using Microsoft.DotNet.Cli.Utils;
+using Microsoft.NET.Build.Tasks;
 using Microsoft.NET.TestFramework;
 using Microsoft.NET.TestFramework.Assertions;
 using Microsoft.NET.TestFramework.Commands;
@@ -71,15 +72,18 @@ namespace Microsoft.NET.Build.Tests
         [Fact]
         public void It_errors_out_when_RuntimeIdentifier_architecture_and_PlatformTarget_do_not_match()
         {
-			var testAsset = _testAssetsManager
+            const string RuntimeIdentifier = "win10-x64";
+            const string PlatformTarget = "x86";
+
+            var testAsset = _testAssetsManager
 				.CopyTestAsset("HelloWorld")
 				.WithSource()
 				.WithProjectChanges(project =>
 				{
 					var ns = project.Root.Name.Namespace;
 					var propertyGroup = project.Root.Elements(ns + "PropertyGroup").First();
-					propertyGroup.Add(new XElement(ns + "RuntimeIdentifier", "win10-x64"));
-                    propertyGroup.Add(new XElement(ns + "PlatformTarget", "x86"));
+					propertyGroup.Add(new XElement(ns + "RuntimeIdentifier", RuntimeIdentifier));
+                    propertyGroup.Add(new XElement(ns + "PlatformTarget", PlatformTarget));
 				})
 				.Restore(Log);
 
@@ -89,7 +93,10 @@ namespace Microsoft.NET.Build.Tests
 				.Execute()
 				.Should()
                 .Fail()
-                .And.HaveStdOutContaining("The RuntimeIdentifier platform 'win10-x64' and the PlatformTarget 'x86' must be compatible.");;
+                .And.HaveStdOutContaining(string.Format(
+                    Strings.CannotHaveRuntimeIdentifierPlatformMismatchPlatformTarget,
+                    RuntimeIdentifier,
+                    PlatformTarget));
         }
 
 		[Fact]

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildASelfContainedApp.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildASelfContainedApp.cs
@@ -88,7 +88,8 @@ namespace Microsoft.NET.Build.Tests
 			buildCommand
 				.Execute()
 				.Should()
-                .Fail();
+                .Fail()
+                .And.HaveStdOutContaining("The RuntimeIdentifier platform 'win10-x64' and the PlatformTarget 'x86' must be compatible.");;
         }
 
 		[Fact]


### PR DESCRIPTION
Adding the Runtime Identifier and PlatformTarget to the error message for when they don't match.

Fixes https://github.com/dotnet/sdk/issues/1616