### PR TITLE
Do no run GenerateShimsAssets when PackAsToolShimRuntimeIdentifiers is not set

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.PackTool.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.PackTool.targets
@@ -98,7 +98,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <Target Name="GenerateShimsAssets"
           BeforeTargets="CopyFilesToOutputDirectory"
           DependsOnTargets="ResolvePackageAssets;_PackToolValidation;_GenerateShimInputCache;_ComputeExpectedEmbeddedApphostPaths"
-          Condition="'$(PackAsTool)' == 'true'"
+          Condition="'$(PackAsTool)' == 'true' and $(PackAsToolShimRuntimeIdentifiers) != '' "
           Inputs="@(_GenerateShimsAssetsInput)"
           Outputs="$(_ShimCreatedSentinelFile)">
 

--- a/src/Tests/Microsoft.NET.ToolPack.Tests/GivenThatWeWantToPackAToolSelfContainedProject.cs
+++ b/src/Tests/Microsoft.NET.ToolPack.Tests/GivenThatWeWantToPackAToolSelfContainedProject.cs
@@ -26,23 +26,41 @@ namespace Microsoft.NET.ToolPack.Tests
         [Fact]
         public void It_should_fail_with_error_message()
         {
-            TestAsset helloWorldAsset = _testAssetsManager
-                                        .CopyTestAsset("PortableTool", "PackSelfContainedTool")
-                                        .WithSource()
-                                        .WithProjectChanges(project =>
-                                        {
-                                            XNamespace ns = project.Root.Name.Namespace;
-                                            XElement propertyGroup = project.Root.Elements(ns + "PropertyGroup").First();
-                                            propertyGroup.Add(new XElement("RuntimeIdentifier", "win-x64"));
-                                        });
-
-            helloWorldAsset.Restore(Log);
+            TestAsset helloWorldAsset = CreateAsset();
 
             var packCommand = new PackCommand(Log, helloWorldAsset.TestRoot);
 
             CommandResult result = packCommand.Execute();
             result.ExitCode.Should().NotBe(0);
             result.StdOut.Should().Contain(Strings.PackAsToolCannotSupportSelfContained);
+        }
+
+        // Reproduce of https://github.com/dotnet/cli/issues/10607
+        [Fact]
+        public void It_should_not_fail_on_build()
+        {
+            TestAsset helloWorldAsset = CreateAsset();
+
+            var packCommand = new BuildCommand(Log, helloWorldAsset.TestRoot);
+
+            CommandResult result = packCommand.Execute();
+            result.ExitCode.Should().Be(0);
+        }
+
+        private TestAsset CreateAsset()
+        {
+            TestAsset helloWorldAsset = _testAssetsManager
+                                                    .CopyTestAsset("PortableTool", "PackSelfContainedTool")
+                                                    .WithSource()
+                                                    .WithProjectChanges(project =>
+                                                    {
+                                                        XNamespace ns = project.Root.Name.Namespace;
+                                                        XElement propertyGroup = project.Root.Elements(ns + "PropertyGroup").First();
+                                                        propertyGroup.Add(new XElement("RuntimeIdentifier", "win-x64"));
+                                                    });
+
+            helloWorldAsset.Restore(Log);
+            return helloWorldAsset;
         }
     }
 }


### PR DESCRIPTION
fix https://github.com/dotnet/sdk/pull/2413

I think the Windows no fail is due to 2.1.402 does not have the change https://github.com/dotnet/sdk/pull/2413 . It failed on my 3.0-preview

The root cause of https://github.com/dotnet/cli/issues/10607 is: Shim generation is moved to build step, so no new exe is created during publish step. However, generate shim require non self contain since there is no existing logic to create a shim on top of an existing exe. The good thing is most of the build project do not need shim generation. So only fail when it is set.

This is a "good enough solution". Since it will still fail to build when _PackAsToolShimRuntimeIdentifiers_ set. But, in the end, it is _build_ depends on _GenerateShimsAssets_. Removing it and put it back to _publish_ will make signing much harder.