### PR TITLE
Improve Error Experience

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ILLink.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ILLink.targets
@@ -110,7 +110,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <PropertyGroup>
       <_ExtraTrimmerArgs>-l none --skip-unresolved true $(_ExtraTrimmerArgs)</_ExtraTrimmerArgs>
-      <_ExtraTrimmerArgs>-c copyused -u copyused $(_ExtraTrimmerArgs)</_ExtraTrimmerArgs>
+      <_ExtraTrimmerArgs>-c copyused -u copyused --verbose $(_ExtraTrimmerArgs)</_ExtraTrimmerArgs>
     </PropertyGroup>
     <ItemGroup>
       <TrimmerRootAssembly Include="@(_ManagedAssembliesToLink)" Condition=" '%(_ManagedAssembliesToLink.IsTrimmable)' != 'true' " />


### PR DESCRIPTION
As part of the improve error experience linker issue (see issue https://github.com/mono/linker/issues/653) we find out that an additional flag was needed in order to print warning messages.
This change mades possible for the linker to print valuable information like warnings when an assembly is unresolved and is going to be skipped. Likely this feature could also work to warning the user when it's using patterns that could break their application.