### PR TITLE
Rename `_HandlePackageFileConflictsForBuild` back to `_HandlePackageFileConflicts`

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Extensions.Tasks/msbuildExtensions/Microsoft/Microsoft.NET.Build.Extensions/Microsoft.NET.Build.Extensions.ConflictResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Extensions.Tasks/msbuildExtensions/Microsoft/Microsoft.NET.Build.Extensions/Microsoft.NET.Build.Extensions.ConflictResolution.targets
@@ -26,7 +26,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <Import Project="Microsoft.NET.DefaultPackageConflictOverrides.targets" />
   
   <UsingTask TaskName="ResolvePackageFileConflicts" AssemblyFile="$(MicrosoftNETBuildExtensionsTasksAssembly)" />
-  <Target Name="_HandlePackageFileConflictsForBuild"
+  <Target Name="_HandlePackageFileConflicts"
           BeforeTargets="$(_HandlePackageFileConflictsBefore)"
           AfterTargets="$(_HandlePackageFileConflictsAfter)"
           DependsOnTargets="GetReferenceAssemblyPaths">

--- a/src/Tasks/Microsoft.NET.Build.Extensions.Tasks/msbuildExtensions/Microsoft/Microsoft.NET.Build.Extensions/Microsoft.NET.Build.Extensions.NETFramework.targets
+++ b/src/Tasks/Microsoft.NET.Build.Extensions.Tasks/msbuildExtensions/Microsoft/Microsoft.NET.Build.Extensions/Microsoft.NET.Build.Extensions.NETFramework.targets
@@ -24,7 +24,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <Target Name="ImplicitlyExpandNETStandardFacades"
           Condition="'$(ImplicitlyExpandNETStandardFacades)' == 'true'"
-          BeforeTargets="_HandlePackageFileConflictsForBuild;ResolveAssemblyReferences">
+          BeforeTargets="_HandlePackageFileConflicts;ResolveAssemblyReferences">
 
     <ItemGroup>
       <_CandidateNETStandardReferences Include="@(Reference);@(_ResolvedProjectReferencePaths)" />

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ConflictResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ConflictResolution.targets
@@ -21,11 +21,11 @@ Copyright (c) .NET Foundation. All rights reserved.
   <UsingTask TaskName="ResolvePackageFileConflicts" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
 
   <!--
-    _HandlePackageFileConflictsForBuild
+    _HandlePackageFileConflicts
     Handles package file conflict resolution for build.
     This will differ from the conflict resolution at publish time if the publish assets differ from build.
   -->
-  <Target Name="_HandlePackageFileConflictsForBuild" DependsOnTargets="GetReferenceAssemblyPaths">
+  <Target Name="_HandlePackageFileConflicts" DependsOnTargets="GetReferenceAssemblyPaths">
 
     <ItemGroup>
       <!--

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -597,7 +597,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <Target Name="GeneratePublishDependencyFile"
           DependsOnTargets="_ComputeUseBuildDependencyFile;
                             _DefaultMicrosoftNETPlatformLibrary;
-                            _HandlePackageFileConflictsForBuild;
+                            _HandlePackageFileConflicts;
                             _HandlePackageFileConflictsForPublish;
                             _ComputeReferenceAssemblies"
           Condition="'$(GenerateDependencyFile)' == 'true' and '$(_UseBuildDependencyFile)' != 'true'">

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -115,7 +115,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <Target Name="GenerateBuildDependencyFile"
           DependsOnTargets="_DefaultMicrosoftNETPlatformLibrary;
-                            _HandlePackageFileConflictsForBuild;
+                            _HandlePackageFileConflicts;
                             _ComputeReferenceAssemblies"
           BeforeTargets="CopyFilesToOutputDirectory"
           Condition="'$(GenerateDependencyFile)' == 'true'"

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.PackageDependencyResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.PackageDependencyResolution.targets
@@ -71,12 +71,12 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ResolveAssemblyReferencesDependsOn>
       $(ResolveAssemblyReferencesDependsOn);
       ResolvePackageDependenciesForBuild;
-      _HandlePackageFileConflictsForBuild;
+      _HandlePackageFileConflicts;
     </ResolveAssemblyReferencesDependsOn>
 
     <PrepareResourcesDependsOn>
       ResolvePackageDependenciesForBuild;
-      _HandlePackageFileConflictsForBuild;
+      _HandlePackageFileConflicts;
       $(PrepareResourcesDependsOn)
     </PrepareResourcesDependsOn>
   </PropertyGroup>

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildADesktopExeWtihNetStandardLib.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildADesktopExeWtihNetStandardLib.cs
@@ -220,7 +220,7 @@ namespace Microsoft.NET.Build.Tests
                         // Add a target to validate that no conflicts are from support libs
                         var target = new XElement(ns + "Target",
                             new XAttribute("Name", "CheckForConflicts"),
-                            new XAttribute("AfterTargets", "_HandlePackageFileConflictsForBuild"));
+                            new XAttribute("AfterTargets", "_HandlePackageFileConflicts"));
                         project.Root.Add(target);
 
                         target.Add(new XElement(ns + "FindUnderPath",


### PR DESCRIPTION
This commit renames the `_HandlePackageFileConflictsForBuild` target back to
the original name of `_HandlePackageFileConflicts`.

This prevents a failure to find the target when using a previously shipping
`Microsoft.NET.Build.Extensions.NETFramework.targets` with a 3.0 .NET Core SDK.

Fixes #2695.