### PR TITLE
Do not use apphost when resolving assets for dotnet store

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ComposeStore.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ComposeStore.targets
@@ -101,7 +101,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 <!-- Resolve phase-->
     <MSBuild Projects="@(PackageReferencesToStore)"
                  Targets="StoreResolver"
-                 Properties="SelfContained=false;MSBuildProjectExtensionsPath=$(ComposeWorkingDir)\%(PackageReferencesToStore.PackageName)_$([System.String]::Copy('%(PackageReferencesToStore.PackageVersion)').Replace('*','-'))\;"
+                 Properties="SelfContained=false;UseAppHost=false;MSBuildProjectExtensionsPath=$(ComposeWorkingDir)\%(PackageReferencesToStore.PackageName)_$([System.String]::Copy('%(PackageReferencesToStore.PackageVersion)').Replace('*','-'))\;"
                  BuildInParallel="$(BuildInParallel)">
       <Output ItemName="ResolvedPackagesFromMapper" TaskParameter="TargetOutputs" />
     </MSBuild>

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToStoreAProjectWithDependencies.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToStoreAProjectWithDependencies.cs
@@ -17,7 +17,7 @@ using Microsoft.NET.TestFramework.ProjectConstruction;
 
 using NuGet.Packaging.Core;
 using NuGet.Versioning;
-
+using Xunit;
 using Xunit.Abstractions;
 
 namespace Microsoft.NET.Publish.Tests
@@ -300,8 +300,10 @@ namespace Microsoft.NET.Publish.Tests
             }
         }
 
-        [CoreMSBuildOnlyFact]
-        public void It_stores_when_targeting_netcoreapp3()
+        [CoreMSBuildOnlyTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void It_stores_when_targeting_netcoreapp3(bool isExe)
         {
             const string TFM = "netcoreapp3.0";
 
@@ -309,12 +311,13 @@ namespace Microsoft.NET.Publish.Tests
             {
                 Name = "Test",
                 IsSdkProject = true,
-                TargetFrameworks = TFM
+                TargetFrameworks = TFM,
+                IsExe = isExe,
             };
 
             testProject.PackageReferences.Add(new TestPackageReference("Newtonsoft.Json", "12.0.1"));
 
-            var testProjectInstance = _testAssetsManager.CreateTestProject(testProject);
+            var testProjectInstance = _testAssetsManager.CreateTestProject(testProject, identifier: isExe.ToString());
 
             var outputFolder = Path.Combine(testProjectInstance.TestRoot, "o");
             var workingDir = Path.Combine(testProjectInstance.TestRoot, "w");


### PR DESCRIPTION
Some changes in the way apphost is handled broke the case where you
use an exe project as the dotnet store "manifest" project.

The fix is to set UseAppHost=false when doing the store resolution.

Fix #3168