### PR TITLE
Ensure Microsoft.NETCore.App is an implicit dependency for publish.

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/ProjectContext.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ProjectContext.cs
@@ -13,7 +13,6 @@ namespace Microsoft.NET.Build.Tasks
     internal class ProjectContext
     {
         private const string NetCorePlatformLibrary = "Microsoft.NETCore.App";
-        private const string AspNetPlatformLibrary = "Microsoft.AspNetCore.App";
 
         private readonly LockFile _lockFile;
         private readonly LockFileTarget _lockFileTarget;
@@ -67,9 +66,9 @@ namespace Microsoft.NET.Build.Tasks
             {
                 allExclusionList.UnionWith(_lockFileTarget.GetPlatformExclusionList(PlatformLibrary, libraryLookup));
 
-                // If the platform library is Microsoft.AspNetCore.App, then implicitly
-                // treat Microsoft.NETCore.App as a dependency and add its exclusions
-                if (String.Equals(PlatformLibrary.Name, AspNetPlatformLibrary, StringComparison.OrdinalIgnoreCase))
+                // If the platform library is not Microsoft.NETCore.App, treat it as an implicit dependency.
+                // This makes it so Microsoft.AspNet.* 2.x platforms also exclude Microsoft.NETCore.App files.
+                if (PlatformLibrary.Name.Length > 0 && !String.Equals(PlatformLibrary.Name, NetCorePlatformLibrary, StringComparison.OrdinalIgnoreCase))
                 {
                     var library = _lockFileTarget.GetLibrary(NetCorePlatformLibrary);
                     if (library != null)

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ProjectContext.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ProjectContext.cs
@@ -12,6 +12,9 @@ namespace Microsoft.NET.Build.Tasks
 {
     internal class ProjectContext
     {
+        private const string NetCorePlatformLibrary = "Microsoft.NETCore.App";
+        private const string AspNetPlatformLibrary = "Microsoft.AspNetCore.App";
+
         private readonly LockFile _lockFile;
         private readonly LockFileTarget _lockFileTarget;
         internal HashSet<PackageIdentity> PackagesToBeFiltered { get; set; }
@@ -63,6 +66,17 @@ namespace Microsoft.NET.Build.Tasks
             if (IsFrameworkDependent)
             {
                 allExclusionList.UnionWith(_lockFileTarget.GetPlatformExclusionList(PlatformLibrary, libraryLookup));
+
+                // If the platform library is Microsoft.AspNetCore.App, then implicitly
+                // treat Microsoft.NETCore.App as a dependency and add its exclusions
+                if (String.Equals(PlatformLibrary.Name, AspNetPlatformLibrary, StringComparison.OrdinalIgnoreCase))
+                {
+                    var library = _lockFileTarget.GetLibrary(NetCorePlatformLibrary);
+                    if (library != null)
+                    {
+                        allExclusionList.UnionWith(_lockFileTarget.GetPlatformExclusionList(library, libraryLookup));
+                    }
+                }
             }
 
             if (excludeFromPublishPackageIds?.Any() == true)

--- a/src/Tests/Microsoft.NET.Publish.Tests/Properties/GivenThatWeWantToPublishAWebProject.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/Properties/GivenThatWeWantToPublishAWebProject.cs
@@ -1,0 +1,137 @@
+using System;
+using System.IO;
+using FluentAssertions;
+using Microsoft.DotNet.Cli.Utils;
+using Microsoft.NET.TestFramework;
+using Microsoft.NET.TestFramework.Assertions;
+using Microsoft.NET.TestFramework.Commands;
+using Microsoft.NET.TestFramework.ProjectConstruction;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.NET.Publish.Tests
+{
+    public class GivenThatWeWantToPublishAWebProject : SdkTest
+    {
+        public GivenThatWeWantToPublishAWebProject(ITestOutputHelper log) : base(log)
+        {
+        }
+
+        [Fact]
+        public void It_should_publish_self_contained()
+        {
+            var tfm = "netcoreapp2.2";
+
+            var testProject = new TestProject()
+            {
+                Name = "WebTest",
+                TargetFrameworks = tfm,
+                IsSdkProject = true,
+                IsExe = true,
+            };
+
+            testProject.AdditionalProperties.Add("AspNetCoreHostingModel", "InProcess");
+            testProject.PackageReferences.Add(new TestPackageReference("Microsoft.AspNetCore.App"));
+            testProject.PackageReferences.Add(new TestPackageReference("Microsoft.AspNetCore.Razor.Design", version: "2.2.0", privateAssets: "all"));
+
+            var testProjectInstance = _testAssetsManager.CreateTestProject(testProject)
+                .WithProjectChanges(
+                    (filename, project) =>
+                    {
+                        project.Root.Attribute("Sdk").Value = "Microsoft.NET.Sdk.Web";
+                    });
+
+            var command = new PublishCommand(Log, Path.Combine(testProjectInstance.Path, testProject.Name));
+
+            var rid = EnvironmentInfo.GetCompatibleRid(tfm);
+            command
+                .Execute("/restore", $"/p:RuntimeIdentifier={rid}")
+                .Should()
+                .Pass();
+
+            var output = command.GetOutputDirectory(
+                targetFramework: tfm,
+                runtimeIdentifier: rid);
+
+            output.Should().HaveFiles(new[] {
+                $"{testProject.Name}{Constants.ExeSuffix}",
+                $"{testProject.Name}.dll",
+                $"{testProject.Name}.pdb",
+                $"{testProject.Name}.deps.json",
+                $"{testProject.Name}.runtimeconfig.json",
+                "web.config",
+                $"{FileConstants.DynamicLibPrefix}hostfxr{FileConstants.DynamicLibSuffix}",
+                $"{FileConstants.DynamicLibPrefix}hostpolicy{FileConstants.DynamicLibSuffix}",
+            });
+
+            output.Should().NotHaveFiles(new[] {
+                $"apphost{Constants.ExeSuffix}",
+            });
+
+            Command.Create(Path.Combine(output.FullName, $"{testProject.Name}{Constants.ExeSuffix}"), new string[] {})
+                .CaptureStdOut()
+                .Execute()
+                .Should()
+                .Pass()
+                .And
+                .HaveStdOutContaining("Hello World!");
+        }
+
+        [Fact]
+        public void It_should_publish_framework_dependent()
+        {
+            var tfm = "netcoreapp2.2";
+
+            var testProject = new TestProject()
+            {
+                Name = "WebTest",
+                TargetFrameworks = tfm,
+                IsSdkProject = true,
+                IsExe = true,
+            };
+
+            testProject.AdditionalProperties.Add("AspNetCoreHostingModel", "InProcess");
+            testProject.PackageReferences.Add(new TestPackageReference("Microsoft.AspNetCore.App"));
+            testProject.PackageReferences.Add(new TestPackageReference("Microsoft.AspNetCore.Razor.Design", version: "2.2.0", privateAssets: "all"));
+
+            var testProjectInstance = _testAssetsManager.CreateTestProject(testProject)
+                .WithProjectChanges(
+                    (filename, project) =>
+                    {
+                        project.Root.Attribute("Sdk").Value = "Microsoft.NET.Sdk.Web";
+                    });
+
+            var command = new PublishCommand(Log, Path.Combine(testProjectInstance.Path, testProject.Name));
+
+            var rid = EnvironmentInfo.GetCompatibleRid(tfm);
+            command
+                .Execute("/restore", $"/p:RuntimeIdentifier={rid}", "/p:SelfContained=false")
+                .Should()
+                .Pass();
+
+            var output = command.GetOutputDirectory(
+                targetFramework: tfm,
+                runtimeIdentifier: rid);
+
+            output.Should().OnlyHaveFiles(new[] {
+                $"{testProject.Name}{Constants.ExeSuffix}",
+                $"{testProject.Name}.dll",
+                $"{testProject.Name}.pdb",
+                $"{testProject.Name}.deps.json",
+                $"{testProject.Name}.runtimeconfig.json",
+                "web.config",
+            });
+
+            Command.Create(Path.Combine(output.FullName, $"{testProject.Name}{Constants.ExeSuffix}"), new string[] {})
+               .EnvironmentVariable(
+                    Environment.Is64BitProcess ? "DOTNET_ROOT" : "DOTNET_ROOT(x86)",
+                    Path.GetDirectoryName(TestContext.Current.ToolsetUnderTest.DotNetHostPath))
+                .CaptureStdOut()
+                .Execute()
+                .Should()
+                .Pass()
+                .And
+                .HaveStdOutContaining("Hello World!");
+        }
+    }
+}

--- a/src/Tests/Microsoft.NET.Publish.Tests/Properties/GivenThatWeWantToPublishAWebProject.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/Properties/GivenThatWeWantToPublishAWebProject.cs
@@ -77,8 +77,11 @@ namespace Microsoft.NET.Publish.Tests
                 .HaveStdOutContaining("Hello World!");
         }
 
-        [Fact]
-        public void It_should_publish_framework_dependent()
+
+        [Theory]
+        [InlineData("Microsoft.AspNetCore.App")]
+        [InlineData("Microsoft.AspNetCore.All")]
+        public void It_should_publish_framework_dependent(string platformLibrary)
         {
             var tfm = "netcoreapp2.2";
 
@@ -91,7 +94,7 @@ namespace Microsoft.NET.Publish.Tests
             };
 
             testProject.AdditionalProperties.Add("AspNetCoreHostingModel", "InProcess");
-            testProject.PackageReferences.Add(new TestPackageReference("Microsoft.AspNetCore.App"));
+            testProject.PackageReferences.Add(new TestPackageReference(platformLibrary));
             testProject.PackageReferences.Add(new TestPackageReference("Microsoft.AspNetCore.Razor.Design", version: "2.2.0", privateAssets: "all"));
 
             var testProjectInstance = _testAssetsManager.CreateTestProject(testProject)

--- a/src/Tests/Microsoft.NET.TestFramework/ProjectConstruction/TestProject.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/ProjectConstruction/TestProject.cs
@@ -151,6 +151,10 @@ namespace Microsoft.NET.TestFramework.ProjectConstruction
                 {
                     packageReferenceElement.Add(new XAttribute("Version", packageReference.Version));
                 }
+                if (packageReference.PrivateAssets != null)
+                {
+                    packageReferenceElement.Add(new XAttribute("PrivateAssets", packageReference.PrivateAssets));
+                }
                 packageReferenceItemGroup.Add(packageReferenceElement);
             }
 

--- a/src/Tests/Microsoft.NET.TestFramework/TestPackageReference.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/TestPackageReference.cs
@@ -11,22 +11,18 @@ namespace Microsoft.NET.TestFramework
 {
     public class TestPackageReference
     {
-        public TestPackageReference(string id, string version)
-            : this(id, version, null)
-        {
-        }
-
-        public TestPackageReference(string id, string version, string nupkgPath)
+        public TestPackageReference(string id, string version = null, string nupkgPath = null, string privateAssets = null)
         {
             ID = id;
             Version = version;
             NupkgPath = nupkgPath;
+            PrivateAssets = privateAssets;
         }
 
         public string ID { get; private set; }
         public string Version { get; private set; }
         public string NupkgPath { get; private set; }
-
+        public string PrivateAssets { get; private set; }
 
         public bool NuGetPackageExists()
         {


### PR DESCRIPTION
This commit ensures that we exclude files from the `Microsoft.NETCore.App`
platform library on publish when the platform library is
`Microsoft.AspNetCore.App`, which doesn't have an explicit dependency on
`Microsoft.NETCore.App`.

When publishing a 2.x ASP.NET application, the `MicrosoftNETPlatformLibrary`
property gets changed by ASP.NET to `Microsoft.AspNetCore.App`.  This causes
the task responsible for determining what files to copy locally to treat files
from `Microsoft.NETCore.App` and its dependencies as not being part of the
platform.

However, when publishing the application as framework-dependent, almost all the
platform files get excluded thanks to conflict resolution which has the files
as part of the platform manifest and preferred packages.  Unfortunately, the
apphost, hostpolicy, and hostfxr files are not part of these lists and as a
result will be copied locally.

This breaks framework-dependent apphost activation because hostfxr and
hostpolicy are copied locally.  Additionally, these files end up in the
deps.json file which also prevents roll-forward activation if the two files are
manually deleted.

The fix is to treat `Microsoft.NETCore.App` as an implicit dependency of
`Microsoft.AspNetCore.App` where we calculate the list of excluded packages for
a framework-dependent publish.

Fixes dotnet/cli#10602.