### PR TITLE
[release/3.1.1xx] Add TFM check for `Publish-Trimmed-ReadyToRun-SingleFile`

### DIFF
--- a/src/Tasks/Common/Resources/Strings.resx
+++ b/src/Tasks/Common/Resources/Strings.resx
@@ -475,7 +475,7 @@ The following are names of parameters or literal values and should not be transl
     <comment>{StrBegin="NETSDK1092: "}</comment>
   </data>
   <data name="ProjectToolOnlySupportTFMLowerThanNetcoreapp22" xml:space="preserve">
-    <value>NETSDK1093: NETSDK1093: Project tools (DotnetCliTool) only support targeting .NET Core 2.2 and lower.</value>
+    <value>NETSDK1093: Project tools (DotnetCliTool) only support targeting .NET Core 2.2 and lower.</value>
     <comment>{StrBegin="NETSDK1093: "}</comment>
   </data>
   <data name="ReadyToRunNoValidRuntimePackageError" xml:space="preserve">
@@ -587,5 +587,33 @@ The following are names of parameters or literal values and should not be transl
   <data name="CppRequiresTFMVersion31" xml:space="preserve">
     <value>NETSDK1120: C++/CLI projects targeting .NET Core require a target framework of at least 'netcoreapp3.1'.</value>
     <comment>{StrBegin="NETSDK1120: "}</comment>
+  </data>
+  <data name="PublishReadyToRunRequiresVersion30" xml:space="preserve">
+    <value>NETSDK1121: ReadyToRun compilation will be skipped because it is only supported for .NET Core 3.0 or higher.</value>
+    <comment>{StrBegin="NETSDK1121: "}</comment>
+  </data>
+  <data name="PublishSingleFileRequiresVersion30" xml:space="preserve">
+    <value>NETSDK1122: Publishing an application to a single-file requires .NET Core 3.0 or higher.</value>
+    <comment>{StrBegin="NETSDK1122: "}</comment>
+  </data>
+  <data name="PublishTrimmedRequiresVersion30" xml:space="preserve">
+    <value>NETSDK1123: Trimming assemblies requires .NET Core 3.0 or higher.</value>
+    <comment>{StrBegin="NETSDK1123: "}</comment>
+  </data>
+  <data name="CanOnlyCreateReadyToRunImagesForNetCoreApp" xml:space="preserve">
+    <value>NETSDK1124: ReadyToRun compilation will be skipped because it is only supported for netcoreapp targets.</value>
+    <comment>{StrBegin="NETSDK1124: "}</comment>
+  </data>
+  <data name="CanOnlyHaveSingleFileWithNetCoreApp" xml:space="preserve">
+    <value>NETSDK1125: Publishing to a single-file is only supported for netcoreapp target.</value>
+    <comment>{StrBegin="NETSDK1125: "}</comment>
+  </data>
+  <data name="CanOnlyTrimForNetCoreApp" xml:space="preserve">
+    <value>NETSDK1126: Trimming assemblies will be skipped because it is only supported for netcoreapp targets.</value>
+    <comment>{StrBegin="NETSDK1126: "}</comment>
+  </data>
+  <data name="CannotTrimForLibProjects" xml:space="preserve">
+    <value>NETSDK1127: Trimming assemblies will be skipped because it is only supported for executable projects.</value>
+    <comment>{StrBegin="NETSDK1127: "}</comment>
   </data>
 </root>

--- a/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
@@ -142,10 +142,30 @@
         <target state="translated">NETSDK1013: Hodnota TargetFramework {0} nebyla rozpoznána. Je možné, že obsahuje překlepy. Pokud tomu tak není, musíte vlastnosti TargetFrameworkIdentifier a TargetFrameworkVersion zadat explicitně.</target>
         <note>{StrBegin="NETSDK1013: "}</note>
       </trans-unit>
+      <trans-unit id="CannotTrimForLibProjects">
+        <source>NETSDK1127: Trimming assemblies will be skipped because it is only supported for executable projects.</source>
+        <target state="new">NETSDK1127: Trimming assemblies will be skipped because it is only supported for executable projects.</target>
+        <note>{StrBegin="NETSDK1127: "}</note>
+      </trans-unit>
       <trans-unit id="CannotUseSelfContainedWithoutAppHost">
         <source>NETSDK1067: Self-contained applications are required to use the application host. Either set SelfContained to false or set UseAppHost to true.</source>
         <target state="translated">NETSDK1067: K používání hostitele aplikace se vyžadují samostatné (nezávislé) aplikace. Nastavte možnost SelfContained na false nebo nastavte UseAppHost na true.</target>
         <note>{StrBegin="NETSDK1067: "}</note>
+      </trans-unit>
+      <trans-unit id="CanOnlyCreateReadyToRunImagesForNetCoreApp">
+        <source>NETSDK1124: ReadyToRun compilation will be skipped because it is only supported for netcoreapp targets.</source>
+        <target state="new">NETSDK1124: ReadyToRun compilation will be skipped because it is only supported for netcoreapp targets.</target>
+        <note>{StrBegin="NETSDK1124: "}</note>
+      </trans-unit>
+      <trans-unit id="CanOnlyHaveSingleFileWithNetCoreApp">
+        <source>NETSDK1125: Publishing to a single-file is only supported for netcoreapp target.</source>
+        <target state="new">NETSDK1125: Publishing to a single-file is only supported for netcoreapp target.</target>
+        <note>{StrBegin="NETSDK1125: "}</note>
+      </trans-unit>
+      <trans-unit id="CanOnlyTrimForNetCoreApp">
+        <source>NETSDK1126: Trimming assemblies will be skipped because it is only supported for netcoreapp targets.</source>
+        <target state="new">NETSDK1126: Trimming assemblies will be skipped because it is only supported for netcoreapp targets.</target>
+        <note>{StrBegin="NETSDK1126: "}</note>
       </trans-unit>
       <trans-unit id="ChoosingAssemblyVersion_Info">
         <source>Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</source>
@@ -472,9 +492,24 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1059: "}</note>
       </trans-unit>
       <trans-unit id="ProjectToolOnlySupportTFMLowerThanNetcoreapp22">
-        <source>NETSDK1093: NETSDK1093: Project tools (DotnetCliTool) only support targeting .NET Core 2.2 and lower.</source>
-        <target state="translated">NETSDK1093: NETSDK1093: Nástroje projektu (DotnetCliTool) podporují jen cílení na .NET Core 2.2 a nižší.</target>
+        <source>NETSDK1093: Project tools (DotnetCliTool) only support targeting .NET Core 2.2 and lower.</source>
+        <target state="translated">NETSDK1093: Nástroje projektu (DotnetCliTool) podporují jen cílení na .NET Core 2.2 a nižší.</target>
         <note>{StrBegin="NETSDK1093: "}</note>
+      </trans-unit>
+      <trans-unit id="PublishReadyToRunRequiresVersion30">
+        <source>NETSDK1121: ReadyToRun compilation will be skipped because it is only supported for .NET Core 3.0 or higher.</source>
+        <target state="new">NETSDK1121: ReadyToRun compilation will be skipped because it is only supported for .NET Core 3.0 or higher.</target>
+        <note>{StrBegin="NETSDK1121: "}</note>
+      </trans-unit>
+      <trans-unit id="PublishSingleFileRequiresVersion30">
+        <source>NETSDK1122: Publishing an application to a single-file requires .NET Core 3.0 or higher.</source>
+        <target state="new">NETSDK1122: Publishing an application to a single-file requires .NET Core 3.0 or higher.</target>
+        <note>{StrBegin="NETSDK1122: "}</note>
+      </trans-unit>
+      <trans-unit id="PublishTrimmedRequiresVersion30">
+        <source>NETSDK1123: Trimming assemblies requires .NET Core 3.0 or higher.</source>
+        <target state="new">NETSDK1123: Trimming assemblies requires .NET Core 3.0 or higher.</target>
+        <note>{StrBegin="NETSDK1123: "}</note>
       </trans-unit>
       <trans-unit id="ReadyToRunCompilationFailed">
         <source>NETSDK1096: Optimizing assemblies for performance failed. You can either exclude the failing assemblies from being optimized, or set the PublishReadyToRun property to false.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.de.xlf
@@ -142,10 +142,30 @@
         <target state="translated">NETSDK1013: Der TargetFramework-Wert "{0}" wurde nicht erkannt. Unter Umständen ist die Schreibweise nicht korrekt. Andernfalls müssen die Eigenschaften TargetFrameworkIdentifier und/oder TargetFrameworkVersion explizit angegeben werden.</target>
         <note>{StrBegin="NETSDK1013: "}</note>
       </trans-unit>
+      <trans-unit id="CannotTrimForLibProjects">
+        <source>NETSDK1127: Trimming assemblies will be skipped because it is only supported for executable projects.</source>
+        <target state="new">NETSDK1127: Trimming assemblies will be skipped because it is only supported for executable projects.</target>
+        <note>{StrBegin="NETSDK1127: "}</note>
+      </trans-unit>
       <trans-unit id="CannotUseSelfContainedWithoutAppHost">
         <source>NETSDK1067: Self-contained applications are required to use the application host. Either set SelfContained to false or set UseAppHost to true.</source>
         <target state="translated">NETSDK1067: Eigenständige Anwendungen müssen den Anwendungshost verwenden. Legen Sie "SelfContained" auf FALSE oder "UseAppHost" auf TRUE fest.</target>
         <note>{StrBegin="NETSDK1067: "}</note>
+      </trans-unit>
+      <trans-unit id="CanOnlyCreateReadyToRunImagesForNetCoreApp">
+        <source>NETSDK1124: ReadyToRun compilation will be skipped because it is only supported for netcoreapp targets.</source>
+        <target state="new">NETSDK1124: ReadyToRun compilation will be skipped because it is only supported for netcoreapp targets.</target>
+        <note>{StrBegin="NETSDK1124: "}</note>
+      </trans-unit>
+      <trans-unit id="CanOnlyHaveSingleFileWithNetCoreApp">
+        <source>NETSDK1125: Publishing to a single-file is only supported for netcoreapp target.</source>
+        <target state="new">NETSDK1125: Publishing to a single-file is only supported for netcoreapp target.</target>
+        <note>{StrBegin="NETSDK1125: "}</note>
+      </trans-unit>
+      <trans-unit id="CanOnlyTrimForNetCoreApp">
+        <source>NETSDK1126: Trimming assemblies will be skipped because it is only supported for netcoreapp targets.</source>
+        <target state="new">NETSDK1126: Trimming assemblies will be skipped because it is only supported for netcoreapp targets.</target>
+        <note>{StrBegin="NETSDK1126: "}</note>
       </trans-unit>
       <trans-unit id="ChoosingAssemblyVersion_Info">
         <source>Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</source>
@@ -472,9 +492,24 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1059: "}</note>
       </trans-unit>
       <trans-unit id="ProjectToolOnlySupportTFMLowerThanNetcoreapp22">
-        <source>NETSDK1093: NETSDK1093: Project tools (DotnetCliTool) only support targeting .NET Core 2.2 and lower.</source>
-        <target state="translated">NETSDK1093: NETSDK1093: Projekttools (DotnetCliTool) unterstützen als Ziel nur .NET Core 2.2 und früher.</target>
+        <source>NETSDK1093: Project tools (DotnetCliTool) only support targeting .NET Core 2.2 and lower.</source>
+        <target state="translated">NETSDK1093: Projekttools (DotnetCliTool) unterstützen als Ziel nur .NET Core 2.2 und früher.</target>
         <note>{StrBegin="NETSDK1093: "}</note>
+      </trans-unit>
+      <trans-unit id="PublishReadyToRunRequiresVersion30">
+        <source>NETSDK1121: ReadyToRun compilation will be skipped because it is only supported for .NET Core 3.0 or higher.</source>
+        <target state="new">NETSDK1121: ReadyToRun compilation will be skipped because it is only supported for .NET Core 3.0 or higher.</target>
+        <note>{StrBegin="NETSDK1121: "}</note>
+      </trans-unit>
+      <trans-unit id="PublishSingleFileRequiresVersion30">
+        <source>NETSDK1122: Publishing an application to a single-file requires .NET Core 3.0 or higher.</source>
+        <target state="new">NETSDK1122: Publishing an application to a single-file requires .NET Core 3.0 or higher.</target>
+        <note>{StrBegin="NETSDK1122: "}</note>
+      </trans-unit>
+      <trans-unit id="PublishTrimmedRequiresVersion30">
+        <source>NETSDK1123: Trimming assemblies requires .NET Core 3.0 or higher.</source>
+        <target state="new">NETSDK1123: Trimming assemblies requires .NET Core 3.0 or higher.</target>
+        <note>{StrBegin="NETSDK1123: "}</note>
       </trans-unit>
       <trans-unit id="ReadyToRunCompilationFailed">
         <source>NETSDK1096: Optimizing assemblies for performance failed. You can either exclude the failing assemblies from being optimized, or set the PublishReadyToRun property to false.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.es.xlf
@@ -142,10 +142,30 @@
         <target state="translated">NETSDK1013: El valor de TargetFramework "{0}" no se reconoció. Puede que esté mal escrito. Si este no es el caso, las propiedades TargetFrameworkIdentifier o TargetFrameworkVersion se deben especificar explícitamente.</target>
         <note>{StrBegin="NETSDK1013: "}</note>
       </trans-unit>
+      <trans-unit id="CannotTrimForLibProjects">
+        <source>NETSDK1127: Trimming assemblies will be skipped because it is only supported for executable projects.</source>
+        <target state="new">NETSDK1127: Trimming assemblies will be skipped because it is only supported for executable projects.</target>
+        <note>{StrBegin="NETSDK1127: "}</note>
+      </trans-unit>
       <trans-unit id="CannotUseSelfContainedWithoutAppHost">
         <source>NETSDK1067: Self-contained applications are required to use the application host. Either set SelfContained to false or set UseAppHost to true.</source>
         <target state="translated">NETSDK1067: Las aplicaciones independientes deben utilizar un host de aplicación. Establezca SelfContained en false o UseAppHost en true.</target>
         <note>{StrBegin="NETSDK1067: "}</note>
+      </trans-unit>
+      <trans-unit id="CanOnlyCreateReadyToRunImagesForNetCoreApp">
+        <source>NETSDK1124: ReadyToRun compilation will be skipped because it is only supported for netcoreapp targets.</source>
+        <target state="new">NETSDK1124: ReadyToRun compilation will be skipped because it is only supported for netcoreapp targets.</target>
+        <note>{StrBegin="NETSDK1124: "}</note>
+      </trans-unit>
+      <trans-unit id="CanOnlyHaveSingleFileWithNetCoreApp">
+        <source>NETSDK1125: Publishing to a single-file is only supported for netcoreapp target.</source>
+        <target state="new">NETSDK1125: Publishing to a single-file is only supported for netcoreapp target.</target>
+        <note>{StrBegin="NETSDK1125: "}</note>
+      </trans-unit>
+      <trans-unit id="CanOnlyTrimForNetCoreApp">
+        <source>NETSDK1126: Trimming assemblies will be skipped because it is only supported for netcoreapp targets.</source>
+        <target state="new">NETSDK1126: Trimming assemblies will be skipped because it is only supported for netcoreapp targets.</target>
+        <note>{StrBegin="NETSDK1126: "}</note>
       </trans-unit>
       <trans-unit id="ChoosingAssemblyVersion_Info">
         <source>Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</source>
@@ -472,9 +492,24 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1059: "}</note>
       </trans-unit>
       <trans-unit id="ProjectToolOnlySupportTFMLowerThanNetcoreapp22">
-        <source>NETSDK1093: NETSDK1093: Project tools (DotnetCliTool) only support targeting .NET Core 2.2 and lower.</source>
-        <target state="translated">NETSDK1093: NETSDK1093: Las herramientas de proyecto (DotnetCliTool) solo admiten como destino .NET Core 2.2 y versioes inferiores.</target>
+        <source>NETSDK1093: Project tools (DotnetCliTool) only support targeting .NET Core 2.2 and lower.</source>
+        <target state="translated">NETSDK1093: Las herramientas de proyecto (DotnetCliTool) solo admiten como destino .NET Core 2.2 y versioes inferiores.</target>
         <note>{StrBegin="NETSDK1093: "}</note>
+      </trans-unit>
+      <trans-unit id="PublishReadyToRunRequiresVersion30">
+        <source>NETSDK1121: ReadyToRun compilation will be skipped because it is only supported for .NET Core 3.0 or higher.</source>
+        <target state="new">NETSDK1121: ReadyToRun compilation will be skipped because it is only supported for .NET Core 3.0 or higher.</target>
+        <note>{StrBegin="NETSDK1121: "}</note>
+      </trans-unit>
+      <trans-unit id="PublishSingleFileRequiresVersion30">
+        <source>NETSDK1122: Publishing an application to a single-file requires .NET Core 3.0 or higher.</source>
+        <target state="new">NETSDK1122: Publishing an application to a single-file requires .NET Core 3.0 or higher.</target>
+        <note>{StrBegin="NETSDK1122: "}</note>
+      </trans-unit>
+      <trans-unit id="PublishTrimmedRequiresVersion30">
+        <source>NETSDK1123: Trimming assemblies requires .NET Core 3.0 or higher.</source>
+        <target state="new">NETSDK1123: Trimming assemblies requires .NET Core 3.0 or higher.</target>
+        <note>{StrBegin="NETSDK1123: "}</note>
       </trans-unit>
       <trans-unit id="ReadyToRunCompilationFailed">
         <source>NETSDK1096: Optimizing assemblies for performance failed. You can either exclude the failing assemblies from being optimized, or set the PublishReadyToRun property to false.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
@@ -142,10 +142,30 @@
         <target state="translated">NETSDK1013: La valeur TargetFramework '{0}' n'a pas été reconnue. Elle est peut-être mal orthographiée. Sinon, vous devez spécifier explicitement les propriétés TargetFrameworkIdentifier et/ou TargetFrameworkVersion.</target>
         <note>{StrBegin="NETSDK1013: "}</note>
       </trans-unit>
+      <trans-unit id="CannotTrimForLibProjects">
+        <source>NETSDK1127: Trimming assemblies will be skipped because it is only supported for executable projects.</source>
+        <target state="new">NETSDK1127: Trimming assemblies will be skipped because it is only supported for executable projects.</target>
+        <note>{StrBegin="NETSDK1127: "}</note>
+      </trans-unit>
       <trans-unit id="CannotUseSelfContainedWithoutAppHost">
         <source>NETSDK1067: Self-contained applications are required to use the application host. Either set SelfContained to false or set UseAppHost to true.</source>
         <target state="translated">NETSDK1067: Des applications autonomes sont obligatoires pour utiliser l'hôte d'application. Définissez SelfContained avec la valeur false ou UseAppHost avec la valeur true.</target>
         <note>{StrBegin="NETSDK1067: "}</note>
+      </trans-unit>
+      <trans-unit id="CanOnlyCreateReadyToRunImagesForNetCoreApp">
+        <source>NETSDK1124: ReadyToRun compilation will be skipped because it is only supported for netcoreapp targets.</source>
+        <target state="new">NETSDK1124: ReadyToRun compilation will be skipped because it is only supported for netcoreapp targets.</target>
+        <note>{StrBegin="NETSDK1124: "}</note>
+      </trans-unit>
+      <trans-unit id="CanOnlyHaveSingleFileWithNetCoreApp">
+        <source>NETSDK1125: Publishing to a single-file is only supported for netcoreapp target.</source>
+        <target state="new">NETSDK1125: Publishing to a single-file is only supported for netcoreapp target.</target>
+        <note>{StrBegin="NETSDK1125: "}</note>
+      </trans-unit>
+      <trans-unit id="CanOnlyTrimForNetCoreApp">
+        <source>NETSDK1126: Trimming assemblies will be skipped because it is only supported for netcoreapp targets.</source>
+        <target state="new">NETSDK1126: Trimming assemblies will be skipped because it is only supported for netcoreapp targets.</target>
+        <note>{StrBegin="NETSDK1126: "}</note>
       </trans-unit>
       <trans-unit id="ChoosingAssemblyVersion_Info">
         <source>Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</source>
@@ -472,9 +492,24 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1059: "}</note>
       </trans-unit>
       <trans-unit id="ProjectToolOnlySupportTFMLowerThanNetcoreapp22">
-        <source>NETSDK1093: NETSDK1093: Project tools (DotnetCliTool) only support targeting .NET Core 2.2 and lower.</source>
-        <target state="translated">NETSDK1093: NETSDK1093: les outils de projet (DotnetCliTool) prennent uniquement en charge le ciblage de .NET Core 2.2 et des versions antérieures.</target>
+        <source>NETSDK1093: Project tools (DotnetCliTool) only support targeting .NET Core 2.2 and lower.</source>
+        <target state="translated">NETSDK1093: les outils de projet (DotnetCliTool) prennent uniquement en charge le ciblage de .NET Core 2.2 et des versions antérieures.</target>
         <note>{StrBegin="NETSDK1093: "}</note>
+      </trans-unit>
+      <trans-unit id="PublishReadyToRunRequiresVersion30">
+        <source>NETSDK1121: ReadyToRun compilation will be skipped because it is only supported for .NET Core 3.0 or higher.</source>
+        <target state="new">NETSDK1121: ReadyToRun compilation will be skipped because it is only supported for .NET Core 3.0 or higher.</target>
+        <note>{StrBegin="NETSDK1121: "}</note>
+      </trans-unit>
+      <trans-unit id="PublishSingleFileRequiresVersion30">
+        <source>NETSDK1122: Publishing an application to a single-file requires .NET Core 3.0 or higher.</source>
+        <target state="new">NETSDK1122: Publishing an application to a single-file requires .NET Core 3.0 or higher.</target>
+        <note>{StrBegin="NETSDK1122: "}</note>
+      </trans-unit>
+      <trans-unit id="PublishTrimmedRequiresVersion30">
+        <source>NETSDK1123: Trimming assemblies requires .NET Core 3.0 or higher.</source>
+        <target state="new">NETSDK1123: Trimming assemblies requires .NET Core 3.0 or higher.</target>
+        <note>{StrBegin="NETSDK1123: "}</note>
       </trans-unit>
       <trans-unit id="ReadyToRunCompilationFailed">
         <source>NETSDK1096: Optimizing assemblies for performance failed. You can either exclude the failing assemblies from being optimized, or set the PublishReadyToRun property to false.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.it.xlf
@@ -142,10 +142,30 @@
         <target state="translated">NETSDK1013: il valore {0}' di TargetFramework non è stato riconosciuto. È possibile che sia stato digitato in modo errato. In caso contrario, le proprietà TargetFrameworkIdentifier e/o TargetFrameworkVersion devono essere specificate in modo esplicito.</target>
         <note>{StrBegin="NETSDK1013: "}</note>
       </trans-unit>
+      <trans-unit id="CannotTrimForLibProjects">
+        <source>NETSDK1127: Trimming assemblies will be skipped because it is only supported for executable projects.</source>
+        <target state="new">NETSDK1127: Trimming assemblies will be skipped because it is only supported for executable projects.</target>
+        <note>{StrBegin="NETSDK1127: "}</note>
+      </trans-unit>
       <trans-unit id="CannotUseSelfContainedWithoutAppHost">
         <source>NETSDK1067: Self-contained applications are required to use the application host. Either set SelfContained to false or set UseAppHost to true.</source>
         <target state="translated">NETSDK1067: con le applicazioni complete è necessario usare l'host applicazione. Impostare SelfContained su false o UseAppHost su true.</target>
         <note>{StrBegin="NETSDK1067: "}</note>
+      </trans-unit>
+      <trans-unit id="CanOnlyCreateReadyToRunImagesForNetCoreApp">
+        <source>NETSDK1124: ReadyToRun compilation will be skipped because it is only supported for netcoreapp targets.</source>
+        <target state="new">NETSDK1124: ReadyToRun compilation will be skipped because it is only supported for netcoreapp targets.</target>
+        <note>{StrBegin="NETSDK1124: "}</note>
+      </trans-unit>
+      <trans-unit id="CanOnlyHaveSingleFileWithNetCoreApp">
+        <source>NETSDK1125: Publishing to a single-file is only supported for netcoreapp target.</source>
+        <target state="new">NETSDK1125: Publishing to a single-file is only supported for netcoreapp target.</target>
+        <note>{StrBegin="NETSDK1125: "}</note>
+      </trans-unit>
+      <trans-unit id="CanOnlyTrimForNetCoreApp">
+        <source>NETSDK1126: Trimming assemblies will be skipped because it is only supported for netcoreapp targets.</source>
+        <target state="new">NETSDK1126: Trimming assemblies will be skipped because it is only supported for netcoreapp targets.</target>
+        <note>{StrBegin="NETSDK1126: "}</note>
       </trans-unit>
       <trans-unit id="ChoosingAssemblyVersion_Info">
         <source>Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</source>
@@ -472,9 +492,24 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1059: "}</note>
       </trans-unit>
       <trans-unit id="ProjectToolOnlySupportTFMLowerThanNetcoreapp22">
-        <source>NETSDK1093: NETSDK1093: Project tools (DotnetCliTool) only support targeting .NET Core 2.2 and lower.</source>
-        <target state="translated">NETSDK1093: NETSDK1093: gli strumenti del progetto (DotnetCliTool) supportano come destinazione solo .NET Core 2.2 e versioni precedenti.</target>
+        <source>NETSDK1093: Project tools (DotnetCliTool) only support targeting .NET Core 2.2 and lower.</source>
+        <target state="translated">NETSDK1093: gli strumenti del progetto (DotnetCliTool) supportano come destinazione solo .NET Core 2.2 e versioni precedenti.</target>
         <note>{StrBegin="NETSDK1093: "}</note>
+      </trans-unit>
+      <trans-unit id="PublishReadyToRunRequiresVersion30">
+        <source>NETSDK1121: ReadyToRun compilation will be skipped because it is only supported for .NET Core 3.0 or higher.</source>
+        <target state="new">NETSDK1121: ReadyToRun compilation will be skipped because it is only supported for .NET Core 3.0 or higher.</target>
+        <note>{StrBegin="NETSDK1121: "}</note>
+      </trans-unit>
+      <trans-unit id="PublishSingleFileRequiresVersion30">
+        <source>NETSDK1122: Publishing an application to a single-file requires .NET Core 3.0 or higher.</source>
+        <target state="new">NETSDK1122: Publishing an application to a single-file requires .NET Core 3.0 or higher.</target>
+        <note>{StrBegin="NETSDK1122: "}</note>
+      </trans-unit>
+      <trans-unit id="PublishTrimmedRequiresVersion30">
+        <source>NETSDK1123: Trimming assemblies requires .NET Core 3.0 or higher.</source>
+        <target state="new">NETSDK1123: Trimming assemblies requires .NET Core 3.0 or higher.</target>
+        <note>{StrBegin="NETSDK1123: "}</note>
       </trans-unit>
       <trans-unit id="ReadyToRunCompilationFailed">
         <source>NETSDK1096: Optimizing assemblies for performance failed. You can either exclude the failing assemblies from being optimized, or set the PublishReadyToRun property to false.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
@@ -142,10 +142,30 @@
         <target state="translated">NETSDK1013: TargetFramework 値 '{0}' が認識されませんでした。つづりが間違っている可能性があります。間違っていない場合は、TargetFrameworkIdentifier または TargetFrameworkVersion プロパティ (あるいはその両方) を明示的に指定する必要があります。</target>
         <note>{StrBegin="NETSDK1013: "}</note>
       </trans-unit>
+      <trans-unit id="CannotTrimForLibProjects">
+        <source>NETSDK1127: Trimming assemblies will be skipped because it is only supported for executable projects.</source>
+        <target state="new">NETSDK1127: Trimming assemblies will be skipped because it is only supported for executable projects.</target>
+        <note>{StrBegin="NETSDK1127: "}</note>
+      </trans-unit>
       <trans-unit id="CannotUseSelfContainedWithoutAppHost">
         <source>NETSDK1067: Self-contained applications are required to use the application host. Either set SelfContained to false or set UseAppHost to true.</source>
         <target state="translated">NETSDK1067: アプリケーション ホストを使用するには、自己完結型のアプリケーションが必要です。SelfContained を false に設定するか、UseAppHost を true に設定してください。</target>
         <note>{StrBegin="NETSDK1067: "}</note>
+      </trans-unit>
+      <trans-unit id="CanOnlyCreateReadyToRunImagesForNetCoreApp">
+        <source>NETSDK1124: ReadyToRun compilation will be skipped because it is only supported for netcoreapp targets.</source>
+        <target state="new">NETSDK1124: ReadyToRun compilation will be skipped because it is only supported for netcoreapp targets.</target>
+        <note>{StrBegin="NETSDK1124: "}</note>
+      </trans-unit>
+      <trans-unit id="CanOnlyHaveSingleFileWithNetCoreApp">
+        <source>NETSDK1125: Publishing to a single-file is only supported for netcoreapp target.</source>
+        <target state="new">NETSDK1125: Publishing to a single-file is only supported for netcoreapp target.</target>
+        <note>{StrBegin="NETSDK1125: "}</note>
+      </trans-unit>
+      <trans-unit id="CanOnlyTrimForNetCoreApp">
+        <source>NETSDK1126: Trimming assemblies will be skipped because it is only supported for netcoreapp targets.</source>
+        <target state="new">NETSDK1126: Trimming assemblies will be skipped because it is only supported for netcoreapp targets.</target>
+        <note>{StrBegin="NETSDK1126: "}</note>
       </trans-unit>
       <trans-unit id="ChoosingAssemblyVersion_Info">
         <source>Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</source>
@@ -472,9 +492,24 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1059: "}</note>
       </trans-unit>
       <trans-unit id="ProjectToolOnlySupportTFMLowerThanNetcoreapp22">
-        <source>NETSDK1093: NETSDK1093: Project tools (DotnetCliTool) only support targeting .NET Core 2.2 and lower.</source>
-        <target state="translated">NETSDK1093: NETSDK1093: プロジェクト ツール (DotnetCliTool) は、ターゲットが .NET Core 2.2 以下の場合のみサポートされます。</target>
+        <source>NETSDK1093: Project tools (DotnetCliTool) only support targeting .NET Core 2.2 and lower.</source>
+        <target state="translated">NETSDK1093: プロジェクト ツール (DotnetCliTool) は、ターゲットが .NET Core 2.2 以下の場合のみサポートされます。</target>
         <note>{StrBegin="NETSDK1093: "}</note>
+      </trans-unit>
+      <trans-unit id="PublishReadyToRunRequiresVersion30">
+        <source>NETSDK1121: ReadyToRun compilation will be skipped because it is only supported for .NET Core 3.0 or higher.</source>
+        <target state="new">NETSDK1121: ReadyToRun compilation will be skipped because it is only supported for .NET Core 3.0 or higher.</target>
+        <note>{StrBegin="NETSDK1121: "}</note>
+      </trans-unit>
+      <trans-unit id="PublishSingleFileRequiresVersion30">
+        <source>NETSDK1122: Publishing an application to a single-file requires .NET Core 3.0 or higher.</source>
+        <target state="new">NETSDK1122: Publishing an application to a single-file requires .NET Core 3.0 or higher.</target>
+        <note>{StrBegin="NETSDK1122: "}</note>
+      </trans-unit>
+      <trans-unit id="PublishTrimmedRequiresVersion30">
+        <source>NETSDK1123: Trimming assemblies requires .NET Core 3.0 or higher.</source>
+        <target state="new">NETSDK1123: Trimming assemblies requires .NET Core 3.0 or higher.</target>
+        <note>{StrBegin="NETSDK1123: "}</note>
       </trans-unit>
       <trans-unit id="ReadyToRunCompilationFailed">
         <source>NETSDK1096: Optimizing assemblies for performance failed. You can either exclude the failing assemblies from being optimized, or set the PublishReadyToRun property to false.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
@@ -142,10 +142,30 @@
         <target state="translated">NETSDK1013: TargetFramework 값 '{0}'을(를) 인식하지 못했습니다. 철자가 틀렸을 수 있습니다. 그렇지 않은 경우 TargetFrameworkIdentifier 및/또는 TargetFrameworkVersion 속성을 명시적으로 지정해야 합니다.</target>
         <note>{StrBegin="NETSDK1013: "}</note>
       </trans-unit>
+      <trans-unit id="CannotTrimForLibProjects">
+        <source>NETSDK1127: Trimming assemblies will be skipped because it is only supported for executable projects.</source>
+        <target state="new">NETSDK1127: Trimming assemblies will be skipped because it is only supported for executable projects.</target>
+        <note>{StrBegin="NETSDK1127: "}</note>
+      </trans-unit>
       <trans-unit id="CannotUseSelfContainedWithoutAppHost">
         <source>NETSDK1067: Self-contained applications are required to use the application host. Either set SelfContained to false or set UseAppHost to true.</source>
         <target state="translated">NETSDK1067: 애플리케이션 호스트를 사용하려면 자체 포함 애플리케이션이 필요합니다. SelfContained를 false로 설정하거나 UseAppHost를 true로 설정하세요.</target>
         <note>{StrBegin="NETSDK1067: "}</note>
+      </trans-unit>
+      <trans-unit id="CanOnlyCreateReadyToRunImagesForNetCoreApp">
+        <source>NETSDK1124: ReadyToRun compilation will be skipped because it is only supported for netcoreapp targets.</source>
+        <target state="new">NETSDK1124: ReadyToRun compilation will be skipped because it is only supported for netcoreapp targets.</target>
+        <note>{StrBegin="NETSDK1124: "}</note>
+      </trans-unit>
+      <trans-unit id="CanOnlyHaveSingleFileWithNetCoreApp">
+        <source>NETSDK1125: Publishing to a single-file is only supported for netcoreapp target.</source>
+        <target state="new">NETSDK1125: Publishing to a single-file is only supported for netcoreapp target.</target>
+        <note>{StrBegin="NETSDK1125: "}</note>
+      </trans-unit>
+      <trans-unit id="CanOnlyTrimForNetCoreApp">
+        <source>NETSDK1126: Trimming assemblies will be skipped because it is only supported for netcoreapp targets.</source>
+        <target state="new">NETSDK1126: Trimming assemblies will be skipped because it is only supported for netcoreapp targets.</target>
+        <note>{StrBegin="NETSDK1126: "}</note>
       </trans-unit>
       <trans-unit id="ChoosingAssemblyVersion_Info">
         <source>Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</source>
@@ -472,9 +492,24 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1059: "}</note>
       </trans-unit>
       <trans-unit id="ProjectToolOnlySupportTFMLowerThanNetcoreapp22">
-        <source>NETSDK1093: NETSDK1093: Project tools (DotnetCliTool) only support targeting .NET Core 2.2 and lower.</source>
-        <target state="translated">NETSDK1093: NETSDK1093: 프로젝트 도구(DotnetCliTool)는 .NET Core 2.2 이하를 대상으로 하는 경우만 지원합니다.</target>
+        <source>NETSDK1093: Project tools (DotnetCliTool) only support targeting .NET Core 2.2 and lower.</source>
+        <target state="translated">NETSDK1093: 프로젝트 도구(DotnetCliTool)는 .NET Core 2.2 이하를 대상으로 하는 경우만 지원합니다.</target>
         <note>{StrBegin="NETSDK1093: "}</note>
+      </trans-unit>
+      <trans-unit id="PublishReadyToRunRequiresVersion30">
+        <source>NETSDK1121: ReadyToRun compilation will be skipped because it is only supported for .NET Core 3.0 or higher.</source>
+        <target state="new">NETSDK1121: ReadyToRun compilation will be skipped because it is only supported for .NET Core 3.0 or higher.</target>
+        <note>{StrBegin="NETSDK1121: "}</note>
+      </trans-unit>
+      <trans-unit id="PublishSingleFileRequiresVersion30">
+        <source>NETSDK1122: Publishing an application to a single-file requires .NET Core 3.0 or higher.</source>
+        <target state="new">NETSDK1122: Publishing an application to a single-file requires .NET Core 3.0 or higher.</target>
+        <note>{StrBegin="NETSDK1122: "}</note>
+      </trans-unit>
+      <trans-unit id="PublishTrimmedRequiresVersion30">
+        <source>NETSDK1123: Trimming assemblies requires .NET Core 3.0 or higher.</source>
+        <target state="new">NETSDK1123: Trimming assemblies requires .NET Core 3.0 or higher.</target>
+        <note>{StrBegin="NETSDK1123: "}</note>
       </trans-unit>
       <trans-unit id="ReadyToRunCompilationFailed">
         <source>NETSDK1096: Optimizing assemblies for performance failed. You can either exclude the failing assemblies from being optimized, or set the PublishReadyToRun property to false.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
@@ -142,10 +142,30 @@
         <target state="translated">NETSDK1013: Nie rozpoznano wartości „{0}” elementu TargetFramework. Być może wpisano ją niepoprawnie. Jeśli nie, należy jawnie określić właściwości TargetFrameworkIdentifier i/lub TargetFrameworkVersion.</target>
         <note>{StrBegin="NETSDK1013: "}</note>
       </trans-unit>
+      <trans-unit id="CannotTrimForLibProjects">
+        <source>NETSDK1127: Trimming assemblies will be skipped because it is only supported for executable projects.</source>
+        <target state="new">NETSDK1127: Trimming assemblies will be skipped because it is only supported for executable projects.</target>
+        <note>{StrBegin="NETSDK1127: "}</note>
+      </trans-unit>
       <trans-unit id="CannotUseSelfContainedWithoutAppHost">
         <source>NETSDK1067: Self-contained applications are required to use the application host. Either set SelfContained to false or set UseAppHost to true.</source>
         <target state="translated">NETSDK1067: Aplikacje autonomiczne muszą korzystać z hosta aplikacji. Ustaw parametr SelfContained na wartość false lub parametr UseAppHost na wartość true.</target>
         <note>{StrBegin="NETSDK1067: "}</note>
+      </trans-unit>
+      <trans-unit id="CanOnlyCreateReadyToRunImagesForNetCoreApp">
+        <source>NETSDK1124: ReadyToRun compilation will be skipped because it is only supported for netcoreapp targets.</source>
+        <target state="new">NETSDK1124: ReadyToRun compilation will be skipped because it is only supported for netcoreapp targets.</target>
+        <note>{StrBegin="NETSDK1124: "}</note>
+      </trans-unit>
+      <trans-unit id="CanOnlyHaveSingleFileWithNetCoreApp">
+        <source>NETSDK1125: Publishing to a single-file is only supported for netcoreapp target.</source>
+        <target state="new">NETSDK1125: Publishing to a single-file is only supported for netcoreapp target.</target>
+        <note>{StrBegin="NETSDK1125: "}</note>
+      </trans-unit>
+      <trans-unit id="CanOnlyTrimForNetCoreApp">
+        <source>NETSDK1126: Trimming assemblies will be skipped because it is only supported for netcoreapp targets.</source>
+        <target state="new">NETSDK1126: Trimming assemblies will be skipped because it is only supported for netcoreapp targets.</target>
+        <note>{StrBegin="NETSDK1126: "}</note>
       </trans-unit>
       <trans-unit id="ChoosingAssemblyVersion_Info">
         <source>Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</source>
@@ -472,9 +492,24 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1059: "}</note>
       </trans-unit>
       <trans-unit id="ProjectToolOnlySupportTFMLowerThanNetcoreapp22">
-        <source>NETSDK1093: NETSDK1093: Project tools (DotnetCliTool) only support targeting .NET Core 2.2 and lower.</source>
+        <source>NETSDK1093: Project tools (DotnetCliTool) only support targeting .NET Core 2.2 and lower.</source>
         <target state="translated">NETSDK1093: Narzędzia projektu (DotnetCliTool) obsługują tylko ukierunkowanie na program .NET Core w wersji 2.2 lub niższej.</target>
         <note>{StrBegin="NETSDK1093: "}</note>
+      </trans-unit>
+      <trans-unit id="PublishReadyToRunRequiresVersion30">
+        <source>NETSDK1121: ReadyToRun compilation will be skipped because it is only supported for .NET Core 3.0 or higher.</source>
+        <target state="new">NETSDK1121: ReadyToRun compilation will be skipped because it is only supported for .NET Core 3.0 or higher.</target>
+        <note>{StrBegin="NETSDK1121: "}</note>
+      </trans-unit>
+      <trans-unit id="PublishSingleFileRequiresVersion30">
+        <source>NETSDK1122: Publishing an application to a single-file requires .NET Core 3.0 or higher.</source>
+        <target state="new">NETSDK1122: Publishing an application to a single-file requires .NET Core 3.0 or higher.</target>
+        <note>{StrBegin="NETSDK1122: "}</note>
+      </trans-unit>
+      <trans-unit id="PublishTrimmedRequiresVersion30">
+        <source>NETSDK1123: Trimming assemblies requires .NET Core 3.0 or higher.</source>
+        <target state="new">NETSDK1123: Trimming assemblies requires .NET Core 3.0 or higher.</target>
+        <note>{StrBegin="NETSDK1123: "}</note>
       </trans-unit>
       <trans-unit id="ReadyToRunCompilationFailed">
         <source>NETSDK1096: Optimizing assemblies for performance failed. You can either exclude the failing assemblies from being optimized, or set the PublishReadyToRun property to false.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
@@ -142,10 +142,30 @@
         <target state="translated">NETSDK1013: O valor '{0}' do TargetFramework não foi reconhecido. Ele pode ter sido escrito com ortografia incorreta. Caso contrário, as propriedades TargetFrameworkIdentifier e/ou TargetFrameworkVersion precisarão ser especificadas explicitamente.</target>
         <note>{StrBegin="NETSDK1013: "}</note>
       </trans-unit>
+      <trans-unit id="CannotTrimForLibProjects">
+        <source>NETSDK1127: Trimming assemblies will be skipped because it is only supported for executable projects.</source>
+        <target state="new">NETSDK1127: Trimming assemblies will be skipped because it is only supported for executable projects.</target>
+        <note>{StrBegin="NETSDK1127: "}</note>
+      </trans-unit>
       <trans-unit id="CannotUseSelfContainedWithoutAppHost">
         <source>NETSDK1067: Self-contained applications are required to use the application host. Either set SelfContained to false or set UseAppHost to true.</source>
         <target state="translated">NETSDK1067: os aplicativos independentes são necessários para utilizar o host do aplicativo. Defina SelfContained como falso ou defina UseAppHost como verdadeiro.</target>
         <note>{StrBegin="NETSDK1067: "}</note>
+      </trans-unit>
+      <trans-unit id="CanOnlyCreateReadyToRunImagesForNetCoreApp">
+        <source>NETSDK1124: ReadyToRun compilation will be skipped because it is only supported for netcoreapp targets.</source>
+        <target state="new">NETSDK1124: ReadyToRun compilation will be skipped because it is only supported for netcoreapp targets.</target>
+        <note>{StrBegin="NETSDK1124: "}</note>
+      </trans-unit>
+      <trans-unit id="CanOnlyHaveSingleFileWithNetCoreApp">
+        <source>NETSDK1125: Publishing to a single-file is only supported for netcoreapp target.</source>
+        <target state="new">NETSDK1125: Publishing to a single-file is only supported for netcoreapp target.</target>
+        <note>{StrBegin="NETSDK1125: "}</note>
+      </trans-unit>
+      <trans-unit id="CanOnlyTrimForNetCoreApp">
+        <source>NETSDK1126: Trimming assemblies will be skipped because it is only supported for netcoreapp targets.</source>
+        <target state="new">NETSDK1126: Trimming assemblies will be skipped because it is only supported for netcoreapp targets.</target>
+        <note>{StrBegin="NETSDK1126: "}</note>
       </trans-unit>
       <trans-unit id="ChoosingAssemblyVersion_Info">
         <source>Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</source>
@@ -472,9 +492,24 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1059: "}</note>
       </trans-unit>
       <trans-unit id="ProjectToolOnlySupportTFMLowerThanNetcoreapp22">
-        <source>NETSDK1093: NETSDK1093: Project tools (DotnetCliTool) only support targeting .NET Core 2.2 and lower.</source>
-        <target state="translated">NETSDK1093: NETSDK1093: as ferramentas de projeto (DotnetCliTool) são suporte somente o .NET Core 2.2 e inferior.</target>
+        <source>NETSDK1093: Project tools (DotnetCliTool) only support targeting .NET Core 2.2 and lower.</source>
+        <target state="translated">NETSDK1093: as ferramentas de projeto (DotnetCliTool) são suporte somente o .NET Core 2.2 e inferior.</target>
         <note>{StrBegin="NETSDK1093: "}</note>
+      </trans-unit>
+      <trans-unit id="PublishReadyToRunRequiresVersion30">
+        <source>NETSDK1121: ReadyToRun compilation will be skipped because it is only supported for .NET Core 3.0 or higher.</source>
+        <target state="new">NETSDK1121: ReadyToRun compilation will be skipped because it is only supported for .NET Core 3.0 or higher.</target>
+        <note>{StrBegin="NETSDK1121: "}</note>
+      </trans-unit>
+      <trans-unit id="PublishSingleFileRequiresVersion30">
+        <source>NETSDK1122: Publishing an application to a single-file requires .NET Core 3.0 or higher.</source>
+        <target state="new">NETSDK1122: Publishing an application to a single-file requires .NET Core 3.0 or higher.</target>
+        <note>{StrBegin="NETSDK1122: "}</note>
+      </trans-unit>
+      <trans-unit id="PublishTrimmedRequiresVersion30">
+        <source>NETSDK1123: Trimming assemblies requires .NET Core 3.0 or higher.</source>
+        <target state="new">NETSDK1123: Trimming assemblies requires .NET Core 3.0 or higher.</target>
+        <note>{StrBegin="NETSDK1123: "}</note>
       </trans-unit>
       <trans-unit id="ReadyToRunCompilationFailed">
         <source>NETSDK1096: Optimizing assemblies for performance failed. You can either exclude the failing assemblies from being optimized, or set the PublishReadyToRun property to false.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
@@ -142,10 +142,30 @@
         <target state="translated">NETSDK1013: значение "{0}" в TargetFramework не распознано. Возможно, оно содержит опечатку. Если это не так, задайте свойства TargetFrameworkIdentifier и (или) TargetFrameworkVersion явным образом.</target>
         <note>{StrBegin="NETSDK1013: "}</note>
       </trans-unit>
+      <trans-unit id="CannotTrimForLibProjects">
+        <source>NETSDK1127: Trimming assemblies will be skipped because it is only supported for executable projects.</source>
+        <target state="new">NETSDK1127: Trimming assemblies will be skipped because it is only supported for executable projects.</target>
+        <note>{StrBegin="NETSDK1127: "}</note>
+      </trans-unit>
       <trans-unit id="CannotUseSelfContainedWithoutAppHost">
         <source>NETSDK1067: Self-contained applications are required to use the application host. Either set SelfContained to false or set UseAppHost to true.</source>
         <target state="translated">NETSDK1067: для использования узла приложений требуются автономные приложения. Задайте свойству SelfContained значение false или задайте свойству UseAppHost значение true.</target>
         <note>{StrBegin="NETSDK1067: "}</note>
+      </trans-unit>
+      <trans-unit id="CanOnlyCreateReadyToRunImagesForNetCoreApp">
+        <source>NETSDK1124: ReadyToRun compilation will be skipped because it is only supported for netcoreapp targets.</source>
+        <target state="new">NETSDK1124: ReadyToRun compilation will be skipped because it is only supported for netcoreapp targets.</target>
+        <note>{StrBegin="NETSDK1124: "}</note>
+      </trans-unit>
+      <trans-unit id="CanOnlyHaveSingleFileWithNetCoreApp">
+        <source>NETSDK1125: Publishing to a single-file is only supported for netcoreapp target.</source>
+        <target state="new">NETSDK1125: Publishing to a single-file is only supported for netcoreapp target.</target>
+        <note>{StrBegin="NETSDK1125: "}</note>
+      </trans-unit>
+      <trans-unit id="CanOnlyTrimForNetCoreApp">
+        <source>NETSDK1126: Trimming assemblies will be skipped because it is only supported for netcoreapp targets.</source>
+        <target state="new">NETSDK1126: Trimming assemblies will be skipped because it is only supported for netcoreapp targets.</target>
+        <note>{StrBegin="NETSDK1126: "}</note>
       </trans-unit>
       <trans-unit id="ChoosingAssemblyVersion_Info">
         <source>Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</source>
@@ -472,9 +492,24 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1059: "}</note>
       </trans-unit>
       <trans-unit id="ProjectToolOnlySupportTFMLowerThanNetcoreapp22">
-        <source>NETSDK1093: NETSDK1093: Project tools (DotnetCliTool) only support targeting .NET Core 2.2 and lower.</source>
-        <target state="translated">NETSDK1093: NETSDK1093: средства проекта (DotnetCliTool) поддерживают только ориентацию на .NET Core 2.2 и более низких версий.</target>
+        <source>NETSDK1093: Project tools (DotnetCliTool) only support targeting .NET Core 2.2 and lower.</source>
+        <target state="translated">NETSDK1093: средства проекта (DotnetCliTool) поддерживают только ориентацию на .NET Core 2.2 и более низких версий.</target>
         <note>{StrBegin="NETSDK1093: "}</note>
+      </trans-unit>
+      <trans-unit id="PublishReadyToRunRequiresVersion30">
+        <source>NETSDK1121: ReadyToRun compilation will be skipped because it is only supported for .NET Core 3.0 or higher.</source>
+        <target state="new">NETSDK1121: ReadyToRun compilation will be skipped because it is only supported for .NET Core 3.0 or higher.</target>
+        <note>{StrBegin="NETSDK1121: "}</note>
+      </trans-unit>
+      <trans-unit id="PublishSingleFileRequiresVersion30">
+        <source>NETSDK1122: Publishing an application to a single-file requires .NET Core 3.0 or higher.</source>
+        <target state="new">NETSDK1122: Publishing an application to a single-file requires .NET Core 3.0 or higher.</target>
+        <note>{StrBegin="NETSDK1122: "}</note>
+      </trans-unit>
+      <trans-unit id="PublishTrimmedRequiresVersion30">
+        <source>NETSDK1123: Trimming assemblies requires .NET Core 3.0 or higher.</source>
+        <target state="new">NETSDK1123: Trimming assemblies requires .NET Core 3.0 or higher.</target>
+        <note>{StrBegin="NETSDK1123: "}</note>
       </trans-unit>
       <trans-unit id="ReadyToRunCompilationFailed">
         <source>NETSDK1096: Optimizing assemblies for performance failed. You can either exclude the failing assemblies from being optimized, or set the PublishReadyToRun property to false.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
@@ -142,10 +142,30 @@
         <target state="translated">NETSDK1013: '{0}' TargetFramework değeri tanınmadı. Yanlış yazılmış olabilir. Sorun bundan kaynaklanmıyorsa, TargetFrameworkIdentifier ve/veya TargetFrameworkVersion özelliklerinin açık bir şekilde belirtilmesi gerekir.</target>
         <note>{StrBegin="NETSDK1013: "}</note>
       </trans-unit>
+      <trans-unit id="CannotTrimForLibProjects">
+        <source>NETSDK1127: Trimming assemblies will be skipped because it is only supported for executable projects.</source>
+        <target state="new">NETSDK1127: Trimming assemblies will be skipped because it is only supported for executable projects.</target>
+        <note>{StrBegin="NETSDK1127: "}</note>
+      </trans-unit>
       <trans-unit id="CannotUseSelfContainedWithoutAppHost">
         <source>NETSDK1067: Self-contained applications are required to use the application host. Either set SelfContained to false or set UseAppHost to true.</source>
         <target state="translated">NETSDK1067: Kendi başına kapsanan uygulamaların uygulama konağını kullanması gerekir. SelfContained değerini false olarak ya da UseAppHost değerini true olarak ayarlayın.</target>
         <note>{StrBegin="NETSDK1067: "}</note>
+      </trans-unit>
+      <trans-unit id="CanOnlyCreateReadyToRunImagesForNetCoreApp">
+        <source>NETSDK1124: ReadyToRun compilation will be skipped because it is only supported for netcoreapp targets.</source>
+        <target state="new">NETSDK1124: ReadyToRun compilation will be skipped because it is only supported for netcoreapp targets.</target>
+        <note>{StrBegin="NETSDK1124: "}</note>
+      </trans-unit>
+      <trans-unit id="CanOnlyHaveSingleFileWithNetCoreApp">
+        <source>NETSDK1125: Publishing to a single-file is only supported for netcoreapp target.</source>
+        <target state="new">NETSDK1125: Publishing to a single-file is only supported for netcoreapp target.</target>
+        <note>{StrBegin="NETSDK1125: "}</note>
+      </trans-unit>
+      <trans-unit id="CanOnlyTrimForNetCoreApp">
+        <source>NETSDK1126: Trimming assemblies will be skipped because it is only supported for netcoreapp targets.</source>
+        <target state="new">NETSDK1126: Trimming assemblies will be skipped because it is only supported for netcoreapp targets.</target>
+        <note>{StrBegin="NETSDK1126: "}</note>
       </trans-unit>
       <trans-unit id="ChoosingAssemblyVersion_Info">
         <source>Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</source>
@@ -472,9 +492,24 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1059: "}</note>
       </trans-unit>
       <trans-unit id="ProjectToolOnlySupportTFMLowerThanNetcoreapp22">
-        <source>NETSDK1093: NETSDK1093: Project tools (DotnetCliTool) only support targeting .NET Core 2.2 and lower.</source>
-        <target state="translated">NETSDK1093: NETSDK1093: Proje araçları (DotnetCliTool) yalnızca .NET Core 2.2 veya altını hedeflemeyi destekliyor.</target>
+        <source>NETSDK1093: Project tools (DotnetCliTool) only support targeting .NET Core 2.2 and lower.</source>
+        <target state="translated">NETSDK1093: Proje araçları (DotnetCliTool) yalnızca .NET Core 2.2 veya altını hedeflemeyi destekliyor.</target>
         <note>{StrBegin="NETSDK1093: "}</note>
+      </trans-unit>
+      <trans-unit id="PublishReadyToRunRequiresVersion30">
+        <source>NETSDK1121: ReadyToRun compilation will be skipped because it is only supported for .NET Core 3.0 or higher.</source>
+        <target state="new">NETSDK1121: ReadyToRun compilation will be skipped because it is only supported for .NET Core 3.0 or higher.</target>
+        <note>{StrBegin="NETSDK1121: "}</note>
+      </trans-unit>
+      <trans-unit id="PublishSingleFileRequiresVersion30">
+        <source>NETSDK1122: Publishing an application to a single-file requires .NET Core 3.0 or higher.</source>
+        <target state="new">NETSDK1122: Publishing an application to a single-file requires .NET Core 3.0 or higher.</target>
+        <note>{StrBegin="NETSDK1122: "}</note>
+      </trans-unit>
+      <trans-unit id="PublishTrimmedRequiresVersion30">
+        <source>NETSDK1123: Trimming assemblies requires .NET Core 3.0 or higher.</source>
+        <target state="new">NETSDK1123: Trimming assemblies requires .NET Core 3.0 or higher.</target>
+        <note>{StrBegin="NETSDK1123: "}</note>
       </trans-unit>
       <trans-unit id="ReadyToRunCompilationFailed">
         <source>NETSDK1096: Optimizing assemblies for performance failed. You can either exclude the failing assemblies from being optimized, or set the PublishReadyToRun property to false.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
@@ -142,10 +142,30 @@
         <target state="translated">NETSDK1013: 未识别 TargetFramework 值“{0}”。可能是因为拼写错误。如果拼写正确，必须显式指定 TargetFrameworkIdentifier 和/或 TargetFrameworkVersion 属性。</target>
         <note>{StrBegin="NETSDK1013: "}</note>
       </trans-unit>
+      <trans-unit id="CannotTrimForLibProjects">
+        <source>NETSDK1127: Trimming assemblies will be skipped because it is only supported for executable projects.</source>
+        <target state="new">NETSDK1127: Trimming assemblies will be skipped because it is only supported for executable projects.</target>
+        <note>{StrBegin="NETSDK1127: "}</note>
+      </trans-unit>
       <trans-unit id="CannotUseSelfContainedWithoutAppHost">
         <source>NETSDK1067: Self-contained applications are required to use the application host. Either set SelfContained to false or set UseAppHost to true.</source>
         <target state="translated">NETSDK1067: 需要自包含应用程序才能使用应用程序主机。将 SelfContained 设置为 false，或者将 UseAppHost 设置为 true。</target>
         <note>{StrBegin="NETSDK1067: "}</note>
+      </trans-unit>
+      <trans-unit id="CanOnlyCreateReadyToRunImagesForNetCoreApp">
+        <source>NETSDK1124: ReadyToRun compilation will be skipped because it is only supported for netcoreapp targets.</source>
+        <target state="new">NETSDK1124: ReadyToRun compilation will be skipped because it is only supported for netcoreapp targets.</target>
+        <note>{StrBegin="NETSDK1124: "}</note>
+      </trans-unit>
+      <trans-unit id="CanOnlyHaveSingleFileWithNetCoreApp">
+        <source>NETSDK1125: Publishing to a single-file is only supported for netcoreapp target.</source>
+        <target state="new">NETSDK1125: Publishing to a single-file is only supported for netcoreapp target.</target>
+        <note>{StrBegin="NETSDK1125: "}</note>
+      </trans-unit>
+      <trans-unit id="CanOnlyTrimForNetCoreApp">
+        <source>NETSDK1126: Trimming assemblies will be skipped because it is only supported for netcoreapp targets.</source>
+        <target state="new">NETSDK1126: Trimming assemblies will be skipped because it is only supported for netcoreapp targets.</target>
+        <note>{StrBegin="NETSDK1126: "}</note>
       </trans-unit>
       <trans-unit id="ChoosingAssemblyVersion_Info">
         <source>Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</source>
@@ -472,9 +492,24 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1059: "}</note>
       </trans-unit>
       <trans-unit id="ProjectToolOnlySupportTFMLowerThanNetcoreapp22">
-        <source>NETSDK1093: NETSDK1093: Project tools (DotnetCliTool) only support targeting .NET Core 2.2 and lower.</source>
-        <target state="translated">NETSDK1093: NETSDK1093: 项目工具(DotnetCliTool)仅支持面向 .NET Core 2.2 及更低版本。</target>
+        <source>NETSDK1093: Project tools (DotnetCliTool) only support targeting .NET Core 2.2 and lower.</source>
+        <target state="translated">NETSDK1093: 项目工具(DotnetCliTool)仅支持面向 .NET Core 2.2 及更低版本。</target>
         <note>{StrBegin="NETSDK1093: "}</note>
+      </trans-unit>
+      <trans-unit id="PublishReadyToRunRequiresVersion30">
+        <source>NETSDK1121: ReadyToRun compilation will be skipped because it is only supported for .NET Core 3.0 or higher.</source>
+        <target state="new">NETSDK1121: ReadyToRun compilation will be skipped because it is only supported for .NET Core 3.0 or higher.</target>
+        <note>{StrBegin="NETSDK1121: "}</note>
+      </trans-unit>
+      <trans-unit id="PublishSingleFileRequiresVersion30">
+        <source>NETSDK1122: Publishing an application to a single-file requires .NET Core 3.0 or higher.</source>
+        <target state="new">NETSDK1122: Publishing an application to a single-file requires .NET Core 3.0 or higher.</target>
+        <note>{StrBegin="NETSDK1122: "}</note>
+      </trans-unit>
+      <trans-unit id="PublishTrimmedRequiresVersion30">
+        <source>NETSDK1123: Trimming assemblies requires .NET Core 3.0 or higher.</source>
+        <target state="new">NETSDK1123: Trimming assemblies requires .NET Core 3.0 or higher.</target>
+        <note>{StrBegin="NETSDK1123: "}</note>
       </trans-unit>
       <trans-unit id="ReadyToRunCompilationFailed">
         <source>NETSDK1096: Optimizing assemblies for performance failed. You can either exclude the failing assemblies from being optimized, or set the PublishReadyToRun property to false.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
@@ -142,10 +142,30 @@
         <target state="translated">NETSDK1013: 無法辨識 TargetFramework 值 '{0}'。拼字可能有誤。若非此情況，即必須明確指定 TargetFrameworkIdentifier 及 (或) TargetFrameworkVersion 屬性。</target>
         <note>{StrBegin="NETSDK1013: "}</note>
       </trans-unit>
+      <trans-unit id="CannotTrimForLibProjects">
+        <source>NETSDK1127: Trimming assemblies will be skipped because it is only supported for executable projects.</source>
+        <target state="new">NETSDK1127: Trimming assemblies will be skipped because it is only supported for executable projects.</target>
+        <note>{StrBegin="NETSDK1127: "}</note>
+      </trans-unit>
       <trans-unit id="CannotUseSelfContainedWithoutAppHost">
         <source>NETSDK1067: Self-contained applications are required to use the application host. Either set SelfContained to false or set UseAppHost to true.</source>
         <target state="translated">NETSDK1067: 需要獨立式應用程式，才可使用該應用程式主機。請將 SelfContained 設定為 False，或是將 UseAppHost 設定為 True。</target>
         <note>{StrBegin="NETSDK1067: "}</note>
+      </trans-unit>
+      <trans-unit id="CanOnlyCreateReadyToRunImagesForNetCoreApp">
+        <source>NETSDK1124: ReadyToRun compilation will be skipped because it is only supported for netcoreapp targets.</source>
+        <target state="new">NETSDK1124: ReadyToRun compilation will be skipped because it is only supported for netcoreapp targets.</target>
+        <note>{StrBegin="NETSDK1124: "}</note>
+      </trans-unit>
+      <trans-unit id="CanOnlyHaveSingleFileWithNetCoreApp">
+        <source>NETSDK1125: Publishing to a single-file is only supported for netcoreapp target.</source>
+        <target state="new">NETSDK1125: Publishing to a single-file is only supported for netcoreapp target.</target>
+        <note>{StrBegin="NETSDK1125: "}</note>
+      </trans-unit>
+      <trans-unit id="CanOnlyTrimForNetCoreApp">
+        <source>NETSDK1126: Trimming assemblies will be skipped because it is only supported for netcoreapp targets.</source>
+        <target state="new">NETSDK1126: Trimming assemblies will be skipped because it is only supported for netcoreapp targets.</target>
+        <note>{StrBegin="NETSDK1126: "}</note>
       </trans-unit>
       <trans-unit id="ChoosingAssemblyVersion_Info">
         <source>Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</source>
@@ -472,9 +492,24 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1059: "}</note>
       </trans-unit>
       <trans-unit id="ProjectToolOnlySupportTFMLowerThanNetcoreapp22">
-        <source>NETSDK1093: NETSDK1093: Project tools (DotnetCliTool) only support targeting .NET Core 2.2 and lower.</source>
-        <target state="translated">NETSDK1093: NETSDK1093: 專案工具 (DotnetCliTool) 僅支援目標為 .NET Core 2.2 或更低的版本。</target>
+        <source>NETSDK1093: Project tools (DotnetCliTool) only support targeting .NET Core 2.2 and lower.</source>
+        <target state="translated">NETSDK1093: 專案工具 (DotnetCliTool) 僅支援目標為 .NET Core 2.2 或更低的版本。</target>
         <note>{StrBegin="NETSDK1093: "}</note>
+      </trans-unit>
+      <trans-unit id="PublishReadyToRunRequiresVersion30">
+        <source>NETSDK1121: ReadyToRun compilation will be skipped because it is only supported for .NET Core 3.0 or higher.</source>
+        <target state="new">NETSDK1121: ReadyToRun compilation will be skipped because it is only supported for .NET Core 3.0 or higher.</target>
+        <note>{StrBegin="NETSDK1121: "}</note>
+      </trans-unit>
+      <trans-unit id="PublishSingleFileRequiresVersion30">
+        <source>NETSDK1122: Publishing an application to a single-file requires .NET Core 3.0 or higher.</source>
+        <target state="new">NETSDK1122: Publishing an application to a single-file requires .NET Core 3.0 or higher.</target>
+        <note>{StrBegin="NETSDK1122: "}</note>
+      </trans-unit>
+      <trans-unit id="PublishTrimmedRequiresVersion30">
+        <source>NETSDK1123: Trimming assemblies requires .NET Core 3.0 or higher.</source>
+        <target state="new">NETSDK1123: Trimming assemblies requires .NET Core 3.0 or higher.</target>
+        <note>{StrBegin="NETSDK1123: "}</note>
       </trans-unit>
       <trans-unit id="ReadyToRunCompilationFailed">
         <source>NETSDK1096: Optimizing assemblies for performance failed. You can either exclude the failing assemblies from being optimized, or set the PublishReadyToRun property to false.</source>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -90,9 +90,21 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <NETSdkError Condition="'$(PublishSingleFile)' == 'true' And '$(_IsExecutable)' != 'true'"
                  ResourceName="CannotHaveSingleFileWithoutExecutable" />
+    <NETSdkError Condition="'$(PublishSingleFile)' == 'true' And '$(_IsExecutable)' == 'true' And '$(TargetFrameworkIdentifier)' != '.NETCoreApp'"
+                 ResourceName="CanOnlyHaveSingleFileWithNetCoreApp" />
+
+    <!-- The checks for PublishReadyToRun PublishTrimmed only generate warnings. 
+         Here, the constraints are an implementation/validation requirement, and may be relaxed in future releases. -->
 
     <NETSdkWarning Condition="'$(PublishReadyToRun)' == 'true' And '$(_IsExecutable)' != 'true'"
                  ResourceName="CannotCreateReadyToRunImagesForLibProjects" />
+    <NETSdkWarning Condition="'$(PublishReadyToRun)' == 'true' And '$(_IsExecutable)' == 'true' And '$(TargetFrameworkIdentifier)' != '.NETCoreApp'" 
+                 ResourceName="CanOnlyCreateReadyToRunImagesForNetCoreApp" />
+
+    <NETSdkWarning Condition="'$(PublishTrimmed)' == 'true' And '$(_IsExecutable)' != 'true'"
+             ResourceName="CannotTrimForLibProjects" />
+    <NETSdkWarning Condition="'$(PublishTrimmed)' == 'true' And '$(_IsExecutable)' == 'true' And '$(TargetFrameworkIdentifier)' != '.NETCoreApp'"
+             ResourceName="CanOnlyTrimForNetCoreApp" />
 
     <PropertyGroup>
       <!-- Ensure any PublishDir has a trailing slash, so it can be concatenated -->

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets
@@ -142,6 +142,18 @@ Copyright (c) .NET Foundation. All rights reserved.
     <NETSdkError Condition="'$(SelfContained)' != 'true' and '$(UseAppHost)' == 'true' and '$(_TargetFrameworkVersionWithoutV)' &lt; '2.1'"
                  ResourceName="FrameworkDependentAppHostRequiresVersion21" />
 
+    <NETSdkError Condition="'$(PublishSingleFile)' == 'true' and '$(_TargetFrameworkVersionWithoutV)' &lt; '3.0'"
+                 ResourceName="PublishSingleFileRequiresVersion30" />
+
+    <!-- The TFM version checks for PublishReadyToRun PublishTrimmed only generate warnings in .Net core 3.1
+         because we do not want the behavior to be a breaking change compared to version 3.0 -->
+
+    <NETSdkWarning Condition="'$(PublishReadyToRun)' == 'true' and '$(_TargetFrameworkVersionWithoutV)' &lt; '3.0'"
+                   ResourceName="PublishReadyToRunRequiresVersion30" />
+
+    <NETSdkWarning Condition="'$(PublishTrimmed)' == 'true' and '$(_TargetFrameworkVersionWithoutV)' &lt; '3.0'"
+                   ResourceName="PublishTrimmedRequiresVersion30" />
+
   </Target>
 
   <Target Name="_CheckForMismatchingPlatform"

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishASingleFileApp.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishASingleFileApp.cs
@@ -27,6 +27,7 @@ namespace Microsoft.NET.Publish.Tests
         private const string DontUseAppHost = "/p:UseAppHost=false";
         private const string ReadyToRun = "/p:PublishReadyToRun=true";
         private const string ReadyToRunWithSymbols = "/p:PublishReadyToRunEmitSymbols=true";
+        private const string UseAppHost = "/p:UseAppHost=true";
 
         private readonly string RuntimeIdentifier = $"/p:RuntimeIdentifier={RuntimeEnvironment.GetRuntimeIdentifier()}";
         private readonly string SingleFile = $"{TestProjectName}{Constants.ExeSuffix}";
@@ -80,7 +81,7 @@ namespace Microsoft.NET.Publish.Tests
         {
             var testProject = new TestProject()
             {
-                Name = "SingleFileClassLib",
+                Name = "ClassLib",
                 TargetFrameworks = "netstandard2.0",
                 IsSdkProject = true,
                 IsExe = false,
@@ -94,7 +95,55 @@ namespace Microsoft.NET.Publish.Tests
                 .Should()
                 .Fail()
                 .And
-                .HaveStdOutContaining(Strings.CannotHaveSingleFileWithoutExecutable);
+                .HaveStdOutContaining(Strings.CannotHaveSingleFileWithoutExecutable)
+                .And
+                .NotHaveStdOutContaining(Strings.CanOnlyHaveSingleFileWithNetCoreApp);
+        }
+
+        [Fact]
+        public void It_errors_when_targetting_netstandard()
+        {
+            var testProject = new TestProject()
+            {
+                Name = "NetStandardExe",
+                TargetFrameworks = "netstandard2.0",
+                IsSdkProject = true,
+                IsExe = true,
+            };
+
+            var testAsset = _testAssetsManager.CreateTestProject(testProject);
+
+            var publishCommand = new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+
+            publishCommand.Execute(PublishSingleFile, RuntimeIdentifier, UseAppHost)
+                .Should()
+                .Fail()
+                .And
+                .HaveStdOutContaining(Strings.CanOnlyHaveSingleFileWithNetCoreApp)
+                .And
+                .NotHaveStdOutContaining(Strings.CannotHaveSingleFileWithoutExecutable);
+        }
+
+        [Fact]
+        public void It_errors_when_targetting_netcoreapp_2_x()
+        {
+            var testProject = new TestProject()
+            {
+                Name = "ConsoleApp",
+                TargetFrameworks = "netcoreapp2.2",
+                IsSdkProject = true,
+                IsExe = true,
+            };
+
+            var testAsset = _testAssetsManager.CreateTestProject(testProject);
+
+            var publishCommand = new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+
+            publishCommand.Execute(PublishSingleFile, RuntimeIdentifier)
+                .Should()
+                .Fail()
+                .And
+                .HaveStdOutContaining(Strings.PublishSingleFileRequiresVersion30);
         }
 
         [Fact]

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToRunCrossgen.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToRunCrossgen.cs
@@ -4,6 +4,7 @@ using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
 using System.Runtime.InteropServices;
 using FluentAssertions;
+using Microsoft.NET.Build.Tasks;
 using Microsoft.NET.TestFramework;
 using Microsoft.NET.TestFramework.Assertions;
 using Microsoft.NET.TestFramework.Commands;
@@ -222,7 +223,81 @@ namespace Microsoft.NET.Publish.Tests
             publishCommand.Execute()
                 .Should()
                 .Fail()
-                .And.HaveStdOutContainingIgnoreCase("NETSDK1095");
+                .And.HaveStdOutContaining(Strings.ReadyToRunTargetNotSupportedError);
+        }
+
+        [Fact]
+        public void It_warns_when_publishing_lib()
+        {
+            var testProject = new TestProject()
+            {
+                Name = "ClassLib",
+                TargetFrameworks = "netstandard2.0",
+                IsSdkProject = true,
+                IsExe = false,
+            };
+
+            var testAsset = _testAssetsManager.CreateTestProject(testProject);
+
+            var publishCommand = new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+
+            publishCommand.Execute($"/p:PublishReadyToRun=true",
+                                   $"/p:RuntimeIdentifier={DotNet.PlatformAbstractions.RuntimeEnvironment.GetRuntimeIdentifier()}")
+                .Should()
+                .Pass()
+                .And
+                .HaveStdOutContaining(Strings.CannotCreateReadyToRunImagesForLibProjects)
+                .And
+                .NotHaveStdOutContaining(Strings.CanOnlyCreateReadyToRunImagesForNetCoreApp);
+        }
+
+        [Fact]
+        public void It_warns_when_targetting_netstandard()
+        {
+            var testProject = new TestProject()
+            {
+                Name = "NetStandardApp",
+                TargetFrameworks = "netstandard2.0",
+                IsSdkProject = true,
+                IsExe = true,
+            };
+
+            var testAsset = _testAssetsManager.CreateTestProject(testProject);
+
+            var publishCommand = new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+
+            publishCommand.Execute($"/p:PublishReadyToRun=true",
+                                   $"/p:RuntimeIdentifier={DotNet.PlatformAbstractions.RuntimeEnvironment.GetRuntimeIdentifier()}",
+                                   $"/p:UseAppHost=true")
+                .Should()
+                .Pass()
+                .And
+                .HaveStdOutContaining(Strings.CanOnlyCreateReadyToRunImagesForNetCoreApp)
+                .And
+                .NotHaveStdOutContaining(Strings.CannotCreateReadyToRunImagesForLibProjects);
+        }
+
+        [Fact]
+        public void It_warns_when_targetting_netcoreapp_2_x()
+        {
+            var testProject = new TestProject()
+            {
+                Name = "ConsoleApp",
+                TargetFrameworks = "netcoreapp2.2",
+                IsSdkProject = true,
+                IsExe = true,
+            };
+
+            var testAsset = _testAssetsManager.CreateTestProject(testProject);
+
+            var publishCommand = new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+
+            publishCommand.Execute($"/p:PublishReadyToRun=true",
+                                   $"/p:RuntimeIdentifier={DotNet.PlatformAbstractions.RuntimeEnvironment.GetRuntimeIdentifier()}")
+                .Should()
+                .Pass()
+                .And
+                .HaveStdOutContaining(Strings.PublishReadyToRunRequiresVersion30);
         }
 
         private TestProject CreateTestProjectForR2RTesting(string ridToUse, string mainProjectName, string referenceProjectName)

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToRunILLink.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToRunILLink.cs
@@ -5,7 +5,9 @@ using System.Xml.Linq;
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
 using FluentAssertions;
+using Microsoft.DotNet.PlatformAbstractions;
 using Microsoft.Extensions.DependencyModel;
+using Microsoft.NET.Build.Tasks;
 using Microsoft.NET.TestFramework;
 using Microsoft.NET.TestFramework.Assertions;
 using Microsoft.NET.TestFramework.Commands;
@@ -389,6 +391,77 @@ namespace Microsoft.NET.Publish.Tests
             project.Root.Elements(ns + "ItemGroup")
                 .Where(ig => ig.Elements(ns + "TrimmerRootDescriptor").Any())
                 .First().Remove();
+        }
+
+        [Fact]
+        public void It_warns_when_publishing_lib()
+        {
+            var testProject = new TestProject()
+            {
+                Name = "ClassLib",
+                TargetFrameworks = "netstandard2.0",
+                IsSdkProject = true,
+                IsExe = false,
+            };
+
+            var testAsset = _testAssetsManager.CreateTestProject(testProject);
+
+            var publishCommand = new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+
+            publishCommand.Execute($"/p:PublishTrimmed=true")
+                .Should()
+                .Pass()
+                .And
+                .HaveStdOutContaining(Strings.CannotTrimForLibProjects)
+                .And
+                .NotHaveStdOutContaining(Strings.CanOnlyTrimForNetCoreApp);
+        }
+
+        [Fact]
+        public void It_warns_when_targetting_netstandard()
+        {
+            var testProject = new TestProject()
+            {
+                Name = "NetStandardApp",
+                TargetFrameworks = "netstandard2.0",
+                IsSdkProject = true,
+                IsExe = true,
+            };
+
+            var testAsset = _testAssetsManager.CreateTestProject(testProject);
+
+            var publishCommand = new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+
+            publishCommand.Execute($"/p:PublishTrimmed=true", $"/p:UseAppHost=true")
+                .Should()
+                .Pass()
+                .And
+                .HaveStdOutContaining(Strings.CanOnlyTrimForNetCoreApp)
+                .And
+                .NotHaveStdOutContaining(Strings.CannotTrimForLibProjects);
+            ;
+        }
+
+        [Fact]
+        public void It_warns_when_targetting_netcoreapp_2_x()
+        {
+            var testProject = new TestProject()
+            {
+                Name = "ConsoleApp",
+                TargetFrameworks = "netcoreapp2.2",
+                IsSdkProject = true,
+                IsExe = true,
+            };
+
+            var testAsset = _testAssetsManager.CreateTestProject(testProject);
+
+            var publishCommand = new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+
+            publishCommand.Execute($"/p:PublishTrimmed=true")
+                .Should()
+                .Pass()
+                .And
+                .HaveStdOutContaining(Strings.PublishTrimmedRequiresVersion30);
         }
 
         private void EnableNonFrameworkTrimming(XDocument project)


### PR DESCRIPTION
The options `PublishSingleFile`, `PublishReadyToRun`, and `PublishTrimmed` are only supported when targetting netcoreapp3.0 or later.

Trying to publish to a different target (say `.netcoreapp2.1`) today:
* `PublishSingleFile` fails with the `PlaceHolderNotFoundInAppHostException` generated by the `HostWriter`.
* `PublishReadyToRun` and `PublishTrimmed` silently fail to turn on, but the `publish` itself suceeds.

This change adds an explicit TFM check to generate error/warnings for non-conforming targets.

`PublishSingleFile`, `PublishReadyToRun`, and `PublishTrimmed` require the following conditions to be true:
* `TargetFramework` is `netcoreapp`
* `TargetFrameworkVersion` is at least `3.0`
* The app is an executable (`OutputType=exe`)

If any of the conditions fail:
* `PublishSingleFile` fails with an appropriate error
* `PublishReadyToRun` and `PublishTrimmed` issue warnings, but publish itself succeeds.
  This is because:
    * The restriction against `classlibs` / `netstandard` frameworks may be relaxed in future releases
    * The version check should ideally be a failure, but they are warnings for maximum compatibility with `3.0` release.

Fixes https://github.com/dotnet/sdk/issues/3728