### PR TITLE
Move `PackageOutputPath` initialization to NuGet's Pack targets

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.DefaultOutputPaths.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.DefaultOutputPaths.targets
@@ -41,9 +41,4 @@ Copyright (c) .NET Foundation. All rights reserved.
     <IntermediateOutputPath Condition="!HasTrailingSlash('$(IntermediateOutputPath)')">$(IntermediateOutputPath)\</IntermediateOutputPath>
   </PropertyGroup>
 
-  <!-- Set the package output path (for nuget pack target) now, before the TargetFramework is appended -->
-  <PropertyGroup>
-    <PackageOutputPath Condition="'$(PackageOutputPath)' == ''">$(OutputPath)</PackageOutputPath>
-  </PropertyGroup>
-
 </Project>


### PR DESCRIPTION
This PR Fixes #10730

 - This should free the SDK from having to manage NuGet Pack's `PackageOutputPath` property.
 - This was possible because of the `BaseOutputPath` that'll be used instead of `OutputPath` in the Pack targets.
 - It does depend on NuGet's Fix (NuGet/Home#9234).