### PR TITLE
Fix publishing of applications that specify a full path to the profile.

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.ImportPublishProfile.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.ImportPublishProfile.targets
@@ -22,8 +22,14 @@ Copyright (c) .NET Foundation. All rights reserved.
     <WebPublishProfileFile Condition="'$(WebPublishProfileFile)' == '' and Exists('$(PublishProfileFullPath)')">$(PublishProfileFullPath)</WebPublishProfileFile>
 
     <!-- If the publish profile doesn't exist, mark as not imported.
-         This allows the Web SDK to import some default profiles that come with the Web SDK. -->
-    <PublishProfileImported Condition="'$(WebPublishProfileFile)' == '' or !Exists('$(WebPublishProfileFile)')">false</PublishProfileImported>
+       This allows the Web SDK to import some default profiles that come with the Web SDK.
+       Publishing in Visual Studio sets `WebPublishProfileFile` as a global property.
+       Therefore, check that `ProjectToOverrideProjectExtensionsPath` is equal to `MSBuildProjectFullPath`
+       to limit the import to the project being published. -->
+    <PublishProfileImported Condition="('$(ProjectToOverrideProjectExtensionsPath)' != '' and
+                                        '$(ProjectToOverrideProjectExtensionsPath)' != '$(MSBuildProjectFullPath)') or
+                                       '$(WebPublishProfileFile)' == '' or
+                                       !Exists('$(WebPublishProfileFile)')">false</PublishProfileImported>
   </PropertyGroup>
 
   <Import Project="$(WebPublishProfileFile)" Condition="'$(PublishProfileImported)' == 'true'" />


### PR DESCRIPTION
#### Description

When an application is published in Visual Studio, the full path to the publish
profile is passed as the `WebPublishProfileFile` global property.

Because the .NET Core SDK now imports the publish profile, this caused every
project referenced to also import the publish profile during restore. This may
have unintentional consequences of restoring `netstandard` projects as
`netcoreapp` if a `netcoreapp` TFM is set in the publish profile, for example.

However, during build/publish, the Web SDK is removing `WebPublishProfileFile`
from the global properties for project references.  This causes an error due to
a potential mismatch between the TFM restored and the TFM being
built/published for dependent projects.

Fixes aspnet/websdk#604.
		
#### Customer Impact

Customers will not be able to publish their .NET Core web applications that have references on projects that have a different TFM (e.g. `netstandard` libraries) from Visual Studio.
		
#### Regression?

Yes.
		
#### Risk

Risk is low.

The fix is to import the publish profile only when the full path isn't set or
if the project being built is the one being published (i.e. the project to
override project extensions for).