### PR TITLE
Change default apphost creation retry count to zero.

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/CreateAppHost.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/CreateAppHost.cs
@@ -19,7 +19,11 @@ namespace Microsoft.NET.Build.Tasks
         /// <summary>
         /// The number of additional retries to attempt for creating the apphost.
         /// <summary>
-        public const int DefaultRetries = 2;
+        /// <remarks>
+        /// The default is no retries because internally the `HostWriter` attempts to retry
+        /// on different I/O operations. Users can optionally retry at the task level if desired.
+        /// </remarks>
+        public const int DefaultRetries = 0;
 
         /// The default delay, in milliseconds, for each retry attempt for creating the apphost.
         /// </summary>

--- a/src/Tests/Microsoft.NET.Build.Tests/AppHostTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/AppHostTests.cs
@@ -260,7 +260,12 @@ namespace Microsoft.NET.Build.Tests
 
             using (var stream = new FileStream(intermediateAppHost, FileMode.Open, FileAccess.Read, FileShare.None))
             {
-                var result = buildCommand.Execute("/clp:NoSummary");
+                const int Retries = 1;
+
+                var result = buildCommand.Execute(
+                    "/clp:NoSummary",
+                    $"/p:CopyRetryCount={Retries}",
+                    "/p:CopyRetryDelayMilliseconds=0");
 
                 result
                     .Should()
@@ -268,7 +273,7 @@ namespace Microsoft.NET.Build.Tests
                     .And
                     .HaveStdOutContaining("System.IO.IOException");
 
-                Regex.Matches(result.StdOut, "NETSDK1113", RegexOptions.None).Count.Should().Be(2);
+                Regex.Matches(result.StdOut, "NETSDK1113", RegexOptions.None).Count.Should().Be(Retries);
             }
         }
 


### PR DESCRIPTION
This commit changes the default apphost creation retry count to zero.

The `HostWriter` now internally implements a retry for relevant I/O exceptions,
so the default retry at the task level would add unnecessary delay for
legitimate failure conditions.

Changing the default to zero still leaves the retry at the task level that
users can optionally enable through build properties.

Helps address dotnet/core-setup#7597.