### PR TITLE
Updating PublishItemsOutputGroup to include the publish deps file when _UseBuildDependencyFile is false

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -1069,7 +1069,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <Target Name="PublishItemsOutputGroup" DependsOnTargets="$(PublishItemsOutputGroupDependsOn)" Returns="@(PublishItemsOutputGroupOutputs)">
     <ItemGroup>
       <PublishItemsOutputGroupOutputs Condition="'$(GenerateDependencyFile)' == 'true' and '$(_UseBuildDependencyFile)' != 'true'"
-                                      Include="$(ProjectDepsFilePath)"
+                                      Include="$(PublishDepsFilePath)"
                                       TargetPath="$(ProjectDepsFileName)" />
       <PublishItemsOutputGroupOutputs Include="@(ResolvedFileToPublish->'%(FullPath)')"
                                       TargetPath="%(ResolvedFileToPublish.RelativePath)"


### PR DESCRIPTION
This is the output group that gets used with VS installer projects.  Right now we're using the wrong deps file in the case where assets are marked as excluded from publish.

For some historical context you can look at the comments in PR 3141.  At that point we didn't actually do a real publish when this output group got used so PublishDepsFilePath wasn't available to us.  But now consuming this output group using an installer project does a real publish, so we can and should use the publish version of the deps file when _UseBuildDependencyFile is false.