### PR TITLE
Flow IsTrimmable from FrameworkReference to resolved assets

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "3.0.100-preview6-011901",
+    "dotnet": "3.0.100-preview6-011903",
     "vs-opt": {
       "version": "15.9"
     }

--- a/src/Tasks/Common/MetadataKeys.cs
+++ b/src/Tasks/Common/MetadataKeys.cs
@@ -24,6 +24,7 @@ namespace Microsoft.NET.Build.Tasks
         public const string TargetFrameworkMoniker = "TargetFrameworkMoniker";
         public const string FrameworkName = "FrameworkName";
         public const string FrameworkVersion = "FrameworkVersion";
+        public const string IsTrimmable = "IsTrimmable";
 
         // SDK Metadata
         public const string SDKPackageItemSpec = "SDKPackageItemSpec";

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolveRuntimePackAssets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveRuntimePackAssets.cs
@@ -87,6 +87,7 @@ namespace Microsoft.NET.Build.Tasks
                     assetItem.SetMetadata(MetadataKeys.PackageName, runtimePack.GetMetadata(MetadataKeys.PackageName));
                     assetItem.SetMetadata(MetadataKeys.PackageVersion, runtimePack.GetMetadata(MetadataKeys.PackageVersion));
                     assetItem.SetMetadata(MetadataKeys.RuntimeIdentifier, runtimeIdentifier);
+                    assetItem.SetMetadata(MetadataKeys.IsTrimmable, runtimePack.GetMetadata(MetadataKeys.IsTrimmable));
 
                     runtimePackAssets.Add(assetItem);
                 }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.TargetingPackResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.TargetingPackResolution.targets
@@ -51,6 +51,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                               AppHostRuntimeIdentifiers="freebsd-x64;linux-arm;linux-arm64;linux-musl-x64;linux-x64;osx-x64;rhel.6-x64;tizen.4.0.0-armel;tizen.5.0.0-armel;win-arm;win-arm64;win-x64;win-x86"
                               RuntimePackNamePatterns="runtime.**RID**.Microsoft.NETCore.App;runtime.**RID**.Microsoft.NETCore.DotNetHostResolver;runtime.**RID**.Microsoft.NETCore.DotNetHostPolicy"
                               RuntimePackRuntimeIdentifiers="freebsd-x64;linux-arm;linux-arm64;linux-musl-x64;linux-x64;osx-x64;rhel.6-x64;tizen.4.0.0-armel;tizen.5.0.0-armel;win-arm;win-arm64;win-x64;win-x86"
+                              IsTrimmable="true"
                               />
       -->
 


### PR DESCRIPTION
Follow-up to https://github.com/dotnet/core-sdk/pull/1992/files. The next step is to flow the metadata from `RuntimePack` to the resolved files.

This flows `IsTrimmable` metadata from `FrameworkReference` and `KnownFrameworkReference` (`FrameworkReference` has priority) to the `RuntimePack` ItemGroup produced by `ResolveFrameworkReferences`. The metadata will ultimately influence the default linker behavior.

@dsplaisted @nguerrera PTAL.