### PR TITLE
Port fix to make satellite generation work for VB to release/2.1.1xx

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.targets
@@ -421,7 +421,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       </SatelliteAssemblyAttribute>
     </ItemGroup>
 
-    <WriteCodeFragment AssemblyAttributes="@(SatelliteAssemblyAttribute)" Language="$(Language)" OutputFile="$(_AssemblyInfoFile)">
+    <WriteCodeFragment AssemblyAttributes="@(SatelliteAssemblyAttribute)" Language="C#" OutputFile="$(_AssemblyInfoFile)">
       <Output TaskParameter="OutputFile" ItemName="FileWrites" />
     </WriteCodeFragment>
 


### PR DESCRIPTION
**Customer scenario**

VB project using SDK and having satellite assemblies. Build breaks trying to compile the Assembly info for the satellite that is written out in VB instead of C# even though satellite builds in SDK always invoke the C# compiler.

2.1.1xx and 2.1.2xx SDKs cannot build themselves because Roslyn in these release branches depends on having this fix.

**Bugs this fixes:** 

https://github.com/dotnet/sdk/issues/1748 (Already fixed, but only for 2.1.300+ and this is a request to have it included in the next 2.1.1xx servicing release as well as 2.1.200.)

**Workarounds, if any**

Wait for 2.1.300 to be released (which already has the fix).

Copy entire target with fix into Directory.Build.targets. This is very fragile because it would shut off any future fixes to the target and tie the customer project to internal implementation details of the SDK. I would be very hesitant to recommend this.

Source build can apply a patch, but this keeps a discrepancy betweeen source and non-source-builds and adds debt. By putting this low risk fix into the next servicing release, we eliminate that debt sooner.

**Risk**

Low

**Performance impact**

None

**Is this a regression from a previous update?**

No. It was broken since the first release that supported VB (1.1 I believe), but Roslyn was the first customer to report it. It seems the intersection of VB sdk projects and satellite assemblies is small.

**Root cause analysis:**

Insufficient VB coverage.

Insufficient understanding / communication that a Roslyn branch effectively cannot depend on a CLI newer than the CLI release train it is on. Otherwise, source build will break. Moving forward, any fix we take to unblock Roslyn will need to consider the correlation between Roslyn branches and CLI branches.

**How was the bug found?**

Dogfooding
