### PR TITLE
Retry apphost creation.

### DIFF
--- a/src/Tasks/Common/Resources/Strings.resx
+++ b/src/Tasks/Common/Resources/Strings.resx
@@ -556,4 +556,8 @@ The following are names of parameters or literal values and should not be transl
     <value>NETSDK1112: The runtime pack for {0} was not downloaded. Try running a NuGet restore with the RuntimeIdentifier '{1}'.</value>
     <comment>{StrBegin="NETSDK1112: "}</comment>
   </data>
+  <data name="AppHostCreationFailedWithRetry" xml:space="preserve">
+    <value>NETSDK1113: Failed to create apphost (try {} out of {}): {}</value>
+    <comment>{StrBegin="NETSDK1113: "}</comment>
+  </data>
 </root>

--- a/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
@@ -12,6 +12,11 @@
         <target state="translated">NETSDK1070: Konfigurační soubor aplikace musí obsahovat kořenový element konfigurace.</target>
         <note>{StrBegin="NETSDK1070: "}</note>
       </trans-unit>
+      <trans-unit id="AppHostCreationFailedWithRetry">
+        <source>NETSDK1113: Failed to create apphost (try {} out of {}): {}</source>
+        <target state="new">NETSDK1113: Failed to create apphost (try {} out of {}): {}</target>
+        <note>{StrBegin="NETSDK1113: "}</note>
+      </trans-unit>
       <trans-unit id="AppHostCustomizationRequiresWindowsHostWarning">
         <source>NETSDK1074: The application host executable will not be customized because adding resources requires that the build be performed on Windows (excluding Nano Server).</source>
         <target state="translated">NETSDK1074: Spustitelný soubor hostitele aplikace se nepřizpůsobí, protože přidávání prostředků vyžaduje, aby se sestavení provedlo na Windows (bez Nano Serveru).</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.de.xlf
@@ -12,6 +12,11 @@
         <target state="translated">NETSDK1070: Die Anwendungskonfigurationsdatei muss das Stammkonfigurationselement enthalten.</target>
         <note>{StrBegin="NETSDK1070: "}</note>
       </trans-unit>
+      <trans-unit id="AppHostCreationFailedWithRetry">
+        <source>NETSDK1113: Failed to create apphost (try {} out of {}): {}</source>
+        <target state="new">NETSDK1113: Failed to create apphost (try {} out of {}): {}</target>
+        <note>{StrBegin="NETSDK1113: "}</note>
+      </trans-unit>
       <trans-unit id="AppHostCustomizationRequiresWindowsHostWarning">
         <source>NETSDK1074: The application host executable will not be customized because adding resources requires that the build be performed on Windows (excluding Nano Server).</source>
         <target state="translated">NETSDK1074: Die ausführbare Anwendungshostdatei wird nicht angepasst, weil für das Hinzufügen von Ressourcen eine Ausführung des Builds unter Windows erforderlich ist (Nano Server ausgeschlossen).</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.es.xlf
@@ -12,6 +12,11 @@
         <target state="translated">NETSDK1070: El archivo de configuración de la aplicación debe tener el elemento de configuración raíz.</target>
         <note>{StrBegin="NETSDK1070: "}</note>
       </trans-unit>
+      <trans-unit id="AppHostCreationFailedWithRetry">
+        <source>NETSDK1113: Failed to create apphost (try {} out of {}): {}</source>
+        <target state="new">NETSDK1113: Failed to create apphost (try {} out of {}): {}</target>
+        <note>{StrBegin="NETSDK1113: "}</note>
+      </trans-unit>
       <trans-unit id="AppHostCustomizationRequiresWindowsHostWarning">
         <source>NETSDK1074: The application host executable will not be customized because adding resources requires that the build be performed on Windows (excluding Nano Server).</source>
         <target state="translated">NETSDK1074: El ejecutable del host de aplicación no se personalizará porque para agregar recursos es necesario que la compilación se realice en Windows (excepto Nano Server).</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
@@ -12,6 +12,11 @@
         <target state="translated">NETSDK1070: Le fichier de configuration de l'application doit avoir un élément de configuration racine.</target>
         <note>{StrBegin="NETSDK1070: "}</note>
       </trans-unit>
+      <trans-unit id="AppHostCreationFailedWithRetry">
+        <source>NETSDK1113: Failed to create apphost (try {} out of {}): {}</source>
+        <target state="new">NETSDK1113: Failed to create apphost (try {} out of {}): {}</target>
+        <note>{StrBegin="NETSDK1113: "}</note>
+      </trans-unit>
       <trans-unit id="AppHostCustomizationRequiresWindowsHostWarning">
         <source>NETSDK1074: The application host executable will not be customized because adding resources requires that the build be performed on Windows (excluding Nano Server).</source>
         <target state="translated">NETSDK1074: l'exécutable d'hôte d'application ne sera pas personnalisé, car l'ajout de ressources nécessite l'exécution de la génération sur Windows (à l'exception de Nano Server).</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.it.xlf
@@ -12,6 +12,11 @@
         <target state="translated">NETSDK1070: il file di configurazione dell'applicazione deve avere un elemento di configurazione radice.</target>
         <note>{StrBegin="NETSDK1070: "}</note>
       </trans-unit>
+      <trans-unit id="AppHostCreationFailedWithRetry">
+        <source>NETSDK1113: Failed to create apphost (try {} out of {}): {}</source>
+        <target state="new">NETSDK1113: Failed to create apphost (try {} out of {}): {}</target>
+        <note>{StrBegin="NETSDK1113: "}</note>
+      </trans-unit>
       <trans-unit id="AppHostCustomizationRequiresWindowsHostWarning">
         <source>NETSDK1074: The application host executable will not be customized because adding resources requires that the build be performed on Windows (excluding Nano Server).</source>
         <target state="translated">NETSDK1074: l'eseguibile dell'host applicazione non verrà personalizzato perché per aggiungere risorse è necessario eseguire la compilazione in Windows (escluso Nano Server).</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
@@ -12,6 +12,11 @@
         <target state="translated">NETSDK1070: アプリケーション構成ファイルには、ルート構成要素が必要です。</target>
         <note>{StrBegin="NETSDK1070: "}</note>
       </trans-unit>
+      <trans-unit id="AppHostCreationFailedWithRetry">
+        <source>NETSDK1113: Failed to create apphost (try {} out of {}): {}</source>
+        <target state="new">NETSDK1113: Failed to create apphost (try {} out of {}): {}</target>
+        <note>{StrBegin="NETSDK1113: "}</note>
+      </trans-unit>
       <trans-unit id="AppHostCustomizationRequiresWindowsHostWarning">
         <source>NETSDK1074: The application host executable will not be customized because adding resources requires that the build be performed on Windows (excluding Nano Server).</source>
         <target state="translated">NETSDK1074: リソースの追加ではビルドが Windows 上で実行される必要があるため、アプリケーション ホストの実行可能ファイルはカスタマイズされません (Nano Server を除く)。</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
@@ -12,6 +12,11 @@
         <target state="translated">NETSDK1070: 애플리케이션 구성 파일에는 루트 구성 요소가 있어야 합니다.</target>
         <note>{StrBegin="NETSDK1070: "}</note>
       </trans-unit>
+      <trans-unit id="AppHostCreationFailedWithRetry">
+        <source>NETSDK1113: Failed to create apphost (try {} out of {}): {}</source>
+        <target state="new">NETSDK1113: Failed to create apphost (try {} out of {}): {}</target>
+        <note>{StrBegin="NETSDK1113: "}</note>
+      </trans-unit>
       <trans-unit id="AppHostCustomizationRequiresWindowsHostWarning">
         <source>NETSDK1074: The application host executable will not be customized because adding resources requires that the build be performed on Windows (excluding Nano Server).</source>
         <target state="translated">NETSDK1074: 리소스를 추가하려면 빌드가 Windows(Nano Server 제외)에서 수행되어야 하므로 애플리케이션 호스트 실행 파일이 사용자 지정되지 않습니다.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
@@ -12,6 +12,11 @@
         <target state="translated">NETSDK1070: Plik konfiguracji aplikacji musi mieć główny element konfiguracji.</target>
         <note>{StrBegin="NETSDK1070: "}</note>
       </trans-unit>
+      <trans-unit id="AppHostCreationFailedWithRetry">
+        <source>NETSDK1113: Failed to create apphost (try {} out of {}): {}</source>
+        <target state="new">NETSDK1113: Failed to create apphost (try {} out of {}): {}</target>
+        <note>{StrBegin="NETSDK1113: "}</note>
+      </trans-unit>
       <trans-unit id="AppHostCustomizationRequiresWindowsHostWarning">
         <source>NETSDK1074: The application host executable will not be customized because adding resources requires that the build be performed on Windows (excluding Nano Server).</source>
         <target state="translated">NETSDK1074: Plik wykonywalny hosta aplikacji nie zostanie dostosowany, ponieważ dodawanie zasobów wymaga, aby kompilacja została wykonana w systemie Windows (z wyjątkiem systemu Nano Server).</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
@@ -12,6 +12,11 @@
         <target state="translated">NETSDK1070: o arquivo de configuração do aplicativo deve ter um elemento de configuração raiz.</target>
         <note>{StrBegin="NETSDK1070: "}</note>
       </trans-unit>
+      <trans-unit id="AppHostCreationFailedWithRetry">
+        <source>NETSDK1113: Failed to create apphost (try {} out of {}): {}</source>
+        <target state="new">NETSDK1113: Failed to create apphost (try {} out of {}): {}</target>
+        <note>{StrBegin="NETSDK1113: "}</note>
+      </trans-unit>
       <trans-unit id="AppHostCustomizationRequiresWindowsHostWarning">
         <source>NETSDK1074: The application host executable will not be customized because adding resources requires that the build be performed on Windows (excluding Nano Server).</source>
         <target state="translated">NETSDK1074: o host do aplicativo executável não será personalizado porque a adição de recursos requer que o build seja executado no Windows (excluindo Nano Server).</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
@@ -12,6 +12,11 @@
         <target state="translated">NETSDK1070: В файле конфигурации приложения должен присутствовать корневой элемент конфигурации.</target>
         <note>{StrBegin="NETSDK1070: "}</note>
       </trans-unit>
+      <trans-unit id="AppHostCreationFailedWithRetry">
+        <source>NETSDK1113: Failed to create apphost (try {} out of {}): {}</source>
+        <target state="new">NETSDK1113: Failed to create apphost (try {} out of {}): {}</target>
+        <note>{StrBegin="NETSDK1113: "}</note>
+      </trans-unit>
       <trans-unit id="AppHostCustomizationRequiresWindowsHostWarning">
         <source>NETSDK1074: The application host executable will not be customized because adding resources requires that the build be performed on Windows (excluding Nano Server).</source>
         <target state="translated">NETSDK1074: исполняемый файл узла приложения не будет настроен, так как для добавления ресурсов требуется, чтобы сборка выполнялась в Windows (за исключением Nano Server).</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
@@ -12,6 +12,11 @@
         <target state="translated">NETSDK1070: Uygulama yapılandırma dosyasının kök yapılandırma öğesi olmalıdır.</target>
         <note>{StrBegin="NETSDK1070: "}</note>
       </trans-unit>
+      <trans-unit id="AppHostCreationFailedWithRetry">
+        <source>NETSDK1113: Failed to create apphost (try {} out of {}): {}</source>
+        <target state="new">NETSDK1113: Failed to create apphost (try {} out of {}): {}</target>
+        <note>{StrBegin="NETSDK1113: "}</note>
+      </trans-unit>
       <trans-unit id="AppHostCustomizationRequiresWindowsHostWarning">
         <source>NETSDK1074: The application host executable will not be customized because adding resources requires that the build be performed on Windows (excluding Nano Server).</source>
         <target state="translated">NETSDK1074: Kaynak eklemek derleme işleminin (Nano Server hariç) Windows'da gerçekleştirilmesini gerektirdiğinden uygulama konağının yürütülebilir dosyası özelleştirilmeyecek.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
@@ -12,6 +12,11 @@
         <target state="translated">NETSDK1070: 应用程序配置文件必须具有根配置元素。</target>
         <note>{StrBegin="NETSDK1070: "}</note>
       </trans-unit>
+      <trans-unit id="AppHostCreationFailedWithRetry">
+        <source>NETSDK1113: Failed to create apphost (try {} out of {}): {}</source>
+        <target state="new">NETSDK1113: Failed to create apphost (try {} out of {}): {}</target>
+        <note>{StrBegin="NETSDK1113: "}</note>
+      </trans-unit>
       <trans-unit id="AppHostCustomizationRequiresWindowsHostWarning">
         <source>NETSDK1074: The application host executable will not be customized because adding resources requires that the build be performed on Windows (excluding Nano Server).</source>
         <target state="translated">NETSDK1074: 未自定义应用程序主机可执行文件，因为添加资源要求在 Windows (不包括 Nano 服务器)上执行生成。</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
@@ -12,6 +12,11 @@
         <target state="translated">NETSDK1070: 應用程式組態檔必須有根組態元素。</target>
         <note>{StrBegin="NETSDK1070: "}</note>
       </trans-unit>
+      <trans-unit id="AppHostCreationFailedWithRetry">
+        <source>NETSDK1113: Failed to create apphost (try {} out of {}): {}</source>
+        <target state="new">NETSDK1113: Failed to create apphost (try {} out of {}): {}</target>
+        <note>{StrBegin="NETSDK1113: "}</note>
+      </trans-unit>
       <trans-unit id="AppHostCustomizationRequiresWindowsHostWarning">
         <source>NETSDK1074: The application host executable will not be customized because adding resources requires that the build be performed on Windows (excluding Nano Server).</source>
         <target state="translated">NETSDK1074: 因為正在新增需要在 Windows (不含 Nano 伺服器) 上執行組建的資源，所以該應用程式主機可執行檔無法進行自訂。</target>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/CreateAppHost.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/CreateAppHost.cs
@@ -24,6 +24,10 @@ namespace Microsoft.NET.Build.Tasks
         [Required]
         public string IntermediateAssembly { get; set; }
 
+        public int Retries { get; set; }
+
+        public int RetryDelayMilliseconds { get; set; } = AppHost.DefaultRetryDelayMilliseconds;
+
         public bool WindowsGraphicalUserInterface { get; set; }
 
         protected override void ExecuteCore()
@@ -34,7 +38,9 @@ namespace Microsoft.NET.Build.Tasks
                 AppBinaryName,
                 windowsGraphicalUserInterface : WindowsGraphicalUserInterface,
                 intermediateAssembly: IntermediateAssembly,
-                log: Log);
+                log: Log,
+                retryCount: Retries,
+                retryDelayMilliseconds: RetryDelayMilliseconds);
         }
     }
 }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResourceUpdater.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResourceUpdater.cs
@@ -424,7 +424,7 @@ namespace Microsoft.NET.Build.Tasks
             }
         }
 
-        private class HResultException : Exception
+        internal class HResultException : Exception
         {
             public HResultException(int hResult) : base(hResult.ToString("X4"))
             {

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -355,12 +355,18 @@ Copyright (c) .NET Foundation. All rights reserved.
                      Exists('$(AppHostSourcePath)')">
     <PropertyGroup>
       <_UseWindowsGraphicalUserInterface Condition="($(RuntimeIdentifier.StartsWith('win')) or $(DefaultAppHostRuntimeIdentifier.StartsWith('win'))) and '$(OutputType)'=='WinExe'">true</_UseWindowsGraphicalUserInterface>
+      <CreateAppHostRetries Condition="'$(CreateAppHostRetries)' == ''">3</CreateAppHostRetries>
+      <CreateAppHostRetryDelay Condition="'$(CreateAppHostRetryDelay)' == ''">1000</CreateAppHostRetryDelay>
     </PropertyGroup>
+
     <CreateAppHost AppHostSourcePath="$(AppHostSourcePath)"
                    AppHostDestinationPath="$(AppHostIntermediatePath)"
                    AppBinaryName="$(AssemblyName)$(TargetExt)"
                    IntermediateAssembly="@(IntermediateAssembly->'%(FullPath)')"
-                   WindowsGraphicalUserInterface="$(_UseWindowsGraphicalUserInterface)" />
+                   WindowsGraphicalUserInterface="$(_UseWindowsGraphicalUserInterface)"
+                   Retries="$(CreateAppHostRetries)"
+                   RetryDelayMilliseconds="$(CreateAppHostRetryDelay)"
+                   />
   </Target>
 
   <!--

--- a/src/Tests/Microsoft.NET.Build.Tests/AppHostTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/AppHostTests.cs
@@ -220,7 +220,50 @@ namespace Microsoft.NET.Build.Tests
             buildCommand.Execute()
                 .Should()
                 .Pass();
+        }
 
+        [Fact]
+        public void It_retries_on_failure_to_create_apphost()
+        {
+            const string TFM = "netcoreapp3.0";
+
+            var testProject = new TestProject()
+            {
+                Name = "RetryAppHost",
+                TargetFrameworks = TFM,
+                IsSdkProject = true,
+                IsExe = true,
+            };
+
+            var testAsset = _testAssetsManager.CreateTestProject(testProject)
+                .Restore(Log, testProject.Name);
+
+            var projectDirectory = Path.Combine(testAsset.TestRoot, testProject.Name);
+
+            var buildCommand = new BuildCommand(Log, projectDirectory);
+
+            buildCommand.Execute()
+                .Should()
+                .Pass();
+
+            var sourceFilePath = Path.Combine(projectDirectory, testProject.Name + ".cs");
+
+            File.SetLastWriteTimeUtc(sourceFilePath, DateTime.UtcNow);
+
+            var intermediateDirectory = buildCommand.GetIntermediateDirectory(targetFramework: TFM).FullName;
+
+            var intermediateAppHost = Path.Combine(intermediateDirectory, testProject.Name + Constants.ExeSuffix);
+
+            using (var stream = new FileStream(intermediateAppHost, FileMode.Open, FileAccess.Read, FileShare.None))
+            {
+                 buildCommand.Execute("/v:diag")
+                    .Should()
+                    .Fail()
+                    .And
+                    .HaveStdOutContaining("System.IO.IOException")
+                    .And
+                    .HaveStdOutContaining("NETSDK1113");
+            }
         }
 
         private static bool IsPE32(string path)


### PR DESCRIPTION
This commit implements a parameterized retry count for creating the apphost.

Like the `Copy` task from MSBuild, the `CreateAppHost` task now takes a
parameter to specify the number of retries and the delay between retries (in
milliseconds) to perform if the creation fails.

This should help alleviate build failures when external processes are locking
the intermediate apphost during a build (especially on Windows).

Fixes devdiv#950462.
Fixes dotnet/cli#11650.