### PR TITLE
Enable content copying transitive in VS.

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -701,6 +701,15 @@ Copyright (c) .NET Foundation. All rights reserved.
     See comment on GetCopyToOutputDirectoryItems, from which this logic was taken.
     ============================================================
     -->
+
+  <!--
+    Workaround for https://github.com/microsoft/msbuild/issues/4923
+    and https://github.com/dotnet/project-system/issues/4665
+  -->
+  <PropertyGroup>
+    <MSBuildCopyContentTransitively>true</MSBuildCopyContentTransitively>
+  </PropertyGroup>
+
   <Target Name="GetCopyToPublishDirectoryItems"
           Returns="@(AllPublishItemsFullPathWithTargetPath)"
           KeepDuplicateOutputs=" '$(MSBuildDisableGetCopyToPublishDirectoryItemsOptimization)' == '' "


### PR DESCRIPTION
This is needed to fix the Fast up-to-date to check
CopyToOutputDirectory items from project references
https://github.com/dotnet/project-system/issues/4665

More details on MSBuildCopyContentTransitively in
https://github.com/microsoft/msbuild/pull/4865

Is there a way to create a dummy insertion to test it out first ? to check the performance test from AzDo