### PR TITLE
Fix regression in selecting default RuntimeIdentifier

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/GetDefaultPlatformTargetForNetFramework.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/GetDefaultPlatformTargetForNetFramework.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Microsoft.Build.Framework;
+
+namespace Microsoft.NET.Build.Tasks
+{
+    public class GetDefaultPlatformTargetForNetFramework : TaskBase
+    {
+        public ITaskItem[] PackageDependencies { get; set; }
+
+        public ITaskItem[] NativeCopyLocalItems { get; set; }
+
+        [Output]
+        public string DefaultPlatformTarget { get; private set; }
+
+        private const string X86 = "x86";
+        private const string AnyCPU = "AnyCPU";
+
+        protected override void ExecuteCore()
+        {
+            //  For .NET Framework projects, the SDK will select a default RuntimeIdentifier and PlatformTarget.  If no
+            //  native assets are found from NuGet packages, then the PlatformTarget will be reset to AnyCPU.  See the
+            //  comments in Microsoft.NET.RuntimeIdentifierInference.targets for details.
+            //  
+            //  Prior to the .NET Core 3.0 SDK, .NET Framework projects would only have a RuntimeIdentifier graph if the
+            //  Microsoft.NETCore.Platforms package was (transitively) referenced.  This meant that native assets would
+            //  only be selected if the platforms package was referenced or if the RuntimeIdentifier matched exactly.
+            //
+            //  Now that the RuntimeIdentifier graph is provided in the SDK, the logic in this task preserves the PlatformTarget
+            //  behavior from earlier SDKs, even though with the RuntimeIdentifier graph supplied, there may be native
+            //  assets selected where in prior SDKs there would not have been.
+
+            if (NativeCopyLocalItems == null || NativeCopyLocalItems.Length == 0)
+            {
+                DefaultPlatformTarget = AnyCPU;
+                return;
+            }
+
+            foreach (var packageDependency in PackageDependencies ?? Enumerable.Empty<ITaskItem>())
+            {
+                //  If the Platforms package is in the dependencies, then any native assets imply an X86 default PlatformTarget
+                if (packageDependency.ItemSpec.Equals("Microsoft.NETCore.Platforms", StringComparison.OrdinalIgnoreCase))
+                {
+                    DefaultPlatformTarget = X86;
+                    return;
+                }
+            }
+
+            foreach (var nativeItem in NativeCopyLocalItems)
+            {
+                //  If the Platforms package was not referenced, but there are native assets for the exact RID win7-x86,
+                //  then the default PlatformTarget should be x86.
+                string pathInPackage = nativeItem.GetMetadata(MetadataKeys.PathInPackage);
+                if (pathInPackage.StartsWith("runtimes/win7-x86/", StringComparison.OrdinalIgnoreCase))
+                {
+                    DefaultPlatformTarget = X86;
+                    return;
+                }
+            }
+
+            //  Otherwise, there would have been no native assets selected on pre-3.0 SDKs, so use AnyCPU as the
+            //  default PlatformTarget
+            DefaultPlatformTarget = AnyCPU;
+        }
+    }
+}

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageAssets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageAssets.cs
@@ -223,7 +223,7 @@ namespace Microsoft.NET.Build.Tasks
         public ITaskItem[] ApphostsForShimRuntimeIdentifiers { get; private set; }
 
         [Output]
-        public ITaskItem[] PackagesReferenced { get; private set; }
+        public ITaskItem[] PackageDependencies { get; private set; }
 
         /// <summary>
         /// Messages from the assets file.
@@ -308,8 +308,8 @@ namespace Microsoft.NET.Build.Tasks
                 FrameworkAssemblies = reader.ReadItemGroup();
                 FrameworkReferences = reader.ReadItemGroup();
                 NativeLibraries = reader.ReadItemGroup();
+                PackageDependencies = reader.ReadItemGroup();
                 PackageFolders = reader.ReadItemGroup();
-                PackagesReferenced = reader.ReadItemGroup();
                 ResourceAssemblies = reader.ReadItemGroup();
                 RuntimeAssemblies = reader.ReadItemGroup();
                 RuntimeTargets = reader.ReadItemGroup();
@@ -772,8 +772,8 @@ namespace Microsoft.NET.Build.Tasks
                 WriteItemGroup(WriteFrameworkAssemblies);
                 WriteItemGroup(WriteFrameworkReferences);
                 WriteItemGroup(WriteNativeLibraries);
-                WriteItemGroup(WritePackageFolders);
-                WriteItemGroup(WritePackagesReferenced);
+                WriteItemGroup(WritePackageDependencies);
+                WriteItemGroup(WritePackageFolders);                
                 WriteItemGroup(WriteResourceAssemblies);
                 WriteItemGroup(WriteRuntimeAssemblies);
                 WriteItemGroup(WriteRuntimeTargets);
@@ -1096,7 +1096,7 @@ namespace Microsoft.NET.Build.Tasks
                 }
             }
 
-            private void WritePackagesReferenced()
+            private void WritePackageDependencies()
             {
                 foreach (var library in _runtimeTarget.Libraries)
                 {

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageAssets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageAssets.cs
@@ -222,6 +222,9 @@ namespace Microsoft.NET.Build.Tasks
         [Output]
         public ITaskItem[] ApphostsForShimRuntimeIdentifiers { get; private set; }
 
+        [Output]
+        public ITaskItem[] PackagesReferenced { get; private set; }
+
         /// <summary>
         /// Messages from the assets file.
         /// These are logged directly and therefore not returned to the targets (note private here).
@@ -275,7 +278,7 @@ namespace Microsoft.NET.Build.Tasks
         ////////////////////////////////////////////////////////////////////////////////////////////////////
 
         private const int CacheFormatSignature = ('P' << 0) | ('K' << 8) | ('G' << 16) | ('A' << 24);
-        private const int CacheFormatVersion = 9;
+        private const int CacheFormatVersion = 10;
         private static readonly Encoding TextEncoding = Encoding.UTF8;
         private const int SettingsHashLength = 256 / 8;
         private HashAlgorithm CreateSettingsHash() => SHA256.Create();
@@ -306,6 +309,7 @@ namespace Microsoft.NET.Build.Tasks
                 FrameworkReferences = reader.ReadItemGroup();
                 NativeLibraries = reader.ReadItemGroup();
                 PackageFolders = reader.ReadItemGroup();
+                PackagesReferenced = reader.ReadItemGroup();
                 ResourceAssemblies = reader.ReadItemGroup();
                 RuntimeAssemblies = reader.ReadItemGroup();
                 RuntimeTargets = reader.ReadItemGroup();
@@ -769,6 +773,7 @@ namespace Microsoft.NET.Build.Tasks
                 WriteItemGroup(WriteFrameworkReferences);
                 WriteItemGroup(WriteNativeLibraries);
                 WriteItemGroup(WritePackageFolders);
+                WriteItemGroup(WritePackagesReferenced);
                 WriteItemGroup(WriteResourceAssemblies);
                 WriteItemGroup(WriteRuntimeAssemblies);
                 WriteItemGroup(WriteRuntimeTargets);
@@ -1088,6 +1093,17 @@ namespace Microsoft.NET.Build.Tasks
                 foreach (var packageFolder in _lockFile.PackageFolders)
                 {
                     WriteItem(packageFolder.Path);
+                }
+            }
+
+            private void WritePackagesReferenced()
+            {
+                foreach (var library in _runtimeTarget.Libraries)
+                {
+                    if (library.IsPackage())
+                    {
+                        WriteItem(library.Name);
+                    }
                 }
             }
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets
@@ -174,6 +174,10 @@ Copyright (c) .NET Foundation. All rights reserved.
     <OutputPath>$(OutputPath)$(RuntimeIdentifier)\</OutputPath>
   </PropertyGroup>
 
+  <UsingTask TaskName="Microsoft.NET.Build.Tasks.GetDefaultPlatformTargetForNetFramework"
+           AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
+
+
   <!-- 
     Switch our default .NETFramework CPU architecture choice back to AnyCPU before 
     compiling the exe if no copy-local native dependencies were resolved from NuGet 
@@ -184,19 +188,12 @@ Copyright (c) .NET Foundation. All rights reserved.
           Condition="'$(_UsingDefaultPlatformTarget)' == 'true' and
                      '$(_UsingDefaultRuntimeIdentifier)' == 'true'">
 
-    <ItemGroup>
-      <_PlatformPackageDependency Include="@(PackageDependencies)" Condition="'%(Identity)' == 'Microsoft.NETCore.Platforms'" />
-    </ItemGroup>
-    
-    <!-- If there were no native assets, or if the Microsoft.NETCore.Platforms package was not referenced, then revert to AnyCPU.
-         The reason we use AnyCPU if Microsoft.NETCore.Platforms is not referenced is to preserve behavior from before 3.0 when
-         the RuntimeIdentifier graph wasn't included in the SDK, and assets where the RuntimeIdentifier didn't match exactly wouldn't
-         be picked up unless the platforms package was referenced. -->
-    
-    <PropertyGroup Condition="('@(NativeCopyLocalItems)' == '' or
-                             '@(_PlatformPackageDependency)' == '')">
-      <PlatformTarget>AnyCPU</PlatformTarget>
-    </PropertyGroup>
+    <GetDefaultPlatformTargetForNetFramework PackageDependencies="@(PackageDependencies)"
+                                             NativeCopyLocalItems="@(NativeCopyLocalItems)">
+
+      <Output TaskParameter="DefaultPlatformTarget" PropertyName="PlatformTarget" />
+      
+    </GetDefaultPlatformTargetForNetFramework>
   </Target>
 
 </Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets
@@ -182,9 +182,19 @@ Copyright (c) .NET Foundation. All rights reserved.
           AfterTargets="ResolvePackageAssets"
           BeforeTargets="CoreCompile"
           Condition="'$(_UsingDefaultPlatformTarget)' == 'true' and
-                     '$(_UsingDefaultRuntimeIdentifier)' == 'true' and
-                     '@(NativeCopyLocalItems)' == ''">
-    <PropertyGroup>
+                     '$(_UsingDefaultRuntimeIdentifier)' == 'true'">
+
+    <ItemGroup>
+      <_ReferencedPlatformPackage Include="@(PackagesReferenced)" Condition="'%(Identity)' == 'Microsoft.NETCore.Platforms'" />
+    </ItemGroup>
+    
+    <!-- If there were no native assets, or if the Microsoft.NETCore.Platforms package was not referenced, then revert to AnyCPU.
+         The reason we use AnyCPU if Microsoft.NETCore.Platforms is not referenced is to preserve behavior from before 3.0 when
+         the RuntimeIdentifier graph wasn't included in the SDK, and assets where the RuntimeIdentifier didn't match exactly wouldn't
+         be picked up unless the platforms package was referenced. -->
+    
+    <PropertyGroup Condition="('@(NativeCopyLocalItems)' == '' or
+                             '@(_ReferencedPlatformPackage)' == '')">
       <PlatformTarget>AnyCPU</PlatformTarget>
     </PropertyGroup>
   </Target>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets
@@ -185,7 +185,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                      '$(_UsingDefaultRuntimeIdentifier)' == 'true'">
 
     <ItemGroup>
-      <_ReferencedPlatformPackage Include="@(PackagesReferenced)" Condition="'%(Identity)' == 'Microsoft.NETCore.Platforms'" />
+      <_PlatformPackageDependency Include="@(PackageDependencies)" Condition="'%(Identity)' == 'Microsoft.NETCore.Platforms'" />
     </ItemGroup>
     
     <!-- If there were no native assets, or if the Microsoft.NETCore.Platforms package was not referenced, then revert to AnyCPU.
@@ -194,7 +194,7 @@ Copyright (c) .NET Foundation. All rights reserved.
          be picked up unless the platforms package was referenced. -->
     
     <PropertyGroup Condition="('@(NativeCopyLocalItems)' == '' or
-                             '@(_ReferencedPlatformPackage)' == '')">
+                             '@(_PlatformPackageDependency)' == '')">
       <PlatformTarget>AnyCPU</PlatformTarget>
     </PropertyGroup>
   </Target>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.PackageDependencyResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.PackageDependencyResolution.targets
@@ -272,7 +272,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       <Output TaskParameter="CompileTimeAssemblies" ItemName="ResolvedCompileFileDefinitions" />
       <Output TaskParameter="TransitiveProjectReferences" ItemName="_TransitiveProjectReferences" />
       <Output TaskParameter="PackageFolders" ItemName="AssetsFilePackageFolder" />
-      <Output TaskParameter="PackagesReferenced" ItemName="PackagesReferenced" />
+      <Output TaskParameter="PackageDependencies" ItemName="PackageDependencies" />
     </ResolvePackageAssets>
 
     <ItemGroup Condition="'$(UseAppHostFromAssetsFile)' == 'true'">

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.PackageDependencyResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.PackageDependencyResolution.targets
@@ -272,6 +272,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       <Output TaskParameter="CompileTimeAssemblies" ItemName="ResolvedCompileFileDefinitions" />
       <Output TaskParameter="TransitiveProjectReferences" ItemName="_TransitiveProjectReferences" />
       <Output TaskParameter="PackageFolders" ItemName="AssetsFilePackageFolder" />
+      <Output TaskParameter="PackagesReferenced" ItemName="PackagesReferenced" />
     </ResolvePackageAssets>
 
     <ItemGroup Condition="'$(UseAppHostFromAssetsFile)' == 'true'">


### PR DESCRIPTION
#### Description
Fixed change in behavior (regression) that was introduced when we started including the RuntimeIdentifier graph in the SDK and passing it to NuGet.

#### Customer Impact
The change in behavior had to do with the automatic selection of the PlatformTarget.  In specific cases, the PlatformTarget would be set to x86, where it would have previously been set to AnyCPU.  This is because previously you had to have a (transitive) dependency on the Microsoft.NETCore.Platforms package to get the RuntimeIdentifier graph, and without it, you wouldn't get assets that didn't exactly match the default RuntimeIdentifier (win7-x86).  Since no native assets were found, the PlatformTarget defaulted to AnyCPU, even though if the RuntimeGraph had been available there would have been native assets.

Roslyn ran into this, their apps switched to x86 unintentionally.  We are not sure how many other customers would be impacted, as the combination of factors necessary to see the behavior change is somewhat of an edge case.

#### Regression?
Yes, regressed with #3406

#### Risk
Low

Fixes #3495

I thought of a "clever" way to fix this regression.  We revert to the AnyCPU PlatformTarget if:
- There are no native assets
- There are native assets, but the Microsoft.NETCore.Platforms package (which was previously necessary to get the RID graph) is not transitively referenced, and there are no native assets for the exact RID win7-x86.

This should match the PlatformTarget which SDKs prior to the 3.0 SDK would have used.