### PR TITLE
Ensure Build target isn't invoked when NoBuild is set.

### DIFF
--- a/src/Tasks/Common/Resources/Strings.resx
+++ b/src/Tasks/Common/Resources/Strings.resx
@@ -440,10 +440,6 @@ The following are names of parameters or literal values and should not be transl
     <value>NETSDK1081: The targeting pack for {0} was not found. You may be able to resolve this by running a NuGet restore on the project.</value>
     <comment>{StrBegin="NETSDK1081: "}</comment>
   </data>
-  <data name="NoAppHostAvailable" xml:space="preserve">
-    <value>NETSDK1084: There is no application host available for the specified RuntimeIdentifier '{0}'.</value>
-    <comment>{StrBegin="NETSDK1084: "}</comment>
-  </data>
   <data name="NoRuntimePackAvailable" xml:space="preserve">
     <value>NETSDK1082: There was no runtime pack for {0} available for the specified RuntimeIdentifier '{1}'.</value>
     <comment>{StrBegin="NETSDK1082: "}</comment>
@@ -451,5 +447,13 @@ The following are names of parameters or literal values and should not be transl
   <data name="RuntimeIdentifierNotRecognized" xml:space="preserve">
     <value>NETSDK1083: The specified RuntimeIdentifier '{0}' is not recognized.</value>
     <comment>{StrBegin="NETSDK1083: "}</comment>
+  </data>
+  <data name="NoAppHostAvailable" xml:space="preserve">
+    <value>NETSDK1084: There is no application host available for the specified RuntimeIdentifier '{0}'.</value>
+    <comment>{StrBegin="NETSDK1084: "}</comment>
+  </data>
+  <data name="NoBuildRequested" xml:space="preserve">
+    <value>NETSDK1085: The 'NoBuild' property was set to true but the 'Build' target was invoked.</value>
+    <comment>{StrBegin="NETSDK1085: "}</comment>
   </data>
 </root>

--- a/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
@@ -296,6 +296,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1084: Není dostupný žádný hostitel aplikace pro zadaný RuntimeIdentifier {0}.</target>
         <note>{StrBegin="NETSDK1084: "}</note>
       </trans-unit>
+      <trans-unit id="NoBuildRequested">
+        <source>NETSDK1085: The 'NoBuild' property was set to true but the 'Build' target was invoked.</source>
+        <target state="new">NETSDK1085: The 'NoBuild' property was set to true but the 'Build' target was invoked.</target>
+        <note>{StrBegin="NETSDK1085: "}</note>
+      </trans-unit>
       <trans-unit id="NoCompatibleTargetFramework">
         <source>NETSDK1002: Project '{0}' targets '{2}'. It cannot be referenced by a project that targets '{1}'.</source>
         <target state="translated">NETSDK1002: Cílem projektu {0} je {2}. Nemůže na něj odkazovat projekt, jehož cílem je {1}.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.de.xlf
@@ -296,6 +296,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1084: Für den angegebenen RuntimeIdentifier "{0}" ist kein Anwendungshost verfügbar.</target>
         <note>{StrBegin="NETSDK1084: "}</note>
       </trans-unit>
+      <trans-unit id="NoBuildRequested">
+        <source>NETSDK1085: The 'NoBuild' property was set to true but the 'Build' target was invoked.</source>
+        <target state="new">NETSDK1085: The 'NoBuild' property was set to true but the 'Build' target was invoked.</target>
+        <note>{StrBegin="NETSDK1085: "}</note>
+      </trans-unit>
       <trans-unit id="NoCompatibleTargetFramework">
         <source>NETSDK1002: Project '{0}' targets '{2}'. It cannot be referenced by a project that targets '{1}'.</source>
         <target state="translated">NETSDK1002: Das Projekt "{0}" hat das Ziel "{2}". Ein Verweis über ein Projekt mit dem Ziel "{1}" ist nicht möglich.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.es.xlf
@@ -296,6 +296,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1084: No hay ningún host de aplicación disponible para el RuntimeIdentifier especificado "{0}".</target>
         <note>{StrBegin="NETSDK1084: "}</note>
       </trans-unit>
+      <trans-unit id="NoBuildRequested">
+        <source>NETSDK1085: The 'NoBuild' property was set to true but the 'Build' target was invoked.</source>
+        <target state="new">NETSDK1085: The 'NoBuild' property was set to true but the 'Build' target was invoked.</target>
+        <note>{StrBegin="NETSDK1085: "}</note>
+      </trans-unit>
       <trans-unit id="NoCompatibleTargetFramework">
         <source>NETSDK1002: Project '{0}' targets '{2}'. It cannot be referenced by a project that targets '{1}'.</source>
         <target state="translated">NETSDK1002: El proyecto "{0}" tiene como destino "{2}". No se puede hacer referencia a él mediante un proyecto que tenga como destino "{1}".</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
@@ -296,6 +296,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1084 : Aucun hôte d'application disponible pour le RuntimeIdentifier '{0}' spécifié.</target>
         <note>{StrBegin="NETSDK1084: "}</note>
       </trans-unit>
+      <trans-unit id="NoBuildRequested">
+        <source>NETSDK1085: The 'NoBuild' property was set to true but the 'Build' target was invoked.</source>
+        <target state="new">NETSDK1085: The 'NoBuild' property was set to true but the 'Build' target was invoked.</target>
+        <note>{StrBegin="NETSDK1085: "}</note>
+      </trans-unit>
       <trans-unit id="NoCompatibleTargetFramework">
         <source>NETSDK1002: Project '{0}' targets '{2}'. It cannot be referenced by a project that targets '{1}'.</source>
         <target state="translated">NETSDK1002: Le projet '{0}' cible '{2}'. Il ne peut pas être référencé par un projet qui cible '{1}'.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.it.xlf
@@ -296,6 +296,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1084: non è disponibile alcun host applicazione per l'elemento RuntimeIdentifier specificato '{0}'.</target>
         <note>{StrBegin="NETSDK1084: "}</note>
       </trans-unit>
+      <trans-unit id="NoBuildRequested">
+        <source>NETSDK1085: The 'NoBuild' property was set to true but the 'Build' target was invoked.</source>
+        <target state="new">NETSDK1085: The 'NoBuild' property was set to true but the 'Build' target was invoked.</target>
+        <note>{StrBegin="NETSDK1085: "}</note>
+      </trans-unit>
       <trans-unit id="NoCompatibleTargetFramework">
         <source>NETSDK1002: Project '{0}' targets '{2}'. It cannot be referenced by a project that targets '{1}'.</source>
         <target state="translated">NETSDK1002: il progetto '{0}' è destinato a '{2}'. Non può essere usato come riferimento in un progetto destinato a '{1}'.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
@@ -296,6 +296,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1084: 指定された RuntimeIdentifier '{0}' で利用可能なアプリケーション ホストがありません。</target>
         <note>{StrBegin="NETSDK1084: "}</note>
       </trans-unit>
+      <trans-unit id="NoBuildRequested">
+        <source>NETSDK1085: The 'NoBuild' property was set to true but the 'Build' target was invoked.</source>
+        <target state="new">NETSDK1085: The 'NoBuild' property was set to true but the 'Build' target was invoked.</target>
+        <note>{StrBegin="NETSDK1085: "}</note>
+      </trans-unit>
       <trans-unit id="NoCompatibleTargetFramework">
         <source>NETSDK1002: Project '{0}' targets '{2}'. It cannot be referenced by a project that targets '{1}'.</source>
         <target state="translated">NETSDK1002: プロジェクト '{0}' は、'{2}' を対象としています。'{1}' を対象とするプロジェクトは、これを参照できません。</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
@@ -296,6 +296,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1084: 지정한 RuntimeIdentifier '{0}'에 사용할 수 있는 애플리케이션 호스트가 없습니다.</target>
         <note>{StrBegin="NETSDK1084: "}</note>
       </trans-unit>
+      <trans-unit id="NoBuildRequested">
+        <source>NETSDK1085: The 'NoBuild' property was set to true but the 'Build' target was invoked.</source>
+        <target state="new">NETSDK1085: The 'NoBuild' property was set to true but the 'Build' target was invoked.</target>
+        <note>{StrBegin="NETSDK1085: "}</note>
+      </trans-unit>
       <trans-unit id="NoCompatibleTargetFramework">
         <source>NETSDK1002: Project '{0}' targets '{2}'. It cannot be referenced by a project that targets '{1}'.</source>
         <target state="translated">NETSDK1002: '{0}' 프로젝트가 '{2}'을(를) 대상으로 합니다. '{1}'을(를) 대상으로 하는 프로젝트에서 참조할 수 없습니다.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
@@ -296,6 +296,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1084: Brak dostępnego hosta aplikacji dla określonego identyfikatora RuntimeIdentifier „{0}”.</target>
         <note>{StrBegin="NETSDK1084: "}</note>
       </trans-unit>
+      <trans-unit id="NoBuildRequested">
+        <source>NETSDK1085: The 'NoBuild' property was set to true but the 'Build' target was invoked.</source>
+        <target state="new">NETSDK1085: The 'NoBuild' property was set to true but the 'Build' target was invoked.</target>
+        <note>{StrBegin="NETSDK1085: "}</note>
+      </trans-unit>
       <trans-unit id="NoCompatibleTargetFramework">
         <source>NETSDK1002: Project '{0}' targets '{2}'. It cannot be referenced by a project that targets '{1}'.</source>
         <target state="translated">NETSDK1002: Projekt „{0}” ma platformę docelową „{2}”. Nie może on być przywoływany przez projekt z platformą docelową „{1}”.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
@@ -296,6 +296,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1084: não há nenhum host de aplicativo disponível para o RuntimeIdentifier especificado '{0}'.</target>
         <note>{StrBegin="NETSDK1084: "}</note>
       </trans-unit>
+      <trans-unit id="NoBuildRequested">
+        <source>NETSDK1085: The 'NoBuild' property was set to true but the 'Build' target was invoked.</source>
+        <target state="new">NETSDK1085: The 'NoBuild' property was set to true but the 'Build' target was invoked.</target>
+        <note>{StrBegin="NETSDK1085: "}</note>
+      </trans-unit>
       <trans-unit id="NoCompatibleTargetFramework">
         <source>NETSDK1002: Project '{0}' targets '{2}'. It cannot be referenced by a project that targets '{1}'.</source>
         <target state="translated">NETSDK1002: O projeto '{0}' é direcionado a '{2}'. Ele não pode ser referenciado por um projeto direcionado a '{1}'.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
@@ -296,6 +296,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1084: Отсутствует доступный узел приложения для указанного идентификатора среды выполнения "{0}".</target>
         <note>{StrBegin="NETSDK1084: "}</note>
       </trans-unit>
+      <trans-unit id="NoBuildRequested">
+        <source>NETSDK1085: The 'NoBuild' property was set to true but the 'Build' target was invoked.</source>
+        <target state="new">NETSDK1085: The 'NoBuild' property was set to true but the 'Build' target was invoked.</target>
+        <note>{StrBegin="NETSDK1085: "}</note>
+      </trans-unit>
       <trans-unit id="NoCompatibleTargetFramework">
         <source>NETSDK1002: Project '{0}' targets '{2}'. It cannot be referenced by a project that targets '{1}'.</source>
         <target state="translated">NETSDK1002: проект "{0}" нацелен на платформу "{2}". На него не может ссылаться проект с целевой платформой "{1}".</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
@@ -296,6 +296,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1084: Belirtilen RuntimeIdentifier '{0}' için kullanılabilir uygulama konağı yok.</target>
         <note>{StrBegin="NETSDK1084: "}</note>
       </trans-unit>
+      <trans-unit id="NoBuildRequested">
+        <source>NETSDK1085: The 'NoBuild' property was set to true but the 'Build' target was invoked.</source>
+        <target state="new">NETSDK1085: The 'NoBuild' property was set to true but the 'Build' target was invoked.</target>
+        <note>{StrBegin="NETSDK1085: "}</note>
+      </trans-unit>
       <trans-unit id="NoCompatibleTargetFramework">
         <source>NETSDK1002: Project '{0}' targets '{2}'. It cannot be referenced by a project that targets '{1}'.</source>
         <target state="translated">NETSDK1002: '{0}' projesi, '{2}' çerçevesini hedefliyor. Bu projeye '{1}' çerçevesini hedefleyen bir proje tarafından başvurulamaz.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
@@ -296,6 +296,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1084: 对于指定的 RuntimeIdentifier“{0}”，没有可用的应用程序主机。</target>
         <note>{StrBegin="NETSDK1084: "}</note>
       </trans-unit>
+      <trans-unit id="NoBuildRequested">
+        <source>NETSDK1085: The 'NoBuild' property was set to true but the 'Build' target was invoked.</source>
+        <target state="new">NETSDK1085: The 'NoBuild' property was set to true but the 'Build' target was invoked.</target>
+        <note>{StrBegin="NETSDK1085: "}</note>
+      </trans-unit>
       <trans-unit id="NoCompatibleTargetFramework">
         <source>NETSDK1002: Project '{0}' targets '{2}'. It cannot be referenced by a project that targets '{1}'.</source>
         <target state="translated">NETSDK1002: 项目“{0}”以“{2}”为目标。它不可由面向“{1}”的项目引用。</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
@@ -296,6 +296,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1084: 指定的 RuntimeIdentifier '{0}’ 沒有可用的應用程式主機。</target>
         <note>{StrBegin="NETSDK1084: "}</note>
       </trans-unit>
+      <trans-unit id="NoBuildRequested">
+        <source>NETSDK1085: The 'NoBuild' property was set to true but the 'Build' target was invoked.</source>
+        <target state="new">NETSDK1085: The 'NoBuild' property was set to true but the 'Build' target was invoked.</target>
+        <note>{StrBegin="NETSDK1085: "}</note>
+      </trans-unit>
       <trans-unit id="NoCompatibleTargetFramework">
         <source>NETSDK1002: Project '{0}' targets '{2}'. It cannot be referenced by a project that targets '{1}'.</source>
         <target state="translated">NETSDK1002: 專案 '{0}' 以 '{2}' 為目標。以 '{1}' 為目標的專案無法參考此專案。</target>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -83,6 +83,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <PropertyGroup>
     <CoreBuildDependsOn>
+      _CheckForBuildWithNoBuild;
       $(CoreBuildDependsOn);
       GenerateBuildDependencyFile;
       GenerateBuildRuntimeConfigurationFiles
@@ -102,6 +103,14 @@ Copyright (c) .NET Foundation. All rights reserved.
       $(RebuildDependsOn)
     </RebuildDependsOn>
   </PropertyGroup>
+
+  <!-- TODO: this target should not check GeneratePackageOnBuild.
+             remove when https://github.com/NuGet/Home/issues/7801 is fixed.
+    -->
+  <Target Name="_CheckForBuildWithNoBuild"
+          Condition="'$(NoBuild)' == 'true' and '$(GeneratePackageOnBuild)' != 'true'">
+    <NETSdkError ResourceName="NoBuildRequested" />
+  </Target>
 
   <!--
     ============================================================

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAHelloWorldProject.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAHelloWorldProject.cs
@@ -438,5 +438,36 @@ public static class Program
 
             publishResult.Should().Pass();
         }
+
+        [Fact]
+        public void It_fails_if_nobuild_was_requested_but_build_was_invoked()
+        {
+            var testProject = new TestProject()
+            {
+                Name = "InvokeBuildOnPublish",
+                IsSdkProject = true,
+                TargetFrameworks = "netcoreapp3.0",
+                IsExe = true
+            };
+
+            var testAsset = _testAssetsManager.CreateTestProject(testProject, testProject.Name)
+                .WithProjectChanges(project =>
+                {
+                    project.Root.Add(XElement.Parse(@"<Target Name=""InvokeBuild"" DependsOnTargets=""Build"" BeforeTargets=""Publish"" />"));
+                })
+                .Restore(Log, testProject.Name);
+
+            new BuildCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name))
+                .Execute()
+                .Should()
+                .Pass();
+
+            new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name))
+                .Execute("/p:NoBuild=true")
+                .Should()
+                .Fail()
+                .And
+                .HaveStdOutContaining("NETSDK1085");
+        }
     }
 }


### PR DESCRIPTION
For `dotnet pack --nobuild` and `dotnet publish --nobuild`, if a target
inadvertently triggers the `Build` target, the build proceeds despite the user
explicitly requesting no build takes place.

This commit ensures the SDK errors if the `Build` target gets invoked when
`NoBuild` is true.

Fixes dotnet/cli#9581.