### PR TITLE
Continue design time builds if resolving package assets fails

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.targets
@@ -274,13 +274,16 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <PropertyGroup>
       <DefaultItemsMoreInformationLink>https://aka.ms/sdkimplicititems</DefaultItemsMoreInformationLink>
+    </PropertyGroup>
 
-      <!-- For the design-time build, we will continue on error and remove the duplicate items.
-           This is because otherwise there won't be any references to pass to the compiler, leading to design-time
-           compilation errors for every API that is used in the project.  Amidst all the compile errors, it would
-           be easy to miss the duplicate items error which is the real source of the problem. -->
-      <CheckForDuplicateItemsContinueOnError>false</CheckForDuplicateItemsContinueOnError>
-      <CheckForDuplicateItemsContinueOnError Condition="'$(DesignTimeBuild)' == 'true'">ErrorAndContinue</CheckForDuplicateItemsContinueOnError>
+    <!-- NOTE for design-time builds we continue on errors and remove the duplicate items.
+         This is because otherwise there won't be any references to pass to the compiler, leading to design-time
+         compilation errors for every API that is used in the project.  Amidst all the compile errors, it would
+         be easy to miss the duplicate items error which is the real source of the problem. -->
+
+    <PropertyGroup>
+      <!-- Design time builds set this property to "ErrorAndContinue" -->
+      <ContinueOnError Condition="'$(ContinueOnError)' == ''">false</ContinueOnError>
     </PropertyGroup>
 
     <CheckForDuplicateItems
@@ -290,7 +293,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       DefaultItemsOfThisTypeEnabled="$(EnableDefaultCompileItems)"
       PropertyNameToDisableDefaultItems="EnableDefaultCompileItems"
       MoreInformationLink="$(DefaultItemsMoreInformationLink)"
-      ContinueOnError="$(CheckForDuplicateItemsContinueOnError)">
+      ContinueOnError="$(ContinueOnError)">
       <Output TaskParameter="DeduplicatedItems" ItemName="DeduplicatedCompileItems" />
     </CheckForDuplicateItems>
 
@@ -301,7 +304,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       DefaultItemsOfThisTypeEnabled="$(EnableDefaultEmbeddedResourceItems)"
       PropertyNameToDisableDefaultItems="EnableDefaultEmbeddedResourceItems"
       MoreInformationLink="$(DefaultItemsMoreInformationLink)"
-      ContinueOnError="$(CheckForDuplicateItemsContinueOnError)">
+      ContinueOnError="$(ContinueOnError)">
       <Output TaskParameter="DeduplicatedItems" ItemName="DeduplicatedEmbeddedResourceItems" />
     </CheckForDuplicateItems>
     
@@ -313,7 +316,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       DefaultItemsOfThisTypeEnabled="$(EnableDefaultContentItems)"
       PropertyNameToDisableDefaultItems="EnableDefaultContentItems"
       MoreInformationLink="$(DefaultItemsMoreInformationLink)"
-      ContinueOnError="$(CheckForDuplicateItemsContinueOnError)">
+      ContinueOnError="$(ContinueOnError)">
       <Output TaskParameter="DeduplicatedItems" ItemName="DeduplicatedContentItems" />
     </CheckForDuplicateItems>
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.targets
@@ -281,11 +281,6 @@ Copyright (c) .NET Foundation. All rights reserved.
          compilation errors for every API that is used in the project.  Amidst all the compile errors, it would
          be easy to miss the duplicate items error which is the real source of the problem. -->
 
-    <PropertyGroup>
-      <!-- Design time builds set this property to "ErrorAndContinue" -->
-      <ContinueOnError Condition="'$(ContinueOnError)' == ''">false</ContinueOnError>
-    </PropertyGroup>
-
     <CheckForDuplicateItems
       Items="@(Compile)"
       ItemName="Compile"

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.targets
@@ -281,6 +281,12 @@ Copyright (c) .NET Foundation. All rights reserved.
          compilation errors for every API that is used in the project.  Amidst all the compile errors, it would
          be easy to miss the duplicate items error which is the real source of the problem. -->
 
+    <!-- We no longer use the CheckForDuplicateItemsContinueOnError property here, but the WPF repo has a dependency upon it.
+         Remove this assignment if https://github.com/dotnet/wpf/pull/1235 is merged. -->
+    <PropertyGroup>
+      <CheckForDuplicateItemsContinueOnError Condition="'$(CheckForDuplicateItemsContinueOnError)' == ''">$(ContinueOnError)</CheckForDuplicateItemsContinueOnError>
+    </PropertyGroup>
+
     <CheckForDuplicateItems
       Items="@(Compile)"
       ItemName="Compile"

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.PackageDependencyResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.PackageDependencyResolution.targets
@@ -231,6 +231,11 @@ Copyright (c) .NET Foundation. All rights reserved.
       <ExpectedPlatformPackages Include="@(PackageReference)" Condition="'%(Identity)' == 'Microsoft.AspNetCore.All'" />
     </ItemGroup>
 
+    <PropertyGroup>
+      <!-- Design time builds set this property to "ErrorAndContinue" -->
+      <ContinueOnError Condition="'$(ContinueOnError)' == ''">false</ContinueOnError>
+    </PropertyGroup>
+
     <ResolvePackageAssets 
       ProjectAssetsFile="$(ProjectAssetsFile)"
       ProjectAssetsCacheFile="$(ProjectAssetsCacheFile)"
@@ -255,6 +260,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       ExpectedPlatformPackages="@(ExpectedPlatformPackages)"
       SatelliteResourceLanguages="$(SatelliteResourceLanguages)"
       DesignTimeBuild="$(DesignTimeBuild)"
+      ContinueOnError="$(ContinueOnError)"
       PackageReferences="@(PackageReference)">
 
       <!-- NOTE: items names here are inconsistent because they match prior implementation

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.PackageDependencyResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.PackageDependencyResolution.targets
@@ -231,11 +231,6 @@ Copyright (c) .NET Foundation. All rights reserved.
       <ExpectedPlatformPackages Include="@(PackageReference)" Condition="'%(Identity)' == 'Microsoft.AspNetCore.All'" />
     </ItemGroup>
 
-    <PropertyGroup>
-      <!-- Design time builds set this property to "ErrorAndContinue" -->
-      <ContinueOnError Condition="'$(ContinueOnError)' == ''">false</ContinueOnError>
-    </PropertyGroup>
-
     <ResolvePackageAssets 
       ProjectAssetsFile="$(ProjectAssetsFile)"
       ProjectAssetsCacheFile="$(ProjectAssetsCacheFile)"


### PR DESCRIPTION
(This is an alternative implementation of #3398.)

Design time builds are stopping if `ResolvePackageAssets` hits an error (dotnet/project-system#4992).

This PR uses the fact that design-time builds set the `ContinueOnError` property to `ErrorAndContinue`.

