### PR TITLE
Updating the SDK to provide default dependentupon metadata for resx files.

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.props
@@ -31,6 +31,14 @@ Copyright (c) .NET Foundation. All rights reserved.
     <None Remove="**/*$(DefaultLanguageSourceExtension)" Condition=" '$(EnableDefaultCompileItems)' == 'true' "/>
     <None Remove="**/*.resx" Condition=" '$(EnableDefaultEmbeddedResourceItems)' == 'true' "/>
   </ItemGroup>
+  <ItemGroup Condition=" '$(EnableDefaultDependentUponMetadata)' == 'true' And '$(EnableDefaultResxDependentUponMetadata)' == 'true' ">
+    <Compile Update="**/*.Designer.cs">
+      <DependentUpon Condition="Exists('%(RecursiveDir)$([System.IO.Path]::ChangeExtension(%(Filename), `.resx`))')">%(RecursiveDir)$([System.IO.Path]::ChangeExtension(%(Filename), '.resx'))</DependentUpon>
+    </Compile>
+    <EmbeddedResource Update="**/*.*.resx">
+      <DependentUpon Condition="Exists('%(RecursiveDir)$([System.IO.Path]::ChangeExtension(%(Filename), `.resx`))') And '%(RecursiveDir)$([System.IO.Path]::ChangeExtension(%(Filename), `.resx`))' != '%(Identity)'">%(RecursiveDir)$([System.IO.Path]::ChangeExtension(%(Filename), '.resx'))</DependentUpon>
+    </EmbeddedResource>
+  </ItemGroup>
 
   <!-- Automatically reference NETStandard.Library or Microsoft.NETCore.App package if targeting the corresponding target framework.
       We can refer here in the .props file to properties set in the .targets files because items and their conditions are

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.targets
@@ -16,10 +16,12 @@ Copyright (c) .NET Foundation. All rights reserved.
   </PropertyGroup>
 
   <PropertyGroup>
-   <EnableDefaultItems Condition=" '$(EnableDefaultItems)' == '' ">true</EnableDefaultItems>
-   <EnableDefaultCompileItems Condition=" '$(EnableDefaultCompileItems)' == '' ">true</EnableDefaultCompileItems>
+    <EnableDefaultItems Condition=" '$(EnableDefaultItems)' == '' ">true</EnableDefaultItems>
+    <EnableDefaultCompileItems Condition=" '$(EnableDefaultCompileItems)' == '' ">true</EnableDefaultCompileItems>
     <EnableDefaultEmbeddedResourceItems Condition=" '$(EnableDefaultEmbeddedResourceItems)' == '' ">true</EnableDefaultEmbeddedResourceItems>
     <EnableDefaultNoneItems Condition=" '$(EnableDefaultNoneItems)' == '' ">true</EnableDefaultNoneItems>
+    <EnableDefaultDependentUponMetadata Condition=" '$(EnableDefaultDependentUponMetadata)' == '' ">true</EnableDefaultDependentUponMetadata>
+    <EnableDefaultResxDependentUponMetadata Condition=" '$(EnableDefaultResxDependentUponMetadata)' == '' ">true</EnableDefaultResxDependentUponMetadata>
   </PropertyGroup>
 
   <PropertyGroup>    


### PR DESCRIPTION
This resolves https://github.com/dotnet/sdk/issues/1441

FYI. @livarcocc, @KathleenDollard, @dotnet/dotnet-cli, @sharwell