### PR TITLE
Add ability to use test config file to list tests to skip

### DIFF
--- a/src/Tests/Common/Program.cs
+++ b/src/Tests/Common/Program.cs
@@ -26,6 +26,7 @@ partial class Program
 
         if (!testCommandLine.ShouldShowHelp)
         {
+            newArgs.AddRange(TestCommandLine.GetXunitArgsFromTestConfig(testCommandLine.TestConfigFile));
             BeforeTestRun(newArgs);
         }
 


### PR DESCRIPTION
Add support for passing a `-testConfigFile` parameter when running tests.  This allows individual tests to be skipped without having to modify the test source code.  This will be helpful to allow tests to be run on other repos, such as with https://github.com/dotnet/core-sdk/pull/1454.

The test config file looks like this

```xml
<Tests>
  <Method Name="Microsoft.NET.Clean.Tests.GivenThatWeWantToCleanAHelloWorldProject.It_can_clean_and_build_without_using_rebuild"
          Skip="true"
          Issue="https://github.com/dotnet/sdk/issues/1234"
          Reason="Reason for skip"/>
</Tests>
```

The `Issue` and `Reason` attributes aren't currently used, they are merely informational to help us keep such a list up-to-date.