### PR TITLE
Implicitly define compilation constant for target framework without version

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.BeforeCommon.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.BeforeCommon.targets
@@ -146,6 +146,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <!-- Add conditional compilation symbols for the target framework (for example NET461, NETSTANDARD2_0, NETCOREAPP1_0) -->
   <PropertyGroup Condition=" '$(DisableImplicitFrameworkDefines)' != 'true' and '$(TargetFrameworkIdentifier)' != '.NETPortable' and '$(TargetFrameworkIdentifier)' != ''">
     <_FrameworkIdentifierForImplicitDefine>$(TargetFrameworkIdentifier.Replace('.', '').ToUpperInvariant())</_FrameworkIdentifierForImplicitDefine>
+    <VersionlessImplicitFrameworkDefine>$(_FrameworkIdentifierForImplicitDefine)</VersionlessImplicitFrameworkDefine>
     <_FrameworkIdentifierForImplicitDefine Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework'">NET</_FrameworkIdentifierForImplicitDefine>
 
     <_FrameworkVersionForImplicitDefine Condition="$(TargetFrameworkVersion.StartsWith('v'))">$(TargetFrameworkVersion.Substring(1))</_FrameworkVersionForImplicitDefine>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.CSharp.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.CSharp.targets
@@ -31,6 +31,6 @@ Copyright (c) .NET Foundation. All rights reserved.
     <DefineConstants>$(DefineConstants);$(ImplicitConfigurationDefine)</DefineConstants>
   </PropertyGroup>
   <PropertyGroup>
-    <DefineConstants>$(DefineConstants);$(ImplicitFrameworkDefine)</DefineConstants>
+    <DefineConstants>$(DefineConstants);$(VersionlessImplicitFrameworkDefine);$(ImplicitFrameworkDefine)</DefineConstants>
   </PropertyGroup>
 </Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FSharp.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FSharp.targets
@@ -37,7 +37,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <DefineConstants>$(DefineConstants);$(ImplicitConfigurationDefine)</DefineConstants>
   </PropertyGroup>
   <PropertyGroup  Condition=" '$(UseBundledFSharpTargets)' == 'true' ">
-    <DefineConstants>$(DefineConstants);$(ImplicitFrameworkDefine)</DefineConstants>
+    <DefineConstants>$(DefineConstants);$(VersionlessImplicitFrameworkDefine);$(ImplicitFrameworkDefine)</DefineConstants>
   </PropertyGroup>
 
   <!-- ***************************************************************************************************************

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.VisualBasic.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.VisualBasic.targets
@@ -15,7 +15,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <AppDesignerFolder Condition="'$(AppDesignerFolder)' == ''">My Project</AppDesignerFolder>
   </PropertyGroup>
   <PropertyGroup>
-    <DefineConstants>$(DefineConstants),$(ImplicitFrameworkDefine)</DefineConstants>
+    <DefineConstants>$(DefineConstants),$(VersionlessImplicitFrameworkDefine),$(ImplicitFrameworkDefine)</DefineConstants>
     <DisableImplicitNamespaceImports Condition="'$(DisableImplicitNamespaceImports)'==''">$(DisableImplicitFrameworkReferences)</DisableImplicitNamespaceImports>
   </PropertyGroup>
   <ItemGroup Condition=" '$(DisableImplicitNamespaceImports)' != 'true' and '$(TargetFrameworkIdentifier)' == '.NETFramework'">

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildALibrary.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildALibrary.cs
@@ -456,20 +456,20 @@ namespace Microsoft.NET.Build.Tests
 
             var definedConstants = getValuesCommand.GetValues();
 
-            definedConstants.Should().BeEquivalentTo(new[] { expectedDefine, "TRACE", "NETSTANDARD1_5" });
+            definedConstants.Should().BeEquivalentTo(new[] { expectedDefine, "TRACE", "NETSTANDARD", "NETSTANDARD1_5" });
         }
 
         [Theory]
-        [InlineData(".NETStandard,Version=v1.0", new[] { "NETSTANDARD1_0" }, false)]
-        [InlineData("netstandard1.3", new[] { "NETSTANDARD1_3" }, false)]
-        [InlineData("netstandard1.6", new[] { "NETSTANDARD1_6" }, false)]
-        [InlineData("net45", new[] { "NET45" }, true)]
-        [InlineData("net461", new[] { "NET461" }, true)]
-        [InlineData("netcoreapp1.0", new[] { "NETCOREAPP1_0" }, false)]
+        [InlineData(".NETStandard,Version=v1.0", new[] { "NETSTANDARD", "NETSTANDARD1_0" }, false)]
+        [InlineData("netstandard1.3", new[] { "NETSTANDARD", "NETSTANDARD1_3" }, false)]
+        [InlineData("netstandard1.6", new[] { "NETSTANDARD", "NETSTANDARD1_6" }, false)]
+        [InlineData("net45", new[] { "NETFRAMEWORK", "NET45" }, true)]
+        [InlineData("net461", new[] { "NETFRAMEWORK", "NET461" }, true)]
+        [InlineData("netcoreapp1.0", new[] { "NETCOREAPP", "NETCOREAPP1_0" }, false)]
         [InlineData(".NETPortable,Version=v4.5,Profile=Profile78", new string[] { }, false)]
-        [InlineData(".NETFramework,Version=v4.0,Profile=Client", new string[] { "NET40" }, false)]
-        [InlineData("Xamarin.iOS,Version=v1.0", new string[] { "XAMARINIOS1_0" }, false)]
-        [InlineData("UnknownFramework,Version=v3.14", new string[] { "UNKNOWNFRAMEWORK3_14" }, false)]
+        [InlineData(".NETFramework,Version=v4.0,Profile=Client", new string[] { "NETFRAMEWORK", "NET40" }, false)]
+        [InlineData("Xamarin.iOS,Version=v1.0", new string[] { "XAMARINIOS", "XAMARINIOS1_0" }, false)]
+        [InlineData("UnknownFramework,Version=v3.14", new string[] { "UNKNOWNFRAMEWORK", "UNKNOWNFRAMEWORK3_14" }, false)]
         public void It_implicitly_defines_compilation_constants_for_the_target_framework(string targetFramework, string[] expectedDefines, bool buildOnlyOnWindows)
         {
             bool shouldCompile = true;

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPreserveCompilationContext.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPreserveCompilationContext.cs
@@ -69,11 +69,11 @@ namespace Microsoft.NET.Publish.Tests
                     string[] expectedDefines;
                     if (targetFramework == "net46")
                     {
-                        expectedDefines = new[] { "DEBUG", "TRACE", "NET46" };
+                        expectedDefines = new[] { "DEBUG", "TRACE", "NETFRAMEWORK", "NET46" };
                     }
                     else
                     {
-                        expectedDefines = new[] { "DEBUG", "TRACE", "NETCOREAPP1_1" };
+                        expectedDefines = new[] { "DEBUG", "TRACE", "NETCOREAPP", "NETCOREAPP1_1" };
                     }
 
                     dependencyContext.CompilationOptions.Defines.Should().BeEquivalentTo(expectedDefines);


### PR DESCRIPTION
Added ImplicitFrameworkDefineHierarchy property with out the versioned value for the given TargetFrameworkIdentifier

More information and origin @ #2072

🚲🏠 Please bike shed this, I just tried pick a name that worked, without changing the meaning of the existing properties.  `Hierarchy`, `Parent`, `Root` are all possibly valid values, along with many more.