### PR TITLE
Add support for Single-file publishing 

### DIFF
--- a/src/Tasks/Common/Resources/Strings.resx
+++ b/src/Tasks/Common/Resources/Strings.resx
@@ -505,4 +505,8 @@ The following are names of parameters or literal values and should not be transl
     <value>NETSDK1096: Optimizing assemblies for performance failed. You can either exclude the failing assemblies from being optimized, or set the ReadyToRun property to false.</value>
     <comment>{StrBegin="NETSDK1096: "}</comment>
   </data>
+  <data name="CannotHaveSingleFileWithoutRuntimeIdentifier" xml:space="preserve">
+    <value>NETSDK1097: It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. Please either specify a RuntimeIdentifier or set PublishSingleFile to false.</value>
+    <comment>{StrBegin="NETSDK1097: "}</comment>
+  </data>  
 </root>

--- a/src/Tasks/Common/Resources/Strings.resx
+++ b/src/Tasks/Common/Resources/Strings.resx
@@ -509,4 +509,8 @@ The following are names of parameters or literal values and should not be transl
     <value>NETSDK1097: It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. Please either specify a RuntimeIdentifier or set PublishSingleFile to false.</value>
     <comment>{StrBegin="NETSDK1097: "}</comment>
   </data>  
+  <data name="CannotHaveSingleFileWithoutAppHost" xml:space="preserve">
+    <value>NETSDK1098: Applications published to a single-file are required to use the application host. Please either set PublishSingleFile to false or set UseAppHost to true.</value>
+    <comment>{StrBegin="NETSDK1098: "}</comment>
+  </data>
 </root>

--- a/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
@@ -107,6 +107,16 @@
         <target state="translated">NETSDK1031: Sestavení nebo publikování nezávislé aplikace bez zadání parametru RuntimeIdentifier není podporované. Zadejte prosím buď parametr RuntimeIdentifier, nebo nastavte parametr SelfContained na hodnotu False.</target>
         <note>{StrBegin="NETSDK1031: "}</note>
       </trans-unit>
+      <trans-unit id="CannotHaveSingleFileWithoutRuntimeIdentifier">
+        <source>NETSDK1097: It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. Please either specify a RuntimeIdentifier or set PublishSingleFile to false.</source>
+        <target state="new">NETSDK1097: It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. Please either specify a RuntimeIdentifier or set PublishSingleFile to false.</target>
+        <note>{StrBegin="NETSDK1097: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotHaveSingleFileWithoutAppHost">
+        <source>NETSDK1098: Applications published to a single-file are required to use the application host. Please either set PublishSingleFile to false or set UseAppHost to true.</source>
+        <target state="new">NETSDK1098: Applications published to a single-file are required to use the application host. Please either set PublishSingleFile to false or set UseAppHost to true.</target>
+        <note>{StrBegin="NETSDK1098: "}</note>
+      </trans-unit>
       <trans-unit id="CannotInferTargetFrameworkIdentifierAndVersion">
         <source>NETSDK1013: The TargetFramework value '{0}' was not recognized. It may be misspelled. If not, then the TargetFrameworkIdentifier and/or TargetFrameworkVersion properties must be specified explicitly.</source>
         <target state="translated">NETSDK1013: Hodnota TargetFramework {0} nebyla rozpoznána. Je možné, že obsahuje překlepy. Pokud tomu tak není, musíte vlastnosti TargetFrameworkIdentifier a TargetFrameworkVersion zadat explicitně.</target>
@@ -485,16 +495,6 @@ The following are names of parameters or literal values and should not be transl
         <source>NETSDK1057: You are using a preview version of .NET Core. See: https://aka.ms/dotnet-core-preview</source>
         <target state="translated">NETSDK1057: Používáte preview verzi .NET Core. Další informace: https://aka.ms/dotnet-core-preview</target>
         <note>{StrBegin="NETSDK1057: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotHaveSingleFileWithoutRuntimeIdentifier">
-        <source>NETSDK1093: It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. Please either specify a RuntimeIdentifier or set PublishSingleFile to false.</source>
-        <target state="new">NETSDK1093: It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. Please either specify a RuntimeIdentifier or set PublishSingleFile to false.</target>
-        <note>{StrBegin="NETSDK1093: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotHaveSingleFileWithoutAppHost">
-        <source>NETSDK1094: Applications published to a single-file are required to use the application host. Please either set PublishSingleFile to false or set UseAppHost to true.</source>
-        <target state="new">NETSDK1094: Applications published to a single-file are required to use the application host. Please either set PublishSingleFile to false or set UseAppHost to true.</target>
-        <note>{StrBegin="NETSDK1094: "}</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
@@ -486,6 +486,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1057: Používáte preview verzi .NET Core. Další informace: https://aka.ms/dotnet-core-preview</target>
         <note>{StrBegin="NETSDK1057: "}</note>
       </trans-unit>
+      <trans-unit id="CannotHaveSingleFileWithoutRuntimeIdentifier">
+        <source>NETSDK1093: It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. Please either specify a RuntimeIdentifier or set PublishSingleFile to false.</source>
+        <target state="new">NETSDK1093: It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. Please either specify a RuntimeIdentifier or set PublishSingleFile to false.</target>
+        <note>{StrBegin="NETSDK1093: "}</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
@@ -491,6 +491,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="new">NETSDK1093: It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. Please either specify a RuntimeIdentifier or set PublishSingleFile to false.</target>
         <note>{StrBegin="NETSDK1093: "}</note>
       </trans-unit>
+      <trans-unit id="CannotHaveSingleFileWithoutAppHost">
+        <source>NETSDK1094: Applications published to a single-file are required to use the application host. Please either set PublishSingleFile to false or set UseAppHost to true.</source>
+        <target state="new">NETSDK1094: Applications published to a single-file are required to use the application host. Please either set PublishSingleFile to false or set UseAppHost to true.</target>
+        <note>{StrBegin="NETSDK1094: "}</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Common/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.de.xlf
@@ -107,6 +107,16 @@
         <target state="translated">NETSDK1031: Das Erstellen oder Veröffentlichen einer eigenständigen Anwendung ohne die Angabe eines RuntimeIdentifier wird nicht unterstützt. Geben Sie entweder einen RuntimeIdentifier an, oder legen Sie für SelfContained "False" fest.</target>
         <note>{StrBegin="NETSDK1031: "}</note>
       </trans-unit>
+      <trans-unit id="CannotHaveSingleFileWithoutRuntimeIdentifier">
+        <source>NETSDK1097: It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. Please either specify a RuntimeIdentifier or set PublishSingleFile to false.</source>
+        <target state="new">NETSDK1097: It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. Please either specify a RuntimeIdentifier or set PublishSingleFile to false.</target>
+        <note>{StrBegin="NETSDK1097: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotHaveSingleFileWithoutAppHost">
+        <source>NETSDK1098: Applications published to a single-file are required to use the application host. Please either set PublishSingleFile to false or set UseAppHost to true.</source>
+        <target state="new">NETSDK1098: Applications published to a single-file are required to use the application host. Please either set PublishSingleFile to false or set UseAppHost to true.</target>
+        <note>{StrBegin="NETSDK1098: "}</note>
+      </trans-unit>
       <trans-unit id="CannotInferTargetFrameworkIdentifierAndVersion">
         <source>NETSDK1013: The TargetFramework value '{0}' was not recognized. It may be misspelled. If not, then the TargetFrameworkIdentifier and/or TargetFrameworkVersion properties must be specified explicitly.</source>
         <target state="translated">NETSDK1013: Der TargetFramework-Wert "{0}" wurde nicht erkannt. Unter Umständen ist die Schreibweise nicht korrekt. Andernfalls müssen die Eigenschaften TargetFrameworkIdentifier und/oder TargetFrameworkVersion explizit angegeben werden.</target>
@@ -485,16 +495,6 @@ The following are names of parameters or literal values and should not be transl
         <source>NETSDK1057: You are using a preview version of .NET Core. See: https://aka.ms/dotnet-core-preview</source>
         <target state="translated">NETSDK1057: Sie verwenden eine Vorschauversion von .NET Core. Weitere Informationen: https://aka.ms/dotnet-core-preview</target>
         <note>{StrBegin="NETSDK1057: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotHaveSingleFileWithoutRuntimeIdentifier">
-        <source>NETSDK1093: It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. Please either specify a RuntimeIdentifier or set PublishSingleFile to false.</source>
-        <target state="new">NETSDK1093: It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. Please either specify a RuntimeIdentifier or set PublishSingleFile to false.</target>
-        <note>{StrBegin="NETSDK1093: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotHaveSingleFileWithoutAppHost">
-        <source>NETSDK1094: Applications published to a single-file are required to use the application host. Please either set PublishSingleFile to false or set UseAppHost to true.</source>
-        <target state="new">NETSDK1094: Applications published to a single-file are required to use the application host. Please either set PublishSingleFile to false or set UseAppHost to true.</target>
-        <note>{StrBegin="NETSDK1094: "}</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Tasks/Common/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.de.xlf
@@ -486,11 +486,16 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1057: Sie verwenden eine Vorschauversion von .NET Core. Weitere Informationen: https://aka.ms/dotnet-core-preview</target>
         <note>{StrBegin="NETSDK1057: "}</note>
       </trans-unit>
-        <trans-unit id="CannotHaveSingleFileWithoutRuntimeIdentifier">
-            <source>NETSDK1093: It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. Please either specify a RuntimeIdentifier or set PublishSingleFile to false.</source>
-            <target state="new">NETSDK1093: It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. Please either specify a RuntimeIdentifier or set PublishSingleFile to false.</target>
-            <note>{StrBegin="NETSDK1093: "}</note>
-        </trans-unit>
+      <trans-unit id="CannotHaveSingleFileWithoutRuntimeIdentifier">
+        <source>NETSDK1093: It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. Please either specify a RuntimeIdentifier or set PublishSingleFile to false.</source>
+        <target state="new">NETSDK1093: It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. Please either specify a RuntimeIdentifier or set PublishSingleFile to false.</target>
+        <note>{StrBegin="NETSDK1093: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotHaveSingleFileWithoutAppHost">
+        <source>NETSDK1094: Applications published to a single-file are required to use the application host. Please either set PublishSingleFile to false or set UseAppHost to true.</source>
+        <target state="new">NETSDK1094: Applications published to a single-file are required to use the application host. Please either set PublishSingleFile to false or set UseAppHost to true.</target>
+        <note>{StrBegin="NETSDK1094: "}</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Common/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.de.xlf
@@ -486,6 +486,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1057: Sie verwenden eine Vorschauversion von .NET Core. Weitere Informationen: https://aka.ms/dotnet-core-preview</target>
         <note>{StrBegin="NETSDK1057: "}</note>
       </trans-unit>
+        <trans-unit id="CannotHaveSingleFileWithoutRuntimeIdentifier">
+            <source>NETSDK1093: It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. Please either specify a RuntimeIdentifier or set PublishSingleFile to false.</source>
+            <target state="new">NETSDK1093: It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. Please either specify a RuntimeIdentifier or set PublishSingleFile to false.</target>
+            <note>{StrBegin="NETSDK1093: "}</note>
+        </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Common/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.es.xlf
@@ -107,6 +107,16 @@
         <target state="translated">NETSDK1031: No se admite compilar o publicar una aplicación autocontenida sin especificar un valor para RuntimeIdentifier. Especifique un valor para RuntimeIdentifier o establezca SelfContained en false.</target>
         <note>{StrBegin="NETSDK1031: "}</note>
       </trans-unit>
+      <trans-unit id="CannotHaveSingleFileWithoutRuntimeIdentifier">
+        <source>NETSDK1097: It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. Please either specify a RuntimeIdentifier or set PublishSingleFile to false.</source>
+        <target state="new">NETSDK1097: It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. Please either specify a RuntimeIdentifier or set PublishSingleFile to false.</target>
+        <note>{StrBegin="NETSDK1097: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotHaveSingleFileWithoutAppHost">
+        <source>NETSDK1098: Applications published to a single-file are required to use the application host. Please either set PublishSingleFile to false or set UseAppHost to true.</source>
+        <target state="new">NETSDK1098: Applications published to a single-file are required to use the application host. Please either set PublishSingleFile to false or set UseAppHost to true.</target>
+        <note>{StrBegin="NETSDK1098: "}</note>
+      </trans-unit>
       <trans-unit id="CannotInferTargetFrameworkIdentifierAndVersion">
         <source>NETSDK1013: The TargetFramework value '{0}' was not recognized. It may be misspelled. If not, then the TargetFrameworkIdentifier and/or TargetFrameworkVersion properties must be specified explicitly.</source>
         <target state="translated">NETSDK1013: El valor de TargetFramework "{0}" no se reconoció. Puede que esté mal escrito. Si este no es el caso, las propiedades TargetFrameworkIdentifier o TargetFrameworkVersion se deben especificar explícitamente.</target>
@@ -485,16 +495,6 @@ The following are names of parameters or literal values and should not be transl
         <source>NETSDK1057: You are using a preview version of .NET Core. See: https://aka.ms/dotnet-core-preview</source>
         <target state="translated">NETSDK1057: Está utilizando una versión preliminar de .NET Core. Vea: https://aka.ms/dotnet-core-preview</target>
         <note>{StrBegin="NETSDK1057: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotHaveSingleFileWithoutRuntimeIdentifier">
-        <source>NETSDK1093: It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. Please either specify a RuntimeIdentifier or set PublishSingleFile to false.</source>
-        <target state="new">NETSDK1093: It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. Please either specify a RuntimeIdentifier or set PublishSingleFile to false.</target>
-        <note>{StrBegin="NETSDK1093: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotHaveSingleFileWithoutAppHost">
-        <source>NETSDK1094: Applications published to a single-file are required to use the application host. Please either set PublishSingleFile to false or set UseAppHost to true.</source>
-        <target state="new">NETSDK1094: Applications published to a single-file are required to use the application host. Please either set PublishSingleFile to false or set UseAppHost to true.</target>
-        <note>{StrBegin="NETSDK1094: "}</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Tasks/Common/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.es.xlf
@@ -486,11 +486,16 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1057: Está utilizando una versión preliminar de .NET Core. Vea: https://aka.ms/dotnet-core-preview</target>
         <note>{StrBegin="NETSDK1057: "}</note>
       </trans-unit>
-        <trans-unit id="CannotHaveSingleFileWithoutRuntimeIdentifier">
-            <source>NETSDK1093: It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. Please either specify a RuntimeIdentifier or set PublishSingleFile to false.</source>
-            <target state="new">NETSDK1093: It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. Please either specify a RuntimeIdentifier or set PublishSingleFile to false.</target>
-            <note>{StrBegin="NETSDK1093: "}</note>
-        </trans-unit>
+      <trans-unit id="CannotHaveSingleFileWithoutRuntimeIdentifier">
+        <source>NETSDK1093: It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. Please either specify a RuntimeIdentifier or set PublishSingleFile to false.</source>
+        <target state="new">NETSDK1093: It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. Please either specify a RuntimeIdentifier or set PublishSingleFile to false.</target>
+        <note>{StrBegin="NETSDK1093: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotHaveSingleFileWithoutAppHost">
+        <source>NETSDK1094: Applications published to a single-file are required to use the application host. Please either set PublishSingleFile to false or set UseAppHost to true.</source>
+        <target state="new">NETSDK1094: Applications published to a single-file are required to use the application host. Please either set PublishSingleFile to false or set UseAppHost to true.</target>
+        <note>{StrBegin="NETSDK1094: "}</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Common/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.es.xlf
@@ -486,6 +486,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1057: Está utilizando una versión preliminar de .NET Core. Vea: https://aka.ms/dotnet-core-preview</target>
         <note>{StrBegin="NETSDK1057: "}</note>
       </trans-unit>
+        <trans-unit id="CannotHaveSingleFileWithoutRuntimeIdentifier">
+            <source>NETSDK1093: It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. Please either specify a RuntimeIdentifier or set PublishSingleFile to false.</source>
+            <target state="new">NETSDK1093: It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. Please either specify a RuntimeIdentifier or set PublishSingleFile to false.</target>
+            <note>{StrBegin="NETSDK1093: "}</note>
+        </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
@@ -107,6 +107,16 @@
         <target state="translated">NETSDK1031: La génération ou la publication d'une application autonome sans spécification de RuntimeIdentifier n'est pas prise en charge. Spécifiez RuntimeIdentifier ou affectez la valeur false à SelfContained.</target>
         <note>{StrBegin="NETSDK1031: "}</note>
       </trans-unit>
+      <trans-unit id="CannotHaveSingleFileWithoutRuntimeIdentifier">
+        <source>NETSDK1097: It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. Please either specify a RuntimeIdentifier or set PublishSingleFile to false.</source>
+        <target state="new">NETSDK1097: It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. Please either specify a RuntimeIdentifier or set PublishSingleFile to false.</target>
+        <note>{StrBegin="NETSDK1097: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotHaveSingleFileWithoutAppHost">
+        <source>NETSDK1098: Applications published to a single-file are required to use the application host. Please either set PublishSingleFile to false or set UseAppHost to true.</source>
+        <target state="new">NETSDK1098: Applications published to a single-file are required to use the application host. Please either set PublishSingleFile to false or set UseAppHost to true.</target>
+        <note>{StrBegin="NETSDK1098: "}</note>
+      </trans-unit>
       <trans-unit id="CannotInferTargetFrameworkIdentifierAndVersion">
         <source>NETSDK1013: The TargetFramework value '{0}' was not recognized. It may be misspelled. If not, then the TargetFrameworkIdentifier and/or TargetFrameworkVersion properties must be specified explicitly.</source>
         <target state="translated">NETSDK1013: La valeur TargetFramework '{0}' n'a pas été reconnue. Elle est peut-être mal orthographiée. Sinon, vous devez spécifier explicitement les propriétés TargetFrameworkIdentifier et/ou TargetFrameworkVersion.</target>
@@ -485,16 +495,6 @@ The following are names of parameters or literal values and should not be transl
         <source>NETSDK1057: You are using a preview version of .NET Core. See: https://aka.ms/dotnet-core-preview</source>
         <target state="translated">NETSDK1057 : Vous utilisez une préversion de .NET Core. Voir : https://aka.ms/dotnet-core-preview</target>
         <note>{StrBegin="NETSDK1057: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotHaveSingleFileWithoutRuntimeIdentifier">
-        <source>NETSDK1093: It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. Please either specify a RuntimeIdentifier or set PublishSingleFile to false.</source>
-        <target state="new">NETSDK1093: It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. Please either specify a RuntimeIdentifier or set PublishSingleFile to false.</target>
-        <note>{StrBegin="NETSDK1093: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotHaveSingleFileWithoutAppHost">
-        <source>NETSDK1094: Applications published to a single-file are required to use the application host. Please either set PublishSingleFile to false or set UseAppHost to true.</source>
-        <target state="new">NETSDK1094: Applications published to a single-file are required to use the application host. Please either set PublishSingleFile to false or set UseAppHost to true.</target>
-        <note>{StrBegin="NETSDK1094: "}</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
@@ -486,6 +486,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1057 : Vous utilisez une préversion de .NET Core. Voir : https://aka.ms/dotnet-core-preview</target>
         <note>{StrBegin="NETSDK1057: "}</note>
       </trans-unit>
+      <trans-unit id="CannotHaveSingleFileWithoutRuntimeIdentifier">
+        <source>NETSDK1093: It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. Please either specify a RuntimeIdentifier or set PublishSingleFile to false.</source>
+        <target state="new">NETSDK1093: It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. Please either specify a RuntimeIdentifier or set PublishSingleFile to false.</target>
+        <note>{StrBegin="NETSDK1093: "}</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
@@ -491,6 +491,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="new">NETSDK1093: It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. Please either specify a RuntimeIdentifier or set PublishSingleFile to false.</target>
         <note>{StrBegin="NETSDK1093: "}</note>
       </trans-unit>
+      <trans-unit id="CannotHaveSingleFileWithoutAppHost">
+        <source>NETSDK1094: Applications published to a single-file are required to use the application host. Please either set PublishSingleFile to false or set UseAppHost to true.</source>
+        <target state="new">NETSDK1094: Applications published to a single-file are required to use the application host. Please either set PublishSingleFile to false or set UseAppHost to true.</target>
+        <note>{StrBegin="NETSDK1094: "}</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Common/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.it.xlf
@@ -107,6 +107,16 @@
         <target state="translated">NETSDK1031: non è possibile compilare o pubblicare un'applicazione indipendente senza specificare un elemento RuntimeIdentifier. Specificare un elemento RuntimeIdentifier o impostare SelfContained su false.</target>
         <note>{StrBegin="NETSDK1031: "}</note>
       </trans-unit>
+      <trans-unit id="CannotHaveSingleFileWithoutRuntimeIdentifier">
+        <source>NETSDK1097: It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. Please either specify a RuntimeIdentifier or set PublishSingleFile to false.</source>
+        <target state="new">NETSDK1097: It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. Please either specify a RuntimeIdentifier or set PublishSingleFile to false.</target>
+        <note>{StrBegin="NETSDK1097: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotHaveSingleFileWithoutAppHost">
+        <source>NETSDK1098: Applications published to a single-file are required to use the application host. Please either set PublishSingleFile to false or set UseAppHost to true.</source>
+        <target state="new">NETSDK1098: Applications published to a single-file are required to use the application host. Please either set PublishSingleFile to false or set UseAppHost to true.</target>
+        <note>{StrBegin="NETSDK1098: "}</note>
+      </trans-unit>
       <trans-unit id="CannotInferTargetFrameworkIdentifierAndVersion">
         <source>NETSDK1013: The TargetFramework value '{0}' was not recognized. It may be misspelled. If not, then the TargetFrameworkIdentifier and/or TargetFrameworkVersion properties must be specified explicitly.</source>
         <target state="translated">NETSDK1013: il valore {0}' di TargetFramework non è stato riconosciuto. È possibile che sia stato digitato in modo errato. In caso contrario, le proprietà TargetFrameworkIdentifier e/o TargetFrameworkVersion devono essere specificate in modo esplicito.</target>
@@ -485,16 +495,6 @@ The following are names of parameters or literal values and should not be transl
         <source>NETSDK1057: You are using a preview version of .NET Core. See: https://aka.ms/dotnet-core-preview</source>
         <target state="translated">NETSDK1057: si sta usando una versione in anteprima di .NET Core. Vedere https://aka.ms/dotnet-core-preview</target>
         <note>{StrBegin="NETSDK1057: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotHaveSingleFileWithoutRuntimeIdentifier">
-        <source>NETSDK1093: It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. Please either specify a RuntimeIdentifier or set PublishSingleFile to false.</source>
-        <target state="new">NETSDK1093: It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. Please either specify a RuntimeIdentifier or set PublishSingleFile to false.</target>
-        <note>{StrBegin="NETSDK1093: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotHaveSingleFileWithoutAppHost">
-        <source>NETSDK1094: Applications published to a single-file are required to use the application host. Please either set PublishSingleFile to false or set UseAppHost to true.</source>
-        <target state="new">NETSDK1094: Applications published to a single-file are required to use the application host. Please either set PublishSingleFile to false or set UseAppHost to true.</target>
-        <note>{StrBegin="NETSDK1094: "}</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Tasks/Common/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.it.xlf
@@ -486,6 +486,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1057: si sta usando una versione in anteprima di .NET Core. Vedere https://aka.ms/dotnet-core-preview</target>
         <note>{StrBegin="NETSDK1057: "}</note>
       </trans-unit>
+      <trans-unit id="CannotHaveSingleFileWithoutRuntimeIdentifier">
+        <source>NETSDK1093: It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. Please either specify a RuntimeIdentifier or set PublishSingleFile to false.</source>
+        <target state="new">NETSDK1093: It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. Please either specify a RuntimeIdentifier or set PublishSingleFile to false.</target>
+        <note>{StrBegin="NETSDK1093: "}</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Common/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.it.xlf
@@ -491,6 +491,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="new">NETSDK1093: It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. Please either specify a RuntimeIdentifier or set PublishSingleFile to false.</target>
         <note>{StrBegin="NETSDK1093: "}</note>
       </trans-unit>
+      <trans-unit id="CannotHaveSingleFileWithoutAppHost">
+        <source>NETSDK1094: Applications published to a single-file are required to use the application host. Please either set PublishSingleFile to false or set UseAppHost to true.</source>
+        <target state="new">NETSDK1094: Applications published to a single-file are required to use the application host. Please either set PublishSingleFile to false or set UseAppHost to true.</target>
+        <note>{StrBegin="NETSDK1094: "}</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
@@ -107,6 +107,16 @@
         <target state="translated">NETSDK1031: RuntimeIdentifier を指定せずに自己完結型アプリケーションをビルドおよび発行することはサポートされていません。RuntimeIdentifier を指定するか SelfContained を false に設定してください。</target>
         <note>{StrBegin="NETSDK1031: "}</note>
       </trans-unit>
+      <trans-unit id="CannotHaveSingleFileWithoutRuntimeIdentifier">
+        <source>NETSDK1097: It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. Please either specify a RuntimeIdentifier or set PublishSingleFile to false.</source>
+        <target state="new">NETSDK1097: It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. Please either specify a RuntimeIdentifier or set PublishSingleFile to false.</target>
+        <note>{StrBegin="NETSDK1097: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotHaveSingleFileWithoutAppHost">
+        <source>NETSDK1098: Applications published to a single-file are required to use the application host. Please either set PublishSingleFile to false or set UseAppHost to true.</source>
+        <target state="new">NETSDK1098: Applications published to a single-file are required to use the application host. Please either set PublishSingleFile to false or set UseAppHost to true.</target>
+        <note>{StrBegin="NETSDK1098: "}</note>
+      </trans-unit>
       <trans-unit id="CannotInferTargetFrameworkIdentifierAndVersion">
         <source>NETSDK1013: The TargetFramework value '{0}' was not recognized. It may be misspelled. If not, then the TargetFrameworkIdentifier and/or TargetFrameworkVersion properties must be specified explicitly.</source>
         <target state="translated">NETSDK1013: TargetFramework 値 '{0}' が認識されませんでした。つづりが間違っている可能性があります。間違っていない場合は、TargetFrameworkIdentifier または TargetFrameworkVersion プロパティ (あるいはその両方) を明示的に指定する必要があります。</target>
@@ -485,16 +495,6 @@ The following are names of parameters or literal values and should not be transl
         <source>NETSDK1057: You are using a preview version of .NET Core. See: https://aka.ms/dotnet-core-preview</source>
         <target state="translated">NETSDK1057: プレビュー版の .NET Core を使用しています。https://aka.ms/dotnet-core-preview をご覧ください</target>
         <note>{StrBegin="NETSDK1057: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotHaveSingleFileWithoutRuntimeIdentifier">
-        <source>NETSDK1093: It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. Please either specify a RuntimeIdentifier or set PublishSingleFile to false.</source>
-        <target state="new">NETSDK1093: It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. Please either specify a RuntimeIdentifier or set PublishSingleFile to false.</target>
-        <note>{StrBegin="NETSDK1093: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotHaveSingleFileWithoutAppHost">
-        <source>NETSDK1094: Applications published to a single-file are required to use the application host. Please either set PublishSingleFile to false or set UseAppHost to true.</source>
-        <target state="new">NETSDK1094: Applications published to a single-file are required to use the application host. Please either set PublishSingleFile to false or set UseAppHost to true.</target>
-        <note>{StrBegin="NETSDK1094: "}</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
@@ -486,6 +486,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1057: プレビュー版の .NET Core を使用しています。https://aka.ms/dotnet-core-preview をご覧ください</target>
         <note>{StrBegin="NETSDK1057: "}</note>
       </trans-unit>
+      <trans-unit id="CannotHaveSingleFileWithoutRuntimeIdentifier">
+        <source>NETSDK1093: It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. Please either specify a RuntimeIdentifier or set PublishSingleFile to false.</source>
+        <target state="new">NETSDK1093: It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. Please either specify a RuntimeIdentifier or set PublishSingleFile to false.</target>
+        <note>{StrBegin="NETSDK1093: "}</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
@@ -491,6 +491,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="new">NETSDK1093: It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. Please either specify a RuntimeIdentifier or set PublishSingleFile to false.</target>
         <note>{StrBegin="NETSDK1093: "}</note>
       </trans-unit>
+      <trans-unit id="CannotHaveSingleFileWithoutAppHost">
+        <source>NETSDK1094: Applications published to a single-file are required to use the application host. Please either set PublishSingleFile to false or set UseAppHost to true.</source>
+        <target state="new">NETSDK1094: Applications published to a single-file are required to use the application host. Please either set PublishSingleFile to false or set UseAppHost to true.</target>
+        <note>{StrBegin="NETSDK1094: "}</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
@@ -107,6 +107,16 @@
         <target state="translated">NETSDK1031: RuntimeIdentifier를 지정하지 않으면 자체 포함 애플리케이션의 빌드 또는 게시가 지원되지 않습니다. RuntimeIdentifier를 지정하거나 SelfContained를 false로 설정하세요.</target>
         <note>{StrBegin="NETSDK1031: "}</note>
       </trans-unit>
+      <trans-unit id="CannotHaveSingleFileWithoutRuntimeIdentifier">
+        <source>NETSDK1097: It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. Please either specify a RuntimeIdentifier or set PublishSingleFile to false.</source>
+        <target state="new">NETSDK1097: It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. Please either specify a RuntimeIdentifier or set PublishSingleFile to false.</target>
+        <note>{StrBegin="NETSDK1097: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotHaveSingleFileWithoutAppHost">
+        <source>NETSDK1098: Applications published to a single-file are required to use the application host. Please either set PublishSingleFile to false or set UseAppHost to true.</source>
+        <target state="new">NETSDK1098: Applications published to a single-file are required to use the application host. Please either set PublishSingleFile to false or set UseAppHost to true.</target>
+        <note>{StrBegin="NETSDK1098: "}</note>
+      </trans-unit>
       <trans-unit id="CannotInferTargetFrameworkIdentifierAndVersion">
         <source>NETSDK1013: The TargetFramework value '{0}' was not recognized. It may be misspelled. If not, then the TargetFrameworkIdentifier and/or TargetFrameworkVersion properties must be specified explicitly.</source>
         <target state="translated">NETSDK1013: TargetFramework 값 '{0}'을(를) 인식하지 못했습니다. 철자가 틀렸을 수 있습니다. 그렇지 않은 경우 TargetFrameworkIdentifier 및/또는 TargetFrameworkVersion 속성을 명시적으로 지정해야 합니다.</target>
@@ -485,16 +495,6 @@ The following are names of parameters or literal values and should not be transl
         <source>NETSDK1057: You are using a preview version of .NET Core. See: https://aka.ms/dotnet-core-preview</source>
         <target state="translated">NETSDK1057: .NET Core의 미리 보기 버전을 사용 중입니다. 참조: https://aka.ms/dotnet-core-preview</target>
         <note>{StrBegin="NETSDK1057: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotHaveSingleFileWithoutRuntimeIdentifier">
-        <source>NETSDK1093: It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. Please either specify a RuntimeIdentifier or set PublishSingleFile to false.</source>
-        <target state="new">NETSDK1093: It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. Please either specify a RuntimeIdentifier or set PublishSingleFile to false.</target>
-        <note>{StrBegin="NETSDK1093: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotHaveSingleFileWithoutAppHost">
-        <source>NETSDK1094: Applications published to a single-file are required to use the application host. Please either set PublishSingleFile to false or set UseAppHost to true.</source>
-        <target state="new">NETSDK1094: Applications published to a single-file are required to use the application host. Please either set PublishSingleFile to false or set UseAppHost to true.</target>
-        <note>{StrBegin="NETSDK1094: "}</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
@@ -486,6 +486,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1057: .NET Core의 미리 보기 버전을 사용 중입니다. 참조: https://aka.ms/dotnet-core-preview</target>
         <note>{StrBegin="NETSDK1057: "}</note>
       </trans-unit>
+      <trans-unit id="CannotHaveSingleFileWithoutRuntimeIdentifier">
+        <source>NETSDK1093: It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. Please either specify a RuntimeIdentifier or set PublishSingleFile to false.</source>
+        <target state="new">NETSDK1093: It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. Please either specify a RuntimeIdentifier or set PublishSingleFile to false.</target>
+        <note>{StrBegin="NETSDK1093: "}</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
@@ -491,6 +491,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="new">NETSDK1093: It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. Please either specify a RuntimeIdentifier or set PublishSingleFile to false.</target>
         <note>{StrBegin="NETSDK1093: "}</note>
       </trans-unit>
+      <trans-unit id="CannotHaveSingleFileWithoutAppHost">
+        <source>NETSDK1094: Applications published to a single-file are required to use the application host. Please either set PublishSingleFile to false or set UseAppHost to true.</source>
+        <target state="new">NETSDK1094: Applications published to a single-file are required to use the application host. Please either set PublishSingleFile to false or set UseAppHost to true.</target>
+        <note>{StrBegin="NETSDK1094: "}</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
@@ -486,6 +486,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1057: Korzystasz z wersji zapoznawczej platformy .NET Core. Zobacz: https://aka.ms/dotnet-core-preview</target>
         <note>{StrBegin="NETSDK1057: "}</note>
       </trans-unit>
+      <trans-unit id="CannotHaveSingleFileWithoutRuntimeIdentifier">
+        <source>NETSDK1093: It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. Please either specify a RuntimeIdentifier or set PublishSingleFile to false.</source>
+        <target state="new">NETSDK1093: It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. Please either specify a RuntimeIdentifier or set PublishSingleFile to false.</target>
+        <note>{StrBegin="NETSDK1093: "}</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
@@ -107,6 +107,16 @@
         <target state="translated">NETSDK1031: Kompilowanie i publikowanie aplikacji autonomicznej bez określania elementu RuntimeIdentifier nie jest obsługiwane. Określ element RuntimeIdentifier lub ustaw wartość false dla elementu SelfContained.</target>
         <note>{StrBegin="NETSDK1031: "}</note>
       </trans-unit>
+      <trans-unit id="CannotHaveSingleFileWithoutRuntimeIdentifier">
+        <source>NETSDK1097: It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. Please either specify a RuntimeIdentifier or set PublishSingleFile to false.</source>
+        <target state="new">NETSDK1097: It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. Please either specify a RuntimeIdentifier or set PublishSingleFile to false.</target>
+        <note>{StrBegin="NETSDK1097: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotHaveSingleFileWithoutAppHost">
+        <source>NETSDK1098: Applications published to a single-file are required to use the application host. Please either set PublishSingleFile to false or set UseAppHost to true.</source>
+        <target state="new">NETSDK1098: Applications published to a single-file are required to use the application host. Please either set PublishSingleFile to false or set UseAppHost to true.</target>
+        <note>{StrBegin="NETSDK1098: "}</note>
+      </trans-unit>
       <trans-unit id="CannotInferTargetFrameworkIdentifierAndVersion">
         <source>NETSDK1013: The TargetFramework value '{0}' was not recognized. It may be misspelled. If not, then the TargetFrameworkIdentifier and/or TargetFrameworkVersion properties must be specified explicitly.</source>
         <target state="translated">NETSDK1013: Nie rozpoznano wartości „{0}” elementu TargetFramework. Być może wpisano ją niepoprawnie. Jeśli nie, należy jawnie określić właściwości TargetFrameworkIdentifier i/lub TargetFrameworkVersion.</target>
@@ -485,16 +495,6 @@ The following are names of parameters or literal values and should not be transl
         <source>NETSDK1057: You are using a preview version of .NET Core. See: https://aka.ms/dotnet-core-preview</source>
         <target state="translated">NETSDK1057: Korzystasz z wersji zapoznawczej platformy .NET Core. Zobacz: https://aka.ms/dotnet-core-preview</target>
         <note>{StrBegin="NETSDK1057: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotHaveSingleFileWithoutRuntimeIdentifier">
-        <source>NETSDK1093: It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. Please either specify a RuntimeIdentifier or set PublishSingleFile to false.</source>
-        <target state="new">NETSDK1093: It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. Please either specify a RuntimeIdentifier or set PublishSingleFile to false.</target>
-        <note>{StrBegin="NETSDK1093: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotHaveSingleFileWithoutAppHost">
-        <source>NETSDK1094: Applications published to a single-file are required to use the application host. Please either set PublishSingleFile to false or set UseAppHost to true.</source>
-        <target state="new">NETSDK1094: Applications published to a single-file are required to use the application host. Please either set PublishSingleFile to false or set UseAppHost to true.</target>
-        <note>{StrBegin="NETSDK1094: "}</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
@@ -491,6 +491,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="new">NETSDK1093: It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. Please either specify a RuntimeIdentifier or set PublishSingleFile to false.</target>
         <note>{StrBegin="NETSDK1093: "}</note>
       </trans-unit>
+      <trans-unit id="CannotHaveSingleFileWithoutAppHost">
+        <source>NETSDK1094: Applications published to a single-file are required to use the application host. Please either set PublishSingleFile to false or set UseAppHost to true.</source>
+        <target state="new">NETSDK1094: Applications published to a single-file are required to use the application host. Please either set PublishSingleFile to false or set UseAppHost to true.</target>
+        <note>{StrBegin="NETSDK1094: "}</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
@@ -486,6 +486,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1057: você está usando uma versão prévia do .NET Core. Consulte: https://aka.ms/dotnet-core-preview</target>
         <note>{StrBegin="NETSDK1057: "}</note>
       </trans-unit>
+      <trans-unit id="CannotHaveSingleFileWithoutRuntimeIdentifier">
+        <source>NETSDK1093: It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. Please either specify a RuntimeIdentifier or set PublishSingleFile to false.</source>
+        <target state="new">NETSDK1093: It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. Please either specify a RuntimeIdentifier or set PublishSingleFile to false.</target>
+        <note>{StrBegin="NETSDK1093: "}</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
@@ -107,6 +107,16 @@
         <target state="translated">NETSDK1031: Não há suporte para criar ou publicar um aplicativo autossuficiente sem especificar um RuntimeIdentifier. Especifique um RuntimeIdentifier ou defina SelfContained como falso.</target>
         <note>{StrBegin="NETSDK1031: "}</note>
       </trans-unit>
+      <trans-unit id="CannotHaveSingleFileWithoutRuntimeIdentifier">
+        <source>NETSDK1097: It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. Please either specify a RuntimeIdentifier or set PublishSingleFile to false.</source>
+        <target state="new">NETSDK1097: It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. Please either specify a RuntimeIdentifier or set PublishSingleFile to false.</target>
+        <note>{StrBegin="NETSDK1097: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotHaveSingleFileWithoutAppHost">
+        <source>NETSDK1098: Applications published to a single-file are required to use the application host. Please either set PublishSingleFile to false or set UseAppHost to true.</source>
+        <target state="new">NETSDK1098: Applications published to a single-file are required to use the application host. Please either set PublishSingleFile to false or set UseAppHost to true.</target>
+        <note>{StrBegin="NETSDK1098: "}</note>
+      </trans-unit>
       <trans-unit id="CannotInferTargetFrameworkIdentifierAndVersion">
         <source>NETSDK1013: The TargetFramework value '{0}' was not recognized. It may be misspelled. If not, then the TargetFrameworkIdentifier and/or TargetFrameworkVersion properties must be specified explicitly.</source>
         <target state="translated">NETSDK1013: O valor '{0}' do TargetFramework não foi reconhecido. Ele pode ter sido escrito com ortografia incorreta. Caso contrário, as propriedades TargetFrameworkIdentifier e/ou TargetFrameworkVersion precisarão ser especificadas explicitamente.</target>
@@ -485,16 +495,6 @@ The following are names of parameters or literal values and should not be transl
         <source>NETSDK1057: You are using a preview version of .NET Core. See: https://aka.ms/dotnet-core-preview</source>
         <target state="translated">NETSDK1057: você está usando uma versão prévia do .NET Core. Consulte: https://aka.ms/dotnet-core-preview</target>
         <note>{StrBegin="NETSDK1057: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotHaveSingleFileWithoutRuntimeIdentifier">
-        <source>NETSDK1093: It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. Please either specify a RuntimeIdentifier or set PublishSingleFile to false.</source>
-        <target state="new">NETSDK1093: It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. Please either specify a RuntimeIdentifier or set PublishSingleFile to false.</target>
-        <note>{StrBegin="NETSDK1093: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotHaveSingleFileWithoutAppHost">
-        <source>NETSDK1094: Applications published to a single-file are required to use the application host. Please either set PublishSingleFile to false or set UseAppHost to true.</source>
-        <target state="new">NETSDK1094: Applications published to a single-file are required to use the application host. Please either set PublishSingleFile to false or set UseAppHost to true.</target>
-        <note>{StrBegin="NETSDK1094: "}</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
@@ -491,6 +491,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="new">NETSDK1093: It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. Please either specify a RuntimeIdentifier or set PublishSingleFile to false.</target>
         <note>{StrBegin="NETSDK1093: "}</note>
       </trans-unit>
+      <trans-unit id="CannotHaveSingleFileWithoutAppHost">
+        <source>NETSDK1094: Applications published to a single-file are required to use the application host. Please either set PublishSingleFile to false or set UseAppHost to true.</source>
+        <target state="new">NETSDK1094: Applications published to a single-file are required to use the application host. Please either set PublishSingleFile to false or set UseAppHost to true.</target>
+        <note>{StrBegin="NETSDK1094: "}</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
@@ -486,6 +486,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1057: Вы используете предварительную версию .NET Core. Дополнительные сведения см. на странице https://aka.ms/dotnet-core-preview</target>
         <note>{StrBegin="NETSDK1057: "}</note>
       </trans-unit>
+      <trans-unit id="CannotHaveSingleFileWithoutRuntimeIdentifier">
+        <source>NETSDK1093: It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. Please either specify a RuntimeIdentifier or set PublishSingleFile to false.</source>
+        <target state="new">NETSDK1093: It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. Please either specify a RuntimeIdentifier or set PublishSingleFile to false.</target>
+        <note>{StrBegin="NETSDK1093: "}</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
@@ -107,6 +107,16 @@
         <target state="translated">NETSDK1031: сборка или публикация автономного приложения без указания RuntimeIdentifier не поддерживается. Укажите RuntimeIdentifier или присвойте свойству SelfContained значение "false".</target>
         <note>{StrBegin="NETSDK1031: "}</note>
       </trans-unit>
+      <trans-unit id="CannotHaveSingleFileWithoutRuntimeIdentifier">
+        <source>NETSDK1097: It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. Please either specify a RuntimeIdentifier or set PublishSingleFile to false.</source>
+        <target state="new">NETSDK1097: It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. Please either specify a RuntimeIdentifier or set PublishSingleFile to false.</target>
+        <note>{StrBegin="NETSDK1097: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotHaveSingleFileWithoutAppHost">
+        <source>NETSDK1098: Applications published to a single-file are required to use the application host. Please either set PublishSingleFile to false or set UseAppHost to true.</source>
+        <target state="new">NETSDK1098: Applications published to a single-file are required to use the application host. Please either set PublishSingleFile to false or set UseAppHost to true.</target>
+        <note>{StrBegin="NETSDK1098: "}</note>
+      </trans-unit>
       <trans-unit id="CannotInferTargetFrameworkIdentifierAndVersion">
         <source>NETSDK1013: The TargetFramework value '{0}' was not recognized. It may be misspelled. If not, then the TargetFrameworkIdentifier and/or TargetFrameworkVersion properties must be specified explicitly.</source>
         <target state="translated">NETSDK1013: значение "{0}" в TargetFramework не распознано. Возможно, оно содержит опечатку. Если это не так, задайте свойства TargetFrameworkIdentifier и (или) TargetFrameworkVersion явным образом.</target>
@@ -485,16 +495,6 @@ The following are names of parameters or literal values and should not be transl
         <source>NETSDK1057: You are using a preview version of .NET Core. See: https://aka.ms/dotnet-core-preview</source>
         <target state="translated">NETSDK1057: Вы используете предварительную версию .NET Core. Дополнительные сведения см. на странице https://aka.ms/dotnet-core-preview</target>
         <note>{StrBegin="NETSDK1057: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotHaveSingleFileWithoutRuntimeIdentifier">
-        <source>NETSDK1093: It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. Please either specify a RuntimeIdentifier or set PublishSingleFile to false.</source>
-        <target state="new">NETSDK1093: It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. Please either specify a RuntimeIdentifier or set PublishSingleFile to false.</target>
-        <note>{StrBegin="NETSDK1093: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotHaveSingleFileWithoutAppHost">
-        <source>NETSDK1094: Applications published to a single-file are required to use the application host. Please either set PublishSingleFile to false or set UseAppHost to true.</source>
-        <target state="new">NETSDK1094: Applications published to a single-file are required to use the application host. Please either set PublishSingleFile to false or set UseAppHost to true.</target>
-        <note>{StrBegin="NETSDK1094: "}</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
@@ -491,6 +491,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="new">NETSDK1093: It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. Please either specify a RuntimeIdentifier or set PublishSingleFile to false.</target>
         <note>{StrBegin="NETSDK1093: "}</note>
       </trans-unit>
+      <trans-unit id="CannotHaveSingleFileWithoutAppHost">
+        <source>NETSDK1094: Applications published to a single-file are required to use the application host. Please either set PublishSingleFile to false or set UseAppHost to true.</source>
+        <target state="new">NETSDK1094: Applications published to a single-file are required to use the application host. Please either set PublishSingleFile to false or set UseAppHost to true.</target>
+        <note>{StrBegin="NETSDK1094: "}</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
@@ -486,6 +486,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1057: .NET Core'un önizleme sürümünü kullanıyorsunuz. Bkz. https://aka.ms/dotnet-core-preview</target>
         <note>{StrBegin="NETSDK1057: "}</note>
       </trans-unit>
+      <trans-unit id="CannotHaveSingleFileWithoutRuntimeIdentifier">
+        <source>NETSDK1093: It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. Please either specify a RuntimeIdentifier or set PublishSingleFile to false.</source>
+        <target state="new">NETSDK1093: It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. Please either specify a RuntimeIdentifier or set PublishSingleFile to false.</target>
+        <note>{StrBegin="NETSDK1093: "}</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
@@ -107,6 +107,16 @@
         <target state="translated">NETSDK1031: Bir RuntimeIdentifier belirtilmeden, bağımsız çalışan uygulamanın derlenmesi veya yayımlanması desteklenmez. Lütfen bir RuntimeIdentifier belirtin veya SelfContained değerini false olarak ayarlayın.</target>
         <note>{StrBegin="NETSDK1031: "}</note>
       </trans-unit>
+      <trans-unit id="CannotHaveSingleFileWithoutRuntimeIdentifier">
+        <source>NETSDK1097: It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. Please either specify a RuntimeIdentifier or set PublishSingleFile to false.</source>
+        <target state="new">NETSDK1097: It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. Please either specify a RuntimeIdentifier or set PublishSingleFile to false.</target>
+        <note>{StrBegin="NETSDK1097: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotHaveSingleFileWithoutAppHost">
+        <source>NETSDK1098: Applications published to a single-file are required to use the application host. Please either set PublishSingleFile to false or set UseAppHost to true.</source>
+        <target state="new">NETSDK1098: Applications published to a single-file are required to use the application host. Please either set PublishSingleFile to false or set UseAppHost to true.</target>
+        <note>{StrBegin="NETSDK1098: "}</note>
+      </trans-unit>
       <trans-unit id="CannotInferTargetFrameworkIdentifierAndVersion">
         <source>NETSDK1013: The TargetFramework value '{0}' was not recognized. It may be misspelled. If not, then the TargetFrameworkIdentifier and/or TargetFrameworkVersion properties must be specified explicitly.</source>
         <target state="translated">NETSDK1013: '{0}' TargetFramework değeri tanınmadı. Yanlış yazılmış olabilir. Sorun bundan kaynaklanmıyorsa, TargetFrameworkIdentifier ve/veya TargetFrameworkVersion özelliklerinin açık bir şekilde belirtilmesi gerekir.</target>
@@ -485,16 +495,6 @@ The following are names of parameters or literal values and should not be transl
         <source>NETSDK1057: You are using a preview version of .NET Core. See: https://aka.ms/dotnet-core-preview</source>
         <target state="translated">NETSDK1057: .NET Core'un önizleme sürümünü kullanıyorsunuz. Bkz. https://aka.ms/dotnet-core-preview</target>
         <note>{StrBegin="NETSDK1057: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotHaveSingleFileWithoutRuntimeIdentifier">
-        <source>NETSDK1093: It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. Please either specify a RuntimeIdentifier or set PublishSingleFile to false.</source>
-        <target state="new">NETSDK1093: It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. Please either specify a RuntimeIdentifier or set PublishSingleFile to false.</target>
-        <note>{StrBegin="NETSDK1093: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotHaveSingleFileWithoutAppHost">
-        <source>NETSDK1094: Applications published to a single-file are required to use the application host. Please either set PublishSingleFile to false or set UseAppHost to true.</source>
-        <target state="new">NETSDK1094: Applications published to a single-file are required to use the application host. Please either set PublishSingleFile to false or set UseAppHost to true.</target>
-        <note>{StrBegin="NETSDK1094: "}</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
@@ -491,6 +491,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="new">NETSDK1093: It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. Please either specify a RuntimeIdentifier or set PublishSingleFile to false.</target>
         <note>{StrBegin="NETSDK1093: "}</note>
       </trans-unit>
+      <trans-unit id="CannotHaveSingleFileWithoutAppHost">
+        <source>NETSDK1094: Applications published to a single-file are required to use the application host. Please either set PublishSingleFile to false or set UseAppHost to true.</source>
+        <target state="new">NETSDK1094: Applications published to a single-file are required to use the application host. Please either set PublishSingleFile to false or set UseAppHost to true.</target>
+        <note>{StrBegin="NETSDK1094: "}</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
@@ -107,6 +107,16 @@
         <target state="translated">NETSDK1031: 不可在未指定 RuntimeIdentifier 的情况下生成或发布自包含应用程序。请指定 RuntimeIdentifier 或将 SelfContained 设置为 false。</target>
         <note>{StrBegin="NETSDK1031: "}</note>
       </trans-unit>
+      <trans-unit id="CannotHaveSingleFileWithoutRuntimeIdentifier">
+        <source>NETSDK1097: It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. Please either specify a RuntimeIdentifier or set PublishSingleFile to false.</source>
+        <target state="new">NETSDK1097: It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. Please either specify a RuntimeIdentifier or set PublishSingleFile to false.</target>
+        <note>{StrBegin="NETSDK1097: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotHaveSingleFileWithoutAppHost">
+        <source>NETSDK1098: Applications published to a single-file are required to use the application host. Please either set PublishSingleFile to false or set UseAppHost to true.</source>
+        <target state="new">NETSDK1098: Applications published to a single-file are required to use the application host. Please either set PublishSingleFile to false or set UseAppHost to true.</target>
+        <note>{StrBegin="NETSDK1098: "}</note>
+      </trans-unit>
       <trans-unit id="CannotInferTargetFrameworkIdentifierAndVersion">
         <source>NETSDK1013: The TargetFramework value '{0}' was not recognized. It may be misspelled. If not, then the TargetFrameworkIdentifier and/or TargetFrameworkVersion properties must be specified explicitly.</source>
         <target state="translated">NETSDK1013: 未识别 TargetFramework 值“{0}”。可能是因为拼写错误。如果拼写正确，必须显式指定 TargetFrameworkIdentifier 和/或 TargetFrameworkVersion 属性。</target>
@@ -485,16 +495,6 @@ The following are names of parameters or literal values and should not be transl
         <source>NETSDK1057: You are using a preview version of .NET Core. See: https://aka.ms/dotnet-core-preview</source>
         <target state="translated">NETSDK1057: 你正在使用 .NET Core 的预览版。请查看 https://aka.ms/dotnet-core-preview</target>
         <note>{StrBegin="NETSDK1057: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotHaveSingleFileWithoutRuntimeIdentifier">
-        <source>NETSDK1093: It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. Please either specify a RuntimeIdentifier or set PublishSingleFile to false.</source>
-        <target state="new">NETSDK1093: It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. Please either specify a RuntimeIdentifier or set PublishSingleFile to false.</target>
-        <note>{StrBegin="NETSDK1093: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotHaveSingleFileWithoutAppHost">
-        <source>NETSDK1094: Applications published to a single-file are required to use the application host. Please either set PublishSingleFile to false or set UseAppHost to true.</source>
-        <target state="new">NETSDK1094: Applications published to a single-file are required to use the application host. Please either set PublishSingleFile to false or set UseAppHost to true.</target>
-        <note>{StrBegin="NETSDK1094: "}</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
@@ -486,6 +486,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1057: 你正在使用 .NET Core 的预览版。请查看 https://aka.ms/dotnet-core-preview</target>
         <note>{StrBegin="NETSDK1057: "}</note>
       </trans-unit>
+      <trans-unit id="CannotHaveSingleFileWithoutRuntimeIdentifier">
+        <source>NETSDK1093: It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. Please either specify a RuntimeIdentifier or set PublishSingleFile to false.</source>
+        <target state="new">NETSDK1093: It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. Please either specify a RuntimeIdentifier or set PublishSingleFile to false.</target>
+        <note>{StrBegin="NETSDK1093: "}</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
@@ -491,6 +491,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="new">NETSDK1093: It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. Please either specify a RuntimeIdentifier or set PublishSingleFile to false.</target>
         <note>{StrBegin="NETSDK1093: "}</note>
       </trans-unit>
+      <trans-unit id="CannotHaveSingleFileWithoutAppHost">
+        <source>NETSDK1094: Applications published to a single-file are required to use the application host. Please either set PublishSingleFile to false or set UseAppHost to true.</source>
+        <target state="new">NETSDK1094: Applications published to a single-file are required to use the application host. Please either set PublishSingleFile to false or set UseAppHost to true.</target>
+        <note>{StrBegin="NETSDK1094: "}</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
@@ -486,6 +486,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1057: 您使用的是 .NET Core 預覽版。請參閱: https://aka.ms/dotnet-core-preview</target>
         <note>{StrBegin="NETSDK1057: "}</note>
       </trans-unit>
+      <trans-unit id="CannotHaveSingleFileWithoutRuntimeIdentifier">
+        <source>NETSDK1093: It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. Please either specify a RuntimeIdentifier or set PublishSingleFile to false.</source>
+        <target state="new">NETSDK1093: It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. Please either specify a RuntimeIdentifier or set PublishSingleFile to false.</target>
+        <note>{StrBegin="NETSDK1093: "}</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
@@ -107,6 +107,16 @@
         <target state="translated">NETSDK1031: 不支援在未指定 RuntimeIdentifier 的情況下，建置或發行獨立的應用程式。請指定 RuntimeIdentifier，或將 SelfContained 設為 False。</target>
         <note>{StrBegin="NETSDK1031: "}</note>
       </trans-unit>
+      <trans-unit id="CannotHaveSingleFileWithoutRuntimeIdentifier">
+        <source>NETSDK1097: It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. Please either specify a RuntimeIdentifier or set PublishSingleFile to false.</source>
+        <target state="new">NETSDK1097: It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. Please either specify a RuntimeIdentifier or set PublishSingleFile to false.</target>
+        <note>{StrBegin="NETSDK1097: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotHaveSingleFileWithoutAppHost">
+        <source>NETSDK1098: Applications published to a single-file are required to use the application host. Please either set PublishSingleFile to false or set UseAppHost to true.</source>
+        <target state="new">NETSDK1098: Applications published to a single-file are required to use the application host. Please either set PublishSingleFile to false or set UseAppHost to true.</target>
+        <note>{StrBegin="NETSDK1098: "}</note>
+      </trans-unit>
       <trans-unit id="CannotInferTargetFrameworkIdentifierAndVersion">
         <source>NETSDK1013: The TargetFramework value '{0}' was not recognized. It may be misspelled. If not, then the TargetFrameworkIdentifier and/or TargetFrameworkVersion properties must be specified explicitly.</source>
         <target state="translated">NETSDK1013: 無法辨識 TargetFramework 值 '{0}'。拼字可能有誤。若非此情況，即必須明確指定 TargetFrameworkIdentifier 及 (或) TargetFrameworkVersion 屬性。</target>
@@ -485,16 +495,6 @@ The following are names of parameters or literal values and should not be transl
         <source>NETSDK1057: You are using a preview version of .NET Core. See: https://aka.ms/dotnet-core-preview</source>
         <target state="translated">NETSDK1057: 您使用的是 .NET Core 預覽版。請參閱: https://aka.ms/dotnet-core-preview</target>
         <note>{StrBegin="NETSDK1057: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotHaveSingleFileWithoutRuntimeIdentifier">
-        <source>NETSDK1093: It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. Please either specify a RuntimeIdentifier or set PublishSingleFile to false.</source>
-        <target state="new">NETSDK1093: It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. Please either specify a RuntimeIdentifier or set PublishSingleFile to false.</target>
-        <note>{StrBegin="NETSDK1093: "}</note>
-      </trans-unit>
-      <trans-unit id="CannotHaveSingleFileWithoutAppHost">
-        <source>NETSDK1094: Applications published to a single-file are required to use the application host. Please either set PublishSingleFile to false or set UseAppHost to true.</source>
-        <target state="new">NETSDK1094: Applications published to a single-file are required to use the application host. Please either set PublishSingleFile to false or set UseAppHost to true.</target>
-        <note>{StrBegin="NETSDK1094: "}</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
@@ -491,6 +491,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="new">NETSDK1093: It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. Please either specify a RuntimeIdentifier or set PublishSingleFile to false.</target>
         <note>{StrBegin="NETSDK1093: "}</note>
       </trans-unit>
+      <trans-unit id="CannotHaveSingleFileWithoutAppHost">
+        <source>NETSDK1094: Applications published to a single-file are required to use the application host. Please either set PublishSingleFile to false or set UseAppHost to true.</source>
+        <target state="new">NETSDK1094: Applications published to a single-file are required to use the application host. Please either set PublishSingleFile to false or set UseAppHost to true.</target>
+        <note>{StrBegin="NETSDK1094: "}</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Microsoft.NET.Build.Tasks.csproj
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Microsoft.NET.Build.Tasks.csproj
@@ -97,6 +97,7 @@
 
       <!-- Include some of the Sdks from the Stage 0 CLI for performance tests-->
       <Stage0SdkFile Include="$(_Stage0SdksFolder)\FSharp.NET.Sdk\**" SdkName="FSharp.NET.Sdk" />
+      <Stage0SdkFile Include="$(_Stage0SdksFolder)\Microsoft.NET.Build.Bundle\**" SdkName="Microsoft.NET.Build.Bundle" />
       <Stage0SdkFile Include="$(_Stage0SdksFolder)\Microsoft.NET.Sdk.Publish\**" SdkName="Microsoft.NET.Sdk.Publish" />
       <Stage0SdkFile Include="$(_Stage0SdksFolder)\Microsoft.NET.Sdk.Web\**" SdkName="Microsoft.NET.Sdk.Web" />
       <Stage0SdkFile Include="$(_Stage0SdksFolder)\Microsoft.NET.Sdk.Web.ProjectSystem\**" SdkName="Microsoft.NET.Sdk.Web.ProjectSystem" />

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -48,6 +48,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       PrepareForPublish;
       ComputeAndCopyFilesToPublishDirectory;
       GeneratePublishDependencyFile;
+      BundlePublishDirectory;
     </_CorePublishTargets>
   </PropertyGroup>
 
@@ -88,8 +89,12 @@ Copyright (c) .NET Foundation. All rights reserved.
     <PropertyGroup>
       <!-- Ensure any PublishDir has a trailing slash, so it can be concatenated -->
       <PublishDir Condition="!HasTrailingSlash('$(PublishDir)')">$(PublishDir)\</PublishDir>
+      
+      <PreBundlePublishDir Condition="'$(PublishSingleFile)' == 'true'">$(IntermediateOutputPath)PublishTemp\</PreBundlePublishDir>
+      <PreBundlePublishDir Condition="'$(PublishSingleFile)' != 'true'">$(PublishDir)</PreBundlePublishDir>
     </PropertyGroup>
 
+    <MakeDir Directories="$(PreBundlePublishDir)" Condition="'$(PublishSingleFile)' == 'true'" />
     <MakeDir Directories="$(PublishDir)" />
 
   </Target>
@@ -127,14 +132,14 @@ Copyright (c) .NET Foundation. All rights reserved.
   <Target Name="_CopyResolvedFilesToPublishPreserveNewest"
           DependsOnTargets="_ComputeResolvedFilesToPublishTypes"
           Inputs="@(_ResolvedFileToPublishPreserveNewest)"
-          Outputs="@(_ResolvedFileToPublishPreserveNewest->'$(PublishDir)%(RelativePath)')">
+          Outputs="@(_ResolvedFileToPublishPreserveNewest->'$(PreBundlePublishDir)%(RelativePath)')">
 
     <!--
         Not using SkipUnchangedFiles="true" because the application may want to change
         one of these files and not have an incremental build replace it.
         -->
     <Copy SourceFiles = "@(_ResolvedFileToPublishPreserveNewest)"
-          DestinationFiles="@(_ResolvedFileToPublishPreserveNewest->'$(PublishDir)%(RelativePath)')"
+          DestinationFiles="@(_ResolvedFileToPublishPreserveNewest->'$(PreBundlePublishDir)%(RelativePath)')"
           OverwriteReadOnlyFiles="$(OverwriteReadOnlyFiles)"
           Retries="$(CopyRetryCount)"
           RetryDelayMilliseconds="$(CopyRetryDelayMilliseconds)"
@@ -162,7 +167,7 @@ Copyright (c) .NET Foundation. All rights reserved.
         one of these files and not have an incremental build replace it.
         -->
     <Copy SourceFiles = "@(_ResolvedFileToPublishAlways)"
-          DestinationFiles="@(_ResolvedFileToPublishAlways->'$(PublishDir)%(RelativePath)')"
+          DestinationFiles="@(_ResolvedFileToPublishAlways->'$(PreBundlePublishDir)%(RelativePath)')"
           OverwriteReadOnlyFiles="$(OverwriteReadOnlyFiles)"
           Retries="$(CopyRetryCount)"
           RetryDelayMilliseconds="$(CopyRetryDelayMilliseconds)"
@@ -172,7 +177,12 @@ Copyright (c) .NET Foundation. All rights reserved.
       <Output TaskParameter="DestinationFiles" ItemName="FileWrites"/>
 
     </Copy>
+  </Target>
 
+  <Import Project="Sdk.props" Sdk="Microsoft.NET.Build.Bundle" />
+
+  <Target Name="BundlePublishDirectory" Condition="'$(PublishSingleFile)' == 'true'">
+    <Exec Command="$(DOTNET_HOST_PATH) $(MicrosoftDotnetBundle) --source $(PreBundlePublishDir) --apphost $(AssemblyName)$(_NativeExecutableExtension) -o $(PublishDir)" />
   </Target>
 
   <!--
@@ -786,7 +796,7 @@ Copyright (c) .NET Foundation. All rights reserved.
           Condition="'$(GenerateDependencyFile)' == 'true' and '$(_UseBuildDependencyFile)' != 'true'">
 
     <PropertyGroup>
-      <PublishDepsFilePath Condition=" '$(PublishDepsFilePath)' == '' ">$(PublishDir)$(ProjectDepsFileName)</PublishDepsFilePath>
+      <PublishDepsFilePath Condition=" '$(PublishDepsFilePath)' == '' ">$(PreBundlePublishDir)$(ProjectDepsFileName)</PublishDepsFilePath>
     </PropertyGroup>
 
     <GenerateDepsFile ProjectPath="$(MSBuildProjectFullPath)"

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -192,7 +192,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <Target Name="_CopyResolvedFilesToPublishPreserveNewest"
           DependsOnTargets="_ComputeResolvedFilesToPublishTypes"
           Inputs="@(_ResolvedFileToPublishPreserveNewest)"
-          Outputs="@(_ResolvedFileToPublishPreserveNewest->'$(PreBundlePublishDir)%(RelativePath)')">
+          Outputs="@(_ResolvedFileToPublishPreserveNewest->'$(PublishDir)%(RelativePath)')">
 
     <!--
         Not using SkipUnchangedFiles="true" because the application may want to change
@@ -855,10 +855,21 @@ Copyright (c) .NET Foundation. All rights reserved.
     -->
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Build.Bundle" />
 
+  <Target Name="_ComputeFilesToBundle"
+        Condition="'$(PublishSingleFile)' == 'true'">
+
+    <ItemGroup>
+      <_FilesToBundle Include="$(PreBundlePublishDir)\**\*.*"/>
+    </ItemGroup>
+
+  </Target>
+
   <Target Name="BundlePublishDirectory" 
           Condition="'$(PublishSingleFile)' == 'true'"
-          Inputs="$(PreBundlePublishDir)\**\*.*"
+          DependsOnTargets="_ComputeFilesToBundle" 
+          Inputs="@(_FilesToBundle)"
           Outputs="$(PublishDir)\$(AssemblyName)$(_NativeExecutableExtension)">
+    
     <PropertyGroup>
       <BundleArgs>--source $(PreBundlePublishDir) </BundleArgs>
       <BundleArgs>$(BundleArgs) --apphost $(AssemblyName)$(_NativeExecutableExtension)</BundleArgs>
@@ -867,6 +878,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     </PropertyGroup>
     
     <Exec Command="$(DOTNET_HOST_PATH) $(MicrosoftDotnetBundle) $(BundleArgs)" />
+    
   </Target>
 
   <!--

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -855,7 +855,10 @@ Copyright (c) .NET Foundation. All rights reserved.
     -->
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Build.Bundle" />
 
-  <Target Name="BundlePublishDirectory" Condition="'$(PublishSingleFile)' == 'true'">
+  <Target Name="BundlePublishDirectory" 
+          Condition="'$(PublishSingleFile)' == 'true'"
+          Inputs="$(PreBundlePublishDir)\**\*.*"
+          Outputs="$(PublishDir)\$(AssemblyName)$(_NativeExecutableExtension)">
     <PropertyGroup>
       <BundleArgs>--source $(PreBundlePublishDir) </BundleArgs>
       <BundleArgs>$(BundleArgs) --apphost $(AssemblyName)$(_NativeExecutableExtension)</BundleArgs>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -487,7 +487,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                              Condition="'$(_DebugSymbolsProduced)'=='true' and '$(CopyOutputSymbolsToPublishDirectory)'=='true'">
         <RelativePath>@(_DebugSymbolsIntermediatePath->'%(Filename)%(Extension)')</RelativePath>
         <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
-        <IncludeInSingleFile Condition="'$(BundlePDBs)'!='true'">false</IncludeInSingleFile>
+        <IncludeInSingleFile Condition="'$(IncludePdbInSingleFile)'!='true'">false</IncludeInSingleFile>
       </ResolvedFileToPublish>
 
       <!-- Copy satellite assemblies. -->
@@ -856,7 +856,14 @@ Copyright (c) .NET Foundation. All rights reserved.
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Build.Bundle" />
 
   <Target Name="BundlePublishDirectory" Condition="'$(PublishSingleFile)' == 'true'">
-    <Exec Command="$(DOTNET_HOST_PATH) $(MicrosoftDotnetBundle) --source $(PreBundlePublishDir) --apphost $(AssemblyName)$(_NativeExecutableExtension) -o $(PublishDir)" />
+    <PropertyGroup>
+      <BundleArgs>--source $(PreBundlePublishDir) </BundleArgs>
+      <BundleArgs>$(BundleArgs) --apphost $(AssemblyName)$(_NativeExecutableExtension)</BundleArgs>
+      <BundleArgs Condition="'$(IncludePdbInSingleFile)'=='true'">$(BundleArgs) --pdb</BundleArgs>
+      <BundleArgs>$(BundleArgs) -o $(PublishDir)</BundleArgs>
+    </PropertyGroup>
+    
+    <Exec Command="$(DOTNET_HOST_PATH) $(MicrosoftDotnetBundle) $(BundleArgs)" />
   </Target>
 
   <!--

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -90,7 +90,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       <!-- Ensure any PublishDir has a trailing slash, so it can be concatenated -->
       <PublishDir Condition="!HasTrailingSlash('$(PublishDir)')">$(PublishDir)\</PublishDir>
       
-      <PreBundlePublishDir Condition="'$(PublishSingleFile)' == 'true'">$(IntermediateOutputPath)PublishTemp\</PreBundlePublishDir>
+      <PreBundlePublishDir Condition="'$(PublishSingleFile)' == 'true'">$(IntermediateOutputPath)PreBundlePublish\</PreBundlePublishDir>
       <PreBundlePublishDir Condition="'$(PublishSingleFile)' != 'true'">$(PublishDir)</PreBundlePublishDir>
     </PropertyGroup>
 
@@ -115,12 +115,72 @@ Copyright (c) .NET Foundation. All rights reserved.
     ============================================================
                                         CopyFilesToPublishDirectory
 
-    Copy all build outputs, satellites and other necessary files to the publish directory.
+    Copy all build outputs, satellites and other necessary files to the pre-bundle publish directory.
+    Some outputs (ex: PDB files) may be directly copied to the final publish directory, based on settings.
     ============================================================
     -->
   <Target Name="CopyFilesToPublishDirectory"
-          DependsOnTargets="_CopyResolvedFilesToPublishPreserveNewest;
+          DependsOnTargets="_CopyResolvedFilesToPreBundlePublishPreserveNewest;
+                            _CopyResolvedFilesToPreBundlePublishAlways;
+                            _CopyResolvedFilesToPublishPreserveNewest;
                             _CopyResolvedFilesToPublishAlways" />
+
+  <!--
+    ============================================================
+                                       _CopyResolvedFilesToPreBundlePublishPreserveNewest
+
+    Copy _ResolvedFileToPreBundlePublishPreserveNewest items to the pre-bundle publish directory.
+    ============================================================
+    -->
+  <Target Name="_CopyResolvedFilesToPreBundlePublishPreserveNewest"
+          DependsOnTargets="_ComputeResolvedFilesToPublishTypes"
+          Inputs="@(_ResolvedFileToPreBundlePublishPreserveNewest)"
+          Outputs="@(_ResolvedFileToPreBundlePublishPreserveNewest->'$(PreBundlePublishDir)%(RelativePath)')">
+
+    <!--
+        Not using SkipUnchangedFiles="true" because the application may want to change
+        one of these files and not have an incremental build replace it.
+        -->
+    <Copy SourceFiles = "@(_ResolvedFileToPreBundlePublishPreserveNewest)"
+          DestinationFiles="@(_ResolvedFileToPreBundlePublishPreserveNewest->'$(PreBundlePublishDir)%(RelativePath)')"
+          OverwriteReadOnlyFiles="$(OverwriteReadOnlyFiles)"
+          Retries="$(CopyRetryCount)"
+          RetryDelayMilliseconds="$(CopyRetryDelayMilliseconds)"
+          UseHardlinksIfPossible="$(CreateHardLinksForPublishFilesIfPossible)"
+          UseSymboliclinksIfPossible="$(CreateSymbolicLinksForPublishFilesIfPossible)">
+
+      <Output TaskParameter="DestinationFiles" ItemName="FileWrites"/>
+
+    </Copy>
+
+  </Target>
+
+  <!--
+    ============================================================
+                                      _CopyResolvedFilesToPreBundlePublishAlways
+
+    Copy _ResolvedFileToPreBundlePublishAlways items to the pre-bundle publish directory.
+    ============================================================
+    -->
+  <Target Name="_CopyResolvedFilesToPreBundlePublishAlways"
+          DependsOnTargets="_ComputeResolvedFilesToPublishTypes">
+
+    <!--
+        Not using SkipUnchangedFiles="true" because the application may want to change
+        one of these files and not have an incremental build replace it.
+        -->
+    <Copy SourceFiles = "@(_ResolvedFileToPreBundlePublishAlways)"
+          DestinationFiles="@(_ResolvedFileToPreBundlePublishAlways->'$(PreBundlePublishDir)%(RelativePath)')"
+          OverwriteReadOnlyFiles="$(OverwriteReadOnlyFiles)"
+          Retries="$(CopyRetryCount)"
+          RetryDelayMilliseconds="$(CopyRetryDelayMilliseconds)"
+          UseHardlinksIfPossible="$(CreateHardLinksForPublishFilesIfPossible)"
+          UseSymboliclinksIfPossible="$(CreateSymbolicLinksForPublishFilesIfPossible)">
+
+      <Output TaskParameter="DestinationFiles" ItemName="FileWrites"/>
+
+    </Copy>
+  </Target>
 
   <!--
     ============================================================
@@ -139,7 +199,7 @@ Copyright (c) .NET Foundation. All rights reserved.
         one of these files and not have an incremental build replace it.
         -->
     <Copy SourceFiles = "@(_ResolvedFileToPublishPreserveNewest)"
-          DestinationFiles="@(_ResolvedFileToPublishPreserveNewest->'$(PreBundlePublishDir)%(RelativePath)')"
+          DestinationFiles="@(_ResolvedFileToPublishPreserveNewest->'$(PublishDir)%(RelativePath)')"
           OverwriteReadOnlyFiles="$(OverwriteReadOnlyFiles)"
           Retries="$(CopyRetryCount)"
           RetryDelayMilliseconds="$(CopyRetryDelayMilliseconds)"
@@ -167,7 +227,7 @@ Copyright (c) .NET Foundation. All rights reserved.
         one of these files and not have an incremental build replace it.
         -->
     <Copy SourceFiles = "@(_ResolvedFileToPublishAlways)"
-          DestinationFiles="@(_ResolvedFileToPublishAlways->'$(PreBundlePublishDir)%(RelativePath)')"
+          DestinationFiles="@(_ResolvedFileToPublishAlways->'$(PublishDir)%(RelativePath)')"
           OverwriteReadOnlyFiles="$(OverwriteReadOnlyFiles)"
           Retries="$(CopyRetryCount)"
           RetryDelayMilliseconds="$(CopyRetryDelayMilliseconds)"
@@ -177,12 +237,6 @@ Copyright (c) .NET Foundation. All rights reserved.
       <Output TaskParameter="DestinationFiles" ItemName="FileWrites"/>
 
     </Copy>
-  </Target>
-
-  <Import Project="Sdk.props" Sdk="Microsoft.NET.Build.Bundle" />
-
-  <Target Name="BundlePublishDirectory" Condition="'$(PublishSingleFile)' == 'true'">
-    <Exec Command="$(DOTNET_HOST_PATH) $(MicrosoftDotnetBundle) --source $(PreBundlePublishDir) --apphost $(AssemblyName)$(_NativeExecutableExtension) -o $(PublishDir)" />
   </Target>
 
   <!--
@@ -363,11 +417,22 @@ Copyright (c) .NET Foundation. All rights reserved.
     -->
   <Target Name="_ComputeResolvedFilesToPublishTypes">
     <ItemGroup>
+
+      <_ResolvedFileToPreBundlePublishPreserveNewest Include="@(ResolvedFileToPublish)"
+                                                     Condition="'%(ResolvedFileToPublish.CopyToPublishDirectory)'=='PreserveNewest' and 
+                                                                '%(ResolvedFileToPublish.IncludeInSingleFile)'!='false'" />
+
+      <_ResolvedFileToPreBundlePublishAlways Include="@(ResolvedFileToPublish)"
+                                             Condition="'%(ResolvedFileToPublish.CopyToPublishDirectory)'=='Always' and 
+                                                        '%(ResolvedFileToPublish.IncludeInSingleFile)'!='false'" />
+
       <_ResolvedFileToPublishPreserveNewest Include="@(ResolvedFileToPublish)"
-                                             Condition="'%(ResolvedFileToPublish.CopyToPublishDirectory)'=='PreserveNewest'" />
+                                            Condition="'%(ResolvedFileToPublish.CopyToPublishDirectory)'=='PreserveNewest' and 
+                                                       '%(ResolvedFileToPublish.IncludeInSingleFile)'=='false'" />
 
       <_ResolvedFileToPublishAlways Include="@(ResolvedFileToPublish)"
-                                     Condition="'%(ResolvedFileToPublish.CopyToPublishDirectory)'=='Always'" />
+                                    Condition="'%(ResolvedFileToPublish.CopyToPublishDirectory)'=='Always' and 
+                                               '%(ResolvedFileToPublish.IncludeInSingleFile)'=='false'" />
     </ItemGroup>
   </Target>
 
@@ -422,6 +487,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                              Condition="'$(_DebugSymbolsProduced)'=='true' and '$(CopyOutputSymbolsToPublishDirectory)'=='true'">
         <RelativePath>@(_DebugSymbolsIntermediatePath->'%(Filename)%(Extension)')</RelativePath>
         <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+        <IncludeInSingleFile Condition="'$(BundlePDBs)'!='true'">false</IncludeInSingleFile>
       </ResolvedFileToPublish>
 
       <!-- Copy satellite assemblies. -->
@@ -778,6 +844,19 @@ Copyright (c) .NET Foundation. All rights reserved.
                                           '$(PreserveStoreLayout)' != 'true'">true</_UseBuildDependencyFile>
     </PropertyGroup>
 
+  </Target>
+
+  <!--
+    ============================================================
+                                        BundlePublishDirectory
+
+    Bundle the items in PreBundlePublishDir into one file in PublishDir
+    ============================================================
+    -->
+  <Import Project="Sdk.props" Sdk="Microsoft.NET.Build.Bundle" />
+
+  <Target Name="BundlePublishDirectory" Condition="'$(PublishSingleFile)' == 'true'">
+    <Exec Command="$(DOTNET_HOST_PATH) $(MicrosoftDotnetBundle) --source $(PreBundlePublishDir) --apphost $(AssemblyName)$(_NativeExecutableExtension) -o $(PublishDir)" />
   </Target>
 
   <!--

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -89,7 +89,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <PropertyGroup>
       <!-- Ensure any PublishDir has a trailing slash, so it can be concatenated -->
       <PublishDir Condition="!HasTrailingSlash('$(PublishDir)')">$(PublishDir)\</PublishDir>
-      
+
       <PreBundlePublishDir Condition="'$(PublishSingleFile)' == 'true'">$(IntermediateOutputPath)PreBundlePublish\</PreBundlePublishDir>
       <PreBundlePublishDir Condition="'$(PublishSingleFile)' != 'true'">$(PublishDir)</PreBundlePublishDir>
     </PropertyGroup>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets
@@ -127,11 +127,14 @@ Copyright (c) .NET Foundation. All rights reserved.
     <NETSdkError Condition="'$(SelfContained)' == 'true' and '$(RuntimeIdentifier)' == ''"
                  ResourceName="CannotHaveSelfContainedWithoutRuntimeIdentifier" />
 
-    <NETSdkError Condition="'$(PublishSingleFile)' == 'true' and '$(RuntimeIdentifier)' == ''"
-                 ResourceName="CannotHaveSingleFileWithoutRuntimeIdentifier" />
-    
     <NETSdkError Condition="'$(SelfContained)' == 'true' and '$(UseAppHost)' != 'true'"
                  ResourceName="CannotUseSelfContainedWithoutAppHost" />
+
+    <NETSdkError Condition="'$(PublishSingleFile)' == 'true' and '$(RuntimeIdentifier)' == ''"
+                 ResourceName="CannotHaveSingleFileWithoutRuntimeIdentifier" />
+
+    <NETSdkError Condition="'$(PublishSingleFile)' == 'true' and '$(UseAppHost)' != 'true'"
+                 ResourceName="CannotHaveSingleFileWithoutAppHost" />
 
     <NETSdkError Condition="'$(SelfContained)' != 'true' and '$(UseAppHost)' == 'true' and '$(_TargetFrameworkVersionWithoutV)' &lt; '2.1'"
                  ResourceName="FrameworkDependentAppHostRequiresVersion21" />

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets
@@ -127,6 +127,9 @@ Copyright (c) .NET Foundation. All rights reserved.
     <NETSdkError Condition="'$(SelfContained)' == 'true' and '$(RuntimeIdentifier)' == ''"
                  ResourceName="CannotHaveSelfContainedWithoutRuntimeIdentifier" />
 
+    <NETSdkError Condition="'$(PublishSingleFile)' == 'true' and '$(RuntimeIdentifier)' == ''"
+                 ResourceName="CannotHaveSingleFileWithoutRuntimeIdentifier" />
+    
     <NETSdkError Condition="'$(SelfContained)' == 'true' and '$(UseAppHost)' != 'true'"
                  ResourceName="CannotUseSelfContainedWithoutAppHost" />
 

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishASingleFileApp.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishASingleFileApp.cs
@@ -1,0 +1,114 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using FluentAssertions;
+using Microsoft.DotNet.PlatformAbstractions;
+using Microsoft.NET.Build.Tasks;
+using Microsoft.NET.TestFramework;
+using Microsoft.NET.TestFramework.Assertions;
+using Microsoft.NET.TestFramework.Commands;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.NET.Publish.Tests
+{
+    public class GivenThatWeWantToPublishASingleFileApp : SdkTest
+    {
+        private const string TestProjectName = "HelloWorld";
+
+        public GivenThatWeWantToPublishASingleFileApp(ITestOutputHelper log) : base(log)
+        {
+        }
+
+        [Fact]
+        public void It_errors_when_publishing_single_file_app_without_rid()
+        {
+             var testAsset = _testAssetsManager
+                .CopyTestAsset(TestProjectName)
+                .WithSource();
+
+            var publishCommand = new PublishCommand(Log, testAsset.TestRoot);
+            publishCommand
+                .Execute("/p:SelfContained=true")
+                .Should()
+                .Fail()
+                .And
+                .HaveStdOutContaining(Strings.CannotHaveSingleFileWithoutRuntimeIdentifier);
+        }
+
+        [Fact]
+        public void It_errors_when_publishing_single_file_without_apphost()
+        {
+            var runtimeIdentifier = RuntimeEnvironment.GetRuntimeIdentifier();
+
+            var testAsset = _testAssetsManager
+                .CopyTestAsset(TestProjectName)
+                .WithSource();
+
+            var publishCommand = new PublishCommand(Log, testAsset.TestRoot);
+            publishCommand
+                .Execute(
+                    "/p:SelfContained=true",
+                    "/p:UseAppHost=false",
+                    $"/p:RuntimeIdentifier={runtimeIdentifier}")
+                .Should()
+                .Fail()
+                .And
+                .HaveStdOutContaining(Strings.CannotHaveSingleFileWithoutAppHost);
+        }
+
+        [Fact]
+        public void It_generates_a_single_file_for_framework_dependent_apps()
+        {
+            var runtimeIdentifier = RuntimeEnvironment.GetRuntimeIdentifier();
+
+            var testAsset = _testAssetsManager
+                .CopyTestAsset(TestProjectName)
+                .WithSource();
+
+            var publishCommand = new PublishCommand(Log, testAsset.TestRoot);
+            publishCommand
+                .Execute(
+                    "/p:SelfContained=false",
+                    $"/p:RuntimeIdentifier={runtimeIdentifier}")
+                .Should()
+                .Pass();
+        }
+
+        [Fact]
+        public void It_generates_a_single_file_for_self_contained_apps()
+        {
+            var runtimeIdentifier = RuntimeEnvironment.GetRuntimeIdentifier();
+
+            var testAsset = _testAssetsManager
+                .CopyTestAsset(TestProjectName)
+                .WithSource();
+
+            var publishCommand = new PublishCommand(Log, testAsset.TestRoot);
+            publishCommand
+                .Execute(
+                    "/p:SelfContained=true",
+                    $"/p:RuntimeIdentifier={runtimeIdentifier}")
+                .Should()
+                .Pass();
+        }
+
+        [Fact]
+        public void It_generates_a_single_file_including_pdbs()
+        {
+            var runtimeIdentifier = RuntimeEnvironment.GetRuntimeIdentifier();
+
+            var testAsset = _testAssetsManager
+                .CopyTestAsset(TestProjectName)
+                .WithSource();
+
+            var publishCommand = new PublishCommand(Log, testAsset.TestRoot);
+            publishCommand
+                .Execute(
+                    "/p:IncludePdbInSingleFile",
+                    $"/p:RuntimeIdentifier={runtimeIdentifier}")
+                .Should()
+                .Pass();
+        }
+    }
+}


### PR DESCRIPTION
This change implements support for publishing apps to a single file.

* ``dotnet publish /p:PublishSingleFile=true`` causes the contents of the "original" publish directory to a single file in the actual publish directory 
* Files marked with the meta-data ``<IncludeInSingleFile>false<IncludeInSingleFile>`` are left in the publish directory unbundled. This includes PDB files by default
* PDB files can be bundled into the single file by setting ``/p:IncludePdbInSingleFile=true``

Publishing to a single file requires publishing wrt a RID using an apphost, because the generated file is the platform-specific AppHost executable with embedded dependencies.

Test Pass: requires a change to the bundler, which is waiting to be updated in the toolset repo.
