### PR TITLE
Allow dotnet host path to be overridden via DOTNET_INSTALL_DIR environment variable

### DIFF
--- a/build/Versions.props
+++ b/build/Versions.props
@@ -45,7 +45,6 @@
     <FluentAssertionsJsonVersion>4.19.0</FluentAssertionsJsonVersion>
     <MicrosoftDotNetCliUtilsVersion>2.0.0</MicrosoftDotNetCliUtilsVersion>
     <MicrosoftNETTestSdkVersion>15.0.0</MicrosoftNETTestSdkVersion>
-    <XUnitConsoleVersion>2.3.1</XUnitConsoleVersion>
   </PropertyGroup>
 
 </Project>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -7,7 +7,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(IsTestProject)' == 'true' AND '$(OutputType)' == 'Exe'">
-    <PackageReference Include="xunit.console" Version="$(XUnitConsoleVersion)" Private="true" />
+    <PackageReference Include="xunit.console" Version="$(XUnitVersion)" Private="true" />
   </ItemGroup>
 
   <Import Project="$(RepoToolsetDir)Imports.targets" />

--- a/src/Tests/Microsoft.NET.TestFramework/ToolsetInfo.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/ToolsetInfo.cs
@@ -111,17 +111,31 @@ namespace Microsoft.NET.TestFramework
             repoRoot = commandLine.SDKRepoPath ?? repoRoot;
             configuration = commandLine.SDKRepoConfiguration ?? configuration;
 
-            if (repoRoot != null)
+            string dotnetInstallDirFromEnvironment = Environment.GetEnvironmentVariable("DOTNET_INSTALL_DIR");
+
+            if (!string.IsNullOrEmpty(commandLine.DotnetHostPath))
+            {
+                ret.DotNetHostPath = commandLine.DotnetHostPath;
+            }
+            else if (!string.IsNullOrEmpty(dotnetInstallDirFromEnvironment))
+            {
+                ret.DotNetHostPath = Path.Combine(dotnetInstallDirFromEnvironment, $"dotnet{Constants.ExeSuffix}");
+            }
+            else if (repoRoot != null)
             {
                 var dotnetCliVersion = GetDotNetCliVersion(repoRoot);
 
-                ret.CliVersionForBundledVersions = dotnetCliVersion;
                 ret.DotNetHostPath = Path.Combine(repoArtifactsDir, ".dotnet", dotnetCliVersion, $"dotnet{Constants.ExeSuffix}");
-                ret.SdksPath = Path.Combine(repoArtifactsDir, configuration, "bin", "Sdks");
             }
             else
             {
                 ret.DotNetHostPath = ResolveCommand("dotnet");
+            }
+
+            if (repoRoot != null)
+            {
+                ret.CliVersionForBundledVersions = GetDotNetCliVersion(repoRoot);
+                ret.SdksPath = Path.Combine(repoArtifactsDir, configuration, "bin", "Sdks");
             }
 
             if (!string.IsNullOrEmpty(commandLine.FullFrameworkMSBuildPath))


### PR DESCRIPTION
Fixes #2098