### PR TITLE
Implement copy-local of package dependencies for 3.0 targeted projects. 

### DIFF
--- a/src/Tasks/Common/MetadataKeys.cs
+++ b/src/Tasks/Common/MetadataKeys.cs
@@ -81,6 +81,12 @@ namespace Microsoft.NET.Build.Tasks
 
         // Resource assemblies
         public const string Culture = "Culture";
+        // The DestinationSubDirectory is the directory containing the asset, relative to the destination folder.
         public const string DestinationSubDirectory = "DestinationSubDirectory";
+
+        // Copy local assets
+        // The DestinationSubPath is the path to the asset, relative to the destination folder.
+        public const string DestinationSubPath = "DestinationSubPath";
+        public const string AssetType = "AssetType";
     }
 }

--- a/src/Tasks/Microsoft.NET.Build.Extensions.Tasks/Microsoft.NET.Build.Extensions.Tasks.csproj
+++ b/src/Tasks/Microsoft.NET.Build.Extensions.Tasks/Microsoft.NET.Build.Extensions.Tasks.csproj
@@ -97,8 +97,7 @@
     </ItemGroup>
   </Target>
 
-  <!-- Remove files from copy local that would not be published as they are provided by the platform package -->
-  <!-- https://github.com/dotnet/sdk/issues/933 tracks a first class feature for this -->
+  <!-- TODO: remove this target when building with a newer 3.0 toolset as this workaround is no longer needed. -->
   <Target Name="FilterCopyLocal" DependsOnTargets="GetFrameworkPaths;GetReferenceAssemblyPaths;RunResolvePublishAssemblies" BeforeTargets="ResolveLockFileCopyLocalProjectDeps">
     <ItemGroup>
       <_CopyLocalButNotPublished Include="@(AllCopyLocalItems)" Exclude="@(ResolvedAssembliesToPublish)" />

--- a/src/Tasks/Microsoft.NET.Build.Extensions.Tasks/msbuildExtensions/Microsoft/Microsoft.NET.Build.Extensions/Microsoft.NET.Build.Extensions.ConflictResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Extensions.Tasks/msbuildExtensions/Microsoft/Microsoft.NET.Build.Extensions/Microsoft.NET.Build.Extensions.ConflictResolution.targets
@@ -26,7 +26,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <Import Project="Microsoft.NET.DefaultPackageConflictOverrides.targets" />
   
   <UsingTask TaskName="ResolvePackageFileConflicts" AssemblyFile="$(MicrosoftNETBuildExtensionsTasksAssembly)" />
-  <Target Name="_HandlePackageFileConflicts" 
+  <Target Name="_HandlePackageFileConflictsForBuild"
           BeforeTargets="$(_HandlePackageFileConflictsBefore)"
           AfterTargets="$(_HandlePackageFileConflictsAfter)"
           DependsOnTargets="GetReferenceAssemblyPaths">

--- a/src/Tasks/Microsoft.NET.Build.Extensions.Tasks/msbuildExtensions/Microsoft/Microsoft.NET.Build.Extensions/Microsoft.NET.Build.Extensions.NETFramework.targets
+++ b/src/Tasks/Microsoft.NET.Build.Extensions.Tasks/msbuildExtensions/Microsoft/Microsoft.NET.Build.Extensions/Microsoft.NET.Build.Extensions.NETFramework.targets
@@ -24,7 +24,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <Target Name="ImplicitlyExpandNETStandardFacades"
           Condition="'$(ImplicitlyExpandNETStandardFacades)' == 'true'"
-          BeforeTargets="_HandlePackageFileConflicts;ResolveAssemblyReferences">
+          BeforeTargets="_HandlePackageFileConflictsForBuild;ResolveAssemblyReferences">
 
     <ItemGroup>
       <_CandidateNETStandardReferences Include="@(Reference);@(_ResolvedProjectReferencePaths)" />

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAnAssetsFileResolver.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAnAssetsFileResolver.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using FluentAssertions;
@@ -13,9 +14,9 @@ using Xunit;
 namespace Microsoft.NET.Build.Tasks.UnitTests
 {
     /// <summary>
-    /// Tests that PublishAssembliesResolver resolves assemblies correctly.
+    /// Tests that AssetsFileResolver resolves files correctly.
     /// </summary>
-    public class GivenAPublishAssembliesResolver
+    public class GivenAnAssetsFileResolver
     {
         [Theory]
         [MemberData(nameof(ProjectData))]
@@ -29,7 +30,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 runtimeFrameworks: null,
                 isSelfContained: false);
 
-            IEnumerable<ResolvedFile> resolvedFiles = new PublishAssembliesResolver(new MockPackageResolver())
+            IEnumerable<ResolvedFile> resolvedFiles = new AssetsFileResolver(new MockPackageResolver())
                 .Resolve(projectContext);
 
             resolvedFiles
@@ -49,7 +50,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 runtimeFrameworks: null,
                 isSelfContained: false);
 
-            IEnumerable<ResolvedFile> resolvedFiles = new PublishAssembliesResolver(new MockPackageResolver())
+            IEnumerable<ResolvedFile> resolvedFiles = new AssetsFileResolver(new MockPackageResolver())
                 .WithPreserveStoreLayout(true)
                 .Resolve(projectContext);
 
@@ -189,7 +190,13 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
 
             string sourcepath = Path.Combine(packageDirectory, filePath);
             string sourcedir = Path.GetDirectoryName(sourcepath);
-            string destinationSubDirPath = preserveStoreLayout ? sourcedir.Substring(packageRoot.Length): destinationSubDirectory;
+            string destinationSubDirPath = preserveStoreLayout ? sourcedir.Substring(packageRoot.Length) : destinationSubDirectory;
+
+            if (!String.IsNullOrEmpty(destinationSubDirPath) && !destinationSubDirPath.EndsWith(Path.DirectorySeparatorChar))
+            {
+                destinationSubDirPath += Path.DirectorySeparatorChar;
+            }
+
             return new ResolvedFile(
                 sourcepath,
                 destinationSubDirPath,

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Microsoft.NET.Build.Tasks.csproj
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Microsoft.NET.Build.Tasks.csproj
@@ -120,8 +120,7 @@
     </ItemGroup>
   </Target>
 
-  <!-- Remove files from copy local that would not be published as they are provided by the platform package -->
-  <!-- https://github.com/dotnet/sdk/issues/933 tracks a first class feature for this -->
+  <!-- TODO: remove this target when building with a newer 3.0 toolset as this workaround is no longer needed. -->
   <Target Name="FilterCopyLocal" DependsOnTargets="GetFrameworkPaths;GetReferenceAssemblyPaths;RunResolvePublishAssemblies" BeforeTargets="ResolveLockFileCopyLocalProjectDeps">
     <ItemGroup>
       <_CopyLocalButNotPublished Include="@(AllCopyLocalItems)" Exclude="@(ResolvedAssembliesToPublish)" />

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ComposeStore.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ComposeStore.targets
@@ -415,7 +415,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     -->
   <UsingTask TaskName="FilterResolvedFiles" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
   <Target Name="ComputeFilesToStore"
-          DependsOnTargets="_ComputeNetPublishAssets;
+          DependsOnTargets="_ComputeResolvedCopyLocalPublishAssets;
                             _ComputeCopyToPublishDirectoryItems">
 
     <PropertyGroup>
@@ -424,18 +424,18 @@ Copyright (c) .NET Foundation. All rights reserved.
     </PropertyGroup>
 
     <FilterResolvedFiles  AssetsFilePath="$(ProjectAssetsFile)"
-                           ResolvedFiles ="@(ResolvedAssembliesToPublish)"
-                           PackagesToPrune="$(PackagesToPrune)"
-                           TargetFramework="$(TargetFrameworkMoniker)"
-                           RuntimeIdentifier="$(RuntimeIdentifier)"
-                           IsSelfContained="$(SelfContained)" >
+                          ResolvedFiles ="@(_ResolvedCopyLocalPublishAssets)"
+                          PackagesToPrune="$(PackagesToPrune)"
+                          TargetFramework="$(TargetFrameworkMoniker)"
+                          RuntimeIdentifier="$(RuntimeIdentifier)"
+                          IsSelfContained="$(SelfContained)" >
       <Output TaskParameter="AssembliesToPublish" ItemName="ResolvedFileToPublish" />
       <Output TaskParameter="PublishedPackages" ItemName="PackagesThatWereResolved" />
     </FilterResolvedFiles>
 
     <ItemGroup>
       <ResolvedPackagesPublished Include="@(PackagesThatWereResolved)"
-                                    Condition="$(DoNotTrackPackageAsResolved) !='true'"/>
+                                 Condition="$(DoNotTrackPackageAsResolved) !='true'"/>
     </ItemGroup>
     
   </Target>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ConflictResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ConflictResolution.targets
@@ -19,28 +19,30 @@ Copyright (c) .NET Foundation. All rights reserved.
   <Import Project="Microsoft.NET.DefaultPackageConflictOverrides.targets" />
 
   <UsingTask TaskName="ResolvePackageFileConflicts" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
-  <Target Name="_HandlePackageFileConflicts" DependsOnTargets="GetReferenceAssemblyPaths">
 
-    <ItemGroup Condition="'$(CopyLocalLockFileAssemblies)' != 'true'">
-      <!-- We need to find all the files that will be loaded from deps for conflict resolution.
-          To do this, we look at the files that would be copied local when CopyLocalLockFileAssemblies is true.
-          However, if CopyLocalLockFileAssemblies is true, then we don't add these items, as they
-          will always be included in ReferenceCopyLocalPaths.
-          -->
-      <_LockFileAssemblies Include="@(RuntimeCopyLocalItems)" />
-      <_LockFileAssemblies Include="@(NativeCopyLocalItems)" />
-      <_LockFileAssemblies Include="@(ResourceCopyLocalItems)" />
-    </ItemGroup>
+  <!--
+    _HandlePackageFileConflictsForBuild
+    Handles package file conflict resolution for build.
+    This will differ from the conflict resolution at publish time if the publish assets differ from build.
+  -->
+  <Target Name="_HandlePackageFileConflictsForBuild" DependsOnTargets="GetReferenceAssemblyPaths">
 
-    <!-- Also include RuntimeTarget items, which aren't ever included in ReferenceCopyLocalPaths, but need to be considered
-         for conflict resolution. -->
     <ItemGroup>
-      <_LockFileAssemblies Include="@(ResolvedRuntimeTargets)" />
+      <!--
+        All runtime assets for conflict resolution.
+        Exclude the copy-local items since those are passed in separately.
+      -->
+      <_RuntimeAssetsForConflictResolution
+        Include="@(RuntimeCopyLocalItems);
+                 @(NativeCopyLocalItems);
+                 @(ResourceCopyLocalItems);
+                 @(RuntimeTargetsCopyLocalItems)"
+        Exclude="@(ReferenceCopyLocalPaths)" />
     </ItemGroup>
 
     <ResolvePackageFileConflicts References="@(Reference)"
                                  ReferenceCopyLocalPaths="@(ReferenceCopyLocalPaths)"
-                                 OtherRuntimeItems="@(_LockFileAssemblies)"
+                                 OtherRuntimeItems="@(_RuntimeAssetsForConflictResolution)"
                                  PlatformManifests="@(PackageConflictPlatformManifests)"
                                  TargetFrameworkDirectories="$(TargetFrameworkDirectory)"
                                  PackageOverrides="@(PackageConflictOverrides)"
@@ -60,20 +62,35 @@ Copyright (c) .NET Foundation. All rights reserved.
       <ReferenceCopyLocalPaths Remove="@(ReferenceCopyLocalPaths)" />
       <ReferenceCopyLocalPaths Include="@(_ReferenceCopyLocalPathsWithoutConflicts)" />
     </ItemGroup>
+
   </Target>
 
-  <Target Name="_HandlePublishFileConflicts" AfterTargets="RunResolvePublishAssemblies"
-          DependsOnTargets="GetReferenceAssemblyPaths">
-    <ResolvePackageFileConflicts ReferenceCopyLocalPaths="@(ResolvedAssembliesToPublish)"
-                                PlatformManifests="@(PackageConflictPlatformManifests)"
-                                TargetFrameworkDirectories="$(TargetFrameworkDirectory)"
-                                PreferredPackages="$(PackageConflictPreferredPackages)">
-      <Output TaskParameter="ReferenceCopyLocalPathsWithoutConflicts" ItemName="_ResolvedAssembliesToPublishWithoutConflicts" />
+  <!--
+    _HandlePackageFileConflictsForPublish
+    Handles package file conflict resolution for publish.
+    Currently, publish assets may differ due to the following reasons:
+      * A package was marked as excluded from publishing (including PrivateAssets="all").
+      * There are runtime store packages to publish against.
+      * If we're preserving store layout, which alters the destination paths of files.
+    When none of these things are true, then we can rely on the conflict resolution from build.
+  -->
+  <Target Name="_HandlePackageFileConflictsForPublish"
+          AfterTargets="_ResolveCopyLocalAssetsForPublish;
+                        _FilterSatelliteResourcesForPublish">
+
+    <ResolvePackageFileConflicts ReferenceCopyLocalPaths="@(_ResolvedCopyLocalPublishAssets)"
+                                 PlatformManifests="@(PackageConflictPlatformManifests)"
+                                 TargetFrameworkDirectories="$(TargetFrameworkDirectory)"
+                                 PreferredPackages="$(PackageConflictPreferredPackages)">
+      <Output TaskParameter="ReferenceCopyLocalPathsWithoutConflicts" ItemName="_ResolvedCopyLocalPublishAssetsWithoutConflicts" />
       <Output TaskParameter="Conflicts" ItemName="_PublishConflictPackageFiles" />
     </ResolvePackageFileConflicts>
+
     <ItemGroup>
-      <ResolvedAssembliesToPublish Remove="@(ResolvedAssembliesToPublish)" />
-      <ResolvedAssembliesToPublish Include="@(_ResolvedAssembliesToPublishWithoutConflicts)" />
+      <_ResolvedCopyLocalPublishAssets Remove="@(_ResolvedCopyLocalPublishAssets)" />
+      <_ResolvedCopyLocalPublishAssets Include="@(_ResolvedCopyLocalPublishAssetsWithoutConflicts)" />
     </ItemGroup>
+
   </Target>
+
 </Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.CrossGen.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.CrossGen.targets
@@ -252,7 +252,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <!--
     ============================================================
                                         _RestoreCrossgen
-Restores netcoreapp and publishes it to a temp directory
+    Restores netcoreapp and publishes it to a temp directory
     ============================================================
     -->
   
@@ -275,18 +275,18 @@ Restores netcoreapp and publishes it to a temp directory
                              StorePackageName=$(MicrosoftNETPlatformLibrary);
                              StorePackageVersion=%(PackageReferenceForCrossGen.Version);"/>
 
-    <ResolvePublishAssemblies ProjectPath="$(MSBuildProjectFullPath)"
-                              AssetsFilePath="$(_CrossProjAssetsFile)"
-                              TargetFramework="$(_TFM)"
-                              RuntimeIdentifier="$(RuntimeIdentifier)"
-                              PlatformLibraryName="$(MicrosoftNETPlatformLibrary)"
-                              RuntimeFrameworks="@(RuntimeFramework)"
-                              ExcludeFromPublishPackageReferences="@(_ExcludeFromPublishPackageReference)"
-                              IsSelfContained="$(SelfContained)"
-                              PreserveStoreLayout="false">
+    <ResolveCopyLocalAssets ProjectPath="$(MSBuildProjectFullPath)"
+                            AssetsFilePath="$(_CrossProjAssetsFile)"
+                            TargetFramework="$(_TFM)"
+                            RuntimeIdentifier="$(RuntimeIdentifier)"
+                            PlatformLibraryName="$(MicrosoftNETPlatformLibrary)"
+                            RuntimeFrameworks="@(RuntimeFramework)"
+                            ExcludedPackageReferences="@(_ExcludeFromPublishPackageReference)"
+                            IsSelfContained="$(SelfContained)"
+                            PreserveStoreLayout="false">
 
-      <Output TaskParameter="AssembliesToPublish" ItemName="CrossgenResolvedAssembliesToPublish" />
-    </ResolvePublishAssemblies>
+      <Output TaskParameter="ResolvedAssets" ItemName="CrossgenResolvedAssembliesToPublish" />
+    </ResolveCopyLocalAssets>
 
     <!-- Copy managed files to  a flat temp directory for passing it as ref for crossgen -->
     <Copy SourceFiles = "@(CrossgenResolvedAssembliesToPublish)"

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.PreserveCompilationContext.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.PreserveCompilationContext.targets
@@ -59,7 +59,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       Don't copy a compilation assembly if it's also a runtime assembly. There is no need to copy the same
       assembly to the 'refs' folder, if it is already in the publish directory.
       -->
-      <_RefAssembliesToExclude Include="@(ResolvedAssembliesToPublish->'%(FullPath)')" />
+      <_RefAssembliesToExclude Include="@(_ResolvedCopyLocalPublishAssets->'%(FullPath)')" />
       <!--
       Similarly, don't copy a compilation assembly if it's also a runtime assembly that is in a runtime store.
       It will be resolved from the runtime store directory at runtime.

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -17,9 +17,6 @@ Copyright (c) .NET Foundation. All rights reserved.
     <DefaultCopyToPublishDirectoryMetadata Condition="'$(DefaultCopyToPublishDirectoryMetadata)' == ''">true</DefaultCopyToPublishDirectoryMetadata>
     <_GetChildProjectCopyToPublishDirectoryItems Condition="'$(_GetChildProjectCopyToPublishDirectoryItems)' == ''">true</_GetChildProjectCopyToPublishDirectoryItems>
 
-    <!-- publishing with the apphost should publish the native host as $(AssemblyName).exe -->
-    <DeployAppHost Condition="'$(DeployAppHost)' == '' and '$(_IsExecutable)' == 'true' and '$(UseAppHost)' == 'true'">true</DeployAppHost>
-  
     <IsPublishable Condition="'$(IsPublishable)'==''">true</IsPublishable>
   </PropertyGroup>
 
@@ -53,7 +50,6 @@ Copyright (c) .NET Foundation. All rights reserved.
       PrepareForPublish;
       ComputeAndCopyFilesToPublishDirectory;
       GeneratePublishDependencyFile;
-      GeneratePublishRuntimeConfigurationFile;
     </_CorePublishTargets>
   </PropertyGroup>
 
@@ -72,7 +68,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <!-- Ensure there is minimal verbosity output pointing to the publish directory and not just the
          build step's minimal output. Otherwise there is no indication at minimal verbosity of where
          the published assets were copied. -->
-    <Message Importance="High" Text="$(MSBuildProjectName) -&gt; $([System.IO.Path]::GetFullPath('$(PublishDir)'))" />
+    <Message Importance="High" Text="$(MSBuildProjectName) -> $([System.IO.Path]::GetFullPath('$(PublishDir)'))" />
   </Target>
 
   <!-- Don't let project reference resolution build project references in NoBuild case. -->
@@ -206,7 +202,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     ============================================================
     -->
   <Target Name="ComputeFilesToPublish"
-          DependsOnTargets="_ComputeNetPublishAssets;
+          DependsOnTargets="_ComputeResolvedCopyLocalPublishAssets;
                             _ComputeCopyToPublishDirectoryItems">
 
     <PropertyGroup>
@@ -217,19 +213,31 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ItemGroup>
       <!-- Copy the build product (.dll or .exe). -->
       <ResolvedFileToPublish Include="@(IntermediateAssembly)"
-                              Condition="'$(CopyBuildOutputToPublishDirectory)' == 'true'">
+                             Condition="'$(CopyBuildOutputToPublishDirectory)' == 'true'">
         <RelativePath>@(IntermediateAssembly->'%(Filename)%(Extension)')</RelativePath>
+      </ResolvedFileToPublish>
+
+      <!-- Copy the deps file if using the build deps file. -->
+      <ResolvedFileToPublish Include="$(ProjectDepsFilePath)"
+                             Condition="'$(GenerateDependencyFile)' == 'true' and '$(_UseBuildDependencyFile)' == 'true'">
+        <RelativePath>$(ProjectDepsFileName)</RelativePath>
+      </ResolvedFileToPublish>
+
+      <!-- Copy the runtime config file. -->
+      <ResolvedFileToPublish Include="$(ProjectRuntimeConfigFilePath)"
+                             Condition="'$(GenerateRuntimeConfigurationFiles)' == 'true'">
+        <RelativePath>$(ProjectRuntimeConfigFileName)</RelativePath>
       </ResolvedFileToPublish>
       
       <!-- Copy the app.config (if any) -->
       <ResolvedFileToPublish Include="@(AppConfigWithTargetPath)"
-                              Condition="'$(CopyBuildOutputToPublishDirectory)' == 'true'">
+                             Condition="'$(CopyBuildOutputToPublishDirectory)' == 'true'">
         <RelativePath>@(AppConfigWithTargetPath->'%(TargetPath)')</RelativePath>
       </ResolvedFileToPublish>
 
       <!-- Copy the debug information file (.pdb), if any -->
       <ResolvedFileToPublish Include="@(_DebugSymbolsIntermediatePath)"
-                              Condition="'$(_DebugSymbolsProduced)'=='true' and '$(CopyOutputSymbolsToPublishDirectory)'=='true'">
+                             Condition="'$(_DebugSymbolsProduced)'=='true' and '$(CopyOutputSymbolsToPublishDirectory)'=='true'">
         <RelativePath>@(_DebugSymbolsIntermediatePath->'%(Filename)%(Extension)')</RelativePath>
       </ResolvedFileToPublish>
 
@@ -238,9 +246,9 @@ Copyright (c) .NET Foundation. All rights reserved.
         <RelativePath>%(IntermediateSatelliteAssembliesWithTargetPath.Culture)\%(Filename)%(Extension)</RelativePath>
       </ResolvedFileToPublish>
 
-      <!-- Copy all the assemblies -->
-      <ResolvedFileToPublish Include="@(ResolvedAssembliesToPublish)">
-        <RelativePath>%(ResolvedAssembliesToPublish.DestinationSubPath)</RelativePath>
+      <!-- Copy the resolved copy local publish assets. -->
+      <ResolvedFileToPublish Include="@(_ResolvedCopyLocalPublishAssets)">
+        <RelativePath>%(_ResolvedCopyLocalPublishAssets.DestinationSubDirectory)%(Filename)%(Extension)</RelativePath>
       </ResolvedFileToPublish>
 
       <!-- Copy the xml documentation (if enabled) -->
@@ -252,72 +260,139 @@ Copyright (c) .NET Foundation. All rights reserved.
       <!-- Copy all PackAsTool shims (if any) -->
       <ResolvedFileToPublish Include="@(_EmbeddedApphostPaths)">
         <RelativePath>shims/%(_EmbeddedApphostPaths.ShimRuntimeIdentifier)/%(_EmbeddedApphostPaths.Filename)%(_EmbeddedApphostPaths.Extension)</RelativePath>
-      </ResolvedFileToPublish >
+      </ResolvedFileToPublish>
     </ItemGroup>
 
-  </Target>
-
-  <Target Name="_ComputeNetPublishAssets"
-          DependsOnTargets="RunResolvePublishAssemblies">
-    <!-- TODO get the content files -->
-    <!-- TODO perform any preprocess transforms on the files -->
-
-    <ItemGroup>
-      <ResolvedAssembliesToPublish Include="@(ReferenceCopyLocalPaths)"
-                                   Exclude="@(ResolvedAssembliesToPublish)"
-                                   Condition="'$(PublishReferencesDocumentationFiles)' == 'true' or '%(Extension)' != '.xml'">
-        <DestinationSubPath>%(ReferenceCopyLocalPaths.DestinationSubDirectory)%(Filename)%(Extension)</DestinationSubPath>
-      </ResolvedAssembliesToPublish>
-    </ItemGroup>
   </Target>
 
   <!--
     ============================================================
-                     RunResolvePublishAssemblies
-
-    Gets the assemblies to be copied to the publish directory
+    _ResolveCopyLocalAssetsForPublish
+    Resolves the assets from packages to copy locally for publish.
+    We can just use the build's copy local assets if we can reuse the build deps file.
     ============================================================
-    -->
-  <UsingTask TaskName="ResolvePublishAssemblies" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
-  <Target Name="RunResolvePublishAssemblies"
-          DependsOnTargets="_ComputeExcludeFromPublishPackageReferences;
-                            _ParseTargetManifestFiles;
+  -->
+  <UsingTask TaskName="ResolveCopyLocalAssets" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
+  <Target Name="_ResolveCopyLocalAssetsForPublish"
+          DependsOnTargets="ResolveLockFileCopyLocalFiles;
+                            _ComputeUseBuildDependencyFile;
                             _DefaultMicrosoftNETPlatformLibrary">
-    <ResolvePublishAssemblies ProjectPath="$(MSBuildProjectFullPath)"
+
+      <ResolveCopyLocalAssets ProjectPath="$(MSBuildProjectFullPath)"
                               AssetsFilePath="$(ProjectAssetsFile)"
                               TargetFramework="$(TargetFrameworkMoniker)"
                               RuntimeIdentifier="$(RuntimeIdentifier)"
                               PlatformLibraryName="$(MicrosoftNETPlatformLibrary)"
                               RuntimeFrameworks="@(RuntimeFramework)"
-                              ExcludeFromPublishPackageReferences="@(_ExcludeFromPublishPackageReference)"
+                              ExcludedPackageReferences="@(_ExcludeFromPublishPackageReference)"
                               RuntimeStorePackages="@(RuntimeStorePackages)"
                               PreserveStoreLayout="$(PreserveStoreLayout)"
-                              IsSelfContained="$(SelfContained)" >
+                              IsSelfContained="$(SelfContained)"
+                              Condition="'$(_UseBuildDependencyFile)' != 'true'">
+        <Output TaskParameter="ResolvedAssets" ItemName="_ResolvedCopyLocalPublishAssets" />
+      </ResolveCopyLocalAssets>
 
-      <Output TaskParameter="AssembliesToPublish" ItemName="ResolvedAssembliesToPublish" />
-    </ResolvePublishAssemblies>
+      <ItemGroup Condition="'$(_UseBuildDependencyFile)' != 'true'">
+        <!-- Remove the apphost executable from publish copy local assets; we will copy the generated apphost instead -->
+        <_ResolvedCopyLocalPublishAssets Remove="@(_NativeRestoredAppHostNETCore)" />
+      </ItemGroup>
+
+      <ItemGroup Condition="'$(_UseBuildDependencyFile)' == 'true'">
+        <_ResolvedCopyLocalPublishAssets Include="@(_ResolvedCopyLocalBuildAssets)" />
+      </ItemGroup>
+
   </Target>
 
-  <Target Name="FilterPublishSatelliteResources" AfterTargets="RunResolvePublishAssemblies"
+   <!--
+    ============================================================
+    _ComputeExcludeFromPublishPackageReferences
+    Builds up the @(_ExcludeFromPublishPackageReference) item by looking for @(PackageReference) items where
+    that have Publish=false metadata, or that have PrivateAssets=All and don't specify Publish
+    ============================================================
+    -->
+  <PropertyGroup>
+    <_ComputeExcludeFromPublishPackageReferences Condition="'$(_ComputeExcludeFromPublishPackageReferences)' == ''">true</_ComputeExcludeFromPublishPackageReferences>
+  </PropertyGroup>
+
+  <Target Name="_ComputeExcludeFromPublishPackageReferences"
+          Condition="'$(_ComputeExcludeFromPublishPackageReferences)' == 'true'">
+
+    <ItemGroup>
+      <!-- PrivateAssets="All" means exclude from publish, unless Publish metadata is specified separately -->
+      <PackageReference Publish="false"
+                        Condition="('%(PackageReference.PrivateAssets)' == 'All') And ('%(PackageReference.Publish)' == '')"/>
+
+      <_ExcludeFromPublishPackageReference Include="@(PackageReference)"
+                                           Condition="('%(PackageReference.Publish)' == 'false')" />
+    </ItemGroup>
+
+  </Target>
+
+  <!--
+    ============================================================
+    _ParseTargetManifestFiles
+    Parses the $(TargetManifestFiles) which contains a list of files into @(RuntimeStorePackages) items
+    which describes which packages should be excluded from publish since they are contained in the runtime store.
+    ============================================================
+    -->
+  <UsingTask TaskName="ParseTargetManifests" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
+    <Target Name="_ParseTargetManifestFiles"
+            Condition="'$(TargetManifestFiles)' != ''"
+            Returns="@(RuntimeStorePackages)">
+
+      <ParseTargetManifests TargetManifestFiles="$(TargetManifestFiles)">
+        <Output TaskParameter="RuntimeStorePackages" ItemName="RuntimeStorePackages"/>
+      </ParseTargetManifests>
+
+  </Target>
+
+  <!--
+    ============================================================
+    _FilterSatelliteResourcesForPublish
+    Filters the resolved resource assets for build to the given resource languages.
+    ============================================================
+  -->
+  <Target Name="_FilterSatelliteResourcesForPublish"
           Condition="'$(SatelliteResourceLanguages)' != ''">
 
     <ItemGroup>
-      <PublishSatelliteResources Include="@(ResolvedAssembliesToPublish)"
-                                 Condition="'%(ResolvedAssembliesToPublish.AssetType)' == 'resources'" />
+      <_PublishSatelliteResources Include="@(_ResolvedCopyLocalPublishAssets)"
+                                  Condition="'%(_ResolvedCopyLocalPublishAssets.AssetType)' == 'resources'" />
     </ItemGroup>
-    
-    <JoinItems Left="@(PublishSatelliteResources)" LeftKey="Culture" LeftMetadata="*"
+
+    <JoinItems Left="@(_PublishSatelliteResources)" LeftKey="Culture" LeftMetadata="*"
                Right="$(SatelliteResourceLanguages)" RightKey="" RightMetadata=""
                ItemSpecToUse="Left">
-      <Output TaskParameter="JoinResult" ItemName="FilteredPublishSatelliteResources" />
+      <Output TaskParameter="JoinResult" ItemName="_FilteredPublishSatelliteResources" />
     </JoinItems>
 
-    <ItemGroup Condition="'@(PublishSatelliteResources)' != ''">
-      <ResolvedAssembliesToPublish Remove="@(PublishSatelliteResources)" />
-      <ResolvedAssembliesToPublish Include="@(FilteredPublishSatelliteResources)" />
+    <ItemGroup Condition="'@(_OutputSatelliteResources)' != ''">
+      <_ResolvedCopyLocalPublishAssets Remove="@(_PublishSatelliteResources)" />
+      <_ResolvedCopyLocalPublishAssets Include="@(_FilteredPublishSatelliteResources)" />
     </ItemGroup>
+
   </Target>
-  
+
+  <!--
+    ============================================================
+    _ComputeResolvedCopyLocalPublishAssets
+    Computes the files from both project and package references.
+    ============================================================
+  -->
+  <Target Name="_ComputeResolvedCopyLocalPublishAssets"
+          DependsOnTargets="_ResolveCopyLocalAssetsForPublish;
+                            _FilterSatelliteResourcesForPublish">
+
+    <ItemGroup>
+      <_ResolvedCopyLocalPublishAssets Include="@(ReferenceCopyLocalPaths)"
+                                       Exclude="@(_ResolvedCopyLocalPublishAssets)"
+                                       Condition="'$(PublishReferencesDocumentationFiles)' == 'true' or '%(Extension)' != '.xml'">
+        <DestinationSubPath>%(ReferenceCopyLocalPaths.DestinationSubDirectory)%(Filename)%(Extension)</DestinationSubPath>
+      </_ResolvedCopyLocalPublishAssets>
+    </ItemGroup>
+
+  </Target>
+
   <!--
     ============================================================
                                         _ComputeCopyToPublishDirectoryItems
@@ -500,29 +575,36 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   </Target>
 
+  <Target Name="_ComputeUseBuildDependencyFile"
+          DependsOnTargets="_ComputeExcludeFromPublishPackageReferences;
+                            _ParseTargetManifestFiles">
+
+    <!-- If there are no excluded packages or runtime store packages, then we can reuse the deps file from the build, -->
+    <PropertyGroup>
+      <_UseBuildDependencyFile Condition="'@(_ExcludeFromPublishPackageReference)' == '' and
+                                          '@(RuntimeStorePackages)' == '' and
+                                          '$(PreserveStoreLayout)' != 'true'">true</_UseBuildDependencyFile>
+    </PropertyGroup>
+
+  </Target>
+
   <!--
     ============================================================
-                                        GeneratePublishDependencyFile
-
+    _GeneratePublishDependencyFile
     Generates the $(project).deps.json file for a published app
     ============================================================
     -->
   <Target Name="GeneratePublishDependencyFile"
-          DependsOnTargets="_ComputeExcludeFromPublishPackageReferences;
-                            _ParseTargetManifestFiles;
+          DependsOnTargets="_ComputeUseBuildDependencyFile;
                             _DefaultMicrosoftNETPlatformLibrary;
-                            _HandlePackageFileConflicts;
-                            _HandlePublishFileConflicts;
+                            _HandlePackageFileConflictsForBuild;
+                            _HandlePackageFileConflictsForPublish;
                             _ComputeReferenceAssemblies"
-          Condition="'$(GenerateDependencyFile)' == 'true'">
-
-    <PropertyGroup>
-      <PublishDepsFilePath Condition=" '$(PublishDepsFilePath)' == '' ">$(PublishDir)$(ProjectDepsFileName)</PublishDepsFilePath>
-    </PropertyGroup>
+          Condition="'$(GenerateDependencyFile)' == 'true' and '$(_UseBuildDependencyFile)' != 'true'">
 
     <GenerateDepsFile ProjectPath="$(MSBuildProjectFullPath)"
                       AssetsFilePath="$(ProjectAssetsFile)"
-                      DepsFilePath="$(PublishDepsFilePath)"
+                      DepsFilePath="$(PublishDir)$(ProjectDepsFileName)"
                       TargetFramework="$(TargetFrameworkMoniker)"
                       AssemblyName="$(AssemblyName)"
                       AssemblyExtension="$(TargetExt)"
@@ -547,115 +629,11 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <!--
     ============================================================
-                                        _ComputeExcludeFromPublishPackageReferences
-
-    Builds up the @(_ExcludeFromPublishPackageReference) item by looking for @(PackageReference) items where
-    that have Publish=false metadata, or that have PrivateAssets=All and don't specify Publish
-    ============================================================
-    -->
-  <PropertyGroup>
-    <_ComputeExcludeFromPublishPackageReferences Condition="'$(_ComputeExcludeFromPublishPackageReferences)' == ''">true</_ComputeExcludeFromPublishPackageReferences>
-  </PropertyGroup>
-
-  <Target Name="_ComputeExcludeFromPublishPackageReferences"
-          Condition="'$(_ComputeExcludeFromPublishPackageReferences)' == 'true'">
-
-    <ItemGroup>
-      
-      <!-- PrivateAssets="All" means exclude from publish, unless Publish metadata is specified separately -->
-      <PackageReference Publish="false"
-                        Condition="('%(PackageReference.PrivateAssets)' == 'All') And ('%(PackageReference.Publish)' == '')"/>
-      
-      <_ExcludeFromPublishPackageReference Include="@(PackageReference)"
-                                          Condition="('%(PackageReference.Publish)' == 'false')" />
-    </ItemGroup>
-
-  </Target>
-
-  <!--
-    ============================================================
-                                        _ParseTargetManifestFiles
-
-    Parses the $(TargetManifestFiles) which contains a list of files into @(RuntimeStorePackages) items
-    which describes which packages should be excluded from publish since they are contained in the runtime store.
-    ============================================================
-    -->
-  <UsingTask TaskName="ParseTargetManifests" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
-  <Target Name="_ParseTargetManifestFiles"
-          Condition="'$(TargetManifestFiles)' != ''"
-          Returns="@(RuntimeStorePackages)">
-
-    <ParseTargetManifests TargetManifestFiles="$(TargetManifestFiles)">
-      <Output TaskParameter="RuntimeStorePackages" ItemName="RuntimeStorePackages"/>
-    </ParseTargetManifests>
-
-  </Target>
-
-
-  <!--
-    ============================================================
-                                        GeneratePublishRuntimeConfigurationFile
-
-    Generates the $(project).runtimeconfig.json file for a published app
-    ============================================================
-    -->
-
-  <Target Name="GeneratePublishRuntimeConfigurationFile"
-          DependsOnTargets="_DefaultMicrosoftNETPlatformLibrary"
-          Condition="'$(GenerateRuntimeConfigurationFiles)' == 'true'">
-
-    <PropertyGroup>
-      <PublishRuntimeConfigFilePath Condition=" '$(PublishRuntimeConfigFilePath)' == '' ">$(PublishDir)$(ProjectRuntimeConfigFileName)</PublishRuntimeConfigFilePath>
-    </PropertyGroup>
-
-    <GenerateRuntimeConfigurationFiles AssetsFilePath="$(ProjectAssetsFile)"
-                                       TargetFrameworkMoniker="$(TargetFrameworkMoniker)"
-                                       TargetFramework="$(TargetFramework)"
-                                       RuntimeConfigPath="$(PublishRuntimeConfigFilePath)"
-                                       RuntimeIdentifier="$(RuntimeIdentifier)"
-                                       PlatformLibraryName="$(MicrosoftNETPlatformLibrary)"
-                                       RuntimeFrameworks="@(RuntimeFramework)"
-                                       UserRuntimeConfig="$(UserRuntimeConfig)"
-                                       HostConfigurationOptions="@(RuntimeHostConfigurationOption)"
-                                       IsSelfContained="$(SelfContained)" />
-
-  </Target>
-
-  <!--
-    ============================================================
-                                        DeployAppHost
-
-    Deploys the host to run the app and ensures it matches the app name.
-    ============================================================
-    -->
-
-  <Target Name="DeployAppHost"
-          DependsOnTargets="_ComputeNETCoreBuildOutputFiles"
-          AfterTargets="ComputeFilesToPublish"
-          BeforeTargets="CopyFilesToPublishDirectory"
-          Condition="'$(DeployAppHost)' == 'true'">
-
-    <ItemGroup>
-
-      <ResolvedFileToRemove  Include ="%(ResolvedFileToPublish.Identity)" Condition="'%(ResolvedFileToPublish.RelativePath)' == '$(_DotNetHostExecutableName)' Or '%(ResolvedFileToPublish.RelativePath)' == '$(_DotNetAppHostExecutableName)'"/>
-      <ResolvedFileToPublish Remove ="%(ResolvedFileToRemove.Identity)"/>
-
-      <ResolvedFileToPublish Include="%(_NativeAppHostNETCore.Identity)">
-        <RelativePath>$(AssemblyName)$(_NativeExecutableExtension)</RelativePath>
-      </ResolvedFileToPublish>
-
-    </ItemGroup>
-
-  </Target>
-
-  <!--
-    ============================================================
                                         ComputeEmbeddedApphostPaths
 
     When no build flag is set, EmbeddedApphostPaths is not available. Compute EmbeddedApphostPaths is required to find build asset.
     ============================================================
     -->
-
   <UsingTask TaskName="Microsoft.NET.Build.Tasks.GetEmbeddedApphostPaths"
           AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
   <Target Name="ComputeEmbeddedApphostPaths">
@@ -674,4 +652,5 @@ Copyright (c) .NET Foundation. All rights reserved.
     </GetEmbeddedApphostPaths>
 
   </Target>
+
 </Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.BeforeCommon.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.BeforeCommon.targets
@@ -61,16 +61,13 @@ Copyright (c) .NET Foundation. All rights reserved.
   <!-- Default settings for .NET Core and .NET Standard build logic -->
   <PropertyGroup Condition="'$(_IsNETCoreOrNETStandard)' == 'true'">
     <GenerateDependencyFile Condition=" '$(GenerateDependencyFile)' == '' ">true</GenerateDependencyFile>
-    
+
     <!-- Assembly and file versions of runtime assets should be written to the deps.json by default, to support
          runtime minor version roll-forward: https://github.com/dotnet/core-setup/issues/3546 -->
     <IncludeFileVersionsInDependencyFile Condition="'$(IncludeFileVersionsInDependencyFile)' == ''">true</IncludeFileVersionsInDependencyFile>
 
     <!-- Force .dll extension for .NETCoreApp and .NETStandard projects even if output type is exe. -->
     <TargetExt Condition="'$(TargetExt)' == ''">.dll</TargetExt>
-
-    <!-- dependencies coming from the package manager lock file should not be copied locally for .NET Core and .NETStandard projects -->
-    <CopyLocalLockFileAssemblies Condition="'$(CopyLocalLockFileAssemblies)' == ''">false</CopyLocalLockFileAssemblies>
 
     <!-- Disable the use of FrameworkPathOverride in Microsoft.Common.CurrentVersion.targets which can slow down evaluation.  FrameworkPathOverride
     is not needed for NETStandard or NETCore since references come from NuGet packages-->

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -115,17 +115,13 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <Target Name="GenerateBuildDependencyFile"
           DependsOnTargets="_DefaultMicrosoftNETPlatformLibrary;
-                            _HandlePackageFileConflicts;
+                            _HandlePackageFileConflictsForBuild;
                             _ComputeReferenceAssemblies"
           BeforeTargets="CopyFilesToOutputDirectory"
-          Condition=" '$(GenerateDependencyFile)' == 'true'"
+          Condition="'$(GenerateDependencyFile)' == 'true'"
           Inputs="$(ProjectAssetsFile);$(MSBuildAllProjects)"
           Outputs="$(ProjectDepsFilePath)">
 
-    <!--
-    Explicitly not passing any ExcludeFromPublishPackageReferences information during 'Build', since these dependencies
-    should be included during 'Build'.  They are only excluded on 'Publish'.
-    -->
     <GenerateDepsFile ProjectPath="$(MSBuildProjectFullPath)"
                       AssetsFilePath="$(ProjectAssetsFile)"
                       DepsFilePath="$(ProjectDepsFilePath)"
@@ -286,7 +282,10 @@ Copyright (c) .NET Foundation. All rights reserved.
           Inputs="@(IntermediateAssembly);@(_NativeRestoredAppHostNETCore)"
           Outputs="@(_NativeAppHostNETCore)"
           DependsOnTargets="_GetAppHostPaths;CoreCompile"
-          Condition="'$(ComputeNETCoreBuildOutputFiles)' == 'true' and Exists('@(IntermediateAssembly)') and Exists('@(_NativeRestoredAppHostNETCore)')">
+          Condition="'$(ComputeNETCoreBuildOutputFiles)' == 'true' and
+                     '@(_NativeAppHostNETCore)' != '' and
+                     Exists('@(IntermediateAssembly)') and
+                     Exists('@(_NativeRestoredAppHostNETCore)')">
     <PropertyGroup>
       <_UseWindowsGraphicalUserInterface Condition="($(RuntimeIdentifier.StartsWith('win')) or $(DefaultAppHostRuntimeIdentifier.StartsWith('win'))) and '$(OutputType)'=='WinExe'">true</_UseWindowsGraphicalUserInterface>
     </PropertyGroup>
@@ -309,12 +308,10 @@ Copyright (c) .NET Foundation. All rights reserved.
           DependsOnTargets="ResolvePackageAssets"
           Condition="'$(UseAppHost)' == 'true' and '$(_IsExecutable)' == 'true'">
     <ItemGroup>
-      <_NativeRestoredAppHostNETCore Include="@(NativeCopyLocalItems)"
-                                     Condition="'%(NativeCopyLocalItems.FileName)%(NativeCopyLocalItems.Extension)' == '$(_DotNetAppHostExecutableName)'"/>
       <_NativeAppHostNETCore Include="@(_NativeRestoredAppHostNETCore->'$(IntermediateOutputPath)$(AssemblyName)%(Extension)')" />
     </ItemGroup>
 
-    <NETSdkError Condition="'@(_NativeRestoredAppHostNETCore->Count())' > 1"
+    <NETSdkError Condition="'@(_NativeAppHostNETCore->Count())' > 1"
                  ResourceName="MultipleFilesResolved"
                  FormatArguments="$(_DotNetAppHostExecutableName)" />
   </Target>
@@ -334,19 +331,17 @@ Copyright (c) .NET Foundation. All rights reserved.
     <!-- Fallback to renaming the dotnet host if there is no apphost for self-contained builds. -->
     <ItemGroup Condition="'@(_NativeAppHostNETCore)' == '' and '$(SelfContained)' == 'true'">
       <_NativeAppHostNETCore Include="@(NativeCopyLocalItems)"
-                            Condition="'%(NativeCopyLocalItems.FileName)%(NativeCopyLocalItems.Extension)' == '$(_DotNetHostExecutableName)'" />
+                             Condition="'%(NativeCopyLocalItems.FileName)%(NativeCopyLocalItems.Extension)' == '$(_DotNetHostExecutableName)'" />
     </ItemGroup>
 
     <ItemGroup Condition="'@(_NativeAppHostNETCore)' != ''">
       <!--
-        TODO: Revisit for https://github.com/dotnet/cli/issues/10061 when doing "self-contained" builds
-        During "build" and "run" of .NET Core projects, the assemblies coming from NuGet packages
-        are loaded from the NuGet cache. But, in order for a self-contained app to be runnable,
-        it requires a host in the output directory to load the app.
-        During "publish", all required assets are copied to the publish directory.
+        If not copying local lock file assemblies, copy the host policy and host fxr libraries for self-contained builds.
+        This is required to allow the host to activate in self-contained mode.
       -->
       <None Include="@(NativeCopyLocalItems)"
             Condition="'$(SelfContained)' == 'true' and
+                       '$(CopyLocalLockFileAssemblies)' != 'true' and
                        ('%(NativeCopyLocalItems.FileName)%(NativeCopyLocalItems.Extension)' == '$(_DotNetHostPolicyLibraryName)' or
                         '%(NativeCopyLocalItems.FileName)%(NativeCopyLocalItems.Extension)' == '$(_DotNetHostFxrLibraryName)')">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
@@ -356,7 +351,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       <None Include="@(_NativeAppHostNETCore)">
         <Link>$(AssemblyName)$(_NativeExecutableExtension)</Link>
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-        <CopyToPublishDirectory>Never</CopyToPublishDirectory>
+        <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
       </None>
     </ItemGroup>
   </Target>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.PackageDependencyResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.PackageDependencyResolution.targets
@@ -31,7 +31,18 @@ Copyright (c) .NET Foundation. All rights reserved.
          be stored in a shared directory next to the assets.json file -->
     <ProjectAssetsCacheFile Condition="'$(ProjectAssetsCacheFile)' == ''">$(IntermediateOutputPath)$(MSBuildProjectName).assets.cache</ProjectAssetsCacheFile>
     <ProjectAssetsCacheFile>$([MSBuild]::NormalizePath($(MSBuildProjectDirectory), $(ProjectAssetsCacheFile)))</ProjectAssetsCacheFile>
-    
+
+    <!-- Don't copy local for netstandard projects. -->
+    <CopyLocalLockFileAssemblies Condition="'$(CopyLocalLockFileAssemblies)' == '' and
+                                            '$(TargetFrameworkIdentifier)' == '.NETStandard'">false</CopyLocalLockFileAssemblies>
+
+    <!-- Don't copy local for netcoreapp projects before 3.0 or non-exe projects. -->
+    <CopyLocalLockFileAssemblies Condition="'$(CopyLocalLockFileAssemblies)' == '' and
+                                            '$(TargetFrameworkIdentifier)' == '.NETCoreApp' and
+                                            ('$(_TargetFrameworkVersionWithoutV)' &lt; '3.0' or
+                                             '$(HasRuntimeOutput)' != 'true')">false</CopyLocalLockFileAssemblies>
+
+    <!-- All other project types should copy local. -->
     <CopyLocalLockFileAssemblies Condition="'$(CopyLocalLockFileAssemblies)' == ''">true</CopyLocalLockFileAssemblies>
 
     <ContentPreprocessorOutputDirectory Condition="'$(ContentPreprocessorOutputDirectory)' == ''">$(IntermediateOutputPath)NuGet\</ContentPreprocessorOutputDirectory>
@@ -60,12 +71,12 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ResolveAssemblyReferencesDependsOn>
       $(ResolveAssemblyReferencesDependsOn);
       ResolvePackageDependenciesForBuild;
-      _HandlePackageFileConflicts;
+      _HandlePackageFileConflictsForBuild;
     </ResolveAssemblyReferencesDependsOn>
 
     <PrepareResourcesDependsOn>
       ResolvePackageDependenciesForBuild;
-      _HandlePackageFileConflicts;
+      _HandlePackageFileConflictsForBuild;
       $(PrepareResourcesDependsOn)
     </PrepareResourcesDependsOn>
   </PropertyGroup>
@@ -120,7 +131,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ResolvePackageDependenciesForBuildDependsOn>
       ResolveLockFileReferences;
       ResolveLockFileAnalyzers;
-      ResolveLockFileCopyLocalProjectDeps;
+      ResolveLockFileCopyLocalFiles;
       RunProduceContentAssets;
       IncludeTransitiveProjectReferences
     </ResolvePackageDependenciesForBuildDependsOn>
@@ -187,7 +198,8 @@ Copyright (c) .NET Foundation. All rights reserved.
   </Target>
 
   <Target Name="ResolvePackageAssets" 
-          Condition=" '$(DesignTimeBuild)' != 'true' Or Exists('$(ProjectAssetsFile)')">
+          Condition=" '$(DesignTimeBuild)' != 'true' Or Exists('$(ProjectAssetsFile)')"
+          DependsOnTargets="ResolveFrameworkReferences;_DefaultMicrosoftNETPlatformLibrary">
 
     <PropertyGroup Condition="'$(EnsureRuntimePackageDependencies)' == ''
                           and '$(TargetFrameworkIdentifier)' == '.NETCoreApp'
@@ -214,6 +226,9 @@ Copyright (c) .NET Foundation. All rights reserved.
       TargetFrameworkMoniker="$(NuGetTargetMoniker)"
       RuntimeIdentifier="$(RuntimeIdentifier)"
       DefaultAppHostRuntimeIdentifier="$(DefaultAppHostRuntimeIdentifier)"
+      PlatformLibraryName="$(MicrosoftNETPlatformLibrary)"
+      RuntimeFrameworks="@(RuntimeFramework)"
+      IsSelfContained="$(SelfContained)"
       MarkPackageReferencesAsExternallyResolved="$(MarkPackageReferencesAsExternallyResolved)"
       DisablePackageAssetsCache="$(DisablePackageAssetsCache)"
       DisableFrameworkAssemblies="$(DisableLockFileFrameworks)"
@@ -222,8 +237,8 @@ Copyright (c) .NET Foundation. All rights reserved.
       ShimRuntimeIdentifiers="@(_PackAsToolShimRuntimeIdentifiers)"
       EnsureRuntimePackageDependencies="$(EnsureRuntimePackageDependencies)"
       VerifyMatchingImplicitPackageVersion="$(VerifyMatchingImplicitPackageVersion)"
-      ExpectedPlatformPackages="@(ExpectedPlatformPackages)"      
-      >
+      ExpectedPlatformPackages="@(ExpectedPlatformPackages)"
+      SatelliteResourceLanguages="$(SatelliteResourceLanguages)">
 
       <!-- NOTE: items names here are inconsistent because they match prior implementation
           (that was spread across different tasks/targets) for backwards compatibility.  -->
@@ -234,27 +249,16 @@ Copyright (c) .NET Foundation. All rights reserved.
       <Output TaskParameter="NativeLibraries" ItemName="NativeCopyLocalItems" />
       <Output TaskParameter="ResourceAssemblies" ItemName="ResourceCopyLocalItems" />
       <Output TaskParameter="RuntimeAssemblies" ItemName="RuntimeCopyLocalItems" />
-      <Output TaskParameter="RuntimeTargets" ItemName="ResolvedRuntimeTargets" />
+      <Output TaskParameter="RuntimeTargets" ItemName="RuntimeTargetsCopyLocalItems" />
       <Output TaskParameter="CompileTimeAssemblies" ItemName="ResolvedCompileFileDefinitions" />
       <Output TaskParameter="TransitiveProjectReferences" ItemName="_TransitiveProjectReferences" />
     </ResolvePackageAssets>
 
-
-  </Target>
-
-  <Target Name="FilterSatelliteResources" AfterTargets="ResolvePackageAssets"
-          Condition="'$(SatelliteResourceLanguages)' != ''">
-
-    <JoinItems Left="@(ResourceCopyLocalItems)" LeftKey="Culture" LeftMetadata="*"
-               Right="$(SatelliteResourceLanguages)" RightKey="" RightMetadata=""
-               ItemSpecToUse="Left">
-      <Output TaskParameter="JoinResult" ItemName="FilteredResourceCopyLocalItems" />
-    </JoinItems>
-
     <ItemGroup>
-      <ResourceCopyLocalItems Remove="@(ResourceCopyLocalItems)" />
-      <ResourceCopyLocalItems Include="@(FilteredResourceCopyLocalItems)" />
+      <_NativeRestoredAppHostNETCore Include="@(NativeCopyLocalItems)"
+                                     Condition="'%(NativeCopyLocalItems.FileName)%(NativeCopyLocalItems.Extension)' == '$(_DotNetAppHostExecutableName)'"/>
     </ItemGroup>
+
   </Target>
 
   <!--
@@ -286,6 +290,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
       <Output TaskParameter="DependenciesDesignTime" ItemName="_DependenciesDesignTime" />
     </PreprocessPackageDependenciesDesignTime>
+
   </Target>
     
   <!--
@@ -310,6 +315,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
       <Output TaskParameter="SDKReferencesDesignTime" ItemName="_SDKReference" />
     </CollectSDKReferencesDesignTime>
+
   </Target>
 
   <!--
@@ -331,6 +337,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
       <Output TaskParameter="SDKReferencesDesignTime" ItemName="_ResolvedSDKReference" />
     </CollectSDKReferencesDesignTime>
+
   </Target>
 
   <!--
@@ -353,8 +360,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       ContentPreprocessorValues="@(PreprocessorValue)"
       ContentPreprocessorOutputDirectory="$(ContentPreprocessorOutputDirectory)"
       ProduceOnlyPreprocessorFiles="true"
-      ProjectLanguage="$(Language)"
- >
+      ProjectLanguage="$(Language)">
 
       <Output TaskParameter="CopyLocalItems" ItemName="_ContentCopyLocalItems" />
       <Output TaskParameter="ProcessedContentItems" ItemName="_ProcessedContentItems" />
@@ -366,6 +372,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <CreateItem Include="@(_ProcessedContentItems)" Condition="'@(_ProcessedContentItems)' != ''">
       <Output TaskParameter="Include" ItemName="%(_ProcessedContentItems.ProcessedItemType)" />
     </CreateItem>
+
   </Target>
 
   <!--
@@ -449,6 +456,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       <!-- Add the references we computed -->
       <Reference Include="@(ResolvedCompileFileDefinitionsToAdd)" />
     </ItemGroup>
+
   </Target>
 
   <!--
@@ -482,29 +490,27 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <!--
     ============================================================
-    CopyLocal Targets: For populating CopyLocal based on lock file
-     _ComputeLockFileCopyLocal
-    - ResolveLockFileCopyLocalProjectDeps
+    ResolveLockFileCopyLocalFiles
+    Resolves the files from the assets file to copy for build and publish.
     ============================================================
-    -->
-
-  <Target Name="_ComputeLockFileCopyLocal"
-        DependsOnTargets="ResolvePackageAssets;RunProduceContentAssets">
-  
-    <ItemGroup>
-      <AllCopyLocalItems Include="@(NativeCopyLocalItems)" />
-      <AllCopyLocalItems Include="@(RuntimeCopyLocalItems)" />
-      <AllCopyLocalItems Include="@(ResourceCopyLocalItems)" />
-      <AllCopyLocalItems Include="@(_ContentCopyLocalItems)" />
-    </ItemGroup>
-  </Target>
-
-  <Target Name="ResolveLockFileCopyLocalProjectDeps"
-          Condition="'$(CopyLocalLockFileAssemblies)' == 'true'"
-          DependsOnTargets="_ComputeLockFileCopyLocal">
+  -->
+  <Target Name="ResolveLockFileCopyLocalFiles"
+          DependsOnTargets="ResolvePackageAssets">
 
     <ItemGroup>
-      <ReferenceCopyLocalPaths Include="@(AllCopyLocalItems)" />
+      <_ResolvedCopyLocalBuildAssets Include="@(RuntimeCopyLocalItems)"
+                                     Condition="'%(RuntimeCopyLocalItems.CopyLocal)' == 'true'" />
+      <_ResolvedCopyLocalBuildAssets Include="@(ResourceCopyLocalItems)"
+                                     Condition="'%(ResourceCopyLocalItems.CopyLocal)' == 'true'" />
+      <!-- Always exclude the apphost executable from copy local assets; we will copy the generated apphost instead. -->
+      <_ResolvedCopyLocalBuildAssets Include="@(NativeCopyLocalItems)"
+                                     Exclude="@(_NativeRestoredAppHostNETCore)"
+                                     Condition="'%(NativeCopyLocalItems.CopyLocal)' == 'true'" />
+      <_ResolvedCopyLocalBuildAssets Include="@(RuntimeTargetsCopyLocalItems)"
+                                     Condition="'%(RuntimeTargetsCopyLocalItems.CopyLocal)' == 'true'" />
+
+      <ReferenceCopyLocalPaths Include="@(_ResolvedCopyLocalBuildAssets)"
+                               Condition="'$(CopyLocalLockFileAssemblies)' == 'true'" />
     </ItemGroup>
 
   </Target>

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildADesktopExeWtihNetStandardLib.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildADesktopExeWtihNetStandardLib.cs
@@ -220,7 +220,7 @@ namespace Microsoft.NET.Build.Tests
                         // Add a target to validate that no conflicts are from support libs
                         var target = new XElement(ns + "Target",
                             new XAttribute("Name", "CheckForConflicts"),
-                            new XAttribute("AfterTargets", "_HandlePackageFileConflicts"));
+                            new XAttribute("AfterTargets", "_HandlePackageFileConflictsForBuild"));
                         project.Root.Add(target);
 
                         target.Add(new XElement(ns + "FindUnderPath",

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildASelfContainedApp.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildASelfContainedApp.cs
@@ -60,6 +60,10 @@ namespace Microsoft.NET.Build.Tests
                 $"{FileConstants.DynamicLibPrefix}hostpolicy{FileConstants.DynamicLibSuffix}",
             });
 
+            outputDirectory.Should().NotHaveFiles(new[] {
+                $"apphost{Constants.ExeSuffix}",
+            });
+
             Command.Create(selfContainedExecutableFullPath, new string[] { })
                 .CaptureStdOut()
                 .Execute()

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToCopyLocalDependencies.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToCopyLocalDependencies.cs
@@ -1,0 +1,352 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Xml.Linq;
+
+using FluentAssertions;
+
+using Microsoft.DotNet.Cli.Utils;
+using Microsoft.NET.TestFramework;
+using Microsoft.NET.TestFramework.Assertions;
+using Microsoft.NET.TestFramework.Commands;
+using Microsoft.NET.TestFramework.ProjectConstruction;
+
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.NET.Build.Tests
+{
+    public class GivenThatWeWantToCopyLocalDependencies : SdkTest
+    {
+        public GivenThatWeWantToCopyLocalDependencies(ITestOutputHelper log) : base(log)
+        {
+        }
+
+        [Fact]
+        public void It_copies_local_package_dependencies_on_build()
+        {
+            const string ProjectName = "TestProjWithPackageDependencies";
+
+            TestProject testProject = new TestProject()
+            {
+                Name = ProjectName,
+                IsSdkProject = true,
+                TargetFrameworks = "netcoreapp3.0",
+                IsExe = true
+            };
+
+            testProject.PackageReferences.Add(new TestPackageReference("Newtonsoft.Json", "11.0.2"));
+            testProject.PackageReferences.Add(new TestPackageReference("sqlite", "3.13.0"));
+
+             var testProjectInstance = _testAssetsManager
+                .CreateTestProject(testProject)
+                .Restore(Log, ProjectName);
+
+            var buildCommand = new BuildCommand(Log, testProjectInstance.TestRoot, ProjectName);
+
+            buildCommand.Execute()
+                .Should()
+                .Pass();
+
+            var outputDirectory = buildCommand.GetOutputDirectory(testProject.TargetFrameworks);
+            outputDirectory.Should().OnlyHaveFiles(new[] {
+                $"{ProjectName}{Constants.ExeSuffix}",
+                $"{ProjectName}.deps.json",
+                $"{ProjectName}.dll",
+                $"{ProjectName}.pdb",
+                $"{ProjectName}.runtimeconfig.dev.json",
+                $"{ProjectName}.runtimeconfig.json",
+                "Newtonsoft.Json.dll",
+                "runtimes/linux-x64/native/libsqlite3.so",
+                "runtimes/osx-x64/native/libsqlite3.dylib",
+                "runtimes/win7-x64/native/sqlite3.dll",
+                "runtimes/win7-x86/native/sqlite3.dll"
+            });
+        }
+
+        [Fact]
+        public void It_does_not_copy_local_package_dependencies_when_requested_not_to()
+        {
+            const string ProjectName = "TestProjWithPackageDependencies";
+
+            TestProject testProject = new TestProject()
+            {
+                Name = ProjectName,
+                IsSdkProject = true,
+                TargetFrameworks = "netcoreapp3.0",
+                IsExe = true
+            };
+
+            testProject.AdditionalProperties["CopyLocalLockFileAssemblies"] = "false";
+            testProject.PackageReferences.Add(new TestPackageReference("Newtonsoft.Json", "11.0.2"));
+            testProject.PackageReferences.Add(new TestPackageReference("sqlite", "3.13.0"));
+
+             var testProjectInstance = _testAssetsManager
+                .CreateTestProject(testProject)
+                .Restore(Log, ProjectName);
+
+            var buildCommand = new BuildCommand(Log, testProjectInstance.TestRoot, ProjectName);
+
+            buildCommand.Execute().Should().Pass();
+
+            var outputDirectory = buildCommand.GetOutputDirectory(testProject.TargetFrameworks);
+            outputDirectory.Should().OnlyHaveFiles(new[] {
+                $"{ProjectName}{Constants.ExeSuffix}",
+                $"{ProjectName}.deps.json",
+                $"{ProjectName}.dll",
+                $"{ProjectName}.pdb",
+                $"{ProjectName}.runtimeconfig.dev.json",
+                $"{ProjectName}.runtimeconfig.json",
+            });
+        }
+
+        [Fact]
+        public void It_copies_local_specific_runtime_package_dependencies_on_build()
+        {
+            const string ProjectName = "TestProjWithPackageDependencies";
+
+            var rid = EnvironmentInfo.GetCompatibleRid("netcoreapp3.0");
+
+            TestProject testProject = new TestProject()
+            {
+                Name = ProjectName,
+                IsSdkProject = true,
+                TargetFrameworks = "netcoreapp3.0",
+                IsExe = true
+            };
+
+            testProject.AdditionalProperties.Add("RuntimeIdentifier", rid);
+            testProject.AdditionalProperties.Add("SelfContained", "false");
+            testProject.PackageReferences.Add(new TestPackageReference("Newtonsoft.Json", "11.0.2"));
+            testProject.PackageReferences.Add(new TestPackageReference("sqlite", "3.13.0"));
+
+             var testProjectInstance = _testAssetsManager
+                .CreateTestProject(testProject)
+                .Restore(Log, ProjectName);
+
+            var buildCommand = new BuildCommand(Log, testProjectInstance.TestRoot, ProjectName);
+
+            buildCommand.Execute()
+                .Should()
+                .Pass();
+
+            var outputDirectory = buildCommand.GetOutputDirectory(targetFramework: testProject.TargetFrameworks, runtimeIdentifier: rid);
+
+            outputDirectory.Should().OnlyHaveFiles(new[] {
+                $"{ProjectName}{Constants.ExeSuffix}",
+                $"{ProjectName}.deps.json",
+                $"{ProjectName}.dll",
+                $"{ProjectName}.pdb",
+                $"{ProjectName}.runtimeconfig.dev.json",
+                $"{ProjectName}.runtimeconfig.json",
+                "Newtonsoft.Json.dll",
+                // NOTE: this may break in the future when the SDK supports platforms that sqlite does not
+                $"{FileConstants.DynamicLibPrefix}sqlite3{FileConstants.DynamicLibSuffix}",
+            });
+        }
+
+        [Fact]
+        public void It_does_not_copy_local_package_dependencies_for_lib_projects()
+        {
+            const string ProjectName = "TestProjWithPackageDependencies";
+
+            TestProject testProject = new TestProject()
+            {
+                Name = ProjectName,
+                IsSdkProject = true,
+                TargetFrameworks = "netcoreapp3.0",
+                IsExe = false
+            };
+
+            testProject.PackageReferences.Add(new TestPackageReference("Newtonsoft.Json", "11.0.2"));
+            testProject.PackageReferences.Add(new TestPackageReference("sqlite", "3.13.0"));
+
+             var testProjectInstance = _testAssetsManager
+                .CreateTestProject(testProject)
+                .Restore(Log, ProjectName);
+
+            var buildCommand = new BuildCommand(Log, testProjectInstance.TestRoot, ProjectName);
+
+            buildCommand.Execute()
+                .Should()
+                .Pass();
+
+            var outputDirectory = buildCommand.GetOutputDirectory(testProject.TargetFrameworks);
+            outputDirectory.Should().OnlyHaveFiles(new[] {
+                $"{ProjectName}.deps.json",
+                $"{ProjectName}.dll",
+                $"{ProjectName}.pdb",
+            });
+        }
+
+        [Fact]
+        public void It_copies_local_package_dependencies_for_lib_projects_when_requested_to()
+        {
+            const string ProjectName = "TestProjWithPackageDependencies";
+
+            TestProject testProject = new TestProject()
+            {
+                Name = ProjectName,
+                IsSdkProject = true,
+                TargetFrameworks = "netcoreapp3.0",
+                IsExe = false
+            };
+
+            testProject.AdditionalProperties["CopyLocalLockFileAssemblies"] = "true";
+            testProject.PackageReferences.Add(new TestPackageReference("Newtonsoft.Json", "11.0.2"));
+            testProject.PackageReferences.Add(new TestPackageReference("sqlite", "3.13.0"));
+
+             var testProjectInstance = _testAssetsManager
+                .CreateTestProject(testProject)
+                .Restore(Log, ProjectName);
+
+            var buildCommand = new BuildCommand(Log, testProjectInstance.TestRoot, ProjectName);
+
+            buildCommand.Execute()
+                .Should()
+                .Pass();
+
+            var outputDirectory = buildCommand.GetOutputDirectory(testProject.TargetFrameworks);
+            outputDirectory.Should().OnlyHaveFiles(new[] {
+                $"{ProjectName}.deps.json",
+                $"{ProjectName}.dll",
+                $"{ProjectName}.pdb",
+                "Newtonsoft.Json.dll",
+                "runtimes/linux-x64/native/libsqlite3.so",
+                "runtimes/osx-x64/native/libsqlite3.dylib",
+                "runtimes/win7-x64/native/sqlite3.dll",
+                "runtimes/win7-x86/native/sqlite3.dll"
+            });
+        }
+
+        [Fact]
+        public void It_does_not_copy_local_package_dependencies_for_netstandard_projects()
+        {
+            const string ProjectName = "TestProjWithPackageDependencies";
+
+            TestProject testProject = new TestProject()
+            {
+                Name = ProjectName,
+                IsSdkProject = true,
+                TargetFrameworks = "netstandard2.0"
+            };
+
+            testProject.PackageReferences.Add(new TestPackageReference("Newtonsoft.Json", "11.0.2"));
+            testProject.PackageReferences.Add(new TestPackageReference("sqlite", "3.13.0"));
+
+             var testProjectInstance = _testAssetsManager
+                .CreateTestProject(testProject)
+                .Restore(Log, ProjectName);
+
+            var buildCommand = new BuildCommand(Log, testProjectInstance.TestRoot, ProjectName);
+
+            buildCommand.Execute()
+                .Should()
+                .Pass();
+
+            var outputDirectory = buildCommand.GetOutputDirectory(testProject.TargetFrameworks);
+            outputDirectory.Should().OnlyHaveFiles(new[] {
+                $"{ProjectName}.deps.json",
+                $"{ProjectName}.dll",
+                $"{ProjectName}.pdb"
+            });
+        }
+
+        [Fact]
+        public void It_copies_local_package_dependencies_for_netstandard_projects_when_requested_to()
+        {
+            const string ProjectName = "TestProjWithPackageDependencies";
+
+            TestProject testProject = new TestProject()
+            {
+                Name = ProjectName,
+                IsSdkProject = true,
+                TargetFrameworks = "netstandard2.0"
+            };
+
+            testProject.AdditionalProperties["CopyLocalLockFileAssemblies"] = "true";
+            testProject.PackageReferences.Add(new TestPackageReference("Newtonsoft.Json", "11.0.2"));
+            testProject.PackageReferences.Add(new TestPackageReference("sqlite", "3.13.0"));
+
+             var testProjectInstance = _testAssetsManager
+                .CreateTestProject(testProject)
+                .Restore(Log, ProjectName);
+
+            var buildCommand = new BuildCommand(Log, testProjectInstance.TestRoot, ProjectName);
+
+            buildCommand.Execute()
+                .Should()
+                .Pass();
+
+            var outputDirectory = buildCommand.GetOutputDirectory(testProject.TargetFrameworks);
+            outputDirectory.Should().OnlyHaveFiles(new[] {
+                $"{ProjectName}.deps.json",
+                $"{ProjectName}.dll",
+                $"{ProjectName}.pdb",
+                "Newtonsoft.Json.dll",
+                "runtimes/linux-x64/native/libsqlite3.so",
+                "runtimes/osx-x64/native/libsqlite3.dylib",
+                "runtimes/win7-x64/native/sqlite3.dll",
+                "runtimes/win7-x86/native/sqlite3.dll"
+            });
+        }
+
+        [Fact]
+        public void It_copies_local_all_assets_on_self_contained_build()
+        {
+            const string ProjectName = "TestProjWithPackageDependencies";
+
+            var rid = EnvironmentInfo.GetCompatibleRid("netcoreapp3.0");
+
+            TestProject testProject = new TestProject()
+            {
+                Name = ProjectName,
+                IsSdkProject = true,
+                TargetFrameworks = "netcoreapp3.0",
+                IsExe = true
+            };
+
+            testProject.AdditionalProperties.Add("RuntimeIdentifier", rid);
+            testProject.PackageReferences.Add(new TestPackageReference("Newtonsoft.Json", "11.0.2"));
+            testProject.PackageReferences.Add(new TestPackageReference("sqlite", "3.13.0"));
+
+             var testProjectInstance = _testAssetsManager
+                .CreateTestProject(testProject)
+                .Restore(Log, ProjectName);
+
+            var buildCommand = new BuildCommand(Log, testProjectInstance.TestRoot, ProjectName);
+
+            buildCommand.Execute()
+                .Should()
+                .Pass();
+
+            var outputDirectory = buildCommand.GetOutputDirectory(targetFramework: testProject.TargetFrameworks, runtimeIdentifier: rid);
+
+            outputDirectory.Should().HaveFiles(new[] {
+                $"{ProjectName}{Constants.ExeSuffix}",
+                $"{ProjectName}.deps.json",
+                $"{ProjectName}.dll",
+                $"{ProjectName}.pdb",
+                $"{ProjectName}.runtimeconfig.dev.json",
+                $"{ProjectName}.runtimeconfig.json",
+                "Newtonsoft.Json.dll",
+                // NOTE: this may break in the future when the SDK supports platforms that sqlite does not
+                $"{FileConstants.DynamicLibPrefix}sqlite3{FileConstants.DynamicLibSuffix}",
+                $"{FileConstants.DynamicLibPrefix}clrjit{FileConstants.DynamicLibSuffix}",
+                $"{FileConstants.DynamicLibPrefix}hostfxr{FileConstants.DynamicLibSuffix}",
+                $"{FileConstants.DynamicLibPrefix}hostpolicy{FileConstants.DynamicLibSuffix}",
+                $"mscorlib.dll",
+                // This is not an exhaustive list as there are many files in self-contained builds
+            });
+
+            outputDirectory.Should().NotHaveFiles(new[] {
+                $"apphost{Constants.ExeSuffix}",
+            });
+        }
+    }
+}

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAHelloWorldProject.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAHelloWorldProject.cs
@@ -33,18 +33,22 @@ namespace Microsoft.NET.Publish.Tests
                 .Restore(Log);
 
             var publishCommand = new PublishCommand(Log, helloWorldAsset.TestRoot);
-            var publishResult = publishCommand.Execute();
+            var publishResult = publishCommand.Execute("-p:CopyLocalLockFileAssemblies=true");
 
             publishResult.Should().Pass();
 
             var publishDirectory = publishCommand.GetOutputDirectory();
+            var outputDirectory = publishDirectory.Parent;
 
-            publishDirectory.Should().OnlyHaveFiles(new[] {
+            var filesPublished = new[] {
                 "HelloWorld.dll",
                 "HelloWorld.pdb",
                 "HelloWorld.deps.json",
                 "HelloWorld.runtimeconfig.json"
-            });
+            };
+
+            outputDirectory.Should().HaveFiles(filesPublished);
+            publishDirectory.Should().HaveFiles(filesPublished);
 
             Command.Create(TestContext.Current.ToolsetUnderTest.DotNetHostPath, new[] { Path.Combine(publishDirectory.FullName, "HelloWorld.dll") })
                 .CaptureStdOut()
@@ -67,18 +71,17 @@ namespace Microsoft.NET.Publish.Tests
                 .Restore(Log, relativePath: "", args: $"/p:RuntimeIdentifier={rid}");
 
             var publishCommand = new PublishCommand(Log, helloWorldAsset.TestRoot);
-            var publishResult = publishCommand.Execute($"/p:RuntimeIdentifier={rid}");
+            var publishResult = publishCommand.Execute($"/p:RuntimeIdentifier={rid}", "/p:CopyLocalLockFileAssemblies=true");
 
             publishResult.Should().Pass();
 
             var publishDirectory = publishCommand.GetOutputDirectory(
                 targetFramework: targetFramework,
                 runtimeIdentifier: rid);
+            var outputDirectory = publishDirectory.Parent;
             var selfContainedExecutable = $"HelloWorld{Constants.ExeSuffix}";
 
-            string selfContainedExecutableFullPath = Path.Combine(publishDirectory.FullName, selfContainedExecutable);
-
-            publishDirectory.Should().HaveFiles(new[] {
+            var filesPublished = new[] {
                 selfContainedExecutable,
                 "HelloWorld.dll",
                 "HelloWorld.pdb",
@@ -89,8 +92,16 @@ namespace Microsoft.NET.Publish.Tests
                 $"{FileConstants.DynamicLibPrefix}hostpolicy{FileConstants.DynamicLibSuffix}",
                 $"mscorlib.dll",
                 $"System.Private.CoreLib.dll",
+            };
+
+            outputDirectory.Should().HaveFiles(filesPublished);
+            publishDirectory.Should().HaveFiles(filesPublished);
+
+            publishDirectory.Should().NotHaveFiles(new[] {
+                $"apphost{Constants.ExeSuffix}",
             });
 
+            string selfContainedExecutableFullPath = Path.Combine(publishDirectory.FullName, selfContainedExecutable);
             Command.Create(selfContainedExecutableFullPath, new string[] { })
                 .CaptureStdOut()
                 .Execute()
@@ -115,7 +126,7 @@ namespace Microsoft.NET.Publish.Tests
                 IsExe = true,
             };
             
-
+            testProject.AdditionalProperties["CopyLocalLockFileAssemblies"] = "true";
             testProject.SourceFiles["Program.cs"] = @"
 using System;
 public static class Program
@@ -156,7 +167,7 @@ public static class Program
                 IsExe = true,
             };
             
-
+            testProject.AdditionalProperties["CopyLocalLockFileAssemblies"] = "true";
             testProject.SourceFiles["Program.cs"] = @"
 using System;
 public static class Program
@@ -178,11 +189,10 @@ public static class Program
             var publishDirectory = publishCommand.GetOutputDirectory(
                 targetFramework: targetFramework,
                 runtimeIdentifier: rid);
+            var outputDirectory = publishDirectory.Parent;
             var selfContainedExecutable = $"Hello{Constants.ExeSuffix}";
 
-            string selfContainedExecutableFullPath = Path.Combine(publishDirectory.FullName, selfContainedExecutable);
-
-            publishDirectory.Should().HaveFiles(new[] {
+            var filesPublished = new[] {
                 selfContainedExecutable,
                 "Hello.dll",
                 "Hello.pdb",
@@ -193,7 +203,19 @@ public static class Program
                 $"{FileConstants.DynamicLibPrefix}hostpolicy{FileConstants.DynamicLibSuffix}",
                 $"mscorlib.dll",
                 $"System.Private.CoreLib.dll",
-            });
+            };
+
+            var filesNotPublished = new[] {
+                $"apphost{Constants.ExeSuffix}"
+            };
+
+            outputDirectory.Should().HaveFiles(filesPublished);
+            publishDirectory.Should().HaveFiles(filesPublished);
+
+            outputDirectory.Should().NotHaveFiles(filesNotPublished);
+            publishDirectory.Should().NotHaveFiles(filesNotPublished);
+
+            string selfContainedExecutableFullPath = Path.Combine(publishDirectory.FullName, selfContainedExecutable);
 
             Command.Create(selfContainedExecutableFullPath, new string[] { })
                 .CaptureStdOut()
@@ -227,7 +249,8 @@ public static class Program
                 RuntimeIdentifier = runtimeIdentifier,
                 IsExe = true,
             };
-            
+
+            testProject.AdditionalProperties["CopyLocalLockFileAssemblies"] = "true";
             testProject.SourceFiles["Program.cs"] = @"
 using System;
 public static class Program
@@ -249,6 +272,7 @@ public static class Program
             var publishDirectory = publishCommand.GetOutputDirectory(
                 targetFramework: targetFramework,
                 runtimeIdentifier: runtimeIdentifier);
+            var outputDirectory = publishDirectory.Parent;
             
             // The name of the self contained executable depends on the runtime identifier.
             // For Windows family ARM publishing, it'll always be Hello.exe.
@@ -256,7 +280,7 @@ public static class Program
             // depending on the RuntimeInformation
             var selfContainedExecutable = "Hello.exe";
 
-            publishDirectory.Should().HaveFiles(new[] {
+            var filesPublished = new [] {
                 selfContainedExecutable,
                 "Hello.dll",
                 "Hello.pdb",
@@ -267,7 +291,10 @@ public static class Program
                 "hostpolicy.dll",
                 "mscorlib.dll",
                 "System.Private.CoreLib.dll",
-            });
+            };
+
+            outputDirectory.Should().HaveFiles(filesPublished);
+            publishDirectory.Should().HaveFiles(filesPublished);
         }
 
         [Fact]
@@ -310,6 +337,7 @@ public static class Program
 
             string outputMessage = $"Hello from {testProject.Name}!";
 
+            testProject.AdditionalProperties["CopyLocalLockFileAssemblies"] = "true";
             testProject.SourceFiles["Program.cs"] = @"
 using System;
 public static class Program
@@ -357,6 +385,7 @@ public static class Program
             var publishDirectory = publishCommand.GetOutputDirectory(
                 targetFramework: targetFramework,
                 runtimeIdentifier: rid ?? string.Empty);
+            var outputDirectory = publishDirectory.Parent;
 
             DependencyContext dependencyContext;
             using (var depsJsonFileStream = File.OpenRead(Path.Combine(publishDirectory.FullName, $"{testProject.Name}.deps.json")))
@@ -381,7 +410,7 @@ public static class Program
 
                 var libPrefix = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "" : "lib";
 
-                publishDirectory.Should().HaveFiles(new[] {
+                var filesPublished = new[] {
                     selfContainedExecutable,
                     $"{testProject.Name}.dll",
                     $"{testProject.Name}.pdb",
@@ -392,7 +421,10 @@ public static class Program
                     $"{libPrefix}hostpolicy{FileConstants.DynamicLibSuffix}",
                     $"mscorlib.dll",
                     $"System.Private.CoreLib.dll",
-                });
+                };
+
+                outputDirectory.Should().HaveFiles(filesPublished);
+                publishDirectory.Should().HaveFiles(filesPublished);
 
                 dependencyContext.Should()
                     .OnlyHaveRuntimeAssembliesWhichAreInFolder(rid, publishDirectory.FullName)
@@ -403,12 +435,15 @@ public static class Program
             }
             else
             {
-                publishDirectory.Should().OnlyHaveFiles(new[] {
+                var filesPublished = new[] {
                     $"{testProject.Name}.dll",
                     $"{testProject.Name}.pdb",
                     $"{testProject.Name}.deps.json",
                     $"{testProject.Name}.runtimeconfig.json"
-                });
+                };
+
+                outputDirectory.Should().HaveFiles(filesPublished);
+                publishDirectory.Should().HaveFiles(filesPublished);
 
                 dependencyContext.Should()
                     .OnlyHaveRuntimeAssemblies(rid ?? "", testProject.Name);

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAnAppWithLibrariesAndRid.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAnAppWithLibrariesAndRid.cs
@@ -47,6 +47,10 @@ namespace Microsoft.NET.Publish.Tests
                 $"{FileConstants.DynamicLibPrefix}hostpolicy{FileConstants.DynamicLibSuffix}",
             });
 
+            publishDirectory.Should().NotHaveFiles(new[] {
+                $"apphost{Constants.ExeSuffix}",
+            });
+
             Command.Create(Path.Combine(publishDirectory.FullName, selfContainedExecutable), new string[] { })
                 .CaptureStdOut()
                 .Execute()


### PR DESCRIPTION
This PR implements some of the unification of the `dotnet build` and
`dotnet publish` experiences.

For 3.0 targeted projects, `dotnet build` will now copy the package
dependencies locally into the output directory instead of relying on the NuGet
cache.  It behaves the same as `dotnet publish`, only copying what is not
provided by the shared frameworks.

Additionally, `dotnet publish` will now copy the build outputs rather than
regenerating a deps file or resolving package dependencies, provided there are
no package references excluded from publishing or packages are coming from a
runtime store.

The `CopyLocalLockFileAssemblies` property can be set to `false` to revert to
the previous behavior for `dotnet build`.

Fixes dotnet/cli#10061.
Fixes #933.

