### PR TITLE
Allow specifying RollForward with Major/LatestMajor on all apps

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -218,7 +218,10 @@ Copyright (c) .NET Foundation. All rights reserved.
       <RollForward Condition="'$(RollForward)' == '' and '$(EnableDynamicLoading)' == 'true' and '$(_IsRollForwardSupported)' == 'true'">LatestMinor</RollForward>
     </PropertyGroup>
 
-    <NETSdkError Condition="'$(RollForward)' != '' and '$(_IsRollForwardSupported)' != 'true'"
+    <!-- RollForward is only supported since .NET Core 3.0, but we should allow limitted usage when the app is targeting even lower versions
+         This is to let 2.* apps specify that they are OK to run on 3.0 and above. So explicitly allow just Major and LatestMajor
+         other values should still keep failing as they won't have any effect when run on 2.*. -->
+    <NETSdkError Condition="'$(RollForward)' != '' and '$(RollForward.ToLowerInvariant())' != 'major' and '$(RollForward.ToLowerInvariant())' != 'latestmajor' and '$(_IsRollForwardSupported)' != 'true'"
                  ResourceName="RollForwardRequiresVersion30"/>
 
     <GenerateRuntimeConfigurationFiles AssetsFilePath="$(ProjectAssetsFile)"

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -221,7 +221,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <!-- RollForward is only supported since .NET Core 3.0, but we should allow limitted usage when the app is targeting even lower versions
          This is to let 2.* apps specify that they are OK to run on 3.0 and above. So explicitly allow just Major and LatestMajor
          other values should still keep failing as they won't have any effect when run on 2.*. -->
-    <NETSdkError Condition="'$(RollForward)' != '' and '$(RollForward.ToLowerInvariant())' != 'major' and '$(RollForward.ToLowerInvariant())' != 'latestmajor' and '$(_IsRollForwardSupported)' != 'true'"
+    <NETSdkError Condition="'$(RollForward)' != '' and '$(RollForward)' != 'Major' and '$(RollForward)' != 'LatestMajor' and '$(_IsRollForwardSupported)' != 'true'"
                  ResourceName="RollForwardRequiresVersion30"/>
 
     <GenerateRuntimeConfigurationFiles AssetsFilePath="$(ProjectAssetsFile)"

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -218,7 +218,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       <RollForward Condition="'$(RollForward)' == '' and '$(EnableDynamicLoading)' == 'true' and '$(_IsRollForwardSupported)' == 'true'">LatestMinor</RollForward>
     </PropertyGroup>
 
-    <!-- RollForward is only supported since .NET Core 3.0, but we should allow limitted usage when the app is targeting even lower versions
+    <!-- RollForward is only supported since .NET Core 3.0, but we should allow limited usage when the app is targeting even lower versions
          This is to let 2.* apps specify that they are OK to run on 3.0 and above. So explicitly allow just Major and LatestMajor
          other values should still keep failing as they won't have any effect when run on 2.*. -->
     <NETSdkError Condition="'$(RollForward)' != '' and '$(RollForward)' != 'Major' and '$(RollForward)' != 'LatestMajor' and '$(_IsRollForwardSupported)' != 'true'"


### PR DESCRIPTION
#### Description
dotnet/cli#12257 - SDK doesn't allow usage of `RollForward` property in `2.*` apps. This complicates creation of tools which are supposed to run across major versions. Typically applies to .NET global tools.

Currently SDK explicitly blocks usage of `RollForward` msbuild property in projects targeting .NET Core `2.*`. Such a limitation makes sense for restrictive settings of this property (like `Disable` or `LatestPatch`) as usage of those could lead to unexpected behavioral changes when .NET 3.0 is installed on the machine. But there's no good reason to block the more relaxing values `Major` and `LatestMajor`. The fix is to change the explicit block to allow `Major` and `LatestMajor` settings even in `2.*` projects, while keep on failing for the more restrictive values (everything else).
The `RollForward` property has no effect on machines with `2.*` only runtimes. It works for all apps (regardless of version) once .NET Core 3.0 is installed on the machine.

#### Customer Impact
.NET Core Tools are a feature enabled as part of .NET Core 2.1. They are similar to libraries in that they are delivered by NuGet but differ in that they are bound to a specific runtime version. If a compatible runtime version is not found, the tools fail to run, with an appropriate error message. 
 
We initially gave guidance to multi-target tools to enable running 2.x tools on 3.0 only machine. After some discussion, we decided that this guidance wasn’t acceptable as the singular answer and funded the runtime binding feature (AKA Roll Forward). The goal was to enable 2.x apps to participate in major version roll-forward but not any of the other policies that are 3.x only. The SDK currently prevents this.
 
We need to enable the major version roll-forward scenario for 2.x apps and tools by making the error state more surgical. Otherwise, we’ll need to go back to the initial multi-targeting guidance or tell tools writers to use a `.runtimeconfig.template`. The template idea would work, but is a very unfortunate workaround for what was intended to be a mainline scenario.

#### Regression?
No - the roll forward feature is new in 3.0.
		
#### Risk
Very small - the `RollForward` msbuild property is new in 3.0 SDK, so its usage is almost certainly intentional. Affected scenarios were failing early (during build), after the fix they are going to work.