### PR TITLE
Add ability to mark self-contained .exe as Windows GUI program.

### DIFF
--- a/src/Tasks/Common/Resources/Strings.resx
+++ b/src/Tasks/Common/Resources/Strings.resx
@@ -406,7 +406,7 @@ The following are names of parameters or literal values and should not be transl
     <comment>{StrBegin="NETSDK1071: "}</comment>
   </data>
   <data name="AppHostNotWindowsCLI" xml:space="preserve">
-    <value>NETSDK1072: Unable to use '{0}' as application host executable because it's not a Windows executable for teh CUI subsystem.</value>
+    <value>NETSDK1072: Unable to use '{0}' as application host executable because it's not a Windows executable for the CUI (Console) subsystem.</value>
     <comment>{StrBegin="NETSDK1072: "}</comment>
   </data>
 </root>

--- a/src/Tasks/Common/Resources/Strings.resx
+++ b/src/Tasks/Common/Resources/Strings.resx
@@ -401,4 +401,12 @@ The following are names of parameters or literal values and should not be transl
     <value>NETSDK1070: The application configuration file must have root configuration element.</value>
     <comment>{StrBegin="NETSDK1070: "}</comment>
   </data>
+  <data name="AppHostNotWindows" xml:space="preserve">
+    <value>NETSDK1071: Unable to use '{0}' as application host executable because it's not a Windows PE file.</value>
+    <comment>{StrBegin="NETSDK1071: "}</comment>
+  </data>
+  <data name="AppHostNotWindowsCLI" xml:space="preserve">
+    <value>NETSDK1072: Unable to use '{0}' as application host executable because it's not a Windows executable for teh CUI subsystem.</value>
+    <comment>{StrBegin="NETSDK1072: "}</comment>
+  </data>
 </root>

--- a/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../Strings.resx">
     <body>
+      <trans-unit id="AppHostNotWindows">
+        <source>NETSDK1071: Unable to use '{0}' as application host executable because it's not a Windows PE file.</source>
+        <target state="new">NETSDK1071: Unable to use '{0}' as application host executable because it's not a Windows PE file.</target>
+        <note>{StrBegin="NETSDK1071: "}</note>
+      </trans-unit>
+      <trans-unit id="AppHostNotWindowsCLI">
+        <source>NETSDK1072: Unable to use '{0}' as application host executable because it's not a Windows executable for teh CUI subsystem.</source>
+        <target state="new">NETSDK1072: Unable to use '{0}' as application host executable because it's not a Windows executable for teh CUI subsystem.</target>
+        <note>{StrBegin="NETSDK1072: "}</note>
+      </trans-unit>
       <trans-unit id="AppConfigRequiresRootConfiguration">
         <source>NETSDK1070: The application configuration file must have root configuration element.</source>
         <target state="new">NETSDK1070: The application configuration file must have root configuration element.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
@@ -8,8 +8,8 @@
         <note>{StrBegin="NETSDK1071: "}</note>
       </trans-unit>
       <trans-unit id="AppHostNotWindowsCLI">
-        <source>NETSDK1072: Unable to use '{0}' as application host executable because it's not a Windows executable for teh CUI subsystem.</source>
-        <target state="new">NETSDK1072: Unable to use '{0}' as application host executable because it's not a Windows executable for teh CUI subsystem.</target>
+        <source>NETSDK1072: Unable to use '{0}' as application host executable because it's not a Windows executable for the CUI (Console) subsystem.</source>
+        <target state="new">NETSDK1072: Unable to use '{0}' as application host executable because it's not a Windows executable for the CUI (Console) subsystem.</target>
         <note>{StrBegin="NETSDK1072: "}</note>
       </trans-unit>
       <trans-unit id="AppConfigRequiresRootConfiguration">

--- a/src/Tasks/Common/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.de.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../Strings.resx">
     <body>
+      <trans-unit id="AppHostNotWindows">
+        <source>NETSDK1071: Unable to use '{0}' as application host executable because it's not a Windows PE file.</source>
+        <target state="new">NETSDK1071: Unable to use '{0}' as application host executable because it's not a Windows PE file.</target>
+        <note>{StrBegin="NETSDK1071: "}</note>
+      </trans-unit>
+      <trans-unit id="AppHostNotWindowsCLI">
+        <source>NETSDK1072: Unable to use '{0}' as application host executable because it's not a Windows executable for teh CUI subsystem.</source>
+        <target state="new">NETSDK1072: Unable to use '{0}' as application host executable because it's not a Windows executable for teh CUI subsystem.</target>
+        <note>{StrBegin="NETSDK1072: "}</note>
+      </trans-unit>
       <trans-unit id="AppConfigRequiresRootConfiguration">
         <source>NETSDK1070: The application configuration file must have root configuration element.</source>
         <target state="new">NETSDK1070: The application configuration file must have root configuration element.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.de.xlf
@@ -8,8 +8,8 @@
         <note>{StrBegin="NETSDK1071: "}</note>
       </trans-unit>
       <trans-unit id="AppHostNotWindowsCLI">
-        <source>NETSDK1072: Unable to use '{0}' as application host executable because it's not a Windows executable for teh CUI subsystem.</source>
-        <target state="new">NETSDK1072: Unable to use '{0}' as application host executable because it's not a Windows executable for teh CUI subsystem.</target>
+        <source>NETSDK1072: Unable to use '{0}' as application host executable because it's not a Windows executable for the CUI (Console) subsystem.</source>
+        <target state="new">NETSDK1072: Unable to use '{0}' as application host executable because it's not a Windows executable for the CUI (Console) subsystem.</target>
         <note>{StrBegin="NETSDK1072: "}</note>
       </trans-unit>
       <trans-unit id="AppConfigRequiresRootConfiguration">

--- a/src/Tasks/Common/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.es.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../Strings.resx">
     <body>
+      <trans-unit id="AppHostNotWindows">
+        <source>NETSDK1071: Unable to use '{0}' as application host executable because it's not a Windows PE file.</source>
+        <target state="new">NETSDK1071: Unable to use '{0}' as application host executable because it's not a Windows PE file.</target>
+        <note>{StrBegin="NETSDK1071: "}</note>
+      </trans-unit>
+      <trans-unit id="AppHostNotWindowsCLI">
+        <source>NETSDK1072: Unable to use '{0}' as application host executable because it's not a Windows executable for teh CUI subsystem.</source>
+        <target state="new">NETSDK1072: Unable to use '{0}' as application host executable because it's not a Windows executable for teh CUI subsystem.</target>
+        <note>{StrBegin="NETSDK1072: "}</note>
+      </trans-unit>
       <trans-unit id="AppConfigRequiresRootConfiguration">
         <source>NETSDK1070: The application configuration file must have root configuration element.</source>
         <target state="new">NETSDK1070: The application configuration file must have root configuration element.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.es.xlf
@@ -8,8 +8,8 @@
         <note>{StrBegin="NETSDK1071: "}</note>
       </trans-unit>
       <trans-unit id="AppHostNotWindowsCLI">
-        <source>NETSDK1072: Unable to use '{0}' as application host executable because it's not a Windows executable for teh CUI subsystem.</source>
-        <target state="new">NETSDK1072: Unable to use '{0}' as application host executable because it's not a Windows executable for teh CUI subsystem.</target>
+        <source>NETSDK1072: Unable to use '{0}' as application host executable because it's not a Windows executable for the CUI (Console) subsystem.</source>
+        <target state="new">NETSDK1072: Unable to use '{0}' as application host executable because it's not a Windows executable for the CUI (Console) subsystem.</target>
         <note>{StrBegin="NETSDK1072: "}</note>
       </trans-unit>
       <trans-unit id="AppConfigRequiresRootConfiguration">

--- a/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../Strings.resx">
     <body>
+      <trans-unit id="AppHostNotWindows">
+        <source>NETSDK1071: Unable to use '{0}' as application host executable because it's not a Windows PE file.</source>
+        <target state="new">NETSDK1071: Unable to use '{0}' as application host executable because it's not a Windows PE file.</target>
+        <note>{StrBegin="NETSDK1071: "}</note>
+      </trans-unit>
+      <trans-unit id="AppHostNotWindowsCLI">
+        <source>NETSDK1072: Unable to use '{0}' as application host executable because it's not a Windows executable for teh CUI subsystem.</source>
+        <target state="new">NETSDK1072: Unable to use '{0}' as application host executable because it's not a Windows executable for teh CUI subsystem.</target>
+        <note>{StrBegin="NETSDK1072: "}</note>
+      </trans-unit>
       <trans-unit id="AppConfigRequiresRootConfiguration">
         <source>NETSDK1070: The application configuration file must have root configuration element.</source>
         <target state="new">NETSDK1070: The application configuration file must have root configuration element.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
@@ -8,8 +8,8 @@
         <note>{StrBegin="NETSDK1071: "}</note>
       </trans-unit>
       <trans-unit id="AppHostNotWindowsCLI">
-        <source>NETSDK1072: Unable to use '{0}' as application host executable because it's not a Windows executable for teh CUI subsystem.</source>
-        <target state="new">NETSDK1072: Unable to use '{0}' as application host executable because it's not a Windows executable for teh CUI subsystem.</target>
+        <source>NETSDK1072: Unable to use '{0}' as application host executable because it's not a Windows executable for the CUI (Console) subsystem.</source>
+        <target state="new">NETSDK1072: Unable to use '{0}' as application host executable because it's not a Windows executable for the CUI (Console) subsystem.</target>
         <note>{StrBegin="NETSDK1072: "}</note>
       </trans-unit>
       <trans-unit id="AppConfigRequiresRootConfiguration">

--- a/src/Tasks/Common/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.it.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../Strings.resx">
     <body>
+      <trans-unit id="AppHostNotWindows">
+        <source>NETSDK1071: Unable to use '{0}' as application host executable because it's not a Windows PE file.</source>
+        <target state="new">NETSDK1071: Unable to use '{0}' as application host executable because it's not a Windows PE file.</target>
+        <note>{StrBegin="NETSDK1071: "}</note>
+      </trans-unit>
+      <trans-unit id="AppHostNotWindowsCLI">
+        <source>NETSDK1072: Unable to use '{0}' as application host executable because it's not a Windows executable for teh CUI subsystem.</source>
+        <target state="new">NETSDK1072: Unable to use '{0}' as application host executable because it's not a Windows executable for teh CUI subsystem.</target>
+        <note>{StrBegin="NETSDK1072: "}</note>
+      </trans-unit>
       <trans-unit id="AppConfigRequiresRootConfiguration">
         <source>NETSDK1070: The application configuration file must have root configuration element.</source>
         <target state="new">NETSDK1070: The application configuration file must have root configuration element.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.it.xlf
@@ -8,8 +8,8 @@
         <note>{StrBegin="NETSDK1071: "}</note>
       </trans-unit>
       <trans-unit id="AppHostNotWindowsCLI">
-        <source>NETSDK1072: Unable to use '{0}' as application host executable because it's not a Windows executable for teh CUI subsystem.</source>
-        <target state="new">NETSDK1072: Unable to use '{0}' as application host executable because it's not a Windows executable for teh CUI subsystem.</target>
+        <source>NETSDK1072: Unable to use '{0}' as application host executable because it's not a Windows executable for the CUI (Console) subsystem.</source>
+        <target state="new">NETSDK1072: Unable to use '{0}' as application host executable because it's not a Windows executable for the CUI (Console) subsystem.</target>
         <note>{StrBegin="NETSDK1072: "}</note>
       </trans-unit>
       <trans-unit id="AppConfigRequiresRootConfiguration">

--- a/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../Strings.resx">
     <body>
+      <trans-unit id="AppHostNotWindows">
+        <source>NETSDK1071: Unable to use '{0}' as application host executable because it's not a Windows PE file.</source>
+        <target state="new">NETSDK1071: Unable to use '{0}' as application host executable because it's not a Windows PE file.</target>
+        <note>{StrBegin="NETSDK1071: "}</note>
+      </trans-unit>
+      <trans-unit id="AppHostNotWindowsCLI">
+        <source>NETSDK1072: Unable to use '{0}' as application host executable because it's not a Windows executable for teh CUI subsystem.</source>
+        <target state="new">NETSDK1072: Unable to use '{0}' as application host executable because it's not a Windows executable for teh CUI subsystem.</target>
+        <note>{StrBegin="NETSDK1072: "}</note>
+      </trans-unit>
       <trans-unit id="AppConfigRequiresRootConfiguration">
         <source>NETSDK1070: The application configuration file must have root configuration element.</source>
         <target state="new">NETSDK1070: The application configuration file must have root configuration element.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
@@ -8,8 +8,8 @@
         <note>{StrBegin="NETSDK1071: "}</note>
       </trans-unit>
       <trans-unit id="AppHostNotWindowsCLI">
-        <source>NETSDK1072: Unable to use '{0}' as application host executable because it's not a Windows executable for teh CUI subsystem.</source>
-        <target state="new">NETSDK1072: Unable to use '{0}' as application host executable because it's not a Windows executable for teh CUI subsystem.</target>
+        <source>NETSDK1072: Unable to use '{0}' as application host executable because it's not a Windows executable for the CUI (Console) subsystem.</source>
+        <target state="new">NETSDK1072: Unable to use '{0}' as application host executable because it's not a Windows executable for the CUI (Console) subsystem.</target>
         <note>{StrBegin="NETSDK1072: "}</note>
       </trans-unit>
       <trans-unit id="AppConfigRequiresRootConfiguration">

--- a/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../Strings.resx">
     <body>
+      <trans-unit id="AppHostNotWindows">
+        <source>NETSDK1071: Unable to use '{0}' as application host executable because it's not a Windows PE file.</source>
+        <target state="new">NETSDK1071: Unable to use '{0}' as application host executable because it's not a Windows PE file.</target>
+        <note>{StrBegin="NETSDK1071: "}</note>
+      </trans-unit>
+      <trans-unit id="AppHostNotWindowsCLI">
+        <source>NETSDK1072: Unable to use '{0}' as application host executable because it's not a Windows executable for teh CUI subsystem.</source>
+        <target state="new">NETSDK1072: Unable to use '{0}' as application host executable because it's not a Windows executable for teh CUI subsystem.</target>
+        <note>{StrBegin="NETSDK1072: "}</note>
+      </trans-unit>
       <trans-unit id="AppConfigRequiresRootConfiguration">
         <source>NETSDK1070: The application configuration file must have root configuration element.</source>
         <target state="new">NETSDK1070: The application configuration file must have root configuration element.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
@@ -8,8 +8,8 @@
         <note>{StrBegin="NETSDK1071: "}</note>
       </trans-unit>
       <trans-unit id="AppHostNotWindowsCLI">
-        <source>NETSDK1072: Unable to use '{0}' as application host executable because it's not a Windows executable for teh CUI subsystem.</source>
-        <target state="new">NETSDK1072: Unable to use '{0}' as application host executable because it's not a Windows executable for teh CUI subsystem.</target>
+        <source>NETSDK1072: Unable to use '{0}' as application host executable because it's not a Windows executable for the CUI (Console) subsystem.</source>
+        <target state="new">NETSDK1072: Unable to use '{0}' as application host executable because it's not a Windows executable for the CUI (Console) subsystem.</target>
         <note>{StrBegin="NETSDK1072: "}</note>
       </trans-unit>
       <trans-unit id="AppConfigRequiresRootConfiguration">

--- a/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../Strings.resx">
     <body>
+      <trans-unit id="AppHostNotWindows">
+        <source>NETSDK1071: Unable to use '{0}' as application host executable because it's not a Windows PE file.</source>
+        <target state="new">NETSDK1071: Unable to use '{0}' as application host executable because it's not a Windows PE file.</target>
+        <note>{StrBegin="NETSDK1071: "}</note>
+      </trans-unit>
+      <trans-unit id="AppHostNotWindowsCLI">
+        <source>NETSDK1072: Unable to use '{0}' as application host executable because it's not a Windows executable for teh CUI subsystem.</source>
+        <target state="new">NETSDK1072: Unable to use '{0}' as application host executable because it's not a Windows executable for teh CUI subsystem.</target>
+        <note>{StrBegin="NETSDK1072: "}</note>
+      </trans-unit>
       <trans-unit id="AppConfigRequiresRootConfiguration">
         <source>NETSDK1070: The application configuration file must have root configuration element.</source>
         <target state="new">NETSDK1070: The application configuration file must have root configuration element.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
@@ -8,8 +8,8 @@
         <note>{StrBegin="NETSDK1071: "}</note>
       </trans-unit>
       <trans-unit id="AppHostNotWindowsCLI">
-        <source>NETSDK1072: Unable to use '{0}' as application host executable because it's not a Windows executable for teh CUI subsystem.</source>
-        <target state="new">NETSDK1072: Unable to use '{0}' as application host executable because it's not a Windows executable for teh CUI subsystem.</target>
+        <source>NETSDK1072: Unable to use '{0}' as application host executable because it's not a Windows executable for the CUI (Console) subsystem.</source>
+        <target state="new">NETSDK1072: Unable to use '{0}' as application host executable because it's not a Windows executable for the CUI (Console) subsystem.</target>
         <note>{StrBegin="NETSDK1072: "}</note>
       </trans-unit>
       <trans-unit id="AppConfigRequiresRootConfiguration">

--- a/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../Strings.resx">
     <body>
+      <trans-unit id="AppHostNotWindows">
+        <source>NETSDK1071: Unable to use '{0}' as application host executable because it's not a Windows PE file.</source>
+        <target state="new">NETSDK1071: Unable to use '{0}' as application host executable because it's not a Windows PE file.</target>
+        <note>{StrBegin="NETSDK1071: "}</note>
+      </trans-unit>
+      <trans-unit id="AppHostNotWindowsCLI">
+        <source>NETSDK1072: Unable to use '{0}' as application host executable because it's not a Windows executable for teh CUI subsystem.</source>
+        <target state="new">NETSDK1072: Unable to use '{0}' as application host executable because it's not a Windows executable for teh CUI subsystem.</target>
+        <note>{StrBegin="NETSDK1072: "}</note>
+      </trans-unit>
       <trans-unit id="AppConfigRequiresRootConfiguration">
         <source>NETSDK1070: The application configuration file must have root configuration element.</source>
         <target state="new">NETSDK1070: The application configuration file must have root configuration element.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
@@ -8,8 +8,8 @@
         <note>{StrBegin="NETSDK1071: "}</note>
       </trans-unit>
       <trans-unit id="AppHostNotWindowsCLI">
-        <source>NETSDK1072: Unable to use '{0}' as application host executable because it's not a Windows executable for teh CUI subsystem.</source>
-        <target state="new">NETSDK1072: Unable to use '{0}' as application host executable because it's not a Windows executable for teh CUI subsystem.</target>
+        <source>NETSDK1072: Unable to use '{0}' as application host executable because it's not a Windows executable for the CUI (Console) subsystem.</source>
+        <target state="new">NETSDK1072: Unable to use '{0}' as application host executable because it's not a Windows executable for the CUI (Console) subsystem.</target>
         <note>{StrBegin="NETSDK1072: "}</note>
       </trans-unit>
       <trans-unit id="AppConfigRequiresRootConfiguration">

--- a/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../Strings.resx">
     <body>
+      <trans-unit id="AppHostNotWindows">
+        <source>NETSDK1071: Unable to use '{0}' as application host executable because it's not a Windows PE file.</source>
+        <target state="new">NETSDK1071: Unable to use '{0}' as application host executable because it's not a Windows PE file.</target>
+        <note>{StrBegin="NETSDK1071: "}</note>
+      </trans-unit>
+      <trans-unit id="AppHostNotWindowsCLI">
+        <source>NETSDK1072: Unable to use '{0}' as application host executable because it's not a Windows executable for teh CUI subsystem.</source>
+        <target state="new">NETSDK1072: Unable to use '{0}' as application host executable because it's not a Windows executable for teh CUI subsystem.</target>
+        <note>{StrBegin="NETSDK1072: "}</note>
+      </trans-unit>
       <trans-unit id="AppConfigRequiresRootConfiguration">
         <source>NETSDK1070: The application configuration file must have root configuration element.</source>
         <target state="new">NETSDK1070: The application configuration file must have root configuration element.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
@@ -8,8 +8,8 @@
         <note>{StrBegin="NETSDK1071: "}</note>
       </trans-unit>
       <trans-unit id="AppHostNotWindowsCLI">
-        <source>NETSDK1072: Unable to use '{0}' as application host executable because it's not a Windows executable for teh CUI subsystem.</source>
-        <target state="new">NETSDK1072: Unable to use '{0}' as application host executable because it's not a Windows executable for teh CUI subsystem.</target>
+        <source>NETSDK1072: Unable to use '{0}' as application host executable because it's not a Windows executable for the CUI (Console) subsystem.</source>
+        <target state="new">NETSDK1072: Unable to use '{0}' as application host executable because it's not a Windows executable for the CUI (Console) subsystem.</target>
         <note>{StrBegin="NETSDK1072: "}</note>
       </trans-unit>
       <trans-unit id="AppConfigRequiresRootConfiguration">

--- a/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../Strings.resx">
     <body>
+      <trans-unit id="AppHostNotWindows">
+        <source>NETSDK1071: Unable to use '{0}' as application host executable because it's not a Windows PE file.</source>
+        <target state="new">NETSDK1071: Unable to use '{0}' as application host executable because it's not a Windows PE file.</target>
+        <note>{StrBegin="NETSDK1071: "}</note>
+      </trans-unit>
+      <trans-unit id="AppHostNotWindowsCLI">
+        <source>NETSDK1072: Unable to use '{0}' as application host executable because it's not a Windows executable for teh CUI subsystem.</source>
+        <target state="new">NETSDK1072: Unable to use '{0}' as application host executable because it's not a Windows executable for teh CUI subsystem.</target>
+        <note>{StrBegin="NETSDK1072: "}</note>
+      </trans-unit>
       <trans-unit id="AppConfigRequiresRootConfiguration">
         <source>NETSDK1070: The application configuration file must have root configuration element.</source>
         <target state="new">NETSDK1070: The application configuration file must have root configuration element.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
@@ -8,8 +8,8 @@
         <note>{StrBegin="NETSDK1071: "}</note>
       </trans-unit>
       <trans-unit id="AppHostNotWindowsCLI">
-        <source>NETSDK1072: Unable to use '{0}' as application host executable because it's not a Windows executable for teh CUI subsystem.</source>
-        <target state="new">NETSDK1072: Unable to use '{0}' as application host executable because it's not a Windows executable for teh CUI subsystem.</target>
+        <source>NETSDK1072: Unable to use '{0}' as application host executable because it's not a Windows executable for the CUI (Console) subsystem.</source>
+        <target state="new">NETSDK1072: Unable to use '{0}' as application host executable because it's not a Windows executable for the CUI (Console) subsystem.</target>
         <note>{StrBegin="NETSDK1072: "}</note>
       </trans-unit>
       <trans-unit id="AppConfigRequiresRootConfiguration">

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../Strings.resx">
     <body>
+      <trans-unit id="AppHostNotWindows">
+        <source>NETSDK1071: Unable to use '{0}' as application host executable because it's not a Windows PE file.</source>
+        <target state="new">NETSDK1071: Unable to use '{0}' as application host executable because it's not a Windows PE file.</target>
+        <note>{StrBegin="NETSDK1071: "}</note>
+      </trans-unit>
+      <trans-unit id="AppHostNotWindowsCLI">
+        <source>NETSDK1072: Unable to use '{0}' as application host executable because it's not a Windows executable for teh CUI subsystem.</source>
+        <target state="new">NETSDK1072: Unable to use '{0}' as application host executable because it's not a Windows executable for teh CUI subsystem.</target>
+        <note>{StrBegin="NETSDK1072: "}</note>
+      </trans-unit>
       <trans-unit id="AppConfigRequiresRootConfiguration">
         <source>NETSDK1070: The application configuration file must have root configuration element.</source>
         <target state="new">NETSDK1070: The application configuration file must have root configuration element.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
@@ -8,8 +8,8 @@
         <note>{StrBegin="NETSDK1071: "}</note>
       </trans-unit>
       <trans-unit id="AppHostNotWindowsCLI">
-        <source>NETSDK1072: Unable to use '{0}' as application host executable because it's not a Windows executable for teh CUI subsystem.</source>
-        <target state="new">NETSDK1072: Unable to use '{0}' as application host executable because it's not a Windows executable for teh CUI subsystem.</target>
+        <source>NETSDK1072: Unable to use '{0}' as application host executable because it's not a Windows executable for the CUI (Console) subsystem.</source>
+        <target state="new">NETSDK1072: Unable to use '{0}' as application host executable because it's not a Windows executable for the CUI (Console) subsystem.</target>
         <note>{StrBegin="NETSDK1072: "}</note>
       </trans-unit>
       <trans-unit id="AppConfigRequiresRootConfiguration">

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../Strings.resx">
     <body>
+      <trans-unit id="AppHostNotWindows">
+        <source>NETSDK1071: Unable to use '{0}' as application host executable because it's not a Windows PE file.</source>
+        <target state="new">NETSDK1071: Unable to use '{0}' as application host executable because it's not a Windows PE file.</target>
+        <note>{StrBegin="NETSDK1071: "}</note>
+      </trans-unit>
+      <trans-unit id="AppHostNotWindowsCLI">
+        <source>NETSDK1072: Unable to use '{0}' as application host executable because it's not a Windows executable for teh CUI subsystem.</source>
+        <target state="new">NETSDK1072: Unable to use '{0}' as application host executable because it's not a Windows executable for teh CUI subsystem.</target>
+        <note>{StrBegin="NETSDK1072: "}</note>
+      </trans-unit>
       <trans-unit id="AppConfigRequiresRootConfiguration">
         <source>NETSDK1070: The application configuration file must have root configuration element.</source>
         <target state="new">NETSDK1070: The application configuration file must have root configuration element.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
@@ -8,8 +8,8 @@
         <note>{StrBegin="NETSDK1071: "}</note>
       </trans-unit>
       <trans-unit id="AppHostNotWindowsCLI">
-        <source>NETSDK1072: Unable to use '{0}' as application host executable because it's not a Windows executable for teh CUI subsystem.</source>
-        <target state="new">NETSDK1072: Unable to use '{0}' as application host executable because it's not a Windows executable for teh CUI subsystem.</target>
+        <source>NETSDK1072: Unable to use '{0}' as application host executable because it's not a Windows executable for the CUI (Console) subsystem.</source>
+        <target state="new">NETSDK1072: Unable to use '{0}' as application host executable because it's not a Windows executable for the CUI (Console) subsystem.</target>
         <note>{StrBegin="NETSDK1072: "}</note>
       </trans-unit>
       <trans-unit id="AppConfigRequiresRootConfiguration">

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAnAppHost.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAnAppHost.cs
@@ -1,0 +1,255 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using FluentAssertions;
+using Xunit;
+
+namespace Microsoft.NET.Build.Tasks.UnitTests
+{
+    public class GivenAnAppHost
+    {
+        private const string _placeHolder = "c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2"; //hash value embedded in default apphost executable
+        private readonly static byte[] _bytesToSearch = Encoding.UTF8.GetBytes(_placeHolder);
+
+        [Fact]
+        public void ItEmbedsAppBinaryPath()
+        {
+            using (TestDirectory testDirectory = TestDirectory.Create())
+            {
+                string sourceAppHostMock = PrepareAppHostMockFile(testDirectory);
+                string destinationFilePath = Path.Combine(testDirectory.Path, "DestinationAppHost.exe.mock");
+                string appBinaryFilePath = "Test/App/Binary/Path.dll";
+
+                AppHost.Create(
+                    sourceAppHostMock,
+                    destinationFilePath,
+                    appBinaryFilePath,
+                    overwriteExisting: false,
+                    customizationSettings: null);
+
+                byte[] binaryPathBlob = Encoding.UTF8.GetBytes(appBinaryFilePath);
+                byte[] result = File.ReadAllBytes(destinationFilePath);
+                result
+                    .Skip(_windowsFileHeader.Length)
+                    .Take(binaryPathBlob.Length)
+                    .Should()
+                    .BeEquivalentTo(binaryPathBlob);
+
+                BitConverter
+                    .ToUInt16(result, _subsystemOffset)
+                    .Should()
+                    .Be(3);
+            }
+        }
+
+        [Fact]
+        public void ItFailsToEmbedAppBinaryIfHashIsWrong()
+        {
+            using (TestDirectory testDirectory = TestDirectory.Create())
+            {
+                string sourceAppHostMock = PrepareAppHostMockFile(testDirectory, content =>
+                {
+                    // Corrupt the has value
+                    content[_windowsFileHeader.Length + 1]++;
+                });
+                string destinationFilePath = Path.Combine(testDirectory.Path, "DestinationAppHost.exe.mock");
+                string appBinaryFilePath = "Test/App/Binary/Path.dll";
+
+                Assert.Throws<BuildErrorException>(() =>
+                    AppHost.Create(
+                        sourceAppHostMock,
+                        destinationFilePath,
+                        appBinaryFilePath,
+                        overwriteExisting: false,
+                        customizationSettings: null))
+                    .Message
+                    .Should()
+                    .Contain(sourceAppHostMock)
+                    .And
+                    .Contain(_placeHolder);
+            }
+        }
+
+        [Fact]
+        public void ItFailsToEmbedTooLongAppBinaryPath()
+        {
+            using (TestDirectory testDirectory = TestDirectory.Create())
+            {
+                string sourceAppHostMock = PrepareAppHostMockFile(testDirectory);
+                string destinationFilePath = Path.Combine(testDirectory.Path, "DestinationAppHost.exe.mock");
+                string appBinaryFilePath = new string('a', 1024 + 5);
+
+                Assert.Throws<BuildErrorException>(() =>
+                    AppHost.Create(
+                        sourceAppHostMock,
+                        destinationFilePath,
+                        appBinaryFilePath,
+                        overwriteExisting: false,
+                        customizationSettings: null))
+                    .Message
+                    .Should()
+                    .Contain(appBinaryFilePath);
+            }
+        }
+
+        [Fact]
+        public void ItCanSetWindowsGUISubsystem()
+        {
+            using (TestDirectory testDirectory = TestDirectory.Create())
+            {
+                string sourceAppHostMock = PrepareAppHostMockFile(testDirectory);
+                string destinationFilePath = Path.Combine(testDirectory.Path, "DestinationAppHost.exe.mock");
+                string appBinaryFilePath = "Test/App/Binary/Path.dll";
+
+                AppHost.Create(
+                    sourceAppHostMock,
+                    destinationFilePath,
+                    appBinaryFilePath,
+                    overwriteExisting: false,
+                    customizationSettings: new AppHost.HostCustomizationSettings
+                    {
+                        WindowsGraphicalUserInterface = true
+                    });
+
+                BitConverter
+                    .ToUInt16(File.ReadAllBytes(destinationFilePath), _subsystemOffset)
+                    .Should()
+                    .Be(2);
+            }
+        }
+
+        [Fact]
+        public void ItFailsToSetGUISubsystemOnNonWindowsPEFile()
+        {
+            using (TestDirectory testDirectory = TestDirectory.Create())
+            {
+                string sourceAppHostMock = PrepareAppHostMockFile(testDirectory, content =>
+                {
+                    // Windows PE files must start with 0x5A4D, so write some other value here.
+                    content[0] = 1;
+                    content[1] = 2;
+                });
+                string destinationFilePath = Path.Combine(testDirectory.Path, "DestinationAppHost.exe.mock");
+                string appBinaryFilePath = "Test/App/Binary/Path.dll";
+
+                Assert.Throws<BuildErrorException>(() =>
+                    AppHost.Create(
+                        sourceAppHostMock,
+                        destinationFilePath,
+                        appBinaryFilePath,
+                        overwriteExisting: false,
+                        customizationSettings: new AppHost.HostCustomizationSettings
+                        {
+                            WindowsGraphicalUserInterface = true
+                        }))
+                    .Message
+                    .Should()
+                    .Contain(sourceAppHostMock);
+            }
+        }
+
+        [Fact]
+        public void ItFailsToSetGUISubsystemWithWrongDefault()
+        {
+            using (TestDirectory testDirectory = TestDirectory.Create())
+            {
+                string sourceAppHostMock = PrepareAppHostMockFile(testDirectory, content =>
+                {
+                    // Corrupt the value of the subsytem (the default should be 3)
+                    content[_subsystemOffset] = 42;
+                });
+                string destinationFilePath = Path.Combine(testDirectory.Path, "DestinationAppHost.exe.mock");
+                string appBinaryFilePath = "Test/App/Binary/Path.dll";
+
+                Assert.Throws<BuildErrorException>(() =>
+                    AppHost.Create(
+                        sourceAppHostMock,
+                        destinationFilePath,
+                        appBinaryFilePath,
+                        overwriteExisting: false,
+                        customizationSettings: new AppHost.HostCustomizationSettings
+                        {
+                            WindowsGraphicalUserInterface = true
+                        }))
+                    .Message
+                    .Should()
+                    .Contain(sourceAppHostMock);
+            }
+        }
+
+        private string PrepareAppHostMockFile(TestDirectory testDirectory, Action<byte[]> customize = null)
+        {
+            // For now we're testing the AppHost on Windows PE files only.
+            // The only customization which we do on non-Windows files is the embeding
+            // of the binary path, which works the same regardless of the file format.
+
+            int size = _windowsFileHeader.Length + _bytesToSearch.Length;
+            byte[] content = new byte[size];
+            Array.Copy(_windowsFileHeader, 0, content, 0, _windowsFileHeader.Length);
+            Array.Copy(_bytesToSearch, 0, content, _windowsFileHeader.Length, _bytesToSearch.Length);
+
+            customize?.Invoke(content);
+
+            string filePath = Path.Combine(testDirectory.Path, "SourceAppHost.exe.mock");
+            File.WriteAllBytes(filePath, content);
+            return filePath;
+        }
+
+        private const int _subsystemOffset = 0xF0 + 0x5C;
+
+        // This is a dump of first 350 bytes of a windows apphost.exe
+        // This includes the PE header and part of the Optional header
+        private static byte[] _windowsFileHeader = new byte[] {
+            77, 90, 144, 0, 3, 0, 0, 0, 4, 0, 0, 0, 255, 255, 0, 0, 184,
+            0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            240, 0, 0, 0, 14, 31, 186, 14, 0, 180, 9, 205,
+            33, 184, 1, 76, 205, 33, 84, 104, 105, 115, 32, 112, 114, 111,
+            103, 114, 97, 109, 32, 99, 97, 110, 110, 111, 116, 32, 98, 101,
+            32, 114, 117, 110, 32, 105, 110, 32, 68, 79, 83, 32, 109, 111,
+            100, 101, 46, 13, 13, 10, 36, 0, 0, 0, 0, 0, 0, 0, 30, 91, 134,
+            254, 90, 58, 232, 173, 90, 58, 232, 173, 90, 58, 232, 173, 97,
+            100, 235, 172, 93, 58, 232, 173, 97, 100, 237, 172, 99, 58,
+            232, 173, 97, 100, 236, 172, 123, 58, 232, 173, 83, 66, 123,
+            173, 72, 58, 232, 173, 135, 197, 35, 173, 89, 58, 232, 173,
+            90, 58, 233, 173, 204, 58, 232, 173, 205, 100, 237, 172, 92,
+            58, 232, 173, 200, 100, 23, 173, 91, 58, 232, 173, 205, 100, 234,
+            172, 91, 58, 232, 173, 82, 105, 99, 104, 90, 58, 232, 173, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            80, 69, 0, 0, 100, 134, 7, 0, 29, 151, 54, 91, 0, 0, 0, 0, 0, 0,
+            0, 0, 240, 0, 34, 0, 11, 2, 14, 0, 0, 28, 1, 0, 0, 8, 1, 0, 0, 0,
+            0, 0, 80, 231, 0, 0, 0, 16, 0, 0, 0, 0, 0, 64, 1, 0, 0, 0, 0, 16,
+            0, 0, 0, 2, 0, 0, 6, 0, 0, 0, 0, 0, 0, 0, 6, 0, 0, 0, 0, 0, 0, 0,
+            0, 112, 2, 0, 0, 4, 0, 0, 0, 0, 0, 0, 3, 0, 96, 193, 0, 0, 24,
+            0, 0, 0, 0, 0, 0, 16, 0, 0, 0, 0 };
+
+        private class TestDirectory : IDisposable
+        {
+            public string Path { get; private set; }
+
+            private TestDirectory(string path)
+            {
+                Path = path;
+                Directory.CreateDirectory(path);
+            }
+
+            public static TestDirectory Create([CallerMemberName] string callingMethod = "")
+            {
+                string path = System.IO.Path.Combine(
+                    System.IO.Path.GetTempPath(),
+                    "dotNetSdkUnitTest_" + callingMethod + (Guid.NewGuid().ToString().Substring(0, 8)));
+                return new TestDirectory(path);
+            }
+
+            public void Dispose()
+            {
+                if (Directory.Exists(Path))
+                {
+                    Directory.Delete(Path, true);
+                }
+            }
+        }
+    }
+}

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAnAppHost.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAnAppHost.cs
@@ -32,13 +32,13 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 byte[] binaryPathBlob = Encoding.UTF8.GetBytes(appBinaryFilePath);
                 byte[] result = File.ReadAllBytes(destinationFilePath);
                 result
-                    .Skip(_windowsFileHeader.Length)
+                    .Skip(WindowsFileHeader.Length)
                     .Take(binaryPathBlob.Length)
                     .Should()
                     .BeEquivalentTo(binaryPathBlob);
 
                 BitConverter
-                    .ToUInt16(result, _subsystemOffset)
+                    .ToUInt16(result, SubsystemOffset)
                     .Should()
                     .Be(3);
             }
@@ -52,7 +52,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 string sourceAppHostMock = PrepareAppHostMockFile(testDirectory, content =>
                 {
                     // Corrupt the has value
-                    content[_windowsFileHeader.Length + 1]++;
+                    content[WindowsFileHeader.Length + 1]++;
                 });
                 string destinationFilePath = Path.Combine(testDirectory.Path, "DestinationAppHost.exe.mock");
                 string appBinaryFilePath = "Test/App/Binary/Path.dll";
@@ -114,7 +114,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                     });
 
                 BitConverter
-                    .ToUInt16(File.ReadAllBytes(destinationFilePath), _subsystemOffset)
+                    .ToUInt16(File.ReadAllBytes(destinationFilePath), SubsystemOffset)
                     .Should()
                     .Be(2);
             }
@@ -158,7 +158,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 string sourceAppHostMock = PrepareAppHostMockFile(testDirectory, content =>
                 {
                     // Corrupt the value of the subsytem (the default should be 3)
-                    content[_subsystemOffset] = 42;
+                    content[SubsystemOffset] = 42;
                 });
                 string destinationFilePath = Path.Combine(testDirectory.Path, "DestinationAppHost.exe.mock");
                 string appBinaryFilePath = "Test/App/Binary/Path.dll";
@@ -185,10 +185,10 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             // The only customization which we do on non-Windows files is the embeding
             // of the binary path, which works the same regardless of the file format.
 
-            int size = _windowsFileHeader.Length + _bytesToSearch.Length;
+            int size = WindowsFileHeader.Length + _bytesToSearch.Length;
             byte[] content = new byte[size];
-            Array.Copy(_windowsFileHeader, 0, content, 0, _windowsFileHeader.Length);
-            Array.Copy(_bytesToSearch, 0, content, _windowsFileHeader.Length, _bytesToSearch.Length);
+            Array.Copy(WindowsFileHeader, 0, content, 0, WindowsFileHeader.Length);
+            Array.Copy(_bytesToSearch, 0, content, WindowsFileHeader.Length, _bytesToSearch.Length);
 
             customize?.Invoke(content);
 
@@ -197,11 +197,11 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             return filePath;
         }
 
-        private const int _subsystemOffset = 0xF0 + 0x5C;
+        private const int SubsystemOffset = 0xF0 + 0x5C;
 
         // This is a dump of first 350 bytes of a windows apphost.exe
         // This includes the PE header and part of the Optional header
-        private static byte[] _windowsFileHeader = new byte[] {
+        private static byte[] WindowsFileHeader = new byte[] {
             77, 90, 144, 0, 3, 0, 0, 0, 4, 0, 0, 0, 255, 255, 0, 0, 184,
             0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAnAppHost.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAnAppHost.cs
@@ -10,8 +10,11 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
 {
     public class GivenAnAppHost
     {
-        private const string _placeHolder = "c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2"; //hash value embedded in default apphost executable
-        private readonly static byte[] _bytesToSearch = Encoding.UTF8.GetBytes(_placeHolder);
+        /// <summary>
+        /// hash value embedded in default apphost executable in a place where the path to the app binary should be stored.
+        /// </summary>
+        private const string AppBinaryPathPlaceholder = "c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2";
+        private readonly static byte[] AppBinaryPathPlaceholderSearchValue = Encoding.UTF8.GetBytes(AppBinaryPathPlaceholder);
 
         [Fact]
         public void ItEmbedsAppBinaryPath()
@@ -68,7 +71,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                     .Should()
                     .Contain(sourceAppHostMock)
                     .And
-                    .Contain(_placeHolder);
+                    .Contain(AppBinaryPathPlaceholder);
             }
         }
 
@@ -185,10 +188,10 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             // The only customization which we do on non-Windows files is the embeding
             // of the binary path, which works the same regardless of the file format.
 
-            int size = WindowsFileHeader.Length + _bytesToSearch.Length;
+            int size = WindowsFileHeader.Length + AppBinaryPathPlaceholderSearchValue.Length;
             byte[] content = new byte[size];
             Array.Copy(WindowsFileHeader, 0, content, 0, WindowsFileHeader.Length);
-            Array.Copy(_bytesToSearch, 0, content, WindowsFileHeader.Length, _bytesToSearch.Length);
+            Array.Copy(AppBinaryPathPlaceholderSearchValue, 0, content, WindowsFileHeader.Length, AppBinaryPathPlaceholderSearchValue.Length);
 
             customize?.Invoke(content);
 
@@ -201,7 +204,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
 
         // This is a dump of first 350 bytes of a windows apphost.exe
         // This includes the PE header and part of the Optional header
-        private static byte[] WindowsFileHeader = new byte[] {
+        private static readonly byte[] WindowsFileHeader = new byte[] {
             77, 90, 144, 0, 3, 0, 0, 0, 4, 0, 0, 0, 255, 255, 0, 0, 184,
             0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAnAppHost.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAnAppHost.cs
@@ -27,7 +27,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                     destinationFilePath,
                     appBinaryFilePath,
                     overwriteExisting: false,
-                    customizationSettings: null);
+                    options: null);
 
                 byte[] binaryPathBlob = Encoding.UTF8.GetBytes(appBinaryFilePath);
                 byte[] result = File.ReadAllBytes(destinationFilePath);
@@ -63,7 +63,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                         destinationFilePath,
                         appBinaryFilePath,
                         overwriteExisting: false,
-                        customizationSettings: null))
+                        options: null))
                     .Message
                     .Should()
                     .Contain(sourceAppHostMock)
@@ -87,7 +87,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                         destinationFilePath,
                         appBinaryFilePath,
                         overwriteExisting: false,
-                        customizationSettings: null))
+                        options: null))
                     .Message
                     .Should()
                     .Contain(appBinaryFilePath);
@@ -108,7 +108,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                     destinationFilePath,
                     appBinaryFilePath,
                     overwriteExisting: false,
-                    customizationSettings: new AppHost.HostCustomizationSettings
+                    options: new AppHostOptions
                     {
                         WindowsGraphicalUserInterface = true
                     });
@@ -140,7 +140,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                         destinationFilePath,
                         appBinaryFilePath,
                         overwriteExisting: false,
-                        customizationSettings: new AppHost.HostCustomizationSettings
+                        options: new AppHostOptions
                         {
                             WindowsGraphicalUserInterface = true
                         }))
@@ -169,7 +169,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                         destinationFilePath,
                         appBinaryFilePath,
                         overwriteExisting: false,
-                        customizationSettings: new AppHost.HostCustomizationSettings
+                        options: new AppHostOptions
                         {
                             WindowsGraphicalUserInterface = true
                         }))

--- a/src/Tasks/Microsoft.NET.Build.Tasks/AppHost.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/AppHost.cs
@@ -4,7 +4,6 @@
 using System;
 using System.IO;
 using System.IO.MemoryMappedFiles;
-using System.Runtime.InteropServices;
 using System.Text;
 
 namespace Microsoft.NET.Build.Tasks
@@ -18,31 +17,19 @@ namespace Microsoft.NET.Build.Tasks
         private readonly static byte[] _bytesToSearch = Encoding.UTF8.GetBytes(_placeHolder);
 
         /// <summary>
-        /// Settings to customize the apphost.
-        /// </summary>
-        public class HostCustomizationSettings
-        {
-            /// <summary>
-            /// If this is set to true and the apphost is a Windows PE executable, it will have its subsystem set to GUI.
-            /// By default apphost's subsystem on Windows is set to CUI (Console).
-            /// </summary>
-            public bool WindowsGraphicalUserInterface { get; set; }
-        }
-
-        /// <summary>
         /// Create an AppHost with embedded configuration of app binary location
         /// </summary>
         /// <param name="appHostSourceFilePath">The path of Apphost template, which has the place holder</param>
         /// <param name="appHostDestinationFilePath">The destination path for desired location to place, including the file name</param>
         /// <param name="appBinaryFilePath">Full path to app binary or relative path to the result apphost file</param>
         /// <param name="overwriteExisting">If override the file existed in <paramref name="appHostDestinationFilePath"/></param>
-        /// <param name="customizationSettings">Optional settings to customize the creates apphost</param>
+        /// <param name="options">Options to customize the created apphost</param>
         public static void Create(
             string appHostSourceFilePath,
             string appHostDestinationFilePath,
             string appBinaryFilePath,
             bool overwriteExisting = false,
-            HostCustomizationSettings customizationSettings = null)
+            AppHostOptions options = null)
         {
             var hostExtension = Path.GetExtension(appHostSourceFilePath);
             var appbaseName = Path.GetFileNameWithoutExtension(appBinaryFilePath);
@@ -69,9 +56,9 @@ namespace Microsoft.NET.Build.Tasks
                 {
                     SearchAndReplace(accessor, _bytesToSearch, bytesToWrite, appHostSourceFilePath);
 
-                    if (customizationSettings != null)
+                    if (options != null)
                     {
-                        if (customizationSettings.WindowsGraphicalUserInterface)
+                        if (options.WindowsGraphicalUserInterface)
                         {
                             SetWindowsGraphicalUserInterfaceBit(accessor, appHostSourceFilePath);
                         }
@@ -202,6 +189,31 @@ namespace Microsoft.NET.Build.Tasks
         }
 
         /// <summary>
+        /// The first two bytes of a PE file are a constant signature.
+        /// </summary>
+        private const UInt16 _peFileSignature = 0x5A4D;
+
+        /// <summary>
+        /// The offset of the PE header pointer in the DOS header.
+        /// </summary>
+        private const uint _peHeaderPointerOffset = 0x3C;
+
+        /// <summary>
+        /// The offset of the Subsystem field in the PE header.
+        /// </summary>
+        private const int _subsystemOffset = 0x5C;
+
+        /// <summary>
+        /// The value of the sybsystem field which indicates Windows GUI (Graphical UI)
+        /// </summary>
+        private const UInt16 _windowsGUISubsystem = 0x2;
+
+        /// <summary>
+        /// The value of the subsystem field which indicates Windows CUI (Console)
+        /// </summary>
+        private const UInt16 _windowsCUISubsystem = 0x3;
+
+        /// <summary>
         /// If the apphost file is a windows PE file (checked by looking at the first few bytes)
         /// this method will set its subsystem to GUI.
         /// </summary>
@@ -220,23 +232,29 @@ namespace Microsoft.NET.Build.Tasks
 
                 // https://en.wikipedia.org/wiki/Portable_Executable
                 // Validate that we're looking at Windows PE file
-                if (((UInt16*)bytes)[0] != 0x5A4D)
+                if (((UInt16*)bytes)[0] != _peFileSignature || accessor.Capacity < _peHeaderPointerOffset + sizeof(UInt32))
                 {
                     throw new BuildErrorException(Strings.AppHostNotWindows, appHostSourcePath);
                 }
 
-                UInt32 peHeaderOffset = ((UInt32*)(bytes + 0x3C))[0];
-                UInt16* subsystem = ((UInt16*)(bytes + peHeaderOffset + 0x5C));
+                UInt32 peHeaderOffset = ((UInt32*)(bytes + _peHeaderPointerOffset))[0];
+
+                if (accessor.Capacity < peHeaderOffset + _subsystemOffset + sizeof(UInt16))
+                {
+                    throw new BuildErrorException(Strings.AppHostNotWindows, appHostSourcePath);
+                }
+
+                UInt16* subsystem = ((UInt16*)(bytes + peHeaderOffset + _subsystemOffset));
 
                 // https://docs.microsoft.com/en-us/windows/desktop/Debug/pe-format#windows-subsystem
-                // The subsystem of the prebuilt apphost should be set to CUI - 3
-                if (subsystem[0] != 3)
+                // The subsystem of the prebuilt apphost should be set to CUI
+                if (subsystem[0] != _windowsCUISubsystem)
                 {
                     throw new BuildErrorException(Strings.AppHostNotWindowsCLI, appHostSourcePath);
                 }
 
-                // Set the subsystem to GUI - 2
-                subsystem[0] = 2;
+                // Set the subsystem to GUI
+                subsystem[0] = _windowsGUISubsystem;
             }
             finally
             {

--- a/src/Tasks/Microsoft.NET.Build.Tasks/AppHostOptions.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/AppHostOptions.cs
@@ -1,0 +1,14 @@
+﻿namespace Microsoft.NET.Build.Tasks
+{
+    /// <summary>
+    /// Options to customize the apphost.
+    /// </summary>
+    public class AppHostOptions
+    {
+        /// <summary>
+        /// If this is set to true and the apphost is a Windows PE executable, it will have its subsystem set to GUI.
+        /// By default apphost's subsystem on Windows is set to CUI (Console).
+        /// </summary>
+        public bool WindowsGraphicalUserInterface { get; set; }
+    }
+}

--- a/src/Tasks/Microsoft.NET.Build.Tasks/CreateAppHost.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/CreateAppHost.cs
@@ -7,9 +7,10 @@ using System.IO;
 namespace Microsoft.NET.Build.Tasks
 {
     /// <summary>
-    /// Embeds the App Name into the AppHost.exe  
+    /// Creates the AppHost.exe to be used by the published app.
+    /// This embeds the app dll path into the AppHost.exe and performs additional customizations as requested.
     /// </summary>
-    public class PrepareAppHost : TaskBase
+    public class CreateAppHost : TaskBase
     {
         [Required]
         public string AppHostSourcePath { get; set; }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/PrepareAppHost.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/PrepareAppHost.cs
@@ -10,7 +10,7 @@ namespace Microsoft.NET.Build.Tasks
     /// <summary>
     /// Embeds the App Name into the AppHost.exe  
     /// </summary>
-    public class EmbedAppNameInHost : TaskBase
+    public class PrepareAppHost : TaskBase
     {
         [Required]
         public string AppHostSourcePath { get; set; }
@@ -20,6 +20,8 @@ namespace Microsoft.NET.Build.Tasks
 
         [Required]
         public string AppBinaryName { get; set; }
+
+        public bool WindowsGraphicalUserInterface { get; set; }
 
         [Output]
         public string ModifiedAppHostPath { get; set; }
@@ -34,9 +36,13 @@ namespace Microsoft.NET.Build.Tasks
             if (!File.Exists(ModifiedAppHostPath))
             {
                 AppHost.Create(
-                    AppHostSourcePath,
-                    ModifiedAppHostPath,
-                    AppBinaryName);
+                AppHostSourcePath,
+                ModifiedAppHostPath,
+                AppBinaryName,
+                customizationSettings: new AppHost.HostCustomizationSettings()
+                {
+                    WindowsGraphicalUserInterface = WindowsGraphicalUserInterface
+                });
             }
         }
     }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/PrepareAppHost.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/PrepareAppHost.cs
@@ -3,7 +3,6 @@
 
 using Microsoft.Build.Framework;
 using System.IO;
-using System.Text;
 
 namespace Microsoft.NET.Build.Tasks
 {
@@ -39,7 +38,7 @@ namespace Microsoft.NET.Build.Tasks
                     AppHostSourcePath,
                     ModifiedAppHostPath,
                     AppBinaryName,
-                    customizationSettings: new AppHost.HostCustomizationSettings()
+                    options: new AppHostOptions()
                     {
                         WindowsGraphicalUserInterface = WindowsGraphicalUserInterface
                     });

--- a/src/Tasks/Microsoft.NET.Build.Tasks/PrepareAppHost.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/PrepareAppHost.cs
@@ -36,13 +36,13 @@ namespace Microsoft.NET.Build.Tasks
             if (!File.Exists(ModifiedAppHostPath))
             {
                 AppHost.Create(
-                AppHostSourcePath,
-                ModifiedAppHostPath,
-                AppBinaryName,
-                customizationSettings: new AppHost.HostCustomizationSettings()
-                {
-                    WindowsGraphicalUserInterface = WindowsGraphicalUserInterface
-                });
+                    AppHostSourcePath,
+                    ModifiedAppHostPath,
+                    AppBinaryName,
+                    customizationSettings: new AppHost.HostCustomizationSettings()
+                    {
+                        WindowsGraphicalUserInterface = WindowsGraphicalUserInterface
+                    });
             }
         }
     }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -272,7 +272,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     Computes any files that need to be copied to the build output folder for .NET Core.
     ============================================================
     -->
-  <UsingTask TaskName="EmbedAppNameInHost" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
+  <UsingTask TaskName="PrepareAppHost" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
   <Target Name="_ComputeNETCoreBuildOutputFiles"
           DependsOnTargets="ResolvePackageAssets"
           AfterTargets="ResolveReferences"
@@ -297,19 +297,21 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <PropertyGroup Condition="'@(NativeRestoredAppHostNETCore)' != '' ">
       <AppHostDestinationDirectoryPath>$(BaseIntermediateOutputPath)\$(TargetFramework)\$(RuntimeIdentifier)\host</AppHostDestinationDirectoryPath>
+      <UseWindowsGraphicalUserInterface Condition="$(RuntimeIdentifier.StartsWith('win')) and '$(OutputType)'=='WinExe'">true</UseWindowsGraphicalUserInterface>
     </PropertyGroup>
 
     <NETSdkError Condition="'@(NativeRestoredAppHostNETCore->Count())' &gt; 1"
                  ResourceName="MultipleFilesResolved"
                  FormatArguments="$(_DotNetAppHostExecutableName)" />
 
-    <EmbedAppNameInHost   AppHostSourcePath="@(NativeRestoredAppHostNETCore)"
-                          AppHostDestinationDirectoryPath="$(AppHostDestinationDirectoryPath)"
-                          AppBinaryName="$(AssemblyName)$(TargetExt)"
-                          Condition="'@(NativeRestoredAppHostNETCore)' != '' ">
+    <PrepareAppHost AppHostSourcePath="@(NativeRestoredAppHostNETCore)"
+                    AppHostDestinationDirectoryPath="$(AppHostDestinationDirectoryPath)"
+                    AppBinaryName="$(AssemblyName)$(TargetExt)"
+                    WindowsGraphicalUserInterface="$(UseWindowsGraphicalUserInterface)"
+                    Condition="'@(NativeRestoredAppHostNETCore)' != '' ">
 
       <Output TaskParameter="ModifiedAppHostPath" ItemName="NativeAppHostNETCore" />
-    </EmbedAppNameInHost>
+    </PrepareAppHost>
 
     <ItemGroup Condition="'@(NativeAppHostNETCore)' == '' ">
       <NativeAppHostNETCore Include="@(NativeCopyLocalItems)"

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -272,7 +272,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     Computes any files that need to be copied to the build output folder for .NET Core.
     ============================================================
     -->
-  <UsingTask TaskName="PrepareAppHost" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
+  <UsingTask TaskName="CreateAppHost" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
   <Target Name="_ComputeNETCoreBuildOutputFiles"
           DependsOnTargets="ResolvePackageAssets"
           AfterTargets="ResolveReferences"
@@ -304,14 +304,14 @@ Copyright (c) .NET Foundation. All rights reserved.
                  ResourceName="MultipleFilesResolved"
                  FormatArguments="$(_DotNetAppHostExecutableName)" />
 
-    <PrepareAppHost AppHostSourcePath="@(NativeRestoredAppHostNETCore)"
-                    AppHostDestinationDirectoryPath="$(AppHostDestinationDirectoryPath)"
-                    AppBinaryName="$(AssemblyName)$(TargetExt)"
-                    WindowsGraphicalUserInterface="$(UseWindowsGraphicalUserInterface)"
-                    Condition="'@(NativeRestoredAppHostNETCore)' != '' ">
+    <CreateAppHost AppHostSourcePath="@(NativeRestoredAppHostNETCore)"
+                   AppHostDestinationDirectoryPath="$(AppHostDestinationDirectoryPath)"
+                   AppBinaryName="$(AssemblyName)$(TargetExt)"
+                   WindowsGraphicalUserInterface="$(UseWindowsGraphicalUserInterface)"
+                   Condition="'@(NativeRestoredAppHostNETCore)' != '' ">
 
       <Output TaskParameter="ModifiedAppHostPath" ItemName="NativeAppHostNETCore" />
-    </PrepareAppHost>
+    </CreateAppHost>
 
     <ItemGroup Condition="'@(NativeAppHostNETCore)' == '' ">
       <NativeAppHostNETCore Include="@(NativeCopyLocalItems)"

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishASelfContainedApp.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishASelfContainedApp.cs
@@ -91,7 +91,8 @@ namespace Microsoft.NET.Publish.Tests
                 .Should().Pass().And.NotHaveStdOutContaining("HelloWorld.exe' already exists");
         }
 
-        private const int _subsystemOffset = 0xF0 + 0x5C;
+        private const int PEHeaderPointerOffset = 0x3C;
+        private const int SubsystemOffset = 0x5C;
 
         [WindowsOnlyFact]
         public void It_can_make_a_Windows_GUI_exe()
@@ -121,9 +122,9 @@ namespace Microsoft.NET.Publish.Tests
                 targetFramework: TargetFramework, 
                 runtimeIdentifier: runtimeIdentifier).FullName;
             byte[] fileContent = File.ReadAllBytes(Path.Combine(outputDirectory, TestProjectName + ".exe"));
-            UInt32 peHeaderOffset = BitConverter.ToUInt32(fileContent, 0x3C);
+            UInt32 peHeaderOffset = BitConverter.ToUInt32(fileContent, PEHeaderPointerOffset);
             BitConverter
-                .ToUInt16(fileContent, (int)(peHeaderOffset + 0x5C))
+                .ToUInt16(fileContent, (int)(peHeaderOffset + SubsystemOffset))
                 .Should()
                 .Be(2);
         }

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishASelfContainedApp.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishASelfContainedApp.cs
@@ -120,8 +120,10 @@ namespace Microsoft.NET.Publish.Tests
             string outputDirectory = publishCommand.GetOutputDirectory(
                 targetFramework: TargetFramework, 
                 runtimeIdentifier: runtimeIdentifier).FullName;
+            byte[] fileContent = File.ReadAllBytes(Path.Combine(outputDirectory, TestProjectName + ".exe"));
+            UInt32 peHeaderOffset = BitConverter.ToUInt32(fileContent, 0x3C);
             BitConverter
-                .ToUInt16(File.ReadAllBytes(Path.Combine(outputDirectory, TestProjectName + ".exe")), _subsystemOffset)
+                .ToUInt16(fileContent, (int)(peHeaderOffset + 0x5C))
                 .Should()
                 .Be(2);
         }

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishASelfContainedApp.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishASelfContainedApp.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using FluentAssertions;
-using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.PlatformAbstractions;
 using Microsoft.NET.Build.Tasks;
 using Microsoft.NET.TestFramework;
@@ -10,7 +9,6 @@ using Microsoft.NET.TestFramework.Assertions;
 using Microsoft.NET.TestFramework.Commands;
 using System;
 using System.IO;
-using System.Linq;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -91,6 +89,41 @@ namespace Microsoft.NET.Publish.Tests
             publishCommand
                 .Execute(msbuildArgs)
                 .Should().Pass().And.NotHaveStdOutContaining("HelloWorld.exe' already exists");
+        }
+
+        private const int _subsystemOffset = 0xF0 + 0x5C;
+
+        [WindowsOnlyFact]
+        public void It_can_make_a_Windows_GUI_exe()
+        {
+            var runtimeIdentifier = EnvironmentInfo.GetCompatibleRid("netcoreapp2.0");
+
+            var testAsset = _testAssetsManager
+                .CopyTestAsset(TestProjectName)
+                .WithSource()
+                .WithProjectChanges(doc =>
+                {
+                    doc.Root.Element("PropertyGroup").Element("TargetFramework").SetValue(TargetFramework);
+                })
+                .Restore(Log, relativePath: "", args: $"/p:RuntimeIdentifier={runtimeIdentifier}");
+
+            var publishCommand = new PublishCommand(Log, testAsset.TestRoot);
+            publishCommand
+                .Execute(
+                    "/p:SelfContained=true",
+                    "/p:OutputType=WinExe",
+                    $"/p:TargetFramework={TargetFramework}",
+                    $"/p:RuntimeIdentifier={runtimeIdentifier}")
+                .Should()
+                .Pass();
+
+            string outputDirectory = publishCommand.GetOutputDirectory(
+                targetFramework: TargetFramework, 
+                runtimeIdentifier: runtimeIdentifier).FullName;
+            BitConverter
+                .ToUInt16(File.ReadAllBytes(Path.Combine(outputDirectory, TestProjectName + ".exe")), _subsystemOffset)
+                .Should()
+                .Be(2);
         }
     }
 }


### PR DESCRIPTION
On Windows only, if the OutputType of the project is WinExe (as oppose to just exe), self-contained published app will now have its subsystem set to Windows GUI.
This means the app will start without a console.

The change renames the task EmbedAppNameInHost to PrepareAppHost as it now does more than just embedding the path to the app.

Added unit tests for the AppHost class and then an E2E for the publish command.