### PR TITLE
Generate shim in build

### DIFF
--- a/src/Tasks/Common/MetadataKeys.cs
+++ b/src/Tasks/Common/MetadataKeys.cs
@@ -27,6 +27,7 @@ namespace Microsoft.NET.Build.Tasks
         public const string SDKPackageItemSpec = "SDKPackageItemSpec";
         public const string OriginalItemSpec = "OriginalItemSpec";
         public const string SDKRootFolder = "SDKRootFolder";
+        public const string ShimRuntimeIdentifier = "ShimRuntimeIdentifier";
 
         // Foreign Keys
         public const string ParentTarget = "ParentTarget";

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAPublishRelativePathToPackPackagePath.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAPublishRelativePathToPackPackagePath.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.Reflection;
+using FluentAssertions;
+using Microsoft.Build.Framework;
+using Microsoft.Extensions.DependencyModel;
+using Xunit;
+
+namespace Microsoft.NET.Build.Tasks.UnitTests
+{
+    public class GivenAPublishRelativePathToPackPackagePath
+    {
+        [Theory]
+        [InlineData("tools/myfile.exe", "tools")]
+        [InlineData(@"tools\myfile.exe", "tools")]
+        [InlineData(@"tools\/myfile.exe", "tools")]
+        [InlineData(@"tools/\myfile.exe", "tools")]
+        [InlineData(@"myfile.exe", "")]
+        [InlineData(@"myfile", "")]
+        [InlineData("tools/myfile", "tools")]
+        [InlineData("/myfile", "")]
+        [InlineData("\\myfile", "")]
+        [InlineData("tools/sub/myfile.exe", "tools/sub")]
+        [InlineData("tools\\sub\\myfile.exe", "tools/sub")]
+        public void ItConvertsFromPublishRelativePathToPackPackagePath(string publishRelativePath, string packPackagePath)
+        {
+            PublishRelativePathToPackPackagePath.GetDirectoryPathInRelativePath(publishRelativePath).Should().Be(packPackagePath);
+        }
+    }
+}

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAPublishRelativePathToPackPackagePath.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAPublishRelativePathToPackPackagePath.cs
@@ -10,7 +10,7 @@ using Xunit;
 
 namespace Microsoft.NET.Build.Tasks.UnitTests
 {
-    public class GivenAPublishRelativePathToPackPackagePath
+    public class GivenARelativePathFormatInPublishToFormatInPackPackage
     {
         [Theory]
         [InlineData("tools/myfile.exe", "tools")]
@@ -26,7 +26,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
         [InlineData("tools\\sub\\myfile.exe", "tools/sub")]
         public void ItConvertsFromPublishRelativePathToPackPackagePath(string publishRelativePath, string packPackagePath)
         {
-            PublishRelativePathToPackPackagePath.GetDirectoryPathInRelativePath(publishRelativePath).Should().Be(packPackagePath);
+            RelativePathFormatInPublishToFormatInPackPackage.GetDirectoryPathInRelativePath(publishRelativePath).Should().Be(packPackagePath);
         }
     }
 }

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAPublishRelativePathToPackPackagePath.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAPublishRelativePathToPackPackagePath.cs
@@ -10,7 +10,7 @@ using Xunit;
 
 namespace Microsoft.NET.Build.Tasks.UnitTests
 {
-    public class GivenARelativePathFormatInPublishToFormatInPackPackage
+    public class GivenAResolveToolPackagePaths
     {
         [Theory]
         [InlineData("tools/myfile.exe", "tools")]
@@ -26,7 +26,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
         [InlineData("tools\\sub\\myfile.exe", "tools/sub")]
         public void ItConvertsFromPublishRelativePathToPackPackagePath(string publishRelativePath, string packPackagePath)
         {
-            RelativePathFormatInPublishToFormatInPackPackage.GetDirectoryPathInRelativePath(publishRelativePath).Should().Be(packPackagePath);
+            ResolveToolPackagePaths.GetDirectoryPathInRelativePath(publishRelativePath).Should().Be(packPackagePath);
         }
     }
 }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/AppHost.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/AppHost.cs
@@ -57,7 +57,7 @@ namespace Microsoft.NET.Build.Tasks
                 }
             }
 
-            File.SetLastWriteTime(appHostDestinationFilePath, DateTime.Now);
+            File.SetLastWriteTimeUtc(appHostDestinationFilePath, DateTime.UtcNow);
         }
 
         // See: https://en.wikipedia.org/wiki/Knuth%E2%80%93Morris%E2%80%93Pratt_algorithm

--- a/src/Tasks/Microsoft.NET.Build.Tasks/AppHost.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/AppHost.cs
@@ -57,6 +57,7 @@ namespace Microsoft.NET.Build.Tasks
                 }
             }
 
+            // Memory-mapped write does not updating last write time
             File.SetLastWriteTimeUtc(appHostDestinationFilePath, DateTime.UtcNow);
         }
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/AppHost.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/AppHost.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.IO;
 using System.IO.MemoryMappedFiles;
 using System.Runtime.InteropServices;
@@ -34,12 +35,6 @@ namespace Microsoft.NET.Build.Tasks
             var bytesToWrite = Encoding.UTF8.GetBytes(appBinaryFilePath);
             var destinationDirectory = new FileInfo(appHostDestinationFilePath).Directory.FullName;
 
-            if (File.Exists(appHostDestinationFilePath))
-            {
-                //We have already done the required modification to apphost.exe
-                return;
-            }
-
             if (bytesToWrite.Length > 1024)
             {
                 throw new BuildErrorException(Strings.FileNameIsTooLong, appBinaryFilePath);
@@ -61,6 +56,8 @@ namespace Microsoft.NET.Build.Tasks
                     SearchAndReplace(accessor, _bytesToSearch, bytesToWrite, appHostSourceFilePath);
                 }
             }
+
+            File.SetLastWriteTime(appHostDestinationFilePath, DateTime.Now);
         }
 
         // See: https://en.wikipedia.org/wiki/Knuth%E2%80%93Morris%E2%80%93Pratt_algorithm

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ExecutableExtension.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ExecutableExtension.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+
+namespace Microsoft.NET.Build.Tasks
+{
+    public sealed class ExecutableExtension
+    {
+        public static string GetExecutableExtensionAccordingToRuntimeIdentifier(string runtimeIdentifier)
+        {
+            if (runtimeIdentifier.StartsWith("win"))
+            {
+                return ".exe";
+            }
+            return string.Empty;
+        }
+    }
+}

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ExecutableExtension.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ExecutableExtension.cs
@@ -1,14 +1,15 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 
 namespace Microsoft.NET.Build.Tasks
 {
     public sealed class ExecutableExtension
     {
-        public static string GetExecutableExtensionAccordingToRuntimeIdentifier(string runtimeIdentifier)
+        public static string ForRuntimeIdentifier(string runtimeIdentifier)
         {
-            if (runtimeIdentifier.StartsWith("win"))
+            if (runtimeIdentifier.StartsWith("win", StringComparison.OrdinalIgnoreCase))
             {
                 return ".exe";
             }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/GenerateShims.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/GenerateShims.cs
@@ -98,7 +98,7 @@ namespace Microsoft.NET.Build.Tasks
 
                 var appHostDestinationFilePath = Path.Combine(
                         packagedShimOutputDirectoryAndRid,
-                        ToolCommandName + Path.GetExtension(resolvedApphostAssetPath));
+                        ToolCommandName + ExecutableExtension.GetExecutableExtensionAccordingToRuntimeIdentifier(runtimeIdentifier));
 
                 Directory.CreateDirectory(packagedShimOutputDirectoryAndRid);
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/GenerateShims.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/GenerateShims.cs
@@ -81,6 +81,7 @@ namespace Microsoft.NET.Build.Tasks
         [Output]
         public ITaskItem[] EmbeddedApphostPaths { get; private set; }
 
+
         protected override void ExecuteCore()
         {
             NuGetFramework targetFramework = NuGetUtils.ParseFrameworkName(TargetFrameworkMoniker);

--- a/src/Tasks/Microsoft.NET.Build.Tasks/GenerateShims.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/GenerateShims.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -13,31 +14,11 @@ namespace Microsoft.NET.Build.Tasks
 {
     public sealed class GenerateShims : TaskBase
     {
-        private NuGetPackageResolver _packageResolver;
-
         /// <summary>
-        /// Path to assets.json.
+        /// Relative paths for Apphost for different ShimRuntimeIdentifiers with RuntimeIdentifier as meta data
         /// </summary>
         [Required]
-        public string ProjectAssetsFile { get; set; }
-
-        /// <summary>
-        /// The file name of Apphost asset.
-        /// </summary>
-        [Required]
-        public string DotNetAppHostExecutableNameWithoutExtension { get; set; }
-
-        /// <summary>
-        /// Path to project file (.csproj|.vbproj|.fsproj)
-        /// </summary>
-        [Required]
-        public string ProjectPath { get; set; }
-
-        /// <summary>
-        /// TFM to use for compile-time assets.
-        /// </summary>
-        [Required]
-        public string TargetFrameworkMoniker { get; set; }
+        public ITaskItem[] ApphostsForShimRuntimeIdentifiers { get; private set; }
 
         /// <summary>
         /// PackageId of the dotnet tool NuGet Package.
@@ -50,6 +31,12 @@ namespace Microsoft.NET.Build.Tasks
         /// </summary>
         [Required]
         public string PackageVersion { get; set; }
+
+        /// <summary>
+        /// TFM to use for compile-time assets.
+        /// </summary>
+        [Required]
+        public string TargetFrameworkMoniker { get; set; }
 
         /// <summary>
         /// The command name of the dotnet tool.
@@ -81,17 +68,12 @@ namespace Microsoft.NET.Build.Tasks
         [Output]
         public ITaskItem[] EmbeddedApphostPaths { get; private set; }
 
-
         protected override void ExecuteCore()
         {
-            NuGetFramework targetFramework = NuGetUtils.ParseFrameworkName(TargetFrameworkMoniker);
-            LockFile lockFile = new LockFileCache(this).GetLockFile(ProjectAssetsFile);
-            _packageResolver = NuGetPackageResolver.CreateResolver(lockFile, ProjectPath);
-
             var embeddedApphostPaths = new List<ITaskItem>();
             foreach (var runtimeIdentifier in ShimRuntimeIdentifiers.Select(r => r.ItemSpec))
             {
-                var resolvedApphostAssetPath = GetApphostAsset(targetFramework, lockFile, runtimeIdentifier);
+                var resolvedApphostAssetPath = GetApphostAsset(ApphostsForShimRuntimeIdentifiers, runtimeIdentifier);
 
                 var packagedShimOutputDirectoryAndRid = Path.Combine(
                         PackagedShimOutputDirectory,
@@ -113,7 +95,7 @@ namespace Microsoft.NET.Build.Tasks
                         PackageId.ToLowerInvariant(),
                         PackageVersion,
                         "tools",
-                        targetFramework.GetShortFolderName(),
+                        NuGetUtils.ParseFrameworkName(TargetFrameworkMoniker).GetShortFolderName(),
                         "any",
                         ToolEntryPoint});
 
@@ -125,53 +107,16 @@ namespace Microsoft.NET.Build.Tasks
                 );
 
                 var item = new TaskItem(appHostDestinationFilePath);
-                item.SetMetadata("ShimRuntimeIdentifier", runtimeIdentifier);
+                item.SetMetadata(MetadataKeys.ShimRuntimeIdentifier, runtimeIdentifier);
                 embeddedApphostPaths.Add(item);
             }
 
             EmbeddedApphostPaths = embeddedApphostPaths.ToArray();
         }
 
-        private string GetApphostAsset(NuGetFramework targetFramework, LockFile lockFile, string runtimeIdentifier)
+        private string GetApphostAsset(ITaskItem[] apphostsForShimRuntimeIdentifiers, string runtimeIdentifier)
         {
-            var apphostName = DotNetAppHostExecutableNameWithoutExtension;
-
-            if (runtimeIdentifier.StartsWith("win"))
-            {
-                apphostName += ".exe";
-            }
-
-            LockFileTarget runtimeTarget = lockFile.GetTargetAndThrowIfNotFound(targetFramework, runtimeIdentifier);
-
-            return FindApphostInRuntimeTarget(apphostName, runtimeTarget);
-        }
-
-        private string FindApphostInRuntimeTarget(string apphostName, LockFileTarget runtimeTarget)
-        {
-            foreach (LockFileTargetLibrary library in runtimeTarget.Libraries)
-            {
-                if (!library.IsPackage())
-                {
-                    continue;
-                }
-
-                foreach (LockFileItem asset in library.NativeLibraries)
-                {
-                    if (asset.IsPlaceholderFile())
-                    {
-                        continue;
-                    }
-
-                    var resolvedPackageAssetPath = _packageResolver.ResolvePackageAssetPath(library, asset.Path);
-
-                    if (Path.GetFileName(resolvedPackageAssetPath) == apphostName)
-                    {
-                        return resolvedPackageAssetPath;
-                    }
-                }
-            }
-
-            throw new BuildErrorException(Strings.CannotFindApphostForRid, runtimeTarget.RuntimeIdentifier);
+            return apphostsForShimRuntimeIdentifiers.Single(i => i.GetMetadata(MetadataKeys.RuntimeIdentifier) == runtimeIdentifier).ItemSpec;
         }
     }
 }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/GenerateShims.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/GenerateShims.cs
@@ -81,7 +81,7 @@ namespace Microsoft.NET.Build.Tasks
 
                 var appHostDestinationFilePath = Path.Combine(
                         packagedShimOutputDirectoryAndRid,
-                        ToolCommandName + ExecutableExtension.GetExecutableExtensionAccordingToRuntimeIdentifier(runtimeIdentifier));
+                        ToolCommandName + ExecutableExtension.ForRuntimeIdentifier(runtimeIdentifier));
 
                 Directory.CreateDirectory(packagedShimOutputDirectoryAndRid);
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/GetEmbeddedApphostPaths.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/GetEmbeddedApphostPaths.cs
@@ -1,0 +1,56 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+namespace Microsoft.NET.Build.Tasks
+{
+    public sealed class GetEmbeddedApphostPaths : TaskBase
+    {
+        /// <summary>
+        /// The command name of the dotnet tool.
+        /// </summary>
+        [Required]
+        public string ToolCommandName { get; set; }
+
+        [Required]
+        public string PackagedShimOutputDirectory { get; set; }
+
+        /// <summary>
+        /// The RuntimeIdentifiers that shims will be generated for.
+        /// </summary>
+        [Required]
+        public ITaskItem[] ShimRuntimeIdentifiers { get; set; }
+
+        /// <summary>
+        /// Path of generated shims. metadata "ShimRuntimeIdentifier" is used to map back to input ShimRuntimeIdentifiers.
+        /// </summary>
+        [Output]
+        public ITaskItem[] EmbeddedApphostPaths { get; private set; }
+
+        protected override void ExecuteCore()
+        {
+            var embeddedApphostPaths = new List<ITaskItem>();
+            foreach (var runtimeIdentifier in ShimRuntimeIdentifiers.Select(r => r.ItemSpec))
+            {
+                var packagedShimOutputDirectoryAndRid = Path.Combine(
+                        PackagedShimOutputDirectory,
+                        runtimeIdentifier);
+
+                var appHostDestinationFilePath = Path.Combine(
+                        packagedShimOutputDirectoryAndRid,
+                        ToolCommandName + ExecutableExtension.GetExecutableExtensionAccordingToRuntimeIdentifier(runtimeIdentifier));
+
+                var item = new TaskItem(appHostDestinationFilePath);
+                item.SetMetadata("ShimRuntimeIdentifier", runtimeIdentifier);
+                embeddedApphostPaths.Add(item);
+            }
+
+            EmbeddedApphostPaths = embeddedApphostPaths.ToArray();
+        }
+    }
+}

--- a/src/Tasks/Microsoft.NET.Build.Tasks/GetEmbeddedApphostPaths.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/GetEmbeddedApphostPaths.cs
@@ -46,7 +46,7 @@ namespace Microsoft.NET.Build.Tasks
                         ToolCommandName + ExecutableExtension.GetExecutableExtensionAccordingToRuntimeIdentifier(runtimeIdentifier));
 
                 var item = new TaskItem(appHostDestinationFilePath);
-                item.SetMetadata("ShimRuntimeIdentifier", runtimeIdentifier);
+                item.SetMetadata(MetadataKeys.ShimRuntimeIdentifier, runtimeIdentifier);
                 embeddedApphostPaths.Add(item);
             }
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/GetEmbeddedApphostPaths.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/GetEmbeddedApphostPaths.cs
@@ -43,7 +43,7 @@ namespace Microsoft.NET.Build.Tasks
 
                 var appHostDestinationFilePath = Path.Combine(
                         packagedShimOutputDirectoryAndRid,
-                        ToolCommandName + ExecutableExtension.GetExecutableExtensionAccordingToRuntimeIdentifier(runtimeIdentifier));
+                        ToolCommandName + ExecutableExtension.ForRuntimeIdentifier(runtimeIdentifier));
 
                 var item = new TaskItem(appHostDestinationFilePath);
                 item.SetMetadata(MetadataKeys.ShimRuntimeIdentifier, runtimeIdentifier);

--- a/src/Tasks/Microsoft.NET.Build.Tasks/PublishRelativePathToPackPackagePath.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/PublishRelativePathToPackPackagePath.cs
@@ -1,0 +1,110 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+namespace Microsoft.NET.Build.Tasks
+{
+    /// <summary>
+    /// 1. Publish PublishRelativePath is a relative <strong>file</strong> path. This need to convert to relative path.
+    /// 2. Due to DotnetTools package format, "tools/{TargetFramework}/any/" is needed in addition to the relative path.
+    /// </summary>
+    public sealed class PublishRelativePathToPackPackagePath : TaskBase
+    {
+        [Required]
+        public ITaskItem[] ResolvedFileToPublish { get; set; }
+
+        [Required]
+        public string PublishDir { get; set; }
+
+        [Required]
+        public string TargetFramework { get; set; }
+
+        [Output]
+        public ITaskItem[] ResolvedFileToPublishWithPackagePath { get; private set; }
+
+        private const char DirectorySeparatorChar = '\\';
+        private const char AltDirectorySeparatorChar = '/';
+
+        protected override void ExecuteCore()
+        {
+            var result = new List<TaskItem>();
+            foreach (ITaskItem r in ResolvedFileToPublish)
+            {
+                string relativePath = r.GetMetadata("RelativePath");
+                var fullpath = Path.GetFullPath(
+                    Path.Combine(PublishDir,
+                    relativePath));
+                var i = new TaskItem(fullpath);
+                i.SetMetadata("PackagePath", $"tools/{TargetFramework}/any/{GetDirectoryPathInRelativePath(relativePath)}");
+                result.Add(i);
+            }
+
+            ResolvedFileToPublishWithPackagePath = result.ToArray();
+        }
+
+        /// <summary>
+        /// Change "dir/file.exe" to "dir"
+        /// </summary>
+        internal static string GetDirectoryPathInRelativePath(string publishRelativePath)
+        {
+            publishRelativePath = NormalizeDirectorySeparatorsToUnixStyle(publishRelativePath);
+            var index = publishRelativePath.LastIndexOf(AltDirectorySeparatorChar);
+            return index == -1 ? string.Empty : publishRelativePath.Substring(0, index);
+        }
+
+        // https://github.com/dotnet/corefx/issues/4208
+        // Basic copy paste from corefx. But Normalize to "/" instead of \
+        private static string NormalizeDirectorySeparatorsToUnixStyle(string path)
+        {
+            if (string.IsNullOrEmpty(path))
+            {
+                return path;
+            }
+
+            char current;
+
+            StringBuilder builder = new StringBuilder(path.Length);
+
+            int start = 0;
+            if (IsDirectorySeparator(path[start]))
+            {
+                start++;
+                builder.Append(AltDirectorySeparatorChar);
+            }
+
+            for (int i = start; i < path.Length; i++)
+            {
+                current = path[i];
+
+                // If we have a separator
+                if (IsDirectorySeparator(current))
+                {
+                    // If the next is a separator, skip adding this
+                    if (i + 1 < path.Length && IsDirectorySeparator(path[i + 1]))
+                    {
+                        continue;
+                    }
+
+                    // Ensure it is the primary separator
+                    current = AltDirectorySeparatorChar;
+                }
+
+                builder.Append(current);
+            }
+
+            return builder.ToString();
+        }
+
+        private static bool IsDirectorySeparator(char c)
+        {
+            return c == DirectorySeparatorChar || c == AltDirectorySeparatorChar;
+        }
+
+    }
+}

--- a/src/Tasks/Microsoft.NET.Build.Tasks/PublishRelativePathToPackPackagePath.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/PublishRelativePathToPackPackagePath.cs
@@ -14,7 +14,7 @@ namespace Microsoft.NET.Build.Tasks
     /// 1. Publish PublishRelativePath is a relative <strong>file</strong> path. This need to convert to relative path.
     /// 2. Due to DotnetTools package format, "tools/{TargetFramework}/any/" is needed in addition to the relative path.
     /// </summary>
-    public sealed class PublishRelativePathToPackPackagePath : TaskBase
+    public sealed class RelativePathFormatInPublishToFormatInPackPackage : TaskBase
     {
         [Required]
         public ITaskItem[] ResolvedFileToPublish { get; set; }
@@ -28,8 +28,8 @@ namespace Microsoft.NET.Build.Tasks
         [Output]
         public ITaskItem[] ResolvedFileToPublishWithPackagePath { get; private set; }
 
-        private const char DirectorySeparatorChar = '\\';
-        private const char AltDirectorySeparatorChar = '/';
+        private const char ForwardSeparatorChar = '\\';
+        private const char BackwardSeparatorChar = '/';
 
         protected override void ExecuteCore()
         {
@@ -54,7 +54,7 @@ namespace Microsoft.NET.Build.Tasks
         internal static string GetDirectoryPathInRelativePath(string publishRelativePath)
         {
             publishRelativePath = NormalizeDirectorySeparatorsToUnixStyle(publishRelativePath);
-            var index = publishRelativePath.LastIndexOf(AltDirectorySeparatorChar);
+            var index = publishRelativePath.LastIndexOf(BackwardSeparatorChar);
             return index == -1 ? string.Empty : publishRelativePath.Substring(0, index);
         }
 
@@ -75,7 +75,7 @@ namespace Microsoft.NET.Build.Tasks
             if (IsDirectorySeparator(path[start]))
             {
                 start++;
-                builder.Append(AltDirectorySeparatorChar);
+                builder.Append(BackwardSeparatorChar);
             }
 
             for (int i = start; i < path.Length; i++)
@@ -92,7 +92,7 @@ namespace Microsoft.NET.Build.Tasks
                     }
 
                     // Ensure it is the primary separator
-                    current = AltDirectorySeparatorChar;
+                    current = BackwardSeparatorChar;
                 }
 
                 builder.Append(current);
@@ -103,7 +103,7 @@ namespace Microsoft.NET.Build.Tasks
 
         private static bool IsDirectorySeparator(char c)
         {
-            return c == DirectorySeparatorChar || c == AltDirectorySeparatorChar;
+            return c == ForwardSeparatorChar || c == BackwardSeparatorChar;
         }
 
     }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageAssets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageAssets.cs
@@ -11,6 +11,7 @@ using System.Text;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using NuGet.Common;
+using NuGet.Frameworks;
 using NuGet.ProjectModel;
 
 namespace Microsoft.NET.Build.Tasks
@@ -105,6 +106,17 @@ namespace Microsoft.NET.Build.Tasks
         public ITaskItem[] ExpectedPlatformPackages { get; set; }
 
         /// <summary>
+        /// The RuntimeIdentifiers that shims will be generated for.
+        /// </summary>
+        public ITaskItem[] ShimRuntimeIdentifiers { get; set; }
+
+        /// <summary>
+        /// The file name of Apphost asset.
+        /// </summary>
+        [Required]
+        public string DotNetAppHostExecutableNameWithoutExtension { get; set; }
+
+        /// <summary>
         /// Full paths to assemblies from packages to pass to compiler as analyzers.
         /// </summary>
         [Output]
@@ -160,6 +172,12 @@ namespace Microsoft.NET.Build.Tasks
         public ITaskItem[] TransitiveProjectReferences { get; private set; }
 
         /// <summary>
+        /// Relative paths for Apphost for different ShimRuntimeIdentifiers with RuntimeIdentifier as meta data
+        /// </summary>
+        [Output]
+        public ITaskItem[] ApphostsForShimRuntimeIdentifiers { get; private set; }
+
+        /// <summary>
         /// Messages from the assets file.
         /// These are logged directly and therefore not returned to the targets (note private here).
         /// However,they are still stored as ITaskItem[] so that the same cache reader/writer code
@@ -212,7 +230,7 @@ namespace Microsoft.NET.Build.Tasks
         ////////////////////////////////////////////////////////////////////////////////////////////////////
 
         private const int CacheFormatSignature = ('P' << 0) | ('K' << 8) | ('G' << 16) | ('A' << 24);
-        private const int CacheFormatVersion = 1;
+        private const int CacheFormatVersion = 2;
         private static readonly Encoding TextEncoding = Encoding.UTF8;
         private const int SettingsHashLength = 256 / 8;
         private HashAlgorithm CreateSettingsHash() => SHA256.Create();
@@ -236,6 +254,7 @@ namespace Microsoft.NET.Build.Tasks
             {
                 // NOTE: Order (alphabetical by group name followed by log messages) must match writer.
                 Analyzers = reader.ReadItemGroup();
+                ApphostsForShimRuntimeIdentifiers = reader.ReadItemGroup();
                 CompileTimeAssemblies = reader.ReadItemGroup();
                 ContentFilesToPreprocess = reader.ReadItemGroup();
                 FrameworkAssemblies = reader.ReadItemGroup();
@@ -601,6 +620,7 @@ namespace Microsoft.NET.Build.Tasks
             {
                 // NOTE: Order (alphabetical by group name followed by log messages) must match reader.
                 WriteItemGroup(WriteAnalyzers);
+                WriteItemGroup(WriteApphostsForShimRuntimeIdentifiers);
                 WriteItemGroup(WriteCompileTimeAssemblies);
                 WriteItemGroup(WriteContentFilesToPreprocess);
                 WriteItemGroup(WriteFrameworkAssemblies);
@@ -866,6 +886,32 @@ namespace Microsoft.NET.Build.Tasks
                     package => package.NativeLibraries);
             }
 
+            private void WriteApphostsForShimRuntimeIdentifiers()
+            {
+                if (_task.ShimRuntimeIdentifiers == null || _task.ShimRuntimeIdentifiers.Length == 0)
+                {
+                    return;
+                }
+
+                foreach (var runtimeIdentifier in _task.ShimRuntimeIdentifiers.Select(r => r.ItemSpec))
+                {
+                    NuGetFramework targetFramework = NuGetUtils.ParseFrameworkName(_task.TargetFrameworkMoniker);
+                    LockFileTarget runtimeTarget = _lockFile.GetTargetAndThrowIfNotFound(targetFramework, runtimeIdentifier);
+
+                    var apphostName = _task.DotNetAppHostExecutableNameWithoutExtension;
+
+                    if (runtimeIdentifier.StartsWith("win"))
+                    {
+                        apphostName += ".exe";
+                    }
+
+                    Tuple<string, LockFileTargetLibrary> resolvedPackageAssetPathAndLibrary = FindApphostInRuntimeTarget(apphostName, runtimeTarget);
+
+                    WriteItem(resolvedPackageAssetPathAndLibrary.Item1, resolvedPackageAssetPathAndLibrary.Item2);
+                    WriteMetadata(MetadataKeys.RuntimeIdentifier, runtimeIdentifier);
+                }
+            }
+
             private void WriteResourceAssemblies()
             {
                 WriteItems(
@@ -1004,6 +1050,34 @@ namespace Microsoft.NET.Build.Tasks
                 }
 
                 return paths;
+            }
+
+            private Tuple<string, LockFileTargetLibrary> FindApphostInRuntimeTarget(string apphostName, LockFileTarget runtimeTarget)
+            {
+                foreach (LockFileTargetLibrary library in runtimeTarget.Libraries)
+                {
+                    if (!library.IsPackage())
+                    {
+                        continue;
+                    }
+
+                    foreach (LockFileItem asset in library.NativeLibraries)
+                    {
+                        if (asset.IsPlaceholderFile())
+                        {
+                            continue;
+                        }
+
+                        var resolvedPackageAssetPath = _packageResolver.ResolvePackageAssetPath(library, asset.Path);
+
+                        if (Path.GetFileName(resolvedPackageAssetPath) == apphostName)
+                        {
+                            return new Tuple<string, LockFileTargetLibrary>(resolvedPackageAssetPath, library);
+                        }
+                    }
+                }
+
+                throw new BuildErrorException(Strings.CannotFindApphostForRid, runtimeTarget.RuntimeIdentifier);
             }
         }
     }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageAssets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageAssets.cs
@@ -906,12 +906,7 @@ namespace Microsoft.NET.Build.Tasks
                     NuGetFramework targetFramework = NuGetUtils.ParseFrameworkName(_task.TargetFrameworkMoniker);
                     LockFileTarget runtimeTarget = _lockFile.GetTargetAndThrowIfNotFound(targetFramework, runtimeIdentifier);
 
-                    var apphostName = _task.DotNetAppHostExecutableNameWithoutExtension;
-
-                    if (runtimeIdentifier.StartsWith("win"))
-                    {
-                        apphostName += ".exe";
-                    }
+                    var apphostName = _task.DotNetAppHostExecutableNameWithoutExtension + ExecutableExtension.ForRuntimeIdentifier(runtimeIdentifier);
 
                     Tuple<string, LockFileTargetLibrary> resolvedPackageAssetPathAndLibrary = FindApphostInRuntimeTarget(apphostName, runtimeTarget);
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageAssets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageAssets.cs
@@ -332,6 +332,7 @@ namespace Microsoft.NET.Build.Tasks
                     writer.Write(DisablePackageAssetsCache);
                     writer.Write(DisableFrameworkAssemblies);
                     writer.Write(DisableTransitiveProjectReferences);
+                    writer.Write(DotNetAppHostExecutableNameWithoutExtension);
                     writer.Write(EmitAssetsLogMessages);
                     writer.Write(EnsureRuntimePackageDependencies);
                     writer.Write(MarkPackageReferencesAsExternallyResolved);
@@ -348,6 +349,13 @@ namespace Microsoft.NET.Build.Tasks
                     writer.Write(ProjectLanguage ?? "");
                     writer.Write(ProjectPath);
                     writer.Write(RuntimeIdentifier ?? "");
+                    if (ShimRuntimeIdentifiers != null)
+                    {
+                        foreach (var r in ShimRuntimeIdentifiers)
+                        {
+                            writer.Write(r.ItemSpec ?? "");
+                        }
+                    }
                     writer.Write(TargetFrameworkMoniker);
                     writer.Write(VerifyMatchingImplicitPackageVersion);
                 }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolveToolPackagePaths.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveToolPackagePaths.cs
@@ -14,7 +14,7 @@ namespace Microsoft.NET.Build.Tasks
     /// 1. Publish PublishRelativePath is a relative <strong>file</strong> path. This need to convert to relative path.
     /// 2. Due to DotnetTools package format, "tools/{TargetFramework}/any/" is needed in addition to the relative path.
     /// </summary>
-    public sealed class RelativePathFormatInPublishToFormatInPackPackage : TaskBase
+    public sealed class ResolveToolPackagePaths : TaskBase
     {
         [Required]
         public ITaskItem[] ResolvedFileToPublish { get; set; }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.PackTool.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.PackTool.targets
@@ -84,7 +84,8 @@ Copyright (c) .NET Foundation. All rights reserved.
     -->
 
   <Target Name="GenerateShimsAssets"
-          AfterTargets="Build"
+          AfterTargets="ResolveReferences"
+          BeforeTargets="IncrementalClean"
           DependsOnTargets="ResolvePackageAssets"
           Condition="'$(PackAsTool)' == 'true'" >
 
@@ -110,6 +111,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       >
 
       <Output TaskParameter="EmbeddedApphostPaths" ItemName="_EmbeddedApphostPaths" />
+      <Output TaskParameter="EmbeddedApphostPaths" ItemName="FileWrites" />
     </GenerateShims>
   </Target>
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.PackTool.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.PackTool.targets
@@ -120,6 +120,8 @@ Copyright (c) .NET Foundation. All rights reserved.
     <!-- Workaround for https://github.com/dotnet/corefx/issues/31379
          LastWriteTime in shims are not accurate. And _ShimInputCacheFile will have later timestamp than generated shims.
          Use a created file to "record" LastWriteTime. And only use it in "Outputs" field for timestamp comparison.
+
+         Touch Task uses the same API File.SetLastWriteTime underneath. So it also cannot be used.
     -->
     <WriteLinesToFile Lines="This file's LastWriteTime is used in incremental build" File="$(_ShimCreatedSentinelFile)" Overwrite="True" />
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.PackTool.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.PackTool.targets
@@ -84,8 +84,8 @@ Copyright (c) .NET Foundation. All rights reserved.
     -->
 
   <Target Name="GenerateShimsAssets"
-          BeforeTargets="IncrementalClean"
-          DependsOnTargets="ResolvePackageAssets"
+          BeforeTargets="CopyFilesToOutputDirectory"
+          DependsOnTargets="ResolveReferences"
           Condition="'$(PackAsTool)' == 'true'" >
 
     <ItemGroup>
@@ -110,8 +110,13 @@ Copyright (c) .NET Foundation. All rights reserved.
       >
 
       <Output TaskParameter="EmbeddedApphostPaths" ItemName="_EmbeddedApphostPaths" />
-      <Output TaskParameter="EmbeddedApphostPaths" ItemName="FileWrites" />
     </GenerateShims>
+
+    <ItemGroup>
+      <!-- Do this in an ItemGroup instead of as an output parameter so that it still gets added to the item set
+           during incremental builds when the task is skipped -->
+      <FileWrites Include="@(_EmbeddedApphostPaths)"/>
+    </ItemGroup>
   </Target>
 
 </Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.PackTool.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.PackTool.targets
@@ -12,9 +12,12 @@ Copyright (c) .NET Foundation. All rights reserved.
 
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <UsingTask TaskName="Microsoft.NET.Build.Tasks.GenerateToolsSettingsFile"
-              AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
+            AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
   <UsingTask TaskName="Microsoft.NET.Build.Tasks.GenerateShims"
-          AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
+            AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
+  <UsingTask TaskName="Microsoft.NET.Build.Tasks.PublishRelativePathToPackPackagePath"
+            AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
+
   <!--
     Mark all dependecy as private assets. But keep them as Publish. So dependency DLLs will be included in NuGet package, while
     there is no dependency in nuspec. And add Microsoft.NETCore.Platforms, which is used to select correct RID assets.
@@ -24,8 +27,8 @@ Copyright (c) .NET Foundation. All rights reserved.
     <SuppressDependenciesWhenPacking Condition=" '$(PackAsTool)' == 'true' ">true</SuppressDependenciesWhenPacking>
   </PropertyGroup>
 
-  <Target Name="PackTool" DependsOnTargets="GenerateToolsSettingsFileFromBuildProperty;Publish;ResolveApphostAsset" Condition=" '$(PackAsTool)' == 'true' ">
 
+  <Target Name="PackTool" DependsOnTargets="GenerateToolsSettingsFileFromBuildProperty;Publish" Condition=" '$(PackAsTool)' == 'true' ">
     <NETSdkError Condition=" '$(SelfContained)' == 'true' "
                  ResourceName="PackAsToolCannotSupportSelfContained" />
 
@@ -41,17 +44,21 @@ Copyright (c) .NET Foundation. All rights reserved.
       <_GeneratedFiles Include="$(_ToolsSettingsFilePath)"/>
     </ItemGroup>
 
+    <PublishRelativePathToPackPackagePath
+      ResolvedFileToPublish="@(ResolvedFileToPublish)"
+      PublishDir="$(PublishDir)"
+      TargetFramework="$(TargetFramework)">
+
+      <Output TaskParameter="ResolvedFileToPublishWithPackagePath" ItemName="_ResolvedFileToPublishWithPackagePath" />
+    </PublishRelativePathToPackPackagePath>
+
     <ItemGroup>
       <TfmSpecificPackageFile Include="@(_GeneratedFiles)">
         <PackagePath>tools/$(TargetFramework)/any/%(_GeneratedFiles.RecursiveDir)%(_GeneratedFiles.Filename)%(_GeneratedFiles.Extension)</PackagePath>
       </TfmSpecificPackageFile>
 
-      <TfmSpecificPackageFile Include="@(ResolvedFileToPublish->'$([MSBuild]::NormalizeDirectory($(PublishDir)))%(RelativePath)')">
-        <PackagePath>tools/$(TargetFramework)/any/%(ResolvedFileToPublish.RelativePath)</PackagePath>
-      </TfmSpecificPackageFile>
-
-      <TfmSpecificPackageFile Include="@(_EmbeddedApphostPaths)">
-        <PackagePath>tools/$(TargetFramework)/any/shims/%(_EmbeddedApphostPaths.ShimRuntimeIdentifier)</PackagePath>
+      <TfmSpecificPackageFile Include="@(_ResolvedFileToPublishWithPackagePath)">
+        <PackagePath>%(_ResolvedFileToPublishWithPackagePath.PackagePath)</PackagePath>
       </TfmSpecificPackageFile>
     </ItemGroup>
   </Target>
@@ -68,13 +75,25 @@ Copyright (c) .NET Foundation. All rights reserved.
        ToolsSettingsFilePath="$(_ToolsSettingsFilePath)" />
   </Target>
 
-  <Target Name="ResolveApphostAsset" DependsOnTargets="ResolveReferences;Publish">
+  <!--
+    ============================================================
+                                        GenerateShimsAssets
+
+    Generate packaged shims for signing when PackAsToolShimRuntimeIdentifiers is set
+    ============================================================
+    -->
+
+  <Target Name="GenerateShimsAssets"
+          AfterTargets="Build"
+          DependsOnTargets="ResolvePackageAssets"
+          Condition="'$(PackAsTool)' == 'true'" >
+
     <ItemGroup>
       <_PackAsToolShimRuntimeIdentifiers Include="$(PackAsToolShimRuntimeIdentifiers)"/>
     </ItemGroup>
 
     <PropertyGroup>
-      <PackagedShimOutputRootDirectory Condition=" '$(PackagedShimOutputRootDirectory)' == '' ">$(IntermediateOutputPath)</PackagedShimOutputRootDirectory>
+      <PackagedShimOutputRootDirectory Condition=" '$(PackagedShimOutputRootDirectory)' == '' ">$(OutDir)</PackagedShimOutputRootDirectory>
     </PropertyGroup>
 
     <GenerateShims

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.PackTool.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.PackTool.targets
@@ -15,7 +15,7 @@ Copyright (c) .NET Foundation. All rights reserved.
             AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
   <UsingTask TaskName="Microsoft.NET.Build.Tasks.GenerateShims"
             AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
-  <UsingTask TaskName="Microsoft.NET.Build.Tasks.PublishRelativePathToPackPackagePath"
+  <UsingTask TaskName="Microsoft.NET.Build.Tasks.RelativePathFormatInPublishToFormatInPackPackage"
             AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
   <UsingTask TaskName="Microsoft.NET.Build.Tasks.GetEmbeddedApphostPaths"
       AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
@@ -36,13 +36,13 @@ Copyright (c) .NET Foundation. All rights reserved.
       <_GeneratedFiles Include="$(_ToolsSettingsFilePath)"/>
     </ItemGroup>
 
-    <PublishRelativePathToPackPackagePath
+    <RelativePathFormatInPublishToFormatInPackPackage
       ResolvedFileToPublish="@(ResolvedFileToPublish)"
       PublishDir="$(PublishDir)"
       TargetFramework="$(TargetFramework)">
 
       <Output TaskParameter="ResolvedFileToPublishWithPackagePath" ItemName="_ResolvedFileToPublishWithPackagePath" />
-    </PublishRelativePathToPackPackagePath>
+    </RelativePathFormatInPublishToFormatInPackPackage>
 
     <ItemGroup>
       <TfmSpecificPackageFile Include="@(_GeneratedFiles)">
@@ -126,8 +126,8 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ItemGroup>
       <!-- Do this in an ItemGroup instead of as an output parameter so that it still gets added to the item set
            during incremental builds when the task is skipped -->
-      <FileWrites Include="@(_EmbeddedApphostPaths)" Condition="Exists('@(_EmbeddedApphostPaths)')"/>
-      <FileWrites Include="$(_ShimCreatedSentinelFile)" Condition="Exists('$(_ShimCreatedSentinelFile)')"/>
+      <FileWrites Include="@(_EmbeddedApphostPaths)" />
+      <FileWrites Include="$(_ShimCreatedSentinelFile)" />
     </ItemGroup>
   </Target>
 
@@ -165,7 +165,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <WriteLinesToFile Lines="$(_GenerateShimsAssetsInputCacheHash)" File="$(_ShimInputCacheFile)" Overwrite="True" WriteOnlyWhenDifferent="True" />
 
     <ItemGroup>
-      <FileWrites Include="$(_ShimInputCacheFile)" Condition="Exists('$(_ShimInputCacheFile)')" />
+      <FileWrites Include="$(_ShimInputCacheFile)" />
     </ItemGroup>
   </Target>
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.PackTool.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.PackTool.targets
@@ -15,7 +15,7 @@ Copyright (c) .NET Foundation. All rights reserved.
             AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
   <UsingTask TaskName="Microsoft.NET.Build.Tasks.GenerateShims"
             AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
-  <UsingTask TaskName="Microsoft.NET.Build.Tasks.RelativePathFormatInPublishToFormatInPackPackage"
+  <UsingTask TaskName="Microsoft.NET.Build.Tasks.ResolveToolPackagePaths"
             AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
   <UsingTask TaskName="Microsoft.NET.Build.Tasks.GetEmbeddedApphostPaths"
       AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
@@ -36,13 +36,13 @@ Copyright (c) .NET Foundation. All rights reserved.
       <_GeneratedFiles Include="$(_ToolsSettingsFilePath)"/>
     </ItemGroup>
 
-    <RelativePathFormatInPublishToFormatInPackPackage
+    <ResolveToolPackagePaths
       ResolvedFileToPublish="@(ResolvedFileToPublish)"
       PublishDir="$(PublishDir)"
       TargetFramework="$(TargetFramework)">
 
       <Output TaskParameter="ResolvedFileToPublishWithPackagePath" ItemName="_ResolvedFileToPublishWithPackagePath" />
-    </RelativePathFormatInPublishToFormatInPackPackage>
+    </ResolveToolPackagePaths>
 
     <ItemGroup>
       <TfmSpecificPackageFile Include="@(_GeneratedFiles)">

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.PackTool.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.PackTool.targets
@@ -89,19 +89,16 @@ Copyright (c) .NET Foundation. All rights reserved.
   <PropertyGroup>
     <_ShimInputCacheFile Condition="'$(_ShimInputCacheFile)' == ''">$(IntermediateOutputPath)$(MSBuildProjectName).shiminput.cache</_ShimInputCacheFile>
     <_ShimInputCacheFile>$([MSBuild]::NormalizePath($(MSBuildProjectDirectory), $(_ShimInputCacheFile)))</_ShimInputCacheFile>
+    <_ShimCreatedSentinelFile Condition="'$(_ShimCreatedSentinelFile)' == ''">$(IntermediateOutputPath)$(MSBuildProjectName).shimcreated.sentinel</_ShimCreatedSentinelFile>
+    <_ShimCreatedSentinelFile>$([MSBuild]::NormalizePath($(MSBuildProjectDirectory), $(_ShimCreatedSentinelFile)))</_ShimCreatedSentinelFile>
   </PropertyGroup>
-
-  <ItemGroup>
-    <_GenerateShimsAssetsInput Include="@(_ApphostsForShimRuntimeIdentifiers)"/>
-  </ItemGroup>
 
   <Target Name="GenerateShimsAssets"
           BeforeTargets="CopyFilesToOutputDirectory"
           DependsOnTargets="ResolvePackageAssets;_PackToolValidation;_GenerateShimInputCache;_ComputeExpectedEmbeddedApphostPaths"
           Condition="'$(PackAsTool)' == 'true'"
           Inputs="@(_GenerateShimsAssetsInput)"
-          Outputs="@(_EmbeddedApphostPaths)"
-          >
+          Outputs="$(_ShimCreatedSentinelFile)">
 
     <PropertyGroup>
       <PackagedShimOutputRootDirectory Condition=" '$(PackagedShimOutputRootDirectory)' == '' ">$(OutDir)</PackagedShimOutputRootDirectory>
@@ -115,44 +112,50 @@ Copyright (c) .NET Foundation. All rights reserved.
       ShimRuntimeIdentifiers="@(_PackAsToolShimRuntimeIdentifiers)"
       TargetFrameworkMoniker="$(NuGetTargetMoniker)"
       ToolCommandName="$(ToolCommandName)"
-      ToolEntryPoint="$(ToolEntryPoint)"
-      >
+      ToolEntryPoint="$(ToolEntryPoint)">
 
       <Output TaskParameter="EmbeddedApphostPaths" ItemName="_EmbeddedApphostPaths" />
     </GenerateShims>
+
+    <!-- Workaround for https://github.com/dotnet/corefx/issues/31379
+         LastWriteTime in shims are not accurate. And _ShimInputCacheFile will have later timestamp than generated shims.
+         Use a created file to "record" LastWriteTime. And only use it in "Outputs" field for timestamp comparison.
+    -->
+    <WriteLinesToFile Lines="This file's LastWriteTime is used in incremental build" File="$(_ShimCreatedSentinelFile)" Overwrite="True" />
 
     <ItemGroup>
       <!-- Do this in an ItemGroup instead of as an output parameter so that it still gets added to the item set
            during incremental builds when the task is skipped -->
       <FileWrites Include="@(_EmbeddedApphostPaths)" Condition="Exists('@(_EmbeddedApphostPaths)')"/>
+      <FileWrites Include="$(_ShimCreatedSentinelFile)" Condition="Exists('$(_ShimCreatedSentinelFile)')"/>
     </ItemGroup>
   </Target>
 
   <Target Name="_ComputeExpectedEmbeddedApphostPaths">
-    <ItemGroup>
-      <_PackAsToolShimRuntimeIdentifiers Include="$(PackAsToolShimRuntimeIdentifiers)"/>
-    </ItemGroup>
-
     <GetEmbeddedApphostPaths
       PackagedShimOutputDirectory="$(OutDir)/shims/$(TargetFramework)"
       ShimRuntimeIdentifiers="@(_PackAsToolShimRuntimeIdentifiers)"
-      ToolCommandName="$(ToolCommandName)"
-      >
+      ToolCommandName="$(ToolCommandName)">
 
       <Output TaskParameter="EmbeddedApphostPaths" ItemName="_EmbeddedApphostPaths" />
     </GetEmbeddedApphostPaths>
   </Target>
 
-  <!--To achieve incremental build with property change. When any property changes, WriteOnlyWhenDifferent will be triggered to write cache file.
+  <!-- To achieve incremental build with property change. When any property changes, WriteOnlyWhenDifferent will be triggered to write cache file.
   And the cache file's timestamp will be later, and it then triggers the incremental build.-->
   <Target Name="_GenerateShimInputCache" DependsOnTargets="ResolveAssemblyReferences">
     <ItemGroup>
       <_GenerateShimsAssetsInput Include="$(_ShimInputCacheFile)" />
+      <_GenerateShimsAssetsInput Include="@(_ApphostsForShimRuntimeIdentifiers)"/>
+      <_GenerateShimsAssetsInput Include="$(_ShimCreatedSentinelFile)"/>
+      <_GenerateShimsAssetsInput Include="$(ProjectAssetsFile)"/>
+
       <_GenerateShimsAssetsInputCacheToHash Include="$(PackageId)"/>
       <_GenerateShimsAssetsInputCacheToHash Include="$(Version)"/>
       <_GenerateShimsAssetsInputCacheToHash Include="$(NuGetTargetMoniker)"/>
       <_GenerateShimsAssetsInputCacheToHash Include="$(ToolCommandName)"/>
       <_GenerateShimsAssetsInputCacheToHash Include="$(ToolEntryPoint)"/>
+      <_GenerateShimsAssetsInputCacheToHash Include="$(PackAsToolShimRuntimeIdentifiers)"/>
     </ItemGroup>
 
     <Hash ItemsToHash="@(_GenerateShimsAssetsInputCacheToHash)">

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.PackTool.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.PackTool.targets
@@ -84,7 +84,6 @@ Copyright (c) .NET Foundation. All rights reserved.
     -->
 
   <Target Name="GenerateShimsAssets"
-          AfterTargets="ResolveReferences"
           BeforeTargets="IncrementalClean"
           DependsOnTargets="ResolvePackageAssets"
           Condition="'$(PackAsTool)' == 'true'" >

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.PackTool.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.PackTool.targets
@@ -17,6 +17,8 @@ Copyright (c) .NET Foundation. All rights reserved.
             AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
   <UsingTask TaskName="Microsoft.NET.Build.Tasks.PublishRelativePathToPackPackagePath"
             AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
+  <UsingTask TaskName="Microsoft.NET.Build.Tasks.GetEmbeddedApphostPaths"
+      AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
 
   <!--
     Mark all dependecy as private assets. But keep them as Publish. So dependency DLLs will be included in NuGet package, while
@@ -27,17 +29,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <SuppressDependenciesWhenPacking Condition=" '$(PackAsTool)' == 'true' ">true</SuppressDependenciesWhenPacking>
   </PropertyGroup>
 
-
-  <Target Name="PackTool" DependsOnTargets="GenerateToolsSettingsFileFromBuildProperty;Publish" Condition=" '$(PackAsTool)' == 'true' ">
-    <NETSdkError Condition=" '$(SelfContained)' == 'true' "
-                 ResourceName="PackAsToolCannotSupportSelfContained" />
-
-    <NETSdkError Condition=" '$(TargetFrameworkIdentifier)' != '.NETCoreApp' "
-                 ResourceName="DotnetToolOnlySupportNetcoreapp" />
-
-    <NETSdkError Condition=" '$(_TargetFrameworkVersionWithoutV)' &lt; '2.1' "
-                 ResourceName="DotnetToolDoesNotSupportTFMLowerThanNetcoreapp21" />
-
+  <Target Name="PackTool" DependsOnTargets="GenerateToolsSettingsFileFromBuildProperty;Publish;_PackToolValidation" Condition=" '$(PackAsTool)' == 'true' ">
     <ItemGroup>
       <_GeneratedFiles Include="$(PublishDepsFilePath)"/>
       <_GeneratedFiles Include="$(PublishRuntimeConfigFilePath)"/>
@@ -75,6 +67,17 @@ Copyright (c) .NET Foundation. All rights reserved.
        ToolsSettingsFilePath="$(_ToolsSettingsFilePath)" />
   </Target>
 
+  <Target Name="_PackToolValidation" Condition=" '$(PackAsTool)' == 'true' ">
+    <NETSdkError Condition=" '$(SelfContained)' == 'true' "
+             ResourceName="PackAsToolCannotSupportSelfContained" />
+
+    <NETSdkError Condition=" '$(TargetFrameworkIdentifier)' != '.NETCoreApp' "
+                 ResourceName="DotnetToolOnlySupportNetcoreapp" />
+
+    <NETSdkError Condition=" '$(_TargetFrameworkVersionWithoutV)' &lt; '2.1' "
+                 ResourceName="DotnetToolDoesNotSupportTFMLowerThanNetcoreapp21" />
+  </Target>
+
   <!--
     ============================================================
                                         GenerateShimsAssets
@@ -83,26 +86,32 @@ Copyright (c) .NET Foundation. All rights reserved.
     ============================================================
     -->
 
+  <PropertyGroup>
+    <_ShimInputCacheFile Condition="'$(_ShimInputCacheFile)' == ''">$(IntermediateOutputPath)$(MSBuildProjectName).shiminput.cache</_ShimInputCacheFile>
+    <_ShimInputCacheFile>$([MSBuild]::NormalizePath($(MSBuildProjectDirectory), $(_ShimInputCacheFile)))</_ShimInputCacheFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <_GenerateShimsAssetsInput Include="@(_ApphostsForShimRuntimeIdentifiers)"/>
+  </ItemGroup>
+
   <Target Name="GenerateShimsAssets"
           BeforeTargets="CopyFilesToOutputDirectory"
-          DependsOnTargets="ResolveReferences"
-          Condition="'$(PackAsTool)' == 'true'" >
-
-    <ItemGroup>
-      <_PackAsToolShimRuntimeIdentifiers Include="$(PackAsToolShimRuntimeIdentifiers)"/>
-    </ItemGroup>
+          DependsOnTargets="ResolvePackageAssets;_PackToolValidation;_GenerateShimInputCache;_ComputeExpectedEmbeddedApphostPaths"
+          Condition="'$(PackAsTool)' == 'true'"
+          Inputs="@(_GenerateShimsAssetsInput)"
+          Outputs="@(_EmbeddedApphostPaths)"
+          >
 
     <PropertyGroup>
       <PackagedShimOutputRootDirectory Condition=" '$(PackagedShimOutputRootDirectory)' == '' ">$(OutDir)</PackagedShimOutputRootDirectory>
     </PropertyGroup>
 
     <GenerateShims
-      DotNetAppHostExecutableNameWithoutExtension="$(_DotNetAppHostExecutableNameWithoutExtension)"
+      ApphostsForShimRuntimeIdentifiers="@(_ApphostsForShimRuntimeIdentifiers)"
       PackagedShimOutputDirectory="$(PackagedShimOutputRootDirectory)/shims/$(TargetFramework)"
       PackageId="$(PackageId)"
       PackageVersion="$(Version)"
-      ProjectAssetsFile="$(ProjectAssetsFile)"
-      ProjectPath="$(MSBuildProjectFullPath)"
       ShimRuntimeIdentifiers="@(_PackAsToolShimRuntimeIdentifiers)"
       TargetFrameworkMoniker="$(NuGetTargetMoniker)"
       ToolCommandName="$(ToolCommandName)"
@@ -115,7 +124,45 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ItemGroup>
       <!-- Do this in an ItemGroup instead of as an output parameter so that it still gets added to the item set
            during incremental builds when the task is skipped -->
-      <FileWrites Include="@(_EmbeddedApphostPaths)"/>
+      <FileWrites Include="@(_EmbeddedApphostPaths)" Condition="Exists('@(_EmbeddedApphostPaths)')"/>
+    </ItemGroup>
+  </Target>
+
+  <Target Name="_ComputeExpectedEmbeddedApphostPaths">
+    <ItemGroup>
+      <_PackAsToolShimRuntimeIdentifiers Include="$(PackAsToolShimRuntimeIdentifiers)"/>
+    </ItemGroup>
+
+    <GetEmbeddedApphostPaths
+      PackagedShimOutputDirectory="$(OutDir)/shims/$(TargetFramework)"
+      ShimRuntimeIdentifiers="@(_PackAsToolShimRuntimeIdentifiers)"
+      ToolCommandName="$(ToolCommandName)"
+      >
+
+      <Output TaskParameter="EmbeddedApphostPaths" ItemName="_EmbeddedApphostPaths" />
+    </GetEmbeddedApphostPaths>
+  </Target>
+
+  <!--To achieve incremental build with property change. When any property changes, WriteOnlyWhenDifferent will be triggered to write cache file.
+  And the cache file's timestamp will be later, and it then triggers the incremental build.-->
+  <Target Name="_GenerateShimInputCache" DependsOnTargets="ResolveAssemblyReferences">
+    <ItemGroup>
+      <_GenerateShimsAssetsInput Include="$(_ShimInputCacheFile)" />
+      <_GenerateShimsAssetsInputCacheToHash Include="$(PackageId)"/>
+      <_GenerateShimsAssetsInputCacheToHash Include="$(Version)"/>
+      <_GenerateShimsAssetsInputCacheToHash Include="$(NuGetTargetMoniker)"/>
+      <_GenerateShimsAssetsInputCacheToHash Include="$(ToolCommandName)"/>
+      <_GenerateShimsAssetsInputCacheToHash Include="$(ToolEntryPoint)"/>
+    </ItemGroup>
+
+    <Hash ItemsToHash="@(_GenerateShimsAssetsInputCacheToHash)">
+      <Output TaskParameter="HashResult" PropertyName="_GenerateShimsAssetsInputCacheHash" />
+    </Hash>
+
+    <WriteLinesToFile Lines="$(_GenerateShimsAssetsInputCacheHash)" File="$(_ShimInputCacheFile)" Overwrite="True" WriteOnlyWhenDifferent="True" />
+
+    <ItemGroup>
+      <FileWrites Include="$(_ShimInputCacheFile)" Condition="Exists('$(_ShimInputCacheFile)')" />
     </ItemGroup>
   </Target>
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -46,6 +46,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       ResolveReferences;
       PrepareResourceNames;
       ComputeIntermediateSatelliteAssemblies;
+      ComputeEmbeddedApphostPaths;
     </_BeforePublishNoBuildTargets>
 
     <_CorePublishTargets>
@@ -247,6 +248,11 @@ Copyright (c) .NET Foundation. All rights reserved.
                               Condition="'$(PublishDocumentationFile)' == 'true'">
         <RelativePath>@(FinalDocFile->'%(Filename)%(Extension)')</RelativePath>
       </ResolvedFileToPublish>
+
+      <!-- Copy all PackAsTool shims (if any) -->
+      <ResolvedFileToPublish Include="@(_EmbeddedApphostPaths)">
+        <RelativePath>shims/%(_EmbeddedApphostPaths.ShimRuntimeIdentifier)/%(_EmbeddedApphostPaths.Filename)%(_EmbeddedApphostPaths.Extension)</RelativePath>
+      </ResolvedFileToPublish >
     </ItemGroup>
 
   </Target>
@@ -634,10 +640,36 @@ Copyright (c) .NET Foundation. All rights reserved.
       <ResolvedFileToPublish Include="%(NativeAppHostNETCore.Identity)">
         <RelativePath>$(AssemblyName)$(_NativeExecutableExtension)</RelativePath>
       </ResolvedFileToPublish>
-      
+
 
     </ItemGroup>
 
   </Target>
 
+  <!--
+    ============================================================
+                                        ComputeEmbeddedApphostPaths
+
+    When no build flag is set, EmbeddedApphostPaths is not available. Compute EmbeddedApphostPaths is required to find build asset.
+    ============================================================
+    -->
+
+  <UsingTask TaskName="Microsoft.NET.Build.Tasks.GetEmbeddedApphostPaths"
+          AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
+  <Target Name="ComputeEmbeddedApphostPaths">
+
+    <ItemGroup>
+      <_PackAsToolShimRuntimeIdentifiers Include="$(PackAsToolShimRuntimeIdentifiers)"/>
+    </ItemGroup>
+
+    <GetEmbeddedApphostPaths
+      PackagedShimOutputDirectory="$(OutDir)/shims/$(TargetFramework)"
+      ShimRuntimeIdentifiers="@(_PackAsToolShimRuntimeIdentifiers)"
+      ToolCommandName="$(ToolCommandName)"
+      >
+
+      <Output TaskParameter="EmbeddedApphostPaths" ItemName="_EmbeddedApphostPaths" />
+    </GetEmbeddedApphostPaths>
+
+  </Target>
 </Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.PackageDependencyResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.PackageDependencyResolution.targets
@@ -195,6 +195,10 @@ Copyright (c) .NET Foundation. All rights reserved.
       <EnsureRuntimePackageDependencies>true</EnsureRuntimePackageDependencies>
     </PropertyGroup>
 
+    <ItemGroup>
+      <_PackAsToolShimRuntimeIdentifiers Include="$(PackAsToolShimRuntimeIdentifiers)"/>
+    </ItemGroup>
+
     <ResolvePackageAssets 
       ProjectAssetsFile="$(ProjectAssetsFile)"
       ProjectAssetsCacheFile="$(ProjectAssetsCacheFile)"
@@ -207,6 +211,8 @@ Copyright (c) .NET Foundation. All rights reserved.
       DisablePackageAssetsCache="$(DisablePackageAssetsCache)"
       DisableFrameworkAssemblies="$(DisableLockFileFrameworks)"
       DisableTransitiveProjectReferences="$(DisableTransitiveProjectReferences)"
+      DotNetAppHostExecutableNameWithoutExtension="$(_DotNetAppHostExecutableNameWithoutExtension)"
+      ShimRuntimeIdentifiers="@(_PackAsToolShimRuntimeIdentifiers)"
       EnsureRuntimePackageDependencies="$(EnsureRuntimePackageDependencies)"
       VerifyMatchingImplicitPackageVersion="$(VerifyMatchingImplicitPackageVersion)"
       ExpectedPlatformPackages="@(ExpectedPlatformPackages)"      
@@ -215,6 +221,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       <!-- NOTE: items names here are inconsistent because they match prior implementation
           (that was spread across different tasks/targets) for backwards compatibility.  -->
       <Output TaskParameter="Analyzers" ItemName="ResolvedAnalyzers" />
+      <Output TaskParameter="ApphostsForShimRuntimeIdentifiers" ItemName="_ApphostsForShimRuntimeIdentifiers" />
       <Output TaskParameter="ContentFilesToPreprocess" ItemName="_ContentFilesToPreprocess" />
       <Output TaskParameter="FrameworkAssemblies" ItemName="ResolvedFrameworkAssemblies" />
       <Output TaskParameter="NativeLibraries" ItemName="NativeCopyLocalItems" />

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAToolProjectWithPackagedShim.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAToolProjectWithPackagedShim.cs
@@ -1,0 +1,77 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Microsoft.NET.TestFramework;
+using Microsoft.NET.TestFramework.Assertions;
+using Microsoft.NET.TestFramework.Commands;
+using FluentAssertions;
+using Xunit;
+using Xunit.Abstractions;
+using NuGet.Packaging;
+using System.Xml.Linq;
+using System.Runtime.CompilerServices;
+using System;
+using NuGet.Frameworks;
+
+namespace Microsoft.NET.ToolPack.Tests
+{
+    public class GivenThatWeWantToPublishAToolProjectWithPackagedShim : SdkTest
+    {
+        private const string _customToolCommandName = "customToolCommandName";
+
+        public GivenThatWeWantToPublishAToolProjectWithPackagedShim(ITestOutputHelper log) : base(log)
+        {
+        }
+
+        private TestAsset SetupTestAsset([CallerMemberName] string callingMethod = "")
+        {
+            TestAsset helloWorldAsset = _testAssetsManager
+                .CopyTestAsset("PortableTool", callingMethod)
+                .WithSource()
+                .WithProjectChanges(project =>
+                {
+                    XNamespace ns = project.Root.Name.Namespace;
+                    XElement propertyGroup = project.Root.Elements(ns + "PropertyGroup").First();
+                    propertyGroup.Add(new XElement(ns + "PackAsToolShimRuntimeIdentifiers", "win-x64;osx.10.12-x64"));
+                    propertyGroup.Add(new XElement(ns + "ToolCommandName", _customToolCommandName));
+                })
+                .Restore(Log);
+
+            return helloWorldAsset;
+        }
+
+        [Fact]
+        public void It_contains_dependencies_shims()
+        {
+            var testAsset = SetupTestAsset();
+            var publishCommand = new PublishCommand(Log, testAsset.TestRoot);
+
+            publishCommand.Execute();
+
+            publishCommand.GetOutputDirectory(targetFramework: "netcoreapp2.1")
+                .Sub("shims")
+                .Sub("win-x64")
+                .EnumerateFiles().Should().Contain(f => f.Name == _customToolCommandName + ".exe");
+        }
+
+        [Fact]
+        public void It_contains_dependencies_shims_with_no_build()
+        {
+            var testAsset = SetupTestAsset();
+            var buildCommand = new BuildCommand(Log, testAsset.TestRoot);
+            buildCommand.Execute();
+
+            var publishCommand = new PublishCommand(Log, testAsset.TestRoot);
+
+            publishCommand.Execute("/p:NoBuild=true");
+
+            publishCommand.GetOutputDirectory(targetFramework: "netcoreapp2.1")
+                .Sub("shims")
+                .Sub("win-x64")
+                .EnumerateFiles().Should().Contain(f => f.Name == _customToolCommandName + ".exe");
+        }
+    }
+}

--- a/src/Tests/Microsoft.NET.ToolPack.Tests/GivenThatWeWantToPackAToolProjectWithPackagedShim.cs
+++ b/src/Tests/Microsoft.NET.ToolPack.Tests/GivenThatWeWantToPackAToolProjectWithPackagedShim.cs
@@ -31,8 +31,22 @@ namespace Microsoft.NET.ToolPack.Tests
 
         private string SetupNuGetPackage(bool multiTarget, [CallerMemberName] string callingMethod = "")
         {
-            TestAsset helloWorldAsset = _testAssetsManager
-                .CopyTestAsset("PortableTool", callingMethod + multiTarget)
+            TestAsset helloWorldAsset = CreateTestAsset(multiTarget, callingMethod);
+
+            _testRoot = helloWorldAsset.TestRoot;
+
+            var packCommand = new PackCommand(Log, helloWorldAsset.TestRoot);
+
+            packCommand.Execute();
+            _packageId = Path.GetFileNameWithoutExtension(packCommand.ProjectFile);
+
+            return packCommand.GetNuGetPackage();
+        }
+
+        private TestAsset CreateTestAsset(bool multiTarget, string uniqueName)
+        {
+            return _testAssetsManager
+                .CopyTestAsset("PortableTool", uniqueName)
                 .WithSource()
                 .WithProjectChanges(project =>
                 {
@@ -48,15 +62,6 @@ namespace Microsoft.NET.ToolPack.Tests
                     }
                 })
                 .Restore(Log);
-
-            _testRoot = helloWorldAsset.TestRoot;
-
-            var packCommand = new PackCommand(Log, helloWorldAsset.TestRoot);
-
-            packCommand.Execute();
-            _packageId = Path.GetFileNameWithoutExtension(packCommand.ProjectFile);
-
-            return packCommand.GetNuGetPackage();
         }
 
         [Theory]
@@ -149,6 +154,37 @@ namespace Microsoft.NET.ToolPack.Tests
             File.Exists(windowShimPath).Should().BeTrue($"Shim {windowShimPath} should exist");
             string osxShimPath = Path.Combine(shimoutputPath, $"shims/netcoreapp2.1/osx.10.12-x64/{_customToolCommandName}");
             File.Exists(osxShimPath).Should().BeTrue($"Shim {osxShimPath} should exist");
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void It_contains_shim_with_no_build(bool multiTarget)
+        {
+            var testAsset = CreateTestAsset(multiTarget, "shim_with_no_build" + multiTarget);
+
+            var buildCommand = new BuildCommand(Log, testAsset.TestRoot);
+            buildCommand.Execute();
+
+            var packCommand = new PackCommand(Log, testAsset.TestRoot);
+
+            packCommand.Execute("/p:NoBuild=true");
+            var nugetPackage = packCommand.GetNuGetPackage();
+
+            using (var nupkgReader = new PackageArchiveReader(nugetPackage))
+            {
+                IEnumerable<NuGetFramework> supportedFrameworks = nupkgReader.GetSupportedFrameworks();
+                supportedFrameworks.Should().NotBeEmpty();
+
+                foreach (NuGetFramework framework in supportedFrameworks)
+                {
+                    var allItems = nupkgReader.GetToolItems().SelectMany(i => i.Items).ToList();
+                    allItems.Should().Contain($"tools/{framework.GetShortFolderName()}/any/shims/win-x64/{_customToolCommandName}.exe",
+                        "Name should be the same as the command name even customized");
+                    allItems.Should().Contain($"tools/{framework.GetShortFolderName()}/any/shims/osx.10.12-x64/{_customToolCommandName}",
+                        "RID should be the exact match of the RID in the property, even Apphost only has version of win, osx and linux");
+                }
+            }
         }
 
         [WindowsOnlyTheory]


### PR DESCRIPTION
Continue of https://github.com/dotnet/sdk/pull/2366

problem i know so far

* pending the solution to use cached asset file

It supports Clean target. However, it will not remove empty folder. Since different RID's shims have the same name. I need to separate them by folder. But msbuild will not remove that https://github.com/Microsoft/msbuild/issues/2408