### PR TITLE
Add PowerShell script to install and run SDK tests as global tools, and fix test in that context

### DIFF
--- a/build/sdktests.ps1
+++ b/build/sdktests.ps1
@@ -1,0 +1,56 @@
+[CmdletBinding(PositionalBinding=$false)]
+Param(
+    [switch] $install,
+    [switch] $uninstall,
+    [switch] $run,
+    [string] $packageVersion = "",
+    [string] $tests = "",
+    [Parameter(ValueFromRemainingArguments=$true)][String[]]$additionalRunParams
+)
+
+Set-StrictMode -Version 2.0
+$ErrorActionPreference = "Stop"
+
+$lkgPackageVersion = "1.0.0-preview-62916-01"
+
+if ($packageVersion -eq "")
+{
+    $packageVersion = $lkgPackageVersion
+}
+
+$testNames = @()
+
+if ($tests -eq "")
+{
+    $testNames = "Build", "Clean", "Pack", "Perf", "Publish", "Rebuild", "Restore", "ToolPack"
+}
+else
+{
+    $testNames = $tests.split(",")
+}
+
+if ($uninstall)
+{
+    foreach ( $name in $testNames )
+    {
+        dotnet tool uninstall -g "testSdk$name"
+    }
+}
+
+if ($install)
+{
+    foreach ( $name in $testNames )
+    {
+        dotnet tool install -g "testSdk$name" --version $packageVersion --add-source https://dotnet.myget.org/F/dotnet-cli/api/v3/index.json
+    }
+}
+
+if ($run)
+{
+    foreach ( $name in $testNames )
+    {
+        $cmd = "testSdk$name"
+        
+        & $cmd -xml ($name + "results.xml") $additionalRunParams
+    }
+}

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToGenerateADepsFileForATool.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToGenerateADepsFileForATool.cs
@@ -141,7 +141,30 @@ class Program
 
             var args = new List<string>();
 
-            string generateDepsProjectDirectoryPath = Path.Combine(TestContext.Current.ToolsetUnderTest.SdksPath, "Microsoft.NET.Sdk", "targets", "GenerateDeps");
+
+            string currentToolsetSdksPath;
+            if (TestContext.Current.ToolsetUnderTest.SdksPath == null)
+            {
+                //  We don't have an overridden path to the SDKs, so figure out which version of the SDK we're using and
+                //  calculate the path based on that
+                var command = new DotnetCommand(Log, "--version");
+                var testDirectory = TestDirectory.Create(Path.Combine(TestContext.Current.TestExecutionDirectory, "sdkversion"));
+
+                command.WorkingDirectory = testDirectory.Path;
+
+                var result = command.Execute();
+
+                result.Should().Pass();
+
+                var sdkVersion = result.StdOut.Trim();
+                string dotnetDir = Path.GetDirectoryName(TestContext.Current.ToolsetUnderTest.DotNetHostPath);
+                currentToolsetSdksPath = Path.Combine(dotnetDir, "sdk", sdkVersion, "Sdks");
+            }
+            else
+            {
+                currentToolsetSdksPath = TestContext.Current.ToolsetUnderTest.SdksPath;
+            }
+            string generateDepsProjectDirectoryPath = Path.Combine(currentToolsetSdksPath, "Microsoft.NET.Sdk", "targets", "GenerateDeps");
             string generateDepsProjectFileName = "GenerateDeps.proj";
 
             args.Add($"/p:ProjectAssetsFile=\"{toolAssetsFilePath}\"");


### PR DESCRIPTION
- Add PowerShell script to install and run SDK tests as global tools
- Fix GivenThatWeWantToGenerateADepsFileForATool tests when run with no repo inference (for example when tests are run as a global tool)