### PR TITLE
[WIP NO MERGE]:  Add support for RuntimeFrameworkName to add an additional implicit package ref for ASP.NET Core 2.1 projects

### DIFF
--- a/src/Tasks/Common/Resources/Strings.resx
+++ b/src/Tasks/Common/Resources/Strings.resx
@@ -397,4 +397,16 @@ The following are names of parameters or literal values and should not be transl
     <value>NETSDK1069: This project uses a library that targets .NET Standard 1.5 or higher, and the project targets a version of .NET Framework that doesn't have built-in support for that version of .NET Standard. Visit https://aka.ms/net-standard-known-issues for a set of known issues. Consider retargeting to .NET Framework 4.7.2.</value>
     <comment>{StrBegin="NETSDK1069: "}</comment>
   </data>
+  <data name="UnrecognizedRuntimeFrameworkName" xml:space="preserve">
+    <value>NETSDK1070: This project uses an unsupported value for RuntimeFrameworkName. Currently, only valid values are: Microsoft.NETCore.App, Microsoft.AspNetCore.App, or Microsoft.AspNetCore.All.</value>
+    <comment>{StrBegin="NETSDK1070: "}</comment>
+  </data>
+  <data name="RecommendRuntimeFrameworkNameForAspNetCorePackages" xml:space="preserve">
+    <value>NETSDK1071: A PackageReference for '{0}' was included in your project. This package can be implicitly defined by the SDK. To resolve this warning, remove this PackageReference and set the RuntimeFrameworkName property to {1}. For more information, see {2}.</value>
+    <comment>{StrBegin="NETSDK1071: "}
+{0} - Package Id (Microsoft.AspNetCore.App or .All)
+{1} - Project name
+{2} - More info link
+    </comment>
+  </data>
 </root>

--- a/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
@@ -62,6 +62,15 @@
         <target state="needs-review-translation">Chybí metadata {0} o {1} položky {2}.</target>
         <note>{StrBegin="NETSDK1008: "}</note>
       </trans-unit>
+      <trans-unit id="RecommendRuntimeFrameworkNameForAspNetCorePackages">
+        <source>NETSDK1071: A PackageReference for '{0}' was included in your project. This package can be implicitly defined by the SDK. To resolve this warning, remove this PackageReference and set the RuntimeFrameworkName property to {1}. For more information, see {2}.</source>
+        <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. This package can be implicitly defined by the SDK. To resolve this warning, remove this PackageReference and set the RuntimeFrameworkName property to {1}. For more information, see {2}.</target>
+        <note>{StrBegin="NETSDK1071: "}
+{0} - Package Id (Microsoft.AspNetCore.App or .All)
+{1} - Project name
+{2} - More info link
+    </note>
+      </trans-unit>
       <trans-unit id="UnrecognizedPreprocessorToken">
         <source>NETSDK1009: Unrecognized preprocessor token '{0}' in '{1}'.</source>
         <target state="needs-review-translation">Nerozpoznaný token preprocesoru {0} v {1}.</target>
@@ -111,6 +120,11 @@
         <source>NETSDK1018: Invalid NuGet version string: '{0}'.</source>
         <target state="needs-review-translation">Neplatný řetězec verze NuGet: {0}</target>
         <note>{StrBegin="NETSDK1018: "}</note>
+      </trans-unit>
+      <trans-unit id="UnrecognizedRuntimeFrameworkName">
+        <source>NETSDK1070: This project uses an unsupported value for RuntimeFrameworkName. Currently, only valid values are: Microsoft.NETCore.App, Microsoft.AspNetCore.App, or Microsoft.AspNetCore.All.</source>
+        <target state="new">NETSDK1070: This project uses an unsupported value for RuntimeFrameworkName. Currently, only valid values are: Microsoft.NETCore.App, Microsoft.AspNetCore.App, or Microsoft.AspNetCore.All.</target>
+        <note>{StrBegin="NETSDK1070: "}</note>
       </trans-unit>
       <trans-unit id="UnsupportedFramework">
         <source>NETSDK1019: {0} is an unsupported framework.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
@@ -62,15 +62,6 @@
         <target state="needs-review-translation">Chybí metadata {0} o {1} položky {2}.</target>
         <note>{StrBegin="NETSDK1008: "}</note>
       </trans-unit>
-      <trans-unit id="RecommendRuntimeFrameworkNameForAspNetCorePackages">
-        <source>NETSDK1071: A PackageReference for '{0}' was included in your project. This package can be implicitly defined by the SDK. To resolve this warning, remove this PackageReference and set the RuntimeFrameworkName property to {1}. For more information, see {2}.</source>
-        <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. This package can be implicitly defined by the SDK. To resolve this warning, remove this PackageReference and set the RuntimeFrameworkName property to {1}. For more information, see {2}.</target>
-        <note>{StrBegin="NETSDK1071: "}
-{0} - Package Id (Microsoft.AspNetCore.App or .All)
-{1} - Project name
-{2} - More info link
-    </note>
-      </trans-unit>
       <trans-unit id="UnrecognizedPreprocessorToken">
         <source>NETSDK1009: Unrecognized preprocessor token '{0}' in '{1}'.</source>
         <target state="needs-review-translation">Nerozpoznaný token preprocesoru {0} v {1}.</target>
@@ -120,11 +111,6 @@
         <source>NETSDK1018: Invalid NuGet version string: '{0}'.</source>
         <target state="needs-review-translation">Neplatný řetězec verze NuGet: {0}</target>
         <note>{StrBegin="NETSDK1018: "}</note>
-      </trans-unit>
-      <trans-unit id="UnrecognizedRuntimeFrameworkName">
-        <source>NETSDK1070: This project uses an unsupported value for RuntimeFrameworkName. Currently, only valid values are: Microsoft.NETCore.App, Microsoft.AspNetCore.App, or Microsoft.AspNetCore.All.</source>
-        <target state="new">NETSDK1070: This project uses an unsupported value for RuntimeFrameworkName. Currently, only valid values are: Microsoft.NETCore.App, Microsoft.AspNetCore.App, or Microsoft.AspNetCore.All.</target>
-        <note>{StrBegin="NETSDK1070: "}</note>
       </trans-unit>
       <trans-unit id="UnsupportedFramework">
         <source>NETSDK1019: {0} is an unsupported framework.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.de.xlf
@@ -62,15 +62,6 @@
         <target state="needs-review-translation">Die Metadaten "{0}" für das Element "{2}" vom Typ "{1}" sind nicht vorhanden.</target>
         <note>{StrBegin="NETSDK1008: "}</note>
       </trans-unit>
-      <trans-unit id="RecommendRuntimeFrameworkNameForAspNetCorePackages">
-        <source>NETSDK1071: A PackageReference for '{0}' was included in your project. This package can be implicitly defined by the SDK. To resolve this warning, remove this PackageReference and set the RuntimeFrameworkName property to {1}. For more information, see {2}.</source>
-        <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. This package can be implicitly defined by the SDK. To resolve this warning, remove this PackageReference and set the RuntimeFrameworkName property to {1}. For more information, see {2}.</target>
-        <note>{StrBegin="NETSDK1071: "}
-{0} - Package Id (Microsoft.AspNetCore.App or .All)
-{1} - Project name
-{2} - More info link
-    </note>
-      </trans-unit>
       <trans-unit id="UnrecognizedPreprocessorToken">
         <source>NETSDK1009: Unrecognized preprocessor token '{0}' in '{1}'.</source>
         <target state="needs-review-translation">Unbekanntes Präprozessortoken "{0}" in "{1}".</target>
@@ -120,11 +111,6 @@
         <source>NETSDK1018: Invalid NuGet version string: '{0}'.</source>
         <target state="needs-review-translation">Ungültige NuGet-Versionszeichenfolge: {0}.</target>
         <note>{StrBegin="NETSDK1018: "}</note>
-      </trans-unit>
-      <trans-unit id="UnrecognizedRuntimeFrameworkName">
-        <source>NETSDK1070: This project uses an unsupported value for RuntimeFrameworkName. Currently, only valid values are: Microsoft.NETCore.App, Microsoft.AspNetCore.App, or Microsoft.AspNetCore.All.</source>
-        <target state="new">NETSDK1070: This project uses an unsupported value for RuntimeFrameworkName. Currently, only valid values are: Microsoft.NETCore.App, Microsoft.AspNetCore.App, or Microsoft.AspNetCore.All.</target>
-        <note>{StrBegin="NETSDK1070: "}</note>
       </trans-unit>
       <trans-unit id="UnsupportedFramework">
         <source>NETSDK1019: {0} is an unsupported framework.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.de.xlf
@@ -62,6 +62,15 @@
         <target state="needs-review-translation">Die Metadaten "{0}" für das Element "{2}" vom Typ "{1}" sind nicht vorhanden.</target>
         <note>{StrBegin="NETSDK1008: "}</note>
       </trans-unit>
+      <trans-unit id="RecommendRuntimeFrameworkNameForAspNetCorePackages">
+        <source>NETSDK1071: A PackageReference for '{0}' was included in your project. This package can be implicitly defined by the SDK. To resolve this warning, remove this PackageReference and set the RuntimeFrameworkName property to {1}. For more information, see {2}.</source>
+        <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. This package can be implicitly defined by the SDK. To resolve this warning, remove this PackageReference and set the RuntimeFrameworkName property to {1}. For more information, see {2}.</target>
+        <note>{StrBegin="NETSDK1071: "}
+{0} - Package Id (Microsoft.AspNetCore.App or .All)
+{1} - Project name
+{2} - More info link
+    </note>
+      </trans-unit>
       <trans-unit id="UnrecognizedPreprocessorToken">
         <source>NETSDK1009: Unrecognized preprocessor token '{0}' in '{1}'.</source>
         <target state="needs-review-translation">Unbekanntes Präprozessortoken "{0}" in "{1}".</target>
@@ -111,6 +120,11 @@
         <source>NETSDK1018: Invalid NuGet version string: '{0}'.</source>
         <target state="needs-review-translation">Ungültige NuGet-Versionszeichenfolge: {0}.</target>
         <note>{StrBegin="NETSDK1018: "}</note>
+      </trans-unit>
+      <trans-unit id="UnrecognizedRuntimeFrameworkName">
+        <source>NETSDK1070: This project uses an unsupported value for RuntimeFrameworkName. Currently, only valid values are: Microsoft.NETCore.App, Microsoft.AspNetCore.App, or Microsoft.AspNetCore.All.</source>
+        <target state="new">NETSDK1070: This project uses an unsupported value for RuntimeFrameworkName. Currently, only valid values are: Microsoft.NETCore.App, Microsoft.AspNetCore.App, or Microsoft.AspNetCore.All.</target>
+        <note>{StrBegin="NETSDK1070: "}</note>
       </trans-unit>
       <trans-unit id="UnsupportedFramework">
         <source>NETSDK1019: {0} is an unsupported framework.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.es.xlf
@@ -62,15 +62,6 @@
         <target state="needs-review-translation">Faltan los metadatos de "{0}" en el elemento de "{1}" "{2}".</target>
         <note>{StrBegin="NETSDK1008: "}</note>
       </trans-unit>
-      <trans-unit id="RecommendRuntimeFrameworkNameForAspNetCorePackages">
-        <source>NETSDK1071: A PackageReference for '{0}' was included in your project. This package can be implicitly defined by the SDK. To resolve this warning, remove this PackageReference and set the RuntimeFrameworkName property to {1}. For more information, see {2}.</source>
-        <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. This package can be implicitly defined by the SDK. To resolve this warning, remove this PackageReference and set the RuntimeFrameworkName property to {1}. For more information, see {2}.</target>
-        <note>{StrBegin="NETSDK1071: "}
-{0} - Package Id (Microsoft.AspNetCore.App or .All)
-{1} - Project name
-{2} - More info link
-    </note>
-      </trans-unit>
       <trans-unit id="UnrecognizedPreprocessorToken">
         <source>NETSDK1009: Unrecognized preprocessor token '{0}' in '{1}'.</source>
         <target state="needs-review-translation">Token de preprocesador no reconocido "{0}" en "{1}".</target>
@@ -120,11 +111,6 @@
         <source>NETSDK1018: Invalid NuGet version string: '{0}'.</source>
         <target state="needs-review-translation">Cadena de versión de NuGet no válida: "{0}".</target>
         <note>{StrBegin="NETSDK1018: "}</note>
-      </trans-unit>
-      <trans-unit id="UnrecognizedRuntimeFrameworkName">
-        <source>NETSDK1070: This project uses an unsupported value for RuntimeFrameworkName. Currently, only valid values are: Microsoft.NETCore.App, Microsoft.AspNetCore.App, or Microsoft.AspNetCore.All.</source>
-        <target state="new">NETSDK1070: This project uses an unsupported value for RuntimeFrameworkName. Currently, only valid values are: Microsoft.NETCore.App, Microsoft.AspNetCore.App, or Microsoft.AspNetCore.All.</target>
-        <note>{StrBegin="NETSDK1070: "}</note>
       </trans-unit>
       <trans-unit id="UnsupportedFramework">
         <source>NETSDK1019: {0} is an unsupported framework.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.es.xlf
@@ -62,6 +62,15 @@
         <target state="needs-review-translation">Faltan los metadatos de "{0}" en el elemento de "{1}" "{2}".</target>
         <note>{StrBegin="NETSDK1008: "}</note>
       </trans-unit>
+      <trans-unit id="RecommendRuntimeFrameworkNameForAspNetCorePackages">
+        <source>NETSDK1071: A PackageReference for '{0}' was included in your project. This package can be implicitly defined by the SDK. To resolve this warning, remove this PackageReference and set the RuntimeFrameworkName property to {1}. For more information, see {2}.</source>
+        <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. This package can be implicitly defined by the SDK. To resolve this warning, remove this PackageReference and set the RuntimeFrameworkName property to {1}. For more information, see {2}.</target>
+        <note>{StrBegin="NETSDK1071: "}
+{0} - Package Id (Microsoft.AspNetCore.App or .All)
+{1} - Project name
+{2} - More info link
+    </note>
+      </trans-unit>
       <trans-unit id="UnrecognizedPreprocessorToken">
         <source>NETSDK1009: Unrecognized preprocessor token '{0}' in '{1}'.</source>
         <target state="needs-review-translation">Token de preprocesador no reconocido "{0}" en "{1}".</target>
@@ -111,6 +120,11 @@
         <source>NETSDK1018: Invalid NuGet version string: '{0}'.</source>
         <target state="needs-review-translation">Cadena de versión de NuGet no válida: "{0}".</target>
         <note>{StrBegin="NETSDK1018: "}</note>
+      </trans-unit>
+      <trans-unit id="UnrecognizedRuntimeFrameworkName">
+        <source>NETSDK1070: This project uses an unsupported value for RuntimeFrameworkName. Currently, only valid values are: Microsoft.NETCore.App, Microsoft.AspNetCore.App, or Microsoft.AspNetCore.All.</source>
+        <target state="new">NETSDK1070: This project uses an unsupported value for RuntimeFrameworkName. Currently, only valid values are: Microsoft.NETCore.App, Microsoft.AspNetCore.App, or Microsoft.AspNetCore.All.</target>
+        <note>{StrBegin="NETSDK1070: "}</note>
       </trans-unit>
       <trans-unit id="UnsupportedFramework">
         <source>NETSDK1019: {0} is an unsupported framework.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
@@ -62,15 +62,6 @@
         <target state="needs-review-translation">Métadonnées '{0}' manquantes sur l'élément '{1}' '{2}'.</target>
         <note>{StrBegin="NETSDK1008: "}</note>
       </trans-unit>
-      <trans-unit id="RecommendRuntimeFrameworkNameForAspNetCorePackages">
-        <source>NETSDK1071: A PackageReference for '{0}' was included in your project. This package can be implicitly defined by the SDK. To resolve this warning, remove this PackageReference and set the RuntimeFrameworkName property to {1}. For more information, see {2}.</source>
-        <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. This package can be implicitly defined by the SDK. To resolve this warning, remove this PackageReference and set the RuntimeFrameworkName property to {1}. For more information, see {2}.</target>
-        <note>{StrBegin="NETSDK1071: "}
-{0} - Package Id (Microsoft.AspNetCore.App or .All)
-{1} - Project name
-{2} - More info link
-    </note>
-      </trans-unit>
       <trans-unit id="UnrecognizedPreprocessorToken">
         <source>NETSDK1009: Unrecognized preprocessor token '{0}' in '{1}'.</source>
         <target state="needs-review-translation">Jeton de préprocesseur '{0}' non reconnu dans '{1}'.</target>
@@ -120,11 +111,6 @@
         <source>NETSDK1018: Invalid NuGet version string: '{0}'.</source>
         <target state="needs-review-translation">Chaîne de version NuGet non valide : '{0}'.</target>
         <note>{StrBegin="NETSDK1018: "}</note>
-      </trans-unit>
-      <trans-unit id="UnrecognizedRuntimeFrameworkName">
-        <source>NETSDK1070: This project uses an unsupported value for RuntimeFrameworkName. Currently, only valid values are: Microsoft.NETCore.App, Microsoft.AspNetCore.App, or Microsoft.AspNetCore.All.</source>
-        <target state="new">NETSDK1070: This project uses an unsupported value for RuntimeFrameworkName. Currently, only valid values are: Microsoft.NETCore.App, Microsoft.AspNetCore.App, or Microsoft.AspNetCore.All.</target>
-        <note>{StrBegin="NETSDK1070: "}</note>
       </trans-unit>
       <trans-unit id="UnsupportedFramework">
         <source>NETSDK1019: {0} is an unsupported framework.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
@@ -62,6 +62,15 @@
         <target state="needs-review-translation">Métadonnées '{0}' manquantes sur l'élément '{1}' '{2}'.</target>
         <note>{StrBegin="NETSDK1008: "}</note>
       </trans-unit>
+      <trans-unit id="RecommendRuntimeFrameworkNameForAspNetCorePackages">
+        <source>NETSDK1071: A PackageReference for '{0}' was included in your project. This package can be implicitly defined by the SDK. To resolve this warning, remove this PackageReference and set the RuntimeFrameworkName property to {1}. For more information, see {2}.</source>
+        <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. This package can be implicitly defined by the SDK. To resolve this warning, remove this PackageReference and set the RuntimeFrameworkName property to {1}. For more information, see {2}.</target>
+        <note>{StrBegin="NETSDK1071: "}
+{0} - Package Id (Microsoft.AspNetCore.App or .All)
+{1} - Project name
+{2} - More info link
+    </note>
+      </trans-unit>
       <trans-unit id="UnrecognizedPreprocessorToken">
         <source>NETSDK1009: Unrecognized preprocessor token '{0}' in '{1}'.</source>
         <target state="needs-review-translation">Jeton de préprocesseur '{0}' non reconnu dans '{1}'.</target>
@@ -111,6 +120,11 @@
         <source>NETSDK1018: Invalid NuGet version string: '{0}'.</source>
         <target state="needs-review-translation">Chaîne de version NuGet non valide : '{0}'.</target>
         <note>{StrBegin="NETSDK1018: "}</note>
+      </trans-unit>
+      <trans-unit id="UnrecognizedRuntimeFrameworkName">
+        <source>NETSDK1070: This project uses an unsupported value for RuntimeFrameworkName. Currently, only valid values are: Microsoft.NETCore.App, Microsoft.AspNetCore.App, or Microsoft.AspNetCore.All.</source>
+        <target state="new">NETSDK1070: This project uses an unsupported value for RuntimeFrameworkName. Currently, only valid values are: Microsoft.NETCore.App, Microsoft.AspNetCore.App, or Microsoft.AspNetCore.All.</target>
+        <note>{StrBegin="NETSDK1070: "}</note>
       </trans-unit>
       <trans-unit id="UnsupportedFramework">
         <source>NETSDK1019: {0} is an unsupported framework.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.it.xlf
@@ -62,15 +62,6 @@
         <target state="needs-review-translation">Mancano i metadati di '{0}' sull'elemento '{2}' di '{1}'.</target>
         <note>{StrBegin="NETSDK1008: "}</note>
       </trans-unit>
-      <trans-unit id="RecommendRuntimeFrameworkNameForAspNetCorePackages">
-        <source>NETSDK1071: A PackageReference for '{0}' was included in your project. This package can be implicitly defined by the SDK. To resolve this warning, remove this PackageReference and set the RuntimeFrameworkName property to {1}. For more information, see {2}.</source>
-        <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. This package can be implicitly defined by the SDK. To resolve this warning, remove this PackageReference and set the RuntimeFrameworkName property to {1}. For more information, see {2}.</target>
-        <note>{StrBegin="NETSDK1071: "}
-{0} - Package Id (Microsoft.AspNetCore.App or .All)
-{1} - Project name
-{2} - More info link
-    </note>
-      </trans-unit>
       <trans-unit id="UnrecognizedPreprocessorToken">
         <source>NETSDK1009: Unrecognized preprocessor token '{0}' in '{1}'.</source>
         <target state="needs-review-translation">Token di preprocessore '{0}' non riconosciuto in '{1}'.</target>
@@ -120,11 +111,6 @@
         <source>NETSDK1018: Invalid NuGet version string: '{0}'.</source>
         <target state="needs-review-translation">La stringa di versione '{0}' di NuGet non è valida.</target>
         <note>{StrBegin="NETSDK1018: "}</note>
-      </trans-unit>
-      <trans-unit id="UnrecognizedRuntimeFrameworkName">
-        <source>NETSDK1070: This project uses an unsupported value for RuntimeFrameworkName. Currently, only valid values are: Microsoft.NETCore.App, Microsoft.AspNetCore.App, or Microsoft.AspNetCore.All.</source>
-        <target state="new">NETSDK1070: This project uses an unsupported value for RuntimeFrameworkName. Currently, only valid values are: Microsoft.NETCore.App, Microsoft.AspNetCore.App, or Microsoft.AspNetCore.All.</target>
-        <note>{StrBegin="NETSDK1070: "}</note>
       </trans-unit>
       <trans-unit id="UnsupportedFramework">
         <source>NETSDK1019: {0} is an unsupported framework.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.it.xlf
@@ -62,6 +62,15 @@
         <target state="needs-review-translation">Mancano i metadati di '{0}' sull'elemento '{2}' di '{1}'.</target>
         <note>{StrBegin="NETSDK1008: "}</note>
       </trans-unit>
+      <trans-unit id="RecommendRuntimeFrameworkNameForAspNetCorePackages">
+        <source>NETSDK1071: A PackageReference for '{0}' was included in your project. This package can be implicitly defined by the SDK. To resolve this warning, remove this PackageReference and set the RuntimeFrameworkName property to {1}. For more information, see {2}.</source>
+        <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. This package can be implicitly defined by the SDK. To resolve this warning, remove this PackageReference and set the RuntimeFrameworkName property to {1}. For more information, see {2}.</target>
+        <note>{StrBegin="NETSDK1071: "}
+{0} - Package Id (Microsoft.AspNetCore.App or .All)
+{1} - Project name
+{2} - More info link
+    </note>
+      </trans-unit>
       <trans-unit id="UnrecognizedPreprocessorToken">
         <source>NETSDK1009: Unrecognized preprocessor token '{0}' in '{1}'.</source>
         <target state="needs-review-translation">Token di preprocessore '{0}' non riconosciuto in '{1}'.</target>
@@ -111,6 +120,11 @@
         <source>NETSDK1018: Invalid NuGet version string: '{0}'.</source>
         <target state="needs-review-translation">La stringa di versione '{0}' di NuGet non è valida.</target>
         <note>{StrBegin="NETSDK1018: "}</note>
+      </trans-unit>
+      <trans-unit id="UnrecognizedRuntimeFrameworkName">
+        <source>NETSDK1070: This project uses an unsupported value for RuntimeFrameworkName. Currently, only valid values are: Microsoft.NETCore.App, Microsoft.AspNetCore.App, or Microsoft.AspNetCore.All.</source>
+        <target state="new">NETSDK1070: This project uses an unsupported value for RuntimeFrameworkName. Currently, only valid values are: Microsoft.NETCore.App, Microsoft.AspNetCore.App, or Microsoft.AspNetCore.All.</target>
+        <note>{StrBegin="NETSDK1070: "}</note>
       </trans-unit>
       <trans-unit id="UnsupportedFramework">
         <source>NETSDK1019: {0} is an unsupported framework.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
@@ -62,6 +62,15 @@
         <target state="needs-review-translation">'{1}' 項目 '{2}' の '{0}' メタデータがありません。</target>
         <note>{StrBegin="NETSDK1008: "}</note>
       </trans-unit>
+      <trans-unit id="RecommendRuntimeFrameworkNameForAspNetCorePackages">
+        <source>NETSDK1071: A PackageReference for '{0}' was included in your project. This package can be implicitly defined by the SDK. To resolve this warning, remove this PackageReference and set the RuntimeFrameworkName property to {1}. For more information, see {2}.</source>
+        <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. This package can be implicitly defined by the SDK. To resolve this warning, remove this PackageReference and set the RuntimeFrameworkName property to {1}. For more information, see {2}.</target>
+        <note>{StrBegin="NETSDK1071: "}
+{0} - Package Id (Microsoft.AspNetCore.App or .All)
+{1} - Project name
+{2} - More info link
+    </note>
+      </trans-unit>
       <trans-unit id="UnrecognizedPreprocessorToken">
         <source>NETSDK1009: Unrecognized preprocessor token '{0}' in '{1}'.</source>
         <target state="needs-review-translation">認識されないプリプロセッサ トークン '{0}' が '{1}' に存在します。</target>
@@ -111,6 +120,11 @@
         <source>NETSDK1018: Invalid NuGet version string: '{0}'.</source>
         <target state="needs-review-translation">無効な NuGet バージョン文字列: '{0}'。</target>
         <note>{StrBegin="NETSDK1018: "}</note>
+      </trans-unit>
+      <trans-unit id="UnrecognizedRuntimeFrameworkName">
+        <source>NETSDK1070: This project uses an unsupported value for RuntimeFrameworkName. Currently, only valid values are: Microsoft.NETCore.App, Microsoft.AspNetCore.App, or Microsoft.AspNetCore.All.</source>
+        <target state="new">NETSDK1070: This project uses an unsupported value for RuntimeFrameworkName. Currently, only valid values are: Microsoft.NETCore.App, Microsoft.AspNetCore.App, or Microsoft.AspNetCore.All.</target>
+        <note>{StrBegin="NETSDK1070: "}</note>
       </trans-unit>
       <trans-unit id="UnsupportedFramework">
         <source>NETSDK1019: {0} is an unsupported framework.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
@@ -62,15 +62,6 @@
         <target state="needs-review-translation">'{1}' 項目 '{2}' の '{0}' メタデータがありません。</target>
         <note>{StrBegin="NETSDK1008: "}</note>
       </trans-unit>
-      <trans-unit id="RecommendRuntimeFrameworkNameForAspNetCorePackages">
-        <source>NETSDK1071: A PackageReference for '{0}' was included in your project. This package can be implicitly defined by the SDK. To resolve this warning, remove this PackageReference and set the RuntimeFrameworkName property to {1}. For more information, see {2}.</source>
-        <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. This package can be implicitly defined by the SDK. To resolve this warning, remove this PackageReference and set the RuntimeFrameworkName property to {1}. For more information, see {2}.</target>
-        <note>{StrBegin="NETSDK1071: "}
-{0} - Package Id (Microsoft.AspNetCore.App or .All)
-{1} - Project name
-{2} - More info link
-    </note>
-      </trans-unit>
       <trans-unit id="UnrecognizedPreprocessorToken">
         <source>NETSDK1009: Unrecognized preprocessor token '{0}' in '{1}'.</source>
         <target state="needs-review-translation">認識されないプリプロセッサ トークン '{0}' が '{1}' に存在します。</target>
@@ -120,11 +111,6 @@
         <source>NETSDK1018: Invalid NuGet version string: '{0}'.</source>
         <target state="needs-review-translation">無効な NuGet バージョン文字列: '{0}'。</target>
         <note>{StrBegin="NETSDK1018: "}</note>
-      </trans-unit>
-      <trans-unit id="UnrecognizedRuntimeFrameworkName">
-        <source>NETSDK1070: This project uses an unsupported value for RuntimeFrameworkName. Currently, only valid values are: Microsoft.NETCore.App, Microsoft.AspNetCore.App, or Microsoft.AspNetCore.All.</source>
-        <target state="new">NETSDK1070: This project uses an unsupported value for RuntimeFrameworkName. Currently, only valid values are: Microsoft.NETCore.App, Microsoft.AspNetCore.App, or Microsoft.AspNetCore.All.</target>
-        <note>{StrBegin="NETSDK1070: "}</note>
       </trans-unit>
       <trans-unit id="UnsupportedFramework">
         <source>NETSDK1019: {0} is an unsupported framework.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
@@ -62,6 +62,15 @@
         <target state="needs-review-translation">'{1}' 항목 '{2}'에 '{0}' 메타데이터가 없습니다.</target>
         <note>{StrBegin="NETSDK1008: "}</note>
       </trans-unit>
+      <trans-unit id="RecommendRuntimeFrameworkNameForAspNetCorePackages">
+        <source>NETSDK1071: A PackageReference for '{0}' was included in your project. This package can be implicitly defined by the SDK. To resolve this warning, remove this PackageReference and set the RuntimeFrameworkName property to {1}. For more information, see {2}.</source>
+        <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. This package can be implicitly defined by the SDK. To resolve this warning, remove this PackageReference and set the RuntimeFrameworkName property to {1}. For more information, see {2}.</target>
+        <note>{StrBegin="NETSDK1071: "}
+{0} - Package Id (Microsoft.AspNetCore.App or .All)
+{1} - Project name
+{2} - More info link
+    </note>
+      </trans-unit>
       <trans-unit id="UnrecognizedPreprocessorToken">
         <source>NETSDK1009: Unrecognized preprocessor token '{0}' in '{1}'.</source>
         <target state="needs-review-translation">'{1}'에서 전처리기 토큰 '{0}'을(를) 인식할 수 없습니다.</target>
@@ -111,6 +120,11 @@
         <source>NETSDK1018: Invalid NuGet version string: '{0}'.</source>
         <target state="needs-review-translation">NuGet 버전 문자열 '{0}'이(가) 잘못되었습니다.</target>
         <note>{StrBegin="NETSDK1018: "}</note>
+      </trans-unit>
+      <trans-unit id="UnrecognizedRuntimeFrameworkName">
+        <source>NETSDK1070: This project uses an unsupported value for RuntimeFrameworkName. Currently, only valid values are: Microsoft.NETCore.App, Microsoft.AspNetCore.App, or Microsoft.AspNetCore.All.</source>
+        <target state="new">NETSDK1070: This project uses an unsupported value for RuntimeFrameworkName. Currently, only valid values are: Microsoft.NETCore.App, Microsoft.AspNetCore.App, or Microsoft.AspNetCore.All.</target>
+        <note>{StrBegin="NETSDK1070: "}</note>
       </trans-unit>
       <trans-unit id="UnsupportedFramework">
         <source>NETSDK1019: {0} is an unsupported framework.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
@@ -62,15 +62,6 @@
         <target state="needs-review-translation">'{1}' 항목 '{2}'에 '{0}' 메타데이터가 없습니다.</target>
         <note>{StrBegin="NETSDK1008: "}</note>
       </trans-unit>
-      <trans-unit id="RecommendRuntimeFrameworkNameForAspNetCorePackages">
-        <source>NETSDK1071: A PackageReference for '{0}' was included in your project. This package can be implicitly defined by the SDK. To resolve this warning, remove this PackageReference and set the RuntimeFrameworkName property to {1}. For more information, see {2}.</source>
-        <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. This package can be implicitly defined by the SDK. To resolve this warning, remove this PackageReference and set the RuntimeFrameworkName property to {1}. For more information, see {2}.</target>
-        <note>{StrBegin="NETSDK1071: "}
-{0} - Package Id (Microsoft.AspNetCore.App or .All)
-{1} - Project name
-{2} - More info link
-    </note>
-      </trans-unit>
       <trans-unit id="UnrecognizedPreprocessorToken">
         <source>NETSDK1009: Unrecognized preprocessor token '{0}' in '{1}'.</source>
         <target state="needs-review-translation">'{1}'에서 전처리기 토큰 '{0}'을(를) 인식할 수 없습니다.</target>
@@ -120,11 +111,6 @@
         <source>NETSDK1018: Invalid NuGet version string: '{0}'.</source>
         <target state="needs-review-translation">NuGet 버전 문자열 '{0}'이(가) 잘못되었습니다.</target>
         <note>{StrBegin="NETSDK1018: "}</note>
-      </trans-unit>
-      <trans-unit id="UnrecognizedRuntimeFrameworkName">
-        <source>NETSDK1070: This project uses an unsupported value for RuntimeFrameworkName. Currently, only valid values are: Microsoft.NETCore.App, Microsoft.AspNetCore.App, or Microsoft.AspNetCore.All.</source>
-        <target state="new">NETSDK1070: This project uses an unsupported value for RuntimeFrameworkName. Currently, only valid values are: Microsoft.NETCore.App, Microsoft.AspNetCore.App, or Microsoft.AspNetCore.All.</target>
-        <note>{StrBegin="NETSDK1070: "}</note>
       </trans-unit>
       <trans-unit id="UnsupportedFramework">
         <source>NETSDK1019: {0} is an unsupported framework.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
@@ -62,6 +62,15 @@
         <target state="needs-review-translation">Brak metadanych „{0}” w elemencie „{1}” „{2}”.</target>
         <note>{StrBegin="NETSDK1008: "}</note>
       </trans-unit>
+      <trans-unit id="RecommendRuntimeFrameworkNameForAspNetCorePackages">
+        <source>NETSDK1071: A PackageReference for '{0}' was included in your project. This package can be implicitly defined by the SDK. To resolve this warning, remove this PackageReference and set the RuntimeFrameworkName property to {1}. For more information, see {2}.</source>
+        <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. This package can be implicitly defined by the SDK. To resolve this warning, remove this PackageReference and set the RuntimeFrameworkName property to {1}. For more information, see {2}.</target>
+        <note>{StrBegin="NETSDK1071: "}
+{0} - Package Id (Microsoft.AspNetCore.App or .All)
+{1} - Project name
+{2} - More info link
+    </note>
+      </trans-unit>
       <trans-unit id="UnrecognizedPreprocessorToken">
         <source>NETSDK1009: Unrecognized preprocessor token '{0}' in '{1}'.</source>
         <target state="needs-review-translation">Nierozpoznany token preprocesora „{0}” w elemencie „{1}”.</target>
@@ -111,6 +120,11 @@
         <source>NETSDK1018: Invalid NuGet version string: '{0}'.</source>
         <target state="needs-review-translation">Nieprawidłowy ciąg wersji NuGet: „{0}”.</target>
         <note>{StrBegin="NETSDK1018: "}</note>
+      </trans-unit>
+      <trans-unit id="UnrecognizedRuntimeFrameworkName">
+        <source>NETSDK1070: This project uses an unsupported value for RuntimeFrameworkName. Currently, only valid values are: Microsoft.NETCore.App, Microsoft.AspNetCore.App, or Microsoft.AspNetCore.All.</source>
+        <target state="new">NETSDK1070: This project uses an unsupported value for RuntimeFrameworkName. Currently, only valid values are: Microsoft.NETCore.App, Microsoft.AspNetCore.App, or Microsoft.AspNetCore.All.</target>
+        <note>{StrBegin="NETSDK1070: "}</note>
       </trans-unit>
       <trans-unit id="UnsupportedFramework">
         <source>NETSDK1019: {0} is an unsupported framework.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
@@ -62,15 +62,6 @@
         <target state="needs-review-translation">Brak metadanych „{0}” w elemencie „{1}” „{2}”.</target>
         <note>{StrBegin="NETSDK1008: "}</note>
       </trans-unit>
-      <trans-unit id="RecommendRuntimeFrameworkNameForAspNetCorePackages">
-        <source>NETSDK1071: A PackageReference for '{0}' was included in your project. This package can be implicitly defined by the SDK. To resolve this warning, remove this PackageReference and set the RuntimeFrameworkName property to {1}. For more information, see {2}.</source>
-        <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. This package can be implicitly defined by the SDK. To resolve this warning, remove this PackageReference and set the RuntimeFrameworkName property to {1}. For more information, see {2}.</target>
-        <note>{StrBegin="NETSDK1071: "}
-{0} - Package Id (Microsoft.AspNetCore.App or .All)
-{1} - Project name
-{2} - More info link
-    </note>
-      </trans-unit>
       <trans-unit id="UnrecognizedPreprocessorToken">
         <source>NETSDK1009: Unrecognized preprocessor token '{0}' in '{1}'.</source>
         <target state="needs-review-translation">Nierozpoznany token preprocesora „{0}” w elemencie „{1}”.</target>
@@ -120,11 +111,6 @@
         <source>NETSDK1018: Invalid NuGet version string: '{0}'.</source>
         <target state="needs-review-translation">Nieprawidłowy ciąg wersji NuGet: „{0}”.</target>
         <note>{StrBegin="NETSDK1018: "}</note>
-      </trans-unit>
-      <trans-unit id="UnrecognizedRuntimeFrameworkName">
-        <source>NETSDK1070: This project uses an unsupported value for RuntimeFrameworkName. Currently, only valid values are: Microsoft.NETCore.App, Microsoft.AspNetCore.App, or Microsoft.AspNetCore.All.</source>
-        <target state="new">NETSDK1070: This project uses an unsupported value for RuntimeFrameworkName. Currently, only valid values are: Microsoft.NETCore.App, Microsoft.AspNetCore.App, or Microsoft.AspNetCore.All.</target>
-        <note>{StrBegin="NETSDK1070: "}</note>
       </trans-unit>
       <trans-unit id="UnsupportedFramework">
         <source>NETSDK1019: {0} is an unsupported framework.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
@@ -62,15 +62,6 @@
         <target state="needs-review-translation">Metadados '{0}' ausentes no item '{1}' '{2}'.</target>
         <note>{StrBegin="NETSDK1008: "}</note>
       </trans-unit>
-      <trans-unit id="RecommendRuntimeFrameworkNameForAspNetCorePackages">
-        <source>NETSDK1071: A PackageReference for '{0}' was included in your project. This package can be implicitly defined by the SDK. To resolve this warning, remove this PackageReference and set the RuntimeFrameworkName property to {1}. For more information, see {2}.</source>
-        <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. This package can be implicitly defined by the SDK. To resolve this warning, remove this PackageReference and set the RuntimeFrameworkName property to {1}. For more information, see {2}.</target>
-        <note>{StrBegin="NETSDK1071: "}
-{0} - Package Id (Microsoft.AspNetCore.App or .All)
-{1} - Project name
-{2} - More info link
-    </note>
-      </trans-unit>
       <trans-unit id="UnrecognizedPreprocessorToken">
         <source>NETSDK1009: Unrecognized preprocessor token '{0}' in '{1}'.</source>
         <target state="needs-review-translation">Token de pré-processador não reconhecido '{0}' no '{1}'.</target>
@@ -120,11 +111,6 @@
         <source>NETSDK1018: Invalid NuGet version string: '{0}'.</source>
         <target state="needs-review-translation">Cadeia de caracteres de versão do NuGet inválida: '{0}'.</target>
         <note>{StrBegin="NETSDK1018: "}</note>
-      </trans-unit>
-      <trans-unit id="UnrecognizedRuntimeFrameworkName">
-        <source>NETSDK1070: This project uses an unsupported value for RuntimeFrameworkName. Currently, only valid values are: Microsoft.NETCore.App, Microsoft.AspNetCore.App, or Microsoft.AspNetCore.All.</source>
-        <target state="new">NETSDK1070: This project uses an unsupported value for RuntimeFrameworkName. Currently, only valid values are: Microsoft.NETCore.App, Microsoft.AspNetCore.App, or Microsoft.AspNetCore.All.</target>
-        <note>{StrBegin="NETSDK1070: "}</note>
       </trans-unit>
       <trans-unit id="UnsupportedFramework">
         <source>NETSDK1019: {0} is an unsupported framework.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
@@ -62,6 +62,15 @@
         <target state="needs-review-translation">Metadados '{0}' ausentes no item '{1}' '{2}'.</target>
         <note>{StrBegin="NETSDK1008: "}</note>
       </trans-unit>
+      <trans-unit id="RecommendRuntimeFrameworkNameForAspNetCorePackages">
+        <source>NETSDK1071: A PackageReference for '{0}' was included in your project. This package can be implicitly defined by the SDK. To resolve this warning, remove this PackageReference and set the RuntimeFrameworkName property to {1}. For more information, see {2}.</source>
+        <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. This package can be implicitly defined by the SDK. To resolve this warning, remove this PackageReference and set the RuntimeFrameworkName property to {1}. For more information, see {2}.</target>
+        <note>{StrBegin="NETSDK1071: "}
+{0} - Package Id (Microsoft.AspNetCore.App or .All)
+{1} - Project name
+{2} - More info link
+    </note>
+      </trans-unit>
       <trans-unit id="UnrecognizedPreprocessorToken">
         <source>NETSDK1009: Unrecognized preprocessor token '{0}' in '{1}'.</source>
         <target state="needs-review-translation">Token de pré-processador não reconhecido '{0}' no '{1}'.</target>
@@ -111,6 +120,11 @@
         <source>NETSDK1018: Invalid NuGet version string: '{0}'.</source>
         <target state="needs-review-translation">Cadeia de caracteres de versão do NuGet inválida: '{0}'.</target>
         <note>{StrBegin="NETSDK1018: "}</note>
+      </trans-unit>
+      <trans-unit id="UnrecognizedRuntimeFrameworkName">
+        <source>NETSDK1070: This project uses an unsupported value for RuntimeFrameworkName. Currently, only valid values are: Microsoft.NETCore.App, Microsoft.AspNetCore.App, or Microsoft.AspNetCore.All.</source>
+        <target state="new">NETSDK1070: This project uses an unsupported value for RuntimeFrameworkName. Currently, only valid values are: Microsoft.NETCore.App, Microsoft.AspNetCore.App, or Microsoft.AspNetCore.All.</target>
+        <note>{StrBegin="NETSDK1070: "}</note>
       </trans-unit>
       <trans-unit id="UnsupportedFramework">
         <source>NETSDK1019: {0} is an unsupported framework.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
@@ -62,6 +62,15 @@
         <target state="needs-review-translation">Отсутствуют метаданные "{0}" для элемента "{2}" "{1}".</target>
         <note>{StrBegin="NETSDK1008: "}</note>
       </trans-unit>
+      <trans-unit id="RecommendRuntimeFrameworkNameForAspNetCorePackages">
+        <source>NETSDK1071: A PackageReference for '{0}' was included in your project. This package can be implicitly defined by the SDK. To resolve this warning, remove this PackageReference and set the RuntimeFrameworkName property to {1}. For more information, see {2}.</source>
+        <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. This package can be implicitly defined by the SDK. To resolve this warning, remove this PackageReference and set the RuntimeFrameworkName property to {1}. For more information, see {2}.</target>
+        <note>{StrBegin="NETSDK1071: "}
+{0} - Package Id (Microsoft.AspNetCore.App or .All)
+{1} - Project name
+{2} - More info link
+    </note>
+      </trans-unit>
       <trans-unit id="UnrecognizedPreprocessorToken">
         <source>NETSDK1009: Unrecognized preprocessor token '{0}' in '{1}'.</source>
         <target state="needs-review-translation">Нераспознанный маркер препроцессора "{0}" в "{1}".</target>
@@ -111,6 +120,11 @@
         <source>NETSDK1018: Invalid NuGet version string: '{0}'.</source>
         <target state="needs-review-translation">Недопустимая строка версии Invalid NuGet: "{0}".</target>
         <note>{StrBegin="NETSDK1018: "}</note>
+      </trans-unit>
+      <trans-unit id="UnrecognizedRuntimeFrameworkName">
+        <source>NETSDK1070: This project uses an unsupported value for RuntimeFrameworkName. Currently, only valid values are: Microsoft.NETCore.App, Microsoft.AspNetCore.App, or Microsoft.AspNetCore.All.</source>
+        <target state="new">NETSDK1070: This project uses an unsupported value for RuntimeFrameworkName. Currently, only valid values are: Microsoft.NETCore.App, Microsoft.AspNetCore.App, or Microsoft.AspNetCore.All.</target>
+        <note>{StrBegin="NETSDK1070: "}</note>
       </trans-unit>
       <trans-unit id="UnsupportedFramework">
         <source>NETSDK1019: {0} is an unsupported framework.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
@@ -2,10 +2,70 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../Strings.resx">
     <body>
+      <trans-unit id="AppHostHasBeenModified">
+        <source>NETSDK1029: Unable to use '{0}' as application host executable as it does not contain the expected placeholder byte sequence '{1}' that would mark where the application name would be written.</source>
+        <target state="new">NETSDK1029: Unable to use '{0}' as application host executable as it does not contain the expected placeholder byte sequence '{1}' that would mark where the application name would be written.</target>
+        <note>{StrBegin="NETSDK1029: "}</note>
+      </trans-unit>
+      <trans-unit id="AssetPreprocessorMustBeConfigured">
+        <source>NETSDK1017: Asset preprocessor must be configured before assets are processed.</source>
+        <target state="new">NETSDK1017: Asset preprocessor must be configured before assets are processed.</target>
+        <note>{StrBegin="NETSDK1017: "}</note>
+      </trans-unit>
+      <trans-unit id="AssetsFileMissingRuntimeIdentifier">
+        <source>NETSDK1047: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project. You may also need to include '{3}' in your project's RuntimeIdentifiers.</source>
+        <target state="new">NETSDK1047: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project. You may also need to include '{3}' in your project's RuntimeIdentifiers.</target>
+        <note>{StrBegin="NETSDK1047: "}</note>
+      </trans-unit>
+      <trans-unit id="AssetsFileMissingTarget">
+        <source>NETSDK1005: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project.</source>
+        <target state="new">NETSDK1005: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project.</target>
+        <note>{StrBegin="NETSDK1005: "}</note>
+      </trans-unit>
+      <trans-unit id="AssetsFileNotFound">
+        <source>NETSDK1004: Assets file '{0}' not found. Run a NuGet package restore to generate this file.</source>
+        <target state="new">NETSDK1004: Assets file '{0}' not found. Run a NuGet package restore to generate this file.</target>
+        <note>{StrBegin="NETSDK1004: "}</note>
+      </trans-unit>
+      <trans-unit id="AssetsFileNotSet">
+        <source>NETSDK1063: The path to the project assets file was not set. Run a NuGet package restore to generate this file.</source>
+        <target state="new">NETSDK1063: The path to the project assets file was not set. Run a NuGet package restore to generate this file.</target>
+        <note>{StrBegin="NETSDK1063: "}</note>
+      </trans-unit>
+      <trans-unit id="AssetsFilePathNotRooted">
+        <source>NETSDK1006: Assets file path '{0}' is not rooted. Only full paths are supported.</source>
+        <target state="new">NETSDK1006: Assets file path '{0}' is not rooted. Only full paths are supported.</target>
+        <note>{StrBegin="NETSDK1006: "}</note>
+      </trans-unit>
       <trans-unit id="AtLeastOneTargetFrameworkMustBeSpecified">
         <source>NETSDK1001: At least one possible target framework must be specified.</source>
-        <target state="needs-review-translation">Необходимо указать хотя бы одну целевую платформу.</target>
+        <target state="new">NETSDK1001: At least one possible target framework must be specified.</target>
         <note>{StrBegin="NETSDK1001: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotFindApphostForRid">
+        <source>NETSDK1065: Cannot find app host for {0}. {0} could be an invalid runtime identifier (RID). For more information about RID, see https://aka.ms/rid-catalog.</source>
+        <target state="new">NETSDK1065: Cannot find app host for {0}. {0} could be an invalid runtime identifier (RID). For more information about RID, see https://aka.ms/rid-catalog.</target>
+        <note>{StrBegin="NETSDK1065: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotFindProjectInfo">
+        <source>NETSDK1007: Cannot find project info for '{0}'. This can indicate a missing project reference.</source>
+        <target state="new">NETSDK1007: Cannot find project info for '{0}'. This can indicate a missing project reference.</target>
+        <note>{StrBegin="NETSDK1007: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotHaveRuntimeIdentifierPlatformMismatchPlatformTarget">
+        <source>NETSDK1032: The RuntimeIdentifier platform '{0}' and the PlatformTarget '{1}' must be compatible.</source>
+        <target state="new">NETSDK1032: The RuntimeIdentifier platform '{0}' and the PlatformTarget '{1}' must be compatible.</target>
+        <note>{StrBegin="NETSDK1032: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotHaveSelfContainedWithoutRuntimeIdentifier">
+        <source>NETSDK1031: It is not supported to build or publish a self-contained application without specifying a RuntimeIdentifier.  Please either specify a RuntimeIdentifier or set SelfContained to false.</source>
+        <target state="new">NETSDK1031: It is not supported to build or publish a self-contained application without specifying a RuntimeIdentifier.  Please either specify a RuntimeIdentifier or set SelfContained to false.</target>
+        <note>{StrBegin="NETSDK1031: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotInferTargetFrameworkIdentiferAndVersion">
+        <source>NETSDK1013: The TargetFramework value '{0}' was not recognized. It may be misspelled. If not, then the TargetFrameworkIdentifier and/or TargetFrameworkVersion properties must be specified explicitly.</source>
+        <target state="new">NETSDK1013: The TargetFramework value '{0}' was not recognized. It may be misspelled. If not, then the TargetFrameworkIdentifier and/or TargetFrameworkVersion properties must be specified explicitly.</target>
+        <note>{StrBegin="NETSDK1013: "}</note>
       </trans-unit>
       <trans-unit id="CannotUseAppHostWithoutRuntimeIdentifier">
         <source>NETSDK1066: A RuntimeIdentifier must be specified to publish a framework-dependent application with an application host.</source>
@@ -17,10 +77,174 @@
         <target state="new">NETSDK1067: Self-contained applications are required to use the application host. Either set SelfContained to false or set UseAppHost to true.</target>
         <note>{StrBegin="NETSDK1067: "}</note>
       </trans-unit>
+      <trans-unit id="ChoosingAssemblyVersion">
+        <source>NETSDK1033: Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</source>
+        <target state="new">NETSDK1033: Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</target>
+        <note>{StrBegin="NETSDK1033: "}</note>
+      </trans-unit>
+      <trans-unit id="ChoosingFileVersion">
+        <source>NETSDK1034: Choosing '{0}' because file version '{1}' is greater than '{2}'.</source>
+        <target state="new">NETSDK1034: Choosing '{0}' because file version '{1}' is greater than '{2}'.</target>
+        <note>{StrBegin="NETSDK1034: "}</note>
+      </trans-unit>
+      <trans-unit id="ChoosingPlatformItem">
+        <source>NETSDK1035: Choosing '{0}' because it is a platform item.</source>
+        <target state="new">NETSDK1035: Choosing '{0}' because it is a platform item.</target>
+        <note>{StrBegin="NETSDK1035: "}</note>
+      </trans-unit>
+      <trans-unit id="ChoosingPreferredPackage">
+        <source>NETSDK1036: Choosing '{0}' because it comes from a package that is preferred.</source>
+        <target state="new">NETSDK1036: Choosing '{0}' because it comes from a package that is preferred.</target>
+        <note>{StrBegin="NETSDK1036: "}</note>
+      </trans-unit>
+      <trans-unit id="ConflictCouldNotDetermineWinner">
+        <source>NETSDK1037: Could not determine winner due to equal file and assembly versions.</source>
+        <target state="new">NETSDK1037: Could not determine winner due to equal file and assembly versions.</target>
+        <note>{StrBegin="NETSDK1037: "}</note>
+      </trans-unit>
+      <trans-unit id="ContentItemDoesNotProvideOutputPath">
+        <source>NETSDK1014: Content item for '{0}' sets '{1}', but does not provide  '{2}' or '{3}'.</source>
+        <target state="new">NETSDK1014: Content item for '{0}' sets '{1}', but does not provide  '{2}' or '{3}'.</target>
+        <note>{StrBegin="NETSDK1014: "}</note>
+      </trans-unit>
+      <trans-unit id="ContentPreproccessorParameterRequired">
+        <source>NETSDK1010: The '{0}' task must be given a value for parameter '{1}' in order to consume preprocessed content.</source>
+        <target state="new">NETSDK1010: The '{0}' task must be given a value for parameter '{1}' in order to consume preprocessed content.</target>
+        <note>{StrBegin="NETSDK1010: "}</note>
+      </trans-unit>
+      <trans-unit id="CouldNotDetermineWinner_DoesntExist">
+        <source>NETSDK1038: Could not determine winner because '{0}' does not exist.</source>
+        <target state="new">NETSDK1038: Could not determine winner because '{0}' does not exist.</target>
+        <note>{StrBegin="NETSDK1001: "}</note>
+      </trans-unit>
+      <trans-unit id="CouldNotDetermineWinner_FileVersion">
+        <source>NETSDK1039: Could not determine a winner because '{0}' has no file version.</source>
+        <target state="new">NETSDK1039: Could not determine a winner because '{0}' has no file version.</target>
+        <note>{StrBegin="NETSDK1039: "}</note>
+      </trans-unit>
+      <trans-unit id="CouldNotDetermineWinner_NotAnAssembly">
+        <source>NETSDK1040: Could not determine a winner because '{0}' is not an assembly.</source>
+        <target state="new">NETSDK1040: Could not determine a winner because '{0}' is not an assembly.</target>
+        <note>{StrBegin="NETSDK1040: "}</note>
+      </trans-unit>
+      <trans-unit id="CouldNotLoadPlatformManifest">
+        <source>NETSDK1042: Could not load PlatformManifest from '{0}' because it did not exist.</source>
+        <target state="new">NETSDK1042: Could not load PlatformManifest from '{0}' because it did not exist.</target>
+        <note>{StrBegin="NETSDK1042: "}</note>
+      </trans-unit>
+      <trans-unit id="DotnetToolDoesNotSupportTFMLowerThanNetcoreapp21">
+        <source>NETSDK1055: DotnetTool does not support target framework lower than netcoreapp2.1.</source>
+        <target state="new">NETSDK1055: DotnetTool does not support target framework lower than netcoreapp2.1.</target>
+        <note>{StrBegin="NETSDK1055: "}</note>
+      </trans-unit>
+      <trans-unit id="DotnetToolOnlySupportNetcoreapp">
+        <source>NETSDK1054: only supports .NET Core.</source>
+        <target state="new">NETSDK1054: only supports .NET Core.</target>
+        <note>{StrBegin="NETSDK1054: "}</note>
+      </trans-unit>
+      <trans-unit id="DuplicateItemsError">
+        <source>NETSDK1022: Duplicate '{0}' items were included. The .NET SDK includes '{0}' items from your project directory by default. You can either remove these items from your project file, or set the '{1}' property to '{2}' if you want to explicitly include them in your project file. For more information, see {4}. The duplicate items were: {3}</source>
+        <target state="new">NETSDK1022: Duplicate '{0}' items were included. The .NET SDK includes '{0}' items from your project directory by default. You can either remove these items from your project file, or set the '{1}' property to '{2}' if you want to explicitly include them in your project file. For more information, see {4}. The duplicate items were: {3}</target>
+        <note>{StrBegin="NETSDK1022: "}</note>
+      </trans-unit>
+      <trans-unit id="DuplicatePreprocessorToken">
+        <source>NETSDK1015: The preprocessor token '{0}' has been given more than one value. Choosing '{1}' as the value.</source>
+        <target state="new">NETSDK1015: The preprocessor token '{0}' has been given more than one value. Choosing '{1}' as the value.</target>
+        <note>{StrBegin="NETSDK1015: "}</note>
+      </trans-unit>
+      <trans-unit id="EncounteredConflict">
+        <source>NETSDK1041: Encountered conflict between '{0}' and '{1}'.</source>
+        <target state="new">NETSDK1041: Encountered conflict between '{0}' and '{1}'.</target>
+        <note>{StrBegin="NETSDK1041: "}</note>
+      </trans-unit>
+      <trans-unit id="ErrorParsingFrameworkListInvalidValue">
+        <source>NETSDK1051: Error parsing FrameworkList from '{0}'.  {1} '{2}' was invalid.</source>
+        <target state="new">NETSDK1051: Error parsing FrameworkList from '{0}'.  {1} '{2}' was invalid.</target>
+        <note>{StrBegin="NETSDK1051: "}</note>
+      </trans-unit>
+      <trans-unit id="ErrorParsingPlatformManifest">
+        <source>NETSDK1043: Error parsing PlatformManifest from '{0}' line {1}.  Lines must have the format {2}.</source>
+        <target state="new">NETSDK1043: Error parsing PlatformManifest from '{0}' line {1}.  Lines must have the format {2}.</target>
+        <note>{StrBegin="NETSDK1043: "}</note>
+      </trans-unit>
+      <trans-unit id="ErrorParsingPlatformManifestInvalidValue">
+        <source>NETSDK1044: Error parsing PlatformManifest from '{0}' line {1}.  {2} '{3}' was invalid.</source>
+        <target state="new">NETSDK1044: Error parsing PlatformManifest from '{0}' line {1}.  {2} '{3}' was invalid.</target>
+        <note>{StrBegin="NETSDK1044: "}</note>
+      </trans-unit>
+      <trans-unit id="ErrorReadingAssetsFile">
+        <source>NETSDK1060: Error reading assets file: {0}</source>
+        <target state="new">NETSDK1060: Error reading assets file: {0}</target>
+        <note>{StrBegin="NETSDK1060: "}</note>
+      </trans-unit>
+      <trans-unit id="FileNameIsTooLong">
+        <source>NETSDK1030: Given file name '{0}' is longer than 1024 bytes</source>
+        <target state="new">NETSDK1030: Given file name '{0}' is longer than 1024 bytes</target>
+        <note>{StrBegin="NETSDK1030: "}</note>
+      </trans-unit>
+      <trans-unit id="FolderAlreadyExists">
+        <source>NETSDK1024: Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</source>
+        <target state="new">NETSDK1024: Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</target>
+        <note>{StrBegin="NETSDK1024: "}</note>
+      </trans-unit>
       <trans-unit id="FrameworkDependentAppHostRequiresVersion21">
         <source>NETSDK1068: The framework-dependent application host requires a target framework of at least 'netcoreapp2.1'.</source>
         <target state="new">NETSDK1068: The framework-dependent application host requires a target framework of at least 'netcoreapp2.1'.</target>
         <note>{StrBegin="NETSDK1068: "}</note>
+      </trans-unit>
+      <trans-unit id="FrameworkListPathNotRooted">
+        <source>NETSDK1052: Framework list file path '{0}' is not rooted. Only full paths are supported.</source>
+        <target state="new">NETSDK1052: Framework list file path '{0}' is not rooted. Only full paths are supported.</target>
+        <note>{StrBegin="NETSDK1052: "}</note>
+      </trans-unit>
+      <trans-unit id="GetDependsOnNETStandardFailedWithException">
+        <source>NETSDK1049: Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0} {1}</source>
+        <target state="new">NETSDK1049: Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0} {1}</target>
+        <note>{StrBegin="NETSDK1049: "}</note>
+      </trans-unit>
+      <trans-unit id="IncorrectPackageRoot">
+        <source>NETSDK1020: Package Root {0} was incorrectly given for Resolved library {1}</source>
+        <target state="new">NETSDK1020: Package Root {0} was incorrectly given for Resolved library {1}</target>
+        <note>{StrBegin="NETSDK1020: "}</note>
+      </trans-unit>
+      <trans-unit id="IncorrectTargetFormat">
+        <source>NETSDK1025: WRThe target manifest {0} provided is of not the correct format</source>
+        <target state="new">NETSDK1025: WRThe target manifest {0} provided is of not the correct format</target>
+        <note>{StrBegin="NETSDK1025: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidFrameworkName">
+        <source>NETSDK1003: Invalid framework name: '{0}'.</source>
+        <target state="new">NETSDK1003: Invalid framework name: '{0}'.</target>
+        <note>{StrBegin="NETSDK1003: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidItemSpecToUse">
+        <source>NETSDK1058: Invalid value for ItemSpecToUse parameter: '{0}'.  This property must be blank or set to 'Left' or 'Right'</source>
+        <target state="new">NETSDK1058: Invalid value for ItemSpecToUse parameter: '{0}'.  This property must be blank or set to 'Left' or 'Right'</target>
+        <note>{StrBegin="NETSDK1058: "}
+The following are names of parameters or literal values and should not be translated: ItemSpecToUse, Left, Right</note>
+      </trans-unit>
+      <trans-unit id="InvalidNuGetVersionString">
+        <source>NETSDK1018: Invalid NuGet version string: '{0}'.</source>
+        <target state="new">NETSDK1018: Invalid NuGet version string: '{0}'.</target>
+        <note>{StrBegin="NETSDK1018: "}</note>
+      </trans-unit>
+      <trans-unit id="MismatchedPlatformPackageVersion">
+        <source>NETSDK1061: The project was restored using {0} version {1}, but with current settings, version {2} would be used instead. To resolve this issue, make sure the same settings are used for restore and for subsequent operations such as build or publish. Typically this issue can occur if the RuntimeIdentifier property is set during build or publish but not during restore. For more information, see https://aka.ms/dotnet-runtime-patch-selection.</source>
+        <target state="new">NETSDK1061: The project was restored using {0} version {1}, but with current settings, version {2} would be used instead. To resolve this issue, make sure the same settings are used for restore and for subsequent operations such as build or publish. Typically this issue can occur if the RuntimeIdentifier property is set during build or publish but not during restore. For more information, see https://aka.ms/dotnet-runtime-patch-selection.</target>
+        <note>{StrBegin="NETSDK1061: "}
+{0} - Package Identifier for platform package
+{1} - Restored version of platform package
+{2} - Current version of platform package</note>
+      </trans-unit>
+      <trans-unit id="MissingItemMetadata">
+        <source>NETSDK1008: Missing '{0}' metadata on '{1}' item '{2}'.</source>
+        <target state="new">NETSDK1008: Missing '{0}' metadata on '{1}' item '{2}'.</target>
+        <note>{StrBegin="NETSDK1008: "}</note>
+      </trans-unit>
+      <trans-unit id="MultipleFilesResolved">
+        <source>NETSDK1021: More than one file found for {0}</source>
+        <target state="new">NETSDK1021: More than one file found for {0}</target>
+        <note>{StrBegin="NETSDK1021: "}</note>
       </trans-unit>
       <trans-unit id="NETFrameworkToNonBuiltInNETStandard">
         <source>NETSDK1069: This project uses a library that targets .NET Standard 1.5 or higher, and the project targets a version of .NET Framework that doesn't have built-in support for that version of .NET Standard. Visit https://aka.ms/net-standard-known-issues for a set of known issues. Consider retargeting to .NET Framework 4.7.2.</source>
@@ -29,327 +253,117 @@
       </trans-unit>
       <trans-unit id="NoCompatibleTargetFramework">
         <source>NETSDK1002: Project '{0}' targets '{2}'. It cannot be referenced by a project that targets '{1}'.</source>
-        <target state="needs-review-translation">Проект "{0}" предназначен для платформы "{2}". На него не может ссылаться проект, предназначенный для платформы "{1}".</target>
+        <target state="new">NETSDK1002: Project '{0}' targets '{2}'. It cannot be referenced by a project that targets '{1}'.</target>
         <note>{StrBegin="NETSDK1002: "}</note>
-      </trans-unit>
-      <trans-unit id="InvalidFrameworkName">
-        <source>NETSDK1003: Invalid framework name: '{0}'.</source>
-        <target state="needs-review-translation">Недопустимое имя платформы: "{0}".</target>
-        <note>{StrBegin="NETSDK1003: "}</note>
-      </trans-unit>
-      <trans-unit id="AssetsFileNotFound">
-        <source>NETSDK1004: Assets file '{0}' not found. Run a NuGet package restore to generate this file.</source>
-        <target state="needs-review-translation">Файл ресурсов "{0}" не найден. Выполните восстановление пакета NuGet, чтобы создать этот файл.</target>
-        <note>{StrBegin="NETSDK1004: "}</note>
-      </trans-unit>
-      <trans-unit id="AssetsFileMissingTarget">
-        <source>NETSDK1005: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project.</source>
-        <target state="needs-review-translation">Файл ресурсов "{0}" не имеет целевого объекта для "{1}". Убедитесь, что восстановление выполнено и что вы включили "{2}" в свойство "TargetFrameworks" для проекта.</target>
-        <note>{StrBegin="NETSDK1005: "}</note>
-      </trans-unit>
-      <trans-unit id="AssetsFilePathNotRooted">
-        <source>NETSDK1006: Assets file path '{0}' is not rooted. Only full paths are supported.</source>
-        <target state="needs-review-translation">Путь к файлу ресурсов "{0}" должен содержать корневой каталог. Поддерживаются только полные пути.</target>
-        <note>{StrBegin="NETSDK1006: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotFindProjectInfo">
-        <source>NETSDK1007: Cannot find project info for '{0}'. This can indicate a missing project reference.</source>
-        <target state="needs-review-translation">Невозможно найти сведения о проекте для "{0}". Возможно, отсутствует ссылка на проект.</target>
-        <note>{StrBegin="NETSDK1007: "}</note>
-      </trans-unit>
-      <trans-unit id="MissingItemMetadata">
-        <source>NETSDK1008: Missing '{0}' metadata on '{1}' item '{2}'.</source>
-        <target state="needs-review-translation">Отсутствуют метаданные "{0}" для элемента "{2}" "{1}".</target>
-        <note>{StrBegin="NETSDK1008: "}</note>
-      </trans-unit>
-      <trans-unit id="UnrecognizedPreprocessorToken">
-        <source>NETSDK1009: Unrecognized preprocessor token '{0}' in '{1}'.</source>
-        <target state="needs-review-translation">Нераспознанный маркер препроцессора "{0}" в "{1}".</target>
-        <note>{StrBegin="NETSDK1009: "}</note>
-      </trans-unit>
-      <trans-unit id="ContentPreproccessorParameterRequired">
-        <source>NETSDK1010: The '{0}' task must be given a value for parameter '{1}' in order to consume preprocessed content.</source>
-        <target state="needs-review-translation">В задачу "{0}" необходимо передать значение для параметра "{1}" для использования предварительно обработанного содержимого.</target>
-        <note>{StrBegin="NETSDK1010: "}</note>
-      </trans-unit>
-      <trans-unit id="ProjectAssetsConsumedWithoutMSBuildProjectPath">
-        <source>NETSDK1011: Assets are consumed from project '{0}', but no corresponding MSBuild project path was  found in '{1}'.</source>
-        <target state="needs-review-translation">Ресурсы используются из проекта "{0}", однако соответствующий путь к проекту MSBuild не найден в "{1}".</target>
-        <note>{StrBegin="NETSDK1011: "}</note>
-      </trans-unit>
-      <trans-unit id="UnexpectedFileType">
-        <source>NETSDK1012: Unexpected file type for '{0}'. Type is both '{1}' and '{2}'.</source>
-        <target state="needs-review-translation">Непредвиденный тип файла для "{0}". Тип является "{1}" и "{2}".</target>
-        <note>{StrBegin="NETSDK1012: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotInferTargetFrameworkIdentiferAndVersion">
-        <source>NETSDK1013: The TargetFramework value '{0}' was not recognized. It may be misspelled. If not, then the TargetFrameworkIdentifier and/or TargetFrameworkVersion properties must be specified explicitly.</source>
-        <target state="needs-review-translation">Значение "{0}" свойства "TargetFramework" не было распознано. Возможно, оно содержит опечатку. В противном случае следует явным образом задать свойства "TargetFrameworkIdentifier" и (или) "TargetFrameworkVersion".</target>
-        <note>{StrBegin="NETSDK1013: "}</note>
-      </trans-unit>
-      <trans-unit id="ContentItemDoesNotProvideOutputPath">
-        <source>NETSDK1014: Content item for '{0}' sets '{1}', but does not provide  '{2}' or '{3}'.</source>
-        <target state="needs-review-translation">Элемент содержимого для "{0}" задает "{1}", но не предоставляет "{2}" или "{3}".</target>
-        <note>{StrBegin="NETSDK1014: "}</note>
-      </trans-unit>
-      <trans-unit id="DuplicatePreprocessorToken">
-        <source>NETSDK1015: The preprocessor token '{0}' has been given more than one value. Choosing '{1}' as the value.</source>
-        <target state="needs-review-translation">Для маркера препроцессора "{0}" задано несколько значений. Выбор "{1}" в качестве значения.</target>
-        <note>{StrBegin="NETSDK1015: "}</note>
-      </trans-unit>
-      <trans-unit id="UnableToFindResolvedPath">
-        <source>NETSDK1016: Unable to find resolved path for '{0}'.</source>
-        <target state="needs-review-translation">Не удается найти разрешенный путь для "{0}".</target>
-        <note>{StrBegin="NETSDK1016: "}</note>
-      </trans-unit>
-      <trans-unit id="AssetPreprocessorMustBeConfigured">
-        <source>NETSDK1017: Asset preprocessor must be configured before assets are processed.</source>
-        <target state="needs-review-translation">Препроцессор ресурсов необходимо настроить перед обработкой ресурсов.</target>
-        <note>{StrBegin="NETSDK1017: "}</note>
-      </trans-unit>
-      <trans-unit id="InvalidNuGetVersionString">
-        <source>NETSDK1018: Invalid NuGet version string: '{0}'.</source>
-        <target state="needs-review-translation">Недопустимая строка версии Invalid NuGet: "{0}".</target>
-        <note>{StrBegin="NETSDK1018: "}</note>
-      </trans-unit>
-      <trans-unit id="UnsupportedFramework">
-        <source>NETSDK1019: {0} is an unsupported framework.</source>
-        <target state="needs-review-translation">Платформа {0} не поддерживается.</target>
-        <note>{StrBegin="NETSDK1019: "}</note>
-      </trans-unit>
-      <trans-unit id="DuplicateItemsError">
-        <source>NETSDK1022: Duplicate '{0}' items were included. The .NET SDK includes '{0}' items from your project directory by default. You can either remove these items from your project file, or set the '{1}' property to '{2}' if you want to explicitly include them in your project file. For more information, see {4}. The duplicate items were: {3}</source>
-        <target state="needs-review-translation">Были включены повторяющиеся элементы ("{0}"). Пакет .NET SDK по умолчанию включает элементы "{0}" из каталога проекта. Можно удалить эти элементы из файла проекта или присвоить свойству "{1}" значение "{2}", если нужно явно включить их в файл проекта. Дополнительные сведения см. в разделе {4}. Повторяющиеся элементы: {3}</target>
-        <note>{StrBegin="NETSDK1022: "}</note>
-      </trans-unit>
-      <trans-unit id="PackageReferenceOverrideWarning">
-        <source>NETSDK1023: A PackageReference for '{0}' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see {1}</source>
-        <target state="needs-review-translation">PackageReference для "{0}" был включен в проект. На этот пакет неявно указывает пакет .NET SDK, и ссылаться на него из проекта обычно не нужно. Дополнительные сведения: {1}</target>
-        <note>{StrBegin="NETSDK1023: "}</note>
-      </trans-unit>
-      <trans-unit id="IncorrectPackageRoot">
-        <source>NETSDK1020: Package Root {0} was incorrectly given for Resolved library {1}</source>
-        <target state="needs-review-translation">Корневой каталог пакета {0} неправильно указан для разрешенной библиотеки {1}</target>
-        <note>{StrBegin="NETSDK1020: "}</note>
-      </trans-unit>
-      <trans-unit id="MultipleFilesResolved">
-        <source>NETSDK1021: More than one file found for {0}</source>
-        <target state="needs-review-translation">Для {0} найдено несколько файлов</target>
-        <note>{StrBegin="NETSDK1021: "}</note>
-      </trans-unit>
-      <trans-unit id="FolderAlreadyExists">
-        <source>NETSDK1024: Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</source>
-        <target state="needs-review-translation">Папка "{0}" уже существует. Удалите ее или укажите другой каталог ComposeWorkingDir</target>
-        <note>{StrBegin="NETSDK1024: "}</note>
-      </trans-unit>
-      <trans-unit id="ParsingFiles">
-        <source>NETSDK1026: Parsing the Files : '{0}'</source>
-        <target state="needs-review-translation">Анализируются файлы: "{0}"</target>
-        <note>{StrBegin="NETSDK1026: "}</note>
-      </trans-unit>
-      <trans-unit id="PackageInfoLog">
-        <source>NETSDK1027: Package Name='{0}', Version='{1}' was parsed</source>
-        <target state="needs-review-translation">Пакет с именем "{0}" версии "{1}" был проанализирован</target>
-        <note>{StrBegin="NETSDK1027: "}</note>
-      </trans-unit>
-      <trans-unit id="RuntimeIdentifierWasNotSpecified">
-        <source>NETSDK1028: Specify a RuntimeIdentifier</source>
-        <target state="needs-review-translation">Укажите RuntimeIdentifier</target>
-        <note>{StrBegin="NETSDK1028: "}</note>
-      </trans-unit>
-      <trans-unit id="IncorrectTargetFormat">
-        <source>NETSDK1025: WRThe target manifest {0} provided is of not the correct format</source>
-        <target state="needs-review-translation">Указанный целевой манифест {0} имеет неправильный формат</target>
-        <note>{StrBegin="NETSDK1025: "}</note>
-      </trans-unit>
-      <trans-unit id="AppHostHasBeenModified">
-        <source>NETSDK1029: Unable to use '{0}' as application host executable as it does not contain the expected placeholder byte sequence '{1}' that would mark where the application name would be written.</source>
-        <target state="needs-review-translation">Невозможно использовать файл "{0}" в качестве исполняемого файла узла приложения, так как он не содержит требуемой последовательности байтов "{1}", которая отмечает место, где должно записываться имя приложения.</target>
-        <note>{StrBegin="NETSDK1029: "}</note>
-      </trans-unit>
-      <trans-unit id="FileNameIsTooLong">
-        <source>NETSDK1030: Given file name '{0}' is longer than 1024 bytes</source>
-        <target state="needs-review-translation">Длина указанного имени файла "{0}" превышает 1024 байта</target>
-        <note>{StrBegin="NETSDK1030: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotHaveSelfContainedWithoutRuntimeIdentifier">
-        <source>NETSDK1031: It is not supported to build or publish a self-contained application without specifying a RuntimeIdentifier.  Please either specify a RuntimeIdentifier or set SelfContained to false.</source>
-        <target state="needs-review-translation">Сборка или публикация автономного приложения без указания идентификатора RuntimeIdentifier не поддерживается. Укажите RuntimeIdentifier или присвойте свойству SelfContained значение false.</target>
-        <note>{StrBegin="NETSDK1031: "}</note>
-      </trans-unit>
-      <trans-unit id="ChoosingAssemblyVersion">
-        <source>NETSDK1033: Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</source>
-        <target state="needs-review-translation">Выбирается "{0}", так как значение AssemblyVersion "{1}" больше "{2}".</target>
-        <note>{StrBegin="NETSDK1033: "}</note>
-      </trans-unit>
-      <trans-unit id="ChoosingFileVersion">
-        <source>NETSDK1034: Choosing '{0}' because file version '{1}' is greater than '{2}'.</source>
-        <target state="needs-review-translation">Выбирается "{0}", так как версия файла "{1}" больше "{2}".</target>
-        <note>{StrBegin="NETSDK1034: "}</note>
-      </trans-unit>
-      <trans-unit id="ChoosingPlatformItem">
-        <source>NETSDK1035: Choosing '{0}' because it is a platform item.</source>
-        <target state="needs-review-translation">Выбирается "{0}", так как это элемент платформы.</target>
-        <note>{StrBegin="NETSDK1035: "}</note>
-      </trans-unit>
-      <trans-unit id="ChoosingPreferredPackage">
-        <source>NETSDK1036: Choosing '{0}' because it comes from a package that is preferred.</source>
-        <target state="needs-review-translation">Выбирается "{0}", так как источником является предпочтительный пакет.</target>
-        <note>{StrBegin="NETSDK1036: "}</note>
-      </trans-unit>
-      <trans-unit id="ConflictCouldNotDetermineWinner">
-        <source>NETSDK1037: Could not determine winner due to equal file and assembly versions.</source>
-        <target state="needs-review-translation">Не удалось определить победителя, так как версии файла и сборки одинаковы.</target>
-        <note>{StrBegin="NETSDK1037: "}</note>
-      </trans-unit>
-      <trans-unit id="CouldNotDetermineWinner_DoesntExist">
-        <source>NETSDK1038: Could not determine winner because '{0}' does not exist.</source>
-        <target state="needs-review-translation">Не удалось определить победителя, так как "{0}" не существует.</target>
-        <note>{StrBegin="NETSDK1001: "}</note>
-      </trans-unit>
-      <trans-unit id="CouldNotDetermineWinner_FileVersion">
-        <source>NETSDK1039: Could not determine a winner because '{0}' has no file version.</source>
-        <target state="needs-review-translation">Не удалось определить победителя, так как "{0}" не имеет версии файла.</target>
-        <note>{StrBegin="NETSDK1039: "}</note>
-      </trans-unit>
-      <trans-unit id="CouldNotDetermineWinner_NotAnAssembly">
-        <source>NETSDK1040: Could not determine a winner because '{0}' is not an assembly.</source>
-        <target state="needs-review-translation">Не удалось определить победителя, так как "{0}" не является сборкой.</target>
-        <note>{StrBegin="NETSDK1040: "}</note>
-      </trans-unit>
-      <trans-unit id="EncounteredConflict">
-        <source>NETSDK1041: Encountered conflict between '{0}' and '{1}'.</source>
-        <target state="needs-review-translation">Обнаружен конфликт между "{0}" и "{1}".</target>
-        <note>{StrBegin="NETSDK1041: "}</note>
-      </trans-unit>
-      <trans-unit id="CouldNotLoadPlatformManifest">
-        <source>NETSDK1042: Could not load PlatformManifest from '{0}' because it did not exist.</source>
-        <target state="needs-review-translation">Не удалось загрузить манифест PlatformManifest из "{0}", так как он не существует.</target>
-        <note>{StrBegin="NETSDK1042: "}</note>
-      </trans-unit>
-      <trans-unit id="ErrorParsingPlatformManifest">
-        <source>NETSDK1043: Error parsing PlatformManifest from '{0}' line {1}.  Lines must have the format {2}.</source>
-        <target state="needs-review-translation">Ошибка при анализе PlatformManifest со строки "{0}" {1}. Строки должны иметь формат {2}.</target>
-        <note>{StrBegin="NETSDK1043: "}</note>
-      </trans-unit>
-      <trans-unit id="ErrorParsingPlatformManifestInvalidValue">
-        <source>NETSDK1044: Error parsing PlatformManifest from '{0}' line {1}.  {2} '{3}' was invalid.</source>
-        <target state="needs-review-translation">Ошибка анализа PlatformManifest со строки "{0}" {1}. Недопустимый {2} "{3}".</target>
-        <note>{StrBegin="NETSDK1044: "}</note>
-      </trans-unit>
-      <trans-unit id="UnsupportedTargetFrameworkVersion">
-        <source>NETSDK1045: The current .NET SDK does not support targeting {0} {1}.  Either target {0} {2} or lower, or use a version of the .NET SDK that supports {0} {1}.</source>
-        <target state="needs-review-translation">Текущий пакет SDK для .NET не поддерживает целевой выбор {0} {1}. Выберите {0} {2} или более раннюю версию либо используйте версию пакета SDK для .NET, которая поддерживает {0} {1}.</target>
-        <note>{StrBegin="NETSDK1045: "}</note>
-      </trans-unit>
-      <trans-unit id="AssetsFileMissingRuntimeIdentifier">
-        <source>NETSDK1047: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project. You may also need to include '{3}' in your project's RuntimeIdentifiers.</source>
-        <target state="needs-review-translation">Файл ресурсов "{0}" не имеет целевого объекта для "{1}". Убедитесь, что восстановление выполнено и что вы включили "{2}" в свойство "TargetFrameworks"для проекта. Возможно, также потребуется включить "{3}" в свойство "RuntimeIdentifiers" проекта.</target>
-        <note>{StrBegin="NETSDK1047: "}</note>
-      </trans-unit>
-      <trans-unit id="TargetFrameworkWithSemicolon">
-        <source>NETSDK1046: The TargetFramework value '{0}' is not valid. To multi-target, use the 'TargetFrameworks' property instead.</source>
-        <target state="needs-review-translation">Значение "{0}" свойства "TargetFramework" недопустимо. Для нацеливания на несколько платформ используйте свойство "TargetFrameworks".</target>
-        <note>{StrBegin="NETSDK1046: "}</note>
-      </trans-unit>
-      <trans-unit id="SkippingAdditionalProbingPaths">
-        <source>NETSDK1048: 'AdditionalProbingPaths' were specified for GenerateRuntimeConfigurationFiles, but are being skipped because 'RuntimeConfigDevPath' is empty.</source>
-        <target state="needs-review-translation">Для "GenerateRuntimeConfigurationFiles" были указаны "AdditionalProbingPaths", но они пропускаются, так как свойство "RuntimeConfigDevPath" пусто.</target>
-        <note>{StrBegin="NETSDK1048: "}</note>
-      </trans-unit>
-      <trans-unit id="GetDependsOnNETStandardFailedWithException">
-        <source>NETSDK1049: Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0} {1}</source>
-        <target state="needs-review-translation">Найденный файл имеет неправильный образ, не имеет метаданных или недоступен по другим причинам. {0} {1}</target>
-        <note>{StrBegin="NETSDK1049: "}</note>
-      </trans-unit>
-      <trans-unit id="UnsupportedSDKVersionForNetStandard20">
-        <source>NETSDK1050: The version of Microsoft.NET.Sdk used by this project is insufficient to support references to libraries targeting .NET Standard 1.5 or higher.  Please install version 2.0 or higher of the .NET Core SDK.</source>
-        <target state="needs-review-translation">Используемая этим проектом версия SDK-пакета Microsoft .NET не поддерживает ссылки на библиотеки для .NET Standard 1.5 или более поздних версий. Установите SDK-пакет .NET Core как минимум версии 2.0.</target>
-        <note>{StrBegin="NETSDK1050: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotHaveRuntimeIdentifierPlatformMismatchPlatformTarget">
-        <source>NETSDK1032: The RuntimeIdentifier platform '{0}' and the PlatformTarget '{1}' must be compatible.</source>
-        <target state="needs-review-translation">Платформа RuntimeIdentifier "{0}" и PlatformTarget "{1}" должны быть совместимы.</target>
-        <note>{StrBegin="NETSDK1032: "}</note>
-      </trans-unit>
-      <trans-unit id="ErrorParsingFrameworkListInvalidValue">
-        <source>NETSDK1051: Error parsing FrameworkList from '{0}'.  {1} '{2}' was invalid.</source>
-        <target state="needs-review-translation">Ошибка анализа FrameworkList со строки "{0}". Недопустимо использовать {1} "{2}".</target>
-        <note>{StrBegin="NETSDK1051: "}</note>
-      </trans-unit>
-      <trans-unit id="FrameworkListPathNotRooted">
-        <source>NETSDK1052: Framework list file path '{0}' is not rooted. Only full paths are supported.</source>
-        <target state="needs-review-translation">Путь к файлу списка платформ "{0}" должен содержать корневой каталог. Поддерживаются только полные пути.</target>
-        <note>{StrBegin="NETSDK1052: "}</note>
       </trans-unit>
       <trans-unit id="PackAsToolCannotSupportSelfContained">
         <source>NETSDK1053: Pack as tool does not support self contained.</source>
-        <target state="needs-review-translation">Упаковка в качестве инструмента не поддерживает автономное использование.</target>
+        <target state="new">NETSDK1053: Pack as tool does not support self contained.</target>
         <note>{StrBegin="NETSDK1001: "}</note>
       </trans-unit>
-      <trans-unit id="UnsupportedRuntimeIdentifier">
-        <source>NETSDK1056: Project is targeting runtime '{0}' but did not resolve any runtime-specific packages. This runtime may not be supported by the target framework.</source>
-        <target state="needs-review-translation">Проект предназначен для среды выполнения "{0}", но не разрешил никакие пакеты среды выполнения. Возможно, целевая платформа не поддерживает эту среду выполнения.</target>
-        <note>{StrBegin="NETSDK1056: "}</note>
-      </trans-unit>
-      <trans-unit id="UsingPreviewSdkWarning">
-        <source>NETSDK1057: You are working with a preview version of the .NET Core SDK. You can define the SDK version via a global.json file in the current project. More at https://go.microsoft.com/fwlink/?linkid=869452</source>
-        <target state="needs-review-translation">Вы работаете с предварительной версией пакета SDK для .NET Core. Задать версию SDK можно в файле global.json текущего проекта. Дополнительные сведения: https://go.microsoft.com/fwlink/?linkid=869452</target>
-        <note>{StrBegin="NETSDK1057: "}</note>
-      </trans-unit>
-      <trans-unit id="InvalidItemSpecToUse">
-        <source>NETSDK1058: Invalid value for ItemSpecToUse parameter: '{0}'.  This property must be blank or set to 'Left' or 'Right'</source>
-        <target state="needs-review-translation">Недопустимое значение для параметра ItemSpecToUse: "{0}". Это свойство должно быть пустым либо иметь значение "Left" или "Right"</target>
-        <note>{StrBegin="NETSDK1058: "}
-The following are names of parameters or literal values and should not be translated: ItemSpecToUse, Left, Right</note>
-      </trans-unit>
-      <trans-unit id="ProjectContainsObsoleteDotNetCliTool">
-        <source>NETSDK1059: The tool '{0}' is now included in the .NET Core SDK. Information on resolving this warning is available at (https://aka.ms/dotnetclitools-in-box).</source>
-        <target state="needs-review-translation">Использование DotNetCliToolReference для ссылки на "{0}" является устаревшим подходом, поэтому его можно удалить из этого проекта. Это средство по умолчанию входит в состав пакета SDK для .NET Core.</target>
-        <note>{StrBegin="NETSDK1059: "}</note>
-      </trans-unit>
-      <trans-unit id="ErrorReadingAssetsFile">
-        <source>NETSDK1060: Error reading assets file: {0}</source>
-        <target state="needs-review-translation">Ошибка при чтении файла ресурсов: "{0}"</target>
-        <note>{StrBegin="NETSDK1060: "}</note>
-      </trans-unit>
-      <trans-unit id="MismatchedPlatformPackageVersion">
-        <source>NETSDK1061: The project was restored using {0} version {1}, but with current settings, version {2} would be used instead. To resolve this issue, make sure the same settings are used for restore and for subsequent operations such as build or publish. Typically this issue can occur if the RuntimeIdentifier property is set during build or publish but not during restore. For more information, see https://aka.ms/dotnet-runtime-patch-selection.</source>
-        <target state="needs-review-translation">Проект был восстановлен с использованием {0} версии {1}, но с текущими параметрами будет использоваться версия {2}. Чтобы устранить эту проблему, убедитесь, что для восстановления и последующих операций, таких как сборка или публикация, используются одинаковые параметры. Обычно эта проблема возникает, если свойство RuntimeIdentifier задается во время сборки или публикации, а не восстановления.</target>
-        <note>{StrBegin="NETSDK1061: "}
-{0} - Package Identifier for platform package
-{1} - Restored version of platform package
-{2} - Current version of platform package</note>
-      </trans-unit>
-      <trans-unit id="AssetsFileNotSet">
-        <source>NETSDK1063: The path to the project assets file was not set. Run a NuGet package restore to generate this file.</source>
-        <target state="needs-review-translation">Не задан путь к файлу ресурсов проекта. Запустите восстановление пакета NuGet, чтобы создать этот файл.</target>
-        <note>{StrBegin="NETSDK1063: "}</note>
-      </trans-unit>
-      <trans-unit id="DotnetToolOnlySupportNetcoreapp">
-        <source>NETSDK1054: only supports .NET Core.</source>
-        <target state="needs-review-translation">поддерживает только .NET Core.</target>
-        <note>{StrBegin="NETSDK1054: "}</note>
-      </trans-unit>
-      <trans-unit id="DotnetToolDoesNotSupportTFMLowerThanNetcoreapp21">
-        <source>NETSDK1055: DotnetTool does not support target framework lower than netcoreapp2.1.</source>
-        <target state="needs-review-translation">DotnetTool не поддерживает целевые платформы версий ниже netcoreapp2.1.</target>
-        <note>{StrBegin="NETSDK1055: "}</note>
-      </trans-unit>
-      <trans-unit id="UnableToUsePackageAssetsCache">
-        <source>NETSDK1062: Unable to use package assets cache due to I/O error. This can occur when the same project is built more than once in parallel. Performance may be degraded, but the build result will not be impacted.</source>
-        <target state="needs-review-translation">Не удается использовать кэш ресурсов пакета из-за ошибки ввода-вывода. Это может происходить при нескольких параллельных сборках одного проекта. Работа может быть замедлена, но результат сборки не изменится.</target>
-        <note>{StrBegin="NETSDK1062: "}</note>
+      <trans-unit id="PackageInfoLog">
+        <source>NETSDK1027: Package Name='{0}', Version='{1}' was parsed</source>
+        <target state="new">NETSDK1027: Package Name='{0}', Version='{1}' was parsed</target>
+        <note>{StrBegin="NETSDK1027: "}</note>
       </trans-unit>
       <trans-unit id="PackageNotFound">
         <source>NETSDK1064: Package {0}, version {1} was not found. It might have been deleted since NuGet restore. Otherwise, NuGet restore might have only partially completed, which might have been due to maximum path length restrictions.</source>
         <target state="new">NETSDK1064: Package {0}, version {1} was not found. It might have been deleted since NuGet restore. Otherwise, NuGet restore might have only partially completed, which might have been due to maximum path length restrictions.</target>
         <note>{StrBegin="NETSDK1064: "}</note>
       </trans-unit>
-      <trans-unit id="CannotFindApphostForRid">
-        <source>NETSDK1065: Cannot find app host for {0}. {0} could be an invalid runtime identifier (RID). For more information about RID, see https://aka.ms/rid-catalog.</source>
-        <target state="new">NETSDK1065: Cannot find app host for {0}. {0} could be an invalid runtime identifier (RID). For more information about RID, see https://aka.ms/rid-catalog.</target>
-        <note>{StrBegin="NETSDK1065: "}</note>
+      <trans-unit id="PackageReferenceOverrideWarning">
+        <source>NETSDK1023: A PackageReference for '{0}' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see {1}</source>
+        <target state="new">NETSDK1023: A PackageReference for '{0}' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see {1}</target>
+        <note>{StrBegin="NETSDK1023: "}</note>
+      </trans-unit>
+      <trans-unit id="ParsingFiles">
+        <source>NETSDK1026: Parsing the Files : '{0}'</source>
+        <target state="new">NETSDK1026: Parsing the Files : '{0}'</target>
+        <note>{StrBegin="NETSDK1026: "}</note>
+      </trans-unit>
+      <trans-unit id="ProjectAssetsConsumedWithoutMSBuildProjectPath">
+        <source>NETSDK1011: Assets are consumed from project '{0}', but no corresponding MSBuild project path was  found in '{1}'.</source>
+        <target state="new">NETSDK1011: Assets are consumed from project '{0}', but no corresponding MSBuild project path was  found in '{1}'.</target>
+        <note>{StrBegin="NETSDK1011: "}</note>
+      </trans-unit>
+      <trans-unit id="ProjectContainsObsoleteDotNetCliTool">
+        <source>NETSDK1059: The tool '{0}' is now included in the .NET Core SDK. Information on resolving this warning is available at (https://aka.ms/dotnetclitools-in-box).</source>
+        <target state="new">NETSDK1059: The tool '{0}' is now included in the .NET Core SDK. Information on resolving this warning is available at (https://aka.ms/dotnetclitools-in-box).</target>
+        <note>{StrBegin="NETSDK1059: "}</note>
+      </trans-unit>
+      <trans-unit id="RecommendRuntimeFrameworkNameForAspNetCorePackages">
+        <source>NETSDK1071: A PackageReference for '{0}' was included in your project. This package can be implicitly defined by the SDK. To resolve this warning, remove this PackageReference and set the RuntimeFrameworkName property to {1}. For more information, see {2}.</source>
+        <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. This package can be implicitly defined by the SDK. To resolve this warning, remove this PackageReference and set the RuntimeFrameworkName property to {1}. For more information, see {2}.</target>
+        <note>{StrBegin="NETSDK1071: "}
+{0} - Package Id (Microsoft.AspNetCore.App or .All)
+{1} - Project name
+{2} - More info link
+    </note>
+      </trans-unit>
+      <trans-unit id="RuntimeIdentifierWasNotSpecified">
+        <source>NETSDK1028: Specify a RuntimeIdentifier</source>
+        <target state="new">NETSDK1028: Specify a RuntimeIdentifier</target>
+        <note>{StrBegin="NETSDK1028: "}</note>
+      </trans-unit>
+      <trans-unit id="SkippingAdditionalProbingPaths">
+        <source>NETSDK1048: 'AdditionalProbingPaths' were specified for GenerateRuntimeConfigurationFiles, but are being skipped because 'RuntimeConfigDevPath' is empty.</source>
+        <target state="new">NETSDK1048: 'AdditionalProbingPaths' were specified for GenerateRuntimeConfigurationFiles, but are being skipped because 'RuntimeConfigDevPath' is empty.</target>
+        <note>{StrBegin="NETSDK1048: "}</note>
+      </trans-unit>
+      <trans-unit id="TargetFrameworkWithSemicolon">
+        <source>NETSDK1046: The TargetFramework value '{0}' is not valid. To multi-target, use the 'TargetFrameworks' property instead.</source>
+        <target state="new">NETSDK1046: The TargetFramework value '{0}' is not valid. To multi-target, use the 'TargetFrameworks' property instead.</target>
+        <note>{StrBegin="NETSDK1046: "}</note>
+      </trans-unit>
+      <trans-unit id="UnableToFindResolvedPath">
+        <source>NETSDK1016: Unable to find resolved path for '{0}'.</source>
+        <target state="new">NETSDK1016: Unable to find resolved path for '{0}'.</target>
+        <note>{StrBegin="NETSDK1016: "}</note>
+      </trans-unit>
+      <trans-unit id="UnableToUsePackageAssetsCache">
+        <source>NETSDK1062: Unable to use package assets cache due to I/O error. This can occur when the same project is built more than once in parallel. Performance may be degraded, but the build result will not be impacted.</source>
+        <target state="new">NETSDK1062: Unable to use package assets cache due to I/O error. This can occur when the same project is built more than once in parallel. Performance may be degraded, but the build result will not be impacted.</target>
+        <note>{StrBegin="NETSDK1062: "}</note>
+      </trans-unit>
+      <trans-unit id="UnexpectedFileType">
+        <source>NETSDK1012: Unexpected file type for '{0}'. Type is both '{1}' and '{2}'.</source>
+        <target state="new">NETSDK1012: Unexpected file type for '{0}'. Type is both '{1}' and '{2}'.</target>
+        <note>{StrBegin="NETSDK1012: "}</note>
+      </trans-unit>
+      <trans-unit id="UnrecognizedPreprocessorToken">
+        <source>NETSDK1009: Unrecognized preprocessor token '{0}' in '{1}'.</source>
+        <target state="new">NETSDK1009: Unrecognized preprocessor token '{0}' in '{1}'.</target>
+        <note>{StrBegin="NETSDK1009: "}</note>
+      </trans-unit>
+      <trans-unit id="UnrecognizedRuntimeFrameworkName">
+        <source>NETSDK1070: This project uses an unsupported value for RuntimeFrameworkName. Currently, only valid values are: Microsoft.NETCore.App, Microsoft.AspNetCore.App, or Microsoft.AspNetCore.All.</source>
+        <target state="new">NETSDK1070: This project uses an unsupported value for RuntimeFrameworkName. Currently, only valid values are: Microsoft.NETCore.App, Microsoft.AspNetCore.App, or Microsoft.AspNetCore.All.</target>
+        <note>{StrBegin="NETSDK1070: "}</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedFramework">
+        <source>NETSDK1019: {0} is an unsupported framework.</source>
+        <target state="new">NETSDK1019: {0} is an unsupported framework.</target>
+        <note>{StrBegin="NETSDK1019: "}</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedRuntimeIdentifier">
+        <source>NETSDK1056: Project is targeting runtime '{0}' but did not resolve any runtime-specific packages. This runtime may not be supported by the target framework.</source>
+        <target state="new">NETSDK1056: Project is targeting runtime '{0}' but did not resolve any runtime-specific packages. This runtime may not be supported by the target framework.</target>
+        <note>{StrBegin="NETSDK1056: "}</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedSDKVersionForNetStandard20">
+        <source>NETSDK1050: The version of Microsoft.NET.Sdk used by this project is insufficient to support references to libraries targeting .NET Standard 1.5 or higher.  Please install version 2.0 or higher of the .NET Core SDK.</source>
+        <target state="new">NETSDK1050: The version of Microsoft.NET.Sdk used by this project is insufficient to support references to libraries targeting .NET Standard 1.5 or higher.  Please install version 2.0 or higher of the .NET Core SDK.</target>
+        <note>{StrBegin="NETSDK1050: "}</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedTargetFrameworkVersion">
+        <source>NETSDK1045: The current .NET SDK does not support targeting {0} {1}.  Either target {0} {2} or lower, or use a version of the .NET SDK that supports {0} {1}.</source>
+        <target state="new">NETSDK1045: The current .NET SDK does not support targeting {0} {1}.  Either target {0} {2} or lower, or use a version of the .NET SDK that supports {0} {1}.</target>
+        <note>{StrBegin="NETSDK1045: "}</note>
+      </trans-unit>
+      <trans-unit id="UsingPreviewSdkWarning">
+        <source>NETSDK1057: You are working with a preview version of the .NET Core SDK. You can define the SDK version via a global.json file in the current project. More at https://go.microsoft.com/fwlink/?linkid=869452</source>
+        <target state="new">NETSDK1057: You are working with a preview version of the .NET Core SDK. You can define the SDK version via a global.json file in the current project. More at https://go.microsoft.com/fwlink/?linkid=869452</target>
+        <note>{StrBegin="NETSDK1057: "}</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
@@ -2,70 +2,10 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../Strings.resx">
     <body>
-      <trans-unit id="AppHostHasBeenModified">
-        <source>NETSDK1029: Unable to use '{0}' as application host executable as it does not contain the expected placeholder byte sequence '{1}' that would mark where the application name would be written.</source>
-        <target state="new">NETSDK1029: Unable to use '{0}' as application host executable as it does not contain the expected placeholder byte sequence '{1}' that would mark where the application name would be written.</target>
-        <note>{StrBegin="NETSDK1029: "}</note>
-      </trans-unit>
-      <trans-unit id="AssetPreprocessorMustBeConfigured">
-        <source>NETSDK1017: Asset preprocessor must be configured before assets are processed.</source>
-        <target state="new">NETSDK1017: Asset preprocessor must be configured before assets are processed.</target>
-        <note>{StrBegin="NETSDK1017: "}</note>
-      </trans-unit>
-      <trans-unit id="AssetsFileMissingRuntimeIdentifier">
-        <source>NETSDK1047: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project. You may also need to include '{3}' in your project's RuntimeIdentifiers.</source>
-        <target state="new">NETSDK1047: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project. You may also need to include '{3}' in your project's RuntimeIdentifiers.</target>
-        <note>{StrBegin="NETSDK1047: "}</note>
-      </trans-unit>
-      <trans-unit id="AssetsFileMissingTarget">
-        <source>NETSDK1005: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project.</source>
-        <target state="new">NETSDK1005: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project.</target>
-        <note>{StrBegin="NETSDK1005: "}</note>
-      </trans-unit>
-      <trans-unit id="AssetsFileNotFound">
-        <source>NETSDK1004: Assets file '{0}' not found. Run a NuGet package restore to generate this file.</source>
-        <target state="new">NETSDK1004: Assets file '{0}' not found. Run a NuGet package restore to generate this file.</target>
-        <note>{StrBegin="NETSDK1004: "}</note>
-      </trans-unit>
-      <trans-unit id="AssetsFileNotSet">
-        <source>NETSDK1063: The path to the project assets file was not set. Run a NuGet package restore to generate this file.</source>
-        <target state="new">NETSDK1063: The path to the project assets file was not set. Run a NuGet package restore to generate this file.</target>
-        <note>{StrBegin="NETSDK1063: "}</note>
-      </trans-unit>
-      <trans-unit id="AssetsFilePathNotRooted">
-        <source>NETSDK1006: Assets file path '{0}' is not rooted. Only full paths are supported.</source>
-        <target state="new">NETSDK1006: Assets file path '{0}' is not rooted. Only full paths are supported.</target>
-        <note>{StrBegin="NETSDK1006: "}</note>
-      </trans-unit>
       <trans-unit id="AtLeastOneTargetFrameworkMustBeSpecified">
         <source>NETSDK1001: At least one possible target framework must be specified.</source>
-        <target state="new">NETSDK1001: At least one possible target framework must be specified.</target>
+        <target state="needs-review-translation">Необходимо указать хотя бы одну целевую платформу.</target>
         <note>{StrBegin="NETSDK1001: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotFindApphostForRid">
-        <source>NETSDK1065: Cannot find app host for {0}. {0} could be an invalid runtime identifier (RID). For more information about RID, see https://aka.ms/rid-catalog.</source>
-        <target state="new">NETSDK1065: Cannot find app host for {0}. {0} could be an invalid runtime identifier (RID). For more information about RID, see https://aka.ms/rid-catalog.</target>
-        <note>{StrBegin="NETSDK1065: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotFindProjectInfo">
-        <source>NETSDK1007: Cannot find project info for '{0}'. This can indicate a missing project reference.</source>
-        <target state="new">NETSDK1007: Cannot find project info for '{0}'. This can indicate a missing project reference.</target>
-        <note>{StrBegin="NETSDK1007: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotHaveRuntimeIdentifierPlatformMismatchPlatformTarget">
-        <source>NETSDK1032: The RuntimeIdentifier platform '{0}' and the PlatformTarget '{1}' must be compatible.</source>
-        <target state="new">NETSDK1032: The RuntimeIdentifier platform '{0}' and the PlatformTarget '{1}' must be compatible.</target>
-        <note>{StrBegin="NETSDK1032: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotHaveSelfContainedWithoutRuntimeIdentifier">
-        <source>NETSDK1031: It is not supported to build or publish a self-contained application without specifying a RuntimeIdentifier.  Please either specify a RuntimeIdentifier or set SelfContained to false.</source>
-        <target state="new">NETSDK1031: It is not supported to build or publish a self-contained application without specifying a RuntimeIdentifier.  Please either specify a RuntimeIdentifier or set SelfContained to false.</target>
-        <note>{StrBegin="NETSDK1031: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotInferTargetFrameworkIdentiferAndVersion">
-        <source>NETSDK1013: The TargetFramework value '{0}' was not recognized. It may be misspelled. If not, then the TargetFrameworkIdentifier and/or TargetFrameworkVersion properties must be specified explicitly.</source>
-        <target state="new">NETSDK1013: The TargetFramework value '{0}' was not recognized. It may be misspelled. If not, then the TargetFrameworkIdentifier and/or TargetFrameworkVersion properties must be specified explicitly.</target>
-        <note>{StrBegin="NETSDK1013: "}</note>
       </trans-unit>
       <trans-unit id="CannotUseAppHostWithoutRuntimeIdentifier">
         <source>NETSDK1066: A RuntimeIdentifier must be specified to publish a framework-dependent application with an application host.</source>
@@ -77,174 +17,10 @@
         <target state="new">NETSDK1067: Self-contained applications are required to use the application host. Either set SelfContained to false or set UseAppHost to true.</target>
         <note>{StrBegin="NETSDK1067: "}</note>
       </trans-unit>
-      <trans-unit id="ChoosingAssemblyVersion">
-        <source>NETSDK1033: Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</source>
-        <target state="new">NETSDK1033: Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</target>
-        <note>{StrBegin="NETSDK1033: "}</note>
-      </trans-unit>
-      <trans-unit id="ChoosingFileVersion">
-        <source>NETSDK1034: Choosing '{0}' because file version '{1}' is greater than '{2}'.</source>
-        <target state="new">NETSDK1034: Choosing '{0}' because file version '{1}' is greater than '{2}'.</target>
-        <note>{StrBegin="NETSDK1034: "}</note>
-      </trans-unit>
-      <trans-unit id="ChoosingPlatformItem">
-        <source>NETSDK1035: Choosing '{0}' because it is a platform item.</source>
-        <target state="new">NETSDK1035: Choosing '{0}' because it is a platform item.</target>
-        <note>{StrBegin="NETSDK1035: "}</note>
-      </trans-unit>
-      <trans-unit id="ChoosingPreferredPackage">
-        <source>NETSDK1036: Choosing '{0}' because it comes from a package that is preferred.</source>
-        <target state="new">NETSDK1036: Choosing '{0}' because it comes from a package that is preferred.</target>
-        <note>{StrBegin="NETSDK1036: "}</note>
-      </trans-unit>
-      <trans-unit id="ConflictCouldNotDetermineWinner">
-        <source>NETSDK1037: Could not determine winner due to equal file and assembly versions.</source>
-        <target state="new">NETSDK1037: Could not determine winner due to equal file and assembly versions.</target>
-        <note>{StrBegin="NETSDK1037: "}</note>
-      </trans-unit>
-      <trans-unit id="ContentItemDoesNotProvideOutputPath">
-        <source>NETSDK1014: Content item for '{0}' sets '{1}', but does not provide  '{2}' or '{3}'.</source>
-        <target state="new">NETSDK1014: Content item for '{0}' sets '{1}', but does not provide  '{2}' or '{3}'.</target>
-        <note>{StrBegin="NETSDK1014: "}</note>
-      </trans-unit>
-      <trans-unit id="ContentPreproccessorParameterRequired">
-        <source>NETSDK1010: The '{0}' task must be given a value for parameter '{1}' in order to consume preprocessed content.</source>
-        <target state="new">NETSDK1010: The '{0}' task must be given a value for parameter '{1}' in order to consume preprocessed content.</target>
-        <note>{StrBegin="NETSDK1010: "}</note>
-      </trans-unit>
-      <trans-unit id="CouldNotDetermineWinner_DoesntExist">
-        <source>NETSDK1038: Could not determine winner because '{0}' does not exist.</source>
-        <target state="new">NETSDK1038: Could not determine winner because '{0}' does not exist.</target>
-        <note>{StrBegin="NETSDK1001: "}</note>
-      </trans-unit>
-      <trans-unit id="CouldNotDetermineWinner_FileVersion">
-        <source>NETSDK1039: Could not determine a winner because '{0}' has no file version.</source>
-        <target state="new">NETSDK1039: Could not determine a winner because '{0}' has no file version.</target>
-        <note>{StrBegin="NETSDK1039: "}</note>
-      </trans-unit>
-      <trans-unit id="CouldNotDetermineWinner_NotAnAssembly">
-        <source>NETSDK1040: Could not determine a winner because '{0}' is not an assembly.</source>
-        <target state="new">NETSDK1040: Could not determine a winner because '{0}' is not an assembly.</target>
-        <note>{StrBegin="NETSDK1040: "}</note>
-      </trans-unit>
-      <trans-unit id="CouldNotLoadPlatformManifest">
-        <source>NETSDK1042: Could not load PlatformManifest from '{0}' because it did not exist.</source>
-        <target state="new">NETSDK1042: Could not load PlatformManifest from '{0}' because it did not exist.</target>
-        <note>{StrBegin="NETSDK1042: "}</note>
-      </trans-unit>
-      <trans-unit id="DotnetToolDoesNotSupportTFMLowerThanNetcoreapp21">
-        <source>NETSDK1055: DotnetTool does not support target framework lower than netcoreapp2.1.</source>
-        <target state="new">NETSDK1055: DotnetTool does not support target framework lower than netcoreapp2.1.</target>
-        <note>{StrBegin="NETSDK1055: "}</note>
-      </trans-unit>
-      <trans-unit id="DotnetToolOnlySupportNetcoreapp">
-        <source>NETSDK1054: only supports .NET Core.</source>
-        <target state="new">NETSDK1054: only supports .NET Core.</target>
-        <note>{StrBegin="NETSDK1054: "}</note>
-      </trans-unit>
-      <trans-unit id="DuplicateItemsError">
-        <source>NETSDK1022: Duplicate '{0}' items were included. The .NET SDK includes '{0}' items from your project directory by default. You can either remove these items from your project file, or set the '{1}' property to '{2}' if you want to explicitly include them in your project file. For more information, see {4}. The duplicate items were: {3}</source>
-        <target state="new">NETSDK1022: Duplicate '{0}' items were included. The .NET SDK includes '{0}' items from your project directory by default. You can either remove these items from your project file, or set the '{1}' property to '{2}' if you want to explicitly include them in your project file. For more information, see {4}. The duplicate items were: {3}</target>
-        <note>{StrBegin="NETSDK1022: "}</note>
-      </trans-unit>
-      <trans-unit id="DuplicatePreprocessorToken">
-        <source>NETSDK1015: The preprocessor token '{0}' has been given more than one value. Choosing '{1}' as the value.</source>
-        <target state="new">NETSDK1015: The preprocessor token '{0}' has been given more than one value. Choosing '{1}' as the value.</target>
-        <note>{StrBegin="NETSDK1015: "}</note>
-      </trans-unit>
-      <trans-unit id="EncounteredConflict">
-        <source>NETSDK1041: Encountered conflict between '{0}' and '{1}'.</source>
-        <target state="new">NETSDK1041: Encountered conflict between '{0}' and '{1}'.</target>
-        <note>{StrBegin="NETSDK1041: "}</note>
-      </trans-unit>
-      <trans-unit id="ErrorParsingFrameworkListInvalidValue">
-        <source>NETSDK1051: Error parsing FrameworkList from '{0}'.  {1} '{2}' was invalid.</source>
-        <target state="new">NETSDK1051: Error parsing FrameworkList from '{0}'.  {1} '{2}' was invalid.</target>
-        <note>{StrBegin="NETSDK1051: "}</note>
-      </trans-unit>
-      <trans-unit id="ErrorParsingPlatformManifest">
-        <source>NETSDK1043: Error parsing PlatformManifest from '{0}' line {1}.  Lines must have the format {2}.</source>
-        <target state="new">NETSDK1043: Error parsing PlatformManifest from '{0}' line {1}.  Lines must have the format {2}.</target>
-        <note>{StrBegin="NETSDK1043: "}</note>
-      </trans-unit>
-      <trans-unit id="ErrorParsingPlatformManifestInvalidValue">
-        <source>NETSDK1044: Error parsing PlatformManifest from '{0}' line {1}.  {2} '{3}' was invalid.</source>
-        <target state="new">NETSDK1044: Error parsing PlatformManifest from '{0}' line {1}.  {2} '{3}' was invalid.</target>
-        <note>{StrBegin="NETSDK1044: "}</note>
-      </trans-unit>
-      <trans-unit id="ErrorReadingAssetsFile">
-        <source>NETSDK1060: Error reading assets file: {0}</source>
-        <target state="new">NETSDK1060: Error reading assets file: {0}</target>
-        <note>{StrBegin="NETSDK1060: "}</note>
-      </trans-unit>
-      <trans-unit id="FileNameIsTooLong">
-        <source>NETSDK1030: Given file name '{0}' is longer than 1024 bytes</source>
-        <target state="new">NETSDK1030: Given file name '{0}' is longer than 1024 bytes</target>
-        <note>{StrBegin="NETSDK1030: "}</note>
-      </trans-unit>
-      <trans-unit id="FolderAlreadyExists">
-        <source>NETSDK1024: Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</source>
-        <target state="new">NETSDK1024: Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</target>
-        <note>{StrBegin="NETSDK1024: "}</note>
-      </trans-unit>
       <trans-unit id="FrameworkDependentAppHostRequiresVersion21">
         <source>NETSDK1068: The framework-dependent application host requires a target framework of at least 'netcoreapp2.1'.</source>
         <target state="new">NETSDK1068: The framework-dependent application host requires a target framework of at least 'netcoreapp2.1'.</target>
         <note>{StrBegin="NETSDK1068: "}</note>
-      </trans-unit>
-      <trans-unit id="FrameworkListPathNotRooted">
-        <source>NETSDK1052: Framework list file path '{0}' is not rooted. Only full paths are supported.</source>
-        <target state="new">NETSDK1052: Framework list file path '{0}' is not rooted. Only full paths are supported.</target>
-        <note>{StrBegin="NETSDK1052: "}</note>
-      </trans-unit>
-      <trans-unit id="GetDependsOnNETStandardFailedWithException">
-        <source>NETSDK1049: Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0} {1}</source>
-        <target state="new">NETSDK1049: Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0} {1}</target>
-        <note>{StrBegin="NETSDK1049: "}</note>
-      </trans-unit>
-      <trans-unit id="IncorrectPackageRoot">
-        <source>NETSDK1020: Package Root {0} was incorrectly given for Resolved library {1}</source>
-        <target state="new">NETSDK1020: Package Root {0} was incorrectly given for Resolved library {1}</target>
-        <note>{StrBegin="NETSDK1020: "}</note>
-      </trans-unit>
-      <trans-unit id="IncorrectTargetFormat">
-        <source>NETSDK1025: WRThe target manifest {0} provided is of not the correct format</source>
-        <target state="new">NETSDK1025: WRThe target manifest {0} provided is of not the correct format</target>
-        <note>{StrBegin="NETSDK1025: "}</note>
-      </trans-unit>
-      <trans-unit id="InvalidFrameworkName">
-        <source>NETSDK1003: Invalid framework name: '{0}'.</source>
-        <target state="new">NETSDK1003: Invalid framework name: '{0}'.</target>
-        <note>{StrBegin="NETSDK1003: "}</note>
-      </trans-unit>
-      <trans-unit id="InvalidItemSpecToUse">
-        <source>NETSDK1058: Invalid value for ItemSpecToUse parameter: '{0}'.  This property must be blank or set to 'Left' or 'Right'</source>
-        <target state="new">NETSDK1058: Invalid value for ItemSpecToUse parameter: '{0}'.  This property must be blank or set to 'Left' or 'Right'</target>
-        <note>{StrBegin="NETSDK1058: "}
-The following are names of parameters or literal values and should not be translated: ItemSpecToUse, Left, Right</note>
-      </trans-unit>
-      <trans-unit id="InvalidNuGetVersionString">
-        <source>NETSDK1018: Invalid NuGet version string: '{0}'.</source>
-        <target state="new">NETSDK1018: Invalid NuGet version string: '{0}'.</target>
-        <note>{StrBegin="NETSDK1018: "}</note>
-      </trans-unit>
-      <trans-unit id="MismatchedPlatformPackageVersion">
-        <source>NETSDK1061: The project was restored using {0} version {1}, but with current settings, version {2} would be used instead. To resolve this issue, make sure the same settings are used for restore and for subsequent operations such as build or publish. Typically this issue can occur if the RuntimeIdentifier property is set during build or publish but not during restore. For more information, see https://aka.ms/dotnet-runtime-patch-selection.</source>
-        <target state="new">NETSDK1061: The project was restored using {0} version {1}, but with current settings, version {2} would be used instead. To resolve this issue, make sure the same settings are used for restore and for subsequent operations such as build or publish. Typically this issue can occur if the RuntimeIdentifier property is set during build or publish but not during restore. For more information, see https://aka.ms/dotnet-runtime-patch-selection.</target>
-        <note>{StrBegin="NETSDK1061: "}
-{0} - Package Identifier for platform package
-{1} - Restored version of platform package
-{2} - Current version of platform package</note>
-      </trans-unit>
-      <trans-unit id="MissingItemMetadata">
-        <source>NETSDK1008: Missing '{0}' metadata on '{1}' item '{2}'.</source>
-        <target state="new">NETSDK1008: Missing '{0}' metadata on '{1}' item '{2}'.</target>
-        <note>{StrBegin="NETSDK1008: "}</note>
-      </trans-unit>
-      <trans-unit id="MultipleFilesResolved">
-        <source>NETSDK1021: More than one file found for {0}</source>
-        <target state="new">NETSDK1021: More than one file found for {0}</target>
-        <note>{StrBegin="NETSDK1021: "}</note>
       </trans-unit>
       <trans-unit id="NETFrameworkToNonBuiltInNETStandard">
         <source>NETSDK1069: This project uses a library that targets .NET Standard 1.5 or higher, and the project targets a version of .NET Framework that doesn't have built-in support for that version of .NET Standard. Visit https://aka.ms/net-standard-known-issues for a set of known issues. Consider retargeting to .NET Framework 4.7.2.</source>
@@ -253,117 +29,327 @@ The following are names of parameters or literal values and should not be transl
       </trans-unit>
       <trans-unit id="NoCompatibleTargetFramework">
         <source>NETSDK1002: Project '{0}' targets '{2}'. It cannot be referenced by a project that targets '{1}'.</source>
-        <target state="new">NETSDK1002: Project '{0}' targets '{2}'. It cannot be referenced by a project that targets '{1}'.</target>
+        <target state="needs-review-translation">Проект "{0}" предназначен для платформы "{2}". На него не может ссылаться проект, предназначенный для платформы "{1}".</target>
         <note>{StrBegin="NETSDK1002: "}</note>
       </trans-unit>
-      <trans-unit id="PackAsToolCannotSupportSelfContained">
-        <source>NETSDK1053: Pack as tool does not support self contained.</source>
-        <target state="new">NETSDK1053: Pack as tool does not support self contained.</target>
-        <note>{StrBegin="NETSDK1001: "}</note>
+      <trans-unit id="InvalidFrameworkName">
+        <source>NETSDK1003: Invalid framework name: '{0}'.</source>
+        <target state="needs-review-translation">Недопустимое имя платформы: "{0}".</target>
+        <note>{StrBegin="NETSDK1003: "}</note>
+      </trans-unit>
+      <trans-unit id="AssetsFileNotFound">
+        <source>NETSDK1004: Assets file '{0}' not found. Run a NuGet package restore to generate this file.</source>
+        <target state="needs-review-translation">Файл ресурсов "{0}" не найден. Выполните восстановление пакета NuGet, чтобы создать этот файл.</target>
+        <note>{StrBegin="NETSDK1004: "}</note>
+      </trans-unit>
+      <trans-unit id="AssetsFileMissingTarget">
+        <source>NETSDK1005: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project.</source>
+        <target state="needs-review-translation">Файл ресурсов "{0}" не имеет целевого объекта для "{1}". Убедитесь, что восстановление выполнено и что вы включили "{2}" в свойство "TargetFrameworks" для проекта.</target>
+        <note>{StrBegin="NETSDK1005: "}</note>
+      </trans-unit>
+      <trans-unit id="AssetsFilePathNotRooted">
+        <source>NETSDK1006: Assets file path '{0}' is not rooted. Only full paths are supported.</source>
+        <target state="needs-review-translation">Путь к файлу ресурсов "{0}" должен содержать корневой каталог. Поддерживаются только полные пути.</target>
+        <note>{StrBegin="NETSDK1006: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotFindProjectInfo">
+        <source>NETSDK1007: Cannot find project info for '{0}'. This can indicate a missing project reference.</source>
+        <target state="needs-review-translation">Невозможно найти сведения о проекте для "{0}". Возможно, отсутствует ссылка на проект.</target>
+        <note>{StrBegin="NETSDK1007: "}</note>
+      </trans-unit>
+      <trans-unit id="MissingItemMetadata">
+        <source>NETSDK1008: Missing '{0}' metadata on '{1}' item '{2}'.</source>
+        <target state="needs-review-translation">Отсутствуют метаданные "{0}" для элемента "{2}" "{1}".</target>
+        <note>{StrBegin="NETSDK1008: "}</note>
+      </trans-unit>
+      <trans-unit id="UnrecognizedPreprocessorToken">
+        <source>NETSDK1009: Unrecognized preprocessor token '{0}' in '{1}'.</source>
+        <target state="needs-review-translation">Нераспознанный маркер препроцессора "{0}" в "{1}".</target>
+        <note>{StrBegin="NETSDK1009: "}</note>
+      </trans-unit>
+      <trans-unit id="ContentPreproccessorParameterRequired">
+        <source>NETSDK1010: The '{0}' task must be given a value for parameter '{1}' in order to consume preprocessed content.</source>
+        <target state="needs-review-translation">В задачу "{0}" необходимо передать значение для параметра "{1}" для использования предварительно обработанного содержимого.</target>
+        <note>{StrBegin="NETSDK1010: "}</note>
+      </trans-unit>
+      <trans-unit id="ProjectAssetsConsumedWithoutMSBuildProjectPath">
+        <source>NETSDK1011: Assets are consumed from project '{0}', but no corresponding MSBuild project path was  found in '{1}'.</source>
+        <target state="needs-review-translation">Ресурсы используются из проекта "{0}", однако соответствующий путь к проекту MSBuild не найден в "{1}".</target>
+        <note>{StrBegin="NETSDK1011: "}</note>
+      </trans-unit>
+      <trans-unit id="UnexpectedFileType">
+        <source>NETSDK1012: Unexpected file type for '{0}'. Type is both '{1}' and '{2}'.</source>
+        <target state="needs-review-translation">Непредвиденный тип файла для "{0}". Тип является "{1}" и "{2}".</target>
+        <note>{StrBegin="NETSDK1012: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotInferTargetFrameworkIdentiferAndVersion">
+        <source>NETSDK1013: The TargetFramework value '{0}' was not recognized. It may be misspelled. If not, then the TargetFrameworkIdentifier and/or TargetFrameworkVersion properties must be specified explicitly.</source>
+        <target state="needs-review-translation">Значение "{0}" свойства "TargetFramework" не было распознано. Возможно, оно содержит опечатку. В противном случае следует явным образом задать свойства "TargetFrameworkIdentifier" и (или) "TargetFrameworkVersion".</target>
+        <note>{StrBegin="NETSDK1013: "}</note>
+      </trans-unit>
+      <trans-unit id="ContentItemDoesNotProvideOutputPath">
+        <source>NETSDK1014: Content item for '{0}' sets '{1}', but does not provide  '{2}' or '{3}'.</source>
+        <target state="needs-review-translation">Элемент содержимого для "{0}" задает "{1}", но не предоставляет "{2}" или "{3}".</target>
+        <note>{StrBegin="NETSDK1014: "}</note>
+      </trans-unit>
+      <trans-unit id="DuplicatePreprocessorToken">
+        <source>NETSDK1015: The preprocessor token '{0}' has been given more than one value. Choosing '{1}' as the value.</source>
+        <target state="needs-review-translation">Для маркера препроцессора "{0}" задано несколько значений. Выбор "{1}" в качестве значения.</target>
+        <note>{StrBegin="NETSDK1015: "}</note>
+      </trans-unit>
+      <trans-unit id="UnableToFindResolvedPath">
+        <source>NETSDK1016: Unable to find resolved path for '{0}'.</source>
+        <target state="needs-review-translation">Не удается найти разрешенный путь для "{0}".</target>
+        <note>{StrBegin="NETSDK1016: "}</note>
+      </trans-unit>
+      <trans-unit id="AssetPreprocessorMustBeConfigured">
+        <source>NETSDK1017: Asset preprocessor must be configured before assets are processed.</source>
+        <target state="needs-review-translation">Препроцессор ресурсов необходимо настроить перед обработкой ресурсов.</target>
+        <note>{StrBegin="NETSDK1017: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidNuGetVersionString">
+        <source>NETSDK1018: Invalid NuGet version string: '{0}'.</source>
+        <target state="needs-review-translation">Недопустимая строка версии Invalid NuGet: "{0}".</target>
+        <note>{StrBegin="NETSDK1018: "}</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedFramework">
+        <source>NETSDK1019: {0} is an unsupported framework.</source>
+        <target state="needs-review-translation">Платформа {0} не поддерживается.</target>
+        <note>{StrBegin="NETSDK1019: "}</note>
+      </trans-unit>
+      <trans-unit id="DuplicateItemsError">
+        <source>NETSDK1022: Duplicate '{0}' items were included. The .NET SDK includes '{0}' items from your project directory by default. You can either remove these items from your project file, or set the '{1}' property to '{2}' if you want to explicitly include them in your project file. For more information, see {4}. The duplicate items were: {3}</source>
+        <target state="needs-review-translation">Были включены повторяющиеся элементы ("{0}"). Пакет .NET SDK по умолчанию включает элементы "{0}" из каталога проекта. Можно удалить эти элементы из файла проекта или присвоить свойству "{1}" значение "{2}", если нужно явно включить их в файл проекта. Дополнительные сведения см. в разделе {4}. Повторяющиеся элементы: {3}</target>
+        <note>{StrBegin="NETSDK1022: "}</note>
+      </trans-unit>
+      <trans-unit id="PackageReferenceOverrideWarning">
+        <source>NETSDK1023: A PackageReference for '{0}' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see {1}</source>
+        <target state="needs-review-translation">PackageReference для "{0}" был включен в проект. На этот пакет неявно указывает пакет .NET SDK, и ссылаться на него из проекта обычно не нужно. Дополнительные сведения: {1}</target>
+        <note>{StrBegin="NETSDK1023: "}</note>
+      </trans-unit>
+      <trans-unit id="IncorrectPackageRoot">
+        <source>NETSDK1020: Package Root {0} was incorrectly given for Resolved library {1}</source>
+        <target state="needs-review-translation">Корневой каталог пакета {0} неправильно указан для разрешенной библиотеки {1}</target>
+        <note>{StrBegin="NETSDK1020: "}</note>
+      </trans-unit>
+      <trans-unit id="MultipleFilesResolved">
+        <source>NETSDK1021: More than one file found for {0}</source>
+        <target state="needs-review-translation">Для {0} найдено несколько файлов</target>
+        <note>{StrBegin="NETSDK1021: "}</note>
+      </trans-unit>
+      <trans-unit id="FolderAlreadyExists">
+        <source>NETSDK1024: Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</source>
+        <target state="needs-review-translation">Папка "{0}" уже существует. Удалите ее или укажите другой каталог ComposeWorkingDir</target>
+        <note>{StrBegin="NETSDK1024: "}</note>
+      </trans-unit>
+      <trans-unit id="ParsingFiles">
+        <source>NETSDK1026: Parsing the Files : '{0}'</source>
+        <target state="needs-review-translation">Анализируются файлы: "{0}"</target>
+        <note>{StrBegin="NETSDK1026: "}</note>
       </trans-unit>
       <trans-unit id="PackageInfoLog">
         <source>NETSDK1027: Package Name='{0}', Version='{1}' was parsed</source>
-        <target state="new">NETSDK1027: Package Name='{0}', Version='{1}' was parsed</target>
+        <target state="needs-review-translation">Пакет с именем "{0}" версии "{1}" был проанализирован</target>
         <note>{StrBegin="NETSDK1027: "}</note>
+      </trans-unit>
+      <trans-unit id="RuntimeIdentifierWasNotSpecified">
+        <source>NETSDK1028: Specify a RuntimeIdentifier</source>
+        <target state="needs-review-translation">Укажите RuntimeIdentifier</target>
+        <note>{StrBegin="NETSDK1028: "}</note>
+      </trans-unit>
+      <trans-unit id="IncorrectTargetFormat">
+        <source>NETSDK1025: WRThe target manifest {0} provided is of not the correct format</source>
+        <target state="needs-review-translation">Указанный целевой манифест {0} имеет неправильный формат</target>
+        <note>{StrBegin="NETSDK1025: "}</note>
+      </trans-unit>
+      <trans-unit id="AppHostHasBeenModified">
+        <source>NETSDK1029: Unable to use '{0}' as application host executable as it does not contain the expected placeholder byte sequence '{1}' that would mark where the application name would be written.</source>
+        <target state="needs-review-translation">Невозможно использовать файл "{0}" в качестве исполняемого файла узла приложения, так как он не содержит требуемой последовательности байтов "{1}", которая отмечает место, где должно записываться имя приложения.</target>
+        <note>{StrBegin="NETSDK1029: "}</note>
+      </trans-unit>
+      <trans-unit id="FileNameIsTooLong">
+        <source>NETSDK1030: Given file name '{0}' is longer than 1024 bytes</source>
+        <target state="needs-review-translation">Длина указанного имени файла "{0}" превышает 1024 байта</target>
+        <note>{StrBegin="NETSDK1030: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotHaveSelfContainedWithoutRuntimeIdentifier">
+        <source>NETSDK1031: It is not supported to build or publish a self-contained application without specifying a RuntimeIdentifier.  Please either specify a RuntimeIdentifier or set SelfContained to false.</source>
+        <target state="needs-review-translation">Сборка или публикация автономного приложения без указания идентификатора RuntimeIdentifier не поддерживается. Укажите RuntimeIdentifier или присвойте свойству SelfContained значение false.</target>
+        <note>{StrBegin="NETSDK1031: "}</note>
+      </trans-unit>
+      <trans-unit id="ChoosingAssemblyVersion">
+        <source>NETSDK1033: Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</source>
+        <target state="needs-review-translation">Выбирается "{0}", так как значение AssemblyVersion "{1}" больше "{2}".</target>
+        <note>{StrBegin="NETSDK1033: "}</note>
+      </trans-unit>
+      <trans-unit id="ChoosingFileVersion">
+        <source>NETSDK1034: Choosing '{0}' because file version '{1}' is greater than '{2}'.</source>
+        <target state="needs-review-translation">Выбирается "{0}", так как версия файла "{1}" больше "{2}".</target>
+        <note>{StrBegin="NETSDK1034: "}</note>
+      </trans-unit>
+      <trans-unit id="ChoosingPlatformItem">
+        <source>NETSDK1035: Choosing '{0}' because it is a platform item.</source>
+        <target state="needs-review-translation">Выбирается "{0}", так как это элемент платформы.</target>
+        <note>{StrBegin="NETSDK1035: "}</note>
+      </trans-unit>
+      <trans-unit id="ChoosingPreferredPackage">
+        <source>NETSDK1036: Choosing '{0}' because it comes from a package that is preferred.</source>
+        <target state="needs-review-translation">Выбирается "{0}", так как источником является предпочтительный пакет.</target>
+        <note>{StrBegin="NETSDK1036: "}</note>
+      </trans-unit>
+      <trans-unit id="ConflictCouldNotDetermineWinner">
+        <source>NETSDK1037: Could not determine winner due to equal file and assembly versions.</source>
+        <target state="needs-review-translation">Не удалось определить победителя, так как версии файла и сборки одинаковы.</target>
+        <note>{StrBegin="NETSDK1037: "}</note>
+      </trans-unit>
+      <trans-unit id="CouldNotDetermineWinner_DoesntExist">
+        <source>NETSDK1038: Could not determine winner because '{0}' does not exist.</source>
+        <target state="needs-review-translation">Не удалось определить победителя, так как "{0}" не существует.</target>
+        <note>{StrBegin="NETSDK1001: "}</note>
+      </trans-unit>
+      <trans-unit id="CouldNotDetermineWinner_FileVersion">
+        <source>NETSDK1039: Could not determine a winner because '{0}' has no file version.</source>
+        <target state="needs-review-translation">Не удалось определить победителя, так как "{0}" не имеет версии файла.</target>
+        <note>{StrBegin="NETSDK1039: "}</note>
+      </trans-unit>
+      <trans-unit id="CouldNotDetermineWinner_NotAnAssembly">
+        <source>NETSDK1040: Could not determine a winner because '{0}' is not an assembly.</source>
+        <target state="needs-review-translation">Не удалось определить победителя, так как "{0}" не является сборкой.</target>
+        <note>{StrBegin="NETSDK1040: "}</note>
+      </trans-unit>
+      <trans-unit id="EncounteredConflict">
+        <source>NETSDK1041: Encountered conflict between '{0}' and '{1}'.</source>
+        <target state="needs-review-translation">Обнаружен конфликт между "{0}" и "{1}".</target>
+        <note>{StrBegin="NETSDK1041: "}</note>
+      </trans-unit>
+      <trans-unit id="CouldNotLoadPlatformManifest">
+        <source>NETSDK1042: Could not load PlatformManifest from '{0}' because it did not exist.</source>
+        <target state="needs-review-translation">Не удалось загрузить манифест PlatformManifest из "{0}", так как он не существует.</target>
+        <note>{StrBegin="NETSDK1042: "}</note>
+      </trans-unit>
+      <trans-unit id="ErrorParsingPlatformManifest">
+        <source>NETSDK1043: Error parsing PlatformManifest from '{0}' line {1}.  Lines must have the format {2}.</source>
+        <target state="needs-review-translation">Ошибка при анализе PlatformManifest со строки "{0}" {1}. Строки должны иметь формат {2}.</target>
+        <note>{StrBegin="NETSDK1043: "}</note>
+      </trans-unit>
+      <trans-unit id="ErrorParsingPlatformManifestInvalidValue">
+        <source>NETSDK1044: Error parsing PlatformManifest from '{0}' line {1}.  {2} '{3}' was invalid.</source>
+        <target state="needs-review-translation">Ошибка анализа PlatformManifest со строки "{0}" {1}. Недопустимый {2} "{3}".</target>
+        <note>{StrBegin="NETSDK1044: "}</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedTargetFrameworkVersion">
+        <source>NETSDK1045: The current .NET SDK does not support targeting {0} {1}.  Either target {0} {2} or lower, or use a version of the .NET SDK that supports {0} {1}.</source>
+        <target state="needs-review-translation">Текущий пакет SDK для .NET не поддерживает целевой выбор {0} {1}. Выберите {0} {2} или более раннюю версию либо используйте версию пакета SDK для .NET, которая поддерживает {0} {1}.</target>
+        <note>{StrBegin="NETSDK1045: "}</note>
+      </trans-unit>
+      <trans-unit id="AssetsFileMissingRuntimeIdentifier">
+        <source>NETSDK1047: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project. You may also need to include '{3}' in your project's RuntimeIdentifiers.</source>
+        <target state="needs-review-translation">Файл ресурсов "{0}" не имеет целевого объекта для "{1}". Убедитесь, что восстановление выполнено и что вы включили "{2}" в свойство "TargetFrameworks"для проекта. Возможно, также потребуется включить "{3}" в свойство "RuntimeIdentifiers" проекта.</target>
+        <note>{StrBegin="NETSDK1047: "}</note>
+      </trans-unit>
+      <trans-unit id="TargetFrameworkWithSemicolon">
+        <source>NETSDK1046: The TargetFramework value '{0}' is not valid. To multi-target, use the 'TargetFrameworks' property instead.</source>
+        <target state="needs-review-translation">Значение "{0}" свойства "TargetFramework" недопустимо. Для нацеливания на несколько платформ используйте свойство "TargetFrameworks".</target>
+        <note>{StrBegin="NETSDK1046: "}</note>
+      </trans-unit>
+      <trans-unit id="SkippingAdditionalProbingPaths">
+        <source>NETSDK1048: 'AdditionalProbingPaths' were specified for GenerateRuntimeConfigurationFiles, but are being skipped because 'RuntimeConfigDevPath' is empty.</source>
+        <target state="needs-review-translation">Для "GenerateRuntimeConfigurationFiles" были указаны "AdditionalProbingPaths", но они пропускаются, так как свойство "RuntimeConfigDevPath" пусто.</target>
+        <note>{StrBegin="NETSDK1048: "}</note>
+      </trans-unit>
+      <trans-unit id="GetDependsOnNETStandardFailedWithException">
+        <source>NETSDK1049: Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0} {1}</source>
+        <target state="needs-review-translation">Найденный файл имеет неправильный образ, не имеет метаданных или недоступен по другим причинам. {0} {1}</target>
+        <note>{StrBegin="NETSDK1049: "}</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedSDKVersionForNetStandard20">
+        <source>NETSDK1050: The version of Microsoft.NET.Sdk used by this project is insufficient to support references to libraries targeting .NET Standard 1.5 or higher.  Please install version 2.0 or higher of the .NET Core SDK.</source>
+        <target state="needs-review-translation">Используемая этим проектом версия SDK-пакета Microsoft .NET не поддерживает ссылки на библиотеки для .NET Standard 1.5 или более поздних версий. Установите SDK-пакет .NET Core как минимум версии 2.0.</target>
+        <note>{StrBegin="NETSDK1050: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotHaveRuntimeIdentifierPlatformMismatchPlatformTarget">
+        <source>NETSDK1032: The RuntimeIdentifier platform '{0}' and the PlatformTarget '{1}' must be compatible.</source>
+        <target state="needs-review-translation">Платформа RuntimeIdentifier "{0}" и PlatformTarget "{1}" должны быть совместимы.</target>
+        <note>{StrBegin="NETSDK1032: "}</note>
+      </trans-unit>
+      <trans-unit id="ErrorParsingFrameworkListInvalidValue">
+        <source>NETSDK1051: Error parsing FrameworkList from '{0}'.  {1} '{2}' was invalid.</source>
+        <target state="needs-review-translation">Ошибка анализа FrameworkList со строки "{0}". Недопустимо использовать {1} "{2}".</target>
+        <note>{StrBegin="NETSDK1051: "}</note>
+      </trans-unit>
+      <trans-unit id="FrameworkListPathNotRooted">
+        <source>NETSDK1052: Framework list file path '{0}' is not rooted. Only full paths are supported.</source>
+        <target state="needs-review-translation">Путь к файлу списка платформ "{0}" должен содержать корневой каталог. Поддерживаются только полные пути.</target>
+        <note>{StrBegin="NETSDK1052: "}</note>
+      </trans-unit>
+      <trans-unit id="PackAsToolCannotSupportSelfContained">
+        <source>NETSDK1053: Pack as tool does not support self contained.</source>
+        <target state="needs-review-translation">Упаковка в качестве инструмента не поддерживает автономное использование.</target>
+        <note>{StrBegin="NETSDK1001: "}</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedRuntimeIdentifier">
+        <source>NETSDK1056: Project is targeting runtime '{0}' but did not resolve any runtime-specific packages. This runtime may not be supported by the target framework.</source>
+        <target state="needs-review-translation">Проект предназначен для среды выполнения "{0}", но не разрешил никакие пакеты среды выполнения. Возможно, целевая платформа не поддерживает эту среду выполнения.</target>
+        <note>{StrBegin="NETSDK1056: "}</note>
+      </trans-unit>
+      <trans-unit id="UsingPreviewSdkWarning">
+        <source>NETSDK1057: You are working with a preview version of the .NET Core SDK. You can define the SDK version via a global.json file in the current project. More at https://go.microsoft.com/fwlink/?linkid=869452</source>
+        <target state="needs-review-translation">Вы работаете с предварительной версией пакета SDK для .NET Core. Задать версию SDK можно в файле global.json текущего проекта. Дополнительные сведения: https://go.microsoft.com/fwlink/?linkid=869452</target>
+        <note>{StrBegin="NETSDK1057: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidItemSpecToUse">
+        <source>NETSDK1058: Invalid value for ItemSpecToUse parameter: '{0}'.  This property must be blank or set to 'Left' or 'Right'</source>
+        <target state="needs-review-translation">Недопустимое значение для параметра ItemSpecToUse: "{0}". Это свойство должно быть пустым либо иметь значение "Left" или "Right"</target>
+        <note>{StrBegin="NETSDK1058: "}
+The following are names of parameters or literal values and should not be translated: ItemSpecToUse, Left, Right</note>
+      </trans-unit>
+      <trans-unit id="ProjectContainsObsoleteDotNetCliTool">
+        <source>NETSDK1059: The tool '{0}' is now included in the .NET Core SDK. Information on resolving this warning is available at (https://aka.ms/dotnetclitools-in-box).</source>
+        <target state="needs-review-translation">Использование DotNetCliToolReference для ссылки на "{0}" является устаревшим подходом, поэтому его можно удалить из этого проекта. Это средство по умолчанию входит в состав пакета SDK для .NET Core.</target>
+        <note>{StrBegin="NETSDK1059: "}</note>
+      </trans-unit>
+      <trans-unit id="ErrorReadingAssetsFile">
+        <source>NETSDK1060: Error reading assets file: {0}</source>
+        <target state="needs-review-translation">Ошибка при чтении файла ресурсов: "{0}"</target>
+        <note>{StrBegin="NETSDK1060: "}</note>
+      </trans-unit>
+      <trans-unit id="MismatchedPlatformPackageVersion">
+        <source>NETSDK1061: The project was restored using {0} version {1}, but with current settings, version {2} would be used instead. To resolve this issue, make sure the same settings are used for restore and for subsequent operations such as build or publish. Typically this issue can occur if the RuntimeIdentifier property is set during build or publish but not during restore. For more information, see https://aka.ms/dotnet-runtime-patch-selection.</source>
+        <target state="needs-review-translation">Проект был восстановлен с использованием {0} версии {1}, но с текущими параметрами будет использоваться версия {2}. Чтобы устранить эту проблему, убедитесь, что для восстановления и последующих операций, таких как сборка или публикация, используются одинаковые параметры. Обычно эта проблема возникает, если свойство RuntimeIdentifier задается во время сборки или публикации, а не восстановления.</target>
+        <note>{StrBegin="NETSDK1061: "}
+{0} - Package Identifier for platform package
+{1} - Restored version of platform package
+{2} - Current version of platform package</note>
+      </trans-unit>
+      <trans-unit id="AssetsFileNotSet">
+        <source>NETSDK1063: The path to the project assets file was not set. Run a NuGet package restore to generate this file.</source>
+        <target state="needs-review-translation">Не задан путь к файлу ресурсов проекта. Запустите восстановление пакета NuGet, чтобы создать этот файл.</target>
+        <note>{StrBegin="NETSDK1063: "}</note>
+      </trans-unit>
+      <trans-unit id="DotnetToolOnlySupportNetcoreapp">
+        <source>NETSDK1054: only supports .NET Core.</source>
+        <target state="needs-review-translation">поддерживает только .NET Core.</target>
+        <note>{StrBegin="NETSDK1054: "}</note>
+      </trans-unit>
+      <trans-unit id="DotnetToolDoesNotSupportTFMLowerThanNetcoreapp21">
+        <source>NETSDK1055: DotnetTool does not support target framework lower than netcoreapp2.1.</source>
+        <target state="needs-review-translation">DotnetTool не поддерживает целевые платформы версий ниже netcoreapp2.1.</target>
+        <note>{StrBegin="NETSDK1055: "}</note>
+      </trans-unit>
+      <trans-unit id="UnableToUsePackageAssetsCache">
+        <source>NETSDK1062: Unable to use package assets cache due to I/O error. This can occur when the same project is built more than once in parallel. Performance may be degraded, but the build result will not be impacted.</source>
+        <target state="needs-review-translation">Не удается использовать кэш ресурсов пакета из-за ошибки ввода-вывода. Это может происходить при нескольких параллельных сборках одного проекта. Работа может быть замедлена, но результат сборки не изменится.</target>
+        <note>{StrBegin="NETSDK1062: "}</note>
       </trans-unit>
       <trans-unit id="PackageNotFound">
         <source>NETSDK1064: Package {0}, version {1} was not found. It might have been deleted since NuGet restore. Otherwise, NuGet restore might have only partially completed, which might have been due to maximum path length restrictions.</source>
         <target state="new">NETSDK1064: Package {0}, version {1} was not found. It might have been deleted since NuGet restore. Otherwise, NuGet restore might have only partially completed, which might have been due to maximum path length restrictions.</target>
         <note>{StrBegin="NETSDK1064: "}</note>
       </trans-unit>
-      <trans-unit id="PackageReferenceOverrideWarning">
-        <source>NETSDK1023: A PackageReference for '{0}' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see {1}</source>
-        <target state="new">NETSDK1023: A PackageReference for '{0}' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see {1}</target>
-        <note>{StrBegin="NETSDK1023: "}</note>
-      </trans-unit>
-      <trans-unit id="ParsingFiles">
-        <source>NETSDK1026: Parsing the Files : '{0}'</source>
-        <target state="new">NETSDK1026: Parsing the Files : '{0}'</target>
-        <note>{StrBegin="NETSDK1026: "}</note>
-      </trans-unit>
-      <trans-unit id="ProjectAssetsConsumedWithoutMSBuildProjectPath">
-        <source>NETSDK1011: Assets are consumed from project '{0}', but no corresponding MSBuild project path was  found in '{1}'.</source>
-        <target state="new">NETSDK1011: Assets are consumed from project '{0}', but no corresponding MSBuild project path was  found in '{1}'.</target>
-        <note>{StrBegin="NETSDK1011: "}</note>
-      </trans-unit>
-      <trans-unit id="ProjectContainsObsoleteDotNetCliTool">
-        <source>NETSDK1059: The tool '{0}' is now included in the .NET Core SDK. Information on resolving this warning is available at (https://aka.ms/dotnetclitools-in-box).</source>
-        <target state="new">NETSDK1059: The tool '{0}' is now included in the .NET Core SDK. Information on resolving this warning is available at (https://aka.ms/dotnetclitools-in-box).</target>
-        <note>{StrBegin="NETSDK1059: "}</note>
-      </trans-unit>
-      <trans-unit id="RecommendRuntimeFrameworkNameForAspNetCorePackages">
-        <source>NETSDK1071: A PackageReference for '{0}' was included in your project. This package can be implicitly defined by the SDK. To resolve this warning, remove this PackageReference and set the RuntimeFrameworkName property to {1}. For more information, see {2}.</source>
-        <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. This package can be implicitly defined by the SDK. To resolve this warning, remove this PackageReference and set the RuntimeFrameworkName property to {1}. For more information, see {2}.</target>
-        <note>{StrBegin="NETSDK1071: "}
-{0} - Package Id (Microsoft.AspNetCore.App or .All)
-{1} - Project name
-{2} - More info link
-    </note>
-      </trans-unit>
-      <trans-unit id="RuntimeIdentifierWasNotSpecified">
-        <source>NETSDK1028: Specify a RuntimeIdentifier</source>
-        <target state="new">NETSDK1028: Specify a RuntimeIdentifier</target>
-        <note>{StrBegin="NETSDK1028: "}</note>
-      </trans-unit>
-      <trans-unit id="SkippingAdditionalProbingPaths">
-        <source>NETSDK1048: 'AdditionalProbingPaths' were specified for GenerateRuntimeConfigurationFiles, but are being skipped because 'RuntimeConfigDevPath' is empty.</source>
-        <target state="new">NETSDK1048: 'AdditionalProbingPaths' were specified for GenerateRuntimeConfigurationFiles, but are being skipped because 'RuntimeConfigDevPath' is empty.</target>
-        <note>{StrBegin="NETSDK1048: "}</note>
-      </trans-unit>
-      <trans-unit id="TargetFrameworkWithSemicolon">
-        <source>NETSDK1046: The TargetFramework value '{0}' is not valid. To multi-target, use the 'TargetFrameworks' property instead.</source>
-        <target state="new">NETSDK1046: The TargetFramework value '{0}' is not valid. To multi-target, use the 'TargetFrameworks' property instead.</target>
-        <note>{StrBegin="NETSDK1046: "}</note>
-      </trans-unit>
-      <trans-unit id="UnableToFindResolvedPath">
-        <source>NETSDK1016: Unable to find resolved path for '{0}'.</source>
-        <target state="new">NETSDK1016: Unable to find resolved path for '{0}'.</target>
-        <note>{StrBegin="NETSDK1016: "}</note>
-      </trans-unit>
-      <trans-unit id="UnableToUsePackageAssetsCache">
-        <source>NETSDK1062: Unable to use package assets cache due to I/O error. This can occur when the same project is built more than once in parallel. Performance may be degraded, but the build result will not be impacted.</source>
-        <target state="new">NETSDK1062: Unable to use package assets cache due to I/O error. This can occur when the same project is built more than once in parallel. Performance may be degraded, but the build result will not be impacted.</target>
-        <note>{StrBegin="NETSDK1062: "}</note>
-      </trans-unit>
-      <trans-unit id="UnexpectedFileType">
-        <source>NETSDK1012: Unexpected file type for '{0}'. Type is both '{1}' and '{2}'.</source>
-        <target state="new">NETSDK1012: Unexpected file type for '{0}'. Type is both '{1}' and '{2}'.</target>
-        <note>{StrBegin="NETSDK1012: "}</note>
-      </trans-unit>
-      <trans-unit id="UnrecognizedPreprocessorToken">
-        <source>NETSDK1009: Unrecognized preprocessor token '{0}' in '{1}'.</source>
-        <target state="new">NETSDK1009: Unrecognized preprocessor token '{0}' in '{1}'.</target>
-        <note>{StrBegin="NETSDK1009: "}</note>
-      </trans-unit>
-      <trans-unit id="UnrecognizedRuntimeFrameworkName">
-        <source>NETSDK1070: This project uses an unsupported value for RuntimeFrameworkName. Currently, only valid values are: Microsoft.NETCore.App, Microsoft.AspNetCore.App, or Microsoft.AspNetCore.All.</source>
-        <target state="new">NETSDK1070: This project uses an unsupported value for RuntimeFrameworkName. Currently, only valid values are: Microsoft.NETCore.App, Microsoft.AspNetCore.App, or Microsoft.AspNetCore.All.</target>
-        <note>{StrBegin="NETSDK1070: "}</note>
-      </trans-unit>
-      <trans-unit id="UnsupportedFramework">
-        <source>NETSDK1019: {0} is an unsupported framework.</source>
-        <target state="new">NETSDK1019: {0} is an unsupported framework.</target>
-        <note>{StrBegin="NETSDK1019: "}</note>
-      </trans-unit>
-      <trans-unit id="UnsupportedRuntimeIdentifier">
-        <source>NETSDK1056: Project is targeting runtime '{0}' but did not resolve any runtime-specific packages. This runtime may not be supported by the target framework.</source>
-        <target state="new">NETSDK1056: Project is targeting runtime '{0}' but did not resolve any runtime-specific packages. This runtime may not be supported by the target framework.</target>
-        <note>{StrBegin="NETSDK1056: "}</note>
-      </trans-unit>
-      <trans-unit id="UnsupportedSDKVersionForNetStandard20">
-        <source>NETSDK1050: The version of Microsoft.NET.Sdk used by this project is insufficient to support references to libraries targeting .NET Standard 1.5 or higher.  Please install version 2.0 or higher of the .NET Core SDK.</source>
-        <target state="new">NETSDK1050: The version of Microsoft.NET.Sdk used by this project is insufficient to support references to libraries targeting .NET Standard 1.5 or higher.  Please install version 2.0 or higher of the .NET Core SDK.</target>
-        <note>{StrBegin="NETSDK1050: "}</note>
-      </trans-unit>
-      <trans-unit id="UnsupportedTargetFrameworkVersion">
-        <source>NETSDK1045: The current .NET SDK does not support targeting {0} {1}.  Either target {0} {2} or lower, or use a version of the .NET SDK that supports {0} {1}.</source>
-        <target state="new">NETSDK1045: The current .NET SDK does not support targeting {0} {1}.  Either target {0} {2} or lower, or use a version of the .NET SDK that supports {0} {1}.</target>
-        <note>{StrBegin="NETSDK1045: "}</note>
-      </trans-unit>
-      <trans-unit id="UsingPreviewSdkWarning">
-        <source>NETSDK1057: You are working with a preview version of the .NET Core SDK. You can define the SDK version via a global.json file in the current project. More at https://go.microsoft.com/fwlink/?linkid=869452</source>
-        <target state="new">NETSDK1057: You are working with a preview version of the .NET Core SDK. You can define the SDK version via a global.json file in the current project. More at https://go.microsoft.com/fwlink/?linkid=869452</target>
-        <note>{StrBegin="NETSDK1057: "}</note>
+      <trans-unit id="CannotFindApphostForRid">
+        <source>NETSDK1065: Cannot find app host for {0}. {0} could be an invalid runtime identifier (RID). For more information about RID, see https://aka.ms/rid-catalog.</source>
+        <target state="new">NETSDK1065: Cannot find app host for {0}. {0} could be an invalid runtime identifier (RID). For more information about RID, see https://aka.ms/rid-catalog.</target>
+        <note>{StrBegin="NETSDK1065: "}</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
@@ -62,15 +62,6 @@
         <target state="needs-review-translation">'{1}' öğesi '{2}' üzerinde '{0}' meta verileri eksik.</target>
         <note>{StrBegin="NETSDK1008: "}</note>
       </trans-unit>
-      <trans-unit id="RecommendRuntimeFrameworkNameForAspNetCorePackages">
-        <source>NETSDK1071: A PackageReference for '{0}' was included in your project. This package can be implicitly defined by the SDK. To resolve this warning, remove this PackageReference and set the RuntimeFrameworkName property to {1}. For more information, see {2}.</source>
-        <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. This package can be implicitly defined by the SDK. To resolve this warning, remove this PackageReference and set the RuntimeFrameworkName property to {1}. For more information, see {2}.</target>
-        <note>{StrBegin="NETSDK1071: "}
-{0} - Package Id (Microsoft.AspNetCore.App or .All)
-{1} - Project name
-{2} - More info link
-    </note>
-      </trans-unit>
       <trans-unit id="UnrecognizedPreprocessorToken">
         <source>NETSDK1009: Unrecognized preprocessor token '{0}' in '{1}'.</source>
         <target state="needs-review-translation">'{1}' içinde tanınmayan ön işlemci belirteci: '{0}'.</target>
@@ -120,11 +111,6 @@
         <source>NETSDK1018: Invalid NuGet version string: '{0}'.</source>
         <target state="needs-review-translation">Geçersiz NuGet sürüm dizesi: '{0}'.</target>
         <note>{StrBegin="NETSDK1018: "}</note>
-      </trans-unit>
-      <trans-unit id="UnrecognizedRuntimeFrameworkName">
-        <source>NETSDK1070: This project uses an unsupported value for RuntimeFrameworkName. Currently, only valid values are: Microsoft.NETCore.App, Microsoft.AspNetCore.App, or Microsoft.AspNetCore.All.</source>
-        <target state="new">NETSDK1070: This project uses an unsupported value for RuntimeFrameworkName. Currently, only valid values are: Microsoft.NETCore.App, Microsoft.AspNetCore.App, or Microsoft.AspNetCore.All.</target>
-        <note>{StrBegin="NETSDK1070: "}</note>
       </trans-unit>
       <trans-unit id="UnsupportedFramework">
         <source>NETSDK1019: {0} is an unsupported framework.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
@@ -62,6 +62,15 @@
         <target state="needs-review-translation">'{1}' öğesi '{2}' üzerinde '{0}' meta verileri eksik.</target>
         <note>{StrBegin="NETSDK1008: "}</note>
       </trans-unit>
+      <trans-unit id="RecommendRuntimeFrameworkNameForAspNetCorePackages">
+        <source>NETSDK1071: A PackageReference for '{0}' was included in your project. This package can be implicitly defined by the SDK. To resolve this warning, remove this PackageReference and set the RuntimeFrameworkName property to {1}. For more information, see {2}.</source>
+        <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. This package can be implicitly defined by the SDK. To resolve this warning, remove this PackageReference and set the RuntimeFrameworkName property to {1}. For more information, see {2}.</target>
+        <note>{StrBegin="NETSDK1071: "}
+{0} - Package Id (Microsoft.AspNetCore.App or .All)
+{1} - Project name
+{2} - More info link
+    </note>
+      </trans-unit>
       <trans-unit id="UnrecognizedPreprocessorToken">
         <source>NETSDK1009: Unrecognized preprocessor token '{0}' in '{1}'.</source>
         <target state="needs-review-translation">'{1}' içinde tanınmayan ön işlemci belirteci: '{0}'.</target>
@@ -111,6 +120,11 @@
         <source>NETSDK1018: Invalid NuGet version string: '{0}'.</source>
         <target state="needs-review-translation">Geçersiz NuGet sürüm dizesi: '{0}'.</target>
         <note>{StrBegin="NETSDK1018: "}</note>
+      </trans-unit>
+      <trans-unit id="UnrecognizedRuntimeFrameworkName">
+        <source>NETSDK1070: This project uses an unsupported value for RuntimeFrameworkName. Currently, only valid values are: Microsoft.NETCore.App, Microsoft.AspNetCore.App, or Microsoft.AspNetCore.All.</source>
+        <target state="new">NETSDK1070: This project uses an unsupported value for RuntimeFrameworkName. Currently, only valid values are: Microsoft.NETCore.App, Microsoft.AspNetCore.App, or Microsoft.AspNetCore.All.</target>
+        <note>{StrBegin="NETSDK1070: "}</note>
       </trans-unit>
       <trans-unit id="UnsupportedFramework">
         <source>NETSDK1019: {0} is an unsupported framework.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
@@ -62,15 +62,6 @@
         <target state="needs-review-translation">在“{1}”项“{2}”上缺少“{0}”元数据。</target>
         <note>{StrBegin="NETSDK1008: "}</note>
       </trans-unit>
-      <trans-unit id="RecommendRuntimeFrameworkNameForAspNetCorePackages">
-        <source>NETSDK1071: A PackageReference for '{0}' was included in your project. This package can be implicitly defined by the SDK. To resolve this warning, remove this PackageReference and set the RuntimeFrameworkName property to {1}. For more information, see {2}.</source>
-        <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. This package can be implicitly defined by the SDK. To resolve this warning, remove this PackageReference and set the RuntimeFrameworkName property to {1}. For more information, see {2}.</target>
-        <note>{StrBegin="NETSDK1071: "}
-{0} - Package Id (Microsoft.AspNetCore.App or .All)
-{1} - Project name
-{2} - More info link
-    </note>
-      </trans-unit>
       <trans-unit id="UnrecognizedPreprocessorToken">
         <source>NETSDK1009: Unrecognized preprocessor token '{0}' in '{1}'.</source>
         <target state="needs-review-translation">“{1}”中无法识别预处理器标记“{0}”。</target>
@@ -120,11 +111,6 @@
         <source>NETSDK1018: Invalid NuGet version string: '{0}'.</source>
         <target state="needs-review-translation">无效的 NuGet 版本字符串:“{0}”。</target>
         <note>{StrBegin="NETSDK1018: "}</note>
-      </trans-unit>
-      <trans-unit id="UnrecognizedRuntimeFrameworkName">
-        <source>NETSDK1070: This project uses an unsupported value for RuntimeFrameworkName. Currently, only valid values are: Microsoft.NETCore.App, Microsoft.AspNetCore.App, or Microsoft.AspNetCore.All.</source>
-        <target state="new">NETSDK1070: This project uses an unsupported value for RuntimeFrameworkName. Currently, only valid values are: Microsoft.NETCore.App, Microsoft.AspNetCore.App, or Microsoft.AspNetCore.All.</target>
-        <note>{StrBegin="NETSDK1070: "}</note>
       </trans-unit>
       <trans-unit id="UnsupportedFramework">
         <source>NETSDK1019: {0} is an unsupported framework.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
@@ -62,6 +62,15 @@
         <target state="needs-review-translation">在“{1}”项“{2}”上缺少“{0}”元数据。</target>
         <note>{StrBegin="NETSDK1008: "}</note>
       </trans-unit>
+      <trans-unit id="RecommendRuntimeFrameworkNameForAspNetCorePackages">
+        <source>NETSDK1071: A PackageReference for '{0}' was included in your project. This package can be implicitly defined by the SDK. To resolve this warning, remove this PackageReference and set the RuntimeFrameworkName property to {1}. For more information, see {2}.</source>
+        <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. This package can be implicitly defined by the SDK. To resolve this warning, remove this PackageReference and set the RuntimeFrameworkName property to {1}. For more information, see {2}.</target>
+        <note>{StrBegin="NETSDK1071: "}
+{0} - Package Id (Microsoft.AspNetCore.App or .All)
+{1} - Project name
+{2} - More info link
+    </note>
+      </trans-unit>
       <trans-unit id="UnrecognizedPreprocessorToken">
         <source>NETSDK1009: Unrecognized preprocessor token '{0}' in '{1}'.</source>
         <target state="needs-review-translation">“{1}”中无法识别预处理器标记“{0}”。</target>
@@ -111,6 +120,11 @@
         <source>NETSDK1018: Invalid NuGet version string: '{0}'.</source>
         <target state="needs-review-translation">无效的 NuGet 版本字符串:“{0}”。</target>
         <note>{StrBegin="NETSDK1018: "}</note>
+      </trans-unit>
+      <trans-unit id="UnrecognizedRuntimeFrameworkName">
+        <source>NETSDK1070: This project uses an unsupported value for RuntimeFrameworkName. Currently, only valid values are: Microsoft.NETCore.App, Microsoft.AspNetCore.App, or Microsoft.AspNetCore.All.</source>
+        <target state="new">NETSDK1070: This project uses an unsupported value for RuntimeFrameworkName. Currently, only valid values are: Microsoft.NETCore.App, Microsoft.AspNetCore.App, or Microsoft.AspNetCore.All.</target>
+        <note>{StrBegin="NETSDK1070: "}</note>
       </trans-unit>
       <trans-unit id="UnsupportedFramework">
         <source>NETSDK1019: {0} is an unsupported framework.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
@@ -62,15 +62,6 @@
         <target state="needs-review-translation">'{1}' 項目 '{2}' 上遺漏 '{0}' 中繼資料。</target>
         <note>{StrBegin="NETSDK1008: "}</note>
       </trans-unit>
-      <trans-unit id="RecommendRuntimeFrameworkNameForAspNetCorePackages">
-        <source>NETSDK1071: A PackageReference for '{0}' was included in your project. This package can be implicitly defined by the SDK. To resolve this warning, remove this PackageReference and set the RuntimeFrameworkName property to {1}. For more information, see {2}.</source>
-        <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. This package can be implicitly defined by the SDK. To resolve this warning, remove this PackageReference and set the RuntimeFrameworkName property to {1}. For more information, see {2}.</target>
-        <note>{StrBegin="NETSDK1071: "}
-{0} - Package Id (Microsoft.AspNetCore.App or .All)
-{1} - Project name
-{2} - More info link
-    </note>
-      </trans-unit>
       <trans-unit id="UnrecognizedPreprocessorToken">
         <source>NETSDK1009: Unrecognized preprocessor token '{0}' in '{1}'.</source>
         <target state="needs-review-translation">'{1}' 中的前置處理器語彙基元 '{0}' 無法辨識。</target>
@@ -240,11 +231,6 @@
         <source>NETSDK1044: Error parsing PlatformManifest from '{0}' line {1}.  {2} '{3}' was invalid.</source>
         <target state="needs-review-translation">從 '{0}' 行 {1} 剖析 PlatformManifest 時發生錯誤。{2} '{3}' 無效。</target>
         <note>{StrBegin="NETSDK1044: "}</note>
-      </trans-unit>
-      <trans-unit id="UnrecognizedRuntimeFrameworkName">
-        <source>NETSDK1070: This project uses an unsupported value for RuntimeFrameworkName. Currently, only valid values are: Microsoft.NETCore.App, Microsoft.AspNetCore.App, or Microsoft.AspNetCore.All.</source>
-        <target state="new">NETSDK1070: This project uses an unsupported value for RuntimeFrameworkName. Currently, only valid values are: Microsoft.NETCore.App, Microsoft.AspNetCore.App, or Microsoft.AspNetCore.All.</target>
-        <note>{StrBegin="NETSDK1070: "}</note>
       </trans-unit>
       <trans-unit id="UnsupportedFramework">
         <source>NETSDK1019: {0} is an unsupported framework.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
@@ -62,6 +62,15 @@
         <target state="needs-review-translation">'{1}' 項目 '{2}' 上遺漏 '{0}' 中繼資料。</target>
         <note>{StrBegin="NETSDK1008: "}</note>
       </trans-unit>
+      <trans-unit id="RecommendRuntimeFrameworkNameForAspNetCorePackages">
+        <source>NETSDK1071: A PackageReference for '{0}' was included in your project. This package can be implicitly defined by the SDK. To resolve this warning, remove this PackageReference and set the RuntimeFrameworkName property to {1}. For more information, see {2}.</source>
+        <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. This package can be implicitly defined by the SDK. To resolve this warning, remove this PackageReference and set the RuntimeFrameworkName property to {1}. For more information, see {2}.</target>
+        <note>{StrBegin="NETSDK1071: "}
+{0} - Package Id (Microsoft.AspNetCore.App or .All)
+{1} - Project name
+{2} - More info link
+    </note>
+      </trans-unit>
       <trans-unit id="UnrecognizedPreprocessorToken">
         <source>NETSDK1009: Unrecognized preprocessor token '{0}' in '{1}'.</source>
         <target state="needs-review-translation">'{1}' 中的前置處理器語彙基元 '{0}' 無法辨識。</target>
@@ -231,6 +240,11 @@
         <source>NETSDK1044: Error parsing PlatformManifest from '{0}' line {1}.  {2} '{3}' was invalid.</source>
         <target state="needs-review-translation">從 '{0}' 行 {1} 剖析 PlatformManifest 時發生錯誤。{2} '{3}' 無效。</target>
         <note>{StrBegin="NETSDK1044: "}</note>
+      </trans-unit>
+      <trans-unit id="UnrecognizedRuntimeFrameworkName">
+        <source>NETSDK1070: This project uses an unsupported value for RuntimeFrameworkName. Currently, only valid values are: Microsoft.NETCore.App, Microsoft.AspNetCore.App, or Microsoft.AspNetCore.All.</source>
+        <target state="new">NETSDK1070: This project uses an unsupported value for RuntimeFrameworkName. Currently, only valid values are: Microsoft.NETCore.App, Microsoft.AspNetCore.App, or Microsoft.AspNetCore.All.</target>
+        <note>{StrBegin="NETSDK1070: "}</note>
       </trans-unit>
       <trans-unit id="UnsupportedFramework">
         <source>NETSDK1019: {0} is an unsupported framework.</source>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.props
@@ -46,6 +46,17 @@ Copyright (c) .NET Foundation. All rights reserved.
   </ItemGroup>
 
   <ItemGroup Condition=" '$(DisableImplicitFrameworkReferences)' != 'true' and '$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
+    <PackageReference Include="$(RuntimeFrameworkName)" Condition=" '$(RuntimeFrameworkName)' != 'Microsoft.NETCore.App' ">
+      <Version>$(RuntimeFrameworkVersion)</Version>
+      <IsImplicitlyDefined>true</IsImplicitlyDefined>
+      <Publish>true</Publish>
+      <!--
+        By default, do not include the runtime framework package in the generated .nuspec when packing the project.
+        The exception is for DotNetCliTool projects, which need the runtime package listed as a dependency.
+      -->
+      <PrivateAssets Condition=" '$(PackageType)' != 'DotNetCliTool' ">All</PrivateAssets>
+    </PackageReference>
+
     <PackageReference Include="Microsoft.NETCore.App" Version="$(RuntimeFrameworkVersion)" IsImplicitlyDefined="true" />
 
     <!-- For libraries targeting .NET Core 2.0 or higher, don't include a dependency on Microsoft.NETCore.App in the package produced by pack.

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.targets
@@ -73,7 +73,14 @@ Copyright (c) .NET Foundation. All rights reserved.
     
     The TargetLatestRuntimePatch property can be set to true or false to explicitly opt in or out of the logic to roll forward
     to the latest patch, regardless of whether the app is self-contained or framework-dependent.
-    
+
+    The RuntimeFrameworkName is the package name of the .NET Core runtime to target. Shared runtimes are installed into the DOTNET_ROOT
+    directory under shared/$(RuntimeFrameworkName)/$(RuntimeFrameworkVersion)/. The runtimeconfig.json generated in the application
+    contains both the framework name and version which should be used.
+
+    This property is different than MicrosoftNETPlatformLibrary. MicrosoftNETPlatformLibrary is used to trim the dependencies
+    published with a framework-dependent app, and can be controlled independently of the default implicit package reference.
+
     The RuntimeFrameworkVersion is where the actual version of the .NET Core runtime to target is stored.  It is the version that is
     used in the implicit PackageReference to Microsoft.NETCore.App.  The RuntimeFrameworkVersion can also be set explicitly, which
     will disable all the other logic that automatically selects the version of .NET Core to target.
@@ -133,10 +140,106 @@ Copyright (c) .NET Foundation. All rights reserved.
     <TargetLatestRuntimePatch Condition="'$(SelfContained)' != 'true' ">false</TargetLatestRuntimePatch>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(RuntimeFrameworkVersion)' == ''">
-    <RuntimeFrameworkVersion Condition="'$(TargetLatestRuntimePatch)' == 'true' ">$(LatestNetCorePatchVersion)</RuntimeFrameworkVersion>
-    <RuntimeFrameworkVersion Condition="'$(TargetLatestRuntimePatch)' != 'true' ">$(DefaultNetCorePatchVersion)</RuntimeFrameworkVersion>
+  <!-- Determine the default values of TargetLatestAspNetCoreRuntimePatch -->
+  <PropertyGroup Condition="'$(TargetLatestAspNetCoreRuntimePatch)' == ''">
+    <TargetLatestAspNetCoreRuntimePatch>$(TargetLatestRuntimePatch)</TargetLatestAspNetCoreRuntimePatch>
   </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(RuntimeFrameworkName)' == ''">
+    <RuntimeFrameworkName>Microsoft.NETCore.App</RuntimeFrameworkName>
+  </PropertyGroup>
+
+  <!--
+    Determine the value of RuntimeFrameworkVersion.
+
+    It is expected that the Microsoft.AspNetCore.App/All and Microsoft.NETCore.App will always ship together with the same version numbers for 2.1 and 2.2.
+    Therefore, this uses the same property fro both implicit package references.
+  -->
+  <Choose>
+    <When Condition=" '$(RuntimeFrameworkName)' == 'Microsoft.AspNetCore.All' " >
+      <PropertyGroup>
+        <!-- These properties will allow the latest patch versions to be set in the CLI (via BundledVersions.props) or overridden by tests -->
+        <DefaultPatchVersionForAspNetCoreAll2_1 Condition="'$(DefaultPatchVersionForAspNetCoreAll2_1)' == ''">2.1.1</DefaultPatchVersionForAspNetCoreAll2_1>
+      </PropertyGroup>
+
+      <!-- Default patch version of .All Framework -->
+      <PropertyGroup Condition="'$(DefaultAspNetCoreAllPatchVersion)' == ''">
+        <DefaultAspNetCoreAllPatchVersion Condition="'$(_TargetFrameworkVersionWithoutV)' == '2.1'">$(DefaultPatchVersionForAspNetCoreAll2_1)</DefaultAspNetCoreAllPatchVersion>
+
+        <!-- If targeting the same pre-release that is bundled with the .NET Core SDK, use the bundled package version
+            provided by Microsoft.NETCoreSdk.BundledVersions.props -->
+        <DefaultAspNetCoreAllPatchVersion Condition="'$(DefaultAspNetCoreAllPatchVersion)' == '' AND '$(_TargetFrameworkVersionWithoutV)' == '$(BundledAspNetCoreAllTargetFrameworkVersion)'">$(BundledAspNetCoreAllPackageVersion)</DefaultAspNetCoreAllPatchVersion>
+        <!-- If not covered by the previous cases use the target framework version for the default patch version -->
+        <DefaultAspNetCoreAllPatchVersion Condition="'$(DefaultAspNetCoreAllPatchVersion)' == ''">$(_TargetFrameworkVersionWithoutV)</DefaultAspNetCoreAllPatchVersion>
+      </PropertyGroup>
+
+      <!-- Latest patch version of .All Framework -->
+      <PropertyGroup Condition="'$(LatestAspNetCoreAllPatchVersion)' == ''">
+        <!-- If LatestPatchVersionForAspNetCoreAll2_1 is explicitly set, use this for netcoreapp2.1 projects. -->
+        <LatestAspNetCoreAllPatchVersion Condition="'$(_TargetFrameworkVersionWithoutV)' == '2.1'">$(LatestPatchVersionForAspNetCoreAll2_1)</LatestAspNetCoreAllPatchVersion>
+
+        <!-- If targeting the same release that is bundled with the .NET Core SDK, use the bundled package version
+            provided by Microsoft.NETCoreSdk.BundledVersions.props -->
+        <LatestAspNetCoreAllPatchVersion Condition="'$(LatestAspNetCoreAllPatchVersion)' == '' AND '$(_TargetFrameworkVersionWithoutV)' == '$(BundledAspNetCoreAllTargetFrameworkVersion)'">$(BundledAspNetCoreAllPackageVersion)</LatestAspNetCoreAllPatchVersion>
+        <!-- If not covered by the previous cases use the target framework version for the latest patch version -->
+        <LatestAspNetCoreAllPatchVersion Condition="'$(LatestAspNetCoreAllPatchVersion)' == ''">$(_TargetFrameworkVersionWithoutV)</LatestAspNetCoreAllPatchVersion>
+      </PropertyGroup>
+
+      <PropertyGroup Condition=" '$(RuntimeFrameworkVersion)' == '' ">
+        <RuntimeFrameworkVersion Condition="'$(TargetLatestAspNetCoreRuntimePatch)' != 'true'">$(DefaultAspNetCoreAllPatchVersion)</RuntimeFrameworkVersion>
+        <RuntimeFrameworkVersion Condition="'$(TargetLatestAspNetCoreRuntimePatch)' == 'true'">$(LatestAspNetCoreAllPatchVersion)</RuntimeFrameworkVersion>
+      </PropertyGroup>
+    </When>
+
+    <When Condition="'$(RuntimeFrameworkName)' == 'Microsoft.AspNetCore.App'" >
+      <PropertyGroup>
+        <!-- These properties will allow the latest patch versions to be set in the CLI (via BundledVersions.props) or overridden by tests -->
+        <DefaultPatchVersionForAspNetCoreApp2_1 Condition="'$(DefaultPatchVersionForAspNetCoreApp2_1)' == ''">2.1.1</DefaultPatchVersionForAspNetCoreApp2_1>
+      </PropertyGroup>
+
+      <!-- Default patch version of .App Framework -->
+      <PropertyGroup Condition="'$(DefaultAspNetCoreAppPatchVersion)' == ''">
+        <DefaultAspNetCoreAppPatchVersion Condition="'$(_TargetFrameworkVersionWithoutV)' == '2.1'">$(DefaultPatchVersionForAspNetCoreApp2_1)</DefaultAspNetCoreAppPatchVersion>
+
+        <!-- If targeting the same pre-release that is bundled with the .NET Core SDK, use the bundled package version
+            provided by Microsoft.NETCoreSdk.BundledVersions.props -->
+        <DefaultAspNetCoreAppPatchVersion Condition="'$(DefaultAspNetCoreAppPatchVersion)' == '' AND '$(_TargetFrameworkVersionWithoutV)' == '$(BundledAspNetCoreAppTargetFrameworkVersion)'">$(BundledAspNetCoreAppPackageVersion)</DefaultAspNetCoreAppPatchVersion>
+        <!-- If not covered by the previous cases use the target framework version for the default patch version -->
+        <DefaultAspNetCoreAppPatchVersion Condition="'$(DefaultAspNetCoreAppPatchVersion)' == ''">$(_TargetFrameworkVersionWithoutV)</DefaultAspNetCoreAppPatchVersion>
+      </PropertyGroup>
+
+      <!-- Latest patch version of .App Framework -->
+      <PropertyGroup Condition="'$(LatestAspNetCoreAppPatchVersion)' == ''">
+        <!-- If LatestPatchVersionForAspNetCoreApp2_1 is explicitly set, use this for netcoreapp2.1 projects. -->
+        <LatestAspNetCoreAppPatchVersion Condition="'$(_TargetFrameworkVersionWithoutV)' == '2.1'">$(LatestPatchVersionForAspNetCoreApp2_1)</LatestAspNetCoreAppPatchVersion>
+
+        <!-- If targeting the same release that is bundled with the .NET Core SDK, use the bundled package version
+            provided by Microsoft.NETCoreSdk.BundledVersions.props -->
+        <LatestAspNetCoreAppPatchVersion Condition="'$(LatestAspNetCoreAppPatchVersion)' == '' AND '$(_TargetFrameworkVersionWithoutV)' == '$(BundledAspNetCoreAppTargetFrameworkVersion)'">$(BundledAspNetCoreAppPackageVersion)</LatestAspNetCoreAppPatchVersion>
+        <!-- If not covered by the previous cases use the target framework version for the latest patch version -->
+        <LatestAspNetCoreAppPatchVersion Condition="'$(LatestAspNetCoreAppPatchVersion)' == ''">$(_TargetFrameworkVersionWithoutV)</LatestAspNetCoreAppPatchVersion>
+      </PropertyGroup>
+
+      <PropertyGroup Condition=" '$(RuntimeFrameworkVersion)' == '' ">
+        <RuntimeFrameworkVersion Condition="'$(TargetLatestAspNetCoreRuntimePatch)' != 'true'">$(DefaultAspNetCoreAppPatchVersion)</RuntimeFrameworkVersion>
+        <RuntimeFrameworkVersion Condition="'$(TargetLatestAspNetCoreRuntimePatch)' == 'true'">$(LatestAspNetCoreAppPatchVersion)</RuntimeFrameworkVersion>
+      </PropertyGroup>
+    </When>
+
+    <When Condition=" '$(RuntimeFrameworkName)' == 'Microsoft.NETCore.App' ">
+      <PropertyGroup Condition=" '$(RuntimeFrameworkVersion)' == '' ">
+        <RuntimeFrameworkVersion Condition="'$(TargetLatestRuntimePatch)' == 'true' ">$(LatestNetCorePatchVersion)</RuntimeFrameworkVersion>
+        <RuntimeFrameworkVersion Condition="'$(TargetLatestRuntimePatch)' != 'true' ">$(DefaultNetCorePatchVersion)</RuntimeFrameworkVersion>
+      </PropertyGroup>
+    </When>
+
+    <Otherwise>
+      <PropertyGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETCoreApp' ">
+        <_UnrecognizedRuntimeFrameworkName>true</_UnrecognizedRuntimeFrameworkName>
+      </PropertyGroup>
+    </Otherwise>
+
+  </Choose>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(DisableImplicitFrameworkReferences)' != 'true'">
     <!-- This property is different than MicrosoftNETPlatformLibrary.  MicrosoftNETPlatformLibrary is
@@ -148,6 +251,7 @@ Copyright (c) .NET Foundation. All rights reserved.
          to verify that the restored versions of the packages matches the expected versions
          -->
     <ExpectedPlatformPackages Include="Microsoft.NETCore.App" ExpectedVersion="$(RuntimeFrameworkVersion)" />
+    <ExpectedPlatformPackages Include="$(RuntimeFrameworkName)" ExpectedVersion="$(RuntimeFrameworkVersion)" Condition="'$(RuntimeFrameworkName)' != 'Microsoft.NETCore.App'" />
   </ItemGroup>
 
   <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(DisableImplicitFrameworkReferences)' != 'true'">
@@ -201,6 +305,13 @@ Copyright (c) .NET Foundation. All rights reserved.
     </EmbeddedResource>
   </ItemGroup>
 
+  <!-- Check that RuntimeFrameworkName is something this SDK supports -->
+  <Target Name="CheckForUnrecognizedRuntimeFrameworkName"
+          BeforeTargets="_CheckForInvalidConfigurationAndPlatform;CollectPackageReferences"
+          Condition=" '$(_UnrecognizedRuntimeFrameworkName)' == 'true' ">
+    <NETSdkError ResourceName="UnrecognizedRuntimeFrameworkName" />
+  </Target>
+
   <UsingTask TaskName="CheckForImplicitPackageReferenceOverrides" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
 
   <!-- Remove package references with metadata IsImplicitlyDefined = true, if there are other PackageReference items with the same identity -->
@@ -226,6 +337,14 @@ Copyright (c) .NET Foundation. All rights reserved.
       <VerifyMatchingImplicitPackageVersion>false</VerifyMatchingImplicitPackageVersion>
     </PropertyGroup>
 
+    <ItemGroup Condition="'$(_TargetFrameworkVersionWithoutV)' != '' AND '$(_TargetFrameworkVersionWithoutV)' >= '2.1' ">
+      <_AspNetMetaPackageReference Include="@(PackageReference->WithMetadataValue('Identity', 'Microsoft.AspNetCore.App'))" />
+      <_AspNetMetaPackageReference Include="@(PackageReference->WithMetadataValue('Identity', 'Microsoft.AspNetCore.All'))" />
+    </ItemGroup>
+
+    <NETSdkWarning Condition=" '$(DisableAspNetCoreMetaPackageWarning)' != 'true' AND '%(_AspNetMetaPackageReference.Identity)' != '' AND '%(_AspNetMetaPackageReference.IsImplicitlyDefined)' != 'true' "
+          ResourceName="RecommendRuntimeFrameworkNameForAspNetCorePackages"
+          FormatArguments="%(_AspNetMetaPackageReference.Identity);$(MSBuildProjectFile);$(ImplicitPackageReferenceInformationLink)" />
   </Target>
 
   <UsingTask TaskName="CheckForDuplicateItems" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -509,12 +509,14 @@ Copyright (c) .NET Foundation. All rights reserved.
   .NET Core apps can have shared frameworks that are pre-installed on the target machine, thus the app is "portable"
   to any machine that already has the shared framework installed. In order to enable this, a "platform" library
   has to be declared. The platform library and its dependencies will be excluded from the runtime assemblies.
+  By default, this should match the RuntimeFrameworkName, which users can set to target different runtimes,
+  such as ASP.NET Core.
   ============================================================
   -->
   <Target Name="_DefaultMicrosoftNETPlatformLibrary">
 
     <PropertyGroup Condition="'$(MicrosoftNETPlatformLibrary)' == ''">
-      <MicrosoftNETPlatformLibrary Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">Microsoft.NETCore.App</MicrosoftNETPlatformLibrary>
+      <MicrosoftNETPlatformLibrary>$(RuntimeFrameworkName)</MicrosoftNETPlatformLibrary>
     </PropertyGroup>
 
   </Target>

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToSetRuntimeFrameworkName.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToSetRuntimeFrameworkName.cs
@@ -1,0 +1,181 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using FluentAssertions;
+using Microsoft.DotNet.Cli.Utils;
+using Microsoft.Extensions.DependencyModel;
+using Microsoft.NET.TestFramework;
+using Microsoft.NET.TestFramework.Assertions;
+using Microsoft.NET.TestFramework.Commands;
+using Microsoft.NET.TestFramework.ProjectConstruction;
+using Newtonsoft.Json.Linq;
+using NuGet.Common;
+using NuGet.Frameworks;
+using NuGet.ProjectModel;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Linq;
+using System.Text;
+using System.Xml.Linq;
+using Xunit;
+using Xunit.Abstractions;
+using Microsoft.NET.Build.Tasks;
+using NuGet.Versioning;
+
+namespace Microsoft.NET.Build.Tests
+{
+    public class GivenThatWeWantToSetRuntimeFrameworkName : SdkTest
+    {
+        private const string ConsoleProgramSource = @"
+using System;
+
+public class Program
+{
+    public static void Main(string[] args)
+    {
+        Console.WriteLine(""Hello World!"");
+    }
+}
+";
+        private const string AspNetProgramSource = @"
+using System;
+using Microsoft.AspNetCore;
+using Microsoft.AspNetCore.Hosting;
+
+public class Program
+{
+    public static void Main(string[] args)
+    {
+        WebHost.CreateDefaultBuilder(args).Build().Run();
+    }
+}
+";
+
+        public GivenThatWeWantToSetRuntimeFrameworkName(ITestOutputHelper log) : base(log)
+        {
+        }
+
+        [Theory]
+        //  TargetFramework, RuntimeFrameworkName, RuntimeFrameworkVersion, ExpectedPackageVersion
+        [InlineData("netcoreapp2.1", "Microsoft.NETCore.App", null, "2.1.0")]
+        [InlineData("netcoreapp2.1", "Microsoft.AspNetCore.App", null, "2.1.1")]
+        [InlineData("netcoreapp2.1", "Microsoft.AspNetCore.App",  "2.1.2", "2.1.2")]
+        [InlineData("netcoreapp2.1", "Microsoft.AspNetCore.All",  null, "2.1.1")]
+        [InlineData("netcoreapp2.1", "Microsoft.AspNetCore.All",  "2.1.2", "2.1.2")]
+        public void It_targets_a_known_runtime_framework_name(
+            string targetFramework,
+            string runtimeFrameworkName,
+            string runtimeFrameworkVersion,
+            string expectedPackageVersion)
+        {
+            string testIdentifier = "SharedRuntimeTargeting_" + string.Join("_", targetFramework, runtimeFrameworkName, runtimeFrameworkVersion ?? "null");
+
+            var testProject = new TestProject
+            {
+                Name = "FrameworkTargetTest",
+                TargetFrameworks = targetFramework,
+                RuntimeFrameworkVersion = runtimeFrameworkVersion,
+                IsSdkProject = true,
+                IsExe = true,
+                RuntimeFrameworkName = runtimeFrameworkName,
+            };
+
+            testProject.SourceFiles["Program.cs"] = runtimeFrameworkName.Contains("AspNetCore")
+                ? AspNetProgramSource
+                : ConsoleProgramSource;
+
+            var testAsset = _testAssetsManager
+                .CreateTestProject(testProject, testIdentifier)
+                .Restore(Log, testProject.Name);
+
+            var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+
+            buildCommand
+                .Execute()
+                .Should()
+                .Pass();
+
+            var outputDirectory = buildCommand.GetOutputDirectory(targetFramework);
+
+            string runtimeConfigFile = Path.Combine(outputDirectory.FullName, testProject.Name + ".runtimeconfig.json");
+            string runtimeConfigContents = File.ReadAllText(runtimeConfigFile);
+            JObject runtimeConfig = JObject.Parse(runtimeConfigContents);
+
+            string actualRuntimeFrameworkName = ((JValue)runtimeConfig["runtimeOptions"]["framework"]["name"]).Value<string>();
+            actualRuntimeFrameworkName.Should().Be(runtimeFrameworkName);
+
+            string actualRuntimeFrameworkVersion = ((JValue)runtimeConfig["runtimeOptions"]["framework"]["version"]).Value<string>();
+            actualRuntimeFrameworkVersion.Should().Be(expectedPackageVersion);
+
+            LockFile lockFile = LockFileUtilities.GetLockFile(Path.Combine(buildCommand.ProjectRootPath, "obj", "project.assets.json"), NullLogger.Instance);
+
+            var target = lockFile.GetTarget(NuGetFramework.Parse(targetFramework), null);
+            var netCoreAppLibrary = target.Libraries.Single(l => l.Name == runtimeFrameworkName);
+            netCoreAppLibrary.Version.ToString().Should().Be(expectedPackageVersion);
+        }
+
+
+        [Fact]
+        public void It_fails_when_unknown_runtimeframework_name_is_used()
+        {
+            TestProject project = new TestProject()
+            {
+                Name = "UnknownFrameworkName",
+                TargetFrameworks = "netcoreapp2.1",
+                IsSdkProject = true,
+                RuntimeFrameworkName = "Banana.App",
+            };
+
+            var testAsset = _testAssetsManager.CreateTestProject(project);
+            var restoreCommand = testAsset.GetRestoreCommand(Log, project.Name);
+
+            restoreCommand.Execute()
+                .Should()
+                .Fail()
+                .And
+                .HaveStdOutContaining("error NETSDK1070:");
+        }
+
+        [Fact]
+        public void It_generates_deps_file_for_aspnet_app()
+        {
+            TestProject project = new TestProject()
+            {
+                Name = "AspNetCore21App",
+                TargetFrameworks = "netcoreapp2.1",
+                IsExe = true,
+                IsSdkProject = true,
+                RuntimeFrameworkName = "Microsoft.AspNetCore.App",
+            };
+
+            project.SourceFiles["Program.cs"] = AspNetProgramSource;
+
+            var testAsset = _testAssetsManager.CreateTestProject(project)
+                .Restore(Log, project.Name);
+
+            string projectFolder = Path.Combine(testAsset.Path, project.Name);
+
+            var buildCommand = new BuildCommand(Log, projectFolder);
+
+            buildCommand
+                .Execute()
+                .Should()
+                .Pass();
+
+            string outputFolder = buildCommand.GetOutputDirectory(project.TargetFrameworks).FullName;
+
+            using (var depsJsonFileStream = File.OpenRead(Path.Combine(outputFolder, $"{project.Name}.deps.json")))
+            {
+                var dependencyContext = new DependencyContextJsonReader().Read(depsJsonFileStream);
+                dependencyContext.Should()
+                    .OnlyHaveRuntimeAssemblies("", project.Name)
+                    .And
+                    .HaveNoDuplicateRuntimeAssemblies("")
+                    .And
+                    .HaveNoDuplicateNativeAssets(""); ;
+            }
+        }
+    }
+}

--- a/src/Tests/Microsoft.NET.Restore.Tests/GivenThatWeWantImplicitAspNetCorePackages.cs
+++ b/src/Tests/Microsoft.NET.Restore.Tests/GivenThatWeWantImplicitAspNetCorePackages.cs
@@ -1,0 +1,152 @@
+using System.IO;
+using System.Linq;
+using FluentAssertions;
+using Microsoft.NET.TestFramework;
+using Microsoft.NET.TestFramework.Assertions;
+using Microsoft.NET.TestFramework.ProjectConstruction;
+using NuGet.Common;
+using NuGet.Frameworks;
+using NuGet.ProjectModel;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.NET.Restore.Tests
+{
+    public class GivenThatWeWantImplicitAspNetCorePackages : SdkTest
+    {
+        public GivenThatWeWantImplicitAspNetCorePackages(ITestOutputHelper log) : base(log)
+        {
+        }
+
+        [Theory]
+        [InlineData("Microsoft.AspNetCore.App")]
+        [InlineData("Microsoft.AspNetCore.All")]
+        public void It_warns_when_explicit_aspnet_package_ref_exists(string packageId)
+        {
+            const string testProjectName = "AspNetCoreWithExplicitRef";
+            var project = new TestProject
+            {
+                Name = testProjectName,
+                TargetFrameworks = "netcoreapp2.1",
+                IsSdkProject = true,
+                PackageReferences =
+                {
+                    new TestPackageReference(packageId, "2.1.0")
+                }
+            };
+
+            var testAsset = _testAssetsManager
+                .CreateTestProject(project)
+                .Restore(Log, project.Name);
+
+            string projectAssetsJsonPath = Path.Combine(
+                testAsset.Path,
+                project.Name,
+                "obj",
+                "project.assets.json");
+
+            var restoreCommand =
+                testAsset.GetRestoreCommand(Log, relativePath: testProjectName);
+            restoreCommand.Execute()
+                .Should().Pass()
+                .And
+                .HaveStdOutContaining("warning NETSDK1071:")
+                .And
+                .HaveStdOutContaining(testProjectName + ".csproj");
+
+            LockFile lockFile = LockFileUtilities.GetLockFile(
+                projectAssetsJsonPath,
+                NullLogger.Instance);
+
+            var target =
+                lockFile.GetTarget(NuGetFramework.Parse(".NETCoreApp,Version=v2.1"), null);
+            var metapackageLibrary =
+                target.Libraries.Single(l => l.Name == packageId);
+            metapackageLibrary.Version.ToString().Should().Be("2.1.0");
+        }
+
+        [Theory]
+        [InlineData("Microsoft.AspNetCore.App")]
+        [InlineData("Microsoft.AspNetCore.All")]
+        public void It_warns_when_aspnet_package_ref_is_overridden(string packageId)
+        {
+            const string testProjectName = "AspNetCoreWithDuplicateRefRef";
+            var project = new TestProject
+            {
+                Name = testProjectName,
+                TargetFrameworks = "netcoreapp2.1",
+                IsSdkProject = true,
+                RuntimeFrameworkName = packageId,
+                PackageReferences =
+                {
+                    new TestPackageReference(packageId, "2.1.1")
+                }
+            };
+
+            var testAsset = _testAssetsManager
+                .CreateTestProject(project)
+                .Restore(Log, project.Name);
+
+            string projectAssetsJsonPath = Path.Combine(
+                testAsset.Path,
+                project.Name,
+                "obj",
+                "project.assets.json");
+
+            var restoreCommand =
+                testAsset.GetRestoreCommand(Log, relativePath: testProjectName);
+            restoreCommand.Execute()
+                .Should().Pass()
+                .And
+                .HaveStdOutContaining("warning NETSDK1023:")
+                .And
+                .HaveStdOutContaining(testProjectName + ".csproj");
+        }
+
+        [Theory]
+        [InlineData("Microsoft.AspNetCore.App")]
+        [InlineData("Microsoft.AspNetCore.All")]
+        public void It_restores_when_RuntimeFrameworkName_is_set(string packageId)
+        {
+            const string testProjectName = "RuntimeFrameworkNameProject";
+            var project = new TestProject
+            {
+                Name = testProjectName,
+                TargetFrameworks = "netcoreapp2.1",
+                IsSdkProject = true,
+                RuntimeFrameworkName = packageId,
+            };
+
+            var testAsset = _testAssetsManager
+                .CreateTestProject(project)
+                .Restore(Log, project.Name);
+
+            string projectAssetsJsonPath = Path.Combine(
+                testAsset.Path,
+                project.Name,
+                "obj",
+                "project.assets.json");
+
+            var restoreCommand =
+                testAsset.GetRestoreCommand(Log, relativePath: testProjectName);
+            restoreCommand.Execute()
+                .Should().Pass()
+                .And
+                .NotHaveStdOutContaining("warning");;
+
+            LockFile lockFile = LockFileUtilities.GetLockFile(
+                projectAssetsJsonPath,
+                NullLogger.Instance);
+
+            var target =
+                lockFile.GetTarget(NuGetFramework.Parse(".NETCoreApp,Version=v2.1"), null);
+            var aspnetLibrary =
+                target.Libraries.Single(l => l.Name == packageId);
+            aspnetLibrary.Version.ToString().Should().Be("2.1.1");
+
+            var netcoreLibrary =
+                target.Libraries.Single(l => l.Name == "Microsoft.NETCore.App");
+            netcoreLibrary.Version.ToString().Should().Be("2.1.1");
+        }
+    }
+}

--- a/src/Tests/Microsoft.NET.TestFramework/ProjectConstruction/TestProject.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/ProjectConstruction/TestProject.cs
@@ -22,6 +22,8 @@ namespace Microsoft.NET.TestFramework.ProjectConstruction
 
         public string RuntimeFrameworkVersion { get; set; }
 
+        public string RuntimeFrameworkName { get; set; }
+
         public string RuntimeIdentifier { get; set; }
 
         //  TargetFrameworkVersion applies to non-SDK projects
@@ -177,6 +179,11 @@ namespace Microsoft.NET.TestFramework.ProjectConstruction
                 else
                 {
                     propertyGroup.Add(new XElement(ns + "TargetFramework", this.TargetFrameworks));
+                }
+
+                if (!string.IsNullOrEmpty(this.RuntimeFrameworkName))
+                {
+                    propertyGroup.Add(new XElement(ns + "RuntimeFrameworkName", this.RuntimeFrameworkName));
                 }
 
                 if (!string.IsNullOrEmpty(this.RuntimeFrameworkVersion))


### PR DESCRIPTION
Part of aspnet/Home#3307

An alternative to https://github.com/dotnet/sdk/pull/2394, which doesn't require changes to runtime packages and keeps the baseline for ASP.NET Core at 2.1.1 (which is the baseline in the 2.1.301 SDK).

Changes:

* Introduce a new property, RuntimeFrameworkName, which defines an additional implicit package reference added when targeting .NET Core. The default platform package, Microsoft.NETCore.App, is still always referenced
* Add information about the default implicit version to use for ASP.NET Core metapackages to use (when selected as the runtime framework) 
* Fail the build if an unrecognized value for RuntimeFrameworkName is specified in a .NET Core project.
* Add a warning when the project contains an explicit PackageReference to AspNetCore.All/App
