### PR TITLE
Add support for dotnet run with launch profile for VB.NET projects

### DIFF
--- a/src/Assets/TestProjects/VbAppWithLaunchSettings/My Project/launchSettings.json
+++ b/src/Assets/TestProjects/VbAppWithLaunchSettings/My Project/launchSettings.json
@@ -1,0 +1,32 @@
+{
+  // This comment is to verify proper comment handling by dotnet run. Do not remove.
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:49850/",
+      "sslPort": 0
+    }
+  },
+  "profiles": {
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "First": {
+      "commandName": "Project",
+      "environmentVariables": {
+        "Message": "First"
+      }
+    },
+    "Second": {
+      "commandName": "Project",
+      "environmentVariables": {
+        "Message": "Second"
+      }
+    }
+  }
+}

--- a/src/Assets/TestProjects/VbAppWithLaunchSettings/Program.vb
+++ b/src/Assets/TestProjects/VbAppWithLaunchSettings/Program.vb
@@ -1,0 +1,20 @@
+' Copyright (c) .NET Foundation and contributors. All rights reserved.
+' Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+Imports System
+
+Public Module Program
+    Public Sub Main(args As String())
+        If args.Length > 0 Then
+            Console.WriteLine("echo args:" & String.Join(";", args))
+        End If
+        
+        Dim message As String = Environment.GetEnvironmentVariable("Message")
+
+        If (String.IsNullOrEmpty(message)) Then
+            message = "(NO MESSAGE)"
+        End If
+
+        Console.WriteLine(message)
+    End Sub
+End Module

--- a/src/Assets/TestProjects/VbAppWithLaunchSettings/VbAppWithLaunchSettings.vbproj
+++ b/src/Assets/TestProjects/VbAppWithLaunchSettings/VbAppWithLaunchSettings.vbproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), testAsset.props))\testAsset.props" />
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <RuntimeIdentifiers>win7-x64;win7-x86;osx.10.12-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;ubuntu.16.10-x64;rhel.6-x64;centos.7-x64;rhel.7-x64;debian.8-x64;fedora.24-x64;opensuse.42.1-x64;linux-musl-x64</RuntimeIdentifiers>
+  </PropertyGroup>
+</Project>

--- a/src/Cli/dotnet/commands/dotnet-run/RunCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-run/RunCommand.cs
@@ -100,7 +100,21 @@ namespace Microsoft.DotNet.Tools.Run
             }
 
             var buildPathContainer = File.Exists(Project) ? Path.GetDirectoryName(Project) : Project;
-            var launchSettingsPath = Path.Combine(buildPathContainer, "Properties", "launchSettings.json");
+            string propsDirectory;
+
+            // VB.NET projects store the launch settings file in the
+            // "My Project" directory instead of a "Properties" directory.
+            if (string.Equals(Path.GetExtension(Project), ".vbproj", StringComparison.OrdinalIgnoreCase))
+            {
+                propsDirectory = "My Project";
+            }
+            else
+            {
+                propsDirectory = "Properties";
+            }
+
+            var launchSettingsPath = Path.Combine(buildPathContainer, propsDirectory, "launchSettings.json");
+
             if (File.Exists(launchSettingsPath))
             {
                 if (!HasQuietVerbosity) {

--- a/src/Tests/dotnet-run.Tests/GivenDotnetRunRunsVbProj.cs
+++ b/src/Tests/dotnet-run.Tests/GivenDotnetRunRunsVbProj.cs
@@ -1,0 +1,115 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.IO;
+using FluentAssertions;
+using Microsoft.NET.TestFramework;
+using Microsoft.NET.TestFramework.Assertions;
+using Microsoft.NET.TestFramework.Commands;
+using Xunit;
+using Xunit.Abstractions;
+using LocalizableStrings = Microsoft.DotNet.Tools.Run.LocalizableStrings;
+
+namespace Microsoft.DotNet.Cli.Run.Tests
+{
+    public class GivenDotnetRunRunsVbproj : SdkTest
+    {
+        public GivenDotnetRunRunsVbproj(ITestOutputHelper log) : base(log)
+        {
+        }
+
+        [Fact]
+        public void ItGivesAnErrorWhenAttemptingToUseALaunchProfileThatDoesNotExistWhenThereIsNoLaunchSettingsFile()
+        {
+            var testAppName = "VBTestApp";
+            var testInstance = _testAssetsManager.CopyTestAsset(testAppName)
+                            .WithSource();
+
+            var testProjectDirectory = testInstance.Path;
+
+            new DotnetCommand(Log, "run")
+                .WithWorkingDirectory(testProjectDirectory)
+                .Execute("--launch-profile", "test")
+                .Should().Pass()
+                         .And.HaveStdOutContaining("Hello World!")
+                         .And.HaveStdErrContaining(LocalizableStrings.RunCommandExceptionCouldNotLocateALaunchSettingsFile);
+        }
+
+        [Fact]
+        public void ItUsesLaunchProfileOfTheSpecifiedName()
+        {
+            var testAppName = "VbAppWithLaunchSettings";
+            var testInstance = _testAssetsManager.CopyTestAsset(testAppName)
+                            .WithSource();
+
+            var testProjectDirectory = testInstance.Path;
+
+            var cmd = new DotnetCommand(Log, "run")
+                .WithWorkingDirectory(testProjectDirectory)
+                .Execute("--launch-profile", "Second");
+
+            cmd.Should().Pass()
+                .And.HaveStdOutContaining("Second");
+
+            cmd.StdErr.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void ItDefaultsToTheFirstUsableLaunchProfile()
+        {
+            var testAppName = "VbAppWithLaunchSettings";
+            var testInstance = _testAssetsManager.CopyTestAsset(testAppName)
+                            .WithSource();
+
+            var testProjectDirectory = testInstance.Path;
+            var launchSettingsPath = Path.Combine(testProjectDirectory, "Properties", "launchSettings.json");
+
+            var cmd = new DotnetCommand(Log, "run")
+                .WithWorkingDirectory(testProjectDirectory)
+                .Execute();
+
+            cmd.Should().Pass()
+                .And.NotHaveStdOutContaining(string.Format(LocalizableStrings.UsingLaunchSettingsFromMessage, launchSettingsPath))
+                .And.HaveStdOutContaining("First");
+
+            cmd.StdErr.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void ItPrintsUsingLaunchSettingsMessageWhenNotQuiet()
+        {
+            var testInstance = _testAssetsManager.CopyTestAsset("VbAppWithLaunchSettings")
+                            .WithSource();
+
+            var testProjectDirectory = testInstance.Path;
+            var launchSettingsPath = Path.Combine(testProjectDirectory, "My Project", "launchSettings.json");
+
+            var cmd = new DotnetCommand(Log, "run")
+                .WithWorkingDirectory(testProjectDirectory)
+                .Execute("-v:m");
+
+            cmd.Should().Pass()
+                .And.HaveStdOutContaining(string.Format(LocalizableStrings.UsingLaunchSettingsFromMessage, launchSettingsPath))
+                .And.HaveStdOutContaining("First");
+
+            cmd.StdErr.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void ItGivesAnErrorWhenTheLaunchProfileNotFound()
+        {
+            var testAppName = "VbAppWithLaunchSettings";
+            var testInstance = _testAssetsManager.CopyTestAsset(testAppName)
+                            .WithSource();
+
+            var testProjectDirectory = testInstance.Path;
+
+            new DotnetCommand(Log, "run")
+                .WithWorkingDirectory(testProjectDirectory)
+                .Execute("--launch-profile", "Third")
+                .Should().Pass()
+                         .And.HaveStdOutContaining("(NO MESSAGE)")
+                         .And.HaveStdErrContaining(string.Format(LocalizableStrings.RunCommandExceptionCouldNotApplyLaunchSettings, "Third", "").Trim());
+        }
+    }
+}


### PR DESCRIPTION
Fixes #10751

If the project is a `.vbproj` file, then the `RunCommand` will look for the `launchSettings.json` file in the `My Project` folder; otherwise, for any other file type, it looks in the `Properties` folder.

I've also added some tests for the `RunCommand` to use a VB.NET project since there weren't any existing tests. I've only copied some tests from the equivalent C# project tests where the launch profile was specified. I didn't think duplicating all of the tests from the C# project tests was worth the effort, since most of those tests are not specific to any particular language type.