### PR TITLE
Remove -log parameter

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -1,3 +1,3 @@
 @echo off
-powershell -NoLogo -NoProfile -ExecutionPolicy ByPass %~dp0build\build.ps1 -build -restore -log %*
+powershell -NoLogo -NoProfile -ExecutionPolicy ByPass %~dp0build\build.ps1 -build -restore %*
 exit /b %ErrorLevel%


### PR DESCRIPTION
Log parameter is passed automatically by the build definitions. Passing twice causes parse errors in powershell