### PR TITLE
[Port from 3.1.3] Updating ComputeFilesCopiedToPublishDir to work during design time builds

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -947,7 +947,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <ItemGroup>
       <ResolvedFileToPublish Remove="@(_FilesToBundle)"/>
-      <!-- ResolvedFileToPublish shouldn't include the output; the single-file bundle is written directly to the publish directory -->
+      <!-- ResolvedFileToPublish shouldn't include PublishedSingleFilePath, since the single-file bundle is written directly to the publish directory -->
     </ItemGroup>
 
   </Target>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -945,6 +945,11 @@ Copyright (c) .NET Foundation. All rights reserved.
       <PublishedSingleFilePath>$(PublishDir)$(PublishedSingleFileName)</PublishedSingleFilePath>
     </PropertyGroup>
 
+    <ItemGroup>
+      <ResolvedFileToPublish Remove="@(_FilesToBundle)"/>
+      <!-- ResolvedFileToPublish shouldn't include the output; the single-file bundle is written directly to the publish directory -->
+    </ItemGroup>
+
   </Target>
 
   <UsingTask TaskName="GenerateBundle" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
@@ -959,12 +964,6 @@ Copyright (c) .NET Foundation. All rights reserved.
                     IncludeSymbols="$(IncludeSymbolsInSingleFile)"
                     OutputDir="$(PublishDir)"
                     ShowDiagnosticOutput="false"/>
-
-    <ItemGroup>
-      <ResolvedFileToPublish Remove="@(_FilesToBundle)"/>
-      <!-- ResolvedFileToPublish shouldn't include the output; the single-file bundle is written directly to the publish directory -->
-    </ItemGroup>
-
 
   </Target>
 
@@ -1067,7 +1066,9 @@ Copyright (c) .NET Foundation. All rights reserved.
     Gathers all the files that were copied to the publish directory.  This is used by wapproj and is required for back compat.
     ============================================================
     -->
-  <Target Name="ComputeFilesCopiedToPublishDir" DependsOnTargets="ComputeFilesToPublish">
+  <Target Name="ComputeFilesCopiedToPublishDir"
+          DependsOnTargets="ComputeResolvedFilesToPublishList;
+                            _ComputeFilesToBundle">
     <ItemGroup>
       <FilesCopiedToPublishDir Include="@(ResolvedFileToPublish)"/>
       <FilesCopiedToPublishDir Include="$(PublishedSingleFilePath)" RelativePath="$(PublishedSingleFileName)" IsKeyOutput="true" Condition="'$(PublishSingleFile)' == 'true'"/>

--- a/src/Tests/Microsoft.NET.Publish.Tests/PublishItemsOutputGroupTests.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/PublishItemsOutputGroupTests.cs
@@ -158,30 +158,15 @@ namespace Microsoft.NET.Publish.Tests
 
             var buildCommand = new BuildCommand(Log, testAsset.Path, testProject.Name);
             buildCommand
-                .Execute("/p:RuntimeIdentifier=win-x86;DesignTimeBuild=true;PublishSingleFile=true", "/t:PublishItemsOutputGroup")
-                .Should()
-                .Pass();
-        }
-
-        [CoreMSBuildAndWindowsOnlyFact]
-        public void GroupBuildDoesNotGeneratePublishFiles()
-        {
-            var testProject = this.SetupProject();
-            var testAsset = _testAssetsManager.CreateTestProject(testProject);
-
-            var restoreCommand = new RestoreCommand(Log, testAsset.Path, testProject.Name);
-            restoreCommand
-                .Execute()
+                .Execute("/p:RuntimeIdentifier=win-x86;DesignTimeBuild=true", "/t:PublishItemsOutputGroup")
                 .Should()
                 .Pass();
 
-            var buildCommand = new BuildCommand(Log, testAsset.Path, testProject.Name);
-
-            // Since this build tries to copies all the final publish artifacts without calling the publish target it should fail
-            buildCommand
-                .Execute("/p:RuntimeIdentifier=win-x86;DesignTimeBuild=true;PublishSingleFile=true", "/t:PublishItemsOutputGroup")
+            // Confirm we were able to build the output group without the publish actually happening
+            var publishDir = new DirectoryInfo(Path.Combine(buildCommand.GetOutputDirectory(testProject.TargetFrameworks).FullName, "win-x86", "publish"));
+            publishDir
                 .Should()
-                .Fail();
+                .NotExist();
         }
 
         private TestProject SetupProject(bool addCopyFilesTargets = true)

--- a/src/Tests/Microsoft.NET.Publish.Tests/PublishItemsOutputGroupTests.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/PublishItemsOutputGroupTests.cs
@@ -115,7 +115,7 @@ namespace Microsoft.NET.Publish.Tests
 
             var buildCommand = new BuildCommand(Log, testAsset.Path, testProject.Name);
             buildCommand
-                .Execute("/p:RuntimeIdentifier=win-x86;DesignTimeBuild=true;PublishSingleFile=true", "/t:PublishItemsOutputGroup")
+                .Execute("/p:RuntimeIdentifier=win-x86;DesignTimeBuild=true;PublishSingleFile=true", "/t:Publish;PublishItemsOutputGroup")
                 .Should()
                 .Pass();
 
@@ -144,7 +144,47 @@ namespace Microsoft.NET.Publish.Tests
             }
         }
 
-        private TestProject SetupProject()
+        [CoreMSBuildAndWindowsOnlyFact]
+        public void GroupBuildsWithoutPublish()
+        {
+            var testProject = this.SetupProject(addCopyFilesTargets: false);
+            var testAsset = _testAssetsManager.CreateTestProject(testProject);
+
+            var restoreCommand = new RestoreCommand(Log, testAsset.Path, testProject.Name);
+            restoreCommand
+                .Execute()
+                .Should()
+                .Pass();
+
+            var buildCommand = new BuildCommand(Log, testAsset.Path, testProject.Name);
+            buildCommand
+                .Execute("/p:RuntimeIdentifier=win-x86;DesignTimeBuild=true;PublishSingleFile=true", "/t:PublishItemsOutputGroup")
+                .Should()
+                .Pass();
+        }
+
+        [CoreMSBuildAndWindowsOnlyFact]
+        public void GroupBuildDoesNotGeneratePublishFiles()
+        {
+            var testProject = this.SetupProject();
+            var testAsset = _testAssetsManager.CreateTestProject(testProject);
+
+            var restoreCommand = new RestoreCommand(Log, testAsset.Path, testProject.Name);
+            restoreCommand
+                .Execute()
+                .Should()
+                .Pass();
+
+            var buildCommand = new BuildCommand(Log, testAsset.Path, testProject.Name);
+
+            // Since this build tries to copies all the final publish artifacts without calling the publish target it should fail
+            buildCommand
+                .Execute("/p:RuntimeIdentifier=win-x86;DesignTimeBuild=true;PublishSingleFile=true", "/t:PublishItemsOutputGroup")
+                .Should()
+                .Fail();
+        }
+
+        private TestProject SetupProject(bool addCopyFilesTargets = true)
         {
             var testProject = new TestProject()
             {
@@ -159,23 +199,26 @@ namespace Microsoft.NET.Publish.Tests
             //  Use a test-specific packages folder
             testProject.AdditionalProperties["RestorePackagesPath"] = @"$(MSBuildProjectDirectory)\..\pkg";
 
-            // Add a target that will dump the contents of the PublishItemsOutputGroup to
-            // a test directory after building.
-            testProject.CopyFilesTargets.Add(new CopyFilesTarget(
-                "CopyPublishItemsOutputGroup",
-                "PublishItemsOutputGroup",
-                "@(PublishItemsOutputGroupOutputs)",
-                null,
-                "$(MSBuildProjectDirectory)\\TestOutput"));
+            if (addCopyFilesTargets)
+            {
+                // Add a target that will dump the contents of the PublishItemsOutputGroup to
+                // a test directory after building.
+                testProject.CopyFilesTargets.Add(new CopyFilesTarget(
+                    "CopyPublishItemsOutputGroup",
+                    "PublishItemsOutputGroup",
+                    "@(PublishItemsOutputGroupOutputs)",
+                    null,
+                    "$(MSBuildProjectDirectory)\\TestOutput"));
 
-            // Add another target that will dump the members of PublishItemsOutputGroup that
-            // have property IsKeyOutput set to true to a different test directory.
-            testProject.CopyFilesTargets.Add(new CopyFilesTarget(
-                "CopyPublishKeyItemsOutputGroup",
-                "PublishItemsOutputGroup",
-                "@(PublishItemsOutputGroupOutputs)",
-                @"'%(PublishItemsOutputGroupOutputs.IsKeyOutput)' == 'True'",
-                "$(MSBuildProjectDirectory)\\TestOutput_Key"));
+                // Add another target that will dump the members of PublishItemsOutputGroup that
+                // have property IsKeyOutput set to true to a different test directory.
+                testProject.CopyFilesTargets.Add(new CopyFilesTarget(
+                    "CopyPublishKeyItemsOutputGroup",
+                    "PublishItemsOutputGroup",
+                    "@(PublishItemsOutputGroupOutputs)",
+                    @"'%(PublishItemsOutputGroupOutputs.IsKeyOutput)' == 'True'",
+                    "$(MSBuildProjectDirectory)\\TestOutput_Key"));
+            }
 
             return testProject;
         }


### PR DESCRIPTION
Manually porting this change since I knew there would be merge conflicts: https://github.com/dotnet/sdk/pull/10907

Fixing a regression caused by my previous change: #10600

That change incorrectly made PublishItemsOutputGroup depend on the targets that actually copy build artifacts instead of the ones that just compute their paths. Since this output group is frequently used during design time builds this caused failures in the case where the build artifacts don't exist yet.

Also adding tests that explicitly add the requirement that this output group should be able to build without the existence of all the publishing artifacts.