### PR TITLE
Updating FilesCopiedToPublishDir output group to remove deps.json file, plus some test changes

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -1072,6 +1072,9 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ItemGroup>
       <FilesCopiedToPublishDir Include="@(ResolvedFileToPublish)"/>
       <FilesCopiedToPublishDir Include="$(PublishedSingleFilePath)" RelativePath="$(PublishedSingleFileName)" IsKeyOutput="true" Condition="'$(PublishSingleFile)' == 'true'"/>
+
+      <!-- Wapproj handles adding the correct deps.json file, so remove it here to avoid duplicates. -->
+      <FilesCopiedToPublishDir Remove="@(FilesCopiedToPublishDir)" Condition="'%(FilesCopiedToPublishDir.Filename)%(FilesCopiedToPublishDir.Extension)' == '$(ProjectDepsFileName)'"/>
     </ItemGroup>
   </Target>
 
@@ -1086,15 +1089,21 @@ Copyright (c) .NET Foundation. All rights reserved.
     <PublishItemsOutputGroupDependsOn>
       $(PublishItemsOutputGroupDependsOn);
       ResolveReferences;
-      ComputeFilesCopiedToPublishDir;
+      ComputeResolvedFilesToPublishList;
+      _ComputeFilesToBundle;
     </PublishItemsOutputGroupDependsOn>
   </PropertyGroup>
 
   <Target Name="PublishItemsOutputGroup" DependsOnTargets="$(PublishItemsOutputGroupDependsOn)" Returns="@(PublishItemsOutputGroupOutputs)">
     <ItemGroup>
-      <PublishItemsOutputGroupOutputs Include="@(FilesCopiedToPublishDir->'%(FullPath)')"
-                                      TargetPath="%(FilesCopiedToPublishDir.RelativePath)"
-                                      IsKeyOutput="%(FilesCopiedToPublishDir.IsKeyOutput)"
+      <PublishItemsOutputGroupOutputs Include="@(ResolvedFileToPublish->'%(FullPath)')"
+                                      TargetPath="%(ResolvedFileToPublish.RelativePath)"
+                                      IsKeyOutput="%(ResolvedFileToPublish.IsKeyOutput)"
+                                      OutputGroup="PublishItemsOutputGroup" />
+      <PublishItemsOutputGroupOutputs Include="$(PublishedSingleFilePath)"
+                                      TargetPath="$(PublishedSingleFileName)"
+                                      IsKeyOutput="true"
+                                      Condition="'$(PublishSingleFile)' == 'true'"
                                       OutputGroup="PublishItemsOutputGroup" />
     </ItemGroup>
   </Target>

--- a/src/Tests/Microsoft.NET.Publish.Tests/FilesCopiedToPublishDirTests.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/FilesCopiedToPublishDirTests.cs
@@ -27,25 +27,11 @@ namespace Microsoft.NET.Publish.Tests
             "WindowsBase.dll",
         };
 
-        [Fact]
-        public void WithRid()
-        {
-            this.RunFilesCopiedToPublishDirTest(specifyRid: true, singleFile: false);
-        }
-
-        [Fact]
-        public void NoRid()
-        {
-            this.RunFilesCopiedToPublishDirTest(specifyRid: false, singleFile: false);
-        }
-
-        [Fact]
-        public void SingleFile()
-        {
-            this.RunFilesCopiedToPublishDirTest(specifyRid: true, singleFile: true);
-        }
-
-        private void RunFilesCopiedToPublishDirTest(bool specifyRid, bool singleFile)
+        [Theory]
+        [InlineData(true, false)]
+        [InlineData(true, true)]
+        [InlineData(false, false)]
+        public void RunFilesCopiedToPublishDirTest(bool specifyRid, bool singleFile)
         {
             var testProject = new TestProject()
             {

--- a/src/Tests/Microsoft.NET.Publish.Tests/FilesCopiedToPublishDirTests.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/FilesCopiedToPublishDirTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using FluentAssertions;
+using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.PlatformAbstractions;
 using Microsoft.NET.TestFramework;
 using Microsoft.NET.TestFramework.Assertions;
@@ -102,7 +103,8 @@ namespace Microsoft.NET.Publish.Tests
             // Check for the main exe
             if (RuntimeEnvironment.OperatingSystemPlatform != Platform.Darwin)
             {
-                items.Should().ContainSingle(i => i.RelativePath.Equals($"{testProject.Name}.exe", StringComparison.OrdinalIgnoreCase));
+                string exeSuffix = specifyRid ? ".exe" : Constants.ExeSuffix;
+                items.Should().ContainSingle(i => i.RelativePath.Equals($"{testProject.Name}{exeSuffix}", StringComparison.OrdinalIgnoreCase));
             }
 
             // Framework assemblies should be there if we specified and rid and this isn't in the single file case

--- a/src/Tests/Microsoft.NET.Publish.Tests/FilesCopiedToPublishDirTests.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/FilesCopiedToPublishDirTests.cs
@@ -93,6 +93,12 @@ namespace Microsoft.NET.Publish.Tests
                             RelativePath = item.metadata["RelativePath"]
                         };
 
+            Log.WriteLine("FilesCopiedToPublishDir contains '{0}' items:", items.Count());
+            foreach (var item in items)
+            {
+                Log.WriteLine("    '{0}': RelativePath = '{1}'", item.Identity, item.RelativePath);
+            }
+
             // Check for the main exe
             if (RuntimeEnvironment.OperatingSystemPlatform != Platform.Darwin)
             {

--- a/src/Tests/Microsoft.NET.Publish.Tests/FilesCopiedToPublishDirTests.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/FilesCopiedToPublishDirTests.cs
@@ -1,0 +1,116 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using FluentAssertions;
+using Microsoft.DotNet.PlatformAbstractions;
+using Microsoft.NET.TestFramework;
+using Microsoft.NET.TestFramework.Assertions;
+using Microsoft.NET.TestFramework.Commands;
+using Microsoft.NET.TestFramework.ProjectConstruction;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.NET.Publish.Tests
+{
+    public class FilesCopiedToPublishDirTests : SdkTest
+    {
+        public FilesCopiedToPublishDirTests(ITestOutputHelper log) : base(log)
+        {
+        }
+
+        private readonly static List<string> FrameworkAssemblies = new List<string>()
+        {
+            "api-ms-win-core-console-l1-1-0.dll",
+            "System.Runtime.dll",
+            "WindowsBase.dll",
+        };
+
+        [Fact]
+        public void WithRid()
+        {
+            this.RunFilesCopiedToPublishDirTest(specifyRid: true, singleFile: false);
+        }
+
+        [Fact]
+        public void NoRid()
+        {
+            this.RunFilesCopiedToPublishDirTest(specifyRid: false, singleFile: false);
+        }
+
+        [Fact]
+        public void SingleFile()
+        {
+            this.RunFilesCopiedToPublishDirTest(specifyRid: true, singleFile: true);
+        }
+
+        private void RunFilesCopiedToPublishDirTest(bool specifyRid, bool singleFile)
+        {
+            var testProject = new TestProject()
+            {
+                Name = "TestFilesCopiedToPublishDir",
+                TargetFrameworks = "netcoreapp3.0",
+                IsSdkProject = true,
+                IsExe = true
+            };
+
+            testProject.AdditionalProperties["RuntimeIdentifiers"] = "win-x86";
+            testProject.AdditionalProperties["RestorePackagesPath"] = @"$(MSBuildProjectDirectory)\..\pkg";
+            if (specifyRid)
+            {
+                testProject.AdditionalProperties["RuntimeIdentifier"] = "win-x86";
+            }
+
+            if (singleFile)
+            {
+                testProject.AdditionalProperties["PublishSingleFile"] = "true";
+            }
+
+            var testAsset = _testAssetsManager.CreateTestProject(testProject);
+
+            var restoreCommand = new RestoreCommand(Log, testAsset.Path, testProject.Name);
+            restoreCommand
+                .Execute()
+                .Should()
+                .Pass();
+
+            var command = new GetValuesCommand(
+                Log,
+                Path.Combine(testAsset.Path, testProject.Name),
+                testProject.TargetFrameworks,
+                "FilesCopiedToPublishDir",
+                GetValuesCommand.ValueType.Item)
+            {
+                DependsOnTargets = "ComputeFilesCopiedToPublishDir",
+                MetadataNames = { "RelativePath", "IsKeyOutput" },
+            };
+
+            command.Execute().Should().Pass();
+            var items = from item in command.GetValuesWithMetadata()
+                        select new
+                        {
+                            Identity = item.value,
+                            RelativePath = item.metadata["RelativePath"]
+                        };
+
+            // Check for the main exe
+            if (RuntimeEnvironment.OperatingSystemPlatform != Platform.Darwin)
+            {
+                items.Should().ContainSingle(i => i.RelativePath.Equals($"{testProject.Name}.exe", StringComparison.OrdinalIgnoreCase));
+            }
+
+            // Framework assemblies should be there if we specified and rid and this isn't in the single file case
+            if (specifyRid && !singleFile)
+            {
+                FrameworkAssemblies.ForEach(fa => items.Should().ContainSingle(i => i.RelativePath.Equals(fa, StringComparison.OrdinalIgnoreCase)));
+            }
+            else
+            {
+                FrameworkAssemblies.ForEach(fa => items.Should().NotContain(i => i.RelativePath.Equals(fa, StringComparison.OrdinalIgnoreCase)));
+            }
+
+            // FilesCopiedToPublishDir should never contain the deps.json file 
+            items.Should().NotContain(i => i.RelativePath.Equals($"{testProject.Name}.deps.json", StringComparison.OrdinalIgnoreCase));
+        }
+    }
+}

--- a/src/Tests/Microsoft.NET.Publish.Tests/PublishItemsOutputGroupTests.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/PublishItemsOutputGroupTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using FluentAssertions;
+using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.PlatformAbstractions;
 using Microsoft.NET.TestFramework;
 using Microsoft.NET.TestFramework.Assertions;
@@ -109,10 +110,11 @@ namespace Microsoft.NET.Publish.Tests
             if (RuntimeEnvironment.OperatingSystemPlatform != Platform.Darwin)
             {
                 // Check that there's only one key item, and it's the exe
+                string exeSuffix = specifyRid ? ".exe" : Constants.ExeSuffix;
                 items.
                     Where(i => i.IsKeyOutput.Equals("true", StringComparison.OrdinalIgnoreCase)).
                     Should().
-                    ContainSingle(i => i.TargetPath.Equals($"{testProject.Name}.exe", StringComparison.OrdinalIgnoreCase));
+                    ContainSingle(i => i.TargetPath.Equals($"{testProject.Name}{exeSuffix}", StringComparison.OrdinalIgnoreCase));
             }
 
             // Framework assemblies should be there if we specified and rid and this isn't in the single file case

--- a/src/Tests/Microsoft.NET.Publish.Tests/PublishItemsOutputGroupTests.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/PublishItemsOutputGroupTests.cs
@@ -27,50 +27,11 @@ namespace Microsoft.NET.Publish.Tests
             "WindowsBase.dll",
         };
 
-        [Fact]
-        public void WithRid()
-        {
-            this.RunPublishItemsOutputGroupTest(specifyRid: true, singleFile: false);
-        }
-
-        [Fact]
-        public void NoRid()
-        {
-            this.RunPublishItemsOutputGroupTest(specifyRid: false, singleFile: false);
-        }
-
-        [Fact]
-        public void SingleFile()
-        {
-            this.RunPublishItemsOutputGroupTest(specifyRid: true, singleFile: true);
-        }
-
-        [Fact]
-        public void GroupBuildsWithoutPublish()
-        {
-            var testProject = this.SetupProject();
-            var testAsset = _testAssetsManager.CreateTestProject(testProject);
-
-            var restoreCommand = new RestoreCommand(Log, testAsset.Path, testProject.Name);
-            restoreCommand
-                .Execute()
-                .Should()
-                .Pass();
-
-            var buildCommand = new BuildCommand(Log, testAsset.Path, testProject.Name);
-            buildCommand
-                .Execute("/p:RuntimeIdentifier=win-x86;DesignTimeBuild=true", "/t:PublishItemsOutputGroup")
-                .Should()
-                .Pass();
-
-            // Confirm we were able to build the output group without the publish actually happening
-            var publishDir = new DirectoryInfo(Path.Combine(buildCommand.GetOutputDirectory(testProject.TargetFrameworks).FullName, "win-x86", "publish"));
-            publishDir
-                .Should()
-                .NotExist();
-        }
-
-        private void RunPublishItemsOutputGroupTest(bool specifyRid, bool singleFile)
+        [Theory]
+        [InlineData(true, false)]
+        [InlineData(true, true)]
+        [InlineData(false, false)]
+        public void RunPublishItemsOutputGroupTest(bool specifyRid, bool singleFile)
         {
             var testProject = this.SetupProject(specifyRid, singleFile);
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
@@ -132,6 +93,31 @@ namespace Microsoft.NET.Publish.Tests
             {
                 items.Should().ContainSingle(i => i.TargetPath.Equals($"{testProject.Name}.deps.json", StringComparison.OrdinalIgnoreCase));
             }
+        }
+
+        [Fact]
+        public void GroupBuildsWithoutPublish()
+        {
+            var testProject = this.SetupProject();
+            var testAsset = _testAssetsManager.CreateTestProject(testProject);
+
+            var restoreCommand = new RestoreCommand(Log, testAsset.Path, testProject.Name);
+            restoreCommand
+                .Execute()
+                .Should()
+                .Pass();
+
+            var buildCommand = new BuildCommand(Log, testAsset.Path, testProject.Name);
+            buildCommand
+                .Execute("/p:RuntimeIdentifier=win-x86;DesignTimeBuild=true", "/t:PublishItemsOutputGroup")
+                .Should()
+                .Pass();
+
+            // Confirm we were able to build the output group without the publish actually happening
+            var publishDir = new DirectoryInfo(Path.Combine(buildCommand.GetOutputDirectory(testProject.TargetFrameworks).FullName, "win-x86", "publish"));
+            publishDir
+                .Should()
+                .NotExist();
         }
 
         private TestProject SetupProject(bool specifyRid = true, bool singleFile = false)

--- a/src/Tests/Microsoft.NET.Publish.Tests/PublishItemsOutputGroupTests.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/PublishItemsOutputGroupTests.cs
@@ -100,6 +100,12 @@ namespace Microsoft.NET.Publish.Tests
                             IsKeyOutput = item.metadata["IsKeyOutput"]
                         };
 
+            Log.WriteLine("PublishItemsOutputGroup contains '{0}' items:", items.Count());
+            foreach (var item in items)
+            {
+                Log.WriteLine("    '{0}': TargetPath = '{1}', IsKeyOutput = '{2}'", item.Identity, item.TargetPath, item.IsKeyOutput);
+            }
+
             if (RuntimeEnvironment.OperatingSystemPlatform != Platform.Darwin)
             {
                 // Check that there's only one key item, and it's the exe


### PR DESCRIPTION
Starting in .NET 5.0 the ResolvedFileToPublish item group now contains the deps.json file.  This is a problem for wapproj scenarios, where a custom deps.json file is generally used.  So I'm explicitly removing the deps.json file when constructing the FilesCopiedToPublishDir item group if it exists.

Since PublishItemsOutputGroup still needs the deps.json file I'm making it no longer use FilesCopiedToPublishDir and instead use ResolvedFileToPublish directly.

Also making a few test changes:
 - Refactoring PublishItemsOutputGroupTests to use GetValuesCommand instead of a test target to copy files
 - Adding new set of tests for FilesCopiedToPublishDir

This will also resolve test issue https://github.com/dotnet/sdk/issues/10610, since we'll no longer be using the CopyFiles target that was sometimes failing on Ubuntu.