### PR TITLE
Adding ResolveReferences target to PublishItemsOutputGroup dependencies

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -894,6 +894,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <PropertyGroup>
     <PublishItemsOutputGroupDependsOn>
       $(PublishItemsOutputGroupDependsOn);
+      ResolveReferences;
       ComputeFilesToPublish;
     </PublishItemsOutputGroupDependsOn>
   </PropertyGroup>


### PR DESCRIPTION
This is needed in order for this output group to contain output from referenced projects.