### PR TITLE
Update the readme with a pointer to the project docs and developer guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,6 @@ From that shell your SDK will be available in:
 
 ## How do I engage and contribute?
 
-We welcome you to try things out, [file issues](https://github.com/dotnet/sdk/issues), make feature requests and join us in design conversations.
+We welcome you to try things out, [file issues](https://github.com/dotnet/sdk/issues), make feature requests and join us in design conversations. Also be sure to check out our [project documentation](toolset/Documentation) and [Developer Guide](toolset/Documentation/project-docs/developer-guide.md).
 
 This project has adopted a code of conduct adapted from the [Contributor Covenant](http://contributor-covenant.org/) to clarify expected behavior in our community. This code of conduct has been [adopted by many other projects](http://contributor-covenant.org/adopters/). For more information see [Contributors Code of conduct](https://github.com/dotnet/home/blob/master/guidance/be-nice.md).


### PR DESCRIPTION
Fixes: https://github.com/dotnet/sdk/issues/10680

Adding a link to make the project documentation and developer guide more obvious.