### PR TITLE
Speed up GetPackageDirectory task and clean up NuGetPackageResolver

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/DependencyContextBuilder.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/DependencyContextBuilder.cs
@@ -48,7 +48,7 @@ namespace Microsoft.NET.Build.Tasks
             {
                 //  This is used to look up the paths to package files on disk, which is only needed in this class if
                 //  it needs to read the file versions
-                _packageResolver = NuGetPackageResolver.CreateResolver(projectContext.LockFile, mainProjectInfo.ProjectPath);
+                _packageResolver = NuGetPackageResolver.CreateResolver(projectContext.LockFile);
             }
         }
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/NuGetPackageResolver.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/NuGetPackageResolver.cs
@@ -33,7 +33,7 @@ namespace Microsoft.NET.Build.Tasks
         
         public string GetPackageDirectory(string packageId, NuGetVersion version, out string packageRoot)
         {
-            var packageInfo = _packagePathResolver?.GetPackageInfo(packageId,version);
+            var packageInfo = _packagePathResolver?.GetPackageInfo(packageId, version);
             if (packageInfo == null)
             {
                 packageRoot = null;

--- a/src/Tasks/Microsoft.NET.Build.Tasks/NuGetPackageResolver.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/NuGetPackageResolver.cs
@@ -12,34 +12,36 @@ using System.Linq;
 
 namespace Microsoft.NET.Build.Tasks
 {
-    internal class NuGetPackageResolver : IPackageResolver
+    internal sealed class NuGetPackageResolver : IPackageResolver
     {
         private readonly FallbackPackagePathResolver _packagePathResolver;
 
-        public NuGetPackageResolver(INuGetPathContext pathContext)
+        // Used when no package folders are provided, finds no packages.
+        private static readonly NuGetPackageResolver s_noPackageFolderResolver = new NuGetPackageResolver();
+
+        private NuGetPackageResolver()
         {
-            _packagePathResolver = new FallbackPackagePathResolver(pathContext);
         }
 
-        public NuGetPackageResolver(string userPackageFolder, IEnumerable<string> fallbackPackageFolders)
+        private NuGetPackageResolver(string userPackageFolder, IEnumerable<string> fallbackPackageFolders)
         {
             _packagePathResolver = new FallbackPackagePathResolver(userPackageFolder, fallbackPackageFolders);
         }
 
         public string GetPackageDirectory(string packageId, NuGetVersion version)
-        {
-            string  packageRoot = null;
-            return GetPackageDirectory(packageId, version, out packageRoot);
-        }
+            => _packagePathResolver?.GetPackageDirectory(packageId, version);
+        
         public string GetPackageDirectory(string packageId, NuGetVersion version, out string packageRoot)
         {
-            packageRoot = null;
-            var pkginfo = _packagePathResolver.GetPackageInfo(packageId,version);
-            if (pkginfo != null)
+            var packageInfo = _packagePathResolver?.GetPackageInfo(packageId,version);
+            if (packageInfo == null)
             {
-                packageRoot = pkginfo.PathResolver.GetVersionListPath("");  //TODO Remove Once Nuget is updated to use FallbackPackagePathInfo.PathResolver.RootPath
+                packageRoot = null;
+                return null;
             }
-            return _packagePathResolver.GetPackageDirectory(packageId, version);
+
+            packageRoot = packageInfo.PathResolver.RootPath;
+            return packageInfo.PathResolver.GetInstallPath(packageId, version);
         }
 
         public string ResolvePackageAssetPath(LockFileTargetLibrary package, string relativePath)
@@ -56,30 +58,21 @@ namespace Microsoft.NET.Build.Tasks
         }
 
         public static string NormalizeRelativePath(string relativePath)
-                => relativePath.Replace('/', Path.DirectorySeparatorChar);
+            => relativePath.Replace('/', Path.DirectorySeparatorChar);
 
-        public static NuGetPackageResolver CreateResolver(LockFile lockFile, string projectPath)
+        public static NuGetPackageResolver CreateResolver(LockFile lockFile)
+            => CreateResolver(lockFile.PackageFolders.Select(f => f.Path));
+
+        public static NuGetPackageResolver CreateResolver(IEnumerable<string> packageFolders)
         {
-            return CreateResolver(lockFile.PackageFolders.Select(f => f.Path), projectPath);
-        }
-
-        public static NuGetPackageResolver CreateResolver(IEnumerable<string> packageFolders, string projectPath)
-        {
-            NuGetPackageResolver packageResolver;
-
             string userPackageFolder = packageFolders.FirstOrDefault();
-            if (userPackageFolder != null)
+
+            if (userPackageFolder == null)
             {
-                var fallBackFolders = packageFolders.Skip(1);
-                packageResolver = new NuGetPackageResolver(userPackageFolder, fallBackFolders);
-            }
-            else
-            {
-                NuGetPathContext nugetPathContext = NuGetPathContext.Create(Path.GetDirectoryName(projectPath));
-                packageResolver = new NuGetPackageResolver(nugetPathContext);
+                return s_noPackageFolderResolver;
             }
 
-            return packageResolver;
+            return new NuGetPackageResolver(userPackageFolder, packageFolders.Skip(1));
         }
     }
 }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolveAppHosts.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveAppHosts.cs
@@ -151,6 +151,7 @@ namespace Microsoft.NET.Build.Tasks
                 if (appHostPackPath != null && Directory.Exists(appHostPackPath))
                 {
                     //  Use AppHost from packs folder
+                    appHostItem.SetMetadata(MetadataKeys.PackageDirectory, appHostPackPath);
                     appHostItem.SetMetadata(MetadataKeys.Path, Path.Combine(appHostPackPath, appHostRelativePathInPackage));
                 }
                 else

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolveCopyLocalAssets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveCopyLocalAssets.cs
@@ -68,7 +68,7 @@ namespace Microsoft.NET.Build.Tasks
             projectContext.PackagesToBeFiltered = packagestoBeFiltered;
 
             var assetsFileResolver =
-                new AssetsFileResolver(NuGetPackageResolver.CreateResolver(lockFile, ProjectPath))
+                new AssetsFileResolver(NuGetPackageResolver.CreateResolver(lockFile))
                     .WithExcludedPackages(PackageReferenceConverter.GetPackageIds(ExcludedPackageReferences))
                     .WithPreserveStoreLayout(PreserveStoreLayout);
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolveCopyLocalAssets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveCopyLocalAssets.cs
@@ -18,9 +18,6 @@ namespace Microsoft.NET.Build.Tasks
     {
         private readonly List<ITaskItem> _resolvedAssets = new List<ITaskItem>();
 
-        [Required]
-        public string ProjectPath { get; set; }
-
         public string AssetsFilePath { get; set; }
 
         [Required]

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolveFrameworkReferences.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveFrameworkReferences.cs
@@ -106,8 +106,9 @@ namespace Microsoft.NET.Build.Tasks
                 }
                 if (targetingPackPath != null && Directory.Exists(targetingPackPath))
                 {
-                    targetingPack.SetMetadata(MetadataKeys.Path, targetingPackPath);
+                    // Use targeting pack from packs folder
                     targetingPack.SetMetadata(MetadataKeys.PackageDirectory, targetingPackPath);
+                    targetingPack.SetMetadata(MetadataKeys.Path, targetingPackPath);
                 }
                 else
                 {

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageAssets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageAssets.cs
@@ -601,7 +601,7 @@ namespace Microsoft.NET.Build.Tasks
 
                 _task = task;
                 _lockFile = new LockFileCache(task).GetLockFile(task.ProjectAssetsFile);
-                _packageResolver = NuGetPackageResolver.CreateResolver(_lockFile, _task.ProjectPath);
+                _packageResolver = NuGetPackageResolver.CreateResolver(_lockFile);
                 _compileTimeTarget = _lockFile.GetTargetAndThrowIfNotFound(targetFramework, runtime: null);
                 _runtimeTarget = _lockFile.GetTargetAndThrowIfNotFound(targetFramework, _task.RuntimeIdentifier);
                 _stringTable = new Dictionary<string, int>(InitialStringTableCapacity, StringComparer.Ordinal);

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageDependencies.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageDependencies.cs
@@ -129,7 +129,7 @@ namespace Microsoft.NET.Build.Tasks
             {
                 if (_packageResolver == null)
                 {
-                    _packageResolver = NuGetPackageResolver.CreateResolver(LockFile, ProjectPath);
+                    _packageResolver = NuGetPackageResolver.CreateResolver(LockFile);
                 }
 
                 return _packageResolver;

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolveTargetingPackAssets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveTargetingPackAssets.cs
@@ -45,13 +45,10 @@ namespace Microsoft.NET.Build.Tasks
             foreach (var frameworkReference in FrameworkReferences)
             {
                 ITaskItem targetingPack;
-                string targetingPackRoot = null;
                 resolvedTargetingPacks.TryGetValue(frameworkReference.ItemSpec, out targetingPack);
-                if (targetingPack != null)
-                {
-                    targetingPackRoot = targetingPack.GetMetadata("Path");
-                }
-                if (targetingPack == null || !Directory.Exists(targetingPackRoot))
+                string targetingPackRoot = targetingPack?.GetMetadata("Path");
+ 
+                if (string.IsNullOrEmpty(targetingPackRoot) || !Directory.Exists(targetingPackRoot))
                 {
                     if (GenerateErrorForMissingTargetingPacks)
                     {

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.CrossGen.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.CrossGen.targets
@@ -272,8 +272,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                              StorePackageName=$(MicrosoftNETPlatformLibrary);
                              StorePackageVersion=%(PackageReferenceForCrossGen.Version);"/>
 
-    <ResolveCopyLocalAssets ProjectPath="$(MSBuildProjectFullPath)"
-                            AssetsFilePath="$(_CrossProjAssetsFile)"
+    <ResolveCopyLocalAssets AssetsFilePath="$(_CrossProjAssetsFile)"
                             TargetFramework="$(_TFM)"
                             RuntimeIdentifier="$(RuntimeIdentifier)"
                             PlatformLibraryName="$(MicrosoftNETPlatformLibrary)"

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -277,8 +277,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                             _DefaultMicrosoftNETPlatformLibrary;
                             ResolveRuntimePackAssets">
 
-      <ResolveCopyLocalAssets ProjectPath="$(MSBuildProjectFullPath)"
-                              AssetsFilePath="$(ProjectAssetsFile)"
+      <ResolveCopyLocalAssets AssetsFilePath="$(ProjectAssetsFile)"
                               TargetFramework="$(TargetFrameworkMoniker)"
                               RuntimeIdentifier="$(RuntimeIdentifier)"
                               PlatformLibraryName="$(MicrosoftNETPlatformLibrary)"

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.TargetingPackResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.TargetingPackResolution.targets
@@ -134,7 +134,6 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <GetPackageDirectory
       Items="@(TargetingPack)"
-      ProjectPath="$(MSBuildProjectFullPath)"
       PackageFolders="@(AssetsFilePackageFolder)">
 
       <Output TaskParameter="Output" ItemName="ResolvedTargetingPack" />
@@ -142,8 +141,8 @@ Copyright (c) .NET Foundation. All rights reserved.
     </GetPackageDirectory>    
     
     <ItemGroup>
-      <ResolvedTargetingPack>
-        <Path Condition="'%(ResolvedTargetingPack.Path)' == ''">%(PackageDirectory)</Path>
+      <ResolvedTargetingPack Condition="'%(ResolvedTargetingPack.Path)' == '' and '%(ResolvedTargetingPack.PackageDirectory)' != ''">
+        <Path>%(ResolvedTargetingPack.PackageDirectory)</Path>
       </ResolvedTargetingPack>
       
     </ItemGroup>
@@ -176,7 +175,6 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <GetPackageDirectory
       Items="@(AppHostPack)"
-      ProjectPath="$(MSBuildProjectFullPath)"
       PackageFolders="@(AssetsFilePackageFolder)">
 
       <Output TaskParameter="Output" ItemName="ResolvedAppHostPack" />
@@ -185,7 +183,6 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <GetPackageDirectory
       Items="@(PackAsToolShimAppHostPack)"
-      ProjectPath="$(MSBuildProjectFullPath)"
       PackageFolders="@(AssetsFilePackageFolder)">
 
       <Output TaskParameter="Output" ItemName="_ApphostsForShimRuntimeIdentifiersGetPackageDirectory" />
@@ -199,8 +196,8 @@ Copyright (c) .NET Foundation. All rights reserved.
     </ItemGroup>
 
     <ItemGroup>
-      <ResolvedAppHostPack>
-        <Path Condition="'%(ResolvedAppHostPack.Path)' == ''">%(PackageDirectory)\%(RelativePath)</Path>
+      <ResolvedAppHostPack Condition="'%(ResolvedAppHostPack.Path)' == '' and '%(ResolvedAppHostPack.PackageDirectory)' != ''">
+        <Path>%(ResolvedAppHostPack.PackageDirectory)\%(ResolvedAppHostPack.RelativePath)</Path>
       </ResolvedAppHostPack>      
     </ItemGroup>
 
@@ -217,7 +214,6 @@ Copyright (c) .NET Foundation. All rights reserved.
     
       <GetPackageDirectory
         Items="@(RuntimePack)"
-        ProjectPath="$(MSBuildProjectFullPath)"
         PackageFolders="@(AssetsFilePackageFolder)">
 
       <Output TaskParameter="Output" ItemName="ResolvedRuntimePack" />


### PR DESCRIPTION
1. Never use INuGetPathContext. It is slow an unpredictable. It was left as a fallback when #361 was fixed, but we should never be resolving from package folders other than what is listed in the assets file. So  instead, if no package folders are in the assets file, we will find no packages. This path should not ever have been taken. Most tasks that call this are skipped in design-time when no assets file is available yet. GetPackageDirectory is not, but that is handled by (3) below.

2. Stop hitting the disk twice on GetPackageDirectory. We were calling GetPackageInfo and GetPackageDirectory and both probe on disk for the package. Instead, use GetInstallPath on result PackageInfo or use GetPackageDirectory alone when we do not need the RootPath.

3. Fix #2928: Replace incorrect check for null package resolver and replace it with up-front defense against empty PackageFolders.

4. Eliminate unnecessary allocations for List<T> resizing and copying to array.

5. Fix TODO in NuGetPackageResolver and Use RootPath property instead of workaround.

6. Stop treating "\\%(RelativePath)" as targeting pack path when not downloaded.

7. Follow same pattern for apphost as targeting pack to avoid probing in packages folder when found in packs folder.