### PR TITLE
[release/3.1.3xx] Pin HostModel

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -15,7 +15,7 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>15f00efd583eab4372b2e9ca25bd80ace5b119ad</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.HostModel" Version="3.1.2">
+    <Dependency Name="Microsoft.NET.HostModel" Version="3.1.2" Pinned="true">
       <Uri>https://github.com/dotnet/core-setup</Uri>
       <Sha>916b5cba268e1e1e803243004f4276cf40b2dda8</Sha>
     </Dependency>


### PR DESCRIPTION
Pin the host model at 3.1.2. It is not required that we update HostModel except to test a new runtime in the SDK, or if breaking changes were made. When this host model does change. it requires that we pull a new stage0 SDK from dotnet/installer, which is a significant cost.