### PR TITLE
Use new HostModel APIs

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -17,7 +17,7 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>b3f81350c856cfd5079c52349024a8f55d0c009a</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.HostModel" Version="5.0.0-preview.2.20152.11">
+    <Dependency Name="Microsoft.NET.HostModel" Version="5.0.0-preview.3.20161.13">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>b3f81350c856cfd5079c52349024a8f55d0c009a</Sha>
     </Dependency>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -33,7 +33,7 @@
     <MicrosoftDotNetPlatformAbstractionsPackageVersion>5.0.0-preview.2.20152.11</MicrosoftDotNetPlatformAbstractionsPackageVersion>
     <MicrosoftExtensionsDependencyModelPackageVersion>5.0.0-preview.2-runtime.20152.11</MicrosoftExtensionsDependencyModelPackageVersion>
     <MicrosoftNETCoreDotNetHostResolverPackageVersion>5.0.0-preview.2.20152.11</MicrosoftNETCoreDotNetHostResolverPackageVersion>
-    <MicrosoftNETHostModelVersion>5.0.0-preview.2.20152.11</MicrosoftNETHostModelVersion>
+    <MicrosoftNETHostModelVersion>5.0.0-preview.3.20161.13</MicrosoftNETHostModelVersion>
     <PlatformAbstractionsVersion>$(MicrosoftDotNetPlatformAbstractionsPackageVersion)</PlatformAbstractionsVersion>
     <MicrosoftExtensionsDependencyModelVersion>$(MicrosoftExtensionsDependencyModelPackageVersion)</MicrosoftExtensionsDependencyModelVersion>
   </PropertyGroup>

--- a/src/Cli/dotnet/ShellShim/AppHostShimMaker.cs
+++ b/src/Cli/dotnet/ShellShim/AppHostShimMaker.cs
@@ -48,7 +48,7 @@ namespace Microsoft.DotNet.ShellShim
 
             if (ResourceUpdater.IsSupportedOS())
             {
-                var windowsGraphicalUserInterfaceBit = BinaryUtils.GetWindowsGraphicalUserInterfaceBit(entryPointFullPath);
+                var windowsGraphicalUserInterfaceBit = PEUtils.GetWindowsGraphicalUserInterfaceBit(entryPointFullPath);
                 HostWriter.CreateAppHost(appHostSourceFilePath: appHostSourcePath,
                                          appHostDestinationFilePath: appHostDestinationFilePath,
                                          appBinaryFilePath: appBinaryFilePath,

--- a/src/Tasks/Microsoft.NET.Build.Tasks/GenerateBundle.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/GenerateBundle.cs
@@ -23,7 +23,8 @@ namespace Microsoft.NET.Build.Tasks
 
         protected override void ExecuteCore()
         {
-            var bundler = new Bundler(AppHostName, OutputDir, IncludeSymbols, ShowDiagnosticOutput);
+            BundleOptions options = BundleOptions.BundleAllContent | (IncludeSymbols ? BundleOptions.BundleSymbolFiles : BundleOptions.None);
+            var bundler = new Bundler(AppHostName, OutputDir, options, diagnosticOutput: ShowDiagnosticOutput);
             var fileSpec = new List<FileSpec>(FilesToBundle.Length);
 
             foreach (var item in FilesToBundle)

--- a/src/Tests/Microsoft.DotNet.ShellShim.Tests/AppHostShellShimMakerTests.cs
+++ b/src/Tests/Microsoft.DotNet.ShellShim.Tests/AppHostShellShimMakerTests.cs
@@ -25,7 +25,7 @@ namespace Microsoft.DotNet.ShellShim.Tests
         {
             string shimPath = CreateApphostAndReturnShimPath();
 
-            BinaryUtils.GetWindowsGraphicalUserInterfaceBit(shimPath).Should().Be(WindowsGUISubsystem);
+            PEUtils.GetWindowsGraphicalUserInterfaceBit(shimPath).Should().Be(WindowsGUISubsystem);
         }
 
         [UnixOnlyFact]

--- a/src/Tests/Microsoft.NET.ToolPack.Tests/GivenThatWeWantToPackAToolProjectWithPackagedShim.cs
+++ b/src/Tests/Microsoft.NET.ToolPack.Tests/GivenThatWeWantToPackAToolProjectWithPackagedShim.cs
@@ -433,7 +433,7 @@ namespace Microsoft.NET.ToolPack.Tests
                     $"tools/netcoreapp3.0/any/shims/win-x64/{_customToolCommandName}.exe",
                     tmpfilePath,
                     null);
-                HostModel.AppHost.BinaryUtils.GetWindowsGraphicalUserInterfaceBit(copiedFile).Should().Be(windowsGUISubsystem);
+                HostModel.AppHost.PEUtils.GetWindowsGraphicalUserInterfaceBit(copiedFile).Should().Be(windowsGUISubsystem);
             }
         }
 


### PR DESCRIPTION
Update GenerateBundle task and a few others to use the new APIs in HostModel intruduced by https://github.com/dotnet/runtime/pull/33413.
This change is in preparation for moving to new PublishSingleFile semantics in .net 5.

In GenerateBundle task, the SDK constructs the bundler with `BundleAllContent` option for all builds.
This keeps the behavior of PublishSingleFile unchanged until Host/Runtime components of the feature are ready.