### PR TITLE
[WIP] dotnet-installer uses Tls 1.2

### DIFF
--- a/scripts/obtain/dotnet-install.ps1
+++ b/scripts/obtain/dotnet-install.ps1
@@ -118,6 +118,9 @@ if ($SharedRuntime -and (-not $Runtime)) {
 $VersionRegEx="/\d+\.\d+[^/]+/"
 $OverrideNonVersionedFiles = !$SkipNonVersionedFiles
 
+# Default Tls protocol for .NET Framework 4.5 does not allow for Tls1.2.
+[System.Net.ServicePointManager]::SecurityProtocol += [System.Net.SecurityProtocolType]::Tls12;
+
 function Say($str) {
     Write-Host "dotnet-install: $str"
 }

--- a/scripts/obtain/dotnet-install.ps1
+++ b/scripts/obtain/dotnet-install.ps1
@@ -119,7 +119,9 @@ $VersionRegEx="/\d+\.\d+[^/]+/"
 $OverrideNonVersionedFiles = !$SkipNonVersionedFiles
 
 # Default Tls protocol for .NET Framework 4.5 does not allow for Tls1.2.
-[System.Net.ServicePointManager]::SecurityProtocol += [System.Net.SecurityProtocolType]::Tls12;
+[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12;
+# Enable 1.3 for systems that have 1.2 disabled
+[System.Net.ServicePointManager]::SecurityProtocol += [System.Net.SecurityProtocolType]::Tls13;
 
 function Say($str) {
     Write-Host "dotnet-install: $str"


### PR DESCRIPTION
Install script was failing since download links can no longer be accessed with Tls1.1.
Explicitly adding Tls1.2 to SecurityProtocol to fix the issue.