### PR TITLE
Ensure inputs exist for CreateAppHost task.

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -283,10 +283,10 @@ Copyright (c) .NET Foundation. All rights reserved.
      -->
   <UsingTask TaskName="CreateAppHost" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
   <Target Name="_CreateAppHost"
-          Inputs="@(IntermediateAssembly)"
+          Inputs="@(IntermediateAssembly);@(_NativeRestoredAppHostNETCore)"
           Outputs="@(_NativeAppHostNETCore)"
           DependsOnTargets="_GetAppHostPaths;CoreCompile"
-          Condition="'$(ComputeNETCoreBuildOutputFiles)' == 'true'">
+          Condition="'$(ComputeNETCoreBuildOutputFiles)' == 'true' and Exists('@(IntermediateAssembly)') and Exists('@(_NativeRestoredAppHostNETCore)')">
     <PropertyGroup>
       <_UseWindowsGraphicalUserInterface Condition="($(RuntimeIdentifier.StartsWith('win')) or $(DefaultAppHostRuntimeIdentifier.StartsWith('win'))) and '$(OutputType)'=='WinExe'">true</_UseWindowsGraphicalUserInterface>
     </PropertyGroup>
@@ -294,8 +294,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                    AppHostDestinationPath="@(_NativeAppHostNETCore)"
                    AppBinaryName="$(AssemblyName)$(TargetExt)"
                    IntermediateAssembly="@(IntermediateAssembly->'%(FullPath)')"
-                   WindowsGraphicalUserInterface="$(_UseWindowsGraphicalUserInterface)"
-                   Condition="'@(_NativeRestoredAppHostNETCore)' != ''" />
+                   WindowsGraphicalUserInterface="$(_UseWindowsGraphicalUserInterface)" />
   </Target>
 
   <!--


### PR DESCRIPTION
This commit fixes design time builds where the intermediate assembly may not
exist, causing the `CreateAppHost` task to fail.

The change is to condition the `_CreateAppHost` target based on the existence
of the two input files: the intermediate assembly and the native apphost.

Fixes #2599.