### PR TITLE
Emit progid information into the CLSIDMap.

### DIFF
--- a/src/Assets/TestProjects/ComServer/ComServer.cs
+++ b/src/Assets/TestProjects/ComServer/ComServer.cs
@@ -38,4 +38,16 @@ namespace COMServer
     {
 
     }
+
+    [ComVisible(true)]
+    [Guid("e5381440-17ca-4807-803c-7e02fc14ce32")]
+    [ProgId("")]
+    public class ClassWithoutProgId
+    { }
+
+    [ComVisible(true)]
+    [Guid("7d00a362-1dee-49d7-a6a0-9986ea02a676")]
+    [ProgId("Explicit.ProgId")]
+    public class ClassWithExplicitProgId
+    { }
 }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ClsidMap.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ClsidMap.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -22,6 +23,8 @@ namespace Microsoft.NET.Build.Tasks
             public string Type;
             [JsonProperty(PropertyName = "assembly")]
             public string Assembly;
+            [JsonProperty(PropertyName = "progid", NullValueHandling = NullValueHandling.Ignore)]
+            public string ProgId;
         }
 
         public static void Create(MetadataReader metadataReader, string clsidMapPath)
@@ -46,11 +49,14 @@ namespace Microsoft.NET.Build.Tasks
                         throw new BuildErrorException(Strings.ClsidMapConflictingGuids, clsidMap[guid].Type, GetTypeName(metadataReader, definition), guid);
                     }
 
+                    string progId = GetProgId(metadataReader, definition);
+
                     clsidMap.Add(guid,
                         new ClsidEntry
                         {
                             Type = GetTypeName(metadataReader, definition),
-                            Assembly = assemblyName
+                            Assembly = assemblyName,
+                            ProgId = !string.IsNullOrWhiteSpace(progId) ? progId : null
                         });
                 }
             }
@@ -101,9 +107,9 @@ namespace Microsoft.NET.Build.Tasks
         {
             if (!type.GetDeclaringType().IsNil)
             {
-                return $"{GetTypeName(metadataReader, metadataReader.GetTypeDefinition(type.GetDeclaringType()))}.{metadataReader.GetString(type.Name)}";
+                return $"{GetTypeName(metadataReader, metadataReader.GetTypeDefinition(type.GetDeclaringType()))}+{metadataReader.GetString(type.Name)}";
             }
-            return $"{metadataReader.GetString(type.Namespace)}.{metadataReader.GetString(type.Name)}";
+            return $"{metadataReader.GetString(type.Namespace)}{Type.Delimiter}{metadataReader.GetString(type.Name)}";
         }
 
         private static bool HasTypeName(MetadataReader metadataReader, TypeReference type, string ns, string name)
@@ -193,6 +199,23 @@ namespace Microsoft.NET.Build.Tasks
                 }
             }
             throw new BuildErrorException(Strings.ClsidMapExportedTypesRequireExplicitGuid, GetTypeName(reader, type));
+        }
+
+        private static string GetProgId(MetadataReader reader, TypeDefinition type)
+        {
+            Debugger.Launch();
+            foreach (CustomAttributeHandle attr in type.GetCustomAttributes())
+            {
+                CustomAttribute attribute = reader.GetCustomAttribute(attr);
+                MemberReference attributeConstructor = reader.GetMemberReference((MemberReferenceHandle)attribute.Constructor);
+                TypeReference attributeType = reader.GetTypeReference((TypeReferenceHandle)attributeConstructor.Parent);
+                if (reader.StringComparer.Equals(attributeType.Namespace, "System.Runtime.InteropServices") && reader.StringComparer.Equals(attributeType.Name, "ProgIdAttribute"))
+                {
+                    CustomAttributeValue<KnownType> data = attribute.DecodeValue(new TypeResolver());
+                    return (string)data.FixedArguments[0].Value;
+                }
+            }
+            return GetTypeName(reader, type);
         }
 
         private enum KnownType

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ClsidMap.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ClsidMap.cs
@@ -203,7 +203,6 @@ namespace Microsoft.NET.Build.Tasks
 
         private static string GetProgId(MetadataReader reader, TypeDefinition type)
         {
-            Debugger.Launch();
             foreach (CustomAttributeHandle attr in type.GetCustomAttributes())
             {
                 CustomAttribute attribute = reader.GetCustomAttribute(attr);

--- a/src/Tasks/Microsoft.NET.Build.Tasks/RegFreeComManifest.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/RegFreeComManifest.cs
@@ -3,7 +3,9 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Text;
 using System.Xml;
 using System.Xml.Linq;
@@ -46,7 +48,17 @@ namespace Microsoft.NET.Build.Tasks
             {
                 string guidMaybe = property.Name;
                 Guid guid = Guid.Parse(guidMaybe);
-                fileElement.Add(new XElement(ns + "comClass", new XAttribute("clsid", guid.ToString("B")), new XAttribute("threadingModel", "Both")));
+                XElement comClassElement = new XElement(ns + "comClass", new XAttribute("clsid", guid.ToString("B")), new XAttribute("threadingModel", "Both"));
+                if (property.Value is JObject clsidEntry)
+                {
+                    JProperty progIdProperty = clsidEntry.Properties().FirstOrDefault(prop => prop.Name == "progid");
+                    if (!(progIdProperty is null))
+                    {
+                        comClassElement.Add(new XAttribute("progid", progIdProperty.Value.ToString()));
+                    }
+                }
+
+                fileElement.Add(comClassElement);
             }
 
             manifest.Add(fileElement);


### PR DESCRIPTION
This is the SDK-side of the work for https://github.com/dotnet/core-setup/pull/7551. These PRs allow users to activate .NET classes via COM using ProgIDs instead of CLSIDs for languages or platforms that do not support using CLSIDs.

Additionally, fixes a bug that would cause loading nested classes via COM to fail to find the type.

Contributes to dotnet/coreclr#25966

This PR doesn't need to wait for dotnet/core-setup#7551 to go in since the changes are backward compatible with previous versions of the COM host that don't have ProgID support.

cc: @nguerrera 

================================

#### Description
Add support for generating .cslidmaps with ProgIDs for com registration. See dotnet/core-setup#7573 for the host work. This PR also fixes a bug that breaks loading nested types via COM.

#### Customer Impact
Without this support consumption of COM classes in languages that don't have `GUID` support is impossible.

Additionally, without the fix for nested types, it is impossible to activate a nested type via COM on .NET Core.

Fixes: dotnet/coreclr#25966
Related: https://github.com/dotnet/coreclr/issues/25946

#### Regression?
COM support is new in 3.0 so this is not a regression from a previous .NET Core release, but is a regression in COM support from .NET Framework using the `RegAsm` tool.

#### Risk
Minimal. Unused information in the clsidmap such as ProgId information is ignored in previous previews of .NET Core.