### PR TITLE
Add .NET Core 2.1 to list of supported target frameworks

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.SupportedTargetFrameworks.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.SupportedTargetFrameworks.props
@@ -22,6 +22,7 @@ Copyright (c) .NET Foundation. All rights reserved.
         <SupportedTargetFramework Include=".NETCoreApp,Version=v1.0" DisplayName=".NET Core 1.0" />
         <SupportedTargetFramework Include=".NETCoreApp,Version=v1.1" DisplayName=".NET Core 1.1" />
         <SupportedTargetFramework Include=".NETCoreApp,Version=v2.0" DisplayName=".NET Core 2.0" />
+        <SupportedTargetFramework Include=".NETCoreApp,Version=v2.1" DisplayName=".NET Core 2.1" />
     </ItemGroup>
 
     <!-- .NET Standard -->


### PR DESCRIPTION
This value is used to configure Visual Studio's Application Properties pages.

**Customer scenario**

Customers using Application properties pages with .NET Core 2.1 are not able to select the runtime from the provided dropdown

**Bugs this fixes:** 

Fixes https://github.com/dotnet/project-system/issues/3183

**Workarounds, if any**

Change by editing csproj file

**Risk**

Low

**Performance impact**

Low

**Is this a regression from a previous update?**

No

**Root cause analysis:**

Need to update this list when moving to a new version of .NET Core

**How was the bug found?**

Partner testing

/cc @livarcocc 
Confirmed that this change fixes the problem in VS.