### PR TITLE
Copy runtime pack resource assemblies on self-contained build/publish.

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageAssets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageAssets.cs
@@ -961,7 +961,7 @@ namespace Microsoft.NET.Build.Tasks
                         WriteMetadata(MetadataKeys.AssetType, "native");
                         if (ShouldCopyLocalPackageAssets(package))
                         {
-                            WriteCopyLocalMetadata(package, Path.GetFileName(asset.Path), "native");
+                            WriteCopyLocalMetadata(package, Path.GetFileName(asset.Path));
                         }
                     });
             }
@@ -1030,7 +1030,6 @@ namespace Microsoft.NET.Build.Tasks
                             WriteCopyLocalMetadata(
                                 package,
                                 Path.GetFileName(asset.Path),
-                                "resources",
                                 destinationSubDirectory: locale + Path.DirectorySeparatorChar);
                         }
                         else
@@ -1051,7 +1050,7 @@ namespace Microsoft.NET.Build.Tasks
                         WriteMetadata(MetadataKeys.AssetType, "runtime");
                         if (ShouldCopyLocalPackageAssets(package))
                         {
-                            WriteCopyLocalMetadata(package, Path.GetFileName(asset.Path), "runtime");
+                            WriteCopyLocalMetadata(package, Path.GetFileName(asset.Path));
                         }
                     });
             }
@@ -1074,7 +1073,6 @@ namespace Microsoft.NET.Build.Tasks
                             WriteCopyLocalMetadata(
                                 package,
                                 Path.GetFileName(asset.Path),
-                                asset.AssetType.ToLowerInvariant(),
                                 destinationSubDirectory: Path.GetDirectoryName(asset.Path) + Path.DirectorySeparatorChar);
                         }
                         else
@@ -1194,7 +1192,7 @@ namespace Microsoft.NET.Build.Tasks
                 }
             }
 
-            private void WriteCopyLocalMetadata(LockFileTargetLibrary package, string assetsFileName, string assetType, string destinationSubDirectory = null)
+            private void WriteCopyLocalMetadata(LockFileTargetLibrary package, string assetsFileName, string destinationSubDirectory = null)
             {
                 WriteMetadata(MetadataKeys.CopyLocal, "true");
                 WriteMetadata(

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolveRuntimePackAssets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveRuntimePackAssets.cs
@@ -16,12 +16,14 @@ namespace Microsoft.NET.Build.Tasks
 
         public ITaskItem[] UnavailableRuntimePacks { get; set; } = Array.Empty<ITaskItem>();
 
+        public ITaskItem[] SatelliteResourceLanguages { get; set; } = Array.Empty<ITaskItem>();
+
         [Output]
         public ITaskItem[] RuntimePackAssets { get; set; }
 
         protected override void ExecuteCore()
         {
-            List<TaskItem> runtimePackAssets = new List<TaskItem>();
+            var runtimePackAssets = new List<ITaskItem>();
 
             HashSet<string> frameworkReferenceNames = new HashSet<string>(FrameworkReferences.Select(item => item.ItemSpec), StringComparer.OrdinalIgnoreCase);
 
@@ -99,9 +101,56 @@ namespace Microsoft.NET.Build.Tasks
                 {
                     AddAsset(asset, "native");
                 }
+
+                runtimePackAssets.AddRange(EnumerateResourceAssets(runtimePackRoot, runtimeIdentifier, runtimePack));
             }
 
             RuntimePackAssets = runtimePackAssets.ToArray();
+        }
+
+        private IEnumerable<ITaskItem> EnumerateResourceAssets(string runtimePackRoot, string runtimeIdentifier, ITaskItem runtimePack)
+        {
+            //  These hard-coded paths are temporary until we have "real" runtime packs, which will likely have a flattened structure
+            var directory = Path.Combine(runtimePackRoot, "runtimes", runtimeIdentifier, "lib", "netcoreapp3.0");
+            if (!Directory.Exists(directory))
+            {
+                yield break;
+            }
+
+            foreach (var subdir in Directory.EnumerateDirectories(directory))
+            {
+                foreach (var asset in EnumerateCultureAssets(subdir, runtimeIdentifier, runtimePack))
+                {
+                    yield return asset;
+                }
+            }
+        }
+
+        private IEnumerable<ITaskItem> EnumerateCultureAssets(string cultureDirectory, string runtimeIdentifier, ITaskItem runtimePack)
+        {
+            var culture = Path.GetFileName(cultureDirectory);
+
+            if (this.SatelliteResourceLanguages.Length > 1 &&
+                !this.SatelliteResourceLanguages.Any(lang => string.Equals(lang.ItemSpec, culture, StringComparison.OrdinalIgnoreCase)))
+            {
+                yield break;
+            }
+
+            foreach (var file in Directory.EnumerateFiles(cultureDirectory, "*.resources.dll"))
+            {
+                var item = new TaskItem(file);
+
+                item.SetMetadata(MetadataKeys.CopyLocal, "true");
+                item.SetMetadata(MetadataKeys.DestinationSubDirectory, culture + Path.DirectorySeparatorChar);
+                item.SetMetadata(MetadataKeys.DestinationSubPath, Path.Combine(culture, Path.GetFileName(file)));
+                item.SetMetadata(MetadataKeys.AssetType, "resources");
+                item.SetMetadata(MetadataKeys.PackageName, runtimePack.GetMetadata(MetadataKeys.PackageName));
+                item.SetMetadata(MetadataKeys.PackageVersion, runtimePack.GetMetadata(MetadataKeys.PackageVersion));
+                item.SetMetadata(MetadataKeys.RuntimeIdentifier, runtimeIdentifier);
+                item.SetMetadata(MetadataKeys.Culture, culture);
+
+                yield return item;
+            }
         }
     }
 }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/RuntimePackAssetInfo.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/RuntimePackAssetInfo.cs
@@ -35,6 +35,10 @@ namespace Microsoft.NET.Build.Tasks
             {
                 assetInfo.AssetType = AssetType.Native;
             }
+            else if (assetTypeString.Equals("resources", StringComparison.OrdinalIgnoreCase))
+            {
+                assetInfo.AssetType = AssetType.Resources;
+            }
             else
             {
                 throw new InvalidOperationException("Unexpected asset type: " + item.GetMetadata(MetadataKeys.AssetType));

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.TargetingPackResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.TargetingPackResolution.targets
@@ -277,7 +277,8 @@ Copyright (c) .NET Foundation. All rights reserved.
     
     <ResolveRuntimePackAssets FrameworkReferences="@(FrameworkReference)"
                               ResolvedRuntimePacks="@(ResolvedRuntimePack)"
-                              UnavailableRuntimePacks="@(UnavailableRuntimePack)">
+                              UnavailableRuntimePacks="@(UnavailableRuntimePack)"
+                              SatelliteResourceLanguages="$(SatelliteResourceLanguages)">
       <Output TaskParameter="RuntimePackAssets" ItemName="RuntimePackAsset" />
     </ResolveRuntimePackAssets>
     

--- a/src/Tests/Microsoft.NET.TestFramework/ProjectConstruction/TestProject.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/ProjectConstruction/TestProject.cs
@@ -17,6 +17,8 @@ namespace Microsoft.NET.TestFramework.ProjectConstruction
 
         public bool IsExe { get; set; }
 
+        public bool IsWinExe { get; set; }
+
         //  Applies to SDK Projects
         public string TargetFrameworks { get; set; }
 
@@ -241,9 +243,13 @@ namespace Microsoft.NET.TestFramework.ProjectConstruction
                 }
             }
 
-            if (this.IsExe)
+            if (this.IsExe && !this.IsWinExe)
             {
                 propertyGroup.Element(ns + "OutputType").SetValue("Exe");
+            }
+            else if (this.IsWinExe)
+            {
+                propertyGroup.Element(ns + "OutputType").SetValue("WinExe");
             }
 
             if (this.ReferencedProjects.Any())
@@ -315,7 +321,7 @@ namespace Microsoft.NET.TestFramework.ProjectConstruction
             {
                 string source;
 
-                if (this.IsExe)
+                if (this.IsExe || this.IsWinExe)
                 {
                     source =
     @"using System;
@@ -425,36 +431,6 @@ namespace {this.Name}
             }
             var requestedReferenceAssembliesPath = Path.Combine(new DirectoryInfo(net461referenceAssemblies).Parent.FullName, targetFrameworkVersion);
             return Directory.Exists(requestedReferenceAssembliesPath);
-        }
-
-        public override string ToString()
-        {
-            var ret = new StringBuilder();
-            if (!string.IsNullOrEmpty(Name))
-            {
-                ret.Append(Name);
-            }
-            if (IsSdkProject)
-            {
-                ret.Append("Sdk");
-            }
-            if (IsExe)
-            {
-                ret.Append("Exe");
-            }
-            if (!string.IsNullOrEmpty(TargetFrameworks))
-            {
-                ret.Append(TargetFrameworks);
-            }
-            if (!string.IsNullOrEmpty(TargetFrameworkProfile))
-            {
-                ret.Append(TargetFrameworkProfile);
-            }
-            else if (!string.IsNullOrEmpty(TargetFrameworkVersion))
-            {
-                ret.Append(TargetFrameworkVersion);
-            }
-            return ret.ToString();
         }
     }
 }


### PR DESCRIPTION
This commit implements copying resource assemblies for self-contained
build/publish from runtime packs.

Closes #3068.