### PR TITLE
Stop adding PublishDepsFilePath twice to publish

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.PackTool.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.PackTool.targets
@@ -33,7 +33,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <Target Name="PackTool" DependsOnTargets="GenerateToolsSettingsFileFromBuildProperty;$(_PackToolPublishDependency);_PackToolValidation" Condition=" '$(PackAsTool)' == 'true' ">
     <ItemGroup>
-      <_GeneratedFiles Include="$(PublishDepsFilePath)"/>
+      <_GeneratedFiles Include="$(PublishDepsFilePath)" Condition="'$(GenerateDependencyFile)' != 'true' or '$(_UseBuildDependencyFile)' == 'true'" />
       <_GeneratedFiles Include="$(PublishRuntimeConfigFilePath)"/>
       <_GeneratedFiles Include="$(_ToolsSettingsFilePath)"/>
     </ItemGroup>


### PR DESCRIPTION
Fixes https://github.com/dotnet/sdk/issues/11521

I'm likely merging this after CI is green to unblock P4 and Arcade SDK progress.

cc @dougbu @dsplaisted 