### PR TITLE
Do not exit on success

### DIFF
--- a/scripts/obtain/dotnet-install.ps1
+++ b/scripts/obtain/dotnet-install.ps1
@@ -583,7 +583,7 @@ if ($DryRun) {
         }
     }
     Say "Repeatable invocation: $RepeatableCommand"
-    exit 0
+    return
 }
 
 if ($Runtime -eq "dotnet") {
@@ -611,7 +611,7 @@ $isAssetInstalled = Is-Dotnet-Package-Installed -InstallRoot $InstallRoot -Relat
 if ($isAssetInstalled) {
     Say "$assetName version $SpecificVersion is already installed."
     Prepend-Sdk-InstallRoot-To-Path -InstallRoot $InstallRoot -BinFolderRelativePath $BinFolderRelativePath
-    exit 0
+    return
 }
 
 New-Item -ItemType Directory -Force -Path $InstallRoot | Out-Null
@@ -620,7 +620,7 @@ $installDrive = $((Get-Item $InstallRoot).PSDrive.Name);
 $diskInfo = Get-PSDrive -Name $installDrive
 if ($diskInfo.Free / 1MB -le 100) {
     Say "There is not enough disk space on drive ${installDrive}:"
-    exit 0
+    return
 }
 
 $ZipPath = [System.IO.Path]::combine([System.IO.Path]::GetTempPath(), [System.IO.Path]::GetRandomFileName())
@@ -683,4 +683,3 @@ Remove-Item $ZipPath
 Prepend-Sdk-InstallRoot-To-Path -InstallRoot $InstallRoot -BinFolderRelativePath $BinFolderRelativePath
 
 Say "Installation finished"
-exit 0


### PR DESCRIPTION
Removed exit 0, because it communicates success in a way that will exit the whole process. This is unnecessary, and discouraged practice. Exiting the process also prevents the PATH from being set correctly, and is a source of frustration when the script is called in-memory. 

This change allows to use the script without saving it into a file, and to do multiple installs in a row safely. 


```powershell
$install = [ScriptBlock]::Create((Invoke-WebRequest 'https://dot.net/v1/dotnet-install.ps1'))

& $install -Channel 3.1 -InstallDir dotnet-sdk-3.1
& $install -Channel 2.1 -InstallDir dotnet-2.1 -Runtime dotnet
```

This will not prevent the current doc examples from working because `-Command` starts a process and then exits it, so return will act the same as exit 0. 

```powershell
$pid; powershell -command '$pid'; $pid
17844
23036
17844
``` 

Partial fix for #8688