### PR TITLE
Escape test run parameters

### DIFF
--- a/src/Assets/TestProjects/VSTestTestRunParameters/Tests.cs
+++ b/src/Assets/TestProjects/VSTestTestRunParameters/Tests.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace TestNamespace
+{
+    [TestClass]
+    public class VSTestTests
+    {
+        public TestContext TestContext { get; set; }
+
+        [TestMethod]
+        public void VSTestTestRunParameters()
+        {
+            var myParam = TestContext.Properties["myParam"];
+            Assert.AreEqual("value", myParam);
+
+            var myParam2 = TestContext.Properties["myParam2"];
+            Assert.AreEqual("value with space", myParam2);
+        }
+    }
+}

--- a/src/Assets/TestProjects/VSTestTestRunParameters/VSTestTestRunParameters.csproj
+++ b/src/Assets/TestProjects/VSTestTestRunParameters/VSTestTestRunParameters.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), testAsset.props))\testAsset.props" />
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MSTest.TestFramework" Version="$(MSTestVersion)" />
+    <PackageReference Include="MSTest.TestAdapter" Version="$(MSTestVersion)" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPackageVersion)" />
+  </ItemGroup>
+</Project>

--- a/src/Cli/dotnet/Properties/launchSettings.json
+++ b/src/Cli/dotnet/Properties/launchSettings.json
@@ -1,0 +1,8 @@
+{
+  "profiles": {
+    "dotnet": {
+      "commandName": "Project",
+      "commandLineArgs": "test C:\\temp\\VSTestTestRunParameters  -- TestRunParameters.Parameter(name=\\\"myParam\\\", value=\\\"value\\\") TestRunParameters.Parameter(name=\\\"myParam2\\\", value=\\\"value with space\\\")"
+    }
+  }
+}

--- a/src/Cli/dotnet/commands/dotnet-test/Program.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/Program.cs
@@ -87,7 +87,7 @@ namespace Microsoft.DotNet.Tools.Test
         {
             DebugHelper.HandleDebugSwitch(ref args);
 
-            // literal parameters are after -- (including --)
+            // settings parameters are after -- (including --), these should not be considered by the parser
             var settings = args.SkipWhile(a => a != "--").ToArray();
             // all parameters before --
             args = args.TakeWhile(a => a != "--").ToArray();
@@ -102,9 +102,9 @@ namespace Microsoft.DotNet.Tools.Test
                     Reporter.Output.WriteLine(string.Format(LocalizableStrings.IgnoredArgumentsMessage, string.Join(" ", ignoredArgs)).Yellow());
                 }
 
-                // we don't need to escape one more time, there is no extra hop via msbuild
+                // merge the args settings, we don't need to escape
+                // one more time, there is no extra hop via msbuild
                 convertedArgs.AddRange(settings);
-
 
                 return new VSTestForwardingApp(convertedArgs).Execute();
             }

--- a/src/Cli/dotnet/commands/dotnet-test/Program.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/Program.cs
@@ -5,11 +5,9 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text.RegularExpressions;
 using Microsoft.DotNet.Cli;
 using Microsoft.DotNet.Cli.CommandLine;
 using Microsoft.DotNet.Cli.Utils;
-using Microsoft.DotNet.Tools.MSBuild;
 using Parser = Microsoft.DotNet.Cli.Parser;
 
 namespace Microsoft.DotNet.Tools.Test
@@ -51,8 +49,10 @@ namespace Microsoft.DotNet.Tools.Test
             if (settings.Any())
             {
                 // skip '--' and escape every \ to be \\ and every " to be \" to survive the next hop
-                var escaped = string.Join(" ", settings.Skip(1)).Replace("\\", "\\\\").Replace("\"", "\\\"");
-                msbuildArgs.Add($"-property:VSTestCLIRunSettings=\"{escaped}\"");
+                var escaped = settings.Skip(1).Select(s => s.Replace("\\", "\\\\").Replace("\"", "\\\"")).ToArray();
+
+                var runSettingsArg = string.Join(";", escaped);
+                msbuildArgs.Add($"-property:VSTestCLIRunSettings=\"{runSettingsArg}\"");
             }
 
             var verbosityArg = parsedTest.ForwardedOptionValues("verbosity").SingleOrDefault();

--- a/src/Cli/dotnet/commands/dotnet-test/VSTestArgumentConverter.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/VSTestArgumentConverter.cs
@@ -3,6 +3,7 @@
 
 namespace Microsoft.DotNet.Cli
 {
+    using System;
     using System.Collections.Generic;
     using System.Linq;
 
@@ -63,6 +64,11 @@ namespace Microsoft.DotNet.Cli
             string activeArgument = null;
             foreach (var arg in args)
             {
+                if (arg == "--")
+                {
+                    throw new ArgumentException("Inline settings should not be passed to Convert.");
+                }
+
                 if (arg.StartsWith("-"))
                 {
                     if (!string.IsNullOrEmpty(activeArgument))

--- a/src/Cli/dotnet/commands/dotnet-test/VSTestArgumentConverter.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/VSTestArgumentConverter.cs
@@ -103,11 +103,6 @@ namespace Microsoft.DotNet.Cli
 
                         newArgList.Add(string.Join(":", argValues));
                     }
-                    // RunConfiguration args, treat -- and remaining args as literals.
-                    else if (arg == "--")
-                    {
-                        newArgList.Add(arg);
-                    }
                     else
                     {
                         activeArgument = arg.ToLower();

--- a/src/Tests/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestfromCsprojWithCorrectTestRunParameters.cs
+++ b/src/Tests/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestfromCsprojWithCorrectTestRunParameters.cs
@@ -1,0 +1,142 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.DotNet.Tools.Test.Utilities;
+using Xunit;
+using FluentAssertions;
+using Microsoft.DotNet.Cli.Utils;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using Microsoft.NET.TestFramework;
+using Microsoft.NET.TestFramework.Assertions;
+using Microsoft.NET.TestFramework.Commands;
+using Xunit.Abstractions;
+
+namespace Microsoft.DotNet.Cli.Test.Tests
+{
+    public class GivenDotnetTestBuildsAndRunsTestfromCsprojWithCorrectTestRunParameters : SdkTest
+    {
+        public GivenDotnetTestBuildsAndRunsTestfromCsprojWithCorrectTestRunParameters(ITestOutputHelper log) : base(log)
+        {
+        }
+
+        private readonly string[] ConsoleLoggerOutputNormal = new[] { "--logger", "console;verbosity=normal" };
+
+        [Fact]
+        public void MSTestSingleTFM()
+        {
+            var testProjectDirectory = this.CopyAndRestoreVSTestDotNetCoreTestApp("1");
+
+            // Call test
+            CommandResult result = new DotnetTestCommand(Log)
+                                        .WithWorkingDirectory(testProjectDirectory)
+                                        .Execute(ConsoleLoggerOutputNormal.Concat(new[] {
+                                            "--",
+                                            "TestRunParameters.Parameter(name=\"myParam\",",
+                                            "value=\"value\")",
+                                            "TestRunParameters.Parameter(name=\"myParam2\",",
+                                            "value=\"myValue with space\")"
+                                        }));
+
+            // Verify
+            if (!TestContext.IsLocalized())
+            {
+                result.StdOut.Should().NotMatch("The test run parameter argument '*' is invalid.");
+                result.StdOut.Should().Contain("Total tests: 1");
+                result.StdOut.Should().Contain("Passed: 1");
+                result.StdOut.Should().Contain("Failed: 0");
+                result.StdOut.Should().Contain("\u221a VSTestTestRunParameters");
+            }
+
+            result.ExitCode.Should().Be(0);
+        }
+
+        // dotnet test + dll
+        //[Fact]
+        //public void TestsFromAGivenContainerShouldRunWithExpectedOutput()
+        //{
+        //    var testAppName = "VSTestCore";
+        //    var testRoot = _testAssetsManager.CopyTestAsset(testAppName)
+        //        .WithSource()
+        //        .WithVersionVariables()
+        //        .Path;
+
+        //    var configuration = Environment.GetEnvironmentVariable("CONFIGURATION") ?? "Debug";
+
+        //    new BuildCommand(Log, testRoot)
+        //        .Execute()
+        //        .Should().Pass();
+
+        //    var outputDll = Path.Combine(testRoot, "bin", configuration, "netcoreapp3.0", $"{testAppName}.dll");
+
+        //    // Call vstest
+        //    var result = new DotnetVSTestCommand(Log)
+        //        .Execute(outputDll, "--logger:console;verbosity=normal");
+        //    if (!TestContext.IsLocalized())
+        //    {
+        //        result.StdOut
+        //            .Should().Contain("Total tests: 2")
+        //            .And.Contain("Passed: 1")
+        //            .And.Contain("Failed: 1")
+        //            .And.Contain("\u221a VSTestPassTest")
+        //            .And.Contain("X VSTestFailTest");
+        //    }
+
+        //    result.ExitCode.Should().Be(1);
+        //}
+
+        // vstest
+        //[Fact]
+        //public void TestsFromAGivenContainerShouldRunWithExpectedOutput()
+        //{
+        //    var testAppName = "VSTestCore";
+        //    var testRoot = _testAssetsManager.CopyTestAsset(testAppName)
+        //        .WithSource()
+        //        .WithVersionVariables()
+        //        .Path;
+
+        //    var configuration = Environment.GetEnvironmentVariable("CONFIGURATION") ?? "Debug";
+
+        //    new BuildCommand(Log, testRoot)
+        //        .Execute()
+        //        .Should().Pass();
+
+        //    var outputDll = Path.Combine(testRoot, "bin", configuration, "netcoreapp3.0", $"{testAppName}.dll");
+
+        //    // Call vstest
+        //    var result = new DotnetVSTestCommand(Log)
+        //        .Execute(outputDll, "--logger:console;verbosity=normal");
+        //    if (!TestContext.IsLocalized())
+        //    {
+        //        result.StdOut
+        //            .Should().Contain("Total tests: 2")
+        //            .And.Contain("Passed: 1")
+        //            .And.Contain("Failed: 1")
+        //            .And.Contain("\u221a VSTestPassTest")
+        //            .And.Contain("X VSTestFailTest");
+        //    }
+
+        //    result.ExitCode.Should().Be(1);
+        //}
+
+        private string CopyAndRestoreVSTestDotNetCoreTestApp([CallerMemberName] string callingMethod = "")
+        {
+            // Copy VSTestCore project in output directory of project dotnet-vstest.Tests
+            string testAppName = "VSTestTestRunParameters";
+
+            var testInstance = _testAssetsManager.CopyTestAsset(testAppName, callingMethod: callingMethod)
+                            .WithSource()
+                            .WithVersionVariables();
+
+            var testProjectDirectory = testInstance.Path;
+
+            // Restore project VSTestCore
+            new RestoreCommand(Log, testProjectDirectory)
+                .Execute()
+                .Should()
+                .Pass();
+
+            return testProjectDirectory;
+        }
+    }
+}


### PR DESCRIPTION
Escape test run parameters to survive a hop via msbuild, so that we can call `dotnet test`, `dotnet vstest`, and `vstest.console` with the same syntax with a single escape: 

For example: 
```shell
# cmd
dotnet test  -- TestRunParameters.Parameter(name=\"myParam\", value=\"value\")

# powershell
dotnet test --%  -- TestRunParameters.Parameter(name=\"myParam\", value=\"value\") 

# bash
dotnet test -- TestRunParameters.Parameter\(name=\"myParam\",\ value=\"value\"\) 
```

Fix https://github.com/microsoft/vstest/issues/862

