### PR TITLE
ILLink cleanup

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ILLink.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ILLink.targets
@@ -79,7 +79,7 @@ Copyright (c) .NET Foundation. All rights reserved.
              RootAssemblyNames="@(IntermediateAssembly->'%(Filename)')"
              RootDescriptorFiles="@(TrimmerRootDescriptor)"
              OutputDirectory="$(IntermediateLinkDir)"
-             ExtraArgs="$(_ExtraTrimmerArgs) --skip-unresolved true" />
+             ExtraArgs="-u copyused -c copyused -l none --skip-unresolved true $(_ExtraTrimmerArgs)" />
 
      <Touch Files="$(_LinkSemaphore)" AlwaysCreate="true" />
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ILLink.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ILLink.targets
@@ -18,9 +18,6 @@ Copyright (c) .NET Foundation. All rights reserved.
     <IntermediateLinkDir Condition=" !HasTrailingSlash('$(IntermediateLinkDir)') ">$(IntermediateLinkDir)\</IntermediateLinkDir>
     <!-- Used to enable incremental build for the linker target. -->
     <_LinkSemaphore>$(IntermediateOutputPath)Link.semaphore</_LinkSemaphore>
-    <!-- Disable old deps file generation logic until
-         https://github.com/dotnet/sdk/issues/3098 is fixed. -->
-    <DepsFileGenerationMode>new</DepsFileGenerationMode>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ILLink.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ILLink.targets
@@ -20,10 +20,6 @@ Copyright (c) .NET Foundation. All rights reserved.
     <_LinkSemaphore>$(IntermediateOutputPath)Link.semaphore</_LinkSemaphore>
   </PropertyGroup>
 
-  <ItemGroup>
-    <TrimmerRootDescriptors Include="$(TrimmerRootDescriptors)" />
-  </ItemGroup>
-
   <!--
     ============================================================
                      _ILLink
@@ -74,14 +70,14 @@ Copyright (c) .NET Foundation. All rights reserved.
    <UsingTask TaskName="ILLink" AssemblyFile="$(ILLinkTasksAssembly)" />
    <Target Name="_RunILLink"
            DependsOnTargets="_ComputeManagedAssembliesToLink"
-           Inputs="$(MSBuildAllProjects);@(_ManagedAssembliesToLink);@(TrimmerRootDescriptors);@(ReferencePath)"
+           Inputs="$(MSBuildAllProjects);@(_ManagedAssembliesToLink);@(TrimmerRootDescriptor);@(ReferencePath)"
            Outputs="$(_LinkSemaphore)">
 
      <Delete Files="@(_LinkedResolvedFileToPublishCandidates)" />
      <ILLink AssemblyPaths="@(_ManagedAssembliesToLink)"
              ReferenceAssemblyPaths="@(ReferencePath)"
              RootAssemblyNames="@(IntermediateAssembly->'%(Filename)')"
-             RootDescriptorFiles="@(TrimmerRootDescriptors)"
+             RootDescriptorFiles="@(TrimmerRootDescriptor)"
              OutputDirectory="$(IntermediateLinkDir)"
              ExtraArgs="$(_ExtraTrimmerArgs) --skip-unresolved true" />
 


### PR DESCRIPTION
Respond to remaining feedback from https://github.com/dotnet/sdk/pull/3125:
- Use default deps generation mode
- Use `TrimmerRootDescriptor` (singular) itemgroup, without a corresponding property

@swaroop-sridhar The second two commits set the proper linker defaults. I made them part of the same PR to avoid having to fix merge conflicts between these changes.