### PR TITLE
Add support for RollForward property

### DIFF
--- a/src/Tasks/Common/Resources/Strings.resx
+++ b/src/Tasks/Common/Resources/Strings.resx
@@ -528,6 +528,14 @@ The following are names of parameters or literal values and should not be transl
   </data>
   <data name="ILLinkNotSupportedError" xml:space="preserve">
     <value>NETSDK1102: Optimizing assemblies for size is not supported for the selected publish configuration. Please ensure that you are publishing a self-contained app.</value>
-    <comment>{StrBegin="NETSDK1102: "}</comment>"
+    <comment>{StrBegin="NETSDK1102: "}</comment>
+  </data>
+  <data name="RollForwardRequiresVersion30" xml:space="preserve">
+    <value>NETSDK1103: RollForward setting is only supported on .NET Core 3.0 or higher.</value>
+    <comment>{StrBegin="NETSDK1103: "}</comment>
+  </data>
+  <data name="InvalidRollForwardValue" xml:space="preserve">
+    <value>NETSDK1104: RollForward value '{0}' is invalid. Allowed values are {1}.</value>
+    <comment>{StrBegin="NETSDK1104: "}</comment>
   </data>
 </root>

--- a/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
@@ -333,6 +333,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1075: Popisovač aktualizace není platný. Tuto instanci nejde použít pro další aktualizace.</target>
         <note>{StrBegin="NETSDK1075: "}</note>
       </trans-unit>
+      <trans-unit id="InvalidRollForwardValue">
+        <source>NETSDK1104: RollForward value '{0}' is invalid. Allowed values are {1}.</source>
+        <target state="new">NETSDK1104: RollForward value '{0}' is invalid. Allowed values are {1}.</target>
+        <note>{StrBegin="NETSDK1104: "}</note>
+      </trans-unit>
       <trans-unit id="MismatchedPlatformPackageVersion">
         <source>NETSDK1061: The project was restored using {0} version {1}, but with current settings, version {2} would be used instead. To resolve this issue, make sure the same settings are used for restore and for subsequent operations such as build or publish. Typically this issue can occur if the RuntimeIdentifier property is set during build or publish but not during restore. For more information, see https://aka.ms/dotnet-runtime-patch-selection.</source>
         <target state="translated">NETSDK1061: Projekt byl obnoven pomocí aplikace {0} verze {1}, ale s aktuálním nastavením by se místo toho použít verze {2}. Tento problém vyřešíte tak, že zkontrolujete, že se pro obnovení a následné operace, například sestavení nebo publikování, používá stejné nastavení. Obvykle k tomuto problému může dojít, pokud je vlastnost RuntimeIdentifier nastavena při sestavování nebo  publikování, ale ne při obnovování. Další informace najdete na stránce https://aka.ms/dotnet-runtime-patch-selection.</target>
@@ -435,6 +440,11 @@ The following are names of parameters or literal values and should not be transl
         <source>NETSDK1095: Optimizing assemblies for performance is not supported for the selected target platform or architecture. Please verify you are publishing a self-contained application using a supported runtime identifier, or set the PublishReadyToRun property to false.</source>
         <target state="new">NETSDK1095: Optimizing assemblies for performance is not supported for the selected target platform or architecture. Please verify you are publishing a self-contained application using a supported runtime identifier, or set the PublishReadyToRun property to false.</target>
         <note>{StrBegin="NETSDK1095: "}</note>
+      </trans-unit>
+      <trans-unit id="RollForwardRequiresVersion30">
+        <source>NETSDK1103: RollForward setting is only supported on .NET Core 3.0 or higher.</source>
+        <target state="new">NETSDK1103: RollForward setting is only supported on .NET Core 3.0 or higher.</target>
+        <note>{StrBegin="NETSDK1103: "}</note>
       </trans-unit>
       <trans-unit id="RuntimeIdentifierNotRecognized">
         <source>NETSDK1083: The specified RuntimeIdentifier '{0}' is not recognized.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.de.xlf
@@ -333,6 +333,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1075: Das Updatehandle ist ungültig. Diese Instanz kann nicht für weitere Updates verwendet werden.</target>
         <note>{StrBegin="NETSDK1075: "}</note>
       </trans-unit>
+      <trans-unit id="InvalidRollForwardValue">
+        <source>NETSDK1104: RollForward value '{0}' is invalid. Allowed values are {1}.</source>
+        <target state="new">NETSDK1104: RollForward value '{0}' is invalid. Allowed values are {1}.</target>
+        <note>{StrBegin="NETSDK1104: "}</note>
+      </trans-unit>
       <trans-unit id="MismatchedPlatformPackageVersion">
         <source>NETSDK1061: The project was restored using {0} version {1}, but with current settings, version {2} would be used instead. To resolve this issue, make sure the same settings are used for restore and for subsequent operations such as build or publish. Typically this issue can occur if the RuntimeIdentifier property is set during build or publish but not during restore. For more information, see https://aka.ms/dotnet-runtime-patch-selection.</source>
         <target state="translated">NETSDK1061: Das Projekt wurde mit {0}, Version {1} wiederhergestellt, aber mit den aktuellen Einstellungen würde stattdessen Version {2} verwendet werden. Um dieses Problem zu beheben, müssen Sie sicherstellen, dass für die Wiederherstellung und für nachfolgende Vorgänge wie das Kompilieren oder Veröffentlichen dieselben Einstellungen verwendet werden. Dieses Problem tritt typischerweise auf, wenn die RuntimeIdentifier-Eigenschaft bei der Kompilierung oder Veröffentlichung, aber nicht bei der Wiederherstellung festgelegt wird. Weitere Informationen finden Sie unter https://aka.ms/dotnet-runtime-patch-selection.</target>
@@ -435,6 +440,11 @@ The following are names of parameters or literal values and should not be transl
         <source>NETSDK1095: Optimizing assemblies for performance is not supported for the selected target platform or architecture. Please verify you are publishing a self-contained application using a supported runtime identifier, or set the PublishReadyToRun property to false.</source>
         <target state="new">NETSDK1095: Optimizing assemblies for performance is not supported for the selected target platform or architecture. Please verify you are publishing a self-contained application using a supported runtime identifier, or set the PublishReadyToRun property to false.</target>
         <note>{StrBegin="NETSDK1095: "}</note>
+      </trans-unit>
+      <trans-unit id="RollForwardRequiresVersion30">
+        <source>NETSDK1103: RollForward setting is only supported on .NET Core 3.0 or higher.</source>
+        <target state="new">NETSDK1103: RollForward setting is only supported on .NET Core 3.0 or higher.</target>
+        <note>{StrBegin="NETSDK1103: "}</note>
       </trans-unit>
       <trans-unit id="RuntimeIdentifierNotRecognized">
         <source>NETSDK1083: The specified RuntimeIdentifier '{0}' is not recognized.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.es.xlf
@@ -333,6 +333,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1075: El identificador de actualización no es válido. Esta instancia no se puede utilizar para otras actualizaciones.</target>
         <note>{StrBegin="NETSDK1075: "}</note>
       </trans-unit>
+      <trans-unit id="InvalidRollForwardValue">
+        <source>NETSDK1104: RollForward value '{0}' is invalid. Allowed values are {1}.</source>
+        <target state="new">NETSDK1104: RollForward value '{0}' is invalid. Allowed values are {1}.</target>
+        <note>{StrBegin="NETSDK1104: "}</note>
+      </trans-unit>
       <trans-unit id="MismatchedPlatformPackageVersion">
         <source>NETSDK1061: The project was restored using {0} version {1}, but with current settings, version {2} would be used instead. To resolve this issue, make sure the same settings are used for restore and for subsequent operations such as build or publish. Typically this issue can occur if the RuntimeIdentifier property is set during build or publish but not during restore. For more information, see https://aka.ms/dotnet-runtime-patch-selection.</source>
         <target state="translated">NETSDK1061: El proyecto fue restaurado utilizando la versión {0} {1}, pero con la configuración actual, la versión {2} se utilizaría en su lugar. Para resolver este problema, asegúrese de que la misma configuración se utiliza para restaurar y para operaciones posteriores como compilar o publicar. Normalmente, este problema puede producirse si la `propiedad RuntimeIdentifier se establece durante la compilación o la publicación pero no durante la restauración. Para obtener más información, consulte https://aka.ms/dotnet-runtime-patch-selection.</target>
@@ -435,6 +440,11 @@ The following are names of parameters or literal values and should not be transl
         <source>NETSDK1095: Optimizing assemblies for performance is not supported for the selected target platform or architecture. Please verify you are publishing a self-contained application using a supported runtime identifier, or set the PublishReadyToRun property to false.</source>
         <target state="new">NETSDK1095: Optimizing assemblies for performance is not supported for the selected target platform or architecture. Please verify you are publishing a self-contained application using a supported runtime identifier, or set the PublishReadyToRun property to false.</target>
         <note>{StrBegin="NETSDK1095: "}</note>
+      </trans-unit>
+      <trans-unit id="RollForwardRequiresVersion30">
+        <source>NETSDK1103: RollForward setting is only supported on .NET Core 3.0 or higher.</source>
+        <target state="new">NETSDK1103: RollForward setting is only supported on .NET Core 3.0 or higher.</target>
+        <note>{StrBegin="NETSDK1103: "}</note>
       </trans-unit>
       <trans-unit id="RuntimeIdentifierNotRecognized">
         <source>NETSDK1083: The specified RuntimeIdentifier '{0}' is not recognized.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
@@ -333,6 +333,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1075 : Le handle de mise à jour n'est pas valide. Cette instance ne peut pas être utilisée pour d'autres mises à jour.</target>
         <note>{StrBegin="NETSDK1075: "}</note>
       </trans-unit>
+      <trans-unit id="InvalidRollForwardValue">
+        <source>NETSDK1104: RollForward value '{0}' is invalid. Allowed values are {1}.</source>
+        <target state="new">NETSDK1104: RollForward value '{0}' is invalid. Allowed values are {1}.</target>
+        <note>{StrBegin="NETSDK1104: "}</note>
+      </trans-unit>
       <trans-unit id="MismatchedPlatformPackageVersion">
         <source>NETSDK1061: The project was restored using {0} version {1}, but with current settings, version {2} would be used instead. To resolve this issue, make sure the same settings are used for restore and for subsequent operations such as build or publish. Typically this issue can occur if the RuntimeIdentifier property is set during build or publish but not during restore. For more information, see https://aka.ms/dotnet-runtime-patch-selection.</source>
         <target state="translated">NETSDK1061 : Le projet a été restauré avec la version {0} {1}, mais avec les paramètres actuels, la version {2} serait utilisée à la place. Pour résoudre ce problème, assurez-vous que les mêmes paramètres sont utilisés pour la restauration et pour les opérations ultérieures telles que la génération et la publication. Généralement, ce problème peut se produire si la propriété RuntimeIdentifier est définie au cours de la génération ou de la publication, mais pas pendant la restauration. Pour plus d’informations, consultez https://aka.ms/dotnet-runtime-patch-selection.</target>
@@ -435,6 +440,11 @@ The following are names of parameters or literal values and should not be transl
         <source>NETSDK1095: Optimizing assemblies for performance is not supported for the selected target platform or architecture. Please verify you are publishing a self-contained application using a supported runtime identifier, or set the PublishReadyToRun property to false.</source>
         <target state="new">NETSDK1095: Optimizing assemblies for performance is not supported for the selected target platform or architecture. Please verify you are publishing a self-contained application using a supported runtime identifier, or set the PublishReadyToRun property to false.</target>
         <note>{StrBegin="NETSDK1095: "}</note>
+      </trans-unit>
+      <trans-unit id="RollForwardRequiresVersion30">
+        <source>NETSDK1103: RollForward setting is only supported on .NET Core 3.0 or higher.</source>
+        <target state="new">NETSDK1103: RollForward setting is only supported on .NET Core 3.0 or higher.</target>
+        <note>{StrBegin="NETSDK1103: "}</note>
       </trans-unit>
       <trans-unit id="RuntimeIdentifierNotRecognized">
         <source>NETSDK1083: The specified RuntimeIdentifier '{0}' is not recognized.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.it.xlf
@@ -333,6 +333,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1075: il punto di controllo dell'aggiornamento non è valido. Non è possibile usare questa istanza per ulteriori aggiornamenti.</target>
         <note>{StrBegin="NETSDK1075: "}</note>
       </trans-unit>
+      <trans-unit id="InvalidRollForwardValue">
+        <source>NETSDK1104: RollForward value '{0}' is invalid. Allowed values are {1}.</source>
+        <target state="new">NETSDK1104: RollForward value '{0}' is invalid. Allowed values are {1}.</target>
+        <note>{StrBegin="NETSDK1104: "}</note>
+      </trans-unit>
       <trans-unit id="MismatchedPlatformPackageVersion">
         <source>NETSDK1061: The project was restored using {0} version {1}, but with current settings, version {2} would be used instead. To resolve this issue, make sure the same settings are used for restore and for subsequent operations such as build or publish. Typically this issue can occur if the RuntimeIdentifier property is set during build or publish but not during restore. For more information, see https://aka.ms/dotnet-runtime-patch-selection.</source>
         <target state="translated">NETSDK1061: per il ripristino del progetto è stato usato {0} versione {1}, ma con le impostazioni correnti viene usata la versione {2}. Per risolvere il problema, assicurarsi di usare le stesse impostazioni per il ripristino e per le operazioni successive, quali compilazione o pubblicazione. In genere questo problema può verificarsi se la proprietà RuntimeIdentifier viene impostata durante la compilazione o la pubblicazione, ma non durante il ripristino. Per altre informazioni, vedere https://aka.ms/dotnet-runtime-patch-selection.</target>
@@ -435,6 +440,11 @@ The following are names of parameters or literal values and should not be transl
         <source>NETSDK1095: Optimizing assemblies for performance is not supported for the selected target platform or architecture. Please verify you are publishing a self-contained application using a supported runtime identifier, or set the PublishReadyToRun property to false.</source>
         <target state="new">NETSDK1095: Optimizing assemblies for performance is not supported for the selected target platform or architecture. Please verify you are publishing a self-contained application using a supported runtime identifier, or set the PublishReadyToRun property to false.</target>
         <note>{StrBegin="NETSDK1095: "}</note>
+      </trans-unit>
+      <trans-unit id="RollForwardRequiresVersion30">
+        <source>NETSDK1103: RollForward setting is only supported on .NET Core 3.0 or higher.</source>
+        <target state="new">NETSDK1103: RollForward setting is only supported on .NET Core 3.0 or higher.</target>
+        <note>{StrBegin="NETSDK1103: "}</note>
       </trans-unit>
       <trans-unit id="RuntimeIdentifierNotRecognized">
         <source>NETSDK1083: The specified RuntimeIdentifier '{0}' is not recognized.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
@@ -333,6 +333,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1075: 更新ハンドルが有効ではありません。このインスタンスは、以降の更新に使用できない可能性があります。</target>
         <note>{StrBegin="NETSDK1075: "}</note>
       </trans-unit>
+      <trans-unit id="InvalidRollForwardValue">
+        <source>NETSDK1104: RollForward value '{0}' is invalid. Allowed values are {1}.</source>
+        <target state="new">NETSDK1104: RollForward value '{0}' is invalid. Allowed values are {1}.</target>
+        <note>{StrBegin="NETSDK1104: "}</note>
+      </trans-unit>
       <trans-unit id="MismatchedPlatformPackageVersion">
         <source>NETSDK1061: The project was restored using {0} version {1}, but with current settings, version {2} would be used instead. To resolve this issue, make sure the same settings are used for restore and for subsequent operations such as build or publish. Typically this issue can occur if the RuntimeIdentifier property is set during build or publish but not during restore. For more information, see https://aka.ms/dotnet-runtime-patch-selection.</source>
         <target state="translated">NETSDK1061: プロジェクトは {0} バージョン {1} を使用して復元されましたが、現在の設定では、バージョン {2} が代わりに使用されます。この問題を解決するには、復元およびこれ以降の操作 (ビルドや発行など) で同じ設定を使用していることをご確認ください。通常この問題は、ビルドや発行の実行時に RuntimeIdentifier プロパティを設定したが、復元時には設定していない場合に発生することがあります。詳しくは、https://aka.ms/dotnet-runtime-patch-selection を参照してください。</target>
@@ -435,6 +440,11 @@ The following are names of parameters or literal values and should not be transl
         <source>NETSDK1095: Optimizing assemblies for performance is not supported for the selected target platform or architecture. Please verify you are publishing a self-contained application using a supported runtime identifier, or set the PublishReadyToRun property to false.</source>
         <target state="new">NETSDK1095: Optimizing assemblies for performance is not supported for the selected target platform or architecture. Please verify you are publishing a self-contained application using a supported runtime identifier, or set the PublishReadyToRun property to false.</target>
         <note>{StrBegin="NETSDK1095: "}</note>
+      </trans-unit>
+      <trans-unit id="RollForwardRequiresVersion30">
+        <source>NETSDK1103: RollForward setting is only supported on .NET Core 3.0 or higher.</source>
+        <target state="new">NETSDK1103: RollForward setting is only supported on .NET Core 3.0 or higher.</target>
+        <note>{StrBegin="NETSDK1103: "}</note>
       </trans-unit>
       <trans-unit id="RuntimeIdentifierNotRecognized">
         <source>NETSDK1083: The specified RuntimeIdentifier '{0}' is not recognized.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
@@ -333,6 +333,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1075: 업데이트 핸들이 잘못되었습니다. 이 인스턴스는 추가 업데이트에 사용할 수 없습니다.</target>
         <note>{StrBegin="NETSDK1075: "}</note>
       </trans-unit>
+      <trans-unit id="InvalidRollForwardValue">
+        <source>NETSDK1104: RollForward value '{0}' is invalid. Allowed values are {1}.</source>
+        <target state="new">NETSDK1104: RollForward value '{0}' is invalid. Allowed values are {1}.</target>
+        <note>{StrBegin="NETSDK1104: "}</note>
+      </trans-unit>
       <trans-unit id="MismatchedPlatformPackageVersion">
         <source>NETSDK1061: The project was restored using {0} version {1}, but with current settings, version {2} would be used instead. To resolve this issue, make sure the same settings are used for restore and for subsequent operations such as build or publish. Typically this issue can occur if the RuntimeIdentifier property is set during build or publish but not during restore. For more information, see https://aka.ms/dotnet-runtime-patch-selection.</source>
         <target state="translated">NETSDK1061: {0} 버전 {1}을(를) 사용하여 프로젝트가 복원되었지만, 현재 설정에서는 버전 {2}을(를) 대신 사용합니다. 이 문제를 해결하려면 복원 및 후속 작업(예: 빌드 또는 게시)에 동일한 설정을 사용해야 합니다. 일반적으로 이 문제는 RuntimeIdentifier 속성이 빌드 또는 게시 중에 설정되었지만, 복원 중에는 설정되지 않은 경우에 발생할 수 있습니다. 자세한 내용은 https://aka.ms/dotnet-runtime-patch-selection을 참조하세요.</target>
@@ -435,6 +440,11 @@ The following are names of parameters or literal values and should not be transl
         <source>NETSDK1095: Optimizing assemblies for performance is not supported for the selected target platform or architecture. Please verify you are publishing a self-contained application using a supported runtime identifier, or set the PublishReadyToRun property to false.</source>
         <target state="new">NETSDK1095: Optimizing assemblies for performance is not supported for the selected target platform or architecture. Please verify you are publishing a self-contained application using a supported runtime identifier, or set the PublishReadyToRun property to false.</target>
         <note>{StrBegin="NETSDK1095: "}</note>
+      </trans-unit>
+      <trans-unit id="RollForwardRequiresVersion30">
+        <source>NETSDK1103: RollForward setting is only supported on .NET Core 3.0 or higher.</source>
+        <target state="new">NETSDK1103: RollForward setting is only supported on .NET Core 3.0 or higher.</target>
+        <note>{StrBegin="NETSDK1103: "}</note>
       </trans-unit>
       <trans-unit id="RuntimeIdentifierNotRecognized">
         <source>NETSDK1083: The specified RuntimeIdentifier '{0}' is not recognized.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
@@ -333,6 +333,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1075: Dojście aktualizacji jest nieprawidłowe. Tego wystąpienia nie można używać do dalszych aktualizacji.</target>
         <note>{StrBegin="NETSDK1075: "}</note>
       </trans-unit>
+      <trans-unit id="InvalidRollForwardValue">
+        <source>NETSDK1104: RollForward value '{0}' is invalid. Allowed values are {1}.</source>
+        <target state="new">NETSDK1104: RollForward value '{0}' is invalid. Allowed values are {1}.</target>
+        <note>{StrBegin="NETSDK1104: "}</note>
+      </trans-unit>
       <trans-unit id="MismatchedPlatformPackageVersion">
         <source>NETSDK1061: The project was restored using {0} version {1}, but with current settings, version {2} would be used instead. To resolve this issue, make sure the same settings are used for restore and for subsequent operations such as build or publish. Typically this issue can occur if the RuntimeIdentifier property is set during build or publish but not during restore. For more information, see https://aka.ms/dotnet-runtime-patch-selection.</source>
         <target state="translated">NETSDK1061: Projekt został przywrócony przy użyciu pakietu {0} w wersji {1}, ale w przypadku bieżących ustawień zamiast niej zostałaby użyta wersja {2}. Aby rozwiązać ten problem, upewnij się, że te same ustawienia są używane do przywracania i dla kolejnych operacji, takich jak kompilacja lub publikowanie. Ten problem zazwyczaj występuje, gdy właściwość RuntimeIdentifier jest ustawiona podczas kompilacji lub publikowania, ale nie podczas przywracania. Aby uzyskać więcej informacji, zobacz https://aka.ms/dotnet-runtime-patch-selection.</target>
@@ -435,6 +440,11 @@ The following are names of parameters or literal values and should not be transl
         <source>NETSDK1095: Optimizing assemblies for performance is not supported for the selected target platform or architecture. Please verify you are publishing a self-contained application using a supported runtime identifier, or set the PublishReadyToRun property to false.</source>
         <target state="new">NETSDK1095: Optimizing assemblies for performance is not supported for the selected target platform or architecture. Please verify you are publishing a self-contained application using a supported runtime identifier, or set the PublishReadyToRun property to false.</target>
         <note>{StrBegin="NETSDK1095: "}</note>
+      </trans-unit>
+      <trans-unit id="RollForwardRequiresVersion30">
+        <source>NETSDK1103: RollForward setting is only supported on .NET Core 3.0 or higher.</source>
+        <target state="new">NETSDK1103: RollForward setting is only supported on .NET Core 3.0 or higher.</target>
+        <note>{StrBegin="NETSDK1103: "}</note>
       </trans-unit>
       <trans-unit id="RuntimeIdentifierNotRecognized">
         <source>NETSDK1083: The specified RuntimeIdentifier '{0}' is not recognized.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
@@ -333,6 +333,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1075: o identificador de atualização não é válido. Esta instância não pode ser usada para atualizações adicionais.</target>
         <note>{StrBegin="NETSDK1075: "}</note>
       </trans-unit>
+      <trans-unit id="InvalidRollForwardValue">
+        <source>NETSDK1104: RollForward value '{0}' is invalid. Allowed values are {1}.</source>
+        <target state="new">NETSDK1104: RollForward value '{0}' is invalid. Allowed values are {1}.</target>
+        <note>{StrBegin="NETSDK1104: "}</note>
+      </trans-unit>
       <trans-unit id="MismatchedPlatformPackageVersion">
         <source>NETSDK1061: The project was restored using {0} version {1}, but with current settings, version {2} would be used instead. To resolve this issue, make sure the same settings are used for restore and for subsequent operations such as build or publish. Typically this issue can occur if the RuntimeIdentifier property is set during build or publish but not during restore. For more information, see https://aka.ms/dotnet-runtime-patch-selection.</source>
         <target state="translated">NETSDK1061: o projeto foi restaurado usando o {0} versão {1}, mas, com as configurações atuais, a versão {2} seria usada. Para resolver esse problema, verifique se as mesmas configurações são usadas para restauração e para operações subsequentes, como compilação ou publicação. Normalmente, esse problema poderá ocorrer se a propriedade RuntimeIdentifier for definida durante a compilação ou a publicação, mas não durante a restauração. Para obter mais informações, consulte https://aka.ms/dotnet-runtime-patch-selection.</target>
@@ -435,6 +440,11 @@ The following are names of parameters or literal values and should not be transl
         <source>NETSDK1095: Optimizing assemblies for performance is not supported for the selected target platform or architecture. Please verify you are publishing a self-contained application using a supported runtime identifier, or set the PublishReadyToRun property to false.</source>
         <target state="new">NETSDK1095: Optimizing assemblies for performance is not supported for the selected target platform or architecture. Please verify you are publishing a self-contained application using a supported runtime identifier, or set the PublishReadyToRun property to false.</target>
         <note>{StrBegin="NETSDK1095: "}</note>
+      </trans-unit>
+      <trans-unit id="RollForwardRequiresVersion30">
+        <source>NETSDK1103: RollForward setting is only supported on .NET Core 3.0 or higher.</source>
+        <target state="new">NETSDK1103: RollForward setting is only supported on .NET Core 3.0 or higher.</target>
+        <note>{StrBegin="NETSDK1103: "}</note>
       </trans-unit>
       <trans-unit id="RuntimeIdentifierNotRecognized">
         <source>NETSDK1083: The specified RuntimeIdentifier '{0}' is not recognized.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
@@ -333,6 +333,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1075: Недопустимый дескриптор обновления. Этот экземпляр не может использоваться для последующих обновлений.</target>
         <note>{StrBegin="NETSDK1075: "}</note>
       </trans-unit>
+      <trans-unit id="InvalidRollForwardValue">
+        <source>NETSDK1104: RollForward value '{0}' is invalid. Allowed values are {1}.</source>
+        <target state="new">NETSDK1104: RollForward value '{0}' is invalid. Allowed values are {1}.</target>
+        <note>{StrBegin="NETSDK1104: "}</note>
+      </trans-unit>
       <trans-unit id="MismatchedPlatformPackageVersion">
         <source>NETSDK1061: The project was restored using {0} version {1}, but with current settings, version {2} would be used instead. To resolve this issue, make sure the same settings are used for restore and for subsequent operations such as build or publish. Typically this issue can occur if the RuntimeIdentifier property is set during build or publish but not during restore. For more information, see https://aka.ms/dotnet-runtime-patch-selection.</source>
         <target state="translated">NETSDK1061: Проект был восстановлен с использованием {0} версии {1}, но с текущими параметрами вместо этой версии будет использована версия {2}. Чтобы устранить эту проблему, убедитесь, что для восстановления и последующих операций (таких как сборка или публикация) используются одинаковые параметры. Обычно эта проблема возникает, когда свойство RuntimeIdentifier устанавливается во время сборки или публикации, но не во время восстановления. Дополнительные сведения см. на странице https://aka.ms/dotnet-runtime-patch-selection.</target>
@@ -435,6 +440,11 @@ The following are names of parameters or literal values and should not be transl
         <source>NETSDK1095: Optimizing assemblies for performance is not supported for the selected target platform or architecture. Please verify you are publishing a self-contained application using a supported runtime identifier, or set the PublishReadyToRun property to false.</source>
         <target state="new">NETSDK1095: Optimizing assemblies for performance is not supported for the selected target platform or architecture. Please verify you are publishing a self-contained application using a supported runtime identifier, or set the PublishReadyToRun property to false.</target>
         <note>{StrBegin="NETSDK1095: "}</note>
+      </trans-unit>
+      <trans-unit id="RollForwardRequiresVersion30">
+        <source>NETSDK1103: RollForward setting is only supported on .NET Core 3.0 or higher.</source>
+        <target state="new">NETSDK1103: RollForward setting is only supported on .NET Core 3.0 or higher.</target>
+        <note>{StrBegin="NETSDK1103: "}</note>
       </trans-unit>
       <trans-unit id="RuntimeIdentifierNotRecognized">
         <source>NETSDK1083: The specified RuntimeIdentifier '{0}' is not recognized.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
@@ -333,6 +333,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1075: Güncelleştirme tanıtıcısı geçersiz. Bu örnek başka güncelleştirme için kullanılamaz.</target>
         <note>{StrBegin="NETSDK1075: "}</note>
       </trans-unit>
+      <trans-unit id="InvalidRollForwardValue">
+        <source>NETSDK1104: RollForward value '{0}' is invalid. Allowed values are {1}.</source>
+        <target state="new">NETSDK1104: RollForward value '{0}' is invalid. Allowed values are {1}.</target>
+        <note>{StrBegin="NETSDK1104: "}</note>
+      </trans-unit>
       <trans-unit id="MismatchedPlatformPackageVersion">
         <source>NETSDK1061: The project was restored using {0} version {1}, but with current settings, version {2} would be used instead. To resolve this issue, make sure the same settings are used for restore and for subsequent operations such as build or publish. Typically this issue can occur if the RuntimeIdentifier property is set during build or publish but not during restore. For more information, see https://aka.ms/dotnet-runtime-patch-selection.</source>
         <target state="translated">NETSDK1061: Proje, {0} sürüm {1} kullanılarak geri yüklendi, ancak geçerli ayarlarla, bunun yerine sürüm {2} kullanılması gerekiyordu. Bu sorunu çözmek amacıyla, geri yükleme için ve derleme veya yayımlama gibi sonraki işlemler için aynı ayarların kullanıldığından emin olun. Bu sorun genellikle RuntimeIdentifier özelliği derleme veya yayımlama sırasında ayarlandığında ancak geri yükleme sırasında ayarlanmadığında oluşur. Daha fazla bilgi için bkz. https://aka.ms/dotnet-runtime-patch-selection.</target>
@@ -435,6 +440,11 @@ The following are names of parameters or literal values and should not be transl
         <source>NETSDK1095: Optimizing assemblies for performance is not supported for the selected target platform or architecture. Please verify you are publishing a self-contained application using a supported runtime identifier, or set the PublishReadyToRun property to false.</source>
         <target state="new">NETSDK1095: Optimizing assemblies for performance is not supported for the selected target platform or architecture. Please verify you are publishing a self-contained application using a supported runtime identifier, or set the PublishReadyToRun property to false.</target>
         <note>{StrBegin="NETSDK1095: "}</note>
+      </trans-unit>
+      <trans-unit id="RollForwardRequiresVersion30">
+        <source>NETSDK1103: RollForward setting is only supported on .NET Core 3.0 or higher.</source>
+        <target state="new">NETSDK1103: RollForward setting is only supported on .NET Core 3.0 or higher.</target>
+        <note>{StrBegin="NETSDK1103: "}</note>
       </trans-unit>
       <trans-unit id="RuntimeIdentifierNotRecognized">
         <source>NETSDK1083: The specified RuntimeIdentifier '{0}' is not recognized.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
@@ -333,6 +333,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1075: 更新句柄无效。此实例不能用于进一步的更新。</target>
         <note>{StrBegin="NETSDK1075: "}</note>
       </trans-unit>
+      <trans-unit id="InvalidRollForwardValue">
+        <source>NETSDK1104: RollForward value '{0}' is invalid. Allowed values are {1}.</source>
+        <target state="new">NETSDK1104: RollForward value '{0}' is invalid. Allowed values are {1}.</target>
+        <note>{StrBegin="NETSDK1104: "}</note>
+      </trans-unit>
       <trans-unit id="MismatchedPlatformPackageVersion">
         <source>NETSDK1061: The project was restored using {0} version {1}, but with current settings, version {2} would be used instead. To resolve this issue, make sure the same settings are used for restore and for subsequent operations such as build or publish. Typically this issue can occur if the RuntimeIdentifier property is set during build or publish but not during restore. For more information, see https://aka.ms/dotnet-runtime-patch-selection.</source>
         <target state="translated">NETSDK1061: 项目是使用 {0} 版本 {1} 还原的, 但使用当前设置, 将改用版本 {2}。要解决此问题, 请确保将相同的设置用于还原和后续操作 (如生成或发布)。通常, 如果 RuntimeIdentifier 属性是在生成或发布过程中设置的, 而不是在还原过程中进行的, 则会发生此问题。有关详细信息, 请参阅 https://aka.ms/dotnet-runtime-patch-selection。</target>
@@ -435,6 +440,11 @@ The following are names of parameters or literal values and should not be transl
         <source>NETSDK1095: Optimizing assemblies for performance is not supported for the selected target platform or architecture. Please verify you are publishing a self-contained application using a supported runtime identifier, or set the PublishReadyToRun property to false.</source>
         <target state="new">NETSDK1095: Optimizing assemblies for performance is not supported for the selected target platform or architecture. Please verify you are publishing a self-contained application using a supported runtime identifier, or set the PublishReadyToRun property to false.</target>
         <note>{StrBegin="NETSDK1095: "}</note>
+      </trans-unit>
+      <trans-unit id="RollForwardRequiresVersion30">
+        <source>NETSDK1103: RollForward setting is only supported on .NET Core 3.0 or higher.</source>
+        <target state="new">NETSDK1103: RollForward setting is only supported on .NET Core 3.0 or higher.</target>
+        <note>{StrBegin="NETSDK1103: "}</note>
       </trans-unit>
       <trans-unit id="RuntimeIdentifierNotRecognized">
         <source>NETSDK1083: The specified RuntimeIdentifier '{0}' is not recognized.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
@@ -333,6 +333,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1075: 更新控制代碼無效。此執行個體無法用於後續更新。</target>
         <note>{StrBegin="NETSDK1075: "}</note>
       </trans-unit>
+      <trans-unit id="InvalidRollForwardValue">
+        <source>NETSDK1104: RollForward value '{0}' is invalid. Allowed values are {1}.</source>
+        <target state="new">NETSDK1104: RollForward value '{0}' is invalid. Allowed values are {1}.</target>
+        <note>{StrBegin="NETSDK1104: "}</note>
+      </trans-unit>
       <trans-unit id="MismatchedPlatformPackageVersion">
         <source>NETSDK1061: The project was restored using {0} version {1}, but with current settings, version {2} would be used instead. To resolve this issue, make sure the same settings are used for restore and for subsequent operations such as build or publish. Typically this issue can occur if the RuntimeIdentifier property is set during build or publish but not during restore. For more information, see https://aka.ms/dotnet-runtime-patch-selection.</source>
         <target state="translated">NETSDK1061: 專案是使用 {0} 版本 {1} 還原的，但依照目前設定，使用的版本會是 {2}。若要解決此問題，請確認用於還原與後續作業 (例如建置或發佈) 的設定相同。一般而言，若在建置或發佈期間設定了 RuntimeIdentifier，但在還原期間未加以設定，就可能發生這個問題。如需詳細資訊，請參閱 https://aka.ms/dotnet-runtime-patch-selection。</target>
@@ -435,6 +440,11 @@ The following are names of parameters or literal values and should not be transl
         <source>NETSDK1095: Optimizing assemblies for performance is not supported for the selected target platform or architecture. Please verify you are publishing a self-contained application using a supported runtime identifier, or set the PublishReadyToRun property to false.</source>
         <target state="new">NETSDK1095: Optimizing assemblies for performance is not supported for the selected target platform or architecture. Please verify you are publishing a self-contained application using a supported runtime identifier, or set the PublishReadyToRun property to false.</target>
         <note>{StrBegin="NETSDK1095: "}</note>
+      </trans-unit>
+      <trans-unit id="RollForwardRequiresVersion30">
+        <source>NETSDK1103: RollForward setting is only supported on .NET Core 3.0 or higher.</source>
+        <target state="new">NETSDK1103: RollForward setting is only supported on .NET Core 3.0 or higher.</target>
+        <note>{StrBegin="NETSDK1103: "}</note>
       </trans-unit>
       <trans-unit id="RuntimeIdentifierNotRecognized">
         <source>NETSDK1083: The specified RuntimeIdentifier '{0}' is not recognized.</source>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/GenerateRuntimeConfigurationFiles.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/GenerateRuntimeConfigurationFiles.cs
@@ -113,7 +113,7 @@ namespace Microsoft.NET.Build.Tasks
         {
             if (projectContext.IsFrameworkDependent)
             {
-                runtimeOptions.tfm = TargetFramework;
+                runtimeOptions.TFM = TargetFramework;
                 runtimeOptions.RollForward = RollForward;
 
                 if (projectContext.RuntimeFrameworks == null || projectContext.RuntimeFrameworks.Length == 0)

--- a/src/Tasks/Microsoft.NET.Build.Tasks/GenerateRuntimeConfigurationFiles.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/GenerateRuntimeConfigurationFiles.cs
@@ -53,6 +53,16 @@ namespace Microsoft.NET.Build.Tasks
 
         List<ITaskItem> _filesWritten = new List<ITaskItem>();
 
+        private static readonly string[] RollForwardValues = new string[]
+        {
+            "Disable",
+            "LatestPatch",
+            "Minor",
+            "LatestMinor",
+            "Major",
+            "LatestMajor"
+        };
+
         [Output]
         public ITaskItem[] FilesWritten
         {
@@ -68,6 +78,15 @@ namespace Microsoft.NET.Build.Tasks
                 if (AdditionalProbingPaths?.Any() == true && !writeDevRuntimeConfig)
                 {
                     Log.LogWarning(Strings.SkippingAdditionalProbingPaths);
+                }
+            }
+
+            if (!string.IsNullOrEmpty(RollForward))
+            {
+                if (!RollForwardValues.Any(v => string.Equals(RollForward, v, StringComparison.OrdinalIgnoreCase)))
+                {
+                    Log.LogError(Strings.InvalidRollForwardValue, RollForward, string.Join(", ", RollForwardValues));
+                    return;
                 }
             }
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/GenerateRuntimeConfigurationFiles.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/GenerateRuntimeConfigurationFiles.cs
@@ -114,7 +114,7 @@ namespace Microsoft.NET.Build.Tasks
             if (projectContext.IsFrameworkDependent)
             {
                 runtimeOptions.tfm = TargetFramework;
-                runtimeOptions.rollForward = RollForward;
+                runtimeOptions.RollForward = RollForward;
 
                 if (projectContext.RuntimeFrameworks == null || projectContext.RuntimeFrameworks.Length == 0)
                 {

--- a/src/Tasks/Microsoft.NET.Build.Tasks/GenerateRuntimeConfigurationFiles.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/GenerateRuntimeConfigurationFiles.cs
@@ -10,7 +10,6 @@ using Microsoft.Build.Utilities;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Newtonsoft.Json.Serialization;
-using NuGet.Frameworks;
 using NuGet.ProjectModel;
 
 namespace Microsoft.NET.Build.Tasks
@@ -39,6 +38,8 @@ namespace Microsoft.NET.Build.Tasks
         public string PlatformLibraryName { get; set; }
 
         public ITaskItem[] RuntimeFrameworks { get; set; }
+
+        public string RollForward { get; set; }
 
         public string UserRuntimeConfig { get; set; }
 
@@ -113,6 +114,7 @@ namespace Microsoft.NET.Build.Tasks
             if (projectContext.IsFrameworkDependent)
             {
                 runtimeOptions.tfm = TargetFramework;
+                runtimeOptions.rollForward = RollForward;
 
                 if (projectContext.RuntimeFrameworks == null || projectContext.RuntimeFrameworks.Length == 0)
                 {

--- a/src/Tasks/Microsoft.NET.Build.Tasks/GenerateRuntimeConfigurationFiles.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/GenerateRuntimeConfigurationFiles.cs
@@ -113,7 +113,7 @@ namespace Microsoft.NET.Build.Tasks
         {
             if (projectContext.IsFrameworkDependent)
             {
-                runtimeOptions.TFM = TargetFramework;
+                runtimeOptions.Tfm = TargetFramework;
                 runtimeOptions.RollForward = RollForward;
 
                 if (projectContext.RuntimeFrameworks == null || projectContext.RuntimeFrameworks.Length == 0)

--- a/src/Tasks/Microsoft.NET.Build.Tasks/RuntimeOptions.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/RuntimeOptions.cs
@@ -9,7 +9,7 @@ namespace Microsoft.NET.Build.Tasks
 {
     internal class RuntimeOptions
     {
-        public string TFM { get; set; }
+        public string Tfm { get; set; }
 
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         public string RollForward { get; set; }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/RuntimeOptions.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/RuntimeOptions.cs
@@ -9,7 +9,7 @@ namespace Microsoft.NET.Build.Tasks
 {
     internal class RuntimeOptions
     {
-        public string tfm { get; set; }
+        public string TFM { get; set; }
 
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         public string RollForward { get; set; }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/RuntimeOptions.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/RuntimeOptions.cs
@@ -12,7 +12,7 @@ namespace Microsoft.NET.Build.Tasks
         public string tfm { get; set; }
 
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
-        public string rollForward { get; set; }
+        public string RollForward { get; set; }
 
         public RuntimeConfigFramework Framework { get; set; }
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/RuntimeOptions.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/RuntimeOptions.cs
@@ -11,6 +11,9 @@ namespace Microsoft.NET.Build.Tasks
     {
         public string tfm { get; set; }
 
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string rollForward { get; set; }
+
         public RuntimeConfigFramework Framework { get; set; }
 
         public List<RuntimeConfigFramework> Frameworks { get; set; }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -191,6 +191,9 @@ Copyright (c) .NET Foundation. All rights reserved.
           Inputs="@(GenerateRuntimeConfigurationFilesInputs)"
           Outputs="$(ProjectRuntimeConfigFilePath);$(ProjectRuntimeConfigDevFilePath)">
 
+    <NETSdkError Condition="'$(RollForward)' != '' and '$(_TargetFrameworkVersionWithoutV)' &lt; '3.0'"
+                 ResourceName="RollForwardRequiresVersion30"/>
+
     <GenerateRuntimeConfigurationFiles AssetsFilePath="$(ProjectAssetsFile)"
                                        TargetFrameworkMoniker="$(TargetFrameworkMoniker)"
                                        TargetFramework="$(TargetFramework)"

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -199,6 +199,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                                        RuntimeIdentifier="$(RuntimeIdentifier)"
                                        PlatformLibraryName="$(MicrosoftNETPlatformLibrary)"
                                        RuntimeFrameworks="@(RuntimeFramework)"
+                                       RollForward="$(RollForward)"
                                        UserRuntimeConfig="$(UserRuntimeConfig)"
                                        HostConfigurationOptions="@(RuntimeHostConfigurationOption)"
                                        AdditionalProbingPaths="@(AdditionalProbingPath)"

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenFrameworkReferences.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenFrameworkReferences.cs
@@ -193,7 +193,7 @@ namespace FrameworkReferenceTest
                 .HaveStdOutContaining("NETSDK1073");
         }
 
-        [CoreMSBuildOnlyTheory]
+        [Theory]
         [InlineData("Major", true)]
         [InlineData("latestMinor", true)]
         [InlineData("Invalid", false)]
@@ -239,7 +239,7 @@ namespace FrameworkReferenceTest
             }
         }
 
-        [CoreMSBuildOnlyFact]
+        [Fact]
         public void RollForwardIsNotSupportedOn22()
         {
             var testProject = new TestProject()


### PR DESCRIPTION
The `GenerateRuntimeConfigurationFiles` task now recognizes `RollForward` parameter (and it's passed from the `RollForward` property). It writes its value into the .runtimeconfig.json as the `rollForward` setting.

This implements the SDK side of the roll forward feature as described in the [runtime binding](https://github.com/dotnet/designs/blob/master/accepted/runtime-binding.md#rollforward).