### PR TITLE
Use PackageDownload in VS, fix design time build failures

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -22,7 +22,7 @@ jobs:
     pool:
       ${{ if eq(variables['System.TeamProject'], 'public') }}:
         name: NetCorePublic-Pool
-        queue: buildpool.windows.10.amd64.vs2017.open
+        queue: BuildPool.Windows.10.Amd64.VS2019.Pre.Open
       ${{ if ne(variables['System.TeamProject'], 'public') }}:
         name: NetCoreInternal-Pool
         queue: buildpool.windows.10.amd64.vs2017
@@ -75,7 +75,7 @@ jobs:
       agentOs: Windows_NT_FullFramework
       pool:
         name: NetCorePublic-Pool
-        queue: buildpool.windows.10.amd64.vs2017.open
+        queue: BuildPool.Windows.10.Amd64.VS2019.Pre.Open
       strategy:
         matrix:
           Build_Debug:
@@ -92,7 +92,7 @@ jobs:
       agentOs: Windows_NT_TestAsTools
       pool:
         name: NetCorePublic-Pool
-        queue: buildpool.windows.10.amd64.vs2017.open
+        queue: BuildPool.Windows.10.Amd64.VS2019.Pre.Open
       strategy:
         matrix:
           Build_Debug:
@@ -157,7 +157,7 @@ jobs:
       agentOs: Windows_Perf_CI
       pool:
         name: NetCorePublic-Pool
-        queue: buildpool.windows.10.amd64.vs2017.open
+        queue: BuildPool.Windows.10.Amd64.VS2019.Pre.Open
       strategy:
         matrix:
           Build_Release:

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAResolvePackageAssetsTask.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAResolvePackageAssetsTask.cs
@@ -17,7 +17,8 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
         {
             var inputProperties = typeof(ResolvePackageAssets)
                 .GetProperties(BindingFlags.DeclaredOnly | BindingFlags.Instance | BindingFlags.Public)
-                .Where(p => !p.IsDefined(typeof(OutputAttribute)))
+                .Where(p => !p.IsDefined(typeof(OutputAttribute)) &&
+                            p.Name != nameof(ResolvePackageAssets.DesignTimeBuild))
                 .OrderBy(p => p.Name, StringComparer.Ordinal);
 
             var requiredProperties = inputProperties

--- a/src/Tasks/Microsoft.NET.Build.Tasks/LockFileExtensions.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/LockFileExtensions.cs
@@ -12,36 +12,28 @@ namespace Microsoft.NET.Build.Tasks
 {
     internal static class LockFileExtensions
     {
-        public static LockFileTarget GetTargetAndThrowIfNotFound(this LockFile lockFile, NuGetFramework framework, string runtime,
-            bool throwIfNotFound = true)
+        public static LockFileTarget GetTargetAndThrowIfNotFound(this LockFile lockFile, NuGetFramework framework, string runtime)
         {
             LockFileTarget lockFileTarget = lockFile.GetTarget(framework, runtime);
 
             if (lockFileTarget == null)
             {
-                if (throwIfNotFound)
+                string frameworkString = framework.DotNetFrameworkName;
+                string targetMoniker = string.IsNullOrEmpty(runtime) ?
+                    frameworkString :
+                    $"{frameworkString}/{runtime}";
+
+                string message;
+                if (string.IsNullOrEmpty(runtime))
                 {
-                    string frameworkString = framework.DotNetFrameworkName;
-                    string targetMoniker = string.IsNullOrEmpty(runtime) ?
-                        frameworkString :
-                        $"{frameworkString}/{runtime}";
-
-                    string message;
-                    if (string.IsNullOrEmpty(runtime))
-                    {
-                        message = string.Format(Strings.AssetsFileMissingTarget, lockFile.Path, targetMoniker, framework.GetShortFolderName());
-                    }
-                    else
-                    {
-                        message = string.Format(Strings.AssetsFileMissingRuntimeIdentifier, lockFile.Path, targetMoniker, framework.GetShortFolderName(), runtime);
-                    }
-
-                    throw new BuildErrorException(message);
+                    message = string.Format(Strings.AssetsFileMissingTarget, lockFile.Path, targetMoniker, framework.GetShortFolderName());
                 }
                 else
                 {
-                    return new LockFileTarget();
+                    message = string.Format(Strings.AssetsFileMissingRuntimeIdentifier, lockFile.Path, targetMoniker, framework.GetShortFolderName(), runtime);
                 }
+
+                throw new BuildErrorException(message);
             }
 
             return lockFileTarget;

--- a/src/Tasks/Microsoft.NET.Build.Tasks/LockFileExtensions.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/LockFileExtensions.cs
@@ -12,28 +12,36 @@ namespace Microsoft.NET.Build.Tasks
 {
     internal static class LockFileExtensions
     {
-        public static LockFileTarget GetTargetAndThrowIfNotFound(this LockFile lockFile, NuGetFramework framework, string runtime)
+        public static LockFileTarget GetTargetAndThrowIfNotFound(this LockFile lockFile, NuGetFramework framework, string runtime,
+            bool throwIfNotFound = true)
         {
             LockFileTarget lockFileTarget = lockFile.GetTarget(framework, runtime);
 
             if (lockFileTarget == null)
             {
-                string frameworkString = framework.DotNetFrameworkName;
-                string targetMoniker = string.IsNullOrEmpty(runtime) ?
-                    frameworkString :
-                    $"{frameworkString}/{runtime}";
-
-                string message;
-                if (string.IsNullOrEmpty(runtime))
+                if (throwIfNotFound)
                 {
-                    message = string.Format(Strings.AssetsFileMissingTarget, lockFile.Path, targetMoniker, framework.GetShortFolderName());
+                    string frameworkString = framework.DotNetFrameworkName;
+                    string targetMoniker = string.IsNullOrEmpty(runtime) ?
+                        frameworkString :
+                        $"{frameworkString}/{runtime}";
+
+                    string message;
+                    if (string.IsNullOrEmpty(runtime))
+                    {
+                        message = string.Format(Strings.AssetsFileMissingTarget, lockFile.Path, targetMoniker, framework.GetShortFolderName());
+                    }
+                    else
+                    {
+                        message = string.Format(Strings.AssetsFileMissingRuntimeIdentifier, lockFile.Path, targetMoniker, framework.GetShortFolderName(), runtime);
+                    }
+
+                    throw new BuildErrorException(message);
                 }
                 else
                 {
-                    message = string.Format(Strings.AssetsFileMissingRuntimeIdentifier, lockFile.Path, targetMoniker, framework.GetShortFolderName(), runtime);
+                    return new LockFileTarget();
                 }
-
-                throw new BuildErrorException(message);
             }
 
             return lockFileTarget;

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.TargetingPackResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.TargetingPackResolution.targets
@@ -284,7 +284,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <UsingTask TaskName="ResolveRuntimePackAssets" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
   
   <Target Name="ResolveRuntimePackAssets" DependsOnTargets="ResolvePackageAssets"
-          Condition="'@(RuntimePack)' != ''">
+          Condition="'@(RuntimePack)' != '' And '$(DesignTimeBuild)' != 'true'">
     
       <GetPackageDirectory
         Items="@(RuntimePack)"

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.TargetingPackResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.TargetingPackResolution.targets
@@ -22,7 +22,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <UsingTask TaskName="ResolveFrameworkReferences" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
   <UsingTask TaskName="ResolveAppHosts" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
 
-  <Target Name="ResolveFrameworkReferences" BeforeTargets="_CheckForInvalidConfigurationAndPlatform;CollectPackageReferences">
+  <Target Name="ResolveFrameworkReferences" BeforeTargets="_CheckForInvalidConfigurationAndPlatform;CollectPackageReferences;CollectPackageDownloads">
     
     <CheckForDuplicateFrameworkReferences
         FrameworkReferences="@(FrameworkReference)"
@@ -142,8 +142,9 @@ Copyright (c) .NET Foundation. All rights reserved.
     </ResolveAppHosts>
 
     <PropertyGroup Condition="'$(UsePackageDownload)' == ''">
-      <UsePackageDownload Condition=" '$(MSBuildRuntimeType)' == 'Core'">true</UsePackageDownload>
-      <UsePackageDownload Condition=" '$(MSBuildRuntimeType)' != 'Core'">false</UsePackageDownload>
+      <UsePackageDownload Condition="'$(MSBuildRuntimeType)' == 'Core'">true</UsePackageDownload>
+      <UsePackageDownload Condition="'$(PackageDownloadSupported)' == 'true'">true</UsePackageDownload>
+      <UsePackageDownload Condition="'$(UsePackageDownload)' == ''">false</UsePackageDownload>
     </PropertyGroup>
     
     <ItemGroup Condition="'$(UsePackageDownload)' == 'true'">

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.PackageDependencyResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.PackageDependencyResolution.targets
@@ -177,7 +177,8 @@ Copyright (c) .NET Foundation. All rights reserved.
     <CheckForTargetInAssetsFile
       AssetsFilePath="$(ProjectAssetsFile)"
       TargetFrameworkMoniker="$(NuGetTargetMoniker)"
-      RuntimeIdentifier="$(RuntimeIdentifier)" />
+      RuntimeIdentifier="$(RuntimeIdentifier)"
+      Condition=" '$(DesignTimeBuild)' != 'true'"/>
 
     <ResolvePackageDependencies
       ProjectPath="$(MSBuildProjectFullPath)"
@@ -252,7 +253,8 @@ Copyright (c) .NET Foundation. All rights reserved.
       EnsureRuntimePackageDependencies="$(EnsureRuntimePackageDependencies)"
       VerifyMatchingImplicitPackageVersion="$(VerifyMatchingImplicitPackageVersion)"
       ExpectedPlatformPackages="@(ExpectedPlatformPackages)"
-      SatelliteResourceLanguages="$(SatelliteResourceLanguages)">
+      SatelliteResourceLanguages="$(SatelliteResourceLanguages)"
+      DesignTimeBuild="$(DesignTimeBuild)">
 
       <!-- NOTE: items names here are inconsistent because they match prior implementation
           (that was spread across different tasks/targets) for backwards compatibility.  -->

--- a/src/Tests/Microsoft.NET.Build.Tests/DesignTimeBuildTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/DesignTimeBuildTests.cs
@@ -36,7 +36,16 @@ namespace Microsoft.NET.Build.Tests
             var testAsset = _testAssetsManager
                 .CopyTestAsset("AppWithLibrary", identifier: relativeProjectPath + "_" + targetFramework ?? string.Empty)
                 .WithSource()
+                .WithProjectChanges(p =>
+                {
+                    var ns = p.Root.Name.Namespace;
+                    //  Add dummy target called by design-time build which may not yet be defined in the version
+                    //  of Visual Studio we are testing with.
+                    p.Root.Add(new XElement(ns + "Target",
+                                    new XAttribute("Name", "CollectFrameworkReferences")));
+                })
                 .WithTargetFramework(targetFramework, relativeProjectPath);
+
 
             var projectDirectory = Path.Combine(testAsset.TestRoot, relativeProjectPath);
 
@@ -87,6 +96,14 @@ namespace Microsoft.NET.Build.Tests
             };
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject)
+                .WithProjectChanges(p =>
+                {
+                    var ns = p.Root.Name.Namespace;
+                    //  Add dummy target called by design-time build which may not yet be defined in the version
+                    //  of Visual Studio we are testing with.
+                    p.Root.Add(new XElement(ns + "Target",
+                                    new XAttribute("Name", "CollectFrameworkReferences")));
+                })
                 .Restore(Log, testProject.Name);
 
             string projectFolder = Path.Combine(testAsset.TestRoot, testProject.Name);

--- a/src/Tests/Microsoft.NET.Build.Tests/DesignTimeBuildTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/DesignTimeBuildTests.cs
@@ -1,0 +1,161 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Xml.Linq;
+using Microsoft.NET.TestFramework;
+using Microsoft.NET.TestFramework.Assertions;
+using Microsoft.NET.TestFramework.Commands;
+using Microsoft.NET.TestFramework.ProjectConstruction;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.NET.Build.Tests
+{
+    public class DesignTimeBuildTests : SdkTest
+    {
+        public DesignTimeBuildTests(ITestOutputHelper log) : base(log)
+        {
+        }
+
+        [Theory]
+        [InlineData("TestLibrary", null)]
+        [InlineData("TestApp", null)]
+        [InlineData("TestApp", "netcoreapp2.1")]
+        [InlineData("TestApp", "netcoreapp3.0")]
+        public void The_design_time_build_succeeds_before_nuget_restore(string relativeProjectPath, string targetFramework)
+        {
+            var args = GetDesignTimeMSBuildArgs();
+            if (args == null)
+            {
+                //  Design-time targets couldn't be found
+                return;
+            }
+
+            var testAsset = _testAssetsManager
+                .CopyTestAsset("AppWithLibrary", identifier: relativeProjectPath + "_" + targetFramework ?? string.Empty)
+                .WithSource()
+                .WithTargetFramework(targetFramework, relativeProjectPath);
+
+            var projectDirectory = Path.Combine(testAsset.TestRoot, relativeProjectPath);
+
+            var command = new MSBuildCommand(Log, "ResolveAssemblyReferencesDesignTime", projectDirectory);
+            var result = command.Execute(args);
+
+            result.Should().Pass();
+        }
+
+        [Fact]
+        public void DesignTimeBuildSucceedsAfterTargetFrameworkIsChanged()
+        {
+            TestDesignTimeBuildAfterChange(project =>
+            {
+                var ns = project.Root.Name.Namespace;
+                project.Root.Element(ns + "PropertyGroup")
+                    .Element(ns + "TargetFramework")
+                    .SetValue("netcoreapp2.1");
+            });
+        }
+
+        [Fact]
+        public void DesignTimeBuildSucceedsAfterRuntimeIdentifierIsChanged()
+        {
+            TestDesignTimeBuildAfterChange(project =>
+            {
+                var ns = project.Root.Name.Namespace;
+                project.Root.Element(ns + "PropertyGroup")
+                    .Add(new XElement(ns + "RuntimeIdentifier", "win-x64"));
+            });
+        }
+
+        private void TestDesignTimeBuildAfterChange(Action<XDocument> projectChange, [CallerMemberName] string callingMethod = "")
+        {
+            var designTimeArgs = GetDesignTimeMSBuildArgs();
+            if (designTimeArgs == null)
+            {
+                //  Design-time targets couldn't be found
+                return;
+            }
+
+            var testProject = new TestProject()
+            {
+                Name = "App",
+                TargetFrameworks = "netcoreapp3.0",
+                IsSdkProject = true,
+                IsExe = true
+            };
+
+            var testAsset = _testAssetsManager.CreateTestProject(testProject)
+                .Restore(Log, testProject.Name);
+
+            string projectFolder = Path.Combine(testAsset.TestRoot, testProject.Name);
+
+            var buildCommand = new MSBuildCommand(Log, null, projectFolder);
+            buildCommand.WorkingDirectory = projectFolder;
+
+            buildCommand
+                .Execute()
+                .Should()
+                .Pass();
+
+            string projectFilePath = Path.Combine(projectFolder, testProject.Name + ".csproj");
+
+            var project = XDocument.Load(projectFilePath);
+
+            projectChange(project);
+
+            project.Save(projectFilePath);
+
+            buildCommand
+                .Execute(designTimeArgs)
+                .Should()
+                .Pass();
+
+            buildCommand
+                .Execute("/restore")
+                .Should()
+                .Pass();
+
+            buildCommand
+                .Execute(designTimeArgs)
+                .Should()
+                .Pass();
+
+        }
+
+        private static string[] GetDesignTimeMSBuildArgs()
+        {
+            //  This test needs the design-time targets, which come with Visual Studio.  So we will use the VSINSTALLDIR
+            //  environment variable to find the install path to Visual Studio and the design-time targets under it.
+            //  This will be set when running from a developer command prompt.  Unfortunately, unless VS is launched
+            //  from a developer command prompt, it won't be set when running tests from VS.  So in that case the
+            //  test will simply be skipped.
+            string vsInstallDir = Environment.GetEnvironmentVariable("VSINSTALLDIR");
+
+            if (vsInstallDir == null)
+            {
+                return null;
+            }
+
+            string csharpDesignTimeTargets = Path.Combine(vsInstallDir, @"MSBuild\Microsoft\VisualStudio\Managed\Microsoft.CSharp.DesignTime.targets");
+
+            var args = new[]
+            {
+                "/p:DesignTimeBuild=true",
+                "/p:SkipCompilerExecution=true",
+                "/p:ProvideCommandLineArgs=true",
+                $"/p:CSharpDesignTimeTargetsPath={csharpDesignTimeTargets}",
+                "/t:CollectResolvedSDKReferencesDesignTime;CollectPackageReferences;ResolveComReferencesDesignTime",
+                "/t:ResolveProjectReferencesDesignTime;BuiltProjectOutputGroup;CollectFrameworkReferences",
+                "/t:CollectUpToDateCheckBuiltDesignTime;CollectPackageDownloads;ResolveAssemblyReferencesDesignTime",
+                "/t:CollectAnalyzersDesignTime;CollectSDKReferencesDesignTime;CollectUpToDateCheckInputDesignTime",
+                "/t:CollectUpToDateCheckOutputDesignTime;ResolvePackageDependenciesDesignTime;CompileDesignTime",
+                "/t:CollectResolvedCompilationReferencesDesignTime",
+                "/bl:designtime.binlog"
+            };
+
+            return args;
+        }
+    }
+}

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToVerifyPCLProjectReferenceCompat.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToVerifyPCLProjectReferenceCompat.cs
@@ -26,7 +26,9 @@ namespace Microsoft.NET.Build.Tests
         [FullMSBuildOnlyTheory]
         [InlineData("netstandard1.1", "Profile7", "v4.5", true, true)]
         [InlineData("netstandard1.0", "Profile31", "v4.6", true, true)]
-        [InlineData("netstandard1.2", "Profile32", "v4.6", true, true)]
+        //  Profile32 test disabled because building it depends on MakePri.exe in the Windows SDK,
+        //  which isn't installed in VS2019 CI machines
+        //[InlineData("netstandard1.2", "Profile32", "v4.6", true, true)]
         [InlineData("netstandard1.2", "Profile44", "v4.6", true, true)]
         [InlineData("netstandard1.0", "Profile49", "v4.5", true, true)]
         [InlineData("netstandard1.0", "Profile78", "v4.5", true, true)]

--- a/src/Tests/Microsoft.NET.TestFramework/ToolsetInfo.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/ToolsetInfo.cs
@@ -110,7 +110,10 @@ namespace Microsoft.NET.TestFramework
         {
 
             var newArgs = args.ToList();
-            newArgs.Insert(0, $"/t:{target}");
+            if (!string.IsNullOrEmpty(target))
+            {
+                newArgs.Insert(0, $"/t:{target}");
+            }
 
             return CreateCommand(newArgs.ToArray());
         }


### PR DESCRIPTION
- Use PackageDownload when supported on full MSBuild.  Fixes https://github.com/dotnet/cli/issues/10440
- Don't fail design-time builds when the target framework or RuntimeIdentifier doesn't match what's in the (now outdated) assets file.  Fixes #2322
  - I'd like to add tests to cover this, but haven't yet