### PR TITLE
[Port to 5.0.1 preview 2] Adding back ComputeFilesCopiedToPublishDir item group to fix wapproj compat bug

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -1055,6 +1055,20 @@ Copyright (c) .NET Foundation. All rights reserved.
     </GetEmbeddedApphostPaths>
 
   </Target>
+  
+  <!--
+    ============================================================
+                                            ComputeFilesCopiedToPublishDir
+
+    Gathers all the files that were copied to the publish directory.  This is used by wapproj and is required for back compat.
+    ============================================================
+    -->
+  <Target Name="ComputeFilesCopiedToPublishDir" DependsOnTargets="ComputeFilesToPublish">
+    <ItemGroup>
+      <FilesCopiedToPublishDir Include="@(ResolvedFileToPublish)"/>
+      <FilesCopiedToPublishDir Include="$(PublishedSingleFilePath)" RelativePath="$(PublishedSingleFileName)" IsKeyOutput="true" Condition="'$(PublishSingleFile)' == 'true'"/>
+    </ItemGroup>
+  </Target>
 
   <!--
     ============================================================
@@ -1067,21 +1081,16 @@ Copyright (c) .NET Foundation. All rights reserved.
     <PublishItemsOutputGroupDependsOn>
       $(PublishItemsOutputGroupDependsOn);
       ResolveReferences;
-      ComputeFilesToPublish;
+      ComputeFilesCopiedToPublishDir;
     </PublishItemsOutputGroupDependsOn>
   </PropertyGroup>
 
   <Target Name="PublishItemsOutputGroup" DependsOnTargets="$(PublishItemsOutputGroupDependsOn)" Returns="@(PublishItemsOutputGroupOutputs)">
     <ItemGroup>
-      <PublishItemsOutputGroupOutputs Include="@(ResolvedFileToPublish->'%(FullPath)')"
-                                      TargetPath="%(ResolvedFileToPublish.RelativePath)"
-                                      IsKeyOutput="%(ResolvedFileToPublish.IsKeyOutput)"
+      <PublishItemsOutputGroupOutputs Include="@(FilesCopiedToPublishDir->'%(FullPath)')"
+                                      TargetPath="%(FilesCopiedToPublishDir.RelativePath)"
+                                      IsKeyOutput="%(FilesCopiedToPublishDir.IsKeyOutput)"
                                       OutputGroup="PublishItemsOutputGroup" />
-      <PublishItemsOutputGroupOutputs Include="$(PublishedSingleFilePath)"
-                                      TargetPath="$(PublishedSingleFileName)"
-                                      IsKeyOutput="true"
-                                      OutputGroup="PublishItemsOutputGroup" 
-                                      Condition="'$(PublishSingleFile)' == 'true'" />    
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
This item group was removed in .NET 5 due to some refactoring around the single file scenario. However, since it's consumed by wapproj we need it to continue to exist for compat reasons. So I'm adding back a simplified version of the target.

Porting to release/5.0.1xx-preview2. This was already checked into Master here: https://github.com/dotnet/sdk/pull/10925