### PR TITLE
Fix dotnet store for netcoreapp3.0

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ComposeStore.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ComposeStore.targets
@@ -53,8 +53,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                              SkipUnchangedFiles=$(SkipUnchangedFiles);
                              PreserveStoreLayout=$(PreserveStoreLayout);
                              CreateProfilingSymbols=$(CreateProfilingSymbols);
-                             StoreSymbolsStagingDir=$(StoreSymbolsStagingDir)"
-                 ContinueOnError="WarnAndContinue">
+                             StoreSymbolsStagingDir=$(StoreSymbolsStagingDir)">
       <Output ItemName="AllResolvedPackagesPublished" TaskParameter="TargetOutputs" />
     </MSBuild>
   </Target>
@@ -71,6 +70,8 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <ItemGroup>
       <PackageReferencesToStore Include="$(MSBuildProjectFullPath)">
+        <PackageName>%(PackageReference.Identity)</PackageName>
+        <PackageVersion>%(PackageReference.Version)</PackageVersion>
         <AdditionalProperties>
           StorePackageName=%(PackageReference.Identity);
           StorePackageVersion=%(PackageReference.Version);
@@ -93,17 +94,15 @@ Copyright (c) .NET Foundation. All rights reserved.
 <!-- Restore phase -->
     <MSBuild Projects="@(PackageReferencesToStore)"
                  Targets="RestoreForComposeStore"
-                 BuildInParallel="$(BuildInParallel)"
-                 ContinueOnError="WarnAndContinue">
+                 BuildInParallel="$(BuildInParallel)">
     </MSBuild>
     
     
 <!-- Resolve phase-->
     <MSBuild Projects="@(PackageReferencesToStore)"
                  Targets="StoreResolver"
-                 Properties="MSBuildProjectExtensionsPath=$(ComposeWorkingDir)\%(PackageReference.Identity)_$([System.String]::Copy('%(PackageReference.Version)').Replace('*','-'))\;"
-                 BuildInParallel="$(BuildInParallel)"
-                 ContinueOnError="WarnAndContinue">
+                 Properties="SelfContained=false;MSBuildProjectExtensionsPath=$(ComposeWorkingDir)\%(PackageReferencesToStore.PackageName)_$([System.String]::Copy('%(PackageReferencesToStore.PackageVersion)').Replace('*','-'))\;"
+                 BuildInParallel="$(BuildInParallel)">
       <Output ItemName="ResolvedPackagesFromMapper" TaskParameter="TargetOutputs" />
     </MSBuild>
   </Target>
@@ -157,8 +156,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                  Importance="high"/>
     <RemoveDir
         Condition="'$(PreserveComposeWorkingDir)' != 'true'"
-        Directories="$(ComposeWorkingDir)"
-        ContinueOnError="WarnAndContinue"/>
+        Directories="$(ComposeWorkingDir)" />
   </Target>
 
   <!--
@@ -177,7 +175,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     </ItemGroup>
 
     <Copy SourceFiles = "@(_OptimizedResolvedFileToPublish)"
-          DestinationFolder="$(PublishDir)%(RecursiveDir)"
+          DestinationFolder="$(PublishDir)%(_OptimizedResolvedFileToPublish.RecursiveDir)"
           OverwriteReadOnlyFiles="$(OverwriteReadOnlyFiles)"
           Retries="$(CopyRetryCount)"
           RetryDelayMilliseconds="$(CopyRetryDelayMilliseconds)"
@@ -189,7 +187,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     </Copy>
 
     <Copy SourceFiles="@(_OptimizedSymbolFileToPublish)"
-          DestinationFolder="$(ProfilingSymbolsDir)%(RecursiveDir)"
+          DestinationFolder="$(ProfilingSymbolsDir)%(_OptimizedSymbolFileToPublish.RecursiveDir)"
           OverwriteReadOnlyFiles="$(OverwriteReadOnlyFiles)"
           Retries="$(CopyRetryCount)"
           RetryDelayMilliseconds="$(CopyRetryDelayMilliseconds)"

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.CrossGen.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.CrossGen.targets
@@ -104,8 +104,8 @@ Copyright (c) .NET Foundation. All rights reserved.
           CrossgenExe=$(Crossgen);
           CrossgenJit=$(JitPath);
           CrossgenInputAssembly=%(_ManagedResolvedFilesToOptimize.Fullpath);
-          CrossgenOutputAssembly=$(_RuntimeOptimizedDir)$(DirectorySeparatorChar)%(FileName)%(Extension);
-          CrossgenSubOutputPath=%(DestinationSubPath);
+          CrossgenOutputAssembly=$(_RuntimeOptimizedDir)$(DirectorySeparatorChar)%(_ManagedResolvedFilesToOptimize.FileName)%(_ManagedResolvedFilesToOptimize.Extension);
+          CrossgenSubOutputPath=%(_ManagedResolvedFilesToOptimize.DestinationSubPath);
           _RuntimeOptimizedDir=$(_RuntimeOptimizedDir);
           PublishDir=$(StoreStagingDir);
           CrossgenPlatformAssembliesPath=$(_RuntimeRefDir)$(PathSeparator)$(_NetCoreRefDir);
@@ -147,7 +147,8 @@ Copyright (c) .NET Foundation. All rights reserved.
     <!--Optimization skip if the assembly is already present in the final output directory-->
     <Exec
      Command="$(CrossgenCommandline)"
-     Condition="!Exists($([System.IO.Path]::Combine($(PublishDir),$(CrossgenSubOutputPath))))" />
+     Condition="!Exists($([System.IO.Path]::Combine($(PublishDir),$(CrossgenSubOutputPath))))"
+     IgnoreStandardErrorWarningFormat="true" />
 
     <Copy SourceFiles = "$(CrossgenOutputAssembly)"
           DestinationFiles="$(PublishDir)\$(CrossgenSubOutputPath)"
@@ -163,7 +164,8 @@ Copyright (c) .NET Foundation. All rights reserved.
     <MakeDir Directories="$(CrossgenProfilingSymbolsOutputDirectory)"
              Condition="'$(CreateProfilingSymbols)' == 'true' and Exists($(CrossgenOutputAssembly))" />
     <Exec Command="$(CrossgenExe) -nologo -readytorun -platform_assemblies_paths $(CrossgenPlatformAssembliesPath) -$(CreateProfilingSymbolsOptionName) $(CrossgenProfilingSymbolsOutputDirectory) $(CrossgenOutputAssembly)"
-          Condition="'$(CreateProfilingSymbols)' == 'true' and Exists($(CrossgenOutputAssembly))" />
+          Condition="'$(CreateProfilingSymbols)' == 'true' and Exists($(CrossgenOutputAssembly))" 
+          IgnoreStandardErrorWarningFormat="true" />
 
     <ItemGroup>
       <_ProfilingSymbols Include="$(CrossgenProfilingSymbolsOutputDirectory)\*"
@@ -267,12 +269,12 @@ Copyright (c) .NET Foundation. All rights reserved.
     <MSBuild Projects="$(MSBuildProjectFullPath)"
                  Targets="Restore"
                  Properties="RestoreGraphProjectInput=$(MSBuildProjectFullPath);
-                             DisableImplicitFrameworkReferences=true;
                              RestoreOutputPath=$(_CrossProjFileDir);
                              StorePackageName=$(MicrosoftNETPlatformLibrary);
                              StorePackageVersion=%(PackageReferenceForCrossGen.Version);"/>
 
-    <ResolveCopyLocalAssets AssetsFilePath="$(_CrossProjAssetsFile)"
+    <ResolveCopyLocalAssets Condition="'$(_TargetFrameworkVersionWithoutV)' &lt; '3.0'"
+                            AssetsFilePath="$(_CrossProjAssetsFile)"
                             TargetFramework="$(_TFM)"
                             RuntimeIdentifier="$(RuntimeIdentifier)"
                             PlatformLibraryName="$(MicrosoftNETPlatformLibrary)"
@@ -283,6 +285,18 @@ Copyright (c) .NET Foundation. All rights reserved.
 
       <Output TaskParameter="ResolvedAssets" ItemName="CrossgenResolvedAssembliesToPublish" />
     </ResolveCopyLocalAssets>
+
+    <GetPackageDirectory Condition="'$(_TargetFrameworkVersionWithoutV)' >= '3.0'"
+                         Items="@(RuntimePack)"
+                         AssetsFileWithAdditionalPackageFolders="$(_CrossProjAssetsFile)">
+      <Output TaskParameter="Output" ItemName="_CrossgenRuntimePack" />
+    </GetPackageDirectory>
+
+    <ResolveRuntimePackAssets Condition="'$(_TargetFrameworkVersionWithoutV)' >= '3.0'"
+                              FrameworkReferences="@(FrameworkReference)"
+                              ResolvedRuntimePacks="@(_CrossgenRuntimePack)">
+      <Output TaskParameter="RuntimePackAssets" ItemName="CrossgenResolvedAssembliesToPublish" />
+    </ResolveRuntimePackAssets>
 
     <!-- Copy managed files to  a flat temp directory for passing it as ref for crossgen -->
     <Copy SourceFiles = "@(CrossgenResolvedAssembliesToPublish)"

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToStoreAProjectWithDependencies.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToStoreAProjectWithDependencies.cs
@@ -161,7 +161,7 @@ namespace Microsoft.NET.Publish.Tests
             storeDirectory.Should().OnlyHaveFiles(files_on_disk);
         }
 
-        [CoreMSBuildOnlyFact(Skip = "https://github.com/dotnet/sdk/issues/2914")]
+        [CoreMSBuildOnlyFact]
         public void compose_multifile()
         {
             TestAsset simpleDependenciesAsset = _testAssetsManager
@@ -177,7 +177,7 @@ namespace Microsoft.NET.Publish.Tests
             var additionalproj2 = Path.Combine(simpleDependenciesAsset.TestRoot, "FluentAssertion.xml");
 
             storeCommand
-                .Execute("/bl:store.binlog", $"/p:RuntimeIdentifier={_runtimeRid}", $"/p:TargetFramework={_tfm}", $"/p:Additionalprojects={additionalproj1}%3b{additionalproj2}", $"/p:ComposeDir={OutputFolder}", $"/p:ComposeWorkingDir={WorkingDir}", "/p:DoNotDecorateComposeDir=true", "/p:CreateProfilingSymbols=false")
+                .Execute($"/p:RuntimeIdentifier={_runtimeRid}", $"/p:TargetFramework={_tfm}", $"/p:Additionalprojects={additionalproj1}%3b{additionalproj2}", $"/p:ComposeDir={OutputFolder}", $"/p:ComposeWorkingDir={WorkingDir}", "/p:DoNotDecorateComposeDir=true", "/p:CreateProfilingSymbols=false")
                 .Should()
                 .Pass();
             DirectoryInfo storeDirectory = new DirectoryInfo(OutputFolder);
@@ -213,7 +213,7 @@ namespace Microsoft.NET.Publish.Tests
 
             foreach (var pkg in knownpackage)
             {
-                packagescomposed.Should().Contain(elem => elem.Equals(pkg), "package {0}, version {1} was not expected to be stored", pkg.Id, pkg.Version);
+                packagescomposed.Should().Contain(elem => elem.Equals(pkg), "package {0}, version {1} was expected to be stored", pkg.Id, pkg.Version);
             }
         }
 
@@ -300,7 +300,7 @@ namespace Microsoft.NET.Publish.Tests
             }
         }
 
-        [CoreMSBuildOnlyFact(Skip = "https://github.com/dotnet/sdk/issues/2914")]
+        [CoreMSBuildOnlyFact]
         public void It_stores_when_targeting_netcoreapp3()
         {
             const string TFM = "netcoreapp3.0";


### PR DESCRIPTION
Also fix msbuild batching error that caused O(N^2) redundant work, and flakiness due to race conditions between the redundant workers.

And replace ContinueOnError=WarnAndContinue with just ignoring standard error format on exec of crossgen. crossgen prior to 3.0 is notorious for spewing noise and the only thing that is reliable is the exit code. The previous approach around it was way too big of a hammer.

This is the "minimal fix" for 3.0. I am still working on a major re-design and simplification of dotnet store, but that will not likely be ready for 3.0 preview 7 and we want to have these issues fixed before then.

It is also not clear yet if we would be able to use the simplified design for all TFMs or only on netcoreapp3.0. That is because the crux of the re-design is to use the new PublishReadyToRun code as the foundation.