### PR TITLE
Don't validate signature for resources files

### DIFF
--- a/eng/SignCheckExclusionsFile.txt
+++ b/eng/SignCheckExclusionsFile.txt
@@ -2,5 +2,7 @@
 
 ;; Localization assemblies for Cli.Utils, which is referenced only by tests
 Microsoft.DotNet.Cli.Utils.resources*.dll
+Microsoft.Net.Build.Extensions.Tasks.Resources*.dll
+Microsoft.Net.Build.Tasks.Resources*.dll
 kerneltracecontrol*.dll
 msdia140*.dll


### PR DESCRIPTION
Relates to: https://github.com/dotnet/core-eng/issues/7569

Independent of the outcome of the current signing issues I believe these files aren't required to be signed.

/cc @riarenas 