### PR TITLE
Separate copying of refs from preservation of compilation info

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Extensions.Tasks/Microsoft.NET.Build.Extensions.Tasks.csproj
+++ b/src/Tasks/Microsoft.NET.Build.Extensions.Tasks/Microsoft.NET.Build.Extensions.Tasks.csproj
@@ -72,7 +72,7 @@
 
   <Target Name="PrepareAdditionalFilesToLayout" BeforeTargets="AssignTargetPaths">
     <PropertyGroup>
-      <_NETStandardLibraryNETFrameworkPath>$(NuGetPackageRoot)NETStandard.Library.NETFramework\$(NETStandardLibraryNETFrameworkVersion)\build</_NETStandardLibraryNETFrameworkPath>
+      <_NETStandardLibraryNETFrameworkPath>$(NuGetPackageRoot)netstandard.library.netframework\$(NETStandardLibraryNETFrameworkVersion)\build</_NETStandardLibraryNETFrameworkPath>
     </PropertyGroup>
     <ItemGroup>
       <LayoutFile Include="@(None)" Condition="'%(None.PackagePath)' != ''">

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.PreserveCompilationContext.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.PreserveCompilationContext.targets
@@ -15,6 +15,8 @@ Copyright (c) .NET Foundation. All rights reserved.
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
 
     <RefAssembliesFolderName Condition="'$(RefAssembliesFolderName)' == ''">refs</RefAssembliesFolderName>
+    
+    <PreserveCompilationReferences Condition=" '$(PreserveCompilationReferences)' == ''">$(PreserveCompilationContext)</PreserveCompilationReferences>
   </PropertyGroup>
 
   <Target Name="ComputeDependencyFileCompilerOptions"
@@ -43,7 +45,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <UsingTask TaskName="FindItemsFromPackages" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
   <Target Name="ComputeRefAssembliesToPublish"
-          Condition="'$(PreserveCompilationContext)' == 'true'"
+          Condition="'$(PreserveCompilationReferences)' == 'true'"
           DependsOnTargets="ResolvePackageAssets;
                             _ParseTargetManifestFiles"
           AfterTargets="ComputeFilesToPublish"
@@ -82,7 +84,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     ============================================================
     -->
   <Target Name="_CopyReferenceOnlyAssembliesForBuild"
-          Condition="'$(PreserveCompilationContext)' == 'true'"
+          Condition="'$(PreserveCompilationReferences)' == 'true'"
           DependsOnTargets="_ComputeReferenceAssemblies"
           AfterTargets="CopyFilesToOutputDirectory">
 


### PR DESCRIPTION
PreserveCompilationContext does two things today:

1. Write compilation info to .deps
2. Copy reference-only assemblies to build/publish refs/ folder

Add PreserveCompilationReferences to control (2) independently and default it to PreserveCompilationContext for backwards compatibility.

Fix #2122 

cc @pranavkm @rynowak @eerhardt 