### PR TITLE
Speed up incremental package asset resolution

### DIFF
--- a/src/Tasks/Common/DiagnosticsHelper.cs
+++ b/src/Tasks/Common/DiagnosticsHelper.cs
@@ -14,12 +14,6 @@ namespace Microsoft.NET.Build.Tasks
     internal sealed class DiagnosticsHelper
     {
         private readonly List<ITaskItem> _diagnosticMessages = new List<ITaskItem>();
-        private readonly ILog _log;
-
-        public DiagnosticsHelper(ILog log)
-        {
-            _log = log;
-        }
 
         public ITaskItem[] GetDiagnosticMessages() => _diagnosticMessages.ToArray();
 
@@ -59,58 +53,7 @@ namespace Microsoft.NET.Build.Tasks
 
             _diagnosticMessages.Add(diagnostic);
 
-            if (logToMSBuild)
-            {
-                LogToMSBuild(diagnosticCode, message, filePath, severity, startLine, startColumn, endLine, endColumn);
-            }
-
             return diagnostic;
-        }
-
-        private void LogToMSBuild(string diagnosticCode, string message, string filePath, DiagnosticMessageSeverity severity, int startLine, int startColumn, int endLine, int endColumn)
-        {
-            switch (severity)
-            {
-                case DiagnosticMessageSeverity.Error:
-                    _log.LogError(
-                        subcategory: null,
-                        errorCode: diagnosticCode,
-                        helpKeyword: null,
-                        file: filePath,
-                        lineNumber: startLine,
-                        columnNumber: startColumn,
-                        endLineNumber: endLine,
-                        endColumnNumber: endColumn,
-                        message: message);
-                    break;
-
-                case DiagnosticMessageSeverity.Warning:
-                    _log.LogWarning(
-                        subcategory: null,
-                        warningCode: diagnosticCode,
-                        helpKeyword: null,
-                        file: filePath,
-                        lineNumber: startLine,
-                        columnNumber: startColumn,
-                        endLineNumber: endLine,
-                        endColumnNumber: endColumn,
-                        message: message);
-                    break;
-
-                case DiagnosticMessageSeverity.Info:
-                    _log.LogMessage(
-                        subcategory: null,
-                        code: diagnosticCode,
-                        helpKeyword: null,
-                        file: filePath,
-                        lineNumber: startLine,
-                        columnNumber: startColumn,
-                        endLineNumber: endLine,
-                        endColumnNumber: endColumn,
-                        importance: MessageImportance.Normal,
-                        message: message);
-                    break;
-            }
         }
     }
 }

--- a/src/Tasks/Common/DiagnosticsHelper.cs
+++ b/src/Tasks/Common/DiagnosticsHelper.cs
@@ -27,8 +27,7 @@ namespace Microsoft.NET.Build.Tasks
             int endLine,
             int endColumn,
             string targetFrameworkMoniker,
-            string packageId,
-            bool logToMSBuild = true)
+            string packageId)
         {
             string itemspec =
                 (string.IsNullOrEmpty(targetFrameworkMoniker) ? string.Empty : $"{targetFrameworkMoniker}/") +

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAResolvePackageAssetsTask.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAResolvePackageAssetsTask.cs
@@ -25,13 +25,13 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
 
             var task = new ResolvePackageAssets();
 
-            // Initialize all required properties as a genuine task invocation would. We 
-            // do this because HashSettings to defend against required parameters being null.
+            // Initialize all required properties as a genuine task invocation would. We do this
+            // because HashSettings need not defend against required parameters being null.
             foreach (var property in requiredProperties)
             {
                 property.PropertyType.Should().Be(
                     typeof(string), 
-                    because: $"this test hasn't been  updated to handle non-string required task parameters like {property.Name}");
+                    because: $"this test hasn't been updated to handle non-string required task parameters like {property.Name}");
 
                 property.SetValue(task, "_");
             }

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAResolvePackageAssetsTask.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAResolvePackageAssetsTask.cs
@@ -1,0 +1,80 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using FluentAssertions;
+using Microsoft.Build.Framework;
+using System;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+
+namespace Microsoft.NET.Build.Tasks.UnitTests
+{
+    public class GivenAResolvePackageAssetsTask
+    {
+        [Fact]
+        public void ItHashesAllParameters()
+        {
+            var inputProperties = typeof(ResolvePackageAssets)
+                .GetProperties(BindingFlags.DeclaredOnly | BindingFlags.Instance | BindingFlags.Public)
+                .Where(p => !p.IsDefined(typeof(OutputAttribute)))
+                .OrderBy(p => p.Name, StringComparer.Ordinal);
+
+            var requiredProperties = inputProperties
+                .Where(p => p.IsDefined(typeof(RequiredAttribute)));
+
+            var task = new ResolvePackageAssets();
+
+            // Initialize all required properties as a genuine task invocation would. We 
+            // do this because HashSettings to defend against required parameters being null.
+            foreach (var property in requiredProperties)
+            {
+                property.PropertyType.Should().Be(
+                    typeof(string), 
+                    because: $"this test hasn't been  updated to handle non-string required task parameters like {property.Name}");
+
+                property.SetValue(task, "_");
+            }
+
+            byte[] oldHash;
+            try
+            {
+                 oldHash = task.HashSettings();
+            }
+            catch (ArgumentNullException)
+            {
+                Assert.True(
+                    false, 
+                    "HashSettings is likely not correctly handling null value of one or more optional task parameters");
+
+                throw; // unreachable
+            }
+
+            foreach (var property in inputProperties)
+            {
+                switch (property.PropertyType)
+                {
+                    case var t when t == typeof(bool):
+                        property.SetValue(task, true);
+                        break;
+
+                    case var t when t == typeof(string):
+                        property.SetValue(task, property.Name);
+                        break;
+
+                    default:
+                        Assert.True(false, $"{property.Name} is not a bool or string. Update the test code to handle that.");
+                        throw null; // unreachable
+                }
+
+                byte[] newHash = task.HashSettings();
+                newHash.Should().NotBeEquivalentTo(
+                    oldHash, 
+                    because: $"{property.Name} should be included in hash.");
+
+                oldHash = newHash;
+            }
+        }
+    }
+}
+

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenThatWeReportAssetsLogMessages.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenThatWeReportAssetsLogMessages.cs
@@ -16,17 +16,15 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
         [Fact]
         public void ItReportsDiagnosticsWithMinimumData()
         {
-            var log = new MockLog();
             string lockFileContent = CreateDefaultLockFileSnippet(
                 logs: new string[] {
                     CreateLog(NuGetLogCode.NU1000, LogLevel.Warning, "Sample warning")
                 }
             );
 
-            var task = GetExecutedTaskFromContents(lockFileContent, log);
+            var task = GetExecutedTaskFromContents(lockFileContent);
 
             task.DiagnosticMessages.Should().HaveCount(1);
-            log.Messages.Should().HaveCount(1);
         }
 
         [Theory]
@@ -34,19 +32,16 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
         [InlineData(new object[] { new string[0] })]
         public void ItReportsZeroDiagnosticsWithNoLogs(string [] logsJson)
         {
-            var log = new MockLog();
             string lockFileContent = CreateDefaultLockFileSnippet(logsJson);
 
-            var task = GetExecutedTaskFromContents(lockFileContent, log);
+            var task = GetExecutedTaskFromContents(lockFileContent);
 
             task.DiagnosticMessages.Should().BeEmpty();
-            log.Messages.Should().BeEmpty();
         }
 
         [Fact]
         public void ItReportsDiagnosticsMetadataWithLogs()
         {
-            var log = new MockLog();
             string lockFileContent = CreateDefaultLockFileSnippet(
                 logs: new string[] {
                     CreateLog(NuGetLogCode.NU1000, LogLevel.Error, "Sample error",
@@ -59,9 +54,8 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 }
             );
 
-            var task = GetExecutedTaskFromContents(lockFileContent, log);
+            var task = GetExecutedTaskFromContents(lockFileContent);
 
-            log.Messages.Should().HaveCount(2);
             task.DiagnosticMessages.Should().HaveCount(2);
 
             Action<string,string,string> checkMetadata = (key, val1, val2) => {
@@ -85,7 +79,6 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
         [InlineData(new string[] { ".NETCoreApp,Version=v1.0" }, "LibA", ".NETCoreApp,Version=v1.0", "LibA/1.2.3")]
         public void ItReportsDiagnosticsWithAllTargetLibraryCases(string[] targetGraphs, string libraryId, string expectedTarget, string expectedPackage)
         {
-            var log = new MockLog();
             string lockFileContent = CreateDefaultLockFileSnippet(
                 logs: new string[] {
                     CreateLog(NuGetLogCode.NU1000, LogLevel.Warning, "Sample warning",
@@ -95,9 +88,8 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 }
             );
 
-            var task = GetExecutedTaskFromContents(lockFileContent, log);
+            var task = GetExecutedTaskFromContents(lockFileContent);
 
-            log.Messages.Should().HaveCount(1);
             task.DiagnosticMessages.Should().HaveCount(1);
             var item = task.DiagnosticMessages.First();
 
@@ -108,7 +100,6 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
         [Fact]
         public void ItHandlesInfoLogLevels()
         {
-            var log = new MockLog();
             string lockFileContent = CreateDefaultLockFileSnippet(
                 logs: new string[] {
                     CreateLog(NuGetLogCode.NU1000, LogLevel.Information, "Sample message"),
@@ -118,9 +109,8 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 }
             );
 
-            var task = GetExecutedTaskFromContents(lockFileContent, log);
+            var task = GetExecutedTaskFromContents(lockFileContent);
 
-            log.Messages.Should().HaveCount(4);
             task.DiagnosticMessages.Should().HaveCount(4);
 
             task.DiagnosticMessages
@@ -133,7 +123,6 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
         [InlineData(new string[] { ".NETCoreApp,Version=v1.0" }, "LibA")]
         public void ItHandlesMultiTFMScenarios(string[] targetGraphs, string libraryId)
         {
-            var log = new MockLog();
             string lockFileContent = CreateLockFileSnippet(
                 targets: new string[] {
                     CreateTarget(".NETCoreApp,Version=v1.0", TargetLibA, TargetLibB, TargetLibC),
@@ -151,13 +140,10 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 }
             );
 
-            var task = GetExecutedTaskFromContents(lockFileContent, log);
+            var task = GetExecutedTaskFromContents(lockFileContent);
 
             // a diagnostic for each target graph...
             task.DiagnosticMessages.Should().HaveCount(targetGraphs.Length);
-
-            // ...but only one is logged
-            log.Messages.Should().HaveCount(1);
 
             task.DiagnosticMessages
                     .Select(item => item.GetMetadata(MetadataKeys.ParentTarget))
@@ -171,7 +157,6 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
         [Fact]
         public void ItSkipsInvalidEntries()
         {
-            var log = new MockLog();
             string lockFileContent = CreateDefaultLockFileSnippet(
                 logs: new string[] {
                     CreateLog(NuGetLogCode.NU1000, LogLevel.Error, "Sample error that will be invalid"),
@@ -180,9 +165,8 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             );
             lockFileContent = lockFileContent.Replace("NU1000", "CA1000");
 
-            var task = GetExecutedTaskFromContents(lockFileContent, log);
+            var task = GetExecutedTaskFromContents(lockFileContent);
 
-            log.Messages.Should().HaveCount(1);
             task.DiagnosticMessages.Should().HaveCount(1);
 
             task.DiagnosticMessages
@@ -202,15 +186,15 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 logs: logs
             );
 
-        private ReportAssetsLogMessages GetExecutedTaskFromContents(string lockFileContents, MockLog logger)
+        private ReportAssetsLogMessages GetExecutedTaskFromContents(string lockFileContents)
         {
             var lockFile = TestLockFiles.CreateLockFile(lockFileContents);
-            return GetExecutedTask(lockFile, logger);
+            return GetExecutedTask(lockFile);
         }
 
-        private ReportAssetsLogMessages GetExecutedTask(LockFile lockFile, MockLog logger)
+        private ReportAssetsLogMessages GetExecutedTask(LockFile lockFile)
         {
-            var task = new ReportAssetsLogMessages(lockFile, logger)
+            var task = new ReportAssetsLogMessages(lockFile)
             {
                 ProjectAssetsFile = lockFile.Path,
             };

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ReportAssetsLogMessages.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ReportAssetsLogMessages.cs
@@ -75,7 +75,6 @@ namespace Microsoft.NET.Build.Tasks
 
         private void AddMessage(IAssetsLogMessage message)
         {
-            var logToMsBuild = true;
             var targetGraphs = message.GetTargetGraphs(LockFile);
 
             targetGraphs = targetGraphs.Any() ? targetGraphs : new LockFileTarget[] { null };
@@ -94,10 +93,7 @@ namespace Microsoft.NET.Build.Tasks
                     message.EndLineNumber,
                     message.EndColumnNumber,
                     target?.Name,
-                    targetLib == null ? null : $"{targetLib.Name}/{targetLib.Version.ToNormalizedString()}",
-                    logToMsBuild);
-
-                logToMsBuild = false; // only write first instance of this diagnostic to msbuild
+                    targetLib == null ? null : $"{targetLib.Name}/{targetLib.Version.ToNormalizedString()}");
             }
         }
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ReportAssetsLogMessages.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ReportAssetsLogMessages.cs
@@ -9,9 +9,9 @@ using System.Linq;
 namespace Microsoft.NET.Build.Tasks
 {
     /// <summary>
-    /// Report Log Messages in the assets file to MSBuild and raise them as
-    /// DiagnosticMessage items that can be consumed downstream (e.g. by the
-    /// dependency node in the solution explorer)
+    /// Raise log messages in the assets file as DiagnosticMessage items
+    /// that can be consumed downstream (e.g. by the dependency node in
+    /// the solution explorer)
     /// </summary>
     public sealed class ReportAssetsLogMessages : TaskBase
     {
@@ -40,15 +40,14 @@ namespace Microsoft.NET.Build.Tasks
 
         public ReportAssetsLogMessages()
         {
-           _diagnostics = new DiagnosticsHelper(new MSBuildLog(Log));
+           _diagnostics = new DiagnosticsHelper();
         }
 
         #region Test Support
 
-        internal ReportAssetsLogMessages(LockFile lockFile, ILog logger)
+        internal ReportAssetsLogMessages(LockFile lockFile) : this()
         {
             _lockFile = lockFile;
-            _diagnostics = new DiagnosticsHelper(logger);
         }
 
         #endregion

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageAssets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageAssets.cs
@@ -511,7 +511,6 @@ namespace Microsoft.NET.Build.Tasks
                 WriteItemGroup(WriteTransitiveProjectReferences);
 
                 WriteItemGroup(WriteLogMessages);
-
             }
 
             private void WriteMetadataStringTable()

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageAssets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageAssets.cs
@@ -32,7 +32,7 @@ namespace Microsoft.NET.Build.Tasks
         public string ProjectAssetsFile { get; set; }
 
         /// <summary>
-        /// Path to assets.cache file in intermediate directory.
+        /// Path to assets.cache file.
         /// </summary>
         [Required]
         public string ProjectAssetsCacheFile { get; set; }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageAssets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageAssets.cs
@@ -315,9 +315,9 @@ namespace Microsoft.NET.Build.Tasks
                         reader = OpenCacheFile(task.ProjectAssetsCacheFile, settingsHash);
                     }
                 }
-                catch (IOException)
-                {
-                }
+                catch (IOException) { }
+                catch (InvalidDataException) { }
+                catch (UnauthorizedAccessException) { }
 
                 if (reader == null)
                 {

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageAssets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageAssets.cs
@@ -277,19 +277,23 @@ namespace Microsoft.NET.Build.Tasks
             }
         }
 
-        private byte[] HashSettings()
+        internal byte[] HashSettings()
         {
             using (var stream = new MemoryStream())
             {
                 using (var writer = new BinaryWriter(stream, TextEncoding, leaveOpen: true))
                 {
-                    writer.Write(ProjectPath);
-                    writer.Write(TargetFrameworkMoniker);
-                    writer.Write(DisableTransitiveProjectReferences);
                     writer.Write(DisableFrameworkAssemblies);
+                    writer.Write(DisableTransitiveProjectReferences);
+                    writer.Write(EmitAssetsLogMessages);
+                    writer.Write(EnsureRuntimePackageDependencies);
                     writer.Write(MarkPackageReferencesAsExternallyResolved);
+                    writer.Write(ProjectAssetsCacheFile);
+                    writer.Write(ProjectAssetsFile);
                     writer.Write(ProjectLanguage ?? "");
+                    writer.Write(ProjectPath);
                     writer.Write(RuntimeIdentifier ?? "");
+                    writer.Write(TargetFrameworkMoniker);
                 }
 
                 stream.Position = 0;

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageAssets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageAssets.cs
@@ -491,7 +491,7 @@ namespace Microsoft.NET.Build.Tasks
 
             private void WriteItemGroups()
             {
-                // NOTE: Order (alphabetical by group name) must match writer.
+                // NOTE: Order (alphabetical by group name) must match reader.
                 WriteItemGroup(WriteAnalyzers);
                 WriteItemGroup(WriteCompileTimeAssemblies);
                 WriteItemGroup(WriteContentFilesToPreprocess);

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageAssets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageAssets.cs
@@ -70,12 +70,14 @@ namespace Microsoft.NET.Build.Tasks
         public bool EmitAssetsLogMessages { get; set; }
 
         /// <summary>
-        /// Indicate to MSBuild ResolveAssemblyReferences that 
+        /// Set ExternallyResolved=true metadata on reference items to indicate to MSBuild ResolveAssemblyReferences
+        /// that these are resolved by an external system (in this case nuget) and therefore several steps can be
+        /// skipped as an optimization.
         /// </summary>
         public bool MarkPackageReferencesAsExternallyResolved { get; set; }
 
         /// <summary>
-        /// Project language ($(ProjectLanguage) in common targets -"VB" or "C#" or "F#" 
+        /// Project language ($(ProjectLanguage) in common targets -"VB" or "C#" or "F#" ).
         /// Impacts applicability of analyzer assets.
         /// </summary>
         public string ProjectLanguage { get; set; }
@@ -112,9 +114,10 @@ namespace Microsoft.NET.Build.Tasks
         public ITaskItem[] FrameworkAssemblies { get; private set; }
 
         /// <summary>
-        /// Messages from the
-        /// These are logged directly and therefore not returned to the targets. ITaskItem[] is used purely
-        /// to share cache reading/writing code with the other items.
+        /// Messages from the assets file.
+        /// These are logged directly and therefore not returned to the targets as items. However,
+        /// they are stored as ITaskItem[] so that the same cache reader/writer code can be used for
+        /// message items and asset items.
         /// </summary>
         private ITaskItem[] LogMessages { get; set; }
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageAssets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageAssets.cs
@@ -3,34 +3,82 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
+using NuGet.Common;
 using NuGet.ProjectModel;
 
 namespace Microsoft.NET.Build.Tasks
 {
-    public class ResolvePackageAssets : TaskBase
+    /// <summary>
+    /// Resolve package assets from projects.assets.json into MSBuild items.
+    ///
+    /// Optimized for fast incrementality using an intermediate, binary assets.cache
+    /// file that contains only the data that is actually returned for the current
+    /// TFM/RID/etc. and written in a format that is easily decoded to ITaskItem
+    /// arrays without undue allocation.
+    /// </summary>
+    public sealed class ResolvePackageAssets : TaskBase
     {
+        /// <summary>
+        /// Path to assets.json.
+        /// </summary>
         [Required]
         public string ProjectAssetsFile { get; set; }
 
+        /// <summary>
+        /// Path to assets.cache file in intermediate directory.
+        /// </summary>
+        [Required]
+        public string ProjectAssetsCacheFile { get; set; }
+
+        /// <summary>
+        /// Path to project file (.csproj|.vbproj|.fsproj)
+        /// </summary>
         [Required]
         public string ProjectPath { get; set; }
 
-        public string ProjectLanguage { get; set; }
-
-        public bool DisableTransitiveProjectReferences { get; set; }
-
-        public bool DisableFrameworkAssemblies { get; set; }
-
+        /// <summary>
+        /// TFM to use for compile-time assets.
+        /// </summary>
         [Required]
         public string TargetFrameworkMoniker { get; set; }
 
+        /// <summary>
+        /// RID to use for runtime assets (may be empty)
+        /// </summary>
         public string RuntimeIdentifier { get; set; }
 
+        /// <summary>
+        /// Do not generate transitive project references.
+        /// </summary>
+        public bool DisableTransitiveProjectReferences { get; set; }
+
+        /// <summary>
+        /// Do not add references to framework assemblies as specified by packages.
+        /// </summary>
+        public bool DisableFrameworkAssemblies { get; set; }
+
+        /// <summary>
+        /// Log messages from assets log to build error/warning/message.
+        /// </summary>
+        public bool EmitAssetsLogMessages { get; set; }
+
+        /// <summary>
+        /// Indicate to MSBuild ResolveAssemblyReferences that 
+        /// </summary>
         public bool MarkPackageReferencesAsExternallyResolved { get; set; }
+
+        /// <summary>
+        /// Project language ($(ProjectLanguage) in common targets -"VB" or "C#" or "F#" 
+        /// Impacts applicability of analyzer assets.
+        /// </summary>
+        public string ProjectLanguage { get; set; }
 
         /// <summary>
         /// Check that there is at least one package dependency in the RID graph that is not in the RID-agnostic graph.
@@ -38,276 +86,737 @@ namespace Microsoft.NET.Build.Tasks
         /// </summary>
         public bool EnsureRuntimePackageDependencies { get; set; }
 
+        /// <summary>
+        /// Full paths to assemblies from packages to pass to compiler as analyzers.
+        /// </summary>
         [Output]
         public ITaskItem[] Analyzers { get; private set; }
 
-        [Output]
-        public ITaskItem[] ContentFilesToPreprocess { get; private set; }
-
+        /// <summary>
+        /// Full paths to assemblies from packages to compiler as references.
+        /// </summary>
         [Output]
         public ITaskItem[] CompileTimeAssemblies { get; private set; }
 
+        /// <summary>
+        /// Content files from package that require preprocessing.
+        /// Content files that do not require preprocessing are written directly to .g.props by nuget restore.
+        /// </summary>
+        [Output]
+        public ITaskItem[] ContentFilesToPreprocess { get; private set; }
+
+        /// <summary>
+        /// Simple names of framework assemblies that packages request to be added as framework references.
+        /// </summary>
         [Output]
         public ITaskItem[] FrameworkAssemblies { get; private set; }
 
+        /// <summary>
+        /// Messages from the
+        /// These are logged directly and therefore not returned to the targets. ITaskItem[] is used purely
+        /// to share cache reading/writing code with the other items.
+        /// </summary>
+        private ITaskItem[] LogMessages { get; set; }
+
+        /// <summary>
+        /// Full paths to native libraries from packages to run against.
+        /// </summary>
         [Output]
         public ITaskItem[] NativeLibraries { get; private set; }
 
+        /// <summary>
+        /// Full paths to satellite assemblies from packages.
+        /// </summary>
         [Output]
         public ITaskItem[] ResourceAssemblies { get; private set; }
 
+        /// <summary>
+        /// Full paths to managed assemblies from packages to run against.
+        /// </summary>
         [Output]
         public ITaskItem[] RuntimeAssemblies { get; private set; }
 
+        /// <summary>
+        /// Full paths to RID-specific assets that go in runtimes/ folder on publish.
+        /// </summary>
         [Output]
         public ITaskItem[] RuntimeTargets { get; private set; }
 
+        /// <summary>
+        /// Relative paths to project files that are referenced transitively (but not directly).
+        /// </summary>
         [Output]
         public ITaskItem[] TransitiveProjectReferences { get; private set; }
 
-        private NuGetPackageResolver _packageResolver;
+        ////////////////////////////////////////////////////////////////////////////////////////////////////
+        // Package Asset Cache File Format Details
+        //
+        // Encodings of Int32, Byte[], String as defined by System.IO.BinaryReader/Writer.
+        //
+        // There are 3 sections, written in the following order:
+        //
+        // 1. Header
+        // ---------
+        // Encodes format and enough information to quickly decide if cache is still valid.
+        //
+        // Header:
+        //   Int32 Signature: Spells PKGA ("package assets") when 4 little-endian bytes are interpreted as ASCII chars.
+        //   Int32 Version: Increased whenever format changes to prevent issues when building incrementally with a different SDK.
+        //   Byte[] SettingsHash: SHA-256 of settings that require the cache to be invalidated when changed.
+        //   Int32 MetadataStringTableOffset: Byte offset in file to start of the metadata string table.
+        //
+        // 2. ItemGroup[] ItemGroups
+        // --------------
+        // There is one ItemGroup for each ITaskItem[] output (Analyzers, CompileTimeAssemblies, etc.)
+        // Count and order of item groups is constant and therefore not encoded in to the file.
+        //
+        // ItemGroup:
+        //   Int32   ItemCount
+        //   Item[]  Items
+        //
+        // Item:
+        //    String      ItemSpec (not index to string table because it generally unique)
+        //    Int32       MetadataCount
+        //    Metadata[]  Metadata
+        //
+        // Metadata:
+        //    Int32 Key: Index in to MetadataStringTable for metadata key
+        //    Int32 Value: Index in to MetadataStringTable for metadata value
+        //
+        // 3. MetadataStringTable
+        // ----------------------
+        // Indexes keys and values of item metadata to compress the cache file
+        //
+        // MetadataStringTable:
+        //    Int32 MetadataStringCount
+        //    String[] MetadataStrings
+        ////////////////////////////////////////////////////////////////////////////////////////////////////
+
+        private const int CacheFormatSignature = ('P' << 0) | ('K' << 8) | ('G' << 16) | ('A' << 24);
+        private const int CacheFormatVersion = 1;
+        private static readonly Encoding TextEncoding = Encoding.UTF8;
+        private const int SettingsHashLength = 256 / 8;
+        private HashAlgorithm CreateSettingsHash() => SHA256.Create();
 
         protected override void ExecuteCore()
         {
-            var lockFile = new LockFileCache(BuildEngine4).GetLockFile(ProjectAssetsFile);
-            _packageResolver = NuGetPackageResolver.CreateResolver(lockFile, ProjectPath);
+            ReadItemGroups();
+            SetImplicitMetadataForCompileTimeAssemblies();
+            SetImplicitMetadataForFrameworkAssemblies();
+            LogMessagesToMSBuild();
+        }
 
-            var targetFramework = NuGetUtils.ParseFrameworkName(TargetFrameworkMoniker);
-            var compileTimeTarget = lockFile.GetTargetAndThrowIfNotFound(targetFramework, runtime: null);
-            var runtimeTarget = lockFile.GetTargetAndThrowIfNotFound(targetFramework, RuntimeIdentifier);
-
-            CheckRuntimePackageDependencies(compileTimeTarget, runtimeTarget);
-
-            Analyzers = RaiseAnalyzers(
-                lockFile,
-                runtimeTarget);
-
-            CompileTimeAssemblies = RaisePackageAssets(
-                compileTimeTarget,
-                package => package.CompileTimeAssemblies,
-                setup: (asset, item) =>
-                {
-                    item.SetMetadata(MetadataKeys.Private, "false");
-                    item.SetMetadata(MetadataKeys.HintPath, item.ItemSpec);
-
-                    if (MarkPackageReferencesAsExternallyResolved)
-                    {
-                        item.SetMetadata(MetadataKeys.ExternallyResolved, "true");
-                    }
-                });
-
-            if (!DisableFrameworkAssemblies)
+        private void ReadItemGroups()
+        {
+            using (var reader = new CacheReader(this))
             {
-                FrameworkAssemblies = RaiseFrameworkAssemblies(
-                    compileTimeTarget,
-                    setup: (asset, item) =>
-                     {
-                         item.SetMetadata(MetadataKeys.Pack, "false");
-                         item.SetMetadata(MetadataKeys.Private, "false");
-                         item.SetMetadata(MetadataKeys.NuGetIsFrameworkReference, "true");
-                     });
-            }
-
-            ContentFilesToPreprocess = RaisePackageAssets(
-                runtimeTarget,
-                p => p.ContentFiles,
-                filter: asset => !string.IsNullOrEmpty(asset.PPOutputPath),
-                setup: (asset, item) => 
-                {
-                    item.SetMetadata(MetadataKeys.BuildAction, asset.BuildAction.ToString());
-                    item.SetMetadata(MetadataKeys.CopyToOutput, asset.CopyToOutput.ToString());
-                    item.SetMetadata(MetadataKeys.PPOutputPath, asset.PPOutputPath);
-
-                    if (!string.IsNullOrEmpty(MetadataKeys.OutputPath))
-                    {
-                        item.SetMetadata(MetadataKeys.OutputPath, asset.OutputPath);
-                    }
-
-                    if (!string.IsNullOrEmpty(asset.CodeLanguage))
-                    {
-                        item.SetMetadata(MetadataKeys.CodeLanguage, asset.CodeLanguage);
-                    }
-                });
-
-            NativeLibraries = RaisePackageAssets(
-                runtimeTarget,
-                package => package.NativeLibraries);
-
-            ResourceAssemblies = RaisePackageAssets(
-                runtimeTarget,
-                package => package.ResourceAssemblies,
-                setup: (asset, item) =>
-                {
-                    string locale = asset.Properties["locale"];
-                    item.SetMetadata(MetadataKeys.Culture, locale);
-                    item.SetMetadata(MetadataKeys.DestinationSubDirectory, locale + Path.DirectorySeparatorChar);
-                });
-
-            RuntimeAssemblies = RaisePackageAssets(
-                runtimeTarget,
-                package => package.RuntimeAssemblies);
-
-            RuntimeTargets = RaisePackageAssets(
-                runtimeTarget,
-                package => package.RuntimeTargets,
-                setup: (asset, item) =>
-                {
-                    string directory = Path.GetDirectoryName(asset.Path);
-                    item.SetMetadata(MetadataKeys.DestinationSubDirectory, directory + Path.DirectorySeparatorChar);
-                });
-
-            if (!DisableTransitiveProjectReferences)
-            {
-                TransitiveProjectReferences = RaiseTransitiveProjectReferences(lockFile, runtimeTarget);
+                // NOTE: Order (alphabetical by group name) must match writer.
+                Analyzers = reader.ReadItemGroup();
+                CompileTimeAssemblies = reader.ReadItemGroup();
+                ContentFilesToPreprocess = reader.ReadItemGroup();
+                FrameworkAssemblies = reader.ReadItemGroup();
+                LogMessages = reader.ReadItemGroup();
+                NativeLibraries = reader.ReadItemGroup();
+                ResourceAssemblies = reader.ReadItemGroup();
+                RuntimeAssemblies = reader.ReadItemGroup();
+                RuntimeTargets = reader.ReadItemGroup();
+                TransitiveProjectReferences = reader.ReadItemGroup();
             }
         }
 
-        private ITaskItem[] RaisePackageAssets<T>(
-            LockFileTarget target, 
-            Func<LockFileTargetLibrary, IList<T>> getAssets,
-            Func<T, bool> filter = null,
-            Action<T, ITaskItem> setup = null) 
-            where T : LockFileItem
+        private void SetImplicitMetadataForCompileTimeAssemblies()
         {
-            var items = new List<ITaskItem>();
+            string externallyResolved = MarkPackageReferencesAsExternallyResolved ? "true" : "";
 
-            foreach (var library in target.Libraries)
+            foreach (var item in CompileTimeAssemblies)
             {
-                if (library.IsPackage())
+                item.SetMetadata(MetadataKeys.Private, "false");
+                item.SetMetadata(MetadataKeys.HintPath, item.ItemSpec);
+                item.SetMetadata(MetadataKeys.ExternallyResolved, externallyResolved);
+            }
+        }
+
+        private void SetImplicitMetadataForFrameworkAssemblies()
+        {
+            foreach (var item in FrameworkAssemblies)
+            {
+                item.SetMetadata(MetadataKeys.NuGetIsFrameworkReference, "true");
+                item.SetMetadata(MetadataKeys.Pack, "false");
+                item.SetMetadata(MetadataKeys.Private, "false");
+            }
+        }
+
+        private void LogMessagesToMSBuild()
+        {
+            if (!EmitAssetsLogMessages)
+            {
+                return;
+            }
+
+            foreach (var item in LogMessages)
+            {
+                string message = item.ItemSpec;
+                string severity = item.GetMetadata(MetadataKeys.Severity);
+                string code = item.GetMetadata(MetadataKeys.DiagnosticCode);
+
+                switch (severity)
                 {
-                    foreach (T asset in getAssets(library))
+                    case nameof(LogLevel.Error):
+                        Log.LogError(null, code, null, ProjectPath, 0, 0, 0, 0, message);
+                        break;
+                    case nameof(LogLevel.Warning):
+                        Log.LogWarning(null, code, null, ProjectPath, 0, 0, 0, 0, message);
+                        break;
+                    default:
+                        Log.LogMessage(null, code, null, ProjectPath, 0, 0, 0, 0, message);
+                        break;
+                }
+            }
+        }
+
+        private byte[] HashSettings()
+        {
+            using (var stream = new MemoryStream())
+            {
+                using (var writer = new BinaryWriter(stream, TextEncoding, leaveOpen: true))
+                {
+                    writer.Write(ProjectPath);
+                    writer.Write(TargetFrameworkMoniker);
+                    writer.Write(DisableTransitiveProjectReferences);
+                    writer.Write(DisableFrameworkAssemblies);
+                    writer.Write(MarkPackageReferencesAsExternallyResolved);
+                    writer.Write(ProjectLanguage ?? "");
+                    writer.Write(RuntimeIdentifier ?? "");
+                }
+
+                stream.Position = 0;
+
+                using (var hash = CreateSettingsHash())
+                {
+                    return hash.ComputeHash(stream);
+                }
+            }
+        }
+
+        private sealed class CacheReader : IDisposable
+        {
+            private BinaryReader _reader;
+            private string[] _metadataStringTable;
+
+            public CacheReader(ResolvePackageAssets task)
+            {
+                byte[] settingsHash = task.HashSettings();
+                BinaryReader reader = null;
+
+                try
+                {
+                    if (File.GetLastWriteTimeUtc(task.ProjectAssetsCacheFile) >= File.GetLastWriteTimeUtc(task.ProjectAssetsFile))
                     {
-                        if (!asset.IsPlaceholderFile() && (filter == null || filter(asset)))
+                        reader = OpenCacheFile(task.ProjectAssetsCacheFile, settingsHash);
+                    }
+                }
+                catch (IOException)
+                {
+                }
+
+                if (reader == null)
+                {
+                    using (var writer = new CacheWriter(task))
+                    {
+                        writer.Write();
+                    }
+
+                    reader = OpenCacheFile(task.ProjectAssetsCacheFile, settingsHash);
+                }
+
+                _reader = reader;
+                ReadMetadataStringTable();
+            }
+
+            private static BinaryReader OpenCacheFile(string path, byte[] settingsHash)
+            {
+                var stream = File.Open(path, FileMode.Open, FileAccess.Read, FileShare.Read);
+                var reader = new BinaryReader(stream, TextEncoding, leaveOpen: false);
+
+                try
+                {
+                    ValidateHeader(reader, settingsHash);
+                }
+                catch
+                {
+                    reader.Dispose();
+                    throw;
+                }
+
+                return reader;
+            }
+
+            private static void ValidateHeader(BinaryReader reader, byte[] settingsHash)
+            {
+                if (reader.ReadInt32() != CacheFormatSignature
+                    || reader.ReadInt32() != CacheFormatVersion
+                    || !reader.ReadBytes(SettingsHashLength).SequenceEqual(settingsHash))
+                {
+                    throw new InvalidDataException();
+                }
+            }
+
+            private void ReadMetadataStringTable()
+            {
+                int stringTablePosition = _reader.ReadInt32();
+                int savedPosition = Position;
+                Position = stringTablePosition;
+
+                _metadataStringTable = new string[_reader.ReadInt32()];
+                for (int i = 0; i < _metadataStringTable.Length; i++)
+                {
+                    _metadataStringTable[i] = _reader.ReadString();
+                }
+
+                Position = savedPosition;
+            }
+
+            private int Position
+            {
+                get => checked((int)_reader.BaseStream.Position);
+                set => _reader.BaseStream.Position = value;
+            }
+
+            public void Dispose()
+            {
+                _reader.Dispose();
+            }
+
+            internal ITaskItem[] ReadItemGroup()
+            {
+                var items = new ITaskItem[_reader.ReadInt32()];
+
+                for (int i = 0; i < items.Length; i++)
+                {
+                    items[i] = ReadItem();
+                }
+
+                return items;
+            }
+
+            private ITaskItem ReadItem()
+            {
+                var item = new TaskItem(_reader.ReadString());
+                int metadataCount = _reader.ReadInt32();
+
+                for (int i = 0; i < metadataCount; i++)
+                {
+                    string key = _metadataStringTable[_reader.ReadInt32()];
+                    string value = _metadataStringTable[_reader.ReadInt32()];
+                    item.SetMetadata(key, value);
+                }
+
+                return item;
+            }
+        }
+
+        private sealed class CacheWriter : IDisposable
+        {
+            private const int InitialStringTableCapacity = 32;
+
+            private ResolvePackageAssets _task;
+            private BinaryWriter _writer;
+            private LockFile _lockFile;
+            private NuGetPackageResolver _packageResolver;
+            private LockFileTarget _compileTimeTarget;
+            private LockFileTarget _runtimeTarget;
+            private Dictionary<string, int> _stringTable;
+            private List<string> _metadataStrings;
+            private List<int> _bufferedMetadata;
+            private Placeholder _metadataStringTablePosition;
+            private int _itemCount;
+
+            public CacheWriter(ResolvePackageAssets task)
+            {
+                var targetFramework = NuGetUtils.ParseFrameworkName(task.TargetFrameworkMoniker);
+
+                _task = task;
+                _lockFile = new LockFileCache(task.BuildEngine4).GetLockFile(task.ProjectAssetsFile);
+                _packageResolver = NuGetPackageResolver.CreateResolver(_lockFile, _task.ProjectPath);
+                _compileTimeTarget = _lockFile.GetTargetAndThrowIfNotFound(targetFramework, runtime: null);
+                _runtimeTarget = _lockFile.GetTargetAndThrowIfNotFound(targetFramework, _task.RuntimeIdentifier);
+                _stringTable = new Dictionary<string, int>(InitialStringTableCapacity, StringComparer.Ordinal);
+                _metadataStrings = new List<string>(InitialStringTableCapacity);
+                _bufferedMetadata = new List<int>();
+
+                Directory.CreateDirectory(Path.GetDirectoryName(task.ProjectAssetsCacheFile));
+                var stream = File.Open(task.ProjectAssetsCacheFile, FileMode.Create, FileAccess.ReadWrite, FileShare.None);
+                _writer = new BinaryWriter(stream, TextEncoding, leaveOpen: false);
+            }
+
+            public void Dispose()
+            {
+                _writer.Dispose();
+            }
+
+            private void FlushMetadata()
+            {
+                if (_itemCount == 0)
+                {
+                    return;
+                }
+
+                Debug.Assert((_bufferedMetadata.Count % 2) == 0);
+
+                _writer.Write(_bufferedMetadata.Count / 2);
+
+                foreach (int m in _bufferedMetadata)
+                {
+                    _writer.Write(m);
+                }
+
+                _bufferedMetadata.Clear();
+            }
+
+            public void Write()
+            {
+                WriteHeader();
+                WriteItemGroups();
+                WriteMetadataStringTable();
+            }
+
+            private void WriteHeader()
+            {
+                _writer.Write(CacheFormatSignature);
+                _writer.Write(CacheFormatVersion);
+
+                byte[] hash = _task.HashSettings();
+                _writer.Write(_task.HashSettings());
+                _metadataStringTablePosition = WritePlaceholder();
+            }
+
+            private void WriteItemGroups()
+            {
+                // NOTE: Order (alphabetical by group name) must match writer.
+                WriteItemGroup(WriteAnalyzers);
+                WriteItemGroup(WriteCompileTimeAssemblies);
+                WriteItemGroup(WriteContentFilesToPreprocess);
+                WriteItemGroup(WriteFrameworkAssemblies);
+                WriteItemGroup(WriteLogMessages);
+                WriteItemGroup(WriteNativeLibraries);
+                WriteItemGroup(WriteResourceAssemblies);
+                WriteItemGroup(WriteRuntimeAssemblies);
+                WriteItemGroup(WriteRuntimeTargets);
+                WriteItemGroup(WriteTransitiveProjectReferences);
+            }
+
+            private void WriteMetadataStringTable()
+            {
+                int savedPosition = Position;
+
+                _writer.Write(_metadataStrings.Count);
+
+                foreach (var s in _metadataStrings)
+                {
+                    _writer.Write(s);
+                }
+
+                WriteToPlaceholder(_metadataStringTablePosition, savedPosition);
+            }
+
+            private int Position
+            {
+                get => checked((int)_writer.BaseStream.Position);
+                set => _writer.BaseStream.Position = value;
+            }
+
+            private struct Placeholder
+            {
+                public readonly int Position;
+                public Placeholder(int position) { Position = position; }
+            }
+
+            private Placeholder WritePlaceholder()
+            {
+                var placeholder = new Placeholder(Position);
+                _writer.Write(int.MinValue);
+                return placeholder;
+            }
+
+            private void WriteToPlaceholder(Placeholder placeholder, int value)
+            {
+                int savedPosition = Position;
+                Position = placeholder.Position;
+                _writer.Write(value);
+                Position = savedPosition;
+            }
+
+            private void WriteAnalyzers()
+            {
+                Dictionary<string, LockFileTargetLibrary> targetLibraries = null;
+
+                foreach (var library in _lockFile.Libraries)
+                {
+                    if (!library.IsPackage())
+                    {
+                        continue;
+                    }
+
+                    foreach (var file in library.Files)
+                    {
+                        if (!NuGetUtils.IsApplicableAnalyzer(file, _task.ProjectLanguage))
                         {
-                            var item = CreatePackageAssetItem(library, ResolvePackageAssetPath(library, asset.Path));
-                            setup?.Invoke(asset, item);
-                            items.Add(item);
+                            continue;
+                        }
+
+                        if (targetLibraries == null)
+                        {
+                            targetLibraries = _runtimeTarget
+                                .Libraries
+                                .ToDictionary(l => l.Name, StringComparer.OrdinalIgnoreCase);
+                        }
+
+                        if (targetLibraries.TryGetValue(library.Name, out var targetLibrary))
+                        {
+                            WriteItem(ResolvePackageAssetPath(targetLibrary, file), targetLibrary);
                         }
                     }
                 }
             }
 
-            return items.ToArray();
-        }
-
-        private static ITaskItem[] RaiseFrameworkAssemblies(LockFileTarget target, Action<string, ITaskItem> setup)
-        {
-            var items = new List<ITaskItem>();
-
-            foreach (var library in target.Libraries)
+            private void WriteItemGroup(Action writeItems)
             {
-                if (library.IsPackage())
+                var placeholder = WritePlaceholder();
+                _itemCount = 0;
+                writeItems();
+                FlushMetadata();
+                WriteToPlaceholder(placeholder, _itemCount);
+            }
+
+            private void WriteCompileTimeAssemblies()
+            {
+                WriteItems(
+                    _compileTimeTarget,
+                    package => package.CompileTimeAssemblies);
+            }
+
+            private void WriteContentFilesToPreprocess()
+            {
+
+                WriteItems(
+                    _runtimeTarget,
+                    p => p.ContentFiles,
+                    filter: asset => !string.IsNullOrEmpty(asset.PPOutputPath),
+                    writeMetadata: asset =>
+                    {
+                        WriteMetadata(MetadataKeys.BuildAction, asset.BuildAction.ToString());
+                        WriteMetadata(MetadataKeys.CopyToOutput, asset.CopyToOutput.ToString());
+                        WriteMetadata(MetadataKeys.PPOutputPath, asset.PPOutputPath);
+                        WriteMetadata(MetadataKeys.OutputPath, asset.OutputPath);
+                        WriteMetadata(MetadataKeys.CodeLanguage, asset.CodeLanguage);
+                    });
+            }
+
+            private void WriteFrameworkAssemblies()
+            {
+                if (_task.DisableFrameworkAssemblies)
                 {
+                    return;
+                }
+
+                foreach (var library in _compileTimeTarget.Libraries)
+                {
+                    if (!library.IsPackage())
+                    {
+                        continue;
+                    }
+
                     foreach (string frameworkAssembly in library.FrameworkAssemblies)
                     {
-                        var item = CreatePackageAssetItem(library, frameworkAssembly);
-                        items.Add(item);
-                        setup?.Invoke(frameworkAssembly, item);
+                        WriteItem(frameworkAssembly, library);
                     }
                 }
             }
 
-            return items.ToArray();
-        }
-
-        private ITaskItem[] RaiseTransitiveProjectReferences(LockFile lockFile, LockFileTarget target)
-        {
-            var items = new List<ITaskItem>();
-
-            Dictionary<string, string> projectReferencePaths = null;
-            HashSet<string> directProjectDependencies = null;
-
-            foreach (var library in target.Libraries)
+            private void WriteLogMessages()
             {
-                if (library.IsTransitiveProjectReference(lockFile, ref directProjectDependencies))
+                string GetSeverity(LogLevel level)
                 {
+                    switch (level)
+                    {
+                        case LogLevel.Warning: return nameof(LogLevel.Warning);
+                        case LogLevel.Error: return nameof(LogLevel.Error);
+                        default: return ""; // treated as info
+                    }
+                }
+
+                foreach (var message in _lockFile.LogMessages)
+                {
+                    WriteItem(message.Message);
+                    WriteMetadata(MetadataKeys.DiagnosticCode, message.Code.ToString());
+                    WriteMetadata(MetadataKeys.Severity, GetSeverity(message.Level));
+                }
+
+                if (_task.EnsureRuntimePackageDependencies && !string.IsNullOrEmpty(_task.RuntimeIdentifier))
+                {
+                    if (_compileTimeTarget.Libraries.Count >= _runtimeTarget.Libraries.Count)
+                    {
+                        WriteItem(string.Format(Strings.UnsupportedRuntimeIdentifier, _task.RuntimeIdentifier));
+                        WriteMetadata(MetadataKeys.Severity, nameof(LogLevel.Error));
+                    }
+                }
+            }
+
+            private void WriteNativeLibraries()
+            {
+                WriteItems(
+                    _runtimeTarget,
+                    package => package.NativeLibraries);
+            }
+
+            private void WriteResourceAssemblies()
+            {
+                WriteItems(
+                    _runtimeTarget,
+                    package => package.ResourceAssemblies,
+                    writeMetadata: asset =>
+                    {
+                        string locale = asset.Properties["locale"];
+                        WriteMetadata(MetadataKeys.Culture, locale);
+                        WriteMetadata(MetadataKeys.DestinationSubDirectory, locale + Path.DirectorySeparatorChar);
+                    });
+            }
+
+            private void WriteRuntimeAssemblies()
+            {
+                WriteItems(
+                    _runtimeTarget,
+                    package => package.RuntimeAssemblies);
+            }
+
+            private void WriteRuntimeTargets()
+            {
+                WriteItems(
+                    _runtimeTarget,
+                    package => package.RuntimeTargets,
+                    writeMetadata: asset =>
+                    {
+                        string directory = Path.GetDirectoryName(asset.Path);
+                        WriteMetadata(MetadataKeys.DestinationSubDirectory, directory + Path.DirectorySeparatorChar);
+                    });
+            }
+
+            private void WriteTransitiveProjectReferences()
+            {
+                if (_task.DisableTransitiveProjectReferences)
+                {
+                    return;
+                }
+
+                Dictionary<string, string> projectReferencePaths = null;
+                HashSet<string> directProjectDependencies = null;
+
+                foreach (var library in _runtimeTarget.Libraries)
+                {
+                    if (!library.IsTransitiveProjectReference(_lockFile, ref directProjectDependencies))
+                    {
+                        continue;
+                    }
+
                     if (projectReferencePaths == null)
                     {
-                        projectReferencePaths = GetProjectReferencePaths(lockFile);
+                        projectReferencePaths = GetProjectReferencePaths(_lockFile);
                     }
 
                     if (!directProjectDependencies.Contains(library.Name))
                     {
-                        items.Add(new TaskItem(projectReferencePaths[library.Name]));
+                        WriteItem(projectReferencePaths[library.Name], library);
                     }
                 }
             }
 
-            return items.ToArray();
-        }
-
-        private ITaskItem[] RaiseAnalyzers(LockFile lockFile, LockFileTarget target)
-        {
-            var items = new List<ITaskItem>();
-            Dictionary<string, LockFileTargetLibrary> targetLibraries = null;
-
-            foreach (var library in lockFile.Libraries)
+            private void WriteItems<T>(
+                LockFileTarget target,
+                Func<LockFileTargetLibrary, IList<T>> getAssets,
+                Func<T, bool> filter = null,
+                Action<T> writeMetadata = null)
+                where T : LockFileItem
             {
-                if (library.IsPackage())
+                foreach (var library in target.Libraries)
                 {
-                    foreach (var file in library.Files)
+                    if (!library.IsPackage())
                     {
-                        if (NuGetUtils.IsApplicableAnalyzer(file, ProjectLanguage))
-                        {
-                            if (targetLibraries == null)
-                            {
-                                targetLibraries = target.Libraries.ToDictionary(l => l.Name, StringComparer.OrdinalIgnoreCase);
-                            }
+                        continue;
+                    }
 
-                            if (targetLibraries.TryGetValue(library.Name, out var targetLibrary))
-                            {
-                                items.Add(CreatePackageAssetItem(targetLibrary, ResolvePackageAssetPath(targetLibrary, file)));
-                            }
+                    foreach (T asset in getAssets(library))
+                    {
+                        if (asset.IsPlaceholderFile() || (filter != null && !filter.Invoke(asset)))
+                        {
+                            continue;
                         }
+
+                        string itemSpec = ResolvePackageAssetPath(library, asset.Path);
+                        WriteItem(itemSpec, library);
+                        writeMetadata?.Invoke(asset);
                     }
                 }
             }
 
-            return items.ToArray();
-        }
-
-        private static ITaskItem CreatePackageAssetItem(LockFileTargetLibrary package, string itemSpec)
-        {
-            var item = new TaskItem(itemSpec);
-            item.SetMetadata(MetadataKeys.NuGetSourceType, "Package");
-            item.SetMetadata(MetadataKeys.NuGetPackageId, package.Name);
-            item.SetMetadata(MetadataKeys.NuGetPackageVersion, package.Version.ToNormalizedString());
-            return item;
-        }
-
-        private string ResolvePackageAssetPath(LockFileTargetLibrary package, string relativePath)
-        {
-            string packagePath = _packageResolver.GetPackageDirectory(package.Name, package.Version);
-            return Path.Combine(packagePath, NormalizeRelativePath(relativePath));
-        }
-
-        private static Dictionary<string, string> GetProjectReferencePaths(LockFile lockFile)
-        {
-            Dictionary<string, string> paths = new Dictionary<string, string>();
-
-            foreach (var library in lockFile.Libraries)
+            private void WriteItem(string itemSpec)
             {
-                if (library.IsProject())
+                FlushMetadata();
+                _itemCount++;
+                _writer.Write(itemSpec);
+
+            }
+
+            private void WriteItem(string itemSpec, LockFileTargetLibrary package)
+            {
+                WriteItem(itemSpec);
+                WriteMetadata(MetadataKeys.NuGetPackageId, package.Name);
+                WriteMetadata(MetadataKeys.NuGetPackageVersion, package.Version.ToNormalizedString());
+            }
+
+            private void WriteMetadata(string key, string value)
+            {
+                if (!string.IsNullOrEmpty(value))
                 {
-                    paths[library.Name] = NormalizeRelativePath(library.MSBuildProject);
+                    _bufferedMetadata.Add(GetMetadataIndex(key));
+                    _bufferedMetadata.Add(GetMetadataIndex(value));
                 }
             }
 
-            return paths;
-        }
-
-        private void CheckRuntimePackageDependencies(LockFileTarget compileTimeTarget, LockFileTarget runtimeTarget)
-        {
-            if (EnsureRuntimePackageDependencies && !string.IsNullOrEmpty(RuntimeIdentifier))
+            private int GetMetadataIndex(string value)
             {
-                if (compileTimeTarget.Libraries.Count >= runtimeTarget.Libraries.Count)
+                if (!_stringTable.TryGetValue(value, out int index))
                 {
-                    throw new BuildErrorException(Strings.UnsupportedRuntimeIdentifier, RuntimeIdentifier);
+                    index = _metadataStrings.Count;
+                    _stringTable.Add(value, index);
+                    _metadataStrings.Add(value);
                 }
-            }
-        }
 
-        private static string NormalizeRelativePath(string relativePath)
-            => relativePath.Replace('/', Path.DirectorySeparatorChar);
+                return index;
+            }
+
+            private string ResolvePackageAssetPath(LockFileTargetLibrary package, string relativePath)
+            {
+                string packagePath = _packageResolver.GetPackageDirectory(package.Name, package.Version);
+                return Path.Combine(packagePath, NormalizeRelativePath(relativePath));
+            }
+
+            private static Dictionary<string, string> GetProjectReferencePaths(LockFile lockFile)
+            {
+                Dictionary<string, string> paths = new Dictionary<string, string>();
+
+                foreach (var library in lockFile.Libraries)
+                {
+                    if (library.IsProject())
+                    {
+                        paths[library.Name] = NormalizeRelativePath(library.MSBuildProject);
+                    }
+                }
+
+                return paths;
+            }
+
+            private static string NormalizeRelativePath(string relativePath)
+                => relativePath.Replace('/', Path.DirectorySeparatorChar);
+        }
     }
 }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageAssets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageAssets.cs
@@ -317,7 +317,7 @@ namespace Microsoft.NET.Build.Tasks
 
                 try
                 {
-                    if (File.GetLastWriteTimeUtc(task.ProjectAssetsCacheFile) >= File.GetLastWriteTimeUtc(task.ProjectAssetsFile))
+                    if (File.GetLastWriteTimeUtc(task.ProjectAssetsCacheFile) > File.GetLastWriteTimeUtc(task.ProjectAssetsFile))
                     {
                         reader = OpenCacheFile(task.ProjectAssetsCacheFile, settingsHash);
                     }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageAssets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageAssets.cs
@@ -444,7 +444,6 @@ namespace Microsoft.NET.Build.Tasks
                 _metadataStrings = new List<string>(InitialStringTableCapacity);
                 _bufferedMetadata = new List<int>();
 
-                Directory.CreateDirectory(Path.GetDirectoryName(task.ProjectAssetsCacheFile));
                 var stream = File.Open(task.ProjectAssetsCacheFile, FileMode.Create, FileAccess.ReadWrite, FileShare.None);
                 _writer = new BinaryWriter(stream, TextEncoding, leaveOpen: false);
             }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.PackageDependencyResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.PackageDependencyResolution.targets
@@ -26,6 +26,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <!-- Project Assets File -->
   <PropertyGroup>
     <ProjectAssetsFile Condition="'$(ProjectAssetsFile)' == ''">$(BaseIntermediateOutputPath)/project.assets.json</ProjectAssetsFile>
+    <ProjectAssetsCacheFile Condition="'$(ProjectAssetsCacheFile)' == ''">$(IntermediateOutputPath)$(MSBuildProjectName).assets.cache</ProjectAssetsCacheFile>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -189,8 +190,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   </Target>
 
   <Target Name="ResolvePackageAssets" 
-          Condition=" '$(DesignTimeBuild)' != 'true' Or Exists('$(ProjectAssetsFile)')"
-          DependsOnTargets="ReportAssetsLogMessages">
+          Condition=" '$(DesignTimeBuild)' != 'true' Or Exists('$(ProjectAssetsFile)')">
 
     <PropertyGroup Condition="'$(EnsureRuntimePackageDependencies)' == ''
                           and '$(TargetFrameworkIdentifier)' == '.NETCoreApp'
@@ -200,8 +200,10 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <ResolvePackageAssets 
       ProjectAssetsFile="$(ProjectAssetsFile)"
+      ProjectAssetsCacheFile="$(ProjectAssetsCacheFile)"
       ProjectPath="$(MSBuildProjectFullPath)"
       ProjectLanguage="$(Language)"
+      EmitAssetsLogMessages="$(EmitAssetsLogMessages)"
       TargetFrameworkMoniker="$(NuGetTargetMoniker)"
       RuntimeIdentifier="$(RuntimeIdentifier)"
       MarkPackageReferencesAsExternallyResolved="$(MarkPackageReferencesAsExternallyResolved)"

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.PackageDependencyResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.PackageDependencyResolution.targets
@@ -190,7 +190,8 @@ Copyright (c) .NET Foundation. All rights reserved.
   </Target>
 
   <Target Name="ResolvePackageAssets" 
-          Condition=" '$(DesignTimeBuild)' != 'true' Or Exists('$(ProjectAssetsFile)')">
+          Condition=" '$(DesignTimeBuild)' != 'true' Or Exists('$(ProjectAssetsFile)')"
+          DependsOnTargets="PrepareForBuild">
 
     <PropertyGroup Condition="'$(EnsureRuntimePackageDependencies)' == ''
                           and '$(TargetFrameworkIdentifier)' == '.NETCoreApp'

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.PackageDependencyResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.PackageDependencyResolution.targets
@@ -26,6 +26,9 @@ Copyright (c) .NET Foundation. All rights reserved.
   <!-- Project Assets File -->
   <PropertyGroup>
     <ProjectAssetsFile Condition="'$(ProjectAssetsFile)' == ''">$(BaseIntermediateOutputPath)/project.assets.json</ProjectAssetsFile>
+
+    <!-- Note that the assets.cache file has contents that are unique to the current TFM and configuration and therefore cannot
+         be stored in a shared directory next to the assets.json file -->
     <ProjectAssetsCacheFile Condition="'$(ProjectAssetsCacheFile)' == ''">$(IntermediateOutputPath)$(MSBuildProjectName).assets.cache</ProjectAssetsCacheFile>
   </PropertyGroup>
 

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantBuildsToBeIncremental.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantBuildsToBeIncremental.cs
@@ -20,7 +20,7 @@ namespace Microsoft.NET.Build.Tests
         }
 
         [Fact]
-        public void GenerateBuildRuntimeConfigurationFiles_runs_incrementaly()
+        public void GenerateBuildRuntimeConfigurationFiles_runs_incrementally()
         {
             var testAsset = _testAssetsManager
                 .CopyTestAsset("HelloWorld")
@@ -32,12 +32,50 @@ namespace Microsoft.NET.Build.Tests
             var runtimeConfigDevJsonPath = Path.Combine(outputDirectory, "HelloWorld.runtimeconfig.dev.json");
 
             buildCommand.Execute().Should().Pass();
-            DateTime runtimeConfigDevJsonFirstModifiedTime = new FileInfo(runtimeConfigDevJsonPath).LastWriteTime;
+            DateTime runtimeConfigDevJsonFirstModifiedTime = File.GetLastWriteTimeUtc(runtimeConfigDevJsonPath);
 
             buildCommand.Execute().Should().Pass();
-            DateTime runtimeConfigDevJsonSecondModifiedTime = new FileInfo(runtimeConfigDevJsonPath).LastWriteTime;
+            DateTime runtimeConfigDevJsonSecondModifiedTime = File.GetLastWriteTimeUtc(runtimeConfigDevJsonPath);
 
             runtimeConfigDevJsonSecondModifiedTime.Should().Be(runtimeConfigDevJsonFirstModifiedTime);
+        }
+
+        [Fact]
+        public void ResolvePackageAssets_runs_incrementally()
+        { 
+            var testAsset = _testAssetsManager
+                .CopyTestAsset("HelloWorld")
+                .WithSource()
+                .Restore(Log);
+
+            var targetFramework = "netcoreapp1.1";
+            var buildCommand = new BuildCommand(Log, testAsset.TestRoot);
+            var outputDirectory = buildCommand.GetOutputDirectory(targetFramework).FullName;
+            var baseIntermediateOutputDirectory = buildCommand.GetBaseIntermediateDirectory().FullName;
+            var intermediateDirectory = buildCommand.GetIntermediateDirectory(targetFramework).FullName;
+
+            var assetsJsonPath = Path.Combine(baseIntermediateOutputDirectory, "project.assets.json");
+            var assetsCachePath = Path.Combine(intermediateDirectory, "HelloWorld.assets.cache");
+
+            // initial build
+            buildCommand.Execute().Should().Pass();
+            var cacheWriteTime1 = File.GetLastWriteTimeUtc(assetsCachePath);
+
+            // build with no change to project.assets.json
+            buildCommand.Execute().Should().Pass();
+            var cacheWriteTime2 = File.GetLastWriteTimeUtc(assetsCachePath);
+            cacheWriteTime2.Should().Be(cacheWriteTime1);
+
+            // build with modified project
+            File.SetLastWriteTimeUtc(assetsJsonPath, DateTime.UtcNow);
+            buildCommand.Execute().Should().Pass();
+            var cacheWriteTime3 = File.GetLastWriteTimeUtc(assetsCachePath);
+            cacheWriteTime3.Should().NotBe(cacheWriteTime2);
+
+            // build with modified settings
+            buildCommand.Execute("/p:DisableLockFileFrameworks=true").Should().Pass();
+            var cacheWriteTime4 = File.GetLastWriteTimeUtc(assetsCachePath);
+            cacheWriteTime4.Should().NotBe(cacheWriteTime3);
         }
     }
 }

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToReferenceAProject.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToReferenceAProject.cs
@@ -122,6 +122,10 @@ namespace Microsoft.NET.Build.Tests
             {
                 result.Should().Pass();
             }
+            else if (referencerIsSdkProject)
+            {
+                result.Should().Fail().And.HaveStdOutContaining("NU1201");
+            }
             else
             {
                 result.Should().Fail()

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToVerifyPCLProjectReferenceCompat.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToVerifyPCLProjectReferenceCompat.cs
@@ -84,8 +84,7 @@ namespace Microsoft.NET.Build.Tests
             }
             else
             {
-                result.Should().Fail()
-                    .And.HaveStdOutContaining("It cannot be referenced by a project that targets");
+                result.Should().Fail().And.HaveStdOutContaining("NU1201");
             }
         }
 

--- a/src/Tests/Microsoft.NET.Restore.Tests/GivenThatWeWantToRestoreProjectsWithPackageDowngrades.cs
+++ b/src/Tests/Microsoft.NET.Restore.Tests/GivenThatWeWantToRestoreProjectsWithPackageDowngrades.cs
@@ -45,6 +45,12 @@ namespace Microsoft.NET.Restore.Tests
                 .Execute($"/p:RestorePackagesPath={packagesFolder}")
                 .Should().Fail()
                 .And.HaveStdOutContaining("NU1605");
+
+            var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.Path, testProjectName));
+            buildCommand
+                .Execute()
+                .Should().Fail()
+                .And.HaveStdOutContaining("NU1605");
         }
 
         [CoreMSBuildOnlyFact]

--- a/src/Tests/Microsoft.NET.TestFramework/Commands/MSBuildCommand.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/Commands/MSBuildCommand.cs
@@ -72,6 +72,16 @@ namespace Microsoft.NET.TestFramework.Commands
             return new DirectoryInfo(output);
         }
 
+        public virtual DirectoryInfo GetIntermediateDirectory(string targetFramework, string configuration = "Debug", string runtimeIdentifier = "")
+        {
+            targetFramework = targetFramework ?? string.Empty;
+            configuration = configuration ?? string.Empty;
+            runtimeIdentifier = runtimeIdentifier ?? string.Empty;
+
+            string output = Path.Combine(ProjectRootPath, "obj", configuration, targetFramework, runtimeIdentifier);
+            return new DirectoryInfo(output);
+        }
+
         public virtual DirectoryInfo GetNonSDKOutputDirectory(string configuration = "Debug")
         {
             configuration = configuration ?? string.Empty;


### PR DESCRIPTION
Whenever project.assets.json changes (or more rarely, a setting influencing ResolvePackageAssets changes), write out a binary cache file for the next incremental build. The file has only the items that used by the build and they are written in a format that can be deserialized to MSBuild ITaskItem[] with minimal time and allocation. 

On top of that, we merge ReportAssetsLogMessages into ResolvePackageAssets, which allows for project.assets.json to not be read at all if it has not changed.

Some early measurement below using https://github.com/mikeharder/dotnet-cli-perf/tree/master/scenarios/web/large/core

First observation, the total size of all assets.cache files is 5 MB vs. 37 MB for assets.json.

I will send a private drop to our internal perf alias as wll.

## Incremental build --no-restore /m:1
```
Before 
      161 ms  JoinItems                                129 calls
      176 ms  AssignProjectConfiguration               129 calls
      264 ms  Copy                                     370 calls
      318 ms  ResolvePackageFileConflicts              129 calls
     1180 ms  ReportAssetsLogMessages                  129 calls
     2873 ms  ResolvePackageAssets                     129 calls
    23138 ms  ResolveAssemblyReference                 129 calls
    
    Time Elapsed 00:00:40.08
    
After
      117 ms  JoinItems                                129 calls
      127 ms  GetReferenceNearestTargetFrameworkTask   109 calls
      136 ms  AssignProjectConfiguration               129 calls
      150 ms  Message                                  388 calls
      252 ms  ResolvePackageAssets                     129 calls
      257 ms  ResolvePackageFileConflicts              129 calls
      307 ms  Copy                                     370 calls
    23261 ms  ResolveAssemblyReference                 129 calls

    Time Elapsed 00:00:36.04
```

Saving 10% overall here and reducing ResolvePackageAssets+ReportAssetsLogMessage (now combined into ResolvePackageAssets) from ~4 seconds to ~250 milliseconds.

## Incremental parallel build --no-restore
```
Before
      184 ms  Hash                                     258 calls
      232 ms  JoinItems                                129 calls
      240 ms  GetReferenceNearestTargetFrameworkTask   109 calls
      299 ms  AssignProjectConfiguration               129 calls
      487 ms  ResolvePackageFileConflicts              129 calls
      492 ms  Copy                                     370 calls
     2654 ms  ReportAssetsLogMessages                  129 calls
     5071 ms  ResolvePackageAssets                     129 calls
    37575 ms  ResolveAssemblyReference                 129 calls
    
    Time Elapsed 00:00:19.72

After
      100 ms  ConvertToAbsolutePath                    129 calls
      116 ms  ProduceContentAssets                     129 calls
      157 ms  FindUnderPath                            645 calls
      185 ms  Hash                                     258 calls
      246 ms  JoinItems                                129 calls
      329 ms  AssignProjectConfiguration               129 calls
      447 ms  GetReferenceNearestTargetFrameworkTask   109 calls
      487 ms  ResolvePackageFileConflicts              129 calls
      502 ms  Copy                                     370 calls
      612 ms  ResolvePackageAssets                     129 calls
    38504 ms  ResolveAssemblyReference                 129 calls

    Time Elapsed 00:00:18.54
```
Overall saving is less in parallel case, but time in   (ResolvePackageAssets + ReportAssetsLogMessage)  goes down from ~7.5 seconds to ~ 600 milliseconds.

It is interesting that just about every task is taking significantly more cumulative time when building in parallel. But, of course, some (most???) of the 7 seconds difference is being recuperated by parallelism.


## Clean parallel build --no-restore (cleaned and restored beforehand)
```
Before
      168 ms  Hash                                     258 calls
      270 ms  GetReferenceNearestTargetFrameworkTask   109 calls
      301 ms  JoinItems                                129 calls
      306 ms  MakeDir                                  129 calls
      333 ms  AssignProjectConfiguration               129 calls
      524 ms  ResolvePackageFileConflicts              129 calls
      559 ms  WriteCodeFragment                        129 calls
     1866 ms  WriteLinesToFile                         387 calls
     3268 ms  ReportAssetsLogMessages                  129 calls
     4616 ms  GenerateDepsFile                         129 calls
     5577 ms  ResolvePackageAssets                     129 calls
     6945 ms  Copy                                     370 calls
    24787 ms  Csc                                      129 calls
    41201 ms  ResolveAssemblyReference                 129 calls
    
    Time Elapsed 00:00:29.46
    
After
      167 ms  Hash                                     258 calls
      181 ms  FindUnderPath                            645 calls
      234 ms  GetReferenceNearestTargetFrameworkTask   109 calls
      270 ms  AssignProjectConfiguration               129 calls
      294 ms  JoinItems                                129 calls
      299 ms  MakeDir                                  129 calls
      487 ms  ResolvePackageFileConflicts              129 calls
      540 ms  WriteCodeFragment                        129 calls
     1501 ms  WriteLinesToFile                         387 calls
     4317 ms  GenerateDepsFile                         129 calls
     6802 ms  Copy                                     370 calls
     9715 ms  ResolvePackageAssets                     129 calls
    26625 ms  Csc                                      129 calls
    39653 ms  ResolveAssemblyReference                 129 calls
    
    Time Elapsed 00:00:30.44
```
This case shows the *slowdown* of  (ResolvePackageAssets + ReportAssetsLogMessage)  from ~8.8 seconds to ~9.7 seconds in the first run of ResolvePackageAssets where the cache needs to be generated. I have some ideas on how to narrow this down significantly, but note that it does not impact the inner loop case where project.assets.json would not be changing between every build.

cc @mikeharder @davkean @livarcocc @dsplaisted 