### PR TITLE
Fix _RestoreCrossgen target dependency.

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.CrossGen.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.CrossGen.targets
@@ -255,6 +255,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <Target Name="_RestoreCrossgen"
           DependsOnTargets="PrepforRestoreForComposeStore;
                            _SetupStageForCrossgen;
+                           ResolveFrameworkReferences;
                            ApplyImplicitVersions"
           Condition="$(SkipOptimization) != 'true' ">
 


### PR DESCRIPTION
The `_RestoreCrossgen` target depends on a package reference to
`Microsoft.NETCore.App` to be present.  However, for `netcoreapp3`
targeted applications, this requires the `ResolveFrameworkReferences`
target to execute.

This commit adds a target dependency from `_RestoreCrossgen` to
`ResolveFrameworkReferences` so that the package references are
populated when coming from a framework reference.

Fixes the CLI tests around `dotnet store` that invoke the crossgen
targets.