### PR TITLE
Fix ArgumentNullException in ResolveFrameworkReferences.

### DIFF
--- a/src/Assets/TestProjects/AppWithNetCoreAppLib/lib/Class1.cs
+++ b/src/Assets/TestProjects/AppWithNetCoreAppLib/lib/Class1.cs
@@ -1,0 +1,8 @@
+﻿using System;
+
+namespace classlib
+{
+    public class Class1
+    {
+    }
+}

--- a/src/Assets/TestProjects/AppWithNetCoreAppLib/lib/lib.csproj
+++ b/src/Assets/TestProjects/AppWithNetCoreAppLib/lib/lib.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp3.0</TargetFrameworks>
+  </PropertyGroup>
+
+</Project>

--- a/src/Assets/TestProjects/AppWithNetCoreAppLib/main/Program.cs
+++ b/src/Assets/TestProjects/AppWithNetCoreAppLib/main/Program.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace main
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            Console.WriteLine("Hello World!");
+        }
+    }
+}

--- a/src/Assets/TestProjects/AppWithNetCoreAppLib/main/main.csproj
+++ b/src/Assets/TestProjects/AppWithNetCoreAppLib/main/main.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\lib\lib.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishASelfContainedApp.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishASelfContainedApp.cs
@@ -128,5 +128,29 @@ namespace Microsoft.NET.Publish.Tests
                 .Should()
                 .Be(2);
         }
+
+        [Fact]
+        public void It_publishes_an_app_with_a_netcoreapp_lib_reference()
+        {
+            var testAsset = _testAssetsManager
+                .CopyTestAsset("AppWithNetCoreAppLib")
+                .WithSource();
+
+            var args = new string[]
+            {
+                "/p:SelfContained=true",
+                "/p:TargetFramework=netcoreapp3.0",
+                $"/p:RuntimeIdentifier={EnvironmentInfo.GetCompatibleRid("netcoreapp3.0")}"
+            };
+
+            var projectRoot = Path.Combine(testAsset.TestRoot, "main");
+
+            new RestoreCommand(Log, projectRoot).Execute(args);
+
+            new PublishCommand(Log, projectRoot)
+                .Execute(args)
+                .Should()
+                .Pass();
+        }
     }
 }


### PR DESCRIPTION
When a `netcoreapp3.0` executable project references a `netcoreapp3.0`
library project, and `SelfContained` is globally true, then an
`ArgumentNullException` occurs in the `ResolveFrameworkReferences` task.

This can happen when publishing with the following command:

```
dotnet publish -f netcoreapp3.0 -r win-x86 --self-contained
```

When `SelfContained` is `true` for the class library project reference,
the task does not take into account that `RuntimeIdentifier` might be
null since it gets filtered out from the reference.

Additionally, some cleanup was needed relating to
`GetBestRuntimeIdentifier`.

Fixes #2851.