### PR TITLE
Remove CheckForDuplicateItemsContinueOnError property

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.targets
@@ -285,12 +285,6 @@ Copyright (c) .NET Foundation. All rights reserved.
          compilation errors for every API that is used in the project.  Amidst all the compile errors, it would
          be easy to miss the duplicate items error which is the real source of the problem. -->
 
-    <!-- We no longer use the CheckForDuplicateItemsContinueOnError property here, but the WPF repo has a dependency upon it.
-         Remove this assignment if https://github.com/dotnet/wpf/pull/1235 is merged. -->
-    <PropertyGroup>
-      <CheckForDuplicateItemsContinueOnError Condition="'$(CheckForDuplicateItemsContinueOnError)' == ''">$(ContinueOnError)</CheckForDuplicateItemsContinueOnError>
-    </PropertyGroup>
-
     <CheckForDuplicateItems
       Items="@(Compile)"
       ItemName="Compile"


### PR DESCRIPTION
#### Description
Remove unused CheckForDuplicateItemsContinueOnError property.

This was logically part of https://github.com/dotnet/sdk/pull/3399, which switched to using the generic ContinueOnError throughout, which is a better pattern for design time builds. but had to wait for https://github.com/dotnet/wpf/pull/1235 to go through.

#### Customer Impact
None. This is just finishing the change so that we don't have dead code to confuse us in 3.0.

#### Regression?
No. 

#### Risk
Low. Removes dead code.

--
Follows #3399.

The `CheckForDuplicateItemsContinueOnError` property was used by WPF projects.

https://github.com/dotnet/wpf/pull/1235 makes WPF use `ContinueOnError` instead, so this temporary property can be removed once things propagate.

Marked as WIP as merging should be [delayed a few days](https://github.com/dotnet/sdk/pull/3399#discussion_r302977781).