### PR TITLE
Simplify preview warning

### DIFF
--- a/src/Tasks/Common/Resources/Strings.resx
+++ b/src/Tasks/Common/Resources/Strings.resx
@@ -328,7 +328,7 @@
     <value>Project is targeting runtime '{0}' but did not resolve any runtime-specific packages. This runtime may not be supported by the target framework.</value>
   </data>
   <data name="UsingPreviewSdkWarning" xml:space="preserve">
-    <value>You are working with a preview version of the .NET Core SDK. You can define the SDK version via a global.json file in the current project. More at https://go.microsoft.com/fwlink/?linkid=869452</value>
+    <value>You are using a preview version of .NET Core. See: https://aka.ms/dotnet-core-preview</value>
   </data>
   <data name="InvalidItemSpecToUse" xml:space="preserve">
     <value>Invalid value for ItemSpecToUse parameter: '{0}'.  This property must be blank or set to 'Left' or 'Right'</value>


### PR DESCRIPTION
This multi-line warning bugs me. I'd like it to be single line.

- Not sure if the localized files need to be updated. I didn't do that, but can.
- The link (same as old one) isn't that helpful. We should have a doc on using previews. Global.json is one part of using previews.