### PR TITLE
Consolidating PackageVersion and NuGetPackageVersion metadata

### DIFF
--- a/src/Tasks/Common/MetadataKeys.cs
+++ b/src/Tasks/Common/MetadataKeys.cs
@@ -12,7 +12,6 @@ namespace Microsoft.NET.Build.Tasks
         public const string FileGroup = "FileGroup";
         public const string Path = "Path";
         public const string ResolvedPath = "ResolvedPath";
-        public const string PackageVersion = "PackageVersion";
         public const string IsImplicitlyDefined = "IsImplicitlyDefined";
         public const string IsTopLevelDependency = "IsTopLevelDependency";
         public const string AllowExplicitVersion = "AllowExplicitVersion";

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAResolvePackageDependenciesTask.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAResolvePackageDependenciesTask.cs
@@ -350,7 +350,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 fileDefns.First().GetMetadata(MetadataKeys.Type).Should().Be(pair.Value);
                 fileDefns.First().GetMetadata(MetadataKeys.Path).Should().Be(pair.Key);
                 fileDefns.First().GetMetadata(MetadataKeys.NuGetPackageId).Should().Be("LibB");
-                fileDefns.First().GetMetadata(MetadataKeys.PackageVersion).Should().Be("1.2.3");
+                fileDefns.First().GetMetadata(MetadataKeys.NuGetPackageVersion).Should().Be("1.2.3");
                 fileDefns.First().GetMetadata(MetadataKeys.ResolvedPath)
                     .Should().Be(Path.Combine(_packageRoot, "LibB", "1.2.3", "path", 
                         pair.Key.Replace('/', Path.DirectorySeparatorChar)));

--- a/src/Tasks/Microsoft.NET.Build.Tasks/FindItemsFromPackages.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/FindItemsFromPackages.cs
@@ -13,7 +13,7 @@ namespace Microsoft.NET.Build.Tasks
     /// set of Packages.
     /// </summary>
     /// <remarks>
-    /// Both Items and Packages are expected to have ('PackageName' and 'PackageVersion)' or ('NuGetPackageId' and 'NuGetPackageVersion')
+    /// Both Items and Packages are expected to have 'NuGetPackageId' and 'NuGetPackageVersion'
     /// metadata properties to use for the matching.
     /// </remarks>
     public sealed class FindItemsFromPackages : TaskBase

--- a/src/Tasks/Microsoft.NET.Build.Tasks/GetPackageDirectory.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/GetPackageDirectory.cs
@@ -45,7 +45,7 @@ namespace Microsoft.NET.Build.Tasks
             foreach (var item in Items)
             {
                 string packageName = item.GetMetadata(MetadataKeys.NuGetPackageId);
-                string packageVersion = item.GetMetadata(MetadataKeys.PackageVersion);
+                string packageVersion = item.GetMetadata(MetadataKeys.NuGetPackageVersion);
 
                 if (string.IsNullOrEmpty(packageName) || string.IsNullOrEmpty(packageVersion)
                     || !string.IsNullOrEmpty(item.GetMetadata(MetadataKeys.PackageDirectory)))

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ItemUtilities.NuGet.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ItemUtilities.NuGet.cs
@@ -12,12 +12,7 @@ namespace Microsoft.NET.Build.Tasks
         public static PackageIdentity GetPackageIdentity(ITaskItem item)
         {
             string packageName = item.GetMetadata(MetadataKeys.NuGetPackageId);
-            string packageVersion = item.GetMetadata(MetadataKeys.PackageVersion);
-
-            if (string.IsNullOrEmpty(packageVersion))
-            {
-                packageVersion = item.GetMetadata(MetadataKeys.NuGetPackageVersion);
-            }
+            string packageVersion = item.GetMetadata(MetadataKeys.NuGetPackageVersion);
 
             if (string.IsNullOrEmpty(packageName) || string.IsNullOrEmpty(packageVersion))
             {

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ParseTargetManifests.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ParseTargetManifests.cs
@@ -56,7 +56,7 @@ namespace Microsoft.NET.Build.Tasks
 
                     TaskItem item = new TaskItem($"{packageName}/{packageVersion}");
                     item.SetMetadata(MetadataKeys.NuGetPackageId, packageName);
-                    item.SetMetadata(MetadataKeys.PackageVersion, packageVersion);
+                    item.SetMetadata(MetadataKeys.NuGetPackageVersion, packageVersion);
                     item.SetMetadata(MetadataKeys.RuntimeStoreManifestNames, storeEntry.Value.ToString());
 
                     resultPackages.Add(item);

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ProcessFrameworkReferences.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ProcessFrameworkReferences.cs
@@ -138,7 +138,7 @@ namespace Microsoft.NET.Build.Tasks
                 {
                     targetingPackVersion = knownFrameworkReference.TargetingPackVersion;
                 }
-                targetingPack.SetMetadata(MetadataKeys.PackageVersion, targetingPackVersion);
+                targetingPack.SetMetadata(MetadataKeys.NuGetPackageVersion, targetingPackVersion);
                 targetingPack.SetMetadata("TargetingPackFormat", knownFrameworkReference.TargetingPackFormat);
                 targetingPack.SetMetadata("TargetFramework", knownFrameworkReference.TargetFramework.GetShortFolderName());
                 targetingPack.SetMetadata(MetadataKeys.RuntimeFrameworkName, knownFrameworkReference.RuntimeFrameworkName);
@@ -305,7 +305,7 @@ namespace Microsoft.NET.Build.Tasks
                     {
                         TaskItem runtimePackItem = new TaskItem(runtimePackName);
                         runtimePackItem.SetMetadata(MetadataKeys.NuGetPackageId, runtimePackName);
-                        runtimePackItem.SetMetadata(MetadataKeys.PackageVersion, runtimePackVersion);
+                        runtimePackItem.SetMetadata(MetadataKeys.NuGetPackageVersion, runtimePackVersion);
                         runtimePackItem.SetMetadata(MetadataKeys.FrameworkName, knownFrameworkReference.Name);
                         runtimePackItem.SetMetadata(MetadataKeys.RuntimeIdentifier, runtimePackRuntimeIdentifier);
                         runtimePackItem.SetMetadata(MetadataKeys.IsTrimmable, isTrimmable);

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ReferenceInfo.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ReferenceInfo.cs
@@ -123,10 +123,6 @@ namespace Microsoft.NET.Build.Tasks
             var packageName = referencePath.GetMetadata(MetadataKeys.NuGetPackageId);
 
             var packageVersion = referencePath.GetMetadata(MetadataKeys.NuGetPackageVersion);
-            if (string.IsNullOrEmpty(packageVersion))
-            {
-                packageVersion = referencePath.GetMetadata(MetadataKeys.PackageVersion);
-            }
 
             var pathInPackage = referencePath.GetMetadata(MetadataKeys.PathInPackage);
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolveAppHosts.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveAppHosts.cs
@@ -266,7 +266,7 @@ namespace Microsoft.NET.Build.Tasks
                     packagesToDownload.Add(packageToDownload);
 
                     appHostItem.SetMetadata(MetadataKeys.NuGetPackageId, hostPackName);
-                    appHostItem.SetMetadata(MetadataKeys.PackageVersion, appHostPackVersion);
+                    appHostItem.SetMetadata(MetadataKeys.NuGetPackageVersion, appHostPackVersion);
                 }
 
                 appHostItem.SetMetadata(MetadataKeys.PathInPackage, hostRelativePathInPackage);

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolveCopyLocalAssets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveCopyLocalAssets.cs
@@ -79,7 +79,7 @@ namespace Microsoft.NET.Build.Tasks
                 item.SetMetadata(MetadataKeys.DestinationSubDirectory, resolvedFile.DestinationSubDirectory);
                 item.SetMetadata(MetadataKeys.AssetType, resolvedFile.Asset.ToString().ToLowerInvariant());
                 item.SetMetadata(MetadataKeys.NuGetPackageId, resolvedFile.PackageName);
-                item.SetMetadata(MetadataKeys.PackageVersion, resolvedFile.PackageVersion.ToLowerInvariant());
+                item.SetMetadata(MetadataKeys.NuGetPackageVersion, resolvedFile.PackageVersion.ToLowerInvariant());
 
                 if (resolvedFile.Asset == AssetType.Resources)
                 {

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolveFrameworkReferences.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveFrameworkReferences.cs
@@ -45,7 +45,7 @@ namespace Microsoft.NET.Build.Tasks
 
                 resolvedFrameworkReference.SetMetadata("TargetingPackPath", targetingPack.GetMetadata(MetadataKeys.Path));
                 resolvedFrameworkReference.SetMetadata("TargetingPackName", targetingPack.GetMetadata(MetadataKeys.NuGetPackageId));
-                resolvedFrameworkReference.SetMetadata("TargetingPackVersion", targetingPack.GetMetadata(MetadataKeys.PackageVersion));
+                resolvedFrameworkReference.SetMetadata("TargetingPackVersion", targetingPack.GetMetadata(MetadataKeys.NuGetPackageVersion));
                 resolvedFrameworkReference.SetMetadata("Profile", targetingPack.GetMetadata("Profile"));
 
                 ITaskItem runtimePack;
@@ -53,7 +53,7 @@ namespace Microsoft.NET.Build.Tasks
                 {
                     resolvedFrameworkReference.SetMetadata("RuntimePackPath", runtimePack.GetMetadata(MetadataKeys.PackageDirectory));
                     resolvedFrameworkReference.SetMetadata("RuntimePackName", runtimePack.GetMetadata(MetadataKeys.NuGetPackageId));
-                    resolvedFrameworkReference.SetMetadata("RuntimePackVersion", runtimePack.GetMetadata(MetadataKeys.PackageVersion));
+                    resolvedFrameworkReference.SetMetadata("RuntimePackVersion", runtimePack.GetMetadata(MetadataKeys.NuGetPackageVersion));
                 }
 
                 resolvedFrameworkReferences.Add(resolvedFrameworkReference);

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageDependencies.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageDependencies.cs
@@ -196,7 +196,7 @@ namespace Microsoft.NET.Build.Tasks
                     var fileItem = new TaskItem(fileKey);
                     fileItem.SetMetadata(MetadataKeys.Path, file);
                     fileItem.SetMetadata(MetadataKeys.NuGetPackageId, packageName);
-                    fileItem.SetMetadata(MetadataKeys.PackageVersion, packageVersion);
+                    fileItem.SetMetadata(MetadataKeys.NuGetPackageVersion, packageVersion);
 
                     string resolvedPath = ResolveFilePath(file, resolvedPackagePath);
                     fileItem.SetMetadata(MetadataKeys.ResolvedPath, resolvedPath ?? string.Empty);
@@ -348,7 +348,7 @@ namespace Microsoft.NET.Build.Tasks
                         // NOTE: the path provided for framework assemblies is the name of the framework reference
                         item.SetMetadata("FrameworkAssembly", filePath);
                         item.SetMetadata(MetadataKeys.NuGetPackageId, package.Name);
-                        item.SetMetadata(MetadataKeys.PackageVersion, package.Version.ToNormalizedString());
+                        item.SetMetadata(MetadataKeys.NuGetPackageVersion, package.Version.ToNormalizedString());
                     }
 
                     foreach (var property in properties)

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolveRuntimePackAssets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveRuntimePackAssets.cs
@@ -168,7 +168,7 @@ namespace Microsoft.NET.Build.Tasks
 
             assetItem.SetMetadata(MetadataKeys.AssetType, assetType);
             assetItem.SetMetadata(MetadataKeys.NuGetPackageId, runtimePack.GetMetadata(MetadataKeys.NuGetPackageId));
-            assetItem.SetMetadata(MetadataKeys.PackageVersion, runtimePack.GetMetadata(MetadataKeys.PackageVersion));
+            assetItem.SetMetadata(MetadataKeys.NuGetPackageVersion, runtimePack.GetMetadata(MetadataKeys.NuGetPackageVersion));
             assetItem.SetMetadata(MetadataKeys.RuntimeIdentifier, runtimeIdentifier);
             assetItem.SetMetadata(MetadataKeys.IsTrimmable, runtimePack.GetMetadata(MetadataKeys.IsTrimmable));
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolveTargetingPackAssets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveTargetingPackAssets.cs
@@ -215,10 +215,10 @@ namespace Microsoft.NET.Build.Tasks
             reference.SetMetadata(MetadataKeys.ExternallyResolved, "true");
             reference.SetMetadata(MetadataKeys.Private, "false");
             reference.SetMetadata(MetadataKeys.NuGetPackageId, targetingPack.GetMetadata(MetadataKeys.NuGetPackageId));
-            reference.SetMetadata(MetadataKeys.NuGetPackageVersion, targetingPack.GetMetadata(MetadataKeys.PackageVersion));
+            reference.SetMetadata(MetadataKeys.NuGetPackageVersion, targetingPack.GetMetadata(MetadataKeys.NuGetPackageVersion));
 
             reference.SetMetadata("FrameworkReferenceName", targetingPack.ItemSpec);
-            reference.SetMetadata("FrameworkReferenceVersion", targetingPack.GetMetadata(MetadataKeys.PackageVersion));
+            reference.SetMetadata("FrameworkReferenceVersion", targetingPack.GetMetadata(MetadataKeys.NuGetPackageVersion));
             
             return reference;
         }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolvedFile.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolvedFile.cs
@@ -79,10 +79,6 @@ namespace Microsoft.NET.Build.Tasks
             PackageName = item.GetMetadata(MetadataKeys.NuGetPackageId);
 
             PackageVersion = item.GetMetadata(MetadataKeys.NuGetPackageVersion);
-            if (string.IsNullOrEmpty(PackageVersion))
-            {
-                PackageVersion = item.GetMetadata(MetadataKeys.PackageVersion);
-            }
 
             PathInPackage = item.GetMetadata(MetadataKeys.PathInPackage);
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/RuntimePackAssetInfo.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/RuntimePackAssetInfo.cs
@@ -45,7 +45,7 @@ namespace Microsoft.NET.Build.Tasks
             }
 
             assetInfo.PackageName = item.GetMetadata(MetadataKeys.NuGetPackageId);
-            assetInfo.PackageVersion = item.GetMetadata(MetadataKeys.PackageVersion);
+            assetInfo.PackageVersion = item.GetMetadata(MetadataKeys.NuGetPackageVersion);
             assetInfo.PackageRuntimeIdentifier = item.GetMetadata(MetadataKeys.RuntimeIdentifier);
 
             return assetInfo;

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenFrameworkReferences.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenFrameworkReferences.cs
@@ -1012,9 +1012,9 @@ namespace FrameworkReferenceTest
     <ItemGroup>
       <LinesToWrite Include=`RuntimeFramework%09%(RuntimeFramework.Identity)%09%(RuntimeFramework.Version)`/>
       <LinesToWrite Include=`PackageDownload%09%(PackageDownload.Identity)%09%(PackageDownload.Version)`/>
-      <LinesToWrite Include=`TargetingPack%09%(TargetingPack.Identity)%09%(TargetingPack.PackageVersion)`/>
-      <LinesToWrite Include=`RuntimePack%09%(RuntimePack.Identity)%09%(RuntimePack.PackageVersion)`/>
-      <LinesToWrite Include=`AppHostPack%09%(AppHostPack.Identity)%09%(AppHostPack.PackageVersion)`/>
+      <LinesToWrite Include=`TargetingPack%09%(TargetingPack.Identity)%09%(TargetingPack.NuGetPackageVersion)`/>
+      <LinesToWrite Include=`RuntimePack%09%(RuntimePack.Identity)%09%(RuntimePack.NuGetPackageVersion)`/>
+      <LinesToWrite Include=`AppHostPack%09%(AppHostPack.Identity)%09%(AppHostPack.NuGetPackageVersion)`/>
     </ItemGroup>
     <WriteLinesToFile File=`$(OutputPath)resolvedversions.txt`
                       Lines=`@(LinesToWrite)`


### PR DESCRIPTION
Removing PacakgeVersion metadata in favor of NuGetPackageVersion 
Fixes #3499