### PR TITLE
Update implicit version checks to operate on list of implicit packages

### DIFF
--- a/src/Tasks/Common/MetadataKeys.cs
+++ b/src/Tasks/Common/MetadataKeys.cs
@@ -79,5 +79,8 @@ namespace Microsoft.NET.Build.Tasks
         // Resource assemblies
         public const string Culture = "Culture";
         public const string DestinationSubDirectory = "DestinationSubDirectory";
+
+        // Expected platform packages
+        public const string ExpectedVersion = "ExpectedVersion";
     }
 }

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAResolvePackageAssetsTask.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAResolvePackageAssetsTask.cs
@@ -62,8 +62,12 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                         property.SetValue(task, property.Name);
                         break;
 
+                    case var t when t == typeof(ITaskItem[]):
+                        property.SetValue(task, new[] { new MockTaskItem() { ItemSpec = property.Name } });
+                        break;
+
                     default:
-                        Assert.True(false, $"{property.Name} is not a bool or string. Update the test code to handle that.");
+                        Assert.True(false, $"{property.Name} is not a bool or string or ITaskItem[]. Update the test code to handle that.");
                         throw null; // unreachable
                 }
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.targets
@@ -137,17 +137,19 @@ Copyright (c) .NET Foundation. All rights reserved.
     <RuntimeFrameworkVersion Condition="'$(TargetLatestRuntimePatch)' != 'true' ">$(DefaultNetCorePatchVersion)</RuntimeFrameworkVersion>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(DisableImplicitFrameworkReferences)' != 'true'">
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(DisableImplicitFrameworkReferences)' != 'true'">
     <!-- This property is different than MicrosoftNETPlatformLibrary.  MicrosoftNETPlatformLibrary is
          used to trim the dependencies published with a framework-dependent app, and is overridden
          by ASP.NET packages.
          
-         The ImplicitPlatformPackageIdentifier is the package that is actually implicitly
+         ExpectedPlatformPackages is the list of packages that are actually implicitly
          referenced by the SDK, and is passed into the ResolvePackageAssets task
-         to verify that the restored version of the package matches the
-         RuntimeFrameworkVersion -->
-    <ImplicitPlatformPackageIdentifier>Microsoft.NETCore.App</ImplicitPlatformPackageIdentifier>
+         to verify that the restored versions of the packages matches the expected versions
+         -->
+    <ExpectedPlatformPackages Include="Microsoft.NETCore.App" ExpectedVersion="$(RuntimeFrameworkVersion)" />
+  </ItemGroup>
 
+  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(DisableImplicitFrameworkReferences)' != 'true'">
     <VerifyMatchingImplicitPackageVersion Condition="'$(VerifyMatchingImplicitPackageVersion)' == ''">true</VerifyMatchingImplicitPackageVersion>
   </PropertyGroup>
   

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.PackageDependencyResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.PackageDependencyResolution.targets
@@ -205,8 +205,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       DisableTransitiveProjectReferences="$(DisableTransitiveProjectReferences)"
       EnsureRuntimePackageDependencies="$(EnsureRuntimePackageDependencies)"
       VerifyMatchingImplicitPackageVersion="$(VerifyMatchingImplicitPackageVersion)"
-      ImplicitPlatformPackageIdentifier="$(ImplicitPlatformPackageIdentifier)"
-      ExpectedPlatformPackageVersion="$(RuntimeFrameworkVersion)"      
+      ExpectedPlatformPackages="@(ExpectedPlatformPackages)"      
       >
 
       <!-- NOTE: items names here are inconsistent because they match prior implementation


### PR DESCRIPTION
Addresses https://github.com/aspnet/Universe/issues/967. As discussed in email. This change will allow us to reuse the dotnet SDK code to check implicit versions against resolved versions. Is this the correct branch for 2.1 rc1? I will send a shiproom email with all the changes later in the day.