### PR TITLE
Update Stage 0, fix package feeds

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -41,7 +41,7 @@
   <PropertyGroup>
     <RestoreSources>
       $(RestoreSources);
-      https://dotnetfeed.blob.core.windows.net/dotnet-core/packages/index.json;
+      https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json;
       https://dotnet.myget.org/F/nuget-build/api/v3/index.json
     </RestoreSources>
   </PropertyGroup>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "3.0.100-preview5-011481",
+    "dotnet": "3.0.100-preview6-011632",
     "vs-opt": {
       "version": "15.9"
     }

--- a/src/Tests/Microsoft.NET.TestFramework/SetupTestRoot.targets
+++ b/src/Tests/Microsoft.NET.TestFramework/SetupTestRoot.targets
@@ -43,6 +43,11 @@
     <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" />
     <add key="container-tools" value="https://www.myget.org/F/container-tools-for-visual-studio/api/v3/index.json" />
     <add key="roslyn-tools" value="https://dotnet.myget.org/F/roslyn-tools/api/v3/index.json" />
+    <add key="dotnet-windowsdesktop" value="https://dotnetfeed.blob.core.windows.net/dotnet-windowsdesktop/index.json" />
+    <add key="aspnet-aspnetcore" value="https://dotnetfeed.blob.core.windows.net/aspnet-aspnetcore/index.json" />
+    <add key="aspnet-aspnetcore-tooling" value="https://dotnetfeed.blob.core.windows.net/aspnet-aspnetcore-tooling/index.json" />
+    <add key="aspnet-entityframeworkcore" value="https://dotnetfeed.blob.core.windows.net/aspnet-entityframeworkcore/index.json" />
+    <add key="aspnet-extensions" value="https://dotnetfeed.blob.core.windows.net/aspnet-extensions/index.json" />
         ]]>
       </NugetConfigFeeds>
 


### PR DESCRIPTION
This stage 0 removes the implicit package feeds for internal builds, so this PR corrects those for the SDK build and test.