### PR TITLE
Fix package override resolver desktop

### DIFF
--- a/src/Tasks/Common/ConflictResolution/PackageOverrideResolver.cs
+++ b/src/Tasks/Common/ConflictResolution/PackageOverrideResolver.cs
@@ -78,20 +78,18 @@ namespace Microsoft.NET.Build.Tasks.ConflictResolution
 
         public TConflictItem Resolve(TConflictItem item1, TConflictItem item2)
         {
-            if (PackageOverrides != null)
+            if (PackageOverrides != null && item1.PackageId != null && item2.PackageId != null)
             {
                 PackageOverride packageOverride;
                 Version version;
-                if (item1.PackageId != null
-                    && PackageOverrides.TryGetValue(item1.PackageId, out packageOverride)
+                if (PackageOverrides.TryGetValue(item1.PackageId, out packageOverride)
                     && packageOverride.OverriddenPackages.TryGetValue(item2.PackageId, out version)
                     && item2.PackageVersion != null
                     && item2.PackageVersion <= version)
                 {
                     return item1;
                 }
-                else if (item2.PackageId != null
-                    && PackageOverrides.TryGetValue(item2.PackageId, out packageOverride)
+                else if (PackageOverrides.TryGetValue(item2.PackageId, out packageOverride)
                     && packageOverride.OverriddenPackages.TryGetValue(item1.PackageId, out version)
                     && item1.PackageVersion != null
                     && item1.PackageVersion <= version)

--- a/src/Tasks/Common/NuGetUtils.cs
+++ b/src/Tasks/Common/NuGetUtils.cs
@@ -36,6 +36,13 @@ namespace Microsoft.NET.Build.Tasks
             {
                 // this method is just a temporary heuristic until we flow the NuGet metadata through the right items
                 // https://github.com/dotnet/sdk/issues/1091
+
+                // Don't try to recurse a relative path.
+                if (!Path.IsPathRooted(fullPath))
+                {
+                    return;
+                }
+
                 for (var dir = Directory.GetParent(fullPath); dir != null; dir = dir.Parent)
                 {
                     var nuspecs = dir.GetFiles("*.nuspec");

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAPackageOverrideResolver.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAPackageOverrideResolver.cs
@@ -48,5 +48,50 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             Assert.Null(resolver.PackageOverrides);
             Assert.Null(resolver.Resolve(new MockConflictItem(), new MockConflictItem()));
         }
+
+        [Fact]
+        public void ItHandlesNullPackageIds()
+        {
+            ITaskItem[] packageOverrides = new[]
+            {
+                new MockTaskItem("FakePlatform", new Dictionary<string, string>
+                {
+                    { MetadataKeys.OverriddenPackages, "System.Ben|4.2.0;System.Jobst-Immo|4.2.0;System.Livar|4.3.0;System.Dave|4.2.0" }
+                })
+            };
+
+            var resolver = new PackageOverrideResolver<MockConflictItem>(packageOverrides);
+
+            Assert.NotNull(resolver.PackageOverrides);
+
+            var packageItem = new MockConflictItem("System.Eric")
+            {
+                PackageId = "System.Eric",
+                PackageVersion = new Version(4, 0, 0),
+                AssemblyVersion = new Version(4, 0, 0, 0),
+                ItemType = ConflictItemType.Reference
+            };
+
+            var platformItem = new MockConflictItem("System.Eric")
+            {
+                PackageId = null,
+                AssemblyVersion = new Version(4, 1, 0, 0),
+                ItemType = ConflictItemType.Platform
+            };
+            
+            Assert.Null(resolver.Resolve(packageItem, platformItem));
+            Assert.Null(resolver.Resolve(platformItem, packageItem));
+
+            var packageItem2 = new MockConflictItem("System.Eric")
+            {
+                PackageId = "FakePlatform",
+                PackageVersion = new Version(4, 0, 0),
+                AssemblyVersion = new Version(4, 0, 0, 0),
+                ItemType = ConflictItemType.Reference
+            };
+
+            Assert.Null(resolver.Resolve(packageItem2, platformItem));
+            Assert.Null(resolver.Resolve(platformItem, packageItem2));
+        }
     }
 }


### PR DESCRIPTION
In desktop projects the PackageOverrideResolver was throwing ArgumentNullException due to 
one item coming from a package and the other not.

Moreover I noticed that the one that was thought to come from a package was actually a platform item
and the reason we thought it came from a package was that I had a *.nuspec in the root of the drive where I was building from.

We need tests to cover these cases.

Fixes #1854