### PR TITLE
Fix shim apphost

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "3.0.100-preview-010000",
+    "dotnet": "3.0.100-preview-010166",
     "vs-opt": {
       "version": "15.9"
     }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ApphostResolver.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ApphostResolver.cs
@@ -21,13 +21,38 @@ namespace Microsoft.NET.Build.Tasks
                                string dotNetAppHostExecutableNameWithoutExtension,
                                Logger logger)
         {
+            if (string.IsNullOrWhiteSpace(appHostPackPattern))
+            {
+                throw new ArgumentException("message", nameof(appHostPackPattern));
+            }
+
+            if (string.IsNullOrWhiteSpace(appHostKnownRuntimeIdentifiers))
+            {
+                throw new ArgumentException("message", nameof(appHostKnownRuntimeIdentifiers));
+            }
+
+            if (string.IsNullOrWhiteSpace(appHostPackVersion))
+            {
+                throw new ArgumentException("message", nameof(appHostPackVersion));
+            }
+
+            if (string.IsNullOrWhiteSpace(targetingPackRoot))
+            {
+                throw new ArgumentException("message", nameof(targetingPackRoot));
+            }
+
+            if (string.IsNullOrWhiteSpace(dotNetAppHostExecutableNameWithoutExtension))
+            {
+                throw new ArgumentException("message", nameof(dotNetAppHostExecutableNameWithoutExtension));
+            }
+
             _appHostPackPattern = appHostPackPattern;
             _appHostKnownRuntimeIdentifiers = appHostKnownRuntimeIdentifiers;
             _appHostPackVersion = appHostPackVersion;
             _targetingPackRoot = targetingPackRoot;
-            _runtimeGraph = runtimeGraph;
+            _runtimeGraph = runtimeGraph ?? throw new ArgumentNullException(nameof(runtimeGraph));
             _dotNetAppHostExecutableNameWithoutExtension = dotNetAppHostExecutableNameWithoutExtension;
-            _logger = logger;
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
         private readonly string _appHostPackPattern;

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ApphostResolver.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ApphostResolver.cs
@@ -1,0 +1,84 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using NuGet.Frameworks;
+using NuGet.RuntimeModel;
+
+namespace Microsoft.NET.Build.Tasks
+{
+    internal static class ApphostResolver
+    {
+        public static (ITaskItem[] AppHost, List<TaskItem> AdditionalPackagesToDownload) GetAppHostItem(
+            string appHostPackPattern,
+            string appHostKnownRuntimeIdentifiers,
+            string appHostPackVersion,
+            string appHostRuntimeIdentifier,
+            string outputItemName, string targetingPackRoot, RuntimeGraph getRuntimeGraph,
+            string dotNetAppHostExecutableNameWithoutExtension, Logger logger)
+        {
+            var additionalPackagesToDownload = new List<TaskItem>();
+            if (!String.IsNullOrEmpty(appHostRuntimeIdentifier) && !String.IsNullOrEmpty(appHostPackPattern))
+            {
+                //  Choose AppHost RID as best match of the specified RID
+                string bestAppHostRuntimeIdentifier = getRuntimeGraph.GetBestRuntimeIdentifier(appHostRuntimeIdentifier, appHostKnownRuntimeIdentifiers, out bool wasInGraph);
+
+                if (bestAppHostRuntimeIdentifier == null)
+                {
+                    if (wasInGraph)
+                    {
+                        //  NETSDK1084: There was no app host for available for the specified RuntimeIdentifier '{0}'.
+                        logger.LogError(Strings.NoAppHostAvailable, appHostRuntimeIdentifier);
+                    }
+                    else
+                    {
+                        //  NETSDK1083: The specified RuntimeIdentifier '{0}' is not recognized.
+                        logger.LogError(Strings.UnsupportedRuntimeIdentifier, appHostRuntimeIdentifier);
+                    }
+                }
+                else
+                {
+                    string appHostPackName = appHostPackPattern.Replace("**RID**", bestAppHostRuntimeIdentifier);
+
+                    string appHostRelativePathInPackage = Path.Combine("runtimes", bestAppHostRuntimeIdentifier, "native",
+                        dotNetAppHostExecutableNameWithoutExtension +
+                        ExecutableExtension.ForRuntimeIdentifier(bestAppHostRuntimeIdentifier));
+
+
+                    TaskItem appHostItem = new TaskItem(outputItemName);
+                    string appHostPackPath = null;
+                    if (!String.IsNullOrEmpty(targetingPackRoot))
+                    {
+                        appHostPackPath = Path.Combine(targetingPackRoot, appHostPackName, appHostPackVersion);
+                    }
+
+                    if (appHostPackPath != null && Directory.Exists(appHostPackPath))
+                    {
+                        //  Use AppHost from packs folder
+                        appHostItem.SetMetadata(MetadataKeys.Path, Path.Combine(appHostPackPath, appHostRelativePathInPackage));
+                    }
+                    else
+                    {
+                        //  Download apphost pack
+                        TaskItem packageToDownload = new TaskItem(appHostPackName);
+                        packageToDownload.SetMetadata(MetadataKeys.Version, appHostPackVersion);
+                        additionalPackagesToDownload.Add(packageToDownload);
+
+                        appHostItem.SetMetadata(MetadataKeys.RuntimeIdentifier, appHostRuntimeIdentifier);
+                        appHostItem.SetMetadata(MetadataKeys.PackageName, appHostPackName);
+                        appHostItem.SetMetadata(MetadataKeys.PackageVersion, appHostPackVersion);
+                        appHostItem.SetMetadata(MetadataKeys.RelativePath, appHostRelativePathInPackage);
+                    }
+
+                    return (new ITaskItem[] {appHostItem}, additionalPackagesToDownload);
+                }
+            }
+
+            return (null, additionalPackagesToDownload);
+        }
+    }
+}

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ApphostResolver.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ApphostResolver.cs
@@ -17,7 +17,7 @@ namespace Microsoft.NET.Build.Tasks
                                string appHostKnownRuntimeIdentifiers,
                                string appHostPackVersion,
                                string targetingPackRoot,
-                               RuntimeGraph runtimeGraph,
+                               Lazy<RuntimeGraph> runtimeGraph,
                                string dotNetAppHostExecutableNameWithoutExtension,
                                Logger logger)
         {
@@ -34,7 +34,7 @@ namespace Microsoft.NET.Build.Tasks
         private readonly string _appHostKnownRuntimeIdentifiers;
         private readonly string _appHostPackVersion;
         private readonly string _targetingPackRoot;
-        private readonly RuntimeGraph _runtimeGraph;
+        private readonly Lazy<RuntimeGraph> _runtimeGraph;
         private readonly string _dotNetAppHostExecutableNameWithoutExtension;
         private readonly Logger _logger;
 
@@ -46,8 +46,10 @@ namespace Microsoft.NET.Build.Tasks
             if (!String.IsNullOrEmpty(appHostRuntimeIdentifier) && !String.IsNullOrEmpty(_appHostPackPattern))
             {
                 //  Choose AppHost RID as best match of the specified RID
+
                 string bestAppHostRuntimeIdentifier =
-                    _runtimeGraph.GetBestRuntimeIdentifier(
+                    BestRuntimeIdentifierFinder.GetBestRuntimeIdentifier(
+                        _runtimeGraph,
                         appHostRuntimeIdentifier,
                         _appHostKnownRuntimeIdentifiers,
                         out bool wasInGraph);

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ApphostResolver.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ApphostResolver.cs
@@ -21,36 +21,11 @@ namespace Microsoft.NET.Build.Tasks
                                string dotNetAppHostExecutableNameWithoutExtension,
                                Logger logger)
         {
-            if (string.IsNullOrWhiteSpace(appHostPackPattern))
-            {
-                throw new ArgumentException("message", nameof(appHostPackPattern));
-            }
-
-            if (string.IsNullOrWhiteSpace(appHostKnownRuntimeIdentifiers))
-            {
-                throw new ArgumentException("message", nameof(appHostKnownRuntimeIdentifiers));
-            }
-
-            if (string.IsNullOrWhiteSpace(appHostPackVersion))
-            {
-                throw new ArgumentException("message", nameof(appHostPackVersion));
-            }
-
-            if (string.IsNullOrWhiteSpace(targetingPackRoot))
-            {
-                throw new ArgumentException("message", nameof(targetingPackRoot));
-            }
-
-            if (string.IsNullOrWhiteSpace(dotNetAppHostExecutableNameWithoutExtension))
-            {
-                throw new ArgumentException("message", nameof(dotNetAppHostExecutableNameWithoutExtension));
-            }
-
             _appHostPackPattern = appHostPackPattern;
             _appHostKnownRuntimeIdentifiers = appHostKnownRuntimeIdentifiers;
             _appHostPackVersion = appHostPackVersion;
             _targetingPackRoot = targetingPackRoot;
-            _runtimeGraph = runtimeGraph ?? throw new ArgumentNullException(nameof(runtimeGraph));
+            _runtimeGraph = runtimeGraph;
             _dotNetAppHostExecutableNameWithoutExtension = dotNetAppHostExecutableNameWithoutExtension;
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ApphostResolver.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ApphostResolver.cs
@@ -11,9 +11,15 @@ using NuGet.RuntimeModel;
 
 namespace Microsoft.NET.Build.Tasks
 {
-    internal class ApphostResolver2
+    internal class ApphostResolver
     {
-        public ApphostResolver2(string appHostPackPattern, string appHostKnownRuntimeIdentifiers, string appHostPackVersion, string targetingPackRoot, RuntimeGraph runtimeGraph, string dotNetAppHostExecutableNameWithoutExtension, Logger logger)
+        public ApphostResolver(string appHostPackPattern,
+                               string appHostKnownRuntimeIdentifiers,
+                               string appHostPackVersion,
+                               string targetingPackRoot,
+                               RuntimeGraph runtimeGraph,
+                               string dotNetAppHostExecutableNameWithoutExtension,
+                               Logger logger)
         {
             AppHostPackPattern = appHostPackPattern;
             AppHostKnownRuntimeIdentifiers = appHostKnownRuntimeIdentifiers;
@@ -31,47 +37,44 @@ namespace Microsoft.NET.Build.Tasks
         public RuntimeGraph RuntimeGraph { get; private set; }
         public string DotNetAppHostExecutableNameWithoutExtension { get; private set; }
         public Logger Logger { get; private set; }
-    }
 
-    internal class ApphostResolver
-    {
-        public static (ITaskItem[] AppHost, List<TaskItem> AdditionalPackagesToDownload) GetAppHostItem(ApphostResolver2 apphostResolver2,
-            string appHostRuntimeIdentifier,
-            string outputItemName)
+        public (ITaskItem[] AppHost, List<TaskItem> AdditionalPackagesToDownload) GetAppHostItem(
+           string appHostRuntimeIdentifier,
+           string outputItemName)
         {
             var additionalPackagesToDownload = new List<TaskItem>();
-            if (!String.IsNullOrEmpty(appHostRuntimeIdentifier) && !String.IsNullOrEmpty(apphostResolver2.AppHostPackPattern))
+            if (!String.IsNullOrEmpty(appHostRuntimeIdentifier) && !String.IsNullOrEmpty(AppHostPackPattern))
             {
                 //  Choose AppHost RID as best match of the specified RID
-                string bestAppHostRuntimeIdentifier = apphostResolver2.RuntimeGraph.GetBestRuntimeIdentifier(appHostRuntimeIdentifier, apphostResolver2.AppHostKnownRuntimeIdentifiers, out bool wasInGraph);
+                string bestAppHostRuntimeIdentifier = RuntimeGraph.GetBestRuntimeIdentifier(appHostRuntimeIdentifier, AppHostKnownRuntimeIdentifiers, out bool wasInGraph);
 
                 if (bestAppHostRuntimeIdentifier == null)
                 {
                     if (wasInGraph)
                     {
                         //  NETSDK1084: There was no app host for available for the specified RuntimeIdentifier '{0}'.
-                        apphostResolver2.Logger.LogError(Strings.NoAppHostAvailable, appHostRuntimeIdentifier);
+                        Logger.LogError(Strings.NoAppHostAvailable, appHostRuntimeIdentifier);
                     }
                     else
                     {
                         //  NETSDK1083: The specified RuntimeIdentifier '{0}' is not recognized.
-                        apphostResolver2.Logger.LogError(Strings.UnsupportedRuntimeIdentifier, appHostRuntimeIdentifier);
+                        Logger.LogError(Strings.UnsupportedRuntimeIdentifier, appHostRuntimeIdentifier);
                     }
                 }
                 else
                 {
-                    string appHostPackName = apphostResolver2.AppHostPackPattern.Replace("**RID**", bestAppHostRuntimeIdentifier);
+                    string appHostPackName = AppHostPackPattern.Replace("**RID**", bestAppHostRuntimeIdentifier);
 
                     string appHostRelativePathInPackage = Path.Combine("runtimes", bestAppHostRuntimeIdentifier, "native",
-                        apphostResolver2.DotNetAppHostExecutableNameWithoutExtension +
+                        DotNetAppHostExecutableNameWithoutExtension +
                         ExecutableExtension.ForRuntimeIdentifier(bestAppHostRuntimeIdentifier));
 
 
                     TaskItem appHostItem = new TaskItem(outputItemName);
                     string appHostPackPath = null;
-                    if (!String.IsNullOrEmpty(apphostResolver2.TargetingPackRoot))
+                    if (!String.IsNullOrEmpty(TargetingPackRoot))
                     {
-                        appHostPackPath = Path.Combine(apphostResolver2.TargetingPackRoot, appHostPackName, apphostResolver2.AppHostPackVersion);
+                        appHostPackPath = Path.Combine(TargetingPackRoot, appHostPackName, AppHostPackVersion);
                     }
 
                     if (appHostPackPath != null && Directory.Exists(appHostPackPath))
@@ -83,16 +86,16 @@ namespace Microsoft.NET.Build.Tasks
                     {
                         //  Download apphost pack
                         TaskItem packageToDownload = new TaskItem(appHostPackName);
-                        packageToDownload.SetMetadata(MetadataKeys.Version, apphostResolver2.AppHostPackVersion);
+                        packageToDownload.SetMetadata(MetadataKeys.Version, AppHostPackVersion);
                         additionalPackagesToDownload.Add(packageToDownload);
 
                         appHostItem.SetMetadata(MetadataKeys.RuntimeIdentifier, appHostRuntimeIdentifier);
                         appHostItem.SetMetadata(MetadataKeys.PackageName, appHostPackName);
-                        appHostItem.SetMetadata(MetadataKeys.PackageVersion, apphostResolver2.AppHostPackVersion);
+                        appHostItem.SetMetadata(MetadataKeys.PackageVersion, AppHostPackVersion);
                         appHostItem.SetMetadata(MetadataKeys.RelativePath, appHostRelativePathInPackage);
                     }
 
-                    return (new ITaskItem[] {appHostItem}, additionalPackagesToDownload);
+                    return (new ITaskItem[] { appHostItem }, additionalPackagesToDownload);
                 }
             }
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolveApphostShimFromFrameworkReferences.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveApphostShimFromFrameworkReferences.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.Build.Framework;
 using static Microsoft.NET.Build.Tasks.ResolveFrameworkReferences;
 
@@ -11,13 +13,19 @@ namespace Microsoft.NET.Build.Tasks
     {
         public string TargetingPackRoot { get; set; }
 
+        public string TargetFrameworkIdentifier { get; set; }
+
+        public string TargetFrameworkVersion { get; set; }
+
         public ITaskItem[] PackAsToolShimAppHostRuntimeIdentifiers { get; set; }
 
         [Required]
         public string RuntimeGraphPath { get; set; }
 
         [Required]
-        public ITaskItem FrameworkReferenceWithApphost { get; set; }
+        public ITaskItem[] FrameworkReferenceWithApphost { get; set; }
+
+        public ITaskItem[] KnownFrameworkReferences { get; set; } = Array.Empty<ITaskItem>();
 
         /// <summary>
         /// The file name of Apphost asset.
@@ -34,7 +42,23 @@ namespace Microsoft.NET.Build.Tasks
         protected override void ExecuteCore()
         {
             List<ITaskItem> packagesToDownload = new List<ITaskItem>();
-            var knownFrameworkReference = new KnownFrameworkReference(FrameworkReferenceWithApphost);
+
+            if (FrameworkReferenceWithApphost.Length == 0)
+            {
+                return;
+            }
+            else if (FrameworkReferenceWithApphost.Length > 1)
+            {
+                throw new ArgumentException($"{nameof(FrameworkReferenceWithApphost)} should contain no more than 1 item.");
+            }
+
+            Dictionary<string, KnownFrameworkReference> knownFrameworkReferences =
+                KnownFrameworkReference.GetKnownFrameworkReferenceDictionary(
+                    KnownFrameworkReferences,
+                    TargetFrameworkIdentifier,
+                    TargetFrameworkVersion);
+
+            var knownFrameworkReference = knownFrameworkReferences[FrameworkReferenceWithApphost[0].ItemSpec];
 
             ApphostResolver apphostResolver =
              new ApphostResolver(

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolveApphostShimFromFrameworkReferences.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveApphostShimFromFrameworkReferences.cs
@@ -26,7 +26,7 @@ namespace Microsoft.NET.Build.Tasks
         public string DotNetAppHostExecutableNameWithoutExtension { get; set; }
 
         [Output]
-        public ITaskItem[] AdditionalPackagesToDownload { get; set; }
+        public ITaskItem[] PackagesToDownload { get; set; }
 
         [Output]
         public ITaskItem[] PackAsToolShimAppHosts { get; set; }
@@ -66,7 +66,7 @@ namespace Microsoft.NET.Build.Tasks
                 }
 
                 PackAsToolShimAppHosts = packAsToolShimAppHostsList.ToArray();
-                AdditionalPackagesToDownload = packagesToDownload.ToArray();
+                PackagesToDownload = packagesToDownload.ToArray();
             }
         }
     }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolveApphostShimFromFrameworkReferences.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveApphostShimFromFrameworkReferences.cs
@@ -3,9 +3,7 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using Microsoft.Build.Framework;
-using static Microsoft.NET.Build.Tasks.ResolveFrameworkReferences;
 
 namespace Microsoft.NET.Build.Tasks
 {

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolveApphostShimFromFrameworkReferences.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveApphostShimFromFrameworkReferences.cs
@@ -1,0 +1,73 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using Microsoft.Build.Framework;
+using static Microsoft.NET.Build.Tasks.ResolveFrameworkReferences;
+
+namespace Microsoft.NET.Build.Tasks
+{
+    public class ResolveApphostShimFromFrameworkReferences : TaskBase
+    {
+        public string TargetingPackRoot { get; set; }
+
+        public ITaskItem[] PackAsToolShimAppHostRuntimeIdentifiers { get; set; }
+
+        [Required]
+        public string RuntimeGraphPath { get; set; }
+
+        [Required]
+        public ITaskItem FrameworkReferenceWithApphost { get; set; }
+
+        /// <summary>
+        /// The file name of Apphost asset.
+        /// </summary>
+        [Required]
+        public string DotNetAppHostExecutableNameWithoutExtension { get; set; }
+
+        [Output]
+        public ITaskItem[] AdditionalPackagesToDownload { get; set; }
+
+        [Output]
+        public ITaskItem[] PackAsToolShimAppHosts { get; set; }
+
+        protected override void ExecuteCore()
+        {
+            List<ITaskItem> packagesToDownload = new List<ITaskItem>();
+            var knownFrameworkReference = new KnownFrameworkReference(FrameworkReferenceWithApphost);
+
+            ApphostResolver apphostResolver =
+             new ApphostResolver(
+                knownFrameworkReference.AppHostPackNamePattern,
+                knownFrameworkReference.AppHostRuntimeIdentifiers,
+                knownFrameworkReference.LatestRuntimeFrameworkVersion,
+                TargetingPackRoot,
+                new RuntimeGraphCache(this).GetRuntimeGraph(RuntimeGraphPath),
+                DotNetAppHostExecutableNameWithoutExtension,
+                Log);
+
+            if (PackAsToolShimAppHostRuntimeIdentifiers != null)
+            {
+                List<ITaskItem> packAsToolShimAppHostsList = new List<ITaskItem>();
+                foreach (var packAsToolShimAppHostRuntimeIdentifier in PackAsToolShimAppHostRuntimeIdentifiers)
+                {
+                    var shimApphostAndPackage
+                        = apphostResolver.GetAppHostItem(
+                            packAsToolShimAppHostRuntimeIdentifier.ItemSpec,
+                            "PackAsToolShimAppHost");
+
+                    var PackAsToolShimAppHosts = shimApphostAndPackage.AppHost;
+                    packagesToDownload.AddRange(shimApphostAndPackage.AdditionalPackagesToDownload);
+
+                    if (PackAsToolShimAppHosts != null)
+                    {
+                        packAsToolShimAppHostsList.AddRange(PackAsToolShimAppHosts);
+                    }
+                }
+
+                PackAsToolShimAppHosts = packAsToolShimAppHostsList.ToArray();
+                AdditionalPackagesToDownload = packagesToDownload.ToArray();
+            }
+        }
+    }
+}

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolveApphostShimFromFrameworkReferences.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveApphostShimFromFrameworkReferences.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using Microsoft.Build.Framework;
+using NuGet.RuntimeModel;
 
 namespace Microsoft.NET.Build.Tasks
 {
@@ -64,7 +65,7 @@ namespace Microsoft.NET.Build.Tasks
                 knownFrameworkReference.AppHostRuntimeIdentifiers,
                 knownFrameworkReference.LatestRuntimeFrameworkVersion,
                 TargetingPackRoot,
-                new RuntimeGraphCache(this).GetRuntimeGraph(RuntimeGraphPath),
+                new Lazy<RuntimeGraph>(() => new RuntimeGraphCache(this).GetRuntimeGraph(RuntimeGraphPath)),
                 DotNetAppHostExecutableNameWithoutExtension,
                 Log);
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolveFrameworkReferences.KnownFrameworkReference.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveFrameworkReferences.KnownFrameworkReference.cs
@@ -6,49 +6,63 @@ using NuGet.Frameworks;
 
 namespace Microsoft.NET.Build.Tasks
 {
-    public partial class ResolveFrameworkReferences
+    internal class KnownFrameworkReference
     {
-        internal class KnownFrameworkReference
+        ITaskItem _item;
+        public KnownFrameworkReference(ITaskItem item)
         {
-            ITaskItem _item;
-            public KnownFrameworkReference(ITaskItem item)
+            _item = item;
+            TargetFramework = NuGetFramework.Parse(item.GetMetadata("TargetFramework"));
+        }
+
+        //  The name / itemspec of the FrameworkReference used in the project
+        public string Name => _item.ItemSpec;
+
+        //  The framework name to write to the runtimeconfig file (and the name of the folder under dotnet/shared)
+        public string RuntimeFrameworkName => _item.GetMetadata("RuntimeFrameworkName");
+        public string DefaultRuntimeFrameworkVersion => _item.GetMetadata("DefaultRuntimeFrameworkVersion");
+        public string LatestRuntimeFrameworkVersion => _item.GetMetadata("LatestRuntimeFrameworkVersion");
+
+        //  The ID of the targeting pack NuGet package to reference
+        public string TargetingPackName => _item.GetMetadata("TargetingPackName");
+        public string TargetingPackVersion => _item.GetMetadata("TargetingPackVersion");
+
+        public string AppHostPackNamePattern => _item.GetMetadata("AppHostPackNamePattern");
+
+        public string AppHostRuntimeIdentifiers => _item.GetMetadata("AppHostRuntimeIdentifiers");
+
+        public string RuntimePackNamePatterns => _item.GetMetadata("RuntimePackNamePatterns");
+
+        public string RuntimePackRuntimeIdentifiers => _item.GetMetadata("RuntimePackRuntimeIdentifiers");
+
+        public NuGetFramework TargetFramework { get; }
+
+        public static Dictionary<string, KnownFrameworkReference> GetKnownFrameworkReferenceDictionary(
+            ITaskItem[] knownFrameworkReferences,
+            string targetFrameworkIdentifier,
+            string targetFrameworkVersion)
+        {
+            return knownFrameworkReferences.Select(item => new KnownFrameworkReference(item))
+            .Where(kfr => kfr.TargetFramework.Framework.Equals(targetFrameworkIdentifier, StringComparison.OrdinalIgnoreCase) &&
+                          NormalizeVersion(kfr.TargetFramework.Version) == NormalizeVersion(new Version(targetFrameworkVersion)))
+            .ToDictionary(kfr => kfr.Name);
+        }
+
+        private static Version NormalizeVersion(Version version)
+        {
+            if (version.Revision == 0)
             {
-                _item = item;
-                TargetFramework = NuGetFramework.Parse(item.GetMetadata("TargetFramework"));
+                if (version.Build == 0)
+                {
+                    return new Version(version.Major, version.Minor);
+                }
+                else
+                {
+                    return new Version(version.Major, version.Minor, version.Build);
+                }
             }
 
-            //  The name / itemspec of the FrameworkReference used in the project
-            public string Name => _item.ItemSpec;
-
-            //  The framework name to write to the runtimeconfig file (and the name of the folder under dotnet/shared)
-            public string RuntimeFrameworkName => _item.GetMetadata("RuntimeFrameworkName");
-            public string DefaultRuntimeFrameworkVersion => _item.GetMetadata("DefaultRuntimeFrameworkVersion");
-            public string LatestRuntimeFrameworkVersion => _item.GetMetadata("LatestRuntimeFrameworkVersion");
-
-            //  The ID of the targeting pack NuGet package to reference
-            public string TargetingPackName => _item.GetMetadata("TargetingPackName");
-            public string TargetingPackVersion => _item.GetMetadata("TargetingPackVersion");
-
-            public string AppHostPackNamePattern => _item.GetMetadata("AppHostPackNamePattern");
-
-            public string AppHostRuntimeIdentifiers => _item.GetMetadata("AppHostRuntimeIdentifiers");
-
-            public string RuntimePackNamePatterns => _item.GetMetadata("RuntimePackNamePatterns");
-
-            public string RuntimePackRuntimeIdentifiers => _item.GetMetadata("RuntimePackRuntimeIdentifiers");
-
-            public NuGetFramework TargetFramework { get; }
-
-            public static Dictionary<string, KnownFrameworkReference> GetKnownFrameworkReferenceDictionary(
-                ITaskItem[] knownFrameworkReferences,
-                string targetFrameworkIdentifier,
-                string targetFrameworkVersion)
-            {
-                return knownFrameworkReferences.Select(item => new KnownFrameworkReference(item))
-                .Where(kfr => kfr.TargetFramework.Framework.Equals(targetFrameworkIdentifier, StringComparison.OrdinalIgnoreCase) &&
-                              NormalizeVersion(kfr.TargetFramework.Version) == NormalizeVersion(new Version(targetFrameworkVersion)))
-                .ToDictionary(kfr => kfr.Name);
-            }
+            return version;
         }
     }
 }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolveFrameworkReferences.KnownFrameworkReference.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveFrameworkReferences.KnownFrameworkReference.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.Build.Framework;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Build.Framework;
 using NuGet.Frameworks;
 
 namespace Microsoft.NET.Build.Tasks
@@ -35,6 +38,17 @@ namespace Microsoft.NET.Build.Tasks
             public string RuntimePackRuntimeIdentifiers => _item.GetMetadata("RuntimePackRuntimeIdentifiers");
 
             public NuGetFramework TargetFramework { get; }
+
+            public static Dictionary<string, KnownFrameworkReference> GetKnownFrameworkReferenceDictionary(
+                ITaskItem[] knownFrameworkReferences,
+                string targetFrameworkIdentifier,
+                string targetFrameworkVersion)
+            {
+                return knownFrameworkReferences.Select(item => new KnownFrameworkReference(item))
+                .Where(kfr => kfr.TargetFramework.Framework.Equals(targetFrameworkIdentifier, StringComparison.OrdinalIgnoreCase) &&
+                              NormalizeVersion(kfr.TargetFramework.Version) == NormalizeVersion(new Version(targetFrameworkVersion)))
+                .ToDictionary(kfr => kfr.Name);
+            }
         }
     }
 }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolveFrameworkReferences.KnownFrameworkReference.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveFrameworkReferences.KnownFrameworkReference.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.Build.Framework;
+using NuGet.Frameworks;
+
+namespace Microsoft.NET.Build.Tasks
+{
+    public partial class ResolveFrameworkReferences
+    {
+        internal class KnownFrameworkReference
+        {
+            ITaskItem _item;
+            public KnownFrameworkReference(ITaskItem item)
+            {
+                _item = item;
+                TargetFramework = NuGetFramework.Parse(item.GetMetadata("TargetFramework"));
+            }
+
+            //  The name / itemspec of the FrameworkReference used in the project
+            public string Name => _item.ItemSpec;
+
+            //  The framework name to write to the runtimeconfig file (and the name of the folder under dotnet/shared)
+            public string RuntimeFrameworkName => _item.GetMetadata("RuntimeFrameworkName");
+            public string DefaultRuntimeFrameworkVersion => _item.GetMetadata("DefaultRuntimeFrameworkVersion");
+            public string LatestRuntimeFrameworkVersion => _item.GetMetadata("LatestRuntimeFrameworkVersion");
+
+            //  The ID of the targeting pack NuGet package to reference
+            public string TargetingPackName => _item.GetMetadata("TargetingPackName");
+            public string TargetingPackVersion => _item.GetMetadata("TargetingPackVersion");
+
+            public string AppHostPackNamePattern => _item.GetMetadata("AppHostPackNamePattern");
+
+            public string AppHostRuntimeIdentifiers => _item.GetMetadata("AppHostRuntimeIdentifiers");
+
+            public string RuntimePackNamePatterns => _item.GetMetadata("RuntimePackNamePatterns");
+
+            public string RuntimePackRuntimeIdentifiers => _item.GetMetadata("RuntimePackRuntimeIdentifiers");
+
+            public NuGetFramework TargetFramework { get; }
+        }
+    }
+}

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolveFrameworkReferences.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveFrameworkReferences.cs
@@ -2,11 +2,9 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using NuGet.Frameworks;
-using NuGet.RuntimeModel;
 
 namespace Microsoft.NET.Build.Tasks
 {
@@ -137,7 +135,13 @@ namespace Microsoft.NET.Build.Tasks
                     {
                         foreach (var runtimePackNamePattern in knownFrameworkReference.RuntimePackNamePatterns.Split(';'))
                         {
-                            string runtimePackRuntimeIdentifier = new RuntimeGraphCache(this).GetRuntimeGraph(RuntimeGraphPath).GetBestRuntimeIdentifier(RuntimeIdentifier, knownFrameworkReference.RuntimePackRuntimeIdentifiers, out bool wasInGraph);
+                            string runtimePackRuntimeIdentifier =
+                                new RuntimeGraphCache(this)
+                                .GetRuntimeGraph(RuntimeGraphPath)
+                                .GetBestRuntimeIdentifier(
+                                    RuntimeIdentifier,
+                                    knownFrameworkReference.RuntimePackRuntimeIdentifiers,
+                                    out bool wasInGraph);
 
                             if (runtimePackRuntimeIdentifier == null)
                             {
@@ -186,8 +190,8 @@ namespace Microsoft.NET.Build.Tasks
                 }
             }
 
-            ApphostResolver apphostResolver
-                = new ApphostResolver(
+            ApphostResolver apphostResolver =
+                 new ApphostResolver(
                     appHostPackPattern,
                     appHostKnownRuntimeIdentifiers,
                     appHostPackVersion,
@@ -206,7 +210,10 @@ namespace Microsoft.NET.Build.Tasks
                 List<ITaskItem> packAsToolShimAppHostsList = new List<ITaskItem>();
                 foreach (var packAsToolShimAppHostRuntimeIdentifier in PackAsToolShimAppHostRuntimeIdentifiers)
                 {
-                    var shimApphostAndPackage = apphostResolver.GetAppHostItem(packAsToolShimAppHostRuntimeIdentifier.ItemSpec, "PackAsToolShimAppHost");
+                    var shimApphostAndPackage
+                        = apphostResolver.GetAppHostItem(
+                            packAsToolShimAppHostRuntimeIdentifier.ItemSpec,
+                            "PackAsToolShimAppHost");
 
                     var PackAsToolShimAppHosts = shimApphostAndPackage.AppHost;
                     packagesToDownload.AddRange(shimApphostAndPackage.AdditionalPackagesToDownload);

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolveFrameworkReferences.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveFrameworkReferences.cs
@@ -137,11 +137,7 @@ namespace Microsoft.NET.Build.Tasks
                     {
                         foreach (var runtimePackNamePattern in knownFrameworkReference.RuntimePackNamePatterns.Split(';'))
                         {
-                            string runtimePackRuntimeIdentifier = RuntimeGraphExtensions.GetBestRuntimeIdentifier(
-                                RuntimeIdentifier,
-                                knownFrameworkReference.RuntimePackRuntimeIdentifiers,
-                                new RuntimeGraphCache(this).GetRuntimeGraph(RuntimeGraphPath),
-                                out bool wasInGraph);
+                            string runtimePackRuntimeIdentifier = new RuntimeGraphCache(this).GetRuntimeGraph(RuntimeGraphPath).GetBestRuntimeIdentifier(RuntimeIdentifier, knownFrameworkReference.RuntimePackRuntimeIdentifiers, out bool wasInGraph);
 
                             if (runtimePackRuntimeIdentifier == null)
                             {
@@ -250,11 +246,7 @@ namespace Microsoft.NET.Build.Tasks
             if (!string.IsNullOrEmpty(appHostRuntimeIdentifier) && !string.IsNullOrEmpty(appHostPackPattern))
             {
                 //  Choose AppHost RID as best match of the specified RID
-                string bestAppHostRuntimeIdentifier = RuntimeGraphExtensions.GetBestRuntimeIdentifier(
-                        appHostRuntimeIdentifier,
-                        appHostRuntimeIdentifiers,
-                        new RuntimeGraphCache(this).GetRuntimeGraph(RuntimeGraphPath),
-                        out bool wasInGraph);
+                string bestAppHostRuntimeIdentifier = new RuntimeGraphCache(this).GetRuntimeGraph(RuntimeGraphPath).GetBestRuntimeIdentifier(appHostRuntimeIdentifier, appHostRuntimeIdentifiers, out bool wasInGraph);
 
                 if (bestAppHostRuntimeIdentifier == null)
                 {

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolveFrameworkReferences.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveFrameworkReferences.cs
@@ -7,7 +7,6 @@ using System.IO;
 using System.Linq;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
-using NuGet.Frameworks;
 
 namespace Microsoft.NET.Build.Tasks
 {

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolveFrameworkReferences.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveFrameworkReferences.cs
@@ -186,7 +186,17 @@ namespace Microsoft.NET.Build.Tasks
                 }
             }
 
-            var AppHostAndAdditionalPackageToDownload = ApphostResolver.GetAppHostItem(new ApphostResolver2(appHostPackPattern, appHostKnownRuntimeIdentifiers, appHostPackVersion, TargetingPackRoot, new RuntimeGraphCache(this).GetRuntimeGraph(RuntimeGraphPath), DotNetAppHostExecutableNameWithoutExtension, Log), AppHostRuntimeIdentifier, "AppHost");
+            ApphostResolver apphostResolver
+                = new ApphostResolver(
+                    appHostPackPattern,
+                    appHostKnownRuntimeIdentifiers,
+                    appHostPackVersion,
+                    TargetingPackRoot,
+                    new RuntimeGraphCache(this).GetRuntimeGraph(RuntimeGraphPath),
+                    DotNetAppHostExecutableNameWithoutExtension,
+                    Log);
+
+            var AppHostAndAdditionalPackageToDownload = apphostResolver.GetAppHostItem(AppHostRuntimeIdentifier, "AppHost");
 
             AppHost = AppHostAndAdditionalPackageToDownload.AppHost;
             packagesToDownload.AddRange(AppHostAndAdditionalPackageToDownload.AdditionalPackagesToDownload);
@@ -196,7 +206,7 @@ namespace Microsoft.NET.Build.Tasks
                 List<ITaskItem> packAsToolShimAppHostsList = new List<ITaskItem>();
                 foreach (var packAsToolShimAppHostRuntimeIdentifier in PackAsToolShimAppHostRuntimeIdentifiers)
                 {
-                    var shimApphostAndPackage = ApphostResolver.GetAppHostItem(new ApphostResolver2(appHostPackPattern, appHostKnownRuntimeIdentifiers, appHostPackVersion, TargetingPackRoot, new RuntimeGraphCache(this).GetRuntimeGraph(RuntimeGraphPath), DotNetAppHostExecutableNameWithoutExtension, Log), packAsToolShimAppHostRuntimeIdentifier.ItemSpec, "PackAsToolShimAppHost");
+                    var shimApphostAndPackage = apphostResolver.GetAppHostItem(packAsToolShimAppHostRuntimeIdentifier.ItemSpec, "PackAsToolShimAppHost");
 
                     var PackAsToolShimAppHosts = shimApphostAndPackage.AppHost;
                     packagesToDownload.AddRange(shimApphostAndPackage.AdditionalPackagesToDownload);

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolveFrameworkReferences.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveFrameworkReferences.cs
@@ -186,7 +186,7 @@ namespace Microsoft.NET.Build.Tasks
                 }
             }
 
-            var AppHostAndAdditionalPackageToDownload = ApphostResolver.GetAppHostItem(appHostPackPattern, appHostKnownRuntimeIdentifiers, appHostPackVersion, AppHostRuntimeIdentifier, "AppHost", TargetingPackRoot, new RuntimeGraphCache(this).GetRuntimeGraph(RuntimeGraphPath), DotNetAppHostExecutableNameWithoutExtension, Log);
+            var AppHostAndAdditionalPackageToDownload = ApphostResolver.GetAppHostItem(new ApphostResolver2(appHostPackPattern, appHostKnownRuntimeIdentifiers, appHostPackVersion, TargetingPackRoot, new RuntimeGraphCache(this).GetRuntimeGraph(RuntimeGraphPath), DotNetAppHostExecutableNameWithoutExtension, Log), AppHostRuntimeIdentifier, "AppHost");
 
             AppHost = AppHostAndAdditionalPackageToDownload.AppHost;
             packagesToDownload.AddRange(AppHostAndAdditionalPackageToDownload.AdditionalPackagesToDownload);
@@ -196,14 +196,7 @@ namespace Microsoft.NET.Build.Tasks
                 List<ITaskItem> packAsToolShimAppHostsList = new List<ITaskItem>();
                 foreach (var packAsToolShimAppHostRuntimeIdentifier in PackAsToolShimAppHostRuntimeIdentifiers)
                 {
-                    var shimApphostAndPackage = ApphostResolver.GetAppHostItem(
-                            appHostPackPattern,
-                            appHostKnownRuntimeIdentifiers,
-                            appHostPackVersion,
-                            packAsToolShimAppHostRuntimeIdentifier.ItemSpec,
-                        "PackAsToolShimAppHost", TargetingPackRoot,
-                        new RuntimeGraphCache(this).GetRuntimeGraph(RuntimeGraphPath),
-                        DotNetAppHostExecutableNameWithoutExtension, Log);
+                    var shimApphostAndPackage = ApphostResolver.GetAppHostItem(new ApphostResolver2(appHostPackPattern, appHostKnownRuntimeIdentifiers, appHostPackVersion, TargetingPackRoot, new RuntimeGraphCache(this).GetRuntimeGraph(RuntimeGraphPath), DotNetAppHostExecutableNameWithoutExtension, Log), packAsToolShimAppHostRuntimeIdentifier.ItemSpec, "PackAsToolShimAppHost");
 
                     var PackAsToolShimAppHosts = shimApphostAndPackage.AppHost;
                     packagesToDownload.AddRange(shimApphostAndPackage.AdditionalPackagesToDownload);

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolveFrameworkReferences.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveFrameworkReferences.cs
@@ -7,7 +7,6 @@ using System.IO;
 using System.Linq;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
-using NuGet.Frameworks;
 
 namespace Microsoft.NET.Build.Tasks
 {
@@ -16,7 +15,7 @@ namespace Microsoft.NET.Build.Tasks
     /// targeting packs which provide the reference assemblies, and creates RuntimeFramework
     /// items, which are written to the runtimeconfig file
     /// </summary>
-    public partial class ResolveFrameworkReferences : TaskBase
+    public class ResolveFrameworkReferences : TaskBase
     {
         public string TargetFrameworkIdentifier { get; set; }
 
@@ -238,23 +237,6 @@ namespace Microsoft.NET.Build.Tasks
         private string GetPackPath(string name, string version)
         {
             return Path.Combine(TargetingPackRoot, name, version);
-        }
-
-        private static Version NormalizeVersion(Version version)
-        {
-            if (version.Revision == 0)
-            {
-                if (version.Build == 0)
-                {
-                    return new Version(version.Major, version.Minor);
-                }
-                else
-                {
-                    return new Version(version.Major, version.Minor, version.Build);
-                }
-            }
-
-            return version;
         }
     }
 }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolveFrameworkReferences.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveFrameworkReferences.cs
@@ -310,7 +310,7 @@ namespace Microsoft.NET.Build.Tasks
             return null;
         }
 
-        private string GetBestRuntimeIdentifier(string targetRuntimeIdentifier, string availableRuntimeIdentifiers,
+        private static string GetBestRuntimeIdentifier(string targetRuntimeIdentifier, string availableRuntimeIdentifiers,
             RuntimeGraph runtimeGraph, out bool wasInGraph)
         {
             if (targetRuntimeIdentifier == null || availableRuntimeIdentifiers == null)

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolveFrameworkReferences.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveFrameworkReferences.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Linq;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
+using NuGet.RuntimeModel;
 
 namespace Microsoft.NET.Build.Tasks
 {
@@ -138,10 +139,12 @@ namespace Microsoft.NET.Build.Tasks
                     {
                         foreach (var runtimePackNamePattern in knownFrameworkReference.RuntimePackNamePatterns.Split(';'))
                         {
+                            var runtimeGraph = new Lazy<RuntimeGraph>(
+                                () => new RuntimeGraphCache(this).GetRuntimeGraph(RuntimeGraphPath));
+
                             string runtimePackRuntimeIdentifier =
-                                new RuntimeGraphCache(this)
-                                .GetRuntimeGraph(RuntimeGraphPath)
-                                .GetBestRuntimeIdentifier(
+                                BestRuntimeIdentifierFinder.GetBestRuntimeIdentifier(
+                                    runtimeGraph,
                                     RuntimeIdentifier,
                                     knownFrameworkReference.RuntimePackRuntimeIdentifiers,
                                     out bool wasInGraph);
@@ -199,7 +202,7 @@ namespace Microsoft.NET.Build.Tasks
                     appHostKnownRuntimeIdentifiers,
                     appHostPackVersion,
                     TargetingPackRoot,
-                    new RuntimeGraphCache(this).GetRuntimeGraph(RuntimeGraphPath),
+                    new Lazy<RuntimeGraph>(() => new RuntimeGraphCache(this).GetRuntimeGraph(RuntimeGraphPath)),
                     DotNetAppHostExecutableNameWithoutExtension,
                     Log);
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolveFrameworkReferences.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveFrameworkReferences.cs
@@ -83,7 +83,7 @@ namespace Microsoft.NET.Build.Tasks
 
             string appHostPackPattern = null;
             string appHostPackVersion = null;
-            string appHostRuntimeIdentifiers = null;
+            string appHostKnownRuntimeIdentifiers = null;
 
             foreach (var frameworkReference in FrameworkReferences)
             {
@@ -96,7 +96,7 @@ namespace Microsoft.NET.Build.Tasks
                         {
                             appHostPackPattern = knownFrameworkReference.AppHostPackNamePattern;
                             appHostPackVersion = knownFrameworkReference.LatestRuntimeFrameworkVersion;
-                            appHostRuntimeIdentifiers = knownFrameworkReference.AppHostRuntimeIdentifiers;
+                            appHostKnownRuntimeIdentifiers = knownFrameworkReference.AppHostRuntimeIdentifiers;
                         }
                         else
                         {
@@ -186,7 +186,7 @@ namespace Microsoft.NET.Build.Tasks
                 }
             }
 
-            AppHost = GetAppHostItem(appHostPackPattern, appHostRuntimeIdentifiers, appHostPackVersion,
+            AppHost = GetAppHostItem(appHostPackPattern, appHostKnownRuntimeIdentifiers, appHostPackVersion,
                 packagesToDownload, AppHostRuntimeIdentifier, "AppHost", TargetingPackRoot, new RuntimeGraphCache(this).GetRuntimeGraph(RuntimeGraphPath), DotNetAppHostExecutableNameWithoutExtension, Log);
 
             if (PackAsToolShimAppHostRuntimeIdentifiers != null)
@@ -196,7 +196,7 @@ namespace Microsoft.NET.Build.Tasks
                 {
                     var PackAsToolShimAppHosts = GetAppHostItem(
                             appHostPackPattern,
-                            appHostRuntimeIdentifiers,
+                            appHostKnownRuntimeIdentifiers,
                             appHostPackVersion,
                             packagesToDownload,
                             packAsToolShimAppHostRuntimeIdentifier.ItemSpec,
@@ -237,11 +237,12 @@ namespace Microsoft.NET.Build.Tasks
         }
 
         private static ITaskItem[] GetAppHostItem(
-            string appHostPackPattern, 
+            string appHostPackPattern,
             string appHostRuntimeIdentifiers,
-            string appHostPackVersion, List<ITaskItem> packagesToDownload, 
-            string appHostRuntimeIdentifier, 
-            string itemName, string targetingPackRoot, RuntimeGraph getRuntimeGraph, string dotNetAppHostExecutableNameWithoutExtension, Logger logger)
+            string appHostPackVersion, List<ITaskItem> packagesToDownload,
+            string appHostRuntimeIdentifier,
+            string itemName, string targetingPackRoot, RuntimeGraph getRuntimeGraph,
+            string dotNetAppHostExecutableNameWithoutExtension, Logger logger)
         {
             if (!string.IsNullOrEmpty(appHostRuntimeIdentifier) && !string.IsNullOrEmpty(appHostPackPattern))
             {

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolveFrameworkReferences.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveFrameworkReferences.cs
@@ -137,7 +137,7 @@ namespace Microsoft.NET.Build.Tasks
                     {
                         foreach (var runtimePackNamePattern in knownFrameworkReference.RuntimePackNamePatterns.Split(';'))
                         {
-                            string runtimePackRuntimeIdentifier = GetBestRuntimeIdentifier(
+                            string runtimePackRuntimeIdentifier = RuntimeGraphExtensions.GetBestRuntimeIdentifier(
                                 RuntimeIdentifier,
                                 knownFrameworkReference.RuntimePackRuntimeIdentifiers,
                                 new RuntimeGraphCache(this).GetRuntimeGraph(RuntimeGraphPath),
@@ -250,8 +250,7 @@ namespace Microsoft.NET.Build.Tasks
             if (!string.IsNullOrEmpty(appHostRuntimeIdentifier) && !string.IsNullOrEmpty(appHostPackPattern))
             {
                 //  Choose AppHost RID as best match of the specified RID
-                string bestAppHostRuntimeIdentifier =
-                    GetBestRuntimeIdentifier(
+                string bestAppHostRuntimeIdentifier = RuntimeGraphExtensions.GetBestRuntimeIdentifier(
                         appHostRuntimeIdentifier,
                         appHostRuntimeIdentifiers,
                         new RuntimeGraphCache(this).GetRuntimeGraph(RuntimeGraphPath),
@@ -308,22 +307,6 @@ namespace Microsoft.NET.Build.Tasks
                 }
             }
             return null;
-        }
-
-        private static string GetBestRuntimeIdentifier(string targetRuntimeIdentifier, string availableRuntimeIdentifiers,
-            RuntimeGraph runtimeGraph, out bool wasInGraph)
-        {
-            if (targetRuntimeIdentifier == null || availableRuntimeIdentifiers == null)
-            {
-                wasInGraph = false;
-                return null;
-            }
-
-            return NuGetUtils.GetBestMatchingRid(
-                runtimeGraph,
-                targetRuntimeIdentifier,
-                availableRuntimeIdentifiers.Split(';'),
-                out wasInGraph);
         }
 
         private string GetPackPath(string name, string version)

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolveFrameworkReferences.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveFrameworkReferences.cs
@@ -241,7 +241,7 @@ namespace Microsoft.NET.Build.Tasks
             string appHostRuntimeIdentifiers,
             string appHostPackVersion, List<ITaskItem> packagesToDownload,
             string appHostRuntimeIdentifier,
-            string itemName, string targetingPackRoot, RuntimeGraph getRuntimeGraph,
+            string outputItemName, string targetingPackRoot, RuntimeGraph getRuntimeGraph,
             string dotNetAppHostExecutableNameWithoutExtension, Logger logger)
         {
             if (!string.IsNullOrEmpty(appHostRuntimeIdentifier) && !string.IsNullOrEmpty(appHostPackPattern))
@@ -271,7 +271,7 @@ namespace Microsoft.NET.Build.Tasks
                         ExecutableExtension.ForRuntimeIdentifier(bestAppHostRuntimeIdentifier));
 
 
-                    TaskItem appHostItem = new TaskItem(itemName);
+                    TaskItem appHostItem = new TaskItem(outputItemName);
                     string appHostPackPath = null;
                     if (!string.IsNullOrEmpty(targetingPackRoot))
                     {

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageAssets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageAssets.cs
@@ -948,6 +948,13 @@ namespace Microsoft.NET.Build.Tasks
 
             private void WriteApphostsForShimRuntimeIdentifiers()
             {
+                NuGetFramework targetFramework = NuGetUtils.ParseFrameworkName(_task.TargetFrameworkMoniker);
+
+                if (CannotResolveApphostFromAssetFile(targetFramework))
+                {
+                    return;
+                }
+
                 if (_task.ShimRuntimeIdentifiers == null || _task.ShimRuntimeIdentifiers.Length == 0)
                 {
                     return;
@@ -955,7 +962,6 @@ namespace Microsoft.NET.Build.Tasks
 
                 foreach (var runtimeIdentifier in _task.ShimRuntimeIdentifiers.Select(r => r.ItemSpec))
                 {
-                    NuGetFramework targetFramework = NuGetUtils.ParseFrameworkName(_task.TargetFrameworkMoniker);
                     LockFileTarget runtimeTarget = _lockFile.GetTargetAndThrowIfNotFound(targetFramework, runtimeIdentifier);
 
                     var apphostName = _task.DotNetAppHostExecutableNameWithoutExtension + ExecutableExtension.ForRuntimeIdentifier(runtimeIdentifier);
@@ -965,6 +971,19 @@ namespace Microsoft.NET.Build.Tasks
                     WriteItem(resolvedPackageAssetPathAndLibrary.Item1, resolvedPackageAssetPathAndLibrary.Item2);
                     WriteMetadata(MetadataKeys.RuntimeIdentifier, runtimeIdentifier);
                 }
+            }
+
+            /// <summary>
+            /// After netcoreapp3.0 apphost is resolved during ResolveFrameworkReferences. It should return nothing here
+            /// </summary>
+            private static bool CannotResolveApphostFromAssetFile(NuGetFramework targetFramework)
+            {
+                if (targetFramework.Version.Major >= 3)
+                {
+                    return true;
+                }
+
+                return false;
             }
 
             private void WritePackageFolders()

--- a/src/Tasks/Microsoft.NET.Build.Tasks/RuntimeGraphExtensions.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/RuntimeGraphExtensions.cs
@@ -1,0 +1,26 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using NuGet.RuntimeModel;
+
+namespace Microsoft.NET.Build.Tasks
+{
+    internal static class RuntimeGraphExtensions
+    {
+        internal static string GetBestRuntimeIdentifier(string targetRuntimeIdentifier, string availableRuntimeIdentifiers,
+            RuntimeGraph runtimeGraph, out bool wasInGraph)
+        {
+            if (targetRuntimeIdentifier == null || availableRuntimeIdentifiers == null)
+            {
+                wasInGraph = false;
+                return null;
+            }
+
+            return NuGetUtils.GetBestMatchingRid(
+                runtimeGraph,
+                targetRuntimeIdentifier,
+                availableRuntimeIdentifiers.Split(';'),
+                out wasInGraph);
+        }
+    }
+}

--- a/src/Tasks/Microsoft.NET.Build.Tasks/RuntimeGraphExtensions.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/RuntimeGraphExtensions.cs
@@ -7,8 +7,9 @@ namespace Microsoft.NET.Build.Tasks
 {
     internal static class RuntimeGraphExtensions
     {
-        internal static string GetBestRuntimeIdentifier(string targetRuntimeIdentifier, string availableRuntimeIdentifiers,
-            RuntimeGraph runtimeGraph, out bool wasInGraph)
+        internal static string GetBestRuntimeIdentifier(this RuntimeGraph runtimeGraph, string targetRuntimeIdentifier,
+            string availableRuntimeIdentifiers,
+            out bool wasInGraph)
         {
             if (targetRuntimeIdentifier == null || availableRuntimeIdentifiers == null)
             {

--- a/src/Tasks/Microsoft.NET.Build.Tasks/RuntimeGraphExtensions.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/RuntimeGraphExtensions.cs
@@ -1,13 +1,16 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using NuGet.RuntimeModel;
 
 namespace Microsoft.NET.Build.Tasks
 {
-    internal static class RuntimeGraphExtensions
+    internal static class BestRuntimeIdentifierFinder
     {
-        internal static string GetBestRuntimeIdentifier(this RuntimeGraph runtimeGraph, string targetRuntimeIdentifier,
+        internal static string GetBestRuntimeIdentifier(
+            Lazy<RuntimeGraph> runtimeGraph,
+            string targetRuntimeIdentifier,
             string availableRuntimeIdentifiers,
             out bool wasInGraph)
         {
@@ -18,7 +21,7 @@ namespace Microsoft.NET.Build.Tasks
             }
 
             return NuGetUtils.GetBestMatchingRid(
-                runtimeGraph,
+                runtimeGraph.Value,
                 targetRuntimeIdentifier,
                 availableRuntimeIdentifiers.Split(';'),
                 out wasInGraph);

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -648,7 +648,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <Target Name="ComputeEmbeddedApphostPaths">
 
     <ItemGroup>
-      <_PackAsToolShimRuntimeIdentifiers Include="$(PackAsToolShimRuntimeIdentifiers)"/>
+      <_PackAsToolShimRuntimeIdentifiers Condition="@(_PackAsToolShimRuntimeIdentifiers) ==''" Include="$(PackAsToolShimRuntimeIdentifiers)"/>
     </ItemGroup>
 
     <GetEmbeddedApphostPaths

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.TargetingPackResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.TargetingPackResolution.targets
@@ -46,12 +46,17 @@ Copyright (c) .NET Foundation. All rights reserved.
       <AppHostRuntimeIdentifier Condition="'$(AppHostRuntimeIdentifier)' == ''">$(DefaultAppHostRuntimeIdentifier)</AppHostRuntimeIdentifier>
     </PropertyGroup>
 
+    <ItemGroup>
+      <_PackAsToolShimRuntimeIdentifiers Condition="@(_PackAsToolShimRuntimeIdentifiers) ==''" Include="$(PackAsToolShimRuntimeIdentifiers)"/>
+    </ItemGroup>
+
     <ResolveFrameworkReferences FrameworkReferences="@(FrameworkReference)"
                                 KnownFrameworkReferences="@(KnownFrameworkReference)"
                                 TargetFrameworkIdentifier="$(TargetFrameworkIdentifier)"
                                 TargetFrameworkVersion="$(_TargetFrameworkVersionWithoutV)"
                                 TargetingPackRoot="$(NetCoreTargetingPackRoot)"
                                 AppHostRuntimeIdentifier="$(AppHostRuntimeIdentifier)"
+                                PackAsToolShimAppHostRuntimeIdentifiers="@(_PackAsToolShimRuntimeIdentifiers)"
                                 RuntimeGraphPath="$(BundledRuntimeIdentifierGraphFile)"
                                 SelfContained="$(SelfContained)"
                                 RuntimeIdentifier="$(RuntimeIdentifier)"
@@ -62,6 +67,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       <Output TaskParameter="TargetingPacks" ItemName="TargetingPack" />
       <Output TaskParameter="RuntimePacks" ItemName="RuntimePack" />
       <Output TaskParameter="AppHost" ItemName="AppHostPack" />
+      <Output TaskParameter="PackAsToolShimAppHosts" ItemName="PackAsToolShimAppHostPack" />
 
       <Output TaskParameter="UnresolvedFrameworkReferences" ItemName="_UnresolvedFrameworkReference" />
 
@@ -131,6 +137,21 @@ Copyright (c) .NET Foundation. All rights reserved.
       <Output TaskParameter="Output" ItemName="ResolvedAppHostPack" />
 
     </GetPackageDirectory>
+
+    <GetPackageDirectory
+      Items="@(PackAsToolShimAppHostPack)"
+      ProjectPath="$(MSBuildProjectFullPath)"
+      PackageFolders="@(AssetsFilePackageFolder)">
+
+      <Output TaskParameter="Output" ItemName="_ApphostsForShimRuntimeIdentifiersGetPackageDirectory" />
+
+    </GetPackageDirectory>
+
+    <ItemGroup>
+      <_ApphostsForShimRuntimeIdentifiers Include="%(_ApphostsForShimRuntimeIdentifiersGetPackageDirectory.PackageDirectory)\%(_ApphostsForShimRuntimeIdentifiersGetPackageDirectory.RelativePath)" >
+        <RuntimeIdentifier>%(_ApphostsForShimRuntimeIdentifiersGetPackageDirectory.RuntimeIdentifier)</RuntimeIdentifier>
+       </_ApphostsForShimRuntimeIdentifiers>
+    </ItemGroup>
 
     <ItemGroup>
       <ResolvedAppHostPack>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.TargetingPackResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.TargetingPackResolution.targets
@@ -46,17 +46,12 @@ Copyright (c) .NET Foundation. All rights reserved.
       <AppHostRuntimeIdentifier Condition="'$(AppHostRuntimeIdentifier)' == ''">$(DefaultAppHostRuntimeIdentifier)</AppHostRuntimeIdentifier>
     </PropertyGroup>
 
-    <ItemGroup>
-      <_PackAsToolShimRuntimeIdentifiers Condition="@(_PackAsToolShimRuntimeIdentifiers) ==''" Include="$(PackAsToolShimRuntimeIdentifiers)"/>
-    </ItemGroup>
-
     <ResolveFrameworkReferences FrameworkReferences="@(FrameworkReference)"
                                 KnownFrameworkReferences="@(KnownFrameworkReference)"
                                 TargetFrameworkIdentifier="$(TargetFrameworkIdentifier)"
                                 TargetFrameworkVersion="$(_TargetFrameworkVersionWithoutV)"
                                 TargetingPackRoot="$(NetCoreTargetingPackRoot)"
                                 AppHostRuntimeIdentifier="$(AppHostRuntimeIdentifier)"
-                                PackAsToolShimAppHostRuntimeIdentifiers="@(_PackAsToolShimRuntimeIdentifiers)"
                                 RuntimeGraphPath="$(BundledRuntimeIdentifierGraphFile)"
                                 SelfContained="$(SelfContained)"
                                 RuntimeIdentifier="$(RuntimeIdentifier)"
@@ -67,14 +62,42 @@ Copyright (c) .NET Foundation. All rights reserved.
       <Output TaskParameter="TargetingPacks" ItemName="TargetingPack" />
       <Output TaskParameter="RuntimePacks" ItemName="RuntimePack" />
       <Output TaskParameter="AppHost" ItemName="AppHostPack" />
-      <Output TaskParameter="PackAsToolShimAppHosts" ItemName="PackAsToolShimAppHostPack" />
 
+      <Output TaskParameter="FrameworkReferenceWithApphost" ItemName="_FrameworkReferenceWithApphost" />
       <Output TaskParameter="UnresolvedFrameworkReferences" ItemName="_UnresolvedFrameworkReference" />
 
     </ResolveFrameworkReferences>
 
     <ItemGroup>
       <PackageReference Include="@(PackageReferenceToAdd)"
+                        IsImplicitlyDefined="true"
+                        PrivateAssets="all"
+                        ExcludeAssets="all" />
+    </ItemGroup>
+
+  </Target>
+
+  <Target Name="ResolvePackAsToolShimApphosts"
+          Condition="$(PackAsToolShimRuntimeIdentifiers) !=''"
+          BeforeTargets="_CheckForInvalidConfigurationAndPlatform;CollectPackageReferences" DependsOnTargets="ResolveFrameworkReferences">
+
+    <ItemGroup>
+      <_PackAsToolShimRuntimeIdentifiers Condition="@(_PackAsToolShimRuntimeIdentifiers) ==''" Include="$(PackAsToolShimRuntimeIdentifiers)"/>
+    </ItemGroup>
+
+    <ResolveFrameworkReferences TargetingPackRoot="$(NetCoreTargetingPackRoot)"
+                                RuntimeGraphPath="$(BundledRuntimeIdentifierGraphFile)"
+                                DotNetAppHostExecutableNameWithoutExtension="$(_DotNetAppHostExecutableNameWithoutExtension)"
+                                FrameworkReferenceWithApphost="$(_FrameworkReferenceWithApphost)"
+                                PackAsToolShimAppHostRuntimeIdentifiers="@(_PackAsToolShimRuntimeIdentifiers)">
+
+      <Output TaskParameter="PackagesToDownload" ItemName="_PackagesToDownloadForPackAsToolShimApphosts" />
+      <Output TaskParameter="PackAsToolShimAppHosts" ItemName="PackAsToolShimAppHostPack" />
+
+    </ResolveFrameworkReferences>
+
+    <ItemGroup>
+      <PackageReference Include="@(_PackagesToDownloadForPackAsToolShimApphosts)"
                         IsImplicitlyDefined="true"
                         PrivateAssets="all"
                         ExcludeAssets="all" />

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.TargetingPackResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.TargetingPackResolution.targets
@@ -19,6 +19,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
 
   <UsingTask TaskName="ResolveFrameworkReferences" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
+  <UsingTask TaskName="ResolveApphostShimFromFrameworkReferences" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
 
   <Target Name="ResolveFrameworkReferences" BeforeTargets="_CheckForInvalidConfigurationAndPlatform;CollectPackageReferences">
     <ItemGroup>
@@ -79,22 +80,27 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <Target Name="ResolvePackAsToolShimApphosts"
           Condition="$(PackAsToolShimRuntimeIdentifiers) !=''"
-          BeforeTargets="_CheckForInvalidConfigurationAndPlatform;CollectPackageReferences" DependsOnTargets="ResolveFrameworkReferences">
+          BeforeTargets="_CheckForInvalidConfigurationAndPlatform;CollectPackageReferences"
+          DependsOnTargets="ResolveFrameworkReferences">
 
     <ItemGroup>
       <_PackAsToolShimRuntimeIdentifiers Condition="@(_PackAsToolShimRuntimeIdentifiers) ==''" Include="$(PackAsToolShimRuntimeIdentifiers)"/>
     </ItemGroup>
 
-    <ResolveFrameworkReferences TargetingPackRoot="$(NetCoreTargetingPackRoot)"
+    <ResolveApphostShimFromFrameworkReferences
+                                TargetingPackRoot="$(NetCoreTargetingPackRoot)"
+                                TargetFrameworkIdentifier="$(TargetFrameworkIdentifier)"
+                                TargetFrameworkVersion="$(_TargetFrameworkVersionWithoutV)"
+                                KnownFrameworkReferences="@(KnownFrameworkReference)"
                                 RuntimeGraphPath="$(BundledRuntimeIdentifierGraphFile)"
                                 DotNetAppHostExecutableNameWithoutExtension="$(_DotNetAppHostExecutableNameWithoutExtension)"
-                                FrameworkReferenceWithApphost="$(_FrameworkReferenceWithApphost)"
+                                FrameworkReferenceWithApphost="@(_FrameworkReferenceWithApphost)"
                                 PackAsToolShimAppHostRuntimeIdentifiers="@(_PackAsToolShimRuntimeIdentifiers)">
 
       <Output TaskParameter="PackagesToDownload" ItemName="_PackagesToDownloadForPackAsToolShimApphosts" />
       <Output TaskParameter="PackAsToolShimAppHosts" ItemName="PackAsToolShimAppHostPack" />
 
-    </ResolveFrameworkReferences>
+    </ResolveApphostShimFromFrameworkReferences>
 
     <ItemGroup>
       <PackageReference Include="@(_PackagesToDownloadForPackAsToolShimApphosts)"

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.PackageDependencyResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.PackageDependencyResolution.targets
@@ -216,7 +216,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     </PropertyGroup>
 
     <ItemGroup>
-      <_PackAsToolShimRuntimeIdentifiers Include="$(PackAsToolShimRuntimeIdentifiers)"/>
+      <_PackAsToolShimRuntimeIdentifiers Condition="@(_PackAsToolShimRuntimeIdentifiers) ==''" Include="$(PackAsToolShimRuntimeIdentifiers)"/>
 
       <!-- Pass these packages into the ResolvePackageAssets task to verify that the restored versions of the packages
            match the expected version -->
@@ -250,7 +250,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       <!-- NOTE: items names here are inconsistent because they match prior implementation
           (that was spread across different tasks/targets) for backwards compatibility.  -->
       <Output TaskParameter="Analyzers" ItemName="ResolvedAnalyzers" />
-      <Output TaskParameter="ApphostsForShimRuntimeIdentifiers" ItemName="_ApphostsForShimRuntimeIdentifiers" />
+      <Output TaskParameter="ApphostsForShimRuntimeIdentifiers" ItemName="_ApphostsForShimRuntimeIdentifiersResolvePackageAssets" />
       <Output TaskParameter="ContentFilesToPreprocess" ItemName="_ContentFilesToPreprocess" />
       <Output TaskParameter="FrameworkAssemblies" ItemName="ResolvedFrameworkAssemblies" />
       <Output TaskParameter="NativeLibraries" ItemName="NativeCopyLocalItems" />
@@ -265,6 +265,10 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ItemGroup Condition="'$(UseAppHostFromAssetsFile)' == 'true'">
       <_NativeRestoredAppHostNETCore Include="@(NativeCopyLocalItems)"
                                      Condition="'%(NativeCopyLocalItems.FileName)%(NativeCopyLocalItems.Extension)' == '$(_DotNetAppHostExecutableName)'"/>
+    </ItemGroup>
+
+    <ItemGroup Condition="'@(_ApphostsForShimRuntimeIdentifiers)' == ''">
+      <_ApphostsForShimRuntimeIdentifiers Include="@(_ApphostsForShimRuntimeIdentifiersResolvePackageAssets)"/>
     </ItemGroup>
 
   </Target>

--- a/src/Tests/Microsoft.NET.PerformanceTests/Microsoft.NET.PerformanceTests.csproj
+++ b/src/Tests/Microsoft.NET.PerformanceTests/Microsoft.NET.PerformanceTests.csproj
@@ -40,16 +40,4 @@
 
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 
-  <Target Name="PopulatePerformanceTestsFromGitHub" BeforeTargets="CoreCompile">
-    <PropertyGroup>
-      <PerformanceTestsRepoURL>https://github.com/dotnet/BuildPerformanceTestAssets</PerformanceTestsRepoURL>
-      <PerformanceTestsCommit>c967e0f</PerformanceTestsCommit>
-      <PerformanceTestsLocalDirectory>$(RepoRoot).perftestsource</PerformanceTestsLocalDirectory>
-    </PropertyGroup>
-
-    <Exec Condition="!Exists($(PerformanceTestsLocalDirectory))"
-          WorkingDirectory="$(RepoRoot)" Command="git clone --quiet $(PerformanceTestsRepoURL) $(PerformanceTestsLocalDirectory)" />
-    <Exec WorkingDirectory="$(PerformanceTestsLocalDirectory)" Command="git checkout --quiet $(PerformanceTestsCommit)" />
-  </Target>
-
 </Project>

--- a/src/Tests/Microsoft.NET.PerformanceTests/Microsoft.NET.PerformanceTests.csproj
+++ b/src/Tests/Microsoft.NET.PerformanceTests/Microsoft.NET.PerformanceTests.csproj
@@ -40,4 +40,16 @@
 
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 
+  <Target Name="PopulatePerformanceTestsFromGitHub" BeforeTargets="CoreCompile">
+    <PropertyGroup>
+      <PerformanceTestsRepoURL>https://github.com/dotnet/BuildPerformanceTestAssets</PerformanceTestsRepoURL>
+      <PerformanceTestsCommit>c967e0f</PerformanceTestsCommit>
+      <PerformanceTestsLocalDirectory>$(RepoRoot).perftestsource</PerformanceTestsLocalDirectory>
+    </PropertyGroup>
+
+    <Exec Condition="!Exists($(PerformanceTestsLocalDirectory))"
+          WorkingDirectory="$(RepoRoot)" Command="git clone --quiet $(PerformanceTestsRepoURL) $(PerformanceTestsLocalDirectory)" />
+    <Exec WorkingDirectory="$(PerformanceTestsLocalDirectory)" Command="git checkout --quiet $(PerformanceTestsCommit)" />
+  </Target>
+
 </Project>

--- a/src/Tests/Microsoft.NET.ToolPack.Tests/GivenThatWeWantToPackAToolProjectWithPackagedShim.cs
+++ b/src/Tests/Microsoft.NET.ToolPack.Tests/GivenThatWeWantToPackAToolProjectWithPackagedShim.cs
@@ -194,10 +194,10 @@ namespace Microsoft.NET.ToolPack.Tests
             var cleanCommand = new CleanCommand(Log, helloWorldAsset.TestRoot);
             cleanCommand.Execute().Should().Pass();
 
-            var outputDirectory = packCommand.GetOutputDirectory("netcoreapp2.1");
-            string windowShimPath = Path.Combine(outputDirectory.FullName, $"shims/netcoreapp2.1/win-x64/{_customToolCommandName}.exe");
+            var outputDirectory = packCommand.GetOutputDirectory(targetFramework);
+            string windowShimPath = Path.Combine(outputDirectory.FullName, $"shims/{targetFramework}/win-x64/{_customToolCommandName}.exe");
             File.Exists(windowShimPath).Should().BeFalse($"Shim {windowShimPath} should not exists");
-            string osxShimPath = Path.Combine(outputDirectory.FullName, $"shims/netcoreapp2.1/osx.10.12-x64/{_customToolCommandName}");
+            string osxShimPath = Path.Combine(outputDirectory.FullName, $"shims/{targetFramework}/osx.10.12-x64/{_customToolCommandName}");
             File.Exists(osxShimPath).Should().BeFalse($"Shim {osxShimPath} should not exists");
         }
 

--- a/src/Tests/Microsoft.NET.ToolPack.Tests/GivenThatWeWantToPackAToolProjectWithPackagedShim.cs
+++ b/src/Tests/Microsoft.NET.ToolPack.Tests/GivenThatWeWantToPackAToolProjectWithPackagedShim.cs
@@ -32,15 +32,20 @@ namespace Microsoft.NET.ToolPack.Tests
         private string SetupNuGetPackage(
             bool multiTarget,
             [CallerMemberName] string callingMethod = "",
-            Dictionary<string, string> additionalProperty = null)
+            Dictionary<string, string> additionalProperty = null,
+            string targetFramework = null)
         {
-            TestAsset helloWorldAsset = CreateTestAsset(multiTarget, callingMethod, additionalProperty);
+            TestAsset helloWorldAsset = CreateTestAsset(
+                multiTarget,
+                callingMethod + multiTarget + targetFramework,
+                targetFramework,
+                additionalProperty);
 
             _testRoot = helloWorldAsset.TestRoot;
 
             var packCommand = new PackCommand(Log, helloWorldAsset.TestRoot);
-
-            packCommand.Execute().Should().Pass();
+            packCommand.WorkingDirectory = helloWorldAsset.TestRoot;
+            packCommand.Execute("-bl").Should().Pass();
             _packageId = Path.GetFileNameWithoutExtension(packCommand.ProjectFile);
 
             return packCommand.GetNuGetPackage(packageVersion: _packageVersion);
@@ -49,6 +54,7 @@ namespace Microsoft.NET.ToolPack.Tests
         private TestAsset CreateTestAsset(
             bool multiTarget,
             string uniqueName,
+            string targetFramework,
             Dictionary<string, string> additionalProperty = null)
         {
             return _testAssetsManager
@@ -69,74 +75,41 @@ namespace Microsoft.NET.ToolPack.Tests
                         }
                     }
 
+                    propertyGroup.Element(ns + "TargetFramework").Remove();
+                    propertyGroup.Add(new XElement(ns + "TargetFramework", targetFramework));
+
                     if (multiTarget)
                     {
                         propertyGroup.Element(ns + "TargetFramework").Remove();
-                        propertyGroup.Add(new XElement(ns + "TargetFrameworks", "netcoreapp2.1"));
+                        propertyGroup.Add(new XElement(ns + "TargetFrameworks", targetFramework));
                     }
                 })
                 .Restore(Log);
         }
 
         [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void It_packs_successfully(bool multiTarget)
+        [InlineData(true, "netcoreapp2.1")]
+        [InlineData(false, "netcoreapp2.1")]
+        [InlineData(true, "netcoreapp3.0")]
+        [InlineData(false, "netcoreapp3.0")]
+        public void Given_default_pack_and_result_nugetPackage(bool multiTarget, string targetFramework)
         {
-            var nugetPackage = SetupNuGetPackage(multiTarget);
+            var nugetPackage = SetupNuGetPackage(multiTarget, targetFramework: targetFramework);
             using (var nupkgReader = new PackageArchiveReader(nugetPackage))
             {
-                nupkgReader
-                    .GetToolItems()
-                    .Should().NotBeEmpty();
+                // Combine assertions to reuse setup and save non trivial time
+                It_packs_successfully(nugetPackage);
+                It_contains_dependencies_dll(nupkgReader);
+                It_contains_shim(nupkgReader);
             }
         }
 
         [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void It_contains_dependencies_dll(bool multiTarget)
-        {
-            var nugetPackage = SetupNuGetPackage(multiTarget);
-            using (var nupkgReader = new PackageArchiveReader(nugetPackage))
-            {
-                IEnumerable<NuGetFramework> supportedFrameworks = nupkgReader.GetSupportedFrameworks();
-                supportedFrameworks.Should().NotBeEmpty();
-
-                foreach (NuGetFramework framework in supportedFrameworks)
-                {
-                    var allItems = nupkgReader.GetToolItems().SelectMany(i => i.Items).ToList();
-                    allItems.Should().Contain($"tools/{framework.GetShortFolderName()}/any/Newtonsoft.Json.dll");
-                }
-            }
-        }
-
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void It_contains_shim(bool multiTarget)
-        {
-            var nugetPackage = SetupNuGetPackage(multiTarget);
-            using (var nupkgReader = new PackageArchiveReader(nugetPackage))
-            {
-                IEnumerable<NuGetFramework> supportedFrameworks = nupkgReader.GetSupportedFrameworks();
-                supportedFrameworks.Should().NotBeEmpty();
-
-                foreach (NuGetFramework framework in supportedFrameworks)
-                {
-                    var allItems = nupkgReader.GetToolItems().SelectMany(i => i.Items).ToList();
-                    allItems.Should().Contain($"tools/{framework.GetShortFolderName()}/any/shims/win-x64/{_customToolCommandName}.exe",
-                        "Name should be the same as the command name even customized");
-                    allItems.Should().Contain($"tools/{framework.GetShortFolderName()}/any/shims/osx.10.12-x64/{_customToolCommandName}",
-                        "RID should be the exact match of the RID in the property, even Apphost only has version of win, osx and linux");
-                }
-            }
-        }
-
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void It_uses_customized_PackagedShimOutputRootDirectory(bool multiTarget)
+        [InlineData(true, "netcoreapp2.1")]
+        [InlineData(false, "netcoreapp2.1")]
+        [InlineData(true, "netcoreapp3.0")]
+        [InlineData(false, "netcoreapp3.0")]
+        public void It_uses_customized_PackagedShimOutputRootDirectory(bool multiTarget, string targetFramework)
         {
             string shimoutputPath = Path.Combine(TestContext.Current.TestExecutionDirectory, "shimoutput");
             TestAsset helloWorldAsset = _testAssetsManager
@@ -150,10 +123,13 @@ namespace Microsoft.NET.ToolPack.Tests
                     propertyGroup.Add(new XElement(ns + "ToolCommandName", _customToolCommandName));
                     propertyGroup.Add(new XElement(ns + "PackagedShimOutputRootDirectory", shimoutputPath));
 
+                    propertyGroup.Element(ns + "TargetFramework").Remove();
+                    propertyGroup.Add(new XElement(ns + "TargetFramework", targetFramework));
+
                     if (multiTarget)
                     {
                         propertyGroup.Element(ns + "TargetFramework").Remove();
-                        propertyGroup.Add(new XElement(ns + "TargetFrameworks", "netcoreapp2.1"));
+                        propertyGroup.Add(new XElement(ns + "TargetFrameworks", targetFramework));
                     }
                 })
                 .Restore(Log);
@@ -164,58 +140,51 @@ namespace Microsoft.NET.ToolPack.Tests
 
             packCommand.Execute().Should().Pass();
 
-            string windowShimPath = Path.Combine(shimoutputPath, $"shims/netcoreapp2.1/win-x64/{_customToolCommandName}.exe");
+            string windowShimPath = Path.Combine(shimoutputPath, $"shims/{targetFramework}/win-x64/{_customToolCommandName}.exe");
             File.Exists(windowShimPath).Should().BeTrue($"Shim {windowShimPath} should exist");
-            string osxShimPath = Path.Combine(shimoutputPath, $"shims/netcoreapp2.1/osx.10.12-x64/{_customToolCommandName}");
+            string osxShimPath = Path.Combine(shimoutputPath, $"shims/{targetFramework}/osx.10.12-x64/{_customToolCommandName}");
             File.Exists(osxShimPath).Should().BeTrue($"Shim {osxShimPath} should exist");
         }
 
         [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void It_uses_outputs_to_bin_by_default(bool multiTarget)
+        [InlineData(true, "netcoreapp2.1")]
+        [InlineData(false, "netcoreapp2.1")]
+        [InlineData(true, "netcoreapp3.0")]
+        [InlineData(false, "netcoreapp3.0")]
+        public void It_uses_outputs_to_bin_by_default(bool multiTarget, string targetFramework)
         {
-            TestAsset helloWorldAsset = SetUpHelloWorld(multiTarget);
+            TestAsset helloWorldAsset = CreateTestAsset(
+                multiTarget,
+                nameof(It_uses_outputs_to_bin_by_default)
+                + multiTarget
+                + targetFramework,
+                targetFramework: targetFramework);
 
             _testRoot = helloWorldAsset.TestRoot;
 
             var packCommand = new PackCommand(Log, helloWorldAsset.TestRoot);
-            var outputDirectory = packCommand.GetOutputDirectory("netcoreapp2.1");
+            var outputDirectory = packCommand.GetOutputDirectory(targetFramework);
             packCommand.Execute().Should().Pass();
 
-            string windowShimPath = Path.Combine(outputDirectory.FullName, $"shims/netcoreapp2.1/win-x64/{_customToolCommandName}.exe");
+            string windowShimPath = Path.Combine(outputDirectory.FullName, $"shims/{targetFramework}/win-x64/{_customToolCommandName}.exe");
             File.Exists(windowShimPath).Should().BeTrue($"Shim {windowShimPath} should exist");
-            string osxShimPath = Path.Combine(outputDirectory.FullName, $"shims/netcoreapp2.1/osx.10.12-x64/{_customToolCommandName}");
+            string osxShimPath = Path.Combine(outputDirectory.FullName, $"shims/{targetFramework}/osx.10.12-x64/{_customToolCommandName}");
             File.Exists(osxShimPath).Should().BeTrue($"Shim {osxShimPath} should exist");
         }
 
-        private TestAsset SetUpHelloWorld(bool multiTarget, [CallerMemberName] string callingMethod = "")
-        {
-            return _testAssetsManager
-                .CopyTestAsset("PortableTool", callingMethod + multiTarget)
-                .WithSource()
-                .WithProjectChanges(project =>
-                {
-                    XNamespace ns = project.Root.Name.Namespace;
-                    XElement propertyGroup = project.Root.Elements(ns + "PropertyGroup").First();
-                    propertyGroup.Add(new XElement(ns + "PackAsToolShimRuntimeIdentifiers", "win-x64;osx.10.12-x64"));
-                    propertyGroup.Add(new XElement(ns + "ToolCommandName", _customToolCommandName));
-
-                    if (multiTarget)
-                    {
-                        propertyGroup.Element(ns + "TargetFramework").Remove();
-                        propertyGroup.Add(new XElement(ns + "TargetFrameworks", "netcoreapp2.1"));
-                    }
-                })
-                .Restore(Log);
-        }
-
         [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void Clean_should_remove_bin_output(bool multiTarget)
+        [InlineData(true, "netcoreapp2.1")]
+        [InlineData(false, "netcoreapp2.1")]
+        [InlineData(true, "netcoreapp3.0")]
+        [InlineData(false, "netcoreapp3.0")]
+        public void Clean_should_remove_bin_output(bool multiTarget, string targetFramework)
         {
-            TestAsset helloWorldAsset = SetUpHelloWorld(multiTarget);
+            TestAsset helloWorldAsset = CreateTestAsset(
+                multiTarget,
+                nameof(Clean_should_remove_bin_output)
+                + multiTarget
+                + targetFramework,
+                targetFramework: targetFramework);
 
             _testRoot = helloWorldAsset.TestRoot;
 
@@ -233,19 +202,26 @@ namespace Microsoft.NET.ToolPack.Tests
         }
 
         [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void Generate_shims_runs_incrementally(bool multiTarget)
+        [InlineData(true, "netcoreapp2.1")]
+        [InlineData(false, "netcoreapp2.1")]
+        [InlineData(true, "netcoreapp3.0")]
+        [InlineData(false, "netcoreapp3.0")]
+        public void Generate_shims_runs_incrementally(bool multiTarget, string targetFramework)
         {
-            TestAsset helloWorldAsset = SetUpHelloWorld(multiTarget);
+            TestAsset helloWorldAsset = CreateTestAsset(
+                multiTarget,
+                nameof(Generate_shims_runs_incrementally)
+                + multiTarget
+                + targetFramework,
+                targetFramework: targetFramework);
 
             _testRoot = helloWorldAsset.TestRoot;
 
             var buildCommand = new BuildCommand(Log, helloWorldAsset.TestRoot);
             buildCommand.Execute().Should().Pass();
 
-            var outputDirectory = buildCommand.GetOutputDirectory("netcoreapp2.1");
-            string windowShimPath = Path.Combine(outputDirectory.FullName, $"shims/netcoreapp2.1/win-x64/{_customToolCommandName}.exe");
+            var outputDirectory = buildCommand.GetOutputDirectory(targetFramework);
+            string windowShimPath = Path.Combine(outputDirectory.FullName, $"shims/{targetFramework}.1/win-x64/{_customToolCommandName}.exe");
 
             DateTime windowShimPathFirstModifiedTime = File.GetLastWriteTimeUtc(windowShimPath);
 
@@ -257,11 +233,13 @@ namespace Microsoft.NET.ToolPack.Tests
         }
 
         [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void It_contains_shim_with_no_build(bool multiTarget)
+        [InlineData(true, "netcoreapp2.1")]
+        [InlineData(false, "netcoreapp2.1")]
+        [InlineData(true, "netcoreapp3.0")]
+        [InlineData(false, "netcoreapp3.0")]
+        public void It_contains_shim_with_no_build(bool multiTarget, string targetFramework)
         {
-            var testAsset = CreateTestAsset(multiTarget, "shim_with_no_build" + multiTarget);
+            var testAsset = CreateTestAsset(multiTarget, nameof(It_contains_shim_with_no_build) + multiTarget + targetFramework, targetFramework);
 
             var buildCommand = new BuildCommand(Log, testAsset.TestRoot);
             buildCommand.Execute().Should().Pass();
@@ -288,9 +266,11 @@ namespace Microsoft.NET.ToolPack.Tests
         }
 
         [WindowsOnlyTheory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void It_produces_valid_shims(bool multiTarget)
+        [InlineData(true, "netcoreapp2.1")]
+        [InlineData(false, "netcoreapp2.1")]
+        [InlineData(true, "netcoreapp3.0")]
+        [InlineData(false, "netcoreapp3.0")]
+        public void It_produces_valid_shims(bool multiTarget, string targetFramework)
         {
             if (!Environment.Is64BitOperatingSystem)
             {
@@ -298,14 +278,16 @@ namespace Microsoft.NET.ToolPack.Tests
                 return;
             }
 
-            var nugetPackage = SetupNuGetPackage(multiTarget);
+            var nugetPackage = SetupNuGetPackage(multiTarget, targetFramework: targetFramework);
             AssertValidShim(_testRoot, nugetPackage);
         }
 
         [WindowsOnlyTheory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void It_produces_valid_shims_when_the_first_build_is_wrong(bool multiTarget)
+        [InlineData(true, "netcoreapp2.1")]
+        [InlineData(false, "netcoreapp2.1")]
+        [InlineData(true, "netcoreapp3.0")]
+        [InlineData(false, "netcoreapp3.0")]
+        public void It_produces_valid_shims_when_the_first_build_is_wrong(bool multiTarget, string targetFramework)
         {
             // The first build use wrong package id and should embed wrong string to shims. However, the pack should produce correct shim
             // since it includes build target. And the incremental build should consider the shim to be invalid and recreate that.
@@ -316,7 +298,9 @@ namespace Microsoft.NET.ToolPack.Tests
                 return;
             }
 
-            TestAsset helloWorldAsset = CreateTestAsset(multiTarget, "It_produces_valid_shims2" + multiTarget.ToString());
+            TestAsset helloWorldAsset = CreateTestAsset(multiTarget,
+                "It_produces_valid_shims2" + multiTarget + targetFramework,
+                targetFramework: targetFramework);
 
             var testRoot = helloWorldAsset.TestRoot;
 
@@ -334,9 +318,11 @@ namespace Microsoft.NET.ToolPack.Tests
         }
 
         [WindowsOnlyTheory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void When_version_and_packageVersion_is_different_It_produces_valid_shims(bool multiTarget)
+        [InlineData(true, "netcoreapp2.1")]
+        [InlineData(false, "netcoreapp2.1")]
+        [InlineData(true, "netcoreapp3.0")]
+        [InlineData(false, "netcoreapp3.0")]
+        public void When_version_and_packageVersion_is_different_It_produces_valid_shims(bool multiTarget, string targetFramework)
         {
             if (!Environment.Is64BitOperatingSystem)
             {
@@ -349,15 +335,18 @@ namespace Microsoft.NET.ToolPack.Tests
                 {
                     ["version"] = "1.0.0-rtm",
                     ["packageVersion"] = _packageVersion
-                });
+                },
+                targetFramework: targetFramework);
 
             AssertValidShim(_testRoot, nugetPackage);
         }
 
         [WindowsOnlyTheory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void When_version_and_packageVersion_is_different_It_produces_valid_shims2(bool multiTarget)
+        [InlineData(true, "netcoreapp2.1")]
+        [InlineData(false, "netcoreapp2.1")]
+        [InlineData(true, "netcoreapp3.0")]
+        [InlineData(false, "netcoreapp3.0")]
+        public void When_version_and_packageVersion_is_different_It_produces_valid_shims2(bool multiTarget, string targetFramework)
         {
             if (!Environment.Is64BitOperatingSystem)
             {
@@ -371,9 +360,47 @@ namespace Microsoft.NET.ToolPack.Tests
                 additionalProperty: new Dictionary<string, string>()
                 {
                     ["version"] = "1000",
-                });
+                },
+                targetFramework: targetFramework);
 
             AssertValidShim(_testRoot, nugetPackage);
+        }
+
+        private static void It_packs_successfully(string nugetPackage)
+        {
+            using (var nupkgReader = new PackageArchiveReader(nugetPackage))
+            {
+                nupkgReader
+                    .GetToolItems()
+                    .Should().NotBeEmpty();
+            }
+        }
+
+        private static void It_contains_dependencies_dll(PackageArchiveReader nupkgReader)
+        {
+            IEnumerable<NuGetFramework> supportedFrameworks = nupkgReader.GetSupportedFrameworks();
+            supportedFrameworks.Should().NotBeEmpty();
+
+            foreach (NuGetFramework framework in supportedFrameworks)
+            {
+                var allItems = nupkgReader.GetToolItems().SelectMany(i => i.Items).ToList();
+                allItems.Should().Contain($"tools/{framework.GetShortFolderName()}/any/Newtonsoft.Json.dll");
+            }
+        }
+
+        private static void It_contains_shim(PackageArchiveReader nupkgReader)
+        {
+            IEnumerable<NuGetFramework> supportedFrameworks = nupkgReader.GetSupportedFrameworks();
+            supportedFrameworks.Should().NotBeEmpty();
+
+            foreach (NuGetFramework framework in supportedFrameworks)
+            {
+                var allItems = nupkgReader.GetToolItems().SelectMany(i => i.Items).ToList();
+                allItems.Should().Contain($"tools/{framework.GetShortFolderName()}/any/shims/win-x64/{_customToolCommandName}.exe",
+                    "Name should be the same as the command name even customized");
+                allItems.Should().Contain($"tools/{framework.GetShortFolderName()}/any/shims/osx.10.12-x64/{_customToolCommandName}",
+                    "RID should be the exact match of the RID in the property, even Apphost only has version of win, osx and linux");
+            }
         }
 
         private void AssertValidShim(string testRoot, string nugetPackage)

--- a/src/Tests/Microsoft.NET.ToolPack.Tests/GivenThatWeWantToPackAToolProjectWithPackagedShim.cs
+++ b/src/Tests/Microsoft.NET.ToolPack.Tests/GivenThatWeWantToPackAToolProjectWithPackagedShim.cs
@@ -44,8 +44,7 @@ namespace Microsoft.NET.ToolPack.Tests
             _testRoot = helloWorldAsset.TestRoot;
 
             var packCommand = new PackCommand(Log, helloWorldAsset.TestRoot);
-            packCommand.WorkingDirectory = helloWorldAsset.TestRoot;
-            packCommand.Execute("-bl").Should().Pass();
+            packCommand.Execute().Should().Pass();
             _packageId = Path.GetFileNameWithoutExtension(packCommand.ProjectFile);
 
             return packCommand.GetNuGetPackage(packageVersion: _packageVersion);


### PR DESCRIPTION
Will squash before merge. Will hold for preview 3

It might be hard to read from direct diff. 798624c is the initial change to make it work. After that are all refactorings to separate it into 2 Targets.

Fix https://github.com/dotnet/sdk/issues/2867