### PR TITLE
Catch app host mach o format exception

### DIFF
--- a/src/Tasks/Common/Resources/Strings.resx
+++ b/src/Tasks/Common/Resources/Strings.resx
@@ -598,12 +598,6 @@ The following are names of parameters or literal values and should not be transl
   <data name="AppHostMachOFormatDuplicateLinkEdit" xml:space="preserve">
     <value>Only one __LINKEDIT segment is expected in the application host</value>
   </data>
-  <data name="AppHostMachOFormatNot64BitExe" xml:space="preserve">
-    <value>Application host is expected to be a 64-bit MachO executable</value>
-  </data>
-  <data name="AppHostMachOFormatDuplicateLinkEdit" xml:space="preserve">
-    <value>Only one __LINKEDIT segment is expected in the application host</value>
-  </data>
   <data name="AppHostMachOFormatDuplicateSymtab" xml:space="preserve">
     <value>Only one SYMTAB is expected in the application host</value>
   </data>
@@ -635,6 +629,6 @@ The following are names of parameters or literal values and should not be transl
     <value>Error reading the memory-mapped application host</value>
   </data>
   <data name="AppHostMachOFormatInvalidUTF8" xml:space="preserve">
-    <value>UTF8 decoding failed </value>
+    <value>UTF8 decoding failed</value>
   </data>
 </root>

--- a/src/Tasks/Common/Resources/Strings.resx
+++ b/src/Tasks/Common/Resources/Strings.resx
@@ -588,4 +588,53 @@ The following are names of parameters or literal values and should not be transl
     <value>NETSDK1120: C++/CLI projects targeting .NET Core require a target framework of at least 'netcoreapp3.1'.</value>
     <comment>{StrBegin="NETSDK1120: "}</comment>
   </data>
+  <data name="AppHostMachONotExpectedFormat" xml:space="preserve">
+    <value>NETSDK1121: Unable to use '{0}' as macOS application host executable it was not in the expected format. Detail reason: {1}.</value>
+    <comment>{StrBegin="NETSDK1121: "}</comment>
+  </data>
+  <data name="AppHostMachOFormatNot64BitExe" xml:space="preserve">
+    <value>Application host is expected to be a 64-bit MachO executable</value>
+  </data>
+  <data name="AppHostMachOFormatDuplicateLinkEdit" xml:space="preserve">
+    <value>Only one __LINKEDIT segment is expected in the application host</value>
+  </data>
+  <data name="AppHostMachOFormatNot64BitExe" xml:space="preserve">
+    <value>Application host is expected to be a 64-bit MachO executable</value>
+  </data>
+  <data name="AppHostMachOFormatDuplicateLinkEdit" xml:space="preserve">
+    <value>Only one __LINKEDIT segment is expected in the application host</value>
+  </data>
+  <data name="AppHostMachOFormatDuplicateSymtab" xml:space="preserve">
+    <value>Only one SYMTAB is expected in the application host</value>
+  </data>
+  <data name="AppHostMachOFormatSignNeedsLinkEdit" xml:space="preserve">
+    <value>CODE_SIGNATURE command must follow a Segment64 command named __LINKEDIT</value>
+  </data>
+  <data name="AppHostMachOFormatSignNeedsSymtab" xml:space="preserve">
+    <value>CODE_SIGNATURE command must follow the SYMTAB command</value>
+  </data>
+  <data name="AppHostMachOFormatLinkEditNotLast" xml:space="preserve">
+    <value>__LINKEDIT must be the last segment in the binary layout</value>
+  </data>
+  <data name="AppHostMachOFormatSymtabNotInLinkEdit" xml:space="preserve">
+    <value>SYMTAB must within the __LINKEDIT segment!</value>
+  </data>
+  <data name="AppHostMachOFormatSignNotInLinkEdit" xml:space="preserve">
+    <value>Signature blob must be within the __LINKEDIT segment!</value>
+  </data>
+  <data name="AppHostMachOFormatSignCommandNotLast" xml:space="preserve">
+    <value>CODE_SIGNATURE command must be the last command</value>
+  </data>
+  <data name="AppHostMachOFormatSignBlobNotLast" xml:space="preserve">
+    <value>Signature blob must be at the very end of the file</value>
+  </data>
+  <data name="AppHostMachOFormatSignDoesntFollowSymtab" xml:space="preserve">
+    <value>Signature blob must immediately follow the Symtab</value>
+  </data>
+  <data name="AppHostMachOFormatMemoryMapAccessFault" xml:space="preserve">
+    <value>Error reading the memory-mapped application host</value>
+  </data>
+  <data name="AppHostMachOFormatInvalidUTF8" xml:space="preserve">
+    <value>UTF8 decoding failed </value>
+  </data>
 </root>

--- a/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
@@ -27,6 +27,76 @@
         <target state="translated">NETSDK1029: {0} nelze použít jako spustitelný soubor hostitele aplikace, protože neobsahuje očekávanou zástupnou bajtovou posloupnost {1}, která by označila, kam se má zapsat název aplikace.</target>
         <note>{StrBegin="NETSDK1029: "}</note>
       </trans-unit>
+      <trans-unit id="AppHostMachOFormatDuplicateLinkEdit">
+        <source>Only one __LINKEDIT segment is expected in the application host</source>
+        <target state="new">Only one __LINKEDIT segment is expected in the application host</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatDuplicateSymtab">
+        <source>Only one SYMTAB is expected in the application host</source>
+        <target state="new">Only one SYMTAB is expected in the application host</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatInvalidUTF8">
+        <source>UTF8 decoding failed</source>
+        <target state="new">UTF8 decoding failed</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatLinkEditNotLast">
+        <source>__LINKEDIT must be the last segment in the binary layout</source>
+        <target state="new">__LINKEDIT must be the last segment in the binary layout</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatMemoryMapAccessFault">
+        <source>Error reading the memory-mapped application host</source>
+        <target state="new">Error reading the memory-mapped application host</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatNot64BitExe">
+        <source>Application host is expected to be a 64-bit MachO executable</source>
+        <target state="new">Application host is expected to be a 64-bit MachO executable</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatSignBlobNotLast">
+        <source>Signature blob must be at the very end of the file</source>
+        <target state="new">Signature blob must be at the very end of the file</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatSignCommandNotLast">
+        <source>CODE_SIGNATURE command must be the last command</source>
+        <target state="new">CODE_SIGNATURE command must be the last command</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatSignDoesntFollowSymtab">
+        <source>Signature blob must immediately follow the Symtab</source>
+        <target state="new">Signature blob must immediately follow the Symtab</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatSignNeedsLinkEdit">
+        <source>CODE_SIGNATURE command must follow a Segment64 command named __LINKEDIT</source>
+        <target state="new">CODE_SIGNATURE command must follow a Segment64 command named __LINKEDIT</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatSignNeedsSymtab">
+        <source>CODE_SIGNATURE command must follow the SYMTAB command</source>
+        <target state="new">CODE_SIGNATURE command must follow the SYMTAB command</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatSignNotInLinkEdit">
+        <source>Signature blob must be within the __LINKEDIT segment!</source>
+        <target state="new">Signature blob must be within the __LINKEDIT segment!</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatSymtabNotInLinkEdit">
+        <source>SYMTAB must within the __LINKEDIT segment!</source>
+        <target state="new">SYMTAB must within the __LINKEDIT segment!</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachONotExpectedFormat">
+        <source>NETSDK1121: Unable to use '{0}' as macOS application host executable it was not in the expected format. Detail reason: {1}.</source>
+        <target state="new">NETSDK1121: Unable to use '{0}' as macOS application host executable it was not in the expected format. Detail reason: {1}.</target>
+        <note>{StrBegin="NETSDK1121: "}</note>
+      </trans-unit>
       <trans-unit id="AppHostNotWindows">
         <source>NETSDK1078: Unable to use '{0}' as application host executable because it's not a Windows PE file.</source>
         <target state="translated">NETSDK1078: Nepovedlo se použít {0} jako spustitelný soubor aplikace, protože to není soubor Windows PE.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.de.xlf
@@ -27,6 +27,76 @@
         <target state="translated">NETSDK1029: "{0}" kann nicht als ausführbare Anwendungshostdatei verwendet werden, da die erwartete Platzhalterbytesequenz "{1}" nicht vorhanden ist, die markiert, wo der Anwendungsname geschrieben wird.</target>
         <note>{StrBegin="NETSDK1029: "}</note>
       </trans-unit>
+      <trans-unit id="AppHostMachOFormatDuplicateLinkEdit">
+        <source>Only one __LINKEDIT segment is expected in the application host</source>
+        <target state="new">Only one __LINKEDIT segment is expected in the application host</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatDuplicateSymtab">
+        <source>Only one SYMTAB is expected in the application host</source>
+        <target state="new">Only one SYMTAB is expected in the application host</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatInvalidUTF8">
+        <source>UTF8 decoding failed</source>
+        <target state="new">UTF8 decoding failed</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatLinkEditNotLast">
+        <source>__LINKEDIT must be the last segment in the binary layout</source>
+        <target state="new">__LINKEDIT must be the last segment in the binary layout</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatMemoryMapAccessFault">
+        <source>Error reading the memory-mapped application host</source>
+        <target state="new">Error reading the memory-mapped application host</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatNot64BitExe">
+        <source>Application host is expected to be a 64-bit MachO executable</source>
+        <target state="new">Application host is expected to be a 64-bit MachO executable</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatSignBlobNotLast">
+        <source>Signature blob must be at the very end of the file</source>
+        <target state="new">Signature blob must be at the very end of the file</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatSignCommandNotLast">
+        <source>CODE_SIGNATURE command must be the last command</source>
+        <target state="new">CODE_SIGNATURE command must be the last command</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatSignDoesntFollowSymtab">
+        <source>Signature blob must immediately follow the Symtab</source>
+        <target state="new">Signature blob must immediately follow the Symtab</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatSignNeedsLinkEdit">
+        <source>CODE_SIGNATURE command must follow a Segment64 command named __LINKEDIT</source>
+        <target state="new">CODE_SIGNATURE command must follow a Segment64 command named __LINKEDIT</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatSignNeedsSymtab">
+        <source>CODE_SIGNATURE command must follow the SYMTAB command</source>
+        <target state="new">CODE_SIGNATURE command must follow the SYMTAB command</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatSignNotInLinkEdit">
+        <source>Signature blob must be within the __LINKEDIT segment!</source>
+        <target state="new">Signature blob must be within the __LINKEDIT segment!</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatSymtabNotInLinkEdit">
+        <source>SYMTAB must within the __LINKEDIT segment!</source>
+        <target state="new">SYMTAB must within the __LINKEDIT segment!</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachONotExpectedFormat">
+        <source>NETSDK1121: Unable to use '{0}' as macOS application host executable it was not in the expected format. Detail reason: {1}.</source>
+        <target state="new">NETSDK1121: Unable to use '{0}' as macOS application host executable it was not in the expected format. Detail reason: {1}.</target>
+        <note>{StrBegin="NETSDK1121: "}</note>
+      </trans-unit>
       <trans-unit id="AppHostNotWindows">
         <source>NETSDK1078: Unable to use '{0}' as application host executable because it's not a Windows PE file.</source>
         <target state="translated">NETSDK1078: "{0}" kann nicht als ausführbare Anwendungshostdatei verwendet werden, weil es sich nicht um eine Windows PE-Datei handelt.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.es.xlf
@@ -27,6 +27,76 @@
         <target state="translated">NETSDK1029: No se puede usar "{0}" como ejecutable del host de aplicación ya que no contiene la secuencia de bytes esperada del marcador de posición "{1}" que marcaría dónde escribir el nombre de la aplicación.</target>
         <note>{StrBegin="NETSDK1029: "}</note>
       </trans-unit>
+      <trans-unit id="AppHostMachOFormatDuplicateLinkEdit">
+        <source>Only one __LINKEDIT segment is expected in the application host</source>
+        <target state="new">Only one __LINKEDIT segment is expected in the application host</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatDuplicateSymtab">
+        <source>Only one SYMTAB is expected in the application host</source>
+        <target state="new">Only one SYMTAB is expected in the application host</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatInvalidUTF8">
+        <source>UTF8 decoding failed</source>
+        <target state="new">UTF8 decoding failed</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatLinkEditNotLast">
+        <source>__LINKEDIT must be the last segment in the binary layout</source>
+        <target state="new">__LINKEDIT must be the last segment in the binary layout</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatMemoryMapAccessFault">
+        <source>Error reading the memory-mapped application host</source>
+        <target state="new">Error reading the memory-mapped application host</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatNot64BitExe">
+        <source>Application host is expected to be a 64-bit MachO executable</source>
+        <target state="new">Application host is expected to be a 64-bit MachO executable</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatSignBlobNotLast">
+        <source>Signature blob must be at the very end of the file</source>
+        <target state="new">Signature blob must be at the very end of the file</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatSignCommandNotLast">
+        <source>CODE_SIGNATURE command must be the last command</source>
+        <target state="new">CODE_SIGNATURE command must be the last command</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatSignDoesntFollowSymtab">
+        <source>Signature blob must immediately follow the Symtab</source>
+        <target state="new">Signature blob must immediately follow the Symtab</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatSignNeedsLinkEdit">
+        <source>CODE_SIGNATURE command must follow a Segment64 command named __LINKEDIT</source>
+        <target state="new">CODE_SIGNATURE command must follow a Segment64 command named __LINKEDIT</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatSignNeedsSymtab">
+        <source>CODE_SIGNATURE command must follow the SYMTAB command</source>
+        <target state="new">CODE_SIGNATURE command must follow the SYMTAB command</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatSignNotInLinkEdit">
+        <source>Signature blob must be within the __LINKEDIT segment!</source>
+        <target state="new">Signature blob must be within the __LINKEDIT segment!</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatSymtabNotInLinkEdit">
+        <source>SYMTAB must within the __LINKEDIT segment!</source>
+        <target state="new">SYMTAB must within the __LINKEDIT segment!</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachONotExpectedFormat">
+        <source>NETSDK1121: Unable to use '{0}' as macOS application host executable it was not in the expected format. Detail reason: {1}.</source>
+        <target state="new">NETSDK1121: Unable to use '{0}' as macOS application host executable it was not in the expected format. Detail reason: {1}.</target>
+        <note>{StrBegin="NETSDK1121: "}</note>
+      </trans-unit>
       <trans-unit id="AppHostNotWindows">
         <source>NETSDK1078: Unable to use '{0}' as application host executable because it's not a Windows PE file.</source>
         <target state="translated">NETSDK1078: No se puede utilizar "{0}" como ejecutable del host de aplicación porque no es un archivo de Windows PE.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
@@ -27,6 +27,76 @@
         <target state="translated">NETSDK1029: Impossible d'utiliser '{0}' en tant qu'exécutable d'hôte d'application, car il ne contient pas la séquence d'octets d'espace réservé attendue '{1}' qui marque l'emplacement où est écrit le nom de l'application.</target>
         <note>{StrBegin="NETSDK1029: "}</note>
       </trans-unit>
+      <trans-unit id="AppHostMachOFormatDuplicateLinkEdit">
+        <source>Only one __LINKEDIT segment is expected in the application host</source>
+        <target state="new">Only one __LINKEDIT segment is expected in the application host</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatDuplicateSymtab">
+        <source>Only one SYMTAB is expected in the application host</source>
+        <target state="new">Only one SYMTAB is expected in the application host</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatInvalidUTF8">
+        <source>UTF8 decoding failed</source>
+        <target state="new">UTF8 decoding failed</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatLinkEditNotLast">
+        <source>__LINKEDIT must be the last segment in the binary layout</source>
+        <target state="new">__LINKEDIT must be the last segment in the binary layout</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatMemoryMapAccessFault">
+        <source>Error reading the memory-mapped application host</source>
+        <target state="new">Error reading the memory-mapped application host</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatNot64BitExe">
+        <source>Application host is expected to be a 64-bit MachO executable</source>
+        <target state="new">Application host is expected to be a 64-bit MachO executable</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatSignBlobNotLast">
+        <source>Signature blob must be at the very end of the file</source>
+        <target state="new">Signature blob must be at the very end of the file</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatSignCommandNotLast">
+        <source>CODE_SIGNATURE command must be the last command</source>
+        <target state="new">CODE_SIGNATURE command must be the last command</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatSignDoesntFollowSymtab">
+        <source>Signature blob must immediately follow the Symtab</source>
+        <target state="new">Signature blob must immediately follow the Symtab</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatSignNeedsLinkEdit">
+        <source>CODE_SIGNATURE command must follow a Segment64 command named __LINKEDIT</source>
+        <target state="new">CODE_SIGNATURE command must follow a Segment64 command named __LINKEDIT</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatSignNeedsSymtab">
+        <source>CODE_SIGNATURE command must follow the SYMTAB command</source>
+        <target state="new">CODE_SIGNATURE command must follow the SYMTAB command</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatSignNotInLinkEdit">
+        <source>Signature blob must be within the __LINKEDIT segment!</source>
+        <target state="new">Signature blob must be within the __LINKEDIT segment!</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatSymtabNotInLinkEdit">
+        <source>SYMTAB must within the __LINKEDIT segment!</source>
+        <target state="new">SYMTAB must within the __LINKEDIT segment!</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachONotExpectedFormat">
+        <source>NETSDK1121: Unable to use '{0}' as macOS application host executable it was not in the expected format. Detail reason: {1}.</source>
+        <target state="new">NETSDK1121: Unable to use '{0}' as macOS application host executable it was not in the expected format. Detail reason: {1}.</target>
+        <note>{StrBegin="NETSDK1121: "}</note>
+      </trans-unit>
       <trans-unit id="AppHostNotWindows">
         <source>NETSDK1078: Unable to use '{0}' as application host executable because it's not a Windows PE file.</source>
         <target state="translated">NETSDK1078: impossible d'utiliser '{0}' en tant qu'exécutable d'hôte d'application, car il ne s'agit pas d'un fichier Windows PE.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.it.xlf
@@ -27,6 +27,76 @@
         <target state="translated">NETSDK1029: non è possibile usare '{0}' come eseguibile host dell'applicazione perché non contiene la sequenza di byte segnaposto prevista '{1}' che indica dove verrà scritto il nome dell'applicazione.</target>
         <note>{StrBegin="NETSDK1029: "}</note>
       </trans-unit>
+      <trans-unit id="AppHostMachOFormatDuplicateLinkEdit">
+        <source>Only one __LINKEDIT segment is expected in the application host</source>
+        <target state="new">Only one __LINKEDIT segment is expected in the application host</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatDuplicateSymtab">
+        <source>Only one SYMTAB is expected in the application host</source>
+        <target state="new">Only one SYMTAB is expected in the application host</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatInvalidUTF8">
+        <source>UTF8 decoding failed</source>
+        <target state="new">UTF8 decoding failed</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatLinkEditNotLast">
+        <source>__LINKEDIT must be the last segment in the binary layout</source>
+        <target state="new">__LINKEDIT must be the last segment in the binary layout</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatMemoryMapAccessFault">
+        <source>Error reading the memory-mapped application host</source>
+        <target state="new">Error reading the memory-mapped application host</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatNot64BitExe">
+        <source>Application host is expected to be a 64-bit MachO executable</source>
+        <target state="new">Application host is expected to be a 64-bit MachO executable</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatSignBlobNotLast">
+        <source>Signature blob must be at the very end of the file</source>
+        <target state="new">Signature blob must be at the very end of the file</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatSignCommandNotLast">
+        <source>CODE_SIGNATURE command must be the last command</source>
+        <target state="new">CODE_SIGNATURE command must be the last command</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatSignDoesntFollowSymtab">
+        <source>Signature blob must immediately follow the Symtab</source>
+        <target state="new">Signature blob must immediately follow the Symtab</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatSignNeedsLinkEdit">
+        <source>CODE_SIGNATURE command must follow a Segment64 command named __LINKEDIT</source>
+        <target state="new">CODE_SIGNATURE command must follow a Segment64 command named __LINKEDIT</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatSignNeedsSymtab">
+        <source>CODE_SIGNATURE command must follow the SYMTAB command</source>
+        <target state="new">CODE_SIGNATURE command must follow the SYMTAB command</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatSignNotInLinkEdit">
+        <source>Signature blob must be within the __LINKEDIT segment!</source>
+        <target state="new">Signature blob must be within the __LINKEDIT segment!</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatSymtabNotInLinkEdit">
+        <source>SYMTAB must within the __LINKEDIT segment!</source>
+        <target state="new">SYMTAB must within the __LINKEDIT segment!</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachONotExpectedFormat">
+        <source>NETSDK1121: Unable to use '{0}' as macOS application host executable it was not in the expected format. Detail reason: {1}.</source>
+        <target state="new">NETSDK1121: Unable to use '{0}' as macOS application host executable it was not in the expected format. Detail reason: {1}.</target>
+        <note>{StrBegin="NETSDK1121: "}</note>
+      </trans-unit>
       <trans-unit id="AppHostNotWindows">
         <source>NETSDK1078: Unable to use '{0}' as application host executable because it's not a Windows PE file.</source>
         <target state="translated">NETSDK1078: non è possibile usare '{0}' come eseguibile dell'host applicazione perché non è un file di Windows PE.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
@@ -27,6 +27,76 @@
         <target state="translated">NETSDK1029: '{0}' は、本来アプリケーション名が書き込まれる場所を示す、必要なプレースホルダー バイト シーケンス '{1}' が含まれていないため、実行可能アプリケーション ホストとして使用できません。</target>
         <note>{StrBegin="NETSDK1029: "}</note>
       </trans-unit>
+      <trans-unit id="AppHostMachOFormatDuplicateLinkEdit">
+        <source>Only one __LINKEDIT segment is expected in the application host</source>
+        <target state="new">Only one __LINKEDIT segment is expected in the application host</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatDuplicateSymtab">
+        <source>Only one SYMTAB is expected in the application host</source>
+        <target state="new">Only one SYMTAB is expected in the application host</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatInvalidUTF8">
+        <source>UTF8 decoding failed</source>
+        <target state="new">UTF8 decoding failed</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatLinkEditNotLast">
+        <source>__LINKEDIT must be the last segment in the binary layout</source>
+        <target state="new">__LINKEDIT must be the last segment in the binary layout</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatMemoryMapAccessFault">
+        <source>Error reading the memory-mapped application host</source>
+        <target state="new">Error reading the memory-mapped application host</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatNot64BitExe">
+        <source>Application host is expected to be a 64-bit MachO executable</source>
+        <target state="new">Application host is expected to be a 64-bit MachO executable</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatSignBlobNotLast">
+        <source>Signature blob must be at the very end of the file</source>
+        <target state="new">Signature blob must be at the very end of the file</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatSignCommandNotLast">
+        <source>CODE_SIGNATURE command must be the last command</source>
+        <target state="new">CODE_SIGNATURE command must be the last command</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatSignDoesntFollowSymtab">
+        <source>Signature blob must immediately follow the Symtab</source>
+        <target state="new">Signature blob must immediately follow the Symtab</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatSignNeedsLinkEdit">
+        <source>CODE_SIGNATURE command must follow a Segment64 command named __LINKEDIT</source>
+        <target state="new">CODE_SIGNATURE command must follow a Segment64 command named __LINKEDIT</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatSignNeedsSymtab">
+        <source>CODE_SIGNATURE command must follow the SYMTAB command</source>
+        <target state="new">CODE_SIGNATURE command must follow the SYMTAB command</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatSignNotInLinkEdit">
+        <source>Signature blob must be within the __LINKEDIT segment!</source>
+        <target state="new">Signature blob must be within the __LINKEDIT segment!</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatSymtabNotInLinkEdit">
+        <source>SYMTAB must within the __LINKEDIT segment!</source>
+        <target state="new">SYMTAB must within the __LINKEDIT segment!</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachONotExpectedFormat">
+        <source>NETSDK1121: Unable to use '{0}' as macOS application host executable it was not in the expected format. Detail reason: {1}.</source>
+        <target state="new">NETSDK1121: Unable to use '{0}' as macOS application host executable it was not in the expected format. Detail reason: {1}.</target>
+        <note>{StrBegin="NETSDK1121: "}</note>
+      </trans-unit>
       <trans-unit id="AppHostNotWindows">
         <source>NETSDK1078: Unable to use '{0}' as application host executable because it's not a Windows PE file.</source>
         <target state="translated">NETSDK1078: Windows PE ファイルではないため、'{0}' をアプリケーション ホストの実行可能ファイルとして使用することはできません。</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
@@ -27,6 +27,76 @@
         <target state="translated">NETSDK1029: 애플리케이션 이름이 기록되는 위치를 표시하는 '{1}' 예상 자리 표시자 바이트 시퀀스가 포함되지 않아서 '{0}'을(를) 애플리케이션 호스트 실행 파일로 사용할 수 없습니다.</target>
         <note>{StrBegin="NETSDK1029: "}</note>
       </trans-unit>
+      <trans-unit id="AppHostMachOFormatDuplicateLinkEdit">
+        <source>Only one __LINKEDIT segment is expected in the application host</source>
+        <target state="new">Only one __LINKEDIT segment is expected in the application host</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatDuplicateSymtab">
+        <source>Only one SYMTAB is expected in the application host</source>
+        <target state="new">Only one SYMTAB is expected in the application host</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatInvalidUTF8">
+        <source>UTF8 decoding failed</source>
+        <target state="new">UTF8 decoding failed</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatLinkEditNotLast">
+        <source>__LINKEDIT must be the last segment in the binary layout</source>
+        <target state="new">__LINKEDIT must be the last segment in the binary layout</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatMemoryMapAccessFault">
+        <source>Error reading the memory-mapped application host</source>
+        <target state="new">Error reading the memory-mapped application host</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatNot64BitExe">
+        <source>Application host is expected to be a 64-bit MachO executable</source>
+        <target state="new">Application host is expected to be a 64-bit MachO executable</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatSignBlobNotLast">
+        <source>Signature blob must be at the very end of the file</source>
+        <target state="new">Signature blob must be at the very end of the file</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatSignCommandNotLast">
+        <source>CODE_SIGNATURE command must be the last command</source>
+        <target state="new">CODE_SIGNATURE command must be the last command</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatSignDoesntFollowSymtab">
+        <source>Signature blob must immediately follow the Symtab</source>
+        <target state="new">Signature blob must immediately follow the Symtab</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatSignNeedsLinkEdit">
+        <source>CODE_SIGNATURE command must follow a Segment64 command named __LINKEDIT</source>
+        <target state="new">CODE_SIGNATURE command must follow a Segment64 command named __LINKEDIT</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatSignNeedsSymtab">
+        <source>CODE_SIGNATURE command must follow the SYMTAB command</source>
+        <target state="new">CODE_SIGNATURE command must follow the SYMTAB command</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatSignNotInLinkEdit">
+        <source>Signature blob must be within the __LINKEDIT segment!</source>
+        <target state="new">Signature blob must be within the __LINKEDIT segment!</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatSymtabNotInLinkEdit">
+        <source>SYMTAB must within the __LINKEDIT segment!</source>
+        <target state="new">SYMTAB must within the __LINKEDIT segment!</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachONotExpectedFormat">
+        <source>NETSDK1121: Unable to use '{0}' as macOS application host executable it was not in the expected format. Detail reason: {1}.</source>
+        <target state="new">NETSDK1121: Unable to use '{0}' as macOS application host executable it was not in the expected format. Detail reason: {1}.</target>
+        <note>{StrBegin="NETSDK1121: "}</note>
+      </trans-unit>
       <trans-unit id="AppHostNotWindows">
         <source>NETSDK1078: Unable to use '{0}' as application host executable because it's not a Windows PE file.</source>
         <target state="translated">NETSDK1078: Windows PE 파일이 아니므로 '{0}'을(를) 애플리케이션 호스트 실행 파일로 사용할 수 없습니다.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
@@ -27,6 +27,76 @@
         <target state="translated">NETSDK1029: Nie można użyć elementu „{0}” jako pliku wykonywalnego hosta aplikacji, ponieważ nie zawiera on oczekiwanej sekwencji bajtów symbolu zastępczego „{1}”, która wskazuje lokalizację zapisu nazwy aplikacji.</target>
         <note>{StrBegin="NETSDK1029: "}</note>
       </trans-unit>
+      <trans-unit id="AppHostMachOFormatDuplicateLinkEdit">
+        <source>Only one __LINKEDIT segment is expected in the application host</source>
+        <target state="new">Only one __LINKEDIT segment is expected in the application host</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatDuplicateSymtab">
+        <source>Only one SYMTAB is expected in the application host</source>
+        <target state="new">Only one SYMTAB is expected in the application host</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatInvalidUTF8">
+        <source>UTF8 decoding failed</source>
+        <target state="new">UTF8 decoding failed</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatLinkEditNotLast">
+        <source>__LINKEDIT must be the last segment in the binary layout</source>
+        <target state="new">__LINKEDIT must be the last segment in the binary layout</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatMemoryMapAccessFault">
+        <source>Error reading the memory-mapped application host</source>
+        <target state="new">Error reading the memory-mapped application host</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatNot64BitExe">
+        <source>Application host is expected to be a 64-bit MachO executable</source>
+        <target state="new">Application host is expected to be a 64-bit MachO executable</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatSignBlobNotLast">
+        <source>Signature blob must be at the very end of the file</source>
+        <target state="new">Signature blob must be at the very end of the file</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatSignCommandNotLast">
+        <source>CODE_SIGNATURE command must be the last command</source>
+        <target state="new">CODE_SIGNATURE command must be the last command</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatSignDoesntFollowSymtab">
+        <source>Signature blob must immediately follow the Symtab</source>
+        <target state="new">Signature blob must immediately follow the Symtab</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatSignNeedsLinkEdit">
+        <source>CODE_SIGNATURE command must follow a Segment64 command named __LINKEDIT</source>
+        <target state="new">CODE_SIGNATURE command must follow a Segment64 command named __LINKEDIT</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatSignNeedsSymtab">
+        <source>CODE_SIGNATURE command must follow the SYMTAB command</source>
+        <target state="new">CODE_SIGNATURE command must follow the SYMTAB command</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatSignNotInLinkEdit">
+        <source>Signature blob must be within the __LINKEDIT segment!</source>
+        <target state="new">Signature blob must be within the __LINKEDIT segment!</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatSymtabNotInLinkEdit">
+        <source>SYMTAB must within the __LINKEDIT segment!</source>
+        <target state="new">SYMTAB must within the __LINKEDIT segment!</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachONotExpectedFormat">
+        <source>NETSDK1121: Unable to use '{0}' as macOS application host executable it was not in the expected format. Detail reason: {1}.</source>
+        <target state="new">NETSDK1121: Unable to use '{0}' as macOS application host executable it was not in the expected format. Detail reason: {1}.</target>
+        <note>{StrBegin="NETSDK1121: "}</note>
+      </trans-unit>
       <trans-unit id="AppHostNotWindows">
         <source>NETSDK1078: Unable to use '{0}' as application host executable because it's not a Windows PE file.</source>
         <target state="translated">NETSDK1078: Nie można użyć pliku „{0}” jako pliku wykonywalnego hosta aplikacji, ponieważ nie jest to plik systemu Windows PE.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
@@ -27,6 +27,76 @@
         <target state="translated">NETSDK1029: Não é possível usar '{0}' como executável do host de aplicativo, porque ele não contém a sequência de bytes de espaço reservado esperada '{1}' que marcaria o local em que o nome do aplicativo seria gravado.</target>
         <note>{StrBegin="NETSDK1029: "}</note>
       </trans-unit>
+      <trans-unit id="AppHostMachOFormatDuplicateLinkEdit">
+        <source>Only one __LINKEDIT segment is expected in the application host</source>
+        <target state="new">Only one __LINKEDIT segment is expected in the application host</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatDuplicateSymtab">
+        <source>Only one SYMTAB is expected in the application host</source>
+        <target state="new">Only one SYMTAB is expected in the application host</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatInvalidUTF8">
+        <source>UTF8 decoding failed</source>
+        <target state="new">UTF8 decoding failed</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatLinkEditNotLast">
+        <source>__LINKEDIT must be the last segment in the binary layout</source>
+        <target state="new">__LINKEDIT must be the last segment in the binary layout</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatMemoryMapAccessFault">
+        <source>Error reading the memory-mapped application host</source>
+        <target state="new">Error reading the memory-mapped application host</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatNot64BitExe">
+        <source>Application host is expected to be a 64-bit MachO executable</source>
+        <target state="new">Application host is expected to be a 64-bit MachO executable</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatSignBlobNotLast">
+        <source>Signature blob must be at the very end of the file</source>
+        <target state="new">Signature blob must be at the very end of the file</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatSignCommandNotLast">
+        <source>CODE_SIGNATURE command must be the last command</source>
+        <target state="new">CODE_SIGNATURE command must be the last command</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatSignDoesntFollowSymtab">
+        <source>Signature blob must immediately follow the Symtab</source>
+        <target state="new">Signature blob must immediately follow the Symtab</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatSignNeedsLinkEdit">
+        <source>CODE_SIGNATURE command must follow a Segment64 command named __LINKEDIT</source>
+        <target state="new">CODE_SIGNATURE command must follow a Segment64 command named __LINKEDIT</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatSignNeedsSymtab">
+        <source>CODE_SIGNATURE command must follow the SYMTAB command</source>
+        <target state="new">CODE_SIGNATURE command must follow the SYMTAB command</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatSignNotInLinkEdit">
+        <source>Signature blob must be within the __LINKEDIT segment!</source>
+        <target state="new">Signature blob must be within the __LINKEDIT segment!</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatSymtabNotInLinkEdit">
+        <source>SYMTAB must within the __LINKEDIT segment!</source>
+        <target state="new">SYMTAB must within the __LINKEDIT segment!</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachONotExpectedFormat">
+        <source>NETSDK1121: Unable to use '{0}' as macOS application host executable it was not in the expected format. Detail reason: {1}.</source>
+        <target state="new">NETSDK1121: Unable to use '{0}' as macOS application host executable it was not in the expected format. Detail reason: {1}.</target>
+        <note>{StrBegin="NETSDK1121: "}</note>
+      </trans-unit>
       <trans-unit id="AppHostNotWindows">
         <source>NETSDK1078: Unable to use '{0}' as application host executable because it's not a Windows PE file.</source>
         <target state="translated">NETSDK1078: não é possível usar '{0}' como um host de aplicativo executável porque ele não é um arquivo do Windows PE.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
@@ -27,6 +27,76 @@
         <target state="translated">NETSDK1029: невозможно использовать файл "{0}" в качестве исполняемого файла узла приложения, так как этот файл не содержит ожидаемого заполнителя с последовательностью байтов "{1}", который отмечает место, где должно быть записано имя приложения.</target>
         <note>{StrBegin="NETSDK1029: "}</note>
       </trans-unit>
+      <trans-unit id="AppHostMachOFormatDuplicateLinkEdit">
+        <source>Only one __LINKEDIT segment is expected in the application host</source>
+        <target state="new">Only one __LINKEDIT segment is expected in the application host</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatDuplicateSymtab">
+        <source>Only one SYMTAB is expected in the application host</source>
+        <target state="new">Only one SYMTAB is expected in the application host</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatInvalidUTF8">
+        <source>UTF8 decoding failed</source>
+        <target state="new">UTF8 decoding failed</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatLinkEditNotLast">
+        <source>__LINKEDIT must be the last segment in the binary layout</source>
+        <target state="new">__LINKEDIT must be the last segment in the binary layout</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatMemoryMapAccessFault">
+        <source>Error reading the memory-mapped application host</source>
+        <target state="new">Error reading the memory-mapped application host</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatNot64BitExe">
+        <source>Application host is expected to be a 64-bit MachO executable</source>
+        <target state="new">Application host is expected to be a 64-bit MachO executable</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatSignBlobNotLast">
+        <source>Signature blob must be at the very end of the file</source>
+        <target state="new">Signature blob must be at the very end of the file</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatSignCommandNotLast">
+        <source>CODE_SIGNATURE command must be the last command</source>
+        <target state="new">CODE_SIGNATURE command must be the last command</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatSignDoesntFollowSymtab">
+        <source>Signature blob must immediately follow the Symtab</source>
+        <target state="new">Signature blob must immediately follow the Symtab</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatSignNeedsLinkEdit">
+        <source>CODE_SIGNATURE command must follow a Segment64 command named __LINKEDIT</source>
+        <target state="new">CODE_SIGNATURE command must follow a Segment64 command named __LINKEDIT</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatSignNeedsSymtab">
+        <source>CODE_SIGNATURE command must follow the SYMTAB command</source>
+        <target state="new">CODE_SIGNATURE command must follow the SYMTAB command</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatSignNotInLinkEdit">
+        <source>Signature blob must be within the __LINKEDIT segment!</source>
+        <target state="new">Signature blob must be within the __LINKEDIT segment!</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatSymtabNotInLinkEdit">
+        <source>SYMTAB must within the __LINKEDIT segment!</source>
+        <target state="new">SYMTAB must within the __LINKEDIT segment!</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachONotExpectedFormat">
+        <source>NETSDK1121: Unable to use '{0}' as macOS application host executable it was not in the expected format. Detail reason: {1}.</source>
+        <target state="new">NETSDK1121: Unable to use '{0}' as macOS application host executable it was not in the expected format. Detail reason: {1}.</target>
+        <note>{StrBegin="NETSDK1121: "}</note>
+      </trans-unit>
       <trans-unit id="AppHostNotWindows">
         <source>NETSDK1078: Unable to use '{0}' as application host executable because it's not a Windows PE file.</source>
         <target state="translated">NETSDK1078: не удалось использовать "{0}" в качестве исполняемого файла узла приложения, так как это не файл Windows PE.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
@@ -27,6 +27,76 @@
         <target state="translated">NETSDK1029: '{0}', uygulama adının yazılacağı yeri işaretlemesi için beklenen yer tutucu bayt dizisini ('{1}') içermediğinden uygulama konak yürütülebilir dosyası olarak kullanılamıyor.</target>
         <note>{StrBegin="NETSDK1029: "}</note>
       </trans-unit>
+      <trans-unit id="AppHostMachOFormatDuplicateLinkEdit">
+        <source>Only one __LINKEDIT segment is expected in the application host</source>
+        <target state="new">Only one __LINKEDIT segment is expected in the application host</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatDuplicateSymtab">
+        <source>Only one SYMTAB is expected in the application host</source>
+        <target state="new">Only one SYMTAB is expected in the application host</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatInvalidUTF8">
+        <source>UTF8 decoding failed</source>
+        <target state="new">UTF8 decoding failed</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatLinkEditNotLast">
+        <source>__LINKEDIT must be the last segment in the binary layout</source>
+        <target state="new">__LINKEDIT must be the last segment in the binary layout</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatMemoryMapAccessFault">
+        <source>Error reading the memory-mapped application host</source>
+        <target state="new">Error reading the memory-mapped application host</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatNot64BitExe">
+        <source>Application host is expected to be a 64-bit MachO executable</source>
+        <target state="new">Application host is expected to be a 64-bit MachO executable</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatSignBlobNotLast">
+        <source>Signature blob must be at the very end of the file</source>
+        <target state="new">Signature blob must be at the very end of the file</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatSignCommandNotLast">
+        <source>CODE_SIGNATURE command must be the last command</source>
+        <target state="new">CODE_SIGNATURE command must be the last command</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatSignDoesntFollowSymtab">
+        <source>Signature blob must immediately follow the Symtab</source>
+        <target state="new">Signature blob must immediately follow the Symtab</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatSignNeedsLinkEdit">
+        <source>CODE_SIGNATURE command must follow a Segment64 command named __LINKEDIT</source>
+        <target state="new">CODE_SIGNATURE command must follow a Segment64 command named __LINKEDIT</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatSignNeedsSymtab">
+        <source>CODE_SIGNATURE command must follow the SYMTAB command</source>
+        <target state="new">CODE_SIGNATURE command must follow the SYMTAB command</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatSignNotInLinkEdit">
+        <source>Signature blob must be within the __LINKEDIT segment!</source>
+        <target state="new">Signature blob must be within the __LINKEDIT segment!</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatSymtabNotInLinkEdit">
+        <source>SYMTAB must within the __LINKEDIT segment!</source>
+        <target state="new">SYMTAB must within the __LINKEDIT segment!</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachONotExpectedFormat">
+        <source>NETSDK1121: Unable to use '{0}' as macOS application host executable it was not in the expected format. Detail reason: {1}.</source>
+        <target state="new">NETSDK1121: Unable to use '{0}' as macOS application host executable it was not in the expected format. Detail reason: {1}.</target>
+        <note>{StrBegin="NETSDK1121: "}</note>
+      </trans-unit>
       <trans-unit id="AppHostNotWindows">
         <source>NETSDK1078: Unable to use '{0}' as application host executable because it's not a Windows PE file.</source>
         <target state="translated">NETSDK1078: '{0}', bir Windows PE dosyası olmadığından uygulama konağının yürütülebilir dosyası olarak kullanılamıyor.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
@@ -27,6 +27,76 @@
         <target state="translated">NETSDK1029: 未能将“{0}”用作应用程序主机可执行文件，因为它没有必需的占位符字节序列“{1}”，该序列会标记应用程序名称的写入位置。</target>
         <note>{StrBegin="NETSDK1029: "}</note>
       </trans-unit>
+      <trans-unit id="AppHostMachOFormatDuplicateLinkEdit">
+        <source>Only one __LINKEDIT segment is expected in the application host</source>
+        <target state="new">Only one __LINKEDIT segment is expected in the application host</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatDuplicateSymtab">
+        <source>Only one SYMTAB is expected in the application host</source>
+        <target state="new">Only one SYMTAB is expected in the application host</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatInvalidUTF8">
+        <source>UTF8 decoding failed</source>
+        <target state="new">UTF8 decoding failed</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatLinkEditNotLast">
+        <source>__LINKEDIT must be the last segment in the binary layout</source>
+        <target state="new">__LINKEDIT must be the last segment in the binary layout</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatMemoryMapAccessFault">
+        <source>Error reading the memory-mapped application host</source>
+        <target state="new">Error reading the memory-mapped application host</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatNot64BitExe">
+        <source>Application host is expected to be a 64-bit MachO executable</source>
+        <target state="new">Application host is expected to be a 64-bit MachO executable</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatSignBlobNotLast">
+        <source>Signature blob must be at the very end of the file</source>
+        <target state="new">Signature blob must be at the very end of the file</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatSignCommandNotLast">
+        <source>CODE_SIGNATURE command must be the last command</source>
+        <target state="new">CODE_SIGNATURE command must be the last command</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatSignDoesntFollowSymtab">
+        <source>Signature blob must immediately follow the Symtab</source>
+        <target state="new">Signature blob must immediately follow the Symtab</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatSignNeedsLinkEdit">
+        <source>CODE_SIGNATURE command must follow a Segment64 command named __LINKEDIT</source>
+        <target state="new">CODE_SIGNATURE command must follow a Segment64 command named __LINKEDIT</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatSignNeedsSymtab">
+        <source>CODE_SIGNATURE command must follow the SYMTAB command</source>
+        <target state="new">CODE_SIGNATURE command must follow the SYMTAB command</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatSignNotInLinkEdit">
+        <source>Signature blob must be within the __LINKEDIT segment!</source>
+        <target state="new">Signature blob must be within the __LINKEDIT segment!</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatSymtabNotInLinkEdit">
+        <source>SYMTAB must within the __LINKEDIT segment!</source>
+        <target state="new">SYMTAB must within the __LINKEDIT segment!</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachONotExpectedFormat">
+        <source>NETSDK1121: Unable to use '{0}' as macOS application host executable it was not in the expected format. Detail reason: {1}.</source>
+        <target state="new">NETSDK1121: Unable to use '{0}' as macOS application host executable it was not in the expected format. Detail reason: {1}.</target>
+        <note>{StrBegin="NETSDK1121: "}</note>
+      </trans-unit>
       <trans-unit id="AppHostNotWindows">
         <source>NETSDK1078: Unable to use '{0}' as application host executable because it's not a Windows PE file.</source>
         <target state="translated">NETSDK1078: 无法将“{0}”用作应用程序主机可执行文件，因为它不是 Windows PE 文件。</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
@@ -27,6 +27,76 @@
         <target state="translated">NETSDK1029: 無法使用 '{0}' 作為應用程式主機可執行檔，因為它並未包含應有的預留位置位元組序列 '{1}'，其會標示寫入應用程式名稱的位置。</target>
         <note>{StrBegin="NETSDK1029: "}</note>
       </trans-unit>
+      <trans-unit id="AppHostMachOFormatDuplicateLinkEdit">
+        <source>Only one __LINKEDIT segment is expected in the application host</source>
+        <target state="new">Only one __LINKEDIT segment is expected in the application host</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatDuplicateSymtab">
+        <source>Only one SYMTAB is expected in the application host</source>
+        <target state="new">Only one SYMTAB is expected in the application host</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatInvalidUTF8">
+        <source>UTF8 decoding failed</source>
+        <target state="new">UTF8 decoding failed</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatLinkEditNotLast">
+        <source>__LINKEDIT must be the last segment in the binary layout</source>
+        <target state="new">__LINKEDIT must be the last segment in the binary layout</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatMemoryMapAccessFault">
+        <source>Error reading the memory-mapped application host</source>
+        <target state="new">Error reading the memory-mapped application host</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatNot64BitExe">
+        <source>Application host is expected to be a 64-bit MachO executable</source>
+        <target state="new">Application host is expected to be a 64-bit MachO executable</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatSignBlobNotLast">
+        <source>Signature blob must be at the very end of the file</source>
+        <target state="new">Signature blob must be at the very end of the file</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatSignCommandNotLast">
+        <source>CODE_SIGNATURE command must be the last command</source>
+        <target state="new">CODE_SIGNATURE command must be the last command</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatSignDoesntFollowSymtab">
+        <source>Signature blob must immediately follow the Symtab</source>
+        <target state="new">Signature blob must immediately follow the Symtab</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatSignNeedsLinkEdit">
+        <source>CODE_SIGNATURE command must follow a Segment64 command named __LINKEDIT</source>
+        <target state="new">CODE_SIGNATURE command must follow a Segment64 command named __LINKEDIT</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatSignNeedsSymtab">
+        <source>CODE_SIGNATURE command must follow the SYMTAB command</source>
+        <target state="new">CODE_SIGNATURE command must follow the SYMTAB command</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatSignNotInLinkEdit">
+        <source>Signature blob must be within the __LINKEDIT segment!</source>
+        <target state="new">Signature blob must be within the __LINKEDIT segment!</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachOFormatSymtabNotInLinkEdit">
+        <source>SYMTAB must within the __LINKEDIT segment!</source>
+        <target state="new">SYMTAB must within the __LINKEDIT segment!</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostMachONotExpectedFormat">
+        <source>NETSDK1121: Unable to use '{0}' as macOS application host executable it was not in the expected format. Detail reason: {1}.</source>
+        <target state="new">NETSDK1121: Unable to use '{0}' as macOS application host executable it was not in the expected format. Detail reason: {1}.</target>
+        <note>{StrBegin="NETSDK1121: "}</note>
+      </trans-unit>
       <trans-unit id="AppHostNotWindows">
         <source>NETSDK1078: Unable to use '{0}' as application host executable because it's not a Windows PE file.</source>
         <target state="translated">NETSDK1078: 因為 '{0}' 並非 Windows PE 檔案，所以無法將其用為應用程式主機可執行檔。</target>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/CreateAppHost.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/CreateAppHost.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Threading;
 using Microsoft.Build.Framework;
@@ -111,8 +112,25 @@ namespace Microsoft.NET.Build.Tasks
             }
             catch (AppHostMachOFormatException ex)
             {
-                throw new BuildErrorException(Strings.FileNameIsTooLong, ex.LongName);
+                throw new BuildErrorException(Strings.AppHostMachONotExpectedFormat , AppHostSourcePath, ErrorMap[ex.Error]);
             }
         }
+
+        private static readonly Dictionary<MachOFormatError, string> ErrorMap = new Dictionary<MachOFormatError, string>
+        {
+            [MachOFormatError.Not64BitExe] = Strings.AppHostMachOFormatNot64BitExe,
+            [MachOFormatError.DuplicateLinkEdit] = Strings.AppHostMachOFormatDuplicateLinkEdit,
+            [MachOFormatError.DuplicateSymtab] = Strings.AppHostMachOFormatDuplicateSymtab,
+            [MachOFormatError.SignNeedsLinkEdit] = Strings.AppHostMachOFormatSignNeedsLinkEdit,
+            [MachOFormatError.SignNeedsSymtab] = Strings.AppHostMachOFormatSignNeedsSymtab,
+            [MachOFormatError.LinkEditNotLast] = Strings.AppHostMachOFormatLinkEditNotLast,
+            [MachOFormatError.SymtabNotInLinkEdit] = Strings.AppHostMachOFormatSymtabNotInLinkEdit,
+            [MachOFormatError.SignNotInLinkEdit] = Strings.AppHostMachOFormatSignNotInLinkEdit,
+            [MachOFormatError.SignCommandNotLast] = Strings.AppHostMachOFormatSignCommandNotLast,
+            [MachOFormatError.SignBlobNotLast] = Strings.AppHostMachOFormatSignBlobNotLast,
+            [MachOFormatError.SignDoesntFollowSymtab] = Strings.AppHostMachOFormatSignDoesntFollowSymtab,
+            [MachOFormatError.MemoryMapAccessFault] = Strings.AppHostMachOFormatMemoryMapAccessFault,
+            [MachOFormatError.InvalidUTF8] = Strings.AppHostMachOFormatInvalidUTF8
+        };
     }
 }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/CreateAppHost.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/CreateAppHost.cs
@@ -109,6 +109,10 @@ namespace Microsoft.NET.Build.Tasks
             {
                 throw new BuildErrorException(Strings.AppHostHasBeenModified, AppHostSourcePath, BitConverter.ToString(ex.MissingPattern));
             }
+            catch (AppHostMachOFormatException ex)
+            {
+                throw new BuildErrorException(Strings.FileNameIsTooLong, ex.LongName);
+            }
         }
     }
 }


### PR DESCRIPTION
Continue https://github.com/dotnet/core-setup/pull/8543

@swaroop-sridhar, that's all for 3.1 for mac right?
@KathleenDollard 

I localized the detail error message. We could just error out generic "format is wrong: DuplicateLinkEdit", but i think i would be easier to debug