### PR TITLE
Updates for running tests as tools

### DIFF
--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildALibrary.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildALibrary.cs
@@ -38,14 +38,13 @@ namespace Microsoft.NET.Build.Tests
             var testAsset = _testAssetsManager
                 .CopyTestAsset("AppWithLibrary", identifier: targetFramework)
                 .WithSource()
-                .WithTargetFramework(targetFramework, "TestLibrary")
-                .Restore(Log, relativePath: "TestLibrary");
+                .WithTargetFramework(targetFramework, "TestLibrary");
 
             var libraryProjectDirectory = Path.Combine(testAsset.TestRoot, "TestLibrary");
 
             var buildCommand = new BuildCommand(Log, libraryProjectDirectory);
             buildCommand
-                .Execute()
+                .Execute("/restore", "/bl:" + Path.Combine(libraryProjectDirectory, "build.binlog"))
                 .Should()
                 .Pass();
 

--- a/src/Tests/Microsoft.NET.TestFramework/TestCommandLine.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/TestCommandLine.cs
@@ -25,6 +25,8 @@ namespace Microsoft.NET.TestFramework
 
         public string SdkVersion { get; private set; }
 
+        public string TestExecutionDirectory { get; set; }
+
         public bool ShowSdkInfo { get; private set; }
 
         public static TestCommandLine Parse(string[] args)
@@ -63,6 +65,10 @@ namespace Microsoft.NET.TestFramework
                 else if (arg.Equals("-sdkVersion", StringComparison.CurrentCultureIgnoreCase))
                 {
                     ret.SdkVersion = argStack.Pop();
+                }
+                else if (arg.Equals("-testExecutionDirectory", StringComparison.CurrentCultureIgnoreCase))
+                {
+                    ret.TestExecutionDirectory = argStack.Pop();
                 }
                 else if (arg.Equals("-showSdkInfo", StringComparison.CurrentCultureIgnoreCase))
                 {
@@ -123,6 +129,7 @@ Options to control toolset to test:
   -sdkConfig <config>     : Use specified configuration for SDK repo
   -noRepoInference        : Don't automatically find SDK repo to use based on path to test binaries
   -sdkVersion             : Use specified SDK version
+  -testExecutionDirectory : Folder for tests to create and build projects
   -showSdkInfo            : Shows SDK info (dotnet --info) for SDK which will be used
   -help                   : Show help");
         }

--- a/src/Tests/Microsoft.NET.TestFramework/TestContext.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/TestContext.cs
@@ -110,7 +110,11 @@ namespace Microsoft.NET.TestFramework
                 }
             }
 
-            if (runAsTool)
+            if (!string.IsNullOrEmpty(commandLine.TestExecutionDirectory))
+            {
+                testContext.TestExecutionDirectory = commandLine.TestExecutionDirectory;
+            }
+            else if (runAsTool)
             {
                 testContext.TestExecutionDirectory = Path.Combine(Path.GetTempPath(), "dotnetSdkTests");
             }


### PR DESCRIPTION
- Allow test execution directory to be specified via command line
- Create .binlogs for basic library building tests (this can help to investigate the environment the tests are running in, which SDK is used, etc.)