### PR TITLE
Fix a bug in computation of files to bundle into a single file app.

### DIFF
--- a/src/Assets/TestProjects/HelloWorldWithSubDirs/HelloWorldWithSubDirs.csproj
+++ b/src/Assets/TestProjects/HelloWorldWithSubDirs/HelloWorldWithSubDirs.csproj
@@ -9,9 +9,13 @@
     <Content Include="$(MSBuildThisFileDirectory)\SmallNameDir\**\*.*" >
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
     </Content>
-    <Content Include="$(MSBuildThisFileDirectory)\Signature.stamp" >
+    <Content Include="$(MSBuildThisFileDirectory)\Signature.Newest.Stamp" >
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
-      <ExcludeFromSingleFile>$(ExcludeContent)</ExcludeFromSingleFile>
+      <ExcludeFromSingleFile>$(ExcludeNewest)</ExcludeFromSingleFile>
+    </Content>
+    <Content Include="$(MSBuildThisFileDirectory)\Signature.Always.Stamp" >
+      <CopyToPublishDirectory>Always</CopyToPublishDirectory>
+      <ExcludeFromSingleFile>$(ExcludeAlways)</ExcludeFromSingleFile>
     </Content>
   </ItemGroup>
 

--- a/src/Assets/TestProjects/HelloWorldWithSubDirs/Signature.Always.Stamp
+++ b/src/Assets/TestProjects/HelloWorldWithSubDirs/Signature.Always.Stamp
@@ -1,0 +1,1 @@
+Signed by all .Net Core SDK devs.

--- a/src/Assets/TestProjects/HelloWorldWithSubDirs/Signature.Newest.Stamp
+++ b/src/Assets/TestProjects/HelloWorldWithSubDirs/Signature.Newest.Stamp
@@ -1,0 +1,1 @@
+Signed by newest .Net Core SDK devs.

--- a/src/Assets/TestProjects/HelloWorldWithSubDirs/Signature.stamp
+++ b/src/Assets/TestProjects/HelloWorldWithSubDirs/Signature.stamp
@@ -1,1 +1,0 @@
-Signed by .Net Core SDK devs.

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -856,7 +856,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       <_FilesToBundle Include="@(_ResolvedFileToPublishPreserveNewest)" 
                       Condition="'%(_ResolvedFileToPublishPreserveNewest.ExcludeFromSingleFile)' != 'true'"/>
       <_FilesToBundle Include="@(_ResolvedFileToPublishAlways)" 
-                      Condition="'%(_ResolvedFileToPublishPreserveNewest.ExcludeFromSingleFile)' != 'true'"/>
+                      Condition="'%(_ResolvedFileToPublishAlways.ExcludeFromSingleFile)' != 'true'"/>
     </ItemGroup>
 
   </Target>

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishASingleFileApp.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishASingleFileApp.cs
@@ -23,7 +23,8 @@ namespace Microsoft.NET.Publish.Tests
         private const string PublishSingleFile = "/p:PublishSingleFile=true";
         private const string FrameworkDependent = "/p:SelfContained=false";
         private const string IncludePdb = "/p:IncludeSymbolsInSingleFile=true";
-        private const string ExcludeContent = "/p:ExcludeContent=true";
+        private const string ExcludeNewest = "/p:ExcludeNewest=true";
+        private const string ExcludeAlways = "/p:ExcludeAlways=true";
         private const string DontUseAppHost = "/p:UseAppHost=false";
         private const string ReadyToRun = "/p:PublishReadyToRun=true";
         private const string ReadyToRunWithSymbols = "/p:PublishReadyToRunEmitSymbols=true";
@@ -32,7 +33,8 @@ namespace Microsoft.NET.Publish.Tests
         private readonly string SingleFile = $"{TestProjectName}{Constants.ExeSuffix}";
         private readonly string PdbFile = $"{TestProjectName}.pdb";
         private readonly string NiPdbFile = $"{TestProjectName}.ni.pdb";
-        private const string ContentFile = "Signature.stamp";
+        private const string NewestContent = "Signature.Newest.Stamp";
+        private const string AlwaysContent = "Signature.Always.Stamp";
 
         public GivenThatWeWantToPublishASingleFileApp(ITestOutputHelper log) : base(log)
         {
@@ -173,16 +175,18 @@ namespace Microsoft.NET.Publish.Tests
                 .OnlyHaveFiles(expectedFiles);
         }
 
-        [Fact]
-        public void It_generates_a_single_file_excluding_content()
+        [Theory]
+        [InlineData(ExcludeNewest, NewestContent)]
+        [InlineData(ExcludeAlways, AlwaysContent)]
+        public void It_generates_a_single_file_excluding_content(string exclusion, string content)
         {
             var publishCommand = GetPublishCommand();
             publishCommand
-                .Execute(PublishSingleFile, RuntimeIdentifier, ExcludeContent)
+                .Execute(PublishSingleFile, RuntimeIdentifier, exclusion)
                 .Should()
                 .Pass();
 
-            string[] expectedFiles = { SingleFile, PdbFile, ContentFile };
+            string[] expectedFiles = { SingleFile, PdbFile, content };
             GetPublishDirectory(publishCommand)
                 .Should()
                 .OnlyHaveFiles(expectedFiles);


### PR DESCRIPTION
## Issue
https://github.com/dotnet/core-setup/issues/7794

## Scenario 
When customer annotates files to be excluded from the single-file bundle,
the annotation may not be honored correctly. Moreover, certain files may
be included in duplicate leading to downstream failure.

## Fix
Fix a copy-paste typo to fix the bug.

## Risk
Very low.

This fix  targets a very specific scenario, triggered by explicit annotations in the project file.
Only affects projects where the property <PublishSingleFile>true</PublishSingleFile> is set,
and some content is annotated with `<ExcludeFromSingleFile>true</ExcludeFromSingleFile>`

## Customer Impact

Exclusion from single-files is handled correctly.