### PR TITLE
Respect PlatformTarget when setting DefaultAppHostRuntimeIdentifier.

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets
@@ -111,6 +111,22 @@ Copyright (c) .NET Foundation. All rights reserved.
     <UseAppHost Condition="'$(UseAppHost)' == ''">false</UseAppHost>
   </PropertyGroup>
 
+  <!-- Only use the default apphost if building without a RID and without a deps file path (used by GenerateDeps.proj for CLI tools). -->
+  <PropertyGroup Condition="'$(DefaultAppHostRuntimeIdentifier)' == '' and
+                            '$(RuntimeIdentifier)' == '' and
+                            '$(UseAppHost)' == 'true' and
+                            '$(ProjectDepsFilePath)' == ''">
+    <DefaultAppHostRuntimeIdentifier>$(NETCoreSdkRuntimeIdentifier)</DefaultAppHostRuntimeIdentifier>
+    <DefaultAppHostRuntimeIdentifier Condition="$(DefaultAppHostRuntimeIdentifier.StartsWith('win')) and '$(PlatformTarget)' == 'x64'">win-x64</DefaultAppHostRuntimeIdentifier>
+    <DefaultAppHostRuntimeIdentifier Condition="$(DefaultAppHostRuntimeIdentifier.StartsWith('win')) and '$(PlatformTarget)' == 'x86'">win-x86</DefaultAppHostRuntimeIdentifier>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(DefaultAppHostRuntimeIdentifier)' != '' and
+                            '$(TargetFrameworkIdentifier)' == '.NETCoreApp' and
+                            '$(_TargetFrameworkVersionWithoutV)' &lt; '3.0'">
+    <RuntimeIdentifiers>$(RuntimeIdentifiers);$(DefaultAppHostRuntimeIdentifier)</RuntimeIdentifiers>
+  </PropertyGroup>
+
   <Target Name="_CheckForUnsupportedAppHostUsage"
           BeforeTargets="_CheckForInvalidConfigurationAndPlatform"
           Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' and '$(HasRuntimeOutput)' == 'true'">

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.Common.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.Common.targets
@@ -28,17 +28,6 @@ Copyright (c) .NET Foundation. All rights reserved.
     <DefaultImplicitPackages>Microsoft.NETCore.App;NETStandard.Library</DefaultImplicitPackages>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <!-- Only use the default apphost if building without a RID and without a deps file path (used by GenerateDeps.proj for CLI tools). -->
-    <!-- This needs to be set prior to _IsExecutable being reassigned below. -->
-    <DefaultAppHostRuntimeIdentifier Condition="'$(DefaultAppHostRuntimeIdentifier)' == '' and '$(RuntimeIdentifier)' == '' and '$(UseAppHost)' == 'true' and '$(_IsExecutable)' == 'true' and '$(ProjectDepsFilePath)' == ''">$(NETCoreSdkRuntimeIdentifier)</DefaultAppHostRuntimeIdentifier>    
-  </PropertyGroup>
-  <!-- If targeting a version prior to 3.0, then the apphost will come from the assets file, and we need to restore for that runtime identifier -->
-  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'
-                          and '$(_TargetFrameworkVersionWithoutV)' &lt; '3.0'">
-    <RuntimeIdentifiers Condition="'$(DefaultAppHostRuntimeIdentifier)' != ''">$(RuntimeIdentifiers);$(DefaultAppHostRuntimeIdentifier)</RuntimeIdentifiers>
-  </PropertyGroup>
-
   <!--
      Some versions of Microsoft.NET.Test.Sdk.targets change the OutputType after we've set _IsExecutable and
      HasRuntimeOutput default in Microsoft.NET.Sdk.BeforeCommon.targets. Refresh these value here for backwards


### PR DESCRIPTION
This commit uses `PlatformTarget` to determine the value for
`DefaultAppHostRuntimeIdentifier` on Windows.

If `PlatformTarget` is set to `x86`, then a PE32 apphost is used.

If `PlatformTarget` is set to `x64`, then a PE32+ apphost is used.

Otherwise, the apphost for the SDK RID is used.

Fixes #2632.