### PR TITLE
Bundle NuGet.Build.Tasks.Console in redist

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -40,6 +40,7 @@
   <PropertyGroup>
     <!-- Dependencies from https://github.com/nuget/nuget.client -->
     <NuGetBuildTasksPackageVersion>5.6.0-preview.1.6478</NuGetBuildTasksPackageVersion>
+    <NuGetBuildTasksConsolePackageVersion>$(NuGetBuildTasksPackageVersion)</NuGetBuildTasksConsolePackageVersion>
     <NuGetBuildTasksPackPackageVersion>$(NuGetBuildTasksPackageVersion)</NuGetBuildTasksPackPackageVersion>
     <NuGetCommandLineXPlatPackageVersion>$(NuGetBuildTasksPackageVersion)</NuGetCommandLineXPlatPackageVersion>
     <NuGetProjectModelPackageVersion>$(NuGetBuildTasksPackageVersion)</NuGetProjectModelPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -40,7 +40,7 @@
   <PropertyGroup>
     <!-- Dependencies from https://github.com/nuget/nuget.client -->
     <NuGetBuildTasksPackageVersion>5.6.0-preview.1.6478</NuGetBuildTasksPackageVersion>
-    <NuGetBuildTasksConsolePackageVersion>$(NuGetBuildTasksPackageVersion)</NuGetBuildTasksConsolePackageVersion>
+    <NuGetBuildTasksConsolePackageVersion>5.6.0-preview.2.6504</NuGetBuildTasksConsolePackageVersion>
     <NuGetBuildTasksPackPackageVersion>$(NuGetBuildTasksPackageVersion)</NuGetBuildTasksPackPackageVersion>
     <NuGetCommandLineXPlatPackageVersion>$(NuGetBuildTasksPackageVersion)</NuGetCommandLineXPlatPackageVersion>
     <NuGetProjectModelPackageVersion>$(NuGetBuildTasksPackageVersion)</NuGetProjectModelPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -39,7 +39,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/nuget/nuget.client -->
-    <NuGetBuildTasksPackageVersion>5.6.0-preview.2.6504</NuGetBuildTasksPackageVersion>
+    <NuGetBuildTasksPackageVersion>5.6.0-preview.2.6508</NuGetBuildTasksPackageVersion>
     <NuGetBuildTasksConsolePackageVersion>$(NuGetBuildTasksPackageVersion)</NuGetBuildTasksConsolePackageVersion>
     <NuGetBuildTasksPackPackageVersion>$(NuGetBuildTasksPackageVersion)</NuGetBuildTasksPackPackageVersion>
     <NuGetCommandLineXPlatPackageVersion>$(NuGetBuildTasksPackageVersion)</NuGetCommandLineXPlatPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -39,8 +39,8 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/nuget/nuget.client -->
-    <NuGetBuildTasksPackageVersion>5.6.0-preview.2.6489</NuGetBuildTasksPackageVersion>
-    <NuGetBuildTasksConsolePackageVersion>5.6.0-preview.2.6504</NuGetBuildTasksConsolePackageVersion>
+    <NuGetBuildTasksPackageVersion>5.6.0-preview.2.6504</NuGetBuildTasksPackageVersion>
+    <NuGetBuildTasksConsolePackageVersion>$(NuGetBuildTasksPackageVersion)</NuGetBuildTasksConsolePackageVersion>
     <NuGetBuildTasksPackPackageVersion>$(NuGetBuildTasksPackageVersion)</NuGetBuildTasksPackPackageVersion>
     <NuGetCommandLineXPlatPackageVersion>$(NuGetBuildTasksPackageVersion)</NuGetCommandLineXPlatPackageVersion>
     <NuGetProjectModelPackageVersion>$(NuGetBuildTasksPackageVersion)</NuGetProjectModelPackageVersion>

--- a/src/Layout/redist/redist.csproj
+++ b/src/Layout/redist/redist.csproj
@@ -20,6 +20,7 @@
 
   <ItemGroup>
     <PackageReference Include="NuGet.Build.Tasks" Version="$(NuGetBuildTasksPackageVersion)" />
+    <PackageReference Include="NuGet.Build.Tasks.Console" Version="$(NuGetBuildTasksConsolePackageVersion)" />
     <PackageReference Include="Microsoft.Build.NuGetSdkResolver" Version="$(MicrosoftBuildNuGetSdkResolverPackageVersion)" />
     <PackageReference Include="Microsoft.TestPlatform.CLI" Version="$(MicrosoftTestPlatformCLIPackageVersion)" ExcludeAssets="All" />
     <PackageReference Include="Microsoft.TestPlatform.Build" Version="$(MicrosoftTestPlatformBuildPackageVersion)" />

--- a/src/Tests/dotnet-restore.Tests/GivenThatIWantToRestoreApp.cs
+++ b/src/Tests/dotnet-restore.Tests/GivenThatIWantToRestoreApp.cs
@@ -22,8 +22,10 @@ namespace Microsoft.DotNet.Restore.Test
         {
         }
 
-        [Fact]
-        public void ItRestoresAppToSpecificDirectory()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void ItRestoresAppToSpecificDirectory(bool useStaticGraphEvaluation)
         {
             var rootPath = _testAssetsManager.CreateTestDirectory().Path;
 
@@ -37,6 +39,7 @@ namespace Microsoft.DotNet.Restore.Test
                 .Path;
 
             string[] args = new[] { "--packages", fullPath };
+            args = HandleStaticGraphEvaluation(useStaticGraphEvaluation, args);
             new DotnetRestoreCommand(Log)
                  .WithWorkingDirectory(projectDirectory)
                  .Execute(args)
@@ -48,8 +51,10 @@ namespace Microsoft.DotNet.Restore.Test
             Directory.EnumerateFiles(fullPath, "*.dll", SearchOption.AllDirectories).Count().Should().BeGreaterThan(0);
         }
 
-        [Fact]
-        public void ItRestoresLibToSpecificDirectory()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void ItRestoresLibToSpecificDirectory(bool useStaticGraphEvaluation)
         {
             var rootPath = _testAssetsManager.CreateTestDirectory().Path;
 
@@ -64,6 +69,7 @@ namespace Microsoft.DotNet.Restore.Test
                 .Pass();
 
             string[] args = new[] { "--packages", dir };
+            args = HandleStaticGraphEvaluation(useStaticGraphEvaluation, args);
             new DotnetRestoreCommand(Log)
                 .WithWorkingDirectory(rootPath)
                 .Execute(args)
@@ -75,8 +81,10 @@ namespace Microsoft.DotNet.Restore.Test
             Directory.EnumerateFiles(fullPath, "*.dll", SearchOption.AllDirectories).Count().Should().BeGreaterThan(0);
         }
 
-        [Fact]
-        public void ItRestoresTestAppToSpecificDirectory()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void ItRestoresTestAppToSpecificDirectory(bool useStaticGraphEvaluation)
         {
             var rootPath = _testAssetsManager.CopyTestAsset("VSTestCore")
                 .WithSource()
@@ -87,6 +95,7 @@ namespace Microsoft.DotNet.Restore.Test
             string fullPath = Path.GetFullPath(Path.Combine(rootPath, dir));
 
             string[] args = new[] { "--packages", dir };
+            args = HandleStaticGraphEvaluation(useStaticGraphEvaluation, args);
             new DotnetRestoreCommand(Log)
                 .WithWorkingDirectory(rootPath)
                 .Execute(args)
@@ -98,8 +107,10 @@ namespace Microsoft.DotNet.Restore.Test
             Directory.EnumerateFiles(fullPath, "*.dll", SearchOption.AllDirectories).Count().Should().BeGreaterThan(0);
         }
 
-        [Fact]
-        public void ItRestoresWithTheSpecifiedVerbosity()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void ItRestoresWithTheSpecifiedVerbosity(bool useStaticGraphEvaluation)
         {
             var rootPath = _testAssetsManager.CreateTestDirectory().Path;
 
@@ -114,6 +125,7 @@ namespace Microsoft.DotNet.Restore.Test
                 .Pass();
 
             string[] args = new[] { "--packages", dir, "--verbosity",  "quiet" };
+            args = HandleStaticGraphEvaluation(useStaticGraphEvaluation, args);
             new DotnetRestoreCommand(Log)
                  .WithWorkingDirectory(rootPath)
                  .Execute(args)
@@ -122,5 +134,10 @@ namespace Microsoft.DotNet.Restore.Test
                  .And.NotHaveStdErr()
                  .And.NotHaveStdOut();
         }
+
+        private static string[] HandleStaticGraphEvaluation(bool useStaticGraphEvaluation, string[] args) =>
+            useStaticGraphEvaluation ? 
+                args.Append("/p:RestoreUseStaticGraphEvaluation=true").ToArray() :
+                args;
     }
 }


### PR DESCRIPTION
Add the NuGet.Build.Tasks.Console package for the pack bundle.
Fixes https://github.com/NuGet/Home/issues/9267