### PR TITLE
Add hook to redirect common props, only ref m.nc.platforms when necessary

### DIFF
--- a/eng/dogfood.ps1
+++ b/eng/dogfood.ps1
@@ -2,7 +2,6 @@
 Param(
   [string] $configuration = "Debug",
   [string] $projects = "",
-  [string] $msbuildEngine = 'vs',
   [switch] $help,
   [Parameter(ValueFromRemainingArguments=$true)][String[]]$command
 )

--- a/src/Tasks/Microsoft.NET.Build.Tasks/sdk/Sdk.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/sdk/Sdk.props
@@ -28,6 +28,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <MSBuildProjectExtensionsPath>$(ProjectExtensionsPathForSpecifiedProject)</MSBuildProjectExtensionsPath>
   </PropertyGroup>
 
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" />
+  <Import Project="$(AlternateCommonProps)" Condition="'$(AlternateCommonProps)' != ''" />
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="'$(AlternateCommonProps)' == ''"/>
   <Import Project="$(MSBuildThisFileDirectory)..\targets\Microsoft.NET.Sdk.props"  />  
 </Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.props
@@ -78,15 +78,6 @@ Copyright (c) .NET Foundation. All rights reserved.
     <FrameworkReference Include="Microsoft.NETCore.App" IsImplicitlyDefined="true"
                     Condition="('$(_TargetFrameworkVersionWithoutV)' != '') And ('$(_TargetFrameworkVersionWithoutV)' >= '3.0')"/>
 
-    <!-- Reference the Platforms package in order to supply the RID graph to NuGet.
-         This can be removed once we do https://github.com/dotnet/cli/issues/10528 or
-         https://github.com/NuGet/Home/issues/7351 -->
-    <PackageReference Include="Microsoft.NETCore.Platforms" 
-                      Version="$(BundledNETCorePlatformsPackageVersion)"
-                      IsImplicitlyDefined="true"
-                      Condition="('$(_TargetFrameworkVersionWithoutV)' != '') And ('$(_TargetFrameworkVersionWithoutV)' >= '3.0')"
-                      PrivateAssets="All"
-                      Publish="true" />
   </ItemGroup>
 
 </Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.targets
@@ -192,6 +192,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                         Version="$(BundledNETCorePlatformsPackageVersion)"
                         IsImplicitlyDefined="true"
                         Condition="'$(DisableImplicitFrameworkReferences)' != 'true'
+                                    and '$(DisableImplicitNETCorePlatformsReference)' != 'true'
                                     and '$(TargetFrameworkIdentifier)' == '.NETCoreApp'
                                     and '$(_TargetFrameworkVersionWithoutV)' != ''
                                     and '$(_TargetFrameworkVersionWithoutV)' >= '3.0'"

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.targets
@@ -155,9 +155,12 @@ Copyright (c) .NET Foundation. All rights reserved.
                    ResourceName="AspNetCoreUsesFrameworkReference" />
     
   </Target>
-  
-  <Target Name="ApplyImplicitVersions" BeforeTargets="_CheckForInvalidConfigurationAndPlatform;CollectPackageReferences"
-          DependsOnTargets="UpdateAspNetToFrameworkReference;CheckForImplicitPackageReferenceOverrides">
+
+  <Target Name="ApplyImplicitVersions" 
+          BeforeTargets="_CheckForInvalidConfigurationAndPlatform;CollectPackageReferences;ResolveFrameworkReferences"
+          DependsOnTargets="UpdateAspNetToFrameworkReference;CheckForImplicitPackageReferenceOverrides"
+          Condition="'@(PackageReference)' != ''">
+    
     <ApplyImplicitVersions TargetFrameworkVersion="$(_TargetFrameworkVersionWithoutV)"
                            TargetLatestRuntimePatch="$(TargetLatestRuntimePatch)"
                            PackageReferences="@(PackageReference)"
@@ -178,6 +181,22 @@ Copyright (c) .NET Foundation. All rights reserved.
       <PackageReference Condition="'%(PackageReference.Identity)' == 'Microsoft.NETCore.App'">
         <Version Condition="'%(PackageReference.Version)' == ''">$(_TargetFrameworkVersionWithoutV)</Version>
       </PackageReference>
+
+      <!-- Reference the Platforms package in order to supply the RID graph to NuGet.
+           This can be removed once we do https://github.com/dotnet/cli/issues/10528 or
+           https://github.com/NuGet/Home/issues/7351 
+            
+           We only do this here when there are PackageReferences. If the only references 
+           are FrameworkReferences, then we do not need to provide this package to NuGet. -->
+      <PackageReference Include="Microsoft.NETCore.Platforms"
+                        Version="$(BundledNETCorePlatformsPackageVersion)"
+                        IsImplicitlyDefined="true"
+                        Condition="'$(DisableImplicitFrameworkReferences)' != 'true'
+                                    and '$(TargetFrameworkIdentifier)' == '.NETCoreApp'
+                                    and '$(_TargetFrameworkVersionWithoutV)' != ''
+                                    and '$(_TargetFrameworkVersionWithoutV)' >= '3.0'"
+                        PrivateAssets="All"
+                        Publish="true" />
     </ItemGroup>
   </Target>
   

--- a/src/Tests/Microsoft.NET.Build.Tests/Microsoft.NET.Build.Tests.csproj
+++ b/src/Tests/Microsoft.NET.Build.Tests/Microsoft.NET.Build.Tests.csproj
@@ -28,7 +28,6 @@
     <PackageReference Include="NuGet.LibraryModel" Version="$(NuGetProjectModelVersion)" />
     <PackageReference Include="NuGet.Versioning" Version="$(NuGetProjectModelVersion)" />
     <PackageReference Include="NuGet.Configuration" Version="$(NuGetProjectModelVersion)" />
-    <PackageReference Include="NuGet.Packaging" Version="$(NuGetProjectModelVersion)" />
     <PackageReference Include="NuGet.Frameworks" Version="$(NuGetProjectModelVersion)" />
     <PackageReference Include="NuGet.Common" Version="$(NuGetProjectModelVersion)" />
 

--- a/src/Tests/Microsoft.NET.Publish.Tests/RuntimeIdentifiersTests.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/RuntimeIdentifiersTests.cs
@@ -25,7 +25,7 @@ namespace Microsoft.NET.Publish.Tests
         {
             var testProject = new TestProject()
             {
-                Name = "BuildWithRuntimeIdentifier",
+                Name = "BuildWithRid",
                 TargetFrameworks = "netcoreapp3.0",
                 IsSdkProject = true,
                 IsExe = true
@@ -43,7 +43,7 @@ namespace Microsoft.NET.Publish.Tests
             testProject.AdditionalProperties["RuntimeIdentifiers"] = string.Join(';', runtimeIdentifiers);
 
             //  Use a test-specific packages folder
-            testProject.AdditionalProperties["RestorePackagesPath"] = @"$(MSBuildProjectDirectory)\packages";
+            testProject.AdditionalProperties["RestorePackagesPath"] = @"$(MSBuildProjectDirectory)\pkg";
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
@@ -89,7 +89,7 @@ namespace Microsoft.NET.Publish.Tests
         {
             var testProject = new TestProject()
             {
-                Name = "PublishWithRuntimeIdentifier",
+                Name = "PublishWithRid",
                 TargetFrameworks = "netcoreapp3.0",
                 IsSdkProject = true,
                 IsExe = true
@@ -107,7 +107,7 @@ namespace Microsoft.NET.Publish.Tests
             testProject.AdditionalProperties["RuntimeIdentifiers"] = string.Join(';', runtimeIdentifiers);
 
             //  Use a test-specific packages folder
-            testProject.AdditionalProperties["RestorePackagesPath"] = @"$(MSBuildProjectDirectory)\packages";
+            testProject.AdditionalProperties["RestorePackagesPath"] = @"$(MSBuildProjectDirectory)\pkg";
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject, identifier: publishNoBuild ? "nobuild" : string.Empty);
 


### PR DESCRIPTION
1. Introduce $(AlternateCommonProps) to redirect the Sdk common props import to a user-defined location. This is morally equivalent to $(LanguageTargets) being customizable on the targets side. Having full control over both of these imports makes it much easier to integrate the SDK into existing heavily-customized builds. The current use case is to get some internal builds over to netcoreapp3.0

2. Getting an intermittent error about 'vs' not being found from dogfood script. Removing unnecessary setting of msbuildEngine seems to have fixed it.

3. With https://github.com/dotnet/core-sdk/pull/698, microsoft.netcore.platforms becomes the only package that cannot be resolved from packs. Make it so that we only pull it in when there are other package references. Otherwise, nuget doesn't need to see it as a package reference. This is just moving the temporary solution around, but means that we can get a working offline experience before we figure out how to adress the runtime graph going into to nuget (or sdk taking over for nuget).