### PR TITLE
[release/5.0.1xx-preview4] Single-File: Fix GenerateBundle Task

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "5.0.100-preview.2.20152.7",
+    "dotnet": "5.0.100-preview.4.20229.10",
     "runtimes": {
       "dotnet": [
         "$(MicrosoftNETCoreAppRuntimePackageVersion)"

--- a/src/Tasks/Microsoft.NET.Build.Tasks/GenerateBundle.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/GenerateBundle.cs
@@ -5,6 +5,8 @@ using Microsoft.Build.Framework;
 using Microsoft.NET.HostModel.Bundle;
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
 
 namespace Microsoft.NET.Build.Tasks
 {
@@ -19,12 +21,23 @@ namespace Microsoft.NET.Build.Tasks
         [Required]
         public string OutputDir { get; set; }
         [Required]
+        public string TargetFrameworkVersion { get; set; }
+        [Required]
+        public string RuntimeIdentifier { get; set; }
+
+        [Required]
         public bool ShowDiagnosticOutput { get; set; }
+
+        [Output]
+        public ITaskItem[] ExcludedFiles { get; set; }
 
         protected override void ExecuteCore()
         {
+            OSPlatform targetOS = RuntimeIdentifier.StartsWith("win") ? OSPlatform.Windows :
+                                  RuntimeIdentifier.StartsWith("osx") ? OSPlatform.OSX : OSPlatform.Linux;
+
             BundleOptions options = BundleOptions.BundleAllContent | (IncludeSymbols ? BundleOptions.BundleSymbolFiles : BundleOptions.None);
-            var bundler = new Bundler(AppHostName, OutputDir, options, diagnosticOutput: ShowDiagnosticOutput);
+            var bundler = new Bundler(AppHostName, OutputDir, options, targetOS, new Version(TargetFrameworkVersion), ShowDiagnosticOutput);
             var fileSpec = new List<FileSpec>(FilesToBundle.Length);
 
             foreach (var item in FilesToBundle)
@@ -34,6 +47,12 @@ namespace Microsoft.NET.Build.Tasks
             }
 
             bundler.GenerateBundle(fileSpec);
+			
+			// Certain files are excluded from the bundle, based on BundleOptions.
+			// For example, native files and contents files are excluded by default.
+			// Return the set of excluded files in ExcludedFiles, so that they can be placed in the publish directory.
+			
+            ExcludedFiles = FilesToBundle.Zip(fileSpec, (item, spec) => (spec.Excluded) ? item : null).Where(x => x != null).ToArray();
         }
     }
 }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -945,11 +945,6 @@ Copyright (c) .NET Foundation. All rights reserved.
       <PublishedSingleFilePath>$(PublishDir)$(PublishedSingleFileName)</PublishedSingleFilePath>
     </PropertyGroup>
 
-    <ItemGroup>
-      <ResolvedFileToPublish Remove="@(_FilesToBundle)"/>
-      <!-- ResolvedFileToPublish shouldn't include PublishedSingleFilePath, since the single-file bundle is written directly to the publish directory -->
-    </ItemGroup>
-
   </Target>
 
   <UsingTask TaskName="GenerateBundle" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
@@ -963,8 +958,17 @@ Copyright (c) .NET Foundation. All rights reserved.
                     AppHostName="$(PublishedSingleFileName)"
                     IncludeSymbols="$(IncludeSymbolsInSingleFile)"
                     OutputDir="$(PublishDir)"
-                    ShowDiagnosticOutput="false"/>
+                    TargetFrameworkVersion="$(_TargetFrameworkVersionWithoutV)"
+                    RuntimeIdentifier="$(RuntimeIdentifier)"
+                    ShowDiagnosticOutput="false">
+      <Output TaskParameter="ExcludedFiles" ItemName="_FilesExcludedFromBundle"/>
+    </GenerateBundle>
 
+    <ItemGroup>
+      <ResolvedFileToPublish Remove="@(_FilesToBundle)"/>
+      <ResolvedFileToPublish Include="@(_FilesExcludedFromBundle)"/>
+      <!-- ResolvedFileToPublish shouldn't include PublishedSingleFilePath, since the single-file bundle is written directly to the publish directory -->
+    </ItemGroup>
   </Target>
 
   <!--


### PR DESCRIPTION
## Customer Scenario
Self-contained Apps published as a single-file fail at run-time.

## Problem

Single-file bundles are now processed in the framework rather than the apphost (https://github.com/dotnet/runtime/pull/34274).
This means that hostpolicy and hostfxr DLLs are excluded from being bundled themselves.
In the case of self-contained single-file apps, these files need to be separate files until static-apphost is available.
This needs to be ensured by the SDK; otherwise app execution will fail.

## Solution

This change fixes the problem by adapting the SDK to:
* Pass the correct target-OS settings (otherwise cross-targetting builds will not work correctly)
* Copy files excluded by the Bundler to the publish directory.

The stage-0 netcoreapp is updated to preview4, because preview2 apphost is not compatible with preview4 bundler.

## Risk

Low

## Alternatives

The alternative to taking this change in preview 4 is to [revert the bundle processing change from runtime preview 4 branch](https://github.com/dotnet/runtime/compare/release/5.0-preview4...swaroop-sridhar:revert?expand=1).

This fix can then be performed in master branch.