### PR TITLE
Support overriding MSBuildProjectExtensionsPath for a specific project via global properties

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/sdk/Sdk.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/sdk/Sdk.props
@@ -26,6 +26,10 @@ Copyright (c) .NET Foundation. All rights reserved.
     <UsingMicrosoftNETSdk>true</UsingMicrosoftNETSdk>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(MSBuildProjectFullPath)' == '$(ProjectToOverrideProjectExtensionsPath)'">
+    <MSBuildProjectExtensionsPath>$(ProjectExtensionsPathForSpecifiedProject)</MSBuildProjectExtensionsPath>
+  </PropertyGroup>
+
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" />
   <Import Project="$(MSBuildThisFileDirectory)..\targets\Microsoft.NET.Sdk.props"  />  
 </Project>


### PR DESCRIPTION
Dual check-in into release/2.1.3xx for change in #2194

Two properties are needed since global properties flow to referenced projects so there needs to be a way to specify which project the override applies to