### PR TITLE
Add MSBuild properties for common ILLink arguments

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ILLink.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ILLink.targets
@@ -83,8 +83,21 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ILLink AssemblyPaths="@(_ManagedAssembliesToLink)"
             ReferenceAssemblyPaths="@(ReferencePath)"
             RootAssemblyNames="@(TrimmerRootAssembly)"
+            DefaultAction="$(_TrimmerDefaultAction)"
+            LinkSymbols="$(_TrimmerLinkSymbols)"
+
+            BeforeFieldInit="$(_TrimmerBeforeFieldInit)"
+            OverrideRemoval="$(_TrimmerOverrideRemoval)"
+            UnreachableBodies="$(_TrimmerUnreachableBodies)"
+            ClearInitLocals="$(_TrimmerClearInitLocals)"
+            UnusedInterfaces="$(_TrimmerUnusedInterfaces)"
+            IPConstProp="$(_TrimmerIPConstProp)"
+            Sealer="$(_TrimmerSealer)"
+
+            CustomSteps="@(_TrimmerCustomSteps)"
             RootDescriptorFiles="@(TrimmerRootDescriptor)"
             OutputDirectory="$(IntermediateLinkDir)"
+            DumpDependencies="$(_TrimmerDumpDependencies)"
             ExtraArgs="$(_ExtraTrimmerArgs)"
             ToolExe="$(_DotNetHostFileName)"
             ToolPath="$(_DotNetHostDirectory)" />
@@ -110,7 +123,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <PropertyGroup>
       <_ExtraTrimmerArgs>--skip-unresolved true $(_ExtraTrimmerArgs)</_ExtraTrimmerArgs>
-      <_ExtraTrimmerArgs>-c copyused -u copyused $(_ExtraTrimmerArgs)</_ExtraTrimmerArgs>
+      <_TrimmerDefaultAction Condition=" '$(_TrimmerDefaultAction)' == '' ">copyused</_TrimmerDefaultAction>
     </PropertyGroup>
     <ItemGroup>
       <TrimmerRootAssembly Include="@(_ManagedAssembliesToLink)" Condition=" '%(_ManagedAssembliesToLink.IsTrimmable)' != 'true' " />

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToRunILLink.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToRunILLink.cs
@@ -146,7 +146,7 @@ namespace Microsoft.NET.Publish.Tests
             var projectName = "HelloWorld";
 
             var testProject = CreateTestProjectForILLinkTesting("net5.0", projectName);
-            var testAsset = _testAssetsManager.CreateTestProject(testProject);
+            var testAsset = _testAssetsManager.CreateTestProject(testProject, identifier: property);
 
             var publishCommand = new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
             publishCommand.Execute("/p:PublishTrimmed=true", $"/p:SelfContained=true", "/p:PublishTrimmed=true", $"/p:{property}=NonBool")
@@ -377,9 +377,9 @@ namespace Microsoft.NET.Publish.Tests
 
         static string unusedFrameworkAssembly = "System.IO";
 
-        private TestPackageReference GetPackageReference(TestProject project, string callingMethod)
+        private TestPackageReference GetPackageReference(TestProject project, string callingMethod, string identifier)
         {
-            var asset = _testAssetsManager.CreateTestProject(project, callingMethod);
+            var asset = _testAssetsManager.CreateTestProject(project, callingMethod: callingMethod, identifier: identifier);
             var pack = new PackCommand(Log, Path.Combine(asset.TestRoot, project.Name));
             pack.Execute().Should().Pass();
 
@@ -458,7 +458,8 @@ namespace Microsoft.NET.Publish.Tests
             string mainProjectName,
             string referenceProjectName = null,
             bool usePackageReference = true,
-            [CallerMemberName] string callingMethod = "")
+            [CallerMemberName] string callingMethod = "",
+            string referenceProjectIdentifier = "")
         {
             var testProject = new TestProject()
             {
@@ -504,7 +505,7 @@ public class ClassLib
 
             if (usePackageReference)
             {
-                var packageReference = GetPackageReference(referenceProject, callingMethod);
+                var packageReference = GetPackageReference(referenceProject, callingMethod, referenceProjectIdentifier);
                 testProject.PackageReferences.Add(packageReference);
                 testProject.AdditionalProperties.Add(
                     "RestoreAdditionalProjectSources",

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToRunILLink.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToRunILLink.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Xml.Linq;
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
+using System.Runtime.CompilerServices;
 using FluentAssertions;
 using Microsoft.DotNet.PlatformAbstractions;
 using Microsoft.Extensions.DependencyModel;
@@ -376,9 +377,9 @@ namespace Microsoft.NET.Publish.Tests
 
         static string unusedFrameworkAssembly = "System.IO";
 
-        private TestPackageReference GetPackageReference(TestProject project)
+        private TestPackageReference GetPackageReference(TestProject project, string callingMethod)
         {
-            var asset = _testAssetsManager.CreateTestProject(project, project.Name);
+            var asset = _testAssetsManager.CreateTestProject(project, callingMethod);
             var pack = new PackCommand(Log, Path.Combine(asset.TestRoot, project.Name));
             pack.Execute().Should().Pass();
 
@@ -452,7 +453,12 @@ namespace Microsoft.NET.Publish.Tests
                                                  new XElement("action"))));
         }
 
-        private TestProject CreateTestProjectForILLinkTesting(string targetFramework, string mainProjectName, string referenceProjectName, bool usePackageReference = true)
+        private TestProject CreateTestProjectForILLinkTesting(
+            string targetFramework,
+            string mainProjectName,
+            string referenceProjectName,
+            bool usePackageReference = true,
+            [CallerMemberName] string callingMethod = "")
         {
             var referenceProject = new TestProject()
             {
@@ -482,7 +488,7 @@ public class ClassLib
 
             if (usePackageReference)
             {
-                var packageReference = GetPackageReference(referenceProject);
+                var packageReference = GetPackageReference(referenceProject, callingMethod);
                 testProject.PackageReferences.Add(packageReference);
                 testProject.AdditionalProperties.Add(
                     "RestoreAdditionalProjectSources",

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToRunILLink.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToRunILLink.cs
@@ -143,9 +143,8 @@ namespace Microsoft.NET.Publish.Tests
         public void ILLink_error_on_nonboolean_optimization_flag(string property)
         {
             var projectName = "HelloWorld";
-            var referenceProjectName = "ClassLibForILLink";
 
-            var testProject = CreateTestProjectForILLinkTesting("net5.0", projectName, referenceProjectName);
+            var testProject = CreateTestProjectForILLinkTesting("net5.0", projectName);
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
             var publishCommand = new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
@@ -456,10 +455,32 @@ namespace Microsoft.NET.Publish.Tests
         private TestProject CreateTestProjectForILLinkTesting(
             string targetFramework,
             string mainProjectName,
-            string referenceProjectName,
+            string referenceProjectName = null,
             bool usePackageReference = true,
             [CallerMemberName] string callingMethod = "")
         {
+            var testProject = new TestProject()
+            {
+                Name = mainProjectName,
+                TargetFrameworks = targetFramework,
+                IsSdkProject = true,
+            };
+
+            testProject.SourceFiles[$"{mainProjectName}.cs"] = @"
+using System;
+public class Program
+{
+    public static void Main()
+    {
+        Console.WriteLine(""Hello world"");
+    }
+}
+";
+
+            if (referenceProjectName == null) {
+                return testProject;
+            }
+
             var referenceProject = new TestProject()
             {
                 Name = referenceProjectName,
@@ -479,12 +500,6 @@ public class ClassLib
     }
 }
 ";
-            var testProject = new TestProject()
-            {
-                Name = mainProjectName,
-                TargetFrameworks = targetFramework,
-                IsSdkProject = true,
-            };
 
             if (usePackageReference)
             {
@@ -499,16 +514,6 @@ public class ClassLib
                 testProject.ReferencedProjects.Add(referenceProject);
             }
 
-            testProject.SourceFiles[$"{mainProjectName}.cs"] = @"
-using System;
-public class Program
-{
-    public static void Main()
-    {
-        Console.WriteLine(""Hello world"");
-    }
-}
-";
 
             testProject.SourceFiles[$"{referenceProjectName}.xml"] = $@"
 <linker>

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToRunILLink.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToRunILLink.cs
@@ -132,7 +132,8 @@ namespace Microsoft.NET.Publish.Tests
             DoesImageHaveMethod(unusedDll, "UnusedMethodToRoot").Should().BeTrue();
         }
 
-        [Theory]
+        //  Core MSBuild only until VS build we use has NuGet changes for net5.0
+        [CoreMSBuildOnlyTheory]
         [InlineData("_TrimmerBeforeFieldInit")]
         [InlineData("_TrimmerOverrideRemoval")]
         [InlineData("_TrimmerUnreachableBodies")]


### PR DESCRIPTION
For now this just adds private properties to make it easier for SDK components to set ILLink arguments (instead of using `_ExtraTrimmerArgs`). Most of them are not set by default, with the exception of `_TrimmerDefaultAction` which replaces the `-c` and `-u` flags.

I don't think there is much to test here, since most of the new properties are not tied to existing SDK logic. An existing test checks the behavior for `_TrimmerDefaultAction`, and I have added a sanity check that the boolean options for the optimizations are actually used by validating that they produce errors if they're not boolean. The functionality of the options themselves is tested in https://github.com/mono/linker.

fixes https://github.com/dotnet/sdk/issues/11006.