### PR TITLE
Removing Redundant Metadata

### DIFF
--- a/src/Tasks/Common/ConflictResolution/ConflictItem.cs
+++ b/src/Tasks/Common/ConflictResolution/ConflictItem.cs
@@ -168,12 +168,7 @@ namespace Microsoft.NET.Build.Tasks.ConflictResolution
                     //  NuGet packages, so we will rely on that.  We still might have items from packages
                     //  that don't have the metadata set if the DLL is explicitly referenced, for example.
 
-                    _packageId = OriginalItem?.GetMetadata(MetadataNames.NuGetPackageId);
-
-                    if (string.IsNullOrEmpty(_packageId))
-                    {
-                        _packageId = OriginalItem?.GetMetadata(MetadataKeys.PackageName) ?? string.Empty;
-                    }
+                    _packageId = OriginalItem?.GetMetadata(MetadataKeys.PackageName) ?? string.Empty;
                 }
 
                 return _packageId.Length == 0 ? null : _packageId;

--- a/src/Tasks/Common/ConflictResolution/MetadataNames.cs
+++ b/src/Tasks/Common/ConflictResolution/MetadataNames.cs
@@ -11,7 +11,6 @@ namespace Microsoft.NET.Build.Tasks.ConflictResolution
         public const string Extension = "Extension";
         public const string FileName = "FileName";
         public const string HintPath = "HintPath";
-        public const string NuGetPackageId = "NuGetPackageId";
         public const string NuGetPackageVersion = "NuGetPackageVersion";
         public const string Path = "Path";
         public const string Private = "Private";

--- a/src/Tasks/Common/ConflictResolution/ResolvePackageFileConflicts.cs
+++ b/src/Tasks/Common/ConflictResolution/ResolvePackageFileConflicts.cs
@@ -208,7 +208,7 @@ namespace Microsoft.NET.Build.Tasks.ConflictResolution
             if (conflict.PackageId != null)
             {
                 item.SetMetadata(nameof(ConflictItemType), conflict.ItemType.ToString());
-                item.SetMetadata(MetadataKeys.NuGetPackageId, conflict.PackageId);
+                item.SetMetadata(MetadataKeys.PackageName, conflict.PackageId);
             }
 
             return item;

--- a/src/Tasks/Common/MetadataKeys.cs
+++ b/src/Tasks/Common/MetadataKeys.cs
@@ -62,7 +62,6 @@ namespace Microsoft.NET.Build.Tasks
 
         // Package assets
         public const string NuGetIsFrameworkReference = "NuGetIsFrameworkReference";
-        public const string NuGetPackageId = "NuGetPackageId";
         public const string NuGetPackageVersion = "NuGetPackageVersion";
         public const string NuGetSourceType = "NuGetSourceType";
         public const string PathInPackage = "PathInPackage";

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAProduceContentsAssetsTask.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAProduceContentsAssetsTask.cs
@@ -169,14 +169,14 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
 
             var item = copyLocalItems.Where(t => t.ItemSpec.EndsWith(assetWritePath)).First();
             item.GetMetadata("TargetPath").Should().Be("samplepp.output.txt");
-            item.GetMetadata(MetadataKeys.NuGetPackageId).Should().Be("LibA");
+            item.GetMetadata(MetadataKeys.PackageName).Should().Be("LibA");
             item.GetMetadata(MetadataKeys.NuGetPackageVersion).Should().Be("1.2.3");
 
             for (int i = 1; i < 3; i++)
             {
                 item = copyLocalItems.Where(t => t.ItemSpec.EndsWith(contentFiles[i])).First();
                 item.GetMetadata("TargetPath").Should().Be(Path.Combine("output", contentFiles[i]));
-                item.GetMetadata(MetadataKeys.NuGetPackageId).Should().Be("LibA");
+                item.GetMetadata(MetadataKeys.PackageName).Should().Be("LibA");
                 item.GetMetadata(MetadataKeys.NuGetPackageVersion).Should().Be("1.2.3");
             }
 
@@ -243,17 +243,17 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
 
             var item = contentItems.Where(t => t.ItemSpec.EndsWith(assetWritePath)).First();
             item.GetMetadata("ProcessedItemType").Should().Be("Content");
-            item.GetMetadata(MetadataKeys.NuGetPackageId).Should().Be(packageId);
+            item.GetMetadata(MetadataKeys.PackageName).Should().Be(packageId);
             item.GetMetadata(MetadataKeys.NuGetPackageVersion).Should().Be(packageVersion);
 
             item = contentItems.Where(t => t.ItemSpec.EndsWith(contentFiles[1])).First();
             item.GetMetadata("ProcessedItemType").Should().Be("EmbeddedResource");
-            item.GetMetadata(MetadataKeys.NuGetPackageId).Should().Be(packageId);
+            item.GetMetadata(MetadataKeys.PackageName).Should().Be(packageId);
             item.GetMetadata(MetadataKeys.NuGetPackageVersion).Should().Be(packageVersion);
 
             item = contentItems.Where(t => t.ItemSpec.EndsWith(contentFiles[2])).First();
             item.GetMetadata("ProcessedItemType").Should().Be("Content");
-            item.GetMetadata(MetadataKeys.NuGetPackageId).Should().Be(packageId);
+            item.GetMetadata(MetadataKeys.PackageName).Should().Be(packageId);
             item.GetMetadata(MetadataKeys.NuGetPackageVersion).Should().Be(packageVersion);
 
             // not added to content items
@@ -373,7 +373,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             var contentItems = task.ProcessedContentItems;
             contentItems.Count().Should().Be(3);
             contentItems.All(t => t.GetMetadata("ProcessedItemType") == "Content").Should().BeTrue();
-            contentItems.All(t => t.GetMetadata(MetadataKeys.NuGetPackageId) == packageId).Should().BeTrue();
+            contentItems.All(t => t.GetMetadata(MetadataKeys.PackageName) == packageId).Should().BeTrue();
             contentItems.All(t => t.GetMetadata(MetadataKeys.NuGetPackageVersion) == packageVersion).Should().BeTrue();
         }
 
@@ -417,7 +417,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             contentItems.First().ItemSpec
                 .Should().Be(Path.Combine(PackageRootDirectory, "LibA", "1.2.3", contentFiles[0]));
             contentItems.First().GetMetadata("ProcessedItemType").Should().Be("Content");
-            contentItems.First().GetMetadata(MetadataKeys.NuGetPackageId).Should().Be(packageId);
+            contentItems.First().GetMetadata(MetadataKeys.PackageName).Should().Be(packageId);
             contentItems.First().GetMetadata(MetadataKeys.NuGetPackageVersion).Should().Be(packageVersion);
         }
 
@@ -466,7 +466,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 item.ItemSpec.Should().Be(
                     Path.Combine(PackageRootDirectory, "LibA", "1.2.3", contentFiles[i+1]));
                 item.GetMetadata("ProcessedItemType").Should().Be("Content");
-                item.GetMetadata(MetadataKeys.NuGetPackageId).Should().Be(packageId);
+                item.GetMetadata(MetadataKeys.PackageName).Should().Be(packageId);
                 item.GetMetadata(MetadataKeys.NuGetPackageVersion).Should().Be(packageVersion);
             }
         }
@@ -488,7 +488,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 itemSpec: Path.Combine(PackageRootDirectory, packageId, packageVersion, path),
                 metadata: new Dictionary<string, string>
                 {
-                    { MetadataKeys.NuGetPackageId, packageId },
+                    { MetadataKeys.PackageName, packageId },
                     { MetadataKeys.NuGetPackageVersion, packageVersion },
                     { MetadataKeys.PPOutputPath, ppOutputPath },
                     { MetadataKeys.CodeLanguage, codeLanguage },

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenThatWeWantToGetDependenciesViaDesignTimeBuild.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenThatWeWantToGetDependenciesViaDesignTimeBuild.cs
@@ -1152,7 +1152,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 itemSpec: "Packages\\MyPackage\\1.5.0\\AnAssembly.dll",
                 metadata: new Dictionary<string, string>
                 {
-                    { "NuGetPackageId", "MyPackage" },
+                    { "PackageName", "MyPackage" },
                     { "NuGetPackageVersion", "1.5.0" }
                 });
 
@@ -1226,7 +1226,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 itemSpec: "Packages\\MyPackage\\1.5.0\\AlphaAssembly.dll",
                 metadata: new Dictionary<string, string>
                 {
-                    { "NuGetPackageId", "MyPackage" },
+                    { "PackageName", "MyPackage" },
                     { "NuGetPackageVersion", "1.5.0" }
                 });
 
@@ -1234,7 +1234,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 itemSpec: "Packages\\MyPackage\\1.5.0\\BetaAssembly.dll",
                 metadata: new Dictionary<string, string>
                 {
-                    { "NuGetPackageId", "MyPackage" },
+                    { "PackageName", "MyPackage" },
                     { "NuGetPackageVersion", "1.5.0" },
                     { "Facade", "false" }
                 });
@@ -1243,7 +1243,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 itemSpec: "Packages\\MyPackage\\1.5.0\\GammaAssembly.dll",
                 metadata: new Dictionary<string, string>
                 {
-                    { "NuGetPackageId", "MyPackage" },
+                    { "PackageName", "MyPackage" },
                     { "NuGetPackageVersion", "1.5.0" },
                     { "Facade", "true" }
                 });

--- a/src/Tasks/Microsoft.NET.Build.Tasks/FindItemsFromPackages.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/FindItemsFromPackages.cs
@@ -13,7 +13,7 @@ namespace Microsoft.NET.Build.Tasks
     /// set of Packages.
     /// </summary>
     /// <remarks>
-    /// Both Items and Packages are expected to have ('PackageName' and 'PackageVersion)' or ('NuGetPackageId' and 'NuGetPackageVersion')
+    /// Both Items and Packages are expected to have 'PackageName' and ('PackageVersion' or 'NuGetPackageVersion')
     /// metadata properties to use for the matching.
     /// </remarks>
     public sealed class FindItemsFromPackages : TaskBase

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ItemUtilities.NuGet.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ItemUtilities.NuGet.cs
@@ -14,9 +14,8 @@ namespace Microsoft.NET.Build.Tasks
             string packageName = item.GetMetadata(MetadataKeys.PackageName);
             string packageVersion = item.GetMetadata(MetadataKeys.PackageVersion);
 
-            if (string.IsNullOrEmpty(packageName) || string.IsNullOrEmpty(packageVersion))
+            if (string.IsNullOrEmpty(packageVersion))
             {
-                packageName = item.GetMetadata(MetadataKeys.NuGetPackageId);
                 packageVersion = item.GetMetadata(MetadataKeys.NuGetPackageVersion);
             }
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/PreprocessPackageDependenciesDesignTime.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/PreprocessPackageDependenciesDesignTime.cs
@@ -209,7 +209,7 @@ namespace Microsoft.NET.Build.Tasks
             var existingReferenceItemDependencies = new List<ITaskItem>();
             foreach (var reference in References)
             {
-                var packageName = reference.GetMetadata(MetadataKeys.NuGetPackageId);
+                var packageName = reference.GetMetadata(MetadataKeys.PackageName);
                 var packageVersion = reference.GetMetadata(MetadataKeys.NuGetPackageVersion);
 
                 // This is not a "pre-resolved" assembly; skip it.

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ProduceContentAssets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ProduceContentAssets.cs
@@ -149,7 +149,7 @@ namespace Microsoft.NET.Build.Tasks
             var contentFileDeps = ContentFileDependencies ?? Enumerable.Empty<ITaskItem>();
             var contentFileGroups = contentFileDeps
                 .Where(f => !ProduceOnlyPreprocessorFiles || IsPreprocessorFile(f))
-                .GroupBy(t => t.GetMetadata(MetadataKeys.NuGetPackageId));
+                .GroupBy(t => t.GetMetadata(MetadataKeys.PackageName));
             foreach (var grouping in contentFileGroups)
             {
                 // Is there an asset with our exact language? If so, we use that. Otherwise we'll simply collect "any" assets.
@@ -198,7 +198,7 @@ namespace Microsoft.NET.Build.Tasks
             string resolvedPath = contentFile.ItemSpec;
             string pathToFinalAsset = resolvedPath;
             string ppOutputPath = contentFile.GetMetadata(MetadataKeys.PPOutputPath);
-            string packageName = contentFile.GetMetadata(MetadataKeys.NuGetPackageId);
+            string packageName = contentFile.GetMetadata(MetadataKeys.PackageName);
             string packageVersion = contentFile.GetMetadata(MetadataKeys.NuGetPackageVersion);
 
             if (!string.IsNullOrEmpty(ppOutputPath))
@@ -225,7 +225,7 @@ namespace Microsoft.NET.Build.Tasks
                 {
                     var item = new TaskItem(pathToFinalAsset);
                     item.SetMetadata("TargetPath", outputPath);
-                    item.SetMetadata(MetadataKeys.NuGetPackageId, packageName);
+                    item.SetMetadata(MetadataKeys.PackageName, packageName);
                     item.SetMetadata(MetadataKeys.NuGetPackageVersion, packageVersion);
 
                     _copyLocalItems.Add(item);
@@ -241,7 +241,7 @@ namespace Microsoft.NET.Build.Tasks
             if (!string.Equals(buildAction, "none", StringComparison.OrdinalIgnoreCase))
             {
                 var item = new TaskItem(pathToFinalAsset);
-                item.SetMetadata(MetadataKeys.NuGetPackageId, packageName);
+                item.SetMetadata(MetadataKeys.PackageName, packageName);
                 item.SetMetadata(MetadataKeys.NuGetPackageVersion, packageVersion);
 
                 // We'll put additional metadata on the item so we can convert it back to the real item group in our targets

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ReferenceInfo.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ReferenceInfo.cs
@@ -120,11 +120,7 @@ namespace Microsoft.NET.Build.Tasks
             string name = Path.GetFileNameWithoutExtension(fullPath);
             string version = GetVersion(referencePath);
 
-            var packageName = referencePath.GetMetadata(MetadataKeys.NuGetPackageId);
-            if (string.IsNullOrEmpty(packageName))
-            {
-                packageName = referencePath.GetMetadata(MetadataKeys.PackageName);
-            }
+            var packageName = referencePath.GetMetadata(MetadataKeys.PackageName);
 
             var packageVersion = referencePath.GetMetadata(MetadataKeys.NuGetPackageVersion);
             if (string.IsNullOrEmpty(packageVersion))

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageAssets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageAssets.cs
@@ -1263,7 +1263,7 @@ namespace Microsoft.NET.Build.Tasks
             private void WriteItem(string itemSpec, LockFileTargetLibrary package)
             {
                 WriteItem(itemSpec);
-                WriteMetadata(MetadataKeys.NuGetPackageId, package.Name);
+                WriteMetadata(MetadataKeys.PackageName, package.Name);
                 WriteMetadata(MetadataKeys.NuGetPackageVersion, package.Version.ToNormalizedString());
             }
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolveTargetingPackAssets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveTargetingPackAssets.cs
@@ -214,7 +214,7 @@ namespace Microsoft.NET.Build.Tasks
 
             reference.SetMetadata(MetadataKeys.ExternallyResolved, "true");
             reference.SetMetadata(MetadataKeys.Private, "false");
-            reference.SetMetadata(MetadataKeys.NuGetPackageId, targetingPack.GetMetadata(MetadataKeys.PackageName));
+            reference.SetMetadata(MetadataKeys.PackageName, targetingPack.GetMetadata(MetadataKeys.PackageName));
             reference.SetMetadata(MetadataKeys.NuGetPackageVersion, targetingPack.GetMetadata(MetadataKeys.PackageVersion));
 
             reference.SetMetadata("FrameworkReferenceName", targetingPack.ItemSpec);

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolvedFile.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolvedFile.cs
@@ -76,11 +76,7 @@ namespace Microsoft.NET.Build.Tasks
                 throw new InvalidOperationException($"Unrecognized AssetType '{assetType}' for {SourcePath}");
             }
 
-            PackageName = item.GetMetadata(MetadataKeys.NuGetPackageId);
-            if (string.IsNullOrEmpty(PackageName))
-            {
-                PackageName = item.GetMetadata(MetadataKeys.PackageName);
-            }
+            PackageName = item.GetMetadata(MetadataKeys.PackageName);
 
             PackageVersion = item.GetMetadata(MetadataKeys.NuGetPackageVersion);
             if (string.IsNullOrEmpty(PackageVersion))

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.PackageDependencyResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.PackageDependencyResolution.targets
@@ -448,11 +448,11 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <ItemGroup Condition="'$(MarkPackageReferencesAsExternallyResolved)' == 'true'">
       <!--
-        Update Reference items with NuGetPackageId metadata to set ExternallyResolved appropriately.
+        Update Reference items with PackageName metadata to set ExternallyResolved appropriately.
         NetStandard.Library adds its assets in targets this way and not in the standard way that
         would get ExternallyResolved set in ResolvePackageAssets.
        -->
-      <Reference Condition="'%(Reference.NuGetPackageId)' != ''">
+      <Reference Condition="'%(Reference.PackageName)' != ''">
         <ExternallyResolved>true</ExternallyResolved>
       </Reference>
 


### PR DESCRIPTION
Removing NuGetPackageId metadata in favor of PackageName to address #3499