### PR TITLE
Fix NullRef generating runtime config for NET Framework TFM

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/GenerateRuntimeConfigurationFiles.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/GenerateRuntimeConfigurationFiles.cs
@@ -137,14 +137,18 @@ namespace Microsoft.NET.Build.Tasks
             var frameworks = new List<RuntimeConfigFramework>();
             if (projectContext.RuntimeFrameworks == null || projectContext.RuntimeFrameworks.Length == 0)
             {
-                //  If there are no RuntimeFrameworks (which would be set in the ProcessFrameworkReferences task based
-                //  on FrameworkReference items), then use package resolved from MicrosoftNETPlatformLibrary for
-                //  the runtimeconfig
-                RuntimeConfigFramework framework = new RuntimeConfigFramework();
-                framework.Name = projectContext.PlatformLibrary.Name;
-                framework.Version = projectContext.PlatformLibrary.Version.ToNormalizedString();
+                // If the project is not targetting .NET Core, it will not have any platform library (and is marked as non-FrameworkDependent).
+                if (projectContext.PlatformLibrary != null)
+                {
+                    //  If there are no RuntimeFrameworks (which would be set in the ProcessFrameworkReferences task based
+                    //  on FrameworkReference items), then use package resolved from MicrosoftNETPlatformLibrary for
+                    //  the runtimeconfig
+                    RuntimeConfigFramework framework = new RuntimeConfigFramework();
+                    framework.Name = projectContext.PlatformLibrary.Name;
+                    framework.Version = projectContext.PlatformLibrary.Version.ToNormalizedString();
 
-                frameworks.Add(framework);
+                    frameworks.Add(framework);
+                }
             }
             else
             {


### PR DESCRIPTION
#### Scenario
Building `net472` project with `<GenerateRuntimeConfigFiles>true</GenerateRuntimeConfigFiles>` fails with a NullRef.
See #3857 for a real-world repro project.

This is a regression in 3.1.1xx - caused by #3697.

#### Fix
If the TFM is net472 (or any other non .NET Core TFM) but something still forces the GenerateRuntimeConfigurationFiles target to run (can be done by setting the same property explicitely to true), there will be no PlatformLibrary available, but the project will otherwise look just like self-contained app (other than the TFM).

Before #3697 the frameworks processing would simply be skipped due to the project not being framework dependent. After that change we still try to process frameworks. The fix is to check for availability of any PlatformLibrary, and if not available treat it as if there are no frameworks (just like before #3697.

#### Risk
Low - simply avoid the NullRef and get the code to the same position it was before #3697 with these projects.

#### Customer impact
Regression in 3.1.1xxx - project built before, now it doesn't.
There's a "workaround" - the project should never set `GenerateRuntimeConfigFiles` for anything but `.NET Core` TFMs - modify the project to only set it for .NET Core TFMs and everything works.