### PR TITLE
Don't include base FrameworkReferences when creating NuGet packages

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.props
@@ -46,7 +46,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                       Publish="true" />
   </ItemGroup>
   <ItemGroup Condition=" '$(DisableImplicitFrameworkReferences)' != 'true' and '$(TargetFrameworkIdentifier)' == '.NETStandard' And '$(_TargetFrameworkVersionWithoutV)' >= '2.1'">
-    <FrameworkReference Include="NETStandard.Library" IsImplicitlyDefined="true" />
+    <FrameworkReference Include="NETStandard.Library" IsImplicitlyDefined="true" Pack="false"/>
   </ItemGroup>
 
   <ItemGroup Condition=" '$(DisableImplicitFrameworkReferences)' != 'true' and '$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
@@ -65,6 +65,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                       Publish="true" />
 
     <FrameworkReference Include="Microsoft.NETCore.App" IsImplicitlyDefined="true"
+                        Pack="false"
                     Condition="('$(_TargetFrameworkVersionWithoutV)' != '') And ('$(_TargetFrameworkVersionWithoutV)' >= '3.0')"/>
 
   </ItemGroup>


### PR DESCRIPTION
Per [comment](https://github.com/aspnet/AspNetCore/pull/9033#issuecomment-481043113) from @nkolev92:

> I think regardless of whether it gets reverted or not, the SDK should set "pack=false" to Microsoft.NETCore.App.