### PR TITLE
Fix failure to read assets cache file the first time it's written

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageAssets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageAssets.cs
@@ -674,8 +674,10 @@ namespace Microsoft.NET.Build.Tasks
             {
                 Directory.CreateDirectory(Path.GetDirectoryName(_task.ProjectAssetsCacheFile));
                 var stream = File.Open(_task.ProjectAssetsCacheFile, FileMode.Create, FileAccess.ReadWrite, FileShare.None);
-                _writer = new BinaryWriter(stream, TextEncoding, leaveOpen: false);
-                Write();
+                using (_writer = new BinaryWriter(stream, TextEncoding, leaveOpen: false))
+                {
+                    Write();
+                }
             }
 
             public Stream WriteToMemoryStream()

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatAProjectHasntBeenRestored.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatAProjectHasntBeenRestored.cs
@@ -7,6 +7,7 @@ using Microsoft.NET.Build.Tasks;
 using Microsoft.NET.TestFramework;
 using Microsoft.NET.TestFramework.Assertions;
 using Microsoft.NET.TestFramework.Commands;
+using Microsoft.NET.TestFramework.ProjectConstruction;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -49,6 +50,31 @@ namespace Microsoft.NET.Build.Tests
                 .And.HaveStdOutContaining(assetsFile)
                 //  We should only get one error
                 .And.HaveStdOutContaining("1 Error(s)");
+        }
+
+        [Fact]
+        public void ReadingCacheDoesNotFail()
+        {
+            var testProject = new TestProject()
+            {
+                Name = "App",
+                TargetFrameworks = "netcoreapp3.0",
+                IsSdkProject = true,
+                IsExe = true
+            };
+
+            var testAsset = _testAssetsManager.CreateTestProject(testProject);
+
+            var buildCommand = new BuildCommand(Log, testAsset.TestRoot, testProject.Name);
+
+            var result = buildCommand
+                .Execute("/restore");
+
+            result
+                .Should()
+                .Pass()
+                .And
+                .NotHaveStdOutContaining("NETSDK1062");
         }
     }
 }


### PR DESCRIPTION
Fixes issue reported by @nguerrera, introduced in #3268:

> Seeing message NETSDK1062: Unable to use package assets cache due to I/O error. This can occur when the same project is built more than once in parallel. Performance may be degraded, but the build result will not be impacted. [D:\Temp\demo\demo.csproj]
>
> Looks like the change you made has the file still open for write when we try to read it back on first build.
>
> Can you take a look, this will be a significant perf regression in preview 6

Fix #3287