### PR TITLE
Show warning if COM server is built with SelfContained=true

### DIFF
--- a/src/Tasks/Common/Resources/Strings.resx
+++ b/src/Tasks/Common/Resources/Strings.resx
@@ -612,4 +612,8 @@ The following are names of parameters or literal values and should not be transl
     <value>NETSDK1127: The targeting pack {0} is not installed. Please restore and try again.</value>
     <comment>{StrBegin="NETSDK1127: "}</comment>
   </data>
+  <data name="NoSupportComSelfContained" xml:space="preserve">
+    <value>NETSDK1128: COM hosting does not support self-contained deployments.</value>
+    <comment>{StrBegin="NETSDK1128: "}</comment>
+  </data>
 </root>

--- a/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
@@ -426,6 +426,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1082: Pro zadaný identifikátor RuntimeIdentifier {1} nebyl k dispozici žádný balíček modulu runtime {0}.</target>
         <note>{StrBegin="NETSDK1082: "}</note>
       </trans-unit>
+      <trans-unit id="NoSupportComSelfContained">
+        <source>NETSDK1128: COM hosting does not support self-contained deployments.</source>
+        <target state="new">NETSDK1128: COM hosting does not support self-contained deployments.</target>
+        <note>{StrBegin="NETSDK1128: "}</note>
+      </trans-unit>
       <trans-unit id="NoSupportCppEnableComHosting">
         <source>NETSDK1119: C++/CLI projects targeting .NET Core cannot use EnableComHosting=true.</source>
         <target state="translated">NETSDK1119: Projekty C++/CLI cílené na rozhraní .NET Core nemůžou používat EnableComHosting=true.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.de.xlf
@@ -426,6 +426,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1082: Für "{0}" stand für den angegebenen RuntimeIdentifier "{1}" kein Runtimepaket zur Verfügung.</target>
         <note>{StrBegin="NETSDK1082: "}</note>
       </trans-unit>
+      <trans-unit id="NoSupportComSelfContained">
+        <source>NETSDK1128: COM hosting does not support self-contained deployments.</source>
+        <target state="new">NETSDK1128: COM hosting does not support self-contained deployments.</target>
+        <note>{StrBegin="NETSDK1128: "}</note>
+      </trans-unit>
       <trans-unit id="NoSupportCppEnableComHosting">
         <source>NETSDK1119: C++/CLI projects targeting .NET Core cannot use EnableComHosting=true.</source>
         <target state="translated">NETSDK1119: C++-/CLI-Projekte für .NET Core können "EnableComHosting=true" nicht verwenden.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.es.xlf
@@ -426,6 +426,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1082: No había ningún paquete de tiempo de ejecución para {0} disponible para el valor de RuntimeIdentifier especificado "{1}".</target>
         <note>{StrBegin="NETSDK1082: "}</note>
       </trans-unit>
+      <trans-unit id="NoSupportComSelfContained">
+        <source>NETSDK1128: COM hosting does not support self-contained deployments.</source>
+        <target state="new">NETSDK1128: COM hosting does not support self-contained deployments.</target>
+        <note>{StrBegin="NETSDK1128: "}</note>
+      </trans-unit>
       <trans-unit id="NoSupportCppEnableComHosting">
         <source>NETSDK1119: C++/CLI projects targeting .NET Core cannot use EnableComHosting=true.</source>
         <target state="translated">NETSDK1119: Los proyectos de C++/CLI destinados a .NET Core no pueden usar EnableComHosting=true.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
@@ -426,6 +426,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1082: aucun pack d'exécution lié à {0} n'est disponible pour le RuntimeIdentifier spécifié '{1}'.</target>
         <note>{StrBegin="NETSDK1082: "}</note>
       </trans-unit>
+      <trans-unit id="NoSupportComSelfContained">
+        <source>NETSDK1128: COM hosting does not support self-contained deployments.</source>
+        <target state="new">NETSDK1128: COM hosting does not support self-contained deployments.</target>
+        <note>{StrBegin="NETSDK1128: "}</note>
+      </trans-unit>
       <trans-unit id="NoSupportCppEnableComHosting">
         <source>NETSDK1119: C++/CLI projects targeting .NET Core cannot use EnableComHosting=true.</source>
         <target state="translated">NETSDK1119: Les projets C++/CLI ciblant .NET Core ne peuvent pas utiliser EnableComHosting=true.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.it.xlf
@@ -426,6 +426,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1082: non è disponibile alcun pacchetto di runtime per {0} per l'elemento RuntimeIdentifier specificato '{1}'.</target>
         <note>{StrBegin="NETSDK1082: "}</note>
       </trans-unit>
+      <trans-unit id="NoSupportComSelfContained">
+        <source>NETSDK1128: COM hosting does not support self-contained deployments.</source>
+        <target state="new">NETSDK1128: COM hosting does not support self-contained deployments.</target>
+        <note>{StrBegin="NETSDK1128: "}</note>
+      </trans-unit>
       <trans-unit id="NoSupportCppEnableComHosting">
         <source>NETSDK1119: C++/CLI projects targeting .NET Core cannot use EnableComHosting=true.</source>
         <target state="translated">NETSDK1119: i progetti C++/CLI destinati a .NET Core non possono usare EnableComHosting=true.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
@@ -426,6 +426,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1082: 指定された RuntimeIdentifier '{1}' で利用できる {0} のランタイム パックがありませんでした。</target>
         <note>{StrBegin="NETSDK1082: "}</note>
       </trans-unit>
+      <trans-unit id="NoSupportComSelfContained">
+        <source>NETSDK1128: COM hosting does not support self-contained deployments.</source>
+        <target state="new">NETSDK1128: COM hosting does not support self-contained deployments.</target>
+        <note>{StrBegin="NETSDK1128: "}</note>
+      </trans-unit>
       <trans-unit id="NoSupportCppEnableComHosting">
         <source>NETSDK1119: C++/CLI projects targeting .NET Core cannot use EnableComHosting=true.</source>
         <target state="translated">NETSDK1119: .NET Core をターゲットとする C++/CLI プロジェクトでは EnableComHosting=true を使用できません。</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
@@ -426,6 +426,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1082: 지정된 RuntimeIdentifier '{1}'에 사용할 수 있는 {0}용 런타임 팩이 없습니다.</target>
         <note>{StrBegin="NETSDK1082: "}</note>
       </trans-unit>
+      <trans-unit id="NoSupportComSelfContained">
+        <source>NETSDK1128: COM hosting does not support self-contained deployments.</source>
+        <target state="new">NETSDK1128: COM hosting does not support self-contained deployments.</target>
+        <note>{StrBegin="NETSDK1128: "}</note>
+      </trans-unit>
       <trans-unit id="NoSupportCppEnableComHosting">
         <source>NETSDK1119: C++/CLI projects targeting .NET Core cannot use EnableComHosting=true.</source>
         <target state="translated">NETSDK1119: .NET Core를 대상으로 하는 C++/CLI 프로젝트는 EnableComHosting=true를 사용할 수 없습니다.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
@@ -426,6 +426,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1082: Brak dostępnego pakietu środowiska uruchomieniowego {0} dla określonego elementu RuntimeIdentifier „{1}”.</target>
         <note>{StrBegin="NETSDK1082: "}</note>
       </trans-unit>
+      <trans-unit id="NoSupportComSelfContained">
+        <source>NETSDK1128: COM hosting does not support self-contained deployments.</source>
+        <target state="new">NETSDK1128: COM hosting does not support self-contained deployments.</target>
+        <note>{StrBegin="NETSDK1128: "}</note>
+      </trans-unit>
       <trans-unit id="NoSupportCppEnableComHosting">
         <source>NETSDK1119: C++/CLI projects targeting .NET Core cannot use EnableComHosting=true.</source>
         <target state="translated">NETSDK1119: Projekty C++/CLI przeznaczone dla platformy .NET Core nie mogą używać elementu EnableComHosting=true.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
@@ -426,6 +426,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1082: não havia nenhum pacote de tempo de execução de {0} disponível para o RuntimeIdentifier especificado '{1}'.</target>
         <note>{StrBegin="NETSDK1082: "}</note>
       </trans-unit>
+      <trans-unit id="NoSupportComSelfContained">
+        <source>NETSDK1128: COM hosting does not support self-contained deployments.</source>
+        <target state="new">NETSDK1128: COM hosting does not support self-contained deployments.</target>
+        <note>{StrBegin="NETSDK1128: "}</note>
+      </trans-unit>
       <trans-unit id="NoSupportCppEnableComHosting">
         <source>NETSDK1119: C++/CLI projects targeting .NET Core cannot use EnableComHosting=true.</source>
         <target state="translated">NETSDK1119: os projetos C++/CLI direcionados ao .NET Core não podem usar EnableComHosting = true.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
@@ -426,6 +426,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1082: не было доступного пакета среды выполнения для {0} для указанного RuntimeIdentifier "{1}".</target>
         <note>{StrBegin="NETSDK1082: "}</note>
       </trans-unit>
+      <trans-unit id="NoSupportComSelfContained">
+        <source>NETSDK1128: COM hosting does not support self-contained deployments.</source>
+        <target state="new">NETSDK1128: COM hosting does not support self-contained deployments.</target>
+        <note>{StrBegin="NETSDK1128: "}</note>
+      </trans-unit>
       <trans-unit id="NoSupportCppEnableComHosting">
         <source>NETSDK1119: C++/CLI projects targeting .NET Core cannot use EnableComHosting=true.</source>
         <target state="translated">NETSDK1119: проекты C++/CLI для .NET Core не могут использовать EnableComHosting=true.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
@@ -426,6 +426,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1082: {0} için, belirtilen RuntimeIdentifier '{1}' için kullanılabilecek bir çalışma zamanı paketi yoktu.</target>
         <note>{StrBegin="NETSDK1082: "}</note>
       </trans-unit>
+      <trans-unit id="NoSupportComSelfContained">
+        <source>NETSDK1128: COM hosting does not support self-contained deployments.</source>
+        <target state="new">NETSDK1128: COM hosting does not support self-contained deployments.</target>
+        <note>{StrBegin="NETSDK1128: "}</note>
+      </trans-unit>
       <trans-unit id="NoSupportCppEnableComHosting">
         <source>NETSDK1119: C++/CLI projects targeting .NET Core cannot use EnableComHosting=true.</source>
         <target state="translated">NETSDK1119: .NET Core'u hedefleyen C++/CLI projeleri EnableComHosting=true kullanamaz.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
@@ -426,6 +426,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1082: {0} 没有运行时包可用于指定的 RuntimeIdentifier“{1}”。</target>
         <note>{StrBegin="NETSDK1082: "}</note>
       </trans-unit>
+      <trans-unit id="NoSupportComSelfContained">
+        <source>NETSDK1128: COM hosting does not support self-contained deployments.</source>
+        <target state="new">NETSDK1128: COM hosting does not support self-contained deployments.</target>
+        <note>{StrBegin="NETSDK1128: "}</note>
+      </trans-unit>
       <trans-unit id="NoSupportCppEnableComHosting">
         <source>NETSDK1119: C++/CLI projects targeting .NET Core cannot use EnableComHosting=true.</source>
         <target state="translated">NETSDK1119: 面向 .NET Core 的 C++/CLI 项目不能使用 EnableComHosting=true。</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
@@ -426,6 +426,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1082: 對指定的 RuntimeIdentifier '{1}'，無法使用任何 {0} 的執行階段套件。</target>
         <note>{StrBegin="NETSDK1082: "}</note>
       </trans-unit>
+      <trans-unit id="NoSupportComSelfContained">
+        <source>NETSDK1128: COM hosting does not support self-contained deployments.</source>
+        <target state="new">NETSDK1128: COM hosting does not support self-contained deployments.</target>
+        <note>{StrBegin="NETSDK1128: "}</note>
+      </trans-unit>
       <trans-unit id="NoSupportCppEnableComHosting">
         <source>NETSDK1119: C++/CLI projects targeting .NET Core cannot use EnableComHosting=true.</source>
         <target state="translated">NETSDK1119: 以 .NET Core 為目標的 C++/CLI 專案無法使用 EnableComHosting=true。</target>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets
@@ -162,6 +162,15 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   </Target>
 
+  <Target Name="_CheckForUnsupportedHostingUsage"
+          BeforeTargets="_CheckForInvalidConfigurationAndPlatform"
+          Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
+
+    <NETSdkWarning Condition="'$(SelfContained)' == 'true' and '$(EnableComHosting)' == 'true'"
+                   ResourceName="NoSupportComSelfContained" />
+
+  </Target>
+
   <Target Name="_CheckForMismatchingPlatform"
           BeforeTargets="_CheckForInvalidConfigurationAndPlatform"
           Condition="'$(RuntimeIdentifier)' != '' and '$(PlatformTarget)' != ''">

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAComServerLibrary.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAComServerLibrary.cs
@@ -117,6 +117,28 @@ namespace Microsoft.NET.Build.Tests
             });
         }
 
+        [WindowsOnlyFact]
+        public void It_warns_on_self_contained_build()
+        {
+            var testAsset = _testAssetsManager
+                .CopyTestAsset("ComServer")
+                .WithSource()
+                .WithProjectChanges(project =>
+                {
+                    var ns = project.Root.Name.Namespace;
+                    var propertyGroup = project.Root.Elements(ns + "PropertyGroup").First();
+                    propertyGroup.Add(new XElement("SelfContained", true));
+                });
+
+            var buildCommand = new BuildCommand(Log, testAsset.TestRoot);
+            buildCommand
+                .Execute()
+                .Should()
+                .Pass()
+                .And
+                .HaveStdOutContaining("NETSDK1128: ");;
+        }
+
         [PlatformSpecificFact(Platform.Linux, Platform.Darwin, Platform.FreeBSD)]
         public void It_fails_to_find_comhost_for_platforms_without_comhost()
         {

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAComServerLibrary.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAComServerLibrary.cs
@@ -136,7 +136,7 @@ namespace Microsoft.NET.Build.Tests
                 .Should()
                 .Pass()
                 .And
-                .HaveStdOutContaining("NETSDK1128: ");;
+                .HaveStdOutContaining("NETSDK1128: ");
         }
 
         [PlatformSpecificFact(Platform.Linux, Platform.Darwin, Platform.FreeBSD)]


### PR DESCRIPTION
Add a warning that COM hosting does not support self-contained.

Related: dotnet/runtime#870

/cc @AaronRobinsonMSFT @jkoritzinsky 