### PR TITLE
Implement framework-dependent application with apphost.

### DIFF
--- a/src/Tasks/Common/Resources/Strings.resx
+++ b/src/Tasks/Common/Resources/Strings.resx
@@ -382,7 +382,7 @@ The following are names of parameters or literal values and should not be transl
     <comment>{StrBegin="NETSDK1065: "}</comment>
   </data>
   <data name="CannotUseAppHostWithoutRuntimeIdentifier" xml:space="preserve">
-    <value>NETSDK1066: The application host cannot be used without specifying a RuntimeIdentifier. Either specify a RuntimeIdentifier or set UseAppHost to false.</value>
+    <value>NETSDK1066: A RuntimeIdentifier must be specified to publish a framework-dependent application with an application host.</value>
     <comment>{StrBegin="NETSDK1066: "}</comment>
   </data>
   <data name="CannotUseSelfContainedWithoutAppHost" xml:space="preserve">

--- a/src/Tasks/Common/Resources/Strings.resx
+++ b/src/Tasks/Common/Resources/Strings.resx
@@ -381,4 +381,16 @@ The following are names of parameters or literal values and should not be transl
     <value>NETSDK1065: Cannot find app host for {0}. {0} could be an invalid runtime identifier (RID). For more information about RID, see https://aka.ms/rid-catalog.</value>
     <comment>{StrBegin="NETSDK1065: "}</comment>
   </data>
+  <data name="CannotUseAppHostWithoutRuntimeIdentifier" xml:space="preserve">
+    <value>NETSDK1066: The application host cannot be used without specifying a RuntimeIdentifier. Either specify a RuntimeIdentifier or set UseAppHost to false.</value>
+    <comment>{StrBegin="NETSDK1066: "}</comment>
+  </data>
+  <data name="CannotUseSelfContainedWithoutAppHost" xml:space="preserve">
+    <value>NETSDK1067: Self-contained applications are required to use the application host. Either set SelfContained to false or set UseAppHost to true.</value>
+    <comment>{StrBegin="NETSDK1067: "}</comment>
+  </data>
+  <data name="FrameworkDependentAppHostRequiresVersion21" xml:space="preserve">
+    <value>NETSDK1068: The framework-dependent application host requires a target framework of at least 'netcoreapp2.1'.</value>
+    <comment>{StrBegin="NETSDK1068: "}</comment>
+  </data>
 </root>

--- a/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
@@ -8,8 +8,8 @@
         <note>{StrBegin="NETSDK1001: "}</note>
       </trans-unit>
       <trans-unit id="CannotUseAppHostWithoutRuntimeIdentifier">
-        <source>NETSDK1066: The application host cannot be used without specifying a RuntimeIdentifier. Either specify a RuntimeIdentifier or set UseAppHost to false.</source>
-        <target state="new">NETSDK1066: The application host cannot be used without specifying a RuntimeIdentifier. Either specify a RuntimeIdentifier or set UseAppHost to false.</target>
+        <source>NETSDK1066: A RuntimeIdentifier must be specified to publish a framework-dependent application with an application host.</source>
+        <target state="new">NETSDK1066: A RuntimeIdentifier must be specified to publish a framework-dependent application with an application host.</target>
         <note>{StrBegin="NETSDK1066: "}</note>
       </trans-unit>
       <trans-unit id="CannotUseSelfContainedWithoutAppHost">

--- a/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
@@ -7,6 +7,21 @@
         <target state="needs-review-translation">Je potřeba zadat alespoň jednu možnou cílovou platformu</target>
         <note>{StrBegin="NETSDK1001: "}</note>
       </trans-unit>
+      <trans-unit id="CannotUseAppHostWithoutRuntimeIdentifier">
+        <source>NETSDK1066: The application host cannot be used without specifying a RuntimeIdentifier. Either specify a RuntimeIdentifier or set UseAppHost to false.</source>
+        <target state="new">NETSDK1066: The application host cannot be used without specifying a RuntimeIdentifier. Either specify a RuntimeIdentifier or set UseAppHost to false.</target>
+        <note>{StrBegin="NETSDK1066: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotUseSelfContainedWithoutAppHost">
+        <source>NETSDK1067: Self-contained applications are required to use the application host. Either set SelfContained to false or set UseAppHost to true.</source>
+        <target state="new">NETSDK1067: Self-contained applications are required to use the application host. Either set SelfContained to false or set UseAppHost to true.</target>
+        <note>{StrBegin="NETSDK1067: "}</note>
+      </trans-unit>
+      <trans-unit id="FrameworkDependentAppHostRequiresVersion21">
+        <source>NETSDK1068: The framework-dependent application host requires a target framework of at least 'netcoreapp2.1'.</source>
+        <target state="new">NETSDK1068: The framework-dependent application host requires a target framework of at least 'netcoreapp2.1'.</target>
+        <note>{StrBegin="NETSDK1068: "}</note>
+      </trans-unit>
       <trans-unit id="NoCompatibleTargetFramework">
         <source>NETSDK1002: Project '{0}' targets '{2}'. It cannot be referenced by a project that targets '{1}'.</source>
         <target state="needs-review-translation">Cílem projektu {0} je {2}. Nemůže na něj odkazovat projekt, jehož cílem je {1}.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.de.xlf
@@ -8,8 +8,8 @@
         <note>{StrBegin="NETSDK1001: "}</note>
       </trans-unit>
       <trans-unit id="CannotUseAppHostWithoutRuntimeIdentifier">
-        <source>NETSDK1066: The application host cannot be used without specifying a RuntimeIdentifier. Either specify a RuntimeIdentifier or set UseAppHost to false.</source>
-        <target state="new">NETSDK1066: The application host cannot be used without specifying a RuntimeIdentifier. Either specify a RuntimeIdentifier or set UseAppHost to false.</target>
+        <source>NETSDK1066: A RuntimeIdentifier must be specified to publish a framework-dependent application with an application host.</source>
+        <target state="new">NETSDK1066: A RuntimeIdentifier must be specified to publish a framework-dependent application with an application host.</target>
         <note>{StrBegin="NETSDK1066: "}</note>
       </trans-unit>
       <trans-unit id="CannotUseSelfContainedWithoutAppHost">

--- a/src/Tasks/Common/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.de.xlf
@@ -7,6 +7,21 @@
         <target state="needs-review-translation">Geben Sie mindestens ein mögliches Zielframework an.</target>
         <note>{StrBegin="NETSDK1001: "}</note>
       </trans-unit>
+      <trans-unit id="CannotUseAppHostWithoutRuntimeIdentifier">
+        <source>NETSDK1066: The application host cannot be used without specifying a RuntimeIdentifier. Either specify a RuntimeIdentifier or set UseAppHost to false.</source>
+        <target state="new">NETSDK1066: The application host cannot be used without specifying a RuntimeIdentifier. Either specify a RuntimeIdentifier or set UseAppHost to false.</target>
+        <note>{StrBegin="NETSDK1066: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotUseSelfContainedWithoutAppHost">
+        <source>NETSDK1067: Self-contained applications are required to use the application host. Either set SelfContained to false or set UseAppHost to true.</source>
+        <target state="new">NETSDK1067: Self-contained applications are required to use the application host. Either set SelfContained to false or set UseAppHost to true.</target>
+        <note>{StrBegin="NETSDK1067: "}</note>
+      </trans-unit>
+      <trans-unit id="FrameworkDependentAppHostRequiresVersion21">
+        <source>NETSDK1068: The framework-dependent application host requires a target framework of at least 'netcoreapp2.1'.</source>
+        <target state="new">NETSDK1068: The framework-dependent application host requires a target framework of at least 'netcoreapp2.1'.</target>
+        <note>{StrBegin="NETSDK1068: "}</note>
+      </trans-unit>
       <trans-unit id="NoCompatibleTargetFramework">
         <source>NETSDK1002: Project '{0}' targets '{2}'. It cannot be referenced by a project that targets '{1}'.</source>
         <target state="needs-review-translation">Das Projekt "{0}" hat das Ziel "{2}". Ein Verweis von einem Projekt mit dem Ziel "{1}" ist nicht möglich.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.es.xlf
@@ -8,8 +8,8 @@
         <note>{StrBegin="NETSDK1001: "}</note>
       </trans-unit>
       <trans-unit id="CannotUseAppHostWithoutRuntimeIdentifier">
-        <source>NETSDK1066: The application host cannot be used without specifying a RuntimeIdentifier. Either specify a RuntimeIdentifier or set UseAppHost to false.</source>
-        <target state="new">NETSDK1066: The application host cannot be used without specifying a RuntimeIdentifier. Either specify a RuntimeIdentifier or set UseAppHost to false.</target>
+        <source>NETSDK1066: A RuntimeIdentifier must be specified to publish a framework-dependent application with an application host.</source>
+        <target state="new">NETSDK1066: A RuntimeIdentifier must be specified to publish a framework-dependent application with an application host.</target>
         <note>{StrBegin="NETSDK1066: "}</note>
       </trans-unit>
       <trans-unit id="CannotUseSelfContainedWithoutAppHost">

--- a/src/Tasks/Common/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.es.xlf
@@ -7,6 +7,21 @@
         <target state="needs-review-translation">Debe especificarse al menos una plataforma de destino posible.</target>
         <note>{StrBegin="NETSDK1001: "}</note>
       </trans-unit>
+      <trans-unit id="CannotUseAppHostWithoutRuntimeIdentifier">
+        <source>NETSDK1066: The application host cannot be used without specifying a RuntimeIdentifier. Either specify a RuntimeIdentifier or set UseAppHost to false.</source>
+        <target state="new">NETSDK1066: The application host cannot be used without specifying a RuntimeIdentifier. Either specify a RuntimeIdentifier or set UseAppHost to false.</target>
+        <note>{StrBegin="NETSDK1066: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotUseSelfContainedWithoutAppHost">
+        <source>NETSDK1067: Self-contained applications are required to use the application host. Either set SelfContained to false or set UseAppHost to true.</source>
+        <target state="new">NETSDK1067: Self-contained applications are required to use the application host. Either set SelfContained to false or set UseAppHost to true.</target>
+        <note>{StrBegin="NETSDK1067: "}</note>
+      </trans-unit>
+      <trans-unit id="FrameworkDependentAppHostRequiresVersion21">
+        <source>NETSDK1068: The framework-dependent application host requires a target framework of at least 'netcoreapp2.1'.</source>
+        <target state="new">NETSDK1068: The framework-dependent application host requires a target framework of at least 'netcoreapp2.1'.</target>
+        <note>{StrBegin="NETSDK1068: "}</note>
+      </trans-unit>
       <trans-unit id="NoCompatibleTargetFramework">
         <source>NETSDK1002: Project '{0}' targets '{2}'. It cannot be referenced by a project that targets '{1}'.</source>
         <target state="needs-review-translation">El proyecto "{0}" tiene como destino "{2}". No se puede hacer referencia a él mediante un proyecto que tenga como destino "{1}".</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
@@ -7,6 +7,21 @@
         <target state="needs-review-translation">Au moins un framework cible doit être spécifié.</target>
         <note>{StrBegin="NETSDK1001: "}</note>
       </trans-unit>
+      <trans-unit id="CannotUseAppHostWithoutRuntimeIdentifier">
+        <source>NETSDK1066: The application host cannot be used without specifying a RuntimeIdentifier. Either specify a RuntimeIdentifier or set UseAppHost to false.</source>
+        <target state="new">NETSDK1066: The application host cannot be used without specifying a RuntimeIdentifier. Either specify a RuntimeIdentifier or set UseAppHost to false.</target>
+        <note>{StrBegin="NETSDK1066: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotUseSelfContainedWithoutAppHost">
+        <source>NETSDK1067: Self-contained applications are required to use the application host. Either set SelfContained to false or set UseAppHost to true.</source>
+        <target state="new">NETSDK1067: Self-contained applications are required to use the application host. Either set SelfContained to false or set UseAppHost to true.</target>
+        <note>{StrBegin="NETSDK1067: "}</note>
+      </trans-unit>
+      <trans-unit id="FrameworkDependentAppHostRequiresVersion21">
+        <source>NETSDK1068: The framework-dependent application host requires a target framework of at least 'netcoreapp2.1'.</source>
+        <target state="new">NETSDK1068: The framework-dependent application host requires a target framework of at least 'netcoreapp2.1'.</target>
+        <note>{StrBegin="NETSDK1068: "}</note>
+      </trans-unit>
       <trans-unit id="NoCompatibleTargetFramework">
         <source>NETSDK1002: Project '{0}' targets '{2}'. It cannot be referenced by a project that targets '{1}'.</source>
         <target state="needs-review-translation">Le projet '{0}' cible '{2}'. Il ne peut pas être référencé par un projet qui cible '{1}'.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
@@ -8,8 +8,8 @@
         <note>{StrBegin="NETSDK1001: "}</note>
       </trans-unit>
       <trans-unit id="CannotUseAppHostWithoutRuntimeIdentifier">
-        <source>NETSDK1066: The application host cannot be used without specifying a RuntimeIdentifier. Either specify a RuntimeIdentifier or set UseAppHost to false.</source>
-        <target state="new">NETSDK1066: The application host cannot be used without specifying a RuntimeIdentifier. Either specify a RuntimeIdentifier or set UseAppHost to false.</target>
+        <source>NETSDK1066: A RuntimeIdentifier must be specified to publish a framework-dependent application with an application host.</source>
+        <target state="new">NETSDK1066: A RuntimeIdentifier must be specified to publish a framework-dependent application with an application host.</target>
         <note>{StrBegin="NETSDK1066: "}</note>
       </trans-unit>
       <trans-unit id="CannotUseSelfContainedWithoutAppHost">

--- a/src/Tasks/Common/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.it.xlf
@@ -8,8 +8,8 @@
         <note>{StrBegin="NETSDK1001: "}</note>
       </trans-unit>
       <trans-unit id="CannotUseAppHostWithoutRuntimeIdentifier">
-        <source>NETSDK1066: The application host cannot be used without specifying a RuntimeIdentifier. Either specify a RuntimeIdentifier or set UseAppHost to false.</source>
-        <target state="new">NETSDK1066: The application host cannot be used without specifying a RuntimeIdentifier. Either specify a RuntimeIdentifier or set UseAppHost to false.</target>
+        <source>NETSDK1066: A RuntimeIdentifier must be specified to publish a framework-dependent application with an application host.</source>
+        <target state="new">NETSDK1066: A RuntimeIdentifier must be specified to publish a framework-dependent application with an application host.</target>
         <note>{StrBegin="NETSDK1066: "}</note>
       </trans-unit>
       <trans-unit id="CannotUseSelfContainedWithoutAppHost">

--- a/src/Tasks/Common/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.it.xlf
@@ -7,6 +7,21 @@
         <target state="needs-review-translation">È necessario specificare almeno un framework di destinazione possibile.</target>
         <note>{StrBegin="NETSDK1001: "}</note>
       </trans-unit>
+      <trans-unit id="CannotUseAppHostWithoutRuntimeIdentifier">
+        <source>NETSDK1066: The application host cannot be used without specifying a RuntimeIdentifier. Either specify a RuntimeIdentifier or set UseAppHost to false.</source>
+        <target state="new">NETSDK1066: The application host cannot be used without specifying a RuntimeIdentifier. Either specify a RuntimeIdentifier or set UseAppHost to false.</target>
+        <note>{StrBegin="NETSDK1066: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotUseSelfContainedWithoutAppHost">
+        <source>NETSDK1067: Self-contained applications are required to use the application host. Either set SelfContained to false or set UseAppHost to true.</source>
+        <target state="new">NETSDK1067: Self-contained applications are required to use the application host. Either set SelfContained to false or set UseAppHost to true.</target>
+        <note>{StrBegin="NETSDK1067: "}</note>
+      </trans-unit>
+      <trans-unit id="FrameworkDependentAppHostRequiresVersion21">
+        <source>NETSDK1068: The framework-dependent application host requires a target framework of at least 'netcoreapp2.1'.</source>
+        <target state="new">NETSDK1068: The framework-dependent application host requires a target framework of at least 'netcoreapp2.1'.</target>
+        <note>{StrBegin="NETSDK1068: "}</note>
+      </trans-unit>
       <trans-unit id="NoCompatibleTargetFramework">
         <source>NETSDK1002: Project '{0}' targets '{2}'. It cannot be referenced by a project that targets '{1}'.</source>
         <target state="needs-review-translation">Il progetto '{0}' è destinato a '{2}'. Non può essere usato come riferimento in un progetto destinato a '{1}'.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
@@ -7,6 +7,21 @@
         <target state="needs-review-translation">可能性のあるターゲット フレームワークを少なくとも 1 つ指定する必要があります。</target>
         <note>{StrBegin="NETSDK1001: "}</note>
       </trans-unit>
+      <trans-unit id="CannotUseAppHostWithoutRuntimeIdentifier">
+        <source>NETSDK1066: The application host cannot be used without specifying a RuntimeIdentifier. Either specify a RuntimeIdentifier or set UseAppHost to false.</source>
+        <target state="new">NETSDK1066: The application host cannot be used without specifying a RuntimeIdentifier. Either specify a RuntimeIdentifier or set UseAppHost to false.</target>
+        <note>{StrBegin="NETSDK1066: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotUseSelfContainedWithoutAppHost">
+        <source>NETSDK1067: Self-contained applications are required to use the application host. Either set SelfContained to false or set UseAppHost to true.</source>
+        <target state="new">NETSDK1067: Self-contained applications are required to use the application host. Either set SelfContained to false or set UseAppHost to true.</target>
+        <note>{StrBegin="NETSDK1067: "}</note>
+      </trans-unit>
+      <trans-unit id="FrameworkDependentAppHostRequiresVersion21">
+        <source>NETSDK1068: The framework-dependent application host requires a target framework of at least 'netcoreapp2.1'.</source>
+        <target state="new">NETSDK1068: The framework-dependent application host requires a target framework of at least 'netcoreapp2.1'.</target>
+        <note>{StrBegin="NETSDK1068: "}</note>
+      </trans-unit>
       <trans-unit id="NoCompatibleTargetFramework">
         <source>NETSDK1002: Project '{0}' targets '{2}'. It cannot be referenced by a project that targets '{1}'.</source>
         <target state="needs-review-translation">プロジェクト '{0}' は、'{2}' を対象としています。'{1}' を対象とするプロジェクトは、これを参照できません。</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
@@ -8,8 +8,8 @@
         <note>{StrBegin="NETSDK1001: "}</note>
       </trans-unit>
       <trans-unit id="CannotUseAppHostWithoutRuntimeIdentifier">
-        <source>NETSDK1066: The application host cannot be used without specifying a RuntimeIdentifier. Either specify a RuntimeIdentifier or set UseAppHost to false.</source>
-        <target state="new">NETSDK1066: The application host cannot be used without specifying a RuntimeIdentifier. Either specify a RuntimeIdentifier or set UseAppHost to false.</target>
+        <source>NETSDK1066: A RuntimeIdentifier must be specified to publish a framework-dependent application with an application host.</source>
+        <target state="new">NETSDK1066: A RuntimeIdentifier must be specified to publish a framework-dependent application with an application host.</target>
         <note>{StrBegin="NETSDK1066: "}</note>
       </trans-unit>
       <trans-unit id="CannotUseSelfContainedWithoutAppHost">

--- a/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
@@ -8,8 +8,8 @@
         <note>{StrBegin="NETSDK1001: "}</note>
       </trans-unit>
       <trans-unit id="CannotUseAppHostWithoutRuntimeIdentifier">
-        <source>NETSDK1066: The application host cannot be used without specifying a RuntimeIdentifier. Either specify a RuntimeIdentifier or set UseAppHost to false.</source>
-        <target state="new">NETSDK1066: The application host cannot be used without specifying a RuntimeIdentifier. Either specify a RuntimeIdentifier or set UseAppHost to false.</target>
+        <source>NETSDK1066: A RuntimeIdentifier must be specified to publish a framework-dependent application with an application host.</source>
+        <target state="new">NETSDK1066: A RuntimeIdentifier must be specified to publish a framework-dependent application with an application host.</target>
         <note>{StrBegin="NETSDK1066: "}</note>
       </trans-unit>
       <trans-unit id="CannotUseSelfContainedWithoutAppHost">

--- a/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
@@ -7,6 +7,21 @@
         <target state="needs-review-translation">가능한 대상 프레임워크를 하나 이상 지정해야 합니다.</target>
         <note>{StrBegin="NETSDK1001: "}</note>
       </trans-unit>
+      <trans-unit id="CannotUseAppHostWithoutRuntimeIdentifier">
+        <source>NETSDK1066: The application host cannot be used without specifying a RuntimeIdentifier. Either specify a RuntimeIdentifier or set UseAppHost to false.</source>
+        <target state="new">NETSDK1066: The application host cannot be used without specifying a RuntimeIdentifier. Either specify a RuntimeIdentifier or set UseAppHost to false.</target>
+        <note>{StrBegin="NETSDK1066: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotUseSelfContainedWithoutAppHost">
+        <source>NETSDK1067: Self-contained applications are required to use the application host. Either set SelfContained to false or set UseAppHost to true.</source>
+        <target state="new">NETSDK1067: Self-contained applications are required to use the application host. Either set SelfContained to false or set UseAppHost to true.</target>
+        <note>{StrBegin="NETSDK1067: "}</note>
+      </trans-unit>
+      <trans-unit id="FrameworkDependentAppHostRequiresVersion21">
+        <source>NETSDK1068: The framework-dependent application host requires a target framework of at least 'netcoreapp2.1'.</source>
+        <target state="new">NETSDK1068: The framework-dependent application host requires a target framework of at least 'netcoreapp2.1'.</target>
+        <note>{StrBegin="NETSDK1068: "}</note>
+      </trans-unit>
       <trans-unit id="NoCompatibleTargetFramework">
         <source>NETSDK1002: Project '{0}' targets '{2}'. It cannot be referenced by a project that targets '{1}'.</source>
         <target state="needs-review-translation">'{0}' 프로젝트가 '{2}'을(를) 대상으로 합니다. '{1}'을(를) 대상으로 하는 프로젝트에서 참조할 수 없습니다.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
@@ -8,8 +8,8 @@
         <note>{StrBegin="NETSDK1001: "}</note>
       </trans-unit>
       <trans-unit id="CannotUseAppHostWithoutRuntimeIdentifier">
-        <source>NETSDK1066: The application host cannot be used without specifying a RuntimeIdentifier. Either specify a RuntimeIdentifier or set UseAppHost to false.</source>
-        <target state="new">NETSDK1066: The application host cannot be used without specifying a RuntimeIdentifier. Either specify a RuntimeIdentifier or set UseAppHost to false.</target>
+        <source>NETSDK1066: A RuntimeIdentifier must be specified to publish a framework-dependent application with an application host.</source>
+        <target state="new">NETSDK1066: A RuntimeIdentifier must be specified to publish a framework-dependent application with an application host.</target>
         <note>{StrBegin="NETSDK1066: "}</note>
       </trans-unit>
       <trans-unit id="CannotUseSelfContainedWithoutAppHost">

--- a/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
@@ -7,6 +7,21 @@
         <target state="needs-review-translation">Należy określić co najmniej jedną możliwą platformę docelową.</target>
         <note>{StrBegin="NETSDK1001: "}</note>
       </trans-unit>
+      <trans-unit id="CannotUseAppHostWithoutRuntimeIdentifier">
+        <source>NETSDK1066: The application host cannot be used without specifying a RuntimeIdentifier. Either specify a RuntimeIdentifier or set UseAppHost to false.</source>
+        <target state="new">NETSDK1066: The application host cannot be used without specifying a RuntimeIdentifier. Either specify a RuntimeIdentifier or set UseAppHost to false.</target>
+        <note>{StrBegin="NETSDK1066: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotUseSelfContainedWithoutAppHost">
+        <source>NETSDK1067: Self-contained applications are required to use the application host. Either set SelfContained to false or set UseAppHost to true.</source>
+        <target state="new">NETSDK1067: Self-contained applications are required to use the application host. Either set SelfContained to false or set UseAppHost to true.</target>
+        <note>{StrBegin="NETSDK1067: "}</note>
+      </trans-unit>
+      <trans-unit id="FrameworkDependentAppHostRequiresVersion21">
+        <source>NETSDK1068: The framework-dependent application host requires a target framework of at least 'netcoreapp2.1'.</source>
+        <target state="new">NETSDK1068: The framework-dependent application host requires a target framework of at least 'netcoreapp2.1'.</target>
+        <note>{StrBegin="NETSDK1068: "}</note>
+      </trans-unit>
       <trans-unit id="NoCompatibleTargetFramework">
         <source>NETSDK1002: Project '{0}' targets '{2}'. It cannot be referenced by a project that targets '{1}'.</source>
         <target state="needs-review-translation">Projekt „{0}” ma platformę docelową „{2}”. Nie może on być przywoływany przez projekt z platformą docelową „{1}”.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
@@ -8,8 +8,8 @@
         <note>{StrBegin="NETSDK1001: "}</note>
       </trans-unit>
       <trans-unit id="CannotUseAppHostWithoutRuntimeIdentifier">
-        <source>NETSDK1066: The application host cannot be used without specifying a RuntimeIdentifier. Either specify a RuntimeIdentifier or set UseAppHost to false.</source>
-        <target state="new">NETSDK1066: The application host cannot be used without specifying a RuntimeIdentifier. Either specify a RuntimeIdentifier or set UseAppHost to false.</target>
+        <source>NETSDK1066: A RuntimeIdentifier must be specified to publish a framework-dependent application with an application host.</source>
+        <target state="new">NETSDK1066: A RuntimeIdentifier must be specified to publish a framework-dependent application with an application host.</target>
         <note>{StrBegin="NETSDK1066: "}</note>
       </trans-unit>
       <trans-unit id="CannotUseSelfContainedWithoutAppHost">

--- a/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
@@ -7,6 +7,21 @@
         <target state="needs-review-translation">É necessário especificar pelo menos uma estrutura de destino possível.</target>
         <note>{StrBegin="NETSDK1001: "}</note>
       </trans-unit>
+      <trans-unit id="CannotUseAppHostWithoutRuntimeIdentifier">
+        <source>NETSDK1066: The application host cannot be used without specifying a RuntimeIdentifier. Either specify a RuntimeIdentifier or set UseAppHost to false.</source>
+        <target state="new">NETSDK1066: The application host cannot be used without specifying a RuntimeIdentifier. Either specify a RuntimeIdentifier or set UseAppHost to false.</target>
+        <note>{StrBegin="NETSDK1066: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotUseSelfContainedWithoutAppHost">
+        <source>NETSDK1067: Self-contained applications are required to use the application host. Either set SelfContained to false or set UseAppHost to true.</source>
+        <target state="new">NETSDK1067: Self-contained applications are required to use the application host. Either set SelfContained to false or set UseAppHost to true.</target>
+        <note>{StrBegin="NETSDK1067: "}</note>
+      </trans-unit>
+      <trans-unit id="FrameworkDependentAppHostRequiresVersion21">
+        <source>NETSDK1068: The framework-dependent application host requires a target framework of at least 'netcoreapp2.1'.</source>
+        <target state="new">NETSDK1068: The framework-dependent application host requires a target framework of at least 'netcoreapp2.1'.</target>
+        <note>{StrBegin="NETSDK1068: "}</note>
+      </trans-unit>
       <trans-unit id="NoCompatibleTargetFramework">
         <source>NETSDK1002: Project '{0}' targets '{2}'. It cannot be referenced by a project that targets '{1}'.</source>
         <target state="needs-review-translation">O projeto '{0}' tem como destino '{2}'. Ele não pode ser referenciado por um projeto que tenha '{1}' como destino.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
@@ -8,8 +8,8 @@
         <note>{StrBegin="NETSDK1001: "}</note>
       </trans-unit>
       <trans-unit id="CannotUseAppHostWithoutRuntimeIdentifier">
-        <source>NETSDK1066: The application host cannot be used without specifying a RuntimeIdentifier. Either specify a RuntimeIdentifier or set UseAppHost to false.</source>
-        <target state="new">NETSDK1066: The application host cannot be used without specifying a RuntimeIdentifier. Either specify a RuntimeIdentifier or set UseAppHost to false.</target>
+        <source>NETSDK1066: A RuntimeIdentifier must be specified to publish a framework-dependent application with an application host.</source>
+        <target state="new">NETSDK1066: A RuntimeIdentifier must be specified to publish a framework-dependent application with an application host.</target>
         <note>{StrBegin="NETSDK1066: "}</note>
       </trans-unit>
       <trans-unit id="CannotUseSelfContainedWithoutAppHost">

--- a/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
@@ -7,6 +7,21 @@
         <target state="needs-review-translation">Необходимо указать хотя бы одну целевую платформу.</target>
         <note>{StrBegin="NETSDK1001: "}</note>
       </trans-unit>
+      <trans-unit id="CannotUseAppHostWithoutRuntimeIdentifier">
+        <source>NETSDK1066: The application host cannot be used without specifying a RuntimeIdentifier. Either specify a RuntimeIdentifier or set UseAppHost to false.</source>
+        <target state="new">NETSDK1066: The application host cannot be used without specifying a RuntimeIdentifier. Either specify a RuntimeIdentifier or set UseAppHost to false.</target>
+        <note>{StrBegin="NETSDK1066: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotUseSelfContainedWithoutAppHost">
+        <source>NETSDK1067: Self-contained applications are required to use the application host. Either set SelfContained to false or set UseAppHost to true.</source>
+        <target state="new">NETSDK1067: Self-contained applications are required to use the application host. Either set SelfContained to false or set UseAppHost to true.</target>
+        <note>{StrBegin="NETSDK1067: "}</note>
+      </trans-unit>
+      <trans-unit id="FrameworkDependentAppHostRequiresVersion21">
+        <source>NETSDK1068: The framework-dependent application host requires a target framework of at least 'netcoreapp2.1'.</source>
+        <target state="new">NETSDK1068: The framework-dependent application host requires a target framework of at least 'netcoreapp2.1'.</target>
+        <note>{StrBegin="NETSDK1068: "}</note>
+      </trans-unit>
       <trans-unit id="NoCompatibleTargetFramework">
         <source>NETSDK1002: Project '{0}' targets '{2}'. It cannot be referenced by a project that targets '{1}'.</source>
         <target state="needs-review-translation">Проект "{0}" предназначен для платформы "{2}". На него не может ссылаться проект, предназначенный для платформы "{1}".</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
@@ -8,8 +8,8 @@
         <note>{StrBegin="NETSDK1001: "}</note>
       </trans-unit>
       <trans-unit id="CannotUseAppHostWithoutRuntimeIdentifier">
-        <source>NETSDK1066: The application host cannot be used without specifying a RuntimeIdentifier. Either specify a RuntimeIdentifier or set UseAppHost to false.</source>
-        <target state="new">NETSDK1066: The application host cannot be used without specifying a RuntimeIdentifier. Either specify a RuntimeIdentifier or set UseAppHost to false.</target>
+        <source>NETSDK1066: A RuntimeIdentifier must be specified to publish a framework-dependent application with an application host.</source>
+        <target state="new">NETSDK1066: A RuntimeIdentifier must be specified to publish a framework-dependent application with an application host.</target>
         <note>{StrBegin="NETSDK1066: "}</note>
       </trans-unit>
       <trans-unit id="CannotUseSelfContainedWithoutAppHost">

--- a/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
@@ -7,6 +7,21 @@
         <target state="needs-review-translation">En az bir olası hedef çerçeve belirtilmelidir.</target>
         <note>{StrBegin="NETSDK1001: "}</note>
       </trans-unit>
+      <trans-unit id="CannotUseAppHostWithoutRuntimeIdentifier">
+        <source>NETSDK1066: The application host cannot be used without specifying a RuntimeIdentifier. Either specify a RuntimeIdentifier or set UseAppHost to false.</source>
+        <target state="new">NETSDK1066: The application host cannot be used without specifying a RuntimeIdentifier. Either specify a RuntimeIdentifier or set UseAppHost to false.</target>
+        <note>{StrBegin="NETSDK1066: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotUseSelfContainedWithoutAppHost">
+        <source>NETSDK1067: Self-contained applications are required to use the application host. Either set SelfContained to false or set UseAppHost to true.</source>
+        <target state="new">NETSDK1067: Self-contained applications are required to use the application host. Either set SelfContained to false or set UseAppHost to true.</target>
+        <note>{StrBegin="NETSDK1067: "}</note>
+      </trans-unit>
+      <trans-unit id="FrameworkDependentAppHostRequiresVersion21">
+        <source>NETSDK1068: The framework-dependent application host requires a target framework of at least 'netcoreapp2.1'.</source>
+        <target state="new">NETSDK1068: The framework-dependent application host requires a target framework of at least 'netcoreapp2.1'.</target>
+        <note>{StrBegin="NETSDK1068: "}</note>
+      </trans-unit>
       <trans-unit id="NoCompatibleTargetFramework">
         <source>NETSDK1002: Project '{0}' targets '{2}'. It cannot be referenced by a project that targets '{1}'.</source>
         <target state="needs-review-translation">'{0}' projesi, '{2}' çerçevesini hedefliyor. Bu projeye '{1}' çerçevesini hedefleyen bir proje tarafından başvurulamaz.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
@@ -8,8 +8,8 @@
         <note>{StrBegin="NETSDK1001: "}</note>
       </trans-unit>
       <trans-unit id="CannotUseAppHostWithoutRuntimeIdentifier">
-        <source>NETSDK1066: The application host cannot be used without specifying a RuntimeIdentifier. Either specify a RuntimeIdentifier or set UseAppHost to false.</source>
-        <target state="new">NETSDK1066: The application host cannot be used without specifying a RuntimeIdentifier. Either specify a RuntimeIdentifier or set UseAppHost to false.</target>
+        <source>NETSDK1066: A RuntimeIdentifier must be specified to publish a framework-dependent application with an application host.</source>
+        <target state="new">NETSDK1066: A RuntimeIdentifier must be specified to publish a framework-dependent application with an application host.</target>
         <note>{StrBegin="NETSDK1066: "}</note>
       </trans-unit>
       <trans-unit id="CannotUseSelfContainedWithoutAppHost">

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
@@ -7,6 +7,21 @@
         <target state="needs-review-translation">必须指定至少一个可能的目标框架。</target>
         <note>{StrBegin="NETSDK1001: "}</note>
       </trans-unit>
+      <trans-unit id="CannotUseAppHostWithoutRuntimeIdentifier">
+        <source>NETSDK1066: The application host cannot be used without specifying a RuntimeIdentifier. Either specify a RuntimeIdentifier or set UseAppHost to false.</source>
+        <target state="new">NETSDK1066: The application host cannot be used without specifying a RuntimeIdentifier. Either specify a RuntimeIdentifier or set UseAppHost to false.</target>
+        <note>{StrBegin="NETSDK1066: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotUseSelfContainedWithoutAppHost">
+        <source>NETSDK1067: Self-contained applications are required to use the application host. Either set SelfContained to false or set UseAppHost to true.</source>
+        <target state="new">NETSDK1067: Self-contained applications are required to use the application host. Either set SelfContained to false or set UseAppHost to true.</target>
+        <note>{StrBegin="NETSDK1067: "}</note>
+      </trans-unit>
+      <trans-unit id="FrameworkDependentAppHostRequiresVersion21">
+        <source>NETSDK1068: The framework-dependent application host requires a target framework of at least 'netcoreapp2.1'.</source>
+        <target state="new">NETSDK1068: The framework-dependent application host requires a target framework of at least 'netcoreapp2.1'.</target>
+        <note>{StrBegin="NETSDK1068: "}</note>
+      </trans-unit>
       <trans-unit id="NoCompatibleTargetFramework">
         <source>NETSDK1002: Project '{0}' targets '{2}'. It cannot be referenced by a project that targets '{1}'.</source>
         <target state="needs-review-translation">项目“{0}”以“{2}”为目标。它不可由面向“{1}”的项目引用。</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
@@ -8,8 +8,8 @@
         <note>{StrBegin="NETSDK1001: "}</note>
       </trans-unit>
       <trans-unit id="CannotUseAppHostWithoutRuntimeIdentifier">
-        <source>NETSDK1066: The application host cannot be used without specifying a RuntimeIdentifier. Either specify a RuntimeIdentifier or set UseAppHost to false.</source>
-        <target state="new">NETSDK1066: The application host cannot be used without specifying a RuntimeIdentifier. Either specify a RuntimeIdentifier or set UseAppHost to false.</target>
+        <source>NETSDK1066: A RuntimeIdentifier must be specified to publish a framework-dependent application with an application host.</source>
+        <target state="new">NETSDK1066: A RuntimeIdentifier must be specified to publish a framework-dependent application with an application host.</target>
         <note>{StrBegin="NETSDK1066: "}</note>
       </trans-unit>
       <trans-unit id="CannotUseSelfContainedWithoutAppHost">

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
@@ -7,6 +7,21 @@
         <target state="needs-review-translation">必須指定至少一個可能的目標 Framework。</target>
         <note>{StrBegin="NETSDK1001: "}</note>
       </trans-unit>
+      <trans-unit id="CannotUseAppHostWithoutRuntimeIdentifier">
+        <source>NETSDK1066: The application host cannot be used without specifying a RuntimeIdentifier. Either specify a RuntimeIdentifier or set UseAppHost to false.</source>
+        <target state="new">NETSDK1066: The application host cannot be used without specifying a RuntimeIdentifier. Either specify a RuntimeIdentifier or set UseAppHost to false.</target>
+        <note>{StrBegin="NETSDK1066: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotUseSelfContainedWithoutAppHost">
+        <source>NETSDK1067: Self-contained applications are required to use the application host. Either set SelfContained to false or set UseAppHost to true.</source>
+        <target state="new">NETSDK1067: Self-contained applications are required to use the application host. Either set SelfContained to false or set UseAppHost to true.</target>
+        <note>{StrBegin="NETSDK1067: "}</note>
+      </trans-unit>
+      <trans-unit id="FrameworkDependentAppHostRequiresVersion21">
+        <source>NETSDK1068: The framework-dependent application host requires a target framework of at least 'netcoreapp2.1'.</source>
+        <target state="new">NETSDK1068: The framework-dependent application host requires a target framework of at least 'netcoreapp2.1'.</target>
+        <note>{StrBegin="NETSDK1068: "}</note>
+      </trans-unit>
       <trans-unit id="NoCompatibleTargetFramework">
         <source>NETSDK1002: Project '{0}' targets '{2}'. It cannot be referenced by a project that targets '{1}'.</source>
         <target state="needs-review-translation">專案 '{0}' 以 '{2}' 為目標。以 '{1}' 為目標的專案無法參考該專案。</target>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -17,8 +17,8 @@ Copyright (c) .NET Foundation. All rights reserved.
     <DefaultCopyToPublishDirectoryMetadata Condition="'$(DefaultCopyToPublishDirectoryMetadata)' == ''">true</DefaultCopyToPublishDirectoryMetadata>
     <_GetChildProjectCopyToPublishDirectoryItems Condition="'$(_GetChildProjectCopyToPublishDirectoryItems)' == ''">true</_GetChildProjectCopyToPublishDirectoryItems>
 
-    <!-- publishing self-contained apps should publish the native host as $(AssemblyName).exe -->
-    <DeployAppHost Condition=" '$(DeployAppHost)' == '' and '$(_IsExecutable)' == 'true' and '$(RuntimeIdentifier)' != '' and '$(SelfContained)' == 'true'">true</DeployAppHost>
+    <!-- publishing with the apphost should publish the native host as $(AssemblyName).exe -->
+    <DeployAppHost Condition="'$(DeployAppHost)' == '' and '$(_IsExecutable)' == 'true' and '$(RuntimeIdentifier)' != '' and '$(UseAppHost)' == 'true'">true</DeployAppHost>
   
     <IsPublishable Condition="'$(IsPublishable)'==''">true</IsPublishable>
   </PropertyGroup>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets
@@ -104,18 +104,27 @@ Copyright (c) .NET Foundation. All rights reserved.
     Default SelfContained based on the RuntimeIdentifier, so projects don't have to explicitly set SelfContained.
     This avoids a breaking change from 1.0 behavior.
     -->
-  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' and '$(HasRuntimeOutput)' == 'true' and '$(SelfContained)' == ''">
-    <SelfContained Condition="'$(RuntimeIdentifier)' == ''">false</SelfContained>
-    <SelfContained Condition="'$(RuntimeIdentifier)' != ''">true</SelfContained>
+  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' and '$(HasRuntimeOutput)' == 'true' and '$(RuntimeIdentifier)' != ''">
+    <SelfContained Condition="'$(SelfContained)' == ''">true</SelfContained>
+    <UseAppHost Condition="'$(UseAppHost)' == '' and ('$(SelfContained)' == 'true' or '$(_TargetFrameworkVersionWithoutV)' >= '2.1')">true</UseAppHost>
   </PropertyGroup>
 
-  <Target Name="_CheckForUnsupportedSelfContained"
+  <Target Name="_CheckForUnsupportedAppHostUsage"
           BeforeTargets="_CheckForInvalidConfigurationAndPlatform"
           Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' and '$(HasRuntimeOutput)' == 'true'">
 
     <NETSdkError Condition="'$(SelfContained)' == 'true' and '$(RuntimeIdentifier)' == ''"
                  ResourceName="CannotHaveSelfContainedWithoutRuntimeIdentifier" />
-    
+
+    <NETSdkError Condition="'$(UseAppHost)' == 'true' and '$(RuntimeIdentifier)' == ''"
+                 ResourceName="CannotUseAppHostWithoutRuntimeIdentifier" />
+
+    <NETSdkError Condition="'$(SelfContained)' == 'true' and '$(UseAppHost)' != 'true'"
+                 ResourceName="CannotUseSelfContainedWithoutAppHost" />
+
+    <NETSdkError Condition="'$(SelfContained)' != 'true' and '$(UseAppHost)' == 'true' and '$(_TargetFrameworkVersionWithoutV)' &lt; '2.1'"
+                 ResourceName="FrameworkDependentAppHostRequiresVersion21" />
+
   </Target>
 
   <Target Name="_CheckForMismatchingPlatform"

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.BeforeCommon.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.BeforeCommon.targets
@@ -32,6 +32,11 @@ Copyright (c) .NET Foundation. All rights reserved.
   -->
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.NET.TargetFrameworkInference.targets" />
 
+  <!-- For .NET Framework, reference core assemblies -->
+  <PropertyGroup>
+    <_TargetFrameworkVersionWithoutV>$(TargetFrameworkVersion.TrimStart('vV'))</_TargetFrameworkVersionWithoutV>
+  </PropertyGroup>
+
   <!--
     Use RuntimeIdentifier to determine PlatformTarget.
     Also, enforce that RuntimeIdentifier is always specified for .NETFramework executables.
@@ -86,12 +91,6 @@ Copyright (c) .NET Foundation. All rights reserved.
                            '$(RuntimeIdentifier)' != '' and
                            '$(_UsingDefaultRuntimeIdentifier)' != 'true'">$(OutputPath)$(RuntimeIdentifier)\$(PublishDirName)\</PublishDir>
     <PublishDir Condition="'$(PublishDir)' == ''">$(OutputPath)$(PublishDirName)\</PublishDir>
-  </PropertyGroup>
-
-  <!-- For .NET Framework, reference core assemblies -->
-
-  <PropertyGroup>
-    <_TargetFrameworkVersionWithoutV>$(TargetFrameworkVersion.TrimStart('vV'))</_TargetFrameworkVersionWithoutV>
   </PropertyGroup>
 
   <!--

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -285,10 +285,11 @@ Copyright (c) .NET Foundation. All rights reserved.
     it requires a host in the output directory to load the app.
     During "publish", all required assets are copied to the publish directory.
     -->
-    <ItemGroup Condition="'$(SelfContained)' == 'true' and '$(RuntimeIdentifier)' != '' and '$(_IsExecutable)' == 'true'">
+    <ItemGroup Condition="'$(UseAppHost)' == 'true' and '$(RuntimeIdentifier)' != '' and '$(_IsExecutable)' == 'true'">
       <NativeNETCoreCopyLocalItems Include="@(NativeCopyLocalItems)"
-                                   Condition="'%(NativeCopyLocalItems.FileName)%(NativeCopyLocalItems.Extension)' == '$(_DotNetHostPolicyLibraryName)' or
-                                              '%(NativeCopyLocalItems.FileName)%(NativeCopyLocalItems.Extension)' == '$(_DotNetHostFxrLibraryName)'" />
+                                   Condition="'$(SelfContained)' == 'true' and
+                                              ('%(NativeCopyLocalItems.FileName)%(NativeCopyLocalItems.Extension)' == '$(_DotNetHostPolicyLibraryName)' or
+                                               '%(NativeCopyLocalItems.FileName)%(NativeCopyLocalItems.Extension)' == '$(_DotNetHostFxrLibraryName)')" />
 
       <NativeRestoredAppHostNETCore Include="@(NativeCopyLocalItems)"
                                    Condition="'%(NativeCopyLocalItems.FileName)%(NativeCopyLocalItems.Extension)' == '$(_DotNetAppHostExecutableName)'"/>
@@ -326,7 +327,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       </NativeNETCoreCopyLocalItems>
     </ItemGroup>
 
-    <ItemGroup Condition="'$(SelfContained)' == 'true' and '$(RuntimeIdentifier)' != '' and '$(_IsExecutable)' == 'true'">
+    <ItemGroup Condition="'$(UseAppHost)' == 'true' and '$(RuntimeIdentifier)' != '' and '$(_IsExecutable)' == 'true'">
       <AllNETCoreCopyLocalItems Include="@(NativeNETCoreCopyLocalItems)">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         <CopyToPublishDirectory>Never</CopyToPublishDirectory>
@@ -394,7 +395,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     </When>
 
     <When Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' and '$(_IsExecutable)' == 'true'">
-      <PropertyGroup Condition="'$(SelfContained)' != 'true'">
+      <PropertyGroup Condition="'$(UseAppHost)' != 'true'">
         <!-- TODO: https://github.com/dotnet/sdk/issues/20 Need to get the DotNetHost path from MSBuild -->
         <RunCommand Condition="'$(RunCommand)' == ''">dotnet</RunCommand>
 
@@ -403,7 +404,7 @@ Copyright (c) .NET Foundation. All rights reserved.
         <RunArguments Condition="'$(RunArguments)' == ''">$(_NetCoreRunArguments)</RunArguments>
       </PropertyGroup>
 
-      <PropertyGroup Condition="'$(SelfContained)' == 'true'">
+      <PropertyGroup Condition="'$(UseAppHost)' == 'true'">
         <RunCommand Condition="'$(RunCommand)' == ''">$(TargetDir)$(AssemblyName)$(_NativeExecutableExtension)</RunCommand>
         <RunArguments Condition="'$(RunArguments)' == ''">$(StartArguments)</RunArguments>
       </PropertyGroup>

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAFrameworkDependentApp.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAFrameworkDependentApp.cs
@@ -1,0 +1,136 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using FluentAssertions;
+using Microsoft.DotNet.Cli.Utils;
+using Microsoft.DotNet.PlatformAbstractions;
+using Microsoft.NET.Build.Tasks;
+using Microsoft.NET.TestFramework;
+using Microsoft.NET.TestFramework.Assertions;
+using Microsoft.NET.TestFramework.Commands;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.NET.Publish.Tests
+{
+    public class GivenThatWeWantToPublishAFrameworkDependentApp : SdkTest
+    {
+        private const string TestProjectName = "HelloWorld";
+        private const string TargetFramework = "netcoreapp2.1";
+
+        public GivenThatWeWantToPublishAFrameworkDependentApp(ITestOutputHelper log) : base(log)
+        {
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("true")]
+        [InlineData("false")]
+        public void It_publishes_with_or_without_apphost(string useAppHost)
+        {
+            var runtimeIdentifier = RuntimeEnvironment.GetRuntimeIdentifier();
+            var appHostName = $"{TestProjectName}{Constants.ExeSuffix}";
+
+            var testAsset = _testAssetsManager
+                .CopyTestAsset(TestProjectName, $"It_publishes_with_or_without_apphost_{(useAppHost ?? "null")}")
+                .WithSource();
+
+            var msbuildArgs = new List<string>()
+            {
+                "/restore",
+                $"/p:RuntimeIdentifier={runtimeIdentifier}",
+                $"/p:TestRuntimeIdentifier={runtimeIdentifier}",
+                "/p:SelfContained=false",
+                $"/p:TargetFramework={TargetFramework}"
+            };
+
+            if (useAppHost != null)
+            {
+                msbuildArgs.Add($"/p:UseAppHost={useAppHost}");
+            }
+
+            var publishCommand = new PublishCommand(Log, testAsset.TestRoot);
+            publishCommand
+                .Execute(msbuildArgs.ToArray())
+                .Should()
+                .Pass();
+
+            var publishDirectory = publishCommand.GetOutputDirectory(TargetFramework, runtimeIdentifier: runtimeIdentifier);
+
+            var expectedFiles = new List<string>()
+            {
+                $"{TestProjectName}.dll",
+                $"{TestProjectName}.pdb",
+                $"{TestProjectName}.deps.json",
+                $"{TestProjectName}.runtimeconfig.json",
+            };
+
+            if (useAppHost != "false")
+            {
+                expectedFiles.Add(appHostName);
+            }
+
+            publishDirectory.Should().NotHaveSubDirectories();
+            publishDirectory.Should().OnlyHaveFiles(expectedFiles);
+
+            // Run the apphost if one was generated
+            if (useAppHost != "false")
+            {
+                Command.Create(Path.Combine(publishDirectory.FullName, appHostName), Enumerable.Empty<string>())
+                    .EnvironmentVariable(
+                        Environment.Is64BitProcess ? "DOTNET_ROOT" : "DOTNET_ROOT(x86)",
+                        Path.GetDirectoryName(TestContext.Current.ToolsetUnderTest.DotNetHostPath))
+                    .CaptureStdOut()
+                    .Execute()
+                    .Should()
+                    .Pass()
+                    .And
+                    .HaveStdOutContaining("Hello World!");
+            }
+        }
+
+        [Fact]
+        public void It_errors_when_using_app_host_without_rid()
+        {
+            var testAsset = _testAssetsManager
+                .CopyTestAsset(TestProjectName)
+                .WithSource();
+
+            var publishCommand = new PublishCommand(Log, testAsset.TestRoot);
+            publishCommand
+                .Execute(
+                    "/p:SelfContained=false",
+                    "/p:UseAppHost=true",
+                    $"/p:TargetFramework={TargetFramework}")
+                .Should()
+                .Fail()
+                .And
+                .HaveStdOutContaining(Strings.CannotUseAppHostWithoutRuntimeIdentifier);
+        }
+
+        [Fact]
+        public void It_errors_when_using_app_host_with_older_target_framework()
+        {
+            var runtimeIdentifier = RuntimeEnvironment.GetRuntimeIdentifier();
+
+            var testAsset = _testAssetsManager
+                .CopyTestAsset(TestProjectName)
+                .WithSource();
+
+            var publishCommand = new PublishCommand(Log, testAsset.TestRoot);
+            publishCommand
+                .Execute(
+                    "/p:SelfContained=false",
+                    "/p:UseAppHost=true",
+                    $"/p:RuntimeIdentifier={runtimeIdentifier}")
+                .Should()
+                .Fail()
+                .And
+                .HaveStdOutContaining(Strings.FrameworkDependentAppHostRequiresVersion21);
+        }
+    }
+}

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishASelfContainedApp.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishASelfContainedApp.cs
@@ -1,0 +1,68 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using FluentAssertions;
+using Microsoft.DotNet.Cli.Utils;
+using Microsoft.DotNet.PlatformAbstractions;
+using Microsoft.NET.Build.Tasks;
+using Microsoft.NET.TestFramework;
+using Microsoft.NET.TestFramework.Assertions;
+using Microsoft.NET.TestFramework.Commands;
+using System;
+using System.IO;
+using System.Linq;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.NET.Publish.Tests
+{
+    public class GivenThatWeWantToPublishASelfContainedApp : SdkTest
+    {
+        private const string TestProjectName = "HelloWorld";
+        private const string TargetFramework = "netcoreapp2.1";
+
+        public GivenThatWeWantToPublishASelfContainedApp(ITestOutputHelper log) : base(log)
+        {
+        }
+
+        [Fact]
+        public void It_errors_when_publishing_self_contained_app_without_rid()
+        {
+             var testAsset = _testAssetsManager
+                .CopyTestAsset(TestProjectName)
+                .WithSource();
+
+            var publishCommand = new PublishCommand(Log, testAsset.TestRoot);
+            publishCommand
+                .Execute(
+                    "/p:SelfContained=true",
+                    $"/p:TargetFramework={TargetFramework}")
+                .Should()
+                .Fail()
+                .And
+                .HaveStdOutContaining(Strings.CannotHaveSelfContainedWithoutRuntimeIdentifier);
+        }
+
+        [Fact]
+        public void It_errors_when_publishing_self_contained_without_apphost()
+        {
+            var runtimeIdentifier = RuntimeEnvironment.GetRuntimeIdentifier();
+
+            var testAsset = _testAssetsManager
+                .CopyTestAsset(TestProjectName)
+                .WithSource();
+
+            var publishCommand = new PublishCommand(Log, testAsset.TestRoot);
+            publishCommand
+                .Execute(
+                    "/p:SelfContained=true",
+                    "/p:UseAppHost=false",
+                    $"/p:TargetFramework={TargetFramework}",
+                    $"/p:RuntimeIdentifier={runtimeIdentifier}")
+                .Should()
+                .Fail()
+                .And
+                .HaveStdOutContaining(Strings.CannotUseSelfContainedWithoutAppHost);
+        }
+    }
+}

--- a/src/Tests/Microsoft.NET.Publish.Tests/Microsoft.NET.Publish.Tests.csproj
+++ b/src/Tests/Microsoft.NET.Publish.Tests/Microsoft.NET.Publish.Tests.csproj
@@ -33,6 +33,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <EmbeddedResource Include="..\..\Tasks\Common\Resources\Strings.resx" LinkBase="Resources" GenerateSource="True" Namespace="Microsoft.NET.Build.Tasks" />
     <EmbeddedResource Include="**\*.resx" Exclude="$(GlobalExclude)" />
   </ItemGroup>
 


### PR DESCRIPTION
This commit implements building and publishing a framework-dependent
application with the application host.

Building with `/p:UseAppHost=true` (when a `RuntimeIdentifier` is specified)
and with `/p:SelfContained=false` will create an executable apphost that can be
used to run the application against globally installed runtimes.

Fixes dotnet/cli#6237.