### PR TITLE
Fix duplicate resolved files to publish

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -553,8 +553,8 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ItemGroup>
       <_ResolvedCopyLocalPublishAssets Include="@(ReferenceCopyLocalPaths)"
                                        Exclude="@(_ResolvedCopyLocalBuildAssets);@(RuntimePackAsset)"
-                                       Condition="'$(PublishReferencesDocumentationFiles)' == 'true' or '%(Extension)' != '.xml'">
-        <DestinationSubPath>%(ReferenceCopyLocalPaths.DestinationSubDirectory)%(Filename)%(Extension)</DestinationSubPath>
+                                       Condition="'$(PublishReferencesDocumentationFiles)' == 'true' or '%(ReferenceCopyLocalPaths.Extension)' != '.xml'">
+        <DestinationSubPath>%(ReferenceCopyLocalPaths.DestinationSubDirectory)%(ReferenceCopyLocalPaths.Filename)%(ReferenceCopyLocalPaths.Extension)</DestinationSubPath>
       </_ResolvedCopyLocalPublishAssets>
     </ItemGroup>
 

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAHelloWorldProject.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAHelloWorldProject.cs
@@ -501,8 +501,11 @@ public static class Program
                 .HaveStdOutContaining("NETSDK1085");
         }
 
+        [WindowsOnlyFact]
+        public void It_contains_no_duplicates_in_resolved_publish_assets_on_windows()
+            => It_contains_no_duplicates_in_resolved_publish_assets("windows");
+
         [Theory]
-        [InlineData("windows")]
         [InlineData("console")]
         [InlineData("web")]
         public void It_contains_no_duplicates_in_resolved_publish_assets(string type)
@@ -520,10 +523,6 @@ public static class Program
             switch (type)
             {
                 case "windows":
-                    if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-                    {
-                        return; // Cannot build for windows on non-Windows
-                    }
                     testProject.ProjectSdk = "Microsoft.NET.Sdk.WindowsDesktop";
                     testProject.AdditionalProperties.Add("UseWpf", "true");
                     testProject.AdditionalProperties.Add("UseWindowsForms", "true");

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAHelloWorldProject.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAHelloWorldProject.cs
@@ -501,8 +501,11 @@ public static class Program
                 .HaveStdOutContaining("NETSDK1085");
         }
 
-        [Fact]
-        public void It_contains_no_duplicates_in_resolved_publish_assets()
+        [Theory]
+        [InlineData("windows")]
+        [InlineData("console")]
+        [InlineData("web")]
+        public void It_contains_no_duplicates_in_resolved_publish_assets(string type)
         {
             // Use a specific RID to guarantee a consistent set of assets
             var testProject = new TestProject()
@@ -514,9 +517,29 @@ public static class Program
                 IsExe = true
             };
 
+            switch (type)
+            {
+                case "windows":
+                    if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                    {
+                        return; // Cannot build for windows on non-Windows
+                    }
+                    testProject.ProjectSdk = "Microsoft.NET.Sdk.WindowsDesktop";
+                    testProject.AdditionalProperties.Add("UseWpf", "true");
+                    testProject.AdditionalProperties.Add("UseWindowsForms", "true");
+                    break;
+               case "console":
+                    break;
+                case "web":
+                    testProject.ProjectSdk = "Microsoft.NET.Sdk.Web";
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(type));
+            }
+
             testProject.PackageReferences.Add(new TestPackageReference("NewtonSoft.Json", "9.0.1"));
 
-            var testAsset = _testAssetsManager.CreateTestProject(testProject, testProject.Name)
+            var testAsset = _testAssetsManager.CreateTestProject(testProject, testProject.Name, identifier: type)
                 .WithProjectChanges(project =>
                 {
                     project.Root.Add(XElement.Parse(@"
@@ -526,12 +549,12 @@ public static class Program
     </RemoveDuplicates>
     <Message Condition=""'@(_ResolvedCopyLocalPublishAssets)' != '@(FilteredAssets)'"" Importance=""High"" Text=""Duplicate items are present in: @(_ResolvedCopyLocalPublishAssets)!"" />
     <ItemGroup>
-        <AssetFilenames Include=""@(_ResolvedCopyLocalPublishAssets->'%(Filename)%(Extension)')"" />
+        <AssetDestinationSubPaths Include=""@(_ResolvedCopyLocalPublishAssets->'%(DestinationSubPath)')"" />
     </ItemGroup>
-    <RemoveDuplicates Inputs=""@(AssetFilenames)"">
-        <Output TaskParameter=""Filtered"" ItemName=""FilteredAssetFilenames""/>
+    <RemoveDuplicates Inputs=""@(AssetDestinationSubPaths)"">
+        <Output TaskParameter=""Filtered"" ItemName=""FilteredAssetDestinationSubPaths""/>
     </RemoveDuplicates>
-    <Message Condition=""'@(AssetFilenames)' != '@(FilteredAssetFilenames)'"" Importance=""High"" Text=""Duplicate filenames are present in: @(_ResolvedCopyLocalPublishAssets)!"" />
+    <Message Condition=""'@(AssetDestinationSubPaths)' != '@(FilteredAssetDestinationSubPaths)'"" Importance=""High"" Text=""Duplicate DestinationSubPaths are present in: @(AssetDestinationSubPaths)!"" />
 </Target>"));
                 })
                 .Restore(Log, testProject.Name);


### PR DESCRIPTION
Fix #3257 

There were two issues.

1. A misunderstanding of msbuild batching rules and unqualified metadata caused satellite assemblies to be included twice (from same source location) into the publish list. (See https://github.com/microsoft/msbuild/issues/4429)
2. There are assemblies with the same name and version in multiple frameworks. We have to choose one arbitrarily.




