### PR TITLE
Run restore and create build log by default from build.cmd

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -1,3 +1,3 @@
 @echo off
-powershell -NoLogo -NoProfile -ExecutionPolicy ByPass %~dp0build\build.ps1 -build %*
+powershell -NoLogo -NoProfile -ExecutionPolicy ByPass %~dp0build\build.ps1 -build -restore -log %*
 exit /b %ErrorLevel%

--- a/build.sh
+++ b/build.sh
@@ -8,4 +8,4 @@ while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symli
 done
 ScriptRoot="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 
-. "$ScriptRoot/build/build.sh" --build $@
+. "$ScriptRoot/build/build.sh" --build --restore --log $@


### PR DESCRIPTION
Revisiting #1758.

This time the defaults are in the `build.cmd` instead of `build\build.ps1`, so it shouldn't affect the "Repo API".

I looked at the defaults in `build.cmd` for the different [repos using RepoToolset](https://github.com/dotnet/roslyn-tools/blob/master/docs/RepoToolset.md), and there wasn't much consistency.  Some of the restore by default, and some don't.  At least one logs by default.  I don't think any of them run tests by default, so I'm not enabling that in this PR.

@nguerrera @tannergooding @tmat @jaredpar