### PR TITLE
Calculate PackageConflictPreferredPackages from KnownFrameworkReference items

### DIFF
--- a/src/Tasks/Common/MetadataKeys.cs
+++ b/src/Tasks/Common/MetadataKeys.cs
@@ -77,6 +77,9 @@ namespace Microsoft.NET.Build.Tasks
         public const string TargetPath = "TargetPath";
         public const string CopyLocal = "CopyLocal";
 
+        //  Targeting packs
+        public const string PackageConflictPreferredPackages = "PackageConflictPreferredPackages";
+
         // Content files
         public const string PPOutputPath = "PPOutputPath";
         public const string CodeLanguage = "CodeLanguage";

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ProcessFrameworkReferences.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ProcessFrameworkReferences.cs
@@ -108,9 +108,23 @@ namespace Microsoft.NET.Build.Tasks
                     continue;
                 }
 
+                List<string> preferredPackages = new List<string>();
+                preferredPackages.Add(knownFrameworkReference.TargetingPackName);
+
+                var knownFrameworkReferenceRuntimePackRuntimeIdentifiers = knownFrameworkReference.RuntimePackRuntimeIdentifiers.Split(';');
+                foreach (var runtimeIdentifier in knownFrameworkReferenceRuntimePackRuntimeIdentifiers)
+                {
+                    foreach (var runtimePackNamePattern in knownFrameworkReference.RuntimePackNamePatterns.Split(';'))
+                    {
+                        string runtimePackName = runtimePackNamePattern.Replace("**RID**", runtimeIdentifier);
+                        preferredPackages.Add(runtimePackName);
+                    }
+                }
+
                 //  Get the path of the targeting pack in the targeting pack root (e.g. dotnet/ref)
                 TaskItem targetingPack = new TaskItem(knownFrameworkReference.Name);
                 targetingPack.SetMetadata(MetadataKeys.PackageName, knownFrameworkReference.TargetingPackName);
+                targetingPack.SetMetadata("PackageConflictPreferredPackages", string.Join(";", preferredPackages));
 
                 string targetingPackVersion = null;
                 if (frameworkReference != null)

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ProcessFrameworkReferences.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ProcessFrameworkReferences.cs
@@ -124,7 +124,7 @@ namespace Microsoft.NET.Build.Tasks
                 //  Get the path of the targeting pack in the targeting pack root (e.g. dotnet/ref)
                 TaskItem targetingPack = new TaskItem(knownFrameworkReference.Name);
                 targetingPack.SetMetadata(MetadataKeys.PackageName, knownFrameworkReference.TargetingPackName);
-                targetingPack.SetMetadata("PackageConflictPreferredPackages", string.Join(";", preferredPackages));
+                targetingPack.SetMetadata(MetadataKeys.PackageConflictPreferredPackages, string.Join(";", preferredPackages));
 
                 string targetingPackVersion = null;
                 if (frameworkReference != null)

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolveTargetingPackAssets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveTargetingPackAssets.cs
@@ -45,6 +45,7 @@ namespace Microsoft.NET.Build.Tasks
             List<TaskItem> platformManifests = new List<TaskItem>();
             PackageConflictPreferredPackages = string.Empty;
             List<TaskItem> packageConflictOverrides = new List<TaskItem>();
+            List<string> preferredPackages = new List<string>();
 
             var resolvedTargetingPacks = ResolvedTargetingPacks.ToDictionary(item => item.ItemSpec, StringComparer.OrdinalIgnoreCase);
 
@@ -100,12 +101,7 @@ namespace Microsoft.NET.Build.Tasks
                             packageConflictOverrides.Add(CreatePackageOverride(targetingPack.GetMetadata("RuntimeFrameworkName"), packageOverridesPath));
                         }
 
-                        if (targetingPack.ItemSpec.Equals("Microsoft.NETCore.App", StringComparison.OrdinalIgnoreCase))
-                        {
-                            //  Hardcode this for now.  Once the targeting pack has PackageOverrides.txt, then delete this code
-                            //  https://github.com/dotnet/cli/issues/10581
-                            PackageConflictPreferredPackages = "Microsoft.NETCore.App;runtime.linux-x64.Microsoft.NETCore.App;runtime.linux-x64.Microsoft.NETCore.App;runtime.linux-musl-x64.Microsoft.NETCore.App;runtime.linux-musl-x64.Microsoft.NETCore.App;runtime.rhel.6-x64.Microsoft.NETCore.App;runtime.rhel.6-x64.Microsoft.NETCore.App;runtime.osx-x64.Microsoft.NETCore.App;runtime.osx-x64.Microsoft.NETCore.App;runtime.freebsd-x64.Microsoft.NETCore.App;runtime.freebsd-x64.Microsoft.NETCore.App;runtime.win-x86.Microsoft.NETCore.App;runtime.win-x86.Microsoft.NETCore.App;runtime.win-arm.Microsoft.NETCore.App;runtime.win-arm.Microsoft.NETCore.App;runtime.win-arm64.Microsoft.NETCore.App;runtime.win-arm64.Microsoft.NETCore.App;runtime.linux-arm.Microsoft.NETCore.App;runtime.linux-arm.Microsoft.NETCore.App;runtime.linux-arm64.Microsoft.NETCore.App;runtime.linux-arm64.Microsoft.NETCore.App;runtime.tizen.4.0.0-armel.Microsoft.NETCore.App;runtime.tizen.4.0.0-armel.Microsoft.NETCore.App;runtime.tizen.5.0.0-armel.Microsoft.NETCore.App;runtime.tizen.5.0.0-armel.Microsoft.NETCore.App;runtime.win-x64.Microsoft.NETCore.App;runtime.win-x64.Microsoft.NETCore.App";
-                        }
+                        preferredPackages.AddRange(targetingPack.GetMetadata("PackageConflictPreferredPackages").Split(';'));
                     }
                 }
             }
@@ -121,6 +117,7 @@ namespace Microsoft.NET.Build.Tasks
 
             PlatformManifests = platformManifests.ToArray();
             PackageConflictOverrides = packageConflictOverrides.ToArray();
+            PackageConflictPreferredPackages = string.Join(";", preferredPackages);
         }
 
         //  Get distinct items based on case-insensitive ItemSpec comparison

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolveTargetingPackAssets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveTargetingPackAssets.cs
@@ -101,7 +101,7 @@ namespace Microsoft.NET.Build.Tasks
                             packageConflictOverrides.Add(CreatePackageOverride(targetingPack.GetMetadata("RuntimeFrameworkName"), packageOverridesPath));
                         }
 
-                        preferredPackages.AddRange(targetingPack.GetMetadata("PackageConflictPreferredPackages").Split(';'));
+                        preferredPackages.AddRange(targetingPack.GetMetadata(MetadataKeys.PackageConflictPreferredPackages).Split(';'));
                     }
                 }
             }


### PR DESCRIPTION
Use `KnownFrameworkReference` metadata to calculate `PackageConflictPreferredPackages` instead of hardcoding.  The hardcoded values were incorrect after the runtime packs had been renamed.

I haven't figured out a good way to test this, as the behavior would only be observable when you reference a package with an asset that matches the assembly and file versions of the same asset in a runtime pack.  But there's not a good way to determine which package version you would need to reference to line these up.

Fix #3362