### PR TITLE
Use invariant form of ToUpper/ToLower

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolveCopyLocalAssets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveCopyLocalAssets.cs
@@ -78,9 +78,9 @@ namespace Microsoft.NET.Build.Tasks
 
                 item.SetMetadata(MetadataKeys.DestinationSubPath, resolvedFile.DestinationSubPath);
                 item.SetMetadata(MetadataKeys.DestinationSubDirectory, resolvedFile.DestinationSubDirectory);
-                item.SetMetadata(MetadataKeys.AssetType, resolvedFile.Asset.ToString().ToLower());
+                item.SetMetadata(MetadataKeys.AssetType, resolvedFile.Asset.ToString().ToLowerInvariant());
                 item.SetMetadata(MetadataKeys.PackageName, resolvedFile.Package.Id.ToString());
-                item.SetMetadata(MetadataKeys.PackageVersion, resolvedFile.Package.Version.ToString().ToLower());
+                item.SetMetadata(MetadataKeys.PackageVersion, resolvedFile.Package.Version.ToString().ToLowerInvariant());
 
                 if (resolvedFile.Asset == AssetType.Resources)
                 {

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageAssets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageAssets.cs
@@ -1028,7 +1028,7 @@ namespace Microsoft.NET.Build.Tasks
                             WriteCopyLocalMetadata(
                                 package,
                                 Path.GetFileName(asset.Path),
-                                asset.AssetType.ToLower(),
+                                asset.AssetType.ToLowerInvariant(),
                                 destinationSubDirectory: Path.GetDirectoryName(asset.Path) + Path.DirectorySeparatorChar);
                         }
                         else
@@ -1133,7 +1133,7 @@ namespace Microsoft.NET.Build.Tasks
                 }
                 WriteMetadata(MetadataKeys.AssetType, assetType);
                 WriteMetadata(MetadataKeys.PackageName, package.Name);
-                WriteMetadata(MetadataKeys.PackageVersion, package.Version.ToString().ToLower());
+                WriteMetadata(MetadataKeys.PackageVersion, package.Version.ToString().ToLowerInvariant());
             }
 
             private int GetMetadataIndex(string value)

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets
@@ -143,7 +143,7 @@ Copyright (c) .NET Foundation. All rights reserved.
           BeforeTargets="_CheckForInvalidConfigurationAndPlatform"
           Condition="'$(RuntimeIdentifier)' != '' and '$(PlatformTarget)' != ''">
 
-    <NETSdkError Condition="'$(PlatformTarget)' != 'AnyCPU' and !$(RuntimeIdentifier.ToUpper().Contains($(PlatformTarget.ToUpper())))"
+    <NETSdkError Condition="'$(PlatformTarget)' != 'AnyCPU' and !$(RuntimeIdentifier.ToUpperInvariant().Contains($(PlatformTarget.ToUpperInvariant())))"
                  ResourceName="CannotHaveRuntimeIdentifierPlatformMismatchPlatformTarget"
                  FormatArguments="$(RuntimeIdentifier);$(PlatformTarget)" />
 

--- a/src/Tests/Microsoft.NET.TestFramework/TestAsset.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/TestAsset.cs
@@ -176,7 +176,7 @@ namespace Microsoft.NET.TestFramework
             var binFolder = $"{System.IO.Path.DirectorySeparatorChar}bin";
             var objFolder = $"{System.IO.Path.DirectorySeparatorChar}obj";
 
-            directory = directory.ToLower();
+            directory = directory.ToLowerInvariant();
             return directory.EndsWith(binFolder)
                   || directory.EndsWith(objFolder)
                   || IsInBinOrObjFolder(directory);
@@ -189,7 +189,7 @@ namespace Microsoft.NET.TestFramework
             var binFolderWithTrailingSlash =
               $"{System.IO.Path.DirectorySeparatorChar}bin{System.IO.Path.DirectorySeparatorChar}";
 
-            path = path.ToLower();
+            path = path.ToLowerInvariant();
             return path.Contains(binFolderWithTrailingSlash)
                   || path.Contains(objFolderWithTrailingSlash);
         }


### PR DESCRIPTION
Fixing a little annoyance spotted while reading code nearby. Some uses of ToUpper/ToLower were depending on current culture.