### PR TITLE
Fix official build signing validation errors

### DIFF
--- a/eng/common/sdk-task.ps1
+++ b/eng/common/sdk-task.ps1
@@ -59,14 +59,15 @@ try {
 
   if( $msbuildEngine -eq "vs") {
     # Ensure desktop MSBuild is available for sdk tasks.
-    if( -not ($GlobalJson.tools.PSObject.Properties.Name -match "vs" )) {
+    if( -not ($GlobalJson.tools.PSObject.Properties.Name -contains "vs" )) {
       $GlobalJson.tools | Add-Member -Name "vs" -Value (ConvertFrom-Json "{ `"version`": `"16.4`" }") -MemberType NoteProperty
     }
     if( -not ($GlobalJson.tools.PSObject.Properties.Name -match "xcopy-msbuild" )) {
       $GlobalJson.tools | Add-Member -Name "xcopy-msbuild" -Value "16.4.0-alpha" -MemberType NoteProperty
     }
 
-    InitializeXCopyMSBuild $GlobalJson.tools."xcopy-msbuild" -install $true
+    $xcopyMSBuildToolsFolder = InitializeXCopyMSBuild $GlobalJson.tools."xcopy-msbuild" -install $true
+    $global:_MSBuildExe = "$($xcopyMSBuildToolsFolder)\MSBuild\Current\Bin\MSBuild.exe"
   }
 
   $taskProject = GetSdkTaskProject $task


### PR DESCRIPTION
Manual port of https://github.com/dotnet/arcade/commit/d023cbcfe276d712283698345cfe94ce4f5191c0 to get official builds green.

@markwilkie let me know that there will be a new Arcade promotion tomorrow with the fix but to get an official build into installer today I'm cherry-picking the fix.

cc @chcosta 