### PR TITLE
Updating PublishItemsOutputGroup to resolve runtime assets during design time builds

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -907,10 +907,17 @@ Copyright (c) .NET Foundation. All rights reserved.
   <PropertyGroup>
     <PublishItemsOutputGroupDependsOn>
       $(PublishItemsOutputGroupDependsOn);
+      BeforePublishItemsOutputGroup;
       ResolveReferences;
       ComputeFilesToPublish;
     </PublishItemsOutputGroupDependsOn>
   </PropertyGroup>
+
+  <Target Name="BeforePublishItemsOutputGroup">
+    <PropertyGroup>
+      <ResolveRuntimeAssetsDuringDesignTimeBuild>true</ResolveRuntimeAssetsDuringDesignTimeBuild>
+    </PropertyGroup>
+  </Target>
 
   <Target Name="PublishItemsOutputGroup" DependsOnTargets="$(PublishItemsOutputGroupDependsOn)" Returns="@(PublishItemsOutputGroupOutputs)">
     <ItemGroup>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -907,17 +907,10 @@ Copyright (c) .NET Foundation. All rights reserved.
   <PropertyGroup>
     <PublishItemsOutputGroupDependsOn>
       $(PublishItemsOutputGroupDependsOn);
-      BeforePublishItemsOutputGroup;
       ResolveReferences;
       ComputeFilesToPublish;
     </PublishItemsOutputGroupDependsOn>
   </PropertyGroup>
-
-  <Target Name="BeforePublishItemsOutputGroup">
-    <PropertyGroup>
-      <ResolveRuntimeAssetsDuringDesignTimeBuild>true</ResolveRuntimeAssetsDuringDesignTimeBuild>
-    </PropertyGroup>
-  </Target>
 
   <Target Name="PublishItemsOutputGroup" DependsOnTargets="$(PublishItemsOutputGroupDependsOn)" Returns="@(PublishItemsOutputGroupOutputs)">
     <ItemGroup>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets
@@ -303,7 +303,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     ============================================================
     -->
   <Target Name="ResolveRuntimePackAssets" DependsOnTargets="ResolveFrameworkReferences"
-          Condition="'@(RuntimePack)' != '' And '$(DesignTimeBuild)' != 'true'">
+          Condition="'@(RuntimePack)' != '' And ('$(DesignTimeBuild)' != 'true' or '$(ResolveRuntimeAssetsDuringDesignTimeBuild)' == 'true')">
         
     <ResolveRuntimePackAssets FrameworkReferences="@(FrameworkReference)"
                               ResolvedRuntimePacks="@(ResolvedRuntimePack)"

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets
@@ -303,7 +303,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     ============================================================
     -->
   <Target Name="ResolveRuntimePackAssets" DependsOnTargets="ResolveFrameworkReferences"
-          Condition="'@(RuntimePack)' != '' And ('$(DesignTimeBuild)' != 'true' or '$(ResolveRuntimeAssetsDuringDesignTimeBuild)' == 'true')">
+          Condition="'@(RuntimePack)' != ''">
         
     <ResolveRuntimePackAssets FrameworkReferences="@(FrameworkReference)"
                               ResolvedRuntimePacks="@(ResolvedRuntimePack)"

--- a/src/Tests/Microsoft.NET.Publish.Tests/PublishItemsOutputGroupTests.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/PublishItemsOutputGroupTests.cs
@@ -38,7 +38,7 @@ namespace Microsoft.NET.Publish.Tests
 
             var buildCommand = new BuildCommand(Log, testAsset.Path, testProject.Name);
             buildCommand
-                .Execute("/p:RuntimeIdentifier=win-x86", "/t:PublishItemsOutputGroup")
+                .Execute("/p:RuntimeIdentifier=win-x86;DesignTimeBuild=true", "/t:PublishItemsOutputGroup")
                 .Should()
                 .Pass();
 
@@ -72,7 +72,7 @@ namespace Microsoft.NET.Publish.Tests
 
             var buildCommand = new BuildCommand(Log, testAsset.Path, testProject.Name);
             buildCommand
-                .Execute("/t:PublishItemsOutputGroup")
+                .Execute("/p:DesignTimeBuild=true", "/t:PublishItemsOutputGroup")
                 .Should()
                 .Pass();
 


### PR DESCRIPTION
Since this output group is meant to be used by installer projects which deal exclusively with design time builds we need ResolveRuntimePackAssets to always run when building it.

Also updating tests for this output group to set DesignTimeBuild=true to more accurately simulate this scenario.