### PR TITLE
Fix transitive content conflicts Fixes #3871

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.props
@@ -102,7 +102,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <CheckForOverflowUnderflow Condition="'$(CheckForOverflowUnderflow)'==''">false</CheckForOverflowUnderflow>
     <AutomaticallyUseReferenceAssemblyPackages>true</AutomaticallyUseReferenceAssemblyPackages>
     <MicrosoftNETFrameworkReferenceAssembliesLatestPackageVersion>1.0.0</MicrosoftNETFrameworkReferenceAssembliesLatestPackageVersion>
-    <CopyConflictingTransitiveContent>true</CopyConflictingTransitiveContent>
+    <CopyConflictingTransitiveContent>false</CopyConflictingTransitiveContent>
 
     <!-- Uncomment this once https://github.com/Microsoft/visualfsharp/issues/3207 gets fixed -->
     <!-- <WarningsAsErrors Condition=" '$(WarningsAsErrors)' == '' ">NU1605</WarningsAsErrors> -->

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.props
@@ -102,7 +102,8 @@ Copyright (c) .NET Foundation. All rights reserved.
     <CheckForOverflowUnderflow Condition="'$(CheckForOverflowUnderflow)'==''">false</CheckForOverflowUnderflow>
     <AutomaticallyUseReferenceAssemblyPackages>true</AutomaticallyUseReferenceAssemblyPackages>
     <MicrosoftNETFrameworkReferenceAssembliesLatestPackageVersion>1.0.0</MicrosoftNETFrameworkReferenceAssembliesLatestPackageVersion>
-    
+    <IgnoreConflictingTransitiveContent>false</IgnoreConflictingTransitiveContent>
+
     <!-- Uncomment this once https://github.com/Microsoft/visualfsharp/issues/3207 gets fixed -->
     <!-- <WarningsAsErrors Condition=" '$(WarningsAsErrors)' == '' ">NU1605</WarningsAsErrors> -->
   </PropertyGroup>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.props
@@ -102,7 +102,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <CheckForOverflowUnderflow Condition="'$(CheckForOverflowUnderflow)'==''">false</CheckForOverflowUnderflow>
     <AutomaticallyUseReferenceAssemblyPackages>true</AutomaticallyUseReferenceAssemblyPackages>
     <MicrosoftNETFrameworkReferenceAssembliesLatestPackageVersion>1.0.0</MicrosoftNETFrameworkReferenceAssembliesLatestPackageVersion>
-    <IgnoreConflictingTransitiveContent>false</IgnoreConflictingTransitiveContent>
+    <CopyConflictingTransitiveContent>true</CopyConflictingTransitiveContent>
 
     <!-- Uncomment this once https://github.com/Microsoft/visualfsharp/issues/3207 gets fixed -->
     <!-- <WarningsAsErrors Condition=" '$(WarningsAsErrors)' == '' ">NU1605</WarningsAsErrors> -->

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToReferenceAProject.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToReferenceAProject.cs
@@ -14,6 +14,7 @@ using FluentAssertions;
 using System.Runtime.InteropServices;
 using System.Linq;
 using Xunit.Abstractions;
+using System.Xml.Linq;
 
 namespace Microsoft.NET.Build.Tests
 {
@@ -151,6 +152,87 @@ namespace Microsoft.NET.Build.Tests
             }
 
             return ret;
+        }
+
+        [CoreMSBuildOnlyTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void It_disables_copying_conflicting_transitive_content(bool copyConflictingTransitiveContent)
+        {
+            var tfm = "netcoreapp3.1";
+            var contentName = "script.sh";
+            var childProject = new TestProject()
+            {
+                TargetFrameworks = tfm,
+                Name = "ChildProject",
+                IsSdkProject = true
+            };
+            var childAsset = _testAssetsManager.CreateTestProject(childProject)
+                .WithProjectChanges(project => AddProjectChanges(project));
+            File.WriteAllText(Path.Combine(childAsset.Path, childProject.Name, contentName), childProject.Name);
+
+            var parentProject = new TestProject()
+            {
+                TargetFrameworks = tfm,
+                Name = "ParentProject",
+                IsSdkProject = true
+            };
+            if (copyConflictingTransitiveContent)
+            {
+                parentProject.AdditionalProperties["CopyConflictingTransitiveContent"] = "true";
+            }
+            var parentAsset = _testAssetsManager.CreateTestProject(parentProject)
+                .WithProjectChanges(project => AddProjectChanges(project, Path.Combine(childAsset.Path, childProject.Name, childProject.Name + ".csproj")));
+            File.WriteAllText(Path.Combine(parentAsset.Path, parentProject.Name, contentName), parentProject.Name);
+
+            var buildCommand = new BuildCommand(Log, Path.Combine(parentAsset.Path, parentProject.Name));
+            buildCommand.Execute().Should().Pass();
+
+            var getValuesCommand = new GetValuesCommand(Log, Path.Combine(parentAsset.Path, parentProject.Name), tfm, "ResultOutput");
+            getValuesCommand.DependsOnTargets = "Build";
+            getValuesCommand.Execute().Should().Pass();
+
+            var valuesResult = getValuesCommand.GetValuesWithMetadata().Select(pair => pair.value);
+            if (copyConflictingTransitiveContent)
+            {
+                valuesResult.Count().Should().Be(2);
+                String.Join(';', valuesResult).Should().Contain(parentProject.Name);
+                String.Join(';',valuesResult).Should().Contain(parentProject.Name);
+            }
+            else
+            {
+                valuesResult.Count().Should().Be(1);
+                valuesResult.First().Should().Contain(parentProject.Name);
+            }
+        }
+
+        private void AddProjectChanges(XDocument project, string childPath = null)
+        {
+            var ns = project.Root.Name.Namespace;
+
+            var itemGroup = new XElement(ns + "ItemGroup");
+            project.Root.Add(itemGroup);
+
+            var content = new XElement(ns + "Content",
+                new XAttribute("Include", "script.sh"), new XAttribute("CopyToOutputDirectory", "PreserveNewest"));
+            itemGroup.Add(content);
+
+            if (childPath != null)
+            {
+                var projRef = new XElement(ns + "ProjectReference",
+                    new XAttribute("Include", childPath));
+                itemGroup.Add(projRef);
+
+                var target = new XElement(ns + "Target",
+                    new XAttribute("Name", "WriteOutput"),
+                    new XAttribute("DependsOnTargets", "GetCopyToOutputDirectoryItems"),
+                    new XAttribute("BeforeTargets", "_CopyOutOfDateSourceItemsToOutputDirectory"));
+
+                var propertyGroup = new XElement(ns + "PropertyGroup");
+                propertyGroup.Add(new XElement("ResultOutput", "@(AllItemsFullPathWithTargetPath)"));
+                target.Add(propertyGroup);
+                project.Root.Add(target);
+            }
         }
     }
 }

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToReferenceAProject.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToReferenceAProject.cs
@@ -155,9 +155,10 @@ namespace Microsoft.NET.Build.Tests
         }
 
         [CoreMSBuildOnlyTheory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void It_disables_copying_conflicting_transitive_content(bool copyConflictingTransitiveContent)
+        [InlineData(true, true)]
+        [InlineData(false, true)]
+        [InlineData(false, false)]
+        public void It_disables_copying_conflicting_transitive_content(bool copyConflictingTransitiveContent, bool explicitlySet)
         {
             var tfm = "netcoreapp3.1";
             var contentName = "script.sh";
@@ -177,9 +178,9 @@ namespace Microsoft.NET.Build.Tests
                 Name = "ParentProject",
                 IsSdkProject = true
             };
-            if (copyConflictingTransitiveContent)
+            if (explicitlySet)
             {
-                parentProject.AdditionalProperties["CopyConflictingTransitiveContent"] = "true";
+                parentProject.AdditionalProperties["CopyConflictingTransitiveContent"] = copyConflictingTransitiveContent.ToString().ToLower();
             }
             var parentAsset = _testAssetsManager.CreateTestProject(parentProject)
                 .WithProjectChanges(project => AddProjectChanges(project, Path.Combine(childAsset.Path, childProject.Name, childProject.Name + ".csproj")));
@@ -196,13 +197,12 @@ namespace Microsoft.NET.Build.Tests
             if (copyConflictingTransitiveContent)
             {
                 valuesResult.Count().Should().Be(2);
-                String.Join(';', valuesResult).Should().Contain(parentProject.Name);
-                String.Join(';',valuesResult).Should().Contain(parentProject.Name);
+                valuesResult.Should().BeEquivalentTo(Path.Combine(parentAsset.Path, parentProject.Name, contentName), Path.Combine(childAsset.Path, childProject.Name, contentName));
             }
             else
             {
                 valuesResult.Count().Should().Be(1);
-                valuesResult.First().Should().Contain(parentProject.Name);
+                valuesResult.First().Should().Contain(Path.Combine(parentAsset.Path, parentProject.Name, contentName));
             }
         }
 


### PR DESCRIPTION
Changes this to opt-out for sdk-style projects. (See discussion in [microsoft/msbuild#4931](https://github.com/microsoft/msbuild/pull/4931) and [microsoft/msbuild#4997](https://github.com/microsoft/msbuild/pull/4997).)

Fixes #3871.