### PR TITLE
Don't set "platform library" for .NET Core 3.0 and higher

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageAssets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageAssets.cs
@@ -1194,19 +1194,6 @@ namespace Microsoft.NET.Build.Tasks
                     }
                 }
 
-                // Exclude any runtime frameworks
-                if (_task.RuntimeFrameworks != null)
-                {
-                    foreach (var framework in _task.RuntimeFrameworks)
-                    {
-                        var frameworkLibrary = _runtimeTarget.GetLibrary(framework.ItemSpec);
-                        if (frameworkLibrary != null)
-                        {
-                            packageExclusions.UnionWith(_runtimeTarget.GetPlatformExclusionList(frameworkLibrary, libraryLookup));
-                        }
-                    }
-                }
-
                 return packageExclusions;
             }
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -661,14 +661,16 @@ Copyright (c) .NET Foundation. All rights reserved.
                            _DefaultMicrosoftNETPlatformLibrary
 
   .NET Core apps can have shared frameworks that are pre-installed on the target machine, thus the app is "portable"
-  to any machine that already has the shared framework installed. In order to enable this, a "platform" library
-  has to be declared. The platform library and its dependencies will be excluded from the runtime assemblies.
+  to any machine that already has the shared framework installed. For .NET Core 1.x and 2.x, a "platform" library
+  is declared. The platform library and its dependencies will be excluded from the publish output.
+  
+  For .NET Core 3 and up, targeting packs and runtime packs are used for shared framework assets instead of PackageReference
   ============================================================
   -->
   <Target Name="_DefaultMicrosoftNETPlatformLibrary">
 
     <PropertyGroup Condition="'$(MicrosoftNETPlatformLibrary)' == ''">
-      <MicrosoftNETPlatformLibrary Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">Microsoft.NETCore.App</MicrosoftNETPlatformLibrary>
+      <MicrosoftNETPlatformLibrary Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(_TargetFrameworkVersionWithoutV)' &lt; '3.0'">Microsoft.NETCore.App</MicrosoftNETPlatformLibrary>
     </PropertyGroup>
 
   </Target>


### PR DESCRIPTION
Don't try to exclude files from the platform library on .NET Core 3.0 and higher, which uses runtime and targeting packs instead

Fixes #3004

To help verify whether this is safe, I looked at the places where `MicrosoftNETPlatformLibrary` is used:

- It's used by the `GenerateDepsFile`, `GenerateRuntimeConfigurationFiles`, and `ResolveCopyLocalAssets` tasks.  These all simply pass it to `LockFileExtensions.CreateProjectContext`.  In that method, it's used as part of the check to determine if the app is framework dependent:
    ```C#
    bool isFrameworkDependent = (platformLibrary != null || runtimeFrameworks?.Any() == true) &&
        (!isSelfContained || string.IsNullOrEmpty(lockFileTarget.RuntimeIdentifier));
    ```
    Note that for .NET Core 3.0 and higher, the `ResolveFrameworkReferences` should add `RuntimeFramework` items, so the `isFrameworkDependent` calculation should still work.
- In the created `ProjectContext`, the `GetRuntimeLibraries` method excludes assets from the platform library for framework dependent apps.
- The `GenerateRuntimeConfigurationFiles` task also uses the platform library from the `ProjectContext` in order to write the runtimeconfig file, but only if there aren't any `RuntimeFrameworks`.
- The `ResolvePackageAssets` task excludes assets from the platform library in `GetPlatformPackageExclusions`.  (It also excludes assets from libraries matching names of `RuntimeFrameworks`, which I believe we should now remove, as those assets will come from runtime packs and won't be in the assets file anyway now).
- The `_RestoreCrossgen` and `PrepforRestoreForComposeStore` use the platform library name.  These are both part of support for `dotnet store`, which we are [considering dropping](https://github.com/dotnet/sdk/issues/2914), and which will need a lot of work in any case if we want it to work when targeting .NET Core 3