### PR TITLE
Silence R2R compiler warnings by default

### DIFF
--- a/src/Tasks/Common/Resources/Strings.resx
+++ b/src/Tasks/Common/Resources/Strings.resx
@@ -533,4 +533,7 @@ The following are names of parameters or literal values and should not be transl
     <value>NETSDK1106: Microsoft.NET.Sdk.WindowsDesktop requires 'UseWpf' or 'UseWindowsForms' to be set to 'true'</value>
     <comment>{StrBegin="NETSDK1106: "}</comment>
   </data>
+  <data name="ReadyToRunCompilationHasWarnings_Info" xml:space="preserve">
+    <value>Some ReadyToRun compilations emitted warnings, indicating potential missing dependencies. Missing dependencies could potentially cause runtime failures. To show the warnings, set the PublishReadyToRunShowWarnings property to true.</value>
+  </data>
 </root>

--- a/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
@@ -426,6 +426,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1096: Nepovedlo se optimalizovat sestavení pro výkonnost. Můžete buď vyloučit neúspěšná sestavení z optimalizace, nebo nastavit vlastnost PublishReadyToRun na false.</target>
         <note>{StrBegin="NETSDK1096: "}</note>
       </trans-unit>
+      <trans-unit id="ReadyToRunCompilationHasWarnings_Info">
+        <source>Some ReadyToRun compilations emitted warnings, indicating potential missing dependencies. Missing dependencies could potentially cause runtime failures. To show the warnings, set the PublishReadyToRunShowWarnings property to true.</source>
+        <target state="new">Some ReadyToRun compilations emitted warnings, indicating potential missing dependencies. Missing dependencies could potentially cause runtime failures. To show the warnings, set the PublishReadyToRunShowWarnings property to true.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ReadyToRunNoValidRuntimePackageError">
         <source>NETSDK1094: Unable to optimize assemblies for performance: a valid runtime package was not found. Either set the PublishReadyToRun property to false, or use a supported runtime identifier when publishing.</source>
         <target state="translated">NETSDK1094: Nepovedlo se optimalizovat sestavení pro výkonnost: nenašel se platný balíček modulu runtime. Buď nastavte vlastnost PublishReadyToRun na false, nebo při publikování použijte podporovaný identifikátor modulu runtime.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.de.xlf
@@ -426,6 +426,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1096: Fehler bei der Leistungsoptimierung von Assemblys. Sie können entweder die fehlerhaften Assemblys von der Optimierung ausschließen oder die PublishReadyToRun-Eigenschaft auf FALSE festlegen.</target>
         <note>{StrBegin="NETSDK1096: "}</note>
       </trans-unit>
+      <trans-unit id="ReadyToRunCompilationHasWarnings_Info">
+        <source>Some ReadyToRun compilations emitted warnings, indicating potential missing dependencies. Missing dependencies could potentially cause runtime failures. To show the warnings, set the PublishReadyToRunShowWarnings property to true.</source>
+        <target state="new">Some ReadyToRun compilations emitted warnings, indicating potential missing dependencies. Missing dependencies could potentially cause runtime failures. To show the warnings, set the PublishReadyToRunShowWarnings property to true.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ReadyToRunNoValidRuntimePackageError">
         <source>NETSDK1094: Unable to optimize assemblies for performance: a valid runtime package was not found. Either set the PublishReadyToRun property to false, or use a supported runtime identifier when publishing.</source>
         <target state="translated">NETSDK1094: Die Leistungsoptimierung ist für Assemblys nicht möglich: Es wurde kein gültiges Runtimepaket gefunden. Legen Sie die PublishReadyToRun-Eigenschaft auf FALSE fest, oder verwenden Sie bei der Veröffentlichung eine unterstützte Runtime-ID.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.es.xlf
@@ -426,6 +426,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1096: Error al optimizar el rendimiento de los ensamblados. Puede excluir los ensamblados con error de la optimización o establecer la propiedad PublishReadyToRun en false.</target>
         <note>{StrBegin="NETSDK1096: "}</note>
       </trans-unit>
+      <trans-unit id="ReadyToRunCompilationHasWarnings_Info">
+        <source>Some ReadyToRun compilations emitted warnings, indicating potential missing dependencies. Missing dependencies could potentially cause runtime failures. To show the warnings, set the PublishReadyToRunShowWarnings property to true.</source>
+        <target state="new">Some ReadyToRun compilations emitted warnings, indicating potential missing dependencies. Missing dependencies could potentially cause runtime failures. To show the warnings, set the PublishReadyToRunShowWarnings property to true.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ReadyToRunNoValidRuntimePackageError">
         <source>NETSDK1094: Unable to optimize assemblies for performance: a valid runtime package was not found. Either set the PublishReadyToRun property to false, or use a supported runtime identifier when publishing.</source>
         <target state="translated">NETSDK1094: No se puede optimizar el rendimiento de los ensamblados: no se encontró ningún paquete de tiempo de ejecución válido. Establezca la propiedad PublishReadyToRun en false o use un identificador de tiempo de ejecución admitido al publicar.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
@@ -426,6 +426,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1096: échec de l'optimisation des assemblys pour l'amélioration du niveau de performance. Vous pouvez exclure les assemblys défaillants de l'optimisation, ou affecter la valeur false à la propriété PublishReadyToRun.</target>
         <note>{StrBegin="NETSDK1096: "}</note>
       </trans-unit>
+      <trans-unit id="ReadyToRunCompilationHasWarnings_Info">
+        <source>Some ReadyToRun compilations emitted warnings, indicating potential missing dependencies. Missing dependencies could potentially cause runtime failures. To show the warnings, set the PublishReadyToRunShowWarnings property to true.</source>
+        <target state="new">Some ReadyToRun compilations emitted warnings, indicating potential missing dependencies. Missing dependencies could potentially cause runtime failures. To show the warnings, set the PublishReadyToRunShowWarnings property to true.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ReadyToRunNoValidRuntimePackageError">
         <source>NETSDK1094: Unable to optimize assemblies for performance: a valid runtime package was not found. Either set the PublishReadyToRun property to false, or use a supported runtime identifier when publishing.</source>
         <target state="translated">NETSDK1094: impossible d'optimiser les assemblys pour améliorer le niveau de performance. Aucun package de runtime valide n'a été localisé. Affectez la valeur false à la propriété PublishReadyToRun, ou utilisez un identificateur de runtime pris en charge au moment de la publication.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.it.xlf
@@ -426,6 +426,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1096: l'ottimizzazione degli assembly per le prestazioni non è riuscita. È possibile escludere gli assembly in errore dall'ottimizzazione oppure impostare la proprietà PublishReadyToRun su false.</target>
         <note>{StrBegin="NETSDK1096: "}</note>
       </trans-unit>
+      <trans-unit id="ReadyToRunCompilationHasWarnings_Info">
+        <source>Some ReadyToRun compilations emitted warnings, indicating potential missing dependencies. Missing dependencies could potentially cause runtime failures. To show the warnings, set the PublishReadyToRunShowWarnings property to true.</source>
+        <target state="new">Some ReadyToRun compilations emitted warnings, indicating potential missing dependencies. Missing dependencies could potentially cause runtime failures. To show the warnings, set the PublishReadyToRunShowWarnings property to true.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ReadyToRunNoValidRuntimePackageError">
         <source>NETSDK1094: Unable to optimize assemblies for performance: a valid runtime package was not found. Either set the PublishReadyToRun property to false, or use a supported runtime identifier when publishing.</source>
         <target state="translated">NETSDK1094: non è possibile ottimizzare gli assembly per le prestazioni perché non è stato trovato alcun pacchetto di runtime valido. Impostare la proprietà PublishReadyToRun su false oppure usare un identificatore di runtime supportato durante la pubblicazione.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
@@ -426,6 +426,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1096: アセンブリのパフォーマンスの最適化が失敗しました。失敗したアセンブリを最適化の対象から除外するか、PublishReadyToRun プロパティを false に設定してください。</target>
         <note>{StrBegin="NETSDK1096: "}</note>
       </trans-unit>
+      <trans-unit id="ReadyToRunCompilationHasWarnings_Info">
+        <source>Some ReadyToRun compilations emitted warnings, indicating potential missing dependencies. Missing dependencies could potentially cause runtime failures. To show the warnings, set the PublishReadyToRunShowWarnings property to true.</source>
+        <target state="new">Some ReadyToRun compilations emitted warnings, indicating potential missing dependencies. Missing dependencies could potentially cause runtime failures. To show the warnings, set the PublishReadyToRunShowWarnings property to true.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ReadyToRunNoValidRuntimePackageError">
         <source>NETSDK1094: Unable to optimize assemblies for performance: a valid runtime package was not found. Either set the PublishReadyToRun property to false, or use a supported runtime identifier when publishing.</source>
         <target state="translated">NETSDK1094: アセンブリのパフォーマンスを最適化できません。有効なランタイム パッケージが見つかりませんでした。PublishReadyToRun プロパティを false に設定するか、公開するときに、サポートされているランタイム識別子を使用してください。</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
@@ -426,6 +426,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1096: 성능 향상을 위해 어셈블리를 최적화하지 못했습니다. 오류가 발생하는 어셈블리를 최적화에서 제외하거나 PublishReadyToRun 속성을 false로 설정할 수 있습니다.</target>
         <note>{StrBegin="NETSDK1096: "}</note>
       </trans-unit>
+      <trans-unit id="ReadyToRunCompilationHasWarnings_Info">
+        <source>Some ReadyToRun compilations emitted warnings, indicating potential missing dependencies. Missing dependencies could potentially cause runtime failures. To show the warnings, set the PublishReadyToRunShowWarnings property to true.</source>
+        <target state="new">Some ReadyToRun compilations emitted warnings, indicating potential missing dependencies. Missing dependencies could potentially cause runtime failures. To show the warnings, set the PublishReadyToRunShowWarnings property to true.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ReadyToRunNoValidRuntimePackageError">
         <source>NETSDK1094: Unable to optimize assemblies for performance: a valid runtime package was not found. Either set the PublishReadyToRun property to false, or use a supported runtime identifier when publishing.</source>
         <target state="translated">NETSDK1094: 성능 향상을 위해 어셈블리를 최적화할 수 없습니다. 유효한 런타임 패키지를 찾을 수 없습니다. PublishReadyToRun 속성을 false로 설정하거나, 게시할 때 지원되는 런타임 식별자를 사용하세요.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
@@ -426,6 +426,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1096: Optymalizacja zestawów pod kątem wydajności nie powiodła się. Możesz wykluczyć błędne zestawy z procesu optymalizacji lub ustawić właściwość PublishReadyToRun na wartość false.</target>
         <note>{StrBegin="NETSDK1096: "}</note>
       </trans-unit>
+      <trans-unit id="ReadyToRunCompilationHasWarnings_Info">
+        <source>Some ReadyToRun compilations emitted warnings, indicating potential missing dependencies. Missing dependencies could potentially cause runtime failures. To show the warnings, set the PublishReadyToRunShowWarnings property to true.</source>
+        <target state="new">Some ReadyToRun compilations emitted warnings, indicating potential missing dependencies. Missing dependencies could potentially cause runtime failures. To show the warnings, set the PublishReadyToRunShowWarnings property to true.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ReadyToRunNoValidRuntimePackageError">
         <source>NETSDK1094: Unable to optimize assemblies for performance: a valid runtime package was not found. Either set the PublishReadyToRun property to false, or use a supported runtime identifier when publishing.</source>
         <target state="translated">NETSDK1094: Nie można zoptymalizować zestawów pod kątem wydajności — nie odnaleziono prawidłowego pakietu środowiska wykonawczego. Ustaw właściwość PublishReadyToRun na wartość false lub użyj obsługiwanego identyfikatora środowiska uruchomieniowego podczas publikowania.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
@@ -426,6 +426,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1096: falha ao otimizar assemblies para desempenho. Você pode impedir que os assemblies com falha sejam otimizados ou definir a propriedade PublishReadyToRun como false.</target>
         <note>{StrBegin="NETSDK1096: "}</note>
       </trans-unit>
+      <trans-unit id="ReadyToRunCompilationHasWarnings_Info">
+        <source>Some ReadyToRun compilations emitted warnings, indicating potential missing dependencies. Missing dependencies could potentially cause runtime failures. To show the warnings, set the PublishReadyToRunShowWarnings property to true.</source>
+        <target state="new">Some ReadyToRun compilations emitted warnings, indicating potential missing dependencies. Missing dependencies could potentially cause runtime failures. To show the warnings, set the PublishReadyToRunShowWarnings property to true.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ReadyToRunNoValidRuntimePackageError">
         <source>NETSDK1094: Unable to optimize assemblies for performance: a valid runtime package was not found. Either set the PublishReadyToRun property to false, or use a supported runtime identifier when publishing.</source>
         <target state="translated">NETSDK1094: não é possível otimizar assemblies para desempenho: não foi encontrado um pacote válido do tempo de execução. Defina a propriedade PublishReadyToRun como false ou use um identificador compatível durante a publicação.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
@@ -426,6 +426,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1096: не удалось оптимизировать сборки для обеспечения производительности. Вы можете исключить неудачно обработанные сборки из оптимизации либо задать значение false для свойства PublishReadyToRun.</target>
         <note>{StrBegin="NETSDK1096: "}</note>
       </trans-unit>
+      <trans-unit id="ReadyToRunCompilationHasWarnings_Info">
+        <source>Some ReadyToRun compilations emitted warnings, indicating potential missing dependencies. Missing dependencies could potentially cause runtime failures. To show the warnings, set the PublishReadyToRunShowWarnings property to true.</source>
+        <target state="new">Some ReadyToRun compilations emitted warnings, indicating potential missing dependencies. Missing dependencies could potentially cause runtime failures. To show the warnings, set the PublishReadyToRunShowWarnings property to true.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ReadyToRunNoValidRuntimePackageError">
         <source>NETSDK1094: Unable to optimize assemblies for performance: a valid runtime package was not found. Either set the PublishReadyToRun property to false, or use a supported runtime identifier when publishing.</source>
         <target state="translated">NETSDK1094: не удалось оптимизировать сборки для производительности: не найден допустимый пакет среды выполнения. Задайте для свойства PublishReadyToRun значение false либо используйте поддерживаемый идентификатор среды выполнения при публикации.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
@@ -426,6 +426,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1096: Derlemeler performans için iyileştirilemedi. Başarısız olan derlemeleri iyileştirmenin dışında tutabilir veya PublishReadyToRun özelliğini false olarak ayarlayabilirsiniz.</target>
         <note>{StrBegin="NETSDK1096: "}</note>
       </trans-unit>
+      <trans-unit id="ReadyToRunCompilationHasWarnings_Info">
+        <source>Some ReadyToRun compilations emitted warnings, indicating potential missing dependencies. Missing dependencies could potentially cause runtime failures. To show the warnings, set the PublishReadyToRunShowWarnings property to true.</source>
+        <target state="new">Some ReadyToRun compilations emitted warnings, indicating potential missing dependencies. Missing dependencies could potentially cause runtime failures. To show the warnings, set the PublishReadyToRunShowWarnings property to true.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ReadyToRunNoValidRuntimePackageError">
         <source>NETSDK1094: Unable to optimize assemblies for performance: a valid runtime package was not found. Either set the PublishReadyToRun property to false, or use a supported runtime identifier when publishing.</source>
         <target state="translated">NETSDK1094: Derlemeler performans için iyileştirilemiyor: Geçerli bir çalışma zamanı paketi bulunamadı. PublishReadyToRun özelliğini false olarak ayarlayın veya yayımlarken desteklenen bir çalışma zamanı tanımlayıcısı kullanın.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
@@ -426,6 +426,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="new">NETSDK1096: Optimizing assemblies for performance failed. You can either exclude the failing assemblies from being optimized, or set the PublishReadyToRun property to false.</target>
         <note>{StrBegin="NETSDK1096: "}</note>
       </trans-unit>
+      <trans-unit id="ReadyToRunCompilationHasWarnings_Info">
+        <source>Some ReadyToRun compilations emitted warnings, indicating potential missing dependencies. Missing dependencies could potentially cause runtime failures. To show the warnings, set the PublishReadyToRunShowWarnings property to true.</source>
+        <target state="new">Some ReadyToRun compilations emitted warnings, indicating potential missing dependencies. Missing dependencies could potentially cause runtime failures. To show the warnings, set the PublishReadyToRunShowWarnings property to true.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ReadyToRunNoValidRuntimePackageError">
         <source>NETSDK1094: Unable to optimize assemblies for performance: a valid runtime package was not found. Either set the PublishReadyToRun property to false, or use a supported runtime identifier when publishing.</source>
         <target state="new">NETSDK1094: Unable to optimize assemblies for performance: a valid runtime package was not found. Either set the PublishReadyToRun property to false, or use a supported runtime identifier when publishing.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
@@ -426,6 +426,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1096: 最佳化組件的效能失敗。您可以排除失敗的組件不予最佳化，或將 ReadyToRun 屬性設定為 false。</target>
         <note>{StrBegin="NETSDK1096: "}</note>
       </trans-unit>
+      <trans-unit id="ReadyToRunCompilationHasWarnings_Info">
+        <source>Some ReadyToRun compilations emitted warnings, indicating potential missing dependencies. Missing dependencies could potentially cause runtime failures. To show the warnings, set the PublishReadyToRunShowWarnings property to true.</source>
+        <target state="new">Some ReadyToRun compilations emitted warnings, indicating potential missing dependencies. Missing dependencies could potentially cause runtime failures. To show the warnings, set the PublishReadyToRunShowWarnings property to true.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ReadyToRunNoValidRuntimePackageError">
         <source>NETSDK1094: Unable to optimize assemblies for performance: a valid runtime package was not found. Either set the PublishReadyToRun property to false, or use a supported runtime identifier when publishing.</source>
         <target state="translated">NETSDK1094: 無法最佳化組件的效能: 找不到有效的執行階段套件。請將 ReadyToRun 屬性設定為 false，或在發佈時使用支援的執行階段識別碼。</target>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -210,6 +210,8 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <NETSdkError Condition="'@(_ReadyToRunCompilationFailures)' != ''" ResourceName="ReadyToRunCompilationFailed" />
 
+    <NETSdkInformation Condition="'$(_ReadyToRunCompilerHasWarnings)' != ''" ResourceName="ReadyToRunCompilationHasWarnings_Info" />
+
     <ItemGroup>
       <!-- 
       Note: we only remove the entries for the IL images and replace them with the entries for the R2R images.
@@ -296,10 +298,17 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <RunReadyToRunCompiler CrossgenTool="@(_CrossgenTool)"
                            ImplementationAssemblies="@(_ReadyToRunImplementationAssemblies)"
+                           ShowCompilerWarnings="$(PublishReadyToRunShowWarnings)"
                            CompilationEntry="@(_ReadyToRunCompileList)"
                            ContinueOnError="ErrorAndContinue">
       <Output TaskParameter="ExitCode" PropertyName="_ReadyToRunCompilerExitCode" />
+      <Output TaskParameter="WarningsDetected" PropertyName="_ReadyToRunWarningsDetected" />
     </RunReadyToRunCompiler>
+
+    <PropertyGroup>
+      <!-- Use distinct property here as any of the invocations can set it -->
+      <_ReadyToRunCompilerHasWarnings Condition="'$(_ReadyToRunWarningsDetected)' == 'true'">true</_ReadyToRunCompilerHasWarnings>
+    </PropertyGroup>
 
     <ItemGroup>
       <_ReadyToRunCompilationFailures Condition="'$(_ReadyToRunCompilerExitCode)' != '' And $(_ReadyToRunCompilerExitCode) != 0"
@@ -320,10 +329,17 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <RunReadyToRunCompiler CrossgenTool="@(_CrossgenTool)"
                            ImplementationAssemblies="@(_ReadyToRunImplementationAssemblies)"
+                           ShowCompilerWarnings="$(PublishReadyToRunShowWarnings)"
                            CompilationEntry="@(_ReadyToRunSymbolsCompileList)"
                            ContinueOnError="ErrorAndContinue">
       <Output TaskParameter="ExitCode" PropertyName="_ReadyToRunCompilerExitCode" />
+      <Output TaskParameter="WarningsDetected" PropertyName="_ReadyToRunWarningsDetected" />
     </RunReadyToRunCompiler>
+
+    <PropertyGroup>
+      <!-- Use distinct property here as any of the invocations can set it -->
+      <_ReadyToRunCompilerHasWarnings Condition="'$(_ReadyToRunWarningsDetected)' == 'true'">true</_ReadyToRunCompilerHasWarnings>
+    </PropertyGroup>
 
     <ItemGroup>
       <_ReadyToRunCompilationFailures Condition="'$(_ReadyToRunCompilerExitCode)' != '' And $(_ReadyToRunCompilerExitCode) != 0"


### PR DESCRIPTION
They can be re-enabled by setting `PublishReadyToRunShowWarnings` to true.
If warnings are detected when the property is not set, a single message will be displayed to inform of the presence of warnings.