### PR TITLE
Fix publishing self-contained ASP.NET apps

### DIFF
--- a/eng/restore-toolset.ps1
+++ b/eng/restore-toolset.ps1
@@ -18,7 +18,7 @@ function InitializeCustomSDKToolset {
   InstallDotNetSharedFramework "1.0.5"
   InstallDotNetSharedFramework "1.1.2"
   InstallDotNetSharedFramework "2.1.0"
-  InstallDotNetSharedFramework "2.2.2"
+  InstallDotNetSharedFramework "2.2.3"
 
   CreateBuildEnvScript
   InstallNuget

--- a/eng/restore-toolset.sh
+++ b/eng/restore-toolset.sh
@@ -13,7 +13,7 @@ function InitializeCustomSDKToolset {
   InstallDotNetSharedFramework "1.0.5"
   InstallDotNetSharedFramework "1.1.2"
   InstallDotNetSharedFramework "2.1.0"
-  InstallDotNetSharedFramework "2.2.2"
+  InstallDotNetSharedFramework "2.2.3"
 }
 
 # Installs additional shared frameworks for testing purposes

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "3.0.100-preview3-010404",
+    "dotnet": "3.0.100-preview4-010556",
     "vs-opt": {
       "version": "15.9"
     }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "3.0.100-preview4-010556",
+    "dotnet": "3.0.100-preview4-010564",
     "vs-opt": {
       "version": "15.9"
     }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolveAppHosts.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveAppHosts.cs
@@ -202,11 +202,12 @@ namespace Microsoft.NET.Build.Tasks
 
                     packagesToDownload.Add(packageToDownload);
 
-                    appHostItem.SetMetadata(MetadataKeys.RuntimeIdentifier, runtimeIdentifier);
                     appHostItem.SetMetadata(MetadataKeys.PackageName, hostPackName);
                     appHostItem.SetMetadata(MetadataKeys.PackageVersion, appHostPackVersion);
-                    appHostItem.SetMetadata(MetadataKeys.RelativePath, hostRelativePathInPackage);
                 }
+
+                appHostItem.SetMetadata(MetadataKeys.RelativePath, hostRelativePathInPackage);
+                appHostItem.SetMetadata(MetadataKeys.RuntimeIdentifier, runtimeIdentifier);
 
                 return appHostItem;
             }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolveRuntimePackAssets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveRuntimePackAssets.cs
@@ -71,6 +71,7 @@ namespace Microsoft.NET.Build.Tasks
                         assetPath.EndsWith(".map", StringComparison.OrdinalIgnoreCase) ||
                         assetPath.EndsWith(".txt", StringComparison.OrdinalIgnoreCase) ||
                         assetPath.EndsWith(".xml", StringComparison.OrdinalIgnoreCase) ||
+                        assetPath.EndsWith(".json", StringComparison.OrdinalIgnoreCase) ||
                         assetPath.EndsWith("._", StringComparison.Ordinal))
                     {
                         //  Don't add assets for these files (shouldn't be necessary if/once we have a manifest in the runtime pack

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.props
@@ -17,17 +17,6 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <Import Project="$(NETCoreSdkBundledVersionsProps)" Condition="Exists('$(NETCoreSdkBundledVersionsProps)')" />
 
-  <ItemGroup Condition="'$(UseRefTargetingPacks)' == 'true'">
-    <KnownFrameworkReference Update="Microsoft.NETCore.App"
-                               TargetingPackName="Microsoft.NETCore.App.Ref"
-                               TargetingPackVersion="3.0.0-preview-27406-5"
-                               />
-    <KnownFrameworkReference Update="Microsoft.AspNetCore.App"
-                               TargetingPackName="Microsoft.AspNetCore.App.Ref"
-                               TargetingPackVersion="3.0.0-preview-19108-04"
-                               />
-  </ItemGroup>
-
   <PropertyGroup>
     <!-- Disable web SDK implicit package versions for ASP.NET packages, since the .NET SDK now handles that -->
     <EnableWebSdkImplicitPackageVersions>false</EnableWebSdkImplicitPackageVersions>

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenFrameworkReferences.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenFrameworkReferences.cs
@@ -468,7 +468,6 @@ namespace FrameworkReferenceTest
             testProject.IsSdkProject = true;
             testProject.IsExe = true;
             testProject.AdditionalProperties["DisableImplicitFrameworkReferences"] = "true";
-            testProject.AdditionalProperties["UseRefTargetingPacks"] = "true";
             testProject.RuntimeIdentifier = EnvironmentInfo.GetCompatibleRid(testProject.TargetFrameworks);
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject, callingMethod, identifier)

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPreserveCompilationContext.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPreserveCompilationContext.cs
@@ -642,6 +642,7 @@ System.Resources.ResourceManager.dll
 System.Resources.Writer.dll
 System.Runtime.CompilerServices.VisualC.dll
 System.Runtime.dll
+System.Runtime.CompilerServices.Unsafe.dll
 System.Runtime.Extensions.dll
 System.Runtime.Handles.dll
 System.Runtime.InteropServices.dll


### PR DESCRIPTION
- Ignore .json files in runtime packs.  Fixes self-contained ASP.NET apps failing to launch with new runtime packs. @pakrym 
- Remove UseRefTargetingPacks property.  Fixes #2962