### PR TITLE
In tests, use .NET Framework reference assembly packages if targeting pack is not installed

### DIFF
--- a/src/Tests/Microsoft.NET.TestFramework/ProjectConstruction/TestProject.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/ProjectConstruction/TestProject.cs
@@ -4,6 +4,8 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Xml.Linq;
+using Microsoft.Build.Utilities;
+using NuGet.Frameworks;
 
 namespace Microsoft.NET.TestFramework.ProjectConstruction
 {
@@ -153,6 +155,15 @@ namespace Microsoft.NET.TestFramework.ProjectConstruction
                 packageReferenceItemGroup.Add(new XElement(ns + "DotNetCliToolReference",
                     new XAttribute("Include", $"{dotnetCliToolReference.ID}"),
                     new XAttribute("Version", $"{dotnetCliToolReference.Version}")));
+            }
+
+            //  If targeting .NET Framework and a required targeting pack isn't installed, add a
+            //  PackageReference to get the targeting pack from a NuGet package
+            if (NeedsReferenceAssemblyPackages())
+            {
+                packageReferenceItemGroup.Add(new XElement(ns + "PackageReference",
+                    new XAttribute("Include", $"Microsoft.NETFramework.ReferenceAssemblies"),
+                    new XAttribute("Version", $"1.0.0-alpha-004")));
             }
 
             var targetFrameworks = IsSdkProject ? TargetFrameworks.Split(';') : new[] { "net" };
@@ -306,6 +317,55 @@ namespace {this.Name}
             {
                 File.WriteAllText(Path.Combine(targetFolder, kvp.Key), kvp.Value);
             }
+        }
+
+        private bool NeedsReferenceAssemblyPackages()
+        {
+            //  Check to see if NuGet packages for reference assemblies need to be referenced (because
+            //  the targeting pack is not installed)
+            bool needsReferenceAssemblyPackages = false;
+            if (IsSdkProject)
+            {
+                foreach (var shortFrameworkName in TargetFrameworks.Split(';').Where(tf => GetShortTargetFrameworkIdentifier(tf) == "net"))
+                {
+                    //  Normalize version to the form used in the reference assemblies path
+                    var version = NuGetFramework.Parse(shortFrameworkName).Version;
+                    version = new Version(version.Major, version.Minor, version.Build);
+                    if (version.Build == 0)
+                    {
+                        version = new Version(version.Major, version.Minor);
+                    }
+                    
+                    if (!ReferenceAssembliesAreInstalled(version.ToString()))
+                    {
+                        needsReferenceAssemblyPackages = true;
+                    }
+                }
+            }
+            else
+            {
+                needsReferenceAssemblyPackages = !ReferenceAssembliesAreInstalled(TargetFrameworkVersion);
+            }
+
+            return needsReferenceAssemblyPackages;
+        }
+
+        private bool ReferenceAssembliesAreInstalled(string targetFrameworkVersion)
+        {
+            if (!targetFrameworkVersion.StartsWith('v'))
+            {
+                targetFrameworkVersion = "v" + targetFrameworkVersion;
+            }
+
+            // Use the MSBuild API to find the path to the 4.6.1 reference assemblies, and locate the desired reference assemblies relative to that.
+            var net461referenceAssemblies = ToolLocationHelper.GetPathToDotNetFrameworkReferenceAssemblies(TargetDotNetFrameworkVersion.Version461);
+            if (net461referenceAssemblies == null)
+            {
+                //  4.6.1 reference assemblies not found, assume that the version we want isn't available either
+                return false;
+            }
+            var requestedReferenceAssembliesPath = Path.Combine(new DirectoryInfo(net461referenceAssemblies).Parent.FullName, targetFrameworkVersion);
+            return Directory.Exists(requestedReferenceAssembliesPath);
         }
 
         public override string ToString()

--- a/src/Tests/Microsoft.NET.TestFramework/SetupTestRoot.targets
+++ b/src/Tests/Microsoft.NET.TestFramework/SetupTestRoot.targets
@@ -41,6 +41,7 @@
     <add key="nuget-build" value="https://dotnet.myget.org/F/nuget-build/api/v3/index.json" />
     <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" />
     <add key="container-tools" value="https://www.myget.org/F/container-tools-for-visual-studio/api/v3/index.json" />
+    <add key="roslyn-tools" value="https://dotnet.myget.org/F/roslyn-tools/api/v3/index.json" />
         ]]>
       </NugetConfigFeeds>
 


### PR DESCRIPTION
This should fix issues we've had with test failures on agents that don't have the .NET 4.7.2 targeting pack installed.