### PR TITLE
Fix copying of build assets when publish assets differ.

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -385,7 +385,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <ItemGroup>
       <_ResolvedCopyLocalPublishAssets Include="@(ReferenceCopyLocalPaths)"
-                                       Exclude="@(_ResolvedCopyLocalPublishAssets)"
+                                       Exclude="@(_ResolvedCopyLocalBuildAssets)"
                                        Condition="'$(PublishReferencesDocumentationFiles)' == 'true' or '%(Extension)' != '.xml'">
         <DestinationSubPath>%(ReferenceCopyLocalPaths.DestinationSubDirectory)%(Filename)%(Extension)</DestinationSubPath>
       </_ResolvedCopyLocalPublishAssets>


### PR DESCRIPTION
When publish copy-local assets differ from build copy-local assets (for
example, runtime store packages were excluded), a typo when adding the
reference copy local items caused items that were copied local for build to be
included in publish output.

This was caught by a CLI test that uses a manifest to exclude a package and
then runs the output of the publish operation, expecting it to fail because the
dependency was not copied locally (and no runtime store is used).

This change will fix the failing CLI test.