### PR TITLE
Don't set a default ProjectAssetsFile path in the SDK

### DIFF
--- a/src/Tasks/Common/Resources/Strings.resx
+++ b/src/Tasks/Common/Resources/Strings.resx
@@ -346,4 +346,8 @@
 {1} - Restored version of platform package
 {2} - Current version of platform package</comment>
   </data>
+  <data name="AssetsFileNotSet" xml:space="preserve">
+    <value>ProjectAssetsFile was not set. Run a NuGet package restore to generate this file.</value>
+    <comment>"ProjectAssetsFile" is the name of a property and parameter to the task, so it should not be translated</comment>
+  </data>
 </root>

--- a/src/Tasks/Common/Resources/Strings.resx
+++ b/src/Tasks/Common/Resources/Strings.resx
@@ -347,7 +347,6 @@
 {2} - Current version of platform package</comment>
   </data>
   <data name="AssetsFileNotSet" xml:space="preserve">
-    <value>ProjectAssetsFile was not set. Run a NuGet package restore to generate this file.</value>
-    <comment>"ProjectAssetsFile" is the name of a property and parameter to the task, so it should not be translated</comment>
+    <value>The path to the project assets file was not set. Run a NuGet package restore to generate this file.</value>
   </data>
 </root>

--- a/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
@@ -379,6 +379,11 @@
 {1} - Restored version of platform package
 {2} - Current version of platform package</note>
       </trans-unit>
+      <trans-unit id="AssetsFileNotSet">
+        <source>ProjectAssetsFile was not set. Run a NuGet package restore to generate this file.</source>
+        <target state="new">ProjectAssetsFile was not set. Run a NuGet package restore to generate this file.</target>
+        <note>"ProjectAssetsFile" is the name of a property and parameter to the task, so it should not be translated</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
@@ -380,9 +380,9 @@
 {2} - Current version of platform package</note>
       </trans-unit>
       <trans-unit id="AssetsFileNotSet">
-        <source>ProjectAssetsFile was not set. Run a NuGet package restore to generate this file.</source>
-        <target state="new">ProjectAssetsFile was not set. Run a NuGet package restore to generate this file.</target>
-        <note>"ProjectAssetsFile" is the name of a property and parameter to the task, so it should not be translated</note>
+        <source>The path to the project assets file was not set. Run a NuGet package restore to generate this file.</source>
+        <target state="new">The path to the project assets file was not set. Run a NuGet package restore to generate this file.</target>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/Tasks/Common/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.de.xlf
@@ -379,6 +379,11 @@
 {1} - Restored version of platform package
 {2} - Current version of platform package</note>
       </trans-unit>
+      <trans-unit id="AssetsFileNotSet">
+        <source>ProjectAssetsFile was not set. Run a NuGet package restore to generate this file.</source>
+        <target state="new">ProjectAssetsFile was not set. Run a NuGet package restore to generate this file.</target>
+        <note>"ProjectAssetsFile" is the name of a property and parameter to the task, so it should not be translated</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Common/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.de.xlf
@@ -380,9 +380,9 @@
 {2} - Current version of platform package</note>
       </trans-unit>
       <trans-unit id="AssetsFileNotSet">
-        <source>ProjectAssetsFile was not set. Run a NuGet package restore to generate this file.</source>
-        <target state="new">ProjectAssetsFile was not set. Run a NuGet package restore to generate this file.</target>
-        <note>"ProjectAssetsFile" is the name of a property and parameter to the task, so it should not be translated</note>
+        <source>The path to the project assets file was not set. Run a NuGet package restore to generate this file.</source>
+        <target state="new">The path to the project assets file was not set. Run a NuGet package restore to generate this file.</target>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/Tasks/Common/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.es.xlf
@@ -379,6 +379,11 @@
 {1} - Restored version of platform package
 {2} - Current version of platform package</note>
       </trans-unit>
+      <trans-unit id="AssetsFileNotSet">
+        <source>ProjectAssetsFile was not set. Run a NuGet package restore to generate this file.</source>
+        <target state="new">ProjectAssetsFile was not set. Run a NuGet package restore to generate this file.</target>
+        <note>"ProjectAssetsFile" is the name of a property and parameter to the task, so it should not be translated</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Common/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.es.xlf
@@ -380,9 +380,9 @@
 {2} - Current version of platform package</note>
       </trans-unit>
       <trans-unit id="AssetsFileNotSet">
-        <source>ProjectAssetsFile was not set. Run a NuGet package restore to generate this file.</source>
-        <target state="new">ProjectAssetsFile was not set. Run a NuGet package restore to generate this file.</target>
-        <note>"ProjectAssetsFile" is the name of a property and parameter to the task, so it should not be translated</note>
+        <source>The path to the project assets file was not set. Run a NuGet package restore to generate this file.</source>
+        <target state="new">The path to the project assets file was not set. Run a NuGet package restore to generate this file.</target>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
@@ -379,6 +379,11 @@
 {1} - Restored version of platform package
 {2} - Current version of platform package</note>
       </trans-unit>
+      <trans-unit id="AssetsFileNotSet">
+        <source>ProjectAssetsFile was not set. Run a NuGet package restore to generate this file.</source>
+        <target state="new">ProjectAssetsFile was not set. Run a NuGet package restore to generate this file.</target>
+        <note>"ProjectAssetsFile" is the name of a property and parameter to the task, so it should not be translated</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
@@ -380,9 +380,9 @@
 {2} - Current version of platform package</note>
       </trans-unit>
       <trans-unit id="AssetsFileNotSet">
-        <source>ProjectAssetsFile was not set. Run a NuGet package restore to generate this file.</source>
-        <target state="new">ProjectAssetsFile was not set. Run a NuGet package restore to generate this file.</target>
-        <note>"ProjectAssetsFile" is the name of a property and parameter to the task, so it should not be translated</note>
+        <source>The path to the project assets file was not set. Run a NuGet package restore to generate this file.</source>
+        <target state="new">The path to the project assets file was not set. Run a NuGet package restore to generate this file.</target>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/Tasks/Common/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.it.xlf
@@ -379,6 +379,11 @@
 {1} - Restored version of platform package
 {2} - Current version of platform package</note>
       </trans-unit>
+      <trans-unit id="AssetsFileNotSet">
+        <source>ProjectAssetsFile was not set. Run a NuGet package restore to generate this file.</source>
+        <target state="new">ProjectAssetsFile was not set. Run a NuGet package restore to generate this file.</target>
+        <note>"ProjectAssetsFile" is the name of a property and parameter to the task, so it should not be translated</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Common/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.it.xlf
@@ -380,9 +380,9 @@
 {2} - Current version of platform package</note>
       </trans-unit>
       <trans-unit id="AssetsFileNotSet">
-        <source>ProjectAssetsFile was not set. Run a NuGet package restore to generate this file.</source>
-        <target state="new">ProjectAssetsFile was not set. Run a NuGet package restore to generate this file.</target>
-        <note>"ProjectAssetsFile" is the name of a property and parameter to the task, so it should not be translated</note>
+        <source>The path to the project assets file was not set. Run a NuGet package restore to generate this file.</source>
+        <target state="new">The path to the project assets file was not set. Run a NuGet package restore to generate this file.</target>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
@@ -379,6 +379,11 @@
 {1} - Restored version of platform package
 {2} - Current version of platform package</note>
       </trans-unit>
+      <trans-unit id="AssetsFileNotSet">
+        <source>ProjectAssetsFile was not set. Run a NuGet package restore to generate this file.</source>
+        <target state="new">ProjectAssetsFile was not set. Run a NuGet package restore to generate this file.</target>
+        <note>"ProjectAssetsFile" is the name of a property and parameter to the task, so it should not be translated</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
@@ -380,9 +380,9 @@
 {2} - Current version of platform package</note>
       </trans-unit>
       <trans-unit id="AssetsFileNotSet">
-        <source>ProjectAssetsFile was not set. Run a NuGet package restore to generate this file.</source>
-        <target state="new">ProjectAssetsFile was not set. Run a NuGet package restore to generate this file.</target>
-        <note>"ProjectAssetsFile" is the name of a property and parameter to the task, so it should not be translated</note>
+        <source>The path to the project assets file was not set. Run a NuGet package restore to generate this file.</source>
+        <target state="new">The path to the project assets file was not set. Run a NuGet package restore to generate this file.</target>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
@@ -379,6 +379,11 @@
 {1} - Restored version of platform package
 {2} - Current version of platform package</note>
       </trans-unit>
+      <trans-unit id="AssetsFileNotSet">
+        <source>ProjectAssetsFile was not set. Run a NuGet package restore to generate this file.</source>
+        <target state="new">ProjectAssetsFile was not set. Run a NuGet package restore to generate this file.</target>
+        <note>"ProjectAssetsFile" is the name of a property and parameter to the task, so it should not be translated</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
@@ -380,9 +380,9 @@
 {2} - Current version of platform package</note>
       </trans-unit>
       <trans-unit id="AssetsFileNotSet">
-        <source>ProjectAssetsFile was not set. Run a NuGet package restore to generate this file.</source>
-        <target state="new">ProjectAssetsFile was not set. Run a NuGet package restore to generate this file.</target>
-        <note>"ProjectAssetsFile" is the name of a property and parameter to the task, so it should not be translated</note>
+        <source>The path to the project assets file was not set. Run a NuGet package restore to generate this file.</source>
+        <target state="new">The path to the project assets file was not set. Run a NuGet package restore to generate this file.</target>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
@@ -379,6 +379,11 @@
 {1} - Restored version of platform package
 {2} - Current version of platform package</note>
       </trans-unit>
+      <trans-unit id="AssetsFileNotSet">
+        <source>ProjectAssetsFile was not set. Run a NuGet package restore to generate this file.</source>
+        <target state="new">ProjectAssetsFile was not set. Run a NuGet package restore to generate this file.</target>
+        <note>"ProjectAssetsFile" is the name of a property and parameter to the task, so it should not be translated</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
@@ -380,9 +380,9 @@
 {2} - Current version of platform package</note>
       </trans-unit>
       <trans-unit id="AssetsFileNotSet">
-        <source>ProjectAssetsFile was not set. Run a NuGet package restore to generate this file.</source>
-        <target state="new">ProjectAssetsFile was not set. Run a NuGet package restore to generate this file.</target>
-        <note>"ProjectAssetsFile" is the name of a property and parameter to the task, so it should not be translated</note>
+        <source>The path to the project assets file was not set. Run a NuGet package restore to generate this file.</source>
+        <target state="new">The path to the project assets file was not set. Run a NuGet package restore to generate this file.</target>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
@@ -379,6 +379,11 @@
 {1} - Restored version of platform package
 {2} - Current version of platform package</note>
       </trans-unit>
+      <trans-unit id="AssetsFileNotSet">
+        <source>ProjectAssetsFile was not set. Run a NuGet package restore to generate this file.</source>
+        <target state="new">ProjectAssetsFile was not set. Run a NuGet package restore to generate this file.</target>
+        <note>"ProjectAssetsFile" is the name of a property and parameter to the task, so it should not be translated</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
@@ -380,9 +380,9 @@
 {2} - Current version of platform package</note>
       </trans-unit>
       <trans-unit id="AssetsFileNotSet">
-        <source>ProjectAssetsFile was not set. Run a NuGet package restore to generate this file.</source>
-        <target state="new">ProjectAssetsFile was not set. Run a NuGet package restore to generate this file.</target>
-        <note>"ProjectAssetsFile" is the name of a property and parameter to the task, so it should not be translated</note>
+        <source>The path to the project assets file was not set. Run a NuGet package restore to generate this file.</source>
+        <target state="new">The path to the project assets file was not set. Run a NuGet package restore to generate this file.</target>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
@@ -379,6 +379,11 @@
 {1} - Restored version of platform package
 {2} - Current version of platform package</note>
       </trans-unit>
+      <trans-unit id="AssetsFileNotSet">
+        <source>ProjectAssetsFile was not set. Run a NuGet package restore to generate this file.</source>
+        <target state="new">ProjectAssetsFile was not set. Run a NuGet package restore to generate this file.</target>
+        <note>"ProjectAssetsFile" is the name of a property and parameter to the task, so it should not be translated</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
@@ -380,9 +380,9 @@
 {2} - Current version of platform package</note>
       </trans-unit>
       <trans-unit id="AssetsFileNotSet">
-        <source>ProjectAssetsFile was not set. Run a NuGet package restore to generate this file.</source>
-        <target state="new">ProjectAssetsFile was not set. Run a NuGet package restore to generate this file.</target>
-        <note>"ProjectAssetsFile" is the name of a property and parameter to the task, so it should not be translated</note>
+        <source>The path to the project assets file was not set. Run a NuGet package restore to generate this file.</source>
+        <target state="new">The path to the project assets file was not set. Run a NuGet package restore to generate this file.</target>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
@@ -379,6 +379,11 @@
 {1} - Restored version of platform package
 {2} - Current version of platform package</note>
       </trans-unit>
+      <trans-unit id="AssetsFileNotSet">
+        <source>ProjectAssetsFile was not set. Run a NuGet package restore to generate this file.</source>
+        <target state="new">ProjectAssetsFile was not set. Run a NuGet package restore to generate this file.</target>
+        <note>"ProjectAssetsFile" is the name of a property and parameter to the task, so it should not be translated</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
@@ -380,9 +380,9 @@
 {2} - Current version of platform package</note>
       </trans-unit>
       <trans-unit id="AssetsFileNotSet">
-        <source>ProjectAssetsFile was not set. Run a NuGet package restore to generate this file.</source>
-        <target state="new">ProjectAssetsFile was not set. Run a NuGet package restore to generate this file.</target>
-        <note>"ProjectAssetsFile" is the name of a property and parameter to the task, so it should not be translated</note>
+        <source>The path to the project assets file was not set. Run a NuGet package restore to generate this file.</source>
+        <target state="new">The path to the project assets file was not set. Run a NuGet package restore to generate this file.</target>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
@@ -379,6 +379,11 @@
 {1} - Restored version of platform package
 {2} - Current version of platform package</note>
       </trans-unit>
+      <trans-unit id="AssetsFileNotSet">
+        <source>ProjectAssetsFile was not set. Run a NuGet package restore to generate this file.</source>
+        <target state="new">ProjectAssetsFile was not set. Run a NuGet package restore to generate this file.</target>
+        <note>"ProjectAssetsFile" is the name of a property and parameter to the task, so it should not be translated</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
@@ -380,9 +380,9 @@
 {2} - Current version of platform package</note>
       </trans-unit>
       <trans-unit id="AssetsFileNotSet">
-        <source>ProjectAssetsFile was not set. Run a NuGet package restore to generate this file.</source>
-        <target state="new">ProjectAssetsFile was not set. Run a NuGet package restore to generate this file.</target>
-        <note>"ProjectAssetsFile" is the name of a property and parameter to the task, so it should not be translated</note>
+        <source>The path to the project assets file was not set. Run a NuGet package restore to generate this file.</source>
+        <target state="new">The path to the project assets file was not set. Run a NuGet package restore to generate this file.</target>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
@@ -379,6 +379,11 @@
 {1} - Restored version of platform package
 {2} - Current version of platform package</note>
       </trans-unit>
+      <trans-unit id="AssetsFileNotSet">
+        <source>ProjectAssetsFile was not set. Run a NuGet package restore to generate this file.</source>
+        <target state="new">ProjectAssetsFile was not set. Run a NuGet package restore to generate this file.</target>
+        <note>"ProjectAssetsFile" is the name of a property and parameter to the task, so it should not be translated</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
@@ -380,9 +380,9 @@
 {2} - Current version of platform package</note>
       </trans-unit>
       <trans-unit id="AssetsFileNotSet">
-        <source>ProjectAssetsFile was not set. Run a NuGet package restore to generate this file.</source>
-        <target state="new">ProjectAssetsFile was not set. Run a NuGet package restore to generate this file.</target>
-        <note>"ProjectAssetsFile" is the name of a property and parameter to the task, so it should not be translated</note>
+        <source>The path to the project assets file was not set. Run a NuGet package restore to generate this file.</source>
+        <target state="new">The path to the project assets file was not set. Run a NuGet package restore to generate this file.</target>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/CheckForTargetInAssetsFile.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/CheckForTargetInAssetsFile.cs
@@ -11,7 +11,6 @@ namespace Microsoft.NET.Build.Tasks
 {
     public class CheckForTargetInAssetsFile : TaskBase
     {
-        [Required]
         public string AssetsFilePath { get; set; }
 
         [Required]

--- a/src/Tasks/Microsoft.NET.Build.Tasks/FilterResolvedFiles.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/FilterResolvedFiles.cs
@@ -19,7 +19,6 @@ namespace Microsoft.NET.Build.Tasks
         private readonly List<ITaskItem> _assembliesToPublish = new List<ITaskItem>();
         private readonly List<ITaskItem> _packagesResolved = new List<ITaskItem>();
 
-        [Required]
         public string AssetsFilePath { get; set; }
 
         [Required]

--- a/src/Tasks/Microsoft.NET.Build.Tasks/GenerateDepsFile.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/GenerateDepsFile.cs
@@ -23,7 +23,6 @@ namespace Microsoft.NET.Build.Tasks
         [Required]
         public string ProjectPath { get; set; }
 
-        [Required]
         public string AssetsFilePath { get; set; }
 
         [Required]

--- a/src/Tasks/Microsoft.NET.Build.Tasks/GenerateRuntimeConfigurationFiles.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/GenerateRuntimeConfigurationFiles.cs
@@ -21,7 +21,6 @@ namespace Microsoft.NET.Build.Tasks
     /// </summary>
     public class GenerateRuntimeConfigurationFiles : TaskBase
     {
-        [Required]
         public string AssetsFilePath { get; set; }
 
         [Required]

--- a/src/Tasks/Microsoft.NET.Build.Tasks/LoadAssetsFile.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/LoadAssetsFile.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.NET.Build.Tasks
+{
+    public sealed class LoadAssetsFile : TaskBase
+    {
+        /// <summary>
+        /// The assets file to process
+        /// </summary>
+        public string ProjectAssetsFile
+        {
+            get; set;
+        }
+
+        protected override void ExecuteCore()
+        {
+            var lockFile = new LockFileCache(this).GetLockFile(ProjectAssetsFile);
+        }
+    }
+}

--- a/src/Tasks/Microsoft.NET.Build.Tasks/LockFileCache.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/LockFileCache.cs
@@ -24,6 +24,10 @@ namespace Microsoft.NET.Build.Tasks
 
         public LockFile GetLockFile(string path)
         {
+            if (string.IsNullOrEmpty(path))
+            {
+                throw new BuildErrorException(Strings.AssetsFileNotSet);
+            }
             if (!Path.IsPathRooted(path))
             {
                 throw new BuildErrorException(Strings.AssetsFilePathNotRooted, path);

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ReportAssetsLogMessages.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ReportAssetsLogMessages.cs
@@ -30,7 +30,6 @@ namespace Microsoft.NET.Build.Tasks
         /// <summary>
         /// The assets file to process
         /// </summary>
-        [Required]
         public string ProjectAssetsFile
         {
             get; set;

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageAssets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageAssets.cs
@@ -28,7 +28,6 @@ namespace Microsoft.NET.Build.Tasks
         /// <summary>
         /// Path to assets.json.
         /// </summary>
-        [Required]
         public string ProjectAssetsFile { get; set; }
 
         /// <summary>
@@ -225,6 +224,11 @@ namespace Microsoft.NET.Build.Tasks
 
         protected override void ExecuteCore()
         {
+            if (string.IsNullOrEmpty(ProjectAssetsFile))
+            {
+                throw new BuildErrorException(Strings.AssetsFileNotSet);
+            }
+
             ReadItemGroups();
             SetImplicitMetadataForCompileTimeAssemblies();
             SetImplicitMetadataForFrameworkAssemblies();

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageAssets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageAssets.cs
@@ -321,7 +321,7 @@ namespace Microsoft.NET.Build.Tasks
                     writer.Write(MarkPackageReferencesAsExternallyResolved);
                     writer.Write(ImplicitPlatformPackageIdentifier ?? "");
                     writer.Write(ProjectAssetsCacheFile);
-                    writer.Write(ProjectAssetsFile);
+                    writer.Write(ProjectAssetsFile ?? "");
                     writer.Write(ProjectLanguage ?? "");
                     writer.Write(ProjectPath);
                     writer.Write(RuntimeIdentifier ?? "");

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageDependencies.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageDependencies.cs
@@ -93,7 +93,6 @@ namespace Microsoft.NET.Build.Tasks
         /// <summary>
         /// The assets file to process
         /// </summary>
-        [Required]
         public string ProjectAssetsFile
         {
             get; set;

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePublishAssemblies.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePublishAssemblies.cs
@@ -20,7 +20,6 @@ namespace Microsoft.NET.Build.Tasks
         [Required]
         public string ProjectPath { get; set; }
 
-        [Required]
         public string AssetsFilePath { get; set; }
 
         [Required]

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.PackageDependencyResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.PackageDependencyResolution.targets
@@ -23,18 +23,12 @@ Copyright (c) .NET Foundation. All rights reserved.
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
   </PropertyGroup>
 
-  <!-- Project Assets File -->
   <PropertyGroup>
-    <ProjectAssetsFile Condition="'$(ProjectAssetsFile)' == ''">$(BaseIntermediateOutputPath)/project.assets.json</ProjectAssetsFile>
-    <ProjectAssetsFile>$([MSBuild]::NormalizePath($(MSBuildProjectDirectory), $(ProjectAssetsFile)))</ProjectAssetsFile>
-
     <!-- Note that the assets.cache file has contents that are unique to the current TFM and configuration and therefore cannot
          be stored in a shared directory next to the assets.json file -->
     <ProjectAssetsCacheFile Condition="'$(ProjectAssetsCacheFile)' == ''">$(IntermediateOutputPath)$(MSBuildProjectName).assets.cache</ProjectAssetsCacheFile>
     <ProjectAssetsCacheFile>$([MSBuild]::NormalizePath($(MSBuildProjectDirectory), $(ProjectAssetsCacheFile)))</ProjectAssetsCacheFile>
-  </PropertyGroup>
-
-  <PropertyGroup>
+    
     <ResolvePackageDependenciesForBuild Condition="'$(ResolvePackageDependenciesForBuild)' == ''">true</ResolvePackageDependenciesForBuild>
     <CopyLocalLockFileAssemblies Condition="'$(CopyLocalLockFileAssemblies)' == ''">true</CopyLocalLockFileAssemblies>
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.PackageDependencyResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.PackageDependencyResolution.targets
@@ -29,7 +29,6 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ProjectAssetsCacheFile Condition="'$(ProjectAssetsCacheFile)' == ''">$(IntermediateOutputPath)$(MSBuildProjectName).assets.cache</ProjectAssetsCacheFile>
     <ProjectAssetsCacheFile>$([MSBuild]::NormalizePath($(MSBuildProjectDirectory), $(ProjectAssetsCacheFile)))</ProjectAssetsCacheFile>
     
-    <ResolvePackageDependenciesForBuild Condition="'$(ResolvePackageDependenciesForBuild)' == ''">true</ResolvePackageDependenciesForBuild>
     <CopyLocalLockFileAssemblies Condition="'$(CopyLocalLockFileAssemblies)' == ''">true</CopyLocalLockFileAssemblies>
 
     <ContentPreprocessorOutputDirectory Condition="'$(ContentPreprocessorOutputDirectory)' == ''">$(IntermediateOutputPath)NuGet\</ContentPreprocessorOutputDirectory>
@@ -124,7 +123,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     </ResolvePackageDependenciesForBuildDependsOn>
   </PropertyGroup>
   <Target Name="ResolvePackageDependenciesForBuild"
-          Condition="'$(ResolvePackageDependenciesForBuild)' == 'true' and Exists('$(ProjectAssetsFile)')"
+          Condition=" '$(DesignTimeBuild)' != 'true' Or Exists('$(ProjectAssetsFile)')"
           BeforeTargets="AssignProjectConfiguration"
           DependsOnTargets="$(ResolvePackageDependenciesForBuildDependsOn)" />
 
@@ -364,6 +363,8 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <UsingTask TaskName="Microsoft.NET.Build.Tasks.ReportAssetsLogMessages"
              AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
+  <UsingTask TaskName="Microsoft.NET.Build.Tasks.LoadAssetsFile"
+             AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
 
   <!-- The condition on this target causes it to be skipped during design-time builds if
         the restore operation hasn't run yet.  This is to avoid displaying an error in
@@ -372,6 +373,10 @@ Copyright (c) .NET Foundation. All rights reserved.
   <Target Name="ReportAssetsLogMessages"
           Condition="'$(EmitAssetsLogMessages)' == 'true' And ('$(DesignTimeBuild)' != 'true' Or Exists('$(ProjectAssetsFile)'))">
 
+    <!-- Load the assets file in a separate task, so that if the file itself can't be loaded (or isn't set), we
+         can generate an error without continuing (since ReportAssetsLogMessages uses ContinueOnError="ErrorAndContinue" -->
+    <LoadAssetsFile ProjectAssetsFile="$(ProjectAssetsFile)" />
+    
     <ReportAssetsLogMessages
       ProjectAssetsFile="$(ProjectAssetsFile)"
       ContinueOnError="ErrorAndContinue">

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatAProjectHasntBeenRestored.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatAProjectHasntBeenRestored.cs
@@ -1,0 +1,94 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using FluentAssertions;
+using Microsoft.NET.Build.Tasks;
+using Microsoft.NET.TestFramework;
+using Microsoft.NET.TestFramework.Assertions;
+using Microsoft.NET.TestFramework.Commands;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.NET.Build.Tests
+{
+    public class GivenThatAProjectHasntBeenRestored : SdkTest
+    {
+        public GivenThatAProjectHasntBeenRestored(ITestOutputHelper log) : base(log)
+        {
+        }
+
+        [Theory]
+        [InlineData("TestLibrary")]
+        [InlineData("TestApp")]
+        public void The_build_fails_if_nuget_restore_has_not_occurred(string relativeProjectPath)
+        {
+            var testAsset = _testAssetsManager
+                .CopyTestAsset("AppWithLibrary")
+                .WithSource();
+
+            var projectDirectory = Path.Combine(testAsset.TestRoot, relativeProjectPath);
+
+            VerifyNotRestoredFailure(projectDirectory);
+        }
+
+        private void VerifyNotRestoredFailure(string projectDirectory)
+        {
+            var buildCommand = new BuildCommand(Log, projectDirectory);
+
+            var expectedError = Strings.AssetsFileNotSet;
+
+            buildCommand
+                //  Pass "/clp:summary" so that we can check output for string "1 Error(s)"
+                .Execute("/clp:summary")
+                .Should()
+                .Fail()
+                .And.HaveStdOutContaining(expectedError)
+                //  We should only get one error
+                .And.HaveStdOutContaining("1 Error(s)");
+        }
+
+        [Theory]
+        [InlineData("TestLibrary")]
+        [InlineData("TestApp")]
+        public void The_design_time_build_succeeds_before_nuget_restore(string relativeProjectPath)
+        {
+            //  This test needs the design-time targets, which come with Visual Studio.  So we will use the VSINSTALLDIR
+            //  environment variable to find the install path to Visual Studio and the design-time targets under it.
+            //  This will be set when running from a developer command prompt.  Unfortunately, unless VS is launched
+            //  from a developer command prompt, it won't be set when running tests from VS.  So in that case the
+            //  test will simply be skipped.
+            string vsInstallDir = Environment.GetEnvironmentVariable("VSINSTALLDIR");
+
+            if (vsInstallDir == null)
+            {
+                return;
+            }
+
+            string csharpDesignTimeTargets = Path.Combine(vsInstallDir, @"MSBuild\Microsoft\VisualStudio\Managed\Microsoft.CSharp.DesignTime.targets");
+
+            var testAsset = _testAssetsManager
+                .CopyTestAsset("AppWithLibrary")
+                .WithSource();
+
+            var projectDirectory = Path.Combine(testAsset.TestRoot, relativeProjectPath);
+
+            var args = new[]
+            {
+                "/p:DesignTimeBuild=true",
+                "/p:SkipCompilerExecution=true",
+                "/p:ProvideCommandLineArgs=true",
+                $"/p:CSharpDesignTimeTargetsPath={csharpDesignTimeTargets}",
+                "/t:ResolveProjectReferencesDesignTime",
+                "/t:ResolveComReferencesDesignTime",
+                "/t:CompileDesignTime",
+                "/t:ResolvePackageDependenciesDesignTime"
+            };
+
+            var command = new MSBuildCommand(Log, "ResolveAssemblyReferencesDesignTime", projectDirectory);
+            var result = command.Execute(args);
+
+            result.Should().Pass();
+        }
+    }
+}

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantDiagnosticsWhenAssetsFileCannotBeRead.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantDiagnosticsWhenAssetsFileCannotBeRead.cs
@@ -4,6 +4,7 @@
 using System.IO;
 using System.Text.RegularExpressions;
 using FluentAssertions;
+using Microsoft.NET.Build.Tasks;
 using Microsoft.NET.TestFramework;
 using Microsoft.NET.TestFramework.Assertions;
 using Microsoft.NET.TestFramework.Commands;
@@ -36,9 +37,8 @@ namespace Microsoft.NET.Build.Tests
         {
             var testAsset = _testAssetsManager.CopyTestAsset("HelloWorld").WithSource();
             var build = new BuildCommand(Log, testAsset.TestRoot);
-            var assetsFile = Path.Combine(build.GetBaseIntermediateDirectory().FullName, "project.assets.json");
 
-            build.Execute().Should().Fail().And.HaveStdOutContaining(assetsFile);
+            build.Execute().Should().Fail().And.HaveStdOutContaining(Strings.AssetsFileNotSet);
         }
 
         [Fact]

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildALibrary.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildALibrary.cs
@@ -19,6 +19,7 @@ using Microsoft.NET.TestFramework.ProjectConstruction;
 using NuGet.ProjectModel;
 using NuGet.Common;
 using Newtonsoft.Json.Linq;
+using Microsoft.NET.Build.Tasks;
 
 namespace Microsoft.NET.Build.Tests
 {
@@ -339,72 +340,6 @@ namespace Microsoft.NET.Build.Tests
                 $"Helper.{language}",
                 $"TestLibrary.{language}proj"
             }, SearchOption.TopDirectoryOnly);
-        }
-
-        [Fact]
-        public void The_design_time_build_succeeds_before_nuget_restore()
-        {
-            //  This test needs the design-time targets, which come with Visual Studio.  So we will use the VSINSTALLDIR
-            //  environment variable to find the install path to Visual Studio and the design-time targets under it.
-            //  This will be set when running from a developer command prompt.  Unfortunately, unless VS is launched
-            //  from a developer command prompt, it won't be set when running tests from VS.  So in that case the
-            //  test will simply be skipped.
-            string vsInstallDir = Environment.GetEnvironmentVariable("VSINSTALLDIR");
-            
-            if (vsInstallDir == null)
-            {
-                return;
-            }
-
-            string csharpDesignTimeTargets = Path.Combine(vsInstallDir, @"MSBuild\Microsoft\VisualStudio\Managed\Microsoft.CSharp.DesignTime.targets");
-
-            var testAsset = _testAssetsManager
-                .CopyTestAsset("AppWithLibrary")
-                .WithSource();
-
-            var libraryProjectDirectory = Path.Combine(testAsset.TestRoot, "TestLibrary");
-            var projectFile = Path.Combine(libraryProjectDirectory, "TestLibrary.csproj");
-
-            var args = new[]
-            {
-                "/p:DesignTimeBuild=true",
-                "/p:SkipCompilerExecution=true",
-                "/p:ProvideCommandLineArgs=true",
-                $"/p:CSharpDesignTimeTargetsPath={csharpDesignTimeTargets}",
-                "/t:ResolveProjectReferencesDesignTime",
-                "/t:ResolveComReferencesDesignTime",
-                "/t:CompileDesignTime",
-                "/t:ResolvePackageDependenciesDesignTime"
-            };
-
-            var command = new MSBuildCommand(Log, "ResolveAssemblyReferencesDesignTime", projectFile);
-            var result = command.Execute(args);
-
-            //  In CI builds, VSINSTALLDIR is set but the CompileDesignTime target doesn't exist, probably because
-            //  it's an earlier version of Visual Studio
-            if (result.ExitCode != 0)
-            {
-                result
-                    .StdOut
-                    .Should()
-                    .Contain("The target \"CompileDesignTime\" does not exist");
-            }
-        }
-
-        [Fact]
-        public void The_build_fails_if_nuget_restore_has_not_occurred()
-        {
-            var testAsset = _testAssetsManager
-                .CopyTestAsset("AppWithLibrary")
-                .WithSource();
-
-            var libraryProjectDirectory = Path.Combine(testAsset.TestRoot, "TestLibrary");
-
-            var buildCommand = new BuildCommand(Log, libraryProjectDirectory);
-            buildCommand
-                .Execute()
-                .Should()
-                .Fail();
         }
 
         [Fact]


### PR DESCRIPTION
Resolves #1486 
Resolves #1438, and #1057 (it doesn't enable the scenario, but does fix the SDK's piece)

NuGet sets the `ProjectAssetsFile` property in the `.g.props` file it generates, so this property should already be set by the time we would get to the code this PR removes.

TODO: Test whether this affects behavior when restore hasn't occurred.