### PR TITLE
Always import BundledVersions.props

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.DefaultItems.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.DefaultItems.props
@@ -15,7 +15,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <NETCoreSdkBundledVersionsProps>$(MSBuildThisFileDirectory)..\..\..\Microsoft.NETCoreSdk.BundledVersions.props</NETCoreSdkBundledVersionsProps>
   </PropertyGroup>
 
-  <Import Project="$(NETCoreSdkBundledVersionsProps)" Condition="Exists('$(NETCoreSdkBundledVersionsProps)')" />
+  <Import Project="$(NETCoreSdkBundledVersionsProps)" />
 
   <PropertyGroup>
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>


### PR DESCRIPTION
Don't know if this is the right thing to do, but it looks like this import always happens. If so, conditioning it on existence represents a needless perf hit, and also makes debugging a failed build due to not having that file much harder.