### PR TITLE
Fix .pp content files copy to output issue

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.PackageDependencyResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.PackageDependencyResolution.targets
@@ -524,7 +524,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     ============================================================
   -->
   <Target Name="ResolveLockFileCopyLocalFiles"
-          DependsOnTargets="ResolvePackageAssets">
+          DependsOnTargets="ResolvePackageAssets;RunProduceContentAssets">
 
     <ItemGroup>
       <_ResolvedCopyLocalBuildAssets Include="@(RuntimeCopyLocalItems)"
@@ -538,6 +538,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       <_ResolvedCopyLocalBuildAssets Include="@(RuntimeTargetsCopyLocalItems)"
                                      Condition="'%(RuntimeTargetsCopyLocalItems.CopyLocal)' == 'true'" />
 
+      <ReferenceCopyLocalPaths Include="@(_ContentCopyLocalItems)" />
       <ReferenceCopyLocalPaths Include="@(_ResolvedCopyLocalBuildAssets)"
                                Condition="'$(CopyLocalLockFileAssemblies)' == 'true'" />
     </ItemGroup>

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToCopyPPFileToOutput.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToCopyPPFileToOutput.cs
@@ -37,17 +37,12 @@ namespace Microsoft.NET.Build.Tests
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
-            var restoreCommand = new RestoreCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
-            restoreCommand.Execute()
-                .Should()
-                .Pass();
-
             var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
             buildCommand.Execute()
                 .Should()
                 .Pass();
 
-            var outputPath = Path.Combine(testAsset.TestRoot, testProject.Name, "bin", "Debug", "netcoreapp3.0");
+            var outputPath = Path.Combine(testAsset.TestRoot, testProject.Name, "bin", "Debug", testProject.TargetFrameworks);
             File.Exists(Path.Combine(outputPath, packageReference.ID + ".dll")).Should().BeTrue();
             File.Exists(Path.Combine(outputPath, "Nontransformed.ps1")).Should().BeTrue();
             File.Exists(Path.Combine(outputPath, "Test.ps1")).Should().BeTrue();
@@ -57,7 +52,7 @@ namespace Microsoft.NET.Build.Tests
         {
             var referencedPackage = new TestProject()
             {
-                Name = "CopyPPTilesToOutput",
+                Name = "CopyPPFilesToOutput",
                 TargetFrameworks = "netcoreapp3.0",
                 IsSdkProject = true
             };
@@ -67,9 +62,6 @@ namespace Microsoft.NET.Build.Tests
             WriteFile(Path.Combine(packageAsset.TestRoot, referencedPackage.Name, "Test.ps1.pp"), "Content file");
             packageAsset = packageAsset
                 .WithProjectChanges(project => AddContent(project));
-
-            var restoreCommand = new RestoreCommand(Log, packageAsset.TestRoot, referencedPackage.Name);
-            restoreCommand.Execute().Should().Pass();
 
             var packCommand = new PackCommand(Log, packageAsset.TestRoot, referencedPackage.Name);
             packCommand.Execute()

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToCopyPPFileToOutput.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToCopyPPFileToOutput.cs
@@ -1,0 +1,99 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.IO;
+using FluentAssertions;
+using Microsoft.NET.TestFramework;
+using Microsoft.NET.TestFramework.Commands;
+using Xunit;
+using Xunit.Abstractions;
+using Microsoft.NET.TestFramework.Assertions;
+using Microsoft.NET.TestFramework.ProjectConstruction;
+using System.Xml.Linq;
+
+namespace Microsoft.NET.Build.Tests
+{
+    public class GivenThatWeHaveAPpContentFile : SdkTest
+    {
+        public GivenThatWeHaveAPpContentFile(ITestOutputHelper log) : base(log)
+        {}
+
+        [Fact]
+        public void It_copies_to_output_successfully()
+        {
+            var packageReference = GetPackageReference();
+
+            TestProject testProject = new TestProject()
+            {
+                Name = "CopyPPToOutputTest",
+                IsSdkProject = true, 
+                IsExe = true, 
+                TargetFrameworks = "netcoreapp3.0"
+            };
+            testProject.PackageReferences.Add(packageReference);
+            testProject.AdditionalProperties.Add("RestoreAdditionalProjectSources", Path.GetDirectoryName(packageReference.NupkgPath));
+            //  Use a test-specific packages folder
+            testProject.AdditionalProperties["RestorePackagesPath"] = @"$(MSBuildProjectDirectory)\..\pkg";
+
+            var testAsset = _testAssetsManager.CreateTestProject(testProject);
+
+            var restoreCommand = new RestoreCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            restoreCommand.Execute()
+                .Should()
+                .Pass();
+
+            var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            buildCommand.Execute()
+                .Should()
+                .Pass();
+
+            var outputPath = Path.Combine(testAsset.TestRoot, testProject.Name, "bin", "Debug", "netcoreapp3.0");
+            File.Exists(Path.Combine(outputPath, packageReference.ID + ".dll")).Should().BeTrue();
+            File.Exists(Path.Combine(outputPath, "Nontransformed.ps1")).Should().BeTrue();
+            File.Exists(Path.Combine(outputPath, "Test.ps1")).Should().BeTrue();
+        }
+
+        private TestPackageReference GetPackageReference()
+        {
+            var referencedPackage = new TestProject()
+            {
+                Name = "CopyPPTilesToOutput",
+                TargetFrameworks = "netcoreapp3.0",
+                IsSdkProject = true
+            };
+
+            var packageAsset = _testAssetsManager.CreateTestProject(referencedPackage);
+            WriteFile(Path.Combine(packageAsset.TestRoot, referencedPackage.Name, "Nontransformed.ps1"), "Content file");
+            WriteFile(Path.Combine(packageAsset.TestRoot, referencedPackage.Name, "Test.ps1.pp"), "Content file");
+            packageAsset = packageAsset
+                .WithProjectChanges(project => AddContent(project));
+
+            var restoreCommand = new RestoreCommand(Log, packageAsset.TestRoot, referencedPackage.Name);
+            restoreCommand.Execute().Should().Pass();
+
+            var packCommand = new PackCommand(Log, packageAsset.TestRoot, referencedPackage.Name);
+            packCommand.Execute()
+                .Should()
+                .Pass();
+            return new TestPackageReference(referencedPackage.Name, "1.0.0", packCommand.GetNuGetPackage(referencedPackage.Name));
+        }
+
+        private void AddContent(XDocument package)
+        {
+            var ns = package.Root.Name.Namespace;
+            XElement itemGroup = new XElement(ns + "ItemGroup");
+            itemGroup.Add(new XElement(ns + "Content", new XAttribute("Include", "Nontransformed.ps1"),
+                new XAttribute("PackageCopyToOutput", "true")));
+            itemGroup.Add(new XElement(ns + "Content", new XAttribute("Include", "Test.ps1.pp"),
+                new XAttribute("PackageCopyToOutput", "true")));
+            package.Root.Add(itemGroup);
+        }
+
+        private void WriteFile(string path, string contents)
+        {
+            string folder = Path.GetDirectoryName(path);
+            Directory.CreateDirectory(folder);
+            File.WriteAllText(path, contents);
+        }
+    }
+}


### PR DESCRIPTION
Addressing Issue #3719

Adding test/ fix to ensure .pp content files in a package marked copy to output are properly copied into the output directory. 