### PR TITLE
Allow test tools to roll forward across major versions of .NET Core

### DIFF
--- a/src/Tests/Common/runtimeconfig.template.json
+++ b/src/Tests/Common/runtimeconfig.template.json
@@ -1,0 +1,3 @@
+{
+    "rollForwardOnNoCandidateFx": 2
+}

--- a/src/Tests/Directory.Build.targets
+++ b/src/Tests/Directory.Build.targets
@@ -13,6 +13,8 @@
 
     <!-- Put packages for tests in subfolder so we don't try to sign them -->
     <PackageOutputPath>$(PackageOutputPath)tests\</PackageOutputPath>
+
+    <UserRuntimeConfig>$(MSBuildThisFileDirectory)Common\runtimeconfig.template.json</UserRuntimeConfig>
   </PropertyGroup>
   
   <ItemGroup Condition="'$(IsTestProject)' == 'true' AND '$(OutputType)' == 'Exe'">


### PR DESCRIPTION
Currently the dotnet tools which run our tests target .NET Core 2.1.  This updates them to allow roll-forward across major .NET Core versions, so that they can run on a 3.0 runtime if 2.x isn't installed.