### PR TITLE
[release/5.0.1xx-preview4] Single-File: Pass TFM Version to the Bundler

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/GenerateBundle.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/GenerateBundle.cs
@@ -19,12 +19,14 @@ namespace Microsoft.NET.Build.Tasks
         [Required]
         public string OutputDir { get; set; }
         [Required]
+        public string TargetFrameworkVersion { get; set; }
+        [Required]
         public bool ShowDiagnosticOutput { get; set; }
 
         protected override void ExecuteCore()
         {
             BundleOptions options = BundleOptions.BundleAllContent | (IncludeSymbols ? BundleOptions.BundleSymbolFiles : BundleOptions.None);
-            var bundler = new Bundler(AppHostName, OutputDir, options, diagnosticOutput: ShowDiagnosticOutput);
+            var bundler = new Bundler(AppHostName, OutputDir, options, targetFrameworkVersion: new Version(TargetFrameworkVersion), diagnosticOutput: ShowDiagnosticOutput);
             var fileSpec = new List<FileSpec>(FilesToBundle.Length);
 
             foreach (var item in FilesToBundle)

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -963,6 +963,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                     AppHostName="$(PublishedSingleFileName)"
                     IncludeSymbols="$(IncludeSymbolsInSingleFile)"
                     OutputDir="$(PublishDir)"
+                    TargetFrameworkVersion="$(_TargetFrameworkVersionWithoutV)"
                     ShowDiagnosticOutput="false"/>
 
   </Target>


### PR DESCRIPTION
## Customer Scenario
A netcoreapp3.0 single file app published from .net5 SDK doesn't run.

## Problem
The netcoreapp3.0 apphost encounters the wrong version of the bundle header when trying to extract the bundle.

## Solution
Pass the TFM version argument to the bundler in GenrateBundle task.

## Risk
Very Low.

## Testing 

Manually tested the SDK by inserting apphost, hostfxr, hostpolicy, and hostmodel library from https://github.com/dotnet/runtime/pull/35679 into the `dotnet/packs` from this build.

Verified that netcoreapp3,0 apps published from this SDK run OK on Windows, Linux, Osx.
Verified that cross-targetting builds of such apps also work OK.