### PR TITLE
Extend default AssetTargetFallback up to net48

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.BeforeCommon.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.BeforeCommon.targets
@@ -144,7 +144,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(DisableImplicitAssetTargetFallback)' != 'true' and '$(_IsNETCoreOrNETStandard)' == 'true' and '$(_TargetFrameworkVersionWithoutV)' >= '2.0'">
-    <AssetTargetFallback>$(AssetTargetFallback);net461</AssetTargetFallback>
+    <AssetTargetFallback>$(AssetTargetFallback);net461;net462;net47;net471;net472;net48</AssetTargetFallback>
   </PropertyGroup>
 
   <!-- Add conditional compilation symbols for the target framework (for example NET461, NETSTANDARD2_0, NETCOREAPP1_0) -->


### PR DESCRIPTION
Before:
```
AssetTargetFallback=net461
```

After:
```
AssetTargetFallback=net461;net462;net47;net471;net472;net48
```

This ensures that existing projects do not get different assets, and that the "oldest" available assets beyond net461 (deemed most compatible) are used.

Fix #2425 