### PR TITLE
[master] Conditionally pack tests as tools based on source-build

### DIFF
--- a/src/Tests/Directory.Build.targets
+++ b/src/Tests/Directory.Build.targets
@@ -5,7 +5,7 @@
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(IsTestProject)' == 'true' AND '$(OutputType)' == 'Exe'">
+  <PropertyGroup Condition="'$(IsTestProject)' == 'true' AND '$(OutputType)' == 'Exe' AND '$(DotNetBuildFromSource)' != 'true'">
     <IsPackable>true</IsPackable>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>$(PackageId)</ToolCommandName>


### PR DESCRIPTION
PackAsTool should only be set if building outside of source-build.  When building source-build, these test projects are skipped because ExcludeFromSourceBuild=true.  Exclusion fails when PackAsTool is set.