### PR TITLE
Mark PDB files generated by R2R as ExcludeFromSingleFile

### DIFF
--- a/src/Tasks/Common/MetadataKeys.cs
+++ b/src/Tasks/Common/MetadataKeys.cs
@@ -82,6 +82,7 @@ namespace Microsoft.NET.Build.Tasks
         public const string BuildAction = "BuildAction";
         public const string OutputPath = "OutputPath";
         public const string CopyToPublishDirectory = "CopyToPublishDirectory";
+        public const string ExcludeFromSingleFile = "ExcludeFromSingleFile";
 
         // Resource assemblies
         public const string Culture = "Culture";

--- a/src/Tasks/Microsoft.NET.Build.Tasks/PrepareForReadyToRunCompilation.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/PrepareForReadyToRunCompilation.cs
@@ -31,6 +31,8 @@ namespace Microsoft.NET.Build.Tasks
         public string RuntimeGraphPath { get; set; }
         [Required]
         public string NETCoreSdkRuntimeIdentifier { get; set; }
+        [Required]
+        public bool IncludeSymbolsInSingleFile { get; set; }
 
         [Output]
         public ITaskItem CrossgenTool { get; set; }
@@ -184,6 +186,11 @@ namespace Microsoft.NET.Build.Tasks
                         r2rSymbolsFileToPublish.ItemSpec = outputPDBImage;
                         r2rSymbolsFileToPublish.SetMetadata(MetadataKeys.RelativePath, outputPDBImageRelativePath);
                         r2rSymbolsFileToPublish.RemoveMetadata(MetadataKeys.OriginalItemSpec);
+                        if(!IncludeSymbolsInSingleFile)
+                        {
+                            r2rSymbolsFileToPublish.SetMetadata(MetadataKeys.ExcludeFromSingleFile, "true");
+                        }
+
                         r2rFilesPublishList.Add(r2rSymbolsFileToPublish);
                     }
                 }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/PrepareForReadyToRunCompilation.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/PrepareForReadyToRunCompilation.cs
@@ -186,7 +186,7 @@ namespace Microsoft.NET.Build.Tasks
                         r2rSymbolsFileToPublish.ItemSpec = outputPDBImage;
                         r2rSymbolsFileToPublish.SetMetadata(MetadataKeys.RelativePath, outputPDBImageRelativePath);
                         r2rSymbolsFileToPublish.RemoveMetadata(MetadataKeys.OriginalItemSpec);
-                        if(!IncludeSymbolsInSingleFile)
+                        if (!IncludeSymbolsInSingleFile)
                         {
                             r2rSymbolsFileToPublish.SetMetadata(MetadataKeys.ExcludeFromSingleFile, "true");
                         }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -92,6 +92,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <PropertyGroup>
       <!-- Ensure any PublishDir has a trailing slash, so it can be concatenated -->
       <PublishDir Condition="!HasTrailingSlash('$(PublishDir)')">$(PublishDir)\</PublishDir>
+      <IncludeSymbolsInSingleFile Condition="'$(IncludeSymbolsInSingleFile)' == ''">false</IncludeSymbolsInSingleFile>
     </PropertyGroup>
 
     <MakeDir Directories="$(PublishDir)" />
@@ -251,7 +252,8 @@ Copyright (c) .NET Foundation. All rights reserved.
                                      OutputPath="$(_ReadyToRunOutputPath)"
                                      FilesToPublish="@(ResolvedFileToPublish)"
                                      ExcludeList="@(PublishReadyToRunExclude)"
-                                     EmitSymbols="$(PublishReadyToRunEmitSymbols)">
+                                     EmitSymbols="$(PublishReadyToRunEmitSymbols)"
+                                     IncludeSymbolsInSingleFile="$(IncludeSymbolsInSingleFile)">
 
       <Output TaskParameter="CrossgenTool" ItemName="_CrossgenTool" />
 
@@ -769,10 +771,6 @@ Copyright (c) .NET Foundation. All rights reserved.
           DependsOnTargets="_ComputeFilesToBundle" 
           Inputs="@(_FilesToBundle)"
           Outputs="$(PublishDir)$(AssemblyName)$(_NativeExecutableExtension)">
-
-    <PropertyGroup>
-      <IncludeSymbolsInSingleFile Condition="'$(IncludeSymbolsInSingleFile)' == ''">false</IncludeSymbolsInSingleFile>
-    </PropertyGroup>
 
     <GenerateBundle FilesToBundle="@(_FilesToBundle)"
                     AppHostName="$(AssemblyName)$(_NativeExecutableExtension)"

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishASingleFileApp.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishASingleFileApp.cs
@@ -26,10 +26,12 @@ namespace Microsoft.NET.Publish.Tests
         private const string ExcludeContent = "/p:ExcludeContent=true";
         private const string DontUseAppHost = "/p:UseAppHost=false";
         private const string ReadyToRun = "/p:PublishReadyToRun=true";
+        private const string ReadyToRunWithSymbols = "/p:PublishReadyToRunEmitSymbols=true";
 
         private readonly string RuntimeIdentifier = $"/p:RuntimeIdentifier={RuntimeEnvironment.GetRuntimeIdentifier()}";
         private readonly string SingleFile = $"{TestProjectName}{Constants.ExeSuffix}";
         private readonly string PdbFile = $"{TestProjectName}.pdb";
+        private readonly string NiPdbFile = $"{TestProjectName}.ni.pdb";
         private const string ContentFile = "Signature.stamp";
 
         public GivenThatWeWantToPublishASingleFileApp(ITestOutputHelper log) : base(log)
@@ -133,6 +135,36 @@ namespace Microsoft.NET.Publish.Tests
             var publishCommand = GetPublishCommand();
             publishCommand
                 .Execute(PublishSingleFile, RuntimeIdentifier, IncludePdb)
+                .Should()
+                .Pass();
+
+            string[] expectedFiles = { SingleFile };
+            GetPublishDirectory(publishCommand)
+                .Should()
+                .OnlyHaveFiles(expectedFiles);
+        }
+
+        [WindowsOnlyFact]
+        public void It_excludes_ni_pdbs_from_single_file()
+        {
+            var publishCommand = GetPublishCommand();
+            publishCommand
+                .Execute(PublishSingleFile, RuntimeIdentifier, ReadyToRun, ReadyToRunWithSymbols)
+                .Should()
+                .Pass();
+
+            string[] expectedFiles = { SingleFile, PdbFile, NiPdbFile };
+            GetPublishDirectory(publishCommand)
+                .Should()
+                .OnlyHaveFiles(expectedFiles);
+        }
+
+        [WindowsOnlyFact]
+        public void It_can_include_ni_pdbs_in_single_file()
+        {
+            var publishCommand = GetPublishCommand();
+            publishCommand
+                .Execute(PublishSingleFile, RuntimeIdentifier, ReadyToRun, ReadyToRunWithSymbols, IncludePdb)
                 .Should()
                 .Pass();
 


### PR DESCRIPTION
When published with `PublishReadyToRun=true` and `PublishReadyToRunEmitSymbols=true` certain additional symbol files are generated:
On Windows: `<app>.ni.pdb`
On Linux: `<app>.<guid>.map`

When additionally publishing with `PublishSingleFile=true` exclude the above files from being bundled into the single-file output.