### PR TITLE
Use correct property for version prefix (master)

### DIFF
--- a/build/Versions.props
+++ b/build/Versions.props
@@ -8,7 +8,7 @@
 
   <!-- Repo Version Information -->
   <PropertyGroup>
-    <VersionBase>2.2.100</VersionBase>
+    <VersionPrefix>2.2.100</VersionPrefix>
     <PreReleaseVersionLabel>preview1</PreReleaseVersionLabel>
   </PropertyGroup>
 


### PR DESCRIPTION
This causes our packages to be versioned 1.0.0-* instead of 2.2.100-*.

Due to merge conflict, the fix to 2.1.3xx was not applied to master.