### PR TITLE
Don't run tests for official builds

### DIFF
--- a/eng/build.yml
+++ b/eng/build.yml
@@ -54,7 +54,7 @@ jobs:
         - _PerfIterations: 25
     steps:
     - ${{ if eq(parameters.agentOs, 'Windows_NT') }}:
-      - script: eng\common\CIBuild.cmd
+      - script: eng\CIBuild.cmd
                   -configuration $(_BuildConfig)
                   $(_PublishArgs)
                   $(_SignArgs)
@@ -81,7 +81,7 @@ jobs:
       #       HelixAccessToken: ''
 
     - ${{ if eq(parameters.agentOs, 'Windows_NT_FullFramework') }}:
-      - script: eng\common\CIBuild.cmd
+      - script: eng\CIBuild.cmd
                   -configuration $(_BuildConfig)
                   $(_PublishArgs)
                   $(_SignArgs)
@@ -110,7 +110,7 @@ jobs:
       #       HelixAccessToken: ''
 
     - ${{ if eq(parameters.agentOs, 'Windows_NT_TestAsTools') }}:
-      - script: eng\common\CIBuild.cmd
+      - script: eng\CIBuild.cmd
                   -configuration $(_BuildConfig)
                   $(_PublishArgs)
                   $(_SignArgs)


### PR DESCRIPTION
Fixes #10771

Use CIBuild.cmd script out of `eng` folder (which doesn't include `-test` explicitly) instead of `eng/common`.