### PR TITLE
Update dogfood support

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,6 +16,9 @@
   </PropertyGroup>
 
   <PropertyGroup>
+    <ArtifactsDir>$(DOTNET_SDK_ARTIFACTS_DIR)</ArtifactsDir>
+    <ArtifactsDir Condition="'$(ArtifactsDir)' == ''">$(RepoRoot)artifacts\</ArtifactsDir>
+    <ArtifactsDir>$([MSBuild]::EnsureTrailingSlash($(ArtifactsDir)))</ArtifactsDir>
     <DOTNET_INSTALL_DIR Condition="'$(DOTNET_INSTALL_DIR)' == ''">$(RepoRoot)artifacts\.dotnet\$(DotNetCliVersion)\</DOTNET_INSTALL_DIR>
   </PropertyGroup>
 

--- a/build/build.ps1
+++ b/build/build.ps1
@@ -84,8 +84,7 @@ function InstallDotNetCli {
     $env:MSBuildSDKsPath = Join-Path $ArtifactsConfigurationDir "bin\Sdks"
     $env:DOTNET_MSBUILD_SDK_RESOLVER_SDKS_DIR = $env:MSBuildSDKsPath
     $env:NETCoreSdkBundledVersionsProps = Join-Path $DotNetRoot "sdk\$DotNetCliVersion\Microsoft.NETCoreSdk.BundledVersions.props"
-    $env:CustomAfterMicrosoftCommonTargets = Join-Path $env:MSBuildSDKsPath "Microsoft.NET.Build.Extensions\msbuildExtensions-ver\Microsoft.Common.Targets\ImportAfter\Microsoft.NET.Build.Extensions.targets"
-    $env:MicrosoftNETBuildExtensionsTargets = $env:CustomAfterMicrosoftCommonTargets
+    $env:MicrosoftNETBuildExtensionsTargets = Join-Path $env:MSBuildSDKsPath "Microsoft.NET.Build.Extensions\msbuildExtensions\Microsoft.Common.Targets\ImportAfter\Microsoft.NET.Build.Extensions.targets"
   }
 
   if (!(Test-Path $DotNetInstallScript)) {

--- a/build/build.ps1
+++ b/build/build.ps1
@@ -206,7 +206,6 @@ function Build {
   InstallDotNetCli
   InstallNuget
   CreateBuildEnvScript
-  CreateTestEnvScript
   $RepoToolsetBuildProj = InstallRepoToolset
 
   if ($prepareMachine) {
@@ -276,30 +275,6 @@ set DOTNET_MULTILEVEL_LOOKUP=0
 
 set PATH=$env:DOTNET_INSTALL_DIR;%PATH%
 set NUGET_PACKAGES=$env:NUGET_PACKAGES
-"@
-
-  Out-File -FilePath $scriptPath -InputObject $scriptContents -Encoding ASCII
-}
-
-function CreateTestEnvScript()
-{
-  Create-Directory $ArtifactsConfigurationDir
-  $scriptPath = Join-Path $ArtifactsConfigurationDir "sdk-test-env.bat"
-
-  $scriptContents = @"
-@echo off
-title SDK Test ($RepoRoot) ($configuration)
-set DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
-set DOTNET_MULTILEVEL_LOOKUP=0
-
-set PATH=$env:DOTNET_INSTALL_DIR;%PATH%
-set NUGET_PACKAGES=$env:NUGET_PACKAGES
-
-set SDK_CLI_VERSION=$DotNetCliVersion
-set MSBuildSDKsPath=$ArtifactsConfigurationDir\bin\Sdks
-set DOTNET_MSBUILD_SDK_RESOLVER_SDKS_DIR=%MSBuildSDKsPath%
-set NETCoreSdkBundledVersionsProps=$env:DOTNET_INSTALL_DIR\sdk\$DotNetCliVersion\Microsoft.NETCoreSdk.BundledVersions.props
-set MicrosoftNETBuildExtensionsTargets=%MSBuildSDKsPath%\Microsoft.NET.Build.Extensions\msbuildExtensions\Microsoft\Microsoft.NET.Build.Extensions\Microsoft.NET.Build.Extensions.targets
 "@
 
   Out-File -FilePath $scriptPath -InputObject $scriptContents -Encoding ASCII

--- a/build/build.ps1
+++ b/build/build.ps1
@@ -72,7 +72,7 @@ function InstallDotNetCli {
   $DotNetInstallVerbosity = ""
 
   if (!$env:DOTNET_INSTALL_DIR) {
-    $env:DOTNET_INSTALL_DIR = Join-Path $RepoRoot "artifacts\.dotnet\$DotNetCliVersion"
+    $env:DOTNET_INSTALL_DIR = Join-Path $ArtifactsDir ".dotnet\$DotNetCliVersion"
   }
 
   $DotNetRoot = $env:DOTNET_INSTALL_DIR
@@ -145,7 +145,7 @@ function InstallDotNetCli {
 }
 
 function InstallNuGet {
-  $NugetInstallDir = Join-Path $RepoRoot "artifacts\.nuget"
+  $NugetInstallDir = Join-Path $ArtifactsDir ".nuget"
   $NugetExe = Join-Path $NugetInstallDir "nuget.exe"
 
   if (!(Test-Path -Path $NugetExe)) {
@@ -293,7 +293,11 @@ if ($help -or (($properties -ne $null) -and ($properties.Contains("/help") -or $
 
 $RepoRoot = Join-Path $PSScriptRoot ".."
 $RepoRoot = [System.IO.Path]::GetFullPath($RepoRoot);
-$ArtifactsDir = Join-Path $RepoRoot "artifacts"
+
+$ArtifactsDir = $env:DOTNET_SDK_ARTIFACTS_DIR
+if (!($ArtifactsDir)) {
+  $ArtifactsDir = Join-Path $RepoRoot "artifacts"
+}
 $ArtifactsConfigurationDir = Join-Path $ArtifactsDir $configuration
 $LogDir = Join-Path $ArtifactsConfigurationDir "log"
 $VersionsProps = Join-Path $PSScriptRoot "Versions.props"

--- a/build/build.sh
+++ b/build/build.sh
@@ -130,7 +130,7 @@ function InstallDotNetCli {
 
   if [ -z "$DOTNET_INSTALL_DIR" ]
   then
-    export DOTNET_INSTALL_DIR="$RepoRoot/artifacts/.dotnet/$DotNetCliVersion"
+    export DOTNET_INSTALL_DIR="$ArtifactsDir/.dotnet/$DotNetCliVersion"
   fi
 
   DotNetRoot=$DOTNET_INSTALL_DIR
@@ -297,7 +297,14 @@ done
 ScriptRoot="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 
 RepoRoot="$ScriptRoot/.."
-ArtifactsDir="$RepoRoot/artifacts"
+if [ -z $DOTNET_SDK_ARTIFACTS_DIR ]
+then
+  ArtifactsDir="$RepoRoot/artifacts"
+else
+  ArtifactsDir="$DOTNET_SDK_ARTIFACTS_DIR"
+fi
+
+
 ArtifactsConfigurationDir="$ArtifactsDir/$configuration"
 LogDir="$ArtifactsConfigurationDir/log"
 VersionsProps="$ScriptRoot/Versions.props"
@@ -305,7 +312,7 @@ VersionsProps="$ScriptRoot/Versions.props"
 # HOME may not be defined in some scenarios, but it is required by NuGet
 if [ -z $HOME ]
 then
-  export HOME="$RepoRoot/artifacts/.home/"
+  export HOME="$ArtifactsDir/.home/"
   CreateDirectory "$HOME"
 fi
 

--- a/src/Tests/Microsoft.NET.TestFramework/TestContext.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/TestContext.cs
@@ -102,11 +102,18 @@ namespace Microsoft.NET.TestFramework
                     repoConfiguration = new DirectoryInfo(AppContext.BaseDirectory).Parent.Parent.Parent.Name;
                 }
             }
+
+            string artifactsDir = Environment.GetEnvironmentVariable("DOTNET_SDK_ARTIFACTS_DIR");
+            if (string.IsNullOrEmpty(artifactsDir))
+            {
+                artifactsDir = Path.Combine(repoRoot, "artifacts");
+            }
+
             if (repoRoot != null)
             {
-                testContext.NuGetFallbackFolder = Path.Combine(repoRoot, "artifacts", ".nuget", "NuGetFallbackFolder");
-                testContext.NuGetExePath = Path.Combine(repoRoot, "artifacts", ".nuget", $"nuget{Constants.ExeSuffix}");
-                testContext.NuGetCachePath = Path.Combine(repoRoot, "artifacts", ".nuget", "packages");
+                testContext.NuGetFallbackFolder = Path.Combine(artifactsDir, ".nuget", "NuGetFallbackFolder");
+                testContext.NuGetExePath = Path.Combine(artifactsDir, ".nuget", $"nuget{Constants.ExeSuffix}");
+                testContext.NuGetCachePath = Path.Combine(artifactsDir, ".nuget", "packages");
             }
             else
             {
@@ -127,7 +134,7 @@ namespace Microsoft.NET.TestFramework
                 testContext.BuildVersion = assemblyInformationalVersion.InformationalVersion;
             }
 
-            testContext.ToolsetUnderTest = ToolsetInfo.Create(repoRoot, repoConfiguration, commandLine);
+            testContext.ToolsetUnderTest = ToolsetInfo.Create(repoRoot, artifactsDir, repoConfiguration, commandLine);
 
             TestContext.Current = testContext;
         }

--- a/src/Tests/Microsoft.NET.TestFramework/ToolsetInfo.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/ToolsetInfo.cs
@@ -104,7 +104,7 @@ namespace Microsoft.NET.TestFramework
             return ret;
         }
 
-        public static ToolsetInfo Create(string repoRoot, string configuration, TestCommandLine commandLine)
+        public static ToolsetInfo Create(string repoRoot, string repoArtifactsDir, string configuration, TestCommandLine commandLine)
         {
             var ret = new ToolsetInfo();
 
@@ -116,8 +116,8 @@ namespace Microsoft.NET.TestFramework
                 var dotnetCliVersion = GetDotNetCliVersion(repoRoot);
 
                 ret.CliVersionForBundledVersions = dotnetCliVersion;
-                ret.DotNetHostPath = Path.Combine(repoRoot, "artifacts", ".dotnet", dotnetCliVersion, $"dotnet{Constants.ExeSuffix}");
-                ret.SdksPath = Path.Combine(repoRoot, "artifacts", configuration, "bin", "Sdks");
+                ret.DotNetHostPath = Path.Combine(repoArtifactsDir, ".dotnet", dotnetCliVersion, $"dotnet{Constants.ExeSuffix}");
+                ret.SdksPath = Path.Combine(repoArtifactsDir, configuration, "bin", "Sdks");
             }
             else
             {


### PR DESCRIPTION
**EDIT: This PR has changed somewhat, see https://github.com/dotnet/sdk/pull/1944#issuecomment-364589664 for a more up-to-date description**

This adds scripts that are created when you run the main build script that will set up a "build" or "test" environment.

The "build" environment basically just sets you up so that the version of `dotnet` on the path is the "Stage 0" one that would be used by the build script.

The "test" environment is set up to use the "Stage 1" versions of the SDK assets when you build.  So if you want to manually repro a test scenario, or to experiment with local changes, then you can do that in the test environment.

We had scripts like this before we moved to repo toolset.  It looks like the `-dogfood` argument to the build script was supposed to do something similar, but that didn't work in my workflow because it doesn't set the environment variables in the calling process.

With this PR, the "build" environment script is generated as `artifacts\sdk-build-env.bat` and the test environment script (for the Debug configuration) is generated as `artifacts\Debug\sdk-test-env.bat`.  That way there's less duplication of path logic, etc (though it is still duplicated between `build.ps1` and the `TestContext` code).

@tannergooding @nguerrera @livarcocc @wli3 @peterhuene @johnbeisner 