### PR TITLE
Fix P2P packtool

### DIFF
--- a/src/Assets/TestProjects/PortableToolWithP2P/App/Program.cs
+++ b/src/Assets/TestProjects/PortableToolWithP2P/App/Program.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using ClassLibrary;
+
+namespace consoledemo
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            Console.WriteLine(Class1.Greeting);
+        }
+    }
+}

--- a/src/Assets/TestProjects/PortableToolWithP2P/App/consoledemo.csproj
+++ b/src/Assets/TestProjects/PortableToolWithP2P/App/consoledemo.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <AssemblyName>consoledemo</AssemblyName>
+    <PackAsTool>true</PackAsTool>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Library\Library.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Assets/TestProjects/PortableToolWithP2P/Library/Class1.cs
+++ b/src/Assets/TestProjects/PortableToolWithP2P/Library/Class1.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace ClassLibrary
+{
+    public class Class1
+    {
+        public static string Greeting = "Hello World from Global Tool";
+    }
+}

--- a/src/Assets/TestProjects/PortableToolWithP2P/Library/Library.csproj
+++ b/src/Assets/TestProjects/PortableToolWithP2P/Library/Library.csproj
@@ -1,0 +1,7 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.PackTool.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.PackTool.targets
@@ -49,7 +49,7 @@ Copyright (c) .NET Foundation. All rights reserved.
         <PackagePath>tools/$(targetframework)/any/%(_GeneratedFiles.RecursiveDir)%(_GeneratedFiles.Filename)%(_GeneratedFiles.Extension)</PackagePath>
       </TfmSpecificPackageFile>
 
-      <TfmSpecificPackageFile Include="@(ResolvedFileToPublish->'$(PublishDir)%(RelativePath)')">
+      <TfmSpecificPackageFile Include="@(ResolvedFileToPublish->'$([MSBuild]::NormalizeDirectory($(PublishDir)))%(RelativePath)')">
         <PackagePath>tools/$(targetframework)/any/%(ResolvedFileToPublish.RelativePath)</PackagePath>
       </TfmSpecificPackageFile>
     </ItemGroup>

--- a/src/Tests/Microsoft.NET.ToolPack.Tests/GivenThatWeWantToPackAToolProjectWithP2PReference.cs
+++ b/src/Tests/Microsoft.NET.ToolPack.Tests/GivenThatWeWantToPackAToolProjectWithP2PReference.cs
@@ -1,0 +1,67 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using FluentAssertions;
+using Microsoft.NET.TestFramework;
+using Microsoft.NET.TestFramework.Commands;
+using NuGet.Packaging;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.NET.ToolPack.Tests
+{
+    public class GivenThatWeWantToPackAToolProjectWithP2PReference : SdkTest
+    {
+        public GivenThatWeWantToPackAToolProjectWithP2PReference(ITestOutputHelper log) : base(log)
+        {
+        }
+
+        private string SetupNuGetPackage([CallerMemberName] string callingMethod = "")
+        {
+            TestAsset testAsset = _testAssetsManager
+                .CopyTestAsset("PortableToolWithP2P", callingMethod)
+                .WithSource()
+                .Restore(Log, "App");
+
+            var appProjectDirectory = Path.Combine(testAsset.TestRoot, "App");
+            var packCommand = new PackCommand(Log, appProjectDirectory);
+
+            packCommand.Execute();
+
+            return packCommand.GetNuGetPackage();
+        }
+
+        [Fact]
+        public void It_packs_successfully()
+        {
+            var nugetPackage = SetupNuGetPackage();
+            using (var nupkgReader = new PackageArchiveReader(nugetPackage))
+            {
+                nupkgReader
+                    .GetToolItems()
+                    .Should().NotBeEmpty();
+            }
+        }
+
+        [Fact]
+        public void It_contains_dependencies_dll()
+        {
+            var nugetPackage = SetupNuGetPackage();
+            using (var nupkgReader = new PackageArchiveReader(nugetPackage))
+            {
+                IEnumerable<NuGet.Frameworks.NuGetFramework> supportedFrameworks = nupkgReader.GetSupportedFrameworks();
+                supportedFrameworks.Should().NotBeEmpty();
+
+                foreach (NuGet.Frameworks.NuGetFramework framework in supportedFrameworks)
+                {
+                    var allItems = nupkgReader.GetToolItems().SelectMany(i => i.Items).ToList();
+                    allItems.Should().Contain($"tools/{framework.GetShortFolderName()}/any/Library.dll");
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fix https://github.com/dotnet/cli/issues/8705

The input of PackTask are relative paths. And it ends up getting wrong full path in the task (prefixed with Library path instead of App path). Give PackTask full path as input.
