### PR TITLE
Miscellaneous perf fixes

### DIFF
--- a/src/Tasks/Common/ConflictResolution/ConflictItem.cs
+++ b/src/Tasks/Common/ConflictResolution/ConflictItem.cs
@@ -5,6 +5,13 @@ using Microsoft.Build.Framework;
 using System;
 using System.IO;
 
+#if EXTENSIONS
+using ConflictVersion = System.Version;
+#else
+using ConflictVersion = NuGet.Versioning.NuGetVersion;
+using NuGet.Versioning;
+#endif
+
 namespace Microsoft.NET.Build.Tasks.ConflictResolution
 {
     internal enum ConflictItemType
@@ -25,10 +32,7 @@ namespace Microsoft.NET.Build.Tasks.ConflictResolution
         string PackageId { get; }
         string DisplayName { get; }
 
-        // NOTE: Technically this should be NuGetVersion because System.Version doesn't work with semver.
-        // However, the only scenarios we need to support this property for in conflict resolution is stable versions
-        // of System packages. PackageVersion will be null if System.Version can't parse the version (i.e. if is pre-release)
-        Version PackageVersion { get; }
+        ConflictVersion PackageVersion { get; }
     }
 
     // Wraps an ITask item and adds lazy evaluated properties used by Conflict resolution.
@@ -178,8 +182,8 @@ namespace Microsoft.NET.Build.Tasks.ConflictResolution
         }
 
         private bool _hasPackageVersion;
-        private Version _packageVersion;
-        public Version PackageVersion
+        private ConflictVersion _packageVersion;
+        public ConflictVersion PackageVersion
         {
             get
             {
@@ -191,7 +195,7 @@ namespace Microsoft.NET.Build.Tasks.ConflictResolution
 
                     if (packageVersionString.Length != 0)
                     {
-                        Version.TryParse(packageVersionString, out _packageVersion);
+                        ConflictVersion.TryParse(packageVersionString, out _packageVersion);
                     }
 
                     // PackageVersion may be null but don't try to recalculate it

--- a/src/Tasks/Common/ConflictResolution/PackageOverride.cs
+++ b/src/Tasks/Common/ConflictResolution/PackageOverride.cs
@@ -6,6 +6,13 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Build.Framework;
 
+#if EXTENSIONS
+using OverrideVersion = System.Version;
+#else
+using OverrideVersion = NuGet.Versioning.NuGetVersion;
+using NuGet.Versioning;
+#endif
+
 namespace Microsoft.NET.Build.Tasks.ConflictResolution
 {
     /// <summary>
@@ -19,14 +26,14 @@ namespace Microsoft.NET.Build.Tasks.ConflictResolution
     internal class PackageOverride
     {
         public string PackageName { get; }
-        public Dictionary<string, Version> OverriddenPackages { get; }
+        public Dictionary<string, OverrideVersion> OverriddenPackages { get; }
 
-        private PackageOverride(string packageName, IEnumerable<Tuple<string, Version>> overriddenPackages)
+        private PackageOverride(string packageName, IEnumerable<Tuple<string, OverrideVersion>> overriddenPackages)
         {
             PackageName = packageName;
 
-            OverriddenPackages = new Dictionary<string, Version>(StringComparer.OrdinalIgnoreCase);
-            foreach (Tuple<string, Version> package in overriddenPackages)
+            OverriddenPackages = new Dictionary<string, OverrideVersion>(StringComparer.OrdinalIgnoreCase);
+            foreach (Tuple<string, OverrideVersion> package in overriddenPackages)
             {
                 OverriddenPackages[package.Item1] = package.Item2;
             }
@@ -40,7 +47,7 @@ namespace Microsoft.NET.Build.Tasks.ConflictResolution
             return new PackageOverride(packageName, CreateOverriddenPackages(overriddenPackagesString));
         }
 
-        private static IEnumerable<Tuple<string, Version>> CreateOverriddenPackages(string overriddenPackagesString)
+        private static IEnumerable<Tuple<string, OverrideVersion>> CreateOverriddenPackages(string overriddenPackagesString)
         {
             if (!string.IsNullOrEmpty(overriddenPackagesString))
             {
@@ -52,10 +59,19 @@ namespace Microsoft.NET.Build.Tasks.ConflictResolution
                     int separatorIndex = trimmedOverriddenPackagesAndVersion.IndexOf('|');
                     if (separatorIndex != -1)
                     {
-                        if (Version.TryParse(trimmedOverriddenPackagesAndVersion.Substring(separatorIndex + 1), out Version version))
+                        string versionString = trimmedOverriddenPackagesAndVersion.Substring(separatorIndex + 1);
+                        string overriddenPackage = trimmedOverriddenPackagesAndVersion.Substring(0, separatorIndex);
+#if EXTENSIONS
+                        if (Version.TryParse(versionString, out Version version))
                         {
-                            yield return Tuple.Create(trimmedOverriddenPackagesAndVersion.Substring(0, separatorIndex), version);
+                            yield return Tuple.Create(overriddenPackage, version);
                         }
+#else
+                        if (NuGetVersion.TryParse(versionString, out NuGetVersion version))
+                        {
+                            yield return Tuple.Create(overriddenPackage, version);
+                        }
+#endif
                     }
                 }
             }

--- a/src/Tasks/Common/ConflictResolution/PackageOverride.cs
+++ b/src/Tasks/Common/ConflictResolution/PackageOverride.cs
@@ -61,17 +61,10 @@ namespace Microsoft.NET.Build.Tasks.ConflictResolution
                     {
                         string versionString = trimmedOverriddenPackagesAndVersion.Substring(separatorIndex + 1);
                         string overriddenPackage = trimmedOverriddenPackagesAndVersion.Substring(0, separatorIndex);
-#if EXTENSIONS
-                        if (Version.TryParse(versionString, out Version version))
+                        if (OverrideVersion.TryParse(versionString, out OverrideVersion version))
                         {
                             yield return Tuple.Create(overriddenPackage, version);
                         }
-#else
-                        if (NuGetVersion.TryParse(versionString, out NuGetVersion version))
-                        {
-                            yield return Tuple.Create(overriddenPackage, version);
-                        }
-#endif
                     }
                 }
             }

--- a/src/Tasks/Common/ConflictResolution/PackageOverrideResolver.cs
+++ b/src/Tasks/Common/ConflictResolution/PackageOverrideResolver.cs
@@ -5,6 +5,13 @@ using System;
 using System.Collections.Generic;
 using Microsoft.Build.Framework;
 
+#if EXTENSIONS
+using OverrideVersion = System.Version;
+#else
+using OverrideVersion = NuGet.Versioning.NuGetVersion;
+using NuGet.Versioning;
+#endif
+
 namespace Microsoft.NET.Build.Tasks.ConflictResolution
 {
     /// <summary>
@@ -60,9 +67,9 @@ namespace Microsoft.NET.Build.Tasks.ConflictResolution
         /// </summary>
         private static void MergePackageOverrides(PackageOverride newPackageOverride, PackageOverride existingPackageOverride)
         {
-            foreach (KeyValuePair<string, Version> newOverride in newPackageOverride.OverriddenPackages)
+            foreach (KeyValuePair<string, OverrideVersion> newOverride in newPackageOverride.OverriddenPackages)
             {
-                if (existingPackageOverride.OverriddenPackages.TryGetValue(newOverride.Key, out Version existingOverrideVersion))
+                if (existingPackageOverride.OverriddenPackages.TryGetValue(newOverride.Key, out OverrideVersion existingOverrideVersion))
                 {
                     if (existingOverrideVersion < newOverride.Value)
                     {
@@ -81,7 +88,7 @@ namespace Microsoft.NET.Build.Tasks.ConflictResolution
             if (PackageOverrides != null && item1.PackageId != null && item2.PackageId != null)
             {
                 PackageOverride packageOverride;
-                Version version;
+                OverrideVersion version;
                 if (PackageOverrides.TryGetValue(item1.PackageId, out packageOverride)
                     && packageOverride.OverriddenPackages.TryGetValue(item2.PackageId, out version)
                     && item2.PackageVersion != null

--- a/src/Tasks/Common/targets/Microsoft.NET.DefaultPackageConflictOverrides.targets
+++ b/src/Tasks/Common/targets/Microsoft.NET.DefaultPackageConflictOverrides.targets
@@ -12,7 +12,8 @@ Copyright (c) .NET Foundation. All rights reserved.
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <ItemGroup Condition="'$(DisableDefaultPackageConflictOverrides)' != 'true'">
-    <PackageConflictOverrides Include="Microsoft.NETCore.App">
+    <PackageConflictOverrides Include="Microsoft.NETCore.App"
+                              Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' And ('$(_TargetFrameworkVersionWithoutV)' != '') And ('$(_TargetFrameworkVersionWithoutV)' &lt; '3.0')">
       <OverriddenPackages>
         Microsoft.CSharp|4.4.0;
         Microsoft.Win32.Primitives|4.3.0;

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAConflictResolver.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAConflictResolver.cs
@@ -8,6 +8,7 @@ using FluentAssertions;
 using Microsoft.Build.Framework;
 using Microsoft.NET.Build.Tasks.ConflictResolution;
 using Microsoft.NET.Build.Tasks.UnitTests.Mocks;
+using NuGet.Versioning;
 using Xunit;
 
 namespace Microsoft.NET.Build.Tasks.UnitTests
@@ -354,13 +355,13 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
         [Fact]
         public void WhenPackageOverridesAreSpecifiedTheyAreUsed()
         {
-            var systemItem1 = new MockConflictItem("System.Ben") { PackageId = "System.Ben", PackageVersion = new Version("4.3.0") };
-            var systemItem2 = new MockConflictItem("System.Immo") { PackageId = "System.Immo", PackageVersion = new Version("4.2.0") };
-            var systemItem3 = new MockConflictItem("System.Dave") { PackageId = "System.Dave", PackageVersion = new Version("4.1.0") };
+            var systemItem1 = new MockConflictItem("System.Ben") { PackageId = "System.Ben", PackageVersion = new NuGetVersion("4.3.0") };
+            var systemItem2 = new MockConflictItem("System.Immo") { PackageId = "System.Immo", PackageVersion = new NuGetVersion("4.2.0") };
+            var systemItem3 = new MockConflictItem("System.Dave") { PackageId = "System.Dave", PackageVersion = new NuGetVersion("4.1.0") };
 
-            var platformItem1 = new MockConflictItem("System.Ben") { PackageId = "Platform", PackageVersion = new Version("2.0.0") };
-            var platformItem2 = new MockConflictItem("System.Immo") { PackageId = "Platform", PackageVersion = new Version("2.0.0") };
-            var platformItem3 = new MockConflictItem("System.Dave") { PackageId = "Platform", PackageVersion = new Version("2.0.0") };
+            var platformItem1 = new MockConflictItem("System.Ben") { PackageId = "Platform", PackageVersion = new NuGetVersion("2.0.0") };
+            var platformItem2 = new MockConflictItem("System.Immo") { PackageId = "Platform", PackageVersion = new NuGetVersion("2.0.0") };
+            var platformItem3 = new MockConflictItem("System.Dave") { PackageId = "Platform", PackageVersion = new NuGetVersion("2.0.0") };
 
             var result = GetConflicts(
                 new[] { systemItem1, systemItem2, systemItem3, platformItem1, platformItem2, platformItem3 },
@@ -379,17 +380,17 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
         [Fact]
         public void WhenAHigherPackageIsUsedPackageOverrideLoses()
         {
-            var platformItem1 = new MockConflictItem("System.Ben") { PackageId = "Platform", PackageVersion = new Version("2.0.0") };
-            var platformItem2 = new MockConflictItem("System.Immo") { PackageId = "Platform", PackageVersion = new Version("2.0.0") };
-            var platformItem3 = new MockConflictItem("System.Dave") { PackageId = "Platform", PackageVersion = new Version("2.0.0") };
+            var platformItem1 = new MockConflictItem("System.Ben") { PackageId = "Platform", PackageVersion = new NuGetVersion("2.0.0") };
+            var platformItem2 = new MockConflictItem("System.Immo") { PackageId = "Platform", PackageVersion = new NuGetVersion("2.0.0") };
+            var platformItem3 = new MockConflictItem("System.Dave") { PackageId = "Platform", PackageVersion = new NuGetVersion("2.0.0") };
 
-            var systemItem1 = new MockConflictItem("System.Ben") { PackageId = "System.Ben", PackageVersion = new Version("4.3.0") };
-            var systemItem2 = new MockConflictItem("System.Immo") { PackageId = "System.Immo", PackageVersion = new Version("4.2.0") };
+            var systemItem1 = new MockConflictItem("System.Ben") { PackageId = "System.Ben", PackageVersion = new NuGetVersion("4.3.0") };
+            var systemItem2 = new MockConflictItem("System.Immo") { PackageId = "System.Immo", PackageVersion = new NuGetVersion("4.2.0") };
             // System.Dave has a higher PackageVersion than the PackageOverride
             var systemItem3 = new MockConflictItem("System.Dave")
             {
                 PackageId = "System.Dave",
-                PackageVersion = new Version("4.4.0"),
+                PackageVersion = new NuGetVersion("4.4.0"),
                 AssemblyVersion = new Version(platformItem3.AssemblyVersion.Major + 1, 0)
             };
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAPackageOverrideResolver.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAPackageOverrideResolver.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using Microsoft.Build.Framework;
 using Microsoft.NET.Build.Tasks.ConflictResolution;
 using Microsoft.NET.Build.Tasks.UnitTests.Mocks;
+using NuGet.Versioning;
 using Xunit;
 
 namespace Microsoft.NET.Build.Tasks.UnitTests
@@ -33,11 +34,11 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
 
             PackageOverride packageOverride = resolver.PackageOverrides["Platform"];
             Assert.Equal(5, packageOverride.OverriddenPackages.Count);
-            Assert.Equal(new Version(4, 2, 0), packageOverride.OverriddenPackages["System.Ben"]);
-            Assert.Equal(new Version(4, 3, 0), packageOverride.OverriddenPackages["System.Immo"]);
-            Assert.Equal(new Version(4, 3, 0), packageOverride.OverriddenPackages["System.Livar"]);
-            Assert.Equal(new Version(4, 2, 0), packageOverride.OverriddenPackages["System.Dave"]);
-            Assert.Equal(new Version(4, 2, 0), packageOverride.OverriddenPackages["System.Nick"]);
+            Assert.Equal(new NuGetVersion(4, 2, 0), packageOverride.OverriddenPackages["System.Ben"]);
+            Assert.Equal(new NuGetVersion(4, 3, 0), packageOverride.OverriddenPackages["System.Immo"]);
+            Assert.Equal(new NuGetVersion(4, 3, 0), packageOverride.OverriddenPackages["System.Livar"]);
+            Assert.Equal(new NuGetVersion(4, 2, 0), packageOverride.OverriddenPackages["System.Dave"]);
+            Assert.Equal(new NuGetVersion(4, 2, 0), packageOverride.OverriddenPackages["System.Nick"]);
         }
 
         [Fact]
@@ -67,7 +68,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             var packageItem = new MockConflictItem("System.Eric")
             {
                 PackageId = "System.Eric",
-                PackageVersion = new Version(4, 0, 0),
+                PackageVersion = new NuGetVersion(4, 0, 0),
                 AssemblyVersion = new Version(4, 0, 0, 0),
                 ItemType = ConflictItemType.Reference
             };
@@ -85,7 +86,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             var packageItem2 = new MockConflictItem("System.Eric")
             {
                 PackageId = "FakePlatform",
-                PackageVersion = new Version(4, 0, 0),
+                PackageVersion = new NuGetVersion(4, 0, 0),
                 AssemblyVersion = new Version(4, 0, 0, 0),
                 ItemType = ConflictItemType.Reference
             };

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/Mocks/MockConflictItem.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/Mocks/MockConflictItem.cs
@@ -3,6 +3,7 @@
 
 using System;
 using Microsoft.NET.Build.Tasks.ConflictResolution;
+using NuGet.Versioning;
 
 namespace Microsoft.NET.Build.Tasks.UnitTests.Mocks
 {
@@ -17,7 +18,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests.Mocks
             FileName = name + ".dll";
             FileVersion = new Version("1.0.0.0");
             PackageId = name;
-            PackageVersion = new Version("1.0.0");
+            PackageVersion = new NuGetVersion("1.0.0");
             DisplayName = name;
         }
         public string Key { get; set; }
@@ -34,7 +35,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests.Mocks
 
         public string PackageId { get; set; }
 
-        public Version PackageVersion { get; set; }
+        public NuGetVersion PackageVersion { get; set; }
 
         public string DisplayName { get; set; }
     }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets
@@ -33,7 +33,8 @@ Copyright (c) .NET Foundation. All rights reserved.
     ============================================================
     -->
   
-  <Target Name="ProcessFrameworkReferences" BeforeTargets="_CheckForInvalidConfigurationAndPlatform;CollectPackageReferences;CollectPackageDownloads">
+  <Target Name="ProcessFrameworkReferences" BeforeTargets="_CheckForInvalidConfigurationAndPlatform;CollectPackageReferences;CollectPackageDownloads"
+          Condition="'@(FrameworkReference)' != ''">
     
     <CheckForDuplicateFrameworkReferences
         FrameworkReferences="@(FrameworkReference)"


### PR DESCRIPTION
#### Description
Several different perf improvements:

- Don't run ProcessFrameworkReferences target if there are no FrameworkReferences
- Support NuGet semantic versions in packageoverrides.txt
  - Without this, the packageoverrides.txt from the ASP.NET Core targeting pack will be ignored for prerelease versions of the SDK
- Don't include default `PackageConflictOverrides` for .NET Core 3 and higher
  - These should come from the packageoverrides.txt file in the targeting pack.  Also, the package name for the default overrides is incorrect for .NET Core 3.0+

#### Customer Impact
Faster build times.  On my machine:

 Scenario Name       | Test Name          | Metric         | Unit | Iterations |   Average |  STDEV.S |       Min |       Max
:------------------- |:------------------ |:-------------- |:----:|:----------:| ---------:| --------:| ---------:| ---------:
Build Web Large 3.0 | Build (no changes) - Before| Execution Time |  ms  |     9      | 19024.212 |   245.835 | 18597.847 |  19386.137
Build Web Large 3.0 | Build (no changes) - After | Execution Time |  ms  |     9      | 17508.622 | 2037.929 | 15226.639 | 21639.623

#### Regression?
No. 

#### Risk
Low