### PR TITLE
Single-File: Update Bundler Invocation.

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/GenerateBundle.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/GenerateBundle.cs
@@ -33,7 +33,7 @@ namespace Microsoft.NET.Build.Tasks
         protected override void ExecuteCore()
         {
             OSPlatform targetOS = RuntimeIdentifier.StartsWith("win") ? OSPlatform.Windows :
-                RuntimeIdentifier.StartsWith("osx") ? OSPlatform.OSX : OSPlatform.Linux;
+                                  RuntimeIdentifier.StartsWith("osx") ? OSPlatform.OSX : OSPlatform.Linux;
 
             BundleOptions options = BundleOptions.BundleAllContent;
             options |= IncludeSymbols ? BundleOptions.BundleSymbolFiles : BundleOptions.None;

--- a/src/Tasks/Microsoft.NET.Build.Tasks/GenerateBundle.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/GenerateBundle.cs
@@ -19,10 +19,6 @@ namespace Microsoft.NET.Build.Tasks
         [Required]
         public bool IncludeSymbols { get; set; }
         [Required]
-        public bool IncludeNativeLibraries { get; set; }
-        [Required]
-        public bool IncludeAllContent { get; set; }
-        [Required]
         public string TargetFrameworkVersion { get; set; }
         [Required]
         public string RuntimeIdentifier { get; set; }
@@ -38,12 +34,6 @@ namespace Microsoft.NET.Build.Tasks
         {
             OSPlatform targetOS = RuntimeIdentifier.StartsWith("win") ? OSPlatform.Windows :
                 RuntimeIdentifier.StartsWith("osx") ? OSPlatform.OSX : OSPlatform.Linux;
-
-            // The default option is temporarily set to BundleOptions.BundleAllContent, which bundles and extracts all published files.
-            // Once the runtime can load assemblies directly from bundle, bundle options should be computed as:
-            //   BundleOptions options = BundleOptions.None;
-            //   options |= IncludeNativeLibraries ? BundleOptions.BundleNativeBinaries : BundleOptions.None;
-            //   options |= IncludeAllContent ? BundleOptions.BundleAllContent : BundleOptions.None;
 
             BundleOptions options = BundleOptions.BundleAllContent;
             options |= IncludeSymbols ? BundleOptions.BundleSymbolFiles : BundleOptions.None;

--- a/src/Tasks/Microsoft.NET.Build.Tasks/GenerateBundle.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/GenerateBundle.cs
@@ -5,6 +5,8 @@ using Microsoft.Build.Framework;
 using Microsoft.NET.HostModel.Bundle;
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
 
 namespace Microsoft.NET.Build.Tasks
 {
@@ -17,14 +19,37 @@ namespace Microsoft.NET.Build.Tasks
         [Required]
         public bool IncludeSymbols { get; set; }
         [Required]
+        public bool IncludeNativeLibraries { get; set; }
+        [Required]
+        public bool IncludeAllContent { get; set; }
+        [Required]
+        public string TargetFrameworkVersion { get; set; }
+        [Required]
+        public string RuntimeIdentifier { get; set; }
+        [Required]
         public string OutputDir { get; set; }
         [Required]
         public bool ShowDiagnosticOutput { get; set; }
 
+        [Output]
+        public ITaskItem[] ExcludedFiles { get; set; }
+
         protected override void ExecuteCore()
         {
-            BundleOptions options = BundleOptions.BundleAllContent | (IncludeSymbols ? BundleOptions.BundleSymbolFiles : BundleOptions.None);
-            var bundler = new Bundler(AppHostName, OutputDir, options, diagnosticOutput: ShowDiagnosticOutput);
+            OSPlatform targetOS = RuntimeIdentifier.StartsWith("win") ? OSPlatform.Windows :
+                RuntimeIdentifier.StartsWith("osx") ? OSPlatform.OSX : OSPlatform.Linux;
+
+            // The default option is temporarily set to BundleOptions.BundleAllContent, which bundles and extracts all published files.
+            // Once the runtime can load assemblies directly from bundle, bundle options should be computed as:
+            //   BundleOptions options = BundleOptions.None;
+            //   options |= IncludeNativeLibraries ? BundleOptions.BundleNativeBinaries : BundleOptions.None;
+            //   options |= IncludeAllContent ? BundleOptions.BundleAllContent : BundleOptions.None;
+
+            BundleOptions options = BundleOptions.BundleAllContent;
+            options |= IncludeSymbols ? BundleOptions.BundleSymbolFiles : BundleOptions.None;
+
+            var bundler = new Bundler(AppHostName, OutputDir, options, targetOS, new Version(TargetFrameworkVersion), ShowDiagnosticOutput);
+
             var fileSpec = new List<FileSpec>(FilesToBundle.Length);
 
             foreach (var item in FilesToBundle)
@@ -34,6 +59,14 @@ namespace Microsoft.NET.Build.Tasks
             }
 
             bundler.GenerateBundle(fileSpec);
+
+            // Certain files are excluded from the bundle, based on BundleOptions.
+            // For example:
+            //    Native files and contents files are excluded by default.
+            //    hostfxr and hostpolicy are excluded until singlefilehost is available.
+            // Return the set of excluded files in ExcludedFiles, so that they can be placed in the publish directory.
+
+            ExcludedFiles = FilesToBundle.Zip(fileSpec, (item, spec) => (spec.Excluded) ? item : null).Where(x => x != null).ToArray();
         }
     }
 }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -947,9 +947,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <ItemGroup>
       <ResolvedFileToPublish Remove="@(_FilesToBundle)"/>
-      <!-- ResolvedFileToPublish shouldn't include PublishedSingleFilePath, since the single-file bundle is written directly to the publish directory -->
     </ItemGroup>
-
   </Target>
 
   <UsingTask TaskName="GenerateBundle" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
@@ -959,12 +957,30 @@ Copyright (c) .NET Foundation. All rights reserved.
           Inputs="@(_FilesToBundle)"
           Outputs="$(PublishedSingleFilePath)">
 
+    <PropertyGroup>
+      <TraceSingleFileBundler Condition="'$(TraceSingleFileBundler)' == ''">false</TraceSingleFileBundler>
+      <IncludeSymbolsInSingleFile Condition="'$(IncludeSymbolsInSingleFile)' == ''">false</IncludeSymbolsInSingleFile>
+      <IncludeNativeLibrariesInSingleFile Condition="'$(IncludeNativeLibrariesInSingleFile)' == ''">false</IncludeNativeLibrariesInSingleFile>
+      <IncludeAllContentInSingleFile Condition="'$(IncludeAllContentInSingleFile)' == ''">false</IncludeAllContentInSingleFile>
+    </PropertyGroup>    
+
     <GenerateBundle FilesToBundle="@(_FilesToBundle)"
                     AppHostName="$(PublishedSingleFileName)"
                     IncludeSymbols="$(IncludeSymbolsInSingleFile)"
+                    IncludeNativeLibraries="$(IncludeNativeLibrariesInSingleFile)"
+                    IncludeAllContent="$(IncludeAllContentInSingleFile)"
+                    TargetFrameworkVersion="$(_TargetFrameworkVersionWithoutV)"
+                    RuntimeIdentifier="$(RuntimeIdentifier)"
                     OutputDir="$(PublishDir)"
-                    ShowDiagnosticOutput="false"/>
-
+                    ShowDiagnosticOutput="$(TraceSingleFileBundler)">
+      <Output TaskParameter="ExcludedFiles" ItemName="_FilesExcludedFromBundle"/>
+    </GenerateBundle>
+  
+    <ItemGroup>
+      <ResolvedFileToPublish Include="@(_FilesExcludedFromBundle)"/>
+      <!-- ResolvedFileToPublish shouldn't include PublishedSingleFilePath, since the single-file bundle is written directly to the publish directory -->
+    </ItemGroup>  
+  
   </Target>
 
   <!--

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -960,8 +960,6 @@ Copyright (c) .NET Foundation. All rights reserved.
     <PropertyGroup>
       <TraceSingleFileBundler Condition="'$(TraceSingleFileBundler)' == ''">false</TraceSingleFileBundler>
       <IncludeSymbolsInSingleFile Condition="'$(IncludeSymbolsInSingleFile)' == ''">false</IncludeSymbolsInSingleFile>
-      <IncludeNativeLibrariesInSingleFile Condition="'$(IncludeNativeLibrariesInSingleFile)' == ''">false</IncludeNativeLibrariesInSingleFile>
-      <IncludeAllContentInSingleFile Condition="'$(IncludeAllContentInSingleFile)' == ''">false</IncludeAllContentInSingleFile>
     </PropertyGroup>    
 
     <GenerateBundle FilesToBundle="@(_FilesToBundle)"

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -967,8 +967,6 @@ Copyright (c) .NET Foundation. All rights reserved.
     <GenerateBundle FilesToBundle="@(_FilesToBundle)"
                     AppHostName="$(PublishedSingleFileName)"
                     IncludeSymbols="$(IncludeSymbolsInSingleFile)"
-                    IncludeNativeLibraries="$(IncludeNativeLibrariesInSingleFile)"
-                    IncludeAllContent="$(IncludeAllContentInSingleFile)"
                     TargetFrameworkVersion="$(_TargetFrameworkVersionWithoutV)"
                     RuntimeIdentifier="$(RuntimeIdentifier)"
                     OutputDir="$(PublishDir)"

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishASingleFileApp.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishASingleFileApp.cs
@@ -355,14 +355,8 @@ namespace Microsoft.NET.Publish.Tests
         }
 
         //  Core MSBuild only due to https://github.com/dotnet/sdk/issues/4244
-        [CoreMSBuildOnlyTheory]
-        [InlineData("netcoreapp3.0", false)]
-        [InlineData("netcoreapp3.0", true)]
-        [InlineData("netcoreapp3.1", false)]
-        [InlineData("netcoreapp3.1", true)]
-        [InlineData("netcoreapp5.0", false)]
-        [InlineData("netcoreapp5.0", true)]
-        public void It_leaves_host_components_unbundled_when_necessary(string targetFramework, bool selfContained)
+        [CoreMSBuildOnlyFact]
+        public void It_leaves_host_components_unbundled_when_necessary()
         {
             // In.net 5, Single-file bundles are processed in the framework.
             // Therefore, in self-contained builds, hostpolicy and hostfxr DLLs cannot themselves be in the bundle.
@@ -373,11 +367,10 @@ namespace Microsoft.NET.Publish.Tests
             var testProject = new TestProject()
             {
                 Name = "SingleFileTest",
-                TargetFrameworks = targetFramework,
+                TargetFrameworks = "netcoreapp5.0",
                 IsSdkProject = true,
-                IsExe = true,
+                IsExe = true
             };
-            testProject.AdditionalProperties.Add("SelfContained", $"{selfContained}");
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
             var publishCommand = new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
@@ -386,30 +379,15 @@ namespace Microsoft.NET.Publish.Tests
                 .Should()
                 .Pass();
 
-            List<string> expectedFiles = new List<string>();
-            expectedFiles.Add($"{testProject.Name}{Constants.ExeSuffix}");
-            expectedFiles.Add($"{testProject.Name}.pdb");
+            string hostfxr = RuntimeInformation.RuntimeIdentifier.StartsWith("win") ? "hostfxr.dll" :
+                             RuntimeInformation.RuntimeIdentifier.StartsWith("osx") ? "libhostfxr.dylib" : "libhostfxr.so";
 
-            if (selfContained && targetFramework.Equals("netcoreapp5.0"))
-            {
-                if (RuntimeInformation.RuntimeIdentifier.StartsWith("win"))
-                {
-                    expectedFiles.Add("hostfxr.dll");
-                    expectedFiles.Add("hostpolicy.dll");
-                }
-                else if (RuntimeInformation.RuntimeIdentifier.StartsWith("osx"))
-                {
-                    expectedFiles.Add("libhostfxr.dylib");
-                    expectedFiles.Add("libhostpolicy.dylib");
-                }
-                else
-                {
-                    expectedFiles.Add("libhostfxr.so");
-                    expectedFiles.Add("libhostpolicy.so");
-                }
-            }
+            string hostpolicy = RuntimeInformation.RuntimeIdentifier.StartsWith("win") ? "hostpolicy.dll" :
+                                RuntimeInformation.RuntimeIdentifier.StartsWith("osx") ? "libhostpolicy.dylib" : "libhostpolicy.so";
 
-            GetPublishDirectory(publishCommand, targetFramework)
+            string[] expectedFiles = { $"{testProject.Name}{Constants.ExeSuffix}", $"{testProject.Name}.pdb", hostfxr, hostpolicy };
+
+            GetPublishDirectory(publishCommand, "netcoreapp5.0")
                 .Should()
                 .OnlyHaveFiles(expectedFiles);
         }

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishIncrementally.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishIncrementally.cs
@@ -181,10 +181,10 @@ namespace Microsoft.NET.Publish.Tests
             newCommand.WorkingDirectory = testDir.Path;
             newCommand.Execute("new", "mvc", "-n", assetName).Should().Pass();
 
-            var expectedRegularFiles = new string[] { ".dll", ".deps.json", ".runtimeconfig.json", ".Views.dll", ".Views.pdb" }
+            var expectedRegularFiles = new string[] { ".dll", ".deps.json", ".runtimeconfig.json", ".Views.dll"}
                 .Select(ending => assetName + ending);
-            var expectedSingleFiles = new string[] { ".pdb", ".exe" }.Select(ending => assetName + ending)
-                .Concat(new string[] { "appsettings.json", "appsettings.Development.json", "web.config" });
+            var expectedSingleFiles = new string[] { ".Views.pdb", ".pdb", ".exe" }.Select(ending => assetName + ending)
+                .Concat(new string[] { "hostfxr.dll", "hostpolicy.dll", "appsettings.json", "appsettings.Development.json", "web.config" });
 
             // Publish normally
             new PublishCommand(Log, Path.Combine(testDir.Path, assetName))


### PR DESCRIPTION
This change updates the SDK to:
* Pass the correct target-OS settings to the bundler
* Copy files excluded by the Bundler to the publish directory.
  * In .net 5, single-file apps will leave native binaries unbundled in the publish directory by default.
  * Since Single-file bundles are processed in the framework, hostpolicy and hostfxr DLLs cannot themselves be in the bundle (until statically linked singlefilehost is supported).