### PR TITLE
Add property for building a library as a component

### DIFF
--- a/src/Assets/TestProjects/ComServer/ComServer.csproj
+++ b/src/Assets/TestProjects/ComServer/ComServer.csproj
@@ -3,6 +3,6 @@
     <Version>42.43.44.45-alpha</Version>
     <OutputType>Library</OutputType>
     <TargetFramework>netcoreapp3.0</TargetFramework>
-    <UseComHost>true</UseComHost>
+    <EnableComHosting>true</EnableComHosting>
   </PropertyGroup>
 </Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets
@@ -115,7 +115,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <PropertyGroup Condition="'$(DefaultAppHostRuntimeIdentifier)' == '' and
                             '$(RuntimeIdentifier)' == '' and
                             (('$(UseAppHost)' == 'true' and '$(ProjectDepsFilePath)' == '') or
-                            ('$(UseComHost)' == 'true' and '$(_IsExecutable)' != 'true'))">
+                            ('$(EnableComHosting)' == 'true' and '$(_IsExecutable)' != 'true'))">
     <DefaultAppHostRuntimeIdentifier>$(NETCoreSdkRuntimeIdentifier)</DefaultAppHostRuntimeIdentifier>
     <DefaultAppHostRuntimeIdentifier Condition="$(DefaultAppHostRuntimeIdentifier.StartsWith('win')) and '$(PlatformTarget)' == 'x64'">win-x64</DefaultAppHostRuntimeIdentifier>
     <DefaultAppHostRuntimeIdentifier Condition="$(DefaultAppHostRuntimeIdentifier.StartsWith('win')) and '$(PlatformTarget)' == 'x86'">win-x86</DefaultAppHostRuntimeIdentifier>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.TargetingPackResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.TargetingPackResolution.targets
@@ -91,7 +91,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     </ResolveFrameworkReferences>
 
     <PropertyGroup Condition="'$(AppHostRuntimeIdentifier)' == '' And
-                              ('$(UseAppHost)' == 'true' Or '$(UseComHost)' == 'true')">
+                              ('$(UseAppHost)' == 'true' Or '$(EnableComHosting)' == 'true')">
       <AppHostRuntimeIdentifier>$(RuntimeIdentifier)</AppHostRuntimeIdentifier>
       <AppHostRuntimeIdentifier Condition="'$(AppHostRuntimeIdentifier)' == ''">$(DefaultAppHostRuntimeIdentifier)</AppHostRuntimeIdentifier>
     </PropertyGroup>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -37,8 +37,8 @@ Copyright (c) .NET Foundation. All rights reserved.
   </PropertyGroup>
 
   <PropertyGroup>
-    <IsComponent Condition="'$(IsComponent)' == '' and '$(UseComHost)' == 'true'">true</IsComponent>
-    <GenerateRuntimeConfigurationFiles Condition=" '$(GenerateRuntimeConfigurationFiles)' == '' and '$(TargetFrameworkIdentifier)' == '.NETCoreApp' and ('$(HasRuntimeOutput)' == 'true' or '$(UseComHost)' == 'true' or '$(IsComponent)' == 'true') ">true</GenerateRuntimeConfigurationFiles>
+    <EnableDynamicLoading Condition="'$(EnableDynamicLoading)' == '' and '$(EnableComHosting)' == 'true'">true</EnableDynamicLoading>
+    <GenerateRuntimeConfigurationFiles Condition=" '$(GenerateRuntimeConfigurationFiles)' == '' and '$(TargetFrameworkIdentifier)' == '.NETCoreApp' and ('$(HasRuntimeOutput)' == 'true' or '$(EnableComHosting)' == 'true' or '$(EnableDynamicLoading)' == 'true') ">true</GenerateRuntimeConfigurationFiles>
     <UserRuntimeConfig Condition=" '$(UserRuntimeConfig)' == '' ">$(MSBuildProjectDirectory)/runtimeconfig.template.json</UserRuntimeConfig>
     <GenerateSatelliteAssembliesForCore Condition=" '$(GenerateSatelliteAssembliesForCore)' == '' and '$(MSBuildRuntimeType)' == 'Core' ">true</GenerateSatelliteAssembliesForCore>
     <ComputeNETCoreBuildOutputFiles Condition=" '$(ComputeNETCoreBuildOutputFiles)' == '' and '$(TargetFrameworkIdentifier)' == '.NETCoreApp'">true</ComputeNETCoreBuildOutputFiles>
@@ -194,7 +194,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <PropertyGroup>
       <_IsRollForwardSupported Condition="'$(_TargetFrameworkVersionWithoutV)' &gt;= '3.0'">true</_IsRollForwardSupported>
-      <RollForward Condition="'$(RollForward)' == '' and '$(IsComponent)' == 'true' and '$(_IsRollForwardSupported)' == 'true'">LatestMinor</RollForward>
+      <RollForward Condition="'$(RollForward)' == '' and '$(EnableDynamicLoading)' == 'true' and '$(_IsRollForwardSupported)' == 'true'">LatestMinor</RollForward>
     </PropertyGroup>
 
     <NETSdkError Condition="'$(RollForward)' != '' and '$(_IsRollForwardSupported)' != 'true'"
@@ -386,7 +386,7 @@ Copyright (c) .NET Foundation. All rights reserved.
           Outputs="@(ClsidMap)"
           DependsOnTargets="CoreCompile"
           Condition="'$(ComputeNETCoreBuildOutputFiles)' == 'true' and
-                     '$(UseComHost)' == 'true'">
+                     '$(EnableComHosting)' == 'true'">
     <GenerateClsidMap
         IntermediateAssembly="@(IntermediateAssembly->'%(FullPath)')"
         CLsidMapDestinationPath="@(ClsidMap->'%(FullPath)')" />
@@ -429,7 +429,7 @@ Copyright (c) .NET Foundation. All rights reserved.
           Inputs="@(ClsidMap);@(IntermediateAssembly)"
           Outputs="@(RegFreeComManifest)"
           Condition="'$(ComputeNETCoreBuildOutputFiles)' == 'true' and
-                     '$(UseComHost)' == 'true' and
+                     '$(EnableComHosting)' == 'true' and
                      '$(EnableRegFreeCom)' == 'true'">
     <GenerateRegFreeComManifest
       IntermediateAssembly="@(IntermediateAssembly)"
@@ -448,7 +448,7 @@ Copyright (c) .NET Foundation. All rights reserved.
      -->
   <Target Name="_GetComHostPaths"
           DependsOnTargets="ResolvePackageAssets"
-          Condition="'$(UseComHost)' == 'true' and '$(_IsExecutable)' != 'true'">
+          Condition="'$(EnableComHosting)' == 'true' and '$(_IsExecutable)' != 'true'">
     <PropertyGroup>
       <ComHostFileName>$(AssemblyName).comhost$(_ComHostLibraryExtension)</ComHostFileName>
       <ComHostIntermediatePath>$([System.IO.Path]::GetFullPath('$(IntermediateOutputPath)$(ComHostFileName)'))</ComHostIntermediatePath>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -37,6 +37,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   </PropertyGroup>
 
   <PropertyGroup>
+    <IsComponent Condition="'$(IsComponent)' == '' and '$(UseComHost)' == 'true'">true</IsComponent>
     <GenerateRuntimeConfigurationFiles Condition=" '$(GenerateRuntimeConfigurationFiles)' == '' and '$(TargetFrameworkIdentifier)' == '.NETCoreApp' and ('$(HasRuntimeOutput)' == 'true' or '$(UseComHost)' == 'true' or '$(IsComponent)' == 'true') ">true</GenerateRuntimeConfigurationFiles>
     <UserRuntimeConfig Condition=" '$(UserRuntimeConfig)' == '' ">$(MSBuildProjectDirectory)/runtimeconfig.template.json</UserRuntimeConfig>
     <GenerateSatelliteAssembliesForCore Condition=" '$(GenerateSatelliteAssembliesForCore)' == '' and '$(MSBuildRuntimeType)' == 'Core' ">true</GenerateSatelliteAssembliesForCore>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -37,7 +37,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   </PropertyGroup>
 
   <PropertyGroup>
-    <GenerateRuntimeConfigurationFiles Condition=" '$(GenerateRuntimeConfigurationFiles)' == '' and '$(TargetFrameworkIdentifier)' == '.NETCoreApp' and ('$(HasRuntimeOutput)' == 'true' or '$(UseComHost)' == 'true') ">true</GenerateRuntimeConfigurationFiles>
+    <GenerateRuntimeConfigurationFiles Condition=" '$(GenerateRuntimeConfigurationFiles)' == '' and '$(TargetFrameworkIdentifier)' == '.NETCoreApp' and ('$(HasRuntimeOutput)' == 'true' or '$(UseComHost)' == 'true' or '$(IsComponent)' == 'true') ">true</GenerateRuntimeConfigurationFiles>
     <UserRuntimeConfig Condition=" '$(UserRuntimeConfig)' == '' ">$(MSBuildProjectDirectory)/runtimeconfig.template.json</UserRuntimeConfig>
     <GenerateSatelliteAssembliesForCore Condition=" '$(GenerateSatelliteAssembliesForCore)' == '' and '$(MSBuildRuntimeType)' == 'Core' ">true</GenerateSatelliteAssembliesForCore>
     <ComputeNETCoreBuildOutputFiles Condition=" '$(ComputeNETCoreBuildOutputFiles)' == '' and '$(TargetFrameworkIdentifier)' == '.NETCoreApp'">true</ComputeNETCoreBuildOutputFiles>
@@ -191,7 +191,12 @@ Copyright (c) .NET Foundation. All rights reserved.
           Inputs="@(GenerateRuntimeConfigurationFilesInputs)"
           Outputs="$(ProjectRuntimeConfigFilePath);$(ProjectRuntimeConfigDevFilePath)">
 
-    <NETSdkError Condition="'$(RollForward)' != '' and '$(_TargetFrameworkVersionWithoutV)' &lt; '3.0'"
+    <PropertyGroup>
+      <_IsRollForwardSupported Condition="'$(_TargetFrameworkVersionWithoutV)' &gt;= '3.0'">true</_IsRollForwardSupported>
+      <RollForward Condition="'$(RollForward)' == '' and '$(IsComponent)' == 'true' and '$(_IsRollForwardSupported)' == 'true'">LatestMinor</RollForward>
+    </PropertyGroup>
+
+    <NETSdkError Condition="'$(RollForward)' != '' and '$(_IsRollForwardSupported)' != 'true'"
                  ResourceName="RollForwardRequiresVersion30"/>
 
     <GenerateRuntimeConfigurationFiles AssetsFilePath="$(ProjectAssetsFile)"

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.PackageDependencyResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.PackageDependencyResolution.targets
@@ -32,11 +32,11 @@ Copyright (c) .NET Foundation. All rights reserved.
     <CopyLocalLockFileAssemblies Condition="'$(CopyLocalLockFileAssemblies)' == '' and
                                             '$(TargetFrameworkIdentifier)' == '.NETStandard'">false</CopyLocalLockFileAssemblies>
 
-    <!-- Don't copy local for netcoreapp projects before 3.0 or non-exe projects. -->
+    <!-- Don't copy local for netcoreapp projects before 3.0 or non-exe and non-component projects. -->
     <CopyLocalLockFileAssemblies Condition="'$(CopyLocalLockFileAssemblies)' == '' and
                                             '$(TargetFrameworkIdentifier)' == '.NETCoreApp' and
                                             ('$(_TargetFrameworkVersionWithoutV)' &lt; '3.0' or
-                                             '$(HasRuntimeOutput)' != 'true')">false</CopyLocalLockFileAssemblies>
+                                             ('$(HasRuntimeOutput)' != 'true' and '$(IsComponent)' != 'true'))">false</CopyLocalLockFileAssemblies>
 
     <!-- All other project types should copy local. -->
     <CopyLocalLockFileAssemblies Condition="'$(CopyLocalLockFileAssemblies)' == ''">true</CopyLocalLockFileAssemblies>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.PackageDependencyResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.PackageDependencyResolution.targets
@@ -36,7 +36,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <CopyLocalLockFileAssemblies Condition="'$(CopyLocalLockFileAssemblies)' == '' and
                                             '$(TargetFrameworkIdentifier)' == '.NETCoreApp' and
                                             ('$(_TargetFrameworkVersionWithoutV)' &lt; '3.0' or
-                                             ('$(HasRuntimeOutput)' != 'true' and '$(IsComponent)' != 'true'))">false</CopyLocalLockFileAssemblies>
+                                             ('$(HasRuntimeOutput)' != 'true' and '$(EnableDynamicLoading)' != 'true'))">false</CopyLocalLockFileAssemblies>
 
     <!-- All other project types should copy local. -->
     <CopyLocalLockFileAssemblies Condition="'$(CopyLocalLockFileAssemblies)' == ''">true</CopyLocalLockFileAssemblies>

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAComServerLibrary.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAComServerLibrary.cs
@@ -1,17 +1,15 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text;
 using System.Xml.Linq;
 using FluentAssertions;
 using Microsoft.DotNet.PlatformAbstractions;
 using Microsoft.NET.TestFramework;
 using Microsoft.NET.TestFramework.Assertions;
 using Microsoft.NET.TestFramework.Commands;
+using Newtonsoft.Json.Linq;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -47,6 +45,12 @@ namespace Microsoft.NET.Build.Tests
                 "ComServer.runtimeconfig.json",
                 "ComServer.runtimeconfig.dev.json"
             });
+
+            string runtimeConfigFile = Path.Combine(outputDirectory.FullName, "ComServer.runtimeconfig.json");
+            string runtimeConfigContents = File.ReadAllText(runtimeConfigFile);
+            JObject runtimeConfig = JObject.Parse(runtimeConfigContents);
+            runtimeConfig["runtimeOptions"]["rollForward"].Value<string>()
+                .Should().Be("LatestMinor");
         }
 
 

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAComServerLibrary.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAComServerLibrary.cs
@@ -53,7 +53,6 @@ namespace Microsoft.NET.Build.Tests
                 .Should().Be("LatestMinor");
         }
 
-
         [WindowsOnlyFact]
         public void It_generates_a_regfree_com_manifest_when_requested()
         {

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildALibrary.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildALibrary.cs
@@ -663,16 +663,16 @@ namespace Microsoft.NET.Build.Tests
         [InlineData("netcoreapp3.0", "LatestMajor", true, null, true)]
         [InlineData("netcoreapp3.0", null, true, false, false)]
         [InlineData("netcoreapp3.0", "LatestMajor", true, false, false)]
-        public void It_can_build_as_a_component(string targetFramework, string rollForwardValue, bool shouldSetRollForward, bool? copyLocal, bool shouldCopyLocal)
+        public void It_can_build_with_dynamic_loading_enabled(string targetFramework, string rollForwardValue, bool shouldSetRollForward, bool? copyLocal, bool shouldCopyLocal)
         {
             var testProject = new TestProject()
             {
-                Name = "BuildAsComponent",
+                Name = "EnableDynamicLoading",
                 TargetFrameworks = targetFramework,
                 IsSdkProject = true
             };
 
-            testProject.AdditionalProperties["IsComponent"] = "true";
+            testProject.AdditionalProperties["EnableDynamicLoading"] = "true";
             if (!string.IsNullOrEmpty(rollForwardValue))
             {
                 testProject.AdditionalProperties["RollForward"] = rollForwardValue;


### PR DESCRIPTION
SDK support for the hosting scenario of loading a managed component and calling into it from a native application: https://github.com/dotnet/core-setup/blob/master/Documentation/design-docs/native-hosting.md#scenarios. This hosting scenario requires a `runtimeconfig.json` file and our recommendation for components is to have a less restrictive `rollForward` setting.

Setting `IsComponent=true` should result in:
- `.runtimeconfig.json` being generated
- `rollForward` being set to `LatestMinor` by default