### PR TITLE
Implement building with an apphost by default.

### DIFF
--- a/src/Tasks/Common/Resources/Strings.resx
+++ b/src/Tasks/Common/Resources/Strings.resx
@@ -381,10 +381,6 @@ The following are names of parameters or literal values and should not be transl
     <value>NETSDK1065: Cannot find app host for {0}. {0} could be an invalid runtime identifier (RID). For more information about RID, see https://aka.ms/rid-catalog.</value>
     <comment>{StrBegin="NETSDK1065: "}</comment>
   </data>
-  <data name="CannotUseAppHostWithoutRuntimeIdentifier" xml:space="preserve">
-    <value>NETSDK1066: A RuntimeIdentifier must be specified to publish a framework-dependent application with an application host.</value>
-    <comment>{StrBegin="NETSDK1066: "}</comment>
-  </data>
   <data name="CannotUseSelfContainedWithoutAppHost" xml:space="preserve">
     <value>NETSDK1067: Self-contained applications are required to use the application host. Either set SelfContained to false or set UseAppHost to true.</value>
     <comment>{StrBegin="NETSDK1067: "}</comment>

--- a/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
@@ -42,11 +42,6 @@
         <target state="translated">NETSDK1001: Je potřeba zadat alespoň jednu možnou cílovou architekturu.</target>
         <note>{StrBegin="NETSDK1001: "}</note>
       </trans-unit>
-      <trans-unit id="CannotUseAppHostWithoutRuntimeIdentifier">
-        <source>NETSDK1066: A RuntimeIdentifier must be specified to publish a framework-dependent application with an application host.</source>
-        <target state="translated">NETSDK1066: RuntimeIdentifier musí být zadaný, aby se mohla publikovat aplikace závislá na architektuře s hostitelem aplikace.</target>
-        <note>{StrBegin="NETSDK1066: "}</note>
-      </trans-unit>
       <trans-unit id="CannotUseSelfContainedWithoutAppHost">
         <source>NETSDK1067: Self-contained applications are required to use the application host. Either set SelfContained to false or set UseAppHost to true.</source>
         <target state="translated">NETSDK1067: K používání hostitele aplikace se vyžadují samostatné (nezávislé) aplikace. Nastavte možnost SelfContained na false nebo nastavte UseAppHost na true.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.de.xlf
@@ -42,11 +42,6 @@
         <target state="translated">NETSDK1001: Geben Sie mindestens ein mögliches Zielframework an.</target>
         <note>{StrBegin="NETSDK1001: "}</note>
       </trans-unit>
-      <trans-unit id="CannotUseAppHostWithoutRuntimeIdentifier">
-        <source>NETSDK1066: A RuntimeIdentifier must be specified to publish a framework-dependent application with an application host.</source>
-        <target state="translated">NETSDK1066: Ein RuntimeIdentifier muss angegeben werden, um eine frameworkabhängige Anwendung bei einem Anwendungshost zu veröffentlichen.</target>
-        <note>{StrBegin="NETSDK1066: "}</note>
-      </trans-unit>
       <trans-unit id="CannotUseSelfContainedWithoutAppHost">
         <source>NETSDK1067: Self-contained applications are required to use the application host. Either set SelfContained to false or set UseAppHost to true.</source>
         <target state="translated">NETSDK1067: Eigenständige Anwendungen müssen den Anwendungshost verwenden. Legen Sie "SelfContained" auf FALSE oder "UseAppHost" auf TRUE fest.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.es.xlf
@@ -42,11 +42,6 @@
         <target state="translated">NETSDK1001: Debe especificarse al menos una plataforma de destino posible.</target>
         <note>{StrBegin="NETSDK1001: "}</note>
       </trans-unit>
-      <trans-unit id="CannotUseAppHostWithoutRuntimeIdentifier">
-        <source>NETSDK1066: A RuntimeIdentifier must be specified to publish a framework-dependent application with an application host.</source>
-        <target state="translated">NETSDK1066: Debe especificarse RuntimeIdentifier para publicar una aplicación dependiente del marco con un host de aplicación.</target>
-        <note>{StrBegin="NETSDK1066: "}</note>
-      </trans-unit>
       <trans-unit id="CannotUseSelfContainedWithoutAppHost">
         <source>NETSDK1067: Self-contained applications are required to use the application host. Either set SelfContained to false or set UseAppHost to true.</source>
         <target state="translated">NETSDK1067: Las aplicaciones independientes deben utilizar un host de aplicación. Establezca SelfContained en false o UseAppHost en true.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
@@ -42,11 +42,6 @@
         <target state="translated">NETSDK1001: Vous devez spécifier au moins un framework cible.</target>
         <note>{StrBegin="NETSDK1001: "}</note>
       </trans-unit>
-      <trans-unit id="CannotUseAppHostWithoutRuntimeIdentifier">
-        <source>NETSDK1066: A RuntimeIdentifier must be specified to publish a framework-dependent application with an application host.</source>
-        <target state="translated">NETSDK1066: Un RuntimeIdentifier doit être spécifié pour publier une application dépendante du framework avec un hôte d'application.</target>
-        <note>{StrBegin="NETSDK1066: "}</note>
-      </trans-unit>
       <trans-unit id="CannotUseSelfContainedWithoutAppHost">
         <source>NETSDK1067: Self-contained applications are required to use the application host. Either set SelfContained to false or set UseAppHost to true.</source>
         <target state="translated">NETSDK1067: Des applications autonomes sont obligatoires pour utiliser l'hôte d'application. Définissez SelfContained avec la valeur false ou UseAppHost avec la valeur true.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.it.xlf
@@ -42,11 +42,6 @@
         <target state="translated">NETSDK1001: è necessario specificare almeno un framework di destinazione possibile.</target>
         <note>{StrBegin="NETSDK1001: "}</note>
       </trans-unit>
-      <trans-unit id="CannotUseAppHostWithoutRuntimeIdentifier">
-        <source>NETSDK1066: A RuntimeIdentifier must be specified to publish a framework-dependent application with an application host.</source>
-        <target state="translated">NETSDK1066: è necessario specificare un elemento RuntimeIdentifier per pubblicare un'applicazione dipendente dal framework con un host applicazione.</target>
-        <note>{StrBegin="NETSDK1066: "}</note>
-      </trans-unit>
       <trans-unit id="CannotUseSelfContainedWithoutAppHost">
         <source>NETSDK1067: Self-contained applications are required to use the application host. Either set SelfContained to false or set UseAppHost to true.</source>
         <target state="translated">NETSDK1067: con le applicazioni complete è necessario usare l'host applicazione. Impostare SelfContained su false o UseAppHost su true.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
@@ -42,11 +42,6 @@
         <target state="translated">NETSDK1001: 可能性のあるターゲット フレームワークを少なくとも 1 つ指定する必要があります。</target>
         <note>{StrBegin="NETSDK1001: "}</note>
       </trans-unit>
-      <trans-unit id="CannotUseAppHostWithoutRuntimeIdentifier">
-        <source>NETSDK1066: A RuntimeIdentifier must be specified to publish a framework-dependent application with an application host.</source>
-        <target state="translated">NETSDK1066: RuntimeIdentifier を指定して、フレームワークに依存するアプリケーションをアプリケーション ホストを使用して発行する必要があります。</target>
-        <note>{StrBegin="NETSDK1066: "}</note>
-      </trans-unit>
       <trans-unit id="CannotUseSelfContainedWithoutAppHost">
         <source>NETSDK1067: Self-contained applications are required to use the application host. Either set SelfContained to false or set UseAppHost to true.</source>
         <target state="translated">NETSDK1067: アプリケーション ホストを使用するには、自己完結型のアプリケーションが必要です。SelfContained を false に設定するか、UseAppHost を true に設定してください。</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
@@ -42,11 +42,6 @@
         <target state="translated">NETSDK1001: 가능한 대상 프레임워크를 하나 이상 지정해야 합니다.</target>
         <note>{StrBegin="NETSDK1001: "}</note>
       </trans-unit>
-      <trans-unit id="CannotUseAppHostWithoutRuntimeIdentifier">
-        <source>NETSDK1066: A RuntimeIdentifier must be specified to publish a framework-dependent application with an application host.</source>
-        <target state="translated">NETSDK1066: 응용 프로그램 호스트와 함께 프레임워크 종속 응용 프로그램을 게시하려면 RuntimeIdentifier를 지정해야 합니다.</target>
-        <note>{StrBegin="NETSDK1066: "}</note>
-      </trans-unit>
       <trans-unit id="CannotUseSelfContainedWithoutAppHost">
         <source>NETSDK1067: Self-contained applications are required to use the application host. Either set SelfContained to false or set UseAppHost to true.</source>
         <target state="translated">NETSDK1067: 응용 프로그램 호스트를 사용하려면 자체 포함 응용 프로그램이 필요합니다. SelfContained를 false로 설정하거나 UseAppHost를 true로 설정하세요.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
@@ -42,11 +42,6 @@
         <target state="translated">NETSDK1001: Należy określić co najmniej jedną możliwą platformę docelową.</target>
         <note>{StrBegin="NETSDK1001: "}</note>
       </trans-unit>
-      <trans-unit id="CannotUseAppHostWithoutRuntimeIdentifier">
-        <source>NETSDK1066: A RuntimeIdentifier must be specified to publish a framework-dependent application with an application host.</source>
-        <target state="translated">NETSDK1066: Należy określić identyfikator RuntimeIdentifier, aby opublikować aplikację zależną od platformy za pomocą hosta aplikacji.</target>
-        <note>{StrBegin="NETSDK1066: "}</note>
-      </trans-unit>
       <trans-unit id="CannotUseSelfContainedWithoutAppHost">
         <source>NETSDK1067: Self-contained applications are required to use the application host. Either set SelfContained to false or set UseAppHost to true.</source>
         <target state="translated">NETSDK1067: Aplikacje autonomiczne muszą korzystać z hosta aplikacji. Ustaw parametr SelfContained na wartość false lub parametr UseAppHost na wartość true.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
@@ -42,11 +42,6 @@
         <target state="translated">NETSDK1001: É necessário especificar pelo menos uma estrutura de destino possível.</target>
         <note>{StrBegin="NETSDK1001: "}</note>
       </trans-unit>
-      <trans-unit id="CannotUseAppHostWithoutRuntimeIdentifier">
-        <source>NETSDK1066: A RuntimeIdentifier must be specified to publish a framework-dependent application with an application host.</source>
-        <target state="translated">NETSDK1066: um RuntimeIdentifier deve ser especificado para publicar um aplicativo dependente de estrutura com um host do aplicativo.</target>
-        <note>{StrBegin="NETSDK1066: "}</note>
-      </trans-unit>
       <trans-unit id="CannotUseSelfContainedWithoutAppHost">
         <source>NETSDK1067: Self-contained applications are required to use the application host. Either set SelfContained to false or set UseAppHost to true.</source>
         <target state="translated">NETSDK1067: os aplicativos independentes são necessários para utilizar o host do aplicativo. Defina SelfContained como falso ou defina UseAppHost como verdadeiro.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
@@ -42,11 +42,6 @@
         <target state="translated">NETSDK1001: необходимо указать хотя бы одну целевую платформу.</target>
         <note>{StrBegin="NETSDK1001: "}</note>
       </trans-unit>
-      <trans-unit id="CannotUseAppHostWithoutRuntimeIdentifier">
-        <source>NETSDK1066: A RuntimeIdentifier must be specified to publish a framework-dependent application with an application host.</source>
-        <target state="translated">NETSDK1066: для публикации зависящего от платформы приложения на узле приложения необходимо указать RuntimeIdentifierentifier.</target>
-        <note>{StrBegin="NETSDK1066: "}</note>
-      </trans-unit>
       <trans-unit id="CannotUseSelfContainedWithoutAppHost">
         <source>NETSDK1067: Self-contained applications are required to use the application host. Either set SelfContained to false or set UseAppHost to true.</source>
         <target state="translated">NETSDK1067: для использования узла приложений требуются автономные приложения. Задайте свойству SelfContained значение false или задайте свойству UseAppHost значение true.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
@@ -102,11 +102,6 @@
         <target state="new">NETSDK1013: The TargetFramework value '{0}' was not recognized. It may be misspelled. If not, then the TargetFrameworkIdentifier and/or TargetFrameworkVersion properties must be specified explicitly.</target>
         <note>{StrBegin="NETSDK1013: "}</note>
       </trans-unit>
-      <trans-unit id="CannotUseAppHostWithoutRuntimeIdentifier">
-        <source>NETSDK1066: A RuntimeIdentifier must be specified to publish a framework-dependent application with an application host.</source>
-        <target state="new">NETSDK1066: A RuntimeIdentifier must be specified to publish a framework-dependent application with an application host.</target>
-        <note>{StrBegin="NETSDK1066: "}</note>
-      </trans-unit>
       <trans-unit id="CannotUseSelfContainedWithoutAppHost">
         <source>NETSDK1067: Self-contained applications are required to use the application host. Either set SelfContained to false or set UseAppHost to true.</source>
         <target state="new">NETSDK1067: Self-contained applications are required to use the application host. Either set SelfContained to false or set UseAppHost to true.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
@@ -42,11 +42,6 @@
         <target state="translated">NETSDK1001: 必须指定至少一个可能的目标框架。</target>
         <note>{StrBegin="NETSDK1001: "}</note>
       </trans-unit>
-      <trans-unit id="CannotUseAppHostWithoutRuntimeIdentifier">
-        <source>NETSDK1066: A RuntimeIdentifier must be specified to publish a framework-dependent application with an application host.</source>
-        <target state="translated">NETSDK1066: 必须指定一个 RuntimeIdentifier，以通过应用程序主机发布框架依赖型应用程序。</target>
-        <note>{StrBegin="NETSDK1066: "}</note>
-      </trans-unit>
       <trans-unit id="CannotUseSelfContainedWithoutAppHost">
         <source>NETSDK1067: Self-contained applications are required to use the application host. Either set SelfContained to false or set UseAppHost to true.</source>
         <target state="translated">NETSDK1067: 需要自包含应用程序才能使用应用程序主机。将 SelfContained 设置为 false，或者将 UseAppHost 设置为 true。</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
@@ -42,11 +42,6 @@
         <target state="translated">NETSDK1001: 至少必須指定一個可能的目標架構。</target>
         <note>{StrBegin="NETSDK1001: "}</note>
       </trans-unit>
-      <trans-unit id="CannotUseAppHostWithoutRuntimeIdentifier">
-        <source>NETSDK1066: A RuntimeIdentifier must be specified to publish a framework-dependent application with an application host.</source>
-        <target state="translated">NETSDK1066: 必須指定 RuntimeIdentifier，才可發行具有應用程式主機且與架構相依的應用程式。</target>
-        <note>{StrBegin="NETSDK1066: "}</note>
-      </trans-unit>
       <trans-unit id="CannotUseSelfContainedWithoutAppHost">
         <source>NETSDK1067: Self-contained applications are required to use the application host. Either set SelfContained to false or set UseAppHost to true.</source>
         <target state="translated">NETSDK1067: 需要獨立式應用程式，才可使用該應用程式主機。請將 SelfContained 設定為 False，或是將 UseAppHost 設定為 True。</target>

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenThatWeHaveErrorCodes.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenThatWeHaveErrorCodes.cs
@@ -20,6 +20,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
         {
             // Put deleted numeric error codes here. 
             // For example, if NETSDK1001 is deleted, add 1001 to this list.
+            1066,
         };
 
         [Fact]
@@ -29,7 +30,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
 
             foreach (var (key, message) in GetMessages())
             {
-                // NB: if we ever need strings that don't have error codes (say because they are not sent to MSBuild), 
+                // NB: if we ever need strings that don't have error codes (say because they are not sent to MSBuild),
                 //     we should use a separate .resx file so that we can preserve this enforcement.
                 var match = Regex.Match(message, "^NETSDK([0-9]{4}): ");
                 match.Success
@@ -47,7 +48,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 int code = _firstCode + i;
                 codes.Contains(code)
                      .Should()
-                     .BeTrue(because: $"error codes should not be skipped (NETSDK{code} was not found)");
+                     .BeTrue(because: $"error codes should not be skipped (NETSDK{code} was not found; add to the deleted codes list if intentionally deleted)");
             }
         }
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/AppHost.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/AppHost.cs
@@ -37,25 +37,22 @@ namespace Microsoft.NET.Build.Tasks
             string intermediateAssembly = null,
             Logger log = null)
         {
-            var hostExtension = Path.GetExtension(appHostSourceFilePath);
-            var appbaseName = Path.GetFileNameWithoutExtension(appBinaryFilePath);
             var bytesToWrite = Encoding.UTF8.GetBytes(appBinaryFilePath);
-            var destinationDirectory = new FileInfo(appHostDestinationFilePath).Directory.FullName;
-
             if (bytesToWrite.Length > 1024)
             {
                 throw new BuildErrorException(Strings.FileNameIsTooLong, appBinaryFilePath);
             }
 
+            var destinationDirectory = new FileInfo(appHostDestinationFilePath).Directory.FullName;
             if (!Directory.Exists(destinationDirectory))
             {
                 Directory.CreateDirectory(destinationDirectory);
             }
 
-            // Copy AppHostSourcePath to ModifiedAppHostPath so it inherits the same attributes\permissions.
+            // Copy apphost to destination path so it inherits the same attributes/permissions.
             File.Copy(appHostSourceFilePath, appHostDestinationFilePath, overwrite: true);
 
-            // Re-write ModifiedAppHostPath with the proper contents.
+            // Re-write the destination apphost with the proper contents.
             bool appHostIsPEImage = false;
             using (var memoryMappedFile = MemoryMappedFile.CreateFromFile(appHostDestinationFilePath))
             {

--- a/src/Tasks/Microsoft.NET.Build.Tasks/CreateAppHost.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/CreateAppHost.cs
@@ -7,8 +7,8 @@ using System.IO;
 namespace Microsoft.NET.Build.Tasks
 {
     /// <summary>
-    /// Creates the AppHost.exe to be used by the published app.
-    /// This embeds the app dll path into the AppHost.exe and performs additional customizations as requested.
+    /// Creates the runtime host to be used for an application.
+    /// This embeds the application DLL path into the apphost and performs additional customizations as requested.
     /// </summary>
     public class CreateAppHost : TaskBase
     {
@@ -28,9 +28,6 @@ namespace Microsoft.NET.Build.Tasks
 
         protected override void ExecuteCore()
         {
-            var hostExtension = Path.GetExtension(AppHostSourcePath);
-            var appbaseName = Path.GetFileNameWithoutExtension(AppBinaryName);
-
             AppHost.Create(
                 AppHostSourcePath,
                 AppHostDestinationPath,

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageAssets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageAssets.cs
@@ -55,6 +55,11 @@ namespace Microsoft.NET.Build.Tasks
         public string RuntimeIdentifier { get; set; }
 
         /// <summary>
+        /// The runtime identifier for the default apphost.
+        /// </summary>
+        public string DefaultAppHostRuntimeIdentifier { get; set; }
+
+        /// <summary>
         /// Do not write package assets cache to disk nor attempt to read previous cache from disk.
         /// </summary>
         public bool DisablePackageAssetsCache { get; set; }
@@ -349,6 +354,7 @@ namespace Microsoft.NET.Build.Tasks
                     writer.Write(ProjectLanguage ?? "");
                     writer.Write(ProjectPath);
                     writer.Write(RuntimeIdentifier ?? "");
+                    writer.Write(DefaultAppHostRuntimeIdentifier ?? "");
                     if (ShimRuntimeIdentifiers != null)
                     {
                         foreach (var r in ShimRuntimeIdentifiers)
@@ -872,7 +878,7 @@ namespace Microsoft.NET.Build.Tasks
                             if (!hasTwoPeriods(expectedVersion))
                             {
                                 expectedVersion += ".0";
-                            }                        
+                            }
 
                             if (restoredVersion != expectedVersion)
                             {
@@ -892,6 +898,26 @@ namespace Microsoft.NET.Build.Tasks
                 WriteItems(
                     _runtimeTarget,
                     package => package.NativeLibraries);
+
+                WriteDefaultNativeApphostAsset();
+            }
+
+            private void WriteDefaultNativeApphostAsset()
+            {
+                if (string.IsNullOrEmpty(_task.DefaultAppHostRuntimeIdentifier))
+                {
+                    return;
+                }
+
+                var assetPathAndLibrary = FindApphostInRuntimeTarget(
+                    _task.DotNetAppHostExecutableNameWithoutExtension + ExecutableExtension.ForRuntimeIdentifier(_task.DefaultAppHostRuntimeIdentifier),
+                    _lockFile.GetTargetAndThrowIfNotFound(
+                        NuGetUtils.ParseFrameworkName(_task.TargetFrameworkMoniker),
+                        _task.DefaultAppHostRuntimeIdentifier
+                    )
+                );
+
+                WriteItem(assetPathAndLibrary.Item1, assetPathAndLibrary.Item2);
             }
 
             private void WriteApphostsForShimRuntimeIdentifiers()

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -18,7 +18,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <_GetChildProjectCopyToPublishDirectoryItems Condition="'$(_GetChildProjectCopyToPublishDirectoryItems)' == ''">true</_GetChildProjectCopyToPublishDirectoryItems>
 
     <!-- publishing with the apphost should publish the native host as $(AssemblyName).exe -->
-    <DeployAppHost Condition="'$(DeployAppHost)' == '' and '$(_IsExecutable)' == 'true' and '$(RuntimeIdentifier)' != '' and '$(UseAppHost)' == 'true'">true</DeployAppHost>
+    <DeployAppHost Condition="'$(DeployAppHost)' == '' and '$(_IsExecutable)' == 'true' and '$(UseAppHost)' == 'true'">true</DeployAppHost>
   
     <IsPublishable Condition="'$(IsPublishable)'==''">true</IsPublishable>
   </PropertyGroup>
@@ -625,7 +625,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     ============================================================
                                         DeployAppHost
 
-    Deploys the host to run the stand alone app and ensures it matches the app name
+    Deploys the host to run the app and ensures it matches the app name.
     ============================================================
     -->
 
@@ -640,10 +640,9 @@ Copyright (c) .NET Foundation. All rights reserved.
       <ResolvedFileToRemove  Include ="%(ResolvedFileToPublish.Identity)" Condition="'%(ResolvedFileToPublish.RelativePath)' == '$(_DotNetHostExecutableName)' Or '%(ResolvedFileToPublish.RelativePath)' == '$(_DotNetAppHostExecutableName)'"/>
       <ResolvedFileToPublish Remove ="%(ResolvedFileToRemove.Identity)"/>
 
-      <ResolvedFileToPublish Include="%(NativeAppHostNETCore.Identity)">
+      <ResolvedFileToPublish Include="%(_NativeAppHostNETCore.Identity)">
         <RelativePath>$(AssemblyName)$(_NativeExecutableExtension)</RelativePath>
       </ResolvedFileToPublish>
-
 
     </ItemGroup>
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets
@@ -107,7 +107,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' and '$(HasRuntimeOutput)' == 'true'">
     <SelfContained Condition="'$(SelfContained)' == '' and '$(RuntimeIdentifier)' != ''">true</SelfContained>
     <SelfContained Condition="'$(SelfContained)' == ''">false</SelfContained>
-    <UseAppHost Condition="'$(UseAppHost)' == '' and ('$(SelfContained)' == 'true' or ('$(RuntimeIdentifier)' != '' and '$(_TargetFrameworkVersionWithoutV)' >= '2.1'))">true</UseAppHost>
+    <UseAppHost Condition="'$(UseAppHost)' == '' and ('$(SelfContained)' == 'true' or '$(_TargetFrameworkVersionWithoutV)' >= '2.1')">true</UseAppHost>
     <UseAppHost Condition="'$(UseAppHost)' == ''">false</UseAppHost>
   </PropertyGroup>
 
@@ -117,9 +117,6 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <NETSdkError Condition="'$(SelfContained)' == 'true' and '$(RuntimeIdentifier)' == ''"
                  ResourceName="CannotHaveSelfContainedWithoutRuntimeIdentifier" />
-
-    <NETSdkError Condition="'$(UseAppHost)' == 'true' and '$(RuntimeIdentifier)' == ''"
-                 ResourceName="CannotUseAppHostWithoutRuntimeIdentifier" />
 
     <NETSdkError Condition="'$(SelfContained)' == 'true' and '$(UseAppHost)' != 'true'"
                  ResourceName="CannotUseSelfContainedWithoutAppHost" />
@@ -170,7 +167,7 @@ Copyright (c) .NET Foundation. All rights reserved.
           AfterTargets="ResolvePackageAssets"
           BeforeTargets="CoreCompile"
           Condition="'$(_UsingDefaultPlatformTarget)' == 'true' and
-                     '$(_UsingDefaultRuntimeIdentifier)' == 'true' and 
+                     '$(_UsingDefaultRuntimeIdentifier)' == 'true' and
                      '@(NativeCopyLocalItems)' == ''">
     <PropertyGroup>
       <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.Common.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.Common.targets
@@ -36,6 +36,10 @@ Copyright (c) .NET Foundation. All rights reserved.
   <PropertyGroup>
     <_IsExecutable Condition="'$(OutputType)' == 'Exe' or '$(OutputType)'=='WinExe'">true</_IsExecutable>
     <HasRuntimeOutput Condition="'$(_UsingDefaultForHasRuntimeOutput)' == 'true'">$(_IsExecutable)</HasRuntimeOutput>
+
+    <!-- Only use the default apphost if building without a RID and without a deps file path (used by GenerateDeps.proj for CLI tools). -->
+    <DefaultAppHostRuntimeIdentifier Condition="'$(DefaultAppHostRuntimeIdentifier)' == '' and '$(RuntimeIdentifier)' == '' and '$(UseAppHost)' == 'true' and '$(_IsExecutable)' == 'true' and '$(ProjectDepsFilePath)' == ''">$(NETCoreSdkRuntimeIdentifier)</DefaultAppHostRuntimeIdentifier>
+    <RuntimeIdentifiers Condition="'$(DefaultAppHostRuntimeIdentifier)' != ''">$(RuntimeIdentifiers);$(DefaultAppHostRuntimeIdentifier)</RuntimeIdentifiers>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(DotnetCliToolTargetFramework)' == '' And '$(BundledNETCoreAppTargetFrameworkVersion)' != ''">

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -66,7 +66,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <_NativeLibraryExtension Condition="'$(_NativeLibraryExtension)' == '' and $(RuntimeIdentifier.StartsWith('osx'))">.dylib</_NativeLibraryExtension>
     <_NativeLibraryExtension Condition="'$(_NativeLibraryExtension)' == ''">.so</_NativeLibraryExtension>
 
-    <_NativeExecutableExtension Condition="'$(_NativeExecutableExtension)' == '' and $(RuntimeIdentifier.StartsWith('win'))">.exe</_NativeExecutableExtension>
+    <_NativeExecutableExtension Condition="'$(_NativeExecutableExtension)' == '' and ($(RuntimeIdentifier.StartsWith('win')) or $(DefaultAppHostRuntimeIdentifier.StartsWith('win')))">.exe</_NativeExecutableExtension>
 
     <_DotNetHostExecutableName>dotnet$(_NativeExecutableExtension)</_DotNetHostExecutableName>
     <_DotNetAppHostExecutableNameWithoutExtension>apphost</_DotNetAppHostExecutableNameWithoutExtension>
@@ -284,18 +284,18 @@ Copyright (c) .NET Foundation. All rights reserved.
   <UsingTask TaskName="CreateAppHost" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
   <Target Name="_CreateAppHost"
           Inputs="@(IntermediateAssembly)"
-          Outputs="@(NativeAppHostNETCore)"
+          Outputs="@(_NativeAppHostNETCore)"
           DependsOnTargets="_GetAppHostPaths;CoreCompile"
           Condition="'$(ComputeNETCoreBuildOutputFiles)' == 'true'">
     <PropertyGroup>
-      <_UseWindowsGraphicalUserInterface Condition="$(RuntimeIdentifier.StartsWith('win')) and '$(OutputType)'=='WinExe'">true</_UseWindowsGraphicalUserInterface>
+      <_UseWindowsGraphicalUserInterface Condition="($(RuntimeIdentifier.StartsWith('win')) or $(DefaultAppHostRuntimeIdentifier.StartsWith('win'))) and '$(OutputType)'=='WinExe'">true</_UseWindowsGraphicalUserInterface>
     </PropertyGroup>
-    <CreateAppHost AppHostSourcePath="@(NativeRestoredAppHostNETCore)"
-                   AppHostDestinationPath="@(NativeAppHostNETCore)"
+    <CreateAppHost AppHostSourcePath="@(_NativeRestoredAppHostNETCore)"
+                   AppHostDestinationPath="@(_NativeAppHostNETCore)"
                    AppBinaryName="$(AssemblyName)$(TargetExt)"
                    IntermediateAssembly="@(IntermediateAssembly->'%(FullPath)')"
                    WindowsGraphicalUserInterface="$(_UseWindowsGraphicalUserInterface)"
-                   Condition="'@(NativeRestoredAppHostNETCore)' != '' " />
+                   Condition="'@(_NativeRestoredAppHostNETCore)' != ''" />
   </Target>
 
   <!--
@@ -307,20 +307,17 @@ Copyright (c) .NET Foundation. All rights reserved.
     ============================================================
      -->
   <Target Name="_GetAppHostPaths"
-          DependsOnTargets="ResolvePackageAssets">
+          DependsOnTargets="ResolvePackageAssets"
+          Condition="'$(UseAppHost)' == 'true' and '$(_IsExecutable)' == 'true'">
     <ItemGroup>
-      <NativeRestoredAppHostNETCore Include="@(NativeCopyLocalItems)"
-                                    Condition="'%(NativeCopyLocalItems.FileName)%(NativeCopyLocalItems.Extension)' == '$(_DotNetAppHostExecutableName)'"/>
+      <_NativeRestoredAppHostNETCore Include="@(NativeCopyLocalItems)"
+                                     Condition="'%(NativeCopyLocalItems.FileName)%(NativeCopyLocalItems.Extension)' == '$(_DotNetAppHostExecutableName)'"/>
+      <_NativeAppHostNETCore Include="@(_NativeRestoredAppHostNETCore->'$(IntermediateOutputPath)$(AssemblyName)%(Extension)')" />
     </ItemGroup>
 
-    <NETSdkError Condition="'@(NativeRestoredAppHostNETCore->Count())' &gt; 1"
+    <NETSdkError Condition="'@(_NativeRestoredAppHostNETCore->Count())' > 1"
                  ResourceName="MultipleFilesResolved"
                  FormatArguments="$(_DotNetAppHostExecutableName)" />
-
-    <ItemGroup>
-      <NativeAppHostNETCore Condition="'@(NativeRestoredAppHostNETCore)' != ''"
-                            Include="@(NativeRestoredAppHostNETCore->'$(IntermediateOutputPath)\$(AssemblyName)%(Extension)')" />
-    </ItemGroup>
   </Target>
 
   <!--
@@ -332,55 +329,37 @@ Copyright (c) .NET Foundation. All rights reserved.
     -->
   <Target Name="_ComputeNETCoreBuildOutputFiles"
           DependsOnTargets="_GetAppHostPaths"
-          BeforeTargets="GetCopyToOutputDirectoryItems"
+          BeforeTargets="AssignTargetPaths"
           Condition="'$(ComputeNETCoreBuildOutputFiles)' == 'true'">
 
-    <!--
-    During "build" and "run" of .NET Core projects, the assemblies coming from NuGet packages
-    are loaded from the NuGet cache. But, in order for a self-contained app to be runnable,
-    it requires a host in the output directory to load the app.
-    During "publish", all required assets are copied to the publish directory.
-    -->
-    <ItemGroup Condition="'$(UseAppHost)' == 'true' and '$(RuntimeIdentifier)' != '' and '$(_IsExecutable)' == 'true'">
-      <NativeNETCoreCopyLocalItems Include="@(NativeCopyLocalItems)"
-                                   Condition="'$(SelfContained)' == 'true' and
-                                              ('%(NativeCopyLocalItems.FileName)%(NativeCopyLocalItems.Extension)' == '$(_DotNetHostPolicyLibraryName)' or
-                                               '%(NativeCopyLocalItems.FileName)%(NativeCopyLocalItems.Extension)' == '$(_DotNetHostFxrLibraryName)')" />
-    </ItemGroup>
-
-    <ItemGroup Condition="'@(NativeAppHostNETCore)' == '' ">
-      <NativeAppHostNETCore Include="@(NativeCopyLocalItems)"
+    <!-- Fallback to renaming the dotnet host if there is no apphost for self-contained builds. -->
+    <ItemGroup Condition="'@(_NativeAppHostNETCore)' == '' and '$(SelfContained)' == 'true'">
+      <_NativeAppHostNETCore Include="@(NativeCopyLocalItems)"
                             Condition="'%(NativeCopyLocalItems.FileName)%(NativeCopyLocalItems.Extension)' == '$(_DotNetHostExecutableName)'" />
     </ItemGroup>
 
-    <NETSdkError Condition="'@(NativeAppHostNETCore->Count())' &gt; 1"
-                 ResourceName="MultipleFilesResolved"
-                 FormatArguments="@(NativeAppHostNETCore)" />
-
-    <ItemGroup Condition="'@(NativeAppHostNETCore)' != '' ">
-      <NativeNETCoreCopyLocalItems Include="@(NativeAppHostNETCore)">
-        <!-- Rename the host executable to the app's name -->
-        <Link>$(AssemblyName)%(NativeAppHostNETCore.Extension)</Link>
-      </NativeNETCoreCopyLocalItems>
-    </ItemGroup>
-
-    <ItemGroup Condition="'$(UseAppHost)' == 'true' and '$(RuntimeIdentifier)' != '' and '$(_IsExecutable)' == 'true'">
-      <AllNETCoreCopyLocalItems Include="@(NativeNETCoreCopyLocalItems)">
+    <ItemGroup Condition="'@(_NativeAppHostNETCore)' != ''">
+      <!--
+        TODO: Revisit for https://github.com/dotnet/cli/issues/10061 when doing "self-contained" builds
+        During "build" and "run" of .NET Core projects, the assemblies coming from NuGet packages
+        are loaded from the NuGet cache. But, in order for a self-contained app to be runnable,
+        it requires a host in the output directory to load the app.
+        During "publish", all required assets are copied to the publish directory.
+      -->
+      <None Include="@(NativeCopyLocalItems)"
+            Condition="'$(SelfContained)' == 'true' and
+                       ('%(NativeCopyLocalItems.FileName)%(NativeCopyLocalItems.Extension)' == '$(_DotNetHostPolicyLibraryName)' or
+                        '%(NativeCopyLocalItems.FileName)%(NativeCopyLocalItems.Extension)' == '$(_DotNetHostFxrLibraryName)')">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         <CopyToPublishDirectory>Never</CopyToPublishDirectory>
-      </AllNETCoreCopyLocalItems>
-    </ItemGroup>
-    <ItemGroup>
-      <!-- Use 'None' so we can rename files using the 'Link' metadata as necessary -->
-      <None Include="@(AllNETCoreCopyLocalItems)" />
-    </ItemGroup>
-    <AssignTargetPath Files="@(AllNETCoreCopyLocalItems)" RootFolder="$(MSBuildProjectDirectory)">
-      <Output TaskParameter="AssignedFiles" ItemName="_AllNETCoreCopyLocalItemsWithTargetPath" />
-    </AssignTargetPath>
-    <ItemGroup>
-      <_NoneWithTargetPath Include="@(_AllNETCoreCopyLocalItemsWithTargetPath)" />
-    </ItemGroup>
+      </None>
 
+      <None Include="@(_NativeAppHostNETCore)">
+        <Link>$(AssemblyName)$(_NativeExecutableExtension)</Link>
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        <CopyToPublishDirectory>Never</CopyToPublishDirectory>
+      </None>
+    </ItemGroup>
   </Target>
 
   <!--

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.PackageDependencyResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.PackageDependencyResolution.targets
@@ -213,6 +213,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       EmitAssetsLogMessages="$(EmitAssetsLogMessages)"
       TargetFrameworkMoniker="$(NuGetTargetMoniker)"
       RuntimeIdentifier="$(RuntimeIdentifier)"
+      DefaultAppHostRuntimeIdentifier="$(DefaultAppHostRuntimeIdentifier)"
       MarkPackageReferencesAsExternallyResolved="$(MarkPackageReferencesAsExternallyResolved)"
       DisablePackageAssetsCache="$(DisablePackageAssetsCache)"
       DisableFrameworkAssemblies="$(DisableLockFileFrameworks)"

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildANetCoreApp.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildANetCoreApp.cs
@@ -253,6 +253,48 @@ namespace Microsoft.NET.Build.Tests
         }
 
         [Theory]
+        [InlineData("netcoreapp2.1")]
+        public void It_builds_a_runnable_apphost_by_default(string targetFramework)
+        {
+            var testAsset = _testAssetsManager
+                .CopyTestAsset("HelloWorld")
+                .WithSource();
+
+            var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot));
+            buildCommand
+                .Execute(new string[] {
+                    "/restore",
+                    $"/p:TargetFramework={targetFramework}",
+                    $"/p:NETCoreSdkRuntimeIdentifier={EnvironmentInfo.GetCompatibleRid(targetFramework)}"
+                })
+                .Should()
+                .Pass();
+
+            var outputDirectory = buildCommand.GetOutputDirectory(targetFramework);
+            var hostExecutable = $"HelloWorld{Constants.ExeSuffix}";
+
+            outputDirectory.Should().OnlyHaveFiles(new[] {
+                hostExecutable,
+                "HelloWorld.dll",
+                "HelloWorld.pdb",
+                "HelloWorld.deps.json",
+                "HelloWorld.runtimeconfig.dev.json",
+                "HelloWorld.runtimeconfig.json",
+            });
+
+            Command.Create(Path.Combine(outputDirectory.FullName, hostExecutable), new string[] {})
+                .EnvironmentVariable(
+                    Environment.Is64BitProcess ? "DOTNET_ROOT" : "DOTNET_ROOT(x86)",
+                    Path.GetDirectoryName(TestContext.Current.ToolsetUnderTest.DotNetHostPath))
+                .CaptureStdOut()
+                .Execute()
+                .Should()
+                .Pass()
+                .And
+                .HaveStdOutContaining("Hello World!");
+        }
+
+        [Theory]
         [InlineData("netcoreapp2.0")]
         [InlineData("netcoreapp2.1")]
         public void It_runs_the_app_from_the_output_folder(string targetFramework)

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAFrameworkDependentApp.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAFrameworkDependentApp.cs
@@ -98,25 +98,6 @@ namespace Microsoft.NET.Publish.Tests
         }
 
         [Fact]
-        public void It_errors_when_using_app_host_without_rid()
-        {
-            var testAsset = _testAssetsManager
-                .CopyTestAsset(TestProjectName)
-                .WithSource();
-
-            var publishCommand = new PublishCommand(Log, testAsset.TestRoot);
-            publishCommand
-                .Execute(
-                    "/p:SelfContained=false",
-                    "/p:UseAppHost=true",
-                    "/p:TargetFramework=netcoreapp2.2")
-                .Should()
-                .Fail()
-                .And
-                .HaveStdOutContaining(Strings.CannotUseAppHostWithoutRuntimeIdentifier);
-        }
-
-        [Fact]
         public void It_errors_when_using_app_host_with_older_target_framework()
         {
             var runtimeIdentifier = RuntimeEnvironment.GetRuntimeIdentifier();


### PR DESCRIPTION
This commit implements building with an apphost by default, without specifying
a `RuntimeIdentifier`.

This works by using the runtime identifier of the SDK to restore the apphost
package.  The apphost will be the only native asset copied to the build output.

Fixes dotnet/cli#6237.