### PR TITLE
Opting into dependentupon convention

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -96,7 +96,10 @@ Copyright (c) .NET Foundation. All rights reserved.
   </PropertyGroup>
 
   <PropertyGroup>
-    <EmbeddedResourceUseDependentUponConvention Condition="'$(EmbeddedResourceUseDependentUponConvention)' == ''">true</EmbeddedResourceUseDependentUponConvention>
+    <EmbeddedResourceUseDependentUponConvention 
+      Condition="'$(EmbeddedResourceUseDependentUponConvention)' == '' and
+                 (('$(TargetFrameworkIdentifier)' == '.NETCoreApp' and '$(_TargetFrameworkVersionWithoutV)' >= '3.0') or
+                  ('$(TargetFrameworkIdentifier)' == '.NetFramework' and '$(_TargetFrameworkVersionWithoutV)' >= '2.1'))">true</EmbeddedResourceUseDependentUponConvention>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -99,7 +99,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <EmbeddedResourceUseDependentUponConvention 
       Condition="'$(EmbeddedResourceUseDependentUponConvention)' == '' and
                  (('$(TargetFrameworkIdentifier)' == '.NETCoreApp' and '$(_TargetFrameworkVersionWithoutV)' >= '3.0') or
-                  ('$(TargetFrameworkIdentifier)' == '.NetFramework' and '$(_TargetFrameworkVersionWithoutV)' >= '2.1'))">true</EmbeddedResourceUseDependentUponConvention>
+                  ('$(TargetFrameworkIdentifier)' == '.NETStandard' and '$(_TargetFrameworkVersionWithoutV)' >= '2.1'))">true</EmbeddedResourceUseDependentUponConvention>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -96,6 +96,10 @@ Copyright (c) .NET Foundation. All rights reserved.
   </PropertyGroup>
 
   <PropertyGroup>
+    <EmbeddedResourceUseDependentUponConvention Condition="'$(EmbeddedResourceUseDependentUponConvention)' == ''">true</EmbeddedResourceUseDependentUponConvention>
+  </PropertyGroup>
+
+  <PropertyGroup>
     <CoreBuildDependsOn>
       _CheckForBuildWithNoBuild;
       $(CoreBuildDependsOn);

--- a/src/Tests/Microsoft.NET.Build.Tests/GenerateResourceTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GenerateResourceTests.cs
@@ -67,7 +67,7 @@ namespace Microsoft.NET.Build.Tests
                 Path.Combine(testAsset.TestRoot, testProject.Name));
 
             buildCommand
-                .Execute("-bl")
+                .Execute()
                 .Should()
                 .Pass();
 

--- a/src/Tests/Microsoft.NET.Build.Tests/GenerateResourceTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GenerateResourceTests.cs
@@ -1,0 +1,84 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using Microsoft.NET.TestFramework;
+using Microsoft.NET.TestFramework.Assertions;
+using Microsoft.NET.TestFramework.Commands;
+using Microsoft.NET.TestFramework.ProjectConstruction;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.NET.Build.Tests
+{
+    public class GenerateResourceTests : SdkTest
+    {
+
+        public GenerateResourceTests(ITestOutputHelper log) : base(log)
+        {
+        }
+
+        [Theory(Skip="https://github.com/microsoft/msbuild/issues/4488")]
+        [InlineData("netcoreapp3.0", true)]
+        public void DependentUponTest(string targetFramework, bool isExe)
+        {
+            var testProject = new TestProject
+            {
+                Name = "HelloWorld",
+                IsSdkProject = true,
+                TargetFrameworks = targetFramework,
+                IsExe = isExe,
+                SourceFiles =
+                {
+                    ["Program.cs"] = @"
+                        using System;
+
+                        namespace SomeNamespace
+                        {
+                            public static class SomeClass
+                            {
+                                public static void Main(string[] args)
+                                {
+                                     var resourceManager = new global::System.Resources.ResourceManager(""SomeNamespace.SomeClass"", typeof(SomeClass).Assembly);
+                                     Console.WriteLine(resourceManager.GetString(""SomeString""));
+                                }
+                            }
+                        }
+                        ",
+                },
+                EmbeddedResources =
+                {
+                    ["Program.resx"] = @"
+                        <root>                          
+                            <data name=""SomeString"" xml:space=""preserve"">
+                                <value>Hello world from a resource!</value>
+                            </data>
+                        </root>
+                        ",
+                }
+            };
+
+            var testAsset = _testAssetsManager
+                .CreateTestProject(testProject, identifier: targetFramework + isExe)
+                .Restore(Log, testProject.Name);
+
+            var buildCommand = new BuildCommand(
+                Log,
+                Path.Combine(testAsset.TestRoot, testProject.Name));
+
+            buildCommand
+                .Execute("-bl")
+                .Should()
+                .Pass();
+
+            var outputDirectory = buildCommand.GetOutputDirectory(targetFramework);
+
+            var runCommand = new RunExeCommand(Log, Path.Combine(outputDirectory.FullName, "HelloWorld.exe"));
+            runCommand
+                .Execute()
+                .Should()
+                .Pass()
+                .And.HaveStdOutContaining("Hello world from a resource!");
+        }
+    }
+}


### PR DESCRIPTION
### Description

In SDK projects and new project system, we have eliminated the need for DependentUpon to make the appropriate file nesting in the IDE tree. However, there is a place where the build actually uses DependentUpon to:

1. Locate a source file, and _parse (!)_ it to get first class name and namespace
2. Generate .resources accordingly.

But people and features in VS rely on this and it has been a consistent source of feedback in moving to .NET Core 3.0. This opts into new behavior to use a convention instead of requiring explicit metadata.

Original issue: https://github.com/microsoft/msbuild/issues/4488

 This change is dependent upon: https://github.com/microsoft/msbuild/pull/4597

### Customer Impact

In a fairly common situation for projects that use resources, avoids the need to specify `DependentUpon` metadata for each resource.

### Regression?

No

### Risk

Low risk.

### Test changes in this PR
Added `DependentUponTest`. Currently it gets skipped, but this test was verified working on a local machine using a version of MSBuild that had the corresponding fix.
