### PR TITLE
Set the default publish profile only if the profile is not imported by NetSdk

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.ImportPublishProfile.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.ImportPublishProfile.targets
@@ -16,9 +16,8 @@ Copyright (c) .NET Foundation. All rights reserved.
     <_PublishProfileDesignerFolder Condition="'$(AppDesignerFolder)' != ''">$(AppDesignerFolder)</_PublishProfileDesignerFolder>
     <_PublishProfileDesignerFolder Condition="'$(_PublishProfileDesignerFolder)' == ''">Properties</_PublishProfileDesignerFolder>
     <_PublishProfileRootFolder Condition="'$(_PublishProfileRootFolder)' == ''">$(MSBuildProjectDirectory)\$(_PublishProfileDesignerFolder)\PublishProfiles\</_PublishProfileRootFolder>
-    <PublishProfile Condition="'$(PublishProfile)' ==''">FileSystem</PublishProfile>
-    <PublishProfileName Condition="'$(PublishProfileName)' == ''">$([System.IO.Path]::GetFileNameWithoutExtension($(PublishProfile)))</PublishProfileName>
-    <PublishProfileFullPath Condition="'$(PublishProfileFullPath)' == ''">$(_PublishProfileRootFolder)$(PublishProfileName).pubxml</PublishProfileFullPath>
+    <PublishProfileName Condition="'$(PublishProfileName)' == '' and '$(PublishProfile)' != ''">$([System.IO.Path]::GetFileNameWithoutExtension($(PublishProfile)))</PublishProfileName>
+    <PublishProfileFullPath Condition="'$(PublishProfileFullPath)' == '' and '$(PublishProfileName)' != ''">$(_PublishProfileRootFolder)$(PublishProfileName).pubxml</PublishProfileFullPath>
     <WebPublishProfileFile Condition="'$(WebPublishProfileFile)' == '' and Exists('$(PublishProfileFullPath)')">$(PublishProfileFullPath)</WebPublishProfileFile>
 
     <!-- If the publish profile doesn't exist, mark as not imported.


### PR DESCRIPTION
Issue:
When an SDK based WebJobs project is published without a profile, publish fails with missing Profile named 'FileSystem'.

This is because the default filesyste profile is shipped in WebSdk but is set in NetSdk.

Fix: Is to not default the publish profile to 'FileSystem' in NetSdk since NetSdk does not ship this default profile.

Impact:
This breaks the Sdk based WebJobs publish scenarios.

There are 2 parts to this fix:

Removing the default publish profile from Netsdk
If the profile is not imported by NetSdk, setting the default publish profile in WebSdk & importing the default profile. This is the websdk part of the fix - aspnet/websdk#1006