### PR TITLE
Always set semvarlevel2

### DIFF
--- a/src/Cli/dotnet/NugetSearch/NugetSearchApiParameter.cs
+++ b/src/Cli/dotnet/NugetSearch/NugetSearchApiParameter.cs
@@ -12,21 +12,18 @@ namespace Microsoft.DotNet.NugetSearch
             string searchTerm = null,
             int? skip = null,
             int? take = null,
-            bool prerelease = false,
-            string semverLevel = null)
+            bool prerelease = false)
         {
             SearchTerm = searchTerm;
             Skip = skip;
             Take = take;
             Prerelease = prerelease;
-            SemverLevel = semverLevel;
         }
 
         public string SearchTerm { get; }
         public int? Skip { get; }
         public int? Take { get; }
         public bool Prerelease { get; }
-        public string SemverLevel { get; }
 
         public NugetSearchApiParameter(AppliedOption appliedOption)
         {
@@ -35,13 +32,11 @@ namespace Microsoft.DotNet.NugetSearch
             var skip = GetParsedResultAsInt(appliedOption, "skip");
             var take = GetParsedResultAsInt(appliedOption, "take");
             var prerelease = appliedOption.ValueOrDefault<bool>("prerelease");
-            var semverLevel = appliedOption.ValueOrDefault<string>("semver-level");
 
             SearchTerm = searchTerm;
             Skip = skip;
             Take = take;
             Prerelease = prerelease;
-            SemverLevel = semverLevel;
         }
 
         private static int? GetParsedResultAsInt(AppliedOption appliedOption, string alias)

--- a/src/Cli/dotnet/NugetSearch/NugetToolSearchApiRequest.cs
+++ b/src/Cli/dotnet/NugetSearch/NugetToolSearchApiRequest.cs
@@ -18,8 +18,7 @@ namespace Microsoft.DotNet.NugetSearch
                 nugetSearchApiParameter.SearchTerm,
                 nugetSearchApiParameter.Skip,
                 nugetSearchApiParameter.Take,
-                nugetSearchApiParameter.Prerelease,
-                nugetSearchApiParameter.SemverLevel);
+                nugetSearchApiParameter.Prerelease);
 
             var httpClient = new HttpClient();
             var cancellation = new CancellationTokenSource(TimeSpan.FromSeconds(10));
@@ -44,7 +43,7 @@ namespace Microsoft.DotNet.NugetSearch
         }
 
         internal static Uri ConstructUrl(string searchTerm = null, int? skip = null, int? take = null,
-            bool prerelease = false, string semverLevel = null)
+            bool prerelease = false)
         {
             var uriBuilder = new UriBuilder("https://azuresearch-usnc.nuget.org/query");
             NameValueCollection query = HttpUtility.ParseQueryString(uriBuilder.Query);
@@ -54,6 +53,10 @@ namespace Microsoft.DotNet.NugetSearch
             }
 
             query["packageType"] = "dotnettool";
+
+            // This is a field for internal nuget back
+            // compactabiliy should be "2.0.0" for all new API usage
+            query["semVerLevel"] = "2.0.0";
 
             if (skip.HasValue)
             {
@@ -68,11 +71,6 @@ namespace Microsoft.DotNet.NugetSearch
             if (prerelease)
             {
                 query["prerelease"] = "true";
-            }
-
-            if (!string.IsNullOrWhiteSpace(semverLevel))
-            {
-                query["semVerLevel"] = semverLevel;
             }
 
             uriBuilder.Query = query.ToString();

--- a/src/Cli/dotnet/commands/dotnet-tool/search/LocalizableStrings.resx
+++ b/src/Cli/dotnet/commands/dotnet-tool/search/LocalizableStrings.resx
@@ -150,12 +150,6 @@
   <data name="PrereleaseDescription" xml:space="preserve">
     <value>determining whether to include pre-release packages.</value>
   </data>
-  <data name="SemVerLevelArgumentName" xml:space="preserve">
-    <value>SemVer Level</value>
-  </data>
-  <data name="SemVerLevelDescription" xml:space="preserve">
-    <value>A SemVer 1.0.0 version string.</value>
-  </data>
   <data name="NoResult" xml:space="preserve">
     <value>Could not find any results.</value>
   </data>

--- a/src/Cli/dotnet/commands/dotnet-tool/search/ToolSearchCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-tool/search/ToolSearchCommandParser.cs
@@ -35,11 +35,6 @@ namespace Microsoft.DotNet.Cli
                     $"--prerelease",
                     LocalizableStrings.PrereleaseDescription,
                     Accept.NoArguments()),
-                Create.Option(
-                    $"--semver-level",
-                    LocalizableStrings.SemVerLevelDescription,
-                    Accept.ExactlyOneArgument()
-                        .With(name: LocalizableStrings.SemVerLevelArgumentName)),
                 CommonOptions.HelpOption());
         }
     }

--- a/src/Cli/dotnet/commands/dotnet-tool/search/xlf/LocalizableStrings.cs.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/search/xlf/LocalizableStrings.cs.xlf
@@ -72,16 +72,6 @@
         <target state="new">Search term from package id or package description. Require at least one character.</target>
         <note />
       </trans-unit>
-      <trans-unit id="SemVerLevelArgumentName">
-        <source>SemVer Level</source>
-        <target state="new">SemVer Level</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SemVerLevelDescription">
-        <source>A SemVer 1.0.0 version string.</source>
-        <target state="new">A SemVer 1.0.0 version string.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SkipArgumentName">
         <source>Skip</source>
         <target state="new">Skip</target>

--- a/src/Cli/dotnet/commands/dotnet-tool/search/xlf/LocalizableStrings.de.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/search/xlf/LocalizableStrings.de.xlf
@@ -72,16 +72,6 @@
         <target state="new">Search term from package id or package description. Require at least one character.</target>
         <note />
       </trans-unit>
-      <trans-unit id="SemVerLevelArgumentName">
-        <source>SemVer Level</source>
-        <target state="new">SemVer Level</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SemVerLevelDescription">
-        <source>A SemVer 1.0.0 version string.</source>
-        <target state="new">A SemVer 1.0.0 version string.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SkipArgumentName">
         <source>Skip</source>
         <target state="new">Skip</target>

--- a/src/Cli/dotnet/commands/dotnet-tool/search/xlf/LocalizableStrings.es.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/search/xlf/LocalizableStrings.es.xlf
@@ -72,16 +72,6 @@
         <target state="new">Search term from package id or package description. Require at least one character.</target>
         <note />
       </trans-unit>
-      <trans-unit id="SemVerLevelArgumentName">
-        <source>SemVer Level</source>
-        <target state="new">SemVer Level</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SemVerLevelDescription">
-        <source>A SemVer 1.0.0 version string.</source>
-        <target state="new">A SemVer 1.0.0 version string.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SkipArgumentName">
         <source>Skip</source>
         <target state="new">Skip</target>

--- a/src/Cli/dotnet/commands/dotnet-tool/search/xlf/LocalizableStrings.fr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/search/xlf/LocalizableStrings.fr.xlf
@@ -72,16 +72,6 @@
         <target state="new">Search term from package id or package description. Require at least one character.</target>
         <note />
       </trans-unit>
-      <trans-unit id="SemVerLevelArgumentName">
-        <source>SemVer Level</source>
-        <target state="new">SemVer Level</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SemVerLevelDescription">
-        <source>A SemVer 1.0.0 version string.</source>
-        <target state="new">A SemVer 1.0.0 version string.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SkipArgumentName">
         <source>Skip</source>
         <target state="new">Skip</target>

--- a/src/Cli/dotnet/commands/dotnet-tool/search/xlf/LocalizableStrings.it.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/search/xlf/LocalizableStrings.it.xlf
@@ -72,16 +72,6 @@
         <target state="new">Search term from package id or package description. Require at least one character.</target>
         <note />
       </trans-unit>
-      <trans-unit id="SemVerLevelArgumentName">
-        <source>SemVer Level</source>
-        <target state="new">SemVer Level</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SemVerLevelDescription">
-        <source>A SemVer 1.0.0 version string.</source>
-        <target state="new">A SemVer 1.0.0 version string.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SkipArgumentName">
         <source>Skip</source>
         <target state="new">Skip</target>

--- a/src/Cli/dotnet/commands/dotnet-tool/search/xlf/LocalizableStrings.ja.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/search/xlf/LocalizableStrings.ja.xlf
@@ -72,16 +72,6 @@
         <target state="new">Search term from package id or package description. Require at least one character.</target>
         <note />
       </trans-unit>
-      <trans-unit id="SemVerLevelArgumentName">
-        <source>SemVer Level</source>
-        <target state="new">SemVer Level</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SemVerLevelDescription">
-        <source>A SemVer 1.0.0 version string.</source>
-        <target state="new">A SemVer 1.0.0 version string.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SkipArgumentName">
         <source>Skip</source>
         <target state="new">Skip</target>

--- a/src/Cli/dotnet/commands/dotnet-tool/search/xlf/LocalizableStrings.ko.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/search/xlf/LocalizableStrings.ko.xlf
@@ -72,16 +72,6 @@
         <target state="new">Search term from package id or package description. Require at least one character.</target>
         <note />
       </trans-unit>
-      <trans-unit id="SemVerLevelArgumentName">
-        <source>SemVer Level</source>
-        <target state="new">SemVer Level</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SemVerLevelDescription">
-        <source>A SemVer 1.0.0 version string.</source>
-        <target state="new">A SemVer 1.0.0 version string.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SkipArgumentName">
         <source>Skip</source>
         <target state="new">Skip</target>

--- a/src/Cli/dotnet/commands/dotnet-tool/search/xlf/LocalizableStrings.pl.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/search/xlf/LocalizableStrings.pl.xlf
@@ -72,16 +72,6 @@
         <target state="new">Search term from package id or package description. Require at least one character.</target>
         <note />
       </trans-unit>
-      <trans-unit id="SemVerLevelArgumentName">
-        <source>SemVer Level</source>
-        <target state="new">SemVer Level</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SemVerLevelDescription">
-        <source>A SemVer 1.0.0 version string.</source>
-        <target state="new">A SemVer 1.0.0 version string.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SkipArgumentName">
         <source>Skip</source>
         <target state="new">Skip</target>

--- a/src/Cli/dotnet/commands/dotnet-tool/search/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/search/xlf/LocalizableStrings.pt-BR.xlf
@@ -72,16 +72,6 @@
         <target state="new">Search term from package id or package description. Require at least one character.</target>
         <note />
       </trans-unit>
-      <trans-unit id="SemVerLevelArgumentName">
-        <source>SemVer Level</source>
-        <target state="new">SemVer Level</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SemVerLevelDescription">
-        <source>A SemVer 1.0.0 version string.</source>
-        <target state="new">A SemVer 1.0.0 version string.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SkipArgumentName">
         <source>Skip</source>
         <target state="new">Skip</target>

--- a/src/Cli/dotnet/commands/dotnet-tool/search/xlf/LocalizableStrings.ru.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/search/xlf/LocalizableStrings.ru.xlf
@@ -72,16 +72,6 @@
         <target state="new">Search term from package id or package description. Require at least one character.</target>
         <note />
       </trans-unit>
-      <trans-unit id="SemVerLevelArgumentName">
-        <source>SemVer Level</source>
-        <target state="new">SemVer Level</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SemVerLevelDescription">
-        <source>A SemVer 1.0.0 version string.</source>
-        <target state="new">A SemVer 1.0.0 version string.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SkipArgumentName">
         <source>Skip</source>
         <target state="new">Skip</target>

--- a/src/Cli/dotnet/commands/dotnet-tool/search/xlf/LocalizableStrings.tr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/search/xlf/LocalizableStrings.tr.xlf
@@ -72,16 +72,6 @@
         <target state="new">Search term from package id or package description. Require at least one character.</target>
         <note />
       </trans-unit>
-      <trans-unit id="SemVerLevelArgumentName">
-        <source>SemVer Level</source>
-        <target state="new">SemVer Level</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SemVerLevelDescription">
-        <source>A SemVer 1.0.0 version string.</source>
-        <target state="new">A SemVer 1.0.0 version string.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SkipArgumentName">
         <source>Skip</source>
         <target state="new">Skip</target>

--- a/src/Cli/dotnet/commands/dotnet-tool/search/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/search/xlf/LocalizableStrings.zh-Hans.xlf
@@ -72,16 +72,6 @@
         <target state="new">Search term from package id or package description. Require at least one character.</target>
         <note />
       </trans-unit>
-      <trans-unit id="SemVerLevelArgumentName">
-        <source>SemVer Level</source>
-        <target state="new">SemVer Level</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SemVerLevelDescription">
-        <source>A SemVer 1.0.0 version string.</source>
-        <target state="new">A SemVer 1.0.0 version string.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SkipArgumentName">
         <source>Skip</source>
         <target state="new">Skip</target>

--- a/src/Cli/dotnet/commands/dotnet-tool/search/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/search/xlf/LocalizableStrings.zh-Hant.xlf
@@ -72,16 +72,6 @@
         <target state="new">Search term from package id or package description. Require at least one character.</target>
         <note />
       </trans-unit>
-      <trans-unit id="SemVerLevelArgumentName">
-        <source>SemVer Level</source>
-        <target state="new">SemVer Level</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SemVerLevelDescription">
-        <source>A SemVer 1.0.0 version string.</source>
-        <target state="new">A SemVer 1.0.0 version string.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SkipArgumentName">
         <source>Skip</source>
         <target state="new">Skip</target>

--- a/src/Tests/dotnet.Tests/ParserTests/ToolSearchParserTests.cs
+++ b/src/Tests/dotnet.Tests/ParserTests/ToolSearchParserTests.cs
@@ -23,7 +23,7 @@ namespace Microsoft.DotNet.Tests.ParserTests
         [Fact]
         public void ListSearchParserCanGetArguments()
         {
-            var result = Parser.Instance.Parse("dotnet tool search mytool --detail --skip 3 --take 4 --prerelease --semver-level 1.0.0");
+            var result = Parser.Instance.Parse("dotnet tool search mytool --detail --skip 3 --take 4 --prerelease");
 
             var appliedOptions = result["dotnet"]["tool"]["search"];
             var packageId = appliedOptions.Arguments.Single();
@@ -34,7 +34,6 @@ namespace Microsoft.DotNet.Tests.ParserTests
             appliedOptions.ValueOrDefault<string>("skip").Should().Be("3");
             appliedOptions.ValueOrDefault<string>("take").Should().Be("4");
             appliedOptions.ValueOrDefault<bool>("prerelease").Should().Be(true);
-            appliedOptions.ValueOrDefault<string>("semver-level").Should().Be("1.0.0");
         }
     }
 }

--- a/src/Tests/dotnet.Tests/ToolSearchTests/NugetSearchApiRequestTests.cs
+++ b/src/Tests/dotnet.Tests/ToolSearchTests/NugetSearchApiRequestTests.cs
@@ -11,10 +11,10 @@ namespace dotnet.Tests.ToolSearchTests
         [Fact]
         public void WhenPassedInRequestParametersItCanConstructTheUrl()
         {
-            NugetToolSearchApiRequest.ConstructUrl("mytool", 3, 4, true, "1.0.0")
+            NugetToolSearchApiRequest.ConstructUrl("mytool", 3, 4, true)
                 .AbsoluteUri
                 .Should().Be(
-                    "https://azuresearch-usnc.nuget.org/query?q=mytool&packageType=dotnettool&skip=3&take=4&prerelease=true&semVerLevel=1.0.0");
+                    "https://azuresearch-usnc.nuget.org/query?q=mytool&packageType=dotnettool&semVerLevel=2.0.0&skip=3&take=4&prerelease=true");
         }
 
         [Fact]
@@ -23,7 +23,7 @@ namespace dotnet.Tests.ToolSearchTests
             NugetToolSearchApiRequest.ConstructUrl()
                 .AbsoluteUri
                 .Should().Be(
-                    "https://azuresearch-usnc.nuget.org/query?packageType=dotnettool");
+                    "https://azuresearch-usnc.nuget.org/query?packageType=dotnettool&semVerLevel=2.0.0");
         }
     }
 }


### PR DESCRIPTION
Fix https://github.com/dotnet/sdk/issues/10752

Return out the parameter semverlevel is not really a public facing parameter. We should just always set it to 2.0.0