### PR TITLE
Use PackageVersion for shim gen

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.PackTool.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.PackTool.targets
@@ -81,7 +81,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       DotNetAppHostExecutableNameWithoutExtension="$(_DotNetAppHostExecutableNameWithoutExtension)"
       PackagedShimOutputDirectory="$(PackagedShimOutputRootDirectory)/shims/$(TargetFramework)"
       PackageId="$(PackageId)"
-      PackageVersion="$(Version)"
+      PackageVersion="$(PackageVersion)"
       ProjectAssetsFile="$(ProjectAssetsFile)"
       ProjectPath="$(MSBuildProjectFullPath)"
       ShimRuntimeIdentifiers="@(_PackAsToolShimRuntimeIdentifiers)"

--- a/src/Tests/Microsoft.NET.ToolPack.Tests/GivenThatWeWantToPackAToolProjectWithPackagedShim.cs
+++ b/src/Tests/Microsoft.NET.ToolPack.Tests/GivenThatWeWantToPackAToolProjectWithPackagedShim.cs
@@ -29,7 +29,7 @@ namespace Microsoft.NET.ToolPack.Tests
         {
         }
 
-        private string SetupNuGetPackage(bool multiTarget, [CallerMemberName] string callingMethod = "")
+        private string SetupNuGetPackage(bool multiTarget, [CallerMemberName] string callingMethod = "", Dictionary<string, string> additionalProperty = null)
         {
             TestAsset helloWorldAsset = _testAssetsManager
                 .CopyTestAsset("PortableTool", callingMethod + multiTarget)
@@ -40,6 +40,14 @@ namespace Microsoft.NET.ToolPack.Tests
                     XElement propertyGroup = project.Root.Elements(ns + "PropertyGroup").First();
                     propertyGroup.Add(new XElement(ns + "PackAsToolShimRuntimeIdentifiers", "win-x64;osx.10.12-x64"));
                     propertyGroup.Add(new XElement(ns + "ToolCommandName", _customToolCommandName));
+
+                    if (additionalProperty != null)
+                    {
+                        foreach (KeyValuePair<string, string> pair in additionalProperty)
+                        {
+                            propertyGroup.Add(new XElement(ns + pair.Key, pair.Value));
+                        }
+                    }
 
                     if (multiTarget)
                     {
@@ -163,6 +171,32 @@ namespace Microsoft.NET.ToolPack.Tests
             }
 
             var nugetPackage = SetupNuGetPackage(multiTarget);
+            AssertShimIsValid(nugetPackage);
+        }
+
+        [WindowsOnlyTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void When_version_and_packageVersion_is_different_It_produces_valid_shims(bool multiTarget)
+        {
+            if (!Environment.Is64BitOperatingSystem)
+            {
+                // only sample test on win-x64 since shims are RID specific
+                return;
+            }
+
+            var nugetPackage = SetupNuGetPackage(multiTarget,
+                additionalProperty: new Dictionary<string, string>()
+                {
+                    ["version"] = "1.0.0-rtm",
+                    ["packageVersion"] = _packageVersion
+                });
+
+            AssertShimIsValid(nugetPackage);
+        }
+
+        private void AssertShimIsValid(string nugetPackage)
+        {
             using (var nupkgReader = new PackageArchiveReader(nugetPackage))
             {
                 IEnumerable<NuGetFramework> supportedFrameworks = nupkgReader.GetSupportedFrameworks();


### PR DESCRIPTION
fix #2698
PackageVersion should be the source of truth for nuget layout.

https://github.com/NuGet/NuGet.Client/blob/3c9b61826814dc800a2a295f0985ce4f295483d6/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.targets#L28