### PR TITLE
Use preserialized resources to target Core 3

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -84,6 +84,17 @@ Copyright (c) .NET Foundation. All rights reserved.
     <UserProfileRuntimeStorePath Condition="'$(UserProfileRuntimeStorePath)' == ''">$(_DefaultUserProfileRuntimeStorePath)</UserProfileRuntimeStorePath>
   </PropertyGroup>
 
+  <!-- Opt into .NET Core resource-serialization strategy by default when targeting frameworks
+       that support it by default.
+       -->
+  <PropertyGroup>
+    <GenerateResourceUsePreserializedResources
+      Condition="'$(GenerateResourceUsePreserializedResources)' == '' and
+                 ( ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' and '$(_TargetFrameworkVersionWithoutV)' > '3.0') or
+                   ('$(TargetFrameworkIdentifier)' == '.NETStandard' and '$(_TargetFrameworkVersionWithoutV)' > '2.1') )">true</GenerateResourceUsePreserializedResources>
+    <GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>
+  </PropertyGroup>
+
   <PropertyGroup>
     <CoreBuildDependsOn>
       _CheckForBuildWithNoBuild;

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -90,9 +90,8 @@ Copyright (c) .NET Foundation. All rights reserved.
   <PropertyGroup>
     <GenerateResourceUsePreserializedResources
       Condition="'$(GenerateResourceUsePreserializedResources)' == '' and
-                 ( ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' and '$(_TargetFrameworkVersionWithoutV)' > '3.0') or
-                   ('$(TargetFrameworkIdentifier)' == '.NETStandard' and '$(_TargetFrameworkVersionWithoutV)' > '2.1') )">true</GenerateResourceUsePreserializedResources>
-    <GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>
+                 ( ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' and '$(_TargetFrameworkVersionWithoutV)' >= '3.0') or
+                   ('$(TargetFrameworkIdentifier)' == '.NETStandard' and '$(_TargetFrameworkVersionWithoutV)' >= '2.1') )">true</GenerateResourceUsePreserializedResources>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -90,8 +90,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <PropertyGroup>
     <GenerateResourceUsePreserializedResources
       Condition="'$(GenerateResourceUsePreserializedResources)' == '' and
-                 ( ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' and '$(_TargetFrameworkVersionWithoutV)' >= '3.0') or
-                   ('$(TargetFrameworkIdentifier)' == '.NETStandard' and '$(_TargetFrameworkVersionWithoutV)' >= '2.1') )">true</GenerateResourceUsePreserializedResources>
+                 ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' and '$(_TargetFrameworkVersionWithoutV)' >= '3.0')">true</GenerateResourceUsePreserializedResources>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Opts into the new System.Resources.Extensions approach to resource
serialization when targeting .NET Core 3.0+/.NET Standard 2.1+.

Respects project setting if the project explicitly sets the property, to
allow opting .NET Framework-targeting applications to opt in.

This is my stake-in-the ground proposal: light this up automatically for the folks who definitely need it. Happy to have discussion about other times when we should set this.

Important factors include:
* TF of the project, including whether that TF has S.R.Extensions guaranteed
* runtime of the building MSBuild (Core MSBuild can't support the legacy approach needed for targeting full without adding the S.R.Extensions reference to the project)

@nguerrera @livarcocc @ericstj @merriemcgaw @dreddy-work

(this property does nothing but is harmless until it runs in conjunction with https://github.com/microsoft/msbuild/pull/4420; posting this now to review in parallel)