### PR TITLE
Use MemoryMappedViewAccessor to reduce memory consumption of creating apphost

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/AppHost.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/AppHost.cs
@@ -108,6 +108,7 @@ namespace Microsoft.NET.Build.Tasks
 
             byte* bytes = null;
             accessor.SafeMemoryMappedViewHandle.AcquirePointer(ref bytes);
+            bytes = bytes + accessor.PointerOffset;
 
             try
             {
@@ -168,17 +169,17 @@ namespace Microsoft.NET.Build.Tasks
             Pad0(accessor, searchPattern, patternToReplace, position);
         }
 
-        private static unsafe void Pad0(MemoryMappedViewAccessor accessor, byte[] searchPattern, byte[] patternToReplace, int position)
+        private static unsafe void Pad0(MemoryMappedViewAccessor accessor, byte[] searchPattern, byte[] patternToReplace, int offset)
         {
-            byte* ptrMemoryMappedView = null;
-            accessor.SafeMemoryMappedViewHandle.AcquirePointer(ref ptrMemoryMappedView);
+            byte* bytes = null;
+            accessor.SafeMemoryMappedViewHandle.AcquirePointer(ref bytes);
+            bytes = bytes + accessor.PointerOffset;
 
             if (patternToReplace.Length < searchPattern.Length)
             {
                 for (int i = patternToReplace.Length; i < searchPattern.Length; i++)
                 {
-                    byte empty = 0x0;
-                    *(ptrMemoryMappedView + i + position) = empty;
+                    bytes[i + offset] = 0x0;
                 }
             }
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/AppHost.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/AppHost.cs
@@ -140,12 +140,13 @@ namespace Microsoft.NET.Build.Tasks
             byte[] patternToReplace,
             string appHostSourcePath)
         {
-            byte* bytes = null;
-            accessor.SafeMemoryMappedViewHandle.AcquirePointer(ref bytes);
-            bytes = bytes + accessor.PointerOffset;
+            byte* pointer = null;
 
             try
             {
+                accessor.SafeMemoryMappedViewHandle.AcquirePointer(ref pointer);
+                byte* bytes = pointer + accessor.PointerOffset;
+
                 int position = KMPSearch(searchPattern, bytes, accessor.Capacity);
                 if (position < 0)
                 {
@@ -162,7 +163,7 @@ namespace Microsoft.NET.Build.Tasks
             }
             finally
             {
-                if (accessor.SafeMemoryMappedViewHandle != null)
+                if (pointer != null)
                 {
                     accessor.SafeMemoryMappedViewHandle.ReleasePointer();
                 }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Microsoft.NET.Build.Tasks.csproj
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Microsoft.NET.Build.Tasks.csproj
@@ -17,6 +17,7 @@
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <OutDirName>Sdks\$(PackageId)\tools</OutDirName>
     <NoPackageAnalysis>true</NoPackageAnalysis>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />


### PR DESCRIPTION
Fix https://github.com/dotnet/sdk/issues/1339. 

It avoids loading the whole apphost in memory.

Measure by adding  `_alllog.AppendLine("memory: " + GC.GetTotalMemory(true));` every important line of creating app host.

memory usage:
Before 168 kb, after 2kb

Time total
Before:
00:00:00.0330214
After:
00:00:00.0240767

Before this change, the search (all in memory) need `00:00:00.0009461`
After using unsafe code, search need `00:00:00.001206`
