### PR TITLE
Add back NuGetSourceType=Package metadata in package resolution

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageAssets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageAssets.cs
@@ -251,6 +251,7 @@ namespace Microsoft.NET.Build.Tasks
 
             foreach (var item in CompileTimeAssemblies)
             {
+                item.SetMetadata(MetadataKeys.NuGetSourceType, "Package");
                 item.SetMetadata(MetadataKeys.Private, "false");
                 item.SetMetadata(MetadataKeys.HintPath, item.ItemSpec);
                 item.SetMetadata(MetadataKeys.ExternallyResolved, externallyResolved);
@@ -262,6 +263,7 @@ namespace Microsoft.NET.Build.Tasks
             foreach (var item in FrameworkAssemblies)
             {
                 item.SetMetadata(MetadataKeys.NuGetIsFrameworkReference, "true");
+                item.SetMetadata(MetadataKeys.NuGetSourceType, "Package");
                 item.SetMetadata(MetadataKeys.Pack, "false");
                 item.SetMetadata(MetadataKeys.Private, "false");
             }


### PR DESCRIPTION
This was used in a few places to distinguish between refs coming from NuGet from others.

In particular, it caused all nuget refs to be copied to refs/folder on Build with PreserveCompilationContext=true.

Fix #2121