### PR TITLE
Prevent environment path error to DOTNET_MSBUILD_SDK_RESOLVER_CLI_DIR

### DIFF
--- a/src/Microsoft.DotNet.MSBuildSdkResolver/MSBuildSdkResolver.cs
+++ b/src/Microsoft.DotNet.MSBuildSdkResolver/MSBuildSdkResolver.cs
@@ -313,7 +313,15 @@ namespace Microsoft.DotNet.MSBuildSdkResolver
             string environmentOverride = _getEnvironmentVariable("DOTNET_MSBUILD_SDK_RESOLVER_CLI_DIR");
             if (environmentOverride != null)
             {
-                return environmentOverride;
+                try
+                {
+                    Path.GetDirectoryName(environmentOverride);
+                    return environmentOverride;
+                }
+                catch
+                {
+                    // Path is not valid
+                }
             }
 
             var environmentProvider = new EnvironmentProvider(_getEnvironmentVariable);


### PR DESCRIPTION
I recently has an error about a problem with this environment variable.

The solution that i found it's check that the path it's correct, but with this PR we can prevent that other person has the same issue.

[I documented completly the issue in Visual Studio Docs ](https://github.com/MicrosoftDocs/visualstudio-docs/issues/5082)