### PR TITLE
Separate supported target framework into app/standard lists.

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.SupportedTargetFrameworks.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.SupportedTargetFrameworks.props
@@ -10,7 +10,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 ***********************************************************************************************
 -->
 
-<!-- This file contains a list of the TFMs that are supported by this SDK for .NET Core and .NET Standard.
+<!-- This file contains a list of the TFMs that are supported by this SDK for .NET Core, .NET Standard, and .NET Framework.
      This is used by VS to show the list of frameworks to which projects can be retargeted. -->
 <Project>
     <!-- .NET Core App -->
@@ -36,8 +36,26 @@ Copyright (c) .NET Foundation. All rights reserved.
         <SupportedNETStandardTargetFramework Include=".NETStandard,Version=v2.1" DisplayName=".NET Standard 2.1" />
     </ItemGroup>
 
+    <!-- .NET Framework -->
+    <ItemGroup>
+        <SupportedNETFrameworkTargetFramework Include=".NETFramework,Version=v2.0"   DisplayName=".NET Framework 2.0" />
+        <SupportedNETFrameworkTargetFramework Include=".NETFramework,Version=v3.0"   DisplayName=".NET Framework 3.0" />
+        <SupportedNETFrameworkTargetFramework Include=".NETFramework,Version=v3.5"   DisplayName=".NET Framework 3.5" />
+        <SupportedNETFrameworkTargetFramework Include=".NETFramework,Version=v4.0"   DisplayName=".NET Framework 4.0" />
+        <SupportedNETFrameworkTargetFramework Include=".NETFramework,Version=v4.5"   DisplayName=".NET Framework 4.5" />
+        <SupportedNETFrameworkTargetFramework Include=".NETFramework,Version=v4.5.1" DisplayName=".NET Framework 4.5.1" />
+        <SupportedNETFrameworkTargetFramework Include=".NETFramework,Version=v4.5.2" DisplayName=".NET Framework 4.5.2" />
+        <SupportedNETFrameworkTargetFramework Include=".NETFramework,Version=v4.6"   DisplayName=".NET Framework 4.6" />
+        <SupportedNETFrameworkTargetFramework Include=".NETFramework,Version=v4.6.1" DisplayName=".NET Framework 4.6.1" />
+        <SupportedNETFrameworkTargetFramework Include=".NETFramework,Version=v4.6.2" DisplayName=".NET Framework 4.6.2" />
+        <SupportedNETFrameworkTargetFramework Include=".NETFramework,Version=v4.7"   DisplayName=".NET Framework 4.7" />
+        <SupportedNETFrameworkTargetFramework Include=".NETFramework,Version=v4.7.1" DisplayName=".NET Framework 4.7.1" />
+        <SupportedNETFrameworkTargetFramework Include=".NETFramework,Version=v4.7.2" DisplayName=".NET Framework 4.7.2" />
+        <SupportedNETFrameworkTargetFramework Include=".NETFramework,Version=v4.8"   DisplayName=".NET Framework 4.8" />
+    </ItemGroup>
+
     <!-- All supported target frameworks -->
     <ItemGroup>
-        <SupportedTargetFramework Include="@(SupportedNETCoreAppTargetFramework);@(SupportedNETStandardTargetFramework)" />
+        <SupportedTargetFramework Include="@(SupportedNETCoreAppTargetFramework);@(SupportedNETStandardTargetFramework);@(SupportedNETFrameworkTargetFramework)" />
     </ItemGroup>
 </Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.SupportedTargetFrameworks.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.SupportedTargetFrameworks.props
@@ -13,26 +13,31 @@ Copyright (c) .NET Foundation. All rights reserved.
 <!-- This file contains a list of the TFMs that are supported by this SDK for .NET Core and .NET Standard.
      This is used by VS to show the list of frameworks to which projects can be retargeted. -->
 <Project>
-    <!-- .NET Core -->
+    <!-- .NET Core App -->
     <ItemGroup>
-        <SupportedTargetFramework Include=".NETCoreApp,Version=v1.0" DisplayName=".NET Core 1.0" />
-        <SupportedTargetFramework Include=".NETCoreApp,Version=v1.1" DisplayName=".NET Core 1.1" />
-        <SupportedTargetFramework Include=".NETCoreApp,Version=v2.0" DisplayName=".NET Core 2.0" />
-        <SupportedTargetFramework Include=".NETCoreApp,Version=v2.1" DisplayName=".NET Core 2.1" />
-        <SupportedTargetFramework Include=".NETCoreApp,Version=v2.2" DisplayName=".NET Core 2.2" />
-        <SupportedTargetFramework Include=".NETCoreApp,Version=v3.0" DisplayName=".NET Core 3.0" />
+        <SupportedNETCoreAppTargetFramework Include=".NETCoreApp,Version=v1.0" DisplayName=".NET Core 1.0" />
+        <SupportedNETCoreAppTargetFramework Include=".NETCoreApp,Version=v1.1" DisplayName=".NET Core 1.1" />
+        <SupportedNETCoreAppTargetFramework Include=".NETCoreApp,Version=v2.0" DisplayName=".NET Core 2.0" />
+        <SupportedNETCoreAppTargetFramework Include=".NETCoreApp,Version=v2.1" DisplayName=".NET Core 2.1" />
+        <SupportedNETCoreAppTargetFramework Include=".NETCoreApp,Version=v2.2" DisplayName=".NET Core 2.2" />
+        <SupportedNETCoreAppTargetFramework Include=".NETCoreApp,Version=v3.0" DisplayName=".NET Core 3.0" />
     </ItemGroup>
 
     <!-- .NET Standard -->
     <ItemGroup>
-        <SupportedTargetFramework Include=".NETStandard,Version=v1.0" DisplayName=".NET Standard 1.0" />
-        <SupportedTargetFramework Include=".NETStandard,Version=v1.1" DisplayName=".NET Standard 1.1" />
-        <SupportedTargetFramework Include=".NETStandard,Version=v1.2" DisplayName=".NET Standard 1.2" />
-        <SupportedTargetFramework Include=".NETStandard,Version=v1.3" DisplayName=".NET Standard 1.3" />
-        <SupportedTargetFramework Include=".NETStandard,Version=v1.4" DisplayName=".NET Standard 1.4" />
-        <SupportedTargetFramework Include=".NETStandard,Version=v1.5" DisplayName=".NET Standard 1.5" />
-        <SupportedTargetFramework Include=".NETStandard,Version=v1.6" DisplayName=".NET Standard 1.6" />
-        <SupportedTargetFramework Include=".NETStandard,Version=v2.0" DisplayName=".NET Standard 2.0" />
-        <SupportedTargetFramework Include=".NETStandard,Version=v2.1" DisplayName=".NET Standard 2.1" />
+        <SupportedNETStandardTargetFramework Include=".NETStandard,Version=v1.0" DisplayName=".NET Standard 1.0" />
+        <SupportedNETStandardTargetFramework Include=".NETStandard,Version=v1.1" DisplayName=".NET Standard 1.1" />
+        <SupportedNETStandardTargetFramework Include=".NETStandard,Version=v1.2" DisplayName=".NET Standard 1.2" />
+        <SupportedNETStandardTargetFramework Include=".NETStandard,Version=v1.3" DisplayName=".NET Standard 1.3" />
+        <SupportedNETStandardTargetFramework Include=".NETStandard,Version=v1.4" DisplayName=".NET Standard 1.4" />
+        <SupportedNETStandardTargetFramework Include=".NETStandard,Version=v1.5" DisplayName=".NET Standard 1.5" />
+        <SupportedNETStandardTargetFramework Include=".NETStandard,Version=v1.6" DisplayName=".NET Standard 1.6" />
+        <SupportedNETStandardTargetFramework Include=".NETStandard,Version=v2.0" DisplayName=".NET Standard 2.0" />
+        <SupportedNETStandardTargetFramework Include=".NETStandard,Version=v2.1" DisplayName=".NET Standard 2.1" />
+    </ItemGroup>
+
+    <!-- All supported target frameworks -->
+    <ItemGroup>
+        <SupportedTargetFramework Include="@(SupportedNETCoreAppTargetFramework);@(SupportedNETStandardTargetFramework)" />
     </ItemGroup>
 </Project>

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeManifestSupportedFrameworks.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeManifestSupportedFrameworks.cs
@@ -94,12 +94,23 @@ namespace Microsoft.NET.Build.Tests
 
             supportedNetStandardTFs.Should().NotBeEmpty();
 
+            var supportedNetFrameworkTFs = GetItems(
+                testDirectory,
+                project.TargetFrameworks,
+                "SupportedNETFrameworkTargetFramework");
+
+            supportedNetFrameworkTFs.Should().NotBeEmpty();
+
             var supportedTFs = GetItems(
                 testDirectory,
                 project.TargetFrameworks,
                 "SupportedTargetFramework");
 
-            supportedNetCoreAppTFs.Union(supportedNetStandardTFs).Should().Equal(supportedTFs);
+            supportedNetCoreAppTFs
+                .Union(supportedNetStandardTFs)
+                .Union(supportedNetFrameworkTFs)
+                .Should()
+                .Equal(supportedTFs);
         }
 
         private List<string> GetItems(string testDirectory, string tfm, string itemName)

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeManifestSupportedFrameworks.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeManifestSupportedFrameworks.cs
@@ -44,7 +44,7 @@ namespace Microsoft.NET.Build.Tests
                 targetFrameworkIdentifier.Substring(1) + "MaximumVersion",
                 GetValuesCommand.ValueType.Property);
 
-             var getSupportedFrameworks = new GetValuesCommand(
+            var getSupportedFrameworks = new GetValuesCommand(
                 Log,
                 testDirectory,
                 project.TargetFrameworks,
@@ -64,6 +64,57 @@ namespace Microsoft.NET.Build.Tests
 
             supportedFrameworks.Should().Contain(expectedTFM,
                 because: $"Microsoft.NET.SupportedTargetFrameworks.props should include an entry for {expectedTFM}");
+        }
+
+        [Fact]
+        public void TheSupportedTargetFrameworkListIsComposed()
+        {
+            var project = new TestProject
+            {
+                Name = "SupportedTargetFrameworkLists",
+                TargetFrameworks = "netcoreapp3.0",
+                IsSdkProject = true,
+            };
+
+            TestAsset asset = _testAssetsManager.CreateTestProject(project);
+
+            string testDirectory = Path.Combine(asset.TestRoot, project.Name);
+
+            var supportedNetCoreAppTFs = GetItems(
+                testDirectory,
+                project.TargetFrameworks,
+                "SupportedNETCoreAppTargetFramework");
+
+            supportedNetCoreAppTFs.Should().NotBeEmpty();
+
+            var supportedNetStandardTFs = GetItems(
+                testDirectory,
+                project.TargetFrameworks,
+                "SupportedNETStandardTargetFramework");
+
+            supportedNetStandardTFs.Should().NotBeEmpty();
+
+            var supportedTFs = GetItems(
+                testDirectory,
+                project.TargetFrameworks,
+                "SupportedTargetFramework");
+
+            supportedNetCoreAppTFs.Union(supportedNetStandardTFs).Should().Equal(supportedTFs);
+        }
+
+        private List<string> GetItems(string testDirectory, string tfm, string itemName)
+        {
+            var command = new GetValuesCommand(
+                Log,
+                testDirectory,
+                tfm,
+                itemName,
+                GetValuesCommand.ValueType.Item);
+
+            command.DependsOnTargets = "";
+            command.Execute().Should().Pass();
+
+            return command.GetValues();
         }
     }
 }


### PR DESCRIPTION
#### Description

This commit makes the `SupportedTargetFramework` items be composed of
`NETCoreApp` and `NETStandard` versions so that other SDKs, such as
WindowsDesktop, can selectively remove unsupported target frameworks from these
lists.

Fixes #3438.
		
#### Customer Impact

Without this change, the Windows Desktop SDK cannot easily filter out unsupported target frameworks.
		
#### Regression?

No.
		
#### Risk

Low