### PR TITLE
Change the assertion to not to catch the RAR warning

### DIFF
--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildADesktopLibrary.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildADesktopLibrary.cs
@@ -387,7 +387,7 @@ public static class {project.Name}
                 .Should().Be(correctHttpReference);
         }
 
-        [FullMSBuildOnlyFact]
+        [Fact]
         public void It_tolerates_newline_in_hint_path()
         {
             string hintPath = BuildReferencedBuildAndReturnOutputDllPath();
@@ -417,7 +417,7 @@ public static class {project.Name}
             var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot, project.Name));
             var msbuildBuildCommand = new MSBuildCommand(Log, "Build", buildCommand.FullPathProjectFile);
             msbuildBuildCommand.Execute().Should().Pass()
-                .And.NotHaveStdOutContaining("Illegal characters in path");
+                .And.NotHaveStdOutContaining("System.ArgumentException");
         }
 
         private string BuildReferencedBuildAndReturnOutputDllPath()


### PR DESCRIPTION
It is intent to catch the warning from Conflict Resolution.

Continue investigation on why RAR start to have such warning in https://github.com/dotnet/sdk/issues/3508

### Description

 The test is blocking any SDK PR. `It_tolerates_newline_in_hint_path` is intended to prevent regression of "crash in conflict resolution when hintpath has new line". However, due to a msbuild change, the RAR warning also has the same partial text the test asserts on.

### Customer Impact

no

### Regression?

no

### Risk

Low risk.

### Test changes in this PR

N/A