### PR TITLE
Fix PublishDepsFilePath setting

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -988,8 +988,8 @@ Copyright (c) .NET Foundation. All rights reserved.
       <!-- _DepsPath is the location where the deps.json file is originally created
            PublishDepsFilePath is the location where the deps.json resides when published 
            PublishDepsFilePath is empty (by default) for PublishSingleFile, since the deps.json file is embedde within the single-file bundle -->      
-      <_DepsFilePath Condition=" '$(PublishDepsFilePath)' != ''">$(PublishDepsFilePath)</_DepsFilePath >
-      <_DepsFilePath Condition=" '$(PublishDepsFilePath)' == ''">$(IntermediateOutputPath)$(ProjectDepsFileName)</_DepsFilePath >
+      <IntermediateDepsFilePath Condition=" '$(PublishDepsFilePath)' != ''">$(PublishDepsFilePath)</IntermediateDepsFilePath >
+      <IntermediateDepsFilePath Condition=" '$(PublishDepsFilePath)' == ''">$(IntermediateOutputPath)$(ProjectDepsFileName)</IntermediateDepsFilePath >
       <PublishDepsFilePath Condition=" '$(PublishDepsFilePath)' == '' And '$(PublishSingleFile)' != 'true'">$(PublishDir)$(ProjectDepsFileName)</PublishDepsFilePath>      
     </PropertyGroup>
     <ItemGroup>
@@ -1005,7 +1005,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <GenerateDepsFile ProjectPath="$(MSBuildProjectFullPath)"
                       AssetsFilePath="$(ProjectAssetsFile)"
-                      DepsFilePath="$(_DepsFilePath)"
+                      DepsFilePath="$(IntermediateDepsFilePath)"
                       TargetFramework="$(TargetFrameworkMoniker)"
                       AssemblyName="$(AssemblyName)"
                       AssemblyExtension="$(TargetExt)"
@@ -1031,7 +1031,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                       RuntimeGraphPath="$(BundledRuntimeIdentifierGraphFile)"/>
 
     <ItemGroup>
-      <ResolvedFileToPublish Include="$(_DepsFilePath)">
+      <ResolvedFileToPublish Include="$(IntermediateDepsFilePath)">
         <RelativePath>$(ProjectDepsFileName)</RelativePath>
       </ResolvedFileToPublish>
     </ItemGroup>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -985,7 +985,12 @@ Copyright (c) .NET Foundation. All rights reserved.
           Condition="'$(GenerateDependencyFile)' == 'true' and '$(_UseBuildDependencyFile)' != 'true'">
 
     <PropertyGroup>
-      <PublishDepsFilePath Condition=" '$(PublishDepsFilePath)' == ''">$(IntermediateOutputPath)$(ProjectDepsFileName)</PublishDepsFilePath>
+      <!-- _DepsPath is the location where the deps.json file is originally created
+           PublishDepsFilePath is the location where the deps.json resides when published 
+           PublishDepsFilePath is empty (by default) for PublishSingleFile, since the deps.json file is embedde within the single-file bundle -->      
+      <_DepsFilePath Condition=" '$(PublishDepsFilePath)' != ''">$(PublishDepsFilePath)</_DepsFilePath >
+      <_DepsFilePath Condition=" '$(PublishDepsFilePath)' == ''">$(IntermediateOutputPath)$(ProjectDepsFileName)</_DepsFilePath >
+      <PublishDepsFilePath Condition=" '$(PublishDepsFilePath)' == '' And '$(PublishSingleFile)' != 'true'">$(PublishDir)$(ProjectDepsFileName)</PublishDepsFilePath>      
     </PropertyGroup>
     <ItemGroup>
       <ResolvedCompileFileDefinitions Remove="@(_PublishConflictPackageFiles)" Condition="'%(_PublishConflictPackageFiles.ConflictItemType)' == 'Reference'" />
@@ -1000,7 +1005,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <GenerateDepsFile ProjectPath="$(MSBuildProjectFullPath)"
                       AssetsFilePath="$(ProjectAssetsFile)"
-                      DepsFilePath="$(PublishDepsFilePath)"
+                      DepsFilePath="$(_DepsFilePath)"
                       TargetFramework="$(TargetFrameworkMoniker)"
                       AssemblyName="$(AssemblyName)"
                       AssemblyExtension="$(TargetExt)"
@@ -1026,7 +1031,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                       RuntimeGraphPath="$(BundledRuntimeIdentifierGraphFile)"/>
 
     <ItemGroup>
-      <ResolvedFileToPublish Include="$(PublishDepsFilePath)">
+      <ResolvedFileToPublish Include="$(_DepsFilePath)">
         <RelativePath>$(ProjectDepsFileName)</RelativePath>
       </ResolvedFileToPublish>
     </ItemGroup>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -985,7 +985,7 @@ Copyright (c) .NET Foundation. All rights reserved.
           Condition="'$(GenerateDependencyFile)' == 'true' and '$(_UseBuildDependencyFile)' != 'true'">
 
     <PropertyGroup>
-      <!-- _DepsPath is the location where the deps.json file is originally created
+      <!-- IntermediateDepsFilePath is the location where the deps.json file is originally created
            PublishDepsFilePath is the location where the deps.json resides when published 
            PublishDepsFilePath is empty (by default) for PublishSingleFile, since the deps.json file is embedde within the single-file bundle -->      
       <IntermediateDepsFilePath Condition=" '$(PublishDepsFilePath)' != ''">$(PublishDepsFilePath)</IntermediateDepsFilePath >

--- a/src/Tests/Microsoft.NET.Publish.Tests/PublishDepsFilePathTests.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/PublishDepsFilePathTests.cs
@@ -28,11 +28,6 @@ namespace Microsoft.NET.Publish.Tests
         {
             var testProject = SetupProject(singleFile: false);
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
-            var restoreCommand = new RestoreCommand(Log, testAsset.Path, testProject.Name);
-            restoreCommand
-                .Execute()
-                .Should()
-                .Pass();
 
             var projectPath = Path.Combine(testAsset.Path, testProject.Name);
             var targetFramework = testProject.TargetFrameworks;
@@ -42,7 +37,7 @@ namespace Microsoft.NET.Publish.Tests
             var publishDepsFilePath = GetPropertyValue(projectPath, targetFramework, "PublishDepsFilePath");
             var expectedDepsFilePath = $"{publishDir}{projectDepsFileName}";
 
-            publishDepsFilePath.Equals(expectedDepsFilePath).Should().BeTrue();
+            publishDepsFilePath.Should().Be(expectedDepsFilePath);
         }
 
         [Fact]

--- a/src/Tests/Microsoft.NET.Publish.Tests/PublishDepsFilePathTests.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/PublishDepsFilePathTests.cs
@@ -1,0 +1,104 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using FluentAssertions;
+using Microsoft.DotNet.Cli.Utils;
+using Microsoft.NET.TestFramework;
+using Microsoft.NET.TestFramework.Assertions;
+using Microsoft.NET.TestFramework.Commands;
+using Microsoft.NET.TestFramework.ProjectConstruction;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.NET.Publish.Tests
+{
+    public class PublishDepsFilePathTests : SdkTest
+    {
+        public PublishDepsFilePathTests(ITestOutputHelper log) : base(log)
+        {
+        }
+
+        [Fact]
+        public void PublishDepsFilePathIsSetAsExpectedForNormalApps()
+        {
+            var testProject = SetupProject(singleFile: false);
+            var testAsset = _testAssetsManager.CreateTestProject(testProject);
+            var restoreCommand = new RestoreCommand(Log, testAsset.Path, testProject.Name);
+            restoreCommand
+                .Execute()
+                .Should()
+                .Pass();
+
+            var projectPath = Path.Combine(testAsset.Path, testProject.Name);
+            var targetFramework = testProject.TargetFrameworks;
+
+            var publishDir = GetPropertyValue(projectPath, targetFramework, "PublishDir");
+            var projectDepsFileName = GetPropertyValue(projectPath, targetFramework, "ProjectDepsFileName");
+            var publishDepsFilePath = GetPropertyValue(projectPath, targetFramework, "PublishDepsFilePath");
+            var expectedDepsFilePath = $"{publishDir}{projectDepsFileName}";
+
+            publishDepsFilePath.Equals(expectedDepsFilePath).Should().BeTrue();
+        }
+
+        [Fact]
+        public void PublishDepsFilePathIsEmptyForSingleFileApps()
+        {
+            var testProject = SetupProject(singleFile: true);
+            var testAsset = _testAssetsManager.CreateTestProject(testProject);
+            var restoreCommand = new RestoreCommand(Log, testAsset.Path, testProject.Name);
+            restoreCommand
+                .Execute()
+                .Should()
+                .Pass();
+
+            var projectPath = Path.Combine(testAsset.Path, testProject.Name);
+            var targetFramework = testProject.TargetFrameworks;
+            var publishDepsFilePath = GetPropertyValue(projectPath, targetFramework, "PublishDepsFilePath");
+
+            String.IsNullOrEmpty(publishDepsFilePath).Should().BeTrue();
+        }
+
+        string GetPropertyValue(string projectPath, string targetFramework, string property)
+        {
+            var getValuesCommand = new GetValuesCommand(Log, projectPath, targetFramework, property)
+            {
+                DependsOnTargets = "GeneratePublishDependencyFile"
+            };
+
+            getValuesCommand
+                .Execute()
+                .Should()
+                .Pass();
+
+            var values = getValuesCommand.GetValues();
+
+            return values.Any() ? values.Single() : null;  
+        }
+
+        private TestProject SetupProject(bool singleFile)
+        {
+            var testProject = new TestProject()
+            {
+                Name = "TestsPublishDepsFilePath",
+                TargetFrameworks = "netcoreapp3.1",
+                IsSdkProject = true,
+                IsExe = true
+            };
+
+            testProject.AdditionalProperties["RuntimeIdentifiers"] = "win-x64";
+            testProject.AdditionalProperties["RestorePackagesPath"] = @"$(MSBuildProjectDirectory)\..\pkg";
+
+            if (singleFile)
+            {
+                testProject.AdditionalProperties["PublishSingleFile"] = "true";
+            }
+
+            return testProject;
+        }
+    }
+}


### PR DESCRIPTION
Restore the semantics of PublishDepsFilePath to be location where the deps.json resides when published.
The PublishDepsFilePath property is used by external projects (ex: asp.net) which rely on this definition.

PublishDepsFilePath is empty (by default) for PublishSingleFile, since the deps.json file is embedde within the single-file bundle.

Add a test case for this property.