### PR TITLE
Support WPF and WindowsForms-specific FrameworkReferences via profiles

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolveFrameworkReferences.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveFrameworkReferences.cs
@@ -125,6 +125,10 @@ namespace Microsoft.NET.Build.Tasks
                 targetingPack.SetMetadata("TargetingPackFormat", knownFrameworkReference.TargetingPackFormat);
                 targetingPack.SetMetadata("TargetFramework", knownFrameworkReference.TargetFramework.GetShortFolderName());
                 targetingPack.SetMetadata("RuntimeFrameworkName", knownFrameworkReference.RuntimeFrameworkName);
+                if (!string.IsNullOrEmpty(knownFrameworkReference.Profile))
+                {
+                    targetingPack.SetMetadata("Profile", knownFrameworkReference.Profile);
+                }
 
                 string targetingPackPath = null;
                 if (!string.IsNullOrEmpty(TargetingPackRoot))
@@ -386,6 +390,9 @@ namespace Microsoft.NET.Build.Tasks
             public string RuntimePackRuntimeIdentifiers => _item.GetMetadata("RuntimePackRuntimeIdentifiers");
 
             public string IsTrimmable => _item.GetMetadata(MetadataKeys.IsTrimmable);
+
+            public string Profile => _item.GetMetadata("Profile");
+
             public string LegacyFrameworkPackages
             {
                 get

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolveRuntimePackAssets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveRuntimePackAssets.cs
@@ -38,6 +38,8 @@ namespace Microsoft.NET.Build.Tasks
                 }
             }
 
+            HashSet<string> processedRuntimePackRoots = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
             foreach (var runtimePack in ResolvedRuntimePacks)
             {
                 if (!frameworkReferenceNames.Contains(runtimePack.GetMetadata(MetadataKeys.FrameworkName)))
@@ -55,6 +57,13 @@ namespace Microsoft.NET.Build.Tasks
                     //  been downloaded, and that restore should be run with that runtime identifier.
                     Log.LogError(Strings.NoRuntimePackAvailable, runtimePack.ItemSpec,
                         runtimePack.GetMetadata(MetadataKeys.RuntimeIdentifier));
+                }
+
+                if (!processedRuntimePackRoots.Add(runtimePackRoot))
+                {
+                    //  We already added assets from this runtime pack (which can happen with FrameworkReferences to different
+                    //  profiles of the same shared framework)
+                    continue;
                 }
 
                 string runtimeIdentifier = runtimePack.GetMetadata(MetadataKeys.RuntimeIdentifier);

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolveTargetingPackAssets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveTargetingPackAssets.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -231,19 +232,26 @@ namespace Microsoft.NET.Build.Tasks
                                     .ToArray();
 
             //  Filter out duplicate references (which can happen when referencing two different profiles that overlap)
-            HashSet<string> seenReferences = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-            List<TaskItem> deduplicatedReferences = new List<TaskItem>(referencesToAdd.Count);
-            foreach (var reference in referencesToAdd)
-            {
-                if (seenReferences.Add(reference.ItemSpec))
-                {
-                    deduplicatedReferences.Add(reference);
-                }
-            }
-
+            List<TaskItem> deduplicatedReferences = DeduplicateItems(referencesToAdd);
             ReferencesToAdd = deduplicatedReferences.Distinct() .ToArray();
+
             PlatformManifests = platformManifests.ToArray();
             PackageConflictOverrides = packageConflictOverrides.ToArray();
+        }
+
+        //  Get distinct items based on case-insensitive ItemSpec comparison
+        private static List<TaskItem> DeduplicateItems(List<TaskItem> items)
+        {
+            HashSet<string> seenItemSpecs = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            List<TaskItem> deduplicatedItems = new List<TaskItem>(items.Count);
+            foreach (var item in items)
+            {
+                if (seenItemSpecs.Add(item.ItemSpec))
+                {
+                    deduplicatedItems.Add(item);
+                }
+            }
+            return deduplicatedItems;
         }
 
         private TaskItem CreatePackageOverride(string runtimeFrameworkName, string packageOverridesPath)

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolveTargetingPackAssets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveTargetingPackAssets.cs
@@ -32,7 +32,99 @@ namespace Microsoft.NET.Build.Tasks
         public ITaskItem[] PackageConflictOverrides { get; set; }
 
         [Output]
-        public ITaskItem[] RuntimeFrameworksToRemove { get; set; }
+        public ITaskItem[] UsedRuntimeFrameworks { get; set; }
+
+        private Dictionary<string, List<string>> _assemblyProfiles;
+
+        public ResolveTargetingPackAssets()
+        {
+            //  Hard-code assembly profiles for WindowDesktop targeting pack here until
+            //  they are added to its FrameworkList.xml: https://github.com/dotnet/core-setup/issues/6210
+            _assemblyProfiles = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
+
+            var bothProfiles = new List<string>() { "WindowsForms", "WPF" };
+
+            foreach (var assemblyName in new []
+            {
+                "Accessibility",
+                "Microsoft.Win32.Registry",
+                "Microsoft.Win32.SystemEvents",
+                "System.CodeDom",
+                "System.Configuration.ConfigurationManager",
+                "System.Diagnostics.EventLog",
+                "System.DirectoryServices",
+                "System.IO.FileSystem.AccessControl",
+                "System.Media.SoundPlayer",
+                "System.Security.AccessControl",
+                "System.Security.Cryptography.Cng",
+                "System.Security.Cryptography.Pkcs",
+                "System.Security.Cryptography.ProtectedData",
+                "System.Security.Cryptography.Xml",
+                "System.Security.Permissions",
+                "System.Security.Principal.Windows",
+                "System.Threading.AccessControl",
+                "System.Windows.Extensions",
+            })
+            {
+                _assemblyProfiles[assemblyName] = bothProfiles;
+            }
+
+            var wpfProfile = new List<string>() { "WPF" };
+
+            foreach (var assemblyName in new []
+            {
+                "DirectWriteForwarder",
+                "PenImc_cor3",
+                "PresentationCore-CommonResources",
+                "PresentationCore",
+                "PresentationFramework-SystemCore",
+                "PresentationFramework-SystemData",
+                "PresentationFramework-SystemDrawing",
+                "PresentationFramework-SystemXml",
+                "PresentationFramework-SystemXmlLinq",
+                "PresentationFramework.Aero",
+                "PresentationFramework.Aero2",
+                "PresentationFramework.AeroLite",
+                "PresentationFramework.Classic",
+                "PresentationFramework",
+                "PresentationFramework.Luna",
+                "PresentationFramework.Royale",
+                "PresentationNative_cor3",
+                "PresentationUI",
+                "ReachFramework",
+                "System.Printing",
+                "System.Windows.Controls.Ribbon",
+                "System.Windows.Input.Manipulations",
+                "System.Windows.Presentation",
+                "System.Xaml",
+                "UIAutomationClient",
+                "UIAutomationClientSideProviders",
+                "UIAutomationProvider",
+                "UIAutomationTypes",
+                "WindowsBase",
+                "WPFgfx_cor3",
+            })
+            {
+                _assemblyProfiles[assemblyName] = wpfProfile;
+            }
+
+            var windowsFormsProfile = new List<string>() { "WindowsForms" };
+
+            foreach (var assemblyName in new[]
+            {
+                "System.Design",
+                "System.Drawing.Common",
+                "System.Drawing.Design",
+                "System.Drawing.Design.Primitives",
+                "System.Windows.Forms.Design",
+                "System.Windows.Forms.Design.Editors",
+                "System.Windows.Forms",
+            })
+            {
+                _assemblyProfiles[assemblyName] = windowsFormsProfile;
+            }
+
+        }
 
         protected override void ExecuteCore()
         {
@@ -133,12 +225,23 @@ namespace Microsoft.NET.Build.Tasks
                 }
             }
 
-            //  Remove RuntimeFramework items for shared frameworks which weren't referenced
+            //  Calculate which RuntimeFramework items should actually be used based on framework references
             HashSet<string> frameworkReferenceNames = new HashSet<string>(FrameworkReferences.Select(fr => fr.ItemSpec), StringComparer.OrdinalIgnoreCase);
-            RuntimeFrameworksToRemove = RuntimeFrameworks.Where(rf => !frameworkReferenceNames.Contains(rf.GetMetadata(MetadataKeys.FrameworkName)))
-                                        .ToArray();
+            UsedRuntimeFrameworks = RuntimeFrameworks.Where(rf => frameworkReferenceNames.Contains(rf.GetMetadata(MetadataKeys.FrameworkName)))
+                                    .ToArray();
 
-            ReferencesToAdd = referencesToAdd.ToArray();
+            //  Filter out duplicate references (which can happen when referencing two different profiles that overlap)
+            HashSet<string> seenReferences = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            List<TaskItem> deduplicatedReferences = new List<TaskItem>(referencesToAdd.Count);
+            foreach (var reference in referencesToAdd)
+            {
+                if (seenReferences.Add(reference.ItemSpec))
+                {
+                    deduplicatedReferences.Add(reference);
+                }
+            }
+
+            ReferencesToAdd = deduplicatedReferences.Distinct() .ToArray();
             PlatformManifests = platformManifests.ToArray();
             PackageConflictOverrides = packageConflictOverrides.ToArray();
         }
@@ -173,9 +276,27 @@ namespace Microsoft.NET.Build.Tasks
         {
             XDocument frameworkListDoc = XDocument.Load(frameworkListPath);
 
+            string profile = targetingPack.GetMetadata("Profile");
+
             foreach (var fileElement in frameworkListDoc.Root.Elements("File"))
             {
                 string assemblyName = fileElement.Attribute("AssemblyName").Value;
+
+                if (!string.IsNullOrEmpty(profile))
+                {
+                    _assemblyProfiles.TryGetValue(assemblyName, out var assemblyProfiles);
+                    if (assemblyProfiles == null)
+                    {
+                        //  If profile was specified but this assembly doesn't belong to any profiles, don't reference it
+                        continue;
+                    }
+                    if (!assemblyProfiles.Contains(profile, StringComparer.OrdinalIgnoreCase))
+                    {
+                        //  Assembly wasn't in profile specified, so don't reference it
+                        continue;
+                    }
+                }
+
                 var dllPath = Path.Combine(targetingPackDllFolder, assemblyName + ".dll");
                 var referenceItem = CreateReferenceItem(dllPath, targetingPack);
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.TargetingPackResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.TargetingPackResolution.targets
@@ -69,6 +69,22 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     </ItemGroup>
 
+    <!-- We will add Microsoft.WindowsDesktop.App.WPF and Microsoft.WindowsDesktop.App.WindowsForms to the bundled versions.
+         Until we do, add them here. -->
+    <ItemGroup>
+      <_WPFKnownFrameworkReference Include="@(KnownFrameworkReference)"
+                                   Condition="'%(Identity)' == 'Microsoft.WindowsDesktop.App.WPF'"/>
+    </ItemGroup>
+    <ItemGroup Condition="'@(_WPFKnownFrameworkReference)' == ''">
+      <_WindowsDesktopKnownFrameworkReference Include="@(KnownFrameworkReference)"
+                                        Condition="'%(Identity)' == 'Microsoft.WindowsDesktop.App'"/>
+
+      <KnownFrameworkReference Include="@(_WindowsDesktopKnownFrameworkReference->'Microsoft.WindowsDesktop.App.WindowsForms')"
+                               Profile="WindowsForms"/>
+      <KnownFrameworkReference Include="@(_WindowsDesktopKnownFrameworkReference->'Microsoft.WindowsDesktop.App.WPF')"
+                               Profile="WPF"/>
+    </ItemGroup>
+
     <PropertyGroup Condition="'$(EnableTargetingPackDownload)' == ''">
       <EnableTargetingPackDownload>true</EnableTargetingPackDownload>
     </PropertyGroup>
@@ -199,7 +215,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       <Output TaskParameter="PlatformManifests" ItemName="PlatformManifestsFromTargetingPacks" />
       <Output TaskParameter="PackageConflictPreferredPackages" PropertyName="PackageConflictPreferredPackages" />
       <Output TaskParameter="PackageConflictOverrides" ItemName="PackageConflictOverrides" />
-      <Output TaskParameter="RuntimeFrameworksToRemove" ItemName="_RuntimeFrameworkToRemove" />
+      <Output TaskParameter="UsedRuntimeFrameworks" ItemName="_UsedRuntimeFramework" />
       
     </ResolveTargetingPackAssets>
     
@@ -208,7 +224,8 @@ Copyright (c) .NET Foundation. All rights reserved.
     </ItemGroup>
 
     <ItemGroup>
-      <RuntimeFramework Remove="@(_RuntimeFrameworkToRemove)"/>
+      <RuntimeFramework Remove="@(RuntimeFramework)" />
+      <RuntimeFramework Include="@(_UsedRuntimeFramework)" />
     </ItemGroup>
 
     <GetPackageDirectory


### PR DESCRIPTION
This PR supports referencing only Windows Forms or only WPF assets from the WindowsDesktop targeting pack.  See https://github.com/dotnet/cli/issues/10536.

This is done by supporting the following additional FrameworkReferences:

- Microsoft.WindowsDesktop.App.WindowsForms
- Microsoft.WindowsDesktop.App.WPF

In the implementation, a KnownFrameworkReference can specify a Profile of the targeting pack via metadata.  https://github.com/dotnet/core-setup/issues/6210 tracks adding this information to the WindowsDesktop FrameworkList.xml.  Until then, this PR hard-codes the assemblies which are in each profile.

After this is merged, the WindowsDesktop SDK should be updated to use the .WindowsForms or .WPF FrameworkReference depending on if the `UseWPF` or `UseWindowsForms` properties are set.  If both of them are set, it should use the base Microsoft.WindomwsDesktop.App FrameworkReference, which will include the integration DLL.

@nguerrera @vatsan-madhavan