### PR TITLE
Use correct property for version prefix (2.1.4xx)

### DIFF
--- a/build/Versions.props
+++ b/build/Versions.props
@@ -8,7 +8,7 @@
 
   <!-- Repo Version Information -->
   <PropertyGroup>
-    <VersionBase>2.1.400</VersionBase>
+    <VersionPrefix>2.1.400</VersionPrefix>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
   </PropertyGroup>
 


### PR DESCRIPTION
This causes our packages to be versioned 1.0.0-* instead of 2.1.400-*.

Due to merge conflict, the fix to 2.1.3xx was not applied to 2.1.4xx.