### PR TITLE
Use correct property name for additional test runner arguments

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -28,7 +28,7 @@
   <PropertyGroup Condition="'$(IsTestProject)' == 'true'">
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <GenerateProgramFile>false</GenerateProgramFile>
-    <XUnitRunnerAdditionalArguments>-parallel none</XUnitRunnerAdditionalArguments>
+    <TestRunnerAdditionalArguments>-parallel none</TestRunnerAdditionalArguments>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
React to https://github.com/dotnet/arcade/pull/1438

Fix #2712 

We were running with too many levels of paralellism, spawning too many processes, and slowing down test runs while wasting resources.