### PR TITLE
Sort xlf files

### DIFF
--- a/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
@@ -2,35 +2,25 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../Strings.resx">
     <body>
-      <trans-unit id="AspNetCoreAllNotSupported">
-        <source>NETSDK1079: The Microsoft.AspNetCore.All package is not supported when targeting .NET Core 3.0 or higher.  A FrameworkReference to Microsoft.AspNetCore.App should be used instead, and will be implicitly included by Microsoft.NET.Sdk.Web.</source>
-        <target state="translated">NETSDK1079: Balíček Microsoft.AspNetCore.All se při cílení na .NET Core 3.0 nebo vyšší nepodporuje. Místo toho byste měli použít FrameworkReference na Microsoft.AspNetCore.App. Ten implicitně zahrnuje Microsoft.NET.Sdk.Web.</target>
-        <note>{StrBegin="NETSDK1079: "}</note>
-      </trans-unit>
-      <trans-unit id="AspNetCoreUsesFrameworkReference">
-        <source>NETSDK1080: A PackageReference to Microsoft.AspNetCore.App is not necessary when targeting .NET Core 3.0 or higher. If Microsoft.NET.Sdk.Web is used, the shared framework will be referenced automatically. Otherwise, the PackageReference should be replaced with a FrameworkReference.</source>
-        <target state="translated">NETSDK1080: Při cílení na .NET Core 3.0 nebo vyšší se nevyžaduje PackageReference na Microsoft.AspNetCore.App. Pokud použijete Microsoft.NET.Sdk.Web, bude se na sdílenou platformu odkazovat automaticky. V opačném případě byste místo PackageReference měli použít FrameworkReference.</target>
-        <note>{StrBegin="NETSDK1080: "}</note>
-      </trans-unit>
-      <trans-unit id="FailedToLockResource">
-        <source>NETSDK1077: Failed to lock resource.</source>
-        <target state="translated">NETSDK1077: Prostředek se nepovedlo uzamknout.</target>
-        <note>{StrBegin="NETSDK1077: "}</note>
-      </trans-unit>
       <trans-unit id="AddResourceWithNonIntegerResource">
         <source>NETSDK1076: AddResource can only be used with integer resource types.</source>
         <target state="translated">NETSDK1076: AddResource se dá použít jenom se zdroji typu celé číslo.</target>
         <note>{StrBegin="NETSDK1076: "}</note>
       </trans-unit>
-      <trans-unit id="InvalidResourceUpdate">
-        <source>NETSDK1075: Update handle is invalid. This instance may not be used for further updates.</source>
-        <target state="translated">NETSDK1075: Popisovač aktualizace není platný. Tuto instanci nejde použít pro další aktualizace.</target>
-        <note>{StrBegin="NETSDK1075: "}</note>
+      <trans-unit id="AppConfigRequiresRootConfiguration">
+        <source>NETSDK1070: The application configuration file must have root configuration element.</source>
+        <target state="translated">NETSDK1070: Konfigurační soubor aplikace musí obsahovat kořenový element konfigurace.</target>
+        <note>{StrBegin="NETSDK1070: "}</note>
       </trans-unit>
       <trans-unit id="AppHostCustomizationRequiresWindowsHostWarning">
         <source>NETSDK1074: The application host executable will not be customized because adding resources requires that the build be performed on Windows (excluding Nano Server).</source>
         <target state="translated">NETSDK1074: Hostitelský spustitelný soubor aplikace se neupraví, protože pro přidání zdrojů je nutné, aby se sestavení provedlo ve Windows (kromě Nano Serveru).</target>
         <note>{StrBegin="NETSDK1074: "}</note>
+      </trans-unit>
+      <trans-unit id="AppHostHasBeenModified">
+        <source>NETSDK1029: Unable to use '{0}' as application host executable as it does not contain the expected placeholder byte sequence '{1}' that would mark where the application name would be written.</source>
+        <target state="translated">NETSDK1029: {0} nelze použít jako spustitelný soubor hostitele aplikace, protože neobsahuje očekávanou zástupnou bajtovou posloupnost {1}, která by označila, kam se má zapsat název aplikace.</target>
+        <note>{StrBegin="NETSDK1029: "}</note>
       </trans-unit>
       <trans-unit id="AppHostNotWindows">
         <source>NETSDK1078: Unable to use '{0}' as application host executable because it's not a Windows PE file.</source>
@@ -42,210 +32,80 @@
         <target state="translated">NETSDK1072: Unable to use '{0}' as application host executable because it's not a Windows executable for the CUI (Console) subsystem.</target>
         <note>{StrBegin="NETSDK1072: "}</note>
       </trans-unit>
-      <trans-unit id="AppConfigRequiresRootConfiguration">
-        <source>NETSDK1070: The application configuration file must have root configuration element.</source>
-        <target state="translated">NETSDK1070: Konfigurační soubor aplikace musí obsahovat kořenový element konfigurace.</target>
-        <note>{StrBegin="NETSDK1070: "}</note>
+      <trans-unit id="AspNetCoreAllNotSupported">
+        <source>NETSDK1079: The Microsoft.AspNetCore.All package is not supported when targeting .NET Core 3.0 or higher.  A FrameworkReference to Microsoft.AspNetCore.App should be used instead, and will be implicitly included by Microsoft.NET.Sdk.Web.</source>
+        <target state="translated">NETSDK1079: Balíček Microsoft.AspNetCore.All se při cílení na .NET Core 3.0 nebo vyšší nepodporuje. Místo toho byste měli použít FrameworkReference na Microsoft.AspNetCore.App. Ten implicitně zahrnuje Microsoft.NET.Sdk.Web.</target>
+        <note>{StrBegin="NETSDK1079: "}</note>
       </trans-unit>
-      <trans-unit id="AtLeastOneTargetFrameworkMustBeSpecified">
-        <source>NETSDK1001: At least one possible target framework must be specified.</source>
-        <target state="translated">NETSDK1001: Je potřeba zadat alespoň jednu možnou cílovou architekturu.</target>
-        <note>{StrBegin="NETSDK1001: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotUseSelfContainedWithoutAppHost">
-        <source>NETSDK1067: Self-contained applications are required to use the application host. Either set SelfContained to false or set UseAppHost to true.</source>
-        <target state="translated">NETSDK1067: K používání hostitele aplikace se vyžadují samostatné (nezávislé) aplikace. Nastavte možnost SelfContained na false nebo nastavte UseAppHost na true.</target>
-        <note>{StrBegin="NETSDK1067: "}</note>
-      </trans-unit>
-      <trans-unit id="FrameworkDependentAppHostRequiresVersion21">
-        <source>NETSDK1068: The framework-dependent application host requires a target framework of at least 'netcoreapp2.1'.</source>
-        <target state="translated">NETSDK1068: Hostitel aplikace závislé na architektuře vyžaduje cílovou architekturu nejméně netcoreapp2.1.</target>
-        <note>{StrBegin="NETSDK1068: "}</note>
-      </trans-unit>
-      <trans-unit id="NETFrameworkToNonBuiltInNETStandard">
-        <source>NETSDK1069: This project uses a library that targets .NET Standard 1.5 or higher, and the project targets a version of .NET Framework that doesn't have built-in support for that version of .NET Standard. Visit https://aka.ms/net-standard-known-issues for a set of known issues. Consider retargeting to .NET Framework 4.7.2.</source>
-        <target state="translated">NETSDK1069: Tento projekt používá knihovnu, která cílí na .NET Standard 1.5 nebo vyšší, a projekt cílí na verzi .NET Frameworku, která nemá integrovanou podporu pro tuto verzi .NET Standardu. Podívejte na stránku https://aka.ms/net-standard-known-issues, kde najdete sadu známých problémů. Zvažte změnu cíle na .NET Framework 4.7.2.</target>
-        <note>{StrBegin="NETSDK1069: "}</note>
-      </trans-unit>
-      <trans-unit id="NoAppHostAvailable">
-        <source>NETSDK1084: There is no application host available for the specified RuntimeIdentifier '{0}'.</source>
-        <target state="new">NETSDK1084: There is no application host available for the specified RuntimeIdentifier '{0}'.</target>
-        <note>{StrBegin="NETSDK1084: "}</note>
-      </trans-unit>
-      <trans-unit id="NoCompatibleTargetFramework">
-        <source>NETSDK1002: Project '{0}' targets '{2}'. It cannot be referenced by a project that targets '{1}'.</source>
-        <target state="translated">NETSDK1002: Cílem projektu {0} je {2}. Nemůže na něj odkazovat projekt, jehož cílem je {1}.</target>
-        <note>{StrBegin="NETSDK1002: "}</note>
-      </trans-unit>
-      <trans-unit id="InvalidFrameworkName">
-        <source>NETSDK1003: Invalid framework name: '{0}'.</source>
-        <target state="translated">NETSDK1003: Neplatný název architektury: {0}</target>
-        <note>{StrBegin="NETSDK1003: "}</note>
-      </trans-unit>
-      <trans-unit id="AssetsFileNotFound">
-        <source>NETSDK1004: Assets file '{0}' not found. Run a NuGet package restore to generate this file.</source>
-        <target state="translated">NETSDK1004: Soubor prostředků {0} se nenašel. Pokud chcete tento soubor vygenerovat, spusťte obnovení balíčku NuGet.</target>
-        <note>{StrBegin="NETSDK1004: "}</note>
-      </trans-unit>
-      <trans-unit id="AssetsFileMissingTarget">
-        <source>NETSDK1005: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project.</source>
-        <target state="translated">NETSDK1005: Soubor prostředků {0} nemá cíl pro {1}. Zkontrolujte, že se obnovení spustilo a že jste do vlastnosti TargetFrameworks projektu zahrnuli {2}.</target>
-        <note>{StrBegin="NETSDK1005: "}</note>
-      </trans-unit>
-      <trans-unit id="AssetsFilePathNotRooted">
-        <source>NETSDK1006: Assets file path '{0}' is not rooted. Only full paths are supported.</source>
-        <target state="translated">NETSDK1006: Cesta k souboru prostředků {0} není uvedena od kořene. Podporované jsou jen celé cesty.</target>
-        <note>{StrBegin="NETSDK1006: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotFindProjectInfo">
-        <source>NETSDK1007: Cannot find project info for '{0}'. This can indicate a missing project reference.</source>
-        <target state="translated">NETSDK1007: Nelze najít informace o projektu pro {0}. Může to znamenat chybějící odkaz na projekt.</target>
-        <note>{StrBegin="NETSDK1007: "}</note>
-      </trans-unit>
-      <trans-unit id="MissingItemMetadata">
-        <source>NETSDK1008: Missing '{0}' metadata on '{1}' item '{2}'.</source>
-        <target state="translated">NETSDK1008: Chybí metadata {0} o {1} položky {2}.</target>
-        <note>{StrBegin="NETSDK1008: "}</note>
-      </trans-unit>
-      <trans-unit id="NoRuntimePackAvailable">
-        <source>NETSDK1082: There was no runtime pack for {0} available for the specified RuntimeIdentifier '{1}'.</source>
-        <target state="new">NETSDK1082: There was no runtime pack for {0} available for the specified RuntimeIdentifier '{1}'.</target>
-        <note>{StrBegin="NETSDK1082: "}</note>
-      </trans-unit>
-      <trans-unit id="PackageReferenceVersionNotRecommended">
-        <source>NETSDK1071: A PackageReference to '{0}' specified a Version of `{1}`. Specifying the version of this package is not recommended. For more information, see https://aka.ms/sdkimplicitrefs</source>
-        <target state="translated">NETSDK1071: PackageReference na balíček {0} určuje verzi {1}. Určení verze tohoto balíčku se nedoporučuje. Další informace najdete na adrese https://aka.ms/sdkimplicitrefs.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="RuntimeIdentifierNotRecognized">
-        <source>NETSDK1083: The specified RuntimeIdentifier '{0}' is not recognized.</source>
-        <target state="new">NETSDK1083: The specified RuntimeIdentifier '{0}' is not recognized.</target>
-        <note>{StrBegin="NETSDK1083: "}</note>
-      </trans-unit>
-      <trans-unit id="UnknownFrameworkReference">
-        <source>NETSDK1073: The FrameworkReference '{0}' was not recognized</source>
-        <target state="translated">NETSDK1073: FrameworkReference {0} nejde rozpoznat.</target>
-        <note>{StrBegin="NETSDK1073: "}</note>
-      </trans-unit>
-      <trans-unit id="UnrecognizedPreprocessorToken">
-        <source>NETSDK1009: Unrecognized preprocessor token '{0}' in '{1}'.</source>
-        <target state="translated">NETSDK1009: Nerozpoznaný token preprocesoru {0} v {1}.</target>
-        <note>{StrBegin="NETSDK1009: "}</note>
-      </trans-unit>
-      <trans-unit id="ContentPreproccessorParameterRequired">
-        <source>NETSDK1010: The '{0}' task must be given a value for parameter '{1}' in order to consume preprocessed content.</source>
-        <target state="translated">NETSDK1010: Úloha {0} musí mít hodnotu parametru {1}, aby mohla použít předem zpracovaný obsah.</target>
-        <note>{StrBegin="NETSDK1010: "}</note>
-      </trans-unit>
-      <trans-unit id="ProjectAssetsConsumedWithoutMSBuildProjectPath">
-        <source>NETSDK1011: Assets are consumed from project '{0}', but no corresponding MSBuild project path was  found in '{1}'.</source>
-        <target state="translated">NETSDK1011: Prostředky se používají z projektu {0}, ale v {1} se nenašla odpovídající cesta k projektu MSBuild.</target>
-        <note>{StrBegin="NETSDK1011: "}</note>
-      </trans-unit>
-      <trans-unit id="UnexpectedFileType">
-        <source>NETSDK1012: Unexpected file type for '{0}'. Type is both '{1}' and '{2}'.</source>
-        <target state="translated">NETSDK1012: Neočekávaný typ souboru pro {0}. Typ je {1} i {2}.</target>
-        <note>{StrBegin="NETSDK1012: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotInferTargetFrameworkIdentifierAndVersion">
-        <source>NETSDK1013: The TargetFramework value '{0}' was not recognized. It may be misspelled. If not, then the TargetFrameworkIdentifier and/or TargetFrameworkVersion properties must be specified explicitly.</source>
-        <target state="translated">NETSDK1013: Hodnota TargetFramework {0} nebyla rozpoznána. Je možné, že obsahuje překlepy. Pokud tomu tak není, musíte vlastnosti TargetFrameworkIdentifier a TargetFrameworkVersion zadat explicitně.</target>
-        <note>{StrBegin="NETSDK1013: "}</note>
-      </trans-unit>
-      <trans-unit id="ContentItemDoesNotProvideOutputPath">
-        <source>NETSDK1014: Content item for '{0}' sets '{1}', but does not provide  '{2}' or '{3}'.</source>
-        <target state="translated">NETSDK1014: Položka obsahu pro {0} nastaví {1}, ale neposkytuje {2} ani {3}.</target>
-        <note>{StrBegin="NETSDK1014: "}</note>
-      </trans-unit>
-      <trans-unit id="DuplicatePreprocessorToken">
-        <source>NETSDK1015: The preprocessor token '{0}' has been given more than one value. Choosing '{1}' as the value.</source>
-        <target state="translated">NETSDK1015: Token preprocesoru {0} získal více než jednu hodnotu. Volí se hodnota {1}.</target>
-        <note>{StrBegin="NETSDK1015: "}</note>
-      </trans-unit>
-      <trans-unit id="UnableToFindResolvedPath">
-        <source>NETSDK1016: Unable to find resolved path for '{0}'.</source>
-        <target state="translated">NETSDK1016: Nepodařilo se najít vyhodnocenou cestu pro {0}.</target>
-        <note>{StrBegin="NETSDK1016: "}</note>
+      <trans-unit id="AspNetCoreUsesFrameworkReference">
+        <source>NETSDK1080: A PackageReference to Microsoft.AspNetCore.App is not necessary when targeting .NET Core 3.0 or higher. If Microsoft.NET.Sdk.Web is used, the shared framework will be referenced automatically. Otherwise, the PackageReference should be replaced with a FrameworkReference.</source>
+        <target state="translated">NETSDK1080: Při cílení na .NET Core 3.0 nebo vyšší se nevyžaduje PackageReference na Microsoft.AspNetCore.App. Pokud použijete Microsoft.NET.Sdk.Web, bude se na sdílenou platformu odkazovat automaticky. V opačném případě byste místo PackageReference měli použít FrameworkReference.</target>
+        <note>{StrBegin="NETSDK1080: "}</note>
       </trans-unit>
       <trans-unit id="AssetPreprocessorMustBeConfigured">
         <source>NETSDK1017: Asset preprocessor must be configured before assets are processed.</source>
         <target state="translated">NETSDK1017: Před zpracováním prostředků je potřeba nakonfigurovat preprocesor prostředků.</target>
         <note>{StrBegin="NETSDK1017: "}</note>
       </trans-unit>
-      <trans-unit id="InvalidNuGetVersionString">
-        <source>NETSDK1018: Invalid NuGet version string: '{0}'.</source>
-        <target state="translated">NETSDK1018: Neplatný řetězec verze NuGet: {0}</target>
-        <note>{StrBegin="NETSDK1018: "}</note>
+      <trans-unit id="AssetsFileMissingRuntimeIdentifier">
+        <source>NETSDK1047: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project. You may also need to include '{3}' in your project's RuntimeIdentifiers.</source>
+        <target state="translated">NETSDK1047: Soubor prostředků {0} nemá cíl pro {1}. Zkontrolujte, že se obnovení spustilo a že jste do vlastnosti TargetFrameworks projektu zahrnuli {2}. Možná budete muset zahrnout také {3} do vlastnosti RuntimeIdentifiers projektu.</target>
+        <note>{StrBegin="NETSDK1047: "}</note>
       </trans-unit>
-      <trans-unit id="UnresolvedTargetingPack">
-        <source>NETSDK1081: The targeting pack for {0} was not found. You may be able to resolve this by running a NuGet restore on the project.</source>
-        <target state="new">NETSDK1081: The targeting pack for {0} was not found. You may be able to resolve this by running a NuGet restore on the project.</target>
-        <note>{StrBegin="NETSDK1081: "}</note>
+      <trans-unit id="AssetsFileMissingTarget">
+        <source>NETSDK1005: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project.</source>
+        <target state="translated">NETSDK1005: Soubor prostředků {0} nemá cíl pro {1}. Zkontrolujte, že se obnovení spustilo a že jste do vlastnosti TargetFrameworks projektu zahrnuli {2}.</target>
+        <note>{StrBegin="NETSDK1005: "}</note>
       </trans-unit>
-      <trans-unit id="UnsupportedFramework">
-        <source>NETSDK1019: {0} is an unsupported framework.</source>
-        <target state="translated">NETSDK1019: {0} není podporovaná architektura.</target>
-        <note>{StrBegin="NETSDK1019: "}</note>
+      <trans-unit id="AssetsFileNotFound">
+        <source>NETSDK1004: Assets file '{0}' not found. Run a NuGet package restore to generate this file.</source>
+        <target state="translated">NETSDK1004: Soubor prostředků {0} se nenašel. Pokud chcete tento soubor vygenerovat, spusťte obnovení balíčku NuGet.</target>
+        <note>{StrBegin="NETSDK1004: "}</note>
       </trans-unit>
-      <trans-unit id="DuplicateItemsError">
-        <source>NETSDK1022: Duplicate '{0}' items were included. The .NET SDK includes '{0}' items from your project directory by default. You can either remove these items from your project file, or set the '{1}' property to '{2}' if you want to explicitly include them in your project file. For more information, see {4}. The duplicate items were: {3}</source>
-        <target state="translated">NETSDK1022: Byl zahrnut tento počet duplicitních položek: {0}. Sada .NET SDK obsahuje standardně tento počet položek z adresáře vašeho projektu: {0}. Buď můžete tyto položky odebrat ze souboru projektu, nebo vlastnost {1} nastavit na {2}, pokud je chcete ze souboru projektu explicitně vyloučit. Další informace najdete na adrese {4}. Duplicitní položky: {3}</target>
-        <note>{StrBegin="NETSDK1022: "}</note>
+      <trans-unit id="AssetsFileNotSet">
+        <source>NETSDK1063: The path to the project assets file was not set. Run a NuGet package restore to generate this file.</source>
+        <target state="translated">NETSDK1063: Nebyla nastavena cesta k souboru prostředků projektu. Pokud chcete tento soubor vygenerovat, spusťte obnovení balíčku NuGet.</target>
+        <note>{StrBegin="NETSDK1063: "}</note>
       </trans-unit>
-      <trans-unit id="PackageReferenceOverrideWarning">
-        <source>NETSDK1023: A PackageReference for '{0}' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see {1}</source>
-        <target state="translated">NETSDK1023: Do projektu byl zahrnut odkaz na balíček pro {0}. Na tento balíček implicitně odkazuje sada .NET SDK, takže na něj zpravidla nemusíte odkazovat z projektu. Další informace najdete na adrese {1}.</target>
-        <note>{StrBegin="NETSDK1023: "}</note>
+      <trans-unit id="AssetsFilePathNotRooted">
+        <source>NETSDK1006: Assets file path '{0}' is not rooted. Only full paths are supported.</source>
+        <target state="translated">NETSDK1006: Cesta k souboru prostředků {0} není uvedena od kořene. Podporované jsou jen celé cesty.</target>
+        <note>{StrBegin="NETSDK1006: "}</note>
       </trans-unit>
-      <trans-unit id="IncorrectPackageRoot">
-        <source>NETSDK1020: Package Root {0} was incorrectly given for Resolved library {1}</source>
-        <target state="translated">NETSDK1020: Kořen balíčku {0} byl pro rozpoznanou knihovnu {1} nesprávně zadán.</target>
-        <note>{StrBegin="NETSDK1020: "}</note>
+      <trans-unit id="AtLeastOneTargetFrameworkMustBeSpecified">
+        <source>NETSDK1001: At least one possible target framework must be specified.</source>
+        <target state="translated">NETSDK1001: Je potřeba zadat alespoň jednu možnou cílovou architekturu.</target>
+        <note>{StrBegin="NETSDK1001: "}</note>
       </trans-unit>
-      <trans-unit id="MultipleFilesResolved">
-        <source>NETSDK1021: More than one file found for {0}</source>
-        <target state="translated">NETSDK1021: Pro {0} se našel více než jeden soubor.</target>
-        <note>{StrBegin="NETSDK1021: "}</note>
+      <trans-unit id="CannotFindApphostForRid">
+        <source>NETSDK1065: Cannot find app host for {0}. {0} could be an invalid runtime identifier (RID). For more information about RID, see https://aka.ms/rid-catalog.</source>
+        <target state="translated">NETSDK1065: Nelze najít hostitele aplikace pro {0}. {0} může být neplatný identifikátor modulu runtime (RID). Další informace o identifikátoru RID najdete na adrese https://aka.ms/rid-catalog.</target>
+        <note>{StrBegin="NETSDK1065: "}</note>
       </trans-unit>
-      <trans-unit id="FolderAlreadyExists">
-        <source>NETSDK1024: Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</source>
-        <target state="translated">NETSDK1024: Složka {0} už existuje. Buď ji odstraňte, nebo zadejte jiný parametr ComposeWorkingDir.</target>
-        <note>{StrBegin="NETSDK1024: "}</note>
+      <trans-unit id="CannotFindProjectInfo">
+        <source>NETSDK1007: Cannot find project info for '{0}'. This can indicate a missing project reference.</source>
+        <target state="translated">NETSDK1007: Nelze najít informace o projektu pro {0}. Může to znamenat chybějící odkaz na projekt.</target>
+        <note>{StrBegin="NETSDK1007: "}</note>
       </trans-unit>
-      <trans-unit id="ParsingFiles">
-        <source>NETSDK1026: Parsing the Files : '{0}'</source>
-        <target state="translated">NETSDK1026: Parsují se soubory: {0}.</target>
-        <note>{StrBegin="NETSDK1026: "}</note>
-      </trans-unit>
-      <trans-unit id="PackageInfoLog">
-        <source>NETSDK1027: Package Name='{0}', Version='{1}' was parsed</source>
-        <target state="translated">NETSDK1027: Balíček s názvem {0} a verzí {1} byl parsován.</target>
-        <note>{StrBegin="NETSDK1027: "}</note>
-      </trans-unit>
-      <trans-unit id="RuntimeIdentifierWasNotSpecified">
-        <source>NETSDK1028: Specify a RuntimeIdentifier</source>
-        <target state="translated">NETSDK1028: Zadejte parametr RuntimeIdentifier.</target>
-        <note>{StrBegin="NETSDK1028: "}</note>
-      </trans-unit>
-      <trans-unit id="IncorrectTargetFormat">
-        <source>NETSDK1025: WRThe target manifest {0} provided is of not the correct format</source>
-        <target state="translated">NETSDK1025: Zadaný cílový manifest {0} nemá správný formát.</target>
-        <note>{StrBegin="NETSDK1025: "}</note>
-      </trans-unit>
-      <trans-unit id="AppHostHasBeenModified">
-        <source>NETSDK1029: Unable to use '{0}' as application host executable as it does not contain the expected placeholder byte sequence '{1}' that would mark where the application name would be written.</source>
-        <target state="translated">NETSDK1029: {0} nelze použít jako spustitelný soubor hostitele aplikace, protože neobsahuje očekávanou zástupnou bajtovou posloupnost {1}, která by označila, kam se má zapsat název aplikace.</target>
-        <note>{StrBegin="NETSDK1029: "}</note>
-      </trans-unit>
-      <trans-unit id="FileNameIsTooLong">
-        <source>NETSDK1030: Given file name '{0}' is longer than 1024 bytes</source>
-        <target state="translated">NETSDK1030: Zadaný název souboru {0} je delší než 1024 bajtů.</target>
-        <note>{StrBegin="NETSDK1030: "}</note>
+      <trans-unit id="CannotHaveRuntimeIdentifierPlatformMismatchPlatformTarget">
+        <source>NETSDK1032: The RuntimeIdentifier platform '{0}' and the PlatformTarget '{1}' must be compatible.</source>
+        <target state="translated">NETSDK1032: Platforma RuntimeIdentifier {0} a PlatformTarget {1} musí být kompatibilní.</target>
+        <note>{StrBegin="NETSDK1032: "}</note>
       </trans-unit>
       <trans-unit id="CannotHaveSelfContainedWithoutRuntimeIdentifier">
         <source>NETSDK1031: It is not supported to build or publish a self-contained application without specifying a RuntimeIdentifier.  Please either specify a RuntimeIdentifier or set SelfContained to false.</source>
         <target state="translated">NETSDK1031: Sestavení nebo publikování nezávislé aplikace bez zadání parametru RuntimeIdentifier není podporované. Zadejte prosím buď parametr RuntimeIdentifier, nebo nastavte parametr SelfContained na hodnotu False.</target>
         <note>{StrBegin="NETSDK1031: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotInferTargetFrameworkIdentifierAndVersion">
+        <source>NETSDK1013: The TargetFramework value '{0}' was not recognized. It may be misspelled. If not, then the TargetFrameworkIdentifier and/or TargetFrameworkVersion properties must be specified explicitly.</source>
+        <target state="translated">NETSDK1013: Hodnota TargetFramework {0} nebyla rozpoznána. Je možné, že obsahuje překlepy. Pokud tomu tak není, musíte vlastnosti TargetFrameworkIdentifier a TargetFrameworkVersion zadat explicitně.</target>
+        <note>{StrBegin="NETSDK1013: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotUseSelfContainedWithoutAppHost">
+        <source>NETSDK1067: Self-contained applications are required to use the application host. Either set SelfContained to false or set UseAppHost to true.</source>
+        <target state="translated">NETSDK1067: K používání hostitele aplikace se vyžadují samostatné (nezávislé) aplikace. Nastavte možnost SelfContained na false nebo nastavte UseAppHost na true.</target>
+        <note>{StrBegin="NETSDK1067: "}</note>
       </trans-unit>
       <trans-unit id="ChoosingAssemblyVersion">
         <source>NETSDK1033: Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</source>
@@ -272,6 +132,16 @@
         <target state="translated">NETSDK1037: Vítěze nebylo možné určit kvůli shodným verzím souboru a sestavení.</target>
         <note>{StrBegin="NETSDK1037: "}</note>
       </trans-unit>
+      <trans-unit id="ContentItemDoesNotProvideOutputPath">
+        <source>NETSDK1014: Content item for '{0}' sets '{1}', but does not provide  '{2}' or '{3}'.</source>
+        <target state="translated">NETSDK1014: Položka obsahu pro {0} nastaví {1}, ale neposkytuje {2} ani {3}.</target>
+        <note>{StrBegin="NETSDK1014: "}</note>
+      </trans-unit>
+      <trans-unit id="ContentPreproccessorParameterRequired">
+        <source>NETSDK1010: The '{0}' task must be given a value for parameter '{1}' in order to consume preprocessed content.</source>
+        <target state="translated">NETSDK1010: Úloha {0} musí mít hodnotu parametru {1}, aby mohla použít předem zpracovaný obsah.</target>
+        <note>{StrBegin="NETSDK1010: "}</note>
+      </trans-unit>
       <trans-unit id="CouldNotDetermineWinner_DoesntExist">
         <source>NETSDK1038: Could not determine winner because '{0}' does not exist.</source>
         <target state="translated">NETSDK1038: Vítěze nebylo možné určit, protože {0} neexistuje.</target>
@@ -287,15 +157,40 @@
         <target state="translated">NETSDK1040: Vítěze nebylo možné určit, protože {0} není sestavení.</target>
         <note>{StrBegin="NETSDK1040: "}</note>
       </trans-unit>
+      <trans-unit id="CouldNotLoadPlatformManifest">
+        <source>NETSDK1042: Could not load PlatformManifest from '{0}' because it did not exist.</source>
+        <target state="translated">NETSDK1042: Ze souboru {0} nebylo možné načíst manifest platformy, protože neexistoval.</target>
+        <note>{StrBegin="NETSDK1042: "}</note>
+      </trans-unit>
+      <trans-unit id="DotnetToolDoesNotSupportTFMLowerThanNetcoreapp21">
+        <source>NETSDK1055: DotnetTool does not support target framework lower than netcoreapp2.1.</source>
+        <target state="translated">NETSDK1055: DotnetTool nepodporuje cílovou architekturu nižší než netcoreapp2.1.</target>
+        <note>{StrBegin="NETSDK1055: "}</note>
+      </trans-unit>
+      <trans-unit id="DotnetToolOnlySupportNetcoreapp">
+        <source>NETSDK1054: only supports .NET Core.</source>
+        <target state="translated">NETSDK1054: Podporuje se jen .NET Core.</target>
+        <note>{StrBegin="NETSDK1054: "}</note>
+      </trans-unit>
+      <trans-unit id="DuplicateItemsError">
+        <source>NETSDK1022: Duplicate '{0}' items were included. The .NET SDK includes '{0}' items from your project directory by default. You can either remove these items from your project file, or set the '{1}' property to '{2}' if you want to explicitly include them in your project file. For more information, see {4}. The duplicate items were: {3}</source>
+        <target state="translated">NETSDK1022: Byl zahrnut tento počet duplicitních položek: {0}. Sada .NET SDK obsahuje standardně tento počet položek z adresáře vašeho projektu: {0}. Buď můžete tyto položky odebrat ze souboru projektu, nebo vlastnost {1} nastavit na {2}, pokud je chcete ze souboru projektu explicitně vyloučit. Další informace najdete na adrese {4}. Duplicitní položky: {3}</target>
+        <note>{StrBegin="NETSDK1022: "}</note>
+      </trans-unit>
+      <trans-unit id="DuplicatePreprocessorToken">
+        <source>NETSDK1015: The preprocessor token '{0}' has been given more than one value. Choosing '{1}' as the value.</source>
+        <target state="translated">NETSDK1015: Token preprocesoru {0} získal více než jednu hodnotu. Volí se hodnota {1}.</target>
+        <note>{StrBegin="NETSDK1015: "}</note>
+      </trans-unit>
       <trans-unit id="EncounteredConflict">
         <source>NETSDK1041: Encountered conflict between '{0}' and '{1}'.</source>
         <target state="translated">NETSDK1041: Mezi {0} a {1} došlo ke konfliktu.</target>
         <note>{StrBegin="NETSDK1041: "}</note>
       </trans-unit>
-      <trans-unit id="CouldNotLoadPlatformManifest">
-        <source>NETSDK1042: Could not load PlatformManifest from '{0}' because it did not exist.</source>
-        <target state="translated">NETSDK1042: Ze souboru {0} nebylo možné načíst manifest platformy, protože neexistoval.</target>
-        <note>{StrBegin="NETSDK1042: "}</note>
+      <trans-unit id="ErrorParsingFrameworkListInvalidValue">
+        <source>NETSDK1051: Error parsing FrameworkList from '{0}'.  {1} '{2}' was invalid.</source>
+        <target state="translated">NETSDK1051: Došlo k chybě při parsování FrameworkList z: {0}. {1} {2} byl neplatný.</target>
+        <note>{StrBegin="NETSDK1051: "}</note>
       </trans-unit>
       <trans-unit id="ErrorParsingPlatformManifest">
         <source>NETSDK1043: Error parsing PlatformManifest from '{0}' line {1}.  Lines must have the format {2}.</source>
@@ -307,65 +202,55 @@
         <target state="translated">NETSDK1044: Při parsování manifestu platformy ze souboru {0} na řádku {1} došlo k chybě. {2} {3} bylo neplatné.</target>
         <note>{StrBegin="NETSDK1044: "}</note>
       </trans-unit>
-      <trans-unit id="UnsupportedTargetFrameworkVersion">
-        <source>NETSDK1045: The current .NET SDK does not support targeting {0} {1}.  Either target {0} {2} or lower, or use a version of the .NET SDK that supports {0} {1}.</source>
-        <target state="translated">NETSDK1045: Aktuální sada .NET SDK nepodporuje cílení {0} {1}. Buď zacilte {0} {2} nebo nižší, nebo použijte verzi sady .NET SDK, která podporuje {0} {1}.</target>
-        <note>{StrBegin="NETSDK1045: "}</note>
+      <trans-unit id="ErrorReadingAssetsFile">
+        <source>NETSDK1060: Error reading assets file: {0}</source>
+        <target state="translated">NETSDK1060: Chyba při načítání souboru prostředků: {0}</target>
+        <note>{StrBegin="NETSDK1060: "}</note>
       </trans-unit>
-      <trans-unit id="AssetsFileMissingRuntimeIdentifier">
-        <source>NETSDK1047: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project. You may also need to include '{3}' in your project's RuntimeIdentifiers.</source>
-        <target state="translated">NETSDK1047: Soubor prostředků {0} nemá cíl pro {1}. Zkontrolujte, že se obnovení spustilo a že jste do vlastnosti TargetFrameworks projektu zahrnuli {2}. Možná budete muset zahrnout také {3} do vlastnosti RuntimeIdentifiers projektu.</target>
-        <note>{StrBegin="NETSDK1047: "}</note>
+      <trans-unit id="FailedToLockResource">
+        <source>NETSDK1077: Failed to lock resource.</source>
+        <target state="translated">NETSDK1077: Prostředek se nepovedlo uzamknout.</target>
+        <note>{StrBegin="NETSDK1077: "}</note>
       </trans-unit>
-      <trans-unit id="TargetFrameworkWithSemicolon">
-        <source>NETSDK1046: The TargetFramework value '{0}' is not valid. To multi-target, use the 'TargetFrameworks' property instead.</source>
-        <target state="translated">NETSDK1046: Hodnota TargetFramework {0} není platná. Pokud chcete cílit na více cílů, použijte raději vlastnost TargetFrameworks.</target>
-        <note>{StrBegin="NETSDK1046: "}</note>
+      <trans-unit id="FileNameIsTooLong">
+        <source>NETSDK1030: Given file name '{0}' is longer than 1024 bytes</source>
+        <target state="translated">NETSDK1030: Zadaný název souboru {0} je delší než 1024 bajtů.</target>
+        <note>{StrBegin="NETSDK1030: "}</note>
       </trans-unit>
-      <trans-unit id="GetDependsOnNETStandardFailedWithException">
-        <source>NETSDK1049: Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0} {1}</source>
-        <target state="translated">NETSDK1049: Přeložený soubor má nesprávnou image, nemá žádná metadata nebo je jiným způsobem nedostupný. {0} {1}</target>
-        <note>{StrBegin="NETSDK1049: "}</note>
+      <trans-unit id="FolderAlreadyExists">
+        <source>NETSDK1024: Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</source>
+        <target state="translated">NETSDK1024: Složka {0} už existuje. Buď ji odstraňte, nebo zadejte jiný parametr ComposeWorkingDir.</target>
+        <note>{StrBegin="NETSDK1024: "}</note>
       </trans-unit>
-      <trans-unit id="UnsupportedSDKVersionForNetStandard20">
-        <source>NETSDK1050: The version of Microsoft.NET.Sdk used by this project is insufficient to support references to libraries targeting .NET Standard 1.5 or higher.  Please install version 2.0 or higher of the .NET Core SDK.</source>
-        <target state="translated">NETSDK1050: Verze sady Microsoft.NET.Sdk používaná tímto projektem nestačí pro podporu odkazů na knihovny, jejichž cílovým rozhraním je .NET Standard 1.5 nebo vyšší. Nainstalujte verzi 2.0 nebo vyšší sady .NET Core SDK.</target>
-        <note>{StrBegin="NETSDK1050: "}</note>
-      </trans-unit>
-      <trans-unit id="SkippingAdditionalProbingPaths">
-        <source>NETSDK1048: 'AdditionalProbingPaths' were specified for GenerateRuntimeConfigurationFiles, but are being skipped because 'RuntimeConfigDevPath' is empty.</source>
-        <target state="translated">NETSDK1048: Cesty AdditionalProbingPaths byly zadány pro GenerateRuntimeConfigurationFiles, ale vynechávají se, protože RuntimeConfigDevPath je prázdné.</target>
-        <note>{StrBegin="NETSDK1048: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotHaveRuntimeIdentifierPlatformMismatchPlatformTarget">
-        <source>NETSDK1032: The RuntimeIdentifier platform '{0}' and the PlatformTarget '{1}' must be compatible.</source>
-        <target state="translated">NETSDK1032: Platforma RuntimeIdentifier {0} a PlatformTarget {1} musí být kompatibilní.</target>
-        <note>{StrBegin="NETSDK1032: "}</note>
-      </trans-unit>
-      <trans-unit id="ErrorParsingFrameworkListInvalidValue">
-        <source>NETSDK1051: Error parsing FrameworkList from '{0}'.  {1} '{2}' was invalid.</source>
-        <target state="translated">NETSDK1051: Došlo k chybě při parsování FrameworkList z: {0}. {1} {2} byl neplatný.</target>
-        <note>{StrBegin="NETSDK1051: "}</note>
+      <trans-unit id="FrameworkDependentAppHostRequiresVersion21">
+        <source>NETSDK1068: The framework-dependent application host requires a target framework of at least 'netcoreapp2.1'.</source>
+        <target state="translated">NETSDK1068: Hostitel aplikace závislé na architektuře vyžaduje cílovou architekturu nejméně netcoreapp2.1.</target>
+        <note>{StrBegin="NETSDK1068: "}</note>
       </trans-unit>
       <trans-unit id="FrameworkListPathNotRooted">
         <source>NETSDK1052: Framework list file path '{0}' is not rooted. Only full paths are supported.</source>
         <target state="translated">NETSDK1052: Cesta k souboru seznamu architektur {0} není uvedena od kořene. Podporují se jen celé cesty.</target>
         <note>{StrBegin="NETSDK1052: "}</note>
       </trans-unit>
-      <trans-unit id="PackAsToolCannotSupportSelfContained">
-        <source>NETSDK1053: Pack as tool does not support self contained.</source>
-        <target state="translated">NETSDK1053: Zabalit jako nástroj nepodporuje nezávislost.</target>
-        <note>{StrBegin="NETSDK1001: "}</note>
+      <trans-unit id="GetDependsOnNETStandardFailedWithException">
+        <source>NETSDK1049: Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0} {1}</source>
+        <target state="translated">NETSDK1049: Přeložený soubor má nesprávnou image, nemá žádná metadata nebo je jiným způsobem nedostupný. {0} {1}</target>
+        <note>{StrBegin="NETSDK1049: "}</note>
       </trans-unit>
-      <trans-unit id="UnsupportedRuntimeIdentifier">
-        <source>NETSDK1056: Project is targeting runtime '{0}' but did not resolve any runtime-specific packages. This runtime may not be supported by the target framework.</source>
-        <target state="translated">NETSDK1056: Cílem projektu je modul runtime {0}, ale nepřeložil žádné balíčky specifické pro modul runtime. Tento modul runtime nemusí cílová architektura podporovat.</target>
-        <note>{StrBegin="NETSDK1056: "}</note>
+      <trans-unit id="IncorrectPackageRoot">
+        <source>NETSDK1020: Package Root {0} was incorrectly given for Resolved library {1}</source>
+        <target state="translated">NETSDK1020: Kořen balíčku {0} byl pro rozpoznanou knihovnu {1} nesprávně zadán.</target>
+        <note>{StrBegin="NETSDK1020: "}</note>
       </trans-unit>
-      <trans-unit id="UsingPreviewSdkWarning">
-        <source>NETSDK1057: You are using a preview version of .NET Core. See: https://aka.ms/dotnet-core-preview</source>
-        <target state="translated">NETSDK1057: Používáte preview verzi .NET Core. Další informace: https://aka.ms/dotnet-core-preview</target>
-        <note>{StrBegin="NETSDK1057: "}</note>
+      <trans-unit id="IncorrectTargetFormat">
+        <source>NETSDK1025: WRThe target manifest {0} provided is of not the correct format</source>
+        <target state="translated">NETSDK1025: Zadaný cílový manifest {0} nemá správný formát.</target>
+        <note>{StrBegin="NETSDK1025: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidFrameworkName">
+        <source>NETSDK1003: Invalid framework name: '{0}'.</source>
+        <target state="translated">NETSDK1003: Neplatný název architektury: {0}</target>
+        <note>{StrBegin="NETSDK1003: "}</note>
       </trans-unit>
       <trans-unit id="InvalidItemSpecToUse">
         <source>NETSDK1058: Invalid value for ItemSpecToUse parameter: '{0}'.  This property must be blank or set to 'Left' or 'Right'</source>
@@ -373,15 +258,15 @@
         <note>{StrBegin="NETSDK1058: "}
 The following are names of parameters or literal values and should not be translated: ItemSpecToUse, Left, Right</note>
       </trans-unit>
-      <trans-unit id="ProjectContainsObsoleteDotNetCliTool">
-        <source>NETSDK1059: The tool '{0}' is now included in the .NET Core SDK. Information on resolving this warning is available at (https://aka.ms/dotnetclitools-in-box).</source>
-        <target state="translated">NETSDK1059: Nástroj {0} je teď zahrnutý v sadě .NET Core SDK. Informace o tom, jak vyřešit toto upozornění, jsou dostupné na adrese https://aka.ms/dotnetclitools-in-box.</target>
-        <note>{StrBegin="NETSDK1059: "}</note>
+      <trans-unit id="InvalidNuGetVersionString">
+        <source>NETSDK1018: Invalid NuGet version string: '{0}'.</source>
+        <target state="translated">NETSDK1018: Neplatný řetězec verze NuGet: {0}</target>
+        <note>{StrBegin="NETSDK1018: "}</note>
       </trans-unit>
-      <trans-unit id="ErrorReadingAssetsFile">
-        <source>NETSDK1060: Error reading assets file: {0}</source>
-        <target state="translated">NETSDK1060: Chyba při načítání souboru prostředků: {0}</target>
-        <note>{StrBegin="NETSDK1060: "}</note>
+      <trans-unit id="InvalidResourceUpdate">
+        <source>NETSDK1075: Update handle is invalid. This instance may not be used for further updates.</source>
+        <target state="translated">NETSDK1075: Popisovač aktualizace není platný. Tuto instanci nejde použít pro další aktualizace.</target>
+        <note>{StrBegin="NETSDK1075: "}</note>
       </trans-unit>
       <trans-unit id="MismatchedPlatformPackageVersion">
         <source>NETSDK1061: The project was restored using {0} version {1}, but with current settings, version {2} would be used instead. To resolve this issue, make sure the same settings are used for restore and for subsequent operations such as build or publish. Typically this issue can occur if the RuntimeIdentifier property is set during build or publish but not during restore. For more information, see https://aka.ms/dotnet-runtime-patch-selection.</source>
@@ -391,35 +276,150 @@ The following are names of parameters or literal values and should not be transl
 {1} - Restored version of platform package
 {2} - Current version of platform package</note>
       </trans-unit>
-      <trans-unit id="AssetsFileNotSet">
-        <source>NETSDK1063: The path to the project assets file was not set. Run a NuGet package restore to generate this file.</source>
-        <target state="translated">NETSDK1063: Nebyla nastavena cesta k souboru prostředků projektu. Pokud chcete tento soubor vygenerovat, spusťte obnovení balíčku NuGet.</target>
-        <note>{StrBegin="NETSDK1063: "}</note>
+      <trans-unit id="MissingItemMetadata">
+        <source>NETSDK1008: Missing '{0}' metadata on '{1}' item '{2}'.</source>
+        <target state="translated">NETSDK1008: Chybí metadata {0} o {1} položky {2}.</target>
+        <note>{StrBegin="NETSDK1008: "}</note>
       </trans-unit>
-      <trans-unit id="DotnetToolOnlySupportNetcoreapp">
-        <source>NETSDK1054: only supports .NET Core.</source>
-        <target state="translated">NETSDK1054: Podporuje se jen .NET Core.</target>
-        <note>{StrBegin="NETSDK1054: "}</note>
+      <trans-unit id="MultipleFilesResolved">
+        <source>NETSDK1021: More than one file found for {0}</source>
+        <target state="translated">NETSDK1021: Pro {0} se našel více než jeden soubor.</target>
+        <note>{StrBegin="NETSDK1021: "}</note>
       </trans-unit>
-      <trans-unit id="DotnetToolDoesNotSupportTFMLowerThanNetcoreapp21">
-        <source>NETSDK1055: DotnetTool does not support target framework lower than netcoreapp2.1.</source>
-        <target state="translated">NETSDK1055: DotnetTool nepodporuje cílovou architekturu nižší než netcoreapp2.1.</target>
-        <note>{StrBegin="NETSDK1055: "}</note>
+      <trans-unit id="NETFrameworkToNonBuiltInNETStandard">
+        <source>NETSDK1069: This project uses a library that targets .NET Standard 1.5 or higher, and the project targets a version of .NET Framework that doesn't have built-in support for that version of .NET Standard. Visit https://aka.ms/net-standard-known-issues for a set of known issues. Consider retargeting to .NET Framework 4.7.2.</source>
+        <target state="translated">NETSDK1069: Tento projekt používá knihovnu, která cílí na .NET Standard 1.5 nebo vyšší, a projekt cílí na verzi .NET Frameworku, která nemá integrovanou podporu pro tuto verzi .NET Standardu. Podívejte na stránku https://aka.ms/net-standard-known-issues, kde najdete sadu známých problémů. Zvažte změnu cíle na .NET Framework 4.7.2.</target>
+        <note>{StrBegin="NETSDK1069: "}</note>
       </trans-unit>
-      <trans-unit id="UnableToUsePackageAssetsCache">
-        <source>NETSDK1062: Unable to use package assets cache due to I/O error. This can occur when the same project is built more than once in parallel. Performance may be degraded, but the build result will not be impacted.</source>
-        <target state="translated">NETSDK1062: Kvůli V/V chybě nelze použít mezipaměť prostředků balíčku. Tento problém může nastat, když je stejný projekt sestavován současně více než jednou. Může se snížit výkon, ale výsledek sestavení to neovlivní.</target>
-        <note>{StrBegin="NETSDK1062: "}</note>
+      <trans-unit id="NoAppHostAvailable">
+        <source>NETSDK1084: There is no application host available for the specified RuntimeIdentifier '{0}'.</source>
+        <target state="new">NETSDK1084: There is no application host available for the specified RuntimeIdentifier '{0}'.</target>
+        <note>{StrBegin="NETSDK1084: "}</note>
+      </trans-unit>
+      <trans-unit id="NoCompatibleTargetFramework">
+        <source>NETSDK1002: Project '{0}' targets '{2}'. It cannot be referenced by a project that targets '{1}'.</source>
+        <target state="translated">NETSDK1002: Cílem projektu {0} je {2}. Nemůže na něj odkazovat projekt, jehož cílem je {1}.</target>
+        <note>{StrBegin="NETSDK1002: "}</note>
+      </trans-unit>
+      <trans-unit id="NoRuntimePackAvailable">
+        <source>NETSDK1082: There was no runtime pack for {0} available for the specified RuntimeIdentifier '{1}'.</source>
+        <target state="new">NETSDK1082: There was no runtime pack for {0} available for the specified RuntimeIdentifier '{1}'.</target>
+        <note>{StrBegin="NETSDK1082: "}</note>
+      </trans-unit>
+      <trans-unit id="PackAsToolCannotSupportSelfContained">
+        <source>NETSDK1053: Pack as tool does not support self contained.</source>
+        <target state="translated">NETSDK1053: Zabalit jako nástroj nepodporuje nezávislost.</target>
+        <note>{StrBegin="NETSDK1001: "}</note>
+      </trans-unit>
+      <trans-unit id="PackageInfoLog">
+        <source>NETSDK1027: Package Name='{0}', Version='{1}' was parsed</source>
+        <target state="translated">NETSDK1027: Balíček s názvem {0} a verzí {1} byl parsován.</target>
+        <note>{StrBegin="NETSDK1027: "}</note>
       </trans-unit>
       <trans-unit id="PackageNotFound">
         <source>NETSDK1064: Package {0}, version {1} was not found. It might have been deleted since NuGet restore. Otherwise, NuGet restore might have only partially completed, which might have been due to maximum path length restrictions.</source>
         <target state="translated">NETSDK1064: Balíček {0} verze {1} se nenašel. Je možné, že se od obnovení NuGet odstranil. Jinak je možné, že obnovení NuGet se provedlo jenom částečně, důvodem mohla být omezení pro maximální délku cesty.</target>
         <note>{StrBegin="NETSDK1064: "}</note>
       </trans-unit>
-      <trans-unit id="CannotFindApphostForRid">
-        <source>NETSDK1065: Cannot find app host for {0}. {0} could be an invalid runtime identifier (RID). For more information about RID, see https://aka.ms/rid-catalog.</source>
-        <target state="translated">NETSDK1065: Nelze najít hostitele aplikace pro {0}. {0} může být neplatný identifikátor modulu runtime (RID). Další informace o identifikátoru RID najdete na adrese https://aka.ms/rid-catalog.</target>
-        <note>{StrBegin="NETSDK1065: "}</note>
+      <trans-unit id="PackageReferenceOverrideWarning">
+        <source>NETSDK1023: A PackageReference for '{0}' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see {1}</source>
+        <target state="translated">NETSDK1023: Do projektu byl zahrnut odkaz na balíček pro {0}. Na tento balíček implicitně odkazuje sada .NET SDK, takže na něj zpravidla nemusíte odkazovat z projektu. Další informace najdete na adrese {1}.</target>
+        <note>{StrBegin="NETSDK1023: "}</note>
+      </trans-unit>
+      <trans-unit id="PackageReferenceVersionNotRecommended">
+        <source>NETSDK1071: A PackageReference to '{0}' specified a Version of `{1}`. Specifying the version of this package is not recommended. For more information, see https://aka.ms/sdkimplicitrefs</source>
+        <target state="translated">NETSDK1071: PackageReference na balíček {0} určuje verzi {1}. Určení verze tohoto balíčku se nedoporučuje. Další informace najdete na adrese https://aka.ms/sdkimplicitrefs.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParsingFiles">
+        <source>NETSDK1026: Parsing the Files : '{0}'</source>
+        <target state="translated">NETSDK1026: Parsují se soubory: {0}.</target>
+        <note>{StrBegin="NETSDK1026: "}</note>
+      </trans-unit>
+      <trans-unit id="ProjectAssetsConsumedWithoutMSBuildProjectPath">
+        <source>NETSDK1011: Assets are consumed from project '{0}', but no corresponding MSBuild project path was  found in '{1}'.</source>
+        <target state="translated">NETSDK1011: Prostředky se používají z projektu {0}, ale v {1} se nenašla odpovídající cesta k projektu MSBuild.</target>
+        <note>{StrBegin="NETSDK1011: "}</note>
+      </trans-unit>
+      <trans-unit id="ProjectContainsObsoleteDotNetCliTool">
+        <source>NETSDK1059: The tool '{0}' is now included in the .NET Core SDK. Information on resolving this warning is available at (https://aka.ms/dotnetclitools-in-box).</source>
+        <target state="translated">NETSDK1059: Nástroj {0} je teď zahrnutý v sadě .NET Core SDK. Informace o tom, jak vyřešit toto upozornění, jsou dostupné na adrese https://aka.ms/dotnetclitools-in-box.</target>
+        <note>{StrBegin="NETSDK1059: "}</note>
+      </trans-unit>
+      <trans-unit id="RuntimeIdentifierNotRecognized">
+        <source>NETSDK1083: The specified RuntimeIdentifier '{0}' is not recognized.</source>
+        <target state="new">NETSDK1083: The specified RuntimeIdentifier '{0}' is not recognized.</target>
+        <note>{StrBegin="NETSDK1083: "}</note>
+      </trans-unit>
+      <trans-unit id="RuntimeIdentifierWasNotSpecified">
+        <source>NETSDK1028: Specify a RuntimeIdentifier</source>
+        <target state="translated">NETSDK1028: Zadejte parametr RuntimeIdentifier.</target>
+        <note>{StrBegin="NETSDK1028: "}</note>
+      </trans-unit>
+      <trans-unit id="SkippingAdditionalProbingPaths">
+        <source>NETSDK1048: 'AdditionalProbingPaths' were specified for GenerateRuntimeConfigurationFiles, but are being skipped because 'RuntimeConfigDevPath' is empty.</source>
+        <target state="translated">NETSDK1048: Cesty AdditionalProbingPaths byly zadány pro GenerateRuntimeConfigurationFiles, ale vynechávají se, protože RuntimeConfigDevPath je prázdné.</target>
+        <note>{StrBegin="NETSDK1048: "}</note>
+      </trans-unit>
+      <trans-unit id="TargetFrameworkWithSemicolon">
+        <source>NETSDK1046: The TargetFramework value '{0}' is not valid. To multi-target, use the 'TargetFrameworks' property instead.</source>
+        <target state="translated">NETSDK1046: Hodnota TargetFramework {0} není platná. Pokud chcete cílit na více cílů, použijte raději vlastnost TargetFrameworks.</target>
+        <note>{StrBegin="NETSDK1046: "}</note>
+      </trans-unit>
+      <trans-unit id="UnableToFindResolvedPath">
+        <source>NETSDK1016: Unable to find resolved path for '{0}'.</source>
+        <target state="translated">NETSDK1016: Nepodařilo se najít vyhodnocenou cestu pro {0}.</target>
+        <note>{StrBegin="NETSDK1016: "}</note>
+      </trans-unit>
+      <trans-unit id="UnableToUsePackageAssetsCache">
+        <source>NETSDK1062: Unable to use package assets cache due to I/O error. This can occur when the same project is built more than once in parallel. Performance may be degraded, but the build result will not be impacted.</source>
+        <target state="translated">NETSDK1062: Kvůli V/V chybě nelze použít mezipaměť prostředků balíčku. Tento problém může nastat, když je stejný projekt sestavován současně více než jednou. Může se snížit výkon, ale výsledek sestavení to neovlivní.</target>
+        <note>{StrBegin="NETSDK1062: "}</note>
+      </trans-unit>
+      <trans-unit id="UnexpectedFileType">
+        <source>NETSDK1012: Unexpected file type for '{0}'. Type is both '{1}' and '{2}'.</source>
+        <target state="translated">NETSDK1012: Neočekávaný typ souboru pro {0}. Typ je {1} i {2}.</target>
+        <note>{StrBegin="NETSDK1012: "}</note>
+      </trans-unit>
+      <trans-unit id="UnknownFrameworkReference">
+        <source>NETSDK1073: The FrameworkReference '{0}' was not recognized</source>
+        <target state="translated">NETSDK1073: FrameworkReference {0} nejde rozpoznat.</target>
+        <note>{StrBegin="NETSDK1073: "}</note>
+      </trans-unit>
+      <trans-unit id="UnrecognizedPreprocessorToken">
+        <source>NETSDK1009: Unrecognized preprocessor token '{0}' in '{1}'.</source>
+        <target state="translated">NETSDK1009: Nerozpoznaný token preprocesoru {0} v {1}.</target>
+        <note>{StrBegin="NETSDK1009: "}</note>
+      </trans-unit>
+      <trans-unit id="UnresolvedTargetingPack">
+        <source>NETSDK1081: The targeting pack for {0} was not found. You may be able to resolve this by running a NuGet restore on the project.</source>
+        <target state="new">NETSDK1081: The targeting pack for {0} was not found. You may be able to resolve this by running a NuGet restore on the project.</target>
+        <note>{StrBegin="NETSDK1081: "}</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedFramework">
+        <source>NETSDK1019: {0} is an unsupported framework.</source>
+        <target state="translated">NETSDK1019: {0} není podporovaná architektura.</target>
+        <note>{StrBegin="NETSDK1019: "}</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedRuntimeIdentifier">
+        <source>NETSDK1056: Project is targeting runtime '{0}' but did not resolve any runtime-specific packages. This runtime may not be supported by the target framework.</source>
+        <target state="translated">NETSDK1056: Cílem projektu je modul runtime {0}, ale nepřeložil žádné balíčky specifické pro modul runtime. Tento modul runtime nemusí cílová architektura podporovat.</target>
+        <note>{StrBegin="NETSDK1056: "}</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedSDKVersionForNetStandard20">
+        <source>NETSDK1050: The version of Microsoft.NET.Sdk used by this project is insufficient to support references to libraries targeting .NET Standard 1.5 or higher.  Please install version 2.0 or higher of the .NET Core SDK.</source>
+        <target state="translated">NETSDK1050: Verze sady Microsoft.NET.Sdk používaná tímto projektem nestačí pro podporu odkazů na knihovny, jejichž cílovým rozhraním je .NET Standard 1.5 nebo vyšší. Nainstalujte verzi 2.0 nebo vyšší sady .NET Core SDK.</target>
+        <note>{StrBegin="NETSDK1050: "}</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedTargetFrameworkVersion">
+        <source>NETSDK1045: The current .NET SDK does not support targeting {0} {1}.  Either target {0} {2} or lower, or use a version of the .NET SDK that supports {0} {1}.</source>
+        <target state="translated">NETSDK1045: Aktuální sada .NET SDK nepodporuje cílení {0} {1}. Buď zacilte {0} {2} nebo nižší, nebo použijte verzi sady .NET SDK, která podporuje {0} {1}.</target>
+        <note>{StrBegin="NETSDK1045: "}</note>
+      </trans-unit>
+      <trans-unit id="UsingPreviewSdkWarning">
+        <source>NETSDK1057: You are using a preview version of .NET Core. See: https://aka.ms/dotnet-core-preview</source>
+        <target state="translated">NETSDK1057: Používáte preview verzi .NET Core. Další informace: https://aka.ms/dotnet-core-preview</target>
+        <note>{StrBegin="NETSDK1057: "}</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Tasks/Common/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.de.xlf
@@ -2,35 +2,25 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../Strings.resx">
     <body>
-      <trans-unit id="AspNetCoreAllNotSupported">
-        <source>NETSDK1079: The Microsoft.AspNetCore.All package is not supported when targeting .NET Core 3.0 or higher.  A FrameworkReference to Microsoft.AspNetCore.App should be used instead, and will be implicitly included by Microsoft.NET.Sdk.Web.</source>
-        <target state="translated">NETSDK1079: Das Microsoft.AspNetCore.All-Paket wird nicht unterstützt, wenn .NET Core 3.0 oder höher angezielt wird. Ein FrameworkReference-Verweis auf Microsoft.AspNetCore.App sollte stattdessen verwendet werden. Dieser wird implizit durch Microsoft.NET.Sdk.Web eingefügt.</target>
-        <note>{StrBegin="NETSDK1079: "}</note>
-      </trans-unit>
-      <trans-unit id="AspNetCoreUsesFrameworkReference">
-        <source>NETSDK1080: A PackageReference to Microsoft.AspNetCore.App is not necessary when targeting .NET Core 3.0 or higher. If Microsoft.NET.Sdk.Web is used, the shared framework will be referenced automatically. Otherwise, the PackageReference should be replaced with a FrameworkReference.</source>
-        <target state="translated">NETSDK1080: Ein PackageReference-Verweis auf Microsoft.AspNetCore.App ist nicht notwendig, wenn .NET Core 3.0 oder höher angezielt wird. Wenn Microsoft.NET.Sdk.Web verwendet wird, wird automatisch auf das freigegebene Framework verwiesen. Andernfalls sollte der PackageReference-Verweis durch einen FrameworkReference-Verweis ersetzt werden.</target>
-        <note>{StrBegin="NETSDK1080: "}</note>
-      </trans-unit>
-      <trans-unit id="FailedToLockResource">
-        <source>NETSDK1077: Failed to lock resource.</source>
-        <target state="translated">NETSDK1077: Fehler beim Sperren der Ressource.</target>
-        <note>{StrBegin="NETSDK1077: "}</note>
-      </trans-unit>
       <trans-unit id="AddResourceWithNonIntegerResource">
         <source>NETSDK1076: AddResource can only be used with integer resource types.</source>
         <target state="translated">NETSDK1076: AddResource kann nur mit ganzzahligen Ressourcentypen verwendet werden.</target>
         <note>{StrBegin="NETSDK1076: "}</note>
       </trans-unit>
-      <trans-unit id="InvalidResourceUpdate">
-        <source>NETSDK1075: Update handle is invalid. This instance may not be used for further updates.</source>
-        <target state="translated">NETSDK1075: Das Updatehandle ist ungültig. Diese Instanz kann nicht für weitere Updates verwendet werden.</target>
-        <note>{StrBegin="NETSDK1075: "}</note>
+      <trans-unit id="AppConfigRequiresRootConfiguration">
+        <source>NETSDK1070: The application configuration file must have root configuration element.</source>
+        <target state="translated">NETSDK1070: Die Anwendungskonfigurationsdatei muss das Stammkonfigurationselement enthalten.</target>
+        <note>{StrBegin="NETSDK1070: "}</note>
       </trans-unit>
       <trans-unit id="AppHostCustomizationRequiresWindowsHostWarning">
         <source>NETSDK1074: The application host executable will not be customized because adding resources requires that the build be performed on Windows (excluding Nano Server).</source>
         <target state="translated">NETSDK1074: Der ausführbare Anwendungshost wird nicht angepasst, da für das Hinzufügen zusätzlicher Ressourcen erforderlich ist, dass der Build unter Windows (ausgenommen Nano Server) durchgeführt wird.</target>
         <note>{StrBegin="NETSDK1074: "}</note>
+      </trans-unit>
+      <trans-unit id="AppHostHasBeenModified">
+        <source>NETSDK1029: Unable to use '{0}' as application host executable as it does not contain the expected placeholder byte sequence '{1}' that would mark where the application name would be written.</source>
+        <target state="translated">NETSDK1029: "{0}" kann nicht als ausführbare Anwendungshostdatei verwendet werden, da die erwartete Platzhalterbytesequenz "{1}" nicht vorhanden ist, die markiert, wo der Anwendungsname geschrieben wird.</target>
+        <note>{StrBegin="NETSDK1029: "}</note>
       </trans-unit>
       <trans-unit id="AppHostNotWindows">
         <source>NETSDK1078: Unable to use '{0}' as application host executable because it's not a Windows PE file.</source>
@@ -42,210 +32,80 @@
         <target state="translated">NETSDK1072: "{0}" kann nicht als ausführbarer Anwendungshost verwendet werden, da es sich dabei nicht um eine ausführbare Windows-Datei für das CUI-Subsystem (Konsole) handelt.</target>
         <note>{StrBegin="NETSDK1072: "}</note>
       </trans-unit>
-      <trans-unit id="AppConfigRequiresRootConfiguration">
-        <source>NETSDK1070: The application configuration file must have root configuration element.</source>
-        <target state="translated">NETSDK1070: Die Anwendungskonfigurationsdatei muss das Stammkonfigurationselement enthalten.</target>
-        <note>{StrBegin="NETSDK1070: "}</note>
+      <trans-unit id="AspNetCoreAllNotSupported">
+        <source>NETSDK1079: The Microsoft.AspNetCore.All package is not supported when targeting .NET Core 3.0 or higher.  A FrameworkReference to Microsoft.AspNetCore.App should be used instead, and will be implicitly included by Microsoft.NET.Sdk.Web.</source>
+        <target state="translated">NETSDK1079: Das Microsoft.AspNetCore.All-Paket wird nicht unterstützt, wenn .NET Core 3.0 oder höher angezielt wird. Ein FrameworkReference-Verweis auf Microsoft.AspNetCore.App sollte stattdessen verwendet werden. Dieser wird implizit durch Microsoft.NET.Sdk.Web eingefügt.</target>
+        <note>{StrBegin="NETSDK1079: "}</note>
       </trans-unit>
-      <trans-unit id="AtLeastOneTargetFrameworkMustBeSpecified">
-        <source>NETSDK1001: At least one possible target framework must be specified.</source>
-        <target state="translated">NETSDK1001: Geben Sie mindestens ein mögliches Zielframework an.</target>
-        <note>{StrBegin="NETSDK1001: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotUseSelfContainedWithoutAppHost">
-        <source>NETSDK1067: Self-contained applications are required to use the application host. Either set SelfContained to false or set UseAppHost to true.</source>
-        <target state="translated">NETSDK1067: Eigenständige Anwendungen müssen den Anwendungshost verwenden. Legen Sie "SelfContained" auf FALSE oder "UseAppHost" auf TRUE fest.</target>
-        <note>{StrBegin="NETSDK1067: "}</note>
-      </trans-unit>
-      <trans-unit id="FrameworkDependentAppHostRequiresVersion21">
-        <source>NETSDK1068: The framework-dependent application host requires a target framework of at least 'netcoreapp2.1'.</source>
-        <target state="translated">NETSDK1068: Für den frameworkabhängigen Anwendungshost ist mindestens das Zielframework "netcoreapp2.1" erforderlich.</target>
-        <note>{StrBegin="NETSDK1068: "}</note>
-      </trans-unit>
-      <trans-unit id="NETFrameworkToNonBuiltInNETStandard">
-        <source>NETSDK1069: This project uses a library that targets .NET Standard 1.5 or higher, and the project targets a version of .NET Framework that doesn't have built-in support for that version of .NET Standard. Visit https://aka.ms/net-standard-known-issues for a set of known issues. Consider retargeting to .NET Framework 4.7.2.</source>
-        <target state="translated">NETSDK1069: Dieses Projekt verwendet eine Bibliothek, die auf .NET Standard 1.5 oder höher ausgerichtet ist, und das Projekt ist auf eine Version von .NET Framework ausgerichtet, die keine integrierte Unterstützung für diese .NET Standard-Version bietet. Besuchen Sie https://aka.ms/net-standard-known-issues for a set of known issues. Ziehen Sie eine neue Ausrichtung auf .NET Framework 4.7.2 in Betracht.</target>
-        <note>{StrBegin="NETSDK1069: "}</note>
-      </trans-unit>
-      <trans-unit id="NoAppHostAvailable">
-        <source>NETSDK1084: There is no application host available for the specified RuntimeIdentifier '{0}'.</source>
-        <target state="new">NETSDK1084: There is no application host available for the specified RuntimeIdentifier '{0}'.</target>
-        <note>{StrBegin="NETSDK1084: "}</note>
-      </trans-unit>
-      <trans-unit id="NoCompatibleTargetFramework">
-        <source>NETSDK1002: Project '{0}' targets '{2}'. It cannot be referenced by a project that targets '{1}'.</source>
-        <target state="translated">NETSDK1002: Das Projekt "{0}" hat das Ziel "{2}". Ein Verweis über ein Projekt mit dem Ziel "{1}" ist nicht möglich.</target>
-        <note>{StrBegin="NETSDK1002: "}</note>
-      </trans-unit>
-      <trans-unit id="InvalidFrameworkName">
-        <source>NETSDK1003: Invalid framework name: '{0}'.</source>
-        <target state="translated">NETSDK1003: Ungültiger Frameworkname: "{0}".</target>
-        <note>{StrBegin="NETSDK1003: "}</note>
-      </trans-unit>
-      <trans-unit id="AssetsFileNotFound">
-        <source>NETSDK1004: Assets file '{0}' not found. Run a NuGet package restore to generate this file.</source>
-        <target state="translated">NETSDK1004: Die Ressourcendatei "{0}" wurde nicht gefunden. Führen Sie eine NuGet-Paketwiederherstellung aus, um diese Datei zu generieren.</target>
-        <note>{StrBegin="NETSDK1004: "}</note>
-      </trans-unit>
-      <trans-unit id="AssetsFileMissingTarget">
-        <source>NETSDK1005: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project.</source>
-        <target state="translated">NETSDK1005: Die Ressourcendatei "{0}" weist kein Ziel für "{1}" auf. Stellen Sie sicher, dass die Wiederherstellung ausgeführt wurde, und dass Sie "{2}" in die TargetFrameworks für Ihr Projekt eingeschlossen haben.</target>
-        <note>{StrBegin="NETSDK1005: "}</note>
-      </trans-unit>
-      <trans-unit id="AssetsFilePathNotRooted">
-        <source>NETSDK1006: Assets file path '{0}' is not rooted. Only full paths are supported.</source>
-        <target state="translated">NETSDK1006: Die Ressourcendateipfad "{0}" hat keinen Stamm. Nur vollständige Pfade werden unterstützt.</target>
-        <note>{StrBegin="NETSDK1006: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotFindProjectInfo">
-        <source>NETSDK1007: Cannot find project info for '{0}'. This can indicate a missing project reference.</source>
-        <target state="translated">NETSDK1007: Die Projektinformationen für "{0}" wurden nicht gefunden. Dies ist möglicherweise auf einen fehlenden Projektverweis zurückzuführen.</target>
-        <note>{StrBegin="NETSDK1007: "}</note>
-      </trans-unit>
-      <trans-unit id="MissingItemMetadata">
-        <source>NETSDK1008: Missing '{0}' metadata on '{1}' item '{2}'.</source>
-        <target state="translated">NETSDK1008: Die Metadaten "{0}" für das Element "{2}" vom Typ "{1}" sind nicht vorhanden.</target>
-        <note>{StrBegin="NETSDK1008: "}</note>
-      </trans-unit>
-      <trans-unit id="NoRuntimePackAvailable">
-        <source>NETSDK1082: There was no runtime pack for {0} available for the specified RuntimeIdentifier '{1}'.</source>
-        <target state="new">NETSDK1082: There was no runtime pack for {0} available for the specified RuntimeIdentifier '{1}'.</target>
-        <note>{StrBegin="NETSDK1082: "}</note>
-      </trans-unit>
-      <trans-unit id="PackageReferenceVersionNotRecommended">
-        <source>NETSDK1071: A PackageReference to '{0}' specified a Version of `{1}`. Specifying the version of this package is not recommended. For more information, see https://aka.ms/sdkimplicitrefs</source>
-        <target state="translated">NETSDK1071: Ein PackageReference-Verweis auf "{0}" hat die Version "{1}" angegeben. Die Angabe der Version dieses Pakets wird nicht empfohlen. Weitere Informationen finden Sie unter https://aka.ms/sdkimplicitrefs.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="RuntimeIdentifierNotRecognized">
-        <source>NETSDK1083: The specified RuntimeIdentifier '{0}' is not recognized.</source>
-        <target state="new">NETSDK1083: The specified RuntimeIdentifier '{0}' is not recognized.</target>
-        <note>{StrBegin="NETSDK1083: "}</note>
-      </trans-unit>
-      <trans-unit id="UnknownFrameworkReference">
-        <source>NETSDK1073: The FrameworkReference '{0}' was not recognized</source>
-        <target state="translated">NETSDK1073: Der FrameworkReference-Verweis "{0}" wurde nicht erkannt.</target>
-        <note>{StrBegin="NETSDK1073: "}</note>
-      </trans-unit>
-      <trans-unit id="UnrecognizedPreprocessorToken">
-        <source>NETSDK1009: Unrecognized preprocessor token '{0}' in '{1}'.</source>
-        <target state="translated">NETSDK1009: Unbekanntes Präprozessortoken "{0}" in "{1}".</target>
-        <note>{StrBegin="NETSDK1009: "}</note>
-      </trans-unit>
-      <trans-unit id="ContentPreproccessorParameterRequired">
-        <source>NETSDK1010: The '{0}' task must be given a value for parameter '{1}' in order to consume preprocessed content.</source>
-        <target state="translated">NETSDK1010: Der Aufgabe "{0}" muss für die Nutzung vorverarbeiteter Inhalte mit einem Wert für den Parameter "{1}" versehen werden.</target>
-        <note>{StrBegin="NETSDK1010: "}</note>
-      </trans-unit>
-      <trans-unit id="ProjectAssetsConsumedWithoutMSBuildProjectPath">
-        <source>NETSDK1011: Assets are consumed from project '{0}', but no corresponding MSBuild project path was  found in '{1}'.</source>
-        <target state="translated">NETSDK1011: Es werden Ressourcen aus dem Projekt "{0}" genutzt, in "{1}" wurde jedoch kein entsprechender MSBuild-Projektpfad gefunden.</target>
-        <note>{StrBegin="NETSDK1011: "}</note>
-      </trans-unit>
-      <trans-unit id="UnexpectedFileType">
-        <source>NETSDK1012: Unexpected file type for '{0}'. Type is both '{1}' and '{2}'.</source>
-        <target state="translated">NETSDK1012: Unerwarteter Dateityp für "{0}". Der Typ ist sowohl "{1}" als auch "{2}".</target>
-        <note>{StrBegin="NETSDK1012: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotInferTargetFrameworkIdentifierAndVersion">
-        <source>NETSDK1013: The TargetFramework value '{0}' was not recognized. It may be misspelled. If not, then the TargetFrameworkIdentifier and/or TargetFrameworkVersion properties must be specified explicitly.</source>
-        <target state="translated">NETSDK1013: Der TargetFramework-Wert "{0}" wurde nicht erkannt. Unter Umständen ist die Schreibweise nicht korrekt. Andernfalls müssen die Eigenschaften TargetFrameworkIdentifier und/oder TargetFrameworkVersion explizit angegeben werden.</target>
-        <note>{StrBegin="NETSDK1013: "}</note>
-      </trans-unit>
-      <trans-unit id="ContentItemDoesNotProvideOutputPath">
-        <source>NETSDK1014: Content item for '{0}' sets '{1}', but does not provide  '{2}' or '{3}'.</source>
-        <target state="translated">NETSDK1014: Das Inhaltselement für "{0}" legt "{1}" fest, gibt aber "{2}" oder "{3}" nicht an.</target>
-        <note>{StrBegin="NETSDK1014: "}</note>
-      </trans-unit>
-      <trans-unit id="DuplicatePreprocessorToken">
-        <source>NETSDK1015: The preprocessor token '{0}' has been given more than one value. Choosing '{1}' as the value.</source>
-        <target state="translated">NETSDK1015: Das Präprozessortoken "{0}" wurde mit mehreren Werten versehen. "{1}" wird als Wert ausgewählt.</target>
-        <note>{StrBegin="NETSDK1015: "}</note>
-      </trans-unit>
-      <trans-unit id="UnableToFindResolvedPath">
-        <source>NETSDK1016: Unable to find resolved path for '{0}'.</source>
-        <target state="translated">NETSDK1016: Der aufgelöste Pfad für "{0}" wurde nicht gefunden.</target>
-        <note>{StrBegin="NETSDK1016: "}</note>
+      <trans-unit id="AspNetCoreUsesFrameworkReference">
+        <source>NETSDK1080: A PackageReference to Microsoft.AspNetCore.App is not necessary when targeting .NET Core 3.0 or higher. If Microsoft.NET.Sdk.Web is used, the shared framework will be referenced automatically. Otherwise, the PackageReference should be replaced with a FrameworkReference.</source>
+        <target state="translated">NETSDK1080: Ein PackageReference-Verweis auf Microsoft.AspNetCore.App ist nicht notwendig, wenn .NET Core 3.0 oder höher angezielt wird. Wenn Microsoft.NET.Sdk.Web verwendet wird, wird automatisch auf das freigegebene Framework verwiesen. Andernfalls sollte der PackageReference-Verweis durch einen FrameworkReference-Verweis ersetzt werden.</target>
+        <note>{StrBegin="NETSDK1080: "}</note>
       </trans-unit>
       <trans-unit id="AssetPreprocessorMustBeConfigured">
         <source>NETSDK1017: Asset preprocessor must be configured before assets are processed.</source>
         <target state="translated">NETSDK1017: Der Ressourcenpräprozessor muss konfiguriert werden, bevor Ressourcen verarbeitet werden.</target>
         <note>{StrBegin="NETSDK1017: "}</note>
       </trans-unit>
-      <trans-unit id="InvalidNuGetVersionString">
-        <source>NETSDK1018: Invalid NuGet version string: '{0}'.</source>
-        <target state="translated">NETSDK1018: Ungültige NuGet-Versionszeichenfolge: "{0}".</target>
-        <note>{StrBegin="NETSDK1018: "}</note>
+      <trans-unit id="AssetsFileMissingRuntimeIdentifier">
+        <source>NETSDK1047: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project. You may also need to include '{3}' in your project's RuntimeIdentifiers.</source>
+        <target state="translated">NETSDK1047: Die Ressourcendatei "{0}" verfügt über kein Ziel für "{1}". Stellen Sie sicher, dass die Wiederherstellung ausgeführt wurde, und dass Sie "{2}" in die TargetFrameworks für Ihr Projekt aufgenommen haben. Unter Umständen müssen Sie auch "{3}" in die RuntimeIdentifiers Ihres Projekts aufnehmen.</target>
+        <note>{StrBegin="NETSDK1047: "}</note>
       </trans-unit>
-      <trans-unit id="UnresolvedTargetingPack">
-        <source>NETSDK1081: The targeting pack for {0} was not found. You may be able to resolve this by running a NuGet restore on the project.</source>
-        <target state="new">NETSDK1081: The targeting pack for {0} was not found. You may be able to resolve this by running a NuGet restore on the project.</target>
-        <note>{StrBegin="NETSDK1081: "}</note>
+      <trans-unit id="AssetsFileMissingTarget">
+        <source>NETSDK1005: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project.</source>
+        <target state="translated">NETSDK1005: Die Ressourcendatei "{0}" weist kein Ziel für "{1}" auf. Stellen Sie sicher, dass die Wiederherstellung ausgeführt wurde, und dass Sie "{2}" in die TargetFrameworks für Ihr Projekt eingeschlossen haben.</target>
+        <note>{StrBegin="NETSDK1005: "}</note>
       </trans-unit>
-      <trans-unit id="UnsupportedFramework">
-        <source>NETSDK1019: {0} is an unsupported framework.</source>
-        <target state="translated">NETSDK1019: "{0}" ist ein nicht unterstütztes Framework.</target>
-        <note>{StrBegin="NETSDK1019: "}</note>
+      <trans-unit id="AssetsFileNotFound">
+        <source>NETSDK1004: Assets file '{0}' not found. Run a NuGet package restore to generate this file.</source>
+        <target state="translated">NETSDK1004: Die Ressourcendatei "{0}" wurde nicht gefunden. Führen Sie eine NuGet-Paketwiederherstellung aus, um diese Datei zu generieren.</target>
+        <note>{StrBegin="NETSDK1004: "}</note>
       </trans-unit>
-      <trans-unit id="DuplicateItemsError">
-        <source>NETSDK1022: Duplicate '{0}' items were included. The .NET SDK includes '{0}' items from your project directory by default. You can either remove these items from your project file, or set the '{1}' property to '{2}' if you want to explicitly include them in your project file. For more information, see {4}. The duplicate items were: {3}</source>
-        <target state="translated">NETSDK1022: Es wurden doppelte {0}-Elemente eingeschlossen. Das .NET SDK enthält standardmäßig {0}-Elemente aus ihrem Projektverzeichnis. Sie können entweder diese Elemente aus der Projektdatei entfernen oder die Eigenschaft "{1}" auf "{2}" festlegen, wenn Sie sie explizit in Ihre Projektdatei einbeziehen möchten. Weitere Informationen erhalten Sie unter "{4}". Die doppelten Elemente waren: {3}.</target>
-        <note>{StrBegin="NETSDK1022: "}</note>
+      <trans-unit id="AssetsFileNotSet">
+        <source>NETSDK1063: The path to the project assets file was not set. Run a NuGet package restore to generate this file.</source>
+        <target state="translated">NETSDK1063: Der Pfad zur Datei mit den Projektobjekten wurde nicht festgelegt. Führen Sie eine NuGet-Paketwiederherstellung durch, um diese Datei zu generieren.</target>
+        <note>{StrBegin="NETSDK1063: "}</note>
       </trans-unit>
-      <trans-unit id="PackageReferenceOverrideWarning">
-        <source>NETSDK1023: A PackageReference for '{0}' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see {1}</source>
-        <target state="translated">NETSDK1023: Ein PackageReference für "{0}" war in Ihrem Projekt vorhanden. Auf dieses Paket wird vom .NET SDK implizit verwiesen, und Sie müssen in der Regel nicht von Ihrem Projekt aus darauf verweisen. Weitere Informationen finden Sie unter "{1}".</target>
-        <note>{StrBegin="NETSDK1023: "}</note>
+      <trans-unit id="AssetsFilePathNotRooted">
+        <source>NETSDK1006: Assets file path '{0}' is not rooted. Only full paths are supported.</source>
+        <target state="translated">NETSDK1006: Die Ressourcendateipfad "{0}" hat keinen Stamm. Nur vollständige Pfade werden unterstützt.</target>
+        <note>{StrBegin="NETSDK1006: "}</note>
       </trans-unit>
-      <trans-unit id="IncorrectPackageRoot">
-        <source>NETSDK1020: Package Root {0} was incorrectly given for Resolved library {1}</source>
-        <target state="translated">NETSDK1020: Der Paketstamm "{0}" war für die aufgelöste Bibliothek "{1}" falsch angegeben.</target>
-        <note>{StrBegin="NETSDK1020: "}</note>
+      <trans-unit id="AtLeastOneTargetFrameworkMustBeSpecified">
+        <source>NETSDK1001: At least one possible target framework must be specified.</source>
+        <target state="translated">NETSDK1001: Geben Sie mindestens ein mögliches Zielframework an.</target>
+        <note>{StrBegin="NETSDK1001: "}</note>
       </trans-unit>
-      <trans-unit id="MultipleFilesResolved">
-        <source>NETSDK1021: More than one file found for {0}</source>
-        <target state="translated">NETSDK1021: Für "{0}" wurden mehrere Dateien gefunden.</target>
-        <note>{StrBegin="NETSDK1021: "}</note>
+      <trans-unit id="CannotFindApphostForRid">
+        <source>NETSDK1065: Cannot find app host for {0}. {0} could be an invalid runtime identifier (RID). For more information about RID, see https://aka.ms/rid-catalog.</source>
+        <target state="translated">NETSDK1065: Der App-Host für "{0}" wurde nicht gefunden. "{0}" könnte ein ungültiger Runtimebezeichner (RID) sein. Weitere Informationen zum RID finden Sie unter https://aka.ms/rid-catalog.</target>
+        <note>{StrBegin="NETSDK1065: "}</note>
       </trans-unit>
-      <trans-unit id="FolderAlreadyExists">
-        <source>NETSDK1024: Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</source>
-        <target state="translated">NETSDK1024: Der Ordner "{0}" ist bereits vorhanden. Löschen Sie ihn, oder geben Sie ein anderes "ComposeWorkingDir" an.</target>
-        <note>{StrBegin="NETSDK1024: "}</note>
+      <trans-unit id="CannotFindProjectInfo">
+        <source>NETSDK1007: Cannot find project info for '{0}'. This can indicate a missing project reference.</source>
+        <target state="translated">NETSDK1007: Die Projektinformationen für "{0}" wurden nicht gefunden. Dies ist möglicherweise auf einen fehlenden Projektverweis zurückzuführen.</target>
+        <note>{StrBegin="NETSDK1007: "}</note>
       </trans-unit>
-      <trans-unit id="ParsingFiles">
-        <source>NETSDK1026: Parsing the Files : '{0}'</source>
-        <target state="translated">NETSDK1026: Die Dateien werden analysiert: "{0}"</target>
-        <note>{StrBegin="NETSDK1026: "}</note>
-      </trans-unit>
-      <trans-unit id="PackageInfoLog">
-        <source>NETSDK1027: Package Name='{0}', Version='{1}' was parsed</source>
-        <target state="translated">NETSDK1027: Paketname="{0}", Version="{1}" wurde analysiert</target>
-        <note>{StrBegin="NETSDK1027: "}</note>
-      </trans-unit>
-      <trans-unit id="RuntimeIdentifierWasNotSpecified">
-        <source>NETSDK1028: Specify a RuntimeIdentifier</source>
-        <target state="translated">NETSDK1028: Geben Sie einen RuntimeIdentifier an.</target>
-        <note>{StrBegin="NETSDK1028: "}</note>
-      </trans-unit>
-      <trans-unit id="IncorrectTargetFormat">
-        <source>NETSDK1025: WRThe target manifest {0} provided is of not the correct format</source>
-        <target state="translated">NETSDK1025: Das angegebene Zielmanifest "{0}" hat nicht das richtige Format.</target>
-        <note>{StrBegin="NETSDK1025: "}</note>
-      </trans-unit>
-      <trans-unit id="AppHostHasBeenModified">
-        <source>NETSDK1029: Unable to use '{0}' as application host executable as it does not contain the expected placeholder byte sequence '{1}' that would mark where the application name would be written.</source>
-        <target state="translated">NETSDK1029: "{0}" kann nicht als ausführbare Anwendungshostdatei verwendet werden, da die erwartete Platzhalterbytesequenz "{1}" nicht vorhanden ist, die markiert, wo der Anwendungsname geschrieben wird.</target>
-        <note>{StrBegin="NETSDK1029: "}</note>
-      </trans-unit>
-      <trans-unit id="FileNameIsTooLong">
-        <source>NETSDK1030: Given file name '{0}' is longer than 1024 bytes</source>
-        <target state="translated">NETSDK1030: Der angegebene Dateiname "{0}" ist länger als 1024 Byte.</target>
-        <note>{StrBegin="NETSDK1030: "}</note>
+      <trans-unit id="CannotHaveRuntimeIdentifierPlatformMismatchPlatformTarget">
+        <source>NETSDK1032: The RuntimeIdentifier platform '{0}' and the PlatformTarget '{1}' must be compatible.</source>
+        <target state="translated">NETSDK1032: Die RuntimeIdentifier-Plattform "{0}" und das PlatformTarget "{1}" müssen kompatibel sein.</target>
+        <note>{StrBegin="NETSDK1032: "}</note>
       </trans-unit>
       <trans-unit id="CannotHaveSelfContainedWithoutRuntimeIdentifier">
         <source>NETSDK1031: It is not supported to build or publish a self-contained application without specifying a RuntimeIdentifier.  Please either specify a RuntimeIdentifier or set SelfContained to false.</source>
         <target state="translated">NETSDK1031: Das Erstellen oder Veröffentlichen einer eigenständigen Anwendung ohne die Angabe eines RuntimeIdentifier wird nicht unterstützt. Geben Sie entweder einen RuntimeIdentifier an, oder legen Sie für SelfContained "False" fest.</target>
         <note>{StrBegin="NETSDK1031: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotInferTargetFrameworkIdentifierAndVersion">
+        <source>NETSDK1013: The TargetFramework value '{0}' was not recognized. It may be misspelled. If not, then the TargetFrameworkIdentifier and/or TargetFrameworkVersion properties must be specified explicitly.</source>
+        <target state="translated">NETSDK1013: Der TargetFramework-Wert "{0}" wurde nicht erkannt. Unter Umständen ist die Schreibweise nicht korrekt. Andernfalls müssen die Eigenschaften TargetFrameworkIdentifier und/oder TargetFrameworkVersion explizit angegeben werden.</target>
+        <note>{StrBegin="NETSDK1013: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotUseSelfContainedWithoutAppHost">
+        <source>NETSDK1067: Self-contained applications are required to use the application host. Either set SelfContained to false or set UseAppHost to true.</source>
+        <target state="translated">NETSDK1067: Eigenständige Anwendungen müssen den Anwendungshost verwenden. Legen Sie "SelfContained" auf FALSE oder "UseAppHost" auf TRUE fest.</target>
+        <note>{StrBegin="NETSDK1067: "}</note>
       </trans-unit>
       <trans-unit id="ChoosingAssemblyVersion">
         <source>NETSDK1033: Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</source>
@@ -272,6 +132,16 @@
         <target state="translated">NETSDK1037: Der Gewinner konnte aufgrund übereinstimmender Datei- und Assemblyversionen nicht bestimmt werden.</target>
         <note>{StrBegin="NETSDK1037: "}</note>
       </trans-unit>
+      <trans-unit id="ContentItemDoesNotProvideOutputPath">
+        <source>NETSDK1014: Content item for '{0}' sets '{1}', but does not provide  '{2}' or '{3}'.</source>
+        <target state="translated">NETSDK1014: Das Inhaltselement für "{0}" legt "{1}" fest, gibt aber "{2}" oder "{3}" nicht an.</target>
+        <note>{StrBegin="NETSDK1014: "}</note>
+      </trans-unit>
+      <trans-unit id="ContentPreproccessorParameterRequired">
+        <source>NETSDK1010: The '{0}' task must be given a value for parameter '{1}' in order to consume preprocessed content.</source>
+        <target state="translated">NETSDK1010: Der Aufgabe "{0}" muss für die Nutzung vorverarbeiteter Inhalte mit einem Wert für den Parameter "{1}" versehen werden.</target>
+        <note>{StrBegin="NETSDK1010: "}</note>
+      </trans-unit>
       <trans-unit id="CouldNotDetermineWinner_DoesntExist">
         <source>NETSDK1038: Could not determine winner because '{0}' does not exist.</source>
         <target state="translated">NETSDK1038: Der Gewinner konnte nicht bestimmt werden, weil "{0}" nicht vorhanden ist.</target>
@@ -287,15 +157,40 @@
         <target state="translated">NETSDK1040: Der Gewinner konnte nicht bestimmt werden, weil es sich bei "{0}" nicht um eine Assembly handelt.</target>
         <note>{StrBegin="NETSDK1040: "}</note>
       </trans-unit>
+      <trans-unit id="CouldNotLoadPlatformManifest">
+        <source>NETSDK1042: Could not load PlatformManifest from '{0}' because it did not exist.</source>
+        <target state="translated">NETSDK1042: PlatformManifest konnte nicht von "{0}" geladen werden, weil es nicht vorhanden ist.</target>
+        <note>{StrBegin="NETSDK1042: "}</note>
+      </trans-unit>
+      <trans-unit id="DotnetToolDoesNotSupportTFMLowerThanNetcoreapp21">
+        <source>NETSDK1055: DotnetTool does not support target framework lower than netcoreapp2.1.</source>
+        <target state="translated">NETSDK1055: DotnetTool unterstützt kein Zielframework vor netcoreapp2.1.</target>
+        <note>{StrBegin="NETSDK1055: "}</note>
+      </trans-unit>
+      <trans-unit id="DotnetToolOnlySupportNetcoreapp">
+        <source>NETSDK1054: only supports .NET Core.</source>
+        <target state="translated">NETSDK1054: Unterstützt nur .NET Core.</target>
+        <note>{StrBegin="NETSDK1054: "}</note>
+      </trans-unit>
+      <trans-unit id="DuplicateItemsError">
+        <source>NETSDK1022: Duplicate '{0}' items were included. The .NET SDK includes '{0}' items from your project directory by default. You can either remove these items from your project file, or set the '{1}' property to '{2}' if you want to explicitly include them in your project file. For more information, see {4}. The duplicate items were: {3}</source>
+        <target state="translated">NETSDK1022: Es wurden doppelte {0}-Elemente eingeschlossen. Das .NET SDK enthält standardmäßig {0}-Elemente aus ihrem Projektverzeichnis. Sie können entweder diese Elemente aus der Projektdatei entfernen oder die Eigenschaft "{1}" auf "{2}" festlegen, wenn Sie sie explizit in Ihre Projektdatei einbeziehen möchten. Weitere Informationen erhalten Sie unter "{4}". Die doppelten Elemente waren: {3}.</target>
+        <note>{StrBegin="NETSDK1022: "}</note>
+      </trans-unit>
+      <trans-unit id="DuplicatePreprocessorToken">
+        <source>NETSDK1015: The preprocessor token '{0}' has been given more than one value. Choosing '{1}' as the value.</source>
+        <target state="translated">NETSDK1015: Das Präprozessortoken "{0}" wurde mit mehreren Werten versehen. "{1}" wird als Wert ausgewählt.</target>
+        <note>{StrBegin="NETSDK1015: "}</note>
+      </trans-unit>
       <trans-unit id="EncounteredConflict">
         <source>NETSDK1041: Encountered conflict between '{0}' and '{1}'.</source>
         <target state="translated">NETSDK1041: Zwischen "{0}" und "{1}" ist ein Konflikt aufgetreten.</target>
         <note>{StrBegin="NETSDK1041: "}</note>
       </trans-unit>
-      <trans-unit id="CouldNotLoadPlatformManifest">
-        <source>NETSDK1042: Could not load PlatformManifest from '{0}' because it did not exist.</source>
-        <target state="translated">NETSDK1042: PlatformManifest konnte nicht von "{0}" geladen werden, weil es nicht vorhanden ist.</target>
-        <note>{StrBegin="NETSDK1042: "}</note>
+      <trans-unit id="ErrorParsingFrameworkListInvalidValue">
+        <source>NETSDK1051: Error parsing FrameworkList from '{0}'.  {1} '{2}' was invalid.</source>
+        <target state="translated">NETSDK1051: Fehler beim Analysieren von FrameworkList aus "{0}". {1} "{2}" war ungültig.</target>
+        <note>{StrBegin="NETSDK1051: "}</note>
       </trans-unit>
       <trans-unit id="ErrorParsingPlatformManifest">
         <source>NETSDK1043: Error parsing PlatformManifest from '{0}' line {1}.  Lines must have the format {2}.</source>
@@ -307,65 +202,55 @@
         <target state="translated">NETSDK1044: Fehler beim Analysieren von PlatformManifest von "{0}" Zeile {1}. {2} "{3}" war ungültig.</target>
         <note>{StrBegin="NETSDK1044: "}</note>
       </trans-unit>
-      <trans-unit id="UnsupportedTargetFrameworkVersion">
-        <source>NETSDK1045: The current .NET SDK does not support targeting {0} {1}.  Either target {0} {2} or lower, or use a version of the .NET SDK that supports {0} {1}.</source>
-        <target state="translated">NETSDK1045: Das aktuelle .NET SDK unterstützt {0} {1} nicht als Ziel. Geben Sie entweder {0} {2} oder niedriger als Ziel an, oder verwenden Sie eine .NET SDK-Version, die {0} {1} unterstützt.</target>
-        <note>{StrBegin="NETSDK1045: "}</note>
+      <trans-unit id="ErrorReadingAssetsFile">
+        <source>NETSDK1060: Error reading assets file: {0}</source>
+        <target state="translated">NETSDK1060: Fehler beim Lesen der Ressourcendatei: {0}</target>
+        <note>{StrBegin="NETSDK1060: "}</note>
       </trans-unit>
-      <trans-unit id="AssetsFileMissingRuntimeIdentifier">
-        <source>NETSDK1047: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project. You may also need to include '{3}' in your project's RuntimeIdentifiers.</source>
-        <target state="translated">NETSDK1047: Die Ressourcendatei "{0}" verfügt über kein Ziel für "{1}". Stellen Sie sicher, dass die Wiederherstellung ausgeführt wurde, und dass Sie "{2}" in die TargetFrameworks für Ihr Projekt aufgenommen haben. Unter Umständen müssen Sie auch "{3}" in die RuntimeIdentifiers Ihres Projekts aufnehmen.</target>
-        <note>{StrBegin="NETSDK1047: "}</note>
+      <trans-unit id="FailedToLockResource">
+        <source>NETSDK1077: Failed to lock resource.</source>
+        <target state="translated">NETSDK1077: Fehler beim Sperren der Ressource.</target>
+        <note>{StrBegin="NETSDK1077: "}</note>
       </trans-unit>
-      <trans-unit id="TargetFrameworkWithSemicolon">
-        <source>NETSDK1046: The TargetFramework value '{0}' is not valid. To multi-target, use the 'TargetFrameworks' property instead.</source>
-        <target state="translated">NETSDK1046: Der TargetFramework-Wert "{0}" ist nicht gültig. Verwenden Sie für mehrere Ziele die Eigenschaft "TargetFrameworks".</target>
-        <note>{StrBegin="NETSDK1046: "}</note>
+      <trans-unit id="FileNameIsTooLong">
+        <source>NETSDK1030: Given file name '{0}' is longer than 1024 bytes</source>
+        <target state="translated">NETSDK1030: Der angegebene Dateiname "{0}" ist länger als 1024 Byte.</target>
+        <note>{StrBegin="NETSDK1030: "}</note>
       </trans-unit>
-      <trans-unit id="GetDependsOnNETStandardFailedWithException">
-        <source>NETSDK1049: Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0} {1}</source>
-        <target state="translated">NETSDK1049: Die aufgelöste Datei enthält ein fehlerhaftes Image oder keine Metadaten, oder der Zugriff ist aus anderen Gründen nicht möglich. {0} {1}</target>
-        <note>{StrBegin="NETSDK1049: "}</note>
+      <trans-unit id="FolderAlreadyExists">
+        <source>NETSDK1024: Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</source>
+        <target state="translated">NETSDK1024: Der Ordner "{0}" ist bereits vorhanden. Löschen Sie ihn, oder geben Sie ein anderes "ComposeWorkingDir" an.</target>
+        <note>{StrBegin="NETSDK1024: "}</note>
       </trans-unit>
-      <trans-unit id="UnsupportedSDKVersionForNetStandard20">
-        <source>NETSDK1050: The version of Microsoft.NET.Sdk used by this project is insufficient to support references to libraries targeting .NET Standard 1.5 or higher.  Please install version 2.0 or higher of the .NET Core SDK.</source>
-        <target state="translated">NETSDK1050: Die von diesem Projekt verwendete Microsoft.NET.Sdk-Version reicht zur Unterstützung von Verweisen auf Bibliotheken für .NET Standard 1.5 oder höher nicht aus. Installieren Sie mindestens .NET Core SDK 2.0.</target>
-        <note>{StrBegin="NETSDK1050: "}</note>
-      </trans-unit>
-      <trans-unit id="SkippingAdditionalProbingPaths">
-        <source>NETSDK1048: 'AdditionalProbingPaths' were specified for GenerateRuntimeConfigurationFiles, but are being skipped because 'RuntimeConfigDevPath' is empty.</source>
-        <target state="translated">NETSDK1048: Für GenerateRuntimeConfigurationFiles wurden "AdditionalProbingPaths" angegeben, sie werden jedoch übersprungen, weil "RuntimeConfigDevPath" leer ist.</target>
-        <note>{StrBegin="NETSDK1048: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotHaveRuntimeIdentifierPlatformMismatchPlatformTarget">
-        <source>NETSDK1032: The RuntimeIdentifier platform '{0}' and the PlatformTarget '{1}' must be compatible.</source>
-        <target state="translated">NETSDK1032: Die RuntimeIdentifier-Plattform "{0}" und das PlatformTarget "{1}" müssen kompatibel sein.</target>
-        <note>{StrBegin="NETSDK1032: "}</note>
-      </trans-unit>
-      <trans-unit id="ErrorParsingFrameworkListInvalidValue">
-        <source>NETSDK1051: Error parsing FrameworkList from '{0}'.  {1} '{2}' was invalid.</source>
-        <target state="translated">NETSDK1051: Fehler beim Analysieren von FrameworkList aus "{0}". {1} "{2}" war ungültig.</target>
-        <note>{StrBegin="NETSDK1051: "}</note>
+      <trans-unit id="FrameworkDependentAppHostRequiresVersion21">
+        <source>NETSDK1068: The framework-dependent application host requires a target framework of at least 'netcoreapp2.1'.</source>
+        <target state="translated">NETSDK1068: Für den frameworkabhängigen Anwendungshost ist mindestens das Zielframework "netcoreapp2.1" erforderlich.</target>
+        <note>{StrBegin="NETSDK1068: "}</note>
       </trans-unit>
       <trans-unit id="FrameworkListPathNotRooted">
         <source>NETSDK1052: Framework list file path '{0}' is not rooted. Only full paths are supported.</source>
         <target state="translated">NETSDK1052: Der FrameworkList-Dateipfad "{0}" enthält keinen Stamm. Nur vollständige Pfade werden unterstützt.</target>
         <note>{StrBegin="NETSDK1052: "}</note>
       </trans-unit>
-      <trans-unit id="PackAsToolCannotSupportSelfContained">
-        <source>NETSDK1053: Pack as tool does not support self contained.</source>
-        <target state="translated">NETSDK1053: Die Paketierung als Tool unterstützt keine eigenständige Bereitstellung.</target>
-        <note>{StrBegin="NETSDK1001: "}</note>
+      <trans-unit id="GetDependsOnNETStandardFailedWithException">
+        <source>NETSDK1049: Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0} {1}</source>
+        <target state="translated">NETSDK1049: Die aufgelöste Datei enthält ein fehlerhaftes Image oder keine Metadaten, oder der Zugriff ist aus anderen Gründen nicht möglich. {0} {1}</target>
+        <note>{StrBegin="NETSDK1049: "}</note>
       </trans-unit>
-      <trans-unit id="UnsupportedRuntimeIdentifier">
-        <source>NETSDK1056: Project is targeting runtime '{0}' but did not resolve any runtime-specific packages. This runtime may not be supported by the target framework.</source>
-        <target state="translated">NETSDK1056: Das Projekt ist auf die Runtime "{0}" ausgelegt, aber hat keine runtimespezifischen Pakete aufgelöst. Diese Runtime wird vom Zielframework möglicherweise nicht unterstützt.</target>
-        <note>{StrBegin="NETSDK1056: "}</note>
+      <trans-unit id="IncorrectPackageRoot">
+        <source>NETSDK1020: Package Root {0} was incorrectly given for Resolved library {1}</source>
+        <target state="translated">NETSDK1020: Der Paketstamm "{0}" war für die aufgelöste Bibliothek "{1}" falsch angegeben.</target>
+        <note>{StrBegin="NETSDK1020: "}</note>
       </trans-unit>
-      <trans-unit id="UsingPreviewSdkWarning">
-        <source>NETSDK1057: You are using a preview version of .NET Core. See: https://aka.ms/dotnet-core-preview</source>
-        <target state="translated">NETSDK1057: Sie verwenden eine Vorschauversion von .NET Core. Weitere Informationen: https://aka.ms/dotnet-core-preview</target>
-        <note>{StrBegin="NETSDK1057: "}</note>
+      <trans-unit id="IncorrectTargetFormat">
+        <source>NETSDK1025: WRThe target manifest {0} provided is of not the correct format</source>
+        <target state="translated">NETSDK1025: Das angegebene Zielmanifest "{0}" hat nicht das richtige Format.</target>
+        <note>{StrBegin="NETSDK1025: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidFrameworkName">
+        <source>NETSDK1003: Invalid framework name: '{0}'.</source>
+        <target state="translated">NETSDK1003: Ungültiger Frameworkname: "{0}".</target>
+        <note>{StrBegin="NETSDK1003: "}</note>
       </trans-unit>
       <trans-unit id="InvalidItemSpecToUse">
         <source>NETSDK1058: Invalid value for ItemSpecToUse parameter: '{0}'.  This property must be blank or set to 'Left' or 'Right'</source>
@@ -373,15 +258,15 @@
         <note>{StrBegin="NETSDK1058: "}
 The following are names of parameters or literal values and should not be translated: ItemSpecToUse, Left, Right</note>
       </trans-unit>
-      <trans-unit id="ProjectContainsObsoleteDotNetCliTool">
-        <source>NETSDK1059: The tool '{0}' is now included in the .NET Core SDK. Information on resolving this warning is available at (https://aka.ms/dotnetclitools-in-box).</source>
-        <target state="translated">NETSDK1059: Das Tool "{0}" ist jetzt im .NET Core SDK enthalten. Informationen zum Auflösen dieser Warnung sind unter https://aka.ms/dotnetclitools-in-box verfügbar.</target>
-        <note>{StrBegin="NETSDK1059: "}</note>
+      <trans-unit id="InvalidNuGetVersionString">
+        <source>NETSDK1018: Invalid NuGet version string: '{0}'.</source>
+        <target state="translated">NETSDK1018: Ungültige NuGet-Versionszeichenfolge: "{0}".</target>
+        <note>{StrBegin="NETSDK1018: "}</note>
       </trans-unit>
-      <trans-unit id="ErrorReadingAssetsFile">
-        <source>NETSDK1060: Error reading assets file: {0}</source>
-        <target state="translated">NETSDK1060: Fehler beim Lesen der Ressourcendatei: {0}</target>
-        <note>{StrBegin="NETSDK1060: "}</note>
+      <trans-unit id="InvalidResourceUpdate">
+        <source>NETSDK1075: Update handle is invalid. This instance may not be used for further updates.</source>
+        <target state="translated">NETSDK1075: Das Updatehandle ist ungültig. Diese Instanz kann nicht für weitere Updates verwendet werden.</target>
+        <note>{StrBegin="NETSDK1075: "}</note>
       </trans-unit>
       <trans-unit id="MismatchedPlatformPackageVersion">
         <source>NETSDK1061: The project was restored using {0} version {1}, but with current settings, version {2} would be used instead. To resolve this issue, make sure the same settings are used for restore and for subsequent operations such as build or publish. Typically this issue can occur if the RuntimeIdentifier property is set during build or publish but not during restore. For more information, see https://aka.ms/dotnet-runtime-patch-selection.</source>
@@ -391,35 +276,150 @@ The following are names of parameters or literal values and should not be transl
 {1} - Restored version of platform package
 {2} - Current version of platform package</note>
       </trans-unit>
-      <trans-unit id="AssetsFileNotSet">
-        <source>NETSDK1063: The path to the project assets file was not set. Run a NuGet package restore to generate this file.</source>
-        <target state="translated">NETSDK1063: Der Pfad zur Datei mit den Projektobjekten wurde nicht festgelegt. Führen Sie eine NuGet-Paketwiederherstellung durch, um diese Datei zu generieren.</target>
-        <note>{StrBegin="NETSDK1063: "}</note>
+      <trans-unit id="MissingItemMetadata">
+        <source>NETSDK1008: Missing '{0}' metadata on '{1}' item '{2}'.</source>
+        <target state="translated">NETSDK1008: Die Metadaten "{0}" für das Element "{2}" vom Typ "{1}" sind nicht vorhanden.</target>
+        <note>{StrBegin="NETSDK1008: "}</note>
       </trans-unit>
-      <trans-unit id="DotnetToolOnlySupportNetcoreapp">
-        <source>NETSDK1054: only supports .NET Core.</source>
-        <target state="translated">NETSDK1054: Unterstützt nur .NET Core.</target>
-        <note>{StrBegin="NETSDK1054: "}</note>
+      <trans-unit id="MultipleFilesResolved">
+        <source>NETSDK1021: More than one file found for {0}</source>
+        <target state="translated">NETSDK1021: Für "{0}" wurden mehrere Dateien gefunden.</target>
+        <note>{StrBegin="NETSDK1021: "}</note>
       </trans-unit>
-      <trans-unit id="DotnetToolDoesNotSupportTFMLowerThanNetcoreapp21">
-        <source>NETSDK1055: DotnetTool does not support target framework lower than netcoreapp2.1.</source>
-        <target state="translated">NETSDK1055: DotnetTool unterstützt kein Zielframework vor netcoreapp2.1.</target>
-        <note>{StrBegin="NETSDK1055: "}</note>
+      <trans-unit id="NETFrameworkToNonBuiltInNETStandard">
+        <source>NETSDK1069: This project uses a library that targets .NET Standard 1.5 or higher, and the project targets a version of .NET Framework that doesn't have built-in support for that version of .NET Standard. Visit https://aka.ms/net-standard-known-issues for a set of known issues. Consider retargeting to .NET Framework 4.7.2.</source>
+        <target state="translated">NETSDK1069: Dieses Projekt verwendet eine Bibliothek, die auf .NET Standard 1.5 oder höher ausgerichtet ist, und das Projekt ist auf eine Version von .NET Framework ausgerichtet, die keine integrierte Unterstützung für diese .NET Standard-Version bietet. Besuchen Sie https://aka.ms/net-standard-known-issues for a set of known issues. Ziehen Sie eine neue Ausrichtung auf .NET Framework 4.7.2 in Betracht.</target>
+        <note>{StrBegin="NETSDK1069: "}</note>
       </trans-unit>
-      <trans-unit id="UnableToUsePackageAssetsCache">
-        <source>NETSDK1062: Unable to use package assets cache due to I/O error. This can occur when the same project is built more than once in parallel. Performance may be degraded, but the build result will not be impacted.</source>
-        <target state="translated">NETSDK1062: Der Cache für Paketressourcen kann aufgrund eines E/A-Fehlers nicht verwendet werden. Dieses Problem kann auftreten, wenn dasselbe Projekt gleichzeitig mehrfach kompiliert wird. Die Leistung ist möglicherweise herabgesetzt, aber das Buildergebnis wird nicht beeinträchtigt.</target>
-        <note>{StrBegin="NETSDK1062: "}</note>
+      <trans-unit id="NoAppHostAvailable">
+        <source>NETSDK1084: There is no application host available for the specified RuntimeIdentifier '{0}'.</source>
+        <target state="new">NETSDK1084: There is no application host available for the specified RuntimeIdentifier '{0}'.</target>
+        <note>{StrBegin="NETSDK1084: "}</note>
+      </trans-unit>
+      <trans-unit id="NoCompatibleTargetFramework">
+        <source>NETSDK1002: Project '{0}' targets '{2}'. It cannot be referenced by a project that targets '{1}'.</source>
+        <target state="translated">NETSDK1002: Das Projekt "{0}" hat das Ziel "{2}". Ein Verweis über ein Projekt mit dem Ziel "{1}" ist nicht möglich.</target>
+        <note>{StrBegin="NETSDK1002: "}</note>
+      </trans-unit>
+      <trans-unit id="NoRuntimePackAvailable">
+        <source>NETSDK1082: There was no runtime pack for {0} available for the specified RuntimeIdentifier '{1}'.</source>
+        <target state="new">NETSDK1082: There was no runtime pack for {0} available for the specified RuntimeIdentifier '{1}'.</target>
+        <note>{StrBegin="NETSDK1082: "}</note>
+      </trans-unit>
+      <trans-unit id="PackAsToolCannotSupportSelfContained">
+        <source>NETSDK1053: Pack as tool does not support self contained.</source>
+        <target state="translated">NETSDK1053: Die Paketierung als Tool unterstützt keine eigenständige Bereitstellung.</target>
+        <note>{StrBegin="NETSDK1001: "}</note>
+      </trans-unit>
+      <trans-unit id="PackageInfoLog">
+        <source>NETSDK1027: Package Name='{0}', Version='{1}' was parsed</source>
+        <target state="translated">NETSDK1027: Paketname="{0}", Version="{1}" wurde analysiert</target>
+        <note>{StrBegin="NETSDK1027: "}</note>
       </trans-unit>
       <trans-unit id="PackageNotFound">
         <source>NETSDK1064: Package {0}, version {1} was not found. It might have been deleted since NuGet restore. Otherwise, NuGet restore might have only partially completed, which might have been due to maximum path length restrictions.</source>
         <target state="translated">NETSDK1064: Das Paket "{0}", Version {1}, wurde nicht gefunden. Möglicherweise wurde es nach der NuGet-Wiederherstellung gelöscht. Andernfalls wurde die NuGet-Wiederherstellung aufgrund von Beschränkungen der maximalen Pfadlänge eventuell nur teilweise abgeschlossen.</target>
         <note>{StrBegin="NETSDK1064: "}</note>
       </trans-unit>
-      <trans-unit id="CannotFindApphostForRid">
-        <source>NETSDK1065: Cannot find app host for {0}. {0} could be an invalid runtime identifier (RID). For more information about RID, see https://aka.ms/rid-catalog.</source>
-        <target state="translated">NETSDK1065: Der App-Host für "{0}" wurde nicht gefunden. "{0}" könnte ein ungültiger Runtimebezeichner (RID) sein. Weitere Informationen zum RID finden Sie unter https://aka.ms/rid-catalog.</target>
-        <note>{StrBegin="NETSDK1065: "}</note>
+      <trans-unit id="PackageReferenceOverrideWarning">
+        <source>NETSDK1023: A PackageReference for '{0}' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see {1}</source>
+        <target state="translated">NETSDK1023: Ein PackageReference für "{0}" war in Ihrem Projekt vorhanden. Auf dieses Paket wird vom .NET SDK implizit verwiesen, und Sie müssen in der Regel nicht von Ihrem Projekt aus darauf verweisen. Weitere Informationen finden Sie unter "{1}".</target>
+        <note>{StrBegin="NETSDK1023: "}</note>
+      </trans-unit>
+      <trans-unit id="PackageReferenceVersionNotRecommended">
+        <source>NETSDK1071: A PackageReference to '{0}' specified a Version of `{1}`. Specifying the version of this package is not recommended. For more information, see https://aka.ms/sdkimplicitrefs</source>
+        <target state="translated">NETSDK1071: Ein PackageReference-Verweis auf "{0}" hat die Version "{1}" angegeben. Die Angabe der Version dieses Pakets wird nicht empfohlen. Weitere Informationen finden Sie unter https://aka.ms/sdkimplicitrefs.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParsingFiles">
+        <source>NETSDK1026: Parsing the Files : '{0}'</source>
+        <target state="translated">NETSDK1026: Die Dateien werden analysiert: "{0}"</target>
+        <note>{StrBegin="NETSDK1026: "}</note>
+      </trans-unit>
+      <trans-unit id="ProjectAssetsConsumedWithoutMSBuildProjectPath">
+        <source>NETSDK1011: Assets are consumed from project '{0}', but no corresponding MSBuild project path was  found in '{1}'.</source>
+        <target state="translated">NETSDK1011: Es werden Ressourcen aus dem Projekt "{0}" genutzt, in "{1}" wurde jedoch kein entsprechender MSBuild-Projektpfad gefunden.</target>
+        <note>{StrBegin="NETSDK1011: "}</note>
+      </trans-unit>
+      <trans-unit id="ProjectContainsObsoleteDotNetCliTool">
+        <source>NETSDK1059: The tool '{0}' is now included in the .NET Core SDK. Information on resolving this warning is available at (https://aka.ms/dotnetclitools-in-box).</source>
+        <target state="translated">NETSDK1059: Das Tool "{0}" ist jetzt im .NET Core SDK enthalten. Informationen zum Auflösen dieser Warnung sind unter https://aka.ms/dotnetclitools-in-box verfügbar.</target>
+        <note>{StrBegin="NETSDK1059: "}</note>
+      </trans-unit>
+      <trans-unit id="RuntimeIdentifierNotRecognized">
+        <source>NETSDK1083: The specified RuntimeIdentifier '{0}' is not recognized.</source>
+        <target state="new">NETSDK1083: The specified RuntimeIdentifier '{0}' is not recognized.</target>
+        <note>{StrBegin="NETSDK1083: "}</note>
+      </trans-unit>
+      <trans-unit id="RuntimeIdentifierWasNotSpecified">
+        <source>NETSDK1028: Specify a RuntimeIdentifier</source>
+        <target state="translated">NETSDK1028: Geben Sie einen RuntimeIdentifier an.</target>
+        <note>{StrBegin="NETSDK1028: "}</note>
+      </trans-unit>
+      <trans-unit id="SkippingAdditionalProbingPaths">
+        <source>NETSDK1048: 'AdditionalProbingPaths' were specified for GenerateRuntimeConfigurationFiles, but are being skipped because 'RuntimeConfigDevPath' is empty.</source>
+        <target state="translated">NETSDK1048: Für GenerateRuntimeConfigurationFiles wurden "AdditionalProbingPaths" angegeben, sie werden jedoch übersprungen, weil "RuntimeConfigDevPath" leer ist.</target>
+        <note>{StrBegin="NETSDK1048: "}</note>
+      </trans-unit>
+      <trans-unit id="TargetFrameworkWithSemicolon">
+        <source>NETSDK1046: The TargetFramework value '{0}' is not valid. To multi-target, use the 'TargetFrameworks' property instead.</source>
+        <target state="translated">NETSDK1046: Der TargetFramework-Wert "{0}" ist nicht gültig. Verwenden Sie für mehrere Ziele die Eigenschaft "TargetFrameworks".</target>
+        <note>{StrBegin="NETSDK1046: "}</note>
+      </trans-unit>
+      <trans-unit id="UnableToFindResolvedPath">
+        <source>NETSDK1016: Unable to find resolved path for '{0}'.</source>
+        <target state="translated">NETSDK1016: Der aufgelöste Pfad für "{0}" wurde nicht gefunden.</target>
+        <note>{StrBegin="NETSDK1016: "}</note>
+      </trans-unit>
+      <trans-unit id="UnableToUsePackageAssetsCache">
+        <source>NETSDK1062: Unable to use package assets cache due to I/O error. This can occur when the same project is built more than once in parallel. Performance may be degraded, but the build result will not be impacted.</source>
+        <target state="translated">NETSDK1062: Der Cache für Paketressourcen kann aufgrund eines E/A-Fehlers nicht verwendet werden. Dieses Problem kann auftreten, wenn dasselbe Projekt gleichzeitig mehrfach kompiliert wird. Die Leistung ist möglicherweise herabgesetzt, aber das Buildergebnis wird nicht beeinträchtigt.</target>
+        <note>{StrBegin="NETSDK1062: "}</note>
+      </trans-unit>
+      <trans-unit id="UnexpectedFileType">
+        <source>NETSDK1012: Unexpected file type for '{0}'. Type is both '{1}' and '{2}'.</source>
+        <target state="translated">NETSDK1012: Unerwarteter Dateityp für "{0}". Der Typ ist sowohl "{1}" als auch "{2}".</target>
+        <note>{StrBegin="NETSDK1012: "}</note>
+      </trans-unit>
+      <trans-unit id="UnknownFrameworkReference">
+        <source>NETSDK1073: The FrameworkReference '{0}' was not recognized</source>
+        <target state="translated">NETSDK1073: Der FrameworkReference-Verweis "{0}" wurde nicht erkannt.</target>
+        <note>{StrBegin="NETSDK1073: "}</note>
+      </trans-unit>
+      <trans-unit id="UnrecognizedPreprocessorToken">
+        <source>NETSDK1009: Unrecognized preprocessor token '{0}' in '{1}'.</source>
+        <target state="translated">NETSDK1009: Unbekanntes Präprozessortoken "{0}" in "{1}".</target>
+        <note>{StrBegin="NETSDK1009: "}</note>
+      </trans-unit>
+      <trans-unit id="UnresolvedTargetingPack">
+        <source>NETSDK1081: The targeting pack for {0} was not found. You may be able to resolve this by running a NuGet restore on the project.</source>
+        <target state="new">NETSDK1081: The targeting pack for {0} was not found. You may be able to resolve this by running a NuGet restore on the project.</target>
+        <note>{StrBegin="NETSDK1081: "}</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedFramework">
+        <source>NETSDK1019: {0} is an unsupported framework.</source>
+        <target state="translated">NETSDK1019: "{0}" ist ein nicht unterstütztes Framework.</target>
+        <note>{StrBegin="NETSDK1019: "}</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedRuntimeIdentifier">
+        <source>NETSDK1056: Project is targeting runtime '{0}' but did not resolve any runtime-specific packages. This runtime may not be supported by the target framework.</source>
+        <target state="translated">NETSDK1056: Das Projekt ist auf die Runtime "{0}" ausgelegt, aber hat keine runtimespezifischen Pakete aufgelöst. Diese Runtime wird vom Zielframework möglicherweise nicht unterstützt.</target>
+        <note>{StrBegin="NETSDK1056: "}</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedSDKVersionForNetStandard20">
+        <source>NETSDK1050: The version of Microsoft.NET.Sdk used by this project is insufficient to support references to libraries targeting .NET Standard 1.5 or higher.  Please install version 2.0 or higher of the .NET Core SDK.</source>
+        <target state="translated">NETSDK1050: Die von diesem Projekt verwendete Microsoft.NET.Sdk-Version reicht zur Unterstützung von Verweisen auf Bibliotheken für .NET Standard 1.5 oder höher nicht aus. Installieren Sie mindestens .NET Core SDK 2.0.</target>
+        <note>{StrBegin="NETSDK1050: "}</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedTargetFrameworkVersion">
+        <source>NETSDK1045: The current .NET SDK does not support targeting {0} {1}.  Either target {0} {2} or lower, or use a version of the .NET SDK that supports {0} {1}.</source>
+        <target state="translated">NETSDK1045: Das aktuelle .NET SDK unterstützt {0} {1} nicht als Ziel. Geben Sie entweder {0} {2} oder niedriger als Ziel an, oder verwenden Sie eine .NET SDK-Version, die {0} {1} unterstützt.</target>
+        <note>{StrBegin="NETSDK1045: "}</note>
+      </trans-unit>
+      <trans-unit id="UsingPreviewSdkWarning">
+        <source>NETSDK1057: You are using a preview version of .NET Core. See: https://aka.ms/dotnet-core-preview</source>
+        <target state="translated">NETSDK1057: Sie verwenden eine Vorschauversion von .NET Core. Weitere Informationen: https://aka.ms/dotnet-core-preview</target>
+        <note>{StrBegin="NETSDK1057: "}</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Tasks/Common/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.es.xlf
@@ -2,35 +2,25 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../Strings.resx">
     <body>
-      <trans-unit id="AspNetCoreAllNotSupported">
-        <source>NETSDK1079: The Microsoft.AspNetCore.All package is not supported when targeting .NET Core 3.0 or higher.  A FrameworkReference to Microsoft.AspNetCore.App should be used instead, and will be implicitly included by Microsoft.NET.Sdk.Web.</source>
-        <target state="translated">NETSDK1079: El paquete Microsoft.AspNetCore.All no es compatible cuando se dirige a .NET Core 3.0 o superior. En su lugar, se debe usar FrameworkReference a Microsoft.AspNetCore.App, que se incluirá implícitamente en Microsoft.NET.Sdk.Web.</target>
-        <note>{StrBegin="NETSDK1079: "}</note>
-      </trans-unit>
-      <trans-unit id="AspNetCoreUsesFrameworkReference">
-        <source>NETSDK1080: A PackageReference to Microsoft.AspNetCore.App is not necessary when targeting .NET Core 3.0 or higher. If Microsoft.NET.Sdk.Web is used, the shared framework will be referenced automatically. Otherwise, the PackageReference should be replaced with a FrameworkReference.</source>
-        <target state="translated">NETSDK1080: Un PackageReference a Microsoft.AspNetCore.App no es necesario cuando el destino es .NET Core 3.0 o superior. Si se utiliza Microsoft.NET.Sdk.Web, se hará referencia al marco común automáticamente. De no ser así, el PackageReference debe reemplazarse por un FrameworkReference.</target>
-        <note>{StrBegin="NETSDK1080: "}</note>
-      </trans-unit>
-      <trans-unit id="FailedToLockResource">
-        <source>NETSDK1077: Failed to lock resource.</source>
-        <target state="translated">NETSDK1077: Error al bloquear recursos.</target>
-        <note>{StrBegin="NETSDK1077: "}</note>
-      </trans-unit>
       <trans-unit id="AddResourceWithNonIntegerResource">
         <source>NETSDK1076: AddResource can only be used with integer resource types.</source>
         <target state="translated">NETSDK1076: AddResource solo se puede utilizar con tipos de recursos enteros.</target>
         <note>{StrBegin="NETSDK1076: "}</note>
       </trans-unit>
-      <trans-unit id="InvalidResourceUpdate">
-        <source>NETSDK1075: Update handle is invalid. This instance may not be used for further updates.</source>
-        <target state="translated">NETSDK1075: El identificador de actualización no es válido. Esta instancia no se puede utilizar para otras actualizaciones.</target>
-        <note>{StrBegin="NETSDK1075: "}</note>
+      <trans-unit id="AppConfigRequiresRootConfiguration">
+        <source>NETSDK1070: The application configuration file must have root configuration element.</source>
+        <target state="translated">NETSDK1070: El archivo de configuración de la aplicación debe tener el elemento de configuración raíz.</target>
+        <note>{StrBegin="NETSDK1070: "}</note>
       </trans-unit>
       <trans-unit id="AppHostCustomizationRequiresWindowsHostWarning">
         <source>NETSDK1074: The application host executable will not be customized because adding resources requires that the build be performed on Windows (excluding Nano Server).</source>
         <target state="translated">NETSDK1074: El ejecutable del host de la aplicación no se personalizará porque la adición de recursos requiere que la compilación se realice en Windows (excluyendo el servidor Nano).</target>
         <note>{StrBegin="NETSDK1074: "}</note>
+      </trans-unit>
+      <trans-unit id="AppHostHasBeenModified">
+        <source>NETSDK1029: Unable to use '{0}' as application host executable as it does not contain the expected placeholder byte sequence '{1}' that would mark where the application name would be written.</source>
+        <target state="translated">NETSDK1029: No se puede usar "{0}" como ejecutable del host de aplicación ya que no contiene la secuencia de bytes esperada del marcador de posición "{1}" que marcaría dónde escribir el nombre de la aplicación.</target>
+        <note>{StrBegin="NETSDK1029: "}</note>
       </trans-unit>
       <trans-unit id="AppHostNotWindows">
         <source>NETSDK1078: Unable to use '{0}' as application host executable because it's not a Windows PE file.</source>
@@ -42,210 +32,80 @@
         <target state="translated">NETSDK1072: No se puede utilizar "{0}" como ejecutable del host de la aplicación porque no es un ejecutable de Windows para el subsistema CUI (consola).</target>
         <note>{StrBegin="NETSDK1072: "}</note>
       </trans-unit>
-      <trans-unit id="AppConfigRequiresRootConfiguration">
-        <source>NETSDK1070: The application configuration file must have root configuration element.</source>
-        <target state="translated">NETSDK1070: El archivo de configuración de la aplicación debe tener el elemento de configuración raíz.</target>
-        <note>{StrBegin="NETSDK1070: "}</note>
+      <trans-unit id="AspNetCoreAllNotSupported">
+        <source>NETSDK1079: The Microsoft.AspNetCore.All package is not supported when targeting .NET Core 3.0 or higher.  A FrameworkReference to Microsoft.AspNetCore.App should be used instead, and will be implicitly included by Microsoft.NET.Sdk.Web.</source>
+        <target state="translated">NETSDK1079: El paquete Microsoft.AspNetCore.All no es compatible cuando se dirige a .NET Core 3.0 o superior. En su lugar, se debe usar FrameworkReference a Microsoft.AspNetCore.App, que se incluirá implícitamente en Microsoft.NET.Sdk.Web.</target>
+        <note>{StrBegin="NETSDK1079: "}</note>
       </trans-unit>
-      <trans-unit id="AtLeastOneTargetFrameworkMustBeSpecified">
-        <source>NETSDK1001: At least one possible target framework must be specified.</source>
-        <target state="translated">NETSDK1001: Debe especificarse al menos una plataforma de destino posible.</target>
-        <note>{StrBegin="NETSDK1001: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotUseSelfContainedWithoutAppHost">
-        <source>NETSDK1067: Self-contained applications are required to use the application host. Either set SelfContained to false or set UseAppHost to true.</source>
-        <target state="translated">NETSDK1067: Las aplicaciones independientes deben utilizar un host de aplicación. Establezca SelfContained en false o UseAppHost en true.</target>
-        <note>{StrBegin="NETSDK1067: "}</note>
-      </trans-unit>
-      <trans-unit id="FrameworkDependentAppHostRequiresVersion21">
-        <source>NETSDK1068: The framework-dependent application host requires a target framework of at least 'netcoreapp2.1'.</source>
-        <target state="translated">NETSDK1068: El host de la aplicación dependiente del marco requiere una plataforma de destino a partir de la versión “netcoreapp2.1”.</target>
-        <note>{StrBegin="NETSDK1068: "}</note>
-      </trans-unit>
-      <trans-unit id="NETFrameworkToNonBuiltInNETStandard">
-        <source>NETSDK1069: This project uses a library that targets .NET Standard 1.5 or higher, and the project targets a version of .NET Framework that doesn't have built-in support for that version of .NET Standard. Visit https://aka.ms/net-standard-known-issues for a set of known issues. Consider retargeting to .NET Framework 4.7.2.</source>
-        <target state="translated">NETSDK1069: Este proyecto utiliza una biblioteca para .NET Standard 1.5 o posterior, pero el proyecto es para una versión de .NET Framework que no incluye compatibilidad con esa versión de .NET Standard. Visite https://aka.ms/net-standard-known-issues para ver un conjunto de problemas conocidos. Considere la posibilidad de cambiar el destino a .NET Framework 4.7.2.</target>
-        <note>{StrBegin="NETSDK1069: "}</note>
-      </trans-unit>
-      <trans-unit id="NoAppHostAvailable">
-        <source>NETSDK1084: There is no application host available for the specified RuntimeIdentifier '{0}'.</source>
-        <target state="new">NETSDK1084: There is no application host available for the specified RuntimeIdentifier '{0}'.</target>
-        <note>{StrBegin="NETSDK1084: "}</note>
-      </trans-unit>
-      <trans-unit id="NoCompatibleTargetFramework">
-        <source>NETSDK1002: Project '{0}' targets '{2}'. It cannot be referenced by a project that targets '{1}'.</source>
-        <target state="translated">NETSDK1002: El proyecto "{0}" tiene como destino "{2}". No se puede hacer referencia a él mediante un proyecto que tenga como destino "{1}".</target>
-        <note>{StrBegin="NETSDK1002: "}</note>
-      </trans-unit>
-      <trans-unit id="InvalidFrameworkName">
-        <source>NETSDK1003: Invalid framework name: '{0}'.</source>
-        <target state="translated">NETSDK1003: Nombre de plataforma no válido: "{0}".</target>
-        <note>{StrBegin="NETSDK1003: "}</note>
-      </trans-unit>
-      <trans-unit id="AssetsFileNotFound">
-        <source>NETSDK1004: Assets file '{0}' not found. Run a NuGet package restore to generate this file.</source>
-        <target state="translated">NETSDK1004: No se encuentra el archivo de recursos '{0}'. Ejecute una restauración de paquetes de NuGet para generar el archivo.</target>
-        <note>{StrBegin="NETSDK1004: "}</note>
-      </trans-unit>
-      <trans-unit id="AssetsFileMissingTarget">
-        <source>NETSDK1005: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project.</source>
-        <target state="translated">NETSDK1005: El archivo de recursos "{0}" no tiene un destino para "{1}". Asegúrese de que la restauración se haya ejecutado y de que haya incluido "{2}" en TargetFrameworks para su proyecto.</target>
-        <note>{StrBegin="NETSDK1005: "}</note>
-      </trans-unit>
-      <trans-unit id="AssetsFilePathNotRooted">
-        <source>NETSDK1006: Assets file path '{0}' is not rooted. Only full paths are supported.</source>
-        <target state="translated">NETSDK1006: La ruta de acceso del archivo de recursos "{0}" no tiene raíz. Solo se admiten rutas de acceso completas.</target>
-        <note>{StrBegin="NETSDK1006: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotFindProjectInfo">
-        <source>NETSDK1007: Cannot find project info for '{0}'. This can indicate a missing project reference.</source>
-        <target state="translated">NETSDK1007: No se encuentra la información de proyecto de "{0}". Esto puede indicar que falta una referencia de proyecto.</target>
-        <note>{StrBegin="NETSDK1007: "}</note>
-      </trans-unit>
-      <trans-unit id="MissingItemMetadata">
-        <source>NETSDK1008: Missing '{0}' metadata on '{1}' item '{2}'.</source>
-        <target state="translated">NETSDK1008: Faltan los metadatos de "{0}" en el elemento de "{1}" "{2}".</target>
-        <note>{StrBegin="NETSDK1008: "}</note>
-      </trans-unit>
-      <trans-unit id="NoRuntimePackAvailable">
-        <source>NETSDK1082: There was no runtime pack for {0} available for the specified RuntimeIdentifier '{1}'.</source>
-        <target state="new">NETSDK1082: There was no runtime pack for {0} available for the specified RuntimeIdentifier '{1}'.</target>
-        <note>{StrBegin="NETSDK1082: "}</note>
-      </trans-unit>
-      <trans-unit id="PackageReferenceVersionNotRecommended">
-        <source>NETSDK1071: A PackageReference to '{0}' specified a Version of `{1}`. Specifying the version of this package is not recommended. For more information, see https://aka.ms/sdkimplicitrefs</source>
-        <target state="translated">NETSDK1071: Un PackageReference a "{0}" especificó una versión de "{1}". No se recomienda especificar la versión de este paquete. Para obtener más información, consulte https://aka.ms/sdkimplicitrefs</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="RuntimeIdentifierNotRecognized">
-        <source>NETSDK1083: The specified RuntimeIdentifier '{0}' is not recognized.</source>
-        <target state="new">NETSDK1083: The specified RuntimeIdentifier '{0}' is not recognized.</target>
-        <note>{StrBegin="NETSDK1083: "}</note>
-      </trans-unit>
-      <trans-unit id="UnknownFrameworkReference">
-        <source>NETSDK1073: The FrameworkReference '{0}' was not recognized</source>
-        <target state="translated">NETSDK1073: No se reconoció el FrameworkReference "{0}"</target>
-        <note>{StrBegin="NETSDK1073: "}</note>
-      </trans-unit>
-      <trans-unit id="UnrecognizedPreprocessorToken">
-        <source>NETSDK1009: Unrecognized preprocessor token '{0}' in '{1}'.</source>
-        <target state="translated">NETSDK1009: Token de preprocesador no reconocido "{0}" en "{1}".</target>
-        <note>{StrBegin="NETSDK1009: "}</note>
-      </trans-unit>
-      <trans-unit id="ContentPreproccessorParameterRequired">
-        <source>NETSDK1010: The '{0}' task must be given a value for parameter '{1}' in order to consume preprocessed content.</source>
-        <target state="translated">NETSDK1010: Debe darse un valor al parámetro "{1}" de la tarea "{0}" para poder consumir contenido preprocesado.</target>
-        <note>{StrBegin="NETSDK1010: "}</note>
-      </trans-unit>
-      <trans-unit id="ProjectAssetsConsumedWithoutMSBuildProjectPath">
-        <source>NETSDK1011: Assets are consumed from project '{0}', but no corresponding MSBuild project path was  found in '{1}'.</source>
-        <target state="translated">NETSDK1011: Los recursos se consumen desde el proyecto "{0}", pero no se ha encontrado la ruta de acceso de proyecto de MSBuild correspondiente en "{1}".</target>
-        <note>{StrBegin="NETSDK1011: "}</note>
-      </trans-unit>
-      <trans-unit id="UnexpectedFileType">
-        <source>NETSDK1012: Unexpected file type for '{0}'. Type is both '{1}' and '{2}'.</source>
-        <target state="translated">NETSDK1012: Tipo de archivo no esperado para "{0}". El tipo es tanto "{1}" como "{2}".</target>
-        <note>{StrBegin="NETSDK1012: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotInferTargetFrameworkIdentifierAndVersion">
-        <source>NETSDK1013: The TargetFramework value '{0}' was not recognized. It may be misspelled. If not, then the TargetFrameworkIdentifier and/or TargetFrameworkVersion properties must be specified explicitly.</source>
-        <target state="translated">NETSDK1013: El valor de TargetFramework "{0}" no se reconoció. Puede que esté mal escrito. Si este no es el caso, las propiedades TargetFrameworkIdentifier o TargetFrameworkVersion se deben especificar explícitamente.</target>
-        <note>{StrBegin="NETSDK1013: "}</note>
-      </trans-unit>
-      <trans-unit id="ContentItemDoesNotProvideOutputPath">
-        <source>NETSDK1014: Content item for '{0}' sets '{1}', but does not provide  '{2}' or '{3}'.</source>
-        <target state="translated">NETSDK1014: El elemento de contenido de "{0}" establece "{1}", pero no proporciona "{2}" ni "{3}".</target>
-        <note>{StrBegin="NETSDK1014: "}</note>
-      </trans-unit>
-      <trans-unit id="DuplicatePreprocessorToken">
-        <source>NETSDK1015: The preprocessor token '{0}' has been given more than one value. Choosing '{1}' as the value.</source>
-        <target state="translated">NETSDK1015: Se han dado varios valores para el token de preprocesador "{0}". Se va a elegir "{1}" como valor.</target>
-        <note>{StrBegin="NETSDK1015: "}</note>
-      </trans-unit>
-      <trans-unit id="UnableToFindResolvedPath">
-        <source>NETSDK1016: Unable to find resolved path for '{0}'.</source>
-        <target state="translated">NETSDK1016: No se encuentra la ruta de acceso resuelta para "{0}".</target>
-        <note>{StrBegin="NETSDK1016: "}</note>
+      <trans-unit id="AspNetCoreUsesFrameworkReference">
+        <source>NETSDK1080: A PackageReference to Microsoft.AspNetCore.App is not necessary when targeting .NET Core 3.0 or higher. If Microsoft.NET.Sdk.Web is used, the shared framework will be referenced automatically. Otherwise, the PackageReference should be replaced with a FrameworkReference.</source>
+        <target state="translated">NETSDK1080: Un PackageReference a Microsoft.AspNetCore.App no es necesario cuando el destino es .NET Core 3.0 o superior. Si se utiliza Microsoft.NET.Sdk.Web, se hará referencia al marco común automáticamente. De no ser así, el PackageReference debe reemplazarse por un FrameworkReference.</target>
+        <note>{StrBegin="NETSDK1080: "}</note>
       </trans-unit>
       <trans-unit id="AssetPreprocessorMustBeConfigured">
         <source>NETSDK1017: Asset preprocessor must be configured before assets are processed.</source>
         <target state="translated">NETSDK1017: Debe configurarse el preprocesador de recursos antes de que se procesen los recursos.</target>
         <note>{StrBegin="NETSDK1017: "}</note>
       </trans-unit>
-      <trans-unit id="InvalidNuGetVersionString">
-        <source>NETSDK1018: Invalid NuGet version string: '{0}'.</source>
-        <target state="translated">NETSDK1018: Cadena de versión de NuGet no válida: "{0}".</target>
-        <note>{StrBegin="NETSDK1018: "}</note>
+      <trans-unit id="AssetsFileMissingRuntimeIdentifier">
+        <source>NETSDK1047: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project. You may also need to include '{3}' in your project's RuntimeIdentifiers.</source>
+        <target state="translated">NETSDK1047: El archivo de recursos "{0}" no tiene un destino para "{1}". Asegúrese de que la restauración se haya ejecutado y de que haya incluido "{2}" en TargetFrameworks para su proyecto. Puede que deba incluir también "{3}" en el valor RuntimeIdentifiers de su proyecto.</target>
+        <note>{StrBegin="NETSDK1047: "}</note>
       </trans-unit>
-      <trans-unit id="UnresolvedTargetingPack">
-        <source>NETSDK1081: The targeting pack for {0} was not found. You may be able to resolve this by running a NuGet restore on the project.</source>
-        <target state="new">NETSDK1081: The targeting pack for {0} was not found. You may be able to resolve this by running a NuGet restore on the project.</target>
-        <note>{StrBegin="NETSDK1081: "}</note>
+      <trans-unit id="AssetsFileMissingTarget">
+        <source>NETSDK1005: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project.</source>
+        <target state="translated">NETSDK1005: El archivo de recursos "{0}" no tiene un destino para "{1}". Asegúrese de que la restauración se haya ejecutado y de que haya incluido "{2}" en TargetFrameworks para su proyecto.</target>
+        <note>{StrBegin="NETSDK1005: "}</note>
       </trans-unit>
-      <trans-unit id="UnsupportedFramework">
-        <source>NETSDK1019: {0} is an unsupported framework.</source>
-        <target state="translated">NETSDK1019: {0} es una plataforma no compatible.</target>
-        <note>{StrBegin="NETSDK1019: "}</note>
+      <trans-unit id="AssetsFileNotFound">
+        <source>NETSDK1004: Assets file '{0}' not found. Run a NuGet package restore to generate this file.</source>
+        <target state="translated">NETSDK1004: No se encuentra el archivo de recursos '{0}'. Ejecute una restauración de paquetes de NuGet para generar el archivo.</target>
+        <note>{StrBegin="NETSDK1004: "}</note>
       </trans-unit>
-      <trans-unit id="DuplicateItemsError">
-        <source>NETSDK1022: Duplicate '{0}' items were included. The .NET SDK includes '{0}' items from your project directory by default. You can either remove these items from your project file, or set the '{1}' property to '{2}' if you want to explicitly include them in your project file. For more information, see {4}. The duplicate items were: {3}</source>
-        <target state="translated">NETSDK1022: Se incluyeron "{0}" elementos duplicados. El SDK de .NET incluye "{0}" elementos de su directorio de proyecto de manera predeterminada. Puede quitar esos elementos del archivo de proyecto o establecer la propiedad "{1}" en "{2}" si desea incluirlos explícitamente en el archivo de proyecto. Para más información, consulte {4}. Los elementos duplicados eran: {3}</target>
-        <note>{StrBegin="NETSDK1022: "}</note>
+      <trans-unit id="AssetsFileNotSet">
+        <source>NETSDK1063: The path to the project assets file was not set. Run a NuGet package restore to generate this file.</source>
+        <target state="translated">NETSDK1063: No se estableció la ruta de acceso al archivo de recursos del proyecto. Ejecute una restauración del paquete NuGet para generar este archivo.</target>
+        <note>{StrBegin="NETSDK1063: "}</note>
       </trans-unit>
-      <trans-unit id="PackageReferenceOverrideWarning">
-        <source>NETSDK1023: A PackageReference for '{0}' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see {1}</source>
-        <target state="translated">NETSDK1023: Se incluyó un elemento PackageReference para "{0}" en su proyecto. El SDK de .NET hace referencia implícita a este paquete y normalmente no tiene que hacer referencia a él desde su proyecto. Para obtener más información, consulte {1}</target>
-        <note>{StrBegin="NETSDK1023: "}</note>
+      <trans-unit id="AssetsFilePathNotRooted">
+        <source>NETSDK1006: Assets file path '{0}' is not rooted. Only full paths are supported.</source>
+        <target state="translated">NETSDK1006: La ruta de acceso del archivo de recursos "{0}" no tiene raíz. Solo se admiten rutas de acceso completas.</target>
+        <note>{StrBegin="NETSDK1006: "}</note>
       </trans-unit>
-      <trans-unit id="IncorrectPackageRoot">
-        <source>NETSDK1020: Package Root {0} was incorrectly given for Resolved library {1}</source>
-        <target state="translated">NETSDK1020: Se proporcionó incorrectamente la raíz del paquete {0} para la biblioteca resuelta {1}</target>
-        <note>{StrBegin="NETSDK1020: "}</note>
+      <trans-unit id="AtLeastOneTargetFrameworkMustBeSpecified">
+        <source>NETSDK1001: At least one possible target framework must be specified.</source>
+        <target state="translated">NETSDK1001: Debe especificarse al menos una plataforma de destino posible.</target>
+        <note>{StrBegin="NETSDK1001: "}</note>
       </trans-unit>
-      <trans-unit id="MultipleFilesResolved">
-        <source>NETSDK1021: More than one file found for {0}</source>
-        <target state="translated">NETSDK1021: Se encontró más de un archivo para {0}</target>
-        <note>{StrBegin="NETSDK1021: "}</note>
+      <trans-unit id="CannotFindApphostForRid">
+        <source>NETSDK1065: Cannot find app host for {0}. {0} could be an invalid runtime identifier (RID). For more information about RID, see https://aka.ms/rid-catalog.</source>
+        <target state="translated">NETSDK1065: No se encuentra el host de la aplicación {0}. {0} puede ser un identificador de tiempo de ejecución no válido. Para obtener más información al respecto, consulte https://aka.ms/rid-catalog.</target>
+        <note>{StrBegin="NETSDK1065: "}</note>
       </trans-unit>
-      <trans-unit id="FolderAlreadyExists">
-        <source>NETSDK1024: Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</source>
-        <target state="translated">NETSDK1024: La carpeta "{0}" ya existe; elimínela o proporcione otro valor para ComposeWorkingDir</target>
-        <note>{StrBegin="NETSDK1024: "}</note>
+      <trans-unit id="CannotFindProjectInfo">
+        <source>NETSDK1007: Cannot find project info for '{0}'. This can indicate a missing project reference.</source>
+        <target state="translated">NETSDK1007: No se encuentra la información de proyecto de "{0}". Esto puede indicar que falta una referencia de proyecto.</target>
+        <note>{StrBegin="NETSDK1007: "}</note>
       </trans-unit>
-      <trans-unit id="ParsingFiles">
-        <source>NETSDK1026: Parsing the Files : '{0}'</source>
-        <target state="translated">NETSDK1026: Analizando los archivos: "{0}"</target>
-        <note>{StrBegin="NETSDK1026: "}</note>
-      </trans-unit>
-      <trans-unit id="PackageInfoLog">
-        <source>NETSDK1027: Package Name='{0}', Version='{1}' was parsed</source>
-        <target state="translated">NETSDK1027: Nombre del paquete="{0}", versión analizada="{1}"</target>
-        <note>{StrBegin="NETSDK1027: "}</note>
-      </trans-unit>
-      <trans-unit id="RuntimeIdentifierWasNotSpecified">
-        <source>NETSDK1028: Specify a RuntimeIdentifier</source>
-        <target state="translated">NETSDK1028: Especificar un valor para RuntimeIdentifier</target>
-        <note>{StrBegin="NETSDK1028: "}</note>
-      </trans-unit>
-      <trans-unit id="IncorrectTargetFormat">
-        <source>NETSDK1025: WRThe target manifest {0} provided is of not the correct format</source>
-        <target state="translated">NETSDK1025: El manifiesto de destino {0} proporcionado no tiene el formato correcto</target>
-        <note>{StrBegin="NETSDK1025: "}</note>
-      </trans-unit>
-      <trans-unit id="AppHostHasBeenModified">
-        <source>NETSDK1029: Unable to use '{0}' as application host executable as it does not contain the expected placeholder byte sequence '{1}' that would mark where the application name would be written.</source>
-        <target state="translated">NETSDK1029: No se puede usar "{0}" como ejecutable del host de aplicación ya que no contiene la secuencia de bytes esperada del marcador de posición "{1}" que marcaría dónde escribir el nombre de la aplicación.</target>
-        <note>{StrBegin="NETSDK1029: "}</note>
-      </trans-unit>
-      <trans-unit id="FileNameIsTooLong">
-        <source>NETSDK1030: Given file name '{0}' is longer than 1024 bytes</source>
-        <target state="translated">NETSDK1030: El nombre de archivo especificado "{0}" tiene más de 1024 bytes</target>
-        <note>{StrBegin="NETSDK1030: "}</note>
+      <trans-unit id="CannotHaveRuntimeIdentifierPlatformMismatchPlatformTarget">
+        <source>NETSDK1032: The RuntimeIdentifier platform '{0}' and the PlatformTarget '{1}' must be compatible.</source>
+        <target state="translated">NETSDK1032: Las plataformas RuntimeIdentifier "{0}" y PlatformTarget "{1}" deben ser compatibles.</target>
+        <note>{StrBegin="NETSDK1032: "}</note>
       </trans-unit>
       <trans-unit id="CannotHaveSelfContainedWithoutRuntimeIdentifier">
         <source>NETSDK1031: It is not supported to build or publish a self-contained application without specifying a RuntimeIdentifier.  Please either specify a RuntimeIdentifier or set SelfContained to false.</source>
         <target state="translated">NETSDK1031: No se admite compilar o publicar una aplicación autocontenida sin especificar un valor para RuntimeIdentifier. Especifique un valor para RuntimeIdentifier o establezca SelfContained en false.</target>
         <note>{StrBegin="NETSDK1031: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotInferTargetFrameworkIdentifierAndVersion">
+        <source>NETSDK1013: The TargetFramework value '{0}' was not recognized. It may be misspelled. If not, then the TargetFrameworkIdentifier and/or TargetFrameworkVersion properties must be specified explicitly.</source>
+        <target state="translated">NETSDK1013: El valor de TargetFramework "{0}" no se reconoció. Puede que esté mal escrito. Si este no es el caso, las propiedades TargetFrameworkIdentifier o TargetFrameworkVersion se deben especificar explícitamente.</target>
+        <note>{StrBegin="NETSDK1013: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotUseSelfContainedWithoutAppHost">
+        <source>NETSDK1067: Self-contained applications are required to use the application host. Either set SelfContained to false or set UseAppHost to true.</source>
+        <target state="translated">NETSDK1067: Las aplicaciones independientes deben utilizar un host de aplicación. Establezca SelfContained en false o UseAppHost en true.</target>
+        <note>{StrBegin="NETSDK1067: "}</note>
       </trans-unit>
       <trans-unit id="ChoosingAssemblyVersion">
         <source>NETSDK1033: Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</source>
@@ -272,6 +132,16 @@
         <target state="translated">NETSDK1037: No se pudo determinar el ganador porque las versiones de archivo y ensamblado son iguales.</target>
         <note>{StrBegin="NETSDK1037: "}</note>
       </trans-unit>
+      <trans-unit id="ContentItemDoesNotProvideOutputPath">
+        <source>NETSDK1014: Content item for '{0}' sets '{1}', but does not provide  '{2}' or '{3}'.</source>
+        <target state="translated">NETSDK1014: El elemento de contenido de "{0}" establece "{1}", pero no proporciona "{2}" ni "{3}".</target>
+        <note>{StrBegin="NETSDK1014: "}</note>
+      </trans-unit>
+      <trans-unit id="ContentPreproccessorParameterRequired">
+        <source>NETSDK1010: The '{0}' task must be given a value for parameter '{1}' in order to consume preprocessed content.</source>
+        <target state="translated">NETSDK1010: Debe darse un valor al parámetro "{1}" de la tarea "{0}" para poder consumir contenido preprocesado.</target>
+        <note>{StrBegin="NETSDK1010: "}</note>
+      </trans-unit>
       <trans-unit id="CouldNotDetermineWinner_DoesntExist">
         <source>NETSDK1038: Could not determine winner because '{0}' does not exist.</source>
         <target state="translated">NETSDK1038: No se pudo determinar el ganador porque "{0}" no existe.</target>
@@ -287,15 +157,40 @@
         <target state="translated">NETSDK1040: No se pudo determinar un ganador porque "{0}" no es un ensamblado.</target>
         <note>{StrBegin="NETSDK1040: "}</note>
       </trans-unit>
+      <trans-unit id="CouldNotLoadPlatformManifest">
+        <source>NETSDK1042: Could not load PlatformManifest from '{0}' because it did not exist.</source>
+        <target state="translated">NETSDK1042: No se pudo cargar PlatformManifest desde "{0}" porque no existe.</target>
+        <note>{StrBegin="NETSDK1042: "}</note>
+      </trans-unit>
+      <trans-unit id="DotnetToolDoesNotSupportTFMLowerThanNetcoreapp21">
+        <source>NETSDK1055: DotnetTool does not support target framework lower than netcoreapp2.1.</source>
+        <target state="translated">NETSDK1055: DotnetTool no admite una plataforma de destino anterior a netcoreapp2.1.</target>
+        <note>{StrBegin="NETSDK1055: "}</note>
+      </trans-unit>
+      <trans-unit id="DotnetToolOnlySupportNetcoreapp">
+        <source>NETSDK1054: only supports .NET Core.</source>
+        <target state="translated">NETSDK1054: Solo admite .NET Core.</target>
+        <note>{StrBegin="NETSDK1054: "}</note>
+      </trans-unit>
+      <trans-unit id="DuplicateItemsError">
+        <source>NETSDK1022: Duplicate '{0}' items were included. The .NET SDK includes '{0}' items from your project directory by default. You can either remove these items from your project file, or set the '{1}' property to '{2}' if you want to explicitly include them in your project file. For more information, see {4}. The duplicate items were: {3}</source>
+        <target state="translated">NETSDK1022: Se incluyeron "{0}" elementos duplicados. El SDK de .NET incluye "{0}" elementos de su directorio de proyecto de manera predeterminada. Puede quitar esos elementos del archivo de proyecto o establecer la propiedad "{1}" en "{2}" si desea incluirlos explícitamente en el archivo de proyecto. Para más información, consulte {4}. Los elementos duplicados eran: {3}</target>
+        <note>{StrBegin="NETSDK1022: "}</note>
+      </trans-unit>
+      <trans-unit id="DuplicatePreprocessorToken">
+        <source>NETSDK1015: The preprocessor token '{0}' has been given more than one value. Choosing '{1}' as the value.</source>
+        <target state="translated">NETSDK1015: Se han dado varios valores para el token de preprocesador "{0}". Se va a elegir "{1}" como valor.</target>
+        <note>{StrBegin="NETSDK1015: "}</note>
+      </trans-unit>
       <trans-unit id="EncounteredConflict">
         <source>NETSDK1041: Encountered conflict between '{0}' and '{1}'.</source>
         <target state="translated">NETSDK1041: Se encontró un conflicto entre "{0}" y "{1}".</target>
         <note>{StrBegin="NETSDK1041: "}</note>
       </trans-unit>
-      <trans-unit id="CouldNotLoadPlatformManifest">
-        <source>NETSDK1042: Could not load PlatformManifest from '{0}' because it did not exist.</source>
-        <target state="translated">NETSDK1042: No se pudo cargar PlatformManifest desde "{0}" porque no existe.</target>
-        <note>{StrBegin="NETSDK1042: "}</note>
+      <trans-unit id="ErrorParsingFrameworkListInvalidValue">
+        <source>NETSDK1051: Error parsing FrameworkList from '{0}'.  {1} '{2}' was invalid.</source>
+        <target state="translated">NETSDK1051: Error al analizar la lista de plataformas de “{0}”. El atributo {1} “{2}” no era válido.</target>
+        <note>{StrBegin="NETSDK1051: "}</note>
       </trans-unit>
       <trans-unit id="ErrorParsingPlatformManifest">
         <source>NETSDK1043: Error parsing PlatformManifest from '{0}' line {1}.  Lines must have the format {2}.</source>
@@ -307,65 +202,55 @@
         <target state="translated">NETSDK1044: Error al analizar PlatformManifest desde la línea "{0}" {1}. {2} "{3}" no era válido.</target>
         <note>{StrBegin="NETSDK1044: "}</note>
       </trans-unit>
-      <trans-unit id="UnsupportedTargetFrameworkVersion">
-        <source>NETSDK1045: The current .NET SDK does not support targeting {0} {1}.  Either target {0} {2} or lower, or use a version of the .NET SDK that supports {0} {1}.</source>
-        <target state="translated">NETSDK1045: El SDK de .NET actual no admite el destino {0} {1}. Use el destino {0} {2} u otro inferior, o bien una versión del SDK de .NET que admita {0} {1}.</target>
-        <note>{StrBegin="NETSDK1045: "}</note>
+      <trans-unit id="ErrorReadingAssetsFile">
+        <source>NETSDK1060: Error reading assets file: {0}</source>
+        <target state="translated">NETSDK1060: Error al leer el archivo de activos: {0}</target>
+        <note>{StrBegin="NETSDK1060: "}</note>
       </trans-unit>
-      <trans-unit id="AssetsFileMissingRuntimeIdentifier">
-        <source>NETSDK1047: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project. You may also need to include '{3}' in your project's RuntimeIdentifiers.</source>
-        <target state="translated">NETSDK1047: El archivo de recursos "{0}" no tiene un destino para "{1}". Asegúrese de que la restauración se haya ejecutado y de que haya incluido "{2}" en TargetFrameworks para su proyecto. Puede que deba incluir también "{3}" en el valor RuntimeIdentifiers de su proyecto.</target>
-        <note>{StrBegin="NETSDK1047: "}</note>
+      <trans-unit id="FailedToLockResource">
+        <source>NETSDK1077: Failed to lock resource.</source>
+        <target state="translated">NETSDK1077: Error al bloquear recursos.</target>
+        <note>{StrBegin="NETSDK1077: "}</note>
       </trans-unit>
-      <trans-unit id="TargetFrameworkWithSemicolon">
-        <source>NETSDK1046: The TargetFramework value '{0}' is not valid. To multi-target, use the 'TargetFrameworks' property instead.</source>
-        <target state="translated">NETSDK1046: El valor de TargetFramework "{0}" no es válido. Para varios destinos, use en su lugar la propiedad "TargetFrameworks".</target>
-        <note>{StrBegin="NETSDK1046: "}</note>
+      <trans-unit id="FileNameIsTooLong">
+        <source>NETSDK1030: Given file name '{0}' is longer than 1024 bytes</source>
+        <target state="translated">NETSDK1030: El nombre de archivo especificado "{0}" tiene más de 1024 bytes</target>
+        <note>{StrBegin="NETSDK1030: "}</note>
       </trans-unit>
-      <trans-unit id="GetDependsOnNETStandardFailedWithException">
-        <source>NETSDK1049: Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0} {1}</source>
-        <target state="translated">NETSDK1049: El archivo resuelto tiene una imagen incorrecta, no tiene metadatos o no es posible su acceso. {0} {1}</target>
-        <note>{StrBegin="NETSDK1049: "}</note>
+      <trans-unit id="FolderAlreadyExists">
+        <source>NETSDK1024: Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</source>
+        <target state="translated">NETSDK1024: La carpeta "{0}" ya existe; elimínela o proporcione otro valor para ComposeWorkingDir</target>
+        <note>{StrBegin="NETSDK1024: "}</note>
       </trans-unit>
-      <trans-unit id="UnsupportedSDKVersionForNetStandard20">
-        <source>NETSDK1050: The version of Microsoft.NET.Sdk used by this project is insufficient to support references to libraries targeting .NET Standard 1.5 or higher.  Please install version 2.0 or higher of the .NET Core SDK.</source>
-        <target state="translated">NETSDK1050: En la versión de Microsoft.NET.Sdk que utiliza este proyecto no se admiten referencias a bibliotecas cuyo destino sea .NET Standard 1.5 o posterior. Instale la versión 2.0 o posterior del SDK de .NET Core.</target>
-        <note>{StrBegin="NETSDK1050: "}</note>
-      </trans-unit>
-      <trans-unit id="SkippingAdditionalProbingPaths">
-        <source>NETSDK1048: 'AdditionalProbingPaths' were specified for GenerateRuntimeConfigurationFiles, but are being skipped because 'RuntimeConfigDevPath' is empty.</source>
-        <target state="translated">NETSDK1048: Se especificaron valores adicionales de "AdditionalProbingPaths" para GenerateRuntimeConfigurationFiles, pero se van a omitir porque el valor de "RuntimeConfigDevPath" está vacío.</target>
-        <note>{StrBegin="NETSDK1048: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotHaveRuntimeIdentifierPlatformMismatchPlatformTarget">
-        <source>NETSDK1032: The RuntimeIdentifier platform '{0}' and the PlatformTarget '{1}' must be compatible.</source>
-        <target state="translated">NETSDK1032: Las plataformas RuntimeIdentifier "{0}" y PlatformTarget "{1}" deben ser compatibles.</target>
-        <note>{StrBegin="NETSDK1032: "}</note>
-      </trans-unit>
-      <trans-unit id="ErrorParsingFrameworkListInvalidValue">
-        <source>NETSDK1051: Error parsing FrameworkList from '{0}'.  {1} '{2}' was invalid.</source>
-        <target state="translated">NETSDK1051: Error al analizar la lista de plataformas de “{0}”. El atributo {1} “{2}” no era válido.</target>
-        <note>{StrBegin="NETSDK1051: "}</note>
+      <trans-unit id="FrameworkDependentAppHostRequiresVersion21">
+        <source>NETSDK1068: The framework-dependent application host requires a target framework of at least 'netcoreapp2.1'.</source>
+        <target state="translated">NETSDK1068: El host de la aplicación dependiente del marco requiere una plataforma de destino a partir de la versión “netcoreapp2.1”.</target>
+        <note>{StrBegin="NETSDK1068: "}</note>
       </trans-unit>
       <trans-unit id="FrameworkListPathNotRooted">
         <source>NETSDK1052: Framework list file path '{0}' is not rooted. Only full paths are supported.</source>
         <target state="translated">NETSDK1052: Falta la raíz en la ruta de acceso del archivo de lista de plataformas “{0}”. Solo se admiten rutas de acceso completas.</target>
         <note>{StrBegin="NETSDK1052: "}</note>
       </trans-unit>
-      <trans-unit id="PackAsToolCannotSupportSelfContained">
-        <source>NETSDK1053: Pack as tool does not support self contained.</source>
-        <target state="translated">NETSDK1053: El paquete como herramienta no admite la autocontención.</target>
-        <note>{StrBegin="NETSDK1001: "}</note>
+      <trans-unit id="GetDependsOnNETStandardFailedWithException">
+        <source>NETSDK1049: Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0} {1}</source>
+        <target state="translated">NETSDK1049: El archivo resuelto tiene una imagen incorrecta, no tiene metadatos o no es posible su acceso. {0} {1}</target>
+        <note>{StrBegin="NETSDK1049: "}</note>
       </trans-unit>
-      <trans-unit id="UnsupportedRuntimeIdentifier">
-        <source>NETSDK1056: Project is targeting runtime '{0}' but did not resolve any runtime-specific packages. This runtime may not be supported by the target framework.</source>
-        <target state="translated">NETSDK1056: El proyecto se dirige al tiempo de ejecución "{0}" pero no resolvió ningún paquete específico del tiempo de ejecución. Es posible que este tiempo de ejecución no sea compatible con la plataforma de destino.</target>
-        <note>{StrBegin="NETSDK1056: "}</note>
+      <trans-unit id="IncorrectPackageRoot">
+        <source>NETSDK1020: Package Root {0} was incorrectly given for Resolved library {1}</source>
+        <target state="translated">NETSDK1020: Se proporcionó incorrectamente la raíz del paquete {0} para la biblioteca resuelta {1}</target>
+        <note>{StrBegin="NETSDK1020: "}</note>
       </trans-unit>
-      <trans-unit id="UsingPreviewSdkWarning">
-        <source>NETSDK1057: You are using a preview version of .NET Core. See: https://aka.ms/dotnet-core-preview</source>
-        <target state="translated">NETSDK1057: Está utilizando una versión preliminar de .NET Core. Vea: https://aka.ms/dotnet-core-preview</target>
-        <note>{StrBegin="NETSDK1057: "}</note>
+      <trans-unit id="IncorrectTargetFormat">
+        <source>NETSDK1025: WRThe target manifest {0} provided is of not the correct format</source>
+        <target state="translated">NETSDK1025: El manifiesto de destino {0} proporcionado no tiene el formato correcto</target>
+        <note>{StrBegin="NETSDK1025: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidFrameworkName">
+        <source>NETSDK1003: Invalid framework name: '{0}'.</source>
+        <target state="translated">NETSDK1003: Nombre de plataforma no válido: "{0}".</target>
+        <note>{StrBegin="NETSDK1003: "}</note>
       </trans-unit>
       <trans-unit id="InvalidItemSpecToUse">
         <source>NETSDK1058: Invalid value for ItemSpecToUse parameter: '{0}'.  This property must be blank or set to 'Left' or 'Right'</source>
@@ -373,15 +258,15 @@
         <note>{StrBegin="NETSDK1058: "}
 The following are names of parameters or literal values and should not be translated: ItemSpecToUse, Left, Right</note>
       </trans-unit>
-      <trans-unit id="ProjectContainsObsoleteDotNetCliTool">
-        <source>NETSDK1059: The tool '{0}' is now included in the .NET Core SDK. Information on resolving this warning is available at (https://aka.ms/dotnetclitools-in-box).</source>
-        <target state="translated">NETSDK1059: La herramienta "{0}" se incluye ahora en el SDK de .NET Core. Hay información disponible sobre cómo resolver esta advertencia en (https://aka.ms/dotnetclitools-in-box).</target>
-        <note>{StrBegin="NETSDK1059: "}</note>
+      <trans-unit id="InvalidNuGetVersionString">
+        <source>NETSDK1018: Invalid NuGet version string: '{0}'.</source>
+        <target state="translated">NETSDK1018: Cadena de versión de NuGet no válida: "{0}".</target>
+        <note>{StrBegin="NETSDK1018: "}</note>
       </trans-unit>
-      <trans-unit id="ErrorReadingAssetsFile">
-        <source>NETSDK1060: Error reading assets file: {0}</source>
-        <target state="translated">NETSDK1060: Error al leer el archivo de activos: {0}</target>
-        <note>{StrBegin="NETSDK1060: "}</note>
+      <trans-unit id="InvalidResourceUpdate">
+        <source>NETSDK1075: Update handle is invalid. This instance may not be used for further updates.</source>
+        <target state="translated">NETSDK1075: El identificador de actualización no es válido. Esta instancia no se puede utilizar para otras actualizaciones.</target>
+        <note>{StrBegin="NETSDK1075: "}</note>
       </trans-unit>
       <trans-unit id="MismatchedPlatformPackageVersion">
         <source>NETSDK1061: The project was restored using {0} version {1}, but with current settings, version {2} would be used instead. To resolve this issue, make sure the same settings are used for restore and for subsequent operations such as build or publish. Typically this issue can occur if the RuntimeIdentifier property is set during build or publish but not during restore. For more information, see https://aka.ms/dotnet-runtime-patch-selection.</source>
@@ -391,35 +276,150 @@ The following are names of parameters or literal values and should not be transl
 {1} - Restored version of platform package
 {2} - Current version of platform package</note>
       </trans-unit>
-      <trans-unit id="AssetsFileNotSet">
-        <source>NETSDK1063: The path to the project assets file was not set. Run a NuGet package restore to generate this file.</source>
-        <target state="translated">NETSDK1063: No se estableció la ruta de acceso al archivo de recursos del proyecto. Ejecute una restauración del paquete NuGet para generar este archivo.</target>
-        <note>{StrBegin="NETSDK1063: "}</note>
+      <trans-unit id="MissingItemMetadata">
+        <source>NETSDK1008: Missing '{0}' metadata on '{1}' item '{2}'.</source>
+        <target state="translated">NETSDK1008: Faltan los metadatos de "{0}" en el elemento de "{1}" "{2}".</target>
+        <note>{StrBegin="NETSDK1008: "}</note>
       </trans-unit>
-      <trans-unit id="DotnetToolOnlySupportNetcoreapp">
-        <source>NETSDK1054: only supports .NET Core.</source>
-        <target state="translated">NETSDK1054: Solo admite .NET Core.</target>
-        <note>{StrBegin="NETSDK1054: "}</note>
+      <trans-unit id="MultipleFilesResolved">
+        <source>NETSDK1021: More than one file found for {0}</source>
+        <target state="translated">NETSDK1021: Se encontró más de un archivo para {0}</target>
+        <note>{StrBegin="NETSDK1021: "}</note>
       </trans-unit>
-      <trans-unit id="DotnetToolDoesNotSupportTFMLowerThanNetcoreapp21">
-        <source>NETSDK1055: DotnetTool does not support target framework lower than netcoreapp2.1.</source>
-        <target state="translated">NETSDK1055: DotnetTool no admite una plataforma de destino anterior a netcoreapp2.1.</target>
-        <note>{StrBegin="NETSDK1055: "}</note>
+      <trans-unit id="NETFrameworkToNonBuiltInNETStandard">
+        <source>NETSDK1069: This project uses a library that targets .NET Standard 1.5 or higher, and the project targets a version of .NET Framework that doesn't have built-in support for that version of .NET Standard. Visit https://aka.ms/net-standard-known-issues for a set of known issues. Consider retargeting to .NET Framework 4.7.2.</source>
+        <target state="translated">NETSDK1069: Este proyecto utiliza una biblioteca para .NET Standard 1.5 o posterior, pero el proyecto es para una versión de .NET Framework que no incluye compatibilidad con esa versión de .NET Standard. Visite https://aka.ms/net-standard-known-issues para ver un conjunto de problemas conocidos. Considere la posibilidad de cambiar el destino a .NET Framework 4.7.2.</target>
+        <note>{StrBegin="NETSDK1069: "}</note>
       </trans-unit>
-      <trans-unit id="UnableToUsePackageAssetsCache">
-        <source>NETSDK1062: Unable to use package assets cache due to I/O error. This can occur when the same project is built more than once in parallel. Performance may be degraded, but the build result will not be impacted.</source>
-        <target state="translated">NETSDK1062: No se puede usar la memoria caché de recursos del paquete debido a un error de E/S. Esto puede ocurrir cuando un mismo proyecto se compila más de una vez en paralelo. Puede que se reduzca el rendimiento, pero no afectará al resultado de la compilación.</target>
-        <note>{StrBegin="NETSDK1062: "}</note>
+      <trans-unit id="NoAppHostAvailable">
+        <source>NETSDK1084: There is no application host available for the specified RuntimeIdentifier '{0}'.</source>
+        <target state="new">NETSDK1084: There is no application host available for the specified RuntimeIdentifier '{0}'.</target>
+        <note>{StrBegin="NETSDK1084: "}</note>
+      </trans-unit>
+      <trans-unit id="NoCompatibleTargetFramework">
+        <source>NETSDK1002: Project '{0}' targets '{2}'. It cannot be referenced by a project that targets '{1}'.</source>
+        <target state="translated">NETSDK1002: El proyecto "{0}" tiene como destino "{2}". No se puede hacer referencia a él mediante un proyecto que tenga como destino "{1}".</target>
+        <note>{StrBegin="NETSDK1002: "}</note>
+      </trans-unit>
+      <trans-unit id="NoRuntimePackAvailable">
+        <source>NETSDK1082: There was no runtime pack for {0} available for the specified RuntimeIdentifier '{1}'.</source>
+        <target state="new">NETSDK1082: There was no runtime pack for {0} available for the specified RuntimeIdentifier '{1}'.</target>
+        <note>{StrBegin="NETSDK1082: "}</note>
+      </trans-unit>
+      <trans-unit id="PackAsToolCannotSupportSelfContained">
+        <source>NETSDK1053: Pack as tool does not support self contained.</source>
+        <target state="translated">NETSDK1053: El paquete como herramienta no admite la autocontención.</target>
+        <note>{StrBegin="NETSDK1001: "}</note>
+      </trans-unit>
+      <trans-unit id="PackageInfoLog">
+        <source>NETSDK1027: Package Name='{0}', Version='{1}' was parsed</source>
+        <target state="translated">NETSDK1027: Nombre del paquete="{0}", versión analizada="{1}"</target>
+        <note>{StrBegin="NETSDK1027: "}</note>
       </trans-unit>
       <trans-unit id="PackageNotFound">
         <source>NETSDK1064: Package {0}, version {1} was not found. It might have been deleted since NuGet restore. Otherwise, NuGet restore might have only partially completed, which might have been due to maximum path length restrictions.</source>
         <target state="translated">NETSDK1064: No se encontró el paquete {0}, versión {1}. Es posible que se haya eliminado desde la restauración de NuGet. De lo contrario, la restauración de NuGet podría haberse completado solo parcialmente, lo que puede deberse a las restricciones de longitud de ruta máxima.</target>
         <note>{StrBegin="NETSDK1064: "}</note>
       </trans-unit>
-      <trans-unit id="CannotFindApphostForRid">
-        <source>NETSDK1065: Cannot find app host for {0}. {0} could be an invalid runtime identifier (RID). For more information about RID, see https://aka.ms/rid-catalog.</source>
-        <target state="translated">NETSDK1065: No se encuentra el host de la aplicación {0}. {0} puede ser un identificador de tiempo de ejecución no válido. Para obtener más información al respecto, consulte https://aka.ms/rid-catalog.</target>
-        <note>{StrBegin="NETSDK1065: "}</note>
+      <trans-unit id="PackageReferenceOverrideWarning">
+        <source>NETSDK1023: A PackageReference for '{0}' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see {1}</source>
+        <target state="translated">NETSDK1023: Se incluyó un elemento PackageReference para "{0}" en su proyecto. El SDK de .NET hace referencia implícita a este paquete y normalmente no tiene que hacer referencia a él desde su proyecto. Para obtener más información, consulte {1}</target>
+        <note>{StrBegin="NETSDK1023: "}</note>
+      </trans-unit>
+      <trans-unit id="PackageReferenceVersionNotRecommended">
+        <source>NETSDK1071: A PackageReference to '{0}' specified a Version of `{1}`. Specifying the version of this package is not recommended. For more information, see https://aka.ms/sdkimplicitrefs</source>
+        <target state="translated">NETSDK1071: Un PackageReference a "{0}" especificó una versión de "{1}". No se recomienda especificar la versión de este paquete. Para obtener más información, consulte https://aka.ms/sdkimplicitrefs</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParsingFiles">
+        <source>NETSDK1026: Parsing the Files : '{0}'</source>
+        <target state="translated">NETSDK1026: Analizando los archivos: "{0}"</target>
+        <note>{StrBegin="NETSDK1026: "}</note>
+      </trans-unit>
+      <trans-unit id="ProjectAssetsConsumedWithoutMSBuildProjectPath">
+        <source>NETSDK1011: Assets are consumed from project '{0}', but no corresponding MSBuild project path was  found in '{1}'.</source>
+        <target state="translated">NETSDK1011: Los recursos se consumen desde el proyecto "{0}", pero no se ha encontrado la ruta de acceso de proyecto de MSBuild correspondiente en "{1}".</target>
+        <note>{StrBegin="NETSDK1011: "}</note>
+      </trans-unit>
+      <trans-unit id="ProjectContainsObsoleteDotNetCliTool">
+        <source>NETSDK1059: The tool '{0}' is now included in the .NET Core SDK. Information on resolving this warning is available at (https://aka.ms/dotnetclitools-in-box).</source>
+        <target state="translated">NETSDK1059: La herramienta "{0}" se incluye ahora en el SDK de .NET Core. Hay información disponible sobre cómo resolver esta advertencia en (https://aka.ms/dotnetclitools-in-box).</target>
+        <note>{StrBegin="NETSDK1059: "}</note>
+      </trans-unit>
+      <trans-unit id="RuntimeIdentifierNotRecognized">
+        <source>NETSDK1083: The specified RuntimeIdentifier '{0}' is not recognized.</source>
+        <target state="new">NETSDK1083: The specified RuntimeIdentifier '{0}' is not recognized.</target>
+        <note>{StrBegin="NETSDK1083: "}</note>
+      </trans-unit>
+      <trans-unit id="RuntimeIdentifierWasNotSpecified">
+        <source>NETSDK1028: Specify a RuntimeIdentifier</source>
+        <target state="translated">NETSDK1028: Especificar un valor para RuntimeIdentifier</target>
+        <note>{StrBegin="NETSDK1028: "}</note>
+      </trans-unit>
+      <trans-unit id="SkippingAdditionalProbingPaths">
+        <source>NETSDK1048: 'AdditionalProbingPaths' were specified for GenerateRuntimeConfigurationFiles, but are being skipped because 'RuntimeConfigDevPath' is empty.</source>
+        <target state="translated">NETSDK1048: Se especificaron valores adicionales de "AdditionalProbingPaths" para GenerateRuntimeConfigurationFiles, pero se van a omitir porque el valor de "RuntimeConfigDevPath" está vacío.</target>
+        <note>{StrBegin="NETSDK1048: "}</note>
+      </trans-unit>
+      <trans-unit id="TargetFrameworkWithSemicolon">
+        <source>NETSDK1046: The TargetFramework value '{0}' is not valid. To multi-target, use the 'TargetFrameworks' property instead.</source>
+        <target state="translated">NETSDK1046: El valor de TargetFramework "{0}" no es válido. Para varios destinos, use en su lugar la propiedad "TargetFrameworks".</target>
+        <note>{StrBegin="NETSDK1046: "}</note>
+      </trans-unit>
+      <trans-unit id="UnableToFindResolvedPath">
+        <source>NETSDK1016: Unable to find resolved path for '{0}'.</source>
+        <target state="translated">NETSDK1016: No se encuentra la ruta de acceso resuelta para "{0}".</target>
+        <note>{StrBegin="NETSDK1016: "}</note>
+      </trans-unit>
+      <trans-unit id="UnableToUsePackageAssetsCache">
+        <source>NETSDK1062: Unable to use package assets cache due to I/O error. This can occur when the same project is built more than once in parallel. Performance may be degraded, but the build result will not be impacted.</source>
+        <target state="translated">NETSDK1062: No se puede usar la memoria caché de recursos del paquete debido a un error de E/S. Esto puede ocurrir cuando un mismo proyecto se compila más de una vez en paralelo. Puede que se reduzca el rendimiento, pero no afectará al resultado de la compilación.</target>
+        <note>{StrBegin="NETSDK1062: "}</note>
+      </trans-unit>
+      <trans-unit id="UnexpectedFileType">
+        <source>NETSDK1012: Unexpected file type for '{0}'. Type is both '{1}' and '{2}'.</source>
+        <target state="translated">NETSDK1012: Tipo de archivo no esperado para "{0}". El tipo es tanto "{1}" como "{2}".</target>
+        <note>{StrBegin="NETSDK1012: "}</note>
+      </trans-unit>
+      <trans-unit id="UnknownFrameworkReference">
+        <source>NETSDK1073: The FrameworkReference '{0}' was not recognized</source>
+        <target state="translated">NETSDK1073: No se reconoció el FrameworkReference "{0}"</target>
+        <note>{StrBegin="NETSDK1073: "}</note>
+      </trans-unit>
+      <trans-unit id="UnrecognizedPreprocessorToken">
+        <source>NETSDK1009: Unrecognized preprocessor token '{0}' in '{1}'.</source>
+        <target state="translated">NETSDK1009: Token de preprocesador no reconocido "{0}" en "{1}".</target>
+        <note>{StrBegin="NETSDK1009: "}</note>
+      </trans-unit>
+      <trans-unit id="UnresolvedTargetingPack">
+        <source>NETSDK1081: The targeting pack for {0} was not found. You may be able to resolve this by running a NuGet restore on the project.</source>
+        <target state="new">NETSDK1081: The targeting pack for {0} was not found. You may be able to resolve this by running a NuGet restore on the project.</target>
+        <note>{StrBegin="NETSDK1081: "}</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedFramework">
+        <source>NETSDK1019: {0} is an unsupported framework.</source>
+        <target state="translated">NETSDK1019: {0} es una plataforma no compatible.</target>
+        <note>{StrBegin="NETSDK1019: "}</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedRuntimeIdentifier">
+        <source>NETSDK1056: Project is targeting runtime '{0}' but did not resolve any runtime-specific packages. This runtime may not be supported by the target framework.</source>
+        <target state="translated">NETSDK1056: El proyecto se dirige al tiempo de ejecución "{0}" pero no resolvió ningún paquete específico del tiempo de ejecución. Es posible que este tiempo de ejecución no sea compatible con la plataforma de destino.</target>
+        <note>{StrBegin="NETSDK1056: "}</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedSDKVersionForNetStandard20">
+        <source>NETSDK1050: The version of Microsoft.NET.Sdk used by this project is insufficient to support references to libraries targeting .NET Standard 1.5 or higher.  Please install version 2.0 or higher of the .NET Core SDK.</source>
+        <target state="translated">NETSDK1050: En la versión de Microsoft.NET.Sdk que utiliza este proyecto no se admiten referencias a bibliotecas cuyo destino sea .NET Standard 1.5 o posterior. Instale la versión 2.0 o posterior del SDK de .NET Core.</target>
+        <note>{StrBegin="NETSDK1050: "}</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedTargetFrameworkVersion">
+        <source>NETSDK1045: The current .NET SDK does not support targeting {0} {1}.  Either target {0} {2} or lower, or use a version of the .NET SDK that supports {0} {1}.</source>
+        <target state="translated">NETSDK1045: El SDK de .NET actual no admite el destino {0} {1}. Use el destino {0} {2} u otro inferior, o bien una versión del SDK de .NET que admita {0} {1}.</target>
+        <note>{StrBegin="NETSDK1045: "}</note>
+      </trans-unit>
+      <trans-unit id="UsingPreviewSdkWarning">
+        <source>NETSDK1057: You are using a preview version of .NET Core. See: https://aka.ms/dotnet-core-preview</source>
+        <target state="translated">NETSDK1057: Está utilizando una versión preliminar de .NET Core. Vea: https://aka.ms/dotnet-core-preview</target>
+        <note>{StrBegin="NETSDK1057: "}</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
@@ -2,35 +2,25 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../Strings.resx">
     <body>
-      <trans-unit id="AspNetCoreAllNotSupported">
-        <source>NETSDK1079: The Microsoft.AspNetCore.All package is not supported when targeting .NET Core 3.0 or higher.  A FrameworkReference to Microsoft.AspNetCore.App should be used instead, and will be implicitly included by Microsoft.NET.Sdk.Web.</source>
-        <target state="translated">NETSDK1079 : Le package Microsoft.AspNetCore.All n'est pas pris en charge quand vous ciblez .NET Core 3.0 ou version supérieure. Vous devez utiliser à la place une référence de framework vers Microsoft.AspNetCore.App, qui est implicitement incluse par Microsoft.NET.Sdk.Web.</target>
-        <note>{StrBegin="NETSDK1079: "}</note>
-      </trans-unit>
-      <trans-unit id="AspNetCoreUsesFrameworkReference">
-        <source>NETSDK1080: A PackageReference to Microsoft.AspNetCore.App is not necessary when targeting .NET Core 3.0 or higher. If Microsoft.NET.Sdk.Web is used, the shared framework will be referenced automatically. Otherwise, the PackageReference should be replaced with a FrameworkReference.</source>
-        <target state="translated">NETSDK1080 : Vous n'avez pas besoin d'une référence de package vers Microsoft.AspNetCore.App quand vous ciblez .NET Core 3.0 ou version supérieure. Si vous utilisez Microsoft.NET.Sdk.Web, le framework partagé est référencé automatiquement. Sinon, la référence de package doit être remplacée par une référence de framework.</target>
-        <note>{StrBegin="NETSDK1080: "}</note>
-      </trans-unit>
-      <trans-unit id="FailedToLockResource">
-        <source>NETSDK1077: Failed to lock resource.</source>
-        <target state="translated">NETSDK1077 : Échec du blocage de la ressource.</target>
-        <note>{StrBegin="NETSDK1077: "}</note>
-      </trans-unit>
       <trans-unit id="AddResourceWithNonIntegerResource">
         <source>NETSDK1076: AddResource can only be used with integer resource types.</source>
         <target state="translated">NETSDK1076 : AddResource est uniquement utilisable avec les types de ressource entiers.</target>
         <note>{StrBegin="NETSDK1076: "}</note>
       </trans-unit>
-      <trans-unit id="InvalidResourceUpdate">
-        <source>NETSDK1075: Update handle is invalid. This instance may not be used for further updates.</source>
-        <target state="translated">NETSDK1075 : Le handle de mise à jour n'est pas valide. Cette instance ne peut pas être utilisée pour d'autres mises à jour.</target>
-        <note>{StrBegin="NETSDK1075: "}</note>
+      <trans-unit id="AppConfigRequiresRootConfiguration">
+        <source>NETSDK1070: The application configuration file must have root configuration element.</source>
+        <target state="translated">NETSDK1070 : Le fichier de configuration de l'application doit avoir un élément de configuration racine.</target>
+        <note>{StrBegin="NETSDK1070: "}</note>
       </trans-unit>
       <trans-unit id="AppHostCustomizationRequiresWindowsHostWarning">
         <source>NETSDK1074: The application host executable will not be customized because adding resources requires that the build be performed on Windows (excluding Nano Server).</source>
         <target state="translated">NETSDK1074 : L'exécutable hôte de l'application n'est pas personnalisé, car l'ajout de ressources nécessite l'exécution de la build sur Windows (sauf Nano Server).</target>
         <note>{StrBegin="NETSDK1074: "}</note>
+      </trans-unit>
+      <trans-unit id="AppHostHasBeenModified">
+        <source>NETSDK1029: Unable to use '{0}' as application host executable as it does not contain the expected placeholder byte sequence '{1}' that would mark where the application name would be written.</source>
+        <target state="translated">NETSDK1029: Impossible d'utiliser '{0}' en tant qu'exécutable d'hôte d'application, car il ne contient pas la séquence d'octets d'espace réservé attendue '{1}' qui marque l'emplacement où est écrit le nom de l'application.</target>
+        <note>{StrBegin="NETSDK1029: "}</note>
       </trans-unit>
       <trans-unit id="AppHostNotWindows">
         <source>NETSDK1078: Unable to use '{0}' as application host executable because it's not a Windows PE file.</source>
@@ -42,210 +32,80 @@
         <target state="translated">NETSDK1072 : Impossible d'utiliser '{0}' comme exécutable hôte de l'application, car il ne s'agit pas d'un exécutable Windows pour le sous-système CUI (console).</target>
         <note>{StrBegin="NETSDK1072: "}</note>
       </trans-unit>
-      <trans-unit id="AppConfigRequiresRootConfiguration">
-        <source>NETSDK1070: The application configuration file must have root configuration element.</source>
-        <target state="translated">NETSDK1070 : Le fichier de configuration de l'application doit avoir un élément de configuration racine.</target>
-        <note>{StrBegin="NETSDK1070: "}</note>
+      <trans-unit id="AspNetCoreAllNotSupported">
+        <source>NETSDK1079: The Microsoft.AspNetCore.All package is not supported when targeting .NET Core 3.0 or higher.  A FrameworkReference to Microsoft.AspNetCore.App should be used instead, and will be implicitly included by Microsoft.NET.Sdk.Web.</source>
+        <target state="translated">NETSDK1079 : Le package Microsoft.AspNetCore.All n'est pas pris en charge quand vous ciblez .NET Core 3.0 ou version supérieure. Vous devez utiliser à la place une référence de framework vers Microsoft.AspNetCore.App, qui est implicitement incluse par Microsoft.NET.Sdk.Web.</target>
+        <note>{StrBegin="NETSDK1079: "}</note>
       </trans-unit>
-      <trans-unit id="AtLeastOneTargetFrameworkMustBeSpecified">
-        <source>NETSDK1001: At least one possible target framework must be specified.</source>
-        <target state="translated">NETSDK1001: Vous devez spécifier au moins un framework cible.</target>
-        <note>{StrBegin="NETSDK1001: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotUseSelfContainedWithoutAppHost">
-        <source>NETSDK1067: Self-contained applications are required to use the application host. Either set SelfContained to false or set UseAppHost to true.</source>
-        <target state="translated">NETSDK1067: Des applications autonomes sont obligatoires pour utiliser l'hôte d'application. Définissez SelfContained avec la valeur false ou UseAppHost avec la valeur true.</target>
-        <note>{StrBegin="NETSDK1067: "}</note>
-      </trans-unit>
-      <trans-unit id="FrameworkDependentAppHostRequiresVersion21">
-        <source>NETSDK1068: The framework-dependent application host requires a target framework of at least 'netcoreapp2.1'.</source>
-        <target state="translated">NETSDK1068: L'hôte d'application dépendant du framework nécessite au minimum le framework cible 'netcoreapp2.1'.</target>
-        <note>{StrBegin="NETSDK1068: "}</note>
-      </trans-unit>
-      <trans-unit id="NETFrameworkToNonBuiltInNETStandard">
-        <source>NETSDK1069: This project uses a library that targets .NET Standard 1.5 or higher, and the project targets a version of .NET Framework that doesn't have built-in support for that version of .NET Standard. Visit https://aka.ms/net-standard-known-issues for a set of known issues. Consider retargeting to .NET Framework 4.7.2.</source>
-        <target state="translated">NETSDK1069: Ce projet utilise une bibliothèque qui cible .NET Standard 1.5 ou ultérieur, et le projet cible une version du .NET Framework qui n'intègre pas la prise en charge de cette version de .NET Standard. Pour obtenir la liste des problèmes connus, visitez https://aka.ms/net-standard-known-issues. Songez à cibler le .NET Framework 4.7.2.</target>
-        <note>{StrBegin="NETSDK1069: "}</note>
-      </trans-unit>
-      <trans-unit id="NoAppHostAvailable">
-        <source>NETSDK1084: There is no application host available for the specified RuntimeIdentifier '{0}'.</source>
-        <target state="new">NETSDK1084: There is no application host available for the specified RuntimeIdentifier '{0}'.</target>
-        <note>{StrBegin="NETSDK1084: "}</note>
-      </trans-unit>
-      <trans-unit id="NoCompatibleTargetFramework">
-        <source>NETSDK1002: Project '{0}' targets '{2}'. It cannot be referenced by a project that targets '{1}'.</source>
-        <target state="translated">NETSDK1002: Le projet '{0}' cible '{2}'. Il ne peut pas être référencé par un projet qui cible '{1}'.</target>
-        <note>{StrBegin="NETSDK1002: "}</note>
-      </trans-unit>
-      <trans-unit id="InvalidFrameworkName">
-        <source>NETSDK1003: Invalid framework name: '{0}'.</source>
-        <target state="translated">NETSDK1003: Nom de framework non valide : '{0}'.</target>
-        <note>{StrBegin="NETSDK1003: "}</note>
-      </trans-unit>
-      <trans-unit id="AssetsFileNotFound">
-        <source>NETSDK1004: Assets file '{0}' not found. Run a NuGet package restore to generate this file.</source>
-        <target state="translated">NETSDK1004: Le fichier de composants '{0}' est introuvable. Exécutez une restauration de package NuGet pour générer ce fichier.</target>
-        <note>{StrBegin="NETSDK1004: "}</note>
-      </trans-unit>
-      <trans-unit id="AssetsFileMissingTarget">
-        <source>NETSDK1005: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project.</source>
-        <target state="translated">NETSDK1005: Le fichier de composants '{0}' n'a aucune cible pour '{1}'. Vérifiez que la restauration s'est exécutée et que vous avez inclus '{2}' dans TargetFrameworks pour votre projet.</target>
-        <note>{StrBegin="NETSDK1005: "}</note>
-      </trans-unit>
-      <trans-unit id="AssetsFilePathNotRooted">
-        <source>NETSDK1006: Assets file path '{0}' is not rooted. Only full paths are supported.</source>
-        <target state="translated">NETSDK1006: Le chemin du fichier de composants '{0}' n'est pas associé à une racine. Seuls les chemins complets sont pris en charge.</target>
-        <note>{StrBegin="NETSDK1006: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotFindProjectInfo">
-        <source>NETSDK1007: Cannot find project info for '{0}'. This can indicate a missing project reference.</source>
-        <target state="translated">NETSDK1007: Les informations relatives au projet sont introuvables pour '{0}'. Cela peut indiquer une référence de projet manquante.</target>
-        <note>{StrBegin="NETSDK1007: "}</note>
-      </trans-unit>
-      <trans-unit id="MissingItemMetadata">
-        <source>NETSDK1008: Missing '{0}' metadata on '{1}' item '{2}'.</source>
-        <target state="translated">NETSDK1008: Métadonnées '{0}' manquantes sur l'élément '{1}' '{2}'.</target>
-        <note>{StrBegin="NETSDK1008: "}</note>
-      </trans-unit>
-      <trans-unit id="NoRuntimePackAvailable">
-        <source>NETSDK1082: There was no runtime pack for {0} available for the specified RuntimeIdentifier '{1}'.</source>
-        <target state="new">NETSDK1082: There was no runtime pack for {0} available for the specified RuntimeIdentifier '{1}'.</target>
-        <note>{StrBegin="NETSDK1082: "}</note>
-      </trans-unit>
-      <trans-unit id="PackageReferenceVersionNotRecommended">
-        <source>NETSDK1071: A PackageReference to '{0}' specified a Version of `{1}`. Specifying the version of this package is not recommended. For more information, see https://aka.ms/sdkimplicitrefs</source>
-        <target state="translated">NETSDK1071 : Une référence de package vers '{0}' a spécifié une version '{1}'. Nous ne vous recommandons pas de spécifier la version de ce package. Pour plus d'informations, consultez https://aka.ms/sdkimplicitrefs</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="RuntimeIdentifierNotRecognized">
-        <source>NETSDK1083: The specified RuntimeIdentifier '{0}' is not recognized.</source>
-        <target state="new">NETSDK1083: The specified RuntimeIdentifier '{0}' is not recognized.</target>
-        <note>{StrBegin="NETSDK1083: "}</note>
-      </trans-unit>
-      <trans-unit id="UnknownFrameworkReference">
-        <source>NETSDK1073: The FrameworkReference '{0}' was not recognized</source>
-        <target state="translated">NETSDK1073 : Référence de framework '{0}' non reconnue</target>
-        <note>{StrBegin="NETSDK1073: "}</note>
-      </trans-unit>
-      <trans-unit id="UnrecognizedPreprocessorToken">
-        <source>NETSDK1009: Unrecognized preprocessor token '{0}' in '{1}'.</source>
-        <target state="translated">NETSDK1009: Jeton de préprocesseur '{0}' non reconnu dans '{1}'.</target>
-        <note>{StrBegin="NETSDK1009: "}</note>
-      </trans-unit>
-      <trans-unit id="ContentPreproccessorParameterRequired">
-        <source>NETSDK1010: The '{0}' task must be given a value for parameter '{1}' in order to consume preprocessed content.</source>
-        <target state="translated">NETSDK1010: La tâche '{0}' doit recevoir une valeur pour le paramètre '{1}', ce qui permet la consommation du contenu prétraité.</target>
-        <note>{StrBegin="NETSDK1010: "}</note>
-      </trans-unit>
-      <trans-unit id="ProjectAssetsConsumedWithoutMSBuildProjectPath">
-        <source>NETSDK1011: Assets are consumed from project '{0}', but no corresponding MSBuild project path was  found in '{1}'.</source>
-        <target state="translated">NETSDK1011: Les composants sont consommés à partir du projet '{0}', mais il n'existe aucun chemin de projet MSBuild correspondant dans '{1}'.</target>
-        <note>{StrBegin="NETSDK1011: "}</note>
-      </trans-unit>
-      <trans-unit id="UnexpectedFileType">
-        <source>NETSDK1012: Unexpected file type for '{0}'. Type is both '{1}' and '{2}'.</source>
-        <target state="translated">NETSDK1012: Type de fichier inattendu pour '{0}'. Le type est à la fois '{1}' et '{2}'.</target>
-        <note>{StrBegin="NETSDK1012: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotInferTargetFrameworkIdentifierAndVersion">
-        <source>NETSDK1013: The TargetFramework value '{0}' was not recognized. It may be misspelled. If not, then the TargetFrameworkIdentifier and/or TargetFrameworkVersion properties must be specified explicitly.</source>
-        <target state="translated">NETSDK1013: La valeur TargetFramework '{0}' n'a pas été reconnue. Elle est peut-être mal orthographiée. Sinon, vous devez spécifier explicitement les propriétés TargetFrameworkIdentifier et/ou TargetFrameworkVersion.</target>
-        <note>{StrBegin="NETSDK1013: "}</note>
-      </trans-unit>
-      <trans-unit id="ContentItemDoesNotProvideOutputPath">
-        <source>NETSDK1014: Content item for '{0}' sets '{1}', but does not provide  '{2}' or '{3}'.</source>
-        <target state="translated">NETSDK1014: L'élément de contenu pour '{0}' définit '{1}', mais ne fournit ni '{2}' ni '{3}'.</target>
-        <note>{StrBegin="NETSDK1014: "}</note>
-      </trans-unit>
-      <trans-unit id="DuplicatePreprocessorToken">
-        <source>NETSDK1015: The preprocessor token '{0}' has been given more than one value. Choosing '{1}' as the value.</source>
-        <target state="translated">NETSDK1015: Le jeton de préprocesseur '{0}' a reçu plusieurs valeurs. La valeur choisie est '{1}'.</target>
-        <note>{StrBegin="NETSDK1015: "}</note>
-      </trans-unit>
-      <trans-unit id="UnableToFindResolvedPath">
-        <source>NETSDK1016: Unable to find resolved path for '{0}'.</source>
-        <target state="translated">NETSDK1016: Chemin résolu introuvable pour '{0}'.</target>
-        <note>{StrBegin="NETSDK1016: "}</note>
+      <trans-unit id="AspNetCoreUsesFrameworkReference">
+        <source>NETSDK1080: A PackageReference to Microsoft.AspNetCore.App is not necessary when targeting .NET Core 3.0 or higher. If Microsoft.NET.Sdk.Web is used, the shared framework will be referenced automatically. Otherwise, the PackageReference should be replaced with a FrameworkReference.</source>
+        <target state="translated">NETSDK1080 : Vous n'avez pas besoin d'une référence de package vers Microsoft.AspNetCore.App quand vous ciblez .NET Core 3.0 ou version supérieure. Si vous utilisez Microsoft.NET.Sdk.Web, le framework partagé est référencé automatiquement. Sinon, la référence de package doit être remplacée par une référence de framework.</target>
+        <note>{StrBegin="NETSDK1080: "}</note>
       </trans-unit>
       <trans-unit id="AssetPreprocessorMustBeConfigured">
         <source>NETSDK1017: Asset preprocessor must be configured before assets are processed.</source>
         <target state="translated">NETSDK1017: Le préprocesseur de composants doit être configuré avant le traitement des composants.</target>
         <note>{StrBegin="NETSDK1017: "}</note>
       </trans-unit>
-      <trans-unit id="InvalidNuGetVersionString">
-        <source>NETSDK1018: Invalid NuGet version string: '{0}'.</source>
-        <target state="translated">NETSDK1018: Chaîne de version NuGet non valide : '{0}'.</target>
-        <note>{StrBegin="NETSDK1018: "}</note>
+      <trans-unit id="AssetsFileMissingRuntimeIdentifier">
+        <source>NETSDK1047: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project. You may also need to include '{3}' in your project's RuntimeIdentifiers.</source>
+        <target state="translated">NETSDK1047: Le fichier de composants '{0}' n'a aucune cible pour '{1}'. Vérifiez que la restauration s'est exécutée et que vous avez inclus '{2}' dans TargetFrameworks pour votre projet. Vous devrez peut-être également inclure '{3}' dans les RuntimeIdentifiers de votre projet.</target>
+        <note>{StrBegin="NETSDK1047: "}</note>
       </trans-unit>
-      <trans-unit id="UnresolvedTargetingPack">
-        <source>NETSDK1081: The targeting pack for {0} was not found. You may be able to resolve this by running a NuGet restore on the project.</source>
-        <target state="new">NETSDK1081: The targeting pack for {0} was not found. You may be able to resolve this by running a NuGet restore on the project.</target>
-        <note>{StrBegin="NETSDK1081: "}</note>
+      <trans-unit id="AssetsFileMissingTarget">
+        <source>NETSDK1005: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project.</source>
+        <target state="translated">NETSDK1005: Le fichier de composants '{0}' n'a aucune cible pour '{1}'. Vérifiez que la restauration s'est exécutée et que vous avez inclus '{2}' dans TargetFrameworks pour votre projet.</target>
+        <note>{StrBegin="NETSDK1005: "}</note>
       </trans-unit>
-      <trans-unit id="UnsupportedFramework">
-        <source>NETSDK1019: {0} is an unsupported framework.</source>
-        <target state="translated">NETSDK1019: {0} est un framework non pris en charge.</target>
-        <note>{StrBegin="NETSDK1019: "}</note>
+      <trans-unit id="AssetsFileNotFound">
+        <source>NETSDK1004: Assets file '{0}' not found. Run a NuGet package restore to generate this file.</source>
+        <target state="translated">NETSDK1004: Le fichier de composants '{0}' est introuvable. Exécutez une restauration de package NuGet pour générer ce fichier.</target>
+        <note>{StrBegin="NETSDK1004: "}</note>
       </trans-unit>
-      <trans-unit id="DuplicateItemsError">
-        <source>NETSDK1022: Duplicate '{0}' items were included. The .NET SDK includes '{0}' items from your project directory by default. You can either remove these items from your project file, or set the '{1}' property to '{2}' if you want to explicitly include them in your project file. For more information, see {4}. The duplicate items were: {3}</source>
-        <target state="translated">NETSDK1022: Des éléments '{0}' dupliqués ont été inclus. Le kit .NET SDK inclut les éléments '{0}' de votre répertoire de projet par défaut. Vous pouvez supprimer ces éléments de votre fichier projet ou affecter à la propriété '{1}' la valeur '{2}', si vous souhaitez les inclure explicitement dans votre fichier projet. Pour plus d'informations, consultez {4}. Les éléments dupliqués sont les suivants : {3}</target>
-        <note>{StrBegin="NETSDK1022: "}</note>
+      <trans-unit id="AssetsFileNotSet">
+        <source>NETSDK1063: The path to the project assets file was not set. Run a NuGet package restore to generate this file.</source>
+        <target state="translated">NETSDK1063: Le chemin du fichier de composants du projet n'a pas été défini. Exécutez une restauration de package NuGet pour générer ce fichier.</target>
+        <note>{StrBegin="NETSDK1063: "}</note>
       </trans-unit>
-      <trans-unit id="PackageReferenceOverrideWarning">
-        <source>NETSDK1023: A PackageReference for '{0}' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see {1}</source>
-        <target state="translated">NETSDK1023: Un PackageReference pour '{0}' a été inclus dans votre projet. Comme ce package est implicitement référencé par le kit .NET SDK, vous n'avez généralement pas besoin de le référencer à partir de votre projet. Pour plus d'informations, consultez {1}</target>
-        <note>{StrBegin="NETSDK1023: "}</note>
+      <trans-unit id="AssetsFilePathNotRooted">
+        <source>NETSDK1006: Assets file path '{0}' is not rooted. Only full paths are supported.</source>
+        <target state="translated">NETSDK1006: Le chemin du fichier de composants '{0}' n'est pas associé à une racine. Seuls les chemins complets sont pris en charge.</target>
+        <note>{StrBegin="NETSDK1006: "}</note>
       </trans-unit>
-      <trans-unit id="IncorrectPackageRoot">
-        <source>NETSDK1020: Package Root {0} was incorrectly given for Resolved library {1}</source>
-        <target state="translated">NETSDK1020: La racine de package {0} a été spécifiée de manière incorrecte pour la bibliothèque Resolved {1}</target>
-        <note>{StrBegin="NETSDK1020: "}</note>
+      <trans-unit id="AtLeastOneTargetFrameworkMustBeSpecified">
+        <source>NETSDK1001: At least one possible target framework must be specified.</source>
+        <target state="translated">NETSDK1001: Vous devez spécifier au moins un framework cible.</target>
+        <note>{StrBegin="NETSDK1001: "}</note>
       </trans-unit>
-      <trans-unit id="MultipleFilesResolved">
-        <source>NETSDK1021: More than one file found for {0}</source>
-        <target state="translated">NETSDK1021: Plusieurs fichiers ont été trouvés pour {0}</target>
-        <note>{StrBegin="NETSDK1021: "}</note>
+      <trans-unit id="CannotFindApphostForRid">
+        <source>NETSDK1065: Cannot find app host for {0}. {0} could be an invalid runtime identifier (RID). For more information about RID, see https://aka.ms/rid-catalog.</source>
+        <target state="translated">NETSDK1065: hôte d'application introuvable pour {0}. {0} est peut-être un RID (identificateur de runtime) non valide. Pour plus d'informations sur les RID, consultez https://aka.ms/rid-catalog.</target>
+        <note>{StrBegin="NETSDK1065: "}</note>
       </trans-unit>
-      <trans-unit id="FolderAlreadyExists">
-        <source>NETSDK1024: Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</source>
-        <target state="translated">NETSDK1024: Le dossier '{0}' existe déjà. Supprimez-le ou indiquez un autre ComposeWorkingDir</target>
-        <note>{StrBegin="NETSDK1024: "}</note>
+      <trans-unit id="CannotFindProjectInfo">
+        <source>NETSDK1007: Cannot find project info for '{0}'. This can indicate a missing project reference.</source>
+        <target state="translated">NETSDK1007: Les informations relatives au projet sont introuvables pour '{0}'. Cela peut indiquer une référence de projet manquante.</target>
+        <note>{StrBegin="NETSDK1007: "}</note>
       </trans-unit>
-      <trans-unit id="ParsingFiles">
-        <source>NETSDK1026: Parsing the Files : '{0}'</source>
-        <target state="translated">NETSDK1026: Analyse des fichiers : '{0}'</target>
-        <note>{StrBegin="NETSDK1026: "}</note>
-      </trans-unit>
-      <trans-unit id="PackageInfoLog">
-        <source>NETSDK1027: Package Name='{0}', Version='{1}' was parsed</source>
-        <target state="translated">NETSDK1027: Le package ayant pour nom '{0}' et pour version '{1}' a été analysé</target>
-        <note>{StrBegin="NETSDK1027: "}</note>
-      </trans-unit>
-      <trans-unit id="RuntimeIdentifierWasNotSpecified">
-        <source>NETSDK1028: Specify a RuntimeIdentifier</source>
-        <target state="translated">NETSDK1028: Spécifiez un RuntimeIdentifier</target>
-        <note>{StrBegin="NETSDK1028: "}</note>
-      </trans-unit>
-      <trans-unit id="IncorrectTargetFormat">
-        <source>NETSDK1025: WRThe target manifest {0} provided is of not the correct format</source>
-        <target state="translated">NETSDK1025: Le manifeste cible {0} fourni n'est pas au format approprié</target>
-        <note>{StrBegin="NETSDK1025: "}</note>
-      </trans-unit>
-      <trans-unit id="AppHostHasBeenModified">
-        <source>NETSDK1029: Unable to use '{0}' as application host executable as it does not contain the expected placeholder byte sequence '{1}' that would mark where the application name would be written.</source>
-        <target state="translated">NETSDK1029: Impossible d'utiliser '{0}' en tant qu'exécutable d'hôte d'application, car il ne contient pas la séquence d'octets d'espace réservé attendue '{1}' qui marque l'emplacement où est écrit le nom de l'application.</target>
-        <note>{StrBegin="NETSDK1029: "}</note>
-      </trans-unit>
-      <trans-unit id="FileNameIsTooLong">
-        <source>NETSDK1030: Given file name '{0}' is longer than 1024 bytes</source>
-        <target state="translated">NETSDK1030: Le nom de fichier spécifié '{0}' dépasse 1 024 octets</target>
-        <note>{StrBegin="NETSDK1030: "}</note>
+      <trans-unit id="CannotHaveRuntimeIdentifierPlatformMismatchPlatformTarget">
+        <source>NETSDK1032: The RuntimeIdentifier platform '{0}' and the PlatformTarget '{1}' must be compatible.</source>
+        <target state="translated">NETSDK1032: La plateforme de RuntimeIdentifier '{0}' et le PlatformTarget '{1}' doivent être compatibles.</target>
+        <note>{StrBegin="NETSDK1032: "}</note>
       </trans-unit>
       <trans-unit id="CannotHaveSelfContainedWithoutRuntimeIdentifier">
         <source>NETSDK1031: It is not supported to build or publish a self-contained application without specifying a RuntimeIdentifier.  Please either specify a RuntimeIdentifier or set SelfContained to false.</source>
         <target state="translated">NETSDK1031: La génération ou la publication d'une application autonome sans spécification de RuntimeIdentifier n'est pas prise en charge. Spécifiez RuntimeIdentifier ou affectez la valeur false à SelfContained.</target>
         <note>{StrBegin="NETSDK1031: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotInferTargetFrameworkIdentifierAndVersion">
+        <source>NETSDK1013: The TargetFramework value '{0}' was not recognized. It may be misspelled. If not, then the TargetFrameworkIdentifier and/or TargetFrameworkVersion properties must be specified explicitly.</source>
+        <target state="translated">NETSDK1013: La valeur TargetFramework '{0}' n'a pas été reconnue. Elle est peut-être mal orthographiée. Sinon, vous devez spécifier explicitement les propriétés TargetFrameworkIdentifier et/ou TargetFrameworkVersion.</target>
+        <note>{StrBegin="NETSDK1013: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotUseSelfContainedWithoutAppHost">
+        <source>NETSDK1067: Self-contained applications are required to use the application host. Either set SelfContained to false or set UseAppHost to true.</source>
+        <target state="translated">NETSDK1067: Des applications autonomes sont obligatoires pour utiliser l'hôte d'application. Définissez SelfContained avec la valeur false ou UseAppHost avec la valeur true.</target>
+        <note>{StrBegin="NETSDK1067: "}</note>
       </trans-unit>
       <trans-unit id="ChoosingAssemblyVersion">
         <source>NETSDK1033: Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</source>
@@ -272,6 +132,16 @@
         <target state="translated">NETSDK1037: Impossible de déterminer le gagnant, car les versions de fichier et d'assembly sont identiques.</target>
         <note>{StrBegin="NETSDK1037: "}</note>
       </trans-unit>
+      <trans-unit id="ContentItemDoesNotProvideOutputPath">
+        <source>NETSDK1014: Content item for '{0}' sets '{1}', but does not provide  '{2}' or '{3}'.</source>
+        <target state="translated">NETSDK1014: L'élément de contenu pour '{0}' définit '{1}', mais ne fournit ni '{2}' ni '{3}'.</target>
+        <note>{StrBegin="NETSDK1014: "}</note>
+      </trans-unit>
+      <trans-unit id="ContentPreproccessorParameterRequired">
+        <source>NETSDK1010: The '{0}' task must be given a value for parameter '{1}' in order to consume preprocessed content.</source>
+        <target state="translated">NETSDK1010: La tâche '{0}' doit recevoir une valeur pour le paramètre '{1}', ce qui permet la consommation du contenu prétraité.</target>
+        <note>{StrBegin="NETSDK1010: "}</note>
+      </trans-unit>
       <trans-unit id="CouldNotDetermineWinner_DoesntExist">
         <source>NETSDK1038: Could not determine winner because '{0}' does not exist.</source>
         <target state="translated">NETSDK1038: Impossible de déterminer le gagnant, car '{0}' n'existe pas.</target>
@@ -287,15 +157,40 @@
         <target state="translated">NETSDK1040: Impossible de déterminer un gagnant, car '{0}' n'est pas un assembly.</target>
         <note>{StrBegin="NETSDK1040: "}</note>
       </trans-unit>
+      <trans-unit id="CouldNotLoadPlatformManifest">
+        <source>NETSDK1042: Could not load PlatformManifest from '{0}' because it did not exist.</source>
+        <target state="translated">NETSDK1042: Impossible de charger PlatformManifest à partir de '{0}', car il n'existe pas.</target>
+        <note>{StrBegin="NETSDK1042: "}</note>
+      </trans-unit>
+      <trans-unit id="DotnetToolDoesNotSupportTFMLowerThanNetcoreapp21">
+        <source>NETSDK1055: DotnetTool does not support target framework lower than netcoreapp2.1.</source>
+        <target state="translated">NETSDK1055: DotnetTool ne prend pas en charge de framework cible inférieur à netcoreapp2.1.</target>
+        <note>{StrBegin="NETSDK1055: "}</note>
+      </trans-unit>
+      <trans-unit id="DotnetToolOnlySupportNetcoreapp">
+        <source>NETSDK1054: only supports .NET Core.</source>
+        <target state="translated">NETSDK1054: prend uniquement en charge .NET Core.</target>
+        <note>{StrBegin="NETSDK1054: "}</note>
+      </trans-unit>
+      <trans-unit id="DuplicateItemsError">
+        <source>NETSDK1022: Duplicate '{0}' items were included. The .NET SDK includes '{0}' items from your project directory by default. You can either remove these items from your project file, or set the '{1}' property to '{2}' if you want to explicitly include them in your project file. For more information, see {4}. The duplicate items were: {3}</source>
+        <target state="translated">NETSDK1022: Des éléments '{0}' dupliqués ont été inclus. Le kit .NET SDK inclut les éléments '{0}' de votre répertoire de projet par défaut. Vous pouvez supprimer ces éléments de votre fichier projet ou affecter à la propriété '{1}' la valeur '{2}', si vous souhaitez les inclure explicitement dans votre fichier projet. Pour plus d'informations, consultez {4}. Les éléments dupliqués sont les suivants : {3}</target>
+        <note>{StrBegin="NETSDK1022: "}</note>
+      </trans-unit>
+      <trans-unit id="DuplicatePreprocessorToken">
+        <source>NETSDK1015: The preprocessor token '{0}' has been given more than one value. Choosing '{1}' as the value.</source>
+        <target state="translated">NETSDK1015: Le jeton de préprocesseur '{0}' a reçu plusieurs valeurs. La valeur choisie est '{1}'.</target>
+        <note>{StrBegin="NETSDK1015: "}</note>
+      </trans-unit>
       <trans-unit id="EncounteredConflict">
         <source>NETSDK1041: Encountered conflict between '{0}' and '{1}'.</source>
         <target state="translated">NETSDK1041: Conflit détecté entre '{0}' et '{1}'.</target>
         <note>{StrBegin="NETSDK1041: "}</note>
       </trans-unit>
-      <trans-unit id="CouldNotLoadPlatformManifest">
-        <source>NETSDK1042: Could not load PlatformManifest from '{0}' because it did not exist.</source>
-        <target state="translated">NETSDK1042: Impossible de charger PlatformManifest à partir de '{0}', car il n'existe pas.</target>
-        <note>{StrBegin="NETSDK1042: "}</note>
+      <trans-unit id="ErrorParsingFrameworkListInvalidValue">
+        <source>NETSDK1051: Error parsing FrameworkList from '{0}'.  {1} '{2}' was invalid.</source>
+        <target state="translated">NETSDK1051: Erreur durant l'analyse de FrameworkList à partir de '{0}'. {1} '{2}' est non valide.</target>
+        <note>{StrBegin="NETSDK1051: "}</note>
       </trans-unit>
       <trans-unit id="ErrorParsingPlatformManifest">
         <source>NETSDK1043: Error parsing PlatformManifest from '{0}' line {1}.  Lines must have the format {2}.</source>
@@ -307,65 +202,55 @@
         <target state="translated">NETSDK1044: Erreur durant l'analyse de PlatformManifest à partir de la ligne '{0}' {1}. {2} '{3}' est non valide.</target>
         <note>{StrBegin="NETSDK1044: "}</note>
       </trans-unit>
-      <trans-unit id="UnsupportedTargetFrameworkVersion">
-        <source>NETSDK1045: The current .NET SDK does not support targeting {0} {1}.  Either target {0} {2} or lower, or use a version of the .NET SDK that supports {0} {1}.</source>
-        <target state="translated">NETSDK1045: Le kit .NET SDK actuel ne prend pas en charge le ciblage de {0} {1}. Vous devez soit cibler {0} {2} ou une version antérieure, soit utiliser une version du kit .NET SDK qui prend en charge {0} {1}.</target>
-        <note>{StrBegin="NETSDK1045: "}</note>
+      <trans-unit id="ErrorReadingAssetsFile">
+        <source>NETSDK1060: Error reading assets file: {0}</source>
+        <target state="translated">NETSDK1060: Erreur durant la lecture du fichier de composants : {0}</target>
+        <note>{StrBegin="NETSDK1060: "}</note>
       </trans-unit>
-      <trans-unit id="AssetsFileMissingRuntimeIdentifier">
-        <source>NETSDK1047: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project. You may also need to include '{3}' in your project's RuntimeIdentifiers.</source>
-        <target state="translated">NETSDK1047: Le fichier de composants '{0}' n'a aucune cible pour '{1}'. Vérifiez que la restauration s'est exécutée et que vous avez inclus '{2}' dans TargetFrameworks pour votre projet. Vous devrez peut-être également inclure '{3}' dans les RuntimeIdentifiers de votre projet.</target>
-        <note>{StrBegin="NETSDK1047: "}</note>
+      <trans-unit id="FailedToLockResource">
+        <source>NETSDK1077: Failed to lock resource.</source>
+        <target state="translated">NETSDK1077 : Échec du blocage de la ressource.</target>
+        <note>{StrBegin="NETSDK1077: "}</note>
       </trans-unit>
-      <trans-unit id="TargetFrameworkWithSemicolon">
-        <source>NETSDK1046: The TargetFramework value '{0}' is not valid. To multi-target, use the 'TargetFrameworks' property instead.</source>
-        <target state="translated">NETSDK1046: La valeur TargetFramework '{0}' est non valide. Pour effectuer un multiciblage, utilisez la propriété 'TargetFrameworks' à la place.</target>
-        <note>{StrBegin="NETSDK1046: "}</note>
+      <trans-unit id="FileNameIsTooLong">
+        <source>NETSDK1030: Given file name '{0}' is longer than 1024 bytes</source>
+        <target state="translated">NETSDK1030: Le nom de fichier spécifié '{0}' dépasse 1 024 octets</target>
+        <note>{StrBegin="NETSDK1030: "}</note>
       </trans-unit>
-      <trans-unit id="GetDependsOnNETStandardFailedWithException">
-        <source>NETSDK1049: Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0} {1}</source>
-        <target state="translated">NETSDK1049: Le fichier résolu a une image incorrecte, ne comporte pas de métadonnées ou n'est pas accessible. {0} {1}</target>
-        <note>{StrBegin="NETSDK1049: "}</note>
+      <trans-unit id="FolderAlreadyExists">
+        <source>NETSDK1024: Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</source>
+        <target state="translated">NETSDK1024: Le dossier '{0}' existe déjà. Supprimez-le ou indiquez un autre ComposeWorkingDir</target>
+        <note>{StrBegin="NETSDK1024: "}</note>
       </trans-unit>
-      <trans-unit id="UnsupportedSDKVersionForNetStandard20">
-        <source>NETSDK1050: The version of Microsoft.NET.Sdk used by this project is insufficient to support references to libraries targeting .NET Standard 1.5 or higher.  Please install version 2.0 or higher of the .NET Core SDK.</source>
-        <target state="translated">NETSDK1050: La version de Microsoft.NET.Sdk utilisée par ce projet ne permet pas de prendre en charge les références aux bibliothèques ciblant .NET Standard 1.5 ou une version ultérieure. Installez la version 2.0 ou une version ultérieure du kit SDK .NET Core.</target>
-        <note>{StrBegin="NETSDK1050: "}</note>
-      </trans-unit>
-      <trans-unit id="SkippingAdditionalProbingPaths">
-        <source>NETSDK1048: 'AdditionalProbingPaths' were specified for GenerateRuntimeConfigurationFiles, but are being skipped because 'RuntimeConfigDevPath' is empty.</source>
-        <target state="translated">NETSDK1048: Des 'AdditionalProbingPaths' ont été spécifiés pour GenerateRuntimeConfigurationFiles, mais ils sont ignorés, car 'RuntimeConfigDevPath' est vide.</target>
-        <note>{StrBegin="NETSDK1048: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotHaveRuntimeIdentifierPlatformMismatchPlatformTarget">
-        <source>NETSDK1032: The RuntimeIdentifier platform '{0}' and the PlatformTarget '{1}' must be compatible.</source>
-        <target state="translated">NETSDK1032: La plateforme de RuntimeIdentifier '{0}' et le PlatformTarget '{1}' doivent être compatibles.</target>
-        <note>{StrBegin="NETSDK1032: "}</note>
-      </trans-unit>
-      <trans-unit id="ErrorParsingFrameworkListInvalidValue">
-        <source>NETSDK1051: Error parsing FrameworkList from '{0}'.  {1} '{2}' was invalid.</source>
-        <target state="translated">NETSDK1051: Erreur durant l'analyse de FrameworkList à partir de '{0}'. {1} '{2}' est non valide.</target>
-        <note>{StrBegin="NETSDK1051: "}</note>
+      <trans-unit id="FrameworkDependentAppHostRequiresVersion21">
+        <source>NETSDK1068: The framework-dependent application host requires a target framework of at least 'netcoreapp2.1'.</source>
+        <target state="translated">NETSDK1068: L'hôte d'application dépendant du framework nécessite au minimum le framework cible 'netcoreapp2.1'.</target>
+        <note>{StrBegin="NETSDK1068: "}</note>
       </trans-unit>
       <trans-unit id="FrameworkListPathNotRooted">
         <source>NETSDK1052: Framework list file path '{0}' is not rooted. Only full paths are supported.</source>
         <target state="translated">NETSDK1052: Le chemin du fichier de liste de frameworks '{0}' n'est pas associé à une racine. Seuls les chemins complets sont pris en charge.</target>
         <note>{StrBegin="NETSDK1052: "}</note>
       </trans-unit>
-      <trans-unit id="PackAsToolCannotSupportSelfContained">
-        <source>NETSDK1053: Pack as tool does not support self contained.</source>
-        <target state="translated">NETSDK1053: L'outil de compression ne prend pas en charge l'autonomie.</target>
-        <note>{StrBegin="NETSDK1001: "}</note>
+      <trans-unit id="GetDependsOnNETStandardFailedWithException">
+        <source>NETSDK1049: Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0} {1}</source>
+        <target state="translated">NETSDK1049: Le fichier résolu a une image incorrecte, ne comporte pas de métadonnées ou n'est pas accessible. {0} {1}</target>
+        <note>{StrBegin="NETSDK1049: "}</note>
       </trans-unit>
-      <trans-unit id="UnsupportedRuntimeIdentifier">
-        <source>NETSDK1056: Project is targeting runtime '{0}' but did not resolve any runtime-specific packages. This runtime may not be supported by the target framework.</source>
-        <target state="translated">NETSDK1056: Le projet cible le runtime '{0}' mais n'a résolu aucun package spécifique au runtime. Ce runtime risque de ne pas être pris en charge par le framework cible.</target>
-        <note>{StrBegin="NETSDK1056: "}</note>
+      <trans-unit id="IncorrectPackageRoot">
+        <source>NETSDK1020: Package Root {0} was incorrectly given for Resolved library {1}</source>
+        <target state="translated">NETSDK1020: La racine de package {0} a été spécifiée de manière incorrecte pour la bibliothèque Resolved {1}</target>
+        <note>{StrBegin="NETSDK1020: "}</note>
       </trans-unit>
-      <trans-unit id="UsingPreviewSdkWarning">
-        <source>NETSDK1057: You are using a preview version of .NET Core. See: https://aka.ms/dotnet-core-preview</source>
-        <target state="translated">NETSDK1057 : Vous utilisez une préversion de .NET Core. Voir : https://aka.ms/dotnet-core-preview</target>
-        <note>{StrBegin="NETSDK1057: "}</note>
+      <trans-unit id="IncorrectTargetFormat">
+        <source>NETSDK1025: WRThe target manifest {0} provided is of not the correct format</source>
+        <target state="translated">NETSDK1025: Le manifeste cible {0} fourni n'est pas au format approprié</target>
+        <note>{StrBegin="NETSDK1025: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidFrameworkName">
+        <source>NETSDK1003: Invalid framework name: '{0}'.</source>
+        <target state="translated">NETSDK1003: Nom de framework non valide : '{0}'.</target>
+        <note>{StrBegin="NETSDK1003: "}</note>
       </trans-unit>
       <trans-unit id="InvalidItemSpecToUse">
         <source>NETSDK1058: Invalid value for ItemSpecToUse parameter: '{0}'.  This property must be blank or set to 'Left' or 'Right'</source>
@@ -373,15 +258,15 @@
         <note>{StrBegin="NETSDK1058: "}
 The following are names of parameters or literal values and should not be translated: ItemSpecToUse, Left, Right</note>
       </trans-unit>
-      <trans-unit id="ProjectContainsObsoleteDotNetCliTool">
-        <source>NETSDK1059: The tool '{0}' is now included in the .NET Core SDK. Information on resolving this warning is available at (https://aka.ms/dotnetclitools-in-box).</source>
-        <target state="translated">NETSDK1059: L'outil '{0}' est désormais inclus dans le kit SDK .NET Core. Des informations sur la résolution de cet avertissement sont disponibles en ligne (https://aka.ms/dotnetclitools-in-box).</target>
-        <note>{StrBegin="NETSDK1059: "}</note>
+      <trans-unit id="InvalidNuGetVersionString">
+        <source>NETSDK1018: Invalid NuGet version string: '{0}'.</source>
+        <target state="translated">NETSDK1018: Chaîne de version NuGet non valide : '{0}'.</target>
+        <note>{StrBegin="NETSDK1018: "}</note>
       </trans-unit>
-      <trans-unit id="ErrorReadingAssetsFile">
-        <source>NETSDK1060: Error reading assets file: {0}</source>
-        <target state="translated">NETSDK1060: Erreur durant la lecture du fichier de composants : {0}</target>
-        <note>{StrBegin="NETSDK1060: "}</note>
+      <trans-unit id="InvalidResourceUpdate">
+        <source>NETSDK1075: Update handle is invalid. This instance may not be used for further updates.</source>
+        <target state="translated">NETSDK1075 : Le handle de mise à jour n'est pas valide. Cette instance ne peut pas être utilisée pour d'autres mises à jour.</target>
+        <note>{StrBegin="NETSDK1075: "}</note>
       </trans-unit>
       <trans-unit id="MismatchedPlatformPackageVersion">
         <source>NETSDK1061: The project was restored using {0} version {1}, but with current settings, version {2} would be used instead. To resolve this issue, make sure the same settings are used for restore and for subsequent operations such as build or publish. Typically this issue can occur if the RuntimeIdentifier property is set during build or publish but not during restore. For more information, see https://aka.ms/dotnet-runtime-patch-selection.</source>
@@ -391,35 +276,150 @@ The following are names of parameters or literal values and should not be transl
 {1} - Restored version of platform package
 {2} - Current version of platform package</note>
       </trans-unit>
-      <trans-unit id="AssetsFileNotSet">
-        <source>NETSDK1063: The path to the project assets file was not set. Run a NuGet package restore to generate this file.</source>
-        <target state="translated">NETSDK1063: Le chemin du fichier de composants du projet n'a pas été défini. Exécutez une restauration de package NuGet pour générer ce fichier.</target>
-        <note>{StrBegin="NETSDK1063: "}</note>
+      <trans-unit id="MissingItemMetadata">
+        <source>NETSDK1008: Missing '{0}' metadata on '{1}' item '{2}'.</source>
+        <target state="translated">NETSDK1008: Métadonnées '{0}' manquantes sur l'élément '{1}' '{2}'.</target>
+        <note>{StrBegin="NETSDK1008: "}</note>
       </trans-unit>
-      <trans-unit id="DotnetToolOnlySupportNetcoreapp">
-        <source>NETSDK1054: only supports .NET Core.</source>
-        <target state="translated">NETSDK1054: prend uniquement en charge .NET Core.</target>
-        <note>{StrBegin="NETSDK1054: "}</note>
+      <trans-unit id="MultipleFilesResolved">
+        <source>NETSDK1021: More than one file found for {0}</source>
+        <target state="translated">NETSDK1021: Plusieurs fichiers ont été trouvés pour {0}</target>
+        <note>{StrBegin="NETSDK1021: "}</note>
       </trans-unit>
-      <trans-unit id="DotnetToolDoesNotSupportTFMLowerThanNetcoreapp21">
-        <source>NETSDK1055: DotnetTool does not support target framework lower than netcoreapp2.1.</source>
-        <target state="translated">NETSDK1055: DotnetTool ne prend pas en charge de framework cible inférieur à netcoreapp2.1.</target>
-        <note>{StrBegin="NETSDK1055: "}</note>
+      <trans-unit id="NETFrameworkToNonBuiltInNETStandard">
+        <source>NETSDK1069: This project uses a library that targets .NET Standard 1.5 or higher, and the project targets a version of .NET Framework that doesn't have built-in support for that version of .NET Standard. Visit https://aka.ms/net-standard-known-issues for a set of known issues. Consider retargeting to .NET Framework 4.7.2.</source>
+        <target state="translated">NETSDK1069: Ce projet utilise une bibliothèque qui cible .NET Standard 1.5 ou ultérieur, et le projet cible une version du .NET Framework qui n'intègre pas la prise en charge de cette version de .NET Standard. Pour obtenir la liste des problèmes connus, visitez https://aka.ms/net-standard-known-issues. Songez à cibler le .NET Framework 4.7.2.</target>
+        <note>{StrBegin="NETSDK1069: "}</note>
       </trans-unit>
-      <trans-unit id="UnableToUsePackageAssetsCache">
-        <source>NETSDK1062: Unable to use package assets cache due to I/O error. This can occur when the same project is built more than once in parallel. Performance may be degraded, but the build result will not be impacted.</source>
-        <target state="translated">NETSDK1062: Impossible d'utiliser le cache de composants du package en raison d'une erreur d'E/S. Cela peut se produire quand un même projet est généré plusieurs fois en parallèle. Les performances peuvent être impactées, mais pas le résultat de la génération.</target>
-        <note>{StrBegin="NETSDK1062: "}</note>
+      <trans-unit id="NoAppHostAvailable">
+        <source>NETSDK1084: There is no application host available for the specified RuntimeIdentifier '{0}'.</source>
+        <target state="new">NETSDK1084: There is no application host available for the specified RuntimeIdentifier '{0}'.</target>
+        <note>{StrBegin="NETSDK1084: "}</note>
+      </trans-unit>
+      <trans-unit id="NoCompatibleTargetFramework">
+        <source>NETSDK1002: Project '{0}' targets '{2}'. It cannot be referenced by a project that targets '{1}'.</source>
+        <target state="translated">NETSDK1002: Le projet '{0}' cible '{2}'. Il ne peut pas être référencé par un projet qui cible '{1}'.</target>
+        <note>{StrBegin="NETSDK1002: "}</note>
+      </trans-unit>
+      <trans-unit id="NoRuntimePackAvailable">
+        <source>NETSDK1082: There was no runtime pack for {0} available for the specified RuntimeIdentifier '{1}'.</source>
+        <target state="new">NETSDK1082: There was no runtime pack for {0} available for the specified RuntimeIdentifier '{1}'.</target>
+        <note>{StrBegin="NETSDK1082: "}</note>
+      </trans-unit>
+      <trans-unit id="PackAsToolCannotSupportSelfContained">
+        <source>NETSDK1053: Pack as tool does not support self contained.</source>
+        <target state="translated">NETSDK1053: L'outil de compression ne prend pas en charge l'autonomie.</target>
+        <note>{StrBegin="NETSDK1001: "}</note>
+      </trans-unit>
+      <trans-unit id="PackageInfoLog">
+        <source>NETSDK1027: Package Name='{0}', Version='{1}' was parsed</source>
+        <target state="translated">NETSDK1027: Le package ayant pour nom '{0}' et pour version '{1}' a été analysé</target>
+        <note>{StrBegin="NETSDK1027: "}</note>
       </trans-unit>
       <trans-unit id="PackageNotFound">
         <source>NETSDK1064: Package {0}, version {1} was not found. It might have been deleted since NuGet restore. Otherwise, NuGet restore might have only partially completed, which might have been due to maximum path length restrictions.</source>
         <target state="translated">NETSDK1064: Le package {0}, version {1}, est introuvable. Il a peut-être été supprimé depuis la restauration NuGet. Sinon, la restauration NuGet a peut-être été partiellement effectuée en raison de restrictions appliquées à la longueur maximale du chemin.</target>
         <note>{StrBegin="NETSDK1064: "}</note>
       </trans-unit>
-      <trans-unit id="CannotFindApphostForRid">
-        <source>NETSDK1065: Cannot find app host for {0}. {0} could be an invalid runtime identifier (RID). For more information about RID, see https://aka.ms/rid-catalog.</source>
-        <target state="translated">NETSDK1065: hôte d'application introuvable pour {0}. {0} est peut-être un RID (identificateur de runtime) non valide. Pour plus d'informations sur les RID, consultez https://aka.ms/rid-catalog.</target>
-        <note>{StrBegin="NETSDK1065: "}</note>
+      <trans-unit id="PackageReferenceOverrideWarning">
+        <source>NETSDK1023: A PackageReference for '{0}' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see {1}</source>
+        <target state="translated">NETSDK1023: Un PackageReference pour '{0}' a été inclus dans votre projet. Comme ce package est implicitement référencé par le kit .NET SDK, vous n'avez généralement pas besoin de le référencer à partir de votre projet. Pour plus d'informations, consultez {1}</target>
+        <note>{StrBegin="NETSDK1023: "}</note>
+      </trans-unit>
+      <trans-unit id="PackageReferenceVersionNotRecommended">
+        <source>NETSDK1071: A PackageReference to '{0}' specified a Version of `{1}`. Specifying the version of this package is not recommended. For more information, see https://aka.ms/sdkimplicitrefs</source>
+        <target state="translated">NETSDK1071 : Une référence de package vers '{0}' a spécifié une version '{1}'. Nous ne vous recommandons pas de spécifier la version de ce package. Pour plus d'informations, consultez https://aka.ms/sdkimplicitrefs</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParsingFiles">
+        <source>NETSDK1026: Parsing the Files : '{0}'</source>
+        <target state="translated">NETSDK1026: Analyse des fichiers : '{0}'</target>
+        <note>{StrBegin="NETSDK1026: "}</note>
+      </trans-unit>
+      <trans-unit id="ProjectAssetsConsumedWithoutMSBuildProjectPath">
+        <source>NETSDK1011: Assets are consumed from project '{0}', but no corresponding MSBuild project path was  found in '{1}'.</source>
+        <target state="translated">NETSDK1011: Les composants sont consommés à partir du projet '{0}', mais il n'existe aucun chemin de projet MSBuild correspondant dans '{1}'.</target>
+        <note>{StrBegin="NETSDK1011: "}</note>
+      </trans-unit>
+      <trans-unit id="ProjectContainsObsoleteDotNetCliTool">
+        <source>NETSDK1059: The tool '{0}' is now included in the .NET Core SDK. Information on resolving this warning is available at (https://aka.ms/dotnetclitools-in-box).</source>
+        <target state="translated">NETSDK1059: L'outil '{0}' est désormais inclus dans le kit SDK .NET Core. Des informations sur la résolution de cet avertissement sont disponibles en ligne (https://aka.ms/dotnetclitools-in-box).</target>
+        <note>{StrBegin="NETSDK1059: "}</note>
+      </trans-unit>
+      <trans-unit id="RuntimeIdentifierNotRecognized">
+        <source>NETSDK1083: The specified RuntimeIdentifier '{0}' is not recognized.</source>
+        <target state="new">NETSDK1083: The specified RuntimeIdentifier '{0}' is not recognized.</target>
+        <note>{StrBegin="NETSDK1083: "}</note>
+      </trans-unit>
+      <trans-unit id="RuntimeIdentifierWasNotSpecified">
+        <source>NETSDK1028: Specify a RuntimeIdentifier</source>
+        <target state="translated">NETSDK1028: Spécifiez un RuntimeIdentifier</target>
+        <note>{StrBegin="NETSDK1028: "}</note>
+      </trans-unit>
+      <trans-unit id="SkippingAdditionalProbingPaths">
+        <source>NETSDK1048: 'AdditionalProbingPaths' were specified for GenerateRuntimeConfigurationFiles, but are being skipped because 'RuntimeConfigDevPath' is empty.</source>
+        <target state="translated">NETSDK1048: Des 'AdditionalProbingPaths' ont été spécifiés pour GenerateRuntimeConfigurationFiles, mais ils sont ignorés, car 'RuntimeConfigDevPath' est vide.</target>
+        <note>{StrBegin="NETSDK1048: "}</note>
+      </trans-unit>
+      <trans-unit id="TargetFrameworkWithSemicolon">
+        <source>NETSDK1046: The TargetFramework value '{0}' is not valid. To multi-target, use the 'TargetFrameworks' property instead.</source>
+        <target state="translated">NETSDK1046: La valeur TargetFramework '{0}' est non valide. Pour effectuer un multiciblage, utilisez la propriété 'TargetFrameworks' à la place.</target>
+        <note>{StrBegin="NETSDK1046: "}</note>
+      </trans-unit>
+      <trans-unit id="UnableToFindResolvedPath">
+        <source>NETSDK1016: Unable to find resolved path for '{0}'.</source>
+        <target state="translated">NETSDK1016: Chemin résolu introuvable pour '{0}'.</target>
+        <note>{StrBegin="NETSDK1016: "}</note>
+      </trans-unit>
+      <trans-unit id="UnableToUsePackageAssetsCache">
+        <source>NETSDK1062: Unable to use package assets cache due to I/O error. This can occur when the same project is built more than once in parallel. Performance may be degraded, but the build result will not be impacted.</source>
+        <target state="translated">NETSDK1062: Impossible d'utiliser le cache de composants du package en raison d'une erreur d'E/S. Cela peut se produire quand un même projet est généré plusieurs fois en parallèle. Les performances peuvent être impactées, mais pas le résultat de la génération.</target>
+        <note>{StrBegin="NETSDK1062: "}</note>
+      </trans-unit>
+      <trans-unit id="UnexpectedFileType">
+        <source>NETSDK1012: Unexpected file type for '{0}'. Type is both '{1}' and '{2}'.</source>
+        <target state="translated">NETSDK1012: Type de fichier inattendu pour '{0}'. Le type est à la fois '{1}' et '{2}'.</target>
+        <note>{StrBegin="NETSDK1012: "}</note>
+      </trans-unit>
+      <trans-unit id="UnknownFrameworkReference">
+        <source>NETSDK1073: The FrameworkReference '{0}' was not recognized</source>
+        <target state="translated">NETSDK1073 : Référence de framework '{0}' non reconnue</target>
+        <note>{StrBegin="NETSDK1073: "}</note>
+      </trans-unit>
+      <trans-unit id="UnrecognizedPreprocessorToken">
+        <source>NETSDK1009: Unrecognized preprocessor token '{0}' in '{1}'.</source>
+        <target state="translated">NETSDK1009: Jeton de préprocesseur '{0}' non reconnu dans '{1}'.</target>
+        <note>{StrBegin="NETSDK1009: "}</note>
+      </trans-unit>
+      <trans-unit id="UnresolvedTargetingPack">
+        <source>NETSDK1081: The targeting pack for {0} was not found. You may be able to resolve this by running a NuGet restore on the project.</source>
+        <target state="new">NETSDK1081: The targeting pack for {0} was not found. You may be able to resolve this by running a NuGet restore on the project.</target>
+        <note>{StrBegin="NETSDK1081: "}</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedFramework">
+        <source>NETSDK1019: {0} is an unsupported framework.</source>
+        <target state="translated">NETSDK1019: {0} est un framework non pris en charge.</target>
+        <note>{StrBegin="NETSDK1019: "}</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedRuntimeIdentifier">
+        <source>NETSDK1056: Project is targeting runtime '{0}' but did not resolve any runtime-specific packages. This runtime may not be supported by the target framework.</source>
+        <target state="translated">NETSDK1056: Le projet cible le runtime '{0}' mais n'a résolu aucun package spécifique au runtime. Ce runtime risque de ne pas être pris en charge par le framework cible.</target>
+        <note>{StrBegin="NETSDK1056: "}</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedSDKVersionForNetStandard20">
+        <source>NETSDK1050: The version of Microsoft.NET.Sdk used by this project is insufficient to support references to libraries targeting .NET Standard 1.5 or higher.  Please install version 2.0 or higher of the .NET Core SDK.</source>
+        <target state="translated">NETSDK1050: La version de Microsoft.NET.Sdk utilisée par ce projet ne permet pas de prendre en charge les références aux bibliothèques ciblant .NET Standard 1.5 ou une version ultérieure. Installez la version 2.0 ou une version ultérieure du kit SDK .NET Core.</target>
+        <note>{StrBegin="NETSDK1050: "}</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedTargetFrameworkVersion">
+        <source>NETSDK1045: The current .NET SDK does not support targeting {0} {1}.  Either target {0} {2} or lower, or use a version of the .NET SDK that supports {0} {1}.</source>
+        <target state="translated">NETSDK1045: Le kit .NET SDK actuel ne prend pas en charge le ciblage de {0} {1}. Vous devez soit cibler {0} {2} ou une version antérieure, soit utiliser une version du kit .NET SDK qui prend en charge {0} {1}.</target>
+        <note>{StrBegin="NETSDK1045: "}</note>
+      </trans-unit>
+      <trans-unit id="UsingPreviewSdkWarning">
+        <source>NETSDK1057: You are using a preview version of .NET Core. See: https://aka.ms/dotnet-core-preview</source>
+        <target state="translated">NETSDK1057 : Vous utilisez une préversion de .NET Core. Voir : https://aka.ms/dotnet-core-preview</target>
+        <note>{StrBegin="NETSDK1057: "}</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Tasks/Common/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.it.xlf
@@ -2,35 +2,25 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../Strings.resx">
     <body>
-      <trans-unit id="AspNetCoreAllNotSupported">
-        <source>NETSDK1079: The Microsoft.AspNetCore.All package is not supported when targeting .NET Core 3.0 or higher.  A FrameworkReference to Microsoft.AspNetCore.App should be used instead, and will be implicitly included by Microsoft.NET.Sdk.Web.</source>
-        <target state="translated">NETSDK1079: il pacchetto Microsoft.AspNetCore.All non è supportato quando la destinazione è .NET Core 3.0 o versione successiva. È necessario un elemento FrameworkReference per Microsoft.AspNetCore.App, che verrà incluso in modo implicito da Microsoft.NET.Sdk.Web.</target>
-        <note>{StrBegin="NETSDK1079: "}</note>
-      </trans-unit>
-      <trans-unit id="AspNetCoreUsesFrameworkReference">
-        <source>NETSDK1080: A PackageReference to Microsoft.AspNetCore.App is not necessary when targeting .NET Core 3.0 or higher. If Microsoft.NET.Sdk.Web is used, the shared framework will be referenced automatically. Otherwise, the PackageReference should be replaced with a FrameworkReference.</source>
-        <target state="translated">NETSDK1080: un elemento PackageReference per Microsoft.AspNetCore.App non è necessario quando la destinazione è .NET Core 3.0 o versione successiva. Se si usa Microsoft.NET.Sdk.Web, il riferimento al framework condiviso verrà inserito automaticamente; in caso contrario, l'elemento PackageReference deve essere sostituito da un elemento FrameworkReference.</target>
-        <note>{StrBegin="NETSDK1080: "}</note>
-      </trans-unit>
-      <trans-unit id="FailedToLockResource">
-        <source>NETSDK1077: Failed to lock resource.</source>
-        <target state="translated">NETSDK1077: non è stato possibile bloccare la risorsa.</target>
-        <note>{StrBegin="NETSDK1077: "}</note>
-      </trans-unit>
       <trans-unit id="AddResourceWithNonIntegerResource">
         <source>NETSDK1076: AddResource can only be used with integer resource types.</source>
         <target state="translated">NETSDK1076: è possibile usare AddResource solo con tipi di risorsa integer.</target>
         <note>{StrBegin="NETSDK1076: "}</note>
       </trans-unit>
-      <trans-unit id="InvalidResourceUpdate">
-        <source>NETSDK1075: Update handle is invalid. This instance may not be used for further updates.</source>
-        <target state="translated">NETSDK1075: il punto di controllo dell'aggiornamento non è valido. Non è possibile usare questa istanza per ulteriori aggiornamenti.</target>
-        <note>{StrBegin="NETSDK1075: "}</note>
+      <trans-unit id="AppConfigRequiresRootConfiguration">
+        <source>NETSDK1070: The application configuration file must have root configuration element.</source>
+        <target state="translated">NETSDK1070: il file di configurazione dell'applicazione deve avere un elemento di configurazione radice.</target>
+        <note>{StrBegin="NETSDK1070: "}</note>
       </trans-unit>
       <trans-unit id="AppHostCustomizationRequiresWindowsHostWarning">
         <source>NETSDK1074: The application host executable will not be customized because adding resources requires that the build be performed on Windows (excluding Nano Server).</source>
         <target state="translated">NETSDK1074: l'eseguibile dell'host applicazione non verrà personalizzato perché per aggiungere risorse è necessario eseguire la compilazione in Windows (escluso Nano Server).</target>
         <note>{StrBegin="NETSDK1074: "}</note>
+      </trans-unit>
+      <trans-unit id="AppHostHasBeenModified">
+        <source>NETSDK1029: Unable to use '{0}' as application host executable as it does not contain the expected placeholder byte sequence '{1}' that would mark where the application name would be written.</source>
+        <target state="translated">NETSDK1029: non è possibile usare '{0}' come eseguibile host dell'applicazione perché non contiene la sequenza di byte segnaposto prevista '{1}' che indica dove verrà scritto il nome dell'applicazione.</target>
+        <note>{StrBegin="NETSDK1029: "}</note>
       </trans-unit>
       <trans-unit id="AppHostNotWindows">
         <source>NETSDK1078: Unable to use '{0}' as application host executable because it's not a Windows PE file.</source>
@@ -42,210 +32,80 @@
         <target state="translated">NETSDK1072: non è possibile usare '{0}' come eseguibile dell'host applicazione perché non è un eseguibile Windows per il sottosistema CUI (Console).</target>
         <note>{StrBegin="NETSDK1072: "}</note>
       </trans-unit>
-      <trans-unit id="AppConfigRequiresRootConfiguration">
-        <source>NETSDK1070: The application configuration file must have root configuration element.</source>
-        <target state="translated">NETSDK1070: il file di configurazione dell'applicazione deve avere un elemento di configurazione radice.</target>
-        <note>{StrBegin="NETSDK1070: "}</note>
+      <trans-unit id="AspNetCoreAllNotSupported">
+        <source>NETSDK1079: The Microsoft.AspNetCore.All package is not supported when targeting .NET Core 3.0 or higher.  A FrameworkReference to Microsoft.AspNetCore.App should be used instead, and will be implicitly included by Microsoft.NET.Sdk.Web.</source>
+        <target state="translated">NETSDK1079: il pacchetto Microsoft.AspNetCore.All non è supportato quando la destinazione è .NET Core 3.0 o versione successiva. È necessario un elemento FrameworkReference per Microsoft.AspNetCore.App, che verrà incluso in modo implicito da Microsoft.NET.Sdk.Web.</target>
+        <note>{StrBegin="NETSDK1079: "}</note>
       </trans-unit>
-      <trans-unit id="AtLeastOneTargetFrameworkMustBeSpecified">
-        <source>NETSDK1001: At least one possible target framework must be specified.</source>
-        <target state="translated">NETSDK1001: è necessario specificare almeno un framework di destinazione possibile.</target>
-        <note>{StrBegin="NETSDK1001: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotUseSelfContainedWithoutAppHost">
-        <source>NETSDK1067: Self-contained applications are required to use the application host. Either set SelfContained to false or set UseAppHost to true.</source>
-        <target state="translated">NETSDK1067: con le applicazioni complete è necessario usare l'host applicazione. Impostare SelfContained su false o UseAppHost su true.</target>
-        <note>{StrBegin="NETSDK1067: "}</note>
-      </trans-unit>
-      <trans-unit id="FrameworkDependentAppHostRequiresVersion21">
-        <source>NETSDK1068: The framework-dependent application host requires a target framework of at least 'netcoreapp2.1'.</source>
-        <target state="translated">NETSDK1068: con l'host applicazione dipendente dal framework il framework di destinazione deve essere impostato almeno su 'netcoreapp2.1'.</target>
-        <note>{StrBegin="NETSDK1068: "}</note>
-      </trans-unit>
-      <trans-unit id="NETFrameworkToNonBuiltInNETStandard">
-        <source>NETSDK1069: This project uses a library that targets .NET Standard 1.5 or higher, and the project targets a version of .NET Framework that doesn't have built-in support for that version of .NET Standard. Visit https://aka.ms/net-standard-known-issues for a set of known issues. Consider retargeting to .NET Framework 4.7.2.</source>
-        <target state="translated">NETSDK1069: questo progetto usa una libreria destinata a .NET Standard 1.5 o versione successiva ed è destinato a una versione di .NET Framework che non include il supporto predefinito per tale versione di .NET Standard. Per un serie di problemi noti, visitare https://aka.ms/net-standard-known-issues. Provare a impostare come destinazione .NET Framework 4.7.2.</target>
-        <note>{StrBegin="NETSDK1069: "}</note>
-      </trans-unit>
-      <trans-unit id="NoAppHostAvailable">
-        <source>NETSDK1084: There is no application host available for the specified RuntimeIdentifier '{0}'.</source>
-        <target state="new">NETSDK1084: There is no application host available for the specified RuntimeIdentifier '{0}'.</target>
-        <note>{StrBegin="NETSDK1084: "}</note>
-      </trans-unit>
-      <trans-unit id="NoCompatibleTargetFramework">
-        <source>NETSDK1002: Project '{0}' targets '{2}'. It cannot be referenced by a project that targets '{1}'.</source>
-        <target state="translated">NETSDK1002: il progetto '{0}' è destinato a '{2}'. Non può essere usato come riferimento in un progetto destinato a '{1}'.</target>
-        <note>{StrBegin="NETSDK1002: "}</note>
-      </trans-unit>
-      <trans-unit id="InvalidFrameworkName">
-        <source>NETSDK1003: Invalid framework name: '{0}'.</source>
-        <target state="translated">NETSDK1003: nome di framework non valido: '{0}'.</target>
-        <note>{StrBegin="NETSDK1003: "}</note>
-      </trans-unit>
-      <trans-unit id="AssetsFileNotFound">
-        <source>NETSDK1004: Assets file '{0}' not found. Run a NuGet package restore to generate this file.</source>
-        <target state="translated">NETSDK1004: il file di risorse '{0}' non è stato trovato. Per generare questo file, eseguire un ripristino del pacchetto NuGet.</target>
-        <note>{StrBegin="NETSDK1004: "}</note>
-      </trans-unit>
-      <trans-unit id="AssetsFileMissingTarget">
-        <source>NETSDK1005: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project.</source>
-        <target state="translated">NETSDK1005: il file di risorse '{0}' non contiene una destinazione per '{1}'. Assicurarsi che il ripristino sia stato eseguito e che '{2}' sia stato incluso negli elementi TargetFramework del progetto.</target>
-        <note>{StrBegin="NETSDK1005: "}</note>
-      </trans-unit>
-      <trans-unit id="AssetsFilePathNotRooted">
-        <source>NETSDK1006: Assets file path '{0}' is not rooted. Only full paths are supported.</source>
-        <target state="translated">NETSDK1006: il percorso dei file di risorse '{0}' non contiene una radice. Sono supportati solo percorsi completi.</target>
-        <note>{StrBegin="NETSDK1006: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotFindProjectInfo">
-        <source>NETSDK1007: Cannot find project info for '{0}'. This can indicate a missing project reference.</source>
-        <target state="translated">NETSDK1007: le informazioni del progetto per '{0}' non sono state trovate. Questo errore può indicare la mancanza di un riferimento al progetto.</target>
-        <note>{StrBegin="NETSDK1007: "}</note>
-      </trans-unit>
-      <trans-unit id="MissingItemMetadata">
-        <source>NETSDK1008: Missing '{0}' metadata on '{1}' item '{2}'.</source>
-        <target state="translated">NETSDK1008: mancano i metadati di '{0}' sull'elemento '{2}' di '{1}'.</target>
-        <note>{StrBegin="NETSDK1008: "}</note>
-      </trans-unit>
-      <trans-unit id="NoRuntimePackAvailable">
-        <source>NETSDK1082: There was no runtime pack for {0} available for the specified RuntimeIdentifier '{1}'.</source>
-        <target state="new">NETSDK1082: There was no runtime pack for {0} available for the specified RuntimeIdentifier '{1}'.</target>
-        <note>{StrBegin="NETSDK1082: "}</note>
-      </trans-unit>
-      <trans-unit id="PackageReferenceVersionNotRecommended">
-        <source>NETSDK1071: A PackageReference to '{0}' specified a Version of `{1}`. Specifying the version of this package is not recommended. For more information, see https://aka.ms/sdkimplicitrefs</source>
-        <target state="translated">NETSDK1071: in un elemento PackageReference che fa riferimento a '{0}' è specificata la versione di `{1}`. È consigliabile non specificare la versione di questo pacchetto. Per altre informazioni, vedere https://aka.ms/sdkimplicitrefs</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="RuntimeIdentifierNotRecognized">
-        <source>NETSDK1083: The specified RuntimeIdentifier '{0}' is not recognized.</source>
-        <target state="new">NETSDK1083: The specified RuntimeIdentifier '{0}' is not recognized.</target>
-        <note>{StrBegin="NETSDK1083: "}</note>
-      </trans-unit>
-      <trans-unit id="UnknownFrameworkReference">
-        <source>NETSDK1073: The FrameworkReference '{0}' was not recognized</source>
-        <target state="translated">NETSDK1073: l'elemento FrameworkReference '{0}' non è stato riconosciuto</target>
-        <note>{StrBegin="NETSDK1073: "}</note>
-      </trans-unit>
-      <trans-unit id="UnrecognizedPreprocessorToken">
-        <source>NETSDK1009: Unrecognized preprocessor token '{0}' in '{1}'.</source>
-        <target state="translated">NETSDK1009: token di preprocessore '{0}' non riconosciuto in '{1}'.</target>
-        <note>{StrBegin="NETSDK1009: "}</note>
-      </trans-unit>
-      <trans-unit id="ContentPreproccessorParameterRequired">
-        <source>NETSDK1010: The '{0}' task must be given a value for parameter '{1}' in order to consume preprocessed content.</source>
-        <target state="translated">NETSDK1010: per poter utilizzare il contenuto pre-elaborato, è necessario assegnare un valore per il parametro '{1}' nell'attività '{0}'.</target>
-        <note>{StrBegin="NETSDK1010: "}</note>
-      </trans-unit>
-      <trans-unit id="ProjectAssetsConsumedWithoutMSBuildProjectPath">
-        <source>NETSDK1011: Assets are consumed from project '{0}', but no corresponding MSBuild project path was  found in '{1}'.</source>
-        <target state="translated">NETSDK1011: le risorse vengono utilizzate dal progetto '{0}', ma non è stato trovato alcun percorso di progetto MSBuild corrispondente in '{1}'.</target>
-        <note>{StrBegin="NETSDK1011: "}</note>
-      </trans-unit>
-      <trans-unit id="UnexpectedFileType">
-        <source>NETSDK1012: Unexpected file type for '{0}'. Type is both '{1}' and '{2}'.</source>
-        <target state="translated">NETSDK1012: tipo di file imprevisto per '{0}'. Il tipo è sia '{1}' che '{2}'.</target>
-        <note>{StrBegin="NETSDK1012: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotInferTargetFrameworkIdentifierAndVersion">
-        <source>NETSDK1013: The TargetFramework value '{0}' was not recognized. It may be misspelled. If not, then the TargetFrameworkIdentifier and/or TargetFrameworkVersion properties must be specified explicitly.</source>
-        <target state="translated">NETSDK1013: il valore {0}' di TargetFramework non è stato riconosciuto. È possibile che sia stato digitato in modo errato. In caso contrario, le proprietà TargetFrameworkIdentifier e/o TargetFrameworkVersion devono essere specificate in modo esplicito.</target>
-        <note>{StrBegin="NETSDK1013: "}</note>
-      </trans-unit>
-      <trans-unit id="ContentItemDoesNotProvideOutputPath">
-        <source>NETSDK1014: Content item for '{0}' sets '{1}', but does not provide  '{2}' or '{3}'.</source>
-        <target state="translated">NETSDK1014: l'elemento di contenuto per '{0}' imposta '{1}', ma non fornisce '{2}' o '{3}'.</target>
-        <note>{StrBegin="NETSDK1014: "}</note>
-      </trans-unit>
-      <trans-unit id="DuplicatePreprocessorToken">
-        <source>NETSDK1015: The preprocessor token '{0}' has been given more than one value. Choosing '{1}' as the value.</source>
-        <target state="translated">NETSDK1015: al token di preprocessore '{0}' è stato assegnato più di un valore. Come valore verrà scelto '{1}'.</target>
-        <note>{StrBegin="NETSDK1015: "}</note>
-      </trans-unit>
-      <trans-unit id="UnableToFindResolvedPath">
-        <source>NETSDK1016: Unable to find resolved path for '{0}'.</source>
-        <target state="translated">NETSDK1016: il percorso risolto per '{0}' non è stato trovato.</target>
-        <note>{StrBegin="NETSDK1016: "}</note>
+      <trans-unit id="AspNetCoreUsesFrameworkReference">
+        <source>NETSDK1080: A PackageReference to Microsoft.AspNetCore.App is not necessary when targeting .NET Core 3.0 or higher. If Microsoft.NET.Sdk.Web is used, the shared framework will be referenced automatically. Otherwise, the PackageReference should be replaced with a FrameworkReference.</source>
+        <target state="translated">NETSDK1080: un elemento PackageReference per Microsoft.AspNetCore.App non è necessario quando la destinazione è .NET Core 3.0 o versione successiva. Se si usa Microsoft.NET.Sdk.Web, il riferimento al framework condiviso verrà inserito automaticamente; in caso contrario, l'elemento PackageReference deve essere sostituito da un elemento FrameworkReference.</target>
+        <note>{StrBegin="NETSDK1080: "}</note>
       </trans-unit>
       <trans-unit id="AssetPreprocessorMustBeConfigured">
         <source>NETSDK1017: Asset preprocessor must be configured before assets are processed.</source>
         <target state="translated">NETSDK1017: prima di elaborare le risorse, è necessario configurare il preprocessore di risorse.</target>
         <note>{StrBegin="NETSDK1017: "}</note>
       </trans-unit>
-      <trans-unit id="InvalidNuGetVersionString">
-        <source>NETSDK1018: Invalid NuGet version string: '{0}'.</source>
-        <target state="translated">NETSDK1018: la stringa di versione '{0}' di NuGet non è valida.</target>
-        <note>{StrBegin="NETSDK1018: "}</note>
+      <trans-unit id="AssetsFileMissingRuntimeIdentifier">
+        <source>NETSDK1047: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project. You may also need to include '{3}' in your project's RuntimeIdentifiers.</source>
+        <target state="translated">NETSDK1047: il file di risorse '{0}' non contiene una destinazione per '{1}'. Assicurarsi che il ripristino sia stato eseguito e che '{2}' sia stato incluso negli elementi TargetFramework del progetto. Potrebbe anche essere necessario includere '{3}' negli elementi RuntimeIdentifier del progetto.</target>
+        <note>{StrBegin="NETSDK1047: "}</note>
       </trans-unit>
-      <trans-unit id="UnresolvedTargetingPack">
-        <source>NETSDK1081: The targeting pack for {0} was not found. You may be able to resolve this by running a NuGet restore on the project.</source>
-        <target state="new">NETSDK1081: The targeting pack for {0} was not found. You may be able to resolve this by running a NuGet restore on the project.</target>
-        <note>{StrBegin="NETSDK1081: "}</note>
+      <trans-unit id="AssetsFileMissingTarget">
+        <source>NETSDK1005: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project.</source>
+        <target state="translated">NETSDK1005: il file di risorse '{0}' non contiene una destinazione per '{1}'. Assicurarsi che il ripristino sia stato eseguito e che '{2}' sia stato incluso negli elementi TargetFramework del progetto.</target>
+        <note>{StrBegin="NETSDK1005: "}</note>
       </trans-unit>
-      <trans-unit id="UnsupportedFramework">
-        <source>NETSDK1019: {0} is an unsupported framework.</source>
-        <target state="translated">NETSDK1019: {0} è un framework non supportato.</target>
-        <note>{StrBegin="NETSDK1019: "}</note>
+      <trans-unit id="AssetsFileNotFound">
+        <source>NETSDK1004: Assets file '{0}' not found. Run a NuGet package restore to generate this file.</source>
+        <target state="translated">NETSDK1004: il file di risorse '{0}' non è stato trovato. Per generare questo file, eseguire un ripristino del pacchetto NuGet.</target>
+        <note>{StrBegin="NETSDK1004: "}</note>
       </trans-unit>
-      <trans-unit id="DuplicateItemsError">
-        <source>NETSDK1022: Duplicate '{0}' items were included. The .NET SDK includes '{0}' items from your project directory by default. You can either remove these items from your project file, or set the '{1}' property to '{2}' if you want to explicitly include them in your project file. For more information, see {4}. The duplicate items were: {3}</source>
-        <target state="translated">NETSDK1022: sono stati inclusi '{0}' elementi duplicati. Per impostazione predefinita, .NET SDK include '{0}' elementi della directory del progetto. È possibile rimuovere tali elementi dal file di progetto oppure impostare la proprietà '{1}' su '{2}' se si vuole includerli implicitamente nel file di progetto. Per altre informazioni, vedere {4}. Gli elementi duplicati sono: {3}</target>
-        <note>{StrBegin="NETSDK1022: "}</note>
+      <trans-unit id="AssetsFileNotSet">
+        <source>NETSDK1063: The path to the project assets file was not set. Run a NuGet package restore to generate this file.</source>
+        <target state="translated">NETSDK1063: il percorso del file di risorse del progetto non è stato impostato. Per generare questo file, eseguire un ripristino del pacchetto NuGet.</target>
+        <note>{StrBegin="NETSDK1063: "}</note>
       </trans-unit>
-      <trans-unit id="PackageReferenceOverrideWarning">
-        <source>NETSDK1023: A PackageReference for '{0}' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see {1}</source>
-        <target state="translated">NETSDK1023: nel progetto è stato incluso un riferimento al pacchetto per '{0}'. Questo pacchetto viene usato come riferimento implicito da .NET SDK e non è in genere necessario farvi riferimento dal progetto. Per altre informazioni, vedere {1}</target>
-        <note>{StrBegin="NETSDK1023: "}</note>
+      <trans-unit id="AssetsFilePathNotRooted">
+        <source>NETSDK1006: Assets file path '{0}' is not rooted. Only full paths are supported.</source>
+        <target state="translated">NETSDK1006: il percorso dei file di risorse '{0}' non contiene una radice. Sono supportati solo percorsi completi.</target>
+        <note>{StrBegin="NETSDK1006: "}</note>
       </trans-unit>
-      <trans-unit id="IncorrectPackageRoot">
-        <source>NETSDK1020: Package Root {0} was incorrectly given for Resolved library {1}</source>
-        <target state="translated">NETSDK1020: la radice {0} del pacchetto specificata per la libreria risolta {1} non è corretta</target>
-        <note>{StrBegin="NETSDK1020: "}</note>
+      <trans-unit id="AtLeastOneTargetFrameworkMustBeSpecified">
+        <source>NETSDK1001: At least one possible target framework must be specified.</source>
+        <target state="translated">NETSDK1001: è necessario specificare almeno un framework di destinazione possibile.</target>
+        <note>{StrBegin="NETSDK1001: "}</note>
       </trans-unit>
-      <trans-unit id="MultipleFilesResolved">
-        <source>NETSDK1021: More than one file found for {0}</source>
-        <target state="translated">NETSDK1021: è stato trovato più di un file per {0}</target>
-        <note>{StrBegin="NETSDK1021: "}</note>
+      <trans-unit id="CannotFindApphostForRid">
+        <source>NETSDK1065: Cannot find app host for {0}. {0} could be an invalid runtime identifier (RID). For more information about RID, see https://aka.ms/rid-catalog.</source>
+        <target state="translated">NETSDK1065: non è possibile trovare l'host delle app per {0}. {0} potrebbe essere un identificatore di runtime (RID) non valido. Per altre informazioni sul RID, vedere https://aka.ms/rid-catalog.</target>
+        <note>{StrBegin="NETSDK1065: "}</note>
       </trans-unit>
-      <trans-unit id="FolderAlreadyExists">
-        <source>NETSDK1024: Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</source>
-        <target state="translated">NETSDK1024: la cartella '{0}' esiste già. Eliminarla o specificare un elemento ComposeWorkingDir diverso</target>
-        <note>{StrBegin="NETSDK1024: "}</note>
+      <trans-unit id="CannotFindProjectInfo">
+        <source>NETSDK1007: Cannot find project info for '{0}'. This can indicate a missing project reference.</source>
+        <target state="translated">NETSDK1007: le informazioni del progetto per '{0}' non sono state trovate. Questo errore può indicare la mancanza di un riferimento al progetto.</target>
+        <note>{StrBegin="NETSDK1007: "}</note>
       </trans-unit>
-      <trans-unit id="ParsingFiles">
-        <source>NETSDK1026: Parsing the Files : '{0}'</source>
-        <target state="translated">NETSDK1026: analisi dei file: '{0}'</target>
-        <note>{StrBegin="NETSDK1026: "}</note>
-      </trans-unit>
-      <trans-unit id="PackageInfoLog">
-        <source>NETSDK1027: Package Name='{0}', Version='{1}' was parsed</source>
-        <target state="translated">NETSDK1027: è stato analizzato il pacchetto con nome '{0}' e versione '{1}'</target>
-        <note>{StrBegin="NETSDK1027: "}</note>
-      </trans-unit>
-      <trans-unit id="RuntimeIdentifierWasNotSpecified">
-        <source>NETSDK1028: Specify a RuntimeIdentifier</source>
-        <target state="translated">NETSDK1028: specificare un elemento RuntimeIdentifier</target>
-        <note>{StrBegin="NETSDK1028: "}</note>
-      </trans-unit>
-      <trans-unit id="IncorrectTargetFormat">
-        <source>NETSDK1025: WRThe target manifest {0} provided is of not the correct format</source>
-        <target state="translated">NETSDK1025: il formato del manifesto di destinazione specificato {0} non è corretto</target>
-        <note>{StrBegin="NETSDK1025: "}</note>
-      </trans-unit>
-      <trans-unit id="AppHostHasBeenModified">
-        <source>NETSDK1029: Unable to use '{0}' as application host executable as it does not contain the expected placeholder byte sequence '{1}' that would mark where the application name would be written.</source>
-        <target state="translated">NETSDK1029: non è possibile usare '{0}' come eseguibile host dell'applicazione perché non contiene la sequenza di byte segnaposto prevista '{1}' che indica dove verrà scritto il nome dell'applicazione.</target>
-        <note>{StrBegin="NETSDK1029: "}</note>
-      </trans-unit>
-      <trans-unit id="FileNameIsTooLong">
-        <source>NETSDK1030: Given file name '{0}' is longer than 1024 bytes</source>
-        <target state="translated">NETSDK1030: il nome file specificato '{0}' supera 1024 byte</target>
-        <note>{StrBegin="NETSDK1030: "}</note>
+      <trans-unit id="CannotHaveRuntimeIdentifierPlatformMismatchPlatformTarget">
+        <source>NETSDK1032: The RuntimeIdentifier platform '{0}' and the PlatformTarget '{1}' must be compatible.</source>
+        <target state="translated">NETSDK1032: la piattaforma '{0}' di RuntimeIdentifier e quella '{1}' di PlatformTarget devono essere compatibili.</target>
+        <note>{StrBegin="NETSDK1032: "}</note>
       </trans-unit>
       <trans-unit id="CannotHaveSelfContainedWithoutRuntimeIdentifier">
         <source>NETSDK1031: It is not supported to build or publish a self-contained application without specifying a RuntimeIdentifier.  Please either specify a RuntimeIdentifier or set SelfContained to false.</source>
         <target state="translated">NETSDK1031: non è possibile compilare o pubblicare un'applicazione indipendente senza specificare un elemento RuntimeIdentifier. Specificare un elemento RuntimeIdentifier o impostare SelfContained su false.</target>
         <note>{StrBegin="NETSDK1031: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotInferTargetFrameworkIdentifierAndVersion">
+        <source>NETSDK1013: The TargetFramework value '{0}' was not recognized. It may be misspelled. If not, then the TargetFrameworkIdentifier and/or TargetFrameworkVersion properties must be specified explicitly.</source>
+        <target state="translated">NETSDK1013: il valore {0}' di TargetFramework non è stato riconosciuto. È possibile che sia stato digitato in modo errato. In caso contrario, le proprietà TargetFrameworkIdentifier e/o TargetFrameworkVersion devono essere specificate in modo esplicito.</target>
+        <note>{StrBegin="NETSDK1013: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotUseSelfContainedWithoutAppHost">
+        <source>NETSDK1067: Self-contained applications are required to use the application host. Either set SelfContained to false or set UseAppHost to true.</source>
+        <target state="translated">NETSDK1067: con le applicazioni complete è necessario usare l'host applicazione. Impostare SelfContained su false o UseAppHost su true.</target>
+        <note>{StrBegin="NETSDK1067: "}</note>
       </trans-unit>
       <trans-unit id="ChoosingAssemblyVersion">
         <source>NETSDK1033: Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</source>
@@ -272,6 +132,16 @@
         <target state="translated">NETSDK1037: non è stato possibile determinare la versione da usare perché le versioni dell'assembly e del file sono uguali.</target>
         <note>{StrBegin="NETSDK1037: "}</note>
       </trans-unit>
+      <trans-unit id="ContentItemDoesNotProvideOutputPath">
+        <source>NETSDK1014: Content item for '{0}' sets '{1}', but does not provide  '{2}' or '{3}'.</source>
+        <target state="translated">NETSDK1014: l'elemento di contenuto per '{0}' imposta '{1}', ma non fornisce '{2}' o '{3}'.</target>
+        <note>{StrBegin="NETSDK1014: "}</note>
+      </trans-unit>
+      <trans-unit id="ContentPreproccessorParameterRequired">
+        <source>NETSDK1010: The '{0}' task must be given a value for parameter '{1}' in order to consume preprocessed content.</source>
+        <target state="translated">NETSDK1010: per poter utilizzare il contenuto pre-elaborato, è necessario assegnare un valore per il parametro '{1}' nell'attività '{0}'.</target>
+        <note>{StrBegin="NETSDK1010: "}</note>
+      </trans-unit>
       <trans-unit id="CouldNotDetermineWinner_DoesntExist">
         <source>NETSDK1038: Could not determine winner because '{0}' does not exist.</source>
         <target state="translated">NETSDK1038: non è stato possibile determinare la versione da usare perché '{0}' non esiste.</target>
@@ -287,15 +157,40 @@
         <target state="translated">NETSDK1040: non è stato possibile determinare la versione da usare perché '{0}' non è un assembly.</target>
         <note>{StrBegin="NETSDK1040: "}</note>
       </trans-unit>
+      <trans-unit id="CouldNotLoadPlatformManifest">
+        <source>NETSDK1042: Could not load PlatformManifest from '{0}' because it did not exist.</source>
+        <target state="translated">NETSDK1042: non è stato possibile caricare PlatformManifest da '{0}' perché non esiste.</target>
+        <note>{StrBegin="NETSDK1042: "}</note>
+      </trans-unit>
+      <trans-unit id="DotnetToolDoesNotSupportTFMLowerThanNetcoreapp21">
+        <source>NETSDK1055: DotnetTool does not support target framework lower than netcoreapp2.1.</source>
+        <target state="translated">NETSDK1055: DotnetTool non supporta framework di destinazione di versioni precedenti a netcoreapp2.1.</target>
+        <note>{StrBegin="NETSDK1055: "}</note>
+      </trans-unit>
+      <trans-unit id="DotnetToolOnlySupportNetcoreapp">
+        <source>NETSDK1054: only supports .NET Core.</source>
+        <target state="translated">NETSDK1054: supporta solo .NET Core.</target>
+        <note>{StrBegin="NETSDK1054: "}</note>
+      </trans-unit>
+      <trans-unit id="DuplicateItemsError">
+        <source>NETSDK1022: Duplicate '{0}' items were included. The .NET SDK includes '{0}' items from your project directory by default. You can either remove these items from your project file, or set the '{1}' property to '{2}' if you want to explicitly include them in your project file. For more information, see {4}. The duplicate items were: {3}</source>
+        <target state="translated">NETSDK1022: sono stati inclusi '{0}' elementi duplicati. Per impostazione predefinita, .NET SDK include '{0}' elementi della directory del progetto. È possibile rimuovere tali elementi dal file di progetto oppure impostare la proprietà '{1}' su '{2}' se si vuole includerli implicitamente nel file di progetto. Per altre informazioni, vedere {4}. Gli elementi duplicati sono: {3}</target>
+        <note>{StrBegin="NETSDK1022: "}</note>
+      </trans-unit>
+      <trans-unit id="DuplicatePreprocessorToken">
+        <source>NETSDK1015: The preprocessor token '{0}' has been given more than one value. Choosing '{1}' as the value.</source>
+        <target state="translated">NETSDK1015: al token di preprocessore '{0}' è stato assegnato più di un valore. Come valore verrà scelto '{1}'.</target>
+        <note>{StrBegin="NETSDK1015: "}</note>
+      </trans-unit>
       <trans-unit id="EncounteredConflict">
         <source>NETSDK1041: Encountered conflict between '{0}' and '{1}'.</source>
         <target state="translated">NETSDK1041: è stato rilevato un conflitto tra '{0}' e '{1}'.</target>
         <note>{StrBegin="NETSDK1041: "}</note>
       </trans-unit>
-      <trans-unit id="CouldNotLoadPlatformManifest">
-        <source>NETSDK1042: Could not load PlatformManifest from '{0}' because it did not exist.</source>
-        <target state="translated">NETSDK1042: non è stato possibile caricare PlatformManifest da '{0}' perché non esiste.</target>
-        <note>{StrBegin="NETSDK1042: "}</note>
+      <trans-unit id="ErrorParsingFrameworkListInvalidValue">
+        <source>NETSDK1051: Error parsing FrameworkList from '{0}'.  {1} '{2}' was invalid.</source>
+        <target state="translated">NETSDK1051: si è verificato un errore durante l'analisi di FrameworkList da '{0}'. {1} '{2}' non è valido.</target>
+        <note>{StrBegin="NETSDK1051: "}</note>
       </trans-unit>
       <trans-unit id="ErrorParsingPlatformManifest">
         <source>NETSDK1043: Error parsing PlatformManifest from '{0}' line {1}.  Lines must have the format {2}.</source>
@@ -307,65 +202,55 @@
         <target state="translated">NETSDK1044: si è verificato un errore durante l'analisi di PlatformManifest da '{0}' a riga {1}. Il valore {2} '{3}' non è valido.</target>
         <note>{StrBegin="NETSDK1044: "}</note>
       </trans-unit>
-      <trans-unit id="UnsupportedTargetFrameworkVersion">
-        <source>NETSDK1045: The current .NET SDK does not support targeting {0} {1}.  Either target {0} {2} or lower, or use a version of the .NET SDK that supports {0} {1}.</source>
-        <target state="translated">NETSDK1045: la versione corrente di .NET SDK non supporta {0} {1} come destinazione. Impostare come destinazione {0} {2} o una versione precedente oppure usare una versione di .NET SDK che supporta {0} {1}.</target>
-        <note>{StrBegin="NETSDK1045: "}</note>
+      <trans-unit id="ErrorReadingAssetsFile">
+        <source>NETSDK1060: Error reading assets file: {0}</source>
+        <target state="translated">NETSDK1060: errore durante la lettura del file di asset: {0}</target>
+        <note>{StrBegin="NETSDK1060: "}</note>
       </trans-unit>
-      <trans-unit id="AssetsFileMissingRuntimeIdentifier">
-        <source>NETSDK1047: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project. You may also need to include '{3}' in your project's RuntimeIdentifiers.</source>
-        <target state="translated">NETSDK1047: il file di risorse '{0}' non contiene una destinazione per '{1}'. Assicurarsi che il ripristino sia stato eseguito e che '{2}' sia stato incluso negli elementi TargetFramework del progetto. Potrebbe anche essere necessario includere '{3}' negli elementi RuntimeIdentifier del progetto.</target>
-        <note>{StrBegin="NETSDK1047: "}</note>
+      <trans-unit id="FailedToLockResource">
+        <source>NETSDK1077: Failed to lock resource.</source>
+        <target state="translated">NETSDK1077: non è stato possibile bloccare la risorsa.</target>
+        <note>{StrBegin="NETSDK1077: "}</note>
       </trans-unit>
-      <trans-unit id="TargetFrameworkWithSemicolon">
-        <source>NETSDK1046: The TargetFramework value '{0}' is not valid. To multi-target, use the 'TargetFrameworks' property instead.</source>
-        <target state="translated">NETSDK1046: il valore '{0}' di TargetFramework non è valido. Per impostare più destinazioni, usare la proprietà 'TargetFrameworks'.</target>
-        <note>{StrBegin="NETSDK1046: "}</note>
+      <trans-unit id="FileNameIsTooLong">
+        <source>NETSDK1030: Given file name '{0}' is longer than 1024 bytes</source>
+        <target state="translated">NETSDK1030: il nome file specificato '{0}' supera 1024 byte</target>
+        <note>{StrBegin="NETSDK1030: "}</note>
       </trans-unit>
-      <trans-unit id="GetDependsOnNETStandardFailedWithException">
-        <source>NETSDK1049: Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0} {1}</source>
-        <target state="translated">NETSDK1049: il file risolto ha un'immagine danneggiata, non contiene metadati o è inaccessibile per altri motivi. {0} {1}</target>
-        <note>{StrBegin="NETSDK1049: "}</note>
+      <trans-unit id="FolderAlreadyExists">
+        <source>NETSDK1024: Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</source>
+        <target state="translated">NETSDK1024: la cartella '{0}' esiste già. Eliminarla o specificare un elemento ComposeWorkingDir diverso</target>
+        <note>{StrBegin="NETSDK1024: "}</note>
       </trans-unit>
-      <trans-unit id="UnsupportedSDKVersionForNetStandard20">
-        <source>NETSDK1050: The version of Microsoft.NET.Sdk used by this project is insufficient to support references to libraries targeting .NET Standard 1.5 or higher.  Please install version 2.0 or higher of the .NET Core SDK.</source>
-        <target state="translated">NETSDK1050: la versione di Microsoft.NET.Sdk usata da questo progetto non è sufficiente per supportare i riferimenti alle librerie destinate a .NET Standard 1.5 o versione successiva. Installare la versione 2.0 o successiva di .NET Core SDK.</target>
-        <note>{StrBegin="NETSDK1050: "}</note>
-      </trans-unit>
-      <trans-unit id="SkippingAdditionalProbingPaths">
-        <source>NETSDK1048: 'AdditionalProbingPaths' were specified for GenerateRuntimeConfigurationFiles, but are being skipped because 'RuntimeConfigDevPath' is empty.</source>
-        <target state="translated">NETSDK1048: per GenerateRuntimeConfigurationFiles è stato specificato 'AdditionalProbingPaths', ma questo valore verrà ignorato perché 'RuntimeConfigDevPath' è vuoto.</target>
-        <note>{StrBegin="NETSDK1048: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotHaveRuntimeIdentifierPlatformMismatchPlatformTarget">
-        <source>NETSDK1032: The RuntimeIdentifier platform '{0}' and the PlatformTarget '{1}' must be compatible.</source>
-        <target state="translated">NETSDK1032: la piattaforma '{0}' di RuntimeIdentifier e quella '{1}' di PlatformTarget devono essere compatibili.</target>
-        <note>{StrBegin="NETSDK1032: "}</note>
-      </trans-unit>
-      <trans-unit id="ErrorParsingFrameworkListInvalidValue">
-        <source>NETSDK1051: Error parsing FrameworkList from '{0}'.  {1} '{2}' was invalid.</source>
-        <target state="translated">NETSDK1051: si è verificato un errore durante l'analisi di FrameworkList da '{0}'. {1} '{2}' non è valido.</target>
-        <note>{StrBegin="NETSDK1051: "}</note>
+      <trans-unit id="FrameworkDependentAppHostRequiresVersion21">
+        <source>NETSDK1068: The framework-dependent application host requires a target framework of at least 'netcoreapp2.1'.</source>
+        <target state="translated">NETSDK1068: con l'host applicazione dipendente dal framework il framework di destinazione deve essere impostato almeno su 'netcoreapp2.1'.</target>
+        <note>{StrBegin="NETSDK1068: "}</note>
       </trans-unit>
       <trans-unit id="FrameworkListPathNotRooted">
         <source>NETSDK1052: Framework list file path '{0}' is not rooted. Only full paths are supported.</source>
         <target state="translated">NETSDK1052: il percorso '{0}' del file dell'elenco di framework non contiene una radice. Sono supportati solo percorsi completi.</target>
         <note>{StrBegin="NETSDK1052: "}</note>
       </trans-unit>
-      <trans-unit id="PackAsToolCannotSupportSelfContained">
-        <source>NETSDK1053: Pack as tool does not support self contained.</source>
-        <target state="translated">NETSDK1053: la creazione di pacchetti come strumenti non prevede elementi autonomi.</target>
-        <note>{StrBegin="NETSDK1001: "}</note>
+      <trans-unit id="GetDependsOnNETStandardFailedWithException">
+        <source>NETSDK1049: Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0} {1}</source>
+        <target state="translated">NETSDK1049: il file risolto ha un'immagine danneggiata, non contiene metadati o è inaccessibile per altri motivi. {0} {1}</target>
+        <note>{StrBegin="NETSDK1049: "}</note>
       </trans-unit>
-      <trans-unit id="UnsupportedRuntimeIdentifier">
-        <source>NETSDK1056: Project is targeting runtime '{0}' but did not resolve any runtime-specific packages. This runtime may not be supported by the target framework.</source>
-        <target state="translated">NETSDK1056: il progetto è destinato al runtime '{0}' ma non ha risolto pacchetti specifici del runtime. È possibile che questo runtime non sia supportato dal framework di destinazione.</target>
-        <note>{StrBegin="NETSDK1056: "}</note>
+      <trans-unit id="IncorrectPackageRoot">
+        <source>NETSDK1020: Package Root {0} was incorrectly given for Resolved library {1}</source>
+        <target state="translated">NETSDK1020: la radice {0} del pacchetto specificata per la libreria risolta {1} non è corretta</target>
+        <note>{StrBegin="NETSDK1020: "}</note>
       </trans-unit>
-      <trans-unit id="UsingPreviewSdkWarning">
-        <source>NETSDK1057: You are using a preview version of .NET Core. See: https://aka.ms/dotnet-core-preview</source>
-        <target state="translated">NETSDK1057: si sta usando una versione in anteprima di .NET Core. Vedere https://aka.ms/dotnet-core-preview</target>
-        <note>{StrBegin="NETSDK1057: "}</note>
+      <trans-unit id="IncorrectTargetFormat">
+        <source>NETSDK1025: WRThe target manifest {0} provided is of not the correct format</source>
+        <target state="translated">NETSDK1025: il formato del manifesto di destinazione specificato {0} non è corretto</target>
+        <note>{StrBegin="NETSDK1025: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidFrameworkName">
+        <source>NETSDK1003: Invalid framework name: '{0}'.</source>
+        <target state="translated">NETSDK1003: nome di framework non valido: '{0}'.</target>
+        <note>{StrBegin="NETSDK1003: "}</note>
       </trans-unit>
       <trans-unit id="InvalidItemSpecToUse">
         <source>NETSDK1058: Invalid value for ItemSpecToUse parameter: '{0}'.  This property must be blank or set to 'Left' or 'Right'</source>
@@ -373,15 +258,15 @@
         <note>{StrBegin="NETSDK1058: "}
 The following are names of parameters or literal values and should not be translated: ItemSpecToUse, Left, Right</note>
       </trans-unit>
-      <trans-unit id="ProjectContainsObsoleteDotNetCliTool">
-        <source>NETSDK1059: The tool '{0}' is now included in the .NET Core SDK. Information on resolving this warning is available at (https://aka.ms/dotnetclitools-in-box).</source>
-        <target state="translated">NETSDK1059: lo strumento '{0}' è ora incluso in .NET Core SDK. Per informazioni sulla risoluzione di questo avviso, vedere (https://aka.ms/dotnetclitools-in-box).</target>
-        <note>{StrBegin="NETSDK1059: "}</note>
+      <trans-unit id="InvalidNuGetVersionString">
+        <source>NETSDK1018: Invalid NuGet version string: '{0}'.</source>
+        <target state="translated">NETSDK1018: la stringa di versione '{0}' di NuGet non è valida.</target>
+        <note>{StrBegin="NETSDK1018: "}</note>
       </trans-unit>
-      <trans-unit id="ErrorReadingAssetsFile">
-        <source>NETSDK1060: Error reading assets file: {0}</source>
-        <target state="translated">NETSDK1060: errore durante la lettura del file di asset: {0}</target>
-        <note>{StrBegin="NETSDK1060: "}</note>
+      <trans-unit id="InvalidResourceUpdate">
+        <source>NETSDK1075: Update handle is invalid. This instance may not be used for further updates.</source>
+        <target state="translated">NETSDK1075: il punto di controllo dell'aggiornamento non è valido. Non è possibile usare questa istanza per ulteriori aggiornamenti.</target>
+        <note>{StrBegin="NETSDK1075: "}</note>
       </trans-unit>
       <trans-unit id="MismatchedPlatformPackageVersion">
         <source>NETSDK1061: The project was restored using {0} version {1}, but with current settings, version {2} would be used instead. To resolve this issue, make sure the same settings are used for restore and for subsequent operations such as build or publish. Typically this issue can occur if the RuntimeIdentifier property is set during build or publish but not during restore. For more information, see https://aka.ms/dotnet-runtime-patch-selection.</source>
@@ -391,35 +276,150 @@ The following are names of parameters or literal values and should not be transl
 {1} - Restored version of platform package
 {2} - Current version of platform package</note>
       </trans-unit>
-      <trans-unit id="AssetsFileNotSet">
-        <source>NETSDK1063: The path to the project assets file was not set. Run a NuGet package restore to generate this file.</source>
-        <target state="translated">NETSDK1063: il percorso del file di risorse del progetto non è stato impostato. Per generare questo file, eseguire un ripristino del pacchetto NuGet.</target>
-        <note>{StrBegin="NETSDK1063: "}</note>
+      <trans-unit id="MissingItemMetadata">
+        <source>NETSDK1008: Missing '{0}' metadata on '{1}' item '{2}'.</source>
+        <target state="translated">NETSDK1008: mancano i metadati di '{0}' sull'elemento '{2}' di '{1}'.</target>
+        <note>{StrBegin="NETSDK1008: "}</note>
       </trans-unit>
-      <trans-unit id="DotnetToolOnlySupportNetcoreapp">
-        <source>NETSDK1054: only supports .NET Core.</source>
-        <target state="translated">NETSDK1054: supporta solo .NET Core.</target>
-        <note>{StrBegin="NETSDK1054: "}</note>
+      <trans-unit id="MultipleFilesResolved">
+        <source>NETSDK1021: More than one file found for {0}</source>
+        <target state="translated">NETSDK1021: è stato trovato più di un file per {0}</target>
+        <note>{StrBegin="NETSDK1021: "}</note>
       </trans-unit>
-      <trans-unit id="DotnetToolDoesNotSupportTFMLowerThanNetcoreapp21">
-        <source>NETSDK1055: DotnetTool does not support target framework lower than netcoreapp2.1.</source>
-        <target state="translated">NETSDK1055: DotnetTool non supporta framework di destinazione di versioni precedenti a netcoreapp2.1.</target>
-        <note>{StrBegin="NETSDK1055: "}</note>
+      <trans-unit id="NETFrameworkToNonBuiltInNETStandard">
+        <source>NETSDK1069: This project uses a library that targets .NET Standard 1.5 or higher, and the project targets a version of .NET Framework that doesn't have built-in support for that version of .NET Standard. Visit https://aka.ms/net-standard-known-issues for a set of known issues. Consider retargeting to .NET Framework 4.7.2.</source>
+        <target state="translated">NETSDK1069: questo progetto usa una libreria destinata a .NET Standard 1.5 o versione successiva ed è destinato a una versione di .NET Framework che non include il supporto predefinito per tale versione di .NET Standard. Per un serie di problemi noti, visitare https://aka.ms/net-standard-known-issues. Provare a impostare come destinazione .NET Framework 4.7.2.</target>
+        <note>{StrBegin="NETSDK1069: "}</note>
       </trans-unit>
-      <trans-unit id="UnableToUsePackageAssetsCache">
-        <source>NETSDK1062: Unable to use package assets cache due to I/O error. This can occur when the same project is built more than once in parallel. Performance may be degraded, but the build result will not be impacted.</source>
-        <target state="translated">NETSDK1062: non è possibile usare la cache delle risorse del pacchetto a causa dell'errore di I/O. Questo problema può verificarsi quando lo stesso progetto viene compilato più volte in parallelo. Può influire sulle prestazioni, ma non sul risultato della compilazione.</target>
-        <note>{StrBegin="NETSDK1062: "}</note>
+      <trans-unit id="NoAppHostAvailable">
+        <source>NETSDK1084: There is no application host available for the specified RuntimeIdentifier '{0}'.</source>
+        <target state="new">NETSDK1084: There is no application host available for the specified RuntimeIdentifier '{0}'.</target>
+        <note>{StrBegin="NETSDK1084: "}</note>
+      </trans-unit>
+      <trans-unit id="NoCompatibleTargetFramework">
+        <source>NETSDK1002: Project '{0}' targets '{2}'. It cannot be referenced by a project that targets '{1}'.</source>
+        <target state="translated">NETSDK1002: il progetto '{0}' è destinato a '{2}'. Non può essere usato come riferimento in un progetto destinato a '{1}'.</target>
+        <note>{StrBegin="NETSDK1002: "}</note>
+      </trans-unit>
+      <trans-unit id="NoRuntimePackAvailable">
+        <source>NETSDK1082: There was no runtime pack for {0} available for the specified RuntimeIdentifier '{1}'.</source>
+        <target state="new">NETSDK1082: There was no runtime pack for {0} available for the specified RuntimeIdentifier '{1}'.</target>
+        <note>{StrBegin="NETSDK1082: "}</note>
+      </trans-unit>
+      <trans-unit id="PackAsToolCannotSupportSelfContained">
+        <source>NETSDK1053: Pack as tool does not support self contained.</source>
+        <target state="translated">NETSDK1053: la creazione di pacchetti come strumenti non prevede elementi autonomi.</target>
+        <note>{StrBegin="NETSDK1001: "}</note>
+      </trans-unit>
+      <trans-unit id="PackageInfoLog">
+        <source>NETSDK1027: Package Name='{0}', Version='{1}' was parsed</source>
+        <target state="translated">NETSDK1027: è stato analizzato il pacchetto con nome '{0}' e versione '{1}'</target>
+        <note>{StrBegin="NETSDK1027: "}</note>
       </trans-unit>
       <trans-unit id="PackageNotFound">
         <source>NETSDK1064: Package {0}, version {1} was not found. It might have been deleted since NuGet restore. Otherwise, NuGet restore might have only partially completed, which might have been due to maximum path length restrictions.</source>
         <target state="translated">NETSDK1064: il pacchetto {0} versione {1} non è stato trovato. Potrebbe essere stato eliminato dopo il ripristino di NuGet. In caso contrario, il ripristino di NuGet potrebbe essere stato completato solo parzialmente, a causa delle restrizioni relative alla lunghezza massima del percorso.</target>
         <note>{StrBegin="NETSDK1064: "}</note>
       </trans-unit>
-      <trans-unit id="CannotFindApphostForRid">
-        <source>NETSDK1065: Cannot find app host for {0}. {0} could be an invalid runtime identifier (RID). For more information about RID, see https://aka.ms/rid-catalog.</source>
-        <target state="translated">NETSDK1065: non è possibile trovare l'host delle app per {0}. {0} potrebbe essere un identificatore di runtime (RID) non valido. Per altre informazioni sul RID, vedere https://aka.ms/rid-catalog.</target>
-        <note>{StrBegin="NETSDK1065: "}</note>
+      <trans-unit id="PackageReferenceOverrideWarning">
+        <source>NETSDK1023: A PackageReference for '{0}' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see {1}</source>
+        <target state="translated">NETSDK1023: nel progetto è stato incluso un riferimento al pacchetto per '{0}'. Questo pacchetto viene usato come riferimento implicito da .NET SDK e non è in genere necessario farvi riferimento dal progetto. Per altre informazioni, vedere {1}</target>
+        <note>{StrBegin="NETSDK1023: "}</note>
+      </trans-unit>
+      <trans-unit id="PackageReferenceVersionNotRecommended">
+        <source>NETSDK1071: A PackageReference to '{0}' specified a Version of `{1}`. Specifying the version of this package is not recommended. For more information, see https://aka.ms/sdkimplicitrefs</source>
+        <target state="translated">NETSDK1071: in un elemento PackageReference che fa riferimento a '{0}' è specificata la versione di `{1}`. È consigliabile non specificare la versione di questo pacchetto. Per altre informazioni, vedere https://aka.ms/sdkimplicitrefs</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParsingFiles">
+        <source>NETSDK1026: Parsing the Files : '{0}'</source>
+        <target state="translated">NETSDK1026: analisi dei file: '{0}'</target>
+        <note>{StrBegin="NETSDK1026: "}</note>
+      </trans-unit>
+      <trans-unit id="ProjectAssetsConsumedWithoutMSBuildProjectPath">
+        <source>NETSDK1011: Assets are consumed from project '{0}', but no corresponding MSBuild project path was  found in '{1}'.</source>
+        <target state="translated">NETSDK1011: le risorse vengono utilizzate dal progetto '{0}', ma non è stato trovato alcun percorso di progetto MSBuild corrispondente in '{1}'.</target>
+        <note>{StrBegin="NETSDK1011: "}</note>
+      </trans-unit>
+      <trans-unit id="ProjectContainsObsoleteDotNetCliTool">
+        <source>NETSDK1059: The tool '{0}' is now included in the .NET Core SDK. Information on resolving this warning is available at (https://aka.ms/dotnetclitools-in-box).</source>
+        <target state="translated">NETSDK1059: lo strumento '{0}' è ora incluso in .NET Core SDK. Per informazioni sulla risoluzione di questo avviso, vedere (https://aka.ms/dotnetclitools-in-box).</target>
+        <note>{StrBegin="NETSDK1059: "}</note>
+      </trans-unit>
+      <trans-unit id="RuntimeIdentifierNotRecognized">
+        <source>NETSDK1083: The specified RuntimeIdentifier '{0}' is not recognized.</source>
+        <target state="new">NETSDK1083: The specified RuntimeIdentifier '{0}' is not recognized.</target>
+        <note>{StrBegin="NETSDK1083: "}</note>
+      </trans-unit>
+      <trans-unit id="RuntimeIdentifierWasNotSpecified">
+        <source>NETSDK1028: Specify a RuntimeIdentifier</source>
+        <target state="translated">NETSDK1028: specificare un elemento RuntimeIdentifier</target>
+        <note>{StrBegin="NETSDK1028: "}</note>
+      </trans-unit>
+      <trans-unit id="SkippingAdditionalProbingPaths">
+        <source>NETSDK1048: 'AdditionalProbingPaths' were specified for GenerateRuntimeConfigurationFiles, but are being skipped because 'RuntimeConfigDevPath' is empty.</source>
+        <target state="translated">NETSDK1048: per GenerateRuntimeConfigurationFiles è stato specificato 'AdditionalProbingPaths', ma questo valore verrà ignorato perché 'RuntimeConfigDevPath' è vuoto.</target>
+        <note>{StrBegin="NETSDK1048: "}</note>
+      </trans-unit>
+      <trans-unit id="TargetFrameworkWithSemicolon">
+        <source>NETSDK1046: The TargetFramework value '{0}' is not valid. To multi-target, use the 'TargetFrameworks' property instead.</source>
+        <target state="translated">NETSDK1046: il valore '{0}' di TargetFramework non è valido. Per impostare più destinazioni, usare la proprietà 'TargetFrameworks'.</target>
+        <note>{StrBegin="NETSDK1046: "}</note>
+      </trans-unit>
+      <trans-unit id="UnableToFindResolvedPath">
+        <source>NETSDK1016: Unable to find resolved path for '{0}'.</source>
+        <target state="translated">NETSDK1016: il percorso risolto per '{0}' non è stato trovato.</target>
+        <note>{StrBegin="NETSDK1016: "}</note>
+      </trans-unit>
+      <trans-unit id="UnableToUsePackageAssetsCache">
+        <source>NETSDK1062: Unable to use package assets cache due to I/O error. This can occur when the same project is built more than once in parallel. Performance may be degraded, but the build result will not be impacted.</source>
+        <target state="translated">NETSDK1062: non è possibile usare la cache delle risorse del pacchetto a causa dell'errore di I/O. Questo problema può verificarsi quando lo stesso progetto viene compilato più volte in parallelo. Può influire sulle prestazioni, ma non sul risultato della compilazione.</target>
+        <note>{StrBegin="NETSDK1062: "}</note>
+      </trans-unit>
+      <trans-unit id="UnexpectedFileType">
+        <source>NETSDK1012: Unexpected file type for '{0}'. Type is both '{1}' and '{2}'.</source>
+        <target state="translated">NETSDK1012: tipo di file imprevisto per '{0}'. Il tipo è sia '{1}' che '{2}'.</target>
+        <note>{StrBegin="NETSDK1012: "}</note>
+      </trans-unit>
+      <trans-unit id="UnknownFrameworkReference">
+        <source>NETSDK1073: The FrameworkReference '{0}' was not recognized</source>
+        <target state="translated">NETSDK1073: l'elemento FrameworkReference '{0}' non è stato riconosciuto</target>
+        <note>{StrBegin="NETSDK1073: "}</note>
+      </trans-unit>
+      <trans-unit id="UnrecognizedPreprocessorToken">
+        <source>NETSDK1009: Unrecognized preprocessor token '{0}' in '{1}'.</source>
+        <target state="translated">NETSDK1009: token di preprocessore '{0}' non riconosciuto in '{1}'.</target>
+        <note>{StrBegin="NETSDK1009: "}</note>
+      </trans-unit>
+      <trans-unit id="UnresolvedTargetingPack">
+        <source>NETSDK1081: The targeting pack for {0} was not found. You may be able to resolve this by running a NuGet restore on the project.</source>
+        <target state="new">NETSDK1081: The targeting pack for {0} was not found. You may be able to resolve this by running a NuGet restore on the project.</target>
+        <note>{StrBegin="NETSDK1081: "}</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedFramework">
+        <source>NETSDK1019: {0} is an unsupported framework.</source>
+        <target state="translated">NETSDK1019: {0} è un framework non supportato.</target>
+        <note>{StrBegin="NETSDK1019: "}</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedRuntimeIdentifier">
+        <source>NETSDK1056: Project is targeting runtime '{0}' but did not resolve any runtime-specific packages. This runtime may not be supported by the target framework.</source>
+        <target state="translated">NETSDK1056: il progetto è destinato al runtime '{0}' ma non ha risolto pacchetti specifici del runtime. È possibile che questo runtime non sia supportato dal framework di destinazione.</target>
+        <note>{StrBegin="NETSDK1056: "}</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedSDKVersionForNetStandard20">
+        <source>NETSDK1050: The version of Microsoft.NET.Sdk used by this project is insufficient to support references to libraries targeting .NET Standard 1.5 or higher.  Please install version 2.0 or higher of the .NET Core SDK.</source>
+        <target state="translated">NETSDK1050: la versione di Microsoft.NET.Sdk usata da questo progetto non è sufficiente per supportare i riferimenti alle librerie destinate a .NET Standard 1.5 o versione successiva. Installare la versione 2.0 o successiva di .NET Core SDK.</target>
+        <note>{StrBegin="NETSDK1050: "}</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedTargetFrameworkVersion">
+        <source>NETSDK1045: The current .NET SDK does not support targeting {0} {1}.  Either target {0} {2} or lower, or use a version of the .NET SDK that supports {0} {1}.</source>
+        <target state="translated">NETSDK1045: la versione corrente di .NET SDK non supporta {0} {1} come destinazione. Impostare come destinazione {0} {2} o una versione precedente oppure usare una versione di .NET SDK che supporta {0} {1}.</target>
+        <note>{StrBegin="NETSDK1045: "}</note>
+      </trans-unit>
+      <trans-unit id="UsingPreviewSdkWarning">
+        <source>NETSDK1057: You are using a preview version of .NET Core. See: https://aka.ms/dotnet-core-preview</source>
+        <target state="translated">NETSDK1057: si sta usando una versione in anteprima di .NET Core. Vedere https://aka.ms/dotnet-core-preview</target>
+        <note>{StrBegin="NETSDK1057: "}</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
@@ -2,35 +2,25 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../Strings.resx">
     <body>
-      <trans-unit id="AspNetCoreAllNotSupported">
-        <source>NETSDK1079: The Microsoft.AspNetCore.All package is not supported when targeting .NET Core 3.0 or higher.  A FrameworkReference to Microsoft.AspNetCore.App should be used instead, and will be implicitly included by Microsoft.NET.Sdk.Web.</source>
-        <target state="translated">NETSDK1079: .NET Core 3.0 以上をターゲットにする場合、Microsoft.AspNetCore.All パッケージはサポートされていません。 代わりに、Microsoft.AspNetCore.App への FrameworkReference を使用する必要があり、それは、Microsoft.NET.Sdk.Web によって暗黙的に含まれます。</target>
-        <note>{StrBegin="NETSDK1079: "}</note>
-      </trans-unit>
-      <trans-unit id="AspNetCoreUsesFrameworkReference">
-        <source>NETSDK1080: A PackageReference to Microsoft.AspNetCore.App is not necessary when targeting .NET Core 3.0 or higher. If Microsoft.NET.Sdk.Web is used, the shared framework will be referenced automatically. Otherwise, the PackageReference should be replaced with a FrameworkReference.</source>
-        <target state="translated">NETSDK1080: .NET Core 3.0 以上をターゲットにする場合は、Microsoft.AspNetCore.App への PackageReference は必要ありません。Microsoft.NET.Sdk.Web を使用する場合、共有のフレームワークは自動的に参照されます。それ以外の場合、PackageReference は、FrameworkReference に置き換える必要があります。</target>
-        <note>{StrBegin="NETSDK1080: "}</note>
-      </trans-unit>
-      <trans-unit id="FailedToLockResource">
-        <source>NETSDK1077: Failed to lock resource.</source>
-        <target state="translated">NETSDK1077: リソースをロックできませんでした。</target>
-        <note>{StrBegin="NETSDK1077: "}</note>
-      </trans-unit>
       <trans-unit id="AddResourceWithNonIntegerResource">
         <source>NETSDK1076: AddResource can only be used with integer resource types.</source>
         <target state="translated">NETSDK1076: AddResource は、整数リソース型でのみ使用することができます。</target>
         <note>{StrBegin="NETSDK1076: "}</note>
       </trans-unit>
-      <trans-unit id="InvalidResourceUpdate">
-        <source>NETSDK1075: Update handle is invalid. This instance may not be used for further updates.</source>
-        <target state="translated">NETSDK1075: 更新ハンドルが有効ではありません。このインスタンスは、以降の更新に使用できない可能性があります。</target>
-        <note>{StrBegin="NETSDK1075: "}</note>
+      <trans-unit id="AppConfigRequiresRootConfiguration">
+        <source>NETSDK1070: The application configuration file must have root configuration element.</source>
+        <target state="translated">NETSDK1070: アプリケーション構成ファイルには、ルート構成要素が必要です。</target>
+        <note>{StrBegin="NETSDK1070: "}</note>
       </trans-unit>
       <trans-unit id="AppHostCustomizationRequiresWindowsHostWarning">
         <source>NETSDK1074: The application host executable will not be customized because adding resources requires that the build be performed on Windows (excluding Nano Server).</source>
         <target state="translated">NETSDK1074: リソースを追加するには Windows (Nano Server を除く) でビルドを実行する必要があるため、アプリケーション ホストの実行可能ファイルはカスタマイズされません。</target>
         <note>{StrBegin="NETSDK1074: "}</note>
+      </trans-unit>
+      <trans-unit id="AppHostHasBeenModified">
+        <source>NETSDK1029: Unable to use '{0}' as application host executable as it does not contain the expected placeholder byte sequence '{1}' that would mark where the application name would be written.</source>
+        <target state="translated">NETSDK1029: '{0}' は、本来アプリケーション名が書き込まれる場所を示す、必要なプレースホルダー バイト シーケンス '{1}' が含まれていないため、実行可能アプリケーション ホストとして使用できません。</target>
+        <note>{StrBegin="NETSDK1029: "}</note>
       </trans-unit>
       <trans-unit id="AppHostNotWindows">
         <source>NETSDK1078: Unable to use '{0}' as application host executable because it's not a Windows PE file.</source>
@@ -42,210 +32,80 @@
         <target state="translated">NETSDK1072: CUI (コンソール) サブシステムの Windows 実行可能ファイルではないため '{0}' をアプリケーション ホストの実行可能ファイルとして使用できません。</target>
         <note>{StrBegin="NETSDK1072: "}</note>
       </trans-unit>
-      <trans-unit id="AppConfigRequiresRootConfiguration">
-        <source>NETSDK1070: The application configuration file must have root configuration element.</source>
-        <target state="translated">NETSDK1070: アプリケーション構成ファイルには、ルート構成要素が必要です。</target>
-        <note>{StrBegin="NETSDK1070: "}</note>
+      <trans-unit id="AspNetCoreAllNotSupported">
+        <source>NETSDK1079: The Microsoft.AspNetCore.All package is not supported when targeting .NET Core 3.0 or higher.  A FrameworkReference to Microsoft.AspNetCore.App should be used instead, and will be implicitly included by Microsoft.NET.Sdk.Web.</source>
+        <target state="translated">NETSDK1079: .NET Core 3.0 以上をターゲットにする場合、Microsoft.AspNetCore.All パッケージはサポートされていません。 代わりに、Microsoft.AspNetCore.App への FrameworkReference を使用する必要があり、それは、Microsoft.NET.Sdk.Web によって暗黙的に含まれます。</target>
+        <note>{StrBegin="NETSDK1079: "}</note>
       </trans-unit>
-      <trans-unit id="AtLeastOneTargetFrameworkMustBeSpecified">
-        <source>NETSDK1001: At least one possible target framework must be specified.</source>
-        <target state="translated">NETSDK1001: 可能性のあるターゲット フレームワークを少なくとも 1 つ指定する必要があります。</target>
-        <note>{StrBegin="NETSDK1001: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotUseSelfContainedWithoutAppHost">
-        <source>NETSDK1067: Self-contained applications are required to use the application host. Either set SelfContained to false or set UseAppHost to true.</source>
-        <target state="translated">NETSDK1067: アプリケーション ホストを使用するには、自己完結型のアプリケーションが必要です。SelfContained を false に設定するか、UseAppHost を true に設定してください。</target>
-        <note>{StrBegin="NETSDK1067: "}</note>
-      </trans-unit>
-      <trans-unit id="FrameworkDependentAppHostRequiresVersion21">
-        <source>NETSDK1068: The framework-dependent application host requires a target framework of at least 'netcoreapp2.1'.</source>
-        <target state="translated">NETSDK1068: フレームワークに依存するアプリケーション ホストには、最低でも 'netcoreapp2.1' のターゲット フレームワークが必要です。</target>
-        <note>{StrBegin="NETSDK1068: "}</note>
-      </trans-unit>
-      <trans-unit id="NETFrameworkToNonBuiltInNETStandard">
-        <source>NETSDK1069: This project uses a library that targets .NET Standard 1.5 or higher, and the project targets a version of .NET Framework that doesn't have built-in support for that version of .NET Standard. Visit https://aka.ms/net-standard-known-issues for a set of known issues. Consider retargeting to .NET Framework 4.7.2.</source>
-        <target state="translated">NETSDK1069: このプロジェクトは .NET Standard 1.5 以上をターゲットとするライブラリを使用します。また、このプロジェクトは、そのバージョンの .NET Standard に対するサポートが組み込まれていない .NET Framework のバージョンをターゲットとしています。一連の既知の問題について、https://aka.ms/net-standard-known-issues をご覧ください。.NET Framework 4.7.2 への再ターゲットを検討してください。</target>
-        <note>{StrBegin="NETSDK1069: "}</note>
-      </trans-unit>
-      <trans-unit id="NoAppHostAvailable">
-        <source>NETSDK1084: There is no application host available for the specified RuntimeIdentifier '{0}'.</source>
-        <target state="new">NETSDK1084: There is no application host available for the specified RuntimeIdentifier '{0}'.</target>
-        <note>{StrBegin="NETSDK1084: "}</note>
-      </trans-unit>
-      <trans-unit id="NoCompatibleTargetFramework">
-        <source>NETSDK1002: Project '{0}' targets '{2}'. It cannot be referenced by a project that targets '{1}'.</source>
-        <target state="translated">NETSDK1002: プロジェクト '{0}' は、'{2}' を対象としています。'{1}' を対象とするプロジェクトは、これを参照できません。</target>
-        <note>{StrBegin="NETSDK1002: "}</note>
-      </trans-unit>
-      <trans-unit id="InvalidFrameworkName">
-        <source>NETSDK1003: Invalid framework name: '{0}'.</source>
-        <target state="translated">NETSDK1003: 無効なフレームワーク名: '{0}'。</target>
-        <note>{StrBegin="NETSDK1003: "}</note>
-      </trans-unit>
-      <trans-unit id="AssetsFileNotFound">
-        <source>NETSDK1004: Assets file '{0}' not found. Run a NuGet package restore to generate this file.</source>
-        <target state="translated">NETSDK1004: 資産ファイル '{0}' が見つかりません。NuGet パッケージの復元を実行して、このファイルを生成してください。</target>
-        <note>{StrBegin="NETSDK1004: "}</note>
-      </trans-unit>
-      <trans-unit id="AssetsFileMissingTarget">
-        <source>NETSDK1005: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project.</source>
-        <target state="translated">NETSDK1005: 資産ファイル '{0}' に '{1}' のターゲットがありません。復元が実行されたことと、'{2}' がプロジェクトの TargetFrameworks に含まれていることを確認してください。</target>
-        <note>{StrBegin="NETSDK1005: "}</note>
-      </trans-unit>
-      <trans-unit id="AssetsFilePathNotRooted">
-        <source>NETSDK1006: Assets file path '{0}' is not rooted. Only full paths are supported.</source>
-        <target state="translated">NETSDK1006: 資産ファイル パス '{0}' にルートが指定されていません。完全パスのみがサポートされます。</target>
-        <note>{StrBegin="NETSDK1006: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotFindProjectInfo">
-        <source>NETSDK1007: Cannot find project info for '{0}'. This can indicate a missing project reference.</source>
-        <target state="translated">NETSDK1007: '{0}' のプロジェクト情報が見つかりません。これは、プロジェクト参照がないことを示している可能性があります。</target>
-        <note>{StrBegin="NETSDK1007: "}</note>
-      </trans-unit>
-      <trans-unit id="MissingItemMetadata">
-        <source>NETSDK1008: Missing '{0}' metadata on '{1}' item '{2}'.</source>
-        <target state="translated">NETSDK1008: '{1}' 項目 '{2}' の '{0}' メタデータがありません。</target>
-        <note>{StrBegin="NETSDK1008: "}</note>
-      </trans-unit>
-      <trans-unit id="NoRuntimePackAvailable">
-        <source>NETSDK1082: There was no runtime pack for {0} available for the specified RuntimeIdentifier '{1}'.</source>
-        <target state="new">NETSDK1082: There was no runtime pack for {0} available for the specified RuntimeIdentifier '{1}'.</target>
-        <note>{StrBegin="NETSDK1082: "}</note>
-      </trans-unit>
-      <trans-unit id="PackageReferenceVersionNotRecommended">
-        <source>NETSDK1071: A PackageReference to '{0}' specified a Version of `{1}`. Specifying the version of this package is not recommended. For more information, see https://aka.ms/sdkimplicitrefs</source>
-        <target state="translated">NETSDK1071: '{0}' への PackageReference は '{1}' のバージョンを指定しました。このパッケージのバージョンを指定することは推奨されません。詳細については、https://aka.ms/sdkimplicitrefs を参照してください</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="RuntimeIdentifierNotRecognized">
-        <source>NETSDK1083: The specified RuntimeIdentifier '{0}' is not recognized.</source>
-        <target state="new">NETSDK1083: The specified RuntimeIdentifier '{0}' is not recognized.</target>
-        <note>{StrBegin="NETSDK1083: "}</note>
-      </trans-unit>
-      <trans-unit id="UnknownFrameworkReference">
-        <source>NETSDK1073: The FrameworkReference '{0}' was not recognized</source>
-        <target state="translated">NETSDK1073: FrameworkReference '{0}' が認識されませんでした</target>
-        <note>{StrBegin="NETSDK1073: "}</note>
-      </trans-unit>
-      <trans-unit id="UnrecognizedPreprocessorToken">
-        <source>NETSDK1009: Unrecognized preprocessor token '{0}' in '{1}'.</source>
-        <target state="translated">NETSDK1009: 認識されないプリプロセッサ トークン '{0}' が '{1}' に存在します。</target>
-        <note>{StrBegin="NETSDK1009: "}</note>
-      </trans-unit>
-      <trans-unit id="ContentPreproccessorParameterRequired">
-        <source>NETSDK1010: The '{0}' task must be given a value for parameter '{1}' in order to consume preprocessed content.</source>
-        <target state="translated">NETSDK1010: 前処理されたコンテンツを使用するためには、パラメーター '{1}' の値を '{0}' タスクに指定する必要があります。</target>
-        <note>{StrBegin="NETSDK1010: "}</note>
-      </trans-unit>
-      <trans-unit id="ProjectAssetsConsumedWithoutMSBuildProjectPath">
-        <source>NETSDK1011: Assets are consumed from project '{0}', but no corresponding MSBuild project path was  found in '{1}'.</source>
-        <target state="translated">NETSDK1011: プロジェクト '{0}' の資産が使用されますが、対応する MSBuild プロジェクト パスが '{1}' で見つかりませんでした。</target>
-        <note>{StrBegin="NETSDK1011: "}</note>
-      </trans-unit>
-      <trans-unit id="UnexpectedFileType">
-        <source>NETSDK1012: Unexpected file type for '{0}'. Type is both '{1}' and '{2}'.</source>
-        <target state="translated">NETSDK1012: '{0}' のファイルの種類が正しくありません。種類は '{1}' と '{2}' の両方です。</target>
-        <note>{StrBegin="NETSDK1012: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotInferTargetFrameworkIdentifierAndVersion">
-        <source>NETSDK1013: The TargetFramework value '{0}' was not recognized. It may be misspelled. If not, then the TargetFrameworkIdentifier and/or TargetFrameworkVersion properties must be specified explicitly.</source>
-        <target state="translated">NETSDK1013: TargetFramework 値 '{0}' が認識されませんでした。つづりが間違っている可能性があります。間違っていない場合は、TargetFrameworkIdentifier または TargetFrameworkVersion プロパティ (あるいはその両方) を明示的に指定する必要があります。</target>
-        <note>{StrBegin="NETSDK1013: "}</note>
-      </trans-unit>
-      <trans-unit id="ContentItemDoesNotProvideOutputPath">
-        <source>NETSDK1014: Content item for '{0}' sets '{1}', but does not provide  '{2}' or '{3}'.</source>
-        <target state="translated">NETSDK1014: '{0}' のコンテンツ項目で '{1}' が設定されていますが、'{2}' または '{3}' は指定されていません。</target>
-        <note>{StrBegin="NETSDK1014: "}</note>
-      </trans-unit>
-      <trans-unit id="DuplicatePreprocessorToken">
-        <source>NETSDK1015: The preprocessor token '{0}' has been given more than one value. Choosing '{1}' as the value.</source>
-        <target state="translated">NETSDK1015: プリプロセッサ トークン '{0}' に複数の値が指定されています。値として '{1}' を選択します。</target>
-        <note>{StrBegin="NETSDK1015: "}</note>
-      </trans-unit>
-      <trans-unit id="UnableToFindResolvedPath">
-        <source>NETSDK1016: Unable to find resolved path for '{0}'.</source>
-        <target state="translated">NETSDK1016: 解決された '{0}' のパスが見つかりません。</target>
-        <note>{StrBegin="NETSDK1016: "}</note>
+      <trans-unit id="AspNetCoreUsesFrameworkReference">
+        <source>NETSDK1080: A PackageReference to Microsoft.AspNetCore.App is not necessary when targeting .NET Core 3.0 or higher. If Microsoft.NET.Sdk.Web is used, the shared framework will be referenced automatically. Otherwise, the PackageReference should be replaced with a FrameworkReference.</source>
+        <target state="translated">NETSDK1080: .NET Core 3.0 以上をターゲットにする場合は、Microsoft.AspNetCore.App への PackageReference は必要ありません。Microsoft.NET.Sdk.Web を使用する場合、共有のフレームワークは自動的に参照されます。それ以外の場合、PackageReference は、FrameworkReference に置き換える必要があります。</target>
+        <note>{StrBegin="NETSDK1080: "}</note>
       </trans-unit>
       <trans-unit id="AssetPreprocessorMustBeConfigured">
         <source>NETSDK1017: Asset preprocessor must be configured before assets are processed.</source>
         <target state="translated">NETSDK1017: 資産を処理する前に、資産プリプロセッサを構成する必要があります。</target>
         <note>{StrBegin="NETSDK1017: "}</note>
       </trans-unit>
-      <trans-unit id="InvalidNuGetVersionString">
-        <source>NETSDK1018: Invalid NuGet version string: '{0}'.</source>
-        <target state="translated">NETSDK1018: 無効な NuGet バージョン文字列: '{0}'。</target>
-        <note>{StrBegin="NETSDK1018: "}</note>
+      <trans-unit id="AssetsFileMissingRuntimeIdentifier">
+        <source>NETSDK1047: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project. You may also need to include '{3}' in your project's RuntimeIdentifiers.</source>
+        <target state="translated">NETSDK1047: 資産ファイル '{0}' に '{1}' のターゲットがありません。復元が実行されたこと、および '{2}' がプロジェクトの TargetFrameworks に含まれていることを確認してください。プロジェクトの RuntimeIdentifiers に '{3}' を組み込む必要が生じる可能性もあります。</target>
+        <note>{StrBegin="NETSDK1047: "}</note>
       </trans-unit>
-      <trans-unit id="UnresolvedTargetingPack">
-        <source>NETSDK1081: The targeting pack for {0} was not found. You may be able to resolve this by running a NuGet restore on the project.</source>
-        <target state="new">NETSDK1081: The targeting pack for {0} was not found. You may be able to resolve this by running a NuGet restore on the project.</target>
-        <note>{StrBegin="NETSDK1081: "}</note>
+      <trans-unit id="AssetsFileMissingTarget">
+        <source>NETSDK1005: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project.</source>
+        <target state="translated">NETSDK1005: 資産ファイル '{0}' に '{1}' のターゲットがありません。復元が実行されたことと、'{2}' がプロジェクトの TargetFrameworks に含まれていることを確認してください。</target>
+        <note>{StrBegin="NETSDK1005: "}</note>
       </trans-unit>
-      <trans-unit id="UnsupportedFramework">
-        <source>NETSDK1019: {0} is an unsupported framework.</source>
-        <target state="translated">NETSDK1019: {0} は、サポートされていないフレームワークです。</target>
-        <note>{StrBegin="NETSDK1019: "}</note>
+      <trans-unit id="AssetsFileNotFound">
+        <source>NETSDK1004: Assets file '{0}' not found. Run a NuGet package restore to generate this file.</source>
+        <target state="translated">NETSDK1004: 資産ファイル '{0}' が見つかりません。NuGet パッケージの復元を実行して、このファイルを生成してください。</target>
+        <note>{StrBegin="NETSDK1004: "}</note>
       </trans-unit>
-      <trans-unit id="DuplicateItemsError">
-        <source>NETSDK1022: Duplicate '{0}' items were included. The .NET SDK includes '{0}' items from your project directory by default. You can either remove these items from your project file, or set the '{1}' property to '{2}' if you want to explicitly include them in your project file. For more information, see {4}. The duplicate items were: {3}</source>
-        <target state="translated">NETSDK1022: 重複する '{0}' 個のアイテムが含められました。.NET SDK には、既定でプロジェクト ディレクトリからのアイテムが '{0}' 個含まれています。これらのアイテムをプロジェクト ファイルから削除するか、'{1}' プロパティを '{2}' に設定してプロジェクト ファイルに明示的に含めることができます。詳細については、{4} をご覧ください。重複するアイテムは、{3} でした。</target>
-        <note>{StrBegin="NETSDK1022: "}</note>
+      <trans-unit id="AssetsFileNotSet">
+        <source>NETSDK1063: The path to the project assets file was not set. Run a NuGet package restore to generate this file.</source>
+        <target state="translated">NETSDK1063: プロジェクト資産ファイルのパスが設定されていません。NuGet パッケージの復元を実行して、このファイルを生成してください。</target>
+        <note>{StrBegin="NETSDK1063: "}</note>
       </trans-unit>
-      <trans-unit id="PackageReferenceOverrideWarning">
-        <source>NETSDK1023: A PackageReference for '{0}' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see {1}</source>
-        <target state="translated">NETSDK1023: '{0}' の PackageReference がプロジェクトに含められました。このパッケージは .NET SDK によって暗黙的に参照されるため、通常はプロジェクトから参照する必要がありません。詳細については、{1} をご覧ください。</target>
-        <note>{StrBegin="NETSDK1023: "}</note>
+      <trans-unit id="AssetsFilePathNotRooted">
+        <source>NETSDK1006: Assets file path '{0}' is not rooted. Only full paths are supported.</source>
+        <target state="translated">NETSDK1006: 資産ファイル パス '{0}' にルートが指定されていません。完全パスのみがサポートされます。</target>
+        <note>{StrBegin="NETSDK1006: "}</note>
       </trans-unit>
-      <trans-unit id="IncorrectPackageRoot">
-        <source>NETSDK1020: Package Root {0} was incorrectly given for Resolved library {1}</source>
-        <target state="translated">NETSDK1020: 解決されたライブラリ {1} に対して指定されたパッケージ ルート {0} が正しくありません。</target>
-        <note>{StrBegin="NETSDK1020: "}</note>
+      <trans-unit id="AtLeastOneTargetFrameworkMustBeSpecified">
+        <source>NETSDK1001: At least one possible target framework must be specified.</source>
+        <target state="translated">NETSDK1001: 可能性のあるターゲット フレームワークを少なくとも 1 つ指定する必要があります。</target>
+        <note>{StrBegin="NETSDK1001: "}</note>
       </trans-unit>
-      <trans-unit id="MultipleFilesResolved">
-        <source>NETSDK1021: More than one file found for {0}</source>
-        <target state="translated">NETSDK1021: {0} で複数のファイルが見つかりました。</target>
-        <note>{StrBegin="NETSDK1021: "}</note>
+      <trans-unit id="CannotFindApphostForRid">
+        <source>NETSDK1065: Cannot find app host for {0}. {0} could be an invalid runtime identifier (RID). For more information about RID, see https://aka.ms/rid-catalog.</source>
+        <target state="translated">NETSDK1065: {0} のアプリ ホストが見つかりません。{0} は無効なランタイム識別子 (RID) である可能性があります。RID の詳細については、https://aka.ms/rid-catalog をご覧ください。</target>
+        <note>{StrBegin="NETSDK1065: "}</note>
       </trans-unit>
-      <trans-unit id="FolderAlreadyExists">
-        <source>NETSDK1024: Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</source>
-        <target state="translated">NETSDK1024: フォルダー '{0}' が既に存在します。そのフォルダーを削除するか、別の ComposeWorkingDir を指定してください。</target>
-        <note>{StrBegin="NETSDK1024: "}</note>
+      <trans-unit id="CannotFindProjectInfo">
+        <source>NETSDK1007: Cannot find project info for '{0}'. This can indicate a missing project reference.</source>
+        <target state="translated">NETSDK1007: '{0}' のプロジェクト情報が見つかりません。これは、プロジェクト参照がないことを示している可能性があります。</target>
+        <note>{StrBegin="NETSDK1007: "}</note>
       </trans-unit>
-      <trans-unit id="ParsingFiles">
-        <source>NETSDK1026: Parsing the Files : '{0}'</source>
-        <target state="translated">NETSDK1026: 次のファイルを解析しています: '{0}'</target>
-        <note>{StrBegin="NETSDK1026: "}</note>
-      </trans-unit>
-      <trans-unit id="PackageInfoLog">
-        <source>NETSDK1027: Package Name='{0}', Version='{1}' was parsed</source>
-        <target state="translated">NETSDK1027: パッケージ名='{0}'、バージョン='{1}' が解析されました</target>
-        <note>{StrBegin="NETSDK1027: "}</note>
-      </trans-unit>
-      <trans-unit id="RuntimeIdentifierWasNotSpecified">
-        <source>NETSDK1028: Specify a RuntimeIdentifier</source>
-        <target state="translated">NETSDK1028: RuntimeIdentifier の指定</target>
-        <note>{StrBegin="NETSDK1028: "}</note>
-      </trans-unit>
-      <trans-unit id="IncorrectTargetFormat">
-        <source>NETSDK1025: WRThe target manifest {0} provided is of not the correct format</source>
-        <target state="translated">NETSDK1025: 指定されたターゲット マニフェスト {0} の形式が正しくありません</target>
-        <note>{StrBegin="NETSDK1025: "}</note>
-      </trans-unit>
-      <trans-unit id="AppHostHasBeenModified">
-        <source>NETSDK1029: Unable to use '{0}' as application host executable as it does not contain the expected placeholder byte sequence '{1}' that would mark where the application name would be written.</source>
-        <target state="translated">NETSDK1029: '{0}' は、本来アプリケーション名が書き込まれる場所を示す、必要なプレースホルダー バイト シーケンス '{1}' が含まれていないため、実行可能アプリケーション ホストとして使用できません。</target>
-        <note>{StrBegin="NETSDK1029: "}</note>
-      </trans-unit>
-      <trans-unit id="FileNameIsTooLong">
-        <source>NETSDK1030: Given file name '{0}' is longer than 1024 bytes</source>
-        <target state="translated">NETSDK1030: 指定されたファイル名 '{0}' の長さが 1024 バイトを超えています。</target>
-        <note>{StrBegin="NETSDK1030: "}</note>
+      <trans-unit id="CannotHaveRuntimeIdentifierPlatformMismatchPlatformTarget">
+        <source>NETSDK1032: The RuntimeIdentifier platform '{0}' and the PlatformTarget '{1}' must be compatible.</source>
+        <target state="translated">NETSDK1032: RuntimeIdentifier プラットフォーム '{0}' と PlatformTarget '{1}' には互換性が必要です。</target>
+        <note>{StrBegin="NETSDK1032: "}</note>
       </trans-unit>
       <trans-unit id="CannotHaveSelfContainedWithoutRuntimeIdentifier">
         <source>NETSDK1031: It is not supported to build or publish a self-contained application without specifying a RuntimeIdentifier.  Please either specify a RuntimeIdentifier or set SelfContained to false.</source>
         <target state="translated">NETSDK1031: RuntimeIdentifier を指定せずに自己完結型アプリケーションをビルドおよび発行することはサポートされていません。RuntimeIdentifier を指定するか SelfContained を false に設定してください。</target>
         <note>{StrBegin="NETSDK1031: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotInferTargetFrameworkIdentifierAndVersion">
+        <source>NETSDK1013: The TargetFramework value '{0}' was not recognized. It may be misspelled. If not, then the TargetFrameworkIdentifier and/or TargetFrameworkVersion properties must be specified explicitly.</source>
+        <target state="translated">NETSDK1013: TargetFramework 値 '{0}' が認識されませんでした。つづりが間違っている可能性があります。間違っていない場合は、TargetFrameworkIdentifier または TargetFrameworkVersion プロパティ (あるいはその両方) を明示的に指定する必要があります。</target>
+        <note>{StrBegin="NETSDK1013: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotUseSelfContainedWithoutAppHost">
+        <source>NETSDK1067: Self-contained applications are required to use the application host. Either set SelfContained to false or set UseAppHost to true.</source>
+        <target state="translated">NETSDK1067: アプリケーション ホストを使用するには、自己完結型のアプリケーションが必要です。SelfContained を false に設定するか、UseAppHost を true に設定してください。</target>
+        <note>{StrBegin="NETSDK1067: "}</note>
       </trans-unit>
       <trans-unit id="ChoosingAssemblyVersion">
         <source>NETSDK1033: Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</source>
@@ -272,6 +132,16 @@
         <target state="translated">NETSDK1037: ファイルとアセンブリのバージョンが等しいため、勝者を判別できませんでした。</target>
         <note>{StrBegin="NETSDK1037: "}</note>
       </trans-unit>
+      <trans-unit id="ContentItemDoesNotProvideOutputPath">
+        <source>NETSDK1014: Content item for '{0}' sets '{1}', but does not provide  '{2}' or '{3}'.</source>
+        <target state="translated">NETSDK1014: '{0}' のコンテンツ項目で '{1}' が設定されていますが、'{2}' または '{3}' は指定されていません。</target>
+        <note>{StrBegin="NETSDK1014: "}</note>
+      </trans-unit>
+      <trans-unit id="ContentPreproccessorParameterRequired">
+        <source>NETSDK1010: The '{0}' task must be given a value for parameter '{1}' in order to consume preprocessed content.</source>
+        <target state="translated">NETSDK1010: 前処理されたコンテンツを使用するためには、パラメーター '{1}' の値を '{0}' タスクに指定する必要があります。</target>
+        <note>{StrBegin="NETSDK1010: "}</note>
+      </trans-unit>
       <trans-unit id="CouldNotDetermineWinner_DoesntExist">
         <source>NETSDK1038: Could not determine winner because '{0}' does not exist.</source>
         <target state="translated">NETSDK1038: '{0}' が存在しないため勝者を判別できませんでした。</target>
@@ -287,15 +157,40 @@
         <target state="translated">NETSDK1040: '{0}' がアセンブリでないため勝者を判別できませんでした。</target>
         <note>{StrBegin="NETSDK1040: "}</note>
       </trans-unit>
+      <trans-unit id="CouldNotLoadPlatformManifest">
+        <source>NETSDK1042: Could not load PlatformManifest from '{0}' because it did not exist.</source>
+        <target state="translated">NETSDK1042: 存在しなかったため、'{0}' から PlatformManifest を読み込めませんでした。</target>
+        <note>{StrBegin="NETSDK1042: "}</note>
+      </trans-unit>
+      <trans-unit id="DotnetToolDoesNotSupportTFMLowerThanNetcoreapp21">
+        <source>NETSDK1055: DotnetTool does not support target framework lower than netcoreapp2.1.</source>
+        <target state="translated">NETSDK1055: DotnetTool は、netcoreapp2.1 未満のターゲット フレームワークをサポートしていません。</target>
+        <note>{StrBegin="NETSDK1055: "}</note>
+      </trans-unit>
+      <trans-unit id="DotnetToolOnlySupportNetcoreapp">
+        <source>NETSDK1054: only supports .NET Core.</source>
+        <target state="translated">NETSDK1054: .NET Core のみがサポートされています。</target>
+        <note>{StrBegin="NETSDK1054: "}</note>
+      </trans-unit>
+      <trans-unit id="DuplicateItemsError">
+        <source>NETSDK1022: Duplicate '{0}' items were included. The .NET SDK includes '{0}' items from your project directory by default. You can either remove these items from your project file, or set the '{1}' property to '{2}' if you want to explicitly include them in your project file. For more information, see {4}. The duplicate items were: {3}</source>
+        <target state="translated">NETSDK1022: 重複する '{0}' 個のアイテムが含められました。.NET SDK には、既定でプロジェクト ディレクトリからのアイテムが '{0}' 個含まれています。これらのアイテムをプロジェクト ファイルから削除するか、'{1}' プロパティを '{2}' に設定してプロジェクト ファイルに明示的に含めることができます。詳細については、{4} をご覧ください。重複するアイテムは、{3} でした。</target>
+        <note>{StrBegin="NETSDK1022: "}</note>
+      </trans-unit>
+      <trans-unit id="DuplicatePreprocessorToken">
+        <source>NETSDK1015: The preprocessor token '{0}' has been given more than one value. Choosing '{1}' as the value.</source>
+        <target state="translated">NETSDK1015: プリプロセッサ トークン '{0}' に複数の値が指定されています。値として '{1}' を選択します。</target>
+        <note>{StrBegin="NETSDK1015: "}</note>
+      </trans-unit>
       <trans-unit id="EncounteredConflict">
         <source>NETSDK1041: Encountered conflict between '{0}' and '{1}'.</source>
         <target state="translated">NETSDK1041: '{0}' と '{1}' の間で競合が発生しました。</target>
         <note>{StrBegin="NETSDK1041: "}</note>
       </trans-unit>
-      <trans-unit id="CouldNotLoadPlatformManifest">
-        <source>NETSDK1042: Could not load PlatformManifest from '{0}' because it did not exist.</source>
-        <target state="translated">NETSDK1042: 存在しなかったため、'{0}' から PlatformManifest を読み込めませんでした。</target>
-        <note>{StrBegin="NETSDK1042: "}</note>
+      <trans-unit id="ErrorParsingFrameworkListInvalidValue">
+        <source>NETSDK1051: Error parsing FrameworkList from '{0}'.  {1} '{2}' was invalid.</source>
+        <target state="translated">NETSDK1051: '{0}' からの FrameworkList の解析でエラーが発生しました。{1} '{2}' が無効でした。</target>
+        <note>{StrBegin="NETSDK1051: "}</note>
       </trans-unit>
       <trans-unit id="ErrorParsingPlatformManifest">
         <source>NETSDK1043: Error parsing PlatformManifest from '{0}' line {1}.  Lines must have the format {2}.</source>
@@ -307,65 +202,55 @@
         <target state="translated">NETSDK1044: '{0}' 行 {1} からの PlatformManifest の解析でエラーが発生しました。{2} '{3}' は無効でした。</target>
         <note>{StrBegin="NETSDK1044: "}</note>
       </trans-unit>
-      <trans-unit id="UnsupportedTargetFrameworkVersion">
-        <source>NETSDK1045: The current .NET SDK does not support targeting {0} {1}.  Either target {0} {2} or lower, or use a version of the .NET SDK that supports {0} {1}.</source>
-        <target state="translated">NETSDK1045: 現在の .NET SDK は、ターゲットとする {0} {1} をサポートしていません。{0} {2} 以下をターゲットとするか、{0} {1} をサポートする .NET SDK のバージョンを使用してください。</target>
-        <note>{StrBegin="NETSDK1045: "}</note>
+      <trans-unit id="ErrorReadingAssetsFile">
+        <source>NETSDK1060: Error reading assets file: {0}</source>
+        <target state="translated">NETSDK1060: アセット ファイルの読み取りでエラーが発生しました: {0}</target>
+        <note>{StrBegin="NETSDK1060: "}</note>
       </trans-unit>
-      <trans-unit id="AssetsFileMissingRuntimeIdentifier">
-        <source>NETSDK1047: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project. You may also need to include '{3}' in your project's RuntimeIdentifiers.</source>
-        <target state="translated">NETSDK1047: 資産ファイル '{0}' に '{1}' のターゲットがありません。復元が実行されたこと、および '{2}' がプロジェクトの TargetFrameworks に含まれていることを確認してください。プロジェクトの RuntimeIdentifiers に '{3}' を組み込む必要が生じる可能性もあります。</target>
-        <note>{StrBegin="NETSDK1047: "}</note>
+      <trans-unit id="FailedToLockResource">
+        <source>NETSDK1077: Failed to lock resource.</source>
+        <target state="translated">NETSDK1077: リソースをロックできませんでした。</target>
+        <note>{StrBegin="NETSDK1077: "}</note>
       </trans-unit>
-      <trans-unit id="TargetFrameworkWithSemicolon">
-        <source>NETSDK1046: The TargetFramework value '{0}' is not valid. To multi-target, use the 'TargetFrameworks' property instead.</source>
-        <target state="translated">NETSDK1046: TargetFramework 値 '{0}' が無効です。複数をターゲットとするには、代わりに 'TargetFrameworks' プロパティを使用してください。</target>
-        <note>{StrBegin="NETSDK1046: "}</note>
+      <trans-unit id="FileNameIsTooLong">
+        <source>NETSDK1030: Given file name '{0}' is longer than 1024 bytes</source>
+        <target state="translated">NETSDK1030: 指定されたファイル名 '{0}' の長さが 1024 バイトを超えています。</target>
+        <note>{StrBegin="NETSDK1030: "}</note>
       </trans-unit>
-      <trans-unit id="GetDependsOnNETStandardFailedWithException">
-        <source>NETSDK1049: Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0} {1}</source>
-        <target state="translated">NETSDK1049: 解決されたファイルは、無効なイメージが含まれているか、メタデータが存在しないか、またはアクセスできません。{0} {1}</target>
-        <note>{StrBegin="NETSDK1049: "}</note>
+      <trans-unit id="FolderAlreadyExists">
+        <source>NETSDK1024: Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</source>
+        <target state="translated">NETSDK1024: フォルダー '{0}' が既に存在します。そのフォルダーを削除するか、別の ComposeWorkingDir を指定してください。</target>
+        <note>{StrBegin="NETSDK1024: "}</note>
       </trans-unit>
-      <trans-unit id="UnsupportedSDKVersionForNetStandard20">
-        <source>NETSDK1050: The version of Microsoft.NET.Sdk used by this project is insufficient to support references to libraries targeting .NET Standard 1.5 or higher.  Please install version 2.0 or higher of the .NET Core SDK.</source>
-        <target state="translated">NETSDK1050: このプロジェクトで使用される Microsoft.NET.Sdk のバージョンは、.NET Standard 1.5 以上を対象とするライブラリへの参照をサポートするには不十分です。.NET Core SDK のバージョン 2.0 以上をインストールしてください。</target>
-        <note>{StrBegin="NETSDK1050: "}</note>
-      </trans-unit>
-      <trans-unit id="SkippingAdditionalProbingPaths">
-        <source>NETSDK1048: 'AdditionalProbingPaths' were specified for GenerateRuntimeConfigurationFiles, but are being skipped because 'RuntimeConfigDevPath' is empty.</source>
-        <target state="translated">NETSDK1048: 'AdditionalProbingPaths' が GenerateRuntimeConfigurationFiles に指定されましたが、'RuntimeConfigDevPath' が空であるためスキップされます。</target>
-        <note>{StrBegin="NETSDK1048: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotHaveRuntimeIdentifierPlatformMismatchPlatformTarget">
-        <source>NETSDK1032: The RuntimeIdentifier platform '{0}' and the PlatformTarget '{1}' must be compatible.</source>
-        <target state="translated">NETSDK1032: RuntimeIdentifier プラットフォーム '{0}' と PlatformTarget '{1}' には互換性が必要です。</target>
-        <note>{StrBegin="NETSDK1032: "}</note>
-      </trans-unit>
-      <trans-unit id="ErrorParsingFrameworkListInvalidValue">
-        <source>NETSDK1051: Error parsing FrameworkList from '{0}'.  {1} '{2}' was invalid.</source>
-        <target state="translated">NETSDK1051: '{0}' からの FrameworkList の解析でエラーが発生しました。{1} '{2}' が無効でした。</target>
-        <note>{StrBegin="NETSDK1051: "}</note>
+      <trans-unit id="FrameworkDependentAppHostRequiresVersion21">
+        <source>NETSDK1068: The framework-dependent application host requires a target framework of at least 'netcoreapp2.1'.</source>
+        <target state="translated">NETSDK1068: フレームワークに依存するアプリケーション ホストには、最低でも 'netcoreapp2.1' のターゲット フレームワークが必要です。</target>
+        <note>{StrBegin="NETSDK1068: "}</note>
       </trans-unit>
       <trans-unit id="FrameworkListPathNotRooted">
         <source>NETSDK1052: Framework list file path '{0}' is not rooted. Only full paths are supported.</source>
         <target state="translated">NETSDK1052: フレームワーク リスト ファイル パス '{0}' にルートが指定されていません。完全パスのみがサポートされています。</target>
         <note>{StrBegin="NETSDK1052: "}</note>
       </trans-unit>
-      <trans-unit id="PackAsToolCannotSupportSelfContained">
-        <source>NETSDK1053: Pack as tool does not support self contained.</source>
-        <target state="translated">NETSDK1053: Pack As ツールは自己完結型をサポートしていません。</target>
-        <note>{StrBegin="NETSDK1001: "}</note>
+      <trans-unit id="GetDependsOnNETStandardFailedWithException">
+        <source>NETSDK1049: Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0} {1}</source>
+        <target state="translated">NETSDK1049: 解決されたファイルは、無効なイメージが含まれているか、メタデータが存在しないか、またはアクセスできません。{0} {1}</target>
+        <note>{StrBegin="NETSDK1049: "}</note>
       </trans-unit>
-      <trans-unit id="UnsupportedRuntimeIdentifier">
-        <source>NETSDK1056: Project is targeting runtime '{0}' but did not resolve any runtime-specific packages. This runtime may not be supported by the target framework.</source>
-        <target state="translated">NETSDK1056: プロジェクトはランタイム '{0}' をターゲットとしていますが、ランタイム固有のパッケージを解決しませんでした。このランタイムはターゲットのフレームワークでサポートされていない可能性があります。</target>
-        <note>{StrBegin="NETSDK1056: "}</note>
+      <trans-unit id="IncorrectPackageRoot">
+        <source>NETSDK1020: Package Root {0} was incorrectly given for Resolved library {1}</source>
+        <target state="translated">NETSDK1020: 解決されたライブラリ {1} に対して指定されたパッケージ ルート {0} が正しくありません。</target>
+        <note>{StrBegin="NETSDK1020: "}</note>
       </trans-unit>
-      <trans-unit id="UsingPreviewSdkWarning">
-        <source>NETSDK1057: You are using a preview version of .NET Core. See: https://aka.ms/dotnet-core-preview</source>
-        <target state="translated">NETSDK1057: プレビュー版の .NET Core を使用しています。https://aka.ms/dotnet-core-preview をご覧ください</target>
-        <note>{StrBegin="NETSDK1057: "}</note>
+      <trans-unit id="IncorrectTargetFormat">
+        <source>NETSDK1025: WRThe target manifest {0} provided is of not the correct format</source>
+        <target state="translated">NETSDK1025: 指定されたターゲット マニフェスト {0} の形式が正しくありません</target>
+        <note>{StrBegin="NETSDK1025: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidFrameworkName">
+        <source>NETSDK1003: Invalid framework name: '{0}'.</source>
+        <target state="translated">NETSDK1003: 無効なフレームワーク名: '{0}'。</target>
+        <note>{StrBegin="NETSDK1003: "}</note>
       </trans-unit>
       <trans-unit id="InvalidItemSpecToUse">
         <source>NETSDK1058: Invalid value for ItemSpecToUse parameter: '{0}'.  This property must be blank or set to 'Left' or 'Right'</source>
@@ -373,15 +258,15 @@
         <note>{StrBegin="NETSDK1058: "}
 The following are names of parameters or literal values and should not be translated: ItemSpecToUse, Left, Right</note>
       </trans-unit>
-      <trans-unit id="ProjectContainsObsoleteDotNetCliTool">
-        <source>NETSDK1059: The tool '{0}' is now included in the .NET Core SDK. Information on resolving this warning is available at (https://aka.ms/dotnetclitools-in-box).</source>
-        <target state="translated">NETSDK1059: ツール '{0}' は .NET Core SDK に含まれるようになりました。この警告の解決に関する情報は、(https://aka.ms/dotnetclitools-in-box) で入手できます。</target>
-        <note>{StrBegin="NETSDK1059: "}</note>
+      <trans-unit id="InvalidNuGetVersionString">
+        <source>NETSDK1018: Invalid NuGet version string: '{0}'.</source>
+        <target state="translated">NETSDK1018: 無効な NuGet バージョン文字列: '{0}'。</target>
+        <note>{StrBegin="NETSDK1018: "}</note>
       </trans-unit>
-      <trans-unit id="ErrorReadingAssetsFile">
-        <source>NETSDK1060: Error reading assets file: {0}</source>
-        <target state="translated">NETSDK1060: アセット ファイルの読み取りでエラーが発生しました: {0}</target>
-        <note>{StrBegin="NETSDK1060: "}</note>
+      <trans-unit id="InvalidResourceUpdate">
+        <source>NETSDK1075: Update handle is invalid. This instance may not be used for further updates.</source>
+        <target state="translated">NETSDK1075: 更新ハンドルが有効ではありません。このインスタンスは、以降の更新に使用できない可能性があります。</target>
+        <note>{StrBegin="NETSDK1075: "}</note>
       </trans-unit>
       <trans-unit id="MismatchedPlatformPackageVersion">
         <source>NETSDK1061: The project was restored using {0} version {1}, but with current settings, version {2} would be used instead. To resolve this issue, make sure the same settings are used for restore and for subsequent operations such as build or publish. Typically this issue can occur if the RuntimeIdentifier property is set during build or publish but not during restore. For more information, see https://aka.ms/dotnet-runtime-patch-selection.</source>
@@ -391,35 +276,150 @@ The following are names of parameters or literal values and should not be transl
 {1} - Restored version of platform package
 {2} - Current version of platform package</note>
       </trans-unit>
-      <trans-unit id="AssetsFileNotSet">
-        <source>NETSDK1063: The path to the project assets file was not set. Run a NuGet package restore to generate this file.</source>
-        <target state="translated">NETSDK1063: プロジェクト資産ファイルのパスが設定されていません。NuGet パッケージの復元を実行して、このファイルを生成してください。</target>
-        <note>{StrBegin="NETSDK1063: "}</note>
+      <trans-unit id="MissingItemMetadata">
+        <source>NETSDK1008: Missing '{0}' metadata on '{1}' item '{2}'.</source>
+        <target state="translated">NETSDK1008: '{1}' 項目 '{2}' の '{0}' メタデータがありません。</target>
+        <note>{StrBegin="NETSDK1008: "}</note>
       </trans-unit>
-      <trans-unit id="DotnetToolOnlySupportNetcoreapp">
-        <source>NETSDK1054: only supports .NET Core.</source>
-        <target state="translated">NETSDK1054: .NET Core のみがサポートされています。</target>
-        <note>{StrBegin="NETSDK1054: "}</note>
+      <trans-unit id="MultipleFilesResolved">
+        <source>NETSDK1021: More than one file found for {0}</source>
+        <target state="translated">NETSDK1021: {0} で複数のファイルが見つかりました。</target>
+        <note>{StrBegin="NETSDK1021: "}</note>
       </trans-unit>
-      <trans-unit id="DotnetToolDoesNotSupportTFMLowerThanNetcoreapp21">
-        <source>NETSDK1055: DotnetTool does not support target framework lower than netcoreapp2.1.</source>
-        <target state="translated">NETSDK1055: DotnetTool は、netcoreapp2.1 未満のターゲット フレームワークをサポートしていません。</target>
-        <note>{StrBegin="NETSDK1055: "}</note>
+      <trans-unit id="NETFrameworkToNonBuiltInNETStandard">
+        <source>NETSDK1069: This project uses a library that targets .NET Standard 1.5 or higher, and the project targets a version of .NET Framework that doesn't have built-in support for that version of .NET Standard. Visit https://aka.ms/net-standard-known-issues for a set of known issues. Consider retargeting to .NET Framework 4.7.2.</source>
+        <target state="translated">NETSDK1069: このプロジェクトは .NET Standard 1.5 以上をターゲットとするライブラリを使用します。また、このプロジェクトは、そのバージョンの .NET Standard に対するサポートが組み込まれていない .NET Framework のバージョンをターゲットとしています。一連の既知の問題について、https://aka.ms/net-standard-known-issues をご覧ください。.NET Framework 4.7.2 への再ターゲットを検討してください。</target>
+        <note>{StrBegin="NETSDK1069: "}</note>
       </trans-unit>
-      <trans-unit id="UnableToUsePackageAssetsCache">
-        <source>NETSDK1062: Unable to use package assets cache due to I/O error. This can occur when the same project is built more than once in parallel. Performance may be degraded, but the build result will not be impacted.</source>
-        <target state="translated">NETSDK1062: I/O エラーのため、パッケージ資産のキャッシュを使用できません。これは、同じプロジェクトが同時に複数回ビルドされるときに発生することがあります。パフォーマンスが低下する可能性がありますが、ビルドの結果には影響はありません。</target>
-        <note>{StrBegin="NETSDK1062: "}</note>
+      <trans-unit id="NoAppHostAvailable">
+        <source>NETSDK1084: There is no application host available for the specified RuntimeIdentifier '{0}'.</source>
+        <target state="new">NETSDK1084: There is no application host available for the specified RuntimeIdentifier '{0}'.</target>
+        <note>{StrBegin="NETSDK1084: "}</note>
+      </trans-unit>
+      <trans-unit id="NoCompatibleTargetFramework">
+        <source>NETSDK1002: Project '{0}' targets '{2}'. It cannot be referenced by a project that targets '{1}'.</source>
+        <target state="translated">NETSDK1002: プロジェクト '{0}' は、'{2}' を対象としています。'{1}' を対象とするプロジェクトは、これを参照できません。</target>
+        <note>{StrBegin="NETSDK1002: "}</note>
+      </trans-unit>
+      <trans-unit id="NoRuntimePackAvailable">
+        <source>NETSDK1082: There was no runtime pack for {0} available for the specified RuntimeIdentifier '{1}'.</source>
+        <target state="new">NETSDK1082: There was no runtime pack for {0} available for the specified RuntimeIdentifier '{1}'.</target>
+        <note>{StrBegin="NETSDK1082: "}</note>
+      </trans-unit>
+      <trans-unit id="PackAsToolCannotSupportSelfContained">
+        <source>NETSDK1053: Pack as tool does not support self contained.</source>
+        <target state="translated">NETSDK1053: Pack As ツールは自己完結型をサポートしていません。</target>
+        <note>{StrBegin="NETSDK1001: "}</note>
+      </trans-unit>
+      <trans-unit id="PackageInfoLog">
+        <source>NETSDK1027: Package Name='{0}', Version='{1}' was parsed</source>
+        <target state="translated">NETSDK1027: パッケージ名='{0}'、バージョン='{1}' が解析されました</target>
+        <note>{StrBegin="NETSDK1027: "}</note>
       </trans-unit>
       <trans-unit id="PackageNotFound">
         <source>NETSDK1064: Package {0}, version {1} was not found. It might have been deleted since NuGet restore. Otherwise, NuGet restore might have only partially completed, which might have been due to maximum path length restrictions.</source>
         <target state="translated">NETSDK1064: パッケージ {0}、バージョン {1} が見つかりませんでした。NuGet の復元により、削除された可能性があります。それ以外の場合、NuGet の復元が最大パス長の制限のために一部分しか完了していない可能性があります。</target>
         <note>{StrBegin="NETSDK1064: "}</note>
       </trans-unit>
-      <trans-unit id="CannotFindApphostForRid">
-        <source>NETSDK1065: Cannot find app host for {0}. {0} could be an invalid runtime identifier (RID). For more information about RID, see https://aka.ms/rid-catalog.</source>
-        <target state="translated">NETSDK1065: {0} のアプリ ホストが見つかりません。{0} は無効なランタイム識別子 (RID) である可能性があります。RID の詳細については、https://aka.ms/rid-catalog をご覧ください。</target>
-        <note>{StrBegin="NETSDK1065: "}</note>
+      <trans-unit id="PackageReferenceOverrideWarning">
+        <source>NETSDK1023: A PackageReference for '{0}' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see {1}</source>
+        <target state="translated">NETSDK1023: '{0}' の PackageReference がプロジェクトに含められました。このパッケージは .NET SDK によって暗黙的に参照されるため、通常はプロジェクトから参照する必要がありません。詳細については、{1} をご覧ください。</target>
+        <note>{StrBegin="NETSDK1023: "}</note>
+      </trans-unit>
+      <trans-unit id="PackageReferenceVersionNotRecommended">
+        <source>NETSDK1071: A PackageReference to '{0}' specified a Version of `{1}`. Specifying the version of this package is not recommended. For more information, see https://aka.ms/sdkimplicitrefs</source>
+        <target state="translated">NETSDK1071: '{0}' への PackageReference は '{1}' のバージョンを指定しました。このパッケージのバージョンを指定することは推奨されません。詳細については、https://aka.ms/sdkimplicitrefs を参照してください</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParsingFiles">
+        <source>NETSDK1026: Parsing the Files : '{0}'</source>
+        <target state="translated">NETSDK1026: 次のファイルを解析しています: '{0}'</target>
+        <note>{StrBegin="NETSDK1026: "}</note>
+      </trans-unit>
+      <trans-unit id="ProjectAssetsConsumedWithoutMSBuildProjectPath">
+        <source>NETSDK1011: Assets are consumed from project '{0}', but no corresponding MSBuild project path was  found in '{1}'.</source>
+        <target state="translated">NETSDK1011: プロジェクト '{0}' の資産が使用されますが、対応する MSBuild プロジェクト パスが '{1}' で見つかりませんでした。</target>
+        <note>{StrBegin="NETSDK1011: "}</note>
+      </trans-unit>
+      <trans-unit id="ProjectContainsObsoleteDotNetCliTool">
+        <source>NETSDK1059: The tool '{0}' is now included in the .NET Core SDK. Information on resolving this warning is available at (https://aka.ms/dotnetclitools-in-box).</source>
+        <target state="translated">NETSDK1059: ツール '{0}' は .NET Core SDK に含まれるようになりました。この警告の解決に関する情報は、(https://aka.ms/dotnetclitools-in-box) で入手できます。</target>
+        <note>{StrBegin="NETSDK1059: "}</note>
+      </trans-unit>
+      <trans-unit id="RuntimeIdentifierNotRecognized">
+        <source>NETSDK1083: The specified RuntimeIdentifier '{0}' is not recognized.</source>
+        <target state="new">NETSDK1083: The specified RuntimeIdentifier '{0}' is not recognized.</target>
+        <note>{StrBegin="NETSDK1083: "}</note>
+      </trans-unit>
+      <trans-unit id="RuntimeIdentifierWasNotSpecified">
+        <source>NETSDK1028: Specify a RuntimeIdentifier</source>
+        <target state="translated">NETSDK1028: RuntimeIdentifier の指定</target>
+        <note>{StrBegin="NETSDK1028: "}</note>
+      </trans-unit>
+      <trans-unit id="SkippingAdditionalProbingPaths">
+        <source>NETSDK1048: 'AdditionalProbingPaths' were specified for GenerateRuntimeConfigurationFiles, but are being skipped because 'RuntimeConfigDevPath' is empty.</source>
+        <target state="translated">NETSDK1048: 'AdditionalProbingPaths' が GenerateRuntimeConfigurationFiles に指定されましたが、'RuntimeConfigDevPath' が空であるためスキップされます。</target>
+        <note>{StrBegin="NETSDK1048: "}</note>
+      </trans-unit>
+      <trans-unit id="TargetFrameworkWithSemicolon">
+        <source>NETSDK1046: The TargetFramework value '{0}' is not valid. To multi-target, use the 'TargetFrameworks' property instead.</source>
+        <target state="translated">NETSDK1046: TargetFramework 値 '{0}' が無効です。複数をターゲットとするには、代わりに 'TargetFrameworks' プロパティを使用してください。</target>
+        <note>{StrBegin="NETSDK1046: "}</note>
+      </trans-unit>
+      <trans-unit id="UnableToFindResolvedPath">
+        <source>NETSDK1016: Unable to find resolved path for '{0}'.</source>
+        <target state="translated">NETSDK1016: 解決された '{0}' のパスが見つかりません。</target>
+        <note>{StrBegin="NETSDK1016: "}</note>
+      </trans-unit>
+      <trans-unit id="UnableToUsePackageAssetsCache">
+        <source>NETSDK1062: Unable to use package assets cache due to I/O error. This can occur when the same project is built more than once in parallel. Performance may be degraded, but the build result will not be impacted.</source>
+        <target state="translated">NETSDK1062: I/O エラーのため、パッケージ資産のキャッシュを使用できません。これは、同じプロジェクトが同時に複数回ビルドされるときに発生することがあります。パフォーマンスが低下する可能性がありますが、ビルドの結果には影響はありません。</target>
+        <note>{StrBegin="NETSDK1062: "}</note>
+      </trans-unit>
+      <trans-unit id="UnexpectedFileType">
+        <source>NETSDK1012: Unexpected file type for '{0}'. Type is both '{1}' and '{2}'.</source>
+        <target state="translated">NETSDK1012: '{0}' のファイルの種類が正しくありません。種類は '{1}' と '{2}' の両方です。</target>
+        <note>{StrBegin="NETSDK1012: "}</note>
+      </trans-unit>
+      <trans-unit id="UnknownFrameworkReference">
+        <source>NETSDK1073: The FrameworkReference '{0}' was not recognized</source>
+        <target state="translated">NETSDK1073: FrameworkReference '{0}' が認識されませんでした</target>
+        <note>{StrBegin="NETSDK1073: "}</note>
+      </trans-unit>
+      <trans-unit id="UnrecognizedPreprocessorToken">
+        <source>NETSDK1009: Unrecognized preprocessor token '{0}' in '{1}'.</source>
+        <target state="translated">NETSDK1009: 認識されないプリプロセッサ トークン '{0}' が '{1}' に存在します。</target>
+        <note>{StrBegin="NETSDK1009: "}</note>
+      </trans-unit>
+      <trans-unit id="UnresolvedTargetingPack">
+        <source>NETSDK1081: The targeting pack for {0} was not found. You may be able to resolve this by running a NuGet restore on the project.</source>
+        <target state="new">NETSDK1081: The targeting pack for {0} was not found. You may be able to resolve this by running a NuGet restore on the project.</target>
+        <note>{StrBegin="NETSDK1081: "}</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedFramework">
+        <source>NETSDK1019: {0} is an unsupported framework.</source>
+        <target state="translated">NETSDK1019: {0} は、サポートされていないフレームワークです。</target>
+        <note>{StrBegin="NETSDK1019: "}</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedRuntimeIdentifier">
+        <source>NETSDK1056: Project is targeting runtime '{0}' but did not resolve any runtime-specific packages. This runtime may not be supported by the target framework.</source>
+        <target state="translated">NETSDK1056: プロジェクトはランタイム '{0}' をターゲットとしていますが、ランタイム固有のパッケージを解決しませんでした。このランタイムはターゲットのフレームワークでサポートされていない可能性があります。</target>
+        <note>{StrBegin="NETSDK1056: "}</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedSDKVersionForNetStandard20">
+        <source>NETSDK1050: The version of Microsoft.NET.Sdk used by this project is insufficient to support references to libraries targeting .NET Standard 1.5 or higher.  Please install version 2.0 or higher of the .NET Core SDK.</source>
+        <target state="translated">NETSDK1050: このプロジェクトで使用される Microsoft.NET.Sdk のバージョンは、.NET Standard 1.5 以上を対象とするライブラリへの参照をサポートするには不十分です。.NET Core SDK のバージョン 2.0 以上をインストールしてください。</target>
+        <note>{StrBegin="NETSDK1050: "}</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedTargetFrameworkVersion">
+        <source>NETSDK1045: The current .NET SDK does not support targeting {0} {1}.  Either target {0} {2} or lower, or use a version of the .NET SDK that supports {0} {1}.</source>
+        <target state="translated">NETSDK1045: 現在の .NET SDK は、ターゲットとする {0} {1} をサポートしていません。{0} {2} 以下をターゲットとするか、{0} {1} をサポートする .NET SDK のバージョンを使用してください。</target>
+        <note>{StrBegin="NETSDK1045: "}</note>
+      </trans-unit>
+      <trans-unit id="UsingPreviewSdkWarning">
+        <source>NETSDK1057: You are using a preview version of .NET Core. See: https://aka.ms/dotnet-core-preview</source>
+        <target state="translated">NETSDK1057: プレビュー版の .NET Core を使用しています。https://aka.ms/dotnet-core-preview をご覧ください</target>
+        <note>{StrBegin="NETSDK1057: "}</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
@@ -2,35 +2,25 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../Strings.resx">
     <body>
-      <trans-unit id="AspNetCoreAllNotSupported">
-        <source>NETSDK1079: The Microsoft.AspNetCore.All package is not supported when targeting .NET Core 3.0 or higher.  A FrameworkReference to Microsoft.AspNetCore.App should be used instead, and will be implicitly included by Microsoft.NET.Sdk.Web.</source>
-        <target state="translated">NETSDK1079: .NET Core 3.0 이상을 대상으로 하는 경우 Microsoft.AspNetCore.All 패키지가 지원되지 않습니다. 대신 Microsoft.AspNetCore.App에 대한 FrameworkReference를 사용해야 하며 Microsoft.NET.Sdk.Web에 의해 이 참조가 암시적으로 포함됩니다.</target>
-        <note>{StrBegin="NETSDK1079: "}</note>
-      </trans-unit>
-      <trans-unit id="AspNetCoreUsesFrameworkReference">
-        <source>NETSDK1080: A PackageReference to Microsoft.AspNetCore.App is not necessary when targeting .NET Core 3.0 or higher. If Microsoft.NET.Sdk.Web is used, the shared framework will be referenced automatically. Otherwise, the PackageReference should be replaced with a FrameworkReference.</source>
-        <target state="translated">NETSDK1080: .NET Core 3.0 이상을 대상으로 할 경우 Microsoft.AspNetCore.App에 대한 PackageReference가 필요하지 않습니다. Microsoft.NET.Sdk.Web을 사용하는 경우 공유 프레임워크가 자동으로 참조됩니다. 그러지 않으면 PackageReference를 FrameworkReference로 바꾸어야 합니다.</target>
-        <note>{StrBegin="NETSDK1080: "}</note>
-      </trans-unit>
-      <trans-unit id="FailedToLockResource">
-        <source>NETSDK1077: Failed to lock resource.</source>
-        <target state="translated">NETSDK1077: 리소스를 잠그지 못했습니다.</target>
-        <note>{StrBegin="NETSDK1077: "}</note>
-      </trans-unit>
       <trans-unit id="AddResourceWithNonIntegerResource">
         <source>NETSDK1076: AddResource can only be used with integer resource types.</source>
         <target state="translated">NETSDK1076: AddResource는 정수 리소스 형식에서만 사용할 수 있습니다.</target>
         <note>{StrBegin="NETSDK1076: "}</note>
       </trans-unit>
-      <trans-unit id="InvalidResourceUpdate">
-        <source>NETSDK1075: Update handle is invalid. This instance may not be used for further updates.</source>
-        <target state="translated">NETSDK1075: 업데이트 핸들이 잘못되었습니다. 이 인스턴스는 추가 업데이트에 사용할 수 없습니다.</target>
-        <note>{StrBegin="NETSDK1075: "}</note>
+      <trans-unit id="AppConfigRequiresRootConfiguration">
+        <source>NETSDK1070: The application configuration file must have root configuration element.</source>
+        <target state="translated">NETSDK1070: 애플리케이션 구성 파일에는 루트 구성 요소가 있어야 합니다.</target>
+        <note>{StrBegin="NETSDK1070: "}</note>
       </trans-unit>
       <trans-unit id="AppHostCustomizationRequiresWindowsHostWarning">
         <source>NETSDK1074: The application host executable will not be customized because adding resources requires that the build be performed on Windows (excluding Nano Server).</source>
         <target state="translated">NETSDK1074: 리소스를 추가하면 Windows(Nano Server 제외)에서 빌드를 수행해야 하므로 애플리케이션 호스트 실행 파일이 사용자 지정되지 않습니다.</target>
         <note>{StrBegin="NETSDK1074: "}</note>
+      </trans-unit>
+      <trans-unit id="AppHostHasBeenModified">
+        <source>NETSDK1029: Unable to use '{0}' as application host executable as it does not contain the expected placeholder byte sequence '{1}' that would mark where the application name would be written.</source>
+        <target state="translated">NETSDK1029: 애플리케이션 이름이 기록되는 위치를 표시하는 '{1}' 예상 자리 표시자 바이트 시퀀스가 포함되지 않아서 '{0}'을(를) 애플리케이션 호스트 실행 파일로 사용할 수 없습니다.</target>
+        <note>{StrBegin="NETSDK1029: "}</note>
       </trans-unit>
       <trans-unit id="AppHostNotWindows">
         <source>NETSDK1078: Unable to use '{0}' as application host executable because it's not a Windows PE file.</source>
@@ -42,210 +32,80 @@
         <target state="translated">NETSDK1072: '{0}'은 CUI(콘솔) 하위 시스템에 대한 Windows 실행 파일이 아니므로 애플리케이션 호스트 실행 파일로 사용할 수 없습니다.</target>
         <note>{StrBegin="NETSDK1072: "}</note>
       </trans-unit>
-      <trans-unit id="AppConfigRequiresRootConfiguration">
-        <source>NETSDK1070: The application configuration file must have root configuration element.</source>
-        <target state="translated">NETSDK1070: 애플리케이션 구성 파일에는 루트 구성 요소가 있어야 합니다.</target>
-        <note>{StrBegin="NETSDK1070: "}</note>
+      <trans-unit id="AspNetCoreAllNotSupported">
+        <source>NETSDK1079: The Microsoft.AspNetCore.All package is not supported when targeting .NET Core 3.0 or higher.  A FrameworkReference to Microsoft.AspNetCore.App should be used instead, and will be implicitly included by Microsoft.NET.Sdk.Web.</source>
+        <target state="translated">NETSDK1079: .NET Core 3.0 이상을 대상으로 하는 경우 Microsoft.AspNetCore.All 패키지가 지원되지 않습니다. 대신 Microsoft.AspNetCore.App에 대한 FrameworkReference를 사용해야 하며 Microsoft.NET.Sdk.Web에 의해 이 참조가 암시적으로 포함됩니다.</target>
+        <note>{StrBegin="NETSDK1079: "}</note>
       </trans-unit>
-      <trans-unit id="AtLeastOneTargetFrameworkMustBeSpecified">
-        <source>NETSDK1001: At least one possible target framework must be specified.</source>
-        <target state="translated">NETSDK1001: 가능한 대상 프레임워크를 하나 이상 지정해야 합니다.</target>
-        <note>{StrBegin="NETSDK1001: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotUseSelfContainedWithoutAppHost">
-        <source>NETSDK1067: Self-contained applications are required to use the application host. Either set SelfContained to false or set UseAppHost to true.</source>
-        <target state="translated">NETSDK1067: 애플리케이션 호스트를 사용하려면 자체 포함 애플리케이션이 필요합니다. SelfContained를 false로 설정하거나 UseAppHost를 true로 설정하세요.</target>
-        <note>{StrBegin="NETSDK1067: "}</note>
-      </trans-unit>
-      <trans-unit id="FrameworkDependentAppHostRequiresVersion21">
-        <source>NETSDK1068: The framework-dependent application host requires a target framework of at least 'netcoreapp2.1'.</source>
-        <target state="translated">NETSDK1068: 프레임워크 종속 애플리케이션 호스트는 'netcoreapp2.1' 이상의 대상 프레임워크가 필요합니다.</target>
-        <note>{StrBegin="NETSDK1068: "}</note>
-      </trans-unit>
-      <trans-unit id="NETFrameworkToNonBuiltInNETStandard">
-        <source>NETSDK1069: This project uses a library that targets .NET Standard 1.5 or higher, and the project targets a version of .NET Framework that doesn't have built-in support for that version of .NET Standard. Visit https://aka.ms/net-standard-known-issues for a set of known issues. Consider retargeting to .NET Framework 4.7.2.</source>
-        <target state="translated">NETSDK1069: 이 프로젝트는 .NET Standard 1.5 이상을 대상으로 하는 라이브러리를 사용하며, 이 프로젝트는 해당 버전의 .NET Standard를 기본으로 제공하지 않는 .NET Framework 버전을 대상으로 합니다. 알려진 문제에 대해서는 https://aka.ms/net-standard-known-issues를 참조하세요. .NET Framework 4.7.2로 대상을 다시 지정해 보세요.</target>
-        <note>{StrBegin="NETSDK1069: "}</note>
-      </trans-unit>
-      <trans-unit id="NoAppHostAvailable">
-        <source>NETSDK1084: There is no application host available for the specified RuntimeIdentifier '{0}'.</source>
-        <target state="new">NETSDK1084: There is no application host available for the specified RuntimeIdentifier '{0}'.</target>
-        <note>{StrBegin="NETSDK1084: "}</note>
-      </trans-unit>
-      <trans-unit id="NoCompatibleTargetFramework">
-        <source>NETSDK1002: Project '{0}' targets '{2}'. It cannot be referenced by a project that targets '{1}'.</source>
-        <target state="translated">NETSDK1002: '{0}' 프로젝트가 '{2}'을(를) 대상으로 합니다. '{1}'을(를) 대상으로 하는 프로젝트에서 참조할 수 없습니다.</target>
-        <note>{StrBegin="NETSDK1002: "}</note>
-      </trans-unit>
-      <trans-unit id="InvalidFrameworkName">
-        <source>NETSDK1003: Invalid framework name: '{0}'.</source>
-        <target state="translated">NETSDK1003: 프레임워크 이름 '{0}'이(가) 잘못되었습니다.</target>
-        <note>{StrBegin="NETSDK1003: "}</note>
-      </trans-unit>
-      <trans-unit id="AssetsFileNotFound">
-        <source>NETSDK1004: Assets file '{0}' not found. Run a NuGet package restore to generate this file.</source>
-        <target state="translated">NETSDK1004: 자산 파일 '{0}'을(를) 찾을 수 없습니다. NuGet 패키지 복원을 실행하여 이 파일을 생성하세요.</target>
-        <note>{StrBegin="NETSDK1004: "}</note>
-      </trans-unit>
-      <trans-unit id="AssetsFileMissingTarget">
-        <source>NETSDK1005: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project.</source>
-        <target state="translated">NETSDK1005: 자산 파일 '{0}'에 '{1}'의 대상이 없습니다. 복원이 실행되었으며 프로젝트의 TargetFrameworks에 '{2}'을(를) 포함했는지 확인하세요.</target>
-        <note>{StrBegin="NETSDK1005: "}</note>
-      </trans-unit>
-      <trans-unit id="AssetsFilePathNotRooted">
-        <source>NETSDK1006: Assets file path '{0}' is not rooted. Only full paths are supported.</source>
-        <target state="translated">NETSDK1006: 자산 파일 경로 '{0}'이(가) 루트에서 시작하지 않습니다. 전체 경로만 지원됩니다.</target>
-        <note>{StrBegin="NETSDK1006: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotFindProjectInfo">
-        <source>NETSDK1007: Cannot find project info for '{0}'. This can indicate a missing project reference.</source>
-        <target state="translated">NETSDK1007: '{0}'에 대한 프로젝트 정보를 찾을 수 없습니다. 프로젝트 참조가 없음을 나타낼 수 있습니다.</target>
-        <note>{StrBegin="NETSDK1007: "}</note>
-      </trans-unit>
-      <trans-unit id="MissingItemMetadata">
-        <source>NETSDK1008: Missing '{0}' metadata on '{1}' item '{2}'.</source>
-        <target state="translated">NETSDK1008: '{1}' 항목 '{2}'에 '{0}' 메타데이터가 없습니다.</target>
-        <note>{StrBegin="NETSDK1008: "}</note>
-      </trans-unit>
-      <trans-unit id="NoRuntimePackAvailable">
-        <source>NETSDK1082: There was no runtime pack for {0} available for the specified RuntimeIdentifier '{1}'.</source>
-        <target state="new">NETSDK1082: There was no runtime pack for {0} available for the specified RuntimeIdentifier '{1}'.</target>
-        <note>{StrBegin="NETSDK1082: "}</note>
-      </trans-unit>
-      <trans-unit id="PackageReferenceVersionNotRecommended">
-        <source>NETSDK1071: A PackageReference to '{0}' specified a Version of `{1}`. Specifying the version of this package is not recommended. For more information, see https://aka.ms/sdkimplicitrefs</source>
-        <target state="translated">NETSDK1071: '{0}'에 대한 PackageReference에서 `{1}`의 버전을 지정했습니다. 이 패키지의 버전을 지정하지 않는 것이 좋습니다. 자세한 내용은 https://aka.ms/sdkimplicitrefs를 참조하세요.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="RuntimeIdentifierNotRecognized">
-        <source>NETSDK1083: The specified RuntimeIdentifier '{0}' is not recognized.</source>
-        <target state="new">NETSDK1083: The specified RuntimeIdentifier '{0}' is not recognized.</target>
-        <note>{StrBegin="NETSDK1083: "}</note>
-      </trans-unit>
-      <trans-unit id="UnknownFrameworkReference">
-        <source>NETSDK1073: The FrameworkReference '{0}' was not recognized</source>
-        <target state="translated">NETSDK1073: FrameworkReference '{0}'이(가) 인식되지 않았습니다.</target>
-        <note>{StrBegin="NETSDK1073: "}</note>
-      </trans-unit>
-      <trans-unit id="UnrecognizedPreprocessorToken">
-        <source>NETSDK1009: Unrecognized preprocessor token '{0}' in '{1}'.</source>
-        <target state="translated">NETSDK1009: '{1}'에서 전처리기 토큰 '{0}'을(를) 인식할 수 없습니다.</target>
-        <note>{StrBegin="NETSDK1009: "}</note>
-      </trans-unit>
-      <trans-unit id="ContentPreproccessorParameterRequired">
-        <source>NETSDK1010: The '{0}' task must be given a value for parameter '{1}' in order to consume preprocessed content.</source>
-        <target state="translated">NETSDK1010: 전처리된 콘텐츠를 사용하려면 '{0}' 작업에서 '{1}' 매개 변수의 값을 지정해야 합니다.</target>
-        <note>{StrBegin="NETSDK1010: "}</note>
-      </trans-unit>
-      <trans-unit id="ProjectAssetsConsumedWithoutMSBuildProjectPath">
-        <source>NETSDK1011: Assets are consumed from project '{0}', but no corresponding MSBuild project path was  found in '{1}'.</source>
-        <target state="translated">NETSDK1011: '{0}' 프로젝트의 자산이 사용되었지만, '{1}'에서 해당 MSBuild 프로젝트 경로를 찾을 수 없습니다.</target>
-        <note>{StrBegin="NETSDK1011: "}</note>
-      </trans-unit>
-      <trans-unit id="UnexpectedFileType">
-        <source>NETSDK1012: Unexpected file type for '{0}'. Type is both '{1}' and '{2}'.</source>
-        <target state="translated">NETSDK1012: '{0}'에 대해 예기치 않은 파일 형식입니다. 형식이 '{1}'인 동시에 '{2}'입니다.</target>
-        <note>{StrBegin="NETSDK1012: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotInferTargetFrameworkIdentifierAndVersion">
-        <source>NETSDK1013: The TargetFramework value '{0}' was not recognized. It may be misspelled. If not, then the TargetFrameworkIdentifier and/or TargetFrameworkVersion properties must be specified explicitly.</source>
-        <target state="translated">NETSDK1013: TargetFramework 값 '{0}'을(를) 인식하지 못했습니다. 철자가 틀렸을 수 있습니다. 그렇지 않은 경우 TargetFrameworkIdentifier 및/또는 TargetFrameworkVersion 속성을 명시적으로 지정해야 합니다.</target>
-        <note>{StrBegin="NETSDK1013: "}</note>
-      </trans-unit>
-      <trans-unit id="ContentItemDoesNotProvideOutputPath">
-        <source>NETSDK1014: Content item for '{0}' sets '{1}', but does not provide  '{2}' or '{3}'.</source>
-        <target state="translated">NETSDK1014: '{0}'의 콘텐츠 항목이 '{1}'을(를) 설정하지만, '{2}' 또는 '{3}'을(를) 제공하지 않습니다.</target>
-        <note>{StrBegin="NETSDK1014: "}</note>
-      </trans-unit>
-      <trans-unit id="DuplicatePreprocessorToken">
-        <source>NETSDK1015: The preprocessor token '{0}' has been given more than one value. Choosing '{1}' as the value.</source>
-        <target state="translated">NETSDK1015: 전처리기 토큰 '{0}'의 값이 두 개 이상 지정되었습니다. '{1}'을(를) 값으로 선택합니다.</target>
-        <note>{StrBegin="NETSDK1015: "}</note>
-      </trans-unit>
-      <trans-unit id="UnableToFindResolvedPath">
-        <source>NETSDK1016: Unable to find resolved path for '{0}'.</source>
-        <target state="translated">NETSDK1016: '{0}'에 대해 확인된 경로를 찾을 수 없습니다.</target>
-        <note>{StrBegin="NETSDK1016: "}</note>
+      <trans-unit id="AspNetCoreUsesFrameworkReference">
+        <source>NETSDK1080: A PackageReference to Microsoft.AspNetCore.App is not necessary when targeting .NET Core 3.0 or higher. If Microsoft.NET.Sdk.Web is used, the shared framework will be referenced automatically. Otherwise, the PackageReference should be replaced with a FrameworkReference.</source>
+        <target state="translated">NETSDK1080: .NET Core 3.0 이상을 대상으로 할 경우 Microsoft.AspNetCore.App에 대한 PackageReference가 필요하지 않습니다. Microsoft.NET.Sdk.Web을 사용하는 경우 공유 프레임워크가 자동으로 참조됩니다. 그러지 않으면 PackageReference를 FrameworkReference로 바꾸어야 합니다.</target>
+        <note>{StrBegin="NETSDK1080: "}</note>
       </trans-unit>
       <trans-unit id="AssetPreprocessorMustBeConfigured">
         <source>NETSDK1017: Asset preprocessor must be configured before assets are processed.</source>
         <target state="translated">NETSDK1017: 자산을 처리하려면 먼저 자산 전처리기를 구성해야 합니다.</target>
         <note>{StrBegin="NETSDK1017: "}</note>
       </trans-unit>
-      <trans-unit id="InvalidNuGetVersionString">
-        <source>NETSDK1018: Invalid NuGet version string: '{0}'.</source>
-        <target state="translated">NETSDK1018: NuGet 버전 문자열 '{0}'이(가) 잘못되었습니다.</target>
-        <note>{StrBegin="NETSDK1018: "}</note>
+      <trans-unit id="AssetsFileMissingRuntimeIdentifier">
+        <source>NETSDK1047: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project. You may also need to include '{3}' in your project's RuntimeIdentifiers.</source>
+        <target state="translated">NETSDK1047: 자산 파일 '{0}'에 '{1}'의 대상이 없습니다. 복원이 실행되었으며 프로젝트의 TargetFrameworks에 '{2}'을(를) 포함했는지 확인하세요. 프로젝트의 RuntimeIdentifiers에 '{3}'을(를) 포함해야 할 수도 있습니다.</target>
+        <note>{StrBegin="NETSDK1047: "}</note>
       </trans-unit>
-      <trans-unit id="UnresolvedTargetingPack">
-        <source>NETSDK1081: The targeting pack for {0} was not found. You may be able to resolve this by running a NuGet restore on the project.</source>
-        <target state="new">NETSDK1081: The targeting pack for {0} was not found. You may be able to resolve this by running a NuGet restore on the project.</target>
-        <note>{StrBegin="NETSDK1081: "}</note>
+      <trans-unit id="AssetsFileMissingTarget">
+        <source>NETSDK1005: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project.</source>
+        <target state="translated">NETSDK1005: 자산 파일 '{0}'에 '{1}'의 대상이 없습니다. 복원이 실행되었으며 프로젝트의 TargetFrameworks에 '{2}'을(를) 포함했는지 확인하세요.</target>
+        <note>{StrBegin="NETSDK1005: "}</note>
       </trans-unit>
-      <trans-unit id="UnsupportedFramework">
-        <source>NETSDK1019: {0} is an unsupported framework.</source>
-        <target state="translated">NETSDK1019: {0}은(는) 지원되지 않는 프레임워크입니다.</target>
-        <note>{StrBegin="NETSDK1019: "}</note>
+      <trans-unit id="AssetsFileNotFound">
+        <source>NETSDK1004: Assets file '{0}' not found. Run a NuGet package restore to generate this file.</source>
+        <target state="translated">NETSDK1004: 자산 파일 '{0}'을(를) 찾을 수 없습니다. NuGet 패키지 복원을 실행하여 이 파일을 생성하세요.</target>
+        <note>{StrBegin="NETSDK1004: "}</note>
       </trans-unit>
-      <trans-unit id="DuplicateItemsError">
-        <source>NETSDK1022: Duplicate '{0}' items were included. The .NET SDK includes '{0}' items from your project directory by default. You can either remove these items from your project file, or set the '{1}' property to '{2}' if you want to explicitly include them in your project file. For more information, see {4}. The duplicate items were: {3}</source>
-        <target state="translated">NETSDK1022: '{0}' 중복 항목이 포함되었습니다. .NET SDK에는 기본적으로 프로젝트 디렉터리의 '{0}' 항목이 포함됩니다. 프로젝트 파일에서 이러한 항목을 제거하거나, 프로젝트 파일에 해당 항목을 명시적으로 포함하려면 '{1}' 속성을 '{2}'(으)로 설정할 수 있습니다. 자세한 내용은 {4}을(를) 참조하세요. 중복 항목은 다음과 같습니다. {3}</target>
-        <note>{StrBegin="NETSDK1022: "}</note>
+      <trans-unit id="AssetsFileNotSet">
+        <source>NETSDK1063: The path to the project assets file was not set. Run a NuGet package restore to generate this file.</source>
+        <target state="translated">NETSDK1063: 프로젝트 자산 파일에 대한 경로가 설정되지 않았습니다. NuGet 패키지 복원을 실행하여 이 파일을 생성하세요.</target>
+        <note>{StrBegin="NETSDK1063: "}</note>
       </trans-unit>
-      <trans-unit id="PackageReferenceOverrideWarning">
-        <source>NETSDK1023: A PackageReference for '{0}' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see {1}</source>
-        <target state="translated">NETSDK1023: '{0}'에 대한 PackageReference가 프로젝트에 포함되어 있습니다. 이 패키지는 .NET SDK에서 암시적으로 참조되며, 일반적으로 사용자가 프로젝트에서 참조할 필요가 없습니다. 자세한 내용은 {1}을(를) 참조하세요.</target>
-        <note>{StrBegin="NETSDK1023: "}</note>
+      <trans-unit id="AssetsFilePathNotRooted">
+        <source>NETSDK1006: Assets file path '{0}' is not rooted. Only full paths are supported.</source>
+        <target state="translated">NETSDK1006: 자산 파일 경로 '{0}'이(가) 루트에서 시작하지 않습니다. 전체 경로만 지원됩니다.</target>
+        <note>{StrBegin="NETSDK1006: "}</note>
       </trans-unit>
-      <trans-unit id="IncorrectPackageRoot">
-        <source>NETSDK1020: Package Root {0} was incorrectly given for Resolved library {1}</source>
-        <target state="translated">NETSDK1020: 패키지 루트 {0}이(가) 확인된 라이브러리 {1}에 대해 잘못 지정되었습니다.</target>
-        <note>{StrBegin="NETSDK1020: "}</note>
+      <trans-unit id="AtLeastOneTargetFrameworkMustBeSpecified">
+        <source>NETSDK1001: At least one possible target framework must be specified.</source>
+        <target state="translated">NETSDK1001: 가능한 대상 프레임워크를 하나 이상 지정해야 합니다.</target>
+        <note>{StrBegin="NETSDK1001: "}</note>
       </trans-unit>
-      <trans-unit id="MultipleFilesResolved">
-        <source>NETSDK1021: More than one file found for {0}</source>
-        <target state="translated">NETSDK1021: {0}에 대해 두 개 이상의 파일을 찾았습니다.</target>
-        <note>{StrBegin="NETSDK1021: "}</note>
+      <trans-unit id="CannotFindApphostForRid">
+        <source>NETSDK1065: Cannot find app host for {0}. {0} could be an invalid runtime identifier (RID). For more information about RID, see https://aka.ms/rid-catalog.</source>
+        <target state="translated">NETSDK1065: {0}에 대한 앱 호스트를 찾을 수 없습니다. {0}이(가) 잘못된 RID(런타임 식별자)일 수 있습니다. RID에 대한 자세한 내용은 https://aka.ms/rid-catalog를 참조하세요.</target>
+        <note>{StrBegin="NETSDK1065: "}</note>
       </trans-unit>
-      <trans-unit id="FolderAlreadyExists">
-        <source>NETSDK1024: Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</source>
-        <target state="translated">NETSDK1024: '{0}' 폴더가 이미 있습니다. 폴더를 삭제하거나 다른 ComposeWorkingDir을 제공하세요.</target>
-        <note>{StrBegin="NETSDK1024: "}</note>
+      <trans-unit id="CannotFindProjectInfo">
+        <source>NETSDK1007: Cannot find project info for '{0}'. This can indicate a missing project reference.</source>
+        <target state="translated">NETSDK1007: '{0}'에 대한 프로젝트 정보를 찾을 수 없습니다. 프로젝트 참조가 없음을 나타낼 수 있습니다.</target>
+        <note>{StrBegin="NETSDK1007: "}</note>
       </trans-unit>
-      <trans-unit id="ParsingFiles">
-        <source>NETSDK1026: Parsing the Files : '{0}'</source>
-        <target state="translated">NETSDK1026: 파일 구문 분석: '{0}'</target>
-        <note>{StrBegin="NETSDK1026: "}</note>
-      </trans-unit>
-      <trans-unit id="PackageInfoLog">
-        <source>NETSDK1027: Package Name='{0}', Version='{1}' was parsed</source>
-        <target state="translated">NETSDK1027: 패키지 이름='{0}', 버전='{1}'이(가) 구문 분석되었습니다.</target>
-        <note>{StrBegin="NETSDK1027: "}</note>
-      </trans-unit>
-      <trans-unit id="RuntimeIdentifierWasNotSpecified">
-        <source>NETSDK1028: Specify a RuntimeIdentifier</source>
-        <target state="translated">NETSDK1028: RuntimeIdentifier 지정</target>
-        <note>{StrBegin="NETSDK1028: "}</note>
-      </trans-unit>
-      <trans-unit id="IncorrectTargetFormat">
-        <source>NETSDK1025: WRThe target manifest {0} provided is of not the correct format</source>
-        <target state="translated">NETSDK1025: 제공한 대상 매니페스트 {0}이(가) 올바른 형식이 아닙니다.</target>
-        <note>{StrBegin="NETSDK1025: "}</note>
-      </trans-unit>
-      <trans-unit id="AppHostHasBeenModified">
-        <source>NETSDK1029: Unable to use '{0}' as application host executable as it does not contain the expected placeholder byte sequence '{1}' that would mark where the application name would be written.</source>
-        <target state="translated">NETSDK1029: 애플리케이션 이름이 기록되는 위치를 표시하는 '{1}' 예상 자리 표시자 바이트 시퀀스가 포함되지 않아서 '{0}'을(를) 애플리케이션 호스트 실행 파일로 사용할 수 없습니다.</target>
-        <note>{StrBegin="NETSDK1029: "}</note>
-      </trans-unit>
-      <trans-unit id="FileNameIsTooLong">
-        <source>NETSDK1030: Given file name '{0}' is longer than 1024 bytes</source>
-        <target state="translated">NETSDK1030: 제공한 파일 이름 '{0}'이(가) 1024바이트보다 깁니다.</target>
-        <note>{StrBegin="NETSDK1030: "}</note>
+      <trans-unit id="CannotHaveRuntimeIdentifierPlatformMismatchPlatformTarget">
+        <source>NETSDK1032: The RuntimeIdentifier platform '{0}' and the PlatformTarget '{1}' must be compatible.</source>
+        <target state="translated">NETSDK1032: RuntimeIdentifier 플랫폼 '{0}'과(와) PlatformTarget '{1}'은(는) 호환되어야 합니다.</target>
+        <note>{StrBegin="NETSDK1032: "}</note>
       </trans-unit>
       <trans-unit id="CannotHaveSelfContainedWithoutRuntimeIdentifier">
         <source>NETSDK1031: It is not supported to build or publish a self-contained application without specifying a RuntimeIdentifier.  Please either specify a RuntimeIdentifier or set SelfContained to false.</source>
         <target state="translated">NETSDK1031: RuntimeIdentifier를 지정하지 않으면 자체 포함 애플리케이션의 빌드 또는 게시가 지원되지 않습니다. RuntimeIdentifier를 지정하거나 SelfContained를 false로 설정하세요.</target>
         <note>{StrBegin="NETSDK1031: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotInferTargetFrameworkIdentifierAndVersion">
+        <source>NETSDK1013: The TargetFramework value '{0}' was not recognized. It may be misspelled. If not, then the TargetFrameworkIdentifier and/or TargetFrameworkVersion properties must be specified explicitly.</source>
+        <target state="translated">NETSDK1013: TargetFramework 값 '{0}'을(를) 인식하지 못했습니다. 철자가 틀렸을 수 있습니다. 그렇지 않은 경우 TargetFrameworkIdentifier 및/또는 TargetFrameworkVersion 속성을 명시적으로 지정해야 합니다.</target>
+        <note>{StrBegin="NETSDK1013: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotUseSelfContainedWithoutAppHost">
+        <source>NETSDK1067: Self-contained applications are required to use the application host. Either set SelfContained to false or set UseAppHost to true.</source>
+        <target state="translated">NETSDK1067: 애플리케이션 호스트를 사용하려면 자체 포함 애플리케이션이 필요합니다. SelfContained를 false로 설정하거나 UseAppHost를 true로 설정하세요.</target>
+        <note>{StrBegin="NETSDK1067: "}</note>
       </trans-unit>
       <trans-unit id="ChoosingAssemblyVersion">
         <source>NETSDK1033: Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</source>
@@ -272,6 +132,16 @@
         <target state="translated">NETSDK1037: 동일한 파일 및 어셈블리 버전으로 인해 적용되는 내용을 확인할 수 없습니다.</target>
         <note>{StrBegin="NETSDK1037: "}</note>
       </trans-unit>
+      <trans-unit id="ContentItemDoesNotProvideOutputPath">
+        <source>NETSDK1014: Content item for '{0}' sets '{1}', but does not provide  '{2}' or '{3}'.</source>
+        <target state="translated">NETSDK1014: '{0}'의 콘텐츠 항목이 '{1}'을(를) 설정하지만, '{2}' 또는 '{3}'을(를) 제공하지 않습니다.</target>
+        <note>{StrBegin="NETSDK1014: "}</note>
+      </trans-unit>
+      <trans-unit id="ContentPreproccessorParameterRequired">
+        <source>NETSDK1010: The '{0}' task must be given a value for parameter '{1}' in order to consume preprocessed content.</source>
+        <target state="translated">NETSDK1010: 전처리된 콘텐츠를 사용하려면 '{0}' 작업에서 '{1}' 매개 변수의 값을 지정해야 합니다.</target>
+        <note>{StrBegin="NETSDK1010: "}</note>
+      </trans-unit>
       <trans-unit id="CouldNotDetermineWinner_DoesntExist">
         <source>NETSDK1038: Could not determine winner because '{0}' does not exist.</source>
         <target state="translated">NETSDK1038: '{0}'이(가) 존재하지 않기 때문에 적용되는 내용을 확인할 수 없습니다.</target>
@@ -287,15 +157,40 @@
         <target state="translated">NETSDK1040: '{0}'이(가) 어셈블리가 아니기 때문에 적용되는 내용을 확인할 수 없습니다.</target>
         <note>{StrBegin="NETSDK1040: "}</note>
       </trans-unit>
+      <trans-unit id="CouldNotLoadPlatformManifest">
+        <source>NETSDK1042: Could not load PlatformManifest from '{0}' because it did not exist.</source>
+        <target state="translated">NETSDK1042: PlatformManifest가 존재하지 않기 때문에 '{0}'에서 로드할 수 없습니다.</target>
+        <note>{StrBegin="NETSDK1042: "}</note>
+      </trans-unit>
+      <trans-unit id="DotnetToolDoesNotSupportTFMLowerThanNetcoreapp21">
+        <source>NETSDK1055: DotnetTool does not support target framework lower than netcoreapp2.1.</source>
+        <target state="translated">NETSDK1055: DotnetTool가 netcoreapp2.1보다 낮은 대상 프레임워크를 지원하지 않습니다.</target>
+        <note>{StrBegin="NETSDK1055: "}</note>
+      </trans-unit>
+      <trans-unit id="DotnetToolOnlySupportNetcoreapp">
+        <source>NETSDK1054: only supports .NET Core.</source>
+        <target state="translated">NETSDK1054: .NET Core만 지원합니다.</target>
+        <note>{StrBegin="NETSDK1054: "}</note>
+      </trans-unit>
+      <trans-unit id="DuplicateItemsError">
+        <source>NETSDK1022: Duplicate '{0}' items were included. The .NET SDK includes '{0}' items from your project directory by default. You can either remove these items from your project file, or set the '{1}' property to '{2}' if you want to explicitly include them in your project file. For more information, see {4}. The duplicate items were: {3}</source>
+        <target state="translated">NETSDK1022: '{0}' 중복 항목이 포함되었습니다. .NET SDK에는 기본적으로 프로젝트 디렉터리의 '{0}' 항목이 포함됩니다. 프로젝트 파일에서 이러한 항목을 제거하거나, 프로젝트 파일에 해당 항목을 명시적으로 포함하려면 '{1}' 속성을 '{2}'(으)로 설정할 수 있습니다. 자세한 내용은 {4}을(를) 참조하세요. 중복 항목은 다음과 같습니다. {3}</target>
+        <note>{StrBegin="NETSDK1022: "}</note>
+      </trans-unit>
+      <trans-unit id="DuplicatePreprocessorToken">
+        <source>NETSDK1015: The preprocessor token '{0}' has been given more than one value. Choosing '{1}' as the value.</source>
+        <target state="translated">NETSDK1015: 전처리기 토큰 '{0}'의 값이 두 개 이상 지정되었습니다. '{1}'을(를) 값으로 선택합니다.</target>
+        <note>{StrBegin="NETSDK1015: "}</note>
+      </trans-unit>
       <trans-unit id="EncounteredConflict">
         <source>NETSDK1041: Encountered conflict between '{0}' and '{1}'.</source>
         <target state="translated">NETSDK1041: '{0}'과(와) '{1}' 사이에 충돌이 발생했습니다.</target>
         <note>{StrBegin="NETSDK1041: "}</note>
       </trans-unit>
-      <trans-unit id="CouldNotLoadPlatformManifest">
-        <source>NETSDK1042: Could not load PlatformManifest from '{0}' because it did not exist.</source>
-        <target state="translated">NETSDK1042: PlatformManifest가 존재하지 않기 때문에 '{0}'에서 로드할 수 없습니다.</target>
-        <note>{StrBegin="NETSDK1042: "}</note>
+      <trans-unit id="ErrorParsingFrameworkListInvalidValue">
+        <source>NETSDK1051: Error parsing FrameworkList from '{0}'.  {1} '{2}' was invalid.</source>
+        <target state="translated">NETSDK1051: '{0}'의 FrameworkList를 구문 분석하는 동안 오류가 발생했습니다. {1} '{2}'이(가) 잘못되었습니다.</target>
+        <note>{StrBegin="NETSDK1051: "}</note>
       </trans-unit>
       <trans-unit id="ErrorParsingPlatformManifest">
         <source>NETSDK1043: Error parsing PlatformManifest from '{0}' line {1}.  Lines must have the format {2}.</source>
@@ -307,65 +202,55 @@
         <target state="translated">NETSDK1044: '{0}' 줄 {1}에서 PlatformManifest를 구문 분석하는 중 오류가 발생했습니다. {2} '{3}'이(가) 잘못되었습니다.</target>
         <note>{StrBegin="NETSDK1044: "}</note>
       </trans-unit>
-      <trans-unit id="UnsupportedTargetFrameworkVersion">
-        <source>NETSDK1045: The current .NET SDK does not support targeting {0} {1}.  Either target {0} {2} or lower, or use a version of the .NET SDK that supports {0} {1}.</source>
-        <target state="translated">NETSDK1045: 현재 .NET SDK에서는 {0} {1}을(를) 대상으로 하는 것을 지원하지 않습니다. {0} {2} 이하를 대상으로 하거나 {0} {1}을(를) 지원하는 .NET SDK 버전을 사용하세요.</target>
-        <note>{StrBegin="NETSDK1045: "}</note>
+      <trans-unit id="ErrorReadingAssetsFile">
+        <source>NETSDK1060: Error reading assets file: {0}</source>
+        <target state="translated">NETSDK1060: 자산 파일 {0}을(를) 읽는 동안 오류가 발생했습니다.</target>
+        <note>{StrBegin="NETSDK1060: "}</note>
       </trans-unit>
-      <trans-unit id="AssetsFileMissingRuntimeIdentifier">
-        <source>NETSDK1047: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project. You may also need to include '{3}' in your project's RuntimeIdentifiers.</source>
-        <target state="translated">NETSDK1047: 자산 파일 '{0}'에 '{1}'의 대상이 없습니다. 복원이 실행되었으며 프로젝트의 TargetFrameworks에 '{2}'을(를) 포함했는지 확인하세요. 프로젝트의 RuntimeIdentifiers에 '{3}'을(를) 포함해야 할 수도 있습니다.</target>
-        <note>{StrBegin="NETSDK1047: "}</note>
+      <trans-unit id="FailedToLockResource">
+        <source>NETSDK1077: Failed to lock resource.</source>
+        <target state="translated">NETSDK1077: 리소스를 잠그지 못했습니다.</target>
+        <note>{StrBegin="NETSDK1077: "}</note>
       </trans-unit>
-      <trans-unit id="TargetFrameworkWithSemicolon">
-        <source>NETSDK1046: The TargetFramework value '{0}' is not valid. To multi-target, use the 'TargetFrameworks' property instead.</source>
-        <target state="translated">NETSDK1046: TargetFramework 값 '{0}'이(가) 잘못되었습니다. 여러 대상을 지정하려면 'TargetFrameworks' 속성을 대신 사용하세요.</target>
-        <note>{StrBegin="NETSDK1046: "}</note>
+      <trans-unit id="FileNameIsTooLong">
+        <source>NETSDK1030: Given file name '{0}' is longer than 1024 bytes</source>
+        <target state="translated">NETSDK1030: 제공한 파일 이름 '{0}'이(가) 1024바이트보다 깁니다.</target>
+        <note>{StrBegin="NETSDK1030: "}</note>
       </trans-unit>
-      <trans-unit id="GetDependsOnNETStandardFailedWithException">
-        <source>NETSDK1049: Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0} {1}</source>
-        <target state="translated">NETSDK1049: 확인된 파일의 이미지가 잘못되었거나, 메타데이터가 없거나, 파일 자체에 액세스할 수 없습니다. {0} {1}</target>
-        <note>{StrBegin="NETSDK1049: "}</note>
+      <trans-unit id="FolderAlreadyExists">
+        <source>NETSDK1024: Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</source>
+        <target state="translated">NETSDK1024: '{0}' 폴더가 이미 있습니다. 폴더를 삭제하거나 다른 ComposeWorkingDir을 제공하세요.</target>
+        <note>{StrBegin="NETSDK1024: "}</note>
       </trans-unit>
-      <trans-unit id="UnsupportedSDKVersionForNetStandard20">
-        <source>NETSDK1050: The version of Microsoft.NET.Sdk used by this project is insufficient to support references to libraries targeting .NET Standard 1.5 or higher.  Please install version 2.0 or higher of the .NET Core SDK.</source>
-        <target state="translated">NETSDK1050: 이 프로젝트에서 사용하는 Microsoft.NET.Sdk 버전은 .NET Standard 1.5 이상을 대상으로 하는 라이브러리에 대한 참조를 지원할 수 없습니다. .NET Core SDK 버전 2.0 이상을 설치하세요.</target>
-        <note>{StrBegin="NETSDK1050: "}</note>
-      </trans-unit>
-      <trans-unit id="SkippingAdditionalProbingPaths">
-        <source>NETSDK1048: 'AdditionalProbingPaths' were specified for GenerateRuntimeConfigurationFiles, but are being skipped because 'RuntimeConfigDevPath' is empty.</source>
-        <target state="translated">NETSDK1048: GenerateRuntimeConfigurationFiles에 대해 'AdditionalProbingPaths'가 지정되었지만 'RuntimeConfigDevPath'가 비어 있어서 건너뜁니다.</target>
-        <note>{StrBegin="NETSDK1048: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotHaveRuntimeIdentifierPlatformMismatchPlatformTarget">
-        <source>NETSDK1032: The RuntimeIdentifier platform '{0}' and the PlatformTarget '{1}' must be compatible.</source>
-        <target state="translated">NETSDK1032: RuntimeIdentifier 플랫폼 '{0}'과(와) PlatformTarget '{1}'은(는) 호환되어야 합니다.</target>
-        <note>{StrBegin="NETSDK1032: "}</note>
-      </trans-unit>
-      <trans-unit id="ErrorParsingFrameworkListInvalidValue">
-        <source>NETSDK1051: Error parsing FrameworkList from '{0}'.  {1} '{2}' was invalid.</source>
-        <target state="translated">NETSDK1051: '{0}'의 FrameworkList를 구문 분석하는 동안 오류가 발생했습니다. {1} '{2}'이(가) 잘못되었습니다.</target>
-        <note>{StrBegin="NETSDK1051: "}</note>
+      <trans-unit id="FrameworkDependentAppHostRequiresVersion21">
+        <source>NETSDK1068: The framework-dependent application host requires a target framework of at least 'netcoreapp2.1'.</source>
+        <target state="translated">NETSDK1068: 프레임워크 종속 애플리케이션 호스트는 'netcoreapp2.1' 이상의 대상 프레임워크가 필요합니다.</target>
+        <note>{StrBegin="NETSDK1068: "}</note>
       </trans-unit>
       <trans-unit id="FrameworkListPathNotRooted">
         <source>NETSDK1052: Framework list file path '{0}' is not rooted. Only full paths are supported.</source>
         <target state="translated">NETSDK1052: 프레임워크 목록 파일 경로 '{0}'이(가) 루트에서 시작하지 않습니다. 전체 경로만 지원됩니다.</target>
         <note>{StrBegin="NETSDK1052: "}</note>
       </trans-unit>
-      <trans-unit id="PackAsToolCannotSupportSelfContained">
-        <source>NETSDK1053: Pack as tool does not support self contained.</source>
-        <target state="translated">NETSDK1053: 도구로서 팩은 자체 포함을 지원하지 않습니다.</target>
-        <note>{StrBegin="NETSDK1001: "}</note>
+      <trans-unit id="GetDependsOnNETStandardFailedWithException">
+        <source>NETSDK1049: Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0} {1}</source>
+        <target state="translated">NETSDK1049: 확인된 파일의 이미지가 잘못되었거나, 메타데이터가 없거나, 파일 자체에 액세스할 수 없습니다. {0} {1}</target>
+        <note>{StrBegin="NETSDK1049: "}</note>
       </trans-unit>
-      <trans-unit id="UnsupportedRuntimeIdentifier">
-        <source>NETSDK1056: Project is targeting runtime '{0}' but did not resolve any runtime-specific packages. This runtime may not be supported by the target framework.</source>
-        <target state="translated">NETSDK1056: 프로젝트가 런타임 '{0}'을(를) 대상으로 하지만 런타임 관련 패키지를 확인하지 않았습니다. 이 런타임은 대상 프레임워크에서 지원되지 않을 수 있습니다.</target>
-        <note>{StrBegin="NETSDK1056: "}</note>
+      <trans-unit id="IncorrectPackageRoot">
+        <source>NETSDK1020: Package Root {0} was incorrectly given for Resolved library {1}</source>
+        <target state="translated">NETSDK1020: 패키지 루트 {0}이(가) 확인된 라이브러리 {1}에 대해 잘못 지정되었습니다.</target>
+        <note>{StrBegin="NETSDK1020: "}</note>
       </trans-unit>
-      <trans-unit id="UsingPreviewSdkWarning">
-        <source>NETSDK1057: You are using a preview version of .NET Core. See: https://aka.ms/dotnet-core-preview</source>
-        <target state="translated">NETSDK1057: .NET Core의 미리 보기 버전을 사용 중입니다. 참조: https://aka.ms/dotnet-core-preview</target>
-        <note>{StrBegin="NETSDK1057: "}</note>
+      <trans-unit id="IncorrectTargetFormat">
+        <source>NETSDK1025: WRThe target manifest {0} provided is of not the correct format</source>
+        <target state="translated">NETSDK1025: 제공한 대상 매니페스트 {0}이(가) 올바른 형식이 아닙니다.</target>
+        <note>{StrBegin="NETSDK1025: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidFrameworkName">
+        <source>NETSDK1003: Invalid framework name: '{0}'.</source>
+        <target state="translated">NETSDK1003: 프레임워크 이름 '{0}'이(가) 잘못되었습니다.</target>
+        <note>{StrBegin="NETSDK1003: "}</note>
       </trans-unit>
       <trans-unit id="InvalidItemSpecToUse">
         <source>NETSDK1058: Invalid value for ItemSpecToUse parameter: '{0}'.  This property must be blank or set to 'Left' or 'Right'</source>
@@ -373,15 +258,15 @@
         <note>{StrBegin="NETSDK1058: "}
 The following are names of parameters or literal values and should not be translated: ItemSpecToUse, Left, Right</note>
       </trans-unit>
-      <trans-unit id="ProjectContainsObsoleteDotNetCliTool">
-        <source>NETSDK1059: The tool '{0}' is now included in the .NET Core SDK. Information on resolving this warning is available at (https://aka.ms/dotnetclitools-in-box).</source>
-        <target state="translated">NETSDK1059: '{0}' 도구가 현재 .NET Core SDK에 포함되어 있습니다. 이 경고를 해결하는 방법은 https://aka.ms/dotnetclitools-in-box를 참조하세요.</target>
-        <note>{StrBegin="NETSDK1059: "}</note>
+      <trans-unit id="InvalidNuGetVersionString">
+        <source>NETSDK1018: Invalid NuGet version string: '{0}'.</source>
+        <target state="translated">NETSDK1018: NuGet 버전 문자열 '{0}'이(가) 잘못되었습니다.</target>
+        <note>{StrBegin="NETSDK1018: "}</note>
       </trans-unit>
-      <trans-unit id="ErrorReadingAssetsFile">
-        <source>NETSDK1060: Error reading assets file: {0}</source>
-        <target state="translated">NETSDK1060: 자산 파일 {0}을(를) 읽는 동안 오류가 발생했습니다.</target>
-        <note>{StrBegin="NETSDK1060: "}</note>
+      <trans-unit id="InvalidResourceUpdate">
+        <source>NETSDK1075: Update handle is invalid. This instance may not be used for further updates.</source>
+        <target state="translated">NETSDK1075: 업데이트 핸들이 잘못되었습니다. 이 인스턴스는 추가 업데이트에 사용할 수 없습니다.</target>
+        <note>{StrBegin="NETSDK1075: "}</note>
       </trans-unit>
       <trans-unit id="MismatchedPlatformPackageVersion">
         <source>NETSDK1061: The project was restored using {0} version {1}, but with current settings, version {2} would be used instead. To resolve this issue, make sure the same settings are used for restore and for subsequent operations such as build or publish. Typically this issue can occur if the RuntimeIdentifier property is set during build or publish but not during restore. For more information, see https://aka.ms/dotnet-runtime-patch-selection.</source>
@@ -391,35 +276,150 @@ The following are names of parameters or literal values and should not be transl
 {1} - Restored version of platform package
 {2} - Current version of platform package</note>
       </trans-unit>
-      <trans-unit id="AssetsFileNotSet">
-        <source>NETSDK1063: The path to the project assets file was not set. Run a NuGet package restore to generate this file.</source>
-        <target state="translated">NETSDK1063: 프로젝트 자산 파일에 대한 경로가 설정되지 않았습니다. NuGet 패키지 복원을 실행하여 이 파일을 생성하세요.</target>
-        <note>{StrBegin="NETSDK1063: "}</note>
+      <trans-unit id="MissingItemMetadata">
+        <source>NETSDK1008: Missing '{0}' metadata on '{1}' item '{2}'.</source>
+        <target state="translated">NETSDK1008: '{1}' 항목 '{2}'에 '{0}' 메타데이터가 없습니다.</target>
+        <note>{StrBegin="NETSDK1008: "}</note>
       </trans-unit>
-      <trans-unit id="DotnetToolOnlySupportNetcoreapp">
-        <source>NETSDK1054: only supports .NET Core.</source>
-        <target state="translated">NETSDK1054: .NET Core만 지원합니다.</target>
-        <note>{StrBegin="NETSDK1054: "}</note>
+      <trans-unit id="MultipleFilesResolved">
+        <source>NETSDK1021: More than one file found for {0}</source>
+        <target state="translated">NETSDK1021: {0}에 대해 두 개 이상의 파일을 찾았습니다.</target>
+        <note>{StrBegin="NETSDK1021: "}</note>
       </trans-unit>
-      <trans-unit id="DotnetToolDoesNotSupportTFMLowerThanNetcoreapp21">
-        <source>NETSDK1055: DotnetTool does not support target framework lower than netcoreapp2.1.</source>
-        <target state="translated">NETSDK1055: DotnetTool가 netcoreapp2.1보다 낮은 대상 프레임워크를 지원하지 않습니다.</target>
-        <note>{StrBegin="NETSDK1055: "}</note>
+      <trans-unit id="NETFrameworkToNonBuiltInNETStandard">
+        <source>NETSDK1069: This project uses a library that targets .NET Standard 1.5 or higher, and the project targets a version of .NET Framework that doesn't have built-in support for that version of .NET Standard. Visit https://aka.ms/net-standard-known-issues for a set of known issues. Consider retargeting to .NET Framework 4.7.2.</source>
+        <target state="translated">NETSDK1069: 이 프로젝트는 .NET Standard 1.5 이상을 대상으로 하는 라이브러리를 사용하며, 이 프로젝트는 해당 버전의 .NET Standard를 기본으로 제공하지 않는 .NET Framework 버전을 대상으로 합니다. 알려진 문제에 대해서는 https://aka.ms/net-standard-known-issues를 참조하세요. .NET Framework 4.7.2로 대상을 다시 지정해 보세요.</target>
+        <note>{StrBegin="NETSDK1069: "}</note>
       </trans-unit>
-      <trans-unit id="UnableToUsePackageAssetsCache">
-        <source>NETSDK1062: Unable to use package assets cache due to I/O error. This can occur when the same project is built more than once in parallel. Performance may be degraded, but the build result will not be impacted.</source>
-        <target state="translated">NETSDK1062: I/O 오류로 인해 패키지 자산 캐시를 사용할 수 없습니다. 동일한 프로젝트가 두 번 이상 동시에 빌드되면 이 오류가 발생합니다. 성능이 저하될 수 있지만 빌드 결과는 영향을 받지 않습니다.</target>
-        <note>{StrBegin="NETSDK1062: "}</note>
+      <trans-unit id="NoAppHostAvailable">
+        <source>NETSDK1084: There is no application host available for the specified RuntimeIdentifier '{0}'.</source>
+        <target state="new">NETSDK1084: There is no application host available for the specified RuntimeIdentifier '{0}'.</target>
+        <note>{StrBegin="NETSDK1084: "}</note>
+      </trans-unit>
+      <trans-unit id="NoCompatibleTargetFramework">
+        <source>NETSDK1002: Project '{0}' targets '{2}'. It cannot be referenced by a project that targets '{1}'.</source>
+        <target state="translated">NETSDK1002: '{0}' 프로젝트가 '{2}'을(를) 대상으로 합니다. '{1}'을(를) 대상으로 하는 프로젝트에서 참조할 수 없습니다.</target>
+        <note>{StrBegin="NETSDK1002: "}</note>
+      </trans-unit>
+      <trans-unit id="NoRuntimePackAvailable">
+        <source>NETSDK1082: There was no runtime pack for {0} available for the specified RuntimeIdentifier '{1}'.</source>
+        <target state="new">NETSDK1082: There was no runtime pack for {0} available for the specified RuntimeIdentifier '{1}'.</target>
+        <note>{StrBegin="NETSDK1082: "}</note>
+      </trans-unit>
+      <trans-unit id="PackAsToolCannotSupportSelfContained">
+        <source>NETSDK1053: Pack as tool does not support self contained.</source>
+        <target state="translated">NETSDK1053: 도구로서 팩은 자체 포함을 지원하지 않습니다.</target>
+        <note>{StrBegin="NETSDK1001: "}</note>
+      </trans-unit>
+      <trans-unit id="PackageInfoLog">
+        <source>NETSDK1027: Package Name='{0}', Version='{1}' was parsed</source>
+        <target state="translated">NETSDK1027: 패키지 이름='{0}', 버전='{1}'이(가) 구문 분석되었습니다.</target>
+        <note>{StrBegin="NETSDK1027: "}</note>
       </trans-unit>
       <trans-unit id="PackageNotFound">
         <source>NETSDK1064: Package {0}, version {1} was not found. It might have been deleted since NuGet restore. Otherwise, NuGet restore might have only partially completed, which might have been due to maximum path length restrictions.</source>
         <target state="translated">NETSDK1064: 패키지 {0}, 버전 {1}을(를) 찾을 수 없습니다. NuGet 복원 이후 삭제되었을 수 있습니다. 아니면, 최대 경로 길이 제한으로 인해 NuGet 복원이 부분적으로만 완료되었을 수 있습니다.</target>
         <note>{StrBegin="NETSDK1064: "}</note>
       </trans-unit>
-      <trans-unit id="CannotFindApphostForRid">
-        <source>NETSDK1065: Cannot find app host for {0}. {0} could be an invalid runtime identifier (RID). For more information about RID, see https://aka.ms/rid-catalog.</source>
-        <target state="translated">NETSDK1065: {0}에 대한 앱 호스트를 찾을 수 없습니다. {0}이(가) 잘못된 RID(런타임 식별자)일 수 있습니다. RID에 대한 자세한 내용은 https://aka.ms/rid-catalog를 참조하세요.</target>
-        <note>{StrBegin="NETSDK1065: "}</note>
+      <trans-unit id="PackageReferenceOverrideWarning">
+        <source>NETSDK1023: A PackageReference for '{0}' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see {1}</source>
+        <target state="translated">NETSDK1023: '{0}'에 대한 PackageReference가 프로젝트에 포함되어 있습니다. 이 패키지는 .NET SDK에서 암시적으로 참조되며, 일반적으로 사용자가 프로젝트에서 참조할 필요가 없습니다. 자세한 내용은 {1}을(를) 참조하세요.</target>
+        <note>{StrBegin="NETSDK1023: "}</note>
+      </trans-unit>
+      <trans-unit id="PackageReferenceVersionNotRecommended">
+        <source>NETSDK1071: A PackageReference to '{0}' specified a Version of `{1}`. Specifying the version of this package is not recommended. For more information, see https://aka.ms/sdkimplicitrefs</source>
+        <target state="translated">NETSDK1071: '{0}'에 대한 PackageReference에서 `{1}`의 버전을 지정했습니다. 이 패키지의 버전을 지정하지 않는 것이 좋습니다. 자세한 내용은 https://aka.ms/sdkimplicitrefs를 참조하세요.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParsingFiles">
+        <source>NETSDK1026: Parsing the Files : '{0}'</source>
+        <target state="translated">NETSDK1026: 파일 구문 분석: '{0}'</target>
+        <note>{StrBegin="NETSDK1026: "}</note>
+      </trans-unit>
+      <trans-unit id="ProjectAssetsConsumedWithoutMSBuildProjectPath">
+        <source>NETSDK1011: Assets are consumed from project '{0}', but no corresponding MSBuild project path was  found in '{1}'.</source>
+        <target state="translated">NETSDK1011: '{0}' 프로젝트의 자산이 사용되었지만, '{1}'에서 해당 MSBuild 프로젝트 경로를 찾을 수 없습니다.</target>
+        <note>{StrBegin="NETSDK1011: "}</note>
+      </trans-unit>
+      <trans-unit id="ProjectContainsObsoleteDotNetCliTool">
+        <source>NETSDK1059: The tool '{0}' is now included in the .NET Core SDK. Information on resolving this warning is available at (https://aka.ms/dotnetclitools-in-box).</source>
+        <target state="translated">NETSDK1059: '{0}' 도구가 현재 .NET Core SDK에 포함되어 있습니다. 이 경고를 해결하는 방법은 https://aka.ms/dotnetclitools-in-box를 참조하세요.</target>
+        <note>{StrBegin="NETSDK1059: "}</note>
+      </trans-unit>
+      <trans-unit id="RuntimeIdentifierNotRecognized">
+        <source>NETSDK1083: The specified RuntimeIdentifier '{0}' is not recognized.</source>
+        <target state="new">NETSDK1083: The specified RuntimeIdentifier '{0}' is not recognized.</target>
+        <note>{StrBegin="NETSDK1083: "}</note>
+      </trans-unit>
+      <trans-unit id="RuntimeIdentifierWasNotSpecified">
+        <source>NETSDK1028: Specify a RuntimeIdentifier</source>
+        <target state="translated">NETSDK1028: RuntimeIdentifier 지정</target>
+        <note>{StrBegin="NETSDK1028: "}</note>
+      </trans-unit>
+      <trans-unit id="SkippingAdditionalProbingPaths">
+        <source>NETSDK1048: 'AdditionalProbingPaths' were specified for GenerateRuntimeConfigurationFiles, but are being skipped because 'RuntimeConfigDevPath' is empty.</source>
+        <target state="translated">NETSDK1048: GenerateRuntimeConfigurationFiles에 대해 'AdditionalProbingPaths'가 지정되었지만 'RuntimeConfigDevPath'가 비어 있어서 건너뜁니다.</target>
+        <note>{StrBegin="NETSDK1048: "}</note>
+      </trans-unit>
+      <trans-unit id="TargetFrameworkWithSemicolon">
+        <source>NETSDK1046: The TargetFramework value '{0}' is not valid. To multi-target, use the 'TargetFrameworks' property instead.</source>
+        <target state="translated">NETSDK1046: TargetFramework 값 '{0}'이(가) 잘못되었습니다. 여러 대상을 지정하려면 'TargetFrameworks' 속성을 대신 사용하세요.</target>
+        <note>{StrBegin="NETSDK1046: "}</note>
+      </trans-unit>
+      <trans-unit id="UnableToFindResolvedPath">
+        <source>NETSDK1016: Unable to find resolved path for '{0}'.</source>
+        <target state="translated">NETSDK1016: '{0}'에 대해 확인된 경로를 찾을 수 없습니다.</target>
+        <note>{StrBegin="NETSDK1016: "}</note>
+      </trans-unit>
+      <trans-unit id="UnableToUsePackageAssetsCache">
+        <source>NETSDK1062: Unable to use package assets cache due to I/O error. This can occur when the same project is built more than once in parallel. Performance may be degraded, but the build result will not be impacted.</source>
+        <target state="translated">NETSDK1062: I/O 오류로 인해 패키지 자산 캐시를 사용할 수 없습니다. 동일한 프로젝트가 두 번 이상 동시에 빌드되면 이 오류가 발생합니다. 성능이 저하될 수 있지만 빌드 결과는 영향을 받지 않습니다.</target>
+        <note>{StrBegin="NETSDK1062: "}</note>
+      </trans-unit>
+      <trans-unit id="UnexpectedFileType">
+        <source>NETSDK1012: Unexpected file type for '{0}'. Type is both '{1}' and '{2}'.</source>
+        <target state="translated">NETSDK1012: '{0}'에 대해 예기치 않은 파일 형식입니다. 형식이 '{1}'인 동시에 '{2}'입니다.</target>
+        <note>{StrBegin="NETSDK1012: "}</note>
+      </trans-unit>
+      <trans-unit id="UnknownFrameworkReference">
+        <source>NETSDK1073: The FrameworkReference '{0}' was not recognized</source>
+        <target state="translated">NETSDK1073: FrameworkReference '{0}'이(가) 인식되지 않았습니다.</target>
+        <note>{StrBegin="NETSDK1073: "}</note>
+      </trans-unit>
+      <trans-unit id="UnrecognizedPreprocessorToken">
+        <source>NETSDK1009: Unrecognized preprocessor token '{0}' in '{1}'.</source>
+        <target state="translated">NETSDK1009: '{1}'에서 전처리기 토큰 '{0}'을(를) 인식할 수 없습니다.</target>
+        <note>{StrBegin="NETSDK1009: "}</note>
+      </trans-unit>
+      <trans-unit id="UnresolvedTargetingPack">
+        <source>NETSDK1081: The targeting pack for {0} was not found. You may be able to resolve this by running a NuGet restore on the project.</source>
+        <target state="new">NETSDK1081: The targeting pack for {0} was not found. You may be able to resolve this by running a NuGet restore on the project.</target>
+        <note>{StrBegin="NETSDK1081: "}</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedFramework">
+        <source>NETSDK1019: {0} is an unsupported framework.</source>
+        <target state="translated">NETSDK1019: {0}은(는) 지원되지 않는 프레임워크입니다.</target>
+        <note>{StrBegin="NETSDK1019: "}</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedRuntimeIdentifier">
+        <source>NETSDK1056: Project is targeting runtime '{0}' but did not resolve any runtime-specific packages. This runtime may not be supported by the target framework.</source>
+        <target state="translated">NETSDK1056: 프로젝트가 런타임 '{0}'을(를) 대상으로 하지만 런타임 관련 패키지를 확인하지 않았습니다. 이 런타임은 대상 프레임워크에서 지원되지 않을 수 있습니다.</target>
+        <note>{StrBegin="NETSDK1056: "}</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedSDKVersionForNetStandard20">
+        <source>NETSDK1050: The version of Microsoft.NET.Sdk used by this project is insufficient to support references to libraries targeting .NET Standard 1.5 or higher.  Please install version 2.0 or higher of the .NET Core SDK.</source>
+        <target state="translated">NETSDK1050: 이 프로젝트에서 사용하는 Microsoft.NET.Sdk 버전은 .NET Standard 1.5 이상을 대상으로 하는 라이브러리에 대한 참조를 지원할 수 없습니다. .NET Core SDK 버전 2.0 이상을 설치하세요.</target>
+        <note>{StrBegin="NETSDK1050: "}</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedTargetFrameworkVersion">
+        <source>NETSDK1045: The current .NET SDK does not support targeting {0} {1}.  Either target {0} {2} or lower, or use a version of the .NET SDK that supports {0} {1}.</source>
+        <target state="translated">NETSDK1045: 현재 .NET SDK에서는 {0} {1}을(를) 대상으로 하는 것을 지원하지 않습니다. {0} {2} 이하를 대상으로 하거나 {0} {1}을(를) 지원하는 .NET SDK 버전을 사용하세요.</target>
+        <note>{StrBegin="NETSDK1045: "}</note>
+      </trans-unit>
+      <trans-unit id="UsingPreviewSdkWarning">
+        <source>NETSDK1057: You are using a preview version of .NET Core. See: https://aka.ms/dotnet-core-preview</source>
+        <target state="translated">NETSDK1057: .NET Core의 미리 보기 버전을 사용 중입니다. 참조: https://aka.ms/dotnet-core-preview</target>
+        <note>{StrBegin="NETSDK1057: "}</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
@@ -2,35 +2,25 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../Strings.resx">
     <body>
-      <trans-unit id="AspNetCoreAllNotSupported">
-        <source>NETSDK1079: The Microsoft.AspNetCore.All package is not supported when targeting .NET Core 3.0 or higher.  A FrameworkReference to Microsoft.AspNetCore.App should be used instead, and will be implicitly included by Microsoft.NET.Sdk.Web.</source>
-        <target state="translated">NETSDK1079: Pakiet Microsoft.AspNetCore.All nie jest obsługiwany, jeśli docelowa platforma to .NET Core 3.0 lub nowsza. Zamiast niego należy użyć odwołania FrameworkReference do pakietu Microsoft.AspNetCore.App. Będzie ono niejawnie uwzględnione w zestawie Microsoft.NET.Sdk.Web.</target>
-        <note>{StrBegin="NETSDK1079: "}</note>
-      </trans-unit>
-      <trans-unit id="AspNetCoreUsesFrameworkReference">
-        <source>NETSDK1080: A PackageReference to Microsoft.AspNetCore.App is not necessary when targeting .NET Core 3.0 or higher. If Microsoft.NET.Sdk.Web is used, the shared framework will be referenced automatically. Otherwise, the PackageReference should be replaced with a FrameworkReference.</source>
-        <target state="translated">NETSDK1080: Odwołanie PackageReference do pakietu Microsoft.AspNetCore.App nie jest konieczne, jeśli platforma docelowa to .NET Core 3.0 lub nowsza. W przypadku używania pakietu Microsoft.NET.Sdk.Web udostępniona platforma będzie przywoływana automatycznie. W przeciwnym razie odwołanie PackageReference należy zastąpić odwołaniem FrameworkReference.</target>
-        <note>{StrBegin="NETSDK1080: "}</note>
-      </trans-unit>
-      <trans-unit id="FailedToLockResource">
-        <source>NETSDK1077: Failed to lock resource.</source>
-        <target state="translated">NETSDK1077: Nie można zablokować zasobu.</target>
-        <note>{StrBegin="NETSDK1077: "}</note>
-      </trans-unit>
       <trans-unit id="AddResourceWithNonIntegerResource">
         <source>NETSDK1076: AddResource can only be used with integer resource types.</source>
         <target state="translated">NETSDK1076: Metody AddResource można używać jedynie z całkowitoliczbowymi typami zasobów.</target>
         <note>{StrBegin="NETSDK1076: "}</note>
       </trans-unit>
-      <trans-unit id="InvalidResourceUpdate">
-        <source>NETSDK1075: Update handle is invalid. This instance may not be used for further updates.</source>
-        <target state="translated">NETSDK1075: Dojście aktualizacji jest nieprawidłowe. Tego wystąpienia nie można używać do dalszych aktualizacji.</target>
-        <note>{StrBegin="NETSDK1075: "}</note>
+      <trans-unit id="AppConfigRequiresRootConfiguration">
+        <source>NETSDK1070: The application configuration file must have root configuration element.</source>
+        <target state="translated">NETSDK1070: Plik konfiguracji aplikacji musi mieć główny element konfiguracji.</target>
+        <note>{StrBegin="NETSDK1070: "}</note>
       </trans-unit>
       <trans-unit id="AppHostCustomizationRequiresWindowsHostWarning">
         <source>NETSDK1074: The application host executable will not be customized because adding resources requires that the build be performed on Windows (excluding Nano Server).</source>
         <target state="translated">NETSDK1074: Plik wykonywalny hosta aplikacji nie zostanie dostosowany, ponieważ kompilacja musi być wykonywana w systemie Windows (z wyjątkiem systemu Nano Server), aby dodawanie zasobów było możliwe.</target>
         <note>{StrBegin="NETSDK1074: "}</note>
+      </trans-unit>
+      <trans-unit id="AppHostHasBeenModified">
+        <source>NETSDK1029: Unable to use '{0}' as application host executable as it does not contain the expected placeholder byte sequence '{1}' that would mark where the application name would be written.</source>
+        <target state="translated">NETSDK1029: Nie można użyć elementu „{0}” jako pliku wykonywalnego hosta aplikacji, ponieważ nie zawiera on oczekiwanej sekwencji bajtów symbolu zastępczego „{1}”, która wskazuje lokalizację zapisu nazwy aplikacji.</target>
+        <note>{StrBegin="NETSDK1029: "}</note>
       </trans-unit>
       <trans-unit id="AppHostNotWindows">
         <source>NETSDK1078: Unable to use '{0}' as application host executable because it's not a Windows PE file.</source>
@@ -42,210 +32,80 @@
         <target state="translated">NETSDK1072: Nie można użyć pliku „{0}” jako pliku wykonywalnego hosta aplikacji, ponieważ nie jest to plik wykonywalny systemu Windows dla podsystemu CUI (konsoli).</target>
         <note>{StrBegin="NETSDK1072: "}</note>
       </trans-unit>
-      <trans-unit id="AppConfigRequiresRootConfiguration">
-        <source>NETSDK1070: The application configuration file must have root configuration element.</source>
-        <target state="translated">NETSDK1070: Plik konfiguracji aplikacji musi mieć główny element konfiguracji.</target>
-        <note>{StrBegin="NETSDK1070: "}</note>
+      <trans-unit id="AspNetCoreAllNotSupported">
+        <source>NETSDK1079: The Microsoft.AspNetCore.All package is not supported when targeting .NET Core 3.0 or higher.  A FrameworkReference to Microsoft.AspNetCore.App should be used instead, and will be implicitly included by Microsoft.NET.Sdk.Web.</source>
+        <target state="translated">NETSDK1079: Pakiet Microsoft.AspNetCore.All nie jest obsługiwany, jeśli docelowa platforma to .NET Core 3.0 lub nowsza. Zamiast niego należy użyć odwołania FrameworkReference do pakietu Microsoft.AspNetCore.App. Będzie ono niejawnie uwzględnione w zestawie Microsoft.NET.Sdk.Web.</target>
+        <note>{StrBegin="NETSDK1079: "}</note>
       </trans-unit>
-      <trans-unit id="AtLeastOneTargetFrameworkMustBeSpecified">
-        <source>NETSDK1001: At least one possible target framework must be specified.</source>
-        <target state="translated">NETSDK1001: Należy określić co najmniej jedną możliwą platformę docelową.</target>
-        <note>{StrBegin="NETSDK1001: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotUseSelfContainedWithoutAppHost">
-        <source>NETSDK1067: Self-contained applications are required to use the application host. Either set SelfContained to false or set UseAppHost to true.</source>
-        <target state="translated">NETSDK1067: Aplikacje autonomiczne muszą korzystać z hosta aplikacji. Ustaw parametr SelfContained na wartość false lub parametr UseAppHost na wartość true.</target>
-        <note>{StrBegin="NETSDK1067: "}</note>
-      </trans-unit>
-      <trans-unit id="FrameworkDependentAppHostRequiresVersion21">
-        <source>NETSDK1068: The framework-dependent application host requires a target framework of at least 'netcoreapp2.1'.</source>
-        <target state="translated">NETSDK1068: Host aplikacji zależnych od platformy wymaga co najmniej platformy docelowej „netcoreapp2.1”.</target>
-        <note>{StrBegin="NETSDK1068: "}</note>
-      </trans-unit>
-      <trans-unit id="NETFrameworkToNonBuiltInNETStandard">
-        <source>NETSDK1069: This project uses a library that targets .NET Standard 1.5 or higher, and the project targets a version of .NET Framework that doesn't have built-in support for that version of .NET Standard. Visit https://aka.ms/net-standard-known-issues for a set of known issues. Consider retargeting to .NET Framework 4.7.2.</source>
-        <target state="translated">NETSDK1069: Projekt korzysta z biblioteki przeznaczonej dla platformy .NET Standard 1.5 lub nowszej, a projekt jest przeznaczony dla wersji programu .NET Framework, która nie ma wbudowanej obsługi tej wersji platformy .NET Standard. Odwiedź witrynę https://aka.ms/net-standard-known-issues, aby zapoznać się z zestawem znanych problemów. Rozważ zmianę elementu docelowego na program .NET Framework 4.7.2.</target>
-        <note>{StrBegin="NETSDK1069: "}</note>
-      </trans-unit>
-      <trans-unit id="NoAppHostAvailable">
-        <source>NETSDK1084: There is no application host available for the specified RuntimeIdentifier '{0}'.</source>
-        <target state="new">NETSDK1084: There is no application host available for the specified RuntimeIdentifier '{0}'.</target>
-        <note>{StrBegin="NETSDK1084: "}</note>
-      </trans-unit>
-      <trans-unit id="NoCompatibleTargetFramework">
-        <source>NETSDK1002: Project '{0}' targets '{2}'. It cannot be referenced by a project that targets '{1}'.</source>
-        <target state="translated">NETSDK1002: Projekt „{0}” ma platformę docelową „{2}”. Nie może on być przywoływany przez projekt z platformą docelową „{1}”.</target>
-        <note>{StrBegin="NETSDK1002: "}</note>
-      </trans-unit>
-      <trans-unit id="InvalidFrameworkName">
-        <source>NETSDK1003: Invalid framework name: '{0}'.</source>
-        <target state="translated">NETSDK1003: Nieprawidłowa nazwa platformy: „{0}”.</target>
-        <note>{StrBegin="NETSDK1003: "}</note>
-      </trans-unit>
-      <trans-unit id="AssetsFileNotFound">
-        <source>NETSDK1004: Assets file '{0}' not found. Run a NuGet package restore to generate this file.</source>
-        <target state="translated">NETSDK1004: Nie odnaleziono pliku zasobów „{0}”. Uruchom przywracanie pakietu NuGet, aby wygenerować ten plik.</target>
-        <note>{StrBegin="NETSDK1004: "}</note>
-      </trans-unit>
-      <trans-unit id="AssetsFileMissingTarget">
-        <source>NETSDK1005: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project.</source>
-        <target state="translated">NETSDK1005: Plik zasobów „{0}” nie ma obiektu docelowego dla „{1}”. Upewnij się, że uruchomiono przywracanie i że w elemencie TargetFrameworks dla projektu uwzględniono element „{2}”.</target>
-        <note>{StrBegin="NETSDK1005: "}</note>
-      </trans-unit>
-      <trans-unit id="AssetsFilePathNotRooted">
-        <source>NETSDK1006: Assets file path '{0}' is not rooted. Only full paths are supported.</source>
-        <target state="translated">NETSDK1006: Ścieżka pliku zasobów „{0}” nie prowadzi do katalogu głównego. Tylko pełne ścieżki są obsługiwane.</target>
-        <note>{StrBegin="NETSDK1006: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotFindProjectInfo">
-        <source>NETSDK1007: Cannot find project info for '{0}'. This can indicate a missing project reference.</source>
-        <target state="translated">NETSDK1007: Nie odnaleziono informacji o projekcie dla elementu „{0}”. Może to wskazywać na brakujące odwołanie do projektu.</target>
-        <note>{StrBegin="NETSDK1007: "}</note>
-      </trans-unit>
-      <trans-unit id="MissingItemMetadata">
-        <source>NETSDK1008: Missing '{0}' metadata on '{1}' item '{2}'.</source>
-        <target state="translated">NETSDK1008: Brak metadanych „{0}” w elemencie „{1}” „{2}”.</target>
-        <note>{StrBegin="NETSDK1008: "}</note>
-      </trans-unit>
-      <trans-unit id="NoRuntimePackAvailable">
-        <source>NETSDK1082: There was no runtime pack for {0} available for the specified RuntimeIdentifier '{1}'.</source>
-        <target state="new">NETSDK1082: There was no runtime pack for {0} available for the specified RuntimeIdentifier '{1}'.</target>
-        <note>{StrBegin="NETSDK1082: "}</note>
-      </trans-unit>
-      <trans-unit id="PackageReferenceVersionNotRecommended">
-        <source>NETSDK1071: A PackageReference to '{0}' specified a Version of `{1}`. Specifying the version of this package is not recommended. For more information, see https://aka.ms/sdkimplicitrefs</source>
-        <target state="translated">NETSDK1071: Odwołanie PackageReference do pakietu „{0}” określiło wersję „{1}”. Określanie wersji tego pakietu nie jest zalecane. Aby uzyskać więcej informacji, zobacz https://aka.ms/sdkimplicitrefs</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="RuntimeIdentifierNotRecognized">
-        <source>NETSDK1083: The specified RuntimeIdentifier '{0}' is not recognized.</source>
-        <target state="new">NETSDK1083: The specified RuntimeIdentifier '{0}' is not recognized.</target>
-        <note>{StrBegin="NETSDK1083: "}</note>
-      </trans-unit>
-      <trans-unit id="UnknownFrameworkReference">
-        <source>NETSDK1073: The FrameworkReference '{0}' was not recognized</source>
-        <target state="translated">NETSDK1073: Odwołanie FrameworkReference „{0}” nie zostało rozpoznane</target>
-        <note>{StrBegin="NETSDK1073: "}</note>
-      </trans-unit>
-      <trans-unit id="UnrecognizedPreprocessorToken">
-        <source>NETSDK1009: Unrecognized preprocessor token '{0}' in '{1}'.</source>
-        <target state="translated">NETSDK1009: Nierozpoznany token preprocesora „{0}” w elemencie „{1}”.</target>
-        <note>{StrBegin="NETSDK1009: "}</note>
-      </trans-unit>
-      <trans-unit id="ContentPreproccessorParameterRequired">
-        <source>NETSDK1010: The '{0}' task must be given a value for parameter '{1}' in order to consume preprocessed content.</source>
-        <target state="translated">NETSDK1010: Dla zadania „{0}” musi zostać podana wartość parametru „{1}” w celu użycia wstępnie przetworzonej zawartości.</target>
-        <note>{StrBegin="NETSDK1010: "}</note>
-      </trans-unit>
-      <trans-unit id="ProjectAssetsConsumedWithoutMSBuildProjectPath">
-        <source>NETSDK1011: Assets are consumed from project '{0}', but no corresponding MSBuild project path was  found in '{1}'.</source>
-        <target state="translated">NETSDK1011: Zasoby są używane z projektu „{0}”, ale w elemencie „{1}” nie odnaleziono odpowiadającej ścieżki projektu MSBuild.</target>
-        <note>{StrBegin="NETSDK1011: "}</note>
-      </trans-unit>
-      <trans-unit id="UnexpectedFileType">
-        <source>NETSDK1012: Unexpected file type for '{0}'. Type is both '{1}' and '{2}'.</source>
-        <target state="translated">NETSDK1012: Nieoczekiwany typ pliku dla „{0}”. Typ to „{1}” oraz „{2}”.</target>
-        <note>{StrBegin="NETSDK1012: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotInferTargetFrameworkIdentifierAndVersion">
-        <source>NETSDK1013: The TargetFramework value '{0}' was not recognized. It may be misspelled. If not, then the TargetFrameworkIdentifier and/or TargetFrameworkVersion properties must be specified explicitly.</source>
-        <target state="translated">NETSDK1013: Nie rozpoznano wartości „{0}” elementu TargetFramework. Być może wpisano ją niepoprawnie. Jeśli nie, należy jawnie określić właściwości TargetFrameworkIdentifier i/lub TargetFrameworkVersion.</target>
-        <note>{StrBegin="NETSDK1013: "}</note>
-      </trans-unit>
-      <trans-unit id="ContentItemDoesNotProvideOutputPath">
-        <source>NETSDK1014: Content item for '{0}' sets '{1}', but does not provide  '{2}' or '{3}'.</source>
-        <target state="translated">NETSDK1014: Element zawartości dla elementu „{0}” ustawia wartość „{1}”, ale nie zapewnia wartości „{2}” ani „{3}”.</target>
-        <note>{StrBegin="NETSDK1014: "}</note>
-      </trans-unit>
-      <trans-unit id="DuplicatePreprocessorToken">
-        <source>NETSDK1015: The preprocessor token '{0}' has been given more than one value. Choosing '{1}' as the value.</source>
-        <target state="translated">NETSDK1015: Dla tokenu preprocesora „{0}” podano więcej niż jedną wartość. Wybieranie elementu „{1}” jako wartości.</target>
-        <note>{StrBegin="NETSDK1015: "}</note>
-      </trans-unit>
-      <trans-unit id="UnableToFindResolvedPath">
-        <source>NETSDK1016: Unable to find resolved path for '{0}'.</source>
-        <target state="translated">NETSDK1016: Nie można odnaleźć rozpoznanej ścieżki dla elementu „{0}”.</target>
-        <note>{StrBegin="NETSDK1016: "}</note>
+      <trans-unit id="AspNetCoreUsesFrameworkReference">
+        <source>NETSDK1080: A PackageReference to Microsoft.AspNetCore.App is not necessary when targeting .NET Core 3.0 or higher. If Microsoft.NET.Sdk.Web is used, the shared framework will be referenced automatically. Otherwise, the PackageReference should be replaced with a FrameworkReference.</source>
+        <target state="translated">NETSDK1080: Odwołanie PackageReference do pakietu Microsoft.AspNetCore.App nie jest konieczne, jeśli platforma docelowa to .NET Core 3.0 lub nowsza. W przypadku używania pakietu Microsoft.NET.Sdk.Web udostępniona platforma będzie przywoływana automatycznie. W przeciwnym razie odwołanie PackageReference należy zastąpić odwołaniem FrameworkReference.</target>
+        <note>{StrBegin="NETSDK1080: "}</note>
       </trans-unit>
       <trans-unit id="AssetPreprocessorMustBeConfigured">
         <source>NETSDK1017: Asset preprocessor must be configured before assets are processed.</source>
         <target state="translated">NETSDK1017: Preprocesor zasobów musi być skonfigurowany przed przetworzeniem zasobów.</target>
         <note>{StrBegin="NETSDK1017: "}</note>
       </trans-unit>
-      <trans-unit id="InvalidNuGetVersionString">
-        <source>NETSDK1018: Invalid NuGet version string: '{0}'.</source>
-        <target state="translated">NETSDK1018: Nieprawidłowy ciąg wersji NuGet: „{0}”.</target>
-        <note>{StrBegin="NETSDK1018: "}</note>
+      <trans-unit id="AssetsFileMissingRuntimeIdentifier">
+        <source>NETSDK1047: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project. You may also need to include '{3}' in your project's RuntimeIdentifiers.</source>
+        <target state="translated">NETSDK1047: Plik zasobów „{0}” nie ma obiektu docelowego dla „{1}”. Upewnij się, że uruchomiono przywracanie i że w elemencie TargetFrameworks dla projektu uwzględniono element „{2}”. Może być też konieczne uwzględnienie elementu „{3}” w obszarze RuntimeIdentifiers projektu.</target>
+        <note>{StrBegin="NETSDK1047: "}</note>
       </trans-unit>
-      <trans-unit id="UnresolvedTargetingPack">
-        <source>NETSDK1081: The targeting pack for {0} was not found. You may be able to resolve this by running a NuGet restore on the project.</source>
-        <target state="new">NETSDK1081: The targeting pack for {0} was not found. You may be able to resolve this by running a NuGet restore on the project.</target>
-        <note>{StrBegin="NETSDK1081: "}</note>
+      <trans-unit id="AssetsFileMissingTarget">
+        <source>NETSDK1005: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project.</source>
+        <target state="translated">NETSDK1005: Plik zasobów „{0}” nie ma obiektu docelowego dla „{1}”. Upewnij się, że uruchomiono przywracanie i że w elemencie TargetFrameworks dla projektu uwzględniono element „{2}”.</target>
+        <note>{StrBegin="NETSDK1005: "}</note>
       </trans-unit>
-      <trans-unit id="UnsupportedFramework">
-        <source>NETSDK1019: {0} is an unsupported framework.</source>
-        <target state="translated">NETSDK1019: {0} to nieobsługiwana platforma.</target>
-        <note>{StrBegin="NETSDK1019: "}</note>
+      <trans-unit id="AssetsFileNotFound">
+        <source>NETSDK1004: Assets file '{0}' not found. Run a NuGet package restore to generate this file.</source>
+        <target state="translated">NETSDK1004: Nie odnaleziono pliku zasobów „{0}”. Uruchom przywracanie pakietu NuGet, aby wygenerować ten plik.</target>
+        <note>{StrBegin="NETSDK1004: "}</note>
       </trans-unit>
-      <trans-unit id="DuplicateItemsError">
-        <source>NETSDK1022: Duplicate '{0}' items were included. The .NET SDK includes '{0}' items from your project directory by default. You can either remove these items from your project file, or set the '{1}' property to '{2}' if you want to explicitly include them in your project file. For more information, see {4}. The duplicate items were: {3}</source>
-        <target state="translated">NETSDK1022: Zostały uwzględnione zduplikowane elementy „{0}”. Zestaw .NET SDK dołącza domyślnie elementy „{0}” z katalogu projektu. Możesz usunąć te elementy z pliku projektu lub ustawić dla właściwości „{1}” wartość „{2}”, aby jawnie uwzględnić je w pliku projektu.Aby uzyskać więcej informacji, zobacz {4}. Zduplikowane elementy: {3}</target>
-        <note>{StrBegin="NETSDK1022: "}</note>
+      <trans-unit id="AssetsFileNotSet">
+        <source>NETSDK1063: The path to the project assets file was not set. Run a NuGet package restore to generate this file.</source>
+        <target state="translated">NETSDK1063: Nie ustawiono ścieżki do pliku zasobów projektu. Uruchom przywracanie pakietu NuGet, aby wygenerować ten plik.</target>
+        <note>{StrBegin="NETSDK1063: "}</note>
       </trans-unit>
-      <trans-unit id="PackageReferenceOverrideWarning">
-        <source>NETSDK1023: A PackageReference for '{0}' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see {1}</source>
-        <target state="translated">NETSDK1023: Odwołanie do pakietu dla „{0}” zostało uwzględnione w projekcie. Ten pakiet jest jawnie przywoływany przez zestaw .NET SDK i zwykle nie ma potrzeby tworzenia odwołania do niego z projektu. Aby uzyskać więcej informacji, zobacz {1}</target>
-        <note>{StrBegin="NETSDK1023: "}</note>
+      <trans-unit id="AssetsFilePathNotRooted">
+        <source>NETSDK1006: Assets file path '{0}' is not rooted. Only full paths are supported.</source>
+        <target state="translated">NETSDK1006: Ścieżka pliku zasobów „{0}” nie prowadzi do katalogu głównego. Tylko pełne ścieżki są obsługiwane.</target>
+        <note>{StrBegin="NETSDK1006: "}</note>
       </trans-unit>
-      <trans-unit id="IncorrectPackageRoot">
-        <source>NETSDK1020: Package Root {0} was incorrectly given for Resolved library {1}</source>
-        <target state="translated">NETSDK1020: Podano niepoprawny element główny pakietu {0} dla rozpoznanej biblioteki {1}</target>
-        <note>{StrBegin="NETSDK1020: "}</note>
+      <trans-unit id="AtLeastOneTargetFrameworkMustBeSpecified">
+        <source>NETSDK1001: At least one possible target framework must be specified.</source>
+        <target state="translated">NETSDK1001: Należy określić co najmniej jedną możliwą platformę docelową.</target>
+        <note>{StrBegin="NETSDK1001: "}</note>
       </trans-unit>
-      <trans-unit id="MultipleFilesResolved">
-        <source>NETSDK1021: More than one file found for {0}</source>
-        <target state="translated">NETSDK1021: Znaleziono więcej niż jeden plik dla elementu {0}</target>
-        <note>{StrBegin="NETSDK1021: "}</note>
+      <trans-unit id="CannotFindApphostForRid">
+        <source>NETSDK1065: Cannot find app host for {0}. {0} could be an invalid runtime identifier (RID). For more information about RID, see https://aka.ms/rid-catalog.</source>
+        <target state="translated">NETSDK1065: Nie można odnaleźć hosta aplikacji dla elementu {0}. {0} może być nieprawidłowym identyfikatorem środowiska uruchomieniowego. Aby uzyskać więcej informacji na temat identyfikatora środowiska uruchomieniowego, zobacz https://aka.ms/rid-catalog.</target>
+        <note>{StrBegin="NETSDK1065: "}</note>
       </trans-unit>
-      <trans-unit id="FolderAlreadyExists">
-        <source>NETSDK1024: Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</source>
-        <target state="translated">NETSDK1024: Folder „{0}” już istnieje. Usuń go lub podaj inny katalog roboczy tworzenia (ComposeWorkingDir)</target>
-        <note>{StrBegin="NETSDK1024: "}</note>
+      <trans-unit id="CannotFindProjectInfo">
+        <source>NETSDK1007: Cannot find project info for '{0}'. This can indicate a missing project reference.</source>
+        <target state="translated">NETSDK1007: Nie odnaleziono informacji o projekcie dla elementu „{0}”. Może to wskazywać na brakujące odwołanie do projektu.</target>
+        <note>{StrBegin="NETSDK1007: "}</note>
       </trans-unit>
-      <trans-unit id="ParsingFiles">
-        <source>NETSDK1026: Parsing the Files : '{0}'</source>
-        <target state="translated">NETSDK1026: Analizowanie plików: „{0}”</target>
-        <note>{StrBegin="NETSDK1026: "}</note>
-      </trans-unit>
-      <trans-unit id="PackageInfoLog">
-        <source>NETSDK1027: Package Name='{0}', Version='{1}' was parsed</source>
-        <target state="translated">NETSDK1027: Przeanalizowano pakiet o nazwie „{0}” w wersji „{1}”</target>
-        <note>{StrBegin="NETSDK1027: "}</note>
-      </trans-unit>
-      <trans-unit id="RuntimeIdentifierWasNotSpecified">
-        <source>NETSDK1028: Specify a RuntimeIdentifier</source>
-        <target state="translated">NETSDK1028: Określ element RuntimeIdentifier</target>
-        <note>{StrBegin="NETSDK1028: "}</note>
-      </trans-unit>
-      <trans-unit id="IncorrectTargetFormat">
-        <source>NETSDK1025: WRThe target manifest {0} provided is of not the correct format</source>
-        <target state="translated">NETSDK1025: Podany manifest docelowy {0} ma niepoprawny format</target>
-        <note>{StrBegin="NETSDK1025: "}</note>
-      </trans-unit>
-      <trans-unit id="AppHostHasBeenModified">
-        <source>NETSDK1029: Unable to use '{0}' as application host executable as it does not contain the expected placeholder byte sequence '{1}' that would mark where the application name would be written.</source>
-        <target state="translated">NETSDK1029: Nie można użyć elementu „{0}” jako pliku wykonywalnego hosta aplikacji, ponieważ nie zawiera on oczekiwanej sekwencji bajtów symbolu zastępczego „{1}”, która wskazuje lokalizację zapisu nazwy aplikacji.</target>
-        <note>{StrBegin="NETSDK1029: "}</note>
-      </trans-unit>
-      <trans-unit id="FileNameIsTooLong">
-        <source>NETSDK1030: Given file name '{0}' is longer than 1024 bytes</source>
-        <target state="translated">NETSDK1030: Podana nazwa pliku „{0}” jest dłuższa niż 1024 bajty</target>
-        <note>{StrBegin="NETSDK1030: "}</note>
+      <trans-unit id="CannotHaveRuntimeIdentifierPlatformMismatchPlatformTarget">
+        <source>NETSDK1032: The RuntimeIdentifier platform '{0}' and the PlatformTarget '{1}' must be compatible.</source>
+        <target state="translated">NETSDK1032: Platforma elementu RuntimeIdentifier „{0}” i element PlatformTarget „{1}” muszą być zgodne.</target>
+        <note>{StrBegin="NETSDK1032: "}</note>
       </trans-unit>
       <trans-unit id="CannotHaveSelfContainedWithoutRuntimeIdentifier">
         <source>NETSDK1031: It is not supported to build or publish a self-contained application without specifying a RuntimeIdentifier.  Please either specify a RuntimeIdentifier or set SelfContained to false.</source>
         <target state="translated">NETSDK1031: Kompilowanie i publikowanie aplikacji autonomicznej bez określania elementu RuntimeIdentifier nie jest obsługiwane. Określ element RuntimeIdentifier lub ustaw wartość false dla elementu SelfContained.</target>
         <note>{StrBegin="NETSDK1031: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotInferTargetFrameworkIdentifierAndVersion">
+        <source>NETSDK1013: The TargetFramework value '{0}' was not recognized. It may be misspelled. If not, then the TargetFrameworkIdentifier and/or TargetFrameworkVersion properties must be specified explicitly.</source>
+        <target state="translated">NETSDK1013: Nie rozpoznano wartości „{0}” elementu TargetFramework. Być może wpisano ją niepoprawnie. Jeśli nie, należy jawnie określić właściwości TargetFrameworkIdentifier i/lub TargetFrameworkVersion.</target>
+        <note>{StrBegin="NETSDK1013: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotUseSelfContainedWithoutAppHost">
+        <source>NETSDK1067: Self-contained applications are required to use the application host. Either set SelfContained to false or set UseAppHost to true.</source>
+        <target state="translated">NETSDK1067: Aplikacje autonomiczne muszą korzystać z hosta aplikacji. Ustaw parametr SelfContained na wartość false lub parametr UseAppHost na wartość true.</target>
+        <note>{StrBegin="NETSDK1067: "}</note>
       </trans-unit>
       <trans-unit id="ChoosingAssemblyVersion">
         <source>NETSDK1033: Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</source>
@@ -272,6 +132,16 @@
         <target state="translated">NETSDK1037: Nie można określić wyniku z powodu takich samych wersji pliku i zestawu.</target>
         <note>{StrBegin="NETSDK1037: "}</note>
       </trans-unit>
+      <trans-unit id="ContentItemDoesNotProvideOutputPath">
+        <source>NETSDK1014: Content item for '{0}' sets '{1}', but does not provide  '{2}' or '{3}'.</source>
+        <target state="translated">NETSDK1014: Element zawartości dla elementu „{0}” ustawia wartość „{1}”, ale nie zapewnia wartości „{2}” ani „{3}”.</target>
+        <note>{StrBegin="NETSDK1014: "}</note>
+      </trans-unit>
+      <trans-unit id="ContentPreproccessorParameterRequired">
+        <source>NETSDK1010: The '{0}' task must be given a value for parameter '{1}' in order to consume preprocessed content.</source>
+        <target state="translated">NETSDK1010: Dla zadania „{0}” musi zostać podana wartość parametru „{1}” w celu użycia wstępnie przetworzonej zawartości.</target>
+        <note>{StrBegin="NETSDK1010: "}</note>
+      </trans-unit>
       <trans-unit id="CouldNotDetermineWinner_DoesntExist">
         <source>NETSDK1038: Could not determine winner because '{0}' does not exist.</source>
         <target state="translated">NETSDK1038: Nie można określić wyniku, ponieważ element „{0}” nie istnieje.</target>
@@ -287,15 +157,40 @@
         <target state="translated">NETSDK1040: Nie można określić wyniku, ponieważ element „{0}” nie jest zestawem.</target>
         <note>{StrBegin="NETSDK1040: "}</note>
       </trans-unit>
+      <trans-unit id="CouldNotLoadPlatformManifest">
+        <source>NETSDK1042: Could not load PlatformManifest from '{0}' because it did not exist.</source>
+        <target state="translated">NETSDK1042: Nie można załadować elementu PlatformManifest z lokalizacji „{0}”, ponieważ ta lokalizacja nie istnieje.</target>
+        <note>{StrBegin="NETSDK1042: "}</note>
+      </trans-unit>
+      <trans-unit id="DotnetToolDoesNotSupportTFMLowerThanNetcoreapp21">
+        <source>NETSDK1055: DotnetTool does not support target framework lower than netcoreapp2.1.</source>
+        <target state="translated">NETSDK1055: Narzędzie DotnetTool nie obsługuje docelowej struktury w wersji niższej niż netcoreapp2.1.</target>
+        <note>{StrBegin="NETSDK1055: "}</note>
+      </trans-unit>
+      <trans-unit id="DotnetToolOnlySupportNetcoreapp">
+        <source>NETSDK1054: only supports .NET Core.</source>
+        <target state="translated">NETSDK1054: obsługuje tylko platformę .NET Core.</target>
+        <note>{StrBegin="NETSDK1054: "}</note>
+      </trans-unit>
+      <trans-unit id="DuplicateItemsError">
+        <source>NETSDK1022: Duplicate '{0}' items were included. The .NET SDK includes '{0}' items from your project directory by default. You can either remove these items from your project file, or set the '{1}' property to '{2}' if you want to explicitly include them in your project file. For more information, see {4}. The duplicate items were: {3}</source>
+        <target state="translated">NETSDK1022: Zostały uwzględnione zduplikowane elementy „{0}”. Zestaw .NET SDK dołącza domyślnie elementy „{0}” z katalogu projektu. Możesz usunąć te elementy z pliku projektu lub ustawić dla właściwości „{1}” wartość „{2}”, aby jawnie uwzględnić je w pliku projektu.Aby uzyskać więcej informacji, zobacz {4}. Zduplikowane elementy: {3}</target>
+        <note>{StrBegin="NETSDK1022: "}</note>
+      </trans-unit>
+      <trans-unit id="DuplicatePreprocessorToken">
+        <source>NETSDK1015: The preprocessor token '{0}' has been given more than one value. Choosing '{1}' as the value.</source>
+        <target state="translated">NETSDK1015: Dla tokenu preprocesora „{0}” podano więcej niż jedną wartość. Wybieranie elementu „{1}” jako wartości.</target>
+        <note>{StrBegin="NETSDK1015: "}</note>
+      </trans-unit>
       <trans-unit id="EncounteredConflict">
         <source>NETSDK1041: Encountered conflict between '{0}' and '{1}'.</source>
         <target state="translated">NETSDK1041: Napotkano konflikt między elementem „{0}” i „{1}”.</target>
         <note>{StrBegin="NETSDK1041: "}</note>
       </trans-unit>
-      <trans-unit id="CouldNotLoadPlatformManifest">
-        <source>NETSDK1042: Could not load PlatformManifest from '{0}' because it did not exist.</source>
-        <target state="translated">NETSDK1042: Nie można załadować elementu PlatformManifest z lokalizacji „{0}”, ponieważ ta lokalizacja nie istnieje.</target>
-        <note>{StrBegin="NETSDK1042: "}</note>
+      <trans-unit id="ErrorParsingFrameworkListInvalidValue">
+        <source>NETSDK1051: Error parsing FrameworkList from '{0}'.  {1} '{2}' was invalid.</source>
+        <target state="translated">NETSDK1051: Błąd analizowania elementu FrameworkList z elementu „{0}”. Element {1} „{2}” był nieprawidłowy.</target>
+        <note>{StrBegin="NETSDK1051: "}</note>
       </trans-unit>
       <trans-unit id="ErrorParsingPlatformManifest">
         <source>NETSDK1043: Error parsing PlatformManifest from '{0}' line {1}.  Lines must have the format {2}.</source>
@@ -307,65 +202,55 @@
         <target state="translated">NETSDK1044: Wystąpił błąd podczas analizowania elementu PlatformManifest w wierszu „{0}” {1}. Element {2} „{3}” jest nieprawidłowy.</target>
         <note>{StrBegin="NETSDK1044: "}</note>
       </trans-unit>
-      <trans-unit id="UnsupportedTargetFrameworkVersion">
-        <source>NETSDK1045: The current .NET SDK does not support targeting {0} {1}.  Either target {0} {2} or lower, or use a version of the .NET SDK that supports {0} {1}.</source>
-        <target state="translated">NETSDK1045: Bieżący zestaw .NET SDK nie obsługuje używania środowiska docelowego {0} {1}. Użyj jako środowiska docelowego wersji {0} {2} lub starszej albo użyj wersji zestawu .NET SDK obsługującej środowisko {0} {1}.</target>
-        <note>{StrBegin="NETSDK1045: "}</note>
+      <trans-unit id="ErrorReadingAssetsFile">
+        <source>NETSDK1060: Error reading assets file: {0}</source>
+        <target state="translated">NETSDK1060: Błąd podczas odczytywania pliku zasobów: {0}</target>
+        <note>{StrBegin="NETSDK1060: "}</note>
       </trans-unit>
-      <trans-unit id="AssetsFileMissingRuntimeIdentifier">
-        <source>NETSDK1047: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project. You may also need to include '{3}' in your project's RuntimeIdentifiers.</source>
-        <target state="translated">NETSDK1047: Plik zasobów „{0}” nie ma obiektu docelowego dla „{1}”. Upewnij się, że uruchomiono przywracanie i że w elemencie TargetFrameworks dla projektu uwzględniono element „{2}”. Może być też konieczne uwzględnienie elementu „{3}” w obszarze RuntimeIdentifiers projektu.</target>
-        <note>{StrBegin="NETSDK1047: "}</note>
+      <trans-unit id="FailedToLockResource">
+        <source>NETSDK1077: Failed to lock resource.</source>
+        <target state="translated">NETSDK1077: Nie można zablokować zasobu.</target>
+        <note>{StrBegin="NETSDK1077: "}</note>
       </trans-unit>
-      <trans-unit id="TargetFrameworkWithSemicolon">
-        <source>NETSDK1046: The TargetFramework value '{0}' is not valid. To multi-target, use the 'TargetFrameworks' property instead.</source>
-        <target state="translated">NETSDK1046: Wartość „{0}” elementu TargetFramework jest nieprawidłowa. Aby obsługiwać wiele środowisk docelowych, użyj zamiast tego właściwości TargetFrameworks.</target>
-        <note>{StrBegin="NETSDK1046: "}</note>
+      <trans-unit id="FileNameIsTooLong">
+        <source>NETSDK1030: Given file name '{0}' is longer than 1024 bytes</source>
+        <target state="translated">NETSDK1030: Podana nazwa pliku „{0}” jest dłuższa niż 1024 bajty</target>
+        <note>{StrBegin="NETSDK1030: "}</note>
       </trans-unit>
-      <trans-unit id="GetDependsOnNETStandardFailedWithException">
-        <source>NETSDK1049: Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0} {1}</source>
-        <target state="translated">NETSDK1049: Rozpoznany plik ma nieprawidłowy obraz, nie ma metadanych lub jest w inny sposób niedostępny. {0} {1}</target>
-        <note>{StrBegin="NETSDK1049: "}</note>
+      <trans-unit id="FolderAlreadyExists">
+        <source>NETSDK1024: Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</source>
+        <target state="translated">NETSDK1024: Folder „{0}” już istnieje. Usuń go lub podaj inny katalog roboczy tworzenia (ComposeWorkingDir)</target>
+        <note>{StrBegin="NETSDK1024: "}</note>
       </trans-unit>
-      <trans-unit id="UnsupportedSDKVersionForNetStandard20">
-        <source>NETSDK1050: The version of Microsoft.NET.Sdk used by this project is insufficient to support references to libraries targeting .NET Standard 1.5 or higher.  Please install version 2.0 or higher of the .NET Core SDK.</source>
-        <target state="translated">NETSDK1050: Używana przez ten projekt wersja zestawu Microsoft.NET.Sdk jest niewystarczająca do zapewnienia obsługi odwołań do bibliotek przeznaczonych dla platformy .NET Standard 1.5 lub nowszych. Zainstaluj zestaw .NET Core SDK w wersji co najmniej 2.0.</target>
-        <note>{StrBegin="NETSDK1050: "}</note>
-      </trans-unit>
-      <trans-unit id="SkippingAdditionalProbingPaths">
-        <source>NETSDK1048: 'AdditionalProbingPaths' were specified for GenerateRuntimeConfigurationFiles, but are being skipped because 'RuntimeConfigDevPath' is empty.</source>
-        <target state="translated">NETSDK1048: Dla elementu GenerateRuntimeConfigurationFiles określono ścieżki AdditionalProbingPaths, ale są one pomijane, ponieważ element „RuntimeConfigDevPath” jest pusty.</target>
-        <note>{StrBegin="NETSDK1048: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotHaveRuntimeIdentifierPlatformMismatchPlatformTarget">
-        <source>NETSDK1032: The RuntimeIdentifier platform '{0}' and the PlatformTarget '{1}' must be compatible.</source>
-        <target state="translated">NETSDK1032: Platforma elementu RuntimeIdentifier „{0}” i element PlatformTarget „{1}” muszą być zgodne.</target>
-        <note>{StrBegin="NETSDK1032: "}</note>
-      </trans-unit>
-      <trans-unit id="ErrorParsingFrameworkListInvalidValue">
-        <source>NETSDK1051: Error parsing FrameworkList from '{0}'.  {1} '{2}' was invalid.</source>
-        <target state="translated">NETSDK1051: Błąd analizowania elementu FrameworkList z elementu „{0}”. Element {1} „{2}” był nieprawidłowy.</target>
-        <note>{StrBegin="NETSDK1051: "}</note>
+      <trans-unit id="FrameworkDependentAppHostRequiresVersion21">
+        <source>NETSDK1068: The framework-dependent application host requires a target framework of at least 'netcoreapp2.1'.</source>
+        <target state="translated">NETSDK1068: Host aplikacji zależnych od platformy wymaga co najmniej platformy docelowej „netcoreapp2.1”.</target>
+        <note>{StrBegin="NETSDK1068: "}</note>
       </trans-unit>
       <trans-unit id="FrameworkListPathNotRooted">
         <source>NETSDK1052: Framework list file path '{0}' is not rooted. Only full paths are supported.</source>
         <target state="translated">NETSDK1052: Ścieżka pliku z listą struktur „{0}” nie zaczyna się od katalogu głównego. Obsługiwane są tylko pełne ścieżki.</target>
         <note>{StrBegin="NETSDK1052: "}</note>
       </trans-unit>
-      <trans-unit id="PackAsToolCannotSupportSelfContained">
-        <source>NETSDK1053: Pack as tool does not support self contained.</source>
-        <target state="translated">NETSDK1053: Funkcja pakowania jako narzędzie nie obsługuje elementów autonomicznych.</target>
-        <note>{StrBegin="NETSDK1001: "}</note>
+      <trans-unit id="GetDependsOnNETStandardFailedWithException">
+        <source>NETSDK1049: Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0} {1}</source>
+        <target state="translated">NETSDK1049: Rozpoznany plik ma nieprawidłowy obraz, nie ma metadanych lub jest w inny sposób niedostępny. {0} {1}</target>
+        <note>{StrBegin="NETSDK1049: "}</note>
       </trans-unit>
-      <trans-unit id="UnsupportedRuntimeIdentifier">
-        <source>NETSDK1056: Project is targeting runtime '{0}' but did not resolve any runtime-specific packages. This runtime may not be supported by the target framework.</source>
-        <target state="translated">NETSDK1056: Projekt jest przeznaczony dla środowiska uruchomieniowego „{0}”, ale nie rozpoznaje żadnych pakietów specyficznych dla tego środowiska. To środowisko uruchomieniowe nie może być obsługiwane przez platformę docelową.</target>
-        <note>{StrBegin="NETSDK1056: "}</note>
+      <trans-unit id="IncorrectPackageRoot">
+        <source>NETSDK1020: Package Root {0} was incorrectly given for Resolved library {1}</source>
+        <target state="translated">NETSDK1020: Podano niepoprawny element główny pakietu {0} dla rozpoznanej biblioteki {1}</target>
+        <note>{StrBegin="NETSDK1020: "}</note>
       </trans-unit>
-      <trans-unit id="UsingPreviewSdkWarning">
-        <source>NETSDK1057: You are using a preview version of .NET Core. See: https://aka.ms/dotnet-core-preview</source>
-        <target state="translated">NETSDK1057: Korzystasz z wersji zapoznawczej platformy .NET Core. Zobacz: https://aka.ms/dotnet-core-preview</target>
-        <note>{StrBegin="NETSDK1057: "}</note>
+      <trans-unit id="IncorrectTargetFormat">
+        <source>NETSDK1025: WRThe target manifest {0} provided is of not the correct format</source>
+        <target state="translated">NETSDK1025: Podany manifest docelowy {0} ma niepoprawny format</target>
+        <note>{StrBegin="NETSDK1025: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidFrameworkName">
+        <source>NETSDK1003: Invalid framework name: '{0}'.</source>
+        <target state="translated">NETSDK1003: Nieprawidłowa nazwa platformy: „{0}”.</target>
+        <note>{StrBegin="NETSDK1003: "}</note>
       </trans-unit>
       <trans-unit id="InvalidItemSpecToUse">
         <source>NETSDK1058: Invalid value for ItemSpecToUse parameter: '{0}'.  This property must be blank or set to 'Left' or 'Right'</source>
@@ -373,15 +258,15 @@
         <note>{StrBegin="NETSDK1058: "}
 The following are names of parameters or literal values and should not be translated: ItemSpecToUse, Left, Right</note>
       </trans-unit>
-      <trans-unit id="ProjectContainsObsoleteDotNetCliTool">
-        <source>NETSDK1059: The tool '{0}' is now included in the .NET Core SDK. Information on resolving this warning is available at (https://aka.ms/dotnetclitools-in-box).</source>
-        <target state="translated">NETSDK1059: Narzędzie „{0}” jest teraz dołączone do zestawu .NET Core SDK. Informacje dotyczące sposobu rozwiązania problemu wskazanego w ostrzeżeniu można znaleźć na stronie https://aka.ms/dotnetclitools-in-box.</target>
-        <note>{StrBegin="NETSDK1059: "}</note>
+      <trans-unit id="InvalidNuGetVersionString">
+        <source>NETSDK1018: Invalid NuGet version string: '{0}'.</source>
+        <target state="translated">NETSDK1018: Nieprawidłowy ciąg wersji NuGet: „{0}”.</target>
+        <note>{StrBegin="NETSDK1018: "}</note>
       </trans-unit>
-      <trans-unit id="ErrorReadingAssetsFile">
-        <source>NETSDK1060: Error reading assets file: {0}</source>
-        <target state="translated">NETSDK1060: Błąd podczas odczytywania pliku zasobów: {0}</target>
-        <note>{StrBegin="NETSDK1060: "}</note>
+      <trans-unit id="InvalidResourceUpdate">
+        <source>NETSDK1075: Update handle is invalid. This instance may not be used for further updates.</source>
+        <target state="translated">NETSDK1075: Dojście aktualizacji jest nieprawidłowe. Tego wystąpienia nie można używać do dalszych aktualizacji.</target>
+        <note>{StrBegin="NETSDK1075: "}</note>
       </trans-unit>
       <trans-unit id="MismatchedPlatformPackageVersion">
         <source>NETSDK1061: The project was restored using {0} version {1}, but with current settings, version {2} would be used instead. To resolve this issue, make sure the same settings are used for restore and for subsequent operations such as build or publish. Typically this issue can occur if the RuntimeIdentifier property is set during build or publish but not during restore. For more information, see https://aka.ms/dotnet-runtime-patch-selection.</source>
@@ -391,35 +276,150 @@ The following are names of parameters or literal values and should not be transl
 {1} - Restored version of platform package
 {2} - Current version of platform package</note>
       </trans-unit>
-      <trans-unit id="AssetsFileNotSet">
-        <source>NETSDK1063: The path to the project assets file was not set. Run a NuGet package restore to generate this file.</source>
-        <target state="translated">NETSDK1063: Nie ustawiono ścieżki do pliku zasobów projektu. Uruchom przywracanie pakietu NuGet, aby wygenerować ten plik.</target>
-        <note>{StrBegin="NETSDK1063: "}</note>
+      <trans-unit id="MissingItemMetadata">
+        <source>NETSDK1008: Missing '{0}' metadata on '{1}' item '{2}'.</source>
+        <target state="translated">NETSDK1008: Brak metadanych „{0}” w elemencie „{1}” „{2}”.</target>
+        <note>{StrBegin="NETSDK1008: "}</note>
       </trans-unit>
-      <trans-unit id="DotnetToolOnlySupportNetcoreapp">
-        <source>NETSDK1054: only supports .NET Core.</source>
-        <target state="translated">NETSDK1054: obsługuje tylko platformę .NET Core.</target>
-        <note>{StrBegin="NETSDK1054: "}</note>
+      <trans-unit id="MultipleFilesResolved">
+        <source>NETSDK1021: More than one file found for {0}</source>
+        <target state="translated">NETSDK1021: Znaleziono więcej niż jeden plik dla elementu {0}</target>
+        <note>{StrBegin="NETSDK1021: "}</note>
       </trans-unit>
-      <trans-unit id="DotnetToolDoesNotSupportTFMLowerThanNetcoreapp21">
-        <source>NETSDK1055: DotnetTool does not support target framework lower than netcoreapp2.1.</source>
-        <target state="translated">NETSDK1055: Narzędzie DotnetTool nie obsługuje docelowej struktury w wersji niższej niż netcoreapp2.1.</target>
-        <note>{StrBegin="NETSDK1055: "}</note>
+      <trans-unit id="NETFrameworkToNonBuiltInNETStandard">
+        <source>NETSDK1069: This project uses a library that targets .NET Standard 1.5 or higher, and the project targets a version of .NET Framework that doesn't have built-in support for that version of .NET Standard. Visit https://aka.ms/net-standard-known-issues for a set of known issues. Consider retargeting to .NET Framework 4.7.2.</source>
+        <target state="translated">NETSDK1069: Projekt korzysta z biblioteki przeznaczonej dla platformy .NET Standard 1.5 lub nowszej, a projekt jest przeznaczony dla wersji programu .NET Framework, która nie ma wbudowanej obsługi tej wersji platformy .NET Standard. Odwiedź witrynę https://aka.ms/net-standard-known-issues, aby zapoznać się z zestawem znanych problemów. Rozważ zmianę elementu docelowego na program .NET Framework 4.7.2.</target>
+        <note>{StrBegin="NETSDK1069: "}</note>
       </trans-unit>
-      <trans-unit id="UnableToUsePackageAssetsCache">
-        <source>NETSDK1062: Unable to use package assets cache due to I/O error. This can occur when the same project is built more than once in parallel. Performance may be degraded, but the build result will not be impacted.</source>
-        <target state="translated">NETSDK1062: Nie można użyć pamięci podręcznej zasobów pakietu ze względu na błąd we/wy. Do tej sytuacji może dochodzić, gdy ten sam projekt jest kompilowany więcej niż jeden raz jednocześnie. Może wystąpić spadek wydajności, ale nie będzie mieć to wpływu na wyniki kompilacji.</target>
-        <note>{StrBegin="NETSDK1062: "}</note>
+      <trans-unit id="NoAppHostAvailable">
+        <source>NETSDK1084: There is no application host available for the specified RuntimeIdentifier '{0}'.</source>
+        <target state="new">NETSDK1084: There is no application host available for the specified RuntimeIdentifier '{0}'.</target>
+        <note>{StrBegin="NETSDK1084: "}</note>
+      </trans-unit>
+      <trans-unit id="NoCompatibleTargetFramework">
+        <source>NETSDK1002: Project '{0}' targets '{2}'. It cannot be referenced by a project that targets '{1}'.</source>
+        <target state="translated">NETSDK1002: Projekt „{0}” ma platformę docelową „{2}”. Nie może on być przywoływany przez projekt z platformą docelową „{1}”.</target>
+        <note>{StrBegin="NETSDK1002: "}</note>
+      </trans-unit>
+      <trans-unit id="NoRuntimePackAvailable">
+        <source>NETSDK1082: There was no runtime pack for {0} available for the specified RuntimeIdentifier '{1}'.</source>
+        <target state="new">NETSDK1082: There was no runtime pack for {0} available for the specified RuntimeIdentifier '{1}'.</target>
+        <note>{StrBegin="NETSDK1082: "}</note>
+      </trans-unit>
+      <trans-unit id="PackAsToolCannotSupportSelfContained">
+        <source>NETSDK1053: Pack as tool does not support self contained.</source>
+        <target state="translated">NETSDK1053: Funkcja pakowania jako narzędzie nie obsługuje elementów autonomicznych.</target>
+        <note>{StrBegin="NETSDK1001: "}</note>
+      </trans-unit>
+      <trans-unit id="PackageInfoLog">
+        <source>NETSDK1027: Package Name='{0}', Version='{1}' was parsed</source>
+        <target state="translated">NETSDK1027: Przeanalizowano pakiet o nazwie „{0}” w wersji „{1}”</target>
+        <note>{StrBegin="NETSDK1027: "}</note>
       </trans-unit>
       <trans-unit id="PackageNotFound">
         <source>NETSDK1064: Package {0}, version {1} was not found. It might have been deleted since NuGet restore. Otherwise, NuGet restore might have only partially completed, which might have been due to maximum path length restrictions.</source>
         <target state="translated">NETSDK1064: Nie odnaleziono pakietu {0} w wersji {1}. Mógł on zostać usunięty po przywróceniu pakietu NuGet. W innym przypadku przywrócenie pakietu NuGet mogło zostać ukończone tylko częściowo, co mogło być spowodowane ograniczeniami wynikającymi z maksymalnej długości ścieżki.</target>
         <note>{StrBegin="NETSDK1064: "}</note>
       </trans-unit>
-      <trans-unit id="CannotFindApphostForRid">
-        <source>NETSDK1065: Cannot find app host for {0}. {0} could be an invalid runtime identifier (RID). For more information about RID, see https://aka.ms/rid-catalog.</source>
-        <target state="translated">NETSDK1065: Nie można odnaleźć hosta aplikacji dla elementu {0}. {0} może być nieprawidłowym identyfikatorem środowiska uruchomieniowego. Aby uzyskać więcej informacji na temat identyfikatora środowiska uruchomieniowego, zobacz https://aka.ms/rid-catalog.</target>
-        <note>{StrBegin="NETSDK1065: "}</note>
+      <trans-unit id="PackageReferenceOverrideWarning">
+        <source>NETSDK1023: A PackageReference for '{0}' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see {1}</source>
+        <target state="translated">NETSDK1023: Odwołanie do pakietu dla „{0}” zostało uwzględnione w projekcie. Ten pakiet jest jawnie przywoływany przez zestaw .NET SDK i zwykle nie ma potrzeby tworzenia odwołania do niego z projektu. Aby uzyskać więcej informacji, zobacz {1}</target>
+        <note>{StrBegin="NETSDK1023: "}</note>
+      </trans-unit>
+      <trans-unit id="PackageReferenceVersionNotRecommended">
+        <source>NETSDK1071: A PackageReference to '{0}' specified a Version of `{1}`. Specifying the version of this package is not recommended. For more information, see https://aka.ms/sdkimplicitrefs</source>
+        <target state="translated">NETSDK1071: Odwołanie PackageReference do pakietu „{0}” określiło wersję „{1}”. Określanie wersji tego pakietu nie jest zalecane. Aby uzyskać więcej informacji, zobacz https://aka.ms/sdkimplicitrefs</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParsingFiles">
+        <source>NETSDK1026: Parsing the Files : '{0}'</source>
+        <target state="translated">NETSDK1026: Analizowanie plików: „{0}”</target>
+        <note>{StrBegin="NETSDK1026: "}</note>
+      </trans-unit>
+      <trans-unit id="ProjectAssetsConsumedWithoutMSBuildProjectPath">
+        <source>NETSDK1011: Assets are consumed from project '{0}', but no corresponding MSBuild project path was  found in '{1}'.</source>
+        <target state="translated">NETSDK1011: Zasoby są używane z projektu „{0}”, ale w elemencie „{1}” nie odnaleziono odpowiadającej ścieżki projektu MSBuild.</target>
+        <note>{StrBegin="NETSDK1011: "}</note>
+      </trans-unit>
+      <trans-unit id="ProjectContainsObsoleteDotNetCliTool">
+        <source>NETSDK1059: The tool '{0}' is now included in the .NET Core SDK. Information on resolving this warning is available at (https://aka.ms/dotnetclitools-in-box).</source>
+        <target state="translated">NETSDK1059: Narzędzie „{0}” jest teraz dołączone do zestawu .NET Core SDK. Informacje dotyczące sposobu rozwiązania problemu wskazanego w ostrzeżeniu można znaleźć na stronie https://aka.ms/dotnetclitools-in-box.</target>
+        <note>{StrBegin="NETSDK1059: "}</note>
+      </trans-unit>
+      <trans-unit id="RuntimeIdentifierNotRecognized">
+        <source>NETSDK1083: The specified RuntimeIdentifier '{0}' is not recognized.</source>
+        <target state="new">NETSDK1083: The specified RuntimeIdentifier '{0}' is not recognized.</target>
+        <note>{StrBegin="NETSDK1083: "}</note>
+      </trans-unit>
+      <trans-unit id="RuntimeIdentifierWasNotSpecified">
+        <source>NETSDK1028: Specify a RuntimeIdentifier</source>
+        <target state="translated">NETSDK1028: Określ element RuntimeIdentifier</target>
+        <note>{StrBegin="NETSDK1028: "}</note>
+      </trans-unit>
+      <trans-unit id="SkippingAdditionalProbingPaths">
+        <source>NETSDK1048: 'AdditionalProbingPaths' were specified for GenerateRuntimeConfigurationFiles, but are being skipped because 'RuntimeConfigDevPath' is empty.</source>
+        <target state="translated">NETSDK1048: Dla elementu GenerateRuntimeConfigurationFiles określono ścieżki AdditionalProbingPaths, ale są one pomijane, ponieważ element „RuntimeConfigDevPath” jest pusty.</target>
+        <note>{StrBegin="NETSDK1048: "}</note>
+      </trans-unit>
+      <trans-unit id="TargetFrameworkWithSemicolon">
+        <source>NETSDK1046: The TargetFramework value '{0}' is not valid. To multi-target, use the 'TargetFrameworks' property instead.</source>
+        <target state="translated">NETSDK1046: Wartość „{0}” elementu TargetFramework jest nieprawidłowa. Aby obsługiwać wiele środowisk docelowych, użyj zamiast tego właściwości TargetFrameworks.</target>
+        <note>{StrBegin="NETSDK1046: "}</note>
+      </trans-unit>
+      <trans-unit id="UnableToFindResolvedPath">
+        <source>NETSDK1016: Unable to find resolved path for '{0}'.</source>
+        <target state="translated">NETSDK1016: Nie można odnaleźć rozpoznanej ścieżki dla elementu „{0}”.</target>
+        <note>{StrBegin="NETSDK1016: "}</note>
+      </trans-unit>
+      <trans-unit id="UnableToUsePackageAssetsCache">
+        <source>NETSDK1062: Unable to use package assets cache due to I/O error. This can occur when the same project is built more than once in parallel. Performance may be degraded, but the build result will not be impacted.</source>
+        <target state="translated">NETSDK1062: Nie można użyć pamięci podręcznej zasobów pakietu ze względu na błąd we/wy. Do tej sytuacji może dochodzić, gdy ten sam projekt jest kompilowany więcej niż jeden raz jednocześnie. Może wystąpić spadek wydajności, ale nie będzie mieć to wpływu na wyniki kompilacji.</target>
+        <note>{StrBegin="NETSDK1062: "}</note>
+      </trans-unit>
+      <trans-unit id="UnexpectedFileType">
+        <source>NETSDK1012: Unexpected file type for '{0}'. Type is both '{1}' and '{2}'.</source>
+        <target state="translated">NETSDK1012: Nieoczekiwany typ pliku dla „{0}”. Typ to „{1}” oraz „{2}”.</target>
+        <note>{StrBegin="NETSDK1012: "}</note>
+      </trans-unit>
+      <trans-unit id="UnknownFrameworkReference">
+        <source>NETSDK1073: The FrameworkReference '{0}' was not recognized</source>
+        <target state="translated">NETSDK1073: Odwołanie FrameworkReference „{0}” nie zostało rozpoznane</target>
+        <note>{StrBegin="NETSDK1073: "}</note>
+      </trans-unit>
+      <trans-unit id="UnrecognizedPreprocessorToken">
+        <source>NETSDK1009: Unrecognized preprocessor token '{0}' in '{1}'.</source>
+        <target state="translated">NETSDK1009: Nierozpoznany token preprocesora „{0}” w elemencie „{1}”.</target>
+        <note>{StrBegin="NETSDK1009: "}</note>
+      </trans-unit>
+      <trans-unit id="UnresolvedTargetingPack">
+        <source>NETSDK1081: The targeting pack for {0} was not found. You may be able to resolve this by running a NuGet restore on the project.</source>
+        <target state="new">NETSDK1081: The targeting pack for {0} was not found. You may be able to resolve this by running a NuGet restore on the project.</target>
+        <note>{StrBegin="NETSDK1081: "}</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedFramework">
+        <source>NETSDK1019: {0} is an unsupported framework.</source>
+        <target state="translated">NETSDK1019: {0} to nieobsługiwana platforma.</target>
+        <note>{StrBegin="NETSDK1019: "}</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedRuntimeIdentifier">
+        <source>NETSDK1056: Project is targeting runtime '{0}' but did not resolve any runtime-specific packages. This runtime may not be supported by the target framework.</source>
+        <target state="translated">NETSDK1056: Projekt jest przeznaczony dla środowiska uruchomieniowego „{0}”, ale nie rozpoznaje żadnych pakietów specyficznych dla tego środowiska. To środowisko uruchomieniowe nie może być obsługiwane przez platformę docelową.</target>
+        <note>{StrBegin="NETSDK1056: "}</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedSDKVersionForNetStandard20">
+        <source>NETSDK1050: The version of Microsoft.NET.Sdk used by this project is insufficient to support references to libraries targeting .NET Standard 1.5 or higher.  Please install version 2.0 or higher of the .NET Core SDK.</source>
+        <target state="translated">NETSDK1050: Używana przez ten projekt wersja zestawu Microsoft.NET.Sdk jest niewystarczająca do zapewnienia obsługi odwołań do bibliotek przeznaczonych dla platformy .NET Standard 1.5 lub nowszych. Zainstaluj zestaw .NET Core SDK w wersji co najmniej 2.0.</target>
+        <note>{StrBegin="NETSDK1050: "}</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedTargetFrameworkVersion">
+        <source>NETSDK1045: The current .NET SDK does not support targeting {0} {1}.  Either target {0} {2} or lower, or use a version of the .NET SDK that supports {0} {1}.</source>
+        <target state="translated">NETSDK1045: Bieżący zestaw .NET SDK nie obsługuje używania środowiska docelowego {0} {1}. Użyj jako środowiska docelowego wersji {0} {2} lub starszej albo użyj wersji zestawu .NET SDK obsługującej środowisko {0} {1}.</target>
+        <note>{StrBegin="NETSDK1045: "}</note>
+      </trans-unit>
+      <trans-unit id="UsingPreviewSdkWarning">
+        <source>NETSDK1057: You are using a preview version of .NET Core. See: https://aka.ms/dotnet-core-preview</source>
+        <target state="translated">NETSDK1057: Korzystasz z wersji zapoznawczej platformy .NET Core. Zobacz: https://aka.ms/dotnet-core-preview</target>
+        <note>{StrBegin="NETSDK1057: "}</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
@@ -2,35 +2,25 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../Strings.resx">
     <body>
-      <trans-unit id="AspNetCoreAllNotSupported">
-        <source>NETSDK1079: The Microsoft.AspNetCore.All package is not supported when targeting .NET Core 3.0 or higher.  A FrameworkReference to Microsoft.AspNetCore.App should be used instead, and will be implicitly included by Microsoft.NET.Sdk.Web.</source>
-        <target state="translated">NETSDK1079: não há suporte para o pacote Microsoft.AspNetCore.All quando há direcionamento para .NET Core 3.0 ou superior. Uma FrameworkReference para Microsoft.AspNetCore.App deve ser usada e será incluída implicitamente pelo Microsoft.NET.Sdk.Web.</target>
-        <note>{StrBegin="NETSDK1079: "}</note>
-      </trans-unit>
-      <trans-unit id="AspNetCoreUsesFrameworkReference">
-        <source>NETSDK1080: A PackageReference to Microsoft.AspNetCore.App is not necessary when targeting .NET Core 3.0 or higher. If Microsoft.NET.Sdk.Web is used, the shared framework will be referenced automatically. Otherwise, the PackageReference should be replaced with a FrameworkReference.</source>
-        <target state="translated">NETSDK1080: uma PackageReference para Microsoft.AspNetCore.App não é necessária quando há direcionamento para .NET Core 3.0 ou superior. Se Microsoft.NET.Sdk.Web for usado, a estrutura compartilhada será referenciada automaticamente. Caso contrário, a PackageReference deverá ser substituída por uma FrameworkReference.</target>
-        <note>{StrBegin="NETSDK1080: "}</note>
-      </trans-unit>
-      <trans-unit id="FailedToLockResource">
-        <source>NETSDK1077: Failed to lock resource.</source>
-        <target state="translated">NETSDK1077: falha ao bloquear recurso.</target>
-        <note>{StrBegin="NETSDK1077: "}</note>
-      </trans-unit>
       <trans-unit id="AddResourceWithNonIntegerResource">
         <source>NETSDK1076: AddResource can only be used with integer resource types.</source>
         <target state="translated">NETSDK1076: AddResource só pode ser usado com tipos de recursos inteiros.</target>
         <note>{StrBegin="NETSDK1076: "}</note>
       </trans-unit>
-      <trans-unit id="InvalidResourceUpdate">
-        <source>NETSDK1075: Update handle is invalid. This instance may not be used for further updates.</source>
-        <target state="translated">NETSDK1075: o identificador de atualização não é válido. Esta instância não pode ser usada para atualizações adicionais.</target>
-        <note>{StrBegin="NETSDK1075: "}</note>
+      <trans-unit id="AppConfigRequiresRootConfiguration">
+        <source>NETSDK1070: The application configuration file must have root configuration element.</source>
+        <target state="translated">NETSDK1070: o arquivo de configuração do aplicativo deve ter um elemento de configuração raiz.</target>
+        <note>{StrBegin="NETSDK1070: "}</note>
       </trans-unit>
       <trans-unit id="AppHostCustomizationRequiresWindowsHostWarning">
         <source>NETSDK1074: The application host executable will not be customized because adding resources requires that the build be performed on Windows (excluding Nano Server).</source>
         <target state="translated">NETSDK1074: o executável do host do aplicativo não será personalizado porque a adição de recursos exige a execução do build no Windows (excluindo o Nano Server).</target>
         <note>{StrBegin="NETSDK1074: "}</note>
+      </trans-unit>
+      <trans-unit id="AppHostHasBeenModified">
+        <source>NETSDK1029: Unable to use '{0}' as application host executable as it does not contain the expected placeholder byte sequence '{1}' that would mark where the application name would be written.</source>
+        <target state="translated">NETSDK1029: Não é possível usar '{0}' como executável do host de aplicativo, porque ele não contém a sequência de bytes de espaço reservado esperada '{1}' que marcaria o local em que o nome do aplicativo seria gravado.</target>
+        <note>{StrBegin="NETSDK1029: "}</note>
       </trans-unit>
       <trans-unit id="AppHostNotWindows">
         <source>NETSDK1078: Unable to use '{0}' as application host executable because it's not a Windows PE file.</source>
@@ -42,210 +32,80 @@
         <target state="translated">NETSDK1072: não é possível usar '{0}' como executável do host do aplicativo porque ele não é um executável do Windows para o subsistema CUI (Console).</target>
         <note>{StrBegin="NETSDK1072: "}</note>
       </trans-unit>
-      <trans-unit id="AppConfigRequiresRootConfiguration">
-        <source>NETSDK1070: The application configuration file must have root configuration element.</source>
-        <target state="translated">NETSDK1070: o arquivo de configuração do aplicativo deve ter um elemento de configuração raiz.</target>
-        <note>{StrBegin="NETSDK1070: "}</note>
+      <trans-unit id="AspNetCoreAllNotSupported">
+        <source>NETSDK1079: The Microsoft.AspNetCore.All package is not supported when targeting .NET Core 3.0 or higher.  A FrameworkReference to Microsoft.AspNetCore.App should be used instead, and will be implicitly included by Microsoft.NET.Sdk.Web.</source>
+        <target state="translated">NETSDK1079: não há suporte para o pacote Microsoft.AspNetCore.All quando há direcionamento para .NET Core 3.0 ou superior. Uma FrameworkReference para Microsoft.AspNetCore.App deve ser usada e será incluída implicitamente pelo Microsoft.NET.Sdk.Web.</target>
+        <note>{StrBegin="NETSDK1079: "}</note>
       </trans-unit>
-      <trans-unit id="AtLeastOneTargetFrameworkMustBeSpecified">
-        <source>NETSDK1001: At least one possible target framework must be specified.</source>
-        <target state="translated">NETSDK1001: É necessário especificar pelo menos uma estrutura de destino possível.</target>
-        <note>{StrBegin="NETSDK1001: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotUseSelfContainedWithoutAppHost">
-        <source>NETSDK1067: Self-contained applications are required to use the application host. Either set SelfContained to false or set UseAppHost to true.</source>
-        <target state="translated">NETSDK1067: os aplicativos independentes são necessários para utilizar o host do aplicativo. Defina SelfContained como falso ou defina UseAppHost como verdadeiro.</target>
-        <note>{StrBegin="NETSDK1067: "}</note>
-      </trans-unit>
-      <trans-unit id="FrameworkDependentAppHostRequiresVersion21">
-        <source>NETSDK1068: The framework-dependent application host requires a target framework of at least 'netcoreapp2.1'.</source>
-        <target state="translated">NETSDK1068: o host do aplicativo dependente de estrutura exige uma estrutura de destino de, pelo menos, 'netcoreapp2.1'.</target>
-        <note>{StrBegin="NETSDK1068: "}</note>
-      </trans-unit>
-      <trans-unit id="NETFrameworkToNonBuiltInNETStandard">
-        <source>NETSDK1069: This project uses a library that targets .NET Standard 1.5 or higher, and the project targets a version of .NET Framework that doesn't have built-in support for that version of .NET Standard. Visit https://aka.ms/net-standard-known-issues for a set of known issues. Consider retargeting to .NET Framework 4.7.2.</source>
-        <target state="translated">NETSDK1069: este projeto utiliza uma biblioteca que tem como destino o .NET Standard 1.5 ou superior, e o projeto tem como destino uma versão do .NET Framework que não tem suporte interno para essa versão do .NET Standard. Visite o site https://aka.ms/net-standard-known-issues para ter acesso a uma variedade de problemas conhecidos. Considere alterar o destino para o .NET Framework 4.7.2.</target>
-        <note>{StrBegin="NETSDK1069: "}</note>
-      </trans-unit>
-      <trans-unit id="NoAppHostAvailable">
-        <source>NETSDK1084: There is no application host available for the specified RuntimeIdentifier '{0}'.</source>
-        <target state="new">NETSDK1084: There is no application host available for the specified RuntimeIdentifier '{0}'.</target>
-        <note>{StrBegin="NETSDK1084: "}</note>
-      </trans-unit>
-      <trans-unit id="NoCompatibleTargetFramework">
-        <source>NETSDK1002: Project '{0}' targets '{2}'. It cannot be referenced by a project that targets '{1}'.</source>
-        <target state="translated">NETSDK1002: O projeto '{0}' é direcionado a '{2}'. Ele não pode ser referenciado por um projeto direcionado a '{1}'.</target>
-        <note>{StrBegin="NETSDK1002: "}</note>
-      </trans-unit>
-      <trans-unit id="InvalidFrameworkName">
-        <source>NETSDK1003: Invalid framework name: '{0}'.</source>
-        <target state="translated">NETSDK1003: Nome de estrutura inválido: '{0}'.</target>
-        <note>{StrBegin="NETSDK1003: "}</note>
-      </trans-unit>
-      <trans-unit id="AssetsFileNotFound">
-        <source>NETSDK1004: Assets file '{0}' not found. Run a NuGet package restore to generate this file.</source>
-        <target state="translated">NETSDK1004: Arquivo de ativos '{0}' não encontrado. Execute uma restauração de pacote do NuGet para gerar esse arquivo.</target>
-        <note>{StrBegin="NETSDK1004: "}</note>
-      </trans-unit>
-      <trans-unit id="AssetsFileMissingTarget">
-        <source>NETSDK1005: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project.</source>
-        <target state="translated">NETSDK1005: O arquivo de ativos '{0}' não tem um destino para '{1}'. Verifique se a restauração foi executada e se você incluiu '{2}' no TargetFrameworks do projeto.</target>
-        <note>{StrBegin="NETSDK1005: "}</note>
-      </trans-unit>
-      <trans-unit id="AssetsFilePathNotRooted">
-        <source>NETSDK1006: Assets file path '{0}' is not rooted. Only full paths are supported.</source>
-        <target state="translated">NETSDK1006: O caminho de arquivo de ativos '{0}' não tem raiz. Há suporte apenas para caminhos completos.</target>
-        <note>{StrBegin="NETSDK1006: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotFindProjectInfo">
-        <source>NETSDK1007: Cannot find project info for '{0}'. This can indicate a missing project reference.</source>
-        <target state="translated">NETSDK1007: Não é possível localizar informações do projeto para '{0}'. Isso pode indicar a ausência de uma referência de projeto.</target>
-        <note>{StrBegin="NETSDK1007: "}</note>
-      </trans-unit>
-      <trans-unit id="MissingItemMetadata">
-        <source>NETSDK1008: Missing '{0}' metadata on '{1}' item '{2}'.</source>
-        <target state="translated">NETSDK1008: Metadados '{0}' ausentes no item '{1}' '{2}'.</target>
-        <note>{StrBegin="NETSDK1008: "}</note>
-      </trans-unit>
-      <trans-unit id="NoRuntimePackAvailable">
-        <source>NETSDK1082: There was no runtime pack for {0} available for the specified RuntimeIdentifier '{1}'.</source>
-        <target state="new">NETSDK1082: There was no runtime pack for {0} available for the specified RuntimeIdentifier '{1}'.</target>
-        <note>{StrBegin="NETSDK1082: "}</note>
-      </trans-unit>
-      <trans-unit id="PackageReferenceVersionNotRecommended">
-        <source>NETSDK1071: A PackageReference to '{0}' specified a Version of `{1}`. Specifying the version of this package is not recommended. For more information, see https://aka.ms/sdkimplicitrefs</source>
-        <target state="translated">NETSDK1071: uma PackageReference para '{0}' especificou uma Versão de '{1}'. Não é recomendado especificar a versão deste pacote. Para obter mais informações, consulte https://aka.ms/sdkimplicitrefs</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="RuntimeIdentifierNotRecognized">
-        <source>NETSDK1083: The specified RuntimeIdentifier '{0}' is not recognized.</source>
-        <target state="new">NETSDK1083: The specified RuntimeIdentifier '{0}' is not recognized.</target>
-        <note>{StrBegin="NETSDK1083: "}</note>
-      </trans-unit>
-      <trans-unit id="UnknownFrameworkReference">
-        <source>NETSDK1073: The FrameworkReference '{0}' was not recognized</source>
-        <target state="translated">NETSDK1073: a FrameworkReference '{0}' não foi reconhecida</target>
-        <note>{StrBegin="NETSDK1073: "}</note>
-      </trans-unit>
-      <trans-unit id="UnrecognizedPreprocessorToken">
-        <source>NETSDK1009: Unrecognized preprocessor token '{0}' in '{1}'.</source>
-        <target state="translated">NETSDK1009: Token de pré-processador não reconhecido '{0}' em '{1}'.</target>
-        <note>{StrBegin="NETSDK1009: "}</note>
-      </trans-unit>
-      <trans-unit id="ContentPreproccessorParameterRequired">
-        <source>NETSDK1010: The '{0}' task must be given a value for parameter '{1}' in order to consume preprocessed content.</source>
-        <target state="translated">NETSDK1010: A tarefa '{0}' precisa receber um valor para o parâmetro '{1}' para consumir o conteúdo pré-processado.</target>
-        <note>{StrBegin="NETSDK1010: "}</note>
-      </trans-unit>
-      <trans-unit id="ProjectAssetsConsumedWithoutMSBuildProjectPath">
-        <source>NETSDK1011: Assets are consumed from project '{0}', but no corresponding MSBuild project path was  found in '{1}'.</source>
-        <target state="translated">NETSDK1011: Os ativos são consumidos de um projeto '{0}', mas não foi encontrado nenhum caminho de projeto do MSBuild correspondente em '{1}'.</target>
-        <note>{StrBegin="NETSDK1011: "}</note>
-      </trans-unit>
-      <trans-unit id="UnexpectedFileType">
-        <source>NETSDK1012: Unexpected file type for '{0}'. Type is both '{1}' and '{2}'.</source>
-        <target state="translated">NETSDK1012: Tipo de arquivo inesperado para '{0}'. O tipo é '{1}' e '{2}'.</target>
-        <note>{StrBegin="NETSDK1012: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotInferTargetFrameworkIdentifierAndVersion">
-        <source>NETSDK1013: The TargetFramework value '{0}' was not recognized. It may be misspelled. If not, then the TargetFrameworkIdentifier and/or TargetFrameworkVersion properties must be specified explicitly.</source>
-        <target state="translated">NETSDK1013: O valor '{0}' do TargetFramework não foi reconhecido. Ele pode ter sido escrito com ortografia incorreta. Caso contrário, as propriedades TargetFrameworkIdentifier e/ou TargetFrameworkVersion precisarão ser especificadas explicitamente.</target>
-        <note>{StrBegin="NETSDK1013: "}</note>
-      </trans-unit>
-      <trans-unit id="ContentItemDoesNotProvideOutputPath">
-        <source>NETSDK1014: Content item for '{0}' sets '{1}', but does not provide  '{2}' or '{3}'.</source>
-        <target state="translated">NETSDK1014: O item de conteúdo para '{0}' define '{1}', mas não fornece '{2}' ou '{3}'.</target>
-        <note>{StrBegin="NETSDK1014: "}</note>
-      </trans-unit>
-      <trans-unit id="DuplicatePreprocessorToken">
-        <source>NETSDK1015: The preprocessor token '{0}' has been given more than one value. Choosing '{1}' as the value.</source>
-        <target state="translated">NETSDK1015: O token de pré-processador '{0}' recebeu mais de um valor. Escolhendo '{1}' como o valor.</target>
-        <note>{StrBegin="NETSDK1015: "}</note>
-      </trans-unit>
-      <trans-unit id="UnableToFindResolvedPath">
-        <source>NETSDK1016: Unable to find resolved path for '{0}'.</source>
-        <target state="translated">NETSDK1016: Não foi possível localizar o caminho resolvido para '{0}'.</target>
-        <note>{StrBegin="NETSDK1016: "}</note>
+      <trans-unit id="AspNetCoreUsesFrameworkReference">
+        <source>NETSDK1080: A PackageReference to Microsoft.AspNetCore.App is not necessary when targeting .NET Core 3.0 or higher. If Microsoft.NET.Sdk.Web is used, the shared framework will be referenced automatically. Otherwise, the PackageReference should be replaced with a FrameworkReference.</source>
+        <target state="translated">NETSDK1080: uma PackageReference para Microsoft.AspNetCore.App não é necessária quando há direcionamento para .NET Core 3.0 ou superior. Se Microsoft.NET.Sdk.Web for usado, a estrutura compartilhada será referenciada automaticamente. Caso contrário, a PackageReference deverá ser substituída por uma FrameworkReference.</target>
+        <note>{StrBegin="NETSDK1080: "}</note>
       </trans-unit>
       <trans-unit id="AssetPreprocessorMustBeConfigured">
         <source>NETSDK1017: Asset preprocessor must be configured before assets are processed.</source>
         <target state="translated">NETSDK1017: O pré-processador de ativos precisa ser configurado antes que os ativos sejam processados.</target>
         <note>{StrBegin="NETSDK1017: "}</note>
       </trans-unit>
-      <trans-unit id="InvalidNuGetVersionString">
-        <source>NETSDK1018: Invalid NuGet version string: '{0}'.</source>
-        <target state="translated">NETSDK1018: Cadeia de caracteres de versão do NuGet inválida: '{0}'.</target>
-        <note>{StrBegin="NETSDK1018: "}</note>
+      <trans-unit id="AssetsFileMissingRuntimeIdentifier">
+        <source>NETSDK1047: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project. You may also need to include '{3}' in your project's RuntimeIdentifiers.</source>
+        <target state="translated">NETSDK1047: O arquivo de ativos '{0}' não tem um destino para '{1}'. Verifique se a restauração foi executada e se você incluiu '{2}' no TargetFrameworks do projeto. Talvez você também precise incluir '{3}' no RuntimeIdentifiers do projeto.</target>
+        <note>{StrBegin="NETSDK1047: "}</note>
       </trans-unit>
-      <trans-unit id="UnresolvedTargetingPack">
-        <source>NETSDK1081: The targeting pack for {0} was not found. You may be able to resolve this by running a NuGet restore on the project.</source>
-        <target state="new">NETSDK1081: The targeting pack for {0} was not found. You may be able to resolve this by running a NuGet restore on the project.</target>
-        <note>{StrBegin="NETSDK1081: "}</note>
+      <trans-unit id="AssetsFileMissingTarget">
+        <source>NETSDK1005: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project.</source>
+        <target state="translated">NETSDK1005: O arquivo de ativos '{0}' não tem um destino para '{1}'. Verifique se a restauração foi executada e se você incluiu '{2}' no TargetFrameworks do projeto.</target>
+        <note>{StrBegin="NETSDK1005: "}</note>
       </trans-unit>
-      <trans-unit id="UnsupportedFramework">
-        <source>NETSDK1019: {0} is an unsupported framework.</source>
-        <target state="translated">NETSDK1019: {0} é uma estrutura sem suporte.</target>
-        <note>{StrBegin="NETSDK1019: "}</note>
+      <trans-unit id="AssetsFileNotFound">
+        <source>NETSDK1004: Assets file '{0}' not found. Run a NuGet package restore to generate this file.</source>
+        <target state="translated">NETSDK1004: Arquivo de ativos '{0}' não encontrado. Execute uma restauração de pacote do NuGet para gerar esse arquivo.</target>
+        <note>{StrBegin="NETSDK1004: "}</note>
       </trans-unit>
-      <trans-unit id="DuplicateItemsError">
-        <source>NETSDK1022: Duplicate '{0}' items were included. The .NET SDK includes '{0}' items from your project directory by default. You can either remove these items from your project file, or set the '{1}' property to '{2}' if you want to explicitly include them in your project file. For more information, see {4}. The duplicate items were: {3}</source>
-        <target state="translated">NETSDK1022: Itens '{0}' duplicados foram incluídos. O SDK do .NET inclui '{0}' itens do diretório do projeto por padrão. Você poderá remover esses itens do arquivo de projeto ou configurar a propriedade '{1}' como '{2}' se desejar incluí-los explicitamente no arquivo de projeto. Para obter mais informações, confira {4}. Os itens duplicados eram: {3}</target>
-        <note>{StrBegin="NETSDK1022: "}</note>
+      <trans-unit id="AssetsFileNotSet">
+        <source>NETSDK1063: The path to the project assets file was not set. Run a NuGet package restore to generate this file.</source>
+        <target state="translated">NETSDK1063: O caminho para o arquivo de ativos do projeto não foi configurado. Execute uma restauração de pacote do NuGet para gerar esse arquivo.</target>
+        <note>{StrBegin="NETSDK1063: "}</note>
       </trans-unit>
-      <trans-unit id="PackageReferenceOverrideWarning">
-        <source>NETSDK1023: A PackageReference for '{0}' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see {1}</source>
-        <target state="translated">NETSDK1023: Uma PackageReference para '{0}' foi incluída no projeto. Esse pacote é referenciado implicitamente pelo SKD do .NET e, geralmente, não é necessário referenciá-lo no seu projeto. Para obter mais informações, confira {1}</target>
-        <note>{StrBegin="NETSDK1023: "}</note>
+      <trans-unit id="AssetsFilePathNotRooted">
+        <source>NETSDK1006: Assets file path '{0}' is not rooted. Only full paths are supported.</source>
+        <target state="translated">NETSDK1006: O caminho de arquivo de ativos '{0}' não tem raiz. Há suporte apenas para caminhos completos.</target>
+        <note>{StrBegin="NETSDK1006: "}</note>
       </trans-unit>
-      <trans-unit id="IncorrectPackageRoot">
-        <source>NETSDK1020: Package Root {0} was incorrectly given for Resolved library {1}</source>
-        <target state="translated">NETSDK1020: A raiz do pacote {0} foi atribuída incorretamente para a biblioteca resolvida {1}</target>
-        <note>{StrBegin="NETSDK1020: "}</note>
+      <trans-unit id="AtLeastOneTargetFrameworkMustBeSpecified">
+        <source>NETSDK1001: At least one possible target framework must be specified.</source>
+        <target state="translated">NETSDK1001: É necessário especificar pelo menos uma estrutura de destino possível.</target>
+        <note>{StrBegin="NETSDK1001: "}</note>
       </trans-unit>
-      <trans-unit id="MultipleFilesResolved">
-        <source>NETSDK1021: More than one file found for {0}</source>
-        <target state="translated">NETSDK1021: Mais de um arquivo encontrado para {0}</target>
-        <note>{StrBegin="NETSDK1021: "}</note>
+      <trans-unit id="CannotFindApphostForRid">
+        <source>NETSDK1065: Cannot find app host for {0}. {0} could be an invalid runtime identifier (RID). For more information about RID, see https://aka.ms/rid-catalog.</source>
+        <target state="translated">NETSDK1065: Não é possível encontrar o host do aplicativo para {0}. {0} poderia ser um RID (identificador de tempo de execução inválido). Para obter mais informações sobre RID, confira https://aka.ms/rid-catalog.</target>
+        <note>{StrBegin="NETSDK1065: "}</note>
       </trans-unit>
-      <trans-unit id="FolderAlreadyExists">
-        <source>NETSDK1024: Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</source>
-        <target state="translated">NETSDK1024: A pasta '{0}' já existe. Exclua essa pasta ou forneça um ComposeWorkingDir diferente</target>
-        <note>{StrBegin="NETSDK1024: "}</note>
+      <trans-unit id="CannotFindProjectInfo">
+        <source>NETSDK1007: Cannot find project info for '{0}'. This can indicate a missing project reference.</source>
+        <target state="translated">NETSDK1007: Não é possível localizar informações do projeto para '{0}'. Isso pode indicar a ausência de uma referência de projeto.</target>
+        <note>{StrBegin="NETSDK1007: "}</note>
       </trans-unit>
-      <trans-unit id="ParsingFiles">
-        <source>NETSDK1026: Parsing the Files : '{0}'</source>
-        <target state="translated">NETSDK1026: Analisando os arquivos: '{0}'</target>
-        <note>{StrBegin="NETSDK1026: "}</note>
-      </trans-unit>
-      <trans-unit id="PackageInfoLog">
-        <source>NETSDK1027: Package Name='{0}', Version='{1}' was parsed</source>
-        <target state="translated">NETSDK1027: O nome do pacote = '{0}', versão = '{1}' foi analisado</target>
-        <note>{StrBegin="NETSDK1027: "}</note>
-      </trans-unit>
-      <trans-unit id="RuntimeIdentifierWasNotSpecified">
-        <source>NETSDK1028: Specify a RuntimeIdentifier</source>
-        <target state="translated">NETSDK1028: Especifique um RuntimeIdentifier</target>
-        <note>{StrBegin="NETSDK1028: "}</note>
-      </trans-unit>
-      <trans-unit id="IncorrectTargetFormat">
-        <source>NETSDK1025: WRThe target manifest {0} provided is of not the correct format</source>
-        <target state="translated">NETSDK1025: O manifesto de destino {0} fornecido não está no formato correto</target>
-        <note>{StrBegin="NETSDK1025: "}</note>
-      </trans-unit>
-      <trans-unit id="AppHostHasBeenModified">
-        <source>NETSDK1029: Unable to use '{0}' as application host executable as it does not contain the expected placeholder byte sequence '{1}' that would mark where the application name would be written.</source>
-        <target state="translated">NETSDK1029: Não é possível usar '{0}' como executável do host de aplicativo, porque ele não contém a sequência de bytes de espaço reservado esperada '{1}' que marcaria o local em que o nome do aplicativo seria gravado.</target>
-        <note>{StrBegin="NETSDK1029: "}</note>
-      </trans-unit>
-      <trans-unit id="FileNameIsTooLong">
-        <source>NETSDK1030: Given file name '{0}' is longer than 1024 bytes</source>
-        <target state="translated">NETSDK1030: O nome de arquivo '{0}' fornecido tem mais de 1024 bytes</target>
-        <note>{StrBegin="NETSDK1030: "}</note>
+      <trans-unit id="CannotHaveRuntimeIdentifierPlatformMismatchPlatformTarget">
+        <source>NETSDK1032: The RuntimeIdentifier platform '{0}' and the PlatformTarget '{1}' must be compatible.</source>
+        <target state="translated">NETSDK1032: A plataforma '{0}' do RuntimeIdentifier e o PlatformTarget '{1}' precisam ser compatíveis.</target>
+        <note>{StrBegin="NETSDK1032: "}</note>
       </trans-unit>
       <trans-unit id="CannotHaveSelfContainedWithoutRuntimeIdentifier">
         <source>NETSDK1031: It is not supported to build or publish a self-contained application without specifying a RuntimeIdentifier.  Please either specify a RuntimeIdentifier or set SelfContained to false.</source>
         <target state="translated">NETSDK1031: Não há suporte para criar ou publicar um aplicativo autossuficiente sem especificar um RuntimeIdentifier. Especifique um RuntimeIdentifier ou defina SelfContained como falso.</target>
         <note>{StrBegin="NETSDK1031: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotInferTargetFrameworkIdentifierAndVersion">
+        <source>NETSDK1013: The TargetFramework value '{0}' was not recognized. It may be misspelled. If not, then the TargetFrameworkIdentifier and/or TargetFrameworkVersion properties must be specified explicitly.</source>
+        <target state="translated">NETSDK1013: O valor '{0}' do TargetFramework não foi reconhecido. Ele pode ter sido escrito com ortografia incorreta. Caso contrário, as propriedades TargetFrameworkIdentifier e/ou TargetFrameworkVersion precisarão ser especificadas explicitamente.</target>
+        <note>{StrBegin="NETSDK1013: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotUseSelfContainedWithoutAppHost">
+        <source>NETSDK1067: Self-contained applications are required to use the application host. Either set SelfContained to false or set UseAppHost to true.</source>
+        <target state="translated">NETSDK1067: os aplicativos independentes são necessários para utilizar o host do aplicativo. Defina SelfContained como falso ou defina UseAppHost como verdadeiro.</target>
+        <note>{StrBegin="NETSDK1067: "}</note>
       </trans-unit>
       <trans-unit id="ChoosingAssemblyVersion">
         <source>NETSDK1033: Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</source>
@@ -272,6 +132,16 @@
         <target state="translated">NETSDK1037: Não foi possível determinar o vencedor porque as versões de arquivo e de assembly são iguais.</target>
         <note>{StrBegin="NETSDK1037: "}</note>
       </trans-unit>
+      <trans-unit id="ContentItemDoesNotProvideOutputPath">
+        <source>NETSDK1014: Content item for '{0}' sets '{1}', but does not provide  '{2}' or '{3}'.</source>
+        <target state="translated">NETSDK1014: O item de conteúdo para '{0}' define '{1}', mas não fornece '{2}' ou '{3}'.</target>
+        <note>{StrBegin="NETSDK1014: "}</note>
+      </trans-unit>
+      <trans-unit id="ContentPreproccessorParameterRequired">
+        <source>NETSDK1010: The '{0}' task must be given a value for parameter '{1}' in order to consume preprocessed content.</source>
+        <target state="translated">NETSDK1010: A tarefa '{0}' precisa receber um valor para o parâmetro '{1}' para consumir o conteúdo pré-processado.</target>
+        <note>{StrBegin="NETSDK1010: "}</note>
+      </trans-unit>
       <trans-unit id="CouldNotDetermineWinner_DoesntExist">
         <source>NETSDK1038: Could not determine winner because '{0}' does not exist.</source>
         <target state="translated">NETSDK1038: Não foi possível determinar o vencedor porque '{0}' não existe.</target>
@@ -287,15 +157,40 @@
         <target state="translated">NETSDK1040: Não foi possível determinar um vencedor porque '{0}' não é um assembly.</target>
         <note>{StrBegin="NETSDK1040: "}</note>
       </trans-unit>
+      <trans-unit id="CouldNotLoadPlatformManifest">
+        <source>NETSDK1042: Could not load PlatformManifest from '{0}' because it did not exist.</source>
+        <target state="translated">NETSDK1042: Não foi possível carregar PlatformManifest de '{0}' porque ele não existia.</target>
+        <note>{StrBegin="NETSDK1042: "}</note>
+      </trans-unit>
+      <trans-unit id="DotnetToolDoesNotSupportTFMLowerThanNetcoreapp21">
+        <source>NETSDK1055: DotnetTool does not support target framework lower than netcoreapp2.1.</source>
+        <target state="translated">NETSDK1055: O DotnetTool não é compatível com uma estrutura de destino inferior ao netcoreapp2.1.</target>
+        <note>{StrBegin="NETSDK1055: "}</note>
+      </trans-unit>
+      <trans-unit id="DotnetToolOnlySupportNetcoreapp">
+        <source>NETSDK1054: only supports .NET Core.</source>
+        <target state="translated">NETSDK1054: É compatível apenas com o .NET Core.</target>
+        <note>{StrBegin="NETSDK1054: "}</note>
+      </trans-unit>
+      <trans-unit id="DuplicateItemsError">
+        <source>NETSDK1022: Duplicate '{0}' items were included. The .NET SDK includes '{0}' items from your project directory by default. You can either remove these items from your project file, or set the '{1}' property to '{2}' if you want to explicitly include them in your project file. For more information, see {4}. The duplicate items were: {3}</source>
+        <target state="translated">NETSDK1022: Itens '{0}' duplicados foram incluídos. O SDK do .NET inclui '{0}' itens do diretório do projeto por padrão. Você poderá remover esses itens do arquivo de projeto ou configurar a propriedade '{1}' como '{2}' se desejar incluí-los explicitamente no arquivo de projeto. Para obter mais informações, confira {4}. Os itens duplicados eram: {3}</target>
+        <note>{StrBegin="NETSDK1022: "}</note>
+      </trans-unit>
+      <trans-unit id="DuplicatePreprocessorToken">
+        <source>NETSDK1015: The preprocessor token '{0}' has been given more than one value. Choosing '{1}' as the value.</source>
+        <target state="translated">NETSDK1015: O token de pré-processador '{0}' recebeu mais de um valor. Escolhendo '{1}' como o valor.</target>
+        <note>{StrBegin="NETSDK1015: "}</note>
+      </trans-unit>
       <trans-unit id="EncounteredConflict">
         <source>NETSDK1041: Encountered conflict between '{0}' and '{1}'.</source>
         <target state="translated">NETSDK1041: Encontrado um conflito entre '{0}' e '{1}'.</target>
         <note>{StrBegin="NETSDK1041: "}</note>
       </trans-unit>
-      <trans-unit id="CouldNotLoadPlatformManifest">
-        <source>NETSDK1042: Could not load PlatformManifest from '{0}' because it did not exist.</source>
-        <target state="translated">NETSDK1042: Não foi possível carregar PlatformManifest de '{0}' porque ele não existia.</target>
-        <note>{StrBegin="NETSDK1042: "}</note>
+      <trans-unit id="ErrorParsingFrameworkListInvalidValue">
+        <source>NETSDK1051: Error parsing FrameworkList from '{0}'.  {1} '{2}' was invalid.</source>
+        <target state="translated">NETSDK1051: Erro ao analisar FrameworkList de '{0}'.  {1} '{2}' era inválido.</target>
+        <note>{StrBegin="NETSDK1051: "}</note>
       </trans-unit>
       <trans-unit id="ErrorParsingPlatformManifest">
         <source>NETSDK1043: Error parsing PlatformManifest from '{0}' line {1}.  Lines must have the format {2}.</source>
@@ -307,65 +202,55 @@
         <target state="translated">NETSDK1044: Erro ao analisar PlatformManifest de '{0}', linha {1}. {2} '{3}' era inválido.</target>
         <note>{StrBegin="NETSDK1044: "}</note>
       </trans-unit>
-      <trans-unit id="UnsupportedTargetFrameworkVersion">
-        <source>NETSDK1045: The current .NET SDK does not support targeting {0} {1}.  Either target {0} {2} or lower, or use a version of the .NET SDK that supports {0} {1}.</source>
-        <target state="translated">NETSDK1045: O SDK do .NET atual não dá suporte para direcionar a {0} {1}. Direcione a {0} {2} ou inferior, ou use uma versão do SDK do .NET compatível com  {0} {1}.</target>
-        <note>{StrBegin="NETSDK1045: "}</note>
+      <trans-unit id="ErrorReadingAssetsFile">
+        <source>NETSDK1060: Error reading assets file: {0}</source>
+        <target state="translated">NETSDK1060: Erro ao ler o arquivo de ativos: {0}</target>
+        <note>{StrBegin="NETSDK1060: "}</note>
       </trans-unit>
-      <trans-unit id="AssetsFileMissingRuntimeIdentifier">
-        <source>NETSDK1047: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project. You may also need to include '{3}' in your project's RuntimeIdentifiers.</source>
-        <target state="translated">NETSDK1047: O arquivo de ativos '{0}' não tem um destino para '{1}'. Verifique se a restauração foi executada e se você incluiu '{2}' no TargetFrameworks do projeto. Talvez você também precise incluir '{3}' no RuntimeIdentifiers do projeto.</target>
-        <note>{StrBegin="NETSDK1047: "}</note>
+      <trans-unit id="FailedToLockResource">
+        <source>NETSDK1077: Failed to lock resource.</source>
+        <target state="translated">NETSDK1077: falha ao bloquear recurso.</target>
+        <note>{StrBegin="NETSDK1077: "}</note>
       </trans-unit>
-      <trans-unit id="TargetFrameworkWithSemicolon">
-        <source>NETSDK1046: The TargetFramework value '{0}' is not valid. To multi-target, use the 'TargetFrameworks' property instead.</source>
-        <target state="translated">NETSDK1046: O valor '{0}' do TargetFramework não é válido. Para vários destinos, use a propriedade 'TargetFrameworks'.</target>
-        <note>{StrBegin="NETSDK1046: "}</note>
+      <trans-unit id="FileNameIsTooLong">
+        <source>NETSDK1030: Given file name '{0}' is longer than 1024 bytes</source>
+        <target state="translated">NETSDK1030: O nome de arquivo '{0}' fornecido tem mais de 1024 bytes</target>
+        <note>{StrBegin="NETSDK1030: "}</note>
       </trans-unit>
-      <trans-unit id="GetDependsOnNETStandardFailedWithException">
-        <source>NETSDK1049: Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0} {1}</source>
-        <target state="translated">NETSDK1049: O arquivo resolvido tem uma imagem inválida, não tem metadados ou está inacessível. {0} {1}</target>
-        <note>{StrBegin="NETSDK1049: "}</note>
+      <trans-unit id="FolderAlreadyExists">
+        <source>NETSDK1024: Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</source>
+        <target state="translated">NETSDK1024: A pasta '{0}' já existe. Exclua essa pasta ou forneça um ComposeWorkingDir diferente</target>
+        <note>{StrBegin="NETSDK1024: "}</note>
       </trans-unit>
-      <trans-unit id="UnsupportedSDKVersionForNetStandard20">
-        <source>NETSDK1050: The version of Microsoft.NET.Sdk used by this project is insufficient to support references to libraries targeting .NET Standard 1.5 or higher.  Please install version 2.0 or higher of the .NET Core SDK.</source>
-        <target state="translated">NETSDK1050: A versão do Microsoft.NET.Sdk usada por este projeto é insuficiente para dar suporte às referências a bibliotecas direcionadas ao .NET Standard 1.5 ou superior. Instale a versão 2.0 ou superior do SDK do .NET Core.</target>
-        <note>{StrBegin="NETSDK1050: "}</note>
-      </trans-unit>
-      <trans-unit id="SkippingAdditionalProbingPaths">
-        <source>NETSDK1048: 'AdditionalProbingPaths' were specified for GenerateRuntimeConfigurationFiles, but are being skipped because 'RuntimeConfigDevPath' is empty.</source>
-        <target state="translated">NETSDK1048: Os 'AdditionalProbingPaths' foram especificados para os GenerateRuntimeConfigurationFiles, mas estão sendo ignorados porque 'RuntimeConfigDevPath' está vazio.</target>
-        <note>{StrBegin="NETSDK1048: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotHaveRuntimeIdentifierPlatformMismatchPlatformTarget">
-        <source>NETSDK1032: The RuntimeIdentifier platform '{0}' and the PlatformTarget '{1}' must be compatible.</source>
-        <target state="translated">NETSDK1032: A plataforma '{0}' do RuntimeIdentifier e o PlatformTarget '{1}' precisam ser compatíveis.</target>
-        <note>{StrBegin="NETSDK1032: "}</note>
-      </trans-unit>
-      <trans-unit id="ErrorParsingFrameworkListInvalidValue">
-        <source>NETSDK1051: Error parsing FrameworkList from '{0}'.  {1} '{2}' was invalid.</source>
-        <target state="translated">NETSDK1051: Erro ao analisar FrameworkList de '{0}'.  {1} '{2}' era inválido.</target>
-        <note>{StrBegin="NETSDK1051: "}</note>
+      <trans-unit id="FrameworkDependentAppHostRequiresVersion21">
+        <source>NETSDK1068: The framework-dependent application host requires a target framework of at least 'netcoreapp2.1'.</source>
+        <target state="translated">NETSDK1068: o host do aplicativo dependente de estrutura exige uma estrutura de destino de, pelo menos, 'netcoreapp2.1'.</target>
+        <note>{StrBegin="NETSDK1068: "}</note>
       </trans-unit>
       <trans-unit id="FrameworkListPathNotRooted">
         <source>NETSDK1052: Framework list file path '{0}' is not rooted. Only full paths are supported.</source>
         <target state="translated">NETSDK1052: O caminho de arquivo de lista de estrutura '{0}' não tem raiz. Há suporte apenas para caminhos completos.</target>
         <note>{StrBegin="NETSDK1052: "}</note>
       </trans-unit>
-      <trans-unit id="PackAsToolCannotSupportSelfContained">
-        <source>NETSDK1053: Pack as tool does not support self contained.</source>
-        <target state="translated">NETSDK1053: O pacote como ferramenta não é compatível com a opção autossuficiente.</target>
-        <note>{StrBegin="NETSDK1001: "}</note>
+      <trans-unit id="GetDependsOnNETStandardFailedWithException">
+        <source>NETSDK1049: Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0} {1}</source>
+        <target state="translated">NETSDK1049: O arquivo resolvido tem uma imagem inválida, não tem metadados ou está inacessível. {0} {1}</target>
+        <note>{StrBegin="NETSDK1049: "}</note>
       </trans-unit>
-      <trans-unit id="UnsupportedRuntimeIdentifier">
-        <source>NETSDK1056: Project is targeting runtime '{0}' but did not resolve any runtime-specific packages. This runtime may not be supported by the target framework.</source>
-        <target state="translated">NETSDK1056: O projeto é direcionado ao tempo de execução '{0}', mas não resolveu nenhum pacote específico do tempo de execução. Esse tempo de execução pode não ser compatível com a estrutura de destino.</target>
-        <note>{StrBegin="NETSDK1056: "}</note>
+      <trans-unit id="IncorrectPackageRoot">
+        <source>NETSDK1020: Package Root {0} was incorrectly given for Resolved library {1}</source>
+        <target state="translated">NETSDK1020: A raiz do pacote {0} foi atribuída incorretamente para a biblioteca resolvida {1}</target>
+        <note>{StrBegin="NETSDK1020: "}</note>
       </trans-unit>
-      <trans-unit id="UsingPreviewSdkWarning">
-        <source>NETSDK1057: You are using a preview version of .NET Core. See: https://aka.ms/dotnet-core-preview</source>
-        <target state="translated">NETSDK1057: você está usando uma versão prévia do .NET Core. Consulte: https://aka.ms/dotnet-core-preview</target>
-        <note>{StrBegin="NETSDK1057: "}</note>
+      <trans-unit id="IncorrectTargetFormat">
+        <source>NETSDK1025: WRThe target manifest {0} provided is of not the correct format</source>
+        <target state="translated">NETSDK1025: O manifesto de destino {0} fornecido não está no formato correto</target>
+        <note>{StrBegin="NETSDK1025: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidFrameworkName">
+        <source>NETSDK1003: Invalid framework name: '{0}'.</source>
+        <target state="translated">NETSDK1003: Nome de estrutura inválido: '{0}'.</target>
+        <note>{StrBegin="NETSDK1003: "}</note>
       </trans-unit>
       <trans-unit id="InvalidItemSpecToUse">
         <source>NETSDK1058: Invalid value for ItemSpecToUse parameter: '{0}'.  This property must be blank or set to 'Left' or 'Right'</source>
@@ -373,15 +258,15 @@
         <note>{StrBegin="NETSDK1058: "}
 The following are names of parameters or literal values and should not be translated: ItemSpecToUse, Left, Right</note>
       </trans-unit>
-      <trans-unit id="ProjectContainsObsoleteDotNetCliTool">
-        <source>NETSDK1059: The tool '{0}' is now included in the .NET Core SDK. Information on resolving this warning is available at (https://aka.ms/dotnetclitools-in-box).</source>
-        <target state="translated">NETSDK1059: A ferramenta '{0}' agora está incluída no SDK do .NET Core. Há informações de como resolver esse aviso em (https://aka.ms/dotnetclitools-in-box).</target>
-        <note>{StrBegin="NETSDK1059: "}</note>
+      <trans-unit id="InvalidNuGetVersionString">
+        <source>NETSDK1018: Invalid NuGet version string: '{0}'.</source>
+        <target state="translated">NETSDK1018: Cadeia de caracteres de versão do NuGet inválida: '{0}'.</target>
+        <note>{StrBegin="NETSDK1018: "}</note>
       </trans-unit>
-      <trans-unit id="ErrorReadingAssetsFile">
-        <source>NETSDK1060: Error reading assets file: {0}</source>
-        <target state="translated">NETSDK1060: Erro ao ler o arquivo de ativos: {0}</target>
-        <note>{StrBegin="NETSDK1060: "}</note>
+      <trans-unit id="InvalidResourceUpdate">
+        <source>NETSDK1075: Update handle is invalid. This instance may not be used for further updates.</source>
+        <target state="translated">NETSDK1075: o identificador de atualização não é válido. Esta instância não pode ser usada para atualizações adicionais.</target>
+        <note>{StrBegin="NETSDK1075: "}</note>
       </trans-unit>
       <trans-unit id="MismatchedPlatformPackageVersion">
         <source>NETSDK1061: The project was restored using {0} version {1}, but with current settings, version {2} would be used instead. To resolve this issue, make sure the same settings are used for restore and for subsequent operations such as build or publish. Typically this issue can occur if the RuntimeIdentifier property is set during build or publish but not during restore. For more information, see https://aka.ms/dotnet-runtime-patch-selection.</source>
@@ -391,35 +276,150 @@ The following are names of parameters or literal values and should not be transl
 {1} - Restored version of platform package
 {2} - Current version of platform package</note>
       </trans-unit>
-      <trans-unit id="AssetsFileNotSet">
-        <source>NETSDK1063: The path to the project assets file was not set. Run a NuGet package restore to generate this file.</source>
-        <target state="translated">NETSDK1063: O caminho para o arquivo de ativos do projeto não foi configurado. Execute uma restauração de pacote do NuGet para gerar esse arquivo.</target>
-        <note>{StrBegin="NETSDK1063: "}</note>
+      <trans-unit id="MissingItemMetadata">
+        <source>NETSDK1008: Missing '{0}' metadata on '{1}' item '{2}'.</source>
+        <target state="translated">NETSDK1008: Metadados '{0}' ausentes no item '{1}' '{2}'.</target>
+        <note>{StrBegin="NETSDK1008: "}</note>
       </trans-unit>
-      <trans-unit id="DotnetToolOnlySupportNetcoreapp">
-        <source>NETSDK1054: only supports .NET Core.</source>
-        <target state="translated">NETSDK1054: É compatível apenas com o .NET Core.</target>
-        <note>{StrBegin="NETSDK1054: "}</note>
+      <trans-unit id="MultipleFilesResolved">
+        <source>NETSDK1021: More than one file found for {0}</source>
+        <target state="translated">NETSDK1021: Mais de um arquivo encontrado para {0}</target>
+        <note>{StrBegin="NETSDK1021: "}</note>
       </trans-unit>
-      <trans-unit id="DotnetToolDoesNotSupportTFMLowerThanNetcoreapp21">
-        <source>NETSDK1055: DotnetTool does not support target framework lower than netcoreapp2.1.</source>
-        <target state="translated">NETSDK1055: O DotnetTool não é compatível com uma estrutura de destino inferior ao netcoreapp2.1.</target>
-        <note>{StrBegin="NETSDK1055: "}</note>
+      <trans-unit id="NETFrameworkToNonBuiltInNETStandard">
+        <source>NETSDK1069: This project uses a library that targets .NET Standard 1.5 or higher, and the project targets a version of .NET Framework that doesn't have built-in support for that version of .NET Standard. Visit https://aka.ms/net-standard-known-issues for a set of known issues. Consider retargeting to .NET Framework 4.7.2.</source>
+        <target state="translated">NETSDK1069: este projeto utiliza uma biblioteca que tem como destino o .NET Standard 1.5 ou superior, e o projeto tem como destino uma versão do .NET Framework que não tem suporte interno para essa versão do .NET Standard. Visite o site https://aka.ms/net-standard-known-issues para ter acesso a uma variedade de problemas conhecidos. Considere alterar o destino para o .NET Framework 4.7.2.</target>
+        <note>{StrBegin="NETSDK1069: "}</note>
       </trans-unit>
-      <trans-unit id="UnableToUsePackageAssetsCache">
-        <source>NETSDK1062: Unable to use package assets cache due to I/O error. This can occur when the same project is built more than once in parallel. Performance may be degraded, but the build result will not be impacted.</source>
-        <target state="translated">NETSDK1062: Não é possível usar o cache de ativos do pacote devido a um erro de E/S. Isso pode ocorrer quando o mesmo projeto é compilado mais de uma vez em paralelo. O desempenho poderá ser degradado, mas o resultado do build não será afetado.</target>
-        <note>{StrBegin="NETSDK1062: "}</note>
+      <trans-unit id="NoAppHostAvailable">
+        <source>NETSDK1084: There is no application host available for the specified RuntimeIdentifier '{0}'.</source>
+        <target state="new">NETSDK1084: There is no application host available for the specified RuntimeIdentifier '{0}'.</target>
+        <note>{StrBegin="NETSDK1084: "}</note>
+      </trans-unit>
+      <trans-unit id="NoCompatibleTargetFramework">
+        <source>NETSDK1002: Project '{0}' targets '{2}'. It cannot be referenced by a project that targets '{1}'.</source>
+        <target state="translated">NETSDK1002: O projeto '{0}' é direcionado a '{2}'. Ele não pode ser referenciado por um projeto direcionado a '{1}'.</target>
+        <note>{StrBegin="NETSDK1002: "}</note>
+      </trans-unit>
+      <trans-unit id="NoRuntimePackAvailable">
+        <source>NETSDK1082: There was no runtime pack for {0} available for the specified RuntimeIdentifier '{1}'.</source>
+        <target state="new">NETSDK1082: There was no runtime pack for {0} available for the specified RuntimeIdentifier '{1}'.</target>
+        <note>{StrBegin="NETSDK1082: "}</note>
+      </trans-unit>
+      <trans-unit id="PackAsToolCannotSupportSelfContained">
+        <source>NETSDK1053: Pack as tool does not support self contained.</source>
+        <target state="translated">NETSDK1053: O pacote como ferramenta não é compatível com a opção autossuficiente.</target>
+        <note>{StrBegin="NETSDK1001: "}</note>
+      </trans-unit>
+      <trans-unit id="PackageInfoLog">
+        <source>NETSDK1027: Package Name='{0}', Version='{1}' was parsed</source>
+        <target state="translated">NETSDK1027: O nome do pacote = '{0}', versão = '{1}' foi analisado</target>
+        <note>{StrBegin="NETSDK1027: "}</note>
       </trans-unit>
       <trans-unit id="PackageNotFound">
         <source>NETSDK1064: Package {0}, version {1} was not found. It might have been deleted since NuGet restore. Otherwise, NuGet restore might have only partially completed, which might have been due to maximum path length restrictions.</source>
         <target state="translated">NETSDK1064: O pacote {0}, versão {1}, não foi encontrado. Ele pode ter sido excluído desde a restauração do NuGet. Caso contrário, a restauração do NuGet pode ter sido concluída apenas parcialmente, o que pode ter ocorrido devido a restrições de comprimento máximo do caminho.</target>
         <note>{StrBegin="NETSDK1064: "}</note>
       </trans-unit>
-      <trans-unit id="CannotFindApphostForRid">
-        <source>NETSDK1065: Cannot find app host for {0}. {0} could be an invalid runtime identifier (RID). For more information about RID, see https://aka.ms/rid-catalog.</source>
-        <target state="translated">NETSDK1065: Não é possível encontrar o host do aplicativo para {0}. {0} poderia ser um RID (identificador de tempo de execução inválido). Para obter mais informações sobre RID, confira https://aka.ms/rid-catalog.</target>
-        <note>{StrBegin="NETSDK1065: "}</note>
+      <trans-unit id="PackageReferenceOverrideWarning">
+        <source>NETSDK1023: A PackageReference for '{0}' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see {1}</source>
+        <target state="translated">NETSDK1023: Uma PackageReference para '{0}' foi incluída no projeto. Esse pacote é referenciado implicitamente pelo SKD do .NET e, geralmente, não é necessário referenciá-lo no seu projeto. Para obter mais informações, confira {1}</target>
+        <note>{StrBegin="NETSDK1023: "}</note>
+      </trans-unit>
+      <trans-unit id="PackageReferenceVersionNotRecommended">
+        <source>NETSDK1071: A PackageReference to '{0}' specified a Version of `{1}`. Specifying the version of this package is not recommended. For more information, see https://aka.ms/sdkimplicitrefs</source>
+        <target state="translated">NETSDK1071: uma PackageReference para '{0}' especificou uma Versão de '{1}'. Não é recomendado especificar a versão deste pacote. Para obter mais informações, consulte https://aka.ms/sdkimplicitrefs</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParsingFiles">
+        <source>NETSDK1026: Parsing the Files : '{0}'</source>
+        <target state="translated">NETSDK1026: Analisando os arquivos: '{0}'</target>
+        <note>{StrBegin="NETSDK1026: "}</note>
+      </trans-unit>
+      <trans-unit id="ProjectAssetsConsumedWithoutMSBuildProjectPath">
+        <source>NETSDK1011: Assets are consumed from project '{0}', but no corresponding MSBuild project path was  found in '{1}'.</source>
+        <target state="translated">NETSDK1011: Os ativos são consumidos de um projeto '{0}', mas não foi encontrado nenhum caminho de projeto do MSBuild correspondente em '{1}'.</target>
+        <note>{StrBegin="NETSDK1011: "}</note>
+      </trans-unit>
+      <trans-unit id="ProjectContainsObsoleteDotNetCliTool">
+        <source>NETSDK1059: The tool '{0}' is now included in the .NET Core SDK. Information on resolving this warning is available at (https://aka.ms/dotnetclitools-in-box).</source>
+        <target state="translated">NETSDK1059: A ferramenta '{0}' agora está incluída no SDK do .NET Core. Há informações de como resolver esse aviso em (https://aka.ms/dotnetclitools-in-box).</target>
+        <note>{StrBegin="NETSDK1059: "}</note>
+      </trans-unit>
+      <trans-unit id="RuntimeIdentifierNotRecognized">
+        <source>NETSDK1083: The specified RuntimeIdentifier '{0}' is not recognized.</source>
+        <target state="new">NETSDK1083: The specified RuntimeIdentifier '{0}' is not recognized.</target>
+        <note>{StrBegin="NETSDK1083: "}</note>
+      </trans-unit>
+      <trans-unit id="RuntimeIdentifierWasNotSpecified">
+        <source>NETSDK1028: Specify a RuntimeIdentifier</source>
+        <target state="translated">NETSDK1028: Especifique um RuntimeIdentifier</target>
+        <note>{StrBegin="NETSDK1028: "}</note>
+      </trans-unit>
+      <trans-unit id="SkippingAdditionalProbingPaths">
+        <source>NETSDK1048: 'AdditionalProbingPaths' were specified for GenerateRuntimeConfigurationFiles, but are being skipped because 'RuntimeConfigDevPath' is empty.</source>
+        <target state="translated">NETSDK1048: Os 'AdditionalProbingPaths' foram especificados para os GenerateRuntimeConfigurationFiles, mas estão sendo ignorados porque 'RuntimeConfigDevPath' está vazio.</target>
+        <note>{StrBegin="NETSDK1048: "}</note>
+      </trans-unit>
+      <trans-unit id="TargetFrameworkWithSemicolon">
+        <source>NETSDK1046: The TargetFramework value '{0}' is not valid. To multi-target, use the 'TargetFrameworks' property instead.</source>
+        <target state="translated">NETSDK1046: O valor '{0}' do TargetFramework não é válido. Para vários destinos, use a propriedade 'TargetFrameworks'.</target>
+        <note>{StrBegin="NETSDK1046: "}</note>
+      </trans-unit>
+      <trans-unit id="UnableToFindResolvedPath">
+        <source>NETSDK1016: Unable to find resolved path for '{0}'.</source>
+        <target state="translated">NETSDK1016: Não foi possível localizar o caminho resolvido para '{0}'.</target>
+        <note>{StrBegin="NETSDK1016: "}</note>
+      </trans-unit>
+      <trans-unit id="UnableToUsePackageAssetsCache">
+        <source>NETSDK1062: Unable to use package assets cache due to I/O error. This can occur when the same project is built more than once in parallel. Performance may be degraded, but the build result will not be impacted.</source>
+        <target state="translated">NETSDK1062: Não é possível usar o cache de ativos do pacote devido a um erro de E/S. Isso pode ocorrer quando o mesmo projeto é compilado mais de uma vez em paralelo. O desempenho poderá ser degradado, mas o resultado do build não será afetado.</target>
+        <note>{StrBegin="NETSDK1062: "}</note>
+      </trans-unit>
+      <trans-unit id="UnexpectedFileType">
+        <source>NETSDK1012: Unexpected file type for '{0}'. Type is both '{1}' and '{2}'.</source>
+        <target state="translated">NETSDK1012: Tipo de arquivo inesperado para '{0}'. O tipo é '{1}' e '{2}'.</target>
+        <note>{StrBegin="NETSDK1012: "}</note>
+      </trans-unit>
+      <trans-unit id="UnknownFrameworkReference">
+        <source>NETSDK1073: The FrameworkReference '{0}' was not recognized</source>
+        <target state="translated">NETSDK1073: a FrameworkReference '{0}' não foi reconhecida</target>
+        <note>{StrBegin="NETSDK1073: "}</note>
+      </trans-unit>
+      <trans-unit id="UnrecognizedPreprocessorToken">
+        <source>NETSDK1009: Unrecognized preprocessor token '{0}' in '{1}'.</source>
+        <target state="translated">NETSDK1009: Token de pré-processador não reconhecido '{0}' em '{1}'.</target>
+        <note>{StrBegin="NETSDK1009: "}</note>
+      </trans-unit>
+      <trans-unit id="UnresolvedTargetingPack">
+        <source>NETSDK1081: The targeting pack for {0} was not found. You may be able to resolve this by running a NuGet restore on the project.</source>
+        <target state="new">NETSDK1081: The targeting pack for {0} was not found. You may be able to resolve this by running a NuGet restore on the project.</target>
+        <note>{StrBegin="NETSDK1081: "}</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedFramework">
+        <source>NETSDK1019: {0} is an unsupported framework.</source>
+        <target state="translated">NETSDK1019: {0} é uma estrutura sem suporte.</target>
+        <note>{StrBegin="NETSDK1019: "}</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedRuntimeIdentifier">
+        <source>NETSDK1056: Project is targeting runtime '{0}' but did not resolve any runtime-specific packages. This runtime may not be supported by the target framework.</source>
+        <target state="translated">NETSDK1056: O projeto é direcionado ao tempo de execução '{0}', mas não resolveu nenhum pacote específico do tempo de execução. Esse tempo de execução pode não ser compatível com a estrutura de destino.</target>
+        <note>{StrBegin="NETSDK1056: "}</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedSDKVersionForNetStandard20">
+        <source>NETSDK1050: The version of Microsoft.NET.Sdk used by this project is insufficient to support references to libraries targeting .NET Standard 1.5 or higher.  Please install version 2.0 or higher of the .NET Core SDK.</source>
+        <target state="translated">NETSDK1050: A versão do Microsoft.NET.Sdk usada por este projeto é insuficiente para dar suporte às referências a bibliotecas direcionadas ao .NET Standard 1.5 ou superior. Instale a versão 2.0 ou superior do SDK do .NET Core.</target>
+        <note>{StrBegin="NETSDK1050: "}</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedTargetFrameworkVersion">
+        <source>NETSDK1045: The current .NET SDK does not support targeting {0} {1}.  Either target {0} {2} or lower, or use a version of the .NET SDK that supports {0} {1}.</source>
+        <target state="translated">NETSDK1045: O SDK do .NET atual não dá suporte para direcionar a {0} {1}. Direcione a {0} {2} ou inferior, ou use uma versão do SDK do .NET compatível com  {0} {1}.</target>
+        <note>{StrBegin="NETSDK1045: "}</note>
+      </trans-unit>
+      <trans-unit id="UsingPreviewSdkWarning">
+        <source>NETSDK1057: You are using a preview version of .NET Core. See: https://aka.ms/dotnet-core-preview</source>
+        <target state="translated">NETSDK1057: você está usando uma versão prévia do .NET Core. Consulte: https://aka.ms/dotnet-core-preview</target>
+        <note>{StrBegin="NETSDK1057: "}</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
@@ -2,35 +2,25 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../Strings.resx">
     <body>
-      <trans-unit id="AspNetCoreAllNotSupported">
-        <source>NETSDK1079: The Microsoft.AspNetCore.All package is not supported when targeting .NET Core 3.0 or higher.  A FrameworkReference to Microsoft.AspNetCore.App should be used instead, and will be implicitly included by Microsoft.NET.Sdk.Web.</source>
-        <target state="translated">NETSDK1079: Пакет Microsoft.AspNetCore.All не поддерживается для целевой платформы .NET Core 3.0 или более поздней версии. Необходимо использовать ссылку FrameworkReference на Microsoft.AspNetCore.App, и она будет явно включена пакетом Microsoft.NET.Sdk.Web.</target>
-        <note>{StrBegin="NETSDK1079: "}</note>
-      </trans-unit>
-      <trans-unit id="AspNetCoreUsesFrameworkReference">
-        <source>NETSDK1080: A PackageReference to Microsoft.AspNetCore.App is not necessary when targeting .NET Core 3.0 or higher. If Microsoft.NET.Sdk.Web is used, the shared framework will be referenced automatically. Otherwise, the PackageReference should be replaced with a FrameworkReference.</source>
-        <target state="translated">NETSDK1080: Ссылка PackageReference на Microsoft.AspNetCore.App не требуется, если в качестве целевой платформы используется .NET Core 3.0 или более поздней версии. Если используется Microsoft.NET.Sdk.Web, будет автоматически добавлена ссылка на общую платформу. В противном случае необходимо заменить PackageReference на FrameworkReference.</target>
-        <note>{StrBegin="NETSDK1080: "}</note>
-      </trans-unit>
-      <trans-unit id="FailedToLockResource">
-        <source>NETSDK1077: Failed to lock resource.</source>
-        <target state="translated">NETSDK1077: Не удается заблокировать ресурс.</target>
-        <note>{StrBegin="NETSDK1077: "}</note>
-      </trans-unit>
       <trans-unit id="AddResourceWithNonIntegerResource">
         <source>NETSDK1076: AddResource can only be used with integer resource types.</source>
         <target state="translated">NETSDK1076: Метод AddResource может использоваться только с ресурсами целочисленного типа.</target>
         <note>{StrBegin="NETSDK1076: "}</note>
       </trans-unit>
-      <trans-unit id="InvalidResourceUpdate">
-        <source>NETSDK1075: Update handle is invalid. This instance may not be used for further updates.</source>
-        <target state="translated">NETSDK1075: Недопустимый дескриптор обновления. Этот экземпляр не может использоваться для последующих обновлений.</target>
-        <note>{StrBegin="NETSDK1075: "}</note>
+      <trans-unit id="AppConfigRequiresRootConfiguration">
+        <source>NETSDK1070: The application configuration file must have root configuration element.</source>
+        <target state="translated">NETSDK1070: В файле конфигурации приложения должен присутствовать корневой элемент конфигурации.</target>
+        <note>{StrBegin="NETSDK1070: "}</note>
       </trans-unit>
       <trans-unit id="AppHostCustomizationRequiresWindowsHostWarning">
         <source>NETSDK1074: The application host executable will not be customized because adding resources requires that the build be performed on Windows (excluding Nano Server).</source>
         <target state="translated">NETSDK1074: Исполняемый файл узла приложения не будет настроен, так как для добавления ресурсов необходимо выполнить сборку в Windows (за исключением Nano Server).</target>
         <note>{StrBegin="NETSDK1074: "}</note>
+      </trans-unit>
+      <trans-unit id="AppHostHasBeenModified">
+        <source>NETSDK1029: Unable to use '{0}' as application host executable as it does not contain the expected placeholder byte sequence '{1}' that would mark where the application name would be written.</source>
+        <target state="translated">NETSDK1029: невозможно использовать файл "{0}" в качестве исполняемого файла узла приложения, так как этот файл не содержит ожидаемого заполнителя с последовательностью байтов "{1}", который отмечает место, где должно быть записано имя приложения.</target>
+        <note>{StrBegin="NETSDK1029: "}</note>
       </trans-unit>
       <trans-unit id="AppHostNotWindows">
         <source>NETSDK1078: Unable to use '{0}' as application host executable because it's not a Windows PE file.</source>
@@ -42,210 +32,80 @@
         <target state="translated">NETSDK1072: Невозможно использовать "{0}" в качестве исполняемого файла узла приложения, так этот файл не является файлом Windows для подсистемы CUI (консоль).</target>
         <note>{StrBegin="NETSDK1072: "}</note>
       </trans-unit>
-      <trans-unit id="AppConfigRequiresRootConfiguration">
-        <source>NETSDK1070: The application configuration file must have root configuration element.</source>
-        <target state="translated">NETSDK1070: В файле конфигурации приложения должен присутствовать корневой элемент конфигурации.</target>
-        <note>{StrBegin="NETSDK1070: "}</note>
+      <trans-unit id="AspNetCoreAllNotSupported">
+        <source>NETSDK1079: The Microsoft.AspNetCore.All package is not supported when targeting .NET Core 3.0 or higher.  A FrameworkReference to Microsoft.AspNetCore.App should be used instead, and will be implicitly included by Microsoft.NET.Sdk.Web.</source>
+        <target state="translated">NETSDK1079: Пакет Microsoft.AspNetCore.All не поддерживается для целевой платформы .NET Core 3.0 или более поздней версии. Необходимо использовать ссылку FrameworkReference на Microsoft.AspNetCore.App, и она будет явно включена пакетом Microsoft.NET.Sdk.Web.</target>
+        <note>{StrBegin="NETSDK1079: "}</note>
       </trans-unit>
-      <trans-unit id="AtLeastOneTargetFrameworkMustBeSpecified">
-        <source>NETSDK1001: At least one possible target framework must be specified.</source>
-        <target state="translated">NETSDK1001: необходимо указать хотя бы одну целевую платформу.</target>
-        <note>{StrBegin="NETSDK1001: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotUseSelfContainedWithoutAppHost">
-        <source>NETSDK1067: Self-contained applications are required to use the application host. Either set SelfContained to false or set UseAppHost to true.</source>
-        <target state="translated">NETSDK1067: для использования узла приложений требуются автономные приложения. Задайте свойству SelfContained значение false или задайте свойству UseAppHost значение true.</target>
-        <note>{StrBegin="NETSDK1067: "}</note>
-      </trans-unit>
-      <trans-unit id="FrameworkDependentAppHostRequiresVersion21">
-        <source>NETSDK1068: The framework-dependent application host requires a target framework of at least 'netcoreapp2.1'.</source>
-        <target state="translated">NETSDK1068: для работы узла зависящих от платформы приложений требуется целевая платформа netcoreapp2.1 или более поздней версии.</target>
-        <note>{StrBegin="NETSDK1068: "}</note>
-      </trans-unit>
-      <trans-unit id="NETFrameworkToNonBuiltInNETStandard">
-        <source>NETSDK1069: This project uses a library that targets .NET Standard 1.5 or higher, and the project targets a version of .NET Framework that doesn't have built-in support for that version of .NET Standard. Visit https://aka.ms/net-standard-known-issues for a set of known issues. Consider retargeting to .NET Framework 4.7.2.</source>
-        <target state="translated">NETSDK1069: этот проект использует библиотеку, предназначенную для .NET Standard 1.5 или более поздней версии. Кроме того, проект работает в версии .NET Framework, не имеющей встроенной поддержки этой версии .NET Standard. Список и описание известных проблем см. по адресу https://aka.ms/net-standard-known-issues. Рекомендуется изменить целевую платформу на .NET Framework 4.7.2.</target>
-        <note>{StrBegin="NETSDK1069: "}</note>
-      </trans-unit>
-      <trans-unit id="NoAppHostAvailable">
-        <source>NETSDK1084: There is no application host available for the specified RuntimeIdentifier '{0}'.</source>
-        <target state="new">NETSDK1084: There is no application host available for the specified RuntimeIdentifier '{0}'.</target>
-        <note>{StrBegin="NETSDK1084: "}</note>
-      </trans-unit>
-      <trans-unit id="NoCompatibleTargetFramework">
-        <source>NETSDK1002: Project '{0}' targets '{2}'. It cannot be referenced by a project that targets '{1}'.</source>
-        <target state="translated">NETSDK1002: проект "{0}" нацелен на платформу "{2}". На него не может ссылаться проект с целевой платформой "{1}".</target>
-        <note>{StrBegin="NETSDK1002: "}</note>
-      </trans-unit>
-      <trans-unit id="InvalidFrameworkName">
-        <source>NETSDK1003: Invalid framework name: '{0}'.</source>
-        <target state="translated">NETSDK1003: недопустимое имя платформы: "{0}".</target>
-        <note>{StrBegin="NETSDK1003: "}</note>
-      </trans-unit>
-      <trans-unit id="AssetsFileNotFound">
-        <source>NETSDK1004: Assets file '{0}' not found. Run a NuGet package restore to generate this file.</source>
-        <target state="translated">NETSDK1004: файл ресурсов "{0}" не найден. Восстановите пакет NuGet, чтобы создать его.</target>
-        <note>{StrBegin="NETSDK1004: "}</note>
-      </trans-unit>
-      <trans-unit id="AssetsFileMissingTarget">
-        <source>NETSDK1005: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project.</source>
-        <target state="translated">NETSDK1005: файл ресурсов "{0}" не содержит целевого объекта для "{1}". Проверьте, что восстановление выполнено и вы включили "{2}" в TargetFrameworks своего проекта.</target>
-        <note>{StrBegin="NETSDK1005: "}</note>
-      </trans-unit>
-      <trans-unit id="AssetsFilePathNotRooted">
-        <source>NETSDK1006: Assets file path '{0}' is not rooted. Only full paths are supported.</source>
-        <target state="translated">NETSDK1006: путь к файлу ресурсов "{0}" относительный. Поддерживаются только полные пути.</target>
-        <note>{StrBegin="NETSDK1006: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotFindProjectInfo">
-        <source>NETSDK1007: Cannot find project info for '{0}'. This can indicate a missing project reference.</source>
-        <target state="translated">NETSDK1007: не удается найти сведения о проекте "{0}". Возможно, отсутствует ссылка на проект.</target>
-        <note>{StrBegin="NETSDK1007: "}</note>
-      </trans-unit>
-      <trans-unit id="MissingItemMetadata">
-        <source>NETSDK1008: Missing '{0}' metadata on '{1}' item '{2}'.</source>
-        <target state="translated">NETSDK1008: отсутствуют метаданные "{0}" для элемента "{2}" в "{1}".</target>
-        <note>{StrBegin="NETSDK1008: "}</note>
-      </trans-unit>
-      <trans-unit id="NoRuntimePackAvailable">
-        <source>NETSDK1082: There was no runtime pack for {0} available for the specified RuntimeIdentifier '{1}'.</source>
-        <target state="new">NETSDK1082: There was no runtime pack for {0} available for the specified RuntimeIdentifier '{1}'.</target>
-        <note>{StrBegin="NETSDK1082: "}</note>
-      </trans-unit>
-      <trans-unit id="PackageReferenceVersionNotRecommended">
-        <source>NETSDK1071: A PackageReference to '{0}' specified a Version of `{1}`. Specifying the version of this package is not recommended. For more information, see https://aka.ms/sdkimplicitrefs</source>
-        <target state="translated">NETSDK1071: В ссылке PackageReference на '{0}' указана версия {1}. Указывать версию этого пакета не рекомендуется. Дополнительные сведения см. на странице https://aka.ms/sdkimplicitrefs</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="RuntimeIdentifierNotRecognized">
-        <source>NETSDK1083: The specified RuntimeIdentifier '{0}' is not recognized.</source>
-        <target state="new">NETSDK1083: The specified RuntimeIdentifier '{0}' is not recognized.</target>
-        <note>{StrBegin="NETSDK1083: "}</note>
-      </trans-unit>
-      <trans-unit id="UnknownFrameworkReference">
-        <source>NETSDK1073: The FrameworkReference '{0}' was not recognized</source>
-        <target state="translated">NETSDK1073: Ссылка FrameworkReference '{0}' не распознана</target>
-        <note>{StrBegin="NETSDK1073: "}</note>
-      </trans-unit>
-      <trans-unit id="UnrecognizedPreprocessorToken">
-        <source>NETSDK1009: Unrecognized preprocessor token '{0}' in '{1}'.</source>
-        <target state="translated">NETSDK1009: не распознан маркер препроцессора "{0}" в "{1}".</target>
-        <note>{StrBegin="NETSDK1009: "}</note>
-      </trans-unit>
-      <trans-unit id="ContentPreproccessorParameterRequired">
-        <source>NETSDK1010: The '{0}' task must be given a value for parameter '{1}' in order to consume preprocessed content.</source>
-        <target state="translated">NETSDK1010: для использования предварительно обработанного содержимого необходимо указать значение параметра "{1}" в задаче "{0}".</target>
-        <note>{StrBegin="NETSDK1010: "}</note>
-      </trans-unit>
-      <trans-unit id="ProjectAssetsConsumedWithoutMSBuildProjectPath">
-        <source>NETSDK1011: Assets are consumed from project '{0}', but no corresponding MSBuild project path was  found in '{1}'.</source>
-        <target state="translated">NETSDK1011: используются ресурсы из проекта "{0}", но соответствующий путь к проекту MSBuild не найден в "{1}".</target>
-        <note>{StrBegin="NETSDK1011: "}</note>
-      </trans-unit>
-      <trans-unit id="UnexpectedFileType">
-        <source>NETSDK1012: Unexpected file type for '{0}'. Type is both '{1}' and '{2}'.</source>
-        <target state="translated">NETSDK1012: недопустимый тип файла для "{0}". Тип является "{1}" и "{2}".</target>
-        <note>{StrBegin="NETSDK1012: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotInferTargetFrameworkIdentifierAndVersion">
-        <source>NETSDK1013: The TargetFramework value '{0}' was not recognized. It may be misspelled. If not, then the TargetFrameworkIdentifier and/or TargetFrameworkVersion properties must be specified explicitly.</source>
-        <target state="translated">NETSDK1013: значение "{0}" в TargetFramework не распознано. Возможно, оно содержит опечатку. Если это не так, задайте свойства TargetFrameworkIdentifier и (или) TargetFrameworkVersion явным образом.</target>
-        <note>{StrBegin="NETSDK1013: "}</note>
-      </trans-unit>
-      <trans-unit id="ContentItemDoesNotProvideOutputPath">
-        <source>NETSDK1014: Content item for '{0}' sets '{1}', but does not provide  '{2}' or '{3}'.</source>
-        <target state="translated">NETSDK1014: элемент содержимого для "{0}" задает "{1}", но не предоставляет "{2}" или "{3}".</target>
-        <note>{StrBegin="NETSDK1014: "}</note>
-      </trans-unit>
-      <trans-unit id="DuplicatePreprocessorToken">
-        <source>NETSDK1015: The preprocessor token '{0}' has been given more than one value. Choosing '{1}' as the value.</source>
-        <target state="translated">NETSDK1015: для маркера препроцессора "{0}" указано множество значений. В качестве значения будет использовано "{1}".</target>
-        <note>{StrBegin="NETSDK1015: "}</note>
-      </trans-unit>
-      <trans-unit id="UnableToFindResolvedPath">
-        <source>NETSDK1016: Unable to find resolved path for '{0}'.</source>
-        <target state="translated">NETSDK1016: не удается найти разрешенный путь для "{0}".</target>
-        <note>{StrBegin="NETSDK1016: "}</note>
+      <trans-unit id="AspNetCoreUsesFrameworkReference">
+        <source>NETSDK1080: A PackageReference to Microsoft.AspNetCore.App is not necessary when targeting .NET Core 3.0 or higher. If Microsoft.NET.Sdk.Web is used, the shared framework will be referenced automatically. Otherwise, the PackageReference should be replaced with a FrameworkReference.</source>
+        <target state="translated">NETSDK1080: Ссылка PackageReference на Microsoft.AspNetCore.App не требуется, если в качестве целевой платформы используется .NET Core 3.0 или более поздней версии. Если используется Microsoft.NET.Sdk.Web, будет автоматически добавлена ссылка на общую платформу. В противном случае необходимо заменить PackageReference на FrameworkReference.</target>
+        <note>{StrBegin="NETSDK1080: "}</note>
       </trans-unit>
       <trans-unit id="AssetPreprocessorMustBeConfigured">
         <source>NETSDK1017: Asset preprocessor must be configured before assets are processed.</source>
         <target state="translated">NETSDK1017: необходимо настроить препроцессор ресурсов перед их обработкой.</target>
         <note>{StrBegin="NETSDK1017: "}</note>
       </trans-unit>
-      <trans-unit id="InvalidNuGetVersionString">
-        <source>NETSDK1018: Invalid NuGet version string: '{0}'.</source>
-        <target state="translated">NETSDK1018: недопустимая строка версии NuGet: "{0}".</target>
-        <note>{StrBegin="NETSDK1018: "}</note>
+      <trans-unit id="AssetsFileMissingRuntimeIdentifier">
+        <source>NETSDK1047: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project. You may also need to include '{3}' in your project's RuntimeIdentifiers.</source>
+        <target state="translated">NETSDK1047: файл ресурсов "{0}" не содержит целевого объекта для "{1}". Проверьте, что восстановление выполнено и вы включили "{2}" в TargetFrameworks своего проекта. Возможно, также нужно включить "{3}" в RuntimeIdentifiers проекта.</target>
+        <note>{StrBegin="NETSDK1047: "}</note>
       </trans-unit>
-      <trans-unit id="UnresolvedTargetingPack">
-        <source>NETSDK1081: The targeting pack for {0} was not found. You may be able to resolve this by running a NuGet restore on the project.</source>
-        <target state="new">NETSDK1081: The targeting pack for {0} was not found. You may be able to resolve this by running a NuGet restore on the project.</target>
-        <note>{StrBegin="NETSDK1081: "}</note>
+      <trans-unit id="AssetsFileMissingTarget">
+        <source>NETSDK1005: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project.</source>
+        <target state="translated">NETSDK1005: файл ресурсов "{0}" не содержит целевого объекта для "{1}". Проверьте, что восстановление выполнено и вы включили "{2}" в TargetFrameworks своего проекта.</target>
+        <note>{StrBegin="NETSDK1005: "}</note>
       </trans-unit>
-      <trans-unit id="UnsupportedFramework">
-        <source>NETSDK1019: {0} is an unsupported framework.</source>
-        <target state="translated">NETSDK1019: платформа {0} не поддерживается.</target>
-        <note>{StrBegin="NETSDK1019: "}</note>
+      <trans-unit id="AssetsFileNotFound">
+        <source>NETSDK1004: Assets file '{0}' not found. Run a NuGet package restore to generate this file.</source>
+        <target state="translated">NETSDK1004: файл ресурсов "{0}" не найден. Восстановите пакет NuGet, чтобы создать его.</target>
+        <note>{StrBegin="NETSDK1004: "}</note>
       </trans-unit>
-      <trans-unit id="DuplicateItemsError">
-        <source>NETSDK1022: Duplicate '{0}' items were included. The .NET SDK includes '{0}' items from your project directory by default. You can either remove these items from your project file, or set the '{1}' property to '{2}' if you want to explicitly include them in your project file. For more information, see {4}. The duplicate items were: {3}</source>
-        <target state="translated">NETSDK1022: были включены повторяющиеся элементы "{0}". Пакет SDK для .NET по умолчанию включает элементы "{0}" из каталога проекта. Вы можете удалить из файла проекта эти элементы или присвоить свойству "{1}" значение "{2}", если нужно включить их в файл проекта в явном виде. Дополнительные сведения: {4}. Повторяющиеся элементы: {3}</target>
-        <note>{StrBegin="NETSDK1022: "}</note>
+      <trans-unit id="AssetsFileNotSet">
+        <source>NETSDK1063: The path to the project assets file was not set. Run a NuGet package restore to generate this file.</source>
+        <target state="translated">NETSDK1063: не задан путь к файлу ресурсов проекта. Запустите восстановление пакета NuGet, чтобы создать его.</target>
+        <note>{StrBegin="NETSDK1063: "}</note>
       </trans-unit>
-      <trans-unit id="PackageReferenceOverrideWarning">
-        <source>NETSDK1023: A PackageReference for '{0}' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see {1}</source>
-        <target state="translated">NETSDK1023: ссылка на пакет (PackageReference) для "{0}" была включена в проект. На этот пакет неявно ссылается пакет SDK для .NET, и ссылаться на него из проекта обычно не нужно. Дополнительные сведения: {1}</target>
-        <note>{StrBegin="NETSDK1023: "}</note>
+      <trans-unit id="AssetsFilePathNotRooted">
+        <source>NETSDK1006: Assets file path '{0}' is not rooted. Only full paths are supported.</source>
+        <target state="translated">NETSDK1006: путь к файлу ресурсов "{0}" относительный. Поддерживаются только полные пути.</target>
+        <note>{StrBegin="NETSDK1006: "}</note>
       </trans-unit>
-      <trans-unit id="IncorrectPackageRoot">
-        <source>NETSDK1020: Package Root {0} was incorrectly given for Resolved library {1}</source>
-        <target state="translated">NETSDK1020: корневой каталог пакета {0} указан некорректно для разрешенной библиотеки {1}</target>
-        <note>{StrBegin="NETSDK1020: "}</note>
+      <trans-unit id="AtLeastOneTargetFrameworkMustBeSpecified">
+        <source>NETSDK1001: At least one possible target framework must be specified.</source>
+        <target state="translated">NETSDK1001: необходимо указать хотя бы одну целевую платформу.</target>
+        <note>{StrBegin="NETSDK1001: "}</note>
       </trans-unit>
-      <trans-unit id="MultipleFilesResolved">
-        <source>NETSDK1021: More than one file found for {0}</source>
-        <target state="translated">NETSDK1021: обнаружено множество файлов для {0}</target>
-        <note>{StrBegin="NETSDK1021: "}</note>
+      <trans-unit id="CannotFindApphostForRid">
+        <source>NETSDK1065: Cannot find app host for {0}. {0} could be an invalid runtime identifier (RID). For more information about RID, see https://aka.ms/rid-catalog.</source>
+        <target state="translated">NETSDK1065: не удалось найти узел приложения для {0}. Возможно, {0} является недопустимым идентификатором среды выполнения (RID). Дополнительные сведения о RID: https://aka.ms/rid-catalog.</target>
+        <note>{StrBegin="NETSDK1065: "}</note>
       </trans-unit>
-      <trans-unit id="FolderAlreadyExists">
-        <source>NETSDK1024: Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</source>
-        <target state="translated">NETSDK1024: папка "{0}" уже существует. Удалите ее или укажите другой каталог ComposeWorkingDir</target>
-        <note>{StrBegin="NETSDK1024: "}</note>
+      <trans-unit id="CannotFindProjectInfo">
+        <source>NETSDK1007: Cannot find project info for '{0}'. This can indicate a missing project reference.</source>
+        <target state="translated">NETSDK1007: не удается найти сведения о проекте "{0}". Возможно, отсутствует ссылка на проект.</target>
+        <note>{StrBegin="NETSDK1007: "}</note>
       </trans-unit>
-      <trans-unit id="ParsingFiles">
-        <source>NETSDK1026: Parsing the Files : '{0}'</source>
-        <target state="translated">NETSDK1026: анализируются файлы: "{0}"</target>
-        <note>{StrBegin="NETSDK1026: "}</note>
-      </trans-unit>
-      <trans-unit id="PackageInfoLog">
-        <source>NETSDK1027: Package Name='{0}', Version='{1}' was parsed</source>
-        <target state="translated">NETSDK1027: пакет с именем "{0}" версии "{1}" проанализирован</target>
-        <note>{StrBegin="NETSDK1027: "}</note>
-      </trans-unit>
-      <trans-unit id="RuntimeIdentifierWasNotSpecified">
-        <source>NETSDK1028: Specify a RuntimeIdentifier</source>
-        <target state="translated">NETSDK1028: укажите RuntimeIdentifier</target>
-        <note>{StrBegin="NETSDK1028: "}</note>
-      </trans-unit>
-      <trans-unit id="IncorrectTargetFormat">
-        <source>NETSDK1025: WRThe target manifest {0} provided is of not the correct format</source>
-        <target state="translated">NETSDK1025: указанный целевой манифест {0} имеет неверный формат</target>
-        <note>{StrBegin="NETSDK1025: "}</note>
-      </trans-unit>
-      <trans-unit id="AppHostHasBeenModified">
-        <source>NETSDK1029: Unable to use '{0}' as application host executable as it does not contain the expected placeholder byte sequence '{1}' that would mark where the application name would be written.</source>
-        <target state="translated">NETSDK1029: невозможно использовать файл "{0}" в качестве исполняемого файла узла приложения, так как этот файл не содержит ожидаемого заполнителя с последовательностью байтов "{1}", который отмечает место, где должно быть записано имя приложения.</target>
-        <note>{StrBegin="NETSDK1029: "}</note>
-      </trans-unit>
-      <trans-unit id="FileNameIsTooLong">
-        <source>NETSDK1030: Given file name '{0}' is longer than 1024 bytes</source>
-        <target state="translated">NETSDK1030: длина указанного имени файла "{0}" превышает 1024 байта</target>
-        <note>{StrBegin="NETSDK1030: "}</note>
+      <trans-unit id="CannotHaveRuntimeIdentifierPlatformMismatchPlatformTarget">
+        <source>NETSDK1032: The RuntimeIdentifier platform '{0}' and the PlatformTarget '{1}' must be compatible.</source>
+        <target state="translated">NETSDK1032: платформа RuntimeIdentifier "{0}" и PlatformTarget "{1}" должны быть совместимы.</target>
+        <note>{StrBegin="NETSDK1032: "}</note>
       </trans-unit>
       <trans-unit id="CannotHaveSelfContainedWithoutRuntimeIdentifier">
         <source>NETSDK1031: It is not supported to build or publish a self-contained application without specifying a RuntimeIdentifier.  Please either specify a RuntimeIdentifier or set SelfContained to false.</source>
         <target state="translated">NETSDK1031: сборка или публикация автономного приложения без указания RuntimeIdentifier не поддерживается. Укажите RuntimeIdentifier или присвойте свойству SelfContained значение "false".</target>
         <note>{StrBegin="NETSDK1031: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotInferTargetFrameworkIdentifierAndVersion">
+        <source>NETSDK1013: The TargetFramework value '{0}' was not recognized. It may be misspelled. If not, then the TargetFrameworkIdentifier and/or TargetFrameworkVersion properties must be specified explicitly.</source>
+        <target state="translated">NETSDK1013: значение "{0}" в TargetFramework не распознано. Возможно, оно содержит опечатку. Если это не так, задайте свойства TargetFrameworkIdentifier и (или) TargetFrameworkVersion явным образом.</target>
+        <note>{StrBegin="NETSDK1013: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotUseSelfContainedWithoutAppHost">
+        <source>NETSDK1067: Self-contained applications are required to use the application host. Either set SelfContained to false or set UseAppHost to true.</source>
+        <target state="translated">NETSDK1067: для использования узла приложений требуются автономные приложения. Задайте свойству SelfContained значение false или задайте свойству UseAppHost значение true.</target>
+        <note>{StrBegin="NETSDK1067: "}</note>
       </trans-unit>
       <trans-unit id="ChoosingAssemblyVersion">
         <source>NETSDK1033: Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</source>
@@ -272,6 +132,16 @@
         <target state="translated">NETSDK1037: не удалось определить победителя, так как версии файла и сборки одинаковы.</target>
         <note>{StrBegin="NETSDK1037: "}</note>
       </trans-unit>
+      <trans-unit id="ContentItemDoesNotProvideOutputPath">
+        <source>NETSDK1014: Content item for '{0}' sets '{1}', but does not provide  '{2}' or '{3}'.</source>
+        <target state="translated">NETSDK1014: элемент содержимого для "{0}" задает "{1}", но не предоставляет "{2}" или "{3}".</target>
+        <note>{StrBegin="NETSDK1014: "}</note>
+      </trans-unit>
+      <trans-unit id="ContentPreproccessorParameterRequired">
+        <source>NETSDK1010: The '{0}' task must be given a value for parameter '{1}' in order to consume preprocessed content.</source>
+        <target state="translated">NETSDK1010: для использования предварительно обработанного содержимого необходимо указать значение параметра "{1}" в задаче "{0}".</target>
+        <note>{StrBegin="NETSDK1010: "}</note>
+      </trans-unit>
       <trans-unit id="CouldNotDetermineWinner_DoesntExist">
         <source>NETSDK1038: Could not determine winner because '{0}' does not exist.</source>
         <target state="translated">NETSDK1038: не удалось определить победителя, так как "{0}" не существует.</target>
@@ -287,15 +157,40 @@
         <target state="translated">NETSDK1040: не удалось определить победителя, так как "{0}" не является сборкой.</target>
         <note>{StrBegin="NETSDK1040: "}</note>
       </trans-unit>
+      <trans-unit id="CouldNotLoadPlatformManifest">
+        <source>NETSDK1042: Could not load PlatformManifest from '{0}' because it did not exist.</source>
+        <target state="translated">NETSDK1042: не удалось загрузить манифест PlatformManifest из "{0}", так как его не существует.</target>
+        <note>{StrBegin="NETSDK1042: "}</note>
+      </trans-unit>
+      <trans-unit id="DotnetToolDoesNotSupportTFMLowerThanNetcoreapp21">
+        <source>NETSDK1055: DotnetTool does not support target framework lower than netcoreapp2.1.</source>
+        <target state="translated">NETSDK1055: DotnetTool не поддерживает целевые платформы версий до netcoreapp2.1.</target>
+        <note>{StrBegin="NETSDK1055: "}</note>
+      </trans-unit>
+      <trans-unit id="DotnetToolOnlySupportNetcoreapp">
+        <source>NETSDK1054: only supports .NET Core.</source>
+        <target state="translated">NETSDK1054: поддерживает только .NET Core.</target>
+        <note>{StrBegin="NETSDK1054: "}</note>
+      </trans-unit>
+      <trans-unit id="DuplicateItemsError">
+        <source>NETSDK1022: Duplicate '{0}' items were included. The .NET SDK includes '{0}' items from your project directory by default. You can either remove these items from your project file, or set the '{1}' property to '{2}' if you want to explicitly include them in your project file. For more information, see {4}. The duplicate items were: {3}</source>
+        <target state="translated">NETSDK1022: были включены повторяющиеся элементы "{0}". Пакет SDK для .NET по умолчанию включает элементы "{0}" из каталога проекта. Вы можете удалить из файла проекта эти элементы или присвоить свойству "{1}" значение "{2}", если нужно включить их в файл проекта в явном виде. Дополнительные сведения: {4}. Повторяющиеся элементы: {3}</target>
+        <note>{StrBegin="NETSDK1022: "}</note>
+      </trans-unit>
+      <trans-unit id="DuplicatePreprocessorToken">
+        <source>NETSDK1015: The preprocessor token '{0}' has been given more than one value. Choosing '{1}' as the value.</source>
+        <target state="translated">NETSDK1015: для маркера препроцессора "{0}" указано множество значений. В качестве значения будет использовано "{1}".</target>
+        <note>{StrBegin="NETSDK1015: "}</note>
+      </trans-unit>
       <trans-unit id="EncounteredConflict">
         <source>NETSDK1041: Encountered conflict between '{0}' and '{1}'.</source>
         <target state="translated">NETSDK1041: обнаружен конфликт между "{0}" и "{1}".</target>
         <note>{StrBegin="NETSDK1041: "}</note>
       </trans-unit>
-      <trans-unit id="CouldNotLoadPlatformManifest">
-        <source>NETSDK1042: Could not load PlatformManifest from '{0}' because it did not exist.</source>
-        <target state="translated">NETSDK1042: не удалось загрузить манифест PlatformManifest из "{0}", так как его не существует.</target>
-        <note>{StrBegin="NETSDK1042: "}</note>
+      <trans-unit id="ErrorParsingFrameworkListInvalidValue">
+        <source>NETSDK1051: Error parsing FrameworkList from '{0}'.  {1} '{2}' was invalid.</source>
+        <target state="translated">NETSDK1051: ошибка анализа FrameworkList со строки "{0}". {1} "{2}" является недопустимым.</target>
+        <note>{StrBegin="NETSDK1051: "}</note>
       </trans-unit>
       <trans-unit id="ErrorParsingPlatformManifest">
         <source>NETSDK1043: Error parsing PlatformManifest from '{0}' line {1}.  Lines must have the format {2}.</source>
@@ -307,65 +202,55 @@
         <target state="translated">NETSDK1044: ошибка при анализе PlatformManifest из строки {1} файла "{0}". {2} "{3}" является недопустимым.</target>
         <note>{StrBegin="NETSDK1044: "}</note>
       </trans-unit>
-      <trans-unit id="UnsupportedTargetFrameworkVersion">
-        <source>NETSDK1045: The current .NET SDK does not support targeting {0} {1}.  Either target {0} {2} or lower, or use a version of the .NET SDK that supports {0} {1}.</source>
-        <target state="translated">NETSDK1045: текущий пакет SDK для .NET не поддерживает целевой объект {0} {1}. Выберите {0} {2} или более раннюю версию либо используйте версию пакета SDK для .NET, которая поддерживает {0} {1}.</target>
-        <note>{StrBegin="NETSDK1045: "}</note>
+      <trans-unit id="ErrorReadingAssetsFile">
+        <source>NETSDK1060: Error reading assets file: {0}</source>
+        <target state="translated">NETSDK1060: ошибка при чтении файла ресурсов {0}</target>
+        <note>{StrBegin="NETSDK1060: "}</note>
       </trans-unit>
-      <trans-unit id="AssetsFileMissingRuntimeIdentifier">
-        <source>NETSDK1047: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project. You may also need to include '{3}' in your project's RuntimeIdentifiers.</source>
-        <target state="translated">NETSDK1047: файл ресурсов "{0}" не содержит целевого объекта для "{1}". Проверьте, что восстановление выполнено и вы включили "{2}" в TargetFrameworks своего проекта. Возможно, также нужно включить "{3}" в RuntimeIdentifiers проекта.</target>
-        <note>{StrBegin="NETSDK1047: "}</note>
+      <trans-unit id="FailedToLockResource">
+        <source>NETSDK1077: Failed to lock resource.</source>
+        <target state="translated">NETSDK1077: Не удается заблокировать ресурс.</target>
+        <note>{StrBegin="NETSDK1077: "}</note>
       </trans-unit>
-      <trans-unit id="TargetFrameworkWithSemicolon">
-        <source>NETSDK1046: The TargetFramework value '{0}' is not valid. To multi-target, use the 'TargetFrameworks' property instead.</source>
-        <target state="translated">NETSDK1046: значение "{0}" свойства TargetFramework недопустимо. Для выбора нескольких целевых платформ используйте свойство "TargetFrameworks".</target>
-        <note>{StrBegin="NETSDK1046: "}</note>
+      <trans-unit id="FileNameIsTooLong">
+        <source>NETSDK1030: Given file name '{0}' is longer than 1024 bytes</source>
+        <target state="translated">NETSDK1030: длина указанного имени файла "{0}" превышает 1024 байта</target>
+        <note>{StrBegin="NETSDK1030: "}</note>
       </trans-unit>
-      <trans-unit id="GetDependsOnNETStandardFailedWithException">
-        <source>NETSDK1049: Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0} {1}</source>
-        <target state="translated">NETSDK1049: разрешенный файл содержит недопустимый образ, не содержит метаданных или недоступен по другим причинам. {0} {1}</target>
-        <note>{StrBegin="NETSDK1049: "}</note>
+      <trans-unit id="FolderAlreadyExists">
+        <source>NETSDK1024: Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</source>
+        <target state="translated">NETSDK1024: папка "{0}" уже существует. Удалите ее или укажите другой каталог ComposeWorkingDir</target>
+        <note>{StrBegin="NETSDK1024: "}</note>
       </trans-unit>
-      <trans-unit id="UnsupportedSDKVersionForNetStandard20">
-        <source>NETSDK1050: The version of Microsoft.NET.Sdk used by this project is insufficient to support references to libraries targeting .NET Standard 1.5 or higher.  Please install version 2.0 or higher of the .NET Core SDK.</source>
-        <target state="translated">NETSDK1050: используемая этим проектом версия Microsoft.NET.Sdk не поддерживает ссылки на библиотеки для .NET Standard 1.5 и более поздних версий. Установите пакет SDK для .NET Core версии 2.0 или выше.</target>
-        <note>{StrBegin="NETSDK1050: "}</note>
-      </trans-unit>
-      <trans-unit id="SkippingAdditionalProbingPaths">
-        <source>NETSDK1048: 'AdditionalProbingPaths' were specified for GenerateRuntimeConfigurationFiles, but are being skipped because 'RuntimeConfigDevPath' is empty.</source>
-        <target state="translated">NETSDK1048: для GenerateRuntimeConfigurationFiles были указаны пути "AdditionalProbingPaths", но они будут пропущены, так как "RuntimeConfigDevPath" пуст.</target>
-        <note>{StrBegin="NETSDK1048: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotHaveRuntimeIdentifierPlatformMismatchPlatformTarget">
-        <source>NETSDK1032: The RuntimeIdentifier platform '{0}' and the PlatformTarget '{1}' must be compatible.</source>
-        <target state="translated">NETSDK1032: платформа RuntimeIdentifier "{0}" и PlatformTarget "{1}" должны быть совместимы.</target>
-        <note>{StrBegin="NETSDK1032: "}</note>
-      </trans-unit>
-      <trans-unit id="ErrorParsingFrameworkListInvalidValue">
-        <source>NETSDK1051: Error parsing FrameworkList from '{0}'.  {1} '{2}' was invalid.</source>
-        <target state="translated">NETSDK1051: ошибка анализа FrameworkList со строки "{0}". {1} "{2}" является недопустимым.</target>
-        <note>{StrBegin="NETSDK1051: "}</note>
+      <trans-unit id="FrameworkDependentAppHostRequiresVersion21">
+        <source>NETSDK1068: The framework-dependent application host requires a target framework of at least 'netcoreapp2.1'.</source>
+        <target state="translated">NETSDK1068: для работы узла зависящих от платформы приложений требуется целевая платформа netcoreapp2.1 или более поздней версии.</target>
+        <note>{StrBegin="NETSDK1068: "}</note>
       </trans-unit>
       <trans-unit id="FrameworkListPathNotRooted">
         <source>NETSDK1052: Framework list file path '{0}' is not rooted. Only full paths are supported.</source>
         <target state="translated">NETSDK1052: путь к файлу списка платформ "{0}" относительный. Поддерживаются только полные пути.</target>
         <note>{StrBegin="NETSDK1052: "}</note>
       </trans-unit>
-      <trans-unit id="PackAsToolCannotSupportSelfContained">
-        <source>NETSDK1053: Pack as tool does not support self contained.</source>
-        <target state="translated">NETSDK1053: упаковка в качестве инструмента не поддерживает автономное использование.</target>
-        <note>{StrBegin="NETSDK1001: "}</note>
+      <trans-unit id="GetDependsOnNETStandardFailedWithException">
+        <source>NETSDK1049: Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0} {1}</source>
+        <target state="translated">NETSDK1049: разрешенный файл содержит недопустимый образ, не содержит метаданных или недоступен по другим причинам. {0} {1}</target>
+        <note>{StrBegin="NETSDK1049: "}</note>
       </trans-unit>
-      <trans-unit id="UnsupportedRuntimeIdentifier">
-        <source>NETSDK1056: Project is targeting runtime '{0}' but did not resolve any runtime-specific packages. This runtime may not be supported by the target framework.</source>
-        <target state="translated">NETSDK1056: проект нацелен на среду выполнения "{0}", но не разрешил ни одного пакета среды выполнения. Возможно, целевая платформа не поддерживает эту среду выполнения.</target>
-        <note>{StrBegin="NETSDK1056: "}</note>
+      <trans-unit id="IncorrectPackageRoot">
+        <source>NETSDK1020: Package Root {0} was incorrectly given for Resolved library {1}</source>
+        <target state="translated">NETSDK1020: корневой каталог пакета {0} указан некорректно для разрешенной библиотеки {1}</target>
+        <note>{StrBegin="NETSDK1020: "}</note>
       </trans-unit>
-      <trans-unit id="UsingPreviewSdkWarning">
-        <source>NETSDK1057: You are using a preview version of .NET Core. See: https://aka.ms/dotnet-core-preview</source>
-        <target state="translated">NETSDK1057: Вы используете предварительную версию .NET Core. Дополнительные сведения см. на странице https://aka.ms/dotnet-core-preview</target>
-        <note>{StrBegin="NETSDK1057: "}</note>
+      <trans-unit id="IncorrectTargetFormat">
+        <source>NETSDK1025: WRThe target manifest {0} provided is of not the correct format</source>
+        <target state="translated">NETSDK1025: указанный целевой манифест {0} имеет неверный формат</target>
+        <note>{StrBegin="NETSDK1025: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidFrameworkName">
+        <source>NETSDK1003: Invalid framework name: '{0}'.</source>
+        <target state="translated">NETSDK1003: недопустимое имя платформы: "{0}".</target>
+        <note>{StrBegin="NETSDK1003: "}</note>
       </trans-unit>
       <trans-unit id="InvalidItemSpecToUse">
         <source>NETSDK1058: Invalid value for ItemSpecToUse parameter: '{0}'.  This property must be blank or set to 'Left' or 'Right'</source>
@@ -373,15 +258,15 @@
         <note>{StrBegin="NETSDK1058: "}
 The following are names of parameters or literal values and should not be translated: ItemSpecToUse, Left, Right</note>
       </trans-unit>
-      <trans-unit id="ProjectContainsObsoleteDotNetCliTool">
-        <source>NETSDK1059: The tool '{0}' is now included in the .NET Core SDK. Information on resolving this warning is available at (https://aka.ms/dotnetclitools-in-box).</source>
-        <target state="translated">NETSDK1059: инструмент "{0}" теперь включен в пакет SDK для .NET Core. Сведения о том, как устранить это предупреждение: https://aka.ms/dotnetclitools-in-box.</target>
-        <note>{StrBegin="NETSDK1059: "}</note>
+      <trans-unit id="InvalidNuGetVersionString">
+        <source>NETSDK1018: Invalid NuGet version string: '{0}'.</source>
+        <target state="translated">NETSDK1018: недопустимая строка версии NuGet: "{0}".</target>
+        <note>{StrBegin="NETSDK1018: "}</note>
       </trans-unit>
-      <trans-unit id="ErrorReadingAssetsFile">
-        <source>NETSDK1060: Error reading assets file: {0}</source>
-        <target state="translated">NETSDK1060: ошибка при чтении файла ресурсов {0}</target>
-        <note>{StrBegin="NETSDK1060: "}</note>
+      <trans-unit id="InvalidResourceUpdate">
+        <source>NETSDK1075: Update handle is invalid. This instance may not be used for further updates.</source>
+        <target state="translated">NETSDK1075: Недопустимый дескриптор обновления. Этот экземпляр не может использоваться для последующих обновлений.</target>
+        <note>{StrBegin="NETSDK1075: "}</note>
       </trans-unit>
       <trans-unit id="MismatchedPlatformPackageVersion">
         <source>NETSDK1061: The project was restored using {0} version {1}, but with current settings, version {2} would be used instead. To resolve this issue, make sure the same settings are used for restore and for subsequent operations such as build or publish. Typically this issue can occur if the RuntimeIdentifier property is set during build or publish but not during restore. For more information, see https://aka.ms/dotnet-runtime-patch-selection.</source>
@@ -391,35 +276,150 @@ The following are names of parameters or literal values and should not be transl
 {1} - Restored version of platform package
 {2} - Current version of platform package</note>
       </trans-unit>
-      <trans-unit id="AssetsFileNotSet">
-        <source>NETSDK1063: The path to the project assets file was not set. Run a NuGet package restore to generate this file.</source>
-        <target state="translated">NETSDK1063: не задан путь к файлу ресурсов проекта. Запустите восстановление пакета NuGet, чтобы создать его.</target>
-        <note>{StrBegin="NETSDK1063: "}</note>
+      <trans-unit id="MissingItemMetadata">
+        <source>NETSDK1008: Missing '{0}' metadata on '{1}' item '{2}'.</source>
+        <target state="translated">NETSDK1008: отсутствуют метаданные "{0}" для элемента "{2}" в "{1}".</target>
+        <note>{StrBegin="NETSDK1008: "}</note>
       </trans-unit>
-      <trans-unit id="DotnetToolOnlySupportNetcoreapp">
-        <source>NETSDK1054: only supports .NET Core.</source>
-        <target state="translated">NETSDK1054: поддерживает только .NET Core.</target>
-        <note>{StrBegin="NETSDK1054: "}</note>
+      <trans-unit id="MultipleFilesResolved">
+        <source>NETSDK1021: More than one file found for {0}</source>
+        <target state="translated">NETSDK1021: обнаружено множество файлов для {0}</target>
+        <note>{StrBegin="NETSDK1021: "}</note>
       </trans-unit>
-      <trans-unit id="DotnetToolDoesNotSupportTFMLowerThanNetcoreapp21">
-        <source>NETSDK1055: DotnetTool does not support target framework lower than netcoreapp2.1.</source>
-        <target state="translated">NETSDK1055: DotnetTool не поддерживает целевые платформы версий до netcoreapp2.1.</target>
-        <note>{StrBegin="NETSDK1055: "}</note>
+      <trans-unit id="NETFrameworkToNonBuiltInNETStandard">
+        <source>NETSDK1069: This project uses a library that targets .NET Standard 1.5 or higher, and the project targets a version of .NET Framework that doesn't have built-in support for that version of .NET Standard. Visit https://aka.ms/net-standard-known-issues for a set of known issues. Consider retargeting to .NET Framework 4.7.2.</source>
+        <target state="translated">NETSDK1069: этот проект использует библиотеку, предназначенную для .NET Standard 1.5 или более поздней версии. Кроме того, проект работает в версии .NET Framework, не имеющей встроенной поддержки этой версии .NET Standard. Список и описание известных проблем см. по адресу https://aka.ms/net-standard-known-issues. Рекомендуется изменить целевую платформу на .NET Framework 4.7.2.</target>
+        <note>{StrBegin="NETSDK1069: "}</note>
       </trans-unit>
-      <trans-unit id="UnableToUsePackageAssetsCache">
-        <source>NETSDK1062: Unable to use package assets cache due to I/O error. This can occur when the same project is built more than once in parallel. Performance may be degraded, but the build result will not be impacted.</source>
-        <target state="translated">NETSDK1062: не удается использовать кэш ресурсов пакета из-за ошибки ввода-вывода. Это может происходить при нескольких параллельных сборках одного проекта. Работа может быть замедлена, но результат сборки не изменится.</target>
-        <note>{StrBegin="NETSDK1062: "}</note>
+      <trans-unit id="NoAppHostAvailable">
+        <source>NETSDK1084: There is no application host available for the specified RuntimeIdentifier '{0}'.</source>
+        <target state="new">NETSDK1084: There is no application host available for the specified RuntimeIdentifier '{0}'.</target>
+        <note>{StrBegin="NETSDK1084: "}</note>
+      </trans-unit>
+      <trans-unit id="NoCompatibleTargetFramework">
+        <source>NETSDK1002: Project '{0}' targets '{2}'. It cannot be referenced by a project that targets '{1}'.</source>
+        <target state="translated">NETSDK1002: проект "{0}" нацелен на платформу "{2}". На него не может ссылаться проект с целевой платформой "{1}".</target>
+        <note>{StrBegin="NETSDK1002: "}</note>
+      </trans-unit>
+      <trans-unit id="NoRuntimePackAvailable">
+        <source>NETSDK1082: There was no runtime pack for {0} available for the specified RuntimeIdentifier '{1}'.</source>
+        <target state="new">NETSDK1082: There was no runtime pack for {0} available for the specified RuntimeIdentifier '{1}'.</target>
+        <note>{StrBegin="NETSDK1082: "}</note>
+      </trans-unit>
+      <trans-unit id="PackAsToolCannotSupportSelfContained">
+        <source>NETSDK1053: Pack as tool does not support self contained.</source>
+        <target state="translated">NETSDK1053: упаковка в качестве инструмента не поддерживает автономное использование.</target>
+        <note>{StrBegin="NETSDK1001: "}</note>
+      </trans-unit>
+      <trans-unit id="PackageInfoLog">
+        <source>NETSDK1027: Package Name='{0}', Version='{1}' was parsed</source>
+        <target state="translated">NETSDK1027: пакет с именем "{0}" версии "{1}" проанализирован</target>
+        <note>{StrBegin="NETSDK1027: "}</note>
       </trans-unit>
       <trans-unit id="PackageNotFound">
         <source>NETSDK1064: Package {0}, version {1} was not found. It might have been deleted since NuGet restore. Otherwise, NuGet restore might have only partially completed, which might have been due to maximum path length restrictions.</source>
         <target state="translated">NETSDK1064: пакет {0} версии {1} не найден. Возможно, с момента восстановления NuGet он был удален или восстановление NuGet было выполнено лишь частично из-за ограничений на максимальную длину пути.</target>
         <note>{StrBegin="NETSDK1064: "}</note>
       </trans-unit>
-      <trans-unit id="CannotFindApphostForRid">
-        <source>NETSDK1065: Cannot find app host for {0}. {0} could be an invalid runtime identifier (RID). For more information about RID, see https://aka.ms/rid-catalog.</source>
-        <target state="translated">NETSDK1065: не удалось найти узел приложения для {0}. Возможно, {0} является недопустимым идентификатором среды выполнения (RID). Дополнительные сведения о RID: https://aka.ms/rid-catalog.</target>
-        <note>{StrBegin="NETSDK1065: "}</note>
+      <trans-unit id="PackageReferenceOverrideWarning">
+        <source>NETSDK1023: A PackageReference for '{0}' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see {1}</source>
+        <target state="translated">NETSDK1023: ссылка на пакет (PackageReference) для "{0}" была включена в проект. На этот пакет неявно ссылается пакет SDK для .NET, и ссылаться на него из проекта обычно не нужно. Дополнительные сведения: {1}</target>
+        <note>{StrBegin="NETSDK1023: "}</note>
+      </trans-unit>
+      <trans-unit id="PackageReferenceVersionNotRecommended">
+        <source>NETSDK1071: A PackageReference to '{0}' specified a Version of `{1}`. Specifying the version of this package is not recommended. For more information, see https://aka.ms/sdkimplicitrefs</source>
+        <target state="translated">NETSDK1071: В ссылке PackageReference на '{0}' указана версия {1}. Указывать версию этого пакета не рекомендуется. Дополнительные сведения см. на странице https://aka.ms/sdkimplicitrefs</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParsingFiles">
+        <source>NETSDK1026: Parsing the Files : '{0}'</source>
+        <target state="translated">NETSDK1026: анализируются файлы: "{0}"</target>
+        <note>{StrBegin="NETSDK1026: "}</note>
+      </trans-unit>
+      <trans-unit id="ProjectAssetsConsumedWithoutMSBuildProjectPath">
+        <source>NETSDK1011: Assets are consumed from project '{0}', but no corresponding MSBuild project path was  found in '{1}'.</source>
+        <target state="translated">NETSDK1011: используются ресурсы из проекта "{0}", но соответствующий путь к проекту MSBuild не найден в "{1}".</target>
+        <note>{StrBegin="NETSDK1011: "}</note>
+      </trans-unit>
+      <trans-unit id="ProjectContainsObsoleteDotNetCliTool">
+        <source>NETSDK1059: The tool '{0}' is now included in the .NET Core SDK. Information on resolving this warning is available at (https://aka.ms/dotnetclitools-in-box).</source>
+        <target state="translated">NETSDK1059: инструмент "{0}" теперь включен в пакет SDK для .NET Core. Сведения о том, как устранить это предупреждение: https://aka.ms/dotnetclitools-in-box.</target>
+        <note>{StrBegin="NETSDK1059: "}</note>
+      </trans-unit>
+      <trans-unit id="RuntimeIdentifierNotRecognized">
+        <source>NETSDK1083: The specified RuntimeIdentifier '{0}' is not recognized.</source>
+        <target state="new">NETSDK1083: The specified RuntimeIdentifier '{0}' is not recognized.</target>
+        <note>{StrBegin="NETSDK1083: "}</note>
+      </trans-unit>
+      <trans-unit id="RuntimeIdentifierWasNotSpecified">
+        <source>NETSDK1028: Specify a RuntimeIdentifier</source>
+        <target state="translated">NETSDK1028: укажите RuntimeIdentifier</target>
+        <note>{StrBegin="NETSDK1028: "}</note>
+      </trans-unit>
+      <trans-unit id="SkippingAdditionalProbingPaths">
+        <source>NETSDK1048: 'AdditionalProbingPaths' were specified for GenerateRuntimeConfigurationFiles, but are being skipped because 'RuntimeConfigDevPath' is empty.</source>
+        <target state="translated">NETSDK1048: для GenerateRuntimeConfigurationFiles были указаны пути "AdditionalProbingPaths", но они будут пропущены, так как "RuntimeConfigDevPath" пуст.</target>
+        <note>{StrBegin="NETSDK1048: "}</note>
+      </trans-unit>
+      <trans-unit id="TargetFrameworkWithSemicolon">
+        <source>NETSDK1046: The TargetFramework value '{0}' is not valid. To multi-target, use the 'TargetFrameworks' property instead.</source>
+        <target state="translated">NETSDK1046: значение "{0}" свойства TargetFramework недопустимо. Для выбора нескольких целевых платформ используйте свойство "TargetFrameworks".</target>
+        <note>{StrBegin="NETSDK1046: "}</note>
+      </trans-unit>
+      <trans-unit id="UnableToFindResolvedPath">
+        <source>NETSDK1016: Unable to find resolved path for '{0}'.</source>
+        <target state="translated">NETSDK1016: не удается найти разрешенный путь для "{0}".</target>
+        <note>{StrBegin="NETSDK1016: "}</note>
+      </trans-unit>
+      <trans-unit id="UnableToUsePackageAssetsCache">
+        <source>NETSDK1062: Unable to use package assets cache due to I/O error. This can occur when the same project is built more than once in parallel. Performance may be degraded, but the build result will not be impacted.</source>
+        <target state="translated">NETSDK1062: не удается использовать кэш ресурсов пакета из-за ошибки ввода-вывода. Это может происходить при нескольких параллельных сборках одного проекта. Работа может быть замедлена, но результат сборки не изменится.</target>
+        <note>{StrBegin="NETSDK1062: "}</note>
+      </trans-unit>
+      <trans-unit id="UnexpectedFileType">
+        <source>NETSDK1012: Unexpected file type for '{0}'. Type is both '{1}' and '{2}'.</source>
+        <target state="translated">NETSDK1012: недопустимый тип файла для "{0}". Тип является "{1}" и "{2}".</target>
+        <note>{StrBegin="NETSDK1012: "}</note>
+      </trans-unit>
+      <trans-unit id="UnknownFrameworkReference">
+        <source>NETSDK1073: The FrameworkReference '{0}' was not recognized</source>
+        <target state="translated">NETSDK1073: Ссылка FrameworkReference '{0}' не распознана</target>
+        <note>{StrBegin="NETSDK1073: "}</note>
+      </trans-unit>
+      <trans-unit id="UnrecognizedPreprocessorToken">
+        <source>NETSDK1009: Unrecognized preprocessor token '{0}' in '{1}'.</source>
+        <target state="translated">NETSDK1009: не распознан маркер препроцессора "{0}" в "{1}".</target>
+        <note>{StrBegin="NETSDK1009: "}</note>
+      </trans-unit>
+      <trans-unit id="UnresolvedTargetingPack">
+        <source>NETSDK1081: The targeting pack for {0} was not found. You may be able to resolve this by running a NuGet restore on the project.</source>
+        <target state="new">NETSDK1081: The targeting pack for {0} was not found. You may be able to resolve this by running a NuGet restore on the project.</target>
+        <note>{StrBegin="NETSDK1081: "}</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedFramework">
+        <source>NETSDK1019: {0} is an unsupported framework.</source>
+        <target state="translated">NETSDK1019: платформа {0} не поддерживается.</target>
+        <note>{StrBegin="NETSDK1019: "}</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedRuntimeIdentifier">
+        <source>NETSDK1056: Project is targeting runtime '{0}' but did not resolve any runtime-specific packages. This runtime may not be supported by the target framework.</source>
+        <target state="translated">NETSDK1056: проект нацелен на среду выполнения "{0}", но не разрешил ни одного пакета среды выполнения. Возможно, целевая платформа не поддерживает эту среду выполнения.</target>
+        <note>{StrBegin="NETSDK1056: "}</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedSDKVersionForNetStandard20">
+        <source>NETSDK1050: The version of Microsoft.NET.Sdk used by this project is insufficient to support references to libraries targeting .NET Standard 1.5 or higher.  Please install version 2.0 or higher of the .NET Core SDK.</source>
+        <target state="translated">NETSDK1050: используемая этим проектом версия Microsoft.NET.Sdk не поддерживает ссылки на библиотеки для .NET Standard 1.5 и более поздних версий. Установите пакет SDK для .NET Core версии 2.0 или выше.</target>
+        <note>{StrBegin="NETSDK1050: "}</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedTargetFrameworkVersion">
+        <source>NETSDK1045: The current .NET SDK does not support targeting {0} {1}.  Either target {0} {2} or lower, or use a version of the .NET SDK that supports {0} {1}.</source>
+        <target state="translated">NETSDK1045: текущий пакет SDK для .NET не поддерживает целевой объект {0} {1}. Выберите {0} {2} или более раннюю версию либо используйте версию пакета SDK для .NET, которая поддерживает {0} {1}.</target>
+        <note>{StrBegin="NETSDK1045: "}</note>
+      </trans-unit>
+      <trans-unit id="UsingPreviewSdkWarning">
+        <source>NETSDK1057: You are using a preview version of .NET Core. See: https://aka.ms/dotnet-core-preview</source>
+        <target state="translated">NETSDK1057: Вы используете предварительную версию .NET Core. Дополнительные сведения см. на странице https://aka.ms/dotnet-core-preview</target>
+        <note>{StrBegin="NETSDK1057: "}</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
@@ -2,35 +2,25 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../Strings.resx">
     <body>
-      <trans-unit id="AspNetCoreAllNotSupported">
-        <source>NETSDK1079: The Microsoft.AspNetCore.All package is not supported when targeting .NET Core 3.0 or higher.  A FrameworkReference to Microsoft.AspNetCore.App should be used instead, and will be implicitly included by Microsoft.NET.Sdk.Web.</source>
-        <target state="translated">NETSDK1079: .NET Core 3.0 veya üzeri hedeflenirken Microsoft.AspNetCore.All paketi desteklenmez.  Bunun yerine Microsoft.AspNetCore.App öğesine yönelik bir FrameworkReference kullanılmalıdır ve Microsoft.NET.Sdk.Web tarafından örtük olarak eklenir.</target>
-        <note>{StrBegin="NETSDK1079: "}</note>
-      </trans-unit>
-      <trans-unit id="AspNetCoreUsesFrameworkReference">
-        <source>NETSDK1080: A PackageReference to Microsoft.AspNetCore.App is not necessary when targeting .NET Core 3.0 or higher. If Microsoft.NET.Sdk.Web is used, the shared framework will be referenced automatically. Otherwise, the PackageReference should be replaced with a FrameworkReference.</source>
-        <target state="translated">NETSDK1080: .NET Core 3.0 veya üzeri hedeflenirken Microsoft.AspNetCore.App öğesine yönelik bir PackageReference gerekli değildir. Microsoft.NET.Sdk.Web kullanılıyorsa otomatik olarak ortak çerçeveye başvurulur. Aksi takdirde, PackageReference bir FrameworkReference ile değiştirilmelidir.</target>
-        <note>{StrBegin="NETSDK1080: "}</note>
-      </trans-unit>
-      <trans-unit id="FailedToLockResource">
-        <source>NETSDK1077: Failed to lock resource.</source>
-        <target state="translated">NETSDK1077: Kaynak kilitlenemedi.</target>
-        <note>{StrBegin="NETSDK1077: "}</note>
-      </trans-unit>
       <trans-unit id="AddResourceWithNonIntegerResource">
         <source>NETSDK1076: AddResource can only be used with integer resource types.</source>
         <target state="translated">NETSDK1076: AddResource yalnızca tamsayı kaynak türleriyle kullanılabilir.</target>
         <note>{StrBegin="NETSDK1076: "}</note>
       </trans-unit>
-      <trans-unit id="InvalidResourceUpdate">
-        <source>NETSDK1075: Update handle is invalid. This instance may not be used for further updates.</source>
-        <target state="translated">NETSDK1075: Güncelleştirme tanıtıcısı geçersiz. Bu örnek başka güncelleştirme için kullanılamaz.</target>
-        <note>{StrBegin="NETSDK1075: "}</note>
+      <trans-unit id="AppConfigRequiresRootConfiguration">
+        <source>NETSDK1070: The application configuration file must have root configuration element.</source>
+        <target state="translated">NETSDK1070: Uygulama yapılandırma dosyasının kök yapılandırma öğesi olmalıdır.</target>
+        <note>{StrBegin="NETSDK1070: "}</note>
       </trans-unit>
       <trans-unit id="AppHostCustomizationRequiresWindowsHostWarning">
         <source>NETSDK1074: The application host executable will not be customized because adding resources requires that the build be performed on Windows (excluding Nano Server).</source>
         <target state="translated">NETSDK1074: Kaynak ekleme işlemi derlemenin Windows'da gerçekleştirilmesini gerektirdiğinden (Nano Server hariç), uygulama konağı yürütülebilir dosyası özelleştirilmez.</target>
         <note>{StrBegin="NETSDK1074: "}</note>
+      </trans-unit>
+      <trans-unit id="AppHostHasBeenModified">
+        <source>NETSDK1029: Unable to use '{0}' as application host executable as it does not contain the expected placeholder byte sequence '{1}' that would mark where the application name would be written.</source>
+        <target state="translated">NETSDK1029: '{0}', uygulama adının yazılacağı yeri işaretlemesi için beklenen yer tutucu bayt dizisini ('{1}') içermediğinden uygulama konak yürütülebilir dosyası olarak kullanılamıyor.</target>
+        <note>{StrBegin="NETSDK1029: "}</note>
       </trans-unit>
       <trans-unit id="AppHostNotWindows">
         <source>NETSDK1078: Unable to use '{0}' as application host executable because it's not a Windows PE file.</source>
@@ -42,210 +32,80 @@
         <target state="translated">NETSDK1072: '{0}', CUI (Console) alt sistemi için bir Windows yürütülebilir dosyası olmadığından uygulama konağı yürütülebilir dosyası olarak kullanılamıyor.</target>
         <note>{StrBegin="NETSDK1072: "}</note>
       </trans-unit>
-      <trans-unit id="AppConfigRequiresRootConfiguration">
-        <source>NETSDK1070: The application configuration file must have root configuration element.</source>
-        <target state="translated">NETSDK1070: Uygulama yapılandırma dosyasının kök yapılandırma öğesi olmalıdır.</target>
-        <note>{StrBegin="NETSDK1070: "}</note>
+      <trans-unit id="AspNetCoreAllNotSupported">
+        <source>NETSDK1079: The Microsoft.AspNetCore.All package is not supported when targeting .NET Core 3.0 or higher.  A FrameworkReference to Microsoft.AspNetCore.App should be used instead, and will be implicitly included by Microsoft.NET.Sdk.Web.</source>
+        <target state="translated">NETSDK1079: .NET Core 3.0 veya üzeri hedeflenirken Microsoft.AspNetCore.All paketi desteklenmez.  Bunun yerine Microsoft.AspNetCore.App öğesine yönelik bir FrameworkReference kullanılmalıdır ve Microsoft.NET.Sdk.Web tarafından örtük olarak eklenir.</target>
+        <note>{StrBegin="NETSDK1079: "}</note>
       </trans-unit>
-      <trans-unit id="AtLeastOneTargetFrameworkMustBeSpecified">
-        <source>NETSDK1001: At least one possible target framework must be specified.</source>
-        <target state="translated">NETSDK1001: En az bir olası hedef çerçeve belirtilmelidir.</target>
-        <note>{StrBegin="NETSDK1001: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotUseSelfContainedWithoutAppHost">
-        <source>NETSDK1067: Self-contained applications are required to use the application host. Either set SelfContained to false or set UseAppHost to true.</source>
-        <target state="translated">NETSDK1067: Kendi başına kapsanan uygulamaların uygulama konağını kullanması gerekir. SelfContained değerini false olarak ya da UseAppHost değerini true olarak ayarlayın.</target>
-        <note>{StrBegin="NETSDK1067: "}</note>
-      </trans-unit>
-      <trans-unit id="FrameworkDependentAppHostRequiresVersion21">
-        <source>NETSDK1068: The framework-dependent application host requires a target framework of at least 'netcoreapp2.1'.</source>
-        <target state="translated">NETSDK1068: Çerçeveye bağımlı uygulama konağı, en az 'netcoreapp2.1' sürümünde bir hedef çerçeve gerektirir.</target>
-        <note>{StrBegin="NETSDK1068: "}</note>
-      </trans-unit>
-      <trans-unit id="NETFrameworkToNonBuiltInNETStandard">
-        <source>NETSDK1069: This project uses a library that targets .NET Standard 1.5 or higher, and the project targets a version of .NET Framework that doesn't have built-in support for that version of .NET Standard. Visit https://aka.ms/net-standard-known-issues for a set of known issues. Consider retargeting to .NET Framework 4.7.2.</source>
-        <target state="translated">NETSDK1069: Bu proje, .NET Standard 1.5 veya üzerini hedefleyen bir kitaplık kullanıyor ve proje .NET Framework’ün bu .NET Standard sürümü için yerleşik destek sunmayan bir sürümünü hedefliyor. Bilinen sorunları görmek için https://aka.ms/net-standard-known-issues adresini ziyaret edin. Hedeflenen sürümü .NET Framework 4.7.2 olarak değiştirmeyi göz önünde bulundurun.</target>
-        <note>{StrBegin="NETSDK1069: "}</note>
-      </trans-unit>
-      <trans-unit id="NoAppHostAvailable">
-        <source>NETSDK1084: There is no application host available for the specified RuntimeIdentifier '{0}'.</source>
-        <target state="new">NETSDK1084: There is no application host available for the specified RuntimeIdentifier '{0}'.</target>
-        <note>{StrBegin="NETSDK1084: "}</note>
-      </trans-unit>
-      <trans-unit id="NoCompatibleTargetFramework">
-        <source>NETSDK1002: Project '{0}' targets '{2}'. It cannot be referenced by a project that targets '{1}'.</source>
-        <target state="translated">NETSDK1002: '{0}' projesi, '{2}' çerçevesini hedefliyor. Bu projeye '{1}' çerçevesini hedefleyen bir proje tarafından başvurulamaz.</target>
-        <note>{StrBegin="NETSDK1002: "}</note>
-      </trans-unit>
-      <trans-unit id="InvalidFrameworkName">
-        <source>NETSDK1003: Invalid framework name: '{0}'.</source>
-        <target state="translated">NETSDK1003: Geçersiz çerçeve adı: '{0}'.</target>
-        <note>{StrBegin="NETSDK1003: "}</note>
-      </trans-unit>
-      <trans-unit id="AssetsFileNotFound">
-        <source>NETSDK1004: Assets file '{0}' not found. Run a NuGet package restore to generate this file.</source>
-        <target state="translated">NETSDK1004: '{0}' varlık dosyası bulunamadı. Bu dosyayı oluşturmak için, NuGet paketi geri yükleme işlemi gerçekleştirin.</target>
-        <note>{StrBegin="NETSDK1004: "}</note>
-      </trans-unit>
-      <trans-unit id="AssetsFileMissingTarget">
-        <source>NETSDK1005: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project.</source>
-        <target state="translated">NETSDK1005: '{0}' varlık dosyasında '{1}' için hedef yok. Geri yüklemenin çalıştırıldığından ve '{2}' öğesinin projeniz için TargetFrameworks’e eklendiğinden emin olun.</target>
-        <note>{StrBegin="NETSDK1005: "}</note>
-      </trans-unit>
-      <trans-unit id="AssetsFilePathNotRooted">
-        <source>NETSDK1006: Assets file path '{0}' is not rooted. Only full paths are supported.</source>
-        <target state="translated">NETSDK1006: '{0}' varlık dosyası yolunun kökü belirtilmemiş. Yalnızca tam yollar desteklenir.</target>
-        <note>{StrBegin="NETSDK1006: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotFindProjectInfo">
-        <source>NETSDK1007: Cannot find project info for '{0}'. This can indicate a missing project reference.</source>
-        <target state="translated">NETSDK1007: '{0}' için proje bilgisi bulunamıyor. Bu durum, bir proje başvurusunun eksik olduğunu gösteriyor olabilir.</target>
-        <note>{StrBegin="NETSDK1007: "}</note>
-      </trans-unit>
-      <trans-unit id="MissingItemMetadata">
-        <source>NETSDK1008: Missing '{0}' metadata on '{1}' item '{2}'.</source>
-        <target state="translated">NETSDK1008: '{1}' öğesi '{2}' üzerinde '{0}' meta verileri eksik.</target>
-        <note>{StrBegin="NETSDK1008: "}</note>
-      </trans-unit>
-      <trans-unit id="NoRuntimePackAvailable">
-        <source>NETSDK1082: There was no runtime pack for {0} available for the specified RuntimeIdentifier '{1}'.</source>
-        <target state="new">NETSDK1082: There was no runtime pack for {0} available for the specified RuntimeIdentifier '{1}'.</target>
-        <note>{StrBegin="NETSDK1082: "}</note>
-      </trans-unit>
-      <trans-unit id="PackageReferenceVersionNotRecommended">
-        <source>NETSDK1071: A PackageReference to '{0}' specified a Version of `{1}`. Specifying the version of this package is not recommended. For more information, see https://aka.ms/sdkimplicitrefs</source>
-        <target state="translated">NETSDK1071: '{0}' öğesine yönelik bir PackageReference, bir `{1}` Sürümünü belirtti. Bu paketin sürümünün belirtilmesi önerilmez. Daha fazla bilgi edinmek için bkz. https://aka.ms/sdkimplicitrefs</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="RuntimeIdentifierNotRecognized">
-        <source>NETSDK1083: The specified RuntimeIdentifier '{0}' is not recognized.</source>
-        <target state="new">NETSDK1083: The specified RuntimeIdentifier '{0}' is not recognized.</target>
-        <note>{StrBegin="NETSDK1083: "}</note>
-      </trans-unit>
-      <trans-unit id="UnknownFrameworkReference">
-        <source>NETSDK1073: The FrameworkReference '{0}' was not recognized</source>
-        <target state="translated">NETSDK1073: FrameworkReference '{0}' tanınmadı</target>
-        <note>{StrBegin="NETSDK1073: "}</note>
-      </trans-unit>
-      <trans-unit id="UnrecognizedPreprocessorToken">
-        <source>NETSDK1009: Unrecognized preprocessor token '{0}' in '{1}'.</source>
-        <target state="translated">NETSDK1009: '{1}' içinde tanınmayan '{0}' ön işlemci belirteci.</target>
-        <note>{StrBegin="NETSDK1009: "}</note>
-      </trans-unit>
-      <trans-unit id="ContentPreproccessorParameterRequired">
-        <source>NETSDK1010: The '{0}' task must be given a value for parameter '{1}' in order to consume preprocessed content.</source>
-        <target state="translated">NETSDK1010: Önceden işlenen içeriği kullanabilmesi için '{0}' görevine, '{1}' parametresine ilişkin bir değer verilmelidir.</target>
-        <note>{StrBegin="NETSDK1010: "}</note>
-      </trans-unit>
-      <trans-unit id="ProjectAssetsConsumedWithoutMSBuildProjectPath">
-        <source>NETSDK1011: Assets are consumed from project '{0}', but no corresponding MSBuild project path was  found in '{1}'.</source>
-        <target state="translated">NETSDK1011: '{0}' projesindeki varlıklar kullanılıyor, ancak '{1}' içinde karşılık gelen bir MSBuild proje yolu bulunamadı.</target>
-        <note>{StrBegin="NETSDK1011: "}</note>
-      </trans-unit>
-      <trans-unit id="UnexpectedFileType">
-        <source>NETSDK1012: Unexpected file type for '{0}'. Type is both '{1}' and '{2}'.</source>
-        <target state="translated">NETSDK1012: '{0}' için beklenmeyen dosya türü. Tür hem '{1}' hem de '{2}'.</target>
-        <note>{StrBegin="NETSDK1012: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotInferTargetFrameworkIdentifierAndVersion">
-        <source>NETSDK1013: The TargetFramework value '{0}' was not recognized. It may be misspelled. If not, then the TargetFrameworkIdentifier and/or TargetFrameworkVersion properties must be specified explicitly.</source>
-        <target state="translated">NETSDK1013: '{0}' TargetFramework değeri tanınmadı. Yanlış yazılmış olabilir. Sorun bundan kaynaklanmıyorsa, TargetFrameworkIdentifier ve/veya TargetFrameworkVersion özelliklerinin açık bir şekilde belirtilmesi gerekir.</target>
-        <note>{StrBegin="NETSDK1013: "}</note>
-      </trans-unit>
-      <trans-unit id="ContentItemDoesNotProvideOutputPath">
-        <source>NETSDK1014: Content item for '{0}' sets '{1}', but does not provide  '{2}' or '{3}'.</source>
-        <target state="translated">NETSDK1014: '{0}' için içerik öğesi, '{1}' değerini ayarlıyor ancak '{2}' veya '{3}' sağlamıyor.</target>
-        <note>{StrBegin="NETSDK1014: "}</note>
-      </trans-unit>
-      <trans-unit id="DuplicatePreprocessorToken">
-        <source>NETSDK1015: The preprocessor token '{0}' has been given more than one value. Choosing '{1}' as the value.</source>
-        <target state="translated">NETSDK1015: '{0}' ön işlemci belirtecine birden fazla değer verildi. Değer olarak '{1}' seçiliyor.</target>
-        <note>{StrBegin="NETSDK1015: "}</note>
-      </trans-unit>
-      <trans-unit id="UnableToFindResolvedPath">
-        <source>NETSDK1016: Unable to find resolved path for '{0}'.</source>
-        <target state="translated">NETSDK1016: '{0}' için çözümlenmiş yol bulunamıyor.</target>
-        <note>{StrBegin="NETSDK1016: "}</note>
+      <trans-unit id="AspNetCoreUsesFrameworkReference">
+        <source>NETSDK1080: A PackageReference to Microsoft.AspNetCore.App is not necessary when targeting .NET Core 3.0 or higher. If Microsoft.NET.Sdk.Web is used, the shared framework will be referenced automatically. Otherwise, the PackageReference should be replaced with a FrameworkReference.</source>
+        <target state="translated">NETSDK1080: .NET Core 3.0 veya üzeri hedeflenirken Microsoft.AspNetCore.App öğesine yönelik bir PackageReference gerekli değildir. Microsoft.NET.Sdk.Web kullanılıyorsa otomatik olarak ortak çerçeveye başvurulur. Aksi takdirde, PackageReference bir FrameworkReference ile değiştirilmelidir.</target>
+        <note>{StrBegin="NETSDK1080: "}</note>
       </trans-unit>
       <trans-unit id="AssetPreprocessorMustBeConfigured">
         <source>NETSDK1017: Asset preprocessor must be configured before assets are processed.</source>
         <target state="translated">NETSDK1017: Varlıkların işlenebilmesi için varlık ön işlemcisi yapılandırılmalıdır.</target>
         <note>{StrBegin="NETSDK1017: "}</note>
       </trans-unit>
-      <trans-unit id="InvalidNuGetVersionString">
-        <source>NETSDK1018: Invalid NuGet version string: '{0}'.</source>
-        <target state="translated">NETSDK1018: Geçersiz NuGet sürüm dizesi: '{0}'.</target>
-        <note>{StrBegin="NETSDK1018: "}</note>
+      <trans-unit id="AssetsFileMissingRuntimeIdentifier">
+        <source>NETSDK1047: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project. You may also need to include '{3}' in your project's RuntimeIdentifiers.</source>
+        <target state="translated">NETSDK1047: '{0}' varlık dosyasında '{1}' için hedef yok. Geri yüklemenin çalıştırıldığından ve '{2}' öğesinin projeniz için TargetFrameworks’e eklendiğinden emin olun. Ayrıca '{3}' öğesini projenizin RuntimeIdentifiers’ına eklemeniz gerekebilir.</target>
+        <note>{StrBegin="NETSDK1047: "}</note>
       </trans-unit>
-      <trans-unit id="UnresolvedTargetingPack">
-        <source>NETSDK1081: The targeting pack for {0} was not found. You may be able to resolve this by running a NuGet restore on the project.</source>
-        <target state="new">NETSDK1081: The targeting pack for {0} was not found. You may be able to resolve this by running a NuGet restore on the project.</target>
-        <note>{StrBegin="NETSDK1081: "}</note>
+      <trans-unit id="AssetsFileMissingTarget">
+        <source>NETSDK1005: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project.</source>
+        <target state="translated">NETSDK1005: '{0}' varlık dosyasında '{1}' için hedef yok. Geri yüklemenin çalıştırıldığından ve '{2}' öğesinin projeniz için TargetFrameworks’e eklendiğinden emin olun.</target>
+        <note>{StrBegin="NETSDK1005: "}</note>
       </trans-unit>
-      <trans-unit id="UnsupportedFramework">
-        <source>NETSDK1019: {0} is an unsupported framework.</source>
-        <target state="translated">NETSDK1019: {0} çerçevesi desteklenmiyor.</target>
-        <note>{StrBegin="NETSDK1019: "}</note>
+      <trans-unit id="AssetsFileNotFound">
+        <source>NETSDK1004: Assets file '{0}' not found. Run a NuGet package restore to generate this file.</source>
+        <target state="translated">NETSDK1004: '{0}' varlık dosyası bulunamadı. Bu dosyayı oluşturmak için, NuGet paketi geri yükleme işlemi gerçekleştirin.</target>
+        <note>{StrBegin="NETSDK1004: "}</note>
       </trans-unit>
-      <trans-unit id="DuplicateItemsError">
-        <source>NETSDK1022: Duplicate '{0}' items were included. The .NET SDK includes '{0}' items from your project directory by default. You can either remove these items from your project file, or set the '{1}' property to '{2}' if you want to explicitly include them in your project file. For more information, see {4}. The duplicate items were: {3}</source>
-        <target state="translated">NETSDK1022: Yinelenen '{0}' öğeleri eklendi. .NET SDK, proje dizininizdeki '{0}' öğelerini varsayılan olarak içeriyor. Bu öğeleri proje dosyanızdan kaldırabilir veya bunları proje dosyanıza açıkça dahil etmek istiyorsanız '{1}' özelliğini '{2}' olarak ayarlayabilirsiniz. Daha fazla bilgi için bkz. {4}. Yinelenen öğeler: {3}</target>
-        <note>{StrBegin="NETSDK1022: "}</note>
+      <trans-unit id="AssetsFileNotSet">
+        <source>NETSDK1063: The path to the project assets file was not set. Run a NuGet package restore to generate this file.</source>
+        <target state="translated">NETSDK1063: Proje varlıkları dosyasının yolu ayarlanmadı. Bu dosyayı oluşturmak için, NuGet paketi geri yükleme işlemi gerçekleştirin.</target>
+        <note>{StrBegin="NETSDK1063: "}</note>
       </trans-unit>
-      <trans-unit id="PackageReferenceOverrideWarning">
-        <source>NETSDK1023: A PackageReference for '{0}' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see {1}</source>
-        <target state="translated">NETSDK1023: Projenize '{0}' için bir PackageReference eklendi. .NET SDK bu pakete örtük olarak başvuruyor; buna projenizden başvurmanız genellikle gerekli değildir. Daha fazla bilgi için bkz. {1}</target>
-        <note>{StrBegin="NETSDK1023: "}</note>
+      <trans-unit id="AssetsFilePathNotRooted">
+        <source>NETSDK1006: Assets file path '{0}' is not rooted. Only full paths are supported.</source>
+        <target state="translated">NETSDK1006: '{0}' varlık dosyası yolunun kökü belirtilmemiş. Yalnızca tam yollar desteklenir.</target>
+        <note>{StrBegin="NETSDK1006: "}</note>
       </trans-unit>
-      <trans-unit id="IncorrectPackageRoot">
-        <source>NETSDK1020: Package Root {0} was incorrectly given for Resolved library {1}</source>
-        <target state="translated">NETSDK1020: {0} Paket Kökü, Çözümlenmiş {1} kitaplığı için yanlışlıkla verildi</target>
-        <note>{StrBegin="NETSDK1020: "}</note>
+      <trans-unit id="AtLeastOneTargetFrameworkMustBeSpecified">
+        <source>NETSDK1001: At least one possible target framework must be specified.</source>
+        <target state="translated">NETSDK1001: En az bir olası hedef çerçeve belirtilmelidir.</target>
+        <note>{StrBegin="NETSDK1001: "}</note>
       </trans-unit>
-      <trans-unit id="MultipleFilesResolved">
-        <source>NETSDK1021: More than one file found for {0}</source>
-        <target state="translated">NETSDK1021: {0} için birden fazla dosya bulundu</target>
-        <note>{StrBegin="NETSDK1021: "}</note>
+      <trans-unit id="CannotFindApphostForRid">
+        <source>NETSDK1065: Cannot find app host for {0}. {0} could be an invalid runtime identifier (RID). For more information about RID, see https://aka.ms/rid-catalog.</source>
+        <target state="translated">NETSDK1065: {0} için uygulama konağı bulunamıyor. {0} geçersiz bir çalışma zamanı tanımlayıcısı (RID) olabilir. RID hakkında daha fazla bilgi için bkz. https://aka.ms/rid-catalog.</target>
+        <note>{StrBegin="NETSDK1065: "}</note>
       </trans-unit>
-      <trans-unit id="FolderAlreadyExists">
-        <source>NETSDK1024: Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</source>
-        <target state="translated">NETSDK1024: '{0}' klasörü zaten var. Klasörü silin veya farklı bir ComposeWorkingDir değeri belirtin</target>
-        <note>{StrBegin="NETSDK1024: "}</note>
+      <trans-unit id="CannotFindProjectInfo">
+        <source>NETSDK1007: Cannot find project info for '{0}'. This can indicate a missing project reference.</source>
+        <target state="translated">NETSDK1007: '{0}' için proje bilgisi bulunamıyor. Bu durum, bir proje başvurusunun eksik olduğunu gösteriyor olabilir.</target>
+        <note>{StrBegin="NETSDK1007: "}</note>
       </trans-unit>
-      <trans-unit id="ParsingFiles">
-        <source>NETSDK1026: Parsing the Files : '{0}'</source>
-        <target state="translated">NETSDK1026: Dosyalar ayrıştırılıyor: '{0}'</target>
-        <note>{StrBegin="NETSDK1026: "}</note>
-      </trans-unit>
-      <trans-unit id="PackageInfoLog">
-        <source>NETSDK1027: Package Name='{0}', Version='{1}' was parsed</source>
-        <target state="translated">NETSDK1027: Paket Adı='{0}', Sürüm='{1}' ayrıştırıldı</target>
-        <note>{StrBegin="NETSDK1027: "}</note>
-      </trans-unit>
-      <trans-unit id="RuntimeIdentifierWasNotSpecified">
-        <source>NETSDK1028: Specify a RuntimeIdentifier</source>
-        <target state="translated">NETSDK1028: Bir RuntimeIdentifier belirtin</target>
-        <note>{StrBegin="NETSDK1028: "}</note>
-      </trans-unit>
-      <trans-unit id="IncorrectTargetFormat">
-        <source>NETSDK1025: WRThe target manifest {0} provided is of not the correct format</source>
-        <target state="translated">NETSDK1025: Belirtilen {0} hedef bildirimi doğru biçimde değil</target>
-        <note>{StrBegin="NETSDK1025: "}</note>
-      </trans-unit>
-      <trans-unit id="AppHostHasBeenModified">
-        <source>NETSDK1029: Unable to use '{0}' as application host executable as it does not contain the expected placeholder byte sequence '{1}' that would mark where the application name would be written.</source>
-        <target state="translated">NETSDK1029: '{0}', uygulama adının yazılacağı yeri işaretlemesi için beklenen yer tutucu bayt dizisini ('{1}') içermediğinden uygulama konak yürütülebilir dosyası olarak kullanılamıyor.</target>
-        <note>{StrBegin="NETSDK1029: "}</note>
-      </trans-unit>
-      <trans-unit id="FileNameIsTooLong">
-        <source>NETSDK1030: Given file name '{0}' is longer than 1024 bytes</source>
-        <target state="translated">NETSDK1030: Belirtilen dosya adı ('{0}') 1024 bayttan uzun</target>
-        <note>{StrBegin="NETSDK1030: "}</note>
+      <trans-unit id="CannotHaveRuntimeIdentifierPlatformMismatchPlatformTarget">
+        <source>NETSDK1032: The RuntimeIdentifier platform '{0}' and the PlatformTarget '{1}' must be compatible.</source>
+        <target state="translated">NETSDK1032: RuntimeIdentifier platformu '{0}' ile PlatformTarget '{1}' uyumlu olmalıdır.</target>
+        <note>{StrBegin="NETSDK1032: "}</note>
       </trans-unit>
       <trans-unit id="CannotHaveSelfContainedWithoutRuntimeIdentifier">
         <source>NETSDK1031: It is not supported to build or publish a self-contained application without specifying a RuntimeIdentifier.  Please either specify a RuntimeIdentifier or set SelfContained to false.</source>
         <target state="translated">NETSDK1031: Bir RuntimeIdentifier belirtilmeden, bağımsız çalışan uygulamanın derlenmesi veya yayımlanması desteklenmez. Lütfen bir RuntimeIdentifier belirtin veya SelfContained değerini false olarak ayarlayın.</target>
         <note>{StrBegin="NETSDK1031: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotInferTargetFrameworkIdentifierAndVersion">
+        <source>NETSDK1013: The TargetFramework value '{0}' was not recognized. It may be misspelled. If not, then the TargetFrameworkIdentifier and/or TargetFrameworkVersion properties must be specified explicitly.</source>
+        <target state="translated">NETSDK1013: '{0}' TargetFramework değeri tanınmadı. Yanlış yazılmış olabilir. Sorun bundan kaynaklanmıyorsa, TargetFrameworkIdentifier ve/veya TargetFrameworkVersion özelliklerinin açık bir şekilde belirtilmesi gerekir.</target>
+        <note>{StrBegin="NETSDK1013: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotUseSelfContainedWithoutAppHost">
+        <source>NETSDK1067: Self-contained applications are required to use the application host. Either set SelfContained to false or set UseAppHost to true.</source>
+        <target state="translated">NETSDK1067: Kendi başına kapsanan uygulamaların uygulama konağını kullanması gerekir. SelfContained değerini false olarak ya da UseAppHost değerini true olarak ayarlayın.</target>
+        <note>{StrBegin="NETSDK1067: "}</note>
       </trans-unit>
       <trans-unit id="ChoosingAssemblyVersion">
         <source>NETSDK1033: Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</source>
@@ -272,6 +132,16 @@
         <target state="translated">NETSDK1037: Dosya ve bütünleştirilmiş kod sürümlerinin eşit olması nedeniyle kazanan belirlenemedi.</target>
         <note>{StrBegin="NETSDK1037: "}</note>
       </trans-unit>
+      <trans-unit id="ContentItemDoesNotProvideOutputPath">
+        <source>NETSDK1014: Content item for '{0}' sets '{1}', but does not provide  '{2}' or '{3}'.</source>
+        <target state="translated">NETSDK1014: '{0}' için içerik öğesi, '{1}' değerini ayarlıyor ancak '{2}' veya '{3}' sağlamıyor.</target>
+        <note>{StrBegin="NETSDK1014: "}</note>
+      </trans-unit>
+      <trans-unit id="ContentPreproccessorParameterRequired">
+        <source>NETSDK1010: The '{0}' task must be given a value for parameter '{1}' in order to consume preprocessed content.</source>
+        <target state="translated">NETSDK1010: Önceden işlenen içeriği kullanabilmesi için '{0}' görevine, '{1}' parametresine ilişkin bir değer verilmelidir.</target>
+        <note>{StrBegin="NETSDK1010: "}</note>
+      </trans-unit>
       <trans-unit id="CouldNotDetermineWinner_DoesntExist">
         <source>NETSDK1038: Could not determine winner because '{0}' does not exist.</source>
         <target state="translated">NETSDK1038: '{0}' mevcut olmadığından kazanan belirlenemedi.</target>
@@ -287,15 +157,40 @@
         <target state="translated">NETSDK1040: '{0}' bir bütünleştirilmiş kod olmadığından kazanan belirlenemedi.</target>
         <note>{StrBegin="NETSDK1040: "}</note>
       </trans-unit>
+      <trans-unit id="CouldNotLoadPlatformManifest">
+        <source>NETSDK1042: Could not load PlatformManifest from '{0}' because it did not exist.</source>
+        <target state="translated">NETSDK1042: '{0}' mevcut olmadığından buradan PlatformManifest yüklenemedi.</target>
+        <note>{StrBegin="NETSDK1042: "}</note>
+      </trans-unit>
+      <trans-unit id="DotnetToolDoesNotSupportTFMLowerThanNetcoreapp21">
+        <source>NETSDK1055: DotnetTool does not support target framework lower than netcoreapp2.1.</source>
+        <target state="translated">NETSDK1055: DotnetTool, netcoreapp2.1’den daha düşük hedef çerçeveleri desteklemez.</target>
+        <note>{StrBegin="NETSDK1055: "}</note>
+      </trans-unit>
+      <trans-unit id="DotnetToolOnlySupportNetcoreapp">
+        <source>NETSDK1054: only supports .NET Core.</source>
+        <target state="translated">NETSDK1054: Yalnızca .NET Core desteklenir.</target>
+        <note>{StrBegin="NETSDK1054: "}</note>
+      </trans-unit>
+      <trans-unit id="DuplicateItemsError">
+        <source>NETSDK1022: Duplicate '{0}' items were included. The .NET SDK includes '{0}' items from your project directory by default. You can either remove these items from your project file, or set the '{1}' property to '{2}' if you want to explicitly include them in your project file. For more information, see {4}. The duplicate items were: {3}</source>
+        <target state="translated">NETSDK1022: Yinelenen '{0}' öğeleri eklendi. .NET SDK, proje dizininizdeki '{0}' öğelerini varsayılan olarak içeriyor. Bu öğeleri proje dosyanızdan kaldırabilir veya bunları proje dosyanıza açıkça dahil etmek istiyorsanız '{1}' özelliğini '{2}' olarak ayarlayabilirsiniz. Daha fazla bilgi için bkz. {4}. Yinelenen öğeler: {3}</target>
+        <note>{StrBegin="NETSDK1022: "}</note>
+      </trans-unit>
+      <trans-unit id="DuplicatePreprocessorToken">
+        <source>NETSDK1015: The preprocessor token '{0}' has been given more than one value. Choosing '{1}' as the value.</source>
+        <target state="translated">NETSDK1015: '{0}' ön işlemci belirtecine birden fazla değer verildi. Değer olarak '{1}' seçiliyor.</target>
+        <note>{StrBegin="NETSDK1015: "}</note>
+      </trans-unit>
       <trans-unit id="EncounteredConflict">
         <source>NETSDK1041: Encountered conflict between '{0}' and '{1}'.</source>
         <target state="translated">NETSDK1041: '{0}' ile '{1}' arasında çakışmayla karşılaşıldı.</target>
         <note>{StrBegin="NETSDK1041: "}</note>
       </trans-unit>
-      <trans-unit id="CouldNotLoadPlatformManifest">
-        <source>NETSDK1042: Could not load PlatformManifest from '{0}' because it did not exist.</source>
-        <target state="translated">NETSDK1042: '{0}' mevcut olmadığından buradan PlatformManifest yüklenemedi.</target>
-        <note>{StrBegin="NETSDK1042: "}</note>
+      <trans-unit id="ErrorParsingFrameworkListInvalidValue">
+        <source>NETSDK1051: Error parsing FrameworkList from '{0}'.  {1} '{2}' was invalid.</source>
+        <target state="translated">NETSDK1051: '{0}' öğesinden FrameworkList ayrıştırılırken hata oluştu.  {1} '{2}' geçersizdi.</target>
+        <note>{StrBegin="NETSDK1051: "}</note>
       </trans-unit>
       <trans-unit id="ErrorParsingPlatformManifest">
         <source>NETSDK1043: Error parsing PlatformManifest from '{0}' line {1}.  Lines must have the format {2}.</source>
@@ -307,65 +202,55 @@
         <target state="translated">NETSDK1044: '{0}' konumundaki {1}. satırdan PlatformManifest ayrıştırılırken hata oluştu. {2} '{3}' geçersizdi.</target>
         <note>{StrBegin="NETSDK1044: "}</note>
       </trans-unit>
-      <trans-unit id="UnsupportedTargetFrameworkVersion">
-        <source>NETSDK1045: The current .NET SDK does not support targeting {0} {1}.  Either target {0} {2} or lower, or use a version of the .NET SDK that supports {0} {1}.</source>
-        <target state="translated">NETSDK1045: Geçerli .NET SDK’sı {0} {1} sürümünü hedeflemeyi desteklemiyor. {0} {2} veya daha düşük bir sürümü hedefleyin veya {0} {1} destekleyen bir .NET SDK’sı kullanın.</target>
-        <note>{StrBegin="NETSDK1045: "}</note>
+      <trans-unit id="ErrorReadingAssetsFile">
+        <source>NETSDK1060: Error reading assets file: {0}</source>
+        <target state="translated">NETSDK1060: Varlıklar dosyası okunurken hata: {0}</target>
+        <note>{StrBegin="NETSDK1060: "}</note>
       </trans-unit>
-      <trans-unit id="AssetsFileMissingRuntimeIdentifier">
-        <source>NETSDK1047: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project. You may also need to include '{3}' in your project's RuntimeIdentifiers.</source>
-        <target state="translated">NETSDK1047: '{0}' varlık dosyasında '{1}' için hedef yok. Geri yüklemenin çalıştırıldığından ve '{2}' öğesinin projeniz için TargetFrameworks’e eklendiğinden emin olun. Ayrıca '{3}' öğesini projenizin RuntimeIdentifiers’ına eklemeniz gerekebilir.</target>
-        <note>{StrBegin="NETSDK1047: "}</note>
+      <trans-unit id="FailedToLockResource">
+        <source>NETSDK1077: Failed to lock resource.</source>
+        <target state="translated">NETSDK1077: Kaynak kilitlenemedi.</target>
+        <note>{StrBegin="NETSDK1077: "}</note>
       </trans-unit>
-      <trans-unit id="TargetFrameworkWithSemicolon">
-        <source>NETSDK1046: The TargetFramework value '{0}' is not valid. To multi-target, use the 'TargetFrameworks' property instead.</source>
-        <target state="translated">NETSDK1046: '{0}' TargetFramework değeri geçerli değil. Çoklu hedefleme için 'TargetFrameworks' özelliğini kullanın.</target>
-        <note>{StrBegin="NETSDK1046: "}</note>
+      <trans-unit id="FileNameIsTooLong">
+        <source>NETSDK1030: Given file name '{0}' is longer than 1024 bytes</source>
+        <target state="translated">NETSDK1030: Belirtilen dosya adı ('{0}') 1024 bayttan uzun</target>
+        <note>{StrBegin="NETSDK1030: "}</note>
       </trans-unit>
-      <trans-unit id="GetDependsOnNETStandardFailedWithException">
-        <source>NETSDK1049: Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0} {1}</source>
-        <target state="translated">NETSDK1049: Çözümlenen dosyada hatalı görüntü var, meta veri yok veya dosya erişilemez durumda. {0} {1}</target>
-        <note>{StrBegin="NETSDK1049: "}</note>
+      <trans-unit id="FolderAlreadyExists">
+        <source>NETSDK1024: Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</source>
+        <target state="translated">NETSDK1024: '{0}' klasörü zaten var. Klasörü silin veya farklı bir ComposeWorkingDir değeri belirtin</target>
+        <note>{StrBegin="NETSDK1024: "}</note>
       </trans-unit>
-      <trans-unit id="UnsupportedSDKVersionForNetStandard20">
-        <source>NETSDK1050: The version of Microsoft.NET.Sdk used by this project is insufficient to support references to libraries targeting .NET Standard 1.5 or higher.  Please install version 2.0 or higher of the .NET Core SDK.</source>
-        <target state="translated">NETSDK1050: Bu proje tarafından kullanılan Microsoft.NET.Sdk, .NET Standard 1.5 veya üzeri kitaplıkları desteklemek için yeterli değil. Lütfen .NET Core SDK 2.0 veya sonraki bir sürümü yükleyin.</target>
-        <note>{StrBegin="NETSDK1050: "}</note>
-      </trans-unit>
-      <trans-unit id="SkippingAdditionalProbingPaths">
-        <source>NETSDK1048: 'AdditionalProbingPaths' were specified for GenerateRuntimeConfigurationFiles, but are being skipped because 'RuntimeConfigDevPath' is empty.</source>
-        <target state="translated">NETSDK1048: GenerateRuntimeConfigurationFiles için 'AdditionalProbingPaths' belirtildi ancak 'RuntimeConfigDevPath' boş olduğundan atlanıyor.</target>
-        <note>{StrBegin="NETSDK1048: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotHaveRuntimeIdentifierPlatformMismatchPlatformTarget">
-        <source>NETSDK1032: The RuntimeIdentifier platform '{0}' and the PlatformTarget '{1}' must be compatible.</source>
-        <target state="translated">NETSDK1032: RuntimeIdentifier platformu '{0}' ile PlatformTarget '{1}' uyumlu olmalıdır.</target>
-        <note>{StrBegin="NETSDK1032: "}</note>
-      </trans-unit>
-      <trans-unit id="ErrorParsingFrameworkListInvalidValue">
-        <source>NETSDK1051: Error parsing FrameworkList from '{0}'.  {1} '{2}' was invalid.</source>
-        <target state="translated">NETSDK1051: '{0}' öğesinden FrameworkList ayrıştırılırken hata oluştu.  {1} '{2}' geçersizdi.</target>
-        <note>{StrBegin="NETSDK1051: "}</note>
+      <trans-unit id="FrameworkDependentAppHostRequiresVersion21">
+        <source>NETSDK1068: The framework-dependent application host requires a target framework of at least 'netcoreapp2.1'.</source>
+        <target state="translated">NETSDK1068: Çerçeveye bağımlı uygulama konağı, en az 'netcoreapp2.1' sürümünde bir hedef çerçeve gerektirir.</target>
+        <note>{StrBegin="NETSDK1068: "}</note>
       </trans-unit>
       <trans-unit id="FrameworkListPathNotRooted">
         <source>NETSDK1052: Framework list file path '{0}' is not rooted. Only full paths are supported.</source>
         <target state="translated">NETSDK1052: '{0}' çerçeve listesi dosya yolunun kökü belirtilmemiş. Yalnızca tam yollar desteklenir.</target>
         <note>{StrBegin="NETSDK1052: "}</note>
       </trans-unit>
-      <trans-unit id="PackAsToolCannotSupportSelfContained">
-        <source>NETSDK1053: Pack as tool does not support self contained.</source>
-        <target state="translated">NETSDK1053: Araç olarak paketleme kendi kendini kapsamayı desteklemiyor.</target>
-        <note>{StrBegin="NETSDK1001: "}</note>
+      <trans-unit id="GetDependsOnNETStandardFailedWithException">
+        <source>NETSDK1049: Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0} {1}</source>
+        <target state="translated">NETSDK1049: Çözümlenen dosyada hatalı görüntü var, meta veri yok veya dosya erişilemez durumda. {0} {1}</target>
+        <note>{StrBegin="NETSDK1049: "}</note>
       </trans-unit>
-      <trans-unit id="UnsupportedRuntimeIdentifier">
-        <source>NETSDK1056: Project is targeting runtime '{0}' but did not resolve any runtime-specific packages. This runtime may not be supported by the target framework.</source>
-        <target state="translated">NETSDK1056: Proje '{0}' çalışma zamanını hedefliyor ancak çalışma zamanına özgü herhangi bir paketi çözümlemedi. Bu çalışma zamanı hedef çerçeve tarafından desteklenmiyor olabilir.</target>
-        <note>{StrBegin="NETSDK1056: "}</note>
+      <trans-unit id="IncorrectPackageRoot">
+        <source>NETSDK1020: Package Root {0} was incorrectly given for Resolved library {1}</source>
+        <target state="translated">NETSDK1020: {0} Paket Kökü, Çözümlenmiş {1} kitaplığı için yanlışlıkla verildi</target>
+        <note>{StrBegin="NETSDK1020: "}</note>
       </trans-unit>
-      <trans-unit id="UsingPreviewSdkWarning">
-        <source>NETSDK1057: You are using a preview version of .NET Core. See: https://aka.ms/dotnet-core-preview</source>
-        <target state="translated">NETSDK1057: .NET Core'un önizleme sürümünü kullanıyorsunuz. Bkz. https://aka.ms/dotnet-core-preview</target>
-        <note>{StrBegin="NETSDK1057: "}</note>
+      <trans-unit id="IncorrectTargetFormat">
+        <source>NETSDK1025: WRThe target manifest {0} provided is of not the correct format</source>
+        <target state="translated">NETSDK1025: Belirtilen {0} hedef bildirimi doğru biçimde değil</target>
+        <note>{StrBegin="NETSDK1025: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidFrameworkName">
+        <source>NETSDK1003: Invalid framework name: '{0}'.</source>
+        <target state="translated">NETSDK1003: Geçersiz çerçeve adı: '{0}'.</target>
+        <note>{StrBegin="NETSDK1003: "}</note>
       </trans-unit>
       <trans-unit id="InvalidItemSpecToUse">
         <source>NETSDK1058: Invalid value for ItemSpecToUse parameter: '{0}'.  This property must be blank or set to 'Left' or 'Right'</source>
@@ -373,15 +258,15 @@
         <note>{StrBegin="NETSDK1058: "}
 The following are names of parameters or literal values and should not be translated: ItemSpecToUse, Left, Right</note>
       </trans-unit>
-      <trans-unit id="ProjectContainsObsoleteDotNetCliTool">
-        <source>NETSDK1059: The tool '{0}' is now included in the .NET Core SDK. Information on resolving this warning is available at (https://aka.ms/dotnetclitools-in-box).</source>
-        <target state="translated">NETSDK1059: '{0}' aracı .NET Core SDK’sına eklendi. Bu uyarının çözümlenmesiyle ilgili bilgi edinmek için bkz. (https://aka.ms/dotnetclitools-in-box).</target>
-        <note>{StrBegin="NETSDK1059: "}</note>
+      <trans-unit id="InvalidNuGetVersionString">
+        <source>NETSDK1018: Invalid NuGet version string: '{0}'.</source>
+        <target state="translated">NETSDK1018: Geçersiz NuGet sürüm dizesi: '{0}'.</target>
+        <note>{StrBegin="NETSDK1018: "}</note>
       </trans-unit>
-      <trans-unit id="ErrorReadingAssetsFile">
-        <source>NETSDK1060: Error reading assets file: {0}</source>
-        <target state="translated">NETSDK1060: Varlıklar dosyası okunurken hata: {0}</target>
-        <note>{StrBegin="NETSDK1060: "}</note>
+      <trans-unit id="InvalidResourceUpdate">
+        <source>NETSDK1075: Update handle is invalid. This instance may not be used for further updates.</source>
+        <target state="translated">NETSDK1075: Güncelleştirme tanıtıcısı geçersiz. Bu örnek başka güncelleştirme için kullanılamaz.</target>
+        <note>{StrBegin="NETSDK1075: "}</note>
       </trans-unit>
       <trans-unit id="MismatchedPlatformPackageVersion">
         <source>NETSDK1061: The project was restored using {0} version {1}, but with current settings, version {2} would be used instead. To resolve this issue, make sure the same settings are used for restore and for subsequent operations such as build or publish. Typically this issue can occur if the RuntimeIdentifier property is set during build or publish but not during restore. For more information, see https://aka.ms/dotnet-runtime-patch-selection.</source>
@@ -391,35 +276,150 @@ The following are names of parameters or literal values and should not be transl
 {1} - Restored version of platform package
 {2} - Current version of platform package</note>
       </trans-unit>
-      <trans-unit id="AssetsFileNotSet">
-        <source>NETSDK1063: The path to the project assets file was not set. Run a NuGet package restore to generate this file.</source>
-        <target state="translated">NETSDK1063: Proje varlıkları dosyasının yolu ayarlanmadı. Bu dosyayı oluşturmak için, NuGet paketi geri yükleme işlemi gerçekleştirin.</target>
-        <note>{StrBegin="NETSDK1063: "}</note>
+      <trans-unit id="MissingItemMetadata">
+        <source>NETSDK1008: Missing '{0}' metadata on '{1}' item '{2}'.</source>
+        <target state="translated">NETSDK1008: '{1}' öğesi '{2}' üzerinde '{0}' meta verileri eksik.</target>
+        <note>{StrBegin="NETSDK1008: "}</note>
       </trans-unit>
-      <trans-unit id="DotnetToolOnlySupportNetcoreapp">
-        <source>NETSDK1054: only supports .NET Core.</source>
-        <target state="translated">NETSDK1054: Yalnızca .NET Core desteklenir.</target>
-        <note>{StrBegin="NETSDK1054: "}</note>
+      <trans-unit id="MultipleFilesResolved">
+        <source>NETSDK1021: More than one file found for {0}</source>
+        <target state="translated">NETSDK1021: {0} için birden fazla dosya bulundu</target>
+        <note>{StrBegin="NETSDK1021: "}</note>
       </trans-unit>
-      <trans-unit id="DotnetToolDoesNotSupportTFMLowerThanNetcoreapp21">
-        <source>NETSDK1055: DotnetTool does not support target framework lower than netcoreapp2.1.</source>
-        <target state="translated">NETSDK1055: DotnetTool, netcoreapp2.1’den daha düşük hedef çerçeveleri desteklemez.</target>
-        <note>{StrBegin="NETSDK1055: "}</note>
+      <trans-unit id="NETFrameworkToNonBuiltInNETStandard">
+        <source>NETSDK1069: This project uses a library that targets .NET Standard 1.5 or higher, and the project targets a version of .NET Framework that doesn't have built-in support for that version of .NET Standard. Visit https://aka.ms/net-standard-known-issues for a set of known issues. Consider retargeting to .NET Framework 4.7.2.</source>
+        <target state="translated">NETSDK1069: Bu proje, .NET Standard 1.5 veya üzerini hedefleyen bir kitaplık kullanıyor ve proje .NET Framework’ün bu .NET Standard sürümü için yerleşik destek sunmayan bir sürümünü hedefliyor. Bilinen sorunları görmek için https://aka.ms/net-standard-known-issues adresini ziyaret edin. Hedeflenen sürümü .NET Framework 4.7.2 olarak değiştirmeyi göz önünde bulundurun.</target>
+        <note>{StrBegin="NETSDK1069: "}</note>
       </trans-unit>
-      <trans-unit id="UnableToUsePackageAssetsCache">
-        <source>NETSDK1062: Unable to use package assets cache due to I/O error. This can occur when the same project is built more than once in parallel. Performance may be degraded, but the build result will not be impacted.</source>
-        <target state="translated">NETSDK1062: G/Ç hatasından dolayı paket varlıkları önbelleği kullanılamıyor. Bu, aynı proje paralel olarak birden fazla kez derlendiğinden dolayı oluşabilir. Performans düşebilir, ancak derleme sonucu etkilenmez.</target>
-        <note>{StrBegin="NETSDK1062: "}</note>
+      <trans-unit id="NoAppHostAvailable">
+        <source>NETSDK1084: There is no application host available for the specified RuntimeIdentifier '{0}'.</source>
+        <target state="new">NETSDK1084: There is no application host available for the specified RuntimeIdentifier '{0}'.</target>
+        <note>{StrBegin="NETSDK1084: "}</note>
+      </trans-unit>
+      <trans-unit id="NoCompatibleTargetFramework">
+        <source>NETSDK1002: Project '{0}' targets '{2}'. It cannot be referenced by a project that targets '{1}'.</source>
+        <target state="translated">NETSDK1002: '{0}' projesi, '{2}' çerçevesini hedefliyor. Bu projeye '{1}' çerçevesini hedefleyen bir proje tarafından başvurulamaz.</target>
+        <note>{StrBegin="NETSDK1002: "}</note>
+      </trans-unit>
+      <trans-unit id="NoRuntimePackAvailable">
+        <source>NETSDK1082: There was no runtime pack for {0} available for the specified RuntimeIdentifier '{1}'.</source>
+        <target state="new">NETSDK1082: There was no runtime pack for {0} available for the specified RuntimeIdentifier '{1}'.</target>
+        <note>{StrBegin="NETSDK1082: "}</note>
+      </trans-unit>
+      <trans-unit id="PackAsToolCannotSupportSelfContained">
+        <source>NETSDK1053: Pack as tool does not support self contained.</source>
+        <target state="translated">NETSDK1053: Araç olarak paketleme kendi kendini kapsamayı desteklemiyor.</target>
+        <note>{StrBegin="NETSDK1001: "}</note>
+      </trans-unit>
+      <trans-unit id="PackageInfoLog">
+        <source>NETSDK1027: Package Name='{0}', Version='{1}' was parsed</source>
+        <target state="translated">NETSDK1027: Paket Adı='{0}', Sürüm='{1}' ayrıştırıldı</target>
+        <note>{StrBegin="NETSDK1027: "}</note>
       </trans-unit>
       <trans-unit id="PackageNotFound">
         <source>NETSDK1064: Package {0}, version {1} was not found. It might have been deleted since NuGet restore. Otherwise, NuGet restore might have only partially completed, which might have been due to maximum path length restrictions.</source>
         <target state="translated">NETSDK1064: {0} paketinin {1} sürümü bulunamadı. NuGet geri yükleme işleminden sonra silinmiş olabilir. Silinmediyse, NuGet geri yükleme işlemi muhtemelen en fazla yol uzunluğu kısıtlamaları nedeniyle yalnızca kısmen başarılı olmuş olabilir.</target>
         <note>{StrBegin="NETSDK1064: "}</note>
       </trans-unit>
-      <trans-unit id="CannotFindApphostForRid">
-        <source>NETSDK1065: Cannot find app host for {0}. {0} could be an invalid runtime identifier (RID). For more information about RID, see https://aka.ms/rid-catalog.</source>
-        <target state="translated">NETSDK1065: {0} için uygulama konağı bulunamıyor. {0} geçersiz bir çalışma zamanı tanımlayıcısı (RID) olabilir. RID hakkında daha fazla bilgi için bkz. https://aka.ms/rid-catalog.</target>
-        <note>{StrBegin="NETSDK1065: "}</note>
+      <trans-unit id="PackageReferenceOverrideWarning">
+        <source>NETSDK1023: A PackageReference for '{0}' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see {1}</source>
+        <target state="translated">NETSDK1023: Projenize '{0}' için bir PackageReference eklendi. .NET SDK bu pakete örtük olarak başvuruyor; buna projenizden başvurmanız genellikle gerekli değildir. Daha fazla bilgi için bkz. {1}</target>
+        <note>{StrBegin="NETSDK1023: "}</note>
+      </trans-unit>
+      <trans-unit id="PackageReferenceVersionNotRecommended">
+        <source>NETSDK1071: A PackageReference to '{0}' specified a Version of `{1}`. Specifying the version of this package is not recommended. For more information, see https://aka.ms/sdkimplicitrefs</source>
+        <target state="translated">NETSDK1071: '{0}' öğesine yönelik bir PackageReference, bir `{1}` Sürümünü belirtti. Bu paketin sürümünün belirtilmesi önerilmez. Daha fazla bilgi edinmek için bkz. https://aka.ms/sdkimplicitrefs</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParsingFiles">
+        <source>NETSDK1026: Parsing the Files : '{0}'</source>
+        <target state="translated">NETSDK1026: Dosyalar ayrıştırılıyor: '{0}'</target>
+        <note>{StrBegin="NETSDK1026: "}</note>
+      </trans-unit>
+      <trans-unit id="ProjectAssetsConsumedWithoutMSBuildProjectPath">
+        <source>NETSDK1011: Assets are consumed from project '{0}', but no corresponding MSBuild project path was  found in '{1}'.</source>
+        <target state="translated">NETSDK1011: '{0}' projesindeki varlıklar kullanılıyor, ancak '{1}' içinde karşılık gelen bir MSBuild proje yolu bulunamadı.</target>
+        <note>{StrBegin="NETSDK1011: "}</note>
+      </trans-unit>
+      <trans-unit id="ProjectContainsObsoleteDotNetCliTool">
+        <source>NETSDK1059: The tool '{0}' is now included in the .NET Core SDK. Information on resolving this warning is available at (https://aka.ms/dotnetclitools-in-box).</source>
+        <target state="translated">NETSDK1059: '{0}' aracı .NET Core SDK’sına eklendi. Bu uyarının çözümlenmesiyle ilgili bilgi edinmek için bkz. (https://aka.ms/dotnetclitools-in-box).</target>
+        <note>{StrBegin="NETSDK1059: "}</note>
+      </trans-unit>
+      <trans-unit id="RuntimeIdentifierNotRecognized">
+        <source>NETSDK1083: The specified RuntimeIdentifier '{0}' is not recognized.</source>
+        <target state="new">NETSDK1083: The specified RuntimeIdentifier '{0}' is not recognized.</target>
+        <note>{StrBegin="NETSDK1083: "}</note>
+      </trans-unit>
+      <trans-unit id="RuntimeIdentifierWasNotSpecified">
+        <source>NETSDK1028: Specify a RuntimeIdentifier</source>
+        <target state="translated">NETSDK1028: Bir RuntimeIdentifier belirtin</target>
+        <note>{StrBegin="NETSDK1028: "}</note>
+      </trans-unit>
+      <trans-unit id="SkippingAdditionalProbingPaths">
+        <source>NETSDK1048: 'AdditionalProbingPaths' were specified for GenerateRuntimeConfigurationFiles, but are being skipped because 'RuntimeConfigDevPath' is empty.</source>
+        <target state="translated">NETSDK1048: GenerateRuntimeConfigurationFiles için 'AdditionalProbingPaths' belirtildi ancak 'RuntimeConfigDevPath' boş olduğundan atlanıyor.</target>
+        <note>{StrBegin="NETSDK1048: "}</note>
+      </trans-unit>
+      <trans-unit id="TargetFrameworkWithSemicolon">
+        <source>NETSDK1046: The TargetFramework value '{0}' is not valid. To multi-target, use the 'TargetFrameworks' property instead.</source>
+        <target state="translated">NETSDK1046: '{0}' TargetFramework değeri geçerli değil. Çoklu hedefleme için 'TargetFrameworks' özelliğini kullanın.</target>
+        <note>{StrBegin="NETSDK1046: "}</note>
+      </trans-unit>
+      <trans-unit id="UnableToFindResolvedPath">
+        <source>NETSDK1016: Unable to find resolved path for '{0}'.</source>
+        <target state="translated">NETSDK1016: '{0}' için çözümlenmiş yol bulunamıyor.</target>
+        <note>{StrBegin="NETSDK1016: "}</note>
+      </trans-unit>
+      <trans-unit id="UnableToUsePackageAssetsCache">
+        <source>NETSDK1062: Unable to use package assets cache due to I/O error. This can occur when the same project is built more than once in parallel. Performance may be degraded, but the build result will not be impacted.</source>
+        <target state="translated">NETSDK1062: G/Ç hatasından dolayı paket varlıkları önbelleği kullanılamıyor. Bu, aynı proje paralel olarak birden fazla kez derlendiğinden dolayı oluşabilir. Performans düşebilir, ancak derleme sonucu etkilenmez.</target>
+        <note>{StrBegin="NETSDK1062: "}</note>
+      </trans-unit>
+      <trans-unit id="UnexpectedFileType">
+        <source>NETSDK1012: Unexpected file type for '{0}'. Type is both '{1}' and '{2}'.</source>
+        <target state="translated">NETSDK1012: '{0}' için beklenmeyen dosya türü. Tür hem '{1}' hem de '{2}'.</target>
+        <note>{StrBegin="NETSDK1012: "}</note>
+      </trans-unit>
+      <trans-unit id="UnknownFrameworkReference">
+        <source>NETSDK1073: The FrameworkReference '{0}' was not recognized</source>
+        <target state="translated">NETSDK1073: FrameworkReference '{0}' tanınmadı</target>
+        <note>{StrBegin="NETSDK1073: "}</note>
+      </trans-unit>
+      <trans-unit id="UnrecognizedPreprocessorToken">
+        <source>NETSDK1009: Unrecognized preprocessor token '{0}' in '{1}'.</source>
+        <target state="translated">NETSDK1009: '{1}' içinde tanınmayan '{0}' ön işlemci belirteci.</target>
+        <note>{StrBegin="NETSDK1009: "}</note>
+      </trans-unit>
+      <trans-unit id="UnresolvedTargetingPack">
+        <source>NETSDK1081: The targeting pack for {0} was not found. You may be able to resolve this by running a NuGet restore on the project.</source>
+        <target state="new">NETSDK1081: The targeting pack for {0} was not found. You may be able to resolve this by running a NuGet restore on the project.</target>
+        <note>{StrBegin="NETSDK1081: "}</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedFramework">
+        <source>NETSDK1019: {0} is an unsupported framework.</source>
+        <target state="translated">NETSDK1019: {0} çerçevesi desteklenmiyor.</target>
+        <note>{StrBegin="NETSDK1019: "}</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedRuntimeIdentifier">
+        <source>NETSDK1056: Project is targeting runtime '{0}' but did not resolve any runtime-specific packages. This runtime may not be supported by the target framework.</source>
+        <target state="translated">NETSDK1056: Proje '{0}' çalışma zamanını hedefliyor ancak çalışma zamanına özgü herhangi bir paketi çözümlemedi. Bu çalışma zamanı hedef çerçeve tarafından desteklenmiyor olabilir.</target>
+        <note>{StrBegin="NETSDK1056: "}</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedSDKVersionForNetStandard20">
+        <source>NETSDK1050: The version of Microsoft.NET.Sdk used by this project is insufficient to support references to libraries targeting .NET Standard 1.5 or higher.  Please install version 2.0 or higher of the .NET Core SDK.</source>
+        <target state="translated">NETSDK1050: Bu proje tarafından kullanılan Microsoft.NET.Sdk, .NET Standard 1.5 veya üzeri kitaplıkları desteklemek için yeterli değil. Lütfen .NET Core SDK 2.0 veya sonraki bir sürümü yükleyin.</target>
+        <note>{StrBegin="NETSDK1050: "}</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedTargetFrameworkVersion">
+        <source>NETSDK1045: The current .NET SDK does not support targeting {0} {1}.  Either target {0} {2} or lower, or use a version of the .NET SDK that supports {0} {1}.</source>
+        <target state="translated">NETSDK1045: Geçerli .NET SDK’sı {0} {1} sürümünü hedeflemeyi desteklemiyor. {0} {2} veya daha düşük bir sürümü hedefleyin veya {0} {1} destekleyen bir .NET SDK’sı kullanın.</target>
+        <note>{StrBegin="NETSDK1045: "}</note>
+      </trans-unit>
+      <trans-unit id="UsingPreviewSdkWarning">
+        <source>NETSDK1057: You are using a preview version of .NET Core. See: https://aka.ms/dotnet-core-preview</source>
+        <target state="translated">NETSDK1057: .NET Core'un önizleme sürümünü kullanıyorsunuz. Bkz. https://aka.ms/dotnet-core-preview</target>
+        <note>{StrBegin="NETSDK1057: "}</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
@@ -2,35 +2,25 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../Strings.resx">
     <body>
-      <trans-unit id="AspNetCoreAllNotSupported">
-        <source>NETSDK1079: The Microsoft.AspNetCore.All package is not supported when targeting .NET Core 3.0 or higher.  A FrameworkReference to Microsoft.AspNetCore.App should be used instead, and will be implicitly included by Microsoft.NET.Sdk.Web.</source>
-        <target state="translated">NETSDK1079: 在面向 .NET Core 3.0 或更高版本时不支持 Microsoft.AspNetCore.All 包。应改用 Microsoft.AspNetCore.App 的 FrameworkReference，且 Microsoft.NET.Sdk.Web 将隐式包含此引用。</target>
-        <note>{StrBegin="NETSDK1079: "}</note>
-      </trans-unit>
-      <trans-unit id="AspNetCoreUsesFrameworkReference">
-        <source>NETSDK1080: A PackageReference to Microsoft.AspNetCore.App is not necessary when targeting .NET Core 3.0 or higher. If Microsoft.NET.Sdk.Web is used, the shared framework will be referenced automatically. Otherwise, the PackageReference should be replaced with a FrameworkReference.</source>
-        <target state="translated">NETSDK1080: 在面向 .NET Core 3.0 或更高版本时，PackageReference to Microsoft.AspNetCore.App 不是必需项。如果使用了 Microsoft.NET.Sdk.Web，则自动引用共享框架。否则，应将 PackageReference 替换为 FrameworkReference。</target>
-        <note>{StrBegin="NETSDK1080: "}</note>
-      </trans-unit>
-      <trans-unit id="FailedToLockResource">
-        <source>NETSDK1077: Failed to lock resource.</source>
-        <target state="translated">NETSDK1077: 未能锁定资源。</target>
-        <note>{StrBegin="NETSDK1077: "}</note>
-      </trans-unit>
       <trans-unit id="AddResourceWithNonIntegerResource">
         <source>NETSDK1076: AddResource can only be used with integer resource types.</source>
         <target state="translated">NETSDK1076: AddResource 仅可用于整数资源类型。</target>
         <note>{StrBegin="NETSDK1076: "}</note>
       </trans-unit>
-      <trans-unit id="InvalidResourceUpdate">
-        <source>NETSDK1075: Update handle is invalid. This instance may not be used for further updates.</source>
-        <target state="translated">NETSDK1075: 更新句柄无效。此实例不能用于进一步的更新。</target>
-        <note>{StrBegin="NETSDK1075: "}</note>
+      <trans-unit id="AppConfigRequiresRootConfiguration">
+        <source>NETSDK1070: The application configuration file must have root configuration element.</source>
+        <target state="translated">NETSDK1070: 应用程序配置文件必须具有根配置元素。</target>
+        <note>{StrBegin="NETSDK1070: "}</note>
       </trans-unit>
       <trans-unit id="AppHostCustomizationRequiresWindowsHostWarning">
         <source>NETSDK1074: The application host executable will not be customized because adding resources requires that the build be performed on Windows (excluding Nano Server).</source>
         <target state="translated">NETSDK1074: 由于必须在 Windows 上执行生成项才能添加资源，因此将不自定义应用程序主机可执行文件(Nano Server 除外)。</target>
         <note>{StrBegin="NETSDK1074: "}</note>
+      </trans-unit>
+      <trans-unit id="AppHostHasBeenModified">
+        <source>NETSDK1029: Unable to use '{0}' as application host executable as it does not contain the expected placeholder byte sequence '{1}' that would mark where the application name would be written.</source>
+        <target state="translated">NETSDK1029: 未能将“{0}”用作应用程序主机可执行文件，因为它没有必需的占位符字节序列“{1}”，该序列会标记应用程序名称的写入位置。</target>
+        <note>{StrBegin="NETSDK1029: "}</note>
       </trans-unit>
       <trans-unit id="AppHostNotWindows">
         <source>NETSDK1078: Unable to use '{0}' as application host executable because it's not a Windows PE file.</source>
@@ -42,210 +32,80 @@
         <target state="translated">NETSDK1072: 无法将“{0}”用作应用程序主机可执行文件，因为它不是 CUI (Console)子系统的 Windows 可执行文件。</target>
         <note>{StrBegin="NETSDK1072: "}</note>
       </trans-unit>
-      <trans-unit id="AppConfigRequiresRootConfiguration">
-        <source>NETSDK1070: The application configuration file must have root configuration element.</source>
-        <target state="translated">NETSDK1070: 应用程序配置文件必须具有根配置元素。</target>
-        <note>{StrBegin="NETSDK1070: "}</note>
+      <trans-unit id="AspNetCoreAllNotSupported">
+        <source>NETSDK1079: The Microsoft.AspNetCore.All package is not supported when targeting .NET Core 3.0 or higher.  A FrameworkReference to Microsoft.AspNetCore.App should be used instead, and will be implicitly included by Microsoft.NET.Sdk.Web.</source>
+        <target state="translated">NETSDK1079: 在面向 .NET Core 3.0 或更高版本时不支持 Microsoft.AspNetCore.All 包。应改用 Microsoft.AspNetCore.App 的 FrameworkReference，且 Microsoft.NET.Sdk.Web 将隐式包含此引用。</target>
+        <note>{StrBegin="NETSDK1079: "}</note>
       </trans-unit>
-      <trans-unit id="AtLeastOneTargetFrameworkMustBeSpecified">
-        <source>NETSDK1001: At least one possible target framework must be specified.</source>
-        <target state="translated">NETSDK1001: 必须指定至少一个可能的目标框架。</target>
-        <note>{StrBegin="NETSDK1001: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotUseSelfContainedWithoutAppHost">
-        <source>NETSDK1067: Self-contained applications are required to use the application host. Either set SelfContained to false or set UseAppHost to true.</source>
-        <target state="translated">NETSDK1067: 需要自包含应用程序才能使用应用程序主机。将 SelfContained 设置为 false，或者将 UseAppHost 设置为 true。</target>
-        <note>{StrBegin="NETSDK1067: "}</note>
-      </trans-unit>
-      <trans-unit id="FrameworkDependentAppHostRequiresVersion21">
-        <source>NETSDK1068: The framework-dependent application host requires a target framework of at least 'netcoreapp2.1'.</source>
-        <target state="translated">NETSDK1068: 框架依赖型应用程序主机需要一个至少 “netcoreapp2.1” 的目标框架。</target>
-        <note>{StrBegin="NETSDK1068: "}</note>
-      </trans-unit>
-      <trans-unit id="NETFrameworkToNonBuiltInNETStandard">
-        <source>NETSDK1069: This project uses a library that targets .NET Standard 1.5 or higher, and the project targets a version of .NET Framework that doesn't have built-in support for that version of .NET Standard. Visit https://aka.ms/net-standard-known-issues for a set of known issues. Consider retargeting to .NET Framework 4.7.2.</source>
-        <target state="translated">NETSDK1069: 此项目使用了一个面向 .NET Standard 1.5 或更高版本的库，且此项目面向一个没有对该版本的 .NET Standard 的内置支持的 .NET Framework 版本。请访问 https://aka.ms/net-standard-known-issues 了解一些已知问题。考虑重定向到 .NET Framework 4.7.2。</target>
-        <note>{StrBegin="NETSDK1069: "}</note>
-      </trans-unit>
-      <trans-unit id="NoAppHostAvailable">
-        <source>NETSDK1084: There is no application host available for the specified RuntimeIdentifier '{0}'.</source>
-        <target state="new">NETSDK1084: There is no application host available for the specified RuntimeIdentifier '{0}'.</target>
-        <note>{StrBegin="NETSDK1084: "}</note>
-      </trans-unit>
-      <trans-unit id="NoCompatibleTargetFramework">
-        <source>NETSDK1002: Project '{0}' targets '{2}'. It cannot be referenced by a project that targets '{1}'.</source>
-        <target state="translated">NETSDK1002: 项目“{0}”以“{2}”为目标。它不可由面向“{1}”的项目引用。</target>
-        <note>{StrBegin="NETSDK1002: "}</note>
-      </trans-unit>
-      <trans-unit id="InvalidFrameworkName">
-        <source>NETSDK1003: Invalid framework name: '{0}'.</source>
-        <target state="translated">NETSDK1003: 无效的框架名称:“{0}”。</target>
-        <note>{StrBegin="NETSDK1003: "}</note>
-      </trans-unit>
-      <trans-unit id="AssetsFileNotFound">
-        <source>NETSDK1004: Assets file '{0}' not found. Run a NuGet package restore to generate this file.</source>
-        <target state="translated">NETSDK1004: 找不到资产文件“{0}”。运行 NuGet 包还原以生成此文件。</target>
-        <note>{StrBegin="NETSDK1004: "}</note>
-      </trans-unit>
-      <trans-unit id="AssetsFileMissingTarget">
-        <source>NETSDK1005: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project.</source>
-        <target state="translated">NETSDK1005: 资产文件“{0}”没有“{1}”的目标。确保已运行还原，且“{2}”已包含在项目的 TargetFrameworks 中。</target>
-        <note>{StrBegin="NETSDK1005: "}</note>
-      </trans-unit>
-      <trans-unit id="AssetsFilePathNotRooted">
-        <source>NETSDK1006: Assets file path '{0}' is not rooted. Only full paths are supported.</source>
-        <target state="translated">NETSDK1006: 资产文件路径“{0}”不是根路径。仅支持完整路径。</target>
-        <note>{StrBegin="NETSDK1006: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotFindProjectInfo">
-        <source>NETSDK1007: Cannot find project info for '{0}'. This can indicate a missing project reference.</source>
-        <target state="translated">NETSDK1007: 找不到“{0}”的项目信息。这可以指示缺少一个项目引用。</target>
-        <note>{StrBegin="NETSDK1007: "}</note>
-      </trans-unit>
-      <trans-unit id="MissingItemMetadata">
-        <source>NETSDK1008: Missing '{0}' metadata on '{1}' item '{2}'.</source>
-        <target state="translated">NETSDK1008: 在“{1}”项“{2}”上缺少“{0}”元数据。</target>
-        <note>{StrBegin="NETSDK1008: "}</note>
-      </trans-unit>
-      <trans-unit id="NoRuntimePackAvailable">
-        <source>NETSDK1082: There was no runtime pack for {0} available for the specified RuntimeIdentifier '{1}'.</source>
-        <target state="new">NETSDK1082: There was no runtime pack for {0} available for the specified RuntimeIdentifier '{1}'.</target>
-        <note>{StrBegin="NETSDK1082: "}</note>
-      </trans-unit>
-      <trans-unit id="PackageReferenceVersionNotRecommended">
-        <source>NETSDK1071: A PackageReference to '{0}' specified a Version of `{1}`. Specifying the version of this package is not recommended. For more information, see https://aka.ms/sdkimplicitrefs</source>
-        <target state="translated">NETSDK1071:“{0}”的 PackageReference 指定了版本“{1}”。不建议指定此包的版本。有关详细信息，请查看 https://aka.ms/sdkimplicitrefs</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="RuntimeIdentifierNotRecognized">
-        <source>NETSDK1083: The specified RuntimeIdentifier '{0}' is not recognized.</source>
-        <target state="new">NETSDK1083: The specified RuntimeIdentifier '{0}' is not recognized.</target>
-        <note>{StrBegin="NETSDK1083: "}</note>
-      </trans-unit>
-      <trans-unit id="UnknownFrameworkReference">
-        <source>NETSDK1073: The FrameworkReference '{0}' was not recognized</source>
-        <target state="translated">NETSDK1073: 未能识别 FrameworkReference“{0}”</target>
-        <note>{StrBegin="NETSDK1073: "}</note>
-      </trans-unit>
-      <trans-unit id="UnrecognizedPreprocessorToken">
-        <source>NETSDK1009: Unrecognized preprocessor token '{0}' in '{1}'.</source>
-        <target state="translated">NETSDK1009:“{1}”中无法识别预处理器标记“{0}”。</target>
-        <note>{StrBegin="NETSDK1009: "}</note>
-      </trans-unit>
-      <trans-unit id="ContentPreproccessorParameterRequired">
-        <source>NETSDK1010: The '{0}' task must be given a value for parameter '{1}' in order to consume preprocessed content.</source>
-        <target state="translated">NETSDK1010: 必须向“{0}”任务提供参数“{1}”的值以便使用预处理的内容。</target>
-        <note>{StrBegin="NETSDK1010: "}</note>
-      </trans-unit>
-      <trans-unit id="ProjectAssetsConsumedWithoutMSBuildProjectPath">
-        <source>NETSDK1011: Assets are consumed from project '{0}', but no corresponding MSBuild project path was  found in '{1}'.</source>
-        <target state="translated">NETSDK1011: 从项目“{0}”消耗资产，但在“{1}”中找不到相应的 MSBuild 项目路径。</target>
-        <note>{StrBegin="NETSDK1011: "}</note>
-      </trans-unit>
-      <trans-unit id="UnexpectedFileType">
-        <source>NETSDK1012: Unexpected file type for '{0}'. Type is both '{1}' and '{2}'.</source>
-        <target state="translated">NETSDK1012:“{0}”的文件类型非预期。类型是“{1}”和“{2}”。</target>
-        <note>{StrBegin="NETSDK1012: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotInferTargetFrameworkIdentifierAndVersion">
-        <source>NETSDK1013: The TargetFramework value '{0}' was not recognized. It may be misspelled. If not, then the TargetFrameworkIdentifier and/or TargetFrameworkVersion properties must be specified explicitly.</source>
-        <target state="translated">NETSDK1013: 未识别 TargetFramework 值“{0}”。可能是因为拼写错误。如果拼写正确，必须显式指定 TargetFrameworkIdentifier 和/或 TargetFrameworkVersion 属性。</target>
-        <note>{StrBegin="NETSDK1013: "}</note>
-      </trans-unit>
-      <trans-unit id="ContentItemDoesNotProvideOutputPath">
-        <source>NETSDK1014: Content item for '{0}' sets '{1}', but does not provide  '{2}' or '{3}'.</source>
-        <target state="translated">NETSDK1014:“{0}”的内容项设置为“{1}”，但不提供“{2}”或“{3}”。</target>
-        <note>{StrBegin="NETSDK1014: "}</note>
-      </trans-unit>
-      <trans-unit id="DuplicatePreprocessorToken">
-        <source>NETSDK1015: The preprocessor token '{0}' has been given more than one value. Choosing '{1}' as the value.</source>
-        <target state="translated">NETSDK1015: 已向预处理器标记“{0}”提供多个值。选择“{1}”作为值。</target>
-        <note>{StrBegin="NETSDK1015: "}</note>
-      </trans-unit>
-      <trans-unit id="UnableToFindResolvedPath">
-        <source>NETSDK1016: Unable to find resolved path for '{0}'.</source>
-        <target state="translated">NETSDK1016: 无法找到“{0}”的已解析路径。</target>
-        <note>{StrBegin="NETSDK1016: "}</note>
+      <trans-unit id="AspNetCoreUsesFrameworkReference">
+        <source>NETSDK1080: A PackageReference to Microsoft.AspNetCore.App is not necessary when targeting .NET Core 3.0 or higher. If Microsoft.NET.Sdk.Web is used, the shared framework will be referenced automatically. Otherwise, the PackageReference should be replaced with a FrameworkReference.</source>
+        <target state="translated">NETSDK1080: 在面向 .NET Core 3.0 或更高版本时，PackageReference to Microsoft.AspNetCore.App 不是必需项。如果使用了 Microsoft.NET.Sdk.Web，则自动引用共享框架。否则，应将 PackageReference 替换为 FrameworkReference。</target>
+        <note>{StrBegin="NETSDK1080: "}</note>
       </trans-unit>
       <trans-unit id="AssetPreprocessorMustBeConfigured">
         <source>NETSDK1017: Asset preprocessor must be configured before assets are processed.</source>
         <target state="translated">NETSDK1017: 必须在处理资产之前配置资产预处理器。</target>
         <note>{StrBegin="NETSDK1017: "}</note>
       </trans-unit>
-      <trans-unit id="InvalidNuGetVersionString">
-        <source>NETSDK1018: Invalid NuGet version string: '{0}'.</source>
-        <target state="translated">NETSDK1018: 无效的 NuGet 版本字符串:“{0}”。</target>
-        <note>{StrBegin="NETSDK1018: "}</note>
+      <trans-unit id="AssetsFileMissingRuntimeIdentifier">
+        <source>NETSDK1047: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project. You may also need to include '{3}' in your project's RuntimeIdentifiers.</source>
+        <target state="translated">NETSDK1047: 资产文件“{0}”没有“{1}”的目标。确保已运行还原，且“{2}”已包含在项目的 TargetFrameworks 中。可能需要在项目 RuntimeIdentifiers 中包括“{3}”。</target>
+        <note>{StrBegin="NETSDK1047: "}</note>
       </trans-unit>
-      <trans-unit id="UnresolvedTargetingPack">
-        <source>NETSDK1081: The targeting pack for {0} was not found. You may be able to resolve this by running a NuGet restore on the project.</source>
-        <target state="new">NETSDK1081: The targeting pack for {0} was not found. You may be able to resolve this by running a NuGet restore on the project.</target>
-        <note>{StrBegin="NETSDK1081: "}</note>
+      <trans-unit id="AssetsFileMissingTarget">
+        <source>NETSDK1005: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project.</source>
+        <target state="translated">NETSDK1005: 资产文件“{0}”没有“{1}”的目标。确保已运行还原，且“{2}”已包含在项目的 TargetFrameworks 中。</target>
+        <note>{StrBegin="NETSDK1005: "}</note>
       </trans-unit>
-      <trans-unit id="UnsupportedFramework">
-        <source>NETSDK1019: {0} is an unsupported framework.</source>
-        <target state="translated">NETSDK1019: {0} 是不受支持的框架。</target>
-        <note>{StrBegin="NETSDK1019: "}</note>
+      <trans-unit id="AssetsFileNotFound">
+        <source>NETSDK1004: Assets file '{0}' not found. Run a NuGet package restore to generate this file.</source>
+        <target state="translated">NETSDK1004: 找不到资产文件“{0}”。运行 NuGet 包还原以生成此文件。</target>
+        <note>{StrBegin="NETSDK1004: "}</note>
       </trans-unit>
-      <trans-unit id="DuplicateItemsError">
-        <source>NETSDK1022: Duplicate '{0}' items were included. The .NET SDK includes '{0}' items from your project directory by default. You can either remove these items from your project file, or set the '{1}' property to '{2}' if you want to explicitly include them in your project file. For more information, see {4}. The duplicate items were: {3}</source>
-        <target state="translated">NETSDK1022: 包含了重复的“{0}”项。.NET SDK 默认包含你项目目录中的“{0}”项。可从项目文件中删除这些项；如果希望将其显式包含在项目文件中，可将“{1}”属性设置为“{2}”。有关详细信息，请参阅 {4}。重复项为: {3}</target>
-        <note>{StrBegin="NETSDK1022: "}</note>
+      <trans-unit id="AssetsFileNotSet">
+        <source>NETSDK1063: The path to the project assets file was not set. Run a NuGet package restore to generate this file.</source>
+        <target state="translated">NETSDK1063: 未设置项目资产文件的路径。运行 NuGet 程序包还原以生成此文件。</target>
+        <note>{StrBegin="NETSDK1063: "}</note>
       </trans-unit>
-      <trans-unit id="PackageReferenceOverrideWarning">
-        <source>NETSDK1023: A PackageReference for '{0}' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see {1}</source>
-        <target state="translated">NETSDK1023: 项目中包含了“{0}”的 PackageReference。此包由 .NET SDK 隐式引用，且通常情况下你无需从项目中对其进行引用。有关详细信息，请参阅 {1}</target>
-        <note>{StrBegin="NETSDK1023: "}</note>
+      <trans-unit id="AssetsFilePathNotRooted">
+        <source>NETSDK1006: Assets file path '{0}' is not rooted. Only full paths are supported.</source>
+        <target state="translated">NETSDK1006: 资产文件路径“{0}”不是根路径。仅支持完整路径。</target>
+        <note>{StrBegin="NETSDK1006: "}</note>
       </trans-unit>
-      <trans-unit id="IncorrectPackageRoot">
-        <source>NETSDK1020: Package Root {0} was incorrectly given for Resolved library {1}</source>
-        <target state="translated">NETSDK1020: 对于“已解析”库 {1}，包根目录 {0} 分配错误</target>
-        <note>{StrBegin="NETSDK1020: "}</note>
+      <trans-unit id="AtLeastOneTargetFrameworkMustBeSpecified">
+        <source>NETSDK1001: At least one possible target framework must be specified.</source>
+        <target state="translated">NETSDK1001: 必须指定至少一个可能的目标框架。</target>
+        <note>{StrBegin="NETSDK1001: "}</note>
       </trans-unit>
-      <trans-unit id="MultipleFilesResolved">
-        <source>NETSDK1021: More than one file found for {0}</source>
-        <target state="translated">NETSDK1021: 找到 {0} 的多个文件</target>
-        <note>{StrBegin="NETSDK1021: "}</note>
+      <trans-unit id="CannotFindApphostForRid">
+        <source>NETSDK1065: Cannot find app host for {0}. {0} could be an invalid runtime identifier (RID). For more information about RID, see https://aka.ms/rid-catalog.</source>
+        <target state="translated">NETSDK1065: 无法找到 {0} 的应用主机。{0} 可能是无效的运行时标识符(RID)。有关 RID 的详细信息，请参阅 https://aka.ms/rid-catalog。</target>
+        <note>{StrBegin="NETSDK1065: "}</note>
       </trans-unit>
-      <trans-unit id="FolderAlreadyExists">
-        <source>NETSDK1024: Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</source>
-        <target state="translated">NETSDK1024: 文件夹“{0}”已存在，请将其删除或提供不同的 ComposeWorkingDir</target>
-        <note>{StrBegin="NETSDK1024: "}</note>
+      <trans-unit id="CannotFindProjectInfo">
+        <source>NETSDK1007: Cannot find project info for '{0}'. This can indicate a missing project reference.</source>
+        <target state="translated">NETSDK1007: 找不到“{0}”的项目信息。这可以指示缺少一个项目引用。</target>
+        <note>{StrBegin="NETSDK1007: "}</note>
       </trans-unit>
-      <trans-unit id="ParsingFiles">
-        <source>NETSDK1026: Parsing the Files : '{0}'</source>
-        <target state="translated">NETSDK1026: 正在分析文件:“{0}”</target>
-        <note>{StrBegin="NETSDK1026: "}</note>
-      </trans-unit>
-      <trans-unit id="PackageInfoLog">
-        <source>NETSDK1027: Package Name='{0}', Version='{1}' was parsed</source>
-        <target state="translated">NETSDK1027: 已分析出包名称为“{0}”、版本为“{1}”</target>
-        <note>{StrBegin="NETSDK1027: "}</note>
-      </trans-unit>
-      <trans-unit id="RuntimeIdentifierWasNotSpecified">
-        <source>NETSDK1028: Specify a RuntimeIdentifier</source>
-        <target state="translated">NETSDK1028: 指定一个 RuntimeIdentifier</target>
-        <note>{StrBegin="NETSDK1028: "}</note>
-      </trans-unit>
-      <trans-unit id="IncorrectTargetFormat">
-        <source>NETSDK1025: WRThe target manifest {0} provided is of not the correct format</source>
-        <target state="translated">NETSDK1025: 指定的目标清单 {0} 的格式不正确</target>
-        <note>{StrBegin="NETSDK1025: "}</note>
-      </trans-unit>
-      <trans-unit id="AppHostHasBeenModified">
-        <source>NETSDK1029: Unable to use '{0}' as application host executable as it does not contain the expected placeholder byte sequence '{1}' that would mark where the application name would be written.</source>
-        <target state="translated">NETSDK1029: 未能将“{0}”用作应用程序主机可执行文件，因为它没有必需的占位符字节序列“{1}”，该序列会标记应用程序名称的写入位置。</target>
-        <note>{StrBegin="NETSDK1029: "}</note>
-      </trans-unit>
-      <trans-unit id="FileNameIsTooLong">
-        <source>NETSDK1030: Given file name '{0}' is longer than 1024 bytes</source>
-        <target state="translated">NETSDK1030: 给定文件名“{0}”的长度超过 1024 个字节</target>
-        <note>{StrBegin="NETSDK1030: "}</note>
+      <trans-unit id="CannotHaveRuntimeIdentifierPlatformMismatchPlatformTarget">
+        <source>NETSDK1032: The RuntimeIdentifier platform '{0}' and the PlatformTarget '{1}' must be compatible.</source>
+        <target state="translated">NETSDK1032: RuntimeIdentifier 平台“{0}”和 PlatformTarget“{1}”必须兼容。</target>
+        <note>{StrBegin="NETSDK1032: "}</note>
       </trans-unit>
       <trans-unit id="CannotHaveSelfContainedWithoutRuntimeIdentifier">
         <source>NETSDK1031: It is not supported to build or publish a self-contained application without specifying a RuntimeIdentifier.  Please either specify a RuntimeIdentifier or set SelfContained to false.</source>
         <target state="translated">NETSDK1031: 不可在未指定 RuntimeIdentifier 的情况下生成或发布自包含应用程序。请指定 RuntimeIdentifier 或将 SelfContained 设置为 false。</target>
         <note>{StrBegin="NETSDK1031: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotInferTargetFrameworkIdentifierAndVersion">
+        <source>NETSDK1013: The TargetFramework value '{0}' was not recognized. It may be misspelled. If not, then the TargetFrameworkIdentifier and/or TargetFrameworkVersion properties must be specified explicitly.</source>
+        <target state="translated">NETSDK1013: 未识别 TargetFramework 值“{0}”。可能是因为拼写错误。如果拼写正确，必须显式指定 TargetFrameworkIdentifier 和/或 TargetFrameworkVersion 属性。</target>
+        <note>{StrBegin="NETSDK1013: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotUseSelfContainedWithoutAppHost">
+        <source>NETSDK1067: Self-contained applications are required to use the application host. Either set SelfContained to false or set UseAppHost to true.</source>
+        <target state="translated">NETSDK1067: 需要自包含应用程序才能使用应用程序主机。将 SelfContained 设置为 false，或者将 UseAppHost 设置为 true。</target>
+        <note>{StrBegin="NETSDK1067: "}</note>
       </trans-unit>
       <trans-unit id="ChoosingAssemblyVersion">
         <source>NETSDK1033: Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</source>
@@ -272,6 +132,16 @@
         <target state="translated">NETSDK1037: 由于文件和程序集版本相等，因此无法确定优胜者。</target>
         <note>{StrBegin="NETSDK1037: "}</note>
       </trans-unit>
+      <trans-unit id="ContentItemDoesNotProvideOutputPath">
+        <source>NETSDK1014: Content item for '{0}' sets '{1}', but does not provide  '{2}' or '{3}'.</source>
+        <target state="translated">NETSDK1014:“{0}”的内容项设置为“{1}”，但不提供“{2}”或“{3}”。</target>
+        <note>{StrBegin="NETSDK1014: "}</note>
+      </trans-unit>
+      <trans-unit id="ContentPreproccessorParameterRequired">
+        <source>NETSDK1010: The '{0}' task must be given a value for parameter '{1}' in order to consume preprocessed content.</source>
+        <target state="translated">NETSDK1010: 必须向“{0}”任务提供参数“{1}”的值以便使用预处理的内容。</target>
+        <note>{StrBegin="NETSDK1010: "}</note>
+      </trans-unit>
       <trans-unit id="CouldNotDetermineWinner_DoesntExist">
         <source>NETSDK1038: Could not determine winner because '{0}' does not exist.</source>
         <target state="translated">NETSDK1038: 由于“{0}”不存在，因此无法确定优胜者。</target>
@@ -287,15 +157,40 @@
         <target state="translated">NETSDK1040: 由于“{0}”不是程序集，因此无法确定优胜者。</target>
         <note>{StrBegin="NETSDK1040: "}</note>
       </trans-unit>
+      <trans-unit id="CouldNotLoadPlatformManifest">
+        <source>NETSDK1042: Could not load PlatformManifest from '{0}' because it did not exist.</source>
+        <target state="translated">NETSDK1042: 无法从“{0}”中加载 PlatformManifest，因为它不存在。</target>
+        <note>{StrBegin="NETSDK1042: "}</note>
+      </trans-unit>
+      <trans-unit id="DotnetToolDoesNotSupportTFMLowerThanNetcoreapp21">
+        <source>NETSDK1055: DotnetTool does not support target framework lower than netcoreapp2.1.</source>
+        <target state="translated">NETSDK1055: DotnetTool 不支持版本低于 netcoreapp2.1 的目标框架。</target>
+        <note>{StrBegin="NETSDK1055: "}</note>
+      </trans-unit>
+      <trans-unit id="DotnetToolOnlySupportNetcoreapp">
+        <source>NETSDK1054: only supports .NET Core.</source>
+        <target state="translated">NETSDK1054: 仅支持 .NET Core。</target>
+        <note>{StrBegin="NETSDK1054: "}</note>
+      </trans-unit>
+      <trans-unit id="DuplicateItemsError">
+        <source>NETSDK1022: Duplicate '{0}' items were included. The .NET SDK includes '{0}' items from your project directory by default. You can either remove these items from your project file, or set the '{1}' property to '{2}' if you want to explicitly include them in your project file. For more information, see {4}. The duplicate items were: {3}</source>
+        <target state="translated">NETSDK1022: 包含了重复的“{0}”项。.NET SDK 默认包含你项目目录中的“{0}”项。可从项目文件中删除这些项；如果希望将其显式包含在项目文件中，可将“{1}”属性设置为“{2}”。有关详细信息，请参阅 {4}。重复项为: {3}</target>
+        <note>{StrBegin="NETSDK1022: "}</note>
+      </trans-unit>
+      <trans-unit id="DuplicatePreprocessorToken">
+        <source>NETSDK1015: The preprocessor token '{0}' has been given more than one value. Choosing '{1}' as the value.</source>
+        <target state="translated">NETSDK1015: 已向预处理器标记“{0}”提供多个值。选择“{1}”作为值。</target>
+        <note>{StrBegin="NETSDK1015: "}</note>
+      </trans-unit>
       <trans-unit id="EncounteredConflict">
         <source>NETSDK1041: Encountered conflict between '{0}' and '{1}'.</source>
         <target state="translated">NETSDK1041:“{0}”和“{1}”之间存在冲突。</target>
         <note>{StrBegin="NETSDK1041: "}</note>
       </trans-unit>
-      <trans-unit id="CouldNotLoadPlatformManifest">
-        <source>NETSDK1042: Could not load PlatformManifest from '{0}' because it did not exist.</source>
-        <target state="translated">NETSDK1042: 无法从“{0}”中加载 PlatformManifest，因为它不存在。</target>
-        <note>{StrBegin="NETSDK1042: "}</note>
+      <trans-unit id="ErrorParsingFrameworkListInvalidValue">
+        <source>NETSDK1051: Error parsing FrameworkList from '{0}'.  {1} '{2}' was invalid.</source>
+        <target state="translated">NETSDK1051: 分析“{0}”中的 FrameworkList 时出错。{1}“{2}”无效。</target>
+        <note>{StrBegin="NETSDK1051: "}</note>
       </trans-unit>
       <trans-unit id="ErrorParsingPlatformManifest">
         <source>NETSDK1043: Error parsing PlatformManifest from '{0}' line {1}.  Lines must have the format {2}.</source>
@@ -307,65 +202,55 @@
         <target state="translated">NETSDK1044: 从“{0}”第 {1} 行处分析 PlatformManifest 时出错。{2} “{3}”无效。</target>
         <note>{StrBegin="NETSDK1044: "}</note>
       </trans-unit>
-      <trans-unit id="UnsupportedTargetFrameworkVersion">
-        <source>NETSDK1045: The current .NET SDK does not support targeting {0} {1}.  Either target {0} {2} or lower, or use a version of the .NET SDK that supports {0} {1}.</source>
-        <target state="translated">NETSDK1045: 当前 .NET SDK 不支持将 {0} {1} 设置为目标。请将 {0} {2} 或更低版本设置为目标，或使用支持 {0} {1} 的 .NET SDK 版本。</target>
-        <note>{StrBegin="NETSDK1045: "}</note>
+      <trans-unit id="ErrorReadingAssetsFile">
+        <source>NETSDK1060: Error reading assets file: {0}</source>
+        <target state="translated">NETSDK1060: 读取资产文件时出错: {0}</target>
+        <note>{StrBegin="NETSDK1060: "}</note>
       </trans-unit>
-      <trans-unit id="AssetsFileMissingRuntimeIdentifier">
-        <source>NETSDK1047: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project. You may also need to include '{3}' in your project's RuntimeIdentifiers.</source>
-        <target state="translated">NETSDK1047: 资产文件“{0}”没有“{1}”的目标。确保已运行还原，且“{2}”已包含在项目的 TargetFrameworks 中。可能需要在项目 RuntimeIdentifiers 中包括“{3}”。</target>
-        <note>{StrBegin="NETSDK1047: "}</note>
+      <trans-unit id="FailedToLockResource">
+        <source>NETSDK1077: Failed to lock resource.</source>
+        <target state="translated">NETSDK1077: 未能锁定资源。</target>
+        <note>{StrBegin="NETSDK1077: "}</note>
       </trans-unit>
-      <trans-unit id="TargetFrameworkWithSemicolon">
-        <source>NETSDK1046: The TargetFramework value '{0}' is not valid. To multi-target, use the 'TargetFrameworks' property instead.</source>
-        <target state="translated">NETSDK1046: TargetFramework 值“{0}”无效。若要设置多个目标，请改用 "TargetFrameworks" 属性。</target>
-        <note>{StrBegin="NETSDK1046: "}</note>
+      <trans-unit id="FileNameIsTooLong">
+        <source>NETSDK1030: Given file name '{0}' is longer than 1024 bytes</source>
+        <target state="translated">NETSDK1030: 给定文件名“{0}”的长度超过 1024 个字节</target>
+        <note>{StrBegin="NETSDK1030: "}</note>
       </trans-unit>
-      <trans-unit id="GetDependsOnNETStandardFailedWithException">
-        <source>NETSDK1049: Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0} {1}</source>
-        <target state="translated">NETSDK1049: 解析的文件包含错误图像、无元数据或不可访问。{0} {1}</target>
-        <note>{StrBegin="NETSDK1049: "}</note>
+      <trans-unit id="FolderAlreadyExists">
+        <source>NETSDK1024: Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</source>
+        <target state="translated">NETSDK1024: 文件夹“{0}”已存在，请将其删除或提供不同的 ComposeWorkingDir</target>
+        <note>{StrBegin="NETSDK1024: "}</note>
       </trans-unit>
-      <trans-unit id="UnsupportedSDKVersionForNetStandard20">
-        <source>NETSDK1050: The version of Microsoft.NET.Sdk used by this project is insufficient to support references to libraries targeting .NET Standard 1.5 or higher.  Please install version 2.0 or higher of the .NET Core SDK.</source>
-        <target state="translated">NETSDK1050: 该项目使用的 Microsoft.NET.Sdk 版本过低，不支持对面向.NET Standard 1.5 或更高版本的库的引用。请安装 2.0 版本或更高版本的 .NET Core SDK。</target>
-        <note>{StrBegin="NETSDK1050: "}</note>
-      </trans-unit>
-      <trans-unit id="SkippingAdditionalProbingPaths">
-        <source>NETSDK1048: 'AdditionalProbingPaths' were specified for GenerateRuntimeConfigurationFiles, but are being skipped because 'RuntimeConfigDevPath' is empty.</source>
-        <target state="translated">NETSDK1048: "AdditionalProbingPaths" 被指定给 GenerateRuntimeConfigurationFiles，但被跳过，因为 "RuntimeConfigDevPath" 为空。</target>
-        <note>{StrBegin="NETSDK1048: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotHaveRuntimeIdentifierPlatformMismatchPlatformTarget">
-        <source>NETSDK1032: The RuntimeIdentifier platform '{0}' and the PlatformTarget '{1}' must be compatible.</source>
-        <target state="translated">NETSDK1032: RuntimeIdentifier 平台“{0}”和 PlatformTarget“{1}”必须兼容。</target>
-        <note>{StrBegin="NETSDK1032: "}</note>
-      </trans-unit>
-      <trans-unit id="ErrorParsingFrameworkListInvalidValue">
-        <source>NETSDK1051: Error parsing FrameworkList from '{0}'.  {1} '{2}' was invalid.</source>
-        <target state="translated">NETSDK1051: 分析“{0}”中的 FrameworkList 时出错。{1}“{2}”无效。</target>
-        <note>{StrBegin="NETSDK1051: "}</note>
+      <trans-unit id="FrameworkDependentAppHostRequiresVersion21">
+        <source>NETSDK1068: The framework-dependent application host requires a target framework of at least 'netcoreapp2.1'.</source>
+        <target state="translated">NETSDK1068: 框架依赖型应用程序主机需要一个至少 “netcoreapp2.1” 的目标框架。</target>
+        <note>{StrBegin="NETSDK1068: "}</note>
       </trans-unit>
       <trans-unit id="FrameworkListPathNotRooted">
         <source>NETSDK1052: Framework list file path '{0}' is not rooted. Only full paths are supported.</source>
         <target state="translated">NETSDK1052: 框架列表路径“{0}”不是根路径。仅支持完整路径。</target>
         <note>{StrBegin="NETSDK1052: "}</note>
       </trans-unit>
-      <trans-unit id="PackAsToolCannotSupportSelfContained">
-        <source>NETSDK1053: Pack as tool does not support self contained.</source>
-        <target state="translated">NETSDK1053: 打包为工具不支持自包含。</target>
-        <note>{StrBegin="NETSDK1001: "}</note>
+      <trans-unit id="GetDependsOnNETStandardFailedWithException">
+        <source>NETSDK1049: Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0} {1}</source>
+        <target state="translated">NETSDK1049: 解析的文件包含错误图像、无元数据或不可访问。{0} {1}</target>
+        <note>{StrBegin="NETSDK1049: "}</note>
       </trans-unit>
-      <trans-unit id="UnsupportedRuntimeIdentifier">
-        <source>NETSDK1056: Project is targeting runtime '{0}' but did not resolve any runtime-specific packages. This runtime may not be supported by the target framework.</source>
-        <target state="translated">NETSDK1056: 项目的目标是运行时“{0}”，但未解析任何运行时特定的包。目标框架可能不支持此运行时。</target>
-        <note>{StrBegin="NETSDK1056: "}</note>
+      <trans-unit id="IncorrectPackageRoot">
+        <source>NETSDK1020: Package Root {0} was incorrectly given for Resolved library {1}</source>
+        <target state="translated">NETSDK1020: 对于“已解析”库 {1}，包根目录 {0} 分配错误</target>
+        <note>{StrBegin="NETSDK1020: "}</note>
       </trans-unit>
-      <trans-unit id="UsingPreviewSdkWarning">
-        <source>NETSDK1057: You are using a preview version of .NET Core. See: https://aka.ms/dotnet-core-preview</source>
-        <target state="translated">NETSDK1057: 你正在使用 .NET Core 的预览版。请查看 https://aka.ms/dotnet-core-preview</target>
-        <note>{StrBegin="NETSDK1057: "}</note>
+      <trans-unit id="IncorrectTargetFormat">
+        <source>NETSDK1025: WRThe target manifest {0} provided is of not the correct format</source>
+        <target state="translated">NETSDK1025: 指定的目标清单 {0} 的格式不正确</target>
+        <note>{StrBegin="NETSDK1025: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidFrameworkName">
+        <source>NETSDK1003: Invalid framework name: '{0}'.</source>
+        <target state="translated">NETSDK1003: 无效的框架名称:“{0}”。</target>
+        <note>{StrBegin="NETSDK1003: "}</note>
       </trans-unit>
       <trans-unit id="InvalidItemSpecToUse">
         <source>NETSDK1058: Invalid value for ItemSpecToUse parameter: '{0}'.  This property must be blank or set to 'Left' or 'Right'</source>
@@ -373,15 +258,15 @@
         <note>{StrBegin="NETSDK1058: "}
 The following are names of parameters or literal values and should not be translated: ItemSpecToUse, Left, Right</note>
       </trans-unit>
-      <trans-unit id="ProjectContainsObsoleteDotNetCliTool">
-        <source>NETSDK1059: The tool '{0}' is now included in the .NET Core SDK. Information on resolving this warning is available at (https://aka.ms/dotnetclitools-in-box).</source>
-        <target state="translated">NETSDK1059: .NET Core SDK 中现已包含工具“{0}”。有关解决此警告的信息，请参阅(https://aka.ms/dotnetclitools-in-box)。</target>
-        <note>{StrBegin="NETSDK1059: "}</note>
+      <trans-unit id="InvalidNuGetVersionString">
+        <source>NETSDK1018: Invalid NuGet version string: '{0}'.</source>
+        <target state="translated">NETSDK1018: 无效的 NuGet 版本字符串:“{0}”。</target>
+        <note>{StrBegin="NETSDK1018: "}</note>
       </trans-unit>
-      <trans-unit id="ErrorReadingAssetsFile">
-        <source>NETSDK1060: Error reading assets file: {0}</source>
-        <target state="translated">NETSDK1060: 读取资产文件时出错: {0}</target>
-        <note>{StrBegin="NETSDK1060: "}</note>
+      <trans-unit id="InvalidResourceUpdate">
+        <source>NETSDK1075: Update handle is invalid. This instance may not be used for further updates.</source>
+        <target state="translated">NETSDK1075: 更新句柄无效。此实例不能用于进一步的更新。</target>
+        <note>{StrBegin="NETSDK1075: "}</note>
       </trans-unit>
       <trans-unit id="MismatchedPlatformPackageVersion">
         <source>NETSDK1061: The project was restored using {0} version {1}, but with current settings, version {2} would be used instead. To resolve this issue, make sure the same settings are used for restore and for subsequent operations such as build or publish. Typically this issue can occur if the RuntimeIdentifier property is set during build or publish but not during restore. For more information, see https://aka.ms/dotnet-runtime-patch-selection.</source>
@@ -391,35 +276,150 @@ The following are names of parameters or literal values and should not be transl
 {1} - Restored version of platform package
 {2} - Current version of platform package</note>
       </trans-unit>
-      <trans-unit id="AssetsFileNotSet">
-        <source>NETSDK1063: The path to the project assets file was not set. Run a NuGet package restore to generate this file.</source>
-        <target state="translated">NETSDK1063: 未设置项目资产文件的路径。运行 NuGet 程序包还原以生成此文件。</target>
-        <note>{StrBegin="NETSDK1063: "}</note>
+      <trans-unit id="MissingItemMetadata">
+        <source>NETSDK1008: Missing '{0}' metadata on '{1}' item '{2}'.</source>
+        <target state="translated">NETSDK1008: 在“{1}”项“{2}”上缺少“{0}”元数据。</target>
+        <note>{StrBegin="NETSDK1008: "}</note>
       </trans-unit>
-      <trans-unit id="DotnetToolOnlySupportNetcoreapp">
-        <source>NETSDK1054: only supports .NET Core.</source>
-        <target state="translated">NETSDK1054: 仅支持 .NET Core。</target>
-        <note>{StrBegin="NETSDK1054: "}</note>
+      <trans-unit id="MultipleFilesResolved">
+        <source>NETSDK1021: More than one file found for {0}</source>
+        <target state="translated">NETSDK1021: 找到 {0} 的多个文件</target>
+        <note>{StrBegin="NETSDK1021: "}</note>
       </trans-unit>
-      <trans-unit id="DotnetToolDoesNotSupportTFMLowerThanNetcoreapp21">
-        <source>NETSDK1055: DotnetTool does not support target framework lower than netcoreapp2.1.</source>
-        <target state="translated">NETSDK1055: DotnetTool 不支持版本低于 netcoreapp2.1 的目标框架。</target>
-        <note>{StrBegin="NETSDK1055: "}</note>
+      <trans-unit id="NETFrameworkToNonBuiltInNETStandard">
+        <source>NETSDK1069: This project uses a library that targets .NET Standard 1.5 or higher, and the project targets a version of .NET Framework that doesn't have built-in support for that version of .NET Standard. Visit https://aka.ms/net-standard-known-issues for a set of known issues. Consider retargeting to .NET Framework 4.7.2.</source>
+        <target state="translated">NETSDK1069: 此项目使用了一个面向 .NET Standard 1.5 或更高版本的库，且此项目面向一个没有对该版本的 .NET Standard 的内置支持的 .NET Framework 版本。请访问 https://aka.ms/net-standard-known-issues 了解一些已知问题。考虑重定向到 .NET Framework 4.7.2。</target>
+        <note>{StrBegin="NETSDK1069: "}</note>
       </trans-unit>
-      <trans-unit id="UnableToUsePackageAssetsCache">
-        <source>NETSDK1062: Unable to use package assets cache due to I/O error. This can occur when the same project is built more than once in parallel. Performance may be degraded, but the build result will not be impacted.</source>
-        <target state="translated">NETSDK1062: 由于 I/O 错误，不能使用程序包资产缓存。如果不止一次地并行生成同样的项目，也可能出现这种情况。可能会降低性能，但是不影响生成结果。</target>
-        <note>{StrBegin="NETSDK1062: "}</note>
+      <trans-unit id="NoAppHostAvailable">
+        <source>NETSDK1084: There is no application host available for the specified RuntimeIdentifier '{0}'.</source>
+        <target state="new">NETSDK1084: There is no application host available for the specified RuntimeIdentifier '{0}'.</target>
+        <note>{StrBegin="NETSDK1084: "}</note>
+      </trans-unit>
+      <trans-unit id="NoCompatibleTargetFramework">
+        <source>NETSDK1002: Project '{0}' targets '{2}'. It cannot be referenced by a project that targets '{1}'.</source>
+        <target state="translated">NETSDK1002: 项目“{0}”以“{2}”为目标。它不可由面向“{1}”的项目引用。</target>
+        <note>{StrBegin="NETSDK1002: "}</note>
+      </trans-unit>
+      <trans-unit id="NoRuntimePackAvailable">
+        <source>NETSDK1082: There was no runtime pack for {0} available for the specified RuntimeIdentifier '{1}'.</source>
+        <target state="new">NETSDK1082: There was no runtime pack for {0} available for the specified RuntimeIdentifier '{1}'.</target>
+        <note>{StrBegin="NETSDK1082: "}</note>
+      </trans-unit>
+      <trans-unit id="PackAsToolCannotSupportSelfContained">
+        <source>NETSDK1053: Pack as tool does not support self contained.</source>
+        <target state="translated">NETSDK1053: 打包为工具不支持自包含。</target>
+        <note>{StrBegin="NETSDK1001: "}</note>
+      </trans-unit>
+      <trans-unit id="PackageInfoLog">
+        <source>NETSDK1027: Package Name='{0}', Version='{1}' was parsed</source>
+        <target state="translated">NETSDK1027: 已分析出包名称为“{0}”、版本为“{1}”</target>
+        <note>{StrBegin="NETSDK1027: "}</note>
       </trans-unit>
       <trans-unit id="PackageNotFound">
         <source>NETSDK1064: Package {0}, version {1} was not found. It might have been deleted since NuGet restore. Otherwise, NuGet restore might have only partially completed, which might have been due to maximum path length restrictions.</source>
         <target state="translated">NETSDK1064: 未找到版本为 {1} 的包 {0}。它可能已在 NuGet 还原后删除。否则，NuGet 还原可能只是部分完成，这种情况可能是最大路径长度限制所导致。</target>
         <note>{StrBegin="NETSDK1064: "}</note>
       </trans-unit>
-      <trans-unit id="CannotFindApphostForRid">
-        <source>NETSDK1065: Cannot find app host for {0}. {0} could be an invalid runtime identifier (RID). For more information about RID, see https://aka.ms/rid-catalog.</source>
-        <target state="translated">NETSDK1065: 无法找到 {0} 的应用主机。{0} 可能是无效的运行时标识符(RID)。有关 RID 的详细信息，请参阅 https://aka.ms/rid-catalog。</target>
-        <note>{StrBegin="NETSDK1065: "}</note>
+      <trans-unit id="PackageReferenceOverrideWarning">
+        <source>NETSDK1023: A PackageReference for '{0}' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see {1}</source>
+        <target state="translated">NETSDK1023: 项目中包含了“{0}”的 PackageReference。此包由 .NET SDK 隐式引用，且通常情况下你无需从项目中对其进行引用。有关详细信息，请参阅 {1}</target>
+        <note>{StrBegin="NETSDK1023: "}</note>
+      </trans-unit>
+      <trans-unit id="PackageReferenceVersionNotRecommended">
+        <source>NETSDK1071: A PackageReference to '{0}' specified a Version of `{1}`. Specifying the version of this package is not recommended. For more information, see https://aka.ms/sdkimplicitrefs</source>
+        <target state="translated">NETSDK1071:“{0}”的 PackageReference 指定了版本“{1}”。不建议指定此包的版本。有关详细信息，请查看 https://aka.ms/sdkimplicitrefs</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParsingFiles">
+        <source>NETSDK1026: Parsing the Files : '{0}'</source>
+        <target state="translated">NETSDK1026: 正在分析文件:“{0}”</target>
+        <note>{StrBegin="NETSDK1026: "}</note>
+      </trans-unit>
+      <trans-unit id="ProjectAssetsConsumedWithoutMSBuildProjectPath">
+        <source>NETSDK1011: Assets are consumed from project '{0}', but no corresponding MSBuild project path was  found in '{1}'.</source>
+        <target state="translated">NETSDK1011: 从项目“{0}”消耗资产，但在“{1}”中找不到相应的 MSBuild 项目路径。</target>
+        <note>{StrBegin="NETSDK1011: "}</note>
+      </trans-unit>
+      <trans-unit id="ProjectContainsObsoleteDotNetCliTool">
+        <source>NETSDK1059: The tool '{0}' is now included in the .NET Core SDK. Information on resolving this warning is available at (https://aka.ms/dotnetclitools-in-box).</source>
+        <target state="translated">NETSDK1059: .NET Core SDK 中现已包含工具“{0}”。有关解决此警告的信息，请参阅(https://aka.ms/dotnetclitools-in-box)。</target>
+        <note>{StrBegin="NETSDK1059: "}</note>
+      </trans-unit>
+      <trans-unit id="RuntimeIdentifierNotRecognized">
+        <source>NETSDK1083: The specified RuntimeIdentifier '{0}' is not recognized.</source>
+        <target state="new">NETSDK1083: The specified RuntimeIdentifier '{0}' is not recognized.</target>
+        <note>{StrBegin="NETSDK1083: "}</note>
+      </trans-unit>
+      <trans-unit id="RuntimeIdentifierWasNotSpecified">
+        <source>NETSDK1028: Specify a RuntimeIdentifier</source>
+        <target state="translated">NETSDK1028: 指定一个 RuntimeIdentifier</target>
+        <note>{StrBegin="NETSDK1028: "}</note>
+      </trans-unit>
+      <trans-unit id="SkippingAdditionalProbingPaths">
+        <source>NETSDK1048: 'AdditionalProbingPaths' were specified for GenerateRuntimeConfigurationFiles, but are being skipped because 'RuntimeConfigDevPath' is empty.</source>
+        <target state="translated">NETSDK1048: "AdditionalProbingPaths" 被指定给 GenerateRuntimeConfigurationFiles，但被跳过，因为 "RuntimeConfigDevPath" 为空。</target>
+        <note>{StrBegin="NETSDK1048: "}</note>
+      </trans-unit>
+      <trans-unit id="TargetFrameworkWithSemicolon">
+        <source>NETSDK1046: The TargetFramework value '{0}' is not valid. To multi-target, use the 'TargetFrameworks' property instead.</source>
+        <target state="translated">NETSDK1046: TargetFramework 值“{0}”无效。若要设置多个目标，请改用 "TargetFrameworks" 属性。</target>
+        <note>{StrBegin="NETSDK1046: "}</note>
+      </trans-unit>
+      <trans-unit id="UnableToFindResolvedPath">
+        <source>NETSDK1016: Unable to find resolved path for '{0}'.</source>
+        <target state="translated">NETSDK1016: 无法找到“{0}”的已解析路径。</target>
+        <note>{StrBegin="NETSDK1016: "}</note>
+      </trans-unit>
+      <trans-unit id="UnableToUsePackageAssetsCache">
+        <source>NETSDK1062: Unable to use package assets cache due to I/O error. This can occur when the same project is built more than once in parallel. Performance may be degraded, but the build result will not be impacted.</source>
+        <target state="translated">NETSDK1062: 由于 I/O 错误，不能使用程序包资产缓存。如果不止一次地并行生成同样的项目，也可能出现这种情况。可能会降低性能，但是不影响生成结果。</target>
+        <note>{StrBegin="NETSDK1062: "}</note>
+      </trans-unit>
+      <trans-unit id="UnexpectedFileType">
+        <source>NETSDK1012: Unexpected file type for '{0}'. Type is both '{1}' and '{2}'.</source>
+        <target state="translated">NETSDK1012:“{0}”的文件类型非预期。类型是“{1}”和“{2}”。</target>
+        <note>{StrBegin="NETSDK1012: "}</note>
+      </trans-unit>
+      <trans-unit id="UnknownFrameworkReference">
+        <source>NETSDK1073: The FrameworkReference '{0}' was not recognized</source>
+        <target state="translated">NETSDK1073: 未能识别 FrameworkReference“{0}”</target>
+        <note>{StrBegin="NETSDK1073: "}</note>
+      </trans-unit>
+      <trans-unit id="UnrecognizedPreprocessorToken">
+        <source>NETSDK1009: Unrecognized preprocessor token '{0}' in '{1}'.</source>
+        <target state="translated">NETSDK1009:“{1}”中无法识别预处理器标记“{0}”。</target>
+        <note>{StrBegin="NETSDK1009: "}</note>
+      </trans-unit>
+      <trans-unit id="UnresolvedTargetingPack">
+        <source>NETSDK1081: The targeting pack for {0} was not found. You may be able to resolve this by running a NuGet restore on the project.</source>
+        <target state="new">NETSDK1081: The targeting pack for {0} was not found. You may be able to resolve this by running a NuGet restore on the project.</target>
+        <note>{StrBegin="NETSDK1081: "}</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedFramework">
+        <source>NETSDK1019: {0} is an unsupported framework.</source>
+        <target state="translated">NETSDK1019: {0} 是不受支持的框架。</target>
+        <note>{StrBegin="NETSDK1019: "}</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedRuntimeIdentifier">
+        <source>NETSDK1056: Project is targeting runtime '{0}' but did not resolve any runtime-specific packages. This runtime may not be supported by the target framework.</source>
+        <target state="translated">NETSDK1056: 项目的目标是运行时“{0}”，但未解析任何运行时特定的包。目标框架可能不支持此运行时。</target>
+        <note>{StrBegin="NETSDK1056: "}</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedSDKVersionForNetStandard20">
+        <source>NETSDK1050: The version of Microsoft.NET.Sdk used by this project is insufficient to support references to libraries targeting .NET Standard 1.5 or higher.  Please install version 2.0 or higher of the .NET Core SDK.</source>
+        <target state="translated">NETSDK1050: 该项目使用的 Microsoft.NET.Sdk 版本过低，不支持对面向.NET Standard 1.5 或更高版本的库的引用。请安装 2.0 版本或更高版本的 .NET Core SDK。</target>
+        <note>{StrBegin="NETSDK1050: "}</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedTargetFrameworkVersion">
+        <source>NETSDK1045: The current .NET SDK does not support targeting {0} {1}.  Either target {0} {2} or lower, or use a version of the .NET SDK that supports {0} {1}.</source>
+        <target state="translated">NETSDK1045: 当前 .NET SDK 不支持将 {0} {1} 设置为目标。请将 {0} {2} 或更低版本设置为目标，或使用支持 {0} {1} 的 .NET SDK 版本。</target>
+        <note>{StrBegin="NETSDK1045: "}</note>
+      </trans-unit>
+      <trans-unit id="UsingPreviewSdkWarning">
+        <source>NETSDK1057: You are using a preview version of .NET Core. See: https://aka.ms/dotnet-core-preview</source>
+        <target state="translated">NETSDK1057: 你正在使用 .NET Core 的预览版。请查看 https://aka.ms/dotnet-core-preview</target>
+        <note>{StrBegin="NETSDK1057: "}</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
@@ -2,35 +2,25 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../Strings.resx">
     <body>
-      <trans-unit id="AspNetCoreAllNotSupported">
-        <source>NETSDK1079: The Microsoft.AspNetCore.All package is not supported when targeting .NET Core 3.0 or higher.  A FrameworkReference to Microsoft.AspNetCore.App should be used instead, and will be implicitly included by Microsoft.NET.Sdk.Web.</source>
-        <target state="translated">NETSDK1079: 當目標為 .NET Core 3.0 或更新版本時，不支援 Microsoft.AspNetCore.All 套件。應改用 Microsoft.AspNetCore.App 的 FrameworkReference，並明確包含在 Microsoft.NET.Sdk.Web 中。</target>
-        <note>{StrBegin="NETSDK1079: "}</note>
-      </trans-unit>
-      <trans-unit id="AspNetCoreUsesFrameworkReference">
-        <source>NETSDK1080: A PackageReference to Microsoft.AspNetCore.App is not necessary when targeting .NET Core 3.0 or higher. If Microsoft.NET.Sdk.Web is used, the shared framework will be referenced automatically. Otherwise, the PackageReference should be replaced with a FrameworkReference.</source>
-        <target state="translated">NETSDK1080: 當目標為 .NET Core 3.0 或更新版本時，不一定要有 Microsoft.AspNetCore.App 的 PackageReference。若使用了 Microsoft.NET.Sdk.Web，就會自動參考共用架構。否則，應以 FrameworkReference 取代 PackageReference。</target>
-        <note>{StrBegin="NETSDK1080: "}</note>
-      </trans-unit>
-      <trans-unit id="FailedToLockResource">
-        <source>NETSDK1077: Failed to lock resource.</source>
-        <target state="translated">NETSDK1077: 無法鎖定資源。</target>
-        <note>{StrBegin="NETSDK1077: "}</note>
-      </trans-unit>
       <trans-unit id="AddResourceWithNonIntegerResource">
         <source>NETSDK1076: AddResource can only be used with integer resource types.</source>
         <target state="translated">NETSDK1076: AddResource 只能搭配整數資源類型使用。</target>
         <note>{StrBegin="NETSDK1076: "}</note>
       </trans-unit>
-      <trans-unit id="InvalidResourceUpdate">
-        <source>NETSDK1075: Update handle is invalid. This instance may not be used for further updates.</source>
-        <target state="translated">NETSDK1075: 更新控制代碼無效。此執行個體無法用於後續更新。</target>
-        <note>{StrBegin="NETSDK1075: "}</note>
+      <trans-unit id="AppConfigRequiresRootConfiguration">
+        <source>NETSDK1070: The application configuration file must have root configuration element.</source>
+        <target state="translated">NETSDK1070: 應用程式組態檔必須有根組態元素。</target>
+        <note>{StrBegin="NETSDK1070: "}</note>
       </trans-unit>
       <trans-unit id="AppHostCustomizationRequiresWindowsHostWarning">
         <source>NETSDK1074: The application host executable will not be customized because adding resources requires that the build be performed on Windows (excluding Nano Server).</source>
         <target state="translated">NETSDK1074: 因為新增資源會需要在 Windows 執行組建 (Nano Server 除外)，所以不會自訂應用程式主機可執行檔。</target>
         <note>{StrBegin="NETSDK1074: "}</note>
+      </trans-unit>
+      <trans-unit id="AppHostHasBeenModified">
+        <source>NETSDK1029: Unable to use '{0}' as application host executable as it does not contain the expected placeholder byte sequence '{1}' that would mark where the application name would be written.</source>
+        <target state="translated">NETSDK1029: 無法使用 '{0}' 作為應用程式主機可執行檔，因為它並未包含應有的預留位置位元組序列 '{1}'，其會標示寫入應用程式名稱的位置。</target>
+        <note>{StrBegin="NETSDK1029: "}</note>
       </trans-unit>
       <trans-unit id="AppHostNotWindows">
         <source>NETSDK1078: Unable to use '{0}' as application host executable because it's not a Windows PE file.</source>
@@ -42,210 +32,80 @@
         <target state="translated">NETSDK1072: 因為 '{0}' 不是 CUI (主控台) 子系統的 Windows 可執行檔，所以無法用作應用程式主機可執行檔。</target>
         <note>{StrBegin="NETSDK1072: "}</note>
       </trans-unit>
-      <trans-unit id="AppConfigRequiresRootConfiguration">
-        <source>NETSDK1070: The application configuration file must have root configuration element.</source>
-        <target state="translated">NETSDK1070: 應用程式組態檔必須有根組態元素。</target>
-        <note>{StrBegin="NETSDK1070: "}</note>
+      <trans-unit id="AspNetCoreAllNotSupported">
+        <source>NETSDK1079: The Microsoft.AspNetCore.All package is not supported when targeting .NET Core 3.0 or higher.  A FrameworkReference to Microsoft.AspNetCore.App should be used instead, and will be implicitly included by Microsoft.NET.Sdk.Web.</source>
+        <target state="translated">NETSDK1079: 當目標為 .NET Core 3.0 或更新版本時，不支援 Microsoft.AspNetCore.All 套件。應改用 Microsoft.AspNetCore.App 的 FrameworkReference，並明確包含在 Microsoft.NET.Sdk.Web 中。</target>
+        <note>{StrBegin="NETSDK1079: "}</note>
       </trans-unit>
-      <trans-unit id="AtLeastOneTargetFrameworkMustBeSpecified">
-        <source>NETSDK1001: At least one possible target framework must be specified.</source>
-        <target state="translated">NETSDK1001: 至少必須指定一個可能的目標架構。</target>
-        <note>{StrBegin="NETSDK1001: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotUseSelfContainedWithoutAppHost">
-        <source>NETSDK1067: Self-contained applications are required to use the application host. Either set SelfContained to false or set UseAppHost to true.</source>
-        <target state="translated">NETSDK1067: 需要獨立式應用程式，才可使用該應用程式主機。請將 SelfContained 設定為 False，或是將 UseAppHost 設定為 True。</target>
-        <note>{StrBegin="NETSDK1067: "}</note>
-      </trans-unit>
-      <trans-unit id="FrameworkDependentAppHostRequiresVersion21">
-        <source>NETSDK1068: The framework-dependent application host requires a target framework of at least 'netcoreapp2.1'.</source>
-        <target state="translated">NETSDK1068: 與架構相依的應用程式主機，至少需要 'netcoreapp2.1' 的目標架構。</target>
-        <note>{StrBegin="NETSDK1068: "}</note>
-      </trans-unit>
-      <trans-unit id="NETFrameworkToNonBuiltInNETStandard">
-        <source>NETSDK1069: This project uses a library that targets .NET Standard 1.5 or higher, and the project targets a version of .NET Framework that doesn't have built-in support for that version of .NET Standard. Visit https://aka.ms/net-standard-known-issues for a set of known issues. Consider retargeting to .NET Framework 4.7.2.</source>
-        <target state="translated">NETSDK1069: 此專案使用以 .NET Standard 1.5 或更新版本為目標的程式庫，而專案的目標 .NET Framework 版本則為尚未具備該 .NET Standard 版本內建支援的 .NET Framework。請瀏覽 https://aka.ms/net-standard-known-issues，以了解已知問題的集合。請考慮轉為以 .NET Framework 4.7.2 為目標。</target>
-        <note>{StrBegin="NETSDK1069: "}</note>
-      </trans-unit>
-      <trans-unit id="NoAppHostAvailable">
-        <source>NETSDK1084: There is no application host available for the specified RuntimeIdentifier '{0}'.</source>
-        <target state="new">NETSDK1084: There is no application host available for the specified RuntimeIdentifier '{0}'.</target>
-        <note>{StrBegin="NETSDK1084: "}</note>
-      </trans-unit>
-      <trans-unit id="NoCompatibleTargetFramework">
-        <source>NETSDK1002: Project '{0}' targets '{2}'. It cannot be referenced by a project that targets '{1}'.</source>
-        <target state="translated">NETSDK1002: 專案 '{0}' 以 '{2}' 為目標。以 '{1}' 為目標的專案無法參考此專案。</target>
-        <note>{StrBegin="NETSDK1002: "}</note>
-      </trans-unit>
-      <trans-unit id="InvalidFrameworkName">
-        <source>NETSDK1003: Invalid framework name: '{0}'.</source>
-        <target state="translated">NETSDK1003: 架構名稱 '{0}' 無效。</target>
-        <note>{StrBegin="NETSDK1003: "}</note>
-      </trans-unit>
-      <trans-unit id="AssetsFileNotFound">
-        <source>NETSDK1004: Assets file '{0}' not found. Run a NuGet package restore to generate this file.</source>
-        <target state="translated">NETSDK1004: 找不到資產檔案 '{0}'。請執行 NuGet 套件還原，以產生此檔案。</target>
-        <note>{StrBegin="NETSDK1004: "}</note>
-      </trans-unit>
-      <trans-unit id="AssetsFileMissingTarget">
-        <source>NETSDK1005: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project.</source>
-        <target state="translated">NETSDK1005: 資產檔 '{0}' 沒有 '{1}' 的目標。請確定已執行還原作業，且在您專案的 TargetFrameworks 中已納入 '{2}'。</target>
-        <note>{StrBegin="NETSDK1005: "}</note>
-      </trans-unit>
-      <trans-unit id="AssetsFilePathNotRooted">
-        <source>NETSDK1006: Assets file path '{0}' is not rooted. Only full paths are supported.</source>
-        <target state="translated">NETSDK1006: 資產檔案路徑 '{0}' 並非根目錄。僅支援完整的路徑。</target>
-        <note>{StrBegin="NETSDK1006: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotFindProjectInfo">
-        <source>NETSDK1007: Cannot find project info for '{0}'. This can indicate a missing project reference.</source>
-        <target state="translated">NETSDK1007: 找不到 '{0}' 的專案資訊。這可能表示遺漏專案參考。</target>
-        <note>{StrBegin="NETSDK1007: "}</note>
-      </trans-unit>
-      <trans-unit id="MissingItemMetadata">
-        <source>NETSDK1008: Missing '{0}' metadata on '{1}' item '{2}'.</source>
-        <target state="translated">NETSDK1008: '{1}' 項目 '{2}' 上遺漏 '{0}' 中繼資料。</target>
-        <note>{StrBegin="NETSDK1008: "}</note>
-      </trans-unit>
-      <trans-unit id="NoRuntimePackAvailable">
-        <source>NETSDK1082: There was no runtime pack for {0} available for the specified RuntimeIdentifier '{1}'.</source>
-        <target state="new">NETSDK1082: There was no runtime pack for {0} available for the specified RuntimeIdentifier '{1}'.</target>
-        <note>{StrBegin="NETSDK1082: "}</note>
-      </trans-unit>
-      <trans-unit id="PackageReferenceVersionNotRecommended">
-        <source>NETSDK1071: A PackageReference to '{0}' specified a Version of `{1}`. Specifying the version of this package is not recommended. For more information, see https://aka.ms/sdkimplicitrefs</source>
-        <target state="translated">NETSDK1071: '{0}' 的 PackageReference 指定了 `{1}` 版本。不建議指定這個套件版本。如需詳細資訊，請參閱 https://aka.ms/sdkimplicitrefs</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="RuntimeIdentifierNotRecognized">
-        <source>NETSDK1083: The specified RuntimeIdentifier '{0}' is not recognized.</source>
-        <target state="new">NETSDK1083: The specified RuntimeIdentifier '{0}' is not recognized.</target>
-        <note>{StrBegin="NETSDK1083: "}</note>
-      </trans-unit>
-      <trans-unit id="UnknownFrameworkReference">
-        <source>NETSDK1073: The FrameworkReference '{0}' was not recognized</source>
-        <target state="translated">NETSDK1073: 無法辨識 FrameworkReference '{0}'</target>
-        <note>{StrBegin="NETSDK1073: "}</note>
-      </trans-unit>
-      <trans-unit id="UnrecognizedPreprocessorToken">
-        <source>NETSDK1009: Unrecognized preprocessor token '{0}' in '{1}'.</source>
-        <target state="translated">NETSDK1009: '{1}' 中的前置處理器語彙基元 '{0}' 無法辨識。</target>
-        <note>{StrBegin="NETSDK1009: "}</note>
-      </trans-unit>
-      <trans-unit id="ContentPreproccessorParameterRequired">
-        <source>NETSDK1010: The '{0}' task must be given a value for parameter '{1}' in order to consume preprocessed content.</source>
-        <target state="translated">NETSDK1010: 必須為 '{0}' 工作指定參數 '{1}' 的值，才可取用前置處理過的內容。</target>
-        <note>{StrBegin="NETSDK1010: "}</note>
-      </trans-unit>
-      <trans-unit id="ProjectAssetsConsumedWithoutMSBuildProjectPath">
-        <source>NETSDK1011: Assets are consumed from project '{0}', but no corresponding MSBuild project path was  found in '{1}'.</source>
-        <target state="translated">NETSDK1011: 已從專案 '{0}' 取用資產，但在 '{1}' 中找不到相對應的 MSBuild 專案路徑。</target>
-        <note>{StrBegin="NETSDK1011: "}</note>
-      </trans-unit>
-      <trans-unit id="UnexpectedFileType">
-        <source>NETSDK1012: Unexpected file type for '{0}'. Type is both '{1}' and '{2}'.</source>
-        <target state="translated">NETSDK1012: 對 '{0}' 來說並非預期的檔案類型。類型為 '{1}' 和 '{2}'。</target>
-        <note>{StrBegin="NETSDK1012: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotInferTargetFrameworkIdentifierAndVersion">
-        <source>NETSDK1013: The TargetFramework value '{0}' was not recognized. It may be misspelled. If not, then the TargetFrameworkIdentifier and/or TargetFrameworkVersion properties must be specified explicitly.</source>
-        <target state="translated">NETSDK1013: 無法辨識 TargetFramework 值 '{0}'。拼字可能有誤。若非此情況，即必須明確指定 TargetFrameworkIdentifier 及 (或) TargetFrameworkVersion 屬性。</target>
-        <note>{StrBegin="NETSDK1013: "}</note>
-      </trans-unit>
-      <trans-unit id="ContentItemDoesNotProvideOutputPath">
-        <source>NETSDK1014: Content item for '{0}' sets '{1}', but does not provide  '{2}' or '{3}'.</source>
-        <target state="translated">NETSDK1014: '{0}' 的內容項目設定了 '{1}'，但未提供 '{2}' 或 '{3}'。</target>
-        <note>{StrBegin="NETSDK1014: "}</note>
-      </trans-unit>
-      <trans-unit id="DuplicatePreprocessorToken">
-        <source>NETSDK1015: The preprocessor token '{0}' has been given more than one value. Choosing '{1}' as the value.</source>
-        <target state="translated">NETSDK1015: 已為前置處理器語彙基元 '{0}' 指定多個值。正在選擇 '{1}' 作為值。</target>
-        <note>{StrBegin="NETSDK1015: "}</note>
-      </trans-unit>
-      <trans-unit id="UnableToFindResolvedPath">
-        <source>NETSDK1016: Unable to find resolved path for '{0}'.</source>
-        <target state="translated">NETSDK1016: 找不到 '{0}' 的解析路徑。</target>
-        <note>{StrBegin="NETSDK1016: "}</note>
+      <trans-unit id="AspNetCoreUsesFrameworkReference">
+        <source>NETSDK1080: A PackageReference to Microsoft.AspNetCore.App is not necessary when targeting .NET Core 3.0 or higher. If Microsoft.NET.Sdk.Web is used, the shared framework will be referenced automatically. Otherwise, the PackageReference should be replaced with a FrameworkReference.</source>
+        <target state="translated">NETSDK1080: 當目標為 .NET Core 3.0 或更新版本時，不一定要有 Microsoft.AspNetCore.App 的 PackageReference。若使用了 Microsoft.NET.Sdk.Web，就會自動參考共用架構。否則，應以 FrameworkReference 取代 PackageReference。</target>
+        <note>{StrBegin="NETSDK1080: "}</note>
       </trans-unit>
       <trans-unit id="AssetPreprocessorMustBeConfigured">
         <source>NETSDK1017: Asset preprocessor must be configured before assets are processed.</source>
         <target state="translated">NETSDK1017: 必須設定資產前置處理器，才可處理資產。</target>
         <note>{StrBegin="NETSDK1017: "}</note>
       </trans-unit>
-      <trans-unit id="InvalidNuGetVersionString">
-        <source>NETSDK1018: Invalid NuGet version string: '{0}'.</source>
-        <target state="translated">NETSDK1018: NuGet 版本字串無效: '{0}'。</target>
-        <note>{StrBegin="NETSDK1018: "}</note>
+      <trans-unit id="AssetsFileMissingRuntimeIdentifier">
+        <source>NETSDK1047: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project. You may also need to include '{3}' in your project's RuntimeIdentifiers.</source>
+        <target state="translated">NETSDK1047: 資產檔 '{0}' 沒有 '{1}' 的目標。請確定已執行還原，且在專案的 TargetFrameworks 中已納入 '{2}'。有可能也需要在專案的 RuntimeIdentifiers 中納入 '{3}'。</target>
+        <note>{StrBegin="NETSDK1047: "}</note>
       </trans-unit>
-      <trans-unit id="UnresolvedTargetingPack">
-        <source>NETSDK1081: The targeting pack for {0} was not found. You may be able to resolve this by running a NuGet restore on the project.</source>
-        <target state="new">NETSDK1081: The targeting pack for {0} was not found. You may be able to resolve this by running a NuGet restore on the project.</target>
-        <note>{StrBegin="NETSDK1081: "}</note>
+      <trans-unit id="AssetsFileMissingTarget">
+        <source>NETSDK1005: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project.</source>
+        <target state="translated">NETSDK1005: 資產檔 '{0}' 沒有 '{1}' 的目標。請確定已執行還原作業，且在您專案的 TargetFrameworks 中已納入 '{2}'。</target>
+        <note>{StrBegin="NETSDK1005: "}</note>
       </trans-unit>
-      <trans-unit id="UnsupportedFramework">
-        <source>NETSDK1019: {0} is an unsupported framework.</source>
-        <target state="translated">NETSDK1019: {0} 為不受支援的架構。</target>
-        <note>{StrBegin="NETSDK1019: "}</note>
+      <trans-unit id="AssetsFileNotFound">
+        <source>NETSDK1004: Assets file '{0}' not found. Run a NuGet package restore to generate this file.</source>
+        <target state="translated">NETSDK1004: 找不到資產檔案 '{0}'。請執行 NuGet 套件還原，以產生此檔案。</target>
+        <note>{StrBegin="NETSDK1004: "}</note>
       </trans-unit>
-      <trans-unit id="DuplicateItemsError">
-        <source>NETSDK1022: Duplicate '{0}' items were included. The .NET SDK includes '{0}' items from your project directory by default. You can either remove these items from your project file, or set the '{1}' property to '{2}' if you want to explicitly include them in your project file. For more information, see {4}. The duplicate items were: {3}</source>
-        <target state="translated">NETSDK1022: 包含 '{0}' 個重複的項目。根據預設，.NET SDK 會包含來自您專案目錄的 '{0}' 個項目。您可以從專案檔移除這些項目，或若想要在專案檔中明確地納入這些項目，也可以將 '{1}' 屬性設定為 '{2}'。如需詳細資訊，請參閱 {4}。重複的項目為: {3}</target>
-        <note>{StrBegin="NETSDK1022: "}</note>
+      <trans-unit id="AssetsFileNotSet">
+        <source>NETSDK1063: The path to the project assets file was not set. Run a NuGet package restore to generate this file.</source>
+        <target state="translated">NETSDK1063: 未設定到達專案資產檔案的路徑。請執行 NuGet 套件還原，以產生此檔案。</target>
+        <note>{StrBegin="NETSDK1063: "}</note>
       </trans-unit>
-      <trans-unit id="PackageReferenceOverrideWarning">
-        <source>NETSDK1023: A PackageReference for '{0}' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see {1}</source>
-        <target state="translated">NETSDK1023: 您的專案中包含 '{0}' 的 PackageReference。.NET SDK 會隱含參考此套件，您通常不需要從專案參考它。如需詳細資訊，請參閱 {1}</target>
-        <note>{StrBegin="NETSDK1023: "}</note>
+      <trans-unit id="AssetsFilePathNotRooted">
+        <source>NETSDK1006: Assets file path '{0}' is not rooted. Only full paths are supported.</source>
+        <target state="translated">NETSDK1006: 資產檔案路徑 '{0}' 並非根目錄。僅支援完整的路徑。</target>
+        <note>{StrBegin="NETSDK1006: "}</note>
       </trans-unit>
-      <trans-unit id="IncorrectPackageRoot">
-        <source>NETSDK1020: Package Root {0} was incorrectly given for Resolved library {1}</source>
-        <target state="translated">NETSDK1020: 為已解析的程式庫 {1} 指定的套件根 {0} 不正確</target>
-        <note>{StrBegin="NETSDK1020: "}</note>
+      <trans-unit id="AtLeastOneTargetFrameworkMustBeSpecified">
+        <source>NETSDK1001: At least one possible target framework must be specified.</source>
+        <target state="translated">NETSDK1001: 至少必須指定一個可能的目標架構。</target>
+        <note>{StrBegin="NETSDK1001: "}</note>
       </trans-unit>
-      <trans-unit id="MultipleFilesResolved">
-        <source>NETSDK1021: More than one file found for {0}</source>
-        <target state="translated">NETSDK1021: 找到一個以上 {0} 的檔案</target>
-        <note>{StrBegin="NETSDK1021: "}</note>
+      <trans-unit id="CannotFindApphostForRid">
+        <source>NETSDK1065: Cannot find app host for {0}. {0} could be an invalid runtime identifier (RID). For more information about RID, see https://aka.ms/rid-catalog.</source>
+        <target state="translated">NETSDK1065: 找不到 {0} 的應用程式主機。{0} 可能是無效的執行階段識別碼 (RID)。如需有關 RID 的詳細資訊，請參閱 https://aka.ms/rid-catalog。</target>
+        <note>{StrBegin="NETSDK1065: "}</note>
       </trans-unit>
-      <trans-unit id="FolderAlreadyExists">
-        <source>NETSDK1024: Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</source>
-        <target state="translated">NETSDK1024: 資料夾 '{0}' 已存在，請將其刪除或提供不同的 ComposeWorkingDir</target>
-        <note>{StrBegin="NETSDK1024: "}</note>
+      <trans-unit id="CannotFindProjectInfo">
+        <source>NETSDK1007: Cannot find project info for '{0}'. This can indicate a missing project reference.</source>
+        <target state="translated">NETSDK1007: 找不到 '{0}' 的專案資訊。這可能表示遺漏專案參考。</target>
+        <note>{StrBegin="NETSDK1007: "}</note>
       </trans-unit>
-      <trans-unit id="ParsingFiles">
-        <source>NETSDK1026: Parsing the Files : '{0}'</source>
-        <target state="translated">NETSDK1026: 正在剖析檔案: '{0}'</target>
-        <note>{StrBegin="NETSDK1026: "}</note>
-      </trans-unit>
-      <trans-unit id="PackageInfoLog">
-        <source>NETSDK1027: Package Name='{0}', Version='{1}' was parsed</source>
-        <target state="translated">NETSDK1027: 已剖析套件名稱='{0}'，版本='{1}'</target>
-        <note>{StrBegin="NETSDK1027: "}</note>
-      </trans-unit>
-      <trans-unit id="RuntimeIdentifierWasNotSpecified">
-        <source>NETSDK1028: Specify a RuntimeIdentifier</source>
-        <target state="translated">NETSDK1028: 指定 RuntimeIdentifier</target>
-        <note>{StrBegin="NETSDK1028: "}</note>
-      </trans-unit>
-      <trans-unit id="IncorrectTargetFormat">
-        <source>NETSDK1025: WRThe target manifest {0} provided is of not the correct format</source>
-        <target state="translated">NETSDK1025: 提供的目標資訊清單 {0} 格式不正確</target>
-        <note>{StrBegin="NETSDK1025: "}</note>
-      </trans-unit>
-      <trans-unit id="AppHostHasBeenModified">
-        <source>NETSDK1029: Unable to use '{0}' as application host executable as it does not contain the expected placeholder byte sequence '{1}' that would mark where the application name would be written.</source>
-        <target state="translated">NETSDK1029: 無法使用 '{0}' 作為應用程式主機可執行檔，因為它並未包含應有的預留位置位元組序列 '{1}'，其會標示寫入應用程式名稱的位置。</target>
-        <note>{StrBegin="NETSDK1029: "}</note>
-      </trans-unit>
-      <trans-unit id="FileNameIsTooLong">
-        <source>NETSDK1030: Given file name '{0}' is longer than 1024 bytes</source>
-        <target state="translated">NETSDK1030: 指定的檔案名稱 '{0}'，長度超過 1024 個位元組</target>
-        <note>{StrBegin="NETSDK1030: "}</note>
+      <trans-unit id="CannotHaveRuntimeIdentifierPlatformMismatchPlatformTarget">
+        <source>NETSDK1032: The RuntimeIdentifier platform '{0}' and the PlatformTarget '{1}' must be compatible.</source>
+        <target state="translated">NETSDK1032: RuntimeIdentifier 平台 '{0}' 必須與 PlatformTarget '{1}' 相容。</target>
+        <note>{StrBegin="NETSDK1032: "}</note>
       </trans-unit>
       <trans-unit id="CannotHaveSelfContainedWithoutRuntimeIdentifier">
         <source>NETSDK1031: It is not supported to build or publish a self-contained application without specifying a RuntimeIdentifier.  Please either specify a RuntimeIdentifier or set SelfContained to false.</source>
         <target state="translated">NETSDK1031: 不支援在未指定 RuntimeIdentifier 的情況下，建置或發行獨立的應用程式。請指定 RuntimeIdentifier，或將 SelfContained 設為 False。</target>
         <note>{StrBegin="NETSDK1031: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotInferTargetFrameworkIdentifierAndVersion">
+        <source>NETSDK1013: The TargetFramework value '{0}' was not recognized. It may be misspelled. If not, then the TargetFrameworkIdentifier and/or TargetFrameworkVersion properties must be specified explicitly.</source>
+        <target state="translated">NETSDK1013: 無法辨識 TargetFramework 值 '{0}'。拼字可能有誤。若非此情況，即必須明確指定 TargetFrameworkIdentifier 及 (或) TargetFrameworkVersion 屬性。</target>
+        <note>{StrBegin="NETSDK1013: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotUseSelfContainedWithoutAppHost">
+        <source>NETSDK1067: Self-contained applications are required to use the application host. Either set SelfContained to false or set UseAppHost to true.</source>
+        <target state="translated">NETSDK1067: 需要獨立式應用程式，才可使用該應用程式主機。請將 SelfContained 設定為 False，或是將 UseAppHost 設定為 True。</target>
+        <note>{StrBegin="NETSDK1067: "}</note>
       </trans-unit>
       <trans-unit id="ChoosingAssemblyVersion">
         <source>NETSDK1033: Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</source>
@@ -272,6 +132,16 @@
         <target state="translated">NETSDK1037: 因為檔案和組件版本相同，所以無法判斷勝出者。</target>
         <note>{StrBegin="NETSDK1037: "}</note>
       </trans-unit>
+      <trans-unit id="ContentItemDoesNotProvideOutputPath">
+        <source>NETSDK1014: Content item for '{0}' sets '{1}', but does not provide  '{2}' or '{3}'.</source>
+        <target state="translated">NETSDK1014: '{0}' 的內容項目設定了 '{1}'，但未提供 '{2}' 或 '{3}'。</target>
+        <note>{StrBegin="NETSDK1014: "}</note>
+      </trans-unit>
+      <trans-unit id="ContentPreproccessorParameterRequired">
+        <source>NETSDK1010: The '{0}' task must be given a value for parameter '{1}' in order to consume preprocessed content.</source>
+        <target state="translated">NETSDK1010: 必須為 '{0}' 工作指定參數 '{1}' 的值，才可取用前置處理過的內容。</target>
+        <note>{StrBegin="NETSDK1010: "}</note>
+      </trans-unit>
       <trans-unit id="CouldNotDetermineWinner_DoesntExist">
         <source>NETSDK1038: Could not determine winner because '{0}' does not exist.</source>
         <target state="translated">NETSDK1038: 因為 '{0}' 不存在，所以無法判斷勝出者。</target>
@@ -287,15 +157,40 @@
         <target state="translated">NETSDK1040: 因為 '{0}' 並非組件，所以無法判斷勝出者。</target>
         <note>{StrBegin="NETSDK1040: "}</note>
       </trans-unit>
+      <trans-unit id="CouldNotLoadPlatformManifest">
+        <source>NETSDK1042: Could not load PlatformManifest from '{0}' because it did not exist.</source>
+        <target state="translated">NETSDK1042: 無法從 '{0}' 載入 PlatformManifest，因為它並不存在。</target>
+        <note>{StrBegin="NETSDK1042: "}</note>
+      </trans-unit>
+      <trans-unit id="DotnetToolDoesNotSupportTFMLowerThanNetcoreapp21">
+        <source>NETSDK1055: DotnetTool does not support target framework lower than netcoreapp2.1.</source>
+        <target state="translated">NETSDK1055: DotnetTool 並不支援低於 netcoreapp2.1 的目標架構。</target>
+        <note>{StrBegin="NETSDK1055: "}</note>
+      </trans-unit>
+      <trans-unit id="DotnetToolOnlySupportNetcoreapp">
+        <source>NETSDK1054: only supports .NET Core.</source>
+        <target state="translated">NETSDK1054: 只支援 .NET Core。</target>
+        <note>{StrBegin="NETSDK1054: "}</note>
+      </trans-unit>
+      <trans-unit id="DuplicateItemsError">
+        <source>NETSDK1022: Duplicate '{0}' items were included. The .NET SDK includes '{0}' items from your project directory by default. You can either remove these items from your project file, or set the '{1}' property to '{2}' if you want to explicitly include them in your project file. For more information, see {4}. The duplicate items were: {3}</source>
+        <target state="translated">NETSDK1022: 包含 '{0}' 個重複的項目。根據預設，.NET SDK 會包含來自您專案目錄的 '{0}' 個項目。您可以從專案檔移除這些項目，或若想要在專案檔中明確地納入這些項目，也可以將 '{1}' 屬性設定為 '{2}'。如需詳細資訊，請參閱 {4}。重複的項目為: {3}</target>
+        <note>{StrBegin="NETSDK1022: "}</note>
+      </trans-unit>
+      <trans-unit id="DuplicatePreprocessorToken">
+        <source>NETSDK1015: The preprocessor token '{0}' has been given more than one value. Choosing '{1}' as the value.</source>
+        <target state="translated">NETSDK1015: 已為前置處理器語彙基元 '{0}' 指定多個值。正在選擇 '{1}' 作為值。</target>
+        <note>{StrBegin="NETSDK1015: "}</note>
+      </trans-unit>
       <trans-unit id="EncounteredConflict">
         <source>NETSDK1041: Encountered conflict between '{0}' and '{1}'.</source>
         <target state="translated">NETSDK1041: '{0}' 與 '{1}' 之間發生衝突。</target>
         <note>{StrBegin="NETSDK1041: "}</note>
       </trans-unit>
-      <trans-unit id="CouldNotLoadPlatformManifest">
-        <source>NETSDK1042: Could not load PlatformManifest from '{0}' because it did not exist.</source>
-        <target state="translated">NETSDK1042: 無法從 '{0}' 載入 PlatformManifest，因為它並不存在。</target>
-        <note>{StrBegin="NETSDK1042: "}</note>
+      <trans-unit id="ErrorParsingFrameworkListInvalidValue">
+        <source>NETSDK1051: Error parsing FrameworkList from '{0}'.  {1} '{2}' was invalid.</source>
+        <target state="translated">NETSDK1051: 剖析來自 '{0}' 的 FrameworkList 時發生錯誤。{1} '{2}' 無效。</target>
+        <note>{StrBegin="NETSDK1051: "}</note>
       </trans-unit>
       <trans-unit id="ErrorParsingPlatformManifest">
         <source>NETSDK1043: Error parsing PlatformManifest from '{0}' line {1}.  Lines must have the format {2}.</source>
@@ -307,65 +202,55 @@
         <target state="translated">NETSDK1044: 從 '{0}' 行 {1} 剖析 PlatformManifest 時發生錯誤。{2} '{3}' 無效。</target>
         <note>{StrBegin="NETSDK1044: "}</note>
       </trans-unit>
-      <trans-unit id="UnsupportedTargetFrameworkVersion">
-        <source>NETSDK1045: The current .NET SDK does not support targeting {0} {1}.  Either target {0} {2} or lower, or use a version of the .NET SDK that supports {0} {1}.</source>
-        <target state="translated">NETSDK1045: 目前的 .NET SDK 不支援以 {0} {1} 作為目標。請以 {0} {2} 或更低版本作為目標，或是使用支援 {0} {1} 的 .NET SDK 版本。</target>
-        <note>{StrBegin="NETSDK1045: "}</note>
+      <trans-unit id="ErrorReadingAssetsFile">
+        <source>NETSDK1060: Error reading assets file: {0}</source>
+        <target state="translated">NETSDK1060: 讀取資產檔案時發生錯誤: {0}</target>
+        <note>{StrBegin="NETSDK1060: "}</note>
       </trans-unit>
-      <trans-unit id="AssetsFileMissingRuntimeIdentifier">
-        <source>NETSDK1047: Assets file '{0}' doesn't have a target for '{1}'. Ensure that restore has run and that you have included '{2}' in the TargetFrameworks for your project. You may also need to include '{3}' in your project's RuntimeIdentifiers.</source>
-        <target state="translated">NETSDK1047: 資產檔 '{0}' 沒有 '{1}' 的目標。請確定已執行還原，且在專案的 TargetFrameworks 中已納入 '{2}'。有可能也需要在專案的 RuntimeIdentifiers 中納入 '{3}'。</target>
-        <note>{StrBegin="NETSDK1047: "}</note>
+      <trans-unit id="FailedToLockResource">
+        <source>NETSDK1077: Failed to lock resource.</source>
+        <target state="translated">NETSDK1077: 無法鎖定資源。</target>
+        <note>{StrBegin="NETSDK1077: "}</note>
       </trans-unit>
-      <trans-unit id="TargetFrameworkWithSemicolon">
-        <source>NETSDK1046: The TargetFramework value '{0}' is not valid. To multi-target, use the 'TargetFrameworks' property instead.</source>
-        <target state="translated">NETSDK1046: TargetFramework 值 '{0}' 無效。若要設定多重目標，請改用 'TargetFrameworks' 屬性。</target>
-        <note>{StrBegin="NETSDK1046: "}</note>
+      <trans-unit id="FileNameIsTooLong">
+        <source>NETSDK1030: Given file name '{0}' is longer than 1024 bytes</source>
+        <target state="translated">NETSDK1030: 指定的檔案名稱 '{0}'，長度超過 1024 個位元組</target>
+        <note>{StrBegin="NETSDK1030: "}</note>
       </trans-unit>
-      <trans-unit id="GetDependsOnNETStandardFailedWithException">
-        <source>NETSDK1049: Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0} {1}</source>
-        <target state="translated">NETSDK1049: 解析的檔案含有毀損的映像、沒有中繼資料，或有其他無法存取的情況。{0} {1}</target>
-        <note>{StrBegin="NETSDK1049: "}</note>
+      <trans-unit id="FolderAlreadyExists">
+        <source>NETSDK1024: Folder '{0}' already exists either delete it or provide a different ComposeWorkingDir</source>
+        <target state="translated">NETSDK1024: 資料夾 '{0}' 已存在，請將其刪除或提供不同的 ComposeWorkingDir</target>
+        <note>{StrBegin="NETSDK1024: "}</note>
       </trans-unit>
-      <trans-unit id="UnsupportedSDKVersionForNetStandard20">
-        <source>NETSDK1050: The version of Microsoft.NET.Sdk used by this project is insufficient to support references to libraries targeting .NET Standard 1.5 or higher.  Please install version 2.0 or higher of the .NET Core SDK.</source>
-        <target state="translated">NETSDK1050: 此專案使用的 Microsoft.NET.Sdk 版本，無法支援以.NET Standard 1.5 或更高版本為目標的程式庫參考。請安裝 .NET Core SDK 2.0 或更高版本。</target>
-        <note>{StrBegin="NETSDK1050: "}</note>
-      </trans-unit>
-      <trans-unit id="SkippingAdditionalProbingPaths">
-        <source>NETSDK1048: 'AdditionalProbingPaths' were specified for GenerateRuntimeConfigurationFiles, but are being skipped because 'RuntimeConfigDevPath' is empty.</source>
-        <target state="translated">NETSDK1048: 已為 GenerateRuntimeConfigurationFiles 指定了 'AdditionalProbingPaths'，但因為 'RuntimeConfigDevPath' 是空的，所以已跳過它。</target>
-        <note>{StrBegin="NETSDK1048: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotHaveRuntimeIdentifierPlatformMismatchPlatformTarget">
-        <source>NETSDK1032: The RuntimeIdentifier platform '{0}' and the PlatformTarget '{1}' must be compatible.</source>
-        <target state="translated">NETSDK1032: RuntimeIdentifier 平台 '{0}' 必須與 PlatformTarget '{1}' 相容。</target>
-        <note>{StrBegin="NETSDK1032: "}</note>
-      </trans-unit>
-      <trans-unit id="ErrorParsingFrameworkListInvalidValue">
-        <source>NETSDK1051: Error parsing FrameworkList from '{0}'.  {1} '{2}' was invalid.</source>
-        <target state="translated">NETSDK1051: 剖析來自 '{0}' 的 FrameworkList 時發生錯誤。{1} '{2}' 無效。</target>
-        <note>{StrBegin="NETSDK1051: "}</note>
+      <trans-unit id="FrameworkDependentAppHostRequiresVersion21">
+        <source>NETSDK1068: The framework-dependent application host requires a target framework of at least 'netcoreapp2.1'.</source>
+        <target state="translated">NETSDK1068: 與架構相依的應用程式主機，至少需要 'netcoreapp2.1' 的目標架構。</target>
+        <note>{StrBegin="NETSDK1068: "}</note>
       </trans-unit>
       <trans-unit id="FrameworkListPathNotRooted">
         <source>NETSDK1052: Framework list file path '{0}' is not rooted. Only full paths are supported.</source>
         <target state="translated">NETSDK1052: 架構清單路徑 '{0}' 並非根目錄。只支援完整路徑。</target>
         <note>{StrBegin="NETSDK1052: "}</note>
       </trans-unit>
-      <trans-unit id="PackAsToolCannotSupportSelfContained">
-        <source>NETSDK1053: Pack as tool does not support self contained.</source>
-        <target state="translated">NETSDK1053: 封裝為工具不支援包含本身。</target>
-        <note>{StrBegin="NETSDK1001: "}</note>
+      <trans-unit id="GetDependsOnNETStandardFailedWithException">
+        <source>NETSDK1049: Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0} {1}</source>
+        <target state="translated">NETSDK1049: 解析的檔案含有毀損的映像、沒有中繼資料，或有其他無法存取的情況。{0} {1}</target>
+        <note>{StrBegin="NETSDK1049: "}</note>
       </trans-unit>
-      <trans-unit id="UnsupportedRuntimeIdentifier">
-        <source>NETSDK1056: Project is targeting runtime '{0}' but did not resolve any runtime-specific packages. This runtime may not be supported by the target framework.</source>
-        <target state="translated">NETSDK1056: 專案以執行階段 '{0}' 為目標，但並未解析任何專屬於執行階段的套件。目標架構可能不支援此執行階段。</target>
-        <note>{StrBegin="NETSDK1056: "}</note>
+      <trans-unit id="IncorrectPackageRoot">
+        <source>NETSDK1020: Package Root {0} was incorrectly given for Resolved library {1}</source>
+        <target state="translated">NETSDK1020: 為已解析的程式庫 {1} 指定的套件根 {0} 不正確</target>
+        <note>{StrBegin="NETSDK1020: "}</note>
       </trans-unit>
-      <trans-unit id="UsingPreviewSdkWarning">
-        <source>NETSDK1057: You are using a preview version of .NET Core. See: https://aka.ms/dotnet-core-preview</source>
-        <target state="translated">NETSDK1057: 您使用的是 .NET Core 預覽版。請參閱: https://aka.ms/dotnet-core-preview</target>
-        <note>{StrBegin="NETSDK1057: "}</note>
+      <trans-unit id="IncorrectTargetFormat">
+        <source>NETSDK1025: WRThe target manifest {0} provided is of not the correct format</source>
+        <target state="translated">NETSDK1025: 提供的目標資訊清單 {0} 格式不正確</target>
+        <note>{StrBegin="NETSDK1025: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidFrameworkName">
+        <source>NETSDK1003: Invalid framework name: '{0}'.</source>
+        <target state="translated">NETSDK1003: 架構名稱 '{0}' 無效。</target>
+        <note>{StrBegin="NETSDK1003: "}</note>
       </trans-unit>
       <trans-unit id="InvalidItemSpecToUse">
         <source>NETSDK1058: Invalid value for ItemSpecToUse parameter: '{0}'.  This property must be blank or set to 'Left' or 'Right'</source>
@@ -373,15 +258,15 @@
         <note>{StrBegin="NETSDK1058: "}
 The following are names of parameters or literal values and should not be translated: ItemSpecToUse, Left, Right</note>
       </trans-unit>
-      <trans-unit id="ProjectContainsObsoleteDotNetCliTool">
-        <source>NETSDK1059: The tool '{0}' is now included in the .NET Core SDK. Information on resolving this warning is available at (https://aka.ms/dotnetclitools-in-box).</source>
-        <target state="translated">NETSDK1059: 工具 '{0}' 現已包含在 .NET Core SDK 中。解決此警告的資訊位於 (https://aka.ms/dotnetclitools-in-box)。</target>
-        <note>{StrBegin="NETSDK1059: "}</note>
+      <trans-unit id="InvalidNuGetVersionString">
+        <source>NETSDK1018: Invalid NuGet version string: '{0}'.</source>
+        <target state="translated">NETSDK1018: NuGet 版本字串無效: '{0}'。</target>
+        <note>{StrBegin="NETSDK1018: "}</note>
       </trans-unit>
-      <trans-unit id="ErrorReadingAssetsFile">
-        <source>NETSDK1060: Error reading assets file: {0}</source>
-        <target state="translated">NETSDK1060: 讀取資產檔案時發生錯誤: {0}</target>
-        <note>{StrBegin="NETSDK1060: "}</note>
+      <trans-unit id="InvalidResourceUpdate">
+        <source>NETSDK1075: Update handle is invalid. This instance may not be used for further updates.</source>
+        <target state="translated">NETSDK1075: 更新控制代碼無效。此執行個體無法用於後續更新。</target>
+        <note>{StrBegin="NETSDK1075: "}</note>
       </trans-unit>
       <trans-unit id="MismatchedPlatformPackageVersion">
         <source>NETSDK1061: The project was restored using {0} version {1}, but with current settings, version {2} would be used instead. To resolve this issue, make sure the same settings are used for restore and for subsequent operations such as build or publish. Typically this issue can occur if the RuntimeIdentifier property is set during build or publish but not during restore. For more information, see https://aka.ms/dotnet-runtime-patch-selection.</source>
@@ -391,35 +276,150 @@ The following are names of parameters or literal values and should not be transl
 {1} - Restored version of platform package
 {2} - Current version of platform package</note>
       </trans-unit>
-      <trans-unit id="AssetsFileNotSet">
-        <source>NETSDK1063: The path to the project assets file was not set. Run a NuGet package restore to generate this file.</source>
-        <target state="translated">NETSDK1063: 未設定到達專案資產檔案的路徑。請執行 NuGet 套件還原，以產生此檔案。</target>
-        <note>{StrBegin="NETSDK1063: "}</note>
+      <trans-unit id="MissingItemMetadata">
+        <source>NETSDK1008: Missing '{0}' metadata on '{1}' item '{2}'.</source>
+        <target state="translated">NETSDK1008: '{1}' 項目 '{2}' 上遺漏 '{0}' 中繼資料。</target>
+        <note>{StrBegin="NETSDK1008: "}</note>
       </trans-unit>
-      <trans-unit id="DotnetToolOnlySupportNetcoreapp">
-        <source>NETSDK1054: only supports .NET Core.</source>
-        <target state="translated">NETSDK1054: 只支援 .NET Core。</target>
-        <note>{StrBegin="NETSDK1054: "}</note>
+      <trans-unit id="MultipleFilesResolved">
+        <source>NETSDK1021: More than one file found for {0}</source>
+        <target state="translated">NETSDK1021: 找到一個以上 {0} 的檔案</target>
+        <note>{StrBegin="NETSDK1021: "}</note>
       </trans-unit>
-      <trans-unit id="DotnetToolDoesNotSupportTFMLowerThanNetcoreapp21">
-        <source>NETSDK1055: DotnetTool does not support target framework lower than netcoreapp2.1.</source>
-        <target state="translated">NETSDK1055: DotnetTool 並不支援低於 netcoreapp2.1 的目標架構。</target>
-        <note>{StrBegin="NETSDK1055: "}</note>
+      <trans-unit id="NETFrameworkToNonBuiltInNETStandard">
+        <source>NETSDK1069: This project uses a library that targets .NET Standard 1.5 or higher, and the project targets a version of .NET Framework that doesn't have built-in support for that version of .NET Standard. Visit https://aka.ms/net-standard-known-issues for a set of known issues. Consider retargeting to .NET Framework 4.7.2.</source>
+        <target state="translated">NETSDK1069: 此專案使用以 .NET Standard 1.5 或更新版本為目標的程式庫，而專案的目標 .NET Framework 版本則為尚未具備該 .NET Standard 版本內建支援的 .NET Framework。請瀏覽 https://aka.ms/net-standard-known-issues，以了解已知問題的集合。請考慮轉為以 .NET Framework 4.7.2 為目標。</target>
+        <note>{StrBegin="NETSDK1069: "}</note>
       </trans-unit>
-      <trans-unit id="UnableToUsePackageAssetsCache">
-        <source>NETSDK1062: Unable to use package assets cache due to I/O error. This can occur when the same project is built more than once in parallel. Performance may be degraded, but the build result will not be impacted.</source>
-        <target state="translated">NETSDK1062: 因為發生 I/O 錯誤，所以無法使用套件資產。平行建置多次相同的專案，即可能發生此情況。效能可能會有所減損，但建置結果將不會受到影響。</target>
-        <note>{StrBegin="NETSDK1062: "}</note>
+      <trans-unit id="NoAppHostAvailable">
+        <source>NETSDK1084: There is no application host available for the specified RuntimeIdentifier '{0}'.</source>
+        <target state="new">NETSDK1084: There is no application host available for the specified RuntimeIdentifier '{0}'.</target>
+        <note>{StrBegin="NETSDK1084: "}</note>
+      </trans-unit>
+      <trans-unit id="NoCompatibleTargetFramework">
+        <source>NETSDK1002: Project '{0}' targets '{2}'. It cannot be referenced by a project that targets '{1}'.</source>
+        <target state="translated">NETSDK1002: 專案 '{0}' 以 '{2}' 為目標。以 '{1}' 為目標的專案無法參考此專案。</target>
+        <note>{StrBegin="NETSDK1002: "}</note>
+      </trans-unit>
+      <trans-unit id="NoRuntimePackAvailable">
+        <source>NETSDK1082: There was no runtime pack for {0} available for the specified RuntimeIdentifier '{1}'.</source>
+        <target state="new">NETSDK1082: There was no runtime pack for {0} available for the specified RuntimeIdentifier '{1}'.</target>
+        <note>{StrBegin="NETSDK1082: "}</note>
+      </trans-unit>
+      <trans-unit id="PackAsToolCannotSupportSelfContained">
+        <source>NETSDK1053: Pack as tool does not support self contained.</source>
+        <target state="translated">NETSDK1053: 封裝為工具不支援包含本身。</target>
+        <note>{StrBegin="NETSDK1001: "}</note>
+      </trans-unit>
+      <trans-unit id="PackageInfoLog">
+        <source>NETSDK1027: Package Name='{0}', Version='{1}' was parsed</source>
+        <target state="translated">NETSDK1027: 已剖析套件名稱='{0}'，版本='{1}'</target>
+        <note>{StrBegin="NETSDK1027: "}</note>
       </trans-unit>
       <trans-unit id="PackageNotFound">
         <source>NETSDK1064: Package {0}, version {1} was not found. It might have been deleted since NuGet restore. Otherwise, NuGet restore might have only partially completed, which might have been due to maximum path length restrictions.</source>
         <target state="translated">NETSDK1064: 找不到套件 {0}，版本 {1}。該套件可能因 NuGet restore 還原而刪除，或是可能因為路徑長度上限的限制，而讓 NuGet restore 可能只有部分完成所致。</target>
         <note>{StrBegin="NETSDK1064: "}</note>
       </trans-unit>
-      <trans-unit id="CannotFindApphostForRid">
-        <source>NETSDK1065: Cannot find app host for {0}. {0} could be an invalid runtime identifier (RID). For more information about RID, see https://aka.ms/rid-catalog.</source>
-        <target state="translated">NETSDK1065: 找不到 {0} 的應用程式主機。{0} 可能是無效的執行階段識別碼 (RID)。如需有關 RID 的詳細資訊，請參閱 https://aka.ms/rid-catalog。</target>
-        <note>{StrBegin="NETSDK1065: "}</note>
+      <trans-unit id="PackageReferenceOverrideWarning">
+        <source>NETSDK1023: A PackageReference for '{0}' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see {1}</source>
+        <target state="translated">NETSDK1023: 您的專案中包含 '{0}' 的 PackageReference。.NET SDK 會隱含參考此套件，您通常不需要從專案參考它。如需詳細資訊，請參閱 {1}</target>
+        <note>{StrBegin="NETSDK1023: "}</note>
+      </trans-unit>
+      <trans-unit id="PackageReferenceVersionNotRecommended">
+        <source>NETSDK1071: A PackageReference to '{0}' specified a Version of `{1}`. Specifying the version of this package is not recommended. For more information, see https://aka.ms/sdkimplicitrefs</source>
+        <target state="translated">NETSDK1071: '{0}' 的 PackageReference 指定了 `{1}` 版本。不建議指定這個套件版本。如需詳細資訊，請參閱 https://aka.ms/sdkimplicitrefs</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParsingFiles">
+        <source>NETSDK1026: Parsing the Files : '{0}'</source>
+        <target state="translated">NETSDK1026: 正在剖析檔案: '{0}'</target>
+        <note>{StrBegin="NETSDK1026: "}</note>
+      </trans-unit>
+      <trans-unit id="ProjectAssetsConsumedWithoutMSBuildProjectPath">
+        <source>NETSDK1011: Assets are consumed from project '{0}', but no corresponding MSBuild project path was  found in '{1}'.</source>
+        <target state="translated">NETSDK1011: 已從專案 '{0}' 取用資產，但在 '{1}' 中找不到相對應的 MSBuild 專案路徑。</target>
+        <note>{StrBegin="NETSDK1011: "}</note>
+      </trans-unit>
+      <trans-unit id="ProjectContainsObsoleteDotNetCliTool">
+        <source>NETSDK1059: The tool '{0}' is now included in the .NET Core SDK. Information on resolving this warning is available at (https://aka.ms/dotnetclitools-in-box).</source>
+        <target state="translated">NETSDK1059: 工具 '{0}' 現已包含在 .NET Core SDK 中。解決此警告的資訊位於 (https://aka.ms/dotnetclitools-in-box)。</target>
+        <note>{StrBegin="NETSDK1059: "}</note>
+      </trans-unit>
+      <trans-unit id="RuntimeIdentifierNotRecognized">
+        <source>NETSDK1083: The specified RuntimeIdentifier '{0}' is not recognized.</source>
+        <target state="new">NETSDK1083: The specified RuntimeIdentifier '{0}' is not recognized.</target>
+        <note>{StrBegin="NETSDK1083: "}</note>
+      </trans-unit>
+      <trans-unit id="RuntimeIdentifierWasNotSpecified">
+        <source>NETSDK1028: Specify a RuntimeIdentifier</source>
+        <target state="translated">NETSDK1028: 指定 RuntimeIdentifier</target>
+        <note>{StrBegin="NETSDK1028: "}</note>
+      </trans-unit>
+      <trans-unit id="SkippingAdditionalProbingPaths">
+        <source>NETSDK1048: 'AdditionalProbingPaths' were specified for GenerateRuntimeConfigurationFiles, but are being skipped because 'RuntimeConfigDevPath' is empty.</source>
+        <target state="translated">NETSDK1048: 已為 GenerateRuntimeConfigurationFiles 指定了 'AdditionalProbingPaths'，但因為 'RuntimeConfigDevPath' 是空的，所以已跳過它。</target>
+        <note>{StrBegin="NETSDK1048: "}</note>
+      </trans-unit>
+      <trans-unit id="TargetFrameworkWithSemicolon">
+        <source>NETSDK1046: The TargetFramework value '{0}' is not valid. To multi-target, use the 'TargetFrameworks' property instead.</source>
+        <target state="translated">NETSDK1046: TargetFramework 值 '{0}' 無效。若要設定多重目標，請改用 'TargetFrameworks' 屬性。</target>
+        <note>{StrBegin="NETSDK1046: "}</note>
+      </trans-unit>
+      <trans-unit id="UnableToFindResolvedPath">
+        <source>NETSDK1016: Unable to find resolved path for '{0}'.</source>
+        <target state="translated">NETSDK1016: 找不到 '{0}' 的解析路徑。</target>
+        <note>{StrBegin="NETSDK1016: "}</note>
+      </trans-unit>
+      <trans-unit id="UnableToUsePackageAssetsCache">
+        <source>NETSDK1062: Unable to use package assets cache due to I/O error. This can occur when the same project is built more than once in parallel. Performance may be degraded, but the build result will not be impacted.</source>
+        <target state="translated">NETSDK1062: 因為發生 I/O 錯誤，所以無法使用套件資產。平行建置多次相同的專案，即可能發生此情況。效能可能會有所減損，但建置結果將不會受到影響。</target>
+        <note>{StrBegin="NETSDK1062: "}</note>
+      </trans-unit>
+      <trans-unit id="UnexpectedFileType">
+        <source>NETSDK1012: Unexpected file type for '{0}'. Type is both '{1}' and '{2}'.</source>
+        <target state="translated">NETSDK1012: 對 '{0}' 來說並非預期的檔案類型。類型為 '{1}' 和 '{2}'。</target>
+        <note>{StrBegin="NETSDK1012: "}</note>
+      </trans-unit>
+      <trans-unit id="UnknownFrameworkReference">
+        <source>NETSDK1073: The FrameworkReference '{0}' was not recognized</source>
+        <target state="translated">NETSDK1073: 無法辨識 FrameworkReference '{0}'</target>
+        <note>{StrBegin="NETSDK1073: "}</note>
+      </trans-unit>
+      <trans-unit id="UnrecognizedPreprocessorToken">
+        <source>NETSDK1009: Unrecognized preprocessor token '{0}' in '{1}'.</source>
+        <target state="translated">NETSDK1009: '{1}' 中的前置處理器語彙基元 '{0}' 無法辨識。</target>
+        <note>{StrBegin="NETSDK1009: "}</note>
+      </trans-unit>
+      <trans-unit id="UnresolvedTargetingPack">
+        <source>NETSDK1081: The targeting pack for {0} was not found. You may be able to resolve this by running a NuGet restore on the project.</source>
+        <target state="new">NETSDK1081: The targeting pack for {0} was not found. You may be able to resolve this by running a NuGet restore on the project.</target>
+        <note>{StrBegin="NETSDK1081: "}</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedFramework">
+        <source>NETSDK1019: {0} is an unsupported framework.</source>
+        <target state="translated">NETSDK1019: {0} 為不受支援的架構。</target>
+        <note>{StrBegin="NETSDK1019: "}</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedRuntimeIdentifier">
+        <source>NETSDK1056: Project is targeting runtime '{0}' but did not resolve any runtime-specific packages. This runtime may not be supported by the target framework.</source>
+        <target state="translated">NETSDK1056: 專案以執行階段 '{0}' 為目標，但並未解析任何專屬於執行階段的套件。目標架構可能不支援此執行階段。</target>
+        <note>{StrBegin="NETSDK1056: "}</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedSDKVersionForNetStandard20">
+        <source>NETSDK1050: The version of Microsoft.NET.Sdk used by this project is insufficient to support references to libraries targeting .NET Standard 1.5 or higher.  Please install version 2.0 or higher of the .NET Core SDK.</source>
+        <target state="translated">NETSDK1050: 此專案使用的 Microsoft.NET.Sdk 版本，無法支援以.NET Standard 1.5 或更高版本為目標的程式庫參考。請安裝 .NET Core SDK 2.0 或更高版本。</target>
+        <note>{StrBegin="NETSDK1050: "}</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedTargetFrameworkVersion">
+        <source>NETSDK1045: The current .NET SDK does not support targeting {0} {1}.  Either target {0} {2} or lower, or use a version of the .NET SDK that supports {0} {1}.</source>
+        <target state="translated">NETSDK1045: 目前的 .NET SDK 不支援以 {0} {1} 作為目標。請以 {0} {2} 或更低版本作為目標，或是使用支援 {0} {1} 的 .NET SDK 版本。</target>
+        <note>{StrBegin="NETSDK1045: "}</note>
+      </trans-unit>
+      <trans-unit id="UsingPreviewSdkWarning">
+        <source>NETSDK1057: You are using a preview version of .NET Core. See: https://aka.ms/dotnet-core-preview</source>
+        <target state="translated">NETSDK1057: 您使用的是 .NET Core 預覽版。請參閱: https://aka.ms/dotnet-core-preview</target>
+        <note>{StrBegin="NETSDK1057: "}</note>
       </trans-unit>
     </body>
   </file>


### PR DESCRIPTION
Our xlf files were created before xliff-tasks was changed to preserve sort order by inserting before first key that would sort after it.

This sorts all of the xlf and the tooling should then keep it correctly sorted. It should help to prevent merge conflicts in more cases moving forward. The sorting was done with `dotnet build /t:SortXlf` from https://github.com/dotnet/xliff-tasks/pull/50

Recently, a change reordered strings.tr.xlf substantially, and I do not know how that happened. If you see a change where data is being moved or inserted out of order, please tag me to investigate the root cause.

FYI, @tmeschter 
