### PR TITLE
Fix package version 1000 cannot install

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/GenerateShims.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/GenerateShims.cs
@@ -8,6 +8,7 @@ using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using NuGet.Frameworks;
 using NuGet.ProjectModel;
+using NuGet.Versioning;
 
 namespace Microsoft.NET.Build.Tasks
 {
@@ -102,15 +103,17 @@ namespace Microsoft.NET.Build.Tasks
 
                 Directory.CreateDirectory(packagedShimOutputDirectoryAndRid);
 
+                // per https://github.com/dotnet/cli/issues/9870 nuget layout (as in {packageid}/{packageversion}/tools/)is normalized version
+                var normalizedPackageVersion = NuGetVersion.Parse(PackageVersion).ToNormalizedString();
                 // This is the embedded string. We should normalize it on forward slash, so the file won't be different according to
                 // build machine.
                 var appBinaryFilePath = string.Join("/",
                     new[] {
                         ".store",
                         PackageId.ToLowerInvariant(),
-                        PackageVersion,
+                        normalizedPackageVersion,
                         PackageId.ToLowerInvariant(),
-                        PackageVersion,
+                        normalizedPackageVersion,
                         "tools",
                         targetFramework.GetShortFolderName(),
                         "any",

--- a/src/Tests/Microsoft.NET.ToolPack.Tests/GivenThatWeWantToPackAToolProjectWithPackagedShim.cs
+++ b/src/Tests/Microsoft.NET.ToolPack.Tests/GivenThatWeWantToPackAToolProjectWithPackagedShim.cs
@@ -22,7 +22,7 @@ namespace Microsoft.NET.ToolPack.Tests
     {
         private string _testRoot;
         private string _packageId;
-        private readonly string _packageVersion = "1.0.0";
+        private string _packageVersion = "1.0.0";
         private const string _customToolCommandName = "customToolCommandName";
 
         public GivenThatWeWantToPackAToolProjectWithPackagedShim(ITestOutputHelper log) : base(log)
@@ -64,7 +64,7 @@ namespace Microsoft.NET.ToolPack.Tests
             packCommand.Execute();
             _packageId = Path.GetFileNameWithoutExtension(packCommand.ProjectFile);
 
-            return packCommand.GetNuGetPackage();
+            return packCommand.GetNuGetPackage(packageVersion: _packageVersion);
         }
 
         [Theory]
@@ -190,6 +190,28 @@ namespace Microsoft.NET.ToolPack.Tests
                 {
                     ["version"] = "1.0.0-rtm",
                     ["packageVersion"] = _packageVersion
+                });
+
+            AssertShimIsValid(nugetPackage);
+        }
+
+        [WindowsOnlyTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void When_version_and_packageVersion_is_different_It_produces_valid_shims2(bool multiTarget)
+        {
+            if (!Environment.Is64BitOperatingSystem)
+            {
+                // only sample test on win-x64 since shims are RID specific
+                return;
+            }
+
+            _packageVersion = "1000.0.0";
+
+            var nugetPackage = SetupNuGetPackage(multiTarget,
+                additionalProperty: new Dictionary<string, string>()
+                {
+                    ["version"] = "1000",
                 });
 
             AssertShimIsValid(nugetPackage);


### PR DESCRIPTION
run `dotnet pack -p:version=1000` with packaged shim, and the result package cannot run. Due to embedded shim has version "1000" while the actual nuget folder layout is "1000.0.0".

the version need to be normalized to much the layout. Per discussion https://github.com/dotnet/cli/issues/9870