### PR TITLE
Default to not importing .net framework winfx targets

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.BeforeCommon.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.BeforeCommon.targets
@@ -20,7 +20,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <!-- Workaround: https://github.com/microsoft/msbuild/issues/4948 -->
   <PropertyGroup>
-    <ImportWinFXTargets>false</ImportWinFXTargets>
+    <ImportFrameworkWinFXTargets>false</ImportFrameworkWinFXTargets>
   </PropertyGroup>
   
   <PropertyGroup>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.BeforeCommon.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.BeforeCommon.targets
@@ -17,6 +17,11 @@ Copyright (c) .NET Foundation. All rights reserved.
     <Import Project="Microsoft.NET.Sdk.DefaultItems.props" />
     <Import Project="Microsoft.NET.SupportedTargetFrameworks.props" />
   </ImportGroup>
+
+    <!-- Workaround: https://github.com/microsoft/msbuild/issues/4948 -->
+  <PropertyGroup>
+    <ImportWinFXTargets>false</ImportWinFXTargets>
+  </PropertyGroup>
   
   <PropertyGroup>
     <_IsExecutable Condition="'$(OutputType)' == 'Exe' or '$(OutputType)'=='WinExe'">true</_IsExecutable>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -23,11 +23,6 @@ Copyright (c) .NET Foundation. All rights reserved.
     <GenerateResourceMSBuildRuntime Condition=" '$(GenerateResourceMSBuildRuntime)' == '' ">CurrentRuntime</GenerateResourceMSBuildRuntime>
   </PropertyGroup>
 
-  <!-- Workaround: https://github.com/microsoft/msbuild/issues/4948 -->
-  <PropertyGroup>
-    <ImportWinFXTargets>false</ImportWinFXTargets>
-  </PropertyGroup>
-
   <Import Project="Microsoft.NET.Sdk.Common.targets" />
 
   <ImportGroup>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -23,6 +23,11 @@ Copyright (c) .NET Foundation. All rights reserved.
     <GenerateResourceMSBuildRuntime Condition=" '$(GenerateResourceMSBuildRuntime)' == '' ">CurrentRuntime</GenerateResourceMSBuildRuntime>
   </PropertyGroup>
 
+  <!-- Workaround: https://github.com/microsoft/msbuild/issues/4948 -->
+  <PropertyGroup>
+    <ImportWinFXTargets>false</ImportWinFXTargets>
+  </PropertyGroup>
+
   <Import Project="Microsoft.NET.Sdk.Common.targets" />
 
   <ImportGroup>


### PR DESCRIPTION
Part 2 fix to https://github.com/microsoft/msbuild/issues/4948

Part 1 is here: https://github.com/microsoft/msbuild/pull/5200

Prevents sdk style projects from importing the .net framework winfx targets.