### PR TITLE
Update implicit NETStandard.Library package version, and re-enable test

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.targets
@@ -56,8 +56,8 @@ Copyright (c) .NET Foundation. All rights reserved.
          produced, so we will roll forward to the latest version. -->
     <NETStandardImplicitPackageVersion Condition="'$(NETStandardImplicitPackageVersion)' =='' And '$(_TargetFrameworkVersionWithoutV)' &lt; '2.0'">1.6.1</NETStandardImplicitPackageVersion>
     
-    <!-- Default to use the latest stable release.  Currently this is the same as the previous clause, but when we have a stable 2.0 package this should change. -->
-    <NETStandardImplicitPackageVersion Condition="'$(NETStandardImplicitPackageVersion)' ==''">2.0.1</NETStandardImplicitPackageVersion>
+    <!-- Default to use the latest stable release. -->
+    <NETStandardImplicitPackageVersion Condition="'$(NETStandardImplicitPackageVersion)' ==''">2.0.2</NETStandardImplicitPackageVersion>
   </PropertyGroup>
   
   <!--  

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildALibrary.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildALibrary.cs
@@ -653,7 +653,7 @@ namespace Microsoft.NET.Build.Tests
 
         [Theory]
         [InlineData("netcoreapp2.2")]
-        [InlineData("netstandard2.3")]
+        [InlineData("netstandard2.1")]
         public void It_fails_to_build_if_targeting_a_higher_framework_than_is_supported(string targetFramework)
         {
             var testProject = new TestProject()


### PR DESCRIPTION
- Re-enable test for error targeting .NET Standard 2.1 (Fixes #1632)
- Update to version 2.0.2 of NETStandard.Library package (Resolves #1608)