### PR TITLE
Defend against parallel access to package assets cache

### DIFF
--- a/src/Tasks/Common/Resources/Strings.resx
+++ b/src/Tasks/Common/Resources/Strings.resx
@@ -346,4 +346,7 @@
 {1} - Restored version of platform package
 {2} - Current version of platform package</comment>
   </data>
+  <data name="UnableToUsePackageAssetsCache" xml:space="preserve">
+    <value>Unable to use package assets cache due to I/O error. This can occur when the same project is built more than once in parallel. Performance may be degraded, but the build result will not be impacted.</value>
+  </data>
 </root>

--- a/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
@@ -379,6 +379,11 @@
 {1} - Restored version of platform package
 {2} - Current version of platform package</note>
       </trans-unit>
+      <trans-unit id="UnableToUsePackageAssetsCache">
+        <source>Unable to use package assets cache due to I/O error. This can occur when the same project is built more than once in parallel. Performance may be degraded, but the build result will not be impacted.</source>
+        <target state="new">Unable to use package assets cache due to I/O error. This can occur when the same project is built more than once in parallel. Performance may be degraded, but the build result will not be impacted.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Common/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.de.xlf
@@ -379,6 +379,11 @@
 {1} - Restored version of platform package
 {2} - Current version of platform package</note>
       </trans-unit>
+      <trans-unit id="UnableToUsePackageAssetsCache">
+        <source>Unable to use package assets cache due to I/O error. This can occur when the same project is built more than once in parallel. Performance may be degraded, but the build result will not be impacted.</source>
+        <target state="new">Unable to use package assets cache due to I/O error. This can occur when the same project is built more than once in parallel. Performance may be degraded, but the build result will not be impacted.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Common/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.es.xlf
@@ -379,6 +379,11 @@
 {1} - Restored version of platform package
 {2} - Current version of platform package</note>
       </trans-unit>
+      <trans-unit id="UnableToUsePackageAssetsCache">
+        <source>Unable to use package assets cache due to I/O error. This can occur when the same project is built more than once in parallel. Performance may be degraded, but the build result will not be impacted.</source>
+        <target state="new">Unable to use package assets cache due to I/O error. This can occur when the same project is built more than once in parallel. Performance may be degraded, but the build result will not be impacted.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
@@ -379,6 +379,11 @@
 {1} - Restored version of platform package
 {2} - Current version of platform package</note>
       </trans-unit>
+      <trans-unit id="UnableToUsePackageAssetsCache">
+        <source>Unable to use package assets cache due to I/O error. This can occur when the same project is built more than once in parallel. Performance may be degraded, but the build result will not be impacted.</source>
+        <target state="new">Unable to use package assets cache due to I/O error. This can occur when the same project is built more than once in parallel. Performance may be degraded, but the build result will not be impacted.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Common/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.it.xlf
@@ -379,6 +379,11 @@
 {1} - Restored version of platform package
 {2} - Current version of platform package</note>
       </trans-unit>
+      <trans-unit id="UnableToUsePackageAssetsCache">
+        <source>Unable to use package assets cache due to I/O error. This can occur when the same project is built more than once in parallel. Performance may be degraded, but the build result will not be impacted.</source>
+        <target state="new">Unable to use package assets cache due to I/O error. This can occur when the same project is built more than once in parallel. Performance may be degraded, but the build result will not be impacted.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
@@ -379,6 +379,11 @@
 {1} - Restored version of platform package
 {2} - Current version of platform package</note>
       </trans-unit>
+      <trans-unit id="UnableToUsePackageAssetsCache">
+        <source>Unable to use package assets cache due to I/O error. This can occur when the same project is built more than once in parallel. Performance may be degraded, but the build result will not be impacted.</source>
+        <target state="new">Unable to use package assets cache due to I/O error. This can occur when the same project is built more than once in parallel. Performance may be degraded, but the build result will not be impacted.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
@@ -379,6 +379,11 @@
 {1} - Restored version of platform package
 {2} - Current version of platform package</note>
       </trans-unit>
+      <trans-unit id="UnableToUsePackageAssetsCache">
+        <source>Unable to use package assets cache due to I/O error. This can occur when the same project is built more than once in parallel. Performance may be degraded, but the build result will not be impacted.</source>
+        <target state="new">Unable to use package assets cache due to I/O error. This can occur when the same project is built more than once in parallel. Performance may be degraded, but the build result will not be impacted.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
@@ -379,6 +379,11 @@
 {1} - Restored version of platform package
 {2} - Current version of platform package</note>
       </trans-unit>
+      <trans-unit id="UnableToUsePackageAssetsCache">
+        <source>Unable to use package assets cache due to I/O error. This can occur when the same project is built more than once in parallel. Performance may be degraded, but the build result will not be impacted.</source>
+        <target state="new">Unable to use package assets cache due to I/O error. This can occur when the same project is built more than once in parallel. Performance may be degraded, but the build result will not be impacted.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
@@ -379,6 +379,11 @@
 {1} - Restored version of platform package
 {2} - Current version of platform package</note>
       </trans-unit>
+      <trans-unit id="UnableToUsePackageAssetsCache">
+        <source>Unable to use package assets cache due to I/O error. This can occur when the same project is built more than once in parallel. Performance may be degraded, but the build result will not be impacted.</source>
+        <target state="new">Unable to use package assets cache due to I/O error. This can occur when the same project is built more than once in parallel. Performance may be degraded, but the build result will not be impacted.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
@@ -379,6 +379,11 @@
 {1} - Restored version of platform package
 {2} - Current version of platform package</note>
       </trans-unit>
+      <trans-unit id="UnableToUsePackageAssetsCache">
+        <source>Unable to use package assets cache due to I/O error. This can occur when the same project is built more than once in parallel. Performance may be degraded, but the build result will not be impacted.</source>
+        <target state="new">Unable to use package assets cache due to I/O error. This can occur when the same project is built more than once in parallel. Performance may be degraded, but the build result will not be impacted.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
@@ -379,6 +379,11 @@
 {1} - Restored version of platform package
 {2} - Current version of platform package</note>
       </trans-unit>
+      <trans-unit id="UnableToUsePackageAssetsCache">
+        <source>Unable to use package assets cache due to I/O error. This can occur when the same project is built more than once in parallel. Performance may be degraded, but the build result will not be impacted.</source>
+        <target state="new">Unable to use package assets cache due to I/O error. This can occur when the same project is built more than once in parallel. Performance may be degraded, but the build result will not be impacted.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
@@ -379,6 +379,11 @@
 {1} - Restored version of platform package
 {2} - Current version of platform package</note>
       </trans-unit>
+      <trans-unit id="UnableToUsePackageAssetsCache">
+        <source>Unable to use package assets cache due to I/O error. This can occur when the same project is built more than once in parallel. Performance may be degraded, but the build result will not be impacted.</source>
+        <target state="new">Unable to use package assets cache due to I/O error. This can occur when the same project is built more than once in parallel. Performance may be degraded, but the build result will not be impacted.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
@@ -379,6 +379,11 @@
 {1} - Restored version of platform package
 {2} - Current version of platform package</note>
       </trans-unit>
+      <trans-unit id="UnableToUsePackageAssetsCache">
+        <source>Unable to use package assets cache due to I/O error. This can occur when the same project is built more than once in parallel. Performance may be degraded, but the build result will not be impacted.</source>
+        <target state="new">Unable to use package assets cache due to I/O error. This can occur when the same project is built more than once in parallel. Performance may be degraded, but the build result will not be impacted.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageAssets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageAssets.cs
@@ -345,6 +345,12 @@ namespace Microsoft.NET.Build.Tasks
 
                 if (!task.DisablePackageAssetsCache)
                 {
+                    // I/O errors can occur here if there are parallel calls to resolve package assets
+                    // for the same project configured with the same intermediate directory. This can
+                    // (for example) happen when design-time builds and real builds overlap.
+                    //
+                    // If there is an I/O error, then we fall back to the same in-memory approach below
+                    // as when DisablePackageAssetsCache is set to true.
                     try
                     {
                         _reader = CreateReaderFromDisk(task, settingsHash);

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToStoreAProjectWithDependencies.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToStoreAProjectWithDependencies.cs
@@ -160,7 +160,7 @@ namespace Microsoft.NET.Publish.Tests
             storeDirectory.Should().OnlyHaveFiles(files_on_disk);
         }
 
-        [CoreMSBuildOnlyFact(Skip="https://github.com/dotnet/sdk/issues/2089")]
+        [CoreMSBuildOnlyFact]
         public void compose_multifile()
         {
             TestAsset simpleDependenciesAsset = _testAssetsManager


### PR DESCRIPTION
This can happen if certain targets are invoked in parallel on the same project
having with global properties not differing sufficiently to provide each build
with a unique intermediate directory.

One case where this can happen is if there is a design-time build and real build
happening in parallel. Another case occurs frequently in `dotnet store`. The
latter may be a design flaw in `dotnet store` but the root cause hasn't been
identified yet. This will at least prevent `dotnet store` from failing, but more
investigation is needed to understand why `dotnet store` gets itself into this
situation.

Now, when we're unable to read or write the assets cache, we fall back to the
same in-memory technique that is used when DisablePackageAssetsCache is set to
true. We will also log a high importance message (not a warning because that can
break builds with warning-as-error and this can happen outside the user's
control). The intent of logging a message is to be able to get feedback if this
is happening frequently. The risk the message is trying to mitigate is if we
start falling back from the fast path in common cases and don't have any clues
about that other than the perf hit.

Fix #2149
Fix #2089
Fix dotnet/cli#9092