### PR TITLE
Allow customization of shim output root

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.PackTool.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.PackTool.targets
@@ -73,9 +73,13 @@ Copyright (c) .NET Foundation. All rights reserved.
       <_PackAsToolShimRuntimeIdentifiers Include="$(PackAsToolShimRuntimeIdentifiers)"/>
     </ItemGroup>
 
+    <PropertyGroup>
+      <PackagedShimOutputRootDirectory Condition=" '$(PackagedShimOutputRootDirectory)' == '' ">$(IntermediateOutputPath)</PackagedShimOutputRootDirectory>
+    </PropertyGroup>
+
     <GenerateShims
       DotNetAppHostExecutableNameWithoutExtension="$(_DotNetAppHostExecutableNameWithoutExtension)"
-      PackagedShimOutputDirectory="$(IntermediateOutputPath)/$(Configuration)/shims/$(TargetFramework)"
+      PackagedShimOutputDirectory="$(PackagedShimOutputRootDirectory)/shims/$(TargetFramework)"
       PackageId="$(PackageId)"
       PackageVersion="$(Version)"
       ProjectAssetsFile="$(ProjectAssetsFile)"


### PR DESCRIPTION
So you could customize the output like the following
``` xml
<Project Sdk="Microsoft.NET.Sdk">

  <PropertyGroup>
    <OutputType>Exe</OutputType>
    <TargetFramework>netcoreapp2.1</TargetFramework>
    <PackAsToolShimRuntimeIdentifiers>win-x64;osx.10.12-x64</PackAsToolShimRuntimeIdentifiers>
    <PackAsTool>true</PackAsTool>
    <PackagedShimOutputRootDirectory>bin/$(Configuration)</PackagedShimOutputRootDirectory>
  </PropertyGroup>

</Project>
```

note you cannot use <PackagedShimOutputRootDirectory>$(OutDir)</PackagedShimOutputRootDirectory> since OutDir is not set by the time of reading project file
