### PR TITLE
Add conditional to not build net46 in sourcebuild

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Extensions.Tasks/Microsoft.NET.Build.Extensions.Tasks.csproj
+++ b/src/Tasks/Microsoft.NET.Build.Extensions.Tasks/Microsoft.NET.Build.Extensions.Tasks.csproj
@@ -10,6 +10,7 @@
     <PackageId>Microsoft.NET.Build.Extensions</PackageId>
     <RootNamespace>Microsoft.NET.Build.Tasks</RootNamespace>
     <TargetFrameworks>netcoreapp2.0;net46</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(DotNetBuildFromSource)' == 'true' ">netcoreapp2.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Microsoft.NET.Build.Tasks.csproj
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Microsoft.NET.Build.Tasks.csproj
@@ -7,6 +7,7 @@
     <OutputType>Library</OutputType>
     <PackageId>Microsoft.NET.Sdk</PackageId>
     <TargetFrameworks>netcoreapp2.0;net46</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(DotNetBuildFromSource)' == 'true' ">netcoreapp2.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
A recent commit https://github.com/dotnet/sdk/commit/b16a4889367f1706ba8b9a7bcb3663329acb94cc to enable x-plat net46 build causes the source-build build to fail for 2.1.

