### PR TITLE
Remove stack dump on dotnet -d

### DIFF
--- a/src/Cli/dotnet/CommandFactory/CommandResolution/LocalToolsCommandResolver.cs
+++ b/src/Cli/dotnet/CommandFactory/CommandResolution/LocalToolsCommandResolver.cs
@@ -57,7 +57,8 @@ namespace Microsoft.DotNet.CommandFactory
                 return null;
             }
 
-            if (!arguments.CommandName.StartsWith(LeadingDotnetPrefix, StringComparison.OrdinalIgnoreCase))
+            if (!arguments.CommandName.StartsWith(LeadingDotnetPrefix, StringComparison.OrdinalIgnoreCase) ||
+                string.IsNullOrWhiteSpace(arguments.CommandName.Substring(LeadingDotnetPrefix.Length)))
             {
                 return null;
             }

--- a/src/Cli/dotnet/Program.cs
+++ b/src/Cli/dotnet/Program.cs
@@ -216,6 +216,10 @@ namespace Microsoft.DotNet.Cli
 
                 exitCode = builtIn.Command(appArgs.ToArray());
             }
+            else if (string.IsNullOrEmpty(topLevelCommandParserResult.Command))
+            {
+                exitCode = 0;
+            }
             else
             {
                 CommandResult result = CommandFactoryUsingResolver.Create(

--- a/src/Tests/Microsoft.DotNet.CommandFactory.Tests/GivenALocalToolsCommandResolver.cs
+++ b/src/Tests/Microsoft.DotNet.CommandFactory.Tests/GivenALocalToolsCommandResolver.cs
@@ -79,6 +79,19 @@ namespace Microsoft.DotNet.Tests
             commandPath.Should().Be(fakeExecutable.Value);
         }
 
+        [Fact]
+        public void WhenResolveWithNoArgumentsItReturnsNull()
+        {
+            (FilePath fakeExecutable, LocalToolsCommandResolver localToolsCommandResolver) = DefaultSetup("-d");
+
+            var result = localToolsCommandResolver.Resolve(new CommandResolverArguments()
+            {
+                CommandName = "-d",
+            });
+
+            result.Should().BeNull();
+        }
+
         private (FilePath, LocalToolsCommandResolver) DefaultSetup(string toolCommand)
         {
             NuGetVersion packageVersionA = NuGetVersion.Parse("1.0.4");

--- a/src/Tests/dotnet.Tests/CommandTests/CommandIntegrationTests.cs
+++ b/src/Tests/dotnet.Tests/CommandTests/CommandIntegrationTests.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using FluentAssertions;
+using Microsoft.NET.TestFramework;
+using Microsoft.NET.TestFramework.Commands;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.DotNet.Tests.Commands
+{
+    public class CommandIntegrationTests : SdkTest
+    {
+        public CommandIntegrationTests(ITestOutputHelper log) : base(log) {}
+
+        [Fact]
+        public void GivenNoArgumentsProvided()
+        {
+            var cmd = new DotnetCommand(Log).Execute(string.Empty);
+            cmd.StdErr.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void GivenOnlyArgumentProvidedIsDiagnosticsFlag()
+        {
+            var cmd = new DotnetCommand(Log).Execute("-d");
+            cmd.ExitCode.Should().Be(0);
+            cmd.StdErr.Should().BeEmpty();
+        }
+    }
+}


### PR DESCRIPTION
Fixes #4104 
@wli3 has already looked at these changes [here](https://github.com/dotnet/toolset/compare/master...sfoslund:Dotnet-dDump) before the repo merge.