### PR TITLE
Updating PublishItemsOutputGroup to handle single file publish scenario

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -864,6 +864,11 @@ Copyright (c) .NET Foundation. All rights reserved.
                       Condition="'%(_ResolvedFileToPublishAlways.ExcludeFromSingleFile)' != 'true'"/>
     </ItemGroup>
 
+    <PropertyGroup>
+      <PublishedSingleFileName>$(AssemblyName)$(_NativeExecutableExtension)</PublishedSingleFileName>
+      <PublishedSingleFilePath>$(PublishDir)$(PublishedSingleFileName)</PublishedSingleFilePath>
+    </PropertyGroup>
+
   </Target>
 
   <UsingTask TaskName="GenerateBundle" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
@@ -871,14 +876,14 @@ Copyright (c) .NET Foundation. All rights reserved.
           Condition="'$(PublishSingleFile)' == 'true'"
           DependsOnTargets="_ComputeFilesToBundle" 
           Inputs="@(_FilesToBundle)"
-          Outputs="$(PublishDir)$(AssemblyName)$(_NativeExecutableExtension)">
+          Outputs="$(PublishedSingleFilePath)">
 
     <GenerateBundle FilesToBundle="@(_FilesToBundle)"
-                    AppHostName="$(AssemblyName)$(_NativeExecutableExtension)"
+                    AppHostName="$(PublishedSingleFileName)"
                     IncludeSymbols="$(IncludeSymbolsInSingleFile)"
                     OutputDir="$(PublishDir)"
                     ShowDiagnosticOutput="false"/>
-    
+
   </Target>
 
   <!--
@@ -977,6 +982,26 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <!--
     ============================================================
+                                        ComputeFilesCopiedToPublishDir
+
+    Gathers all the files that were copied to the publish directory.
+    ============================================================
+    -->
+  <Target Name="ComputeFilesCopiedToPublishDir"
+          DependsOnTargets="_CopyResolvedFilesToPublishPreserveNewest;
+                            _CopyResolvedFilesToPublishAlways;
+                            BundlePublishDirectory">
+
+    <ItemGroup>
+      <FilesCopiedToPublishDir Include="@(_ResolvedUnbundledFileToPublishPreserveNewest)"/>
+      <FilesCopiedToPublishDir Include="@(_ResolvedUnbundledFileToPublishAlways)"/>
+      <FilesCopiedToPublishDir Include="$(PublishedSingleFilePath)" RelativePath="$(PublishedSingleFileName)" IsKeyOutput="true" Condition="'$(PublishSingleFile)' == 'true'"/>
+    </ItemGroup>
+
+  </Target>
+
+  <!--
+    ============================================================
                                             PublishItemsOutputGroup
 
     Emit an output group containing all files that get published.  This will be consumed by VS installer projects.
@@ -987,17 +1012,18 @@ Copyright (c) .NET Foundation. All rights reserved.
       $(PublishItemsOutputGroupDependsOn);
       ResolveReferences;
       ComputeFilesToPublish;
+      ComputeFilesCopiedToPublishDir;
     </PublishItemsOutputGroupDependsOn>
   </PropertyGroup>
 
   <Target Name="PublishItemsOutputGroup" DependsOnTargets="$(PublishItemsOutputGroupDependsOn)" Returns="@(PublishItemsOutputGroupOutputs)">
     <ItemGroup>
-      <PublishItemsOutputGroupOutputs Condition="'$(GenerateDependencyFile)' == 'true' and '$(_UseBuildDependencyFile)' != 'true'"
+      <PublishItemsOutputGroupOutputs Condition="'$(GenerateDependencyFile)' == 'true' and '$(_UseBuildDependencyFile)' != 'true' and '$(PublishSingleFile)' != 'true'"
                                       Include="$(PublishDepsFilePath)"
                                       TargetPath="$(ProjectDepsFileName)" />
-      <PublishItemsOutputGroupOutputs Include="@(ResolvedFileToPublish->'%(FullPath)')"
-                                      TargetPath="%(ResolvedFileToPublish.RelativePath)"
-                                      IsKeyOutput="%(ResolvedFileToPublish.IsKeyOutput)"
+      <PublishItemsOutputGroupOutputs Include="@(FilesCopiedToPublishDir->'%(FullPath)')"
+                                      TargetPath="%(FilesCopiedToPublishDir.RelativePath)"
+                                      IsKeyOutput="%(FilesCopiedToPublishDir.IsKeyOutput)"
                                       OutputGroup="PublishItemsOutputGroup" />
     </ItemGroup>
   </Target>

--- a/src/Tests/Microsoft.NET.Publish.Tests/PublishItemsOutputGroupTests.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/PublishItemsOutputGroupTests.cs
@@ -82,11 +82,12 @@ namespace Microsoft.NET.Publish.Tests
 
             if (RuntimeEnvironment.OperatingSystemPlatform != Platform.Darwin)
             {
-                // Since no RID was specified the output group should only contain framework dependent output
                 testOutputDir.Should().HaveFile($"{testProject.Name}{Constants.ExeSuffix}");
             }
 
             testOutputDir.Should().HaveFile($"{testProject.Name}.deps.json");
+
+            // Since no RID was specified the output group should not contain framework assemblies
             testOutputDir.Should().NotHaveFiles(FrameworkAssemblies);
 
             var testKeyOutputDir = new DirectoryInfo(Path.Combine(testAsset.Path, testProject.Name, "TestOutput_Key"));

--- a/src/Tests/Microsoft.NET.Publish.Tests/PublishItemsOutputGroupTests.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/PublishItemsOutputGroupTests.cs
@@ -80,9 +80,9 @@ namespace Microsoft.NET.Publish.Tests
             var testOutputDir = new DirectoryInfo(Path.Combine(testAsset.Path, testProject.Name, "TestOutput"));
             Log.WriteLine("Contents of PublishItemsOutputGroup dumped to '{0}'.", testOutputDir.FullName);
 
-            // Since no RID was specified the output group should only contain framework dependent output
             if (RuntimeEnvironment.OperatingSystemPlatform != Platform.Darwin)
             {
+                // Since no RID was specified the output group should only contain framework dependent output
                 testOutputDir.Should().HaveFile($"{testProject.Name}{Constants.ExeSuffix}");
             }
 
@@ -97,6 +97,49 @@ namespace Microsoft.NET.Publish.Tests
                 // Verify the only key item is the exe
                 testKeyOutputDir.Should()
                     .OnlyHaveFiles(new List<string>() {$"{testProject.Name}{Constants.ExeSuffix}"});
+            }
+        }
+
+        [CoreMSBuildAndWindowsOnlyFact]
+        public void GroupPopulatedCorrectlyWithSingleFile()
+        {
+            var testProject = this.SetupProject();
+            var testAsset = _testAssetsManager.CreateTestProject(testProject);
+
+            var restoreCommand = new RestoreCommand(Log, testAsset.Path, testProject.Name);
+            restoreCommand
+                .Execute()
+                .Should()
+                .Pass();
+
+            var buildCommand = new BuildCommand(Log, testAsset.Path, testProject.Name);
+            buildCommand
+                .Execute("/p:RuntimeIdentifier=win-x86;DesignTimeBuild=true;PublishSingleFile=true", "/t:PublishItemsOutputGroup")
+                .Should()
+                .Pass();
+
+            var testOutputDir = new DirectoryInfo(Path.Combine(testAsset.Path, testProject.Name, "TestOutput"));
+            Log.WriteLine("Contents of PublishItemsOutputGroup dumped to '{0}'.", testOutputDir.FullName);
+
+            if (RuntimeEnvironment.OperatingSystemPlatform != Platform.Darwin)
+            {
+                testOutputDir.Should().HaveFile($"{testProject.Name}{Constants.ExeSuffix}");
+            }
+
+            // In the single file case there shouldn't be a deps.json file 
+            testOutputDir.Should().NotHaveFile($"{testProject.Name}.deps.json");
+
+            // The framework assemblies should also get bundled with the main exe
+            testOutputDir.Should().NotHaveFiles(FrameworkAssemblies);
+
+            var testKeyOutputDir = new DirectoryInfo(Path.Combine(testAsset.Path, testProject.Name, "TestOutput_Key"));
+            Log.WriteLine("PublishItemsOutputGroup key items dumped to '{0}'.", testKeyOutputDir.FullName);
+
+            if (RuntimeEnvironment.OperatingSystemPlatform != Platform.Darwin)
+            {
+                // Verify the only key item is the exe
+                testKeyOutputDir.Should()
+                    .OnlyHaveFiles(new List<string>() { $"{testProject.Name}{Constants.ExeSuffix}" });
             }
         }
 


### PR DESCRIPTION
Right now we're using the ResolvedFileToPublish item group, but this doesn't take into account the single file scenario.  So I'm creating a new item group that will track what actually gets placed in the publish directory.

I intentionally didn't remove items from ResolvedFileToPublish since that is used in several other targets files.

I plan on also consuming this new item group from the wapproj targets.