### PR TITLE
Limit default apphost feature to netcoreapp3.0 targeted apps.

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageAssets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageAssets.cs
@@ -55,11 +55,6 @@ namespace Microsoft.NET.Build.Tasks
         public string RuntimeIdentifier { get; set; }
 
         /// <summary>
-        /// The runtime identifier for the default apphost.
-        /// </summary>
-        public string DefaultAppHostRuntimeIdentifier { get; set; }
-
-        /// <summary>
         /// The platform library name for resolving copy local assets.
         /// </summary>
         public string PlatformLibraryName { get; set; }
@@ -261,7 +256,7 @@ namespace Microsoft.NET.Build.Tasks
         ////////////////////////////////////////////////////////////////////////////////////////////////////
 
         private const int CacheFormatSignature = ('P' << 0) | ('K' << 8) | ('G' << 16) | ('A' << 24);
-        private const int CacheFormatVersion = 4;
+        private const int CacheFormatVersion = 5;
         private static readonly Encoding TextEncoding = Encoding.UTF8;
         private const int SettingsHashLength = 256 / 8;
         private HashAlgorithm CreateSettingsHash() => SHA256.Create();
@@ -397,7 +392,6 @@ namespace Microsoft.NET.Build.Tasks
                     writer.Write(ProjectLanguage ?? "");
                     writer.Write(ProjectPath);
                     writer.Write(RuntimeIdentifier ?? "");
-                    writer.Write(DefaultAppHostRuntimeIdentifier ?? "");
                     if (ShimRuntimeIdentifiers != null)
                     {
                         foreach (var r in ShimRuntimeIdentifiers)
@@ -950,26 +944,6 @@ namespace Microsoft.NET.Build.Tasks
                             WriteCopyLocalMetadata(package, Path.GetFileName(asset.Path), "native");
                         }
                     });
-
-                WriteDefaultNativeApphostAsset();
-            }
-
-            private void WriteDefaultNativeApphostAsset()
-            {
-                if (string.IsNullOrEmpty(_task.DefaultAppHostRuntimeIdentifier))
-                {
-                    return;
-                }
-
-                var assetPathAndLibrary = FindApphostInRuntimeTarget(
-                    _task.DotNetAppHostExecutableNameWithoutExtension + ExecutableExtension.ForRuntimeIdentifier(_task.DefaultAppHostRuntimeIdentifier),
-                    _lockFile.GetTargetAndThrowIfNotFound(
-                        NuGetUtils.ParseFrameworkName(_task.TargetFrameworkMoniker),
-                        _task.DefaultAppHostRuntimeIdentifier
-                    )
-                );
-
-                WriteItem(assetPathAndLibrary.Item1, assetPathAndLibrary.Item2);
             }
 
             private void WriteApphostsForShimRuntimeIdentifiers()

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets
@@ -107,7 +107,10 @@ Copyright (c) .NET Foundation. All rights reserved.
   <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' and '$(HasRuntimeOutput)' == 'true'">
     <SelfContained Condition="'$(SelfContained)' == '' and '$(RuntimeIdentifier)' != ''">true</SelfContained>
     <SelfContained Condition="'$(SelfContained)' == ''">false</SelfContained>
-    <UseAppHost Condition="'$(UseAppHost)' == '' and ('$(SelfContained)' == 'true' or '$(_TargetFrameworkVersionWithoutV)' >= '2.1')">true</UseAppHost>
+    <UseAppHost Condition="'$(UseAppHost)' == '' and
+                           ('$(SelfContained)' == 'true' or
+                            ('$(RuntimeIdentifier)' != '' and '$(_TargetFrameworkVersionWithoutV)' >= '2.1') or
+                            '$(_TargetFrameworkVersionWithoutV)' >= '3.0')">true</UseAppHost>
     <UseAppHost Condition="'$(UseAppHost)' == ''">false</UseAppHost>
   </PropertyGroup>
 
@@ -119,12 +122,6 @@ Copyright (c) .NET Foundation. All rights reserved.
     <DefaultAppHostRuntimeIdentifier>$(NETCoreSdkRuntimeIdentifier)</DefaultAppHostRuntimeIdentifier>
     <DefaultAppHostRuntimeIdentifier Condition="$(DefaultAppHostRuntimeIdentifier.StartsWith('win')) and '$(PlatformTarget)' == 'x64'">win-x64</DefaultAppHostRuntimeIdentifier>
     <DefaultAppHostRuntimeIdentifier Condition="$(DefaultAppHostRuntimeIdentifier.StartsWith('win')) and '$(PlatformTarget)' == 'x86'">win-x86</DefaultAppHostRuntimeIdentifier>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(DefaultAppHostRuntimeIdentifier)' != '' and
-                            '$(TargetFrameworkIdentifier)' == '.NETCoreApp' and
-                            '$(_TargetFrameworkVersionWithoutV)' &lt; '3.0'">
-    <RuntimeIdentifiers>$(RuntimeIdentifiers);$(DefaultAppHostRuntimeIdentifier)</RuntimeIdentifiers>
   </PropertyGroup>
 
   <Target Name="_CheckForUnsupportedAppHostUsage"

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.PackageDependencyResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.PackageDependencyResolution.targets
@@ -209,7 +209,6 @@ Copyright (c) .NET Foundation. All rights reserved.
     </PropertyGroup>
     <PropertyGroup Condition="'$(UseAppHostFromAssetsFile)' == ''">
       <UseAppHostFromAssetsFile>true</UseAppHostFromAssetsFile>
-      <DefaultAppHostRuntimeIdentifierFromAssetsFile>$(DefaultAppHostRuntimeIdentifier)</DefaultAppHostRuntimeIdentifierFromAssetsFile>
     </PropertyGroup>
     
     <PropertyGroup Condition="'$(EnsureRuntimePackageDependencies)' == ''
@@ -237,7 +236,6 @@ Copyright (c) .NET Foundation. All rights reserved.
       EmitAssetsLogMessages="$(EmitAssetsLogMessages)"
       TargetFrameworkMoniker="$(NuGetTargetMoniker)"
       RuntimeIdentifier="$(RuntimeIdentifier)"
-      DefaultAppHostRuntimeIdentifier="$(DefaultAppHostRuntimeIdentifierFromAssetsFile)"
       PlatformLibraryName="$(MicrosoftNETPlatformLibrary)"
       RuntimeFrameworks="@(RuntimeFramework)"
       IsSelfContained="$(SelfContained)"

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildADesktopExeWithFSharp.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildADesktopExeWithFSharp.cs
@@ -62,7 +62,7 @@ namespace Microsoft.NET.Build.Tests
         [WindowsOnlyFact]
         public void It_can_customize_the_apphost()
         {
-            var targetFramework = "netcoreapp2.1";
+            var targetFramework = "netcoreapp3.0";
             var testAsset = _testAssetsManager
                 .CopyTestAsset("HelloWorldFS")
                 .WithSource()
@@ -76,7 +76,7 @@ namespace Microsoft.NET.Build.Tests
 
             var buildCommand = new BuildCommand(Log, testAsset.TestRoot);
             buildCommand
-                .Execute()
+                .Execute("/p:CopyLocalLockFileAssemblies=false")
                 .Should()
                 .Pass();
 

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildANetCoreApp.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildANetCoreApp.cs
@@ -254,7 +254,6 @@ namespace Microsoft.NET.Build.Tests
         }
 
         [Theory]
-        [InlineData("netcoreapp2.1")]
         [InlineData("netcoreapp3.0")]
         public void It_builds_a_runnable_apphost_by_default(string targetFramework)
         {
@@ -293,6 +292,33 @@ namespace Microsoft.NET.Build.Tests
                 .Pass()
                 .And
                 .HaveStdOutContaining("Hello World!");
+        }
+
+        [Theory]
+        [InlineData("netcoreapp2.1")]
+        [InlineData("netcoreapp2.2")]
+        public void It_does_not_build_with_an_apphost_by_default_before_netcoreapp_3(string targetFramework)
+        {
+            var testAsset = _testAssetsManager
+                .CopyTestAsset("HelloWorld", identifier: targetFramework)
+                .WithSource()
+                .WithTargetFramework(targetFramework);
+
+            var buildCommand = new BuildCommand(Log, testAsset.TestRoot);
+            buildCommand
+                .Execute(new string[] { "/restore" })
+                .Should()
+                .Pass();
+
+            var outputDirectory = buildCommand.GetOutputDirectory(targetFramework);
+
+            outputDirectory.Should().OnlyHaveFiles(new[] {
+                "HelloWorld.dll",
+                "HelloWorld.pdb",
+                "HelloWorld.deps.json",
+                "HelloWorld.runtimeconfig.dev.json",
+                "HelloWorld.runtimeconfig.json",
+            });
         }
 
         [WindowsOnlyTheory]


### PR DESCRIPTION
This commit limits the default apphost feature to applications that target
`netcoreapp3.0` or later.

This prevents altering the expected outputs of previous projects after an
upgrade to a 3.0 SDK.

More importantly, this allows for the removal of the hack that was put in place
to force a restore of the SDK RID to obtain the apphost; the apphost is now
resolved through framework references.

Fixes dotnet/cli#10566.