### PR TITLE
Exclude unit test projects from source-build

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -29,6 +29,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(IsTestProject)' == 'true'">
+    <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <GenerateProgramFile>false</GenerateProgramFile>
     <XUnitRunnerAdditionalArguments>-parallel none</XUnitRunnerAdditionalArguments>


### PR DESCRIPTION
This is a patch for removing test dependencies from source-build: https://github.com/dotnet/source-build/pull/847.

RepoToolset picks up on this `ExcludeFromSourceBuild` property I'm adding and disables restore and build.

@nguerrera, PTAL.