### PR TITLE
Add references to platform assemblies that win compile conflict resolution

### DIFF
--- a/src/Tasks/Common/ConflictResolution/ConflictResolver.cs
+++ b/src/Tasks/Common/ConflictResolution/ConflictResolver.cs
@@ -11,6 +11,7 @@ using System.Linq;
 namespace Microsoft.NET.Build.Tasks.ConflictResolution
 {
     internal delegate void ConflictCallback<T>(T winner, T loser);
+
     //  The conflict resolver finds conflicting items, and if there are any of them it reports the "losing" item via the foundConflict callback
     internal class ConflictResolver<TConflictItem> where TConflictItem : class, IConflictItem
     {

--- a/src/Tasks/Common/ConflictResolution/ConflictResolver.cs
+++ b/src/Tasks/Common/ConflictResolution/ConflictResolver.cs
@@ -9,6 +9,7 @@ using System.Globalization;
 
 namespace Microsoft.NET.Build.Tasks.ConflictResolution
 {
+    internal delegate void ConflictCallback<T>(T winner, T loser);
     //  The conflict resolver finds conflicting items, and if there are any of them it reports the "losing" item via the foundConflict callback
     internal class ConflictResolver<TConflictItem> where TConflictItem : class, IConflictItem
     {
@@ -25,7 +26,7 @@ namespace Microsoft.NET.Build.Tasks.ConflictResolution
         }
 
         public void ResolveConflicts(IEnumerable<TConflictItem> conflictItems, Func<TConflictItem, string> getItemKey,
-            Action<TConflictItem> foundConflict, bool commitWinner = true,
+            ConflictCallback<TConflictItem> foundConflict, bool commitWinner = true,
             Action<TConflictItem> unresolvedConflict = null)
         {
             if (conflictItems == null)
@@ -76,7 +77,7 @@ namespace Microsoft.NET.Build.Tasks.ConflictResolution
 
                     }
 
-                    foundConflict(loser);
+                    foundConflict(winner, loser);
                 }
                 else if (commitWinner)
                 {

--- a/src/Tasks/Common/ConflictResolution/ConflictResolver.cs
+++ b/src/Tasks/Common/ConflictResolution/ConflictResolver.cs
@@ -36,7 +36,7 @@ namespace Microsoft.NET.Build.Tasks.ConflictResolution
                 return;
             }
 
-            Dictionary<string, List<TConflictItem>> unresolvedConflictItems = new Dictionary<string, List<TConflictItem>>();
+            var unresolvedConflictItems = new Dictionary<string, List<TConflictItem>>(StringComparer.Ordinal);
 
             foreach (var conflictItem in conflictItems)
             {

--- a/src/Tasks/Common/ConflictResolution/ResolvePackageFileConflicts.cs
+++ b/src/Tasks/Common/ConflictResolution/ResolvePackageFileConflicts.cs
@@ -158,28 +158,17 @@ namespace Microsoft.NET.Build.Tasks.ConflictResolution
         //  and return null if the result would be empty.
         private ITaskItem[] SafeConcat(ITaskItem[] first, IEnumerable<ITaskItem> second)
         {
-            if (first == null)
+            if (first == null || first.Length == 0)
             {
-                if (second == null || !second.Any())
-                {
-                    return null;
-                }
-                else
-                {
-                    return second.ToArray();
-                }
+                return second?.ToArray();
             }
-            else
+
+            if (second == null || !second.Any())
             {
-                if (second == null || !second.Any())
-                {
-                    return first;
-                }
-                else
-                {
-                    return first.Concat(second).ToArray();
-                }
+                return first;
             }
+
+            return first.Concat(second).ToArray();
         }
 
         private ITaskItem[] CreateConflictTaskItems(ICollection<ConflictItem> conflicts)

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAConflictResolver.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAConflictResolver.cs
@@ -216,6 +216,25 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             result.UnresolvedConflicts.Should().BeEmpty();
         }
 
+        [Theory]
+        [InlineData(new[] { 1, 1, 2}, 2)]
+        [InlineData(new[] { 1, 2, 1}, 1)]
+        [InlineData(new[] { 2, 1, 1}, 0)]
+        [InlineData(new[] { 1, 1, 2, 1, 2, 2, 3 }, 6)]
+        [InlineData(new[] { 1, 1, 2, 3, 1, 2, 2 }, 3)]
+        [InlineData(new[] { 3, 1, 1, 2, 1, 2, 2 }, 0)]
+
+        public void ItemsWithNoWinnerWillCountAsConflictsIfAnotherItemWins(int[] versions, int winnerIndex)
+        {
+            var items = versions.Select(v => new MockConflictItem() { FileVersion = new Version(v, 0, 0, 0) })
+                .ToArray();
+
+            var result = GetConflicts(items);
+
+            result.Conflicts.Should().BeEquivalentTo(items.Except(new[] { items[winnerIndex] }));
+            result.UnresolvedConflicts.Should().BeEmpty();
+        }
+
         [Fact]
         public void WhenItemsConflictAndBothArePlatformItemsTheConflictCannotBeResolved()
         {

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAConflictResolver.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAConflictResolver.cs
@@ -384,9 +384,9 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
         {
             ConflictResults ret = new ConflictResults();
 
-            void ConflictHandler(MockConflictItem item)
+            void ConflictHandler(MockConflictItem winner, MockConflictItem loser)
             {
-                ret.Conflicts.Add(item);
+                ret.Conflicts.Add(loser);
             }
 
             void UnresolvedConflictHandler(MockConflictItem item)

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAConflictResolver.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAConflictResolver.cs
@@ -35,7 +35,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             var result = GetConflicts(item1, item2);
 
             result.Conflicts.Should().BeEmpty();
-            result.UnresolvedConflicts.Should().Equal(item2);
+            result.UnresolvedConflicts.Should().Equal(item1, item2);
         }
 
         [Fact]
@@ -47,7 +47,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             var result = GetConflicts(item1, item2);
 
             result.Conflicts.Should().BeEmpty();
-            result.UnresolvedConflicts.Should().Equal(item2);
+            result.UnresolvedConflicts.Should().Equal(item1, item2);
         }
 
         
@@ -86,7 +86,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             var result = GetConflicts(item1, item2);
 
             result.Conflicts.Should().BeEmpty();
-            result.UnresolvedConflicts.Should().Equal(item2);
+            result.UnresolvedConflicts.Should().Equal(item1, item2);
         }
 
         [Fact]
@@ -137,7 +137,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             var result = GetConflicts(item1, item2);
 
             result.Conflicts.Should().BeEmpty();
-            result.UnresolvedConflicts.Should().Equal(item2);
+            result.UnresolvedConflicts.Should().Equal(item1, item2);
         }
 
         [Fact]
@@ -243,7 +243,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             var result = GetConflicts(item1, item2);
 
             result.Conflicts.Should().BeEmpty();
-            result.UnresolvedConflicts.Should().Equal(item2);
+            result.UnresolvedConflicts.Should().Equal(item1, item2);
         }
 
         [Fact]
@@ -255,7 +255,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             var result = GetConflicts(item1, item2);
 
             result.Conflicts.Should().BeEmpty();
-            result.UnresolvedConflicts.Should().Equal(item2);
+            result.UnresolvedConflicts.Should().Equal(item1, item2);
         }
 
         [Fact]
@@ -297,7 +297,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             var result = GetConflicts(new[] { committedItem }, uncommittedItem1, uncommittedItem2, uncommittedItem3);
 
             result.Conflicts.Should().BeEmpty();
-            result.UnresolvedConflicts.Should().Equal(uncommittedItem1, uncommittedItem2, uncommittedItem3);
+            result.UnresolvedConflicts.Should().Equal(committedItem, uncommittedItem1, uncommittedItem2, uncommittedItem3);
         }
 
         [Fact]

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAConflictResolver.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAConflictResolver.cs
@@ -223,7 +223,6 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
         [InlineData(new[] { 1, 1, 2, 1, 2, 2, 3 }, 6)]
         [InlineData(new[] { 1, 1, 2, 3, 1, 2, 2 }, 3)]
         [InlineData(new[] { 3, 1, 1, 2, 1, 2, 2 }, 0)]
-
         public void ItemsWithNoWinnerWillCountAsConflictsIfAnotherItemWins(int[] versions, int winnerIndex)
         {
             var items = versions.Select(v => new MockConflictItem() { FileVersion = new Version(v, 0, 0, 0) })

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAConflictResolver.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAConflictResolver.cs
@@ -421,14 +421,15 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
 
             var overrideResolver = new PackageOverrideResolver<MockConflictItem>(packageOverrides);
 
-            var resolver = new ConflictResolver<MockConflictItem>(new PackageRank(packagesForRank), overrideResolver, new MockLog());
+            using (var resolver = new ConflictResolver<MockConflictItem>(new PackageRank(packagesForRank), overrideResolver, new MockLog()))
+            {
+                resolver.UnresolvedConflictHandler = UnresolvedConflictHandler;
 
-            resolver.ResolveConflicts(itemsToCommit, GetItemKey, ConflictHandler,
-                unresolvedConflict: UnresolvedConflictHandler);
+                resolver.ResolveConflicts(itemsToCommit, GetItemKey, ConflictHandler);
 
-            resolver.ResolveConflicts(itemsNotToCommit, GetItemKey, ConflictHandler,
-                commitWinner: false,
-                unresolvedConflict: UnresolvedConflictHandler);
+                resolver.ResolveConflicts(itemsNotToCommit, GetItemKey, ConflictHandler,
+                    commitWinner: false);
+            }
 
             return ret;
         }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageAssets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageAssets.cs
@@ -732,7 +732,7 @@ namespace Microsoft.NET.Build.Tasks
                 //  and may improve perf.  If you really want to know all the packages
                 //  that brought in a framework assembly, you can look in the assets
                 //  file.
-                var writtenFrameworkAssemblies = new HashSet<string>();
+                var writtenFrameworkAssemblies = new HashSet<string>(StringComparer.Ordinal);
 
                 foreach (var library in _compileTimeTarget.Libraries)
                 {

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageAssets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageAssets.cs
@@ -724,6 +724,16 @@ namespace Microsoft.NET.Build.Tasks
                     return;
                 }
 
+                //  Keep track of Framework assemblies that we've already written items for,
+                //  in order to only create one item for each Framework assembly.
+                //  This means that if multiple packages have a dependency on the same
+                //  Framework assembly, we will no longer emit separate items for each one.
+                //  This should make the logs a lot cleaner and easier to understand,
+                //  and may improve perf.  If you really want to know all the packages
+                //  that brought in a framework assembly, you can look in the assets
+                //  file.
+                var writtenFrameworkAssemblies = new HashSet<string>();
+
                 foreach (var library in _compileTimeTarget.Libraries)
                 {
                     if (!library.IsPackage())
@@ -733,7 +743,10 @@ namespace Microsoft.NET.Build.Tasks
 
                     foreach (string frameworkAssembly in library.FrameworkAssemblies)
                     {
-                        WriteItem(frameworkAssembly, library);
+                        if (writtenFrameworkAssemblies.Add(frameworkAssembly))
+                        {
+                            WriteItem(frameworkAssembly, library);
+                        }
                     }
                 }
             }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.PackageDependencyResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.PackageDependencyResolution.targets
@@ -414,8 +414,12 @@ Copyright (c) .NET Foundation. All rights reserved.
       <Reference Include="@(ResolvedFrameworkAssemblies)" />
     </ItemGroup>
     
+    <!-- If there are any references from a NuGet package that match a simple reference which
+         would resolve to a framework assembly, then update the NuGet references to use the
+         simple name as the ItemSpec.  This will prevent the VS project system from marking
+         a reference with a warning.  See https://github.com/dotnet/sdk/issues/1499 -->
     <JoinItems Left="@(ResolvedCompileFileDefinitions)" LeftKey="FileName" LeftMetadata="*"
-               Right="@(Reference)" RightKey="" RightMetadata="*">
+               Right="@(Reference)" RightKey="" RightMetadata="">
       <Output TaskParameter="JoinResult" ItemName="_JoinedResolvedCompileFileDefinitions" />
     </JoinItems>
 

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildADesktopExe.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildADesktopExe.cs
@@ -496,12 +496,6 @@ namespace DefaultReferences
 
         void Test_inbox_assembly_wins_conflict_resolution(bool useSdkProject, string httpPackageVersion)
         {
-            //  https://github.com/dotnet/sdk/issues/1625
-            if (!ToolsetInfo.ReferenceAssembliesInstalled("v4.7.2"))
-            {
-                return;
-            }
-
             var testProject = new TestProject()
             {
                 Name = "DesktopInBoxConflictResolution",

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildADesktopExe.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildADesktopExe.cs
@@ -496,6 +496,12 @@ namespace DefaultReferences
 
         void Test_inbox_assembly_wins_conflict_resolution(bool useSdkProject, string httpPackageVersion)
         {
+            //  https://github.com/dotnet/sdk/issues/1625
+            if (!ToolsetInfo.ReferenceAssembliesInstalled("v4.7.2"))
+            {
+                return;
+            }
+
             var testProject = new TestProject()
             {
                 Name = "DesktopInBoxConflictResolution",

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildADesktopExe.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildADesktopExe.cs
@@ -486,7 +486,7 @@ namespace DefaultReferences
             Test_inbox_assembly_wins_conflict_resolution(false, httpPackageVersion);
         }
 
-        [Theory]
+        [WindowsOnlyTheory]
         [InlineData("4.3.3")]
         [InlineData("4.1.0")]
         public void It_builds_successfully_if_inbox_assembly_wins_conflict_resolution_sdk(string httpPackageVersion)

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToTargetNet471.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToTargetNet471.cs
@@ -44,11 +44,6 @@ namespace Microsoft.NET.Build.Tests
         [WindowsOnlyFact]
         public void It_builds_a_net471_app()
         {
-            //  https://github.com/dotnet/sdk/issues/1625
-            if (!Net471ReferenceAssembliesAreInstalled())
-            {
-                return;
-            }
             var testProject = new TestProject()
             {
                 Name = "Net471App",
@@ -81,11 +76,6 @@ namespace Microsoft.NET.Build.Tests
         [WindowsOnlyFact]
         public void It_builds_a_net471_app_referencing_netstandard20()
         {
-            //  https://github.com/dotnet/sdk/issues/1625
-            if (!Net471ReferenceAssembliesAreInstalled())
-            {
-                return;
-            }
             var testProject = new TestProject()
             {
                 Name = "Net471App_Referencing_NetStandard20",
@@ -130,11 +120,6 @@ namespace Microsoft.NET.Build.Tests
         [WindowsOnlyFact]
         public void It_does_not_include_facades_from_nuget_packages()
         {
-            //  https://github.com/dotnet/sdk/issues/1625
-            if (!Net471ReferenceAssembliesAreInstalled())
-            {
-                return;
-            }
             var testProject = new TestProject()
             {
                 Name = "Net471_NuGetFacades",
@@ -176,11 +161,6 @@ namespace Microsoft.NET.Build.Tests
         [WindowsOnlyFact]
         public void It_includes_shims_when_net471_app_references_netstandard16()
         {
-            //  https://github.com/dotnet/sdk/issues/1625
-            if (!Net471ReferenceAssembliesAreInstalled())
-            {
-                return;
-            }
             var testProject = new TestProject()
             {
                 Name = "Net471App_Referencing_NetStandard16",
@@ -226,11 +206,6 @@ namespace Microsoft.NET.Build.Tests
         [WindowsOnlyFact]
         public void It_does_not_include_shims_when_app_references_471_library_and_461_library()
         {
-            //  https://github.com/dotnet/sdk/issues/1625
-            if (!Net471ReferenceAssembliesAreInstalled())
-            {
-                return;
-            }
             var testProject = new TestProject()
             {
                 Name = "Net471App_Referencing_Net471Library",
@@ -284,11 +259,6 @@ namespace Microsoft.NET.Build.Tests
         [WindowsOnlyFact]
         public void It_contains_shims_if_override_property_is_set()
         {
-            //  https://github.com/dotnet/sdk/issues/1625
-            if (!Net471ReferenceAssembliesAreInstalled())
-            {
-                return;
-            }
             var testProject = new TestProject()
             {
                 Name = "Net471App",
@@ -319,11 +289,6 @@ namespace Microsoft.NET.Build.Tests
                 $"{testProject.Name}.pdb",
                 $"{testProject.Name}.exe.config", // We have now added binding redirects so we should expect a config flag to be dropped to the output directory.
             }.Concat(net471Shims));
-        }
-
-        static bool Net471ReferenceAssembliesAreInstalled()
-        {
-            return ToolsetInfo.ReferenceAssembliesInstalled("v4.7.1");
         }
     }
 }

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToTargetNet471.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToTargetNet471.cs
@@ -67,6 +67,7 @@ namespace Microsoft.NET.Build.Tests
                 .Should()
                 .Pass()
                 .And.NotHaveStdOutContaining("MSB3277") // MSB3277: Found conflicts between different versions of the same dependent assembly that could not be resolved.
+                .And.NotHaveStdOutContaining("MSB3243") // MSB3243: No way to resolve conflict between...
                 .And.NotHaveStdOutContaining("Could not determine");
 
             var outputDirectory = buildCommand.GetOutputDirectory(testProject.TargetFrameworks);
@@ -112,6 +113,7 @@ namespace Microsoft.NET.Build.Tests
                 .Should()
                 .Pass()
                 .And.NotHaveStdOutContaining("MSB3277") // MSB3277: Found conflicts between different versions of the same dependent assembly that could not be resolved.
+                .And.NotHaveStdOutContaining("MSB3243") // MSB3243: No way to resolve conflict between...
                 .And.NotHaveStdOutContaining("Could not determine");
 
             var outputDirectory = buildCommand.GetOutputDirectory(testProject.TargetFrameworks);
@@ -153,6 +155,7 @@ namespace Microsoft.NET.Build.Tests
                 .Should()
                 .Pass()
                 .And.NotHaveStdOutContaining("MSB3277") // MSB3277: Found conflicts between different versions of the same dependent assembly that could not be resolved.
+                .And.NotHaveStdOutContaining("MSB3243") // MSB3243: No way to resolve conflict between...
                 .And.NotHaveStdOutContaining("Could not determine");
 
             var outputDirectory = buildCommand.GetOutputDirectory(testProject.TargetFrameworks);
@@ -205,6 +208,7 @@ namespace Microsoft.NET.Build.Tests
                 .Should()
                 .Pass()
                 .And.NotHaveStdOutContaining("MSB3277") // MSB3277: Found conflicts between different versions of the same dependent assembly that could not be resolved.
+                .And.NotHaveStdOutContaining("MSB3243") // MSB3243: No way to resolve conflict between...
                 .And.NotHaveStdOutContaining("Could not determine");
 
             var outputDirectory = buildCommand.GetOutputDirectory(testProject.TargetFrameworks);
@@ -262,6 +266,7 @@ namespace Microsoft.NET.Build.Tests
                 .Should()
                 .Pass()
                 .And.NotHaveStdOutContaining("MSB3277") // MSB3277: Found conflicts between different versions of the same dependent assembly that could not be resolved.
+                .And.NotHaveStdOutContaining("MSB3243") // MSB3243: No way to resolve conflict between...
                 .And.NotHaveStdOutContaining("Could not determine");
 
             var outputDirectory = buildCommand.GetOutputDirectory(testProject.TargetFrameworks);
@@ -304,6 +309,7 @@ namespace Microsoft.NET.Build.Tests
                 .Should()
                 .Pass()
                 .And.NotHaveStdOutContaining("MSB3277") // MSB3277: Found conflicts between different versions of the same dependent assembly that could not be resolved.
+                .And.NotHaveStdOutContaining("MSB3243") // MSB3243: No way to resolve conflict between...
                 .And.NotHaveStdOutContaining("Could not determine");
 
             var outputDirectory = buildCommand.GetOutputDirectory(testProject.TargetFrameworks);

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToTargetNet471.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToTargetNet471.cs
@@ -323,16 +323,7 @@ namespace Microsoft.NET.Build.Tests
 
         static bool Net471ReferenceAssembliesAreInstalled()
         {
-            // The version of the MSBuild libraries we are referencing doesn't have an enum value for .NET 4.7.1. So we use the MSBuild API to find 
-            // the path to the 4.6.1 reference assemblies, and locate the 4.7.1 reference assemblies relative to that.
-            var net461referenceAssemblies = ToolLocationHelper.GetPathToDotNetFrameworkReferenceAssemblies(TargetDotNetFrameworkVersion.Version461);
-            if (net461referenceAssemblies == null)
-            {
-                //  4.6.1 reference assemblies not found, assume that 4.7.1 isn't available either
-                return false;
-            }
-            var net471referenceAssemblies = Path.Combine(new DirectoryInfo(net461referenceAssemblies).Parent.FullName, "v4.7.1");
-            return Directory.Exists(net471referenceAssemblies);
+            return ToolsetInfo.ReferenceAssembliesInstalled("v4.7.1");
         }
     }
 }

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToTargetNet471.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToTargetNet471.cs
@@ -41,7 +41,7 @@ namespace Microsoft.NET.Build.Tests
             "System.Xml.XPath.XDocument.dll"
         };
 
-        [Fact]
+        [WindowsOnlyFact]
         public void It_builds_a_net471_app()
         {
             //  https://github.com/dotnet/sdk/issues/1625
@@ -78,7 +78,7 @@ namespace Microsoft.NET.Build.Tests
             });
         }
 
-        [Fact]
+        [WindowsOnlyFact]
         public void It_builds_a_net471_app_referencing_netstandard20()
         {
             //  https://github.com/dotnet/sdk/issues/1625
@@ -127,7 +127,7 @@ namespace Microsoft.NET.Build.Tests
             }.Concat(net471Shims));
         }
 
-        [Fact]
+        [WindowsOnlyFact]
         public void It_does_not_include_facades_from_nuget_packages()
         {
             //  https://github.com/dotnet/sdk/issues/1625
@@ -173,7 +173,7 @@ namespace Microsoft.NET.Build.Tests
             });
         }
 
-        [Fact]
+        [WindowsOnlyFact]
         public void It_includes_shims_when_net471_app_references_netstandard16()
         {
             //  https://github.com/dotnet/sdk/issues/1625
@@ -223,7 +223,7 @@ namespace Microsoft.NET.Build.Tests
             }.Concat(net471Shims));
         }
 
-        [Fact]
+        [WindowsOnlyFact]
         public void It_does_not_include_shims_when_app_references_471_library_and_461_library()
         {
             //  https://github.com/dotnet/sdk/issues/1625
@@ -281,7 +281,7 @@ namespace Microsoft.NET.Build.Tests
             });
         }
 
-        [Fact]
+        [WindowsOnlyFact]
         public void It_contains_shims_if_override_property_is_set()
         {
             //  https://github.com/dotnet/sdk/issues/1625

--- a/src/Tests/Microsoft.NET.TestFramework/ToolsetInfo.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/ToolsetInfo.cs
@@ -8,6 +8,7 @@ using Microsoft.DotNet.Cli.Utils;
 using Microsoft.NET.TestFramework.Commands;
 using System.Xml.Linq;
 using System.Reflection;
+using Microsoft.Build.Utilities;
 
 namespace Microsoft.NET.TestFramework
 {
@@ -103,6 +104,21 @@ namespace Microsoft.NET.TestFramework
             TestContext.Current.AddTestEnvironmentVariables(ret);
 
             return ret;
+        }
+
+        public static bool ReferenceAssembliesInstalled(string version)
+        {
+            //  The version of the MSBuild libraries we are referencing doesn't have an enum value for the versions of .NET we want reference assemblies
+            //  for. So we use the MSBuild API to find the path to the 4.6.1 reference assemblies, and locate the
+            //  desired reference assemblies relative to that.
+            var net461referenceAssemblies = ToolLocationHelper.GetPathToDotNetFrameworkReferenceAssemblies(TargetDotNetFrameworkVersion.Version461);
+            if (net461referenceAssemblies == null)
+            {
+                //  4.6.1 reference assemblies not found, assume that the ones we want aren't available either
+                return false;
+            }
+            var requestedReferenceAssemblies = Path.Combine(new DirectoryInfo(net461referenceAssemblies).Parent.FullName, version);
+            return Directory.Exists(requestedReferenceAssemblies);
         }
 
         public static ToolsetInfo Create(string repoRoot, string repoArtifactsDir, string configuration, TestCommandLine commandLine)

--- a/src/Tests/Microsoft.NET.TestFramework/ToolsetInfo.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/ToolsetInfo.cs
@@ -105,23 +105,6 @@ namespace Microsoft.NET.TestFramework
 
             return ret;
         }
-
-        public static bool ReferenceAssembliesInstalled(string version)
-        {
-            return true;
-            ////  The version of the MSBuild libraries we are referencing doesn't have an enum value for the versions of .NET we want reference assemblies
-            ////  for. So we use the MSBuild API to find the path to the 4.6.1 reference assemblies, and locate the
-            ////  desired reference assemblies relative to that.
-            //var net461referenceAssemblies = ToolLocationHelper.GetPathToDotNetFrameworkReferenceAssemblies(TargetDotNetFrameworkVersion.Version461);
-            //if (net461referenceAssemblies == null)
-            //{
-            //    //  4.6.1 reference assemblies not found, assume that the ones we want aren't available either
-            //    return false;
-            //}
-            //var requestedReferenceAssemblies = Path.Combine(new DirectoryInfo(net461referenceAssemblies).Parent.FullName, version);
-            //return Directory.Exists(requestedReferenceAssemblies);
-        }
-
         public static ToolsetInfo Create(string repoRoot, string repoArtifactsDir, string configuration, TestCommandLine commandLine)
         {
             var ret = new ToolsetInfo();

--- a/src/Tests/Microsoft.NET.TestFramework/ToolsetInfo.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/ToolsetInfo.cs
@@ -108,17 +108,18 @@ namespace Microsoft.NET.TestFramework
 
         public static bool ReferenceAssembliesInstalled(string version)
         {
-            //  The version of the MSBuild libraries we are referencing doesn't have an enum value for the versions of .NET we want reference assemblies
-            //  for. So we use the MSBuild API to find the path to the 4.6.1 reference assemblies, and locate the
-            //  desired reference assemblies relative to that.
-            var net461referenceAssemblies = ToolLocationHelper.GetPathToDotNetFrameworkReferenceAssemblies(TargetDotNetFrameworkVersion.Version461);
-            if (net461referenceAssemblies == null)
-            {
-                //  4.6.1 reference assemblies not found, assume that the ones we want aren't available either
-                return false;
-            }
-            var requestedReferenceAssemblies = Path.Combine(new DirectoryInfo(net461referenceAssemblies).Parent.FullName, version);
-            return Directory.Exists(requestedReferenceAssemblies);
+            return true;
+            ////  The version of the MSBuild libraries we are referencing doesn't have an enum value for the versions of .NET we want reference assemblies
+            ////  for. So we use the MSBuild API to find the path to the 4.6.1 reference assemblies, and locate the
+            ////  desired reference assemblies relative to that.
+            //var net461referenceAssemblies = ToolLocationHelper.GetPathToDotNetFrameworkReferenceAssemblies(TargetDotNetFrameworkVersion.Version461);
+            //if (net461referenceAssemblies == null)
+            //{
+            //    //  4.6.1 reference assemblies not found, assume that the ones we want aren't available either
+            //    return false;
+            //}
+            //var requestedReferenceAssemblies = Path.Combine(new DirectoryInfo(net461referenceAssemblies).Parent.FullName, version);
+            //return Directory.Exists(requestedReferenceAssemblies);
         }
 
         public static ToolsetInfo Create(string repoRoot, string repoArtifactsDir, string configuration, TestCommandLine commandLine)


### PR DESCRIPTION
Fixes #2221

The issue is caused because before conflict resolution runs, references to assemblies in the framework that also match an assembly coming from a NuGet package are either removed (in non-SDK targets via the `ResolveNuGetPackageAssets` target in Microsoft.NuGet.targets) or transformed to refer to the assembly coming from the NuGet package (for SDK projects in the `ResolveLockFileReferences` task).

In either case, there ends up being no Reference item which will resolve to the DLL in the reference assemblies.  This is a problem if the platform item from the reference assemblies wins a conflict in the compile scope (which appears to be happening for the first time with .NET 4.7.2), as the reference to the assembly from the NuGet package will be removed, but there will be no reference to the Framework assembly passed to the compiler.

So what this PR does is keep track of Platform items that win conflicts with Reference items in the compile scope, and explicitly add references to them in the `ResolvePackageFileConflicts` task.

A possible alternative solution would be:

- Modify the targets that are removing / transforming the simple references that match references from NuGet packages to not do so.  Instead let all of the references flow into `ResolvePackageFileConflicts`.
- Update `ResolvePackageFileConflicts` to be able to resolve the simple name references as platform assemblies and correctly handle the conflict resolution

I didn't choose this solution because:

- `ResolvePackageFileConflicts` would end up duplicating logic from `ResolveAssemblyReference` - namely taking a simple reference and resolving it to a platform assembly
- This would require changes in more places and more repos (ie Microsoft.NuGet.targets [in the NuGet.BuildTasks repo](https://github.com/NuGet/NuGet.BuildTasks/blob/dev/src/Microsoft.NuGet.Build.Tasks/Microsoft.NuGet.targets))
- Projects with a reference to the `System.Net.Http` package but not a simple name `Reference` item would fail to build after they retargeted to .NET 4.7.2 (they would need to add `<Reference Include="System.Net.Http" />` to the project file)

I expect the tests to fail on this currently, as the CI machines don't have the reference assemblies for .NET 4.7.2.  I've filed https://github.com/dotnet/core-eng/issues/3500 to create / update the images with this targeting pack.

@ericstj @nguerrera @joperezr @AlexGhiondea