### PR TITLE
Fix flow for Microsoft.NET.Sdk.WindowsDesktop from dotnet/wpf

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -57,10 +57,6 @@
       <Uri>https://github.com/dotnet/aspnetcore-tooling</Uri>
       <Sha>cc096c2460701eb1072359d939628c0b91c610a1</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk.WindowsDesktop" Version="5.0.0-preview.1.20127.4">
-      <Uri>https://github.com/dotnet/wpf</Uri>
-      <Sha>efb8416d6de753c84030444d926bf2661346a2b7</Sha>
-    </Dependency>
     <Dependency Name="NuGet.Build.Tasks" Version="5.5.0-rtm.6422">
       <Uri>https://github.com/NuGet/NuGet.Client</Uri>
       <Sha>7bac015acc5b7e0161a058c8febc98abe2386d51</Sha>
@@ -92,6 +88,14 @@
     <Dependency Name="System.Resources.Extensions" Version="5.0.0-preview.1.20120.5">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>3c523a6a7a3ebc25fe524359127b1d8846e23ea3</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.WindowsDesktop.App" Version="5.0.0-preview.1.20127.5">
+      <Uri>https://github.com/dotnet/windowsdesktop</Uri>
+      <Sha>3220fe28e26c10885932b29f653b573f7d845b31</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.NET.Sdk.WindowsDesktop" Version="5.0.0-preview.1.20127.4" CoherentParentDependency="Microsoft.WindowsDesktop.App">
+      <Uri>https://github.com/dotnet/wpf</Uri>
+      <Sha>efb8416d6de753c84030444d926bf2661346a2b7</Sha>
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -27,6 +27,9 @@
     <SystemDiagnosticsFileVersionInfoVersion>4.0.0</SystemDiagnosticsFileVersionInfoVersion>
     <SystemReflectionMetadataVersion>1.8.0</SystemReflectionMetadataVersion>
     <MicrosoftDotNetSignToolVersion>5.0.0-beta.20118.1</MicrosoftDotNetSignToolVersion>
+    <MicrosoftWindowsDesktopAppVersion>5.0.0-preview.1.20127.5</MicrosoftWindowsDesktopAppVersion>
+    <MicrosoftNETSdkWindowsDesktopVersion>
+    </MicrosoftNETSdkWindowsDesktopVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/core-setup -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -27,9 +27,6 @@
     <SystemDiagnosticsFileVersionInfoVersion>4.0.0</SystemDiagnosticsFileVersionInfoVersion>
     <SystemReflectionMetadataVersion>1.8.0</SystemReflectionMetadataVersion>
     <MicrosoftDotNetSignToolVersion>5.0.0-beta.20118.1</MicrosoftDotNetSignToolVersion>
-    <MicrosoftWindowsDesktopAppVersion>5.0.0-preview.1.20127.5</MicrosoftWindowsDesktopAppVersion>
-    <MicrosoftNETSdkWindowsDesktopVersion>
-    </MicrosoftNETSdkWindowsDesktopVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/core-setup -->
@@ -125,6 +122,10 @@
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/wpf -->
     <MicrosoftNETSdkWindowsDesktopPackageVersion>5.0.0-preview.1.20127.4</MicrosoftNETSdkWindowsDesktopPackageVersion>
+  </PropertyGroup>
+  <PropertyGroup>
+    <!-- Dependencies from https://github.com/dotnet/windowsdesktop -->
+    <MicrosoftWindowsDesktopAppVersion>5.0.0-preview.1.20127.5</MicrosoftWindowsDesktopAppVersion>
   </PropertyGroup>
   <!-- Get .NET Framework reference assemblies from NuGet packages -->
   <PropertyGroup>


### PR DESCRIPTION
- Add dependency to `Microsoft.WindowsDesktop.App `
- Update `Microsoft.NET.Sdk.WindowsDesktop` to have a CPD to `Microsoft.WindowsDesktop.App`

There is no actual subscription from `dotnet/wpf` to` dotnet/sdk. `

There is a subscription from `dotnet/windowsdesktop` to `dotnet/sdk` instead, which will notify whenever a new version of `Microsoft.WindowsDesktop.App` is successfully created. 

`dotnet/sdk` will consume the version of `Microsoft.NET.Sdk.WindowsDesktop` (produced previously by `dotnet/wpf`) corresponding to that successful build of `Microsoft.WindowsDesktop.App`. 
 
/cc @rladuca, @nguerrera, @dsplaisted, @mmitche 
/cc @dotnet/wpf-developers 