### PR TITLE
Move DefineConstants where they'll actually apply

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Extensions.Tasks.UnitTests/GivenANETBuildExtensionsError.cs
+++ b/src/Tasks/Microsoft.NET.Build.Extensions.Tasks.UnitTests/GivenANETBuildExtensionsError.cs
@@ -1,0 +1,19 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Xunit;
+
+namespace Microsoft.NET.Build.Tasks.UnitTests
+{
+    public class GivenANETBuildExtensionsError
+    {
+        [Fact]
+        public void It_is_compiled_with_extensions_specific_name()
+        {
+            // Regression test for https://github.com/dotnet/sdk/issues/2061
+            // Infrastructure changes made #if EXTENSIONS that changes the task name to not apply.
+            // This test would fail to compile if we made that mistake again.
+            new NETBuildExtensionsError();
+        }
+    }
+}

--- a/src/Tasks/Microsoft.NET.Build.Extensions.Tasks/Microsoft.NET.Build.Extensions.Tasks.csproj
+++ b/src/Tasks/Microsoft.NET.Build.Extensions.Tasks/Microsoft.NET.Build.Extensions.Tasks.csproj
@@ -5,7 +5,6 @@
   <!-- This is a smaller build of Microsoft.NET.Build.Tasks to be used outside of SDK projects -->
 
   <PropertyGroup>
-    <DefineConstants>$(DefineConstants);EXTENSIONS</DefineConstants>
     <Description>The MSBuild targets and tasks which extend MSBuild's common targets.</Description>
     <OutputType>Library</OutputType>
     <PackageId>Microsoft.NET.Build.Extensions</PackageId>
@@ -26,6 +25,7 @@
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
 
   <PropertyGroup>
+    <DefineConstants>$(DefineConstants);EXTENSIONS</DefineConstants>
     <IsPackable>true</IsPackable>
     <PackageLayoutOutputPath>$(ArtifactsBinDir)Sdks\$(PackageId)\</PackageLayoutOutputPath>
   </PropertyGroup>


### PR DESCRIPTION
We were setting it before Sdk.props / Directory.Build.props, and repo toolset was overwriting it.

This caused #if EXTENSIONS to never be taken and a task loading error to occur when NETBuildExtensionsError was used.

This is the minimal fix for 2.1.2xx / 15.7. I hope to refactor things in 2.1.3xx so that our project files are more standard and this mistake is harder to make.

**Customer scenario**

Customers is attempting to reference a version of .NETStandard library (greater than certain version) from .NETFramework, but does not have a recent enough SDK.

There is supposed to be an error message indicating that the SDK is not recent enough, but instead it triggers a task loading failure with no indication of what is actually wrong.

**Bugs this fixes:** 

Fix #2061 

**Workarounds, if any**

Learn what the real error message was supposed to read and follow its instructions to update SDK used.

**Risk**

Low

**Performance impact**

None. Triggers only in error case.

**Is this a regression from a previous update?**

No

**Root cause analysis:**

Infrastructure changes in move to repo toolset cause a DefineConstants in the csproj to not be honored. Test coverage has been added to prevent a regression.

**How was the bug found?**

Customer reported
