### PR TITLE
Fix renaming issue with copying ComReferences during publishing.

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -446,7 +446,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
       <!-- Copy generated COM References. -->
       <ResolvedFileToPublish Include="@(ReferenceComWrappersToCopyLocal)">
-        <RelativePath>@(ReferenceComWrappersToCopyLocal->'%(Filename)%(Extension)')</RelativePath>
+        <RelativePath>%(Filename)%(Extension)</RelativePath>
         <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
       </ResolvedFileToPublish>
 

--- a/src/Tests/Microsoft.NET.Build.Tests/COMReferenceTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/COMReferenceTests.cs
@@ -19,59 +19,43 @@ namespace Microsoft.NET.Build.Tests
         {
         }
 
-        [FullMSBuildOnlyTheory(Skip ="Too much dependency on build machine state.")]
+        [FullMSBuildOnlyTheory()]
         [InlineData(true)]
         [InlineData(false)]
         public void COMReferenceBuildsAndRuns(bool embedInteropTypes)
         {
             var targetFramework = "netcoreapp3.0";
 
-
             var testProject = new TestProject
             {
-                Name = "UseMediaPlayer",
+                Name = "UseComReferences",
                 IsSdkProject = true,
                 TargetFrameworks = targetFramework,
                 IsExe = true,
                 SourceFiles =
                     {
                         ["Program.cs"] = @"
-                            using MediaPlayer;
                             class Program
                             {
                                 static void Main(string[] args)
                                 {
-                                    var mediaPlayer = (IMediaPlayer2)new MediaPlayerClass();
+                                    System.Console.WriteLine(typeof(VSLangProj.VSProject));
                                 }
                             }
                         ",
                 }
             };
 
-            if (embedInteropTypes)
-            {
-                testProject.SourceFiles.Add("MediaPlayerClass.cs", @"
-                    using System.Runtime.InteropServices;
-                    namespace MediaPlayer
-                    {
-                        [ComImport]
-                        [Guid(""22D6F312-B0F6-11D0-94AB-0080C74C7E95"")]
-                        class MediaPlayerClass { }
-                    }
-                ");
-            }
-
             var reference = new XElement("ItemGroup",
                 new XElement("COMReference",
-                    new XAttribute("Include", "MediaPlayer.dll"),
-                    new XElement("Guid", "22d6f304-b0f6-11d0-94ab-0080c74c7e95"),
-                    new XElement("VersionMajor", "1"),
+                    new XAttribute("Include", "VSLangProj.dll"),
+                    new XElement("Guid", "49a1950e-3e35-4595-8cb9-920c64c44d67"),
+                    new XElement("VersionMajor", "7"),
                     new XElement("VersionMinor", "0"),
                     new XElement("WrapperTool", "tlbimp"),
                     new XElement("Lcid", "0"),
                     new XElement("Isolated", "false"),
                     new XElement("EmbedInteropTypes", embedInteropTypes)));
-
 
             var testAsset = _testAssetsManager
                 .CreateTestProject(testProject, identifier: embedInteropTypes.ToString())
@@ -81,7 +65,7 @@ namespace Microsoft.NET.Build.Tests
             buildCommand.Execute().Should().Pass();
             
             var outputDirectory = buildCommand.GetOutputDirectory(targetFramework);
-            var runCommand = new RunExeCommand(Log, outputDirectory.File("UseMediaPlayer.exe").FullName);
+            var runCommand = new RunExeCommand(Log, outputDirectory.File("UseComReferences.exe").FullName);
             runCommand.Execute().Should().Pass();
         }
 
@@ -89,7 +73,6 @@ namespace Microsoft.NET.Build.Tests
         public void COMReferenceProperlyPublish()
         {
             var targetFramework = "netcoreapp3.0";
-
 
             var testProject = new TestProject
             {
@@ -110,24 +93,24 @@ namespace Microsoft.NET.Build.Tests
                 }
             };
 
-            var vslangProj80ComRef = "VSLangProj80.dll";
+            var vslangProj70ComRef = "VSLangProj.dll";
             var reference1 = new XElement("ItemGroup",
                 new XElement("COMReference",
-                    new XAttribute("Include", vslangProj80ComRef),
-                    new XElement("Guid", "307953c0-7973-490a-a4a7-25999e023be8"),
-                    new XElement("VersionMajor", "8"),
+                    new XAttribute("Include", vslangProj70ComRef),
+                    new XElement("Guid", "49a1950e-3e35-4595-8cb9-920c64c44d67"),
+                    new XElement("VersionMajor", "7"),
                     new XElement("VersionMinor", "0"),
                     new XElement("WrapperTool", "tlbimp"),
                     new XElement("Lcid", "0"),
                     new XElement("Isolated", "false"),
                     new XElement("EmbedInteropTypes", "false")));
 
-            var vslangProj90ComRef = "VSLangProj90.dll";
+            var vslangProj80ComRef = "VSLangProj80.dll";
             var reference2 = new XElement("ItemGroup",
                 new XElement("COMReference",
-                    new XAttribute("Include", vslangProj90ComRef),
-                    new XElement("Guid", "dcbf68c6-da4b-44f5-b9e0-1563ec000392"),
-                    new XElement("VersionMajor", "9"),
+                    new XAttribute("Include", vslangProj80ComRef),
+                    new XElement("Guid", "307953c0-7973-490a-a4a7-25999e023be8"),
+                    new XElement("VersionMajor", "8"),
                     new XElement("VersionMinor", "0"),
                     new XElement("WrapperTool", "tlbimp"),
                     new XElement("Lcid", "0"),
@@ -144,8 +127,8 @@ namespace Microsoft.NET.Build.Tests
             var outputDirectory = buildCommand.GetOutputDirectory(targetFramework);
 
             // COM References by default adds the 'Interop.' prefix.
+            Assert.True(outputDirectory.File($"Interop.{vslangProj70ComRef}").Exists);
             Assert.True(outputDirectory.File($"Interop.{vslangProj80ComRef}").Exists);
-            Assert.True(outputDirectory.File($"Interop.{vslangProj90ComRef}").Exists);
 
             var publishCommand = new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
             publishCommand.Execute().Should().Pass();
@@ -153,8 +136,8 @@ namespace Microsoft.NET.Build.Tests
             outputDirectory = publishCommand.GetOutputDirectory(targetFramework);
 
             // COM References by default adds the 'Interop.' prefix.
+            Assert.True(outputDirectory.File($"Interop.{vslangProj70ComRef}").Exists);
             Assert.True(outputDirectory.File($"Interop.{vslangProj80ComRef}").Exists);
-            Assert.True(outputDirectory.File($"Interop.{vslangProj90ComRef}").Exists);
         }
     }
 }

--- a/src/Tests/Microsoft.NET.Build.Tests/COMReferenceTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/COMReferenceTests.cs
@@ -85,7 +85,7 @@ namespace Microsoft.NET.Build.Tests
             runCommand.Execute().Should().Pass();
         }
 
-        [FullMSBuildOnlyFact(Skip ="Too much dependency on build machine state.")]
+        [FullMSBuildOnlyFact]
         public void COMReferenceProperlyPublish()
         {
             var targetFramework = "netcoreapp3.0";
@@ -100,45 +100,34 @@ namespace Microsoft.NET.Build.Tests
                 SourceFiles =
                     {
                         ["Program.cs"] = @"
-                            using MediaPlayer;
                             class Program
                             {
                                 static void Main(string[] args)
                                 {
-                                    var mediaPlayer = (IMediaPlayer2)new MediaPlayerClass();
                                 }
-                            }
-                        ",
-                        ["MediaPlayerClass.cs"] = @"
-                            using System.Runtime.InteropServices;
-                            namespace MediaPlayer
-                            {
-                                [ComImport]
-                                [Guid(""22D6F312-B0F6-11D0-94AB-0080C74C7E95"")]
-                                class MediaPlayerClass { }
                             }
                         "
                 }
             };
 
-            var mediaPlayerComRef = "MediaPlayer.dll";
+            var vslangProj80ComRef = "VSLangProj80.dll";
             var reference1 = new XElement("ItemGroup",
                 new XElement("COMReference",
-                    new XAttribute("Include", mediaPlayerComRef),
-                    new XElement("Guid", "22d6f304-b0f6-11d0-94ab-0080c74c7e95"),
-                    new XElement("VersionMajor", "1"),
+                    new XAttribute("Include", vslangProj80ComRef),
+                    new XElement("Guid", "307953c0-7973-490a-a4a7-25999e023be8"),
+                    new XElement("VersionMajor", "8"),
                     new XElement("VersionMinor", "0"),
                     new XElement("WrapperTool", "tlbimp"),
                     new XElement("Lcid", "0"),
                     new XElement("Isolated", "false"),
                     new XElement("EmbedInteropTypes", "false")));
 
-            var vslangProj80ComRef = "VSLangProj80.dll";
+            var vslangProj90ComRef = "VSLangProj90.dll";
             var reference2 = new XElement("ItemGroup",
                 new XElement("COMReference",
-                    new XAttribute("Include", vslangProj80ComRef),
-                    new XElement("Guid", "307953c0-7973-490a-a4a7-25999e023be8"),
-                    new XElement("VersionMajor", "8"),
+                    new XAttribute("Include", vslangProj90ComRef),
+                    new XElement("Guid", "dcbf68c6-da4b-44f5-b9e0-1563ec000392"),
+                    new XElement("VersionMajor", "9"),
                     new XElement("VersionMinor", "0"),
                     new XElement("WrapperTool", "tlbimp"),
                     new XElement("Lcid", "0"),
@@ -155,8 +144,8 @@ namespace Microsoft.NET.Build.Tests
             var outputDirectory = buildCommand.GetOutputDirectory(targetFramework);
 
             // COM References by default adds the 'Interop.' prefix.
-            Assert.True(outputDirectory.File($"Interop.{mediaPlayerComRef}").Exists);
             Assert.True(outputDirectory.File($"Interop.{vslangProj80ComRef}").Exists);
+            Assert.True(outputDirectory.File($"Interop.{vslangProj90ComRef}").Exists);
 
             var publishCommand = new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
             publishCommand.Execute().Should().Pass();
@@ -164,8 +153,8 @@ namespace Microsoft.NET.Build.Tests
             outputDirectory = publishCommand.GetOutputDirectory(targetFramework);
 
             // COM References by default adds the 'Interop.' prefix.
-            Assert.True(outputDirectory.File($"Interop.{mediaPlayerComRef}").Exists);
             Assert.True(outputDirectory.File($"Interop.{vslangProj80ComRef}").Exists);
+            Assert.True(outputDirectory.File($"Interop.{vslangProj90ComRef}").Exists);
         }
     }
 }


### PR DESCRIPTION
Fixes #10908 

~~This fix is missing tests for this scenario since it requires and only runs using the .NET Framework version of MSBuild. The current [`COMReference` tests](https://github.com/dotnet/sdk/blob/master/src/Tests/Microsoft.NET.Build.Tests/COMReferenceTests.cs) appear to have a relatively simply path forward, but this will also require understanding the build machines in order to select two COM servers that can be used for validation.~~

Added test relying on a Visual Studio published COM server.

/cc @dsplaisted 