### PR TITLE
Add `dotnet add file`

### DIFF
--- a/src/Cli/dotnet/CommonLocalizableStrings.resx
+++ b/src/Cli/dotnet/CommonLocalizableStrings.resx
@@ -671,4 +671,19 @@ setx PATH "%PATH%;{0}"
   <data name="CommandInteractiveOptionDescription" xml:space="preserve">
     <value>Allows the command to stop and wait for user input or action (for example to complete authentication).</value>
   </data>
+  <data name="CouldNotFindFile" xml:space="preserve">
+    <value>Could not find flie `{0}`.</value>
+  </data>
+  <data name="FileAddedToTheProject" xml:space="preserve">
+    <value>File `{0}` added to the project.</value>
+  </data>
+  <data name="ProjectAlreadyHasAfile" xml:space="preserve">
+    <value>Project already has a file `{0}`.</value>
+  </data>
+  <data name="FileRemoved" xml:space="preserve">
+    <value>File `{0}` removed.</value>
+  </data>
+  <data name="FileReferenceCouldNotBeFound" xml:space="preserve">
+    <value>File reference `{0}` could not be found.</value>
+  </data>
 </root>

--- a/src/Cli/dotnet/commands/dotnet-add/AddCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-add/AddCommandParser.cs
@@ -21,6 +21,7 @@ namespace Microsoft.DotNet.Cli
                             description: CommonLocalizableStrings.ProjectArgumentDescription),
                 AddPackageParser.AddPackage(),
                 AddProjectToProjectReferenceParser.AddProjectReference(),
+                AddFileParser.AddFile(),
                 CommonOptions.HelpOption());
     }
 }

--- a/src/Cli/dotnet/commands/dotnet-add/Program.cs
+++ b/src/Cli/dotnet/commands/dotnet-add/Program.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using Microsoft.DotNet.Cli;
 using Microsoft.DotNet.Cli.CommandLine;
 using Microsoft.DotNet.Cli.Utils;
+using Microsoft.DotNet.Tools.Add.FileReference;
 using Microsoft.DotNet.Tools.Add.PackageReference;
 using Microsoft.DotNet.Tools.Add.ProjectToProjectReference;
 
@@ -31,6 +32,12 @@ namespace Microsoft.DotNet.Tools.Add
                 ["package"] =
                 add => new AddPackageReferenceCommand(
                     add["package"],
+                    add.Value<string>(),
+                    ParseResult),
+
+                ["file"] =
+                add => new AddFileReferenceCommand(
+                    add["file"],
                     add.Value<string>(),
                     ParseResult)
             };

--- a/src/Cli/dotnet/commands/dotnet-add/dotnet-add-file/AddFileParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-add/dotnet-add-file/AddFileParser.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.DotNet.Cli.CommandLine;
+using LocalizableStrings = Microsoft.DotNet.Tools.Add.FileReference.LocalizableStrings;
+
+namespace Microsoft.DotNet.Cli
+{
+    internal static class AddFileParser
+    {
+        public static Command AddFile()
+        {
+            return Create.Command(
+                "file",
+                LocalizableStrings.AppFullName, 
+                Accept.OneOrMoreArguments()
+                      .With(name: LocalizableStrings.FilePathArgumentName,
+                            description: LocalizableStrings.FilePathArgumentDescription),
+                CommonOptions.HelpOption(),
+                Create.Option("-f|--framework", LocalizableStrings.CmdFrameworkDescription,
+                              Accept.ExactlyOneArgument()
+                                    .WithSuggestionsFrom(_ => Suggest.TargetFrameworksFromProjectFile())
+                                    .With(name: Tools.Add.PackageReference.LocalizableStrings.CmdFramework)),
+                CommonOptions.InteractiveOption());
+        }
+    } 
+}

--- a/src/Cli/dotnet/commands/dotnet-add/dotnet-add-file/LocalizableStrings.resx
+++ b/src/Cli/dotnet/commands/dotnet-add/dotnet-add-file/LocalizableStrings.resx
@@ -1,0 +1,135 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="AppDescription" xml:space="preserve">
+    <value>Command to add file</value>
+  </data>
+  <data name="AppFullName" xml:space="preserve">
+    <value>Add a file to the project.</value>
+  </data>
+  <data name="CmdFrameworkDescription" xml:space="preserve">
+    <value>Add the reference only when targeting a specific framework.</value>
+  </data>
+  <data name="FilePathArgumentDescription" xml:space="preserve">
+    <value>The files to add.</value>
+  </data>
+  <data name="FilePathArgumentName" xml:space="preserve">
+    <value>FILE</value>
+  </data>
+</root>

--- a/src/Cli/dotnet/commands/dotnet-add/dotnet-add-file/Program.cs
+++ b/src/Cli/dotnet/commands/dotnet-add/dotnet-add-file/Program.cs
@@ -1,0 +1,84 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Microsoft.Build.Evaluation;
+using Microsoft.DotNet.Cli;
+using Microsoft.DotNet.Cli.CommandLine;
+using Microsoft.DotNet.Cli.Utils;
+using Microsoft.DotNet.Tools.Common;
+using NuGet.Frameworks;
+
+namespace Microsoft.DotNet.Tools.Add.FileReference
+{
+    internal class AddFileReferenceCommand : CommandBase
+    {
+        private readonly AppliedOption _appliedCommand;
+        private readonly string _fileOrDirectory;
+
+        public AddFileReferenceCommand(
+            AppliedOption appliedCommand,
+            string fileOrDirectory,
+            ParseResult parseResult) : base(parseResult)
+        {
+            if (appliedCommand == null)
+            {
+                throw new ArgumentNullException(nameof(appliedCommand));
+            }
+            if (fileOrDirectory == null)
+            {
+                throw new ArgumentNullException(nameof(fileOrDirectory));
+            }
+
+            _appliedCommand = appliedCommand;
+            _fileOrDirectory = fileOrDirectory;
+        }
+
+        public override int Execute()
+        {
+            var projects = new ProjectCollection();
+            bool interactive = CommonOptionResult.GetInteractive(_appliedCommand);
+            MsbuildProject msbuildProj = MsbuildProject.FromFileOrDirectory(
+                projects,
+                _fileOrDirectory,
+                interactive);
+
+            var frameworkString = _appliedCommand.ValueOrDefault<string>("framework");
+            var refs = _appliedCommand.Arguments;
+
+            if (frameworkString != null)
+            {
+                var framework = NuGetFramework.Parse(frameworkString);
+                if (!msbuildProj.IsTargetingFramework(framework)) {
+                    Reporter.Error.WriteLine(string.Format(
+                                                    CommonLocalizableStrings.ProjectDoesNotTargetFramework,
+                                                    msbuildProj.ProjectRootElement.FullPath,
+                                                    frameworkString));
+                    return 1;
+                }
+            }
+
+            PathUtility.EnsureAllPathsExist(refs, CommonLocalizableStrings.CouldNotFindProjectOrDirectory, true);
+
+            var relativePathReferences = refs.Select((r) =>
+                                                            Path.GetRelativePath(
+                                                                msbuildProj.ProjectDirectory,
+                                                                System.IO.Path.GetFullPath(r))).ToList();
+
+            int numberOfAddedReferences = msbuildProj.AddFileReferences(
+                    frameworkString,
+                    relativePathReferences);
+
+            if (numberOfAddedReferences != 0)
+            {
+                msbuildProj.ProjectRootElement.Save();
+            }
+
+            return 0;
+        }
+    }
+}

--- a/src/Cli/dotnet/commands/dotnet-add/dotnet-add-file/xlf/LocalizableStrings.cs.xlf
+++ b/src/Cli/dotnet/commands/dotnet-add/dotnet-add-file/xlf/LocalizableStrings.cs.xlf
@@ -1,0 +1,32 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="cs" original="../LocalizableStrings.resx">
+    <body>
+      <trans-unit id="AppDescription">
+        <source>Command to add file</source>
+        <target state="new">Command to add file</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppFullName">
+        <source>Add a file to the project.</source>
+        <target state="new">Add a file to the project.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdFrameworkDescription">
+        <source>Add the reference only when targeting a specific framework.</source>
+        <target state="new">Add the reference only when targeting a specific framework.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilePathArgumentDescription">
+        <source>The files to add.</source>
+        <target state="new">The files to add.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilePathArgumentName">
+        <source>FILE</source>
+        <target state="new">FILE</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Cli/dotnet/commands/dotnet-add/dotnet-add-file/xlf/LocalizableStrings.de.xlf
+++ b/src/Cli/dotnet/commands/dotnet-add/dotnet-add-file/xlf/LocalizableStrings.de.xlf
@@ -1,0 +1,32 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="de" original="../LocalizableStrings.resx">
+    <body>
+      <trans-unit id="AppDescription">
+        <source>Command to add file</source>
+        <target state="new">Command to add file</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppFullName">
+        <source>Add a file to the project.</source>
+        <target state="new">Add a file to the project.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdFrameworkDescription">
+        <source>Add the reference only when targeting a specific framework.</source>
+        <target state="new">Add the reference only when targeting a specific framework.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilePathArgumentDescription">
+        <source>The files to add.</source>
+        <target state="new">The files to add.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilePathArgumentName">
+        <source>FILE</source>
+        <target state="new">FILE</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Cli/dotnet/commands/dotnet-add/dotnet-add-file/xlf/LocalizableStrings.es.xlf
+++ b/src/Cli/dotnet/commands/dotnet-add/dotnet-add-file/xlf/LocalizableStrings.es.xlf
@@ -1,0 +1,32 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="es" original="../LocalizableStrings.resx">
+    <body>
+      <trans-unit id="AppDescription">
+        <source>Command to add file</source>
+        <target state="new">Command to add file</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppFullName">
+        <source>Add a file to the project.</source>
+        <target state="new">Add a file to the project.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdFrameworkDescription">
+        <source>Add the reference only when targeting a specific framework.</source>
+        <target state="new">Add the reference only when targeting a specific framework.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilePathArgumentDescription">
+        <source>The files to add.</source>
+        <target state="new">The files to add.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilePathArgumentName">
+        <source>FILE</source>
+        <target state="new">FILE</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Cli/dotnet/commands/dotnet-add/dotnet-add-file/xlf/LocalizableStrings.fr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-add/dotnet-add-file/xlf/LocalizableStrings.fr.xlf
@@ -1,0 +1,32 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="fr" original="../LocalizableStrings.resx">
+    <body>
+      <trans-unit id="AppDescription">
+        <source>Command to add file</source>
+        <target state="new">Command to add file</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppFullName">
+        <source>Add a file to the project.</source>
+        <target state="new">Add a file to the project.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdFrameworkDescription">
+        <source>Add the reference only when targeting a specific framework.</source>
+        <target state="new">Add the reference only when targeting a specific framework.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilePathArgumentDescription">
+        <source>The files to add.</source>
+        <target state="new">The files to add.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilePathArgumentName">
+        <source>FILE</source>
+        <target state="new">FILE</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Cli/dotnet/commands/dotnet-add/dotnet-add-file/xlf/LocalizableStrings.it.xlf
+++ b/src/Cli/dotnet/commands/dotnet-add/dotnet-add-file/xlf/LocalizableStrings.it.xlf
@@ -1,0 +1,32 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="it" original="../LocalizableStrings.resx">
+    <body>
+      <trans-unit id="AppDescription">
+        <source>Command to add file</source>
+        <target state="new">Command to add file</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppFullName">
+        <source>Add a file to the project.</source>
+        <target state="new">Add a file to the project.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdFrameworkDescription">
+        <source>Add the reference only when targeting a specific framework.</source>
+        <target state="new">Add the reference only when targeting a specific framework.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilePathArgumentDescription">
+        <source>The files to add.</source>
+        <target state="new">The files to add.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilePathArgumentName">
+        <source>FILE</source>
+        <target state="new">FILE</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Cli/dotnet/commands/dotnet-add/dotnet-add-file/xlf/LocalizableStrings.ja.xlf
+++ b/src/Cli/dotnet/commands/dotnet-add/dotnet-add-file/xlf/LocalizableStrings.ja.xlf
@@ -1,0 +1,32 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ja" original="../LocalizableStrings.resx">
+    <body>
+      <trans-unit id="AppDescription">
+        <source>Command to add file</source>
+        <target state="new">Command to add file</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppFullName">
+        <source>Add a file to the project.</source>
+        <target state="new">Add a file to the project.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdFrameworkDescription">
+        <source>Add the reference only when targeting a specific framework.</source>
+        <target state="new">Add the reference only when targeting a specific framework.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilePathArgumentDescription">
+        <source>The files to add.</source>
+        <target state="new">The files to add.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilePathArgumentName">
+        <source>FILE</source>
+        <target state="new">FILE</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Cli/dotnet/commands/dotnet-add/dotnet-add-file/xlf/LocalizableStrings.ko.xlf
+++ b/src/Cli/dotnet/commands/dotnet-add/dotnet-add-file/xlf/LocalizableStrings.ko.xlf
@@ -1,0 +1,32 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ko" original="../LocalizableStrings.resx">
+    <body>
+      <trans-unit id="AppDescription">
+        <source>Command to add file</source>
+        <target state="new">Command to add file</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppFullName">
+        <source>Add a file to the project.</source>
+        <target state="new">Add a file to the project.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdFrameworkDescription">
+        <source>Add the reference only when targeting a specific framework.</source>
+        <target state="new">Add the reference only when targeting a specific framework.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilePathArgumentDescription">
+        <source>The files to add.</source>
+        <target state="new">The files to add.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilePathArgumentName">
+        <source>FILE</source>
+        <target state="new">FILE</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Cli/dotnet/commands/dotnet-add/dotnet-add-file/xlf/LocalizableStrings.pl.xlf
+++ b/src/Cli/dotnet/commands/dotnet-add/dotnet-add-file/xlf/LocalizableStrings.pl.xlf
@@ -1,0 +1,32 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="pl" original="../LocalizableStrings.resx">
+    <body>
+      <trans-unit id="AppDescription">
+        <source>Command to add file</source>
+        <target state="new">Command to add file</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppFullName">
+        <source>Add a file to the project.</source>
+        <target state="new">Add a file to the project.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdFrameworkDescription">
+        <source>Add the reference only when targeting a specific framework.</source>
+        <target state="new">Add the reference only when targeting a specific framework.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilePathArgumentDescription">
+        <source>The files to add.</source>
+        <target state="new">The files to add.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilePathArgumentName">
+        <source>FILE</source>
+        <target state="new">FILE</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Cli/dotnet/commands/dotnet-add/dotnet-add-file/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/commands/dotnet-add/dotnet-add-file/xlf/LocalizableStrings.pt-BR.xlf
@@ -1,0 +1,32 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="pt-BR" original="../LocalizableStrings.resx">
+    <body>
+      <trans-unit id="AppDescription">
+        <source>Command to add file</source>
+        <target state="new">Command to add file</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppFullName">
+        <source>Add a file to the project.</source>
+        <target state="new">Add a file to the project.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdFrameworkDescription">
+        <source>Add the reference only when targeting a specific framework.</source>
+        <target state="new">Add the reference only when targeting a specific framework.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilePathArgumentDescription">
+        <source>The files to add.</source>
+        <target state="new">The files to add.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilePathArgumentName">
+        <source>FILE</source>
+        <target state="new">FILE</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Cli/dotnet/commands/dotnet-add/dotnet-add-file/xlf/LocalizableStrings.ru.xlf
+++ b/src/Cli/dotnet/commands/dotnet-add/dotnet-add-file/xlf/LocalizableStrings.ru.xlf
@@ -1,0 +1,32 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ru" original="../LocalizableStrings.resx">
+    <body>
+      <trans-unit id="AppDescription">
+        <source>Command to add file</source>
+        <target state="new">Command to add file</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppFullName">
+        <source>Add a file to the project.</source>
+        <target state="new">Add a file to the project.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdFrameworkDescription">
+        <source>Add the reference only when targeting a specific framework.</source>
+        <target state="new">Add the reference only when targeting a specific framework.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilePathArgumentDescription">
+        <source>The files to add.</source>
+        <target state="new">The files to add.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilePathArgumentName">
+        <source>FILE</source>
+        <target state="new">FILE</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Cli/dotnet/commands/dotnet-add/dotnet-add-file/xlf/LocalizableStrings.tr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-add/dotnet-add-file/xlf/LocalizableStrings.tr.xlf
@@ -1,0 +1,32 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="tr" original="../LocalizableStrings.resx">
+    <body>
+      <trans-unit id="AppDescription">
+        <source>Command to add file</source>
+        <target state="new">Command to add file</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppFullName">
+        <source>Add a file to the project.</source>
+        <target state="new">Add a file to the project.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdFrameworkDescription">
+        <source>Add the reference only when targeting a specific framework.</source>
+        <target state="new">Add the reference only when targeting a specific framework.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilePathArgumentDescription">
+        <source>The files to add.</source>
+        <target state="new">The files to add.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilePathArgumentName">
+        <source>FILE</source>
+        <target state="new">FILE</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Cli/dotnet/commands/dotnet-add/dotnet-add-file/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/commands/dotnet-add/dotnet-add-file/xlf/LocalizableStrings.zh-Hans.xlf
@@ -1,0 +1,32 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="zh-Hans" original="../LocalizableStrings.resx">
+    <body>
+      <trans-unit id="AppDescription">
+        <source>Command to add file</source>
+        <target state="new">Command to add file</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppFullName">
+        <source>Add a file to the project.</source>
+        <target state="new">Add a file to the project.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdFrameworkDescription">
+        <source>Add the reference only when targeting a specific framework.</source>
+        <target state="new">Add the reference only when targeting a specific framework.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilePathArgumentDescription">
+        <source>The files to add.</source>
+        <target state="new">The files to add.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilePathArgumentName">
+        <source>FILE</source>
+        <target state="new">FILE</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Cli/dotnet/commands/dotnet-add/dotnet-add-file/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/commands/dotnet-add/dotnet-add-file/xlf/LocalizableStrings.zh-Hant.xlf
@@ -1,0 +1,32 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="zh-Hant" original="../LocalizableStrings.resx">
+    <body>
+      <trans-unit id="AppDescription">
+        <source>Command to add file</source>
+        <target state="new">Command to add file</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppFullName">
+        <source>Add a file to the project.</source>
+        <target state="new">Add a file to the project.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdFrameworkDescription">
+        <source>Add the reference only when targeting a specific framework.</source>
+        <target state="new">Add the reference only when targeting a specific framework.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilePathArgumentDescription">
+        <source>The files to add.</source>
+        <target state="new">The files to add.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilePathArgumentName">
+        <source>FILE</source>
+        <target state="new">FILE</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Cli/dotnet/dotnet.csproj
+++ b/src/Cli/dotnet/dotnet.csproj
@@ -23,6 +23,7 @@
     <EmbeddedResource Update="CommandFactory\*.resx" Namespace="Microsoft.DotNet.CommandFactory" />
     <EmbeddedResource Update="**\dotnet-add-package\*.resx" Namespace="Microsoft.DotNet.Tools.Add.PackageReference" />
     <EmbeddedResource Update="**\dotnet-add-reference\*.resx" Namespace="Microsoft.DotNet.Tools.Add.ProjectToProjectReference" />
+    <EmbeddedResource Update="**\dotnet-add-file\*.resx" Namespace="Microsoft.DotNet.Tools.Add.FileReference" />
     <EmbeddedResource Update="**\dotnet-add\*.resx" Namespace="Microsoft.DotNet.Tools.Add" />
     <EmbeddedResource Update="**\dotnet-build\*.resx" Namespace="Microsoft.DotNet.Tools.Build" />
     <EmbeddedResource Update="**\dotnet-buildserver\*.resx" Namespace="Microsoft.DotNet.Tools.BuildServer" />

--- a/src/Cli/dotnet/xlf/CommonLocalizableStrings.cs.xlf
+++ b/src/Cli/dotnet/xlf/CommonLocalizableStrings.cs.xlf
@@ -12,6 +12,11 @@
         <target state="translated">V {0} se nenašel žádný projekt.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CouldNotFindFile">
+        <source>Could not find flie `{0}`.</source>
+        <target state="new">Could not find flie `{0}`.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnvironmentPathOSXBashManualInstructions">
         <source>Tools directory '{0}' is not currently on the PATH environment variable.
 If you are using bash, you can add it to your profile by running the following command:
@@ -70,9 +75,29 @@ export PATH="$PATH:{0}"
 </target>
         <note />
       </trans-unit>
+      <trans-unit id="FileAddedToTheProject">
+        <source>File `{0}` added to the project.</source>
+        <target state="new">File `{0}` added to the project.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileReferenceCouldNotBeFound">
+        <source>File reference `{0}` could not be found.</source>
+        <target state="new">File reference `{0}` could not be found.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileRemoved">
+        <source>File `{0}` removed.</source>
+        <target state="new">File `{0}` removed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MoreThanOneProjectInDirectory">
         <source>Found more than one project in `{0}`. Specify which one to use.</source>
         <target state="translated">V {0} se našlo několik projektů. Vyberte, který z nich chcete použít.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectAlreadyHasAfile">
+        <source>Project already has a file `{0}`.</source>
+        <target state="new">Project already has a file `{0}`.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectAlreadyHasAreference">

--- a/src/Cli/dotnet/xlf/CommonLocalizableStrings.de.xlf
+++ b/src/Cli/dotnet/xlf/CommonLocalizableStrings.de.xlf
@@ -12,6 +12,11 @@
         <target state="translated">In "{0}" wurde kein Projekt gefunden.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CouldNotFindFile">
+        <source>Could not find flie `{0}`.</source>
+        <target state="new">Could not find flie `{0}`.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnvironmentPathOSXBashManualInstructions">
         <source>Tools directory '{0}' is not currently on the PATH environment variable.
 If you are using bash, you can add it to your profile by running the following command:
@@ -70,9 +75,29 @@ export PATH="$PATH:{0}"
 </target>
         <note />
       </trans-unit>
+      <trans-unit id="FileAddedToTheProject">
+        <source>File `{0}` added to the project.</source>
+        <target state="new">File `{0}` added to the project.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileReferenceCouldNotBeFound">
+        <source>File reference `{0}` could not be found.</source>
+        <target state="new">File reference `{0}` could not be found.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileRemoved">
+        <source>File `{0}` removed.</source>
+        <target state="new">File `{0}` removed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MoreThanOneProjectInDirectory">
         <source>Found more than one project in `{0}`. Specify which one to use.</source>
         <target state="translated">In "{0}" wurden mehrere Projekte gefunden. Geben Sie an, welches davon verwendet werden soll.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectAlreadyHasAfile">
+        <source>Project already has a file `{0}`.</source>
+        <target state="new">Project already has a file `{0}`.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectAlreadyHasAreference">

--- a/src/Cli/dotnet/xlf/CommonLocalizableStrings.es.xlf
+++ b/src/Cli/dotnet/xlf/CommonLocalizableStrings.es.xlf
@@ -12,6 +12,11 @@
         <target state="translated">No se encuentra ningún proyecto en "{0}".</target>
         <note />
       </trans-unit>
+      <trans-unit id="CouldNotFindFile">
+        <source>Could not find flie `{0}`.</source>
+        <target state="new">Could not find flie `{0}`.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnvironmentPathOSXBashManualInstructions">
         <source>Tools directory '{0}' is not currently on the PATH environment variable.
 If you are using bash, you can add it to your profile by running the following command:
@@ -70,9 +75,29 @@ export PATH="$PATH:{0}"
 </target>
         <note />
       </trans-unit>
+      <trans-unit id="FileAddedToTheProject">
+        <source>File `{0}` added to the project.</source>
+        <target state="new">File `{0}` added to the project.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileReferenceCouldNotBeFound">
+        <source>File reference `{0}` could not be found.</source>
+        <target state="new">File reference `{0}` could not be found.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileRemoved">
+        <source>File `{0}` removed.</source>
+        <target state="new">File `{0}` removed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MoreThanOneProjectInDirectory">
         <source>Found more than one project in `{0}`. Specify which one to use.</source>
         <target state="translated">Se han encontrado varios proyectos en "{0}". Especifique el que debe usarse.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectAlreadyHasAfile">
+        <source>Project already has a file `{0}`.</source>
+        <target state="new">Project already has a file `{0}`.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectAlreadyHasAreference">

--- a/src/Cli/dotnet/xlf/CommonLocalizableStrings.fr.xlf
+++ b/src/Cli/dotnet/xlf/CommonLocalizableStrings.fr.xlf
@@ -12,6 +12,11 @@
         <target state="translated">Projet introuvable dans '{0}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CouldNotFindFile">
+        <source>Could not find flie `{0}`.</source>
+        <target state="new">Could not find flie `{0}`.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnvironmentPathOSXBashManualInstructions">
         <source>Tools directory '{0}' is not currently on the PATH environment variable.
 If you are using bash, you can add it to your profile by running the following command:
@@ -70,9 +75,29 @@ export PATH="$PATH:{0}"
 </target>
         <note />
       </trans-unit>
+      <trans-unit id="FileAddedToTheProject">
+        <source>File `{0}` added to the project.</source>
+        <target state="new">File `{0}` added to the project.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileReferenceCouldNotBeFound">
+        <source>File reference `{0}` could not be found.</source>
+        <target state="new">File reference `{0}` could not be found.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileRemoved">
+        <source>File `{0}` removed.</source>
+        <target state="new">File `{0}` removed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MoreThanOneProjectInDirectory">
         <source>Found more than one project in `{0}`. Specify which one to use.</source>
         <target state="translated">Plusieurs projets dans '{0}'. Spécifiez celui à utiliser.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectAlreadyHasAfile">
+        <source>Project already has a file `{0}`.</source>
+        <target state="new">Project already has a file `{0}`.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectAlreadyHasAreference">

--- a/src/Cli/dotnet/xlf/CommonLocalizableStrings.it.xlf
+++ b/src/Cli/dotnet/xlf/CommonLocalizableStrings.it.xlf
@@ -12,6 +12,11 @@
         <target state="translated">Non è stato trovato alcun progetto in `{0}`.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CouldNotFindFile">
+        <source>Could not find flie `{0}`.</source>
+        <target state="new">Could not find flie `{0}`.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnvironmentPathOSXBashManualInstructions">
         <source>Tools directory '{0}' is not currently on the PATH environment variable.
 If you are using bash, you can add it to your profile by running the following command:
@@ -70,9 +75,29 @@ export PATH="$PATH:{0}"
 </target>
         <note />
       </trans-unit>
+      <trans-unit id="FileAddedToTheProject">
+        <source>File `{0}` added to the project.</source>
+        <target state="new">File `{0}` added to the project.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileReferenceCouldNotBeFound">
+        <source>File reference `{0}` could not be found.</source>
+        <target state="new">File reference `{0}` could not be found.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileRemoved">
+        <source>File `{0}` removed.</source>
+        <target state="new">File `{0}` removed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MoreThanOneProjectInDirectory">
         <source>Found more than one project in `{0}`. Specify which one to use.</source>
         <target state="translated">Sono stati trovati più progetti in `{0}`. Specificare quello da usare.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectAlreadyHasAfile">
+        <source>Project already has a file `{0}`.</source>
+        <target state="new">Project already has a file `{0}`.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectAlreadyHasAreference">

--- a/src/Cli/dotnet/xlf/CommonLocalizableStrings.ja.xlf
+++ b/src/Cli/dotnet/xlf/CommonLocalizableStrings.ja.xlf
@@ -12,6 +12,11 @@
         <target state="translated">`{0}` にプロジェクトが見つかりませんでした。</target>
         <note />
       </trans-unit>
+      <trans-unit id="CouldNotFindFile">
+        <source>Could not find flie `{0}`.</source>
+        <target state="new">Could not find flie `{0}`.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnvironmentPathOSXBashManualInstructions">
         <source>Tools directory '{0}' is not currently on the PATH environment variable.
 If you are using bash, you can add it to your profile by running the following command:
@@ -70,9 +75,29 @@ export PATH="$PATH:{0}"
 </target>
         <note />
       </trans-unit>
+      <trans-unit id="FileAddedToTheProject">
+        <source>File `{0}` added to the project.</source>
+        <target state="new">File `{0}` added to the project.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileReferenceCouldNotBeFound">
+        <source>File reference `{0}` could not be found.</source>
+        <target state="new">File reference `{0}` could not be found.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileRemoved">
+        <source>File `{0}` removed.</source>
+        <target state="new">File `{0}` removed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MoreThanOneProjectInDirectory">
         <source>Found more than one project in `{0}`. Specify which one to use.</source>
         <target state="translated">`{0}` に複数のプロジェクトが見つかりました。使用するプロジェクトを指定してください。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectAlreadyHasAfile">
+        <source>Project already has a file `{0}`.</source>
+        <target state="new">Project already has a file `{0}`.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectAlreadyHasAreference">

--- a/src/Cli/dotnet/xlf/CommonLocalizableStrings.ko.xlf
+++ b/src/Cli/dotnet/xlf/CommonLocalizableStrings.ko.xlf
@@ -12,6 +12,11 @@
         <target state="translated">'{0}'에서 프로젝트를 찾을 수 없습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CouldNotFindFile">
+        <source>Could not find flie `{0}`.</source>
+        <target state="new">Could not find flie `{0}`.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnvironmentPathOSXBashManualInstructions">
         <source>Tools directory '{0}' is not currently on the PATH environment variable.
 If you are using bash, you can add it to your profile by running the following command:
@@ -70,9 +75,29 @@ export PATH="$PATH:{0}"
 </target>
         <note />
       </trans-unit>
+      <trans-unit id="FileAddedToTheProject">
+        <source>File `{0}` added to the project.</source>
+        <target state="new">File `{0}` added to the project.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileReferenceCouldNotBeFound">
+        <source>File reference `{0}` could not be found.</source>
+        <target state="new">File reference `{0}` could not be found.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileRemoved">
+        <source>File `{0}` removed.</source>
+        <target state="new">File `{0}` removed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MoreThanOneProjectInDirectory">
         <source>Found more than one project in `{0}`. Specify which one to use.</source>
         <target state="translated">'{0}'에서 프로젝트를 두 개 이상 찾았습니다. 사용할 프로젝트를 지정하세요.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectAlreadyHasAfile">
+        <source>Project already has a file `{0}`.</source>
+        <target state="new">Project already has a file `{0}`.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectAlreadyHasAreference">

--- a/src/Cli/dotnet/xlf/CommonLocalizableStrings.pl.xlf
+++ b/src/Cli/dotnet/xlf/CommonLocalizableStrings.pl.xlf
@@ -12,6 +12,11 @@
         <target state="translated">Nie można odnaleźć żadnego projektu w lokalizacji „{0}”.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CouldNotFindFile">
+        <source>Could not find flie `{0}`.</source>
+        <target state="new">Could not find flie `{0}`.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnvironmentPathOSXBashManualInstructions">
         <source>Tools directory '{0}' is not currently on the PATH environment variable.
 If you are using bash, you can add it to your profile by running the following command:
@@ -70,9 +75,29 @@ export PATH="$PATH:{0}"
 </target>
         <note />
       </trans-unit>
+      <trans-unit id="FileAddedToTheProject">
+        <source>File `{0}` added to the project.</source>
+        <target state="new">File `{0}` added to the project.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileReferenceCouldNotBeFound">
+        <source>File reference `{0}` could not be found.</source>
+        <target state="new">File reference `{0}` could not be found.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileRemoved">
+        <source>File `{0}` removed.</source>
+        <target state="new">File `{0}` removed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MoreThanOneProjectInDirectory">
         <source>Found more than one project in `{0}`. Specify which one to use.</source>
         <target state="translated">Znaleziono więcej niż jeden projekt w lokalizacji „{0}”. Określ, który ma zostać użyty.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectAlreadyHasAfile">
+        <source>Project already has a file `{0}`.</source>
+        <target state="new">Project already has a file `{0}`.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectAlreadyHasAreference">

--- a/src/Cli/dotnet/xlf/CommonLocalizableStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/xlf/CommonLocalizableStrings.pt-BR.xlf
@@ -12,6 +12,11 @@
         <target state="translated">Não foi possível encontrar nenhum projeto em ‘{0}’.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CouldNotFindFile">
+        <source>Could not find flie `{0}`.</source>
+        <target state="new">Could not find flie `{0}`.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnvironmentPathOSXBashManualInstructions">
         <source>Tools directory '{0}' is not currently on the PATH environment variable.
 If you are using bash, you can add it to your profile by running the following command:
@@ -70,9 +75,29 @@ export PATH="$PATH:{0}"
 </target>
         <note />
       </trans-unit>
+      <trans-unit id="FileAddedToTheProject">
+        <source>File `{0}` added to the project.</source>
+        <target state="new">File `{0}` added to the project.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileReferenceCouldNotBeFound">
+        <source>File reference `{0}` could not be found.</source>
+        <target state="new">File reference `{0}` could not be found.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileRemoved">
+        <source>File `{0}` removed.</source>
+        <target state="new">File `{0}` removed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MoreThanOneProjectInDirectory">
         <source>Found more than one project in `{0}`. Specify which one to use.</source>
         <target state="translated">Foi encontrado mais de um projeto em ‘{0}’. Especifique qual deve ser usado.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectAlreadyHasAfile">
+        <source>Project already has a file `{0}`.</source>
+        <target state="new">Project already has a file `{0}`.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectAlreadyHasAreference">

--- a/src/Cli/dotnet/xlf/CommonLocalizableStrings.ru.xlf
+++ b/src/Cli/dotnet/xlf/CommonLocalizableStrings.ru.xlf
@@ -12,6 +12,11 @@
         <target state="translated">Не удалось найти проекты в "{0}".</target>
         <note />
       </trans-unit>
+      <trans-unit id="CouldNotFindFile">
+        <source>Could not find flie `{0}`.</source>
+        <target state="new">Could not find flie `{0}`.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnvironmentPathOSXBashManualInstructions">
         <source>Tools directory '{0}' is not currently on the PATH environment variable.
 If you are using bash, you can add it to your profile by running the following command:
@@ -70,9 +75,29 @@ export PATH="$PATH:{0}"
 </target>
         <note />
       </trans-unit>
+      <trans-unit id="FileAddedToTheProject">
+        <source>File `{0}` added to the project.</source>
+        <target state="new">File `{0}` added to the project.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileReferenceCouldNotBeFound">
+        <source>File reference `{0}` could not be found.</source>
+        <target state="new">File reference `{0}` could not be found.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileRemoved">
+        <source>File `{0}` removed.</source>
+        <target state="new">File `{0}` removed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MoreThanOneProjectInDirectory">
         <source>Found more than one project in `{0}`. Specify which one to use.</source>
         <target state="translated">Найдено несколько проектов в "{0}". Выберите один.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectAlreadyHasAfile">
+        <source>Project already has a file `{0}`.</source>
+        <target state="new">Project already has a file `{0}`.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectAlreadyHasAreference">

--- a/src/Cli/dotnet/xlf/CommonLocalizableStrings.tr.xlf
+++ b/src/Cli/dotnet/xlf/CommonLocalizableStrings.tr.xlf
@@ -12,6 +12,11 @@
         <target state="translated">`{0}` içinde proje bulunamadı.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CouldNotFindFile">
+        <source>Could not find flie `{0}`.</source>
+        <target state="new">Could not find flie `{0}`.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnvironmentPathOSXBashManualInstructions">
         <source>Tools directory '{0}' is not currently on the PATH environment variable.
 If you are using bash, you can add it to your profile by running the following command:
@@ -70,9 +75,29 @@ export PATH="$PATH:{0}"
 </target>
         <note />
       </trans-unit>
+      <trans-unit id="FileAddedToTheProject">
+        <source>File `{0}` added to the project.</source>
+        <target state="new">File `{0}` added to the project.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileReferenceCouldNotBeFound">
+        <source>File reference `{0}` could not be found.</source>
+        <target state="new">File reference `{0}` could not be found.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileRemoved">
+        <source>File `{0}` removed.</source>
+        <target state="new">File `{0}` removed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MoreThanOneProjectInDirectory">
         <source>Found more than one project in `{0}`. Specify which one to use.</source>
         <target state="translated">`{0}` içinde birden fazla proje bulundu. Hangisinin kullanılacağını belirtin.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectAlreadyHasAfile">
+        <source>Project already has a file `{0}`.</source>
+        <target state="new">Project already has a file `{0}`.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectAlreadyHasAreference">

--- a/src/Cli/dotnet/xlf/CommonLocalizableStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/xlf/CommonLocalizableStrings.zh-Hans.xlf
@@ -12,6 +12,11 @@
         <target state="translated">“{0}”中找不到任何项目。</target>
         <note />
       </trans-unit>
+      <trans-unit id="CouldNotFindFile">
+        <source>Could not find flie `{0}`.</source>
+        <target state="new">Could not find flie `{0}`.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnvironmentPathOSXBashManualInstructions">
         <source>Tools directory '{0}' is not currently on the PATH environment variable.
 If you are using bash, you can add it to your profile by running the following command:
@@ -70,9 +75,29 @@ EOF
 </target>
         <note />
       </trans-unit>
+      <trans-unit id="FileAddedToTheProject">
+        <source>File `{0}` added to the project.</source>
+        <target state="new">File `{0}` added to the project.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileReferenceCouldNotBeFound">
+        <source>File reference `{0}` could not be found.</source>
+        <target state="new">File reference `{0}` could not be found.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileRemoved">
+        <source>File `{0}` removed.</source>
+        <target state="new">File `{0}` removed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MoreThanOneProjectInDirectory">
         <source>Found more than one project in `{0}`. Specify which one to use.</source>
         <target state="translated">在“{0}”中找到多个项目。请指定使用哪一个。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectAlreadyHasAfile">
+        <source>Project already has a file `{0}`.</source>
+        <target state="new">Project already has a file `{0}`.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectAlreadyHasAreference">

--- a/src/Cli/dotnet/xlf/CommonLocalizableStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/xlf/CommonLocalizableStrings.zh-Hant.xlf
@@ -12,6 +12,11 @@
         <target state="translated">在 `{0}` 中找不到任何專案。</target>
         <note />
       </trans-unit>
+      <trans-unit id="CouldNotFindFile">
+        <source>Could not find flie `{0}`.</source>
+        <target state="new">Could not find flie `{0}`.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnvironmentPathOSXBashManualInstructions">
         <source>Tools directory '{0}' is not currently on the PATH environment variable.
 If you are using bash, you can add it to your profile by running the following command:
@@ -70,9 +75,29 @@ export PATH="$PATH:{0}"
 </target>
         <note />
       </trans-unit>
+      <trans-unit id="FileAddedToTheProject">
+        <source>File `{0}` added to the project.</source>
+        <target state="new">File `{0}` added to the project.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileReferenceCouldNotBeFound">
+        <source>File reference `{0}` could not be found.</source>
+        <target state="new">File reference `{0}` could not be found.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileRemoved">
+        <source>File `{0}` removed.</source>
+        <target state="new">File `{0}` removed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MoreThanOneProjectInDirectory">
         <source>Found more than one project in `{0}`. Specify which one to use.</source>
         <target state="translated">在 `{0}` 中找到多個專案。請指定要使用的專案。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectAlreadyHasAfile">
+        <source>Project already has a file `{0}`.</source>
+        <target state="new">Project already has a file `{0}`.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectAlreadyHasAreference">


### PR DESCRIPTION
This is more a proof of concept and a start of discussion rather than complete implementation. So... as in title - it extends current `dotnet CLI` with `dotnet add file`. 

This feature is probably mostly useful for F# developers - in C# users can use globbing, but in F# order of files in project matters - so we specify every `.fs` file separately in the project file. Having this feature will be also great for better editor integration - VSCode (with Ionide) is used by a huge part of the F# community and we provide "solution explorer" view in the editor but we need good commands to add files and/or move the up-down (again the order of files matters) - we currently provide that functionality using a custom utility (https://github.com/ionide/Forge) but... well, let's just say it's not my best work ever. 

So there's a couple of things to discuss here:
 - would you be open to having such a feature?
 - how to determine default location of the file (probably on top of the group, current implementation adds it adds the bottom)
 - should it have something like `--above` and `--below` options that would allow specifying a location of the file (it's a common scenario to say "I want to add helpers.fs above my_test.fs")
 - should it allow not only adding but also moving files (changing the order of files and moving files up/down) is another common scenario during the development of F# projects

CC: @cartermp 

P.S. the changes include all generated translation files, please let me know if they shouldn't be included in PR - there's no contribution guide in the repo that would specify such details ;-)

P.S.2

Even tho, it's proof of concept it actually works ✨

![image](https://user-images.githubusercontent.com/5427083/80763560-1503ea00-8b3f-11ea-80fd-4ccac25659e5.png)
