### PR TITLE
Bump Arcade version.

### DIFF
--- a/global.json
+++ b/global.json
@@ -4,6 +4,6 @@
     "vswhere": "2.2.7"
   },
   "msbuild-sdks": {
-    "Microsoft.DotNet.Arcade.Sdk": "1.0.0-beta.18563.21"
+    "Microsoft.DotNet.Arcade.Sdk": "1.0.0-beta.18564.20"
   }
 }


### PR DESCRIPTION
Bumping Arcade version to `1.0.0-beta.18564.20`.