### PR TITLE
Generate target platform assembly attributes

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "5.0.100-preview.8.20351.5",
+    "dotnet": "5.0.100-preview.8.20359.7",
     "runtimes": {
       "dotnet": [
         "$(MicrosoftNETCoreAppRuntimePackageVersion)"

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.GenerateAssemblyInfo.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.GenerateAssemblyInfo.targets
@@ -115,6 +115,12 @@ Copyright (c) .NET Foundation. All rights reserved.
         <_Parameter2>%(AssemblyMetadata.Value)</_Parameter2>
       </AssemblyAttribute>
     </ItemGroup>
+
+    <ItemGroup Condition="'$(TargetPlatformIdentifier)' != '' and '$(MinimumOSPlatform)' != ''">
+      <AssemblyAttribute Include="System.Runtime.Versioning.MinimumOSPlatformAttribute">
+        <_Parameter1>$(TargetPlatformIdentifier.ToLower())$(MinimumOSPlatform)</_Parameter1>
+      </AssemblyAttribute>
+    </ItemGroup>
   </Target>
 
   <!-- 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.GenerateAssemblyInfo.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.GenerateAssemblyInfo.targets
@@ -118,7 +118,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <ItemGroup Condition="'$(TargetPlatformIdentifier)' != '' and '$(MinimumOSPlatform)' != ''">
       <AssemblyAttribute Include="System.Runtime.Versioning.MinimumOSPlatformAttribute">
-        <_Parameter1>$(TargetPlatformIdentifier.ToLower())$(MinimumOSPlatform)</_Parameter1>
+        <_Parameter1>$(TargetPlatformIdentifier)$(MinimumOSPlatform)</_Parameter1>
       </AssemblyAttribute>
     </ItemGroup>
   </Target>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.GenerateAssemblyInfo.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.GenerateAssemblyInfo.targets
@@ -116,7 +116,10 @@ Copyright (c) .NET Foundation. All rights reserved.
       </AssemblyAttribute>
     </ItemGroup>
 
-    <ItemGroup Condition="'$(TargetPlatformIdentifier)' != '' and '$(MinimumOSPlatform)' != ''">
+    <ItemGroup Condition="'$(TargetPlatformIdentifier)' != ''
+                         and '$(MinimumOSPlatform)' != ''
+                         and '$(TargetFrameworkIdentifier)' == '.NETCoreApp'
+                         and $([MSBuild]::VersionGreaterThanOrEquals($(_TargetFrameworkVersionWithoutV), '5.0'))">
       <AssemblyAttribute Include="System.Runtime.Versioning.MinimumOSPlatformAttribute">
         <_Parameter1>$(TargetPlatformIdentifier)$(MinimumOSPlatform)</_Parameter1>
       </AssemblyAttribute>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.TargetFrameworkInference.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.TargetFrameworkInference.targets
@@ -88,6 +88,11 @@ Copyright (c) .NET Foundation. All rights reserved.
     <_UnsupportedTargetFrameworkError>true</_UnsupportedTargetFrameworkError>
   </PropertyGroup>
 
+  <!--Default MinimumOSPlatform to TargetPlatformVersion-->
+  <PropertyGroup Condition="'$(MinimumOSPlatform)' == '' and '$(TargetPlatformVersion)' != ''">
+    <MinimumOSPlatform>$(TargetPlatformVersion)</MinimumOSPlatform>
+  </PropertyGroup>
+
   <!--
     NOTE: We must not validate the TFM before restore target runs as it prevents adding additional TFM 
           support from being provided by a nuget package such as MSBuild.Sdk.Extras.

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildALibraryWithOSMinimumVersion.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildALibraryWithOSMinimumVersion.cs
@@ -1,0 +1,142 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.IO;
+using Microsoft.NET.TestFramework;
+using Microsoft.NET.TestFramework.Assertions;
+using Microsoft.NET.TestFramework.Commands;
+using Xunit;
+using FluentAssertions;
+using Xunit.Abstractions;
+using Microsoft.NET.TestFramework.ProjectConstruction;
+using System.Runtime.Versioning;
+
+namespace Microsoft.NET.Build.Tests
+{
+    public class GivenThatWeWantToBuildALibraryWithOSMinimumVersion : SdkTest
+    {
+        public GivenThatWeWantToBuildALibraryWithOSMinimumVersion(ITestOutputHelper log) : base(log)
+        {
+        }
+
+        [Fact]
+        public void WhenPropertiesAreNotSetItShouldNotGenerateMinimumOSPlatformAttribute()
+        {
+            TestProject testProject = SetUpProject();
+            var testAsset = _testAssetsManager.CreateTestProject(testProject);
+
+            var runCommand = new DotnetCommand(Log, "run");
+            runCommand.WorkingDirectory = Path.Combine(testAsset.TestRoot, testProject.Name);
+            runCommand.Execute()
+                .Should()
+                .Pass().And.HaveStdOutContaining("NO ATTRIBUTE");
+        }
+
+        [Fact]
+        public void WhenPropertiesAreSetItCanGenerateMinimumOSPlatformAttribute()
+        {
+            TestProject testProject = SetUpProject();
+
+            var targetPlatformIdentifier = "iOS";
+            testProject.AdditionalProperties["TargetPlatformIdentifier"] = targetPlatformIdentifier;
+            testProject.AdditionalProperties["MinimumOSPlatform"] = "13.2";
+
+            var testAsset = _testAssetsManager.CreateTestProject(testProject);
+
+            var runCommand = new DotnetCommand(Log, "run");
+            runCommand.WorkingDirectory = Path.Combine(testAsset.TestRoot, testProject.Name);
+            runCommand.Execute()
+                .Should()
+                .Pass().And.HaveStdOutContaining("PlatformName:ios13.2");
+        }
+
+        [Fact]
+        public void WhenMinimumOSPlatformISNotSetTargetPlatformVersionIsSetItCanGenerateMinimumOSPlatformAttribute()
+        {
+            TestProject testProject = SetUpProject();
+
+            var targetPlatformIdentifier = "iOS";
+            testProject.AdditionalProperties["TargetPlatformIdentifier"] = targetPlatformIdentifier;
+            testProject.AdditionalProperties["TargetPlatformVersion"] = "13.2";
+
+            var testAsset = _testAssetsManager.CreateTestProject(testProject);
+
+            var runCommand = new DotnetCommand(Log, "run");
+            runCommand.WorkingDirectory = Path.Combine(testAsset.TestRoot, testProject.Name);
+            runCommand.Execute()
+                .Should()
+                .Pass().And.HaveStdOutContaining("PlatformName:ios13.2");
+        }
+
+        private static TestProject SetUpProject()
+        {
+            TestProject testProject = new TestProject()
+            {
+                Name = "Project",
+                IsSdkProject = true,
+                IsExe = true,
+                TargetFrameworks = "net5.0",
+            };
+
+            testProject.SourceFiles["PrintAttribute.cs"] = _printAttribute;
+            testProject.SourceFiles[$"AttributeIsNotDefinedYetWorkaround.cs"] = _attributeIsNotDefinedYetWorkaround;
+            return testProject;
+        }
+
+        private static readonly string _printAttribute = @"
+using System;
+using System.Runtime.Versioning;
+
+namespace CustomAttributesTestApp
+{
+    internal static class CustomAttributesTestApp
+    {
+        public static void Main()
+        {
+            var assembly = typeof(CustomAttributesTestApp).Assembly;
+            object[] attributes = assembly.GetCustomAttributes(typeof(System.Runtime.Versioning.MinimumOSPlatformAttribute), false);
+            if (attributes.Length > 0)
+            {
+                var attribute = attributes[0] as System.Runtime.Versioning.MinimumOSPlatformAttribute;
+                Console.WriteLine($""PlatformName:{attribute.PlatformName}"");
+            }
+            else
+            {
+                Console.WriteLine(""NO ATTRIBUTE"");
+            }
+        }
+    }
+}
+";
+
+        private static readonly string _attributeIsNotDefinedYetWorkaround = @"
+namespace System.Runtime.Versioning
+{
+    [AttributeUsage(AttributeTargets.Assembly |
+                AttributeTargets.Class |
+                AttributeTargets.Constructor |
+                AttributeTargets.Event |
+                AttributeTargets.Method |
+                AttributeTargets.Module |
+                AttributeTargets.Property |
+                AttributeTargets.Struct,
+                AllowMultiple = true, Inherited = false)]
+    public sealed class MinimumOSPlatformAttribute : OSPlatformAttribute
+    {
+        public MinimumOSPlatformAttribute(string platformName) : base(platformName)
+        {
+        }
+    }
+
+    public abstract class OSPlatformAttribute : Attribute
+    {
+        private protected OSPlatformAttribute(string platformName)
+        {
+            PlatformName = platformName;
+        }
+        public string PlatformName { get; }
+    }
+}";
+
+    }
+}

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildALibraryWithOSMinimumVersion.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildALibraryWithOSMinimumVersion.cs
@@ -9,7 +9,6 @@ using Xunit;
 using FluentAssertions;
 using Xunit.Abstractions;
 using Microsoft.NET.TestFramework.ProjectConstruction;
-using System.Runtime.Versioning;
 
 namespace Microsoft.NET.Build.Tests
 {
@@ -40,6 +39,7 @@ namespace Microsoft.NET.Build.Tests
             var targetPlatformIdentifier = "iOS";
             testProject.AdditionalProperties["TargetPlatformIdentifier"] = targetPlatformIdentifier;
             testProject.AdditionalProperties["MinimumOSPlatform"] = "13.2";
+            testProject.AdditionalProperties["TargetPlatformVersion"] = "14.0";
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
@@ -47,7 +47,7 @@ namespace Microsoft.NET.Build.Tests
             runCommand.WorkingDirectory = Path.Combine(testAsset.TestRoot, testProject.Name);
             runCommand.Execute()
                 .Should()
-                .Pass().And.HaveStdOutContaining("PlatformName:ios13.2");
+                .Pass().And.HaveStdOutContaining("PlatformName:iOS13.2");
         }
 
         [Fact]
@@ -65,7 +65,7 @@ namespace Microsoft.NET.Build.Tests
             runCommand.WorkingDirectory = Path.Combine(testAsset.TestRoot, testProject.Name);
             runCommand.Execute()
                 .Should()
-                .Pass().And.HaveStdOutContaining("PlatformName:ios13.2");
+                .Pass().And.HaveStdOutContaining("PlatformName:iOS13.2");
         }
 
         private static TestProject SetUpProject()
@@ -79,7 +79,6 @@ namespace Microsoft.NET.Build.Tests
             };
 
             testProject.SourceFiles["PrintAttribute.cs"] = _printAttribute;
-            testProject.SourceFiles[$"AttributeIsNotDefinedYetWorkaround.cs"] = _attributeIsNotDefinedYetWorkaround;
             return testProject;
         }
 
@@ -108,35 +107,6 @@ namespace CustomAttributesTestApp
     }
 }
 ";
-
-        private static readonly string _attributeIsNotDefinedYetWorkaround = @"
-namespace System.Runtime.Versioning
-{
-    [AttributeUsage(AttributeTargets.Assembly |
-                AttributeTargets.Class |
-                AttributeTargets.Constructor |
-                AttributeTargets.Event |
-                AttributeTargets.Method |
-                AttributeTargets.Module |
-                AttributeTargets.Property |
-                AttributeTargets.Struct,
-                AllowMultiple = true, Inherited = false)]
-    public sealed class MinimumOSPlatformAttribute : OSPlatformAttribute
-    {
-        public MinimumOSPlatformAttribute(string platformName) : base(platformName)
-        {
-        }
-    }
-
-    public abstract class OSPlatformAttribute : Attribute
-    {
-        private protected OSPlatformAttribute(string platformName)
-        {
-            PlatformName = platformName;
-        }
-        public string PlatformName { get; }
-    }
-}";
 
     }
 }

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishASingleFileApp.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishASingleFileApp.cs
@@ -202,7 +202,7 @@ namespace Microsoft.NET.Publish.Tests
                 .Should()
                 .Pass();
 
-            string[] expectedFiles = { SingleFile, PdbFile, SmallNameDirWord, LargeNameDirWord, GetNativeDll("coreclr"), GetNativeDll("clrjit") };
+            string[] expectedFiles = { SingleFile, PdbFile, SmallNameDirWord, LargeNameDirWord };
             string[] unexpectedFiles = { GetNativeDll("hostfxr"), GetNativeDll("hostpolicy") };
 
             GetPublishDirectory(publishCommand)


### PR DESCRIPTION
Fix https://github.com/dotnet/sdk/issues/11239

make sure 
- `MinimumOSPlatform` is the property name we want derive the property directly from. 
- `MinimumOSPlatform` will default to `TargetPlatformVersion` is fine. 
- the assembly attributes is just `$(TargetPlatformIdentifier)$(MinimumOSPlatform)` --- "Windows10.0.1234"