### PR TITLE
Exclude binlogs by default

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.targets
@@ -30,6 +30,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <!-- Various files that should generally always be ignored -->
     <DefaultItemExcludes>$(DefaultItemExcludes);**/*.user</DefaultItemExcludes>
+    <DefaultItemExcludes>$(DefaultItemExcludes);**/*.binlog</DefaultItemExcludes>
     <DefaultItemExcludes>$(DefaultItemExcludes);**/*.*proj</DefaultItemExcludes>
     <DefaultItemExcludes>$(DefaultItemExcludes);**/*.sln</DefaultItemExcludes>
     <DefaultItemExcludes>$(DefaultItemExcludes);**/*.vssscc</DefaultItemExcludes>


### PR DESCRIPTION
For troubleshooting purposes, it's not uncommon to run `msbuild -r` from the project 
directory to simply inspect a build more deeply. That currently results in the file being 
shown in the project sytem/IDE, which won't typically be what you wanted.