### PR TITLE
Include SourceRevisionId in InformationalVersion

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.GenerateAssemblyInfo.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.GenerateAssemblyInfo.targets
@@ -34,6 +34,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <GenerateAssemblyTitleAttribute Condition="'$(GenerateAssemblyTitleAttribute)' == ''">true</GenerateAssemblyTitleAttribute>
     <GenerateAssemblyVersionAttribute Condition="'$(GenerateAssemblyVersionAttribute)' == ''">true</GenerateAssemblyVersionAttribute>
     <GenerateNeutralResourcesLanguageAttribute Condition="'$(GenerateNeutralResourcesLanguageAttribute)' == ''">true</GenerateNeutralResourcesLanguageAttribute>
+    <IncludeSourceRevisionInInformationalVersion Condition="'$(IncludeSourceRevisionInInformationalVersion)' == ''">true</IncludeSourceRevisionInInformationalVersion>
   </PropertyGroup>
 
   <!-- 
@@ -48,8 +49,21 @@ Copyright (c) .NET Foundation. All rights reserved.
           DependsOnTargets="PrepareForBuild;CoreGenerateAssemblyInfo"
           Condition="'$(GenerateAssemblyInfo)' == 'true'" />
 
+  <Target Name="AddSourceRevisionToInformationalVersion"
+          DependsOnTargets="InitializeSourceControlInformation"
+          Condition="'$(SourceControlInformationFeatureSupported)' == 'true' and '$(IncludeSourceRevisionInInformationalVersion)' == 'true'">
+    <PropertyGroup Condition="'$(SourceRevisionId)' != ''">
+      <!-- Follow SemVer 2.0 rules -->
+      <_InformationalVersionContainsPlus>false</_InformationalVersionContainsPlus>
+      <_InformationalVersionContainsPlus Condition="$(InformationalVersion.Contains('+'))">true</_InformationalVersionContainsPlus>
+
+      <InformationalVersion Condition="!$(_InformationalVersionContainsPlus)">$(InformationalVersion)+$(SourceRevisionId)</InformationalVersion>
+      <InformationalVersion Condition="$(_InformationalVersionContainsPlus)">$(InformationalVersion).$(SourceRevisionId)</InformationalVersion>
+    </PropertyGroup>
+  </Target>
+
   <Target Name="GetAssemblyAttributes"
-          DependsOnTargets="GetAssemblyVersion">
+          DependsOnTargets="GetAssemblyVersion;AddSourceRevisionToInformationalVersion">
     <ItemGroup>
       <AssemblyAttribute Include="System.Reflection.AssemblyCompanyAttribute" Condition="'$(Company)' != '' and '$(GenerateAssemblyCompanyAttribute)' == 'true'">
         <_Parameter1>$(Company)</_Parameter1>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.GenerateAssemblyInfo.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.GenerateAssemblyInfo.targets
@@ -50,7 +50,7 @@ Copyright (c) .NET Foundation. All rights reserved.
           Condition="'$(GenerateAssemblyInfo)' == 'true'" />
 
   <Target Name="AddSourceRevisionToInformationalVersion"
-          DependsOnTargets="InitializeSourceControlInformation"
+          DependsOnTargets="GetAssemblyVersion;InitializeSourceControlInformation"
           Condition="'$(SourceControlInformationFeatureSupported)' == 'true' and '$(IncludeSourceRevisionInInformationalVersion)' == 'true'">
     <PropertyGroup Condition="'$(SourceRevisionId)' != ''">
       <!-- Follow SemVer 2.0 rules -->

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToControlGeneratedAssemblyInfo.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToControlGeneratedAssemblyInfo.cs
@@ -92,7 +92,7 @@ namespace Microsoft.NET.Build.Tests
         }
 
         [Fact]
-        public void It_does_not_include_source_revision_id_if_not_available1()
+        public void It_does_not_include_source_revision_id_if_initialize_source_control_target_not_available()
         {
             TestProject testProject = new TestProject()
             {
@@ -105,14 +105,14 @@ namespace Microsoft.NET.Build.Tests
 
             testAsset.Restore(Log, testProject.Name);
 
-            var command = new GetValuesCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name), "netcoreapp2.0", valueName: "InformationalVersion");
+            var command = new GetValuesCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name), testProject.TargetFrameworks, valueName: "InformationalVersion");
             command.Execute().Should().Pass();
 
             command.GetValues().ShouldBeEquivalentTo(new[] { "1.0.0" });
         }
 
         [Fact]
-        public void It_does_not_include_source_revision_id_if_not_available2()
+        public void It_does_not_include_source_revision_id_if_source_revision_id_not_set()
         {
             TestProject testProject = new TestProject()
             {
@@ -134,13 +134,12 @@ namespace Microsoft.NET.Build.Tests
 
                     project.Root.Add(
                         new XElement(ns + "PropertyGroup",
-                            new XElement("SourceControlInformationFeatureSupported", "true"),
-                            new XElement("IncludeSourceRevisionInInformationalVersion", "true")));
+                            new XElement("SourceControlInformationFeatureSupported", "true")));
                 });
 
             testAsset.Restore(Log, testProject.Name);
 
-            var command = new GetValuesCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name), "netcoreapp2.0", valueName: "InformationalVersion");
+            var command = new GetValuesCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name), testProject.TargetFrameworks, valueName: "InformationalVersion");
             command.Execute().Should().Pass();
 
             command.GetValues().ShouldBeEquivalentTo(new[] { "1.0.0" });
@@ -175,7 +174,7 @@ namespace Microsoft.NET.Build.Tests
 
             testAsset.Restore(Log, testProject.Name);
 
-            var command = new GetValuesCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name), "netcoreapp2.0", valueName: "InformationalVersion");
+            var command = new GetValuesCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name), testProject.TargetFrameworks, valueName: "InformationalVersion");
             command.Execute().Should().Pass();
 
             command.GetValues().ShouldBeEquivalentTo(new[] { "1.0.0" });
@@ -214,7 +213,7 @@ namespace Microsoft.NET.Build.Tests
 
             testAsset.Restore(Log, testProject.Name);
 
-            var command = new GetValuesCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name), "netcoreapp2.0", valueName: "InformationalVersion");
+            var command = new GetValuesCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name), testProject.TargetFrameworks, valueName: "InformationalVersion");
             command.Execute().Should().Pass();
 
             command.GetValues().ShouldBeEquivalentTo(new[] { "1.0.0+xyz" });
@@ -254,7 +253,7 @@ namespace Microsoft.NET.Build.Tests
 
             testAsset.Restore(Log, testProject.Name);
 
-            var command = new GetValuesCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name), "netcoreapp2.0", valueName: "InformationalVersion");
+            var command = new GetValuesCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name), testProject.TargetFrameworks, valueName: "InformationalVersion");
             command.Execute().Should().Pass();
 
             command.GetValues().ShouldBeEquivalentTo(new[] { "1.2.3+abc.xyz" });

--- a/src/Tests/Microsoft.NET.TestFramework/TestAssetsManager.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/TestAssetsManager.cs
@@ -68,7 +68,7 @@ namespace Microsoft.NET.TestFramework
                 var project = projectStack.Pop();
                 if (!createdProjects.Contains(project))
                 {
-                    project.Create(testAsset, ProjectsRoot);
+                   project.Create(testAsset, ProjectsRoot);
                     createdProjects.Add(project);
 
                     foreach (var referencedProject in project.ReferencedProjects)


### PR DESCRIPTION
When a source control provider is available in the project append the value of SourceRevisionId set by the provider to InformationalVersion string.

See https://github.com/tmat/repository-info/blob/master/docs/Readme.md and https://github.com/Microsoft/msbuild/pull/3063 for details.

