### PR TITLE
Update RuntimeIdentifiers test

### DIFF
--- a/src/Tests/Microsoft.NET.Publish.Tests/RuntimeIdentifiersTests.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/RuntimeIdentifiersTests.cs
@@ -59,7 +59,7 @@ namespace Microsoft.NET.Publish.Tests
                 var buildCommand = new BuildCommand(Log, testAsset.Path, testProject.Name);
 
                 buildCommand
-                    .Execute($"/p:RuntimeIdentifier={runtimeIdentifier}")
+                    .ExecuteWithoutRestore($"/p:RuntimeIdentifier={runtimeIdentifier}")
                     .Should()
                     .Pass();
 


### PR DESCRIPTION
Validate that restore operation downloads runtime packs for all RIDs from the RuntimeIdentifiers property.

I think the test originally worked this way but we lost it when we refactored the tests to use built-in restore by default.