### PR TITLE
Add missing semicolon in CoreCleanDependsOn

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -93,7 +93,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <PropertyGroup>
     <CoreCleanDependsOn>
-      _SdkBeforeClean
+      _SdkBeforeClean;
       $(CoreCleanDependsOn)
     </CoreCleanDependsOn>
   </PropertyGroup>


### PR DESCRIPTION
This property is defined to be empty in common targets, but not having this semicolon would break anyone defining it to non-empty without a leading semicolon.

Fix #2387