### PR TITLE
Port fix for mismatched NuGet versions to release/2.1.1xx.

### DIFF
--- a/build/Versions.props
+++ b/build/Versions.props
@@ -32,8 +32,8 @@
     <NETStandardLibraryNETFrameworkVersion>2.0.1-servicing-26011-01</NETStandardLibraryNETFrameworkVersion>
     <NewtonsoftJsonVersion>9.0.1</NewtonsoftJsonVersion>
     <NuGetBuildTasksPackVersion>4.6.0-rtm-4918</NuGetBuildTasksPackVersion>
-    <NuGetPackagingVersion>4.5.0-preview2-4529</NuGetPackagingVersion>
-    <NuGetProjectModelVersion>4.4.0-preview3-4475</NuGetProjectModelVersion>
+    <NuGetPackagingVersion>$(NuGetBuildTasksPackVersion)</NuGetPackagingVersion>
+    <NuGetProjectModelVersion>$(NuGetBuildTasksPackVersion)</NuGetProjectModelVersion>
     <PlatformAbstractionsVersion>2.0.0</PlatformAbstractionsVersion>
     <SystemDiagnosticsFileVersionInfoVersion>4.0.0</SystemDiagnosticsFileVersionInfoVersion>
     <SystemReflectionMetadataVersion>1.4.2</SystemReflectionMetadataVersion>

--- a/src/Tests/Microsoft.NET.Restore.Tests/GivenThatWeWantToRestoreProjectsUsingNuGetConfigProperties.cs
+++ b/src/Tests/Microsoft.NET.Restore.Tests/GivenThatWeWantToRestoreProjectsUsingNuGetConfigProperties.cs
@@ -144,14 +144,15 @@ namespace Microsoft.NET.Restore.Tests
             {
                 using (var fileStream = File.OpenRead(nupkg))
                 {
-                    PackageExtractor.InstallFromSourceAsync((stream) =>
-                        fileStream.CopyToAsync(stream, 4096, CancellationToken.None),
-                        new VersionFolderPathContext(
-                            identity,
-                            nugetCache,
-                            NullLogger.Instance,
+                    PackageExtractor.InstallFromSourceAsync(
+                        identity,
+                        stream => fileStream.CopyToAsync(stream, 4096, CancellationToken.None),
+                        pathResolver,
+                        new PackageExtractionContext(
                             PackageSaveMode.Defaultv3,
-                            XmlDocFileSaveMode.None),
+                            XmlDocFileSaveMode.None,
+                            NullLogger.Instance,
+                            signedPackageVerifier: null),
                         CancellationToken.None).Wait();
                 }
             }


### PR DESCRIPTION
This commit ports the fix for the mismatched NuGet version numbers used by the
SDK.

See https://github.com/dotnet/sdk/pull/1831 for the change into master.