### PR TITLE
Exclude unit test projects from source-build

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -29,6 +29,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(IsTestProject)' == 'true'">
+    <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <GenerateProgramFile>false</GenerateProgramFile>
     <XUnitRunnerAdditionalArguments>-parallel none</XUnitRunnerAdditionalArguments>


### PR DESCRIPTION
Reopening https://github.com/dotnet/sdk/pull/2642. (I don't seem to have permissions to reopen the PR in-place.)

> This is a patch for removing test dependencies from source-build: https://github.com/dotnet/source-build/pull/847.
> 
> RepoToolset picks up on this `ExcludeFromSourceBuild` property I'm adding and disables restore and build.
> 
> @nguerrera, PTAL.

This is the patch directly: https://github.com/dotnet/source-build/blob/ecc7b00f5b7cf2d21cb6f545669690f7ab4996fc/patches/sdk/0001-Exclude-unit-test-projects-from-source-build.patch. Getting patch fixes pulled into the repo is important to us to avoid maintenance costs.