### PR TITLE
Fix filtering of satellite assemblies when publishing for netcoreapp3.0.

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -522,7 +522,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       <Output TaskParameter="JoinResult" ItemName="_FilteredPublishSatelliteResources" />
     </JoinItems>
 
-    <ItemGroup Condition="'@(_OutputSatelliteResources)' != ''">
+    <ItemGroup Condition="'@(_PublishSatelliteResources)' != ''">
       <_ResolvedCopyLocalPublishAssets Remove="@(_PublishSatelliteResources)" />
       <_ResolvedCopyLocalPublishAssets Include="@(_FilteredPublishSatelliteResources)" />
     </ItemGroup>

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToFilterSatelliteAssemblies.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToFilterSatelliteAssemblies.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Runtime.InteropServices;
 using System.Text;
 using FluentAssertions;
+using Microsoft.DotNet.Cli.Utils;
 using Microsoft.NET.TestFramework;
 using Microsoft.NET.TestFramework.Assertions;
 using Microsoft.NET.TestFramework.Commands;
@@ -21,6 +22,7 @@ namespace Microsoft.NET.Build.Tests
 
         [Theory]
         [InlineData("netcoreapp2.0", true, false)]
+        [InlineData("netcoreapp3.0", false, false)]
         [InlineData("net47", false, true)]
         public void It_only_publish_selected_ResourceLanguages(string targetFramework, bool explicitCopyLocalLockFile,
             bool needsNetFrameworkReferenceAssemblies)
@@ -73,6 +75,11 @@ namespace Microsoft.NET.Build.Tests
                     $"{testProject.Name}.runtimeconfig.json",
                     $"{testProject.Name}.runtimeconfig.dev.json"
                 });
+
+                if (testProject.TargetFrameworks == "netcoreapp3.0")
+                {
+                    expectedFiles.Add($"{testProject.Name}{Constants.ExeSuffix}");
+                }
             }
             else
             {

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToFilterSatelliteAssemblies.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToFilterSatelliteAssemblies.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Generic;
 using System.IO;
 using System.Runtime.InteropServices;
 using Microsoft.DotNet.Cli.Utils;
@@ -21,13 +22,16 @@ namespace Microsoft.NET.Publish.Tests
         {
         }
 
-        [Fact]
-        public void It_only_publishes_selected_ResourceLanguages()
+        [Theory]
+        [InlineData("netcoreapp2.0")]
+        [InlineData("netcoreapp3.0")]
+
+        public void It_only_publishes_selected_ResourceLanguages(string tfm)
         {
             var testProject = new TestProject()
             {
                 Name = "PublishFilteredSatelliteAssemblies",
-                TargetFrameworks = "netcoreapp2.0",
+                TargetFrameworks = tfm,
                 IsExe = true,
                 IsSdkProject = true
             };
@@ -45,7 +49,7 @@ namespace Microsoft.NET.Publish.Tests
 
             var publishDirectory = publishCommand.GetOutputDirectory(targetFramework: testProject.TargetFrameworks);
 
-            publishDirectory.Should().OnlyHaveFiles(new[] {
+            var files = new List<string>() {
                 "it/System.Spatial.resources.dll",
                 "fr/System.Spatial.resources.dll",
                 "System.Spatial.dll",
@@ -53,7 +57,14 @@ namespace Microsoft.NET.Publish.Tests
                 $"{testProject.Name}.pdb",
                 $"{testProject.Name}.deps.json",
                 $"{testProject.Name}.runtimeconfig.json"
-            });
+            };
+
+            if (tfm == "netcoreapp3.0")
+            {
+                files.Add($"{testProject.Name}{Constants.ExeSuffix}");
+            }
+
+            publishDirectory.Should().OnlyHaveFiles(files);
         }
         [Fact]
         public void It_publishes_all_satellites_when_not_filtered()


### PR DESCRIPTION
This PR fixes filtering of satellite assemblies when publishing an
application targeting netcoreapp3.0.

An incorrect property name in the `_FilterSatelliteResourcesForPublish` target
was causing the satellite filtering done for publish to have no effect.

This was only a problem when not reusing the build output for publish;
unfortunately this is currently the case for netcoreapp3.0 targeted
applications due to references that are marked as `PrivateAssets="all"`.

This PR fixes the property name and adds test coverage for publishing
when targeting netcoreapp3.0 with filtered satellite assemblies.

Fixes #3277.