### PR TITLE
Fix conflict resolver issue which could prevent System.Net.Http APIs from being used

### DIFF
--- a/src/Tasks/Common/ConflictResolution/ConflictResolver.cs
+++ b/src/Tasks/Common/ConflictResolution/ConflictResolver.cs
@@ -97,10 +97,13 @@ namespace Microsoft.NET.Build.Tasks.ConflictResolution
                     foundConflict(winner, loser);
 
                     //  If there were any other items that tied with the loser, report them as conflicts here
+                    //  if they lose against the new winner.  Otherwise, keep them in the unresolved conflict
+                    //  list.
                     List<TConflictItem> previouslyUnresolvedConflicts;
-                    if (_unresolvedConflictItems.TryGetValue(itemKey, out previouslyUnresolvedConflicts) &&
+                    if(_unresolvedConflictItems.TryGetValue(itemKey, out previouslyUnresolvedConflicts) &&
                         previouslyUnresolvedConflicts.Contains(loser))
                     {
+                        List<TConflictItem> newUnresolvedConflicts = new List<TConflictItem>();
                         foreach (var previouslyUnresolvedItem in previouslyUnresolvedConflicts)
                         {
                             //  Don't re-report the item that just lost and was already reported
@@ -110,13 +113,31 @@ namespace Microsoft.NET.Build.Tasks.ConflictResolution
                             }
 
                             //  Call ResolveConflict with the new winner and item that previously had an unresolved
-                            //  conflict, so that the correct message will be logged recording that the winner
-                            //  won and why
-                            ResolveConflict(winner, previouslyUnresolvedItem, logUnresolvedConflicts: true);
+                            //  conflict, so that if the previously unresolved conflict loses, the correct message
+                            //  will be logged recording that the winner won and why.  If the conflict can't be
+                            //  resolved, then keep the previously unresolved conflict in the list of unresolved
+                            //  conflicts.
+                            var newWinner = ResolveConflict(winner, previouslyUnresolvedItem, logUnresolvedConflicts: true);
+                            if (newWinner == winner)
+                            {
+                                foundConflict(winner, previouslyUnresolvedItem);
+                            }
+                            else if (newWinner == null)
+                            {
+                                if (newUnresolvedConflicts.Count == 0)
+                                {
+                                    newUnresolvedConflicts.Add(winner);
+                                }
+                                newUnresolvedConflicts.Add(previouslyUnresolvedItem);
+                            }
 
-                            foundConflict(winner, previouslyUnresolvedItem);
+                            
                         }
                         _unresolvedConflictItems.Remove(itemKey);
+                        if (newUnresolvedConflicts.Count > 0)
+                        {
+                            _unresolvedConflictItems[itemKey] = newUnresolvedConflicts;
+                        }
                     }
                 }
                 else if (commitWinner)

--- a/src/Tasks/Common/ConflictResolution/ConflictResolver.cs
+++ b/src/Tasks/Common/ConflictResolution/ConflictResolver.cs
@@ -98,7 +98,8 @@ namespace Microsoft.NET.Build.Tasks.ConflictResolution
 
                     //  If there were any other items that tied with the loser, report them as conflicts here
                     List<TConflictItem> previouslyUnresolvedConflicts;
-                    if (_unresolvedConflictItems.TryGetValue(itemKey, out previouslyUnresolvedConflicts))
+                    if (_unresolvedConflictItems.TryGetValue(itemKey, out previouslyUnresolvedConflicts) &&
+                        previouslyUnresolvedConflicts.Contains(loser))
                     {
                         foreach (var previouslyUnresolvedItem in previouslyUnresolvedConflicts)
                         {

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAConflictResolver.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAConflictResolver.cs
@@ -235,6 +235,25 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
         }
 
         [Fact]
+        public void ItemsWithNoWinnerWillBeUnresolvedIfAnotherItemLoses()
+        {
+            int[] versions = new[]
+            {
+                3,
+                3,
+                2
+            };
+
+            var items = versions.Select(v => new MockConflictItem() { FileVersion = new Version(v, 0, 0, 0) })
+                .ToArray();
+
+            var result = GetConflicts(items);
+
+            result.Conflicts.Should().BeEquivalentTo(new[] { items[2] });
+            result.UnresolvedConflicts.Should().BeEquivalentTo(new[] { items[0], items[1] });
+        }
+
+        [Fact]
         public void WhenItemsConflictAndBothArePlatformItemsTheConflictCannotBeResolved()
         {
             var item1 = new MockConflictItem() { ItemType = ConflictItemType.Platform };

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToTargetNet471.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToTargetNet471.cs
@@ -459,5 +459,95 @@ public static class NS16LibClass
 
 
         }
+
+        //  Regression test for https://github.com/dotnet/sdk/issues/2479
+        [FullMSBuildOnlyFact]
+        public void HttpClient_can_be_used_in_project_references()
+        {
+            var referencedProject = new TestProject()
+            {
+                Name = "ReferencedHttpClientProject",
+                IsExe = false,
+                IsSdkProject = false,
+                TargetFrameworkVersion = "v4.7.1"
+            };
+            referencedProject.PackageReferences.Add(new TestPackageReference("dotless.Core", "1.6.4"));
+            referencedProject.PackageReferences.Add(new TestPackageReference("Microsoft.Owin.Security.Facebook", "4.0.0"));
+
+            referencedProject.SourceFiles["FacebookHandler.cs"] = @"
+using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+public class FacebookHandler : HttpClientHandler
+{
+	protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+	{
+        return await base.SendAsync(request, cancellationToken);
+    }
+}";
+
+            var testProject = new TestProject()
+            {
+                Name = "Net471HttpClientTest",
+                IsExe = true,
+                IsSdkProject = false,
+                TargetFrameworkVersion = "v4.7.1"
+            };
+
+            testProject.AdditionalProperties["RestoreProjectStyle"] = "PackageReference";
+
+            testProject.ReferencedProjects.Add(referencedProject);
+            testProject.SourceFiles["Program.cs"] = @"
+using Microsoft.Owin.Security.Facebook;
+using Owin;
+
+public class Startup
+{
+    public static void Main(string [] args)
+    {
+    }
+
+    public void Configuration(IAppBuilder app)
+    {
+        var facebookOptions = new FacebookAuthenticationOptions
+        {
+            BackchannelHttpHandler = new FacebookHandler()
+        };
+    }
+}
+";
+
+            var testAsset = _testAssetsManager.CreateTestProject(testProject)
+                .WithProjectChanges((projectPath, project) =>
+                {
+                    if (Path.GetFileNameWithoutExtension(projectPath) == testProject.Name)
+                    {
+                        var ns = project.Root.Name.Namespace;
+
+                        //  Add target which helped trigger the error case.  A target like this was provided as
+                        //  a workaround to a different issue: https://github.com/dotnet/sdk/pull/1582#issuecomment-329571228
+                        var reproTarget = XElement.Parse(@"
+  <Target Name=""AddAdditionalReference"" AfterTargets=""ImplicitlyExpandNETStandardFacades"">
+    <ItemGroup>
+      <Reference Include = ""@(_NETStandardLibraryNETFrameworkLib)"" Condition = ""'%(FileName)' == 'system.net.http'"">
+        <Private>true</Private>
+      </Reference>
+    </ItemGroup>
+  </Target> ");
+                        foreach (var element in reproTarget.DescendantsAndSelf())
+                        {
+                            element.Name = ns + element.Name.LocalName;
+                        }
+                        project.Root.Add(reproTarget);
+                    }
+                })
+                .Restore(Log, testProject.Name);
+
+            var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+
+            buildCommand.Execute().Should().Pass();
+        }
     }
 }


### PR DESCRIPTION
(This could affect other APIs as well, but the reports we have are for System.Net.Http)

Fixes #2479

#### Description
New changes in the conflict resolution task broke the case where you have two references to the same dll that have different Identity but same HintPath. What is happening now, is that we could come to a case where we flag both items as conflicts even when they were actually the winners, and the task ends up removing both from the references, which causes compiler errors when types/assemblies are not found. The particular problem happens on these lines:
https://github.com/dotnet/sdk/blob/1b17e16afbb66598cc6f67747bbd71f8b13240c5/src/Tasks/Common/ConflictResolution/ConflictResolver.cs#L99-L120
which blindly assumes that all of the `previouslyUnresolvedConflicts` should lose, when that may not be the case, since a previous unresolved conflict might tie with the winner.

#### Customer Impact
 This will impact customers using the new conflict resolution task (Using VS15.8 or newer) and have a project that needs the runtime facades from the support package, and depends on one library which also needs the runtime facades from a support package. In other words, this will hit users that have a net471 app that uses a .NET Standard package, and that also references another net471 lib which also uses a .NET Standard package. By our estimates, this is not a uncommon scenario, so we do expect a decent amount of users hitting this.

#### Regression?
 Yes. Even though the logic was faulty, this scenario used to work fine before we made [this change]( https://github.com/dotnet/sdk/commit/2360a208be21e565c97fada4e32230259e505401#diff-d9ff88f07f5fbd9297634a77f002d30eR103) since we were skipping the first item of the unresolved conflicts which was causing the reference to get preserved. This does mean that consumers might have a working project on 15.7.x but will get broken once they upgrade VS into 15.8

#### Risk
Test cases have been added in order to reduce the risk at the minimum.  We will also do some manual testing to ensure we didn’t break any additional mainline scenario.

@livarcocc @joperezr @ericstj for review