### PR TITLE
Locate dotnet host for illink on desktop

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ILLink.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ILLink.targets
@@ -76,7 +76,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <!-- When running from Desktop MSBuild, DOTNET_HOST_PATH is not set.
          In this case, explicitly specify the path to the dotnet host. -->
     <PropertyGroup Condition=" '$(DOTNET_HOST_PATH)' == '' ">
-      <_DotNetHostDirectory>$([System.IO.Path]::GetFullPath($(MSBuildThisFileDirectory)../../../../../))</_DotNetHostDirectory>
+      <_DotNetHostDirectory>$(NetCoreRoot)</_DotNetHostDirectory>
       <_DotNetHostFileName>dotnet</_DotNetHostFileName>
       <_DotNetHostFileName Condition=" '$(OS)' == 'Windows_NT' ">dotnet.exe</_DotNetHostFileName>
     </PropertyGroup>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ILLink.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ILLink.targets
@@ -67,19 +67,29 @@ Copyright (c) .NET Foundation. All rights reserved.
     if the output semaphore file is out of date with respect to the inputs.
     ============================================================
     -->
-   <UsingTask TaskName="ILLink" AssemblyFile="$(ILLinkTasksAssembly)" />
-   <Target Name="_RunILLink"
-           DependsOnTargets="_ComputeManagedAssembliesToLink"
-           Inputs="$(MSBuildAllProjects);@(_ManagedAssembliesToLink);@(TrimmerRootDescriptor);@(ReferencePath)"
-           Outputs="$(_LinkSemaphore)">
+  <UsingTask TaskName="ILLink" AssemblyFile="$(ILLinkTasksAssembly)" />
+  <Target Name="_RunILLink"
+         DependsOnTargets="_ComputeManagedAssembliesToLink"
+          Inputs="$(MSBuildAllProjects);@(_ManagedAssembliesToLink);@(TrimmerRootDescriptor);@(ReferencePath)"
+          Outputs="$(_LinkSemaphore)">
 
-     <Delete Files="@(_LinkedResolvedFileToPublishCandidates)" />
-     <ILLink AssemblyPaths="@(_ManagedAssembliesToLink)"
-             ReferenceAssemblyPaths="@(ReferencePath)"
-             RootAssemblyNames="@(IntermediateAssembly->'%(Filename)')"
-             RootDescriptorFiles="@(TrimmerRootDescriptor)"
-             OutputDirectory="$(IntermediateLinkDir)"
-             ExtraArgs="-u copyused -c copyused -l none --skip-unresolved true $(_ExtraTrimmerArgs)" />
+    <!-- When running from Desktop MSBuild, DOTNET_HOST_PATH is not set.
+         In this case, explicitly specify the path to the dotnet host. -->
+    <PropertyGroup Condition=" '$(DOTNET_HOST_PATH)' == '' ">
+      <_DotNetHostDirectory>$([System.IO.Path]::GetFullPath($(MSBuildThisFileDirectory)../../../../../))</_DotNetHostDirectory>
+      <_DotNetHostFileName>dotnet</_DotNetHostFileName>
+      <_DotNetHostFileName Condition=" '$(OS)' == 'Windows_NT' ">dotnet.exe</_DotNetHostFileName>
+    </PropertyGroup>
+
+    <Delete Files="@(_LinkedResolvedFileToPublishCandidates)" />
+    <ILLink AssemblyPaths="@(_ManagedAssembliesToLink)"
+            ReferenceAssemblyPaths="@(ReferencePath)"
+            RootAssemblyNames="@(IntermediateAssembly->'%(Filename)')"
+            RootDescriptorFiles="@(TrimmerRootDescriptor)"
+            OutputDirectory="$(IntermediateLinkDir)"
+            ExtraArgs="-u copyused -c copyused -l none --skip-unresolved true $(_ExtraTrimmerArgs)"
+            ToolExe="$(_DotNetHostFileName)"
+            ToolPath="$(_DotNetHostDirectory)" />
 
      <Touch Files="$(_LinkSemaphore)" AlwaysCreate="true" />
 

--- a/src/Tests/Microsoft.NET.TestFramework/ToolsetInfo.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/ToolsetInfo.cs
@@ -124,6 +124,9 @@ namespace Microsoft.NET.TestFramework
             {
                 ret.FileName = FullFrameworkMSBuildPath;
                 ret.Arguments = args.ToList();
+                // Don't propagate DOTNET_HOST_PATH to the msbuild process, to match behavior
+                // when running desktop msbuild outside of the test harness.
+                ret.Environment["DOTNET_HOST_PATH"] = null;
             }
             else
             {
@@ -194,7 +197,7 @@ namespace Microsoft.NET.TestFramework
             }
             else
             {
-                pathSplitChar = ':';                
+                pathSplitChar = ':';
             }
 
             var paths = Environment.GetEnvironmentVariable("PATH").Split(pathSplitChar);


### PR DESCRIPTION
When running on full framework MSBuild, the environment variable `DOTNET_HOST_PATH` is not set, causing the linker to fail. This was not caught by the SDK tests because they are started by a test process that uses the dotnet cli, so this includes a change to prevent `DOTNET_HOST_PATH` from propagating to the MSBuild process.

For the desktop MSBuild case, I believe the correct thing to do is to use the dotnet host that comes with the SDK that is being used to build the app, so I'm trying to explicitly pass the location of that host (rather than searching the `PATH`, for example). @dsplaisted and @nguerrera does that sound right to you, or should I be doing something else?

The current fix has a problem: the relative path from the targets file to the dotnet host is correct for an actual product SDK, but because the tests run against a different layout, the computed location is incorrect when tests are run. @dsplaisted, @nguerrera do you have any suggestions? Perhaps the SDK already has some information about the dotnet host location that I can reuse.