### PR TITLE
Fix NullReferenceException in dotnet store

### DIFF
--- a/src/Assets/TestProjects/TargetManifests/PrunePackages.xml
+++ b/src/Assets/TestProjects/TargetManifests/PrunePackages.xml
@@ -1,0 +1,36 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+    <PackageReference Include="FluentAssertions" Version="5.10.3" />
+  </ItemGroup>
+    
+  <Target Name="AddPackagesToPrune" AfterTargets="PrepforRestoreForComposeStore">
+    <ItemGroup>
+      <PackageToPrune Include="Microsoft.CSharp" />
+      <PackageToPrune Include="System.Collections" />
+      <PackageToPrune Include="System.Diagnostics.Debug" />
+      <PackageToPrune Include="System.Dynamic.Runtime" />
+      <PackageToPrune Include="System.Globalization" />
+      <PackageToPrune Include="System.IO" />
+      <PackageToPrune Include="System.Linq" />
+      <PackageToPrune Include="System.Linq.Expressions" />
+      <PackageToPrune Include="System.ObjectModel" />
+      <PackageToPrune Include="System.Reflection" />
+      <PackageToPrune Include="System.Reflection.Extensions" />
+      <PackageToPrune Include="System.Resources.ResourceManager" />
+      <PackageToPrune Include="System.Runtime" />
+      <PackageToPrune Include="System.Runtime.Extensions" />
+      <PackageToPrune Include="System.Runtime.Serialization.Primitives" />
+      <PackageToPrune Include="System.Text.Encoding" />
+      <PackageToPrune Include="System.Text.Encoding.Extensions" />
+      <PackageToPrune Include="System.Text.RegularExpressions" />
+      <PackageToPrune Include="System.Threading" />
+      <PackageToPrune Include="System.Threading.Tasks" />
+      <PackageToPrune Include="System.Xml.ReaderWriter" />
+      <PackageToPrune Include="System.Xml.XDocument" />
+    </ItemGroup>
+    <PropertyGroup>
+      <PackagesToPrune>$(PackagesToPrune);@(PackageToPrune)</PackagesToPrune>
+    </PropertyGroup>
+  </Target>
+</Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/FilterResolvedFiles.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/FilterResolvedFiles.cs
@@ -69,7 +69,7 @@ namespace Microsoft.NET.Build.Tasks
                 var pkgName = packageItem.ItemSpec;
                 if (!string.IsNullOrEmpty(pkgName))
                 {
-                    packageClosure.UnionWith(projectContext.GetTransitiveList(pkgName));
+                    packageClosure.UnionWith(projectContext.GetTransitiveList(pkgName, ignoreIfNotFound: true));
                 }
             }
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ProjectContext.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ProjectContext.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Build.Framework;
+using Microsoft.DotNet.PlatformAbstractions;
 using NuGet.Packaging.Core;
 using NuGet.ProjectModel;
 using System;
@@ -145,9 +146,13 @@ namespace Microsoft.NET.Build.Tasks
             return runtimeLibraries.Filter(allExclusionList).ToArray();
         }
 
-        internal IEnumerable<PackageIdentity> GetTransitiveList(string package)
+        internal IEnumerable<PackageIdentity> GetTransitiveList(string package, bool ignoreIfNotFound = false)
         {
             LockFileTargetLibrary platformLibrary = _lockFileTarget.GetLibrary(package);
+            if (platformLibrary == null && ignoreIfNotFound)
+            {
+                return Enumerable.Empty<PackageIdentity>();
+            }
             IEnumerable<LockFileTargetLibrary> runtimeLibraries = _lockFileTarget.Libraries;
             Dictionary<string, LockFileTargetLibrary> libraryLookup =
                 runtimeLibraries.ToDictionary(e => e.Name, StringComparer.OrdinalIgnoreCase);


### PR DESCRIPTION
This will allow specifying `PackageToPune` items whether they are in the package closure or not.

This will make it a lot easier to work around #10973.