### PR TITLE
Set PrivateAssets="all", not PrivateAssets="true"

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolveFrameworkReferences.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveFrameworkReferences.cs
@@ -45,7 +45,7 @@ namespace Microsoft.NET.Build.Tasks
                     TaskItem packageReference = new TaskItem(knownFrameworkReference.TargetingPackName);
                     packageReference.SetMetadata(MetadataKeys.Version, knownFrameworkReference.TargetingPackVersion);
                     packageReference.SetMetadata(MetadataKeys.IsImplicitlyDefined, "true");
-                    packageReference.SetMetadata("PrivateAssets", "true");
+                    packageReference.SetMetadata("PrivateAssets", "all");
 
                     packageReferencesToAdd.Add(packageReference);
 


### PR DESCRIPTION
FrameworkReferences are being persisted into nuspec as package dependencies right now because we used the wrong value for PrivateAssets.

cc @dsplaisted @ericstj @AArnott