### PR TITLE
Add the frameworkName property to runtimepack libraries

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/DependencyContextBuilder.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/DependencyContextBuilder.cs
@@ -488,16 +488,22 @@ namespace Microsoft.NET.Build.Tasks
                     runtimePack.Value.Where(asset => asset.AssetType == AssetType.Native)
                     .Select(asset => CreateRuntimeFile(asset.DestinationSubPath, asset.SourcePath)));
 
+                var assetInfo = runtimePack.Value.First();
+
                 return new RuntimeLibrary(
                     type: "runtimepack",
                     name: runtimePack.Key,
-                    version: runtimePack.Value.First().PackageVersion,
+                    version: assetInfo.PackageVersion,
                     hash: string.Empty,
                     runtimeAssemblyGroups: new[] { runtimeAssemblyGroup },
                     nativeLibraryGroups: new[] { nativeLibraryGroup },
                     resourceAssemblies: Enumerable.Empty<ResourceAssembly>(),
                     dependencies: Enumerable.Empty<Dependency>(),
-                    serviceable: false);
+                    serviceable: false,
+                    path: null,
+                    hashPath: null,
+                    runtimeStoreManifestName: null,
+                    frameworkName: assetInfo.FrameworkName);
             });
         }
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolveRuntimePackAssets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveRuntimePackAssets.cs
@@ -46,7 +46,8 @@ namespace Microsoft.NET.Build.Tasks
 
             foreach (var runtimePack in ResolvedRuntimePacks)
             {
-                if (!frameworkReferenceNames.Contains(runtimePack.GetMetadata(MetadataKeys.FrameworkName)))
+                var runtimePackFrameworkName = runtimePack.GetMetadata(MetadataKeys.FrameworkName);
+                if (!frameworkReferenceNames.Contains(runtimePackFrameworkName))
                 {
                     //  This is a runtime pack for a shared framework that ultimately wasn't referenced, so don't include its assets
                     continue;
@@ -78,7 +79,7 @@ namespace Microsoft.NET.Build.Tasks
 
                 if (File.Exists(runtimeListPath))
                 {
-                    AddRuntimePackAssetsFromManifest(runtimePackAssets, runtimePackRoot, runtimeListPath, runtimePack);
+                    AddRuntimePackAssetsFromManifest(runtimePackAssets, runtimePackRoot, runtimeListPath, runtimePack, runtimePackFrameworkName);
                 }
                 else
                 {
@@ -90,7 +91,7 @@ namespace Microsoft.NET.Build.Tasks
         }
 
         private void AddRuntimePackAssetsFromManifest(List<ITaskItem> runtimePackAssets, string runtimePackRoot,
-            string runtimeListPath, ITaskItem runtimePack)
+            string runtimeListPath, ITaskItem runtimePack, string runtimePackFrameworkName)
         {
             var assetSubPaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
@@ -130,7 +131,7 @@ namespace Microsoft.NET.Build.Tasks
                     throw new BuildErrorException($"Unrecognized file type '{typeAttributeValue}' in {runtimeListPath}");
                 }
 
-                var assetItem = CreateAssetItem(assetPath, assetType, runtimePack, culture);
+                var assetItem = CreateAssetItem(assetPath, assetType, runtimePack, culture, runtimePackFrameworkName);
 
                 // Ensure the asset item's destination sub-path is unique
                 var assetSubPath = assetItem.GetMetadata(MetadataKeys.DestinationSubPath);
@@ -148,7 +149,7 @@ namespace Microsoft.NET.Build.Tasks
             }
         }
 
-        private static TaskItem CreateAssetItem(string assetPath, string assetType, ITaskItem runtimePack, string culture)
+        private static TaskItem CreateAssetItem(string assetPath, string assetType, ITaskItem runtimePack, string culture, string runtimePackFrameworkName)
         {
             string runtimeIdentifier = runtimePack.GetMetadata(MetadataKeys.RuntimeIdentifier);
 
@@ -171,6 +172,7 @@ namespace Microsoft.NET.Build.Tasks
             assetItem.SetMetadata(MetadataKeys.NuGetPackageVersion, runtimePack.GetMetadata(MetadataKeys.NuGetPackageVersion));
             assetItem.SetMetadata(MetadataKeys.RuntimeIdentifier, runtimeIdentifier);
             assetItem.SetMetadata(MetadataKeys.IsTrimmable, runtimePack.GetMetadata(MetadataKeys.IsTrimmable));
+            assetItem.SetMetadata(MetadataKeys.FrameworkName, runtimePackFrameworkName);
 
             return assetItem;
         }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/RuntimePackAssetInfo.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/RuntimePackAssetInfo.cs
@@ -20,6 +20,8 @@ namespace Microsoft.NET.Build.Tasks
 
         public string PackageRuntimeIdentifier { get; set; }
 
+        public string FrameworkName { get; set; }
+
         public static RuntimePackAssetInfo FromItem(ITaskItem item)
         {
             var assetInfo = new RuntimePackAssetInfo();
@@ -47,6 +49,7 @@ namespace Microsoft.NET.Build.Tasks
             assetInfo.PackageName = item.GetMetadata(MetadataKeys.NuGetPackageId);
             assetInfo.PackageVersion = item.GetMetadata(MetadataKeys.NuGetPackageVersion);
             assetInfo.PackageRuntimeIdentifier = item.GetMetadata(MetadataKeys.RuntimeIdentifier);
+            assetInfo.FrameworkName = item.GetMetadata(MetadataKeys.FrameworkName);
 
             return assetInfo;
         }

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishASelfContainedApp.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishASelfContainedApp.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using FluentAssertions;
+using Microsoft.Extensions.DependencyModel;
 using Microsoft.NET.Build.Tasks;
 using Microsoft.NET.TestFramework;
 using Microsoft.NET.TestFramework.Assertions;
@@ -196,6 +197,13 @@ namespace Microsoft.NET.Publish.Tests
                 "zh-Hans/PresentationCore.resources.dll",
                 "zh-Hant/PresentationCore.resources.dll",
             });
+
+            using (var depsJsonFileStream = File.OpenRead(Path.Combine(output.FullName, $"{testProject.Name}.deps.json")))
+            {
+                var dependencyContext = new DependencyContextJsonReader().Read(depsJsonFileStream);
+                dependencyContext.Should()
+                    .OnlyHaveRuntimePacksWithFrameworkNameProperties();
+            }
         }
 
         [WindowsOnlyFact]

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishASelfContainedApp.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishASelfContainedApp.cs
@@ -201,7 +201,10 @@ namespace Microsoft.NET.Publish.Tests
             using (var depsJsonFileStream = File.OpenRead(Path.Combine(output.FullName, $"{testProject.Name}.deps.json")))
             {
                 var dependencyContext = new DependencyContextJsonReader().Read(depsJsonFileStream);
-                dependencyContext.Should()
+                dependencyContext
+                    .Should()
+                    .HaveRuntimePacks()
+                    .And
                     .OnlyHaveRuntimePacksWithFrameworkNameProperties();
             }
         }

--- a/src/Tests/Microsoft.NET.TestFramework/Assertions/DependencyContextAssertions.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/Assertions/DependencyContextAssertions.cs
@@ -39,6 +39,16 @@ namespace Microsoft.NET.TestFramework.Assertions
             return new AndConstraint<DependencyContextAssertions>(this);
         }
 
+        public AndConstraint<DependencyContextAssertions> HaveRuntimePacks()
+        {
+            var runtimePacks = _dependencyContext.RuntimeLibraries
+                .Where(l => string.Equals(l.Type, "runtimepack", StringComparison.OrdinalIgnoreCase));
+
+            runtimePacks.Should().NotBeEmpty();
+
+            return new AndConstraint<DependencyContextAssertions>(this);
+        }
+
         public AndConstraint<DependencyContextAssertions> OnlyHaveRuntimeAssemblies(string runtimeIdentifier, params string[] runtimeAssemblyNames)
         {
             var assemblyNames = _dependencyContext.GetRuntimeAssemblyNames(runtimeIdentifier);

--- a/src/Tests/Microsoft.NET.TestFramework/Assertions/DependencyContextAssertions.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/Assertions/DependencyContextAssertions.cs
@@ -98,5 +98,18 @@ namespace Microsoft.NET.TestFramework.Assertions
 
             return new AndConstraint<DependencyContextAssertions>(this);
         }
+
+        public AndConstraint<DependencyContextAssertions> OnlyHaveRuntimePacksWithFrameworkNameProperties()
+        {
+            var runtimePacks = _dependencyContext.RuntimeLibraries
+                .Where(l => string.Equals(l.Type, "runtimepack", StringComparison.OrdinalIgnoreCase));
+
+            foreach (var runtimePack in runtimePacks)
+            {
+                runtimePack.FrameworkName.Should().NotBeNullOrEmpty($"Every RuntimeLibrary with Type='runtimepack' should have a FrameworkName, but {runtimePack.Name} does not.");
+            }
+
+            return new AndConstraint<DependencyContextAssertions>(this);
+        }
     }
 }


### PR DESCRIPTION
This is the dotnet/sdk part of https://github.com/dotnet/sdk/issues/3339. It is dependent on the dotnet/runtime part from https://github.com/dotnet/runtime/pull/35764.