### PR TITLE
Update tests for updated stage 0 and netcoreapp2.2

### DIFF
--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildALibrary.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildALibrary.cs
@@ -587,7 +587,7 @@ namespace Microsoft.NET.Build.Tests
         }
 
         [Theory]
-        [InlineData("netcoreapp2.2")]
+        [InlineData("netcoreapp2.3")]
         [InlineData("netstandard2.1")]
         public void It_fails_to_build_if_targeting_a_higher_framework_than_is_supported(string targetFramework)
         {

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildANetCoreApp.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildANetCoreApp.cs
@@ -53,10 +53,10 @@ namespace Microsoft.NET.Build.Tests
         //  Test behavior when implicit version differs for framework-dependent and self-contained apps
         [Theory]
         [InlineData("netcoreapp1.0", false, true, "1.0.5")]
-        [InlineData("netcoreapp1.0", true, true, "1.0.10")]
+        [InlineData("netcoreapp1.0", true, true, "1.0.11")]
         [InlineData("netcoreapp1.0", false, false, "1.0.5")]
         [InlineData("netcoreapp1.1", false, true, "1.1.2")]
-        [InlineData("netcoreapp1.1", true, true, "1.1.7")]
+        [InlineData("netcoreapp1.1", true, true, "1.1.8")]
         [InlineData("netcoreapp1.1", false, false, "1.1.2")]
         [InlineData("netcoreapp2.0", false, true, "2.0.0")]
         [InlineData("netcoreapp2.0", true, true, TestContext.LatestRuntimePatchForNetCoreApp2_0)]

--- a/src/Tests/Microsoft.NET.TestFramework/TestContext.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/TestContext.cs
@@ -45,7 +45,7 @@ namespace Microsoft.NET.TestFramework
             }
         }
 
-        public const string LatestRuntimePatchForNetCoreApp2_0 = "2.0.6";
+        public const string LatestRuntimePatchForNetCoreApp2_0 = "2.0.7";
 
         public void AddTestEnvironmentVariables(SdkCommandSpec command)
         {


### PR DESCRIPTION
I accidentally pushed [a commit](https://github.com/dotnet/sdk/commit/33d51eab4d1e8dccf90eec946cf311ef29e0857f) to master without using a PR.  This PR fixes tests that were broken because of this:

- Update latest patch versions expected in tests to correspond with updated stage 0
- Update test to allow targeting netcoreapp2.2

