### PR TITLE
Fix a few tests that didn't work when run as global tools

### DIFF
--- a/build/sdktests.ps1
+++ b/build/sdktests.ps1
@@ -11,7 +11,7 @@ Param(
 Set-StrictMode -Version 2.0
 $ErrorActionPreference = "Stop"
 
-$lkgPackageVersion = "1.0.0-preview-62916-01"
+$lkgPackageVersion = "1.0.0-preview-62918-03"
 
 if ($packageVersion -eq "")
 {

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildADesktopLibrary.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildADesktopLibrary.cs
@@ -365,7 +365,8 @@ public static class {project.Name}
             string correctHttpReference;
             if (useFacades)
             {
-                correctHttpReference = Path.Combine(TestContext.Current.ToolsetUnderTest.BuildExtensionsMSBuildPath, @"net461\lib\System.Net.Http.dll");
+                string microsoftNETBuildExtensionsPath = TestContext.Current.ToolsetUnderTest.GetMicrosoftNETBuildExtensionsPath(Log);
+                correctHttpReference = Path.Combine(microsoftNETBuildExtensionsPath, @"net461\lib\System.Net.Http.dll");
             }
             else
             {

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToGenerateADepsFileForATool.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToGenerateADepsFileForATool.cs
@@ -147,18 +147,8 @@ class Program
             {
                 //  We don't have an overridden path to the SDKs, so figure out which version of the SDK we're using and
                 //  calculate the path based on that
-                var command = new DotnetCommand(Log, "--version");
-                var testDirectory = TestDirectory.Create(Path.Combine(TestContext.Current.TestExecutionDirectory, "sdkversion"));
-
-                command.WorkingDirectory = testDirectory.Path;
-
-                var result = command.Execute();
-
-                result.Should().Pass();
-
-                var sdkVersion = result.StdOut.Trim();
-                string dotnetDir = Path.GetDirectoryName(TestContext.Current.ToolsetUnderTest.DotNetHostPath);
-                currentToolsetSdksPath = Path.Combine(dotnetDir, "sdk", sdkVersion, "Sdks");
+                string dotnetSdkDir = TestContext.Current.ToolsetUnderTest.GetDotnetSdkDir(Log);
+                currentToolsetSdksPath = Path.Combine(dotnetSdkDir, "Sdks");
             }
             else
             {


### PR DESCRIPTION
- Fix some toolset paths to work correctly when the SDKs / Microsoft.NET.Build.Extensions paths haven't been overridden
- Update a test that simulated .NET 4.7.1 with a target (because 4.7.1 wasn't available when it was written) to actually target .NET 4.7.1