### PR TITLE
React to removal of types in Microsoft.VisualBasic.Core.dll

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.VisualBasic.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.VisualBasic.targets
@@ -103,6 +103,22 @@ Copyright (c) .NET Foundation. All rights reserved.
     <VBRuntime>Embed</VBRuntime>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETFramework'">
+    <!--
+      Prevent the .NET Framework compiler from trying to locate assemblies
+      in the .NET Framework directory when not targeting .NET Framework
+    -->
+    <DisableSdkPath Condition="'$(DisableSdkPath)' == ''">true</DisableSdkPath>
+
+    <!--
+      VB Runtime does not yet have enough support for My.* outside .NET Framework,
+      so default MyType=Empty for non .NET Framework. Project templates will be
+      responsible for setting MyType to non-Empty (Console, Windows, etc.) when 
+      the VB Runtime can allow it and as appropriate for the project type.
+     -->
+    <FinalDefineConstants Condition="'$(MyType)' == ''">$(FinalDefineConstants),_MyType=&quot;Empty&quot;</FinalDefineConstants>
+  </PropertyGroup>
+
   <!--
     NOTE: We must hook directly to CoreCompile for compatibility with two phase XAML
           build. We also must not pull in a dependency on ResolveAssemblyReferences

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildALibraryWithVB.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildALibraryWithVB.cs
@@ -170,10 +170,10 @@ namespace Microsoft.NET.Build.Tests
         }
 
         [Theory]
-        [InlineData("Debug", new[] { "CONFIG=\"Debug\"", "DEBUG=-1", "TRACE=-1" })]
-        [InlineData("Release", new[] { "CONFIG=\"Release\"", "RELEASE=-1", "TRACE=-1" })]
-        [InlineData("CustomConfiguration",  new[] { "CONFIG=\"CustomConfiguration\"", "CUSTOMCONFIGURATION=-1" })]
-        [InlineData("Debug-NetCore",  new[] { "CONFIG=\"Debug-NetCore\"", "DEBUG_NETCORE=-1" })]
+        [InlineData("Debug", new[] { "CONFIG=\"Debug\"", "DEBUG=-1", "TRACE=-1", "_MyType=\"Empty\"" })]
+        [InlineData("Release", new[] { "CONFIG=\"Release\"", "RELEASE=-1", "TRACE=-1", "_MyType=\"Empty\"" })]
+        [InlineData("CustomConfiguration",  new[] { "CONFIG=\"CustomConfiguration\"", "CUSTOMCONFIGURATION=-1", "_MyType=\"Empty\"" })]
+        [InlineData("Debug-NetCore",  new[] { "CONFIG=\"Debug-NetCore\"", "DEBUG_NETCORE=-1", "_MyType=\"Empty\"" })]
         public void It_implicitly_defines_compilation_constants_for_the_configuration(string configuration, string[] expectedDefines)
         {
             var testAsset = _testAssetsManager
@@ -200,16 +200,16 @@ namespace Microsoft.NET.Build.Tests
         }
 
         [Theory]
-        [InlineData(".NETStandard,Version=v1.0", new[] { "NETSTANDARD=-1", "NETSTANDARD1_0=-1" }, false)]
-        [InlineData("netstandard1.3", new[] { "NETSTANDARD=-1", "NETSTANDARD1_3=-1" }, false)]
-        [InlineData("netstandard1.6", new[] { "NETSTANDARD=-1", "NETSTANDARD1_6=-1" }, false)]
+        [InlineData(".NETStandard,Version=v1.0", new[] { "NETSTANDARD=-1", "NETSTANDARD1_0=-1", "_MyType=\"Empty\"" }, false)]
+        [InlineData("netstandard1.3", new[] { "NETSTANDARD=-1", "NETSTANDARD1_3=-1", "_MyType=\"Empty\"" }, false)]
+        [InlineData("netstandard1.6", new[] { "NETSTANDARD=-1", "NETSTANDARD1_6=-1", "_MyType=\"Empty\"" }, false)]
         [InlineData("net45", new[] { "NETFRAMEWORK=-1", "NET45=-1" }, true)]
         [InlineData("net461", new[] { "NETFRAMEWORK=-1", "NET461=-1" }, true)]
-        [InlineData("netcoreapp1.0", new[] { "NETCOREAPP=-1", "NETCOREAPP1_0=-1" }, false)]
-        [InlineData(".NETPortable,Version=v4.5,Profile=Profile78", new string[] { }, false)]
+        [InlineData("netcoreapp1.0", new[] { "NETCOREAPP=-1", "NETCOREAPP1_0=-1", "_MyType=\"Empty\"" }, false)]
+        [InlineData(".NETPortable,Version=v4.5,Profile=Profile78", new string[] { "_MyType=\"Empty\"" }, false)]
         [InlineData(".NETFramework,Version=v4.0,Profile=Client", new string[] { "NETFRAMEWORK=-1", "NET40=-1" }, false)]
-        [InlineData("Xamarin.iOS,Version=v1.0", new string[] { "XAMARINIOS=-1", "XAMARINIOS1_0=-1" }, false)]
-        [InlineData("UnknownFramework,Version=v3.14", new string[] { "UNKNOWNFRAMEWORK=-1", "UNKNOWNFRAMEWORK3_14=-1" }, false)]
+        [InlineData("Xamarin.iOS,Version=v1.0", new string[] { "XAMARINIOS=-1", "XAMARINIOS1_0=-1", "_MyType=\"Empty\"" }, false)]
+        [InlineData("UnknownFramework,Version=v3.14", new string[] { "UNKNOWNFRAMEWORK=-1", "UNKNOWNFRAMEWORK3_14=-1", "_MyType=\"Empty\"" }, false)]
         public void It_implicitly_defines_compilation_constants_for_the_target_framework(string targetFramework, string[] expectedDefines, bool buildOnlyOnWindows)
         {
             bool shouldCompile = true;

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToUseVB.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToUseVB.cs
@@ -98,7 +98,7 @@ namespace Microsoft.NET.Build.Tests
             };
 
             buildCommand
-                .Execute(@"/bl:d:\temp\vb.binlog")
+                .Execute()
                 .Should()
                 .Pass();
 

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToUseVB.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToUseVB.cs
@@ -32,11 +32,12 @@ namespace Microsoft.NET.Build.Tests
         }
 
         [Theory]
-        [InlineData("net45")]
-        [InlineData("netstandard2.0")]
-        [InlineData("netcoreapp2.1")]
-        [InlineData("netcoreapp3.0")]
-        public void It_builds_a_simple_vb_project(string targetFramework)
+        [InlineData("net45", true)]
+        [InlineData("netstandard2.0", false)]
+        [InlineData("netcoreapp2.1", true)]
+        [InlineData("netcoreapp3.0", true)]
+        [InlineData("netcoreapp3.0", false)]
+        public void It_builds_a_simple_vb_project(string targetFramework, bool isExe)
         {
             if (targetFramework == "net45" && !TestProject.ReferenceAssembliesAreInstalled("v4.5"))
             {
@@ -45,27 +46,33 @@ namespace Microsoft.NET.Build.Tests
                 return;
             }
 
-            var (expectedVBRuntime, expectedOutputFiles) = GetExpectedOutputs(targetFramework);
+            var (expectedVBRuntime, expectedOutputFiles) = GetExpectedOutputs(targetFramework, isExe);
 
             var testProject = new TestProject
             {
                 Name = "HelloWorld",
                 IsSdkProject = true,
                 TargetFrameworks = targetFramework,
-                IsExe = targetFramework != "netstandard2.0",
-                AdditionalProperties =
-                {
-                    ["MyType"] = "Console" ,
-                },
+                IsExe = isExe,
                 SourceFiles =
                 {
                     ["Program.vb"] = @"
                         Imports System
 
                         Module Program
+                            #If NETFRAMEWORK Or NETCOREAPP3_0
+                                ' https://github.com/dotnet/sdk/issues/2793
+                                Private Const TabChar As Char = Chr(9)
+                            #End If
+
                             Function MyComputerName() As String
-                                #If NETFRAMEWORK Or NETCOREAPP3_0 Then
+                                #If NETFRAMEWORK
                                     Return My.Computer.Name
+                                #End If
+
+                                #If NETFRAMEWORK Or NETCOREAPP_3_0
+                                    ' https://github.com/dotnet/sdk/issues/3379
+                                    End
                                 #End If
                             End Function
 
@@ -78,7 +85,7 @@ namespace Microsoft.NET.Build.Tests
             };
 
             var testAsset = _testAssetsManager
-                .CreateTestProject(testProject, identifier: targetFramework, targetExtension: ".vbproj")
+                .CreateTestProject(testProject, identifier: targetFramework + isExe, targetExtension: ".vbproj")
                 .Restore(Log, testProject.Name);
 
             var buildCommand = new GetValuesCommand(
@@ -91,7 +98,7 @@ namespace Microsoft.NET.Build.Tests
             };
 
             buildCommand
-                .Execute()
+                .Execute(@"/bl:d:\temp\vb.binlog")
                 .Should()
                 .Pass();
 
@@ -103,11 +110,11 @@ namespace Microsoft.NET.Build.Tests
             actualVBRuntime.Should().Be(expectedVBRuntime);
         }
 
-        private static (VBRuntime, string[]) GetExpectedOutputs(string targetFramework)
+        private static (VBRuntime, string[]) GetExpectedOutputs(string targetFramework, bool isExe)
         {
-            switch (targetFramework)
+            switch ((targetFramework, isExe))
             {
-                case "net45":
+                case ("net45", true):
                     return (VBRuntime.Default, new[]
                     {
                         "HelloWorld.exe",
@@ -115,7 +122,7 @@ namespace Microsoft.NET.Build.Tests
                         "HelloWorld.pdb"
                     });
 
-                case "netcoreapp2.1":
+                case ("netcoreapp2.1", true):
                     return (VBRuntime.Embedded, new[]
                     {
                         "HelloWorld.dll",
@@ -125,7 +132,7 @@ namespace Microsoft.NET.Build.Tests
                         "HelloWorld.deps.json",
                     });
 
-                case "netcoreapp3.0":
+                case ("netcoreapp3.0", true):
                     return (VBRuntime.Referenced, new[]
                     {
                         "HelloWorld.dll",
@@ -136,7 +143,15 @@ namespace Microsoft.NET.Build.Tests
                         "HelloWorld.deps.json",
                     });
 
-                case "netstandard2.0":
+                case ("netcoreapp3.0", false):
+                   return (VBRuntime.Referenced, new[]
+                   {
+                        "HelloWorld.dll",
+                        "HelloWorld.pdb",
+                        "HelloWorld.deps.json",
+                    });
+
+                case ("netstandard2.0", false):
                     return (VBRuntime.Embedded, new[]
                     {
                         "HelloWorld.dll",
@@ -145,7 +160,7 @@ namespace Microsoft.NET.Build.Tests
                     });
 
                 default:
-                    throw new ArgumentOutOfRangeException(nameof(targetFramework));
+                    throw new ArgumentOutOfRangeException();
             }
         }
 


### PR DESCRIPTION
#### Description
Types are being removed from Microsoft.VisualBasic.Core.dll in https://github.com/dotnet/corefx/pull/39972 to allow them to be put in a higher layer in a future release.

Disable generation of `My.*` code by default, as `My.*` cannot compile without those types.

#### Customer Impact
All VB projects would fail to build without the corefx change, but not this change.  (There would be a workaround of disabling `My.* yourself, but we can't have File -> New Project -> VB fail.


#### Regression?
No. This was expected fallout of removing those types.

#### Risk
Minimal. Tested all 11 VB .NET Core projects with this + a private drop of  https://github.com/dotnet/corefx/pull/39972 

---

Due to layering issues, several types that are necessary for VB My.* support are being removed from 3.0:

https://github.com/dotnet/corefx/pull/39972

Furthermore, this would cause all .NET Core 3.0 projects to fail to build without this change, which sets MyType=Empty by default to prevent the My.* code spit that would depend on these types from happening by default.

Note that .NET Core 2.x is not impacted because it still uses VBRuntime=Embed, which also suppresses `My.*`. It also prevents other VB constructs from working that still work .NET Core 3.0 without these types. The test has been adapted to test some of those constructs for 3.0 instead of testing for `My.*` working.

Also fix related issue that could cause a bug or misconfigured project to result in the .NET Framework VB compiler trying to reference the .NET Framework Microsoft.VisualBasic.dll in the runtime directory instead of the resolved Microsoft.VisualBasic.dll.