### PR TITLE
[WIP NO MERGE]: Add support for RuntimeFrameworkName to set the platform package for .NET Core 2.1 projects

### DIFF
--- a/src/Tasks/Common/Resources/Strings.resx
+++ b/src/Tasks/Common/Resources/Strings.resx
@@ -401,4 +401,20 @@ The following are names of parameters or literal values and should not be transl
     <value>NETSDK1070: This project uses an unsupported value for RuntimeFrameworkName. Currently, only valid values are: Microsoft.NETCore.App, Microsoft.AspNetCore.App, or Microsoft.AspNetCore.All.</value>
     <comment>{StrBegin="NETSDK1070: "}</comment>
   </data>
+  <data name="AspNetCoreRequiresRuntimeFrameworkName" xml:space="preserve">
+    <value><![CDATA[NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher.
+To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}.
+
+<PropertyGroup>
+    <RuntimeFrameworkName>{0}</RuntimeFrameworkName>
+</PropertyGroup>
+
+For more information, see {2}.
+    ]]></value>
+    <comment>{StrBegin="NETSDK1071: "}
+{0} - Package Id (AspNetCore.App or .All)
+{1} - Project name
+{2} - More info link
+    </comment>
+  </data>
 </root>

--- a/src/Tasks/Common/Resources/Strings.resx
+++ b/src/Tasks/Common/Resources/Strings.resx
@@ -402,11 +402,7 @@ The following are names of parameters or literal values and should not be transl
     <comment>{StrBegin="NETSDK1070: "}</comment>
   </data>
   <data name="AspNetCoreRequiresRuntimeFrameworkName" xml:space="preserve">
-    <value><![CDATA[NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher. To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}. For more information, see {2}.
-<PropertyGroup>
-    <RuntimeFrameworkName>{0}</RuntimeFrameworkName>
-</PropertyGroup>
-    ]]></value>
+    <value>NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher. To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}. For more information, see {2}.</value>
     <comment>{StrBegin="NETSDK1071: "}
 {0} - Package Id (AspNetCore.App or .All)
 {1} - Project name

--- a/src/Tasks/Common/Resources/Strings.resx
+++ b/src/Tasks/Common/Resources/Strings.resx
@@ -402,14 +402,10 @@ The following are names of parameters or literal values and should not be transl
     <comment>{StrBegin="NETSDK1070: "}</comment>
   </data>
   <data name="AspNetCoreRequiresRuntimeFrameworkName" xml:space="preserve">
-    <value><![CDATA[NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher.
-To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}.
-
+    <value><![CDATA[NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher. To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}. For more information, see {2}.
 <PropertyGroup>
     <RuntimeFrameworkName>{0}</RuntimeFrameworkName>
 </PropertyGroup>
-
-For more information, see {2}.
     ]]></value>
     <comment>{StrBegin="NETSDK1071: "}
 {0} - Package Id (AspNetCore.App or .All)

--- a/src/Tasks/Common/Resources/Strings.resx
+++ b/src/Tasks/Common/Resources/Strings.resx
@@ -397,4 +397,8 @@ The following are names of parameters or literal values and should not be transl
     <value>NETSDK1069: This project uses a library that targets .NET Standard 1.5 or higher, and the project targets a version of .NET Framework that doesn't have built-in support for that version of .NET Standard. Visit https://aka.ms/net-standard-known-issues for a set of known issues. Consider retargeting to .NET Framework 4.7.2.</value>
     <comment>{StrBegin="NETSDK1069: "}</comment>
   </data>
+  <data name="UnrecognizedRuntimeFrameworkName" xml:space="preserve">
+    <value>NETSDK1070: This project uses an unsupported value for RuntimeFrameworkName. Currently, only valid values are: Microsoft.NETCore.App, Microsoft.AspNetCore.App, or Microsoft.AspNetCore.All.</value>
+    <comment>{StrBegin="NETSDK1070: "}</comment>
+  </data>
 </root>

--- a/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
@@ -3,23 +3,15 @@
   <file datatype="xml" source-language="en" target-language="cs" original="../Strings.resx">
     <body>
       <trans-unit id="AspNetCoreRequiresRuntimeFrameworkName">
-        <source>NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher.
-To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}.
-
+        <source>NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher. To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}. For more information, see {2}.
 &lt;PropertyGroup&gt;
     &lt;RuntimeFrameworkName&gt;{0}&lt;/RuntimeFrameworkName&gt;
 &lt;/PropertyGroup&gt;
-
-For more information, see {2}.
     </source>
-        <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher.
-To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}.
-
+        <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher. To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}. For more information, see {2}.
 &lt;PropertyGroup&gt;
     &lt;RuntimeFrameworkName&gt;{0}&lt;/RuntimeFrameworkName&gt;
 &lt;/PropertyGroup&gt;
-
-For more information, see {2}.
     </target>
         <note>{StrBegin="NETSDK1071: "}
 {0} - Package Id (AspNetCore.App or .All)

--- a/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
@@ -112,6 +112,11 @@
         <target state="needs-review-translation">Neplatný řetězec verze NuGet: {0}</target>
         <note>{StrBegin="NETSDK1018: "}</note>
       </trans-unit>
+      <trans-unit id="UnrecognizedRuntimeFrameworkName">
+        <source>NETSDK1070: This project uses an unsupported value for RuntimeFrameworkName. Currently, only valid values are: Microsoft.NETCore.App, Microsoft.AspNetCore.App, or Microsoft.AspNetCore.All.</source>
+        <target state="new">NETSDK1070: This project uses an unsupported value for RuntimeFrameworkName. Currently, only valid values are: Microsoft.NETCore.App, Microsoft.AspNetCore.App, or Microsoft.AspNetCore.All.</target>
+        <note>{StrBegin="NETSDK1070: "}</note>
+      </trans-unit>
       <trans-unit id="UnsupportedFramework">
         <source>NETSDK1019: {0} is an unsupported framework.</source>
         <target state="needs-review-translation">{0} není podporovaná platforma.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
@@ -2,6 +2,31 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../Strings.resx">
     <body>
+      <trans-unit id="AspNetCoreRequiresRuntimeFrameworkName">
+        <source>NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher.
+To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}.
+
+&lt;PropertyGroup&gt;
+    &lt;RuntimeFrameworkName&gt;{0}&lt;/RuntimeFrameworkName&gt;
+&lt;/PropertyGroup&gt;
+
+For more information, see {2}.
+    </source>
+        <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher.
+To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}.
+
+&lt;PropertyGroup&gt;
+    &lt;RuntimeFrameworkName&gt;{0}&lt;/RuntimeFrameworkName&gt;
+&lt;/PropertyGroup&gt;
+
+For more information, see {2}.
+    </target>
+        <note>{StrBegin="NETSDK1071: "}
+{0} - Package Id (AspNetCore.App or .All)
+{1} - Project name
+{2} - More info link
+    </note>
+      </trans-unit>
       <trans-unit id="AtLeastOneTargetFrameworkMustBeSpecified">
         <source>NETSDK1001: At least one possible target framework must be specified.</source>
         <target state="needs-review-translation">Je potřeba zadat alespoň jednu možnou cílovou platformu</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
@@ -3,16 +3,8 @@
   <file datatype="xml" source-language="en" target-language="cs" original="../Strings.resx">
     <body>
       <trans-unit id="AspNetCoreRequiresRuntimeFrameworkName">
-        <source>NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher. To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}. For more information, see {2}.
-&lt;PropertyGroup&gt;
-    &lt;RuntimeFrameworkName&gt;{0}&lt;/RuntimeFrameworkName&gt;
-&lt;/PropertyGroup&gt;
-    </source>
-        <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher. To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}. For more information, see {2}.
-&lt;PropertyGroup&gt;
-    &lt;RuntimeFrameworkName&gt;{0}&lt;/RuntimeFrameworkName&gt;
-&lt;/PropertyGroup&gt;
-    </target>
+        <source>NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher. To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}. For more information, see {2}.</source>
+        <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher. To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}. For more information, see {2}.</target>
         <note>{StrBegin="NETSDK1071: "}
 {0} - Package Id (AspNetCore.App or .All)
 {1} - Project name

--- a/src/Tasks/Common/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.de.xlf
@@ -3,23 +3,15 @@
   <file datatype="xml" source-language="en" target-language="de" original="../Strings.resx">
     <body>
       <trans-unit id="AspNetCoreRequiresRuntimeFrameworkName">
-        <source>NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher.
-To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}.
-
+        <source>NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher. To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}. For more information, see {2}.
 &lt;PropertyGroup&gt;
     &lt;RuntimeFrameworkName&gt;{0}&lt;/RuntimeFrameworkName&gt;
 &lt;/PropertyGroup&gt;
-
-For more information, see {2}.
     </source>
-        <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher.
-To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}.
-
+        <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher. To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}. For more information, see {2}.
 &lt;PropertyGroup&gt;
     &lt;RuntimeFrameworkName&gt;{0}&lt;/RuntimeFrameworkName&gt;
 &lt;/PropertyGroup&gt;
-
-For more information, see {2}.
     </target>
         <note>{StrBegin="NETSDK1071: "}
 {0} - Package Id (AspNetCore.App or .All)

--- a/src/Tasks/Common/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.de.xlf
@@ -2,6 +2,31 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../Strings.resx">
     <body>
+      <trans-unit id="AspNetCoreRequiresRuntimeFrameworkName">
+        <source>NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher.
+To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}.
+
+&lt;PropertyGroup&gt;
+    &lt;RuntimeFrameworkName&gt;{0}&lt;/RuntimeFrameworkName&gt;
+&lt;/PropertyGroup&gt;
+
+For more information, see {2}.
+    </source>
+        <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher.
+To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}.
+
+&lt;PropertyGroup&gt;
+    &lt;RuntimeFrameworkName&gt;{0}&lt;/RuntimeFrameworkName&gt;
+&lt;/PropertyGroup&gt;
+
+For more information, see {2}.
+    </target>
+        <note>{StrBegin="NETSDK1071: "}
+{0} - Package Id (AspNetCore.App or .All)
+{1} - Project name
+{2} - More info link
+    </note>
+      </trans-unit>
       <trans-unit id="AtLeastOneTargetFrameworkMustBeSpecified">
         <source>NETSDK1001: At least one possible target framework must be specified.</source>
         <target state="needs-review-translation">Geben Sie mindestens ein mögliches Zielframework an.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.de.xlf
@@ -112,6 +112,11 @@
         <target state="needs-review-translation">Ungültige NuGet-Versionszeichenfolge: {0}.</target>
         <note>{StrBegin="NETSDK1018: "}</note>
       </trans-unit>
+      <trans-unit id="UnrecognizedRuntimeFrameworkName">
+        <source>NETSDK1070: This project uses an unsupported value for RuntimeFrameworkName. Currently, only valid values are: Microsoft.NETCore.App, Microsoft.AspNetCore.App, or Microsoft.AspNetCore.All.</source>
+        <target state="new">NETSDK1070: This project uses an unsupported value for RuntimeFrameworkName. Currently, only valid values are: Microsoft.NETCore.App, Microsoft.AspNetCore.App, or Microsoft.AspNetCore.All.</target>
+        <note>{StrBegin="NETSDK1070: "}</note>
+      </trans-unit>
       <trans-unit id="UnsupportedFramework">
         <source>NETSDK1019: {0} is an unsupported framework.</source>
         <target state="needs-review-translation">{0} ist ein nicht unterstütztes Framework.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.de.xlf
@@ -3,16 +3,8 @@
   <file datatype="xml" source-language="en" target-language="de" original="../Strings.resx">
     <body>
       <trans-unit id="AspNetCoreRequiresRuntimeFrameworkName">
-        <source>NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher. To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}. For more information, see {2}.
-&lt;PropertyGroup&gt;
-    &lt;RuntimeFrameworkName&gt;{0}&lt;/RuntimeFrameworkName&gt;
-&lt;/PropertyGroup&gt;
-    </source>
-        <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher. To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}. For more information, see {2}.
-&lt;PropertyGroup&gt;
-    &lt;RuntimeFrameworkName&gt;{0}&lt;/RuntimeFrameworkName&gt;
-&lt;/PropertyGroup&gt;
-    </target>
+        <source>NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher. To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}. For more information, see {2}.</source>
+        <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher. To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}. For more information, see {2}.</target>
         <note>{StrBegin="NETSDK1071: "}
 {0} - Package Id (AspNetCore.App or .All)
 {1} - Project name

--- a/src/Tasks/Common/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.es.xlf
@@ -2,6 +2,31 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../Strings.resx">
     <body>
+      <trans-unit id="AspNetCoreRequiresRuntimeFrameworkName">
+        <source>NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher.
+To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}.
+
+&lt;PropertyGroup&gt;
+    &lt;RuntimeFrameworkName&gt;{0}&lt;/RuntimeFrameworkName&gt;
+&lt;/PropertyGroup&gt;
+
+For more information, see {2}.
+    </source>
+        <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher.
+To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}.
+
+&lt;PropertyGroup&gt;
+    &lt;RuntimeFrameworkName&gt;{0}&lt;/RuntimeFrameworkName&gt;
+&lt;/PropertyGroup&gt;
+
+For more information, see {2}.
+    </target>
+        <note>{StrBegin="NETSDK1071: "}
+{0} - Package Id (AspNetCore.App or .All)
+{1} - Project name
+{2} - More info link
+    </note>
+      </trans-unit>
       <trans-unit id="AtLeastOneTargetFrameworkMustBeSpecified">
         <source>NETSDK1001: At least one possible target framework must be specified.</source>
         <target state="needs-review-translation">Debe especificarse al menos una plataforma de destino posible.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.es.xlf
@@ -3,23 +3,15 @@
   <file datatype="xml" source-language="en" target-language="es" original="../Strings.resx">
     <body>
       <trans-unit id="AspNetCoreRequiresRuntimeFrameworkName">
-        <source>NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher.
-To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}.
-
+        <source>NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher. To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}. For more information, see {2}.
 &lt;PropertyGroup&gt;
     &lt;RuntimeFrameworkName&gt;{0}&lt;/RuntimeFrameworkName&gt;
 &lt;/PropertyGroup&gt;
-
-For more information, see {2}.
     </source>
-        <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher.
-To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}.
-
+        <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher. To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}. For more information, see {2}.
 &lt;PropertyGroup&gt;
     &lt;RuntimeFrameworkName&gt;{0}&lt;/RuntimeFrameworkName&gt;
 &lt;/PropertyGroup&gt;
-
-For more information, see {2}.
     </target>
         <note>{StrBegin="NETSDK1071: "}
 {0} - Package Id (AspNetCore.App or .All)

--- a/src/Tasks/Common/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.es.xlf
@@ -3,16 +3,8 @@
   <file datatype="xml" source-language="en" target-language="es" original="../Strings.resx">
     <body>
       <trans-unit id="AspNetCoreRequiresRuntimeFrameworkName">
-        <source>NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher. To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}. For more information, see {2}.
-&lt;PropertyGroup&gt;
-    &lt;RuntimeFrameworkName&gt;{0}&lt;/RuntimeFrameworkName&gt;
-&lt;/PropertyGroup&gt;
-    </source>
-        <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher. To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}. For more information, see {2}.
-&lt;PropertyGroup&gt;
-    &lt;RuntimeFrameworkName&gt;{0}&lt;/RuntimeFrameworkName&gt;
-&lt;/PropertyGroup&gt;
-    </target>
+        <source>NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher. To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}. For more information, see {2}.</source>
+        <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher. To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}. For more information, see {2}.</target>
         <note>{StrBegin="NETSDK1071: "}
 {0} - Package Id (AspNetCore.App or .All)
 {1} - Project name

--- a/src/Tasks/Common/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.es.xlf
@@ -112,6 +112,11 @@
         <target state="needs-review-translation">Cadena de versión de NuGet no válida: "{0}".</target>
         <note>{StrBegin="NETSDK1018: "}</note>
       </trans-unit>
+      <trans-unit id="UnrecognizedRuntimeFrameworkName">
+        <source>NETSDK1070: This project uses an unsupported value for RuntimeFrameworkName. Currently, only valid values are: Microsoft.NETCore.App, Microsoft.AspNetCore.App, or Microsoft.AspNetCore.All.</source>
+        <target state="new">NETSDK1070: This project uses an unsupported value for RuntimeFrameworkName. Currently, only valid values are: Microsoft.NETCore.App, Microsoft.AspNetCore.App, or Microsoft.AspNetCore.All.</target>
+        <note>{StrBegin="NETSDK1070: "}</note>
+      </trans-unit>
       <trans-unit id="UnsupportedFramework">
         <source>NETSDK1019: {0} is an unsupported framework.</source>
         <target state="needs-review-translation">{0} es una plataforma no compatible.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
@@ -112,6 +112,11 @@
         <target state="needs-review-translation">Chaîne de version NuGet non valide : '{0}'.</target>
         <note>{StrBegin="NETSDK1018: "}</note>
       </trans-unit>
+      <trans-unit id="UnrecognizedRuntimeFrameworkName">
+        <source>NETSDK1070: This project uses an unsupported value for RuntimeFrameworkName. Currently, only valid values are: Microsoft.NETCore.App, Microsoft.AspNetCore.App, or Microsoft.AspNetCore.All.</source>
+        <target state="new">NETSDK1070: This project uses an unsupported value for RuntimeFrameworkName. Currently, only valid values are: Microsoft.NETCore.App, Microsoft.AspNetCore.App, or Microsoft.AspNetCore.All.</target>
+        <note>{StrBegin="NETSDK1070: "}</note>
+      </trans-unit>
       <trans-unit id="UnsupportedFramework">
         <source>NETSDK1019: {0} is an unsupported framework.</source>
         <target state="needs-review-translation">{0} est un framework non pris en charge.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
@@ -3,16 +3,8 @@
   <file datatype="xml" source-language="en" target-language="fr" original="../Strings.resx">
     <body>
       <trans-unit id="AspNetCoreRequiresRuntimeFrameworkName">
-        <source>NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher. To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}. For more information, see {2}.
-&lt;PropertyGroup&gt;
-    &lt;RuntimeFrameworkName&gt;{0}&lt;/RuntimeFrameworkName&gt;
-&lt;/PropertyGroup&gt;
-    </source>
-        <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher. To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}. For more information, see {2}.
-&lt;PropertyGroup&gt;
-    &lt;RuntimeFrameworkName&gt;{0}&lt;/RuntimeFrameworkName&gt;
-&lt;/PropertyGroup&gt;
-    </target>
+        <source>NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher. To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}. For more information, see {2}.</source>
+        <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher. To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}. For more information, see {2}.</target>
         <note>{StrBegin="NETSDK1071: "}
 {0} - Package Id (AspNetCore.App or .All)
 {1} - Project name

--- a/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
@@ -2,6 +2,31 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../Strings.resx">
     <body>
+      <trans-unit id="AspNetCoreRequiresRuntimeFrameworkName">
+        <source>NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher.
+To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}.
+
+&lt;PropertyGroup&gt;
+    &lt;RuntimeFrameworkName&gt;{0}&lt;/RuntimeFrameworkName&gt;
+&lt;/PropertyGroup&gt;
+
+For more information, see {2}.
+    </source>
+        <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher.
+To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}.
+
+&lt;PropertyGroup&gt;
+    &lt;RuntimeFrameworkName&gt;{0}&lt;/RuntimeFrameworkName&gt;
+&lt;/PropertyGroup&gt;
+
+For more information, see {2}.
+    </target>
+        <note>{StrBegin="NETSDK1071: "}
+{0} - Package Id (AspNetCore.App or .All)
+{1} - Project name
+{2} - More info link
+    </note>
+      </trans-unit>
       <trans-unit id="AtLeastOneTargetFrameworkMustBeSpecified">
         <source>NETSDK1001: At least one possible target framework must be specified.</source>
         <target state="needs-review-translation">Au moins un framework cible doit être spécifié.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
@@ -3,23 +3,15 @@
   <file datatype="xml" source-language="en" target-language="fr" original="../Strings.resx">
     <body>
       <trans-unit id="AspNetCoreRequiresRuntimeFrameworkName">
-        <source>NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher.
-To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}.
-
+        <source>NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher. To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}. For more information, see {2}.
 &lt;PropertyGroup&gt;
     &lt;RuntimeFrameworkName&gt;{0}&lt;/RuntimeFrameworkName&gt;
 &lt;/PropertyGroup&gt;
-
-For more information, see {2}.
     </source>
-        <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher.
-To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}.
-
+        <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher. To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}. For more information, see {2}.
 &lt;PropertyGroup&gt;
     &lt;RuntimeFrameworkName&gt;{0}&lt;/RuntimeFrameworkName&gt;
 &lt;/PropertyGroup&gt;
-
-For more information, see {2}.
     </target>
         <note>{StrBegin="NETSDK1071: "}
 {0} - Package Id (AspNetCore.App or .All)

--- a/src/Tasks/Common/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.it.xlf
@@ -3,16 +3,8 @@
   <file datatype="xml" source-language="en" target-language="it" original="../Strings.resx">
     <body>
       <trans-unit id="AspNetCoreRequiresRuntimeFrameworkName">
-        <source>NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher. To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}. For more information, see {2}.
-&lt;PropertyGroup&gt;
-    &lt;RuntimeFrameworkName&gt;{0}&lt;/RuntimeFrameworkName&gt;
-&lt;/PropertyGroup&gt;
-    </source>
-        <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher. To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}. For more information, see {2}.
-&lt;PropertyGroup&gt;
-    &lt;RuntimeFrameworkName&gt;{0}&lt;/RuntimeFrameworkName&gt;
-&lt;/PropertyGroup&gt;
-    </target>
+        <source>NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher. To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}. For more information, see {2}.</source>
+        <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher. To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}. For more information, see {2}.</target>
         <note>{StrBegin="NETSDK1071: "}
 {0} - Package Id (AspNetCore.App or .All)
 {1} - Project name

--- a/src/Tasks/Common/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.it.xlf
@@ -2,6 +2,31 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../Strings.resx">
     <body>
+      <trans-unit id="AspNetCoreRequiresRuntimeFrameworkName">
+        <source>NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher.
+To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}.
+
+&lt;PropertyGroup&gt;
+    &lt;RuntimeFrameworkName&gt;{0}&lt;/RuntimeFrameworkName&gt;
+&lt;/PropertyGroup&gt;
+
+For more information, see {2}.
+    </source>
+        <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher.
+To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}.
+
+&lt;PropertyGroup&gt;
+    &lt;RuntimeFrameworkName&gt;{0}&lt;/RuntimeFrameworkName&gt;
+&lt;/PropertyGroup&gt;
+
+For more information, see {2}.
+    </target>
+        <note>{StrBegin="NETSDK1071: "}
+{0} - Package Id (AspNetCore.App or .All)
+{1} - Project name
+{2} - More info link
+    </note>
+      </trans-unit>
       <trans-unit id="AtLeastOneTargetFrameworkMustBeSpecified">
         <source>NETSDK1001: At least one possible target framework must be specified.</source>
         <target state="needs-review-translation">È necessario specificare almeno un framework di destinazione possibile.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.it.xlf
@@ -112,6 +112,11 @@
         <target state="needs-review-translation">La stringa di versione '{0}' di NuGet non è valida.</target>
         <note>{StrBegin="NETSDK1018: "}</note>
       </trans-unit>
+      <trans-unit id="UnrecognizedRuntimeFrameworkName">
+        <source>NETSDK1070: This project uses an unsupported value for RuntimeFrameworkName. Currently, only valid values are: Microsoft.NETCore.App, Microsoft.AspNetCore.App, or Microsoft.AspNetCore.All.</source>
+        <target state="new">NETSDK1070: This project uses an unsupported value for RuntimeFrameworkName. Currently, only valid values are: Microsoft.NETCore.App, Microsoft.AspNetCore.App, or Microsoft.AspNetCore.All.</target>
+        <note>{StrBegin="NETSDK1070: "}</note>
+      </trans-unit>
       <trans-unit id="UnsupportedFramework">
         <source>NETSDK1019: {0} is an unsupported framework.</source>
         <target state="needs-review-translation">{0} è un framework non supportato.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.it.xlf
@@ -3,23 +3,15 @@
   <file datatype="xml" source-language="en" target-language="it" original="../Strings.resx">
     <body>
       <trans-unit id="AspNetCoreRequiresRuntimeFrameworkName">
-        <source>NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher.
-To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}.
-
+        <source>NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher. To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}. For more information, see {2}.
 &lt;PropertyGroup&gt;
     &lt;RuntimeFrameworkName&gt;{0}&lt;/RuntimeFrameworkName&gt;
 &lt;/PropertyGroup&gt;
-
-For more information, see {2}.
     </source>
-        <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher.
-To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}.
-
+        <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher. To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}. For more information, see {2}.
 &lt;PropertyGroup&gt;
     &lt;RuntimeFrameworkName&gt;{0}&lt;/RuntimeFrameworkName&gt;
 &lt;/PropertyGroup&gt;
-
-For more information, see {2}.
     </target>
         <note>{StrBegin="NETSDK1071: "}
 {0} - Package Id (AspNetCore.App or .All)

--- a/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
@@ -2,6 +2,31 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../Strings.resx">
     <body>
+      <trans-unit id="AspNetCoreRequiresRuntimeFrameworkName">
+        <source>NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher.
+To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}.
+
+&lt;PropertyGroup&gt;
+    &lt;RuntimeFrameworkName&gt;{0}&lt;/RuntimeFrameworkName&gt;
+&lt;/PropertyGroup&gt;
+
+For more information, see {2}.
+    </source>
+        <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher.
+To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}.
+
+&lt;PropertyGroup&gt;
+    &lt;RuntimeFrameworkName&gt;{0}&lt;/RuntimeFrameworkName&gt;
+&lt;/PropertyGroup&gt;
+
+For more information, see {2}.
+    </target>
+        <note>{StrBegin="NETSDK1071: "}
+{0} - Package Id (AspNetCore.App or .All)
+{1} - Project name
+{2} - More info link
+    </note>
+      </trans-unit>
       <trans-unit id="AtLeastOneTargetFrameworkMustBeSpecified">
         <source>NETSDK1001: At least one possible target framework must be specified.</source>
         <target state="needs-review-translation">可能性のあるターゲット フレームワークを少なくとも 1 つ指定する必要があります。</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
@@ -2,24 +2,21 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../Strings.resx">
     <body>
+      <trans-unit id="AppHostHasBeenModified">
+        <source>NETSDK1029: Unable to use '{0}' as application host executable as it does not contain the expected placeholder byte sequence '{1}' that would mark where the application name would be written.</source>
+        <target state="new">NETSDK1029: Unable to use '{0}' as application host executable as it does not contain the expected placeholder byte sequence '{1}' that would mark where the application name would be written.</target>
+        <note>{StrBegin="NETSDK1029: "}</note>
+      </trans-unit>
       <trans-unit id="AspNetCoreRequiresRuntimeFrameworkName">
-        <source>NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher.
-To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}.
-
+        <source>NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher. To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}. For more information, see {2}.
 &lt;PropertyGroup&gt;
     &lt;RuntimeFrameworkName&gt;{0}&lt;/RuntimeFrameworkName&gt;
 &lt;/PropertyGroup&gt;
-
-For more information, see {2}.
     </source>
-        <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher.
-To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}.
-
+        <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher. To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}. For more information, see {2}.
 &lt;PropertyGroup&gt;
     &lt;RuntimeFrameworkName&gt;{0}&lt;/RuntimeFrameworkName&gt;
 &lt;/PropertyGroup&gt;
-
-For more information, see {2}.
     </target>
         <note>{StrBegin="NETSDK1071: "}
 {0} - Package Id (AspNetCore.App or .All)
@@ -27,10 +24,65 @@ For more information, see {2}.
 {2} - More info link
     </note>
       </trans-unit>
+      <trans-unit id="AssetPreprocessorMustBeConfigured">
+        <source>NETSDK1017: Asset preprocessor must be configured before assets are processed.</source>
+        <target state="new">NETSDK1017: Asset preprocessor must be configured before assets are processed.</target>
+        <note>{StrBegin="NETSDK1017: "}</note>
+      </trans-unit>
+      <trans-unit id="AssetsFileMissingRuntimeIdentifier">
+        <source>NETSDK1047: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project. You may also need to include '{3}' in your project's RuntimeIdentifiers.</source>
+        <target state="new">NETSDK1047: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project. You may also need to include '{3}' in your project's RuntimeIdentifiers.</target>
+        <note>{StrBegin="NETSDK1047: "}</note>
+      </trans-unit>
+      <trans-unit id="AssetsFileMissingTarget">
+        <source>NETSDK1005: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project.</source>
+        <target state="new">NETSDK1005: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project.</target>
+        <note>{StrBegin="NETSDK1005: "}</note>
+      </trans-unit>
+      <trans-unit id="AssetsFileNotFound">
+        <source>NETSDK1004: Assets file '{0}' not found. Run a NuGet package restore to generate this file.</source>
+        <target state="new">NETSDK1004: Assets file '{0}' not found. Run a NuGet package restore to generate this file.</target>
+        <note>{StrBegin="NETSDK1004: "}</note>
+      </trans-unit>
+      <trans-unit id="AssetsFileNotSet">
+        <source>NETSDK1063: The path to the project assets file was not set. Run a NuGet package restore to generate this file.</source>
+        <target state="new">NETSDK1063: The path to the project assets file was not set. Run a NuGet package restore to generate this file.</target>
+        <note>{StrBegin="NETSDK1063: "}</note>
+      </trans-unit>
+      <trans-unit id="AssetsFilePathNotRooted">
+        <source>NETSDK1006: Assets file path '{0}' is not rooted. Only full paths are supported.</source>
+        <target state="new">NETSDK1006: Assets file path '{0}' is not rooted. Only full paths are supported.</target>
+        <note>{StrBegin="NETSDK1006: "}</note>
+      </trans-unit>
       <trans-unit id="AtLeastOneTargetFrameworkMustBeSpecified">
         <source>NETSDK1001: At least one possible target framework must be specified.</source>
-        <target state="needs-review-translation">可能性のあるターゲット フレームワークを少なくとも 1 つ指定する必要があります。</target>
+        <target state="new">NETSDK1001: At least one possible target framework must be specified.</target>
         <note>{StrBegin="NETSDK1001: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotFindApphostForRid">
+        <source>NETSDK1065: Cannot find app host for {0}. {0} could be an invalid runtime identifier (RID). For more information about RID, see https://aka.ms/rid-catalog.</source>
+        <target state="new">NETSDK1065: Cannot find app host for {0}. {0} could be an invalid runtime identifier (RID). For more information about RID, see https://aka.ms/rid-catalog.</target>
+        <note>{StrBegin="NETSDK1065: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotFindProjectInfo">
+        <source>NETSDK1007: Cannot find project info for '{0}'. This can indicate a missing project reference.</source>
+        <target state="new">NETSDK1007: Cannot find project info for '{0}'. This can indicate a missing project reference.</target>
+        <note>{StrBegin="NETSDK1007: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotHaveRuntimeIdentifierPlatformMismatchPlatformTarget">
+        <source>NETSDK1032: The RuntimeIdentifier platform '{0}' and the PlatformTarget '{1}' must be compatible.</source>
+        <target state="new">NETSDK1032: The RuntimeIdentifier platform '{0}' and the PlatformTarget '{1}' must be compatible.</target>
+        <note>{StrBegin="NETSDK1032: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotHaveSelfContainedWithoutRuntimeIdentifier">
+        <source>NETSDK1031: It is not supported to build or publish a self-contained application without specifying a RuntimeIdentifier.  Please either specify a RuntimeIdentifier or set SelfContained to false.</source>
+        <target state="new">NETSDK1031: It is not supported to build or publish a self-contained application without specifying a RuntimeIdentifier.  Please either specify a RuntimeIdentifier or set SelfContained to false.</target>
+        <note>{StrBegin="NETSDK1031: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotInferTargetFrameworkIdentiferAndVersion">
+        <source>NETSDK1013: The TargetFramework value '{0}' was not recognized. It may be misspelled. If not, then the TargetFrameworkIdentifier and/or TargetFrameworkVersion properties must be specified explicitly.</source>
+        <target state="new">NETSDK1013: The TargetFramework value '{0}' was not recognized. It may be misspelled. If not, then the TargetFrameworkIdentifier and/or TargetFrameworkVersion properties must be specified explicitly.</target>
+        <note>{StrBegin="NETSDK1013: "}</note>
       </trans-unit>
       <trans-unit id="CannotUseAppHostWithoutRuntimeIdentifier">
         <source>NETSDK1066: A RuntimeIdentifier must be specified to publish a framework-dependent application with an application host.</source>
@@ -42,10 +94,174 @@ For more information, see {2}.
         <target state="new">NETSDK1067: Self-contained applications are required to use the application host. Either set SelfContained to false or set UseAppHost to true.</target>
         <note>{StrBegin="NETSDK1067: "}</note>
       </trans-unit>
+      <trans-unit id="ChoosingAssemblyVersion">
+        <source>NETSDK1033: Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</source>
+        <target state="new">NETSDK1033: Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</target>
+        <note>{StrBegin="NETSDK1033: "}</note>
+      </trans-unit>
+      <trans-unit id="ChoosingFileVersion">
+        <source>NETSDK1034: Choosing '{0}' because file version '{1}' is greater than '{2}'.</source>
+        <target state="new">NETSDK1034: Choosing '{0}' because file version '{1}' is greater than '{2}'.</target>
+        <note>{StrBegin="NETSDK1034: "}</note>
+      </trans-unit>
+      <trans-unit id="ChoosingPlatformItem">
+        <source>NETSDK1035: Choosing '{0}' because it is a platform item.</source>
+        <target state="new">NETSDK1035: Choosing '{0}' because it is a platform item.</target>
+        <note>{StrBegin="NETSDK1035: "}</note>
+      </trans-unit>
+      <trans-unit id="ChoosingPreferredPackage">
+        <source>NETSDK1036: Choosing '{0}' because it comes from a package that is preferred.</source>
+        <target state="new">NETSDK1036: Choosing '{0}' because it comes from a package that is preferred.</target>
+        <note>{StrBegin="NETSDK1036: "}</note>
+      </trans-unit>
+      <trans-unit id="ConflictCouldNotDetermineWinner">
+        <source>NETSDK1037: Could not determine winner due to equal file and assembly versions.</source>
+        <target state="new">NETSDK1037: Could not determine winner due to equal file and assembly versions.</target>
+        <note>{StrBegin="NETSDK1037: "}</note>
+      </trans-unit>
+      <trans-unit id="ContentItemDoesNotProvideOutputPath">
+        <source>NETSDK1014: Content item for '{0}' sets '{1}', but does not provide  '{2}' or '{3}'.</source>
+        <target state="new">NETSDK1014: Content item for '{0}' sets '{1}', but does not provide  '{2}' or '{3}'.</target>
+        <note>{StrBegin="NETSDK1014: "}</note>
+      </trans-unit>
+      <trans-unit id="ContentPreproccessorParameterRequired">
+        <source>NETSDK1010: The '{0}' task must be given a value for parameter '{1}' in order to consume preprocessed content.</source>
+        <target state="new">NETSDK1010: The '{0}' task must be given a value for parameter '{1}' in order to consume preprocessed content.</target>
+        <note>{StrBegin="NETSDK1010: "}</note>
+      </trans-unit>
+      <trans-unit id="CouldNotDetermineWinner_DoesntExist">
+        <source>NETSDK1038: Could not determine winner because '{0}' does not exist.</source>
+        <target state="new">NETSDK1038: Could not determine winner because '{0}' does not exist.</target>
+        <note>{StrBegin="NETSDK1001: "}</note>
+      </trans-unit>
+      <trans-unit id="CouldNotDetermineWinner_FileVersion">
+        <source>NETSDK1039: Could not determine a winner because '{0}' has no file version.</source>
+        <target state="new">NETSDK1039: Could not determine a winner because '{0}' has no file version.</target>
+        <note>{StrBegin="NETSDK1039: "}</note>
+      </trans-unit>
+      <trans-unit id="CouldNotDetermineWinner_NotAnAssembly">
+        <source>NETSDK1040: Could not determine a winner because '{0}' is not an assembly.</source>
+        <target state="new">NETSDK1040: Could not determine a winner because '{0}' is not an assembly.</target>
+        <note>{StrBegin="NETSDK1040: "}</note>
+      </trans-unit>
+      <trans-unit id="CouldNotLoadPlatformManifest">
+        <source>NETSDK1042: Could not load PlatformManifest from '{0}' because it did not exist.</source>
+        <target state="new">NETSDK1042: Could not load PlatformManifest from '{0}' because it did not exist.</target>
+        <note>{StrBegin="NETSDK1042: "}</note>
+      </trans-unit>
+      <trans-unit id="DotnetToolDoesNotSupportTFMLowerThanNetcoreapp21">
+        <source>NETSDK1055: DotnetTool does not support target framework lower than netcoreapp2.1.</source>
+        <target state="new">NETSDK1055: DotnetTool does not support target framework lower than netcoreapp2.1.</target>
+        <note>{StrBegin="NETSDK1055: "}</note>
+      </trans-unit>
+      <trans-unit id="DotnetToolOnlySupportNetcoreapp">
+        <source>NETSDK1054: only supports .NET Core.</source>
+        <target state="new">NETSDK1054: only supports .NET Core.</target>
+        <note>{StrBegin="NETSDK1054: "}</note>
+      </trans-unit>
+      <trans-unit id="DuplicateItemsError">
+        <source>NETSDK1022: Duplicate '{0}' items were included. The .NET SDK includes '{0}' items from your project directory by default. You can either remove these items from your project file, or set the '{1}' property to '{2}' if you want to explicitly include them in your project file. For more information, see {4}. The duplicate items were: {3}</source>
+        <target state="new">NETSDK1022: Duplicate '{0}' items were included. The .NET SDK includes '{0}' items from your project directory by default. You can either remove these items from your project file, or set the '{1}' property to '{2}' if you want to explicitly include them in your project file. For more information, see {4}. The duplicate items were: {3}</target>
+        <note>{StrBegin="NETSDK1022: "}</note>
+      </trans-unit>
+      <trans-unit id="DuplicatePreprocessorToken">
+        <source>NETSDK1015: The preprocessor token '{0}' has been given more than one value. Choosing '{1}' as the value.</source>
+        <target state="new">NETSDK1015: The preprocessor token '{0}' has been given more than one value. Choosing '{1}' as the value.</target>
+        <note>{StrBegin="NETSDK1015: "}</note>
+      </trans-unit>
+      <trans-unit id="EncounteredConflict">
+        <source>NETSDK1041: Encountered conflict between '{0}' and '{1}'.</source>
+        <target state="new">NETSDK1041: Encountered conflict between '{0}' and '{1}'.</target>
+        <note>{StrBegin="NETSDK1041: "}</note>
+      </trans-unit>
+      <trans-unit id="ErrorParsingFrameworkListInvalidValue">
+        <source>NETSDK1051: Error parsing FrameworkList from '{0}'.  {1} '{2}' was invalid.</source>
+        <target state="new">NETSDK1051: Error parsing FrameworkList from '{0}'.  {1} '{2}' was invalid.</target>
+        <note>{StrBegin="NETSDK1051: "}</note>
+      </trans-unit>
+      <trans-unit id="ErrorParsingPlatformManifest">
+        <source>NETSDK1043: Error parsing PlatformManifest from '{0}' line {1}.  Lines must have the format {2}.</source>
+        <target state="new">NETSDK1043: Error parsing PlatformManifest from '{0}' line {1}.  Lines must have the format {2}.</target>
+        <note>{StrBegin="NETSDK1043: "}</note>
+      </trans-unit>
+      <trans-unit id="ErrorParsingPlatformManifestInvalidValue">
+        <source>NETSDK1044: Error parsing PlatformManifest from '{0}' line {1}.  {2} '{3}' was invalid.</source>
+        <target state="new">NETSDK1044: Error parsing PlatformManifest from '{0}' line {1}.  {2} '{3}' was invalid.</target>
+        <note>{StrBegin="NETSDK1044: "}</note>
+      </trans-unit>
+      <trans-unit id="ErrorReadingAssetsFile">
+        <source>NETSDK1060: Error reading assets file: {0}</source>
+        <target state="new">NETSDK1060: Error reading assets file: {0}</target>
+        <note>{StrBegin="NETSDK1060: "}</note>
+      </trans-unit>
+      <trans-unit id="FileNameIsTooLong">
+        <source>NETSDK1030: Given file name '{0}' is longer than 1024 bytes</source>
+        <target state="new">NETSDK1030: Given file name '{0}' is longer than 1024 bytes</target>
+        <note>{StrBegin="NETSDK1030: "}</note>
+      </trans-unit>
+      <trans-unit id="FolderAlreadyExists">
+        <source>NETSDK1024: Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</source>
+        <target state="new">NETSDK1024: Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</target>
+        <note>{StrBegin="NETSDK1024: "}</note>
+      </trans-unit>
       <trans-unit id="FrameworkDependentAppHostRequiresVersion21">
         <source>NETSDK1068: The framework-dependent application host requires a target framework of at least 'netcoreapp2.1'.</source>
         <target state="new">NETSDK1068: The framework-dependent application host requires a target framework of at least 'netcoreapp2.1'.</target>
         <note>{StrBegin="NETSDK1068: "}</note>
+      </trans-unit>
+      <trans-unit id="FrameworkListPathNotRooted">
+        <source>NETSDK1052: Framework list file path '{0}' is not rooted. Only full paths are supported.</source>
+        <target state="new">NETSDK1052: Framework list file path '{0}' is not rooted. Only full paths are supported.</target>
+        <note>{StrBegin="NETSDK1052: "}</note>
+      </trans-unit>
+      <trans-unit id="GetDependsOnNETStandardFailedWithException">
+        <source>NETSDK1049: Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0} {1}</source>
+        <target state="new">NETSDK1049: Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0} {1}</target>
+        <note>{StrBegin="NETSDK1049: "}</note>
+      </trans-unit>
+      <trans-unit id="IncorrectPackageRoot">
+        <source>NETSDK1020: Package Root {0} was incorrectly given for Resolved library {1}</source>
+        <target state="new">NETSDK1020: Package Root {0} was incorrectly given for Resolved library {1}</target>
+        <note>{StrBegin="NETSDK1020: "}</note>
+      </trans-unit>
+      <trans-unit id="IncorrectTargetFormat">
+        <source>NETSDK1025: WRThe target manifest {0} provided is of not the correct format</source>
+        <target state="new">NETSDK1025: WRThe target manifest {0} provided is of not the correct format</target>
+        <note>{StrBegin="NETSDK1025: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidFrameworkName">
+        <source>NETSDK1003: Invalid framework name: '{0}'.</source>
+        <target state="new">NETSDK1003: Invalid framework name: '{0}'.</target>
+        <note>{StrBegin="NETSDK1003: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidItemSpecToUse">
+        <source>NETSDK1058: Invalid value for ItemSpecToUse parameter: '{0}'.  This property must be blank or set to 'Left' or 'Right'</source>
+        <target state="new">NETSDK1058: Invalid value for ItemSpecToUse parameter: '{0}'.  This property must be blank or set to 'Left' or 'Right'</target>
+        <note>{StrBegin="NETSDK1058: "}
+The following are names of parameters or literal values and should not be translated: ItemSpecToUse, Left, Right</note>
+      </trans-unit>
+      <trans-unit id="InvalidNuGetVersionString">
+        <source>NETSDK1018: Invalid NuGet version string: '{0}'.</source>
+        <target state="new">NETSDK1018: Invalid NuGet version string: '{0}'.</target>
+        <note>{StrBegin="NETSDK1018: "}</note>
+      </trans-unit>
+      <trans-unit id="MismatchedPlatformPackageVersion">
+        <source>NETSDK1061: The project was restored using {0} version {1}, but with current settings, version {2} would be used instead. To resolve this issue, make sure the same settings are used for restore and for subsequent operations such as build or publish. Typically this issue can occur if the RuntimeIdentifier property is set during build or publish but not during restore. For more information, see https://aka.ms/dotnet-runtime-patch-selection.</source>
+        <target state="new">NETSDK1061: The project was restored using {0} version {1}, but with current settings, version {2} would be used instead. To resolve this issue, make sure the same settings are used for restore and for subsequent operations such as build or publish. Typically this issue can occur if the RuntimeIdentifier property is set during build or publish but not during restore. For more information, see https://aka.ms/dotnet-runtime-patch-selection.</target>
+        <note>{StrBegin="NETSDK1061: "}
+{0} - Package Identifier for platform package
+{1} - Restored version of platform package
+{2} - Current version of platform package</note>
+      </trans-unit>
+      <trans-unit id="MissingItemMetadata">
+        <source>NETSDK1008: Missing '{0}' metadata on '{1}' item '{2}'.</source>
+        <target state="new">NETSDK1008: Missing '{0}' metadata on '{1}' item '{2}'.</target>
+        <note>{StrBegin="NETSDK1008: "}</note>
+      </trans-unit>
+      <trans-unit id="MultipleFilesResolved">
+        <source>NETSDK1021: More than one file found for {0}</source>
+        <target state="new">NETSDK1021: More than one file found for {0}</target>
+        <note>{StrBegin="NETSDK1021: "}</note>
       </trans-unit>
       <trans-unit id="NETFrameworkToNonBuiltInNETStandard">
         <source>NETSDK1069: This project uses a library that targets .NET Standard 1.5 or higher, and the project targets a version of .NET Framework that doesn't have built-in support for that version of .NET Standard. Visit https://aka.ms/net-standard-known-issues for a set of known issues. Consider retargeting to .NET Framework 4.7.2.</source>
@@ -54,88 +270,78 @@ For more information, see {2}.
       </trans-unit>
       <trans-unit id="NoCompatibleTargetFramework">
         <source>NETSDK1002: Project '{0}' targets '{2}'. It cannot be referenced by a project that targets '{1}'.</source>
-        <target state="needs-review-translation">プロジェクト '{0}' は、'{2}' を対象としています。'{1}' を対象とするプロジェクトは、これを参照できません。</target>
+        <target state="new">NETSDK1002: Project '{0}' targets '{2}'. It cannot be referenced by a project that targets '{1}'.</target>
         <note>{StrBegin="NETSDK1002: "}</note>
       </trans-unit>
-      <trans-unit id="InvalidFrameworkName">
-        <source>NETSDK1003: Invalid framework name: '{0}'.</source>
-        <target state="needs-review-translation">無効なフレームワーク名: '{0}'。</target>
-        <note>{StrBegin="NETSDK1003: "}</note>
+      <trans-unit id="PackAsToolCannotSupportSelfContained">
+        <source>NETSDK1053: Pack as tool does not support self contained.</source>
+        <target state="new">NETSDK1053: Pack as tool does not support self contained.</target>
+        <note>{StrBegin="NETSDK1001: "}</note>
       </trans-unit>
-      <trans-unit id="AssetsFileNotFound">
-        <source>NETSDK1004: Assets file '{0}' not found. Run a NuGet package restore to generate this file.</source>
-        <target state="needs-review-translation">資産ファイル '{0}' が見つかりません。NuGet パッケージの復元を実行して、このファイルを生成してください。</target>
-        <note>{StrBegin="NETSDK1004: "}</note>
+      <trans-unit id="PackageInfoLog">
+        <source>NETSDK1027: Package Name='{0}', Version='{1}' was parsed</source>
+        <target state="new">NETSDK1027: Package Name='{0}', Version='{1}' was parsed</target>
+        <note>{StrBegin="NETSDK1027: "}</note>
       </trans-unit>
-      <trans-unit id="AssetsFileMissingTarget">
-        <source>NETSDK1005: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project.</source>
-        <target state="needs-review-translation">資産ファイル '{0}' に '{1}' のターゲットがありません。復元が実行されたこと、および '{2}' がプロジェクトの TargetFrameworks に含まれていることを確認してください。</target>
-        <note>{StrBegin="NETSDK1005: "}</note>
+      <trans-unit id="PackageNotFound">
+        <source>NETSDK1064: Package {0}, version {1} was not found. It might have been deleted since NuGet restore. Otherwise, NuGet restore might have only partially completed, which might have been due to maximum path length restrictions.</source>
+        <target state="new">NETSDK1064: Package {0}, version {1} was not found. It might have been deleted since NuGet restore. Otherwise, NuGet restore might have only partially completed, which might have been due to maximum path length restrictions.</target>
+        <note>{StrBegin="NETSDK1064: "}</note>
       </trans-unit>
-      <trans-unit id="AssetsFilePathNotRooted">
-        <source>NETSDK1006: Assets file path '{0}' is not rooted. Only full paths are supported.</source>
-        <target state="needs-review-translation">資産ファイル パス '{0}' にルートが指定されていません。完全パスのみがサポートされます。</target>
-        <note>{StrBegin="NETSDK1006: "}</note>
+      <trans-unit id="PackageReferenceOverrideWarning">
+        <source>NETSDK1023: A PackageReference for '{0}' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see {1}</source>
+        <target state="new">NETSDK1023: A PackageReference for '{0}' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see {1}</target>
+        <note>{StrBegin="NETSDK1023: "}</note>
       </trans-unit>
-      <trans-unit id="CannotFindProjectInfo">
-        <source>NETSDK1007: Cannot find project info for '{0}'. This can indicate a missing project reference.</source>
-        <target state="needs-review-translation">'{0}' のプロジェクト情報が見つかりません。これは、プロジェクト参照がないことを示している可能性があります。</target>
-        <note>{StrBegin="NETSDK1007: "}</note>
-      </trans-unit>
-      <trans-unit id="MissingItemMetadata">
-        <source>NETSDK1008: Missing '{0}' metadata on '{1}' item '{2}'.</source>
-        <target state="needs-review-translation">'{1}' 項目 '{2}' の '{0}' メタデータがありません。</target>
-        <note>{StrBegin="NETSDK1008: "}</note>
-      </trans-unit>
-      <trans-unit id="UnrecognizedPreprocessorToken">
-        <source>NETSDK1009: Unrecognized preprocessor token '{0}' in '{1}'.</source>
-        <target state="needs-review-translation">認識されないプリプロセッサ トークン '{0}' が '{1}' に存在します。</target>
-        <note>{StrBegin="NETSDK1009: "}</note>
-      </trans-unit>
-      <trans-unit id="ContentPreproccessorParameterRequired">
-        <source>NETSDK1010: The '{0}' task must be given a value for parameter '{1}' in order to consume preprocessed content.</source>
-        <target state="needs-review-translation">前処理されたコンテンツを使用するためには、パラメーター '{1}' の値を '{0}' タスクに指定する必要があります。</target>
-        <note>{StrBegin="NETSDK1010: "}</note>
+      <trans-unit id="ParsingFiles">
+        <source>NETSDK1026: Parsing the Files : '{0}'</source>
+        <target state="new">NETSDK1026: Parsing the Files : '{0}'</target>
+        <note>{StrBegin="NETSDK1026: "}</note>
       </trans-unit>
       <trans-unit id="ProjectAssetsConsumedWithoutMSBuildProjectPath">
         <source>NETSDK1011: Assets are consumed from project '{0}', but no corresponding MSBuild project path was  found in '{1}'.</source>
-        <target state="needs-review-translation">プロジェクト '{0}' の資産が使用されますが、対応する MSBuild プロジェクト パスが '{1}' で見つかりませんでした。</target>
+        <target state="new">NETSDK1011: Assets are consumed from project '{0}', but no corresponding MSBuild project path was  found in '{1}'.</target>
         <note>{StrBegin="NETSDK1011: "}</note>
       </trans-unit>
-      <trans-unit id="UnexpectedFileType">
-        <source>NETSDK1012: Unexpected file type for '{0}'. Type is both '{1}' and '{2}'.</source>
-        <target state="needs-review-translation">'{0}' のファイルの種類が正しくありません。種類は '{1}' と '{2}' の両方です。</target>
-        <note>{StrBegin="NETSDK1012: "}</note>
+      <trans-unit id="ProjectContainsObsoleteDotNetCliTool">
+        <source>NETSDK1059: The tool '{0}' is now included in the .NET Core SDK. Information on resolving this warning is available at (https://aka.ms/dotnetclitools-in-box).</source>
+        <target state="new">NETSDK1059: The tool '{0}' is now included in the .NET Core SDK. Information on resolving this warning is available at (https://aka.ms/dotnetclitools-in-box).</target>
+        <note>{StrBegin="NETSDK1059: "}</note>
       </trans-unit>
-      <trans-unit id="CannotInferTargetFrameworkIdentiferAndVersion">
-        <source>NETSDK1013: The TargetFramework value '{0}' was not recognized. It may be misspelled. If not, then the TargetFrameworkIdentifier and/or TargetFrameworkVersion properties must be specified explicitly.</source>
-        <target state="needs-review-translation">TargetFramework 値 '{0}' が認識されませんでした。つづりが間違っている可能性があります。間違っていない場合は、TargetFrameworkIdentifier または TargetFrameworkVersion properties (あるいはその両方) を明示的に指定する必要があります。</target>
-        <note>{StrBegin="NETSDK1013: "}</note>
+      <trans-unit id="RuntimeIdentifierWasNotSpecified">
+        <source>NETSDK1028: Specify a RuntimeIdentifier</source>
+        <target state="new">NETSDK1028: Specify a RuntimeIdentifier</target>
+        <note>{StrBegin="NETSDK1028: "}</note>
       </trans-unit>
-      <trans-unit id="ContentItemDoesNotProvideOutputPath">
-        <source>NETSDK1014: Content item for '{0}' sets '{1}', but does not provide  '{2}' or '{3}'.</source>
-        <target state="needs-review-translation">'{0}' のコンテンツ項目で '{1}' が設定されますが、'{2}' または '{3}' は指定されません。</target>
-        <note>{StrBegin="NETSDK1014: "}</note>
+      <trans-unit id="SkippingAdditionalProbingPaths">
+        <source>NETSDK1048: 'AdditionalProbingPaths' were specified for GenerateRuntimeConfigurationFiles, but are being skipped because 'RuntimeConfigDevPath' is empty.</source>
+        <target state="new">NETSDK1048: 'AdditionalProbingPaths' were specified for GenerateRuntimeConfigurationFiles, but are being skipped because 'RuntimeConfigDevPath' is empty.</target>
+        <note>{StrBegin="NETSDK1048: "}</note>
       </trans-unit>
-      <trans-unit id="DuplicatePreprocessorToken">
-        <source>NETSDK1015: The preprocessor token '{0}' has been given more than one value. Choosing '{1}' as the value.</source>
-        <target state="needs-review-translation">プリプロセッサ トークン '{0}' に複数の値が指定されています。値として '{1}' を選択します。</target>
-        <note>{StrBegin="NETSDK1015: "}</note>
+      <trans-unit id="TargetFrameworkWithSemicolon">
+        <source>NETSDK1046: The TargetFramework value '{0}' is not valid. To multi-target, use the 'TargetFrameworks' property instead.</source>
+        <target state="new">NETSDK1046: The TargetFramework value '{0}' is not valid. To multi-target, use the 'TargetFrameworks' property instead.</target>
+        <note>{StrBegin="NETSDK1046: "}</note>
       </trans-unit>
       <trans-unit id="UnableToFindResolvedPath">
         <source>NETSDK1016: Unable to find resolved path for '{0}'.</source>
-        <target state="needs-review-translation">解決された '{0}' のパスが見つかりません。</target>
+        <target state="new">NETSDK1016: Unable to find resolved path for '{0}'.</target>
         <note>{StrBegin="NETSDK1016: "}</note>
       </trans-unit>
-      <trans-unit id="AssetPreprocessorMustBeConfigured">
-        <source>NETSDK1017: Asset preprocessor must be configured before assets are processed.</source>
-        <target state="needs-review-translation">資産を処理する前に、資産プリプロセッサを構成する必要があります。</target>
-        <note>{StrBegin="NETSDK1017: "}</note>
+      <trans-unit id="UnableToUsePackageAssetsCache">
+        <source>NETSDK1062: Unable to use package assets cache due to I/O error. This can occur when the same project is built more than once in parallel. Performance may be degraded, but the build result will not be impacted.</source>
+        <target state="new">NETSDK1062: Unable to use package assets cache due to I/O error. This can occur when the same project is built more than once in parallel. Performance may be degraded, but the build result will not be impacted.</target>
+        <note>{StrBegin="NETSDK1062: "}</note>
       </trans-unit>
-      <trans-unit id="InvalidNuGetVersionString">
-        <source>NETSDK1018: Invalid NuGet version string: '{0}'.</source>
-        <target state="needs-review-translation">無効な NuGet バージョン文字列: '{0}'。</target>
-        <note>{StrBegin="NETSDK1018: "}</note>
+      <trans-unit id="UnexpectedFileType">
+        <source>NETSDK1012: Unexpected file type for '{0}'. Type is both '{1}' and '{2}'.</source>
+        <target state="new">NETSDK1012: Unexpected file type for '{0}'. Type is both '{1}' and '{2}'.</target>
+        <note>{StrBegin="NETSDK1012: "}</note>
+      </trans-unit>
+      <trans-unit id="UnrecognizedPreprocessorToken">
+        <source>NETSDK1009: Unrecognized preprocessor token '{0}' in '{1}'.</source>
+        <target state="new">NETSDK1009: Unrecognized preprocessor token '{0}' in '{1}'.</target>
+        <note>{StrBegin="NETSDK1009: "}</note>
       </trans-unit>
       <trans-unit id="UnrecognizedRuntimeFrameworkName">
         <source>NETSDK1070: This project uses an unsupported value for RuntimeFrameworkName. Currently, only valid values are: Microsoft.NETCore.App, Microsoft.AspNetCore.App, or Microsoft.AspNetCore.All.</source>
@@ -144,242 +350,28 @@ For more information, see {2}.
       </trans-unit>
       <trans-unit id="UnsupportedFramework">
         <source>NETSDK1019: {0} is an unsupported framework.</source>
-        <target state="needs-review-translation">{0} は、サポートされていないフレームワークです。</target>
+        <target state="new">NETSDK1019: {0} is an unsupported framework.</target>
         <note>{StrBegin="NETSDK1019: "}</note>
-      </trans-unit>
-      <trans-unit id="DuplicateItemsError">
-        <source>NETSDK1022: Duplicate '{0}' items were included. The .NET SDK includes '{0}' items from your project directory by default. You can either remove these items from your project file, or set the '{1}' property to '{2}' if you want to explicitly include them in your project file. For more information, see {4}. The duplicate items were: {3}</source>
-        <target state="needs-review-translation">重複する '{0}' 個のアイテムが含められました。.NET SDK には、既定でプロジェクト ディレクトリからのアイテムが '{0}' 個含まれています。これらのアイテムをプロジェクト ファイルから削除するか、'{1}' プロパティを '{2}' に設定してプロジェクト ファイルに明示的に含めることができます。詳細については、{4} を参照してください。重複するアイテムは、{3} でした。</target>
-        <note>{StrBegin="NETSDK1022: "}</note>
-      </trans-unit>
-      <trans-unit id="PackageReferenceOverrideWarning">
-        <source>NETSDK1023: A PackageReference for '{0}' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see {1}</source>
-        <target state="needs-review-translation">'{0}' の PackageReference がプロジェクトに含められました。このパッケージは .NET SDK によって暗黙的に参照されるため、通常はプロジェクトから参照する必要がありません。詳細については、{1} をご覧ください。</target>
-        <note>{StrBegin="NETSDK1023: "}</note>
-      </trans-unit>
-      <trans-unit id="IncorrectPackageRoot">
-        <source>NETSDK1020: Package Root {0} was incorrectly given for Resolved library {1}</source>
-        <target state="needs-review-translation">解決されたライブラリ {1} に対して指定されたパッケージ ルート {0} が正しくありません。</target>
-        <note>{StrBegin="NETSDK1020: "}</note>
-      </trans-unit>
-      <trans-unit id="MultipleFilesResolved">
-        <source>NETSDK1021: More than one file found for {0}</source>
-        <target state="needs-review-translation">{0} で複数のファイルが見つかりました。</target>
-        <note>{StrBegin="NETSDK1021: "}</note>
-      </trans-unit>
-      <trans-unit id="FolderAlreadyExists">
-        <source>NETSDK1024: Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</source>
-        <target state="needs-review-translation">フォルダー '{0}' が既に存在します。そのフォルダーを削除するか、別の ComposeWorkingDir を指定してください。</target>
-        <note>{StrBegin="NETSDK1024: "}</note>
-      </trans-unit>
-      <trans-unit id="ParsingFiles">
-        <source>NETSDK1026: Parsing the Files : '{0}'</source>
-        <target state="needs-review-translation">次のファイルを解析しています: '{0}'</target>
-        <note>{StrBegin="NETSDK1026: "}</note>
-      </trans-unit>
-      <trans-unit id="PackageInfoLog">
-        <source>NETSDK1027: Package Name='{0}', Version='{1}' was parsed</source>
-        <target state="needs-review-translation">パッケージ名='{0}'、バージョン='{1}' が解析されました</target>
-        <note>{StrBegin="NETSDK1027: "}</note>
-      </trans-unit>
-      <trans-unit id="RuntimeIdentifierWasNotSpecified">
-        <source>NETSDK1028: Specify a RuntimeIdentifier</source>
-        <target state="needs-review-translation">RuntimeIdentifier の指定</target>
-        <note>{StrBegin="NETSDK1028: "}</note>
-      </trans-unit>
-      <trans-unit id="IncorrectTargetFormat">
-        <source>NETSDK1025: WRThe target manifest {0} provided is of not the correct format</source>
-        <target state="needs-review-translation">指定されたターゲット マニフェスト {0} の形式が正しくありません</target>
-        <note>{StrBegin="NETSDK1025: "}</note>
-      </trans-unit>
-      <trans-unit id="AppHostHasBeenModified">
-        <source>NETSDK1029: Unable to use '{0}' as application host executable as it does not contain the expected placeholder byte sequence '{1}' that would mark where the application name would be written.</source>
-        <target state="needs-review-translation">'{0}' は、本来アプリケーション名が書き込まれる場所を示す、必要なプレースホルダー バイト シーケンス '{1}' が含まれていないため、実行可能アプリケーション ホストとして使用できません。</target>
-        <note>{StrBegin="NETSDK1029: "}</note>
-      </trans-unit>
-      <trans-unit id="FileNameIsTooLong">
-        <source>NETSDK1030: Given file name '{0}' is longer than 1024 bytes</source>
-        <target state="needs-review-translation">指定されたファイル名 '{0}' が 1024 バイトを超えています。</target>
-        <note>{StrBegin="NETSDK1030: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotHaveSelfContainedWithoutRuntimeIdentifier">
-        <source>NETSDK1031: It is not supported to build or publish a self-contained application without specifying a RuntimeIdentifier.  Please either specify a RuntimeIdentifier or set SelfContained to false.</source>
-        <target state="needs-review-translation">RuntimeIdentifier を指定せずに自己完結型アプリケーションをビルドおよび発行することはサポートされていません。RuntimeIdentifier を指定するか SelfContained を false に設定してください。</target>
-        <note>{StrBegin="NETSDK1031: "}</note>
-      </trans-unit>
-      <trans-unit id="ChoosingAssemblyVersion">
-        <source>NETSDK1033: Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</source>
-        <target state="needs-review-translation">AssemblyVersion '{1}' が '{2}' より大きいため、'{0}' を選択しています。</target>
-        <note>{StrBegin="NETSDK1033: "}</note>
-      </trans-unit>
-      <trans-unit id="ChoosingFileVersion">
-        <source>NETSDK1034: Choosing '{0}' because file version '{1}' is greater than '{2}'.</source>
-        <target state="needs-review-translation">ファイルのバージョン '{1}' が '{2}' より大きいため、'{0}' を選択しています。</target>
-        <note>{StrBegin="NETSDK1034: "}</note>
-      </trans-unit>
-      <trans-unit id="ChoosingPlatformItem">
-        <source>NETSDK1035: Choosing '{0}' because it is a platform item.</source>
-        <target state="needs-review-translation">'{0}' はプラットフォーム項目であるため、これを選択しています。</target>
-        <note>{StrBegin="NETSDK1035: "}</note>
-      </trans-unit>
-      <trans-unit id="ChoosingPreferredPackage">
-        <source>NETSDK1036: Choosing '{0}' because it comes from a package that is preferred.</source>
-        <target state="needs-review-translation">'{0}' は優先されるパッケージからのものであるため、これを選択しています。</target>
-        <note>{StrBegin="NETSDK1036: "}</note>
-      </trans-unit>
-      <trans-unit id="ConflictCouldNotDetermineWinner">
-        <source>NETSDK1037: Could not determine winner due to equal file and assembly versions.</source>
-        <target state="needs-review-translation">ファイルとアセンブリのバージョンが等しいため、勝者を判別できませんでした。</target>
-        <note>{StrBegin="NETSDK1037: "}</note>
-      </trans-unit>
-      <trans-unit id="CouldNotDetermineWinner_DoesntExist">
-        <source>NETSDK1038: Could not determine winner because '{0}' does not exist.</source>
-        <target state="needs-review-translation">'{0}' が存在しないため勝者を判別できませんでした。</target>
-        <note>{StrBegin="NETSDK1001: "}</note>
-      </trans-unit>
-      <trans-unit id="CouldNotDetermineWinner_FileVersion">
-        <source>NETSDK1039: Could not determine a winner because '{0}' has no file version.</source>
-        <target state="needs-review-translation">'{0}' にファイルのバージョンがないため勝者を判別できませんでした。</target>
-        <note>{StrBegin="NETSDK1039: "}</note>
-      </trans-unit>
-      <trans-unit id="CouldNotDetermineWinner_NotAnAssembly">
-        <source>NETSDK1040: Could not determine a winner because '{0}' is not an assembly.</source>
-        <target state="needs-review-translation">'{0}' がアセンブリでないため勝者を判別できませんでした。</target>
-        <note>{StrBegin="NETSDK1040: "}</note>
-      </trans-unit>
-      <trans-unit id="EncounteredConflict">
-        <source>NETSDK1041: Encountered conflict between '{0}' and '{1}'.</source>
-        <target state="needs-review-translation">'{0}' と '{1}' の間で競合が発生しました。</target>
-        <note>{StrBegin="NETSDK1041: "}</note>
-      </trans-unit>
-      <trans-unit id="CouldNotLoadPlatformManifest">
-        <source>NETSDK1042: Could not load PlatformManifest from '{0}' because it did not exist.</source>
-        <target state="needs-review-translation">存在しなかったため、'{0}' から PlatformManifest を読み込めませんでした。</target>
-        <note>{StrBegin="NETSDK1042: "}</note>
-      </trans-unit>
-      <trans-unit id="ErrorParsingPlatformManifest">
-        <source>NETSDK1043: Error parsing PlatformManifest from '{0}' line {1}.  Lines must have the format {2}.</source>
-        <target state="needs-review-translation">{0}' 行 {1} から PlatformManifest を解析できませんでした。行の形式は {2} である必要があります。</target>
-        <note>{StrBegin="NETSDK1043: "}</note>
-      </trans-unit>
-      <trans-unit id="ErrorParsingPlatformManifestInvalidValue">
-        <source>NETSDK1044: Error parsing PlatformManifest from '{0}' line {1}.  {2} '{3}' was invalid.</source>
-        <target state="needs-review-translation">{0}' 行 {1} から PlatformManifest を解析できませんでした。{2} '{3}' は無効でした。</target>
-        <note>{StrBegin="NETSDK1044: "}</note>
-      </trans-unit>
-      <trans-unit id="UnsupportedTargetFrameworkVersion">
-        <source>NETSDK1045: The current .NET SDK does not support targeting {0} {1}.  Either target {0} {2} or lower, or use a version of the .NET SDK that supports {0} {1}.</source>
-        <target state="needs-review-translation">現在の .NET SDK は、ターゲットとする {0} {1} をサポートしていません。{0} {2} 以下をターゲットとするか、{0} {1} をサポートする .NET SDK のバージョンを使用してください。</target>
-        <note>{StrBegin="NETSDK1045: "}</note>
-      </trans-unit>
-      <trans-unit id="AssetsFileMissingRuntimeIdentifier">
-        <source>NETSDK1047: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project. You may also need to include '{3}' in your project's RuntimeIdentifiers.</source>
-        <target state="needs-review-translation">資産ファイル '{0}' に '{1}' のターゲットがありません。復元が実行されたこと、および '{2}' がプロジェクトの TargetFrameworks に含まれていることを確認してください。プロジェクトの RuntimeIdentifiers に '{3}' を組み込む必要が生じる可能性もあります。</target>
-        <note>{StrBegin="NETSDK1047: "}</note>
-      </trans-unit>
-      <trans-unit id="TargetFrameworkWithSemicolon">
-        <source>NETSDK1046: The TargetFramework value '{0}' is not valid. To multi-target, use the 'TargetFrameworks' property instead.</source>
-        <target state="needs-review-translation">TargetFramework 値 '{0}' が無効です。複数をターゲットとするには、代わりに 'TargetFrameworks' プロパティを使用してください。</target>
-        <note>{StrBegin="NETSDK1046: "}</note>
-      </trans-unit>
-      <trans-unit id="SkippingAdditionalProbingPaths">
-        <source>NETSDK1048: 'AdditionalProbingPaths' were specified for GenerateRuntimeConfigurationFiles, but are being skipped because 'RuntimeConfigDevPath' is empty.</source>
-        <target state="needs-review-translation">'AdditionalProbingPaths' が GenerateRuntimeConfigurationFiles に指定されましたが、'RuntimeConfigDevPath' が空であるためスキップされます。</target>
-        <note>{StrBegin="NETSDK1048: "}</note>
-      </trans-unit>
-      <trans-unit id="GetDependsOnNETStandardFailedWithException">
-        <source>NETSDK1049: Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0} {1}</source>
-        <target state="needs-review-translation">解決されたファイルには、無効なイメージが含まれているか、メタデータが存在しないか、またはアクセスできません。{0} {1}</target>
-        <note>{StrBegin="NETSDK1049: "}</note>
-      </trans-unit>
-      <trans-unit id="UnsupportedSDKVersionForNetStandard20">
-        <source>NETSDK1050: The version of Microsoft.NET.Sdk used by this project is insufficient to support references to libraries targeting .NET Standard 1.5 or higher.  Please install version 2.0 or higher of the .NET Core SDK.</source>
-        <target state="needs-review-translation">このプロジェクトで使用される Microsoft.NET.Sdk のバージョンは、.NET Standard 1.5 以上を対象とするライブラリへの参照をサポートするには不十分です。.NET Core SDK のバージョン 2.0 以上をインストールしてください。</target>
-        <note>{StrBegin="NETSDK1050: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotHaveRuntimeIdentifierPlatformMismatchPlatformTarget">
-        <source>NETSDK1032: The RuntimeIdentifier platform '{0}' and the PlatformTarget '{1}' must be compatible.</source>
-        <target state="needs-review-translation">RuntimeIdentifier プラットフォーム '{0}' と PlatformTarget '{1}' には互換性が必要です。</target>
-        <note>{StrBegin="NETSDK1032: "}</note>
-      </trans-unit>
-      <trans-unit id="ErrorParsingFrameworkListInvalidValue">
-        <source>NETSDK1051: Error parsing FrameworkList from '{0}'.  {1} '{2}' was invalid.</source>
-        <target state="needs-review-translation">'{0}' からの FrameworkList の解析でエラーが発生しました。{1} '{2}' が無効でした。</target>
-        <note>{StrBegin="NETSDK1051: "}</note>
-      </trans-unit>
-      <trans-unit id="FrameworkListPathNotRooted">
-        <source>NETSDK1052: Framework list file path '{0}' is not rooted. Only full paths are supported.</source>
-        <target state="needs-review-translation">フレームワーク リスト ファイル パス '{0}' にルートが指定されていません。完全パスのみがサポートされています。</target>
-        <note>{StrBegin="NETSDK1052: "}</note>
-      </trans-unit>
-      <trans-unit id="PackAsToolCannotSupportSelfContained">
-        <source>NETSDK1053: Pack as tool does not support self contained.</source>
-        <target state="needs-review-translation">Pack As ツールは自己完結型をサポートしていません。</target>
-        <note>{StrBegin="NETSDK1001: "}</note>
       </trans-unit>
       <trans-unit id="UnsupportedRuntimeIdentifier">
         <source>NETSDK1056: Project is targeting runtime '{0}' but did not resolve any runtime-specific packages. This runtime may not be supported by the target framework.</source>
-        <target state="needs-review-translation">プロジェクトはランタイム '{0}' をターゲットとしていますが、ランタイム固有のパッケージを解決しませんでした。このランタイムはターゲットのフレームワークでサポートされていない可能性があります。</target>
+        <target state="new">NETSDK1056: Project is targeting runtime '{0}' but did not resolve any runtime-specific packages. This runtime may not be supported by the target framework.</target>
         <note>{StrBegin="NETSDK1056: "}</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedSDKVersionForNetStandard20">
+        <source>NETSDK1050: The version of Microsoft.NET.Sdk used by this project is insufficient to support references to libraries targeting .NET Standard 1.5 or higher.  Please install version 2.0 or higher of the .NET Core SDK.</source>
+        <target state="new">NETSDK1050: The version of Microsoft.NET.Sdk used by this project is insufficient to support references to libraries targeting .NET Standard 1.5 or higher.  Please install version 2.0 or higher of the .NET Core SDK.</target>
+        <note>{StrBegin="NETSDK1050: "}</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedTargetFrameworkVersion">
+        <source>NETSDK1045: The current .NET SDK does not support targeting {0} {1}.  Either target {0} {2} or lower, or use a version of the .NET SDK that supports {0} {1}.</source>
+        <target state="new">NETSDK1045: The current .NET SDK does not support targeting {0} {1}.  Either target {0} {2} or lower, or use a version of the .NET SDK that supports {0} {1}.</target>
+        <note>{StrBegin="NETSDK1045: "}</note>
       </trans-unit>
       <trans-unit id="UsingPreviewSdkWarning">
         <source>NETSDK1057: You are working with a preview version of the .NET Core SDK. You can define the SDK version via a global.json file in the current project. More at https://go.microsoft.com/fwlink/?linkid=869452</source>
-        <target state="needs-review-translation">.NET Core SDK のプレビュー バージョンで作業をしています。現在のプロジェクトの global.json ファイルによって SDK バージョンを定義できます。詳細については、https://go.microsoft.com/fwlink/?linkid=869452 をご覧ください</target>
+        <target state="new">NETSDK1057: You are working with a preview version of the .NET Core SDK. You can define the SDK version via a global.json file in the current project. More at https://go.microsoft.com/fwlink/?linkid=869452</target>
         <note>{StrBegin="NETSDK1057: "}</note>
-      </trans-unit>
-      <trans-unit id="InvalidItemSpecToUse">
-        <source>NETSDK1058: Invalid value for ItemSpecToUse parameter: '{0}'.  This property must be blank or set to 'Left' or 'Right'</source>
-        <target state="needs-review-translation">ItemSpecToUse パラメーターの値が無効です: '{0}'。このプロパティは空白にするか、'Left' または 'Right' に設定する必要があります</target>
-        <note>{StrBegin="NETSDK1058: "}
-The following are names of parameters or literal values and should not be translated: ItemSpecToUse, Left, Right</note>
-      </trans-unit>
-      <trans-unit id="ProjectContainsObsoleteDotNetCliTool">
-        <source>NETSDK1059: The tool '{0}' is now included in the .NET Core SDK. Information on resolving this warning is available at (https://aka.ms/dotnetclitools-in-box).</source>
-        <target state="needs-review-translation">DotNetCliToolReference を使用して '{0}' を参照するのは古い方法であるため、このプロジェクトから削除できます。既定で、このツールは .NET Core SDK にバンドルされています。</target>
-        <note>{StrBegin="NETSDK1059: "}</note>
-      </trans-unit>
-      <trans-unit id="ErrorReadingAssetsFile">
-        <source>NETSDK1060: Error reading assets file: {0}</source>
-        <target state="needs-review-translation">アセット ファイルの読み取りでエラーが発生しました: {0}</target>
-        <note>{StrBegin="NETSDK1060: "}</note>
-      </trans-unit>
-      <trans-unit id="MismatchedPlatformPackageVersion">
-        <source>NETSDK1061: The project was restored using {0} version {1}, but with current settings, version {2} would be used instead. To resolve this issue, make sure the same settings are used for restore and for subsequent operations such as build or publish. Typically this issue can occur if the RuntimeIdentifier property is set during build or publish but not during restore. For more information, see https://aka.ms/dotnet-runtime-patch-selection.</source>
-        <target state="needs-review-translation">プロジェクトは {0} バージョン {1} を使用して復元されましたが、現在の設定ではバージョン {2} を使用すべきところでした。この問題を解決するには、復元と後続の操作 (ビルドや発行など) で確実に同じ設定を使用するようにしてください。通常、この問題は、RuntimeIdentifier プロパティがビルドまたは発行の際に設定されたものの、復元の際には設定されなかったことで生じます。</target>
-        <note>{StrBegin="NETSDK1061: "}
-{0} - Package Identifier for platform package
-{1} - Restored version of platform package
-{2} - Current version of platform package</note>
-      </trans-unit>
-      <trans-unit id="AssetsFileNotSet">
-        <source>NETSDK1063: The path to the project assets file was not set. Run a NuGet package restore to generate this file.</source>
-        <target state="needs-review-translation">プロジェクト資産ファイルのパスが設定されていません。NuGet パッケージの復元を実行して、このファイルを生成してください。</target>
-        <note>{StrBegin="NETSDK1063: "}</note>
-      </trans-unit>
-      <trans-unit id="DotnetToolOnlySupportNetcoreapp">
-        <source>NETSDK1054: only supports .NET Core.</source>
-        <target state="needs-review-translation">.NET Core のみがサポートされています。</target>
-        <note>{StrBegin="NETSDK1054: "}</note>
-      </trans-unit>
-      <trans-unit id="DotnetToolDoesNotSupportTFMLowerThanNetcoreapp21">
-        <source>NETSDK1055: DotnetTool does not support target framework lower than netcoreapp2.1.</source>
-        <target state="needs-review-translation">DotnetTool は、netcoreapp2.1 未満のターゲット フレームワークをサポートしていません。</target>
-        <note>{StrBegin="NETSDK1055: "}</note>
-      </trans-unit>
-      <trans-unit id="UnableToUsePackageAssetsCache">
-        <source>NETSDK1062: Unable to use package assets cache due to I/O error. This can occur when the same project is built more than once in parallel. Performance may be degraded, but the build result will not be impacted.</source>
-        <target state="needs-review-translation">I/O エラーのため、パッケージ資産のキャッシュを使用できません。これは、同じプロジェクトが同時に複数回ビルドされるときに発生することがあります。パフォーマンスが低下する可能性がありますが、ビルドの結果には影響はありません。</target>
-        <note>{StrBegin="NETSDK1062: "}</note>
-      </trans-unit>
-      <trans-unit id="PackageNotFound">
-        <source>NETSDK1064: Package {0}, version {1} was not found. It might have been deleted since NuGet restore. Otherwise, NuGet restore might have only partially completed, which might have been due to maximum path length restrictions.</source>
-        <target state="new">NETSDK1064: Package {0}, version {1} was not found. It might have been deleted since NuGet restore. Otherwise, NuGet restore might have only partially completed, which might have been due to maximum path length restrictions.</target>
-        <note>{StrBegin="NETSDK1064: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotFindApphostForRid">
-        <source>NETSDK1065: Cannot find app host for {0}. {0} could be an invalid runtime identifier (RID). For more information about RID, see https://aka.ms/rid-catalog.</source>
-        <target state="new">NETSDK1065: Cannot find app host for {0}. {0} could be an invalid runtime identifier (RID). For more information about RID, see https://aka.ms/rid-catalog.</target>
-        <note>{StrBegin="NETSDK1065: "}</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
@@ -8,16 +8,8 @@
         <note>{StrBegin="NETSDK1029: "}</note>
       </trans-unit>
       <trans-unit id="AspNetCoreRequiresRuntimeFrameworkName">
-        <source>NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher. To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}. For more information, see {2}.
-&lt;PropertyGroup&gt;
-    &lt;RuntimeFrameworkName&gt;{0}&lt;/RuntimeFrameworkName&gt;
-&lt;/PropertyGroup&gt;
-    </source>
-        <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher. To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}. For more information, see {2}.
-&lt;PropertyGroup&gt;
-    &lt;RuntimeFrameworkName&gt;{0}&lt;/RuntimeFrameworkName&gt;
-&lt;/PropertyGroup&gt;
-    </target>
+        <source>NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher. To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}. For more information, see {2}.</source>
+        <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher. To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}. For more information, see {2}.</target>
         <note>{StrBegin="NETSDK1071: "}
 {0} - Package Id (AspNetCore.App or .All)
 {1} - Project name

--- a/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
@@ -112,6 +112,11 @@
         <target state="needs-review-translation">無効な NuGet バージョン文字列: '{0}'。</target>
         <note>{StrBegin="NETSDK1018: "}</note>
       </trans-unit>
+      <trans-unit id="UnrecognizedRuntimeFrameworkName">
+        <source>NETSDK1070: This project uses an unsupported value for RuntimeFrameworkName. Currently, only valid values are: Microsoft.NETCore.App, Microsoft.AspNetCore.App, or Microsoft.AspNetCore.All.</source>
+        <target state="new">NETSDK1070: This project uses an unsupported value for RuntimeFrameworkName. Currently, only valid values are: Microsoft.NETCore.App, Microsoft.AspNetCore.App, or Microsoft.AspNetCore.All.</target>
+        <note>{StrBegin="NETSDK1070: "}</note>
+      </trans-unit>
       <trans-unit id="UnsupportedFramework">
         <source>NETSDK1019: {0} is an unsupported framework.</source>
         <target state="needs-review-translation">{0} は、サポートされていないフレームワークです。</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
@@ -3,16 +3,8 @@
   <file datatype="xml" source-language="en" target-language="ko" original="../Strings.resx">
     <body>
       <trans-unit id="AspNetCoreRequiresRuntimeFrameworkName">
-        <source>NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher. To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}. For more information, see {2}.
-&lt;PropertyGroup&gt;
-    &lt;RuntimeFrameworkName&gt;{0}&lt;/RuntimeFrameworkName&gt;
-&lt;/PropertyGroup&gt;
-    </source>
-        <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher. To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}. For more information, see {2}.
-&lt;PropertyGroup&gt;
-    &lt;RuntimeFrameworkName&gt;{0}&lt;/RuntimeFrameworkName&gt;
-&lt;/PropertyGroup&gt;
-    </target>
+        <source>NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher. To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}. For more information, see {2}.</source>
+        <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher. To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}. For more information, see {2}.</target>
         <note>{StrBegin="NETSDK1071: "}
 {0} - Package Id (AspNetCore.App or .All)
 {1} - Project name

--- a/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
@@ -112,6 +112,11 @@
         <target state="needs-review-translation">NuGet 버전 문자열 '{0}'이(가) 잘못되었습니다.</target>
         <note>{StrBegin="NETSDK1018: "}</note>
       </trans-unit>
+      <trans-unit id="UnrecognizedRuntimeFrameworkName">
+        <source>NETSDK1070: This project uses an unsupported value for RuntimeFrameworkName. Currently, only valid values are: Microsoft.NETCore.App, Microsoft.AspNetCore.App, or Microsoft.AspNetCore.All.</source>
+        <target state="new">NETSDK1070: This project uses an unsupported value for RuntimeFrameworkName. Currently, only valid values are: Microsoft.NETCore.App, Microsoft.AspNetCore.App, or Microsoft.AspNetCore.All.</target>
+        <note>{StrBegin="NETSDK1070: "}</note>
+      </trans-unit>
       <trans-unit id="UnsupportedFramework">
         <source>NETSDK1019: {0} is an unsupported framework.</source>
         <target state="needs-review-translation">{0}은(는) 지원되지 않는 프레임워크입니다.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
@@ -3,23 +3,15 @@
   <file datatype="xml" source-language="en" target-language="ko" original="../Strings.resx">
     <body>
       <trans-unit id="AspNetCoreRequiresRuntimeFrameworkName">
-        <source>NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher.
-To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}.
-
+        <source>NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher. To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}. For more information, see {2}.
 &lt;PropertyGroup&gt;
     &lt;RuntimeFrameworkName&gt;{0}&lt;/RuntimeFrameworkName&gt;
 &lt;/PropertyGroup&gt;
-
-For more information, see {2}.
     </source>
-        <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher.
-To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}.
-
+        <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher. To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}. For more information, see {2}.
 &lt;PropertyGroup&gt;
     &lt;RuntimeFrameworkName&gt;{0}&lt;/RuntimeFrameworkName&gt;
 &lt;/PropertyGroup&gt;
-
-For more information, see {2}.
     </target>
         <note>{StrBegin="NETSDK1071: "}
 {0} - Package Id (AspNetCore.App or .All)

--- a/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
@@ -2,6 +2,31 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../Strings.resx">
     <body>
+      <trans-unit id="AspNetCoreRequiresRuntimeFrameworkName">
+        <source>NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher.
+To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}.
+
+&lt;PropertyGroup&gt;
+    &lt;RuntimeFrameworkName&gt;{0}&lt;/RuntimeFrameworkName&gt;
+&lt;/PropertyGroup&gt;
+
+For more information, see {2}.
+    </source>
+        <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher.
+To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}.
+
+&lt;PropertyGroup&gt;
+    &lt;RuntimeFrameworkName&gt;{0}&lt;/RuntimeFrameworkName&gt;
+&lt;/PropertyGroup&gt;
+
+For more information, see {2}.
+    </target>
+        <note>{StrBegin="NETSDK1071: "}
+{0} - Package Id (AspNetCore.App or .All)
+{1} - Project name
+{2} - More info link
+    </note>
+      </trans-unit>
       <trans-unit id="AtLeastOneTargetFrameworkMustBeSpecified">
         <source>NETSDK1001: At least one possible target framework must be specified.</source>
         <target state="needs-review-translation">가능한 대상 프레임워크를 하나 이상 지정해야 합니다.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
@@ -2,6 +2,31 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../Strings.resx">
     <body>
+      <trans-unit id="AspNetCoreRequiresRuntimeFrameworkName">
+        <source>NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher.
+To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}.
+
+&lt;PropertyGroup&gt;
+    &lt;RuntimeFrameworkName&gt;{0}&lt;/RuntimeFrameworkName&gt;
+&lt;/PropertyGroup&gt;
+
+For more information, see {2}.
+    </source>
+        <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher.
+To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}.
+
+&lt;PropertyGroup&gt;
+    &lt;RuntimeFrameworkName&gt;{0}&lt;/RuntimeFrameworkName&gt;
+&lt;/PropertyGroup&gt;
+
+For more information, see {2}.
+    </target>
+        <note>{StrBegin="NETSDK1071: "}
+{0} - Package Id (AspNetCore.App or .All)
+{1} - Project name
+{2} - More info link
+    </note>
+      </trans-unit>
       <trans-unit id="AtLeastOneTargetFrameworkMustBeSpecified">
         <source>NETSDK1001: At least one possible target framework must be specified.</source>
         <target state="needs-review-translation">Należy określić co najmniej jedną możliwą platformę docelową.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
@@ -112,6 +112,11 @@
         <target state="needs-review-translation">Nieprawidłowy ciąg wersji NuGet: „{0}”.</target>
         <note>{StrBegin="NETSDK1018: "}</note>
       </trans-unit>
+      <trans-unit id="UnrecognizedRuntimeFrameworkName">
+        <source>NETSDK1070: This project uses an unsupported value for RuntimeFrameworkName. Currently, only valid values are: Microsoft.NETCore.App, Microsoft.AspNetCore.App, or Microsoft.AspNetCore.All.</source>
+        <target state="new">NETSDK1070: This project uses an unsupported value for RuntimeFrameworkName. Currently, only valid values are: Microsoft.NETCore.App, Microsoft.AspNetCore.App, or Microsoft.AspNetCore.All.</target>
+        <note>{StrBegin="NETSDK1070: "}</note>
+      </trans-unit>
       <trans-unit id="UnsupportedFramework">
         <source>NETSDK1019: {0} is an unsupported framework.</source>
         <target state="needs-review-translation">{0} to nieobsługiwana platforma.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
@@ -3,23 +3,15 @@
   <file datatype="xml" source-language="en" target-language="pl" original="../Strings.resx">
     <body>
       <trans-unit id="AspNetCoreRequiresRuntimeFrameworkName">
-        <source>NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher.
-To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}.
-
+        <source>NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher. To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}. For more information, see {2}.
 &lt;PropertyGroup&gt;
     &lt;RuntimeFrameworkName&gt;{0}&lt;/RuntimeFrameworkName&gt;
 &lt;/PropertyGroup&gt;
-
-For more information, see {2}.
     </source>
-        <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher.
-To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}.
-
+        <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher. To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}. For more information, see {2}.
 &lt;PropertyGroup&gt;
     &lt;RuntimeFrameworkName&gt;{0}&lt;/RuntimeFrameworkName&gt;
 &lt;/PropertyGroup&gt;
-
-For more information, see {2}.
     </target>
         <note>{StrBegin="NETSDK1071: "}
 {0} - Package Id (AspNetCore.App or .All)

--- a/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
@@ -3,16 +3,8 @@
   <file datatype="xml" source-language="en" target-language="pl" original="../Strings.resx">
     <body>
       <trans-unit id="AspNetCoreRequiresRuntimeFrameworkName">
-        <source>NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher. To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}. For more information, see {2}.
-&lt;PropertyGroup&gt;
-    &lt;RuntimeFrameworkName&gt;{0}&lt;/RuntimeFrameworkName&gt;
-&lt;/PropertyGroup&gt;
-    </source>
-        <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher. To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}. For more information, see {2}.
-&lt;PropertyGroup&gt;
-    &lt;RuntimeFrameworkName&gt;{0}&lt;/RuntimeFrameworkName&gt;
-&lt;/PropertyGroup&gt;
-    </target>
+        <source>NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher. To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}. For more information, see {2}.</source>
+        <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher. To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}. For more information, see {2}.</target>
         <note>{StrBegin="NETSDK1071: "}
 {0} - Package Id (AspNetCore.App or .All)
 {1} - Project name

--- a/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
@@ -2,6 +2,31 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../Strings.resx">
     <body>
+      <trans-unit id="AspNetCoreRequiresRuntimeFrameworkName">
+        <source>NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher.
+To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}.
+
+&lt;PropertyGroup&gt;
+    &lt;RuntimeFrameworkName&gt;{0}&lt;/RuntimeFrameworkName&gt;
+&lt;/PropertyGroup&gt;
+
+For more information, see {2}.
+    </source>
+        <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher.
+To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}.
+
+&lt;PropertyGroup&gt;
+    &lt;RuntimeFrameworkName&gt;{0}&lt;/RuntimeFrameworkName&gt;
+&lt;/PropertyGroup&gt;
+
+For more information, see {2}.
+    </target>
+        <note>{StrBegin="NETSDK1071: "}
+{0} - Package Id (AspNetCore.App or .All)
+{1} - Project name
+{2} - More info link
+    </note>
+      </trans-unit>
       <trans-unit id="AtLeastOneTargetFrameworkMustBeSpecified">
         <source>NETSDK1001: At least one possible target framework must be specified.</source>
         <target state="needs-review-translation">É necessário especificar pelo menos uma estrutura de destino possível.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
@@ -3,16 +3,8 @@
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../Strings.resx">
     <body>
       <trans-unit id="AspNetCoreRequiresRuntimeFrameworkName">
-        <source>NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher. To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}. For more information, see {2}.
-&lt;PropertyGroup&gt;
-    &lt;RuntimeFrameworkName&gt;{0}&lt;/RuntimeFrameworkName&gt;
-&lt;/PropertyGroup&gt;
-    </source>
-        <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher. To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}. For more information, see {2}.
-&lt;PropertyGroup&gt;
-    &lt;RuntimeFrameworkName&gt;{0}&lt;/RuntimeFrameworkName&gt;
-&lt;/PropertyGroup&gt;
-    </target>
+        <source>NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher. To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}. For more information, see {2}.</source>
+        <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher. To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}. For more information, see {2}.</target>
         <note>{StrBegin="NETSDK1071: "}
 {0} - Package Id (AspNetCore.App or .All)
 {1} - Project name

--- a/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
@@ -112,6 +112,11 @@
         <target state="needs-review-translation">Cadeia de caracteres de versão do NuGet inválida: '{0}'.</target>
         <note>{StrBegin="NETSDK1018: "}</note>
       </trans-unit>
+      <trans-unit id="UnrecognizedRuntimeFrameworkName">
+        <source>NETSDK1070: This project uses an unsupported value for RuntimeFrameworkName. Currently, only valid values are: Microsoft.NETCore.App, Microsoft.AspNetCore.App, or Microsoft.AspNetCore.All.</source>
+        <target state="new">NETSDK1070: This project uses an unsupported value for RuntimeFrameworkName. Currently, only valid values are: Microsoft.NETCore.App, Microsoft.AspNetCore.App, or Microsoft.AspNetCore.All.</target>
+        <note>{StrBegin="NETSDK1070: "}</note>
+      </trans-unit>
       <trans-unit id="UnsupportedFramework">
         <source>NETSDK1019: {0} is an unsupported framework.</source>
         <target state="needs-review-translation">{0} é uma estrutura sem suporte.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
@@ -3,23 +3,15 @@
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../Strings.resx">
     <body>
       <trans-unit id="AspNetCoreRequiresRuntimeFrameworkName">
-        <source>NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher.
-To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}.
-
+        <source>NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher. To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}. For more information, see {2}.
 &lt;PropertyGroup&gt;
     &lt;RuntimeFrameworkName&gt;{0}&lt;/RuntimeFrameworkName&gt;
 &lt;/PropertyGroup&gt;
-
-For more information, see {2}.
     </source>
-        <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher.
-To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}.
-
+        <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher. To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}. For more information, see {2}.
 &lt;PropertyGroup&gt;
     &lt;RuntimeFrameworkName&gt;{0}&lt;/RuntimeFrameworkName&gt;
 &lt;/PropertyGroup&gt;
-
-For more information, see {2}.
     </target>
         <note>{StrBegin="NETSDK1071: "}
 {0} - Package Id (AspNetCore.App or .All)

--- a/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
@@ -3,23 +3,15 @@
   <file datatype="xml" source-language="en" target-language="ru" original="../Strings.resx">
     <body>
       <trans-unit id="AspNetCoreRequiresRuntimeFrameworkName">
-        <source>NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher.
-To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}.
-
+        <source>NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher. To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}. For more information, see {2}.
 &lt;PropertyGroup&gt;
     &lt;RuntimeFrameworkName&gt;{0}&lt;/RuntimeFrameworkName&gt;
 &lt;/PropertyGroup&gt;
-
-For more information, see {2}.
     </source>
-        <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher.
-To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}.
-
+        <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher. To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}. For more information, see {2}.
 &lt;PropertyGroup&gt;
     &lt;RuntimeFrameworkName&gt;{0}&lt;/RuntimeFrameworkName&gt;
 &lt;/PropertyGroup&gt;
-
-For more information, see {2}.
     </target>
         <note>{StrBegin="NETSDK1071: "}
 {0} - Package Id (AspNetCore.App or .All)

--- a/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
@@ -3,16 +3,8 @@
   <file datatype="xml" source-language="en" target-language="ru" original="../Strings.resx">
     <body>
       <trans-unit id="AspNetCoreRequiresRuntimeFrameworkName">
-        <source>NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher. To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}. For more information, see {2}.
-&lt;PropertyGroup&gt;
-    &lt;RuntimeFrameworkName&gt;{0}&lt;/RuntimeFrameworkName&gt;
-&lt;/PropertyGroup&gt;
-    </source>
-        <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher. To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}. For more information, see {2}.
-&lt;PropertyGroup&gt;
-    &lt;RuntimeFrameworkName&gt;{0}&lt;/RuntimeFrameworkName&gt;
-&lt;/PropertyGroup&gt;
-    </target>
+        <source>NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher. To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}. For more information, see {2}.</source>
+        <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher. To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}. For more information, see {2}.</target>
         <note>{StrBegin="NETSDK1071: "}
 {0} - Package Id (AspNetCore.App or .All)
 {1} - Project name

--- a/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
@@ -112,6 +112,11 @@
         <target state="needs-review-translation">Недопустимая строка версии Invalid NuGet: "{0}".</target>
         <note>{StrBegin="NETSDK1018: "}</note>
       </trans-unit>
+      <trans-unit id="UnrecognizedRuntimeFrameworkName">
+        <source>NETSDK1070: This project uses an unsupported value for RuntimeFrameworkName. Currently, only valid values are: Microsoft.NETCore.App, Microsoft.AspNetCore.App, or Microsoft.AspNetCore.All.</source>
+        <target state="new">NETSDK1070: This project uses an unsupported value for RuntimeFrameworkName. Currently, only valid values are: Microsoft.NETCore.App, Microsoft.AspNetCore.App, or Microsoft.AspNetCore.All.</target>
+        <note>{StrBegin="NETSDK1070: "}</note>
+      </trans-unit>
       <trans-unit id="UnsupportedFramework">
         <source>NETSDK1019: {0} is an unsupported framework.</source>
         <target state="needs-review-translation">Платформа {0} не поддерживается.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
@@ -2,6 +2,31 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../Strings.resx">
     <body>
+      <trans-unit id="AspNetCoreRequiresRuntimeFrameworkName">
+        <source>NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher.
+To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}.
+
+&lt;PropertyGroup&gt;
+    &lt;RuntimeFrameworkName&gt;{0}&lt;/RuntimeFrameworkName&gt;
+&lt;/PropertyGroup&gt;
+
+For more information, see {2}.
+    </source>
+        <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher.
+To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}.
+
+&lt;PropertyGroup&gt;
+    &lt;RuntimeFrameworkName&gt;{0}&lt;/RuntimeFrameworkName&gt;
+&lt;/PropertyGroup&gt;
+
+For more information, see {2}.
+    </target>
+        <note>{StrBegin="NETSDK1071: "}
+{0} - Package Id (AspNetCore.App or .All)
+{1} - Project name
+{2} - More info link
+    </note>
+      </trans-unit>
       <trans-unit id="AtLeastOneTargetFrameworkMustBeSpecified">
         <source>NETSDK1001: At least one possible target framework must be specified.</source>
         <target state="needs-review-translation">Необходимо указать хотя бы одну целевую платформу.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
@@ -112,6 +112,11 @@
         <target state="needs-review-translation">Geçersiz NuGet sürüm dizesi: '{0}'.</target>
         <note>{StrBegin="NETSDK1018: "}</note>
       </trans-unit>
+      <trans-unit id="UnrecognizedRuntimeFrameworkName">
+        <source>NETSDK1070: This project uses an unsupported value for RuntimeFrameworkName. Currently, only valid values are: Microsoft.NETCore.App, Microsoft.AspNetCore.App, or Microsoft.AspNetCore.All.</source>
+        <target state="new">NETSDK1070: This project uses an unsupported value for RuntimeFrameworkName. Currently, only valid values are: Microsoft.NETCore.App, Microsoft.AspNetCore.App, or Microsoft.AspNetCore.All.</target>
+        <note>{StrBegin="NETSDK1070: "}</note>
+      </trans-unit>
       <trans-unit id="UnsupportedFramework">
         <source>NETSDK1019: {0} is an unsupported framework.</source>
         <target state="needs-review-translation">{0} çerçevesi desteklenmiyor.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
@@ -8,16 +8,8 @@
         <note>{StrBegin="NETSDK1029: "}</note>
       </trans-unit>
       <trans-unit id="AspNetCoreRequiresRuntimeFrameworkName">
-        <source>NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher. To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}. For more information, see {2}.
-&lt;PropertyGroup&gt;
-    &lt;RuntimeFrameworkName&gt;{0}&lt;/RuntimeFrameworkName&gt;
-&lt;/PropertyGroup&gt;
-    </source>
-        <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher. To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}. For more information, see {2}.
-&lt;PropertyGroup&gt;
-    &lt;RuntimeFrameworkName&gt;{0}&lt;/RuntimeFrameworkName&gt;
-&lt;/PropertyGroup&gt;
-    </target>
+        <source>NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher. To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}. For more information, see {2}.</source>
+        <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher. To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}. For more information, see {2}.</target>
         <note>{StrBegin="NETSDK1071: "}
 {0} - Package Id (AspNetCore.App or .All)
 {1} - Project name

--- a/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
@@ -8,23 +8,15 @@
         <note>{StrBegin="NETSDK1029: "}</note>
       </trans-unit>
       <trans-unit id="AspNetCoreRequiresRuntimeFrameworkName">
-        <source>NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher.
-To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}.
-
+        <source>NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher. To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}. For more information, see {2}.
 &lt;PropertyGroup&gt;
     &lt;RuntimeFrameworkName&gt;{0}&lt;/RuntimeFrameworkName&gt;
 &lt;/PropertyGroup&gt;
-
-For more information, see {2}.
     </source>
-        <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher.
-To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}.
-
+        <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher. To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}. For more information, see {2}.
 &lt;PropertyGroup&gt;
     &lt;RuntimeFrameworkName&gt;{0}&lt;/RuntimeFrameworkName&gt;
 &lt;/PropertyGroup&gt;
-
-For more information, see {2}.
     </target>
         <note>{StrBegin="NETSDK1071: "}
 {0} - Package Id (AspNetCore.App or .All)

--- a/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
@@ -2,10 +2,95 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../Strings.resx">
     <body>
+      <trans-unit id="AppHostHasBeenModified">
+        <source>NETSDK1029: Unable to use '{0}' as application host executable as it does not contain the expected placeholder byte sequence '{1}' that would mark where the application name would be written.</source>
+        <target state="new">NETSDK1029: Unable to use '{0}' as application host executable as it does not contain the expected placeholder byte sequence '{1}' that would mark where the application name would be written.</target>
+        <note>{StrBegin="NETSDK1029: "}</note>
+      </trans-unit>
+      <trans-unit id="AspNetCoreRequiresRuntimeFrameworkName">
+        <source>NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher.
+To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}.
+
+&lt;PropertyGroup&gt;
+    &lt;RuntimeFrameworkName&gt;{0}&lt;/RuntimeFrameworkName&gt;
+&lt;/PropertyGroup&gt;
+
+For more information, see {2}.
+    </source>
+        <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher.
+To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}.
+
+&lt;PropertyGroup&gt;
+    &lt;RuntimeFrameworkName&gt;{0}&lt;/RuntimeFrameworkName&gt;
+&lt;/PropertyGroup&gt;
+
+For more information, see {2}.
+    </target>
+        <note>{StrBegin="NETSDK1071: "}
+{0} - Package Id (AspNetCore.App or .All)
+{1} - Project name
+{2} - More info link
+    </note>
+      </trans-unit>
+      <trans-unit id="AssetPreprocessorMustBeConfigured">
+        <source>NETSDK1017: Asset preprocessor must be configured before assets are processed.</source>
+        <target state="new">NETSDK1017: Asset preprocessor must be configured before assets are processed.</target>
+        <note>{StrBegin="NETSDK1017: "}</note>
+      </trans-unit>
+      <trans-unit id="AssetsFileMissingRuntimeIdentifier">
+        <source>NETSDK1047: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project. You may also need to include '{3}' in your project's RuntimeIdentifiers.</source>
+        <target state="new">NETSDK1047: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project. You may also need to include '{3}' in your project's RuntimeIdentifiers.</target>
+        <note>{StrBegin="NETSDK1047: "}</note>
+      </trans-unit>
+      <trans-unit id="AssetsFileMissingTarget">
+        <source>NETSDK1005: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project.</source>
+        <target state="new">NETSDK1005: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project.</target>
+        <note>{StrBegin="NETSDK1005: "}</note>
+      </trans-unit>
+      <trans-unit id="AssetsFileNotFound">
+        <source>NETSDK1004: Assets file '{0}' not found. Run a NuGet package restore to generate this file.</source>
+        <target state="new">NETSDK1004: Assets file '{0}' not found. Run a NuGet package restore to generate this file.</target>
+        <note>{StrBegin="NETSDK1004: "}</note>
+      </trans-unit>
+      <trans-unit id="AssetsFileNotSet">
+        <source>NETSDK1063: The path to the project assets file was not set. Run a NuGet package restore to generate this file.</source>
+        <target state="new">NETSDK1063: The path to the project assets file was not set. Run a NuGet package restore to generate this file.</target>
+        <note>{StrBegin="NETSDK1063: "}</note>
+      </trans-unit>
+      <trans-unit id="AssetsFilePathNotRooted">
+        <source>NETSDK1006: Assets file path '{0}' is not rooted. Only full paths are supported.</source>
+        <target state="new">NETSDK1006: Assets file path '{0}' is not rooted. Only full paths are supported.</target>
+        <note>{StrBegin="NETSDK1006: "}</note>
+      </trans-unit>
       <trans-unit id="AtLeastOneTargetFrameworkMustBeSpecified">
         <source>NETSDK1001: At least one possible target framework must be specified.</source>
-        <target state="needs-review-translation">En az bir olası hedef çerçeve belirtilmelidir.</target>
+        <target state="new">NETSDK1001: At least one possible target framework must be specified.</target>
         <note>{StrBegin="NETSDK1001: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotFindApphostForRid">
+        <source>NETSDK1065: Cannot find app host for {0}. {0} could be an invalid runtime identifier (RID). For more information about RID, see https://aka.ms/rid-catalog.</source>
+        <target state="new">NETSDK1065: Cannot find app host for {0}. {0} could be an invalid runtime identifier (RID). For more information about RID, see https://aka.ms/rid-catalog.</target>
+        <note>{StrBegin="NETSDK1065: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotFindProjectInfo">
+        <source>NETSDK1007: Cannot find project info for '{0}'. This can indicate a missing project reference.</source>
+        <target state="new">NETSDK1007: Cannot find project info for '{0}'. This can indicate a missing project reference.</target>
+        <note>{StrBegin="NETSDK1007: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotHaveRuntimeIdentifierPlatformMismatchPlatformTarget">
+        <source>NETSDK1032: The RuntimeIdentifier platform '{0}' and the PlatformTarget '{1}' must be compatible.</source>
+        <target state="new">NETSDK1032: The RuntimeIdentifier platform '{0}' and the PlatformTarget '{1}' must be compatible.</target>
+        <note>{StrBegin="NETSDK1032: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotHaveSelfContainedWithoutRuntimeIdentifier">
+        <source>NETSDK1031: It is not supported to build or publish a self-contained application without specifying a RuntimeIdentifier.  Please either specify a RuntimeIdentifier or set SelfContained to false.</source>
+        <target state="new">NETSDK1031: It is not supported to build or publish a self-contained application without specifying a RuntimeIdentifier.  Please either specify a RuntimeIdentifier or set SelfContained to false.</target>
+        <note>{StrBegin="NETSDK1031: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotInferTargetFrameworkIdentiferAndVersion">
+        <source>NETSDK1013: The TargetFramework value '{0}' was not recognized. It may be misspelled. If not, then the TargetFrameworkIdentifier and/or TargetFrameworkVersion properties must be specified explicitly.</source>
+        <target state="new">NETSDK1013: The TargetFramework value '{0}' was not recognized. It may be misspelled. If not, then the TargetFrameworkIdentifier and/or TargetFrameworkVersion properties must be specified explicitly.</target>
+        <note>{StrBegin="NETSDK1013: "}</note>
       </trans-unit>
       <trans-unit id="CannotUseAppHostWithoutRuntimeIdentifier">
         <source>NETSDK1066: A RuntimeIdentifier must be specified to publish a framework-dependent application with an application host.</source>
@@ -17,10 +102,174 @@
         <target state="new">NETSDK1067: Self-contained applications are required to use the application host. Either set SelfContained to false or set UseAppHost to true.</target>
         <note>{StrBegin="NETSDK1067: "}</note>
       </trans-unit>
+      <trans-unit id="ChoosingAssemblyVersion">
+        <source>NETSDK1033: Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</source>
+        <target state="new">NETSDK1033: Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</target>
+        <note>{StrBegin="NETSDK1033: "}</note>
+      </trans-unit>
+      <trans-unit id="ChoosingFileVersion">
+        <source>NETSDK1034: Choosing '{0}' because file version '{1}' is greater than '{2}'.</source>
+        <target state="new">NETSDK1034: Choosing '{0}' because file version '{1}' is greater than '{2}'.</target>
+        <note>{StrBegin="NETSDK1034: "}</note>
+      </trans-unit>
+      <trans-unit id="ChoosingPlatformItem">
+        <source>NETSDK1035: Choosing '{0}' because it is a platform item.</source>
+        <target state="new">NETSDK1035: Choosing '{0}' because it is a platform item.</target>
+        <note>{StrBegin="NETSDK1035: "}</note>
+      </trans-unit>
+      <trans-unit id="ChoosingPreferredPackage">
+        <source>NETSDK1036: Choosing '{0}' because it comes from a package that is preferred.</source>
+        <target state="new">NETSDK1036: Choosing '{0}' because it comes from a package that is preferred.</target>
+        <note>{StrBegin="NETSDK1036: "}</note>
+      </trans-unit>
+      <trans-unit id="ConflictCouldNotDetermineWinner">
+        <source>NETSDK1037: Could not determine winner due to equal file and assembly versions.</source>
+        <target state="new">NETSDK1037: Could not determine winner due to equal file and assembly versions.</target>
+        <note>{StrBegin="NETSDK1037: "}</note>
+      </trans-unit>
+      <trans-unit id="ContentItemDoesNotProvideOutputPath">
+        <source>NETSDK1014: Content item for '{0}' sets '{1}', but does not provide  '{2}' or '{3}'.</source>
+        <target state="new">NETSDK1014: Content item for '{0}' sets '{1}', but does not provide  '{2}' or '{3}'.</target>
+        <note>{StrBegin="NETSDK1014: "}</note>
+      </trans-unit>
+      <trans-unit id="ContentPreproccessorParameterRequired">
+        <source>NETSDK1010: The '{0}' task must be given a value for parameter '{1}' in order to consume preprocessed content.</source>
+        <target state="new">NETSDK1010: The '{0}' task must be given a value for parameter '{1}' in order to consume preprocessed content.</target>
+        <note>{StrBegin="NETSDK1010: "}</note>
+      </trans-unit>
+      <trans-unit id="CouldNotDetermineWinner_DoesntExist">
+        <source>NETSDK1038: Could not determine winner because '{0}' does not exist.</source>
+        <target state="new">NETSDK1038: Could not determine winner because '{0}' does not exist.</target>
+        <note>{StrBegin="NETSDK1001: "}</note>
+      </trans-unit>
+      <trans-unit id="CouldNotDetermineWinner_FileVersion">
+        <source>NETSDK1039: Could not determine a winner because '{0}' has no file version.</source>
+        <target state="new">NETSDK1039: Could not determine a winner because '{0}' has no file version.</target>
+        <note>{StrBegin="NETSDK1039: "}</note>
+      </trans-unit>
+      <trans-unit id="CouldNotDetermineWinner_NotAnAssembly">
+        <source>NETSDK1040: Could not determine a winner because '{0}' is not an assembly.</source>
+        <target state="new">NETSDK1040: Could not determine a winner because '{0}' is not an assembly.</target>
+        <note>{StrBegin="NETSDK1040: "}</note>
+      </trans-unit>
+      <trans-unit id="CouldNotLoadPlatformManifest">
+        <source>NETSDK1042: Could not load PlatformManifest from '{0}' because it did not exist.</source>
+        <target state="new">NETSDK1042: Could not load PlatformManifest from '{0}' because it did not exist.</target>
+        <note>{StrBegin="NETSDK1042: "}</note>
+      </trans-unit>
+      <trans-unit id="DotnetToolDoesNotSupportTFMLowerThanNetcoreapp21">
+        <source>NETSDK1055: DotnetTool does not support target framework lower than netcoreapp2.1.</source>
+        <target state="new">NETSDK1055: DotnetTool does not support target framework lower than netcoreapp2.1.</target>
+        <note>{StrBegin="NETSDK1055: "}</note>
+      </trans-unit>
+      <trans-unit id="DotnetToolOnlySupportNetcoreapp">
+        <source>NETSDK1054: only supports .NET Core.</source>
+        <target state="new">NETSDK1054: only supports .NET Core.</target>
+        <note>{StrBegin="NETSDK1054: "}</note>
+      </trans-unit>
+      <trans-unit id="DuplicateItemsError">
+        <source>NETSDK1022: Duplicate '{0}' items were included. The .NET SDK includes '{0}' items from your project directory by default. You can either remove these items from your project file, or set the '{1}' property to '{2}' if you want to explicitly include them in your project file. For more information, see {4}. The duplicate items were: {3}</source>
+        <target state="new">NETSDK1022: Duplicate '{0}' items were included. The .NET SDK includes '{0}' items from your project directory by default. You can either remove these items from your project file, or set the '{1}' property to '{2}' if you want to explicitly include them in your project file. For more information, see {4}. The duplicate items were: {3}</target>
+        <note>{StrBegin="NETSDK1022: "}</note>
+      </trans-unit>
+      <trans-unit id="DuplicatePreprocessorToken">
+        <source>NETSDK1015: The preprocessor token '{0}' has been given more than one value. Choosing '{1}' as the value.</source>
+        <target state="new">NETSDK1015: The preprocessor token '{0}' has been given more than one value. Choosing '{1}' as the value.</target>
+        <note>{StrBegin="NETSDK1015: "}</note>
+      </trans-unit>
+      <trans-unit id="EncounteredConflict">
+        <source>NETSDK1041: Encountered conflict between '{0}' and '{1}'.</source>
+        <target state="new">NETSDK1041: Encountered conflict between '{0}' and '{1}'.</target>
+        <note>{StrBegin="NETSDK1041: "}</note>
+      </trans-unit>
+      <trans-unit id="ErrorParsingFrameworkListInvalidValue">
+        <source>NETSDK1051: Error parsing FrameworkList from '{0}'.  {1} '{2}' was invalid.</source>
+        <target state="new">NETSDK1051: Error parsing FrameworkList from '{0}'.  {1} '{2}' was invalid.</target>
+        <note>{StrBegin="NETSDK1051: "}</note>
+      </trans-unit>
+      <trans-unit id="ErrorParsingPlatformManifest">
+        <source>NETSDK1043: Error parsing PlatformManifest from '{0}' line {1}.  Lines must have the format {2}.</source>
+        <target state="new">NETSDK1043: Error parsing PlatformManifest from '{0}' line {1}.  Lines must have the format {2}.</target>
+        <note>{StrBegin="NETSDK1043: "}</note>
+      </trans-unit>
+      <trans-unit id="ErrorParsingPlatformManifestInvalidValue">
+        <source>NETSDK1044: Error parsing PlatformManifest from '{0}' line {1}.  {2} '{3}' was invalid.</source>
+        <target state="new">NETSDK1044: Error parsing PlatformManifest from '{0}' line {1}.  {2} '{3}' was invalid.</target>
+        <note>{StrBegin="NETSDK1044: "}</note>
+      </trans-unit>
+      <trans-unit id="ErrorReadingAssetsFile">
+        <source>NETSDK1060: Error reading assets file: {0}</source>
+        <target state="new">NETSDK1060: Error reading assets file: {0}</target>
+        <note>{StrBegin="NETSDK1060: "}</note>
+      </trans-unit>
+      <trans-unit id="FileNameIsTooLong">
+        <source>NETSDK1030: Given file name '{0}' is longer than 1024 bytes</source>
+        <target state="new">NETSDK1030: Given file name '{0}' is longer than 1024 bytes</target>
+        <note>{StrBegin="NETSDK1030: "}</note>
+      </trans-unit>
+      <trans-unit id="FolderAlreadyExists">
+        <source>NETSDK1024: Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</source>
+        <target state="new">NETSDK1024: Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</target>
+        <note>{StrBegin="NETSDK1024: "}</note>
+      </trans-unit>
       <trans-unit id="FrameworkDependentAppHostRequiresVersion21">
         <source>NETSDK1068: The framework-dependent application host requires a target framework of at least 'netcoreapp2.1'.</source>
         <target state="new">NETSDK1068: The framework-dependent application host requires a target framework of at least 'netcoreapp2.1'.</target>
         <note>{StrBegin="NETSDK1068: "}</note>
+      </trans-unit>
+      <trans-unit id="FrameworkListPathNotRooted">
+        <source>NETSDK1052: Framework list file path '{0}' is not rooted. Only full paths are supported.</source>
+        <target state="new">NETSDK1052: Framework list file path '{0}' is not rooted. Only full paths are supported.</target>
+        <note>{StrBegin="NETSDK1052: "}</note>
+      </trans-unit>
+      <trans-unit id="GetDependsOnNETStandardFailedWithException">
+        <source>NETSDK1049: Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0} {1}</source>
+        <target state="new">NETSDK1049: Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0} {1}</target>
+        <note>{StrBegin="NETSDK1049: "}</note>
+      </trans-unit>
+      <trans-unit id="IncorrectPackageRoot">
+        <source>NETSDK1020: Package Root {0} was incorrectly given for Resolved library {1}</source>
+        <target state="new">NETSDK1020: Package Root {0} was incorrectly given for Resolved library {1}</target>
+        <note>{StrBegin="NETSDK1020: "}</note>
+      </trans-unit>
+      <trans-unit id="IncorrectTargetFormat">
+        <source>NETSDK1025: WRThe target manifest {0} provided is of not the correct format</source>
+        <target state="new">NETSDK1025: WRThe target manifest {0} provided is of not the correct format</target>
+        <note>{StrBegin="NETSDK1025: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidFrameworkName">
+        <source>NETSDK1003: Invalid framework name: '{0}'.</source>
+        <target state="new">NETSDK1003: Invalid framework name: '{0}'.</target>
+        <note>{StrBegin="NETSDK1003: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidItemSpecToUse">
+        <source>NETSDK1058: Invalid value for ItemSpecToUse parameter: '{0}'.  This property must be blank or set to 'Left' or 'Right'</source>
+        <target state="new">NETSDK1058: Invalid value for ItemSpecToUse parameter: '{0}'.  This property must be blank or set to 'Left' or 'Right'</target>
+        <note>{StrBegin="NETSDK1058: "}
+The following are names of parameters or literal values and should not be translated: ItemSpecToUse, Left, Right</note>
+      </trans-unit>
+      <trans-unit id="InvalidNuGetVersionString">
+        <source>NETSDK1018: Invalid NuGet version string: '{0}'.</source>
+        <target state="new">NETSDK1018: Invalid NuGet version string: '{0}'.</target>
+        <note>{StrBegin="NETSDK1018: "}</note>
+      </trans-unit>
+      <trans-unit id="MismatchedPlatformPackageVersion">
+        <source>NETSDK1061: The project was restored using {0} version {1}, but with current settings, version {2} would be used instead. To resolve this issue, make sure the same settings are used for restore and for subsequent operations such as build or publish. Typically this issue can occur if the RuntimeIdentifier property is set during build or publish but not during restore. For more information, see https://aka.ms/dotnet-runtime-patch-selection.</source>
+        <target state="new">NETSDK1061: The project was restored using {0} version {1}, but with current settings, version {2} would be used instead. To resolve this issue, make sure the same settings are used for restore and for subsequent operations such as build or publish. Typically this issue can occur if the RuntimeIdentifier property is set during build or publish but not during restore. For more information, see https://aka.ms/dotnet-runtime-patch-selection.</target>
+        <note>{StrBegin="NETSDK1061: "}
+{0} - Package Identifier for platform package
+{1} - Restored version of platform package
+{2} - Current version of platform package</note>
+      </trans-unit>
+      <trans-unit id="MissingItemMetadata">
+        <source>NETSDK1008: Missing '{0}' metadata on '{1}' item '{2}'.</source>
+        <target state="new">NETSDK1008: Missing '{0}' metadata on '{1}' item '{2}'.</target>
+        <note>{StrBegin="NETSDK1008: "}</note>
+      </trans-unit>
+      <trans-unit id="MultipleFilesResolved">
+        <source>NETSDK1021: More than one file found for {0}</source>
+        <target state="new">NETSDK1021: More than one file found for {0}</target>
+        <note>{StrBegin="NETSDK1021: "}</note>
       </trans-unit>
       <trans-unit id="NETFrameworkToNonBuiltInNETStandard">
         <source>NETSDK1069: This project uses a library that targets .NET Standard 1.5 or higher, and the project targets a version of .NET Framework that doesn't have built-in support for that version of .NET Standard. Visit https://aka.ms/net-standard-known-issues for a set of known issues. Consider retargeting to .NET Framework 4.7.2.</source>
@@ -29,88 +278,78 @@
       </trans-unit>
       <trans-unit id="NoCompatibleTargetFramework">
         <source>NETSDK1002: Project '{0}' targets '{2}'. It cannot be referenced by a project that targets '{1}'.</source>
-        <target state="needs-review-translation">'{0}' projesi, '{2}' çerçevesini hedefliyor. Bu projeye '{1}' çerçevesini hedefleyen bir proje tarafından başvurulamaz.</target>
+        <target state="new">NETSDK1002: Project '{0}' targets '{2}'. It cannot be referenced by a project that targets '{1}'.</target>
         <note>{StrBegin="NETSDK1002: "}</note>
       </trans-unit>
-      <trans-unit id="InvalidFrameworkName">
-        <source>NETSDK1003: Invalid framework name: '{0}'.</source>
-        <target state="needs-review-translation">Geçersiz çerçeve adı: '{0}'.</target>
-        <note>{StrBegin="NETSDK1003: "}</note>
+      <trans-unit id="PackAsToolCannotSupportSelfContained">
+        <source>NETSDK1053: Pack as tool does not support self contained.</source>
+        <target state="new">NETSDK1053: Pack as tool does not support self contained.</target>
+        <note>{StrBegin="NETSDK1001: "}</note>
       </trans-unit>
-      <trans-unit id="AssetsFileNotFound">
-        <source>NETSDK1004: Assets file '{0}' not found. Run a NuGet package restore to generate this file.</source>
-        <target state="needs-review-translation">'{0}' varlık dosyası bulunamadı. Bu dosyayı oluşturmak için, NuGet paketi geri yükleme işlemi gerçekleştirin.</target>
-        <note>{StrBegin="NETSDK1004: "}</note>
+      <trans-unit id="PackageInfoLog">
+        <source>NETSDK1027: Package Name='{0}', Version='{1}' was parsed</source>
+        <target state="new">NETSDK1027: Package Name='{0}', Version='{1}' was parsed</target>
+        <note>{StrBegin="NETSDK1027: "}</note>
       </trans-unit>
-      <trans-unit id="AssetsFileMissingTarget">
-        <source>NETSDK1005: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project.</source>
-        <target state="needs-review-translation">'{0}' varlık dosyasında '{1}' için hedef yok. Geri yüklemenin çalıştırıldığından ve '{2}' öğesinin projeniz için TargetFrameworks’e eklendiğinden emin olun.</target>
-        <note>{StrBegin="NETSDK1005: "}</note>
+      <trans-unit id="PackageNotFound">
+        <source>NETSDK1064: Package {0}, version {1} was not found. It might have been deleted since NuGet restore. Otherwise, NuGet restore might have only partially completed, which might have been due to maximum path length restrictions.</source>
+        <target state="new">NETSDK1064: Package {0}, version {1} was not found. It might have been deleted since NuGet restore. Otherwise, NuGet restore might have only partially completed, which might have been due to maximum path length restrictions.</target>
+        <note>{StrBegin="NETSDK1064: "}</note>
       </trans-unit>
-      <trans-unit id="AssetsFilePathNotRooted">
-        <source>NETSDK1006: Assets file path '{0}' is not rooted. Only full paths are supported.</source>
-        <target state="needs-review-translation">'{0}' varlık dosya yolunun kökü belirtilmemiş. Yalnızca tam yollar desteklenir.</target>
-        <note>{StrBegin="NETSDK1006: "}</note>
+      <trans-unit id="PackageReferenceOverrideWarning">
+        <source>NETSDK1023: A PackageReference for '{0}' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see {1}</source>
+        <target state="new">NETSDK1023: A PackageReference for '{0}' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see {1}</target>
+        <note>{StrBegin="NETSDK1023: "}</note>
       </trans-unit>
-      <trans-unit id="CannotFindProjectInfo">
-        <source>NETSDK1007: Cannot find project info for '{0}'. This can indicate a missing project reference.</source>
-        <target state="needs-review-translation">'{0}' için proje bilgisi bulunamıyor. Bu durum, eksik bir proje başvurusu olduğunu gösteriyor olabilir.</target>
-        <note>{StrBegin="NETSDK1007: "}</note>
-      </trans-unit>
-      <trans-unit id="MissingItemMetadata">
-        <source>NETSDK1008: Missing '{0}' metadata on '{1}' item '{2}'.</source>
-        <target state="needs-review-translation">'{1}' öğesi '{2}' üzerinde '{0}' meta verileri eksik.</target>
-        <note>{StrBegin="NETSDK1008: "}</note>
-      </trans-unit>
-      <trans-unit id="UnrecognizedPreprocessorToken">
-        <source>NETSDK1009: Unrecognized preprocessor token '{0}' in '{1}'.</source>
-        <target state="needs-review-translation">'{1}' içinde tanınmayan ön işlemci belirteci: '{0}'.</target>
-        <note>{StrBegin="NETSDK1009: "}</note>
-      </trans-unit>
-      <trans-unit id="ContentPreproccessorParameterRequired">
-        <source>NETSDK1010: The '{0}' task must be given a value for parameter '{1}' in order to consume preprocessed content.</source>
-        <target state="needs-review-translation">Önceden işlenen içeriği kullanabilmesi için '{0}' görevine, '{1}' parametresine ilişkin bir değer verilmelidir.</target>
-        <note>{StrBegin="NETSDK1010: "}</note>
+      <trans-unit id="ParsingFiles">
+        <source>NETSDK1026: Parsing the Files : '{0}'</source>
+        <target state="new">NETSDK1026: Parsing the Files : '{0}'</target>
+        <note>{StrBegin="NETSDK1026: "}</note>
       </trans-unit>
       <trans-unit id="ProjectAssetsConsumedWithoutMSBuildProjectPath">
         <source>NETSDK1011: Assets are consumed from project '{0}', but no corresponding MSBuild project path was  found in '{1}'.</source>
-        <target state="needs-review-translation">'{0}' projesindeki varlıklar kullanılıyor, ancak '{1}' içinde karşılık gelen bir MSBuild proje yolu bulunamadı.</target>
+        <target state="new">NETSDK1011: Assets are consumed from project '{0}', but no corresponding MSBuild project path was  found in '{1}'.</target>
         <note>{StrBegin="NETSDK1011: "}</note>
       </trans-unit>
-      <trans-unit id="UnexpectedFileType">
-        <source>NETSDK1012: Unexpected file type for '{0}'. Type is both '{1}' and '{2}'.</source>
-        <target state="needs-review-translation">'{0}' için beklenmeyen dosya türü. Tür, hem '{1}' hem de '{2}'.</target>
-        <note>{StrBegin="NETSDK1012: "}</note>
+      <trans-unit id="ProjectContainsObsoleteDotNetCliTool">
+        <source>NETSDK1059: The tool '{0}' is now included in the .NET Core SDK. Information on resolving this warning is available at (https://aka.ms/dotnetclitools-in-box).</source>
+        <target state="new">NETSDK1059: The tool '{0}' is now included in the .NET Core SDK. Information on resolving this warning is available at (https://aka.ms/dotnetclitools-in-box).</target>
+        <note>{StrBegin="NETSDK1059: "}</note>
       </trans-unit>
-      <trans-unit id="CannotInferTargetFrameworkIdentiferAndVersion">
-        <source>NETSDK1013: The TargetFramework value '{0}' was not recognized. It may be misspelled. If not, then the TargetFrameworkIdentifier and/or TargetFrameworkVersion properties must be specified explicitly.</source>
-        <target state="needs-review-translation">'{0}' TargetFramework değeri tanınmadı. Yanlış yazılmış olabilir. Sorun bundan kaynaklanmıyorsa, TargetFrameworkIdentifier ve/veya TargetFrameworkVersion özelliklerinin açık bir şekilde belirtilmesi gerekir.</target>
-        <note>{StrBegin="NETSDK1013: "}</note>
+      <trans-unit id="RuntimeIdentifierWasNotSpecified">
+        <source>NETSDK1028: Specify a RuntimeIdentifier</source>
+        <target state="new">NETSDK1028: Specify a RuntimeIdentifier</target>
+        <note>{StrBegin="NETSDK1028: "}</note>
       </trans-unit>
-      <trans-unit id="ContentItemDoesNotProvideOutputPath">
-        <source>NETSDK1014: Content item for '{0}' sets '{1}', but does not provide  '{2}' or '{3}'.</source>
-        <target state="needs-review-translation">'{0}' için içerik öğesi, '{1}' değerini ayarlıyor ancak '{2}' veya '{3}' sağlamıyor.</target>
-        <note>{StrBegin="NETSDK1014: "}</note>
+      <trans-unit id="SkippingAdditionalProbingPaths">
+        <source>NETSDK1048: 'AdditionalProbingPaths' were specified for GenerateRuntimeConfigurationFiles, but are being skipped because 'RuntimeConfigDevPath' is empty.</source>
+        <target state="new">NETSDK1048: 'AdditionalProbingPaths' were specified for GenerateRuntimeConfigurationFiles, but are being skipped because 'RuntimeConfigDevPath' is empty.</target>
+        <note>{StrBegin="NETSDK1048: "}</note>
       </trans-unit>
-      <trans-unit id="DuplicatePreprocessorToken">
-        <source>NETSDK1015: The preprocessor token '{0}' has been given more than one value. Choosing '{1}' as the value.</source>
-        <target state="needs-review-translation">'{0}' ön işlemci belirtecine birden fazla değer verildi. Değer olarak '{1}' seçiliyor.</target>
-        <note>{StrBegin="NETSDK1015: "}</note>
+      <trans-unit id="TargetFrameworkWithSemicolon">
+        <source>NETSDK1046: The TargetFramework value '{0}' is not valid. To multi-target, use the 'TargetFrameworks' property instead.</source>
+        <target state="new">NETSDK1046: The TargetFramework value '{0}' is not valid. To multi-target, use the 'TargetFrameworks' property instead.</target>
+        <note>{StrBegin="NETSDK1046: "}</note>
       </trans-unit>
       <trans-unit id="UnableToFindResolvedPath">
         <source>NETSDK1016: Unable to find resolved path for '{0}'.</source>
-        <target state="needs-review-translation">'{0}' için çözümlenmiş yol bulunamıyor.</target>
+        <target state="new">NETSDK1016: Unable to find resolved path for '{0}'.</target>
         <note>{StrBegin="NETSDK1016: "}</note>
       </trans-unit>
-      <trans-unit id="AssetPreprocessorMustBeConfigured">
-        <source>NETSDK1017: Asset preprocessor must be configured before assets are processed.</source>
-        <target state="needs-review-translation">Varlıkların işlenebilmesi için varlık ön işlemcisi yapılandırılmalıdır.</target>
-        <note>{StrBegin="NETSDK1017: "}</note>
+      <trans-unit id="UnableToUsePackageAssetsCache">
+        <source>NETSDK1062: Unable to use package assets cache due to I/O error. This can occur when the same project is built more than once in parallel. Performance may be degraded, but the build result will not be impacted.</source>
+        <target state="new">NETSDK1062: Unable to use package assets cache due to I/O error. This can occur when the same project is built more than once in parallel. Performance may be degraded, but the build result will not be impacted.</target>
+        <note>{StrBegin="NETSDK1062: "}</note>
       </trans-unit>
-      <trans-unit id="InvalidNuGetVersionString">
-        <source>NETSDK1018: Invalid NuGet version string: '{0}'.</source>
-        <target state="needs-review-translation">Geçersiz NuGet sürüm dizesi: '{0}'.</target>
-        <note>{StrBegin="NETSDK1018: "}</note>
+      <trans-unit id="UnexpectedFileType">
+        <source>NETSDK1012: Unexpected file type for '{0}'. Type is both '{1}' and '{2}'.</source>
+        <target state="new">NETSDK1012: Unexpected file type for '{0}'. Type is both '{1}' and '{2}'.</target>
+        <note>{StrBegin="NETSDK1012: "}</note>
+      </trans-unit>
+      <trans-unit id="UnrecognizedPreprocessorToken">
+        <source>NETSDK1009: Unrecognized preprocessor token '{0}' in '{1}'.</source>
+        <target state="new">NETSDK1009: Unrecognized preprocessor token '{0}' in '{1}'.</target>
+        <note>{StrBegin="NETSDK1009: "}</note>
       </trans-unit>
       <trans-unit id="UnrecognizedRuntimeFrameworkName">
         <source>NETSDK1070: This project uses an unsupported value for RuntimeFrameworkName. Currently, only valid values are: Microsoft.NETCore.App, Microsoft.AspNetCore.App, or Microsoft.AspNetCore.All.</source>
@@ -119,242 +358,28 @@
       </trans-unit>
       <trans-unit id="UnsupportedFramework">
         <source>NETSDK1019: {0} is an unsupported framework.</source>
-        <target state="needs-review-translation">{0} çerçevesi desteklenmiyor.</target>
+        <target state="new">NETSDK1019: {0} is an unsupported framework.</target>
         <note>{StrBegin="NETSDK1019: "}</note>
-      </trans-unit>
-      <trans-unit id="DuplicateItemsError">
-        <source>NETSDK1022: Duplicate '{0}' items were included. The .NET SDK includes '{0}' items from your project directory by default. You can either remove these items from your project file, or set the '{1}' property to '{2}' if you want to explicitly include them in your project file. For more information, see {4}. The duplicate items were: {3}</source>
-        <target state="needs-review-translation">Yinelenen '{0}' öğeleri eklendi. .NET SDK, proje dizininizdeki '{0}' öğelerini varsayılan olarak içeriyor. Bu öğeleri proje dosyanızdan kaldırabilir veya bunları proje dosyanıza açıkça dahil etmek istiyorsanız '{1}' özelliğini '{2}' olarak ayarlayabilirsiniz. Daha fazla bilgi için bkz. {4}. Yinelenen öğeler: {3}</target>
-        <note>{StrBegin="NETSDK1022: "}</note>
-      </trans-unit>
-      <trans-unit id="PackageReferenceOverrideWarning">
-        <source>NETSDK1023: A PackageReference for '{0}' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see {1}</source>
-        <target state="needs-review-translation">Projenize '{0}' için bir paket başvurusu eklendi. .NET SDK bu pakete örtük olarak başvuruyor; buna projenizden başvurmanız genellikle gerekli değildir. Daha fazla bilgi için bkz. {1}</target>
-        <note>{StrBegin="NETSDK1023: "}</note>
-      </trans-unit>
-      <trans-unit id="IncorrectPackageRoot">
-        <source>NETSDK1020: Package Root {0} was incorrectly given for Resolved library {1}</source>
-        <target state="needs-review-translation">{0} Paket Kökü, Çözümlenmiş kitaplık {1} için yanlışlıkla verildi</target>
-        <note>{StrBegin="NETSDK1020: "}</note>
-      </trans-unit>
-      <trans-unit id="MultipleFilesResolved">
-        <source>NETSDK1021: More than one file found for {0}</source>
-        <target state="needs-review-translation">{0} için birden fazla dosya bulundu</target>
-        <note>{StrBegin="NETSDK1021: "}</note>
-      </trans-unit>
-      <trans-unit id="FolderAlreadyExists">
-        <source>NETSDK1024: Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</source>
-        <target state="needs-review-translation">'{0}' klasörü zaten var, klasörü silin veya farklı bir ComposeWorkingDir değeri belirtin</target>
-        <note>{StrBegin="NETSDK1024: "}</note>
-      </trans-unit>
-      <trans-unit id="ParsingFiles">
-        <source>NETSDK1026: Parsing the Files : '{0}'</source>
-        <target state="needs-review-translation">Dosyalar ayrıştırılıyor: '{0}'</target>
-        <note>{StrBegin="NETSDK1026: "}</note>
-      </trans-unit>
-      <trans-unit id="PackageInfoLog">
-        <source>NETSDK1027: Package Name='{0}', Version='{1}' was parsed</source>
-        <target state="needs-review-translation">Paket Adı='{0}', Sürüm='{1}' ayrıştırıldı</target>
-        <note>{StrBegin="NETSDK1027: "}</note>
-      </trans-unit>
-      <trans-unit id="RuntimeIdentifierWasNotSpecified">
-        <source>NETSDK1028: Specify a RuntimeIdentifier</source>
-        <target state="needs-review-translation">Bir RuntimeIdentifier belirtin</target>
-        <note>{StrBegin="NETSDK1028: "}</note>
-      </trans-unit>
-      <trans-unit id="IncorrectTargetFormat">
-        <source>NETSDK1025: WRThe target manifest {0} provided is of not the correct format</source>
-        <target state="needs-review-translation">Belirtilen hedef bildirimi {0} doğru biçimde değil</target>
-        <note>{StrBegin="NETSDK1025: "}</note>
-      </trans-unit>
-      <trans-unit id="AppHostHasBeenModified">
-        <source>NETSDK1029: Unable to use '{0}' as application host executable as it does not contain the expected placeholder byte sequence '{1}' that would mark where the application name would be written.</source>
-        <target state="needs-review-translation">'{0}', uygulama adının yazılacağı yeri işaretlemesi için beklenen yer tutucu bayt dizisini ('{1}') içermediğinden uygulama konak yürütülebiliri olarak kullanılamıyor.</target>
-        <note>{StrBegin="NETSDK1029: "}</note>
-      </trans-unit>
-      <trans-unit id="FileNameIsTooLong">
-        <source>NETSDK1030: Given file name '{0}' is longer than 1024 bytes</source>
-        <target state="needs-review-translation">Belirtilen dosya adı ('{0})' 1024 bayttan uzun</target>
-        <note>{StrBegin="NETSDK1030: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotHaveSelfContainedWithoutRuntimeIdentifier">
-        <source>NETSDK1031: It is not supported to build or publish a self-contained application without specifying a RuntimeIdentifier.  Please either specify a RuntimeIdentifier or set SelfContained to false.</source>
-        <target state="needs-review-translation">Bir RuntimeIdentifier belirtilmeden, bağımsız çalışan uygulama derlenmesi veya yayımlanması desteklenmez. Lütfen bir RuntimeIdentifier belirtin veya SelfContained değerini false olarak ayarlayın.</target>
-        <note>{StrBegin="NETSDK1031: "}</note>
-      </trans-unit>
-      <trans-unit id="ChoosingAssemblyVersion">
-        <source>NETSDK1033: Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</source>
-        <target state="needs-review-translation">AssemblyVersion '{1}', '{2}' değerinden büyük olduğundan '{0}' seçiliyor.</target>
-        <note>{StrBegin="NETSDK1033: "}</note>
-      </trans-unit>
-      <trans-unit id="ChoosingFileVersion">
-        <source>NETSDK1034: Choosing '{0}' because file version '{1}' is greater than '{2}'.</source>
-        <target state="needs-review-translation">'{1}' dosya sürümü '{2}' değerinden büyük olduğundan '{0}' seçiliyor.</target>
-        <note>{StrBegin="NETSDK1034: "}</note>
-      </trans-unit>
-      <trans-unit id="ChoosingPlatformItem">
-        <source>NETSDK1035: Choosing '{0}' because it is a platform item.</source>
-        <target state="needs-review-translation">Bir platform öğesi olduğu için '{0}' seçiliyor.</target>
-        <note>{StrBegin="NETSDK1035: "}</note>
-      </trans-unit>
-      <trans-unit id="ChoosingPreferredPackage">
-        <source>NETSDK1036: Choosing '{0}' because it comes from a package that is preferred.</source>
-        <target state="needs-review-translation">Tercih edilen bir paketten geldiği için '{0}' seçiliyor.</target>
-        <note>{StrBegin="NETSDK1036: "}</note>
-      </trans-unit>
-      <trans-unit id="ConflictCouldNotDetermineWinner">
-        <source>NETSDK1037: Could not determine winner due to equal file and assembly versions.</source>
-        <target state="needs-review-translation">Dosya ve bütünleştirilmiş kod sürümlerinin eşit olması nedeniyle kazanan belirlenemedi.</target>
-        <note>{StrBegin="NETSDK1037: "}</note>
-      </trans-unit>
-      <trans-unit id="CouldNotDetermineWinner_DoesntExist">
-        <source>NETSDK1038: Could not determine winner because '{0}' does not exist.</source>
-        <target state="needs-review-translation">'{0}' mevcut olmadığından kazanan belirlenemedi.</target>
-        <note>{StrBegin="NETSDK1001: "}</note>
-      </trans-unit>
-      <trans-unit id="CouldNotDetermineWinner_FileVersion">
-        <source>NETSDK1039: Could not determine a winner because '{0}' has no file version.</source>
-        <target state="needs-review-translation">'{0}' bir dosya sürümüne sahip olmadığından kazanan belirlenemedi.</target>
-        <note>{StrBegin="NETSDK1039: "}</note>
-      </trans-unit>
-      <trans-unit id="CouldNotDetermineWinner_NotAnAssembly">
-        <source>NETSDK1040: Could not determine a winner because '{0}' is not an assembly.</source>
-        <target state="needs-review-translation">'{0}' bir bütünleştirilmiş kod olmadığından kazanan belirlenemedi.</target>
-        <note>{StrBegin="NETSDK1040: "}</note>
-      </trans-unit>
-      <trans-unit id="EncounteredConflict">
-        <source>NETSDK1041: Encountered conflict between '{0}' and '{1}'.</source>
-        <target state="needs-review-translation">'{0}' ile '{1}' arasında çakışmayla karşılaşıldı.</target>
-        <note>{StrBegin="NETSDK1041: "}</note>
-      </trans-unit>
-      <trans-unit id="CouldNotLoadPlatformManifest">
-        <source>NETSDK1042: Could not load PlatformManifest from '{0}' because it did not exist.</source>
-        <target state="needs-review-translation">'{0}' mevcut olmadığından buradan PlatformManifest yüklenemedi.</target>
-        <note>{StrBegin="NETSDK1042: "}</note>
-      </trans-unit>
-      <trans-unit id="ErrorParsingPlatformManifest">
-        <source>NETSDK1043: Error parsing PlatformManifest from '{0}' line {1}.  Lines must have the format {2}.</source>
-        <target state="needs-review-translation">'{0}' içindeki {1} satırından PlatformManifest ayrıştırılırken hata oluştu. Satırlar {2} biçiminde olmalıdır.</target>
-        <note>{StrBegin="NETSDK1043: "}</note>
-      </trans-unit>
-      <trans-unit id="ErrorParsingPlatformManifestInvalidValue">
-        <source>NETSDK1044: Error parsing PlatformManifest from '{0}' line {1}.  {2} '{3}' was invalid.</source>
-        <target state="needs-review-translation">'{0}' konumundaki {1} satırından PlatformManifest ayrıştırılırken hata oluştu. {2} '{3}' geçersizdi.</target>
-        <note>{StrBegin="NETSDK1044: "}</note>
-      </trans-unit>
-      <trans-unit id="UnsupportedTargetFrameworkVersion">
-        <source>NETSDK1045: The current .NET SDK does not support targeting {0} {1}.  Either target {0} {2} or lower, or use a version of the .NET SDK that supports {0} {1}.</source>
-        <target state="needs-review-translation">Geçerli .NET SDK’sı {0} {1} sürümünü hedeflemeyi desteklemiyor. {0} {2} veya daha düşük bir sürümü hedefleyin veya {0} {1} destekleyen bir .NET SDK’sı kullanın.</target>
-        <note>{StrBegin="NETSDK1045: "}</note>
-      </trans-unit>
-      <trans-unit id="AssetsFileMissingRuntimeIdentifier">
-        <source>NETSDK1047: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project. You may also need to include '{3}' in your project's RuntimeIdentifiers.</source>
-        <target state="needs-review-translation">'{0}' varlık dosyasında '{1}' için hedef yok. Geri yüklemenin çalıştırıldığından ve '{2}' öğesinin projeniz için TargetFrameworks’e eklendiğinden emin olun. Ayrıca '{3}' öğesini projenizin RuntimeIdentifiers’ına eklemeniz gerekebilir.</target>
-        <note>{StrBegin="NETSDK1047: "}</note>
-      </trans-unit>
-      <trans-unit id="TargetFrameworkWithSemicolon">
-        <source>NETSDK1046: The TargetFramework value '{0}' is not valid. To multi-target, use the 'TargetFrameworks' property instead.</source>
-        <target state="needs-review-translation">'{0}' TargetFramework değeri geçerli değil. Çoklu hedefleme için 'TargetFrameworks' özelliğini kullanın.</target>
-        <note>{StrBegin="NETSDK1046: "}</note>
-      </trans-unit>
-      <trans-unit id="SkippingAdditionalProbingPaths">
-        <source>NETSDK1048: 'AdditionalProbingPaths' were specified for GenerateRuntimeConfigurationFiles, but are being skipped because 'RuntimeConfigDevPath' is empty.</source>
-        <target state="needs-review-translation">GenerateRuntimeConfigurationFiles için 'AdditionalProbingPaths' belirtildi ancak 'RuntimeConfigDevPath' boş olduğundan atlanıyor.</target>
-        <note>{StrBegin="NETSDK1048: "}</note>
-      </trans-unit>
-      <trans-unit id="GetDependsOnNETStandardFailedWithException">
-        <source>NETSDK1049: Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0} {1}</source>
-        <target state="needs-review-translation">Çözümlenen dosyada hatalı görüntü var, meta veri yok veya dosya erişilemez durumda. {0} {1}</target>
-        <note>{StrBegin="NETSDK1049: "}</note>
-      </trans-unit>
-      <trans-unit id="UnsupportedSDKVersionForNetStandard20">
-        <source>NETSDK1050: The version of Microsoft.NET.Sdk used by this project is insufficient to support references to libraries targeting .NET Standard 1.5 or higher.  Please install version 2.0 or higher of the .NET Core SDK.</source>
-        <target state="needs-review-translation">Bu proje tarafından kullanılan Microsoft.NET.Sdk, .NET Standard 1.5 veya üzeri kitaplıkları desteklemek için yeterli değil. Lütfen .NET Core SDK 2.0 veya sonraki bir sürümü yükleyin.</target>
-        <note>{StrBegin="NETSDK1050: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotHaveRuntimeIdentifierPlatformMismatchPlatformTarget">
-        <source>NETSDK1032: The RuntimeIdentifier platform '{0}' and the PlatformTarget '{1}' must be compatible.</source>
-        <target state="needs-review-translation">RuntimeIdentifier platformu '{0}' ile PlatformTarget '{1}' uyumlu olmalıdır.</target>
-        <note>{StrBegin="NETSDK1032: "}</note>
-      </trans-unit>
-      <trans-unit id="ErrorParsingFrameworkListInvalidValue">
-        <source>NETSDK1051: Error parsing FrameworkList from '{0}'.  {1} '{2}' was invalid.</source>
-        <target state="needs-review-translation">FrameworkList '{0}' öğesinden ayrıştırılırken hata oluştu.  {1} '{2}' geçersizdi.</target>
-        <note>{StrBegin="NETSDK1051: "}</note>
-      </trans-unit>
-      <trans-unit id="FrameworkListPathNotRooted">
-        <source>NETSDK1052: Framework list file path '{0}' is not rooted. Only full paths are supported.</source>
-        <target state="needs-review-translation">'{0}' çerçeve listesi dosya yolunun kökü belirtilmemiş. Yalnızca tam yollar desteklenir.</target>
-        <note>{StrBegin="NETSDK1052: "}</note>
-      </trans-unit>
-      <trans-unit id="PackAsToolCannotSupportSelfContained">
-        <source>NETSDK1053: Pack as tool does not support self contained.</source>
-        <target state="needs-review-translation">Araç olarak paketleme kendi kendini kapsamayı desteklemiyor.</target>
-        <note>{StrBegin="NETSDK1001: "}</note>
       </trans-unit>
       <trans-unit id="UnsupportedRuntimeIdentifier">
         <source>NETSDK1056: Project is targeting runtime '{0}' but did not resolve any runtime-specific packages. This runtime may not be supported by the target framework.</source>
-        <target state="needs-review-translation">Proje '{0}' çalışma zamanını hedefliyor ancak çalışma zamanına özgü herhangi bir paketi çözümlemedi. Bu çalışma zamanı hedef çerçeve tarafından desteklenmiyor olabilir.</target>
+        <target state="new">NETSDK1056: Project is targeting runtime '{0}' but did not resolve any runtime-specific packages. This runtime may not be supported by the target framework.</target>
         <note>{StrBegin="NETSDK1056: "}</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedSDKVersionForNetStandard20">
+        <source>NETSDK1050: The version of Microsoft.NET.Sdk used by this project is insufficient to support references to libraries targeting .NET Standard 1.5 or higher.  Please install version 2.0 or higher of the .NET Core SDK.</source>
+        <target state="new">NETSDK1050: The version of Microsoft.NET.Sdk used by this project is insufficient to support references to libraries targeting .NET Standard 1.5 or higher.  Please install version 2.0 or higher of the .NET Core SDK.</target>
+        <note>{StrBegin="NETSDK1050: "}</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedTargetFrameworkVersion">
+        <source>NETSDK1045: The current .NET SDK does not support targeting {0} {1}.  Either target {0} {2} or lower, or use a version of the .NET SDK that supports {0} {1}.</source>
+        <target state="new">NETSDK1045: The current .NET SDK does not support targeting {0} {1}.  Either target {0} {2} or lower, or use a version of the .NET SDK that supports {0} {1}.</target>
+        <note>{StrBegin="NETSDK1045: "}</note>
       </trans-unit>
       <trans-unit id="UsingPreviewSdkWarning">
         <source>NETSDK1057: You are working with a preview version of the .NET Core SDK. You can define the SDK version via a global.json file in the current project. More at https://go.microsoft.com/fwlink/?linkid=869452</source>
-        <target state="needs-review-translation">.NET Core SDK’nın önizleme sürümüyle çalışıyorsunuz. SDK sürümünü geçerli projedeki bir global.json dosyası aracılığıyla tanımlayabilirsiniz. Daha fazla bilgi edinmek için bkz. https://go.microsoft.com/fwlink/?linkid=869452</target>
+        <target state="new">NETSDK1057: You are working with a preview version of the .NET Core SDK. You can define the SDK version via a global.json file in the current project. More at https://go.microsoft.com/fwlink/?linkid=869452</target>
         <note>{StrBegin="NETSDK1057: "}</note>
-      </trans-unit>
-      <trans-unit id="InvalidItemSpecToUse">
-        <source>NETSDK1058: Invalid value for ItemSpecToUse parameter: '{0}'.  This property must be blank or set to 'Left' or 'Right'</source>
-        <target state="needs-review-translation">ItemSpecToUse parametresi için geçersiz değer: '{0}'. Bu özellik boş olmalı veya 'Left' veya 'Right' olarak ayarlanmalıdır</target>
-        <note>{StrBegin="NETSDK1058: "}
-The following are names of parameters or literal values and should not be translated: ItemSpecToUse, Left, Right</note>
-      </trans-unit>
-      <trans-unit id="ProjectContainsObsoleteDotNetCliTool">
-        <source>NETSDK1059: The tool '{0}' is now included in the .NET Core SDK. Information on resolving this warning is available at (https://aka.ms/dotnetclitools-in-box).</source>
-        <target state="needs-review-translation">'{0}' başvurusuna yönelik DotNetCliToolReference kullanımı kalktı ve bu projeden kaldırılabilir. Bu araç varsayılan olarak .NET Core SDK’sında paketlenmiştir.</target>
-        <note>{StrBegin="NETSDK1059: "}</note>
-      </trans-unit>
-      <trans-unit id="ErrorReadingAssetsFile">
-        <source>NETSDK1060: Error reading assets file: {0}</source>
-        <target state="needs-review-translation">Varlıklar dosyası okunurken hata: {0}</target>
-        <note>{StrBegin="NETSDK1060: "}</note>
-      </trans-unit>
-      <trans-unit id="MismatchedPlatformPackageVersion">
-        <source>NETSDK1061: The project was restored using {0} version {1}, but with current settings, version {2} would be used instead. To resolve this issue, make sure the same settings are used for restore and for subsequent operations such as build or publish. Typically this issue can occur if the RuntimeIdentifier property is set during build or publish but not during restore. For more information, see https://aka.ms/dotnet-runtime-patch-selection.</source>
-        <target state="needs-review-translation">Proje {0} sürümü {1} kullanılarak geri yüklendi ancak geçerli ayarlarla bunun yerine {2} sürümü kullanılır. Bu sorunu çözmek için, geri yükleme işleminde ve derleme ya da yayımlama gibi sonraki işlemlerde aynı ayarların kullanıldığından emin olun. Genellikle RuntimeIdentifier özelliği derleme veya yayımlama sırasında ayarlanır ancak geri yükleme sırasında ayarlanmazsa bu durum oluşabilir.</target>
-        <note>{StrBegin="NETSDK1061: "}
-{0} - Package Identifier for platform package
-{1} - Restored version of platform package
-{2} - Current version of platform package</note>
-      </trans-unit>
-      <trans-unit id="AssetsFileNotSet">
-        <source>NETSDK1063: The path to the project assets file was not set. Run a NuGet package restore to generate this file.</source>
-        <target state="needs-review-translation">Proje varlıkları dosyasının yolu ayarlanmadı. Bu dosyayı oluşturmak için, NuGet paketi geri yükleme işlemi gerçekleştirin.</target>
-        <note>{StrBegin="NETSDK1063: "}</note>
-      </trans-unit>
-      <trans-unit id="DotnetToolOnlySupportNetcoreapp">
-        <source>NETSDK1054: only supports .NET Core.</source>
-        <target state="needs-review-translation">yalnızca .NET Core desteklenir.</target>
-        <note>{StrBegin="NETSDK1054: "}</note>
-      </trans-unit>
-      <trans-unit id="DotnetToolDoesNotSupportTFMLowerThanNetcoreapp21">
-        <source>NETSDK1055: DotnetTool does not support target framework lower than netcoreapp2.1.</source>
-        <target state="needs-review-translation">DotnetTool, netcoreapp2.1’den daha düşük hedef çerçeveleri desteklemez.</target>
-        <note>{StrBegin="NETSDK1055: "}</note>
-      </trans-unit>
-      <trans-unit id="UnableToUsePackageAssetsCache">
-        <source>NETSDK1062: Unable to use package assets cache due to I/O error. This can occur when the same project is built more than once in parallel. Performance may be degraded, but the build result will not be impacted.</source>
-        <target state="needs-review-translation">G/Ç hatasından dolayı paket varlıkları önbelleği kullanılamıyor. Bu, aynı proje paralel olarak birden fazla kez derlendiğinden dolayı oluşabilir. Performans düşebilir, ancak derleme sonucu etkilenmez.</target>
-        <note>{StrBegin="NETSDK1062: "}</note>
-      </trans-unit>
-      <trans-unit id="PackageNotFound">
-        <source>NETSDK1064: Package {0}, version {1} was not found. It might have been deleted since NuGet restore. Otherwise, NuGet restore might have only partially completed, which might have been due to maximum path length restrictions.</source>
-        <target state="new">NETSDK1064: Package {0}, version {1} was not found. It might have been deleted since NuGet restore. Otherwise, NuGet restore might have only partially completed, which might have been due to maximum path length restrictions.</target>
-        <note>{StrBegin="NETSDK1064: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotFindApphostForRid">
-        <source>NETSDK1065: Cannot find app host for {0}. {0} could be an invalid runtime identifier (RID). For more information about RID, see https://aka.ms/rid-catalog.</source>
-        <target state="new">NETSDK1065: Cannot find app host for {0}. {0} could be an invalid runtime identifier (RID). For more information about RID, see https://aka.ms/rid-catalog.</target>
-        <note>{StrBegin="NETSDK1065: "}</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
@@ -2,10 +2,95 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../Strings.resx">
     <body>
+      <trans-unit id="AppHostHasBeenModified">
+        <source>NETSDK1029: Unable to use '{0}' as application host executable as it does not contain the expected placeholder byte sequence '{1}' that would mark where the application name would be written.</source>
+        <target state="new">NETSDK1029: Unable to use '{0}' as application host executable as it does not contain the expected placeholder byte sequence '{1}' that would mark where the application name would be written.</target>
+        <note>{StrBegin="NETSDK1029: "}</note>
+      </trans-unit>
+      <trans-unit id="AspNetCoreRequiresRuntimeFrameworkName">
+        <source>NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher.
+To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}.
+
+&lt;PropertyGroup&gt;
+    &lt;RuntimeFrameworkName&gt;{0}&lt;/RuntimeFrameworkName&gt;
+&lt;/PropertyGroup&gt;
+
+For more information, see {2}.
+    </source>
+        <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher.
+To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}.
+
+&lt;PropertyGroup&gt;
+    &lt;RuntimeFrameworkName&gt;{0}&lt;/RuntimeFrameworkName&gt;
+&lt;/PropertyGroup&gt;
+
+For more information, see {2}.
+    </target>
+        <note>{StrBegin="NETSDK1071: "}
+{0} - Package Id (AspNetCore.App or .All)
+{1} - Project name
+{2} - More info link
+    </note>
+      </trans-unit>
+      <trans-unit id="AssetPreprocessorMustBeConfigured">
+        <source>NETSDK1017: Asset preprocessor must be configured before assets are processed.</source>
+        <target state="new">NETSDK1017: Asset preprocessor must be configured before assets are processed.</target>
+        <note>{StrBegin="NETSDK1017: "}</note>
+      </trans-unit>
+      <trans-unit id="AssetsFileMissingRuntimeIdentifier">
+        <source>NETSDK1047: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project. You may also need to include '{3}' in your project's RuntimeIdentifiers.</source>
+        <target state="new">NETSDK1047: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project. You may also need to include '{3}' in your project's RuntimeIdentifiers.</target>
+        <note>{StrBegin="NETSDK1047: "}</note>
+      </trans-unit>
+      <trans-unit id="AssetsFileMissingTarget">
+        <source>NETSDK1005: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project.</source>
+        <target state="new">NETSDK1005: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project.</target>
+        <note>{StrBegin="NETSDK1005: "}</note>
+      </trans-unit>
+      <trans-unit id="AssetsFileNotFound">
+        <source>NETSDK1004: Assets file '{0}' not found. Run a NuGet package restore to generate this file.</source>
+        <target state="new">NETSDK1004: Assets file '{0}' not found. Run a NuGet package restore to generate this file.</target>
+        <note>{StrBegin="NETSDK1004: "}</note>
+      </trans-unit>
+      <trans-unit id="AssetsFileNotSet">
+        <source>NETSDK1063: The path to the project assets file was not set. Run a NuGet package restore to generate this file.</source>
+        <target state="new">NETSDK1063: The path to the project assets file was not set. Run a NuGet package restore to generate this file.</target>
+        <note>{StrBegin="NETSDK1063: "}</note>
+      </trans-unit>
+      <trans-unit id="AssetsFilePathNotRooted">
+        <source>NETSDK1006: Assets file path '{0}' is not rooted. Only full paths are supported.</source>
+        <target state="new">NETSDK1006: Assets file path '{0}' is not rooted. Only full paths are supported.</target>
+        <note>{StrBegin="NETSDK1006: "}</note>
+      </trans-unit>
       <trans-unit id="AtLeastOneTargetFrameworkMustBeSpecified">
         <source>NETSDK1001: At least one possible target framework must be specified.</source>
-        <target state="needs-review-translation">必须指定至少一个可能的目标框架。</target>
+        <target state="new">NETSDK1001: At least one possible target framework must be specified.</target>
         <note>{StrBegin="NETSDK1001: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotFindApphostForRid">
+        <source>NETSDK1065: Cannot find app host for {0}. {0} could be an invalid runtime identifier (RID). For more information about RID, see https://aka.ms/rid-catalog.</source>
+        <target state="new">NETSDK1065: Cannot find app host for {0}. {0} could be an invalid runtime identifier (RID). For more information about RID, see https://aka.ms/rid-catalog.</target>
+        <note>{StrBegin="NETSDK1065: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotFindProjectInfo">
+        <source>NETSDK1007: Cannot find project info for '{0}'. This can indicate a missing project reference.</source>
+        <target state="new">NETSDK1007: Cannot find project info for '{0}'. This can indicate a missing project reference.</target>
+        <note>{StrBegin="NETSDK1007: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotHaveRuntimeIdentifierPlatformMismatchPlatformTarget">
+        <source>NETSDK1032: The RuntimeIdentifier platform '{0}' and the PlatformTarget '{1}' must be compatible.</source>
+        <target state="new">NETSDK1032: The RuntimeIdentifier platform '{0}' and the PlatformTarget '{1}' must be compatible.</target>
+        <note>{StrBegin="NETSDK1032: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotHaveSelfContainedWithoutRuntimeIdentifier">
+        <source>NETSDK1031: It is not supported to build or publish a self-contained application without specifying a RuntimeIdentifier.  Please either specify a RuntimeIdentifier or set SelfContained to false.</source>
+        <target state="new">NETSDK1031: It is not supported to build or publish a self-contained application without specifying a RuntimeIdentifier.  Please either specify a RuntimeIdentifier or set SelfContained to false.</target>
+        <note>{StrBegin="NETSDK1031: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotInferTargetFrameworkIdentiferAndVersion">
+        <source>NETSDK1013: The TargetFramework value '{0}' was not recognized. It may be misspelled. If not, then the TargetFrameworkIdentifier and/or TargetFrameworkVersion properties must be specified explicitly.</source>
+        <target state="new">NETSDK1013: The TargetFramework value '{0}' was not recognized. It may be misspelled. If not, then the TargetFrameworkIdentifier and/or TargetFrameworkVersion properties must be specified explicitly.</target>
+        <note>{StrBegin="NETSDK1013: "}</note>
       </trans-unit>
       <trans-unit id="CannotUseAppHostWithoutRuntimeIdentifier">
         <source>NETSDK1066: A RuntimeIdentifier must be specified to publish a framework-dependent application with an application host.</source>
@@ -17,10 +102,174 @@
         <target state="new">NETSDK1067: Self-contained applications are required to use the application host. Either set SelfContained to false or set UseAppHost to true.</target>
         <note>{StrBegin="NETSDK1067: "}</note>
       </trans-unit>
+      <trans-unit id="ChoosingAssemblyVersion">
+        <source>NETSDK1033: Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</source>
+        <target state="new">NETSDK1033: Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</target>
+        <note>{StrBegin="NETSDK1033: "}</note>
+      </trans-unit>
+      <trans-unit id="ChoosingFileVersion">
+        <source>NETSDK1034: Choosing '{0}' because file version '{1}' is greater than '{2}'.</source>
+        <target state="new">NETSDK1034: Choosing '{0}' because file version '{1}' is greater than '{2}'.</target>
+        <note>{StrBegin="NETSDK1034: "}</note>
+      </trans-unit>
+      <trans-unit id="ChoosingPlatformItem">
+        <source>NETSDK1035: Choosing '{0}' because it is a platform item.</source>
+        <target state="new">NETSDK1035: Choosing '{0}' because it is a platform item.</target>
+        <note>{StrBegin="NETSDK1035: "}</note>
+      </trans-unit>
+      <trans-unit id="ChoosingPreferredPackage">
+        <source>NETSDK1036: Choosing '{0}' because it comes from a package that is preferred.</source>
+        <target state="new">NETSDK1036: Choosing '{0}' because it comes from a package that is preferred.</target>
+        <note>{StrBegin="NETSDK1036: "}</note>
+      </trans-unit>
+      <trans-unit id="ConflictCouldNotDetermineWinner">
+        <source>NETSDK1037: Could not determine winner due to equal file and assembly versions.</source>
+        <target state="new">NETSDK1037: Could not determine winner due to equal file and assembly versions.</target>
+        <note>{StrBegin="NETSDK1037: "}</note>
+      </trans-unit>
+      <trans-unit id="ContentItemDoesNotProvideOutputPath">
+        <source>NETSDK1014: Content item for '{0}' sets '{1}', but does not provide  '{2}' or '{3}'.</source>
+        <target state="new">NETSDK1014: Content item for '{0}' sets '{1}', but does not provide  '{2}' or '{3}'.</target>
+        <note>{StrBegin="NETSDK1014: "}</note>
+      </trans-unit>
+      <trans-unit id="ContentPreproccessorParameterRequired">
+        <source>NETSDK1010: The '{0}' task must be given a value for parameter '{1}' in order to consume preprocessed content.</source>
+        <target state="new">NETSDK1010: The '{0}' task must be given a value for parameter '{1}' in order to consume preprocessed content.</target>
+        <note>{StrBegin="NETSDK1010: "}</note>
+      </trans-unit>
+      <trans-unit id="CouldNotDetermineWinner_DoesntExist">
+        <source>NETSDK1038: Could not determine winner because '{0}' does not exist.</source>
+        <target state="new">NETSDK1038: Could not determine winner because '{0}' does not exist.</target>
+        <note>{StrBegin="NETSDK1001: "}</note>
+      </trans-unit>
+      <trans-unit id="CouldNotDetermineWinner_FileVersion">
+        <source>NETSDK1039: Could not determine a winner because '{0}' has no file version.</source>
+        <target state="new">NETSDK1039: Could not determine a winner because '{0}' has no file version.</target>
+        <note>{StrBegin="NETSDK1039: "}</note>
+      </trans-unit>
+      <trans-unit id="CouldNotDetermineWinner_NotAnAssembly">
+        <source>NETSDK1040: Could not determine a winner because '{0}' is not an assembly.</source>
+        <target state="new">NETSDK1040: Could not determine a winner because '{0}' is not an assembly.</target>
+        <note>{StrBegin="NETSDK1040: "}</note>
+      </trans-unit>
+      <trans-unit id="CouldNotLoadPlatformManifest">
+        <source>NETSDK1042: Could not load PlatformManifest from '{0}' because it did not exist.</source>
+        <target state="new">NETSDK1042: Could not load PlatformManifest from '{0}' because it did not exist.</target>
+        <note>{StrBegin="NETSDK1042: "}</note>
+      </trans-unit>
+      <trans-unit id="DotnetToolDoesNotSupportTFMLowerThanNetcoreapp21">
+        <source>NETSDK1055: DotnetTool does not support target framework lower than netcoreapp2.1.</source>
+        <target state="new">NETSDK1055: DotnetTool does not support target framework lower than netcoreapp2.1.</target>
+        <note>{StrBegin="NETSDK1055: "}</note>
+      </trans-unit>
+      <trans-unit id="DotnetToolOnlySupportNetcoreapp">
+        <source>NETSDK1054: only supports .NET Core.</source>
+        <target state="new">NETSDK1054: only supports .NET Core.</target>
+        <note>{StrBegin="NETSDK1054: "}</note>
+      </trans-unit>
+      <trans-unit id="DuplicateItemsError">
+        <source>NETSDK1022: Duplicate '{0}' items were included. The .NET SDK includes '{0}' items from your project directory by default. You can either remove these items from your project file, or set the '{1}' property to '{2}' if you want to explicitly include them in your project file. For more information, see {4}. The duplicate items were: {3}</source>
+        <target state="new">NETSDK1022: Duplicate '{0}' items were included. The .NET SDK includes '{0}' items from your project directory by default. You can either remove these items from your project file, or set the '{1}' property to '{2}' if you want to explicitly include them in your project file. For more information, see {4}. The duplicate items were: {3}</target>
+        <note>{StrBegin="NETSDK1022: "}</note>
+      </trans-unit>
+      <trans-unit id="DuplicatePreprocessorToken">
+        <source>NETSDK1015: The preprocessor token '{0}' has been given more than one value. Choosing '{1}' as the value.</source>
+        <target state="new">NETSDK1015: The preprocessor token '{0}' has been given more than one value. Choosing '{1}' as the value.</target>
+        <note>{StrBegin="NETSDK1015: "}</note>
+      </trans-unit>
+      <trans-unit id="EncounteredConflict">
+        <source>NETSDK1041: Encountered conflict between '{0}' and '{1}'.</source>
+        <target state="new">NETSDK1041: Encountered conflict between '{0}' and '{1}'.</target>
+        <note>{StrBegin="NETSDK1041: "}</note>
+      </trans-unit>
+      <trans-unit id="ErrorParsingFrameworkListInvalidValue">
+        <source>NETSDK1051: Error parsing FrameworkList from '{0}'.  {1} '{2}' was invalid.</source>
+        <target state="new">NETSDK1051: Error parsing FrameworkList from '{0}'.  {1} '{2}' was invalid.</target>
+        <note>{StrBegin="NETSDK1051: "}</note>
+      </trans-unit>
+      <trans-unit id="ErrorParsingPlatformManifest">
+        <source>NETSDK1043: Error parsing PlatformManifest from '{0}' line {1}.  Lines must have the format {2}.</source>
+        <target state="new">NETSDK1043: Error parsing PlatformManifest from '{0}' line {1}.  Lines must have the format {2}.</target>
+        <note>{StrBegin="NETSDK1043: "}</note>
+      </trans-unit>
+      <trans-unit id="ErrorParsingPlatformManifestInvalidValue">
+        <source>NETSDK1044: Error parsing PlatformManifest from '{0}' line {1}.  {2} '{3}' was invalid.</source>
+        <target state="new">NETSDK1044: Error parsing PlatformManifest from '{0}' line {1}.  {2} '{3}' was invalid.</target>
+        <note>{StrBegin="NETSDK1044: "}</note>
+      </trans-unit>
+      <trans-unit id="ErrorReadingAssetsFile">
+        <source>NETSDK1060: Error reading assets file: {0}</source>
+        <target state="new">NETSDK1060: Error reading assets file: {0}</target>
+        <note>{StrBegin="NETSDK1060: "}</note>
+      </trans-unit>
+      <trans-unit id="FileNameIsTooLong">
+        <source>NETSDK1030: Given file name '{0}' is longer than 1024 bytes</source>
+        <target state="new">NETSDK1030: Given file name '{0}' is longer than 1024 bytes</target>
+        <note>{StrBegin="NETSDK1030: "}</note>
+      </trans-unit>
+      <trans-unit id="FolderAlreadyExists">
+        <source>NETSDK1024: Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</source>
+        <target state="new">NETSDK1024: Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</target>
+        <note>{StrBegin="NETSDK1024: "}</note>
+      </trans-unit>
       <trans-unit id="FrameworkDependentAppHostRequiresVersion21">
         <source>NETSDK1068: The framework-dependent application host requires a target framework of at least 'netcoreapp2.1'.</source>
         <target state="new">NETSDK1068: The framework-dependent application host requires a target framework of at least 'netcoreapp2.1'.</target>
         <note>{StrBegin="NETSDK1068: "}</note>
+      </trans-unit>
+      <trans-unit id="FrameworkListPathNotRooted">
+        <source>NETSDK1052: Framework list file path '{0}' is not rooted. Only full paths are supported.</source>
+        <target state="new">NETSDK1052: Framework list file path '{0}' is not rooted. Only full paths are supported.</target>
+        <note>{StrBegin="NETSDK1052: "}</note>
+      </trans-unit>
+      <trans-unit id="GetDependsOnNETStandardFailedWithException">
+        <source>NETSDK1049: Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0} {1}</source>
+        <target state="new">NETSDK1049: Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0} {1}</target>
+        <note>{StrBegin="NETSDK1049: "}</note>
+      </trans-unit>
+      <trans-unit id="IncorrectPackageRoot">
+        <source>NETSDK1020: Package Root {0} was incorrectly given for Resolved library {1}</source>
+        <target state="new">NETSDK1020: Package Root {0} was incorrectly given for Resolved library {1}</target>
+        <note>{StrBegin="NETSDK1020: "}</note>
+      </trans-unit>
+      <trans-unit id="IncorrectTargetFormat">
+        <source>NETSDK1025: WRThe target manifest {0} provided is of not the correct format</source>
+        <target state="new">NETSDK1025: WRThe target manifest {0} provided is of not the correct format</target>
+        <note>{StrBegin="NETSDK1025: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidFrameworkName">
+        <source>NETSDK1003: Invalid framework name: '{0}'.</source>
+        <target state="new">NETSDK1003: Invalid framework name: '{0}'.</target>
+        <note>{StrBegin="NETSDK1003: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidItemSpecToUse">
+        <source>NETSDK1058: Invalid value for ItemSpecToUse parameter: '{0}'.  This property must be blank or set to 'Left' or 'Right'</source>
+        <target state="new">NETSDK1058: Invalid value for ItemSpecToUse parameter: '{0}'.  This property must be blank or set to 'Left' or 'Right'</target>
+        <note>{StrBegin="NETSDK1058: "}
+The following are names of parameters or literal values and should not be translated: ItemSpecToUse, Left, Right</note>
+      </trans-unit>
+      <trans-unit id="InvalidNuGetVersionString">
+        <source>NETSDK1018: Invalid NuGet version string: '{0}'.</source>
+        <target state="new">NETSDK1018: Invalid NuGet version string: '{0}'.</target>
+        <note>{StrBegin="NETSDK1018: "}</note>
+      </trans-unit>
+      <trans-unit id="MismatchedPlatformPackageVersion">
+        <source>NETSDK1061: The project was restored using {0} version {1}, but with current settings, version {2} would be used instead. To resolve this issue, make sure the same settings are used for restore and for subsequent operations such as build or publish. Typically this issue can occur if the RuntimeIdentifier property is set during build or publish but not during restore. For more information, see https://aka.ms/dotnet-runtime-patch-selection.</source>
+        <target state="new">NETSDK1061: The project was restored using {0} version {1}, but with current settings, version {2} would be used instead. To resolve this issue, make sure the same settings are used for restore and for subsequent operations such as build or publish. Typically this issue can occur if the RuntimeIdentifier property is set during build or publish but not during restore. For more information, see https://aka.ms/dotnet-runtime-patch-selection.</target>
+        <note>{StrBegin="NETSDK1061: "}
+{0} - Package Identifier for platform package
+{1} - Restored version of platform package
+{2} - Current version of platform package</note>
+      </trans-unit>
+      <trans-unit id="MissingItemMetadata">
+        <source>NETSDK1008: Missing '{0}' metadata on '{1}' item '{2}'.</source>
+        <target state="new">NETSDK1008: Missing '{0}' metadata on '{1}' item '{2}'.</target>
+        <note>{StrBegin="NETSDK1008: "}</note>
+      </trans-unit>
+      <trans-unit id="MultipleFilesResolved">
+        <source>NETSDK1021: More than one file found for {0}</source>
+        <target state="new">NETSDK1021: More than one file found for {0}</target>
+        <note>{StrBegin="NETSDK1021: "}</note>
       </trans-unit>
       <trans-unit id="NETFrameworkToNonBuiltInNETStandard">
         <source>NETSDK1069: This project uses a library that targets .NET Standard 1.5 or higher, and the project targets a version of .NET Framework that doesn't have built-in support for that version of .NET Standard. Visit https://aka.ms/net-standard-known-issues for a set of known issues. Consider retargeting to .NET Framework 4.7.2.</source>
@@ -29,88 +278,78 @@
       </trans-unit>
       <trans-unit id="NoCompatibleTargetFramework">
         <source>NETSDK1002: Project '{0}' targets '{2}'. It cannot be referenced by a project that targets '{1}'.</source>
-        <target state="needs-review-translation">项目“{0}”以“{2}”为目标。它不可由面向“{1}”的项目引用。</target>
+        <target state="new">NETSDK1002: Project '{0}' targets '{2}'. It cannot be referenced by a project that targets '{1}'.</target>
         <note>{StrBegin="NETSDK1002: "}</note>
       </trans-unit>
-      <trans-unit id="InvalidFrameworkName">
-        <source>NETSDK1003: Invalid framework name: '{0}'.</source>
-        <target state="needs-review-translation">无效的框架名称:“{0}”。</target>
-        <note>{StrBegin="NETSDK1003: "}</note>
+      <trans-unit id="PackAsToolCannotSupportSelfContained">
+        <source>NETSDK1053: Pack as tool does not support self contained.</source>
+        <target state="new">NETSDK1053: Pack as tool does not support self contained.</target>
+        <note>{StrBegin="NETSDK1001: "}</note>
       </trans-unit>
-      <trans-unit id="AssetsFileNotFound">
-        <source>NETSDK1004: Assets file '{0}' not found. Run a NuGet package restore to generate this file.</source>
-        <target state="needs-review-translation">找不到资产文件“{0}”。运行 NuGet 程序包还原以生成此文件。</target>
-        <note>{StrBegin="NETSDK1004: "}</note>
+      <trans-unit id="PackageInfoLog">
+        <source>NETSDK1027: Package Name='{0}', Version='{1}' was parsed</source>
+        <target state="new">NETSDK1027: Package Name='{0}', Version='{1}' was parsed</target>
+        <note>{StrBegin="NETSDK1027: "}</note>
       </trans-unit>
-      <trans-unit id="AssetsFileMissingTarget">
-        <source>NETSDK1005: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project.</source>
-        <target state="needs-review-translation">资产文件“{0}”没有“{1}”的目标。确保已运行还原，且“{2}”已包含在项目的 TargetFrameworks 中。</target>
-        <note>{StrBegin="NETSDK1005: "}</note>
+      <trans-unit id="PackageNotFound">
+        <source>NETSDK1064: Package {0}, version {1} was not found. It might have been deleted since NuGet restore. Otherwise, NuGet restore might have only partially completed, which might have been due to maximum path length restrictions.</source>
+        <target state="new">NETSDK1064: Package {0}, version {1} was not found. It might have been deleted since NuGet restore. Otherwise, NuGet restore might have only partially completed, which might have been due to maximum path length restrictions.</target>
+        <note>{StrBegin="NETSDK1064: "}</note>
       </trans-unit>
-      <trans-unit id="AssetsFilePathNotRooted">
-        <source>NETSDK1006: Assets file path '{0}' is not rooted. Only full paths are supported.</source>
-        <target state="needs-review-translation">资产文件路径“{0}”不是根路径。仅支持完整路径。</target>
-        <note>{StrBegin="NETSDK1006: "}</note>
+      <trans-unit id="PackageReferenceOverrideWarning">
+        <source>NETSDK1023: A PackageReference for '{0}' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see {1}</source>
+        <target state="new">NETSDK1023: A PackageReference for '{0}' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see {1}</target>
+        <note>{StrBegin="NETSDK1023: "}</note>
       </trans-unit>
-      <trans-unit id="CannotFindProjectInfo">
-        <source>NETSDK1007: Cannot find project info for '{0}'. This can indicate a missing project reference.</source>
-        <target state="needs-review-translation">找不到“{0}”的项目信息。这可以指示缺少一个项目引用。</target>
-        <note>{StrBegin="NETSDK1007: "}</note>
-      </trans-unit>
-      <trans-unit id="MissingItemMetadata">
-        <source>NETSDK1008: Missing '{0}' metadata on '{1}' item '{2}'.</source>
-        <target state="needs-review-translation">在“{1}”项“{2}”上缺少“{0}”元数据。</target>
-        <note>{StrBegin="NETSDK1008: "}</note>
-      </trans-unit>
-      <trans-unit id="UnrecognizedPreprocessorToken">
-        <source>NETSDK1009: Unrecognized preprocessor token '{0}' in '{1}'.</source>
-        <target state="needs-review-translation">“{1}”中无法识别预处理器标记“{0}”。</target>
-        <note>{StrBegin="NETSDK1009: "}</note>
-      </trans-unit>
-      <trans-unit id="ContentPreproccessorParameterRequired">
-        <source>NETSDK1010: The '{0}' task must be given a value for parameter '{1}' in order to consume preprocessed content.</source>
-        <target state="needs-review-translation">必须向“{0}”任务提供参数“{1}”的值以便使用预处理的内容。</target>
-        <note>{StrBegin="NETSDK1010: "}</note>
+      <trans-unit id="ParsingFiles">
+        <source>NETSDK1026: Parsing the Files : '{0}'</source>
+        <target state="new">NETSDK1026: Parsing the Files : '{0}'</target>
+        <note>{StrBegin="NETSDK1026: "}</note>
       </trans-unit>
       <trans-unit id="ProjectAssetsConsumedWithoutMSBuildProjectPath">
         <source>NETSDK1011: Assets are consumed from project '{0}', but no corresponding MSBuild project path was  found in '{1}'.</source>
-        <target state="needs-review-translation">从项目“{0}”消耗资产，但在“{1}”中找不到相应的 MSBuild 项目路径。</target>
+        <target state="new">NETSDK1011: Assets are consumed from project '{0}', but no corresponding MSBuild project path was  found in '{1}'.</target>
         <note>{StrBegin="NETSDK1011: "}</note>
       </trans-unit>
-      <trans-unit id="UnexpectedFileType">
-        <source>NETSDK1012: Unexpected file type for '{0}'. Type is both '{1}' and '{2}'.</source>
-        <target state="needs-review-translation">“{0}”的文件类型非预期。类型是“{1}”和“{2}”。</target>
-        <note>{StrBegin="NETSDK1012: "}</note>
+      <trans-unit id="ProjectContainsObsoleteDotNetCliTool">
+        <source>NETSDK1059: The tool '{0}' is now included in the .NET Core SDK. Information on resolving this warning is available at (https://aka.ms/dotnetclitools-in-box).</source>
+        <target state="new">NETSDK1059: The tool '{0}' is now included in the .NET Core SDK. Information on resolving this warning is available at (https://aka.ms/dotnetclitools-in-box).</target>
+        <note>{StrBegin="NETSDK1059: "}</note>
       </trans-unit>
-      <trans-unit id="CannotInferTargetFrameworkIdentiferAndVersion">
-        <source>NETSDK1013: The TargetFramework value '{0}' was not recognized. It may be misspelled. If not, then the TargetFrameworkIdentifier and/or TargetFrameworkVersion properties must be specified explicitly.</source>
-        <target state="needs-review-translation">未识别 TargetFramework 值“{0}”。可能是因为拼写错误。如果拼写正确，必须显式指定 TargetFrameworkIdentifier 和/或 TargetFrameworkVersion 属性。</target>
-        <note>{StrBegin="NETSDK1013: "}</note>
+      <trans-unit id="RuntimeIdentifierWasNotSpecified">
+        <source>NETSDK1028: Specify a RuntimeIdentifier</source>
+        <target state="new">NETSDK1028: Specify a RuntimeIdentifier</target>
+        <note>{StrBegin="NETSDK1028: "}</note>
       </trans-unit>
-      <trans-unit id="ContentItemDoesNotProvideOutputPath">
-        <source>NETSDK1014: Content item for '{0}' sets '{1}', but does not provide  '{2}' or '{3}'.</source>
-        <target state="needs-review-translation">“{0}”的内容项设置为“{1}”，但不提供“{2}”或“{3}”。</target>
-        <note>{StrBegin="NETSDK1014: "}</note>
+      <trans-unit id="SkippingAdditionalProbingPaths">
+        <source>NETSDK1048: 'AdditionalProbingPaths' were specified for GenerateRuntimeConfigurationFiles, but are being skipped because 'RuntimeConfigDevPath' is empty.</source>
+        <target state="new">NETSDK1048: 'AdditionalProbingPaths' were specified for GenerateRuntimeConfigurationFiles, but are being skipped because 'RuntimeConfigDevPath' is empty.</target>
+        <note>{StrBegin="NETSDK1048: "}</note>
       </trans-unit>
-      <trans-unit id="DuplicatePreprocessorToken">
-        <source>NETSDK1015: The preprocessor token '{0}' has been given more than one value. Choosing '{1}' as the value.</source>
-        <target state="needs-review-translation">已向预处理器标记“{0}”提供多个值。选择“{1}”作为值。</target>
-        <note>{StrBegin="NETSDK1015: "}</note>
+      <trans-unit id="TargetFrameworkWithSemicolon">
+        <source>NETSDK1046: The TargetFramework value '{0}' is not valid. To multi-target, use the 'TargetFrameworks' property instead.</source>
+        <target state="new">NETSDK1046: The TargetFramework value '{0}' is not valid. To multi-target, use the 'TargetFrameworks' property instead.</target>
+        <note>{StrBegin="NETSDK1046: "}</note>
       </trans-unit>
       <trans-unit id="UnableToFindResolvedPath">
         <source>NETSDK1016: Unable to find resolved path for '{0}'.</source>
-        <target state="needs-review-translation">找不到“{0}”的已解析路径。</target>
+        <target state="new">NETSDK1016: Unable to find resolved path for '{0}'.</target>
         <note>{StrBegin="NETSDK1016: "}</note>
       </trans-unit>
-      <trans-unit id="AssetPreprocessorMustBeConfigured">
-        <source>NETSDK1017: Asset preprocessor must be configured before assets are processed.</source>
-        <target state="needs-review-translation">必须在处理资产之前配置资产预处理器。</target>
-        <note>{StrBegin="NETSDK1017: "}</note>
+      <trans-unit id="UnableToUsePackageAssetsCache">
+        <source>NETSDK1062: Unable to use package assets cache due to I/O error. This can occur when the same project is built more than once in parallel. Performance may be degraded, but the build result will not be impacted.</source>
+        <target state="new">NETSDK1062: Unable to use package assets cache due to I/O error. This can occur when the same project is built more than once in parallel. Performance may be degraded, but the build result will not be impacted.</target>
+        <note>{StrBegin="NETSDK1062: "}</note>
       </trans-unit>
-      <trans-unit id="InvalidNuGetVersionString">
-        <source>NETSDK1018: Invalid NuGet version string: '{0}'.</source>
-        <target state="needs-review-translation">无效的 NuGet 版本字符串:“{0}”。</target>
-        <note>{StrBegin="NETSDK1018: "}</note>
+      <trans-unit id="UnexpectedFileType">
+        <source>NETSDK1012: Unexpected file type for '{0}'. Type is both '{1}' and '{2}'.</source>
+        <target state="new">NETSDK1012: Unexpected file type for '{0}'. Type is both '{1}' and '{2}'.</target>
+        <note>{StrBegin="NETSDK1012: "}</note>
+      </trans-unit>
+      <trans-unit id="UnrecognizedPreprocessorToken">
+        <source>NETSDK1009: Unrecognized preprocessor token '{0}' in '{1}'.</source>
+        <target state="new">NETSDK1009: Unrecognized preprocessor token '{0}' in '{1}'.</target>
+        <note>{StrBegin="NETSDK1009: "}</note>
       </trans-unit>
       <trans-unit id="UnrecognizedRuntimeFrameworkName">
         <source>NETSDK1070: This project uses an unsupported value for RuntimeFrameworkName. Currently, only valid values are: Microsoft.NETCore.App, Microsoft.AspNetCore.App, or Microsoft.AspNetCore.All.</source>
@@ -119,242 +358,28 @@
       </trans-unit>
       <trans-unit id="UnsupportedFramework">
         <source>NETSDK1019: {0} is an unsupported framework.</source>
-        <target state="needs-review-translation">{0} 是不受支持的框架。</target>
+        <target state="new">NETSDK1019: {0} is an unsupported framework.</target>
         <note>{StrBegin="NETSDK1019: "}</note>
-      </trans-unit>
-      <trans-unit id="DuplicateItemsError">
-        <source>NETSDK1022: Duplicate '{0}' items were included. The .NET SDK includes '{0}' items from your project directory by default. You can either remove these items from your project file, or set the '{1}' property to '{2}' if you want to explicitly include them in your project file. For more information, see {4}. The duplicate items were: {3}</source>
-        <target state="needs-review-translation">包含了重复的“{0}”项。.NET SDK 默认包含你项目目录中的“{0}”项。可从项目文件中删除这些项；如果希望将其显式包含在项目文件中，可将“{1}”属性设置为“{2}”。有关详细信息，请参阅 {4}。重复项为: {3}</target>
-        <note>{StrBegin="NETSDK1022: "}</note>
-      </trans-unit>
-      <trans-unit id="PackageReferenceOverrideWarning">
-        <source>NETSDK1023: A PackageReference for '{0}' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see {1}</source>
-        <target state="needs-review-translation">项目中包含了“{0}”的 PackageReference。此包由 .NET SDK 隐式引用，且通常情况下你无需从项目中对其进行引用。有关详细信息，请参阅 {1}</target>
-        <note>{StrBegin="NETSDK1023: "}</note>
-      </trans-unit>
-      <trans-unit id="IncorrectPackageRoot">
-        <source>NETSDK1020: Package Root {0} was incorrectly given for Resolved library {1}</source>
-        <target state="needs-review-translation">对于“已解析”库 {1}，包根目录 {0} 分配错误。</target>
-        <note>{StrBegin="NETSDK1020: "}</note>
-      </trans-unit>
-      <trans-unit id="MultipleFilesResolved">
-        <source>NETSDK1021: More than one file found for {0}</source>
-        <target state="needs-review-translation">找到 {0} 的多个文件</target>
-        <note>{StrBegin="NETSDK1021: "}</note>
-      </trans-unit>
-      <trans-unit id="FolderAlreadyExists">
-        <source>NETSDK1024: Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</source>
-        <target state="needs-review-translation">文件夹“{0}”已存在，请将其删除或提供不同的 ComposeWorkingDir</target>
-        <note>{StrBegin="NETSDK1024: "}</note>
-      </trans-unit>
-      <trans-unit id="ParsingFiles">
-        <source>NETSDK1026: Parsing the Files : '{0}'</source>
-        <target state="needs-review-translation">正在分析文件:“{0}”</target>
-        <note>{StrBegin="NETSDK1026: "}</note>
-      </trans-unit>
-      <trans-unit id="PackageInfoLog">
-        <source>NETSDK1027: Package Name='{0}', Version='{1}' was parsed</source>
-        <target state="needs-review-translation">已分析出包名称为“{0}”、版本为“{1}”</target>
-        <note>{StrBegin="NETSDK1027: "}</note>
-      </trans-unit>
-      <trans-unit id="RuntimeIdentifierWasNotSpecified">
-        <source>NETSDK1028: Specify a RuntimeIdentifier</source>
-        <target state="needs-review-translation">指定一个 RuntimeIdentifier</target>
-        <note>{StrBegin="NETSDK1028: "}</note>
-      </trans-unit>
-      <trans-unit id="IncorrectTargetFormat">
-        <source>NETSDK1025: WRThe target manifest {0} provided is of not the correct format</source>
-        <target state="needs-review-translation">指定的目标清单 {0} 的格式不正确</target>
-        <note>{StrBegin="NETSDK1025: "}</note>
-      </trans-unit>
-      <trans-unit id="AppHostHasBeenModified">
-        <source>NETSDK1029: Unable to use '{0}' as application host executable as it does not contain the expected placeholder byte sequence '{1}' that would mark where the application name would be written.</source>
-        <target state="needs-review-translation">未能将“{0}”用作应用程序主机可执行文件，因为它没有必需的占位符字节序列“{1}”，该序列会标记应用程序名称的写入位置。</target>
-        <note>{StrBegin="NETSDK1029: "}</note>
-      </trans-unit>
-      <trans-unit id="FileNameIsTooLong">
-        <source>NETSDK1030: Given file name '{0}' is longer than 1024 bytes</source>
-        <target state="needs-review-translation">给定文件名“{0}”的长度超过 1024 个字节</target>
-        <note>{StrBegin="NETSDK1030: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotHaveSelfContainedWithoutRuntimeIdentifier">
-        <source>NETSDK1031: It is not supported to build or publish a self-contained application without specifying a RuntimeIdentifier.  Please either specify a RuntimeIdentifier or set SelfContained to false.</source>
-        <target state="needs-review-translation">不可在未指定 RuntimeIdentifier 的情况下生成或发布自包含应用程序。请指定 RuntimeIdentifier 或将 SelfContained 设置为 false。</target>
-        <note>{StrBegin="NETSDK1031: "}</note>
-      </trans-unit>
-      <trans-unit id="ChoosingAssemblyVersion">
-        <source>NETSDK1033: Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</source>
-        <target state="needs-review-translation">选择“{0}”，因为 AssemblyVersion“{1}”高于“{2}”。</target>
-        <note>{StrBegin="NETSDK1033: "}</note>
-      </trans-unit>
-      <trans-unit id="ChoosingFileVersion">
-        <source>NETSDK1034: Choosing '{0}' because file version '{1}' is greater than '{2}'.</source>
-        <target state="needs-review-translation">选择“{0}”，因为版本“{1}”高于“{2}”。</target>
-        <note>{StrBegin="NETSDK1034: "}</note>
-      </trans-unit>
-      <trans-unit id="ChoosingPlatformItem">
-        <source>NETSDK1035: Choosing '{0}' because it is a platform item.</source>
-        <target state="needs-review-translation">选择“{0}”，因为它是平台项目。</target>
-        <note>{StrBegin="NETSDK1035: "}</note>
-      </trans-unit>
-      <trans-unit id="ChoosingPreferredPackage">
-        <source>NETSDK1036: Choosing '{0}' because it comes from a package that is preferred.</source>
-        <target state="needs-review-translation">选择“{0}”，因为它来自首选包。</target>
-        <note>{StrBegin="NETSDK1036: "}</note>
-      </trans-unit>
-      <trans-unit id="ConflictCouldNotDetermineWinner">
-        <source>NETSDK1037: Could not determine winner due to equal file and assembly versions.</source>
-        <target state="needs-review-translation">由于文件和程序集版本相等，因此无法确定优胜者。</target>
-        <note>{StrBegin="NETSDK1037: "}</note>
-      </trans-unit>
-      <trans-unit id="CouldNotDetermineWinner_DoesntExist">
-        <source>NETSDK1038: Could not determine winner because '{0}' does not exist.</source>
-        <target state="needs-review-translation">由于“{0}”不存在，因此无法确定优胜者。</target>
-        <note>{StrBegin="NETSDK1001: "}</note>
-      </trans-unit>
-      <trans-unit id="CouldNotDetermineWinner_FileVersion">
-        <source>NETSDK1039: Could not determine a winner because '{0}' has no file version.</source>
-        <target state="needs-review-translation">由于“{0}”没有文件版本，因此无法确定优胜者。</target>
-        <note>{StrBegin="NETSDK1039: "}</note>
-      </trans-unit>
-      <trans-unit id="CouldNotDetermineWinner_NotAnAssembly">
-        <source>NETSDK1040: Could not determine a winner because '{0}' is not an assembly.</source>
-        <target state="needs-review-translation">由于“{0}”不是程序集，因此无法确定优胜者。</target>
-        <note>{StrBegin="NETSDK1040: "}</note>
-      </trans-unit>
-      <trans-unit id="EncounteredConflict">
-        <source>NETSDK1041: Encountered conflict between '{0}' and '{1}'.</source>
-        <target state="needs-review-translation">“{0}”和“{1}”之间存在冲突。</target>
-        <note>{StrBegin="NETSDK1041: "}</note>
-      </trans-unit>
-      <trans-unit id="CouldNotLoadPlatformManifest">
-        <source>NETSDK1042: Could not load PlatformManifest from '{0}' because it did not exist.</source>
-        <target state="needs-review-translation">无法从“{0}”中加载 PlatformManifest，因为它不存在。</target>
-        <note>{StrBegin="NETSDK1042: "}</note>
-      </trans-unit>
-      <trans-unit id="ErrorParsingPlatformManifest">
-        <source>NETSDK1043: Error parsing PlatformManifest from '{0}' line {1}.  Lines must have the format {2}.</source>
-        <target state="needs-review-translation">从“{0}”第 {1} 行处分析 PlatformManifest 时出错。行的格式必须为 {2}。</target>
-        <note>{StrBegin="NETSDK1043: "}</note>
-      </trans-unit>
-      <trans-unit id="ErrorParsingPlatformManifestInvalidValue">
-        <source>NETSDK1044: Error parsing PlatformManifest from '{0}' line {1}.  {2} '{3}' was invalid.</source>
-        <target state="needs-review-translation">从“{0}”第 {1} 行处分析 PlatformManifest 时出错。{2} “{3}”无效。</target>
-        <note>{StrBegin="NETSDK1044: "}</note>
-      </trans-unit>
-      <trans-unit id="UnsupportedTargetFrameworkVersion">
-        <source>NETSDK1045: The current .NET SDK does not support targeting {0} {1}.  Either target {0} {2} or lower, or use a version of the .NET SDK that supports {0} {1}.</source>
-        <target state="needs-review-translation">当前 .NET SDK 不支持将 {0} {1} 设置为目标。请将 {0} {2} 或更低版本设置为目标，或使用支持 {0} {1} 的 .NET SDK 版本。</target>
-        <note>{StrBegin="NETSDK1045: "}</note>
-      </trans-unit>
-      <trans-unit id="AssetsFileMissingRuntimeIdentifier">
-        <source>NETSDK1047: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project. You may also need to include '{3}' in your project's RuntimeIdentifiers.</source>
-        <target state="needs-review-translation">资产文件“{0}”没有“{1}”的目标。确保已运行还原，且“{2}”已包含在项目的 TargetFrameworks 中。可能需要在项目 RuntimeIdentifiers 中包括“{3}”。</target>
-        <note>{StrBegin="NETSDK1047: "}</note>
-      </trans-unit>
-      <trans-unit id="TargetFrameworkWithSemicolon">
-        <source>NETSDK1046: The TargetFramework value '{0}' is not valid. To multi-target, use the 'TargetFrameworks' property instead.</source>
-        <target state="needs-review-translation">TargetFramework 值“{0}”无效。若要设置多个目标，请改用“TargetFrameworks”属性。</target>
-        <note>{StrBegin="NETSDK1046: "}</note>
-      </trans-unit>
-      <trans-unit id="SkippingAdditionalProbingPaths">
-        <source>NETSDK1048: 'AdditionalProbingPaths' were specified for GenerateRuntimeConfigurationFiles, but are being skipped because 'RuntimeConfigDevPath' is empty.</source>
-        <target state="needs-review-translation">“AdditionalProbingPaths”被指定给 GenerateRuntimeConfigurationFiles，但被跳过，因为“RuntimeConfigDevPath”为空。</target>
-        <note>{StrBegin="NETSDK1048: "}</note>
-      </trans-unit>
-      <trans-unit id="GetDependsOnNETStandardFailedWithException">
-        <source>NETSDK1049: Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0} {1}</source>
-        <target state="needs-review-translation">解析的文件包含错误图像、无元数据或不可访问。{0} {1}</target>
-        <note>{StrBegin="NETSDK1049: "}</note>
-      </trans-unit>
-      <trans-unit id="UnsupportedSDKVersionForNetStandard20">
-        <source>NETSDK1050: The version of Microsoft.NET.Sdk used by this project is insufficient to support references to libraries targeting .NET Standard 1.5 or higher.  Please install version 2.0 or higher of the .NET Core SDK.</source>
-        <target state="needs-review-translation">该项目使用的 Microsoft.NET.Sdk 版本过低，不支持对面向.NET Standard 1.5 或更高版本的库的引用。请安装 2.0 版本或更高版本的 .NET Core SDK。</target>
-        <note>{StrBegin="NETSDK1050: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotHaveRuntimeIdentifierPlatformMismatchPlatformTarget">
-        <source>NETSDK1032: The RuntimeIdentifier platform '{0}' and the PlatformTarget '{1}' must be compatible.</source>
-        <target state="needs-review-translation">RuntimeIdentifier 平台“{0}”和 PlatformTarget“{1}”必须兼容。</target>
-        <note>{StrBegin="NETSDK1032: "}</note>
-      </trans-unit>
-      <trans-unit id="ErrorParsingFrameworkListInvalidValue">
-        <source>NETSDK1051: Error parsing FrameworkList from '{0}'.  {1} '{2}' was invalid.</source>
-        <target state="needs-review-translation">分析“{0}”中的 FrameworkList 时出错。{1}“{2}”无效。</target>
-        <note>{StrBegin="NETSDK1051: "}</note>
-      </trans-unit>
-      <trans-unit id="FrameworkListPathNotRooted">
-        <source>NETSDK1052: Framework list file path '{0}' is not rooted. Only full paths are supported.</source>
-        <target state="needs-review-translation">框架列表路径“{0}”不是根路径。仅支持完整路径。</target>
-        <note>{StrBegin="NETSDK1052: "}</note>
-      </trans-unit>
-      <trans-unit id="PackAsToolCannotSupportSelfContained">
-        <source>NETSDK1053: Pack as tool does not support self contained.</source>
-        <target state="needs-review-translation">打包为工具不支持自包含。</target>
-        <note>{StrBegin="NETSDK1001: "}</note>
       </trans-unit>
       <trans-unit id="UnsupportedRuntimeIdentifier">
         <source>NETSDK1056: Project is targeting runtime '{0}' but did not resolve any runtime-specific packages. This runtime may not be supported by the target framework.</source>
-        <target state="needs-review-translation">项目的目标是运行时“{0}”，但未解析任何运行时特定的包。目标框架可能不支持此运行时。</target>
+        <target state="new">NETSDK1056: Project is targeting runtime '{0}' but did not resolve any runtime-specific packages. This runtime may not be supported by the target framework.</target>
         <note>{StrBegin="NETSDK1056: "}</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedSDKVersionForNetStandard20">
+        <source>NETSDK1050: The version of Microsoft.NET.Sdk used by this project is insufficient to support references to libraries targeting .NET Standard 1.5 or higher.  Please install version 2.0 or higher of the .NET Core SDK.</source>
+        <target state="new">NETSDK1050: The version of Microsoft.NET.Sdk used by this project is insufficient to support references to libraries targeting .NET Standard 1.5 or higher.  Please install version 2.0 or higher of the .NET Core SDK.</target>
+        <note>{StrBegin="NETSDK1050: "}</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedTargetFrameworkVersion">
+        <source>NETSDK1045: The current .NET SDK does not support targeting {0} {1}.  Either target {0} {2} or lower, or use a version of the .NET SDK that supports {0} {1}.</source>
+        <target state="new">NETSDK1045: The current .NET SDK does not support targeting {0} {1}.  Either target {0} {2} or lower, or use a version of the .NET SDK that supports {0} {1}.</target>
+        <note>{StrBegin="NETSDK1045: "}</note>
       </trans-unit>
       <trans-unit id="UsingPreviewSdkWarning">
         <source>NETSDK1057: You are working with a preview version of the .NET Core SDK. You can define the SDK version via a global.json file in the current project. More at https://go.microsoft.com/fwlink/?linkid=869452</source>
-        <target state="needs-review-translation">你正在使用 .NET Core SDK 的预览版。可通过当前项目中的 global.json 文件来定义 SDK 版本。详细信息请访问 https://go.microsoft.com/fwlink/?linkid=869452</target>
+        <target state="new">NETSDK1057: You are working with a preview version of the .NET Core SDK. You can define the SDK version via a global.json file in the current project. More at https://go.microsoft.com/fwlink/?linkid=869452</target>
         <note>{StrBegin="NETSDK1057: "}</note>
-      </trans-unit>
-      <trans-unit id="InvalidItemSpecToUse">
-        <source>NETSDK1058: Invalid value for ItemSpecToUse parameter: '{0}'.  This property must be blank or set to 'Left' or 'Right'</source>
-        <target state="needs-review-translation">无效的 ItemSpecToUse 参数值:“{0}”。此属性必须为空或设为“左”或“右”</target>
-        <note>{StrBegin="NETSDK1058: "}
-The following are names of parameters or literal values and should not be translated: ItemSpecToUse, Left, Right</note>
-      </trans-unit>
-      <trans-unit id="ProjectContainsObsoleteDotNetCliTool">
-        <source>NETSDK1059: The tool '{0}' is now included in the .NET Core SDK. Information on resolving this warning is available at (https://aka.ms/dotnetclitools-in-box).</source>
-        <target state="needs-review-translation">使用 DotNetCliToolReference 引用“{0}”已过时，且可从此项目中删除。此工具默认捆绑于 .NET Core SDK。</target>
-        <note>{StrBegin="NETSDK1059: "}</note>
-      </trans-unit>
-      <trans-unit id="ErrorReadingAssetsFile">
-        <source>NETSDK1060: Error reading assets file: {0}</source>
-        <target state="needs-review-translation">读取资产文件时出错: {0}</target>
-        <note>{StrBegin="NETSDK1060: "}</note>
-      </trans-unit>
-      <trans-unit id="MismatchedPlatformPackageVersion">
-        <source>NETSDK1061: The project was restored using {0} version {1}, but with current settings, version {2} would be used instead. To resolve this issue, make sure the same settings are used for restore and for subsequent operations such as build or publish. Typically this issue can occur if the RuntimeIdentifier property is set during build or publish but not during restore. For more information, see https://aka.ms/dotnet-runtime-patch-selection.</source>
-        <target state="needs-review-translation">该项目使用 {0} 版本 {1} 进行了还原，但使用当前设置，将改用版本 {2}。若要解决此问题，请确保还原及后续操作（如生成或发布）使用的设置相同。通常，如果在生成或发布期间设置了 RuntimeIdentifier 属性，但在还原期间未设置，则会发生此问题。</target>
-        <note>{StrBegin="NETSDK1061: "}
-{0} - Package Identifier for platform package
-{1} - Restored version of platform package
-{2} - Current version of platform package</note>
-      </trans-unit>
-      <trans-unit id="AssetsFileNotSet">
-        <source>NETSDK1063: The path to the project assets file was not set. Run a NuGet package restore to generate this file.</source>
-        <target state="needs-review-translation">未设置项目资产文件的路径。运行 NuGet 程序包还原以生成此文件。</target>
-        <note>{StrBegin="NETSDK1063: "}</note>
-      </trans-unit>
-      <trans-unit id="DotnetToolOnlySupportNetcoreapp">
-        <source>NETSDK1054: only supports .NET Core.</source>
-        <target state="needs-review-translation">仅支持 .NET Core。</target>
-        <note>{StrBegin="NETSDK1054: "}</note>
-      </trans-unit>
-      <trans-unit id="DotnetToolDoesNotSupportTFMLowerThanNetcoreapp21">
-        <source>NETSDK1055: DotnetTool does not support target framework lower than netcoreapp2.1.</source>
-        <target state="needs-review-translation">DotnetTool 不支持版本低于 netcoreapp2.1 的目标框架。</target>
-        <note>{StrBegin="NETSDK1055: "}</note>
-      </trans-unit>
-      <trans-unit id="UnableToUsePackageAssetsCache">
-        <source>NETSDK1062: Unable to use package assets cache due to I/O error. This can occur when the same project is built more than once in parallel. Performance may be degraded, but the build result will not be impacted.</source>
-        <target state="needs-review-translation">由于 I/O 错误，不能使用程序包资产缓存。如果不止一次地并行生成同样的项目，也可能出现这种情况。可能会降低性能，但是不影响生成结果。</target>
-        <note>{StrBegin="NETSDK1062: "}</note>
-      </trans-unit>
-      <trans-unit id="PackageNotFound">
-        <source>NETSDK1064: Package {0}, version {1} was not found. It might have been deleted since NuGet restore. Otherwise, NuGet restore might have only partially completed, which might have been due to maximum path length restrictions.</source>
-        <target state="new">NETSDK1064: Package {0}, version {1} was not found. It might have been deleted since NuGet restore. Otherwise, NuGet restore might have only partially completed, which might have been due to maximum path length restrictions.</target>
-        <note>{StrBegin="NETSDK1064: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotFindApphostForRid">
-        <source>NETSDK1065: Cannot find app host for {0}. {0} could be an invalid runtime identifier (RID). For more information about RID, see https://aka.ms/rid-catalog.</source>
-        <target state="new">NETSDK1065: Cannot find app host for {0}. {0} could be an invalid runtime identifier (RID). For more information about RID, see https://aka.ms/rid-catalog.</target>
-        <note>{StrBegin="NETSDK1065: "}</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
@@ -8,16 +8,8 @@
         <note>{StrBegin="NETSDK1029: "}</note>
       </trans-unit>
       <trans-unit id="AspNetCoreRequiresRuntimeFrameworkName">
-        <source>NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher. To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}. For more information, see {2}.
-&lt;PropertyGroup&gt;
-    &lt;RuntimeFrameworkName&gt;{0}&lt;/RuntimeFrameworkName&gt;
-&lt;/PropertyGroup&gt;
-    </source>
-        <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher. To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}. For more information, see {2}.
-&lt;PropertyGroup&gt;
-    &lt;RuntimeFrameworkName&gt;{0}&lt;/RuntimeFrameworkName&gt;
-&lt;/PropertyGroup&gt;
-    </target>
+        <source>NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher. To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}. For more information, see {2}.</source>
+        <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher. To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}. For more information, see {2}.</target>
         <note>{StrBegin="NETSDK1071: "}
 {0} - Package Id (AspNetCore.App or .All)
 {1} - Project name

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
@@ -8,23 +8,15 @@
         <note>{StrBegin="NETSDK1029: "}</note>
       </trans-unit>
       <trans-unit id="AspNetCoreRequiresRuntimeFrameworkName">
-        <source>NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher.
-To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}.
-
+        <source>NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher. To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}. For more information, see {2}.
 &lt;PropertyGroup&gt;
     &lt;RuntimeFrameworkName&gt;{0}&lt;/RuntimeFrameworkName&gt;
 &lt;/PropertyGroup&gt;
-
-For more information, see {2}.
     </source>
-        <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher.
-To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}.
-
+        <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher. To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}. For more information, see {2}.
 &lt;PropertyGroup&gt;
     &lt;RuntimeFrameworkName&gt;{0}&lt;/RuntimeFrameworkName&gt;
 &lt;/PropertyGroup&gt;
-
-For more information, see {2}.
     </target>
         <note>{StrBegin="NETSDK1071: "}
 {0} - Package Id (AspNetCore.App or .All)

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
@@ -112,6 +112,11 @@
         <target state="needs-review-translation">无效的 NuGet 版本字符串:“{0}”。</target>
         <note>{StrBegin="NETSDK1018: "}</note>
       </trans-unit>
+      <trans-unit id="UnrecognizedRuntimeFrameworkName">
+        <source>NETSDK1070: This project uses an unsupported value for RuntimeFrameworkName. Currently, only valid values are: Microsoft.NETCore.App, Microsoft.AspNetCore.App, or Microsoft.AspNetCore.All.</source>
+        <target state="new">NETSDK1070: This project uses an unsupported value for RuntimeFrameworkName. Currently, only valid values are: Microsoft.NETCore.App, Microsoft.AspNetCore.App, or Microsoft.AspNetCore.All.</target>
+        <note>{StrBegin="NETSDK1070: "}</note>
+      </trans-unit>
       <trans-unit id="UnsupportedFramework">
         <source>NETSDK1019: {0} is an unsupported framework.</source>
         <target state="needs-review-translation">{0} 是不受支持的框架。</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
@@ -232,6 +232,11 @@
         <target state="needs-review-translation">從 '{0}' 行 {1} 剖析 PlatformManifest 時發生錯誤。{2} '{3}' 無效。</target>
         <note>{StrBegin="NETSDK1044: "}</note>
       </trans-unit>
+      <trans-unit id="UnrecognizedRuntimeFrameworkName">
+        <source>NETSDK1070: This project uses an unsupported value for RuntimeFrameworkName. Currently, only valid values are: Microsoft.NETCore.App, Microsoft.AspNetCore.App, or Microsoft.AspNetCore.All.</source>
+        <target state="new">NETSDK1070: This project uses an unsupported value for RuntimeFrameworkName. Currently, only valid values are: Microsoft.NETCore.App, Microsoft.AspNetCore.App, or Microsoft.AspNetCore.All.</target>
+        <note>{StrBegin="NETSDK1070: "}</note>
+      </trans-unit>
       <trans-unit id="UnsupportedFramework">
         <source>NETSDK1019: {0} is an unsupported framework.</source>
         <target state="new">NETSDK1019: {0} is an unsupported framework.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
@@ -3,16 +3,8 @@
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../Strings.resx">
     <body>
       <trans-unit id="AspNetCoreRequiresRuntimeFrameworkName">
-        <source>NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher. To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}. For more information, see {2}.
-&lt;PropertyGroup&gt;
-    &lt;RuntimeFrameworkName&gt;{0}&lt;/RuntimeFrameworkName&gt;
-&lt;/PropertyGroup&gt;
-    </source>
-        <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher. To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}. For more information, see {2}.
-&lt;PropertyGroup&gt;
-    &lt;RuntimeFrameworkName&gt;{0}&lt;/RuntimeFrameworkName&gt;
-&lt;/PropertyGroup&gt;
-    </target>
+        <source>NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher. To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}. For more information, see {2}.</source>
+        <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher. To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}. For more information, see {2}.</target>
         <note>{StrBegin="NETSDK1071: "}
 {0} - Package Id (AspNetCore.App or .All)
 {1} - Project name

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
@@ -3,23 +3,15 @@
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../Strings.resx">
     <body>
       <trans-unit id="AspNetCoreRequiresRuntimeFrameworkName">
-        <source>NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher.
-To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}.
-
+        <source>NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher. To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}. For more information, see {2}.
 &lt;PropertyGroup&gt;
     &lt;RuntimeFrameworkName&gt;{0}&lt;/RuntimeFrameworkName&gt;
 &lt;/PropertyGroup&gt;
-
-For more information, see {2}.
     </source>
-        <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher.
-To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}.
-
+        <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher. To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}. For more information, see {2}.
 &lt;PropertyGroup&gt;
     &lt;RuntimeFrameworkName&gt;{0}&lt;/RuntimeFrameworkName&gt;
 &lt;/PropertyGroup&gt;
-
-For more information, see {2}.
     </target>
         <note>{StrBegin="NETSDK1071: "}
 {0} - Package Id (AspNetCore.App or .All)

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
@@ -2,6 +2,31 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../Strings.resx">
     <body>
+      <trans-unit id="AspNetCoreRequiresRuntimeFrameworkName">
+        <source>NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher.
+To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}.
+
+&lt;PropertyGroup&gt;
+    &lt;RuntimeFrameworkName&gt;{0}&lt;/RuntimeFrameworkName&gt;
+&lt;/PropertyGroup&gt;
+
+For more information, see {2}.
+    </source>
+        <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. This will cause issues when upgrading to 2.1.3 and higher.
+To upgrade, remove this PackageReference and add the RuntimeFrameworkName property to {1}.
+
+&lt;PropertyGroup&gt;
+    &lt;RuntimeFrameworkName&gt;{0}&lt;/RuntimeFrameworkName&gt;
+&lt;/PropertyGroup&gt;
+
+For more information, see {2}.
+    </target>
+        <note>{StrBegin="NETSDK1071: "}
+{0} - Package Id (AspNetCore.App or .All)
+{1} - Project name
+{2} - More info link
+    </note>
+      </trans-unit>
       <trans-unit id="AtLeastOneTargetFrameworkMustBeSpecified">
         <source>NETSDK1001: At least one possible target framework must be specified.</source>
         <target state="needs-review-translation">必須指定至少一個可能的目標 Framework。</target>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.Common.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.Common.targets
@@ -20,12 +20,6 @@ Copyright (c) .NET Foundation. All rights reserved.
     <MicrosoftNETBuildTasksTFM Condition=" '$(MicrosoftNETBuildTasksTFM)' == ''">net46</MicrosoftNETBuildTasksTFM>
     <MicrosoftNETBuildTasksDirectory>$(MicrosoftNETBuildTasksDirectoryRoot)$(MicrosoftNETBuildTasksTFM)/</MicrosoftNETBuildTasksDirectory>
     <MicrosoftNETBuildTasksAssembly>$(MicrosoftNETBuildTasksDirectory)Microsoft.NET.Build.Tasks.dll</MicrosoftNETBuildTasksAssembly>
-
-    <!--
-          Hardcoded list of known implicit packges that are added to project from default SDK targets implicitly.
-          Should be re-visited when multiple TFM support is added to Dependencies logic.
-    -->
-    <DefaultImplicitPackages>Microsoft.NETCore.App;NETStandard.Library</DefaultImplicitPackages>
   </PropertyGroup>
 
   <!--

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.Common.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.Common.targets
@@ -25,7 +25,7 @@ Copyright (c) .NET Foundation. All rights reserved.
           Hardcoded list of known implicit packges that are added to project from default SDK targets implicitly.
           Should be re-visited when multiple TFM support is added to Dependencies logic.
     -->
-    <DefaultImplicitPackages>Microsoft.AspNetCore.All;Microsoft.AspNetCore.App;Microsoft.NETCore.App;NETStandard.Library</DefaultImplicitPackages>
+    <DefaultImplicitPackages>Microsoft.NETCore.App;NETStandard.Library</DefaultImplicitPackages>
   </PropertyGroup>
 
   <!--

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.Common.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.Common.targets
@@ -20,6 +20,12 @@ Copyright (c) .NET Foundation. All rights reserved.
     <MicrosoftNETBuildTasksTFM Condition=" '$(MicrosoftNETBuildTasksTFM)' == ''">net46</MicrosoftNETBuildTasksTFM>
     <MicrosoftNETBuildTasksDirectory>$(MicrosoftNETBuildTasksDirectoryRoot)$(MicrosoftNETBuildTasksTFM)/</MicrosoftNETBuildTasksDirectory>
     <MicrosoftNETBuildTasksAssembly>$(MicrosoftNETBuildTasksDirectory)Microsoft.NET.Build.Tasks.dll</MicrosoftNETBuildTasksAssembly>
+
+    <!--
+          Hardcoded list of known implicit packges that are added to project from default SDK targets implicitly.
+          Should be re-visited when multiple TFM support is added to Dependencies logic.
+    -->
+    <DefaultImplicitPackages>Microsoft.AspNetCore.All;Microsoft.AspNetCore.App;Microsoft.NETCore.App;NETStandard.Library</DefaultImplicitPackages>
   </PropertyGroup>
 
   <!--

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.props
@@ -45,15 +45,24 @@ Copyright (c) .NET Foundation. All rights reserved.
                       Publish="true" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(DisableImplicitFrameworkReferences)' != 'true' and '$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
-    <PackageReference Include="Microsoft.NETCore.App" Version="$(RuntimeFrameworkVersion)" IsImplicitlyDefined="true" />
+  <ItemGroup Condition=" '$(DisableImplicitFrameworkReferences)' != 'true' and '$(RuntimeFrameworkName)' != ''">
+    <PackageReference Include="$(RuntimeFrameworkName)">
+      <Version>$(RuntimeFrameworkVersion)</Version>
+      <IsImplicitlyDefined>true</IsImplicitlyDefined>
+      <Publish>true</Publish>
+      <!-- 
+        By default, do not include the runtime framework package in the generated .nuspec when packing the project.
+        The exception is for DotNetCliTool projects, which need the runtime package listed as a dependency.
+      -->
+      <PrivateAssets Condition=" '$(RuntimeFrameworkName)' != 'Microsoft.NETCore.App' AND '$(PackageType)' != 'DotNetCliTool' ">All</PrivateAssets>
+    </PackageReference>
 
     <!-- For libraries targeting .NET Core 2.0 or higher, don't include a dependency on Microsoft.NETCore.App in the package produced by pack.
          Packing an app (for example a .NET CLI tool) should include the Microsoft.NETCore.App package dependency. -->
     <PackageReference Update="Microsoft.NETCore.App"
                       Condition="('$(OutputType)' != 'Exe') And ('$(_TargetFrameworkVersionWithoutV)' != '') And ('$(_TargetFrameworkVersionWithoutV)' >= '2.0')"
                       PrivateAssets="All"
-                      Publish="true" />    
+                      Publish="true" />  
   </ItemGroup>
 
 </Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.props
@@ -61,8 +61,7 @@ Copyright (c) .NET Foundation. All rights reserved.
          Packing an app (for example a .NET CLI tool) should include the Microsoft.NETCore.App package dependency. -->
     <PackageReference Update="Microsoft.NETCore.App"
                       Condition="('$(OutputType)' != 'Exe') And ('$(_TargetFrameworkVersionWithoutV)' != '') And ('$(_TargetFrameworkVersionWithoutV)' >= '2.0')"
-                      PrivateAssets="All"
-                      Publish="true" />  
+                      PrivateAssets="All" />  
   </ItemGroup>
 
 </Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.targets
@@ -124,6 +124,75 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <Choose>
 
+    <When Condition="'$(RuntimeFrameworkName)' == 'Microsoft.AspNetCore.All'">
+
+      <PropertyGroup>
+        <DefaultPatchVersionForAspNetCoreAll2_1 Condition="'$(DefaultPatchVersionForAspNetCoreAll2_1)' == ''">2.1.1</DefaultPatchVersionForAspNetCoreAll2_1>
+      </PropertyGroup>
+
+      <!-- Default patch version of .All Framework -->
+      <PropertyGroup Condition="'$(DefaultAspNetCoreAllPatchVersion)' == ''">
+        <DefaultAspNetCoreAllPatchVersion Condition="'$(_TargetFrameworkVersionWithoutV)' == '2.1'">$(DefaultPatchVersionForAspNetCoreAll2_1)</DefaultAspNetCoreAllPatchVersion>
+
+        <!-- If targeting the same pre-release that is bundled with the .NET Core SDK, use the bundled package version
+            provided by Microsoft.NETCoreSdk.BundledVersions.props -->
+        <DefaultAspNetCoreAllPatchVersion Condition="'$(DefaultAspNetCoreAllPatchVersion)' == '' AND '$(_TargetFrameworkVersionWithoutV)' == '$(BundledAspNetCoreAllTargetFrameworkVersion)'">$(BundledAspNetCoreAllPackageVersion)</DefaultAspNetCoreAllPatchVersion>
+        <!-- If not covered by the previous cases use the target framework version for the default patch version -->
+        <DefaultAspNetCoreAllPatchVersion Condition="'$(DefaultAspNetCoreAllPatchVersion)' == ''">$(_TargetFrameworkVersionWithoutV)</DefaultAspNetCoreAllPatchVersion>
+      </PropertyGroup>
+
+      <!-- Latest patch version of .All Framework -->
+      <PropertyGroup Condition="'$(LatestAspNetCoreAllPatchVersion)' == ''">
+        <!-- If LatestPatchVersionForAspNetCoreAll2_1 is explicitly set, use this for netcoreapp2.1 projects. -->
+        <LatestAspNetCoreAllPatchVersion Condition="'$(_TargetFrameworkVersionWithoutV)' == '2.1'">$(LatestPatchVersionForAspNetCoreAll2_1)</LatestAspNetCoreAllPatchVersion>
+
+        <!-- If targeting the same release that is bundled with the .NET Core SDK, use the bundled package version
+            provided by Microsoft.NETCoreSdk.BundledVersions.props -->
+        <LatestAspNetCoreAllPatchVersion Condition="'$(LatestAspNetCoreAllPatchVersion)' == '' AND '$(_TargetFrameworkVersionWithoutV)' == '$(BundledAspNetCoreAllTargetFrameworkVersion)'">$(BundledAspNetCoreAllPackageVersion)</LatestAspNetCoreAllPatchVersion>
+        <!-- If not covered by the previous cases use the target framework version for the latest patch version -->
+        <LatestAspNetCoreAllPatchVersion Condition="'$(LatestAspNetCoreAllPatchVersion)' == ''">$(_TargetFrameworkVersionWithoutV)</LatestAspNetCoreAllPatchVersion>
+      </PropertyGroup>
+
+      <PropertyGroup>
+        <LatestRuntimeFrameworkPatchVersion>$(LatestAspNetCoreAllPatchVersion)</LatestRuntimeFrameworkPatchVersion>
+        <DefaultRuntimeFrameworkPatchVersion>$(DefaultAspNetCoreAllPatchVersion)</DefaultRuntimeFrameworkPatchVersion>
+      </PropertyGroup>
+    </When>
+
+    <When Condition="'$(RuntimeFrameworkName)' == 'Microsoft.AspNetCore.App'">
+      <PropertyGroup>
+        <DefaultPatchVersionForAspNetCoreApp2_1 Condition="'$(DefaultPatchVersionForAspNetCoreApp2_1)' == ''">2.1.1</DefaultPatchVersionForAspNetCoreApp2_1>
+      </PropertyGroup>
+
+      <!-- Default patch version of .App Framework -->
+      <PropertyGroup Condition="'$(DefaultAspNetCoreAppPatchVersion)' == ''">
+        <DefaultAspNetCoreAppPatchVersion Condition="'$(_TargetFrameworkVersionWithoutV)' == '2.1'">$(DefaultPatchVersionForAspNetCoreApp2_1)</DefaultAspNetCoreAppPatchVersion>
+
+        <!-- If targeting the same pre-release that is bundled with the .NET Core SDK, use the bundled package version
+            provided by Microsoft.NETCoreSdk.BundledVersions.props -->
+        <DefaultAspNetCoreAppPatchVersion Condition="'$(DefaultAspNetCoreAppPatchVersion)' == '' AND '$(_TargetFrameworkVersionWithoutV)' == '$(BundledAspNetCoreAppTargetFrameworkVersion)'">$(BundledAspNetCoreAppPackageVersion)</DefaultAspNetCoreAppPatchVersion>
+        <!-- If not covered by the previous cases use the target framework version for the default patch version -->
+        <DefaultAspNetCoreAppPatchVersion Condition="'$(DefaultAspNetCoreAppPatchVersion)' == ''">$(_TargetFrameworkVersionWithoutV)</DefaultAspNetCoreAppPatchVersion>
+      </PropertyGroup>
+
+      <!-- Latest patch version of .App Framework -->
+      <PropertyGroup Condition="'$(LatestAspNetCoreAppPatchVersion)' == ''">
+        <!-- If LatestPatchVersionForAspNetCoreApp2_1 is explicitly set, use this for netcoreapp2.1 projects. -->
+        <LatestAspNetCoreAppPatchVersion Condition="'$(_TargetFrameworkVersionWithoutV)' == '2.1'">$(LatestPatchVersionForAspNetCoreApp2_1)</LatestAspNetCoreAppPatchVersion>
+
+        <!-- If targeting the same release that is bundled with the .NET Core SDK, use the bundled package version
+            provided by Microsoft.NETCoreSdk.BundledVersions.props -->
+        <LatestAspNetCoreAppPatchVersion Condition="'$(LatestAspNetCoreAppPatchVersion)' == '' AND '$(_TargetFrameworkVersionWithoutV)' == '$(BundledAspNetCoreAppTargetFrameworkVersion)'">$(BundledAspNetCoreAppPackageVersion)</LatestAspNetCoreAppPatchVersion>
+        <!-- If not covered by the previous cases use the target framework version for the latest patch version -->
+        <LatestAspNetCoreAppPatchVersion Condition="'$(LatestAspNetCoreAppPatchVersion)' == ''">$(_TargetFrameworkVersionWithoutV)</LatestAspNetCoreAppPatchVersion>
+      </PropertyGroup>
+
+      <PropertyGroup>
+        <LatestRuntimeFrameworkPatchVersion>$(LatestAspNetCoreAppPatchVersion)</LatestRuntimeFrameworkPatchVersion>
+        <DefaultRuntimeFrameworkPatchVersion>$(DefaultAspNetCoreAppPatchVersion)</DefaultRuntimeFrameworkPatchVersion>
+      </PropertyGroup>
+    </When>
+
     <When Condition="'$(RuntimeFrameworkName)' == 'Microsoft.NETCore.App'">
       <PropertyGroup>
         <!-- These properties will allow the latest patch versions to be set in the CLI (via BundledVersions.props) or overridden by tests -->
@@ -161,6 +230,12 @@ Copyright (c) .NET Foundation. All rights reserved.
         <DefaultRuntimeFrameworkPatchVersion>$(DefaultNetCorePatchVersion)</DefaultRuntimeFrameworkPatchVersion>
       </PropertyGroup>
     </When>
+
+    <Otherwise>
+      <PropertyGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETCoreApp' ">
+        <_UnrecognizedRuntimeFrameworkName>true</_UnrecognizedRuntimeFrameworkName>
+      </PropertyGroup>
+    </Otherwise>
 
   </Choose>
 
@@ -230,6 +305,13 @@ Copyright (c) .NET Foundation. All rights reserved.
   </ItemGroup>
 
   <UsingTask TaskName="CheckForImplicitPackageReferenceOverrides" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
+
+  <!-- Check that RuntimeFrameworkName is something this SDK supports -->
+  <Target Name="CheckForUnrecognizedRuntimeFrameworkName"
+          BeforeTargets="_CheckForInvalidConfigurationAndPlatform;CollectPackageReferences"
+          Condition=" '$(_UnrecognizedRuntimeFrameworkName)' == 'true' ">
+    <NETSdkError ResourceName="UnrecognizedRuntimeFrameworkName" />
+  </Target>
 
   <!-- Remove package references with metadata IsImplicitlyDefined = true, if there are other PackageReference items with the same identity -->
   <Target Name="CheckForImplicitPackageReferenceOverrides" BeforeTargets="_CheckForInvalidConfigurationAndPlatform;CollectPackageReferences">

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.targets
@@ -114,14 +114,6 @@ Copyright (c) .NET Foundation. All rights reserved.
     <RuntimeFrameworkName>Microsoft.NETCore.App</RuntimeFrameworkName>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <!--
-      Hardcoded list of known implicit packges that are added to project from default SDK targets implicitly.
-      Should be re-visited when multiple TFM support is added to Dependencies logic.
-    -->
-    <DefaultImplicitPackages>$(RuntimeFrameworkName);NETStandard.Library</DefaultImplicitPackages>
-  </PropertyGroup>
-
   <Choose>
 
     <When Condition="'$(RuntimeFrameworkName)' == 'Microsoft.AspNetCore.All'">

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.targets
@@ -127,7 +127,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <When Condition="'$(RuntimeFrameworkName)' == 'Microsoft.AspNetCore.All'">
 
       <PropertyGroup>
-        <DefaultPatchVersionForAspNetCoreAll2_1 Condition="'$(DefaultPatchVersionForAspNetCoreAll2_1)' == ''">2.1.1</DefaultPatchVersionForAspNetCoreAll2_1>
+        <DefaultPatchVersionForAspNetCoreAll2_1 Condition="'$(DefaultPatchVersionForAspNetCoreAll2_1)' == ''">2.1.3</DefaultPatchVersionForAspNetCoreAll2_1>
       </PropertyGroup>
 
       <!-- Default patch version of .All Framework -->
@@ -161,7 +161,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <When Condition="'$(RuntimeFrameworkName)' == 'Microsoft.AspNetCore.App'">
       <PropertyGroup>
-        <DefaultPatchVersionForAspNetCoreApp2_1 Condition="'$(DefaultPatchVersionForAspNetCoreApp2_1)' == ''">2.1.1</DefaultPatchVersionForAspNetCoreApp2_1>
+        <DefaultPatchVersionForAspNetCoreApp2_1 Condition="'$(DefaultPatchVersionForAspNetCoreApp2_1)' == ''">2.1.3</DefaultPatchVersionForAspNetCoreApp2_1>
       </PropertyGroup>
 
       <!-- Default patch version of .App Framework -->

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.targets
@@ -328,7 +328,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       <VerifyMatchingImplicitPackageVersion>false</VerifyMatchingImplicitPackageVersion>
     </PropertyGroup>
 
-    <ItemGroup>
+    <ItemGroup Condition="'$(_TargetFrameworkVersionWithoutV)' != '' AND '$(_TargetFrameworkVersionWithoutV)' >= '2.1' ">
       <_AspNetMetaPackageReference Include="@(PackageReference->WithMetadataValue('Identity', 'Microsoft.AspNetCore.App'))" />
       <_AspNetMetaPackageReference Include="@(PackageReference->WithMetadataValue('Identity', 'Microsoft.AspNetCore.All'))" />
     </ItemGroup>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.targets
@@ -6,7 +6,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
           created a backup copy.  Incorrect changes to this file will make it
           impossible to load or build your projects from the command-line or the IDE.
 
-Copyright (c) .NET Foundation. All rights reserved. 
+Copyright (c) .NET Foundation. All rights reserved.
 ***********************************************************************************************
 -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
@@ -22,10 +22,10 @@ Copyright (c) .NET Foundation. All rights reserved.
     <EnableDefaultNoneItems Condition=" '$(EnableDefaultNoneItems)' == '' ">true</EnableDefaultNoneItems>
   </PropertyGroup>
 
-  <PropertyGroup>    
+  <PropertyGroup>
     <!-- Set DefaultItemExcludes property for items that should be excluded from the default Compile, etc items.
          This is in the .targets because it needs to come after the final BaseOutputPath has been evaluated. -->
-    
+
     <!-- bin folder, by default -->
     <DefaultItemExcludes>$(DefaultItemExcludes);$(BaseOutputPath)/**</DefaultItemExcludes>
     <!-- obj folder, by default -->
@@ -36,12 +36,12 @@ Copyright (c) .NET Foundation. All rights reserved.
     <DefaultItemExcludes>$(DefaultItemExcludes);**/*.*proj</DefaultItemExcludes>
     <DefaultItemExcludes>$(DefaultItemExcludes);**/*.sln</DefaultItemExcludes>
     <DefaultItemExcludes>$(DefaultItemExcludes);**/*.vssscc</DefaultItemExcludes>
-    
+
     <!-- WARNING: This pattern is there to ignore folders such as .git and .vs, but it will also match items included with a
          relative path outside the project folder (for example "..\Shared\Shared.cs").  So be sure only to apply it to items
          that are in the project folder. -->
     <DefaultExcludesInProjectFolder>$(DefaultItemExcludesInProjectFolder);**/.*/**</DefaultExcludesInProjectFolder>
-   
+
   </PropertyGroup>
 
   <!-- Set the default versions of the NETStandard.Library or Microsoft.NETCore.App packages to reference.
@@ -55,28 +55,28 @@ Copyright (c) .NET Foundation. All rights reserved.
          updating to the 2.0 or higher SDK.  When targeting .NET Standard 2.0 or higher, the NETStandard.Library reference won't show up as a dependency of the package
          produced, so we will roll forward to the latest version. -->
     <NETStandardImplicitPackageVersion Condition="'$(NETStandardImplicitPackageVersion)' =='' And '$(_TargetFrameworkVersionWithoutV)' &lt; '2.0'">1.6.1</NETStandardImplicitPackageVersion>
-    
+
     <!-- Default to use the latest stable release. -->
     <NETStandardImplicitPackageVersion Condition="'$(NETStandardImplicitPackageVersion)' ==''">2.0.2</NETStandardImplicitPackageVersion>
   </PropertyGroup>
 
   <!--
     Determine the version (including patch) of .NET Core to target.
-    
+
     When targeting .NET Core, the TargetFramework is used to specify the major and minor version of the runtime to use.  By default,
     the patch version is inferred.  The general logic is that self-contained apps will target the latest patch that the SDK
     knows about, while framework-dependent apps will target the ".0" patch (and roll forward to the latest patch installed at
     runtime).
-    
+
     When targeting .NET Core 1.0 and 1.1, framework-dependent apps use 1.0.5 and 1.1.2, respectively.  This is done for compatibility
     with previous releases that bumped the self-contained and framework-dependent versions together.
-    
+
     The TargetLatestRuntimePatch property can be set to true or false to explicitly opt in or out of the logic to roll forward
     to the latest patch, regardless of whether the app is self-contained or framework-dependent.
-    
+
     The RuntimeFrameworkName is the package name of the .NET Core runtime to target. Shared runtimes are installed into the DOTNET_ROOT
     directory under shared/$(RuntimeFrameworkName)/$(RuntimeFrameworkVersion)/. The runtimeconfig.json generated in the application
-    contains both the framework name and version which should be used. By default, projects targeting .NETCoreApp use the 
+    contains both the framework name and version which should be used. By default, projects targeting .NETCoreApp use the
     Microsoft.NETCore.App shared runtime.
 
     This property is different than MicrosoftNETPlatformLibrary. MicrosoftNETPlatformLibrary is used to trim the dependencies
@@ -85,11 +85,11 @@ Copyright (c) .NET Foundation. All rights reserved.
     The RuntimeFrameworkVersion is where the actual version of the .NET Core runtime to target is stored.  It is the version that is
     used in the implicit PackageReference to shared runtime.  The RuntimeFrameworkVersion can also be set explicitly, which
     will disable all the other logic that automatically selects the version of .NET Core to target.
-    
+
     The framework version that is written to the runtimeconfig.json file is based on the actual resolved package version
     of the shared runtime package.  This is to allow floating the verion number (ie the RuntimeFrameworkVersion could be set to
     "2.0-*".
-  
+
   -->
 
   <!--
@@ -98,18 +98,18 @@ Copyright (c) .NET Foundation. All rights reserved.
       - TargetLatestNetCoreRuntimePatch
       - RollForwardRuntime
       - RollForwardNetCoreRuntime
-      
+
      Possible property names for roll-forward/not roll-forward versions
       - LatestNetCorePatchVersion / DefaultNetCorePatchVersion
-      
+
       TODO: Get feedback on these names and then delete this comment
   -->
-      
+
   <PropertyGroup Condition="'$(TargetLatestRuntimePatch)' == ''">
     <TargetLatestRuntimePatch Condition="'$(SelfContained)' == 'true' ">true</TargetLatestRuntimePatch>
     <TargetLatestRuntimePatch Condition="'$(SelfContained)' != 'true' ">false</TargetLatestRuntimePatch>
   </PropertyGroup>
-        
+
   <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(RuntimeFrameworkName)' == ''">
     <RuntimeFrameworkName>Microsoft.NETCore.App</RuntimeFrameworkName>
   </PropertyGroup>
@@ -248,7 +248,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <PropertyGroup Condition="'$(RuntimeFrameworkName)' != '' And '$(DisableImplicitFrameworkReferences)' != 'true'">
     <VerifyMatchingImplicitPackageVersion Condition="'$(VerifyMatchingImplicitPackageVersion)' == ''">true</VerifyMatchingImplicitPackageVersion>
   </PropertyGroup>
-  
+
   <!--
     Automatically add Link metadata to items of specific types if they are outside of the project folder and don't already have the Link metadata set.
     This will cause them to be shown in the Solution Explorer.  If an item has LinkBase metadata, the automatic Link will start with that value, and
@@ -257,12 +257,12 @@ Copyright (c) .NET Foundation. All rights reserved.
   <ItemGroup Condition="'$(SetLinkMetadataAutomatically)' != 'false'">
     <Compile Update="@(Compile)">
       <!-- First, add a trailing slash to the LinkBase metadata if necessary.  This allows us to use the same value
-           for the Link metadata whether or not LinkBase metadata is set: %(LinkBase)%(RecursiveDir)%(Filename)%(Extension) 
-           
+           for the Link metadata whether or not LinkBase metadata is set: %(LinkBase)%(RecursiveDir)%(Filename)%(Extension)
+
            Note that RecursiveDir already includes the trailing slash.
       -->
       <LinkBase Condition="'%(LinkBase)' != ''">$([MSBuild]::EnsureTrailingSlash(%(LinkBase)))</LinkBase>
-    
+
       <!-- Set the Link metadata if it's not already set, if the item wasn't defined in a shared project,  and the item is outside of the project directory.
            Check whether the item was defined in a shared project by checking whether the extension of the defining project was .projitems.
            Check whether an item is inside the project directory by seeing if the FullPath starts with EnsureTrailingSlash(MSBuildProjectDirectory)
@@ -271,7 +271,7 @@ Copyright (c) .NET Foundation. All rights reserved.
            not possible to call a string method on a metadata item directly.  The intrinsic ValueOrDefault() will be more
            performant than calling String.Copy(), which has been used for this in other contexts, but actually makes a copy
            of the string data.
-      -->    
+      -->
       <Link Condition="'%(Link)' == '' And '%(DefiningProjectExtension)' != '.projitems' And !$([MSBuild]::ValueOrDefault('%(FullPath)', '').StartsWith($([MSBuild]::EnsureTrailingSlash($(MSBuildProjectDirectory)))))">%(LinkBase)%(RecursiveDir)%(Filename)%(Extension)</Link>
     </Compile>
 
@@ -279,7 +279,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       <LinkBase Condition="'%(LinkBase)' != ''">$([MSBuild]::EnsureTrailingSlash(%(LinkBase)))</LinkBase>
       <Link Condition="'%(Link)' == '' And '%(DefiningProjectExtension)' != '.projitems' And !$([MSBuild]::ValueOrDefault('%(FullPath)', '').StartsWith($([MSBuild]::EnsureTrailingSlash($(MSBuildProjectDirectory)))))">%(LinkBase)%(RecursiveDir)%(Filename)%(Extension)</Link>
     </AdditionalFiles>
-    
+
     <None Update="@(None)">
       <LinkBase Condition="'%(LinkBase)' != ''">$([MSBuild]::EnsureTrailingSlash(%(LinkBase)))</LinkBase>
       <Link Condition="'%(Link)' == '' And '%(DefiningProjectExtension)' != '.projitems' And !$([MSBuild]::ValueOrDefault('%(FullPath)', '').StartsWith($([MSBuild]::EnsureTrailingSlash($(MSBuildProjectDirectory)))))">%(LinkBase)%(RecursiveDir)%(Filename)%(Extension)</Link>
@@ -296,14 +296,14 @@ Copyright (c) .NET Foundation. All rights reserved.
     </EmbeddedResource>
   </ItemGroup>
 
-  <UsingTask TaskName="CheckForImplicitPackageReferenceOverrides" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
-
   <!-- Check that RuntimeFrameworkName is something this SDK supports -->
   <Target Name="CheckForUnrecognizedRuntimeFrameworkName"
           BeforeTargets="_CheckForInvalidConfigurationAndPlatform;CollectPackageReferences"
           Condition=" '$(_UnrecognizedRuntimeFrameworkName)' == 'true' ">
     <NETSdkError ResourceName="UnrecognizedRuntimeFrameworkName" />
   </Target>
+
+  <UsingTask TaskName="CheckForImplicitPackageReferenceOverrides" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
 
   <!-- Remove package references with metadata IsImplicitlyDefined = true, if there are other PackageReference items with the same identity -->
   <Target Name="CheckForImplicitPackageReferenceOverrides" BeforeTargets="_CheckForInvalidConfigurationAndPlatform;CollectPackageReferences">
@@ -322,12 +322,20 @@ Copyright (c) .NET Foundation. All rights reserved.
            that had duplicates, instead of leaving the ones without IsImplicitlyDefined set to true. -->
       <PackageReference Remove="@(_PackageReferenceToRemove)" Condition="'%(PackageReference.IsImplicitlyDefined)' == 'true' "/>
     </ItemGroup>
-    
+
     <!-- If any implicit package references were overridden, then don't check that RuntimeFrameworkVersion matches the package version -->
     <PropertyGroup Condition="'@(_PackageReferenceToRemove)' != ''">
       <VerifyMatchingImplicitPackageVersion>false</VerifyMatchingImplicitPackageVersion>
     </PropertyGroup>
 
+    <ItemGroup>
+      <_AspNetMetaPackageReference Include="@(PackageReference->WithMetadataValue('Identity', 'Microsoft.AspNetCore.App'))" />
+      <_AspNetMetaPackageReference Include="@(PackageReference->WithMetadataValue('Identity', 'Microsoft.AspNetCore.All'))" />
+    </ItemGroup>
+
+    <NETSdkWarning Condition=" '$(DisableAspNetCoreMetaPackageUpgradeWarning)' != 'true' AND '%(_AspNetMetaPackageReference.Identity)' != '' AND '%(_AspNetMetaPackageReference.IsImplicitlyDefined)' != 'true' "
+          ResourceName="AspNetCoreRequiresRuntimeFrameworkName"
+          FormatArguments="%(_AspNetMetaPackageReference.Identity);$(MSBuildProjectFile);$(ImplicitPackageReferenceInformationLink)" />
   </Target>
 
   <UsingTask TaskName="CheckForDuplicateItems" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
@@ -366,7 +374,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       ContinueOnError="$(CheckForDuplicateItemsContinueOnError)">
       <Output TaskParameter="DeduplicatedItems" ItemName="DeduplicatedEmbeddedResourceItems" />
     </CheckForDuplicateItems>
-    
+
     <!-- Default content items are enabled by the Web SDK, not the .NET SDK, but we check it here for simplicity -->
     <CheckForDuplicateItems
       Items="@(Content)"
@@ -393,6 +401,6 @@ Copyright (c) .NET Foundation. All rights reserved.
       <Content Remove="@(Content)" />
       <Content Include="@(DeduplicatedContentItems)" />
     </ItemGroup>
-    
+
   </Target>
 </Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.targets
@@ -74,12 +74,20 @@ Copyright (c) .NET Foundation. All rights reserved.
     The TargetLatestRuntimePatch property can be set to true or false to explicitly opt in or out of the logic to roll forward
     to the latest patch, regardless of whether the app is self-contained or framework-dependent.
     
+    The RuntimeFrameworkName is the package name of the .NET Core runtime to target. Shared runtimes are installed into the DOTNET_ROOT
+    directory under shared/$(RuntimeFrameworkName)/$(RuntimeFrameworkVersion)/. The runtimeconfig.json generated in the application
+    contains both the framework name and version which should be used. By default, projects targeting .NETCoreApp use the 
+    Microsoft.NETCore.App shared runtime.
+
+    This property is different than MicrosoftNETPlatformLibrary. MicrosoftNETPlatformLibrary is used to trim the dependencies
+    published with a framework-dependent app, and can be controlled independently of the default implicit package reference.
+
     The RuntimeFrameworkVersion is where the actual version of the .NET Core runtime to target is stored.  It is the version that is
-    used in the implicit PackageReference to Microsoft.NETCore.App.  The RuntimeFrameworkVersion can also be set explicitly, which
+    used in the implicit PackageReference to shared runtime.  The RuntimeFrameworkVersion can also be set explicitly, which
     will disable all the other logic that automatically selects the version of .NET Core to target.
     
     The framework version that is written to the runtimeconfig.json file is based on the actual resolved package version
-    of Microsoft.NETCore.App.  This is to allow floating the verion number (ie the RuntimeFrameworkVersion could be set to
+    of the shared runtime package.  This is to allow floating the verion number (ie the RuntimeFrameworkVersion could be set to
     "2.0-*".
   
   -->
@@ -96,61 +104,81 @@ Copyright (c) .NET Foundation. All rights reserved.
       
       TODO: Get feedback on these names and then delete this comment
   -->
-
-  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
-    <!-- These properties will allow the latest patch versions to be set in the CLI (via BundledVersions.props) or overridden by tests -->
-    <LatestPatchVersionForNetCore1_0 Condition="'$(LatestPatchVersionForNetCore1_0)' == ''">1.0.10</LatestPatchVersionForNetCore1_0>
-    <LatestPatchVersionForNetCore1_1 Condition="'$(LatestPatchVersionForNetCore1_1)' == ''">1.1.7</LatestPatchVersionForNetCore1_1>
-    <LatestPatchVersionForNetCore2_0 Condition="'$(LatestPatchVersionForNetCore2_0)' == ''">2.0.6</LatestPatchVersionForNetCore2_0>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(DefaultNetCorePatchVersion)' == ''">
-    <DefaultNetCorePatchVersion Condition="'$(_TargetFrameworkVersionWithoutV)' == '1.0'">1.0.5</DefaultNetCorePatchVersion>
-    <DefaultNetCorePatchVersion Condition="'$(_TargetFrameworkVersionWithoutV)' == '1.1'">1.1.2</DefaultNetCorePatchVersion>
-
-    <!-- If targeting the same pre-release that is bundled with the .NET Core SDK, use the bundled package version
-         provided by Microsoft.NETCoreSdk.BundledVersions.props -->
-    <DefaultNetCorePatchVersion Condition="'$(DefaultNetCorePatchVersion)' == '' And '$(_TargetFrameworkVersionWithoutV)' == '$(BundledNETCoreAppTargetFrameworkVersion)' And '$(UseBundledNETCoreAppPackageVersionAsDefaultNetCorePatchVersion)' == 'true'">$(BundledNETCoreAppPackageVersion)</DefaultNetCorePatchVersion>
-    <!-- If not covered by the previous cases use the target framework version for the default patch version -->
-    <DefaultNetCorePatchVersion Condition="'$(DefaultNetCorePatchVersion)' == ''">$(_TargetFrameworkVersionWithoutV)</DefaultNetCorePatchVersion>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(LatestNetCorePatchVersion)' == ''">
-    <LatestNetCorePatchVersion Condition="'$(_TargetFrameworkVersionWithoutV)' == '1.0'">$(LatestPatchVersionForNetCore1_0)</LatestNetCorePatchVersion>
-    <LatestNetCorePatchVersion Condition="'$(_TargetFrameworkVersionWithoutV)' == '1.1'">$(LatestPatchVersionForNetCore1_1)</LatestNetCorePatchVersion>
-    <LatestNetCorePatchVersion Condition="'$(_TargetFrameworkVersionWithoutV)' == '2.0'">$(LatestPatchVersionForNetCore2_0)</LatestNetCorePatchVersion>
-    <LatestNetCorePatchVersion Condition="'$(_TargetFrameworkVersionWithoutV)' == '2.1'">$(LatestPatchVersionForNetCore2_1)</LatestNetCorePatchVersion>
-
-    <!-- If targeting the same pre-release that is bundled with the .NET Core SDK, use the bundled package version
-         provided by Microsoft.NETCoreSdk.BundledVersions.props -->
-    <LatestNetCorePatchVersion Condition="'$(_TargetFrameworkVersionWithoutV)' == '$(BundledNETCoreAppTargetFrameworkVersion)'">$(BundledNETCoreAppPackageVersion)</LatestNetCorePatchVersion>
-    <!-- If not covered by the previous cases use the target framework version for the latest patch version -->
-    <LatestNetCorePatchVersion Condition="'$(LatestNetCorePatchVersion)' == ''">$(_TargetFrameworkVersionWithoutV)</LatestNetCorePatchVersion>
-  </PropertyGroup>
-  
+      
   <PropertyGroup Condition="'$(TargetLatestRuntimePatch)' == ''">
     <TargetLatestRuntimePatch Condition="'$(SelfContained)' == 'true' ">true</TargetLatestRuntimePatch>
     <TargetLatestRuntimePatch Condition="'$(SelfContained)' != 'true' ">false</TargetLatestRuntimePatch>
   </PropertyGroup>
-
-  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(RuntimeFrameworkVersion)' == ''">
-    <RuntimeFrameworkVersion Condition="'$(TargetLatestRuntimePatch)' == 'true' ">$(LatestNetCorePatchVersion)</RuntimeFrameworkVersion>
-    <RuntimeFrameworkVersion Condition="'$(TargetLatestRuntimePatch)' != 'true' ">$(DefaultNetCorePatchVersion)</RuntimeFrameworkVersion>
+        
+  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(RuntimeFrameworkName)' == ''">
+    <RuntimeFrameworkName>Microsoft.NETCore.App</RuntimeFrameworkName>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(DisableImplicitFrameworkReferences)' != 'true'">
-    <!-- This property is different than MicrosoftNETPlatformLibrary.  MicrosoftNETPlatformLibrary is
-         used to trim the dependencies published with a framework-dependent app, and is overridden
-         by ASP.NET packages.
-         
-         ExpectedPlatformPackages is the list of packages that are actually implicitly
-         referenced by the SDK, and is passed into the ResolvePackageAssets task
-         to verify that the restored versions of the packages matches the expected versions
-         -->
-    <ExpectedPlatformPackages Include="Microsoft.NETCore.App" ExpectedVersion="$(RuntimeFrameworkVersion)" />
+  <PropertyGroup>
+    <!--
+      Hardcoded list of known implicit packges that are added to project from default SDK targets implicitly.
+      Should be re-visited when multiple TFM support is added to Dependencies logic.
+    -->
+    <DefaultImplicitPackages>$(RuntimeFrameworkName);NETStandard.Library</DefaultImplicitPackages>
+  </PropertyGroup>
+
+  <Choose>
+
+    <When Condition="'$(RuntimeFrameworkName)' == 'Microsoft.NETCore.App'">
+      <PropertyGroup>
+        <!-- These properties will allow the latest patch versions to be set in the CLI (via BundledVersions.props) or overridden by tests -->
+        <LatestPatchVersionForNetCore1_0 Condition="'$(LatestPatchVersionForNetCore1_0)' == ''">1.0.10</LatestPatchVersionForNetCore1_0>
+        <LatestPatchVersionForNetCore1_1 Condition="'$(LatestPatchVersionForNetCore1_1)' == ''">1.1.7</LatestPatchVersionForNetCore1_1>
+        <LatestPatchVersionForNetCore2_0 Condition="'$(LatestPatchVersionForNetCore2_0)' == ''">2.0.6</LatestPatchVersionForNetCore2_0>
+      </PropertyGroup>
+
+      <PropertyGroup Condition="'$(DefaultNetCorePatchVersion)' == ''">
+        <DefaultNetCorePatchVersion Condition="'$(_TargetFrameworkVersionWithoutV)' == '1.0'">1.0.5</DefaultNetCorePatchVersion>
+        <DefaultNetCorePatchVersion Condition="'$(_TargetFrameworkVersionWithoutV)' == '1.1'">1.1.2</DefaultNetCorePatchVersion>
+
+        <!-- If targeting the same pre-release that is bundled with the .NET Core SDK, use the bundled package version
+            provided by Microsoft.NETCoreSdk.BundledVersions.props -->
+        <DefaultNetCorePatchVersion Condition="'$(DefaultNetCorePatchVersion)' == '' And '$(_TargetFrameworkVersionWithoutV)' == '$(BundledNETCoreAppTargetFrameworkVersion)' And '$(UseBundledNETCoreAppPackageVersionAsDefaultNetCorePatchVersion)' == 'true'">$(BundledNETCoreAppPackageVersion)</DefaultNetCorePatchVersion>
+        <!-- If not covered by the previous cases use the target framework version for the default patch version -->
+        <DefaultNetCorePatchVersion Condition="'$(DefaultNetCorePatchVersion)' == ''">$(_TargetFrameworkVersionWithoutV)</DefaultNetCorePatchVersion>
+      </PropertyGroup>
+
+      <PropertyGroup Condition="'$(LatestNetCorePatchVersion)' == ''">
+        <LatestNetCorePatchVersion Condition="'$(_TargetFrameworkVersionWithoutV)' == '1.0'">$(LatestPatchVersionForNetCore1_0)</LatestNetCorePatchVersion>
+        <LatestNetCorePatchVersion Condition="'$(_TargetFrameworkVersionWithoutV)' == '1.1'">$(LatestPatchVersionForNetCore1_1)</LatestNetCorePatchVersion>
+        <LatestNetCorePatchVersion Condition="'$(_TargetFrameworkVersionWithoutV)' == '2.0'">$(LatestPatchVersionForNetCore2_0)</LatestNetCorePatchVersion>
+        <LatestNetCorePatchVersion Condition="'$(_TargetFrameworkVersionWithoutV)' == '2.1'">$(LatestPatchVersionForNetCore2_1)</LatestNetCorePatchVersion>
+
+        <!-- If targeting the same pre-release that is bundled with the .NET Core SDK, use the bundled package version
+            provided by Microsoft.NETCoreSdk.BundledVersions.props -->
+        <LatestNetCorePatchVersion Condition="'$(_TargetFrameworkVersionWithoutV)' == '$(BundledNETCoreAppTargetFrameworkVersion)'">$(BundledNETCoreAppPackageVersion)</LatestNetCorePatchVersion>
+        <!-- If not covered by the previous cases use the target framework version for the latest patch version -->
+        <LatestNetCorePatchVersion Condition="'$(LatestNetCorePatchVersion)' == ''">$(_TargetFrameworkVersionWithoutV)</LatestNetCorePatchVersion>
+      </PropertyGroup>
+
+      <PropertyGroup>
+        <LatestRuntimeFrameworkPatchVersion>$(LatestNetCorePatchVersion)</LatestRuntimeFrameworkPatchVersion>
+        <DefaultRuntimeFrameworkPatchVersion>$(DefaultNetCorePatchVersion)</DefaultRuntimeFrameworkPatchVersion>
+      </PropertyGroup>
+    </When>
+
+  </Choose>
+
+  <PropertyGroup Condition="'$(RuntimeFrameworkVersion)' == ''">
+    <RuntimeFrameworkVersion Condition="'$(TargetLatestRuntimePatch)' == 'true' ">$(LatestRuntimeFrameworkPatchVersion)</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion Condition="'$(TargetLatestRuntimePatch)' != 'true' ">$(DefaultRuntimeFrameworkPatchVersion)</RuntimeFrameworkVersion>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(RuntimeFrameworkName)' != '' And '$(DisableImplicitFrameworkReferences)' != 'true'">
+    <!--
+          ExpectedPlatformPackages is the list of packages that are actually implicitly
+          referenced by the SDK, and is passed into the ResolvePackageAssets task
+          to verify that the restored versions of the packages matches the expected versions
+    -->
+    <ExpectedPlatformPackages Include="$(RuntimeFrameworkName)" ExpectedVersion="$(RuntimeFrameworkVersion)" />
   </ItemGroup>
 
-  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(DisableImplicitFrameworkReferences)' != 'true'">
+  <PropertyGroup Condition="'$(RuntimeFrameworkName)' != '' And '$(DisableImplicitFrameworkReferences)' != 'true'">
     <VerifyMatchingImplicitPackageVersion Condition="'$(VerifyMatchingImplicitPackageVersion)' == ''">true</VerifyMatchingImplicitPackageVersion>
   </PropertyGroup>
   

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -509,12 +509,14 @@ Copyright (c) .NET Foundation. All rights reserved.
   .NET Core apps can have shared frameworks that are pre-installed on the target machine, thus the app is "portable"
   to any machine that already has the shared framework installed. In order to enable this, a "platform" library
   has to be declared. The platform library and its dependencies will be excluded from the runtime assemblies.
+  By default, this should match the RuntimeFrameworkName, which users can set to target different runtimes,
+  such as ASP.NET Core.
   ============================================================
   -->
   <Target Name="_DefaultMicrosoftNETPlatformLibrary">
 
     <PropertyGroup Condition="'$(MicrosoftNETPlatformLibrary)' == ''">
-      <MicrosoftNETPlatformLibrary Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">Microsoft.NETCore.App</MicrosoftNETPlatformLibrary>
+      <MicrosoftNETPlatformLibrary>$(RuntimeFrameworkName)</MicrosoftNETPlatformLibrary>
     </PropertyGroup>
 
   </Target>

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToSetRuntimeFrameworkName.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToSetRuntimeFrameworkName.cs
@@ -1,0 +1,184 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using FluentAssertions;
+using Microsoft.DotNet.Cli.Utils;
+using Microsoft.Extensions.DependencyModel;
+using Microsoft.NET.TestFramework;
+using Microsoft.NET.TestFramework.Assertions;
+using Microsoft.NET.TestFramework.Commands;
+using Microsoft.NET.TestFramework.ProjectConstruction;
+using Newtonsoft.Json.Linq;
+using NuGet.Common;
+using NuGet.Frameworks;
+using NuGet.ProjectModel;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Linq;
+using System.Text;
+using System.Xml.Linq;
+using Xunit;
+using Xunit.Abstractions;
+using Microsoft.NET.Build.Tasks;
+using NuGet.Versioning;
+
+namespace Microsoft.NET.Build.Tests
+{
+    public class GivenThatWeWantToSetRuntimeFrameworkName : SdkTest
+    {
+        private const string AspNetTestPackageVersion = "2.1.3-feature-metapackage-chain-30910";
+        private const string ConsoleProgramSource = @"
+using System;
+
+public class Program
+{
+    public static void Main(string[] args)
+    {
+        Console.WriteLine(""Hello World!"");
+    }
+}
+";
+        private const string AspNetProgramSource = @"
+using System;
+using Microsoft.AspNetCore;
+using Microsoft.AspNetCore.Hosting;
+
+public class Program
+{
+    public static void Main(string[] args)
+    {
+        WebHost.CreateDefaultBuilder(args).Build().Run();
+    }
+}
+";
+
+        public GivenThatWeWantToSetRuntimeFrameworkName(ITestOutputHelper log) : base(log)
+        {
+        }
+
+        [Theory]
+        //  TargetFramework, RuntimeFrameworkName, RuntimeFrameworkVersion, ExpectedPackageVersion
+        [InlineData("netcoreapp2.1", "Microsoft.NETCore.App", null, "2.1.0")]
+        // TODO uncomment once 2.1.3 ships
+        // [InlineData("netcoreapp2.1", "Microsoft.AspNetCore.App", null, "2.1.3")]
+        // [InlineData("netcoreapp2.1", "Microsoft.AspNetCore.All", null, "2.1.3")]
+        [InlineData("netcoreapp2.1", "Microsoft.AspNetCore.App", AspNetTestPackageVersion, AspNetTestPackageVersion)]
+        [InlineData("netcoreapp2.1", "Microsoft.AspNetCore.All", AspNetTestPackageVersion, AspNetTestPackageVersion)]
+        public void It_targets_a_known_runtime_framework_name(
+            string targetFramework,
+            string runtimeFrameworkName,
+            string runtimeFrameworkVersion,
+            string expectedPackageVersion)
+        {
+            string testIdentifier = "SharedRuntimeTargeting_" + string.Join("_", targetFramework, runtimeFrameworkName, runtimeFrameworkVersion ?? "null");
+
+            var testProject = new TestProject
+            {
+                Name = "FrameworkTargetTest",
+                TargetFrameworks = targetFramework,
+                RuntimeFrameworkVersion = runtimeFrameworkVersion,
+                IsSdkProject = true,
+                IsExe = true,
+                RuntimeFrameworkName = runtimeFrameworkName,
+            };
+
+            testProject.SourceFiles["Program.cs"] = runtimeFrameworkName.Contains("AspNetCore")
+                ? AspNetProgramSource
+                : ConsoleProgramSource;
+
+            var testAsset = _testAssetsManager
+                .CreateTestProject(testProject, testIdentifier)
+                .Restore(Log, testProject.Name);
+
+            var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+
+            buildCommand
+                .Execute()
+                .Should()
+                .Pass();
+
+            var outputDirectory = buildCommand.GetOutputDirectory(targetFramework);
+
+            string runtimeConfigFile = Path.Combine(outputDirectory.FullName, testProject.Name + ".runtimeconfig.json");
+            string runtimeConfigContents = File.ReadAllText(runtimeConfigFile);
+            JObject runtimeConfig = JObject.Parse(runtimeConfigContents);
+
+            string actualRuntimeFrameworkName = ((JValue)runtimeConfig["runtimeOptions"]["framework"]["name"]).Value<string>();
+            actualRuntimeFrameworkName.Should().Be(runtimeFrameworkName);
+
+            string actualRuntimeFrameworkVersion = ((JValue)runtimeConfig["runtimeOptions"]["framework"]["version"]).Value<string>();
+            actualRuntimeFrameworkVersion.Should().Be(expectedPackageVersion);
+
+            LockFile lockFile = LockFileUtilities.GetLockFile(Path.Combine(buildCommand.ProjectRootPath, "obj", "project.assets.json"), NullLogger.Instance);
+
+            var target = lockFile.GetTarget(NuGetFramework.Parse(targetFramework), null);
+            var netCoreAppLibrary = target.Libraries.Single(l => l.Name == runtimeFrameworkName);
+            netCoreAppLibrary.Version.ToString().Should().Be(expectedPackageVersion);
+        }
+
+
+        [Fact]
+        public void It_fails_when_unknown_runtimeframework_name_is_used()
+        {
+            TestProject project = new TestProject()
+            {
+                Name = "UnknownFrameworkName",
+                TargetFrameworks = "netcoreapp2.1",
+                IsSdkProject = true,
+                RuntimeFrameworkName = "Banana.App",
+            };
+
+            var testAsset = _testAssetsManager.CreateTestProject(project);
+            var restoreCommand = testAsset.GetRestoreCommand(Log, project.Name);
+
+            restoreCommand.Execute()
+                .Should()
+                .Fail()
+                .And
+                .HaveStdOutContaining("error NETSDK1070:");
+        }
+
+        [Fact]
+        public void It_generates_deps_file_for_aspnet_app()
+        {
+            TestProject project = new TestProject()
+            {
+                Name = "AspNetCore21App",
+                TargetFrameworks = "netcoreapp2.1",
+                IsExe = true,
+                IsSdkProject = true,
+                RuntimeFrameworkName = "Microsoft.AspNetCore.App",
+                RuntimeFrameworkVersion = AspNetTestPackageVersion,
+            };
+
+            project.SourceFiles["Program.cs"] = AspNetProgramSource;
+
+            var testAsset = _testAssetsManager.CreateTestProject(project)
+                .Restore(Log, project.Name);
+
+            string projectFolder = Path.Combine(testAsset.Path, project.Name);
+
+            var buildCommand = new BuildCommand(Log, projectFolder);
+
+            buildCommand
+                .Execute()
+                .Should()
+                .Pass();
+
+            string outputFolder = buildCommand.GetOutputDirectory(project.TargetFrameworks).FullName;
+
+            using (var depsJsonFileStream = File.OpenRead(Path.Combine(outputFolder, $"{project.Name}.deps.json")))
+            {
+                var dependencyContext = new DependencyContextJsonReader().Read(depsJsonFileStream);
+                dependencyContext.Should()
+                    .OnlyHaveRuntimeAssemblies("", project.Name)
+                    .And
+                    .HaveNoDuplicateRuntimeAssemblies("")
+                    .And
+                    .HaveNoDuplicateNativeAssets(""); ;
+            }
+        }
+    }
+}

--- a/src/Tests/Microsoft.NET.Restore.Tests/GivenThatWeWantImplicitAspNetCorePackages.cs
+++ b/src/Tests/Microsoft.NET.Restore.Tests/GivenThatWeWantImplicitAspNetCorePackages.cs
@@ -1,0 +1,155 @@
+using System.IO;
+using System.Linq;
+using FluentAssertions;
+using Microsoft.NET.TestFramework;
+using Microsoft.NET.TestFramework.Assertions;
+using Microsoft.NET.TestFramework.ProjectConstruction;
+using NuGet.Common;
+using NuGet.Frameworks;
+using NuGet.ProjectModel;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.NET.Restore.Tests
+{
+    public class GivenThatWeWantImplicitAspNetCorePackages : SdkTest
+    {
+        // TODO: after 2.1.3 is released, remove the explicit RuntimeFrameworkVersion from tests
+        private const string _aspnetPackageVersion = "2.1.3-feature-metapackage-chain-30910";
+
+        public GivenThatWeWantImplicitAspNetCorePackages(ITestOutputHelper log) : base(log)
+        {
+        }
+
+        [Theory]
+        [InlineData("Microsoft.AspNetCore.App")]
+        [InlineData("Microsoft.AspNetCore.All")]
+        public void It_warns_when_explicit_aspnet_package_ref_exists(string packageId)
+        {
+            const string testProjectName = "AspNetCoreWithExplicitRef";
+            var project = new TestProject
+            {
+                Name = testProjectName,
+                TargetFrameworks = "netcoreapp2.1",
+                IsSdkProject = true,
+                PackageReferences =
+                {
+                    new TestPackageReference(packageId, "2.1.0")
+                }
+            };
+
+            var testAsset = _testAssetsManager
+                .CreateTestProject(project)
+                .Restore(Log, project.Name);
+
+            string projectAssetsJsonPath = Path.Combine(
+                testAsset.Path,
+                project.Name,
+                "obj",
+                "project.assets.json");
+
+            var restoreCommand =
+                testAsset.GetRestoreCommand(Log, relativePath: testProjectName);
+            restoreCommand.Execute()
+                .Should().Pass()
+                .And
+                .HaveStdOutContaining("warning NETSDK1071:")
+                .And
+                .HaveStdOutContaining(testProjectName + ".csproj");
+
+            LockFile lockFile = LockFileUtilities.GetLockFile(
+                projectAssetsJsonPath,
+                NullLogger.Instance);
+
+            var target =
+                lockFile.GetTarget(NuGetFramework.Parse(".NETCoreApp,Version=v2.1"), null);
+            var metapackageLibrary =
+                target.Libraries.Single(l => l.Name == packageId);
+            metapackageLibrary.Version.ToString().Should().Be("2.1.0");
+        }
+
+        [Theory]
+        [InlineData("Microsoft.AspNetCore.App")]
+        [InlineData("Microsoft.AspNetCore.All")]
+        public void It_warns_when_aspnet_package_ref_is_overridden(string packageId)
+        {
+            const string testProjectName = "AspNetCoreWithDuplicateRefRef";
+            var project = new TestProject
+            {
+                Name = testProjectName,
+                TargetFrameworks = "netcoreapp2.1",
+                IsSdkProject = true,
+                RuntimeFrameworkName = packageId,
+                RuntimeFrameworkVersion = _aspnetPackageVersion,
+                PackageReferences =
+                {
+                    new TestPackageReference(packageId, _aspnetPackageVersion)
+                }
+            };
+
+            var testAsset = _testAssetsManager
+                .CreateTestProject(project)
+                .Restore(Log, project.Name);
+
+            string projectAssetsJsonPath = Path.Combine(
+                testAsset.Path,
+                project.Name,
+                "obj",
+                "project.assets.json");
+
+            var restoreCommand =
+                testAsset.GetRestoreCommand(Log, relativePath: testProjectName);
+            restoreCommand.Execute()
+                .Should().Pass()
+                .And
+                .HaveStdOutContaining("warning NETSDK1023:")
+                .And
+                .HaveStdOutContaining(testProjectName + ".csproj");
+        }
+
+        [Theory]
+        [InlineData("Microsoft.AspNetCore.App")]
+        [InlineData("Microsoft.AspNetCore.All")]
+        public void It_restores_when_RuntimeFrameworkName_is_set(string packageId)
+        {
+            const string testProjectName = "RuntimeFrameworkNameProject";
+            var project = new TestProject
+            {
+                Name = testProjectName,
+                TargetFrameworks = "netcoreapp2.1",
+                IsSdkProject = true,
+                RuntimeFrameworkName = packageId,
+                RuntimeFrameworkVersion = _aspnetPackageVersion,
+            };
+
+            var testAsset = _testAssetsManager
+                .CreateTestProject(project)
+                .Restore(Log, project.Name);
+
+            string projectAssetsJsonPath = Path.Combine(
+                testAsset.Path,
+                project.Name,
+                "obj",
+                "project.assets.json");
+
+            var restoreCommand =
+                testAsset.GetRestoreCommand(Log, relativePath: testProjectName);
+            restoreCommand.Execute()
+                .Should().Pass()
+                .And
+                .NotHaveStdOutContaining("warning");;
+
+            LockFile lockFile = LockFileUtilities.GetLockFile(
+                projectAssetsJsonPath,
+                NullLogger.Instance);
+
+            var target =
+                lockFile.GetTarget(NuGetFramework.Parse(".NETCoreApp,Version=v2.1"), null);
+            var metapackageLibrary =
+                target.Libraries.Single(l => l.Name == packageId);
+            metapackageLibrary.Version.ToString().Should().Be(_aspnetPackageVersion);
+
+            target.Libraries.Should().Contain(l => l.Name == "Microsoft.NETCore.App");
+        }
+    }
+}

--- a/src/Tests/Microsoft.NET.TestFramework/ProjectConstruction/TestProject.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/ProjectConstruction/TestProject.cs
@@ -20,6 +20,8 @@ namespace Microsoft.NET.TestFramework.ProjectConstruction
 
         public string RuntimeFrameworkVersion { get; set; }
 
+        public string RuntimeFrameworkName { get; set; }
+
         public string RuntimeIdentifier { get; set; }
 
         //  TargetFrameworkVersion applies to non-SDK projects
@@ -166,6 +168,11 @@ namespace Microsoft.NET.TestFramework.ProjectConstruction
                 else
                 {
                     propertyGroup.Add(new XElement(ns + "TargetFramework", this.TargetFrameworks));
+                }
+
+                if (!string.IsNullOrEmpty(this.RuntimeFrameworkName))
+                {
+                    propertyGroup.Add(new XElement(ns + "RuntimeFrameworkName", this.RuntimeFrameworkName));
                 }
 
                 if (!string.IsNullOrEmpty(this.RuntimeFrameworkVersion))

--- a/src/Tests/Microsoft.NET.TestFramework/SetupTestRoot.targets
+++ b/src/Tests/Microsoft.NET.TestFramework/SetupTestRoot.targets
@@ -14,7 +14,7 @@
   <Target Name="_CopyDirectoryBuildTestDependencies" AfterTargets="Build" Inputs="@(_CopyDirectoryBuildTestDependenciesInput)" Outputs="@(_CopyDirectoryBuildTestDependenciesOutput)">
     <Copy SourceFiles="@(_CopyDirectoryBuildTestDependenciesInput)" DestinationFiles="@(_CopyDirectoryBuildTestDependenciesOutput)" />
   </Target>
-  
+
   <Target Name="WriteNugetConfigFile" AfterTargets="Build">
 
     <ItemGroup>
@@ -36,7 +36,7 @@
       <NugetConfigFeeds>
         <![CDATA[
     <add key="BlobFeed" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
-    <add key="aspnetcore-release" value="https://dotnet.myget.org/F/aspnetcore-release/api/v3/index.json" />
+    <add key="aspnetcore-dev" value="https://dotnet.myget.org/F/aspnetcore-dev/api/v3/index.json" />
     <add key="roslyn" value="https://dotnet.myget.org/f/roslyn/api/v3/index.json" />
     <add key="nuget-build" value="https://dotnet.myget.org/F/nuget-build/api/v3/index.json" />
     <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" />


### PR DESCRIPTION
Part of https://github.com/aspnet/Home/issues/3307

Changes:

* Introduce a new property, RuntimeFrameworkName, which defines the implicit package reference added when targeting .NET Core. The default is still 'Microsoft.NETCore.App'
* Add information about the default implicit version to use for ASP.NET Core metapackages to use (when selected as the runtime framework) 
* Fail the build if an unrecognized value for RuntimeFrameworkName is specified in a .NET Core project.

------

Marking as "NO MERGE" because there is still ongoing discussion about when this should happen (if at all). I've opened this PR so we can take a look at the actual impact on the SDK when implementing this. We're meeting later this afternoon to take a closer look.

TODO: add automated tests to verify this works on aspnet core packages

cc @DamianEdwards @dsplaisted @nguerrera @Petermarcu @tmds @vijayrkn 