### PR TITLE
Enable test for net5.0 TargetFramework

### DIFF
--- a/src/Tests/Microsoft.NET.Build.Tests/DeleteNuGetArtifactsFixture.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/DeleteNuGetArtifactsFixture.cs
@@ -14,7 +14,7 @@ namespace Microsoft.NET.Build.Tests
         public static string TestDirectoriesNamePrefix = "Nuget_reference_compat";
         public static string ReferencerDirectoryName = "Reference";
         public static string NuGetSharedDirectoryNamePostfix = "_NuGetDependencies";
-        public static string NetstandardToken = "netstandard";
+        public static string NetstandardTargetFrameworkIdentifier = ".NETStandard";
         public static string DependencyDirectoryNamePrefix = "D_";
 
         public static string ConstructNuGetPackageReferencePath(TestProject dependencyProject)

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToReferenceAProject.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToReferenceAProject.cs
@@ -71,7 +71,7 @@ namespace Microsoft.NET.Build.Tests
             referencerProject.ReferencedProjects.Add(dependencyProject);
 
             //  Set the referencer project as an Exe unless it targets .NET Standard
-            if (!referencerProject.ShortTargetFrameworkIdentifiers.Contains("netstandard"))
+            if (!referencerProject.TargetFrameworkIdentifiers.Contains(ConstantStringValues.NetstandardTargetFrameworkIdentifier))
             {
                 referencerProject.IsExe = true;
             }

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToVerifyNuGetReferenceCompat.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToVerifyNuGetReferenceCompat.cs
@@ -92,7 +92,7 @@ namespace Microsoft.NET.Build.Tests
             }
 
             //  Set the referencer project as an Exe unless it targets .NET Standard
-            if (!referencerProject.ShortTargetFrameworkIdentifiers.Contains(ConstantStringValues.NetstandardToken))
+            if (!referencerProject.TargetFrameworkIdentifiers.Contains(ConstantStringValues.NetstandardTargetFrameworkIdentifier))
             {
                 referencerProject.IsExe = true;
             }

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToVerifyProjectReferenceCompat.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToVerifyProjectReferenceCompat.cs
@@ -63,7 +63,7 @@ namespace Microsoft.NET.Build.Tests
             }
 
             //  Set the referencer project as an Exe unless it targets .NET Standard
-            if (!referencerProject.ShortTargetFrameworkIdentifiers.Contains("netstandard"))
+            if (!referencerProject.TargetFrameworkIdentifiers.Contains(ConstantStringValues.NetstandardTargetFrameworkIdentifier))
             {
                 referencerProject.IsExe = true;
             }

--- a/src/Tests/Microsoft.NET.Build.Tests/Net50Targeting.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/Net50Targeting.cs
@@ -20,7 +20,8 @@ namespace Microsoft.NET.Build.Tests
         {
         }
 
-        [Fact]
+        //  Core MSBuild only until VS build we use has NuGet changes for net5.0
+        [CoreMSBuildOnlyFact]
         public void Net50TargetFrameworkParsesAsNetCoreAppTargetFrameworkIdentifier()
         {
             var testProject = new TestProject()

--- a/src/Tests/Microsoft.NET.Build.Tests/Net50Targeting.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/Net50Targeting.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -19,7 +20,7 @@ namespace Microsoft.NET.Build.Tests
         {
         }
 
-        [Fact(Skip="Need NuGet support for net5.0 TFM")]
+        [Fact]
         public void Net50TargetFrameworkParsesAsNetCoreAppTargetFrameworkIdentifier()
         {
             var testProject = new TestProject()
@@ -37,7 +38,7 @@ namespace Microsoft.NET.Build.Tests
                 .Should()
                 .Pass();
 
-            var getValuesCommand = new GetValuesCommand(Log, testAsset.TestRoot, testProject.TargetFrameworks, "TargetFrameworkIdentifier");
+            var getValuesCommand = new GetValuesCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name), testProject.TargetFrameworks, "TargetFrameworkIdentifier");
             getValuesCommand.Execute()
                 .Should()
                 .Pass();


### PR DESCRIPTION
Enable basic test coverage for `net5.0`, now that we have a version of NuGet that supports it.