### PR TITLE
Setting IsKeyOutput metadata on AppHost file in PublishItemsOutputGroup

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -561,13 +561,13 @@ Copyright (c) .NET Foundation. All rights reserved.
       <ResolvedFileToPublish Include="@(_SourceItemsToCopyToPublishDirectoryAlways)">
         <RelativePath>%(_SourceItemsToCopyToPublishDirectoryAlways.TargetPath)</RelativePath>
         <CopyToPublishDirectory>Always</CopyToPublishDirectory>
-        <IsKeyOutput Condition="@(_SourceItemsToCopyToPublishDirectoryAlways->'%(FullPath)') == $(AppHostIntermediatePath)">True</IsKeyOutput>
+        <IsKeyOutput Condition="'%(_SourceItemsToCopyToPublishDirectoryAlways.FullPath)' == '$(AppHostIntermediatePath)'">True</IsKeyOutput>
       </ResolvedFileToPublish>
 
       <ResolvedFileToPublish Include="@(_SourceItemsToCopyToPublishDirectory)">
         <RelativePath>%(_SourceItemsToCopyToPublishDirectory.TargetPath)</RelativePath>
         <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
-        <IsKeyOutput Condition="@(_SourceItemsToCopyToPublishDirectory->'%(FullPath)') == $(AppHostIntermediatePath)">True</IsKeyOutput>
+        <IsKeyOutput Condition="'%(_SourceItemsToCopyToPublishDirectory.FullPath)' == '$(AppHostIntermediatePath)'">True</IsKeyOutput>
       </ResolvedFileToPublish>
     </ItemGroup>
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -559,11 +559,13 @@ Copyright (c) .NET Foundation. All rights reserved.
       <ResolvedFileToPublish Include="@(_SourceItemsToCopyToPublishDirectoryAlways)">
         <RelativePath>%(_SourceItemsToCopyToPublishDirectoryAlways.TargetPath)</RelativePath>
         <CopyToPublishDirectory>Always</CopyToPublishDirectory>
+        <IsKeyOutput Condition="@(_SourceItemsToCopyToPublishDirectoryAlways->'%(FullPath)') == $(AppHostIntermediatePath)">True</IsKeyOutput>
       </ResolvedFileToPublish>
 
       <ResolvedFileToPublish Include="@(_SourceItemsToCopyToPublishDirectory)">
         <RelativePath>%(_SourceItemsToCopyToPublishDirectory.TargetPath)</RelativePath>
         <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+        <IsKeyOutput Condition="@(_SourceItemsToCopyToPublishDirectory->'%(FullPath)') == $(AppHostIntermediatePath)">True</IsKeyOutput>
       </ResolvedFileToPublish>
     </ItemGroup>
 
@@ -889,8 +891,13 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <Target Name="PublishItemsOutputGroup" DependsOnTargets="$(PublishItemsOutputGroupDependsOn)" Returns="@(PublishItemsOutputGroupOutputs)">
     <ItemGroup>
-      <PublishItemsOutputGroupOutputs Condition="'$(GenerateDependencyFile)' == 'true' and '$(_UseBuildDependencyFile)' != 'true'" Include="$(ProjectDepsFilePath)" TargetPath="$(ProjectDepsFileName)" />
-      <PublishItemsOutputGroupOutputs Include="@(ResolvedFileToPublish->'%(FullPath)')" TargetPath="%(ResolvedFileToPublish.RelativePath)" OutputGroup="PublishItemsOutputGroup" />
+      <PublishItemsOutputGroupOutputs Condition="'$(GenerateDependencyFile)' == 'true' and '$(_UseBuildDependencyFile)' != 'true'"
+                                      Include="$(ProjectDepsFilePath)"
+                                      TargetPath="$(ProjectDepsFileName)" />
+      <PublishItemsOutputGroupOutputs Include="@(ResolvedFileToPublish->'%(FullPath)')"
+                                      TargetPath="%(ResolvedFileToPublish.RelativePath)"
+                                      IsKeyOutput="%(ResolvedFileToPublish.IsKeyOutput)"
+                                      OutputGroup="PublishItemsOutputGroup" />
     </ItemGroup>
   </Target>
 

--- a/src/Tests/Microsoft.NET.Publish.Tests/PublishItemsOutputGroupTests.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/PublishItemsOutputGroupTests.cs
@@ -50,6 +50,12 @@ namespace Microsoft.NET.Publish.Tests
             testOutputDir.Should().HaveFile($"{testProject.Name}.exe");
             testOutputDir.Should().HaveFile($"{testProject.Name}.deps.json");
             testOutputDir.Should().HaveFiles(FrameworkAssemblies);
+
+            var testKeyOutputDir = new DirectoryInfo(Path.Combine(testAsset.Path, testProject.Name, "TestOutput_Key"));
+            Log.WriteLine("PublishItemsOutputGroup key items dumped to '{0}'.", testKeyOutputDir.FullName);
+
+            // Verify the only key item is the exe
+            testKeyOutputDir.Should().OnlyHaveFiles(new List<string>() { $"{testProject.Name}.exe" });
         }
 
         [Fact]
@@ -77,6 +83,12 @@ namespace Microsoft.NET.Publish.Tests
             testOutputDir.Should().HaveFile($"{testProject.Name}{Constants.ExeSuffix}");
             testOutputDir.Should().HaveFile($"{testProject.Name}.deps.json");
             testOutputDir.Should().NotHaveFiles(FrameworkAssemblies);
+
+            var testKeyOutputDir = new DirectoryInfo(Path.Combine(testAsset.Path, testProject.Name, "TestOutput_Key"));
+            Log.WriteLine("PublishItemsOutputGroup key items dumped to '{0}'.", testKeyOutputDir.FullName);
+
+            // Verify the only key item is the exe
+            testKeyOutputDir.Should().OnlyHaveFiles(new List<string>() { $"{testProject.Name}{Constants.ExeSuffix}" });
         }
 
         private TestProject SetupProject()
@@ -100,7 +112,17 @@ namespace Microsoft.NET.Publish.Tests
                 "CopyPublishItemsOutputGroup",
                 "PublishItemsOutputGroup",
                 "@(PublishItemsOutputGroupOutputs)",
+                null,
                 "$(MSBuildProjectDirectory)\\TestOutput"));
+
+            // Add another target that will dump the members of PublishItemsOutputGroup that
+            // have property IsKeyOutput set to true to a different test directory.
+            testProject.CopyFilesTargets.Add(new CopyFilesTarget(
+                "CopyPublishKeyItemsOutputGroup",
+                "PublishItemsOutputGroup",
+                "@(PublishItemsOutputGroupOutputs)",
+                @"'%(PublishItemsOutputGroupOutputs.IsKeyOutput)' == 'True'",
+                "$(MSBuildProjectDirectory)\\TestOutput_Key"));
 
             return testProject;
         }

--- a/src/Tests/Microsoft.NET.TestFramework/CopyFilesTarget.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/CopyFilesTarget.cs
@@ -9,17 +9,19 @@ namespace Microsoft.NET.TestFramework
     /// </summary>
     public class CopyFilesTarget
     {
-        public CopyFilesTarget(string targetName, string targetToRunAfter, string sourceFiles, string destination)
+        public CopyFilesTarget(string targetName, string targetToRunAfter, string sourceFiles, string condition, string destination)
         {
             TargetName = targetName;
             TargetToRunAfter = targetToRunAfter;
             SourceFiles = sourceFiles;
+            Condition = condition;
             Destination = destination;
         }
 
         public string TargetName { get; private set; }
         public string TargetToRunAfter { get; private set; }
         public string SourceFiles { get; private set; }
+        public string Condition { get; private set; }
         public string Destination { get; private set; }
     }
 }

--- a/src/Tests/Microsoft.NET.TestFramework/ProjectConstruction/TestProject.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/ProjectConstruction/TestProject.cs
@@ -304,10 +304,16 @@ namespace Microsoft.NET.TestFramework.ProjectConstruction
                         new XAttribute("Name", copyFilesTarget.TargetName),
                         new XAttribute("AfterTargets", copyFilesTarget.TargetToRunAfter));
 
-                    target.Add(new XElement(ns + "Copy",
+                    var copyElement = new XElement(ns + "Copy",
                         new XAttribute("SourceFiles", copyFilesTarget.SourceFiles),
-                        new XAttribute("DestinationFolder", copyFilesTarget.Destination)));
+                        new XAttribute("DestinationFolder", copyFilesTarget.Destination));
 
+                    if (!string.IsNullOrEmpty(copyFilesTarget.Condition))
+                    {
+                        copyElement.SetAttributeValue("Condition", copyFilesTarget.Condition);
+                    }
+
+                    target.Add(copyElement);
                     projectXml.Root.Add(target);
                 }
             }


### PR DESCRIPTION
Updating the publishing targets to set the IsKeyOutput metadata on the apphost file (exe).  The key output is used when creating shortcuts using Installer Projects.

