### PR TITLE
Fix apphost creation when using a publish profile.

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -17,9 +17,6 @@ Copyright (c) .NET Foundation. All rights reserved.
     <DefaultCopyToPublishDirectoryMetadata Condition="'$(DefaultCopyToPublishDirectoryMetadata)' == ''">true</DefaultCopyToPublishDirectoryMetadata>
     <_GetChildProjectCopyToPublishDirectoryItems Condition="'$(_GetChildProjectCopyToPublishDirectoryItems)' == ''">true</_GetChildProjectCopyToPublishDirectoryItems>
 
-    <!-- publishing with the apphost should publish the native host as $(AssemblyName).exe -->
-    <DeployAppHost Condition="'$(DeployAppHost)' == '' and '$(_IsExecutable)' == 'true' and '$(RuntimeIdentifier)' != '' and '$(UseAppHost)' == 'true'">true</DeployAppHost>
-  
     <IsPublishable Condition="'$(IsPublishable)'==''">true</IsPublishable>
   </PropertyGroup>
 
@@ -627,21 +624,22 @@ Copyright (c) .NET Foundation. All rights reserved.
     -->
 
   <Target Name="DeployAppHost"
-          DependsOnTargets="_ComputeNETCoreBuildOutputFiles"
+          DependsOnTargets="_ComputeDotNetRuntimeFiles;_ComputeNETCoreBuildOutputFiles"
           AfterTargets="ComputeFilesToPublish"
-          BeforeTargets="CopyFilesToPublishDirectory"
-          Condition="'$(DeployAppHost)' == 'true'">
+          BeforeTargets="CopyFilesToPublishDirectory">
 
-    <ItemGroup>
+    <!-- publishing with the apphost should publish the native host as $(AssemblyName).exe -->
+    <PropertyGroup>
+      <DeployAppHost Condition="'$(DeployAppHost)' == '' and '$(_IsExecutable)' == 'true' and '$(RuntimeIdentifier)' != '' and '$(UseAppHost)' == 'true'">true</DeployAppHost>
+    </PropertyGroup>
 
+    <ItemGroup Condition="'$(DeployAppHost)' == 'true'">
       <ResolvedFileToRemove  Include ="%(ResolvedFileToPublish.Identity)" Condition="'%(ResolvedFileToPublish.RelativePath)' == '$(_DotNetHostExecutableName)' Or '%(ResolvedFileToPublish.RelativePath)' == '$(_DotNetAppHostExecutableName)'"/>
       <ResolvedFileToPublish Remove ="%(ResolvedFileToRemove.Identity)"/>
 
       <ResolvedFileToPublish Include="%(NativeAppHostNETCore.Identity)">
         <RelativePath>$(AssemblyName)$(_NativeExecutableExtension)</RelativePath>
       </ResolvedFileToPublish>
-
-
     </ItemGroup>
 
   </Target>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -60,23 +60,6 @@ Copyright (c) .NET Foundation. All rights reserved.
   </PropertyGroup>
 
   <PropertyGroup>
-    <_NativeLibraryPrefix Condition="'$(_NativeLibraryPrefix)' == '' and !$(RuntimeIdentifier.StartsWith('win'))">lib</_NativeLibraryPrefix>
-
-    <_NativeLibraryExtension Condition="'$(_NativeLibraryExtension)' == '' and $(RuntimeIdentifier.StartsWith('win'))">.dll</_NativeLibraryExtension>
-    <_NativeLibraryExtension Condition="'$(_NativeLibraryExtension)' == '' and $(RuntimeIdentifier.StartsWith('osx'))">.dylib</_NativeLibraryExtension>
-    <_NativeLibraryExtension Condition="'$(_NativeLibraryExtension)' == ''">.so</_NativeLibraryExtension>
-
-    <_NativeExecutableExtension Condition="'$(_NativeExecutableExtension)' == '' and $(RuntimeIdentifier.StartsWith('win'))">.exe</_NativeExecutableExtension>
-
-    <_DotNetHostExecutableName>dotnet$(_NativeExecutableExtension)</_DotNetHostExecutableName>
-    <_DotNetAppHostExecutableNameWithoutExtension>apphost</_DotNetAppHostExecutableNameWithoutExtension>
-    <_DotNetAppHostExecutableName>$(_DotNetAppHostExecutableNameWithoutExtension)$(_NativeExecutableExtension)</_DotNetAppHostExecutableName>
-
-    <_DotNetHostPolicyLibraryName>$(_NativeLibraryPrefix)hostpolicy$(_NativeLibraryExtension)</_DotNetHostPolicyLibraryName>
-    <_DotNetHostFxrLibraryName>$(_NativeLibraryPrefix)hostfxr$(_NativeLibraryExtension)</_DotNetHostFxrLibraryName>
-  </PropertyGroup>
-
-  <PropertyGroup>
     <_DefaultUserProfileRuntimeStorePath>$(HOME)</_DefaultUserProfileRuntimeStorePath>
     <_DefaultUserProfileRuntimeStorePath Condition="'$(OS)' == 'Windows_NT'">$(USERPROFILE)</_DefaultUserProfileRuntimeStorePath>
     <_DefaultUserProfileRuntimeStorePath>$([System.IO.Path]::Combine($(_DefaultUserProfileRuntimeStorePath), '.dotnet', 'store'))</_DefaultUserProfileRuntimeStorePath>
@@ -104,6 +87,32 @@ Copyright (c) .NET Foundation. All rights reserved.
       $(RebuildDependsOn)
     </RebuildDependsOn>
   </PropertyGroup>
+
+  <!--
+    ============================================================
+    _ComputeDotNetRuntimeFiles
+
+    Computes various runtime file properties based on the current RuntimeIdentifier.
+    ============================================================
+  -->
+  <Target Name="_ComputeDotNetRuntimeFiles">
+    <PropertyGroup>
+      <_NativeLibraryPrefix Condition="'$(_NativeLibraryPrefix)' == '' and !$(RuntimeIdentifier.StartsWith('win'))">lib</_NativeLibraryPrefix>
+
+      <_NativeLibraryExtension Condition="'$(_NativeLibraryExtension)' == '' and $(RuntimeIdentifier.StartsWith('win'))">.dll</_NativeLibraryExtension>
+      <_NativeLibraryExtension Condition="'$(_NativeLibraryExtension)' == '' and $(RuntimeIdentifier.StartsWith('osx'))">.dylib</_NativeLibraryExtension>
+      <_NativeLibraryExtension Condition="'$(_NativeLibraryExtension)' == ''">.so</_NativeLibraryExtension>
+
+      <_NativeExecutableExtension Condition="'$(_NativeExecutableExtension)' == '' and $(RuntimeIdentifier.StartsWith('win'))">.exe</_NativeExecutableExtension>
+
+      <_DotNetHostExecutableName>dotnet$(_NativeExecutableExtension)</_DotNetHostExecutableName>
+      <_DotNetAppHostExecutableNameWithoutExtension>apphost</_DotNetAppHostExecutableNameWithoutExtension>
+      <_DotNetAppHostExecutableName>$(_DotNetAppHostExecutableNameWithoutExtension)$(_NativeExecutableExtension)</_DotNetAppHostExecutableName>
+
+      <_DotNetHostPolicyLibraryName>$(_NativeLibraryPrefix)hostpolicy$(_NativeLibraryExtension)</_DotNetHostPolicyLibraryName>
+      <_DotNetHostFxrLibraryName>$(_NativeLibraryPrefix)hostfxr$(_NativeLibraryExtension)</_DotNetHostFxrLibraryName>
+    </PropertyGroup>
+  </Target>
 
   <!--
     ============================================================
@@ -276,7 +285,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     -->
   <UsingTask TaskName="EmbedAppNameInHost" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
   <Target Name="_ComputeNETCoreBuildOutputFiles"
-          DependsOnTargets="ResolvePackageAssets"
+          DependsOnTargets="_ComputeDotNetRuntimeFiles;ResolvePackageAssets"
           AfterTargets="ResolveReferences"
           BeforeTargets="AssignTargetPaths"
           Condition="'$(ComputeNETCoreBuildOutputFiles)' == 'true'">
@@ -350,7 +359,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     ============================================================
     -->
   <Target Name="_ComputeReferenceAssemblies"
-          DependsOnTargets="ResolveAssemblyReferences">
+          DependsOnTargets="_ComputeDotNetRuntimeFiles;ResolveAssemblyReferences">
 
     <ItemGroup>
       <_FrameworkReferenceAssemblies Include="@(ReferencePath)"

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.PackageDependencyResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.PackageDependencyResolution.targets
@@ -187,7 +187,8 @@ Copyright (c) .NET Foundation. All rights reserved.
   </Target>
 
   <Target Name="ResolvePackageAssets" 
-          Condition=" '$(DesignTimeBuild)' != 'true' Or Exists('$(ProjectAssetsFile)')">
+          Condition=" '$(DesignTimeBuild)' != 'true' Or Exists('$(ProjectAssetsFile)')"
+          DependsOnTargets="_ComputeDotNetRuntimeFiles">
 
     <PropertyGroup Condition="'$(EnsureRuntimePackageDependencies)' == ''
                           and '$(TargetFrameworkIdentifier)' == '.NETCoreApp'

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAWebProject.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAWebProject.cs
@@ -77,7 +77,6 @@ namespace Microsoft.NET.Publish.Tests
                 .HaveStdOutContaining("Hello World!");
         }
 
-
         [Theory]
         [InlineData("Microsoft.AspNetCore.App")]
         [InlineData("Microsoft.AspNetCore.All")]
@@ -135,6 +134,89 @@ namespace Microsoft.NET.Publish.Tests
                 .Pass()
                 .And
                 .HaveStdOutContaining("Hello World!");
+        }
+
+        [Theory]
+        [InlineData(false, false)]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        [InlineData(true, true)]
+        public void It_publishes_with_a_publish_profile(bool selfContained, bool useAppHost)
+        {
+            var tfm = "netcoreapp2.2";
+
+            var testProject = new TestProject()
+            {
+                Name = "WebWithPublishProfile",
+                TargetFrameworks = tfm,
+                IsSdkProject = true,
+                IsExe = true,
+            };
+
+            testProject.AdditionalProperties.Add("AspNetCoreHostingModel", "InProcess");
+            testProject.PackageReferences.Add(new TestPackageReference("Microsoft.AspNetCore.App"));
+            testProject.PackageReferences.Add(new TestPackageReference("Microsoft.AspNetCore.Razor.Design", version: "2.2.0", privateAssets: "all"));
+
+            var testProjectInstance = _testAssetsManager.CreateTestProject(testProject)
+                .WithProjectChanges(
+                    (filename, project) =>
+                    {
+                        project.Root.Attribute("Sdk").Value = "Microsoft.NET.Sdk.Web";
+                    });
+
+            var projectDirectory = Path.Combine(testProjectInstance.Path, testProject.Name);
+            var publishProfilesDirectory = Path.Combine(projectDirectory, "Properties", "PublishProfiles");
+            Directory.CreateDirectory(publishProfilesDirectory);
+
+            File.WriteAllText(Path.Combine(publishProfilesDirectory, "test.pubxml"), $@"
+<Project>
+  <PropertyGroup>
+    <RuntimeIdentifier>{EnvironmentInfo.GetCompatibleRid(tfm)}</RuntimeIdentifier>
+    <SelfContained>{selfContained}</SelfContained>
+    <UseAppHost>{selfContained || useAppHost}</UseAppHost>
+  </PropertyGroup>
+</Project>
+");
+
+            var command = new PublishCommand(Log, projectDirectory);
+            command
+                .Execute("/restore", "/p:PublishProfile=test")
+                .Should()
+                .Pass();
+
+            var output = command.GetOutputDirectory(tfm);
+
+            output.Should().HaveFiles(new[] {
+                $"{testProject.Name}.dll",
+                $"{testProject.Name}.pdb",
+                $"{testProject.Name}.deps.json",
+                $"{testProject.Name}.runtimeconfig.json",
+                "web.config",
+            });
+
+            if (selfContained)
+            {
+                output.Should().HaveFiles(new[] {
+                    $"{FileConstants.DynamicLibPrefix}hostfxr{FileConstants.DynamicLibSuffix}",
+                    $"{FileConstants.DynamicLibPrefix}hostpolicy{FileConstants.DynamicLibSuffix}",
+                });
+            }
+            else
+            {
+                output.Should().NotHaveFiles(new[] {
+                    $"{FileConstants.DynamicLibPrefix}hostfxr{FileConstants.DynamicLibSuffix}",
+                    $"{FileConstants.DynamicLibPrefix}hostpolicy{FileConstants.DynamicLibSuffix}",
+                });
+            }
+
+            if (selfContained || useAppHost)
+            {
+                output.Should().HaveFile($"{testProject.Name}{Constants.ExeSuffix}");
+            }
+            else
+            {
+                output.Should().NotHaveFile($"{testProject.Name}{Constants.ExeSuffix}");
+            }
         }
     }
 }


### PR DESCRIPTION
When publishing an ASP.NET project using a publish profile that sets
`RuntimeIdentifier`, various apphost-related properties are calculated before
the RID is set when the publish profile is imported.

This typically results in the expected file names for the restored assets not
having the correct prefixes and suffixes for the target RID.  For example, if a
Windows RID is set in the publish profile, the expected apphost asset is named
`apphost` instead of the correct `apphost.exe`. This causes the apphost
customization to be skipped because the expected apphost asset wasn't found.

The fix is to delay setting these properties until after the publish profile
has been imported by the Web SDK.  This is accomplished by moving the
properties into a target that is invoked based on every place in the SDK
where the properties are used.

Fixes dotnet/cli#10647.