### PR TITLE
Updating the obsolete cli tool package message.

### DIFF
--- a/src/Tasks/Common/Resources/Strings.resx
+++ b/src/Tasks/Common/Resources/Strings.resx
@@ -341,7 +341,7 @@
     <comment>The following are names of parameters or literal values and should not be translated: ItemSpecToUse, Left, Right</comment>
   </data>
   <data name="ProjectContainsObsoleteDotNetCliTool" xml:space="preserve">
-    <value>Using DotNetCliToolReference to reference '{0}' is obsolete and can be removed from this project. This tool is bundled by default in the .NET Core SDK.</value>
+    <value>The tool '{0}' is now included in the .NET Core SDK. Information on resolving this warning is available at (https://aka.ms/dotnetclitools-in-box).</value>
   </data>
   <data name="ErrorReadingAssetsFile" xml:space="preserve">
     <value>Error reading assets file: {0}</value>

--- a/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
@@ -363,8 +363,8 @@
         <note>The following are names of parameters or literal values and should not be translated: ItemSpecToUse, Left, Right</note>
       </trans-unit>
       <trans-unit id="ProjectContainsObsoleteDotNetCliTool">
-        <source>Using DotNetCliToolReference to reference '{0}' is obsolete and can be removed from this project. This tool is bundled by default in the .NET Core SDK.</source>
-        <target state="translated">Použití DotNetCliToolReference k odkazování na {0} je zastaralé a lze je z tohoto projektu odebrat. Tento nástroj je standardně součástí sady .NET Core SDK.</target>
+        <source>The tool '{0}' is now included in the .NET Core SDK. Information on resolving this warning is available at (https://aka.ms/dotnetclitools-in-box).</source>
+        <target state="needs-review-translation">Použití DotNetCliToolReference k odkazování na {0} je zastaralé a lze je z tohoto projektu odebrat. Tento nástroj je standardně součástí sady .NET Core SDK.</target>
         <note />
       </trans-unit>
       <trans-unit id="ErrorReadingAssetsFile">

--- a/src/Tasks/Common/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.de.xlf
@@ -363,8 +363,8 @@
         <note>The following are names of parameters or literal values and should not be translated: ItemSpecToUse, Left, Right</note>
       </trans-unit>
       <trans-unit id="ProjectContainsObsoleteDotNetCliTool">
-        <source>Using DotNetCliToolReference to reference '{0}' is obsolete and can be removed from this project. This tool is bundled by default in the .NET Core SDK.</source>
-        <target state="translated">Die Verwendung von DotNetCliToolReference zum Verweisen auf "{0}" ist veraltet und kann aus diesem Projekt entfernt werden. Dieses Tool ist standardmäßig im .NET Core SDK-Paket enthalten.</target>
+        <source>The tool '{0}' is now included in the .NET Core SDK. Information on resolving this warning is available at (https://aka.ms/dotnetclitools-in-box).</source>
+        <target state="needs-review-translation">Die Verwendung von DotNetCliToolReference zum Verweisen auf "{0}" ist veraltet und kann aus diesem Projekt entfernt werden. Dieses Tool ist standardmäßig im .NET Core SDK-Paket enthalten.</target>
         <note />
       </trans-unit>
       <trans-unit id="ErrorReadingAssetsFile">

--- a/src/Tasks/Common/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.es.xlf
@@ -363,8 +363,8 @@
         <note>The following are names of parameters or literal values and should not be translated: ItemSpecToUse, Left, Right</note>
       </trans-unit>
       <trans-unit id="ProjectContainsObsoleteDotNetCliTool">
-        <source>Using DotNetCliToolReference to reference '{0}' is obsolete and can be removed from this project. This tool is bundled by default in the .NET Core SDK.</source>
-        <target state="translated">El uso de DotNetCliToolReference para hacer referencia a "{0}" es obsoleto y se puede eliminar de este proyecto. Esta herramienta se incluye de manera predeterminada el SDK de .NET Core.</target>
+        <source>The tool '{0}' is now included in the .NET Core SDK. Information on resolving this warning is available at (https://aka.ms/dotnetclitools-in-box).</source>
+        <target state="needs-review-translation">El uso de DotNetCliToolReference para hacer referencia a "{0}" es obsoleto y se puede eliminar de este proyecto. Esta herramienta se incluye de manera predeterminada el SDK de .NET Core.</target>
         <note />
       </trans-unit>
       <trans-unit id="ErrorReadingAssetsFile">

--- a/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
@@ -363,8 +363,8 @@
         <note>The following are names of parameters or literal values and should not be translated: ItemSpecToUse, Left, Right</note>
       </trans-unit>
       <trans-unit id="ProjectContainsObsoleteDotNetCliTool">
-        <source>Using DotNetCliToolReference to reference '{0}' is obsolete and can be removed from this project. This tool is bundled by default in the .NET Core SDK.</source>
-        <target state="translated">L'utilisation de DotNetCliToolReference pour référencer '{0}' est obsolète et peut être supprimée de ce projet. Cet outil est fourni en bundle par défaut dans le kit SDK .NET Core.</target>
+        <source>The tool '{0}' is now included in the .NET Core SDK. Information on resolving this warning is available at (https://aka.ms/dotnetclitools-in-box).</source>
+        <target state="needs-review-translation">L'utilisation de DotNetCliToolReference pour référencer '{0}' est obsolète et peut être supprimée de ce projet. Cet outil est fourni en bundle par défaut dans le kit SDK .NET Core.</target>
         <note />
       </trans-unit>
       <trans-unit id="ErrorReadingAssetsFile">

--- a/src/Tasks/Common/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.it.xlf
@@ -363,8 +363,8 @@
         <note>The following are names of parameters or literal values and should not be translated: ItemSpecToUse, Left, Right</note>
       </trans-unit>
       <trans-unit id="ProjectContainsObsoleteDotNetCliTool">
-        <source>Using DotNetCliToolReference to reference '{0}' is obsolete and can be removed from this project. This tool is bundled by default in the .NET Core SDK.</source>
-        <target state="translated">L'uso di DotNetCliToolReference per fare riferimento a '{0}' è obsoleto e può essere da questo progetto. Questo strumento è incluso in .NET Core SDK per impostazione predefinita.</target>
+        <source>The tool '{0}' is now included in the .NET Core SDK. Information on resolving this warning is available at (https://aka.ms/dotnetclitools-in-box).</source>
+        <target state="needs-review-translation">L'uso di DotNetCliToolReference per fare riferimento a '{0}' è obsoleto e può essere da questo progetto. Questo strumento è incluso in .NET Core SDK per impostazione predefinita.</target>
         <note />
       </trans-unit>
       <trans-unit id="ErrorReadingAssetsFile">

--- a/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
@@ -363,8 +363,8 @@
         <note>The following are names of parameters or literal values and should not be translated: ItemSpecToUse, Left, Right</note>
       </trans-unit>
       <trans-unit id="ProjectContainsObsoleteDotNetCliTool">
-        <source>Using DotNetCliToolReference to reference '{0}' is obsolete and can be removed from this project. This tool is bundled by default in the .NET Core SDK.</source>
-        <target state="translated">DotNetCliToolReference を使用して '{0}' を参照するのは古い方法であるため、このプロジェクトから削除できます。既定で、このツールは .NET Core SDK にバンドルされています。</target>
+        <source>The tool '{0}' is now included in the .NET Core SDK. Information on resolving this warning is available at (https://aka.ms/dotnetclitools-in-box).</source>
+        <target state="needs-review-translation">DotNetCliToolReference を使用して '{0}' を参照するのは古い方法であるため、このプロジェクトから削除できます。既定で、このツールは .NET Core SDK にバンドルされています。</target>
         <note />
       </trans-unit>
       <trans-unit id="ErrorReadingAssetsFile">

--- a/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
@@ -363,8 +363,8 @@
         <note>The following are names of parameters or literal values and should not be translated: ItemSpecToUse, Left, Right</note>
       </trans-unit>
       <trans-unit id="ProjectContainsObsoleteDotNetCliTool">
-        <source>Using DotNetCliToolReference to reference '{0}' is obsolete and can be removed from this project. This tool is bundled by default in the .NET Core SDK.</source>
-        <target state="translated">DotNetCliToolReference를 사용한 '{0}' 참조는 사용되지 않으며 이 프로젝트에서 제거할 수 있습니다. 이도구는 .NET Core SDK에 기본적으로 포함되어 있습니다.</target>
+        <source>The tool '{0}' is now included in the .NET Core SDK. Information on resolving this warning is available at (https://aka.ms/dotnetclitools-in-box).</source>
+        <target state="needs-review-translation">DotNetCliToolReference를 사용한 '{0}' 참조는 사용되지 않으며 이 프로젝트에서 제거할 수 있습니다. 이도구는 .NET Core SDK에 기본적으로 포함되어 있습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="ErrorReadingAssetsFile">

--- a/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
@@ -363,8 +363,8 @@
         <note>The following are names of parameters or literal values and should not be translated: ItemSpecToUse, Left, Right</note>
       </trans-unit>
       <trans-unit id="ProjectContainsObsoleteDotNetCliTool">
-        <source>Using DotNetCliToolReference to reference '{0}' is obsolete and can be removed from this project. This tool is bundled by default in the .NET Core SDK.</source>
-        <target state="translated">Używanie elementu DotNetCliToolReference w celu odwołania do elementu „{0}” jest przestarzałe i może zostać usunięte z tego projektu. To narzędzie domyślnie znajduje się w zestawie .NET Core SDK.</target>
+        <source>The tool '{0}' is now included in the .NET Core SDK. Information on resolving this warning is available at (https://aka.ms/dotnetclitools-in-box).</source>
+        <target state="needs-review-translation">Używanie elementu DotNetCliToolReference w celu odwołania do elementu „{0}” jest przestarzałe i może zostać usunięte z tego projektu. To narzędzie domyślnie znajduje się w zestawie .NET Core SDK.</target>
         <note />
       </trans-unit>
       <trans-unit id="ErrorReadingAssetsFile">

--- a/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
@@ -363,8 +363,8 @@
         <note>The following are names of parameters or literal values and should not be translated: ItemSpecToUse, Left, Right</note>
       </trans-unit>
       <trans-unit id="ProjectContainsObsoleteDotNetCliTool">
-        <source>Using DotNetCliToolReference to reference '{0}' is obsolete and can be removed from this project. This tool is bundled by default in the .NET Core SDK.</source>
-        <target state="translated">O uso de DotNetCliToolReference para referenciar '{0}' está obsoleto e pode ser removido do projeto. Por padrão, essa ferramenta está no pacote do SDK do .NET Core.</target>
+        <source>The tool '{0}' is now included in the .NET Core SDK. Information on resolving this warning is available at (https://aka.ms/dotnetclitools-in-box).</source>
+        <target state="needs-review-translation">O uso de DotNetCliToolReference para referenciar '{0}' está obsoleto e pode ser removido do projeto. Por padrão, essa ferramenta está no pacote do SDK do .NET Core.</target>
         <note />
       </trans-unit>
       <trans-unit id="ErrorReadingAssetsFile">

--- a/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
@@ -363,8 +363,8 @@
         <note>The following are names of parameters or literal values and should not be translated: ItemSpecToUse, Left, Right</note>
       </trans-unit>
       <trans-unit id="ProjectContainsObsoleteDotNetCliTool">
-        <source>Using DotNetCliToolReference to reference '{0}' is obsolete and can be removed from this project. This tool is bundled by default in the .NET Core SDK.</source>
-        <target state="translated">Использование DotNetCliToolReference для ссылки на "{0}" является устаревшим подходом, поэтому его можно удалить из этого проекта. Это средство по умолчанию входит в состав пакета SDK для .NET Core.</target>
+        <source>The tool '{0}' is now included in the .NET Core SDK. Information on resolving this warning is available at (https://aka.ms/dotnetclitools-in-box).</source>
+        <target state="needs-review-translation">Использование DotNetCliToolReference для ссылки на "{0}" является устаревшим подходом, поэтому его можно удалить из этого проекта. Это средство по умолчанию входит в состав пакета SDK для .NET Core.</target>
         <note />
       </trans-unit>
       <trans-unit id="ErrorReadingAssetsFile">

--- a/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
@@ -363,8 +363,8 @@
         <note>The following are names of parameters or literal values and should not be translated: ItemSpecToUse, Left, Right</note>
       </trans-unit>
       <trans-unit id="ProjectContainsObsoleteDotNetCliTool">
-        <source>Using DotNetCliToolReference to reference '{0}' is obsolete and can be removed from this project. This tool is bundled by default in the .NET Core SDK.</source>
-        <target state="translated">'{0}' başvurusuna yönelik DotNetCliToolReference kullanımı kalktı ve bu projeden kaldırılabilir. Bu araç varsayılan olarak .NET Core SDK’sında paketlenmiştir.</target>
+        <source>The tool '{0}' is now included in the .NET Core SDK. Information on resolving this warning is available at (https://aka.ms/dotnetclitools-in-box).</source>
+        <target state="needs-review-translation">'{0}' başvurusuna yönelik DotNetCliToolReference kullanımı kalktı ve bu projeden kaldırılabilir. Bu araç varsayılan olarak .NET Core SDK’sında paketlenmiştir.</target>
         <note />
       </trans-unit>
       <trans-unit id="ErrorReadingAssetsFile">

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
@@ -363,8 +363,8 @@
         <note>The following are names of parameters or literal values and should not be translated: ItemSpecToUse, Left, Right</note>
       </trans-unit>
       <trans-unit id="ProjectContainsObsoleteDotNetCliTool">
-        <source>Using DotNetCliToolReference to reference '{0}' is obsolete and can be removed from this project. This tool is bundled by default in the .NET Core SDK.</source>
-        <target state="translated">使用 DotNetCliToolReference 引用“{0}”已过时，且可从此项目中删除。此工具默认捆绑于 .NET Core SDK。</target>
+        <source>The tool '{0}' is now included in the .NET Core SDK. Information on resolving this warning is available at (https://aka.ms/dotnetclitools-in-box).</source>
+        <target state="needs-review-translation">使用 DotNetCliToolReference 引用“{0}”已过时，且可从此项目中删除。此工具默认捆绑于 .NET Core SDK。</target>
         <note />
       </trans-unit>
       <trans-unit id="ErrorReadingAssetsFile">

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
@@ -363,8 +363,8 @@
         <note>The following are names of parameters or literal values and should not be translated: ItemSpecToUse, Left, Right</note>
       </trans-unit>
       <trans-unit id="ProjectContainsObsoleteDotNetCliTool">
-        <source>Using DotNetCliToolReference to reference '{0}' is obsolete and can be removed from this project. This tool is bundled by default in the .NET Core SDK.</source>
-        <target state="translated">使用 DotNetCliToolReference 來參考 '{0}' 的作法已過時，並可以從此專案中移除。此工具預設包含在 .NET Core SDK 中。</target>
+        <source>The tool '{0}' is now included in the .NET Core SDK. Information on resolving this warning is available at (https://aka.ms/dotnetclitools-in-box).</source>
+        <target state="needs-review-translation">使用 DotNetCliToolReference 來參考 '{0}' 的作法已過時，並可以從此專案中移除。此工具預設包含在 .NET Core SDK 中。</target>
         <note />
       </trans-unit>
       <trans-unit id="ErrorReadingAssetsFile">

--- a/src/Tests/Microsoft.NET.Restore.Tests/GivenThatWeWantToIgnoreObsoleteDotNetCliToolPackages.cs
+++ b/src/Tests/Microsoft.NET.Restore.Tests/GivenThatWeWantToIgnoreObsoleteDotNetCliToolPackages.cs
@@ -53,7 +53,7 @@ namespace Microsoft.NET.Restore.Tests
             restoreCommand.Execute("/v:n").Should()
                 .Pass()
                 .And
-                .HaveStdOutContaining($"warning : Using DotNetCliToolReference to reference '{obsoletePackageId}' is obsolete and can be removed from this project. This tool is bundled by default in the .NET Core SDK.");
+                .HaveStdOutContaining($"warning : The tool '{obsoletePackageId}' is now included in the .NET Core SDK. Information on resolving this warning is available at (https://aka.ms/dotnetclitools-in-box).");
 
             string toolAssetsFilePath = Path.Combine(TestContext.Current.NuGetCachePath, ".tools", toolProject.Name.ToLowerInvariant(), "99.99.99", toolProject.TargetFrameworks, "project.assets.json");
             Assert.False(File.Exists(toolAssetsFilePath), "Tool assets path should not have been generated");


### PR DESCRIPTION
@MattGertz for approval to take to ship room for RTM

**Issues fixed**

https://github.com/dotnet/cli/issues/9119

**Description of Issue**

Update the warning for obsolete cli tool package references. We agreed to have it changed and we finally decided on what it should look like.

**Customer Impact**

Improve the message so that it can better handle the different situations involved in this warning.

**Risk**

Low - Just text change.

**Testing**

CLI CI.

