### PR TITLE
Use profiles defined in FrameworkList.xml in targeting pack instead of hard-coding

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "3.0.100-preview6-012021",
+    "dotnet": "3.0.100-preview7-012270",
     "vs-opt": {
       "version": "15.9"
     }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolveTargetingPackAssets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveTargetingPackAssets.cs
@@ -35,96 +35,8 @@ namespace Microsoft.NET.Build.Tasks
         [Output]
         public ITaskItem[] UsedRuntimeFrameworks { get; set; }
 
-        private Dictionary<string, List<string>> _assemblyProfiles;
-
         public ResolveTargetingPackAssets()
         {
-            //  Hard-code assembly profiles for WindowDesktop targeting pack here until
-            //  they are added to its FrameworkList.xml: https://github.com/dotnet/core-setup/issues/6210
-            _assemblyProfiles = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
-
-            var bothProfiles = new List<string>() { "WindowsForms", "WPF" };
-
-            foreach (var assemblyName in new []
-            {
-                "Accessibility",
-                "Microsoft.Win32.Registry",
-                "Microsoft.Win32.SystemEvents",
-                "System.CodeDom",
-                "System.Configuration.ConfigurationManager",
-                "System.Diagnostics.EventLog",
-                "System.DirectoryServices",
-                "System.IO.FileSystem.AccessControl",
-                "System.Media.SoundPlayer",
-                "System.Security.AccessControl",
-                "System.Security.Cryptography.Cng",
-                "System.Security.Cryptography.Pkcs",
-                "System.Security.Cryptography.ProtectedData",
-                "System.Security.Cryptography.Xml",
-                "System.Security.Permissions",
-                "System.Security.Principal.Windows",
-                "System.Threading.AccessControl",
-                "System.Windows.Extensions",
-            })
-            {
-                _assemblyProfiles[assemblyName] = bothProfiles;
-            }
-
-            var wpfProfile = new List<string>() { "WPF" };
-
-            foreach (var assemblyName in new []
-            {
-                "DirectWriteForwarder",
-                "PenImc_cor3",
-                "PresentationCore-CommonResources",
-                "PresentationCore",
-                "PresentationFramework-SystemCore",
-                "PresentationFramework-SystemData",
-                "PresentationFramework-SystemDrawing",
-                "PresentationFramework-SystemXml",
-                "PresentationFramework-SystemXmlLinq",
-                "PresentationFramework.Aero",
-                "PresentationFramework.Aero2",
-                "PresentationFramework.AeroLite",
-                "PresentationFramework.Classic",
-                "PresentationFramework",
-                "PresentationFramework.Luna",
-                "PresentationFramework.Royale",
-                "PresentationNative_cor3",
-                "PresentationUI",
-                "ReachFramework",
-                "System.Printing",
-                "System.Windows.Controls.Ribbon",
-                "System.Windows.Input.Manipulations",
-                "System.Windows.Presentation",
-                "System.Xaml",
-                "UIAutomationClient",
-                "UIAutomationClientSideProviders",
-                "UIAutomationProvider",
-                "UIAutomationTypes",
-                "WindowsBase",
-                "WPFgfx_cor3",
-            })
-            {
-                _assemblyProfiles[assemblyName] = wpfProfile;
-            }
-
-            var windowsFormsProfile = new List<string>() { "WindowsForms" };
-
-            foreach (var assemblyName in new[]
-            {
-                "System.Design",
-                "System.Drawing.Common",
-                "System.Drawing.Design",
-                "System.Drawing.Design.Primitives",
-                "System.Windows.Forms.Design",
-                "System.Windows.Forms.Design.Editors",
-                "System.Windows.Forms",
-            })
-            {
-                _assemblyProfiles[assemblyName] = windowsFormsProfile;
-            }
-
         }
 
         protected override void ExecuteCore()
@@ -292,12 +204,15 @@ namespace Microsoft.NET.Build.Tasks
 
                 if (!string.IsNullOrEmpty(profile))
                 {
-                    _assemblyProfiles.TryGetValue(assemblyName, out var assemblyProfiles);
-                    if (assemblyProfiles == null)
+                    var profileAttributeValue = fileElement.Attribute("Profile")?.Value;
+
+                    if (profileAttributeValue == null)
                     {
                         //  If profile was specified but this assembly doesn't belong to any profiles, don't reference it
                         continue;
                     }
+
+                    var assemblyProfiles = profileAttributeValue.Split(';');
                     if (!assemblyProfiles.Contains(profile, StringComparer.OrdinalIgnoreCase))
                     {
                         //  Assembly wasn't in profile specified, so don't reference it

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.TargetingPackResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.TargetingPackResolution.targets
@@ -17,14 +17,6 @@ Copyright (c) .NET Foundation. All rights reserved.
     </ResolveAssemblyReferencesDependsOn>
   </PropertyGroup>
 
-  <!-- Mark the WindowsDesktop frameworks as being windows only.
-       TODO: remove this once the metadata exists on the items in the SDK props file. -->
-  <ItemGroup>
-    <KnownFrameworkReference Update="Microsoft.WindowsDesktop.App" IsWindowsOnly="True" />
-    <KnownFrameworkReference Update="Microsoft.WindowsDesktop.App.WindowsForms" IsWindowsOnly="True" />
-    <KnownFrameworkReference Update="Microsoft.WindowsDesktop.App.WPF" IsWindowsOnly="True" />
-  </ItemGroup>
-
   <UsingTask TaskName="CheckForDuplicateFrameworkReferences" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
   <UsingTask TaskName="ResolveFrameworkReferences" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
   <UsingTask TaskName="ResolveAppHosts" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
@@ -41,22 +33,6 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ItemGroup>
       <FrameworkReference Remove="@(_FrameworkReferenceToRemove)" />
       <FrameworkReference Include="@(_FrameworkReferenceToAdd)" />
-    </ItemGroup>
-
-    <!-- We will add Microsoft.WindowsDesktop.App.WPF and Microsoft.WindowsDesktop.App.WindowsForms to the bundled versions.
-         Until we do, add them here. -->
-    <ItemGroup>
-      <_WPFKnownFrameworkReference Include="@(KnownFrameworkReference)"
-                                   Condition="'%(Identity)' == 'Microsoft.WindowsDesktop.App.WPF'"/>
-    </ItemGroup>
-    <ItemGroup Condition="'@(_WPFKnownFrameworkReference)' == ''">
-      <_WindowsDesktopKnownFrameworkReference Include="@(KnownFrameworkReference)"
-                                        Condition="'%(Identity)' == 'Microsoft.WindowsDesktop.App'"/>
-
-      <KnownFrameworkReference Include="@(_WindowsDesktopKnownFrameworkReference->'Microsoft.WindowsDesktop.App.WindowsForms')"
-                               Profile="WindowsForms"/>
-      <KnownFrameworkReference Include="@(_WindowsDesktopKnownFrameworkReference->'Microsoft.WindowsDesktop.App.WPF')"
-                               Profile="WPF"/>
     </ItemGroup>
 
     <PropertyGroup Condition="'$(EnableTargetingPackDownload)' == ''">

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPreserveCompilationContext.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPreserveCompilationContext.cs
@@ -129,6 +129,15 @@ namespace Microsoft.NET.Publish.Tests
                 var extraCompileLibraryNames = compileLibraryAssemblyNames.Except(expectedCompileLibraryNames).ToList();
                 var missingCompileLibraryNames = expectedCompileLibraryNames.Except(compileLibraryAssemblyNames).ToList();
 
+                if (extraCompileLibraryNames.Any())
+                {
+                    Log.WriteLine("Unexpected compile libraries: " + string.Join(' ', extraCompileLibraryNames));
+                }
+                if (missingCompileLibraryNames.Any())
+                {
+                    Log.WriteLine("Missing compile libraries: " + string.Join(' ', missingCompileLibraryNames));
+                }
+
                 compileLibraryAssemblyNames.Should().BeEquivalentTo(expectedCompileLibraryNames);
 
                 // Ensure P2P references are specified correctly
@@ -669,6 +678,7 @@ System.Text.Encoding.Extensions.dll
 System.Text.Encodings.Web.dll
 System.Text.RegularExpressions.dll
 System.Threading.dll
+System.Threading.Channels.dll
 System.Threading.Overlapped.dll
 System.Threading.Tasks.Dataflow.dll
 System.Threading.Tasks.dll


### PR DESCRIPTION
- Update stage 0, and remove code that added information that wasn't yet in bundled versions .props file.
- Use profiles defined in FrameworkList.xml in targeting pack instead of hard-coding
