### PR TITLE
Don't include non-CopyLocal direct references of referenced projects in deps.json

### DIFF
--- a/src/Tasks/Common/MSBuildUtilities.cs
+++ b/src/Tasks/Common/MSBuildUtilities.cs
@@ -3,7 +3,7 @@
 
 using System;
 
-namespace Microsoft.NET.Build.Tasks.ConflictResolution
+namespace Microsoft.NET.Build.Tasks
 {
     /// <summary>
     /// Internal utilties copied from microsoft/MSBuild repo.

--- a/src/Tasks/Common/MetadataKeys.cs
+++ b/src/Tasks/Common/MetadataKeys.cs
@@ -68,6 +68,7 @@ namespace Microsoft.NET.Build.Tasks
         public const string Pack = "Pack";
         public const string ReferenceSourceTarget = "ReferenceSourceTarget";
         public const string TargetPath = "TargetPath";
+        public const string CopyLocal = "CopyLocal";
 
         // Content files
         public const string PPOutputPath = "PPOutputPath";

--- a/src/Tasks/Microsoft.NET.Build.Tasks/SingleProjectInfo.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/SingleProjectInfo.cs
@@ -83,8 +83,10 @@ namespace Microsoft.NET.Build.Tasks
                     new SingleProjectInfo(sourceProjectFile, name, version, outputName, dependencyReferences: null, resourceAssemblies: null));
             }
 
+            //  Include direct references of referenced projects, but only if they are CopyLocal
             IEnumerable<ITaskItem> projectReferenceDependencyPaths = referenceDependencyPaths
-                .Where(r => string.Equals(r.GetMetadata(MetadataKeys.ReferenceSourceTarget), "ProjectReference", StringComparison.OrdinalIgnoreCase));
+                .Where(r => string.Equals(r.GetMetadata(MetadataKeys.ReferenceSourceTarget), "ProjectReference", StringComparison.OrdinalIgnoreCase) &&
+                            MSBuildUtilities.ConvertStringToBool(r.GetMetadata(MetadataKeys.CopyLocal)));
 
             foreach (ITaskItem projectReferenceDependencyPath in projectReferenceDependencyPaths)
             {

--- a/src/Tests/Microsoft.NET.Build.Tests/AspNetCoreOnFullFramework.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/AspNetCoreOnFullFramework.cs
@@ -18,7 +18,7 @@ namespace Microsoft.NET.Build.Tests
         {
         }
 
-        [Theory]
+        [WindowsOnlyTheory]
         [InlineData("1.1.2")]
         [InlineData("2.0.4")]
         public void It_discovers_assembly_parts(string aspnetVersion)

--- a/src/Tests/Microsoft.NET.Build.Tests/AspNetCoreOnFullFramework.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/AspNetCoreOnFullFramework.cs
@@ -1,0 +1,114 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using Microsoft.DotNet.Cli.Utils;
+using Microsoft.NET.TestFramework;
+using Microsoft.NET.TestFramework.Assertions;
+using Microsoft.NET.TestFramework.Commands;
+using Microsoft.NET.TestFramework.ProjectConstruction;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.NET.Build.Tests
+{
+    public class AspNetCoreOnFullFramework : SdkTest
+    {
+        public AspNetCoreOnFullFramework(ITestOutputHelper log) : base(log)
+        {
+        }
+
+        [Theory]
+        [InlineData("1.1.2")]
+        [InlineData("2.0.4")]
+        public void It_discovers_assembly_parts(string aspnetVersion)
+        {
+            var testProject = new TestProject()
+            {
+                Name = "AssemblyPartDiscovery",
+                IsSdkProject = true,
+                TargetFrameworks = "net461",
+                IsExe = true
+            };
+
+            testProject.SourceFiles["Program.cs"] = @"
+using Microsoft.AspNetCore.Mvc.Internal;
+using Microsoft.Extensions.DependencyModel;
+using System.IO;
+using System.Linq;
+
+public class Program
+{
+    public static void Main(string[] args)
+    {
+        var parts = DefaultAssemblyPartDiscoveryProvider.DiscoverAssemblyParts(""" + testProject.Name + @""");
+        foreach (var item in parts)
+        {
+            System.Console.WriteLine(item.Name);
+        }
+    }
+}";
+
+            TestProject referencedProjectWithPart = new TestProject()
+            {
+                Name = "ReferencedProjectWithPart",
+                IsSdkProject = true,
+                TargetFrameworks = "net461",
+                IsExe = false
+            };
+
+            
+            referencedProjectWithPart.References.Add("System.ServiceModel");
+
+            referencedProjectWithPart.SourceFiles["Class1.cs"] = @"
+class Class1
+{
+    public string X => typeof(System.ServiceModel.AddressFilterMode).ToString();
+}";
+
+            TestProject referencedProjectWithMvc = new TestProject()
+            {
+                Name = "ReferencedProjectWithMVC",
+                IsSdkProject = true,
+                TargetFrameworks = "net461",
+                IsExe = false
+            };
+
+            referencedProjectWithMvc.PackageReferences.Add(new TestPackageReference("Microsoft.AspNetCore.Mvc", aspnetVersion));
+
+            testProject.ReferencedProjects.Add(referencedProjectWithPart);
+            testProject.ReferencedProjects.Add(referencedProjectWithMvc);
+
+            var testProjectInstance = _testAssetsManager.CreateTestProject(testProject, identifier: aspnetVersion)
+                                    .WithProjectChanges((filename, project) =>
+                                    {
+                                        var ns = project.Root.Name.Namespace;
+
+                                        project.Root.Attribute("Sdk").Value = "Microsoft.NET.Sdk.Web";
+                                    })
+                                    .Restore(Log, testProject.Name);
+
+            var buildCommand = new BuildCommand(Log, testProjectInstance.TestRoot, testProject.Name);
+
+            buildCommand.Execute()
+                .Should()
+                .Pass();
+
+            string outputPath = buildCommand.GetOutputDirectory(testProject.TargetFrameworks).FullName;
+
+            string exePath = Path.Combine(outputPath, testProject.Name + ".exe");
+
+            var toolCommandSpec = new SdkCommandSpec()
+            {
+                FileName = exePath
+            };
+            TestContext.Current.AddTestEnvironmentVariables(toolCommandSpec);
+
+            ICommand toolCommand = toolCommandSpec.ToCommand().CaptureStdOut();
+
+            var toolResult = toolCommand.Execute();
+
+            toolResult.Should().Pass();
+        }
+    }
+}


### PR DESCRIPTION
Fixes aspnet/Home#3132

Fixes regression introduced with #2090.  That change will also include Framework references, which under some circumstances will cause a runtime failure with ASP.NET Core 1.x running on .NET Framework.