### PR TITLE
WIP test ci

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ Please refer to [dotnet/cli](https://github.com/dotnet/cli) for .NET Core CLI so
 ## How do I engage and contribute?
 We welcome you to try things out, [file issues](https://github.com/dotnet/sdk/issues), make feature requests and join us in design conversations.
 
+
+
+
 This project has adopted a code of conduct adapted from the [Contributor Covenant](http://contributor-covenant.org/) to clarify expected behavior in our community. This code of conduct has been [adopted by many other projects](http://contributor-covenant.org/adopters/). For more information see [Contributors Code of conduct](https://github.com/dotnet/home/blob/master/guidance/be-nice.md).
 
 ## Performance Status


### PR DESCRIPTION
Seems It_uses_NetstandardLibrary20x_as_the_implicit_version_for_NetStandard20 will always fail with 2.0.2 instead of 2.0.3