### PR TITLE
Check if assembly has any IL code that needs R2R compilation

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/PrepareForReadyToRunCompilation.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/PrepareForReadyToRunCompilation.cs
@@ -311,7 +311,9 @@ namespace Microsoft.NET.Build.Tasks
             {
                 MethodDefinition methodDef = mdReader.GetMethodDefinition(methoddefHandle);
                 if (methodDef.RelativeVirtualAddress > 0)
+                {
                     return true;
+                }
             }
 
             return false;

--- a/src/Tasks/Microsoft.NET.Build.Tasks/PrepareForReadyToRunCompilation.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/PrepareForReadyToRunCompilation.cs
@@ -311,11 +311,7 @@ namespace Microsoft.NET.Build.Tasks
             {
                 MethodDefinition methodDef = mdReader.GetMethodDefinition(methoddefHandle);
                 if (methodDef.RelativeVirtualAddress > 0)
-                {
-                    MethodBodyBlock methodBody = PEReaderExtensions.GetMethodBody(peReader, methodDef.RelativeVirtualAddress);
-                    if (methodBody.Size > 0)
-                        return true;
-                }
+                    return true;
             }
 
             return false;

--- a/src/Tasks/Microsoft.NET.Build.Tasks/PrepareForReadyToRunCompilation.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/PrepareForReadyToRunCompilation.cs
@@ -238,7 +238,7 @@ namespace Microsoft.NET.Build.Tasks
                         }
 
                         // Skip reference assemblies and assemblies that reference winmds
-                        if (ReferencesWinMD(mdReader) || IsReferenceAssembly(mdReader))
+                        if (ReferencesWinMD(mdReader) || IsReferenceAssembly(mdReader) || !HasILCode(pereader, mdReader))
                         {
                             return false;
                         }
@@ -300,6 +300,22 @@ namespace Microsoft.NET.Build.Tasks
                 AssemblyReference assemblyRef = mdReader.GetAssemblyReference(assemblyRefHandle);
                 if ((assemblyRef.Flags & AssemblyFlags.WindowsRuntime) == AssemblyFlags.WindowsRuntime)
                     return true;
+            }
+
+            return false;
+        }
+
+        private bool HasILCode(PEReader peReader, MetadataReader mdReader)
+        {
+            foreach (var methoddefHandle in mdReader.MethodDefinitions)
+            {
+                MethodDefinition methodDef = mdReader.GetMethodDefinition(methoddefHandle);
+                if (methodDef.RelativeVirtualAddress > 0)
+                {
+                    MethodBodyBlock methodBody = PEReaderExtensions.GetMethodBody(peReader, methodDef.RelativeVirtualAddress);
+                    if (methodBody.Size > 0)
+                        return true;
+                }
             }
 
             return false;


### PR DESCRIPTION
Exclude assemblies with no IL from being added to the R2R compilation list. There are some "reference" assemblies that do not have the ReferenceAssemblyAttribute. Crossgenning them is like a "nop" and will produce an output assembly with no R2R compilation, but if the PDB generation option is enabled, crossgen will now fail if the input "R2R" assembly does not contain any R2R compiled code.