### PR TITLE
[release/3.1.2xx]Generate RID graph in self-contained builds

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenADependencyContextBuilder.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenADependencyContextBuilder.cs
@@ -66,7 +66,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 resolvedNuGetFiles = Array.Empty<ResolvedFile>();
             }
 
-            DependencyContext dependencyContext = new DependencyContextBuilder(mainProject, projectContext, includeRuntimeFileVersions: false, runtimeGraph:null)
+            DependencyContext dependencyContext = new DependencyContextBuilder(mainProject, projectContext, includeRuntimeFileVersions: false, runtimeGraph: null)
                 .WithDirectReferences(directReferences)
                 .WithCompilationOptions(compilationOptions)
                 .WithResolvedNuGetFiles((ResolvedFile[]) resolvedNuGetFiles)

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenADependencyContextBuilder.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenADependencyContextBuilder.cs
@@ -11,11 +11,13 @@ using NuGet.Frameworks;
 using NuGet.Packaging.Core;
 using NuGet.ProjectModel;
 using NuGet.Versioning;
+using NuGet.RuntimeModel;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Xunit;
+using Xunit.Sdk;
 
 namespace Microsoft.NET.Build.Tasks.UnitTests
 {
@@ -64,7 +66,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 resolvedNuGetFiles = Array.Empty<ResolvedFile>();
             }
 
-            DependencyContext dependencyContext = new DependencyContextBuilder(mainProject, projectContext, includeRuntimeFileVersions: false)
+            DependencyContext dependencyContext = new DependencyContextBuilder(mainProject, projectContext, includeRuntimeFileVersions: false, runtimeGraph:null)
                 .WithDirectReferences(directReferences)
                 .WithCompilationOptions(compilationOptions)
                 .WithResolvedNuGetFiles((ResolvedFile[]) resolvedNuGetFiles)
@@ -261,7 +263,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 useCompilationOptions ? CreateCompilationOptions() :
                 null;
 
-            DependencyContext dependencyContext = new DependencyContextBuilder(mainProject, projectContext, includeRuntimeFileVersions: false)
+            DependencyContext dependencyContext = new DependencyContextBuilder(mainProject, projectContext, includeRuntimeFileVersions: false, runtimeGraph: null)
                 .WithReferenceAssemblies(ReferenceInfo.CreateReferenceInfos(referencePaths))
                 .WithCompilationOptions(compilationOptions)
                 .Build();
@@ -287,6 +289,60 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                     debugType: "portable",
                     emitEntryPoint: true,
                     generateXmlDocumentation: true);
+        }
+
+        [Fact]
+        public void ItCanGenerateTheRuntimeFallbackGraph()
+        {
+            string mainProjectName = "simple.dependencies";
+            LockFile lockFile = TestLockFiles.GetLockFile(mainProjectName);
+
+            SingleProjectInfo mainProject = SingleProjectInfo.Create(
+                "/usr/Path",
+                mainProjectName,
+                ".dll",
+                "1.0.0",
+                new ITaskItem[] { });
+
+            ProjectContext projectContext = lockFile.CreateProjectContext(
+                FrameworkConstants.CommonFrameworks.NetCoreApp10,
+                runtime: null,
+                platformLibraryName: Constants.DefaultPlatformLibrary,
+                runtimeFrameworks: null,
+                isSelfContained: true);
+
+            var runtimeGraph = new RuntimeGraph(
+                new RuntimeDescription []
+                {
+                    new RuntimeDescription("os-arch", new string [] { "os", "base" }),
+                    new RuntimeDescription("new_os-arch", new string [] { "os-arch", "os", "base" }),
+                    new RuntimeDescription("os-new_arch", new string [] { "os-arch", "os", "base" }),
+                    new RuntimeDescription("new_os-new_arch", new string [] { "new_os-arch", "os-new_arch", "os-arch", "os", "base" }),
+                    new RuntimeDescription("os-another_arch", new string [] { "os", "base" })
+                });
+
+            void CheckRuntimeFallbacks(string runtimeIdentifier, int fallbackCount)
+            {
+                projectContext.LockFileTarget.RuntimeIdentifier = runtimeIdentifier;
+                var dependencyContextBuilder = new DependencyContextBuilder(mainProject, projectContext, includeRuntimeFileVersions: false, runtimeGraph);
+                var runtimeFallbacks = dependencyContextBuilder.Build().RuntimeGraph;
+
+                runtimeFallbacks
+                    .Count()
+                    .Should()
+                    .Be(fallbackCount);
+
+                runtimeFallbacks
+                    .Any(runtimeFallback => !runtimeFallback.Runtime.Equals(runtimeIdentifier) && !runtimeFallback.Fallbacks.Contains(runtimeIdentifier))
+                    .Should()
+                    .BeFalse();
+            }
+
+            CheckRuntimeFallbacks("os-arch", 4);
+            CheckRuntimeFallbacks("new_os-arch", 2);
+            CheckRuntimeFallbacks("os-new_arch", 2);
+            CheckRuntimeFallbacks("new_os-new_arch", 1);
+            CheckRuntimeFallbacks("unrelated_os-unknown_arch", 0);
         }
     }
 }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/DependencyContextBuilder.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/DependencyContextBuilder.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.DependencyModel;
 using NuGet.Packaging;
 using NuGet.Packaging.Core;
 using NuGet.ProjectModel;
+using NuGet.RuntimeModel;
 using NuGet.Versioning;
 
 namespace Microsoft.NET.Build.Tasks
@@ -36,6 +37,7 @@ namespace Microsoft.NET.Build.Tasks
         private string _runtimeIdentifier;
         private bool _isPortable;
         private HashSet<string> _usedLibraryNames;
+        private readonly RuntimeGraph _runtimeGraph;
 
         private Dictionary<ReferenceInfo, string> _referenceLibraryNames;
 
@@ -44,10 +46,11 @@ namespace Microsoft.NET.Build.Tasks
 
         private const string NetCorePlatformLibrary = "Microsoft.NETCore.App";
 
-        public DependencyContextBuilder(SingleProjectInfo mainProjectInfo, ProjectContext projectContext, bool includeRuntimeFileVersions)
+        public DependencyContextBuilder(SingleProjectInfo mainProjectInfo, ProjectContext projectContext, bool includeRuntimeFileVersions, RuntimeGraph runtimeGraph)
         {
             _mainProjectInfo = mainProjectInfo;
             _includeRuntimeFileVersions = includeRuntimeFileVersions;
+            _runtimeGraph = runtimeGraph;
 
             var libraryLookup = new LockFileLookup(projectContext.LockFile);
 
@@ -322,19 +325,34 @@ namespace Microsoft.NET.Build.Tasks
                 }
             }
 
-
             var targetInfo = new TargetInfo(
                 _dotnetFrameworkName,
                 _runtimeIdentifier,
                 runtimeSignature: string.Empty,
                 _isPortable);
 
+            // Compute the runtime fallback graph 
+            // 
+            // If the input RuntimeGraph is empty, or we're not compiling
+            // for a specific RID, then an runtime fallback graph is empty
+            //
+            // Otherwise, it is the set of all runtimes compatible with (inheriting)
+            // the current runtime-identifier.
+
+            var runtimeFallbackGraph =
+                (_runtimeGraph == null || _runtimeIdentifier == null) ? 
+                    new RuntimeFallbacks[] { } :
+                    _runtimeGraph.Runtimes
+                        .Select(runtimeDict => _runtimeGraph.ExpandRuntime(runtimeDict.Key))
+                        .Where(expansion => expansion.Contains(_runtimeIdentifier))
+                        .Select(expansion => new RuntimeFallbacks(expansion.First(), expansion.Skip(1))); // ExpandRuntime return runtime itself as first item.
+
             return new DependencyContext(
-                targetInfo,
-                _compilationOptions ?? CompilationOptions.Default,
-                compilationLibraries,
-                runtimeLibraries,
-                new RuntimeFallbacks[] { });
+            targetInfo,
+            _compilationOptions ?? CompilationOptions.Default,
+            compilationLibraries,
+            runtimeLibraries,
+            runtimeFallbackGraph);
         }
 
         private RuntimeLibrary GetProjectRuntimeLibrary()

--- a/src/Tasks/Microsoft.NET.Build.Tasks/DependencyContextBuilder.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/DependencyContextBuilder.cs
@@ -337,7 +337,7 @@ namespace Microsoft.NET.Build.Tasks
             // for a specific RID, then an runtime fallback graph is empty
             //
             // Otherwise, it is the set of all runtimes compatible with (inheriting)
-            // the current runtime-identifier.
+            // the target runtime-identifier.
 
             var runtimeFallbackGraph =
                 (_runtimeGraph == null || _runtimeIdentifier == null) ? 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/GenerateDepsFile.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/GenerateDepsFile.cs
@@ -159,12 +159,16 @@ namespace Microsoft.NET.Build.Tasks
 
             // Generate the RID-fallback for self-contained builds.
             //
-            // In order to support loading components with RID-specific assets, the AssemblyDependencyResolver requires a RID fallback graph.
-            // The component itself should not carry the RID fallback graph with it (it would need to have the graph of all the RIDs there are and it would need to be updated with every addition).
-            // For framework dependent apps, the RID fallback graph comes from the core framework Microsoft.NETCore.App, so there is no need to write it into the app.
+            // In order to support loading components with RID-specific assets, 
+            // the AssemblyDependencyResolver requires a RID fallback graph.
+            // The component itself should not carry the RID fallback graph with it, because
+            // it would need to carry graph of all the RIDs and needs updates for newer RIDs.
+            // For framework dependent apps, the RID fallback graph comes from the core framework Microsoft.NETCore.App, 
+            // so there is no need to write it into the app.
             // If self-contained apps, the (applicable subset of) RID fallback graph needs to be written to the deps.json manifest.
             //
-            // If a RID-graph is provided to the DependencyContextBuilder, it generates a RID-fallback graph wrt the current RuntimeIdentifier.
+            // If a RID-graph is provided to the DependencyContextBuilder, it generates a RID-fallback 
+            // graph with respect to the target RuntimeIdentifier.
 
             RuntimeGraph runtimeGraph =
                 IsSelfContained ? new RuntimeGraphCache(this).GetRuntimeGraph(RuntimeGraphPath) : null;

--- a/src/Tasks/Microsoft.NET.Build.Tasks/GenerateDepsFile.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/GenerateDepsFile.cs
@@ -5,10 +5,9 @@ using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using Microsoft.Extensions.DependencyModel;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 using NuGet.Packaging.Core;
+using NuGet.RuntimeModel;
 using NuGet.ProjectModel;
-using NuGet.Versioning;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -92,6 +91,9 @@ namespace Microsoft.NET.Build.Tasks
 
         public bool IncludeRuntimeFileVersions { get; set; }
 
+        [Required]
+        public string RuntimeGraphPath { get; set; }
+
         List<ITaskItem> _filesWritten = new List<ITaskItem>();
 
         [Output]
@@ -155,7 +157,19 @@ namespace Microsoft.NET.Build.Tasks
                 RuntimeFrameworks,
                 IsSelfContained);
 
-            var builder = new DependencyContextBuilder(mainProject, projectContext, IncludeRuntimeFileVersions);
+            // Generate the RID-fallback for self-contained builds.
+            //
+            // In order to support loading components with RID-specific assets, the AssemblyDependencyResolver requires a RID fallback graph.
+            // The component itself should not carry the RID fallback graph with it (it would need to have the graph of all the RIDs there are and it would need to be updated with every addition).
+            // For framework dependent apps, the RID fallback graph comes from the core framework Microsoft.NETCore.App, so there is no need to write it into the app.
+            // If self-contained apps, the (applicable subset of) RID fallback graph needs to be written to the deps.json manifest.
+            //
+            // If a RID-graph is provided to the DependencyContextBuilder, it generates a RID-fallback graph wrt the current RuntimeIdentifier.
+
+            RuntimeGraph runtimeGraph =
+                IsSelfContained ? new RuntimeGraphCache(this).GetRuntimeGraph(RuntimeGraphPath) : null;
+
+            var builder = new DependencyContextBuilder(mainProject, projectContext, IncludeRuntimeFileVersions, runtimeGraph);
 
             builder = builder
                 .WithMainProjectInDepsFile(IncludeMainProject)

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.DesignerSupport.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.DesignerSupport.targets
@@ -67,6 +67,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       ResolvedNuGetFiles="@(NativeCopyLocalItems);@(ResourceCopyLocalItems);@(RuntimeCopyLocalItems)"
       ResolvedRuntimeTargetsFiles="@(RuntimeTargetsCopyLocalItems)"
       TargetFramework="$(TargetFrameworkMoniker)"
+      RuntimeGraphPath="$(BundledRuntimeIdentifierGraphFile)"
       />
 
     <ItemGroup>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -933,7 +933,8 @@ Copyright (c) .NET Foundation. All rights reserved.
                       ResolvedRuntimeTargetsFiles="@(RuntimeTargetsCopyLocalItems)"
                       UserRuntimeAssemblies="@(UserRuntimeAssembly)"
                       IsSelfContained="$(SelfContained)"
-                      IncludeRuntimeFileVersions="$(IncludeFileVersionsInDependencyFile)"/>
+                      IncludeRuntimeFileVersions="$(IncludeFileVersionsInDependencyFile)"
+                      RuntimeGraphPath="$(BundledRuntimeIdentifierGraphFile)"/>
 
     <ItemGroup>
       <_FilesToBundle Include="$(PublishDepsFilePath)" Condition="'$(PublishSingleFile)' == 'true'">

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -212,8 +212,8 @@ Copyright (c) .NET Foundation. All rights reserved.
                       UserRuntimeAssemblies="@(UserRuntimeAssembly)"
                       ResolvedRuntimeTargetsFiles="@(RuntimeTargetsCopyLocalItems)"
                       IsSelfContained="$(SelfContained)"
-                      IncludeRuntimeFileVersions="$(IncludeFileVersionsInDependencyFile)">
-    </GenerateDepsFile>
+                      IncludeRuntimeFileVersions="$(IncludeFileVersionsInDependencyFile)"
+                      RuntimeGraphPath="$(BundledRuntimeIdentifierGraphFile)"/>
 
     <ItemGroup>
       <!-- Do this in an ItemGroup instead of as an output parameter of the GenerateDepsFile task so that it still gets added to the item set


### PR DESCRIPTION
## Issue 
#3361

## Scenario
Customer tries to load load plugins with RID-specific assets into a self-contained app.
This operation currently fails.

## Fix

In order to support loading components (plugins) with RID-specific assets, the `AssemblyDependencyResolver` requires the RID fallback graph.

The component itself should not carry the RID fallback graph with it (it would need to have the graph of all the RIDs there are and it would need to be updated with every addition).

For framework dependent apps, the RID fallback graph comes from the core framework Microsoft.NETCore.App, so there is no need to write it into the app.

If self-contained apps, the (applicable subset of) RID fallback graph needs to be written to the deps.json manifest.

## Risk
Medium

This change affects contents generated in the deps.json file for every single-file app.
However, it only adds information (RID-graph) that is consumed by the `AssemblyDependencyResolver`.
It doesn't change any other sections in the `deps.json` manifest.

## Customer impact
Customer is able to load load plugins with RID-specific assets into a self-contained app.
