### PR TITLE
Single-File: Update Bundler Invocation.

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -947,9 +947,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <ItemGroup>
       <ResolvedFileToPublish Remove="@(_FilesToBundle)"/>
-      <!-- ResolvedFileToPublish shouldn't include PublishedSingleFilePath, since the single-file bundle is written directly to the publish directory -->
     </ItemGroup>
-
   </Target>
 
   <UsingTask TaskName="GenerateBundle" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
@@ -959,12 +957,26 @@ Copyright (c) .NET Foundation. All rights reserved.
           Inputs="@(_FilesToBundle)"
           Outputs="$(PublishedSingleFilePath)">
 
+    <PropertyGroup>
+      <TraceSingleFileBundler Condition="'$(TraceSingleFileBundler)' == ''">false</TraceSingleFileBundler>
+      <IncludeSymbolsInSingleFile Condition="'$(IncludeSymbolsInSingleFile)' == ''">false</IncludeSymbolsInSingleFile>
+    </PropertyGroup>    
+
     <GenerateBundle FilesToBundle="@(_FilesToBundle)"
                     AppHostName="$(PublishedSingleFileName)"
                     IncludeSymbols="$(IncludeSymbolsInSingleFile)"
+                    TargetFrameworkVersion="$(_TargetFrameworkVersionWithoutV)"
+                    RuntimeIdentifier="$(RuntimeIdentifier)"
                     OutputDir="$(PublishDir)"
-                    ShowDiagnosticOutput="false"/>
-
+                    ShowDiagnosticOutput="$(TraceSingleFileBundler)">
+      <Output TaskParameter="ExcludedFiles" ItemName="_FilesExcludedFromBundle"/>
+    </GenerateBundle>
+  
+    <ItemGroup>
+      <ResolvedFileToPublish Include="@(_FilesExcludedFromBundle)"/>
+      <!-- ResolvedFileToPublish shouldn't include PublishedSingleFilePath, since the single-file bundle is written directly to the publish directory -->
+    </ItemGroup>  
+  
   </Target>
 
   <!--

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishIncrementally.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishIncrementally.cs
@@ -181,10 +181,10 @@ namespace Microsoft.NET.Publish.Tests
             newCommand.WorkingDirectory = testDir.Path;
             newCommand.Execute("new", "mvc", "-n", assetName).Should().Pass();
 
-            var expectedRegularFiles = new string[] { ".dll", ".deps.json", ".runtimeconfig.json", ".Views.dll", ".Views.pdb" }
+            var expectedRegularFiles = new string[] { ".dll", ".deps.json", ".runtimeconfig.json", ".Views.dll"}
                 .Select(ending => assetName + ending);
-            var expectedSingleFiles = new string[] { ".pdb", ".exe" }.Select(ending => assetName + ending)
-                .Concat(new string[] { "appsettings.json", "appsettings.Development.json", "web.config" });
+            var expectedSingleFiles = new string[] { ".Views.pdb", ".pdb", ".exe" }.Select(ending => assetName + ending)
+                .Concat(new string[] { "hostfxr.dll", "hostpolicy.dll", "appsettings.json", "appsettings.Development.json", "web.config" });
 
             // Publish normally
             new PublishCommand(Log, Path.Combine(testDir.Path, assetName))


### PR DESCRIPTION
## Customer Scenario
.net5 self-contained single-file apps don't run.

## Problem

Since Single-file bundles are processed in the framework, hostpolicy and hostfxr DLLs cannot themselves be in the bundle (until statically linked singlefilehost is supported).
Microsoft.NET.HostModel library excludes these files from the bundle, but the SDK must copy the excluded files to the publish directory.

## Solution
This change updates the SDK to:
* Pass the correct target-OS settings to the bundler
* Copy files excluded by the Bundler to the publish directory.

## Risk
Low.