### PR TITLE
Fix dotnet-core feed url in Versions.props

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -41,7 +41,7 @@
   <PropertyGroup>
     <RestoreSources>
       $(RestoreSources);
-      https://dotnetfeed.blob.core.windows.net/dotnet-core/packages/index.json;
+      https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json;
       https://dotnet.myget.org/F/nuget-build/api/v3/index.json
     </RestoreSources>
   </PropertyGroup>


### PR DESCRIPTION
This fixes some build failures I was seeing locally, where the
Microsoft.NET.HostModel package was not found.

I wonder if it may be related to the restore failures we were seeing elsewhere @peterhuene.