### PR TITLE
Continue design time builds if resolving package assets fails

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.PackageDependencyResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.PackageDependencyResolution.targets
@@ -221,6 +221,12 @@ Copyright (c) .NET Foundation. All rights reserved.
       <CopyLocalRuntimeTargetAssets>true</CopyLocalRuntimeTargetAssets>
     </PropertyGroup>
 
+    <!-- Continue design time builds if resolving package assets fails -->
+    <PropertyGroup>
+      <_ResolvePackageAssetsContinueOnError Condition="'$(DesignTimeBuild)' == 'true'">ErrorAndContinue</_ResolvePackageAssetsContinueOnError>
+      <_ResolvePackageAssetsContinueOnError Condition="'$(_ResolvePackageAssetsContinueOnError)' == ''">false</_ResolvePackageAssetsContinueOnError>
+    </PropertyGroup>
+
     <ItemGroup>
       <_PackAsToolShimRuntimeIdentifiers Condition="@(_PackAsToolShimRuntimeIdentifiers) ==''" Include="$(PackAsToolShimRuntimeIdentifiers)"/>
 
@@ -255,6 +261,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       ExpectedPlatformPackages="@(ExpectedPlatformPackages)"
       SatelliteResourceLanguages="$(SatelliteResourceLanguages)"
       DesignTimeBuild="$(DesignTimeBuild)"
+      ContinueOnError="$(_ResolvePackageAssetsContinueOnError)"
       PackageReferences="@(PackageReference)">
 
       <!-- NOTE: items names here are inconsistent because they match prior implementation


### PR DESCRIPTION
Design time builds are stopping if `ResolvePackageAssets` hits an error (https://github.com/dotnet/project-system/issues/4992). This PR sets `ContinueOnError` on `ResolvePackageAssets` to `ErrorAndContinue` for design time builds only.

Would the property be better defined in `Microsoft.NET.Sdk.props` with a more general name for broader use?

Alternatively, should this logic piggyback off the `DesignTimeBuild` property of the task itself?

https://github.com/dotnet/sdk/blob/adf76a594158a742e2c22b49b0fb4942cb53317d/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageAssets.cs#L153