### PR TITLE
Fix P/Invoke signatures for the resource updater.

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResourceUpdater.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResourceUpdater.cs
@@ -21,7 +21,7 @@ namespace Microsoft.NET.Build.Tasks
             // Native methods for updating resources
             //
 
-            [DllImport(nameof(Kernel32), SetLastError=true)]
+            [DllImport(nameof(Kernel32), CharSet = CharSet.Unicode, SetLastError=true)]
             public static extern SafeUpdateHandle BeginUpdateResource(string pFileName,
                                                                       [MarshalAs(UnmanagedType.Bool)]bool bDeleteExistingResources);
 
@@ -71,7 +71,7 @@ namespace Microsoft.NET.Build.Tasks
                 LOAD_LIBRARY_AS_IMAGE_RESOURCE = 0x00000020
             }
 
-            [DllImport(nameof(Kernel32), SetLastError=true)]
+            [DllImport(nameof(Kernel32), CharSet = CharSet.Unicode, SetLastError=true)]
             public static extern IntPtr LoadLibraryEx(string lpFileName,
                                                       IntPtr hReservedNull,
                                                       LoadLibraryFlags dwFlags);

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildANetCoreApp.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildANetCoreApp.cs
@@ -696,8 +696,29 @@ class Program
             packageReferences
                 .Should()
                 .BeEmpty();
+        }
 
+        [WindowsOnlyFact]
+        public void It_builds_with_unicode_characters_in_path()
+        {
+            var testProject = new TestProject()
+            {
+                Name = "Prj_すおヸょー",
+                TargetFrameworks = "netcoreapp3.0",
+                IsSdkProject = true,
+                IsExe = true,
+            };
 
+            var testAsset = _testAssetsManager
+                .CreateTestProject(testProject)
+                .Restore(Log, testProject.Name);
+
+            var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+
+            buildCommand
+                .Execute()
+                .Should()
+                .Pass();
         }
     }
 }


### PR DESCRIPTION
The resource updater was not specifying a CharSet for the Windows API
P/Invoke signatures and therefore the ANSI versions of the APIs were
being used.

This caused an unhandled exception when customizing the apphost on
Windows when the intermediate apphost path contained Unicode characters
because the ANSI resource updating API couldn't find the file.

Fixes [AB#900429](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/900429).