### PR TITLE
Order GenerateAssemblyInfo target before BeforeCompile (#10613)

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.GenerateAssemblyInfo.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.GenerateAssemblyInfo.targets
@@ -42,9 +42,12 @@ Copyright (c) .NET Foundation. All rights reserved.
     where CoreCompile is invoked without other potential hooks such as Compile or CoreBuild,
     etc., so we hook directly on to CoreCompile. Furthermore, we  must run *after* 
     PrepareForBuild to ensure that the intermediate directory has been created.
+
+    Targets that generate Compile items are also expected to run before
+    BeforeCompile targets (common targets convention).
    -->
   <Target Name="GenerateAssemblyInfo"
-          BeforeTargets="CoreCompile"
+          BeforeTargets="BeforeCompile;CoreCompile"
           DependsOnTargets="PrepareForBuild;CoreGenerateAssemblyInfo"
           Condition="'$(GenerateAssemblyInfo)' == 'true'" />
 


### PR DESCRIPTION
Port from master.
Fixes https://github.com/dotnet/sdk/issues/10614