### PR TITLE
Delete output apphost upon failure of the CreateAppHost task.

### DIFF
--- a/src/Tasks/Common/Resources/Strings.resx
+++ b/src/Tasks/Common/Resources/Strings.resx
@@ -540,12 +540,16 @@ The following are names of parameters or literal values and should not be transl
     <value>NETSDK1108: ReadyToRun compilation will be skipped because it is only supported for executable projects.</value>
     <comment>{StrBegin="NETSDK1108: "}</comment>
   </data>
-    <data name="RuntimeListNotFound" xml:space="preserve">
+  <data name="RuntimeListNotFound" xml:space="preserve">
     <value>NETSDK1109: Runtime list file '{0}' was not found. Report this error to the .NET Core team here: https://aka.ms/dotnet-sdk-issue.</value>
     <comment>{StrBegin="NETSDK1109: "}</comment>
   </data>
   <data name="DuplicateRuntimePackAsset" xml:space="preserve">
     <value>NETSDK1110: More than one asset in the runtime pack has the same destination sub-path of '{0}'. Report this error to the .NET Core team here: https://aka.ms/dotnet-sdk-issue.</value>
     <comment>{StrBegin="NETSDK1110: "}</comment>
+  </data>
+  <data name="FailedToDeleteApphost" xml:space="preserve">
+    <value>NETSDK1111: Failed to delete output apphost: {0}</value>
+    <comment>{StrBegin="NETSDK1111: "}</comment>
   </data>
 </root>

--- a/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
@@ -267,6 +267,11 @@
         <target state="translated">NETSDK1060: Chyba při načítání souboru prostředků: {0}</target>
         <note>{StrBegin="NETSDK1060: "}</note>
       </trans-unit>
+      <trans-unit id="FailedToDeleteApphost">
+        <source>NETSDK1111: Failed to delete output apphost: {0}</source>
+        <target state="new">NETSDK1111: Failed to delete output apphost: {0}</target>
+        <note>{StrBegin="NETSDK1111: "}</note>
+      </trans-unit>
       <trans-unit id="FailedToLockResource">
         <source>NETSDK1077: Failed to lock resource.</source>
         <target state="translated">NETSDK1077: Nepovedlo se uzamknout prostředek.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.de.xlf
@@ -267,6 +267,11 @@
         <target state="translated">NETSDK1060: Fehler beim Lesen der Ressourcendatei: {0}</target>
         <note>{StrBegin="NETSDK1060: "}</note>
       </trans-unit>
+      <trans-unit id="FailedToDeleteApphost">
+        <source>NETSDK1111: Failed to delete output apphost: {0}</source>
+        <target state="new">NETSDK1111: Failed to delete output apphost: {0}</target>
+        <note>{StrBegin="NETSDK1111: "}</note>
+      </trans-unit>
       <trans-unit id="FailedToLockResource">
         <source>NETSDK1077: Failed to lock resource.</source>
         <target state="translated">NETSDK1077: Fehler beim Sperren der Ressource.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.es.xlf
@@ -267,6 +267,11 @@
         <target state="translated">NETSDK1060: Error al leer el archivo de activos: {0}</target>
         <note>{StrBegin="NETSDK1060: "}</note>
       </trans-unit>
+      <trans-unit id="FailedToDeleteApphost">
+        <source>NETSDK1111: Failed to delete output apphost: {0}</source>
+        <target state="new">NETSDK1111: Failed to delete output apphost: {0}</target>
+        <note>{StrBegin="NETSDK1111: "}</note>
+      </trans-unit>
       <trans-unit id="FailedToLockResource">
         <source>NETSDK1077: Failed to lock resource.</source>
         <target state="translated">NETSDK1077: No se pudo bloquear el recurso.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
@@ -267,6 +267,11 @@
         <target state="translated">NETSDK1060: Erreur durant la lecture du fichier de composants : {0}</target>
         <note>{StrBegin="NETSDK1060: "}</note>
       </trans-unit>
+      <trans-unit id="FailedToDeleteApphost">
+        <source>NETSDK1111: Failed to delete output apphost: {0}</source>
+        <target state="new">NETSDK1111: Failed to delete output apphost: {0}</target>
+        <note>{StrBegin="NETSDK1111: "}</note>
+      </trans-unit>
       <trans-unit id="FailedToLockResource">
         <source>NETSDK1077: Failed to lock resource.</source>
         <target state="translated">NETSDK1077: échec du verrouillage de la ressource.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.it.xlf
@@ -267,6 +267,11 @@
         <target state="translated">NETSDK1060: errore durante la lettura del file di asset: {0}</target>
         <note>{StrBegin="NETSDK1060: "}</note>
       </trans-unit>
+      <trans-unit id="FailedToDeleteApphost">
+        <source>NETSDK1111: Failed to delete output apphost: {0}</source>
+        <target state="new">NETSDK1111: Failed to delete output apphost: {0}</target>
+        <note>{StrBegin="NETSDK1111: "}</note>
+      </trans-unit>
       <trans-unit id="FailedToLockResource">
         <source>NETSDK1077: Failed to lock resource.</source>
         <target state="translated">NETSDK1077: non è stato possibile bloccare la risorsa.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
@@ -267,6 +267,11 @@
         <target state="translated">NETSDK1060: アセット ファイルの読み取りでエラーが発生しました: {0}</target>
         <note>{StrBegin="NETSDK1060: "}</note>
       </trans-unit>
+      <trans-unit id="FailedToDeleteApphost">
+        <source>NETSDK1111: Failed to delete output apphost: {0}</source>
+        <target state="new">NETSDK1111: Failed to delete output apphost: {0}</target>
+        <note>{StrBegin="NETSDK1111: "}</note>
+      </trans-unit>
       <trans-unit id="FailedToLockResource">
         <source>NETSDK1077: Failed to lock resource.</source>
         <target state="translated">NETSDK1077: リソースをロックできませんでした。</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
@@ -267,6 +267,11 @@
         <target state="translated">NETSDK1060: 자산 파일 {0}을(를) 읽는 동안 오류가 발생했습니다.</target>
         <note>{StrBegin="NETSDK1060: "}</note>
       </trans-unit>
+      <trans-unit id="FailedToDeleteApphost">
+        <source>NETSDK1111: Failed to delete output apphost: {0}</source>
+        <target state="new">NETSDK1111: Failed to delete output apphost: {0}</target>
+        <note>{StrBegin="NETSDK1111: "}</note>
+      </trans-unit>
       <trans-unit id="FailedToLockResource">
         <source>NETSDK1077: Failed to lock resource.</source>
         <target state="translated">NETSDK1077: 리소스를 잠그지 못했습니다.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
@@ -267,6 +267,11 @@
         <target state="translated">NETSDK1060: Błąd podczas odczytywania pliku zasobów: {0}</target>
         <note>{StrBegin="NETSDK1060: "}</note>
       </trans-unit>
+      <trans-unit id="FailedToDeleteApphost">
+        <source>NETSDK1111: Failed to delete output apphost: {0}</source>
+        <target state="new">NETSDK1111: Failed to delete output apphost: {0}</target>
+        <note>{StrBegin="NETSDK1111: "}</note>
+      </trans-unit>
       <trans-unit id="FailedToLockResource">
         <source>NETSDK1077: Failed to lock resource.</source>
         <target state="translated">NETSDK1077: Nie można zablokować zasobu.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
@@ -267,6 +267,11 @@
         <target state="translated">NETSDK1060: Erro ao ler o arquivo de ativos: {0}</target>
         <note>{StrBegin="NETSDK1060: "}</note>
       </trans-unit>
+      <trans-unit id="FailedToDeleteApphost">
+        <source>NETSDK1111: Failed to delete output apphost: {0}</source>
+        <target state="new">NETSDK1111: Failed to delete output apphost: {0}</target>
+        <note>{StrBegin="NETSDK1111: "}</note>
+      </trans-unit>
       <trans-unit id="FailedToLockResource">
         <source>NETSDK1077: Failed to lock resource.</source>
         <target state="translated">NETSDK1077: falha ao bloquear o recurso.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
@@ -267,6 +267,11 @@
         <target state="translated">NETSDK1060: ошибка при чтении файла ресурсов {0}</target>
         <note>{StrBegin="NETSDK1060: "}</note>
       </trans-unit>
+      <trans-unit id="FailedToDeleteApphost">
+        <source>NETSDK1111: Failed to delete output apphost: {0}</source>
+        <target state="new">NETSDK1111: Failed to delete output apphost: {0}</target>
+        <note>{StrBegin="NETSDK1111: "}</note>
+      </trans-unit>
       <trans-unit id="FailedToLockResource">
         <source>NETSDK1077: Failed to lock resource.</source>
         <target state="translated">NETSDK1077: не удалось заблокировать ресурс.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
@@ -267,6 +267,11 @@
         <target state="translated">NETSDK1060: Varlıklar dosyası okunurken hata: {0}</target>
         <note>{StrBegin="NETSDK1060: "}</note>
       </trans-unit>
+      <trans-unit id="FailedToDeleteApphost">
+        <source>NETSDK1111: Failed to delete output apphost: {0}</source>
+        <target state="new">NETSDK1111: Failed to delete output apphost: {0}</target>
+        <note>{StrBegin="NETSDK1111: "}</note>
+      </trans-unit>
       <trans-unit id="FailedToLockResource">
         <source>NETSDK1077: Failed to lock resource.</source>
         <target state="translated">NETSDK1077: Kaynak kilitlenemedi.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
@@ -267,6 +267,11 @@
         <target state="translated">NETSDK1060: 读取资产文件时出错: {0}</target>
         <note>{StrBegin="NETSDK1060: "}</note>
       </trans-unit>
+      <trans-unit id="FailedToDeleteApphost">
+        <source>NETSDK1111: Failed to delete output apphost: {0}</source>
+        <target state="new">NETSDK1111: Failed to delete output apphost: {0}</target>
+        <note>{StrBegin="NETSDK1111: "}</note>
+      </trans-unit>
       <trans-unit id="FailedToLockResource">
         <source>NETSDK1077: Failed to lock resource.</source>
         <target state="translated">NETSDK1077: 无法锁定资源。</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
@@ -267,6 +267,11 @@
         <target state="translated">NETSDK1060: 讀取資產檔案時發生錯誤: {0}</target>
         <note>{StrBegin="NETSDK1060: "}</note>
       </trans-unit>
+      <trans-unit id="FailedToDeleteApphost">
+        <source>NETSDK1111: Failed to delete output apphost: {0}</source>
+        <target state="new">NETSDK1111: Failed to delete output apphost: {0}</target>
+        <note>{StrBegin="NETSDK1111: "}</note>
+      </trans-unit>
       <trans-unit id="FailedToLockResource">
         <source>NETSDK1077: Failed to lock resource.</source>
         <target state="translated">NETSDK1077: 無法鎖定資源。</target>

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAnAppHost.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAnAppHost.cs
@@ -68,6 +68,8 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                     .Contain(sourceAppHostMock)
                     .And
                     .Contain(AppBinaryPathPlaceholder);
+
+                File.Exists(destinationFilePath).Should().BeFalse();
             }
         }
 
@@ -88,6 +90,8 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                     .Message
                     .Should()
                     .Contain(appBinaryFilePath);
+
+                File.Exists(destinationFilePath).Should().BeFalse();
             }
         }
 
@@ -161,6 +165,8 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                     .Message
                     .Should()
                     .Contain(sourceAppHostMock);
+
+                File.Exists(destinationFilePath).Should().BeFalse();
             }
         }
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/AppHost.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/AppHost.cs
@@ -97,7 +97,14 @@ namespace Microsoft.NET.Build.Tasks
             catch (Exception)
             {
                 // Delete the destination file so we don't leave an unmodified apphost
-                File.Delete(appHostDestinationFilePath);
+                try
+                {
+                    File.Delete(appHostDestinationFilePath);
+                }
+                catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException)
+                {
+                    log?.LogError(Strings.FailedToDeleteApphost, ex.Message);
+                }
                 throw;
             }
         }


### PR DESCRIPTION
This commit deletes the output apphost when the `CreateAppHost` task fails from
an exception.

Partially fixes #2989.