### PR TITLE
Handle asset file reading errors more robustly

### DIFF
--- a/src/Tasks/Common/Resources/Strings.resx
+++ b/src/Tasks/Common/Resources/Strings.resx
@@ -333,4 +333,7 @@
   <data name="ProjectContainsObsoleteDotNetCliTool" xml:space="preserve">
     <value>Using DotNetCliToolReference to reference '{0}' is obsolete and can be removed from this project. This tool is bundled by default in the .NET Core SDK.</value>
   </data>
+  <data name="ErrorReadingAssetsFile" xml:space="preserve">
+    <value>Error reading assets file: {0}</value>
+  </data>
 </root>

--- a/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
@@ -362,6 +362,11 @@
         <target state="new">Using DotNetCliToolReference to reference '{0}' is obsolete and can be removed from this project. This tool is bundled by default in the .NET Core SDK.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ErrorReadingAssetsFile">
+        <source>Error reading assets file: {0}</source>
+        <target state="new">Error reading assets file: {0}</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Common/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.de.xlf
@@ -362,6 +362,11 @@
         <target state="new">Using DotNetCliToolReference to reference '{0}' is obsolete and can be removed from this project. This tool is bundled by default in the .NET Core SDK.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ErrorReadingAssetsFile">
+        <source>Error reading assets file: {0}</source>
+        <target state="new">Error reading assets file: {0}</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Common/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.es.xlf
@@ -362,6 +362,11 @@
         <target state="new">Using DotNetCliToolReference to reference '{0}' is obsolete and can be removed from this project. This tool is bundled by default in the .NET Core SDK.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ErrorReadingAssetsFile">
+        <source>Error reading assets file: {0}</source>
+        <target state="new">Error reading assets file: {0}</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
@@ -362,6 +362,11 @@
         <target state="new">Using DotNetCliToolReference to reference '{0}' is obsolete and can be removed from this project. This tool is bundled by default in the .NET Core SDK.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ErrorReadingAssetsFile">
+        <source>Error reading assets file: {0}</source>
+        <target state="new">Error reading assets file: {0}</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Common/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.it.xlf
@@ -362,6 +362,11 @@
         <target state="new">Using DotNetCliToolReference to reference '{0}' is obsolete and can be removed from this project. This tool is bundled by default in the .NET Core SDK.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ErrorReadingAssetsFile">
+        <source>Error reading assets file: {0}</source>
+        <target state="new">Error reading assets file: {0}</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
@@ -362,6 +362,11 @@
         <target state="new">Using DotNetCliToolReference to reference '{0}' is obsolete and can be removed from this project. This tool is bundled by default in the .NET Core SDK.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ErrorReadingAssetsFile">
+        <source>Error reading assets file: {0}</source>
+        <target state="new">Error reading assets file: {0}</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
@@ -362,6 +362,11 @@
         <target state="new">Using DotNetCliToolReference to reference '{0}' is obsolete and can be removed from this project. This tool is bundled by default in the .NET Core SDK.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ErrorReadingAssetsFile">
+        <source>Error reading assets file: {0}</source>
+        <target state="new">Error reading assets file: {0}</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
@@ -362,6 +362,11 @@
         <target state="new">Using DotNetCliToolReference to reference '{0}' is obsolete and can be removed from this project. This tool is bundled by default in the .NET Core SDK.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ErrorReadingAssetsFile">
+        <source>Error reading assets file: {0}</source>
+        <target state="new">Error reading assets file: {0}</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
@@ -362,6 +362,11 @@
         <target state="new">Using DotNetCliToolReference to reference '{0}' is obsolete and can be removed from this project. This tool is bundled by default in the .NET Core SDK.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ErrorReadingAssetsFile">
+        <source>Error reading assets file: {0}</source>
+        <target state="new">Error reading assets file: {0}</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
@@ -362,6 +362,11 @@
         <target state="new">Using DotNetCliToolReference to reference '{0}' is obsolete and can be removed from this project. This tool is bundled by default in the .NET Core SDK.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ErrorReadingAssetsFile">
+        <source>Error reading assets file: {0}</source>
+        <target state="new">Error reading assets file: {0}</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
@@ -362,6 +362,11 @@
         <target state="new">Using DotNetCliToolReference to reference '{0}' is obsolete and can be removed from this project. This tool is bundled by default in the .NET Core SDK.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ErrorReadingAssetsFile">
+        <source>Error reading assets file: {0}</source>
+        <target state="new">Error reading assets file: {0}</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
@@ -362,6 +362,11 @@
         <target state="new">Using DotNetCliToolReference to reference '{0}' is obsolete and can be removed from this project. This tool is bundled by default in the .NET Core SDK.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ErrorReadingAssetsFile">
+        <source>Error reading assets file: {0}</source>
+        <target state="new">Error reading assets file: {0}</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
@@ -362,6 +362,11 @@
         <target state="new">Using DotNetCliToolReference to reference '{0}' is obsolete and can be removed from this project. This tool is bundled by default in the .NET Core SDK.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ErrorReadingAssetsFile">
+        <source>Error reading assets file: {0}</source>
+        <target state="new">Error reading assets file: {0}</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/CheckForTargetInAssetsFile.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/CheckForTargetInAssetsFile.cs
@@ -22,7 +22,7 @@ namespace Microsoft.NET.Build.Tasks
 
         protected override void ExecuteCore()
         {
-            LockFile lockFile = new LockFileCache(BuildEngine4).GetLockFile(AssetsFilePath);
+            LockFile lockFile = new LockFileCache(this).GetLockFile(AssetsFilePath);
 
             var nugetFramework = NuGetUtils.ParseFrameworkName(TargetFrameworkMoniker);
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/FilterResolvedFiles.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/FilterResolvedFiles.cs
@@ -53,7 +53,7 @@ namespace Microsoft.NET.Build.Tasks
 
         protected override void ExecuteCore()
         {
-            var lockFileCache = new LockFileCache(BuildEngine4);
+            var lockFileCache = new LockFileCache(this);
             LockFile lockFile = lockFileCache.GetLockFile(AssetsFilePath);
 
             ProjectContext projectContext = lockFile.CreateProjectContext(

--- a/src/Tasks/Microsoft.NET.Build.Tasks/GenerateDepsFile.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/GenerateDepsFile.cs
@@ -104,7 +104,7 @@ namespace Microsoft.NET.Build.Tasks
         {
             LoadFilesToSkip();
 
-            LockFile lockFile = new LockFileCache(BuildEngine4).GetLockFile(AssetsFilePath);
+            LockFile lockFile = new LockFileCache(this).GetLockFile(AssetsFilePath);
             CompilationOptions compilationOptions = CompilationOptionsConverter.ConvertFrom(CompilerOptions);
 
             SingleProjectInfo mainProject = SingleProjectInfo.Create(

--- a/src/Tasks/Microsoft.NET.Build.Tasks/GenerateRuntimeConfigurationFiles.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/GenerateRuntimeConfigurationFiles.cs
@@ -64,7 +64,7 @@ namespace Microsoft.NET.Build.Tasks
                 Log.LogWarning(Strings.SkippingAdditionalProbingPaths);
             }
 
-            LockFile lockFile = new LockFileCache(BuildEngine4).GetLockFile(AssetsFilePath);
+            LockFile lockFile = new LockFileCache(this).GetLockFile(AssetsFilePath);
             ProjectContext projectContext = lockFile.CreateProjectContext(
                 NuGetUtils.ParseFrameworkName(TargetFrameworkMoniker),
                 RuntimeIdentifier,

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ReportAssetsLogMessages.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ReportAssetsLogMessages.cs
@@ -58,7 +58,7 @@ namespace Microsoft.NET.Build.Tasks
             {
                 if (_lockFile == null)
                 {
-                    _lockFile = new LockFileCache(BuildEngine4).GetLockFile(ProjectAssetsFile);
+                    _lockFile = new LockFileCache(this).GetLockFile(ProjectAssetsFile);
                 }
 
                 return _lockFile;

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageAssets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageAssets.cs
@@ -444,7 +444,7 @@ namespace Microsoft.NET.Build.Tasks
                 var targetFramework = NuGetUtils.ParseFrameworkName(task.TargetFrameworkMoniker);
 
                 _task = task;
-                _lockFile = new LockFileCache(task.BuildEngine4).GetLockFile(task.ProjectAssetsFile);
+                _lockFile = new LockFileCache(task).GetLockFile(task.ProjectAssetsFile);
                 _packageResolver = NuGetPackageResolver.CreateResolver(_lockFile, _task.ProjectPath);
                 _compileTimeTarget = _lockFile.GetTargetAndThrowIfNotFound(targetFramework, runtime: null);
                 _runtimeTarget = _lockFile.GetTargetAndThrowIfNotFound(targetFramework, _task.RuntimeIdentifier);

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageDependencies.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageDependencies.cs
@@ -143,7 +143,7 @@ namespace Microsoft.NET.Build.Tasks
             {
                 if (_lockFile == null)
                 {
-                    _lockFile = new LockFileCache(BuildEngine4).GetLockFile(ProjectAssetsFile);
+                    _lockFile = new LockFileCache(this).GetLockFile(ProjectAssetsFile);
                 }
 
                 return _lockFile;

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePublishAssemblies.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePublishAssemblies.cs
@@ -49,7 +49,7 @@ namespace Microsoft.NET.Build.Tasks
 
         protected override void ExecuteCore()
         {
-            var lockFileCache = new LockFileCache(BuildEngine4);
+            var lockFileCache = new LockFileCache(this);
             LockFile lockFile = lockFileCache.GetLockFile(AssetsFilePath);
             IEnumerable<string> excludeFromPublishPackageIds = PackageReferenceConverter.GetPackageIds(ExcludeFromPublishPackageReferences);
             IPackageResolver packageResolver = NuGetPackageResolver.CreateResolver(lockFile, ProjectPath);

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantDiagnosticsWhenAssetsFileCannotBeRead.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantDiagnosticsWhenAssetsFileCannotBeRead.cs
@@ -1,0 +1,55 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.IO;
+using System.Text.RegularExpressions;
+using FluentAssertions;
+using Microsoft.NET.TestFramework;
+using Microsoft.NET.TestFramework.Assertions;
+using Microsoft.NET.TestFramework.Commands;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.NET.Build.Tests
+{
+    public class GivenThatWeWantDiagnosticsWhenAssetsFileCannotBeRead : SdkTest
+    {
+        public GivenThatWeWantDiagnosticsWhenAssetsFileCannotBeRead(ITestOutputHelper log) : base(log)
+        {
+        }
+
+        [Fact]
+        public void It_reports_inaccessible_file()
+        {
+            var testAsset = _testAssetsManager.CopyTestAsset("HelloWorld").WithSource().Restore(Log);
+            var build = new BuildCommand(Log, testAsset.TestRoot);
+            var assetsFile = Path.Combine(build.GetBaseIntermediateDirectory().FullName, "project.assets.json");
+
+            using (var exclusive = File.Open(assetsFile, FileMode.Open, FileAccess.ReadWrite, FileShare.None))
+            {
+                build.Execute().Should().Fail().And.HaveStdOutContaining(assetsFile);
+            }
+        }
+
+        [Fact]
+        public void It_reports_missing_file()
+        {
+            var testAsset = _testAssetsManager.CopyTestAsset("HelloWorld").WithSource();
+            var build = new BuildCommand(Log, testAsset.TestRoot);
+            var assetsFile = Path.Combine(build.GetBaseIntermediateDirectory().FullName, "project.assets.json");
+
+            build.Execute().Should().Fail().And.HaveStdOutContaining(assetsFile);
+        }
+
+        [Fact]
+        public void It_reports_corrupt_file()
+        {
+            var testAsset = _testAssetsManager.CopyTestAsset("HelloWorld").WithSource().Restore(Log);
+            var build = new BuildCommand(Log, testAsset.TestRoot);
+            var assetsFile = Path.Combine(build.GetBaseIntermediateDirectory().FullName, "project.assets.json");
+
+            File.WriteAllText(assetsFile, "{ corrupt_file: ");
+            build.Execute().Should().Fail().And.HaveStdOutMatching($"{Regex.Escape(assetsFile)}.*corrupt_file");
+        }
+    }
+}

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToStoreAProjectWithDependencies.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToStoreAProjectWithDependencies.cs
@@ -160,7 +160,7 @@ namespace Microsoft.NET.Publish.Tests
             storeDirectory.Should().OnlyHaveFiles(files_on_disk);
         }
 
-        [CoreMSBuildOnlyFact]
+        [CoreMSBuildAndWindowsOnlyFact] // Windows only because of flakiness on Linux tracked by https://github.com/dotnet/sdk/issues/2089
         public void compose_multifile()
         {
             TestAsset simpleDependenciesAsset = _testAssetsManager


### PR DESCRIPTION
The recent episode where an assembly binding conflict resulted in nonsensical "Missing target in assets file" errors revealed several holes in how errors in the assets file are handled. This ensures that we never allow a bogus empty lock file to surface to our build logic and that all messages from NuGet or System.IO are preseved in the build output.

Fix #18 