### PR TITLE
Add warnings related to Microsoft.NET.Sdk.WindowsDesktop

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "3.0.100-preview7-012270",
+    "dotnet": "3.0.100-preview7-012402",
     "vs-opt": {
       "version": "15.9"
     }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "3.0.100-preview7-012386",
+    "dotnet": "3.0.100-preview7-012390",
     "vs-opt": {
       "version": "15.9"
     }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "3.0.100-preview7-012270",
+    "dotnet": "3.0.100-preview7-012386",
     "vs-opt": {
       "version": "15.9"
     }

--- a/src/Tasks/Common/Resources/Strings.resx
+++ b/src/Tasks/Common/Resources/Strings.resx
@@ -538,4 +538,16 @@ The following are names of parameters or literal values and should not be transl
     <value>NETSDK1104: RollForward value '{0}' is invalid. Allowed values are {1}.</value>
     <comment>{StrBegin="NETSDK1104: "}</comment>
   </data>
+  <data name="WindowsDesktopFrameworkRequiresVersion30" xml:space="preserve">
+    <value>NETSDK1105: Windows desktop applications are only supported on .NET Core 3.0 or higher.</value>
+    <comment>{StrBegin="NETSDK1105: "}</comment>
+  </data>
+  <data name="UseWpfOrUseWindowsFormsRequiresWindowsDesktopFramework" xml:space="preserve">
+    <value>NETSDK1107: Microsoft.NET.Sdk.WindowsDesktop is required to build Windows desktop applications. 'UseWpf' and 'UseWindowsForms' are not supported by the current SDK.</value>
+    <comment>{StrBegin="NETSDK1107: "}</comment>
+  </data>
+  <data name="WindowsDesktopFrameworkRequiresUseWpfOrUseWindowsForms" xml:space="preserve">
+    <value>NETSDK1106: Microsoft.NET.Sdk.WindowsDesktop requires 'UseWpf' or 'UseWindowsForms' to be set to 'true'</value>
+    <comment>{StrBegin="NETSDK1106: "}</comment>
+  </data>
 </root>

--- a/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
@@ -516,10 +516,25 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1045: Aktuální sada .NET SDK nepodporuje cílení {0} {1}. Buď zacilte {0} {2} nebo nižší, nebo použijte verzi sady .NET SDK, která podporuje {0} {1}.</target>
         <note>{StrBegin="NETSDK1045: "}</note>
       </trans-unit>
+      <trans-unit id="UseWpfOrUseWindowsFormsRequiresWindowsDesktopFramework">
+        <source>NETSDK1107: Microsoft.NET.Sdk.WindowsDesktop is required to build Windows desktop applications. 'UseWpf' and 'UseWindowsForms' are not supported by the current SDK.</source>
+        <target state="new">NETSDK1107: Microsoft.NET.Sdk.WindowsDesktop is required to build Windows desktop applications. 'UseWpf' and 'UseWindowsForms' are not supported by the current SDK.</target>
+        <note>{StrBegin="NETSDK1107: "}</note>
+      </trans-unit>
       <trans-unit id="UsingPreviewSdkWarning">
         <source>NETSDK1057: You are using a preview version of .NET Core. See: https://aka.ms/dotnet-core-preview</source>
         <target state="translated">NETSDK1057: Používáte preview verzi .NET Core. Další informace: https://aka.ms/dotnet-core-preview</target>
         <note>{StrBegin="NETSDK1057: "}</note>
+      </trans-unit>
+      <trans-unit id="WindowsDesktopFrameworkRequiresUseWpfOrUseWindowsForms">
+        <source>NETSDK1106: Microsoft.NET.Sdk.WindowsDesktop requires 'UseWpf' or 'UseWindowsForms' to be set to 'true'</source>
+        <target state="new">NETSDK1106: Microsoft.NET.Sdk.WindowsDesktop requires 'UseWpf' or 'UseWindowsForms' to be set to 'true'</target>
+        <note>{StrBegin="NETSDK1106: "}</note>
+      </trans-unit>
+      <trans-unit id="WindowsDesktopFrameworkRequiresVersion30">
+        <source>NETSDK1105: Windows desktop applications are only supported on .NET Core 3.0 or higher.</source>
+        <target state="new">NETSDK1105: Windows desktop applications are only supported on .NET Core 3.0 or higher.</target>
+        <note>{StrBegin="NETSDK1105: "}</note>
       </trans-unit>
       <trans-unit id="WindowsDesktopFrameworkRequiresWindows">
         <source>NETSDK1100: Windows is required to build Windows desktop applications.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.de.xlf
@@ -516,10 +516,25 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1045: Das aktuelle .NET SDK unterstützt {0} {1} nicht als Ziel. Geben Sie entweder {0} {2} oder niedriger als Ziel an, oder verwenden Sie eine .NET SDK-Version, die {0} {1} unterstützt.</target>
         <note>{StrBegin="NETSDK1045: "}</note>
       </trans-unit>
+      <trans-unit id="UseWpfOrUseWindowsFormsRequiresWindowsDesktopFramework">
+        <source>NETSDK1107: Microsoft.NET.Sdk.WindowsDesktop is required to build Windows desktop applications. 'UseWpf' and 'UseWindowsForms' are not supported by the current SDK.</source>
+        <target state="new">NETSDK1107: Microsoft.NET.Sdk.WindowsDesktop is required to build Windows desktop applications. 'UseWpf' and 'UseWindowsForms' are not supported by the current SDK.</target>
+        <note>{StrBegin="NETSDK1107: "}</note>
+      </trans-unit>
       <trans-unit id="UsingPreviewSdkWarning">
         <source>NETSDK1057: You are using a preview version of .NET Core. See: https://aka.ms/dotnet-core-preview</source>
         <target state="translated">NETSDK1057: Sie verwenden eine Vorschauversion von .NET Core. Weitere Informationen: https://aka.ms/dotnet-core-preview</target>
         <note>{StrBegin="NETSDK1057: "}</note>
+      </trans-unit>
+      <trans-unit id="WindowsDesktopFrameworkRequiresUseWpfOrUseWindowsForms">
+        <source>NETSDK1106: Microsoft.NET.Sdk.WindowsDesktop requires 'UseWpf' or 'UseWindowsForms' to be set to 'true'</source>
+        <target state="new">NETSDK1106: Microsoft.NET.Sdk.WindowsDesktop requires 'UseWpf' or 'UseWindowsForms' to be set to 'true'</target>
+        <note>{StrBegin="NETSDK1106: "}</note>
+      </trans-unit>
+      <trans-unit id="WindowsDesktopFrameworkRequiresVersion30">
+        <source>NETSDK1105: Windows desktop applications are only supported on .NET Core 3.0 or higher.</source>
+        <target state="new">NETSDK1105: Windows desktop applications are only supported on .NET Core 3.0 or higher.</target>
+        <note>{StrBegin="NETSDK1105: "}</note>
       </trans-unit>
       <trans-unit id="WindowsDesktopFrameworkRequiresWindows">
         <source>NETSDK1100: Windows is required to build Windows desktop applications.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.es.xlf
@@ -516,10 +516,25 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1045: El SDK de .NET actual no admite el destino {0} {1}. Use el destino {0} {2} u otro inferior, o bien una versión del SDK de .NET que admita {0} {1}.</target>
         <note>{StrBegin="NETSDK1045: "}</note>
       </trans-unit>
+      <trans-unit id="UseWpfOrUseWindowsFormsRequiresWindowsDesktopFramework">
+        <source>NETSDK1107: Microsoft.NET.Sdk.WindowsDesktop is required to build Windows desktop applications. 'UseWpf' and 'UseWindowsForms' are not supported by the current SDK.</source>
+        <target state="new">NETSDK1107: Microsoft.NET.Sdk.WindowsDesktop is required to build Windows desktop applications. 'UseWpf' and 'UseWindowsForms' are not supported by the current SDK.</target>
+        <note>{StrBegin="NETSDK1107: "}</note>
+      </trans-unit>
       <trans-unit id="UsingPreviewSdkWarning">
         <source>NETSDK1057: You are using a preview version of .NET Core. See: https://aka.ms/dotnet-core-preview</source>
         <target state="translated">NETSDK1057: Está utilizando una versión preliminar de .NET Core. Vea: https://aka.ms/dotnet-core-preview</target>
         <note>{StrBegin="NETSDK1057: "}</note>
+      </trans-unit>
+      <trans-unit id="WindowsDesktopFrameworkRequiresUseWpfOrUseWindowsForms">
+        <source>NETSDK1106: Microsoft.NET.Sdk.WindowsDesktop requires 'UseWpf' or 'UseWindowsForms' to be set to 'true'</source>
+        <target state="new">NETSDK1106: Microsoft.NET.Sdk.WindowsDesktop requires 'UseWpf' or 'UseWindowsForms' to be set to 'true'</target>
+        <note>{StrBegin="NETSDK1106: "}</note>
+      </trans-unit>
+      <trans-unit id="WindowsDesktopFrameworkRequiresVersion30">
+        <source>NETSDK1105: Windows desktop applications are only supported on .NET Core 3.0 or higher.</source>
+        <target state="new">NETSDK1105: Windows desktop applications are only supported on .NET Core 3.0 or higher.</target>
+        <note>{StrBegin="NETSDK1105: "}</note>
       </trans-unit>
       <trans-unit id="WindowsDesktopFrameworkRequiresWindows">
         <source>NETSDK1100: Windows is required to build Windows desktop applications.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
@@ -516,10 +516,25 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1045: Le kit .NET SDK actuel ne prend pas en charge le ciblage de {0} {1}. Vous devez soit cibler {0} {2} ou une version antérieure, soit utiliser une version du kit .NET SDK qui prend en charge {0} {1}.</target>
         <note>{StrBegin="NETSDK1045: "}</note>
       </trans-unit>
+      <trans-unit id="UseWpfOrUseWindowsFormsRequiresWindowsDesktopFramework">
+        <source>NETSDK1107: Microsoft.NET.Sdk.WindowsDesktop is required to build Windows desktop applications. 'UseWpf' and 'UseWindowsForms' are not supported by the current SDK.</source>
+        <target state="new">NETSDK1107: Microsoft.NET.Sdk.WindowsDesktop is required to build Windows desktop applications. 'UseWpf' and 'UseWindowsForms' are not supported by the current SDK.</target>
+        <note>{StrBegin="NETSDK1107: "}</note>
+      </trans-unit>
       <trans-unit id="UsingPreviewSdkWarning">
         <source>NETSDK1057: You are using a preview version of .NET Core. See: https://aka.ms/dotnet-core-preview</source>
         <target state="translated">NETSDK1057 : Vous utilisez une préversion de .NET Core. Voir : https://aka.ms/dotnet-core-preview</target>
         <note>{StrBegin="NETSDK1057: "}</note>
+      </trans-unit>
+      <trans-unit id="WindowsDesktopFrameworkRequiresUseWpfOrUseWindowsForms">
+        <source>NETSDK1106: Microsoft.NET.Sdk.WindowsDesktop requires 'UseWpf' or 'UseWindowsForms' to be set to 'true'</source>
+        <target state="new">NETSDK1106: Microsoft.NET.Sdk.WindowsDesktop requires 'UseWpf' or 'UseWindowsForms' to be set to 'true'</target>
+        <note>{StrBegin="NETSDK1106: "}</note>
+      </trans-unit>
+      <trans-unit id="WindowsDesktopFrameworkRequiresVersion30">
+        <source>NETSDK1105: Windows desktop applications are only supported on .NET Core 3.0 or higher.</source>
+        <target state="new">NETSDK1105: Windows desktop applications are only supported on .NET Core 3.0 or higher.</target>
+        <note>{StrBegin="NETSDK1105: "}</note>
       </trans-unit>
       <trans-unit id="WindowsDesktopFrameworkRequiresWindows">
         <source>NETSDK1100: Windows is required to build Windows desktop applications.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.it.xlf
@@ -516,10 +516,25 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1045: la versione corrente di .NET SDK non supporta {0} {1} come destinazione. Impostare come destinazione {0} {2} o una versione precedente oppure usare una versione di .NET SDK che supporta {0} {1}.</target>
         <note>{StrBegin="NETSDK1045: "}</note>
       </trans-unit>
+      <trans-unit id="UseWpfOrUseWindowsFormsRequiresWindowsDesktopFramework">
+        <source>NETSDK1107: Microsoft.NET.Sdk.WindowsDesktop is required to build Windows desktop applications. 'UseWpf' and 'UseWindowsForms' are not supported by the current SDK.</source>
+        <target state="new">NETSDK1107: Microsoft.NET.Sdk.WindowsDesktop is required to build Windows desktop applications. 'UseWpf' and 'UseWindowsForms' are not supported by the current SDK.</target>
+        <note>{StrBegin="NETSDK1107: "}</note>
+      </trans-unit>
       <trans-unit id="UsingPreviewSdkWarning">
         <source>NETSDK1057: You are using a preview version of .NET Core. See: https://aka.ms/dotnet-core-preview</source>
         <target state="translated">NETSDK1057: si sta usando una versione in anteprima di .NET Core. Vedere https://aka.ms/dotnet-core-preview</target>
         <note>{StrBegin="NETSDK1057: "}</note>
+      </trans-unit>
+      <trans-unit id="WindowsDesktopFrameworkRequiresUseWpfOrUseWindowsForms">
+        <source>NETSDK1106: Microsoft.NET.Sdk.WindowsDesktop requires 'UseWpf' or 'UseWindowsForms' to be set to 'true'</source>
+        <target state="new">NETSDK1106: Microsoft.NET.Sdk.WindowsDesktop requires 'UseWpf' or 'UseWindowsForms' to be set to 'true'</target>
+        <note>{StrBegin="NETSDK1106: "}</note>
+      </trans-unit>
+      <trans-unit id="WindowsDesktopFrameworkRequiresVersion30">
+        <source>NETSDK1105: Windows desktop applications are only supported on .NET Core 3.0 or higher.</source>
+        <target state="new">NETSDK1105: Windows desktop applications are only supported on .NET Core 3.0 or higher.</target>
+        <note>{StrBegin="NETSDK1105: "}</note>
       </trans-unit>
       <trans-unit id="WindowsDesktopFrameworkRequiresWindows">
         <source>NETSDK1100: Windows is required to build Windows desktop applications.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
@@ -516,10 +516,25 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1045: 現在の .NET SDK は、ターゲットとする {0} {1} をサポートしていません。{0} {2} 以下をターゲットとするか、{0} {1} をサポートする .NET SDK のバージョンを使用してください。</target>
         <note>{StrBegin="NETSDK1045: "}</note>
       </trans-unit>
+      <trans-unit id="UseWpfOrUseWindowsFormsRequiresWindowsDesktopFramework">
+        <source>NETSDK1107: Microsoft.NET.Sdk.WindowsDesktop is required to build Windows desktop applications. 'UseWpf' and 'UseWindowsForms' are not supported by the current SDK.</source>
+        <target state="new">NETSDK1107: Microsoft.NET.Sdk.WindowsDesktop is required to build Windows desktop applications. 'UseWpf' and 'UseWindowsForms' are not supported by the current SDK.</target>
+        <note>{StrBegin="NETSDK1107: "}</note>
+      </trans-unit>
       <trans-unit id="UsingPreviewSdkWarning">
         <source>NETSDK1057: You are using a preview version of .NET Core. See: https://aka.ms/dotnet-core-preview</source>
         <target state="translated">NETSDK1057: プレビュー版の .NET Core を使用しています。https://aka.ms/dotnet-core-preview をご覧ください</target>
         <note>{StrBegin="NETSDK1057: "}</note>
+      </trans-unit>
+      <trans-unit id="WindowsDesktopFrameworkRequiresUseWpfOrUseWindowsForms">
+        <source>NETSDK1106: Microsoft.NET.Sdk.WindowsDesktop requires 'UseWpf' or 'UseWindowsForms' to be set to 'true'</source>
+        <target state="new">NETSDK1106: Microsoft.NET.Sdk.WindowsDesktop requires 'UseWpf' or 'UseWindowsForms' to be set to 'true'</target>
+        <note>{StrBegin="NETSDK1106: "}</note>
+      </trans-unit>
+      <trans-unit id="WindowsDesktopFrameworkRequiresVersion30">
+        <source>NETSDK1105: Windows desktop applications are only supported on .NET Core 3.0 or higher.</source>
+        <target state="new">NETSDK1105: Windows desktop applications are only supported on .NET Core 3.0 or higher.</target>
+        <note>{StrBegin="NETSDK1105: "}</note>
       </trans-unit>
       <trans-unit id="WindowsDesktopFrameworkRequiresWindows">
         <source>NETSDK1100: Windows is required to build Windows desktop applications.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
@@ -516,10 +516,25 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1045: 현재 .NET SDK에서는 {0} {1}을(를) 대상으로 하는 것을 지원하지 않습니다. {0} {2} 이하를 대상으로 하거나 {0} {1}을(를) 지원하는 .NET SDK 버전을 사용하세요.</target>
         <note>{StrBegin="NETSDK1045: "}</note>
       </trans-unit>
+      <trans-unit id="UseWpfOrUseWindowsFormsRequiresWindowsDesktopFramework">
+        <source>NETSDK1107: Microsoft.NET.Sdk.WindowsDesktop is required to build Windows desktop applications. 'UseWpf' and 'UseWindowsForms' are not supported by the current SDK.</source>
+        <target state="new">NETSDK1107: Microsoft.NET.Sdk.WindowsDesktop is required to build Windows desktop applications. 'UseWpf' and 'UseWindowsForms' are not supported by the current SDK.</target>
+        <note>{StrBegin="NETSDK1107: "}</note>
+      </trans-unit>
       <trans-unit id="UsingPreviewSdkWarning">
         <source>NETSDK1057: You are using a preview version of .NET Core. See: https://aka.ms/dotnet-core-preview</source>
         <target state="translated">NETSDK1057: .NET Core의 미리 보기 버전을 사용 중입니다. 참조: https://aka.ms/dotnet-core-preview</target>
         <note>{StrBegin="NETSDK1057: "}</note>
+      </trans-unit>
+      <trans-unit id="WindowsDesktopFrameworkRequiresUseWpfOrUseWindowsForms">
+        <source>NETSDK1106: Microsoft.NET.Sdk.WindowsDesktop requires 'UseWpf' or 'UseWindowsForms' to be set to 'true'</source>
+        <target state="new">NETSDK1106: Microsoft.NET.Sdk.WindowsDesktop requires 'UseWpf' or 'UseWindowsForms' to be set to 'true'</target>
+        <note>{StrBegin="NETSDK1106: "}</note>
+      </trans-unit>
+      <trans-unit id="WindowsDesktopFrameworkRequiresVersion30">
+        <source>NETSDK1105: Windows desktop applications are only supported on .NET Core 3.0 or higher.</source>
+        <target state="new">NETSDK1105: Windows desktop applications are only supported on .NET Core 3.0 or higher.</target>
+        <note>{StrBegin="NETSDK1105: "}</note>
       </trans-unit>
       <trans-unit id="WindowsDesktopFrameworkRequiresWindows">
         <source>NETSDK1100: Windows is required to build Windows desktop applications.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
@@ -516,10 +516,25 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1045: Bieżący zestaw .NET SDK nie obsługuje używania środowiska docelowego {0} {1}. Użyj jako środowiska docelowego wersji {0} {2} lub starszej albo użyj wersji zestawu .NET SDK obsługującej środowisko {0} {1}.</target>
         <note>{StrBegin="NETSDK1045: "}</note>
       </trans-unit>
+      <trans-unit id="UseWpfOrUseWindowsFormsRequiresWindowsDesktopFramework">
+        <source>NETSDK1107: Microsoft.NET.Sdk.WindowsDesktop is required to build Windows desktop applications. 'UseWpf' and 'UseWindowsForms' are not supported by the current SDK.</source>
+        <target state="new">NETSDK1107: Microsoft.NET.Sdk.WindowsDesktop is required to build Windows desktop applications. 'UseWpf' and 'UseWindowsForms' are not supported by the current SDK.</target>
+        <note>{StrBegin="NETSDK1107: "}</note>
+      </trans-unit>
       <trans-unit id="UsingPreviewSdkWarning">
         <source>NETSDK1057: You are using a preview version of .NET Core. See: https://aka.ms/dotnet-core-preview</source>
         <target state="translated">NETSDK1057: Korzystasz z wersji zapoznawczej platformy .NET Core. Zobacz: https://aka.ms/dotnet-core-preview</target>
         <note>{StrBegin="NETSDK1057: "}</note>
+      </trans-unit>
+      <trans-unit id="WindowsDesktopFrameworkRequiresUseWpfOrUseWindowsForms">
+        <source>NETSDK1106: Microsoft.NET.Sdk.WindowsDesktop requires 'UseWpf' or 'UseWindowsForms' to be set to 'true'</source>
+        <target state="new">NETSDK1106: Microsoft.NET.Sdk.WindowsDesktop requires 'UseWpf' or 'UseWindowsForms' to be set to 'true'</target>
+        <note>{StrBegin="NETSDK1106: "}</note>
+      </trans-unit>
+      <trans-unit id="WindowsDesktopFrameworkRequiresVersion30">
+        <source>NETSDK1105: Windows desktop applications are only supported on .NET Core 3.0 or higher.</source>
+        <target state="new">NETSDK1105: Windows desktop applications are only supported on .NET Core 3.0 or higher.</target>
+        <note>{StrBegin="NETSDK1105: "}</note>
       </trans-unit>
       <trans-unit id="WindowsDesktopFrameworkRequiresWindows">
         <source>NETSDK1100: Windows is required to build Windows desktop applications.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
@@ -516,10 +516,25 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1045: O SDK do .NET atual não dá suporte para direcionar a {0} {1}. Direcione a {0} {2} ou inferior, ou use uma versão do SDK do .NET compatível com  {0} {1}.</target>
         <note>{StrBegin="NETSDK1045: "}</note>
       </trans-unit>
+      <trans-unit id="UseWpfOrUseWindowsFormsRequiresWindowsDesktopFramework">
+        <source>NETSDK1107: Microsoft.NET.Sdk.WindowsDesktop is required to build Windows desktop applications. 'UseWpf' and 'UseWindowsForms' are not supported by the current SDK.</source>
+        <target state="new">NETSDK1107: Microsoft.NET.Sdk.WindowsDesktop is required to build Windows desktop applications. 'UseWpf' and 'UseWindowsForms' are not supported by the current SDK.</target>
+        <note>{StrBegin="NETSDK1107: "}</note>
+      </trans-unit>
       <trans-unit id="UsingPreviewSdkWarning">
         <source>NETSDK1057: You are using a preview version of .NET Core. See: https://aka.ms/dotnet-core-preview</source>
         <target state="translated">NETSDK1057: você está usando uma versão prévia do .NET Core. Consulte: https://aka.ms/dotnet-core-preview</target>
         <note>{StrBegin="NETSDK1057: "}</note>
+      </trans-unit>
+      <trans-unit id="WindowsDesktopFrameworkRequiresUseWpfOrUseWindowsForms">
+        <source>NETSDK1106: Microsoft.NET.Sdk.WindowsDesktop requires 'UseWpf' or 'UseWindowsForms' to be set to 'true'</source>
+        <target state="new">NETSDK1106: Microsoft.NET.Sdk.WindowsDesktop requires 'UseWpf' or 'UseWindowsForms' to be set to 'true'</target>
+        <note>{StrBegin="NETSDK1106: "}</note>
+      </trans-unit>
+      <trans-unit id="WindowsDesktopFrameworkRequiresVersion30">
+        <source>NETSDK1105: Windows desktop applications are only supported on .NET Core 3.0 or higher.</source>
+        <target state="new">NETSDK1105: Windows desktop applications are only supported on .NET Core 3.0 or higher.</target>
+        <note>{StrBegin="NETSDK1105: "}</note>
       </trans-unit>
       <trans-unit id="WindowsDesktopFrameworkRequiresWindows">
         <source>NETSDK1100: Windows is required to build Windows desktop applications.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
@@ -516,10 +516,25 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1045: текущий пакет SDK для .NET не поддерживает целевой объект {0} {1}. Выберите {0} {2} или более раннюю версию либо используйте версию пакета SDK для .NET, которая поддерживает {0} {1}.</target>
         <note>{StrBegin="NETSDK1045: "}</note>
       </trans-unit>
+      <trans-unit id="UseWpfOrUseWindowsFormsRequiresWindowsDesktopFramework">
+        <source>NETSDK1107: Microsoft.NET.Sdk.WindowsDesktop is required to build Windows desktop applications. 'UseWpf' and 'UseWindowsForms' are not supported by the current SDK.</source>
+        <target state="new">NETSDK1107: Microsoft.NET.Sdk.WindowsDesktop is required to build Windows desktop applications. 'UseWpf' and 'UseWindowsForms' are not supported by the current SDK.</target>
+        <note>{StrBegin="NETSDK1107: "}</note>
+      </trans-unit>
       <trans-unit id="UsingPreviewSdkWarning">
         <source>NETSDK1057: You are using a preview version of .NET Core. See: https://aka.ms/dotnet-core-preview</source>
         <target state="translated">NETSDK1057: Вы используете предварительную версию .NET Core. Дополнительные сведения см. на странице https://aka.ms/dotnet-core-preview</target>
         <note>{StrBegin="NETSDK1057: "}</note>
+      </trans-unit>
+      <trans-unit id="WindowsDesktopFrameworkRequiresUseWpfOrUseWindowsForms">
+        <source>NETSDK1106: Microsoft.NET.Sdk.WindowsDesktop requires 'UseWpf' or 'UseWindowsForms' to be set to 'true'</source>
+        <target state="new">NETSDK1106: Microsoft.NET.Sdk.WindowsDesktop requires 'UseWpf' or 'UseWindowsForms' to be set to 'true'</target>
+        <note>{StrBegin="NETSDK1106: "}</note>
+      </trans-unit>
+      <trans-unit id="WindowsDesktopFrameworkRequiresVersion30">
+        <source>NETSDK1105: Windows desktop applications are only supported on .NET Core 3.0 or higher.</source>
+        <target state="new">NETSDK1105: Windows desktop applications are only supported on .NET Core 3.0 or higher.</target>
+        <note>{StrBegin="NETSDK1105: "}</note>
       </trans-unit>
       <trans-unit id="WindowsDesktopFrameworkRequiresWindows">
         <source>NETSDK1100: Windows is required to build Windows desktop applications.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
@@ -516,10 +516,25 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1045: Geçerli .NET SDK’sı {0} {1} sürümünü hedeflemeyi desteklemiyor. {0} {2} veya daha düşük bir sürümü hedefleyin veya {0} {1} destekleyen bir .NET SDK’sı kullanın.</target>
         <note>{StrBegin="NETSDK1045: "}</note>
       </trans-unit>
+      <trans-unit id="UseWpfOrUseWindowsFormsRequiresWindowsDesktopFramework">
+        <source>NETSDK1107: Microsoft.NET.Sdk.WindowsDesktop is required to build Windows desktop applications. 'UseWpf' and 'UseWindowsForms' are not supported by the current SDK.</source>
+        <target state="new">NETSDK1107: Microsoft.NET.Sdk.WindowsDesktop is required to build Windows desktop applications. 'UseWpf' and 'UseWindowsForms' are not supported by the current SDK.</target>
+        <note>{StrBegin="NETSDK1107: "}</note>
+      </trans-unit>
       <trans-unit id="UsingPreviewSdkWarning">
         <source>NETSDK1057: You are using a preview version of .NET Core. See: https://aka.ms/dotnet-core-preview</source>
         <target state="translated">NETSDK1057: .NET Core'un önizleme sürümünü kullanıyorsunuz. Bkz. https://aka.ms/dotnet-core-preview</target>
         <note>{StrBegin="NETSDK1057: "}</note>
+      </trans-unit>
+      <trans-unit id="WindowsDesktopFrameworkRequiresUseWpfOrUseWindowsForms">
+        <source>NETSDK1106: Microsoft.NET.Sdk.WindowsDesktop requires 'UseWpf' or 'UseWindowsForms' to be set to 'true'</source>
+        <target state="new">NETSDK1106: Microsoft.NET.Sdk.WindowsDesktop requires 'UseWpf' or 'UseWindowsForms' to be set to 'true'</target>
+        <note>{StrBegin="NETSDK1106: "}</note>
+      </trans-unit>
+      <trans-unit id="WindowsDesktopFrameworkRequiresVersion30">
+        <source>NETSDK1105: Windows desktop applications are only supported on .NET Core 3.0 or higher.</source>
+        <target state="new">NETSDK1105: Windows desktop applications are only supported on .NET Core 3.0 or higher.</target>
+        <note>{StrBegin="NETSDK1105: "}</note>
       </trans-unit>
       <trans-unit id="WindowsDesktopFrameworkRequiresWindows">
         <source>NETSDK1100: Windows is required to build Windows desktop applications.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
@@ -516,10 +516,25 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1045: 当前 .NET SDK 不支持将 {0} {1} 设置为目标。请将 {0} {2} 或更低版本设置为目标，或使用支持 {0} {1} 的 .NET SDK 版本。</target>
         <note>{StrBegin="NETSDK1045: "}</note>
       </trans-unit>
+      <trans-unit id="UseWpfOrUseWindowsFormsRequiresWindowsDesktopFramework">
+        <source>NETSDK1107: Microsoft.NET.Sdk.WindowsDesktop is required to build Windows desktop applications. 'UseWpf' and 'UseWindowsForms' are not supported by the current SDK.</source>
+        <target state="new">NETSDK1107: Microsoft.NET.Sdk.WindowsDesktop is required to build Windows desktop applications. 'UseWpf' and 'UseWindowsForms' are not supported by the current SDK.</target>
+        <note>{StrBegin="NETSDK1107: "}</note>
+      </trans-unit>
       <trans-unit id="UsingPreviewSdkWarning">
         <source>NETSDK1057: You are using a preview version of .NET Core. See: https://aka.ms/dotnet-core-preview</source>
         <target state="translated">NETSDK1057: 你正在使用 .NET Core 的预览版。请查看 https://aka.ms/dotnet-core-preview</target>
         <note>{StrBegin="NETSDK1057: "}</note>
+      </trans-unit>
+      <trans-unit id="WindowsDesktopFrameworkRequiresUseWpfOrUseWindowsForms">
+        <source>NETSDK1106: Microsoft.NET.Sdk.WindowsDesktop requires 'UseWpf' or 'UseWindowsForms' to be set to 'true'</source>
+        <target state="new">NETSDK1106: Microsoft.NET.Sdk.WindowsDesktop requires 'UseWpf' or 'UseWindowsForms' to be set to 'true'</target>
+        <note>{StrBegin="NETSDK1106: "}</note>
+      </trans-unit>
+      <trans-unit id="WindowsDesktopFrameworkRequiresVersion30">
+        <source>NETSDK1105: Windows desktop applications are only supported on .NET Core 3.0 or higher.</source>
+        <target state="new">NETSDK1105: Windows desktop applications are only supported on .NET Core 3.0 or higher.</target>
+        <note>{StrBegin="NETSDK1105: "}</note>
       </trans-unit>
       <trans-unit id="WindowsDesktopFrameworkRequiresWindows">
         <source>NETSDK1100: Windows is required to build Windows desktop applications.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
@@ -516,10 +516,25 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1045: 目前的 .NET SDK 不支援以 {0} {1} 作為目標。請以 {0} {2} 或更低版本作為目標，或是使用支援 {0} {1} 的 .NET SDK 版本。</target>
         <note>{StrBegin="NETSDK1045: "}</note>
       </trans-unit>
+      <trans-unit id="UseWpfOrUseWindowsFormsRequiresWindowsDesktopFramework">
+        <source>NETSDK1107: Microsoft.NET.Sdk.WindowsDesktop is required to build Windows desktop applications. 'UseWpf' and 'UseWindowsForms' are not supported by the current SDK.</source>
+        <target state="new">NETSDK1107: Microsoft.NET.Sdk.WindowsDesktop is required to build Windows desktop applications. 'UseWpf' and 'UseWindowsForms' are not supported by the current SDK.</target>
+        <note>{StrBegin="NETSDK1107: "}</note>
+      </trans-unit>
       <trans-unit id="UsingPreviewSdkWarning">
         <source>NETSDK1057: You are using a preview version of .NET Core. See: https://aka.ms/dotnet-core-preview</source>
         <target state="translated">NETSDK1057: 您使用的是 .NET Core 預覽版。請參閱: https://aka.ms/dotnet-core-preview</target>
         <note>{StrBegin="NETSDK1057: "}</note>
+      </trans-unit>
+      <trans-unit id="WindowsDesktopFrameworkRequiresUseWpfOrUseWindowsForms">
+        <source>NETSDK1106: Microsoft.NET.Sdk.WindowsDesktop requires 'UseWpf' or 'UseWindowsForms' to be set to 'true'</source>
+        <target state="new">NETSDK1106: Microsoft.NET.Sdk.WindowsDesktop requires 'UseWpf' or 'UseWindowsForms' to be set to 'true'</target>
+        <note>{StrBegin="NETSDK1106: "}</note>
+      </trans-unit>
+      <trans-unit id="WindowsDesktopFrameworkRequiresVersion30">
+        <source>NETSDK1105: Windows desktop applications are only supported on .NET Core 3.0 or higher.</source>
+        <target state="new">NETSDK1105: Windows desktop applications are only supported on .NET Core 3.0 or higher.</target>
+        <note>{StrBegin="NETSDK1105: "}</note>
       </trans-unit>
       <trans-unit id="WindowsDesktopFrameworkRequiresWindows">
         <source>NETSDK1100: Windows is required to build Windows desktop applications.</source>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/PrepareForReadyToRunCompilation.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/PrepareForReadyToRunCompilation.cs
@@ -69,7 +69,9 @@ namespace Microsoft.NET.Build.Tasks
             string supportedRuntimeIdentifiers = frameworkRef == null ? null : frameworkRef.GetMetadata("RuntimePackRuntimeIdentifiers");
 
             // Get information on the runtime package used for the current target
-            ITaskItem frameworkPack = RuntimePacks.Where(pack => pack.ItemSpec.EndsWith(".Microsoft.NETCore.App", StringComparison.InvariantCultureIgnoreCase)).SingleOrDefault();
+            ITaskItem frameworkPack = RuntimePacks.Where(pack => 
+                    pack.GetMetadata(MetadataKeys.FrameworkName).Equals("Microsoft.NETCore.App", StringComparison.OrdinalIgnoreCase))
+                .SingleOrDefault();
             _runtimeIdentifier = frameworkPack == null ? null : frameworkPack.GetMetadata(MetadataKeys.RuntimeIdentifier);
             _packagePath = frameworkPack == null ? null : frameworkPack.GetMetadata(MetadataKeys.PackageDirectory);
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageAssets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageAssets.cs
@@ -373,7 +373,6 @@ namespace Microsoft.NET.Build.Tasks
             {
                 using (var writer = new BinaryWriter(stream, TextEncoding, leaveOpen: true))
                 {
-                    writer.Write(DesignTimeBuild);
                     writer.Write(DisablePackageAssetsCache);
                     writer.Write(DisableFrameworkAssemblies);
                     writer.Write(CopyLocalRuntimeTargetAssets);

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.targets
@@ -333,4 +333,11 @@ Copyright (c) .NET Foundation. All rights reserved.
     </ItemGroup>
     
   </Target>
+
+  <Target Name="CheckWindowsDesktopSdkInUse" 
+          BeforeTargets="_CheckForInvalidConfigurationAndPlatform" 
+          Condition="'$(UseWpf)' == 'true' Or '$(UseWindowsForms)' == 'true'">
+    <NetSdkWarning Condition="'$(_MicrosoftNetSdkWindowsDesktop)' != 'true'" 
+                   ResourceName="UseWpfOrUseWindowsFormsRequiresWindowsDesktopFramework" />
+  </Target>
 </Project>

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenFrameworkReferences.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenFrameworkReferences.cs
@@ -396,7 +396,7 @@ namespace FrameworkReferenceTest
             resolvedVersions.RuntimeFramework["Microsoft.NETCore.App"].Should().Be(runtimeFrameworkVersion);
             resolvedVersions.PackageDownload["Microsoft.NETCore.App.Ref"].Should().Be(targetingPackVersion);
             string runtimePackName = resolvedVersions.PackageDownload.Keys
-                .Where(k => k.StartsWith("runtime.") && k.EndsWith(".Microsoft.NETCore.App"))
+                .Where(k => k.StartsWith("Microsoft.NETCore.App.Runtime."))
                 .Single();
             resolvedVersions.PackageDownload[runtimePackName].Should().Be(runtimeFrameworkVersion);
             resolvedVersions.TargetingPack["Microsoft.NETCore.App"].Should().Be(targetingPackVersion);
@@ -419,7 +419,7 @@ namespace FrameworkReferenceTest
             resolvedVersions.RuntimeFramework["Microsoft.NETCore.App"].Should().Be(runtimeFrameworkVersion);
             resolvedVersions.PackageDownload["Microsoft.NETCore.App.Ref"].Should().Be(targetingPackVersion);
             string runtimePackName = resolvedVersions.PackageDownload.Keys
-                .Where(k => k.StartsWith("runtime.") && k.EndsWith(".Microsoft.NETCore.App"))
+                .Where(k => k.StartsWith("Microsoft.NETCore.App.Runtime."))
                 .Single();
             resolvedVersions.PackageDownload[runtimePackName].Should().Be(runtimeFrameworkVersion);
             resolvedVersions.TargetingPack["Microsoft.NETCore.App"].Should().Be(targetingPackVersion);
@@ -455,7 +455,7 @@ namespace FrameworkReferenceTest
             resolvedVersions.RuntimeFramework["Microsoft.NETCore.App"].Should().Be(expectedRuntimeFrameworkVersion);
             resolvedVersions.PackageDownload["Microsoft.NETCore.App.Ref"].Should().Be(targetingPackVersion);
             string runtimePackName = resolvedVersions.PackageDownload.Keys
-                .Where(k => k.StartsWith("runtime.") && k.EndsWith(".Microsoft.NETCore.App"))
+                .Where(k => k.StartsWith("Microsoft.NETCore.App.Runtime."))
                 .Single();
             resolvedVersions.PackageDownload[runtimePackName].Should().Be(expectedRuntimeFrameworkVersion);
             resolvedVersions.TargetingPack["Microsoft.NETCore.App"].Should().Be(targetingPackVersion);
@@ -481,7 +481,7 @@ namespace FrameworkReferenceTest
             resolvedVersions.RuntimeFramework["Microsoft.NETCore.App"].Should().Be(expectedRuntimeFrameworkVersion);
             resolvedVersions.PackageDownload["Microsoft.NETCore.App.Ref"].Should().Be(targetingPackVersion);
             string runtimePackName = resolvedVersions.PackageDownload.Keys
-                .Where(k => k.StartsWith("runtime.") && k.EndsWith(".Microsoft.NETCore.App"))
+                .Where(k => k.StartsWith("Microsoft.NETCore.App.Runtime."))
                 .Single();
             resolvedVersions.PackageDownload[runtimePackName].Should().Be(expectedRuntimeFrameworkVersion);
             resolvedVersions.TargetingPack["Microsoft.NETCore.App"].Should().Be(targetingPackVersion);
@@ -512,7 +512,7 @@ namespace FrameworkReferenceTest
             resolvedVersions.RuntimeFramework["Microsoft.NETCore.App"].Should().Be(expectedRuntimeFrameworkVersion);
             resolvedVersions.PackageDownload["Microsoft.NETCore.App.Ref"].Should().Be(targetingPackVersion);
             string runtimePackName = resolvedVersions.PackageDownload.Keys
-                .Where(k => k.StartsWith("runtime.") && k.EndsWith(".Microsoft.NETCore.App"))
+                .Where(k => k.StartsWith("Microsoft.NETCore.App.Runtime."))
                 .Single();
             resolvedVersions.PackageDownload[runtimePackName].Should().Be(expectedRuntimeFrameworkVersion);
             resolvedVersions.TargetingPack["Microsoft.NETCore.App"].Should().Be(targetingPackVersion);
@@ -629,7 +629,7 @@ namespace FrameworkReferenceTest
             var runtimeAssetTrimInfo = GetRuntimeAssetTrimInfo(testProject);
 
             string runtimePackName = runtimeAssetTrimInfo.Keys
-                .Where(k => k.StartsWith("runtime.") && k.EndsWith(".Microsoft.NETCore.App"))
+                .Where(k => k.StartsWith("Microsoft.NETCore.App.Runtime."))
                 .Single();
 
             foreach (var runtimeAsset in runtimeAssetTrimInfo[runtimePackName])
@@ -657,7 +657,7 @@ namespace FrameworkReferenceTest
                 });
 
             string runtimePackName = runtimeAssetTrimInfo.Keys
-                .Where(k => k.StartsWith("runtime.") && k.EndsWith(".Microsoft.NETCore.App"))
+                .Where(k => k.StartsWith("Microsoft.NETCore.App.Runtime."))
                 .Single();
 
             foreach (var runtimeAsset in runtimeAssetTrimInfo[runtimePackName])

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPreserveCompilationContext.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPreserveCompilationContext.cs
@@ -674,6 +674,7 @@ System.Security.SecureString.dll
 System.ServiceModel.Web.dll
 System.ServiceProcess.dll
 System.Text.Encoding.dll
+System.Text.Encoding.CodePages.dll
 System.Text.Encoding.Extensions.dll
 System.Text.Encodings.Web.dll
 System.Text.RegularExpressions.dll


### PR DESCRIPTION
Related: #3126 
This is also needed to completely fix https://github.com/dotnet/wpf/issues/866 - we still can't support support multitargeting `netcoreapp2.2`, and also to fix https://github.com/dotnet/wpf/issues/867

- Adds warning strings related to `Microsoft.NET.Sdk.WindowsDesktop`
- Adds a check to warn when `UseWpf` or `UseWindowsForms` is set without including `Microsoft.NET.Sdk.WindowsDesktop`