### PR TITLE
Skip tests where .NET Core version they use isn't supported on current OS

### DIFF
--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildANetCoreApp.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildANetCoreApp.cs
@@ -275,6 +275,11 @@ namespace Microsoft.NET.Build.Tests
         [InlineData("netcoreapp3.0")]
         public void It_runs_the_app_with_conflicts_from_the_output_folder(string targetFramework)
         {
+            if (!EnvironmentInfo.SupportsTargetFramework(targetFramework))
+            {
+                return;
+            }
+
             RunAppFromOutputFolder("RunFromOutputFolderConflicts_" + targetFramework, false, true, targetFramework);
         }
 
@@ -283,6 +288,11 @@ namespace Microsoft.NET.Build.Tests
         [InlineData("netcoreapp3.0")]
         public void It_runs_a_rid_specific_app_with_conflicts_from_the_output_folder(string targetFramework)
         {
+            if (!EnvironmentInfo.SupportsTargetFramework(targetFramework))
+            {
+                return;
+            }
+
             RunAppFromOutputFolder("RunFromOutputFolderWithRIDConflicts_" + targetFramework, true, true, targetFramework);
         }
 

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildASelfContainedApp.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildASelfContainedApp.cs
@@ -27,6 +27,11 @@ namespace Microsoft.NET.Build.Tests
         [InlineData("netcoreapp3.0", true)]
         public void It_builds_a_runnable_output(string targetFramework, bool dependenciesIncluded)
         {
+            if (!EnvironmentInfo.SupportsTargetFramework(targetFramework))
+            {
+                return;
+            }
+
             var runtimeIdentifier = EnvironmentInfo.GetCompatibleRid(targetFramework);
             var testAsset = _testAssetsManager
                 .CopyTestAsset("HelloWorld", identifier: targetFramework)

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToReferenceAnAssembly.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToReferenceAnAssembly.cs
@@ -30,6 +30,11 @@ namespace Microsoft.NET.Build.Tests
             string referencerTarget,
             string dependencyTarget)
         {
+            if (!EnvironmentInfo.SupportsTargetFramework(referencerTarget))
+            {
+                return;
+            }
+
             string identifier = referencerTarget.ToString() + "_" + dependencyTarget.ToString();
 
             TestProject dependencyProject = new TestProject()
@@ -97,6 +102,11 @@ public static class Program
             string referencerTarget,
             string dependencyTarget)
         {
+            if (!EnvironmentInfo.SupportsTargetFramework(referencerTarget))
+            {
+                return;
+            }
+
             string identifier = referencerTarget.ToString() + "_" + dependencyTarget.ToString();
 
             TestProject dependencyProject = new TestProject()
@@ -219,6 +229,11 @@ public static class Program
             string referencerTarget,
             string dllDependencyTarget)
         {
+            if (!EnvironmentInfo.SupportsTargetFramework(referencerTarget))
+            {
+                return;
+            }
+
             string identifier = referencerTarget.ToString() + "_" + dllDependencyTarget.ToString();
 
             TestProject dllDependencyProjectDependency = new TestProject()
@@ -304,6 +319,11 @@ public static class Program
             string referencerTarget,
             string dllDependencyTarget)
         {
+            if (!EnvironmentInfo.SupportsTargetFramework(referencerTarget))
+            {
+                return;
+            }
+
             string identifier = referencerTarget.ToString() + "_" + dllDependencyTarget.ToString();
 
             TestProject dllDependencyProjectDependency = new TestProject()
@@ -445,6 +465,11 @@ public static class Program
             string dependencyTarget,
             string dllDependencyTarget)
         {
+            if (!EnvironmentInfo.SupportsTargetFramework(referencerTarget))
+            {
+                return;
+            }
+
             string identifier = referencerTarget.ToString() + "_" + dependencyTarget.ToString();
 
             TestProject dllDependencyProject = new TestProject()
@@ -531,6 +556,11 @@ public static class Program
             string dependencyTarget,
             string dllDependencyTarget)
         {
+            if (!EnvironmentInfo.SupportsTargetFramework(referencerTarget))
+            {
+                return;
+            }
+
             string identifier = referencerTarget.ToString() + "_" + dependencyTarget.ToString();
 
             TestProject dllDependencyProject = new TestProject()
@@ -672,6 +702,11 @@ public static class Program
             string dependencyTarget,
             string dllDependencyTarget)
         {
+            if (!EnvironmentInfo.SupportsTargetFramework(referencerTarget))
+            {
+                return;
+            }
+
             string identifier = referencerTarget.ToString() + "_" + dependencyTarget.ToString();
 
             TestProject dllDependencyProjectDependency = new TestProject()
@@ -776,6 +811,11 @@ public static class Program
             string dependencyTarget,
             string dllDependencyTarget)
         {
+            if (!EnvironmentInfo.SupportsTargetFramework(referencerTarget))
+            {
+                return;
+            }
+
             string identifier = referencerTarget.ToString() + "_" + dependencyTarget.ToString();
 
             TestProject dllDependencyProjectDependency = new TestProject()

--- a/src/Tests/Microsoft.NET.TestFramework/EnvironmentInfo.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/EnvironmentInfo.cs
@@ -5,6 +5,7 @@ using System;
 using System.IO;
 using System.Runtime.InteropServices;
 using Microsoft.DotNet.PlatformAbstractions;
+using NuGet.Frameworks;
 
 namespace Microsoft.NET.TestFramework
 {
@@ -37,6 +38,82 @@ namespace Microsoft.NET.TestFramework
             }
 
             return rid;
+        }
+
+        //  Encode relevant information from https://github.com/dotnet/core/blob/master/os-lifecycle-policy.md
+        //  so that we can check if a test targeting a particular version of .NET Core should be
+        //  able to run on the current OS
+        public static bool SupportsTargetFramework(string targetFramework)
+        {
+            var nugetFramework = NuGetFramework.Parse(targetFramework);
+            string currentRid = DotNet.PlatformAbstractions.RuntimeEnvironment.GetRuntimeIdentifier();
+
+            string ridOS = currentRid.Split('.')[0];
+            if (ridOS.Equals("alpine", StringComparison.OrdinalIgnoreCase))
+            {
+                if (nugetFramework.Version < new Version(2, 1, 0, 0))
+                {
+                    return false;
+                }
+            }
+            else if (ridOS.Equals("fedora", StringComparison.OrdinalIgnoreCase))
+            {
+                string restOfRid = currentRid.Substring(ridOS.Length + 1);
+                string fedoraVersionString = restOfRid.Split('-')[0];
+                if (int.TryParse(fedoraVersionString, out int fedoraVersion))
+                {
+                    if (fedoraVersion <= 27)
+                    {
+                        if (nugetFramework.Version < new Version(2, 1, 0, 0))
+                        {
+                            return true;
+                        }
+                        else
+                        {
+                            return false;
+                        }
+                    }
+                    else if (fedoraVersion == 28)
+                    {
+                        if (nugetFramework.Version < new Version(2, 1, 0, 0))
+                        {
+                            return false;
+                        }
+                        else
+                        {
+                            return true;
+                        }
+                    }
+                    else if (fedoraVersion >= 29)
+                    {
+                        if (nugetFramework.Version < new Version(2, 2, 0, 0))
+                        {
+                            return false;
+                        }
+                        else
+                        {
+                            return true;
+                        }
+                    }
+                }
+            }
+            else if (ridOS.Equals("rhel", StringComparison.OrdinalIgnoreCase))
+            {
+                string restOfRid = currentRid.Substring(ridOS.Length + 1);
+                string rhelVersionString = restOfRid.Split('-')[0];
+                if (int.TryParse(rhelVersionString, out int rhelVersion))
+                {
+                    if (rhelVersion == 6)
+                    {
+                        if (nugetFramework.Version < new Version(2, 0, 0, 0))
+                        {
+                            return false;
+                        }
+                    }
+                }
+            }
+
+            return true;
         }
     }
 }


### PR DESCRIPTION
Update some tests to skip running if the current operating system doesn't support the right version of .NET Core.

This will help run the sdk tests in dotnet/core-sdk, which tests more operating systems than this repo does.