### PR TITLE
Change VSTest invocation verbosity to minimal

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-test/Program.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/Program.cs
@@ -40,7 +40,6 @@ namespace Microsoft.DotNet.Tools.Test
             var msbuildArgs = new List<string>()
             {
                 "-target:VSTest",
-                $"-verbosity:{GetDefaultVerbosity(parsedTest)}",
                 "-nodereuse:false", // workaround for https://github.com/Microsoft/vstest/issues/1503
                 "-nologo"
             };
@@ -86,17 +85,6 @@ namespace Microsoft.DotNet.Tools.Test
             }
 
             return testCommand;
-        }
-
-        private static string GetDefaultVerbosity(AppliedOption options)
-        {
-            var defaultVerbosity = "quiet";
-            if (options.HasOption(Constants.RestoreInteractiveOption))
-            {
-                defaultVerbosity = "minimal";
-            }
-
-            return defaultVerbosity;
         }
 
         public static int Run(string[] args)

--- a/src/Tests/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestfromCsproj.cs
+++ b/src/Tests/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestfromCsproj.cs
@@ -532,7 +532,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
         }
 
         [Fact]
-        public void ItShouldNotShowImportantMessage()
+        public void ItShouldShowImportantMessage()
         {
             string testAppName = "VSTestCore";
             var testInstance = _testAssetsManager.CopyTestAsset(testAppName)
@@ -546,31 +546,6 @@ namespace Microsoft.DotNet.Cli.Test.Tests
             CommandResult result = new DotnetTestCommand(Log)
                 .WithWorkingDirectory(testProjectDirectory)
                 .Execute();
-
-            // Verify
-            if (!TestContext.IsLocalized())
-            {
-                result.StdOut.Should().NotContain("Important text");
-            }
-
-            result.ExitCode.Should().Be(1);
-        }
-
-        [Fact]
-        public void ItShouldShowImportantMessageWhenInteractiveFlagIsPassed()
-        {
-            string testAppName = "VSTestCore";
-            var testInstance = _testAssetsManager.CopyTestAsset(testAppName)
-                .WithSource()
-                .WithVersionVariables()
-                .WithProjectChanges(ProjectModification.AddDisplayMessageBeforeVsTestToProject);
-
-            var testProjectDirectory = testInstance.Path;
-
-            // Call test
-            CommandResult result = new DotnetTestCommand(Log)
-                .WithWorkingDirectory(testProjectDirectory)
-                .Execute("--interactive");
 
             // Verify
             if (!TestContext.IsLocalized())

--- a/src/Tests/msbuild.Integration.Tests/GivenDotnetInvokesMSBuild.cs
+++ b/src/Tests/msbuild.Integration.Tests/GivenDotnetInvokesMSBuild.cs
@@ -79,7 +79,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.IntegrationTests
         }
 
         [Fact]
-        public void When_dotnet_test_invokes_msbuild_with_no_args_verbosity_is_set_to_quiet()
+        public void When_dotnet_test_invokes_msbuild_with_no_args_verbosity_is_set_to_minimum()
         {
             var testInstance = _testAssetsManager.CopyTestAsset("MSBuildIntegration")
                 .WithSource();
@@ -89,7 +89,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.IntegrationTests
                 .Execute("test");
 
             cmd.Should().Pass();
-            cmd.StdOut.Should().NotContain("Message with high importance");
+            cmd.StdOut.Should().Contain("Message with high importance");
         }
 
         [Fact]


### PR DESCRIPTION
Fixes https://github.com/microsoft/vstest/issues/2413

This was set to quiet in 2016 probably because the build logged more details. The current output is identical between quiet and minimal. Setting this to quiet to align with the other dotnet verbs and stop swallowing outputs when sequencing on BeforeTargets or AfterTargets VSTest.

Removing the verbosity switch as minimal is already passed in: `-verbosity:m -verbosity:quiet`