### PR TITLE
Implement DesignerRuntimeImplementationProjectOutputGroup

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/GenerateDepsFile.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/GenerateDepsFile.cs
@@ -46,28 +46,24 @@ namespace Microsoft.NET.Build.Tasks
         [Required]
         public string AssemblyVersion { get; set; }
 
-        [Required]
-        public ITaskItem[] AssemblySatelliteAssemblies { get; set; }
+        public ITaskItem[] AssemblySatelliteAssemblies { get; set; } = Array.Empty<ITaskItem>();
 
         [Required]
         public bool IncludeMainProject { get; set; }
 
-        [Required]
-        public ITaskItem[] ReferencePaths { get; set; }
 
-        [Required]
-        public ITaskItem[] ReferenceDependencyPaths { get; set; }
+        public ITaskItem[] ReferencePaths { get; set; } = Array.Empty<ITaskItem>();
 
-        [Required]
-        public ITaskItem[] ReferenceSatellitePaths { get; set; }
+        public ITaskItem[] ReferenceDependencyPaths { get; set; } = Array.Empty<ITaskItem>();
 
-        [Required]
-        public ITaskItem[] ReferenceAssemblies { get; set; }
+        public ITaskItem[] ReferenceSatellitePaths { get; set; } = Array.Empty<ITaskItem>();
+
+        public ITaskItem[] ReferenceAssemblies { get; set; } = Array.Empty<ITaskItem>();
 
         [Required]
         public ITaskItem[] FilesToSkip { get; set; }
 
-        public ITaskItem[] RuntimePackAssets { get; set; }
+        public ITaskItem[] RuntimePackAssets { get; set; } = Array.Empty<ITaskItem>();
 
         public ITaskItem CompilerOptions { get; set; }
 
@@ -138,7 +134,7 @@ namespace Microsoft.NET.Build.Tasks
 
             IEnumerable<string> excludeFromPublishAssets = PackageReferenceConverter.GetPackageIds(ExcludeFromPublishPackageReferences);
 
-            IEnumerable<RuntimePackAssetInfo> runtimePackAssets = RuntimePackAssets == null ? Enumerable.Empty<RuntimePackAssetInfo>() :
+            IEnumerable<RuntimePackAssetInfo> runtimePackAssets = 
                 RuntimePackAssets.Select(item => RuntimePackAssetInfo.FromItem(item));
 
             ProjectContext projectContext = lockFile.CreateProjectContext(

--- a/src/Tasks/Microsoft.NET.Build.Tasks/GenerateRuntimeConfigurationFiles.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/GenerateRuntimeConfigurationFiles.cs
@@ -48,6 +48,8 @@ namespace Microsoft.NET.Build.Tasks
 
         public bool IsSelfContained { get; set; }
 
+        public bool WriteAdditionalProbingPathsToMainConfig { get; set; }
+
         List<ITaskItem> _filesWritten = new List<ITaskItem>();
 
         [Output]
@@ -60,9 +62,12 @@ namespace Microsoft.NET.Build.Tasks
         {
             bool writeDevRuntimeConfig = !string.IsNullOrEmpty(RuntimeConfigDevPath);
 
-            if (AdditionalProbingPaths?.Any() == true && !writeDevRuntimeConfig)
+            if (!WriteAdditionalProbingPathsToMainConfig)
             {
-                Log.LogWarning(Strings.SkippingAdditionalProbingPaths);
+                if (AdditionalProbingPaths?.Any() == true && !writeDevRuntimeConfig)
+                {
+                    Log.LogWarning(Strings.SkippingAdditionalProbingPaths);
+                }
             }
 
             LockFile lockFile = new LockFileCache(this).GetLockFile(AssetsFilePath);
@@ -93,6 +98,11 @@ namespace Microsoft.NET.Build.Tasks
             // conflicts the HostConfigurationOptions win. The reasoning is that HostConfigurationOptions
             // can be changed using MSBuild properties, which can be specified at build time.
             AddHostConfigurationOptions(config.RuntimeOptions);
+
+            if (WriteAdditionalProbingPathsToMainConfig)
+            {
+                AddAdditionalProbingPaths(config.RuntimeOptions, projectContext);
+            }
 
             WriteToJsonFile(RuntimeConfigPath, config);
             _filesWritten.Add(new TaskItem(RuntimeConfigPath));

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.DesignerSupport.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.DesignerSupport.targets
@@ -1,0 +1,141 @@
+<!--
+***********************************************************************************************
+Microsoft.NET.DesignerSupport.targets
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+          created a backup copy.  Incorrect changes to this file will make it
+          impossible to load or build your projects from the command-line or the IDE.
+
+Copyright (c) .NET Foundation. All rights reserved. 
+***********************************************************************************************
+-->
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <PropertyGroup Condition="'$(DesignerRuntimeImplementationProjectOutputGroupDependsOn)' == ''">
+    <DesignerRuntimeImplementationProjectOutputGroupDependsOn>
+      $(CommonOutputGroupsDependsOn);
+    </DesignerRuntimeImplementationProjectOutputGroupDependsOn>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <DesignerRuntimeImplementationProjectOutputGroupDependsOn>
+      $(DesignerRuntimeImplementationProjectOutputGroupDependsOn);
+      _GenerateDesignerDepsFile;
+      _GenerateDesignerRuntimeConfigFile;
+      _GatherDesignerShadowCopyFiles;
+    </DesignerRuntimeImplementationProjectOutputGroupDependsOn>
+
+    <_DesignerDepsFileName>$(AssemblyName).designer.deps.json</_DesignerDepsFileName>
+    <_DesignerRuntimeConfigFileName>$(AssemblyName).designer.runtimeconfig.json</_DesignerRuntimeConfigFileName>
+
+    <_DesignerDepsFilePath>$(IntermediateOutputPath)$(_DesignerDepsFileName)</_DesignerDepsFilePath>
+    <_DesignerRuntimeConfigFilePath>$(IntermediateOutputPath)$(_DesignerRuntimeConfigFileName)</_DesignerRuntimeConfigFilePath>
+  </PropertyGroup>
+
+  <Target
+    Name="DesignerRuntimeImplementationProjectOutputGroup"
+    DependsOnTargets="$(DesignerRuntimeImplementationProjectOutputGroupDependsOn)"
+    Returns="@(DesignerRuntimeImplementationProjectOutputGroupOutput)"
+    />
+
+  <Target
+    Name="_GenerateDesignerDepsFile"
+    Inputs="$(MSBuildAllProjectFiles);$(ProjectAssetsFile)"
+    Outputs="$(_DesignerDepsFilePath)"
+    Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'"
+    >
+    <!-- 
+      NOTE: We do not include the main assembly info or non-NuGet dependencies
+      in designer deps file as these files may not be built yet at design time.
+      Instead, we rely on SetAppPaths in runtimeconfig to allow loading of
+      non-NuGet assets from shadow copied app base directory. This further
+      allows loading of designer dll(s) that are not seen by the build. 
+    -->
+    <GenerateDepsFile 
+      AssemblyName="_"
+      AssemblyExtension="_"
+      AssemblyVersion="_"
+      AssetsFilePath="$(ProjectAssetsFile)"
+      DepsFilePath="$(_DesignerDepsFilePath)"
+      FilesToSkip="@(_ConflictPackageFiles)"
+      IncludeMainProject="false"
+      IncludeRuntimeFileVersions="$(IncludeFileVersionsInDependencyFile)"
+      IsSelfContained="false"
+      PlatformLibraryName="$(MicrosoftNETPlatformLibrary)"
+      ProjectPath="$(MSBuildProjectFullPath)"
+      RuntimeFrameworks="@(RuntimeFramework)"
+      TargetFramework="$(TargetFrameworkMoniker)"
+      />
+
+    <ItemGroup>
+      <!-- Designer will rename to <surface process name>.deps.json -->
+      <DesignerRuntimeImplementationProjectOutputGroupOutput 
+        Include="$([MSBuild]::NormalizePath($(_DesignerDepsFilePath)))"
+        TargetPath="$(_DesignerDepsFileName)"
+        />
+
+      <FileWrites Include="$(_DesignerDepsFilePath)" />
+    </ItemGroup>
+  </Target>
+
+  <Target
+    Name="_GenerateDesignerRuntimeConfigFile"
+    Inputs="$(MSBuildAllProjectFiles);$(ProjectAssetsFile)"
+    Outputs="$(_DesignerRuntimeConfigFilePath)"
+    Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'"
+    >
+
+    <ItemGroup>
+      <_DesignerHostConfigurationOption
+        Include="Microsoft.NETCore.DotNetHostPolicy.SetAppPaths"
+        Value="true" 
+        />
+    </ItemGroup>
+
+    <GenerateRuntimeConfigurationFiles 
+      AdditionalProbingPaths="@(AdditionalProbingPath)"
+      AssetsFilePath="$(ProjectAssetsFile)"
+      HostConfigurationOptions="@(RuntimeHostConfigurationOption);@(_DesignerHostConfigurationOption)"
+      IsSelfContained="false"
+      PlatformLibraryName="$(MicrosoftNETPlatformLibrary)"
+      RuntimeConfigPath="$(_DesignerRuntimeConfigFilePath)"
+      RuntimeFrameworks="@(RuntimeFramework)"
+      TargetFramework="$(TargetFramework)"
+      TargetFrameworkMoniker="$(TargetFrameworkMoniker)"
+      UserRuntimeConfig="$(UserRuntimeConfig)"
+      WriteAdditionalProbingPathsToMainConfig="true"
+      />
+
+    <ItemGroup>
+      <!-- Designer will rename to <surface process name>.runtimeconfig.json -->
+      <DesignerRuntimeImplementationProjectOutputGroupOutput 
+        Include="$([MSBuild]::NormalizePath($(_DesignerRuntimeConfigFilePath)))"
+        TargetPath="$(_DesignerRuntimeConfigFileName)"
+        />
+
+      <FileWrites Include="$(_DesignerRuntimeConfigFilePath)" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="_GatherDesignerShadowCopyFiles">
+    <ItemGroup>
+      <_DesignerShadowCopy Include="@(ReferenceCopyLocalPaths)" />
+
+      <!--
+        For .NET Core, we do not include NuGet package assets or runtime pack
+        assets, irrespective of self-contained / copy-local settings. Designer
+        will load these from the NuGet cache or shared framework always.
+      -->
+      <_DesignerShadowCopy
+        Remove="@(_ResolvedCopyLocalBuildAssets);@(RuntimePackAsset)"
+        Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'"
+        />
+
+      <DesignerRuntimeImplementationProjectOutputGroupOutput 
+        Include="@(_DesignerShadowCopy->'%(FullPath)')"
+        TargetPath="%(_DesignerShadowCopy.DestinationSubDirectory)%(_DesignerShadowCopy.Filename)%(_DesignerShadowCopy.Extension)"
+        />
+      </ItemGroup>
+  </Target>
+
+</Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -603,6 +603,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   </ItemGroup>
 
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.NET.DisableStandardFrameworkResolution.targets" Condition="'$(DisableStandardFrameworkResolution)' == 'true'" />
+  <Import Project="$(MSBuildThisFileDirectory)Microsoft.NET.DesignerSupport.targets" />
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.NET.GenerateAssemblyInfo.targets" />
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.NET.GenerateSupportedRuntime.targets" />
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.NET.ComposeStore.targets" />

--- a/src/Tests/Microsoft.NET.Build.Tests/GiventThatWeWantDesignerSupport.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GiventThatWeWantDesignerSupport.cs
@@ -1,0 +1,152 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyModel;
+using Microsoft.NET.TestFramework;
+using Microsoft.NET.TestFramework.Assertions;
+using Microsoft.NET.TestFramework.Commands;
+using Microsoft.NET.TestFramework.ProjectConstruction;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.NET.Build.Tests
+{
+    public class GivenThatWeWantDesignerSupport : SdkTest
+    {
+        public GivenThatWeWantDesignerSupport(ITestOutputHelper log) : base(log)
+        {
+        }
+
+        [Theory]
+        [InlineData("net46")]
+        [InlineData("netcoreapp3.0")]
+        public void It_provides_runtime_configuration_and_shadow_copy_files_via_outputgroup(string targetFramework)
+        {
+            var projectRef = new TestProject
+            {
+                Name = "ReferencedProject",
+                TargetFrameworks = targetFramework,
+                IsSdkProject = true,
+            };
+
+            var project = new TestProject
+            {
+                Name = "DesignerTest",
+                IsExe = true,
+                TargetFrameworks = targetFramework,
+                IsSdkProject = true,
+                PackageReferences = { new TestPackageReference("NewtonSoft.Json", "12.0.1") },
+                ReferencedProjects = { projectRef }
+            };
+
+            var asset = _testAssetsManager
+                .CreateTestProject(project, identifier: targetFramework)
+                .Restore(Log, project.Name);
+
+            var command = new GetValuesCommand(
+                Log, 
+                Path.Combine(asset.Path, project.Name),
+                targetFramework,
+                "DesignerRuntimeImplementationProjectOutputGroupOutput",
+                GetValuesCommand.ValueType.Item)
+            {
+                DependsOnTargets = "DesignerRuntimeImplementationProjectOutputGroup",
+                MetadataNames = { "TargetPath" },
+            };
+
+            command.Execute().Should().Pass();
+
+            var items = 
+                from item in command.GetValuesWithMetadata()
+                select new
+                {
+                   Identity = item.value,
+                   TargetPath = item.metadata["TargetPath"]
+                };
+
+            string depsFile = null;
+            string runtimeConfig = null;
+            var otherFiles = new List<string>();
+
+            foreach (var item in items)
+            {
+                Path.IsPathFullyQualified(item.Identity).Should().BeTrue();
+                Path.GetFileName(item.Identity).Should().Be(item.TargetPath);
+
+                switch (item.TargetPath)
+                {
+                    case "DesignerTest.designer.deps.json":
+                        depsFile = item.Identity;
+                        break;
+                    case "DesignerTest.designer.runtimeconfig.json":
+                        runtimeConfig = item.Identity;
+                        break;
+                    default:
+                        otherFiles.Add(item.TargetPath);
+                        break;
+                }
+            }
+
+            switch (targetFramework)
+            {
+                case "netcoreapp3.0":
+                    var depsFileLibraries = GetRuntimeLibraryFileNames(depsFile);
+                    depsFileLibraries.Should().BeEquivalentTo(new[] { "Newtonsoft.Json.dll" });
+                    
+                    var options = GetRuntimeOptions(runtimeConfig);
+                    options["configProperties"]["Microsoft.NETCore.DotNetHostPolicy.SetAppPaths"].Value<bool>().Should().BeTrue();
+                    options["tfm"].Value<string>().Should().Be(targetFramework);
+                    options["additionalProbingPaths"].Value<JArray>().Should().NotBeEmpty();
+
+                    otherFiles.Should().BeEquivalentTo(new[] { "ReferencedProject.dll", "ReferencedProject.pdb" });
+                    break;
+
+                case "net46":
+                    depsFile.Should().BeNull();
+                    runtimeConfig.Should().BeNull();
+                    otherFiles.Should().BeEquivalentTo(new[] { "Newtonsoft.Json.dll", "ReferencedProject.dll", "ReferencedProject.pdb" });
+                    break;
+            }
+        }
+
+        private static JToken GetRuntimeOptions(string runtimeConfigFilePath)
+        {
+            var config = ParseRuntimeConfig(runtimeConfigFilePath);
+            return config["runtimeOptions"];
+        }
+
+        private static IEnumerable<string> GetRuntimeLibraryFileNames(string depsFilePath)
+        {
+            var deps = ParseDepsFile(depsFilePath);
+  
+            return deps.RuntimeLibraries
+                       .SelectMany(r => r.RuntimeAssemblyGroups)
+                       .SelectMany(a => a.AssetPaths)
+                       .Select(p => Path.GetFileName(p));
+        }
+
+        private static JToken ParseRuntimeConfig(string path)
+        {
+            using (var streamReader = File.OpenText(path))
+            using (var jsonReader = new JsonTextReader(streamReader))
+            {
+                return JObject.Load(jsonReader);
+            }
+        }
+
+        private static DependencyContext ParseDepsFile(string path)
+        {
+            using (var stream = File.OpenRead(path))
+            using (var reader = new DependencyContextJsonReader())
+            { 
+                return reader.Read(stream);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Generate a .designer.deps.json to obj and .designer.runtimeconfig.json to obj/ and returns them + non-NuGet, non-Framework ReferenceCopyLocalPaths.

The designer deps file contains only NuGet assets, and the designer runtimeconfig sets the option to allow other files to load from app base.

Fix #2707 

cc @chabiss @lutzroeder