### PR TITLE
Fix building VB WPF project

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.VisualBasic.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.VisualBasic.targets
@@ -103,7 +103,13 @@ Copyright (c) .NET Foundation. All rights reserved.
     <VBRuntime>Embed</VBRuntime>
   </PropertyGroup>
 
-  <Target Name="_UseReferencedVBRuntime" Condition="'$(UseReferencedVBRuntime)' == 'true'" AfterTargets="ResolveAssemblyReferences">
+  <!--
+    NOTE: We must hook directly to CoreCompile for compatibility with two phase XAML
+          build. We also must not pull in a dependency on ResolveAssemblyReferences
+          as the generated temporary project for xaml compilation has a hard-coded list
+          of items in ReferencePath, and does not need to run RAR.
+  -->
+  <Target Name="_UseReferencedVBRuntime" Condition="'$(UseReferencedVBRuntime)' == 'true'" BeforeTargets="CoreCompile">
     <PropertyGroup>
       <VBRuntime Condition="'%(ReferencePath.FileName)' == 'Microsoft.VisualBasic'">%(ReferencePath.Identity)</VBRuntime>
     </PropertyGroup>

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToUseVB.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToUseVB.cs
@@ -36,7 +36,7 @@ namespace Microsoft.NET.Build.Tests
         [InlineData("netstandard2.0")]
         [InlineData("netcoreapp2.1")]
         [InlineData("netcoreapp3.0")]
-        public void It_builds_a_simple_project(string targetFramework)
+        public void It_builds_a_simple_vb_project(string targetFramework)
         {
             if (targetFramework == "net45" && !TestProject.ReferenceAssembliesAreInstalled("v4.5"))
             {
@@ -164,6 +164,19 @@ namespace Microsoft.NET.Build.Tests
                         ? VBRuntime.Referenced
                         : VBRuntime.Unknown;
             }
+        }
+
+        [WindowsOnlyFact]
+        public void It_builds_a_vb_wpf_app()
+        {
+            var testDirectory = _testAssetsManager.CreateTestDirectory().Path;
+
+            var newCommand = new DotnetCommand(Log, "new", "wpf", "-lang", "vb");
+            newCommand.WorkingDirectory = testDirectory;
+            newCommand.Execute().Should().Pass();
+
+            var buildCommand = new BuildCommand(Log, testDirectory);
+            buildCommand.Execute().Should().Pass();
         }
     }
 }


### PR DESCRIPTION
The target to select the VB runtime DLL from ReferencePath was not being run when compiling the temporary project for a XAML build.

Fix #3450