### PR TITLE
Spaces in the configuration name create invalid preprocessor defines

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.CSharp.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.CSharp.targets
@@ -28,6 +28,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     
     <ImplicitConfigurationDefine>$(ImplicitConfigurationDefine.Replace('-', '_'))</ImplicitConfigurationDefine>
     <ImplicitConfigurationDefine>$(ImplicitConfigurationDefine.Replace('.', '_'))</ImplicitConfigurationDefine>
+    <ImplicitConfigurationDefine>$(ImplicitConfigurationDefine.Replace(' ', '_'))</ImplicitConfigurationDefine>
     <DefineConstants>$(DefineConstants);$(ImplicitConfigurationDefine)</DefineConstants>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.VisualBasic.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.VisualBasic.targets
@@ -55,6 +55,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     
     <ImplicitConfigurationDefine>$(ImplicitConfigurationDefine.Replace('-', '_'))</ImplicitConfigurationDefine>
     <ImplicitConfigurationDefine>$(ImplicitConfigurationDefine.Replace('.', '_'))</ImplicitConfigurationDefine>
+    <ImplicitConfigurationDefine>$(ImplicitConfigurationDefine.Replace(' ', '_'))</ImplicitConfigurationDefine>
     <!-- In F# and C# this is called DefineConstants, VB is idiosyncratic and calls it FinalDefineConstants -->
   </PropertyGroup>
 

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildASolutionWithNonDefaultConfiguration.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildASolutionWithNonDefaultConfiguration.cs
@@ -1,0 +1,56 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using Microsoft.NET.TestFramework;
+using Microsoft.NET.TestFramework.Assertions;
+using Microsoft.NET.TestFramework.Commands;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.NET.Build.Tests
+{
+    public class GivenThatWeWantToBuildASolutionWithNonDefaultConfiguration : SdkTest
+    {
+        public GivenThatWeWantToBuildASolutionWithNonDefaultConfiguration(ITestOutputHelper log) : base(log)
+        {
+        }
+
+        [Theory]
+        [InlineData("Release With Spaces", "RELEASE_WITH_SPACES")]
+        [InlineData("Release-With-Hyphens", "RELEASE_WITH_HYPHENS")]
+        [InlineData("Release.With.Dots", "RELEASE_WITH_DOTS")]
+        [InlineData("Release.With-A Mix", "RELEASE_WITH_A_MIX")]
+        public void Properly_changes_implicit_defines(string configuration, string expected)
+        {
+            var targetFramework = "net45";
+            var testAsset = _testAssetsManager
+                .CopyTestAsset("HelloWorld")
+                .WithSource()
+                .WithProjectChanges(project =>
+                {
+                    var ns = project.Root.Name.Namespace;
+                    var propertyGroup = project.Root.Elements(ns + "PropertyGroup").First();
+                    propertyGroup.Element(ns + "TargetFramework").SetValue(targetFramework);
+                    propertyGroup.SetElementValue(ns + "Configurations", configuration);
+                })
+                .Restore(Log);
+
+
+            var buildCommand = new BuildCommand(Log, testAsset.TestRoot);
+            buildCommand
+                .Execute(new[] { "/v:d", $"/p:Configuration={configuration}" })
+                .Should().HaveStdOutContaining($"$(ImplicitConfigurationDefine)=\"{expected}\"");
+
+            var outputDirectory = buildCommand.GetOutputDirectory(targetFramework, configuration);
+
+            outputDirectory.Should().OnlyHaveFiles(new[] {
+                "HelloWorld.exe",
+                "HelloWorld.exe.config",
+                "HelloWorld.pdb",
+            });
+        }
+    }
+}

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildASolutionWithNonDefaultConfiguration.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildASolutionWithNonDefaultConfiguration.cs
@@ -4,6 +4,7 @@
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
+using Microsoft.DotNet.Cli.Utils;
 using Microsoft.NET.TestFramework;
 using Microsoft.NET.TestFramework.Assertions;
 using Microsoft.NET.TestFramework.Commands;
@@ -25,7 +26,7 @@ namespace Microsoft.NET.Build.Tests
         [InlineData("Release.With-A Mix", "RELEASE_WITH_A_MIX")]
         public void Properly_changes_implicit_defines(string configuration, string expected)
         {
-            var targetFramework = "net45";
+            var targetFramework = "netcoreapp1.0";
             var testAsset = _testAssetsManager
                 .CopyTestAsset("HelloWorld")
                 .WithSource()
@@ -47,9 +48,11 @@ namespace Microsoft.NET.Build.Tests
             var outputDirectory = buildCommand.GetOutputDirectory(targetFramework, configuration);
 
             outputDirectory.Should().OnlyHaveFiles(new[] {
-                "HelloWorld.exe",
-                "HelloWorld.exe.config",
+                "HelloWorld.dll",
                 "HelloWorld.pdb",
+                "HelloWorld.deps.json",
+                "HelloWorld.runtimeconfig.dev.json",
+                "HelloWorld.runtimeconfig.json",
             });
         }
     }

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildASolutionWithNonDefaultConfigurationVB.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildASolutionWithNonDefaultConfigurationVB.cs
@@ -1,0 +1,56 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using Microsoft.NET.TestFramework;
+using Microsoft.NET.TestFramework.Assertions;
+using Microsoft.NET.TestFramework.Commands;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.NET.Build.Tests
+{
+    public class GivenThatWeWantToBuildASolutionWithNonDefaultConfigurationVB : SdkTest
+    {
+        public GivenThatWeWantToBuildASolutionWithNonDefaultConfigurationVB(ITestOutputHelper log) : base(log)
+        {
+        }
+
+        [Theory]
+        [InlineData("Release With Spaces", "RELEASE_WITH_SPACES")]
+        [InlineData("Release-With-Hyphens", "RELEASE_WITH_HYPHENS")]
+        [InlineData("Release.With.Dots", "RELEASE_WITH_DOTS")]
+        [InlineData("Release.With-A Mix", "RELEASE_WITH_A_MIX")]
+        public void Properly_changes_implicit_defines(string configuration, string expected)
+        {
+            var targetFramework = "net45";
+            var testAsset = _testAssetsManager
+                .CopyTestAsset("HelloWorldVB")
+                .WithSource()
+                .WithProjectChanges(project =>
+                {
+                    var ns = project.Root.Name.Namespace;
+                    var propertyGroup = project.Root.Elements(ns + "PropertyGroup").First();
+                    propertyGroup.Element(ns + "TargetFramework").SetValue(targetFramework);
+                    propertyGroup.SetElementValue(ns + "Configurations", configuration);
+                })
+                .Restore(Log);
+
+
+            var buildCommand = new BuildCommand(Log, testAsset.TestRoot);
+            buildCommand
+                .Execute(new[] { "/v:d", $"/p:Configuration={configuration}" })
+                .Should().HaveStdOutContaining($"$(ImplicitConfigurationDefine)=\"{expected}\"");
+
+            var outputDirectory = buildCommand.GetOutputDirectory(targetFramework, configuration);
+
+            outputDirectory.Should().OnlyHaveFiles(new[] {
+                "HelloWorld.exe",
+                "HelloWorld.exe.config",
+                "HelloWorld.pdb",
+            });
+        }
+    }
+}

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildASolutionWithNonDefaultConfigurationVB.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildASolutionWithNonDefaultConfigurationVB.cs
@@ -25,7 +25,7 @@ namespace Microsoft.NET.Build.Tests
         [InlineData("Release.With-A Mix", "RELEASE_WITH_A_MIX")]
         public void Properly_changes_implicit_defines(string configuration, string expected)
         {
-            var targetFramework = "net45";
+            var targetFramework = "netcoreapp1.0";
             var testAsset = _testAssetsManager
                 .CopyTestAsset("HelloWorldVB")
                 .WithSource()
@@ -47,9 +47,11 @@ namespace Microsoft.NET.Build.Tests
             var outputDirectory = buildCommand.GetOutputDirectory(targetFramework, configuration);
 
             outputDirectory.Should().OnlyHaveFiles(new[] {
-                "HelloWorld.exe",
-                "HelloWorld.exe.config",
+                "HelloWorld.dll",
                 "HelloWorld.pdb",
+                "HelloWorld.deps.json",
+                "HelloWorld.runtimeconfig.dev.json",
+                "HelloWorld.runtimeconfig.json",
             });
         }
     }


### PR DESCRIPTION
If you have a custom configuration, such as "Release Obfuscated", the implicit defines created contain spaces, but they don't throw any compiler errors. Though they are still unusable.
Replace spaces if they exist in the configuration name.

For example, as shown in Visual Studio IDE:

`NETSTANDARD2_0;RELEASE OBFUSCATED;MYDEFINE`