### PR TITLE
Fix 1.0 project tools missing dll in runtime

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "3.0.100-preview3-010324",
+    "dotnet": "3.0.100-preview3-010343",
     "vs-opt": {
       "version": "15.9"
     }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/GenerateDeps/GenerateDeps.proj
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/GenerateDeps/GenerateDeps.proj
@@ -51,9 +51,8 @@ Copyright (c) .NET Foundation. All rights reserved.
          matches the one that would be resolved based on the TargetFramework that was passed in. -->
     <VerifyMatchingImplicitPackageVersion>false</VerifyMatchingImplicitPackageVersion>
 
-    <!-- In 3.0 and above. To match the same behavior as above and allow deps.json include assets from package we need to
-         disable ImplicitFrameworkReferences. So assets from the packages will be in deps.json instead of being removed by
-         conflict resolution.-->
+    <!--In 3.0 and above, disable implicit framework references so we don't resolve targeting packs and conflict resolve 
+        dependencies which need to be written to the deps file. -->
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
   </PropertyGroup>
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/GenerateDeps/GenerateDeps.proj
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/GenerateDeps/GenerateDeps.proj
@@ -50,6 +50,11 @@ Copyright (c) .NET Foundation. All rights reserved.
          So we need to disable the logic which checks that the version of Microsoft.NETCore.App from the assets file
          matches the one that would be resolved based on the TargetFramework that was passed in. -->
     <VerifyMatchingImplicitPackageVersion>false</VerifyMatchingImplicitPackageVersion>
+
+    <!-- In 3.0 and above. To match the same behavior as above and allow deps.json include assets from package we need to
+         disable ImplicitFrameworkReferences. So assets from the packages will be in deps.json instead of being removed by
+         conflict resolution.-->
+    <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
   </PropertyGroup>
 
   <Target Name="BuildDepsJson" DependsOnTargets="$(ResolvePackageDependenciesForBuildDependsOn);GenerateBuildDependencyFile" />

--- a/src/Tests/Microsoft.NET.Restore.Tests/GivenThatWeWantToRestoreAndGenerateDepsjsonDotNetCliToolReference.cs
+++ b/src/Tests/Microsoft.NET.Restore.Tests/GivenThatWeWantToRestoreAndGenerateDepsjsonDotNetCliToolReference.cs
@@ -30,6 +30,8 @@ namespace Microsoft.NET.Restore.Tests
                 TargetFrameworks = "netcoreapp1.0",
             };
 
+            // The following is needed since part of the graph of Microsoft.VisualStudio.Web.CodeGeneration.Tools
+            // it not on netcoreapp. This line is in aspnet 1.0 template as well.
             toolProject.AdditionalProperties.Add("PackageTargetFallback", "$(PackageTargetFallback);portable-net45+win8+wp8+wpa81;");
             toolProject.AdditionalProperties.Add("RestorePackagesPath", "packages");
             toolProject.PackageReferences.Add(

--- a/src/Tests/Microsoft.NET.Restore.Tests/GivenThatWeWantToRestoreAndGenerateDepsjsonDotNetCliToolReference.cs
+++ b/src/Tests/Microsoft.NET.Restore.Tests/GivenThatWeWantToRestoreAndGenerateDepsjsonDotNetCliToolReference.cs
@@ -1,0 +1,70 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.IO;
+using System.Xml.Linq;
+using FluentAssertions;
+using Microsoft.NET.TestFramework;
+using Microsoft.NET.TestFramework.Assertions;
+using Microsoft.NET.TestFramework.Commands;
+using Microsoft.NET.TestFramework.ProjectConstruction;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.NET.Restore.Tests
+{
+    public class GivenThatWeWantToRestoreAndGenerateDepsjsonDotNetCliToolReference : SdkTest
+    {
+        public GivenThatWeWantToRestoreAndGenerateDepsjsonDotNetCliToolReference(ITestOutputHelper log) : base(log)
+        {
+        }
+
+        [Fact]
+        public void It_can_generate_correct_deps_json()
+        {
+            TestProject toolProject = new TestProject()
+            {
+                Name = "DotNetCliToolReferenceProject",
+                IsSdkProject = true,
+                IsExe = true,
+                TargetFrameworks = "netcoreapp1.0",
+            };
+
+            toolProject.AdditionalProperties.Add("PackageTargetFallback", "$(PackageTargetFallback);portable-net45+win8+wp8+wpa81;");
+            toolProject.AdditionalProperties.Add("RestorePackagesPath", "packages");
+            toolProject.PackageReferences.Add(
+                new TestPackageReference(
+                    id: "Microsoft.VisualStudio.Web.CodeGeneration.Design",
+                    version: "1.0.3",
+                    nupkgPath: null));
+            toolProject.DotNetCliToolReferences.Add(
+                new TestPackageReference(id: "Microsoft.VisualStudio.Web.CodeGeneration.Tools",
+                                         version: "1.0.3",
+                                         nupkgPath: null));
+
+            TestAsset toolProjectInstance = _testAssetsManager.CreateTestProject(toolProject, identifier: toolProject.Name);
+
+            NuGetConfigWriter.Write(toolProjectInstance.TestRoot, NuGetConfigWriter.DotnetCoreBlobFeed);
+
+            RestoreWithRetryDueToDownloadFromWeb(toolProject, toolProjectInstance);
+
+            var runProjectToolCommand = new DotnetCommand(Log, "aspnet-codegenerator")
+            {
+                WorkingDirectory = Path.Combine(toolProjectInstance.TestRoot, toolProject.Name)
+            };
+
+            runProjectToolCommand.Execute().Should().Pass();
+        }
+
+        private void RestoreWithRetryDueToDownloadFromWeb(TestProject toolProject, TestAsset toolProjectInstance)
+        {
+            var restoreResult = toolProjectInstance.GetRestoreCommand(log: Log, relativePath: toolProject.Name)
+                .Execute("/v:n");
+
+            if (restoreResult.ExitCode != 0)
+            {
+                toolProjectInstance.Restore(Log, toolProject.Name, "/v:n");
+            }
+        }
+    }
+}


### PR DESCRIPTION
By Disabling targeting pack reference in generate deps.json

In short, since generating deps.json in 2.x.xxx SDK does not have Microsoft.NETCore.App reference. We need to do the same for 2.x.xxx.

Detail:

Project Tools deps.json generator is not ideal. When restore, since we don’t know what is the tool’s TFM before restoring it, we will always restore with SDK’s TFM, which is netcoreapp3.0.

In 2.x.xxx time due to special restore logic, there is no reference to Microsoft.NETCore.App in asset.json file. So when generate deps.son, assets from the packages will be in deps.json instead of being removed by conflict resolution. This is important since when invoke the command, 1.0 runtime will be used (due to the tool is targeting 1.0), and 1.0 runtime will not have all the dlls restored in netcoreapp2.0 TFM available to load these dll need dep.json.

And now in 3.0, ImplicitFrameworkReferences need to be disabled to match existing “no reference to Microsoft.NETCore.App” behavior.