### PR TITLE
Disable implicit package version match check when generating deps.json for DotNetCliToolReference

### DIFF
--- a/build/Versions.props
+++ b/build/Versions.props
@@ -45,7 +45,7 @@
     <FluentAssertionsJsonVersion>4.19.0</FluentAssertionsJsonVersion>
     <MicrosoftDotNetCliUtilsVersion>2.0.0</MicrosoftDotNetCliUtilsVersion>
     <MicrosoftNETTestSdkVersion>15.0.0</MicrosoftNETTestSdkVersion>
-    <XUnitConsoleVersion>2.3.0</XUnitConsoleVersion>
+    <XUnitConsoleVersion>2.3.1</XUnitConsoleVersion>
   </PropertyGroup>
 
 </Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageAssets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageAssets.cs
@@ -89,6 +89,12 @@ namespace Microsoft.NET.Build.Tasks
         public bool EnsureRuntimePackageDependencies { get; set; }
 
         /// <summary>
+        /// Specifies whether to validate that the version of the implicit platform package in the assets
+        /// file matches the version specified by <see cref="ExpectedPlatformPackageVersion"/>
+        /// </summary>
+        public bool VerifyMatchingImplicitPackageVersion { get; set; }
+
+        /// <summary>
         /// Identifier for implicitly referenced platform package.  If set, then an error will be generated if the
         /// version of that package from the assets file does not match the <see cref="ExpectedPlatformPackageVersion"/>
         /// </summary>
@@ -308,6 +314,7 @@ namespace Microsoft.NET.Build.Tasks
                     writer.Write(ProjectPath);
                     writer.Write(RuntimeIdentifier ?? "");
                     writer.Write(TargetFrameworkMoniker);
+                    writer.Write(VerifyMatchingImplicitPackageVersion);
                 }
 
                 stream.Position = 0;
@@ -718,7 +725,8 @@ namespace Microsoft.NET.Build.Tasks
                     return secondPeriodIndex >= 0;
                 }
 
-                if (!string.IsNullOrEmpty(_task.ImplicitPlatformPackageIdentifier) &&
+                if (_task.VerifyMatchingImplicitPackageVersion &&
+                    !string.IsNullOrEmpty(_task.ImplicitPlatformPackageIdentifier) &&
                     !string.IsNullOrEmpty(_task.ExpectedPlatformPackageVersion) &&
                     //  If RuntimeFrameworkVersion was specified as a version range or a floating version,
                     //  then we can't compare the versions directly, so just skip the check

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/GenerateDeps/GenerateDeps.proj
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/GenerateDeps/GenerateDeps.proj
@@ -31,6 +31,15 @@ Copyright (c) .NET Foundation. All rights reserved.
     
     <OutputType>Exe</OutputType>
     <IncludeMainProjectInDepsFile>false</IncludeMainProjectInDepsFile>
+
+    <!-- The tool asets file is restored as a separate graph and doesn't get an implicit reference to Microsoft.NETCore.App.  So
+         the version of that package will be determined by the version the tool package references.  However, when building
+         GenerateDeps.proj, the CLI sets the TargetFramework to match the target it finds in the assets file, which is
+         based on what the project with the DotNetCliToolReference was targeting, not what the tool itself was targeting.
+         
+         So we need to disable the logic which checks that the version of Microsoft.NETCore.App from the assets file
+         matches the one that would be resolved based on the TargetFramework that was passed in. -->
+    <VerifyMatchingImplicitPackageVersion>false</VerifyMatchingImplicitPackageVersion>
   </PropertyGroup>
 
   <Target Name="BuildDepsJson" DependsOnTargets="$(ResolvePackageDependenciesForBuildDependsOn);GenerateBuildDependencyFile" />

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.targets
@@ -147,6 +147,8 @@ Copyright (c) .NET Foundation. All rights reserved.
          to verify that the restored version of the package matches the
          RuntimeFrameworkVersion -->
     <ImplicitPlatformPackageIdentifier>Microsoft.NETCore.App</ImplicitPlatformPackageIdentifier>
+
+    <VerifyMatchingImplicitPackageVersion Condition="'$(VerifyMatchingImplicitPackageVersion)' == ''">true</VerifyMatchingImplicitPackageVersion>
   </PropertyGroup>
   
   <!--

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.PackageDependencyResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.PackageDependencyResolution.targets
@@ -214,6 +214,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       DisableFrameworkAssemblies="$(DisableLockFileFrameworks)"
       DisableTransitiveProjectReferences="$(DisableTransitiveProjectReferences)"
       EnsureRuntimePackageDependencies="$(EnsureRuntimePackageDependencies)"
+      VerifyMatchingImplicitPackageVersion="$(VerifyMatchingImplicitPackageVersion)"
       ImplicitPlatformPackageIdentifier="$(ImplicitPlatformPackageIdentifier)"
       ExpectedPlatformPackageVersion="$(RuntimeFrameworkVersion)"      
       >


### PR DESCRIPTION
When generating a deps.json file for a `DotNetCliToolReference`, the `TargetFramework` is based on the project using the tool, but the version of `Microsoft.NETCore.App` in its assets file depends on what the tool itself referenced.  So disable the check that these versions match when generating the tool's deps.json.

Also:

- Update xunit.console version, which may fix failures to run tests in VS
- Update floating RuntimeFrameworkVersion test to be resilient to new patch releases