### PR TITLE
Roll forward self-contained apps to latest patch version

### DIFF
--- a/build/Versions.props
+++ b/build/Versions.props
@@ -19,7 +19,7 @@
 
   <!-- Toolset Dependencies -->
   <PropertyGroup>
-    <DotNetCliVersion>2.1.300-preview2-008290</DotNetCliVersion>
+    <DotNetCliVersion>2.1.300-preview3-008414</DotNetCliVersion>
     <RoslynToolsRepoToolsetVersion>1.0.0-beta-62615-02</RoslynToolsRepoToolsetVersion>
     <VSWhereVersion>2.2.7</VSWhereVersion>
   </PropertyGroup>

--- a/src/Tasks/Common/Resources/Strings.resx
+++ b/src/Tasks/Common/Resources/Strings.resx
@@ -336,4 +336,10 @@
   <data name="ErrorReadingAssetsFile" xml:space="preserve">
     <value>Error reading assets file: {0}</value>
   </data>
+  <data name="MismatchedPlatformPackageVersion" xml:space="preserve">
+    <value>The project was restored using {0} version {1}, but with current settings, version {2} would be used instead.  To resolve this issue, make sure the same settings are used for restore and for subsequent operations such as build or publish.  Typically this issue can occur if the RuntimeIdentifier property is set during build or publish but not during restore.</value>
+    <comment>{0} - Package Identifier for platform package
+{1} - Restored version of platform package
+{2} - Current version of platform package</comment>
+  </data>
 </root>

--- a/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
@@ -367,6 +367,13 @@
         <target state="new">Error reading assets file: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="MismatchedPlatformPackageVersion">
+        <source>The project was restored using {0} version {1}, but with current settings, version {2} would be used instead.  To resolve this issue, make sure the same settings are used for restore and for subsequent operations such as build or publish.  Typically this issue can occur if the RuntimeIdentifier property is set during build or publish but not during restore.</source>
+        <target state="new">The project was restored using {0} version {1}, but with current settings, version {2} would be used instead.  To resolve this issue, make sure the same settings are used for restore and for subsequent operations such as build or publish.  Typically this issue can occur if the RuntimeIdentifier property is set during build or publish but not during restore.</target>
+        <note>{0} - Package Identifier for platform package
+{1} - Restored version of platform package
+{2} - Current version of platform package</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Common/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.de.xlf
@@ -367,6 +367,13 @@
         <target state="new">Error reading assets file: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="MismatchedPlatformPackageVersion">
+        <source>The project was restored using {0} version {1}, but with current settings, version {2} would be used instead.  To resolve this issue, make sure the same settings are used for restore and for subsequent operations such as build or publish.  Typically this issue can occur if the RuntimeIdentifier property is set during build or publish but not during restore.</source>
+        <target state="new">The project was restored using {0} version {1}, but with current settings, version {2} would be used instead.  To resolve this issue, make sure the same settings are used for restore and for subsequent operations such as build or publish.  Typically this issue can occur if the RuntimeIdentifier property is set during build or publish but not during restore.</target>
+        <note>{0} - Package Identifier for platform package
+{1} - Restored version of platform package
+{2} - Current version of platform package</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Common/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.es.xlf
@@ -367,6 +367,13 @@
         <target state="new">Error reading assets file: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="MismatchedPlatformPackageVersion">
+        <source>The project was restored using {0} version {1}, but with current settings, version {2} would be used instead.  To resolve this issue, make sure the same settings are used for restore and for subsequent operations such as build or publish.  Typically this issue can occur if the RuntimeIdentifier property is set during build or publish but not during restore.</source>
+        <target state="new">The project was restored using {0} version {1}, but with current settings, version {2} would be used instead.  To resolve this issue, make sure the same settings are used for restore and for subsequent operations such as build or publish.  Typically this issue can occur if the RuntimeIdentifier property is set during build or publish but not during restore.</target>
+        <note>{0} - Package Identifier for platform package
+{1} - Restored version of platform package
+{2} - Current version of platform package</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
@@ -367,6 +367,13 @@
         <target state="new">Error reading assets file: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="MismatchedPlatformPackageVersion">
+        <source>The project was restored using {0} version {1}, but with current settings, version {2} would be used instead.  To resolve this issue, make sure the same settings are used for restore and for subsequent operations such as build or publish.  Typically this issue can occur if the RuntimeIdentifier property is set during build or publish but not during restore.</source>
+        <target state="new">The project was restored using {0} version {1}, but with current settings, version {2} would be used instead.  To resolve this issue, make sure the same settings are used for restore and for subsequent operations such as build or publish.  Typically this issue can occur if the RuntimeIdentifier property is set during build or publish but not during restore.</target>
+        <note>{0} - Package Identifier for platform package
+{1} - Restored version of platform package
+{2} - Current version of platform package</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Common/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.it.xlf
@@ -367,6 +367,13 @@
         <target state="new">Error reading assets file: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="MismatchedPlatformPackageVersion">
+        <source>The project was restored using {0} version {1}, but with current settings, version {2} would be used instead.  To resolve this issue, make sure the same settings are used for restore and for subsequent operations such as build or publish.  Typically this issue can occur if the RuntimeIdentifier property is set during build or publish but not during restore.</source>
+        <target state="new">The project was restored using {0} version {1}, but with current settings, version {2} would be used instead.  To resolve this issue, make sure the same settings are used for restore and for subsequent operations such as build or publish.  Typically this issue can occur if the RuntimeIdentifier property is set during build or publish but not during restore.</target>
+        <note>{0} - Package Identifier for platform package
+{1} - Restored version of platform package
+{2} - Current version of platform package</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
@@ -367,6 +367,13 @@
         <target state="new">Error reading assets file: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="MismatchedPlatformPackageVersion">
+        <source>The project was restored using {0} version {1}, but with current settings, version {2} would be used instead.  To resolve this issue, make sure the same settings are used for restore and for subsequent operations such as build or publish.  Typically this issue can occur if the RuntimeIdentifier property is set during build or publish but not during restore.</source>
+        <target state="new">The project was restored using {0} version {1}, but with current settings, version {2} would be used instead.  To resolve this issue, make sure the same settings are used for restore and for subsequent operations such as build or publish.  Typically this issue can occur if the RuntimeIdentifier property is set during build or publish but not during restore.</target>
+        <note>{0} - Package Identifier for platform package
+{1} - Restored version of platform package
+{2} - Current version of platform package</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
@@ -367,6 +367,13 @@
         <target state="new">Error reading assets file: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="MismatchedPlatformPackageVersion">
+        <source>The project was restored using {0} version {1}, but with current settings, version {2} would be used instead.  To resolve this issue, make sure the same settings are used for restore and for subsequent operations such as build or publish.  Typically this issue can occur if the RuntimeIdentifier property is set during build or publish but not during restore.</source>
+        <target state="new">The project was restored using {0} version {1}, but with current settings, version {2} would be used instead.  To resolve this issue, make sure the same settings are used for restore and for subsequent operations such as build or publish.  Typically this issue can occur if the RuntimeIdentifier property is set during build or publish but not during restore.</target>
+        <note>{0} - Package Identifier for platform package
+{1} - Restored version of platform package
+{2} - Current version of platform package</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
@@ -367,6 +367,13 @@
         <target state="new">Error reading assets file: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="MismatchedPlatformPackageVersion">
+        <source>The project was restored using {0} version {1}, but with current settings, version {2} would be used instead.  To resolve this issue, make sure the same settings are used for restore and for subsequent operations such as build or publish.  Typically this issue can occur if the RuntimeIdentifier property is set during build or publish but not during restore.</source>
+        <target state="new">The project was restored using {0} version {1}, but with current settings, version {2} would be used instead.  To resolve this issue, make sure the same settings are used for restore and for subsequent operations such as build or publish.  Typically this issue can occur if the RuntimeIdentifier property is set during build or publish but not during restore.</target>
+        <note>{0} - Package Identifier for platform package
+{1} - Restored version of platform package
+{2} - Current version of platform package</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
@@ -367,6 +367,13 @@
         <target state="new">Error reading assets file: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="MismatchedPlatformPackageVersion">
+        <source>The project was restored using {0} version {1}, but with current settings, version {2} would be used instead.  To resolve this issue, make sure the same settings are used for restore and for subsequent operations such as build or publish.  Typically this issue can occur if the RuntimeIdentifier property is set during build or publish but not during restore.</source>
+        <target state="new">The project was restored using {0} version {1}, but with current settings, version {2} would be used instead.  To resolve this issue, make sure the same settings are used for restore and for subsequent operations such as build or publish.  Typically this issue can occur if the RuntimeIdentifier property is set during build or publish but not during restore.</target>
+        <note>{0} - Package Identifier for platform package
+{1} - Restored version of platform package
+{2} - Current version of platform package</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
@@ -367,6 +367,13 @@
         <target state="new">Error reading assets file: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="MismatchedPlatformPackageVersion">
+        <source>The project was restored using {0} version {1}, but with current settings, version {2} would be used instead.  To resolve this issue, make sure the same settings are used for restore and for subsequent operations such as build or publish.  Typically this issue can occur if the RuntimeIdentifier property is set during build or publish but not during restore.</source>
+        <target state="new">The project was restored using {0} version {1}, but with current settings, version {2} would be used instead.  To resolve this issue, make sure the same settings are used for restore and for subsequent operations such as build or publish.  Typically this issue can occur if the RuntimeIdentifier property is set during build or publish but not during restore.</target>
+        <note>{0} - Package Identifier for platform package
+{1} - Restored version of platform package
+{2} - Current version of platform package</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
@@ -367,6 +367,13 @@
         <target state="new">Error reading assets file: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="MismatchedPlatformPackageVersion">
+        <source>The project was restored using {0} version {1}, but with current settings, version {2} would be used instead.  To resolve this issue, make sure the same settings are used for restore and for subsequent operations such as build or publish.  Typically this issue can occur if the RuntimeIdentifier property is set during build or publish but not during restore.</source>
+        <target state="new">The project was restored using {0} version {1}, but with current settings, version {2} would be used instead.  To resolve this issue, make sure the same settings are used for restore and for subsequent operations such as build or publish.  Typically this issue can occur if the RuntimeIdentifier property is set during build or publish but not during restore.</target>
+        <note>{0} - Package Identifier for platform package
+{1} - Restored version of platform package
+{2} - Current version of platform package</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
@@ -367,6 +367,13 @@
         <target state="new">Error reading assets file: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="MismatchedPlatformPackageVersion">
+        <source>The project was restored using {0} version {1}, but with current settings, version {2} would be used instead.  To resolve this issue, make sure the same settings are used for restore and for subsequent operations such as build or publish.  Typically this issue can occur if the RuntimeIdentifier property is set during build or publish but not during restore.</source>
+        <target state="new">The project was restored using {0} version {1}, but with current settings, version {2} would be used instead.  To resolve this issue, make sure the same settings are used for restore and for subsequent operations such as build or publish.  Typically this issue can occur if the RuntimeIdentifier property is set during build or publish but not during restore.</target>
+        <note>{0} - Package Identifier for platform package
+{1} - Restored version of platform package
+{2} - Current version of platform package</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
@@ -367,6 +367,13 @@
         <target state="new">Error reading assets file: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="MismatchedPlatformPackageVersion">
+        <source>The project was restored using {0} version {1}, but with current settings, version {2} would be used instead.  To resolve this issue, make sure the same settings are used for restore and for subsequent operations such as build or publish.  Typically this issue can occur if the RuntimeIdentifier property is set during build or publish but not during restore.</source>
+        <target state="new">The project was restored using {0} version {1}, but with current settings, version {2} would be used instead.  To resolve this issue, make sure the same settings are used for restore and for subsequent operations such as build or publish.  Typically this issue can occur if the RuntimeIdentifier property is set during build or publish but not during restore.</target>
+        <note>{0} - Package Identifier for platform package
+{1} - Restored version of platform package
+{2} - Current version of platform package</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.targets
@@ -97,6 +97,13 @@ Copyright (c) .NET Foundation. All rights reserved.
       TODO: Get feedback on these names and then delete this comment
   -->
 
+  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
+    <!-- These properties will allow the latest patch versions to be set in the CLI (via BundledVersions.props) or overridden by tests -->
+    <LatestPatchVersionForNetCore1_0 Condition="'$(LatestPatchVersionForNetCore1_0)' == ''">1.0.10</LatestPatchVersionForNetCore1_0>
+    <LatestPatchVersionForNetCore1_1 Condition="'$(LatestPatchVersionForNetCore1_1)' == ''">1.1.7</LatestPatchVersionForNetCore1_1>
+    <LatestPatchVersionForNetCore2_0 Condition="'$(LatestPatchVersionForNetCore2_0)' == ''">2.0.6</LatestPatchVersionForNetCore2_0>
+  </PropertyGroup>
+
   <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(DefaultNetCorePatchVersion)' == ''">
     <DefaultNetCorePatchVersion Condition="'$(_TargetFrameworkVersionWithoutV)' == '1.0'">1.0.5</DefaultNetCorePatchVersion>
     <DefaultNetCorePatchVersion Condition="'$(_TargetFrameworkVersionWithoutV)' == '1.1'">1.1.2</DefaultNetCorePatchVersion>
@@ -109,9 +116,9 @@ Copyright (c) .NET Foundation. All rights reserved.
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(LatestNetCorePatchVersion)' == ''">
-    <LatestNetCorePatchVersion Condition="'$(_TargetFrameworkVersionWithoutV)' == '1.0'">1.0.10</LatestNetCorePatchVersion>
-    <LatestNetCorePatchVersion Condition="'$(_TargetFrameworkVersionWithoutV)' == '1.1'">1.1.7</LatestNetCorePatchVersion>
-    <LatestNetCorePatchVersion Condition="'$(_TargetFrameworkVersionWithoutV)' == '2.0'">2.0.6</LatestNetCorePatchVersion>
+    <LatestNetCorePatchVersion Condition="'$(_TargetFrameworkVersionWithoutV)' == '1.0'">$(LatestPatchVersionForNetCore1_0)</LatestNetCorePatchVersion>
+    <LatestNetCorePatchVersion Condition="'$(_TargetFrameworkVersionWithoutV)' == '1.1'">$(LatestPatchVersionForNetCore1_1)</LatestNetCorePatchVersion>
+    <LatestNetCorePatchVersion Condition="'$(_TargetFrameworkVersionWithoutV)' == '2.0'">$(LatestPatchVersionForNetCore2_0)</LatestNetCorePatchVersion>
 
     <!-- If targeting the same pre-release that is bundled with the .NET Core SDK, use the bundled package version
          provided by Microsoft.NETCoreSdk.BundledVersions.props -->

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.targets
@@ -59,86 +59,77 @@ Copyright (c) .NET Foundation. All rights reserved.
     <!-- Default to use the latest stable release. -->
     <NETStandardImplicitPackageVersion Condition="'$(NETStandardImplicitPackageVersion)' ==''">2.0.2</NETStandardImplicitPackageVersion>
   </PropertyGroup>
-  
-  <!--  
-    Determine the RuntimeFrameworkVersion when targeting .NET Core
+
+  <!--
+    Determine the version (including patch) of .NET Core to target.
     
-    When targeting .NET Core, the TargetFramework is generally used to specify which version of the runtime to use.
+    When targeting .NET Core, the TargetFramework is used to specify the major and minor version of the runtime to use.  By default,
+    the patch version is inferred.  The general logic is that self-contained apps will target the latest patch that the SDK
+    knows about, while framework-dependent apps will target the ".0" patch (and roll forward to the latest patch installed at
+    runtime).
     
-    In order to target a specific patch version, or to float the version number (2.0-*), the RuntimeFrameworkVersion
-    property can be used.
+    When targeting .NET Core 1.0 and 1.1, framework-dependent apps use 1.0.5 and 1.1.2, respectively.  This is done for compatibility
+    with previous releases that bumped the self-contained and framework-dependent versions together.
+    
+    The TargetLatestRuntimePatch property can be set to true or false to explicitly opt in or out of the logic to roll forward
+    to the latest patch, regardless of whether the app is self-contained or framework-dependent.
+    
+    The RuntimeFrameworkVersion is where the actual version of the .NET Core runtime to target is stored.  It is the version that is
+    used in the implicit PackageReference to Microsoft.NETCore.App.  The RuntimeFrameworkVersion can also be set explicitly, which
+    will disable all the other logic that automatically selects the version of .NET Core to target.
     
     The framework version that is written to the runtimeconfig.json file is based on the actual resolved package version
-    of Microsoft.NETCore.App.  This is to allow floating the verion number.
-    
-    If RuntimeFrameworkVersion is not specified, the following logic applies:
-    
-    - Self-contained apps use the latest corrsesponding patch version (from when the SDK shipped)
-
-    - When targeting .NET Core 2.0 or higher:
-      - Framework-dependent apps use the target framework version with a ".0" patch version
-
-    - When targeting .NET Core 1.0 and 1.1
-      - Framework-dependent apps use 1.0.5 and 1.1.2, respectively.
-      - This is done for compatibility with previous releases that bumped the self-contained and framework-dependent versions together.
+    of Microsoft.NETCore.App.  This is to allow floating the verion number (ie the RuntimeFrameworkVersion could be set to
+    "2.0-*".
+  
   -->
 
-  <!-- These properties are here as a test hook so that we can test with the versions bumped before the actual framework
-       builds are available. -->
-  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(RuntimeFrameworkVersion)' == ''"> 
-    <ImplicitRuntimeFrameworkVersionForSelfContainedNetCoreApp1_0
-      Condition="'$(ImplicitRuntimeFrameworkVersionForSelfContainedNetCoreApp1_0)' == ''">1.0.5</ImplicitRuntimeFrameworkVersionForSelfContainedNetCoreApp1_0>
-    <ImplicitRuntimeFrameworkVersionForSelfContainedNetCoreApp1_1
-      Condition="'$(ImplicitRuntimeFrameworkVersionForSelfContainedNetCoreApp1_1)' == ''">1.1.2</ImplicitRuntimeFrameworkVersionForSelfContainedNetCoreApp1_1>
-    <ImplicitRuntimeFrameworkVersionForSelfContainedNetCoreApp2_0
-      Condition="'$(ImplicitRuntimeFrameworkVersionForSelfContainedNetCoreApp2_0)' == ''">2.0.0</ImplicitRuntimeFrameworkVersionForSelfContainedNetCoreApp2_0>
+  <!--
+      Possible property names to enable roll-forward:
+      - TargetLatestRuntimePatch
+      - TargetLatestNetCoreRuntimePatch
+      - RollForwardRuntime
+      - RollForwardNetCoreRuntime
+      
+     Possible property names for roll-forward/not roll-forward versions
+      - LatestNetCorePatchVersion / DefaultNetCorePatchVersion
+      
+      TODO: Get feedback on these names and then delete this comment
+  -->
+
+  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(DefaultNetCorePatchVersion)' == ''">
+    <DefaultNetCorePatchVersion Condition="'$(_TargetFrameworkVersionWithoutV)' == '1.0'">1.0.5</DefaultNetCorePatchVersion>
+    <DefaultNetCorePatchVersion Condition="'$(_TargetFrameworkVersionWithoutV)' == '1.1'">1.1.2</DefaultNetCorePatchVersion>
+
+    <!-- If targeting the same pre-release that is bundled with the .NET Core SDK, use the bundled package version
+         provided by Microsoft.NETCoreSdk.BundledVersions.props -->
+    <DefaultNetCorePatchVersion Condition="'$(_TargetFrameworkVersionWithoutV)' == '$(BundledNETCoreAppTargetFrameworkVersion)'">$(BundledNETCoreAppPackageVersion)</DefaultNetCorePatchVersion>
+    <!-- If not covered by the previous cases use the target framework version for the default patch version -->
+    <DefaultNetCorePatchVersion Condition="'$(DefaultNetCorePatchVersion)' == ''">$(_TargetFrameworkVersionWithoutV)</DefaultNetCorePatchVersion>
   </PropertyGroup>
 
-  <!-- Select implicit runtime framework versions -->
-  <Choose>
-    <!-- If not targeting .NET Core, or if RuntimeFrameworkVersion is already set, do nothing -->
-    <When Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp' Or '$(RuntimeFrameworkVersion)' != ''" />
+  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(LatestNetCorePatchVersion)' == ''">
+    <LatestNetCorePatchVersion Condition="'$(_TargetFrameworkVersionWithoutV)' == '1.0'">1.0.10</LatestNetCorePatchVersion>
+    <LatestNetCorePatchVersion Condition="'$(_TargetFrameworkVersionWithoutV)' == '1.1'">1.1.7</LatestNetCorePatchVersion>
+    <LatestNetCorePatchVersion Condition="'$(_TargetFrameworkVersionWithoutV)' == '2.0'">2.0.6</LatestNetCorePatchVersion>
 
-    <When Condition="'$(_TargetFrameworkVersionWithoutV)' == '1.0'">
-      <PropertyGroup>
-        <ImplicitRuntimeFrameworkVersionForFrameworkDependentApp>1.0.5</ImplicitRuntimeFrameworkVersionForFrameworkDependentApp>
-        <ImplicitRuntimeFrameworkVersionForSelfContainedApp>$(ImplicitRuntimeFrameworkVersionForSelfContainedNetCoreApp1_0)</ImplicitRuntimeFrameworkVersionForSelfContainedApp>
-      </PropertyGroup>
-    </When>
-    <When Condition="'$(_TargetFrameworkVersionWithoutV)' == '1.1'">
-      <PropertyGroup>
-        <ImplicitRuntimeFrameworkVersionForFrameworkDependentApp>1.1.2</ImplicitRuntimeFrameworkVersionForFrameworkDependentApp>
-        <ImplicitRuntimeFrameworkVersionForSelfContainedApp>$(ImplicitRuntimeFrameworkVersionForSelfContainedNetCoreApp1_1)</ImplicitRuntimeFrameworkVersionForSelfContainedApp>
-      </PropertyGroup>
-    </When>
-    <When Condition="'$(_TargetFrameworkVersionWithoutV)' == '2.0'">
-      <PropertyGroup>
-        <ImplicitRuntimeFrameworkVersionForFrameworkDependentApp>2.0.0</ImplicitRuntimeFrameworkVersionForFrameworkDependentApp>
-        <ImplicitRuntimeFrameworkVersionForSelfContainedApp>$(ImplicitRuntimeFrameworkVersionForSelfContainedNetCoreApp2_0)</ImplicitRuntimeFrameworkVersionForSelfContainedApp>
-      </PropertyGroup>
-    </When>
-
-    <!-- If targeting the same pre-release that is bundled with the .NET Core SDK, use the bundled package version provided by Microsoft.NETCoreSdk.BundledVersions.props -->
-    <When Condition="'$(_TargetFrameworkVersionWithoutV)' == '$(BundledNETCoreAppTargetFrameworkVersion)'">
-      <PropertyGroup>
-        <ImplicitRuntimeFrameworkVersionForFrameworkDependentApp>$(BundledNETCoreAppPackageVersion)</ImplicitRuntimeFrameworkVersionForFrameworkDependentApp>
-        <ImplicitRuntimeFrameworkVersionForSelfContainedApp>$(BundledNETCoreAppPackageVersion)</ImplicitRuntimeFrameworkVersionForSelfContainedApp>
-      </PropertyGroup>
-    </When>
-    
-    <!-- If not covered by the previous cases, use the target framework version for the implicit RuntimeFrameworkVersions -->
-    <Otherwise>
-      <PropertyGroup>
-        <ImplicitRuntimeFrameworkVersionForFrameworkDependentApp>$(_TargetFrameworkVersionWithoutV)</ImplicitRuntimeFrameworkVersionForFrameworkDependentApp>
-        <ImplicitRuntimeFrameworkVersionForSelfContainedApp>$(_TargetFrameworkVersionWithoutV)</ImplicitRuntimeFrameworkVersionForSelfContainedApp>
-      </PropertyGroup>
-    </Otherwise>
-  </Choose>
+    <!-- If targeting the same pre-release that is bundled with the .NET Core SDK, use the bundled package version
+         provided by Microsoft.NETCoreSdk.BundledVersions.props -->
+    <LatestNetCorePatchVersion Condition="'$(_TargetFrameworkVersionWithoutV)' == '$(BundledNETCoreAppTargetFrameworkVersion)'">$(BundledNETCoreAppPackageVersion)</LatestNetCorePatchVersion>
+    <!-- If not covered by the previous cases use the target framework version for the latest patch version -->
+    <LatestNetCorePatchVersion Condition="'$(LatestNetCorePatchVersion)' == ''">$(_TargetFrameworkVersionWithoutV)</LatestNetCorePatchVersion>
+  </PropertyGroup>
+  
+  <PropertyGroup Condition="'$(TargetLatestRuntimePatch)' == ''">
+    <TargetLatestRuntimePatch Condition="'$(SelfContained)' == 'true' ">true</TargetLatestRuntimePatch>
+    <TargetLatestRuntimePatch Condition="'$(SelfContained)' != 'true' ">false</TargetLatestRuntimePatch>
+  </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(RuntimeFrameworkVersion)' == ''">
-    <RuntimeFrameworkVersion Condition="'$(SelfContained)' == 'true' ">$(ImplicitRuntimeFrameworkVersionForSelfContainedApp)</RuntimeFrameworkVersion>
-    <RuntimeFrameworkVersion Condition="'$(SelfContained)' != 'true' ">$(ImplicitRuntimeFrameworkVersionForFrameworkDependentApp)</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion Condition="'$(TargetLatestRuntimePatch)' == 'true' ">$(LatestNetCorePatchVersion)</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion Condition="'$(TargetLatestRuntimePatch)' != 'true' ">$(DefaultNetCorePatchVersion)</RuntimeFrameworkVersion>
   </PropertyGroup>
+  
   
   <!--
     Automatically add Link metadata to items of specific types if they are outside of the project folder and don't already have the Link metadata set.

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.targets
@@ -129,7 +129,18 @@ Copyright (c) .NET Foundation. All rights reserved.
     <RuntimeFrameworkVersion Condition="'$(TargetLatestRuntimePatch)' == 'true' ">$(LatestNetCorePatchVersion)</RuntimeFrameworkVersion>
     <RuntimeFrameworkVersion Condition="'$(TargetLatestRuntimePatch)' != 'true' ">$(DefaultNetCorePatchVersion)</RuntimeFrameworkVersion>
   </PropertyGroup>
-  
+
+  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
+    <!-- This property is different than MicrosoftNETPlatformLibrary.  MicrosoftNETPlatformLibrary is
+         used to trim the dependencies published with a framework-dependent app, and is overridden
+         by ASP.NET packages.
+         
+         The ImplicitPlatformPackageIdentifier is the package that is actually implicitly
+         referenced by the SDK, and is passed into the ResolvePackageAssets task
+         to verify that the restored version of the package matches the
+         RuntimeFrameworkVersion -->
+    <ImplicitPlatformPackageIdentifier>Microsoft.NETCore.App</ImplicitPlatformPackageIdentifier>
+  </PropertyGroup>
   
   <!--
     Automatically add Link metadata to items of specific types if they are outside of the project folder and don't already have the Link metadata set.

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.PackageDependencyResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.PackageDependencyResolution.targets
@@ -214,6 +214,8 @@ Copyright (c) .NET Foundation. All rights reserved.
       DisableFrameworkAssemblies="$(DisableLockFileFrameworks)"
       DisableTransitiveProjectReferences="$(DisableTransitiveProjectReferences)"
       EnsureRuntimePackageDependencies="$(EnsureRuntimePackageDependencies)"
+      ImplicitPlatformPackageIdentifier="$(ImplicitPlatformPackageIdentifier)"
+      ExpectedPlatformPackageVersion="$(RuntimeFrameworkVersion)"      
       >
 
       <!-- NOTE: items names here are inconsistent because they match prior implementation

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildADesktopExeWtihNetStandardLib.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildADesktopExeWtihNetStandardLib.cs
@@ -98,7 +98,7 @@ namespace Microsoft.NET.Build.Tests
         public void It_includes_netstandard(bool isSdk, ReferenceScenario scenario)
         {
             var testAsset = _testAssetsManager
-                .CopyTestAsset(GetTemplateName(isSdk), identifier: scenario.ToString())
+                .CopyTestAsset(GetTemplateName(isSdk), identifier: (isSdk ? "sdk_" : "") + scenario.ToString())
                 .WithSource()
                 .WithProjectChanges((projectPath, project) =>
                 {
@@ -194,7 +194,8 @@ namespace Microsoft.NET.Build.Tests
             var successMessage = "No conflicts found for support libs";
 
             var testAsset = _testAssetsManager
-                .CopyTestAsset(GetTemplateName(isSdk, usePackagesConfig))
+                .CopyTestAsset(GetTemplateName(isSdk, usePackagesConfig),
+                               identifier: isSdk.ToString() + "_" + usePackagesConfig.ToString())
                 .WithSource()
                 .WithProjectChanges((projectPath, project) =>
                 {
@@ -276,7 +277,7 @@ namespace Microsoft.NET.Build.Tests
         public void It_does_not_include_netstandard_when_inbox(bool isSdk)
         {
             var testAsset = _testAssetsManager
-                .CopyTestAsset(GetTemplateName(isSdk))
+                .CopyTestAsset(GetTemplateName(isSdk), identifier: isSdk.ToString())
                 .WithSource()
                 .WithProjectChanges((projectPath, project) =>
                 {
@@ -345,7 +346,7 @@ namespace Microsoft.NET.Build.Tests
         public void It_does_not_include_netstandard_when_libary_targets_netstandard14(bool isSdk)
         {
             var testAsset = _testAssetsManager
-                .CopyTestAsset(GetTemplateName(isSdk))
+                .CopyTestAsset(GetTemplateName(isSdk), identifier: isSdk.ToString())
                 .WithSource()
                 .WithProjectChanges((projectPath, project) =>
                 {
@@ -385,7 +386,7 @@ namespace Microsoft.NET.Build.Tests
         public void It_includes_netstandard_when_libary_targets_netstandard15(bool isSdk)
         {
             var testAsset = _testAssetsManager
-                .CopyTestAsset(GetTemplateName(isSdk))
+                .CopyTestAsset(GetTemplateName(isSdk), identifier: isSdk.ToString())
                 .WithSource()
                 .WithProjectChanges((projectPath, project) =>
                 {

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildANetCoreApp.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildANetCoreApp.cs
@@ -51,13 +51,13 @@ namespace Microsoft.NET.Build.Tests
         //  Test behavior when implicit version differs for framework-dependent and self-contained apps
         [Theory]
         [InlineData("netcoreapp1.0", false, true, "1.0.5")]
-        [InlineData("netcoreapp1.0", true, true, TestContext.ImplicitRuntimeFrameworkVersionForSelfContainedNetCoreApp1_0)]
+        [InlineData("netcoreapp1.0", true, true, "1.0.10")]
         [InlineData("netcoreapp1.0", false, false, "1.0.5")]
         [InlineData("netcoreapp1.1", false, true, "1.1.2")]
-        [InlineData("netcoreapp1.1", true, true, TestContext.ImplicitRuntimeFrameworkVersionForSelfContainedNetCoreApp1_1)]
+        [InlineData("netcoreapp1.1", true, true, "1.1.7")]
         [InlineData("netcoreapp1.1", false, false, "1.1.2")]
         [InlineData("netcoreapp2.0", false, true, "2.0.0")]
-        [InlineData("netcoreapp2.0", true, true, TestContext.ImplicitRuntimeFrameworkVersionForSelfContainedNetCoreApp2_0)]
+        [InlineData("netcoreapp2.0", true, true, "2.0.6")]
         [InlineData("netcoreapp2.0", false, false, "2.0.0")]
         public void It_targets_the_right_framework_depending_on_output_type(string targetFramework, bool selfContained, bool isExe, string expectedFrameworkVersion)
         {

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildANetCoreApp.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildANetCoreApp.cs
@@ -127,7 +127,7 @@ namespace Microsoft.NET.Build.Tests
 
                 var additionalProbingPaths = ((JArray)devruntimeConfig["runtimeOptions"]["additionalProbingPaths"]).Values<string>();
                 // can't use Path.Combine on segments with an illegal `|` character
-                var expectedPath = $"{Path.Combine(GetUserProfile(), ".dotnet", "store")}{Path.DirectorySeparatorChar}|arch|{Path.DirectorySeparatorChar}|tfm|";
+                var expectedPath = $"{Path.Combine(FileConstants.UserProfileFolder, ".dotnet", "store")}{Path.DirectorySeparatorChar}|arch|{Path.DirectorySeparatorChar}|tfm|";
                 additionalProbingPaths.Should().Contain(expectedPath);
             }
 
@@ -429,21 +429,6 @@ public static class Program
                 .Select(Path.GetFileName)
                 .Should()
                 .BeEquivalentTo("netcoreapp1.1");
-        }
-
-        private static string GetUserProfile()
-        {
-            string userDir;
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                userDir = "USERPROFILE";
-            }
-            else
-            {
-                userDir = "HOME";
-            }
-
-            return Environment.GetEnvironmentVariable(userDir);
         }
     }
 }

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAnAppWithLibrariesAndRid.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAnAppWithLibrariesAndRid.cs
@@ -23,6 +23,12 @@ namespace Microsoft.NET.Build.Tests
         public void It_builds_a_RID_specific_runnable_output()
         {
             var runtimeIdentifier = RuntimeEnvironment.GetRuntimeIdentifier();
+            string[] msbuildArgs = new[]
+            {
+                $"/p:RuntimeIdentifier={runtimeIdentifier}",
+                $"/p:TestRuntimeIdentifier={runtimeIdentifier}"
+            };
+
             var testAsset = _testAssetsManager
                 .CopyTestAsset("AppWithLibraryAndRid")
                 .WithSource();
@@ -31,14 +37,14 @@ namespace Microsoft.NET.Build.Tests
 
             var restoreCommand = new RestoreCommand(Log, projectPath, "App.csproj");
             restoreCommand
-                .Execute($"/p:TestRuntimeIdentifier={runtimeIdentifier}")
+                .Execute(msbuildArgs)
                 .Should()
                 .Pass();
 
             var buildCommand = new BuildCommand(Log, projectPath);
 
             buildCommand
-                .Execute($"/p:RuntimeIdentifier={runtimeIdentifier}", $"/p:TestRuntimeIdentifier={runtimeIdentifier}")
+                .Execute(msbuildArgs)
                 .Should()
                 .Pass();
 

--- a/src/Tests/Microsoft.NET.PerformanceTests/BuildPerf.cs
+++ b/src/Tests/Microsoft.NET.PerformanceTests/BuildPerf.cs
@@ -66,7 +66,7 @@ namespace Microsoft.NET.Perf.Tests
         {
             var testDir = _testAssetsManager.CreateTestDirectory(identifier: operation.ToString());
 
-            NuGetConfigWriter.Write(testDir.Path, NuGetConfigWriter.AspNetCoreDevFeed);
+            NuGetConfigWriter.Write(testDir.Path, NuGetConfigWriter.AspNetCoreDevFeed, NuGetConfigWriter.DotnetCoreMyGetFeed);
 
             var newCommand = new DotnetCommand(Log);
             newCommand.WorkingDirectory = testDir.Path;

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPreserveCompilationContext.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPreserveCompilationContext.cs
@@ -13,6 +13,8 @@ using Microsoft.NET.TestFramework.Commands;
 using Xunit;
 using System.Xml.Linq;
 using Xunit.Abstractions;
+using System.Collections.Generic;
+using Microsoft.NET.TestFramework.ProjectConstruction;
 
 namespace Microsoft.NET.Publish.Tests
 {
@@ -22,106 +24,128 @@ namespace Microsoft.NET.Publish.Tests
         {
         }
 
-        [Fact]
-        public void It_publishes_the_project_with_a_refs_folder_and_correct_deps_file()
+        [Theory]
+        [InlineData("net46", "netstandard1.3")]
+        [InlineData("netcoreapp1.1", "netstandard1.3")]
+        [InlineData("netcoreapp2.0", "netstandard2.0")]
+        public void It_publishes_the_project_with_a_refs_folder_and_correct_deps_file(string appTargetFramework, string libraryTargetFramework)
         {
-            var testAsset = _testAssetsManager
-                .CopyTestAsset("CompilationContext", "PreserveCompilationContext")
-                .WithSource();
+            if (appTargetFramework == "net46" && !RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return;
+            }
+
+            var testLibraryProject = new TestProject()
+            {
+                Name = "TestLibrary",
+                IsSdkProject = true,
+                TargetFrameworks = libraryTargetFramework
+            };
+
+            var testProject = new TestProject()
+            {
+                Name = "TestApp",
+                IsSdkProject = true,
+                IsExe = true,
+                TargetFrameworks = appTargetFramework,
+                RuntimeIdentifier = "win7-x86"
+            };
+
+            testProject.AdditionalProperties["PreserveCompilationContext"] = "true";
+            testProject.ReferencedProjects.Add(testLibraryProject);
+            testProject.PackageReferences.Add(new TestPackageReference("Newtonsoft.Json", "9.0.1"));
+            testProject.PackageReferences.Add(new TestPackageReference("System.Data.SqlClient", "4.4.3"));
+
+            var testAsset = _testAssetsManager.CreateTestProject(testProject, identifier: appTargetFramework);
 
             testAsset.Restore(Log, "TestApp");
-            testAsset.Restore(Log, "TestLibrary");
 
             var appProjectDirectory = Path.Combine(testAsset.TestRoot, "TestApp");
+            var publishCommand = new PublishCommand(Log, appProjectDirectory);
 
-            foreach (var targetFramework in new[] { "net46", "netcoreapp1.1" })
+            publishCommand
+                .Execute()
+                .Should()
+                .Pass();
+
+            var publishDirectory = publishCommand.GetOutputDirectory(appTargetFramework, runtimeIdentifier: "win7-x86");
+
+            publishDirectory.Should().HaveFiles(new[] {
+                appTargetFramework == "net46" ? "TestApp.exe" : "TestApp.dll",
+                "TestLibrary.dll",
+                "Newtonsoft.Json.dll"});
+
+            var refsDirectory = new DirectoryInfo(Path.Combine(publishDirectory.FullName, "refs"));
+            // Should have compilation time assemblies
+            refsDirectory.Should().HaveFile("System.IO.dll");
+            // Libraries in which lib==ref should be deduped
+            refsDirectory.Should().NotHaveFile("TestLibrary.dll");
+            refsDirectory.Should().NotHaveFile("Newtonsoft.Json.dll");
+
+            using (var depsJsonFileStream = File.OpenRead(Path.Combine(publishDirectory.FullName, "TestApp.deps.json")))
             {
-                var publishCommand = new PublishCommand(Log, appProjectDirectory);
+                var dependencyContext = new DependencyContextJsonReader().Read(depsJsonFileStream);
 
-                if (targetFramework == "net46" && !RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                string[] expectedDefines;
+                if (appTargetFramework == "net46")
                 {
-                    continue;
+                    expectedDefines = new[] { "DEBUG", "TRACE", "NETFRAMEWORK", "NET46" };
+                }
+                else if (appTargetFramework == "netcoreapp1.1")
+                {
+                    expectedDefines = new[] { "DEBUG", "TRACE", "NETCOREAPP", "NETCOREAPP1_1" };
+                }
+                else
+                {
+                    expectedDefines = new[] { "DEBUG", "TRACE", "NETCOREAPP", "NETCOREAPP2_0" };
                 }
 
-                publishCommand
-                    .Execute($"/p:TargetFramework={targetFramework}")
-                    .Should()
-                    .Pass();
+                dependencyContext.CompilationOptions.Defines.Should().BeEquivalentTo(expectedDefines);
+                dependencyContext.CompilationOptions.LanguageVersion.Should().Be("");
+                dependencyContext.CompilationOptions.Platform.Should().Be("x86");
+                dependencyContext.CompilationOptions.Optimize.Should().Be(false);
+                dependencyContext.CompilationOptions.KeyFile.Should().Be("");
+                dependencyContext.CompilationOptions.EmitEntryPoint.Should().Be(true);
+                dependencyContext.CompilationOptions.DebugType.Should().Be("portable");
 
-                var publishDirectory = publishCommand.GetOutputDirectory(targetFramework, runtimeIdentifier: "win7-x86");
+                var compileLibraryAssemblyNames = dependencyContext.CompileLibraries.SelectMany(cl => cl.Assemblies)
+                    .Select(a => a.Split('/').Last())
+                    .Distinct().ToList();
+                var expectedCompileLibraryNames = CompileLibraryNames[appTargetFramework].Split(new char[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
 
-                publishDirectory.Should().HaveFiles(new[] {
-                    targetFramework == "net46" ? "TestApp.exe" : "TestApp.dll",
-                    "TestLibrary.dll",
-                    "Newtonsoft.Json.dll"});
+                var extraCompileLibraryNames = compileLibraryAssemblyNames.Except(expectedCompileLibraryNames).ToList();
+                var missingCompileLibraryNames = expectedCompileLibraryNames.Except(compileLibraryAssemblyNames).ToList();
 
-                var refsDirectory = new DirectoryInfo(Path.Combine(publishDirectory.FullName, "refs"));
-                // Should have compilation time assemblies
-                refsDirectory.Should().HaveFile("System.IO.dll");
-                // Libraries in which lib==ref should be deduped
-                refsDirectory.Should().NotHaveFile("TestLibrary.dll");
-                refsDirectory.Should().NotHaveFile("Newtonsoft.Json.dll");
+                compileLibraryAssemblyNames.Should().BeEquivalentTo(expectedCompileLibraryNames);
 
-                using (var depsJsonFileStream = File.OpenRead(Path.Combine(publishDirectory.FullName, "TestApp.deps.json")))
+                // Ensure P2P references are specified correctly
+                var testLibrary = dependencyContext
+                    .CompileLibraries
+                    .FirstOrDefault(l => string.Equals(l.Name, "testlibrary", StringComparison.OrdinalIgnoreCase));
+
+                testLibrary.Assemblies.Count.Should().Be(1);
+                testLibrary.Assemblies[0].Should().Be("TestLibrary.dll");
+
+                // Ensure framework references are specified correctly
+                if (appTargetFramework == "net46")
                 {
-                    var dependencyContext = new DependencyContextJsonReader().Read(depsJsonFileStream);
-
-                    string[] expectedDefines;
-                    if (targetFramework == "net46")
-                    {
-                        expectedDefines = new[] { "DEBUG", "TRACE", "NETFRAMEWORK", "NET46" };
-                    }
-                    else
-                    {
-                        expectedDefines = new[] { "DEBUG", "TRACE", "NETCOREAPP", "NETCOREAPP1_1" };
-                    }
-
-                    dependencyContext.CompilationOptions.Defines.Should().BeEquivalentTo(expectedDefines);
-                    dependencyContext.CompilationOptions.LanguageVersion.Should().Be("");
-                    dependencyContext.CompilationOptions.Platform.Should().Be("x86");
-                    dependencyContext.CompilationOptions.Optimize.Should().Be(false);
-                    dependencyContext.CompilationOptions.KeyFile.Should().Be("");
-                    dependencyContext.CompilationOptions.EmitEntryPoint.Should().Be(true);
-                    dependencyContext.CompilationOptions.DebugType.Should().Be("portable");
-
-                    var compileLibraryAssemblyNames = dependencyContext.CompileLibraries.SelectMany(cl => cl.Assemblies)
-                        .Select(a => a.Split('/').Last())
-                        .Distinct().ToList();
-                    var expectedCompileLibraryNames = targetFramework == "net46" ? Net46CompileLibraryNames.Distinct() : NetCoreAppCompileLibraryNames.Distinct();
-
-                    var extraCompileLibraryNames = compileLibraryAssemblyNames.Except(expectedCompileLibraryNames).ToList();
-
-                    compileLibraryAssemblyNames.Should().BeEquivalentTo(expectedCompileLibraryNames);
-
-                    // Ensure P2P references are specified correctly
-                    var testLibrary = dependencyContext
+                    var mscorlibLibrary = dependencyContext
                         .CompileLibraries
-                        .FirstOrDefault(l => string.Equals(l.Name, "testlibrary", StringComparison.OrdinalIgnoreCase));
+                        .FirstOrDefault(l => string.Equals(l.Name, "mscorlib", StringComparison.OrdinalIgnoreCase));
+                    mscorlibLibrary.Assemblies.Count.Should().Be(1);
+                    mscorlibLibrary.Assemblies[0].Should().Be(".NETFramework/v4.6/mscorlib.dll");
 
-                    testLibrary.Assemblies.Count.Should().Be(1);
-                    testLibrary.Assemblies[0].Should().Be("TestLibrary.dll");
+                    var systemCoreLibrary = dependencyContext
+                        .CompileLibraries
+                        .FirstOrDefault(l => string.Equals(l.Name, "system.core", StringComparison.OrdinalIgnoreCase));
+                    systemCoreLibrary.Assemblies.Count.Should().Be(1);
+                    systemCoreLibrary.Assemblies[0].Should().Be(".NETFramework/v4.6/System.Core.dll");
 
-                    // Ensure framework references are specified correctly
-                    if (targetFramework == "net46")
-                    {
-                        var mscorlibLibrary = dependencyContext
-                            .CompileLibraries
-                            .FirstOrDefault(l => string.Equals(l.Name, "mscorlib", StringComparison.OrdinalIgnoreCase));
-                        mscorlibLibrary.Assemblies.Count.Should().Be(1);
-                        mscorlibLibrary.Assemblies[0].Should().Be(".NETFramework/v4.6/mscorlib.dll");
-
-                        var systemCoreLibrary = dependencyContext
-                            .CompileLibraries
-                            .FirstOrDefault(l => string.Equals(l.Name, "system.core", StringComparison.OrdinalIgnoreCase));
-                        systemCoreLibrary.Assemblies.Count.Should().Be(1);
-                        systemCoreLibrary.Assemblies[0].Should().Be(".NETFramework/v4.6/System.Core.dll");
-
-                        var systemCollectionsLibrary = dependencyContext
-                            .CompileLibraries
-                            .FirstOrDefault(l => string.Equals(l.Name, "system.collections.reference", StringComparison.OrdinalIgnoreCase));
-                        systemCollectionsLibrary.Assemblies.Count.Should().Be(1);
-                        systemCollectionsLibrary.Assemblies[0].Should().Be(".NETFramework/v4.6/Facades/System.Collections.dll");
-                    }
+                    var systemCollectionsLibrary = dependencyContext
+                        .CompileLibraries
+                        .FirstOrDefault(l => string.Equals(l.Name, "system.collections.reference", StringComparison.OrdinalIgnoreCase));
+                    systemCollectionsLibrary.Assemblies.Count.Should().Be(1);
+                    systemCollectionsLibrary.Assemblies[0].Should().Be(".NETFramework/v4.6/Facades/System.Collections.dll");
                 }
             }
         }
@@ -186,7 +210,10 @@ namespace Microsoft.NET.Publish.Tests
             refsDirectory.Should().NotHaveFile("Newtonsoft.Json.dll");
         }
 
-        string[] Net46CompileLibraryNames = @"TestApp.exe
+        Dictionary<string, string> CompileLibraryNames = new Dictionary<string, string>()
+        {
+            { "net46",
+@"TestApp.exe
 mscorlib.dll
 System.ComponentModel.Composition.dll
 System.Core.dll
@@ -269,9 +296,11 @@ System.Security.Cryptography.Encoding.dll
 System.Security.Cryptography.Primitives.dll
 System.Security.Cryptography.X509Certificates.dll
 System.Xml.ReaderWriter.dll
-TestLibrary.dll".Split(new char[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
-
-        string[] NetCoreAppCompileLibraryNames = @"TestApp.dll
+TestLibrary.dll"
+            },
+            {
+                "netcoreapp1.1",
+@"TestApp.dll
 Microsoft.CSharp.dll
 Microsoft.VisualBasic.dll
 Microsoft.Win32.Primitives.dll
@@ -334,6 +363,7 @@ System.Runtime.Serialization.Primitives.dll
 System.Security.Claims.dll
 System.Security.Cryptography.Algorithms.dll
 System.Security.Cryptography.Encoding.dll
+System.Security.Cryptography.OpenSsl.dll
 System.Security.Cryptography.Primitives.dll
 System.Security.Cryptography.X509Certificates.dll
 System.Security.Principal.dll
@@ -352,6 +382,157 @@ System.Threading.ThreadPool.dll
 System.Threading.Timer.dll
 System.Xml.ReaderWriter.dll
 System.Xml.XDocument.dll
-TestLibrary.dll".Split(new char[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
+TestLibrary.dll"
+            },
+            {
+                "netcoreapp2.0",
+@"TestApp.dll
+Microsoft.CSharp.dll
+Microsoft.VisualBasic.dll
+Microsoft.Win32.Primitives.dll
+mscorlib.dll
+netstandard.dll
+Newtonsoft.Json.dll
+System.AppContext.dll
+System.Buffers.dll
+System.Collections.Concurrent.dll
+System.Collections.dll
+System.Collections.Immutable.dll
+System.Collections.NonGeneric.dll
+System.Collections.Specialized.dll
+System.ComponentModel.Annotations.dll
+System.ComponentModel.Composition.dll
+System.ComponentModel.DataAnnotations.dll
+System.ComponentModel.dll
+System.ComponentModel.EventBasedAsync.dll
+System.ComponentModel.Primitives.dll
+System.ComponentModel.TypeConverter.dll
+System.Configuration.dll
+System.Console.dll
+System.Core.dll
+System.Data.Common.dll
+System.Data.dll
+System.Data.SqlClient.dll
+System.Diagnostics.Contracts.dll
+System.Diagnostics.Debug.dll
+System.Diagnostics.DiagnosticSource.dll
+System.Diagnostics.FileVersionInfo.dll
+System.Diagnostics.Process.dll
+System.Diagnostics.StackTrace.dll
+System.Diagnostics.TextWriterTraceListener.dll
+System.Diagnostics.Tools.dll
+System.Diagnostics.TraceSource.dll
+System.Diagnostics.Tracing.dll
+System.dll
+System.Drawing.dll
+System.Drawing.Primitives.dll
+System.Dynamic.Runtime.dll
+System.Globalization.Calendars.dll
+System.Globalization.dll
+System.Globalization.Extensions.dll
+System.IO.Compression.dll
+System.IO.Compression.FileSystem.dll
+System.IO.Compression.ZipFile.dll
+System.IO.dll
+System.IO.FileSystem.dll
+System.IO.FileSystem.DriveInfo.dll
+System.IO.FileSystem.Primitives.dll
+System.IO.FileSystem.Watcher.dll
+System.IO.IsolatedStorage.dll
+System.IO.MemoryMappedFiles.dll
+System.IO.Pipes.dll
+System.IO.UnmanagedMemoryStream.dll
+System.Linq.dll
+System.Linq.Expressions.dll
+System.Linq.Parallel.dll
+System.Linq.Queryable.dll
+System.Net.dll
+System.Net.Http.dll
+System.Net.HttpListener.dll
+System.Net.Mail.dll
+System.Net.NameResolution.dll
+System.Net.NetworkInformation.dll
+System.Net.Ping.dll
+System.Net.Primitives.dll
+System.Net.Requests.dll
+System.Net.Security.dll
+System.Net.ServicePoint.dll
+System.Net.Sockets.dll
+System.Net.WebClient.dll
+System.Net.WebHeaderCollection.dll
+System.Net.WebProxy.dll
+System.Net.WebSockets.Client.dll
+System.Net.WebSockets.dll
+System.Numerics.dll
+System.Numerics.Vectors.dll
+System.ObjectModel.dll
+System.Reflection.DispatchProxy.dll
+System.Reflection.dll
+System.Reflection.Emit.dll
+System.Reflection.Emit.ILGeneration.dll
+System.Reflection.Emit.Lightweight.dll
+System.Reflection.Extensions.dll
+System.Reflection.Metadata.dll
+System.Reflection.Primitives.dll
+System.Reflection.TypeExtensions.dll
+System.Resources.Reader.dll
+System.Resources.ResourceManager.dll
+System.Resources.Writer.dll
+System.Runtime.CompilerServices.VisualC.dll
+System.Runtime.dll
+System.Runtime.Extensions.dll
+System.Runtime.Handles.dll
+System.Runtime.InteropServices.dll
+System.Runtime.InteropServices.RuntimeInformation.dll
+System.Runtime.InteropServices.WindowsRuntime.dll
+System.Runtime.Loader.dll
+System.Runtime.Numerics.dll
+System.Runtime.Serialization.dll
+System.Runtime.Serialization.Formatters.dll
+System.Runtime.Serialization.Json.dll
+System.Runtime.Serialization.Primitives.dll
+System.Runtime.Serialization.Xml.dll
+System.Security.Claims.dll
+System.Security.Cryptography.Algorithms.dll
+System.Security.Cryptography.Csp.dll
+System.Security.Cryptography.Encoding.dll
+System.Security.Cryptography.Primitives.dll
+System.Security.Cryptography.X509Certificates.dll
+System.Security.dll
+System.Security.Principal.dll
+System.Security.SecureString.dll
+System.ServiceModel.Web.dll
+System.ServiceProcess.dll
+System.Text.Encoding.dll
+System.Text.Encoding.Extensions.dll
+System.Text.RegularExpressions.dll
+System.Threading.dll
+System.Threading.Overlapped.dll
+System.Threading.Tasks.Dataflow.dll
+System.Threading.Tasks.dll
+System.Threading.Tasks.Extensions.dll
+System.Threading.Tasks.Parallel.dll
+System.Threading.Thread.dll
+System.Threading.ThreadPool.dll
+System.Threading.Timer.dll
+System.Transactions.dll
+System.Transactions.Local.dll
+System.ValueTuple.dll
+System.Web.dll
+System.Web.HttpUtility.dll
+System.Windows.dll
+System.Xml.dll
+System.Xml.Linq.dll
+System.Xml.ReaderWriter.dll
+System.Xml.Serialization.dll
+System.Xml.XDocument.dll
+System.Xml.XmlDocument.dll
+System.Xml.XmlSerializer.dll
+System.Xml.XPath.dll
+System.Xml.XPath.XDocument.dll
+WindowsBase.dll
+TestLibrary.dll"
+            }
+        };
     }
 }

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAHelloWorldProject.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAHelloWorldProject.cs
@@ -64,7 +64,7 @@ namespace Microsoft.NET.Publish.Tests
             var helloWorldAsset = _testAssetsManager
                 .CopyTestAsset("HelloWorld", "SelfContained")
                 .WithSource()
-                .Restore(Log, relativePath: "", args: $"/p:RuntimeIdentifiers={rid}");
+                .Restore(Log, relativePath: "", args: $"/p:RuntimeIdentifier={rid}");
 
             var publishCommand = new PublishCommand(Log, helloWorldAsset.TestRoot);
             var publishResult = publishCommand.Execute($"/p:RuntimeIdentifier={rid}");

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAnAppWithLibrariesAndRid.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAnAppWithLibrariesAndRid.cs
@@ -92,19 +92,23 @@ namespace Microsoft.NET.Publish.Tests
 
             var projectPath = Path.Combine(testAsset.TestRoot, "App");
 
+            var msbuildArgs = new[]
+            {
+                $"/p:RuntimeIdentifier={runtimeIdentifier}",
+                $"/p:TestRuntimeIdentifier={runtimeIdentifier}",
+                $"/p:SelfContained={selfContained}"
+            };
+
             var restoreCommand = new RestoreCommand(Log, projectPath, "App.csproj");
             restoreCommand
-                .Execute($"/p:TestRuntimeIdentifier={runtimeIdentifier}")
+                .Execute(msbuildArgs)
                 .Should()
                 .Pass();
 
             var publishCommand = new PublishCommand(Log, projectPath);
 
             publishCommand
-                .Execute(
-                    $"/p:RuntimeIdentifier={runtimeIdentifier}", 
-                    $"/p:TestRuntimeIdentifier={runtimeIdentifier}", 
-                    $"/p:SelfContained={selfContained}")
+                .Execute(msbuildArgs)
                 .Should().Pass();
 
             publishDirectory = publishCommand.GetOutputDirectory("netcoreapp1.1", runtimeIdentifier: runtimeIdentifier);

--- a/src/Tests/Microsoft.NET.TestFramework/FileConstants.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/FileConstants.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Runtime.InteropServices;
 
 namespace Microsoft.NET.TestFramework
@@ -11,6 +12,8 @@ namespace Microsoft.NET.TestFramework
 
         public static readonly string DynamicLibSuffix = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? ".dll" :
                                                          RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? ".dylib" : ".so";
-
+        public static readonly string UserProfileFolder = Environment.GetEnvironmentVariable(
+                                                                RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ?
+                                                                    "USERPROFILE" : "HOME");
     }
 }

--- a/src/Tests/Microsoft.NET.TestFramework/TestContext.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/TestContext.cs
@@ -45,6 +45,8 @@ namespace Microsoft.NET.TestFramework
             }
         }
 
+        public const string LatestRuntimePatchForNetCoreApp2_0 = "2.0.6";
+
         public void AddTestEnvironmentVariables(SdkCommandSpec command)
         {
             command.Environment["DOTNET_MULTILEVEL_LOOKUP"] = "0";

--- a/src/Tests/Microsoft.NET.TestFramework/TestContext.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/TestContext.cs
@@ -45,15 +45,6 @@ namespace Microsoft.NET.TestFramework
             }
         }
 
-        // For test purposes, override the implicit .NETCoreApp version for self-contained apps that to builds thare 
-        //  (1) different from the fixed framework-dependent defaults (1.0.5, 1.1.2, 2.0.0)
-        //  (2) currently available on nuget.org
-        //
-        // This allows bumping the versions before builds without causing tests to fail.
-        public const string ImplicitRuntimeFrameworkVersionForSelfContainedNetCoreApp1_0 = "1.0.4";
-        public const string ImplicitRuntimeFrameworkVersionForSelfContainedNetCoreApp1_1 = "1.1.1";
-        public const string ImplicitRuntimeFrameworkVersionForSelfContainedNetCoreApp2_0 = "2.0.0-preview2-25407-01";
-
         public void AddTestEnvironmentVariables(SdkCommandSpec command)
         {
             command.Environment["DOTNET_MULTILEVEL_LOOKUP"] = "0";
@@ -62,10 +53,6 @@ namespace Microsoft.NET.TestFramework
             command.Environment["NUGET_PACKAGES"] = NuGetCachePath;
 
             command.Environment["DOTNET_SKIP_FIRST_TIME_EXPERIENCE"] = "1";
-
-            command.Environment[nameof(ImplicitRuntimeFrameworkVersionForSelfContainedNetCoreApp1_0)] = ImplicitRuntimeFrameworkVersionForSelfContainedNetCoreApp1_0;
-            command.Environment[nameof(ImplicitRuntimeFrameworkVersionForSelfContainedNetCoreApp1_1)] = ImplicitRuntimeFrameworkVersionForSelfContainedNetCoreApp1_1;
-            command.Environment[nameof(ImplicitRuntimeFrameworkVersionForSelfContainedNetCoreApp2_0)] = ImplicitRuntimeFrameworkVersionForSelfContainedNetCoreApp2_0;
 
             command.Environment["GenerateResourceMSBuildArchitecture"] = "CurrentArchitecture";
             command.Environment["GenerateResourceMSBuildRuntime"] = "CurrentRuntime";

--- a/src/Tests/Microsoft.NET.TestFramework/TestDirectory.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/TestDirectory.cs
@@ -29,7 +29,14 @@ namespace Microsoft.NET.TestFramework
         {
             if (Directory.Exists(path))
             {
-                Directory.Delete(path, true);
+                try
+                {
+                    Directory.Delete(path, true);
+                }
+                catch (IOException ex)
+                {
+                    throw new IOException("Unable to delete directory " + path, ex);
+                }
             }
 
             Directory.CreateDirectory(path);

--- a/src/Tests/Microsoft.NET.ToolPack.Tests/GivenThatWeWantToPackAToolSelfContainedProject.cs
+++ b/src/Tests/Microsoft.NET.ToolPack.Tests/GivenThatWeWantToPackAToolSelfContainedProject.cs
@@ -25,7 +25,7 @@ namespace Microsoft.NET.ToolPack.Tests
         public void It_should_fail_with_error_message()
         {
             TestAsset helloWorldAsset = _testAssetsManager
-                                        .CopyTestAsset("PortableTool", "PackPortableToolToolEntryPoint")
+                                        .CopyTestAsset("PortableTool", "PackSelfContainedTool")
                                         .WithSource()
                                         .WithProjectChanges(project =>
                                         {


### PR DESCRIPTION
- Bring back behavior where self-contained apps will roll-forward to the latest patch the SDK knows about
  - We had reverted this in #1574
  - Hopefully the implementation here should be a bit easier to follow
- Add an error message when the version of .NET Core in the assets file is different than what was expected based on current settings: `The project was restored using Microsoft.NETCore.App version 2.0.0, but with current settings, version 2.0.6 would be used instead.  To resolve this issue, make sure the same settings are used for restore and for subsequent operations such as build or publish.  Typically this issue can occur if the RuntimeIdentifier property is set during build or publish but not during restore.`
- Fix various test issues

Related: #1570

@nguerrera @livarcocc @dotnet/dotnet-cli for review