### PR TITLE
Remove duplicates items from resolved publish assets.

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -300,7 +300,8 @@ Copyright (c) .NET Foundation. All rights reserved.
       </ResolveCopyLocalAssets>
 
       <ItemGroup>
-        <_ResolvedCopyLocalPublishAssets Include="@(RuntimePackAsset)"/>
+        <!-- If CopyLocalLockFileAssemblies is true, then ReferenceCopyLocalPaths (added below) already contains the runtime pack assets. -->
+        <_ResolvedCopyLocalPublishAssets Include="@(RuntimePackAsset)" Condition="'$(CopyLocalLockFileAssemblies)' != 'true'" />
       </ItemGroup>
 
       <ItemGroup Condition="'$(_UseBuildDependencyFile)' != 'true'">


### PR DESCRIPTION
When `CopyLocalLockFileAssemblies` was true, `ReferenceCopyLocalPaths`
contained the set of `RuntimePackAsset` items.

When resolving assets to copy local for publish, the `RuntimePackAsset` items
were added twice: once explicitly and again via `ReferenceCopyLocalPaths`.

This commit fixes this by only adding to the resolved copy local assets for
publish when `CopyLocalLockFileAssemblies` is false.

Fixes #3007.