### PR TITLE
Add netcoreapp2.2 to supported framework list

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.SupportedTargetFrameworks.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.SupportedTargetFrameworks.props
@@ -23,6 +23,7 @@ Copyright (c) .NET Foundation. All rights reserved.
         <SupportedTargetFramework Include=".NETCoreApp,Version=v1.1" DisplayName=".NET Core 1.1" />
         <SupportedTargetFramework Include=".NETCoreApp,Version=v2.0" DisplayName=".NET Core 2.0" />
         <SupportedTargetFramework Include=".NETCoreApp,Version=v2.1" DisplayName=".NET Core 2.1" />
+        <SupportedTargetFramework Include=".NETCoreApp,Version=v2.2" DisplayName=".NET Core 2.2" />
     </ItemGroup>
 
     <!-- .NET Standard -->

--- a/src/Tests/Microsoft.NET.Build.Tests/GiventThatWeManifestSupportedFrameworks.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GiventThatWeManifestSupportedFrameworks.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using FluentAssertions;
+using Microsoft.NET.Build.Tasks;
+using Microsoft.NET.TestFramework;
+using Microsoft.NET.TestFramework.Assertions;
+using Microsoft.NET.TestFramework.Commands;
+using Microsoft.NET.TestFramework.ProjectConstruction;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.NET.Build.Tests
+{
+    public class GiventThatWeManifestSupportedFrameworks : SdkTest
+    {
+        public GiventThatWeManifestSupportedFrameworks(ITestOutputHelper log) : base(log)
+        {
+        }
+
+        [Theory]
+        [InlineData(".NETCoreApp")]
+        [InlineData(".NETStandard")]
+        public void TheMaximumVersionsAreSupported(string targetFrameworkIdentifier)
+        {
+            var project = new TestProject
+            {
+                Name = "packagethatwillgomissing",
+                TargetFrameworks = targetFrameworkIdentifier ==  ".NETCoreApp" ? "netcoreapp2.0" : "netstandard2.0",
+                IsSdkProject = true,
+            };
+
+            TestAsset asset = _testAssetsManager
+                .CreateTestProject(project, identifier: targetFrameworkIdentifier);
+
+            string testDirectory = Path.Combine(asset.TestRoot, project.Name);
+
+            var getMaximumVersion = new GetValuesCommand(
+                Log, 
+                testDirectory, 
+                project.TargetFrameworks, 
+                targetFrameworkIdentifier.Substring(1) + "MaximumVersion",
+                GetValuesCommand.ValueType.Property);
+
+             var getSupportedFrameworks = new GetValuesCommand(
+                Log,
+                testDirectory,
+                project.TargetFrameworks,
+                "SupportedTargetFramework",
+                GetValuesCommand.ValueType.Item);
+
+            getMaximumVersion.DependsOnTargets = "";
+            getMaximumVersion.Execute().Should().Pass();
+
+            getSupportedFrameworks.DependsOnTargets = "";
+            getSupportedFrameworks.Execute().Should().Pass();
+
+            string maximumVersion = getMaximumVersion.GetValues().Single();
+            List<string> supportedFrameworks = getSupportedFrameworks.GetValues();
+
+            supportedFrameworks.Should().Contain($"{targetFrameworkIdentifier},Version=v{maximumVersion}");
+        }
+    }
+}


### PR DESCRIPTION
Also add test that maximum netcoreapp/netstandard versions are in list. We tend to fix the maximum version every time without remembering to update the supported list. This should prevent that in future releases.

Fix https://devdiv.visualstudio.com/DevDiv/_workitems/edit/655213