### PR TITLE
Issue a warning on restore about obsolete DotNetCliToolReference

### DIFF
--- a/src/Tasks/Common/NETSdkWarning.cs
+++ b/src/Tasks/Common/NETSdkWarning.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.NET.Build.Tasks
+{
+    /// <summary>
+    /// Provides a localizable mechanism for logging a warning from the SDK targets.
+    /// </summary>
+    public class
+#if EXTENSIONS
+        // This task source is shared with multiple task Dlls.  Since both tasks
+        // may be loaded into the same project and each task accesses only resources
+        // in its own assembly they must have a unique name so-as not to clash.
+        NETBuildExtensionsWarning
+#else
+        NETSdkWarning
+#endif
+     : MessageBase
+    {
+        protected override void LogMessage(string message)
+        {
+            Log.LogWarning(message);
+        }
+    }
+}

--- a/src/Tasks/Common/Resources/Strings.resx
+++ b/src/Tasks/Common/Resources/Strings.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -329,5 +329,8 @@
   </data>
   <data name="UsingPreviewSdkWarning" xml:space="preserve">
     <value>You are working with a preview version of the .NET Core SDK. You can define the SDK version via a global.json file in the current project. More at https://go.microsoft.com/fwlink/?linkid=869452</value>
+  </data>
+  <data name="ProjectContainsObsoleteDotNetCliTool" xml:space="preserve">
+    <value>Using DotNetCliToolReference to reference '{0}' is obsolete and can be removed from this project. This tool is bundled by default in the .NET Core SDK.</value>
   </data>
 </root>

--- a/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
@@ -357,6 +357,11 @@
         <target state="translated">Pracujete se sadou .NET Core SDK verze Preview. Verzi sady SDK můžete definovat prostřednictvím souboru global.json v aktuálním projektu. Další informace najdete na adrese https://go.microsoft.com/fwlink/?linkid=869452.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectContainsObsoleteDotNetCliTool">
+        <source>Using DotNetCliToolReference to reference '{0}' is obsolete and can be removed from this project. This tool is bundled by default in the .NET Core SDK.</source>
+        <target state="new">Using DotNetCliToolReference to reference '{0}' is obsolete and can be removed from this project. This tool is bundled by default in the .NET Core SDK.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Common/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.de.xlf
@@ -357,6 +357,11 @@
         <target state="translated">Sie arbeiten mit einer Vorschauversion des .NET Core SDK. Sie können die SDK-Version über eine Datei "global.json" im aktuellen Projekt definieren. Weitere Informationen finden Sie unter https://go.microsoft.com/fwlink/?linkid=869452.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectContainsObsoleteDotNetCliTool">
+        <source>Using DotNetCliToolReference to reference '{0}' is obsolete and can be removed from this project. This tool is bundled by default in the .NET Core SDK.</source>
+        <target state="new">Using DotNetCliToolReference to reference '{0}' is obsolete and can be removed from this project. This tool is bundled by default in the .NET Core SDK.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Common/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.es.xlf
@@ -357,6 +357,11 @@
         <target state="translated">Está trabajando con una versión preliminar del SDK de .NET Core. Puede definir la versión del SDK mediante un archivo .json global en el proyecto actual. Más información en https://go.microsoft.com/fwlink/?linkid=869452</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectContainsObsoleteDotNetCliTool">
+        <source>Using DotNetCliToolReference to reference '{0}' is obsolete and can be removed from this project. This tool is bundled by default in the .NET Core SDK.</source>
+        <target state="new">Using DotNetCliToolReference to reference '{0}' is obsolete and can be removed from this project. This tool is bundled by default in the .NET Core SDK.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
@@ -357,6 +357,11 @@
         <target state="translated">Vous utilisez une préversion du SDK .NET Core. Vous pouvez définir la version du SDK via un fichier global.json dans le projet actuel. Plus d'informations sur https://go.microsoft.com/fwlink/?linkid=869452</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectContainsObsoleteDotNetCliTool">
+        <source>Using DotNetCliToolReference to reference '{0}' is obsolete and can be removed from this project. This tool is bundled by default in the .NET Core SDK.</source>
+        <target state="new">Using DotNetCliToolReference to reference '{0}' is obsolete and can be removed from this project. This tool is bundled by default in the .NET Core SDK.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Common/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.it.xlf
@@ -357,6 +357,11 @@
         <target state="translated">Si sta usando una versione in anteprima di .NET Core SDK. È possibile definire la versione dell'SDK tramite un file global.json nel progetto corrente. Per altre informazioni, vedere https://go.microsoft.com/fwlink/?linkid=869452</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectContainsObsoleteDotNetCliTool">
+        <source>Using DotNetCliToolReference to reference '{0}' is obsolete and can be removed from this project. This tool is bundled by default in the .NET Core SDK.</source>
+        <target state="new">Using DotNetCliToolReference to reference '{0}' is obsolete and can be removed from this project. This tool is bundled by default in the .NET Core SDK.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
@@ -357,6 +357,11 @@
         <target state="translated">.NET Core SDK のプレビュー バージョンで作業をしています。現在のプロジェクトの global.json ファイルによって SDK バージョンを定義できます。詳細については、https://go.microsoft.com/fwlink/?linkid=869452 をご覧ください</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectContainsObsoleteDotNetCliTool">
+        <source>Using DotNetCliToolReference to reference '{0}' is obsolete and can be removed from this project. This tool is bundled by default in the .NET Core SDK.</source>
+        <target state="new">Using DotNetCliToolReference to reference '{0}' is obsolete and can be removed from this project. This tool is bundled by default in the .NET Core SDK.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
@@ -357,6 +357,11 @@
         <target state="translated">.NET Core SDK의 미리 보기 버전으로 작업하고 있습니다. 현재 프로젝트의 global.json 파일을 통해 SDK 버전을 정의할 수 있습니다. 자세한 내용은 https://go.microsoft.com/fwlink/?linkid=869452를 참조하세요.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectContainsObsoleteDotNetCliTool">
+        <source>Using DotNetCliToolReference to reference '{0}' is obsolete and can be removed from this project. This tool is bundled by default in the .NET Core SDK.</source>
+        <target state="new">Using DotNetCliToolReference to reference '{0}' is obsolete and can be removed from this project. This tool is bundled by default in the .NET Core SDK.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
@@ -357,6 +357,11 @@
         <target state="translated">Korzystasz z zestawu .NET Core SDK w wersji zapoznawczej. Możesz zdefiniować wersję zestawu SDK za pomocą pliku global.json w bieżącym projekcie. Więcej informacji można znaleźć na stronie https://go.microsoft.com/fwlink/?linkid=869452</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectContainsObsoleteDotNetCliTool">
+        <source>Using DotNetCliToolReference to reference '{0}' is obsolete and can be removed from this project. This tool is bundled by default in the .NET Core SDK.</source>
+        <target state="new">Using DotNetCliToolReference to reference '{0}' is obsolete and can be removed from this project. This tool is bundled by default in the .NET Core SDK.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
@@ -357,6 +357,11 @@
         <target state="translated">Você está trabalhando com a versão prévia do SDK do .NET Core. É possível definir a versão do SDK usando um arquivo global.json no projeto atual. Mais informações em https://go.microsoft.com/fwlink/?linkid=869452</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectContainsObsoleteDotNetCliTool">
+        <source>Using DotNetCliToolReference to reference '{0}' is obsolete and can be removed from this project. This tool is bundled by default in the .NET Core SDK.</source>
+        <target state="new">Using DotNetCliToolReference to reference '{0}' is obsolete and can be removed from this project. This tool is bundled by default in the .NET Core SDK.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
@@ -357,6 +357,11 @@
         <target state="translated">Вы работаете с предварительной версией пакета SDK для .NET Core. Задать версию SDK можно в файле global.json текущего проекта. Дополнительные сведения: https://go.microsoft.com/fwlink/?linkid=869452</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectContainsObsoleteDotNetCliTool">
+        <source>Using DotNetCliToolReference to reference '{0}' is obsolete and can be removed from this project. This tool is bundled by default in the .NET Core SDK.</source>
+        <target state="new">Using DotNetCliToolReference to reference '{0}' is obsolete and can be removed from this project. This tool is bundled by default in the .NET Core SDK.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
@@ -357,6 +357,11 @@
         <target state="translated">.NET Core SDK’nın önizleme sürümüyle çalışıyorsunuz. SDK sürümünü geçerli projedeki bir global.json dosyası aracılığıyla tanımlayabilirsiniz. Daha fazla bilgi edinmek için bkz. https://go.microsoft.com/fwlink/?linkid=869452</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectContainsObsoleteDotNetCliTool">
+        <source>Using DotNetCliToolReference to reference '{0}' is obsolete and can be removed from this project. This tool is bundled by default in the .NET Core SDK.</source>
+        <target state="new">Using DotNetCliToolReference to reference '{0}' is obsolete and can be removed from this project. This tool is bundled by default in the .NET Core SDK.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
@@ -357,6 +357,11 @@
         <target state="translated">你正在使用 .NET Core SDK 的预览版。可通过当前项目中的 global.json 文件来定义 SDK 版本。详细信息请访问 https://go.microsoft.com/fwlink/?linkid=869452</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectContainsObsoleteDotNetCliTool">
+        <source>Using DotNetCliToolReference to reference '{0}' is obsolete and can be removed from this project. This tool is bundled by default in the .NET Core SDK.</source>
+        <target state="new">Using DotNetCliToolReference to reference '{0}' is obsolete and can be removed from this project. This tool is bundled by default in the .NET Core SDK.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
@@ -357,6 +357,11 @@
         <target state="translated">您目前使用 .NET Core SDK 的預覽版本。您可透過目前專案中的 global.json 檔案定義 SDK 版本。如需更多項目，請前往 https://go.microsoft.com/fwlink/?linkid=869452</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectContainsObsoleteDotNetCliTool">
+        <source>Using DotNetCliToolReference to reference '{0}' is obsolete and can be removed from this project. This tool is bundled by default in the .NET Core SDK.</source>
+        <target state="new">Using DotNetCliToolReference to reference '{0}' is obsolete and can be removed from this project. This tool is bundled by default in the .NET Core SDK.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Microsoft.NET.Build.Extensions.Tasks/msbuildExtensions/Microsoft/Microsoft.NET.Build.Extensions/Microsoft.NET.Build.Extensions.NETFramework.targets
+++ b/src/Tasks/Microsoft.NET.Build.Extensions.Tasks/msbuildExtensions/Microsoft/Microsoft.NET.Build.Extensions/Microsoft.NET.Build.Extensions.NETFramework.targets
@@ -6,7 +6,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
           created a backup copy.  Incorrect changes to this file will make it
           impossible to load or build your projects from the command-line or the IDE.
 
-Copyright (c) .NET Foundation. All rights reserved. 
+Copyright (c) .NET Foundation. All rights reserved.
 ***********************************************************************************************
 -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
@@ -20,6 +20,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <UsingTask TaskName="GetDependsOnNETStandard" AssemblyFile="$(MicrosoftNETBuildExtensionsTasksAssembly)" />
   <UsingTask TaskName="NETBuildExtensionsError" AssemblyFile="$(MicrosoftNETBuildExtensionsTasksAssembly)" />
+  <UsingTask TaskName="NETBuildExtensionsWarning" AssemblyFile="$(MicrosoftNETBuildExtensionsTasksAssembly)" />
 
   <Target Name="ImplicitlyExpandNETStandardFacades"
           Condition="'$(ImplicitlyExpandNETStandardFacades)' == 'true'"
@@ -39,7 +40,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <!-- Check metadata of _ResolvedProjectReferencePaths items.  This handles the case where we are doing a design-time build and a referenced project
          hasn't been built yet, so there is no corresponding assembly on disk for the GetDependsOnNETStandard task to examine.
-         
+
          More context: https://github.com/dotnet/sdk/issues/1403
          -->
     <PropertyGroup Condition="'$(DependsOnNETStandard)' == '' AND '$(NETStandardInbox)' != 'true'">
@@ -53,7 +54,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       <!-- 2. The target framework is .NET 4.7.1, which needs to special case some shims -->
       <_RunGetDependsOnNETStandard Condition="'$(DependsOnNETStandard)' == '' AND '$(_TargetFrameworkVersionWithoutV)' == '4.7.1'">true</_RunGetDependsOnNETStandard>
     </PropertyGroup>
-    
+
     <GetDependsOnNETStandard Condition="'$(_RunGetDependsOnNETStandard)' == 'true'"
                              References="@(_CandidateNETStandardReferences)">
       <Output TaskParameter="DependsOnNETStandard" PropertyName="DependsOnNETStandard" />
@@ -77,13 +78,13 @@ Copyright (c) .NET Foundation. All rights reserved.
     <!--
       .NET 4.7.1 has support for .NET Standard 2.0 built-in, so most of the facades aren't necessary.  However, the assembly versions of a few set of assemblies
       do not yet match the ones shipped in the support package for .NET Standard 2.0 on .NET 4.7 and below. This means that .NET 4.7 or lower libraries might have
-      references to higher versions of these assemblies than are available in-box in .NET 4.7, leading to assembly loading errors. So if there is a dependency on 
+      references to higher versions of these assemblies than are available in-box in .NET 4.7, leading to assembly loading errors. So if there is a dependency on
       netstandard.dll, we include DLLs for .NET 4.7.1 from the support package to avoid these errors.
       -->
     <ItemGroup Condition="'$(_TargetFrameworkVersionWithoutV)' == '4.7.1'">
       <_NETStandardLibraryNETFrameworkLib Include="$(MSBuildThisFileDirectory)\net471\lib\*.dll" Condition="'$(DependsOnNETStandard)' == 'true'"/>
     </ItemGroup>
-    
+
     <!-- if any reference depends on netstandard and it is not inbox, add references and implementation assemblies for netstandard2.0  -->
     <ItemGroup Condition="'$(DependsOnNETStandard)' == 'true' AND '$(NETStandardInbox)' != 'true' AND '$(_TargetFrameworkVersionWithoutV)' &lt; '4.7.1'">
       <_NETStandardLibraryNETFrameworkLib Condition="'$(_TargetFrameworkVersionWithoutV)' &gt;= '4.7'"
@@ -98,7 +99,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <ItemGroup Condition="'@(_NETStandardLibraryNETFrameworkLib)' != ''">
       <!-- Remove simple name references if we're directly providing a reference assembly to the compiler. For example,
-           consider a project with a Reference Include="System.Net.Http" or "System.IO.Compression", which are both in 
+           consider a project with a Reference Include="System.Net.Http" or "System.IO.Compression", which are both in
            _NETStandardLibraryNETFrameworkReference.
            Simple references can also come from NuGet framework assemblies, hence this statement should occur after
            including all computed references, thus this target is scheduled after references have been raised by NuGet
@@ -109,22 +110,22 @@ Copyright (c) .NET Foundation. All rights reserved.
            copied locally, and ReferenceCopyLocalPaths, which will be copied locally.  The reason for this split is to
            workaround https://github.com/dotnet/core-setup/issues/2981 by ensuring that the facades are written
            to the deps.json with a type of "referenceassembly" instead of "reference".
-           
+
            The exception is netfx.force.conflicts.dll, which shouldn't be copied local.  So it isn't included in
            ReferenceCopyLocalPaths.
-           
+
            When we add the Reference items, we use the simple name as the ItemSpec, and refer to the full path
            to the DLL via the HintPath metadata.  This is so that if we're replacing a simple Reference,
            the OriginalItemSpec of the resolved reference will match to the Reference that was replaced,
            and VS won't show a warning icon on the reference.  See https://github.com/dotnet/sdk/issues/1499
            -->
-      
+
       <Reference Include="%(_NETStandardLibraryNETFrameworkLib.FileName)">
         <HintPath>%(_NETStandardLibraryNETFrameworkLib.Identity)</HintPath>
         <Private>false</Private>
         <ExternallyResolved>$(MarkNETFrameworkExtensionAssembliesAsExternallyResolved)</ExternallyResolved>
       </Reference>
-      
+
       <ReferenceCopyLocalPaths Include="@(_NETStandardLibraryNETFrameworkLib)" Condition="'%(FileName)' != 'netfx.force.conflicts'">
         <Private>false</Private>
       </ReferenceCopyLocalPaths>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ObsoleteReferences.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ObsoleteReferences.targets
@@ -15,17 +15,24 @@ Copyright (c) .NET Foundation. All rights reserved.
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
   </PropertyGroup>
 
-  <Target Name="_WarnAboutObsoleteDotNetCliToolReferences" BeforeTargets="CollectPackageReferences">
-    <ItemGroup>
-      <_ReferenceToObsoleteDotNetCliTool Include="@(DotNetCliToolReference)" />
-      <DotNetCliToolReference Remove="@(BundledDotNetCliToolReference)" />
-      <_ReferenceToObsoleteDotNetCliTool Remove="@(DotNetCliToolReference)" />
-    </ItemGroup>
+  <PropertyGroup Condition="'$(NETCoreSdkBundledCliToolsProps)' == ''">
+    <NETCoreSdkBundledCliToolsProps>$(MSBuildThisFileDirectory)..\..\..\Microsoft.NETCoreSdk.BundledCliTools.props</NETCoreSdkBundledCliToolsProps>
+  </PropertyGroup>
 
-    <Warning
-      Code="DOTNET1018"
-      Text="Using DotNetCliToolReference to reference '%(_ReferenceToObsoleteDotNetCliTool.Identity)' is obsolete and can be removed from this project. This tool is bundled by default in the .NET Core SDK."
-      Condition=" '%(_ReferenceToObsoleteDotNetCliTool.Identity)' != '' " />
+  <Import Project="$(NETCoreSdkBundledCliToolsProps)" Condition="Exists('$(NETCoreSdkBundledCliToolsProps)')" />
+
+  <ItemGroup>
+    <_ReferenceToObsoleteDotNetCliTool Include="@(DotNetCliToolReference)" />
+    <DotNetCliToolReference Remove="@(BundledDotNetCliToolReference)" />
+    <_ReferenceToObsoleteDotNetCliTool Remove="@(DotNetCliToolReference)" />
+  </ItemGroup>
+
+  <Target Name="_CheckForObsoleteDotNetCliToolReferences"
+          BeforeTargets="CollectPackageReferences"
+          Condition=" '$(SuppressObsoleteDotNetCliToolWarning)' != 'true' ">
+    <NETSdkWarning Condition=" '%(_ReferenceToObsoleteDotNetCliTool.Identity)' != '' "
+                   ResourceName="ProjectContainsObsoleteDotNetCliTool"
+                   FormatArguments="%(_ReferenceToObsoleteDotNetCliTool.Identity)" />
   </Target>
 
 </Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ObsoleteReferences.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ObsoleteReferences.targets
@@ -1,0 +1,31 @@
+<!--
+***********************************************************************************************
+Microsoft.NET.ObsoleteReferences.targets
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+          created a backup copy.  Incorrect changes to this file will make it
+          impossible to load or build your projects from the command-line or the IDE.
+
+Copyright (c) .NET Foundation. All rights reserved.
+***********************************************************************************************
+-->
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <PropertyGroup>
+    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+  </PropertyGroup>
+
+  <Target Name="_WarnAboutObsoleteDotNetCliToolReferences" BeforeTargets="CollectPackageReferences">
+    <ItemGroup>
+      <_ReferenceToObsoleteDotNetCliTool Include="@(DotNetCliToolReference)" />
+      <DotNetCliToolReference Remove="@(BundledDotNetCliToolReference)" />
+      <_ReferenceToObsoleteDotNetCliTool Remove="@(DotNetCliToolReference)" />
+    </ItemGroup>
+
+    <Warning
+      Code="DOTNET1018"
+      Text="Using DotNetCliToolReference to reference '%(_ReferenceToObsoleteDotNetCliTool.Identity)' is obsolete and can be removed from this project. This tool is bundled by default in the .NET Core SDK."
+      Condition=" '%(_ReferenceToObsoleteDotNetCliTool.Identity)' != '' " />
+  </Target>
+
+</Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.Common.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.Common.targets
@@ -6,7 +6,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
           created a backup copy.  Incorrect changes to this file will make it
           impossible to load or build your projects from the command-line or the IDE.
 
-Copyright (c) .NET Foundation. All rights reserved. 
+Copyright (c) .NET Foundation. All rights reserved.
 ***********************************************************************************************
 -->
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
@@ -20,8 +20,8 @@ Copyright (c) .NET Foundation. All rights reserved.
     <MicrosoftNETBuildTasksTFM Condition=" '$(MicrosoftNETBuildTasksTFM)' == ''">net46</MicrosoftNETBuildTasksTFM>
     <MicrosoftNETBuildTasksDirectory>$(MicrosoftNETBuildTasksDirectoryRoot)$(MicrosoftNETBuildTasksTFM)/</MicrosoftNETBuildTasksDirectory>
     <MicrosoftNETBuildTasksAssembly>$(MicrosoftNETBuildTasksDirectory)Microsoft.NET.Build.Tasks.dll</MicrosoftNETBuildTasksAssembly>
-    
-    <!-- 
+
+    <!--
           Hardcoded list of known implicit packges that are added to project from default SDK targets implicitly.
           Should be re-visited when multiple TFM support is added to Dependencies logic.
     -->
@@ -45,18 +45,19 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <UsingTask TaskName="GetNearestTargetFramework" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
   <UsingTask TaskName="NETSdkError" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
+  <UsingTask TaskName="NETSdkWarning" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
   <UsingTask TaskName="ShowPreviewMessage" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
-  
+
   <!--
   ============================================================
                               GetTargetFrameworkProperties
 
-    Invoked by common targets to return the set of properties 
-    (in the form  "key1=value1;...keyN=valueN") needed to build 
+    Invoked by common targets to return the set of properties
+    (in the form  "key1=value1;...keyN=valueN") needed to build
     against the target framework that best matches the referring
     project's target framework.
 
-    The referring project's $(TargetFrameworkMoniker) is passed 
+    The referring project's $(TargetFrameworkMoniker) is passed
     in as $(ReferringTargetFramework).
 
     This is in the common targets so that it will apply to both
@@ -85,12 +86,12 @@ Copyright (c) .NET Foundation. All rights reserved.
       <_PossibleTargetFrameworks Condition="'$(TargetFramework)' == ''">$(TargetFrameworks)</_PossibleTargetFrameworks>
     </PropertyGroup>
 
-    <GetNearestTargetFramework ReferringTargetFramework="$(ReferringTargetFramework)" 
+    <GetNearestTargetFramework ReferringTargetFramework="$(ReferringTargetFramework)"
                                PossibleTargetFrameworks="$(_PossibleTargetFrameworks)"
                                ProjectFilePath="$(MSBuildProjectFullPath)"
                                Condition="'$(_SkipNearestTargetFrameworkResolution)' != 'true'">
       <Output PropertyName="NearestTargetFramework" TaskParameter="NearestTargetFramework" />
     </GetNearestTargetFramework>
   </Target>
-  
+
 </Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -6,7 +6,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
           created a backup copy.  Incorrect changes to this file will make it
           impossible to load or build your projects from the command-line or the IDE.
 
-Copyright (c) .NET Foundation. All rights reserved. 
+Copyright (c) .NET Foundation. All rights reserved.
 ***********************************************************************************************
 -->
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
@@ -20,7 +20,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <GenerateResourceMSBuildArchitecture Condition=" '$(GenerateResourceMSBuildArchitecture)' == '' ">CurrentArchitecture</GenerateResourceMSBuildArchitecture>
     <GenerateResourceMSBuildRuntime Condition=" '$(GenerateResourceMSBuildRuntime)' == '' ">CurrentRuntime</GenerateResourceMSBuildRuntime>
   </PropertyGroup>
-  
+
   <Import Project="Microsoft.NET.Sdk.Common.targets" />
 
   <ImportGroup>
@@ -28,7 +28,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   </ImportGroup>
 
   <Import Project="Microsoft.NET.Sdk.DefaultItems.targets" />
-  
+
   <UsingTask TaskName="GenerateDepsFile" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
   <UsingTask TaskName="GenerateRuntimeConfigurationFiles" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
   <UsingTask TaskName="GetAssemblyVersion" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
@@ -121,7 +121,7 @@ Copyright (c) .NET Foundation. All rights reserved.
           Inputs="$(ProjectAssetsFile)"
           Outputs="$(ProjectDepsFilePath)">
 
-    <!-- 
+    <!--
     Explicitly not passing any ExcludeFromPublishPackageReferences information during 'Build', since these dependencies
     should be included during 'Build'.  They are only excluded on 'Publish'.
     -->
@@ -177,9 +177,9 @@ Copyright (c) .NET Foundation. All rights reserved.
                                        HostConfigurationOptions="@(RuntimeHostConfigurationOption)"
                                        AdditionalProbingPaths="@(AdditionalProbingPath)"
                                        IsSelfContained="$(SelfContained)">
-      
+
     </GenerateRuntimeConfigurationFiles>
-    
+
     <ItemGroup>
       <!-- Do this in an ItemGroup instead of as an output parameter of the GenerateDepsFile task so that it still gets added to the item set
           during incremental builds when the task is skipped -->
@@ -236,19 +236,19 @@ Copyright (c) .NET Foundation. All rights reserved.
     <RuntimeHostConfigurationOption Include="System.GC.Concurrent"
                                     Condition="'$(ConcurrentGarbageCollection)' != ''"
                                     Value="$(ConcurrentGarbageCollection)" />
-    
+
     <RuntimeHostConfigurationOption Include="System.GC.Server"
                                     Condition="'$(ServerGarbageCollection)' != ''"
                                     Value="$(ServerGarbageCollection)" />
-    
+
     <RuntimeHostConfigurationOption Include="System.GC.RetainVM"
                                     Condition="'$(RetainVMGarbageCollection)' != ''"
                                     Value="$(RetainVMGarbageCollection)" />
-    
+
     <RuntimeHostConfigurationOption Include="System.Threading.ThreadPool.MinThreads"
                                     Condition="'$(ThreadPoolMinThreads)' != ''"
                                     Value="$(ThreadPoolMinThreads)" />
-    
+
     <RuntimeHostConfigurationOption Include="System.Threading.ThreadPool.MaxThreads"
                                     Condition="'$(ThreadPoolMaxThreads)' != ''"
                                     Value="$(ThreadPoolMaxThreads)" />
@@ -303,7 +303,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <NETSdkError Condition="'@(NativeRestoredAppHostNETCore->Count())' &gt; 1"
                  ResourceName="MultipleFilesResolved"
                  FormatArguments="$(_DotNetAppHostExecutableName)" />
-    
+
     <EmbedAppNameInHost   AppHostSourcePath="@(NativeRestoredAppHostNETCore)"
                           AppHostDestinationDirectoryPath="$(AppHostDestinationDirectoryPath)"
                           AppBinaryName="$(AssemblyName)$(TargetExt)"
@@ -311,7 +311,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
       <Output TaskParameter="ModifiedAppHostPath" ItemName="NativeAppHostNETCore" />
     </EmbedAppNameInHost>
-    
+
     <ItemGroup Condition="'@(NativeAppHostNETCore)' == '' ">
       <NativeAppHostNETCore Include="@(NativeCopyLocalItems)"
                             Condition="'%(NativeCopyLocalItems.FileName)%(NativeCopyLocalItems.Extension)' == '$(_DotNetHostExecutableName)'" />
@@ -320,7 +320,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <NETSdkError Condition="'@(NativeAppHostNETCore->Count())' &gt; 1"
                  ResourceName="MultipleFilesResolved"
                  FormatArguments="@(NativeAppHostNETCore)" />
-    
+
     <ItemGroup Condition="'@(NativeAppHostNETCore)' != '' ">
       <NativeNETCoreCopyLocalItems Include="@(NativeAppHostNETCore)">
         <!-- Rename the host executable to the app's name -->
@@ -355,7 +355,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       <_FrameworkReferenceAssemblies Include="@(ReferencePath)"
                                      Condition="%(ReferencePath.FrameworkFile) == 'true' or
                                                 %(ReferencePath.ResolvedFrom) == 'ImplicitlyExpandDesignTimeFacades'" />
-      
+
       <!--
       "ReferenceOnly" assemblies are assemblies that are only used at compile-time, and they can't be resolved
       by the normal compile-assembly resolvers at runtime:
@@ -366,7 +366,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       -->
       <_ReferenceOnlyAssemblies Include="@(ReferencePath)"
                                 Exclude="@(_FrameworkReferenceAssemblies)"
-                                Condition="%(ReferencePath.CopyLocal) != 'true' and 
+                                Condition="%(ReferencePath.CopyLocal) != 'true' and
                                            %(ReferencePath.NuGetSourceType) == ''" />
 
       <_ReferenceAssemblies Include="@(_FrameworkReferenceAssemblies)" />
@@ -394,7 +394,7 @@ Copyright (c) .NET Foundation. All rights reserved.
         <RunArguments Condition="'$(RunArguments)' == ''">$(StartArguments)</RunArguments>
       </PropertyGroup>
     </When>
-    
+
     <When Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' and '$(_IsExecutable)' == 'true'">
       <PropertyGroup Condition="'$(SelfContained)' != 'true'">
         <!-- TODO: https://github.com/dotnet/sdk/issues/20 Need to get the DotNetHost path from MSBuild -->
@@ -410,7 +410,7 @@ Copyright (c) .NET Foundation. All rights reserved.
         <RunArguments Condition="'$(RunArguments)' == ''">$(StartArguments)</RunArguments>
       </PropertyGroup>
     </When>
-    
+
     <When Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework' and '$(_IsExecutable)' == 'true'">
       <PropertyGroup>
         <RunCommand Condition="'$(RunCommand)' == ''">$(TargetPath)</RunCommand>
@@ -511,11 +511,11 @@ Copyright (c) .NET Foundation. All rights reserved.
   ============================================================
   -->
   <Target Name="_DefaultMicrosoftNETPlatformLibrary">
-    
+
     <PropertyGroup Condition="'$(MicrosoftNETPlatformLibrary)' == ''">
       <MicrosoftNETPlatformLibrary Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">Microsoft.NETCore.App</MicrosoftNETPlatformLibrary>
     </PropertyGroup>
-    
+
   </Target>
 
   <!--
@@ -523,19 +523,19 @@ Copyright (c) .NET Foundation. All rights reserved.
                                       GetAllRuntimeIdentifiers
   ============================================================
   -->
-  <Target Name="GetAllRuntimeIdentifiers" 
+  <Target Name="GetAllRuntimeIdentifiers"
           Returns="$(RuntimeIdentifiers);$(RuntimeIdentifier)" />
 
   <!--
   ============================================================
                                       InjectTargetPathMetadata
-  
+
   Update TargetPathWithTargetPlatformMoniker with target framework
   identifier and version metadata.  This is so that the
   ImplicitlyExpandNETStandardFacades target can determine if a
   referenced project needs the .NET Standard facades even if
   the project hasn't been compiled to disk yet.
-  
+
   See https://github.com/dotnet/sdk/issues/1403 for more context
   ============================================================
   -->
@@ -546,7 +546,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       <TargetFrameworkVersion>$(_TargetFrameworkVersionWithoutV)</TargetFrameworkVersion>
     </TargetPathWithTargetPlatformMoniker>
   </ItemDefinitionGroup>
-  
+
   <!--
   ============================================================
                                          Project Capabilities
@@ -572,6 +572,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.NET.GenerateAssemblyInfo.targets" />
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.NET.ComposeStore.targets" />
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.NET.CrossGen.targets" />
+  <Import Project="$(MSBuildThisFileDirectory)Microsoft.NET.ObsoleteReferences.targets" />
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.NET.Publish.targets" />
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.NET.PackTool.targets" />
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.NET.PreserveCompilationContext.targets" />

--- a/src/Tests/Microsoft.NET.Restore.Tests/GivenThatWeWantToIgnoreObsoleteDotNetCliToolPackages.cs
+++ b/src/Tests/Microsoft.NET.Restore.Tests/GivenThatWeWantToIgnoreObsoleteDotNetCliToolPackages.cs
@@ -2,11 +2,11 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.IO;
-using System.Linq;
 using System.Xml.Linq;
 using FluentAssertions;
 using Microsoft.NET.TestFramework;
 using Microsoft.NET.TestFramework.Assertions;
+using Microsoft.NET.TestFramework.Commands;
 using Microsoft.NET.TestFramework.ProjectConstruction;
 using Xunit;
 using Xunit.Abstractions;
@@ -33,10 +33,10 @@ namespace Microsoft.NET.Restore.Tests
 
             toolProject.DotNetCliToolReferences.Add(new TestPackageReference(obsoletePackageId, "99.99.99", null));
 
-            var toolProjectInstance = _testAssetsManager.CreateTestProject(toolProject, identifier: toolProject.Name)
+            TestAsset toolProjectInstance = _testAssetsManager.CreateTestProject(toolProject, identifier: toolProject.Name)
                 .WithProjectChanges(project =>
                 {
-                    var ns = project.Root.Name.Namespace;
+                    XNamespace ns = project.Root.Name.Namespace;
 
                     var itemGroup = new XElement(ns + "ItemGroup");
                     project.Root.Add(itemGroup);
@@ -49,11 +49,11 @@ namespace Microsoft.NET.Restore.Tests
 
             toolProjectInstance.Restore(Log, toolProject.Name, "/v:n");
 
-            var restoreCommand = toolProjectInstance.GetRestoreCommand(Log, toolProject.Name);
+            RestoreCommand restoreCommand = toolProjectInstance.GetRestoreCommand(Log, toolProject.Name);
             restoreCommand.Execute("/v:n").Should()
                 .Pass()
                 .And
-                .HaveStdOutContaining($"warning DOTNET1018: Using DotNetCliToolReference to reference '{obsoletePackageId}' is obsolete and can be removed from this project. This tool is bundled by default in the .NET Core SDK.");
+                .HaveStdOutContaining($"warning : Using DotNetCliToolReference to reference '{obsoletePackageId}' is obsolete and can be removed from this project. This tool is bundled by default in the .NET Core SDK.");
 
             string toolAssetsFilePath = Path.Combine(TestContext.Current.NuGetCachePath, ".tools", toolProject.Name.ToLowerInvariant(), "99.99.99", toolProject.TargetFrameworks, "project.assets.json");
             Assert.False(File.Exists(toolAssetsFilePath), "Tool assets path should not have been generated");

--- a/src/Tests/Microsoft.NET.Restore.Tests/GivenThatWeWantToIgnoreObsoleteDotNetCliToolPackages.cs
+++ b/src/Tests/Microsoft.NET.Restore.Tests/GivenThatWeWantToIgnoreObsoleteDotNetCliToolPackages.cs
@@ -1,0 +1,62 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+using FluentAssertions;
+using Microsoft.NET.TestFramework;
+using Microsoft.NET.TestFramework.Assertions;
+using Microsoft.NET.TestFramework.ProjectConstruction;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.NET.Restore.Tests
+{
+    public class GivenThatWeWantToIgnoreObsoleteDotNetCliToolPackages : SdkTest
+    {
+        public GivenThatWeWantToIgnoreObsoleteDotNetCliToolPackages(ITestOutputHelper log) : base(log)
+        {
+        }
+
+        [Fact]
+        public void It_issues_warning_and_skips_restore_for_obsolete_DotNetCliToolReference()
+        {
+            const string obsoletePackageId = "Banana.CommandLineTool";
+
+            TestProject toolProject = new TestProject()
+            {
+                Name = "ObsoleteCliToolRefRestoreProject",
+                IsSdkProject = true,
+                TargetFrameworks = "netstandard2.0",
+            };
+
+            toolProject.DotNetCliToolReferences.Add(new TestPackageReference(obsoletePackageId, "99.99.99", null));
+
+            var toolProjectInstance = _testAssetsManager.CreateTestProject(toolProject, identifier: toolProject.Name)
+                .WithProjectChanges(project =>
+                {
+                    var ns = project.Root.Name.Namespace;
+
+                    var itemGroup = new XElement(ns + "ItemGroup");
+                    project.Root.Add(itemGroup);
+
+                    itemGroup.Add(new XElement(ns + "BundledDotNetCliToolReference",
+                        new XAttribute("Include", obsoletePackageId)));
+                });
+
+            NuGetConfigWriter.Write(toolProjectInstance.TestRoot, NuGetConfigWriter.DotnetCoreMyGetFeed);
+
+            toolProjectInstance.Restore(Log, toolProject.Name, "/v:n");
+
+            var restoreCommand = toolProjectInstance.GetRestoreCommand(Log, toolProject.Name);
+            restoreCommand.Execute("/v:n").Should()
+                .Pass()
+                .And
+                .HaveStdOutContaining($"warning DOTNET1018: Using DotNetCliToolReference to reference '{obsoletePackageId}' is obsolete and can be removed from this project. This tool is bundled by default in the .NET Core SDK.");
+
+            string toolAssetsFilePath = Path.Combine(TestContext.Current.NuGetCachePath, ".tools", toolProject.Name.ToLowerInvariant(), "99.99.99", toolProject.TargetFrameworks, "project.assets.json");
+            Assert.False(File.Exists(toolAssetsFilePath), "Tool assets path should not have been generated");
+        }
+    }
+}

--- a/src/Tests/Microsoft.NET.TestFramework/ProjectConstruction/TestProject.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/ProjectConstruction/TestProject.cs
@@ -21,7 +21,7 @@ namespace Microsoft.NET.TestFramework.ProjectConstruction
         public string RuntimeFrameworkVersion { get; set; }
 
         public string RuntimeIdentifier { get; set; }
-        
+
         //  TargetFrameworkVersion applies to non-SDK projects
         public string TargetFrameworkVersion { get; set; }
 
@@ -32,6 +32,8 @@ namespace Microsoft.NET.TestFramework.ProjectConstruction
         public List<string> References { get; } = new List<string>();
 
         public List<TestPackageReference> PackageReferences { get; } = new List<TestPackageReference>();
+
+        public List<TestPackageReference> DotNetCliToolReferences { get; } = new List<TestPackageReference>();
 
         public Dictionary<string, string> SourceFiles { get; } = new Dictionary<string, string>();
 
@@ -129,11 +131,19 @@ namespace Microsoft.NET.TestFramework.ProjectConstruction
                 packageReferenceItemGroup = new XElement(ns + "ItemGroup");
                 projectXml.Root.Add(packageReferenceItemGroup);
             }
+
             foreach (TestPackageReference packageReference in PackageReferences)
             {
-                    packageReferenceItemGroup.Add(new XElement(ns + "PackageReference",
-                        new XAttribute("Include", $"{packageReference.ID}"),
-                        new XAttribute("Version", $"{packageReference.Version}")));
+                packageReferenceItemGroup.Add(new XElement(ns + "PackageReference",
+                    new XAttribute("Include", $"{packageReference.ID}"),
+                    new XAttribute("Version", $"{packageReference.Version}")));
+            }
+
+            foreach (TestPackageReference dotnetCliToolReference in DotNetCliToolReferences)
+            {
+                packageReferenceItemGroup.Add(new XElement(ns + "DotNetCliToolReference",
+                    new XAttribute("Include", $"{dotnetCliToolReference.ID}"),
+                    new XAttribute("Version", $"{dotnetCliToolReference.Version}")));
             }
 
             var targetFrameworks = IsSdkProject ? TargetFrameworks.Split(';') : new[] { "net" };
@@ -161,7 +171,7 @@ namespace Microsoft.NET.TestFramework.ProjectConstruction
 
                 //  Update SDK reference to the version under test
                 targetTestAsset.SetSdkVersion(projectXml);
-                
+
             }
             else
             {


### PR DESCRIPTION
Resolves #2014 

I will make a corresponding change to dotnet/cli to generate Microsoft.NETCoreSdk.BundledCliTools.props with a list of obsolete package IDs to match https://github.com/dotnet/cli/blob/master/build/BundledDotnetTools.props.

VS:

![image](https://user-images.githubusercontent.com/2696087/37615207-eeb0e088-2b69-11e8-9a11-86c8e3a67ff6.png)

Command line:

![image](https://user-images.githubusercontent.com/2696087/37615256-100ade78-2b6a-11e8-9c78-a9420f76c85d.png)

FYI @muratg @DamianEdwards @prafullbhosale @divega @bricelam @Eilon 