### PR TITLE
Always publish the AppHost

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -143,9 +143,10 @@ Copyright (c) .NET Foundation. All rights reserved.
     </ItemGroup>
 
     <!--
-        Not using SkipUnchangedFiles="true" because the application may want to change
-        one of these files and not have an incremental build replace it.
-        -->
+      PreserveNewest means that we will only copy the source to the destination if the source is newer.
+      SkipUnchangedFiles is not used for that purpose because it will copy if the source and destination
+      differ by size too.  Instead, this target uses inputs and outputs to only copy when the source is newer.
+      -->
     <Copy SourceFiles = "@(_ResolvedUnbundledFileToPublishPreserveNewest)"
           DestinationFiles="@(_ResolvedUnbundledFileToPublishPreserveNewest->'$(PublishDir)%(RelativePath)')"
           OverwriteReadOnlyFiles="$(OverwriteReadOnlyFiles)"
@@ -179,11 +180,13 @@ Copyright (c) .NET Foundation. All rights reserved.
     </ItemGroup>
 
     <!--
-        Not using SkipUnchangedFiles="true" because the application may want to change
-        one of these files and not have an incremental build replace it.
-        -->
+      Use SkipUnchangedFiles to prevent unnecessary file copies. The copy will occur if the
+      destination doesn't exist, the source is newer than the destination, or if the source and
+      destination differ by file size.
+      -->
     <Copy SourceFiles = "@(_ResolvedUnbundledFileToPublishAlways)"
           DestinationFiles="@(_ResolvedUnbundledFileToPublishAlways->'$(PublishDir)%(RelativePath)')"
+          SkipUnchangedFiles="$(SkipCopyUnchangedFiles)"
           OverwriteReadOnlyFiles="$(OverwriteReadOnlyFiles)"
           Retries="$(CopyRetryCount)"
           RetryDelayMilliseconds="$(CopyRetryDelayMilliseconds)"

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -522,7 +522,12 @@ Copyright (c) .NET Foundation. All rights reserved.
       <None Include="$(AppHostIntermediatePath)">
         <Link>$(AssemblyName)$(_NativeExecutableExtension)</Link>
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-        <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+        <!-- Always copy the AppHost because the contents of the apphost binary can change during the publish step (due to single-file bundling). 
+             Always copying the apphost ensures that that the sequence
+                 dotnet publish /p:PublishSingleFile=true 
+                 dotnet publish /p:PublishSingleFile=false
+             places the correct unbundled apphost in the publish directory. -->
+        <CopyToPublishDirectory>Always</CopyToPublishDirectory>
       </None>
     </ItemGroup>
     

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAHelloWorldProject.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAHelloWorldProject.cs
@@ -445,15 +445,23 @@ public static class Program
             publishResult.Should().Pass();
         }
 
-        [Fact]
-        public void It_preserves_newest_files_on_publish()
+        [Theory]
+        [InlineData("netcoreapp2.1")]
+        [InlineData("netcoreapp3.0")]
+        public void It_preserves_newest_files_on_publish(string tfm)
         {
-            var helloWorldAsset = _testAssetsManager
-                .CopyTestAsset("HelloWorld")
-                .WithSource()
-                .Restore(Log);
+            var testProject = new TestProject()
+            {
+                Name = "PreserveNewestFilesOnPublish",
+                IsSdkProject = true,
+                TargetFrameworks = tfm,
+                IsExe = true
+            };
 
-            var publishCommand = new PublishCommand(Log, helloWorldAsset.TestRoot);
+            var testAsset = _testAssetsManager.CreateTestProject(testProject, testProject.Name)
+                .Restore(Log, testProject.Name);
+
+            var publishCommand = new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
 
             publishCommand
                 .Execute("-v:n")

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishASingleFileApp.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishASingleFileApp.cs
@@ -227,5 +227,52 @@ namespace Microsoft.NET.Publish.Tests
             fileWriteTimeAfterSecondRun.Should().Be(fileWriteTimeAfterFirstRun);
         }
 
+        [Fact]
+        public void It_rewrites_the_apphost_for_single_file_publish()
+        {
+            var publishCommand = GetPublishCommand();
+            var appHostPath = Path.Combine(GetPublishDirectory(publishCommand).FullName, SingleFile);
+            var singleFilePath = appHostPath;
+
+            publishCommand
+                .Execute(RuntimeIdentifier, FrameworkDependent)
+                .Should()
+                .Pass();
+            var appHostSize = new FileInfo(appHostPath).Length;
+
+            WaitForUtcNowToAdvance();
+
+            publishCommand
+                .Execute(PublishSingleFile, RuntimeIdentifier, FrameworkDependent)
+                .Should()
+                .Pass();
+            var singleFileSize = new FileInfo(singleFilePath).Length;
+
+            singleFileSize.Should().BeGreaterThan(appHostSize);
+        }
+
+        [Fact]
+        public void It_rewrites_the_apphost_for_non_single_file_publish()
+        {
+            var publishCommand = GetPublishCommand();
+            var appHostPath = Path.Combine(GetPublishDirectory(publishCommand).FullName, SingleFile);
+            var singleFilePath = appHostPath;
+
+            publishCommand
+                .Execute(PublishSingleFile, RuntimeIdentifier, FrameworkDependent)
+                .Should()
+                .Pass();
+            var singleFileSize = new FileInfo(singleFilePath).Length;
+
+            WaitForUtcNowToAdvance();
+
+            publishCommand
+                .Execute(RuntimeIdentifier, FrameworkDependent)
+                .Should()
+                .Pass();
+            var appHostSize = new FileInfo(appHostPath).Length;
+
+            appHostSize.Should().BeLessThan(singleFileSize);
+        }
     }
 }


### PR DESCRIPTION
Always copy the AppHost from intermediate to publish directory in order to ensure that the sequence
    dotnet publish /p:PublishSingleFile=true
    dotnet publish /p:PublishSingleFile=false
places the correct unbundled apphost in the publish directory.

Fixes #3337