### PR TITLE
 Fix F# typo, add smoke tests, Fix behaviour for implicit defines

### DIFF
--- a/src/Assets/TestProjects/AppWithLibraryFS/TestApp/TestApp.fsproj
+++ b/src/Assets/TestProjects/AppWithLibraryFS/TestApp/TestApp.fsproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.0</TargetFramework>
+    <FSharpCoreImplicitPackageVersion>4.2.3</FSharpCoreImplicitPackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Assets/TestProjects/AppWithLibraryFS/TestLibrary/TestLibrary.fsproj
+++ b/src/Assets/TestProjects/AppWithLibraryFS/TestLibrary/TestLibrary.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netstandard1.6</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Assets/TestProjects/AppWithLibraryFS/TestLibrary/TestLibrary.fsproj
+++ b/src/Assets/TestProjects/AppWithLibraryFS/TestLibrary/TestLibrary.fsproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard1.6</TargetFramework>
+    <FSharpCoreImplicitPackageVersion>4.2.3</FSharpCoreImplicitPackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Assets/TestProjects/HelloWorldFS/Program.fs
+++ b/src/Assets/TestProjects/HelloWorldFS/Program.fs
@@ -1,0 +1,6 @@
+﻿open System
+
+[<EntryPoint>]
+let main argv =
+    printfn "Hello, World!"
+    0 // return an integer exit code

--- a/src/Assets/TestProjects/HelloWorldFS/TestApp.fsproj
+++ b/src/Assets/TestProjects/HelloWorldFS/TestApp.fsproj
@@ -1,0 +1,12 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Program.fs" />
+  </ItemGroup>
+
+</Project>

--- a/src/Assets/TestProjects/HelloWorldFS/TestApp.fsproj
+++ b/src/Assets/TestProjects/HelloWorldFS/TestApp.fsproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.0</TargetFramework>
+    <FSharpCoreImplicitPackageVersion>4.2.3</FSharpCoreImplicitPackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FSharp.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FSharp.targets
@@ -23,9 +23,13 @@ Copyright (c) .NET Foundation. All rights reserved.
        if running core msbuild select Microsoft.FSharp.targets from dotnet cli deployment
        *************************************************************************************************************** -->
   <PropertyGroup Condition=" '$(IsCrossTargetingBuild)' != 'true' " >
-     <FSharpTargetsShim Condition = " '$(FSharpOverridesTargetsShim)' == '' and Exists('$(MSBuildToolsPath)\FSharp\Microsoft.FSharp.Overrides.NetSdk.targets') ">$(MSBuildToolsPath)\FSharp\Microsoft.FSharp.Overrides.NetSdk.targets</FSharpTargetsShim>
-     <FSharpTargetsShim Condition = " '$(FSharpOverridesTargetsShim)' == '' and Exists('$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Overrides.NetSdk.targets') ">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.NetSdk.targets</FSharpTargetsShim>
+     <FSharpOverridesTargetsShim Condition = " '$(FSharpOverridesTargetsShim)' == '' and Exists('$(MSBuildToolsPath)\FSharp\Microsoft.FSharp.Overrides.NetSdk.targets') ">$(MSBuildToolsPath)\FSharp\Microsoft.FSharp.Overrides.NetSdk.targets</FSharpOverridesTargetsShim>
+     <FSharpOverridesTargetsShim Condition = " '$(FSharpOverridesTargetsShim)' == '' and Exists('$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Overrides.NetSdk.targets') ">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.NetSdk.targets</FSharpOverridesTargetsShim>
   </PropertyGroup>
   <Import Condition=" '$(UseBundledFSharpTargets)' == 'true' and  '$(IsCrossTargetingBuild)' != 'true' and Exists('$(FSharpOverridesTargetsShim)') " Project="$(FSharpOverridesTargetsShim)" />
+
+  <PropertyGroup>
+    <DefineConstants>$(DefineConstants);$(VersionlessImplicitFrameworkDefine);$(ImplicitFrameworkDefine)</DefineConstants>
+  </PropertyGroup>
 
 </Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FSharpTargetsShim.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FSharpTargetsShim.targets
@@ -36,9 +36,6 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ImplicitConfigurationDefine>$(ImplicitConfigurationDefine.Replace('.', '_'))</ImplicitConfigurationDefine>
     <DefineConstants>$(DefineConstants);$(ImplicitConfigurationDefine)</DefineConstants>
   </PropertyGroup>
-  <PropertyGroup  Condition=" '$(UseBundledFSharpTargets)' == 'true' ">
-    <DefineConstants>$(DefineConstants);$(ImplicitFrameworkDefine)</DefineConstants>
-  </PropertyGroup>
 
   <!-- ***************************************************************************************************************
        Loads the cross-targeting targets if we are doing a cross-targeting build

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildADesktopExeWithFSharp.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildADesktopExeWithFSharp.cs
@@ -1,0 +1,75 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Xml.Linq;
+
+using Microsoft.DotNet.Cli.Utils;
+using Microsoft.NET.TestFramework;
+using Microsoft.NET.TestFramework.Assertions;
+using Microsoft.NET.TestFramework.Commands;
+using Microsoft.NET.TestFramework.ProjectConstruction;
+
+using FluentAssertions;
+using Xunit;
+
+using Xunit.Abstractions;
+using System.Text.RegularExpressions;
+
+namespace Microsoft.NET.Build.Tests
+{
+    public class GivenThatWeWantToBuildADesktopExeWithFSharp : SdkTest
+    {
+        public GivenThatWeWantToBuildADesktopExeWithFSharp(ITestOutputHelper log) : base(log)
+        {
+        }
+
+        [WindowsOnlyFact]
+        public void It_builds_a_simple_desktop_app()
+        {
+            var targetFramework = "net45";
+            var testAsset = _testAssetsManager
+                .CopyTestAsset("HelloWorldFS")
+                .WithSource()
+                .WithProjectChanges(project =>
+                {
+                    var ns = project.Root.Name.Namespace;
+                    var propertyGroup = project.Root.Elements(ns + "PropertyGroup").First();
+                    propertyGroup.Element(ns + "TargetFramework").SetValue(targetFramework);
+                })
+                .Restore(Log);
+
+            var buildCommand = new BuildCommand(Log, testAsset.TestRoot);
+            buildCommand
+                .Execute()
+                .Should()
+                .Pass();
+
+            var outputDirectory = buildCommand.GetOutputDirectory(targetFramework);
+
+            outputDirectory.Should().OnlyHaveFiles(new[] {
+                "TestApp.exe",
+                "TestApp.pdb",
+                "FSharp.Core.dll",
+                "System.ValueTuple.dll",
+                "cs/FSharp.Core.resources.dll",
+                "de/FSharp.Core.resources.dll",
+                "en/FSharp.Core.resources.dll",
+                "es/FSharp.Core.resources.dll",
+                "fr/FSharp.Core.resources.dll",
+                "it/FSharp.Core.resources.dll",
+                "ja/FSharp.Core.resources.dll",
+                "ko/FSharp.Core.resources.dll",
+                "pl/FSharp.Core.resources.dll",
+                "pt-BR/FSharp.Core.resources.dll",
+                "ru/FSharp.Core.resources.dll",
+                "tr/FSharp.Core.resources.dll",
+                "zh-Hans/FSharp.Core.resources.dll",
+                "zh-Hant/FSharp.Core.resources.dll"
+            });
+        }
+    }
+}

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildADesktopExeWithFSharp.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildADesktopExeWithFSharp.cs
@@ -55,20 +55,6 @@ namespace Microsoft.NET.Build.Tests
                 "TestApp.pdb",
                 "FSharp.Core.dll",
                 "System.ValueTuple.dll",
-                "cs/FSharp.Core.resources.dll",
-                "de/FSharp.Core.resources.dll",
-                "en/FSharp.Core.resources.dll",
-                "es/FSharp.Core.resources.dll",
-                "fr/FSharp.Core.resources.dll",
-                "it/FSharp.Core.resources.dll",
-                "ja/FSharp.Core.resources.dll",
-                "ko/FSharp.Core.resources.dll",
-                "pl/FSharp.Core.resources.dll",
-                "pt-BR/FSharp.Core.resources.dll",
-                "ru/FSharp.Core.resources.dll",
-                "tr/FSharp.Core.resources.dll",
-                "zh-Hans/FSharp.Core.resources.dll",
-                "zh-Hant/FSharp.Core.resources.dll"
             });
         }
     }

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildALibraryWithFSharp.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildALibraryWithFSharp.cs
@@ -166,7 +166,7 @@ namespace Microsoft.NET.Build.Tests
         public void It_implicitly_defines_compilation_constants_for_the_configuration(string configuration, string expectedDefine)
         {
             var testAsset = _testAssetsManager
-                .CopyTestAsset("AppWithLibraryFS", "ImplicitConfigurationConstants", configuration)
+                .CopyTestAsset("AppWithLibraryFS", "ImplicitConfigurationConstantsFS", configuration)
                 .WithSource()
                 .Restore(Log, relativePath: "TestLibrary");
 
@@ -198,7 +198,7 @@ namespace Microsoft.NET.Build.Tests
             bool shouldCompile = true;
 
             var testAsset = _testAssetsManager
-                .CopyTestAsset("AppWithLibraryFS", "ImplicitFrameworkConstants", targetFramework)
+                .CopyTestAsset("AppWithLibraryFS", "ImplicitFrameworkConstantsFS", targetFramework)
                 .WithSource()
                 .WithProjectChanges(project =>
                 {

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildALibraryWithFSharp.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildALibraryWithFSharp.cs
@@ -1,0 +1,264 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.IO;
+using Microsoft.NET.TestFramework;
+using Microsoft.NET.TestFramework.Assertions;
+using Microsoft.NET.TestFramework.Commands;
+using Xunit;
+using System.Linq;
+using FluentAssertions;
+using System.Xml.Linq;
+using System.Runtime.Versioning;
+using System.Runtime.InteropServices;
+using System.Collections.Generic;
+using System;
+using System.Runtime.CompilerServices;
+using Xunit.Abstractions;
+using Microsoft.NET.TestFramework.ProjectConstruction;
+using NuGet.ProjectModel;
+using NuGet.Common;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.NET.Build.Tests
+{
+    public class GivenThatWeWantToBuildALibraryWithFSharp : SdkTest
+    {
+        public GivenThatWeWantToBuildALibraryWithFSharp(ITestOutputHelper log) : base(log)
+        {
+        }
+
+        [Fact]
+        public void It_builds_the_library_successfully()
+        {
+            var testAsset = _testAssetsManager
+                .CopyTestAsset("AppWithLibraryFS")
+                .WithSource()
+                .Restore(Log, relativePath: "TestLibrary");
+
+            var libraryProjectDirectory = Path.Combine(testAsset.TestRoot, "TestLibrary");
+
+            var buildCommand = new BuildCommand(Log, libraryProjectDirectory);
+            buildCommand
+                .Execute()
+                .Should()
+                .Pass();
+
+            var outputDirectory = buildCommand.GetOutputDirectory("netstandard1.6");
+
+            outputDirectory.Should().OnlyHaveFiles(new[] {
+                "TestLibrary.dll",
+                "TestLibrary.pdb",
+                "TestLibrary.deps.json"
+            });
+        }
+
+        [Fact]
+        public void It_builds_the_library_twice_in_a_row()
+        {
+            var testAsset = _testAssetsManager
+                .CopyTestAsset("AppWithLibraryFS")
+                .WithSource()
+                .Restore(Log, relativePath: "TestLibrary");
+
+            var libraryProjectDirectory = Path.Combine(testAsset.TestRoot, "TestLibrary");
+
+            var buildCommand = new BuildCommand(Log, libraryProjectDirectory);
+            buildCommand
+                .Execute()
+                .Should()
+                .Pass();
+
+            buildCommand
+                .Execute()
+                .Should()
+                .Pass();
+        }
+
+        internal static List<string> GetValuesFromTestLibrary(
+            ITestOutputHelper log,
+            TestAssetsManager testAssetsManager,
+            string itemTypeOrPropertyName,
+            Action<GetValuesCommand> setup = null, 
+            string[] msbuildArgs = null,
+            GetValuesCommand.ValueType valueType = GetValuesCommand.ValueType.Item, 
+            [CallerMemberName] string callingMethod = "", 
+            Action<XDocument> projectChanges = null)
+        {
+            msbuildArgs = msbuildArgs ?? Array.Empty<string>();
+
+            string targetFramework = "netstandard1.6";
+
+            var testAsset = testAssetsManager
+                .CopyTestAsset("AppWithLibraryFS", callingMethod)
+                .WithSource();
+
+            if (projectChanges != null)
+            {
+                testAsset.WithProjectChanges(projectChanges);
+            }
+
+            testAsset.Restore(log, relativePath: "TestLibrary");
+
+            var libraryProjectDirectory = Path.Combine(testAsset.TestRoot, "TestLibrary");
+
+            var getValuesCommand = new GetValuesCommand(log, libraryProjectDirectory,
+                targetFramework, itemTypeOrPropertyName, valueType);
+
+            if (setup != null)
+            {
+                setup(getValuesCommand);
+            }
+
+            getValuesCommand
+                .Execute(msbuildArgs)
+                .Should()
+                .Pass();
+
+            var itemValues = getValuesCommand.GetValues();
+
+            return itemValues;
+        }
+
+        [Fact]
+        public void The_build_fails_if_nuget_restore_has_not_occurred()
+        {
+            var testAsset = _testAssetsManager
+                .CopyTestAsset("AppWithLibraryFS")
+                .WithSource();
+
+            var libraryProjectDirectory = Path.Combine(testAsset.TestRoot, "TestLibrary");
+
+            var buildCommand = new BuildCommand(Log, libraryProjectDirectory);
+            buildCommand
+                .Execute()
+                .Should()
+                .Fail();
+        }
+
+        [Fact]
+        public void Restore_succeeds_even_if_the_project_extension_is_for_a_different_language()
+        {
+            var testAsset = _testAssetsManager
+                .CopyTestAsset("AppWithLibraryFS")
+                .WithSource();
+
+            var libraryProjectDirectory = Path.Combine(testAsset.TestRoot, "TestLibrary");
+
+            var oldProjectFile = Path.Combine(libraryProjectDirectory, "TestLibrary.fsproj");
+            var newProjectFile = Path.Combine(libraryProjectDirectory, "TestLibrary.different_language_proj");
+
+            File.Move(oldProjectFile, newProjectFile);
+
+            var restoreCommand = new RestoreCommand(Log, libraryProjectDirectory, "TestLibrary.different_language_proj");
+
+            restoreCommand
+                .Execute()
+                .Should()
+                .Pass();
+        }
+
+        [Theory]
+        [InlineData("Debug", "DEBUG")]
+        [InlineData("Release", "RELEASE")]
+        [InlineData("CustomConfiguration", "CUSTOMCONFIGURATION")]
+        [InlineData("Debug-NetCore", "DEBUG_NETCORE")]
+        public void It_implicitly_defines_compilation_constants_for_the_configuration(string configuration, string expectedDefine)
+        {
+            var testAsset = _testAssetsManager
+                .CopyTestAsset("AppWithLibraryFS", "ImplicitConfigurationConstants", configuration)
+                .WithSource()
+                .Restore(Log, relativePath: "TestLibrary");
+
+            var libraryProjectDirectory = Path.Combine(testAsset.TestRoot, "TestLibrary");
+
+            var getValuesCommand = new GetValuesCommand(Log, libraryProjectDirectory,
+                "netstandard1.6", "DefineConstants");
+
+            getValuesCommand.ShouldCompile = true;
+            getValuesCommand.Configuration = configuration;
+
+            getValuesCommand
+                .Execute("/p:Configuration=" + configuration)
+                .Should()
+                .Pass();
+
+            var definedConstants = getValuesCommand.GetValues();
+
+            definedConstants.Should().BeEquivalentTo(new[] { expectedDefine, "TRACE", "NETSTANDARD", "NETSTANDARD1_6" });
+        }
+
+        [Theory]
+        [InlineData("netstandard1.6", new[] { "NETSTANDARD", "NETSTANDARD1_6" }, false)]
+        [InlineData("net45", new[] { "NETFRAMEWORK", "NET45" }, true)]
+        [InlineData("net461", new[] { "NETFRAMEWORK", "NET461" }, true)]
+        [InlineData("netcoreapp2.0", new[] { "NETCOREAPP", "NETCOREAPP2_0" }, false)]
+        public void It_implicitly_defines_compilation_constants_for_the_target_framework(string targetFramework, string[] expectedDefines, bool buildOnlyOnWindows)
+        {
+            bool shouldCompile = true;
+
+            var testAsset = _testAssetsManager
+                .CopyTestAsset("AppWithLibraryFS", "ImplicitFrameworkConstants", targetFramework)
+                .WithSource()
+                .WithProjectChanges(project =>
+                {
+                    //  Update target framework in project
+                    var ns = project.Root.Name.Namespace;
+                    var targetFrameworkProperties = project.Root
+                        .Elements(ns + "PropertyGroup")
+                        .Elements(ns + "TargetFramework")
+                        .ToList();
+
+                    targetFrameworkProperties.Count.Should().Be(1);
+
+                    if (targetFramework.Contains(",Version="))
+                    {
+                        //  We use the full TFM for frameworks we don't have built-in support for targeting, so we don't want to run the Compile target
+                        shouldCompile = false;
+
+                        var frameworkName = new FrameworkName(targetFramework);
+
+                        var targetFrameworkProperty = targetFrameworkProperties.Single();
+                        targetFrameworkProperty.AddBeforeSelf(new XElement(ns + "TargetFrameworkIdentifier", frameworkName.Identifier));
+                        targetFrameworkProperty.AddBeforeSelf(new XElement(ns + "TargetFrameworkVersion", "v" + frameworkName.Version.ToString()));
+                        if (!string.IsNullOrEmpty(frameworkName.Profile))
+                        {
+                            targetFrameworkProperty.AddBeforeSelf(new XElement(ns + "TargetFrameworkProfile", frameworkName.Profile));
+                        }
+
+                        //  For the NuGet restore task to work with package references, it needs the TargetFramework property to be set.
+                        //  Otherwise we would just remove the property.
+                        targetFrameworkProperty.SetValue(targetFramework);
+                    }
+                    else
+                    {
+                        shouldCompile = true;
+                        targetFrameworkProperties.Single().SetValue(targetFramework);
+                    }
+                })
+                .Restore(Log, relativePath: "TestLibrary");
+
+            if (buildOnlyOnWindows && !RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                shouldCompile = false;
+            }
+
+            var libraryProjectDirectory = Path.Combine(testAsset.TestRoot, "TestLibrary");
+
+            var getValuesCommand = new GetValuesCommand(Log, libraryProjectDirectory,
+                targetFramework, "DefineConstants")
+            {
+                ShouldCompile = shouldCompile
+            };
+
+            getValuesCommand
+                .Execute()
+                .Should()
+                .Pass();
+
+            var definedConstants = getValuesCommand.GetValues();
+
+            definedConstants.Should().BeEquivalentTo(new[] { "DEBUG", "TRACE" }.Concat(expectedDefines).ToArray());
+        }
+    }
+}


### PR DESCRIPTION
This Fixes: 
1.  a typo in the FSharp targets files:   https://github.com/dotnet/sdk/compare/master...KevinRansom:addtests?expand=1#diff-28f8d0028b86867ebcdb1cc7ecc55a3cR26
2.  Adds smoke tests for building F# .dll's and .exe's

3.  Also fixes an issue with implicit #defines

Thanks

Kevin

/cc @livarcocc @nguerrera 

