### PR TITLE
Remove BundledNETCoreAppTargetFrameworkVersion

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.Common.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.Common.targets
@@ -37,7 +37,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <HasRuntimeOutput Condition="'$(_UsingDefaultForHasRuntimeOutput)' == 'true'">$(_IsExecutable)</HasRuntimeOutput>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(DotnetCliToolTargetFramework)' == '' And '$(BundledNETCoreAppTargetFrameworkVersion)' != ''">
+  <PropertyGroup Condition="'$(DotnetCliToolTargetFramework)' == ''">
     <!-- Maximum supported target framework for DotnetCliProjectTools is .NET Core 2.2 -->
     <DotnetCliToolTargetFramework>netcoreapp2.2</DotnetCliToolTargetFramework>
   </PropertyGroup>


### PR DESCRIPTION
It should be removed in https://github.com/dotnet/sdk/commit/0979dd3c53a8971a5434cf4bc68efd103fe5ea68
since it is no longer used