### PR TITLE
Add back `RunResolvePublishAssemblies` target.

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -653,4 +653,12 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   </Target>
 
+  <!--
+    This target exists for back-compat with Azure Functions SDK: https://github.com/dotnet/cli/issues/10363
+    Because build copy-local now behaves the same as publish with respect to package dependency resolution,
+    the Azure Functions SDK doesn't need to resolve publish assets for build.
+    TODO: Remove this target when no longer needed as a workaround.
+    -->
+  <Target Name="RunResolvePublishAssemblies" />
+
 </Project>


### PR DESCRIPTION
This commit adds the `RunResolvePublishAssemblies` target back as a no-op
target.  The Azure Functions SDK relies on this target for making copy local
work for build.  However, since the 3.0 SDK behaves the same as publish for
build copy local, this is no longer necessary.

Adding the target back will prevent the Azure Functions SDK from breaking.

Fixes dotnet/cli#10363.