### PR TITLE
SingleFile: Update a test with ni-pdbs

### DIFF
--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishASingleFileApp.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishASingleFileApp.cs
@@ -157,6 +157,8 @@ namespace Microsoft.NET.Publish.Tests
             GetPublishDirectory(publishCommand)
                 .Should()
                 .HaveFiles(expectedFiles);
+            // Once coreclr/#25522 is fixed, the above test can be changed
+            // to .OnlyHaveFiles(expectedFiles)
         }
 
         [WindowsOnlyFact]

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishASingleFileApp.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishASingleFileApp.cs
@@ -156,7 +156,7 @@ namespace Microsoft.NET.Publish.Tests
             string[] expectedFiles = { SingleFile, PdbFile, NiPdbFile };
             GetPublishDirectory(publishCommand)
                 .Should()
-                .OnlyHaveFiles(expectedFiles);
+                .HaveFiles(expectedFiles);
         }
 
         [WindowsOnlyFact]


### PR DESCRIPTION
The test GivenThatWeWantToPublishASingleFileApp.It_excludes_ni_pdbs_from_single_file
checks for the fact that ni.pdb files are not bundled into the single-file by default.

This test was expecting only the `<app>.ni.pdb` file to exist in the publish directory.
However, in recent versions of the build, mscorlib.ni.pdb is also found.

This commit changes the test to accomodate additional files in the publish directory.