### PR TITLE
Use Environment.OSVersion on Windows and macOS.

### DIFF
--- a/src/Cli/Microsoft.DotNet.Cli.Utils/RuntimeEnvironment.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/RuntimeEnvironment.cs
@@ -53,35 +53,15 @@ namespace Microsoft.DotNet.Cli.Utils
             switch (GetOSPlatform())
             {
                 case Platform.Windows:
-                    return NativeMethods.Windows.RtlGetVersion() ?? string.Empty;
+                    return Environment.OSVersion.Version.ToString(3);
                 case Platform.Linux:
                     return GetDistroVersionId() ?? string.Empty;
                 case Platform.Darwin:
-                    return GetDarwinVersion() ?? string.Empty;
+                    return Environment.OSVersion.Version.ToString(2);
                 case Platform.FreeBSD:
                     return GetFreeBSDVersion() ?? string.Empty;
                 default:
                     return string.Empty;
-            }
-        }
-
-        private static string GetDarwinVersion()
-        {
-            Version version;
-            var kernelRelease = NativeMethods.Darwin.GetKernelRelease();
-            if (!Version.TryParse(kernelRelease, out version) || version.Major < 5)
-            {
-                // 10.0 covers all versions prior to Darwin 5
-                // Similarly, if the version is not a valid version number, but we have still detected that it is Darwin, we just assume
-                // it is OS X 10.0
-                return "10.0";
-            }
-            else
-            {
-                // Mac OS X 10.1 mapped to Darwin 5.x, and the mapping continues that way
-                // So just subtract 4 from the Darwin version.
-                // https://en.wikipedia.org/wiki/Darwin_%28operating_system%29
-                return $"10.{version.Major - 4}";
             }
         }
 
@@ -205,86 +185,6 @@ namespace Microsoft.DotNet.Cli.Utils
             }
 
             return Platform.Unknown;
-        }
-
-        private static class NativeMethods
-        {
-            public static class Darwin
-            {
-                private const int CTL_KERN = 1;
-                private const int KERN_OSRELEASE = 2;
-
-                public unsafe static string GetKernelRelease()
-                {
-                    const uint BUFFER_LENGTH = 32;
-
-                    var name = stackalloc int[2];
-                    name[0] = CTL_KERN;
-                    name[1] = KERN_OSRELEASE;
-
-                    var buf = stackalloc byte[(int)BUFFER_LENGTH];
-                    var len = stackalloc uint[1];
-                    *len = BUFFER_LENGTH;
-
-                    try
-                    {
-                        // If the buffer isn't big enough, it seems sysctl still returns 0 and just sets len to the
-                        // necessary buffer size. This appears to be contrary to the man page, but it's easy to detect
-                        // by simply checking len against the buffer length.
-                        if (sysctl(name, 2, buf, len, IntPtr.Zero, 0) == 0 && *len < BUFFER_LENGTH)
-                        {
-                            return Marshal.PtrToStringAnsi((IntPtr)buf, (int)*len);
-                        }
-                    }
-                    catch (Exception ex)
-                    {
-                        throw new PlatformNotSupportedException("Error reading Darwin Kernel Version", ex);
-                    }
-                    throw new PlatformNotSupportedException("Unknown error reading Darwin Kernel Version");
-                }
-
-                [DllImport("libc")]
-                private unsafe static extern int sysctl(
-                    int* name,
-                    uint namelen,
-                    byte* oldp,
-                    uint* oldlenp,
-                    IntPtr newp,
-                    uint newlen);
-            }
-
-            public static class Windows
-            {
-                [StructLayout(LayoutKind.Sequential)]
-                internal struct RTL_OSVERSIONINFOEX
-                {
-                    internal uint dwOSVersionInfoSize;
-                    internal uint dwMajorVersion;
-                    internal uint dwMinorVersion;
-                    internal uint dwBuildNumber;
-                    internal uint dwPlatformId;
-                    [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 128)]
-                    internal string szCSDVersion;
-                }
-
-                // This call avoids the shimming Windows does to report old versions
-                [DllImport("ntdll")]
-                private static extern int RtlGetVersion(out RTL_OSVERSIONINFOEX lpVersionInformation);
-
-                internal static string RtlGetVersion()
-                {
-                    RTL_OSVERSIONINFOEX osvi = new RTL_OSVERSIONINFOEX();
-                    osvi.dwOSVersionInfoSize = (uint)Marshal.SizeOf(osvi);
-                    if (RtlGetVersion(out osvi) == 0)
-                    {
-                        return $"{osvi.dwMajorVersion}.{osvi.dwMinorVersion}.{osvi.dwBuildNumber}";
-                    }
-                    else
-                    {
-                        return null;
-                    }
-                }
-            }
         }
     }
 }

--- a/src/Tests/Microsoft.DotNet.Cli.Utils.Tests/RuntimeEnvironmentTests.cs
+++ b/src/Tests/Microsoft.DotNet.Cli.Utils.Tests/RuntimeEnvironmentTests.cs
@@ -24,9 +24,11 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
             Version osVersion = Version.Parse(RuntimeEnvironment.OperatingSystemVersion);
             Version expectedOSVersion = Environment.OSVersion.Version;
 
+            // 3 parts of the version should be supplied for Windows
             Assert.Equal(expectedOSVersion.Major, osVersion.Major);
             Assert.Equal(expectedOSVersion.Minor, osVersion.Minor);
             Assert.Equal(expectedOSVersion.Build, osVersion.Build);
+            Assert.Equal(-1, osVersion.Revision);
         }
 
         [MacOsOnlyFact]
@@ -36,9 +38,13 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
             Assert.Equal("Mac OS X", RuntimeEnvironment.OperatingSystem);
 
             Version osVersion = Version.Parse(RuntimeEnvironment.OperatingSystemVersion);
+            Version expectedOSVersion = Environment.OSVersion.Version;
 
-            Assert.Equal(Environment.OSVersion.Version.Major, osVersion.Major);
-            Assert.Equal(Environment.OSVersion.Version.Minor, osVersion.Minor);
+            // 2 parts of the version should be supplied for macOS
+            Assert.Equal(expectedOSVersion.Major, osVersion.Major);
+            Assert.Equal(expectedOSVersion.Minor, osVersion.Minor);
+            Assert.Equal(-1, osVersion.Build);
+            Assert.Equal(-1, osVersion.Revision);
         }
 
         [LinuxOnlyFact]

--- a/src/Tests/Microsoft.NET.TestFramework/EnvironmentInfo.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/EnvironmentInfo.cs
@@ -32,19 +32,16 @@ namespace Microsoft.NET.TestFramework
             {
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
                 {
-                    Version osVersion;
-                    if (Version.TryParse(DotNet.Cli.Utils.RuntimeEnvironment.OperatingSystemVersion, out osVersion))
+                    Version osVersion = Environment.OSVersion.Version;
+                    if (osVersion > new Version(10, 11))
                     {
-                        if (osVersion > new Version(10, 11))
-                        {
-                            //  netcoreapp1.0 only supports osx.10.10 and osx.10.11
-                            rid = "osx.10.11-x64";
-                        }
-                        else if (osVersion > new Version(10, 12))
-                        {
-                            //  netcoreapp1.1 only supports up to osx.10.12
-                            rid = "osx.10.12-x64";
-                        }
+                        //  netcoreapp1.0 only supports osx.10.10 and osx.10.11
+                        rid = "osx.10.11-x64";
+                    }
+                    else if (osVersion > new Version(10, 12))
+                    {
+                        //  netcoreapp1.1 only supports up to osx.10.12
+                        rid = "osx.10.12-x64";
                     }
                 }
             }


### PR DESCRIPTION
Now that https://github.com/dotnet/runtime/issues/34977 and https://github.com/dotnet/runtime/issues/33643 are fixed, Environment.OSVersion returns the correct version for Windows and macOS.