### PR TITLE
Add CI legs to run tests as tools

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -55,6 +55,22 @@ phases:
             _BuildConfig: Release
             _PublishType: none
             _SignType: test
+  - template: /eng/build.yml
+    parameters:
+      agentOs: Windows_NT_TestAsTools
+      queue:
+        name: dotnet-external-temp
+        parallel: 2
+        timeoutInMinutes: 120
+        matrix:
+          Build_Debug:
+            _BuildConfig: Debug
+            _PublishType: none
+            _SignType: test
+          Build_Release:
+            _BuildConfig: Release
+            _PublishType: none
+            _SignType: test
 
   - template: /eng/build.yml
     parameters:

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -67,10 +67,6 @@ phases:
             _BuildConfig: Debug
             _PublishType: none
             _SignType: test
-          Build_Release:
-            _BuildConfig: Release
-            _PublishType: none
-            _SignType: test
 
   - template: /eng/build.yml
     parameters:

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -22,4 +22,8 @@
     <TestRunnerAdditionalArguments>-parallel none</TestRunnerAdditionalArguments>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <SdkLayoutDirectory>$(ArtifactsBinDir)$(Configuration)\dotnetLayout</SdkLayoutDirectory>
+  </PropertyGroup>
+
 </Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -15,4 +15,11 @@
   </ItemGroup>
 
   <Import Project="Sdk.targets" Sdk="Microsoft.DotNet.Arcade.Sdk" />
+
+  <!-- Optionally override arcade's test target with one which will run the tests as tools.
+       Conditionally overriding a target requires a conditional import of another (.targets)
+       file. -->
+  <Import Project="OverrideTest.targets"
+          Condition="'$(RunTestsAsTool)' == 'true' And '$(CanRunTestAsTool)' == 'true'"/>
+
 </Project>

--- a/OverrideTest.targets
+++ b/OverrideTest.targets
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the MIT license. See License.txt in the project root for full license information. -->
+<Project>
+  <Target Name="Test" DependsOnTargets="TestAsTool"
+          Condition="'$(IsUnitTestProject)' == 'true' or '$(IsPerformanceTestProject)' == 'true'"/>
+
+</Project>

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -72,7 +72,20 @@ phases:
           PublishType: $(_PublishType)
           TestFullMSBuild: 'true'
 
-    - ${{ if notIn(parameters.agentOs, 'Windows_NT', 'Windows_NT_FullFramework') }}:
+    - ${{ if eq(parameters.agentOs, 'Windows_NT_TestAsTools') }}:
+      - script: eng\common\CIBuild.cmd 
+                  -configuration $(_BuildConfig)
+                  $(_PublishArgs)
+                  $(_SignArgs)
+                  $(_OfficialBuildIdArgs)
+                  /p:RunTestsAsTool=true
+        displayName: Build
+        env:
+          BuildConfig: $(_BuildConfig)
+          BlobFeedUrl: $(PB_PublishBlobFeedUrl)
+          PublishType: $(_PublishType)
+
+    - ${{ if notIn(parameters.agentOs, 'Windows_NT', 'Windows_NT_FullFramework', 'Windows_NT_TestAsTools') }}:
       - script: eng/common/cibuild.sh 
                   --configuration $(_BuildConfig)
                   $(_PublishArgs)

--- a/src/LayoutSdk/LayoutSdk.proj
+++ b/src/LayoutSdk/LayoutSdk.proj
@@ -1,16 +1,9 @@
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the MIT license. See License.txt in the project root for full license information. -->
 <Project Sdk="Microsoft.NET.Sdk">
   <Target Name="LayoutSdk">
-    <ItemGroup>
-      <Stage0SdkPaths Include="$([System.IO.Directory]::GetDirectories(&quot;$(_DotNetRoot)sdk\&quot;))"/>
-    </ItemGroup>
-    <PropertyGroup>
-      <!-- Reverse list, and put in property -->
-      <Stage0SdkPaths>@(Stage0SdkPaths->Reverse())</Stage0SdkPaths>
-      <!-- Get first path in reversed list, which should hopefully be the latest version -->
-      <Stage0SdkPath>$(Stage0SdkPaths.Split($([System.Convert]::ToString(";").ToCharArray())).GetValue($([System.Convert]::ToInt32(0))))</Stage0SdkPath>
-      <Stage0SdkVersion>$([System.IO.Path]::GetFileName('$(Stage0SdkPath)'))</Stage0SdkVersion>
-    </PropertyGroup>
+    <Exec Command="$(_DotNetRoot)/dotnet --version" ConsoleToMsBuild="true">
+      <Output TaskParameter="ConsoleOutput" PropertyName="Stage0SdkVersion"/>
+    </Exec>
 
     <ItemGroup>
       <Stage0FilestToCopy Include="$(_DotNetRoot)/**/*.*"

--- a/src/LayoutSdk/LayoutSdk.proj
+++ b/src/LayoutSdk/LayoutSdk.proj
@@ -1,0 +1,29 @@
+<!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the MIT license. See License.txt in the project root for full license information. -->
+<Project Sdk="Microsoft.NET.Sdk">
+  <Target Name="LayoutSdk">
+    <ItemGroup>
+      <Stage0SdkPaths Include="$([System.IO.Directory]::GetDirectories(&quot;$(_DotNetRoot)sdk\&quot;))"/>
+    </ItemGroup>
+    <PropertyGroup>
+      <!-- Reverse list, and put in property -->
+      <Stage0SdkPaths>@(Stage0SdkPaths->Reverse())</Stage0SdkPaths>
+      <!-- Get first path in reversed list, which should hopefully be the latest version -->
+      <Stage0SdkPath>$(Stage0SdkPaths.Split($([System.Convert]::ToString(";").ToCharArray())).GetValue($([System.Convert]::ToInt32(0))))</Stage0SdkPath>
+      <Stage0SdkVersion>$([System.IO.Path]::GetFileName('$(Stage0SdkPath)'))</Stage0SdkVersion>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <Stage0FilestToCopy Include="$(_DotNetRoot)/**/*.*"
+                          Exclude="$(_DotNetRoot)/sdk/$(Stage0SdkVersion)/Sdks/Microsoft.NET.Sdk/**/*.*)"/>
+      <LayoutFilesToCopy Include="$(ArtifactsBinDir)$(Configuration)\Sdks\Microsoft.NET.Sdk/**/*.*" />
+    </ItemGroup>
+
+    <RemoveDir Directories="SdkLayoutDirectory" />
+
+    <Copy SourceFiles="@(Stage0FilestToCopy)"
+          DestinationFiles="@(Stage0FilestToCopy->'$(SdkLayoutDirectory)\%(RecursiveDir)%(Filename)%(Extension)')" />
+
+    <Copy SourceFiles="@(LayoutFilesToCopy)"
+          DestinationFiles="@(LayoutFilesToCopy->'$(SdkLayoutDirectory)\sdk\$(Stage0SdkVersion)\Sdks\Microsoft.NET.Sdk\%(RecursiveDir)%(Filename)%(Extension)')" />
+  </Target>
+</Project>

--- a/src/Tests/Directory.Build.targets
+++ b/src/Tests/Directory.Build.targets
@@ -27,7 +27,12 @@
     
   </ItemGroup>
 
-  <Target Name="TestAsTool" DependsOnTargets="Pack;_InnerGetTestsToRun">
+  <Target Name="LayoutSdk">
+    <MSBuild Projects="$(RepoRoot)\src\LayoutSdk\LayoutSdk.proj"
+             Targets="LayoutSdk"/>
+  </Target>
+
+  <Target Name="TestAsTool" DependsOnTargets="Pack;LayoutSdk;_InnerGetTestsToRun">
     <PropertyGroup>
       <TestLocalToolFolder>$(ArtifactsTmpDir)$(ToolCommandName)\</TestLocalToolFolder>
     </PropertyGroup>
@@ -49,6 +54,7 @@
       <!--<ResultsStdOutPath>$(ArtifactsLogDir)$(_ResultFileNameNoExt).log</ResultsStdOutPath>-->
 
       <TestArgs>-noautoreporters -noRepoInference</TestArgs>
+      <TestArgs>$(TestArgs) -dotnetPath $(SdkLayoutDirectory)\dotnet</TestArgs>
       <TestArgs>$(TestArgs) -xml "$(ResultsXmlPath)"</TestArgs>
       <TestArgs>$(TestArgs) -html "$(ResultsHtmlPath)" $(TestRunnerAdditionalArguments)</TestArgs>
     </PropertyGroup>

--- a/src/Tests/Directory.Build.targets
+++ b/src/Tests/Directory.Build.targets
@@ -42,6 +42,10 @@
 
     <MakeDir Directories="$(ArtifactsTestResultsDir)" />
 
+    <!-- Remove tool package from NuGet cache, so that local changes will be reflected if the package version
+         hasn't changed. -->
+    <RemoveDir Directories="$(NuGetPackageRoot)$(ToolCommandName)\$(PackageVersion)" />
+
     <Exec Command="dotnet new tool-manifest"
       WorkingDirectory="$(TestLocalToolFolder)"/>
     

--- a/src/Tests/Directory.Build.targets
+++ b/src/Tests/Directory.Build.targets
@@ -9,6 +9,7 @@
     <IsPackable>true</IsPackable>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>$(PackageId)</ToolCommandName>
+    <CanRunTestAsTool>true</CanRunTestAsTool>
 
     <!-- Put packages for tests in subfolder so we don't try to sign them -->
     <PackageOutputPath>$(PackageOutputPath)tests\</PackageOutputPath>
@@ -26,7 +27,7 @@
     
   </ItemGroup>
 
-  <Target Name="TestAsTool" DependsOnTargets="_InnerGetTestsToRun">
+  <Target Name="TestAsTool" DependsOnTargets="Pack;_InnerGetTestsToRun">
     <PropertyGroup>
       <TestLocalToolFolder>$(ArtifactsTmpDir)$(ToolCommandName)\</TestLocalToolFolder>
     </PropertyGroup>

--- a/src/Tests/Directory.Build.targets
+++ b/src/Tests/Directory.Build.targets
@@ -64,7 +64,8 @@
     </PropertyGroup>
 
     <Exec Command="dotnet tool run $(ToolCommandName) $(TestArgs)"
-          WorkingDirectory="$(TestLocalToolFolder)" />
+          WorkingDirectory="$(TestLocalToolFolder)"
+          IgnoreStandardErrorWarningFormat="true" />
   </Target>
 
   <Import Project="..\..\Directory.Build.targets" />

--- a/src/Tests/Directory.Build.targets
+++ b/src/Tests/Directory.Build.targets
@@ -26,6 +26,36 @@
     
   </ItemGroup>
 
+  <Target Name="TestAsTool" DependsOnTargets="_InnerGetTestsToRun">
+    <PropertyGroup>
+      <TestLocalToolFolder>$(ArtifactsTmpDir)$(ToolCommandName)\</TestLocalToolFolder>
+    </PropertyGroup>
+
+    <RemoveDir Directories="$(TestLocalToolFolder)" />
+    <MakeDir Directories="$(TestLocalToolFolder)" />
+
+    <MakeDir Directories="$(ArtifactsTestResultsDir)" />
+
+    <Exec Command="dotnet new tool-manifest"
+      WorkingDirectory="$(TestLocalToolFolder)"/>
+    
+    <Exec Command="dotnet tool install --local $(ToolCommandName) --version $(PackageVersion) --add-source $(ArtifactsShippingPackagesDir)"
+      WorkingDirectory="$(TestLocalToolFolder)"/>
+
+    <PropertyGroup>
+      <ResultsXmlPath>$(ArtifactsTestResultsDir)$(_ResultFileNameNoExt).xml</ResultsXmlPath>
+      <ResultsHtmlPath>$(ArtifactsTestResultsDir)$(_ResultFileNameNoExt).html</ResultsHtmlPath>
+      <!--<ResultsStdOutPath>$(ArtifactsLogDir)$(_ResultFileNameNoExt).log</ResultsStdOutPath>-->
+
+      <TestArgs>-noautoreporters -noRepoInference</TestArgs>
+      <TestArgs>$(TestArgs) -xml "$(ResultsXmlPath)"</TestArgs>
+      <TestArgs>$(TestArgs) -html "$(ResultsHtmlPath)" $(TestRunnerAdditionalArguments)</TestArgs>
+    </PropertyGroup>
+
+    <Exec Command="dotnet tool run $(ToolCommandName) $(TestArgs)"
+          WorkingDirectory="$(TestLocalToolFolder)" />
+  </Target>
+
   <Import Project="..\..\Directory.Build.targets" />
 
 </Project>

--- a/src/Tests/Directory.Build.targets
+++ b/src/Tests/Directory.Build.targets
@@ -53,14 +53,15 @@
       WorkingDirectory="$(TestLocalToolFolder)"/>
 
     <PropertyGroup>
-      <ResultsXmlPath>$(ArtifactsTestResultsDir)$(_ResultFileNameNoExt).xml</ResultsXmlPath>
-      <ResultsHtmlPath>$(ArtifactsTestResultsDir)$(_ResultFileNameNoExt).html</ResultsHtmlPath>
-      <!--<ResultsStdOutPath>$(ArtifactsLogDir)$(_ResultFileNameNoExt).log</ResultsStdOutPath>-->
+      <ResultsXmlPath>@(TestToRun->'%(ResultsXmlPath)')</ResultsXmlPath>
+      <ResultsHtmlPath>@(TestToRun->'%(ResultsHtmlPath)')</ResultsHtmlPath>
+      <ResultsStdOutPath>@(TestToRun->'%(ResultsStdOutPath)')</ResultsStdOutPath>
 
       <TestArgs>-noautoreporters -noRepoInference</TestArgs>
       <TestArgs>$(TestArgs) -dotnetPath $(SdkLayoutDirectory)\dotnet</TestArgs>
       <TestArgs>$(TestArgs) -xml "$(ResultsXmlPath)"</TestArgs>
       <TestArgs>$(TestArgs) -html "$(ResultsHtmlPath)" $(TestRunnerAdditionalArguments)</TestArgs>
+      <TestArgs>$(TestArgs) &gt; $(ResultsStdOutPath)</TestArgs>
     </PropertyGroup>
 
     <Exec Command="dotnet tool run $(ToolCommandName) $(TestArgs)"

--- a/src/Tests/Microsoft.NET.Build.Tests/Microsoft.NET.Build.Tests.csproj
+++ b/src/Tests/Microsoft.NET.Build.Tests/Microsoft.NET.Build.Tests.csproj
@@ -23,7 +23,6 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
     <PackageReference Include="Microsoft.DotNet.Cli.Utils" Version="$(MicrosoftDotNetCliUtilsVersion)" />
-    <PackageReference Include="NuGet.Packaging" Version="$(NuGetProjectModelVersion)" />
     <PackageReference Include="NuGet.ProjectModel" Version="$(NuGetProjectModelVersion)" />
     <PackageReference Include="NuGet.LibraryModel" Version="$(NuGetProjectModelVersion)" />
     <PackageReference Include="NuGet.Versioning" Version="$(NuGetProjectModelVersion)" />

--- a/src/Tests/Microsoft.NET.Publish.Tests/RuntimeIdentifiersTests.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/RuntimeIdentifiersTests.cs
@@ -43,7 +43,7 @@ namespace Microsoft.NET.Publish.Tests
             testProject.AdditionalProperties["RuntimeIdentifiers"] = string.Join(';', runtimeIdentifiers);
 
             //  Use a test-specific packages folder
-            testProject.AdditionalProperties["RestorePackagesPath"] = @"$(MSBuildProjectDirectory)\packages";
+            testProject.AdditionalProperties["RestorePackagesPath"] = @"$(MSBuildProjectDirectory)\..\pkg";
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
@@ -107,7 +107,7 @@ namespace Microsoft.NET.Publish.Tests
             testProject.AdditionalProperties["RuntimeIdentifiers"] = string.Join(';', runtimeIdentifiers);
 
             //  Use a test-specific packages folder
-            testProject.AdditionalProperties["RestorePackagesPath"] = @"$(MSBuildProjectDirectory)\packages";
+            testProject.AdditionalProperties["RestorePackagesPath"] = @"$(MSBuildProjectDirectory)\..\pkg";
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject, identifier: publishNoBuild ? "nobuild" : string.Empty);
 

--- a/src/Tests/Microsoft.NET.TestFramework/Commands/NuGetRestoreCommand.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/Commands/NuGetRestoreCommand.cs
@@ -70,6 +70,12 @@ namespace Microsoft.NET.TestFramework.Commands
             {
                 throw new InvalidOperationException("Path to nuget.exe not set");
             }
+            else if (!File.Exists(TestContext.Current.NuGetExePath))
+            {
+                //  https://dist.nuget.org/win-x86-commandline/latest/nuget.exe
+                var client = new System.Net.WebClient();
+                client.DownloadFile("https://dist.nuget.org/win-x86-commandline/latest/nuget.exe", TestContext.Current.NuGetExePath);
+            }
 
             var ret = new SdkCommandSpec()
             {

--- a/src/Tests/Microsoft.NET.TestFramework/ProjectConstruction/TestProject.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/ProjectConstruction/TestProject.cs
@@ -168,6 +168,8 @@ namespace Microsoft.NET.TestFramework.ProjectConstruction
                 packageReferenceItemGroup.Add(new XElement(ns + "PackageReference",
                     new XAttribute("Include", $"Microsoft.NETFramework.ReferenceAssemblies"),
                     new XAttribute("Version", $"1.0.0-alpha-5")));
+
+                propertyGroup.Add(new XElement(ns + "RestoreAdditionalProjectSources", "$(RestoreAdditionalProjectSources);https://dotnet.myget.org/F/roslyn-tools/api/v3/index.json"));
             }
 
             var targetFrameworks = IsSdkProject ? TargetFrameworks.Split(';') : new[] { "net" };

--- a/src/Tests/Microsoft.NET.TestFramework/TestContext.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/TestContext.cs
@@ -163,7 +163,7 @@ namespace Microsoft.NET.TestFramework
 
             while (!Directory.Exists(Path.Combine(directory, ".git")) && directory != null)
             {
-                directory = Directory.GetParent(directory).FullName;
+                directory = Directory.GetParent(directory)?.FullName;
             }
 
             if (directory == null)

--- a/src/Tests/Microsoft.NET.TestFramework/TestContext.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/TestContext.cs
@@ -70,6 +70,10 @@ namespace Microsoft.NET.TestFramework
         {
             Environment.SetEnvironmentVariable("DOTNET_MULTILEVEL_LOOKUP", "0");
 
+            //  Reset this environment variable so that if the dotnet under test is different than the
+            //  one running the tests, it won't interfere
+            Environment.SetEnvironmentVariable("MSBuildSdksPath", null);
+
             TestContext testContext = new TestContext();
             
             bool runAsTool = false;

--- a/src/Tests/Microsoft.NET.TestFramework/ToolsetInfo.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/ToolsetInfo.cs
@@ -65,8 +65,6 @@ namespace Microsoft.NET.TestFramework
         }
         public void AddTestEnvironmentVariables(SdkCommandSpec command)
         {
-            string dotnetRoot = Path.GetDirectoryName(DotNetHostPath);
-
             if (SdksPath != null)
             {
                 command.Environment["MSBuildSDKsPath"] = SdksPath;
@@ -83,14 +81,16 @@ namespace Microsoft.NET.TestFramework
                         "msbuildExtensions-ver", "Microsoft.Common.targets", "ImportAfter", "Microsoft.NET.Build.Extensions.targets");
                 }
 
-                if (Environment.Is64BitProcess)
-                {
-                    command.Environment.Add("DOTNET_ROOT", dotnetRoot);
-                }
-                else
-                {
-                    command.Environment.Add("DOTNET_ROOT(x86)", dotnetRoot);
-                }
+            }
+
+            string dotnetRoot = Path.GetDirectoryName(DotNetHostPath);
+            if (Environment.Is64BitProcess)
+            {
+                command.Environment.Add("DOTNET_ROOT", dotnetRoot);
+            }
+            else
+            {
+                command.Environment.Add("DOTNET_ROOT(x86)", dotnetRoot);
             }
 
             DirectoryInfo latestSdk = GetLatestSdk(dotnetRoot);


### PR DESCRIPTION
Eventually I'd like to use the tests from this repo in other repos such as dotnet/core-sdk.  This PR adds CI legs which runs the tests as tools, in order to make sure they run correctly as tools.