### PR TITLE
Log error when building for Windows Desktop on non-Windows.

### DIFF
--- a/src/Tasks/Common/Resources/Strings.resx
+++ b/src/Tasks/Common/Resources/Strings.resx
@@ -518,4 +518,8 @@ The following are names of parameters or literal values and should not be transl
     <value>NETSDK1099: Publishing to a single-file is only supported for executable applications.</value>
     <comment>{StrBegin="NETSDK1099: "}</comment>
   </data>
+  <data name="WindowsDesktopFrameworkRequiresWindows" xml:space="preserve">
+    <value>NETSDK1100: Windows is required to build Windows desktop applications.</value>
+    <comment>{StrBegin="NETSDK1100: "}</comment>
+  </data>
 </root>

--- a/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
@@ -501,6 +501,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1057: Používáte preview verzi .NET Core. Další informace: https://aka.ms/dotnet-core-preview</target>
         <note>{StrBegin="NETSDK1057: "}</note>
       </trans-unit>
+      <trans-unit id="WindowsDesktopFrameworkRequiresWindows">
+        <source>NETSDK1100: Windows is required to build Windows desktop applications.</source>
+        <target state="new">NETSDK1100: Windows is required to build Windows desktop applications.</target>
+        <note>{StrBegin="NETSDK1100: "}</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Common/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.de.xlf
@@ -501,6 +501,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1057: Sie verwenden eine Vorschauversion von .NET Core. Weitere Informationen: https://aka.ms/dotnet-core-preview</target>
         <note>{StrBegin="NETSDK1057: "}</note>
       </trans-unit>
+      <trans-unit id="WindowsDesktopFrameworkRequiresWindows">
+        <source>NETSDK1100: Windows is required to build Windows desktop applications.</source>
+        <target state="new">NETSDK1100: Windows is required to build Windows desktop applications.</target>
+        <note>{StrBegin="NETSDK1100: "}</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Common/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.es.xlf
@@ -501,6 +501,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1057: Está utilizando una versión preliminar de .NET Core. Vea: https://aka.ms/dotnet-core-preview</target>
         <note>{StrBegin="NETSDK1057: "}</note>
       </trans-unit>
+      <trans-unit id="WindowsDesktopFrameworkRequiresWindows">
+        <source>NETSDK1100: Windows is required to build Windows desktop applications.</source>
+        <target state="new">NETSDK1100: Windows is required to build Windows desktop applications.</target>
+        <note>{StrBegin="NETSDK1100: "}</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
@@ -501,6 +501,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1057 : Vous utilisez une préversion de .NET Core. Voir : https://aka.ms/dotnet-core-preview</target>
         <note>{StrBegin="NETSDK1057: "}</note>
       </trans-unit>
+      <trans-unit id="WindowsDesktopFrameworkRequiresWindows">
+        <source>NETSDK1100: Windows is required to build Windows desktop applications.</source>
+        <target state="new">NETSDK1100: Windows is required to build Windows desktop applications.</target>
+        <note>{StrBegin="NETSDK1100: "}</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Common/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.it.xlf
@@ -501,6 +501,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1057: si sta usando una versione in anteprima di .NET Core. Vedere https://aka.ms/dotnet-core-preview</target>
         <note>{StrBegin="NETSDK1057: "}</note>
       </trans-unit>
+      <trans-unit id="WindowsDesktopFrameworkRequiresWindows">
+        <source>NETSDK1100: Windows is required to build Windows desktop applications.</source>
+        <target state="new">NETSDK1100: Windows is required to build Windows desktop applications.</target>
+        <note>{StrBegin="NETSDK1100: "}</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
@@ -501,6 +501,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1057: プレビュー版の .NET Core を使用しています。https://aka.ms/dotnet-core-preview をご覧ください</target>
         <note>{StrBegin="NETSDK1057: "}</note>
       </trans-unit>
+      <trans-unit id="WindowsDesktopFrameworkRequiresWindows">
+        <source>NETSDK1100: Windows is required to build Windows desktop applications.</source>
+        <target state="new">NETSDK1100: Windows is required to build Windows desktop applications.</target>
+        <note>{StrBegin="NETSDK1100: "}</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
@@ -501,6 +501,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1057: .NET Core의 미리 보기 버전을 사용 중입니다. 참조: https://aka.ms/dotnet-core-preview</target>
         <note>{StrBegin="NETSDK1057: "}</note>
       </trans-unit>
+      <trans-unit id="WindowsDesktopFrameworkRequiresWindows">
+        <source>NETSDK1100: Windows is required to build Windows desktop applications.</source>
+        <target state="new">NETSDK1100: Windows is required to build Windows desktop applications.</target>
+        <note>{StrBegin="NETSDK1100: "}</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
@@ -501,6 +501,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1057: Korzystasz z wersji zapoznawczej platformy .NET Core. Zobacz: https://aka.ms/dotnet-core-preview</target>
         <note>{StrBegin="NETSDK1057: "}</note>
       </trans-unit>
+      <trans-unit id="WindowsDesktopFrameworkRequiresWindows">
+        <source>NETSDK1100: Windows is required to build Windows desktop applications.</source>
+        <target state="new">NETSDK1100: Windows is required to build Windows desktop applications.</target>
+        <note>{StrBegin="NETSDK1100: "}</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
@@ -501,6 +501,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1057: você está usando uma versão prévia do .NET Core. Consulte: https://aka.ms/dotnet-core-preview</target>
         <note>{StrBegin="NETSDK1057: "}</note>
       </trans-unit>
+      <trans-unit id="WindowsDesktopFrameworkRequiresWindows">
+        <source>NETSDK1100: Windows is required to build Windows desktop applications.</source>
+        <target state="new">NETSDK1100: Windows is required to build Windows desktop applications.</target>
+        <note>{StrBegin="NETSDK1100: "}</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
@@ -501,6 +501,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1057: Вы используете предварительную версию .NET Core. Дополнительные сведения см. на странице https://aka.ms/dotnet-core-preview</target>
         <note>{StrBegin="NETSDK1057: "}</note>
       </trans-unit>
+      <trans-unit id="WindowsDesktopFrameworkRequiresWindows">
+        <source>NETSDK1100: Windows is required to build Windows desktop applications.</source>
+        <target state="new">NETSDK1100: Windows is required to build Windows desktop applications.</target>
+        <note>{StrBegin="NETSDK1100: "}</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
@@ -501,6 +501,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1057: .NET Core'un önizleme sürümünü kullanıyorsunuz. Bkz. https://aka.ms/dotnet-core-preview</target>
         <note>{StrBegin="NETSDK1057: "}</note>
       </trans-unit>
+      <trans-unit id="WindowsDesktopFrameworkRequiresWindows">
+        <source>NETSDK1100: Windows is required to build Windows desktop applications.</source>
+        <target state="new">NETSDK1100: Windows is required to build Windows desktop applications.</target>
+        <note>{StrBegin="NETSDK1100: "}</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
@@ -501,6 +501,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1057: 你正在使用 .NET Core 的预览版。请查看 https://aka.ms/dotnet-core-preview</target>
         <note>{StrBegin="NETSDK1057: "}</note>
       </trans-unit>
+      <trans-unit id="WindowsDesktopFrameworkRequiresWindows">
+        <source>NETSDK1100: Windows is required to build Windows desktop applications.</source>
+        <target state="new">NETSDK1100: Windows is required to build Windows desktop applications.</target>
+        <note>{StrBegin="NETSDK1100: "}</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
@@ -501,6 +501,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1057: 您使用的是 .NET Core 預覽版。請參閱: https://aka.ms/dotnet-core-preview</target>
         <note>{StrBegin="NETSDK1057: "}</note>
       </trans-unit>
+      <trans-unit id="WindowsDesktopFrameworkRequiresWindows">
+        <source>NETSDK1100: Windows is required to build Windows desktop applications.</source>
+        <target state="new">NETSDK1100: Windows is required to build Windows desktop applications.</target>
+        <note>{StrBegin="NETSDK1100: "}</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolveFrameworkReferences.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveFrameworkReferences.cs
@@ -107,6 +107,8 @@ namespace Microsoft.NET.Build.Tasks
                         Log.LogError(Strings.WindowsDesktopFrameworkRequiresWindows);
                         windowsOnlyErrorLogged = true;
                     }
+
+                    // Ignore (and don't download) this known framework reference as it requires Windows
                     continue;
                 }
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.TargetingPackResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.TargetingPackResolution.targets
@@ -17,6 +17,13 @@ Copyright (c) .NET Foundation. All rights reserved.
     </ResolveAssemblyReferencesDependsOn>
   </PropertyGroup>
 
+  <!-- Mark the WindowsDesktop frameworks as being windows only.
+       TODO: remove this once the metadata exists on the items in the SDK props file. -->
+  <ItemGroup>
+    <KnownFrameworkReference Update="Microsoft.WindowsDesktop.App" IsWindowsOnly="True" />
+    <KnownFrameworkReference Update="Microsoft.WindowsDesktop.App.WindowsForms" IsWindowsOnly="True" />
+    <KnownFrameworkReference Update="Microsoft.WindowsDesktop.App.WPF" IsWindowsOnly="True" />
+  </ItemGroup>
 
   <UsingTask TaskName="CheckForDuplicateFrameworkReferences" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
   <UsingTask TaskName="ResolveFrameworkReferences" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
@@ -34,39 +41,6 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ItemGroup>
       <FrameworkReference Remove="@(_FrameworkReferenceToRemove)" />
       <FrameworkReference Include="@(_FrameworkReferenceToAdd)" />
-    </ItemGroup>
-      
-    <ItemGroup>
-      <!-- The KnownFrameworkReference items that this target expects will be defined in the bundled
-           versions .props file. They should look something like this:
-           
-    <KnownFrameworkReference Include="Microsoft.NETCore.App"
-                              TargetFramework="netcoreapp3.0"
-                              RuntimeFrameworkName="Microsoft.NETCore.App"
-                              DefaultRuntimeFrameworkVersion="3.0.0-preview-27214-02"
-                              LatestRuntimeFrameworkVersion="3.0.0-preview-27214-02"
-                              TargetingPackName="Microsoft.NETCore.App"
-                              TargetingPackVersion="3.0.0-preview-27122-01"
-                              AppHostPackNamePattern="runtime.**RID**.Microsoft.NETCore.DotNetAppHost"
-                              AppHostRuntimeIdentifiers="freebsd-x64;linux-arm;linux-arm64;linux-musl-x64;linux-x64;osx-x64;rhel.6-x64;tizen.4.0.0-armel;tizen.5.0.0-armel;win-arm;win-arm64;win-x64;win-x86"
-                              RuntimePackNamePatterns="runtime.**RID**.Microsoft.NETCore.App;runtime.**RID**.Microsoft.NETCore.DotNetHostResolver;runtime.**RID**.Microsoft.NETCore.DotNetHostPolicy"
-                              RuntimePackRuntimeIdentifiers="freebsd-x64;linux-arm;linux-arm64;linux-musl-x64;linux-x64;osx-x64;rhel.6-x64;tizen.4.0.0-armel;tizen.5.0.0-armel;win-arm;win-arm64;win-x64;win-x86"
-                              IsTrimmable="true"
-                              />
-      -->
-
-
-      <!-- KnownAppHost items will look something like this:
-      
-      <KnownAppHostPack Condition="'@(KnownAppHostPack)' == ''"
-                        Include="Microsoft.NETCore.App"
-                        TargetFramework="netcoreapp3.0"
-                        AppHostPackNamePattern="runtime.**RID**.Microsoft.NETCore.DotNetAppHost"
-                        AppHostPackVersion="3.0.0-preview-27218-01"
-                        AppHostRuntimeIdentifiers="freebsd-x64;linux-arm;linux-arm64;linux-musl-x64;linux-x64;osx-x64;rhel.6-x64;tizen.4.0.0-armel;tizen.5.0.0-armel;win-arm;win-arm64;win-x64;win-x86"
-                        />
-      -->
-
     </ItemGroup>
 
     <!-- We will add Microsoft.WindowsDesktop.App.WPF and Microsoft.WindowsDesktop.App.WindowsForms to the bundled versions.

--- a/src/Tests/Microsoft.NET.Build.Tests/AspNetCoreOnFullFramework.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/AspNetCoreOnFullFramework.cs
@@ -70,6 +70,7 @@ class Class1
             {
                 Name = "ReferencedProjectWithMVC",
                 IsSdkProject = true,
+                ProjectSdk = "Microsoft.NET.Sdk.Web",
                 TargetFrameworks = "net461",
                 IsExe = false
             };
@@ -79,14 +80,9 @@ class Class1
             testProject.ReferencedProjects.Add(referencedProjectWithPart);
             testProject.ReferencedProjects.Add(referencedProjectWithMvc);
 
-            var testProjectInstance = _testAssetsManager.CreateTestProject(testProject, identifier: aspnetVersion)
-                                    .WithProjectChanges((filename, project) =>
-                                    {
-                                        var ns = project.Root.Name.Namespace;
-
-                                        project.Root.Attribute("Sdk").Value = "Microsoft.NET.Sdk.Web";
-                                    })
-                                    .Restore(Log, testProject.Name);
+            var testProjectInstance = _testAssetsManager
+                .CreateTestProject(testProject, identifier: aspnetVersion)
+                .Restore(Log, testProject.Name);
 
             var buildCommand = new BuildCommand(Log, testProjectInstance.TestRoot, testProject.Name);
 

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenFrameworkReferences.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenFrameworkReferences.cs
@@ -192,7 +192,7 @@ namespace FrameworkReferenceTest
                 .HaveStdOutContaining("NETSDK1073");
         }
 
-        [CoreMSBuildOnlyFact]
+        [CoreMSBuildAndWindowsOnlyFact]
         public void BuildFailsIfRuntimePackIsNotAvailableForRuntimeIdentifier()
         {
             var testProject = new TestProject()

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenWeWantToRequireWindowsForDesktopApps.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenWeWantToRequireWindowsForDesktopApps.cs
@@ -96,6 +96,33 @@ namespace Microsoft.NET.Build.Tests
                 .HaveStdOutContaining(Strings.WindowsDesktopFrameworkRequiresWindows);
         }
 
+
+        [PlatformSpecificFact(Platform.Linux, Platform.Darwin, Platform.FreeBSD)]
+        public void It_does_not_download_desktop_targeting_packs_on_unix()
+        {
+            const string ProjectName = "NoDownloadTest";
+
+            var testProject = new TestProject()
+            {
+                Name = ProjectName,
+                TargetFrameworks = "netcoreapp3.0",
+                IsSdkProject = true,
+            };
+
+            testProject.AdditionalProperties["RestorePackagesPath"] = @"$(MSBuildProjectDirectory)\packages";
+
+            var asset = _testAssetsManager.CreateTestProject(testProject);
+
+            var command = new BuildCommand(Log, Path.Combine(asset.Path, ProjectName));
+
+            command
+                .Execute("/restore")
+                .Should()
+                .Pass();
+
+            Directory.Exists(Path.Combine(asset.Path, "packages")).Should().BeFalse();
+        }
+
         private TestAsset CreateWindowsDesktopSdkTestAsset(string projectName, string uiFrameworkProperty)
         {
             const string tfm = "netcoreapp3.0";

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenWeWantToRequireWindowsForDesktopApps.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenWeWantToRequireWindowsForDesktopApps.cs
@@ -1,0 +1,134 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using System.Xml.Linq;
+using Microsoft.DotNet.PlatformAbstractions;
+using Microsoft.NET.Build.Tasks;
+using Microsoft.NET.TestFramework;
+using Microsoft.NET.TestFramework.Assertions;
+using Microsoft.NET.TestFramework.Commands;
+using Microsoft.NET.TestFramework.ProjectConstruction;
+using FluentAssertions;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.NET.Build.Tests
+{
+    public class GivenWeWantToRequireWindowsForDesktopApps : SdkTest
+    {
+        public GivenWeWantToRequireWindowsForDesktopApps(ITestOutputHelper log) : base(log)
+        {
+        }
+
+        [WindowsOnlyTheory]
+        [InlineData("UseWPF")]
+        [InlineData("UseWindowsForms")]
+        public void It_builds_on_windows_with_the_windows_desktop_sdk(string uiFrameworkProperty)
+        {
+            const string ProjectName = "WindowsDesktopSdkTest";
+
+            var asset = CreateWindowsDesktopSdkTestAsset(ProjectName, uiFrameworkProperty);
+
+            var command = new BuildCommand(Log, Path.Combine(asset.Path, ProjectName));
+
+            command
+                .Execute("/restore")
+                .Should()
+                .Pass();
+        }
+
+        [PlatformSpecificTheory(Platform.Linux, Platform.Darwin, Platform.FreeBSD)]
+        [InlineData("UseWPF")]
+        [InlineData("UseWindowsForms")]
+        public void It_errors_on_nonwindows_with_the_windows_desktop_sdk(string uiFrameworkProperty)
+        {
+            const string ProjectName = "WindowsDesktopSdkErrorTest";
+
+            var asset = CreateWindowsDesktopSdkTestAsset(ProjectName, uiFrameworkProperty);
+
+            var command = new BuildCommand(Log, Path.Combine(asset.Path, ProjectName));
+
+            command
+                .Execute("/restore")
+                .Should()
+                .Fail()
+                .And
+                .HaveStdOutContaining(Strings.WindowsDesktopFrameworkRequiresWindows);
+        }
+
+        [WindowsOnlyTheory]
+        [InlineData("Microsoft.WindowsDesktop.App")]
+        [InlineData("Microsoft.WindowsDesktop.App.WindowsForms")]
+        [InlineData("Microsoft.WindowsDesktop.App.WPF")]
+        public void It_builds_on_windows_with_a_framework_reference(string desktopFramework)
+        {
+            const string ProjectName = "WindowsDesktopReferenceTest";
+
+            var asset = CreateWindowsDesktopReferenceTestAsset(ProjectName, desktopFramework);
+
+            var command = new BuildCommand(Log, Path.Combine(asset.Path, ProjectName));
+
+            command
+                .Execute("/restore")
+                .Should()
+                .Pass();
+        }
+
+        [PlatformSpecificTheory(Platform.Linux, Platform.Darwin, Platform.FreeBSD)]
+        [InlineData("Microsoft.WindowsDesktop.App")]
+        [InlineData("Microsoft.WindowsDesktop.App.WindowsForms")]
+        [InlineData("Microsoft.WindowsDesktop.App.WPF")]
+        public void It_errors_on_nonwindows_with_a_framework_reference(string desktopFramework)
+        {
+            const string ProjectName = "WindowsDesktopReferenceErrorTest";
+
+            var asset = CreateWindowsDesktopReferenceTestAsset(ProjectName, desktopFramework);
+
+            var command = new BuildCommand(Log, Path.Combine(asset.Path, ProjectName));
+
+            command
+                .Execute("/restore")
+                .Should()
+                .Fail()
+                .And
+                .HaveStdOutContaining(Strings.WindowsDesktopFrameworkRequiresWindows);
+        }
+
+        private TestAsset CreateWindowsDesktopSdkTestAsset(string projectName, string uiFrameworkProperty)
+        {
+            const string tfm = "netcoreapp3.0";
+
+            var testProject = new TestProject()
+            {
+                Name = projectName,
+                TargetFrameworks = tfm,
+                IsSdkProject = true,
+                ProjectSdk = "Microsoft.NET.Sdk.WindowsDesktop",
+                IsWinExe = true,
+            };
+
+            testProject.AdditionalProperties.Add(uiFrameworkProperty, "true");
+
+            return _testAssetsManager.CreateTestProject(testProject);
+        }
+
+        private TestAsset CreateWindowsDesktopReferenceTestAsset(string projectName, string desktopFramework)
+        {
+            const string tfm = "netcoreapp3.0";
+
+            var testProject = new TestProject()
+            {
+                Name = projectName,
+                TargetFrameworks = tfm,
+                IsSdkProject = true,
+                IsWinExe = true,
+            };
+
+            testProject.FrameworkReferences.Add(desktopFramework);
+
+            return _testAssetsManager.CreateTestProject(testProject);
+        }
+    }
+}

--- a/src/Tests/Microsoft.NET.Build.Tests/ImplicitAspNetVersions.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/ImplicitAspNetVersions.cs
@@ -204,21 +204,15 @@ namespace Microsoft.NET.Build.Tests
                 Name = "AspNetCoreAll_On3_0",
                 TargetFrameworks = "netcoreapp3.0",
                 IsSdkProject = true,
+                ProjectSdk = useWebSdk ? "Microsoft.NET.Sdk.Web" : null,
                 IsExe = true
             };
 
             //  Add PackageReference
             testProject.PackageReferences.Add(new TestPackageReference("Microsoft.AspNetCore.All", packageVersion));
 
-            var testAsset = _testAssetsManager.CreateTestProject(testProject, identifier: $"{useWebSdk}_{packageVersion}")
-                .WithProjectChanges(project =>
-                {
-                    var ns = project.Root.Name.Namespace;
-                    if (useWebSdk)
-                    {
-                        project.Root.Attribute("Sdk").Value = "Microsoft.NET.Sdk.Web";
-                    }
-                });
+            var testAsset = _testAssetsManager.CreateTestProject(testProject, identifier: $"{useWebSdk}_{packageVersion}");
+
             var restoreCommand = new RestoreCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
             restoreCommand.Execute()
                 .Should()
@@ -246,21 +240,15 @@ namespace Microsoft.NET.Build.Tests
                 Name = "AspNetCoreApp_On3_0",
                 TargetFrameworks = "netcoreapp3.0",
                 IsSdkProject = true,
+                ProjectSdk = useWebSdk ? "Microsoft.NET.Sdk.Web" : null,
                 IsExe = true
             };
 
             //  Add PackageReference
             testProject.PackageReferences.Add(new TestPackageReference("Microsoft.AspNetCore.App", packageVersion));
 
-            var testAsset = _testAssetsManager.CreateTestProject(testProject, identifier: $"{useWebSdk}_{packageVersion}")
-                .WithProjectChanges(project =>
-                {
-                    var ns = project.Root.Name.Namespace;
-                    if (useWebSdk)
-                    {
-                        project.Root.Attribute("Sdk").Value = "Microsoft.NET.Sdk.Web";
-                    }
-                });
+            var testAsset = _testAssetsManager.CreateTestProject(testProject, identifier: $"{useWebSdk}_{packageVersion}");
+
             var restoreCommand = new RestoreCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
             restoreCommand.Execute()
                 .Should()

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAHelloWorldProject.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAHelloWorldProject.cs
@@ -569,15 +569,11 @@ public static class Program
                 Name = "ConsoleWithPublishProfile",
                 TargetFrameworks = tfm,
                 IsSdkProject = true,
+                ProjectSdk = "Microsoft.NET.Sdk;Microsoft.NET.Sdk.Publish",
                 IsExe = true,
             };
 
-            var testProjectInstance = _testAssetsManager.CreateTestProject(testProject)
-                .WithProjectChanges(
-                    (filename, project) =>
-                    {
-                        project.Root.Attribute("Sdk").Value = "Microsoft.NET.Sdk;Microsoft.NET.Sdk.Publish";
-                    });
+            var testProjectInstance = _testAssetsManager.CreateTestProject(testProject);
 
             var projectDirectory = Path.Combine(testProjectInstance.Path, testProject.Name);
             var publishProfilesDirectory = Path.Combine(projectDirectory, "Properties", "PublishProfiles");

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishASelfContainedApp.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishASelfContainedApp.cs
@@ -164,17 +164,13 @@ namespace Microsoft.NET.Publish.Tests
                 Name = "WpfProjectAllResources",
                 TargetFrameworks = tfm,
                 IsSdkProject = true,
+                ProjectSdk = "Microsoft.NET.Sdk.WindowsDesktop",
                 IsWinExe = true,
             };
 
             testProject.AdditionalProperties.Add("UseWPF", "true");
 
-            var testProjectInstance = _testAssetsManager.CreateTestProject(testProject)
-                .WithProjectChanges(
-                    (filename, project) =>
-                    {
-                        project.Root.Attribute("Sdk").Value = "Microsoft.NET.Sdk.WindowsDesktop";
-                    });
+            var testProjectInstance = _testAssetsManager.CreateTestProject(testProject);
 
             var rid = EnvironmentInfo.GetCompatibleRid(tfm);
             var command = new PublishCommand(Log, Path.Combine(testProjectInstance.Path, testProject.Name));
@@ -213,18 +209,14 @@ namespace Microsoft.NET.Publish.Tests
                 Name = "WpfProjectSelectResources",
                 TargetFrameworks = tfm,
                 IsSdkProject = true,
+                ProjectSdk = "Microsoft.NET.Sdk.WindowsDesktop",
                 IsWinExe = true,
             };
 
             testProject.AdditionalProperties.Add("UseWPF", "true");
             testProject.AdditionalProperties.Add("SatelliteResourceLanguages", "cs;zh-Hant;ko");
 
-            var testProjectInstance = _testAssetsManager.CreateTestProject(testProject)
-                .WithProjectChanges(
-                    (filename, project) =>
-                    {
-                        project.Root.Attribute("Sdk").Value = "Microsoft.NET.Sdk.WindowsDesktop";
-                    });
+            var testProjectInstance = _testAssetsManager.CreateTestProject(testProject);
 
             var rid = EnvironmentInfo.GetCompatibleRid(tfm);
             var command = new PublishCommand(Log, Path.Combine(testProjectInstance.Path, testProject.Name));

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAWebApp.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAWebApp.cs
@@ -70,6 +70,7 @@ namespace Microsoft.NET.Publish.Tests
                 Name = "WebTest",
                 TargetFrameworks = tfm,
                 IsSdkProject = true,
+                ProjectSdk = "Microsoft.NET.Sdk.Web",
                 IsExe = true,
             };
 
@@ -77,12 +78,7 @@ namespace Microsoft.NET.Publish.Tests
             testProject.PackageReferences.Add(new TestPackageReference("Microsoft.AspNetCore.App"));
             testProject.PackageReferences.Add(new TestPackageReference("Microsoft.AspNetCore.Razor.Design", version: "2.2.0", privateAssets: "all"));
 
-            var testProjectInstance = _testAssetsManager.CreateTestProject(testProject)
-                .WithProjectChanges(
-                    (filename, project) =>
-                    {
-                        project.Root.Attribute("Sdk").Value = "Microsoft.NET.Sdk.Web";
-                    });
+            var testProjectInstance = _testAssetsManager.CreateTestProject(testProject);
 
             var command = new PublishCommand(Log, Path.Combine(testProjectInstance.Path, testProject.Name));
 
@@ -133,6 +129,7 @@ namespace Microsoft.NET.Publish.Tests
                 Name = "WebTest",
                 TargetFrameworks = tfm,
                 IsSdkProject = true,
+                ProjectSdk = "Microsoft.NET.Sdk.Web",
                 IsExe = true,
             };
 
@@ -140,12 +137,7 @@ namespace Microsoft.NET.Publish.Tests
             testProject.PackageReferences.Add(new TestPackageReference(platformLibrary));
             testProject.PackageReferences.Add(new TestPackageReference("Microsoft.AspNetCore.Razor.Design", version: "2.2.0", privateAssets: "all"));
 
-            var testProjectInstance = _testAssetsManager.CreateTestProject(testProject)
-                .WithProjectChanges(
-                    (filename, project) =>
-                    {
-                        project.Root.Attribute("Sdk").Value = "Microsoft.NET.Sdk.Web";
-                    });
+            var testProjectInstance = _testAssetsManager.CreateTestProject(testProject);
 
             var command = new PublishCommand(Log, Path.Combine(testProjectInstance.Path, testProject.Name));
 
@@ -189,6 +181,7 @@ namespace Microsoft.NET.Publish.Tests
                 Name = "WebWithPublishProfile",
                 TargetFrameworks = tfm,
                 IsSdkProject = true,
+                ProjectSdk = "Microsoft.NET.Sdk.Web",
                 IsExe = true,
             };
 
@@ -196,12 +189,7 @@ namespace Microsoft.NET.Publish.Tests
             testProject.PackageReferences.Add(new TestPackageReference("Microsoft.AspNetCore.App"));
             testProject.PackageReferences.Add(new TestPackageReference("Microsoft.AspNetCore.Razor.Design", version: "2.2.0", privateAssets: "all"));
 
-            var testProjectInstance = _testAssetsManager.CreateTestProject(testProject)
-                .WithProjectChanges(
-                    (filename, project) =>
-                    {
-                        project.Root.Attribute("Sdk").Value = "Microsoft.NET.Sdk.Web";
-                    });
+            var testProjectInstance = _testAssetsManager.CreateTestProject(testProject);
 
             var projectDirectory = Path.Combine(testProjectInstance.Path, testProject.Name);
             var publishProfilesDirectory = Path.Combine(projectDirectory, "Properties", "PublishProfiles");

--- a/src/Tests/Microsoft.NET.TestFramework/ProjectConstruction/TestProject.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/ProjectConstruction/TestProject.cs
@@ -19,6 +19,8 @@ namespace Microsoft.NET.TestFramework.ProjectConstruction
 
         public bool IsWinExe { get; set; }
 
+        public string ProjectSdk { get; set; }
+
         //  Applies to SDK Projects
         public string TargetFrameworks { get; set; }
 
@@ -135,6 +137,11 @@ namespace Microsoft.NET.TestFramework.ProjectConstruction
             var projectXml = XDocument.Load(sourceProject);
 
             var ns = projectXml.Root.Name.Namespace;
+
+            if (ProjectSdk != null)
+            {
+                projectXml.Root.Attribute("Sdk").Value = ProjectSdk;
+            }
 
             var propertyGroup = projectXml.Root.Elements(ns + "PropertyGroup").First();
 


### PR DESCRIPTION
This PR causes the SDK to log an error (NETSDK1100) if the user attempts to
build a Windows Desktop targeted application on a non-Windows platform.

This works via any explicit or implicit (i.e. from the SDK) framework reference
to `Microsoft.WindowsDesktop.App*`; if the current platform is not Windows and
the framework reference exists, the error is logged.

Fixes dotnet/cli#11410 and dotnet/cli#10842.