### PR TITLE
[WIP] 2.2: Add support for referencing Microsoft.AspNetCore.App as a FrameworkReference

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "2.2.100-preview1-009263"
+    "version": "2.2.100-preview1-009349"
   },
   "msbuild-sdks": {
     "RoslynTools.RepoToolset": "1.0.0-beta2-62912-01"

--- a/src/Tasks/Common/Resources/Strings.resx
+++ b/src/Tasks/Common/Resources/Strings.resx
@@ -403,7 +403,7 @@ The following are names of parameters or literal values and should not be transl
   </data>
   <data name="RecommendFrameworkReferenceForAspNetCorePackages" xml:space="preserve">
     <value>NETSDK1071: A PackageReference for '{0}' was included in your project. Referencing this item as NuGet package is no longer supported. To resolve this warning, change the PackageReference to a FrameworkReference. For more information, see {1}.</value>
-    <comment>{StrBegin="NETSDK1072: "}
+    <comment>{StrBegin="NETSDK1071: "}
 {0} - Package Id (Microsoft.AspNetCore.App or .All)
 {1} - More info link
     </comment>

--- a/src/Tasks/Common/Resources/Strings.resx
+++ b/src/Tasks/Common/Resources/Strings.resx
@@ -401,4 +401,15 @@ The following are names of parameters or literal values and should not be transl
     <value>NETSDK1070: The application configuration file must have root configuration element.</value>
     <comment>{StrBegin="NETSDK1070: "}</comment>
   </data>
+  <data name="RecommendFrameworkReferenceForAspNetCorePackages" xml:space="preserve">
+    <value>NETSDK1071: A PackageReference for '{0}' was included in your project. Referencing this item as NuGet package is no longer supported. To resolve this warning, change the PackageReference to a FrameworkReference. For more information, see {1}.</value>
+    <comment>{StrBegin="NETSDK1072: "}
+{0} - Package Id (Microsoft.AspNetCore.App or .All)
+{1} - More info link
+    </comment>
+  </data>
+  <data name="UnknownFrameworkReference" xml:space="preserve">
+    <value>NETSDK1072: The FrameworkReference '{0}' was not recognized.</value>
+    <comment>{StrBegin="NETSDK1072: "}</comment>
+  </data>
 </root>

--- a/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
@@ -67,6 +67,19 @@
         <target state="translated">NETSDK1008: Chybí metadata {0} o {1} položky {2}.</target>
         <note>{StrBegin="NETSDK1008: "}</note>
       </trans-unit>
+      <trans-unit id="RecommendFrameworkReferenceForAspNetCorePackages">
+        <source>NETSDK1071: A PackageReference for '{0}' was included in your project. Referencing this item as NuGet package is no longer supported. To resolve this warning, change the PackageReference to a FrameworkReference. For more information, see {1}.</source>
+        <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. Referencing this item as NuGet package is no longer supported. To resolve this warning, change the PackageReference to a FrameworkReference. For more information, see {1}.</target>
+        <note>{StrBegin="NETSDK1072: "}
+{0} - Package Id (Microsoft.AspNetCore.App or .All)
+{1} - More info link
+    </note>
+      </trans-unit>
+      <trans-unit id="UnknownFrameworkReference">
+        <source>NETSDK1072: The FrameworkReference '{0}' was not recognized.</source>
+        <target state="new">NETSDK1072: The FrameworkReference '{0}' was not recognized.</target>
+        <note>{StrBegin="NETSDK1072: "}</note>
+      </trans-unit>
       <trans-unit id="UnrecognizedPreprocessorToken">
         <source>NETSDK1009: Unrecognized preprocessor token '{0}' in '{1}'.</source>
         <target state="translated">NETSDK1009: Nerozpoznaný token preprocesoru {0} v {1}.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
@@ -70,7 +70,7 @@
       <trans-unit id="RecommendFrameworkReferenceForAspNetCorePackages">
         <source>NETSDK1071: A PackageReference for '{0}' was included in your project. Referencing this item as NuGet package is no longer supported. To resolve this warning, change the PackageReference to a FrameworkReference. For more information, see {1}.</source>
         <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. Referencing this item as NuGet package is no longer supported. To resolve this warning, change the PackageReference to a FrameworkReference. For more information, see {1}.</target>
-        <note>{StrBegin="NETSDK1072: "}
+        <note>{StrBegin="NETSDK1071: "}
 {0} - Package Id (Microsoft.AspNetCore.App or .All)
 {1} - More info link
     </note>

--- a/src/Tasks/Common/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.de.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../Strings.resx">
     <body>
@@ -7,73 +7,332 @@
         <target state="new">NETSDK1070: The application configuration file must have root configuration element.</target>
         <note>{StrBegin="NETSDK1070: "}</note>
       </trans-unit>
+      <trans-unit id="AppHostHasBeenModified">
+        <source>NETSDK1029: Unable to use '{0}' as application host executable as it does not contain the expected placeholder byte sequence '{1}' that would mark where the application name would be written.</source>
+        <target state="new">NETSDK1029: Unable to use '{0}' as application host executable as it does not contain the expected placeholder byte sequence '{1}' that would mark where the application name would be written.</target>
+        <note>{StrBegin="NETSDK1029: "}</note>
+      </trans-unit>
+      <trans-unit id="AssetPreprocessorMustBeConfigured">
+        <source>NETSDK1017: Asset preprocessor must be configured before assets are processed.</source>
+        <target state="new">NETSDK1017: Asset preprocessor must be configured before assets are processed.</target>
+        <note>{StrBegin="NETSDK1017: "}</note>
+      </trans-unit>
+      <trans-unit id="AssetsFileMissingRuntimeIdentifier">
+        <source>NETSDK1047: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project. You may also need to include '{3}' in your project's RuntimeIdentifiers.</source>
+        <target state="new">NETSDK1047: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project. You may also need to include '{3}' in your project's RuntimeIdentifiers.</target>
+        <note>{StrBegin="NETSDK1047: "}</note>
+      </trans-unit>
+      <trans-unit id="AssetsFileMissingTarget">
+        <source>NETSDK1005: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project.</source>
+        <target state="new">NETSDK1005: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project.</target>
+        <note>{StrBegin="NETSDK1005: "}</note>
+      </trans-unit>
+      <trans-unit id="AssetsFileNotFound">
+        <source>NETSDK1004: Assets file '{0}' not found. Run a NuGet package restore to generate this file.</source>
+        <target state="new">NETSDK1004: Assets file '{0}' not found. Run a NuGet package restore to generate this file.</target>
+        <note>{StrBegin="NETSDK1004: "}</note>
+      </trans-unit>
+      <trans-unit id="AssetsFileNotSet">
+        <source>NETSDK1063: The path to the project assets file was not set. Run a NuGet package restore to generate this file.</source>
+        <target state="new">NETSDK1063: The path to the project assets file was not set. Run a NuGet package restore to generate this file.</target>
+        <note>{StrBegin="NETSDK1063: "}</note>
+      </trans-unit>
+      <trans-unit id="AssetsFilePathNotRooted">
+        <source>NETSDK1006: Assets file path '{0}' is not rooted. Only full paths are supported.</source>
+        <target state="new">NETSDK1006: Assets file path '{0}' is not rooted. Only full paths are supported.</target>
+        <note>{StrBegin="NETSDK1006: "}</note>
+      </trans-unit>
       <trans-unit id="AtLeastOneTargetFrameworkMustBeSpecified">
         <source>NETSDK1001: At least one possible target framework must be specified.</source>
-        <target state="translated">NETSDK1001: Geben Sie mindestens ein mögliches Zielframework an.</target>
+        <target state="new">NETSDK1001: At least one possible target framework must be specified.</target>
         <note>{StrBegin="NETSDK1001: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotFindApphostForRid">
+        <source>NETSDK1065: Cannot find app host for {0}. {0} could be an invalid runtime identifier (RID). For more information about RID, see https://aka.ms/rid-catalog.</source>
+        <target state="new">NETSDK1065: Cannot find app host for {0}. {0} could be an invalid runtime identifier (RID). For more information about RID, see https://aka.ms/rid-catalog.</target>
+        <note>{StrBegin="NETSDK1065: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotFindProjectInfo">
+        <source>NETSDK1007: Cannot find project info for '{0}'. This can indicate a missing project reference.</source>
+        <target state="new">NETSDK1007: Cannot find project info for '{0}'. This can indicate a missing project reference.</target>
+        <note>{StrBegin="NETSDK1007: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotHaveRuntimeIdentifierPlatformMismatchPlatformTarget">
+        <source>NETSDK1032: The RuntimeIdentifier platform '{0}' and the PlatformTarget '{1}' must be compatible.</source>
+        <target state="new">NETSDK1032: The RuntimeIdentifier platform '{0}' and the PlatformTarget '{1}' must be compatible.</target>
+        <note>{StrBegin="NETSDK1032: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotHaveSelfContainedWithoutRuntimeIdentifier">
+        <source>NETSDK1031: It is not supported to build or publish a self-contained application without specifying a RuntimeIdentifier.  Please either specify a RuntimeIdentifier or set SelfContained to false.</source>
+        <target state="new">NETSDK1031: It is not supported to build or publish a self-contained application without specifying a RuntimeIdentifier.  Please either specify a RuntimeIdentifier or set SelfContained to false.</target>
+        <note>{StrBegin="NETSDK1031: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotInferTargetFrameworkIdentiferAndVersion">
+        <source>NETSDK1013: The TargetFramework value '{0}' was not recognized. It may be misspelled. If not, then the TargetFrameworkIdentifier and/or TargetFrameworkVersion properties must be specified explicitly.</source>
+        <target state="new">NETSDK1013: The TargetFramework value '{0}' was not recognized. It may be misspelled. If not, then the TargetFrameworkIdentifier and/or TargetFrameworkVersion properties must be specified explicitly.</target>
+        <note>{StrBegin="NETSDK1013: "}</note>
       </trans-unit>
       <trans-unit id="CannotUseAppHostWithoutRuntimeIdentifier">
         <source>NETSDK1066: A RuntimeIdentifier must be specified to publish a framework-dependent application with an application host.</source>
-        <target state="translated">NETSDK1066: Ein RuntimeIdentifier muss angegeben werden, um eine frameworkabhängige Anwendung bei einem Anwendungshost zu veröffentlichen.</target>
+        <target state="new">NETSDK1066: A RuntimeIdentifier must be specified to publish a framework-dependent application with an application host.</target>
         <note>{StrBegin="NETSDK1066: "}</note>
       </trans-unit>
       <trans-unit id="CannotUseSelfContainedWithoutAppHost">
         <source>NETSDK1067: Self-contained applications are required to use the application host. Either set SelfContained to false or set UseAppHost to true.</source>
-        <target state="translated">NETSDK1067: Eigenständige Anwendungen müssen den Anwendungshost verwenden. Legen Sie "SelfContained" auf FALSE oder "UseAppHost" auf TRUE fest.</target>
+        <target state="new">NETSDK1067: Self-contained applications are required to use the application host. Either set SelfContained to false or set UseAppHost to true.</target>
         <note>{StrBegin="NETSDK1067: "}</note>
+      </trans-unit>
+      <trans-unit id="ChoosingAssemblyVersion">
+        <source>NETSDK1033: Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</source>
+        <target state="new">NETSDK1033: Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</target>
+        <note>{StrBegin="NETSDK1033: "}</note>
+      </trans-unit>
+      <trans-unit id="ChoosingFileVersion">
+        <source>NETSDK1034: Choosing '{0}' because file version '{1}' is greater than '{2}'.</source>
+        <target state="new">NETSDK1034: Choosing '{0}' because file version '{1}' is greater than '{2}'.</target>
+        <note>{StrBegin="NETSDK1034: "}</note>
+      </trans-unit>
+      <trans-unit id="ChoosingPlatformItem">
+        <source>NETSDK1035: Choosing '{0}' because it is a platform item.</source>
+        <target state="new">NETSDK1035: Choosing '{0}' because it is a platform item.</target>
+        <note>{StrBegin="NETSDK1035: "}</note>
+      </trans-unit>
+      <trans-unit id="ChoosingPreferredPackage">
+        <source>NETSDK1036: Choosing '{0}' because it comes from a package that is preferred.</source>
+        <target state="new">NETSDK1036: Choosing '{0}' because it comes from a package that is preferred.</target>
+        <note>{StrBegin="NETSDK1036: "}</note>
+      </trans-unit>
+      <trans-unit id="ConflictCouldNotDetermineWinner">
+        <source>NETSDK1037: Could not determine winner due to equal file and assembly versions.</source>
+        <target state="new">NETSDK1037: Could not determine winner due to equal file and assembly versions.</target>
+        <note>{StrBegin="NETSDK1037: "}</note>
+      </trans-unit>
+      <trans-unit id="ContentItemDoesNotProvideOutputPath">
+        <source>NETSDK1014: Content item for '{0}' sets '{1}', but does not provide  '{2}' or '{3}'.</source>
+        <target state="new">NETSDK1014: Content item for '{0}' sets '{1}', but does not provide  '{2}' or '{3}'.</target>
+        <note>{StrBegin="NETSDK1014: "}</note>
+      </trans-unit>
+      <trans-unit id="ContentPreproccessorParameterRequired">
+        <source>NETSDK1010: The '{0}' task must be given a value for parameter '{1}' in order to consume preprocessed content.</source>
+        <target state="new">NETSDK1010: The '{0}' task must be given a value for parameter '{1}' in order to consume preprocessed content.</target>
+        <note>{StrBegin="NETSDK1010: "}</note>
+      </trans-unit>
+      <trans-unit id="CouldNotDetermineWinner_DoesntExist">
+        <source>NETSDK1038: Could not determine winner because '{0}' does not exist.</source>
+        <target state="new">NETSDK1038: Could not determine winner because '{0}' does not exist.</target>
+        <note>{StrBegin="NETSDK1001: "}</note>
+      </trans-unit>
+      <trans-unit id="CouldNotDetermineWinner_FileVersion">
+        <source>NETSDK1039: Could not determine a winner because '{0}' has no file version.</source>
+        <target state="new">NETSDK1039: Could not determine a winner because '{0}' has no file version.</target>
+        <note>{StrBegin="NETSDK1039: "}</note>
+      </trans-unit>
+      <trans-unit id="CouldNotDetermineWinner_NotAnAssembly">
+        <source>NETSDK1040: Could not determine a winner because '{0}' is not an assembly.</source>
+        <target state="new">NETSDK1040: Could not determine a winner because '{0}' is not an assembly.</target>
+        <note>{StrBegin="NETSDK1040: "}</note>
+      </trans-unit>
+      <trans-unit id="CouldNotLoadPlatformManifest">
+        <source>NETSDK1042: Could not load PlatformManifest from '{0}' because it did not exist.</source>
+        <target state="new">NETSDK1042: Could not load PlatformManifest from '{0}' because it did not exist.</target>
+        <note>{StrBegin="NETSDK1042: "}</note>
+      </trans-unit>
+      <trans-unit id="DotnetToolDoesNotSupportTFMLowerThanNetcoreapp21">
+        <source>NETSDK1055: DotnetTool does not support target framework lower than netcoreapp2.1.</source>
+        <target state="new">NETSDK1055: DotnetTool does not support target framework lower than netcoreapp2.1.</target>
+        <note>{StrBegin="NETSDK1055: "}</note>
+      </trans-unit>
+      <trans-unit id="DotnetToolOnlySupportNetcoreapp">
+        <source>NETSDK1054: only supports .NET Core.</source>
+        <target state="new">NETSDK1054: only supports .NET Core.</target>
+        <note>{StrBegin="NETSDK1054: "}</note>
+      </trans-unit>
+      <trans-unit id="DuplicateItemsError">
+        <source>NETSDK1022: Duplicate '{0}' items were included. The .NET SDK includes '{0}' items from your project directory by default. You can either remove these items from your project file, or set the '{1}' property to '{2}' if you want to explicitly include them in your project file. For more information, see {4}. The duplicate items were: {3}</source>
+        <target state="new">NETSDK1022: Duplicate '{0}' items were included. The .NET SDK includes '{0}' items from your project directory by default. You can either remove these items from your project file, or set the '{1}' property to '{2}' if you want to explicitly include them in your project file. For more information, see {4}. The duplicate items were: {3}</target>
+        <note>{StrBegin="NETSDK1022: "}</note>
+      </trans-unit>
+      <trans-unit id="DuplicatePreprocessorToken">
+        <source>NETSDK1015: The preprocessor token '{0}' has been given more than one value. Choosing '{1}' as the value.</source>
+        <target state="new">NETSDK1015: The preprocessor token '{0}' has been given more than one value. Choosing '{1}' as the value.</target>
+        <note>{StrBegin="NETSDK1015: "}</note>
+      </trans-unit>
+      <trans-unit id="EncounteredConflict">
+        <source>NETSDK1041: Encountered conflict between '{0}' and '{1}'.</source>
+        <target state="new">NETSDK1041: Encountered conflict between '{0}' and '{1}'.</target>
+        <note>{StrBegin="NETSDK1041: "}</note>
+      </trans-unit>
+      <trans-unit id="ErrorParsingFrameworkListInvalidValue">
+        <source>NETSDK1051: Error parsing FrameworkList from '{0}'.  {1} '{2}' was invalid.</source>
+        <target state="new">NETSDK1051: Error parsing FrameworkList from '{0}'.  {1} '{2}' was invalid.</target>
+        <note>{StrBegin="NETSDK1051: "}</note>
+      </trans-unit>
+      <trans-unit id="ErrorParsingPlatformManifest">
+        <source>NETSDK1043: Error parsing PlatformManifest from '{0}' line {1}.  Lines must have the format {2}.</source>
+        <target state="new">NETSDK1043: Error parsing PlatformManifest from '{0}' line {1}.  Lines must have the format {2}.</target>
+        <note>{StrBegin="NETSDK1043: "}</note>
+      </trans-unit>
+      <trans-unit id="ErrorParsingPlatformManifestInvalidValue">
+        <source>NETSDK1044: Error parsing PlatformManifest from '{0}' line {1}.  {2} '{3}' was invalid.</source>
+        <target state="new">NETSDK1044: Error parsing PlatformManifest from '{0}' line {1}.  {2} '{3}' was invalid.</target>
+        <note>{StrBegin="NETSDK1044: "}</note>
+      </trans-unit>
+      <trans-unit id="ErrorReadingAssetsFile">
+        <source>NETSDK1060: Error reading assets file: {0}</source>
+        <target state="new">NETSDK1060: Error reading assets file: {0}</target>
+        <note>{StrBegin="NETSDK1060: "}</note>
+      </trans-unit>
+      <trans-unit id="FileNameIsTooLong">
+        <source>NETSDK1030: Given file name '{0}' is longer than 1024 bytes</source>
+        <target state="new">NETSDK1030: Given file name '{0}' is longer than 1024 bytes</target>
+        <note>{StrBegin="NETSDK1030: "}</note>
+      </trans-unit>
+      <trans-unit id="FolderAlreadyExists">
+        <source>NETSDK1024: Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</source>
+        <target state="new">NETSDK1024: Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</target>
+        <note>{StrBegin="NETSDK1024: "}</note>
       </trans-unit>
       <trans-unit id="FrameworkDependentAppHostRequiresVersion21">
         <source>NETSDK1068: The framework-dependent application host requires a target framework of at least 'netcoreapp2.1'.</source>
-        <target state="translated">NETSDK1068: Für den frameworkabhängigen Anwendungshost ist mindestens das Zielframework "netcoreapp2.1" erforderlich.</target>
+        <target state="new">NETSDK1068: The framework-dependent application host requires a target framework of at least 'netcoreapp2.1'.</target>
         <note>{StrBegin="NETSDK1068: "}</note>
+      </trans-unit>
+      <trans-unit id="FrameworkListPathNotRooted">
+        <source>NETSDK1052: Framework list file path '{0}' is not rooted. Only full paths are supported.</source>
+        <target state="new">NETSDK1052: Framework list file path '{0}' is not rooted. Only full paths are supported.</target>
+        <note>{StrBegin="NETSDK1052: "}</note>
+      </trans-unit>
+      <trans-unit id="GetDependsOnNETStandardFailedWithException">
+        <source>NETSDK1049: Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0} {1}</source>
+        <target state="new">NETSDK1049: Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0} {1}</target>
+        <note>{StrBegin="NETSDK1049: "}</note>
+      </trans-unit>
+      <trans-unit id="IncorrectPackageRoot">
+        <source>NETSDK1020: Package Root {0} was incorrectly given for Resolved library {1}</source>
+        <target state="new">NETSDK1020: Package Root {0} was incorrectly given for Resolved library {1}</target>
+        <note>{StrBegin="NETSDK1020: "}</note>
+      </trans-unit>
+      <trans-unit id="IncorrectTargetFormat">
+        <source>NETSDK1025: WRThe target manifest {0} provided is of not the correct format</source>
+        <target state="new">NETSDK1025: WRThe target manifest {0} provided is of not the correct format</target>
+        <note>{StrBegin="NETSDK1025: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidFrameworkName">
+        <source>NETSDK1003: Invalid framework name: '{0}'.</source>
+        <target state="new">NETSDK1003: Invalid framework name: '{0}'.</target>
+        <note>{StrBegin="NETSDK1003: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidItemSpecToUse">
+        <source>NETSDK1058: Invalid value for ItemSpecToUse parameter: '{0}'.  This property must be blank or set to 'Left' or 'Right'</source>
+        <target state="new">NETSDK1058: Invalid value for ItemSpecToUse parameter: '{0}'.  This property must be blank or set to 'Left' or 'Right'</target>
+        <note>{StrBegin="NETSDK1058: "}
+The following are names of parameters or literal values and should not be translated: ItemSpecToUse, Left, Right</note>
+      </trans-unit>
+      <trans-unit id="InvalidNuGetVersionString">
+        <source>NETSDK1018: Invalid NuGet version string: '{0}'.</source>
+        <target state="new">NETSDK1018: Invalid NuGet version string: '{0}'.</target>
+        <note>{StrBegin="NETSDK1018: "}</note>
+      </trans-unit>
+      <trans-unit id="MismatchedPlatformPackageVersion">
+        <source>NETSDK1061: The project was restored using {0} version {1}, but with current settings, version {2} would be used instead. To resolve this issue, make sure the same settings are used for restore and for subsequent operations such as build or publish. Typically this issue can occur if the RuntimeIdentifier property is set during build or publish but not during restore. For more information, see https://aka.ms/dotnet-runtime-patch-selection.</source>
+        <target state="new">NETSDK1061: The project was restored using {0} version {1}, but with current settings, version {2} would be used instead. To resolve this issue, make sure the same settings are used for restore and for subsequent operations such as build or publish. Typically this issue can occur if the RuntimeIdentifier property is set during build or publish but not during restore. For more information, see https://aka.ms/dotnet-runtime-patch-selection.</target>
+        <note>{StrBegin="NETSDK1061: "}
+{0} - Package Identifier for platform package
+{1} - Restored version of platform package
+{2} - Current version of platform package</note>
+      </trans-unit>
+      <trans-unit id="MissingItemMetadata">
+        <source>NETSDK1008: Missing '{0}' metadata on '{1}' item '{2}'.</source>
+        <target state="new">NETSDK1008: Missing '{0}' metadata on '{1}' item '{2}'.</target>
+        <note>{StrBegin="NETSDK1008: "}</note>
+      </trans-unit>
+      <trans-unit id="MultipleFilesResolved">
+        <source>NETSDK1021: More than one file found for {0}</source>
+        <target state="new">NETSDK1021: More than one file found for {0}</target>
+        <note>{StrBegin="NETSDK1021: "}</note>
       </trans-unit>
       <trans-unit id="NETFrameworkToNonBuiltInNETStandard">
         <source>NETSDK1069: This project uses a library that targets .NET Standard 1.5 or higher, and the project targets a version of .NET Framework that doesn't have built-in support for that version of .NET Standard. Visit https://aka.ms/net-standard-known-issues for a set of known issues. Consider retargeting to .NET Framework 4.7.2.</source>
-        <target state="translated">NETSDK1069: Dieses Projekt verwendet eine Bibliothek, die auf .NET Standard 1.5 oder höher ausgerichtet ist, und das Projekt ist auf eine Version von .NET Framework ausgerichtet, die keine integrierte Unterstützung für diese .NET Standard-Version bietet. Besuchen Sie https://aka.ms/net-standard-known-issues for a set of known issues. Ziehen Sie eine neue Ausrichtung auf .NET Framework 4.7.2 in Betracht.</target>
+        <target state="new">NETSDK1069: This project uses a library that targets .NET Standard 1.5 or higher, and the project targets a version of .NET Framework that doesn't have built-in support for that version of .NET Standard. Visit https://aka.ms/net-standard-known-issues for a set of known issues. Consider retargeting to .NET Framework 4.7.2.</target>
         <note>{StrBegin="NETSDK1069: "}</note>
       </trans-unit>
       <trans-unit id="NoCompatibleTargetFramework">
         <source>NETSDK1002: Project '{0}' targets '{2}'. It cannot be referenced by a project that targets '{1}'.</source>
-        <target state="translated">NETSDK1002: Das Projekt "{0}" hat das Ziel "{2}". Ein Verweis über ein Projekt mit dem Ziel "{1}" ist nicht möglich.</target>
+        <target state="new">NETSDK1002: Project '{0}' targets '{2}'. It cannot be referenced by a project that targets '{1}'.</target>
         <note>{StrBegin="NETSDK1002: "}</note>
       </trans-unit>
-      <trans-unit id="InvalidFrameworkName">
-        <source>NETSDK1003: Invalid framework name: '{0}'.</source>
-        <target state="translated">NETSDK1003: Ungültiger Frameworkname: "{0}".</target>
-        <note>{StrBegin="NETSDK1003: "}</note>
+      <trans-unit id="PackAsToolCannotSupportSelfContained">
+        <source>NETSDK1053: Pack as tool does not support self contained.</source>
+        <target state="new">NETSDK1053: Pack as tool does not support self contained.</target>
+        <note>{StrBegin="NETSDK1001: "}</note>
       </trans-unit>
-      <trans-unit id="AssetsFileNotFound">
-        <source>NETSDK1004: Assets file '{0}' not found. Run a NuGet package restore to generate this file.</source>
-        <target state="translated">NETSDK1004: Die Ressourcendatei "{0}" wurde nicht gefunden. Führen Sie eine NuGet-Paketwiederherstellung aus, um diese Datei zu generieren.</target>
-        <note>{StrBegin="NETSDK1004: "}</note>
+      <trans-unit id="PackageInfoLog">
+        <source>NETSDK1027: Package Name='{0}', Version='{1}' was parsed</source>
+        <target state="new">NETSDK1027: Package Name='{0}', Version='{1}' was parsed</target>
+        <note>{StrBegin="NETSDK1027: "}</note>
       </trans-unit>
-      <trans-unit id="AssetsFileMissingTarget">
-        <source>NETSDK1005: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project.</source>
-        <target state="translated">NETSDK1005: Die Ressourcendatei "{0}" weist kein Ziel für "{1}" auf. Stellen Sie sicher, dass die Wiederherstellung ausgeführt wurde, und dass Sie "{2}" in die TargetFrameworks für Ihr Projekt eingeschlossen haben.</target>
-        <note>{StrBegin="NETSDK1005: "}</note>
+      <trans-unit id="PackageNotFound">
+        <source>NETSDK1064: Package {0}, version {1} was not found. It might have been deleted since NuGet restore. Otherwise, NuGet restore might have only partially completed, which might have been due to maximum path length restrictions.</source>
+        <target state="new">NETSDK1064: Package {0}, version {1} was not found. It might have been deleted since NuGet restore. Otherwise, NuGet restore might have only partially completed, which might have been due to maximum path length restrictions.</target>
+        <note>{StrBegin="NETSDK1064: "}</note>
       </trans-unit>
-      <trans-unit id="AssetsFilePathNotRooted">
-        <source>NETSDK1006: Assets file path '{0}' is not rooted. Only full paths are supported.</source>
-        <target state="translated">NETSDK1006: Die Ressourcendateipfad "{0}" hat keinen Stamm. Nur vollständige Pfade werden unterstützt.</target>
-        <note>{StrBegin="NETSDK1006: "}</note>
+      <trans-unit id="PackageReferenceOverrideWarning">
+        <source>NETSDK1023: A PackageReference for '{0}' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see {1}</source>
+        <target state="new">NETSDK1023: A PackageReference for '{0}' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see {1}</target>
+        <note>{StrBegin="NETSDK1023: "}</note>
       </trans-unit>
-      <trans-unit id="CannotFindProjectInfo">
-        <source>NETSDK1007: Cannot find project info for '{0}'. This can indicate a missing project reference.</source>
-        <target state="translated">NETSDK1007: Die Projektinformationen für "{0}" wurden nicht gefunden. Dies ist möglicherweise auf einen fehlenden Projektverweis zurückzuführen.</target>
-        <note>{StrBegin="NETSDK1007: "}</note>
+      <trans-unit id="ParsingFiles">
+        <source>NETSDK1026: Parsing the Files : '{0}'</source>
+        <target state="new">NETSDK1026: Parsing the Files : '{0}'</target>
+        <note>{StrBegin="NETSDK1026: "}</note>
       </trans-unit>
-      <trans-unit id="MissingItemMetadata">
-        <source>NETSDK1008: Missing '{0}' metadata on '{1}' item '{2}'.</source>
-        <target state="translated">NETSDK1008: Die Metadaten "{0}" für das Element "{2}" vom Typ "{1}" sind nicht vorhanden.</target>
-        <note>{StrBegin="NETSDK1008: "}</note>
+      <trans-unit id="ProjectAssetsConsumedWithoutMSBuildProjectPath">
+        <source>NETSDK1011: Assets are consumed from project '{0}', but no corresponding MSBuild project path was  found in '{1}'.</source>
+        <target state="new">NETSDK1011: Assets are consumed from project '{0}', but no corresponding MSBuild project path was  found in '{1}'.</target>
+        <note>{StrBegin="NETSDK1011: "}</note>
+      </trans-unit>
+      <trans-unit id="ProjectContainsObsoleteDotNetCliTool">
+        <source>NETSDK1059: The tool '{0}' is now included in the .NET Core SDK. Information on resolving this warning is available at (https://aka.ms/dotnetclitools-in-box).</source>
+        <target state="new">NETSDK1059: The tool '{0}' is now included in the .NET Core SDK. Information on resolving this warning is available at (https://aka.ms/dotnetclitools-in-box).</target>
+        <note>{StrBegin="NETSDK1059: "}</note>
       </trans-unit>
       <trans-unit id="RecommendFrameworkReferenceForAspNetCorePackages">
         <source>NETSDK1071: A PackageReference for '{0}' was included in your project. Referencing this item as NuGet package is no longer supported. To resolve this warning, change the PackageReference to a FrameworkReference. For more information, see {1}.</source>
         <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. Referencing this item as NuGet package is no longer supported. To resolve this warning, change the PackageReference to a FrameworkReference. For more information, see {1}.</target>
-        <note>{StrBegin="NETSDK1072: "}
+        <note>{StrBegin="NETSDK1071: "}
 {0} - Package Id (Microsoft.AspNetCore.App or .All)
 {1} - More info link
     </note>
+      </trans-unit>
+      <trans-unit id="RuntimeIdentifierWasNotSpecified">
+        <source>NETSDK1028: Specify a RuntimeIdentifier</source>
+        <target state="new">NETSDK1028: Specify a RuntimeIdentifier</target>
+        <note>{StrBegin="NETSDK1028: "}</note>
+      </trans-unit>
+      <trans-unit id="SkippingAdditionalProbingPaths">
+        <source>NETSDK1048: 'AdditionalProbingPaths' were specified for GenerateRuntimeConfigurationFiles, but are being skipped because 'RuntimeConfigDevPath' is empty.</source>
+        <target state="new">NETSDK1048: 'AdditionalProbingPaths' were specified for GenerateRuntimeConfigurationFiles, but are being skipped because 'RuntimeConfigDevPath' is empty.</target>
+        <note>{StrBegin="NETSDK1048: "}</note>
+      </trans-unit>
+      <trans-unit id="TargetFrameworkWithSemicolon">
+        <source>NETSDK1046: The TargetFramework value '{0}' is not valid. To multi-target, use the 'TargetFrameworks' property instead.</source>
+        <target state="new">NETSDK1046: The TargetFramework value '{0}' is not valid. To multi-target, use the 'TargetFrameworks' property instead.</target>
+        <note>{StrBegin="NETSDK1046: "}</note>
+      </trans-unit>
+      <trans-unit id="UnableToFindResolvedPath">
+        <source>NETSDK1016: Unable to find resolved path for '{0}'.</source>
+        <target state="new">NETSDK1016: Unable to find resolved path for '{0}'.</target>
+        <note>{StrBegin="NETSDK1016: "}</note>
+      </trans-unit>
+      <trans-unit id="UnableToUsePackageAssetsCache">
+        <source>NETSDK1062: Unable to use package assets cache due to I/O error. This can occur when the same project is built more than once in parallel. Performance may be degraded, but the build result will not be impacted.</source>
+        <target state="new">NETSDK1062: Unable to use package assets cache due to I/O error. This can occur when the same project is built more than once in parallel. Performance may be degraded, but the build result will not be impacted.</target>
+        <note>{StrBegin="NETSDK1062: "}</note>
+      </trans-unit>
+      <trans-unit id="UnexpectedFileType">
+        <source>NETSDK1012: Unexpected file type for '{0}'. Type is both '{1}' and '{2}'.</source>
+        <target state="new">NETSDK1012: Unexpected file type for '{0}'. Type is both '{1}' and '{2}'.</target>
+        <note>{StrBegin="NETSDK1012: "}</note>
       </trans-unit>
       <trans-unit id="UnknownFrameworkReference">
         <source>NETSDK1072: The FrameworkReference '{0}' was not recognized.</source>
@@ -82,292 +341,33 @@
       </trans-unit>
       <trans-unit id="UnrecognizedPreprocessorToken">
         <source>NETSDK1009: Unrecognized preprocessor token '{0}' in '{1}'.</source>
-        <target state="translated">NETSDK1009: Unbekanntes Präprozessortoken "{0}" in "{1}".</target>
+        <target state="new">NETSDK1009: Unrecognized preprocessor token '{0}' in '{1}'.</target>
         <note>{StrBegin="NETSDK1009: "}</note>
-      </trans-unit>
-      <trans-unit id="ContentPreproccessorParameterRequired">
-        <source>NETSDK1010: The '{0}' task must be given a value for parameter '{1}' in order to consume preprocessed content.</source>
-        <target state="translated">NETSDK1010: Der Aufgabe "{0}" muss für die Nutzung vorverarbeiteter Inhalte mit einem Wert für den Parameter "{1}" versehen werden.</target>
-        <note>{StrBegin="NETSDK1010: "}</note>
-      </trans-unit>
-      <trans-unit id="ProjectAssetsConsumedWithoutMSBuildProjectPath">
-        <source>NETSDK1011: Assets are consumed from project '{0}', but no corresponding MSBuild project path was  found in '{1}'.</source>
-        <target state="translated">NETSDK1011: Es werden Ressourcen aus dem Projekt "{0}" genutzt, in "{1}" wurde jedoch kein entsprechender MSBuild-Projektpfad gefunden.</target>
-        <note>{StrBegin="NETSDK1011: "}</note>
-      </trans-unit>
-      <trans-unit id="UnexpectedFileType">
-        <source>NETSDK1012: Unexpected file type for '{0}'. Type is both '{1}' and '{2}'.</source>
-        <target state="translated">NETSDK1012: Unerwarteter Dateityp für "{0}". Der Typ ist sowohl "{1}" als auch "{2}".</target>
-        <note>{StrBegin="NETSDK1012: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotInferTargetFrameworkIdentiferAndVersion">
-        <source>NETSDK1013: The TargetFramework value '{0}' was not recognized. It may be misspelled. If not, then the TargetFrameworkIdentifier and/or TargetFrameworkVersion properties must be specified explicitly.</source>
-        <target state="translated">NETSDK1013: Der TargetFramework-Wert "{0}" wurde nicht erkannt. Unter Umständen ist die Schreibweise nicht korrekt. Andernfalls müssen die Eigenschaften TargetFrameworkIdentifier und/oder TargetFrameworkVersion explizit angegeben werden.</target>
-        <note>{StrBegin="NETSDK1013: "}</note>
-      </trans-unit>
-      <trans-unit id="ContentItemDoesNotProvideOutputPath">
-        <source>NETSDK1014: Content item for '{0}' sets '{1}', but does not provide  '{2}' or '{3}'.</source>
-        <target state="translated">NETSDK1014: Das Inhaltselement für "{0}" legt "{1}" fest, gibt aber "{2}" oder "{3}" nicht an.</target>
-        <note>{StrBegin="NETSDK1014: "}</note>
-      </trans-unit>
-      <trans-unit id="DuplicatePreprocessorToken">
-        <source>NETSDK1015: The preprocessor token '{0}' has been given more than one value. Choosing '{1}' as the value.</source>
-        <target state="translated">NETSDK1015: Das Präprozessortoken "{0}" wurde mit mehreren Werten versehen. "{1}" wird als Wert ausgewählt.</target>
-        <note>{StrBegin="NETSDK1015: "}</note>
-      </trans-unit>
-      <trans-unit id="UnableToFindResolvedPath">
-        <source>NETSDK1016: Unable to find resolved path for '{0}'.</source>
-        <target state="translated">NETSDK1016: Der aufgelöste Pfad für "{0}" wurde nicht gefunden.</target>
-        <note>{StrBegin="NETSDK1016: "}</note>
-      </trans-unit>
-      <trans-unit id="AssetPreprocessorMustBeConfigured">
-        <source>NETSDK1017: Asset preprocessor must be configured before assets are processed.</source>
-        <target state="translated">NETSDK1017: Der Ressourcenpräprozessor muss konfiguriert werden, bevor Ressourcen verarbeitet werden.</target>
-        <note>{StrBegin="NETSDK1017: "}</note>
-      </trans-unit>
-      <trans-unit id="InvalidNuGetVersionString">
-        <source>NETSDK1018: Invalid NuGet version string: '{0}'.</source>
-        <target state="translated">NETSDK1018: Ungültige NuGet-Versionszeichenfolge: "{0}".</target>
-        <note>{StrBegin="NETSDK1018: "}</note>
       </trans-unit>
       <trans-unit id="UnsupportedFramework">
         <source>NETSDK1019: {0} is an unsupported framework.</source>
-        <target state="translated">NETSDK1019: "{0}" ist ein nicht unterstütztes Framework.</target>
+        <target state="new">NETSDK1019: {0} is an unsupported framework.</target>
         <note>{StrBegin="NETSDK1019: "}</note>
-      </trans-unit>
-      <trans-unit id="DuplicateItemsError">
-        <source>NETSDK1022: Duplicate '{0}' items were included. The .NET SDK includes '{0}' items from your project directory by default. You can either remove these items from your project file, or set the '{1}' property to '{2}' if you want to explicitly include them in your project file. For more information, see {4}. The duplicate items were: {3}</source>
-        <target state="translated">NETSDK1022: Es wurden doppelte {0}-Elemente eingeschlossen. Das .NET SDK enthält standardmäßig {0}-Elemente aus ihrem Projektverzeichnis. Sie können entweder diese Elemente aus der Projektdatei entfernen oder die Eigenschaft "{1}" auf "{2}" festlegen, wenn Sie sie explizit in Ihre Projektdatei einbeziehen möchten. Weitere Informationen erhalten Sie unter "{4}". Die doppelten Elemente waren: {3}.</target>
-        <note>{StrBegin="NETSDK1022: "}</note>
-      </trans-unit>
-      <trans-unit id="PackageReferenceOverrideWarning">
-        <source>NETSDK1023: A PackageReference for '{0}' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see {1}</source>
-        <target state="translated">NETSDK1023: Ein PackageReference für "{0}" war in Ihrem Projekt vorhanden. Auf dieses Paket wird vom .NET SDK implizit verwiesen, und Sie müssen in der Regel nicht von Ihrem Projekt aus darauf verweisen. Weitere Informationen finden Sie unter "{1}".</target>
-        <note>{StrBegin="NETSDK1023: "}</note>
-      </trans-unit>
-      <trans-unit id="IncorrectPackageRoot">
-        <source>NETSDK1020: Package Root {0} was incorrectly given for Resolved library {1}</source>
-        <target state="translated">NETSDK1020: Der Paketstamm "{0}" war für die aufgelöste Bibliothek "{1}" falsch angegeben.</target>
-        <note>{StrBegin="NETSDK1020: "}</note>
-      </trans-unit>
-      <trans-unit id="MultipleFilesResolved">
-        <source>NETSDK1021: More than one file found for {0}</source>
-        <target state="translated">NETSDK1021: Für "{0}" wurden mehrere Dateien gefunden.</target>
-        <note>{StrBegin="NETSDK1021: "}</note>
-      </trans-unit>
-      <trans-unit id="FolderAlreadyExists">
-        <source>NETSDK1024: Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</source>
-        <target state="translated">NETSDK1024: Der Ordner "{0}" ist bereits vorhanden. Löschen Sie ihn, oder geben Sie ein anderes "ComposeWorkingDir" an.</target>
-        <note>{StrBegin="NETSDK1024: "}</note>
-      </trans-unit>
-      <trans-unit id="ParsingFiles">
-        <source>NETSDK1026: Parsing the Files : '{0}'</source>
-        <target state="translated">NETSDK1026: Die Dateien werden analysiert: "{0}"</target>
-        <note>{StrBegin="NETSDK1026: "}</note>
-      </trans-unit>
-      <trans-unit id="PackageInfoLog">
-        <source>NETSDK1027: Package Name='{0}', Version='{1}' was parsed</source>
-        <target state="translated">NETSDK1027: Paketname="{0}", Version="{1}" wurde analysiert</target>
-        <note>{StrBegin="NETSDK1027: "}</note>
-      </trans-unit>
-      <trans-unit id="RuntimeIdentifierWasNotSpecified">
-        <source>NETSDK1028: Specify a RuntimeIdentifier</source>
-        <target state="translated">NETSDK1028: Geben Sie einen RuntimeIdentifier an.</target>
-        <note>{StrBegin="NETSDK1028: "}</note>
-      </trans-unit>
-      <trans-unit id="IncorrectTargetFormat">
-        <source>NETSDK1025: WRThe target manifest {0} provided is of not the correct format</source>
-        <target state="translated">NETSDK1025: Das angegebene Zielmanifest "{0}" hat nicht das richtige Format.</target>
-        <note>{StrBegin="NETSDK1025: "}</note>
-      </trans-unit>
-      <trans-unit id="AppHostHasBeenModified">
-        <source>NETSDK1029: Unable to use '{0}' as application host executable as it does not contain the expected placeholder byte sequence '{1}' that would mark where the application name would be written.</source>
-        <target state="translated">NETSDK1029: "{0}" kann nicht als ausführbare Anwendungshostdatei verwendet werden, da die erwartete Platzhalterbytesequenz "{1}" nicht vorhanden ist, die markiert, wo der Anwendungsname geschrieben wird.</target>
-        <note>{StrBegin="NETSDK1029: "}</note>
-      </trans-unit>
-      <trans-unit id="FileNameIsTooLong">
-        <source>NETSDK1030: Given file name '{0}' is longer than 1024 bytes</source>
-        <target state="translated">NETSDK1030: Der angegebene Dateiname "{0}" ist länger als 1024 Byte.</target>
-        <note>{StrBegin="NETSDK1030: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotHaveSelfContainedWithoutRuntimeIdentifier">
-        <source>NETSDK1031: It is not supported to build or publish a self-contained application without specifying a RuntimeIdentifier.  Please either specify a RuntimeIdentifier or set SelfContained to false.</source>
-        <target state="translated">NETSDK1031: Das Erstellen oder Veröffentlichen einer eigenständigen Anwendung ohne die Angabe eines RuntimeIdentifier wird nicht unterstützt. Geben Sie entweder einen RuntimeIdentifier an, oder legen Sie für SelfContained "False" fest.</target>
-        <note>{StrBegin="NETSDK1031: "}</note>
-      </trans-unit>
-      <trans-unit id="ChoosingAssemblyVersion">
-        <source>NETSDK1033: Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</source>
-        <target state="translated">NETSDK1033: "{0}" wird ausgewählt, weil AssemblyVersion "{1}" höher ist als "{2}".</target>
-        <note>{StrBegin="NETSDK1033: "}</note>
-      </trans-unit>
-      <trans-unit id="ChoosingFileVersion">
-        <source>NETSDK1034: Choosing '{0}' because file version '{1}' is greater than '{2}'.</source>
-        <target state="translated">NETSDK1034: "{0}" wird ausgewählt, weil die Dateiversion "{1}" höher ist als "{2}".</target>
-        <note>{StrBegin="NETSDK1034: "}</note>
-      </trans-unit>
-      <trans-unit id="ChoosingPlatformItem">
-        <source>NETSDK1035: Choosing '{0}' because it is a platform item.</source>
-        <target state="translated">NETSDK1035: "{0}" wird ausgewählt, weil es sich um ein Plattformelement handelt.</target>
-        <note>{StrBegin="NETSDK1035: "}</note>
-      </trans-unit>
-      <trans-unit id="ChoosingPreferredPackage">
-        <source>NETSDK1036: Choosing '{0}' because it comes from a package that is preferred.</source>
-        <target state="translated">NETSDK1036: "{0}" wird ausgewählt, weil es von einem bevorzugten Paket stammt.</target>
-        <note>{StrBegin="NETSDK1036: "}</note>
-      </trans-unit>
-      <trans-unit id="ConflictCouldNotDetermineWinner">
-        <source>NETSDK1037: Could not determine winner due to equal file and assembly versions.</source>
-        <target state="translated">NETSDK1037: Der Gewinner konnte aufgrund übereinstimmender Datei- und Assemblyversionen nicht bestimmt werden.</target>
-        <note>{StrBegin="NETSDK1037: "}</note>
-      </trans-unit>
-      <trans-unit id="CouldNotDetermineWinner_DoesntExist">
-        <source>NETSDK1038: Could not determine winner because '{0}' does not exist.</source>
-        <target state="translated">NETSDK1038: Der Gewinner konnte nicht bestimmt werden, weil "{0}" nicht vorhanden ist.</target>
-        <note>{StrBegin="NETSDK1001: "}</note>
-      </trans-unit>
-      <trans-unit id="CouldNotDetermineWinner_FileVersion">
-        <source>NETSDK1039: Could not determine a winner because '{0}' has no file version.</source>
-        <target state="translated">NETSDK1039: Der Gewinner konnte nicht bestimmt werden, weil "{0}" keine Dateiversion aufweist.</target>
-        <note>{StrBegin="NETSDK1039: "}</note>
-      </trans-unit>
-      <trans-unit id="CouldNotDetermineWinner_NotAnAssembly">
-        <source>NETSDK1040: Could not determine a winner because '{0}' is not an assembly.</source>
-        <target state="translated">NETSDK1040: Der Gewinner konnte nicht bestimmt werden, weil es sich bei "{0}" nicht um eine Assembly handelt.</target>
-        <note>{StrBegin="NETSDK1040: "}</note>
-      </trans-unit>
-      <trans-unit id="EncounteredConflict">
-        <source>NETSDK1041: Encountered conflict between '{0}' and '{1}'.</source>
-        <target state="translated">NETSDK1041: Zwischen "{0}" und "{1}" ist ein Konflikt aufgetreten.</target>
-        <note>{StrBegin="NETSDK1041: "}</note>
-      </trans-unit>
-      <trans-unit id="CouldNotLoadPlatformManifest">
-        <source>NETSDK1042: Could not load PlatformManifest from '{0}' because it did not exist.</source>
-        <target state="translated">NETSDK1042: PlatformManifest konnte nicht von "{0}" geladen werden, weil es nicht vorhanden ist.</target>
-        <note>{StrBegin="NETSDK1042: "}</note>
-      </trans-unit>
-      <trans-unit id="ErrorParsingPlatformManifest">
-        <source>NETSDK1043: Error parsing PlatformManifest from '{0}' line {1}.  Lines must have the format {2}.</source>
-        <target state="translated">NETSDK1043: Fehler beim Analysieren von PlatformManifest von "{0}" Zeile {1}. Zeilen müssen das Format "{2}" aufweisen.</target>
-        <note>{StrBegin="NETSDK1043: "}</note>
-      </trans-unit>
-      <trans-unit id="ErrorParsingPlatformManifestInvalidValue">
-        <source>NETSDK1044: Error parsing PlatformManifest from '{0}' line {1}.  {2} '{3}' was invalid.</source>
-        <target state="translated">NETSDK1044: Fehler beim Analysieren von PlatformManifest von "{0}" Zeile {1}. {2} "{3}" war ungültig.</target>
-        <note>{StrBegin="NETSDK1044: "}</note>
-      </trans-unit>
-      <trans-unit id="UnsupportedTargetFrameworkVersion">
-        <source>NETSDK1045: The current .NET SDK does not support targeting {0} {1}.  Either target {0} {2} or lower, or use a version of the .NET SDK that supports {0} {1}.</source>
-        <target state="translated">NETSDK1045: Das aktuelle .NET SDK unterstützt {0} {1} nicht als Ziel. Geben Sie entweder {0} {2} oder niedriger als Ziel an, oder verwenden Sie eine .NET SDK-Version, die {0} {1} unterstützt.</target>
-        <note>{StrBegin="NETSDK1045: "}</note>
-      </trans-unit>
-      <trans-unit id="AssetsFileMissingRuntimeIdentifier">
-        <source>NETSDK1047: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project. You may also need to include '{3}' in your project's RuntimeIdentifiers.</source>
-        <target state="translated">NETSDK1047: Die Ressourcendatei "{0}" verfügt über kein Ziel für "{1}". Stellen Sie sicher, dass die Wiederherstellung ausgeführt wurde, und dass Sie "{2}" in die TargetFrameworks für Ihr Projekt aufgenommen haben. Unter Umständen müssen Sie auch "{3}" in die RuntimeIdentifiers Ihres Projekts aufnehmen.</target>
-        <note>{StrBegin="NETSDK1047: "}</note>
-      </trans-unit>
-      <trans-unit id="TargetFrameworkWithSemicolon">
-        <source>NETSDK1046: The TargetFramework value '{0}' is not valid. To multi-target, use the 'TargetFrameworks' property instead.</source>
-        <target state="translated">NETSDK1046: Der TargetFramework-Wert "{0}" ist nicht gültig. Verwenden Sie für mehrere Ziele die Eigenschaft "TargetFrameworks".</target>
-        <note>{StrBegin="NETSDK1046: "}</note>
-      </trans-unit>
-      <trans-unit id="SkippingAdditionalProbingPaths">
-        <source>NETSDK1048: 'AdditionalProbingPaths' were specified for GenerateRuntimeConfigurationFiles, but are being skipped because 'RuntimeConfigDevPath' is empty.</source>
-        <target state="translated">NETSDK1048: Für GenerateRuntimeConfigurationFiles wurden "AdditionalProbingPaths" angegeben, sie werden jedoch übersprungen, weil "RuntimeConfigDevPath" leer ist.</target>
-        <note>{StrBegin="NETSDK1048: "}</note>
-      </trans-unit>
-      <trans-unit id="GetDependsOnNETStandardFailedWithException">
-        <source>NETSDK1049: Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0} {1}</source>
-        <target state="translated">NETSDK1049: Die aufgelöste Datei enthält ein fehlerhaftes Image oder keine Metadaten, oder der Zugriff ist aus anderen Gründen nicht möglich. {0} {1}</target>
-        <note>{StrBegin="NETSDK1049: "}</note>
-      </trans-unit>
-      <trans-unit id="UnsupportedSDKVersionForNetStandard20">
-        <source>NETSDK1050: The version of Microsoft.NET.Sdk used by this project is insufficient to support references to libraries targeting .NET Standard 1.5 or higher.  Please install version 2.0 or higher of the .NET Core SDK.</source>
-        <target state="translated">NETSDK1050: Die von diesem Projekt verwendete Microsoft.NET.Sdk-Version reicht zur Unterstützung von Verweisen auf Bibliotheken für .NET Standard 1.5 oder höher nicht aus. Installieren Sie mindestens .NET Core SDK 2.0.</target>
-        <note>{StrBegin="NETSDK1050: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotHaveRuntimeIdentifierPlatformMismatchPlatformTarget">
-        <source>NETSDK1032: The RuntimeIdentifier platform '{0}' and the PlatformTarget '{1}' must be compatible.</source>
-        <target state="translated">NETSDK1032: Die RuntimeIdentifier-Plattform "{0}" und das PlatformTarget "{1}" müssen kompatibel sein.</target>
-        <note>{StrBegin="NETSDK1032: "}</note>
-      </trans-unit>
-      <trans-unit id="ErrorParsingFrameworkListInvalidValue">
-        <source>NETSDK1051: Error parsing FrameworkList from '{0}'.  {1} '{2}' was invalid.</source>
-        <target state="translated">NETSDK1051: Fehler beim Analysieren von FrameworkList aus "{0}". {1} "{2}" war ungültig.</target>
-        <note>{StrBegin="NETSDK1051: "}</note>
-      </trans-unit>
-      <trans-unit id="FrameworkListPathNotRooted">
-        <source>NETSDK1052: Framework list file path '{0}' is not rooted. Only full paths are supported.</source>
-        <target state="translated">NETSDK1052: Der FrameworkList-Dateipfad "{0}" enthält keinen Stamm. Nur vollständige Pfade werden unterstützt.</target>
-        <note>{StrBegin="NETSDK1052: "}</note>
-      </trans-unit>
-      <trans-unit id="PackAsToolCannotSupportSelfContained">
-        <source>NETSDK1053: Pack as tool does not support self contained.</source>
-        <target state="translated">NETSDK1053: Die Paketierung als Tool unterstützt keine eigenständige Bereitstellung.</target>
-        <note>{StrBegin="NETSDK1001: "}</note>
       </trans-unit>
       <trans-unit id="UnsupportedRuntimeIdentifier">
         <source>NETSDK1056: Project is targeting runtime '{0}' but did not resolve any runtime-specific packages. This runtime may not be supported by the target framework.</source>
-        <target state="translated">NETSDK1056: Das Projekt ist auf die Runtime "{0}" ausgelegt, aber hat keine runtimespezifischen Pakete aufgelöst. Diese Runtime wird vom Zielframework möglicherweise nicht unterstützt.</target>
+        <target state="new">NETSDK1056: Project is targeting runtime '{0}' but did not resolve any runtime-specific packages. This runtime may not be supported by the target framework.</target>
         <note>{StrBegin="NETSDK1056: "}</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedSDKVersionForNetStandard20">
+        <source>NETSDK1050: The version of Microsoft.NET.Sdk used by this project is insufficient to support references to libraries targeting .NET Standard 1.5 or higher.  Please install version 2.0 or higher of the .NET Core SDK.</source>
+        <target state="new">NETSDK1050: The version of Microsoft.NET.Sdk used by this project is insufficient to support references to libraries targeting .NET Standard 1.5 or higher.  Please install version 2.0 or higher of the .NET Core SDK.</target>
+        <note>{StrBegin="NETSDK1050: "}</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedTargetFrameworkVersion">
+        <source>NETSDK1045: The current .NET SDK does not support targeting {0} {1}.  Either target {0} {2} or lower, or use a version of the .NET SDK that supports {0} {1}.</source>
+        <target state="new">NETSDK1045: The current .NET SDK does not support targeting {0} {1}.  Either target {0} {2} or lower, or use a version of the .NET SDK that supports {0} {1}.</target>
+        <note>{StrBegin="NETSDK1045: "}</note>
       </trans-unit>
       <trans-unit id="UsingPreviewSdkWarning">
         <source>NETSDK1057: You are using a preview version of .NET Core. See: https://aka.ms/dotnet-core-preview</source>
-        <target state="needs-review-translation">NETSDK1057: Sie arbeiten mit einer Vorschauversion des .NET Core SDK. Sie können die SDK-Version über eine Datei "global.json" im aktuellen Projekt definieren. Weitere Informationen finden Sie unter https://go.microsoft.com/fwlink/?linkid=869452.</target>
+        <target state="new">NETSDK1057: You are using a preview version of .NET Core. See: https://aka.ms/dotnet-core-preview</target>
         <note>{StrBegin="NETSDK1057: "}</note>
-      </trans-unit>
-      <trans-unit id="InvalidItemSpecToUse">
-        <source>NETSDK1058: Invalid value for ItemSpecToUse parameter: '{0}'.  This property must be blank or set to 'Left' or 'Right'</source>
-        <target state="translated">NETSDK1058: Ungültiger Wert für den ItemSpecToUse-Parameter: "{0}". Diese Eigenschaft muss leer oder auf "Left" bzw. "Right" festgelegt sein.</target>
-        <note>{StrBegin="NETSDK1058: "}
-The following are names of parameters or literal values and should not be translated: ItemSpecToUse, Left, Right</note>
-      </trans-unit>
-      <trans-unit id="ProjectContainsObsoleteDotNetCliTool">
-        <source>NETSDK1059: The tool '{0}' is now included in the .NET Core SDK. Information on resolving this warning is available at (https://aka.ms/dotnetclitools-in-box).</source>
-        <target state="translated">NETSDK1059: Das Tool "{0}" ist jetzt im .NET Core SDK enthalten. Informationen zum Auflösen dieser Warnung sind unter https://aka.ms/dotnetclitools-in-box verfügbar.</target>
-        <note>{StrBegin="NETSDK1059: "}</note>
-      </trans-unit>
-      <trans-unit id="ErrorReadingAssetsFile">
-        <source>NETSDK1060: Error reading assets file: {0}</source>
-        <target state="translated">NETSDK1060: Fehler beim Lesen der Ressourcendatei: {0}</target>
-        <note>{StrBegin="NETSDK1060: "}</note>
-      </trans-unit>
-      <trans-unit id="MismatchedPlatformPackageVersion">
-        <source>NETSDK1061: The project was restored using {0} version {1}, but with current settings, version {2} would be used instead. To resolve this issue, make sure the same settings are used for restore and for subsequent operations such as build or publish. Typically this issue can occur if the RuntimeIdentifier property is set during build or publish but not during restore. For more information, see https://aka.ms/dotnet-runtime-patch-selection.</source>
-        <target state="translated">NETSDK1061: Das Projekt wurde mit {0}, Version {1} wiederhergestellt, aber mit den aktuellen Einstellungen würde stattdessen Version {2} verwendet werden. Um dieses Problem zu beheben, müssen Sie sicherstellen, dass für die Wiederherstellung und für nachfolgende Vorgänge wie das Kompilieren oder Veröffentlichen dieselben Einstellungen verwendet werden. Dieses Problem tritt typischerweise auf, wenn die RuntimeIdentifier-Eigenschaft bei der Kompilierung oder Veröffentlichung, aber nicht bei der Wiederherstellung festgelegt wird. Weitere Informationen finden Sie unter https://aka.ms/dotnet-runtime-patch-selection.</target>
-        <note>{StrBegin="NETSDK1061: "}
-{0} - Package Identifier for platform package
-{1} - Restored version of platform package
-{2} - Current version of platform package</note>
-      </trans-unit>
-      <trans-unit id="AssetsFileNotSet">
-        <source>NETSDK1063: The path to the project assets file was not set. Run a NuGet package restore to generate this file.</source>
-        <target state="translated">NETSDK1063: Der Pfad zur Datei mit den Projektobjekten wurde nicht festgelegt. Führen Sie eine NuGet-Paketwiederherstellung durch, um diese Datei zu generieren.</target>
-        <note>{StrBegin="NETSDK1063: "}</note>
-      </trans-unit>
-      <trans-unit id="DotnetToolOnlySupportNetcoreapp">
-        <source>NETSDK1054: only supports .NET Core.</source>
-        <target state="translated">NETSDK1054: Unterstützt nur .NET Core.</target>
-        <note>{StrBegin="NETSDK1054: "}</note>
-      </trans-unit>
-      <trans-unit id="DotnetToolDoesNotSupportTFMLowerThanNetcoreapp21">
-        <source>NETSDK1055: DotnetTool does not support target framework lower than netcoreapp2.1.</source>
-        <target state="translated">NETSDK1055: DotnetTool unterstützt kein Zielframework vor netcoreapp2.1.</target>
-        <note>{StrBegin="NETSDK1055: "}</note>
-      </trans-unit>
-      <trans-unit id="UnableToUsePackageAssetsCache">
-        <source>NETSDK1062: Unable to use package assets cache due to I/O error. This can occur when the same project is built more than once in parallel. Performance may be degraded, but the build result will not be impacted.</source>
-        <target state="translated">NETSDK1062: Der Cache für Paketressourcen kann aufgrund eines E/A-Fehlers nicht verwendet werden. Dieses Problem kann auftreten, wenn dasselbe Projekt gleichzeitig mehrfach kompiliert wird. Die Leistung ist möglicherweise herabgesetzt, aber das Buildergebnis wird nicht beeinträchtigt.</target>
-        <note>{StrBegin="NETSDK1062: "}</note>
-      </trans-unit>
-      <trans-unit id="PackageNotFound">
-        <source>NETSDK1064: Package {0}, version {1} was not found. It might have been deleted since NuGet restore. Otherwise, NuGet restore might have only partially completed, which might have been due to maximum path length restrictions.</source>
-        <target state="translated">NETSDK1064: Das Paket "{0}", Version {1}, wurde nicht gefunden. Möglicherweise wurde es nach der NuGet-Wiederherstellung gelöscht. Andernfalls wurde die NuGet-Wiederherstellung aufgrund von Beschränkungen der maximalen Pfadlänge eventuell nur teilweise abgeschlossen.</target>
-        <note>{StrBegin="NETSDK1064: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotFindApphostForRid">
-        <source>NETSDK1065: Cannot find app host for {0}. {0} could be an invalid runtime identifier (RID). For more information about RID, see https://aka.ms/rid-catalog.</source>
-        <target state="translated">NETSDK1065: Der App-Host für "{0}" wurde nicht gefunden. "{0}" könnte ein ungültiger Runtimebezeichner (RID) sein. Weitere Informationen zum RID finden Sie unter https://aka.ms/rid-catalog.</target>
-        <note>{StrBegin="NETSDK1065: "}</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Tasks/Common/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.de.xlf
@@ -67,6 +67,19 @@
         <target state="translated">NETSDK1008: Die Metadaten "{0}" für das Element "{2}" vom Typ "{1}" sind nicht vorhanden.</target>
         <note>{StrBegin="NETSDK1008: "}</note>
       </trans-unit>
+      <trans-unit id="RecommendFrameworkReferenceForAspNetCorePackages">
+        <source>NETSDK1071: A PackageReference for '{0}' was included in your project. Referencing this item as NuGet package is no longer supported. To resolve this warning, change the PackageReference to a FrameworkReference. For more information, see {1}.</source>
+        <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. Referencing this item as NuGet package is no longer supported. To resolve this warning, change the PackageReference to a FrameworkReference. For more information, see {1}.</target>
+        <note>{StrBegin="NETSDK1072: "}
+{0} - Package Id (Microsoft.AspNetCore.App or .All)
+{1} - More info link
+    </note>
+      </trans-unit>
+      <trans-unit id="UnknownFrameworkReference">
+        <source>NETSDK1072: The FrameworkReference '{0}' was not recognized.</source>
+        <target state="new">NETSDK1072: The FrameworkReference '{0}' was not recognized.</target>
+        <note>{StrBegin="NETSDK1072: "}</note>
+      </trans-unit>
       <trans-unit id="UnrecognizedPreprocessorToken">
         <source>NETSDK1009: Unrecognized preprocessor token '{0}' in '{1}'.</source>
         <target state="translated">NETSDK1009: Unbekanntes Präprozessortoken "{0}" in "{1}".</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.es.xlf
@@ -67,6 +67,19 @@
         <target state="translated">NETSDK1008: Faltan los metadatos de "{0}" en el elemento de "{1}" "{2}".</target>
         <note>{StrBegin="NETSDK1008: "}</note>
       </trans-unit>
+      <trans-unit id="RecommendFrameworkReferenceForAspNetCorePackages">
+        <source>NETSDK1071: A PackageReference for '{0}' was included in your project. Referencing this item as NuGet package is no longer supported. To resolve this warning, change the PackageReference to a FrameworkReference. For more information, see {1}.</source>
+        <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. Referencing this item as NuGet package is no longer supported. To resolve this warning, change the PackageReference to a FrameworkReference. For more information, see {1}.</target>
+        <note>{StrBegin="NETSDK1072: "}
+{0} - Package Id (Microsoft.AspNetCore.App or .All)
+{1} - More info link
+    </note>
+      </trans-unit>
+      <trans-unit id="UnknownFrameworkReference">
+        <source>NETSDK1072: The FrameworkReference '{0}' was not recognized.</source>
+        <target state="new">NETSDK1072: The FrameworkReference '{0}' was not recognized.</target>
+        <note>{StrBegin="NETSDK1072: "}</note>
+      </trans-unit>
       <trans-unit id="UnrecognizedPreprocessorToken">
         <source>NETSDK1009: Unrecognized preprocessor token '{0}' in '{1}'.</source>
         <target state="translated">NETSDK1009: Token de preprocesador no reconocido "{0}" en "{1}".</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.es.xlf
@@ -70,7 +70,7 @@
       <trans-unit id="RecommendFrameworkReferenceForAspNetCorePackages">
         <source>NETSDK1071: A PackageReference for '{0}' was included in your project. Referencing this item as NuGet package is no longer supported. To resolve this warning, change the PackageReference to a FrameworkReference. For more information, see {1}.</source>
         <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. Referencing this item as NuGet package is no longer supported. To resolve this warning, change the PackageReference to a FrameworkReference. For more information, see {1}.</target>
-        <note>{StrBegin="NETSDK1072: "}
+        <note>{StrBegin="NETSDK1071: "}
 {0} - Package Id (Microsoft.AspNetCore.App or .All)
 {1} - More info link
     </note>

--- a/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
@@ -67,6 +67,19 @@
         <target state="translated">NETSDK1008: Métadonnées '{0}' manquantes sur l'élément '{1}' '{2}'.</target>
         <note>{StrBegin="NETSDK1008: "}</note>
       </trans-unit>
+      <trans-unit id="RecommendFrameworkReferenceForAspNetCorePackages">
+        <source>NETSDK1071: A PackageReference for '{0}' was included in your project. Referencing this item as NuGet package is no longer supported. To resolve this warning, change the PackageReference to a FrameworkReference. For more information, see {1}.</source>
+        <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. Referencing this item as NuGet package is no longer supported. To resolve this warning, change the PackageReference to a FrameworkReference. For more information, see {1}.</target>
+        <note>{StrBegin="NETSDK1072: "}
+{0} - Package Id (Microsoft.AspNetCore.App or .All)
+{1} - More info link
+    </note>
+      </trans-unit>
+      <trans-unit id="UnknownFrameworkReference">
+        <source>NETSDK1072: The FrameworkReference '{0}' was not recognized.</source>
+        <target state="new">NETSDK1072: The FrameworkReference '{0}' was not recognized.</target>
+        <note>{StrBegin="NETSDK1072: "}</note>
+      </trans-unit>
       <trans-unit id="UnrecognizedPreprocessorToken">
         <source>NETSDK1009: Unrecognized preprocessor token '{0}' in '{1}'.</source>
         <target state="translated">NETSDK1009: Jeton de préprocesseur '{0}' non reconnu dans '{1}'.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../Strings.resx">
     <body>
@@ -7,73 +7,332 @@
         <target state="new">NETSDK1070: The application configuration file must have root configuration element.</target>
         <note>{StrBegin="NETSDK1070: "}</note>
       </trans-unit>
+      <trans-unit id="AppHostHasBeenModified">
+        <source>NETSDK1029: Unable to use '{0}' as application host executable as it does not contain the expected placeholder byte sequence '{1}' that would mark where the application name would be written.</source>
+        <target state="new">NETSDK1029: Unable to use '{0}' as application host executable as it does not contain the expected placeholder byte sequence '{1}' that would mark where the application name would be written.</target>
+        <note>{StrBegin="NETSDK1029: "}</note>
+      </trans-unit>
+      <trans-unit id="AssetPreprocessorMustBeConfigured">
+        <source>NETSDK1017: Asset preprocessor must be configured before assets are processed.</source>
+        <target state="new">NETSDK1017: Asset preprocessor must be configured before assets are processed.</target>
+        <note>{StrBegin="NETSDK1017: "}</note>
+      </trans-unit>
+      <trans-unit id="AssetsFileMissingRuntimeIdentifier">
+        <source>NETSDK1047: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project. You may also need to include '{3}' in your project's RuntimeIdentifiers.</source>
+        <target state="new">NETSDK1047: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project. You may also need to include '{3}' in your project's RuntimeIdentifiers.</target>
+        <note>{StrBegin="NETSDK1047: "}</note>
+      </trans-unit>
+      <trans-unit id="AssetsFileMissingTarget">
+        <source>NETSDK1005: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project.</source>
+        <target state="new">NETSDK1005: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project.</target>
+        <note>{StrBegin="NETSDK1005: "}</note>
+      </trans-unit>
+      <trans-unit id="AssetsFileNotFound">
+        <source>NETSDK1004: Assets file '{0}' not found. Run a NuGet package restore to generate this file.</source>
+        <target state="new">NETSDK1004: Assets file '{0}' not found. Run a NuGet package restore to generate this file.</target>
+        <note>{StrBegin="NETSDK1004: "}</note>
+      </trans-unit>
+      <trans-unit id="AssetsFileNotSet">
+        <source>NETSDK1063: The path to the project assets file was not set. Run a NuGet package restore to generate this file.</source>
+        <target state="new">NETSDK1063: The path to the project assets file was not set. Run a NuGet package restore to generate this file.</target>
+        <note>{StrBegin="NETSDK1063: "}</note>
+      </trans-unit>
+      <trans-unit id="AssetsFilePathNotRooted">
+        <source>NETSDK1006: Assets file path '{0}' is not rooted. Only full paths are supported.</source>
+        <target state="new">NETSDK1006: Assets file path '{0}' is not rooted. Only full paths are supported.</target>
+        <note>{StrBegin="NETSDK1006: "}</note>
+      </trans-unit>
       <trans-unit id="AtLeastOneTargetFrameworkMustBeSpecified">
         <source>NETSDK1001: At least one possible target framework must be specified.</source>
-        <target state="translated">NETSDK1001: Vous devez spécifier au moins un framework cible.</target>
+        <target state="new">NETSDK1001: At least one possible target framework must be specified.</target>
         <note>{StrBegin="NETSDK1001: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotFindApphostForRid">
+        <source>NETSDK1065: Cannot find app host for {0}. {0} could be an invalid runtime identifier (RID). For more information about RID, see https://aka.ms/rid-catalog.</source>
+        <target state="new">NETSDK1065: Cannot find app host for {0}. {0} could be an invalid runtime identifier (RID). For more information about RID, see https://aka.ms/rid-catalog.</target>
+        <note>{StrBegin="NETSDK1065: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotFindProjectInfo">
+        <source>NETSDK1007: Cannot find project info for '{0}'. This can indicate a missing project reference.</source>
+        <target state="new">NETSDK1007: Cannot find project info for '{0}'. This can indicate a missing project reference.</target>
+        <note>{StrBegin="NETSDK1007: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotHaveRuntimeIdentifierPlatformMismatchPlatformTarget">
+        <source>NETSDK1032: The RuntimeIdentifier platform '{0}' and the PlatformTarget '{1}' must be compatible.</source>
+        <target state="new">NETSDK1032: The RuntimeIdentifier platform '{0}' and the PlatformTarget '{1}' must be compatible.</target>
+        <note>{StrBegin="NETSDK1032: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotHaveSelfContainedWithoutRuntimeIdentifier">
+        <source>NETSDK1031: It is not supported to build or publish a self-contained application without specifying a RuntimeIdentifier.  Please either specify a RuntimeIdentifier or set SelfContained to false.</source>
+        <target state="new">NETSDK1031: It is not supported to build or publish a self-contained application without specifying a RuntimeIdentifier.  Please either specify a RuntimeIdentifier or set SelfContained to false.</target>
+        <note>{StrBegin="NETSDK1031: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotInferTargetFrameworkIdentiferAndVersion">
+        <source>NETSDK1013: The TargetFramework value '{0}' was not recognized. It may be misspelled. If not, then the TargetFrameworkIdentifier and/or TargetFrameworkVersion properties must be specified explicitly.</source>
+        <target state="new">NETSDK1013: The TargetFramework value '{0}' was not recognized. It may be misspelled. If not, then the TargetFrameworkIdentifier and/or TargetFrameworkVersion properties must be specified explicitly.</target>
+        <note>{StrBegin="NETSDK1013: "}</note>
       </trans-unit>
       <trans-unit id="CannotUseAppHostWithoutRuntimeIdentifier">
         <source>NETSDK1066: A RuntimeIdentifier must be specified to publish a framework-dependent application with an application host.</source>
-        <target state="translated">NETSDK1066: Un RuntimeIdentifier doit être spécifié pour publier une application dépendante du framework avec un hôte d'application.</target>
+        <target state="new">NETSDK1066: A RuntimeIdentifier must be specified to publish a framework-dependent application with an application host.</target>
         <note>{StrBegin="NETSDK1066: "}</note>
       </trans-unit>
       <trans-unit id="CannotUseSelfContainedWithoutAppHost">
         <source>NETSDK1067: Self-contained applications are required to use the application host. Either set SelfContained to false or set UseAppHost to true.</source>
-        <target state="translated">NETSDK1067: Des applications autonomes sont obligatoires pour utiliser l'hôte d'application. Définissez SelfContained avec la valeur false ou UseAppHost avec la valeur true.</target>
+        <target state="new">NETSDK1067: Self-contained applications are required to use the application host. Either set SelfContained to false or set UseAppHost to true.</target>
         <note>{StrBegin="NETSDK1067: "}</note>
+      </trans-unit>
+      <trans-unit id="ChoosingAssemblyVersion">
+        <source>NETSDK1033: Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</source>
+        <target state="new">NETSDK1033: Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</target>
+        <note>{StrBegin="NETSDK1033: "}</note>
+      </trans-unit>
+      <trans-unit id="ChoosingFileVersion">
+        <source>NETSDK1034: Choosing '{0}' because file version '{1}' is greater than '{2}'.</source>
+        <target state="new">NETSDK1034: Choosing '{0}' because file version '{1}' is greater than '{2}'.</target>
+        <note>{StrBegin="NETSDK1034: "}</note>
+      </trans-unit>
+      <trans-unit id="ChoosingPlatformItem">
+        <source>NETSDK1035: Choosing '{0}' because it is a platform item.</source>
+        <target state="new">NETSDK1035: Choosing '{0}' because it is a platform item.</target>
+        <note>{StrBegin="NETSDK1035: "}</note>
+      </trans-unit>
+      <trans-unit id="ChoosingPreferredPackage">
+        <source>NETSDK1036: Choosing '{0}' because it comes from a package that is preferred.</source>
+        <target state="new">NETSDK1036: Choosing '{0}' because it comes from a package that is preferred.</target>
+        <note>{StrBegin="NETSDK1036: "}</note>
+      </trans-unit>
+      <trans-unit id="ConflictCouldNotDetermineWinner">
+        <source>NETSDK1037: Could not determine winner due to equal file and assembly versions.</source>
+        <target state="new">NETSDK1037: Could not determine winner due to equal file and assembly versions.</target>
+        <note>{StrBegin="NETSDK1037: "}</note>
+      </trans-unit>
+      <trans-unit id="ContentItemDoesNotProvideOutputPath">
+        <source>NETSDK1014: Content item for '{0}' sets '{1}', but does not provide  '{2}' or '{3}'.</source>
+        <target state="new">NETSDK1014: Content item for '{0}' sets '{1}', but does not provide  '{2}' or '{3}'.</target>
+        <note>{StrBegin="NETSDK1014: "}</note>
+      </trans-unit>
+      <trans-unit id="ContentPreproccessorParameterRequired">
+        <source>NETSDK1010: The '{0}' task must be given a value for parameter '{1}' in order to consume preprocessed content.</source>
+        <target state="new">NETSDK1010: The '{0}' task must be given a value for parameter '{1}' in order to consume preprocessed content.</target>
+        <note>{StrBegin="NETSDK1010: "}</note>
+      </trans-unit>
+      <trans-unit id="CouldNotDetermineWinner_DoesntExist">
+        <source>NETSDK1038: Could not determine winner because '{0}' does not exist.</source>
+        <target state="new">NETSDK1038: Could not determine winner because '{0}' does not exist.</target>
+        <note>{StrBegin="NETSDK1001: "}</note>
+      </trans-unit>
+      <trans-unit id="CouldNotDetermineWinner_FileVersion">
+        <source>NETSDK1039: Could not determine a winner because '{0}' has no file version.</source>
+        <target state="new">NETSDK1039: Could not determine a winner because '{0}' has no file version.</target>
+        <note>{StrBegin="NETSDK1039: "}</note>
+      </trans-unit>
+      <trans-unit id="CouldNotDetermineWinner_NotAnAssembly">
+        <source>NETSDK1040: Could not determine a winner because '{0}' is not an assembly.</source>
+        <target state="new">NETSDK1040: Could not determine a winner because '{0}' is not an assembly.</target>
+        <note>{StrBegin="NETSDK1040: "}</note>
+      </trans-unit>
+      <trans-unit id="CouldNotLoadPlatformManifest">
+        <source>NETSDK1042: Could not load PlatformManifest from '{0}' because it did not exist.</source>
+        <target state="new">NETSDK1042: Could not load PlatformManifest from '{0}' because it did not exist.</target>
+        <note>{StrBegin="NETSDK1042: "}</note>
+      </trans-unit>
+      <trans-unit id="DotnetToolDoesNotSupportTFMLowerThanNetcoreapp21">
+        <source>NETSDK1055: DotnetTool does not support target framework lower than netcoreapp2.1.</source>
+        <target state="new">NETSDK1055: DotnetTool does not support target framework lower than netcoreapp2.1.</target>
+        <note>{StrBegin="NETSDK1055: "}</note>
+      </trans-unit>
+      <trans-unit id="DotnetToolOnlySupportNetcoreapp">
+        <source>NETSDK1054: only supports .NET Core.</source>
+        <target state="new">NETSDK1054: only supports .NET Core.</target>
+        <note>{StrBegin="NETSDK1054: "}</note>
+      </trans-unit>
+      <trans-unit id="DuplicateItemsError">
+        <source>NETSDK1022: Duplicate '{0}' items were included. The .NET SDK includes '{0}' items from your project directory by default. You can either remove these items from your project file, or set the '{1}' property to '{2}' if you want to explicitly include them in your project file. For more information, see {4}. The duplicate items were: {3}</source>
+        <target state="new">NETSDK1022: Duplicate '{0}' items were included. The .NET SDK includes '{0}' items from your project directory by default. You can either remove these items from your project file, or set the '{1}' property to '{2}' if you want to explicitly include them in your project file. For more information, see {4}. The duplicate items were: {3}</target>
+        <note>{StrBegin="NETSDK1022: "}</note>
+      </trans-unit>
+      <trans-unit id="DuplicatePreprocessorToken">
+        <source>NETSDK1015: The preprocessor token '{0}' has been given more than one value. Choosing '{1}' as the value.</source>
+        <target state="new">NETSDK1015: The preprocessor token '{0}' has been given more than one value. Choosing '{1}' as the value.</target>
+        <note>{StrBegin="NETSDK1015: "}</note>
+      </trans-unit>
+      <trans-unit id="EncounteredConflict">
+        <source>NETSDK1041: Encountered conflict between '{0}' and '{1}'.</source>
+        <target state="new">NETSDK1041: Encountered conflict between '{0}' and '{1}'.</target>
+        <note>{StrBegin="NETSDK1041: "}</note>
+      </trans-unit>
+      <trans-unit id="ErrorParsingFrameworkListInvalidValue">
+        <source>NETSDK1051: Error parsing FrameworkList from '{0}'.  {1} '{2}' was invalid.</source>
+        <target state="new">NETSDK1051: Error parsing FrameworkList from '{0}'.  {1} '{2}' was invalid.</target>
+        <note>{StrBegin="NETSDK1051: "}</note>
+      </trans-unit>
+      <trans-unit id="ErrorParsingPlatformManifest">
+        <source>NETSDK1043: Error parsing PlatformManifest from '{0}' line {1}.  Lines must have the format {2}.</source>
+        <target state="new">NETSDK1043: Error parsing PlatformManifest from '{0}' line {1}.  Lines must have the format {2}.</target>
+        <note>{StrBegin="NETSDK1043: "}</note>
+      </trans-unit>
+      <trans-unit id="ErrorParsingPlatformManifestInvalidValue">
+        <source>NETSDK1044: Error parsing PlatformManifest from '{0}' line {1}.  {2} '{3}' was invalid.</source>
+        <target state="new">NETSDK1044: Error parsing PlatformManifest from '{0}' line {1}.  {2} '{3}' was invalid.</target>
+        <note>{StrBegin="NETSDK1044: "}</note>
+      </trans-unit>
+      <trans-unit id="ErrorReadingAssetsFile">
+        <source>NETSDK1060: Error reading assets file: {0}</source>
+        <target state="new">NETSDK1060: Error reading assets file: {0}</target>
+        <note>{StrBegin="NETSDK1060: "}</note>
+      </trans-unit>
+      <trans-unit id="FileNameIsTooLong">
+        <source>NETSDK1030: Given file name '{0}' is longer than 1024 bytes</source>
+        <target state="new">NETSDK1030: Given file name '{0}' is longer than 1024 bytes</target>
+        <note>{StrBegin="NETSDK1030: "}</note>
+      </trans-unit>
+      <trans-unit id="FolderAlreadyExists">
+        <source>NETSDK1024: Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</source>
+        <target state="new">NETSDK1024: Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</target>
+        <note>{StrBegin="NETSDK1024: "}</note>
       </trans-unit>
       <trans-unit id="FrameworkDependentAppHostRequiresVersion21">
         <source>NETSDK1068: The framework-dependent application host requires a target framework of at least 'netcoreapp2.1'.</source>
-        <target state="translated">NETSDK1068: L'hôte d'application dépendant du framework nécessite au minimum le framework cible 'netcoreapp2.1'.</target>
+        <target state="new">NETSDK1068: The framework-dependent application host requires a target framework of at least 'netcoreapp2.1'.</target>
         <note>{StrBegin="NETSDK1068: "}</note>
+      </trans-unit>
+      <trans-unit id="FrameworkListPathNotRooted">
+        <source>NETSDK1052: Framework list file path '{0}' is not rooted. Only full paths are supported.</source>
+        <target state="new">NETSDK1052: Framework list file path '{0}' is not rooted. Only full paths are supported.</target>
+        <note>{StrBegin="NETSDK1052: "}</note>
+      </trans-unit>
+      <trans-unit id="GetDependsOnNETStandardFailedWithException">
+        <source>NETSDK1049: Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0} {1}</source>
+        <target state="new">NETSDK1049: Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0} {1}</target>
+        <note>{StrBegin="NETSDK1049: "}</note>
+      </trans-unit>
+      <trans-unit id="IncorrectPackageRoot">
+        <source>NETSDK1020: Package Root {0} was incorrectly given for Resolved library {1}</source>
+        <target state="new">NETSDK1020: Package Root {0} was incorrectly given for Resolved library {1}</target>
+        <note>{StrBegin="NETSDK1020: "}</note>
+      </trans-unit>
+      <trans-unit id="IncorrectTargetFormat">
+        <source>NETSDK1025: WRThe target manifest {0} provided is of not the correct format</source>
+        <target state="new">NETSDK1025: WRThe target manifest {0} provided is of not the correct format</target>
+        <note>{StrBegin="NETSDK1025: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidFrameworkName">
+        <source>NETSDK1003: Invalid framework name: '{0}'.</source>
+        <target state="new">NETSDK1003: Invalid framework name: '{0}'.</target>
+        <note>{StrBegin="NETSDK1003: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidItemSpecToUse">
+        <source>NETSDK1058: Invalid value for ItemSpecToUse parameter: '{0}'.  This property must be blank or set to 'Left' or 'Right'</source>
+        <target state="new">NETSDK1058: Invalid value for ItemSpecToUse parameter: '{0}'.  This property must be blank or set to 'Left' or 'Right'</target>
+        <note>{StrBegin="NETSDK1058: "}
+The following are names of parameters or literal values and should not be translated: ItemSpecToUse, Left, Right</note>
+      </trans-unit>
+      <trans-unit id="InvalidNuGetVersionString">
+        <source>NETSDK1018: Invalid NuGet version string: '{0}'.</source>
+        <target state="new">NETSDK1018: Invalid NuGet version string: '{0}'.</target>
+        <note>{StrBegin="NETSDK1018: "}</note>
+      </trans-unit>
+      <trans-unit id="MismatchedPlatformPackageVersion">
+        <source>NETSDK1061: The project was restored using {0} version {1}, but with current settings, version {2} would be used instead. To resolve this issue, make sure the same settings are used for restore and for subsequent operations such as build or publish. Typically this issue can occur if the RuntimeIdentifier property is set during build or publish but not during restore. For more information, see https://aka.ms/dotnet-runtime-patch-selection.</source>
+        <target state="new">NETSDK1061: The project was restored using {0} version {1}, but with current settings, version {2} would be used instead. To resolve this issue, make sure the same settings are used for restore and for subsequent operations such as build or publish. Typically this issue can occur if the RuntimeIdentifier property is set during build or publish but not during restore. For more information, see https://aka.ms/dotnet-runtime-patch-selection.</target>
+        <note>{StrBegin="NETSDK1061: "}
+{0} - Package Identifier for platform package
+{1} - Restored version of platform package
+{2} - Current version of platform package</note>
+      </trans-unit>
+      <trans-unit id="MissingItemMetadata">
+        <source>NETSDK1008: Missing '{0}' metadata on '{1}' item '{2}'.</source>
+        <target state="new">NETSDK1008: Missing '{0}' metadata on '{1}' item '{2}'.</target>
+        <note>{StrBegin="NETSDK1008: "}</note>
+      </trans-unit>
+      <trans-unit id="MultipleFilesResolved">
+        <source>NETSDK1021: More than one file found for {0}</source>
+        <target state="new">NETSDK1021: More than one file found for {0}</target>
+        <note>{StrBegin="NETSDK1021: "}</note>
       </trans-unit>
       <trans-unit id="NETFrameworkToNonBuiltInNETStandard">
         <source>NETSDK1069: This project uses a library that targets .NET Standard 1.5 or higher, and the project targets a version of .NET Framework that doesn't have built-in support for that version of .NET Standard. Visit https://aka.ms/net-standard-known-issues for a set of known issues. Consider retargeting to .NET Framework 4.7.2.</source>
-        <target state="translated">NETSDK1069: Ce projet utilise une bibliothèque qui cible .NET Standard 1.5 ou ultérieur, et le projet cible une version du .NET Framework qui n'intègre pas la prise en charge de cette version de .NET Standard. Pour obtenir la liste des problèmes connus, visitez https://aka.ms/net-standard-known-issues. Songez à cibler le .NET Framework 4.7.2.</target>
+        <target state="new">NETSDK1069: This project uses a library that targets .NET Standard 1.5 or higher, and the project targets a version of .NET Framework that doesn't have built-in support for that version of .NET Standard. Visit https://aka.ms/net-standard-known-issues for a set of known issues. Consider retargeting to .NET Framework 4.7.2.</target>
         <note>{StrBegin="NETSDK1069: "}</note>
       </trans-unit>
       <trans-unit id="NoCompatibleTargetFramework">
         <source>NETSDK1002: Project '{0}' targets '{2}'. It cannot be referenced by a project that targets '{1}'.</source>
-        <target state="translated">NETSDK1002: Le projet '{0}' cible '{2}'. Il ne peut pas être référencé par un projet qui cible '{1}'.</target>
+        <target state="new">NETSDK1002: Project '{0}' targets '{2}'. It cannot be referenced by a project that targets '{1}'.</target>
         <note>{StrBegin="NETSDK1002: "}</note>
       </trans-unit>
-      <trans-unit id="InvalidFrameworkName">
-        <source>NETSDK1003: Invalid framework name: '{0}'.</source>
-        <target state="translated">NETSDK1003: Nom de framework non valide : '{0}'.</target>
-        <note>{StrBegin="NETSDK1003: "}</note>
+      <trans-unit id="PackAsToolCannotSupportSelfContained">
+        <source>NETSDK1053: Pack as tool does not support self contained.</source>
+        <target state="new">NETSDK1053: Pack as tool does not support self contained.</target>
+        <note>{StrBegin="NETSDK1001: "}</note>
       </trans-unit>
-      <trans-unit id="AssetsFileNotFound">
-        <source>NETSDK1004: Assets file '{0}' not found. Run a NuGet package restore to generate this file.</source>
-        <target state="translated">NETSDK1004: Le fichier de composants '{0}' est introuvable. Exécutez une restauration de package NuGet pour générer ce fichier.</target>
-        <note>{StrBegin="NETSDK1004: "}</note>
+      <trans-unit id="PackageInfoLog">
+        <source>NETSDK1027: Package Name='{0}', Version='{1}' was parsed</source>
+        <target state="new">NETSDK1027: Package Name='{0}', Version='{1}' was parsed</target>
+        <note>{StrBegin="NETSDK1027: "}</note>
       </trans-unit>
-      <trans-unit id="AssetsFileMissingTarget">
-        <source>NETSDK1005: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project.</source>
-        <target state="translated">NETSDK1005: Le fichier de composants '{0}' n'a aucune cible pour '{1}'. Vérifiez que la restauration s'est exécutée et que vous avez inclus '{2}' dans TargetFrameworks pour votre projet.</target>
-        <note>{StrBegin="NETSDK1005: "}</note>
+      <trans-unit id="PackageNotFound">
+        <source>NETSDK1064: Package {0}, version {1} was not found. It might have been deleted since NuGet restore. Otherwise, NuGet restore might have only partially completed, which might have been due to maximum path length restrictions.</source>
+        <target state="new">NETSDK1064: Package {0}, version {1} was not found. It might have been deleted since NuGet restore. Otherwise, NuGet restore might have only partially completed, which might have been due to maximum path length restrictions.</target>
+        <note>{StrBegin="NETSDK1064: "}</note>
       </trans-unit>
-      <trans-unit id="AssetsFilePathNotRooted">
-        <source>NETSDK1006: Assets file path '{0}' is not rooted. Only full paths are supported.</source>
-        <target state="translated">NETSDK1006: Le chemin du fichier de composants '{0}' n'est pas associé à une racine. Seuls les chemins complets sont pris en charge.</target>
-        <note>{StrBegin="NETSDK1006: "}</note>
+      <trans-unit id="PackageReferenceOverrideWarning">
+        <source>NETSDK1023: A PackageReference for '{0}' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see {1}</source>
+        <target state="new">NETSDK1023: A PackageReference for '{0}' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see {1}</target>
+        <note>{StrBegin="NETSDK1023: "}</note>
       </trans-unit>
-      <trans-unit id="CannotFindProjectInfo">
-        <source>NETSDK1007: Cannot find project info for '{0}'. This can indicate a missing project reference.</source>
-        <target state="translated">NETSDK1007: Les informations relatives au projet sont introuvables pour '{0}'. Cela peut indiquer une référence de projet manquante.</target>
-        <note>{StrBegin="NETSDK1007: "}</note>
+      <trans-unit id="ParsingFiles">
+        <source>NETSDK1026: Parsing the Files : '{0}'</source>
+        <target state="new">NETSDK1026: Parsing the Files : '{0}'</target>
+        <note>{StrBegin="NETSDK1026: "}</note>
       </trans-unit>
-      <trans-unit id="MissingItemMetadata">
-        <source>NETSDK1008: Missing '{0}' metadata on '{1}' item '{2}'.</source>
-        <target state="translated">NETSDK1008: Métadonnées '{0}' manquantes sur l'élément '{1}' '{2}'.</target>
-        <note>{StrBegin="NETSDK1008: "}</note>
+      <trans-unit id="ProjectAssetsConsumedWithoutMSBuildProjectPath">
+        <source>NETSDK1011: Assets are consumed from project '{0}', but no corresponding MSBuild project path was  found in '{1}'.</source>
+        <target state="new">NETSDK1011: Assets are consumed from project '{0}', but no corresponding MSBuild project path was  found in '{1}'.</target>
+        <note>{StrBegin="NETSDK1011: "}</note>
+      </trans-unit>
+      <trans-unit id="ProjectContainsObsoleteDotNetCliTool">
+        <source>NETSDK1059: The tool '{0}' is now included in the .NET Core SDK. Information on resolving this warning is available at (https://aka.ms/dotnetclitools-in-box).</source>
+        <target state="new">NETSDK1059: The tool '{0}' is now included in the .NET Core SDK. Information on resolving this warning is available at (https://aka.ms/dotnetclitools-in-box).</target>
+        <note>{StrBegin="NETSDK1059: "}</note>
       </trans-unit>
       <trans-unit id="RecommendFrameworkReferenceForAspNetCorePackages">
         <source>NETSDK1071: A PackageReference for '{0}' was included in your project. Referencing this item as NuGet package is no longer supported. To resolve this warning, change the PackageReference to a FrameworkReference. For more information, see {1}.</source>
         <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. Referencing this item as NuGet package is no longer supported. To resolve this warning, change the PackageReference to a FrameworkReference. For more information, see {1}.</target>
-        <note>{StrBegin="NETSDK1072: "}
+        <note>{StrBegin="NETSDK1071: "}
 {0} - Package Id (Microsoft.AspNetCore.App or .All)
 {1} - More info link
     </note>
+      </trans-unit>
+      <trans-unit id="RuntimeIdentifierWasNotSpecified">
+        <source>NETSDK1028: Specify a RuntimeIdentifier</source>
+        <target state="new">NETSDK1028: Specify a RuntimeIdentifier</target>
+        <note>{StrBegin="NETSDK1028: "}</note>
+      </trans-unit>
+      <trans-unit id="SkippingAdditionalProbingPaths">
+        <source>NETSDK1048: 'AdditionalProbingPaths' were specified for GenerateRuntimeConfigurationFiles, but are being skipped because 'RuntimeConfigDevPath' is empty.</source>
+        <target state="new">NETSDK1048: 'AdditionalProbingPaths' were specified for GenerateRuntimeConfigurationFiles, but are being skipped because 'RuntimeConfigDevPath' is empty.</target>
+        <note>{StrBegin="NETSDK1048: "}</note>
+      </trans-unit>
+      <trans-unit id="TargetFrameworkWithSemicolon">
+        <source>NETSDK1046: The TargetFramework value '{0}' is not valid. To multi-target, use the 'TargetFrameworks' property instead.</source>
+        <target state="new">NETSDK1046: The TargetFramework value '{0}' is not valid. To multi-target, use the 'TargetFrameworks' property instead.</target>
+        <note>{StrBegin="NETSDK1046: "}</note>
+      </trans-unit>
+      <trans-unit id="UnableToFindResolvedPath">
+        <source>NETSDK1016: Unable to find resolved path for '{0}'.</source>
+        <target state="new">NETSDK1016: Unable to find resolved path for '{0}'.</target>
+        <note>{StrBegin="NETSDK1016: "}</note>
+      </trans-unit>
+      <trans-unit id="UnableToUsePackageAssetsCache">
+        <source>NETSDK1062: Unable to use package assets cache due to I/O error. This can occur when the same project is built more than once in parallel. Performance may be degraded, but the build result will not be impacted.</source>
+        <target state="new">NETSDK1062: Unable to use package assets cache due to I/O error. This can occur when the same project is built more than once in parallel. Performance may be degraded, but the build result will not be impacted.</target>
+        <note>{StrBegin="NETSDK1062: "}</note>
+      </trans-unit>
+      <trans-unit id="UnexpectedFileType">
+        <source>NETSDK1012: Unexpected file type for '{0}'. Type is both '{1}' and '{2}'.</source>
+        <target state="new">NETSDK1012: Unexpected file type for '{0}'. Type is both '{1}' and '{2}'.</target>
+        <note>{StrBegin="NETSDK1012: "}</note>
       </trans-unit>
       <trans-unit id="UnknownFrameworkReference">
         <source>NETSDK1072: The FrameworkReference '{0}' was not recognized.</source>
@@ -82,292 +341,33 @@
       </trans-unit>
       <trans-unit id="UnrecognizedPreprocessorToken">
         <source>NETSDK1009: Unrecognized preprocessor token '{0}' in '{1}'.</source>
-        <target state="translated">NETSDK1009: Jeton de préprocesseur '{0}' non reconnu dans '{1}'.</target>
+        <target state="new">NETSDK1009: Unrecognized preprocessor token '{0}' in '{1}'.</target>
         <note>{StrBegin="NETSDK1009: "}</note>
-      </trans-unit>
-      <trans-unit id="ContentPreproccessorParameterRequired">
-        <source>NETSDK1010: The '{0}' task must be given a value for parameter '{1}' in order to consume preprocessed content.</source>
-        <target state="translated">NETSDK1010: La tâche '{0}' doit recevoir une valeur pour le paramètre '{1}', ce qui permet la consommation du contenu prétraité.</target>
-        <note>{StrBegin="NETSDK1010: "}</note>
-      </trans-unit>
-      <trans-unit id="ProjectAssetsConsumedWithoutMSBuildProjectPath">
-        <source>NETSDK1011: Assets are consumed from project '{0}', but no corresponding MSBuild project path was  found in '{1}'.</source>
-        <target state="translated">NETSDK1011: Les composants sont consommés à partir du projet '{0}', mais il n'existe aucun chemin de projet MSBuild correspondant dans '{1}'.</target>
-        <note>{StrBegin="NETSDK1011: "}</note>
-      </trans-unit>
-      <trans-unit id="UnexpectedFileType">
-        <source>NETSDK1012: Unexpected file type for '{0}'. Type is both '{1}' and '{2}'.</source>
-        <target state="translated">NETSDK1012: Type de fichier inattendu pour '{0}'. Le type est à la fois '{1}' et '{2}'.</target>
-        <note>{StrBegin="NETSDK1012: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotInferTargetFrameworkIdentiferAndVersion">
-        <source>NETSDK1013: The TargetFramework value '{0}' was not recognized. It may be misspelled. If not, then the TargetFrameworkIdentifier and/or TargetFrameworkVersion properties must be specified explicitly.</source>
-        <target state="translated">NETSDK1013: La valeur TargetFramework '{0}' n'a pas été reconnue. Elle est peut-être mal orthographiée. Sinon, vous devez spécifier explicitement les propriétés TargetFrameworkIdentifier et/ou TargetFrameworkVersion.</target>
-        <note>{StrBegin="NETSDK1013: "}</note>
-      </trans-unit>
-      <trans-unit id="ContentItemDoesNotProvideOutputPath">
-        <source>NETSDK1014: Content item for '{0}' sets '{1}', but does not provide  '{2}' or '{3}'.</source>
-        <target state="translated">NETSDK1014: L'élément de contenu pour '{0}' définit '{1}', mais ne fournit ni '{2}' ni '{3}'.</target>
-        <note>{StrBegin="NETSDK1014: "}</note>
-      </trans-unit>
-      <trans-unit id="DuplicatePreprocessorToken">
-        <source>NETSDK1015: The preprocessor token '{0}' has been given more than one value. Choosing '{1}' as the value.</source>
-        <target state="translated">NETSDK1015: Le jeton de préprocesseur '{0}' a reçu plusieurs valeurs. La valeur choisie est '{1}'.</target>
-        <note>{StrBegin="NETSDK1015: "}</note>
-      </trans-unit>
-      <trans-unit id="UnableToFindResolvedPath">
-        <source>NETSDK1016: Unable to find resolved path for '{0}'.</source>
-        <target state="translated">NETSDK1016: Chemin résolu introuvable pour '{0}'.</target>
-        <note>{StrBegin="NETSDK1016: "}</note>
-      </trans-unit>
-      <trans-unit id="AssetPreprocessorMustBeConfigured">
-        <source>NETSDK1017: Asset preprocessor must be configured before assets are processed.</source>
-        <target state="translated">NETSDK1017: Le préprocesseur de composants doit être configuré avant le traitement des composants.</target>
-        <note>{StrBegin="NETSDK1017: "}</note>
-      </trans-unit>
-      <trans-unit id="InvalidNuGetVersionString">
-        <source>NETSDK1018: Invalid NuGet version string: '{0}'.</source>
-        <target state="translated">NETSDK1018: Chaîne de version NuGet non valide : '{0}'.</target>
-        <note>{StrBegin="NETSDK1018: "}</note>
       </trans-unit>
       <trans-unit id="UnsupportedFramework">
         <source>NETSDK1019: {0} is an unsupported framework.</source>
-        <target state="translated">NETSDK1019: {0} est un framework non pris en charge.</target>
+        <target state="new">NETSDK1019: {0} is an unsupported framework.</target>
         <note>{StrBegin="NETSDK1019: "}</note>
-      </trans-unit>
-      <trans-unit id="DuplicateItemsError">
-        <source>NETSDK1022: Duplicate '{0}' items were included. The .NET SDK includes '{0}' items from your project directory by default. You can either remove these items from your project file, or set the '{1}' property to '{2}' if you want to explicitly include them in your project file. For more information, see {4}. The duplicate items were: {3}</source>
-        <target state="translated">NETSDK1022: Des éléments '{0}' dupliqués ont été inclus. Le kit .NET SDK inclut les éléments '{0}' de votre répertoire de projet par défaut. Vous pouvez supprimer ces éléments de votre fichier projet ou affecter à la propriété '{1}' la valeur '{2}', si vous souhaitez les inclure explicitement dans votre fichier projet. Pour plus d'informations, consultez {4}. Les éléments dupliqués sont les suivants : {3}</target>
-        <note>{StrBegin="NETSDK1022: "}</note>
-      </trans-unit>
-      <trans-unit id="PackageReferenceOverrideWarning">
-        <source>NETSDK1023: A PackageReference for '{0}' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see {1}</source>
-        <target state="translated">NETSDK1023: Un PackageReference pour '{0}' a été inclus dans votre projet. Comme ce package est implicitement référencé par le kit .NET SDK, vous n'avez généralement pas besoin de le référencer à partir de votre projet. Pour plus d'informations, consultez {1}</target>
-        <note>{StrBegin="NETSDK1023: "}</note>
-      </trans-unit>
-      <trans-unit id="IncorrectPackageRoot">
-        <source>NETSDK1020: Package Root {0} was incorrectly given for Resolved library {1}</source>
-        <target state="translated">NETSDK1020: La racine de package {0} a été spécifiée de manière incorrecte pour la bibliothèque Resolved {1}</target>
-        <note>{StrBegin="NETSDK1020: "}</note>
-      </trans-unit>
-      <trans-unit id="MultipleFilesResolved">
-        <source>NETSDK1021: More than one file found for {0}</source>
-        <target state="translated">NETSDK1021: Plusieurs fichiers ont été trouvés pour {0}</target>
-        <note>{StrBegin="NETSDK1021: "}</note>
-      </trans-unit>
-      <trans-unit id="FolderAlreadyExists">
-        <source>NETSDK1024: Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</source>
-        <target state="translated">NETSDK1024: Le dossier '{0}' existe déjà. Supprimez-le ou indiquez un autre ComposeWorkingDir</target>
-        <note>{StrBegin="NETSDK1024: "}</note>
-      </trans-unit>
-      <trans-unit id="ParsingFiles">
-        <source>NETSDK1026: Parsing the Files : '{0}'</source>
-        <target state="translated">NETSDK1026: Analyse des fichiers : '{0}'</target>
-        <note>{StrBegin="NETSDK1026: "}</note>
-      </trans-unit>
-      <trans-unit id="PackageInfoLog">
-        <source>NETSDK1027: Package Name='{0}', Version='{1}' was parsed</source>
-        <target state="translated">NETSDK1027: Le package ayant pour nom '{0}' et pour version '{1}' a été analysé</target>
-        <note>{StrBegin="NETSDK1027: "}</note>
-      </trans-unit>
-      <trans-unit id="RuntimeIdentifierWasNotSpecified">
-        <source>NETSDK1028: Specify a RuntimeIdentifier</source>
-        <target state="translated">NETSDK1028: Spécifiez un RuntimeIdentifier</target>
-        <note>{StrBegin="NETSDK1028: "}</note>
-      </trans-unit>
-      <trans-unit id="IncorrectTargetFormat">
-        <source>NETSDK1025: WRThe target manifest {0} provided is of not the correct format</source>
-        <target state="translated">NETSDK1025: Le manifeste cible {0} fourni n'est pas au format approprié</target>
-        <note>{StrBegin="NETSDK1025: "}</note>
-      </trans-unit>
-      <trans-unit id="AppHostHasBeenModified">
-        <source>NETSDK1029: Unable to use '{0}' as application host executable as it does not contain the expected placeholder byte sequence '{1}' that would mark where the application name would be written.</source>
-        <target state="translated">NETSDK1029: Impossible d'utiliser '{0}' en tant qu'exécutable d'hôte d'application, car il ne contient pas la séquence d'octets d'espace réservé attendue '{1}' qui marque l'emplacement où est écrit le nom de l'application.</target>
-        <note>{StrBegin="NETSDK1029: "}</note>
-      </trans-unit>
-      <trans-unit id="FileNameIsTooLong">
-        <source>NETSDK1030: Given file name '{0}' is longer than 1024 bytes</source>
-        <target state="translated">NETSDK1030: Le nom de fichier spécifié '{0}' dépasse 1 024 octets</target>
-        <note>{StrBegin="NETSDK1030: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotHaveSelfContainedWithoutRuntimeIdentifier">
-        <source>NETSDK1031: It is not supported to build or publish a self-contained application without specifying a RuntimeIdentifier.  Please either specify a RuntimeIdentifier or set SelfContained to false.</source>
-        <target state="translated">NETSDK1031: La génération ou la publication d'une application autonome sans spécification de RuntimeIdentifier n'est pas prise en charge. Spécifiez RuntimeIdentifier ou affectez la valeur false à SelfContained.</target>
-        <note>{StrBegin="NETSDK1031: "}</note>
-      </trans-unit>
-      <trans-unit id="ChoosingAssemblyVersion">
-        <source>NETSDK1033: Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</source>
-        <target state="translated">NETSDK1033: '{0}' choisi, car AssemblyVersion '{1}' est supérieur à '{2}'.</target>
-        <note>{StrBegin="NETSDK1033: "}</note>
-      </trans-unit>
-      <trans-unit id="ChoosingFileVersion">
-        <source>NETSDK1034: Choosing '{0}' because file version '{1}' is greater than '{2}'.</source>
-        <target state="translated">NETSDK1034: '{0}' choisi, car la version de fichier '{1}' est supérieure à '{2}'.</target>
-        <note>{StrBegin="NETSDK1034: "}</note>
-      </trans-unit>
-      <trans-unit id="ChoosingPlatformItem">
-        <source>NETSDK1035: Choosing '{0}' because it is a platform item.</source>
-        <target state="translated">NETSDK1035: '{0}' choisi, car il s'agit d'un élément de plateforme.</target>
-        <note>{StrBegin="NETSDK1035: "}</note>
-      </trans-unit>
-      <trans-unit id="ChoosingPreferredPackage">
-        <source>NETSDK1036: Choosing '{0}' because it comes from a package that is preferred.</source>
-        <target state="translated">NETSDK1036: '{0}' choisi, car il provient d'un package préféré.</target>
-        <note>{StrBegin="NETSDK1036: "}</note>
-      </trans-unit>
-      <trans-unit id="ConflictCouldNotDetermineWinner">
-        <source>NETSDK1037: Could not determine winner due to equal file and assembly versions.</source>
-        <target state="translated">NETSDK1037: Impossible de déterminer le gagnant, car les versions de fichier et d'assembly sont identiques.</target>
-        <note>{StrBegin="NETSDK1037: "}</note>
-      </trans-unit>
-      <trans-unit id="CouldNotDetermineWinner_DoesntExist">
-        <source>NETSDK1038: Could not determine winner because '{0}' does not exist.</source>
-        <target state="translated">NETSDK1038: Impossible de déterminer le gagnant, car '{0}' n'existe pas.</target>
-        <note>{StrBegin="NETSDK1001: "}</note>
-      </trans-unit>
-      <trans-unit id="CouldNotDetermineWinner_FileVersion">
-        <source>NETSDK1039: Could not determine a winner because '{0}' has no file version.</source>
-        <target state="translated">NETSDK1039: Impossible de déterminer un gagnant, car '{0}' n'a aucune version de fichier.</target>
-        <note>{StrBegin="NETSDK1039: "}</note>
-      </trans-unit>
-      <trans-unit id="CouldNotDetermineWinner_NotAnAssembly">
-        <source>NETSDK1040: Could not determine a winner because '{0}' is not an assembly.</source>
-        <target state="translated">NETSDK1040: Impossible de déterminer un gagnant, car '{0}' n'est pas un assembly.</target>
-        <note>{StrBegin="NETSDK1040: "}</note>
-      </trans-unit>
-      <trans-unit id="EncounteredConflict">
-        <source>NETSDK1041: Encountered conflict between '{0}' and '{1}'.</source>
-        <target state="translated">NETSDK1041: Conflit détecté entre '{0}' et '{1}'.</target>
-        <note>{StrBegin="NETSDK1041: "}</note>
-      </trans-unit>
-      <trans-unit id="CouldNotLoadPlatformManifest">
-        <source>NETSDK1042: Could not load PlatformManifest from '{0}' because it did not exist.</source>
-        <target state="translated">NETSDK1042: Impossible de charger PlatformManifest à partir de '{0}', car il n'existe pas.</target>
-        <note>{StrBegin="NETSDK1042: "}</note>
-      </trans-unit>
-      <trans-unit id="ErrorParsingPlatformManifest">
-        <source>NETSDK1043: Error parsing PlatformManifest from '{0}' line {1}.  Lines must have the format {2}.</source>
-        <target state="translated">NETSDK1043: Erreur durant l'analyse de PlatformManifest à partir de la ligne '{0}' {1}. Les lignes doivent avoir le format {2}.</target>
-        <note>{StrBegin="NETSDK1043: "}</note>
-      </trans-unit>
-      <trans-unit id="ErrorParsingPlatformManifestInvalidValue">
-        <source>NETSDK1044: Error parsing PlatformManifest from '{0}' line {1}.  {2} '{3}' was invalid.</source>
-        <target state="translated">NETSDK1044: Erreur durant l'analyse de PlatformManifest à partir de la ligne '{0}' {1}. {2} '{3}' est non valide.</target>
-        <note>{StrBegin="NETSDK1044: "}</note>
-      </trans-unit>
-      <trans-unit id="UnsupportedTargetFrameworkVersion">
-        <source>NETSDK1045: The current .NET SDK does not support targeting {0} {1}.  Either target {0} {2} or lower, or use a version of the .NET SDK that supports {0} {1}.</source>
-        <target state="translated">NETSDK1045: Le kit .NET SDK actuel ne prend pas en charge le ciblage de {0} {1}. Vous devez soit cibler {0} {2} ou une version antérieure, soit utiliser une version du kit .NET SDK qui prend en charge {0} {1}.</target>
-        <note>{StrBegin="NETSDK1045: "}</note>
-      </trans-unit>
-      <trans-unit id="AssetsFileMissingRuntimeIdentifier">
-        <source>NETSDK1047: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project. You may also need to include '{3}' in your project's RuntimeIdentifiers.</source>
-        <target state="translated">NETSDK1047: Le fichier de composants '{0}' n'a aucune cible pour '{1}'. Vérifiez que la restauration s'est exécutée et que vous avez inclus '{2}' dans TargetFrameworks pour votre projet. Vous devrez peut-être également inclure '{3}' dans les RuntimeIdentifiers de votre projet.</target>
-        <note>{StrBegin="NETSDK1047: "}</note>
-      </trans-unit>
-      <trans-unit id="TargetFrameworkWithSemicolon">
-        <source>NETSDK1046: The TargetFramework value '{0}' is not valid. To multi-target, use the 'TargetFrameworks' property instead.</source>
-        <target state="translated">NETSDK1046: La valeur TargetFramework '{0}' est non valide. Pour effectuer un multiciblage, utilisez la propriété 'TargetFrameworks' à la place.</target>
-        <note>{StrBegin="NETSDK1046: "}</note>
-      </trans-unit>
-      <trans-unit id="SkippingAdditionalProbingPaths">
-        <source>NETSDK1048: 'AdditionalProbingPaths' were specified for GenerateRuntimeConfigurationFiles, but are being skipped because 'RuntimeConfigDevPath' is empty.</source>
-        <target state="translated">NETSDK1048: Des 'AdditionalProbingPaths' ont été spécifiés pour GenerateRuntimeConfigurationFiles, mais ils sont ignorés, car 'RuntimeConfigDevPath' est vide.</target>
-        <note>{StrBegin="NETSDK1048: "}</note>
-      </trans-unit>
-      <trans-unit id="GetDependsOnNETStandardFailedWithException">
-        <source>NETSDK1049: Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0} {1}</source>
-        <target state="translated">NETSDK1049: Le fichier résolu a une image incorrecte, ne comporte pas de métadonnées ou n'est pas accessible. {0} {1}</target>
-        <note>{StrBegin="NETSDK1049: "}</note>
-      </trans-unit>
-      <trans-unit id="UnsupportedSDKVersionForNetStandard20">
-        <source>NETSDK1050: The version of Microsoft.NET.Sdk used by this project is insufficient to support references to libraries targeting .NET Standard 1.5 or higher.  Please install version 2.0 or higher of the .NET Core SDK.</source>
-        <target state="translated">NETSDK1050: La version de Microsoft.NET.Sdk utilisée par ce projet ne permet pas de prendre en charge les références aux bibliothèques ciblant .NET Standard 1.5 ou une version ultérieure. Installez la version 2.0 ou une version ultérieure du kit SDK .NET Core.</target>
-        <note>{StrBegin="NETSDK1050: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotHaveRuntimeIdentifierPlatformMismatchPlatformTarget">
-        <source>NETSDK1032: The RuntimeIdentifier platform '{0}' and the PlatformTarget '{1}' must be compatible.</source>
-        <target state="translated">NETSDK1032: La plateforme de RuntimeIdentifier '{0}' et le PlatformTarget '{1}' doivent être compatibles.</target>
-        <note>{StrBegin="NETSDK1032: "}</note>
-      </trans-unit>
-      <trans-unit id="ErrorParsingFrameworkListInvalidValue">
-        <source>NETSDK1051: Error parsing FrameworkList from '{0}'.  {1} '{2}' was invalid.</source>
-        <target state="translated">NETSDK1051: Erreur durant l'analyse de FrameworkList à partir de '{0}'. {1} '{2}' est non valide.</target>
-        <note>{StrBegin="NETSDK1051: "}</note>
-      </trans-unit>
-      <trans-unit id="FrameworkListPathNotRooted">
-        <source>NETSDK1052: Framework list file path '{0}' is not rooted. Only full paths are supported.</source>
-        <target state="translated">NETSDK1052: Le chemin du fichier de liste de frameworks '{0}' n'est pas associé à une racine. Seuls les chemins complets sont pris en charge.</target>
-        <note>{StrBegin="NETSDK1052: "}</note>
-      </trans-unit>
-      <trans-unit id="PackAsToolCannotSupportSelfContained">
-        <source>NETSDK1053: Pack as tool does not support self contained.</source>
-        <target state="translated">NETSDK1053: L'outil de compression ne prend pas en charge l'autonomie.</target>
-        <note>{StrBegin="NETSDK1001: "}</note>
       </trans-unit>
       <trans-unit id="UnsupportedRuntimeIdentifier">
         <source>NETSDK1056: Project is targeting runtime '{0}' but did not resolve any runtime-specific packages. This runtime may not be supported by the target framework.</source>
-        <target state="translated">NETSDK1056: Le projet cible le runtime '{0}' mais n'a résolu aucun package spécifique au runtime. Ce runtime risque de ne pas être pris en charge par le framework cible.</target>
+        <target state="new">NETSDK1056: Project is targeting runtime '{0}' but did not resolve any runtime-specific packages. This runtime may not be supported by the target framework.</target>
         <note>{StrBegin="NETSDK1056: "}</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedSDKVersionForNetStandard20">
+        <source>NETSDK1050: The version of Microsoft.NET.Sdk used by this project is insufficient to support references to libraries targeting .NET Standard 1.5 or higher.  Please install version 2.0 or higher of the .NET Core SDK.</source>
+        <target state="new">NETSDK1050: The version of Microsoft.NET.Sdk used by this project is insufficient to support references to libraries targeting .NET Standard 1.5 or higher.  Please install version 2.0 or higher of the .NET Core SDK.</target>
+        <note>{StrBegin="NETSDK1050: "}</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedTargetFrameworkVersion">
+        <source>NETSDK1045: The current .NET SDK does not support targeting {0} {1}.  Either target {0} {2} or lower, or use a version of the .NET SDK that supports {0} {1}.</source>
+        <target state="new">NETSDK1045: The current .NET SDK does not support targeting {0} {1}.  Either target {0} {2} or lower, or use a version of the .NET SDK that supports {0} {1}.</target>
+        <note>{StrBegin="NETSDK1045: "}</note>
       </trans-unit>
       <trans-unit id="UsingPreviewSdkWarning">
         <source>NETSDK1057: You are using a preview version of .NET Core. See: https://aka.ms/dotnet-core-preview</source>
-        <target state="needs-review-translation">NETSDK1057: Vous utilisez une préversion du kit SDK .NET Core. Vous pouvez définir la version du kit SDK via un fichier global.json dans le projet actif. Pour plus d'informations, consultez https://go.microsoft.com/fwlink/?linkid=869452</target>
+        <target state="new">NETSDK1057: You are using a preview version of .NET Core. See: https://aka.ms/dotnet-core-preview</target>
         <note>{StrBegin="NETSDK1057: "}</note>
-      </trans-unit>
-      <trans-unit id="InvalidItemSpecToUse">
-        <source>NETSDK1058: Invalid value for ItemSpecToUse parameter: '{0}'.  This property must be blank or set to 'Left' or 'Right'</source>
-        <target state="translated">NETSDK1058: Valeur non valide pour le paramètre ItemSpecToUse : '{0}'. Cette propriété doit être vide ou doit avoir la valeur 'Left' ou 'Right'</target>
-        <note>{StrBegin="NETSDK1058: "}
-The following are names of parameters or literal values and should not be translated: ItemSpecToUse, Left, Right</note>
-      </trans-unit>
-      <trans-unit id="ProjectContainsObsoleteDotNetCliTool">
-        <source>NETSDK1059: The tool '{0}' is now included in the .NET Core SDK. Information on resolving this warning is available at (https://aka.ms/dotnetclitools-in-box).</source>
-        <target state="translated">NETSDK1059: L'outil '{0}' est désormais inclus dans le kit SDK .NET Core. Des informations sur la résolution de cet avertissement sont disponibles en ligne (https://aka.ms/dotnetclitools-in-box).</target>
-        <note>{StrBegin="NETSDK1059: "}</note>
-      </trans-unit>
-      <trans-unit id="ErrorReadingAssetsFile">
-        <source>NETSDK1060: Error reading assets file: {0}</source>
-        <target state="translated">NETSDK1060: Erreur durant la lecture du fichier de composants : {0}</target>
-        <note>{StrBegin="NETSDK1060: "}</note>
-      </trans-unit>
-      <trans-unit id="MismatchedPlatformPackageVersion">
-        <source>NETSDK1061: The project was restored using {0} version {1}, but with current settings, version {2} would be used instead. To resolve this issue, make sure the same settings are used for restore and for subsequent operations such as build or publish. Typically this issue can occur if the RuntimeIdentifier property is set during build or publish but not during restore. For more information, see https://aka.ms/dotnet-runtime-patch-selection.</source>
-        <target state="translated">NETSDK1061 : Le projet a été restauré avec la version {0} {1}, mais avec les paramètres actuels, la version {2} serait utilisée à la place. Pour résoudre ce problème, assurez-vous que les mêmes paramètres sont utilisés pour la restauration et pour les opérations ultérieures telles que la génération et la publication. Généralement, ce problème peut se produire si la propriété RuntimeIdentifier est définie au cours de la génération ou de la publication, mais pas pendant la restauration. Pour plus d’informations, consultez https://aka.ms/dotnet-runtime-patch-selection.</target>
-        <note>{StrBegin="NETSDK1061: "}
-{0} - Package Identifier for platform package
-{1} - Restored version of platform package
-{2} - Current version of platform package</note>
-      </trans-unit>
-      <trans-unit id="AssetsFileNotSet">
-        <source>NETSDK1063: The path to the project assets file was not set. Run a NuGet package restore to generate this file.</source>
-        <target state="translated">NETSDK1063: Le chemin du fichier de composants du projet n'a pas été défini. Exécutez une restauration de package NuGet pour générer ce fichier.</target>
-        <note>{StrBegin="NETSDK1063: "}</note>
-      </trans-unit>
-      <trans-unit id="DotnetToolOnlySupportNetcoreapp">
-        <source>NETSDK1054: only supports .NET Core.</source>
-        <target state="translated">NETSDK1054: prend uniquement en charge .NET Core.</target>
-        <note>{StrBegin="NETSDK1054: "}</note>
-      </trans-unit>
-      <trans-unit id="DotnetToolDoesNotSupportTFMLowerThanNetcoreapp21">
-        <source>NETSDK1055: DotnetTool does not support target framework lower than netcoreapp2.1.</source>
-        <target state="translated">NETSDK1055: DotnetTool ne prend pas en charge de framework cible inférieur à netcoreapp2.1.</target>
-        <note>{StrBegin="NETSDK1055: "}</note>
-      </trans-unit>
-      <trans-unit id="UnableToUsePackageAssetsCache">
-        <source>NETSDK1062: Unable to use package assets cache due to I/O error. This can occur when the same project is built more than once in parallel. Performance may be degraded, but the build result will not be impacted.</source>
-        <target state="translated">NETSDK1062: Impossible d'utiliser le cache de composants du package en raison d'une erreur d'E/S. Cela peut se produire quand un même projet est généré plusieurs fois en parallèle. Les performances peuvent être impactées, mais pas le résultat de la génération.</target>
-        <note>{StrBegin="NETSDK1062: "}</note>
-      </trans-unit>
-      <trans-unit id="PackageNotFound">
-        <source>NETSDK1064: Package {0}, version {1} was not found. It might have been deleted since NuGet restore. Otherwise, NuGet restore might have only partially completed, which might have been due to maximum path length restrictions.</source>
-        <target state="translated">NETSDK1064: Le package {0}, version {1}, est introuvable. Il a peut-être été supprimé depuis la restauration NuGet. Sinon, la restauration NuGet a peut-être été partiellement effectuée en raison de restrictions appliquées à la longueur maximale du chemin.</target>
-        <note>{StrBegin="NETSDK1064: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotFindApphostForRid">
-        <source>NETSDK1065: Cannot find app host for {0}. {0} could be an invalid runtime identifier (RID). For more information about RID, see https://aka.ms/rid-catalog.</source>
-        <target state="translated">NETSDK1065: hôte d'application introuvable pour {0}. {0} est peut-être un RID (identificateur de runtime) non valide. Pour plus d'informations sur les RID, consultez https://aka.ms/rid-catalog.</target>
-        <note>{StrBegin="NETSDK1065: "}</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Tasks/Common/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.it.xlf
@@ -70,7 +70,7 @@
       <trans-unit id="RecommendFrameworkReferenceForAspNetCorePackages">
         <source>NETSDK1071: A PackageReference for '{0}' was included in your project. Referencing this item as NuGet package is no longer supported. To resolve this warning, change the PackageReference to a FrameworkReference. For more information, see {1}.</source>
         <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. Referencing this item as NuGet package is no longer supported. To resolve this warning, change the PackageReference to a FrameworkReference. For more information, see {1}.</target>
-        <note>{StrBegin="NETSDK1072: "}
+        <note>{StrBegin="NETSDK1071: "}
 {0} - Package Id (Microsoft.AspNetCore.App or .All)
 {1} - More info link
     </note>

--- a/src/Tasks/Common/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.it.xlf
@@ -67,6 +67,19 @@
         <target state="translated">NETSDK1008: mancano i metadati di '{0}' sull'elemento '{2}' di '{1}'.</target>
         <note>{StrBegin="NETSDK1008: "}</note>
       </trans-unit>
+      <trans-unit id="RecommendFrameworkReferenceForAspNetCorePackages">
+        <source>NETSDK1071: A PackageReference for '{0}' was included in your project. Referencing this item as NuGet package is no longer supported. To resolve this warning, change the PackageReference to a FrameworkReference. For more information, see {1}.</source>
+        <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. Referencing this item as NuGet package is no longer supported. To resolve this warning, change the PackageReference to a FrameworkReference. For more information, see {1}.</target>
+        <note>{StrBegin="NETSDK1072: "}
+{0} - Package Id (Microsoft.AspNetCore.App or .All)
+{1} - More info link
+    </note>
+      </trans-unit>
+      <trans-unit id="UnknownFrameworkReference">
+        <source>NETSDK1072: The FrameworkReference '{0}' was not recognized.</source>
+        <target state="new">NETSDK1072: The FrameworkReference '{0}' was not recognized.</target>
+        <note>{StrBegin="NETSDK1072: "}</note>
+      </trans-unit>
       <trans-unit id="UnrecognizedPreprocessorToken">
         <source>NETSDK1009: Unrecognized preprocessor token '{0}' in '{1}'.</source>
         <target state="translated">NETSDK1009: token di preprocessore '{0}' non riconosciuto in '{1}'.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
@@ -67,6 +67,19 @@
         <target state="translated">NETSDK1008: '{1}' 項目 '{2}' の '{0}' メタデータがありません。</target>
         <note>{StrBegin="NETSDK1008: "}</note>
       </trans-unit>
+      <trans-unit id="RecommendFrameworkReferenceForAspNetCorePackages">
+        <source>NETSDK1071: A PackageReference for '{0}' was included in your project. Referencing this item as NuGet package is no longer supported. To resolve this warning, change the PackageReference to a FrameworkReference. For more information, see {1}.</source>
+        <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. Referencing this item as NuGet package is no longer supported. To resolve this warning, change the PackageReference to a FrameworkReference. For more information, see {1}.</target>
+        <note>{StrBegin="NETSDK1072: "}
+{0} - Package Id (Microsoft.AspNetCore.App or .All)
+{1} - More info link
+    </note>
+      </trans-unit>
+      <trans-unit id="UnknownFrameworkReference">
+        <source>NETSDK1072: The FrameworkReference '{0}' was not recognized.</source>
+        <target state="new">NETSDK1072: The FrameworkReference '{0}' was not recognized.</target>
+        <note>{StrBegin="NETSDK1072: "}</note>
+      </trans-unit>
       <trans-unit id="UnrecognizedPreprocessorToken">
         <source>NETSDK1009: Unrecognized preprocessor token '{0}' in '{1}'.</source>
         <target state="translated">NETSDK1009: 認識されないプリプロセッサ トークン '{0}' が '{1}' に存在します。</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
@@ -70,7 +70,7 @@
       <trans-unit id="RecommendFrameworkReferenceForAspNetCorePackages">
         <source>NETSDK1071: A PackageReference for '{0}' was included in your project. Referencing this item as NuGet package is no longer supported. To resolve this warning, change the PackageReference to a FrameworkReference. For more information, see {1}.</source>
         <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. Referencing this item as NuGet package is no longer supported. To resolve this warning, change the PackageReference to a FrameworkReference. For more information, see {1}.</target>
-        <note>{StrBegin="NETSDK1072: "}
+        <note>{StrBegin="NETSDK1071: "}
 {0} - Package Id (Microsoft.AspNetCore.App or .All)
 {1} - More info link
     </note>

--- a/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../Strings.resx">
     <body>
@@ -7,354 +7,367 @@
         <target state="new">NETSDK1070: The application configuration file must have root configuration element.</target>
         <note>{StrBegin="NETSDK1070: "}</note>
       </trans-unit>
+      <trans-unit id="AppHostHasBeenModified">
+        <source>NETSDK1029: Unable to use '{0}' as application host executable as it does not contain the expected placeholder byte sequence '{1}' that would mark where the application name would be written.</source>
+        <target state="new">NETSDK1029: Unable to use '{0}' as application host executable as it does not contain the expected placeholder byte sequence '{1}' that would mark where the application name would be written.</target>
+        <note>{StrBegin="NETSDK1029: "}</note>
+      </trans-unit>
+      <trans-unit id="AssetPreprocessorMustBeConfigured">
+        <source>NETSDK1017: Asset preprocessor must be configured before assets are processed.</source>
+        <target state="new">NETSDK1017: Asset preprocessor must be configured before assets are processed.</target>
+        <note>{StrBegin="NETSDK1017: "}</note>
+      </trans-unit>
+      <trans-unit id="AssetsFileMissingRuntimeIdentifier">
+        <source>NETSDK1047: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project. You may also need to include '{3}' in your project's RuntimeIdentifiers.</source>
+        <target state="new">NETSDK1047: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project. You may also need to include '{3}' in your project's RuntimeIdentifiers.</target>
+        <note>{StrBegin="NETSDK1047: "}</note>
+      </trans-unit>
+      <trans-unit id="AssetsFileMissingTarget">
+        <source>NETSDK1005: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project.</source>
+        <target state="new">NETSDK1005: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project.</target>
+        <note>{StrBegin="NETSDK1005: "}</note>
+      </trans-unit>
+      <trans-unit id="AssetsFileNotFound">
+        <source>NETSDK1004: Assets file '{0}' not found. Run a NuGet package restore to generate this file.</source>
+        <target state="new">NETSDK1004: Assets file '{0}' not found. Run a NuGet package restore to generate this file.</target>
+        <note>{StrBegin="NETSDK1004: "}</note>
+      </trans-unit>
+      <trans-unit id="AssetsFileNotSet">
+        <source>NETSDK1063: The path to the project assets file was not set. Run a NuGet package restore to generate this file.</source>
+        <target state="new">NETSDK1063: The path to the project assets file was not set. Run a NuGet package restore to generate this file.</target>
+        <note>{StrBegin="NETSDK1063: "}</note>
+      </trans-unit>
+      <trans-unit id="AssetsFilePathNotRooted">
+        <source>NETSDK1006: Assets file path '{0}' is not rooted. Only full paths are supported.</source>
+        <target state="new">NETSDK1006: Assets file path '{0}' is not rooted. Only full paths are supported.</target>
+        <note>{StrBegin="NETSDK1006: "}</note>
+      </trans-unit>
       <trans-unit id="AtLeastOneTargetFrameworkMustBeSpecified">
         <source>NETSDK1001: At least one possible target framework must be specified.</source>
-        <target state="translated">NETSDK1001: 가능한 대상 프레임워크를 하나 이상 지정해야 합니다.</target>
+        <target state="new">NETSDK1001: At least one possible target framework must be specified.</target>
         <note>{StrBegin="NETSDK1001: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotFindApphostForRid">
+        <source>NETSDK1065: Cannot find app host for {0}. {0} could be an invalid runtime identifier (RID). For more information about RID, see https://aka.ms/rid-catalog.</source>
+        <target state="new">NETSDK1065: Cannot find app host for {0}. {0} could be an invalid runtime identifier (RID). For more information about RID, see https://aka.ms/rid-catalog.</target>
+        <note>{StrBegin="NETSDK1065: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotFindProjectInfo">
+        <source>NETSDK1007: Cannot find project info for '{0}'. This can indicate a missing project reference.</source>
+        <target state="new">NETSDK1007: Cannot find project info for '{0}'. This can indicate a missing project reference.</target>
+        <note>{StrBegin="NETSDK1007: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotHaveRuntimeIdentifierPlatformMismatchPlatformTarget">
+        <source>NETSDK1032: The RuntimeIdentifier platform '{0}' and the PlatformTarget '{1}' must be compatible.</source>
+        <target state="new">NETSDK1032: The RuntimeIdentifier platform '{0}' and the PlatformTarget '{1}' must be compatible.</target>
+        <note>{StrBegin="NETSDK1032: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotHaveSelfContainedWithoutRuntimeIdentifier">
+        <source>NETSDK1031: It is not supported to build or publish a self-contained application without specifying a RuntimeIdentifier.  Please either specify a RuntimeIdentifier or set SelfContained to false.</source>
+        <target state="new">NETSDK1031: It is not supported to build or publish a self-contained application without specifying a RuntimeIdentifier.  Please either specify a RuntimeIdentifier or set SelfContained to false.</target>
+        <note>{StrBegin="NETSDK1031: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotInferTargetFrameworkIdentiferAndVersion">
+        <source>NETSDK1013: The TargetFramework value '{0}' was not recognized. It may be misspelled. If not, then the TargetFrameworkIdentifier and/or TargetFrameworkVersion properties must be specified explicitly.</source>
+        <target state="new">NETSDK1013: The TargetFramework value '{0}' was not recognized. It may be misspelled. If not, then the TargetFrameworkIdentifier and/or TargetFrameworkVersion properties must be specified explicitly.</target>
+        <note>{StrBegin="NETSDK1013: "}</note>
       </trans-unit>
       <trans-unit id="CannotUseAppHostWithoutRuntimeIdentifier">
         <source>NETSDK1066: A RuntimeIdentifier must be specified to publish a framework-dependent application with an application host.</source>
-        <target state="translated">NETSDK1066: 응용 프로그램 호스트와 함께 프레임워크 종속 응용 프로그램을 게시하려면 RuntimeIdentifier를 지정해야 합니다.</target>
+        <target state="new">NETSDK1066: A RuntimeIdentifier must be specified to publish a framework-dependent application with an application host.</target>
         <note>{StrBegin="NETSDK1066: "}</note>
       </trans-unit>
       <trans-unit id="CannotUseSelfContainedWithoutAppHost">
         <source>NETSDK1067: Self-contained applications are required to use the application host. Either set SelfContained to false or set UseAppHost to true.</source>
-        <target state="translated">NETSDK1067: 응용 프로그램 호스트를 사용하려면 자체 포함 응용 프로그램이 필요합니다. SelfContained를 false로 설정하거나 UseAppHost를 true로 설정하세요.</target>
+        <target state="new">NETSDK1067: Self-contained applications are required to use the application host. Either set SelfContained to false or set UseAppHost to true.</target>
         <note>{StrBegin="NETSDK1067: "}</note>
-      </trans-unit>
-      <trans-unit id="FrameworkDependentAppHostRequiresVersion21">
-        <source>NETSDK1068: The framework-dependent application host requires a target framework of at least 'netcoreapp2.1'.</source>
-        <target state="translated">NETSDK1068: 프레임워크 종속 응용 프로그램 호스트는 'netcoreapp2.1' 이상의 대상 프레임워크가 필요합니다.</target>
-        <note>{StrBegin="NETSDK1068: "}</note>
-      </trans-unit>
-      <trans-unit id="NETFrameworkToNonBuiltInNETStandard">
-        <source>NETSDK1069: This project uses a library that targets .NET Standard 1.5 or higher, and the project targets a version of .NET Framework that doesn't have built-in support for that version of .NET Standard. Visit https://aka.ms/net-standard-known-issues for a set of known issues. Consider retargeting to .NET Framework 4.7.2.</source>
-        <target state="translated">NETSDK1069: 이 프로젝트는 .NET Standard 1.5 이상을 대상으로 하는 라이브러리를 사용하며, 이 프로젝트는 해당 버전의 .NET Standard를 기본으로 제공하지 않는 .NET Framework 버전을 대상으로 합니다. 알려진 문제에 대해서는 https://aka.ms/net-standard-known-issues를 참조하세요. .NET Framework 4.7.2로 대상을 다시 지정해 보세요.</target>
-        <note>{StrBegin="NETSDK1069: "}</note>
-      </trans-unit>
-      <trans-unit id="NoCompatibleTargetFramework">
-        <source>NETSDK1002: Project '{0}' targets '{2}'. It cannot be referenced by a project that targets '{1}'.</source>
-        <target state="translated">NETSDK1002: '{0}' 프로젝트가 '{2}'을(를) 대상으로 합니다. '{1}'을(를) 대상으로 하는 프로젝트에서 참조할 수 없습니다.</target>
-        <note>{StrBegin="NETSDK1002: "}</note>
-      </trans-unit>
-      <trans-unit id="InvalidFrameworkName">
-        <source>NETSDK1003: Invalid framework name: '{0}'.</source>
-        <target state="translated">NETSDK1003: 프레임워크 이름 '{0}'이(가) 잘못되었습니다.</target>
-        <note>{StrBegin="NETSDK1003: "}</note>
-      </trans-unit>
-      <trans-unit id="AssetsFileNotFound">
-        <source>NETSDK1004: Assets file '{0}' not found. Run a NuGet package restore to generate this file.</source>
-        <target state="translated">NETSDK1004: 자산 파일 '{0}'을(를) 찾을 수 없습니다. NuGet 패키지 복원을 실행하여 이 파일을 생성하세요.</target>
-        <note>{StrBegin="NETSDK1004: "}</note>
-      </trans-unit>
-      <trans-unit id="AssetsFileMissingTarget">
-        <source>NETSDK1005: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project.</source>
-        <target state="translated">NETSDK1005: 자산 파일 '{0}'에 '{1}'의 대상이 없습니다. 복원이 실행되었으며 프로젝트의 TargetFrameworks에 '{2}'을(를) 포함했는지 확인하세요.</target>
-        <note>{StrBegin="NETSDK1005: "}</note>
-      </trans-unit>
-      <trans-unit id="AssetsFilePathNotRooted">
-        <source>NETSDK1006: Assets file path '{0}' is not rooted. Only full paths are supported.</source>
-        <target state="translated">NETSDK1006: 자산 파일 경로 '{0}'이(가) 루트에서 시작하지 않습니다. 전체 경로만 지원됩니다.</target>
-        <note>{StrBegin="NETSDK1006: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotFindProjectInfo">
-        <source>NETSDK1007: Cannot find project info for '{0}'. This can indicate a missing project reference.</source>
-        <target state="translated">NETSDK1007: '{0}'에 대한 프로젝트 정보를 찾을 수 없습니다. 프로젝트 참조가 없음을 나타낼 수 있습니다.</target>
-        <note>{StrBegin="NETSDK1007: "}</note>
-      </trans-unit>
-      <trans-unit id="MissingItemMetadata">
-        <source>NETSDK1008: Missing '{0}' metadata on '{1}' item '{2}'.</source>
-        <target state="translated">NETSDK1008: '{1}' 항목 '{2}'에 '{0}' 메타데이터가 없습니다.</target>
-        <note>{StrBegin="NETSDK1008: "}</note>
-      </trans-unit>
-      <trans-unit id="UnrecognizedPreprocessorToken">
-        <source>NETSDK1009: Unrecognized preprocessor token '{0}' in '{1}'.</source>
-        <target state="translated">NETSDK1009: '{1}'에서 전처리기 토큰 '{0}'을(를) 인식할 수 없습니다.</target>
-        <note>{StrBegin="NETSDK1009: "}</note>
-      </trans-unit>
-      <trans-unit id="ContentPreproccessorParameterRequired">
-        <source>NETSDK1010: The '{0}' task must be given a value for parameter '{1}' in order to consume preprocessed content.</source>
-        <target state="translated">NETSDK1010: 전처리된 콘텐츠를 사용하려면 '{0}' 작업에서 '{1}' 매개 변수의 값을 지정해야 합니다.</target>
-        <note>{StrBegin="NETSDK1010: "}</note>
-      </trans-unit>
-      <trans-unit id="ProjectAssetsConsumedWithoutMSBuildProjectPath">
-        <source>NETSDK1011: Assets are consumed from project '{0}', but no corresponding MSBuild project path was  found in '{1}'.</source>
-        <target state="translated">NETSDK1011: '{0}' 프로젝트의 자산이 사용되었지만, '{1}'에서 해당 MSBuild 프로젝트 경로를 찾을 수 없습니다.</target>
-        <note>{StrBegin="NETSDK1011: "}</note>
-      </trans-unit>
-      <trans-unit id="UnexpectedFileType">
-        <source>NETSDK1012: Unexpected file type for '{0}'. Type is both '{1}' and '{2}'.</source>
-        <target state="translated">NETSDK1012: '{0}'에 대해 예기치 않은 파일 형식입니다. 형식이 '{1}'인 동시에 '{2}'입니다.</target>
-        <note>{StrBegin="NETSDK1012: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotInferTargetFrameworkIdentiferAndVersion">
-        <source>NETSDK1013: The TargetFramework value '{0}' was not recognized. It may be misspelled. If not, then the TargetFrameworkIdentifier and/or TargetFrameworkVersion properties must be specified explicitly.</source>
-        <target state="translated">NETSDK1013: TargetFramework 값 '{0}'을(를) 인식하지 못했습니다. 철자가 틀렸을 수 있습니다. 그렇지 않은 경우 TargetFrameworkIdentifier 및/또는 TargetFrameworkVersion 속성을 명시적으로 지정해야 합니다.</target>
-        <note>{StrBegin="NETSDK1013: "}</note>
-      </trans-unit>
-      <trans-unit id="ContentItemDoesNotProvideOutputPath">
-        <source>NETSDK1014: Content item for '{0}' sets '{1}', but does not provide  '{2}' or '{3}'.</source>
-        <target state="translated">NETSDK1014: '{0}'의 콘텐츠 항목이 '{1}'을(를) 설정하지만, '{2}' 또는 '{3}'을(를) 제공하지 않습니다.</target>
-        <note>{StrBegin="NETSDK1014: "}</note>
-      </trans-unit>
-      <trans-unit id="DuplicatePreprocessorToken">
-        <source>NETSDK1015: The preprocessor token '{0}' has been given more than one value. Choosing '{1}' as the value.</source>
-        <target state="translated">NETSDK1015: 전처리기 토큰 '{0}'의 값이 두 개 이상 지정되었습니다. '{1}'을(를) 값으로 선택합니다.</target>
-        <note>{StrBegin="NETSDK1015: "}</note>
-      </trans-unit>
-      <trans-unit id="UnableToFindResolvedPath">
-        <source>NETSDK1016: Unable to find resolved path for '{0}'.</source>
-        <target state="translated">NETSDK1016: '{0}'에 대해 확인된 경로를 찾을 수 없습니다.</target>
-        <note>{StrBegin="NETSDK1016: "}</note>
-      </trans-unit>
-      <trans-unit id="AssetPreprocessorMustBeConfigured">
-        <source>NETSDK1017: Asset preprocessor must be configured before assets are processed.</source>
-        <target state="translated">NETSDK1017: 자산을 처리하려면 먼저 자산 전처리기를 구성해야 합니다.</target>
-        <note>{StrBegin="NETSDK1017: "}</note>
-      </trans-unit>
-      <trans-unit id="InvalidNuGetVersionString">
-        <source>NETSDK1018: Invalid NuGet version string: '{0}'.</source>
-        <target state="translated">NETSDK1018: NuGet 버전 문자열 '{0}'이(가) 잘못되었습니다.</target>
-        <note>{StrBegin="NETSDK1018: "}</note>
-      </trans-unit>
-      <trans-unit id="UnsupportedFramework">
-        <source>NETSDK1019: {0} is an unsupported framework.</source>
-        <target state="translated">NETSDK1019: {0}은(는) 지원되지 않는 프레임워크입니다.</target>
-        <note>{StrBegin="NETSDK1019: "}</note>
-      </trans-unit>
-      <trans-unit id="DuplicateItemsError">
-        <source>NETSDK1022: Duplicate '{0}' items were included. The .NET SDK includes '{0}' items from your project directory by default. You can either remove these items from your project file, or set the '{1}' property to '{2}' if you want to explicitly include them in your project file. For more information, see {4}. The duplicate items were: {3}</source>
-        <target state="translated">NETSDK1022: '{0}' 중복 항목이 포함되었습니다. .NET SDK에는 기본적으로 프로젝트 디렉터리의 '{0}' 항목이 포함됩니다. 프로젝트 파일에서 이러한 항목을 제거하거나, 프로젝트 파일에 해당 항목을 명시적으로 포함하려면 '{1}' 속성을 '{2}'(으)로 설정할 수 있습니다. 자세한 내용은 {4}을(를) 참조하세요. 중복 항목은 다음과 같습니다. {3}</target>
-        <note>{StrBegin="NETSDK1022: "}</note>
-      </trans-unit>
-      <trans-unit id="PackageReferenceOverrideWarning">
-        <source>NETSDK1023: A PackageReference for '{0}' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see {1}</source>
-        <target state="translated">NETSDK1023: '{0}'에 대한 PackageReference가 프로젝트에 포함되어 있습니다. 이 패키지는 .NET SDK에서 암시적으로 참조되며, 일반적으로 사용자가 프로젝트에서 참조할 필요가 없습니다. 자세한 내용은 {1}을(를) 참조하세요.</target>
-        <note>{StrBegin="NETSDK1023: "}</note>
-      </trans-unit>
-      <trans-unit id="IncorrectPackageRoot">
-        <source>NETSDK1020: Package Root {0} was incorrectly given for Resolved library {1}</source>
-        <target state="translated">NETSDK1020: 패키지 루트 {0}이(가) 확인된 라이브러리 {1}에 대해 잘못 지정되었습니다.</target>
-        <note>{StrBegin="NETSDK1020: "}</note>
-      </trans-unit>
-      <trans-unit id="MultipleFilesResolved">
-        <source>NETSDK1021: More than one file found for {0}</source>
-        <target state="translated">NETSDK1021: {0}에 대해 두 개 이상의 파일을 찾았습니다.</target>
-        <note>{StrBegin="NETSDK1021: "}</note>
-      </trans-unit>
-      <trans-unit id="FolderAlreadyExists">
-        <source>NETSDK1024: Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</source>
-        <target state="translated">NETSDK1024: '{0}' 폴더가 이미 있습니다. 폴더를 삭제하거나 다른 ComposeWorkingDir을 제공하세요.</target>
-        <note>{StrBegin="NETSDK1024: "}</note>
-      </trans-unit>
-      <trans-unit id="ParsingFiles">
-        <source>NETSDK1026: Parsing the Files : '{0}'</source>
-        <target state="translated">NETSDK1026: 파일 구문 분석: '{0}'</target>
-        <note>{StrBegin="NETSDK1026: "}</note>
-      </trans-unit>
-      <trans-unit id="PackageInfoLog">
-        <source>NETSDK1027: Package Name='{0}', Version='{1}' was parsed</source>
-        <target state="translated">NETSDK1027: 패키지 이름='{0}', 버전='{1}'이(가) 구문 분석되었습니다.</target>
-        <note>{StrBegin="NETSDK1027: "}</note>
-      </trans-unit>
-      <trans-unit id="RuntimeIdentifierWasNotSpecified">
-        <source>NETSDK1028: Specify a RuntimeIdentifier</source>
-        <target state="translated">NETSDK1028: RuntimeIdentifier 지정</target>
-        <note>{StrBegin="NETSDK1028: "}</note>
-      </trans-unit>
-      <trans-unit id="IncorrectTargetFormat">
-        <source>NETSDK1025: WRThe target manifest {0} provided is of not the correct format</source>
-        <target state="translated">NETSDK1025: 제공한 대상 매니페스트 {0}이(가) 올바른 형식이 아닙니다.</target>
-        <note>{StrBegin="NETSDK1025: "}</note>
-      </trans-unit>
-      <trans-unit id="AppHostHasBeenModified">
-        <source>NETSDK1029: Unable to use '{0}' as application host executable as it does not contain the expected placeholder byte sequence '{1}' that would mark where the application name would be written.</source>
-        <target state="translated">NETSDK1029: 응용 프로그램 이름이 기록되는 위치를 표시하는 '{1}' 예상 자리 표시자 바이트 시퀀스가 포함되지 않아서 '{0}'을(를) 응용 프로그램 호스트 실행 파일로 사용할 수 없습니다.</target>
-        <note>{StrBegin="NETSDK1029: "}</note>
-      </trans-unit>
-      <trans-unit id="FileNameIsTooLong">
-        <source>NETSDK1030: Given file name '{0}' is longer than 1024 bytes</source>
-        <target state="translated">NETSDK1030: 제공한 파일 이름 '{0}'이(가) 1024바이트보다 깁니다.</target>
-        <note>{StrBegin="NETSDK1030: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotHaveSelfContainedWithoutRuntimeIdentifier">
-        <source>NETSDK1031: It is not supported to build or publish a self-contained application without specifying a RuntimeIdentifier.  Please either specify a RuntimeIdentifier or set SelfContained to false.</source>
-        <target state="translated">NETSDK1031: RuntimeIdentifier를 지정하지 않으면 자체 포함 응용 프로그램의 빌드 또는 게시가 지원되지 않습니다. RuntimeIdentifier를 지정하거나 SelfContained를 false로 설정하세요.</target>
-        <note>{StrBegin="NETSDK1031: "}</note>
       </trans-unit>
       <trans-unit id="ChoosingAssemblyVersion">
         <source>NETSDK1033: Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</source>
-        <target state="translated">NETSDK1033: AssemblyVersion '{1}'이(가) '{2}'보다 크기 때문에 '{0}'을(를) 선택합니다.</target>
+        <target state="new">NETSDK1033: Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</target>
         <note>{StrBegin="NETSDK1033: "}</note>
       </trans-unit>
       <trans-unit id="ChoosingFileVersion">
         <source>NETSDK1034: Choosing '{0}' because file version '{1}' is greater than '{2}'.</source>
-        <target state="translated">NETSDK1034: 파일 버전 '{1}'이(가) '{2}'보다 크기 때문에 '{0}'을(를) 선택합니다.</target>
+        <target state="new">NETSDK1034: Choosing '{0}' because file version '{1}' is greater than '{2}'.</target>
         <note>{StrBegin="NETSDK1034: "}</note>
       </trans-unit>
       <trans-unit id="ChoosingPlatformItem">
         <source>NETSDK1035: Choosing '{0}' because it is a platform item.</source>
-        <target state="translated">NETSDK1035: 플랫폼 항목이기 때문에 '{0}'을(를) 선택합니다.</target>
+        <target state="new">NETSDK1035: Choosing '{0}' because it is a platform item.</target>
         <note>{StrBegin="NETSDK1035: "}</note>
       </trans-unit>
       <trans-unit id="ChoosingPreferredPackage">
         <source>NETSDK1036: Choosing '{0}' because it comes from a package that is preferred.</source>
-        <target state="translated">NETSDK1036: 기본 설정되는 패키지에 있기 때문에 '{0}'을(를) 선택합니다.</target>
+        <target state="new">NETSDK1036: Choosing '{0}' because it comes from a package that is preferred.</target>
         <note>{StrBegin="NETSDK1036: "}</note>
       </trans-unit>
       <trans-unit id="ConflictCouldNotDetermineWinner">
         <source>NETSDK1037: Could not determine winner due to equal file and assembly versions.</source>
-        <target state="translated">NETSDK1037: 동일한 파일 및 어셈블리 버전으로 인해 적용되는 내용을 확인할 수 없습니다.</target>
+        <target state="new">NETSDK1037: Could not determine winner due to equal file and assembly versions.</target>
         <note>{StrBegin="NETSDK1037: "}</note>
+      </trans-unit>
+      <trans-unit id="ContentItemDoesNotProvideOutputPath">
+        <source>NETSDK1014: Content item for '{0}' sets '{1}', but does not provide  '{2}' or '{3}'.</source>
+        <target state="new">NETSDK1014: Content item for '{0}' sets '{1}', but does not provide  '{2}' or '{3}'.</target>
+        <note>{StrBegin="NETSDK1014: "}</note>
+      </trans-unit>
+      <trans-unit id="ContentPreproccessorParameterRequired">
+        <source>NETSDK1010: The '{0}' task must be given a value for parameter '{1}' in order to consume preprocessed content.</source>
+        <target state="new">NETSDK1010: The '{0}' task must be given a value for parameter '{1}' in order to consume preprocessed content.</target>
+        <note>{StrBegin="NETSDK1010: "}</note>
       </trans-unit>
       <trans-unit id="CouldNotDetermineWinner_DoesntExist">
         <source>NETSDK1038: Could not determine winner because '{0}' does not exist.</source>
-        <target state="translated">NETSDK1038: '{0}'이(가) 존재하지 않기 때문에 적용되는 내용을 확인할 수 없습니다.</target>
+        <target state="new">NETSDK1038: Could not determine winner because '{0}' does not exist.</target>
         <note>{StrBegin="NETSDK1001: "}</note>
       </trans-unit>
       <trans-unit id="CouldNotDetermineWinner_FileVersion">
         <source>NETSDK1039: Could not determine a winner because '{0}' has no file version.</source>
-        <target state="translated">NETSDK1039: '{0}'에 파일 버전이 없기 때문에 적용되는 내용을 확인할 수 없습니다.</target>
+        <target state="new">NETSDK1039: Could not determine a winner because '{0}' has no file version.</target>
         <note>{StrBegin="NETSDK1039: "}</note>
       </trans-unit>
       <trans-unit id="CouldNotDetermineWinner_NotAnAssembly">
         <source>NETSDK1040: Could not determine a winner because '{0}' is not an assembly.</source>
-        <target state="translated">NETSDK1040: '{0}'이(가) 어셈블리가 아니기 때문에 적용되는 내용을 확인할 수 없습니다.</target>
+        <target state="new">NETSDK1040: Could not determine a winner because '{0}' is not an assembly.</target>
         <note>{StrBegin="NETSDK1040: "}</note>
-      </trans-unit>
-      <trans-unit id="EncounteredConflict">
-        <source>NETSDK1041: Encountered conflict between '{0}' and '{1}'.</source>
-        <target state="translated">NETSDK1041: '{0}'과(와) '{1}' 사이에 충돌이 발생했습니다.</target>
-        <note>{StrBegin="NETSDK1041: "}</note>
       </trans-unit>
       <trans-unit id="CouldNotLoadPlatformManifest">
         <source>NETSDK1042: Could not load PlatformManifest from '{0}' because it did not exist.</source>
-        <target state="translated">NETSDK1042: PlatformManifest가 존재하지 않기 때문에 '{0}'에서 로드할 수 없습니다.</target>
+        <target state="new">NETSDK1042: Could not load PlatformManifest from '{0}' because it did not exist.</target>
         <note>{StrBegin="NETSDK1042: "}</note>
+      </trans-unit>
+      <trans-unit id="DotnetToolDoesNotSupportTFMLowerThanNetcoreapp21">
+        <source>NETSDK1055: DotnetTool does not support target framework lower than netcoreapp2.1.</source>
+        <target state="new">NETSDK1055: DotnetTool does not support target framework lower than netcoreapp2.1.</target>
+        <note>{StrBegin="NETSDK1055: "}</note>
+      </trans-unit>
+      <trans-unit id="DotnetToolOnlySupportNetcoreapp">
+        <source>NETSDK1054: only supports .NET Core.</source>
+        <target state="new">NETSDK1054: only supports .NET Core.</target>
+        <note>{StrBegin="NETSDK1054: "}</note>
+      </trans-unit>
+      <trans-unit id="DuplicateItemsError">
+        <source>NETSDK1022: Duplicate '{0}' items were included. The .NET SDK includes '{0}' items from your project directory by default. You can either remove these items from your project file, or set the '{1}' property to '{2}' if you want to explicitly include them in your project file. For more information, see {4}. The duplicate items were: {3}</source>
+        <target state="new">NETSDK1022: Duplicate '{0}' items were included. The .NET SDK includes '{0}' items from your project directory by default. You can either remove these items from your project file, or set the '{1}' property to '{2}' if you want to explicitly include them in your project file. For more information, see {4}. The duplicate items were: {3}</target>
+        <note>{StrBegin="NETSDK1022: "}</note>
+      </trans-unit>
+      <trans-unit id="DuplicatePreprocessorToken">
+        <source>NETSDK1015: The preprocessor token '{0}' has been given more than one value. Choosing '{1}' as the value.</source>
+        <target state="new">NETSDK1015: The preprocessor token '{0}' has been given more than one value. Choosing '{1}' as the value.</target>
+        <note>{StrBegin="NETSDK1015: "}</note>
+      </trans-unit>
+      <trans-unit id="EncounteredConflict">
+        <source>NETSDK1041: Encountered conflict between '{0}' and '{1}'.</source>
+        <target state="new">NETSDK1041: Encountered conflict between '{0}' and '{1}'.</target>
+        <note>{StrBegin="NETSDK1041: "}</note>
+      </trans-unit>
+      <trans-unit id="ErrorParsingFrameworkListInvalidValue">
+        <source>NETSDK1051: Error parsing FrameworkList from '{0}'.  {1} '{2}' was invalid.</source>
+        <target state="new">NETSDK1051: Error parsing FrameworkList from '{0}'.  {1} '{2}' was invalid.</target>
+        <note>{StrBegin="NETSDK1051: "}</note>
       </trans-unit>
       <trans-unit id="ErrorParsingPlatformManifest">
         <source>NETSDK1043: Error parsing PlatformManifest from '{0}' line {1}.  Lines must have the format {2}.</source>
-        <target state="translated">NETSDK1043: '{0}' 줄 {1}에서 PlatformManifest를 구문 분석하는 중 오류가 발생했습니다. 줄이 {2} 형식이어야 합니다.</target>
+        <target state="new">NETSDK1043: Error parsing PlatformManifest from '{0}' line {1}.  Lines must have the format {2}.</target>
         <note>{StrBegin="NETSDK1043: "}</note>
       </trans-unit>
       <trans-unit id="ErrorParsingPlatformManifestInvalidValue">
         <source>NETSDK1044: Error parsing PlatformManifest from '{0}' line {1}.  {2} '{3}' was invalid.</source>
-        <target state="translated">NETSDK1044: '{0}' 줄 {1}에서 PlatformManifest를 구문 분석하는 중 오류가 발생했습니다. {2} '{3}'이(가) 잘못되었습니다.</target>
+        <target state="new">NETSDK1044: Error parsing PlatformManifest from '{0}' line {1}.  {2} '{3}' was invalid.</target>
         <note>{StrBegin="NETSDK1044: "}</note>
-      </trans-unit>
-      <trans-unit id="UnsupportedTargetFrameworkVersion">
-        <source>NETSDK1045: The current .NET SDK does not support targeting {0} {1}.  Either target {0} {2} or lower, or use a version of the .NET SDK that supports {0} {1}.</source>
-        <target state="translated">NETSDK1045: 현재 .NET SDK에서는 {0} {1}을(를) 대상으로 하는 것을 지원하지 않습니다. {0} {2} 이하를 대상으로 하거나 {0} {1}을(를) 지원하는 .NET SDK 버전을 사용하세요.</target>
-        <note>{StrBegin="NETSDK1045: "}</note>
-      </trans-unit>
-      <trans-unit id="AssetsFileMissingRuntimeIdentifier">
-        <source>NETSDK1047: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project. You may also need to include '{3}' in your project's RuntimeIdentifiers.</source>
-        <target state="translated">NETSDK1047: 자산 파일 '{0}'에 '{1}'의 대상이 없습니다. 복원이 실행되었으며 프로젝트의 TargetFrameworks에 '{2}'을(를) 포함했는지 확인하세요. 프로젝트의 RuntimeIdentifiers에 '{3}'을(를) 포함해야 할 수도 있습니다.</target>
-        <note>{StrBegin="NETSDK1047: "}</note>
-      </trans-unit>
-      <trans-unit id="TargetFrameworkWithSemicolon">
-        <source>NETSDK1046: The TargetFramework value '{0}' is not valid. To multi-target, use the 'TargetFrameworks' property instead.</source>
-        <target state="translated">NETSDK1046: TargetFramework 값 '{0}'이(가) 잘못되었습니다. 여러 대상을 지정하려면 'TargetFrameworks' 속성을 대신 사용하세요.</target>
-        <note>{StrBegin="NETSDK1046: "}</note>
-      </trans-unit>
-      <trans-unit id="GetDependsOnNETStandardFailedWithException">
-        <source>NETSDK1049: Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0} {1}</source>
-        <target state="translated">NETSDK1049: 확인된 파일의 이미지가 잘못되었거나, 메타데이터가 없거나, 파일 자체에 액세스할 수 없습니다. {0} {1}</target>
-        <note>{StrBegin="NETSDK1049: "}</note>
-      </trans-unit>
-      <trans-unit id="UnsupportedSDKVersionForNetStandard20">
-        <source>NETSDK1050: The version of Microsoft.NET.Sdk used by this project is insufficient to support references to libraries targeting .NET Standard 1.5 or higher.  Please install version 2.0 or higher of the .NET Core SDK.</source>
-        <target state="translated">NETSDK1050: 이 프로젝트에서 사용하는 Microsoft.NET.Sdk 버전은 .NET Standard 1.5 이상을 대상으로 하는 라이브러리에 대한 참조를 지원할 수 없습니다. .NET Core SDK 버전 2.0 이상을 설치하세요.</target>
-        <note>{StrBegin="NETSDK1050: "}</note>
-      </trans-unit>
-      <trans-unit id="SkippingAdditionalProbingPaths">
-        <source>NETSDK1048: 'AdditionalProbingPaths' were specified for GenerateRuntimeConfigurationFiles, but are being skipped because 'RuntimeConfigDevPath' is empty.</source>
-        <target state="translated">NETSDK1048: GenerateRuntimeConfigurationFiles에 대해 'AdditionalProbingPaths'가 지정되었지만 'RuntimeConfigDevPath'가 비어 있어서 건너뜁니다.</target>
-        <note>{StrBegin="NETSDK1048: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotHaveRuntimeIdentifierPlatformMismatchPlatformTarget">
-        <source>NETSDK1032: The RuntimeIdentifier platform '{0}' and the PlatformTarget '{1}' must be compatible.</source>
-        <target state="translated">NETSDK1032: RuntimeIdentifier 플랫폼 '{0}'과(와) PlatformTarget '{1}'은(는) 호환되어야 합니다.</target>
-        <note>{StrBegin="NETSDK1032: "}</note>
-      </trans-unit>
-      <trans-unit id="ErrorParsingFrameworkListInvalidValue">
-        <source>NETSDK1051: Error parsing FrameworkList from '{0}'.  {1} '{2}' was invalid.</source>
-        <target state="translated">NETSDK1051: '{0}'의 FrameworkList를 구문 분석하는 동안 오류가 발생했습니다. {1} '{2}'이(가) 잘못되었습니다.</target>
-        <note>{StrBegin="NETSDK1051: "}</note>
-      </trans-unit>
-      <trans-unit id="FrameworkListPathNotRooted">
-        <source>NETSDK1052: Framework list file path '{0}' is not rooted. Only full paths are supported.</source>
-        <target state="translated">NETSDK1052: 프레임워크 목록 파일 경로 '{0}'이(가) 루트에서 시작하지 않습니다. 전체 경로만 지원됩니다.</target>
-        <note>{StrBegin="NETSDK1052: "}</note>
-      </trans-unit>
-      <trans-unit id="PackAsToolCannotSupportSelfContained">
-        <source>NETSDK1053: Pack as tool does not support self contained.</source>
-        <target state="translated">NETSDK1053: 도구로서 팩은 자체 포함을 지원하지 않습니다.</target>
-        <note>{StrBegin="NETSDK1001: "}</note>
-      </trans-unit>
-      <trans-unit id="UnsupportedRuntimeIdentifier">
-        <source>NETSDK1056: Project is targeting runtime '{0}' but did not resolve any runtime-specific packages. This runtime may not be supported by the target framework.</source>
-        <target state="translated">NETSDK1056: 프로젝트가 런타임 '{0}'을(를) 대상으로 하지만 런타임 관련 패키지를 확인하지 않았습니다. 이 런타임은 대상 프레임워크에서 지원되지 않을 수 있습니다.</target>
-        <note>{StrBegin="NETSDK1056: "}</note>
-      </trans-unit>
-      <trans-unit id="UsingPreviewSdkWarning">
-        <source>NETSDK1057: You are using a preview version of .NET Core. See: https://aka.ms/dotnet-core-preview</source>
-        <target state="needs-review-translation">NETSDK1057: .NET Core SDK의 미리 보기 버전으로 작업하고 있습니다. 현재 프로젝트의 global.json 파일을 통해 SDK 버전을 정의할 수 있습니다. 자세한 내용은 https://go.microsoft.com/fwlink/?linkid=869452를 참조하세요.</target>
-        <note>{StrBegin="NETSDK1057: "}</note>
-      </trans-unit>
-      <trans-unit id="InvalidItemSpecToUse">
-        <source>NETSDK1058: Invalid value for ItemSpecToUse parameter: '{0}'.  This property must be blank or set to 'Left' or 'Right'</source>
-        <target state="translated">NETSDK1058: ItemSpecToUse 매개 변수 값이 잘못되었습니다. '{0}'. 이 속성은 비워 두거나 'Left' 또는 'Right'로 설정해야 합니다.</target>
-        <note>{StrBegin="NETSDK1058: "}
-The following are names of parameters or literal values and should not be translated: ItemSpecToUse, Left, Right</note>
-      </trans-unit>
-      <trans-unit id="ProjectContainsObsoleteDotNetCliTool">
-        <source>NETSDK1059: The tool '{0}' is now included in the .NET Core SDK. Information on resolving this warning is available at (https://aka.ms/dotnetclitools-in-box).</source>
-        <target state="translated">NETSDK1059: '{0}' 도구가 현재 .NET Core SDK에 포함되어 있습니다. 이 경고를 해결하는 방법은 https://aka.ms/dotnetclitools-in-box를 참조하세요.</target>
-        <note>{StrBegin="NETSDK1059: "}</note>
       </trans-unit>
       <trans-unit id="ErrorReadingAssetsFile">
         <source>NETSDK1060: Error reading assets file: {0}</source>
-        <target state="translated">NETSDK1060: 자산 파일 {0}을(를) 읽는 동안 오류가 발생했습니다.</target>
+        <target state="new">NETSDK1060: Error reading assets file: {0}</target>
         <note>{StrBegin="NETSDK1060: "}</note>
+      </trans-unit>
+      <trans-unit id="FileNameIsTooLong">
+        <source>NETSDK1030: Given file name '{0}' is longer than 1024 bytes</source>
+        <target state="new">NETSDK1030: Given file name '{0}' is longer than 1024 bytes</target>
+        <note>{StrBegin="NETSDK1030: "}</note>
+      </trans-unit>
+      <trans-unit id="FolderAlreadyExists">
+        <source>NETSDK1024: Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</source>
+        <target state="new">NETSDK1024: Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</target>
+        <note>{StrBegin="NETSDK1024: "}</note>
+      </trans-unit>
+      <trans-unit id="FrameworkDependentAppHostRequiresVersion21">
+        <source>NETSDK1068: The framework-dependent application host requires a target framework of at least 'netcoreapp2.1'.</source>
+        <target state="new">NETSDK1068: The framework-dependent application host requires a target framework of at least 'netcoreapp2.1'.</target>
+        <note>{StrBegin="NETSDK1068: "}</note>
+      </trans-unit>
+      <trans-unit id="FrameworkListPathNotRooted">
+        <source>NETSDK1052: Framework list file path '{0}' is not rooted. Only full paths are supported.</source>
+        <target state="new">NETSDK1052: Framework list file path '{0}' is not rooted. Only full paths are supported.</target>
+        <note>{StrBegin="NETSDK1052: "}</note>
+      </trans-unit>
+      <trans-unit id="GetDependsOnNETStandardFailedWithException">
+        <source>NETSDK1049: Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0} {1}</source>
+        <target state="new">NETSDK1049: Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0} {1}</target>
+        <note>{StrBegin="NETSDK1049: "}</note>
+      </trans-unit>
+      <trans-unit id="IncorrectPackageRoot">
+        <source>NETSDK1020: Package Root {0} was incorrectly given for Resolved library {1}</source>
+        <target state="new">NETSDK1020: Package Root {0} was incorrectly given for Resolved library {1}</target>
+        <note>{StrBegin="NETSDK1020: "}</note>
+      </trans-unit>
+      <trans-unit id="IncorrectTargetFormat">
+        <source>NETSDK1025: WRThe target manifest {0} provided is of not the correct format</source>
+        <target state="new">NETSDK1025: WRThe target manifest {0} provided is of not the correct format</target>
+        <note>{StrBegin="NETSDK1025: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidFrameworkName">
+        <source>NETSDK1003: Invalid framework name: '{0}'.</source>
+        <target state="new">NETSDK1003: Invalid framework name: '{0}'.</target>
+        <note>{StrBegin="NETSDK1003: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidItemSpecToUse">
+        <source>NETSDK1058: Invalid value for ItemSpecToUse parameter: '{0}'.  This property must be blank or set to 'Left' or 'Right'</source>
+        <target state="new">NETSDK1058: Invalid value for ItemSpecToUse parameter: '{0}'.  This property must be blank or set to 'Left' or 'Right'</target>
+        <note>{StrBegin="NETSDK1058: "}
+The following are names of parameters or literal values and should not be translated: ItemSpecToUse, Left, Right</note>
+      </trans-unit>
+      <trans-unit id="InvalidNuGetVersionString">
+        <source>NETSDK1018: Invalid NuGet version string: '{0}'.</source>
+        <target state="new">NETSDK1018: Invalid NuGet version string: '{0}'.</target>
+        <note>{StrBegin="NETSDK1018: "}</note>
       </trans-unit>
       <trans-unit id="MismatchedPlatformPackageVersion">
         <source>NETSDK1061: The project was restored using {0} version {1}, but with current settings, version {2} would be used instead. To resolve this issue, make sure the same settings are used for restore and for subsequent operations such as build or publish. Typically this issue can occur if the RuntimeIdentifier property is set during build or publish but not during restore. For more information, see https://aka.ms/dotnet-runtime-patch-selection.</source>
-        <target state="translated">NETSDK1061: {0} 버전 {1}을(를) 사용하여 프로젝트가 복원되었지만, 현재 설정에서는 버전 {2}을(를) 대신 사용합니다. 이 문제를 해결하려면 복원 및 후속 작업(예: 빌드 또는 게시)에 동일한 설정을 사용해야 합니다. 일반적으로 이 문제는 RuntimeIdentifier 속성이 빌드 또는 게시 중에 설정되었지만, 복원 중에는 설정되지 않은 경우에 발생할 수 있습니다. 자세한 내용은 https://aka.ms/dotnet-runtime-patch-selection을 참조하세요.</target>
+        <target state="new">NETSDK1061: The project was restored using {0} version {1}, but with current settings, version {2} would be used instead. To resolve this issue, make sure the same settings are used for restore and for subsequent operations such as build or publish. Typically this issue can occur if the RuntimeIdentifier property is set during build or publish but not during restore. For more information, see https://aka.ms/dotnet-runtime-patch-selection.</target>
         <note>{StrBegin="NETSDK1061: "}
 {0} - Package Identifier for platform package
 {1} - Restored version of platform package
 {2} - Current version of platform package</note>
       </trans-unit>
-      <trans-unit id="AssetsFileNotSet">
-        <source>NETSDK1063: The path to the project assets file was not set. Run a NuGet package restore to generate this file.</source>
-        <target state="translated">NETSDK1063: 프로젝트 자산 파일에 대한 경로가 설정되지 않았습니다. NuGet 패키지 복원을 실행하여 이 파일을 생성하세요.</target>
-        <note>{StrBegin="NETSDK1063: "}</note>
+      <trans-unit id="MissingItemMetadata">
+        <source>NETSDK1008: Missing '{0}' metadata on '{1}' item '{2}'.</source>
+        <target state="new">NETSDK1008: Missing '{0}' metadata on '{1}' item '{2}'.</target>
+        <note>{StrBegin="NETSDK1008: "}</note>
       </trans-unit>
-      <trans-unit id="DotnetToolOnlySupportNetcoreapp">
-        <source>NETSDK1054: only supports .NET Core.</source>
-        <target state="translated">NETSDK1054: .NET Core만 지원합니다.</target>
-        <note>{StrBegin="NETSDK1054: "}</note>
+      <trans-unit id="MultipleFilesResolved">
+        <source>NETSDK1021: More than one file found for {0}</source>
+        <target state="new">NETSDK1021: More than one file found for {0}</target>
+        <note>{StrBegin="NETSDK1021: "}</note>
       </trans-unit>
-      <trans-unit id="DotnetToolDoesNotSupportTFMLowerThanNetcoreapp21">
-        <source>NETSDK1055: DotnetTool does not support target framework lower than netcoreapp2.1.</source>
-        <target state="translated">NETSDK1055: DotnetTool가 netcoreapp2.1보다 낮은 대상 프레임워크를 지원하지 않습니다.</target>
-        <note>{StrBegin="NETSDK1055: "}</note>
+      <trans-unit id="NETFrameworkToNonBuiltInNETStandard">
+        <source>NETSDK1069: This project uses a library that targets .NET Standard 1.5 or higher, and the project targets a version of .NET Framework that doesn't have built-in support for that version of .NET Standard. Visit https://aka.ms/net-standard-known-issues for a set of known issues. Consider retargeting to .NET Framework 4.7.2.</source>
+        <target state="new">NETSDK1069: This project uses a library that targets .NET Standard 1.5 or higher, and the project targets a version of .NET Framework that doesn't have built-in support for that version of .NET Standard. Visit https://aka.ms/net-standard-known-issues for a set of known issues. Consider retargeting to .NET Framework 4.7.2.</target>
+        <note>{StrBegin="NETSDK1069: "}</note>
       </trans-unit>
-      <trans-unit id="UnableToUsePackageAssetsCache">
-        <source>NETSDK1062: Unable to use package assets cache due to I/O error. This can occur when the same project is built more than once in parallel. Performance may be degraded, but the build result will not be impacted.</source>
-        <target state="translated">NETSDK1062: I/O 오류로 인해 패키지 자산 캐시를 사용할 수 없습니다. 동일한 프로젝트가 두 번 이상 동시에 빌드되면 이 오류가 발생합니다. 성능이 저하될 수 있지만 빌드 결과는 영향을 받지 않습니다.</target>
-        <note>{StrBegin="NETSDK1062: "}</note>
+      <trans-unit id="NoCompatibleTargetFramework">
+        <source>NETSDK1002: Project '{0}' targets '{2}'. It cannot be referenced by a project that targets '{1}'.</source>
+        <target state="new">NETSDK1002: Project '{0}' targets '{2}'. It cannot be referenced by a project that targets '{1}'.</target>
+        <note>{StrBegin="NETSDK1002: "}</note>
+      </trans-unit>
+      <trans-unit id="PackAsToolCannotSupportSelfContained">
+        <source>NETSDK1053: Pack as tool does not support self contained.</source>
+        <target state="new">NETSDK1053: Pack as tool does not support self contained.</target>
+        <note>{StrBegin="NETSDK1001: "}</note>
+      </trans-unit>
+      <trans-unit id="PackageInfoLog">
+        <source>NETSDK1027: Package Name='{0}', Version='{1}' was parsed</source>
+        <target state="new">NETSDK1027: Package Name='{0}', Version='{1}' was parsed</target>
+        <note>{StrBegin="NETSDK1027: "}</note>
       </trans-unit>
       <trans-unit id="PackageNotFound">
         <source>NETSDK1064: Package {0}, version {1} was not found. It might have been deleted since NuGet restore. Otherwise, NuGet restore might have only partially completed, which might have been due to maximum path length restrictions.</source>
-        <target state="translated">NETSDK1064: 패키지 {0}, 버전 {1}을(를) 찾을 수 없습니다. NuGet 복원 이후 삭제되었을 수 있습니다. 아니면, 최대 경로 길이 제한으로 인해 NuGet 복원이 부분적으로만 완료되었을 수 있습니다.</target>
+        <target state="new">NETSDK1064: Package {0}, version {1} was not found. It might have been deleted since NuGet restore. Otherwise, NuGet restore might have only partially completed, which might have been due to maximum path length restrictions.</target>
         <note>{StrBegin="NETSDK1064: "}</note>
       </trans-unit>
-      <trans-unit id="CannotFindApphostForRid">
-        <source>NETSDK1065: Cannot find app host for {0}. {0} could be an invalid runtime identifier (RID). For more information about RID, see https://aka.ms/rid-catalog.</source>
-        <target state="translated">NETSDK1065: {0}에 대한 앱 호스트를 찾을 수 없습니다. {0}이(가) 잘못된 RID(런타임 식별자)일 수 있습니다. RID에 대한 자세한 내용은 https://aka.ms/rid-catalog를 참조하세요.</target>
-        <note>{StrBegin="NETSDK1065: "}</note>
+      <trans-unit id="PackageReferenceOverrideWarning">
+        <source>NETSDK1023: A PackageReference for '{0}' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see {1}</source>
+        <target state="new">NETSDK1023: A PackageReference for '{0}' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see {1}</target>
+        <note>{StrBegin="NETSDK1023: "}</note>
+      </trans-unit>
+      <trans-unit id="ParsingFiles">
+        <source>NETSDK1026: Parsing the Files : '{0}'</source>
+        <target state="new">NETSDK1026: Parsing the Files : '{0}'</target>
+        <note>{StrBegin="NETSDK1026: "}</note>
+      </trans-unit>
+      <trans-unit id="ProjectAssetsConsumedWithoutMSBuildProjectPath">
+        <source>NETSDK1011: Assets are consumed from project '{0}', but no corresponding MSBuild project path was  found in '{1}'.</source>
+        <target state="new">NETSDK1011: Assets are consumed from project '{0}', but no corresponding MSBuild project path was  found in '{1}'.</target>
+        <note>{StrBegin="NETSDK1011: "}</note>
+      </trans-unit>
+      <trans-unit id="ProjectContainsObsoleteDotNetCliTool">
+        <source>NETSDK1059: The tool '{0}' is now included in the .NET Core SDK. Information on resolving this warning is available at (https://aka.ms/dotnetclitools-in-box).</source>
+        <target state="new">NETSDK1059: The tool '{0}' is now included in the .NET Core SDK. Information on resolving this warning is available at (https://aka.ms/dotnetclitools-in-box).</target>
+        <note>{StrBegin="NETSDK1059: "}</note>
+      </trans-unit>
+      <trans-unit id="RecommendFrameworkReferenceForAspNetCorePackages">
+        <source>NETSDK1071: A PackageReference for '{0}' was included in your project. Referencing this item as NuGet package is no longer supported. To resolve this warning, change the PackageReference to a FrameworkReference. For more information, see {1}.</source>
+        <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. Referencing this item as NuGet package is no longer supported. To resolve this warning, change the PackageReference to a FrameworkReference. For more information, see {1}.</target>
+        <note>{StrBegin="NETSDK1072: "}
+{0} - Package Id (Microsoft.AspNetCore.App or .All)
+{1} - More info link
+    </note>
+      </trans-unit>
+      <trans-unit id="RuntimeIdentifierWasNotSpecified">
+        <source>NETSDK1028: Specify a RuntimeIdentifier</source>
+        <target state="new">NETSDK1028: Specify a RuntimeIdentifier</target>
+        <note>{StrBegin="NETSDK1028: "}</note>
+      </trans-unit>
+      <trans-unit id="SkippingAdditionalProbingPaths">
+        <source>NETSDK1048: 'AdditionalProbingPaths' were specified for GenerateRuntimeConfigurationFiles, but are being skipped because 'RuntimeConfigDevPath' is empty.</source>
+        <target state="new">NETSDK1048: 'AdditionalProbingPaths' were specified for GenerateRuntimeConfigurationFiles, but are being skipped because 'RuntimeConfigDevPath' is empty.</target>
+        <note>{StrBegin="NETSDK1048: "}</note>
+      </trans-unit>
+      <trans-unit id="TargetFrameworkWithSemicolon">
+        <source>NETSDK1046: The TargetFramework value '{0}' is not valid. To multi-target, use the 'TargetFrameworks' property instead.</source>
+        <target state="new">NETSDK1046: The TargetFramework value '{0}' is not valid. To multi-target, use the 'TargetFrameworks' property instead.</target>
+        <note>{StrBegin="NETSDK1046: "}</note>
+      </trans-unit>
+      <trans-unit id="UnableToFindResolvedPath">
+        <source>NETSDK1016: Unable to find resolved path for '{0}'.</source>
+        <target state="new">NETSDK1016: Unable to find resolved path for '{0}'.</target>
+        <note>{StrBegin="NETSDK1016: "}</note>
+      </trans-unit>
+      <trans-unit id="UnableToUsePackageAssetsCache">
+        <source>NETSDK1062: Unable to use package assets cache due to I/O error. This can occur when the same project is built more than once in parallel. Performance may be degraded, but the build result will not be impacted.</source>
+        <target state="new">NETSDK1062: Unable to use package assets cache due to I/O error. This can occur when the same project is built more than once in parallel. Performance may be degraded, but the build result will not be impacted.</target>
+        <note>{StrBegin="NETSDK1062: "}</note>
+      </trans-unit>
+      <trans-unit id="UnexpectedFileType">
+        <source>NETSDK1012: Unexpected file type for '{0}'. Type is both '{1}' and '{2}'.</source>
+        <target state="new">NETSDK1012: Unexpected file type for '{0}'. Type is both '{1}' and '{2}'.</target>
+        <note>{StrBegin="NETSDK1012: "}</note>
+      </trans-unit>
+      <trans-unit id="UnknownFrameworkReference">
+        <source>NETSDK1072: The FrameworkReference '{0}' was not recognized.</source>
+        <target state="new">NETSDK1072: The FrameworkReference '{0}' was not recognized.</target>
+        <note>{StrBegin="NETSDK1072: "}</note>
+      </trans-unit>
+      <trans-unit id="UnrecognizedPreprocessorToken">
+        <source>NETSDK1009: Unrecognized preprocessor token '{0}' in '{1}'.</source>
+        <target state="new">NETSDK1009: Unrecognized preprocessor token '{0}' in '{1}'.</target>
+        <note>{StrBegin="NETSDK1009: "}</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedFramework">
+        <source>NETSDK1019: {0} is an unsupported framework.</source>
+        <target state="new">NETSDK1019: {0} is an unsupported framework.</target>
+        <note>{StrBegin="NETSDK1019: "}</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedRuntimeIdentifier">
+        <source>NETSDK1056: Project is targeting runtime '{0}' but did not resolve any runtime-specific packages. This runtime may not be supported by the target framework.</source>
+        <target state="new">NETSDK1056: Project is targeting runtime '{0}' but did not resolve any runtime-specific packages. This runtime may not be supported by the target framework.</target>
+        <note>{StrBegin="NETSDK1056: "}</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedSDKVersionForNetStandard20">
+        <source>NETSDK1050: The version of Microsoft.NET.Sdk used by this project is insufficient to support references to libraries targeting .NET Standard 1.5 or higher.  Please install version 2.0 or higher of the .NET Core SDK.</source>
+        <target state="new">NETSDK1050: The version of Microsoft.NET.Sdk used by this project is insufficient to support references to libraries targeting .NET Standard 1.5 or higher.  Please install version 2.0 or higher of the .NET Core SDK.</target>
+        <note>{StrBegin="NETSDK1050: "}</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedTargetFrameworkVersion">
+        <source>NETSDK1045: The current .NET SDK does not support targeting {0} {1}.  Either target {0} {2} or lower, or use a version of the .NET SDK that supports {0} {1}.</source>
+        <target state="new">NETSDK1045: The current .NET SDK does not support targeting {0} {1}.  Either target {0} {2} or lower, or use a version of the .NET SDK that supports {0} {1}.</target>
+        <note>{StrBegin="NETSDK1045: "}</note>
+      </trans-unit>
+      <trans-unit id="UsingPreviewSdkWarning">
+        <source>NETSDK1057: You are using a preview version of .NET Core. See: https://aka.ms/dotnet-core-preview</source>
+        <target state="new">NETSDK1057: You are using a preview version of .NET Core. See: https://aka.ms/dotnet-core-preview</target>
+        <note>{StrBegin="NETSDK1057: "}</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
@@ -299,7 +299,7 @@ The following are names of parameters or literal values and should not be transl
       <trans-unit id="RecommendFrameworkReferenceForAspNetCorePackages">
         <source>NETSDK1071: A PackageReference for '{0}' was included in your project. Referencing this item as NuGet package is no longer supported. To resolve this warning, change the PackageReference to a FrameworkReference. For more information, see {1}.</source>
         <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. Referencing this item as NuGet package is no longer supported. To resolve this warning, change the PackageReference to a FrameworkReference. For more information, see {1}.</target>
-        <note>{StrBegin="NETSDK1072: "}
+        <note>{StrBegin="NETSDK1071: "}
 {0} - Package Id (Microsoft.AspNetCore.App or .All)
 {1} - More info link
     </note>

--- a/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
@@ -299,7 +299,7 @@ The following are names of parameters or literal values and should not be transl
       <trans-unit id="RecommendFrameworkReferenceForAspNetCorePackages">
         <source>NETSDK1071: A PackageReference for '{0}' was included in your project. Referencing this item as NuGet package is no longer supported. To resolve this warning, change the PackageReference to a FrameworkReference. For more information, see {1}.</source>
         <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. Referencing this item as NuGet package is no longer supported. To resolve this warning, change the PackageReference to a FrameworkReference. For more information, see {1}.</target>
-        <note>{StrBegin="NETSDK1072: "}
+        <note>{StrBegin="NETSDK1071: "}
 {0} - Package Id (Microsoft.AspNetCore.App or .All)
 {1} - More info link
     </note>

--- a/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../Strings.resx">
     <body>
@@ -7,354 +7,367 @@
         <target state="new">NETSDK1070: The application configuration file must have root configuration element.</target>
         <note>{StrBegin="NETSDK1070: "}</note>
       </trans-unit>
+      <trans-unit id="AppHostHasBeenModified">
+        <source>NETSDK1029: Unable to use '{0}' as application host executable as it does not contain the expected placeholder byte sequence '{1}' that would mark where the application name would be written.</source>
+        <target state="new">NETSDK1029: Unable to use '{0}' as application host executable as it does not contain the expected placeholder byte sequence '{1}' that would mark where the application name would be written.</target>
+        <note>{StrBegin="NETSDK1029: "}</note>
+      </trans-unit>
+      <trans-unit id="AssetPreprocessorMustBeConfigured">
+        <source>NETSDK1017: Asset preprocessor must be configured before assets are processed.</source>
+        <target state="new">NETSDK1017: Asset preprocessor must be configured before assets are processed.</target>
+        <note>{StrBegin="NETSDK1017: "}</note>
+      </trans-unit>
+      <trans-unit id="AssetsFileMissingRuntimeIdentifier">
+        <source>NETSDK1047: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project. You may also need to include '{3}' in your project's RuntimeIdentifiers.</source>
+        <target state="new">NETSDK1047: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project. You may also need to include '{3}' in your project's RuntimeIdentifiers.</target>
+        <note>{StrBegin="NETSDK1047: "}</note>
+      </trans-unit>
+      <trans-unit id="AssetsFileMissingTarget">
+        <source>NETSDK1005: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project.</source>
+        <target state="new">NETSDK1005: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project.</target>
+        <note>{StrBegin="NETSDK1005: "}</note>
+      </trans-unit>
+      <trans-unit id="AssetsFileNotFound">
+        <source>NETSDK1004: Assets file '{0}' not found. Run a NuGet package restore to generate this file.</source>
+        <target state="new">NETSDK1004: Assets file '{0}' not found. Run a NuGet package restore to generate this file.</target>
+        <note>{StrBegin="NETSDK1004: "}</note>
+      </trans-unit>
+      <trans-unit id="AssetsFileNotSet">
+        <source>NETSDK1063: The path to the project assets file was not set. Run a NuGet package restore to generate this file.</source>
+        <target state="new">NETSDK1063: The path to the project assets file was not set. Run a NuGet package restore to generate this file.</target>
+        <note>{StrBegin="NETSDK1063: "}</note>
+      </trans-unit>
+      <trans-unit id="AssetsFilePathNotRooted">
+        <source>NETSDK1006: Assets file path '{0}' is not rooted. Only full paths are supported.</source>
+        <target state="new">NETSDK1006: Assets file path '{0}' is not rooted. Only full paths are supported.</target>
+        <note>{StrBegin="NETSDK1006: "}</note>
+      </trans-unit>
       <trans-unit id="AtLeastOneTargetFrameworkMustBeSpecified">
         <source>NETSDK1001: At least one possible target framework must be specified.</source>
-        <target state="translated">NETSDK1001: Należy określić co najmniej jedną możliwą platformę docelową.</target>
+        <target state="new">NETSDK1001: At least one possible target framework must be specified.</target>
         <note>{StrBegin="NETSDK1001: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotFindApphostForRid">
+        <source>NETSDK1065: Cannot find app host for {0}. {0} could be an invalid runtime identifier (RID). For more information about RID, see https://aka.ms/rid-catalog.</source>
+        <target state="new">NETSDK1065: Cannot find app host for {0}. {0} could be an invalid runtime identifier (RID). For more information about RID, see https://aka.ms/rid-catalog.</target>
+        <note>{StrBegin="NETSDK1065: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotFindProjectInfo">
+        <source>NETSDK1007: Cannot find project info for '{0}'. This can indicate a missing project reference.</source>
+        <target state="new">NETSDK1007: Cannot find project info for '{0}'. This can indicate a missing project reference.</target>
+        <note>{StrBegin="NETSDK1007: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotHaveRuntimeIdentifierPlatformMismatchPlatformTarget">
+        <source>NETSDK1032: The RuntimeIdentifier platform '{0}' and the PlatformTarget '{1}' must be compatible.</source>
+        <target state="new">NETSDK1032: The RuntimeIdentifier platform '{0}' and the PlatformTarget '{1}' must be compatible.</target>
+        <note>{StrBegin="NETSDK1032: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotHaveSelfContainedWithoutRuntimeIdentifier">
+        <source>NETSDK1031: It is not supported to build or publish a self-contained application without specifying a RuntimeIdentifier.  Please either specify a RuntimeIdentifier or set SelfContained to false.</source>
+        <target state="new">NETSDK1031: It is not supported to build or publish a self-contained application without specifying a RuntimeIdentifier.  Please either specify a RuntimeIdentifier or set SelfContained to false.</target>
+        <note>{StrBegin="NETSDK1031: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotInferTargetFrameworkIdentiferAndVersion">
+        <source>NETSDK1013: The TargetFramework value '{0}' was not recognized. It may be misspelled. If not, then the TargetFrameworkIdentifier and/or TargetFrameworkVersion properties must be specified explicitly.</source>
+        <target state="new">NETSDK1013: The TargetFramework value '{0}' was not recognized. It may be misspelled. If not, then the TargetFrameworkIdentifier and/or TargetFrameworkVersion properties must be specified explicitly.</target>
+        <note>{StrBegin="NETSDK1013: "}</note>
       </trans-unit>
       <trans-unit id="CannotUseAppHostWithoutRuntimeIdentifier">
         <source>NETSDK1066: A RuntimeIdentifier must be specified to publish a framework-dependent application with an application host.</source>
-        <target state="translated">NETSDK1066: Należy określić identyfikator RuntimeIdentifier, aby opublikować aplikację zależną od platformy za pomocą hosta aplikacji.</target>
+        <target state="new">NETSDK1066: A RuntimeIdentifier must be specified to publish a framework-dependent application with an application host.</target>
         <note>{StrBegin="NETSDK1066: "}</note>
       </trans-unit>
       <trans-unit id="CannotUseSelfContainedWithoutAppHost">
         <source>NETSDK1067: Self-contained applications are required to use the application host. Either set SelfContained to false or set UseAppHost to true.</source>
-        <target state="translated">NETSDK1067: Aplikacje autonomiczne muszą korzystać z hosta aplikacji. Ustaw parametr SelfContained na wartość false lub parametr UseAppHost na wartość true.</target>
+        <target state="new">NETSDK1067: Self-contained applications are required to use the application host. Either set SelfContained to false or set UseAppHost to true.</target>
         <note>{StrBegin="NETSDK1067: "}</note>
-      </trans-unit>
-      <trans-unit id="FrameworkDependentAppHostRequiresVersion21">
-        <source>NETSDK1068: The framework-dependent application host requires a target framework of at least 'netcoreapp2.1'.</source>
-        <target state="translated">NETSDK1068: Host aplikacji zależnych od platformy wymaga co najmniej platformy docelowej „netcoreapp2.1”.</target>
-        <note>{StrBegin="NETSDK1068: "}</note>
-      </trans-unit>
-      <trans-unit id="NETFrameworkToNonBuiltInNETStandard">
-        <source>NETSDK1069: This project uses a library that targets .NET Standard 1.5 or higher, and the project targets a version of .NET Framework that doesn't have built-in support for that version of .NET Standard. Visit https://aka.ms/net-standard-known-issues for a set of known issues. Consider retargeting to .NET Framework 4.7.2.</source>
-        <target state="translated">NETSDK1069: Projekt korzysta z biblioteki przeznaczonej dla platformy .NET Standard 1.5 lub nowszej, a projekt jest przeznaczony dla wersji programu .NET Framework, która nie ma wbudowanej obsługi tej wersji platformy .NET Standard. Odwiedź witrynę https://aka.ms/net-standard-known-issues, aby zapoznać się z zestawem znanych problemów. Rozważ zmianę elementu docelowego na program .NET Framework 4.7.2.</target>
-        <note>{StrBegin="NETSDK1069: "}</note>
-      </trans-unit>
-      <trans-unit id="NoCompatibleTargetFramework">
-        <source>NETSDK1002: Project '{0}' targets '{2}'. It cannot be referenced by a project that targets '{1}'.</source>
-        <target state="translated">NETSDK1002: Projekt „{0}” ma platformę docelową „{2}”. Nie może on być przywoływany przez projekt z platformą docelową „{1}”.</target>
-        <note>{StrBegin="NETSDK1002: "}</note>
-      </trans-unit>
-      <trans-unit id="InvalidFrameworkName">
-        <source>NETSDK1003: Invalid framework name: '{0}'.</source>
-        <target state="translated">NETSDK1003: Nieprawidłowa nazwa platformy: „{0}”.</target>
-        <note>{StrBegin="NETSDK1003: "}</note>
-      </trans-unit>
-      <trans-unit id="AssetsFileNotFound">
-        <source>NETSDK1004: Assets file '{0}' not found. Run a NuGet package restore to generate this file.</source>
-        <target state="translated">NETSDK1004: Nie odnaleziono pliku zasobów „{0}”. Uruchom przywracanie pakietu NuGet, aby wygenerować ten plik.</target>
-        <note>{StrBegin="NETSDK1004: "}</note>
-      </trans-unit>
-      <trans-unit id="AssetsFileMissingTarget">
-        <source>NETSDK1005: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project.</source>
-        <target state="translated">NETSDK1005: Plik zasobów „{0}” nie ma obiektu docelowego dla „{1}”. Upewnij się, że uruchomiono przywracanie i że w elemencie TargetFrameworks dla projektu uwzględniono element „{2}”.</target>
-        <note>{StrBegin="NETSDK1005: "}</note>
-      </trans-unit>
-      <trans-unit id="AssetsFilePathNotRooted">
-        <source>NETSDK1006: Assets file path '{0}' is not rooted. Only full paths are supported.</source>
-        <target state="translated">NETSDK1006: Ścieżka pliku zasobów „{0}” nie prowadzi do katalogu głównego. Tylko pełne ścieżki są obsługiwane.</target>
-        <note>{StrBegin="NETSDK1006: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotFindProjectInfo">
-        <source>NETSDK1007: Cannot find project info for '{0}'. This can indicate a missing project reference.</source>
-        <target state="translated">NETSDK1007: Nie odnaleziono informacji o projekcie dla elementu „{0}”. Może to wskazywać na brakujące odwołanie do projektu.</target>
-        <note>{StrBegin="NETSDK1007: "}</note>
-      </trans-unit>
-      <trans-unit id="MissingItemMetadata">
-        <source>NETSDK1008: Missing '{0}' metadata on '{1}' item '{2}'.</source>
-        <target state="translated">NETSDK1008: Brak metadanych „{0}” w elemencie „{1}” „{2}”.</target>
-        <note>{StrBegin="NETSDK1008: "}</note>
-      </trans-unit>
-      <trans-unit id="UnrecognizedPreprocessorToken">
-        <source>NETSDK1009: Unrecognized preprocessor token '{0}' in '{1}'.</source>
-        <target state="translated">NETSDK1009: Nierozpoznany token preprocesora „{0}” w elemencie „{1}”.</target>
-        <note>{StrBegin="NETSDK1009: "}</note>
-      </trans-unit>
-      <trans-unit id="ContentPreproccessorParameterRequired">
-        <source>NETSDK1010: The '{0}' task must be given a value for parameter '{1}' in order to consume preprocessed content.</source>
-        <target state="translated">NETSDK1010: Dla zadania „{0}” musi zostać podana wartość parametru „{1}” w celu użycia wstępnie przetworzonej zawartości.</target>
-        <note>{StrBegin="NETSDK1010: "}</note>
-      </trans-unit>
-      <trans-unit id="ProjectAssetsConsumedWithoutMSBuildProjectPath">
-        <source>NETSDK1011: Assets are consumed from project '{0}', but no corresponding MSBuild project path was  found in '{1}'.</source>
-        <target state="translated">NETSDK1011: Zasoby są używane z projektu „{0}”, ale w elemencie „{1}” nie odnaleziono odpowiadającej ścieżki projektu MSBuild.</target>
-        <note>{StrBegin="NETSDK1011: "}</note>
-      </trans-unit>
-      <trans-unit id="UnexpectedFileType">
-        <source>NETSDK1012: Unexpected file type for '{0}'. Type is both '{1}' and '{2}'.</source>
-        <target state="translated">NETSDK1012: Nieoczekiwany typ pliku dla „{0}”. Typ to „{1}” oraz „{2}”.</target>
-        <note>{StrBegin="NETSDK1012: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotInferTargetFrameworkIdentiferAndVersion">
-        <source>NETSDK1013: The TargetFramework value '{0}' was not recognized. It may be misspelled. If not, then the TargetFrameworkIdentifier and/or TargetFrameworkVersion properties must be specified explicitly.</source>
-        <target state="translated">NETSDK1013: Nie rozpoznano wartości „{0}” elementu TargetFramework. Być może wpisano ją niepoprawnie. Jeśli nie, należy jawnie określić właściwości TargetFrameworkIdentifier i/lub TargetFrameworkVersion.</target>
-        <note>{StrBegin="NETSDK1013: "}</note>
-      </trans-unit>
-      <trans-unit id="ContentItemDoesNotProvideOutputPath">
-        <source>NETSDK1014: Content item for '{0}' sets '{1}', but does not provide  '{2}' or '{3}'.</source>
-        <target state="translated">NETSDK1014: Element zawartości dla elementu „{0}” ustawia wartość „{1}”, ale nie zapewnia wartości „{2}” ani „{3}”.</target>
-        <note>{StrBegin="NETSDK1014: "}</note>
-      </trans-unit>
-      <trans-unit id="DuplicatePreprocessorToken">
-        <source>NETSDK1015: The preprocessor token '{0}' has been given more than one value. Choosing '{1}' as the value.</source>
-        <target state="translated">NETSDK1015: Dla tokenu preprocesora „{0}” podano więcej niż jedną wartość. Wybieranie elementu „{1}” jako wartości.</target>
-        <note>{StrBegin="NETSDK1015: "}</note>
-      </trans-unit>
-      <trans-unit id="UnableToFindResolvedPath">
-        <source>NETSDK1016: Unable to find resolved path for '{0}'.</source>
-        <target state="translated">NETSDK1016: Nie można odnaleźć rozpoznanej ścieżki dla elementu „{0}”.</target>
-        <note>{StrBegin="NETSDK1016: "}</note>
-      </trans-unit>
-      <trans-unit id="AssetPreprocessorMustBeConfigured">
-        <source>NETSDK1017: Asset preprocessor must be configured before assets are processed.</source>
-        <target state="translated">NETSDK1017: Preprocesor zasobów musi być skonfigurowany przed przetworzeniem zasobów.</target>
-        <note>{StrBegin="NETSDK1017: "}</note>
-      </trans-unit>
-      <trans-unit id="InvalidNuGetVersionString">
-        <source>NETSDK1018: Invalid NuGet version string: '{0}'.</source>
-        <target state="translated">NETSDK1018: Nieprawidłowy ciąg wersji NuGet: „{0}”.</target>
-        <note>{StrBegin="NETSDK1018: "}</note>
-      </trans-unit>
-      <trans-unit id="UnsupportedFramework">
-        <source>NETSDK1019: {0} is an unsupported framework.</source>
-        <target state="translated">NETSDK1019: {0} to nieobsługiwana platforma.</target>
-        <note>{StrBegin="NETSDK1019: "}</note>
-      </trans-unit>
-      <trans-unit id="DuplicateItemsError">
-        <source>NETSDK1022: Duplicate '{0}' items were included. The .NET SDK includes '{0}' items from your project directory by default. You can either remove these items from your project file, or set the '{1}' property to '{2}' if you want to explicitly include them in your project file. For more information, see {4}. The duplicate items were: {3}</source>
-        <target state="translated">NETSDK1022: Zostały uwzględnione zduplikowane elementy „{0}”. Zestaw .NET SDK dołącza domyślnie elementy „{0}” z katalogu projektu. Możesz usunąć te elementy z pliku projektu lub ustawić dla właściwości „{1}” wartość „{2}”, aby jawnie uwzględnić je w pliku projektu.Aby uzyskać więcej informacji, zobacz {4}. Zduplikowane elementy: {3}</target>
-        <note>{StrBegin="NETSDK1022: "}</note>
-      </trans-unit>
-      <trans-unit id="PackageReferenceOverrideWarning">
-        <source>NETSDK1023: A PackageReference for '{0}' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see {1}</source>
-        <target state="translated">NETSDK1023: Odwołanie do pakietu dla „{0}” zostało uwzględnione w projekcie. Ten pakiet jest jawnie przywoływany przez zestaw .NET SDK i zwykle nie ma potrzeby tworzenia odwołania do niego z projektu. Aby uzyskać więcej informacji, zobacz {1}</target>
-        <note>{StrBegin="NETSDK1023: "}</note>
-      </trans-unit>
-      <trans-unit id="IncorrectPackageRoot">
-        <source>NETSDK1020: Package Root {0} was incorrectly given for Resolved library {1}</source>
-        <target state="translated">NETSDK1020: Podano niepoprawny element główny pakietu {0} dla rozpoznanej biblioteki {1}</target>
-        <note>{StrBegin="NETSDK1020: "}</note>
-      </trans-unit>
-      <trans-unit id="MultipleFilesResolved">
-        <source>NETSDK1021: More than one file found for {0}</source>
-        <target state="translated">NETSDK1021: Znaleziono więcej niż jeden plik dla elementu {0}</target>
-        <note>{StrBegin="NETSDK1021: "}</note>
-      </trans-unit>
-      <trans-unit id="FolderAlreadyExists">
-        <source>NETSDK1024: Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</source>
-        <target state="translated">NETSDK1024: Folder „{0}” już istnieje. Usuń go lub podaj inny katalog roboczy tworzenia (ComposeWorkingDir)</target>
-        <note>{StrBegin="NETSDK1024: "}</note>
-      </trans-unit>
-      <trans-unit id="ParsingFiles">
-        <source>NETSDK1026: Parsing the Files : '{0}'</source>
-        <target state="translated">NETSDK1026: Analizowanie plików: „{0}”</target>
-        <note>{StrBegin="NETSDK1026: "}</note>
-      </trans-unit>
-      <trans-unit id="PackageInfoLog">
-        <source>NETSDK1027: Package Name='{0}', Version='{1}' was parsed</source>
-        <target state="translated">NETSDK1027: Przeanalizowano pakiet o nazwie „{0}” w wersji „{1}”</target>
-        <note>{StrBegin="NETSDK1027: "}</note>
-      </trans-unit>
-      <trans-unit id="RuntimeIdentifierWasNotSpecified">
-        <source>NETSDK1028: Specify a RuntimeIdentifier</source>
-        <target state="translated">NETSDK1028: Określ element RuntimeIdentifier</target>
-        <note>{StrBegin="NETSDK1028: "}</note>
-      </trans-unit>
-      <trans-unit id="IncorrectTargetFormat">
-        <source>NETSDK1025: WRThe target manifest {0} provided is of not the correct format</source>
-        <target state="translated">NETSDK1025: Podany manifest docelowy {0} ma niepoprawny format</target>
-        <note>{StrBegin="NETSDK1025: "}</note>
-      </trans-unit>
-      <trans-unit id="AppHostHasBeenModified">
-        <source>NETSDK1029: Unable to use '{0}' as application host executable as it does not contain the expected placeholder byte sequence '{1}' that would mark where the application name would be written.</source>
-        <target state="translated">NETSDK1029: Nie można użyć elementu „{0}” jako pliku wykonywalnego hosta aplikacji, ponieważ nie zawiera on oczekiwanej sekwencji bajtów symbolu zastępczego „{1}”, która wskazuje lokalizację zapisu nazwy aplikacji.</target>
-        <note>{StrBegin="NETSDK1029: "}</note>
-      </trans-unit>
-      <trans-unit id="FileNameIsTooLong">
-        <source>NETSDK1030: Given file name '{0}' is longer than 1024 bytes</source>
-        <target state="translated">NETSDK1030: Podana nazwa pliku „{0}” jest dłuższa niż 1024 bajty</target>
-        <note>{StrBegin="NETSDK1030: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotHaveSelfContainedWithoutRuntimeIdentifier">
-        <source>NETSDK1031: It is not supported to build or publish a self-contained application without specifying a RuntimeIdentifier.  Please either specify a RuntimeIdentifier or set SelfContained to false.</source>
-        <target state="translated">NETSDK1031: Kompilowanie i publikowanie aplikacji autonomicznej bez określania elementu RuntimeIdentifier nie jest obsługiwane. Określ element RuntimeIdentifier lub ustaw wartość false dla elementu SelfContained.</target>
-        <note>{StrBegin="NETSDK1031: "}</note>
       </trans-unit>
       <trans-unit id="ChoosingAssemblyVersion">
         <source>NETSDK1033: Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</source>
-        <target state="translated">NETSDK1033: Zostanie wybrany element „{0}”, ponieważ wartość atrybutu AssemblyVersion „{1}” jest większa niż „{2}”.</target>
+        <target state="new">NETSDK1033: Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</target>
         <note>{StrBegin="NETSDK1033: "}</note>
       </trans-unit>
       <trans-unit id="ChoosingFileVersion">
         <source>NETSDK1034: Choosing '{0}' because file version '{1}' is greater than '{2}'.</source>
-        <target state="translated">NETSDK1034: Zostanie wybrany element „{0}”, ponieważ wersja pliku „{1}” jest nowsza niż „{2}”.</target>
+        <target state="new">NETSDK1034: Choosing '{0}' because file version '{1}' is greater than '{2}'.</target>
         <note>{StrBegin="NETSDK1034: "}</note>
       </trans-unit>
       <trans-unit id="ChoosingPlatformItem">
         <source>NETSDK1035: Choosing '{0}' because it is a platform item.</source>
-        <target state="translated">NETSDK1035: Zostanie wybrany element „{0}”, ponieważ jest to element platformy.</target>
+        <target state="new">NETSDK1035: Choosing '{0}' because it is a platform item.</target>
         <note>{StrBegin="NETSDK1035: "}</note>
       </trans-unit>
       <trans-unit id="ChoosingPreferredPackage">
         <source>NETSDK1036: Choosing '{0}' because it comes from a package that is preferred.</source>
-        <target state="translated">NETSDK1036: Zostanie wybrany element „{0}”, ponieważ pochodzi on z preferowanego pakietu.</target>
+        <target state="new">NETSDK1036: Choosing '{0}' because it comes from a package that is preferred.</target>
         <note>{StrBegin="NETSDK1036: "}</note>
       </trans-unit>
       <trans-unit id="ConflictCouldNotDetermineWinner">
         <source>NETSDK1037: Could not determine winner due to equal file and assembly versions.</source>
-        <target state="translated">NETSDK1037: Nie można określić wyniku z powodu takich samych wersji pliku i zestawu.</target>
+        <target state="new">NETSDK1037: Could not determine winner due to equal file and assembly versions.</target>
         <note>{StrBegin="NETSDK1037: "}</note>
+      </trans-unit>
+      <trans-unit id="ContentItemDoesNotProvideOutputPath">
+        <source>NETSDK1014: Content item for '{0}' sets '{1}', but does not provide  '{2}' or '{3}'.</source>
+        <target state="new">NETSDK1014: Content item for '{0}' sets '{1}', but does not provide  '{2}' or '{3}'.</target>
+        <note>{StrBegin="NETSDK1014: "}</note>
+      </trans-unit>
+      <trans-unit id="ContentPreproccessorParameterRequired">
+        <source>NETSDK1010: The '{0}' task must be given a value for parameter '{1}' in order to consume preprocessed content.</source>
+        <target state="new">NETSDK1010: The '{0}' task must be given a value for parameter '{1}' in order to consume preprocessed content.</target>
+        <note>{StrBegin="NETSDK1010: "}</note>
       </trans-unit>
       <trans-unit id="CouldNotDetermineWinner_DoesntExist">
         <source>NETSDK1038: Could not determine winner because '{0}' does not exist.</source>
-        <target state="translated">NETSDK1038: Nie można określić wyniku, ponieważ element „{0}” nie istnieje.</target>
+        <target state="new">NETSDK1038: Could not determine winner because '{0}' does not exist.</target>
         <note>{StrBegin="NETSDK1001: "}</note>
       </trans-unit>
       <trans-unit id="CouldNotDetermineWinner_FileVersion">
         <source>NETSDK1039: Could not determine a winner because '{0}' has no file version.</source>
-        <target state="translated">NETSDK1039: Nie można określić wyniku, ponieważ element „{0}” nie ma wersji pliku.</target>
+        <target state="new">NETSDK1039: Could not determine a winner because '{0}' has no file version.</target>
         <note>{StrBegin="NETSDK1039: "}</note>
       </trans-unit>
       <trans-unit id="CouldNotDetermineWinner_NotAnAssembly">
         <source>NETSDK1040: Could not determine a winner because '{0}' is not an assembly.</source>
-        <target state="translated">NETSDK1040: Nie można określić wyniku, ponieważ element „{0}” nie jest zestawem.</target>
+        <target state="new">NETSDK1040: Could not determine a winner because '{0}' is not an assembly.</target>
         <note>{StrBegin="NETSDK1040: "}</note>
-      </trans-unit>
-      <trans-unit id="EncounteredConflict">
-        <source>NETSDK1041: Encountered conflict between '{0}' and '{1}'.</source>
-        <target state="translated">NETSDK1041: Napotkano konflikt między elementem „{0}” i „{1}”.</target>
-        <note>{StrBegin="NETSDK1041: "}</note>
       </trans-unit>
       <trans-unit id="CouldNotLoadPlatformManifest">
         <source>NETSDK1042: Could not load PlatformManifest from '{0}' because it did not exist.</source>
-        <target state="translated">NETSDK1042: Nie można załadować elementu PlatformManifest z lokalizacji „{0}”, ponieważ ta lokalizacja nie istnieje.</target>
+        <target state="new">NETSDK1042: Could not load PlatformManifest from '{0}' because it did not exist.</target>
         <note>{StrBegin="NETSDK1042: "}</note>
+      </trans-unit>
+      <trans-unit id="DotnetToolDoesNotSupportTFMLowerThanNetcoreapp21">
+        <source>NETSDK1055: DotnetTool does not support target framework lower than netcoreapp2.1.</source>
+        <target state="new">NETSDK1055: DotnetTool does not support target framework lower than netcoreapp2.1.</target>
+        <note>{StrBegin="NETSDK1055: "}</note>
+      </trans-unit>
+      <trans-unit id="DotnetToolOnlySupportNetcoreapp">
+        <source>NETSDK1054: only supports .NET Core.</source>
+        <target state="new">NETSDK1054: only supports .NET Core.</target>
+        <note>{StrBegin="NETSDK1054: "}</note>
+      </trans-unit>
+      <trans-unit id="DuplicateItemsError">
+        <source>NETSDK1022: Duplicate '{0}' items were included. The .NET SDK includes '{0}' items from your project directory by default. You can either remove these items from your project file, or set the '{1}' property to '{2}' if you want to explicitly include them in your project file. For more information, see {4}. The duplicate items were: {3}</source>
+        <target state="new">NETSDK1022: Duplicate '{0}' items were included. The .NET SDK includes '{0}' items from your project directory by default. You can either remove these items from your project file, or set the '{1}' property to '{2}' if you want to explicitly include them in your project file. For more information, see {4}. The duplicate items were: {3}</target>
+        <note>{StrBegin="NETSDK1022: "}</note>
+      </trans-unit>
+      <trans-unit id="DuplicatePreprocessorToken">
+        <source>NETSDK1015: The preprocessor token '{0}' has been given more than one value. Choosing '{1}' as the value.</source>
+        <target state="new">NETSDK1015: The preprocessor token '{0}' has been given more than one value. Choosing '{1}' as the value.</target>
+        <note>{StrBegin="NETSDK1015: "}</note>
+      </trans-unit>
+      <trans-unit id="EncounteredConflict">
+        <source>NETSDK1041: Encountered conflict between '{0}' and '{1}'.</source>
+        <target state="new">NETSDK1041: Encountered conflict between '{0}' and '{1}'.</target>
+        <note>{StrBegin="NETSDK1041: "}</note>
+      </trans-unit>
+      <trans-unit id="ErrorParsingFrameworkListInvalidValue">
+        <source>NETSDK1051: Error parsing FrameworkList from '{0}'.  {1} '{2}' was invalid.</source>
+        <target state="new">NETSDK1051: Error parsing FrameworkList from '{0}'.  {1} '{2}' was invalid.</target>
+        <note>{StrBegin="NETSDK1051: "}</note>
       </trans-unit>
       <trans-unit id="ErrorParsingPlatformManifest">
         <source>NETSDK1043: Error parsing PlatformManifest from '{0}' line {1}.  Lines must have the format {2}.</source>
-        <target state="translated">NETSDK1043: Wystąpił błąd podczas analizowania elementu PlatformManifest w wierszu „{0}” {1}. Wiersze muszą mieć format {2}.</target>
+        <target state="new">NETSDK1043: Error parsing PlatformManifest from '{0}' line {1}.  Lines must have the format {2}.</target>
         <note>{StrBegin="NETSDK1043: "}</note>
       </trans-unit>
       <trans-unit id="ErrorParsingPlatformManifestInvalidValue">
         <source>NETSDK1044: Error parsing PlatformManifest from '{0}' line {1}.  {2} '{3}' was invalid.</source>
-        <target state="translated">NETSDK1044: Wystąpił błąd podczas analizowania elementu PlatformManifest w wierszu „{0}” {1}. Element {2} „{3}” jest nieprawidłowy.</target>
+        <target state="new">NETSDK1044: Error parsing PlatformManifest from '{0}' line {1}.  {2} '{3}' was invalid.</target>
         <note>{StrBegin="NETSDK1044: "}</note>
-      </trans-unit>
-      <trans-unit id="UnsupportedTargetFrameworkVersion">
-        <source>NETSDK1045: The current .NET SDK does not support targeting {0} {1}.  Either target {0} {2} or lower, or use a version of the .NET SDK that supports {0} {1}.</source>
-        <target state="translated">NETSDK1045: Bieżący zestaw .NET SDK nie obsługuje używania środowiska docelowego {0} {1}. Użyj jako środowiska docelowego wersji {0} {2} lub starszej albo użyj wersji zestawu .NET SDK obsługującej środowisko {0} {1}.</target>
-        <note>{StrBegin="NETSDK1045: "}</note>
-      </trans-unit>
-      <trans-unit id="AssetsFileMissingRuntimeIdentifier">
-        <source>NETSDK1047: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project. You may also need to include '{3}' in your project's RuntimeIdentifiers.</source>
-        <target state="translated">NETSDK1047: Plik zasobów „{0}” nie ma obiektu docelowego dla „{1}”. Upewnij się, że uruchomiono przywracanie i że w elemencie TargetFrameworks dla projektu uwzględniono element „{2}”. Może być też konieczne uwzględnienie elementu „{3}” w obszarze RuntimeIdentifiers projektu.</target>
-        <note>{StrBegin="NETSDK1047: "}</note>
-      </trans-unit>
-      <trans-unit id="TargetFrameworkWithSemicolon">
-        <source>NETSDK1046: The TargetFramework value '{0}' is not valid. To multi-target, use the 'TargetFrameworks' property instead.</source>
-        <target state="translated">NETSDK1046: Wartość „{0}” elementu TargetFramework jest nieprawidłowa. Aby obsługiwać wiele środowisk docelowych, użyj zamiast tego właściwości TargetFrameworks.</target>
-        <note>{StrBegin="NETSDK1046: "}</note>
-      </trans-unit>
-      <trans-unit id="GetDependsOnNETStandardFailedWithException">
-        <source>NETSDK1049: Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0} {1}</source>
-        <target state="translated">NETSDK1049: Rozpoznany plik ma nieprawidłowy obraz, nie ma metadanych lub jest w inny sposób niedostępny. {0} {1}</target>
-        <note>{StrBegin="NETSDK1049: "}</note>
-      </trans-unit>
-      <trans-unit id="UnsupportedSDKVersionForNetStandard20">
-        <source>NETSDK1050: The version of Microsoft.NET.Sdk used by this project is insufficient to support references to libraries targeting .NET Standard 1.5 or higher.  Please install version 2.0 or higher of the .NET Core SDK.</source>
-        <target state="translated">NETSDK1050: Używana przez ten projekt wersja zestawu Microsoft.NET.Sdk jest niewystarczająca do zapewnienia obsługi odwołań do bibliotek przeznaczonych dla platformy .NET Standard 1.5 lub nowszych. Zainstaluj zestaw .NET Core SDK w wersji co najmniej 2.0.</target>
-        <note>{StrBegin="NETSDK1050: "}</note>
-      </trans-unit>
-      <trans-unit id="SkippingAdditionalProbingPaths">
-        <source>NETSDK1048: 'AdditionalProbingPaths' were specified for GenerateRuntimeConfigurationFiles, but are being skipped because 'RuntimeConfigDevPath' is empty.</source>
-        <target state="translated">NETSDK1048: Dla elementu GenerateRuntimeConfigurationFiles określono ścieżki AdditionalProbingPaths, ale są one pomijane, ponieważ element „RuntimeConfigDevPath” jest pusty.</target>
-        <note>{StrBegin="NETSDK1048: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotHaveRuntimeIdentifierPlatformMismatchPlatformTarget">
-        <source>NETSDK1032: The RuntimeIdentifier platform '{0}' and the PlatformTarget '{1}' must be compatible.</source>
-        <target state="translated">NETSDK1032: Platforma elementu RuntimeIdentifier „{0}” i element PlatformTarget „{1}” muszą być zgodne.</target>
-        <note>{StrBegin="NETSDK1032: "}</note>
-      </trans-unit>
-      <trans-unit id="ErrorParsingFrameworkListInvalidValue">
-        <source>NETSDK1051: Error parsing FrameworkList from '{0}'.  {1} '{2}' was invalid.</source>
-        <target state="translated">NETSDK1051: Błąd analizowania elementu FrameworkList z elementu „{0}”. Element {1} „{2}” był nieprawidłowy.</target>
-        <note>{StrBegin="NETSDK1051: "}</note>
-      </trans-unit>
-      <trans-unit id="FrameworkListPathNotRooted">
-        <source>NETSDK1052: Framework list file path '{0}' is not rooted. Only full paths are supported.</source>
-        <target state="translated">NETSDK1052: Ścieżka pliku z listą struktur „{0}” nie zaczyna się od katalogu głównego. Obsługiwane są tylko pełne ścieżki.</target>
-        <note>{StrBegin="NETSDK1052: "}</note>
-      </trans-unit>
-      <trans-unit id="PackAsToolCannotSupportSelfContained">
-        <source>NETSDK1053: Pack as tool does not support self contained.</source>
-        <target state="translated">NETSDK1053: Funkcja pakowania jako narzędzie nie obsługuje elementów autonomicznych.</target>
-        <note>{StrBegin="NETSDK1001: "}</note>
-      </trans-unit>
-      <trans-unit id="UnsupportedRuntimeIdentifier">
-        <source>NETSDK1056: Project is targeting runtime '{0}' but did not resolve any runtime-specific packages. This runtime may not be supported by the target framework.</source>
-        <target state="translated">NETSDK1056: Projekt jest przeznaczony dla środowiska uruchomieniowego „{0}”, ale nie rozpoznaje żadnych pakietów specyficznych dla tego środowiska. To środowisko uruchomieniowe nie może być obsługiwane przez platformę docelową.</target>
-        <note>{StrBegin="NETSDK1056: "}</note>
-      </trans-unit>
-      <trans-unit id="UsingPreviewSdkWarning">
-        <source>NETSDK1057: You are using a preview version of .NET Core. See: https://aka.ms/dotnet-core-preview</source>
-        <target state="needs-review-translation">NETSDK1057: Korzystasz z zestawu .NET Core SDK w wersji zapoznawczej. Możesz zdefiniować wersję zestawu SDK za pomocą pliku global.json w bieżącym projekcie. Więcej informacji można znaleźć na stronie https://go.microsoft.com/fwlink/?linkid=869452</target>
-        <note>{StrBegin="NETSDK1057: "}</note>
-      </trans-unit>
-      <trans-unit id="InvalidItemSpecToUse">
-        <source>NETSDK1058: Invalid value for ItemSpecToUse parameter: '{0}'.  This property must be blank or set to 'Left' or 'Right'</source>
-        <target state="translated">NETSDK1058: Nieprawidłowa wartość parametru ItemSpecToUse: „{0}”. Ta właściwość musi być pusta lub ustawiona na wartość „Left” albo „Right”</target>
-        <note>{StrBegin="NETSDK1058: "}
-The following are names of parameters or literal values and should not be translated: ItemSpecToUse, Left, Right</note>
-      </trans-unit>
-      <trans-unit id="ProjectContainsObsoleteDotNetCliTool">
-        <source>NETSDK1059: The tool '{0}' is now included in the .NET Core SDK. Information on resolving this warning is available at (https://aka.ms/dotnetclitools-in-box).</source>
-        <target state="translated">NETSDK1059: Narzędzie „{0}” jest teraz dołączone do zestawu .NET Core SDK. Informacje dotyczące sposobu rozwiązania problemu wskazanego w ostrzeżeniu można znaleźć na stronie https://aka.ms/dotnetclitools-in-box.</target>
-        <note>{StrBegin="NETSDK1059: "}</note>
       </trans-unit>
       <trans-unit id="ErrorReadingAssetsFile">
         <source>NETSDK1060: Error reading assets file: {0}</source>
-        <target state="translated">NETSDK1060: Błąd podczas odczytywania pliku zasobów: {0}</target>
+        <target state="new">NETSDK1060: Error reading assets file: {0}</target>
         <note>{StrBegin="NETSDK1060: "}</note>
+      </trans-unit>
+      <trans-unit id="FileNameIsTooLong">
+        <source>NETSDK1030: Given file name '{0}' is longer than 1024 bytes</source>
+        <target state="new">NETSDK1030: Given file name '{0}' is longer than 1024 bytes</target>
+        <note>{StrBegin="NETSDK1030: "}</note>
+      </trans-unit>
+      <trans-unit id="FolderAlreadyExists">
+        <source>NETSDK1024: Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</source>
+        <target state="new">NETSDK1024: Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</target>
+        <note>{StrBegin="NETSDK1024: "}</note>
+      </trans-unit>
+      <trans-unit id="FrameworkDependentAppHostRequiresVersion21">
+        <source>NETSDK1068: The framework-dependent application host requires a target framework of at least 'netcoreapp2.1'.</source>
+        <target state="new">NETSDK1068: The framework-dependent application host requires a target framework of at least 'netcoreapp2.1'.</target>
+        <note>{StrBegin="NETSDK1068: "}</note>
+      </trans-unit>
+      <trans-unit id="FrameworkListPathNotRooted">
+        <source>NETSDK1052: Framework list file path '{0}' is not rooted. Only full paths are supported.</source>
+        <target state="new">NETSDK1052: Framework list file path '{0}' is not rooted. Only full paths are supported.</target>
+        <note>{StrBegin="NETSDK1052: "}</note>
+      </trans-unit>
+      <trans-unit id="GetDependsOnNETStandardFailedWithException">
+        <source>NETSDK1049: Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0} {1}</source>
+        <target state="new">NETSDK1049: Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0} {1}</target>
+        <note>{StrBegin="NETSDK1049: "}</note>
+      </trans-unit>
+      <trans-unit id="IncorrectPackageRoot">
+        <source>NETSDK1020: Package Root {0} was incorrectly given for Resolved library {1}</source>
+        <target state="new">NETSDK1020: Package Root {0} was incorrectly given for Resolved library {1}</target>
+        <note>{StrBegin="NETSDK1020: "}</note>
+      </trans-unit>
+      <trans-unit id="IncorrectTargetFormat">
+        <source>NETSDK1025: WRThe target manifest {0} provided is of not the correct format</source>
+        <target state="new">NETSDK1025: WRThe target manifest {0} provided is of not the correct format</target>
+        <note>{StrBegin="NETSDK1025: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidFrameworkName">
+        <source>NETSDK1003: Invalid framework name: '{0}'.</source>
+        <target state="new">NETSDK1003: Invalid framework name: '{0}'.</target>
+        <note>{StrBegin="NETSDK1003: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidItemSpecToUse">
+        <source>NETSDK1058: Invalid value for ItemSpecToUse parameter: '{0}'.  This property must be blank or set to 'Left' or 'Right'</source>
+        <target state="new">NETSDK1058: Invalid value for ItemSpecToUse parameter: '{0}'.  This property must be blank or set to 'Left' or 'Right'</target>
+        <note>{StrBegin="NETSDK1058: "}
+The following are names of parameters or literal values and should not be translated: ItemSpecToUse, Left, Right</note>
+      </trans-unit>
+      <trans-unit id="InvalidNuGetVersionString">
+        <source>NETSDK1018: Invalid NuGet version string: '{0}'.</source>
+        <target state="new">NETSDK1018: Invalid NuGet version string: '{0}'.</target>
+        <note>{StrBegin="NETSDK1018: "}</note>
       </trans-unit>
       <trans-unit id="MismatchedPlatformPackageVersion">
         <source>NETSDK1061: The project was restored using {0} version {1}, but with current settings, version {2} would be used instead. To resolve this issue, make sure the same settings are used for restore and for subsequent operations such as build or publish. Typically this issue can occur if the RuntimeIdentifier property is set during build or publish but not during restore. For more information, see https://aka.ms/dotnet-runtime-patch-selection.</source>
-        <target state="translated">NETSDK1061: Projekt został przywrócony przy użyciu pakietu {0} w wersji {1}, ale w przypadku bieżących ustawień zamiast niej zostałaby użyta wersja {2}. Aby rozwiązać ten problem, upewnij się, że te same ustawienia są używane do przywracania i dla kolejnych operacji, takich jak kompilacja lub publikowanie. Ten problem zazwyczaj występuje, gdy właściwość RuntimeIdentifier jest ustawiona podczas kompilacji lub publikowania, ale nie podczas przywracania. Aby uzyskać więcej informacji, zobacz https://aka.ms/dotnet-runtime-patch-selection.</target>
+        <target state="new">NETSDK1061: The project was restored using {0} version {1}, but with current settings, version {2} would be used instead. To resolve this issue, make sure the same settings are used for restore and for subsequent operations such as build or publish. Typically this issue can occur if the RuntimeIdentifier property is set during build or publish but not during restore. For more information, see https://aka.ms/dotnet-runtime-patch-selection.</target>
         <note>{StrBegin="NETSDK1061: "}
 {0} - Package Identifier for platform package
 {1} - Restored version of platform package
 {2} - Current version of platform package</note>
       </trans-unit>
-      <trans-unit id="AssetsFileNotSet">
-        <source>NETSDK1063: The path to the project assets file was not set. Run a NuGet package restore to generate this file.</source>
-        <target state="translated">NETSDK1063: Nie ustawiono ścieżki do pliku zasobów projektu. Uruchom przywracanie pakietu NuGet, aby wygenerować ten plik.</target>
-        <note>{StrBegin="NETSDK1063: "}</note>
+      <trans-unit id="MissingItemMetadata">
+        <source>NETSDK1008: Missing '{0}' metadata on '{1}' item '{2}'.</source>
+        <target state="new">NETSDK1008: Missing '{0}' metadata on '{1}' item '{2}'.</target>
+        <note>{StrBegin="NETSDK1008: "}</note>
       </trans-unit>
-      <trans-unit id="DotnetToolOnlySupportNetcoreapp">
-        <source>NETSDK1054: only supports .NET Core.</source>
-        <target state="translated">NETSDK1054: obsługuje tylko platformę .NET Core.</target>
-        <note>{StrBegin="NETSDK1054: "}</note>
+      <trans-unit id="MultipleFilesResolved">
+        <source>NETSDK1021: More than one file found for {0}</source>
+        <target state="new">NETSDK1021: More than one file found for {0}</target>
+        <note>{StrBegin="NETSDK1021: "}</note>
       </trans-unit>
-      <trans-unit id="DotnetToolDoesNotSupportTFMLowerThanNetcoreapp21">
-        <source>NETSDK1055: DotnetTool does not support target framework lower than netcoreapp2.1.</source>
-        <target state="translated">NETSDK1055: Narzędzie DotnetTool nie obsługuje docelowej struktury w wersji niższej niż netcoreapp2.1.</target>
-        <note>{StrBegin="NETSDK1055: "}</note>
+      <trans-unit id="NETFrameworkToNonBuiltInNETStandard">
+        <source>NETSDK1069: This project uses a library that targets .NET Standard 1.5 or higher, and the project targets a version of .NET Framework that doesn't have built-in support for that version of .NET Standard. Visit https://aka.ms/net-standard-known-issues for a set of known issues. Consider retargeting to .NET Framework 4.7.2.</source>
+        <target state="new">NETSDK1069: This project uses a library that targets .NET Standard 1.5 or higher, and the project targets a version of .NET Framework that doesn't have built-in support for that version of .NET Standard. Visit https://aka.ms/net-standard-known-issues for a set of known issues. Consider retargeting to .NET Framework 4.7.2.</target>
+        <note>{StrBegin="NETSDK1069: "}</note>
       </trans-unit>
-      <trans-unit id="UnableToUsePackageAssetsCache">
-        <source>NETSDK1062: Unable to use package assets cache due to I/O error. This can occur when the same project is built more than once in parallel. Performance may be degraded, but the build result will not be impacted.</source>
-        <target state="translated">NETSDK1062: Nie można użyć pamięci podręcznej zasobów pakietu ze względu na błąd we/wy. Do tej sytuacji może dochodzić, gdy ten sam projekt jest kompilowany więcej niż jeden raz jednocześnie. Może wystąpić spadek wydajności, ale nie będzie mieć to wpływu na wyniki kompilacji.</target>
-        <note>{StrBegin="NETSDK1062: "}</note>
+      <trans-unit id="NoCompatibleTargetFramework">
+        <source>NETSDK1002: Project '{0}' targets '{2}'. It cannot be referenced by a project that targets '{1}'.</source>
+        <target state="new">NETSDK1002: Project '{0}' targets '{2}'. It cannot be referenced by a project that targets '{1}'.</target>
+        <note>{StrBegin="NETSDK1002: "}</note>
+      </trans-unit>
+      <trans-unit id="PackAsToolCannotSupportSelfContained">
+        <source>NETSDK1053: Pack as tool does not support self contained.</source>
+        <target state="new">NETSDK1053: Pack as tool does not support self contained.</target>
+        <note>{StrBegin="NETSDK1001: "}</note>
+      </trans-unit>
+      <trans-unit id="PackageInfoLog">
+        <source>NETSDK1027: Package Name='{0}', Version='{1}' was parsed</source>
+        <target state="new">NETSDK1027: Package Name='{0}', Version='{1}' was parsed</target>
+        <note>{StrBegin="NETSDK1027: "}</note>
       </trans-unit>
       <trans-unit id="PackageNotFound">
         <source>NETSDK1064: Package {0}, version {1} was not found. It might have been deleted since NuGet restore. Otherwise, NuGet restore might have only partially completed, which might have been due to maximum path length restrictions.</source>
-        <target state="translated">NETSDK1064: Nie odnaleziono pakietu {0} w wersji {1}. Mógł on zostać usunięty po przywróceniu pakietu NuGet. W innym przypadku przywrócenie pakietu NuGet mogło zostać ukończone tylko częściowo, co mogło być spowodowane ograniczeniami wynikającymi z maksymalnej długości ścieżki.</target>
+        <target state="new">NETSDK1064: Package {0}, version {1} was not found. It might have been deleted since NuGet restore. Otherwise, NuGet restore might have only partially completed, which might have been due to maximum path length restrictions.</target>
         <note>{StrBegin="NETSDK1064: "}</note>
       </trans-unit>
-      <trans-unit id="CannotFindApphostForRid">
-        <source>NETSDK1065: Cannot find app host for {0}. {0} could be an invalid runtime identifier (RID). For more information about RID, see https://aka.ms/rid-catalog.</source>
-        <target state="translated">NETSDK1065: Nie można odnaleźć hosta aplikacji dla elementu {0}. {0} może być nieprawidłowym identyfikatorem środowiska uruchomieniowego. Aby uzyskać więcej informacji na temat identyfikatora środowiska uruchomieniowego, zobacz https://aka.ms/rid-catalog.</target>
-        <note>{StrBegin="NETSDK1065: "}</note>
+      <trans-unit id="PackageReferenceOverrideWarning">
+        <source>NETSDK1023: A PackageReference for '{0}' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see {1}</source>
+        <target state="new">NETSDK1023: A PackageReference for '{0}' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see {1}</target>
+        <note>{StrBegin="NETSDK1023: "}</note>
+      </trans-unit>
+      <trans-unit id="ParsingFiles">
+        <source>NETSDK1026: Parsing the Files : '{0}'</source>
+        <target state="new">NETSDK1026: Parsing the Files : '{0}'</target>
+        <note>{StrBegin="NETSDK1026: "}</note>
+      </trans-unit>
+      <trans-unit id="ProjectAssetsConsumedWithoutMSBuildProjectPath">
+        <source>NETSDK1011: Assets are consumed from project '{0}', but no corresponding MSBuild project path was  found in '{1}'.</source>
+        <target state="new">NETSDK1011: Assets are consumed from project '{0}', but no corresponding MSBuild project path was  found in '{1}'.</target>
+        <note>{StrBegin="NETSDK1011: "}</note>
+      </trans-unit>
+      <trans-unit id="ProjectContainsObsoleteDotNetCliTool">
+        <source>NETSDK1059: The tool '{0}' is now included in the .NET Core SDK. Information on resolving this warning is available at (https://aka.ms/dotnetclitools-in-box).</source>
+        <target state="new">NETSDK1059: The tool '{0}' is now included in the .NET Core SDK. Information on resolving this warning is available at (https://aka.ms/dotnetclitools-in-box).</target>
+        <note>{StrBegin="NETSDK1059: "}</note>
+      </trans-unit>
+      <trans-unit id="RecommendFrameworkReferenceForAspNetCorePackages">
+        <source>NETSDK1071: A PackageReference for '{0}' was included in your project. Referencing this item as NuGet package is no longer supported. To resolve this warning, change the PackageReference to a FrameworkReference. For more information, see {1}.</source>
+        <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. Referencing this item as NuGet package is no longer supported. To resolve this warning, change the PackageReference to a FrameworkReference. For more information, see {1}.</target>
+        <note>{StrBegin="NETSDK1072: "}
+{0} - Package Id (Microsoft.AspNetCore.App or .All)
+{1} - More info link
+    </note>
+      </trans-unit>
+      <trans-unit id="RuntimeIdentifierWasNotSpecified">
+        <source>NETSDK1028: Specify a RuntimeIdentifier</source>
+        <target state="new">NETSDK1028: Specify a RuntimeIdentifier</target>
+        <note>{StrBegin="NETSDK1028: "}</note>
+      </trans-unit>
+      <trans-unit id="SkippingAdditionalProbingPaths">
+        <source>NETSDK1048: 'AdditionalProbingPaths' were specified for GenerateRuntimeConfigurationFiles, but are being skipped because 'RuntimeConfigDevPath' is empty.</source>
+        <target state="new">NETSDK1048: 'AdditionalProbingPaths' were specified for GenerateRuntimeConfigurationFiles, but are being skipped because 'RuntimeConfigDevPath' is empty.</target>
+        <note>{StrBegin="NETSDK1048: "}</note>
+      </trans-unit>
+      <trans-unit id="TargetFrameworkWithSemicolon">
+        <source>NETSDK1046: The TargetFramework value '{0}' is not valid. To multi-target, use the 'TargetFrameworks' property instead.</source>
+        <target state="new">NETSDK1046: The TargetFramework value '{0}' is not valid. To multi-target, use the 'TargetFrameworks' property instead.</target>
+        <note>{StrBegin="NETSDK1046: "}</note>
+      </trans-unit>
+      <trans-unit id="UnableToFindResolvedPath">
+        <source>NETSDK1016: Unable to find resolved path for '{0}'.</source>
+        <target state="new">NETSDK1016: Unable to find resolved path for '{0}'.</target>
+        <note>{StrBegin="NETSDK1016: "}</note>
+      </trans-unit>
+      <trans-unit id="UnableToUsePackageAssetsCache">
+        <source>NETSDK1062: Unable to use package assets cache due to I/O error. This can occur when the same project is built more than once in parallel. Performance may be degraded, but the build result will not be impacted.</source>
+        <target state="new">NETSDK1062: Unable to use package assets cache due to I/O error. This can occur when the same project is built more than once in parallel. Performance may be degraded, but the build result will not be impacted.</target>
+        <note>{StrBegin="NETSDK1062: "}</note>
+      </trans-unit>
+      <trans-unit id="UnexpectedFileType">
+        <source>NETSDK1012: Unexpected file type for '{0}'. Type is both '{1}' and '{2}'.</source>
+        <target state="new">NETSDK1012: Unexpected file type for '{0}'. Type is both '{1}' and '{2}'.</target>
+        <note>{StrBegin="NETSDK1012: "}</note>
+      </trans-unit>
+      <trans-unit id="UnknownFrameworkReference">
+        <source>NETSDK1072: The FrameworkReference '{0}' was not recognized.</source>
+        <target state="new">NETSDK1072: The FrameworkReference '{0}' was not recognized.</target>
+        <note>{StrBegin="NETSDK1072: "}</note>
+      </trans-unit>
+      <trans-unit id="UnrecognizedPreprocessorToken">
+        <source>NETSDK1009: Unrecognized preprocessor token '{0}' in '{1}'.</source>
+        <target state="new">NETSDK1009: Unrecognized preprocessor token '{0}' in '{1}'.</target>
+        <note>{StrBegin="NETSDK1009: "}</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedFramework">
+        <source>NETSDK1019: {0} is an unsupported framework.</source>
+        <target state="new">NETSDK1019: {0} is an unsupported framework.</target>
+        <note>{StrBegin="NETSDK1019: "}</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedRuntimeIdentifier">
+        <source>NETSDK1056: Project is targeting runtime '{0}' but did not resolve any runtime-specific packages. This runtime may not be supported by the target framework.</source>
+        <target state="new">NETSDK1056: Project is targeting runtime '{0}' but did not resolve any runtime-specific packages. This runtime may not be supported by the target framework.</target>
+        <note>{StrBegin="NETSDK1056: "}</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedSDKVersionForNetStandard20">
+        <source>NETSDK1050: The version of Microsoft.NET.Sdk used by this project is insufficient to support references to libraries targeting .NET Standard 1.5 or higher.  Please install version 2.0 or higher of the .NET Core SDK.</source>
+        <target state="new">NETSDK1050: The version of Microsoft.NET.Sdk used by this project is insufficient to support references to libraries targeting .NET Standard 1.5 or higher.  Please install version 2.0 or higher of the .NET Core SDK.</target>
+        <note>{StrBegin="NETSDK1050: "}</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedTargetFrameworkVersion">
+        <source>NETSDK1045: The current .NET SDK does not support targeting {0} {1}.  Either target {0} {2} or lower, or use a version of the .NET SDK that supports {0} {1}.</source>
+        <target state="new">NETSDK1045: The current .NET SDK does not support targeting {0} {1}.  Either target {0} {2} or lower, or use a version of the .NET SDK that supports {0} {1}.</target>
+        <note>{StrBegin="NETSDK1045: "}</note>
+      </trans-unit>
+      <trans-unit id="UsingPreviewSdkWarning">
+        <source>NETSDK1057: You are using a preview version of .NET Core. See: https://aka.ms/dotnet-core-preview</source>
+        <target state="new">NETSDK1057: You are using a preview version of .NET Core. See: https://aka.ms/dotnet-core-preview</target>
+        <note>{StrBegin="NETSDK1057: "}</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
@@ -67,6 +67,19 @@
         <target state="translated">NETSDK1008: Metadados '{0}' ausentes no item '{1}' '{2}'.</target>
         <note>{StrBegin="NETSDK1008: "}</note>
       </trans-unit>
+      <trans-unit id="RecommendFrameworkReferenceForAspNetCorePackages">
+        <source>NETSDK1071: A PackageReference for '{0}' was included in your project. Referencing this item as NuGet package is no longer supported. To resolve this warning, change the PackageReference to a FrameworkReference. For more information, see {1}.</source>
+        <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. Referencing this item as NuGet package is no longer supported. To resolve this warning, change the PackageReference to a FrameworkReference. For more information, see {1}.</target>
+        <note>{StrBegin="NETSDK1072: "}
+{0} - Package Id (Microsoft.AspNetCore.App or .All)
+{1} - More info link
+    </note>
+      </trans-unit>
+      <trans-unit id="UnknownFrameworkReference">
+        <source>NETSDK1072: The FrameworkReference '{0}' was not recognized.</source>
+        <target state="new">NETSDK1072: The FrameworkReference '{0}' was not recognized.</target>
+        <note>{StrBegin="NETSDK1072: "}</note>
+      </trans-unit>
       <trans-unit id="UnrecognizedPreprocessorToken">
         <source>NETSDK1009: Unrecognized preprocessor token '{0}' in '{1}'.</source>
         <target state="translated">NETSDK1009: Token de pré-processador não reconhecido '{0}' em '{1}'.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../Strings.resx">
     <body>
@@ -7,73 +7,332 @@
         <target state="new">NETSDK1070: The application configuration file must have root configuration element.</target>
         <note>{StrBegin="NETSDK1070: "}</note>
       </trans-unit>
+      <trans-unit id="AppHostHasBeenModified">
+        <source>NETSDK1029: Unable to use '{0}' as application host executable as it does not contain the expected placeholder byte sequence '{1}' that would mark where the application name would be written.</source>
+        <target state="new">NETSDK1029: Unable to use '{0}' as application host executable as it does not contain the expected placeholder byte sequence '{1}' that would mark where the application name would be written.</target>
+        <note>{StrBegin="NETSDK1029: "}</note>
+      </trans-unit>
+      <trans-unit id="AssetPreprocessorMustBeConfigured">
+        <source>NETSDK1017: Asset preprocessor must be configured before assets are processed.</source>
+        <target state="new">NETSDK1017: Asset preprocessor must be configured before assets are processed.</target>
+        <note>{StrBegin="NETSDK1017: "}</note>
+      </trans-unit>
+      <trans-unit id="AssetsFileMissingRuntimeIdentifier">
+        <source>NETSDK1047: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project. You may also need to include '{3}' in your project's RuntimeIdentifiers.</source>
+        <target state="new">NETSDK1047: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project. You may also need to include '{3}' in your project's RuntimeIdentifiers.</target>
+        <note>{StrBegin="NETSDK1047: "}</note>
+      </trans-unit>
+      <trans-unit id="AssetsFileMissingTarget">
+        <source>NETSDK1005: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project.</source>
+        <target state="new">NETSDK1005: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project.</target>
+        <note>{StrBegin="NETSDK1005: "}</note>
+      </trans-unit>
+      <trans-unit id="AssetsFileNotFound">
+        <source>NETSDK1004: Assets file '{0}' not found. Run a NuGet package restore to generate this file.</source>
+        <target state="new">NETSDK1004: Assets file '{0}' not found. Run a NuGet package restore to generate this file.</target>
+        <note>{StrBegin="NETSDK1004: "}</note>
+      </trans-unit>
+      <trans-unit id="AssetsFileNotSet">
+        <source>NETSDK1063: The path to the project assets file was not set. Run a NuGet package restore to generate this file.</source>
+        <target state="new">NETSDK1063: The path to the project assets file was not set. Run a NuGet package restore to generate this file.</target>
+        <note>{StrBegin="NETSDK1063: "}</note>
+      </trans-unit>
+      <trans-unit id="AssetsFilePathNotRooted">
+        <source>NETSDK1006: Assets file path '{0}' is not rooted. Only full paths are supported.</source>
+        <target state="new">NETSDK1006: Assets file path '{0}' is not rooted. Only full paths are supported.</target>
+        <note>{StrBegin="NETSDK1006: "}</note>
+      </trans-unit>
       <trans-unit id="AtLeastOneTargetFrameworkMustBeSpecified">
         <source>NETSDK1001: At least one possible target framework must be specified.</source>
-        <target state="translated">NETSDK1001: É necessário especificar pelo menos uma estrutura de destino possível.</target>
+        <target state="new">NETSDK1001: At least one possible target framework must be specified.</target>
         <note>{StrBegin="NETSDK1001: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotFindApphostForRid">
+        <source>NETSDK1065: Cannot find app host for {0}. {0} could be an invalid runtime identifier (RID). For more information about RID, see https://aka.ms/rid-catalog.</source>
+        <target state="new">NETSDK1065: Cannot find app host for {0}. {0} could be an invalid runtime identifier (RID). For more information about RID, see https://aka.ms/rid-catalog.</target>
+        <note>{StrBegin="NETSDK1065: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotFindProjectInfo">
+        <source>NETSDK1007: Cannot find project info for '{0}'. This can indicate a missing project reference.</source>
+        <target state="new">NETSDK1007: Cannot find project info for '{0}'. This can indicate a missing project reference.</target>
+        <note>{StrBegin="NETSDK1007: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotHaveRuntimeIdentifierPlatformMismatchPlatformTarget">
+        <source>NETSDK1032: The RuntimeIdentifier platform '{0}' and the PlatformTarget '{1}' must be compatible.</source>
+        <target state="new">NETSDK1032: The RuntimeIdentifier platform '{0}' and the PlatformTarget '{1}' must be compatible.</target>
+        <note>{StrBegin="NETSDK1032: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotHaveSelfContainedWithoutRuntimeIdentifier">
+        <source>NETSDK1031: It is not supported to build or publish a self-contained application without specifying a RuntimeIdentifier.  Please either specify a RuntimeIdentifier or set SelfContained to false.</source>
+        <target state="new">NETSDK1031: It is not supported to build or publish a self-contained application without specifying a RuntimeIdentifier.  Please either specify a RuntimeIdentifier or set SelfContained to false.</target>
+        <note>{StrBegin="NETSDK1031: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotInferTargetFrameworkIdentiferAndVersion">
+        <source>NETSDK1013: The TargetFramework value '{0}' was not recognized. It may be misspelled. If not, then the TargetFrameworkIdentifier and/or TargetFrameworkVersion properties must be specified explicitly.</source>
+        <target state="new">NETSDK1013: The TargetFramework value '{0}' was not recognized. It may be misspelled. If not, then the TargetFrameworkIdentifier and/or TargetFrameworkVersion properties must be specified explicitly.</target>
+        <note>{StrBegin="NETSDK1013: "}</note>
       </trans-unit>
       <trans-unit id="CannotUseAppHostWithoutRuntimeIdentifier">
         <source>NETSDK1066: A RuntimeIdentifier must be specified to publish a framework-dependent application with an application host.</source>
-        <target state="translated">NETSDK1066: um RuntimeIdentifier deve ser especificado para publicar um aplicativo dependente de estrutura com um host do aplicativo.</target>
+        <target state="new">NETSDK1066: A RuntimeIdentifier must be specified to publish a framework-dependent application with an application host.</target>
         <note>{StrBegin="NETSDK1066: "}</note>
       </trans-unit>
       <trans-unit id="CannotUseSelfContainedWithoutAppHost">
         <source>NETSDK1067: Self-contained applications are required to use the application host. Either set SelfContained to false or set UseAppHost to true.</source>
-        <target state="translated">NETSDK1067: os aplicativos independentes são necessários para utilizar o host do aplicativo. Defina SelfContained como falso ou defina UseAppHost como verdadeiro.</target>
+        <target state="new">NETSDK1067: Self-contained applications are required to use the application host. Either set SelfContained to false or set UseAppHost to true.</target>
         <note>{StrBegin="NETSDK1067: "}</note>
+      </trans-unit>
+      <trans-unit id="ChoosingAssemblyVersion">
+        <source>NETSDK1033: Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</source>
+        <target state="new">NETSDK1033: Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</target>
+        <note>{StrBegin="NETSDK1033: "}</note>
+      </trans-unit>
+      <trans-unit id="ChoosingFileVersion">
+        <source>NETSDK1034: Choosing '{0}' because file version '{1}' is greater than '{2}'.</source>
+        <target state="new">NETSDK1034: Choosing '{0}' because file version '{1}' is greater than '{2}'.</target>
+        <note>{StrBegin="NETSDK1034: "}</note>
+      </trans-unit>
+      <trans-unit id="ChoosingPlatformItem">
+        <source>NETSDK1035: Choosing '{0}' because it is a platform item.</source>
+        <target state="new">NETSDK1035: Choosing '{0}' because it is a platform item.</target>
+        <note>{StrBegin="NETSDK1035: "}</note>
+      </trans-unit>
+      <trans-unit id="ChoosingPreferredPackage">
+        <source>NETSDK1036: Choosing '{0}' because it comes from a package that is preferred.</source>
+        <target state="new">NETSDK1036: Choosing '{0}' because it comes from a package that is preferred.</target>
+        <note>{StrBegin="NETSDK1036: "}</note>
+      </trans-unit>
+      <trans-unit id="ConflictCouldNotDetermineWinner">
+        <source>NETSDK1037: Could not determine winner due to equal file and assembly versions.</source>
+        <target state="new">NETSDK1037: Could not determine winner due to equal file and assembly versions.</target>
+        <note>{StrBegin="NETSDK1037: "}</note>
+      </trans-unit>
+      <trans-unit id="ContentItemDoesNotProvideOutputPath">
+        <source>NETSDK1014: Content item for '{0}' sets '{1}', but does not provide  '{2}' or '{3}'.</source>
+        <target state="new">NETSDK1014: Content item for '{0}' sets '{1}', but does not provide  '{2}' or '{3}'.</target>
+        <note>{StrBegin="NETSDK1014: "}</note>
+      </trans-unit>
+      <trans-unit id="ContentPreproccessorParameterRequired">
+        <source>NETSDK1010: The '{0}' task must be given a value for parameter '{1}' in order to consume preprocessed content.</source>
+        <target state="new">NETSDK1010: The '{0}' task must be given a value for parameter '{1}' in order to consume preprocessed content.</target>
+        <note>{StrBegin="NETSDK1010: "}</note>
+      </trans-unit>
+      <trans-unit id="CouldNotDetermineWinner_DoesntExist">
+        <source>NETSDK1038: Could not determine winner because '{0}' does not exist.</source>
+        <target state="new">NETSDK1038: Could not determine winner because '{0}' does not exist.</target>
+        <note>{StrBegin="NETSDK1001: "}</note>
+      </trans-unit>
+      <trans-unit id="CouldNotDetermineWinner_FileVersion">
+        <source>NETSDK1039: Could not determine a winner because '{0}' has no file version.</source>
+        <target state="new">NETSDK1039: Could not determine a winner because '{0}' has no file version.</target>
+        <note>{StrBegin="NETSDK1039: "}</note>
+      </trans-unit>
+      <trans-unit id="CouldNotDetermineWinner_NotAnAssembly">
+        <source>NETSDK1040: Could not determine a winner because '{0}' is not an assembly.</source>
+        <target state="new">NETSDK1040: Could not determine a winner because '{0}' is not an assembly.</target>
+        <note>{StrBegin="NETSDK1040: "}</note>
+      </trans-unit>
+      <trans-unit id="CouldNotLoadPlatformManifest">
+        <source>NETSDK1042: Could not load PlatformManifest from '{0}' because it did not exist.</source>
+        <target state="new">NETSDK1042: Could not load PlatformManifest from '{0}' because it did not exist.</target>
+        <note>{StrBegin="NETSDK1042: "}</note>
+      </trans-unit>
+      <trans-unit id="DotnetToolDoesNotSupportTFMLowerThanNetcoreapp21">
+        <source>NETSDK1055: DotnetTool does not support target framework lower than netcoreapp2.1.</source>
+        <target state="new">NETSDK1055: DotnetTool does not support target framework lower than netcoreapp2.1.</target>
+        <note>{StrBegin="NETSDK1055: "}</note>
+      </trans-unit>
+      <trans-unit id="DotnetToolOnlySupportNetcoreapp">
+        <source>NETSDK1054: only supports .NET Core.</source>
+        <target state="new">NETSDK1054: only supports .NET Core.</target>
+        <note>{StrBegin="NETSDK1054: "}</note>
+      </trans-unit>
+      <trans-unit id="DuplicateItemsError">
+        <source>NETSDK1022: Duplicate '{0}' items were included. The .NET SDK includes '{0}' items from your project directory by default. You can either remove these items from your project file, or set the '{1}' property to '{2}' if you want to explicitly include them in your project file. For more information, see {4}. The duplicate items were: {3}</source>
+        <target state="new">NETSDK1022: Duplicate '{0}' items were included. The .NET SDK includes '{0}' items from your project directory by default. You can either remove these items from your project file, or set the '{1}' property to '{2}' if you want to explicitly include them in your project file. For more information, see {4}. The duplicate items were: {3}</target>
+        <note>{StrBegin="NETSDK1022: "}</note>
+      </trans-unit>
+      <trans-unit id="DuplicatePreprocessorToken">
+        <source>NETSDK1015: The preprocessor token '{0}' has been given more than one value. Choosing '{1}' as the value.</source>
+        <target state="new">NETSDK1015: The preprocessor token '{0}' has been given more than one value. Choosing '{1}' as the value.</target>
+        <note>{StrBegin="NETSDK1015: "}</note>
+      </trans-unit>
+      <trans-unit id="EncounteredConflict">
+        <source>NETSDK1041: Encountered conflict between '{0}' and '{1}'.</source>
+        <target state="new">NETSDK1041: Encountered conflict between '{0}' and '{1}'.</target>
+        <note>{StrBegin="NETSDK1041: "}</note>
+      </trans-unit>
+      <trans-unit id="ErrorParsingFrameworkListInvalidValue">
+        <source>NETSDK1051: Error parsing FrameworkList from '{0}'.  {1} '{2}' was invalid.</source>
+        <target state="new">NETSDK1051: Error parsing FrameworkList from '{0}'.  {1} '{2}' was invalid.</target>
+        <note>{StrBegin="NETSDK1051: "}</note>
+      </trans-unit>
+      <trans-unit id="ErrorParsingPlatformManifest">
+        <source>NETSDK1043: Error parsing PlatformManifest from '{0}' line {1}.  Lines must have the format {2}.</source>
+        <target state="new">NETSDK1043: Error parsing PlatformManifest from '{0}' line {1}.  Lines must have the format {2}.</target>
+        <note>{StrBegin="NETSDK1043: "}</note>
+      </trans-unit>
+      <trans-unit id="ErrorParsingPlatformManifestInvalidValue">
+        <source>NETSDK1044: Error parsing PlatformManifest from '{0}' line {1}.  {2} '{3}' was invalid.</source>
+        <target state="new">NETSDK1044: Error parsing PlatformManifest from '{0}' line {1}.  {2} '{3}' was invalid.</target>
+        <note>{StrBegin="NETSDK1044: "}</note>
+      </trans-unit>
+      <trans-unit id="ErrorReadingAssetsFile">
+        <source>NETSDK1060: Error reading assets file: {0}</source>
+        <target state="new">NETSDK1060: Error reading assets file: {0}</target>
+        <note>{StrBegin="NETSDK1060: "}</note>
+      </trans-unit>
+      <trans-unit id="FileNameIsTooLong">
+        <source>NETSDK1030: Given file name '{0}' is longer than 1024 bytes</source>
+        <target state="new">NETSDK1030: Given file name '{0}' is longer than 1024 bytes</target>
+        <note>{StrBegin="NETSDK1030: "}</note>
+      </trans-unit>
+      <trans-unit id="FolderAlreadyExists">
+        <source>NETSDK1024: Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</source>
+        <target state="new">NETSDK1024: Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</target>
+        <note>{StrBegin="NETSDK1024: "}</note>
       </trans-unit>
       <trans-unit id="FrameworkDependentAppHostRequiresVersion21">
         <source>NETSDK1068: The framework-dependent application host requires a target framework of at least 'netcoreapp2.1'.</source>
-        <target state="translated">NETSDK1068: o host do aplicativo dependente de estrutura exige uma estrutura de destino de, pelo menos, 'netcoreapp2.1'.</target>
+        <target state="new">NETSDK1068: The framework-dependent application host requires a target framework of at least 'netcoreapp2.1'.</target>
         <note>{StrBegin="NETSDK1068: "}</note>
+      </trans-unit>
+      <trans-unit id="FrameworkListPathNotRooted">
+        <source>NETSDK1052: Framework list file path '{0}' is not rooted. Only full paths are supported.</source>
+        <target state="new">NETSDK1052: Framework list file path '{0}' is not rooted. Only full paths are supported.</target>
+        <note>{StrBegin="NETSDK1052: "}</note>
+      </trans-unit>
+      <trans-unit id="GetDependsOnNETStandardFailedWithException">
+        <source>NETSDK1049: Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0} {1}</source>
+        <target state="new">NETSDK1049: Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0} {1}</target>
+        <note>{StrBegin="NETSDK1049: "}</note>
+      </trans-unit>
+      <trans-unit id="IncorrectPackageRoot">
+        <source>NETSDK1020: Package Root {0} was incorrectly given for Resolved library {1}</source>
+        <target state="new">NETSDK1020: Package Root {0} was incorrectly given for Resolved library {1}</target>
+        <note>{StrBegin="NETSDK1020: "}</note>
+      </trans-unit>
+      <trans-unit id="IncorrectTargetFormat">
+        <source>NETSDK1025: WRThe target manifest {0} provided is of not the correct format</source>
+        <target state="new">NETSDK1025: WRThe target manifest {0} provided is of not the correct format</target>
+        <note>{StrBegin="NETSDK1025: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidFrameworkName">
+        <source>NETSDK1003: Invalid framework name: '{0}'.</source>
+        <target state="new">NETSDK1003: Invalid framework name: '{0}'.</target>
+        <note>{StrBegin="NETSDK1003: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidItemSpecToUse">
+        <source>NETSDK1058: Invalid value for ItemSpecToUse parameter: '{0}'.  This property must be blank or set to 'Left' or 'Right'</source>
+        <target state="new">NETSDK1058: Invalid value for ItemSpecToUse parameter: '{0}'.  This property must be blank or set to 'Left' or 'Right'</target>
+        <note>{StrBegin="NETSDK1058: "}
+The following are names of parameters or literal values and should not be translated: ItemSpecToUse, Left, Right</note>
+      </trans-unit>
+      <trans-unit id="InvalidNuGetVersionString">
+        <source>NETSDK1018: Invalid NuGet version string: '{0}'.</source>
+        <target state="new">NETSDK1018: Invalid NuGet version string: '{0}'.</target>
+        <note>{StrBegin="NETSDK1018: "}</note>
+      </trans-unit>
+      <trans-unit id="MismatchedPlatformPackageVersion">
+        <source>NETSDK1061: The project was restored using {0} version {1}, but with current settings, version {2} would be used instead. To resolve this issue, make sure the same settings are used for restore and for subsequent operations such as build or publish. Typically this issue can occur if the RuntimeIdentifier property is set during build or publish but not during restore. For more information, see https://aka.ms/dotnet-runtime-patch-selection.</source>
+        <target state="new">NETSDK1061: The project was restored using {0} version {1}, but with current settings, version {2} would be used instead. To resolve this issue, make sure the same settings are used for restore and for subsequent operations such as build or publish. Typically this issue can occur if the RuntimeIdentifier property is set during build or publish but not during restore. For more information, see https://aka.ms/dotnet-runtime-patch-selection.</target>
+        <note>{StrBegin="NETSDK1061: "}
+{0} - Package Identifier for platform package
+{1} - Restored version of platform package
+{2} - Current version of platform package</note>
+      </trans-unit>
+      <trans-unit id="MissingItemMetadata">
+        <source>NETSDK1008: Missing '{0}' metadata on '{1}' item '{2}'.</source>
+        <target state="new">NETSDK1008: Missing '{0}' metadata on '{1}' item '{2}'.</target>
+        <note>{StrBegin="NETSDK1008: "}</note>
+      </trans-unit>
+      <trans-unit id="MultipleFilesResolved">
+        <source>NETSDK1021: More than one file found for {0}</source>
+        <target state="new">NETSDK1021: More than one file found for {0}</target>
+        <note>{StrBegin="NETSDK1021: "}</note>
       </trans-unit>
       <trans-unit id="NETFrameworkToNonBuiltInNETStandard">
         <source>NETSDK1069: This project uses a library that targets .NET Standard 1.5 or higher, and the project targets a version of .NET Framework that doesn't have built-in support for that version of .NET Standard. Visit https://aka.ms/net-standard-known-issues for a set of known issues. Consider retargeting to .NET Framework 4.7.2.</source>
-        <target state="translated">NETSDK1069: este projeto utiliza uma biblioteca que tem como destino o .NET Standard 1.5 ou superior, e o projeto tem como destino uma versão do .NET Framework que não tem suporte interno para essa versão do .NET Standard. Visite o site https://aka.ms/net-standard-known-issues para ter acesso a uma variedade de problemas conhecidos. Considere alterar o destino para o .NET Framework 4.7.2.</target>
+        <target state="new">NETSDK1069: This project uses a library that targets .NET Standard 1.5 or higher, and the project targets a version of .NET Framework that doesn't have built-in support for that version of .NET Standard. Visit https://aka.ms/net-standard-known-issues for a set of known issues. Consider retargeting to .NET Framework 4.7.2.</target>
         <note>{StrBegin="NETSDK1069: "}</note>
       </trans-unit>
       <trans-unit id="NoCompatibleTargetFramework">
         <source>NETSDK1002: Project '{0}' targets '{2}'. It cannot be referenced by a project that targets '{1}'.</source>
-        <target state="translated">NETSDK1002: O projeto '{0}' é direcionado a '{2}'. Ele não pode ser referenciado por um projeto direcionado a '{1}'.</target>
+        <target state="new">NETSDK1002: Project '{0}' targets '{2}'. It cannot be referenced by a project that targets '{1}'.</target>
         <note>{StrBegin="NETSDK1002: "}</note>
       </trans-unit>
-      <trans-unit id="InvalidFrameworkName">
-        <source>NETSDK1003: Invalid framework name: '{0}'.</source>
-        <target state="translated">NETSDK1003: Nome de estrutura inválido: '{0}'.</target>
-        <note>{StrBegin="NETSDK1003: "}</note>
+      <trans-unit id="PackAsToolCannotSupportSelfContained">
+        <source>NETSDK1053: Pack as tool does not support self contained.</source>
+        <target state="new">NETSDK1053: Pack as tool does not support self contained.</target>
+        <note>{StrBegin="NETSDK1001: "}</note>
       </trans-unit>
-      <trans-unit id="AssetsFileNotFound">
-        <source>NETSDK1004: Assets file '{0}' not found. Run a NuGet package restore to generate this file.</source>
-        <target state="translated">NETSDK1004: Arquivo de ativos '{0}' não encontrado. Execute uma restauração de pacote do NuGet para gerar esse arquivo.</target>
-        <note>{StrBegin="NETSDK1004: "}</note>
+      <trans-unit id="PackageInfoLog">
+        <source>NETSDK1027: Package Name='{0}', Version='{1}' was parsed</source>
+        <target state="new">NETSDK1027: Package Name='{0}', Version='{1}' was parsed</target>
+        <note>{StrBegin="NETSDK1027: "}</note>
       </trans-unit>
-      <trans-unit id="AssetsFileMissingTarget">
-        <source>NETSDK1005: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project.</source>
-        <target state="translated">NETSDK1005: O arquivo de ativos '{0}' não tem um destino para '{1}'. Verifique se a restauração foi executada e se você incluiu '{2}' no TargetFrameworks do projeto.</target>
-        <note>{StrBegin="NETSDK1005: "}</note>
+      <trans-unit id="PackageNotFound">
+        <source>NETSDK1064: Package {0}, version {1} was not found. It might have been deleted since NuGet restore. Otherwise, NuGet restore might have only partially completed, which might have been due to maximum path length restrictions.</source>
+        <target state="new">NETSDK1064: Package {0}, version {1} was not found. It might have been deleted since NuGet restore. Otherwise, NuGet restore might have only partially completed, which might have been due to maximum path length restrictions.</target>
+        <note>{StrBegin="NETSDK1064: "}</note>
       </trans-unit>
-      <trans-unit id="AssetsFilePathNotRooted">
-        <source>NETSDK1006: Assets file path '{0}' is not rooted. Only full paths are supported.</source>
-        <target state="translated">NETSDK1006: O caminho de arquivo de ativos '{0}' não tem raiz. Há suporte apenas para caminhos completos.</target>
-        <note>{StrBegin="NETSDK1006: "}</note>
+      <trans-unit id="PackageReferenceOverrideWarning">
+        <source>NETSDK1023: A PackageReference for '{0}' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see {1}</source>
+        <target state="new">NETSDK1023: A PackageReference for '{0}' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see {1}</target>
+        <note>{StrBegin="NETSDK1023: "}</note>
       </trans-unit>
-      <trans-unit id="CannotFindProjectInfo">
-        <source>NETSDK1007: Cannot find project info for '{0}'. This can indicate a missing project reference.</source>
-        <target state="translated">NETSDK1007: Não é possível localizar informações do projeto para '{0}'. Isso pode indicar a ausência de uma referência de projeto.</target>
-        <note>{StrBegin="NETSDK1007: "}</note>
+      <trans-unit id="ParsingFiles">
+        <source>NETSDK1026: Parsing the Files : '{0}'</source>
+        <target state="new">NETSDK1026: Parsing the Files : '{0}'</target>
+        <note>{StrBegin="NETSDK1026: "}</note>
       </trans-unit>
-      <trans-unit id="MissingItemMetadata">
-        <source>NETSDK1008: Missing '{0}' metadata on '{1}' item '{2}'.</source>
-        <target state="translated">NETSDK1008: Metadados '{0}' ausentes no item '{1}' '{2}'.</target>
-        <note>{StrBegin="NETSDK1008: "}</note>
+      <trans-unit id="ProjectAssetsConsumedWithoutMSBuildProjectPath">
+        <source>NETSDK1011: Assets are consumed from project '{0}', but no corresponding MSBuild project path was  found in '{1}'.</source>
+        <target state="new">NETSDK1011: Assets are consumed from project '{0}', but no corresponding MSBuild project path was  found in '{1}'.</target>
+        <note>{StrBegin="NETSDK1011: "}</note>
+      </trans-unit>
+      <trans-unit id="ProjectContainsObsoleteDotNetCliTool">
+        <source>NETSDK1059: The tool '{0}' is now included in the .NET Core SDK. Information on resolving this warning is available at (https://aka.ms/dotnetclitools-in-box).</source>
+        <target state="new">NETSDK1059: The tool '{0}' is now included in the .NET Core SDK. Information on resolving this warning is available at (https://aka.ms/dotnetclitools-in-box).</target>
+        <note>{StrBegin="NETSDK1059: "}</note>
       </trans-unit>
       <trans-unit id="RecommendFrameworkReferenceForAspNetCorePackages">
         <source>NETSDK1071: A PackageReference for '{0}' was included in your project. Referencing this item as NuGet package is no longer supported. To resolve this warning, change the PackageReference to a FrameworkReference. For more information, see {1}.</source>
         <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. Referencing this item as NuGet package is no longer supported. To resolve this warning, change the PackageReference to a FrameworkReference. For more information, see {1}.</target>
-        <note>{StrBegin="NETSDK1072: "}
+        <note>{StrBegin="NETSDK1071: "}
 {0} - Package Id (Microsoft.AspNetCore.App or .All)
 {1} - More info link
     </note>
+      </trans-unit>
+      <trans-unit id="RuntimeIdentifierWasNotSpecified">
+        <source>NETSDK1028: Specify a RuntimeIdentifier</source>
+        <target state="new">NETSDK1028: Specify a RuntimeIdentifier</target>
+        <note>{StrBegin="NETSDK1028: "}</note>
+      </trans-unit>
+      <trans-unit id="SkippingAdditionalProbingPaths">
+        <source>NETSDK1048: 'AdditionalProbingPaths' were specified for GenerateRuntimeConfigurationFiles, but are being skipped because 'RuntimeConfigDevPath' is empty.</source>
+        <target state="new">NETSDK1048: 'AdditionalProbingPaths' were specified for GenerateRuntimeConfigurationFiles, but are being skipped because 'RuntimeConfigDevPath' is empty.</target>
+        <note>{StrBegin="NETSDK1048: "}</note>
+      </trans-unit>
+      <trans-unit id="TargetFrameworkWithSemicolon">
+        <source>NETSDK1046: The TargetFramework value '{0}' is not valid. To multi-target, use the 'TargetFrameworks' property instead.</source>
+        <target state="new">NETSDK1046: The TargetFramework value '{0}' is not valid. To multi-target, use the 'TargetFrameworks' property instead.</target>
+        <note>{StrBegin="NETSDK1046: "}</note>
+      </trans-unit>
+      <trans-unit id="UnableToFindResolvedPath">
+        <source>NETSDK1016: Unable to find resolved path for '{0}'.</source>
+        <target state="new">NETSDK1016: Unable to find resolved path for '{0}'.</target>
+        <note>{StrBegin="NETSDK1016: "}</note>
+      </trans-unit>
+      <trans-unit id="UnableToUsePackageAssetsCache">
+        <source>NETSDK1062: Unable to use package assets cache due to I/O error. This can occur when the same project is built more than once in parallel. Performance may be degraded, but the build result will not be impacted.</source>
+        <target state="new">NETSDK1062: Unable to use package assets cache due to I/O error. This can occur when the same project is built more than once in parallel. Performance may be degraded, but the build result will not be impacted.</target>
+        <note>{StrBegin="NETSDK1062: "}</note>
+      </trans-unit>
+      <trans-unit id="UnexpectedFileType">
+        <source>NETSDK1012: Unexpected file type for '{0}'. Type is both '{1}' and '{2}'.</source>
+        <target state="new">NETSDK1012: Unexpected file type for '{0}'. Type is both '{1}' and '{2}'.</target>
+        <note>{StrBegin="NETSDK1012: "}</note>
       </trans-unit>
       <trans-unit id="UnknownFrameworkReference">
         <source>NETSDK1072: The FrameworkReference '{0}' was not recognized.</source>
@@ -82,292 +341,33 @@
       </trans-unit>
       <trans-unit id="UnrecognizedPreprocessorToken">
         <source>NETSDK1009: Unrecognized preprocessor token '{0}' in '{1}'.</source>
-        <target state="translated">NETSDK1009: Token de pré-processador não reconhecido '{0}' em '{1}'.</target>
+        <target state="new">NETSDK1009: Unrecognized preprocessor token '{0}' in '{1}'.</target>
         <note>{StrBegin="NETSDK1009: "}</note>
-      </trans-unit>
-      <trans-unit id="ContentPreproccessorParameterRequired">
-        <source>NETSDK1010: The '{0}' task must be given a value for parameter '{1}' in order to consume preprocessed content.</source>
-        <target state="translated">NETSDK1010: A tarefa '{0}' precisa receber um valor para o parâmetro '{1}' para consumir o conteúdo pré-processado.</target>
-        <note>{StrBegin="NETSDK1010: "}</note>
-      </trans-unit>
-      <trans-unit id="ProjectAssetsConsumedWithoutMSBuildProjectPath">
-        <source>NETSDK1011: Assets are consumed from project '{0}', but no corresponding MSBuild project path was  found in '{1}'.</source>
-        <target state="translated">NETSDK1011: Os ativos são consumidos de um projeto '{0}', mas não foi encontrado nenhum caminho de projeto do MSBuild correspondente em '{1}'.</target>
-        <note>{StrBegin="NETSDK1011: "}</note>
-      </trans-unit>
-      <trans-unit id="UnexpectedFileType">
-        <source>NETSDK1012: Unexpected file type for '{0}'. Type is both '{1}' and '{2}'.</source>
-        <target state="translated">NETSDK1012: Tipo de arquivo inesperado para '{0}'. O tipo é '{1}' e '{2}'.</target>
-        <note>{StrBegin="NETSDK1012: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotInferTargetFrameworkIdentiferAndVersion">
-        <source>NETSDK1013: The TargetFramework value '{0}' was not recognized. It may be misspelled. If not, then the TargetFrameworkIdentifier and/or TargetFrameworkVersion properties must be specified explicitly.</source>
-        <target state="translated">NETSDK1013: O valor '{0}' do TargetFramework não foi reconhecido. Ele pode ter sido escrito com ortografia incorreta. Caso contrário, as propriedades TargetFrameworkIdentifier e/ou TargetFrameworkVersion precisarão ser especificadas explicitamente.</target>
-        <note>{StrBegin="NETSDK1013: "}</note>
-      </trans-unit>
-      <trans-unit id="ContentItemDoesNotProvideOutputPath">
-        <source>NETSDK1014: Content item for '{0}' sets '{1}', but does not provide  '{2}' or '{3}'.</source>
-        <target state="translated">NETSDK1014: O item de conteúdo para '{0}' define '{1}', mas não fornece '{2}' ou '{3}'.</target>
-        <note>{StrBegin="NETSDK1014: "}</note>
-      </trans-unit>
-      <trans-unit id="DuplicatePreprocessorToken">
-        <source>NETSDK1015: The preprocessor token '{0}' has been given more than one value. Choosing '{1}' as the value.</source>
-        <target state="translated">NETSDK1015: O token de pré-processador '{0}' recebeu mais de um valor. Escolhendo '{1}' como o valor.</target>
-        <note>{StrBegin="NETSDK1015: "}</note>
-      </trans-unit>
-      <trans-unit id="UnableToFindResolvedPath">
-        <source>NETSDK1016: Unable to find resolved path for '{0}'.</source>
-        <target state="translated">NETSDK1016: Não foi possível localizar o caminho resolvido para '{0}'.</target>
-        <note>{StrBegin="NETSDK1016: "}</note>
-      </trans-unit>
-      <trans-unit id="AssetPreprocessorMustBeConfigured">
-        <source>NETSDK1017: Asset preprocessor must be configured before assets are processed.</source>
-        <target state="translated">NETSDK1017: O pré-processador de ativos precisa ser configurado antes que os ativos sejam processados.</target>
-        <note>{StrBegin="NETSDK1017: "}</note>
-      </trans-unit>
-      <trans-unit id="InvalidNuGetVersionString">
-        <source>NETSDK1018: Invalid NuGet version string: '{0}'.</source>
-        <target state="translated">NETSDK1018: Cadeia de caracteres de versão do NuGet inválida: '{0}'.</target>
-        <note>{StrBegin="NETSDK1018: "}</note>
       </trans-unit>
       <trans-unit id="UnsupportedFramework">
         <source>NETSDK1019: {0} is an unsupported framework.</source>
-        <target state="translated">NETSDK1019: {0} é uma estrutura sem suporte.</target>
+        <target state="new">NETSDK1019: {0} is an unsupported framework.</target>
         <note>{StrBegin="NETSDK1019: "}</note>
-      </trans-unit>
-      <trans-unit id="DuplicateItemsError">
-        <source>NETSDK1022: Duplicate '{0}' items were included. The .NET SDK includes '{0}' items from your project directory by default. You can either remove these items from your project file, or set the '{1}' property to '{2}' if you want to explicitly include them in your project file. For more information, see {4}. The duplicate items were: {3}</source>
-        <target state="translated">NETSDK1022: Itens '{0}' duplicados foram incluídos. O SDK do .NET inclui '{0}' itens do diretório do projeto por padrão. Você poderá remover esses itens do arquivo de projeto ou configurar a propriedade '{1}' como '{2}' se desejar incluí-los explicitamente no arquivo de projeto. Para obter mais informações, confira {4}. Os itens duplicados eram: {3}</target>
-        <note>{StrBegin="NETSDK1022: "}</note>
-      </trans-unit>
-      <trans-unit id="PackageReferenceOverrideWarning">
-        <source>NETSDK1023: A PackageReference for '{0}' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see {1}</source>
-        <target state="translated">NETSDK1023: Uma PackageReference para '{0}' foi incluída no projeto. Esse pacote é referenciado implicitamente pelo SKD do .NET e, geralmente, não é necessário referenciá-lo no seu projeto. Para obter mais informações, confira {1}</target>
-        <note>{StrBegin="NETSDK1023: "}</note>
-      </trans-unit>
-      <trans-unit id="IncorrectPackageRoot">
-        <source>NETSDK1020: Package Root {0} was incorrectly given for Resolved library {1}</source>
-        <target state="translated">NETSDK1020: A raiz do pacote {0} foi atribuída incorretamente para a biblioteca resolvida {1}</target>
-        <note>{StrBegin="NETSDK1020: "}</note>
-      </trans-unit>
-      <trans-unit id="MultipleFilesResolved">
-        <source>NETSDK1021: More than one file found for {0}</source>
-        <target state="translated">NETSDK1021: Mais de um arquivo encontrado para {0}</target>
-        <note>{StrBegin="NETSDK1021: "}</note>
-      </trans-unit>
-      <trans-unit id="FolderAlreadyExists">
-        <source>NETSDK1024: Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</source>
-        <target state="translated">NETSDK1024: A pasta '{0}' já existe. Exclua essa pasta ou forneça um ComposeWorkingDir diferente</target>
-        <note>{StrBegin="NETSDK1024: "}</note>
-      </trans-unit>
-      <trans-unit id="ParsingFiles">
-        <source>NETSDK1026: Parsing the Files : '{0}'</source>
-        <target state="translated">NETSDK1026: Analisando os arquivos: '{0}'</target>
-        <note>{StrBegin="NETSDK1026: "}</note>
-      </trans-unit>
-      <trans-unit id="PackageInfoLog">
-        <source>NETSDK1027: Package Name='{0}', Version='{1}' was parsed</source>
-        <target state="translated">NETSDK1027: O nome do pacote = '{0}', versão = '{1}' foi analisado</target>
-        <note>{StrBegin="NETSDK1027: "}</note>
-      </trans-unit>
-      <trans-unit id="RuntimeIdentifierWasNotSpecified">
-        <source>NETSDK1028: Specify a RuntimeIdentifier</source>
-        <target state="translated">NETSDK1028: Especifique um RuntimeIdentifier</target>
-        <note>{StrBegin="NETSDK1028: "}</note>
-      </trans-unit>
-      <trans-unit id="IncorrectTargetFormat">
-        <source>NETSDK1025: WRThe target manifest {0} provided is of not the correct format</source>
-        <target state="translated">NETSDK1025: O manifesto de destino {0} fornecido não está no formato correto</target>
-        <note>{StrBegin="NETSDK1025: "}</note>
-      </trans-unit>
-      <trans-unit id="AppHostHasBeenModified">
-        <source>NETSDK1029: Unable to use '{0}' as application host executable as it does not contain the expected placeholder byte sequence '{1}' that would mark where the application name would be written.</source>
-        <target state="translated">NETSDK1029: Não é possível usar '{0}' como executável do host de aplicativo, porque ele não contém a sequência de bytes de espaço reservado esperada '{1}' que marcaria o local em que o nome do aplicativo seria gravado.</target>
-        <note>{StrBegin="NETSDK1029: "}</note>
-      </trans-unit>
-      <trans-unit id="FileNameIsTooLong">
-        <source>NETSDK1030: Given file name '{0}' is longer than 1024 bytes</source>
-        <target state="translated">NETSDK1030: O nome de arquivo '{0}' fornecido tem mais de 1024 bytes</target>
-        <note>{StrBegin="NETSDK1030: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotHaveSelfContainedWithoutRuntimeIdentifier">
-        <source>NETSDK1031: It is not supported to build or publish a self-contained application without specifying a RuntimeIdentifier.  Please either specify a RuntimeIdentifier or set SelfContained to false.</source>
-        <target state="translated">NETSDK1031: Não há suporte para criar ou publicar um aplicativo autossuficiente sem especificar um RuntimeIdentifier. Especifique um RuntimeIdentifier ou defina SelfContained como falso.</target>
-        <note>{StrBegin="NETSDK1031: "}</note>
-      </trans-unit>
-      <trans-unit id="ChoosingAssemblyVersion">
-        <source>NETSDK1033: Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</source>
-        <target state="translated">NETSDK1033: Escolhendo '{0}' porque AssemblyVersion '{1}' é maior que '{2}'.</target>
-        <note>{StrBegin="NETSDK1033: "}</note>
-      </trans-unit>
-      <trans-unit id="ChoosingFileVersion">
-        <source>NETSDK1034: Choosing '{0}' because file version '{1}' is greater than '{2}'.</source>
-        <target state="translated">NETSDK1034: Escolhendo '{0}' porque a versão do arquivo '{1}' é maior que '{2}'.</target>
-        <note>{StrBegin="NETSDK1034: "}</note>
-      </trans-unit>
-      <trans-unit id="ChoosingPlatformItem">
-        <source>NETSDK1035: Choosing '{0}' because it is a platform item.</source>
-        <target state="translated">NETSDK1035: Escolhendo '{0}' porque ele é um item de plataforma.</target>
-        <note>{StrBegin="NETSDK1035: "}</note>
-      </trans-unit>
-      <trans-unit id="ChoosingPreferredPackage">
-        <source>NETSDK1036: Choosing '{0}' because it comes from a package that is preferred.</source>
-        <target state="translated">NETSDK1036: Escolhendo '{0}' porque vem de um pacote que é preferencial.</target>
-        <note>{StrBegin="NETSDK1036: "}</note>
-      </trans-unit>
-      <trans-unit id="ConflictCouldNotDetermineWinner">
-        <source>NETSDK1037: Could not determine winner due to equal file and assembly versions.</source>
-        <target state="translated">NETSDK1037: Não foi possível determinar o vencedor porque as versões de arquivo e de assembly são iguais.</target>
-        <note>{StrBegin="NETSDK1037: "}</note>
-      </trans-unit>
-      <trans-unit id="CouldNotDetermineWinner_DoesntExist">
-        <source>NETSDK1038: Could not determine winner because '{0}' does not exist.</source>
-        <target state="translated">NETSDK1038: Não foi possível determinar o vencedor porque '{0}' não existe.</target>
-        <note>{StrBegin="NETSDK1001: "}</note>
-      </trans-unit>
-      <trans-unit id="CouldNotDetermineWinner_FileVersion">
-        <source>NETSDK1039: Could not determine a winner because '{0}' has no file version.</source>
-        <target state="translated">NETSDK1039: Não foi possível determinar um vencedor porque '{0}' não tem versão de arquivo.</target>
-        <note>{StrBegin="NETSDK1039: "}</note>
-      </trans-unit>
-      <trans-unit id="CouldNotDetermineWinner_NotAnAssembly">
-        <source>NETSDK1040: Could not determine a winner because '{0}' is not an assembly.</source>
-        <target state="translated">NETSDK1040: Não foi possível determinar um vencedor porque '{0}' não é um assembly.</target>
-        <note>{StrBegin="NETSDK1040: "}</note>
-      </trans-unit>
-      <trans-unit id="EncounteredConflict">
-        <source>NETSDK1041: Encountered conflict between '{0}' and '{1}'.</source>
-        <target state="translated">NETSDK1041: Encontrado um conflito entre '{0}' e '{1}'.</target>
-        <note>{StrBegin="NETSDK1041: "}</note>
-      </trans-unit>
-      <trans-unit id="CouldNotLoadPlatformManifest">
-        <source>NETSDK1042: Could not load PlatformManifest from '{0}' because it did not exist.</source>
-        <target state="translated">NETSDK1042: Não foi possível carregar PlatformManifest de '{0}' porque ele não existia.</target>
-        <note>{StrBegin="NETSDK1042: "}</note>
-      </trans-unit>
-      <trans-unit id="ErrorParsingPlatformManifest">
-        <source>NETSDK1043: Error parsing PlatformManifest from '{0}' line {1}.  Lines must have the format {2}.</source>
-        <target state="translated">NETSDK1043: Erro ao analisar PlatformManifest de '{0}', linha {1}. As linhas precisam ter o formato {2}.</target>
-        <note>{StrBegin="NETSDK1043: "}</note>
-      </trans-unit>
-      <trans-unit id="ErrorParsingPlatformManifestInvalidValue">
-        <source>NETSDK1044: Error parsing PlatformManifest from '{0}' line {1}.  {2} '{3}' was invalid.</source>
-        <target state="translated">NETSDK1044: Erro ao analisar PlatformManifest de '{0}', linha {1}. {2} '{3}' era inválido.</target>
-        <note>{StrBegin="NETSDK1044: "}</note>
-      </trans-unit>
-      <trans-unit id="UnsupportedTargetFrameworkVersion">
-        <source>NETSDK1045: The current .NET SDK does not support targeting {0} {1}.  Either target {0} {2} or lower, or use a version of the .NET SDK that supports {0} {1}.</source>
-        <target state="translated">NETSDK1045: O SDK do .NET atual não dá suporte para direcionar a {0} {1}. Direcione a {0} {2} ou inferior, ou use uma versão do SDK do .NET compatível com  {0} {1}.</target>
-        <note>{StrBegin="NETSDK1045: "}</note>
-      </trans-unit>
-      <trans-unit id="AssetsFileMissingRuntimeIdentifier">
-        <source>NETSDK1047: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project. You may also need to include '{3}' in your project's RuntimeIdentifiers.</source>
-        <target state="translated">NETSDK1047: O arquivo de ativos '{0}' não tem um destino para '{1}'. Verifique se a restauração foi executada e se você incluiu '{2}' no TargetFrameworks do projeto. Talvez você também precise incluir '{3}' no RuntimeIdentifiers do projeto.</target>
-        <note>{StrBegin="NETSDK1047: "}</note>
-      </trans-unit>
-      <trans-unit id="TargetFrameworkWithSemicolon">
-        <source>NETSDK1046: The TargetFramework value '{0}' is not valid. To multi-target, use the 'TargetFrameworks' property instead.</source>
-        <target state="translated">NETSDK1046: O valor '{0}' do TargetFramework não é válido. Para vários destinos, use a propriedade 'TargetFrameworks'.</target>
-        <note>{StrBegin="NETSDK1046: "}</note>
-      </trans-unit>
-      <trans-unit id="GetDependsOnNETStandardFailedWithException">
-        <source>NETSDK1049: Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0} {1}</source>
-        <target state="translated">NETSDK1049: O arquivo resolvido tem uma imagem inválida, não tem metadados ou está inacessível. {0} {1}</target>
-        <note>{StrBegin="NETSDK1049: "}</note>
-      </trans-unit>
-      <trans-unit id="UnsupportedSDKVersionForNetStandard20">
-        <source>NETSDK1050: The version of Microsoft.NET.Sdk used by this project is insufficient to support references to libraries targeting .NET Standard 1.5 or higher.  Please install version 2.0 or higher of the .NET Core SDK.</source>
-        <target state="translated">NETSDK1050: A versão do Microsoft.NET.Sdk usada por este projeto é insuficiente para dar suporte às referências a bibliotecas direcionadas ao .NET Standard 1.5 ou superior. Instale a versão 2.0 ou superior do SDK do .NET Core.</target>
-        <note>{StrBegin="NETSDK1050: "}</note>
-      </trans-unit>
-      <trans-unit id="SkippingAdditionalProbingPaths">
-        <source>NETSDK1048: 'AdditionalProbingPaths' were specified for GenerateRuntimeConfigurationFiles, but are being skipped because 'RuntimeConfigDevPath' is empty.</source>
-        <target state="translated">NETSDK1048: Os 'AdditionalProbingPaths' foram especificados para os GenerateRuntimeConfigurationFiles, mas estão sendo ignorados porque 'RuntimeConfigDevPath' está vazio.</target>
-        <note>{StrBegin="NETSDK1048: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotHaveRuntimeIdentifierPlatformMismatchPlatformTarget">
-        <source>NETSDK1032: The RuntimeIdentifier platform '{0}' and the PlatformTarget '{1}' must be compatible.</source>
-        <target state="translated">NETSDK1032: A plataforma '{0}' do RuntimeIdentifier e o PlatformTarget '{1}' precisam ser compatíveis.</target>
-        <note>{StrBegin="NETSDK1032: "}</note>
-      </trans-unit>
-      <trans-unit id="ErrorParsingFrameworkListInvalidValue">
-        <source>NETSDK1051: Error parsing FrameworkList from '{0}'.  {1} '{2}' was invalid.</source>
-        <target state="translated">NETSDK1051: Erro ao analisar FrameworkList de '{0}'.  {1} '{2}' era inválido.</target>
-        <note>{StrBegin="NETSDK1051: "}</note>
-      </trans-unit>
-      <trans-unit id="FrameworkListPathNotRooted">
-        <source>NETSDK1052: Framework list file path '{0}' is not rooted. Only full paths are supported.</source>
-        <target state="translated">NETSDK1052: O caminho de arquivo de lista de estrutura '{0}' não tem raiz. Há suporte apenas para caminhos completos.</target>
-        <note>{StrBegin="NETSDK1052: "}</note>
-      </trans-unit>
-      <trans-unit id="PackAsToolCannotSupportSelfContained">
-        <source>NETSDK1053: Pack as tool does not support self contained.</source>
-        <target state="translated">NETSDK1053: O pacote como ferramenta não é compatível com a opção autossuficiente.</target>
-        <note>{StrBegin="NETSDK1001: "}</note>
       </trans-unit>
       <trans-unit id="UnsupportedRuntimeIdentifier">
         <source>NETSDK1056: Project is targeting runtime '{0}' but did not resolve any runtime-specific packages. This runtime may not be supported by the target framework.</source>
-        <target state="translated">NETSDK1056: O projeto é direcionado ao tempo de execução '{0}', mas não resolveu nenhum pacote específico do tempo de execução. Esse tempo de execução pode não ser compatível com a estrutura de destino.</target>
+        <target state="new">NETSDK1056: Project is targeting runtime '{0}' but did not resolve any runtime-specific packages. This runtime may not be supported by the target framework.</target>
         <note>{StrBegin="NETSDK1056: "}</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedSDKVersionForNetStandard20">
+        <source>NETSDK1050: The version of Microsoft.NET.Sdk used by this project is insufficient to support references to libraries targeting .NET Standard 1.5 or higher.  Please install version 2.0 or higher of the .NET Core SDK.</source>
+        <target state="new">NETSDK1050: The version of Microsoft.NET.Sdk used by this project is insufficient to support references to libraries targeting .NET Standard 1.5 or higher.  Please install version 2.0 or higher of the .NET Core SDK.</target>
+        <note>{StrBegin="NETSDK1050: "}</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedTargetFrameworkVersion">
+        <source>NETSDK1045: The current .NET SDK does not support targeting {0} {1}.  Either target {0} {2} or lower, or use a version of the .NET SDK that supports {0} {1}.</source>
+        <target state="new">NETSDK1045: The current .NET SDK does not support targeting {0} {1}.  Either target {0} {2} or lower, or use a version of the .NET SDK that supports {0} {1}.</target>
+        <note>{StrBegin="NETSDK1045: "}</note>
       </trans-unit>
       <trans-unit id="UsingPreviewSdkWarning">
         <source>NETSDK1057: You are using a preview version of .NET Core. See: https://aka.ms/dotnet-core-preview</source>
-        <target state="needs-review-translation">NETSDK1057: Você está trabalhando com uma versão prévia do SDK do .NET Core. É possível definir a versão do SDK usando um arquivo global.json no projeto atual. Mais informações em https://go.microsoft.com/fwlink/?linkid=869452</target>
+        <target state="new">NETSDK1057: You are using a preview version of .NET Core. See: https://aka.ms/dotnet-core-preview</target>
         <note>{StrBegin="NETSDK1057: "}</note>
-      </trans-unit>
-      <trans-unit id="InvalidItemSpecToUse">
-        <source>NETSDK1058: Invalid value for ItemSpecToUse parameter: '{0}'.  This property must be blank or set to 'Left' or 'Right'</source>
-        <target state="translated">NETSDK1058: Valor inválido para o parâmetro ItemSpecToUse: '{0}'. Essa propriedade precisa estar em branco ou ser definida como 'Left' ou 'Right'</target>
-        <note>{StrBegin="NETSDK1058: "}
-The following are names of parameters or literal values and should not be translated: ItemSpecToUse, Left, Right</note>
-      </trans-unit>
-      <trans-unit id="ProjectContainsObsoleteDotNetCliTool">
-        <source>NETSDK1059: The tool '{0}' is now included in the .NET Core SDK. Information on resolving this warning is available at (https://aka.ms/dotnetclitools-in-box).</source>
-        <target state="translated">NETSDK1059: A ferramenta '{0}' agora está incluída no SDK do .NET Core. Há informações de como resolver esse aviso em (https://aka.ms/dotnetclitools-in-box).</target>
-        <note>{StrBegin="NETSDK1059: "}</note>
-      </trans-unit>
-      <trans-unit id="ErrorReadingAssetsFile">
-        <source>NETSDK1060: Error reading assets file: {0}</source>
-        <target state="translated">NETSDK1060: Erro ao ler o arquivo de ativos: {0}</target>
-        <note>{StrBegin="NETSDK1060: "}</note>
-      </trans-unit>
-      <trans-unit id="MismatchedPlatformPackageVersion">
-        <source>NETSDK1061: The project was restored using {0} version {1}, but with current settings, version {2} would be used instead. To resolve this issue, make sure the same settings are used for restore and for subsequent operations such as build or publish. Typically this issue can occur if the RuntimeIdentifier property is set during build or publish but not during restore. For more information, see https://aka.ms/dotnet-runtime-patch-selection.</source>
-        <target state="translated">NETSDK1061: o projeto foi restaurado usando o {0} versão {1}, mas, com as configurações atuais, a versão {2} seria usada. Para resolver esse problema, verifique se as mesmas configurações são usadas para restauração e para operações subsequentes, como compilação ou publicação. Normalmente, esse problema poderá ocorrer se a propriedade RuntimeIdentifier for definida durante a compilação ou a publicação, mas não durante a restauração. Para obter mais informações, consulte https://aka.ms/dotnet-runtime-patch-selection.</target>
-        <note>{StrBegin="NETSDK1061: "}
-{0} - Package Identifier for platform package
-{1} - Restored version of platform package
-{2} - Current version of platform package</note>
-      </trans-unit>
-      <trans-unit id="AssetsFileNotSet">
-        <source>NETSDK1063: The path to the project assets file was not set. Run a NuGet package restore to generate this file.</source>
-        <target state="translated">NETSDK1063: O caminho para o arquivo de ativos do projeto não foi configurado. Execute uma restauração de pacote do NuGet para gerar esse arquivo.</target>
-        <note>{StrBegin="NETSDK1063: "}</note>
-      </trans-unit>
-      <trans-unit id="DotnetToolOnlySupportNetcoreapp">
-        <source>NETSDK1054: only supports .NET Core.</source>
-        <target state="translated">NETSDK1054: É compatível apenas com o .NET Core.</target>
-        <note>{StrBegin="NETSDK1054: "}</note>
-      </trans-unit>
-      <trans-unit id="DotnetToolDoesNotSupportTFMLowerThanNetcoreapp21">
-        <source>NETSDK1055: DotnetTool does not support target framework lower than netcoreapp2.1.</source>
-        <target state="translated">NETSDK1055: O DotnetTool não é compatível com uma estrutura de destino inferior ao netcoreapp2.1.</target>
-        <note>{StrBegin="NETSDK1055: "}</note>
-      </trans-unit>
-      <trans-unit id="UnableToUsePackageAssetsCache">
-        <source>NETSDK1062: Unable to use package assets cache due to I/O error. This can occur when the same project is built more than once in parallel. Performance may be degraded, but the build result will not be impacted.</source>
-        <target state="translated">NETSDK1062: Não é possível usar o cache de ativos do pacote devido a um erro de E/S. Isso pode ocorrer quando o mesmo projeto é compilado mais de uma vez em paralelo. O desempenho poderá ser degradado, mas o resultado do build não será afetado.</target>
-        <note>{StrBegin="NETSDK1062: "}</note>
-      </trans-unit>
-      <trans-unit id="PackageNotFound">
-        <source>NETSDK1064: Package {0}, version {1} was not found. It might have been deleted since NuGet restore. Otherwise, NuGet restore might have only partially completed, which might have been due to maximum path length restrictions.</source>
-        <target state="translated">NETSDK1064: O pacote {0}, versão {1}, não foi encontrado. Ele pode ter sido excluído desde a restauração do NuGet. Caso contrário, a restauração do NuGet pode ter sido concluída apenas parcialmente, o que pode ter ocorrido devido a restrições de comprimento máximo do caminho.</target>
-        <note>{StrBegin="NETSDK1064: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotFindApphostForRid">
-        <source>NETSDK1065: Cannot find app host for {0}. {0} could be an invalid runtime identifier (RID). For more information about RID, see https://aka.ms/rid-catalog.</source>
-        <target state="translated">NETSDK1065: Não é possível encontrar o host do aplicativo para {0}. {0} poderia ser um RID (identificador de tempo de execução inválido). Para obter mais informações sobre RID, confira https://aka.ms/rid-catalog.</target>
-        <note>{StrBegin="NETSDK1065: "}</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
@@ -67,6 +67,19 @@
         <target state="translated">NETSDK1008: отсутствуют метаданные "{0}" для элемента "{2}" в "{1}".</target>
         <note>{StrBegin="NETSDK1008: "}</note>
       </trans-unit>
+      <trans-unit id="RecommendFrameworkReferenceForAspNetCorePackages">
+        <source>NETSDK1071: A PackageReference for '{0}' was included in your project. Referencing this item as NuGet package is no longer supported. To resolve this warning, change the PackageReference to a FrameworkReference. For more information, see {1}.</source>
+        <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. Referencing this item as NuGet package is no longer supported. To resolve this warning, change the PackageReference to a FrameworkReference. For more information, see {1}.</target>
+        <note>{StrBegin="NETSDK1072: "}
+{0} - Package Id (Microsoft.AspNetCore.App or .All)
+{1} - More info link
+    </note>
+      </trans-unit>
+      <trans-unit id="UnknownFrameworkReference">
+        <source>NETSDK1072: The FrameworkReference '{0}' was not recognized.</source>
+        <target state="new">NETSDK1072: The FrameworkReference '{0}' was not recognized.</target>
+        <note>{StrBegin="NETSDK1072: "}</note>
+      </trans-unit>
       <trans-unit id="UnrecognizedPreprocessorToken">
         <source>NETSDK1009: Unrecognized preprocessor token '{0}' in '{1}'.</source>
         <target state="translated">NETSDK1009: не распознан маркер препроцессора "{0}" в "{1}".</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
@@ -70,7 +70,7 @@
       <trans-unit id="RecommendFrameworkReferenceForAspNetCorePackages">
         <source>NETSDK1071: A PackageReference for '{0}' was included in your project. Referencing this item as NuGet package is no longer supported. To resolve this warning, change the PackageReference to a FrameworkReference. For more information, see {1}.</source>
         <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. Referencing this item as NuGet package is no longer supported. To resolve this warning, change the PackageReference to a FrameworkReference. For more information, see {1}.</target>
-        <note>{StrBegin="NETSDK1072: "}
+        <note>{StrBegin="NETSDK1071: "}
 {0} - Package Id (Microsoft.AspNetCore.App or .All)
 {1} - More info link
     </note>

--- a/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
@@ -67,6 +67,19 @@
         <target state="translated">NETSDK1008: '{1}' öğesi '{2}' üzerinde '{0}' meta verileri eksik.</target>
         <note>{StrBegin="NETSDK1008: "}</note>
       </trans-unit>
+      <trans-unit id="RecommendFrameworkReferenceForAspNetCorePackages">
+        <source>NETSDK1071: A PackageReference for '{0}' was included in your project. Referencing this item as NuGet package is no longer supported. To resolve this warning, change the PackageReference to a FrameworkReference. For more information, see {1}.</source>
+        <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. Referencing this item as NuGet package is no longer supported. To resolve this warning, change the PackageReference to a FrameworkReference. For more information, see {1}.</target>
+        <note>{StrBegin="NETSDK1072: "}
+{0} - Package Id (Microsoft.AspNetCore.App or .All)
+{1} - More info link
+    </note>
+      </trans-unit>
+      <trans-unit id="UnknownFrameworkReference">
+        <source>NETSDK1072: The FrameworkReference '{0}' was not recognized.</source>
+        <target state="new">NETSDK1072: The FrameworkReference '{0}' was not recognized.</target>
+        <note>{StrBegin="NETSDK1072: "}</note>
+      </trans-unit>
       <trans-unit id="UnrecognizedPreprocessorToken">
         <source>NETSDK1009: Unrecognized preprocessor token '{0}' in '{1}'.</source>
         <target state="translated">NETSDK1009: '{1}' içinde tanınmayan '{0}' ön işlemci belirteci.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
@@ -70,7 +70,7 @@
       <trans-unit id="RecommendFrameworkReferenceForAspNetCorePackages">
         <source>NETSDK1071: A PackageReference for '{0}' was included in your project. Referencing this item as NuGet package is no longer supported. To resolve this warning, change the PackageReference to a FrameworkReference. For more information, see {1}.</source>
         <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. Referencing this item as NuGet package is no longer supported. To resolve this warning, change the PackageReference to a FrameworkReference. For more information, see {1}.</target>
-        <note>{StrBegin="NETSDK1072: "}
+        <note>{StrBegin="NETSDK1071: "}
 {0} - Package Id (Microsoft.AspNetCore.App or .All)
 {1} - More info link
     </note>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
@@ -67,6 +67,19 @@
         <target state="translated">NETSDK1008: 在“{1}”项“{2}”上缺少“{0}”元数据。</target>
         <note>{StrBegin="NETSDK1008: "}</note>
       </trans-unit>
+      <trans-unit id="RecommendFrameworkReferenceForAspNetCorePackages">
+        <source>NETSDK1071: A PackageReference for '{0}' was included in your project. Referencing this item as NuGet package is no longer supported. To resolve this warning, change the PackageReference to a FrameworkReference. For more information, see {1}.</source>
+        <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. Referencing this item as NuGet package is no longer supported. To resolve this warning, change the PackageReference to a FrameworkReference. For more information, see {1}.</target>
+        <note>{StrBegin="NETSDK1072: "}
+{0} - Package Id (Microsoft.AspNetCore.App or .All)
+{1} - More info link
+    </note>
+      </trans-unit>
+      <trans-unit id="UnknownFrameworkReference">
+        <source>NETSDK1072: The FrameworkReference '{0}' was not recognized.</source>
+        <target state="new">NETSDK1072: The FrameworkReference '{0}' was not recognized.</target>
+        <note>{StrBegin="NETSDK1072: "}</note>
+      </trans-unit>
       <trans-unit id="UnrecognizedPreprocessorToken">
         <source>NETSDK1009: Unrecognized preprocessor token '{0}' in '{1}'.</source>
         <target state="translated">NETSDK1009:“{1}”中无法识别预处理器标记“{0}”。</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
@@ -70,7 +70,7 @@
       <trans-unit id="RecommendFrameworkReferenceForAspNetCorePackages">
         <source>NETSDK1071: A PackageReference for '{0}' was included in your project. Referencing this item as NuGet package is no longer supported. To resolve this warning, change the PackageReference to a FrameworkReference. For more information, see {1}.</source>
         <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. Referencing this item as NuGet package is no longer supported. To resolve this warning, change the PackageReference to a FrameworkReference. For more information, see {1}.</target>
-        <note>{StrBegin="NETSDK1072: "}
+        <note>{StrBegin="NETSDK1071: "}
 {0} - Package Id (Microsoft.AspNetCore.App or .All)
 {1} - More info link
     </note>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
@@ -70,7 +70,7 @@
       <trans-unit id="RecommendFrameworkReferenceForAspNetCorePackages">
         <source>NETSDK1071: A PackageReference for '{0}' was included in your project. Referencing this item as NuGet package is no longer supported. To resolve this warning, change the PackageReference to a FrameworkReference. For more information, see {1}.</source>
         <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. Referencing this item as NuGet package is no longer supported. To resolve this warning, change the PackageReference to a FrameworkReference. For more information, see {1}.</target>
-        <note>{StrBegin="NETSDK1072: "}
+        <note>{StrBegin="NETSDK1071: "}
 {0} - Package Id (Microsoft.AspNetCore.App or .All)
 {1} - More info link
     </note>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
@@ -67,6 +67,19 @@
         <target state="translated">NETSDK1008: '{1}' 項目 '{2}' 上遺漏 '{0}' 中繼資料。</target>
         <note>{StrBegin="NETSDK1008: "}</note>
       </trans-unit>
+      <trans-unit id="RecommendFrameworkReferenceForAspNetCorePackages">
+        <source>NETSDK1071: A PackageReference for '{0}' was included in your project. Referencing this item as NuGet package is no longer supported. To resolve this warning, change the PackageReference to a FrameworkReference. For more information, see {1}.</source>
+        <target state="new">NETSDK1071: A PackageReference for '{0}' was included in your project. Referencing this item as NuGet package is no longer supported. To resolve this warning, change the PackageReference to a FrameworkReference. For more information, see {1}.</target>
+        <note>{StrBegin="NETSDK1072: "}
+{0} - Package Id (Microsoft.AspNetCore.App or .All)
+{1} - More info link
+    </note>
+      </trans-unit>
+      <trans-unit id="UnknownFrameworkReference">
+        <source>NETSDK1072: The FrameworkReference '{0}' was not recognized.</source>
+        <target state="new">NETSDK1072: The FrameworkReference '{0}' was not recognized.</target>
+        <note>{StrBegin="NETSDK1072: "}</note>
+      </trans-unit>
       <trans-unit id="UnrecognizedPreprocessorToken">
         <source>NETSDK1009: Unrecognized preprocessor token '{0}' in '{1}'.</source>
         <target state="translated">NETSDK1009: '{1}' 中的前置處理器語彙基元 '{0}' 無法辨識。</target>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ComposeStore.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ComposeStore.targets
@@ -221,7 +221,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     </PropertyGroup>
 
     <NETSdkError Condition="'2.0' > '$(_TargetFrameworkVersionWithoutV)'"
-                 ResourceName="UnuspportedFramework"
+                 ResourceName="UnsupportedFramework"
                  FormatArguments="$(TargetFrameworkMoniker)"/>
 
     <NETSdkError Condition="'$(RuntimeIdentifier)' =='' and '$(_PureManagedAssets)' == ''"

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.targets
@@ -6,7 +6,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
           created a backup copy.  Incorrect changes to this file will make it
           impossible to load or build your projects from the command-line or the IDE.
 
-Copyright (c) .NET Foundation. All rights reserved. 
+Copyright (c) .NET Foundation. All rights reserved.
 ***********************************************************************************************
 -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
@@ -22,10 +22,10 @@ Copyright (c) .NET Foundation. All rights reserved.
     <EnableDefaultNoneItems Condition=" '$(EnableDefaultNoneItems)' == '' ">true</EnableDefaultNoneItems>
   </PropertyGroup>
 
-  <PropertyGroup>    
+  <PropertyGroup>
     <!-- Set DefaultItemExcludes property for items that should be excluded from the default Compile, etc items.
          This is in the .targets because it needs to come after the final BaseOutputPath has been evaluated. -->
-    
+
     <!-- bin folder, by default -->
     <DefaultItemExcludes>$(DefaultItemExcludes);$(BaseOutputPath)/**</DefaultItemExcludes>
     <!-- obj folder, by default -->
@@ -36,12 +36,12 @@ Copyright (c) .NET Foundation. All rights reserved.
     <DefaultItemExcludes>$(DefaultItemExcludes);**/*.*proj</DefaultItemExcludes>
     <DefaultItemExcludes>$(DefaultItemExcludes);**/*.sln</DefaultItemExcludes>
     <DefaultItemExcludes>$(DefaultItemExcludes);**/*.vssscc</DefaultItemExcludes>
-    
+
     <!-- WARNING: This pattern is there to ignore folders such as .git and .vs, but it will also match items included with a
          relative path outside the project folder (for example "..\Shared\Shared.cs").  So be sure only to apply it to items
          that are in the project folder. -->
     <DefaultExcludesInProjectFolder>$(DefaultItemExcludesInProjectFolder);**/.*/**</DefaultExcludesInProjectFolder>
-   
+
   </PropertyGroup>
 
   <!-- Set the default versions of the NETStandard.Library or Microsoft.NETCore.App packages to reference.
@@ -57,33 +57,33 @@ Copyright (c) .NET Foundation. All rights reserved.
          updating to the 2.0 or higher SDK.  When targeting .NET Standard 2.0 or higher, the NETStandard.Library reference won't show up as a dependency of the package
          produced, so we will roll forward to the latest version. -->
     <NETStandardImplicitPackageVersion Condition="'$(NETStandardImplicitPackageVersion)' =='' And '$(_TargetFrameworkVersionWithoutV)' &lt; '2.0'">1.6.1</NETStandardImplicitPackageVersion>
-    
+
     <!-- Default to use the latest stable release. -->
     <NETStandardImplicitPackageVersion Condition="'$(NETStandardImplicitPackageVersion)' ==''">2.0.3</NETStandardImplicitPackageVersion>
   </PropertyGroup>
 
   <!--
     Determine the version (including patch) of .NET Core to target.
-    
+
     When targeting .NET Core, the TargetFramework is used to specify the major and minor version of the runtime to use.  By default,
     the patch version is inferred.  The general logic is that self-contained apps will target the latest patch that the SDK
     knows about, while framework-dependent apps will target the ".0" patch (and roll forward to the latest patch installed at
     runtime).
-    
+
     When targeting .NET Core 1.0 and 1.1, framework-dependent apps use 1.0.5 and 1.1.2, respectively.  This is done for compatibility
     with previous releases that bumped the self-contained and framework-dependent versions together.
-    
+
     The TargetLatestRuntimePatch property can be set to true or false to explicitly opt in or out of the logic to roll forward
     to the latest patch, regardless of whether the app is self-contained or framework-dependent.
 
     The RuntimeFrameworkVersion is where the actual version of the .NET Core runtime to target is stored.  It is the version that is
     used in the implicit PackageReference to Microsoft.NETCore.App.  The RuntimeFrameworkVersion can also be set explicitly, which
     will disable all the other logic that automatically selects the version of .NET Core to target.
-    
+
     The framework version that is written to the runtimeconfig.json file is based on the actual resolved package version
     of Microsoft.NETCore.App.  This is to allow floating the verion number (ie the RuntimeFrameworkVersion could be set to
     "2.0-*".
-  
+
   -->
 
   <!--
@@ -92,10 +92,10 @@ Copyright (c) .NET Foundation. All rights reserved.
       - TargetLatestNetCoreRuntimePatch
       - RollForwardRuntime
       - RollForwardNetCoreRuntime
-      
+
      Possible property names for roll-forward/not roll-forward versions
       - LatestNetCorePatchVersion / DefaultNetCorePatchVersion
-      
+
       TODO: Get feedback on these names and then delete this comment
   -->
 
@@ -129,10 +129,16 @@ Copyright (c) .NET Foundation. All rights reserved.
     <!-- If not covered by the previous cases use the target framework version for the latest patch version -->
     <LatestNetCorePatchVersion Condition="'$(LatestNetCorePatchVersion)' == ''">$(_TargetFrameworkVersionWithoutV)</LatestNetCorePatchVersion>
   </PropertyGroup>
-  
+
   <PropertyGroup Condition="'$(TargetLatestRuntimePatch)' == ''">
     <TargetLatestRuntimePatch Condition="'$(SelfContained)' == 'true' ">true</TargetLatestRuntimePatch>
     <TargetLatestRuntimePatch Condition="'$(SelfContained)' != 'true' ">false</TargetLatestRuntimePatch>
+  </PropertyGroup>
+
+  <!-- RuntimeFrameworkVersion can be used to set both Microsoft.NETCore.App and AspnetCore.App/All. It is expected that these package versions will always align. -->
+  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(RuntimeFrameworkVersion)' != ''">
+    <AspNetCoreAllRuntimeFrameworkVersion Condition=" '$(AspNetCoreAllRuntimeFrameworkVersion)' == '' ">$(RuntimeFrameworkVersion)</AspNetCoreAllRuntimeFrameworkVersion>
+    <AspNetCoreAppRuntimeFrameworkVersion Condition=" '$(AspNetCoreAppRuntimeFrameworkVersion)' == '' ">$(RuntimeFrameworkVersion)</AspNetCoreAppRuntimeFrameworkVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(RuntimeFrameworkVersion)' == ''">
@@ -144,7 +150,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <!-- This property is different than MicrosoftNETPlatformLibrary.  MicrosoftNETPlatformLibrary is
          used to trim the dependencies published with a framework-dependent app, and is overridden
          by ASP.NET packages.
-         
+
          ExpectedPlatformPackages is the list of packages that are actually implicitly
          referenced by the SDK, and is passed into the ResolvePackageAssets task
          to verify that the restored versions of the packages matches the expected versions
@@ -155,7 +161,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(DisableImplicitFrameworkReferences)' != 'true'">
     <VerifyMatchingImplicitPackageVersion Condition="'$(VerifyMatchingImplicitPackageVersion)' == ''">true</VerifyMatchingImplicitPackageVersion>
   </PropertyGroup>
-  
+
   <!--
     Automatically add Link metadata to items of specific types if they are outside of the project folder and don't already have the Link metadata set.
     This will cause them to be shown in the Solution Explorer.  If an item has LinkBase metadata, the automatic Link will start with that value, and
@@ -164,12 +170,12 @@ Copyright (c) .NET Foundation. All rights reserved.
   <ItemGroup Condition="'$(SetLinkMetadataAutomatically)' != 'false'">
     <Compile Update="@(Compile)">
       <!-- First, add a trailing slash to the LinkBase metadata if necessary.  This allows us to use the same value
-           for the Link metadata whether or not LinkBase metadata is set: %(LinkBase)%(RecursiveDir)%(Filename)%(Extension) 
-           
+           for the Link metadata whether or not LinkBase metadata is set: %(LinkBase)%(RecursiveDir)%(Filename)%(Extension)
+
            Note that RecursiveDir already includes the trailing slash.
       -->
       <LinkBase Condition="'%(LinkBase)' != ''">$([MSBuild]::EnsureTrailingSlash(%(LinkBase)))</LinkBase>
-    
+
       <!-- Set the Link metadata if it's not already set, if the item wasn't defined in a shared project,  and the item is outside of the project directory.
            Check whether the item was defined in a shared project by checking whether the extension of the defining project was .projitems.
            Check whether an item is inside the project directory by seeing if the FullPath starts with EnsureTrailingSlash(MSBuildProjectDirectory)
@@ -178,7 +184,7 @@ Copyright (c) .NET Foundation. All rights reserved.
            not possible to call a string method on a metadata item directly.  The intrinsic ValueOrDefault() will be more
            performant than calling String.Copy(), which has been used for this in other contexts, but actually makes a copy
            of the string data.
-      -->    
+      -->
       <Link Condition="'%(Link)' == '' And '%(DefiningProjectExtension)' != '.projitems' And !$([MSBuild]::ValueOrDefault('%(FullPath)', '').StartsWith($([MSBuild]::EnsureTrailingSlash($(MSBuildProjectDirectory)))))">%(LinkBase)%(RecursiveDir)%(Filename)%(Extension)</Link>
     </Compile>
 
@@ -186,7 +192,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       <LinkBase Condition="'%(LinkBase)' != ''">$([MSBuild]::EnsureTrailingSlash(%(LinkBase)))</LinkBase>
       <Link Condition="'%(Link)' == '' And '%(DefiningProjectExtension)' != '.projitems' And !$([MSBuild]::ValueOrDefault('%(FullPath)', '').StartsWith($([MSBuild]::EnsureTrailingSlash($(MSBuildProjectDirectory)))))">%(LinkBase)%(RecursiveDir)%(Filename)%(Extension)</Link>
     </AdditionalFiles>
-    
+
     <None Update="@(None)">
       <LinkBase Condition="'%(LinkBase)' != ''">$([MSBuild]::EnsureTrailingSlash(%(LinkBase)))</LinkBase>
       <Link Condition="'%(Link)' == '' And '%(DefiningProjectExtension)' != '.projitems' And !$([MSBuild]::ValueOrDefault('%(FullPath)', '').StartsWith($([MSBuild]::EnsureTrailingSlash($(MSBuildProjectDirectory)))))">%(LinkBase)%(RecursiveDir)%(Filename)%(Extension)</Link>
@@ -213,6 +219,9 @@ Copyright (c) .NET Foundation. All rights reserved.
     The TargetLatestAspNetCoreRuntimePatch property can be set to true or false to explicitly opt in or out of the logic
     to roll forward to the latest patch, regardless of whether the app is self-contained or framework-dependent. The
     default value of this property is TargetLatestRuntimePatch set by the dotnet SDK.
+
+    The RuntimeFrameworkVersion property can be used to set an explicit minimum version of Microsoft.NETCore.App
+    and Microsoft.AspNetCore.App/All.
 
     The AspNetCoreAppRuntimeFrameworkVersion and AspNetCoreAllRuntimeFrameworkVersion are where the actual versions of the
     ASPNET Core runtimes to target is stored. They are the versions that are used in the implicit PackageReference to
@@ -310,7 +319,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <Target Name="ResolveImplicitPackageReferenceVersions" BeforeTargets="CollectPackageReferences">
     <ItemGroup>
-      <!-- 
+      <!--
         Backwards compat with 2.1 templates: update version-less ASP.NET metapackage references.
       -->
       <PackageReference Condition=" '%(PackageReference.Identity)' == 'Microsoft.AspNetCore.All' AND '%(PackageReference.Version)' == '' ">
@@ -390,7 +399,7 @@ Copyright (c) .NET Foundation. All rights reserved.
            that had duplicates, instead of leaving the ones without IsImplicitlyDefined set to true. -->
       <PackageReference Remove="@(_PackageReferenceToRemove)" Condition="'%(PackageReference.IsImplicitlyDefined)' == 'true' "/>
     </ItemGroup>
-    
+
     <!-- If any implicit package references were overridden, then don't check that RuntimeFrameworkVersion matches the package version -->
     <PropertyGroup Condition="'@(_PackageReferenceToRemove)' != ''">
       <VerifyMatchingImplicitPackageVersion>false</VerifyMatchingImplicitPackageVersion>
@@ -442,7 +451,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       ContinueOnError="$(CheckForDuplicateItemsContinueOnError)">
       <Output TaskParameter="DeduplicatedItems" ItemName="DeduplicatedEmbeddedResourceItems" />
     </CheckForDuplicateItems>
-    
+
     <!-- Default content items are enabled by the Web SDK, not the .NET SDK, but we check it here for simplicity -->
     <CheckForDuplicateItems
       Items="@(Content)"
@@ -469,6 +478,6 @@ Copyright (c) .NET Foundation. All rights reserved.
       <Content Remove="@(Content)" />
       <Content Include="@(DeduplicatedContentItems)" />
     </ItemGroup>
-    
+
   </Target>
 </Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.targets
@@ -363,7 +363,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <!-- Check for unrecognized FrameworkReference items. -->
   <Target Name="ReportUnresolvedFrameworkReferences"
           DependsOnTargets="ResolveFrameworkReferences"
-          BeforeTargets="_CheckForInvalidConfigurationAndPlatform"
+          BeforeTargets="_CheckForInvalidConfigurationAndPlatform;CollectPackageReferences"
           Condition=" @(_UnresolvedFrameworkReference->Count()) != 0 ">
     <NETSdkError ResourceName="UnknownFrameworkReference" FormatArguments="%(_UnresolvedFrameworkReference.Identity)" />
   </Target>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.targets
@@ -286,22 +286,23 @@ Copyright (c) .NET Foundation. All rights reserved.
         <LatestAspNetCoreAppPatchVersion Condition="'$(LatestAspNetCoreAppPatchVersion)' == ''">$(_TargetFrameworkVersionWithoutV)</LatestAspNetCoreAppPatchVersion>
       </PropertyGroup>
 
-      <!-- Determine the default values of TargetLatestAspNetCoreRuntimePatch -->
-      <PropertyGroup Condition="'$(TargetLatestAspNetCoreRuntimePatch)' == ''">
-        <TargetLatestAspNetCoreRuntimePatch>false</TargetLatestAspNetCoreRuntimePatch>
-        <TargetLatestAspNetCoreRuntimePatch Condition="'$(SelfContained)' == 'true'">true</TargetLatestAspNetCoreRuntimePatch>
-        <TargetLatestAspNetCoreRuntimePatch Condition="'$(TargetLatestRuntimePatch)' != ''">$(TargetLatestRuntimePatch)</TargetLatestAspNetCoreRuntimePatch>
+      <PropertyGroup>
+        <!--
+          Determine determines the default value used for ASP.NET Core, which can be controlled separately from Microsoft.NETCore.App, but should not be in most cases.
+          This property was added in 2.1 to support source-build SDKs where the ASP.NET Core shared framework is not available.
+         -->
+        <TargetLatestAspNetCoreRuntimePatch Condition="'$(TargetLatestAspNetCoreRuntimePatch)' == ''">$(TargetLatestRuntimePatch)</TargetLatestAspNetCoreRuntimePatch>
       </PropertyGroup>
 
       <!-- Set the framework version of .All Framework -->
       <PropertyGroup Condition="'$(AspNetCoreAllRuntimeFrameworkVersion)' == ''">
-        <AspNetCoreAllRuntimeFrameworkVersion>$(DefaultAspNetCoreAllPatchVersion)</AspNetCoreAllRuntimeFrameworkVersion>
+        <AspNetCoreAllRuntimeFrameworkVersion Condition="'$(TargetLatestAspNetCoreRuntimePatch)' != 'true'">$(DefaultAspNetCoreAllPatchVersion)</AspNetCoreAllRuntimeFrameworkVersion>
         <AspNetCoreAllRuntimeFrameworkVersion Condition="'$(TargetLatestAspNetCoreRuntimePatch)' == 'true'">$(LatestAspNetCoreAllPatchVersion)</AspNetCoreAllRuntimeFrameworkVersion>
       </PropertyGroup>
 
       <!-- Set the framework version of .App Framework -->
       <PropertyGroup Condition="'$(AspNetCoreAppRuntimeFrameworkVersion)' == ''">
-        <AspNetCoreAppRuntimeFrameworkVersion >$(DefaultAspNetCoreAppPatchVersion)</AspNetCoreAppRuntimeFrameworkVersion>
+        <AspNetCoreAppRuntimeFrameworkVersion Condition="'$(TargetLatestAspNetCoreRuntimePatch)' != 'true'">$(DefaultAspNetCoreAppPatchVersion)</AspNetCoreAppRuntimeFrameworkVersion>
         <AspNetCoreAppRuntimeFrameworkVersion Condition="'$(TargetLatestAspNetCoreRuntimePatch)' == 'true'">$(LatestAspNetCoreAppPatchVersion)</AspNetCoreAppRuntimeFrameworkVersion>
       </PropertyGroup>
     </When>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.targets
@@ -75,7 +75,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     
     The TargetLatestRuntimePatch property can be set to true or false to explicitly opt in or out of the logic to roll forward
     to the latest patch, regardless of whether the app is self-contained or framework-dependent.
-    
+
     The RuntimeFrameworkVersion is where the actual version of the .NET Core runtime to target is stored.  It is the version that is
     used in the implicit PackageReference to Microsoft.NETCore.App.  The RuntimeFrameworkVersion can also be set explicitly, which
     will disable all the other logic that automatically selects the version of .NET Core to target.
@@ -203,12 +203,179 @@ Copyright (c) .NET Foundation. All rights reserved.
     </EmbeddedResource>
   </ItemGroup>
 
+  <!--
+    Determine the version (including patch) of ASP.NET Core to target.
+    When targeting ASP.NET Core, the TargetFramework is used to specify the major and minor version of the runtime to use.
+    By default, the patch version is inferred. The general logic is that self-contained apps will target the latest patch
+    that the SDK knows about, while framework-dependent apps will target the ".0" patch (and roll forward to the latest
+    patch installed at runtime).
+
+    The TargetLatestAspNetCoreRuntimePatch property can be set to true or false to explicitly opt in or out of the logic
+    to roll forward to the latest patch, regardless of whether the app is self-contained or framework-dependent. The
+    default value of this property is TargetLatestRuntimePatch set by the dotnet SDK.
+
+    The AspNetCoreAppRuntimeFrameworkVersion and AspNetCoreAllRuntimeFrameworkVersion are where the actual versions of the
+    ASPNET Core runtimes to target is stored. They are the versions that are used in the implicit PackageReference to
+    Microsoft.AspNetCore.App and Microsoft.AspNetCore.All. The AspNetCoreAppRuntimeFrameworkVersion and
+    AspNetCoreAllRuntimeFrameworkVersion can also be set explicitly, which will disable all the other logic that
+    automatically selects the version of .NET Core to target.
+
+    The framework version that is written to the runtimeconfig.json file is based on the actual resolved package version
+    of Microsoft.AspNetCore.App or Microsoft.AspNetCore.All. This is to allow floating the version number (i.e. the user
+    could set the version to "2.0-*".
+  -->
+  <Choose>
+    <When Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'" >
+
+      <PropertyGroup>
+        <!--
+          The default version for ASP.NET Core 2.1 is pinned to 2.1.1. The original plan was for it to be "2.1" like Microsoft.NETCore.App is,
+          but this was increased to 2.1.1 due to https://github.com/aspnet/Universe/issues/1180.
+        -->
+        <DefaultPatchVersionForAspNetCoreAll2_1 Condition="'$(DefaultPatchVersionForAspNetCoreAll2_1)' == ''">2.1.1</DefaultPatchVersionForAspNetCoreAll2_1>
+        <DefaultPatchVersionForAspNetCoreApp2_1 Condition="'$(DefaultPatchVersionForAspNetCoreApp2_1)' == ''">2.1.1</DefaultPatchVersionForAspNetCoreApp2_1>
+      </PropertyGroup>
+
+      <!-- Default patch version of .All Framework -->
+      <PropertyGroup Condition="'$(DefaultAspNetCoreAllPatchVersion)' == ''">
+        <DefaultAspNetCoreAllPatchVersion Condition="'$(_TargetFrameworkVersionWithoutV)' == '2.1'">$(DefaultPatchVersionForAspNetCoreAll2_1)</DefaultAspNetCoreAllPatchVersion>
+        <DefaultAspNetCoreAllPatchVersion Condition="'$(_TargetFrameworkVersionWithoutV)' == '2.2'">$(DefaultPatchVersionForAspNetCoreAll2_2)</DefaultAspNetCoreAllPatchVersion>
+
+        <!-- If targeting the same pre-release that is bundled with the .NET Core SDK, use the bundled package version
+            provided by Microsoft.NETCoreSdk.BundledVersions.props -->
+        <DefaultAspNetCoreAllPatchVersion Condition="'$(DefaultAspNetCoreAllPatchVersion)' == '' AND '$(_TargetFrameworkVersionWithoutV)' == '$(BundledAspNetCoreAllTargetFrameworkVersion)'">$(BundledAspNetCoreAllPackageVersion)</DefaultAspNetCoreAllPatchVersion>
+        <!-- If not covered by the previous cases use the target framework version for the default patch version -->
+        <DefaultAspNetCoreAllPatchVersion Condition="'$(DefaultAspNetCoreAllPatchVersion)' == ''">$(_TargetFrameworkVersionWithoutV)</DefaultAspNetCoreAllPatchVersion>
+      </PropertyGroup>
+
+      <!-- Default patch version of .App Framework -->
+      <PropertyGroup Condition="'$(DefaultAspNetCoreAppPatchVersion)' == ''">
+        <DefaultAspNetCoreAppPatchVersion Condition="'$(_TargetFrameworkVersionWithoutV)' == '2.1'">$(DefaultPatchVersionForAspNetCoreApp2_1)</DefaultAspNetCoreAppPatchVersion>
+        <DefaultAspNetCoreAppPatchVersion Condition="'$(_TargetFrameworkVersionWithoutV)' == '2.2'">$(DefaultPatchVersionForAspNetCoreApp2_2)</DefaultAspNetCoreAppPatchVersion>
+
+        <!-- If targeting the same pre-release that is bundled with the .NET Core SDK, use the bundled package version
+            provided by Microsoft.NETCoreSdk.BundledVersions.props -->
+        <DefaultAspNetCoreAppPatchVersion Condition="'$(DefaultAspNetCoreAppPatchVersion)' == '' AND '$(_TargetFrameworkVersionWithoutV)' == '$(BundledAspNetCoreAppTargetFrameworkVersion)'">$(BundledAspNetCoreAppPackageVersion)</DefaultAspNetCoreAppPatchVersion>
+        <!-- If not covered by the previous cases use the target framework version for the default patch version -->
+        <DefaultAspNetCoreAppPatchVersion Condition="'$(DefaultAspNetCoreAppPatchVersion)' == ''">$(_TargetFrameworkVersionWithoutV)</DefaultAspNetCoreAppPatchVersion>
+      </PropertyGroup>
+
+      <!-- Latest patch version of .All Framework -->
+      <PropertyGroup Condition="'$(LatestAspNetCoreAllPatchVersion)' == ''">
+        <!-- If LatestPatchVersionForAspNetCoreAll2_x is explicitly set, use this for netcoreapp2.x projects. -->
+        <LatestAspNetCoreAllPatchVersion Condition="'$(_TargetFrameworkVersionWithoutV)' == '2.1'">$(LatestPatchVersionForAspNetCoreAll2_1)</LatestAspNetCoreAllPatchVersion>
+        <LatestAspNetCoreAllPatchVersion Condition="'$(_TargetFrameworkVersionWithoutV)' == '2.2'">$(LatestPatchVersionForAspNetCoreAll2_2)</LatestAspNetCoreAllPatchVersion>
+
+        <!-- If targeting the same release that is bundled with the .NET Core SDK, use the bundled package version
+            provided by Microsoft.NETCoreSdk.BundledVersions.props -->
+        <LatestAspNetCoreAllPatchVersion Condition="'$(LatestAspNetCoreAllPatchVersion)' == '' AND '$(_TargetFrameworkVersionWithoutV)' == '$(BundledAspNetCoreAllTargetFrameworkVersion)'">$(BundledAspNetCoreAllPackageVersion)</LatestAspNetCoreAllPatchVersion>
+        <!-- If not covered by the previous cases use the target framework version for the latest patch version -->
+        <LatestAspNetCoreAllPatchVersion Condition="'$(LatestAspNetCoreAllPatchVersion)' == ''">$(_TargetFrameworkVersionWithoutV)</LatestAspNetCoreAllPatchVersion>
+      </PropertyGroup>
+
+      <!-- Latest patch version of .App Framework -->
+      <PropertyGroup Condition="'$(LatestAspNetCoreAppPatchVersion)' == ''">
+        <!-- If LatestPatchVersionForAspNetCoreApp2_x is explicitly set, use this for netcoreapp2.x projects. -->
+        <LatestAspNetCoreAppPatchVersion Condition="'$(_TargetFrameworkVersionWithoutV)' == '2.1'">$(LatestPatchVersionForAspNetCoreApp2_1)</LatestAspNetCoreAppPatchVersion>
+        <LatestAspNetCoreAppPatchVersion Condition="'$(_TargetFrameworkVersionWithoutV)' == '2.2'">$(LatestPatchVersionForAspNetCoreApp2_2)</LatestAspNetCoreAppPatchVersion>
+
+        <!-- If targeting the same release that is bundled with the .NET Core SDK, use the bundled package version
+            provided by Microsoft.NETCoreSdk.BundledVersions.props -->
+        <LatestAspNetCoreAppPatchVersion Condition="'$(LatestAspNetCoreAppPatchVersion)' == '' AND '$(_TargetFrameworkVersionWithoutV)' == '$(BundledAspNetCoreAppTargetFrameworkVersion)'">$(BundledAspNetCoreAppPackageVersion)</LatestAspNetCoreAppPatchVersion>
+        <!-- If not covered by the previous cases use the target framework version for the latest patch version -->
+        <LatestAspNetCoreAppPatchVersion Condition="'$(LatestAspNetCoreAppPatchVersion)' == ''">$(_TargetFrameworkVersionWithoutV)</LatestAspNetCoreAppPatchVersion>
+      </PropertyGroup>
+
+      <!-- Determine the default values of TargetLatestAspNetCoreRuntimePatch -->
+      <PropertyGroup Condition="'$(TargetLatestAspNetCoreRuntimePatch)' == ''">
+        <TargetLatestAspNetCoreRuntimePatch>false</TargetLatestAspNetCoreRuntimePatch>
+        <TargetLatestAspNetCoreRuntimePatch Condition="'$(SelfContained)' == 'true'">true</TargetLatestAspNetCoreRuntimePatch>
+        <TargetLatestAspNetCoreRuntimePatch Condition="'$(TargetLatestRuntimePatch)' != ''">$(TargetLatestRuntimePatch)</TargetLatestAspNetCoreRuntimePatch>
+      </PropertyGroup>
+
+      <!-- Set the framework version of .All Framework -->
+      <PropertyGroup Condition="'$(AspNetCoreAllRuntimeFrameworkVersion)' == ''">
+        <AspNetCoreAllRuntimeFrameworkVersion>$(DefaultAspNetCoreAllPatchVersion)</AspNetCoreAllRuntimeFrameworkVersion>
+        <AspNetCoreAllRuntimeFrameworkVersion Condition="'$(TargetLatestAspNetCoreRuntimePatch)' == 'true'">$(LatestAspNetCoreAllPatchVersion)</AspNetCoreAllRuntimeFrameworkVersion>
+      </PropertyGroup>
+
+      <!-- Set the framework version of .App Framework -->
+      <PropertyGroup Condition="'$(AspNetCoreAppRuntimeFrameworkVersion)' == ''">
+        <AspNetCoreAppRuntimeFrameworkVersion >$(DefaultAspNetCoreAppPatchVersion)</AspNetCoreAppRuntimeFrameworkVersion>
+        <AspNetCoreAppRuntimeFrameworkVersion Condition="'$(TargetLatestAspNetCoreRuntimePatch)' == 'true'">$(LatestAspNetCoreAppPatchVersion)</AspNetCoreAppRuntimeFrameworkVersion>
+      </PropertyGroup>
+    </When>
+  </Choose>
+
+  <Target Name="ResolveImplicitPackageReferenceVersions" BeforeTargets="CollectPackageReferences">
+    <ItemGroup>
+      <!-- 
+        Backwards compat with 2.1 templates: update version-less ASP.NET metapackage references.
+      -->
+      <PackageReference Condition=" '%(PackageReference.Identity)' == 'Microsoft.AspNetCore.All' AND '%(PackageReference.Version)' == '' ">
+        <Version>$(AspNetCoreAllRuntimeFrameworkVersion)</Version>
+        <IsImplicitlyDefined>true</IsImplicitlyDefined>
+        <PrivateAssets>All</PrivateAssets>
+        <Publish>true</Publish>
+      </PackageReference>
+
+      <PackageReference Condition=" '%(PackageReference.Identity)' == 'Microsoft.AspNetCore.App' AND '%(PackageReference.Version)' == '' ">
+        <Version>$(AspNetCoreAppRuntimeFrameworkVersion)</Version>
+        <IsImplicitlyDefined>true</IsImplicitlyDefined>
+        <PrivateAssets>All</PrivateAssets>
+        <Publish>true</Publish>
+      </PackageReference>
+    </ItemGroup>
+  </Target>
+
+  <Target Name="ResolveFrameworkReferences"
+          BeforeTargets="_CheckForInvalidConfigurationAndPlatform;CollectPackageReferences"
+          DependsOnTargets="ResolveImplicitPackageReferenceVersions">
+
+    <!-- FrameworkReference items are only supported in .NET Core 2.1 and 2.2 for ASP.NET Core packages only. -->
+    <ItemGroup Condition="'$(_TargetFrameworkVersionWithoutV)' != '' AND '$(_TargetFrameworkVersionWithoutV)' >= '2.1' AND '$(_TargetFrameworkVersionWithoutV)' &lt; '3.0' ">
+      <!-- Transform FrameworkReference to PackageReference for known items -->
+      <PackageReference Include="%(FrameworkReference.Identity)" Condition=" '%(FrameworkReference.Identity)' == 'Microsoft.AspNetCore.App' OR '%(FrameworkReference.Identity)' == 'Microsoft.AspNetCore.All' ">
+        <Version Condition=" '%(FrameworkReference.Identity)' == 'Microsoft.AspNetCore.App' ">$(AspNetCoreAllRuntimeFrameworkVersion)</Version>
+        <Version Condition=" '%(FrameworkReference.Identity)' == 'Microsoft.AspNetCore.All' ">$(AspNetCoreAppRuntimeFrameworkVersion)</Version>
+        <IsImplicitlyDefined>true</IsImplicitlyDefined>
+        <PrivateAssets>All</PrivateAssets>
+        <Publish>true</Publish>
+        <!-- For internal use: used to keep track of package references that are added implicitly from FrameworkReference. -->
+        <_IsFrameworkReference>true</_IsFrameworkReference>
+      </PackageReference>
+
+      <FrameworkReference Remove="Microsoft.AspNetCore.App" />
+      <FrameworkReference Remove="Microsoft.AspNetCore.All" />
+      <_UnresolvedFrameworkReference Include="@(FrameworkReference)" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <!-- Update list of implicit platform packages which require version verification -->
+      <ExpectedPlatformPackages
+        Include="%(PackageReference.Identity)"
+        ExpectedVersion="%(PackageReference.Version)"
+        Condition="'%(PackageReference.Identity)' == 'Microsoft.AspNetCore.App' OR '%(PackageReference.Identity)' == 'Microsoft.AspNetCore.All' "/>
+    </ItemGroup>
+  </Target>
+
+  <!-- Check for unrecognized FrameworkReference items. -->
+  <Target Name="ReportUnresolvedFrameworkReferences"
+          DependsOnTargets="ResolveFrameworkReferences"
+          BeforeTargets="_CheckForInvalidConfigurationAndPlatform"
+          Condition=" @(_UnresolvedFrameworkReference->Count()) != 0 ">
+    <NETSdkError ResourceName="UnknownFrameworkReference" FormatArguments="%(_UnresolvedFrameworkReference.Identity)" />
+  </Target>
+
   <UsingTask TaskName="CheckForImplicitPackageReferenceOverrides" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
 
   <!-- Remove package references with metadata IsImplicitlyDefined = true, if there are other PackageReference items with the same identity -->
-  <Target Name="CheckForImplicitPackageReferenceOverrides" BeforeTargets="_CheckForInvalidConfigurationAndPlatform;CollectPackageReferences">
+  <Target Name="CheckForImplicitPackageReferenceOverrides"
+          BeforeTargets="_CheckForInvalidConfigurationAndPlatform;CollectPackageReferences"
+          DependsOnTargets="ResolveImplicitPackageReferenceVersions">
     <PropertyGroup>
       <ImplicitPackageReferenceInformationLink>https://aka.ms/sdkimplicitrefs</ImplicitPackageReferenceInformationLink>
+      <FrameworkReferencesInformationLink>https://aka.ms/dotnet/framework-references</FrameworkReferencesInformationLink>
     </PropertyGroup>
 
     <CheckForImplicitPackageReferenceOverrides
@@ -228,6 +395,14 @@ Copyright (c) .NET Foundation. All rights reserved.
       <VerifyMatchingImplicitPackageVersion>false</VerifyMatchingImplicitPackageVersion>
     </PropertyGroup>
 
+    <ItemGroup Condition="'$(_TargetFrameworkVersionWithoutV)' != '' AND '$(_TargetFrameworkVersionWithoutV)' >= '2.1' ">
+      <_AspNetMetaPackageReference Include="@(PackageReference->WithMetadataValue('Identity', 'Microsoft.AspNetCore.App'))" />
+      <_AspNetMetaPackageReference Include="@(PackageReference->WithMetadataValue('Identity', 'Microsoft.AspNetCore.All'))" />
+    </ItemGroup>
+
+    <NETSdkWarning Condition=" '$(DisableAspNetCoreMetaPackageWarning)' != 'true' AND '%(_AspNetMetaPackageReference.Identity)' != '' AND '%(_AspNetMetaPackageReference._IsFrameworkReference)' != 'true' "
+          ResourceName="RecommendFrameworkReferenceForAspNetCorePackages"
+          FormatArguments="%(_AspNetMetaPackageReference.Identity);$(FrameworkReferencesInformationLink)" />
   </Target>
 
   <UsingTask TaskName="CheckForDuplicateItems" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.props
@@ -111,7 +111,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <!-- Path to project that the .NET CLI will build in order to generate deps.json files for .NET CLI tools -->
     <ToolDepsJsonGeneratorProject>$(MSBuildThisFileDirectory)GenerateDeps\GenerateDeps.proj</ToolDepsJsonGeneratorProject>
   </PropertyGroup>
-  
+
   <!-- Default item includes (globs and implicit references) -->
   <Import Project="Microsoft.NET.Sdk.DefaultItems.props" />
   

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToUseFrameworkReferenceIn2x.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToUseFrameworkReferenceIn2x.cs
@@ -47,24 +47,28 @@ public class Program
         }
 
         [Theory]
-        //  TargetFramework, FrameworkReference, ExpectedPackageVersion
-        [InlineData("netcoreapp2.1", "Microsoft.AspNetCore.App", "2.1.1")]
-        [InlineData("netcoreapp2.1", "Microsoft.AspNetCore.All", "2.1.1")]
+        //  TargetFramework, FrameworkReference, RuntimeFrameworkVersion, ExpectedPackageVersion
+        [InlineData("netcoreapp2.1", "Microsoft.AspNetCore.App", null, "2.1.1")]
+        [InlineData("netcoreapp2.1", "Microsoft.AspNetCore.All", null, "2.1.1")]
+        [InlineData("netcoreapp2.1", "Microsoft.AspNetCore.App", "2.1.3", "2.1.3")]
 
         // TODO enable when 2.2 is released
-        // [InlineData("netcoreapp2.2", "Microsoft.AspNetCore.App", "2.2.0")]
-        // [InlineData("netcoreapp2.2", "Microsoft.AspNetCore.All", "2.2.0")]
+        // [InlineData("netcoreapp2.2", "Microsoft.AspNetCore.App", null, "2.2.0")]
+        // [InlineData("netcoreapp2.2", "Microsoft.AspNetCore.All", null, "2.2.0")]
         public void It_targets_a_known_runtime_framework_name(
             string targetFramework,
             string frameworkReferenceName,
+            string runtimeFrameworkVersion,
             string expectedPackageVersion)
         {
             var testProject = new TestProject
             {
-                Name = $"FrameworkRef.{targetFramework}.{frameworkReferenceName}",
+                // Keep the test project name short to avoid MAX_PATH issues with MSBuild
+                Name = $"FrameworkRef.{targetFramework.Substring(targetFramework.Length - 3)}.{frameworkReferenceName.Substring(frameworkReferenceName.Length - 3)}",
                 TargetFrameworks = targetFramework,
                 IsSdkProject = true,
                 IsExe = true,
+                RuntimeFrameworkVersion = runtimeFrameworkVersion,
                 FrameworkReferences =
                 {
                     new TestFrameworkReference(frameworkReferenceName)

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToUseFrameworkReferenceIn2x.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToUseFrameworkReferenceIn2x.cs
@@ -1,0 +1,227 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using FluentAssertions;
+using Microsoft.DotNet.Cli.Utils;
+using Microsoft.Extensions.DependencyModel;
+using Microsoft.NET.TestFramework;
+using Microsoft.NET.TestFramework.Assertions;
+using Microsoft.NET.TestFramework.Commands;
+using Microsoft.NET.TestFramework.ProjectConstruction;
+using Newtonsoft.Json.Linq;
+using NuGet.Common;
+using NuGet.Frameworks;
+using NuGet.ProjectModel;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Linq;
+using System.Text;
+using System.Xml.Linq;
+using Xunit;
+using Xunit.Abstractions;
+using Microsoft.NET.Build.Tasks;
+using NuGet.Versioning;
+
+namespace Microsoft.NET.Build.Tests
+{
+    public class GivenThatWeWantToUseFrameworkReferenceIn2x : SdkTest
+    {
+        private const string AspNetProgramSource = @"
+using System;
+using Microsoft.AspNetCore;
+using Microsoft.AspNetCore.Hosting;
+
+public class Program
+{
+    public static void Main(string[] args)
+    {
+        WebHost.CreateDefaultBuilder(args).Build().Run();
+    }
+}
+";
+
+        public GivenThatWeWantToUseFrameworkReferenceIn2x(ITestOutputHelper log) : base(log)
+        {
+        }
+
+        [Theory]
+        //  TargetFramework, FrameworkReference, ExpectedPackageVersion
+        [InlineData("netcoreapp2.1", "Microsoft.AspNetCore.App", "2.1.1")]
+        [InlineData("netcoreapp2.1", "Microsoft.AspNetCore.ALl", "2.1.1")]
+        [InlineData("netcoreapp2.2", "Microsoft.AspNetCore.App", "2.2.0")]
+        [InlineData("netcoreapp2.2", "Microsoft.AspNetCore.All", "2.2.0")]
+        public void It_targets_a_known_runtime_framework_name(
+            string targetFramework,
+            string frameworkReferenceName,
+            string expectedPackageVersion)
+        {
+            string testIdentifier = "SharedRuntimeTargeting_" + string.Join("_", targetFramework, frameworkReferenceName);
+
+            var testProject = new TestProject
+            {
+                Name = "FrameworkTargetTest",
+                TargetFrameworks = targetFramework,
+                IsSdkProject = true,
+                IsExe = true,
+                FrameworkReferences =
+                {
+                    new TestFrameworkReference(frameworkReferenceName)
+                }
+            };
+
+            testProject.SourceFiles["Program.cs"] = AspNetProgramSource;
+
+            var testAsset = _testAssetsManager.CreateTestProject(testProject, testIdentifier);
+
+            var restoreCommand = testAsset.GetRestoreCommand(Log, relativePath: testIdentifier);
+            restoreCommand.Execute()
+                .Should().Pass()
+                .And
+                .NotHaveStdOutContaining("warning");
+
+            var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+
+            buildCommand
+                .Execute()
+                .Should()
+                .Pass();
+
+            var outputDirectory = buildCommand.GetOutputDirectory(targetFramework);
+
+            string runtimeConfigFile = Path.Combine(outputDirectory.FullName, testProject.Name + ".runtimeconfig.json");
+            string runtimeConfigContents = File.ReadAllText(runtimeConfigFile);
+            JObject runtimeConfig = JObject.Parse(runtimeConfigContents);
+
+            string actualRuntimeFrameworkName = ((JValue)runtimeConfig["runtimeOptions"]["framework"]["name"]).Value<string>();
+            actualRuntimeFrameworkName.Should().Be(frameworkReferenceName);
+
+            string actualRuntimeFrameworkVersion = ((JValue)runtimeConfig["runtimeOptions"]["framework"]["version"]).Value<string>();
+            actualRuntimeFrameworkVersion.Should().Be(expectedPackageVersion);
+
+            string projectAssetsJsonPath = Path.Combine(buildCommand.ProjectRootPath, "obj", "project.assets.json");
+            LockFile lockFile = LockFileUtilities.GetLockFile(projectAssetsJsonPath, NullLogger.Instance);
+
+            var target = lockFile.GetTarget(NuGetFramework.Parse(targetFramework), null);
+            var packageLibrary = target.Libraries.Single(l => l.Name == frameworkReferenceName);
+            packageLibrary.Version.ToString().Should().Be(expectedPackageVersion);
+
+            target.Libraries.Should().Contain(l => l.Name == "Microsoft.NETCore.App");
+        }
+
+        [Theory]
+        [InlineData("Microsoft.AspNetCore.App")]
+        [InlineData("Microsoft.AspNetCore.All")]
+        public void It_warns_when_explicit_aspnet_package_ref_exists(string packageId)
+        {
+            const string testProjectName = "AspNetCoreWithExplicitRef";
+            var project = new TestProject
+            {
+                Name = testProjectName,
+                TargetFrameworks = "netcoreapp2.1",
+                IsSdkProject = true,
+                PackageReferences =
+                {
+                    new TestPackageReference(packageId, "2.1.0")
+                }
+            };
+
+            var testAsset = _testAssetsManager
+                .CreateTestProject(project)
+                .Restore(Log, project.Name);
+
+            string projectAssetsJsonPath = Path.Combine(
+                testAsset.Path,
+                project.Name,
+                "obj",
+                "project.assets.json");
+
+            var restoreCommand =
+                testAsset.GetRestoreCommand(Log, relativePath: testProjectName);
+            restoreCommand.Execute()
+                .Should().Pass()
+                .And
+                .HaveStdOutContaining("warning NETSDK1071:")
+                .And
+                .HaveStdOutContaining(testProjectName + ".csproj");
+
+            LockFile lockFile = LockFileUtilities.GetLockFile(
+                projectAssetsJsonPath,
+                NullLogger.Instance);
+
+            var target =
+                lockFile.GetTarget(NuGetFramework.Parse(".NETCoreApp,Version=v2.1"), null);
+            var metapackageLibrary =
+                target.Libraries.Single(l => l.Name == packageId);
+            metapackageLibrary.Version.ToString().Should().Be("2.1.0");
+        }
+
+        [Fact]
+        public void It_fails_when_unknown_framework_reference_is_used()
+        {
+            TestProject project = new TestProject()
+            {
+                Name = "UnknownFrameworkRefence",
+                TargetFrameworks = "netcoreapp2.1",
+                IsSdkProject = true,
+                FrameworkReferences =
+                {
+                    new TestFrameworkReference("Banana.App")
+                }
+            };
+
+            var testAsset = _testAssetsManager.CreateTestProject(project);
+            var restoreCommand = testAsset.GetRestoreCommand(Log, project.Name);
+
+            restoreCommand.Execute()
+                .Should()
+                .Fail()
+                .And
+                .HaveStdOutContaining("error NETSDK1072:");
+        }
+
+        [Fact]
+        public void It_generates_deps_file_for_aspnet_app()
+        {
+            TestProject project = new TestProject()
+            {
+                Name = "AspNetCore21App",
+                TargetFrameworks = "netcoreapp2.1",
+                IsExe = true,
+                IsSdkProject = true,
+                FrameworkReferences =
+                {
+                    new TestFrameworkReference("Microsoft.AspNetCore.App")
+                }
+            };
+
+            project.SourceFiles["Program.cs"] = AspNetProgramSource;
+
+            var testAsset = _testAssetsManager.CreateTestProject(project)
+                .Restore(Log, project.Name);
+
+            string projectFolder = Path.Combine(testAsset.Path, project.Name);
+
+            var buildCommand = new BuildCommand(Log, projectFolder);
+
+            buildCommand
+                .Execute()
+                .Should()
+                .Pass();
+
+            string outputFolder = buildCommand.GetOutputDirectory(project.TargetFrameworks).FullName;
+
+            using (var depsJsonFileStream = File.OpenRead(Path.Combine(outputFolder, $"{project.Name}.deps.json")))
+            {
+                var dependencyContext = new DependencyContextJsonReader().Read(depsJsonFileStream);
+                dependencyContext.Should()
+                    .OnlyHaveRuntimeAssemblies("", project.Name)
+                    .And
+                    .HaveNoDuplicateRuntimeAssemblies("")
+                    .And
+                    .HaveNoDuplicateNativeAssets(""); ;
+            }
+        }
+    }
+}

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToUseFrameworkReferenceIn2x.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToUseFrameworkReferenceIn2x.cs
@@ -49,7 +49,7 @@ public class Program
         [Theory]
         //  TargetFramework, FrameworkReference, ExpectedPackageVersion
         [InlineData("netcoreapp2.1", "Microsoft.AspNetCore.App", "2.1.1")]
-        [InlineData("netcoreapp2.1", "Microsoft.AspNetCore.ALl", "2.1.1")]
+        [InlineData("netcoreapp2.1", "Microsoft.AspNetCore.All", "2.1.1")]
 
         // TODO enable when 2.2 is released
         // [InlineData("netcoreapp2.2", "Microsoft.AspNetCore.App", "2.2.0")]
@@ -160,7 +160,7 @@ public class Program
         {
             var testProject = new TestProject()
             {
-                Name = "UnknownFrameworkRefence",
+                Name = "UnknownFrameworkReference",
                 TargetFrameworks = "netcoreapp2.1",
                 IsSdkProject = true,
                 FrameworkReferences =
@@ -169,10 +169,10 @@ public class Program
                 }
             };
 
-            var testAsset = _testAssetsManager.CreateTestProject(testProject);
-            var restoreCommand = testAsset.GetRestoreCommand(Log, testProject.Name);
-
-            restoreCommand.Execute()
+            _testAssetsManager
+                .CreateTestProject(testProject)
+                .GetRestoreCommand(Log, testProject.Name)
+                .Execute()
                 .Should()
                 .Fail()
                 .And

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToUseImplicitPackageRefVersions.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToUseImplicitPackageRefVersions.cs
@@ -74,9 +74,7 @@ public class Program
 
             var restoreCommand = testAsset.GetRestoreCommand(Log, testProject.Name);
             restoreCommand.Execute()
-                .Should().Pass()
-                .And
-                .NotHaveStdOutContaining("warning");
+                .Should().Pass();
 
 
             var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToUseImplicitPackageRefVersions.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToUseImplicitPackageRefVersions.cs
@@ -1,0 +1,99 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using FluentAssertions;
+using Microsoft.DotNet.Cli.Utils;
+using Microsoft.Extensions.DependencyModel;
+using Microsoft.NET.TestFramework;
+using Microsoft.NET.TestFramework.Assertions;
+using Microsoft.NET.TestFramework.Commands;
+using Microsoft.NET.TestFramework.ProjectConstruction;
+using Newtonsoft.Json.Linq;
+using NuGet.Common;
+using NuGet.Frameworks;
+using NuGet.ProjectModel;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Linq;
+using System.Text;
+using System.Xml.Linq;
+using Xunit;
+using Xunit.Abstractions;
+using Microsoft.NET.Build.Tasks;
+using NuGet.Versioning;
+
+namespace Microsoft.NET.Build.Tests
+{
+    // Tests for backwards compatibility with ASP.NET Core 2.1 templates
+    public class GivenThatWeWantToUseImplicitPackageRefVersions : SdkTest
+    {
+        private const string AspNetProgramSource = @"
+using System;
+using Microsoft.AspNetCore;
+using Microsoft.AspNetCore.Hosting;
+
+public class Program
+{
+    public static void Main(string[] args)
+    {
+        WebHost.CreateDefaultBuilder(args).Build().Run();
+    }
+}
+";
+
+        public GivenThatWeWantToUseImplicitPackageRefVersions(ITestOutputHelper log) : base(log)
+        {
+        }
+
+        [Theory]
+        //  TargetFramework, FrameworkReference, ExpectedPackageVersion
+        [InlineData("Microsoft.AspNetCore.App", "2.1.1")]
+        [InlineData("Microsoft.AspNetCore.All", "2.1.1")]
+        public void It_sets_an_implicit_package_ref_version(
+            string packageId,
+            string expectedPackageVersion)
+        {
+            const string targetFramework = "netcoreapp2.1";
+            string testIdentifier = $"ImplicitPackageRefVersion_{packageId}";
+
+            var testProject = new TestProject
+            {
+                Name = "FrameworkTargetTest",
+                TargetFrameworks = targetFramework,
+                IsSdkProject = true,
+                IsExe = true,
+                PackageReferences =
+                {
+                    new TestPackageReference(packageId, null)
+                }
+            };
+
+            testProject.SourceFiles["Program.cs"] = AspNetProgramSource;
+
+            var testAsset = _testAssetsManager.CreateTestProject(testProject, testIdentifier);
+
+            var restoreCommand = testAsset.GetRestoreCommand(Log, relativePath: testIdentifier);
+            restoreCommand.Execute()
+                .Should().Pass()
+                .And
+                .NotHaveStdOutContaining("warning");
+
+
+            var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+
+            buildCommand
+                .Execute()
+                .Should()
+                .Pass();
+
+            string projectAssetsJsonPath = Path.Combine(buildCommand.ProjectRootPath, "obj", "project.assets.json");
+            LockFile lockFile = LockFileUtilities.GetLockFile(projectAssetsJsonPath, NullLogger.Instance);
+
+            var target = lockFile.GetTarget(NuGetFramework.Parse(targetFramework), null);
+            var packageLibrary = target.Libraries.Single(l => l.Name == packageId);
+            packageLibrary.Version.ToString().Should().Be(expectedPackageVersion);
+        }
+    }
+}

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToUseImplicitPackageRefVersions.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToUseImplicitPackageRefVersions.cs
@@ -58,7 +58,8 @@ public class Program
         {
             var testProject = new TestProject
             {
-                Name = $"ImplicitPackageRefVersion.{targetFramework}.{packageId}",
+                // Keep the test project name short to avoid MAX_PATH issues with MSBuild
+                Name = $"ImplicitPkgRefVersion.{targetFramework.Substring(targetFramework.Length - 3)}.{packageId.Substring(packageId.Length - 3)}",
                 TargetFrameworks = targetFramework,
                 IsSdkProject = true,
                 IsExe = true,

--- a/src/Tests/Microsoft.NET.PerformanceTests/Microsoft.NET.PerformanceTests.csproj
+++ b/src/Tests/Microsoft.NET.PerformanceTests/Microsoft.NET.PerformanceTests.csproj
@@ -47,7 +47,7 @@
       <PerformanceTestsLocalDirectory>$(RepoRoot).perftestsource</PerformanceTestsLocalDirectory>
     </PropertyGroup>
 
-    <Exec Condition="!Exists($(PerformanceTestsLocalDirectory))"
+  <Exec Condition="!Exists($(PerformanceTestsLocalDirectory))"
           WorkingDirectory="$(RepoRoot)" Command="git clone --quiet $(PerformanceTestsRepoURL) $(PerformanceTestsLocalDirectory)" />
     <Exec WorkingDirectory="$(PerformanceTestsLocalDirectory)" Command="git checkout --quiet $(PerformanceTestsCommit)" />
   </Target>

--- a/src/Tests/Microsoft.NET.TestFramework/ProjectConstruction/TestProject.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/ProjectConstruction/TestProject.cs
@@ -35,6 +35,8 @@ namespace Microsoft.NET.TestFramework.ProjectConstruction
 
         public List<TestPackageReference> PackageReferences { get; } = new List<TestPackageReference>();
 
+        public List<TestFrameworkReference> FrameworkReferences { get; } = new List<TestFrameworkReference>();
+
         public List<TestPackageReference> DotNetCliToolReferences { get; } = new List<TestPackageReference>();
 
         public Dictionary<string, string> SourceFiles { get; } = new Dictionary<string, string>();
@@ -148,6 +150,12 @@ namespace Microsoft.NET.TestFramework.ProjectConstruction
                 packageReferenceItemGroup.Add(new XElement(ns + "PackageReference",
                     new XAttribute("Include", $"{packageReference.ID}"),
                     new XAttribute("Version", $"{packageReference.Version}")));
+            }
+
+            foreach (TestFrameworkReference frameworkReference in FrameworkReferences)
+            {
+                packageReferenceItemGroup.Add(new XElement(ns + "FrameworkReference",
+                    new XAttribute("Include", frameworkReference.Name)));
             }
 
             foreach (TestPackageReference dotnetCliToolReference in DotNetCliToolReferences)

--- a/src/Tests/Microsoft.NET.TestFramework/TestFrameworkReference.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/TestFrameworkReference.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.NET.TestFramework
+{
+    public class TestFrameworkReference
+    {
+        public TestFrameworkReference(string name)
+        {
+            Name = name;
+        }
+
+        public string Name { get; private set; }
+    }
+}


### PR DESCRIPTION
For your consideration. We need to get more agreement from the PMs first, but wanted to get @dsplaisted to take a look since he made similar changes in the master branch.

Changes:
* Move support for the version-less PackageReference from Microsoft.NET.Sdk.Web into the base SDK
* Add support for specifying Microsoft.AspNetCore.App/All as `<FrameworkReference>` items in 2.1 and 2.2 
* Issue a warning when a `<PackageReference>` to "Microsoft.AspNetCore.App" exists.
![image](https://user-images.githubusercontent.com/2696087/44808178-6bf23880-ab80-11e8-95bb-a9a0291ff61c.png)
* Make it an error to use unrecognized FrameworkReference items

![image](https://user-images.githubusercontent.com/2696087/44809712-5d0d8500-ab84-11e8-8889-1af3a5e61350.png)
* Add support for using RuntimeFrameworkVersion to control both NETCore.App and AspNetCore.App/All implicit packages. It is expected that these package versions should always align.

Sample usage:
```xml
<Project Sdk="Microsoft.NET.Sdk">

  <PropertyGroup>
    <TargetFramework>netcoreapp2.1</TargetFramework>
    <!-- Optional -->
    <RuntimeFrameworkVersion>2.1.3</RuntimeFrameworkVersion>
  </PropertyGroup>

  <ItemGroup>
    <FrameworkReference Include="Microsoft.AspNetCore.App" />
  </ItemGroup>

</Project>
```

TODO:
* Get agreement from @DamianEdwards who is OOF till next week.
* Make FrameworkReference transitive accross ProjRef's, maybe?