### PR TITLE
Don't run _HandlePackageFileConflicts target if there are no references

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Extensions.Tasks/msbuildExtensions/Microsoft/Microsoft.NET.Build.Extensions/Microsoft.NET.Build.Extensions.ConflictResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Extensions.Tasks/msbuildExtensions/Microsoft/Microsoft.NET.Build.Extensions/Microsoft.NET.Build.Extensions.ConflictResolution.targets
@@ -26,7 +26,7 @@ Copyright (c) .NET Foundation. All rights reserved.
           BeforeTargets="$(_HandlePackageFileConflictsBefore)"
           AfterTargets="$(_HandlePackageFileConflictsAfter)"
           DependsOnTargets="GetFrameworkPaths;GetReferenceAssemblyPaths"
-          Condition="'@(Reference)' != '' Or '@(ReferencePath)' != ''">
+          Condition="'@(Reference)' != '' Or '@(ReferenceCopyLocalPaths)' != ''">
     <ResolvePackageFileConflicts References="@(Reference)"
                                  ReferenceCopyLocalPaths="@(ReferenceCopyLocalPaths)"
                                  PlatformManifests="@(PackageConflictPlatformManifests)"

--- a/src/Tasks/Microsoft.NET.Build.Extensions.Tasks/msbuildExtensions/Microsoft/Microsoft.NET.Build.Extensions/Microsoft.NET.Build.Extensions.ConflictResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Extensions.Tasks/msbuildExtensions/Microsoft/Microsoft.NET.Build.Extensions/Microsoft.NET.Build.Extensions.ConflictResolution.targets
@@ -25,7 +25,8 @@ Copyright (c) .NET Foundation. All rights reserved.
   <Target Name="_HandlePackageFileConflicts"
           BeforeTargets="$(_HandlePackageFileConflictsBefore)"
           AfterTargets="$(_HandlePackageFileConflictsAfter)"
-          DependsOnTargets="GetFrameworkPaths;GetReferenceAssemblyPaths">
+          DependsOnTargets="GetFrameworkPaths;GetReferenceAssemblyPaths"
+          Condition="'@(Reference)' != '' Or '@(ReferencePath)' != ''">
     <ResolvePackageFileConflicts References="@(Reference)"
                                  ReferenceCopyLocalPaths="@(ReferenceCopyLocalPaths)"
                                  PlatformManifests="@(PackageConflictPlatformManifests)"


### PR DESCRIPTION
Fixes #3585