### PR TITLE
Fix setting SelfContained to false.

### DIFF
--- a/src/Assets/TestProjects/WebApp/Program.cs
+++ b/src/Assets/TestProjects/WebApp/Program.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace web
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            BuildWebHost(args).Run();
+        }
+
+        public static IWebHost BuildWebHost(string[] args) =>
+            WebHost.CreateDefaultBuilder(args)
+                .UseStartup<Startup>()
+                .Build();
+    }
+}

--- a/src/Assets/TestProjects/WebApp/Startup.cs
+++ b/src/Assets/TestProjects/WebApp/Startup.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace web
+{
+    public class Startup
+    {
+        // This method gets called by the runtime. Use this method to add services to the container.
+        // For more information on how to configure your application, visit https://go.microsoft.com/fwlink/?LinkID=398940
+        public void ConfigureServices(IServiceCollection services)
+        {
+        }
+
+        // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
+        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+        {
+            if (env.IsDevelopment())
+            {
+                app.UseDeveloperExceptionPage();
+            }
+
+            app.Run(async (context) =>
+            {
+                await context.Response.WriteAsync("Hello World!");
+            });
+        }
+    }
+}

--- a/src/Assets/TestProjects/WebApp/web.csproj
+++ b/src/Assets/TestProjects/WebApp/web.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Folder Include="wwwroot\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.9" />
+  </ItemGroup>
+
+</Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets
@@ -104,9 +104,11 @@ Copyright (c) .NET Foundation. All rights reserved.
     Default SelfContained based on the RuntimeIdentifier, so projects don't have to explicitly set SelfContained.
     This avoids a breaking change from 1.0 behavior.
     -->
-  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' and '$(HasRuntimeOutput)' == 'true' and '$(RuntimeIdentifier)' != ''">
-    <SelfContained Condition="'$(SelfContained)' == ''">true</SelfContained>
-    <UseAppHost Condition="'$(UseAppHost)' == '' and ('$(SelfContained)' == 'true' or '$(_TargetFrameworkVersionWithoutV)' >= '2.1')">true</UseAppHost>
+  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' and '$(HasRuntimeOutput)' == 'true'">
+    <SelfContained Condition="'$(SelfContained)' == '' and '$(RuntimeIdentifier)' != ''">true</SelfContained>
+    <SelfContained Condition="'$(SelfContained)' == ''">false</SelfContained>
+    <UseAppHost Condition="'$(UseAppHost)' == '' and ('$(SelfContained)' == 'true' or ('$(RuntimeIdentifier)' != '' and '$(_TargetFrameworkVersionWithoutV)' >= '2.1'))">true</UseAppHost>
+    <UseAppHost Condition="'$(UseAppHost)' == ''">false</UseAppHost>
   </PropertyGroup>
 
   <Target Name="_CheckForUnsupportedAppHostUsage"

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAWebApp.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAWebApp.cs
@@ -1,0 +1,62 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using FluentAssertions;
+using Microsoft.DotNet.Cli.Utils;
+using Microsoft.DotNet.PlatformAbstractions;
+using Microsoft.NET.TestFramework;
+using Microsoft.NET.TestFramework.Assertions;
+using Microsoft.NET.TestFramework.Commands;
+using System.IO;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.NET.Publish.Tests
+{
+    public class GivenThatWeWantToPublishAWebApp : SdkTest
+    {
+        public GivenThatWeWantToPublishAWebApp(ITestOutputHelper log) : base(log)
+        {
+        }
+
+        [Fact]
+        public void It_publishes_as_framework_dependent_by_default()
+        {
+            var testAsset = _testAssetsManager
+                .CopyTestAsset("WebApp")
+                .WithSource();
+
+            var args = new[]
+            {
+                "-p:Configuration=Release"
+            };
+
+            var restoreCommand = new RestoreCommand(Log, testAsset.TestRoot);
+            restoreCommand
+                .Execute(args)
+                .Should()
+                .Pass();
+
+            var command = new PublishCommand(Log, testAsset.TestRoot);
+
+            command
+                .Execute(args)
+                .Should()
+                .Pass();
+
+            var publishDirectory =
+                command.GetOutputDirectory(targetFramework: "netcoreapp2.0", configuration: "Release");
+
+            publishDirectory.Should().NotHaveSubDirectories();
+            publishDirectory.Should().OnlyHaveFiles(new[] {
+                "web.config",
+                "web.deps.json",
+                "web.dll",
+                "web.pdb",
+                "web.PrecompiledViews.dll",
+                "web.PrecompiledViews.pdb",
+                "web.runtimeconfig.json",
+            });
+        }
+    }
+}


### PR DESCRIPTION
The 2.1.400 SDK changed the way `SelfContained` was being set: it would only set
it to `true` if not set, otherwise it would leave it as an empty string.

While this was fine for the .NET Core SDK because all "false" checks against
`SelfContained` were using `'$(SelfContained)' != 'true'`, thus that expression
would evaluate to true when `SelfContained` was empty.

However, the 2.0 Web SDK used an expression of `'$(SelfContained)' == 'false'`,
which no longer evaluated to true because `SelfContained` was now an empty
string.  This resulted in publishing a project as self-contained when it should
have been framework-dependent.

The fix is to set `SelfContained` to false like the .NET Core SDK was doing
before.

Likewise, this commit also sets the related `UseAppHost` property to false when
it would be empty otherwise in case external SDKs make similar comparisons.

Fixes dotnet/cli#9852.