### PR TITLE
[release/3.1.2xx] Add TFM check for `Publish-Trimmed-ReadyToRun-SingleFile`

### DIFF
--- a/src/Tasks/Common/Resources/Strings.resx
+++ b/src/Tasks/Common/Resources/Strings.resx
@@ -475,7 +475,7 @@ The following are names of parameters or literal values and should not be transl
     <comment>{StrBegin="NETSDK1092: "}</comment>
   </data>
   <data name="ProjectToolOnlySupportTFMLowerThanNetcoreapp22" xml:space="preserve">
-    <value>NETSDK1093: NETSDK1093: Project tools (DotnetCliTool) only support targeting .NET Core 2.2 and lower.</value>
+    <value>NETSDK1093: Project tools (DotnetCliTool) only support targeting .NET Core 2.2 and lower.</value>
     <comment>{StrBegin="NETSDK1093: "}</comment>
   </data>
   <data name="ReadyToRunNoValidRuntimePackageError" xml:space="preserve">
@@ -587,5 +587,21 @@ The following are names of parameters or literal values and should not be transl
   <data name="NoSupportCppSelfContained" xml:space="preserve">
     <value>NETSDK1121: C++/CLI projects targeting .NET Core cannot use SelfContained=true.</value>
     <comment>{StrBegin="NETSDK1121: "}</comment>
+  </data>
+  <data name="PublishReadyToRunRequiresVersion30" xml:space="preserve">
+    <value>NETSDK1122: ReadyToRun compilation will be skipped because it is only supported for .NET Core 3.0 or higher.</value>
+    <comment>{StrBegin="NETSDK1122: "}</comment>
+  </data>
+  <data name="PublishSingleFileRequiresVersion30" xml:space="preserve">
+    <value>NETSDK1123: Publishing an application to a single-file requires .NET Core 3.0 or higher.</value>
+    <comment>{StrBegin="NETSDK1123: "}</comment>
+  </data>
+  <data name="PublishTrimmedRequiresVersion30" xml:space="preserve">
+    <value>NETSDK1124: Trimming assemblies requires .NET Core 3.0 or higher.</value>
+    <comment>{StrBegin="NETSDK1124: "}</comment>
+  </data>
+  <data name="CanOnlyHaveSingleFileWithNetCoreApp" xml:space="preserve">
+    <value>NETSDK1125: Publishing to a single-file is only supported for netcoreapp target.</value>
+    <comment>{StrBegin="NETSDK1125: "}</comment>
   </data>
 </root>

--- a/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
@@ -142,6 +142,11 @@
         <target state="translated">NETSDK1067: K používání hostitele aplikace se vyžadují samostatné (nezávislé) aplikace. Nastavte možnost SelfContained na false nebo nastavte UseAppHost na true.</target>
         <note>{StrBegin="NETSDK1067: "}</note>
       </trans-unit>
+      <trans-unit id="CanOnlyHaveSingleFileWithNetCoreApp">
+        <source>NETSDK1125: Publishing to a single-file is only supported for netcoreapp target.</source>
+        <target state="new">NETSDK1125: Publishing to a single-file is only supported for netcoreapp target.</target>
+        <note>{StrBegin="NETSDK1125: "}</note>
+      </trans-unit>
       <trans-unit id="ChoosingAssemblyVersion_Info">
         <source>Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</source>
         <target state="translated">Volí se {0}, protože verze sestavení {1} je větší než {2}.</target>
@@ -472,9 +477,24 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1059: "}</note>
       </trans-unit>
       <trans-unit id="ProjectToolOnlySupportTFMLowerThanNetcoreapp22">
-        <source>NETSDK1093: NETSDK1093: Project tools (DotnetCliTool) only support targeting .NET Core 2.2 and lower.</source>
-        <target state="translated">NETSDK1093: NETSDK1093: Nástroje projektu (DotnetCliTool) podporují jen cílení na .NET Core 2.2 a nižší.</target>
+        <source>NETSDK1093: Project tools (DotnetCliTool) only support targeting .NET Core 2.2 and lower.</source>
+        <target state="translated">NETSDK1093: Nástroje projektu (DotnetCliTool) podporují jen cílení na .NET Core 2.2 a nižší.</target>
         <note>{StrBegin="NETSDK1093: "}</note>
+      </trans-unit>
+      <trans-unit id="PublishReadyToRunRequiresVersion30">
+        <source>NETSDK1122: ReadyToRun compilation will be skipped because it is only supported for .NET Core 3.0 or higher.</source>
+        <target state="new">NETSDK1122: ReadyToRun compilation will be skipped because it is only supported for .NET Core 3.0 or higher.</target>
+        <note>{StrBegin="NETSDK1122: "}</note>
+      </trans-unit>
+      <trans-unit id="PublishSingleFileRequiresVersion30">
+        <source>NETSDK1123: Publishing an application to a single-file requires .NET Core 3.0 or higher.</source>
+        <target state="new">NETSDK1123: Publishing an application to a single-file requires .NET Core 3.0 or higher.</target>
+        <note>{StrBegin="NETSDK1123: "}</note>
+      </trans-unit>
+      <trans-unit id="PublishTrimmedRequiresVersion30">
+        <source>NETSDK1124: Trimming assemblies requires .NET Core 3.0 or higher.</source>
+        <target state="new">NETSDK1124: Trimming assemblies requires .NET Core 3.0 or higher.</target>
+        <note>{StrBegin="NETSDK1124: "}</note>
       </trans-unit>
       <trans-unit id="ReadyToRunCompilationFailed">
         <source>NETSDK1096: Optimizing assemblies for performance failed. You can either exclude the failing assemblies from being optimized, or set the PublishReadyToRun property to false.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.de.xlf
@@ -142,6 +142,11 @@
         <target state="translated">NETSDK1067: Eigenständige Anwendungen müssen den Anwendungshost verwenden. Legen Sie "SelfContained" auf FALSE oder "UseAppHost" auf TRUE fest.</target>
         <note>{StrBegin="NETSDK1067: "}</note>
       </trans-unit>
+      <trans-unit id="CanOnlyHaveSingleFileWithNetCoreApp">
+        <source>NETSDK1125: Publishing to a single-file is only supported for netcoreapp target.</source>
+        <target state="new">NETSDK1125: Publishing to a single-file is only supported for netcoreapp target.</target>
+        <note>{StrBegin="NETSDK1125: "}</note>
+      </trans-unit>
       <trans-unit id="ChoosingAssemblyVersion_Info">
         <source>Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</source>
         <target state="translated">Auswahl von "{0}", weil AssemblyVersion {1} höher ist als {2}.</target>
@@ -472,9 +477,24 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1059: "}</note>
       </trans-unit>
       <trans-unit id="ProjectToolOnlySupportTFMLowerThanNetcoreapp22">
-        <source>NETSDK1093: NETSDK1093: Project tools (DotnetCliTool) only support targeting .NET Core 2.2 and lower.</source>
-        <target state="translated">NETSDK1093: NETSDK1093: Projekttools (DotnetCliTool) unterstützen als Ziel nur .NET Core 2.2 und früher.</target>
+        <source>NETSDK1093: Project tools (DotnetCliTool) only support targeting .NET Core 2.2 and lower.</source>
+        <target state="translated">NETSDK1093: Projekttools (DotnetCliTool) unterstützen als Ziel nur .NET Core 2.2 und früher.</target>
         <note>{StrBegin="NETSDK1093: "}</note>
+      </trans-unit>
+      <trans-unit id="PublishReadyToRunRequiresVersion30">
+        <source>NETSDK1122: ReadyToRun compilation will be skipped because it is only supported for .NET Core 3.0 or higher.</source>
+        <target state="new">NETSDK1122: ReadyToRun compilation will be skipped because it is only supported for .NET Core 3.0 or higher.</target>
+        <note>{StrBegin="NETSDK1122: "}</note>
+      </trans-unit>
+      <trans-unit id="PublishSingleFileRequiresVersion30">
+        <source>NETSDK1123: Publishing an application to a single-file requires .NET Core 3.0 or higher.</source>
+        <target state="new">NETSDK1123: Publishing an application to a single-file requires .NET Core 3.0 or higher.</target>
+        <note>{StrBegin="NETSDK1123: "}</note>
+      </trans-unit>
+      <trans-unit id="PublishTrimmedRequiresVersion30">
+        <source>NETSDK1124: Trimming assemblies requires .NET Core 3.0 or higher.</source>
+        <target state="new">NETSDK1124: Trimming assemblies requires .NET Core 3.0 or higher.</target>
+        <note>{StrBegin="NETSDK1124: "}</note>
       </trans-unit>
       <trans-unit id="ReadyToRunCompilationFailed">
         <source>NETSDK1096: Optimizing assemblies for performance failed. You can either exclude the failing assemblies from being optimized, or set the PublishReadyToRun property to false.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.es.xlf
@@ -142,6 +142,11 @@
         <target state="translated">NETSDK1067: Las aplicaciones independientes deben utilizar un host de aplicación. Establezca SelfContained en false o UseAppHost en true.</target>
         <note>{StrBegin="NETSDK1067: "}</note>
       </trans-unit>
+      <trans-unit id="CanOnlyHaveSingleFileWithNetCoreApp">
+        <source>NETSDK1125: Publishing to a single-file is only supported for netcoreapp target.</source>
+        <target state="new">NETSDK1125: Publishing to a single-file is only supported for netcoreapp target.</target>
+        <note>{StrBegin="NETSDK1125: "}</note>
+      </trans-unit>
       <trans-unit id="ChoosingAssemblyVersion_Info">
         <source>Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</source>
         <target state="translated">Se elegirá "{0}" porque AssemblyVersion "{1}" es mayor que "{2}".</target>
@@ -472,9 +477,24 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1059: "}</note>
       </trans-unit>
       <trans-unit id="ProjectToolOnlySupportTFMLowerThanNetcoreapp22">
-        <source>NETSDK1093: NETSDK1093: Project tools (DotnetCliTool) only support targeting .NET Core 2.2 and lower.</source>
-        <target state="translated">NETSDK1093: NETSDK1093: Las herramientas de proyecto (DotnetCliTool) solo admiten como destino .NET Core 2.2 y versioes inferiores.</target>
+        <source>NETSDK1093: Project tools (DotnetCliTool) only support targeting .NET Core 2.2 and lower.</source>
+        <target state="translated">NETSDK1093: Las herramientas de proyecto (DotnetCliTool) solo admiten como destino .NET Core 2.2 y versioes inferiores.</target>
         <note>{StrBegin="NETSDK1093: "}</note>
+      </trans-unit>
+      <trans-unit id="PublishReadyToRunRequiresVersion30">
+        <source>NETSDK1122: ReadyToRun compilation will be skipped because it is only supported for .NET Core 3.0 or higher.</source>
+        <target state="new">NETSDK1122: ReadyToRun compilation will be skipped because it is only supported for .NET Core 3.0 or higher.</target>
+        <note>{StrBegin="NETSDK1122: "}</note>
+      </trans-unit>
+      <trans-unit id="PublishSingleFileRequiresVersion30">
+        <source>NETSDK1123: Publishing an application to a single-file requires .NET Core 3.0 or higher.</source>
+        <target state="new">NETSDK1123: Publishing an application to a single-file requires .NET Core 3.0 or higher.</target>
+        <note>{StrBegin="NETSDK1123: "}</note>
+      </trans-unit>
+      <trans-unit id="PublishTrimmedRequiresVersion30">
+        <source>NETSDK1124: Trimming assemblies requires .NET Core 3.0 or higher.</source>
+        <target state="new">NETSDK1124: Trimming assemblies requires .NET Core 3.0 or higher.</target>
+        <note>{StrBegin="NETSDK1124: "}</note>
       </trans-unit>
       <trans-unit id="ReadyToRunCompilationFailed">
         <source>NETSDK1096: Optimizing assemblies for performance failed. You can either exclude the failing assemblies from being optimized, or set the PublishReadyToRun property to false.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
@@ -142,6 +142,11 @@
         <target state="translated">NETSDK1067: Des applications autonomes sont obligatoires pour utiliser l'hôte d'application. Définissez SelfContained avec la valeur false ou UseAppHost avec la valeur true.</target>
         <note>{StrBegin="NETSDK1067: "}</note>
       </trans-unit>
+      <trans-unit id="CanOnlyHaveSingleFileWithNetCoreApp">
+        <source>NETSDK1125: Publishing to a single-file is only supported for netcoreapp target.</source>
+        <target state="new">NETSDK1125: Publishing to a single-file is only supported for netcoreapp target.</target>
+        <note>{StrBegin="NETSDK1125: "}</note>
+      </trans-unit>
       <trans-unit id="ChoosingAssemblyVersion_Info">
         <source>Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</source>
         <target state="translated">'{0}' choisi, car AssemblyVersion '{1}' est supérieur à '{2}'.</target>
@@ -472,9 +477,24 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1059: "}</note>
       </trans-unit>
       <trans-unit id="ProjectToolOnlySupportTFMLowerThanNetcoreapp22">
-        <source>NETSDK1093: NETSDK1093: Project tools (DotnetCliTool) only support targeting .NET Core 2.2 and lower.</source>
-        <target state="translated">NETSDK1093: NETSDK1093: les outils de projet (DotnetCliTool) prennent uniquement en charge le ciblage de .NET Core 2.2 et des versions antérieures.</target>
+        <source>NETSDK1093: Project tools (DotnetCliTool) only support targeting .NET Core 2.2 and lower.</source>
+        <target state="translated">NETSDK1093: les outils de projet (DotnetCliTool) prennent uniquement en charge le ciblage de .NET Core 2.2 et des versions antérieures.</target>
         <note>{StrBegin="NETSDK1093: "}</note>
+      </trans-unit>
+      <trans-unit id="PublishReadyToRunRequiresVersion30">
+        <source>NETSDK1122: ReadyToRun compilation will be skipped because it is only supported for .NET Core 3.0 or higher.</source>
+        <target state="new">NETSDK1122: ReadyToRun compilation will be skipped because it is only supported for .NET Core 3.0 or higher.</target>
+        <note>{StrBegin="NETSDK1122: "}</note>
+      </trans-unit>
+      <trans-unit id="PublishSingleFileRequiresVersion30">
+        <source>NETSDK1123: Publishing an application to a single-file requires .NET Core 3.0 or higher.</source>
+        <target state="new">NETSDK1123: Publishing an application to a single-file requires .NET Core 3.0 or higher.</target>
+        <note>{StrBegin="NETSDK1123: "}</note>
+      </trans-unit>
+      <trans-unit id="PublishTrimmedRequiresVersion30">
+        <source>NETSDK1124: Trimming assemblies requires .NET Core 3.0 or higher.</source>
+        <target state="new">NETSDK1124: Trimming assemblies requires .NET Core 3.0 or higher.</target>
+        <note>{StrBegin="NETSDK1124: "}</note>
       </trans-unit>
       <trans-unit id="ReadyToRunCompilationFailed">
         <source>NETSDK1096: Optimizing assemblies for performance failed. You can either exclude the failing assemblies from being optimized, or set the PublishReadyToRun property to false.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.it.xlf
@@ -142,6 +142,11 @@
         <target state="translated">NETSDK1067: con le applicazioni complete è necessario usare l'host applicazione. Impostare SelfContained su false o UseAppHost su true.</target>
         <note>{StrBegin="NETSDK1067: "}</note>
       </trans-unit>
+      <trans-unit id="CanOnlyHaveSingleFileWithNetCoreApp">
+        <source>NETSDK1125: Publishing to a single-file is only supported for netcoreapp target.</source>
+        <target state="new">NETSDK1125: Publishing to a single-file is only supported for netcoreapp target.</target>
+        <note>{StrBegin="NETSDK1125: "}</note>
+      </trans-unit>
       <trans-unit id="ChoosingAssemblyVersion_Info">
         <source>Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</source>
         <target state="translated">Verrà scelto '{0}' perché il valore di AssemblyVersion '{1}' è maggiore di '{2}'.</target>
@@ -472,9 +477,24 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1059: "}</note>
       </trans-unit>
       <trans-unit id="ProjectToolOnlySupportTFMLowerThanNetcoreapp22">
-        <source>NETSDK1093: NETSDK1093: Project tools (DotnetCliTool) only support targeting .NET Core 2.2 and lower.</source>
-        <target state="translated">NETSDK1093: NETSDK1093: gli strumenti del progetto (DotnetCliTool) supportano come destinazione solo .NET Core 2.2 e versioni precedenti.</target>
+        <source>NETSDK1093: Project tools (DotnetCliTool) only support targeting .NET Core 2.2 and lower.</source>
+        <target state="translated">NETSDK1093: gli strumenti del progetto (DotnetCliTool) supportano come destinazione solo .NET Core 2.2 e versioni precedenti.</target>
         <note>{StrBegin="NETSDK1093: "}</note>
+      </trans-unit>
+      <trans-unit id="PublishReadyToRunRequiresVersion30">
+        <source>NETSDK1122: ReadyToRun compilation will be skipped because it is only supported for .NET Core 3.0 or higher.</source>
+        <target state="new">NETSDK1122: ReadyToRun compilation will be skipped because it is only supported for .NET Core 3.0 or higher.</target>
+        <note>{StrBegin="NETSDK1122: "}</note>
+      </trans-unit>
+      <trans-unit id="PublishSingleFileRequiresVersion30">
+        <source>NETSDK1123: Publishing an application to a single-file requires .NET Core 3.0 or higher.</source>
+        <target state="new">NETSDK1123: Publishing an application to a single-file requires .NET Core 3.0 or higher.</target>
+        <note>{StrBegin="NETSDK1123: "}</note>
+      </trans-unit>
+      <trans-unit id="PublishTrimmedRequiresVersion30">
+        <source>NETSDK1124: Trimming assemblies requires .NET Core 3.0 or higher.</source>
+        <target state="new">NETSDK1124: Trimming assemblies requires .NET Core 3.0 or higher.</target>
+        <note>{StrBegin="NETSDK1124: "}</note>
       </trans-unit>
       <trans-unit id="ReadyToRunCompilationFailed">
         <source>NETSDK1096: Optimizing assemblies for performance failed. You can either exclude the failing assemblies from being optimized, or set the PublishReadyToRun property to false.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
@@ -142,6 +142,11 @@
         <target state="translated">NETSDK1067: アプリケーション ホストを使用するには、自己完結型のアプリケーションが必要です。SelfContained を false に設定するか、UseAppHost を true に設定してください。</target>
         <note>{StrBegin="NETSDK1067: "}</note>
       </trans-unit>
+      <trans-unit id="CanOnlyHaveSingleFileWithNetCoreApp">
+        <source>NETSDK1125: Publishing to a single-file is only supported for netcoreapp target.</source>
+        <target state="new">NETSDK1125: Publishing to a single-file is only supported for netcoreapp target.</target>
+        <note>{StrBegin="NETSDK1125: "}</note>
+      </trans-unit>
       <trans-unit id="ChoosingAssemblyVersion_Info">
         <source>Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</source>
         <target state="translated">AssemblyVersion '{1}' が '{2}' より大きいため、'{0}' を選択しています。</target>
@@ -472,9 +477,24 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1059: "}</note>
       </trans-unit>
       <trans-unit id="ProjectToolOnlySupportTFMLowerThanNetcoreapp22">
-        <source>NETSDK1093: NETSDK1093: Project tools (DotnetCliTool) only support targeting .NET Core 2.2 and lower.</source>
-        <target state="translated">NETSDK1093: NETSDK1093: プロジェクト ツール (DotnetCliTool) は、ターゲットが .NET Core 2.2 以下の場合のみサポートされます。</target>
+        <source>NETSDK1093: Project tools (DotnetCliTool) only support targeting .NET Core 2.2 and lower.</source>
+        <target state="translated">NETSDK1093: プロジェクト ツール (DotnetCliTool) は、ターゲットが .NET Core 2.2 以下の場合のみサポートされます。</target>
         <note>{StrBegin="NETSDK1093: "}</note>
+      </trans-unit>
+      <trans-unit id="PublishReadyToRunRequiresVersion30">
+        <source>NETSDK1122: ReadyToRun compilation will be skipped because it is only supported for .NET Core 3.0 or higher.</source>
+        <target state="new">NETSDK1122: ReadyToRun compilation will be skipped because it is only supported for .NET Core 3.0 or higher.</target>
+        <note>{StrBegin="NETSDK1122: "}</note>
+      </trans-unit>
+      <trans-unit id="PublishSingleFileRequiresVersion30">
+        <source>NETSDK1123: Publishing an application to a single-file requires .NET Core 3.0 or higher.</source>
+        <target state="new">NETSDK1123: Publishing an application to a single-file requires .NET Core 3.0 or higher.</target>
+        <note>{StrBegin="NETSDK1123: "}</note>
+      </trans-unit>
+      <trans-unit id="PublishTrimmedRequiresVersion30">
+        <source>NETSDK1124: Trimming assemblies requires .NET Core 3.0 or higher.</source>
+        <target state="new">NETSDK1124: Trimming assemblies requires .NET Core 3.0 or higher.</target>
+        <note>{StrBegin="NETSDK1124: "}</note>
       </trans-unit>
       <trans-unit id="ReadyToRunCompilationFailed">
         <source>NETSDK1096: Optimizing assemblies for performance failed. You can either exclude the failing assemblies from being optimized, or set the PublishReadyToRun property to false.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
@@ -142,6 +142,11 @@
         <target state="translated">NETSDK1067: 애플리케이션 호스트를 사용하려면 자체 포함 애플리케이션이 필요합니다. SelfContained를 false로 설정하거나 UseAppHost를 true로 설정하세요.</target>
         <note>{StrBegin="NETSDK1067: "}</note>
       </trans-unit>
+      <trans-unit id="CanOnlyHaveSingleFileWithNetCoreApp">
+        <source>NETSDK1125: Publishing to a single-file is only supported for netcoreapp target.</source>
+        <target state="new">NETSDK1125: Publishing to a single-file is only supported for netcoreapp target.</target>
+        <note>{StrBegin="NETSDK1125: "}</note>
+      </trans-unit>
       <trans-unit id="ChoosingAssemblyVersion_Info">
         <source>Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</source>
         <target state="translated">AssemblyVersion '{1}'이(가) '{2}'보다 크기 때문에 '{0}'을(를) 선택합니다.</target>
@@ -472,9 +477,24 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1059: "}</note>
       </trans-unit>
       <trans-unit id="ProjectToolOnlySupportTFMLowerThanNetcoreapp22">
-        <source>NETSDK1093: NETSDK1093: Project tools (DotnetCliTool) only support targeting .NET Core 2.2 and lower.</source>
-        <target state="translated">NETSDK1093: NETSDK1093: 프로젝트 도구(DotnetCliTool)는 .NET Core 2.2 이하를 대상으로 하는 경우만 지원합니다.</target>
+        <source>NETSDK1093: Project tools (DotnetCliTool) only support targeting .NET Core 2.2 and lower.</source>
+        <target state="translated">NETSDK1093: 프로젝트 도구(DotnetCliTool)는 .NET Core 2.2 이하를 대상으로 하는 경우만 지원합니다.</target>
         <note>{StrBegin="NETSDK1093: "}</note>
+      </trans-unit>
+      <trans-unit id="PublishReadyToRunRequiresVersion30">
+        <source>NETSDK1122: ReadyToRun compilation will be skipped because it is only supported for .NET Core 3.0 or higher.</source>
+        <target state="new">NETSDK1122: ReadyToRun compilation will be skipped because it is only supported for .NET Core 3.0 or higher.</target>
+        <note>{StrBegin="NETSDK1122: "}</note>
+      </trans-unit>
+      <trans-unit id="PublishSingleFileRequiresVersion30">
+        <source>NETSDK1123: Publishing an application to a single-file requires .NET Core 3.0 or higher.</source>
+        <target state="new">NETSDK1123: Publishing an application to a single-file requires .NET Core 3.0 or higher.</target>
+        <note>{StrBegin="NETSDK1123: "}</note>
+      </trans-unit>
+      <trans-unit id="PublishTrimmedRequiresVersion30">
+        <source>NETSDK1124: Trimming assemblies requires .NET Core 3.0 or higher.</source>
+        <target state="new">NETSDK1124: Trimming assemblies requires .NET Core 3.0 or higher.</target>
+        <note>{StrBegin="NETSDK1124: "}</note>
       </trans-unit>
       <trans-unit id="ReadyToRunCompilationFailed">
         <source>NETSDK1096: Optimizing assemblies for performance failed. You can either exclude the failing assemblies from being optimized, or set the PublishReadyToRun property to false.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
@@ -142,6 +142,11 @@
         <target state="translated">NETSDK1067: Aplikacje autonomiczne muszą korzystać z hosta aplikacji. Ustaw parametr SelfContained na wartość false lub parametr UseAppHost na wartość true.</target>
         <note>{StrBegin="NETSDK1067: "}</note>
       </trans-unit>
+      <trans-unit id="CanOnlyHaveSingleFileWithNetCoreApp">
+        <source>NETSDK1125: Publishing to a single-file is only supported for netcoreapp target.</source>
+        <target state="new">NETSDK1125: Publishing to a single-file is only supported for netcoreapp target.</target>
+        <note>{StrBegin="NETSDK1125: "}</note>
+      </trans-unit>
       <trans-unit id="ChoosingAssemblyVersion_Info">
         <source>Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</source>
         <target state="translated">Zostanie wybrany element „{0}”, ponieważ wartość atrybutu AssemblyVersion „{1}” jest większa niż „{2}”.</target>
@@ -472,9 +477,24 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1059: "}</note>
       </trans-unit>
       <trans-unit id="ProjectToolOnlySupportTFMLowerThanNetcoreapp22">
-        <source>NETSDK1093: NETSDK1093: Project tools (DotnetCliTool) only support targeting .NET Core 2.2 and lower.</source>
+        <source>NETSDK1093: Project tools (DotnetCliTool) only support targeting .NET Core 2.2 and lower.</source>
         <target state="translated">NETSDK1093: Narzędzia projektu (DotnetCliTool) obsługują tylko ukierunkowanie na program .NET Core w wersji 2.2 lub niższej.</target>
         <note>{StrBegin="NETSDK1093: "}</note>
+      </trans-unit>
+      <trans-unit id="PublishReadyToRunRequiresVersion30">
+        <source>NETSDK1122: ReadyToRun compilation will be skipped because it is only supported for .NET Core 3.0 or higher.</source>
+        <target state="new">NETSDK1122: ReadyToRun compilation will be skipped because it is only supported for .NET Core 3.0 or higher.</target>
+        <note>{StrBegin="NETSDK1122: "}</note>
+      </trans-unit>
+      <trans-unit id="PublishSingleFileRequiresVersion30">
+        <source>NETSDK1123: Publishing an application to a single-file requires .NET Core 3.0 or higher.</source>
+        <target state="new">NETSDK1123: Publishing an application to a single-file requires .NET Core 3.0 or higher.</target>
+        <note>{StrBegin="NETSDK1123: "}</note>
+      </trans-unit>
+      <trans-unit id="PublishTrimmedRequiresVersion30">
+        <source>NETSDK1124: Trimming assemblies requires .NET Core 3.0 or higher.</source>
+        <target state="new">NETSDK1124: Trimming assemblies requires .NET Core 3.0 or higher.</target>
+        <note>{StrBegin="NETSDK1124: "}</note>
       </trans-unit>
       <trans-unit id="ReadyToRunCompilationFailed">
         <source>NETSDK1096: Optimizing assemblies for performance failed. You can either exclude the failing assemblies from being optimized, or set the PublishReadyToRun property to false.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
@@ -142,6 +142,11 @@
         <target state="translated">NETSDK1067: os aplicativos independentes são necessários para utilizar o host do aplicativo. Defina SelfContained como falso ou defina UseAppHost como verdadeiro.</target>
         <note>{StrBegin="NETSDK1067: "}</note>
       </trans-unit>
+      <trans-unit id="CanOnlyHaveSingleFileWithNetCoreApp">
+        <source>NETSDK1125: Publishing to a single-file is only supported for netcoreapp target.</source>
+        <target state="new">NETSDK1125: Publishing to a single-file is only supported for netcoreapp target.</target>
+        <note>{StrBegin="NETSDK1125: "}</note>
+      </trans-unit>
       <trans-unit id="ChoosingAssemblyVersion_Info">
         <source>Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</source>
         <target state="translated">Escolhendo '{0}' porque AssemblyVersion '{1}' é maior que '{2}'.</target>
@@ -472,9 +477,24 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1059: "}</note>
       </trans-unit>
       <trans-unit id="ProjectToolOnlySupportTFMLowerThanNetcoreapp22">
-        <source>NETSDK1093: NETSDK1093: Project tools (DotnetCliTool) only support targeting .NET Core 2.2 and lower.</source>
-        <target state="translated">NETSDK1093: NETSDK1093: as ferramentas de projeto (DotnetCliTool) são suporte somente o .NET Core 2.2 e inferior.</target>
+        <source>NETSDK1093: Project tools (DotnetCliTool) only support targeting .NET Core 2.2 and lower.</source>
+        <target state="translated">NETSDK1093: as ferramentas de projeto (DotnetCliTool) são suporte somente o .NET Core 2.2 e inferior.</target>
         <note>{StrBegin="NETSDK1093: "}</note>
+      </trans-unit>
+      <trans-unit id="PublishReadyToRunRequiresVersion30">
+        <source>NETSDK1122: ReadyToRun compilation will be skipped because it is only supported for .NET Core 3.0 or higher.</source>
+        <target state="new">NETSDK1122: ReadyToRun compilation will be skipped because it is only supported for .NET Core 3.0 or higher.</target>
+        <note>{StrBegin="NETSDK1122: "}</note>
+      </trans-unit>
+      <trans-unit id="PublishSingleFileRequiresVersion30">
+        <source>NETSDK1123: Publishing an application to a single-file requires .NET Core 3.0 or higher.</source>
+        <target state="new">NETSDK1123: Publishing an application to a single-file requires .NET Core 3.0 or higher.</target>
+        <note>{StrBegin="NETSDK1123: "}</note>
+      </trans-unit>
+      <trans-unit id="PublishTrimmedRequiresVersion30">
+        <source>NETSDK1124: Trimming assemblies requires .NET Core 3.0 or higher.</source>
+        <target state="new">NETSDK1124: Trimming assemblies requires .NET Core 3.0 or higher.</target>
+        <note>{StrBegin="NETSDK1124: "}</note>
       </trans-unit>
       <trans-unit id="ReadyToRunCompilationFailed">
         <source>NETSDK1096: Optimizing assemblies for performance failed. You can either exclude the failing assemblies from being optimized, or set the PublishReadyToRun property to false.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
@@ -142,6 +142,11 @@
         <target state="translated">NETSDK1067: для использования узла приложений требуются автономные приложения. Задайте свойству SelfContained значение false или задайте свойству UseAppHost значение true.</target>
         <note>{StrBegin="NETSDK1067: "}</note>
       </trans-unit>
+      <trans-unit id="CanOnlyHaveSingleFileWithNetCoreApp">
+        <source>NETSDK1125: Publishing to a single-file is only supported for netcoreapp target.</source>
+        <target state="new">NETSDK1125: Publishing to a single-file is only supported for netcoreapp target.</target>
+        <note>{StrBegin="NETSDK1125: "}</note>
+      </trans-unit>
       <trans-unit id="ChoosingAssemblyVersion_Info">
         <source>Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</source>
         <target state="translated">Используется "{0}", так как значение AssemblyVersion "{1}" больше "{2}".</target>
@@ -472,9 +477,24 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1059: "}</note>
       </trans-unit>
       <trans-unit id="ProjectToolOnlySupportTFMLowerThanNetcoreapp22">
-        <source>NETSDK1093: NETSDK1093: Project tools (DotnetCliTool) only support targeting .NET Core 2.2 and lower.</source>
-        <target state="translated">NETSDK1093: NETSDK1093: средства проекта (DotnetCliTool) поддерживают только ориентацию на .NET Core 2.2 и более низких версий.</target>
+        <source>NETSDK1093: Project tools (DotnetCliTool) only support targeting .NET Core 2.2 and lower.</source>
+        <target state="translated">NETSDK1093: средства проекта (DotnetCliTool) поддерживают только ориентацию на .NET Core 2.2 и более низких версий.</target>
         <note>{StrBegin="NETSDK1093: "}</note>
+      </trans-unit>
+      <trans-unit id="PublishReadyToRunRequiresVersion30">
+        <source>NETSDK1122: ReadyToRun compilation will be skipped because it is only supported for .NET Core 3.0 or higher.</source>
+        <target state="new">NETSDK1122: ReadyToRun compilation will be skipped because it is only supported for .NET Core 3.0 or higher.</target>
+        <note>{StrBegin="NETSDK1122: "}</note>
+      </trans-unit>
+      <trans-unit id="PublishSingleFileRequiresVersion30">
+        <source>NETSDK1123: Publishing an application to a single-file requires .NET Core 3.0 or higher.</source>
+        <target state="new">NETSDK1123: Publishing an application to a single-file requires .NET Core 3.0 or higher.</target>
+        <note>{StrBegin="NETSDK1123: "}</note>
+      </trans-unit>
+      <trans-unit id="PublishTrimmedRequiresVersion30">
+        <source>NETSDK1124: Trimming assemblies requires .NET Core 3.0 or higher.</source>
+        <target state="new">NETSDK1124: Trimming assemblies requires .NET Core 3.0 or higher.</target>
+        <note>{StrBegin="NETSDK1124: "}</note>
       </trans-unit>
       <trans-unit id="ReadyToRunCompilationFailed">
         <source>NETSDK1096: Optimizing assemblies for performance failed. You can either exclude the failing assemblies from being optimized, or set the PublishReadyToRun property to false.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
@@ -142,6 +142,11 @@
         <target state="translated">NETSDK1067: Kendi başına kapsanan uygulamaların uygulama konağını kullanması gerekir. SelfContained değerini false olarak ya da UseAppHost değerini true olarak ayarlayın.</target>
         <note>{StrBegin="NETSDK1067: "}</note>
       </trans-unit>
+      <trans-unit id="CanOnlyHaveSingleFileWithNetCoreApp">
+        <source>NETSDK1125: Publishing to a single-file is only supported for netcoreapp target.</source>
+        <target state="new">NETSDK1125: Publishing to a single-file is only supported for netcoreapp target.</target>
+        <note>{StrBegin="NETSDK1125: "}</note>
+      </trans-unit>
       <trans-unit id="ChoosingAssemblyVersion_Info">
         <source>Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</source>
         <target state="translated">'{1}' AssemblyVersion değeri '{2}' değerinden büyük olduğundan '{0}' seçiliyor.</target>
@@ -472,9 +477,24 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1059: "}</note>
       </trans-unit>
       <trans-unit id="ProjectToolOnlySupportTFMLowerThanNetcoreapp22">
-        <source>NETSDK1093: NETSDK1093: Project tools (DotnetCliTool) only support targeting .NET Core 2.2 and lower.</source>
-        <target state="translated">NETSDK1093: NETSDK1093: Proje araçları (DotnetCliTool) yalnızca .NET Core 2.2 veya altını hedeflemeyi destekliyor.</target>
+        <source>NETSDK1093: Project tools (DotnetCliTool) only support targeting .NET Core 2.2 and lower.</source>
+        <target state="translated">NETSDK1093: Proje araçları (DotnetCliTool) yalnızca .NET Core 2.2 veya altını hedeflemeyi destekliyor.</target>
         <note>{StrBegin="NETSDK1093: "}</note>
+      </trans-unit>
+      <trans-unit id="PublishReadyToRunRequiresVersion30">
+        <source>NETSDK1122: ReadyToRun compilation will be skipped because it is only supported for .NET Core 3.0 or higher.</source>
+        <target state="new">NETSDK1122: ReadyToRun compilation will be skipped because it is only supported for .NET Core 3.0 or higher.</target>
+        <note>{StrBegin="NETSDK1122: "}</note>
+      </trans-unit>
+      <trans-unit id="PublishSingleFileRequiresVersion30">
+        <source>NETSDK1123: Publishing an application to a single-file requires .NET Core 3.0 or higher.</source>
+        <target state="new">NETSDK1123: Publishing an application to a single-file requires .NET Core 3.0 or higher.</target>
+        <note>{StrBegin="NETSDK1123: "}</note>
+      </trans-unit>
+      <trans-unit id="PublishTrimmedRequiresVersion30">
+        <source>NETSDK1124: Trimming assemblies requires .NET Core 3.0 or higher.</source>
+        <target state="new">NETSDK1124: Trimming assemblies requires .NET Core 3.0 or higher.</target>
+        <note>{StrBegin="NETSDK1124: "}</note>
       </trans-unit>
       <trans-unit id="ReadyToRunCompilationFailed">
         <source>NETSDK1096: Optimizing assemblies for performance failed. You can either exclude the failing assemblies from being optimized, or set the PublishReadyToRun property to false.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
@@ -142,6 +142,11 @@
         <target state="translated">NETSDK1067: 需要自包含应用程序才能使用应用程序主机。将 SelfContained 设置为 false，或者将 UseAppHost 设置为 true。</target>
         <note>{StrBegin="NETSDK1067: "}</note>
       </trans-unit>
+      <trans-unit id="CanOnlyHaveSingleFileWithNetCoreApp">
+        <source>NETSDK1125: Publishing to a single-file is only supported for netcoreapp target.</source>
+        <target state="new">NETSDK1125: Publishing to a single-file is only supported for netcoreapp target.</target>
+        <note>{StrBegin="NETSDK1125: "}</note>
+      </trans-unit>
       <trans-unit id="ChoosingAssemblyVersion_Info">
         <source>Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</source>
         <target state="translated">选择“{0}”，因为 AssemblyVersion“{1}”高于“{2}”。</target>
@@ -472,9 +477,24 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1059: "}</note>
       </trans-unit>
       <trans-unit id="ProjectToolOnlySupportTFMLowerThanNetcoreapp22">
-        <source>NETSDK1093: NETSDK1093: Project tools (DotnetCliTool) only support targeting .NET Core 2.2 and lower.</source>
-        <target state="translated">NETSDK1093: NETSDK1093: 项目工具(DotnetCliTool)仅支持面向 .NET Core 2.2 及更低版本。</target>
+        <source>NETSDK1093: Project tools (DotnetCliTool) only support targeting .NET Core 2.2 and lower.</source>
+        <target state="translated">NETSDK1093: 项目工具(DotnetCliTool)仅支持面向 .NET Core 2.2 及更低版本。</target>
         <note>{StrBegin="NETSDK1093: "}</note>
+      </trans-unit>
+      <trans-unit id="PublishReadyToRunRequiresVersion30">
+        <source>NETSDK1122: ReadyToRun compilation will be skipped because it is only supported for .NET Core 3.0 or higher.</source>
+        <target state="new">NETSDK1122: ReadyToRun compilation will be skipped because it is only supported for .NET Core 3.0 or higher.</target>
+        <note>{StrBegin="NETSDK1122: "}</note>
+      </trans-unit>
+      <trans-unit id="PublishSingleFileRequiresVersion30">
+        <source>NETSDK1123: Publishing an application to a single-file requires .NET Core 3.0 or higher.</source>
+        <target state="new">NETSDK1123: Publishing an application to a single-file requires .NET Core 3.0 or higher.</target>
+        <note>{StrBegin="NETSDK1123: "}</note>
+      </trans-unit>
+      <trans-unit id="PublishTrimmedRequiresVersion30">
+        <source>NETSDK1124: Trimming assemblies requires .NET Core 3.0 or higher.</source>
+        <target state="new">NETSDK1124: Trimming assemblies requires .NET Core 3.0 or higher.</target>
+        <note>{StrBegin="NETSDK1124: "}</note>
       </trans-unit>
       <trans-unit id="ReadyToRunCompilationFailed">
         <source>NETSDK1096: Optimizing assemblies for performance failed. You can either exclude the failing assemblies from being optimized, or set the PublishReadyToRun property to false.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
@@ -142,6 +142,11 @@
         <target state="translated">NETSDK1067: 需要獨立式應用程式，才可使用該應用程式主機。請將 SelfContained 設定為 False，或是將 UseAppHost 設定為 True。</target>
         <note>{StrBegin="NETSDK1067: "}</note>
       </trans-unit>
+      <trans-unit id="CanOnlyHaveSingleFileWithNetCoreApp">
+        <source>NETSDK1125: Publishing to a single-file is only supported for netcoreapp target.</source>
+        <target state="new">NETSDK1125: Publishing to a single-file is only supported for netcoreapp target.</target>
+        <note>{StrBegin="NETSDK1125: "}</note>
+      </trans-unit>
       <trans-unit id="ChoosingAssemblyVersion_Info">
         <source>Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</source>
         <target state="translated">因為 AssemblyVersion '{1}' 大於 '{2}'，所以選擇 '{0}'。</target>
@@ -472,9 +477,24 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1059: "}</note>
       </trans-unit>
       <trans-unit id="ProjectToolOnlySupportTFMLowerThanNetcoreapp22">
-        <source>NETSDK1093: NETSDK1093: Project tools (DotnetCliTool) only support targeting .NET Core 2.2 and lower.</source>
-        <target state="translated">NETSDK1093: NETSDK1093: 專案工具 (DotnetCliTool) 僅支援目標為 .NET Core 2.2 或更低的版本。</target>
+        <source>NETSDK1093: Project tools (DotnetCliTool) only support targeting .NET Core 2.2 and lower.</source>
+        <target state="translated">NETSDK1093: 專案工具 (DotnetCliTool) 僅支援目標為 .NET Core 2.2 或更低的版本。</target>
         <note>{StrBegin="NETSDK1093: "}</note>
+      </trans-unit>
+      <trans-unit id="PublishReadyToRunRequiresVersion30">
+        <source>NETSDK1122: ReadyToRun compilation will be skipped because it is only supported for .NET Core 3.0 or higher.</source>
+        <target state="new">NETSDK1122: ReadyToRun compilation will be skipped because it is only supported for .NET Core 3.0 or higher.</target>
+        <note>{StrBegin="NETSDK1122: "}</note>
+      </trans-unit>
+      <trans-unit id="PublishSingleFileRequiresVersion30">
+        <source>NETSDK1123: Publishing an application to a single-file requires .NET Core 3.0 or higher.</source>
+        <target state="new">NETSDK1123: Publishing an application to a single-file requires .NET Core 3.0 or higher.</target>
+        <note>{StrBegin="NETSDK1123: "}</note>
+      </trans-unit>
+      <trans-unit id="PublishTrimmedRequiresVersion30">
+        <source>NETSDK1124: Trimming assemblies requires .NET Core 3.0 or higher.</source>
+        <target state="new">NETSDK1124: Trimming assemblies requires .NET Core 3.0 or higher.</target>
+        <note>{StrBegin="NETSDK1124: "}</note>
       </trans-unit>
       <trans-unit id="ReadyToRunCompilationFailed">
         <source>NETSDK1096: Optimizing assemblies for performance failed. You can either exclude the failing assemblies from being optimized, or set the PublishReadyToRun property to false.</source>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -90,6 +90,8 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <NETSdkError Condition="'$(PublishSingleFile)' == 'true' And '$(_IsExecutable)' != 'true'"
                  ResourceName="CannotHaveSingleFileWithoutExecutable" />
+    <NETSdkError Condition="'$(PublishSingleFile)' == 'true' And '$(_IsExecutable)' == 'true' And '$(TargetFrameworkIdentifier)' != '.NETCoreApp'"
+                 ResourceName="CanOnlyHaveSingleFileWithNetCoreApp" />
 
     <PropertyGroup>
       <!-- Ensure any PublishDir has a trailing slash, so it can be concatenated -->

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets
@@ -145,6 +145,18 @@ Copyright (c) .NET Foundation. All rights reserved.
     <NETSdkError Condition="'$(SelfContained)' != 'true' and '$(UseAppHost)' == 'true' and '$(_TargetFrameworkVersionWithoutV)' &lt; '2.1'"
                  ResourceName="FrameworkDependentAppHostRequiresVersion21" />
 
+    <NETSdkError Condition="'$(PublishSingleFile)' == 'true' and '$(_TargetFrameworkVersionWithoutV)' &lt; '3.0'"
+                 ResourceName="PublishSingleFileRequiresVersion30" />
+
+    <!-- The TFM version checks for PublishReadyToRun PublishTrimmed only generate warnings in .Net core 3.1
+         because we do not want the behavior to be a breaking change compared to version 3.0 -->
+
+    <NETSdkWarning Condition="'$(PublishReadyToRun)' == 'true' and '$(_TargetFrameworkVersionWithoutV)' &lt; '3.0'"
+                   ResourceName="PublishReadyToRunRequiresVersion30" />
+
+    <NETSdkWarning Condition="'$(PublishTrimmed)' == 'true' and '$(_TargetFrameworkVersionWithoutV)' &lt; '3.0'"
+                   ResourceName="PublishTrimmedRequiresVersion30" />
+
   </Target>
 
   <Target Name="_CheckForMismatchingPlatform"

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishReadyToRun.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishReadyToRun.cs
@@ -4,6 +4,7 @@ using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
 using System.Runtime.InteropServices;
 using FluentAssertions;
+using Microsoft.NET.Build.Tasks;
 using Microsoft.NET.TestFramework;
 using Microsoft.NET.TestFramework.Assertions;
 using Microsoft.NET.TestFramework.Commands;
@@ -225,6 +226,28 @@ namespace Microsoft.NET.Publish.Tests
                 .And.HaveStdOutContainingIgnoreCase("NETSDK1095");
         }
 
+        [Fact]
+        public void It_warns_when_targetting_netcoreapp_2_x()
+        {
+            var testProject = new TestProject()
+            {
+                Name = "ConsoleApp",
+                TargetFrameworks = "netcoreapp2.2",
+                IsSdkProject = true,
+                IsExe = true,
+            };
+
+            var testAsset = _testAssetsManager.CreateTestProject(testProject);
+
+            var publishCommand = new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+
+            publishCommand.Execute($"/p:PublishReadyToRun=true",
+                                   $"/p:RuntimeIdentifier={DotNet.PlatformAbstractions.RuntimeEnvironment.GetRuntimeIdentifier()}")
+                .Should()
+                .Pass()
+                .And
+                .HaveStdOutContaining(Strings.PublishReadyToRunRequiresVersion30);
+        }
 
         [Theory]
         [InlineData("netcoreapp3.0")]


### PR DESCRIPTION
## Issue 
Fixes #3728

## Scenario
The options `PublishSingleFile`, `PublishReadyToRun`, and `PublishTrimmed` are only supported when targetting netcoreapp3.0 or later.

Trying to publish to a different target (say `.netcoreapp2.1`) today:
* `PublishSingleFile` fails with the `PlaceHolderNotFoundInAppHostException` generated by the `HostWriter`.
* `PublishReadyToRun` and `PublishTrimmed` silently fail to turn on, but the `publish` itself suceeds.

## Fix

This change adds an explicit TFM check to generate error/warnings for non-conforming targets.

`PublishSingleFile`, requires the following conditions to be true:
* `TargetFramework` is `netcoreapp`
* `TargetFrameworkVersion` is at least `3.0`
* The app is an executable (`OutputType=exe`)
If any of the conditions fail, build fails with an appropriate error

`PublishReadyToRun`, and `PublishTrimmed` require the following conditions to be true:
* `TargetFrameworkVersion` is at least `3.0`
If this condition fails, the build issue warnings, but publish itself succeeds.
The version check should ideally be a failure, but they are warnings for maximum compatibility with `3.0` release.

## Risk
Low

## Customer impact

Customers targeting frameworks earlier than netcoreapp3.0 do not observe surprising failures modes for  `PublishSingleFile`, `PublishReadyToRun`, and `PublishTrimmed`, instead they receive a clear error/warning.
