### PR TITLE
Fix failure to load System.IO.Compression.ZipFile due to automatic binding redirect

### DIFF
--- a/build/build.ps1
+++ b/build/build.ps1
@@ -241,7 +241,7 @@ function LocateVisualStudio {
     Invoke-WebRequest "http://github.com/Microsoft/vswhere/releases/download/$VSWhereVersion/vswhere.exe" -UseBasicParsing -OutFile $VSWhereExe
   }
 
-  $VSInstallDir = & $VSWhereExe -latest -property installationPath -requires Microsoft.Component.MSBuild -requires Microsoft.VisualStudio.Component.VSSDK -requires Microsoft.Net.Component.4.6.TargetingPack -requires Microsoft.VisualStudio.Component.Roslyn.Compiler -requires Microsoft.VisualStudio.Component.VSSDK
+  $VSInstallDir = & $VSWhereExe -latest -property installationPath -requires Microsoft.Component.MSBuild -requires Microsoft.VisualStudio.Component.VSSDK -requires Microsoft.Net.Component.4.6.TargetingPack -requires Microsoft.VisualStudio.Component.Roslyn.Compiler -requires Microsoft.VisualStudio.Component.VSSDK -prerelease
 
   if (!(Test-Path $VSInstallDir)) {
     throw "Failed to locate Visual Studio (exit code '$LASTEXITCODE')."

--- a/src/Assets/TestProjects/ProjectConstruction/NetFrameworkProject/NetFrameworkProject.csproj
+++ b/src/Assets/TestProjects/ProjectConstruction/NetFrameworkProject/NetFrameworkProject.csproj
@@ -11,6 +11,7 @@
     <AssemblyName>$(MSBuildProjectName)</AssemblyName>
     <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/Tasks/Common/ConflictResolution/ConflictResolver.cs
+++ b/src/Tasks/Common/ConflictResolution/ConflictResolver.cs
@@ -100,10 +100,14 @@ namespace Microsoft.NET.Build.Tasks.ConflictResolution
                     List<TConflictItem> previouslyUnresolvedConflicts;
                     if (_unresolvedConflictItems.TryGetValue(itemKey, out previouslyUnresolvedConflicts))
                     {
-                        //  Skip the first item in the list of items that had unresolved conflicts, as it should
-                        //  be the same as the losing item which was just reported.
-                        foreach (var previouslyUnresolvedItem in previouslyUnresolvedConflicts.Skip(1))
+                        foreach (var previouslyUnresolvedItem in previouslyUnresolvedConflicts)
                         {
+                            //  Don't re-report the item that just lost and was already reported
+                            if (object.ReferenceEquals(previouslyUnresolvedItem, loser))
+                            {
+                                continue;
+                            }
+
                             //  Call ResolveConflict with the new winner and item that previously had an unresolved
                             //  conflict, so that the correct message will be logged recording that the winner
                             //  won and why

--- a/src/Tasks/Common/ConflictResolution/ResolvePackageFileConflicts.cs
+++ b/src/Tasks/Common/ConflictResolution/ResolvePackageFileConflicts.cs
@@ -157,7 +157,12 @@ namespace Microsoft.NET.Build.Tasks.ConflictResolution
             //  So what we do is keep track of Platform items that win conflicts with Reference items in
             //  the compile scope, and explicitly add references to them here.
             ReferencesWithoutConflicts = SafeConcat(ReferencesWithoutConflicts,
-                compilePlatformWinners.Select(c => new TaskItem(c.FileName)));
+                //  The Reference item we create in this case should be without the .dll extension
+                //  (which is added in FrameworkListReader in order to make the framework items
+                //  correctly conflict with DLLs from NuGet packages)
+                compilePlatformWinners.Select(c => Path.GetFileNameWithoutExtension(c.FileName))
+                                      .Select(r => new TaskItem(r)));
+
         }
 
         //  Concatanate two things, either of which may be null.  Interpret null as empty,

--- a/src/Tasks/Common/ConflictResolution/ResolvePackageFileConflicts.cs
+++ b/src/Tasks/Common/ConflictResolution/ResolvePackageFileConflicts.cs
@@ -67,7 +67,7 @@ namespace Microsoft.NET.Build.Tasks.ConflictResolution
                 compilePlatformItems = TargetFrameworkDirectories.SelectMany(tfd =>
                 {
                     return frameworkListReader.GetConflictItems(Path.Combine(tfd.ItemSpec, "RedistList", "FrameworkList.xml"), log);
-                }).ToList();
+                }).ToArray();
             }
 
             // resolve conflicts at compile time
@@ -90,7 +90,7 @@ namespace Microsoft.NET.Build.Tasks.ConflictResolution
             //  Remove platform items which won a conflict with a reference but subsequently lost to something else
             compilePlatformWinners.ExceptWith(allConflicts);
 
-            // resolve conflicts that class in output
+            // resolve conflicts that clash in output
             IEnumerable<ConflictItem> copyLocalItems;
             IEnumerable<ConflictItem> otherRuntimeItems;
             using (var runtimeConflictScope = new ConflictResolver<ConflictItem>(packageRanks, packageOverrides, log))

--- a/src/Tasks/Microsoft.NET.Build.Extensions.Tasks/msbuildExtensions/Microsoft/Microsoft.NET.Build.Extensions/Microsoft.NET.Build.Extensions.NETFramework.targets
+++ b/src/Tasks/Microsoft.NET.Build.Extensions.Tasks/msbuildExtensions/Microsoft/Microsoft.NET.Build.Extensions/Microsoft.NET.Build.Extensions.NETFramework.targets
@@ -135,4 +135,15 @@ Copyright (c) .NET Foundation. All rights reserved.
       </ReferenceCopyLocalPaths>
     </ItemGroup>
   </Target>
+
+  <Target Name="RemoveZipFileSuggestedRedirect"
+          BeforeTargets="GenerateBindingRedirects"
+          DependsOnTargets="ResolveAssemblyReferences"
+          Condition="'$(_TargetFrameworkVersionWithoutV)' &gt;= '4.7.1'">
+    <ItemGroup>
+      <SuggestedBindingRedirects Remove="System.IO.Compression.ZipFile, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+    </ItemGroup>
+    
+  </Target>
+  
 </Project>

--- a/src/Tasks/Microsoft.NET.Build.Extensions.Tasks/msbuildExtensions/Microsoft/Microsoft.NET.Build.Extensions/Microsoft.NET.Build.Extensions.NETFramework.targets
+++ b/src/Tasks/Microsoft.NET.Build.Extensions.Tasks/msbuildExtensions/Microsoft/Microsoft.NET.Build.Extensions/Microsoft.NET.Build.Extensions.NETFramework.targets
@@ -136,7 +136,16 @@ Copyright (c) .NET Foundation. All rights reserved.
     </ItemGroup>
   </Target>
 
-  <Target Name="RemoveZipFileSuggestedRedirect"
+  <!-- There was issue in .NET 4.7.1 where System.IO.Compression.ZipFile was not correctly in the unification table.
+       A workaround to issues that caused was to add a binding redirect for the assembly from version 4.0.3.0 down to
+       4.0.0.0.  However, with the fix to dotnet/sdk#2221, ResolveAssemblyReference now sees a conflicting version for
+       the assembly, and suggests a redirect to 4.0.3.0.  With automatic binding redirection, this overrides the redirect
+       to 4.0.0.0, which causes a runtime failure.
+       
+       So here we disable any suggested binding redirect for System.IO.Compression.ZipFile.  Assemblies in the unification
+       table generally should not need binding redirects, so it should be OK to do this for 4.7.2 and forward, and on 4.7.1
+       the assembly isn't in the unification table so this allows the original workaround redirect to be preserved. -->
+  <Target Name="_RemoveZipFileSuggestedRedirect"
           BeforeTargets="GenerateBindingRedirects"
           DependsOnTargets="ResolveAssemblyReferences"
           Condition="'$(_TargetFrameworkVersionWithoutV)' &gt;= '4.7.1' And '$(AllowZipFileRedirect)' != 'true'">

--- a/src/Tasks/Microsoft.NET.Build.Extensions.Tasks/msbuildExtensions/Microsoft/Microsoft.NET.Build.Extensions/Microsoft.NET.Build.Extensions.NETFramework.targets
+++ b/src/Tasks/Microsoft.NET.Build.Extensions.Tasks/msbuildExtensions/Microsoft/Microsoft.NET.Build.Extensions/Microsoft.NET.Build.Extensions.NETFramework.targets
@@ -139,7 +139,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <Target Name="RemoveZipFileSuggestedRedirect"
           BeforeTargets="GenerateBindingRedirects"
           DependsOnTargets="ResolveAssemblyReferences"
-          Condition="'$(_TargetFrameworkVersionWithoutV)' &gt;= '4.7.1'">
+          Condition="'$(_TargetFrameworkVersionWithoutV)' &gt;= '4.7.1' And '$(AllowZipFileRedirect)' != 'true'">
     <ItemGroup>
       <SuggestedBindingRedirects Remove="System.IO.Compression.ZipFile, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
     </ItemGroup>

--- a/src/Tests/Microsoft.NET.TestFramework/ProjectConstruction/TestProject.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/ProjectConstruction/TestProject.cs
@@ -113,6 +113,15 @@ namespace Microsoft.NET.TestFramework.ProjectConstruction
                 sourceProject = Path.Combine(sourceProjectBase, "NetFrameworkProject", "NetFrameworkProject.csproj");
             }
 
+            //  Copy any additional files from template
+            foreach (var file in Directory.GetFiles(Path.GetDirectoryName(sourceProject)))
+            {
+                if (file != sourceProject)
+                {
+                    File.Copy(file, Path.Combine(targetFolder, Path.GetFileName(file)));
+                }
+            }
+
             var projectXml = XDocument.Load(sourceProject);
 
             var ns = projectXml.Root.Name.Namespace;


### PR DESCRIPTION
Fixes #2292

There is a bug with the unification table for .NET 4.7.1, and the [workaround](https://github.com/Microsoft/dotnet/blob/master/releases/net471/KnownIssues/623552-BCL%20Higher%20assembly%20versions%20that%204.0.0.0%20for%20System.IO.Compression.ZipFile%20cannot%20be%20loaded%20without%20a%20binding%20redirect.md) is to add the following binding redirect:

```xml
  <runtime>
    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
      <dependentAssembly>
        <assemblyIdentity name="System.IO.Compression.ZipFile" publicKeyToken="b77a5c561934e089" culture="neutral" />
        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.0.0" />
      </dependentAssembly>
    </assemblyBinding>
  </runtime>
```

With the fix for #2221, this is getting overridden with an automatic binding redirect to version 4.0.3.0, which fails at runtime because it disables the unification table, and because the version of the runtime file is 4.0.0.0.

Since the suggested binding redirect is wrong in this case, this PR removes that suggested redirect after RAR suggests it.