### PR TITLE
Ignore NuGet warning NU5123 (for long paths)

### DIFF
--- a/src/Tests/Directory.Build.props
+++ b/src/Tests/Directory.Build.props
@@ -11,6 +11,11 @@
   <PropertyGroup>
     <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
     <NoWarn>$(NoWarn);NU5125</NoWarn>
+
+    <!-- Don't warn about long filenames in packages, we bundle test assets that have long paths
+         (ie HelloWorldWithSubDirs) -->
+    <NoWarn>$(NoWarn);NU5123</NoWarn>
+    
     <GenerateProgramFile>false</GenerateProgramFile>
   </PropertyGroup>
 


### PR DESCRIPTION
#3132 added a test project with a long path in it (HelloWorldWithSubDirs).  When we create dotnet tool packages for the tests, we bundle the test assets in them, and this is triggering [NU5123](https://docs.microsoft.com/en-us/nuget/reference/errors-and-warnings/nu5123) [in our builds](https://dev.azure.com/dnceng/internal/_build/results?buildId=166542).

So this PR fixes this by ignoring that NuGet warning.