### PR TITLE
Include the generated COM wrappers during the publish step

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -442,6 +442,12 @@ Copyright (c) .NET Foundation. All rights reserved.
         <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
       </ResolvedFileToPublish>
 
+      <!-- Copy generated COM References. -->
+      <ResolvedFileToPublish Include="@(ReferenceComWrappersToCopyLocal)">
+        <RelativePath>@(ReferenceComWrappersToCopyLocal->'%(Filename)%(Extension)')</RelativePath>
+        <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+      </ResolvedFileToPublish>
+
       <!-- Copy the resolved copy local publish assets. -->
       <ResolvedFileToPublish Include="@(_ResolvedCopyLocalPublishAssets)">
         <RelativePath>%(_ResolvedCopyLocalPublishAssets.DestinationSubDirectory)%(Filename)%(Extension)</RelativePath>


### PR DESCRIPTION
See https://developercommunity.visualstudio.com/content/problem/848273/publish-in-vs2019-do-not-process-com-assemblies.html

Fixes: https://github.com/dotnet/runtime/issues/707
Fixes: https://github.com/dotnet/sdk/issues/3993

/cc @rainersigwald @nguerrera @jkoritzinsky 