### PR TITLE
Add reference to empty Microsoft.NETCore.App package

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolveFrameworkReferences.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveFrameworkReferences.cs
@@ -49,6 +49,9 @@ namespace Microsoft.NET.Build.Tasks
         public ITaskItem[] PackagesToDownload { get; set; }
 
         [Output]
+        public ITaskItem[] PackagesToReference { get; set; }
+
+        [Output]
         public ITaskItem[] RuntimeFrameworks { get; set; }
 
         [Output]
@@ -80,6 +83,7 @@ namespace Microsoft.NET.Build.Tasks
             var frameworkReferenceMap = FrameworkReferences.ToDictionary(fr => fr.ItemSpec);
 
             List<ITaskItem> packagesToDownload = new List<ITaskItem>();
+            List<ITaskItem> packagesToReference = new List<ITaskItem>();
             List<ITaskItem> runtimeFrameworks = new List<ITaskItem>();
             List<ITaskItem> targetingPacks = new List<ITaskItem>();
             List<ITaskItem> runtimePacks = new List<ITaskItem>();
@@ -90,6 +94,21 @@ namespace Microsoft.NET.Build.Tasks
             foreach (var knownFrameworkReference in knownFrameworkReferencesForTargetFramework)
             {
                 frameworkReferenceMap.TryGetValue(knownFrameworkReference.Name, out ITaskItem frameworkReference);
+
+                if (frameworkReference != null)
+                {
+                    if (!string.IsNullOrEmpty(knownFrameworkReference.PackagesToReference))
+                    {
+                        foreach (var packageAndVersion in knownFrameworkReference.PackagesToReference.Split(';'))
+                        {
+                            var items = packageAndVersion.Split('/');
+                            TaskItem packageToReference = new TaskItem(items[0]);
+                            packageToReference.SetMetadata(MetadataKeys.Version, items[1]);
+
+                            packagesToReference.Add(packageToReference);
+                        }
+                    }
+                }
 
                 //  Get the path of the targeting pack in the targeting pack root (e.g. dotnet/ref)
                 TaskItem targetingPack = new TaskItem(knownFrameworkReference.Name);
@@ -180,6 +199,11 @@ namespace Microsoft.NET.Build.Tasks
             if (packagesToDownload.Any())
             {
                 PackagesToDownload = packagesToDownload.ToArray();
+            }
+
+            if (packagesToReference.Any())
+            {
+                PackagesToReference = packagesToReference.ToArray();
             }
 
             if (runtimeFrameworks.Any())
@@ -351,6 +375,8 @@ namespace Microsoft.NET.Build.Tasks
             public string RuntimePackNamePatterns => _item.GetMetadata("RuntimePackNamePatterns");
 
             public string RuntimePackRuntimeIdentifiers => _item.GetMetadata("RuntimePackRuntimeIdentifiers");
+
+            public string PackagesToReference => _item.GetMetadata("PackagesToReference");
 
             public NuGetFramework TargetFramework { get; }
         }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.targets
@@ -181,23 +181,6 @@ Copyright (c) .NET Foundation. All rights reserved.
       <PackageReference Condition="'%(PackageReference.Identity)' == 'Microsoft.NETCore.App'">
         <Version Condition="'%(PackageReference.Version)' == ''">$(_TargetFrameworkVersionWithoutV)</Version>
       </PackageReference>
-
-      <!-- Reference the Platforms package in order to supply the RID graph to NuGet.
-           This can be removed once we do https://github.com/dotnet/cli/issues/10528 or
-           https://github.com/NuGet/Home/issues/7351 
-            
-           We only do this here when there are PackageReferences. If the only references 
-           are FrameworkReferences, then we do not need to provide this package to NuGet. -->
-      <PackageReference Include="Microsoft.NETCore.Platforms"
-                        Version="$(BundledNETCorePlatformsPackageVersion)"
-                        IsImplicitlyDefined="true"
-                        Condition="'$(DisableImplicitFrameworkReferences)' != 'true'
-                                    and '$(DisableImplicitNETCorePlatformsReference)' != 'true'
-                                    and '$(TargetFrameworkIdentifier)' == '.NETCoreApp'
-                                    and '$(_TargetFrameworkVersionWithoutV)' != ''
-                                    and '$(_TargetFrameworkVersionWithoutV)' >= '3.0'"
-                        PrivateAssets="All"
-                        Publish="true" />
     </ItemGroup>
   </Target>
   

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.TargetingPackResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.TargetingPackResolution.targets
@@ -91,6 +91,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                                 EnableTargetingPackDownload="$(EnableTargetingPackDownload)">
 
       <Output TaskParameter="PackagesToDownload" ItemName="_PackageToDownload" />
+      <Output TaskParameter="PackagesToReference" ItemName="_PackageToReference" />
       <Output TaskParameter="RuntimeFrameworks" ItemName="RuntimeFramework" />
       <Output TaskParameter="TargetingPacks" ItemName="TargetingPack" />
       <Output TaskParameter="RuntimePacks" ItemName="RuntimePack" />
@@ -136,6 +137,16 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <ItemGroup Condition="'$(UsePackageDownload)' != 'true'">
       <PackageReference Include="@(_PackageToDownload)"
+                        IsImplicitlyDefined="true"
+                        PrivateAssets="all"
+                        ExcludeAssets="all" />
+    </ItemGroup>
+
+    <!-- Only add these package references if there are already existing package references,
+         as they are only needed in those scenarios (for example supplying the RID graph to
+         NuGet, or preventing older versions of Framework packages from being used). -->
+    <ItemGroup Condition="'@(PackageReference)' != '' and '$(DisableImplicitFrameworkReferences)' != 'true'">
+      <PackageReference Include="@(_PackageToReference)"
                         IsImplicitlyDefined="true"
                         PrivateAssets="all"
                         ExcludeAssets="all" />

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.TargetingPackResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.TargetingPackResolution.targets
@@ -91,7 +91,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                                 EnableTargetingPackDownload="$(EnableTargetingPackDownload)">
 
       <Output TaskParameter="PackagesToDownload" ItemName="_PackageToDownload" />
-      <Output TaskParameter="PackagesToReference" ItemName="_PackageToReference" />
+      <Output TaskParameter="LegacyFrameworkPackages" ItemName="_LegacyFrameworkPackage" />
       <Output TaskParameter="RuntimeFrameworks" ItemName="RuntimeFramework" />
       <Output TaskParameter="TargetingPacks" ItemName="TargetingPack" />
       <Output TaskParameter="RuntimePacks" ItemName="RuntimePack" />
@@ -142,11 +142,11 @@ Copyright (c) .NET Foundation. All rights reserved.
                         ExcludeAssets="all" />
     </ItemGroup>
 
-    <!-- Only add these package references if there are already existing package references,
+    <!-- Only add these "legacy" package references if there are already existing package references,
          as they are only needed in those scenarios (for example supplying the RID graph to
          NuGet, or preventing older versions of Framework packages from being used). -->
     <ItemGroup Condition="'@(PackageReference)' != '' and '$(DisableImplicitFrameworkReferences)' != 'true'">
-      <PackageReference Include="@(_PackageToReference)"
+      <PackageReference Include="@(_LegacyFrameworkPackage)"
                         IsImplicitlyDefined="true"
                         PrivateAssets="all"
                         ExcludeAssets="all" />


### PR DESCRIPTION
The reference to the Microsoft.NETCore.App package is specified via the PackagesToReference metadata on KnownFrameworkReference.  This metadata was added in https://github.com/dotnet/core-sdk/pull/1766, and the package was produced in https://github.com/dotnet/core-setup/pull/5893.

Once https://github.com/dotnet/core-setup/issues/6222 is done, this should fix #3044.  This PR also adds a test case for that issue, which is currently skipped.

This PR removes the implicit reference to the Microsoft.NETCore.Platforms package, as that will now come in as a dependency of the Microsoft.NETCore.App package.