### PR TITLE
Allow compileTimeTarget.Libraries.Count == _runtimeTarget.Libraries.Count

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageAssets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageAssets.cs
@@ -818,7 +818,7 @@ namespace Microsoft.NET.Build.Tasks
             {
                 if (_task.EnsureRuntimePackageDependencies && !string.IsNullOrEmpty(_task.RuntimeIdentifier))
                 {
-                    if (_compileTimeTarget.Libraries.Count >= _runtimeTarget.Libraries.Count)
+                    if (_compileTimeTarget.Libraries.Count > _runtimeTarget.Libraries.Count)
                     {
                         WriteItem(string.Format(Strings.UnsupportedRuntimeIdentifier, _task.RuntimeIdentifier));
                         WriteMetadata(MetadataKeys.Severity, nameof(LogLevel.Error));


### PR DESCRIPTION
I am creating this pull request as an attempt to fix issue #2503.

I am not sure what is the underlying rationale to requires 

   compileTimeTarget.Libraries.Count **strictly ** less than _runtimeTarget.Libraries.Count

So I relaxed the condition to allow equals as well.