### PR TITLE
Fix case sensitivity when mapping project paths to project infos.

### DIFF
--- a/src/Assets/TestProjects/AppWithProjRefCaseDiff/AppWithProjRefCaseDiff.sln
+++ b/src/Assets/TestProjects/AppWithProjRefCaseDiff/AppWithProjRefCaseDiff.sln
@@ -1,0 +1,48 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26124.0
+MinimumVisualStudioVersion = 15.0.26124.0
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "liba", "liba\liba.csproj", "{C46E4038-BD0F-4C55-B16D-3614EA22F4DD}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "libb", "libb\libb.csproj", "{FE57DF17-BCAF-45BE-86BB-2E66A27C43CF}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{C46E4038-BD0F-4C55-B16D-3614EA22F4DD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C46E4038-BD0F-4C55-B16D-3614EA22F4DD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C46E4038-BD0F-4C55-B16D-3614EA22F4DD}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{C46E4038-BD0F-4C55-B16D-3614EA22F4DD}.Debug|x64.Build.0 = Debug|Any CPU
+		{C46E4038-BD0F-4C55-B16D-3614EA22F4DD}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{C46E4038-BD0F-4C55-B16D-3614EA22F4DD}.Debug|x86.Build.0 = Debug|Any CPU
+		{C46E4038-BD0F-4C55-B16D-3614EA22F4DD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C46E4038-BD0F-4C55-B16D-3614EA22F4DD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C46E4038-BD0F-4C55-B16D-3614EA22F4DD}.Release|x64.ActiveCfg = Release|Any CPU
+		{C46E4038-BD0F-4C55-B16D-3614EA22F4DD}.Release|x64.Build.0 = Release|Any CPU
+		{C46E4038-BD0F-4C55-B16D-3614EA22F4DD}.Release|x86.ActiveCfg = Release|Any CPU
+		{C46E4038-BD0F-4C55-B16D-3614EA22F4DD}.Release|x86.Build.0 = Release|Any CPU
+		{FE57DF17-BCAF-45BE-86BB-2E66A27C43CF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FE57DF17-BCAF-45BE-86BB-2E66A27C43CF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FE57DF17-BCAF-45BE-86BB-2E66A27C43CF}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{FE57DF17-BCAF-45BE-86BB-2E66A27C43CF}.Debug|x64.Build.0 = Debug|Any CPU
+		{FE57DF17-BCAF-45BE-86BB-2E66A27C43CF}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{FE57DF17-BCAF-45BE-86BB-2E66A27C43CF}.Debug|x86.Build.0 = Debug|Any CPU
+		{FE57DF17-BCAF-45BE-86BB-2E66A27C43CF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FE57DF17-BCAF-45BE-86BB-2E66A27C43CF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FE57DF17-BCAF-45BE-86BB-2E66A27C43CF}.Release|x64.ActiveCfg = Release|Any CPU
+		{FE57DF17-BCAF-45BE-86BB-2E66A27C43CF}.Release|x64.Build.0 = Release|Any CPU
+		{FE57DF17-BCAF-45BE-86BB-2E66A27C43CF}.Release|x86.ActiveCfg = Release|Any CPU
+		{FE57DF17-BCAF-45BE-86BB-2E66A27C43CF}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/src/Assets/TestProjects/AppWithProjRefCaseDiff/LibA/Class1.cs
+++ b/src/Assets/TestProjects/AppWithProjRefCaseDiff/LibA/Class1.cs
@@ -1,0 +1,8 @@
+﻿using System;
+
+namespace LibA
+{
+    public class Class1
+    {
+    }
+}

--- a/src/Assets/TestProjects/AppWithProjRefCaseDiff/LibA/LibA.csproj
+++ b/src/Assets/TestProjects/AppWithProjRefCaseDiff/LibA/LibA.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/src/Assets/TestProjects/AppWithProjRefCaseDiff/LibB/Class1.cs
+++ b/src/Assets/TestProjects/AppWithProjRefCaseDiff/LibB/Class1.cs
@@ -1,0 +1,8 @@
+﻿using System;
+
+namespace LibB
+{
+    public class Class1
+    {
+    }
+}

--- a/src/Assets/TestProjects/AppWithProjRefCaseDiff/LibB/LibB.csproj
+++ b/src/Assets/TestProjects/AppWithProjRefCaseDiff/LibB/LibB.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\LibA\LibA.csproj" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/SingleProjectInfo.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/SingleProjectInfo.cs
@@ -51,7 +51,7 @@ namespace Microsoft.NET.Build.Tasks
             IEnumerable<ITaskItem> referencePaths,
             IEnumerable<ITaskItem> referenceSatellitePaths)
         {
-            Dictionary<string, SingleProjectInfo> projectReferences = new Dictionary<string, SingleProjectInfo>();
+            Dictionary<string, SingleProjectInfo> projectReferences = new Dictionary<string, SingleProjectInfo>(StringComparer.OrdinalIgnoreCase);
 
             IEnumerable<ITaskItem> projectReferencePaths = referencePaths
                 .Where(r => string.Equals(r.GetMetadata("ReferenceSourceTarget"), "ProjectReference", StringComparison.OrdinalIgnoreCase));

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildASolutionWithProjRefDiffCase.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildASolutionWithProjRefDiffCase.cs
@@ -1,0 +1,38 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Microsoft.DotNet.PlatformAbstractions;
+using Microsoft.NET.TestFramework;
+using Microsoft.NET.TestFramework.Assertions;
+using Microsoft.NET.TestFramework.Commands;
+using FluentAssertions;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.NET.Build.Tests
+{
+    public class GivenThatWeWantToBuildASolutionWithProjRefDiffCase : SdkTest
+    {
+        public GivenThatWeWantToBuildASolutionWithProjRefDiffCase(ITestOutputHelper log) : base(log)
+        {
+        }
+
+        [PlatformSpecificFact(Platform.Windows, Platform.Darwin)]
+        public void ItBuildsTheSolutionSuccessfully()
+        {
+            const string solutionFile = "AppWithProjRefCaseDiff.sln";
+
+            var asset = _testAssetsManager
+                .CopyTestAsset("AppWithProjRefCaseDiff")
+                .WithSource()
+                .Restore(Log, solutionFile);
+
+            var command = new BuildCommand(Log, Path.Combine(asset.TestRoot, solutionFile));
+            command.Execute().Should().Pass();
+        }
+    }
+}

--- a/src/Tests/Microsoft.NET.TestFramework/Attributes/PlatformSpecificFact.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/Attributes/PlatformSpecificFact.cs
@@ -1,0 +1,20 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Linq;
+using Microsoft.DotNet.PlatformAbstractions;
+using Xunit;
+
+namespace Microsoft.NET.TestFramework
+{
+    public class PlatformSpecificFact : FactAttribute
+    {
+        public PlatformSpecificFact(params Platform[] platforms)
+        {
+            if (!platforms.Contains(RuntimeEnvironment.OperatingSystemPlatform))
+            {
+                this.Skip = "This test is not supported on this platform.";
+            }
+        }
+    }
+}

--- a/src/Tests/Microsoft.NET.TestFramework/Attributes/PlatformSpecificTheory.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/Attributes/PlatformSpecificTheory.cs
@@ -1,0 +1,20 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Linq;
+using Microsoft.DotNet.PlatformAbstractions;
+using Xunit;
+
+namespace Microsoft.NET.TestFramework
+{
+    public class PlatformSpecificTheory : TheoryAttribute
+    {
+        public PlatformSpecificTheory(params Platform[] platforms)
+        {
+            if (!platforms.Contains(RuntimeEnvironment.OperatingSystemPlatform))
+            {
+                this.Skip = "This test is not supported on this platform.";
+            }
+        }
+    }
+}


### PR DESCRIPTION
When a solution contains a path to a project that differs by case for a project
reference identity, the build fails because the project info can't be found.

The fix is to make the internal map case insensitive, allowing the case
difference in a project's path in the solution file.

Fixes dotnet/cli#8048.