### PR TITLE
When converting CompileOptions, exclude empty entries when spliting DefineConstants.

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenACompilationOptionsConverter.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenACompilationOptionsConverter.cs
@@ -65,6 +65,40 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                         generateXmlDocumentation: true)
                 };
 
+                yield return new object[] {
+                    new MockTaskItem(
+                        itemSpec: "CompilerOptions",
+                        metadata: new Dictionary<string, string>
+                        {
+                            { "DefineConstants", ";NETCOREAPP1_0" },
+                            { "LangVersion", "6" },
+                            { "PlatformTarget", "x64" },
+                            { "AllowUnsafeBlocks", "true" },
+                            { "TreatWarningsAsErrors", "false" },
+                            //{ "Optimize", "" }, Explicitly not setting Optmize
+                            { "AssemblyOriginatorKeyFile", "../keyfile.snk" },
+                            { "DelaySign", "" },
+                            { "PublicSign", "notFalseOrTrue" },
+                            { "DebugType", "portable" },
+                            { "OutputType", "Exe" },
+                            { "GenerateDocumentationFile", "true" },
+                        }
+                    ),
+                    new CompilationOptions(
+                        defines: new[] { "NETCOREAPP1_0" },
+                        languageVersion: "6",
+                        platform: "x64",
+                        allowUnsafe: true,
+                        warningsAsErrors: false,
+                        optimize: null,
+                        keyFile: "../keyfile.snk",
+                        delaySign: null,
+                        publicSign: null,
+                        debugType: "portable",
+                        emitEntryPoint: true,
+                        generateXmlDocumentation: true)
+                };
+
                 yield return new object[]
                 {
                     null,

--- a/src/Tasks/Microsoft.NET.Build.Tasks/CompilationOptionsConverter.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/CompilationOptionsConverter.cs
@@ -17,7 +17,7 @@ namespace Microsoft.NET.Build.Tasks
             }
 
             return new CompilationOptions(
-                compilerOptionsItem.GetMetadata("DefineConstants")?.Split(';'),
+                compilerOptionsItem.GetMetadata("DefineConstants")?.Split(';', StringSplitOptions.RemoveEmptyEntries),
                 compilerOptionsItem.GetMetadata("LangVersion"),
                 compilerOptionsItem.GetMetadata("PlatformTarget"),
                 compilerOptionsItem.GetBooleanMetadata("AllowUnsafeBlocks"),

--- a/src/Tasks/Microsoft.NET.Build.Tasks/CompilationOptionsConverter.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/CompilationOptionsConverter.cs
@@ -17,7 +17,7 @@ namespace Microsoft.NET.Build.Tasks
             }
 
             return new CompilationOptions(
-                compilerOptionsItem.GetMetadata("DefineConstants")?.Split(';', StringSplitOptions.RemoveEmptyEntries),
+                compilerOptionsItem.GetMetadata("DefineConstants")?.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries),
                 compilerOptionsItem.GetMetadata("LangVersion"),
                 compilerOptionsItem.GetMetadata("PlatformTarget"),
                 compilerOptionsItem.GetBooleanMetadata("AllowUnsafeBlocks"),


### PR DESCRIPTION
Fixes https://github.com/dotnet/sdk/issues/1628