### PR TITLE
Configure feeds for tests, add basic test coverage for targeting .NET Core 2.1

### DIFF
--- a/src/Assets/NuGet.Config
+++ b/src/Assets/NuGet.Config
@@ -1,5 +1,0 @@
-<configuration>
-  <packageSources>
-    <add key="dotnet-core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/packages/index.json" />
-  </packageSources>
-</configuration>

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildANetCoreApp.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildANetCoreApp.cs
@@ -248,10 +248,12 @@ namespace Microsoft.NET.Build.Tests
             targetDefs.Should().Contain(".NETCoreApp,Version=v1.1");
         }
 
-        [Fact]
-        public void It_runs_the_app_from_the_output_folder()
+        [Theory]
+        [InlineData("netcoreapp2.0")]
+        [InlineData("netcoreapp2.1")]
+        public void It_runs_the_app_from_the_output_folder(string targetFramework)
         {
-            RunAppFromOutputFolder("RunFromOutputFolder", false, false);
+            RunAppFromOutputFolder("RunFromOutputFolder_" + targetFramework, false, false, targetFramework);
         }
 
         [Fact]
@@ -272,9 +274,9 @@ namespace Microsoft.NET.Build.Tests
             RunAppFromOutputFolder("RunFromOutputFolderWithRIDConflicts", true, true);
         }
 
-        private void RunAppFromOutputFolder(string testName, bool useRid, bool includeConflicts)
+        private void RunAppFromOutputFolder(string testName, bool useRid, bool includeConflicts,
+            string targetFramework = "netcoreapp2.0")
         {
-            var targetFramework = "netcoreapp2.0";
             var runtimeIdentifier = useRid ? EnvironmentInfo.GetCompatibleRid(targetFramework) : null;
 
             TestProject project = new TestProject()

--- a/src/Tests/Microsoft.NET.TestFramework/Microsoft.NET.TestFramework.csproj
+++ b/src/Tests/Microsoft.NET.TestFramework/Microsoft.NET.TestFramework.csproj
@@ -31,21 +31,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <_CopyDirectoryBuildTestDependenciesInput Include="$(MSBuildThisFileDirectory)..\Common\Empty.props" />
-    <_CopyDirectoryBuildTestDependenciesInput Include="$(MSBuildThisFileDirectory)..\Common\Empty.targets" />
+    <None Include="SetupTestRoot.targets" />
   </ItemGroup>
 
-  <ItemGroup>
-    <_CopyDirectoryBuildTestDependenciesOutput Include="$(ArtifactsTmpDir)Directory.Build.props" />
-    <_CopyDirectoryBuildTestDependenciesOutput Include="$(ArtifactsTmpDir)Directory.Build.targets" />
-  </ItemGroup>
-
-  <Target Name="_CopyDirectoryBuildTestDependencies" AfterTargets="Build" Inputs="@(_CopyDirectoryBuildTestDependenciesInput)" Outputs="@(_CopyDirectoryBuildTestDependenciesOutput)">
-    <Copy SourceFiles="@(_CopyDirectoryBuildTestDependenciesInput)" DestinationFiles="@(_CopyDirectoryBuildTestDependenciesOutput)" />
-  </Target>
-  <Target Name="_CopyTestNuGetConfig" AfterTargets="Build">
-    <Copy SourceFiles="$(MSBuildThisFileDirectory)..\..\Assets\NuGet.Config" DestinationFolder="$(ArtifactsTmpDir)" SkipUnchangedFiles="true" />
-  </Target>
+  <Import Project="SetupTestRoot.targets" />
 
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 

--- a/src/Tests/Microsoft.NET.TestFramework/SetupTestRoot.targets
+++ b/src/Tests/Microsoft.NET.TestFramework/SetupTestRoot.targets
@@ -1,0 +1,76 @@
+<!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the MIT license. See License.txt in the project root for full license information. -->
+<Project>
+
+  <ItemGroup>
+    <_CopyDirectoryBuildTestDependenciesInput Include="$(MSBuildThisFileDirectory)..\Common\Empty.props" />
+    <_CopyDirectoryBuildTestDependenciesInput Include="$(MSBuildThisFileDirectory)..\Common\Empty.targets" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <_CopyDirectoryBuildTestDependenciesOutput Include="$(ArtifactsTmpDir)Directory.Build.props" />
+    <_CopyDirectoryBuildTestDependenciesOutput Include="$(ArtifactsTmpDir)Directory.Build.targets" />
+  </ItemGroup>
+
+  <Target Name="_CopyDirectoryBuildTestDependencies" AfterTargets="Build" Inputs="@(_CopyDirectoryBuildTestDependenciesInput)" Outputs="@(_CopyDirectoryBuildTestDependenciesOutput)">
+    <Copy SourceFiles="@(_CopyDirectoryBuildTestDependenciesInput)" DestinationFiles="@(_CopyDirectoryBuildTestDependenciesOutput)" />
+  </Target>
+  
+  <Target Name="WriteNugetConfigFile" AfterTargets="Build">
+
+    <ItemGroup>
+      <NugetConfigPrivateFeeds Include="$(ExternalRestoreSources.Split(';'))" />
+    </ItemGroup>
+
+    <PropertyGroup>
+      <GeneratedNuGetConfig>$(ArtifactsTmpDir)NuGet.config</GeneratedNuGetConfig>
+      <NugetConfigHeader>
+        <![CDATA[
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+<packageSources>
+<!--To inherit the global NuGet package sources remove the <clear/> line below -->
+<clear />
+        ]]>
+      </NugetConfigHeader>
+
+      <NugetConfigFeeds>
+        <![CDATA[
+    <add key="BlobFeed" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
+    <add key="aspnetcore-release" value="https://dotnet.myget.org/F/aspnetcore-release/api/v3/index.json" />
+    <add key="roslyn" value="https://dotnet.myget.org/f/roslyn/api/v3/index.json" />
+    <add key="nuget-build" value="https://dotnet.myget.org/F/nuget-build/api/v3/index.json" />
+    <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="container-tools" value="https://www.myget.org/F/container-tools-for-visual-studio/api/v3/index.json" />
+        ]]>
+      </NugetConfigFeeds>
+
+      <NugetConfigSuffix>
+        <![CDATA[
+</packageSources>
+</configuration>
+        ]]>
+      </NugetConfigSuffix>
+
+  </PropertyGroup>
+
+  <WriteLinesToFile File="$(GeneratedNuGetConfig)"
+                    Lines="$(NugetConfigHeader)"
+                    Overwrite="true" />
+
+  <WriteLinesToFile Condition="'$(ExternalRestoreSources)' != '' and '$(DotNetBuildOffline)' != 'true'"
+                    File="$(GeneratedNuGetConfig)"
+                    Lines="&lt;add key=&quot;PrivateBlobFeed%(NugetConfigPrivateFeeds.Filename)&quot; value=&quot;%(NugetConfigPrivateFeeds.Identity)&quot; /&gt;"
+                    Overwrite="false" />
+
+  <WriteLinesToFile Condition="'$(DotNetBuildOffline)' != 'true'"
+                    File="$(GeneratedNuGetConfig)"
+                    Lines="$(NugetConfigFeeds)"
+                    Overwrite="false" />
+
+  <WriteLinesToFile File="$(GeneratedNuGetConfig)"
+                    Lines="$(NugetConfigSuffix)"
+                    Overwrite="false" />
+
+  </Target>
+
+</Project>


### PR DESCRIPTION
This essentially copies the logic for setting up a NuGet.config for tests with the right feeds from https://github.com/dotnet/cli/blob/8c937a0db08e56660aca456ac088f2d0e70735ab/build/NugetConfigFile.targets