### PR TITLE
Consistently use PackagedShimOutputRootDirectory to set the path to generated shims

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.PackTool.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.PackTool.targets
@@ -91,6 +91,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <_ShimInputCacheFile>$([MSBuild]::NormalizePath($(MSBuildProjectDirectory), $(_ShimInputCacheFile)))</_ShimInputCacheFile>
     <_ShimCreatedSentinelFile Condition="'$(_ShimCreatedSentinelFile)' == ''">$(IntermediateOutputPath)$(MSBuildProjectName).shimcreated.sentinel</_ShimCreatedSentinelFile>
     <_ShimCreatedSentinelFile>$([MSBuild]::NormalizePath($(MSBuildProjectDirectory), $(_ShimCreatedSentinelFile)))</_ShimCreatedSentinelFile>
+    <PackagedShimOutputRootDirectory Condition=" '$(PackagedShimOutputRootDirectory)' == '' ">$(OutDir)</PackagedShimOutputRootDirectory>
   </PropertyGroup>
 
   <Target Name="GenerateShimsAssets"
@@ -99,10 +100,6 @@ Copyright (c) .NET Foundation. All rights reserved.
           Condition="'$(PackAsTool)' == 'true'"
           Inputs="@(_GenerateShimsAssetsInput)"
           Outputs="$(_ShimCreatedSentinelFile)">
-
-    <PropertyGroup>
-      <PackagedShimOutputRootDirectory Condition=" '$(PackagedShimOutputRootDirectory)' == '' ">$(OutDir)</PackagedShimOutputRootDirectory>
-    </PropertyGroup>
 
     <GenerateShims
       ApphostsForShimRuntimeIdentifiers="@(_ApphostsForShimRuntimeIdentifiers)"
@@ -135,7 +132,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <Target Name="_ComputeExpectedEmbeddedApphostPaths">
     <GetEmbeddedApphostPaths
-      PackagedShimOutputDirectory="$(OutDir)/shims/$(TargetFramework)"
+      PackagedShimOutputDirectory="$(PackagedShimOutputRootDirectory)/shims/$(TargetFramework)"
       ShimRuntimeIdentifiers="@(_PackAsToolShimRuntimeIdentifiers)"
       ToolCommandName="$(ToolCommandName)">
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -663,7 +663,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     </ItemGroup>
 
     <GetEmbeddedApphostPaths
-      PackagedShimOutputDirectory="$(OutDir)/shims/$(TargetFramework)"
+      PackagedShimOutputDirectory="$(PackagedShimOutputRootDirectory)/shims/$(TargetFramework)"
       ShimRuntimeIdentifiers="@(_PackAsToolShimRuntimeIdentifiers)"
       ToolCommandName="$(ToolCommandName)"
       >

--- a/src/Tests/Microsoft.NET.ToolPack.Tests/GivenThatWeWantToPackAToolProjectWithPackagedShim.cs
+++ b/src/Tests/Microsoft.NET.ToolPack.Tests/GivenThatWeWantToPackAToolProjectWithPackagedShim.cs
@@ -37,7 +37,7 @@ namespace Microsoft.NET.ToolPack.Tests
 
             var packCommand = new PackCommand(Log, helloWorldAsset.TestRoot);
 
-            packCommand.Execute();
+            packCommand.Execute().Should().Pass();
             _packageId = Path.GetFileNameWithoutExtension(packCommand.ProjectFile);
 
             return packCommand.GetNuGetPackage();
@@ -148,7 +148,7 @@ namespace Microsoft.NET.ToolPack.Tests
 
             var packCommand = new PackCommand(Log, helloWorldAsset.TestRoot);
 
-            packCommand.Execute();
+            packCommand.Execute().Should().Pass();
 
             string windowShimPath = Path.Combine(shimoutputPath, $"shims/netcoreapp2.1/win-x64/{_customToolCommandName}.exe");
             File.Exists(windowShimPath).Should().BeTrue($"Shim {windowShimPath} should exist");
@@ -167,7 +167,7 @@ namespace Microsoft.NET.ToolPack.Tests
 
             var packCommand = new PackCommand(Log, helloWorldAsset.TestRoot);
             var outputDirectory = packCommand.GetOutputDirectory("netcoreapp2.1");
-            packCommand.Execute();
+            packCommand.Execute().Should().Pass();
 
             string windowShimPath = Path.Combine(outputDirectory.FullName, $"shims/netcoreapp2.1/win-x64/{_customToolCommandName}.exe");
             File.Exists(windowShimPath).Should().BeTrue($"Shim {windowShimPath} should exist");
@@ -206,10 +206,10 @@ namespace Microsoft.NET.ToolPack.Tests
             _testRoot = helloWorldAsset.TestRoot;
 
             var packCommand = new PackCommand(Log, helloWorldAsset.TestRoot);
-            packCommand.Execute();
+            packCommand.Execute().Should().Pass();
 
             var cleanCommand = new CleanCommand(Log, helloWorldAsset.TestRoot);
-            cleanCommand.Execute();
+            cleanCommand.Execute().Should().Pass();
 
             var outputDirectory = packCommand.GetOutputDirectory("netcoreapp2.1");
             string windowShimPath = Path.Combine(outputDirectory.FullName, $"shims/netcoreapp2.1/win-x64/{_customToolCommandName}.exe");
@@ -250,11 +250,11 @@ namespace Microsoft.NET.ToolPack.Tests
             var testAsset = CreateTestAsset(multiTarget, "shim_with_no_build" + multiTarget);
 
             var buildCommand = new BuildCommand(Log, testAsset.TestRoot);
-            buildCommand.Execute();
+            buildCommand.Execute().Should().Pass();
 
             var packCommand = new PackCommand(Log, testAsset.TestRoot);
 
-            packCommand.Execute("/p:NoBuild=true");
+            packCommand.Execute("/p:NoBuild=true").Should().Pass();
             var nugetPackage = packCommand.GetNuGetPackage();
 
             using (var nupkgReader = new PackageArchiveReader(nugetPackage))
@@ -311,7 +311,7 @@ namespace Microsoft.NET.ToolPack.Tests
 
             var packCommand = new PackCommand(Log, helloWorldAsset.TestRoot);
 
-            packCommand.Execute();
+            packCommand.Execute().Should().Pass();
             var nugetPackage = packCommand.GetNuGetPackage();
 
             _packageId = Path.GetFileNameWithoutExtension(packCommand.ProjectFile);


### PR DESCRIPTION
Follow up to bug in https://github.com/dotnet/sdk/pull/2413

When PackagedShimOutputRootDirectory is set to a custom location, `dotnet pack` on a global tool project fails. E.g.

> C:\Users\namc\.dotnet\x64\sdk\2.2.100-preview2-009404\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.Publish.targets(169,5): error MSB3030: Could not copy the file "bin\Debug\netcoreapp2.1\/shims/netcoreapp2.1\win-x86\cowsay.exe" because it was not found. [C:\Users\namc\AppData\Local\Temp\korebuild\nu2in0u1.af5\src\Simple.CliTool\Simple.CliTool.csproj]