### PR TITLE
Disable Windows_Perf_Helix leg in 3.1

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -55,20 +55,6 @@ stages:
   - ${{ if ne(variables['System.TeamProject'], 'public') }}:
     - template: /eng/build.yml
       parameters:
-        agentOs: Windows_Perf_Helix
-        pool:
-          name: Hosted VS2017
-        strategy:
-          matrix:
-            Build_Release:
-              _BuildConfig: Release
-              _PublishType: none
-              _SignType: test
-              _DotNetPublishToBlobFeed: false
-
-  - ${{ if ne(variables['System.TeamProject'], 'public') }}:
-    - template: /eng/build.yml
-      parameters:
         agentOs: Windows_Perf_Helix_Fullframework
         pool:
           name: Hosted VS2017


### PR DESCRIPTION
This leg has been failing in 3.1 internal builds without producing any useable test logs from Helix. Perf isn't a blocker here, so I'm disabling the leg to get the 3.1-preview2 builds going again.

CC @nguerrera @dsplaisted @wli3 @livarcocc 