### PR TITLE
Add support in .NET SDK for implicit versions of AspNetCore.App and .All

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "2.2.100-preview1-009263"
+    "version": "2.2.100-preview2-009404"
   },
   "msbuild-sdks": {
     "RoslynTools.RepoToolset": "1.0.0-beta2-62912-01"

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "2.2.100-preview2-009404"
+    "version": "2.2.100-preview3-009413"
   },
   "msbuild-sdks": {
     "RoslynTools.RepoToolset": "1.0.0-beta2-62912-01"

--- a/src/Tasks/Common/MetadataKeys.cs
+++ b/src/Tasks/Common/MetadataKeys.cs
@@ -16,6 +16,7 @@ namespace Microsoft.NET.Build.Tasks
         public const string PackageVersion = "PackageVersion";
         public const string IsImplicitlyDefined = "IsImplicitlyDefined";
         public const string IsTopLevelDependency = "IsTopLevelDependency";
+        public const string AllowExplicitVersion = "AllowExplicitVersion";
 
         // Target Metadata
         public const string RuntimeIdentifier = "RuntimeIdentifier";
@@ -81,8 +82,5 @@ namespace Microsoft.NET.Build.Tasks
         // Resource assemblies
         public const string Culture = "Culture";
         public const string DestinationSubDirectory = "DestinationSubDirectory";
-
-        // Expected platform packages
-        public const string ExpectedVersion = "ExpectedVersion";
     }
 }

--- a/src/Tasks/Common/Resources/Strings.resx
+++ b/src/Tasks/Common/Resources/Strings.resx
@@ -401,4 +401,7 @@ The following are names of parameters or literal values and should not be transl
     <value>NETSDK1070: The application configuration file must have root configuration element.</value>
     <comment>{StrBegin="NETSDK1070: "}</comment>
   </data>
+  <data name="PackageReferenceVersionNotRecommended" xml:space="preserve">
+    <value>NETSDK1071: A PackageReference to '{0}' specified a Version of `{1}`. Specifying the version of this package is not recommended. For more information, see https://aka.ms/sdkimplicitrefs</value>
+  </data>
 </root>

--- a/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
@@ -67,6 +67,11 @@
         <target state="translated">NETSDK1008: Chybí metadata {0} o {1} položky {2}.</target>
         <note>{StrBegin="NETSDK1008: "}</note>
       </trans-unit>
+      <trans-unit id="PackageReferenceVersionNotRecommended">
+        <source>NETSDK1071: A PackageReference to '{0}' specified a Version of `{1}`. Specifying the version of this package is not recommended. For more information, see https://aka.ms/sdkimplicitrefs</source>
+        <target state="new">NETSDK1071: A PackageReference to '{0}' specified a Version of `{1}`. Specifying the version of this package is not recommended. For more information, see https://aka.ms/sdkimplicitrefs</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnrecognizedPreprocessorToken">
         <source>NETSDK1009: Unrecognized preprocessor token '{0}' in '{1}'.</source>
         <target state="translated">NETSDK1009: Nerozpoznaný token preprocesoru {0} v {1}.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.de.xlf
@@ -67,6 +67,11 @@
         <target state="translated">NETSDK1008: Die Metadaten "{0}" für das Element "{2}" vom Typ "{1}" sind nicht vorhanden.</target>
         <note>{StrBegin="NETSDK1008: "}</note>
       </trans-unit>
+      <trans-unit id="PackageReferenceVersionNotRecommended">
+        <source>NETSDK1071: A PackageReference to '{0}' specified a Version of `{1}`. Specifying the version of this package is not recommended. For more information, see https://aka.ms/sdkimplicitrefs</source>
+        <target state="new">NETSDK1071: A PackageReference to '{0}' specified a Version of `{1}`. Specifying the version of this package is not recommended. For more information, see https://aka.ms/sdkimplicitrefs</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnrecognizedPreprocessorToken">
         <source>NETSDK1009: Unrecognized preprocessor token '{0}' in '{1}'.</source>
         <target state="translated">NETSDK1009: Unbekanntes Präprozessortoken "{0}" in "{1}".</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.es.xlf
@@ -67,6 +67,11 @@
         <target state="translated">NETSDK1008: Faltan los metadatos de "{0}" en el elemento de "{1}" "{2}".</target>
         <note>{StrBegin="NETSDK1008: "}</note>
       </trans-unit>
+      <trans-unit id="PackageReferenceVersionNotRecommended">
+        <source>NETSDK1071: A PackageReference to '{0}' specified a Version of `{1}`. Specifying the version of this package is not recommended. For more information, see https://aka.ms/sdkimplicitrefs</source>
+        <target state="new">NETSDK1071: A PackageReference to '{0}' specified a Version of `{1}`. Specifying the version of this package is not recommended. For more information, see https://aka.ms/sdkimplicitrefs</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnrecognizedPreprocessorToken">
         <source>NETSDK1009: Unrecognized preprocessor token '{0}' in '{1}'.</source>
         <target state="translated">NETSDK1009: Token de preprocesador no reconocido "{0}" en "{1}".</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
@@ -67,6 +67,11 @@
         <target state="translated">NETSDK1008: Métadonnées '{0}' manquantes sur l'élément '{1}' '{2}'.</target>
         <note>{StrBegin="NETSDK1008: "}</note>
       </trans-unit>
+      <trans-unit id="PackageReferenceVersionNotRecommended">
+        <source>NETSDK1071: A PackageReference to '{0}' specified a Version of `{1}`. Specifying the version of this package is not recommended. For more information, see https://aka.ms/sdkimplicitrefs</source>
+        <target state="new">NETSDK1071: A PackageReference to '{0}' specified a Version of `{1}`. Specifying the version of this package is not recommended. For more information, see https://aka.ms/sdkimplicitrefs</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnrecognizedPreprocessorToken">
         <source>NETSDK1009: Unrecognized preprocessor token '{0}' in '{1}'.</source>
         <target state="translated">NETSDK1009: Jeton de préprocesseur '{0}' non reconnu dans '{1}'.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.it.xlf
@@ -67,6 +67,11 @@
         <target state="translated">NETSDK1008: mancano i metadati di '{0}' sull'elemento '{2}' di '{1}'.</target>
         <note>{StrBegin="NETSDK1008: "}</note>
       </trans-unit>
+      <trans-unit id="PackageReferenceVersionNotRecommended">
+        <source>NETSDK1071: A PackageReference to '{0}' specified a Version of `{1}`. Specifying the version of this package is not recommended. For more information, see https://aka.ms/sdkimplicitrefs</source>
+        <target state="new">NETSDK1071: A PackageReference to '{0}' specified a Version of `{1}`. Specifying the version of this package is not recommended. For more information, see https://aka.ms/sdkimplicitrefs</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnrecognizedPreprocessorToken">
         <source>NETSDK1009: Unrecognized preprocessor token '{0}' in '{1}'.</source>
         <target state="translated">NETSDK1009: token di preprocessore '{0}' non riconosciuto in '{1}'.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
@@ -67,6 +67,11 @@
         <target state="translated">NETSDK1008: '{1}' 項目 '{2}' の '{0}' メタデータがありません。</target>
         <note>{StrBegin="NETSDK1008: "}</note>
       </trans-unit>
+      <trans-unit id="PackageReferenceVersionNotRecommended">
+        <source>NETSDK1071: A PackageReference to '{0}' specified a Version of `{1}`. Specifying the version of this package is not recommended. For more information, see https://aka.ms/sdkimplicitrefs</source>
+        <target state="new">NETSDK1071: A PackageReference to '{0}' specified a Version of `{1}`. Specifying the version of this package is not recommended. For more information, see https://aka.ms/sdkimplicitrefs</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnrecognizedPreprocessorToken">
         <source>NETSDK1009: Unrecognized preprocessor token '{0}' in '{1}'.</source>
         <target state="translated">NETSDK1009: 認識されないプリプロセッサ トークン '{0}' が '{1}' に存在します。</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
@@ -67,6 +67,11 @@
         <target state="translated">NETSDK1008: '{1}' 항목 '{2}'에 '{0}' 메타데이터가 없습니다.</target>
         <note>{StrBegin="NETSDK1008: "}</note>
       </trans-unit>
+      <trans-unit id="PackageReferenceVersionNotRecommended">
+        <source>NETSDK1071: A PackageReference to '{0}' specified a Version of `{1}`. Specifying the version of this package is not recommended. For more information, see https://aka.ms/sdkimplicitrefs</source>
+        <target state="new">NETSDK1071: A PackageReference to '{0}' specified a Version of `{1}`. Specifying the version of this package is not recommended. For more information, see https://aka.ms/sdkimplicitrefs</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnrecognizedPreprocessorToken">
         <source>NETSDK1009: Unrecognized preprocessor token '{0}' in '{1}'.</source>
         <target state="translated">NETSDK1009: '{1}'에서 전처리기 토큰 '{0}'을(를) 인식할 수 없습니다.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
@@ -67,6 +67,11 @@
         <target state="translated">NETSDK1008: Brak metadanych „{0}” w elemencie „{1}” „{2}”.</target>
         <note>{StrBegin="NETSDK1008: "}</note>
       </trans-unit>
+      <trans-unit id="PackageReferenceVersionNotRecommended">
+        <source>NETSDK1071: A PackageReference to '{0}' specified a Version of `{1}`. Specifying the version of this package is not recommended. For more information, see https://aka.ms/sdkimplicitrefs</source>
+        <target state="new">NETSDK1071: A PackageReference to '{0}' specified a Version of `{1}`. Specifying the version of this package is not recommended. For more information, see https://aka.ms/sdkimplicitrefs</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnrecognizedPreprocessorToken">
         <source>NETSDK1009: Unrecognized preprocessor token '{0}' in '{1}'.</source>
         <target state="translated">NETSDK1009: Nierozpoznany token preprocesora „{0}” w elemencie „{1}”.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
@@ -67,6 +67,11 @@
         <target state="translated">NETSDK1008: Metadados '{0}' ausentes no item '{1}' '{2}'.</target>
         <note>{StrBegin="NETSDK1008: "}</note>
       </trans-unit>
+      <trans-unit id="PackageReferenceVersionNotRecommended">
+        <source>NETSDK1071: A PackageReference to '{0}' specified a Version of `{1}`. Specifying the version of this package is not recommended. For more information, see https://aka.ms/sdkimplicitrefs</source>
+        <target state="new">NETSDK1071: A PackageReference to '{0}' specified a Version of `{1}`. Specifying the version of this package is not recommended. For more information, see https://aka.ms/sdkimplicitrefs</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnrecognizedPreprocessorToken">
         <source>NETSDK1009: Unrecognized preprocessor token '{0}' in '{1}'.</source>
         <target state="translated">NETSDK1009: Token de pré-processador não reconhecido '{0}' em '{1}'.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
@@ -67,6 +67,11 @@
         <target state="translated">NETSDK1008: отсутствуют метаданные "{0}" для элемента "{2}" в "{1}".</target>
         <note>{StrBegin="NETSDK1008: "}</note>
       </trans-unit>
+      <trans-unit id="PackageReferenceVersionNotRecommended">
+        <source>NETSDK1071: A PackageReference to '{0}' specified a Version of `{1}`. Specifying the version of this package is not recommended. For more information, see https://aka.ms/sdkimplicitrefs</source>
+        <target state="new">NETSDK1071: A PackageReference to '{0}' specified a Version of `{1}`. Specifying the version of this package is not recommended. For more information, see https://aka.ms/sdkimplicitrefs</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnrecognizedPreprocessorToken">
         <source>NETSDK1009: Unrecognized preprocessor token '{0}' in '{1}'.</source>
         <target state="translated">NETSDK1009: не распознан маркер препроцессора "{0}" в "{1}".</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
@@ -67,6 +67,11 @@
         <target state="translated">NETSDK1008: '{1}' öğesi '{2}' üzerinde '{0}' meta verileri eksik.</target>
         <note>{StrBegin="NETSDK1008: "}</note>
       </trans-unit>
+      <trans-unit id="PackageReferenceVersionNotRecommended">
+        <source>NETSDK1071: A PackageReference to '{0}' specified a Version of `{1}`. Specifying the version of this package is not recommended. For more information, see https://aka.ms/sdkimplicitrefs</source>
+        <target state="new">NETSDK1071: A PackageReference to '{0}' specified a Version of `{1}`. Specifying the version of this package is not recommended. For more information, see https://aka.ms/sdkimplicitrefs</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnrecognizedPreprocessorToken">
         <source>NETSDK1009: Unrecognized preprocessor token '{0}' in '{1}'.</source>
         <target state="translated">NETSDK1009: '{1}' içinde tanınmayan '{0}' ön işlemci belirteci.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
@@ -67,6 +67,11 @@
         <target state="translated">NETSDK1008: 在“{1}”项“{2}”上缺少“{0}”元数据。</target>
         <note>{StrBegin="NETSDK1008: "}</note>
       </trans-unit>
+      <trans-unit id="PackageReferenceVersionNotRecommended">
+        <source>NETSDK1071: A PackageReference to '{0}' specified a Version of `{1}`. Specifying the version of this package is not recommended. For more information, see https://aka.ms/sdkimplicitrefs</source>
+        <target state="new">NETSDK1071: A PackageReference to '{0}' specified a Version of `{1}`. Specifying the version of this package is not recommended. For more information, see https://aka.ms/sdkimplicitrefs</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnrecognizedPreprocessorToken">
         <source>NETSDK1009: Unrecognized preprocessor token '{0}' in '{1}'.</source>
         <target state="translated">NETSDK1009:“{1}”中无法识别预处理器标记“{0}”。</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
@@ -67,6 +67,11 @@
         <target state="translated">NETSDK1008: '{1}' 項目 '{2}' 上遺漏 '{0}' 中繼資料。</target>
         <note>{StrBegin="NETSDK1008: "}</note>
       </trans-unit>
+      <trans-unit id="PackageReferenceVersionNotRecommended">
+        <source>NETSDK1071: A PackageReference to '{0}' specified a Version of `{1}`. Specifying the version of this package is not recommended. For more information, see https://aka.ms/sdkimplicitrefs</source>
+        <target state="new">NETSDK1071: A PackageReference to '{0}' specified a Version of `{1}`. Specifying the version of this package is not recommended. For more information, see https://aka.ms/sdkimplicitrefs</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnrecognizedPreprocessorToken">
         <source>NETSDK1009: Unrecognized preprocessor token '{0}' in '{1}'.</source>
         <target state="translated">NETSDK1009: '{1}' 中的前置處理器語彙基元 '{0}' 無法辨識。</target>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ApplyImplicitVersions.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ApplyImplicitVersions.cs
@@ -51,8 +51,6 @@ namespace Microsoft.NET.Build.Tasks
                             TargetLatestRuntimePatch ? implicitVersion.LatestVersion : implicitVersion.DefaultVersion);
 
                         packageReference.SetMetadata(MetadataKeys.IsImplicitlyDefined, "true");
-                        packageReference.SetMetadata("PrivateAssets", "all");
-                        packageReference.SetMetadata("Publish", "true");
 
                         packageReferencesToUpdate.Add(packageReference);
                     }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ApplyImplicitVersions.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ApplyImplicitVersions.cs
@@ -54,7 +54,7 @@ namespace Microsoft.NET.Build.Tasks
 
                         packageReferencesToUpdate.Add(packageReference);
                     }
-                    else
+                    else if (!(packageReference.GetBooleanMetadata(MetadataKeys.AllowExplicitVersion) ?? false))
                     {
                         // NETSDK1071: A PackageReference to '{0}' specified a Version of `{1}`. Specifying the version of this package is not recommended.  For more information, see https://aka.ms/sdkimplicitrefs
                         buildWarnings.Add(string.Format(Strings.PackageReferenceVersionNotRecommended, packageReference.ItemSpec, versionOnPackageReference));

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ApplyImplicitVersions.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ApplyImplicitVersions.cs
@@ -6,9 +6,6 @@ using Microsoft.Build.Framework;
 
 namespace Microsoft.NET.Build.Tasks
 {
-
-    //  TODO: Provide way to opt out of warning when Version is specified (possibly with the DisableImplicitFrameworkReferences property)
-    //  TODO: Add behavior (and test) for duplicate PackageReferences
     public sealed class ApplyImplicitVersions : TaskBase
     {
         public string TargetFrameworkVersion { get; set; }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ApplyImplicitVersions.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ApplyImplicitVersions.cs
@@ -50,6 +50,10 @@ namespace Microsoft.NET.Build.Tasks
                         packageReference.SetMetadata(MetadataKeys.Version, 
                             TargetLatestRuntimePatch ? implicitVersion.LatestVersion : implicitVersion.DefaultVersion);
 
+                        packageReference.SetMetadata(MetadataKeys.IsImplicitlyDefined, "true");
+                        packageReference.SetMetadata("PrivateAssets", "all");
+                        packageReference.SetMetadata("Publish", "true");
+
                         packageReferencesToUpdate.Add(packageReference);
 
                     }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ApplyImplicitVersions.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ApplyImplicitVersions.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Microsoft.Build.Framework;
+
+namespace Microsoft.NET.Build.Tasks
+{
+
+    //  TODO: Provide way to opt out of warning when Version is specified (possibly with the DisableImplicitFrameworkReferences property)
+    public class ApplyImplicitVersions : TaskBase
+    {
+        public string TargetFrameworkVersion { get; set; }
+
+        public bool TargetLatestRuntimePatch { get; set; }
+
+        public ITaskItem[] PackageReferences { get; set; } = Array.Empty<ITaskItem>();
+
+        public ITaskItem[] ImplicitPackageReferenceVersions { get; set; } = Array.Empty<ITaskItem>();
+
+        [Output]
+        public ITaskItem[] PackageReferencesToUpdate { get; set; }
+
+        protected override void ExecuteCore()
+        {
+            var packageReferencesToUpdate = new List<ITaskItem>();
+
+            var implicitReferencesForThisFramework = ImplicitPackageReferenceVersions
+                .Select(item => new ImplicitPackageReferenceVersion(item))
+                .Where(item => item.TargetFrameworkVersion == this.TargetFrameworkVersion)
+                .ToDictionary(implicitVersion => implicitVersion.Name);
+
+            foreach (var packageReference in PackageReferences)
+            {
+                ImplicitPackageReferenceVersion implicitVersion;
+                if (implicitReferencesForThisFramework.TryGetValue(packageReference.ItemSpec, out implicitVersion))
+                {
+                    string versionOnPackageReference = packageReference.GetMetadata(MetadataKeys.Version);
+                    if (string.IsNullOrEmpty(versionOnPackageReference))
+                    {
+                        
+                        packageReference.SetMetadata(MetadataKeys.Version, 
+                            TargetLatestRuntimePatch ? implicitVersion.LatestVersion : implicitVersion.DefaultVersion);
+
+                        packageReferencesToUpdate.Add(packageReference);
+
+                    }
+                    else
+                    {
+                        // NETSDK1071: A PackageReference to '{0}' specified a Version of `{1}`. Specifying the version of this package is not recommended.  For more information, see https://aka.ms/sdkimplicitrefs
+                        Log.LogWarning(Strings.PackageReferenceVersionNotRecommended, packageReference.ItemSpec, versionOnPackageReference);
+                    }
+                }
+            }
+
+            PackageReferencesToUpdate = packageReferencesToUpdate.ToArray();
+        }
+
+        class ImplicitPackageReferenceVersion
+        {
+            ITaskItem _item;
+            public ImplicitPackageReferenceVersion(ITaskItem item)
+            {
+                _item = item;
+            }
+            //  The name / Package ID
+            public string Name => _item.ItemSpec;
+
+            //  The target framework version that this item applies to
+            public string TargetFrameworkVersion => _item.GetMetadata("TargetFrameworkVersion");
+
+            public string DefaultVersion => _item.GetMetadata("DefaultVersion");
+
+            public string LatestVersion => _item.GetMetadata("LatestVersion");
+
+        }
+    }
+}

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ApplyImplicitVersions.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ApplyImplicitVersions.cs
@@ -31,15 +31,12 @@ namespace Microsoft.NET.Build.Tasks
 
             var packageReferencesToUpdate = new List<ITaskItem>();
 
-            var implicitReferencesForThisFramework = ImplicitPackageReferenceVersions
-                .Select(item => new ImplicitPackageReferenceVersion(item))
-                .Where(item => item.TargetFrameworkVersion == this.TargetFrameworkVersion)
-                .ToDictionary(implicitVersion => implicitVersion.Name);
+            var implicitVersionTable = GetApplicableImplicitVersionTable();
 
             foreach (var packageReference in PackageReferences)
             {
                 ImplicitPackageReferenceVersion implicitVersion;
-                if (implicitReferencesForThisFramework.TryGetValue(packageReference.ItemSpec, out implicitVersion))
+                if (implicitVersionTable.TryGetValue(packageReference.ItemSpec, out implicitVersion))
                 {
                     string versionOnPackageReference = packageReference.GetMetadata(MetadataKeys.Version);
                     if (string.IsNullOrEmpty(versionOnPackageReference))
@@ -61,6 +58,22 @@ namespace Microsoft.NET.Build.Tasks
 
             PackageReferencesToUpdate = packageReferencesToUpdate.ToArray();
             SdkBuildWarnings = buildWarnings.ToArray();
+        }
+
+        private Dictionary<string, ImplicitPackageReferenceVersion> GetApplicableImplicitVersionTable()
+        {
+            var result = new Dictionary<string, ImplicitPackageReferenceVersion>();
+            foreach (var item in ImplicitPackageReferenceVersions)
+            {
+                var implicitPackageReferenceVersion = new ImplicitPackageReferenceVersion(item);
+
+                if (implicitPackageReferenceVersion.TargetFrameworkVersion == this.TargetFrameworkVersion)
+                {
+                    result.Add(implicitPackageReferenceVersion.Name, implicitPackageReferenceVersion);
+                }
+            }
+
+            return result;
         }
 
         private sealed class ImplicitPackageReferenceVersion

--- a/src/Tasks/Microsoft.NET.Build.Tasks/CheckForImplicitPackageReferenceOverrides.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/CheckForImplicitPackageReferenceOverrides.cs
@@ -36,11 +36,8 @@ namespace Microsoft.NET.Build.Tasks
                         if (item.GetMetadata(MetadataKeys.IsImplicitlyDefined).Equals("true", StringComparison.OrdinalIgnoreCase))
                         {
                             itemsToRemove.Add(item);
-                            string message = string.Format(CultureInfo.CurrentCulture, Strings.PackageReferenceOverrideWarning,
-                                item.ItemSpec,
-                                MoreInformationLink);
-
-                            Log.LogWarning(message);
+  
+                            Log.LogWarning(Strings.PackageReferenceOverrideWarning, item.ItemSpec, MoreInformationLink);
                         }
                         else
                         {

--- a/src/Tasks/Microsoft.NET.Build.Tasks/CheckForImplicitPackageReferenceOverrides.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/CheckForImplicitPackageReferenceOverrides.cs
@@ -9,8 +9,6 @@ namespace Microsoft.NET.Build.Tasks
 {
     public class CheckForImplicitPackageReferenceOverrides : TaskBase
     {
-        const string MetadataKeyForItemsToRemove = "IsImplicitlyDefined";
-
         [Required]
         public ITaskItem [] PackageReferenceItems { get; set; }
 
@@ -20,21 +18,44 @@ namespace Microsoft.NET.Build.Tasks
         [Output]
         public ITaskItem[] ItemsToRemove { get; set; }
 
+        [Output]
+        public ITaskItem[] ItemsToAdd { get; set; }
+
         protected override void ExecuteCore()
         {
             var duplicateItems = PackageReferenceItems.GroupBy(i => i.ItemSpec, StringComparer.OrdinalIgnoreCase).Where(g => g.Count() > 1);
-            var duplicateItemsToRemove = duplicateItems.SelectMany(g => g.Where(
-                item => item.GetMetadata(MetadataKeyForItemsToRemove).Equals("true", StringComparison.OrdinalIgnoreCase)));
 
-            ItemsToRemove = duplicateItemsToRemove.ToArray();
-
-            foreach (var itemToRemove in ItemsToRemove)
+            if (duplicateItems.Any())
             {
-                string message = string.Format(CultureInfo.CurrentCulture, Strings.PackageReferenceOverrideWarning,
-                    itemToRemove.ItemSpec,
-                    MoreInformationLink);
+                List<ITaskItem> itemsToRemove = new List<ITaskItem>();
+                List<ITaskItem> itemsToAdd = new List<ITaskItem>();
+                foreach (var duplicateItemGroup in duplicateItems)
+                {
+                    foreach (var item in duplicateItemGroup)
+                    {
+                        if (item.GetMetadata(MetadataKeys.IsImplicitlyDefined).Equals("true", StringComparison.OrdinalIgnoreCase))
+                        {
+                            itemsToRemove.Add(item);
+                            string message = string.Format(CultureInfo.CurrentCulture, Strings.PackageReferenceOverrideWarning,
+                                item.ItemSpec,
+                                MoreInformationLink);
 
-                Log.LogWarning(message);
+                            Log.LogWarning(message);
+                        }
+                        else
+                        {
+                            //  For the explicit items, we want to add metadata to them so that the ApplyImplicitVersions task
+                            //  won't generate another error.  The easiest way to do this is to add them both to a list of
+                            //  items to remove, and then a list of items which gets added back.
+                            itemsToRemove.Add(item);
+                            item.SetMetadata(MetadataKeys.AllowExplicitVersion, "true");
+                            itemsToAdd.Add(item);
+                        }
+                    }
+                }
+
+                ItemsToRemove = itemsToRemove.ToArray();
+                ItemsToAdd = itemsToAdd.ToArray();
             }
         }
     }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageAssets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageAssets.cs
@@ -341,7 +341,7 @@ namespace Microsoft.NET.Build.Tasks
                         foreach (var implicitPackage in ExpectedPlatformPackages)
                         {
                             writer.Write(implicitPackage.ItemSpec ?? "");
-                            writer.Write(implicitPackage.GetMetadata(MetadataKeys.ExpectedVersion) ?? "");
+                            writer.Write(implicitPackage.GetMetadata(MetadataKeys.Version) ?? "");
                         }
                     }
                     writer.Write(ProjectAssetsCacheFile);
@@ -849,10 +849,10 @@ namespace Microsoft.NET.Build.Tasks
                 if (_task.VerifyMatchingImplicitPackageVersion &&
                     _task.ExpectedPlatformPackages != null)
                 {
-                    foreach (var implicitPackge in _task.ExpectedPlatformPackages)
+                    foreach (var implicitPackage in _task.ExpectedPlatformPackages)
                     {
-                        var packageName = implicitPackge.ItemSpec;
-                        var expectedVersion = implicitPackge.GetMetadata(MetadataKeys.ExpectedVersion);
+                        var packageName = implicitPackage.ItemSpec;
+                        var expectedVersion = implicitPackage.GetMetadata(MetadataKeys.Version);
 
                         if (string.IsNullOrEmpty(packageName) ||
                             string.IsNullOrEmpty(expectedVersion) ||

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.CrossGen.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.CrossGen.targets
@@ -258,15 +258,22 @@ Restores netcoreapp and publishes it to a temp directory
   
   <Target Name="_RestoreCrossgen"
           DependsOnTargets="PrepforRestoreForComposeStore;
-                           _SetupStageForCrossgen;"
+                           _SetupStageForCrossgen;
+                           ApplyImplicitVersions"
           Condition="$(SkipOptimization) != 'true' ">
+
+    <ItemGroup>
+      <!-- Filter package references to the one for the platform library, in order to find the right version -->
+      <PackageReferenceForCrossGen Include="@(PackageReference)" Condition="'%(Identity)' == '$(MicrosoftNETPlatformLibrary)'" />
+    </ItemGroup>
+
     <MSBuild Projects="$(MSBuildProjectFullPath)"
                  Targets="Restore"
                  Properties="RestoreGraphProjectInput=$(MSBuildProjectFullPath);
                              DisableImplicitFrameworkReferences=true;
                              RestoreOutputPath=$(_CrossProjFileDir);
                              StorePackageName=$(MicrosoftNETPlatformLibrary);
-                             StorePackageVersion=$(RuntimeFrameworkVersion);"/>
+                             StorePackageVersion=%(PackageReferenceForCrossGen.Version);"/>
 
     <ResolvePublishAssemblies ProjectPath="$(MSBuildProjectFullPath)"
                               AssetsFilePath="$(_CrossProjAssetsFile)"

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.props
@@ -19,6 +19,9 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <PropertyGroup>
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+
+    <!-- Disable web SDK implicit package versions for ASP.NET packages, since the .NET SDK now handles that -->
+    <EnableWebSdkImplicitPackageVersions>false</EnableWebSdkImplicitPackageVersions>
   </PropertyGroup>
 
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.props
@@ -46,7 +46,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   </ItemGroup>
 
   <ItemGroup Condition=" '$(DisableImplicitFrameworkReferences)' != 'true' and '$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
-    <PackageReference Include="Microsoft.NETCore.App" Version="$(RuntimeFrameworkVersion)" IsImplicitlyDefined="true" />
+    <PackageReference Include="Microsoft.NETCore.App" IsImplicitlyDefined="true" />
 
     <!-- For targeting .NET Core 2.0 or higher, don't include a dependency on Microsoft.NETCore.App in the package produced by pack.
          Packing an DotnetCliTool should include the Microsoft.NETCore.App package dependency. -->

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.targets
@@ -76,98 +76,23 @@ Copyright (c) .NET Foundation. All rights reserved.
     The TargetLatestRuntimePatch property can be set to true or false to explicitly opt in or out of the logic to roll forward
     to the latest patch, regardless of whether the app is self-contained or framework-dependent.
     
-    The RuntimeFrameworkVersion is where the actual version of the .NET Core runtime to target is stored.  It is the version that is
-    used in the implicit PackageReference to Microsoft.NETCore.App.  The RuntimeFrameworkVersion can also be set explicitly, which
-    will disable all the other logic that automatically selects the version of .NET Core to target.
+    The RuntimeFrameworkVersion is where the actual version of the .NET Core runtime to target can be set.  If set, it will be
+    used in the implicit PackageReference to Microsoft.NETCore.App.  
     
     The framework version that is written to the runtimeconfig.json file is based on the actual resolved package version
     of Microsoft.NETCore.App.  This is to allow floating the verion number (ie the RuntimeFrameworkVersion could be set to
     "2.0-*".
   
   -->
-
-  <!--
-      Possible property names to enable roll-forward:
-      - TargetLatestRuntimePatch
-      - TargetLatestNetCoreRuntimePatch
-      - RollForwardRuntime
-      - RollForwardNetCoreRuntime
-      
-     Possible property names for roll-forward/not roll-forward versions
-      - LatestNetCorePatchVersion / DefaultNetCorePatchVersion
-      
-      TODO: Get feedback on these names and then delete this comment
-  -->
-
-  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
-    <!-- These properties will allow the latest patch versions to be set in the CLI (via BundledVersions.props) or overridden by tests -->
-    <LatestPatchVersionForNetCore1_0 Condition="'$(LatestPatchVersionForNetCore1_0)' == ''">1.0.10</LatestPatchVersionForNetCore1_0>
-    <LatestPatchVersionForNetCore1_1 Condition="'$(LatestPatchVersionForNetCore1_1)' == ''">1.1.7</LatestPatchVersionForNetCore1_1>
-    <LatestPatchVersionForNetCore2_0 Condition="'$(LatestPatchVersionForNetCore2_0)' == ''">2.0.6</LatestPatchVersionForNetCore2_0>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(DefaultNetCorePatchVersion)' == ''">
-    <DefaultNetCorePatchVersion Condition="'$(_TargetFrameworkVersionWithoutV)' == '1.0'">1.0.5</DefaultNetCorePatchVersion>
-    <DefaultNetCorePatchVersion Condition="'$(_TargetFrameworkVersionWithoutV)' == '1.1'">1.1.2</DefaultNetCorePatchVersion>
-
-    <!-- If targeting the same pre-release that is bundled with the .NET Core SDK, use the bundled package version
-         provided by Microsoft.NETCoreSdk.BundledVersions.props -->
-    <DefaultNetCorePatchVersion Condition="'$(DefaultNetCorePatchVersion)' == '' And '$(_TargetFrameworkVersionWithoutV)' == '$(BundledNETCoreAppTargetFrameworkVersion)' And '$(UseBundledNETCoreAppPackageVersionAsDefaultNetCorePatchVersion)' == 'true'">$(BundledNETCoreAppPackageVersion)</DefaultNetCorePatchVersion>
-    <!-- If not covered by the previous cases use the target framework version for the default patch version -->
-    <DefaultNetCorePatchVersion Condition="'$(DefaultNetCorePatchVersion)' == ''">$(_TargetFrameworkVersionWithoutV)</DefaultNetCorePatchVersion>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(LatestNetCorePatchVersion)' == ''">
-    <LatestNetCorePatchVersion Condition="'$(_TargetFrameworkVersionWithoutV)' == '1.0'">$(LatestPatchVersionForNetCore1_0)</LatestNetCorePatchVersion>
-    <LatestNetCorePatchVersion Condition="'$(_TargetFrameworkVersionWithoutV)' == '1.1'">$(LatestPatchVersionForNetCore1_1)</LatestNetCorePatchVersion>
-    <LatestNetCorePatchVersion Condition="'$(_TargetFrameworkVersionWithoutV)' == '2.0'">$(LatestPatchVersionForNetCore2_0)</LatestNetCorePatchVersion>
-    <LatestNetCorePatchVersion Condition="'$(_TargetFrameworkVersionWithoutV)' == '2.1'">$(LatestPatchVersionForNetCore2_1)</LatestNetCorePatchVersion>
-
-    <!-- If targeting the same pre-release that is bundled with the .NET Core SDK, use the bundled package version
-         provided by Microsoft.NETCoreSdk.BundledVersions.props -->
-    <LatestNetCorePatchVersion Condition="'$(_TargetFrameworkVersionWithoutV)' == '$(BundledNETCoreAppTargetFrameworkVersion)'">$(BundledNETCoreAppPackageVersion)</LatestNetCorePatchVersion>
-    <!-- If not covered by the previous cases use the target framework version for the latest patch version -->
-    <LatestNetCorePatchVersion Condition="'$(LatestNetCorePatchVersion)' == ''">$(_TargetFrameworkVersionWithoutV)</LatestNetCorePatchVersion>
-  </PropertyGroup>
   
   <PropertyGroup Condition="'$(TargetLatestRuntimePatch)' == ''">
     <TargetLatestRuntimePatch Condition="'$(SelfContained)' == 'true' ">true</TargetLatestRuntimePatch>
     <TargetLatestRuntimePatch Condition="'$(SelfContained)' != 'true' ">false</TargetLatestRuntimePatch>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(RuntimeFrameworkVersion)' == ''">
-    <RuntimeFrameworkVersion Condition="'$(TargetLatestRuntimePatch)' == 'true' ">$(LatestNetCorePatchVersion)</RuntimeFrameworkVersion>
-    <RuntimeFrameworkVersion Condition="'$(TargetLatestRuntimePatch)' != 'true' ">$(DefaultNetCorePatchVersion)</RuntimeFrameworkVersion>
-  </PropertyGroup>
-
-  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(DisableImplicitFrameworkReferences)' != 'true'">
-    <!-- This property is different than MicrosoftNETPlatformLibrary.  MicrosoftNETPlatformLibrary is
-         used to trim the dependencies published with a framework-dependent app, and is overridden
-         by ASP.NET packages.
-         
-         ExpectedPlatformPackages is the list of packages that are actually implicitly
-         referenced by the SDK, and is passed into the ResolvePackageAssets task
-         to verify that the restored versions of the packages matches the expected versions
-         -->
-    <ExpectedPlatformPackages Include="Microsoft.NETCore.App" ExpectedVersion="$(RuntimeFrameworkVersion)" />
-  </ItemGroup>
-
   <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(DisableImplicitFrameworkReferences)' != 'true'">
     <VerifyMatchingImplicitPackageVersion Condition="'$(VerifyMatchingImplicitPackageVersion)' == ''">true</VerifyMatchingImplicitPackageVersion>
   </PropertyGroup>
-
-  <!-- ImplicitPackageReferenceVersion will go in BundledVersions, but until they do, put defaults here -->
-  <ItemGroup Condition="'@(ImplicitPackageReferenceVersion)' == ''">
-    <ImplicitPackageReferenceVersion Include="Microsoft.NETCore.App" TargetFrameworkVersion="1.0" DefaultVersion="1.0.5" LatestVersion="1.0.12"/>
-    <ImplicitPackageReferenceVersion Include="Microsoft.NETCore.App" TargetFrameworkVersion="1.1" DefaultVersion="1.1.2" LatestVersion="1.1.9"/>
-    <ImplicitPackageReferenceVersion Include="Microsoft.NETCore.App" TargetFrameworkVersion="2.0" DefaultVersion="2.0.0" LatestVersion="2.0.9"/>
-    <ImplicitPackageReferenceVersion Include="Microsoft.NETCore.App" TargetFrameworkVersion="2.1" DefaultVersion="2.1.0" LatestVersion="2.1.2"/>
-    <ImplicitPackageReferenceVersion Include="Microsoft.NETCore.App" TargetFrameworkVersion="2.2" DefaultVersion="$(BundledNETCoreAppPackageVersion)" LatestVersion="$(BundledNETCoreAppPackageVersion)"/>
-    <ImplicitPackageReferenceVersion Include="Microsoft.AspNetCore.App" TargetFrameworkVersion="2.1" DefaultVersion="2.1.1" LatestVersion="2.1.3"/>
-    <ImplicitPackageReferenceVersion Include="Microsoft.AspNetCore.All" TargetFrameworkVersion="2.1" DefaultVersion="2.1.1" LatestVersion="2.1.3"/>
-    <ImplicitPackageReferenceVersion Include="Microsoft.AspNetCore.App" TargetFrameworkVersion="2.2" DefaultVersion="$(BundledAspNetCoreAppPackageVersion)" LatestVersion="$(BundledAspNetCoreAppPackageVersion)"/>
-    <ImplicitPackageReferenceVersion Include="Microsoft.AspNetCore.All" TargetFrameworkVersion="2.2" DefaultVersion="$(BundledAspNetCoreAllPackageVersion)" LatestVersion="$(BundledAspNetCoreAllPackageVersion)"/>
-  </ItemGroup>
 
   <ItemGroup>
     <!-- Set implicit metadata on ASP.NET package references -->
@@ -180,11 +105,18 @@ Copyright (c) .NET Foundation. All rights reserved.
       <PrivateAssets Condition="'%(PackageReference.Version)' == ''">true</PrivateAssets>
       <Publish Condition="'%(PackageReference.Version)' == ''">true</Publish>
     </PackageReference>
+  
+    <!-- Allow RuntimeFrameworkVersion to be used to explicitly specify the version of Microsoft.NETCore.App -->
+    <PackageReference Update="Microsoft.NETCore.App"
+                      Version="$(RuntimeFrameworkVersion)"
+                      Condition="'$(RuntimeFrameworkVersion)' != ''" 
+                      AllowExplicitVersion="true"/>
   </ItemGroup>
   
   <UsingTask TaskName="ApplyImplicitVersions" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
 
-  <Target Name="ApplyImplicitVersions" BeforeTargets="_CheckForInvalidConfigurationAndPlatform;CollectPackageReferences">
+  <Target Name="ApplyImplicitVersions" BeforeTargets="_CheckForInvalidConfigurationAndPlatform;CollectPackageReferences"
+          DependsOnTargets="CheckForImplicitPackageReferenceOverrides">
     <ApplyImplicitVersions TargetFrameworkVersion="$(_TargetFrameworkVersionWithoutV)"
                            TargetLatestRuntimePatch="$(TargetLatestRuntimePatch)"
                            PackageReferences="@(PackageReference)"
@@ -272,6 +204,10 @@ Copyright (c) .NET Foundation. All rights reserved.
       <!-- Note that the condition here is important, otherwise the Remove will operate based just on item identity and remove all items
            that had duplicates, instead of leaving the ones without IsImplicitlyDefined set to true. -->
       <PackageReference Remove="@(_PackageReferenceToRemove)" Condition="'%(PackageReference.IsImplicitlyDefined)' == 'true' "/>
+    
+      <!-- If we've already warned that an implicit PackageReference was overridden, don't also warn that the version was explicitly
+           specified -->
+      <PackageReference Update="@(_PackageReferenceToRemove)" AllowExplicitVersion="true"/>
     </ItemGroup>
     
     <!-- If any implicit package references were overridden, then don't check that RuntimeFrameworkVersion matches the package version -->

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.targets
@@ -129,6 +129,15 @@ Copyright (c) .NET Foundation. All rights reserved.
       <PackageReference Remove="@(PackageReferenceToUpdate)" />
       <PackageReference Include="@(PackageReferenceToUpdate)" />
     </ItemGroup>
+
+    <ItemGroup>
+      <!-- Support using a patch version in the TargetFramework, ie netcoreapp1.1.1
+           Note that this isn't officially supported, but it worked in the past so
+           this should prevent breaking it. -->
+      <PackageReference Condition="'%(PackageReference.Identity)' == 'Microsoft.NETCore.App'">
+        <Version Condition="'%(PackageReference.Version)' == ''">$(_TargetFrameworkVersionWithoutV)</Version>
+      </PackageReference>
+    </ItemGroup>
   </Target>
   
   <!-- This target runs before build but not before restore, to avoid duplicating these warnings

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.targets
@@ -198,16 +198,14 @@ Copyright (c) .NET Foundation. All rights reserved.
         PackageReferenceItems="@(PackageReference)"
         MoreInformationLink="$(ImplicitPackageReferenceInformationLink)">
       <Output TaskParameter="ItemsToRemove" ItemName="_PackageReferenceToRemove" />
+      <Output TaskParameter="ItemsToAdd" ItemName="_PackageReferenceToAdd" />
     </CheckForImplicitPackageReferenceOverrides>
 
     <ItemGroup>
-      <!-- Note that the condition here is important, otherwise the Remove will operate based just on item identity and remove all items
-           that had duplicates, instead of leaving the ones without IsImplicitlyDefined set to true. -->
-      <PackageReference Remove="@(_PackageReferenceToRemove)" Condition="'%(PackageReference.IsImplicitlyDefined)' == 'true' "/>
-    
-      <!-- If we've already warned that an implicit PackageReference was overridden, don't also warn that the version was explicitly
-           specified -->
-      <PackageReference Update="@(_PackageReferenceToRemove)" AllowExplicitVersion="true"/>
+      <!-- Remove and add the PackageReference items according to the output from the task -->
+      <PackageReference Remove="@(_PackageReferenceToRemove)" />
+
+      <PackageReference Include="@(_PackageReferenceToAdd)" />
     </ItemGroup>
     
     <!-- If any implicit package references were overridden, then don't check that RuntimeFrameworkVersion matches the package version -->

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.targets
@@ -185,12 +185,21 @@ Copyright (c) .NET Foundation. All rights reserved.
                            PackageReferences="@(PackageReference)"
                            ImplicitPackageReferenceVersions="@(ImplicitPackageReferenceVersion)">
       <Output TaskParameter="PackageReferencesToUpdate" ItemName="PackageReferenceToUpdate" />
+      <Output TaskParameter="SdkBuildWarnings" ItemName="SdkBuildWarning" />
     </ApplyImplicitVersions>
 
     <ItemGroup>
       <PackageReference Remove="@(PackageReferenceToUpdate)" />
       <PackageReference Include="@(PackageReferenceToUpdate)" />
     </ItemGroup>
+  </Target>
+  
+  <!-- This target runs before build but not before restore, to avoid duplicating these warnings
+       if building with an implicit restore. -->
+  <Target Name="WarnForExplicitVersions" BeforeTargets="_CheckForInvalidConfigurationAndPlatform"
+          DependsOnTargets="ApplyImplicitVersions"
+          Condition="'@(SdkBuildWarning)' != ''">
+    <NetSdkWarning FormattedText="%(SdkBuildWarning.Identity)" />
   </Target>
   
   <!--

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.targets
@@ -155,6 +155,43 @@ Copyright (c) .NET Foundation. All rights reserved.
   <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(DisableImplicitFrameworkReferences)' != 'true'">
     <VerifyMatchingImplicitPackageVersion Condition="'$(VerifyMatchingImplicitPackageVersion)' == ''">true</VerifyMatchingImplicitPackageVersion>
   </PropertyGroup>
+
+  <!-- ImplicitPackageReferenceVersion will go in BundledVersions, but until they do, put defaults here -->
+  <ItemGroup Condition="'@(ImplicitPackageReferenceVersion)' == ''">
+    <ImplicitPackageReferenceVersion Include="Microsoft.AspNetCore.App"
+                                     TargetFrameworkVersion="2.1"
+                                     DefaultVersion="2.1.1"
+                                     LatestVersion="2.1.3"/>
+    <ImplicitPackageReferenceVersion Include="Microsoft.AspNetCore.All"
+                                     TargetFrameworkVersion="2.1"
+                                     DefaultVersion="2.1.1"
+                                     LatestVersion="2.1.3"/>
+
+    <ImplicitPackageReferenceVersion Include="Microsoft.AspNetCore.App"
+                                     TargetFrameworkVersion="2.2"
+                                     DefaultVersion="$(BundledAspNetCoreAppPackageVersion)"
+                                     LatestVersion="$(BundledAspNetCoreAppPackageVersion)"/>
+    <ImplicitPackageReferenceVersion Include="Microsoft.AspNetCore.All"
+                                     TargetFrameworkVersion="2.2"
+                                     DefaultVersion="$(BundledAspNetCoreAllPackageVersion)"
+                                     LatestVersion="$(BundledAspNetCoreAllPackageVersion)"/>
+  </ItemGroup>
+  
+  <UsingTask TaskName="ApplyImplicitVersions" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
+
+  <Target Name="ApplyImplicitVersions" BeforeTargets="_CheckForInvalidConfigurationAndPlatform;CollectPackageReferences">
+    <ApplyImplicitVersions TargetFrameworkVersion="$(_TargetFrameworkVersionWithoutV)"
+                           TargetLatestRuntimePatch="$(TargetLatestRuntimePatch)"
+                           PackageReferences="@(PackageReference)"
+                           ImplicitPackageReferenceVersions="@(ImplicitPackageReferenceVersion)">
+      <Output TaskParameter="PackageReferencesToUpdate" ItemName="PackageReferenceToUpdate" />
+    </ApplyImplicitVersions>
+
+    <ItemGroup>
+      <PackageReference Remove="@(PackageReferenceToUpdate)" />
+      <PackageReference Include="@(PackageReferenceToUpdate)" />
+    </ItemGroup>
+  </Target>
   
   <!--
     Automatically add Link metadata to items of specific types if they are outside of the project folder and don't already have the Link metadata set.

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.targets
@@ -111,6 +111,11 @@ Copyright (c) .NET Foundation. All rights reserved.
                       Version="$(RuntimeFrameworkVersion)"
                       Condition="'$(RuntimeFrameworkVersion)' != ''" 
                       AllowExplicitVersion="true"/>
+    
+    <!-- If implicit PackageReferences are disabled, then don't warn about explicit versions at all -->
+    <PackageReference Update="@(PackageReference)"
+                      Condition="'$(DisableImplicitFrameworkReferences)' == 'true'"
+                      AllowExplicitVersion="true"/>
   </ItemGroup>
   
   <UsingTask TaskName="ApplyImplicitVersions" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.targets
@@ -158,23 +158,28 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <!-- ImplicitPackageReferenceVersion will go in BundledVersions, but until they do, put defaults here -->
   <ItemGroup Condition="'@(ImplicitPackageReferenceVersion)' == ''">
-    <ImplicitPackageReferenceVersion Include="Microsoft.AspNetCore.App"
-                                     TargetFrameworkVersion="2.1"
-                                     DefaultVersion="2.1.1"
-                                     LatestVersion="2.1.3"/>
-    <ImplicitPackageReferenceVersion Include="Microsoft.AspNetCore.All"
-                                     TargetFrameworkVersion="2.1"
-                                     DefaultVersion="2.1.1"
-                                     LatestVersion="2.1.3"/>
+    <ImplicitPackageReferenceVersion Include="Microsoft.NETCore.App" TargetFrameworkVersion="1.0" DefaultVersion="1.0.5" LatestVersion="1.0.12"/>
+    <ImplicitPackageReferenceVersion Include="Microsoft.NETCore.App" TargetFrameworkVersion="1.1" DefaultVersion="1.1.2" LatestVersion="1.1.9"/>
+    <ImplicitPackageReferenceVersion Include="Microsoft.NETCore.App" TargetFrameworkVersion="2.0" DefaultVersion="2.0.0" LatestVersion="2.0.9"/>
+    <ImplicitPackageReferenceVersion Include="Microsoft.NETCore.App" TargetFrameworkVersion="2.1" DefaultVersion="2.1.0" LatestVersion="2.1.2"/>
+    <ImplicitPackageReferenceVersion Include="Microsoft.NETCore.App" TargetFrameworkVersion="2.2" DefaultVersion="$(BundledNETCoreAppPackageVersion)" LatestVersion="$(BundledNETCoreAppPackageVersion)"/>
+    <ImplicitPackageReferenceVersion Include="Microsoft.AspNetCore.App" TargetFrameworkVersion="2.1" DefaultVersion="2.1.1" LatestVersion="2.1.3"/>
+    <ImplicitPackageReferenceVersion Include="Microsoft.AspNetCore.All" TargetFrameworkVersion="2.1" DefaultVersion="2.1.1" LatestVersion="2.1.3"/>
+    <ImplicitPackageReferenceVersion Include="Microsoft.AspNetCore.App" TargetFrameworkVersion="2.2" DefaultVersion="$(BundledAspNetCoreAppPackageVersion)" LatestVersion="$(BundledAspNetCoreAppPackageVersion)"/>
+    <ImplicitPackageReferenceVersion Include="Microsoft.AspNetCore.All" TargetFrameworkVersion="2.2" DefaultVersion="$(BundledAspNetCoreAllPackageVersion)" LatestVersion="$(BundledAspNetCoreAllPackageVersion)"/>
+  </ItemGroup>
 
-    <ImplicitPackageReferenceVersion Include="Microsoft.AspNetCore.App"
-                                     TargetFrameworkVersion="2.2"
-                                     DefaultVersion="$(BundledAspNetCoreAppPackageVersion)"
-                                     LatestVersion="$(BundledAspNetCoreAppPackageVersion)"/>
-    <ImplicitPackageReferenceVersion Include="Microsoft.AspNetCore.All"
-                                     TargetFrameworkVersion="2.2"
-                                     DefaultVersion="$(BundledAspNetCoreAllPackageVersion)"
-                                     LatestVersion="$(BundledAspNetCoreAllPackageVersion)"/>
+  <ItemGroup>
+    <!-- Set implicit metadata on ASP.NET package references -->
+    <PackageReference Update="Microsoft.AspNetCore.App">
+      <PrivateAssets Condition="'%(PackageReference.Version)' == ''">true</PrivateAssets>
+      <Publish Condition="'%(PackageReference.Version)' == ''">true</Publish>
+    </PackageReference>
+  
+    <PackageReference Update="Microsoft.AspNetCore.All">
+      <PrivateAssets Condition="'%(PackageReference.Version)' == ''">true</PrivateAssets>
+      <Publish Condition="'%(PackageReference.Version)' == ''">true</Publish>
+    </PackageReference>
   </ItemGroup>
   
   <UsingTask TaskName="ApplyImplicitVersions" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.PackageDependencyResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.PackageDependencyResolution.targets
@@ -197,6 +197,12 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <ItemGroup>
       <_PackAsToolShimRuntimeIdentifiers Include="$(PackAsToolShimRuntimeIdentifiers)"/>
+
+      <!-- Pass these packages into the ResolvePackageAssets task to verify that the restored versions of the packages
+           match the expected version -->
+      <ExpectedPlatformPackages Include="@(PackageReference)" Condition="'%(Identity)' == 'Microsoft.NETCore.App'" />
+      <ExpectedPlatformPackages Include="@(PackageReference)" Condition="'%(Identity)' == 'Microsoft.AspNetCore.App'" />
+      <ExpectedPlatformPackages Include="@(PackageReference)" Condition="'%(Identity)' == 'Microsoft.AspNetCore.All'" />
     </ItemGroup>
 
     <ResolvePackageAssets 

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildANetCoreApp.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildANetCoreApp.cs
@@ -39,7 +39,8 @@ namespace Microsoft.NET.Build.Tests
         [InlineData("netcoreapp1.0", "1.0.3", "1.0.3", "1.0.3")]
         [InlineData("netcoreapp1.1", null, "1.1.2", "1.1.2")]
         [InlineData("netcoreapp1.1", "1.1.0", "1.1.0", "1.1.0")]
-        [InlineData("netcoreapp1.1.1", null, "1.1.1", "1.1.1")]
+        //  Putting a patch in the TargetFramework property is no longer supported with the switch to ImplicitPackageReferenceVersion items
+        //[InlineData("netcoreapp1.1.1", null, "1.1.1", "1.1.1")]
         [InlineData("netcoreapp2.0", null, "2.0.0", "2.0.0")]
         [InlineData("netcoreapp2.1", null, "2.1.0", "2.1.0")]
         public void It_targets_the_right_shared_framework(string targetFramework, string runtimeFrameworkVersion,

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildANetCoreApp.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildANetCoreApp.cs
@@ -39,8 +39,7 @@ namespace Microsoft.NET.Build.Tests
         [InlineData("netcoreapp1.0", "1.0.3", "1.0.3", "1.0.3")]
         [InlineData("netcoreapp1.1", null, "1.1.2", "1.1.2")]
         [InlineData("netcoreapp1.1", "1.1.0", "1.1.0", "1.1.0")]
-        //  Putting a patch in the TargetFramework property is no longer supported with the switch to ImplicitPackageReferenceVersion items
-        //[InlineData("netcoreapp1.1.1", null, "1.1.1", "1.1.1")]
+        [InlineData("netcoreapp1.1.1", null, "1.1.1", "1.1.1")]
         [InlineData("netcoreapp2.0", null, "2.0.0", "2.0.0")]
         [InlineData("netcoreapp2.1", null, "2.1.0", "2.1.0")]
         public void It_targets_the_right_shared_framework(string targetFramework, string runtimeFrameworkVersion,

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThereAreDefaultItems.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThereAreDefaultItems.cs
@@ -640,7 +640,10 @@ namespace Microsoft.NET.Build.Tests
             buildCommand
                 .Execute()
                 .Should()
-                .Pass();
+                .Pass()
+                .And
+                .NotHaveStdOutContaining("NETSDK1071");
+                ;
 
             LockFile lockFile = LockFileUtilities.GetLockFile(Path.Combine(buildCommand.ProjectRootPath, "obj", "project.assets.json"), NullLogger.Instance);
 

--- a/src/Tests/Microsoft.NET.Build.Tests/ImplicitAspNetVersions.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/ImplicitAspNetVersions.cs
@@ -1,0 +1,208 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using FluentAssertions;
+using Microsoft.NET.TestFramework;
+using Microsoft.NET.TestFramework.Assertions;
+using Microsoft.NET.TestFramework.Commands;
+using Microsoft.NET.TestFramework.ProjectConstruction;
+using NuGet.Common;
+using NuGet.Frameworks;
+using NuGet.ProjectModel;
+using NuGet.Versioning;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.NET.Build.Tests
+{
+    public class ImplicitAspNetVersions : SdkTest
+    {
+        public ImplicitAspNetVersions(ITestOutputHelper log) : base(log)
+        {
+        }
+
+        [Theory]
+        [InlineData("Microsoft.AspNetCore.App")]
+        [InlineData("Microsoft.AspNetCore.All")]
+        public void AspNetCoreVersionIsSetImplicitly(string aspnetPackageName)
+        {
+            var testProject = new TestProject()
+            {
+                Name = "AspNetImplicitVersion",
+                TargetFrameworks = "netcoreapp2.1",
+                IsSdkProject = true,
+                IsExe = true
+            };
+
+            //  Add versionless PackageReference
+            testProject.PackageReferences.Add(new TestPackageReference(aspnetPackageName, null));
+
+            var testAsset = _testAssetsManager.CreateTestProject(testProject, identifier: aspnetPackageName)
+                .Restore(Log, testProject.Name);
+
+            var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+
+            buildCommand
+                .Execute()
+                .Should()
+                .Pass();
+
+            var aspnetVersion = GetLibraryVersion(testProject, buildCommand, aspnetPackageName);
+
+            //  Version of AspNetCore packages is 2.1.1 because 2.1.0 packages had exact version constraints, which was broken
+            aspnetVersion.ToString().Should().Be("2.1.1");
+        }
+
+        [Theory]
+        [InlineData("Microsoft.AspNetCore.App")]
+        [InlineData("Microsoft.AspNetCore.All")]
+        public void AspNetCoreVersionRollsForward(string aspnetPackageName)
+        {
+            var testProject = new TestProject()
+            {
+                Name = "AspNetImplicitVersion",
+                TargetFrameworks = "netcoreapp2.1",
+                IsSdkProject = true,
+                IsExe = true,
+                
+            };
+
+            testProject.RuntimeIdentifier = EnvironmentInfo.GetCompatibleRid(testProject.TargetFrameworks);
+
+            //  Add versionless PackageReference
+            testProject.PackageReferences.Add(new TestPackageReference(aspnetPackageName, null));
+
+            var testAsset = _testAssetsManager.CreateTestProject(testProject, identifier: aspnetPackageName)
+                .Restore(Log, testProject.Name);
+
+            var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+
+            buildCommand
+                .Execute()
+                .Should()
+                .Pass();
+
+            var aspnetVersion = GetLibraryVersion(testProject, buildCommand, aspnetPackageName);
+
+            //  Self-contained app (because RID is specified) should roll forward to later patch
+            aspnetVersion.CompareTo(new SemanticVersion(2, 1, 1)).Should().BeGreaterThan(0);
+        }
+
+        [Theory]
+        [InlineData("Microsoft.AspNetCore.App")]
+        [InlineData("Microsoft.AspNetCore.All")]
+        public void ExplicitVersionsOfAspNetCoreWarn(string aspnetPackageName)
+        {
+            var testProject = new TestProject()
+            {
+                Name = "AspNetExplicitVersion",
+                TargetFrameworks = "netcoreapp2.1",
+                IsSdkProject = true,
+                IsExe = true
+            };
+
+            string explicitVersion = "2.1.0";
+
+            testProject.PackageReferences.Add(new TestPackageReference(aspnetPackageName, explicitVersion));
+
+            var testAsset = _testAssetsManager.CreateTestProject(testProject, identifier: aspnetPackageName)
+                .Restore(Log, testProject.Name);
+
+            var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+
+            buildCommand
+                .Execute()
+                .Should()
+                .Pass()
+                .And
+                .HaveStdOutContaining("NETSDK1071");
+
+            var aspnetVersion = GetLibraryVersion(testProject, buildCommand, aspnetPackageName);
+
+            aspnetVersion.ToString().Should().Be(explicitVersion);
+        }
+
+        [Theory]
+        [InlineData("netcoreapp2.0", "Microsoft.AspNetCore.All", "2.0.9")]
+        [InlineData("netcoreapp1.1", "Microsoft.AspNetCore", "1.1.7")]
+        public void ExplicitVersionsDontWarnForOlderVersions(string targetFramework, string packageName, string packageVersion)
+        {
+            var testProject = new TestProject()
+            {
+                Name = "AspNetPreviousVersion",
+                TargetFrameworks = targetFramework,
+                IsSdkProject = true,
+                IsExe = true
+            };
+
+            testProject.PackageReferences.Add(new TestPackageReference(packageName, packageVersion));
+
+            var testAsset = _testAssetsManager.CreateTestProject(testProject, identifier: targetFramework)
+                .Restore(Log, testProject.Name);
+
+            var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+
+            buildCommand
+                .Execute()
+                .Should()
+                .Pass()
+                .And
+                .NotHaveStdOutContaining("warning");
+
+            var aspnetVersion = GetLibraryVersion(testProject, buildCommand, packageName);
+
+            aspnetVersion.ToString().Should().Be(packageVersion);
+        }
+
+        [Fact]
+        public void MultipleWarningsAreGeneratedForMultipleExplicitReferences()
+        {
+            var testProject = new TestProject()
+            {
+                Name = "MultipleExplicitReferences",
+                TargetFrameworks = "netcoreapp2.1",
+                IsSdkProject = true,
+                IsExe = true
+            };
+
+            testProject.PackageReferences.Add(new TestPackageReference("Microsoft.NETCore.App", "2.1.0"));
+            testProject.PackageReferences.Add(new TestPackageReference("Microsoft.AspNetCore.App", "2.1.0"));
+
+            var testAsset = _testAssetsManager.CreateTestProject(testProject);
+
+            var restoreCommand = new RestoreCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            restoreCommand
+                .Execute()
+                .Should()
+                .Pass()
+                .And
+                .NotHaveStdOutContaining("NETSDK1071");
+                
+
+            var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+
+            buildCommand
+                .Execute()
+                .Should()
+                .Pass()
+                .And
+                .HaveStdOutContaining("NETSDK1071")
+                .And
+                .HaveStdOutContaining("NETSDK1023");
+        }
+
+        static NuGetVersion GetLibraryVersion(TestProject testProject, BuildCommand buildCommand, string libraryName)
+        {
+            LockFile lockFile = LockFileUtilities.GetLockFile(
+                Path.Combine(buildCommand.GetBaseIntermediateDirectory().FullName, "project.assets.json"),
+                NullLogger.Instance);
+
+            var target = lockFile.GetTarget(NuGetFramework.Parse(testProject.TargetFrameworks), testProject.RuntimeIdentifier);
+            var lockFileLibrary = target.Libraries.Single(l => l.Name == libraryName);
+
+            return lockFileLibrary.Version;
+        }
+    }
+}

--- a/src/Tests/Microsoft.NET.TestFramework/ProjectConstruction/TestProject.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/ProjectConstruction/TestProject.cs
@@ -145,9 +145,13 @@ namespace Microsoft.NET.TestFramework.ProjectConstruction
 
             foreach (TestPackageReference packageReference in PackageReferences)
             {
-                packageReferenceItemGroup.Add(new XElement(ns + "PackageReference",
-                    new XAttribute("Include", $"{packageReference.ID}"),
-                    new XAttribute("Version", $"{packageReference.Version}")));
+                var packageReferenceElement = new XElement(ns + "PackageReference",
+                    new XAttribute("Include", packageReference.ID));
+                if (packageReference.Version != null)
+                {
+                    packageReferenceElement.Add(new XAttribute("Version", packageReference.Version));
+                }
+                packageReferenceItemGroup.Add(packageReferenceElement);
             }
 
             foreach (TestPackageReference dotnetCliToolReference in DotNetCliToolReferences)


### PR DESCRIPTION
This adds support for implicit versions on PackageReferences to Microsoft.AspNetCore.App and Microsoft.AspNetCore.All.  Currently this is implemented in the Web SDK, which causes problems when you have a non-Web project (for example a test project) referencing a Web project.  Adding this to the base Microsoft.NET.Sdk will allow the versionless AspNetCore PackageReference in any project.

#### Description

Move logic to implicitly set version of ASP.NET package references into .NET SDK.

#### Customer Impact

Allows projects which do not use the Web SDK to reference Microsoft.AspNetCore.App without specifying the version.  This is especially important for test projects which reference Web projects.  Currently, the test project needs reference the ASP.NET package, and specify the exact version.  Since the version is implicit in the ASP.NET project, it's hard to know which version to use, and it can change, leading to package downgrade warnings, if the project is built with a RID specified.

With this change, the test project will be able to specify a versionless `PackageReference` to ASP.NET the same way the web project can.

#### Regression?

No

#### Risk

In addition to moving the logic, this PR uses an MSBuild task to select the implicit version instead of static MSBuild logic.  So there is some risk associated with that change, but it is counterbalanced by the fact that the version selection code becomes a lot clearer, which reduces the risk of getting it wrong.

#### Notes

Additional PRs will be required along with this PR:

- https://github.com/dotnet/cli/pull/10018: adding the `ImplicitPackageReferenceVersion` items in the bundled versions file
- https://github.com/aspnet/websdk/pull/414: allow the existing version selection logic there to be turned off