### PR TITLE
Expose option to disable tier 0 JIT for configuring from a project file

### DIFF
--- a/src/Assets/TestProjects/KitchenSink/TestApp/TestApp.csproj
+++ b/src/Assets/TestProjects/KitchenSink/TestApp/TestApp.csproj
@@ -15,6 +15,7 @@
     <ThreadPoolMaxThreads>9</ThreadPoolMaxThreads>
     <InvariantGlobalization>true</InvariantGlobalization>
     <TieredCompilation>true</TieredCompilation>
+    <DisableTier0Jit>true</DisableTier0Jit>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -239,6 +239,10 @@ Copyright (c) .NET Foundation. All rights reserved.
                                     Condition="'$(TieredCompilation)' != ''"
                                     Value="$(TieredCompilation)" />
 
+    <RuntimeHostConfigurationOption Include="System.Runtime.TieredCompilation.DisableTier0Jit"
+                                    Condition="'$(DisableTier0Jit)' != ''"
+                                    Value="$(DisableTier0Jit)" />
+
     <RuntimeHostConfigurationOption Include="System.Threading.ThreadPool.MinThreads"
                                     Condition="'$(ThreadPoolMinThreads)' != ''"
                                     Value="$(ThreadPoolMinThreads)" />

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAProjectWithAllFeatures.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAProjectWithAllFeatures.cs
@@ -70,6 +70,7 @@ namespace Microsoft.NET.Publish.Tests
             ""System.GC.Server"": true,
             ""System.GC.RetainVM"": false,
             ""System.Runtime.TieredCompilation"": true,
+            ""System.Runtime.TieredCompilation.DisableTier0Jit"": true,
             ""System.Threading.ThreadPool.MinThreads"": 2,
             ""System.Threading.ThreadPool.MaxThreads"": 9,
             ""System.Globalization.Invariant"": true,


### PR DESCRIPTION
- For scenarios that don't mind giving up some startup time (but not too much), it may be a reasonable option when it is desirable to avoid spending two JIT cycles on methods
- I'd like to use this mode as the default for microbenchmarks in the performance repo and the most convenient way of doing so would be to have a way to specify it in a project file, to keep benchmarks easily runnable with `dotnet run`. It serves as a soft workaround to https://github.com/dotnet/coreclr/issues/19751 while still allowing perf improvements from tiering to show when R2R is being used, in benchmarks that could help to get more representative numbers.