### PR TITLE
Fix failure building .NET Standard 2.1 projects

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "3.0.100-preview8-013410",
+    "dotnet": "3.0.100-preview8-013462",
     "vs-opt": {
       "version": "15.9"
     }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolveTargetingPackAssets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveTargetingPackAssets.cs
@@ -97,7 +97,7 @@ namespace Microsoft.NET.Build.Tasks
 
                         if (File.Exists(packageOverridesPath))
                         {
-                            packageConflictOverrides.Add(CreatePackageOverride(targetingPack.GetMetadata("RuntimeFrameworkName"), packageOverridesPath));
+                            packageConflictOverrides.Add(CreatePackageOverride(targetingPack.GetMetadata(MetadataKeys.PackageName), packageOverridesPath));
                         }
 
                         if (targetingPack.ItemSpec.Equals("Microsoft.NETCore.App", StringComparison.OrdinalIgnoreCase))


### PR DESCRIPTION
Since the .NET Standard 2.1 targeting pack added PackageOverrides.txt, building .NET Standard 2.1 projects is broken.  The problem is that `ResolveTargetingPackAssets` was using the `RuntimeFrameworkName` metadata from the targeting pack as the itemspec for PackageConflictOverrides.  This metadata wasn't set for the .NET Standard 2.1 targeting pack, causing the following error:

> C:\git\dotnet-sdk\artifacts\bin\Debug\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.Sdk.FrameworkReferenceResolution.targets(269,7): error MSB4028: The "ResolveTargetingPackAssets" task's outputs could not be retrieved from the "PackageConflictOverrides" parameter. Parameter "includeEscaped" cannot have zero length. [C:\git\dotnet-sdk\artifacts\tmp\Debug\netstandard\netstandard.csproj]