### PR TITLE
Skip tests in official builds. We have no reason to run them again si…

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -40,14 +40,17 @@ stages:
               _BuildConfig: Debug
               _PublishType: none
               _SignType: test
+              _Test: -test
           Build_Release:
             _BuildConfig: Release
             ${{ if eq(variables['System.TeamProject'], 'public') }}:
               _PublishType: none
               _SignType: test
+              _Test: -test
             ${{ if ne(variables['System.TeamProject'], 'public') }}:
               _PublishType: blob
               _SignType: real
+              _Test: ''
 
   - ${{ if ne(variables['System.TeamProject'], 'public') }}:
     - template: /eng/build.yml

--- a/eng/CIBuild.cmd
+++ b/eng/CIBuild.cmd
@@ -1,0 +1,2 @@
+@echo off
+powershell -ExecutionPolicy ByPass -NoProfile -command "& """%~dp0common\Build.ps1""" -restore -build -sign -pack -publish -ci %*"

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -36,6 +36,7 @@ jobs:
       - _OfficialBuildIdArgs: ''
       - _PublishArgs: ''
       - _SignArgs: ''
+      - _TestArgs: $(_Test)
       - ${{ if ne(variables['System.TeamProject'], 'public') }}:
         - group: DotNet-Symbol-Server-PATs
         - group: DotNet-HelixApi-Access
@@ -53,11 +54,12 @@ jobs:
         - _PerfIterations: 25
     steps:
     - ${{ if eq(parameters.agentOs, 'Windows_NT') }}:
-      - script: eng\common\CIBuild.cmd
+      - script: eng\CIBuild.cmd
                   -configuration $(_BuildConfig)
                   $(_PublishArgs)
                   $(_SignArgs)
                   $(_OfficialBuildIdArgs)
+                  $(_TestArgs)
         displayName: Build
         env:
           BuildConfig: $(_BuildConfig)


### PR DESCRIPTION
…nce they already ran on CI. This should speed up builds out of the sdk repo.