### PR TITLE
Updating ComputeFilesCopiedToPublishDir to work during design time builds

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -139,13 +139,6 @@ Copyright (c) .NET Foundation. All rights reserved.
           Inputs="@(_ResolvedFileToPublishPreserveNewest)"
           Outputs="@(_ResolvedFileToPublishPreserveNewest->'$(PublishDir)%(RelativePath)')">
 
-    <ItemGroup>
-      <_ResolvedUnbundledFileToPublishPreserveNewest 
-                    Include="@(_ResolvedFileToPublishPreserveNewest)" 
-                    Condition="'$(PublishSingleFile)' != 'true' or 
-                               '%(_ResolvedFileToPublishPreserveNewest.ExcludeFromSingleFile)'=='true'" />
-    </ItemGroup>
-
     <!--
       PreserveNewest means that we will only copy the source to the destination if the source is newer.
       SkipUnchangedFiles is not used for that purpose because it will copy if the source and destination
@@ -175,13 +168,6 @@ Copyright (c) .NET Foundation. All rights reserved.
     -->
   <Target Name="_CopyResolvedFilesToPublishAlways"
           DependsOnTargets="_ComputeResolvedFilesToPublishTypes">
-
-    <ItemGroup>
-      <_ResolvedUnbundledFileToPublishAlways
-                    Include="@(_ResolvedFileToPublishAlways)"
-                    Condition="'$(PublishSingleFile)' != 'true' or 
-                               '%(_ResolvedFileToPublishAlways.ExcludeFromSingleFile)'=='true'" />
-    </ItemGroup>
 
     <!--
       Use SkipUnchangedFiles to prevent unnecessary file copies. The copy will occur if the
@@ -358,6 +344,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                                         _ComputeResolvedFilesToPublishTypes
 
     Splits ResolvedFileToPublish items into 'PreserveNewest' and 'Always' buckets.
+    Then further splits those into 'Unbundled' buckets based on the single file setting.
     ============================================================
     -->
   <Target Name="_ComputeResolvedFilesToPublishTypes">
@@ -368,6 +355,19 @@ Copyright (c) .NET Foundation. All rights reserved.
 
       <_ResolvedFileToPublishAlways Include="@(ResolvedFileToPublish)"
                                     Condition="'%(ResolvedFileToPublish.CopyToPublishDirectory)'=='Always'" />
+    </ItemGroup>
+
+    <ItemGroup>
+
+      <_ResolvedUnbundledFileToPublishPreserveNewest
+                    Include="@(_ResolvedFileToPublishPreserveNewest)"
+                    Condition="'$(PublishSingleFile)' != 'true' or 
+                               '%(_ResolvedFileToPublishPreserveNewest.ExcludeFromSingleFile)'=='true'" />
+
+      <_ResolvedUnbundledFileToPublishAlways
+              Include="@(_ResolvedFileToPublishAlways)"
+              Condition="'$(PublishSingleFile)' != 'true' or 
+                         '%(_ResolvedFileToPublishAlways.ExcludeFromSingleFile)'=='true'" />
     </ItemGroup>
   </Target>
 
@@ -984,13 +984,12 @@ Copyright (c) .NET Foundation. All rights reserved.
     ============================================================
                                         ComputeFilesCopiedToPublishDir
 
-    Gathers all the files that were copied to the publish directory.
+    Gathers all the files that will be copied to the publish directory.
     ============================================================
     -->
   <Target Name="ComputeFilesCopiedToPublishDir"
-          DependsOnTargets="_CopyResolvedFilesToPublishPreserveNewest;
-                            _CopyResolvedFilesToPublishAlways;
-                            BundlePublishDirectory">
+          DependsOnTargets="_ComputeResolvedFilesToPublishTypes;
+                            _ComputeFilesToBundle">
 
     <ItemGroup>
       <FilesCopiedToPublishDir Include="@(_ResolvedUnbundledFileToPublishPreserveNewest)"/>

--- a/src/Tests/Microsoft.NET.Publish.Tests/PublishItemsOutputGroupTests.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/PublishItemsOutputGroupTests.cs
@@ -158,30 +158,15 @@ namespace Microsoft.NET.Publish.Tests
 
             var buildCommand = new BuildCommand(Log, testAsset.Path, testProject.Name);
             buildCommand
-                .Execute("/p:RuntimeIdentifier=win-x86;DesignTimeBuild=true;PublishSingleFile=true", "/t:PublishItemsOutputGroup")
-                .Should()
-                .Pass();
-        }
-
-        [CoreMSBuildAndWindowsOnlyFact]
-        public void GroupBuildDoesNotGeneratePublishFiles()
-        {
-            var testProject = this.SetupProject();
-            var testAsset = _testAssetsManager.CreateTestProject(testProject);
-
-            var restoreCommand = new RestoreCommand(Log, testAsset.Path, testProject.Name);
-            restoreCommand
-                .Execute()
+                .Execute("/p:RuntimeIdentifier=win-x86;DesignTimeBuild=true", "/t:PublishItemsOutputGroup")
                 .Should()
                 .Pass();
 
-            var buildCommand = new BuildCommand(Log, testAsset.Path, testProject.Name);
-
-            // Since this build tries to copies all the final publish artifacts without calling the publish target it should fail
-            buildCommand
-                .Execute("/p:RuntimeIdentifier=win-x86;DesignTimeBuild=true;PublishSingleFile=true", "/t:PublishItemsOutputGroup")
+            // Confirm we were able to build the output group without the publish actually happening
+            var publishDir = new DirectoryInfo(Path.Combine(buildCommand.GetOutputDirectory(testProject.TargetFrameworks).FullName, "win-x86", "publish"));
+            publishDir
                 .Should()
-                .Fail();
+                .NotExist();
         }
 
         private TestProject SetupProject(bool addCopyFilesTargets = true)

--- a/src/Tests/Microsoft.NET.Publish.Tests/PublishItemsOutputGroupTests.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/PublishItemsOutputGroupTests.cs
@@ -115,7 +115,7 @@ namespace Microsoft.NET.Publish.Tests
 
             var buildCommand = new BuildCommand(Log, testAsset.Path, testProject.Name);
             buildCommand
-                .Execute("/p:RuntimeIdentifier=win-x86;DesignTimeBuild=true;PublishSingleFile=true", "/t:PublishItemsOutputGroup")
+                .Execute("/p:RuntimeIdentifier=win-x86;DesignTimeBuild=true;PublishSingleFile=true", "/t:Publish;PublishItemsOutputGroup")
                 .Should()
                 .Pass();
 
@@ -144,7 +144,47 @@ namespace Microsoft.NET.Publish.Tests
             }
         }
 
-        private TestProject SetupProject()
+        [CoreMSBuildAndWindowsOnlyFact]
+        public void GroupBuildsWithoutPublish()
+        {
+            var testProject = this.SetupProject(addCopyFilesTargets: false);
+            var testAsset = _testAssetsManager.CreateTestProject(testProject);
+
+            var restoreCommand = new RestoreCommand(Log, testAsset.Path, testProject.Name);
+            restoreCommand
+                .Execute()
+                .Should()
+                .Pass();
+
+            var buildCommand = new BuildCommand(Log, testAsset.Path, testProject.Name);
+            buildCommand
+                .Execute("/p:RuntimeIdentifier=win-x86;DesignTimeBuild=true;PublishSingleFile=true", "/t:PublishItemsOutputGroup")
+                .Should()
+                .Pass();
+        }
+
+        [CoreMSBuildAndWindowsOnlyFact]
+        public void GroupBuildDoesNotGeneratePublishFiles()
+        {
+            var testProject = this.SetupProject();
+            var testAsset = _testAssetsManager.CreateTestProject(testProject);
+
+            var restoreCommand = new RestoreCommand(Log, testAsset.Path, testProject.Name);
+            restoreCommand
+                .Execute()
+                .Should()
+                .Pass();
+
+            var buildCommand = new BuildCommand(Log, testAsset.Path, testProject.Name);
+
+            // Since this build tries to copies all the final publish artifacts without calling the publish target it should fail
+            buildCommand
+                .Execute("/p:RuntimeIdentifier=win-x86;DesignTimeBuild=true;PublishSingleFile=true", "/t:PublishItemsOutputGroup")
+                .Should()
+                .Fail();
+        }
+
+        private TestProject SetupProject(bool addCopyFilesTargets = true)
         {
             var testProject = new TestProject()
             {
@@ -159,23 +199,26 @@ namespace Microsoft.NET.Publish.Tests
             //  Use a test-specific packages folder
             testProject.AdditionalProperties["RestorePackagesPath"] = @"$(MSBuildProjectDirectory)\..\pkg";
 
-            // Add a target that will dump the contents of the PublishItemsOutputGroup to
-            // a test directory after building.
-            testProject.CopyFilesTargets.Add(new CopyFilesTarget(
-                "CopyPublishItemsOutputGroup",
-                "PublishItemsOutputGroup",
-                "@(PublishItemsOutputGroupOutputs)",
-                null,
-                "$(MSBuildProjectDirectory)\\TestOutput"));
+            if (addCopyFilesTargets)
+            {
+                // Add a target that will dump the contents of the PublishItemsOutputGroup to
+                // a test directory after building.
+                testProject.CopyFilesTargets.Add(new CopyFilesTarget(
+                    "CopyPublishItemsOutputGroup",
+                    "PublishItemsOutputGroup",
+                    "@(PublishItemsOutputGroupOutputs)",
+                    null,
+                    "$(MSBuildProjectDirectory)\\TestOutput"));
 
-            // Add another target that will dump the members of PublishItemsOutputGroup that
-            // have property IsKeyOutput set to true to a different test directory.
-            testProject.CopyFilesTargets.Add(new CopyFilesTarget(
-                "CopyPublishKeyItemsOutputGroup",
-                "PublishItemsOutputGroup",
-                "@(PublishItemsOutputGroupOutputs)",
-                @"'%(PublishItemsOutputGroupOutputs.IsKeyOutput)' == 'True'",
-                "$(MSBuildProjectDirectory)\\TestOutput_Key"));
+                // Add another target that will dump the members of PublishItemsOutputGroup that
+                // have property IsKeyOutput set to true to a different test directory.
+                testProject.CopyFilesTargets.Add(new CopyFilesTarget(
+                    "CopyPublishKeyItemsOutputGroup",
+                    "PublishItemsOutputGroup",
+                    "@(PublishItemsOutputGroupOutputs)",
+                    @"'%(PublishItemsOutputGroupOutputs.IsKeyOutput)' == 'True'",
+                    "$(MSBuildProjectDirectory)\\TestOutput_Key"));
+            }
 
             return testProject;
         }


### PR DESCRIPTION
Fixing a regression caused by my previous change: https://github.com/dotnet/sdk/pull/10600

That change incorrectly made PublishItemsOutputGroup depend on the targets that actually copy build artifacts instead of the ones that just compute their paths.  Since this output group is frequently used during design time builds this caused failures in the case where the build artifacts don't exist yet.

Also adding tests that explicitly add the requirement that this output group should be able to build without the existence of all the publishing artifacts.