### PR TITLE
allow publish solutions with non-publishable multi-target projects

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.CrossTargeting.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.CrossTargeting.targets
@@ -23,7 +23,7 @@ Copyright (c) .NET Foundation. All rights reserved.
    multiple published applications in a single directory.
   ============================================================
    -->
-  <Target Name="Publish">
+  <Target Name="Publish" Condition="'$(IsPublishable)' != 'false'">
     <Error Text="The 'Publish' target is not supported without specifying a target framework. The current project targets multiple frameworks, please specify the framework for the published application." />
   </Target>
 


### PR DESCRIPTION
Taken you have have a solution with two projects:

1. class library, multiple target frameworks (e.g. `netstandard2.1;net461`)
2. console application, one target framework (e.g. `netcoreapp3.1`)

Currently we cannot run "dotnet publish" on solution level because of the error in `Microsoft.NET.Sdk.CrossTargeting.targets`.
This is true, even if the class library is marked as `<IsPublishable>false</IsPublishable>`.

Currently you have call publish just for console project (2). This isn't simple in more generic scenarios or in larger solutions with multiple projects having different target opt-in/opt-out settings defined only by project properties (like `IsPublishable`, `IsPackable`, `IsTestProject`, `RuntimeIdentifier` etc.)

There is no need to throw a "cannot publish error" message for projects not to be published at all. This change should fix this.

See https://github.com/dotnet/sdk/issues/1059#issuecomment-574744801