### PR TITLE
Fix regression in clean when no assets file is present

### DIFF
--- a/build/build.ps1
+++ b/build/build.ps1
@@ -92,6 +92,9 @@ function InitializeDotNetCli {
     $env:DOTNET_INSTALL_DIR = $env:DotNetCoreSdkDir    
   }
 
+  # Save MSBuild crash files info to log directory so that they are captured as build artifacts
+  $env:MSBUILDDEBUGPATH=$LogDir
+
   # Use dotnet installation specified in DOTNET_INSTALL_DIR if it contains the required SDK version, 
   # otherwise install the dotnet CLI and SDK to repo local .dotnet directory to avoid potential permission issues.
   if (($env:DOTNET_INSTALL_DIR -ne $null) -and (Test-Path(Join-Path $env:DOTNET_INSTALL_DIR "sdk\$($GlobalJson.sdk.version)"))) {

--- a/build/build.sh
+++ b/build/build.sh
@@ -167,6 +167,9 @@ function InitializeDotNetCli {
     export DOTNET_INSTALL_DIR="$DotNetCoreSdkDir"
   fi
 
+  # Save MSBuild crash files info to log directory so that they are captured as build artifacts
+  export MSBUILDDEBUGPATH="$log_dir"
+
   ReadJson "$global_json_file" "version"
   local dotnet_sdk_version="$readjsonvalue"
   local dotnet_root=""

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -92,14 +92,14 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <PropertyGroup>
     <CoreCleanDependsOn>
-      SuppressAssetsLogMessages;
+      _SdkBeforeClean
       $(CoreCleanDependsOn)
     </CoreCleanDependsOn>
   </PropertyGroup>
 
   <PropertyGroup>
     <RebuildDependsOn>
-      UnsuppressAssetsLogMessages;
+      _SdkBeforeRebuild;
       $(RebuildDependsOn)
     </RebuildDependsOn>
   </PropertyGroup>
@@ -200,29 +200,16 @@ Copyright (c) .NET Foundation. All rights reserved.
     </ItemGroup>
   </Target>
 
-  <!--
-    ============================================================
-                                        SuppressAssetsLogMessages
-
-    Suppresses log messages from an existing project assets file.
-    ============================================================
-    -->
-  <Target Name="SuppressAssetsLogMessages" Condition="'$(UnsuppressAssetsLogMessages)' != 'true'">
-    <PropertyGroup>
+  <Target Name="_SdkBeforeClean">
+    <PropertyGroup Condition="'$(_CleaningWithoutRebuilding)' == ''">
+      <_CleaningWithoutRebuilding>true</_CleaningWithoutRebuilding>
       <EmitAssetsLogMessages>false</EmitAssetsLogMessages>
     </PropertyGroup>
   </Target>
 
-  <!--
-    ============================================================
-                                        UnsuppressAssetsLogMessages
-
-    Unsuppresses log messages from an existing project assets file.
-    ============================================================
-    -->
-  <Target Name="UnsuppressAssetsLogMessages">
+  <Target Name="_SdkBeforeRebuild">
     <PropertyGroup>
-      <UnsuppressAssetsLogMessages>true</UnsuppressAssetsLogMessages>
+      <_CleaningWithoutRebuilding>false</_CleaningWithoutRebuilding>
     </PropertyGroup>
   </Target>
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.PackageDependencyResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.PackageDependencyResolution.targets
@@ -126,7 +126,8 @@ Copyright (c) .NET Foundation. All rights reserved.
     </ResolvePackageDependenciesForBuildDependsOn>
   </PropertyGroup>
   <Target Name="ResolvePackageDependenciesForBuild"
-          Condition=" '$(DesignTimeBuild)' != 'true' Or Exists('$(ProjectAssetsFile)')"
+          Condition=" ('$(DesignTimeBuild)' != 'true' and '$(_CleaningWithoutRebuilding)' != 'true')
+                      Or Exists('$(ProjectAssetsFile)')"
           BeforeTargets="AssignProjectConfiguration"
           DependsOnTargets="$(ResolvePackageDependenciesForBuildDependsOn)" />
 

--- a/src/Tests/Microsoft.NET.Clean.Tests/GivenThatWeWantToCleanAProject.cs
+++ b/src/Tests/Microsoft.NET.Clean.Tests/GivenThatWeWantToCleanAProject.cs
@@ -61,8 +61,8 @@ namespace Microsoft.NET.Clean.Tests
                 .CopyTestAsset("HelloWorld")
                 .WithSource();
 
-            var lockFilePath = Path.Combine(testAsset.TestRoot, "obj", "project.assets.json");
-            File.Exists(lockFilePath).Should().BeFalse();
+            var assetsFilePath = Path.Combine(testAsset.TestRoot, "obj", "project.assets.json");
+            File.Exists(assetsFilePath).Should().BeFalse();
 
             var cleanCommand = new CleanCommand(Log, testAsset.TestRoot);
 
@@ -72,6 +72,8 @@ namespace Microsoft.NET.Clean.Tests
                 .Pass();
         }
 
+        // Related to https://github.com/dotnet/sdk/issues/2233
+        // This test will fail if the naive fix for not reading assets file during clean is attempted
         [Fact]
         public void It_can_clean_and_build_without_using_rebuild()
         {
@@ -80,10 +82,10 @@ namespace Microsoft.NET.Clean.Tests
               .WithSource()
               .Restore(Log);
 
-            var cleanAndBuildCommand = new CleanCommand(Log, testAsset.TestRoot);
+            var cleanAndBuildCommand = new MSBuildCommand(Log, "Clean;Build", testAsset.TestRoot);
 
             cleanAndBuildCommand
-                .Execute("/t:Build")
+                .Execute()
                 .Should()
                 .Pass();
         }

--- a/src/Tests/Microsoft.NET.Clean.Tests/GivenThatWeWantToCleanAProject.cs
+++ b/src/Tests/Microsoft.NET.Clean.Tests/GivenThatWeWantToCleanAProject.cs
@@ -53,5 +53,39 @@ namespace Microsoft.NET.Clean.Tests
                 .And
                 .NotHaveStdOutContaining("warning");
         }
+
+        [Fact]
+        public void It_cleans_without_assets_file_present()
+        {
+            var testAsset = _testAssetsManager
+                .CopyTestAsset("HelloWorld")
+                .WithSource();
+
+            var lockFilePath = Path.Combine(testAsset.TestRoot, "obj", "project.assets.json");
+            File.Exists(lockFilePath).Should().BeFalse();
+
+            var cleanCommand = new CleanCommand(Log, testAsset.TestRoot);
+
+            cleanCommand
+                .Execute()
+                .Should()
+                .Pass();
+        }
+
+        [Fact]
+        public void It_can_clean_and_build_without_using_rebuild()
+        {
+            var testAsset = _testAssetsManager
+              .CopyTestAsset("HelloWorld")
+              .WithSource()
+              .Restore(Log);
+
+            var cleanAndBuildCommand = new CleanCommand(Log, testAsset.TestRoot);
+
+            cleanAndBuildCommand
+                .Execute("/t:Build")
+                .Should()
+                .Pass();
+        }
     }
 }


### PR DESCRIPTION
## Issues fixed

#2226 

## Description of Issue

Running `dotnet clean` on a pristine working copy with no project.assets.json files present will fail.

Also impacts `msbuild /t:Clean` and Clean from VS with auto-restore disabled.

This regressed from preview 2 to RTM and was reported by a customer.

## Customer Impact

Can't clean without doing restore first, which is extremely unintuitive: why do I need to restore things in order to delete things?
Another workaround is to use `git clean` to obliterate everything instead of using the build target.

## Risk

Low

## Testing

Regression coverage added as a unit test

## Implementation notes

Ideally, we wouldn't read the assets file at all on Clean, but there are complications around rebuild with that, so it is tracked #2233 and not fixed here. A test is added that will fail if the naive fix for #2233. 

Instead, this change takes the conservative approach of reverting to the 2.1.300-preview2 (and all releases before that) behavior of having Clean only read the assets file when present.

I've also replaced the SuppressAssetsLogMessages and UnsuppressAssetsLogMessages with _SdkBeforeClean and _SdkBeforeRebuild for two reasons:

1. These have never shipped in an RTM release and I don't want them to be considered supported extensibility points. Hence the "_". In addressing #2233, we may find a better way to handle issues with cleaning.
2.  I didn't want to start a pattern of adding more target pairs every time something is wrong with clean.