### PR TITLE
Resolve runtime target assets without copying for non-netcoreapp targets.

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolveCopyLocalAssets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveCopyLocalAssets.cs
@@ -37,7 +37,7 @@ namespace Microsoft.NET.Build.Tasks
 
         public bool IsSelfContained { get; set; }
 
-        public bool DisableRuntimeTargets { get; set; }
+        public bool ResolveRuntimeTargets { get; set; }
 
         [Output]
         public ITaskItem[] ResolvedAssets => _resolvedAssets.ToArray();
@@ -71,7 +71,7 @@ namespace Microsoft.NET.Build.Tasks
                     .WithExcludedPackages(PackageReferenceConverter.GetPackageIds(ExcludedPackageReferences))
                     .WithPreserveStoreLayout(PreserveStoreLayout);
 
-            foreach (var resolvedFile in assetsFileResolver.Resolve(projectContext, resolveRuntimeTargets: !DisableRuntimeTargets))
+            foreach (var resolvedFile in assetsFileResolver.Resolve(projectContext, resolveRuntimeTargets: ResolveRuntimeTargets))
             {
                 TaskItem item = new TaskItem(resolvedFile.SourcePath);
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -449,7 +449,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                               ExcludedPackageReferences="@(_ExcludeFromPublishPackageReference)"
                               RuntimeStorePackages="@(RuntimeStorePackages)"
                               PreserveStoreLayout="$(PreserveStoreLayout)"
-                              DisableRuntimeTargets="$(DisableRuntimeTargets)"
+                              ResolveRuntimeTargets="$(CopyLocalRuntimeTargetAssets)"
                               IsSelfContained="$(SelfContained)"
                               Condition="'$(_UseBuildDependencyFile)' != 'true'">
         <Output TaskParameter="ResolvedAssets" ItemName="_ResolvedCopyLocalPublishAssets" />

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.PackageDependencyResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.PackageDependencyResolution.targets
@@ -216,9 +216,9 @@ Copyright (c) .NET Foundation. All rights reserved.
       <EnsureRuntimePackageDependencies>true</EnsureRuntimePackageDependencies>
     </PropertyGroup>
 
-    <!-- Disable resolution of runtime target assets if not targeting .NETCoreApp -->
-    <PropertyGroup Condition="'$(DisableRuntimeTargets)' == '' and '$(TargetFrameworkIdentifier)' != '.NETCoreApp'">
-      <DisableRuntimeTargets>true</DisableRuntimeTargets>
+    <!-- Only copy local runtime target assets if targeting netcoreapp -->
+    <PropertyGroup Condition="'$(CopyLocalRuntimeTargetAssets)' == '' and '$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
+      <CopyLocalRuntimeTargetAssets>true</CopyLocalRuntimeTargetAssets>
     </PropertyGroup>
 
     <ItemGroup>
@@ -245,7 +245,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       MarkPackageReferencesAsExternallyResolved="$(MarkPackageReferencesAsExternallyResolved)"
       DisablePackageAssetsCache="$(DisablePackageAssetsCache)"
       DisableFrameworkAssemblies="$(DisableLockFileFrameworks)"
-      DisableRuntimeTargets="$(DisableRuntimeTargets)"
+      CopyLocalRuntimeTargetAssets="$(CopyLocalRuntimeTargetAssets)"
       DisableTransitiveProjectReferences="$(DisableTransitiveProjectReferences)"
       DisableTransitiveFrameworkReferences="$(DisableTransitiveFrameworkReferences)"
       DotNetAppHostExecutableNameWithoutExtension="$(_DotNetAppHostExecutableNameWithoutExtension)"

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToCopyLocalDependencies.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToCopyLocalDependencies.cs
@@ -270,7 +270,7 @@ namespace Microsoft.NET.Build.Tests
             };
 
             testProject.AdditionalProperties["CopyLocalLockFileAssemblies"] = "true";
-            testProject.AdditionalProperties["DisableRuntimeTargets"] = "false";
+            testProject.AdditionalProperties["CopyLocalRuntimeTargetAssets"] = "true";
             testProject.PackageReferences.Add(new TestPackageReference("Newtonsoft.Json", "11.0.2"));
             testProject.PackageReferences.Add(new TestPackageReference("sqlite", "3.13.0"));
 


### PR DESCRIPTION
A [previous change](https://github.com/peterhuene/sdk/commit/545410772bb7c41d26b22dd9f3ba0cd3e8acd63e) disabled the resolution of runtime target assets when not
targeting netcoreapp by default. However, some users may want to be able to
inspect the runtime target assets from their package dependencies without
having them copied locally by default when not targeting netcoreapp.

This commit changes the previous fix by resolving the runtime target assets to
populate the `RuntimeTargetsCopyLocalItems` group, but sets the `CopyLocal`
metadata to false which prevents the items from ultimately being included in
the copy local files.  The property `CopyLocalRuntimeTargetAssets` now controls
this behavior, which defaults to `true` only when netcoreapp is the target TFM.

Fixes #3261.