### PR TITLE
Fix regeneration of files when asset cache changes.

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -46,6 +46,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <ItemGroup>
     <GenerateRuntimeConfigurationFilesInputs Include="$(ProjectAssetsFile)" />
+    <GenerateRuntimeConfigurationFilesInputs Include="$(ProjectAssetsCacheFile)" />
     <GenerateRuntimeConfigurationFilesInputs Include="$(UserRuntimeConfig)" Condition=" Exists($(UserRuntimeConfig)) " />
   </ItemGroup>
 
@@ -153,7 +154,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                             _ComputePackageReferencePublish"
           BeforeTargets="CopyFilesToOutputDirectory"
           Condition="'$(GenerateDependencyFile)' == 'true'"
-          Inputs="$(ProjectAssetsFile);$(MSBuildAllProjects)"
+          Inputs="$(ProjectAssetsFile);$(ProjectAssetsCacheFile);$(MSBuildAllProjects)"
           Outputs="$(ProjectDepsFilePath)">
 
     <ItemGroup>


### PR DESCRIPTION
Both the deps.json and runtimeconfig.json files remain unchanged when an
incremental build takes place that changes a property that would invalidate the
assets cache.

For a property like `SelfContained`, this might mean the files are no longer
valid for the incremental build's output.

Fixes dotnet/cli#11956.