### PR TITLE
Import publish profiles in the .NET Core SDK.

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.BeforeCommon.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.BeforeCommon.targets
@@ -25,6 +25,12 @@ Copyright (c) .NET Foundation. All rights reserved.
   <!-- Set default intermediate and output paths -->
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.NET.DefaultOutputPaths.targets" />
   
+  <!-- Before any additional SDK targets are imported, import the publish profile.
+       This allows the publish profile to set properties like RuntimeIdentifier and them be
+       respected by the SDK. -->
+  <Import Project="$(MSBuildThisFileDirectory)Microsoft.NET.Sdk.ImportPublishProfile.targets"
+          Condition="'$(PublishProfileImported)' != 'true'"/>
+
   <!-- 
     Expand TargetFramework to TargetFrameworkIdentifier and TargetFrameworkVersion,
     and adjust intermediate and output paths to include it.

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.ImportPublishProfile.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.ImportPublishProfile.targets
@@ -1,0 +1,31 @@
+<!--
+***********************************************************************************************
+Microsoft.NET.Sdk.ImportPublishProfile.targets
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+          created a backup copy.  Incorrect changes to this file will make it
+          impossible to load or build your projects from the command-line or the IDE.
+
+Copyright (c) .NET Foundation. All rights reserved.
+***********************************************************************************************
+-->
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <!-- Default to having imported the publish profile so the Web SDK doesn't also attempt to do so. -->
+    <PublishProfileImported>true</PublishProfileImported>
+    <_PublishProfileDesignerFolder Condition="'$(AppDesignerFolder)' != ''">$(AppDesignerFolder)</_PublishProfileDesignerFolder>
+    <_PublishProfileDesignerFolder Condition="'$(_PublishProfileDesignerFolder)' == ''">Properties</_PublishProfileDesignerFolder>
+    <_PublishProfileRootFolder Condition="'$(_PublishProfileRootFolder)' == ''">$(MSBuildProjectDirectory)\$(_PublishProfileDesignerFolder)\PublishProfiles\</_PublishProfileRootFolder>
+    <PublishProfile Condition="'$(PublishProfile)' ==''">FileSystem</PublishProfile>
+    <PublishProfileName Condition="'$(PublishProfileName)' == ''">$([System.IO.Path]::GetFileNameWithoutExtension($(PublishProfile)))</PublishProfileName>
+    <PublishProfileFullPath Condition="'$(PublishProfileFullPath)' == ''">$(_PublishProfileRootFolder)$(PublishProfileName).pubxml</PublishProfileFullPath>
+    <WebPublishProfileFile Condition="'$(WebPublishProfileFile)' == '' and Exists('$(PublishProfileFullPath)')">$(PublishProfileFullPath)</WebPublishProfileFile>
+
+    <!-- If the publish profile doesn't exist, mark as not imported.
+         This allows the Web SDK to import some default profiles that come with the Web SDK. -->
+    <PublishProfileImported Condition="'$(WebPublishProfileFile)' == '' or !Exists('$(WebPublishProfileFile)')">false</PublishProfileImported>
+  </PropertyGroup>
+
+  <Import Project="$(WebPublishProfileFile)" Condition="'$(PublishProfileImported)' == 'true'" />
+  <Import Project="$(WebPublishProfileFile).user" Condition="'$(PublishProfileImported)' == 'true' and Exists('$(WebPublishProfileFile).user')" />
+</Project>

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAWebApp.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAWebApp.cs
@@ -168,5 +168,94 @@ namespace Microsoft.NET.Publish.Tests
                 "web.config",
             });
         }
+
+        [Theory]
+        [InlineData(null, null)]
+        [InlineData(false, null)]
+        [InlineData(true, null)]
+        [InlineData(null, false)]
+        [InlineData(null, true)]
+        [InlineData(false, false)]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        [InlineData(true, true)]
+        public void It_publishes_with_a_publish_profile(bool? selfContained, bool? useAppHost)
+        {
+            var tfm = "netcoreapp2.2";
+            var rid = EnvironmentInfo.GetCompatibleRid(tfm);
+
+            var testProject = new TestProject()
+            {
+                Name = "WebWithPublishProfile",
+                TargetFrameworks = tfm,
+                IsSdkProject = true,
+                IsExe = true,
+            };
+
+            testProject.AdditionalProperties.Add("AspNetCoreHostingModel", "InProcess");
+            testProject.PackageReferences.Add(new TestPackageReference("Microsoft.AspNetCore.App"));
+            testProject.PackageReferences.Add(new TestPackageReference("Microsoft.AspNetCore.Razor.Design", version: "2.2.0", privateAssets: "all"));
+
+            var testProjectInstance = _testAssetsManager.CreateTestProject(testProject)
+                .WithProjectChanges(
+                    (filename, project) =>
+                    {
+                        project.Root.Attribute("Sdk").Value = "Microsoft.NET.Sdk.Web";
+                    });
+
+            var projectDirectory = Path.Combine(testProjectInstance.Path, testProject.Name);
+            var publishProfilesDirectory = Path.Combine(projectDirectory, "Properties", "PublishProfiles");
+            Directory.CreateDirectory(publishProfilesDirectory);
+
+            File.WriteAllText(Path.Combine(publishProfilesDirectory, "test.pubxml"), $@"
+<Project>
+  <PropertyGroup>
+    <RuntimeIdentifier>{rid}</RuntimeIdentifier>
+    {(selfContained.HasValue ? $"<SelfContained>{selfContained}</SelfContained>" : "")}
+    {((!(selfContained ?? true) && useAppHost.HasValue) ? $"<UseAppHost>{useAppHost}</UseAppHost>" : "")}
+  </PropertyGroup>
+</Project>
+");
+
+            var command = new PublishCommand(Log, projectDirectory);
+            command
+                .Execute("/restore", "/p:PublishProfile=test")
+                .Should()
+                .Pass();
+
+            var output = command.GetOutputDirectory(targetFramework: tfm, runtimeIdentifier: rid);
+
+            output.Should().HaveFiles(new[] {
+                $"{testProject.Name}.dll",
+                $"{testProject.Name}.pdb",
+                $"{testProject.Name}.deps.json",
+                $"{testProject.Name}.runtimeconfig.json",
+                "web.config",
+            });
+
+            if (selfContained ?? true)
+            {
+                output.Should().HaveFiles(new[] {
+                    $"{FileConstants.DynamicLibPrefix}hostfxr{FileConstants.DynamicLibSuffix}",
+                    $"{FileConstants.DynamicLibPrefix}hostpolicy{FileConstants.DynamicLibSuffix}",
+                });
+            }
+            else
+            {
+                output.Should().NotHaveFiles(new[] {
+                    $"{FileConstants.DynamicLibPrefix}hostfxr{FileConstants.DynamicLibSuffix}",
+                    $"{FileConstants.DynamicLibPrefix}hostpolicy{FileConstants.DynamicLibSuffix}",
+                });
+            }
+
+            if ((selfContained ?? true) || (useAppHost ?? true))
+            {
+                output.Should().HaveFile($"{testProject.Name}{Constants.ExeSuffix}");
+            }
+            else
+            {
+                output.Should().NotHaveFile($"{testProject.Name}{Constants.ExeSuffix}");
+            }
+        }
     }
 }


### PR DESCRIPTION
This commit implements importing publish profiles in the .NET Core SDK.

Previously, there were two ways to get the publish profile respected when
publishing .NET Core applications:

* Using the Web SDK, which implicitly imports the `Microsoft.NET.Sdk.Publish`
SDK.
* Explicitly referencing the `Microsoft.NET.Sdk.Publish` SDK in the `Project
element` (e.g. `Project="Microsoft.NET.Sdk;Microsoft.NET.Sdk.Publish"`).

The problem is that the publish profile was being imported *after* many of the
important SDK properties (such as RuntimeIdentifier, SelfContained, and
UseAppHost) were defaulted by the .NET Core SDK.  Because the .NET Core SDK
does not expect the values of these properties to change once defaulted, users
are unable to set a particular property in the publish profile and get the
expected behavior in the .NET Core SDK.

For example, when setting just the `RuntimeIdentifier` in the publish profile,
it would publish without a RID-subdirectory, not as self-contained, and without
an apphost.  Contrast this to using the `--runtime` option for `dotnet
publish`, which uses a RID-subdirectory and publishes self-contained with an
apphost. Up until now, users had to work around this by setting *all* of the
desired properties in the publish profile that would otherwise be defaulted by
the .NET Core SDK.

The Web SDK fixed this by importing the publish profile *before* the .NET Core
SDK was imported (see aspnet/websdk#534).  However, this could not fix the
problem for users that have an existing project that directly references the
`Microsoft.NET.Sdk.Publish` SDK.

To fix that, the .NET Core SDK will not attempt to import the publish profile
if it hasn't already been imported by the Web SDK.  If the .NET Core SDK
successfully imports the publish profile, it sets a property that prevents the
Web SDK from attempting to import it.

Fixes #10647.