### PR TITLE
Attempt to fix flaky "test as tool" runs

### DIFF
--- a/src/Tests/Directory.Build.targets
+++ b/src/Tests/Directory.Build.targets
@@ -35,6 +35,7 @@
   <Target Name="TestAsTool" DependsOnTargets="Pack;LayoutSdk;_InnerGetTestsToRun">
     <PropertyGroup>
       <TestLocalToolFolder>$(ArtifactsTmpDir)$(ToolCommandName)\</TestLocalToolFolder>
+      <DOTNET_CLI_HOME>$(ArtifactsTmpDir)DOTNET_CLI_HOME\</DOTNET_CLI_HOME>
     </PropertyGroup>
 
     <RemoveDir Directories="$(TestLocalToolFolder)" />
@@ -47,13 +48,16 @@
     <RemoveDir Directories="$(NuGetPackageRoot)$(ToolCommandName)\$(PackageVersion)" />
 
     <Exec Command="dotnet new tool-manifest"
-      WorkingDirectory="$(TestLocalToolFolder)"/>
+      WorkingDirectory="$(TestLocalToolFolder)"
+      EnvironmentVariables="DOTNET_CLI_HOME=$(DOTNET_CLI_HOME)"/>
     
     <Exec Command="dotnet tool install --local $(ToolCommandName) --version $(PackageVersion) --add-source $(ArtifactsShippingPackagesDir)"
-      WorkingDirectory="$(TestLocalToolFolder)"/>
+      WorkingDirectory="$(TestLocalToolFolder)"
+      EnvironmentVariables="DOTNET_CLI_HOME=$(DOTNET_CLI_HOME)"/>
     
     <Exec Command="dotnet tool restore"
-      WorkingDirectory="$(TestLocalToolFolder)"/>
+      WorkingDirectory="$(TestLocalToolFolder)"
+      EnvironmentVariables="DOTNET_CLI_HOME=$(DOTNET_CLI_HOME)"/>
 
     <PropertyGroup>
       <ResultsXmlPath>@(TestToRun->'%(ResultsXmlPath)')</ResultsXmlPath>
@@ -69,6 +73,7 @@
 
     <Exec Command="dotnet tool run $(ToolCommandName) -- $(TestArgs)"
           WorkingDirectory="$(TestLocalToolFolder)"
+          EnvironmentVariables="DOTNET_CLI_HOME=$(DOTNET_CLI_HOME)"
           IgnoreStandardErrorWarningFormat="true" />
   </Target>
 

--- a/src/Tests/Directory.Build.targets
+++ b/src/Tests/Directory.Build.targets
@@ -51,6 +51,9 @@
     
     <Exec Command="dotnet tool install --local $(ToolCommandName) --version $(PackageVersion) --add-source $(ArtifactsShippingPackagesDir)"
       WorkingDirectory="$(TestLocalToolFolder)"/>
+    
+    <Exec Command="dotnet tool restore"
+      WorkingDirectory="$(TestLocalToolFolder)"/>
 
     <PropertyGroup>
       <ResultsXmlPath>@(TestToRun->'%(ResultsXmlPath)')</ResultsXmlPath>
@@ -64,7 +67,7 @@
       <TestArgs>$(TestArgs) &gt; $(ResultsStdOutPath)</TestArgs>
     </PropertyGroup>
 
-    <Exec Command="dotnet tool run $(ToolCommandName) $(TestArgs)"
+    <Exec Command="dotnet tool run $(ToolCommandName) -- $(TestArgs)"
           WorkingDirectory="$(TestLocalToolFolder)"
           IgnoreStandardErrorWarningFormat="true" />
   </Target>


### PR DESCRIPTION
We've been having some of the "test as tool" runs fail.  The command to run the tool is failing, and the output ends up being the usage information for `dotnet tool run`, for example:

```
Usage: dotnet tool run [options] <COMMAND_NAME> [[--] <additional arguments>...]]

Arguments:
  <COMMAND_NAME>   The command name of the tool to run.

Options:
  -h, --help   Show command line help.
Additional Arguments:
  Arguments passed to the application that is being run.
```

In the .binlog, there is also a message:

> Run "dotnet tool restore" to make the "testSdkClean" command available.

So this PR attempts to fix this by explicitly including the `--` before the arguments to the tool, as well as explicitly running `dotnet tool restore` before running the tool.