### PR TITLE
Fix issues with dogfood environment setup

### DIFF
--- a/build/build.ps1
+++ b/build/build.ps1
@@ -89,7 +89,7 @@ function InstallDotNetCli {
     $env:MSBuildSDKsPath = Join-Path $ArtifactsConfigurationDir "bin\Sdks"
     $env:DOTNET_MSBUILD_SDK_RESOLVER_SDKS_DIR = $env:MSBuildSDKsPath
     $env:NETCoreSdkBundledVersionsProps = Join-Path $DotNetRoot "sdk\$DotNetCliVersion\Microsoft.NETCoreSdk.BundledVersions.props"
-    $env:MicrosoftNETBuildExtensionsTargets = Join-Path $env:MSBuildSDKsPath "Microsoft.NET.Build.Extensions\msbuildExtensions\Microsoft\Microoft.NET.Build.Extensions\Microsoft.NET.Build.Extensions.targets"
+    $env:MicrosoftNETBuildExtensionsTargets = Join-Path $env:MSBuildSDKsPath "Microsoft.NET.Build.Extensions\msbuildExtensions\Microsoft\Microsoft.NET.Build.Extensions\Microsoft.NET.Build.Extensions.targets"
   }
 
   if (!(Test-Path $DotNetInstallScript)) {

--- a/build/build.sh
+++ b/build/build.sh
@@ -119,6 +119,13 @@ function InstallDotNetCli {
   DotNetCliVersion="$( GetVersionsPropsVersion DotNetCliVersion )"
   DotNetInstallVerbosity=""
 
+  if [ -z "$DOTNET_INSTALL_DIR" ]
+  then
+    export DOTNET_INSTALL_DIR="$ArtifactsDir/.dotnet/$DotNetCliVersion"
+  fi
+
+  DotNetRoot=$DOTNET_INSTALL_DIR
+
   if $dogfood
   then
     export SDK_REPO_ROOT="$RepoRoot"
@@ -129,12 +136,6 @@ function InstallDotNetCli {
     export MicrosoftNETBuildExtensionsTargets="$MSBuildSDKsPath/Microsoft.NET.Build.Extensions/msbuildExtensions/Microsoft/Microsoft.NET.Build.Extensions/Microsoft.NET.Build.Extensions.targets"
   fi
 
-  if [ -z "$DOTNET_INSTALL_DIR" ]
-  then
-    export DOTNET_INSTALL_DIR="$ArtifactsDir/.dotnet/$DotNetCliVersion"
-  fi
-
-  DotNetRoot=$DOTNET_INSTALL_DIR
   DotNetInstallScript="$DotNetRoot/dotnet-install.sh"
 
   if [ ! -a "$DotNetInstallScript" ]

--- a/build/build.sh
+++ b/build/build.sh
@@ -126,8 +126,7 @@ function InstallDotNetCli {
     export MSBuildSDKsPath="$ArtifactsConfigurationDir/bin/Sdks"
     export DOTNET_MSBUILD_SDK_RESOLVER_SDKS_DIR="$MSBuildSDKsPath"
     export NETCoreSdkBundledVersionsProps="$DotNetRoot/sdk/$DotNetCliVersion/Microsoft.NETCoreSdk.BundledVersions.props"
-    export CustomAfterMicrosoftCommonTargets="$MSBuildSDKsPath/Microsoft.NET.Build.Extensions/msbuildExtensions-ver/Microsoft.Common.Targets/ImportAfter/Microsoft.NET.Build.Extensions.targets"
-    export MicrosoftNETBuildExtensionsTargets="$CustomAfterMicrosoftCommonTargets"
+    export MicrosoftNETBuildExtensionsTargets="$MSBuildSDKsPath/Microsoft.NET.Build.Extensions/msbuildExtensions/Microsoft/Microsoft.NET.Build.Extensions/Microsoft.NET.Build.Extensions.targets"
   fi
 
   if [ -z "$DOTNET_INSTALL_DIR" ]


### PR DESCRIPTION
1. There's a typo in the extensions targets in some branches
2. The .sh had the old-old incorrect extensions targets path
3. DotNetRoot was not set early enough in .sh
4. .sh was still setting CustomAfter targets