### PR TITLE
Add TargetPath metadata to runtimeconfig BuiltProjectOutputGroup

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -197,7 +197,9 @@ Copyright (c) .NET Foundation. All rights reserved.
           Condition=" '$(GenerateRuntimeConfigurationFiles)' == 'true'"
           BeforeTargets="BuiltProjectOutputGroup">
     <ItemGroup>
-      <BuiltProjectOutputGroupOutput Include="$(ProjectRuntimeConfigFilePath)" FinalOutputPath="$(ProjectRuntimeConfigFilePath)" />
+      <BuiltProjectOutputGroupOutput Include="$(ProjectRuntimeConfigFilePath)" 
+                                     TargetPath="$(ProjectRuntimeConfigFileName)"
+                                     FinalOutputPath="$(ProjectRuntimeConfigFilePath)" />
     </ItemGroup>
   </Target>
 

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantRuntimeConfigInBuiltProjectOutputGroup.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantRuntimeConfigInBuiltProjectOutputGroup.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using Microsoft.NET.TestFramework;
+using Microsoft.NET.TestFramework.Assertions;
+using Microsoft.NET.TestFramework.Commands;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.NET.Build.Tests
+{
+    public class GivenThatWeWantRuntimeConfigInBuiltProjectOutputGroup : SdkTest
+    {
+        public GivenThatWeWantRuntimeConfigInBuiltProjectOutputGroup(ITestOutputHelper log) : base(log)
+        {
+        }
+
+        [Fact]
+        public void It_has_target_path_and_final_outputput_path_metadata()
+        {
+            const string targetFramework = "netcoreapp1.1";
+
+            var testAsset = _testAssetsManager
+                .CopyTestAsset("HelloWorld")
+                .WithSource()
+                .Restore(Log);
+
+            var command = new GetValuesCommand(
+                Log,
+                testAsset.TestRoot,
+                targetFramework,
+                "BuiltProjectOutputGroupOutput",
+                GetValuesCommand.ValueType.Item)
+            {
+                MetadataNames = { "FinalOutputPath", "TargetPath" },
+                DependsOnTargets = "BuiltProjectOutputGroup",
+            };
+
+            command.Execute().Should().Pass();
+
+            var outputDirectory = command.GetOutputDirectory(targetFramework);
+            var runtimeConfigFile = outputDirectory.File("HelloWorld.runtimeconfig.json");
+            var (_, metadata) = command.GetValuesWithMetadata().Single(i => i.value == runtimeConfigFile.FullName);
+
+            metadata.Count.Should().Be(2);
+            metadata.Should().Contain(KeyValuePair.Create("FinalOutputPath", runtimeConfigFile.FullName));
+            metadata.Should().Contain(KeyValuePair.Create("TargetPath", runtimeConfigFile.Name));
+        }
+    }
+}

--- a/src/Tests/Microsoft.NET.TestFramework/Assertions/DirectoryInfoExtensions.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/Assertions/DirectoryInfoExtensions.cs
@@ -20,5 +20,10 @@ namespace Microsoft.NET.TestFramework.Assertions
         {
             return new DirectoryInfo(Path.Combine(dir.FullName, name));
         }
+
+        public static FileInfo File(this DirectoryInfo dir, string name)
+        {
+            return new FileInfo(Path.Combine(dir.FullName, name));
+        }
     }
 }


### PR DESCRIPTION
Fix #2430 

NOTE: I have some open questions on the bug and in email, but I think this handles the 99% case. The 1% cases are if consumers care if TargetPath is in obj\ and bin\ or if the runtimeconfig.json path has been customized.