### PR TITLE
Add ILLink targets and tests

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/Microsoft.NET.Build.Tasks.csproj
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Microsoft.NET.Build.Tasks.csproj
@@ -104,6 +104,7 @@
       <Stage0SdkFile Include="$(_Stage0SdksFolder)\Microsoft.NET.Sdk.Web.ProjectSystem\**" SdkName="Microsoft.NET.Sdk.Web.ProjectSystem" />
       <Stage0SdkFile Include="$(_Stage0SdksFolder)\Microsoft.NET.Sdk.Razor\**" SdkName="Microsoft.NET.Sdk.Razor" />
       <Stage0SdkFile Include="$(_Stage0SdksFolder)\Microsoft.NET.Sdk.WindowsDesktop\**" SdkName="Microsoft.NET.Sdk.WindowsDesktop" />
+      <Stage0SdkFile Include="$(_Stage0SdksFolder)\ILLink.Tasks\**" SdkName="ILLink.Tasks" />
       <LayoutFile Include="@(Stage0SdkFile)">
         <TargetPath>..\%(Stage0SdkFile.SdkName)\%(Stage0SdkFile.RecursiveDir)%(Stage0SdkFile.Filename)%(Stage0SdkFile.Extension)</TargetPath>
       </LayoutFile>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ILLink.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ILLink.targets
@@ -57,7 +57,13 @@ Copyright (c) .NET Foundation. All rights reserved.
       <RuntimeCopyLocalItems Remove="@(_RemovedManagedAssemblies)" />
       <RuntimeTargetsCopyLocalItems Remove="@(_RemovedManagedAssemblies)" />
       <RuntimePackAsset Remove="@(_RemovedManagedAssemblies)" />
+
+      <!-- Also remove them from the old deps file generation logic,
+           until https://github.com/dotnet/sdk/issues/3098 is
+           fixed. -->
+      <_PublishConflictPackageFiles Include="@(_RemovedManagedAssemblies)" />
     </ItemGroup>
+
 
   </Target>
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ILLink.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ILLink.targets
@@ -46,12 +46,17 @@ Copyright (c) .NET Foundation. All rights reserved.
       <ResolvedFileToPublish Include="@(_LinkedResolvedFileToPublish)" />
     </ItemGroup>
 
-    <!-- Use _PublishConflictPackageFiles to remove assemblies from
-         the deps file. This will change with the fix to
-         https://github.com/dotnet/sdk/issues/3010. -->
+    <!-- Remove assemblies from inputs to GenerateDepsFile. See
+         https://github.com/dotnet/sdk/pull/3086. -->
     <ItemGroup>
       <_RemovedManagedAssemblies Include="@(_ManagedAssembliesToLink)" Condition="!Exists('$(IntermediateLinkDir)/%(Filename)%(Extension)')" />
-      <_PublishConflictPackageFiles Include="@(_RemovedManagedAssemblies)" />
+
+      <ResolvedCompileFileDefinitions Remove="@(_RemovedManagedAssemblies)" />
+      <NativeCopyLocalItems Remove="@(_RemovedManagedAssemblies)" />
+      <ResourceCopyLocalItems Remove="@(_RemovedManagedAssemblies)" />
+      <RuntimeCopyLocalItems Remove="@(_RemovedManagedAssemblies)" />
+      <RuntimeTargetsCopyLocalItems Remove="@(_RemovedManagedAssemblies)" />
+      <RuntimePackAsset Remove="@(_RemovedManagedAssemblies)" />
     </ItemGroup>
 
   </Target>
@@ -72,8 +77,8 @@ Copyright (c) .NET Foundation. All rights reserved.
            Outputs="$(_LinkSemaphore)">
 
      <Delete Files="@(_LinkedResolvedFileToPublishCandidates)" />
-     <!-- TODO: add ReferenceAssemblyPaths="@(ReferencePath)" -->
      <ILLink AssemblyPaths="@(_ManagedAssembliesToLink)"
+             ReferenceAssemblyPaths="@(ReferencePath)"
              RootAssemblyNames="@(IntermediateAssembly->'%(Filename)')"
              RootDescriptorFiles="@(LinkerRootDescriptors)"
              OutputDirectory="$(IntermediateLinkDir)"

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ILLink.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ILLink.targets
@@ -1,0 +1,110 @@
+<!--
+***********************************************************************************************
+Microsoft.NET.ILLink.targets
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+          created a backup copy.  Incorrect changes to this file will make it
+          impossible to load or build your projects from the command-line or the IDE.
+
+Copyright (c) .NET Foundation. All rights reserved.
+***********************************************************************************************
+-->
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <Import Project="Sdk.props" Sdk="ILLink.Tasks" />
+
+  <PropertyGroup>
+    <ILTransformDependsOn>$(ILTransformDependsOn);ILLink</ILTransformDependsOn>
+    <IntermediateLinkDir Condition=" '$(IntermediateLinkDir)' == '' ">$(IntermediateOutputPath)linked</IntermediateLinkDir>
+    <!-- Used to enable incremental build for the linker target. -->
+    <_LinkSemaphore>$(IntermediateOutputPath)Link.semaphore</_LinkSemaphore>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <LinkerRootDescriptors Include="$(LinkerRootDescriptors)" />
+  </ItemGroup>
+
+  <!--
+    ============================================================
+                     ILLink
+
+    Replace the files to be published with versions that have been
+    passed through the linker. Also prevent removed files from being
+    included in the generated deps.json.
+    ============================================================
+    -->
+  <Target Name="ILLink"
+          Condition=" '$(LinkDuringPublish)' == 'true' "
+          DependsOnTargets="RunILLink">
+
+    <!-- For now, use ResolvedFileToPublish as input/output. This
+         should go away in favor of a well-defined set of runtime
+         assemblies with https://github.com/dotnet/sdk/issues/3109. -->
+    <ItemGroup>
+      <_LinkedResolvedFileToPublish Include="@(_LinkedResolvedFileToPublishCandidates)" Condition="Exists('%(Identity)')" />
+      <ResolvedFileToPublish Remove="@(_ManagedAssembliesToLink)" />
+      <ResolvedFileToPublish Include="@(_LinkedResolvedFileToPublish)" />
+    </ItemGroup>
+
+    <!-- Use _PublishConflictPackageFiles to remove assemblies from
+         the deps file. This will change with the fix to
+         https://github.com/dotnet/sdk/issues/3010. -->
+    <ItemGroup>
+      <_RemovedManagedAssemblies Include="@(_ManagedAssembliesToLink)" Condition="!Exists('$(IntermediateLinkDir)/%(Filename)%(Extension)')" />
+      <_PublishConflictPackageFiles Include="@(_RemovedManagedAssemblies)" />
+    </ItemGroup>
+
+  </Target>
+
+
+  <!--
+    ============================================================
+                     RunILLink
+
+    Execute the linker. This target runs incrementally, only executing
+    if the output semaphore file is out of date with respect to the inputs.
+    ============================================================
+    -->
+   <UsingTask TaskName="ILLink" AssemblyFile="$(ILLinkTasksAssembly)" />
+   <Target Name="RunILLink"
+           DependsOnTargets="_ComputeManagedAssembliesToLink"
+           Inputs="@(_ManagedAssembliesToLink);@(LinkerRootDescriptors);@(ReferencePath)"
+           Outputs="$(_LinkSemaphore)">
+
+     <Delete Files="@(_LinkedResolvedFileToPublishCandidates)" />
+     <!-- TODO: add ReferenceAssemblyPaths="@(ReferencePath)" -->
+     <ILLink AssemblyPaths="@(_ManagedAssembliesToLink)"
+             RootAssemblyNames="@(IntermediateAssembly->'%(Filename)')"
+             RootDescriptorFiles="@(LinkerRootDescriptors)"
+             OutputDirectory="$(IntermediateLinkDir)"
+             ExtraArgs="$(ExtraLinkerArgs) --skip-unresolved true" />
+
+     <Touch Files="$(_LinkSemaphore)" AlwaysCreate="true" />
+
+  </Target>
+
+  <!--
+    ============================================================
+                     _ComputeManagedAssembliesToLink
+
+    Compute the set of inputs to the linker. Currently this uses a
+    heuristic to get the relevant input from ResolvedFileToPublish,
+    but in the future this should be replaced with the exact set of
+    runtime assemblies that will be in the deps file.
+    ============================================================
+    -->
+  <UsingTask TaskName="ComputeManagedAssemblies" AssemblyFile="$(ILLinkTasksAssembly)" />
+  <Target Name="_ComputeManagedAssembliesToLink">
+    <ComputeManagedAssemblies Assemblies="@(ResolvedFileToPublish)">
+      <Output TaskParameter="ManagedAssemblies" ItemName="_ManagedAssembliesToLink" />
+    </ComputeManagedAssemblies>
+
+    <ItemGroup>
+      <_ManagedAssembliesToLink Remove="@(_ManagedResolvedFileToPublish->WithMetadataValue('AssetType', 'resources'))" />
+      <_LinkedResolvedFileToPublishCandidates Include="@(_ManagedAssembliesToLink->'$(IntermediateLinkDir)/%(Filename)%(Extension)')" />
+    </ItemGroup>
+
+  </Target>
+
+
+</Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ILLink.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ILLink.targets
@@ -14,28 +14,28 @@ Copyright (c) .NET Foundation. All rights reserved.
   <Import Project="Sdk.props" Sdk="ILLink.Tasks" />
 
   <PropertyGroup>
-    <ILTransformDependsOn>$(ILTransformDependsOn);ILLink</ILTransformDependsOn>
+    <ILTransformForPublishDependsOn>$(ILTransformForPublishDependsOn);_ILLink</ILTransformForPublishDependsOn>
     <IntermediateLinkDir Condition=" '$(IntermediateLinkDir)' == '' ">$(IntermediateOutputPath)linked</IntermediateLinkDir>
     <!-- Used to enable incremental build for the linker target. -->
     <_LinkSemaphore>$(IntermediateOutputPath)Link.semaphore</_LinkSemaphore>
   </PropertyGroup>
 
   <ItemGroup>
-    <LinkerRootDescriptors Include="$(LinkerRootDescriptors)" />
+    <TrimmerRootDescriptors Include="$(TrimmerRootDescriptors)" />
   </ItemGroup>
 
   <!--
     ============================================================
-                     ILLink
+                     _ILLink
 
     Replace the files to be published with versions that have been
     passed through the linker. Also prevent removed files from being
     included in the generated deps.json.
     ============================================================
     -->
-  <Target Name="ILLink"
-          Condition=" '$(LinkDuringPublish)' == 'true' "
-          DependsOnTargets="RunILLink">
+  <Target Name="_ILLink"
+          Condition=" '$(PublishTrimmed)' == 'true' "
+          DependsOnTargets="_RunILLink">
 
     <!-- For now, use ResolvedFileToPublish as input/output. This
          should go away in favor of a well-defined set of runtime
@@ -70,23 +70,23 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <!--
     ============================================================
-                     RunILLink
+                     _RunILLink
 
     Execute the linker. This target runs incrementally, only executing
     if the output semaphore file is out of date with respect to the inputs.
     ============================================================
     -->
    <UsingTask TaskName="ILLink" AssemblyFile="$(ILLinkTasksAssembly)" />
-   <Target Name="RunILLink"
+   <Target Name="_RunILLink"
            DependsOnTargets="_ComputeManagedAssembliesToLink"
-           Inputs="@(_ManagedAssembliesToLink);@(LinkerRootDescriptors);@(ReferencePath)"
+           Inputs="$(MSBuildAllProjects);@(_ManagedAssembliesToLink);@(TrimmerRootDescriptors);@(ReferencePath)"
            Outputs="$(_LinkSemaphore)">
 
      <Delete Files="@(_LinkedResolvedFileToPublishCandidates)" />
      <ILLink AssemblyPaths="@(_ManagedAssembliesToLink)"
              ReferenceAssemblyPaths="@(ReferencePath)"
              RootAssemblyNames="@(IntermediateAssembly->'%(Filename)')"
-             RootDescriptorFiles="@(LinkerRootDescriptors)"
+             RootDescriptorFiles="@(TrimmerRootDescriptors)"
              OutputDirectory="$(IntermediateLinkDir)"
              ExtraArgs="$(ExtraLinkerArgs) --skip-unresolved true" />
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ILLink.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ILLink.targets
@@ -15,9 +15,13 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <PropertyGroup>
     <ILTransformForPublishDependsOn>$(ILTransformForPublishDependsOn);_ILLink</ILTransformForPublishDependsOn>
-    <IntermediateLinkDir Condition=" '$(IntermediateLinkDir)' == '' ">$(IntermediateOutputPath)linked</IntermediateLinkDir>
+    <IntermediateLinkDir Condition=" '$(IntermediateLinkDir)' == '' ">$(IntermediateOutputPath)linked\</IntermediateLinkDir>
+    <IntermediateLinkDir Condition=" !HasTrailingSlash('$(IntermediateLinkDir)') ">$(IntermediateLinkDir)\</IntermediateLinkDir>
     <!-- Used to enable incremental build for the linker target. -->
     <_LinkSemaphore>$(IntermediateOutputPath)Link.semaphore</_LinkSemaphore>
+    <!-- Disable old deps file generation logic until
+         https://github.com/dotnet/sdk/issues/3098 is fixed. -->
+    <DepsFileGenerationMode>new</DepsFileGenerationMode>
   </PropertyGroup>
 
   <ItemGroup>
@@ -34,7 +38,8 @@ Copyright (c) .NET Foundation. All rights reserved.
     ============================================================
     -->
   <Target Name="_ILLink"
-          Condition=" '$(PublishTrimmed)' == 'true' "
+          Condition=" '$(PublishTrimmed)' == 'true' And
+                      '$(_TargetFrameworkVersionWithoutV)' >= '3.0' And '$(TargetFrameworkIdentifier)' == '.NETCoreApp' "
           DependsOnTargets="_RunILLink">
 
     <!-- For now, use ResolvedFileToPublish as input/output. This
@@ -49,7 +54,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <!-- Remove assemblies from inputs to GenerateDepsFile. See
          https://github.com/dotnet/sdk/pull/3086. -->
     <ItemGroup>
-      <_RemovedManagedAssemblies Include="@(_ManagedAssembliesToLink)" Condition="!Exists('$(IntermediateLinkDir)/%(Filename)%(Extension)')" />
+      <_RemovedManagedAssemblies Include="@(_ManagedAssembliesToLink)" Condition="!Exists('$(IntermediateLinkDir)%(Filename)%(Extension)')" />
 
       <ResolvedCompileFileDefinitions Remove="@(_RemovedManagedAssemblies)" />
       <NativeCopyLocalItems Remove="@(_RemovedManagedAssemblies)" />
@@ -57,13 +62,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       <RuntimeCopyLocalItems Remove="@(_RemovedManagedAssemblies)" />
       <RuntimeTargetsCopyLocalItems Remove="@(_RemovedManagedAssemblies)" />
       <RuntimePackAsset Remove="@(_RemovedManagedAssemblies)" />
-
-      <!-- Also remove them from the old deps file generation logic,
-           until https://github.com/dotnet/sdk/issues/3098 is
-           fixed. -->
-      <_PublishConflictPackageFiles Include="@(_RemovedManagedAssemblies)" />
     </ItemGroup>
-
 
   </Target>
 
@@ -88,7 +87,7 @@ Copyright (c) .NET Foundation. All rights reserved.
              RootAssemblyNames="@(IntermediateAssembly->'%(Filename)')"
              RootDescriptorFiles="@(TrimmerRootDescriptors)"
              OutputDirectory="$(IntermediateLinkDir)"
-             ExtraArgs="$(ExtraLinkerArgs) --skip-unresolved true" />
+             ExtraArgs="$(_ExtraTrimmerArgs) --skip-unresolved true" />
 
      <Touch Files="$(_LinkSemaphore)" AlwaysCreate="true" />
 
@@ -100,8 +99,9 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     Compute the set of inputs to the linker. Currently this uses a
     heuristic to get the relevant input from ResolvedFileToPublish,
-    but in the future this should be replaced with the exact set of
-    runtime assemblies that will be in the deps file.
+    but with https://github.com/dotnet/sdk/issues/3109, this should be
+    replaced with the exact set of runtime assemblies that will be in
+    the deps file.
     ============================================================
     -->
   <UsingTask TaskName="ComputeManagedAssemblies" AssemblyFile="$(ILLinkTasksAssembly)" />
@@ -112,7 +112,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <ItemGroup>
       <_ManagedAssembliesToLink Remove="@(_ManagedResolvedFileToPublish->WithMetadataValue('AssetType', 'resources'))" />
-      <_LinkedResolvedFileToPublishCandidates Include="@(_ManagedAssembliesToLink->'$(IntermediateLinkDir)/%(Filename)%(Extension)')" />
+      <_LinkedResolvedFileToPublishCandidates Include="@(_ManagedAssembliesToLink->'$(IntermediateLinkDir)%(Filename)%(Extension)')" />
     </ItemGroup>
 
   </Target>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ILLink.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ILLink.targets
@@ -14,7 +14,6 @@ Copyright (c) .NET Foundation. All rights reserved.
   <Import Project="Sdk.props" Sdk="ILLink.Tasks" />
 
   <PropertyGroup>
-    <ILTransformForPublishDependsOn>$(ILTransformForPublishDependsOn);_ILLink</ILTransformForPublishDependsOn>
     <IntermediateLinkDir Condition=" '$(IntermediateLinkDir)' == '' ">$(IntermediateOutputPath)linked\</IntermediateLinkDir>
     <IntermediateLinkDir Condition=" !HasTrailingSlash('$(IntermediateLinkDir)') ">$(IntermediateLinkDir)\</IntermediateLinkDir>
     <!-- Used to enable incremental build for the linker target. -->

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -107,6 +107,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     -->
   <Target Name="ComputeAndCopyFilesToPublishDirectory"
           DependsOnTargets="ComputeFilesToPublish;
+                            ILTransform;
                             CreateReadyToRunImages;
                             CopyFilesToPublishDirectory" />
 
@@ -195,6 +196,17 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     </Copy>
   </Target>
+
+  <!--
+    ============================================================
+                                        ILTransform
+
+    Extension point for IL transformations.
+    ============================================================
+    -->
+  <Target Name="ILTransform"
+          Condition="'$(_TargetFrameworkVersionWithoutV)' >= '3.0' And '$(TargetFrameworkIdentifier)' == '.NETCoreApp'"
+          DependsOnTargets="$(ILTransformDependsOn)" />
 
   <!--
     ============================================================

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -107,7 +107,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     -->
   <Target Name="ComputeAndCopyFilesToPublishDirectory"
           DependsOnTargets="ComputeFilesToPublish;
-                            ILTransform;
+                            ILTransformForPublish;
                             CreateReadyToRunImages;
                             CopyFilesToPublishDirectory" />
 
@@ -199,14 +199,14 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <!--
     ============================================================
-                                        ILTransform
+                                        ILTransformForPublish
 
-    Extension point for IL transformations.
+    Extension point for IL transformations that happen on publish.
     ============================================================
     -->
-  <Target Name="ILTransform"
-          Condition="'$(_TargetFrameworkVersionWithoutV)' >= '3.0' And '$(TargetFrameworkIdentifier)' == '.NETCoreApp'"
-          DependsOnTargets="$(ILTransformDependsOn)" />
+  <Target Name="ILTransformForPublish"
+          Condition="'$(_TargetFrameworkVersionWithoutV)' >= '3.0' And ( '$(TargetFrameworkIdentifier)' == '.NETCoreApp' Or '$(TargetFrameworkIdentifier)' == '.NETStandard' )"
+          DependsOnTargets="$(ILTransformForPublishDependsOn)" />
 
   <!--
     ============================================================
@@ -749,7 +749,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       <_UseBuildDependencyFile Condition="'@(_ExcludeFromPublishPackageReference)' == '' and
                                           '@(RuntimeStorePackages)' == '' and
                                           '$(PreserveStoreLayout)' != 'true' and
-                                          '$(LinkDuringPublish)' != 'true'">true</_UseBuildDependencyFile>
+                                          '$(PublishTrimmed)' != 'true'">true</_UseBuildDependencyFile>
     </PropertyGroup>
 
   </Target>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -744,11 +744,12 @@ Copyright (c) .NET Foundation. All rights reserved.
           DependsOnTargets="_ComputeExcludeFromPublishPackageReferences;
                             _ParseTargetManifestFiles">
 
-    <!-- If there are no excluded packages or runtime store packages, then we can reuse the deps file from the build, -->
+    <!-- If there are no excluded packages or runtime store packages, and we are not linking, then we can reuse the deps file from the build, -->
     <PropertyGroup>
       <_UseBuildDependencyFile Condition="'@(_ExcludeFromPublishPackageReference)' == '' and
                                           '@(RuntimeStorePackages)' == '' and
-                                          '$(PreserveStoreLayout)' != 'true'">true</_UseBuildDependencyFile>
+                                          '$(PreserveStoreLayout)' != 'true' and
+                                          '$(LinkDuringPublish)' != 'true'">true</_UseBuildDependencyFile>
     </PropertyGroup>
 
   </Target>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -107,7 +107,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     -->
   <Target Name="ComputeAndCopyFilesToPublishDirectory"
           DependsOnTargets="ComputeFilesToPublish;
-                            ILTransformForPublish;
+                            _ILLink;
                             CreateReadyToRunImages;
                             CopyFilesToPublishDirectory" />
 
@@ -196,17 +196,6 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     </Copy>
   </Target>
-
-  <!--
-    ============================================================
-                                        ILTransformForPublish
-
-    Extension point for IL transformations that happen on publish.
-    ============================================================
-    -->
-  <Target Name="ILTransformForPublish"
-          Condition="'$(_TargetFrameworkVersionWithoutV)' >= '3.0' And ( '$(TargetFrameworkIdentifier)' == '.NETCoreApp' Or '$(TargetFrameworkIdentifier)' == '.NETStandard' )"
-          DependsOnTargets="$(ILTransformForPublishDependsOn)" />
 
   <!--
     ============================================================

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -753,4 +753,5 @@ Copyright (c) .NET Foundation. All rights reserved.
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.NET.Sdk.CSharp.targets" Condition="'$(Language)' == 'C#'" />
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.NET.Sdk.VisualBasic.targets" Condition="'$(Language)' == 'VB'" />
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.NET.Sdk.FSharp.targets" Condition="'$(Language)' == 'F#'" />
+  <Import Project="$(MSBuildThisFileDirectory)Microsoft.NET.ILLink.targets" />
 </Project>

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToRunILLink.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToRunILLink.cs
@@ -1,0 +1,303 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyModel;
+using Microsoft.NET.TestFramework;
+using Microsoft.NET.TestFramework.Assertions;
+using Microsoft.NET.TestFramework.Commands;
+using Microsoft.NET.TestFramework.ProjectConstruction;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.NET.Publish.Tests
+{
+    public class GivenThatWeWantToRunILLink : SdkTest
+    {
+        public GivenThatWeWantToRunILLink(ITestOutputHelper log) : base(log)
+        {
+        }
+
+        [Theory]
+        [InlineData("netcoreapp3.0")]
+        public void ILLink_only_runs_when_switch_is_enabled(string targetFramework)
+        {
+            var projectName = "HelloWorld";
+            var referenceProjectName = "ClassLib";
+            var rid = EnvironmentInfo.GetCompatibleRid(targetFramework);
+
+            var testProject = CreateTestProjectForILLinkTesting(targetFramework, projectName, referenceProjectName);
+            var testAsset = _testAssetsManager.CreateTestProject(testProject)
+                .Restore(Log, testProject.Name, args: $"/p:RuntimeIdentifier={rid}");
+
+            var publishCommand = new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            publishCommand.Execute($"/p:RuntimeIdentifier={rid}", $"/p:SelfContained=true").Should().Pass();
+
+            var publishDirectory = publishCommand.GetOutputDirectory(targetFramework: targetFramework, runtimeIdentifier: rid).FullName;
+            var intermediateDirectory = publishCommand.GetIntermediateDirectory(targetFramework: targetFramework, runtimeIdentifier: rid).FullName;
+            var linkedDirectory = Path.Combine(intermediateDirectory, "linked");
+
+            Directory.Exists(linkedDirectory).Should().BeFalse();
+
+            var publishedDll = Path.Combine(publishDirectory, $"{projectName}.dll");
+            var unusedDll = Path.Combine(publishDirectory, $"{referenceProjectName}.dll");
+
+            // Linker inputs are kept, including unused assemblies
+            File.Exists(publishedDll).Should().BeTrue();
+            File.Exists(unusedDll).Should().BeTrue();
+        }
+
+        [Theory]
+        [InlineData("netcoreapp3.0")]
+        public void ILLink_runs_and_creates_linked_app(string targetFramework)
+        {
+            var projectName = "HelloWorld";
+            var referenceProjectName = "ClassLib";
+            var rid = EnvironmentInfo.GetCompatibleRid(targetFramework);
+
+            var testProject = CreateTestProjectForILLinkTesting(targetFramework, projectName, referenceProjectName);
+            var testAsset = _testAssetsManager.CreateTestProject(testProject)
+                .Restore(Log, testProject.Name, args: $"/p:RuntimeIdentifier={rid}");
+
+            var publishCommand = new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            publishCommand.Execute($"/p:RuntimeIdentifier={rid}", $"/p:SelfContained=true", "/p:LinkDuringPublish=true").Should().Pass();
+
+            var publishDirectory = publishCommand.GetOutputDirectory(targetFramework: targetFramework, runtimeIdentifier: rid).FullName;
+            var intermediateDirectory = publishCommand.GetIntermediateDirectory(targetFramework: targetFramework, runtimeIdentifier: rid).FullName;
+            var linkedDirectory = Path.Combine(intermediateDirectory, "linked");
+
+            Directory.Exists(linkedDirectory).Should().BeTrue();
+
+            var linkedDll = Path.Combine(linkedDirectory, $"{projectName}.dll");
+            var publishedDll = Path.Combine(publishDirectory, $"{projectName}.dll");
+            var unusedDll = Path.Combine(publishDirectory, $"{referenceProjectName}.dll");
+
+            // Intermediate assembly is kept by linker and published, but not unused assemblies
+            File.Exists(linkedDll).Should().BeTrue();
+            File.Exists(publishedDll).Should().BeTrue();
+            File.Exists(unusedDll).Should().BeFalse();
+
+            var depsFile = Path.Combine(publishDirectory, $"{projectName}.deps.json");
+            DoesDepsFileHaveAssembly(depsFile, referenceProjectName).Should().BeFalse();
+        }
+
+        [Theory]
+        [InlineData("netcoreapp3.0")]
+        public void ILLink_accepts_root_descriptor(string targetFramework)
+        {
+            var projectName = "HelloWorld";
+            var referenceProjectName = "ClassLib";
+            var rid = EnvironmentInfo.GetCompatibleRid(targetFramework);
+
+            var testProject = CreateTestProjectForILLinkTesting(targetFramework, projectName, referenceProjectName);
+            var testAsset = _testAssetsManager.CreateTestProject(testProject)
+                .Restore(Log, testProject.Name, args: $"/p:RuntimeIdentifier={rid}");
+
+            var publishCommand = new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            publishCommand.Execute($"/p:RuntimeIdentifier={rid}", $"/p:SelfContained=true", "/p:LinkDuringPublish=true",
+                                   $"/p:LinkerRootDescriptors={referenceProjectName}.xml").Should().Pass();
+
+            var publishDirectory = publishCommand.GetOutputDirectory(targetFramework: targetFramework, runtimeIdentifier: rid).FullName;
+            var publishedDll = Path.Combine(publishDirectory, $"{projectName}.dll");
+            var unusedDll = Path.Combine(publishDirectory, $"{referenceProjectName}.dll");
+
+            // With root descriptor, linker keeps specified roots but removes unused methods
+            File.Exists(publishedDll).Should().BeTrue();
+            File.Exists(unusedDll).Should().BeTrue();
+            DoesImageHaveMethod(unusedDll, "UnusedMethod").Should().BeFalse();
+            DoesImageHaveMethod(unusedDll, "UnusedMethodToRoot").Should().BeTrue();
+        }
+
+        [Theory]
+        [InlineData("netcoreapp3.0")]
+        public void ILLink_runs_incrementally(string targetFramework)
+        {
+            var projectName = "HelloWorld";
+            var referenceProjectName = "ClassLib";
+            var rid = EnvironmentInfo.GetCompatibleRid(targetFramework);
+
+            var testProject = CreateTestProjectForILLinkTesting(targetFramework, projectName, referenceProjectName);
+            var testAsset = _testAssetsManager.CreateTestProject(testProject)
+                .Restore(Log, testProject.Name, args: $"/p:RuntimeIdentifier={rid}");
+
+            var publishCommand = new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+
+            var publishDirectory = publishCommand.GetOutputDirectory(targetFramework: targetFramework, runtimeIdentifier: rid).FullName;
+            var intermediateDirectory = publishCommand.GetIntermediateDirectory(targetFramework: targetFramework, runtimeIdentifier: rid).FullName;
+            var linkedDirectory = Path.Combine(intermediateDirectory, "linked");
+
+            var linkSemaphore = Path.Combine(intermediateDirectory, "Link.semaphore");
+
+            publishCommand.Execute($"/p:RuntimeIdentifier={rid}", $"/p:SelfContained=true", "/p:LinkDuringPublish=true").Should().Pass();
+            DateTime semaphoreFirstModifiedTime = File.GetLastWriteTimeUtc(linkSemaphore);
+
+            WaitForUtcNowToAdvance();
+
+            publishCommand.Execute($"/p:RuntimeIdentifier={rid}", $"/p:SelfContained=true", "/p:LinkDuringPublish=true").Should().Pass();
+            DateTime semaphoreSecondModifiedTime = File.GetLastWriteTimeUtc(linkSemaphore);
+
+            semaphoreFirstModifiedTime.Should().Be(semaphoreSecondModifiedTime);
+        }
+
+        [Theory]
+        [InlineData("netcoreapp3.0")]
+        public void ILLink_does_not_include_leftover_artifacts_on_second_run(string targetFramework)
+        {
+            var projectName = "HelloWorld";
+            var referenceProjectName = "ClassLib";
+            var rid = EnvironmentInfo.GetCompatibleRid(targetFramework);
+
+            var testProject = CreateTestProjectForILLinkTesting(targetFramework, projectName, referenceProjectName);
+            var testAsset = _testAssetsManager.CreateTestProject(testProject)
+                .Restore(Log, testProject.Name, args: $"/p:RuntimeIdentifier={rid}");
+
+            var publishCommand = new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+
+            var publishDirectory = publishCommand.GetOutputDirectory(targetFramework: targetFramework, runtimeIdentifier: rid).FullName;
+            var intermediateDirectory = publishCommand.GetIntermediateDirectory(targetFramework: targetFramework, runtimeIdentifier: rid).FullName;
+            var linkedDirectory = Path.Combine(intermediateDirectory, "linked");
+
+            var linkSemaphore = Path.Combine(intermediateDirectory, "Link.semaphore");
+
+            // Link, keeping classlib
+            publishCommand.Execute($"/p:RuntimeIdentifier={rid}", $"/p:SelfContained=true", "/p:LinkDuringPublish=true",
+                                   $"/p:LinkerRootDescriptors={referenceProjectName}.xml").Should().Pass();
+            var publishedDllKeptFirstTimeOnly = Path.Combine(publishDirectory, $"{referenceProjectName}.dll");
+            var linkedDllKeptFirstTimeOnly = Path.Combine(linkedDirectory, $"{referenceProjectName}.dll");
+            File.Exists(linkedDllKeptFirstTimeOnly).Should().BeTrue();
+            File.Exists(publishedDllKeptFirstTimeOnly).Should().BeTrue();
+
+            // Delete kept dll from publish output (works around lack of incremental publish)
+            File.Delete(publishedDllKeptFirstTimeOnly);
+
+            // Modify input timestamp to force a re-build and re-link
+            WaitForUtcNowToAdvance();
+            File.SetLastWriteTimeUtc(Path.Combine(testAsset.TestRoot, testProject.Name, $"{projectName}.cs"), DateTime.UtcNow);
+
+            // Link, discarding classlib
+            publishCommand.Execute($"/p:RuntimeIdentifier={rid}", $"/p:SelfContained=true", "/p:LinkDuringPublish=true").Should().Pass();
+            File.Exists(linkedDllKeptFirstTimeOnly).Should().BeFalse();
+            File.Exists(publishedDllKeptFirstTimeOnly).Should().BeFalse();
+
+            // "linked" intermediate directory does not pollute the publish output
+            Directory.Exists(Path.Combine(publishDirectory, "linked")).Should().BeFalse();
+        }
+
+        [Theory]
+        [InlineData("netcoreapp3.0")]
+        public void ILLink_runs_on_portable_app(string targetFramework)
+        {
+            var projectName = "HelloWorld";
+            var referenceProjectName = "ClassLib";
+
+            var testProject = CreateTestProjectForILLinkTesting(targetFramework, projectName, referenceProjectName);
+            var testAsset = _testAssetsManager.CreateTestProject(testProject)
+                .Restore(Log, testProject.Name);
+
+            var publishCommand = new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            publishCommand.Execute("/p:LinkDuringPublish=true").Should().Pass();
+
+            var publishDirectory = publishCommand.GetOutputDirectory(targetFramework: targetFramework).FullName;
+            var intermediateDirectory = publishCommand.GetIntermediateDirectory(targetFramework: targetFramework).FullName;
+            var linkedDirectory = Path.Combine(intermediateDirectory, "linked");
+
+            Directory.Exists(linkedDirectory).Should().BeTrue();
+
+            var linkedDll = Path.Combine(linkedDirectory, $"{projectName}.dll");
+            var publishedDll = Path.Combine(publishDirectory, $"{projectName}.dll");
+            var unusedDll = Path.Combine(publishDirectory, $"{referenceProjectName}.dll");
+
+            File.Exists(linkedDll).Should().BeTrue();
+            File.Exists(publishedDll).Should().BeTrue();
+            File.Exists(unusedDll).Should().BeFalse();
+
+            var depsFile = Path.Combine(publishDirectory, $"{projectName}.deps.json");
+            DoesDepsFileHaveAssembly(depsFile, referenceProjectName).Should().BeFalse();
+        }
+
+        private static bool DoesImageHaveMethod(string path, string methodNameToCheck)
+        {
+            using (FileStream fs = new FileStream(path, FileMode.Open, FileAccess.Read))
+            using (var peReader = new PEReader(fs))
+            {
+                var metadataReader = peReader.GetMetadataReader();
+                foreach (var handle in metadataReader.MethodDefinitions)
+                {
+                    var methodDefinition = metadataReader.GetMethodDefinition(handle);
+                    string methodName = metadataReader.GetString(methodDefinition.Name);
+                    if (methodName == methodNameToCheck)
+                        return true;
+                }
+            }
+            return false;
+        }
+
+        private static bool DoesDepsFileHaveAssembly(string depsFilePath, string assemblyName)
+        {
+            DependencyContext dependencyContext;
+            using (var fs = File.OpenRead(depsFilePath))
+            {
+                dependencyContext = new DependencyContextJsonReader().Read(fs);
+            }
+
+            var runtimeLibrary = dependencyContext.RuntimeLibraries.Single(l => l.Name == assemblyName);
+            var runtimeFiles = runtimeLibrary.RuntimeAssemblyGroups.SelectMany(rag => rag.RuntimeFiles).ToList();
+            return runtimeFiles.Any();
+        }
+
+        private TestProject CreateTestProjectForILLinkTesting(string targetFramework, string mainProjectName, string referenceProjectName)
+        {
+            var referenceProject = new TestProject()
+            {
+                Name = referenceProjectName,
+                TargetFrameworks = targetFramework,
+                IsSdkProject = true
+            };
+            referenceProject.SourceFiles[$"{referenceProjectName}.cs"] = @"
+using System;
+public class ClassLib
+{
+    public void UnusedMethod()
+    {
+    }
+
+    public void UnusedMethodToRoot()
+    {
+    }
+}
+";
+
+            var testProject = new TestProject()
+            {
+                Name = mainProjectName,
+                TargetFrameworks = targetFramework,
+                IsSdkProject = true,
+                ReferencedProjects = { referenceProject }
+            };
+            testProject.SourceFiles[$"{mainProjectName}.cs"] = @"
+using System;
+public class Program
+{
+    public static void Main()
+    {
+        Console.WriteLine(""Hello world"");
+    }
+}
+";
+
+            testProject.SourceFiles[$"{referenceProjectName}.xml"] = $@"
+<linker>
+  <assembly fullname=""{referenceProjectName}"">
+    <type fullname=""ClassLib"">
+      <method name=""UnusedMethodToRoot"" />
+    </type>
+  </assembly>
+</linker>
+";
+
+            return testProject;
+        }
+    }
+}

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToRunILLink.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToRunILLink.cs
@@ -68,7 +68,7 @@ namespace Microsoft.NET.Publish.Tests
                 .Restore(Log, testProject.Name, args: $"/p:RuntimeIdentifier={rid}");
 
             var publishCommand = new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
-            publishCommand.Execute($"/p:RuntimeIdentifier={rid}", $"/p:SelfContained=true", "/p:LinkDuringPublish=true").Should().Pass();
+            publishCommand.Execute($"/p:RuntimeIdentifier={rid}", $"/p:SelfContained=true", "/p:PublishTrimmed=true").Should().Pass();
 
             var publishDirectory = publishCommand.GetOutputDirectory(targetFramework: targetFramework, runtimeIdentifier: rid).FullName;
             var intermediateDirectory = publishCommand.GetIntermediateDirectory(targetFramework: targetFramework, runtimeIdentifier: rid).FullName;
@@ -106,8 +106,8 @@ namespace Microsoft.NET.Publish.Tests
                 .Restore(Log, testProject.Name, args: $"/p:RuntimeIdentifier={rid}");
 
             var publishCommand = new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
-            publishCommand.Execute($"/p:RuntimeIdentifier={rid}", $"/p:SelfContained=true", "/p:LinkDuringPublish=true",
-                                   $"/p:LinkerRootDescriptors={referenceProjectName}.xml").Should().Pass();
+            publishCommand.Execute($"/p:RuntimeIdentifier={rid}", $"/p:SelfContained=true", "/p:PublishTrimmed=true",
+                                   $"/p:TrimmerRootDescriptors={referenceProjectName}.xml").Should().Pass();
 
             var publishDirectory = publishCommand.GetOutputDirectory(targetFramework: targetFramework, runtimeIdentifier: rid).FullName;
             var publishedDll = Path.Combine(publishDirectory, $"{projectName}.dll");
@@ -140,12 +140,12 @@ namespace Microsoft.NET.Publish.Tests
 
             var linkSemaphore = Path.Combine(intermediateDirectory, "Link.semaphore");
 
-            publishCommand.Execute($"/p:RuntimeIdentifier={rid}", $"/p:SelfContained=true", "/p:LinkDuringPublish=true").Should().Pass();
+            publishCommand.Execute($"/p:RuntimeIdentifier={rid}", $"/p:SelfContained=true", "/p:PublishTrimmed=true").Should().Pass();
             DateTime semaphoreFirstModifiedTime = File.GetLastWriteTimeUtc(linkSemaphore);
 
             WaitForUtcNowToAdvance();
 
-            publishCommand.Execute($"/p:RuntimeIdentifier={rid}", $"/p:SelfContained=true", "/p:LinkDuringPublish=true").Should().Pass();
+            publishCommand.Execute($"/p:RuntimeIdentifier={rid}", $"/p:SelfContained=true", "/p:PublishTrimmed=true").Should().Pass();
             DateTime semaphoreSecondModifiedTime = File.GetLastWriteTimeUtc(linkSemaphore);
 
             semaphoreFirstModifiedTime.Should().Be(semaphoreSecondModifiedTime);
@@ -172,8 +172,8 @@ namespace Microsoft.NET.Publish.Tests
             var linkSemaphore = Path.Combine(intermediateDirectory, "Link.semaphore");
 
             // Link, keeping classlib
-            publishCommand.Execute($"/p:RuntimeIdentifier={rid}", $"/p:SelfContained=true", "/p:LinkDuringPublish=true",
-                                   $"/p:LinkerRootDescriptors={referenceProjectName}.xml").Should().Pass();
+            publishCommand.Execute($"/p:RuntimeIdentifier={rid}", $"/p:SelfContained=true", "/p:PublishTrimmed=true",
+                                   $"/p:TrimmerRootDescriptors={referenceProjectName}.xml").Should().Pass();
             var publishedDllKeptFirstTimeOnly = Path.Combine(publishDirectory, $"{referenceProjectName}.dll");
             var linkedDllKeptFirstTimeOnly = Path.Combine(linkedDirectory, $"{referenceProjectName}.dll");
             File.Exists(linkedDllKeptFirstTimeOnly).Should().BeTrue();
@@ -187,7 +187,7 @@ namespace Microsoft.NET.Publish.Tests
             File.SetLastWriteTimeUtc(Path.Combine(testAsset.TestRoot, testProject.Name, $"{projectName}.cs"), DateTime.UtcNow);
 
             // Link, discarding classlib
-            publishCommand.Execute($"/p:RuntimeIdentifier={rid}", $"/p:SelfContained=true", "/p:LinkDuringPublish=true").Should().Pass();
+            publishCommand.Execute($"/p:RuntimeIdentifier={rid}", $"/p:SelfContained=true", "/p:PublishTrimmed=true").Should().Pass();
             File.Exists(linkedDllKeptFirstTimeOnly).Should().BeFalse();
             File.Exists(publishedDllKeptFirstTimeOnly).Should().BeFalse();
 
@@ -207,7 +207,7 @@ namespace Microsoft.NET.Publish.Tests
                 .Restore(Log, testProject.Name);
 
             var publishCommand = new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
-            publishCommand.Execute("/p:LinkDuringPublish=true").Should().Pass();
+            publishCommand.Execute("/p:PublishTrimmed=true").Should().Pass();
 
             var publishDirectory = publishCommand.GetOutputDirectory(targetFramework: targetFramework).FullName;
             var intermediateDirectory = publishCommand.GetIntermediateDirectory(targetFramework: targetFramework).FullName;


### PR DESCRIPTION
This adds linker targets, mostly adapted from https://github.com/mono/linker/blob/9766e2b2406a3d44cbf05e49ab2bd19b535e3e5a/src/ILLink.Tasks/ILLink.Tasks.targets, to run the linker after `ComputeFilesToPublish`.

A few things still need to change (but I wanted to get what I have so far out for review):
- ~~Change property names to agreed-upon strings~~
- ~~Update deps file generation in response to https://github.com/dotnet/sdk/pull/3086. I think this needs https://github.com/dotnet/sdk/pull/3113 or another update PR to be merged.~~
- ~~Update the linker:~~
  - ~~to include `UsingTask` for other tasks in the assembly (namely, `ComputeManagedAssemblies`)~~
  - ~~for `ReferencePath` support~~
  - ~~with a net472 build of the task dll~~

~~When I run these tests locally with a recent version of the linker, the checks pass up to the deps file asserts.~~
All checks are passing.

@nguerrera, @fadimounir, @swaroop-sridhar PTAL