### PR TITLE
Add DefaultNetCorePatchVersion and LatestPatchVersionForNetCore2_1 for 2.1

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.targets
@@ -108,9 +108,11 @@ Copyright (c) .NET Foundation. All rights reserved.
     <DefaultNetCorePatchVersion Condition="'$(_TargetFrameworkVersionWithoutV)' == '1.0'">1.0.5</DefaultNetCorePatchVersion>
     <DefaultNetCorePatchVersion Condition="'$(_TargetFrameworkVersionWithoutV)' == '1.1'">1.1.2</DefaultNetCorePatchVersion>
 
+    <DefaultNetCorePatchVersion Condition="'$(_TargetFrameworkVersionWithoutV)' == '2.1'">2.1.0</DefaultNetCorePatchVersion>
+
     <!-- If targeting the same pre-release that is bundled with the .NET Core SDK, use the bundled package version
          provided by Microsoft.NETCoreSdk.BundledVersions.props -->
-    <DefaultNetCorePatchVersion Condition="'$(_TargetFrameworkVersionWithoutV)' == '$(BundledNETCoreAppTargetFrameworkVersion)'">$(BundledNETCoreAppPackageVersion)</DefaultNetCorePatchVersion>
+    <DefaultNetCorePatchVersion Condition="'$(DefaultNetCorePatchVersion)' == '' and '$(_TargetFrameworkVersionWithoutV)' == '$(BundledNETCoreAppTargetFrameworkVersion)'">$(BundledNETCoreAppPackageVersion)</DefaultNetCorePatchVersion>
     <!-- If not covered by the previous cases use the target framework version for the default patch version -->
     <DefaultNetCorePatchVersion Condition="'$(DefaultNetCorePatchVersion)' == ''">$(_TargetFrameworkVersionWithoutV)</DefaultNetCorePatchVersion>
   </PropertyGroup>
@@ -119,6 +121,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <LatestNetCorePatchVersion Condition="'$(_TargetFrameworkVersionWithoutV)' == '1.0'">$(LatestPatchVersionForNetCore1_0)</LatestNetCorePatchVersion>
     <LatestNetCorePatchVersion Condition="'$(_TargetFrameworkVersionWithoutV)' == '1.1'">$(LatestPatchVersionForNetCore1_1)</LatestNetCorePatchVersion>
     <LatestNetCorePatchVersion Condition="'$(_TargetFrameworkVersionWithoutV)' == '2.0'">$(LatestPatchVersionForNetCore2_0)</LatestNetCorePatchVersion>
+    <LatestNetCorePatchVersion Condition="'$(_TargetFrameworkVersionWithoutV)' == '2.1'">$(LatestPatchVersionForNetCore2_1)</LatestNetCorePatchVersion>
 
     <!-- If targeting the same pre-release that is bundled with the .NET Core SDK, use the bundled package version
          provided by Microsoft.NETCoreSdk.BundledVersions.props -->

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildANetCoreApp.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildANetCoreApp.cs
@@ -40,6 +40,8 @@ namespace Microsoft.NET.Build.Tests
         [InlineData("netcoreapp1.1", null, "1.1.2", "1.1.2")]
         [InlineData("netcoreapp1.1", "1.1.0", "1.1.0", "1.1.0")]
         [InlineData("netcoreapp1.1.1", null, "1.1.1", "1.1.1")]
+        [InlineData("netcoreapp2.0", null, "2.0.0", "2.0.0")]
+        [InlineData("netcoreapp2.1", null, "2.1.0", "2.1.0")]
         public void It_targets_the_right_shared_framework(string targetFramework, string runtimeFrameworkVersion,
             string expectedPackageVersion, string expectedRuntimeVersion)
         {


### PR DESCRIPTION
Fix https://github.com/dotnet/sdk/issues/2275

Submitting the following CLI change for approval be fixed in .NET Core 2.1 servicing:

> Link to GitHub issue for open source changes  

https://github.com/dotnet/sdk/issues/2275

> Link to GitHub dotnet:release/[version] pull request (see Git Prepping a PR from the Release Branch) 

https://github.com/dotnet/sdk/pull/2298

> ProjectK TFS bug and changeset for closed source changes (security fix, package authoring, etc) 

N/A 

> Describe the issue and how it manifests to the customer. 

DefaultNetCorePatchVersion is not set explicitly for netcoreapp2.1. And by the default calculation, when CLI use 2.1.1 runtime, the version “2.1.1” will be used for portable app during publish. 

> What is the impact on the customer? 

If the portable app is published using the new 2.1 servicing build. The published portable app cannot be run on 2.1 runtime while it should.

> Are there changes that cannot be made in GitHub? (security fixes, etc) 

No

> Characterize potential risks introduced by the fix. 

Low risk.

> Does the change alter existing behaviors? (return values or types, error messages or exceptions, etc. In other words, is this a build-to-build breaking change?) 

No

 >> What changed?
>> What will teams need to do to respond?
>> Once check-in is approved send breaking change mail to netcorebreak

> Code reviewers:

dsplaisted

> What testing has been completed? 

Unit test

> Which platforms are impacted? (Linux | Mac | Windows) 

All

> Effected binaries and packages (exact name)

Microsoft.NET.Sdk.DefaultItems.targets
