### PR TITLE
Don't run ProduceContentAssets unnecessarily

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.PackageDependencyResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.PackageDependencyResolution.targets
@@ -377,7 +377,8 @@ Copyright (c) .NET Foundation. All rights reserved.
              AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
 
   <Target Name="RunProduceContentAssets"
-          DependsOnTargets="ResolvePackageAssets">
+          DependsOnTargets="ResolvePackageAssets"
+          Condition="'@(_ContentFilesToPreprocess)' != ''">
 
     <ProduceContentAssets
       ContentFileDependencies="@(_ContentFilesToPreprocess)"


### PR DESCRIPTION
It is rare to have preprocessed content assets from NuGet, save unneccessary ~10 ms per incremental build in the common case.