### PR TITLE
Remove opt-out of COM Reference Manager Tab

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -600,13 +600,11 @@ Copyright (c) .NET Foundation. All rights reserved.
   ============================================================
   -->
 
-  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' and '$(_IsExecutable)' == 'true'">
-    <ProjectCapability Include="CrossPlatformExecutable" />
-  </ItemGroup>
-
-  <!-- Reference Manager capabilities -->
+  <!-- NETCoreApp capabilities -->
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
     <ProjectCapability Remove="ReferenceManagerAssemblies" />
+    <ProjectCapability Remove="ReferenceManagerCOM" Condition="$(_TargetFrameworkVersionWithoutV) &lt; '3.0'" />
+    <ProjectCapability Include="CrossPlatformExecutable" Condition="'$(_IsExecutable)' == 'true'" />
   </ItemGroup>
 
   <!-- Publish capabilities -->

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -607,6 +607,11 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ProjectCapability Include="CrossPlatformExecutable" Condition="'$(_IsExecutable)' == 'true'" />
   </ItemGroup>
 
+  <!-- NETStandard capabilities -->
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard'">
+    <ProjectCapability Remove="ReferenceManagerCOM" />
+  </ItemGroup>
+
   <!-- Publish capabilities -->
   <ItemGroup>
     <ProjectCapability Include="FolderPublish" />

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -607,7 +607,6 @@ Copyright (c) .NET Foundation. All rights reserved.
   <!-- Reference Manager capabilities -->
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
     <ProjectCapability Remove="ReferenceManagerAssemblies" />
-    <ProjectCapability Remove="ReferenceManagerCOM" />
   </ItemGroup>
 
   <!-- Publish capabilities -->

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -600,16 +600,13 @@ Copyright (c) .NET Foundation. All rights reserved.
   ============================================================
   -->
 
-  <!-- NETCoreApp capabilities -->
-  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
-    <ProjectCapability Remove="ReferenceManagerAssemblies" />
-    <ProjectCapability Remove="ReferenceManagerCOM" Condition="$(_TargetFrameworkVersionWithoutV) &lt; '3.0'" />
-    <ProjectCapability Include="CrossPlatformExecutable" Condition="'$(_IsExecutable)' == 'true'" />
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' and '$(_IsExecutable)' == 'true'">
+    <ProjectCapability Include="CrossPlatformExecutable" />
   </ItemGroup>
 
-  <!-- NETStandard capabilities -->
-  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard'">
-    <ProjectCapability Remove="ReferenceManagerCOM" />
+  <!-- Reference Manager capabilities -->
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
+    <ProjectCapability Remove="ReferenceManagerAssemblies" />
   </ItemGroup>
 
   <!-- Publish capabilities -->


### PR DESCRIPTION
This is a fix for: https://github.com/dotnet/project-system/issues/4355
I tested this locally and ensured that projects built with COM references but I am not sure if anything is blocking this on the SDK side. 