### PR TITLE
Prevent copy-local of runtime assets when targeting .NET Framework TFM.

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/AssetsFileResolver.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/AssetsFileResolver.cs
@@ -31,7 +31,7 @@ namespace Microsoft.NET.Build.Tasks
             _preserveStoreLayout = preserveStoreLayout;
             return this;
         }
-        public IEnumerable<ResolvedFile> Resolve(ProjectContext projectContext)
+        public IEnumerable<ResolvedFile> Resolve(ProjectContext projectContext, bool resolveRuntimeTargets = true)
         {
             List<ResolvedFile> results = new List<ResolvedFile>();
 
@@ -49,23 +49,26 @@ namespace Microsoft.NET.Build.Tasks
                 results.AddRange(GetResolvedFiles(targetLibrary.RuntimeAssemblies, targetLibraryPackage, libraryPath, pkgRoot, AssetType.Runtime));
                 results.AddRange(GetResolvedFiles(targetLibrary.NativeLibraries, targetLibraryPackage, libraryPath, pkgRoot, AssetType.Native));
 
-                foreach (LockFileRuntimeTarget runtimeTarget in targetLibrary.RuntimeTargets.FilterPlaceholderFiles())
+                if (resolveRuntimeTargets)
                 {
-                    if (string.Equals(runtimeTarget.AssetType, "native", StringComparison.OrdinalIgnoreCase) ||
-                        string.Equals(runtimeTarget.AssetType, "runtime", StringComparison.OrdinalIgnoreCase))
+                    foreach (LockFileRuntimeTarget runtimeTarget in targetLibrary.RuntimeTargets.FilterPlaceholderFiles())
                     {
-                        string sourcePath = Path.Combine(libraryPath, runtimeTarget.Path);
-                        AssetType _assetType = AssetType.None;
-                        Enum.TryParse<AssetType>(runtimeTarget.AssetType, true, out _assetType);
+                        if (string.Equals(runtimeTarget.AssetType, "native", StringComparison.OrdinalIgnoreCase) ||
+                            string.Equals(runtimeTarget.AssetType, "runtime", StringComparison.OrdinalIgnoreCase))
+                        {
+                            string sourcePath = Path.Combine(libraryPath, runtimeTarget.Path);
+                            AssetType _assetType = AssetType.None;
+                            Enum.TryParse<AssetType>(runtimeTarget.AssetType, true, out _assetType);
 
-                        results.Add(
-                            new ResolvedFile(
-                                sourcePath: sourcePath,
-                                destinationSubDirectory: GetDestinationSubDirectory(sourcePath,
-                                                                                    pkgRoot,
-                                                                                    GetRuntimeTargetDestinationSubDirectory(runtimeTarget)),
-                                package: targetLibraryPackage,
-                                assetType: _assetType));
+                            results.Add(
+                                new ResolvedFile(
+                                    sourcePath: sourcePath,
+                                    destinationSubDirectory: GetDestinationSubDirectory(sourcePath,
+                                                                                        pkgRoot,
+                                                                                        GetRuntimeTargetDestinationSubDirectory(runtimeTarget)),
+                                    package: targetLibraryPackage,
+                                    assetType: _assetType));
+                        }
                     }
                 }
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolveCopyLocalAssets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveCopyLocalAssets.cs
@@ -37,6 +37,8 @@ namespace Microsoft.NET.Build.Tasks
 
         public bool IsSelfContained { get; set; }
 
+        public bool DisableRuntimeTargets { get; set; }
+
         [Output]
         public ITaskItem[] ResolvedAssets => _resolvedAssets.ToArray();
 
@@ -69,7 +71,7 @@ namespace Microsoft.NET.Build.Tasks
                     .WithExcludedPackages(PackageReferenceConverter.GetPackageIds(ExcludedPackageReferences))
                     .WithPreserveStoreLayout(PreserveStoreLayout);
 
-            foreach (var resolvedFile in assetsFileResolver.Resolve(projectContext))
+            foreach (var resolvedFile in assetsFileResolver.Resolve(projectContext, resolveRuntimeTargets: !DisableRuntimeTargets))
             {
                 TaskItem item = new TaskItem(resolvedFile.SourcePath);
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -294,6 +294,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                               ExcludedPackageReferences="@(_ExcludeFromPublishPackageReference)"
                               RuntimeStorePackages="@(RuntimeStorePackages)"
                               PreserveStoreLayout="$(PreserveStoreLayout)"
+                              DisableRuntimeTargets="$(DisableRuntimeTargets)"
                               IsSelfContained="$(SelfContained)"
                               Condition="'$(_UseBuildDependencyFile)' != 'true'">
         <Output TaskParameter="ResolvedAssets" ItemName="_ResolvedCopyLocalPublishAssets" />

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.PackageDependencyResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.PackageDependencyResolution.targets
@@ -215,6 +215,11 @@ Copyright (c) .NET Foundation. All rights reserved.
       <EnsureRuntimePackageDependencies>true</EnsureRuntimePackageDependencies>
     </PropertyGroup>
 
+    <!-- Disable resolution of runtime target assets if not targeting .NETCoreApp -->
+    <PropertyGroup Condition="'$(DisableRuntimeTargets)' == '' and '$(TargetFrameworkIdentifier)' != '.NETCoreApp'">
+      <DisableRuntimeTargets>true</DisableRuntimeTargets>
+    </PropertyGroup>
+
     <ItemGroup>
       <_PackAsToolShimRuntimeIdentifiers Condition="@(_PackAsToolShimRuntimeIdentifiers) ==''" Include="$(PackAsToolShimRuntimeIdentifiers)"/>
 
@@ -239,6 +244,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       MarkPackageReferencesAsExternallyResolved="$(MarkPackageReferencesAsExternallyResolved)"
       DisablePackageAssetsCache="$(DisablePackageAssetsCache)"
       DisableFrameworkAssemblies="$(DisableLockFileFrameworks)"
+      DisableRuntimeTargets="$(DisableRuntimeTargets)"
       DisableTransitiveProjectReferences="$(DisableTransitiveProjectReferences)"
       DotNetAppHostExecutableNameWithoutExtension="$(_DotNetAppHostExecutableNameWithoutExtension)"
       ShimRuntimeIdentifiers="@(_PackAsToolShimRuntimeIdentifiers)"


### PR DESCRIPTION
This commit prevents the copying of "runtime" assets (those that end up
in the `runtimes/` sub-directory for resolution based on the RID at
runtime) when building or publishing an application that targets a .NET
Framework TFM.  Only the .NET Core runtime will resolve these assets
based on RID, so copying them for .NET Framework targeted applications
is unnecessary.

Fixes dotnet/cli#10979.