### PR TITLE
Implement writing includedFrameworks references for self-contained apps

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/GenerateRuntimeConfigurationFiles.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/GenerateRuntimeConfigurationFiles.cs
@@ -10,7 +10,6 @@ using Microsoft.Build.Utilities;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Newtonsoft.Json.Serialization;
-using NuGet.Packaging;
 using NuGet.ProjectModel;
 
 namespace Microsoft.NET.Build.Tasks
@@ -51,6 +50,8 @@ namespace Microsoft.NET.Build.Tasks
         public bool IsSelfContained { get; set; }
 
         public bool WriteAdditionalProbingPathsToMainConfig { get; set; }
+
+        public bool WriteIncludedFrameworks { get; set; }
 
         List<ITaskItem> _filesWritten = new List<ITaskItem>();
 
@@ -131,67 +132,73 @@ namespace Microsoft.NET.Build.Tasks
 
         private void AddFrameworks(RuntimeOptions runtimeOptions, ProjectContext projectContext)
         {
+            runtimeOptions.Tfm = TargetFramework;
+
+            List<RuntimeConfigFramework> frameworks = new List<RuntimeConfigFramework>();
+            if (projectContext.RuntimeFrameworks == null || projectContext.RuntimeFrameworks.Length == 0)
+            {
+                //  If there are no RuntimeFrameworks (which would be set in the ProcessFrameworkReferences task based
+                //  on FrameworkReference items), then use package resolved from MicrosoftNETPlatformLibrary for
+                //  the runtimeconfig
+                RuntimeConfigFramework framework = new RuntimeConfigFramework();
+                framework.Name = projectContext.PlatformLibrary.Name;
+                framework.Version = projectContext.PlatformLibrary.Version.ToNormalizedString();
+
+                frameworks.Add(framework);
+            }
+            else
+            {
+                HashSet<string> usedFrameworkNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                foreach (var platformLibrary in projectContext.RuntimeFrameworks)
+                {
+                    if (projectContext.RuntimeFrameworks.Length > 1 &&
+                        platformLibrary.Name.Equals("Microsoft.NETCore.App", StringComparison.OrdinalIgnoreCase) &&
+                        projectContext.IsFrameworkDependent)
+                    {
+                        //  If there are multiple runtime frameworks, then exclude Microsoft.NETCore.App,
+                        //  as a workaround for https://github.com/dotnet/core-setup/issues/4947
+                        //  The workaround only applies to normal framework references, included frameworks
+                        //  (in self-contained apps) must list all frameworks.
+                        continue;
+                    }
+
+                    //  Don't add multiple entries for the same shared framework.
+                    //  This is necessary if there are FrameworkReferences to different profiles
+                    //  that map to the same shared framework.
+                    if (!usedFrameworkNames.Add(platformLibrary.Name))
+                    {
+                        continue;
+                    }
+
+                    RuntimeConfigFramework framework = new RuntimeConfigFramework();
+                    framework.Name = platformLibrary.Name;
+                    framework.Version = platformLibrary.Version;
+
+                    frameworks.Add(framework);
+                }
+            }
+
             if (projectContext.IsFrameworkDependent)
             {
-                runtimeOptions.Tfm = TargetFramework;
                 runtimeOptions.RollForward = RollForward;
 
-                if (projectContext.RuntimeFrameworks == null || projectContext.RuntimeFrameworks.Length == 0)
+                //  If there is only one runtime framework, then it goes in the framework property of the json
+                //  If there are multiples, then we leave the framework property unset and put the list in
+                //  the frameworks property.
+                if (frameworks.Count == 1)
                 {
-                    //  If there are no RuntimeFrameworks (which would be set in the ProcessFrameworkReferences task based
-                    //  on FrameworkReference items), then use package resolved from MicrosoftNETPlatformLibrary for
-                    //  the runtimeconfig
-                    RuntimeConfigFramework framework = new RuntimeConfigFramework();
-                    framework.Name = projectContext.PlatformLibrary.Name;
-                    framework.Version = projectContext.PlatformLibrary.Version.ToNormalizedString();
-
-                    runtimeOptions.Framework = framework;
+                    runtimeOptions.Framework = frameworks[0];
                 }
                 else
                 {
-                    HashSet<string> usedFrameworkNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-                    foreach (var platformLibrary in projectContext.RuntimeFrameworks)
-                    {
-                        if (projectContext.RuntimeFrameworks.Length > 1 &&
-                            platformLibrary.Name.Equals("Microsoft.NETCore.App", StringComparison.OrdinalIgnoreCase))
-                        {
-                            //  If there are multiple runtime frameworks, then exclude Microsoft.NETCore.App,
-                            //  as a workaround for https://github.com/dotnet/core-setup/issues/4947
-                            continue;
-                        }
-
-                        //  Don't add multiple entries for the same shared framework.
-                        //  This is necessary if there are FrameworkReferences to different profiles
-                        //  that map to the same shared framework.
-                        if (!usedFrameworkNames.Add(platformLibrary.Name))
-                        {
-                            continue;
-                        }
-
-                        RuntimeConfigFramework framework = new RuntimeConfigFramework();
-                        framework.Name = platformLibrary.Name;
-                        framework.Version = platformLibrary.Version;
-
-                        //  If there is only one runtime framework, then it goes in the framework property of the json
-                        //  If there are multiples, then we leave the framework property unset and put the list in
-                        //  the frameworks property.
-                        if (runtimeOptions.Framework == null && runtimeOptions.Frameworks == null)
-                        {
-                            runtimeOptions.Framework = framework;
-                        }
-                        else
-                        {
-                            if (runtimeOptions.Frameworks == null)
-                            {
-                                runtimeOptions.Frameworks = new List<RuntimeConfigFramework>();
-                                runtimeOptions.Frameworks.Add(runtimeOptions.Framework);
-                                runtimeOptions.Framework = null;
-                            }
-
-                            runtimeOptions.Frameworks.Add(framework);
-                        }
-                    }
+                    runtimeOptions.Frameworks = frameworks;
                 }
+            }
+            else if (WriteIncludedFrameworks)
+            {
+                //  Self-contained apps don't have framework references, instead write the frameworks
+                //  into the includedFrameworks property.
+                runtimeOptions.IncludedFrameworks = frameworks;
             }
         }
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/GenerateRuntimeConfigurationFiles.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/GenerateRuntimeConfigurationFiles.cs
@@ -134,7 +134,7 @@ namespace Microsoft.NET.Build.Tasks
         {
             runtimeOptions.Tfm = TargetFramework;
 
-            List<RuntimeConfigFramework> frameworks = new List<RuntimeConfigFramework>();
+            var frameworks = new List<RuntimeConfigFramework>();
             if (projectContext.RuntimeFrameworks == null || projectContext.RuntimeFrameworks.Length == 0)
             {
                 //  If there are no RuntimeFrameworks (which would be set in the ProcessFrameworkReferences task based

--- a/src/Tasks/Microsoft.NET.Build.Tasks/RuntimeOptions.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/RuntimeOptions.cs
@@ -18,6 +18,8 @@ namespace Microsoft.NET.Build.Tasks
 
         public List<RuntimeConfigFramework> Frameworks { get; set; }
 
+        public List<RuntimeConfigFramework> IncludedFrameworks { get; set; }
+
         public List<string> AdditionalProbingPaths { get; set; }
 
         [JsonExtensionData]

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -249,8 +249,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                  ResourceName="RollForwardRequiresVersion30"/>
 
     <PropertyGroup>
-      <!-- TODO: Once ported to 3.1 branches, this should be changed to 3.1 - we only want the new property to be written for 3.1 and above. -->
-      <_WriteIncludedFrameworks Condition="'$(SelfContained)' == 'true' and '$(_TargetFrameworkVersionWithoutV)' &gt;= '3.0'">true</_WriteIncludedFrameworks>
+      <_WriteIncludedFrameworks Condition="'$(SelfContained)' == 'true' and '$(_TargetFrameworkVersionWithoutV)' &gt;= '3.1'">true</_WriteIncludedFrameworks>
     </PropertyGroup>
     
     <GenerateRuntimeConfigurationFiles AssetsFilePath="$(ProjectAssetsFile)"

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -248,6 +248,11 @@ Copyright (c) .NET Foundation. All rights reserved.
     <NETSdkError Condition="'$(RollForward)' != '' and '$(RollForward)' != 'Major' and '$(RollForward)' != 'LatestMajor' and '$(_IsRollForwardSupported)' != 'true'"
                  ResourceName="RollForwardRequiresVersion30"/>
 
+    <PropertyGroup>
+      <!-- TODO: Once ported to 3.1 branches, this should be changed to 3.1 - we only want the new property to be written for 3.1 and above. -->
+      <_WriteIncludedFrameworks Condition="'$(SelfContained)' == 'true' and '$(_TargetFrameworkVersionWithoutV)' &gt;= '3.0'">true</_WriteIncludedFrameworks>
+    </PropertyGroup>
+    
     <GenerateRuntimeConfigurationFiles AssetsFilePath="$(ProjectAssetsFile)"
                                        TargetFrameworkMoniker="$(TargetFrameworkMoniker)"
                                        TargetFramework="$(TargetFramework)"
@@ -260,7 +265,8 @@ Copyright (c) .NET Foundation. All rights reserved.
                                        UserRuntimeConfig="$(UserRuntimeConfig)"
                                        HostConfigurationOptions="@(RuntimeHostConfigurationOption)"
                                        AdditionalProbingPaths="@(AdditionalProbingPath)"
-                                       IsSelfContained="$(SelfContained)">
+                                       IsSelfContained="$(SelfContained)"
+                                       WriteIncludedFrameworks="$(_WriteIncludedFrameworks)">
 
     </GenerateRuntimeConfigurationFiles>
 

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenFrameworkReferences.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenFrameworkReferences.cs
@@ -1,13 +1,10 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
-using System.Text;
 using System.Xml.Linq;
 using FluentAssertions;
-using Microsoft.Build.Construction;
 using Microsoft.NET.TestFramework;
 using Microsoft.NET.TestFramework.Assertions;
 using Microsoft.NET.TestFramework.Commands;
@@ -15,7 +12,6 @@ using Microsoft.NET.TestFramework.ProjectConstruction;
 using Newtonsoft.Json.Linq;
 using Xunit;
 using Xunit.Abstractions;
-using Xunit.Sdk;
 
 namespace Microsoft.NET.Build.Tests
 {
@@ -24,6 +20,19 @@ namespace Microsoft.NET.Build.Tests
         public GivenFrameworkReferences(ITestOutputHelper log) : base(log)
         {
         }
+
+        private const string FrameworkReferenceEmptyProgramSource = @"
+using System;
+
+namespace FrameworkReferenceTest
+{
+    public class Program
+    {
+        public static void Main(string [] args)
+        {
+        }
+    }
+}";
 
         //  Tests in this class are currently Core MSBuild only, as they check for PackageDownload items,
         //  which are currently only used in Core MSBuild
@@ -41,18 +50,7 @@ namespace Microsoft.NET.Build.Tests
             testProject.FrameworkReferences.Add("Microsoft.ASPNETCORE.App");
             testProject.FrameworkReferences.Add("Microsoft.WindowsDesktop.App");
 
-            testProject.SourceFiles.Add("Program.cs", @"
-using System;
-
-namespace FrameworkReferenceTest
-{
-    public class Program
-    {
-        public static void Main(string [] args)
-        {
-        }
-    }
-}");
+            testProject.SourceFiles.Add("Program.cs", FrameworkReferenceEmptyProgramSource);
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
@@ -73,6 +71,55 @@ namespace FrameworkReferenceTest
             runtimeFrameworkNames.Should().BeEquivalentTo("Microsoft.AspNetCore.App", "Microsoft.WindowsDesktop.App");
         }
 
+        [CoreMSBuildAndWindowsOnlyTheory]
+        // TODO - once integrated into 3.1 branch this should test 3.0 as false and 3.1 as success
+        [InlineData("netcoreapp2.1", false)]
+        [InlineData("netcoreapp3.0", true)]
+        public void Multiple_frameworks_are_written_to_runtimeconfig_for_self_contained_apps(string tfm, bool shouldHaveIncludedFrameworks)
+        {
+            var testProject = new TestProject()
+            {
+                Name = "MultipleFrameworkReferenceTest",
+                TargetFrameworks = tfm,
+                IsSdkProject = true,
+                IsExe = true
+            };
+
+            // Specifying RID makes the produced app self-contained.
+            testProject.RuntimeIdentifier = EnvironmentInfo.GetCompatibleRid(testProject.TargetFrameworks);
+
+            if (tfm == "netcoreapp3.0")
+            {
+                testProject.FrameworkReferences.Add("Microsoft.ASPNETCORE.App");
+                testProject.FrameworkReferences.Add("Microsoft.WindowsDesktop.App");
+            }
+
+            testProject.SourceFiles.Add("Program.cs", FrameworkReferenceEmptyProgramSource);
+
+            var testAsset = _testAssetsManager.CreateTestProject(testProject)
+                .Restore(Log, testProject.Name);
+
+            var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+
+            buildCommand
+                .Execute()
+                .Should()
+                .Pass();
+
+            var outputDirectory = buildCommand.GetOutputDirectory(testProject.TargetFrameworks);
+
+            string runtimeConfigFile = Path.Combine(outputDirectory.FullName, testProject.RuntimeIdentifier, testProject.Name + ".runtimeconfig.json");
+            var includedFrameworkNames = GetIncludedFrameworks(runtimeConfigFile);
+            if (shouldHaveIncludedFrameworks)
+            {
+                includedFrameworkNames.Should().BeEquivalentTo("Microsoft.NETCore.App", "Microsoft.WindowsDesktop.App", "Microsoft.AspNetCore.App");
+            }
+            else
+            {
+                includedFrameworkNames.Should().BeEmpty();
+            }
+        }
+
         [CoreMSBuildAndWindowsOnlyFact]
         public void DuplicateFrameworksAreNotWrittenToRuntimeConfigWhenThereAreDifferentProfiles()
         {
@@ -87,18 +134,7 @@ namespace FrameworkReferenceTest
             testProject.FrameworkReferences.Add("Microsoft.WindowsDesktop.App.WPF");
             testProject.FrameworkReferences.Add("Microsoft.WindowsDesktop.App.WindowsForms");
 
-            testProject.SourceFiles.Add("Program.cs", @"
-using System;
-
-namespace FrameworkReferenceTest
-{
-    public class Program
-    {
-        public static void Main(string [] args)
-        {
-        }
-    }
-}");
+            testProject.SourceFiles.Add("Program.cs", FrameworkReferenceEmptyProgramSource);
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
@@ -924,6 +960,16 @@ namespace FrameworkReferenceTest
 
                 return runtimeFrameworkNames;
             }
+        }
+
+        private List<string> GetIncludedFrameworks(string runtimeConfigPath)
+        {
+            JObject runtimeConfig = ReadRuntimeConfig(runtimeConfigPath);
+
+            var runtimeFrameworksList = (JArray)runtimeConfig["runtimeOptions"]["includedFrameworks"];
+            return runtimeFrameworksList == null
+                ? new List<string>()
+                : runtimeFrameworksList.Select(element => ((JValue)element["name"]).Value<string>()).ToList();
         }
 
         private ResolvedVersionInfo GetResolvedVersions(TestProject testProject,


### PR DESCRIPTION
For self-contained apps which are of the right version (to maintain backward compat), write the framework references to a new `includedFrameworks` property in `.runtimeconfig.json`.

When the native hosting APIs are used to load a managed component into a process which is running a .NET Core app, the hosting layer should validate that the new component framework requirements are met by the frameworks loaded into the process already. This is to allow the new component to communicate with the app (same FX types), but also to overcome the fact that we don't want to load frameworks twice ever.

In order to validate the framework references declared by the new component, the host must know what frameworks are loaded into the process. For framework dependent apps this works fine as the host knows which frameworks it resolved during the app startup. But for self-contained apps, the host doesn't know as everything looks like an app to it.

This change adds he new `includedFrameworks` property to the `.runtimeconfig.json` which will be used for self-contained apps (only, it should not occur when `framework` or `frameworks` properties are used). It will contain the list of frameworks which were used to build the self-contained apps. The format is the same as `frameworks` property content.

To maintain strict backward compatibility, this change will only write the new property to projects targeting `netcoreapp3.1` or higher.

As coded this assumes the change will be approved for 3.1. If it's rejected, I will follow up with a change which will make the new property occur only for 5.0 and above.

#3541 - master (5.0) version