### PR TITLE
Remove redundant Update attribute

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ILLink.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ILLink.targets
@@ -114,7 +114,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     </PropertyGroup>
     <ItemGroup>
       <TrimmerRootAssembly Include="@(_ManagedAssembliesToLink)" Condition=" '%(_ManagedAssembliesToLink.IsTrimmable)' != 'true' " />
-      <_ManagedAssembliesToLink Update="@(_ManagedAssembliesToLink)" Condition=" '%(_ManagedAssembliesToLink.IsTrimmable)' != 'true' ">
+      <_ManagedAssembliesToLink Condition=" '%(_ManagedAssembliesToLink.IsTrimmable)' != 'true' ">
         <action>copy</action>
       </_ManagedAssembliesToLink>
     </ItemGroup>


### PR DESCRIPTION
Inside a target, Update on items is ignored (microsoft/msbuild#2835).

This is harmless in this case because the update was intended to apply to
all items where the condition matched, which is the same as not specifying
an Update filter. But it is misleading.