### PR TITLE
Remove NETStandard.Library version override

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,7 +10,6 @@
   <Import Project="Sdk.props" Sdk="Microsoft.DotNet.Arcade.Sdk" />
 
   <PropertyGroup>
-    <NetStandardImplicitPackageVersion>1.6.0</NetStandardImplicitPackageVersion>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <DebugType>embedded</DebugType>
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
This caused downgrade errors while trying to manually build projects in the .perftestsource repo.

We should make sure to prevent the perf test projects from picking up the outer repository customization, and I believe @johnbeisner is looking at that.

Nevertheless, I see no reason for this override remaining, so taking the opportunity to clean it up. We don't even have any non-test assets in this repo targeting netstandard.