### PR TITLE
[WIP] Add warning for ref to netstandard >= 1.5 from netfx without built-in support

### DIFF
--- a/src/Tasks/Common/Resources/Strings.resx
+++ b/src/Tasks/Common/Resources/Strings.resx
@@ -381,4 +381,8 @@ The following are names of parameters or literal values and should not be transl
     <value>NETSDK1065: Cannot find app host for {0}. {0} could be an invalid runtime identifier (RID). For more information about RID, see https://aka.ms/rid-catalog.</value>
     <comment>{StrBegin="NETSDK1065: "}</comment>
   </data>
+  <data name="NETFrameworkToNonBuiltInNETStandard" xml:space="preserve">
+    <value>NETSDK1066: You’re using a .NET Standard 1.5 or higher library but targeting a .NET Framework without built-in support. Visit https://go.microsoft.com/fwlink/?linkid=874511 for a set of known issues. Consider retargeting to .NET Framework 4.7.2.</value>
+    <comment>{StrBegin="NETSDK1066: "}</comment>
+  </data>
 </root>

--- a/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
@@ -7,6 +7,11 @@
         <target state="needs-review-translation">Je potřeba zadat alespoň jednu možnou cílovou platformu</target>
         <note>{StrBegin="NETSDK1001: "}</note>
       </trans-unit>
+      <trans-unit id="NETFrameworkToNonBuiltInNETStandard">
+        <source>NETSDK1066: You’re using a .NET Standard 1.5 or higher library but targeting a .NET Framework without built-in support. Visit https://go.microsoft.com/fwlink/?linkid=874511 for a set of known issues. Consider retargeting to .NET Framework 4.7.2.</source>
+        <target state="new">NETSDK1066: You’re using a .NET Standard 1.5 or higher library but targeting a .NET Framework without built-in support. Visit https://go.microsoft.com/fwlink/?linkid=874511 for a set of known issues. Consider retargeting to .NET Framework 4.7.2.</target>
+        <note>{StrBegin="NETSDK1066: "}</note>
+      </trans-unit>
       <trans-unit id="NoCompatibleTargetFramework">
         <source>NETSDK1002: Project '{0}' targets '{2}'. It cannot be referenced by a project that targets '{1}'.</source>
         <target state="needs-review-translation">Cílem projektu {0} je {2}. Nemůže na něj odkazovat projekt, jehož cílem je {1}.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.de.xlf
@@ -7,6 +7,11 @@
         <target state="needs-review-translation">Geben Sie mindestens ein mögliches Zielframework an.</target>
         <note>{StrBegin="NETSDK1001: "}</note>
       </trans-unit>
+      <trans-unit id="NETFrameworkToNonBuiltInNETStandard">
+        <source>NETSDK1066: You’re using a .NET Standard 1.5 or higher library but targeting a .NET Framework without built-in support. Visit https://go.microsoft.com/fwlink/?linkid=874511 for a set of known issues. Consider retargeting to .NET Framework 4.7.2.</source>
+        <target state="new">NETSDK1066: You’re using a .NET Standard 1.5 or higher library but targeting a .NET Framework without built-in support. Visit https://go.microsoft.com/fwlink/?linkid=874511 for a set of known issues. Consider retargeting to .NET Framework 4.7.2.</target>
+        <note>{StrBegin="NETSDK1066: "}</note>
+      </trans-unit>
       <trans-unit id="NoCompatibleTargetFramework">
         <source>NETSDK1002: Project '{0}' targets '{2}'. It cannot be referenced by a project that targets '{1}'.</source>
         <target state="needs-review-translation">Das Projekt "{0}" hat das Ziel "{2}". Ein Verweis von einem Projekt mit dem Ziel "{1}" ist nicht möglich.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.es.xlf
@@ -7,6 +7,11 @@
         <target state="needs-review-translation">Debe especificarse al menos una plataforma de destino posible.</target>
         <note>{StrBegin="NETSDK1001: "}</note>
       </trans-unit>
+      <trans-unit id="NETFrameworkToNonBuiltInNETStandard">
+        <source>NETSDK1066: You’re using a .NET Standard 1.5 or higher library but targeting a .NET Framework without built-in support. Visit https://go.microsoft.com/fwlink/?linkid=874511 for a set of known issues. Consider retargeting to .NET Framework 4.7.2.</source>
+        <target state="new">NETSDK1066: You’re using a .NET Standard 1.5 or higher library but targeting a .NET Framework without built-in support. Visit https://go.microsoft.com/fwlink/?linkid=874511 for a set of known issues. Consider retargeting to .NET Framework 4.7.2.</target>
+        <note>{StrBegin="NETSDK1066: "}</note>
+      </trans-unit>
       <trans-unit id="NoCompatibleTargetFramework">
         <source>NETSDK1002: Project '{0}' targets '{2}'. It cannot be referenced by a project that targets '{1}'.</source>
         <target state="needs-review-translation">El proyecto "{0}" tiene como destino "{2}". No se puede hacer referencia a él mediante un proyecto que tenga como destino "{1}".</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
@@ -7,6 +7,11 @@
         <target state="needs-review-translation">Au moins un framework cible doit être spécifié.</target>
         <note>{StrBegin="NETSDK1001: "}</note>
       </trans-unit>
+      <trans-unit id="NETFrameworkToNonBuiltInNETStandard">
+        <source>NETSDK1066: You’re using a .NET Standard 1.5 or higher library but targeting a .NET Framework without built-in support. Visit https://go.microsoft.com/fwlink/?linkid=874511 for a set of known issues. Consider retargeting to .NET Framework 4.7.2.</source>
+        <target state="new">NETSDK1066: You’re using a .NET Standard 1.5 or higher library but targeting a .NET Framework without built-in support. Visit https://go.microsoft.com/fwlink/?linkid=874511 for a set of known issues. Consider retargeting to .NET Framework 4.7.2.</target>
+        <note>{StrBegin="NETSDK1066: "}</note>
+      </trans-unit>
       <trans-unit id="NoCompatibleTargetFramework">
         <source>NETSDK1002: Project '{0}' targets '{2}'. It cannot be referenced by a project that targets '{1}'.</source>
         <target state="needs-review-translation">Le projet '{0}' cible '{2}'. Il ne peut pas être référencé par un projet qui cible '{1}'.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.it.xlf
@@ -7,6 +7,11 @@
         <target state="needs-review-translation">È necessario specificare almeno un framework di destinazione possibile.</target>
         <note>{StrBegin="NETSDK1001: "}</note>
       </trans-unit>
+      <trans-unit id="NETFrameworkToNonBuiltInNETStandard">
+        <source>NETSDK1066: You’re using a .NET Standard 1.5 or higher library but targeting a .NET Framework without built-in support. Visit https://go.microsoft.com/fwlink/?linkid=874511 for a set of known issues. Consider retargeting to .NET Framework 4.7.2.</source>
+        <target state="new">NETSDK1066: You’re using a .NET Standard 1.5 or higher library but targeting a .NET Framework without built-in support. Visit https://go.microsoft.com/fwlink/?linkid=874511 for a set of known issues. Consider retargeting to .NET Framework 4.7.2.</target>
+        <note>{StrBegin="NETSDK1066: "}</note>
+      </trans-unit>
       <trans-unit id="NoCompatibleTargetFramework">
         <source>NETSDK1002: Project '{0}' targets '{2}'. It cannot be referenced by a project that targets '{1}'.</source>
         <target state="needs-review-translation">Il progetto '{0}' è destinato a '{2}'. Non può essere usato come riferimento in un progetto destinato a '{1}'.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
@@ -7,6 +7,11 @@
         <target state="needs-review-translation">可能性のあるターゲット フレームワークを少なくとも 1 つ指定する必要があります。</target>
         <note>{StrBegin="NETSDK1001: "}</note>
       </trans-unit>
+      <trans-unit id="NETFrameworkToNonBuiltInNETStandard">
+        <source>NETSDK1066: You’re using a .NET Standard 1.5 or higher library but targeting a .NET Framework without built-in support. Visit https://go.microsoft.com/fwlink/?linkid=874511 for a set of known issues. Consider retargeting to .NET Framework 4.7.2.</source>
+        <target state="new">NETSDK1066: You’re using a .NET Standard 1.5 or higher library but targeting a .NET Framework without built-in support. Visit https://go.microsoft.com/fwlink/?linkid=874511 for a set of known issues. Consider retargeting to .NET Framework 4.7.2.</target>
+        <note>{StrBegin="NETSDK1066: "}</note>
+      </trans-unit>
       <trans-unit id="NoCompatibleTargetFramework">
         <source>NETSDK1002: Project '{0}' targets '{2}'. It cannot be referenced by a project that targets '{1}'.</source>
         <target state="needs-review-translation">プロジェクト '{0}' は、'{2}' を対象としています。'{1}' を対象とするプロジェクトは、これを参照できません。</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
@@ -7,6 +7,11 @@
         <target state="needs-review-translation">가능한 대상 프레임워크를 하나 이상 지정해야 합니다.</target>
         <note>{StrBegin="NETSDK1001: "}</note>
       </trans-unit>
+      <trans-unit id="NETFrameworkToNonBuiltInNETStandard">
+        <source>NETSDK1066: You’re using a .NET Standard 1.5 or higher library but targeting a .NET Framework without built-in support. Visit https://go.microsoft.com/fwlink/?linkid=874511 for a set of known issues. Consider retargeting to .NET Framework 4.7.2.</source>
+        <target state="new">NETSDK1066: You’re using a .NET Standard 1.5 or higher library but targeting a .NET Framework without built-in support. Visit https://go.microsoft.com/fwlink/?linkid=874511 for a set of known issues. Consider retargeting to .NET Framework 4.7.2.</target>
+        <note>{StrBegin="NETSDK1066: "}</note>
+      </trans-unit>
       <trans-unit id="NoCompatibleTargetFramework">
         <source>NETSDK1002: Project '{0}' targets '{2}'. It cannot be referenced by a project that targets '{1}'.</source>
         <target state="needs-review-translation">'{0}' 프로젝트가 '{2}'을(를) 대상으로 합니다. '{1}'을(를) 대상으로 하는 프로젝트에서 참조할 수 없습니다.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
@@ -7,6 +7,11 @@
         <target state="needs-review-translation">Należy określić co najmniej jedną możliwą platformę docelową.</target>
         <note>{StrBegin="NETSDK1001: "}</note>
       </trans-unit>
+      <trans-unit id="NETFrameworkToNonBuiltInNETStandard">
+        <source>NETSDK1066: You’re using a .NET Standard 1.5 or higher library but targeting a .NET Framework without built-in support. Visit https://go.microsoft.com/fwlink/?linkid=874511 for a set of known issues. Consider retargeting to .NET Framework 4.7.2.</source>
+        <target state="new">NETSDK1066: You’re using a .NET Standard 1.5 or higher library but targeting a .NET Framework without built-in support. Visit https://go.microsoft.com/fwlink/?linkid=874511 for a set of known issues. Consider retargeting to .NET Framework 4.7.2.</target>
+        <note>{StrBegin="NETSDK1066: "}</note>
+      </trans-unit>
       <trans-unit id="NoCompatibleTargetFramework">
         <source>NETSDK1002: Project '{0}' targets '{2}'. It cannot be referenced by a project that targets '{1}'.</source>
         <target state="needs-review-translation">Projekt „{0}” ma platformę docelową „{2}”. Nie może on być przywoływany przez projekt z platformą docelową „{1}”.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
@@ -7,6 +7,11 @@
         <target state="needs-review-translation">É necessário especificar pelo menos uma estrutura de destino possível.</target>
         <note>{StrBegin="NETSDK1001: "}</note>
       </trans-unit>
+      <trans-unit id="NETFrameworkToNonBuiltInNETStandard">
+        <source>NETSDK1066: You’re using a .NET Standard 1.5 or higher library but targeting a .NET Framework without built-in support. Visit https://go.microsoft.com/fwlink/?linkid=874511 for a set of known issues. Consider retargeting to .NET Framework 4.7.2.</source>
+        <target state="new">NETSDK1066: You’re using a .NET Standard 1.5 or higher library but targeting a .NET Framework without built-in support. Visit https://go.microsoft.com/fwlink/?linkid=874511 for a set of known issues. Consider retargeting to .NET Framework 4.7.2.</target>
+        <note>{StrBegin="NETSDK1066: "}</note>
+      </trans-unit>
       <trans-unit id="NoCompatibleTargetFramework">
         <source>NETSDK1002: Project '{0}' targets '{2}'. It cannot be referenced by a project that targets '{1}'.</source>
         <target state="needs-review-translation">O projeto '{0}' tem como destino '{2}'. Ele não pode ser referenciado por um projeto que tenha '{1}' como destino.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
@@ -7,6 +7,11 @@
         <target state="needs-review-translation">Необходимо указать хотя бы одну целевую платформу.</target>
         <note>{StrBegin="NETSDK1001: "}</note>
       </trans-unit>
+      <trans-unit id="NETFrameworkToNonBuiltInNETStandard">
+        <source>NETSDK1066: You’re using a .NET Standard 1.5 or higher library but targeting a .NET Framework without built-in support. Visit https://go.microsoft.com/fwlink/?linkid=874511 for a set of known issues. Consider retargeting to .NET Framework 4.7.2.</source>
+        <target state="new">NETSDK1066: You’re using a .NET Standard 1.5 or higher library but targeting a .NET Framework without built-in support. Visit https://go.microsoft.com/fwlink/?linkid=874511 for a set of known issues. Consider retargeting to .NET Framework 4.7.2.</target>
+        <note>{StrBegin="NETSDK1066: "}</note>
+      </trans-unit>
       <trans-unit id="NoCompatibleTargetFramework">
         <source>NETSDK1002: Project '{0}' targets '{2}'. It cannot be referenced by a project that targets '{1}'.</source>
         <target state="needs-review-translation">Проект "{0}" предназначен для платформы "{2}". На него не может ссылаться проект, предназначенный для платформы "{1}".</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
@@ -7,6 +7,11 @@
         <target state="needs-review-translation">En az bir olası hedef çerçeve belirtilmelidir.</target>
         <note>{StrBegin="NETSDK1001: "}</note>
       </trans-unit>
+      <trans-unit id="NETFrameworkToNonBuiltInNETStandard">
+        <source>NETSDK1066: You’re using a .NET Standard 1.5 or higher library but targeting a .NET Framework without built-in support. Visit https://go.microsoft.com/fwlink/?linkid=874511 for a set of known issues. Consider retargeting to .NET Framework 4.7.2.</source>
+        <target state="new">NETSDK1066: You’re using a .NET Standard 1.5 or higher library but targeting a .NET Framework without built-in support. Visit https://go.microsoft.com/fwlink/?linkid=874511 for a set of known issues. Consider retargeting to .NET Framework 4.7.2.</target>
+        <note>{StrBegin="NETSDK1066: "}</note>
+      </trans-unit>
       <trans-unit id="NoCompatibleTargetFramework">
         <source>NETSDK1002: Project '{0}' targets '{2}'. It cannot be referenced by a project that targets '{1}'.</source>
         <target state="needs-review-translation">'{0}' projesi, '{2}' çerçevesini hedefliyor. Bu projeye '{1}' çerçevesini hedefleyen bir proje tarafından başvurulamaz.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
@@ -7,6 +7,11 @@
         <target state="needs-review-translation">必须指定至少一个可能的目标框架。</target>
         <note>{StrBegin="NETSDK1001: "}</note>
       </trans-unit>
+      <trans-unit id="NETFrameworkToNonBuiltInNETStandard">
+        <source>NETSDK1066: You’re using a .NET Standard 1.5 or higher library but targeting a .NET Framework without built-in support. Visit https://go.microsoft.com/fwlink/?linkid=874511 for a set of known issues. Consider retargeting to .NET Framework 4.7.2.</source>
+        <target state="new">NETSDK1066: You’re using a .NET Standard 1.5 or higher library but targeting a .NET Framework without built-in support. Visit https://go.microsoft.com/fwlink/?linkid=874511 for a set of known issues. Consider retargeting to .NET Framework 4.7.2.</target>
+        <note>{StrBegin="NETSDK1066: "}</note>
+      </trans-unit>
       <trans-unit id="NoCompatibleTargetFramework">
         <source>NETSDK1002: Project '{0}' targets '{2}'. It cannot be referenced by a project that targets '{1}'.</source>
         <target state="needs-review-translation">项目“{0}”以“{2}”为目标。它不可由面向“{1}”的项目引用。</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
@@ -7,6 +7,11 @@
         <target state="needs-review-translation">必須指定至少一個可能的目標 Framework。</target>
         <note>{StrBegin="NETSDK1001: "}</note>
       </trans-unit>
+      <trans-unit id="NETFrameworkToNonBuiltInNETStandard">
+        <source>NETSDK1066: You’re using a .NET Standard 1.5 or higher library but targeting a .NET Framework without built-in support. Visit https://go.microsoft.com/fwlink/?linkid=874511 for a set of known issues. Consider retargeting to .NET Framework 4.7.2.</source>
+        <target state="new">NETSDK1066: You’re using a .NET Standard 1.5 or higher library but targeting a .NET Framework without built-in support. Visit https://go.microsoft.com/fwlink/?linkid=874511 for a set of known issues. Consider retargeting to .NET Framework 4.7.2.</target>
+        <note>{StrBegin="NETSDK1066: "}</note>
+      </trans-unit>
       <trans-unit id="NoCompatibleTargetFramework">
         <source>NETSDK1002: Project '{0}' targets '{2}'. It cannot be referenced by a project that targets '{1}'.</source>
         <target state="needs-review-translation">專案 '{0}' 以 '{2}' 為目標。以 '{1}' 為目標的專案無法參考該專案。</target>

--- a/src/Tasks/Microsoft.NET.Build.Extensions.Tasks/msbuildExtensions/Microsoft/Microsoft.NET.Build.Extensions/Microsoft.NET.Build.Extensions.NETFramework.targets
+++ b/src/Tasks/Microsoft.NET.Build.Extensions.Tasks/msbuildExtensions/Microsoft/Microsoft.NET.Build.Extensions/Microsoft.NET.Build.Extensions.NETFramework.targets
@@ -97,6 +97,10 @@ Copyright (c) .NET Foundation. All rights reserved.
                                           Exclude="@(_NETStandardLibraryNETFrameworkLib->'$(MSBuildThisFileDirectory)net461\lib\%(FileName).dll')" />
     </ItemGroup>
 
+    <NETBuildExtensionsWarning Condition="'@(_NETStandardLibraryNETFrameworkLib)' != ''"
+                               ResourceName="NETFrameworkToNonBuiltInNETStandard"
+                               />
+
     <ItemGroup Condition="'@(_NETStandardLibraryNETFrameworkLib)' != ''">
       <!-- Remove simple name references if we're directly providing a reference assembly to the compiler. For example,
            consider a project with a Reference Include="System.Net.Http" or "System.IO.Compression", which are both in


### PR DESCRIPTION
I'm handing this off to a teammate while I'm away.

Still TODO:

- [ ] Confirm final error message text with PMs
- [ ] Make sure fwlink points to valid content
- [ ] Tests
  - The existing tests of the extensions adding support files probably just need to be updated to also check for the correct warning or lack thereof. The matrix is the same as the cases where we do/do not add support files:
   - [ ]  .NETFramework < 4.7.2 -> .NETStandard >= 1.5 --> warning
   - [ ] .NETFramework any -> .NETStandard < 1.5 --> no warning
   - [ ] .NETFramework >= 4.7.2 -> .NETStandard any --> no warning
   - [ ] Warning can be suppressed