### PR TITLE
Fix cannot publish self contain twice

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/EmbedAppNameInHost.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/EmbedAppNameInHost.cs
@@ -31,10 +31,13 @@ namespace Microsoft.NET.Build.Tasks
             var destinationDirectory = Path.GetFullPath(AppHostDestinationDirectoryPath);
             ModifiedAppHostPath = Path.Combine(destinationDirectory, $"{appbaseName}{hostExtension}");
 
-            AppHost.Create(
-                AppHostSourcePath,
-                ModifiedAppHostPath,
-                AppBinaryName);
+            if (!File.Exists(ModifiedAppHostPath))
+            {
+                AppHost.Create(
+                    AppHostSourcePath,
+                    ModifiedAppHostPath,
+                    AppBinaryName);
+            }
         }
     }
 }


### PR DESCRIPTION
Fix https://github.com/dotnet/sdk/issues/2466

Introduced by this #2239

AppHost.Create will not skip when file exists. However, old the call site is not changed to encounter that. And I didn't add test coverage before changing the old code