### PR TITLE
Fix resource updating for the apphost when the assembly contains no resources.

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResourceUpdater.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResourceUpdater.cs
@@ -119,6 +119,7 @@ namespace Microsoft.NET.Build.Tasks
                                                             IntPtr lParam);
 
             public const int UserStoppedResourceEnumerationHRESULT = unchecked((int)0x80073B02);
+            public const int ResourceDataNotFoundHRESULT = unchecked((int)0x80070714);
 
             // Querying and loading resources
 
@@ -220,9 +221,11 @@ namespace Microsoft.NET.Build.Tasks
             {
                 if (!Kernel32.EnumResourceTypes(hModule, enumTypesCallback, errorInfoPtr))
                 {
-                    CaptureEnumResourcesErrorInfo(errorInfoPtr);
-
-                    errorInfo.ThrowException();
+                    if (Marshal.GetHRForLastWin32Error() != Kernel32.ResourceDataNotFoundHRESULT)
+                    {
+                        CaptureEnumResourcesErrorInfo(errorInfoPtr);
+                        errorInfo.ThrowException();
+                    }
                 }
             }
             finally

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -291,7 +291,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       <_UseWindowsGraphicalUserInterface Condition="($(RuntimeIdentifier.StartsWith('win')) or $(DefaultAppHostRuntimeIdentifier.StartsWith('win'))) and '$(OutputType)'=='WinExe'">true</_UseWindowsGraphicalUserInterface>
     </PropertyGroup>
     <CreateAppHost AppHostSourcePath="@(_NativeRestoredAppHostNETCore)"
-                   AppHostDestinationPath="@(_NativeAppHostNETCore)"
+                   AppHostDestinationPath="@(_NativeAppHostNETCore->'%(FullPath)')"
                    AppBinaryName="$(AssemblyName)$(TargetExt)"
                    IntermediateAssembly="@(IntermediateAssembly->'%(FullPath)')"
                    WindowsGraphicalUserInterface="$(_UseWindowsGraphicalUserInterface)" />

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildADesktopExeWithFSharp.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildADesktopExeWithFSharp.cs
@@ -58,5 +58,38 @@ namespace Microsoft.NET.Build.Tests
                 "System.ValueTuple.dll",
             });
         }
+
+        [WindowsOnlyFact]
+        public void It_can_customize_the_apphost()
+        {
+            var targetFramework = "netcoreapp2.1";
+            var testAsset = _testAssetsManager
+                .CopyTestAsset("HelloWorldFS")
+                .WithSource()
+                .WithProjectChanges(project =>
+                {
+                    var ns = project.Root.Name.Namespace;
+                    var propertyGroup = project.Root.Elements(ns + "PropertyGroup").First();
+                    propertyGroup.Element(ns + "TargetFramework").SetValue(targetFramework);
+                })
+                .Restore(Log);
+
+            var buildCommand = new BuildCommand(Log, testAsset.TestRoot);
+            buildCommand
+                .Execute()
+                .Should()
+                .Pass();
+
+            var outputDirectory = buildCommand.GetOutputDirectory(targetFramework);
+
+            outputDirectory.Should().OnlyHaveFiles(new[] {
+                "TestApp.deps.json",
+                "TestApp.dll",
+                "TestApp.exe",
+                "TestApp.pdb",
+                "TestApp.runtimeconfig.dev.json",
+                "TestApp.runtimeconfig.json",
+            });
+        }
     }
 }


### PR DESCRIPTION
This commit fixes the resource updater so that it can handle enumerating
resources on an assembly that contains no Win32 resources.

Fixes #10276.