### PR TITLE
Fix publish conflict resolution for runtime pack assets.

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -301,8 +301,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       </ResolveCopyLocalAssets>
 
       <ItemGroup>
-        <!-- If CopyLocalLockFileAssemblies is true, then ReferenceCopyLocalPaths (added below) already contains the runtime pack assets. -->
-        <_ResolvedCopyLocalPublishAssets Include="@(RuntimePackAsset)" Condition="'$(CopyLocalLockFileAssemblies)' != 'true'" />
+        <_ResolvedCopyLocalPublishAssets Include="@(RuntimePackAsset)" />
       </ItemGroup>
 
       <ItemGroup Condition="'$(_UseBuildDependencyFile)' != 'true'">
@@ -398,7 +397,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <ItemGroup>
       <_ResolvedCopyLocalPublishAssets Include="@(ReferenceCopyLocalPaths)"
-                                       Exclude="@(_ResolvedCopyLocalBuildAssets)"
+                                       Exclude="@(_ResolvedCopyLocalBuildAssets);@(RuntimePackAsset)"
                                        Condition="'$(PublishReferencesDocumentationFiles)' == 'true' or '%(Extension)' != '.xml'">
         <DestinationSubPath>%(ReferenceCopyLocalPaths.DestinationSubDirectory)%(Filename)%(Extension)</DestinationSubPath>
       </_ResolvedCopyLocalPublishAssets>


### PR DESCRIPTION
This commit fixes a bug in the conflict resolution for runtime pack assets that
was caused by a recent fix to filter out duplicates items in the set of
publish assets introduced by adding the runtime pack assets twice. The
regression was that the adding of the runtime pack assets to the publish assets
was done *after* the conflict resolution occurred; thus, conflicts weren't
detected properly for assets that should conflict with runtime pack assets.

The fix is to always add the runtime pack assets to the list of publish assets
before conflict resolution occurs.  To prevent the duplicate add of the items,
we now filter out the runtime pack assets when adding the
`ReferenceCopyLocalPaths` items to the publish assets.

Fixes #3035.