### PR TITLE
Support overriding MSBuildProjectExtensionsPath for a specific project via global properties

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/sdk/Sdk.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/sdk/Sdk.props
@@ -26,6 +26,10 @@ Copyright (c) .NET Foundation. All rights reserved.
     <UsingMicrosoftNETSdk>true</UsingMicrosoftNETSdk>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(MSBuildProjectFullPath)' == '$(ProjectToOverrideProjectExtensionsPath)'">
+    <MSBuildProjectExtensionsPath>$(ProjectExtensionsPathForSpecifiedProject)</MSBuildProjectExtensionsPath>
+  </PropertyGroup>
+
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" />
   <Import Project="$(MSBuildThisFileDirectory)..\build\Microsoft.NET.Sdk.props"  />  
 </Project>


### PR DESCRIPTION
Two properties are needed since global properties flow to referenced projects so there needs to be a way to specify which project the override applies to

Part of the fix to https://github.com/dotnet/cli/issues/9129