### PR TITLE
Fix issue where ASP.NET PackageReferences with implicit versions had incorrect PrivateAssets value

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.targets
@@ -97,12 +97,12 @@ Copyright (c) .NET Foundation. All rights reserved.
   <ItemGroup>
     <!-- Set implicit metadata on ASP.NET package references -->
     <PackageReference Update="Microsoft.AspNetCore.App">
-      <PrivateAssets Condition="'%(PackageReference.Version)' == ''">true</PrivateAssets>
+      <PrivateAssets Condition="'%(PackageReference.Version)' == ''">all</PrivateAssets>
       <Publish Condition="'%(PackageReference.Version)' == ''">true</Publish>
     </PackageReference>
   
     <PackageReference Update="Microsoft.AspNetCore.All">
-      <PrivateAssets Condition="'%(PackageReference.Version)' == ''">true</PrivateAssets>
+      <PrivateAssets Condition="'%(PackageReference.Version)' == ''">all</PrivateAssets>
       <Publish Condition="'%(PackageReference.Version)' == ''">true</Publish>
     </PackageReference>
   

--- a/src/Tests/Microsoft.NET.Pack.Tests/GivenThatThereAreImplicitPackageReferences.cs
+++ b/src/Tests/Microsoft.NET.Pack.Tests/GivenThatThereAreImplicitPackageReferences.cs
@@ -158,6 +158,27 @@ namespace Microsoft.NET.Pack.Tests
             dependencies.Should().BeEmpty();
         }
 
+        [Theory]
+        [InlineData("Microsoft.AspNetCore.App")]
+        [InlineData("Microsoft.AspNetCore.All")]
+        public void Package_an_aspnetcore_2_1_app_does_not_include_the_implicit_dependency(string packageId)
+        {
+            TestProject testProject = new TestProject()
+            {
+                Name = "PackAspNetCoreApp21App",
+                IsSdkProject = true,
+                TargetFrameworks = "netcoreapp2.1",
+                IsExe = true
+            };
+
+            testProject.PackageReferences.Add(new TestPackageReference(packageId, ""));
+
+            var dependencies = PackAndGetDependencies(testProject);
+
+            dependencies.Should().BeEmpty();
+
+        }
+
         [Fact]
         public void Packing_a_netcoreapp_2_0_DotnetCliTool_app_includes_the_implicit_dependency()
         {


### PR DESCRIPTION
In #2533, I set the `PrivateAssets` metadata for ASP.NET Core `PackageReferences` to `true`, when it should have been `all`.  (This is what it was when the logic was in the web SDK: https://github.com/aspnet/websdk/blob/ee152187bf59ef13e214b8329773a81da66e5e47/src/Web/Microsoft.NET.Sdk.Web.Targets/Sdk.DefaultItems.targets#L132)

This would cause a failure if a project that didn't have an ASP.NET Core PackageReference referenced one that did.  The .props file from the package which set the `MicrosoftNETPlatformLibrary` to the ASP.NET package would then flow, causing a failure in the referencing project's GenerateDepsFile task.

FYI @natemcmaster 