### PR TITLE
Fix parsing of metadata when looking for COM related CustomAttributes. [3.1.2xx]

### DIFF
--- a/src/Assets/TestProjects/ComServer/ComServer.cs
+++ b/src/Assets/TestProjects/ComServer/ComServer.cs
@@ -6,6 +6,13 @@ using System.Runtime.InteropServices;
 
 namespace COMServer
 {
+    // User defined attribute on types. Ensure that user defined
+    // attributes don't break us from parsing metadata.
+    public class UserDefinedAttribute : Attribute
+    {
+    }
+
+    [UserDefined]
     [ComVisible(true)]
     [Guid("17B6329E-B025-4FC7-A854-97D34600C5A6")]
     public class Class1
@@ -25,6 +32,7 @@ namespace COMServer
     [Guid("D88137C9-9B6F-4B46-AA3D-55791BF906EE")]
     public class Class4
     {
+        [UserDefined]
         [ComVisible(true)]
         [Guid("D88137C9-9B6F-4B46-AA3D-55791BF906ED")]
         public class Class5

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ClsidMap.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ClsidMap.cs
@@ -214,7 +214,7 @@ namespace Microsoft.NET.Build.Tasks
         private static bool IsTargetAttribute(MetadataReader reader, CustomAttribute attribute, string targetNamespace, string targetName)
         {
             StringHandle namespaceMaybe;
-            StringHandle nameMaybe = new StringHandle();
+            StringHandle nameMaybe;
             switch (attribute.Constructor.Kind)
             {
                 case HandleKind.MemberReference:

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ClsidMap.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ClsidMap.cs
@@ -173,9 +173,7 @@ namespace Microsoft.NET.Build.Tasks
             foreach (CustomAttributeHandle attr in customAttributes)
             {
                 CustomAttribute attribute = reader.GetCustomAttribute(attr);
-                MemberReference attributeConstructor = reader.GetMemberReference((MemberReferenceHandle)attribute.Constructor);
-                TypeReference attributeType = reader.GetTypeReference((TypeReferenceHandle)attributeConstructor.Parent);
-                if (reader.StringComparer.Equals(attributeType.Namespace, "System.Runtime.InteropServices") && reader.StringComparer.Equals(attributeType.Name, "ComVisibleAttribute"))
+                if (IsTargetAttribute(reader, attribute, "System.Runtime.InteropServices", "ComVisibleAttribute"))
                 {
                     return attr;
                 }
@@ -190,9 +188,7 @@ namespace Microsoft.NET.Build.Tasks
             foreach (CustomAttributeHandle attr in type.GetCustomAttributes())
             {
                 CustomAttribute attribute = reader.GetCustomAttribute(attr);
-                MemberReference attributeConstructor = reader.GetMemberReference((MemberReferenceHandle)attribute.Constructor);
-                TypeReference attributeType = reader.GetTypeReference((TypeReferenceHandle)attributeConstructor.Parent);
-                if (reader.StringComparer.Equals(attributeType.Namespace, "System.Runtime.InteropServices") && reader.StringComparer.Equals(attributeType.Name, "GuidAttribute"))
+                if (IsTargetAttribute(reader, attribute, "System.Runtime.InteropServices", "GuidAttribute"))
                 {
                     CustomAttributeValue<KnownType> data = attribute.DecodeValue(new TypeResolver());
                     return Guid.Parse((string)data.FixedArguments[0].Value);
@@ -206,15 +202,41 @@ namespace Microsoft.NET.Build.Tasks
             foreach (CustomAttributeHandle attr in type.GetCustomAttributes())
             {
                 CustomAttribute attribute = reader.GetCustomAttribute(attr);
-                MemberReference attributeConstructor = reader.GetMemberReference((MemberReferenceHandle)attribute.Constructor);
-                TypeReference attributeType = reader.GetTypeReference((TypeReferenceHandle)attributeConstructor.Parent);
-                if (reader.StringComparer.Equals(attributeType.Namespace, "System.Runtime.InteropServices") && reader.StringComparer.Equals(attributeType.Name, "ProgIdAttribute"))
+                if (IsTargetAttribute(reader, attribute, "System.Runtime.InteropServices", "ProgIdAttribute"))
                 {
                     CustomAttributeValue<KnownType> data = attribute.DecodeValue(new TypeResolver());
                     return (string)data.FixedArguments[0].Value;
                 }
             }
             return GetTypeName(reader, type);
+        }
+
+        private static bool IsTargetAttribute(MetadataReader reader, CustomAttribute attribute, string targetNamespace, string targetName)
+        {
+            StringHandle namespaceMaybe = new StringHandle();
+            StringHandle nameMaybe = new StringHandle();
+            switch (attribute.Constructor.Kind)
+            {
+                case HandleKind.MemberReference:
+                    MemberReference refConstructor = reader.GetMemberReference((MemberReferenceHandle)attribute.Constructor);
+                    TypeReference refType = reader.GetTypeReference((TypeReferenceHandle)refConstructor.Parent);
+                    namespaceMaybe = refType.Namespace;
+                    nameMaybe = refType.Name;
+                    break;
+
+                case HandleKind.MethodDefinition:
+                    MethodDefinition defConstructor = reader.GetMethodDefinition((MethodDefinitionHandle)attribute.Constructor);
+                    TypeDefinition defType = reader.GetTypeDefinition(defConstructor.GetDeclaringType());
+                    namespaceMaybe = defType.Namespace;
+                    nameMaybe = defType.Name;
+                    break;
+
+                default:
+                    Debug.Assert(false, "Unknown attribute constructor kind");
+                    return false;
+            }
+
+            return reader.StringComparer.Equals(namespaceMaybe, targetNamespace) && reader.StringComparer.Equals(nameMaybe, targetName);
         }
 
         private enum KnownType

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ClsidMap.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ClsidMap.cs
@@ -213,7 +213,7 @@ namespace Microsoft.NET.Build.Tasks
 
         private static bool IsTargetAttribute(MetadataReader reader, CustomAttribute attribute, string targetNamespace, string targetName)
         {
-            StringHandle namespaceMaybe = new StringHandle();
+            StringHandle namespaceMaybe;
             StringHandle nameMaybe = new StringHandle();
             switch (attribute.Constructor.Kind)
             {

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ComHost.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ComHost.cs
@@ -12,7 +12,7 @@ namespace Microsoft.NET.Build.Tasks
 {
     internal static class ComHost
     {
-        // These need to match RESOURCEID_CLISDMAP and RESOURCETYPE_CLSIDMAP in core-setup, defined in comhost.h.
+        // These need to match RESOURCEID_CLSIDMAP and RESOURCETYPE_CLSIDMAP in core-setup, defined in comhost.h.
         private const int ClsidmapResourceId = 64;
         private const int ClsidmapResourceType = 1024;
 


### PR DESCRIPTION
# Description

When enumerating a class during COM `ClsidMap` generation, it can occur that the class contains an attribute that is defined in the same assembly as the class it is adorning. This causes the current attribute enumerating code to fail because it was written assuming all attributes where 'references' not actual definitions.

Fixes #4099
Replaces #4112 

# Customer Impact

If a user has a class they intend to expose as a COM server with attributes defined in the current class's assembly, the entire build will fail.

# Risk

Minimal. Additional testing has been added for these scenarios. This also will only impact scenarios involving authoring of COM server, which are already small.

# Regression

No. This code was introduced in .NET 3.0 and has not changed.
