### PR TITLE
Fix KeyNotFoundException in GenerateDepsFile task

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/DependencyContextBuilder2.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/DependencyContextBuilder2.cs
@@ -769,9 +769,9 @@ namespace Microsoft.NET.Build.Tasks
                         //  There may not be a library in the assets file if a referenced project has
                         //  PrivateAssets="all" for a package reference, and there is a package in the graph
                         //  that depends on the same packge.
-                        if (_dependencyLibraries.ContainsKey(dependencyName))
+                        if (_dependencyLibraries.TryGetValue(dependencyName, out var dependencyLibrary))
                         {
-                            includedDependencies.Add(dependencyName, _dependencyLibraries[dependencyName]);
+                            includedDependencies.Add(dependencyName, dependencyLibrary);
                             foreach (var newDependency in _libraryDependencies[dependencyName])
                             {
                                 dependenciesToWalk.Push(newDependency.Name);

--- a/src/Tasks/Microsoft.NET.Build.Tasks/DependencyContextBuilder2.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/DependencyContextBuilder2.cs
@@ -766,10 +766,16 @@ namespace Microsoft.NET.Build.Tasks
                     var dependencyName = dependenciesToWalk.Pop();
                     if (!includedDependencies.ContainsKey(dependencyName))
                     {
-                        includedDependencies.Add(dependencyName, _dependencyLibraries[dependencyName]);
-                        foreach (var newDependency in _libraryDependencies[dependencyName])
+                        //  There may not be a library in the assets file if a referenced project has
+                        //  PrivateAssets="all" for a package reference, and there is a package in the graph
+                        //  that depends on the same packge.
+                        if (_dependencyLibraries.ContainsKey(dependencyName))
                         {
-                            dependenciesToWalk.Push(newDependency.Name);
+                            includedDependencies.Add(dependencyName, _dependencyLibraries[dependencyName]);
+                            foreach (var newDependency in _libraryDependencies[dependencyName])
+                            {
+                                dependenciesToWalk.Push(newDependency.Name);
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
This would occur when there was a library in the assets file with a dependency on a library that wasn't in the assets file.

Fixes #3159