### PR TITLE
Pass well-defined set of managed assemblies to linker and crossgen

### DIFF
--- a/src/Tasks/Common/ItemUtilities.cs
+++ b/src/Tasks/Common/ItemUtilities.cs
@@ -24,6 +24,13 @@ namespace Microsoft.NET.Build.Tasks
             return result;
         }
 
+        public static bool HasMetadataValue(this ITaskItem item, string name)
+        {
+            string value = item.GetMetadata(name);
+
+            return !string.IsNullOrEmpty(value);
+        }
+
         public static bool HasMetadataValue(this ITaskItem item, string name, string expectedValue)
         {
             string value = item.GetMetadata(name);

--- a/src/Tasks/Common/MetadataKeys.cs
+++ b/src/Tasks/Common/MetadataKeys.cs
@@ -98,5 +98,7 @@ namespace Microsoft.NET.Build.Tasks
         // The DestinationSubPath is the path to the asset, relative to the destination folder.
         public const string DestinationSubPath = "DestinationSubPath";
         public const string AssetType = "AssetType";
+
+        public const string ReferenceOnly = "ReferenceOnly";
     }
 }

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenADependencyContextBuilder.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenADependencyContextBuilder.cs
@@ -49,7 +49,8 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             IEnumerable<ReferenceInfo> directReferences =
                 ReferenceInfo.CreateDirectReferenceInfos(
                     referencePaths ?? new ITaskItem[] { },
-                    referenceSatellitePaths ?? new ITaskItem[] { });
+                    referenceSatellitePaths ?? new ITaskItem[] { },
+                    i => true);
 
             ProjectContext projectContext = lockFile.CreateProjectContext(
                 FrameworkConstants.CommonFrameworks.NetCoreApp10,

--- a/src/Tasks/Microsoft.NET.Build.Tasks/GenerateDepsFile.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/GenerateDepsFile.cs
@@ -52,29 +52,40 @@ namespace Microsoft.NET.Build.Tasks
         [Required]
         public bool IncludeMainProject { get; set; }
 
+        // @(ReferencePath) that will be passed to
         public ITaskItem[] ReferencePaths { get; set; } = Array.Empty<ITaskItem>();
 
+        // Full set of @(ReferenceDependencyPaths) found by RAR
         public ITaskItem[] ReferenceDependencyPaths { get; set; } = Array.Empty<ITaskItem>();
 
+        // Full set of @(ReferenceSatellitePaths) found by RAR
         public ITaskItem[] ReferenceSatellitePaths { get; set; } = Array.Empty<ITaskItem>();
 
+        // Subset of @(ReferencePath) that is not CopyLoca:, used for compilation, but not runtime assets
         public ITaskItem[] ReferenceAssemblies { get; set; } = Array.Empty<ITaskItem>();
 
+        // Runtime assets for self-contained deployment from runtime pack
         public ITaskItem[] RuntimePackAssets { get; set; } = Array.Empty<ITaskItem>();
 
         public ITaskItem CompilerOptions { get; set; }
 
         public ITaskItem[] RuntimeStorePackages { get; set; }
 
+        // NuGet compilation assets
         [Required]
         public ITaskItem[] CompileReferences { get; set; }
 
-        //  NativeCopyLocalItems, ResourceCopyLocalItems, RuntimeCopyLocalItems
+        // NuGet runtime assets for root directory: @(NativeCopyLocalItems), @(ResourceCopyLocalItems), @(RuntimeCopyLocalItems)
         [Required]
         public ITaskItem[] ResolvedNuGetFiles { get; set; }
 
+        // NuGet runtime assets for runtimes* directory
         [Required]
         public ITaskItem[] ResolvedRuntimeTargetsFiles { get; set; }
+
+        // CopyLocal subset ot of @(ReferencePath), @(ReferenceDependencyPath)
+        // Only the item spec is needed as it is used to filter the other items
+        public string[] UserRuntimeAssemblies { get; set; }
 
         public bool IsSelfContained { get; set; }
 
@@ -118,23 +129,23 @@ namespace Microsoft.NET.Build.Tasks
                 AssemblyVersion,
                 AssemblySatelliteAssemblies);
 
+            var userRuntimeAssemblySet = new HashSet<string>(UserRuntimeAssemblies ?? Enumerable.Empty<string>(), StringComparer.OrdinalIgnoreCase);
+            Func<ITaskItem, bool> isUserRuntimeAssembly = item => userRuntimeAssemblySet.Contains(item.ItemSpec);
+
             IEnumerable<ReferenceInfo> referenceAssemblyInfos =
                 ReferenceInfo.CreateReferenceInfos(ReferenceAssemblies);
 
             IEnumerable<ReferenceInfo> directReferences =
-                ReferenceInfo.CreateDirectReferenceInfos(ReferencePaths, ReferenceSatellitePaths);
+                ReferenceInfo.CreateDirectReferenceInfos(ReferencePaths, ReferenceSatellitePaths, isUserRuntimeAssembly);
 
             IEnumerable<ReferenceInfo> dependencyReferences =
-                ReferenceInfo.CreateDependencyReferenceInfos(ReferenceDependencyPaths, ReferenceSatellitePaths);
+                ReferenceInfo.CreateDependencyReferenceInfos(ReferenceDependencyPaths, ReferenceSatellitePaths, isUserRuntimeAssembly);
 
-            Dictionary<string, SingleProjectInfo> referenceProjects = SingleProjectInfo.CreateProjectReferenceInfos(
-                ReferencePaths,
-                ReferenceDependencyPaths,
-                ReferenceSatellitePaths);
+            Dictionary<string, SingleProjectInfo> referenceProjects =
+                SingleProjectInfo.CreateProjectReferenceInfos(ReferencePaths, ReferenceSatellitePaths, isUserRuntimeAssembly);
 
             IEnumerable<RuntimePackAssetInfo> runtimePackAssets =
                 IsSelfContained ? RuntimePackAssets.Select(item => RuntimePackAssetInfo.FromItem(item)) : Enumerable.Empty<RuntimePackAssetInfo>();
-
 
             ProjectContext projectContext = lockFile.CreateProjectContext(
                 NuGetUtils.ParseFrameworkName(TargetFramework),

--- a/src/Tasks/Microsoft.NET.Build.Tasks/GenerateDepsFile.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/GenerateDepsFile.cs
@@ -61,7 +61,7 @@ namespace Microsoft.NET.Build.Tasks
         // Full set of @(ReferenceSatellitePaths) found by RAR
         public ITaskItem[] ReferenceSatellitePaths { get; set; } = Array.Empty<ITaskItem>();
 
-        // Subset of @(ReferencePath) that is not CopyLoca:, used for compilation, but not runtime assets
+        // Subset of @(ReferencePath) that is not CopyLocal, used for compilation, but not runtime assets
         public ITaskItem[] ReferenceAssemblies { get; set; } = Array.Empty<ITaskItem>();
 
         // Runtime assets for self-contained deployment from runtime pack
@@ -84,7 +84,8 @@ namespace Microsoft.NET.Build.Tasks
         public ITaskItem[] ResolvedRuntimeTargetsFiles { get; set; }
 
         // CopyLocal subset ot of @(ReferencePath), @(ReferenceDependencyPath)
-        // Only the item spec is needed as it is used to filter the other items
+        // Used to filter out non-runtime assemblies from deps file. Only project and direct references in this
+        // set will be written to deps file as runtime dependencies.
         public string[] UserRuntimeAssemblies { get; set; }
 
         public bool IsSelfContained { get; set; }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/PrepareForReadyToRunCompilation.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/PrepareForReadyToRunCompilation.cs
@@ -50,7 +50,7 @@ namespace Microsoft.NET.Build.Tasks
         public ITaskItem[] ReadyToRunFilesToPublish => _r2rFiles.ToArray();
 
         [Output]
-        public ITaskItem[] ReadyToRunFilesToReference => _r2rReferences.ToArray();
+        public ITaskItem[] ReadyToRunAssembliesToReference => _r2rReferences.ToArray();
 
         private List<ITaskItem> _compileList = new List<ITaskItem>();
         private List<ITaskItem> _symbolsCompileList = new List<ITaskItem>();

--- a/src/Tasks/Microsoft.NET.Build.Tasks/PrepareForReadyToRunCompilation.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/PrepareForReadyToRunCompilation.cs
@@ -118,7 +118,7 @@ namespace Microsoft.NET.Build.Tasks
             ProcessInputFileList(Assemblies, _compileList, _symbolsCompileList, _r2rFiles, _r2rReferences);
         }
 
-        void ProcessInputFileList(ITaskItem[] inputFiles, List<ITaskItem> imageCompilationList, List<ITaskItem> symbolsCompilationList, List<ITaskItem> r2rFilesPublishList, List<ITaskItem> r2rReferenceList)
+        private void ProcessInputFileList(ITaskItem[] inputFiles, List<ITaskItem> imageCompilationList, List<ITaskItem> symbolsCompilationList, List<ITaskItem> r2rFilesPublishList, List<ITaskItem> r2rReferenceList)
         {
             if (inputFiles == null)
             {
@@ -222,7 +222,7 @@ namespace Microsoft.NET.Build.Tasks
             CompileAndReference
         };
 
-        Eligibility GetInputFileEligibility(ITaskItem file, HashSet<string> exclusionSet)
+        private static Eligibility GetInputFileEligibility(ITaskItem file, HashSet<string> exclusionSet)
         {
             // Check to see if this is a valid ILOnly image that we can compile
             using (FileStream fs = new FileStream(file.ItemSpec, FileMode.Open, FileAccess.Read))
@@ -280,7 +280,7 @@ namespace Microsoft.NET.Build.Tasks
             }
         }
 
-        private bool IsReferenceAssembly(MetadataReader mdReader)
+        private static bool IsReferenceAssembly(MetadataReader mdReader)
         {
             foreach (var attributeHandle in mdReader.GetAssemblyDefinition().GetCustomAttributes())
             {
@@ -319,7 +319,7 @@ namespace Microsoft.NET.Build.Tasks
             return false;
         }
 
-        private bool ReferencesWinMD(MetadataReader mdReader)
+        private static bool ReferencesWinMD(MetadataReader mdReader)
         {
             foreach (var assemblyRefHandle in mdReader.AssemblyReferences)
             {
@@ -331,7 +331,7 @@ namespace Microsoft.NET.Build.Tasks
             return false;
         }
 
-        private bool HasILCode(PEReader peReader, MetadataReader mdReader)
+        private static bool HasILCode(PEReader peReader, MetadataReader mdReader)
         {
             foreach (var methoddefHandle in mdReader.MethodDefinitions)
             {
@@ -345,7 +345,7 @@ namespace Microsoft.NET.Build.Tasks
             return false;
         }
 
-        bool ExtractTargetPlatformAndArchitecture(string runtimeIdentifier, out string platform, out Architecture architecture)
+        private static bool ExtractTargetPlatformAndArchitecture(string runtimeIdentifier, out string platform, out Architecture architecture)
         {
             platform = null;
             architecture = default;
@@ -380,7 +380,7 @@ namespace Microsoft.NET.Build.Tasks
             return true;
         }
 
-        bool GetCrossgenComponentsPaths()
+        private bool GetCrossgenComponentsPaths()
         {
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {

--- a/src/Tasks/Microsoft.NET.Build.Tasks/PrepareForReadyToRunCompilation.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/PrepareForReadyToRunCompilation.cs
@@ -17,7 +17,7 @@ namespace Microsoft.NET.Build.Tasks
 {
     public class PrepareForReadyToRunCompilation : TaskBase
     {
-        public ITaskItem[] FilesToPublish { get; set; }
+        public ITaskItem[] Assemblies { get; set; }
         public string[] ExcludeList { get; set; }
         public bool EmitSymbols { get; set; }
 
@@ -49,10 +49,13 @@ namespace Microsoft.NET.Build.Tasks
         [Output]
         public ITaskItem[] ReadyToRunFilesToPublish => _r2rFiles.ToArray();
 
+        [Output]
+        public ITaskItem[] ReadyToRunFilesToReference => _r2rReferences.ToArray();
+
         private List<ITaskItem> _compileList = new List<ITaskItem>();
         private List<ITaskItem> _symbolsCompileList = new List<ITaskItem>();
-
         private List<ITaskItem> _r2rFiles = new List<ITaskItem>();
+        private List<ITaskItem> _r2rReferences = new List<ITaskItem>();
 
         private string _runtimeIdentifier;
         private string _packagePath;
@@ -112,10 +115,10 @@ namespace Microsoft.NET.Build.Tasks
                 CrossgenTool.SetMetadata("DiaSymReader", _diasymreaderPath);
 
             // Process input lists of files
-            ProcessInputFileList(FilesToPublish, _compileList, _symbolsCompileList, _r2rFiles);
+            ProcessInputFileList(Assemblies, _compileList, _symbolsCompileList, _r2rFiles, _r2rReferences);
         }
 
-        void ProcessInputFileList(ITaskItem[] inputFiles, List<ITaskItem> imageCompilationList, List<ITaskItem> symbolsCompilationList, List<ITaskItem> r2rFilesPublishList)
+        void ProcessInputFileList(ITaskItem[] inputFiles, List<ITaskItem> imageCompilationList, List<ITaskItem> symbolsCompilationList, List<ITaskItem> r2rFilesPublishList, List<ITaskItem> r2rReferenceList)
         {
             if (inputFiles == null)
             {
@@ -124,8 +127,19 @@ namespace Microsoft.NET.Build.Tasks
 
             foreach (var file in inputFiles)
             {
-                if (!InputFileEligibleForCompilation(file))
+                var eligibility = GetInputFileEligibility(file);
+
+                if (eligibility == Eligibility.None)
+                {
                     continue;
+                }
+
+                r2rReferenceList.Add(file);
+
+                if (eligibility == Eligibility.ReferenceOnly)
+                {
+                    continue;
+                }
 
                 var outputR2RImageRelativePath = file.GetMetadata(MetadataKeys.RelativePath);
                 var outputR2RImage = Path.Combine(OutputPath, outputR2RImageRelativePath);
@@ -199,20 +213,15 @@ namespace Microsoft.NET.Build.Tasks
             }
         }
 
-        bool InputFileEligibleForCompilation(ITaskItem file)
+        private enum Eligibility
         {
-            // Check if the file is explicitly excluded from being compiled
-            if (ExcludeList != null)
-            {
-                foreach (var item in ExcludeList)
-                {
-                    if (String.Compare(Path.GetFileName(file.ItemSpec), item, true) == 0)
-                    {
-                        return false;
-                    }
-                }
-            }
+            None,
+            ReferenceOnly,
+            CompileAndReference
+        };
 
+        Eligibility GetInputFileEligibility(ITaskItem file)
+        {
             // Check to see if this is a valid ILOnly image that we can compile
             using (FileStream fs = new FileStream(file.ItemSpec, FileMode.Open, FileAccess.Read))
             {
@@ -221,32 +230,53 @@ namespace Microsoft.NET.Build.Tasks
                     using (var pereader = new PEReader(fs))
                     {
                         if (!pereader.HasMetadata)
-                            return false;
-
-                        if ((pereader.PEHeaders.CorHeader.Flags & CorFlags.ILOnly) != CorFlags.ILOnly)
-                            return false;
+                        {
+                            return Eligibility.None;
+                        }
 
                         MetadataReader mdReader = pereader.GetMetadataReader();
                         if (!mdReader.IsAssembly)
                         {
-                            return false;
+                            return Eligibility.None;
+                        }
+
+                        if ((pereader.PEHeaders.CorHeader.Flags & CorFlags.ILOnly) != CorFlags.ILOnly)
+                        {
+                            return Eligibility.ReferenceOnly;
                         }
 
                         // Skip reference assemblies and assemblies that reference winmds
                         if (ReferencesWinMD(mdReader) || IsReferenceAssembly(mdReader) || !HasILCode(pereader, mdReader))
                         {
-                            return false;
+                            return Eligibility.ReferenceOnly;
                         }
                     }
                 }
                 catch (BadImageFormatException)
                 {
                     // Not a valid assembly file
-                    return false;
+                    return Eligibility.None;
                 }
             }
 
-            return true;
+            if (file.HasMetadataValue(MetadataKeys.ReferenceOnly, "true"))
+            {
+                return Eligibility.ReferenceOnly;
+            }
+  
+            // Check if the file is explicitly excluded from being compiled
+            if (ExcludeList != null)
+            {
+                foreach (var item in ExcludeList)
+                {
+                    if (String.Compare(Path.GetFileName(file.ItemSpec), item, true) == 0)
+                    {
+                        return Eligibility.ReferenceOnly;
+                    }
+                }
+            }
+
+            return Eligibility.CompileAndReference;
         }
 
         private bool IsReferenceAssembly(MetadataReader mdReader)

--- a/src/Tasks/Microsoft.NET.Build.Tasks/RunReadyToRunCompiler.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/RunReadyToRunCompiler.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
@@ -19,7 +20,7 @@ namespace Microsoft.NET.Build.Tasks
         [Required]
         public ITaskItem CompilationEntry { get; set; }
         [Required]
-        public ITaskItem[] ImplementationAssemblies { get; set; }
+        public ITaskItem[] References { get; set; }
         public bool ShowCompilerWarnings { get; set; }
 
         [Output]
@@ -88,51 +89,6 @@ namespace Microsoft.NET.Build.Tasks
             return true;
         }
 
-        // TEMP LOGIC - SDK Should provide correct list - When fixing https://github.com/dotnet/sdk/issues/3110, delete
-        // both IsManagedAssemblyToUseAsCrossgenReference and IsReferenceAssembly
-        bool IsManagedAssemblyToUseAsCrossgenReference(ITaskItem file)
-        {
-            // Reference only managed assemblies that will be published to the root directory.
-            string relativeOutputPath = file.GetMetadata(MetadataKeys.RelativePath);
-
-            if (string.IsNullOrEmpty(relativeOutputPath))
-            {
-                relativeOutputPath = file.GetMetadata(MetadataKeys.DestinationSubPath);
-            }
-
-            if (!String.IsNullOrEmpty(Path.GetDirectoryName(relativeOutputPath)))
-            {
-                return false;
-            }
-
-            using (FileStream fs = new FileStream(file.ItemSpec, FileMode.Open, FileAccess.Read))
-            {
-                try
-                {
-                    using (var pereader = new PEReader(fs))
-                    {
-                        if (!pereader.HasMetadata)
-                            return false;
-
-                        MetadataReader mdReader = pereader.GetMetadataReader();
-                        if (!mdReader.IsAssembly)
-                            return false;
-
-                        // Reference assemblies should never be given to crossgen
-                        if (IsReferenceAssembly(mdReader))
-                            return false;
-                    }
-                }
-                catch (BadImageFormatException)
-                {
-                    // Not a valid assembly file
-                    return false;
-                }
-            }
-
-            return true;
-        }
-
         private bool IsReferenceAssembly(MetadataReader mdReader)
         {
             foreach (var attributeHandle in mdReader.GetAssemblyDefinition().GetCustomAttributes())
@@ -175,18 +131,13 @@ namespace Microsoft.NET.Build.Tasks
         {
             StringBuilder result = new StringBuilder();
 
-            // Add all runtime libraries to the list of references passed to crossgen
-            foreach (var runtimeAssembly in ImplementationAssemblies)
+            foreach (var reference in References)
             {
                 // When generating PDBs, we must not add a reference to the IL version of the R2R image for which we're trying to generate a PDB
-                if (IsPdbCompilation && String.Equals(Path.GetFileName(runtimeAssembly.ItemSpec), Path.GetFileName(_outputR2RImage), StringComparison.OrdinalIgnoreCase))
+                if (IsPdbCompilation && String.Equals(Path.GetFileName(reference.ItemSpec), Path.GetFileName(_outputR2RImage), StringComparison.OrdinalIgnoreCase))
                     continue;
 
-                // TODO: Delete check when fixing https://github.com/dotnet/sdk/issues/3109
-                if (!IsManagedAssemblyToUseAsCrossgenReference(runtimeAssembly))
-                    continue;
-
-                result.AppendLine($"/r \"{runtimeAssembly}\"");
+                result.AppendLine($"/r \"{reference}\"");
             }
 
             return result.ToString();

--- a/src/Tasks/Microsoft.NET.Build.Tasks/RunReadyToRunCompiler.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/RunReadyToRunCompiler.cs
@@ -20,7 +20,7 @@ namespace Microsoft.NET.Build.Tasks
         [Required]
         public ITaskItem CompilationEntry { get; set; }
         [Required]
-        public ITaskItem[] References { get; set; }
+        public ITaskItem[] ImplementationAssemblyReferences { get; set; }
         public bool ShowCompilerWarnings { get; set; }
 
         [Output]
@@ -93,7 +93,7 @@ namespace Microsoft.NET.Build.Tasks
         {
             StringBuilder result = new StringBuilder();
 
-            foreach (var reference in References)
+            foreach (var reference in ImplementationAssemblyReferences)
             {
                 // When generating PDBs, we must not add a reference to the IL version of the R2R image for which we're trying to generate a PDB
                 if (IsPdbCompilation && String.Equals(Path.GetFileName(reference.ItemSpec), Path.GetFileName(_outputR2RImage), StringComparison.OrdinalIgnoreCase))

--- a/src/Tasks/Microsoft.NET.Build.Tasks/RunReadyToRunCompiler.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/RunReadyToRunCompiler.cs
@@ -89,44 +89,6 @@ namespace Microsoft.NET.Build.Tasks
             return true;
         }
 
-        private bool IsReferenceAssembly(MetadataReader mdReader)
-        {
-            foreach (var attributeHandle in mdReader.GetAssemblyDefinition().GetCustomAttributes())
-            {
-                StringHandle attributeTypeName = default;
-                StringHandle attributeTypeNamespace = default;
-                EntityHandle attributeCtor = mdReader.GetCustomAttribute(attributeHandle).Constructor;
-
-                if (attributeCtor.Kind == HandleKind.MemberReference)
-                {
-                    EntityHandle attributeMemberParent = mdReader.GetMemberReference((MemberReferenceHandle)attributeCtor).Parent;
-                    if (attributeMemberParent.Kind == HandleKind.TypeReference)
-                    {
-                        TypeReference attributeTypeRef = mdReader.GetTypeReference((TypeReferenceHandle)attributeMemberParent);
-                        attributeTypeName = attributeTypeRef.Name;
-                        attributeTypeNamespace = attributeTypeRef.Namespace;
-                    }
-                }
-                else if (attributeCtor.Kind == HandleKind.MethodDefinition)
-                {
-                    TypeDefinitionHandle attributeTypeDefHandle = mdReader.GetMethodDefinition((MethodDefinitionHandle)attributeCtor).GetDeclaringType();
-                    TypeDefinition attributeTypeDef = mdReader.GetTypeDefinition(attributeTypeDefHandle);
-                    attributeTypeName = attributeTypeDef.Name;
-                    attributeTypeNamespace = attributeTypeDef.Namespace;
-                }
-
-                if (!attributeTypeName.IsNil &&
-                    !attributeTypeNamespace.IsNil &&
-                    mdReader.StringComparer.Equals(attributeTypeName, "ReferenceAssemblyAttribute") &&
-                    mdReader.StringComparer.Equals(attributeTypeNamespace, "System.Runtime.CompilerServices"))
-                {
-                    return true;
-                }
-            }
-
-            return false;
-        }
-
         private string GetAssemblyReferencesCommands()
         {
             StringBuilder result = new StringBuilder();

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ILLink.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ILLink.targets
@@ -36,9 +36,6 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <NETSdkInformation ResourceName="ILLink_Info" />
 
-    <!-- For now, use ResolvedFileToPublish as input/output. This
-         should go away in favor of a well-defined set of runtime
-         assemblies with https://github.com/dotnet/sdk/issues/3109. -->
     <ItemGroup>
       <_LinkedResolvedFileToPublish Include="@(_LinkedResolvedFileToPublishCandidates)" Condition="Exists('%(Identity)')" />
       <ResolvedFileToPublish Remove="@(_ManagedAssembliesToLink)" />
@@ -51,10 +48,9 @@ Copyright (c) .NET Foundation. All rights reserved.
       <_RemovedManagedAssemblies Include="@(_ManagedAssembliesToLink)" Condition="!Exists('$(IntermediateLinkDir)%(Filename)%(Extension)')" />
 
       <ResolvedCompileFileDefinitions Remove="@(_RemovedManagedAssemblies)" />
-      <NativeCopyLocalItems Remove="@(_RemovedManagedAssemblies)" />
-      <ResourceCopyLocalItems Remove="@(_RemovedManagedAssemblies)" />
       <RuntimeCopyLocalItems Remove="@(_RemovedManagedAssemblies)" />
       <RuntimeTargetsCopyLocalItems Remove="@(_RemovedManagedAssemblies)" />
+      <UserRuntimeAssembly Remove="@(_RemovedManagedAssemblies)" />
       <RuntimePackAsset Remove="@(_RemovedManagedAssemblies)" />
     </ItemGroup>
 
@@ -129,22 +125,19 @@ Copyright (c) .NET Foundation. All rights reserved.
     ============================================================
                      _ComputeManagedAssembliesToLink
 
-    Compute the set of inputs to the linker. Currently this uses a
-    heuristic to get the relevant input from ResolvedFileToPublish,
-    but with https://github.com/dotnet/sdk/issues/3109, this should be
-    replaced with the exact set of runtime assemblies that will be in
-    the deps file.
+    Compute the set of inputs to the linker.
     ============================================================
     -->
   <UsingTask TaskName="ComputeManagedAssemblies" AssemblyFile="$(ILLinkTasksAssembly)" />
-  <Target Name="_ComputeManagedAssembliesToLink">
+  <Target Name="_ComputeManagedAssembliesToLink" DependsOnTargets="_ComputeAssembliesToPostprocessOnPublish">
 
-    <ComputeManagedAssemblies Assemblies="@(ResolvedFileToPublish)">
+    <!-- NB: There should not be non-managed assemblies in this list, but we still give the linker a chance to
+         further refine this list. It currently drops C++/CLI assemblies in ComputeManageAssemblies. -->
+    <ComputeManagedAssemblies Assemblies="@(ResolvedFileToPublish->WithMetadataValue('PostprocessAssembly', 'true'))">
       <Output TaskParameter="ManagedAssemblies" ItemName="_ManagedAssembliesToLink" />
     </ComputeManagedAssemblies>
 
     <ItemGroup>
-      <_ManagedAssembliesToLink Remove="@(_ManagedResolvedFileToPublish->WithMetadataValue('AssetType', 'resources'))" />
       <_LinkedResolvedFileToPublishCandidates Include="@(_ManagedAssembliesToLink->'$(IntermediateLinkDir)%(Filename)%(Extension)')" />
     </ItemGroup>
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.PreserveCompilationContext.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.PreserveCompilationContext.targets
@@ -45,9 +45,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <Target Name="ComputeRefAssembliesToPublish"
           Condition="'$(PreserveCompilationReferences)' == 'true'"
           DependsOnTargets="ResolvePackageAssets;
-                            _ParseTargetManifestFiles"
-          AfterTargets="ComputeFilesToPublish"
-          BeforeTargets="CopyFilesToPublishDirectory">
+                            _ParseTargetManifestFiles">
 
     <FindItemsFromPackages Items="@(RuntimeCopyLocalItems)"
                            Packages="@(RuntimeStorePackages)">

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -241,7 +241,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     ============================================================
     -->
   <UsingTask TaskName="PrepareForReadyToRunCompilation" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
-  <Target Name="_PrepareForReadyToRunCompilation">
+  <Target Name="_PrepareForReadyToRunCompilation" DependsOnTargets="_ComputeManagedRuntimePackAssemblies;_ComputeAssembliesToPostprocessOnPublish">
 
     <PropertyGroup>
       <_ReadyToRunOutputPath>$(IntermediateOutputPath)R2R</_ReadyToRunOutputPath>
@@ -249,12 +249,33 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <MakeDir Directories="$(_ReadyToRunOutputPath)" />
 
+    <ItemGroup>
+      <_ReadyToRunImplementationAssemblies Include="@(ResolvedFileToPublish->WithMetadataValue('PostprocessAssembly', 'true'))" />
+    </ItemGroup>
+
+    <!-- Even if app is not self-contained, crossgen requires closure of implementation assemblies. Resolve conflicts
+         of the runtime pack assets as though we were copying them locally, and add them to the R2R implementation
+         assembly list. -->
+     <ItemGroup Condition="'$(SelfContained)' != 'true'">
+       <_ReadyToRunImplementationAssemblies Include="@(_ManagedRuntimePackAssembly)" ReferenceOnly="true" />
+     </ItemGroup>
+
+     <ResolvePackageFileConflicts Condition="'$(SelfContained)' != 'true'"
+                                 ReferenceCopyLocalPaths="@(_ReadyToRunImplementationAssemblies)">
+      <Output TaskParameter="ReferenceCopyLocalPathsWithoutConflicts" ItemName="_ReadyToRunImplementationAssembliesWithoutConflicts" />
+    </ResolvePackageFileConflicts>
+
+    <ItemGroup Condition="'$(SelfContained)' != 'true'">
+      <_ReadyToRunImplementationAssemblies Remove="@(_ReadyToRunImplementationAssemblies)" />
+      <_ReadyToRunImplementationAssemblies Include="@(_ReadyToRunImplementationAssembliesWithoutConflicts)" />
+    </ItemGroup>
+
     <PrepareForReadyToRunCompilation RuntimePacks="@(ResolvedRuntimePack)"
                                      RuntimeGraphPath="$(BundledRuntimeIdentifierGraphFile)"
                                      KnownFrameworkReferences="@(KnownFrameworkReference)"
                                      NETCoreSdkRuntimeIdentifier="$(NETCoreSdkRuntimeIdentifier)"
                                      OutputPath="$(_ReadyToRunOutputPath)"
-                                     FilesToPublish="@(ResolvedFileToPublish)"
+                                     Assemblies="@(_ReadyToRunImplementationAssemblies)"
                                      ExcludeList="@(PublishReadyToRunExclude)"
                                      EmitSymbols="$(PublishReadyToRunEmitSymbols)"
                                      IncludeSymbolsInSingleFile="$(IncludeSymbolsInSingleFile)">
@@ -265,31 +286,9 @@ Copyright (c) .NET Foundation. All rights reserved.
       <Output TaskParameter="ReadyToRunSymbolsCompileList" ItemName="_ReadyToRunSymbolsCompileList" />
 
       <Output TaskParameter="ReadyToRunFilesToPublish" ItemName="_ReadyToRunFilesToPublish" />
+      <Output TaskParameter="ReadyToRunFilesToReference" ItemName="_ReadyToRunFilesToReference" />
 
     </PrepareForReadyToRunCompilation>
-
-    <!--  TODO: https://github.com/dotnet/sdk/issues/3109 - Gather appropriate list of managed runtime assemblies for crossen.
-          Current approach is to pass all resolved files to publish and inspect if they are managed. -->
-    <ItemGroup>
-      <_ReadyToRunImplementationAssemblies Include="@(ResolvedFileToPublish)" />
-    </ItemGroup>
-
-    <!-- Even if app is not self-contained, crossgen requires closure of implementation assemblies. Resolve conflicts
-         of the runtime pack assets as though we were copying them locally, and add them to the R2R implementation
-         assembly list. -->
-    <ItemGroup Condition="'$(SelfContained)' != 'true'">
-      <_ReadyToRunImplementationAssemblies Include="@(RuntimePackAsset)" />
-    </ItemGroup>
-
-    <ResolvePackageFileConflicts Condition="'$(SelfContained)' != 'true'"
-                                 ReferenceCopyLocalPaths="@(_ReadyToRunImplementationAssemblies)">
-      <Output TaskParameter="ReferenceCopyLocalPathsWithoutConflicts" ItemName="_ReadyToRunImplementationAssembliesWithoutConflicts" />
-    </ResolvePackageFileConflicts>
-
-    <ItemGroup Condition="'$(SelfContained)' != 'true'">
-      <_ReadyToRunImplementationAssemblies Remove="@(_ReadyToRunImplementationAssemblies)" />
-      <_ReadyToRunImplementationAssemblies Include="@(_ReadyToRunImplementationAssembliesWithoutConflicts)" />
-    </ItemGroup>
   </Target>
 
   <!--
@@ -305,7 +304,7 @@ Copyright (c) .NET Foundation. All rights reserved.
           Outputs="%(_ReadyToRunCompileList.OutputR2RImage)">
 
     <RunReadyToRunCompiler CrossgenTool="@(_CrossgenTool)"
-                           ImplementationAssemblies="@(_ReadyToRunImplementationAssemblies)"
+                           References="@(_ReadyToRunFilesToReference)"
                            ShowCompilerWarnings="$(PublishReadyToRunShowWarnings)"
                            CompilationEntry="@(_ReadyToRunCompileList)"
                            ContinueOnError="ErrorAndContinue">
@@ -336,7 +335,7 @@ Copyright (c) .NET Foundation. All rights reserved.
           Outputs="%(_ReadyToRunSymbolsCompileList.OutputPDBImage)">
 
     <RunReadyToRunCompiler CrossgenTool="@(_CrossgenTool)"
-                           ImplementationAssemblies="@(_ReadyToRunImplementationAssemblies)"
+                           References="@(_ReadyToRunFilesToReference)"
                            ShowCompilerWarnings="$(PublishReadyToRunShowWarnings)"
                            CompilationEntry="@(_ReadyToRunSymbolsCompileList)"
                            ContinueOnError="ErrorAndContinue">
@@ -386,6 +385,12 @@ Copyright (c) .NET Foundation. All rights reserved.
                             CreateReadyToRunImages">
   </Target>
 
+  <PropertyGroup>
+    <CopyBuildOutputToPublishDirectory Condition="'$(CopyBuildOutputToPublishDirectory)'==''">true</CopyBuildOutputToPublishDirectory>
+    <CopyOutputSymbolsToPublishDirectory Condition="'$(CopyOutputSymbolsToPublishDirectory)'==''">true</CopyOutputSymbolsToPublishDirectory>
+    <IncludeSymbolsInSingleFile Condition="'$(IncludeSymbolsInSingleFile)' == ''">false</IncludeSymbolsInSingleFile>
+  </PropertyGroup>
+
   <!--
     ============================================================
                                         ComputeResolvedFilesToPublishList
@@ -395,14 +400,8 @@ Copyright (c) .NET Foundation. All rights reserved.
     -->
   <Target Name="ComputeResolvedFilesToPublishList"
           DependsOnTargets="_ComputeResolvedCopyLocalPublishAssets;
-                            _ComputeCopyToPublishDirectoryItems">
-
-    <PropertyGroup>
-      <CopyBuildOutputToPublishDirectory Condition="'$(CopyBuildOutputToPublishDirectory)'==''">true</CopyBuildOutputToPublishDirectory>
-      <CopyOutputSymbolsToPublishDirectory Condition="'$(CopyOutputSymbolsToPublishDirectory)'==''">true</CopyOutputSymbolsToPublishDirectory>
-      <IncludeSymbolsInSingleFile Condition="'$(IncludeSymbolsInSingleFile)' == ''">false</IncludeSymbolsInSingleFile>
-    </PropertyGroup>
-
+                            _ComputeCopyToPublishDirectoryItems;
+                            ComputeRefAssembliesToPublish">
     <ItemGroup>
       <!-- Copy the build product (.dll or .exe). -->
       <ResolvedFileToPublish Include="@(IntermediateAssembly)"
@@ -762,7 +761,67 @@ Copyright (c) .NET Foundation. All rights reserved.
       </_NoneWithTargetPath>
 
     </ItemGroup>
+  </Target>
+  
+  <!-- Determine the managed assembly subset of ResolvedFileToPublish that should be post-processed by linker, and ready to run compilation -->
+  <!-- -->
+  <Target Name="_ComputeAssembliesToPostprocessOnPublish" 
+          DependsOnTargets="_ComputeUserRuntimeAssemblies">
+    
+    <!-- 
+      Default set of files to post-process correspond to the items that would be designated
+      as managed runtime assemblies in .deps.json, and published to root of the application.
+      RuntimeTargets and satellite assemblies are excluded. Currently, both linker and ready
+      to run require a RID, so there will not be RuntimeTargets. Linker could conceptually 
+      operate without a RID, but would not know how to handle multiple assemblies with same
+      identity.
+    -->
+    <ItemGroup>
+      <!-- Assemblies from packages -->
+      <_ManagedRuntimeAssembly Include="@(RuntimeCopyLocalItems)" />
+      
+      <!-- Assemblies from other references -->
+      <_ManagedRuntimeAssembly Include="@(UserRuntimeAssembly)" />
+      
+      <!-- Assembly produced by this project -->
+      <_ManagedRuntimeAssembly Include="@(IntermediateAssembly)" />
+    </ItemGroup>
+    
+    <!-- Assemblies from runtime packs for self-contained apps -->
+    <CallTarget Targets="_ComputeManagedRuntimePackAssemblies" Condition="'$(SelfContained)' == 'true'">
+      <Output TaskParameter="TargetOutputs" ItemName="_ManagedRuntimeAssembly" />
+    </CallTarget>
+    
+    <!-- 
+      Match above with ResolvedFileToPublish. Some of above would have been excluded from publish in
+      various ways and should be excluded from the list of files to postprocess as well. Furthermore,
+      the metadata must match ResolvedFileToPublish as the tools modify or remove these items in that
+      list to implement their post-processing.
+    -->
+    <JoinItems Left="@(_ManagedRuntimeAssembly)" Right="@(ResolvedFileToPublish)" RightMetadata="*">
+      <Output TaskParameter="JoinResult" ItemName="_AssemblyToPostprocessOnPublish" />
+    </JoinItems>
 
+    <!--
+      Set PostprocessAssembly=true metadata on ResolvedFileToPublish, which will be honored by linker
+      and crossgen.
+      
+      Assemblies injected into ResolvedFileToPublish outside the set above (such as razor views) are
+      responsible for setting this metadata to opt in to post-processing.
+    -->
+    <ItemGroup>
+      <ResolvedFileToPublish Remove="@(_AssemblyToPostprocessOnPublish)" />
+      <ResolvedFileToPublish Include="@(_AssemblyToPostprocessOnPublish)" PostprocessAssembly="true" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="_ComputeManagedRuntimePackAssemblies" Returns="@(_ManagedRuntimePackAssembly)">
+    <ItemGroup>
+      <!-- Special case for System.Private.Corelib due to https://github.com/dotnet/core-setup/issues/7728 -->
+      <_ManagedRuntimePackAssembly Include="@(RuntimePackAsset)"
+                                   Condition="'%(RuntimePackAsset.AssetType)' == 'runtime' 
+                                                or '%(RuntimePackAsset.Filename)' == 'System.Private.Corelib'" />
+    </ItemGroup>
   </Target>
 
   <Target Name="_ComputeUseBuildDependencyFile"
@@ -826,6 +885,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                             _HandlePackageFileConflicts;
                             _HandlePackageFileConflictsForPublish;
                             _ComputeReferenceAssemblies;
+                            _ComputeUserRuntimeAssemblies;
                             ResolveRuntimePackAssets;
                             _ComputePackageReferencePublish"
           Condition="'$(GenerateDependencyFile)' == 'true' and '$(_UseBuildDependencyFile)' != 'true'">
@@ -868,6 +928,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                       CompileReferences="@(ResolvedCompileFileDefinitions)"
                       ResolvedNuGetFiles="@(_ResolvedNuGetFilesForPublish)"
                       ResolvedRuntimeTargetsFiles="@(RuntimeTargetsCopyLocalItems)"
+                      UserRuntimeAssemblies="@(UserRuntimeAssembly)"
                       IsSelfContained="$(SelfContained)"
                       IncludeRuntimeFileVersions="$(IncludeFileVersionsInDependencyFile)"/>
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -286,7 +286,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       <Output TaskParameter="ReadyToRunSymbolsCompileList" ItemName="_ReadyToRunSymbolsCompileList" />
 
       <Output TaskParameter="ReadyToRunFilesToPublish" ItemName="_ReadyToRunFilesToPublish" />
-      <Output TaskParameter="ReadyToRunFilesToReference" ItemName="_ReadyToRunFilesToReference" />
+      <Output TaskParameter="ReadyToRunAssembliesToReference" ItemName="_ReadyToRunAssembliesToReference" />
 
     </PrepareForReadyToRunCompilation>
   </Target>
@@ -304,7 +304,7 @@ Copyright (c) .NET Foundation. All rights reserved.
           Outputs="%(_ReadyToRunCompileList.OutputR2RImage)">
 
     <RunReadyToRunCompiler CrossgenTool="@(_CrossgenTool)"
-                           References="@(_ReadyToRunFilesToReference)"
+                           ImplementationAssemblyReferences="@(_ReadyToRunAssembliesToReference)"
                            ShowCompilerWarnings="$(PublishReadyToRunShowWarnings)"
                            CompilationEntry="@(_ReadyToRunCompileList)"
                            ContinueOnError="ErrorAndContinue">
@@ -335,7 +335,7 @@ Copyright (c) .NET Foundation. All rights reserved.
           Outputs="%(_ReadyToRunSymbolsCompileList.OutputPDBImage)">
 
     <RunReadyToRunCompiler CrossgenTool="@(_CrossgenTool)"
-                           References="@(_ReadyToRunFilesToReference)"
+                           ImplementationAssemblyReferences="@(_ReadyToRunAssembliesToReference)"
                            ShowCompilerWarnings="$(PublishReadyToRunShowWarnings)"
                            CompilationEntry="@(_ReadyToRunSymbolsCompileList)"
                            ContinueOnError="ErrorAndContinue">

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -762,11 +762,14 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     </ItemGroup>
   </Target>
-  
+
+  <PropertyGroup Condition="'$(SelfContained)' == 'true'">
+    <_ComputeManagedRuntimePackAssembliesIfSelfContained>_ComputeManagedRuntimePackAssemblies</_ComputeManagedRuntimePackAssembliesIfSelfContained>
+  </PropertyGroup>
+
   <!-- Determine the managed assembly subset of ResolvedFileToPublish that should be post-processed by linker, and ready to run compilation -->
-  <!-- -->
   <Target Name="_ComputeAssembliesToPostprocessOnPublish" 
-          DependsOnTargets="_ComputeUserRuntimeAssemblies">
+          DependsOnTargets="_ComputeUserRuntimeAssemblies;$(_ComputeManagedRuntimePackAssembliesIfSelfContained)">
     
     <!-- 
       Default set of files to post-process correspond to the items that would be designated
@@ -786,11 +789,11 @@ Copyright (c) .NET Foundation. All rights reserved.
       <!-- Assembly produced by this project -->
       <_ManagedRuntimeAssembly Include="@(IntermediateAssembly)" />
     </ItemGroup>
-    
+
     <!-- Assemblies from runtime packs for self-contained apps -->
-    <CallTarget Targets="_ComputeManagedRuntimePackAssemblies" Condition="'$(SelfContained)' == 'true'">
-      <Output TaskParameter="TargetOutputs" ItemName="_ManagedRuntimeAssembly" />
-    </CallTarget>
+    <ItemGroup Condition="'$(SelfContained)' == 'true'">
+      <_ManagedRuntimeAssembly Include="@(_ManagedRuntimePackAssembly)" />
+    </ItemGroup>
     
     <!-- 
       Match above with ResolvedFileToPublish. Some of above would have been excluded from publish in

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -150,6 +150,7 @@ Copyright (c) .NET Foundation. All rights reserved.
           DependsOnTargets="_DefaultMicrosoftNETPlatformLibrary;
                             _HandlePackageFileConflicts;
                             _ComputeReferenceAssemblies;
+                            _ComputeUserRuntimeAssemblies;
                             ResolveRuntimePackAssets;
                             _ComputePackageReferencePublish"
           BeforeTargets="CopyFilesToOutputDirectory"
@@ -186,6 +187,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                       CompilerOptions="@(DependencyFileCompilerOptions)"
                       CompileReferences="@(ResolvedCompileFileDefinitions)"
                       ResolvedNuGetFiles="@(NativeCopyLocalItems);@(ResourceCopyLocalItems);@(RuntimeCopyLocalItems)"
+                      UserRuntimeAssemblies="@(UserRuntimeAssembly)"
                       ResolvedRuntimeTargetsFiles="@(RuntimeTargetsCopyLocalItems)"
                       IsSelfContained="$(SelfContained)"
                       IncludeRuntimeFileVersions="$(IncludeFileVersionsInDependencyFile)">
@@ -585,6 +587,31 @@ Copyright (c) .NET Foundation. All rights reserved.
       <_ReferenceAssemblies Include="@(_ReferenceOnlyAssemblies)" />
     </ItemGroup>
 
+  </Target>
+  <!--
+    ============================================================
+                                        _ComputeUserRuntimeAssemblies
+
+    Computes references or reference dependencies that are copy local.
+
+     NOTE: NuGet and framework references are never copy local so those are not included here.
+           These will be project references and direct references and their copy local dependencies.
+    ============================================================
+    -->
+  <Target Name="_ComputeUserRuntimeAssemblies">
+    <ItemGroup>
+      <!-- IncludeRuntimeDependency=true metadata is escape hatch to include a non-copy local reference in deps file as a runtime dependency -->
+      <ReferencePath>
+        <IncludeRuntimeDependency Condition="'%(ReferencePath.IncludeRuntimeDependency)' == '' and '%(ReferencePath.CopyLocal)' == 'true'">true</IncludeRuntimeDependency>
+      </ReferencePath>
+
+      <ReferenceDependencyPaths>
+        <IncludeRuntimeDependency Condition="'%(ReferenceDependencyPaths.IncludeRuntimeDependency)' == '' and '%(ReferenceDependencyPaths.CopyLocal)' == 'true'">true</IncludeRuntimeDependency>
+      </ReferenceDependencyPaths>
+
+      <UserRuntimeAssembly Include="@(ReferencePath->WithMetadataValue('IncludeRuntimeDependency', 'true'))"  />
+      <UserRuntimeAssembly Include="@(ReferenceDependencyPaths->WithMetadataValue('IncludeRuntimeDependency', 'true'))" />
+    </ItemGroup>
   </Target>
 
   <!--

--- a/src/Tests/Microsoft.NET.Build.Tests/COMReferenceTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/COMReferenceTests.cs
@@ -1,0 +1,89 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.IO;
+using System.Xml.Linq;
+using FluentAssertions;
+using Microsoft.NET.TestFramework;
+using Microsoft.NET.TestFramework.Assertions;
+using Microsoft.NET.TestFramework.Commands;
+using Microsoft.NET.TestFramework.ProjectConstruction;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.NET.Build.Tests
+{
+    public class COMReferenceTests : SdkTest
+    {
+        public COMReferenceTests(ITestOutputHelper log) : base(log)
+        {
+        }
+
+        [FullMSBuildOnlyTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void COMReferenceBuildsAndRuns(bool embedInteropTypes)
+        {
+            var targetFramework = "netcoreapp3.0";
+
+
+            var testProject = new TestProject
+            {
+                Name = "UseMediaPlayer",
+                IsSdkProject = true,
+                TargetFrameworks = targetFramework,
+                IsExe = true,
+                SourceFiles =
+                    {
+                        ["Program.cs"] = @"
+                            using MediaPlayer;
+                            class Program
+                            {
+                                static void Main(string[] args)
+                                {
+                                    var mediaPlayer = (IMediaPlayer2)new MediaPlayerClass();
+                                }
+                            }
+                        ",
+                }
+            };
+
+            if (embedInteropTypes)
+            {
+                testProject.SourceFiles.Add("MediaPlayerClass.cs", @"
+                    using System.Runtime.InteropServices;
+                    namespace MediaPlayer
+                    {
+                        [ComImport]
+                        [Guid(""22D6F312-B0F6-11D0-94AB-0080C74C7E95"")]
+                        class MediaPlayerClass { }
+                    }
+                ");
+            }
+
+            var reference = new XElement("ItemGroup",
+                new XElement("COMReference",
+                    new XAttribute("Include", "MediaPlayer.dll"),
+                    new XElement("Guid", "22d6f304-b0f6-11d0-94ab-0080c74c7e95"),
+                    new XElement("VersionMajor", "1"),
+                    new XElement("VersionMinor", "0"),
+                    new XElement("WrapperTool", "tlbimp"),
+                    new XElement("Lcid", "0"),
+                    new XElement("Isolated", "false"),
+                    new XElement("EmbedInteropTypes", embedInteropTypes)));
+
+
+            var testAsset = _testAssetsManager
+                .CreateTestProject(testProject, identifier: embedInteropTypes.ToString())
+                .WithProjectChanges(doc => doc.Root.Add(reference))
+                .Restore(Log, testProject.Name);
+
+            var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            buildCommand.Execute().Should().Pass();
+            
+            var outputDirectory = buildCommand.GetOutputDirectory(targetFramework);
+            var runCommand = new RunExeCommand(Log, outputDirectory.File("UseMediaPlayer.exe").FullName);
+            runCommand.Execute().Should().Pass();
+        }
+    }
+}

--- a/src/Tests/Microsoft.NET.Build.Tests/COMReferenceTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/COMReferenceTests.cs
@@ -19,7 +19,7 @@ namespace Microsoft.NET.Build.Tests
         {
         }
 
-        [FullMSBuildOnlyTheory]
+        [FullMSBuildOnlyTheory(Skip ="Too much dependency on build machine state.")]
         [InlineData(true)]
         [InlineData(false)]
         public void COMReferenceBuildsAndRuns(bool embedInteropTypes)

--- a/src/Tests/Microsoft.NET.Build.Tests/NonCopyLocalProjectReferenceTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/NonCopyLocalProjectReferenceTests.cs
@@ -1,0 +1,73 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyModel;
+using Microsoft.NET.TestFramework;
+using Microsoft.NET.TestFramework.Assertions;
+using Microsoft.NET.TestFramework.Commands;
+using Microsoft.NET.TestFramework.ProjectConstruction;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.NET.Build.Tests
+{
+    public class NonCopyLocalProjectReferenceTests : SdkTest
+    {
+        public NonCopyLocalProjectReferenceTests(ITestOutputHelper log) : base(log)
+        {
+        }
+
+        [Fact]
+        public void NonCopyLocalProjectReferenceDoesNotGoToDeps()
+        {
+            var targetFramework = "netcoreapp3.0";
+
+            var referencedProject = new TestProject
+            {
+                Name = "ReferencedProject",
+                IsSdkProject = true,
+                TargetFrameworks = targetFramework,
+                IsExe = false,
+            };
+
+            var testProject = new TestProject
+            {
+                Name = "MainProject",
+                IsSdkProject = true,
+                TargetFrameworks = targetFramework,
+                IsExe = true,
+                ReferencedProjects = { referencedProject },
+            };
+
+            var testAsset = _testAssetsManager
+                .CreateTestProject(testProject)
+                .WithProjectChanges(doc =>
+                    doc.Root
+                       .DescendantNodes()
+                       .OfType<XElement>()
+                       .Where(e => e.Name.LocalName == "ProjectReference")
+                       .SingleOrDefault()
+                       ?.Add(new XAttribute("Private", "False")))
+                .Restore(Log, testProject.Name);
+
+            var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            buildCommand.Execute().Should().Pass();
+
+            var outputDirectory = buildCommand.GetOutputDirectory(targetFramework);
+
+            using var stream = File.OpenRead(outputDirectory.File("MainProject.deps.json").FullName);
+            using var reader = new DependencyContextJsonReader();
+
+            reader
+                .Read(stream)
+                .GetRuntimeAssemblyNames("any")
+                .Select(n => n.Name)
+                .Should()
+                .NotContain("ReferencedProject");
+        }
+    }
+}

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToRunCrossgen.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToRunCrossgen.cs
@@ -292,7 +292,7 @@ public class Program
             return null;
         }
 
-        private bool DoesImageHaveR2RInfo(string path)
+        public static bool DoesImageHaveR2RInfo(string path)
         {
             using (FileStream fs = new FileStream(path, FileMode.Open, FileAccess.Read))
             {

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToRunILLink.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToRunILLink.cs
@@ -58,16 +58,17 @@ namespace Microsoft.NET.Publish.Tests
         }
 
         [Theory]
-        [InlineData("netcoreapp3.0")]
-        public void ILLink_runs_and_creates_linked_app(string targetFramework)
+        [InlineData("netcoreapp3.0", true)]
+        [InlineData("netcoreapp3.0", false)]
+        public void ILLink_runs_and_creates_linked_app(string targetFramework, bool referenceClassLibAsPackage)
         {
             var projectName = "HelloWorld";
             var referenceProjectName = "ClassLibForILLink";
             var rid = EnvironmentInfo.GetCompatibleRid(targetFramework);
 
-            var testProject = CreateTestProjectForILLinkTesting(targetFramework, projectName, referenceProjectName);
+            var testProject = CreateTestProjectForILLinkTesting(targetFramework, projectName, referenceProjectName, referenceClassLibAsPackage);
             string[] restoreArgs = { $"/p:RuntimeIdentifier={rid}", "/p:SelfContained=true" };
-            var testAsset = _testAssetsManager.CreateTestProject(testProject)
+            var testAsset = _testAssetsManager.CreateTestProject(testProject, identifier: targetFramework + referenceClassLibAsPackage)
                 .WithProjectChanges(project => EnableNonFrameworkTrimming(project))
                 .Restore(Log, testProject.Name, restoreArgs);
 
@@ -424,7 +425,7 @@ namespace Microsoft.NET.Publish.Tests
                                                  new XElement("action"))));
         }
 
-        private TestProject CreateTestProjectForILLinkTesting(string targetFramework, string mainProjectName, string referenceProjectName)
+        private TestProject CreateTestProjectForILLinkTesting(string targetFramework, string mainProjectName, string referenceProjectName, bool usePackageReference = true)
         {
             var referenceProject = new TestProject()
             {
@@ -445,19 +446,25 @@ public class ClassLib
     }
 }
 ";
-
-            var packageReference = GetPackageReference(referenceProject);
-
             var testProject = new TestProject()
             {
                 Name = mainProjectName,
                 TargetFrameworks = targetFramework,
                 IsSdkProject = true,
-                PackageReferences = { packageReference }
             };
 
-            testProject.AdditionalProperties.Add("RestoreAdditionalProjectSources", 
-                                                 "$(RestoreAdditionalProjectSources);" + Path.GetDirectoryName(packageReference.NupkgPath));
+            if (usePackageReference)
+            {
+                var packageReference = GetPackageReference(referenceProject);
+                testProject.PackageReferences.Add(packageReference);
+                testProject.AdditionalProperties.Add(
+                    "RestoreAdditionalProjectSources",
+                    "$(RestoreAdditionalProjectSources);" + Path.GetDirectoryName(packageReference.NupkgPath));
+            }
+            else
+            {
+                testProject.ReferencedProjects.Add(referenceProject);
+            }
 
             testProject.SourceFiles[$"{mainProjectName}.cs"] = @"
 using System;

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToRunILLink.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToRunILLink.cs
@@ -293,7 +293,7 @@ namespace Microsoft.NET.Publish.Tests
                 .Should().Pass().And.HaveStdOutContainingIgnoreCase("https://aka.ms/dotnet-illink");
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/aspnet/AspNetCore/issues/12064")]
         public void ILLink_and_crossgen_process_razor_assembly()
         { 
             var targetFramework = "netcoreapp3.0";


### PR DESCRIPTION
### Description

Both the linker and crossgen features currently scan the entire set of published files, looking for managed assemblies. This was meant to be temporary and the design was to pass them the set of managed assemblies designated in .deps.json. This was not trivial due to ordering issues so we have been living with the temporary design. This change implements the planned design of passing the true set of managed assemblies.

The temporary design is inefficient, there's a first chance exception for every non-dll in the publish set, and can be incorrect in the edge case where there are dlls that are not part of the applications runtime dependencies included as content.

While working on this, bugs related to identifying the correct set of assemblies in the .deps file were fixed. It is difficult to split up the bug fixes as they were done on the foundation of the better design.

In total, 4 bugs are fixed.

1. Fix #3109 -  tracked the correct design that is implemented here
2. Fix #3547 - COMReference with PIA do not show up in .deps file, and therefore do not load. EmbedInteropTypes must be used.
3. Fix #2660 - Project references that are not copy local are incorrectly recorded in .deps file
4. Fix #3548 - linker cannot remove project references or direct file references from deps file

Relates to a fifth bug, https://github.com/aspnet/AspNetCore/issues/12064 (failure to account for views assembly in linker and crossgen), but a fix for that has been made that does not depend on this one. It includes a future proofing so that it can work with both the existing design and the design implemented here.

### Customer impact

This is primarily about having the planned correct design in place for the long term so that we do not have to support the temporary design indefinitely. It would be rare for an application to publish incorrectly with the temporary design.

The second bug has a simple workaround of using No-PIA, but the failure is not obvious.

The third bug has been worked around by the runtime. It now tolerates missing assemblies in .deps by default. That was also intended to be temporary so the longer we leave the SDK producing the incorrect .deps file, the longer the runtime will have to support this by default.

The fourth bug is benign for now as the linker only removes framework assemblies in this release, but this is expected to change in future releases, and it demonstrates the problem of having the poorer design in place as the foundation for these features evolving.

### Regression

No


### Risk

Medium. The code delta is not too large, but the change is in a tricky part of the code and it took 3 tries to come up with the right approach. More regression testing is still needed, which may take until tomorrow to finish authoring.
