### PR TITLE
Support ".Ref" targeting packs and .NET Standard 2.1

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolveFrameworkReferences.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveFrameworkReferences.cs
@@ -134,12 +134,13 @@ namespace Microsoft.NET.Build.Tasks
                     !string.IsNullOrEmpty(knownFrameworkReference.RuntimePackNamePatterns))
                 {
                     var runtimeGraph = new RuntimeGraphCache(this).GetRuntimeGraph(RuntimeGraphPath);
+                    var knownFrameworkReferenceRuntimePackRuntimeIdentifiers = knownFrameworkReference.RuntimePackRuntimeIdentifiers.Split(';');
                     foreach (var runtimePackNamePattern in knownFrameworkReference.RuntimePackNamePatterns.Split(';'))
                     {
                         string runtimePackRuntimeIdentifier = NuGetUtils.GetBestMatchingRid(
                             runtimeGraph,
                             RuntimeIdentifier,
-                            knownFrameworkReference.RuntimePackRuntimeIdentifiers.Split(';'),
+                            knownFrameworkReferenceRuntimePackRuntimeIdentifiers,
                             out bool wasInGraph);
 
                         if (runtimePackRuntimeIdentifier == null)

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolveFrameworkReferences.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveFrameworkReferences.cs
@@ -100,6 +100,8 @@ namespace Microsoft.NET.Build.Tasks
                     targetingPackVersion = knownFrameworkReference.TargetingPackVersion;
                 }
                 targetingPack.SetMetadata(MetadataKeys.PackageVersion, targetingPackVersion);
+                targetingPack.SetMetadata("TargetingPackFormat", knownFrameworkReference.TargetingPackFormat);
+                targetingPack.SetMetadata("TargetFramework", knownFrameworkReference.TargetFramework.GetShortFolderName());
 
                 string targetingPackPath = null;
                 if (!string.IsNullOrEmpty(TargetingPackRoot))
@@ -180,12 +182,15 @@ namespace Microsoft.NET.Build.Tasks
                     }
                 }
 
-                TaskItem runtimeFramework = new TaskItem(knownFrameworkReference.RuntimeFrameworkName);
+                if (!string.IsNullOrEmpty(knownFrameworkReference.RuntimeFrameworkName))
+                {
+                    TaskItem runtimeFramework = new TaskItem(knownFrameworkReference.RuntimeFrameworkName);
 
-                runtimeFramework.SetMetadata(MetadataKeys.Version, runtimeFrameworkVersion);
-                runtimeFramework.SetMetadata(MetadataKeys.FrameworkName, knownFrameworkReference.Name);
+                    runtimeFramework.SetMetadata(MetadataKeys.Version, runtimeFrameworkVersion);
+                    runtimeFramework.SetMetadata(MetadataKeys.FrameworkName, knownFrameworkReference.Name);
 
-                runtimeFrameworks.Add(runtimeFramework);
+                    runtimeFrameworks.Add(runtimeFramework);
+                }
             }
                                                       
             if (packagesToDownload.Any())
@@ -299,6 +304,7 @@ namespace Microsoft.NET.Build.Tasks
             //  The ID of the targeting pack NuGet package to reference
             public string TargetingPackName => _item.GetMetadata("TargetingPackName");
             public string TargetingPackVersion => _item.GetMetadata("TargetingPackVersion");
+            public string TargetingPackFormat => _item.GetMetadata("TargetingPackFormat");
 
             public string RuntimePackNamePatterns => _item.GetMetadata("RuntimePackNamePatterns");
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolveFrameworkReferences.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveFrameworkReferences.cs
@@ -64,9 +64,11 @@ namespace Microsoft.NET.Build.Tasks
                 return;
             }
 
+            var normalizedTargetFrameworkVersion = NormalizeVersion(new Version(TargetFrameworkVersion));
+
             var knownFrameworkReferencesForTargetFramework = KnownFrameworkReferences.Select(item => new KnownFrameworkReference(item))
                 .Where(kfr => kfr.TargetFramework.Framework.Equals(TargetFrameworkIdentifier, StringComparison.OrdinalIgnoreCase) &&
-                              NormalizeVersion(kfr.TargetFramework.Version) == NormalizeVersion(new Version(TargetFrameworkVersion)))
+                              NormalizeVersion(kfr.TargetFramework.Version) == normalizedTargetFrameworkVersion)
                 .ToList();
 
             var frameworkReferenceMap = FrameworkReferences.ToDictionary(fr => fr.ItemSpec);
@@ -129,10 +131,11 @@ namespace Microsoft.NET.Build.Tasks
                     !string.IsNullOrEmpty(RuntimeIdentifier) &&
                     !string.IsNullOrEmpty(knownFrameworkReference.RuntimePackNamePatterns))
                 {
+                    var runtimeGraph = new RuntimeGraphCache(this).GetRuntimeGraph(RuntimeGraphPath);
                     foreach (var runtimePackNamePattern in knownFrameworkReference.RuntimePackNamePatterns.Split(';'))
                     {
                         string runtimePackRuntimeIdentifier = NuGetUtils.GetBestMatchingRid(
-                            new RuntimeGraphCache(this).GetRuntimeGraph(RuntimeGraphPath),
+                            runtimeGraph,
                             RuntimeIdentifier,
                             knownFrameworkReference.RuntimePackRuntimeIdentifiers.Split(';'),
                             out bool wasInGraph);

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolveRuntimePackAssets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveRuntimePackAssets.cs
@@ -45,6 +45,16 @@ namespace Microsoft.NET.Build.Tasks
                 }
 
                 string runtimePackRoot = runtimePack.GetMetadata(MetadataKeys.PackageDirectory);
+
+                if (string.IsNullOrEmpty(runtimePackRoot) || !Directory.Exists(runtimePackRoot))
+                {
+                    //  If we do the work in https://github.com/dotnet/cli/issues/10528,
+                    //  then we should add a new error message here indicating that the runtime pack hasn't
+                    //  been downloaded, and that restore should be run with that runtime identifier.
+                    Log.LogError(Strings.NoRuntimePackAvailable, runtimePack.ItemSpec,
+                        runtimePack.GetMetadata(MetadataKeys.RuntimeIdentifier));
+                }
+
                 string runtimeIdentifier = runtimePack.GetMetadata(MetadataKeys.RuntimeIdentifier);
 
                 //  These hard-coded paths are temporary until we have "real" runtime packs, which will likely have a flattened

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolveTargetingPackAssets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveTargetingPackAssets.cs
@@ -60,7 +60,20 @@ namespace Microsoft.NET.Build.Tasks
                 }
                 else
                 {
-                    foreach (var dll in Directory.GetFiles(Path.Combine(targetingPackRoot, "ref", "netcoreapp3.0"), "*.dll"))
+                    string targetingPackAssetPath = Path.Combine(targetingPackRoot, "data");
+                    string platformManifestPath;
+                    if (Directory.Exists(targetingPackAssetPath))
+                    {
+                        platformManifestPath = Path.Combine(targetingPackAssetPath,
+                                    targetingPack.GetMetadata(MetadataKeys.PackageName) + ".PlatformManifest.txt");
+                    }
+                    else
+                    {
+                        targetingPackAssetPath = Path.Combine(targetingPackRoot, "ref", "netcoreapp3.0");
+                        platformManifestPath = Path.Combine(targetingPackRoot, "build", "netcoreapp3.0",
+                            targetingPack.GetMetadata(MetadataKeys.PackageName) + ".PlatformManifest.txt");
+                    }
+                    foreach (var dll in Directory.GetFiles(targetingPackAssetPath, "*.dll"))
                     {
                         var reference = new TaskItem(dll);
 
@@ -78,9 +91,6 @@ namespace Microsoft.NET.Build.Tasks
 
                         referencesToAdd.Add(reference);
                     }
-
-                    var platformManifestPath = Path.Combine(targetingPackRoot, "build", "netcoreapp3.0",
-                        targetingPack.GetMetadata(MetadataKeys.PackageName) + ".PlatformManifest.txt");
 
                     if (File.Exists(platformManifestPath))
                     {

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolveTargetingPackAssets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveTargetingPackAssets.cs
@@ -90,7 +90,10 @@ namespace Microsoft.NET.Build.Tasks
                                         targetingPack.GetMetadata(MetadataKeys.PackageName) + ".PlatformManifest.txt"),
                         };
 
-                        string targetingPackDllPath = possibleDllPaths.First(path => Directory.GetFiles(path, "*.dll").Any());
+                        string targetingPackDllPath = possibleDllPaths.First(path =>
+                                    Directory.Exists(path) &&
+                                    Directory.GetFiles(path, "*.dll").Any());
+
                         string platformManifestPath = possibleManifestPaths.FirstOrDefault(File.Exists);
 
                         foreach (var dll in Directory.GetFiles(targetingPackDllPath, "*.dll"))

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.props
@@ -22,6 +22,10 @@ Copyright (c) .NET Foundation. All rights reserved.
                                TargetingPackName="Microsoft.NETCore.App.Ref"
                                TargetingPackVersion="3.0.0-preview-27406-5"
                                />
+    <KnownFrameworkReference Update="Microsoft.AspNetCore.App"
+                               TargetingPackName="Microsoft.AspNetCore.App.Ref"
+                               TargetingPackVersion="3.0.0-preview-19108-04"
+                               />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.props
@@ -17,7 +17,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <Import Project="$(NETCoreSdkBundledVersionsProps)" Condition="Exists('$(NETCoreSdkBundledVersionsProps)')" />
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(UseRefTargetingPacks)' == 'true'">
     <KnownFrameworkReference Update="Microsoft.NETCore.App"
                                TargetingPackName="Microsoft.NETCore.App.Ref"
                                TargetingPackVersion="3.0.0-preview-27406-5"

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.props
@@ -17,6 +17,13 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <Import Project="$(NETCoreSdkBundledVersionsProps)" Condition="Exists('$(NETCoreSdkBundledVersionsProps)')" />
 
+  <ItemGroup>
+    <KnownFrameworkReference Update="Microsoft.NETCore.App"
+                               TargetingPackName="Microsoft.NETCore.App.Ref"
+                               TargetingPackVersion="3.0.0-preview-27406-5"
+                               />
+  </ItemGroup>
+
   <PropertyGroup>
     <!-- Disable web SDK implicit package versions for ASP.NET packages, since the .NET SDK now handles that -->
     <EnableWebSdkImplicitPackageVersions>false</EnableWebSdkImplicitPackageVersions>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.props
@@ -28,6 +28,20 @@ Copyright (c) .NET Foundation. All rights reserved.
                                />
   </ItemGroup>
 
+  <ItemGroup>
+    <KnownFrameworkReference Include="NETStandard.Library"
+                              TargetFramework="netstandard2.1"
+                              RuntimeFrameworkName=""
+                              DefaultRuntimeFrameworkVersion=""
+                              LatestRuntimeFrameworkVersion=""
+                              TargetingPackName="NETStandard.Library"
+                              TargetingPackVersion="2.1.0-prerelease.19078.1"
+                              TargetingPackFormat="NETStandardLegacy"
+                              RuntimePackNamePatterns=""
+                              RuntimePackRuntimeIdentifiers=""
+                              />
+  </ItemGroup>
+
   <PropertyGroup>
     <!-- Disable web SDK implicit package versions for ASP.NET packages, since the .NET SDK now handles that -->
     <EnableWebSdkImplicitPackageVersions>false</EnableWebSdkImplicitPackageVersions>
@@ -47,7 +61,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <!-- Automatically reference NETStandard.Library or Microsoft.NETCore.App package if targeting the corresponding target framework.
       We can refer here in the .props file to properties set in the .targets files because items and their conditions are
       evaluated in the second pass of evaluation, after all properties have been evaluated. -->
-  <ItemGroup Condition=" '$(DisableImplicitFrameworkReferences)' != 'true' and '$(TargetFrameworkIdentifier)' == '.NETStandard'">
+  <ItemGroup Condition=" '$(DisableImplicitFrameworkReferences)' != 'true' and '$(TargetFrameworkIdentifier)' == '.NETStandard' And '$(_TargetFrameworkVersionWithoutV)' &lt; '2.1'">
     <PackageReference Include="NETStandard.Library" Version="$(NETStandardImplicitPackageVersion)" IsImplicitlyDefined="true" />
 
     <!-- If targeting .NET Standard 2.0 or higher, then don't include a dependency on NETStandard.Library in the package produced by pack -->
@@ -55,6 +69,9 @@ Copyright (c) .NET Foundation. All rights reserved.
                       Condition=" ('$(_TargetFrameworkVersionWithoutV)' != '') And ('$(_TargetFrameworkVersionWithoutV)' >= '2.0') "
                       PrivateAssets="All" 
                       Publish="true" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(DisableImplicitFrameworkReferences)' != 'true' and '$(TargetFrameworkIdentifier)' == '.NETStandard' And '$(_TargetFrameworkVersionWithoutV)' >= '2.1'">
+    <FrameworkReference Include="NETStandard.Library" IsImplicitlyDefined="true" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(DisableImplicitFrameworkReferences)' != 'true' and '$(TargetFrameworkIdentifier)' == '.NETCoreApp'">

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.targets
@@ -43,7 +43,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <!-- Set the default versions of the NETStandard.Library or Microsoft.NETCore.App packages to reference.
        The implicit package references themselves are defined in Microsoft.NET.Sdk.props, so that they can be overridden
        in the project file. -->
-  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard'">
+  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard' And '$(_TargetFrameworkVersionWithoutV)' &lt; '2.1'">
     <!-- If targeting the same release that is bundled with the .NET Core SDK, use the bundled package version provided by Microsoft.NETCoreSdk.BundledVersions.props -->
     <!-- This is disabled due to https://github.com/dotnet/sdk/issues/2410
     <NETStandardImplicitPackageVersion Condition="'$(NETStandardImplicitPackageVersion)' =='' And '$(_TargetFrameworkVersionWithoutV)' == '$(BundledNETStandardTargetFrameworkVersion)'">$(BundledNETStandardPackageVersion)</NETStandardImplicitPackageVersion>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.TargetingPackResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.TargetingPackResolution.targets
@@ -89,6 +89,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                                 RuntimeGraphPath="$(BundledRuntimeIdentifierGraphFile)"
                                 SelfContained="$(SelfContained)"
                                 RuntimeIdentifier="$(RuntimeIdentifier)"
+                                RuntimeIdentifiers="$(RuntimeIdentifiers)"
                                 RuntimeFrameworkVersion="$(RuntimeFrameworkVersion)"
                                 TargetLatestRuntimePatch="$(TargetLatestRuntimePatch)"
                                 EnableTargetingPackDownload="$(EnableTargetingPackDownload)">

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.SupportedTargetFrameworks.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.SupportedTargetFrameworks.props
@@ -33,5 +33,6 @@ Copyright (c) .NET Foundation. All rights reserved.
         <SupportedTargetFramework Include=".NETStandard,Version=v1.5" DisplayName=".NET Standard 1.5" />
         <SupportedTargetFramework Include=".NETStandard,Version=v1.6" DisplayName=".NET Standard 1.6" />
         <SupportedTargetFramework Include=".NETStandard,Version=v2.0" DisplayName=".NET Standard 2.0" />
+        <SupportedTargetFramework Include=".NETStandard,Version=v2.1" DisplayName=".NET Standard 2.1" />
     </ItemGroup>
 </Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.TargetFrameworkInference.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.TargetFrameworkInference.targets
@@ -146,7 +146,8 @@ Copyright (c) .NET Foundation. All rights reserved.
   </Target>
 
   <PropertyGroup  Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard' And '$(NETStandardMaximumVersion)' == ''">
-    <NETStandardMaximumVersion>$(BundledNETStandardTargetFrameworkVersion)</NETStandardMaximumVersion>
+    <!--<NETStandardMaximumVersion>$(BundledNETStandardTargetFrameworkVersion)</NETStandardMaximumVersion>-->
+    <NETStandardMaximumVersion>2.1</NETStandardMaximumVersion>
   </PropertyGroup>
 
   <Target Name="_CheckForUnsupportedNETStandardVersion" BeforeTargets="_CheckForInvalidConfigurationAndPlatform;Restore;CollectPackageReferences"

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenFrameworkReferences.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenFrameworkReferences.cs
@@ -427,6 +427,7 @@ namespace FrameworkReferenceTest
             testProject.IsSdkProject = true;
             testProject.IsExe = true;
             testProject.AdditionalProperties["DisableImplicitFrameworkReferences"] = "true";
+            testProject.AdditionalProperties["UseRefTargetingPacks"] = "true";
             testProject.RuntimeIdentifier = EnvironmentInfo.GetCompatibleRid(testProject.TargetFrameworks);
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject, callingMethod, identifier)

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenFrameworkReferences.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenFrameworkReferences.cs
@@ -291,7 +291,7 @@ namespace FrameworkReferenceTest
                 });
 
             resolvedVersions.RuntimeFramework["Microsoft.NETCore.App"].Should().Be(runtimeFrameworkVersion);
-            resolvedVersions.PackageDownload["Microsoft.NETCore.App"].Should().Be(targetingPackVersion);
+            resolvedVersions.PackageDownload["Microsoft.NETCore.App.Ref"].Should().Be(targetingPackVersion);
             string runtimePackName = resolvedVersions.PackageDownload.Keys
                 .Where(k => k.StartsWith("runtime.") && k.EndsWith(".Microsoft.NETCore.App"))
                 .Single();
@@ -314,7 +314,7 @@ namespace FrameworkReferenceTest
             var resolvedVersions = GetResolvedVersions(testProject);
 
             resolvedVersions.RuntimeFramework["Microsoft.NETCore.App"].Should().Be(runtimeFrameworkVersion);
-            resolvedVersions.PackageDownload["Microsoft.NETCore.App"].Should().Be(targetingPackVersion);
+            resolvedVersions.PackageDownload["Microsoft.NETCore.App.Ref"].Should().Be(targetingPackVersion);
             string runtimePackName = resolvedVersions.PackageDownload.Keys
                 .Where(k => k.StartsWith("runtime.") && k.EndsWith(".Microsoft.NETCore.App"))
                 .Single();
@@ -350,7 +350,7 @@ namespace FrameworkReferenceTest
             string expectedRuntimeFrameworkVersion = attributeValue ? "3.0.0-latestversion" : "3.0.0-defaultversion";
 
             resolvedVersions.RuntimeFramework["Microsoft.NETCore.App"].Should().Be(expectedRuntimeFrameworkVersion);
-            resolvedVersions.PackageDownload["Microsoft.NETCore.App"].Should().Be(targetingPackVersion);
+            resolvedVersions.PackageDownload["Microsoft.NETCore.App.Ref"].Should().Be(targetingPackVersion);
             string runtimePackName = resolvedVersions.PackageDownload.Keys
                 .Where(k => k.StartsWith("runtime.") && k.EndsWith(".Microsoft.NETCore.App"))
                 .Single();
@@ -376,7 +376,7 @@ namespace FrameworkReferenceTest
             string expectedRuntimeFrameworkVersion = propertyValue ? "3.0.0-latestversion" : "3.0.0-defaultversion";
 
             resolvedVersions.RuntimeFramework["Microsoft.NETCore.App"].Should().Be(expectedRuntimeFrameworkVersion);
-            resolvedVersions.PackageDownload["Microsoft.NETCore.App"].Should().Be(targetingPackVersion);
+            resolvedVersions.PackageDownload["Microsoft.NETCore.App.Ref"].Should().Be(targetingPackVersion);
             string runtimePackName = resolvedVersions.PackageDownload.Keys
                 .Where(k => k.StartsWith("runtime.") && k.EndsWith(".Microsoft.NETCore.App"))
                 .Single();
@@ -407,7 +407,7 @@ namespace FrameworkReferenceTest
             string expectedRuntimeFrameworkVersion = "3.0.0-latestversion";
 
             resolvedVersions.RuntimeFramework["Microsoft.NETCore.App"].Should().Be(expectedRuntimeFrameworkVersion);
-            resolvedVersions.PackageDownload["Microsoft.NETCore.App"].Should().Be(targetingPackVersion);
+            resolvedVersions.PackageDownload["Microsoft.NETCore.App.Ref"].Should().Be(targetingPackVersion);
             string runtimePackName = resolvedVersions.PackageDownload.Keys
                 .Where(k => k.StartsWith("runtime.") && k.EndsWith(".Microsoft.NETCore.App"))
                 .Single();

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeManifestSupportedFrameworks.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeManifestSupportedFrameworks.cs
@@ -28,7 +28,7 @@ namespace Microsoft.NET.Build.Tests
             var project = new TestProject
             {
                 Name = "packagethatwillgomissing",
-                TargetFrameworks = targetFrameworkIdentifier ==  ".NETCoreApp" ? "netcoreapp2.0" : "netstandard2.0",
+                TargetFrameworks = targetFrameworkIdentifier ==  ".NETCoreApp" ? "netcoreapp3.0" : "netstandard2.1",
                 IsSdkProject = true,
             };
 
@@ -63,7 +63,7 @@ namespace Microsoft.NET.Build.Tests
             string expectedTFM = $"{targetFrameworkIdentifier},Version=v{maximumVersion}";
 
             supportedFrameworks.Should().Contain(expectedTFM,
-                because: $"Microsoft.NET.SupportedTargetFrameworks.targets should include an entry for {expectedTFM}");
+                because: $"Microsoft.NET.SupportedTargetFrameworks.props should include an entry for {expectedTFM}");
         }
     }
 }

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildALibrary.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildALibrary.cs
@@ -516,7 +516,7 @@ namespace Microsoft.NET.Build.Tests
 
         [Theory]
         [InlineData("netcoreapp3.1")]
-        [InlineData("netstandard2.1")]
+        [InlineData("netstandard2.2")]
         public void It_fails_to_build_if_targeting_a_higher_framework_than_is_supported(string targetFramework)
         {
             var testProject = new TestProject()

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildANetStandard2Library.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildANetStandard2Library.cs
@@ -24,17 +24,19 @@ namespace Microsoft.NET.Build.Tests
         {
         }
 
-        [Fact]
-        public void It_builds_a_netstandard2_library_successfully()
+        [Theory]
+        [InlineData("netstandard2.0")]
+        [InlineData("netstandard2.1")]
+        public void It_builds_a_netstandard2_library_successfully(string targetFramework)
         {
             TestProject project = new TestProject()
             {
                 Name = "NetStandard2Library",
-                TargetFrameworks = "netstandard2.0",
+                TargetFrameworks = targetFramework,
                 IsSdkProject = true
             };
 
-            var testAsset = _testAssetsManager.CreateTestProject(project)
+            var testAsset = _testAssetsManager.CreateTestProject(project, identifier: targetFramework)
                 .Restore(Log, project.Name);
 
             string projectFolder = Path.Combine(testAsset.Path, project.Name);

--- a/src/Tests/Microsoft.NET.Publish.Tests/RuntimeIdentifiersTests.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/RuntimeIdentifiersTests.cs
@@ -1,0 +1,184 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using FluentAssertions;
+using Microsoft.DotNet.Cli.Utils;
+using Microsoft.NET.TestFramework;
+using Microsoft.NET.TestFramework.Assertions;
+using Microsoft.NET.TestFramework.Commands;
+using Microsoft.NET.TestFramework.ProjectConstruction;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.NET.Publish.Tests
+{
+    public class RuntimeIdentifiersTests : SdkTest
+    {
+        public RuntimeIdentifiersTests(ITestOutputHelper log) : base(log)
+        {
+        }
+
+        [Fact]
+        public void BuildWithRuntimeIdentifier()
+        {
+            var testProject = new TestProject()
+            {
+                Name = "BuildWithRuntimeIdentifier",
+                TargetFrameworks = "netcoreapp3.0",
+                IsSdkProject = true,
+                IsExe = true
+            };
+
+            var compatibleRid = EnvironmentInfo.GetCompatibleRid(testProject.TargetFrameworks);
+
+            var runtimeIdentifiers = new[]
+            {
+                "win-x64",
+                "linux-x64",
+                compatibleRid
+            };
+
+            testProject.AdditionalProperties["RuntimeIdentifiers"] = string.Join(';', runtimeIdentifiers);
+
+            //  Use a test-specific packages folder
+            testProject.AdditionalProperties["RestorePackagesPath"] = @"$(MSBuildProjectDirectory)\packages";
+
+            var testAsset = _testAssetsManager.CreateTestProject(testProject);
+
+            var restoreCommand = new RestoreCommand(Log, testAsset.Path, testProject.Name);
+
+            restoreCommand
+                .Execute()
+                .Should()
+                .Pass();
+
+            foreach (var runtimeIdentifier in runtimeIdentifiers)
+            {
+                var buildCommand = new BuildCommand(Log, testAsset.Path, testProject.Name);
+
+                buildCommand
+                    .Execute($"/p:RuntimeIdentifier={runtimeIdentifier}")
+                    .Should()
+                    .Pass();
+
+                if (runtimeIdentifier == compatibleRid)
+                {
+                    var outputDirectory = buildCommand.GetOutputDirectory(testProject.TargetFrameworks, runtimeIdentifier: runtimeIdentifier);
+                    var selfContainedExecutable = $"{testProject.Name}{Constants.ExeSuffix}";
+                    string selfContainedExecutableFullPath = Path.Combine(outputDirectory.FullName, selfContainedExecutable);
+
+                    Command.Create(selfContainedExecutableFullPath, new string[] { })
+                        .CaptureStdOut()
+                        .Execute()
+                        .Should()
+                        .Pass()
+                        .And
+                        .HaveStdOutContaining("Hello World!");
+                }
+            }
+        }
+
+        [Theory]
+        [InlineData(false)]
+        //  "No build" scenario doesn't currently work: https://github.com/dotnet/sdk/issues/2956
+        //[InlineData(true)]
+        public void PublishWithRuntimeIdentifier(bool publishNoBuild)
+        {
+            var testProject = new TestProject()
+            {
+                Name = "PublishWithRuntimeIdentifier",
+                TargetFrameworks = "netcoreapp3.0",
+                IsSdkProject = true,
+                IsExe = true
+            };
+
+            var compatibleRid = EnvironmentInfo.GetCompatibleRid(testProject.TargetFrameworks);
+
+            var runtimeIdentifiers = new[]
+            {
+                "win-x64",
+                "linux-x64",
+                compatibleRid
+            };
+
+            testProject.AdditionalProperties["RuntimeIdentifiers"] = string.Join(';', runtimeIdentifiers);
+
+            //  Use a test-specific packages folder
+            testProject.AdditionalProperties["RestorePackagesPath"] = @"$(MSBuildProjectDirectory)\packages";
+
+            var testAsset = _testAssetsManager.CreateTestProject(testProject, identifier: publishNoBuild ? "nobuild" : string.Empty);
+
+            var buildCommand = new BuildCommand(Log, testAsset.Path, testProject.Name);
+
+            buildCommand
+                .Execute("/restore")
+                .Should()
+                .Pass();
+
+            foreach (var runtimeIdentifier in runtimeIdentifiers)
+            {
+                var publishArgs = new List<string>()
+                {
+                    $"/p:RuntimeIdentifier={runtimeIdentifier}"
+                };
+                if (publishNoBuild)
+                {
+                    publishArgs.Add("/p:NoBuild=true");
+                }
+
+                var publishCommand = new PublishCommand(Log, Path.Combine(testAsset.Path, testProject.Name));
+                publishCommand.Execute(publishArgs.ToArray())
+                    .Should()
+                    .Pass();
+
+                if (runtimeIdentifier == compatibleRid)
+                {
+                    var outputDirectory = publishCommand.GetOutputDirectory(testProject.TargetFrameworks, runtimeIdentifier: runtimeIdentifier);
+                    var selfContainedExecutable = $"{testProject.Name}{Constants.ExeSuffix}";
+                    string selfContainedExecutableFullPath = Path.Combine(outputDirectory.FullName, selfContainedExecutable);
+
+                    Command.Create(selfContainedExecutableFullPath, new string[] { })
+                        .CaptureStdOut()
+                        .Execute()
+                        .Should()
+                        .Pass()
+                        .And
+                        .HaveStdOutContaining("Hello World!");
+
+                }
+            }
+        }
+
+        [Fact]
+        public void DuplicateRuntimeIdentifiers()
+        {
+            var testProject = new TestProject()
+            {
+                Name = "DuplicateRuntimeIdentifiers",
+                TargetFrameworks = "netcoreapp3.0",
+                IsSdkProject = true,
+                IsExe = true
+            };
+
+            var compatibleRid = EnvironmentInfo.GetCompatibleRid(testProject.TargetFrameworks);
+
+            testProject.AdditionalProperties["RuntimeIdentifiers"] = compatibleRid + ";" + compatibleRid;
+            testProject.RuntimeIdentifier = compatibleRid;
+
+            var testAsset = _testAssetsManager.CreateTestProject(testProject)
+                .Restore(Log, testProject.Name);
+
+            var buildCommand = new BuildCommand(Log, testAsset.Path, testProject.Name);
+
+            buildCommand
+                .Execute()
+                .Should()
+                .Pass();
+
+
+
+
+        }
+    }
+}

--- a/src/Tests/Microsoft.NET.Publish.Tests/RuntimeIdentifiersTests.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/RuntimeIdentifiersTests.cs
@@ -19,7 +19,8 @@ namespace Microsoft.NET.Publish.Tests
         {
         }
 
-        [Fact]
+        //  Run on core MSBuild only as using a local packages folder hits long path issues on full MSBuild
+        [CoreMSBuildOnlyFact]
         public void BuildWithRuntimeIdentifier()
         {
             var testProject = new TestProject()
@@ -79,7 +80,8 @@ namespace Microsoft.NET.Publish.Tests
             }
         }
 
-        [Theory]
+        //  Run on core MSBuild only as using a local packages folder hits long path issues on full MSBuild
+        [CoreMSBuildOnlyTheory]
         [InlineData(false)]
         //  "No build" scenario doesn't currently work: https://github.com/dotnet/sdk/issues/2956
         //[InlineData(true)]


### PR DESCRIPTION
This supports the ".Ref" targeting packs for .NET Core and ASP.NET Core, as well as .NET Standard 2.1.

The core-sdk repo needs to be updated to include these in the `KnownFrameworkReference` items in the bundled versions file.  However, we need to check this logic into the SDK (and flow it into core-sdk) first, because we changed the layout for the .NET Core targeting pack and things would fail if we bundled a version of the targeting pack that the SDK code couldn't understand.  (Note that the layout in this PR isn't necessarily final either.)

There's temporary logic in this PR to update the `KnownFrameworkReference` items to refer to the new targeting packs for testing purposes.  Once we do the round trip through core-sdk, we can remove that logic.

Also note that this PR currently adds a `KnownFrameworkReference` for NETStandard.Library, but that is checked in to core-sdk already (since it's for a new TargetFramework), so once we have a build from core-sdk with the changes from https://github.com/dotnet/core-sdk/pull/477, I will update this PR to remove that workaround.