### PR TITLE
Ensure default apphost RID is set prior to `_IsExecutable` reassignment. 

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.Common.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.Common.targets
@@ -28,6 +28,13 @@ Copyright (c) .NET Foundation. All rights reserved.
     <DefaultImplicitPackages>Microsoft.NETCore.App;NETStandard.Library</DefaultImplicitPackages>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <!-- Only use the default apphost if building without a RID and without a deps file path (used by GenerateDeps.proj for CLI tools). -->
+    <!-- This needs to be set prior to _IsExecutable being reassigned below. -->
+    <DefaultAppHostRuntimeIdentifier Condition="'$(DefaultAppHostRuntimeIdentifier)' == '' and '$(RuntimeIdentifier)' == '' and '$(UseAppHost)' == 'true' and '$(_IsExecutable)' == 'true' and '$(ProjectDepsFilePath)' == ''">$(NETCoreSdkRuntimeIdentifier)</DefaultAppHostRuntimeIdentifier>
+    <RuntimeIdentifiers Condition="'$(DefaultAppHostRuntimeIdentifier)' != ''">$(RuntimeIdentifiers);$(DefaultAppHostRuntimeIdentifier)</RuntimeIdentifiers>
+  </PropertyGroup>
+
   <!--
      Some versions of Microsoft.NET.Test.Sdk.targets change the OutputType after we've set _IsExecutable and
      HasRuntimeOutput default in Microsoft.NET.Sdk.BeforeCommon.targets. Refresh these value here for backwards
@@ -36,10 +43,6 @@ Copyright (c) .NET Foundation. All rights reserved.
   <PropertyGroup>
     <_IsExecutable Condition="'$(OutputType)' == 'Exe' or '$(OutputType)'=='WinExe'">true</_IsExecutable>
     <HasRuntimeOutput Condition="'$(_UsingDefaultForHasRuntimeOutput)' == 'true'">$(_IsExecutable)</HasRuntimeOutput>
-
-    <!-- Only use the default apphost if building without a RID and without a deps file path (used by GenerateDeps.proj for CLI tools). -->
-    <DefaultAppHostRuntimeIdentifier Condition="'$(DefaultAppHostRuntimeIdentifier)' == '' and '$(RuntimeIdentifier)' == '' and '$(UseAppHost)' == 'true' and '$(_IsExecutable)' == 'true' and '$(ProjectDepsFilePath)' == ''">$(NETCoreSdkRuntimeIdentifier)</DefaultAppHostRuntimeIdentifier>
-    <RuntimeIdentifiers Condition="'$(DefaultAppHostRuntimeIdentifier)' != ''">$(RuntimeIdentifiers);$(DefaultAppHostRuntimeIdentifier)</RuntimeIdentifiers>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(DotnetCliToolTargetFramework)' == '' And '$(BundledNETCoreAppTargetFrameworkVersion)' != ''">

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildANetCoreApp.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildANetCoreApp.cs
@@ -260,7 +260,7 @@ namespace Microsoft.NET.Build.Tests
                 .CopyTestAsset("HelloWorld")
                 .WithSource();
 
-            var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot));
+            var buildCommand = new BuildCommand(Log, testAsset.TestRoot);
             buildCommand
                 .Execute(new string[] {
                     "/restore",

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAUnitTestProject.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAUnitTestProject.cs
@@ -33,5 +33,26 @@ namespace Microsoft.NET.Build.Tests
             var outputDirectory = buildCommand.GetOutputDirectory("netcoreapp2.0");
             outputDirectory.Should().HaveFile(@"XUnitTestProject.runtimeconfig.json");
         }
+
+        [Fact]
+        public void It_builds_when_has_runtime_output_is_true()
+        {
+            const string targetFramework = "netcoreapp2.1";
+
+            var testAsset = _testAssetsManager
+                .CopyTestAsset("XUnitTestProject")
+                .WithSource();
+
+            var buildCommand = new BuildCommand(Log, testAsset.TestRoot);
+            buildCommand
+                .Execute(new string[] {
+                    "/restore",
+                    $"/p:TargetFramework={targetFramework}",
+                    $"/p:HasRuntimeOutput=true",
+                    $"/p:NETCoreSdkRuntimeIdentifier={EnvironmentInfo.GetCompatibleRid(targetFramework)}"
+                })
+                .Should()
+                .Pass();
+        }
     }
 }


### PR DESCRIPTION
Because of the `_IsExecutable` reassignment that happens when the Test SDK
changes `OutputType`, a test project that builds with `HasRuntimeOutput` set to
true will cause a build failure due to the default apphost not being restored,
but requested to be resolved as a project asset.

The fix is to ensure that the `DefaultAppHostRuntimeIdentifier` property is set
prior to reassigning the `_IsExecutable` property.

Fixes #2620.