### PR TITLE
Need apphost in build but do not pack it

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolveToolPackagePaths.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveToolPackagePaths.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -16,6 +17,8 @@ namespace Microsoft.NET.Build.Tasks
     /// </summary>
     public sealed class ResolveToolPackagePaths : TaskBase
     {
+        public string AppHostIntermediatePath { get; set; }
+
         [Required]
         public ITaskItem[] ResolvedFileToPublish { get; set; }
 
@@ -36,6 +39,12 @@ namespace Microsoft.NET.Build.Tasks
             var result = new List<TaskItem>();
             foreach (ITaskItem r in ResolvedFileToPublish)
             {
+                // skip packing apphost since a dotnet tool will get a generated shim executable once installed
+                if (r.ItemSpec.Equals(AppHostIntermediatePath, StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
                 string relativePath = r.GetMetadata("RelativePath");
                 var fullpath = Path.GetFullPath(
                     Path.Combine(PublishDir,

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.PackTool.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.PackTool.targets
@@ -37,6 +37,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     </ItemGroup>
 
     <ResolveToolPackagePaths
+      AppHostIntermediatePath="$(AppHostIntermediatePath)"
       ResolvedFileToPublish="@(ResolvedFileToPublish)"
       PublishDir="$(PublishDir)"
       TargetFramework="$(TargetFramework)">

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets
@@ -104,7 +104,6 @@ Copyright (c) .NET Foundation. All rights reserved.
     <SelfContained Condition="'$(SelfContained)' == '' and '$(RuntimeIdentifier)' != ''">true</SelfContained>
     <SelfContained Condition="'$(SelfContained)' == ''">false</SelfContained>
     <UseAppHost Condition="'$(UseAppHost)' == '' and
-                           ('$(SelfContained)' == 'true' or '$(PackAsTool)' != 'true') and
                            ('$(SelfContained)' == 'true' or
                             ('$(RuntimeIdentifier)' != '' and '$(_TargetFrameworkVersionWithoutV)' >= '2.1') or
                             '$(_TargetFrameworkVersionWithoutV)' >= '3.0')">true</UseAppHost>


### PR DESCRIPTION
fix https://github.com/dotnet/sdk/issues/3023

### Description

Apphost generation is disabled for dotnet tools to prevent the apphost from being packaged in the package. When debugging a WPF or Winforms project that has PackAsTool set to true, there is no exe generated with appropriate Windows PE bits set, because we disabled it as described above. Instead of disabling apphost generation when PackAsTool=true, SDK should generate it during build, but prevent it from being packaged in the nupkg.

### Customer Impact

When debugging an WPF or Winforms dotnet tool project (PackAsTool=true) in VS, the user would see the command line instead of the GUI. The app's GUI is not rendered and you get only a blank command prompt.

### Regression?

Yes. This regressed from .NET Core SDK 3.0.100-preview3 due to https://github.com/dotnet/sdk/commit/3487007c6bf8316ce3c871aadbe75498ab2da7c4

### Risk

Low risk.

### Test changes in this PR

Added new unit test coverage to ensure `RunCommand`(which VS debug calls) uses the apphost exe instead of the dll.