### PR TITLE
Use runtime pack manifest

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolveRuntimePackAssets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveRuntimePackAssets.cs
@@ -132,6 +132,11 @@ namespace Microsoft.NET.Build.Tasks
                 }
 
                 var assetItem = CreateAssetItem(assetPath, assetType, runtimePack);
+
+                assetItem.SetMetadata("AssemblyVersion", fileElement.Attribute("AssemblyVersion")?.Value);
+                assetItem.SetMetadata("FileVersion", fileElement.Attribute("FileVersion")?.Value);
+                assetItem.SetMetadata("PublicKeyToken", fileElement.Attribute("PublicKeyToken")?.Value);
+
                 runtimePackAssets.Add(assetItem);
             }
 


### PR DESCRIPTION
Use runtime pack manifest instead of using conventions and scanning folders.

Resources are still handled using conventions, we need updates to the runtime pack manifest in order to be able to consume them from it: https://github.com/dotnet/core-setup/issues/6768