### PR TITLE
Support more test config options

### DIFF
--- a/src/Tests/Common/Program.cs
+++ b/src/Tests/Common/Program.cs
@@ -26,7 +26,7 @@ partial class Program
 
         if (!testCommandLine.ShouldShowHelp)
         {
-            newArgs.AddRange(TestCommandLine.GetXunitArgsFromTestConfig(testCommandLine.TestConfigFile));
+            newArgs.AddRange(testCommandLine.GetXunitArgsFromTestConfig());
             BeforeTestRun(newArgs);
         }
 


### PR DESCRIPTION
#### Description
Add more support for specifying tests to run via test config file

#### Customer Impact
No direct customer impact, this is a test infrastructure change

#### Regression?
No

#### Risk
Low

Adds more options for controlling which tests are run.

- Multiple test config files can be specified (via `-testConfig` or `-testConfigFile`)
- Test config files can have named test lists
- One or more test lists to run can be specified via `-testList` on the command line
- Tests can be specified in test config by method, class, or namespace
- Tests to skip can be put in a `SkippedTests` element in the test config file

This should help apply the SDK test assets to other repos, as it will be easier to start by specifying a small set of tests to run instead of trying to skip or fix all the failing tests.  It also may help if we want to have inner / outer loop tests.

A sample test config file showing the different options:

```xml
<Tests>

  <TestList Name="BasicBuildTests">
    <Method Name="Microsoft.NET.Build.Tests.GivenThatWeWantToBuildANetCoreApp.It_runs_the_app_from_the_output_folder" />
    <Class Name="Microsoft.NET.Build.Tests.GivenThatWeWantToBuildANetStandard2Library" />
  </TestList>

  <TestList Name="MoreBuildTests">
    <Class Name="Microsoft.NET.Build.Tests.GivenThatWeWantToSetPropertiesInDirectoryBuildProps" />
  </TestList>
  
  <SkippedTests>
    <Method Name="Microsoft.NET.Build.Tests.GivenThatWeWantToBuildANetStandard2Library.It_resolves_assembly_conflicts"
            Issue="none"
            Reason="Testing"/>
  </SkippedTests>

  <TestList Name="TestList1">
    <Method Name="MyNamespace.MyClass.MyTestName" />
    <Class Name="MyNamespace.MyClass" />
  </TestList>

  <Method Name="Microsoft.NET.Build.Tests.GivenThatWeWantToBuildANetStandard2Library.It_builds_a_netstandard2_library_successfully"
            Skip="true"
            Issue="none"
            Reason="Testing"/>

</Tests>
```