### PR TITLE
Implement a workaround for DefaultProjectTypeGuid and cross-targeting.

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.CrossTargeting.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.CrossTargeting.targets
@@ -105,4 +105,11 @@ Copyright (c) .NET Foundation. All rights reserved.
   -->
   <Target Name="GetPackagingOutputs" />
 
+  <!-- This exists as a workaround for https://github.com/Microsoft/msbuild/issues/3558 -->
+  <PropertyGroup Condition="'$(DefaultProjectTypeGuid)' == ''">
+    <DefaultProjectTypeGuid Condition="'$(MSBuildProjectExtension)' == '.csproj'">{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</DefaultProjectTypeGuid>
+    <DefaultProjectTypeGuid Condition="'$(MSBuildProjectExtension)' == '.vbproj'">{F184B08F-C81C-45F6-A57F-5ABD9991F28F}</DefaultProjectTypeGuid>
+    <!-- Note: F# sets DefaultProjectTypeGuid in the F# SDK -->
+  </PropertyGroup>
+
 </Project>


### PR DESCRIPTION
Currently MSBuild only sets the `DefaultProjectTypeGuid` property from the
language properties for a project that is not cross-targeting (it gets set on
the inner projects that are invoked for each target framework instead).  As a
result, `dotnet sln add` is currently not working for projects that
cross-target.

This commit implements a workaround until such a time that MSBuild can ensure
`DefaultProjectTypeGuid` is set via the language-specific cross-targeting
targets.

See https://github.com/Microsoft/msbuild/issues/3558 for the issue tracking the
fix on the MSBuild side.

Fixes dotnet/cli#9477.