### PR TITLE
disable useapphost on mac by default

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets
@@ -99,14 +99,17 @@ Copyright (c) .NET Foundation. All rights reserved.
     SelfContained was not an option in .NET Core SDK 1.0. 
     Default SelfContained based on the RuntimeIdentifier, so projects don't have to explicitly set SelfContained.
     This avoids a breaking change from 1.0 behavior.
+
+    Due to https://github.com/dotnet/sdk/issues/4012 we decided to disable UseAppHost to be the default on mac
     -->
   <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' and '$(HasRuntimeOutput)' == 'true'">
     <SelfContained Condition="'$(SelfContained)' == '' and '$(RuntimeIdentifier)' != ''">true</SelfContained>
     <SelfContained Condition="'$(SelfContained)' == ''">false</SelfContained>
+    <_OnOsx>$(NETCoreSdkRuntimeIdentifier.StartsWith('osx'))</_OnOsx>
     <UseAppHost Condition="'$(UseAppHost)' == '' and
                            ('$(SelfContained)' == 'true' or
                             ('$(RuntimeIdentifier)' != '' and '$(_TargetFrameworkVersionWithoutV)' >= '2.1') or
-                            '$(_TargetFrameworkVersionWithoutV)' >= '3.0')">true</UseAppHost>
+                            ('$(_TargetFrameworkVersionWithoutV)' >= '3.0' and $(_OnOsx) != 'true'))">true</UseAppHost>
     <UseAppHost Condition="'$(UseAppHost)' == ''">false</UseAppHost>
   </PropertyGroup>
 

--- a/src/Tests/Microsoft.NET.Build.Tests/AppHostTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/AppHostTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -9,6 +10,7 @@ using System.Reflection.PortableExecutable;
 using System.Text.RegularExpressions;
 using FluentAssertions;
 using Microsoft.DotNet.Cli.Utils;
+using Microsoft.DotNet.PlatformAbstractions;
 using Microsoft.NET.TestFramework;
 using Microsoft.NET.TestFramework.Assertions;
 using Microsoft.NET.TestFramework.Commands;
@@ -24,7 +26,7 @@ namespace Microsoft.NET.Build.Tests
         {
         }
 
-        [Theory]
+        [PlatformSpecificTheory(Platform.Windows, Platform.Linux, Platform.FreeBSD)]
         [InlineData("netcoreapp3.0")]
         public void It_builds_a_runnable_apphost_by_default(string targetFramework)
         {
@@ -65,11 +67,47 @@ namespace Microsoft.NET.Build.Tests
                 .HaveStdOutContaining("Hello World!");
         }
 
+        [PlatformSpecificFact(Platform.Darwin)]
+        public void It_builds_a_runnable_apphost_if_opt_in_on_mac()
+        {
+            var targetFramework = "netcoreapp3.0";
+            var testAsset = _testAssetsManager
+                .CopyTestAsset("HelloWorld", identifier: targetFramework)
+                .WithSource()
+                .WithTargetFramework(targetFramework);
+
+            var buildCommand = new BuildCommand(Log, testAsset.TestRoot);
+            buildCommand
+                .Execute(new string[] {
+                    "/restore", "/p:UseAppHost=true",
+                })
+                .Should()
+                .Pass();
+
+            var outputDirectory = buildCommand.GetOutputDirectory(targetFramework);
+            var hostExecutable = $"HelloWorld{Constants.ExeSuffix}";
+
+            outputDirectory.Should().OnlyHaveFiles(new[] {
+                hostExecutable,
+                "HelloWorld.dll",
+                "HelloWorld.pdb",
+                "HelloWorld.deps.json",
+                "HelloWorld.runtimeconfig.dev.json",
+                "HelloWorld.runtimeconfig.json",
+            });
+        }
+
         [Theory]
         [InlineData("netcoreapp2.1")]
         [InlineData("netcoreapp2.2")]
-        public void It_does_not_build_with_an_apphost_by_default_before_netcoreapp_3(string targetFramework)
+        [InlineData("netcoreapp3.0")] // only on macOS
+        public void It_does_not_build_with_an_apphost_by_default_before_netcoreapp_3_or_macOs(string targetFramework)
         {
+            if (targetFramework == "netcoreapp3.0" && RuntimeEnvironment.OperatingSystemPlatform != Platform.Darwin)
+            {
+                return;
+            }
+
             var testAsset = _testAssetsManager
                 .CopyTestAsset("HelloWorld", identifier: targetFramework)
                 .WithSource()
@@ -236,6 +274,9 @@ namespace Microsoft.NET.Build.Tests
                 IsSdkProject = true,
                 IsExe = true,
             };
+            
+            // enable generating apphost even on macOS
+            testProject.AdditionalProperties.Add("UseApphost", "true");
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject)
                 .Restore(Log, testProject.Name);

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToCopyLocalDependencies.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToCopyLocalDependencies.cs
@@ -11,6 +11,7 @@ using System.Xml.Linq;
 using FluentAssertions;
 
 using Microsoft.DotNet.Cli.Utils;
+using Microsoft.DotNet.PlatformAbstractions;
 using Microsoft.NET.TestFramework;
 using Microsoft.NET.TestFramework.Assertions;
 using Microsoft.NET.TestFramework.Commands;
@@ -54,8 +55,9 @@ namespace Microsoft.NET.Build.Tests
                 .Pass();
 
             var outputDirectory = buildCommand.GetOutputDirectory(testProject.TargetFrameworks);
-            outputDirectory.Should().OnlyHaveFiles(new[] {
-                $"{ProjectName}{Constants.ExeSuffix}",
+
+            var expectedFiles = new []
+            {
                 $"{ProjectName}.deps.json",
                 $"{ProjectName}.dll",
                 $"{ProjectName}.pdb",
@@ -66,7 +68,9 @@ namespace Microsoft.NET.Build.Tests
                 "runtimes/osx-x64/native/libsqlite3.dylib",
                 "runtimes/win7-x64/native/sqlite3.dll",
                 "runtimes/win7-x86/native/sqlite3.dll"
-            });
+            };
+
+            outputDirectory.Should().OnlyHaveFiles(AssertionHelper.AppendApphostOnNonMacOS(ProjectName, expectedFiles));
         }
 
         [Fact]
@@ -95,14 +99,13 @@ namespace Microsoft.NET.Build.Tests
             buildCommand.Execute().Should().Pass();
 
             var outputDirectory = buildCommand.GetOutputDirectory(testProject.TargetFrameworks);
-            outputDirectory.Should().OnlyHaveFiles(new[] {
-                $"{ProjectName}{Constants.ExeSuffix}",
+            outputDirectory.Should().OnlyHaveFiles(AssertionHelper.AppendApphostOnNonMacOS(ProjectName, new[] {
                 $"{ProjectName}.deps.json",
                 $"{ProjectName}.dll",
                 $"{ProjectName}.pdb",
                 $"{ProjectName}.runtimeconfig.dev.json",
                 $"{ProjectName}.runtimeconfig.json",
-            });
+            }));
         }
 
         //  Core MSBuild only because CI machines don't have updated VS (with support for RuntimeIdentifierGraphPath)
@@ -147,7 +150,7 @@ namespace Microsoft.NET.Build.Tests
                 $"{ProjectName}.runtimeconfig.json",
                 "Newtonsoft.Json.dll",
                 // NOTE: this may break in the future when the SDK supports platforms that sqlite does not
-                $"{FileConstants.DynamicLibPrefix}sqlite3{FileConstants.DynamicLibSuffix}",
+                $"{FileConstants.DynamicLibPrefix}sqlite3{FileConstants.DynamicLibSuffix}"
             });
         }
 

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToFilterSatelliteAssemblies.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToFilterSatelliteAssemblies.cs
@@ -5,12 +5,14 @@ using System.Runtime.InteropServices;
 using System.Text;
 using FluentAssertions;
 using Microsoft.DotNet.Cli.Utils;
+using Microsoft.DotNet.PlatformAbstractions;
 using Microsoft.NET.TestFramework;
 using Microsoft.NET.TestFramework.Assertions;
 using Microsoft.NET.TestFramework.Commands;
 using Microsoft.NET.TestFramework.ProjectConstruction;
 using Xunit;
 using Xunit.Abstractions;
+using RuntimeEnvironment = System.Runtime.InteropServices.RuntimeEnvironment;
 
 namespace Microsoft.NET.Build.Tests
 {
@@ -76,7 +78,7 @@ namespace Microsoft.NET.Build.Tests
                     $"{testProject.Name}.runtimeconfig.dev.json"
                 });
 
-                if (testProject.TargetFrameworks == "netcoreapp3.0")
+                if (testProject.TargetFrameworks == "netcoreapp3.0" && Microsoft.DotNet.PlatformAbstractions.RuntimeEnvironment.OperatingSystemPlatform != Platform.Darwin)
                 {
                     expectedFiles.Add($"{testProject.Name}{Constants.ExeSuffix}");
                 }

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToUseVB.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToUseVB.cs
@@ -13,6 +13,7 @@ using Xunit.Abstractions;
 using Xunit;
 using System;
 using System.IO;
+using Microsoft.DotNet.PlatformAbstractions;
 using Microsoft.NET.TestFramework.ProjectConstruction;
 
 namespace Microsoft.NET.Build.Tests
@@ -133,15 +134,14 @@ namespace Microsoft.NET.Build.Tests
                     });
 
                 case ("netcoreapp3.0", true):
-                    return (VBRuntime.Referenced, new[]
+                    return (VBRuntime.Referenced, AssertionHelper.AppendApphostOnNonMacOS("HelloWorld", new[]
                     {
                         "HelloWorld.dll",
                         "HelloWorld.pdb",
-                        "HelloWorld" + EnvironmentInfo.ExecutableExtension,
                         "HelloWorld.runtimeconfig.json",
                         "HelloWorld.runtimeconfig.dev.json",
                         "HelloWorld.deps.json",
-                    });
+                    }));
 
                 case ("netcoreapp3.0", false):
                    return (VBRuntime.Referenced, new[]

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToExcludeAPackageFromPublish.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToExcludeAPackageFromPublish.cs
@@ -13,6 +13,7 @@ using System.Xml.Linq;
 using Xunit.Abstractions;
 using System.Collections.Generic;
 using Microsoft.NET.TestFramework.ProjectConstruction;
+using RuntimeEnvironment = Microsoft.DotNet.PlatformAbstractions.RuntimeEnvironment;
 
 namespace Microsoft.NET.Publish.Tests
 {
@@ -61,7 +62,7 @@ namespace Microsoft.NET.Publish.Tests
                 "HelloWorld.runtimeconfig.json"
             };
 
-            if (shouldIncludeExecutable)
+            if (shouldIncludeExecutable && RuntimeEnvironment.OperatingSystemPlatform != Platform.Darwin)
             {
                 expectedFiles.Add("HelloWorld" + EnvironmentInfo.ExecutableExtension);
             }
@@ -107,7 +108,7 @@ namespace Microsoft.NET.Publish.Tests
                 "HelloWorld.runtimeconfig.json"
             };
 
-            if (shouldIncludeExecutable)
+            if (shouldIncludeExecutable && RuntimeEnvironment.OperatingSystemPlatform != Platform.Darwin)
             {
                 expectedFiles.Add("HelloWorld" + EnvironmentInfo.ExecutableExtension);
             }
@@ -160,7 +161,7 @@ namespace Microsoft.NET.Publish.Tests
                 expectedFiles.Add("System.Runtime.Serialization.Primitives.dll");
             }
 
-            if (shouldIncludeExecutable)
+            if (shouldIncludeExecutable && RuntimeEnvironment.OperatingSystemPlatform != Platform.Darwin)
             {
                 expectedFiles.Add("HelloWorld" + EnvironmentInfo.ExecutableExtension);
             }

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToFilterSatelliteAssemblies.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToFilterSatelliteAssemblies.cs
@@ -13,6 +13,7 @@ using Xunit;
 using System.Xml.Linq;
 using Xunit.Abstractions;
 using Microsoft.NET.TestFramework.ProjectConstruction;
+using RuntimeEnvironment = Microsoft.DotNet.PlatformAbstractions.RuntimeEnvironment;
 
 namespace Microsoft.NET.Publish.Tests
 {
@@ -59,7 +60,7 @@ namespace Microsoft.NET.Publish.Tests
                 $"{testProject.Name}.runtimeconfig.json"
             };
 
-            if (tfm == "netcoreapp3.0")
+            if (tfm == "netcoreapp3.0" && RuntimeEnvironment.OperatingSystemPlatform != Platform.Darwin)
             {
                 files.Add($"{testProject.Name}{Constants.ExeSuffix}");
             }

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAHelloWorldProject.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAHelloWorldProject.cs
@@ -15,6 +15,7 @@ using System.Runtime.CompilerServices;
 using System;
 using Microsoft.Extensions.DependencyModel;
 using Xunit.Abstractions;
+using RuntimeEnvironment = Microsoft.DotNet.PlatformAbstractions.RuntimeEnvironment;
 
 namespace Microsoft.NET.Publish.Tests
 {

--- a/src/Tests/Microsoft.NET.Publish.Tests/PublishItemsOutputGroupTests.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/PublishItemsOutputGroupTests.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using FluentAssertions;
 using Microsoft.DotNet.Cli.Utils;
+using Microsoft.DotNet.PlatformAbstractions;
 using Microsoft.NET.TestFramework;
 using Microsoft.NET.TestFramework.Assertions;
 using Microsoft.NET.TestFramework.Commands;
@@ -80,15 +81,23 @@ namespace Microsoft.NET.Publish.Tests
             Log.WriteLine("Contents of PublishItemsOutputGroup dumped to '{0}'.", testOutputDir.FullName);
 
             // Since no RID was specified the output group should only contain framework dependent output
-            testOutputDir.Should().HaveFile($"{testProject.Name}{Constants.ExeSuffix}");
+            if (RuntimeEnvironment.OperatingSystemPlatform != Platform.Darwin)
+            {
+                testOutputDir.Should().HaveFile($"{testProject.Name}{Constants.ExeSuffix}");
+            }
+
             testOutputDir.Should().HaveFile($"{testProject.Name}.deps.json");
             testOutputDir.Should().NotHaveFiles(FrameworkAssemblies);
 
             var testKeyOutputDir = new DirectoryInfo(Path.Combine(testAsset.Path, testProject.Name, "TestOutput_Key"));
             Log.WriteLine("PublishItemsOutputGroup key items dumped to '{0}'.", testKeyOutputDir.FullName);
 
-            // Verify the only key item is the exe
-            testKeyOutputDir.Should().OnlyHaveFiles(new List<string>() { $"{testProject.Name}{Constants.ExeSuffix}" });
+            if (RuntimeEnvironment.OperatingSystemPlatform != Platform.Darwin)
+            {
+                // Verify the only key item is the exe
+                testKeyOutputDir.Should()
+                    .OnlyHaveFiles(new List<string>() {$"{testProject.Name}{Constants.ExeSuffix}"});
+            }
         }
 
         private TestProject SetupProject()

--- a/src/Tests/Microsoft.NET.TestFramework/AssertionHelper.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/AssertionHelper.cs
@@ -1,0 +1,18 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Linq;
+using Microsoft.DotNet.Cli.Utils;
+using Microsoft.DotNet.PlatformAbstractions;
+
+public static class AssertionHelper
+{
+    public static string[] AppendApphostOnNonMacOS(string ProjectName, string[] expectedFiles)
+    {
+        string apphost = $"{ProjectName}{Constants.ExeSuffix}";
+        // No UseApphost is false by default on macOS
+        return RuntimeEnvironment.OperatingSystemPlatform != Platform.Darwin
+            ? expectedFiles.Append(apphost).ToArray()
+            : expectedFiles;
+    }
+}

--- a/src/Tests/Microsoft.NET.ToolPack.Tests/GivenThatWeWantToPackAToolProject.cs
+++ b/src/Tests/Microsoft.NET.ToolPack.Tests/GivenThatWeWantToPackAToolProject.cs
@@ -16,6 +16,7 @@ using System.Runtime.CompilerServices;
 using System;
 using System.Runtime.InteropServices;
 using Microsoft.DotNet.PlatformAbstractions;
+using RuntimeEnvironment = Microsoft.DotNet.PlatformAbstractions.RuntimeEnvironment;
 
 namespace Microsoft.NET.ToolPack.Tests
 {
@@ -154,12 +155,15 @@ namespace Microsoft.NET.ToolPack.Tests
                "RunCommand",
                GetValuesCommand.ValueType.Property);
 
-            getValuesCommand.Execute();
-            string runCommandPath = getValuesCommand.GetValues().Single();
-            Path.GetExtension(runCommandPath)
-                .Should().Be(extension);
-            File.Exists(runCommandPath).Should()
-                .BeTrue("run command should be apphost executable (for WinExe) to debug. But it will not be packed");
+            if (RuntimeEnvironment.OperatingSystemPlatform != Platform.Darwin)
+            {
+                getValuesCommand.Execute();
+                string runCommandPath = getValuesCommand.GetValues().Single();
+                Path.GetExtension(runCommandPath)
+                    .Should().Be(extension);
+                File.Exists(runCommandPath).Should()
+                    .BeTrue("run command should be apphost executable (for WinExe) to debug. But it will not be packed");
+            }
         }
 
         [Theory]


### PR DESCRIPTION
Fixes https://github.com/dotnet/sdk/issues/4012

**Pending 1/6 branch open**

Require approval for all the following PR
3.0.1xx
SDK https://github.com/dotnet/sdk/pull/4019
CLI https://github.com/dotnet/cli/pull/13167 (and counter part for 3.1.1xx, 3.1.2xx. This change is to align the tests' expectation in CLI. This change is required when SDK build insert into CLI)

3.1.1xx
SDK https://github.com/dotnet/sdk/pull/4114

3.1.2xx
SDK https://github.com/dotnet/sdk/pull/4115

### Description

Change the default build behavior (which was just changed in .NET Core 3) to not use apphost. Essentially use 2.x behavior only on macOS.

### Customer Impact

With System Integrity Protection enforced, as a result of notarization, the following golden path ASP.NET Core scenario fails:

```
Install .NET Core

dotnet new mvc

dotnet run

Blank Safari with no indication
```

### Regression?

Yes, caused by notarization. New build of 3.x after January, 2020

### Risk

Low. Revert to known 2.x behavior