### PR TITLE
Fix generate package on build pack as tool

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -53,11 +53,11 @@ Copyright (c) .NET Foundation. All rights reserved.
   </PropertyGroup>
 
   <Target Name="_PublishBuildAlternative"
-          Condition="'$(NoBuild)' != 'true'"
+          Condition="'$(NoBuild)' != 'true' and '$(GeneratePackageOnBuild)' != 'true'"
           DependsOnTargets="Build;$(_CorePublishTargets)" />
 
   <Target Name="_PublishNoBuildAlternative"
-          Condition="'$(NoBuild)' == 'true'"
+          Condition="'$(NoBuild)' == 'true' or '$(GeneratePackageOnBuild)' == 'true'"
           DependsOnTargets="$(_BeforePublishNoBuildTargets);$(_CorePublishTargets)" />
 
   <Target Name="Publish"

--- a/src/Tests/Microsoft.NET.ToolPack.Tests/GivenThatWeWantToPackAToolProjectWithGeneratePackageOnBuild.cs
+++ b/src/Tests/Microsoft.NET.ToolPack.Tests/GivenThatWeWantToPackAToolProjectWithGeneratePackageOnBuild.cs
@@ -46,7 +46,7 @@ namespace Microsoft.NET.ToolPack.Tests
             return testAsset;
         }
 
-        [Fact(Skip = "https://github.com/dotnet/sdk/issues/3253")]
+        [Fact]
         public void It_builds_successfully()
         {
             TestAsset testAsset = SetupAndRestoreTestAsset();
@@ -61,7 +61,7 @@ namespace Microsoft.NET.ToolPack.Tests
                   .NotHaveStdOutContaining("There is a circular dependency");
         }
 
-        [Fact(Skip = "https://github.com/dotnet/sdk/issues/3253")]
+        [Fact]
         public void It_builds_and_result_contains_dependencies_dll()
         {
             TestAsset testAsset = SetupAndRestoreTestAsset();


### PR DESCRIPTION
NuGet/Home#7801

(the easiest way to understand that is)since nuget no longer sets NoBuild on GeneratePackageOnBuild, we need to do similar logic to get the previous state.

fix https://github.com/dotnet/sdk/issues/3253