### PR TITLE
Fix Publish with GeneratePackageOnBuild=true

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.PackTool.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.PackTool.targets
@@ -27,9 +27,11 @@ Copyright (c) .NET Foundation. All rights reserved.
   <PropertyGroup>
     <_ToolsSettingsFilePath>$(BaseIntermediateOutputPath)DotnetToolSettings.xml</_ToolsSettingsFilePath>
     <SuppressDependenciesWhenPacking Condition=" '$(PackAsTool)' == 'true' ">true</SuppressDependenciesWhenPacking>
+    <_PackToolPublishDependency Condition=" ('$(GeneratePackageOnBuild)' != 'true' and '$(NoBuild)' != 'true') and $(IsPublishable) == 'true' ">_PublishBuildAlternative</_PackToolPublishDependency>
+    <_PackToolPublishDependency Condition=" ('$(GeneratePackageOnBuild)' == 'true' or '$(NoBuild)' == 'true') and $(IsPublishable) == 'true' ">$(_PublishNoBuildAlternativeDependsOn)</_PackToolPublishDependency>
   </PropertyGroup>
 
-  <Target Name="PackTool" DependsOnTargets="GenerateToolsSettingsFileFromBuildProperty;Publish;_PackToolValidation" Condition=" '$(PackAsTool)' == 'true' ">
+  <Target Name="PackTool" DependsOnTargets="GenerateToolsSettingsFileFromBuildProperty;$(_PackToolPublishDependency);_PackToolValidation" Condition=" '$(PackAsTool)' == 'true' ">
     <ItemGroup>
       <_GeneratedFiles Include="$(PublishDepsFilePath)"/>
       <_GeneratedFiles Include="$(PublishRuntimeConfigFilePath)"/>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -50,15 +50,17 @@ Copyright (c) .NET Foundation. All rights reserved.
       GeneratePublishDependencyFile;
       BundlePublishDirectory;
     </_CorePublishTargets>
+
+    <_PublishNoBuildAlternativeDependsOn>$(_BeforePublishNoBuildTargets);$(_CorePublishTargets)</_PublishNoBuildAlternativeDependsOn>
   </PropertyGroup>
 
   <Target Name="_PublishBuildAlternative"
-          Condition="'$(NoBuild)' != 'true' and '$(GeneratePackageOnBuild)' != 'true'"
+          Condition="'$(NoBuild)' != 'true'"
           DependsOnTargets="Build;$(_CorePublishTargets)" />
 
   <Target Name="_PublishNoBuildAlternative"
-          Condition="'$(NoBuild)' == 'true' or '$(GeneratePackageOnBuild)' == 'true'"
-          DependsOnTargets="$(_BeforePublishNoBuildTargets);$(_CorePublishTargets)" />
+          Condition="'$(NoBuild)' == 'true'"
+          DependsOnTargets="$(_PublishNoBuildAlternativeDependsOn)" />
 
   <Target Name="Publish"
           Condition="$(IsPublishable) == 'true'"

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToPublishWithGeneratePackageOnBuildAndPackAsTool.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToPublishWithGeneratePackageOnBuildAndPackAsTool.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Xml.Linq;
+using FluentAssertions;
+using Microsoft.DotNet.Cli.Utils;
+using Microsoft.NET.TestFramework;
+using Microsoft.NET.TestFramework.Commands;
+using NuGet.Packaging;
+using Xunit;
+using Xunit.Abstractions;
+using Microsoft.NET.TestFramework.Assertions;
+
+namespace Microsoft.NET.ToolPack.Tests
+{
+    public class GivenThatWeWantToBuildWithGeneratePackageOnBuildAndPackAsTool : SdkTest
+    {
+        public GivenThatWeWantToBuildWithGeneratePackageOnBuildAndPackAsTool(ITestOutputHelper log) : base(log)
+        {}
+
+        [Theory]
+        [InlineData(false, false)]
+        [InlineData(false, true)]
+        [InlineData(true, false)]
+        [InlineData(true, true)]
+        public void It_builds_successfully(bool generatePackageOnBuild, bool packAsTool)
+        {
+            TestAsset testAsset = _testAssetsManager
+                .CopyTestAsset("HelloWorld", identifier: generatePackageOnBuild.ToString() + packAsTool.ToString())
+                .WithSource()
+                .WithProjectChanges((projectPath, project) =>
+                {
+                    XNamespace ns = project.Root.Name.Namespace;
+                    XElement propertyGroup = project.Root.Elements(ns + "PropertyGroup").First();
+                    propertyGroup.Add(new XElement(ns + "GeneratePackageOnBuild", generatePackageOnBuild.ToString()));
+                    propertyGroup.Add(new XElement(ns + "PackAsTool", packAsTool.ToString()));
+                });
+
+            var appProjectDirectory = Path.Combine(testAsset.TestRoot);
+            var buildCommand = new BuildCommand(Log, appProjectDirectory);
+
+            CommandResult result = buildCommand.Execute("/restore");
+
+            result.Should()
+                  .Pass();
+        }
+    }
+}

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishWithGeneratePackageOnBuildAndPackAsTool.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishWithGeneratePackageOnBuildAndPackAsTool.cs
@@ -1,0 +1,82 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Xml.Linq;
+using FluentAssertions;
+using Microsoft.DotNet.Cli.Utils;
+using Microsoft.NET.TestFramework;
+using Microsoft.NET.TestFramework.Commands;
+using NuGet.Packaging;
+using Xunit;
+using Xunit.Abstractions;
+using Microsoft.NET.TestFramework.Assertions;
+
+namespace Microsoft.NET.ToolPack.Tests
+{
+    public class GivenThatWeWantToPublishWithGeneratePackageOnBuildAndPackAsTool : SdkTest
+    {
+        public GivenThatWeWantToPublishWithGeneratePackageOnBuildAndPackAsTool(ITestOutputHelper log) : base(log)
+        {}
+
+        [Theory]
+        [InlineData(false, false)]
+        [InlineData(false, true)]
+        [InlineData(true, false)]
+        [InlineData(true, true)]
+        public void It_publishes_successfully(bool generatePackageOnBuild, bool packAsTool)
+        {
+            Console.WriteLine(generatePackageOnBuild.ToString() + packAsTool.ToString());
+
+            TestAsset testAsset = _testAssetsManager
+                .CopyTestAsset("HelloWorld", identifier: generatePackageOnBuild.ToString() + packAsTool.ToString())
+                .WithSource()
+                .WithProjectChanges((projectPath, project) =>
+                {
+                    XNamespace ns = project.Root.Name.Namespace;
+                    XElement propertyGroup = project.Root.Elements(ns + "PropertyGroup").First();
+                    propertyGroup.Add(new XElement(ns + "GeneratePackageOnBuild", generatePackageOnBuild.ToString()));
+                    propertyGroup.Add(new XElement(ns + "PackAsTool", packAsTool.ToString()));
+                });
+
+            var appProjectDirectory = Path.Combine(testAsset.TestRoot);
+            var publishCommand = new PublishCommand(Log, appProjectDirectory);
+
+            CommandResult result = publishCommand.Execute("/restore");
+
+            result.Should()
+                  .Pass();
+        }
+
+        [Theory]
+        [InlineData(false, false)]
+        [InlineData(false, true)]
+        [InlineData(true, false)]
+        [InlineData(true, true)]
+        public void It_builds_successfully(bool generatePackageOnBuild, bool packAsTool)
+        {
+            TestAsset testAsset = _testAssetsManager
+                .CopyTestAsset("HelloWorld", identifier: generatePackageOnBuild.ToString() + packAsTool.ToString())
+                .WithSource()
+                .WithProjectChanges((projectPath, project) =>
+                {
+                    XNamespace ns = project.Root.Name.Namespace;
+                    XElement propertyGroup = project.Root.Elements(ns + "PropertyGroup").First();
+                    propertyGroup.Add(new XElement(ns + "GeneratePackageOnBuild", generatePackageOnBuild.ToString()));
+                    propertyGroup.Add(new XElement(ns + "PackAsTool", packAsTool.ToString()));
+                });
+
+            var appProjectDirectory = Path.Combine(testAsset.TestRoot);
+            var buildCommand = new BuildCommand(Log, appProjectDirectory);
+
+            CommandResult result = buildCommand.Execute("/restore");
+
+            result.Should()
+                  .Pass();
+        }
+    }
+}


### PR DESCRIPTION
### Description

The previous change https://github.com/dotnet/sdk/pull/3255/files caused the _Build_ target to no longer be part of the dependency of the _Publish_ target when `GeneratePackageOnBuild=true`. With this change, we edited the dependency targets graph to add the targets publish needs without adding _Build back to the list. We also added test coverage for the combination of related msbuild properties to prevent future regression.

### Customer Impact

`dotnet publish` fails when `GeneratePackageOnBuild=true`

### Regression?

Yes. By https://github.com/dotnet/sdk/pull/3255/files, since dotne core SDK 3.0.100-preview 6

### Risk

Low risk.

### Test changes in this PR

Added `GeneratePackageOnBuild` + `PackAsTool` + Publish/Build/Pack all combinations in unit test.

===============

Fix https://github.com/dotnet/sdk/issues/3367

===============

What I did is essentially write a different dependency graph in GeneratePackageOnBuild = true to avoid circular dependency . Original bug. I added the https://github.com/dotnet/sdk/pull/3255/files and essentially regressed https://github.com/NuGet/Home/issues/7801. Instead of the logic is in nuget, it is in SDK now. Publish should not skip Build  if GeneratePackageOnBuild is true. Or it will mean no build even use Publish verb.

But revert 3255 means, https://github.com/dotnet/sdk/issues/2114 will be back. The solution is to break Pack’s dependency on Build in GeneratePackageOnBuild. But it still need Publish. So I need to let Pack depend directly on no build version of publish.

> Why cannot directly use “_PublishNoBuildAlternative”?

We want to exclude Build step regardless NoBuild flag is true or not.

> Test coverage

I have GeneratePackageOnBuild + PackAsTool + Publish/Build/Pack all combinations covered in tests. Although I did discover GeneratePackageOnBuild+Pack https://github.com/dotnet/sdk/issues/3471 does not work. But it was there since 2.0. And without nuget help, we cannot easily fix it.