### PR TITLE
Remove _WriteAppConfigWithSupportedRuntime Input dependency 

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.GenerateSupportedRuntime.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.GenerateSupportedRuntime.targets
@@ -41,7 +41,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   </Target>
 
   <Target Name="_WriteAppConfigWithSupportedRuntime"
-          Inputs="$(MSBuildAllProjects);@(AppConfigWithTargetPath);$(ResolveAssemblyReferencesStateFile)"
+          Inputs="$(MSBuildAllProjects);@(AppConfigWithTargetPath)"
           Outputs="$(_GenerateSupportedRuntimeIntermediateAppConfig)"
           DependsOnTargets="PrepareForBuild">
 


### PR DESCRIPTION
on ResolveAssemblyReferencesStateFile

fix https://github.com/dotnet/sdk/issues/3131

I tried to get a repro in test. However, I cannot pin down a minimal repro to cause rar cache file to be invalid between builds.

cc @KirillOsenkov