### PR TITLE
Make UseAppHost default to false for framework-dependent applications.

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets
@@ -106,7 +106,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     -->
   <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' and '$(HasRuntimeOutput)' == 'true' and '$(RuntimeIdentifier)' != ''">
     <SelfContained Condition="'$(SelfContained)' == ''">true</SelfContained>
-    <UseAppHost Condition="'$(UseAppHost)' == '' and ('$(SelfContained)' == 'true' or '$(_TargetFrameworkVersionWithoutV)' >= '2.1')">true</UseAppHost>
+    <UseAppHost Condition="'$(UseAppHost)' == '' and '$(SelfContained)' == 'true'">true</UseAppHost>
   </PropertyGroup>
 
   <Target Name="_CheckForUnsupportedAppHostUsage"

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAFrameworkDependentApp.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAFrameworkDependentApp.cs
@@ -69,7 +69,7 @@ namespace Microsoft.NET.Publish.Tests
                 $"{TestProjectName}.runtimeconfig.json",
             };
 
-            if (useAppHost != "false")
+            if (useAppHost == "true")
             {
                 expectedFiles.Add(appHostName);
             }
@@ -78,7 +78,7 @@ namespace Microsoft.NET.Publish.Tests
             publishDirectory.Should().OnlyHaveFiles(expectedFiles);
 
             // Run the apphost if one was generated
-            if (useAppHost != "false")
+            if (useAppHost == "true")
             {
                 Command.Create(Path.Combine(publishDirectory.FullName, appHostName), Enumerable.Empty<string>())
                     .EnvironmentVariable(


### PR DESCRIPTION
This commit makes the default for `UseAppHost` to not be `true` when publishing
a framework-dependent application that targets a supporting netcoreapp version.

Fixes #2380.