### PR TITLE
Add option to enable hang and crash dumps

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-test/LocalizableStrings.resx
+++ b/src/Cli/dotnet/commands/dotnet-test/LocalizableStrings.resx
@@ -199,8 +199,17 @@ RunSettings arguments:
                                         More info here: https://aka.ms/vstest-collect</value>
   </data>
   <data name="CmdBlameDescription" xml:space="preserve">
-    <value>Run the tests in blame mode. This option is helpful in isolating a problematic test causing the test host to crash.
-Outputs a 'Sequence.xml' file in the current directory that captures the order of execution of test before the crash.</value>
+    <value>Runs the tests in blame mode. This option is helpful in isolating problematic tests that cause the test host to crash or hang. 
+When a crash is detected, it creates an sequence file in TestResults/guid/guid_Sequence.xml that captures the order of tests that were run before the crash.
+Based on the additional settings, hang dump or crash dump can also be collected.
+Example: 
+  Timeout the test run when test takes more than the default timeout of 1 hour, and collect crash dump when the test host exits unexpectedly. 
+  (Crash dumps require additional setup, see below.)
+  dotnet test --blame-hang --blame-crash
+Example: 
+  Timeout the test run when a test takes more than 20 minutes and collect hang dump. 
+  dotnet test --blame-hang-timeout 20min
+</value>
   </data>
   <data name="FrameworkOptionDescription" xml:space="preserve">
     <value>The target framework to run tests for. The target framework must also be specified in the project file.</value>
@@ -216,5 +225,40 @@ Outputs a 'Sequence.xml' file in the current directory that captures the order o
   </data>
   <data name="IgnoredArgumentsMessage" xml:space="preserve">
     <value>The following arguments have been ignored : "{0}"</value>
+  </data>
+  <data name="CmdBlameCrashCollectAlwaysDescription" xml:space="preserve">
+    <value>Enables collecting crash dump on expected as well as unexpected testhost exit.</value>
+  </data>
+  <data name="CmdBlameCrashDescription" xml:space="preserve">
+    <value>Runs the tests in blame mode and enables collecting crash dump when testhost exits unexpectedly. 
+This option is currently only supported on Windows, and requires procdump.exe and procdump64.exe to be available in PATH.
+Or PROCDUMP_PATH environment variable to be set, and point to a directory that contains procdump.exe and procdump64.exe. 
+The tools can be downloaded here: https://docs.microsoft.com/en-us/sysinternals/downloads/procdump 
+Implies --blame.</value>
+  </data>
+  <data name="CmdBlameCrashDumpTypeDescription" xml:space="preserve">
+    <value>The type of crash dump to be collected. Implies --blame-crash.</value>
+  </data>
+  <data name="CmdBlameHangDescription" xml:space="preserve">
+    <value>Run the tests in blame mode and enables collecting hang dump when test exceeds the given timeout. Implies --blame-hang.</value>
+  </data>
+  <data name="CmdBlameHangDumpTypeDescription" xml:space="preserve">
+    <value>The type of crash dump to be collected. When None, is used then test host is terminated on timeout, but no dump is collected. Implies --blame-hang.</value>
+  </data>
+  <data name="CmdBlameHangTimeoutDescription" xml:space="preserve">
+    <value>Per-test timeout, after which hang dump is triggered and the testhost process is terminated. 
+The timeout value is specified in the following format: 1.5h / 90m / 5400s / 5400000ms. When no unit is used (e.g. 5400000), the value is assumed to be in milliseconds.
+When used together with data driven tests, the timeout behavior depends on the test adapter used. For xUnit and NUnit the timeout is renewed after every test case,
+For MSTest, the timeout is used for all testcases.
+This option is currently supported only on Windows together with netcoreapp2.1 and newer. And on Linux with netcoreapp3.1 and newer. OSX and UWP are not supported.</value>
+  </data>
+  <data name="CrashDumpTypeArgumentName" xml:space="preserve">
+    <value>DUMP_TYPE</value>
+  </data>
+  <data name="HangDumpTypeArgumentName" xml:space="preserve">
+    <value>DUMP_TYPE</value>
+  </data>
+  <data name="HangTimeoutArgumentName" xml:space="preserve">
+    <value>TIMESPAN</value>
   </data>
 </root>

--- a/src/Cli/dotnet/commands/dotnet-test/TestCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/TestCommandParser.cs
@@ -50,9 +50,9 @@ namespace Microsoft.DotNet.Cli
                               .With(name: LocalizableStrings.CmdLoggerOption)
                               .ForwardAsSingle(o =>
                                     {
-                                          var loggersString = string.Join(";", GetSemiColonEscapedArgs(o.Arguments));
+                                        var loggersString = string.Join(";", GetSemiColonEscapedArgs(o.Arguments));
 
-                                          return $"-property:VSTestLogger=\"{loggersString}\"";
+                                        return $"-property:VSTestLogger=\"{loggersString}\"";
                                     })),
                   CommonOptions.ConfigurationOption(LocalizableStrings.ConfigurationOptionDescription),
                   CommonOptions.FrameworkOption(LocalizableStrings.FrameworkOptionDescription),
@@ -91,6 +91,55 @@ namespace Microsoft.DotNet.Cli
                         LocalizableStrings.CmdBlameDescription,
                         Accept.NoArguments()
                               .ForwardAsSingle(o => "-property:VSTestBlame=true")),
+                  Create.Option(
+                        "--blame-crash",
+                        LocalizableStrings.CmdBlameCrashDescription,
+                        Accept.NoArguments()
+                              .ForwardAsSingle(o => "-property:VSTestBlameCrash=true")),
+                  Create.Option(
+                        "--blame-crash-dump-type",
+                        LocalizableStrings.CmdBlameCrashDumpTypeDescription,
+                        Accept.AnyOneOf(
+                            "full",
+                            "mini")
+                              .With(name: LocalizableStrings.CrashDumpTypeArgumentName, defaultValue: () => "full")
+                              .ForwardAsMany(o => new[] {
+                                  "-property:VSTestBlameCrash=true",
+                                  $"-property:VSTestBlameCrashDumpType={o.Arguments.Single()}" })),
+                   Create.Option(
+                        "--blame-crash-collect-always",
+                        LocalizableStrings.CmdBlameCrashCollectAlwaysDescription,
+                        Accept.NoArguments()
+                              .ForwardAsMany(o => new[] {
+                                  "-property:VSTestBlameCrash=true",
+                                  "-property:VSTestBlameCrashCollectAlways=true"
+                              })),
+                Create.Option(
+                        "--blame-hang",
+                        LocalizableStrings.CmdBlameHangDescription,
+                        Accept.NoArguments()
+                              .ForwardAsSingle(o => "-property:VSTestBlameHang=true")),
+                  Create.Option(
+                        "--blame-hang-dump-type",
+                        LocalizableStrings.CmdBlameHangDumpTypeDescription,
+                        Accept.AnyOneOf(
+                            "full",
+                            "mini",
+                            "none")
+                              .With(name: LocalizableStrings.HangDumpTypeArgumentName, defaultValue: () => "full")
+                              .ForwardAsMany(o => new[] {
+                                  "-property:VSTestBlameHang=true",
+                                  $"-property:VSTestBlameHangDumpType={o.Arguments.Single()}" })),
+                   Create.Option(
+                        "--blame-hang-timeout",
+                        LocalizableStrings.CmdBlameHangTimeoutDescription,
+                        Accept.ExactlyOneArgument()
+                              .With(name: LocalizableStrings.HangTimeoutArgumentName)
+                              .ForwardAsMany(o => new[] {
+                                  "-property:VSTestBlameHang=true",
+                                  $"-property:VSTestBlameHangTimeout={o.Arguments.Single()}"
+                              })),
+
                   Create.Option(
                         "--nologo|/nologo",
                         LocalizableStrings.CmdNoLogo,

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.cs.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.cs.xlf
@@ -13,33 +13,49 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameCrashCollectAlwaysDescription">
-        <source>TODO</source>
-        <target state="new">TODO</target>
+        <source>Enables collecting crash dump on expected as well as unexpected testhost exit.</source>
+        <target state="new">Enables collecting crash dump on expected as well as unexpected testhost exit.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameCrashDescription">
-        <source>TODO</source>
-        <target state="new">TODO</target>
+        <source>Runs the tests in blame mode and enables collecting crash dump when testhost exits unexpectedly. 
+This option is currently only supported on Windows, and requires procdump.exe and procdump64.exe to be available in PATH.
+Or PROCDUMP_PATH environment variable to be set, and point to a directory that contains procdump.exe and procdump64.exe. 
+The tools can be downloaded here: https://docs.microsoft.com/en-us/sysinternals/downloads/procdump 
+Implies --blame.</source>
+        <target state="new">Runs the tests in blame mode and enables collecting crash dump when testhost exits unexpectedly. 
+This option is currently only supported on Windows, and requires procdump.exe and procdump64.exe to be available in PATH.
+Or PROCDUMP_PATH environment variable to be set, and point to a directory that contains procdump.exe and procdump64.exe. 
+The tools can be downloaded here: https://docs.microsoft.com/en-us/sysinternals/downloads/procdump 
+Implies --blame.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameCrashDumpTypeDescription">
-        <source>TODO</source>
-        <target state="new">TODO</target>
+        <source>The type of crash dump to be collected. Implies --blame-crash.</source>
+        <target state="new">The type of crash dump to be collected. Implies --blame-crash.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangDescription">
-        <source>TODO</source>
-        <target state="new">TODO</target>
+        <source>Run the tests in blame mode and enables collecting hang dump when test exceeds the given timeout. Implies --blame-hang.</source>
+        <target state="new">Run the tests in blame mode and enables collecting hang dump when test exceeds the given timeout. Implies --blame-hang.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangDumpTypeDescription">
-        <source>TODO</source>
-        <target state="new">TODO</target>
+        <source>The type of crash dump to be collected. When None, is used then test host is terminated on timeout, but no dump is collected. Implies --blame-hang.</source>
+        <target state="new">The type of crash dump to be collected. When None, is used then test host is terminated on timeout, but no dump is collected. Implies --blame-hang.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangTimeoutDescription">
-        <source>TODO</source>
-        <target state="new">TODO</target>
+        <source>Per-test timeout, after which hang dump is triggered and the testhost process is terminated. 
+The timeout value is specified in the following format: 1.5h / 90m / 5400s / 5400000ms. When no unit is used (e.g. 5400000), the value is assumed to be in milliseconds.
+When used together with data driven tests, the timeout behavior depends on the test adapter used. For xUnit and NUnit the timeout is renewed after every test case,
+For MSTest, the timeout is used for all testcases.
+This option is currently supported only on Windows together with netcoreapp2.1 and newer. And on Linux with netcoreapp3.1 and newer. OSX and UWP are not supported.</source>
+        <target state="new">Per-test timeout, after which hang dump is triggered and the testhost process is terminated. 
+The timeout value is specified in the following format: 1.5h / 90m / 5400s / 5400000ms. When no unit is used (e.g. 5400000), the value is assumed to be in milliseconds.
+When used together with data driven tests, the timeout behavior depends on the test adapter used. For xUnit and NUnit the timeout is renewed after every test case,
+For MSTest, the timeout is used for all testcases.
+This option is currently supported only on Windows together with netcoreapp2.1 and newer. And on Linux with netcoreapp3.1 and newer. OSX and UWP are not supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdNoLogo">
@@ -199,9 +215,18 @@ Argumenty RunSettings:
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameDescription">
-        <source>Run the tests in blame mode. This option is helpful in isolating a problematic test causing the test host to crash.
-Outputs a 'Sequence.xml' file in the current directory that captures the order of execution of test before the crash.</source>
-        <target state="translated">Spustí testy v režimu blame. Tato možnost je užitečná pro izolování problematického testu, který způsobuje chybové ukončení hostitele testů.
+        <source>Runs the tests in blame mode. This option is helpful in isolating problematic tests that cause the test host to crash or hang. 
+When a crash is detected, it creates an sequence file in TestResults/guid/guid_Sequence.xml that captures the order of tests that were run before the crash.
+Based on the additional settings, hang dump or crash dump can also be collected.
+Example: 
+  Timeout the test run when test takes more than the default timeout of 1 hour, and collect crash dump when the test host exits unexpectedly. 
+  (Crash dumps require additional setup, see below.)
+  dotnet test --blame-hang --blame-crash
+Example: 
+  Timeout the test run when a test takes more than 20 minutes and collect hang dump. 
+  dotnet test --blame-hang-timeout 20min
+</source>
+        <target state="needs-review-translation">Spustí testy v režimu blame. Tato možnost je užitečná pro izolování problematického testu, který způsobuje chybové ukončení hostitele testů.
 Výstupem je soubor Sequence.xml v aktuálním adresáři, do kterého se zaznamená pořadí provádění testů před chybovým ukončením.</target>
         <note />
       </trans-unit>

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.cs.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.cs.xlf
@@ -12,6 +12,36 @@
         <target state="translated">Testovací ovladač pro platformu .NET</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdBlameCrashCollectAlwaysDescription">
+        <source>TODO</source>
+        <target state="new">TODO</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdBlameCrashDescription">
+        <source>TODO</source>
+        <target state="new">TODO</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdBlameCrashDumpTypeDescription">
+        <source>TODO</source>
+        <target state="new">TODO</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdBlameHangDescription">
+        <source>TODO</source>
+        <target state="new">TODO</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdBlameHangDumpTypeDescription">
+        <source>TODO</source>
+        <target state="new">TODO</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdBlameHangTimeoutDescription">
+        <source>TODO</source>
+        <target state="new">TODO</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdNoLogo">
         <source>Run test(s), without displaying Microsoft Testplatform banner</source>
         <target state="translated">Spustit testy bez zobrazení nápisu Microsoft Testplatform</target>
@@ -117,6 +147,21 @@ Pokud zadaný adresář neexistuje, bude vytvořen.</target>
       <trans-unit id="CmdPathToResultsDirectory">
         <source>RESULTS_DIR</source>
         <target state="translated">RESULTS_DIR</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CrashDumpTypeArgumentName">
+        <source>DUMP_TYPE</source>
+        <target state="new">DUMP_TYPE</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HangDumpTypeArgumentName">
+        <source>DUMP_TYPE</source>
+        <target state="new">DUMP_TYPE</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HangTimeoutArgumentName">
+        <source>TIMESPAN</source>
+        <target state="new">TIMESPAN</target>
         <note />
       </trans-unit>
       <trans-unit id="IgnoredArgumentsMessage">

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.de.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.de.xlf
@@ -12,6 +12,36 @@
         <target state="translated">Testtreiber für die .NET-Plattform</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdBlameCrashCollectAlwaysDescription">
+        <source>TODO</source>
+        <target state="new">TODO</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdBlameCrashDescription">
+        <source>TODO</source>
+        <target state="new">TODO</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdBlameCrashDumpTypeDescription">
+        <source>TODO</source>
+        <target state="new">TODO</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdBlameHangDescription">
+        <source>TODO</source>
+        <target state="new">TODO</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdBlameHangDumpTypeDescription">
+        <source>TODO</source>
+        <target state="new">TODO</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdBlameHangTimeoutDescription">
+        <source>TODO</source>
+        <target state="new">TODO</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdNoLogo">
         <source>Run test(s), without displaying Microsoft Testplatform banner</source>
         <target state="translated">Test(s) ohne Anzeige des Microsoft-Testplattformbanners ausführen</target>
@@ -117,6 +147,21 @@ Das angegebene Verzeichnis wird erstellt, wenn es nicht vorhanden ist.</target>
       <trans-unit id="CmdPathToResultsDirectory">
         <source>RESULTS_DIR</source>
         <target state="translated">RESULTS_DIR</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CrashDumpTypeArgumentName">
+        <source>DUMP_TYPE</source>
+        <target state="new">DUMP_TYPE</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HangDumpTypeArgumentName">
+        <source>DUMP_TYPE</source>
+        <target state="new">DUMP_TYPE</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HangTimeoutArgumentName">
+        <source>TIMESPAN</source>
+        <target state="new">TIMESPAN</target>
         <note />
       </trans-unit>
       <trans-unit id="IgnoredArgumentsMessage">

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.de.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.de.xlf
@@ -13,33 +13,49 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameCrashCollectAlwaysDescription">
-        <source>TODO</source>
-        <target state="new">TODO</target>
+        <source>Enables collecting crash dump on expected as well as unexpected testhost exit.</source>
+        <target state="new">Enables collecting crash dump on expected as well as unexpected testhost exit.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameCrashDescription">
-        <source>TODO</source>
-        <target state="new">TODO</target>
+        <source>Runs the tests in blame mode and enables collecting crash dump when testhost exits unexpectedly. 
+This option is currently only supported on Windows, and requires procdump.exe and procdump64.exe to be available in PATH.
+Or PROCDUMP_PATH environment variable to be set, and point to a directory that contains procdump.exe and procdump64.exe. 
+The tools can be downloaded here: https://docs.microsoft.com/en-us/sysinternals/downloads/procdump 
+Implies --blame.</source>
+        <target state="new">Runs the tests in blame mode and enables collecting crash dump when testhost exits unexpectedly. 
+This option is currently only supported on Windows, and requires procdump.exe and procdump64.exe to be available in PATH.
+Or PROCDUMP_PATH environment variable to be set, and point to a directory that contains procdump.exe and procdump64.exe. 
+The tools can be downloaded here: https://docs.microsoft.com/en-us/sysinternals/downloads/procdump 
+Implies --blame.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameCrashDumpTypeDescription">
-        <source>TODO</source>
-        <target state="new">TODO</target>
+        <source>The type of crash dump to be collected. Implies --blame-crash.</source>
+        <target state="new">The type of crash dump to be collected. Implies --blame-crash.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangDescription">
-        <source>TODO</source>
-        <target state="new">TODO</target>
+        <source>Run the tests in blame mode and enables collecting hang dump when test exceeds the given timeout. Implies --blame-hang.</source>
+        <target state="new">Run the tests in blame mode and enables collecting hang dump when test exceeds the given timeout. Implies --blame-hang.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangDumpTypeDescription">
-        <source>TODO</source>
-        <target state="new">TODO</target>
+        <source>The type of crash dump to be collected. When None, is used then test host is terminated on timeout, but no dump is collected. Implies --blame-hang.</source>
+        <target state="new">The type of crash dump to be collected. When None, is used then test host is terminated on timeout, but no dump is collected. Implies --blame-hang.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangTimeoutDescription">
-        <source>TODO</source>
-        <target state="new">TODO</target>
+        <source>Per-test timeout, after which hang dump is triggered and the testhost process is terminated. 
+The timeout value is specified in the following format: 1.5h / 90m / 5400s / 5400000ms. When no unit is used (e.g. 5400000), the value is assumed to be in milliseconds.
+When used together with data driven tests, the timeout behavior depends on the test adapter used. For xUnit and NUnit the timeout is renewed after every test case,
+For MSTest, the timeout is used for all testcases.
+This option is currently supported only on Windows together with netcoreapp2.1 and newer. And on Linux with netcoreapp3.1 and newer. OSX and UWP are not supported.</source>
+        <target state="new">Per-test timeout, after which hang dump is triggered and the testhost process is terminated. 
+The timeout value is specified in the following format: 1.5h / 90m / 5400s / 5400000ms. When no unit is used (e.g. 5400000), the value is assumed to be in milliseconds.
+When used together with data driven tests, the timeout behavior depends on the test adapter used. For xUnit and NUnit the timeout is renewed after every test case,
+For MSTest, the timeout is used for all testcases.
+This option is currently supported only on Windows together with netcoreapp2.1 and newer. And on Linux with netcoreapp3.1 and newer. OSX and UWP are not supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdNoLogo">
@@ -199,9 +215,18 @@ RunSettings-Argumente:
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameDescription">
-        <source>Run the tests in blame mode. This option is helpful in isolating a problematic test causing the test host to crash.
-Outputs a 'Sequence.xml' file in the current directory that captures the order of execution of test before the crash.</source>
-        <target state="translated">Hiermit wird der Test im Modus "Verantwortung zuweisen" ausgeführt. Diese Option hilft bei der Isolierung eines problematischen Tests, der den Absturz des Testhosts verursacht.
+        <source>Runs the tests in blame mode. This option is helpful in isolating problematic tests that cause the test host to crash or hang. 
+When a crash is detected, it creates an sequence file in TestResults/guid/guid_Sequence.xml that captures the order of tests that were run before the crash.
+Based on the additional settings, hang dump or crash dump can also be collected.
+Example: 
+  Timeout the test run when test takes more than the default timeout of 1 hour, and collect crash dump when the test host exits unexpectedly. 
+  (Crash dumps require additional setup, see below.)
+  dotnet test --blame-hang --blame-crash
+Example: 
+  Timeout the test run when a test takes more than 20 minutes and collect hang dump. 
+  dotnet test --blame-hang-timeout 20min
+</source>
+        <target state="needs-review-translation">Hiermit wird der Test im Modus "Verantwortung zuweisen" ausgeführt. Diese Option hilft bei der Isolierung eines problematischen Tests, der den Absturz des Testhosts verursacht.
 Im aktuellen Verzeichnis wird eine Datei namens "Sequence.xml" ausgegeben, in der die Reihenfolge der Testausführung vor dem Absturz erfasst wird.</target>
         <note />
       </trans-unit>

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.es.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.es.xlf
@@ -12,6 +12,36 @@
         <target state="translated">Controlador de pruebas para la plataforma .NET</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdBlameCrashCollectAlwaysDescription">
+        <source>TODO</source>
+        <target state="new">TODO</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdBlameCrashDescription">
+        <source>TODO</source>
+        <target state="new">TODO</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdBlameCrashDumpTypeDescription">
+        <source>TODO</source>
+        <target state="new">TODO</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdBlameHangDescription">
+        <source>TODO</source>
+        <target state="new">TODO</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdBlameHangDumpTypeDescription">
+        <source>TODO</source>
+        <target state="new">TODO</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdBlameHangTimeoutDescription">
+        <source>TODO</source>
+        <target state="new">TODO</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdNoLogo">
         <source>Run test(s), without displaying Microsoft Testplatform banner</source>
         <target state="translated">Ejecutar pruebas, sin mostrar la pancarta de Microsoft Testplatform</target>
@@ -117,6 +147,21 @@ Si no existe, se creará el directorio especificado.</target>
       <trans-unit id="CmdPathToResultsDirectory">
         <source>RESULTS_DIR</source>
         <target state="translated">RESULTS_DIR</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CrashDumpTypeArgumentName">
+        <source>DUMP_TYPE</source>
+        <target state="new">DUMP_TYPE</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HangDumpTypeArgumentName">
+        <source>DUMP_TYPE</source>
+        <target state="new">DUMP_TYPE</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HangTimeoutArgumentName">
+        <source>TIMESPAN</source>
+        <target state="new">TIMESPAN</target>
         <note />
       </trans-unit>
       <trans-unit id="IgnoredArgumentsMessage">

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.es.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.es.xlf
@@ -13,33 +13,49 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameCrashCollectAlwaysDescription">
-        <source>TODO</source>
-        <target state="new">TODO</target>
+        <source>Enables collecting crash dump on expected as well as unexpected testhost exit.</source>
+        <target state="new">Enables collecting crash dump on expected as well as unexpected testhost exit.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameCrashDescription">
-        <source>TODO</source>
-        <target state="new">TODO</target>
+        <source>Runs the tests in blame mode and enables collecting crash dump when testhost exits unexpectedly. 
+This option is currently only supported on Windows, and requires procdump.exe and procdump64.exe to be available in PATH.
+Or PROCDUMP_PATH environment variable to be set, and point to a directory that contains procdump.exe and procdump64.exe. 
+The tools can be downloaded here: https://docs.microsoft.com/en-us/sysinternals/downloads/procdump 
+Implies --blame.</source>
+        <target state="new">Runs the tests in blame mode and enables collecting crash dump when testhost exits unexpectedly. 
+This option is currently only supported on Windows, and requires procdump.exe and procdump64.exe to be available in PATH.
+Or PROCDUMP_PATH environment variable to be set, and point to a directory that contains procdump.exe and procdump64.exe. 
+The tools can be downloaded here: https://docs.microsoft.com/en-us/sysinternals/downloads/procdump 
+Implies --blame.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameCrashDumpTypeDescription">
-        <source>TODO</source>
-        <target state="new">TODO</target>
+        <source>The type of crash dump to be collected. Implies --blame-crash.</source>
+        <target state="new">The type of crash dump to be collected. Implies --blame-crash.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangDescription">
-        <source>TODO</source>
-        <target state="new">TODO</target>
+        <source>Run the tests in blame mode and enables collecting hang dump when test exceeds the given timeout. Implies --blame-hang.</source>
+        <target state="new">Run the tests in blame mode and enables collecting hang dump when test exceeds the given timeout. Implies --blame-hang.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangDumpTypeDescription">
-        <source>TODO</source>
-        <target state="new">TODO</target>
+        <source>The type of crash dump to be collected. When None, is used then test host is terminated on timeout, but no dump is collected. Implies --blame-hang.</source>
+        <target state="new">The type of crash dump to be collected. When None, is used then test host is terminated on timeout, but no dump is collected. Implies --blame-hang.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangTimeoutDescription">
-        <source>TODO</source>
-        <target state="new">TODO</target>
+        <source>Per-test timeout, after which hang dump is triggered and the testhost process is terminated. 
+The timeout value is specified in the following format: 1.5h / 90m / 5400s / 5400000ms. When no unit is used (e.g. 5400000), the value is assumed to be in milliseconds.
+When used together with data driven tests, the timeout behavior depends on the test adapter used. For xUnit and NUnit the timeout is renewed after every test case,
+For MSTest, the timeout is used for all testcases.
+This option is currently supported only on Windows together with netcoreapp2.1 and newer. And on Linux with netcoreapp3.1 and newer. OSX and UWP are not supported.</source>
+        <target state="new">Per-test timeout, after which hang dump is triggered and the testhost process is terminated. 
+The timeout value is specified in the following format: 1.5h / 90m / 5400s / 5400000ms. When no unit is used (e.g. 5400000), the value is assumed to be in milliseconds.
+When used together with data driven tests, the timeout behavior depends on the test adapter used. For xUnit and NUnit the timeout is renewed after every test case,
+For MSTest, the timeout is used for all testcases.
+This option is currently supported only on Windows together with netcoreapp2.1 and newer. And on Linux with netcoreapp3.1 and newer. OSX and UWP are not supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdNoLogo">
@@ -199,9 +215,18 @@ Argumentos RunSettings:
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameDescription">
-        <source>Run the tests in blame mode. This option is helpful in isolating a problematic test causing the test host to crash.
-Outputs a 'Sequence.xml' file in the current directory that captures the order of execution of test before the crash.</source>
-        <target state="translated">Ejecuta las pruebas en modo de culpa. Esta opción es útil para aislar una prueba problemática que provoca el bloqueo del host de prueba.
+        <source>Runs the tests in blame mode. This option is helpful in isolating problematic tests that cause the test host to crash or hang. 
+When a crash is detected, it creates an sequence file in TestResults/guid/guid_Sequence.xml that captures the order of tests that were run before the crash.
+Based on the additional settings, hang dump or crash dump can also be collected.
+Example: 
+  Timeout the test run when test takes more than the default timeout of 1 hour, and collect crash dump when the test host exits unexpectedly. 
+  (Crash dumps require additional setup, see below.)
+  dotnet test --blame-hang --blame-crash
+Example: 
+  Timeout the test run when a test takes more than 20 minutes and collect hang dump. 
+  dotnet test --blame-hang-timeout 20min
+</source>
+        <target state="needs-review-translation">Ejecuta las pruebas en modo de culpa. Esta opción es útil para aislar una prueba problemática que provoca el bloqueo del host de prueba.
 Crea un archivo de salida "Sequence.xml" en el directorio actual que captura el orden de ejecución de la prueba antes del bloqueo.</target>
         <note />
       </trans-unit>

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.fr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.fr.xlf
@@ -13,33 +13,49 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameCrashCollectAlwaysDescription">
-        <source>TODO</source>
-        <target state="new">TODO</target>
+        <source>Enables collecting crash dump on expected as well as unexpected testhost exit.</source>
+        <target state="new">Enables collecting crash dump on expected as well as unexpected testhost exit.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameCrashDescription">
-        <source>TODO</source>
-        <target state="new">TODO</target>
+        <source>Runs the tests in blame mode and enables collecting crash dump when testhost exits unexpectedly. 
+This option is currently only supported on Windows, and requires procdump.exe and procdump64.exe to be available in PATH.
+Or PROCDUMP_PATH environment variable to be set, and point to a directory that contains procdump.exe and procdump64.exe. 
+The tools can be downloaded here: https://docs.microsoft.com/en-us/sysinternals/downloads/procdump 
+Implies --blame.</source>
+        <target state="new">Runs the tests in blame mode and enables collecting crash dump when testhost exits unexpectedly. 
+This option is currently only supported on Windows, and requires procdump.exe and procdump64.exe to be available in PATH.
+Or PROCDUMP_PATH environment variable to be set, and point to a directory that contains procdump.exe and procdump64.exe. 
+The tools can be downloaded here: https://docs.microsoft.com/en-us/sysinternals/downloads/procdump 
+Implies --blame.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameCrashDumpTypeDescription">
-        <source>TODO</source>
-        <target state="new">TODO</target>
+        <source>The type of crash dump to be collected. Implies --blame-crash.</source>
+        <target state="new">The type of crash dump to be collected. Implies --blame-crash.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangDescription">
-        <source>TODO</source>
-        <target state="new">TODO</target>
+        <source>Run the tests in blame mode and enables collecting hang dump when test exceeds the given timeout. Implies --blame-hang.</source>
+        <target state="new">Run the tests in blame mode and enables collecting hang dump when test exceeds the given timeout. Implies --blame-hang.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangDumpTypeDescription">
-        <source>TODO</source>
-        <target state="new">TODO</target>
+        <source>The type of crash dump to be collected. When None, is used then test host is terminated on timeout, but no dump is collected. Implies --blame-hang.</source>
+        <target state="new">The type of crash dump to be collected. When None, is used then test host is terminated on timeout, but no dump is collected. Implies --blame-hang.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangTimeoutDescription">
-        <source>TODO</source>
-        <target state="new">TODO</target>
+        <source>Per-test timeout, after which hang dump is triggered and the testhost process is terminated. 
+The timeout value is specified in the following format: 1.5h / 90m / 5400s / 5400000ms. When no unit is used (e.g. 5400000), the value is assumed to be in milliseconds.
+When used together with data driven tests, the timeout behavior depends on the test adapter used. For xUnit and NUnit the timeout is renewed after every test case,
+For MSTest, the timeout is used for all testcases.
+This option is currently supported only on Windows together with netcoreapp2.1 and newer. And on Linux with netcoreapp3.1 and newer. OSX and UWP are not supported.</source>
+        <target state="new">Per-test timeout, after which hang dump is triggered and the testhost process is terminated. 
+The timeout value is specified in the following format: 1.5h / 90m / 5400s / 5400000ms. When no unit is used (e.g. 5400000), the value is assumed to be in milliseconds.
+When used together with data driven tests, the timeout behavior depends on the test adapter used. For xUnit and NUnit the timeout is renewed after every test case,
+For MSTest, the timeout is used for all testcases.
+This option is currently supported only on Windows together with netcoreapp2.1 and newer. And on Linux with netcoreapp3.1 and newer. OSX and UWP are not supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdNoLogo">
@@ -199,9 +215,18 @@ Arguments de RunSettings :
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameDescription">
-        <source>Run the tests in blame mode. This option is helpful in isolating a problematic test causing the test host to crash.
-Outputs a 'Sequence.xml' file in the current directory that captures the order of execution of test before the crash.</source>
-        <target state="translated">Permet d'exécuter le test en mode blame (responsabilité). Cette option permet d'isoler un test problématique à l'origine d'un plantage sur l'hôte de test.
+        <source>Runs the tests in blame mode. This option is helpful in isolating problematic tests that cause the test host to crash or hang. 
+When a crash is detected, it creates an sequence file in TestResults/guid/guid_Sequence.xml that captures the order of tests that were run before the crash.
+Based on the additional settings, hang dump or crash dump can also be collected.
+Example: 
+  Timeout the test run when test takes more than the default timeout of 1 hour, and collect crash dump when the test host exits unexpectedly. 
+  (Crash dumps require additional setup, see below.)
+  dotnet test --blame-hang --blame-crash
+Example: 
+  Timeout the test run when a test takes more than 20 minutes and collect hang dump. 
+  dotnet test --blame-hang-timeout 20min
+</source>
+        <target state="needs-review-translation">Permet d'exécuter le test en mode blame (responsabilité). Cette option permet d'isoler un test problématique à l'origine d'un plantage sur l'hôte de test.
 Elle génère dans le répertoire actif un fichier de sortie nommé 'Sequence.xml', qui capture l'ordre d'exécution du test avant le plantage.</target>
         <note />
       </trans-unit>

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.fr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.fr.xlf
@@ -12,6 +12,36 @@
         <target state="translated">Pilote de test pour la plateforme .NET</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdBlameCrashCollectAlwaysDescription">
+        <source>TODO</source>
+        <target state="new">TODO</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdBlameCrashDescription">
+        <source>TODO</source>
+        <target state="new">TODO</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdBlameCrashDumpTypeDescription">
+        <source>TODO</source>
+        <target state="new">TODO</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdBlameHangDescription">
+        <source>TODO</source>
+        <target state="new">TODO</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdBlameHangDumpTypeDescription">
+        <source>TODO</source>
+        <target state="new">TODO</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdBlameHangTimeoutDescription">
+        <source>TODO</source>
+        <target state="new">TODO</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdNoLogo">
         <source>Run test(s), without displaying Microsoft Testplatform banner</source>
         <target state="translated">Exécute le ou les tests, sans afficher la bannière Microsoft Testplatform</target>
@@ -117,6 +147,21 @@ Le répertoire spécifié est créé, s'il n'existe pas déjà.</target>
       <trans-unit id="CmdPathToResultsDirectory">
         <source>RESULTS_DIR</source>
         <target state="translated">RESULTS_DIR</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CrashDumpTypeArgumentName">
+        <source>DUMP_TYPE</source>
+        <target state="new">DUMP_TYPE</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HangDumpTypeArgumentName">
+        <source>DUMP_TYPE</source>
+        <target state="new">DUMP_TYPE</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HangTimeoutArgumentName">
+        <source>TIMESPAN</source>
+        <target state="new">TIMESPAN</target>
         <note />
       </trans-unit>
       <trans-unit id="IgnoredArgumentsMessage">

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.it.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.it.xlf
@@ -13,33 +13,49 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameCrashCollectAlwaysDescription">
-        <source>TODO</source>
-        <target state="new">TODO</target>
+        <source>Enables collecting crash dump on expected as well as unexpected testhost exit.</source>
+        <target state="new">Enables collecting crash dump on expected as well as unexpected testhost exit.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameCrashDescription">
-        <source>TODO</source>
-        <target state="new">TODO</target>
+        <source>Runs the tests in blame mode and enables collecting crash dump when testhost exits unexpectedly. 
+This option is currently only supported on Windows, and requires procdump.exe and procdump64.exe to be available in PATH.
+Or PROCDUMP_PATH environment variable to be set, and point to a directory that contains procdump.exe and procdump64.exe. 
+The tools can be downloaded here: https://docs.microsoft.com/en-us/sysinternals/downloads/procdump 
+Implies --blame.</source>
+        <target state="new">Runs the tests in blame mode and enables collecting crash dump when testhost exits unexpectedly. 
+This option is currently only supported on Windows, and requires procdump.exe and procdump64.exe to be available in PATH.
+Or PROCDUMP_PATH environment variable to be set, and point to a directory that contains procdump.exe and procdump64.exe. 
+The tools can be downloaded here: https://docs.microsoft.com/en-us/sysinternals/downloads/procdump 
+Implies --blame.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameCrashDumpTypeDescription">
-        <source>TODO</source>
-        <target state="new">TODO</target>
+        <source>The type of crash dump to be collected. Implies --blame-crash.</source>
+        <target state="new">The type of crash dump to be collected. Implies --blame-crash.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangDescription">
-        <source>TODO</source>
-        <target state="new">TODO</target>
+        <source>Run the tests in blame mode and enables collecting hang dump when test exceeds the given timeout. Implies --blame-hang.</source>
+        <target state="new">Run the tests in blame mode and enables collecting hang dump when test exceeds the given timeout. Implies --blame-hang.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangDumpTypeDescription">
-        <source>TODO</source>
-        <target state="new">TODO</target>
+        <source>The type of crash dump to be collected. When None, is used then test host is terminated on timeout, but no dump is collected. Implies --blame-hang.</source>
+        <target state="new">The type of crash dump to be collected. When None, is used then test host is terminated on timeout, but no dump is collected. Implies --blame-hang.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangTimeoutDescription">
-        <source>TODO</source>
-        <target state="new">TODO</target>
+        <source>Per-test timeout, after which hang dump is triggered and the testhost process is terminated. 
+The timeout value is specified in the following format: 1.5h / 90m / 5400s / 5400000ms. When no unit is used (e.g. 5400000), the value is assumed to be in milliseconds.
+When used together with data driven tests, the timeout behavior depends on the test adapter used. For xUnit and NUnit the timeout is renewed after every test case,
+For MSTest, the timeout is used for all testcases.
+This option is currently supported only on Windows together with netcoreapp2.1 and newer. And on Linux with netcoreapp3.1 and newer. OSX and UWP are not supported.</source>
+        <target state="new">Per-test timeout, after which hang dump is triggered and the testhost process is terminated. 
+The timeout value is specified in the following format: 1.5h / 90m / 5400s / 5400000ms. When no unit is used (e.g. 5400000), the value is assumed to be in milliseconds.
+When used together with data driven tests, the timeout behavior depends on the test adapter used. For xUnit and NUnit the timeout is renewed after every test case,
+For MSTest, the timeout is used for all testcases.
+This option is currently supported only on Windows together with netcoreapp2.1 and newer. And on Linux with netcoreapp3.1 and newer. OSX and UWP are not supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdNoLogo">
@@ -199,9 +215,18 @@ Argomenti di RunSettings:
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameDescription">
-        <source>Run the tests in blame mode. This option is helpful in isolating a problematic test causing the test host to crash.
-Outputs a 'Sequence.xml' file in the current directory that captures the order of execution of test before the crash.</source>
-        <target state="translated">Esegue i test in modalità di segnalazione errore. Questa opzione è utile per isolare il test problematico che causa l'arresto anomalo dell'host dei test.
+        <source>Runs the tests in blame mode. This option is helpful in isolating problematic tests that cause the test host to crash or hang. 
+When a crash is detected, it creates an sequence file in TestResults/guid/guid_Sequence.xml that captures the order of tests that were run before the crash.
+Based on the additional settings, hang dump or crash dump can also be collected.
+Example: 
+  Timeout the test run when test takes more than the default timeout of 1 hour, and collect crash dump when the test host exits unexpectedly. 
+  (Crash dumps require additional setup, see below.)
+  dotnet test --blame-hang --blame-crash
+Example: 
+  Timeout the test run when a test takes more than 20 minutes and collect hang dump. 
+  dotnet test --blame-hang-timeout 20min
+</source>
+        <target state="needs-review-translation">Esegue i test in modalità di segnalazione errore. Questa opzione è utile per isolare il test problematico che causa l'arresto anomalo dell'host dei test.
 Crea nella directory corrente un file di output denominato "Sequence.xml", in cui viene acquisito l'ordine di esecuzione del test prima dell'arresto anomalo.</target>
         <note />
       </trans-unit>

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.it.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.it.xlf
@@ -12,6 +12,36 @@
         <target state="translated">Driver di test per la piattaforma .NET</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdBlameCrashCollectAlwaysDescription">
+        <source>TODO</source>
+        <target state="new">TODO</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdBlameCrashDescription">
+        <source>TODO</source>
+        <target state="new">TODO</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdBlameCrashDumpTypeDescription">
+        <source>TODO</source>
+        <target state="new">TODO</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdBlameHangDescription">
+        <source>TODO</source>
+        <target state="new">TODO</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdBlameHangDumpTypeDescription">
+        <source>TODO</source>
+        <target state="new">TODO</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdBlameHangTimeoutDescription">
+        <source>TODO</source>
+        <target state="new">TODO</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdNoLogo">
         <source>Run test(s), without displaying Microsoft Testplatform banner</source>
         <target state="translated">Esegui test senza visualizzare il banner di Microsoft Testplatform</target>
@@ -117,6 +147,21 @@ Se non esiste, la directory specificata verrà creata.</target>
       <trans-unit id="CmdPathToResultsDirectory">
         <source>RESULTS_DIR</source>
         <target state="translated">DIR_RISULTATI</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CrashDumpTypeArgumentName">
+        <source>DUMP_TYPE</source>
+        <target state="new">DUMP_TYPE</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HangDumpTypeArgumentName">
+        <source>DUMP_TYPE</source>
+        <target state="new">DUMP_TYPE</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HangTimeoutArgumentName">
+        <source>TIMESPAN</source>
+        <target state="new">TIMESPAN</target>
         <note />
       </trans-unit>
       <trans-unit id="IgnoredArgumentsMessage">

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.ja.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.ja.xlf
@@ -12,6 +12,36 @@
         <target state="translated">.NET Platform 用テスト ドライバー</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdBlameCrashCollectAlwaysDescription">
+        <source>TODO</source>
+        <target state="new">TODO</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdBlameCrashDescription">
+        <source>TODO</source>
+        <target state="new">TODO</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdBlameCrashDumpTypeDescription">
+        <source>TODO</source>
+        <target state="new">TODO</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdBlameHangDescription">
+        <source>TODO</source>
+        <target state="new">TODO</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdBlameHangDumpTypeDescription">
+        <source>TODO</source>
+        <target state="new">TODO</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdBlameHangTimeoutDescription">
+        <source>TODO</source>
+        <target state="new">TODO</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdNoLogo">
         <source>Run test(s), without displaying Microsoft Testplatform banner</source>
         <target state="translated">Microsoft Testplatform バナーを表示せずにテストを実行する</target>
@@ -117,6 +147,21 @@ The specified directory will be created if it does not exist.</source>
       <trans-unit id="CmdPathToResultsDirectory">
         <source>RESULTS_DIR</source>
         <target state="translated">RESULTS_DIR</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CrashDumpTypeArgumentName">
+        <source>DUMP_TYPE</source>
+        <target state="new">DUMP_TYPE</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HangDumpTypeArgumentName">
+        <source>DUMP_TYPE</source>
+        <target state="new">DUMP_TYPE</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HangTimeoutArgumentName">
+        <source>TIMESPAN</source>
+        <target state="new">TIMESPAN</target>
         <note />
       </trans-unit>
       <trans-unit id="IgnoredArgumentsMessage">

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.ja.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.ja.xlf
@@ -13,33 +13,49 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameCrashCollectAlwaysDescription">
-        <source>TODO</source>
-        <target state="new">TODO</target>
+        <source>Enables collecting crash dump on expected as well as unexpected testhost exit.</source>
+        <target state="new">Enables collecting crash dump on expected as well as unexpected testhost exit.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameCrashDescription">
-        <source>TODO</source>
-        <target state="new">TODO</target>
+        <source>Runs the tests in blame mode and enables collecting crash dump when testhost exits unexpectedly. 
+This option is currently only supported on Windows, and requires procdump.exe and procdump64.exe to be available in PATH.
+Or PROCDUMP_PATH environment variable to be set, and point to a directory that contains procdump.exe and procdump64.exe. 
+The tools can be downloaded here: https://docs.microsoft.com/en-us/sysinternals/downloads/procdump 
+Implies --blame.</source>
+        <target state="new">Runs the tests in blame mode and enables collecting crash dump when testhost exits unexpectedly. 
+This option is currently only supported on Windows, and requires procdump.exe and procdump64.exe to be available in PATH.
+Or PROCDUMP_PATH environment variable to be set, and point to a directory that contains procdump.exe and procdump64.exe. 
+The tools can be downloaded here: https://docs.microsoft.com/en-us/sysinternals/downloads/procdump 
+Implies --blame.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameCrashDumpTypeDescription">
-        <source>TODO</source>
-        <target state="new">TODO</target>
+        <source>The type of crash dump to be collected. Implies --blame-crash.</source>
+        <target state="new">The type of crash dump to be collected. Implies --blame-crash.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangDescription">
-        <source>TODO</source>
-        <target state="new">TODO</target>
+        <source>Run the tests in blame mode and enables collecting hang dump when test exceeds the given timeout. Implies --blame-hang.</source>
+        <target state="new">Run the tests in blame mode and enables collecting hang dump when test exceeds the given timeout. Implies --blame-hang.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangDumpTypeDescription">
-        <source>TODO</source>
-        <target state="new">TODO</target>
+        <source>The type of crash dump to be collected. When None, is used then test host is terminated on timeout, but no dump is collected. Implies --blame-hang.</source>
+        <target state="new">The type of crash dump to be collected. When None, is used then test host is terminated on timeout, but no dump is collected. Implies --blame-hang.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangTimeoutDescription">
-        <source>TODO</source>
-        <target state="new">TODO</target>
+        <source>Per-test timeout, after which hang dump is triggered and the testhost process is terminated. 
+The timeout value is specified in the following format: 1.5h / 90m / 5400s / 5400000ms. When no unit is used (e.g. 5400000), the value is assumed to be in milliseconds.
+When used together with data driven tests, the timeout behavior depends on the test adapter used. For xUnit and NUnit the timeout is renewed after every test case,
+For MSTest, the timeout is used for all testcases.
+This option is currently supported only on Windows together with netcoreapp2.1 and newer. And on Linux with netcoreapp3.1 and newer. OSX and UWP are not supported.</source>
+        <target state="new">Per-test timeout, after which hang dump is triggered and the testhost process is terminated. 
+The timeout value is specified in the following format: 1.5h / 90m / 5400s / 5400000ms. When no unit is used (e.g. 5400000), the value is assumed to be in milliseconds.
+When used together with data driven tests, the timeout behavior depends on the test adapter used. For xUnit and NUnit the timeout is renewed after every test case,
+For MSTest, the timeout is used for all testcases.
+This option is currently supported only on Windows together with netcoreapp2.1 and newer. And on Linux with netcoreapp3.1 and newer. OSX and UWP are not supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdNoLogo">
@@ -199,9 +215,18 @@ RunSettings 引数:
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameDescription">
-        <source>Run the tests in blame mode. This option is helpful in isolating a problematic test causing the test host to crash.
-Outputs a 'Sequence.xml' file in the current directory that captures the order of execution of test before the crash.</source>
-        <target state="translated">変更履歴モードでテストを実行します。このオプションは、テスト ホストのクラッシュの原因となる問題のあるテストを分離する場合に役立ちます。
+        <source>Runs the tests in blame mode. This option is helpful in isolating problematic tests that cause the test host to crash or hang. 
+When a crash is detected, it creates an sequence file in TestResults/guid/guid_Sequence.xml that captures the order of tests that were run before the crash.
+Based on the additional settings, hang dump or crash dump can also be collected.
+Example: 
+  Timeout the test run when test takes more than the default timeout of 1 hour, and collect crash dump when the test host exits unexpectedly. 
+  (Crash dumps require additional setup, see below.)
+  dotnet test --blame-hang --blame-crash
+Example: 
+  Timeout the test run when a test takes more than 20 minutes and collect hang dump. 
+  dotnet test --blame-hang-timeout 20min
+</source>
+        <target state="needs-review-translation">変更履歴モードでテストを実行します。このオプションは、テスト ホストのクラッシュの原因となる問題のあるテストを分離する場合に役立ちます。
 現在のディレクトリに、クラッシュする前のテスト実行順序をキャプチャした出力ファイル 'Sequence.xml' が作成されます。</target>
         <note />
       </trans-unit>

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.ko.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.ko.xlf
@@ -13,33 +13,49 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameCrashCollectAlwaysDescription">
-        <source>TODO</source>
-        <target state="new">TODO</target>
+        <source>Enables collecting crash dump on expected as well as unexpected testhost exit.</source>
+        <target state="new">Enables collecting crash dump on expected as well as unexpected testhost exit.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameCrashDescription">
-        <source>TODO</source>
-        <target state="new">TODO</target>
+        <source>Runs the tests in blame mode and enables collecting crash dump when testhost exits unexpectedly. 
+This option is currently only supported on Windows, and requires procdump.exe and procdump64.exe to be available in PATH.
+Or PROCDUMP_PATH environment variable to be set, and point to a directory that contains procdump.exe and procdump64.exe. 
+The tools can be downloaded here: https://docs.microsoft.com/en-us/sysinternals/downloads/procdump 
+Implies --blame.</source>
+        <target state="new">Runs the tests in blame mode and enables collecting crash dump when testhost exits unexpectedly. 
+This option is currently only supported on Windows, and requires procdump.exe and procdump64.exe to be available in PATH.
+Or PROCDUMP_PATH environment variable to be set, and point to a directory that contains procdump.exe and procdump64.exe. 
+The tools can be downloaded here: https://docs.microsoft.com/en-us/sysinternals/downloads/procdump 
+Implies --blame.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameCrashDumpTypeDescription">
-        <source>TODO</source>
-        <target state="new">TODO</target>
+        <source>The type of crash dump to be collected. Implies --blame-crash.</source>
+        <target state="new">The type of crash dump to be collected. Implies --blame-crash.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangDescription">
-        <source>TODO</source>
-        <target state="new">TODO</target>
+        <source>Run the tests in blame mode and enables collecting hang dump when test exceeds the given timeout. Implies --blame-hang.</source>
+        <target state="new">Run the tests in blame mode and enables collecting hang dump when test exceeds the given timeout. Implies --blame-hang.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangDumpTypeDescription">
-        <source>TODO</source>
-        <target state="new">TODO</target>
+        <source>The type of crash dump to be collected. When None, is used then test host is terminated on timeout, but no dump is collected. Implies --blame-hang.</source>
+        <target state="new">The type of crash dump to be collected. When None, is used then test host is terminated on timeout, but no dump is collected. Implies --blame-hang.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangTimeoutDescription">
-        <source>TODO</source>
-        <target state="new">TODO</target>
+        <source>Per-test timeout, after which hang dump is triggered and the testhost process is terminated. 
+The timeout value is specified in the following format: 1.5h / 90m / 5400s / 5400000ms. When no unit is used (e.g. 5400000), the value is assumed to be in milliseconds.
+When used together with data driven tests, the timeout behavior depends on the test adapter used. For xUnit and NUnit the timeout is renewed after every test case,
+For MSTest, the timeout is used for all testcases.
+This option is currently supported only on Windows together with netcoreapp2.1 and newer. And on Linux with netcoreapp3.1 and newer. OSX and UWP are not supported.</source>
+        <target state="new">Per-test timeout, after which hang dump is triggered and the testhost process is terminated. 
+The timeout value is specified in the following format: 1.5h / 90m / 5400s / 5400000ms. When no unit is used (e.g. 5400000), the value is assumed to be in milliseconds.
+When used together with data driven tests, the timeout behavior depends on the test adapter used. For xUnit and NUnit the timeout is renewed after every test case,
+For MSTest, the timeout is used for all testcases.
+This option is currently supported only on Windows together with netcoreapp2.1 and newer. And on Linux with netcoreapp3.1 and newer. OSX and UWP are not supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdNoLogo">
@@ -199,9 +215,18 @@ RunSettings 인수:
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameDescription">
-        <source>Run the tests in blame mode. This option is helpful in isolating a problematic test causing the test host to crash.
-Outputs a 'Sequence.xml' file in the current directory that captures the order of execution of test before the crash.</source>
-        <target state="translated">테스트를 원인 모드로 실행합니다. 이 옵션은 테스트 호스트 크래시를 유발하는 문제 있는 테스트를 격리하는 데 유용합니다.
+        <source>Runs the tests in blame mode. This option is helpful in isolating problematic tests that cause the test host to crash or hang. 
+When a crash is detected, it creates an sequence file in TestResults/guid/guid_Sequence.xml that captures the order of tests that were run before the crash.
+Based on the additional settings, hang dump or crash dump can also be collected.
+Example: 
+  Timeout the test run when test takes more than the default timeout of 1 hour, and collect crash dump when the test host exits unexpectedly. 
+  (Crash dumps require additional setup, see below.)
+  dotnet test --blame-hang --blame-crash
+Example: 
+  Timeout the test run when a test takes more than 20 minutes and collect hang dump. 
+  dotnet test --blame-hang-timeout 20min
+</source>
+        <target state="needs-review-translation">테스트를 원인 모드로 실행합니다. 이 옵션은 테스트 호스트 크래시를 유발하는 문제 있는 테스트를 격리하는 데 유용합니다.
 크래시 이전의 테스트 실행 순서를 캡처하는 현재 디렉터리의 'Sequence.xml' 파일을 출력합니다.</target>
         <note />
       </trans-unit>

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.ko.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.ko.xlf
@@ -12,6 +12,36 @@
         <target state="translated">.NET 플랫폼용 테스트 드라이버입니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdBlameCrashCollectAlwaysDescription">
+        <source>TODO</source>
+        <target state="new">TODO</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdBlameCrashDescription">
+        <source>TODO</source>
+        <target state="new">TODO</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdBlameCrashDumpTypeDescription">
+        <source>TODO</source>
+        <target state="new">TODO</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdBlameHangDescription">
+        <source>TODO</source>
+        <target state="new">TODO</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdBlameHangDumpTypeDescription">
+        <source>TODO</source>
+        <target state="new">TODO</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdBlameHangTimeoutDescription">
+        <source>TODO</source>
+        <target state="new">TODO</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdNoLogo">
         <source>Run test(s), without displaying Microsoft Testplatform banner</source>
         <target state="translated">Microsoft Testplatform 배너를 표시하지 않고 테스트 실행</target>
@@ -117,6 +147,21 @@ The specified directory will be created if it does not exist.</source>
       <trans-unit id="CmdPathToResultsDirectory">
         <source>RESULTS_DIR</source>
         <target state="translated">RESULTS_DIR</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CrashDumpTypeArgumentName">
+        <source>DUMP_TYPE</source>
+        <target state="new">DUMP_TYPE</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HangDumpTypeArgumentName">
+        <source>DUMP_TYPE</source>
+        <target state="new">DUMP_TYPE</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HangTimeoutArgumentName">
+        <source>TIMESPAN</source>
+        <target state="new">TIMESPAN</target>
         <note />
       </trans-unit>
       <trans-unit id="IgnoredArgumentsMessage">

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.pl.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.pl.xlf
@@ -12,6 +12,36 @@
         <target state="translated">Sterownik testów dla platformy .NET</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdBlameCrashCollectAlwaysDescription">
+        <source>TODO</source>
+        <target state="new">TODO</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdBlameCrashDescription">
+        <source>TODO</source>
+        <target state="new">TODO</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdBlameCrashDumpTypeDescription">
+        <source>TODO</source>
+        <target state="new">TODO</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdBlameHangDescription">
+        <source>TODO</source>
+        <target state="new">TODO</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdBlameHangDumpTypeDescription">
+        <source>TODO</source>
+        <target state="new">TODO</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdBlameHangTimeoutDescription">
+        <source>TODO</source>
+        <target state="new">TODO</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdNoLogo">
         <source>Run test(s), without displaying Microsoft Testplatform banner</source>
         <target state="translated">Uruchom testy bez wyświetlania baneru platformy testowej firmy Microsoft</target>
@@ -117,6 +147,21 @@ Jeśli określony katalog nie istnieje, zostanie utworzony.</target>
       <trans-unit id="CmdPathToResultsDirectory">
         <source>RESULTS_DIR</source>
         <target state="translated">KATALOG_WYNIKÓW</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CrashDumpTypeArgumentName">
+        <source>DUMP_TYPE</source>
+        <target state="new">DUMP_TYPE</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HangDumpTypeArgumentName">
+        <source>DUMP_TYPE</source>
+        <target state="new">DUMP_TYPE</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HangTimeoutArgumentName">
+        <source>TIMESPAN</source>
+        <target state="new">TIMESPAN</target>
         <note />
       </trans-unit>
       <trans-unit id="IgnoredArgumentsMessage">

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.pl.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.pl.xlf
@@ -13,33 +13,49 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameCrashCollectAlwaysDescription">
-        <source>TODO</source>
-        <target state="new">TODO</target>
+        <source>Enables collecting crash dump on expected as well as unexpected testhost exit.</source>
+        <target state="new">Enables collecting crash dump on expected as well as unexpected testhost exit.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameCrashDescription">
-        <source>TODO</source>
-        <target state="new">TODO</target>
+        <source>Runs the tests in blame mode and enables collecting crash dump when testhost exits unexpectedly. 
+This option is currently only supported on Windows, and requires procdump.exe and procdump64.exe to be available in PATH.
+Or PROCDUMP_PATH environment variable to be set, and point to a directory that contains procdump.exe and procdump64.exe. 
+The tools can be downloaded here: https://docs.microsoft.com/en-us/sysinternals/downloads/procdump 
+Implies --blame.</source>
+        <target state="new">Runs the tests in blame mode and enables collecting crash dump when testhost exits unexpectedly. 
+This option is currently only supported on Windows, and requires procdump.exe and procdump64.exe to be available in PATH.
+Or PROCDUMP_PATH environment variable to be set, and point to a directory that contains procdump.exe and procdump64.exe. 
+The tools can be downloaded here: https://docs.microsoft.com/en-us/sysinternals/downloads/procdump 
+Implies --blame.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameCrashDumpTypeDescription">
-        <source>TODO</source>
-        <target state="new">TODO</target>
+        <source>The type of crash dump to be collected. Implies --blame-crash.</source>
+        <target state="new">The type of crash dump to be collected. Implies --blame-crash.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangDescription">
-        <source>TODO</source>
-        <target state="new">TODO</target>
+        <source>Run the tests in blame mode and enables collecting hang dump when test exceeds the given timeout. Implies --blame-hang.</source>
+        <target state="new">Run the tests in blame mode and enables collecting hang dump when test exceeds the given timeout. Implies --blame-hang.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangDumpTypeDescription">
-        <source>TODO</source>
-        <target state="new">TODO</target>
+        <source>The type of crash dump to be collected. When None, is used then test host is terminated on timeout, but no dump is collected. Implies --blame-hang.</source>
+        <target state="new">The type of crash dump to be collected. When None, is used then test host is terminated on timeout, but no dump is collected. Implies --blame-hang.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangTimeoutDescription">
-        <source>TODO</source>
-        <target state="new">TODO</target>
+        <source>Per-test timeout, after which hang dump is triggered and the testhost process is terminated. 
+The timeout value is specified in the following format: 1.5h / 90m / 5400s / 5400000ms. When no unit is used (e.g. 5400000), the value is assumed to be in milliseconds.
+When used together with data driven tests, the timeout behavior depends on the test adapter used. For xUnit and NUnit the timeout is renewed after every test case,
+For MSTest, the timeout is used for all testcases.
+This option is currently supported only on Windows together with netcoreapp2.1 and newer. And on Linux with netcoreapp3.1 and newer. OSX and UWP are not supported.</source>
+        <target state="new">Per-test timeout, after which hang dump is triggered and the testhost process is terminated. 
+The timeout value is specified in the following format: 1.5h / 90m / 5400s / 5400000ms. When no unit is used (e.g. 5400000), the value is assumed to be in milliseconds.
+When used together with data driven tests, the timeout behavior depends on the test adapter used. For xUnit and NUnit the timeout is renewed after every test case,
+For MSTest, the timeout is used for all testcases.
+This option is currently supported only on Windows together with netcoreapp2.1 and newer. And on Linux with netcoreapp3.1 and newer. OSX and UWP are not supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdNoLogo">
@@ -199,9 +215,18 @@ Argumenty RunSettings:
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameDescription">
-        <source>Run the tests in blame mode. This option is helpful in isolating a problematic test causing the test host to crash.
-Outputs a 'Sequence.xml' file in the current directory that captures the order of execution of test before the crash.</source>
-        <target state="translated">Uruchom testy w trybie Blame. Ta opcja jest przydatna przy izolowaniu problematycznego testu powodującego awarię hosta testów.
+        <source>Runs the tests in blame mode. This option is helpful in isolating problematic tests that cause the test host to crash or hang. 
+When a crash is detected, it creates an sequence file in TestResults/guid/guid_Sequence.xml that captures the order of tests that were run before the crash.
+Based on the additional settings, hang dump or crash dump can also be collected.
+Example: 
+  Timeout the test run when test takes more than the default timeout of 1 hour, and collect crash dump when the test host exits unexpectedly. 
+  (Crash dumps require additional setup, see below.)
+  dotnet test --blame-hang --blame-crash
+Example: 
+  Timeout the test run when a test takes more than 20 minutes and collect hang dump. 
+  dotnet test --blame-hang-timeout 20min
+</source>
+        <target state="needs-review-translation">Uruchom testy w trybie Blame. Ta opcja jest przydatna przy izolowaniu problematycznego testu powodującego awarię hosta testów.
 Tworzy w bieżącym katalogu plik wyjściowy „Sequence.xml”, który przechwytuje kolejność wykonywania testu przed awarią.</target>
         <note />
       </trans-unit>

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.pt-BR.xlf
@@ -12,6 +12,36 @@
         <target state="translated">Driver de Teste para a Plataforma .NET</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdBlameCrashCollectAlwaysDescription">
+        <source>TODO</source>
+        <target state="new">TODO</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdBlameCrashDescription">
+        <source>TODO</source>
+        <target state="new">TODO</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdBlameCrashDumpTypeDescription">
+        <source>TODO</source>
+        <target state="new">TODO</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdBlameHangDescription">
+        <source>TODO</source>
+        <target state="new">TODO</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdBlameHangDumpTypeDescription">
+        <source>TODO</source>
+        <target state="new">TODO</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdBlameHangTimeoutDescription">
+        <source>TODO</source>
+        <target state="new">TODO</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdNoLogo">
         <source>Run test(s), without displaying Microsoft Testplatform banner</source>
         <target state="translated">Executar testes, sem exibir a faixa do Microsoft Testplatform</target>
@@ -117,6 +147,21 @@ O diretório especificado será criado se ele ainda não existir.</target>
       <trans-unit id="CmdPathToResultsDirectory">
         <source>RESULTS_DIR</source>
         <target state="translated">RESULTS_DIR</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CrashDumpTypeArgumentName">
+        <source>DUMP_TYPE</source>
+        <target state="new">DUMP_TYPE</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HangDumpTypeArgumentName">
+        <source>DUMP_TYPE</source>
+        <target state="new">DUMP_TYPE</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HangTimeoutArgumentName">
+        <source>TIMESPAN</source>
+        <target state="new">TIMESPAN</target>
         <note />
       </trans-unit>
       <trans-unit id="IgnoredArgumentsMessage">

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.pt-BR.xlf
@@ -13,33 +13,49 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameCrashCollectAlwaysDescription">
-        <source>TODO</source>
-        <target state="new">TODO</target>
+        <source>Enables collecting crash dump on expected as well as unexpected testhost exit.</source>
+        <target state="new">Enables collecting crash dump on expected as well as unexpected testhost exit.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameCrashDescription">
-        <source>TODO</source>
-        <target state="new">TODO</target>
+        <source>Runs the tests in blame mode and enables collecting crash dump when testhost exits unexpectedly. 
+This option is currently only supported on Windows, and requires procdump.exe and procdump64.exe to be available in PATH.
+Or PROCDUMP_PATH environment variable to be set, and point to a directory that contains procdump.exe and procdump64.exe. 
+The tools can be downloaded here: https://docs.microsoft.com/en-us/sysinternals/downloads/procdump 
+Implies --blame.</source>
+        <target state="new">Runs the tests in blame mode and enables collecting crash dump when testhost exits unexpectedly. 
+This option is currently only supported on Windows, and requires procdump.exe and procdump64.exe to be available in PATH.
+Or PROCDUMP_PATH environment variable to be set, and point to a directory that contains procdump.exe and procdump64.exe. 
+The tools can be downloaded here: https://docs.microsoft.com/en-us/sysinternals/downloads/procdump 
+Implies --blame.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameCrashDumpTypeDescription">
-        <source>TODO</source>
-        <target state="new">TODO</target>
+        <source>The type of crash dump to be collected. Implies --blame-crash.</source>
+        <target state="new">The type of crash dump to be collected. Implies --blame-crash.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangDescription">
-        <source>TODO</source>
-        <target state="new">TODO</target>
+        <source>Run the tests in blame mode and enables collecting hang dump when test exceeds the given timeout. Implies --blame-hang.</source>
+        <target state="new">Run the tests in blame mode and enables collecting hang dump when test exceeds the given timeout. Implies --blame-hang.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangDumpTypeDescription">
-        <source>TODO</source>
-        <target state="new">TODO</target>
+        <source>The type of crash dump to be collected. When None, is used then test host is terminated on timeout, but no dump is collected. Implies --blame-hang.</source>
+        <target state="new">The type of crash dump to be collected. When None, is used then test host is terminated on timeout, but no dump is collected. Implies --blame-hang.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangTimeoutDescription">
-        <source>TODO</source>
-        <target state="new">TODO</target>
+        <source>Per-test timeout, after which hang dump is triggered and the testhost process is terminated. 
+The timeout value is specified in the following format: 1.5h / 90m / 5400s / 5400000ms. When no unit is used (e.g. 5400000), the value is assumed to be in milliseconds.
+When used together with data driven tests, the timeout behavior depends on the test adapter used. For xUnit and NUnit the timeout is renewed after every test case,
+For MSTest, the timeout is used for all testcases.
+This option is currently supported only on Windows together with netcoreapp2.1 and newer. And on Linux with netcoreapp3.1 and newer. OSX and UWP are not supported.</source>
+        <target state="new">Per-test timeout, after which hang dump is triggered and the testhost process is terminated. 
+The timeout value is specified in the following format: 1.5h / 90m / 5400s / 5400000ms. When no unit is used (e.g. 5400000), the value is assumed to be in milliseconds.
+When used together with data driven tests, the timeout behavior depends on the test adapter used. For xUnit and NUnit the timeout is renewed after every test case,
+For MSTest, the timeout is used for all testcases.
+This option is currently supported only on Windows together with netcoreapp2.1 and newer. And on Linux with netcoreapp3.1 and newer. OSX and UWP are not supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdNoLogo">
@@ -199,9 +215,18 @@ Argumentos de RunSettings:
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameDescription">
-        <source>Run the tests in blame mode. This option is helpful in isolating a problematic test causing the test host to crash.
-Outputs a 'Sequence.xml' file in the current directory that captures the order of execution of test before the crash.</source>
-        <target state="translated">Executar os testes no modo de acusação. Essa opção é útil para isolar um teste problemático que esteja causando falha no host de teste.
+        <source>Runs the tests in blame mode. This option is helpful in isolating problematic tests that cause the test host to crash or hang. 
+When a crash is detected, it creates an sequence file in TestResults/guid/guid_Sequence.xml that captures the order of tests that were run before the crash.
+Based on the additional settings, hang dump or crash dump can also be collected.
+Example: 
+  Timeout the test run when test takes more than the default timeout of 1 hour, and collect crash dump when the test host exits unexpectedly. 
+  (Crash dumps require additional setup, see below.)
+  dotnet test --blame-hang --blame-crash
+Example: 
+  Timeout the test run when a test takes more than 20 minutes and collect hang dump. 
+  dotnet test --blame-hang-timeout 20min
+</source>
+        <target state="needs-review-translation">Executar os testes no modo de acusação. Essa opção é útil para isolar um teste problemático que esteja causando falha no host de teste.
 Emite um arquivo 'Sequence.xml' no diretório atual que captura a ordem de execução de teste antes da falha.</target>
         <note />
       </trans-unit>

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.ru.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.ru.xlf
@@ -12,6 +12,36 @@
         <target state="translated">Драйвер тестов для платформы .NET</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdBlameCrashCollectAlwaysDescription">
+        <source>TODO</source>
+        <target state="new">TODO</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdBlameCrashDescription">
+        <source>TODO</source>
+        <target state="new">TODO</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdBlameCrashDumpTypeDescription">
+        <source>TODO</source>
+        <target state="new">TODO</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdBlameHangDescription">
+        <source>TODO</source>
+        <target state="new">TODO</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdBlameHangDumpTypeDescription">
+        <source>TODO</source>
+        <target state="new">TODO</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdBlameHangTimeoutDescription">
+        <source>TODO</source>
+        <target state="new">TODO</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdNoLogo">
         <source>Run test(s), without displaying Microsoft Testplatform banner</source>
         <target state="translated">Запуск тестов без отображения баннера Testplatform Майкрософт</target>
@@ -117,6 +147,21 @@ The specified directory will be created if it does not exist.</source>
       <trans-unit id="CmdPathToResultsDirectory">
         <source>RESULTS_DIR</source>
         <target state="translated">RESULTS_DIR</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CrashDumpTypeArgumentName">
+        <source>DUMP_TYPE</source>
+        <target state="new">DUMP_TYPE</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HangDumpTypeArgumentName">
+        <source>DUMP_TYPE</source>
+        <target state="new">DUMP_TYPE</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HangTimeoutArgumentName">
+        <source>TIMESPAN</source>
+        <target state="new">TIMESPAN</target>
         <note />
       </trans-unit>
       <trans-unit id="IgnoredArgumentsMessage">

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.ru.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.ru.xlf
@@ -13,33 +13,49 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameCrashCollectAlwaysDescription">
-        <source>TODO</source>
-        <target state="new">TODO</target>
+        <source>Enables collecting crash dump on expected as well as unexpected testhost exit.</source>
+        <target state="new">Enables collecting crash dump on expected as well as unexpected testhost exit.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameCrashDescription">
-        <source>TODO</source>
-        <target state="new">TODO</target>
+        <source>Runs the tests in blame mode and enables collecting crash dump when testhost exits unexpectedly. 
+This option is currently only supported on Windows, and requires procdump.exe and procdump64.exe to be available in PATH.
+Or PROCDUMP_PATH environment variable to be set, and point to a directory that contains procdump.exe and procdump64.exe. 
+The tools can be downloaded here: https://docs.microsoft.com/en-us/sysinternals/downloads/procdump 
+Implies --blame.</source>
+        <target state="new">Runs the tests in blame mode and enables collecting crash dump when testhost exits unexpectedly. 
+This option is currently only supported on Windows, and requires procdump.exe and procdump64.exe to be available in PATH.
+Or PROCDUMP_PATH environment variable to be set, and point to a directory that contains procdump.exe and procdump64.exe. 
+The tools can be downloaded here: https://docs.microsoft.com/en-us/sysinternals/downloads/procdump 
+Implies --blame.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameCrashDumpTypeDescription">
-        <source>TODO</source>
-        <target state="new">TODO</target>
+        <source>The type of crash dump to be collected. Implies --blame-crash.</source>
+        <target state="new">The type of crash dump to be collected. Implies --blame-crash.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangDescription">
-        <source>TODO</source>
-        <target state="new">TODO</target>
+        <source>Run the tests in blame mode and enables collecting hang dump when test exceeds the given timeout. Implies --blame-hang.</source>
+        <target state="new">Run the tests in blame mode and enables collecting hang dump when test exceeds the given timeout. Implies --blame-hang.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangDumpTypeDescription">
-        <source>TODO</source>
-        <target state="new">TODO</target>
+        <source>The type of crash dump to be collected. When None, is used then test host is terminated on timeout, but no dump is collected. Implies --blame-hang.</source>
+        <target state="new">The type of crash dump to be collected. When None, is used then test host is terminated on timeout, but no dump is collected. Implies --blame-hang.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangTimeoutDescription">
-        <source>TODO</source>
-        <target state="new">TODO</target>
+        <source>Per-test timeout, after which hang dump is triggered and the testhost process is terminated. 
+The timeout value is specified in the following format: 1.5h / 90m / 5400s / 5400000ms. When no unit is used (e.g. 5400000), the value is assumed to be in milliseconds.
+When used together with data driven tests, the timeout behavior depends on the test adapter used. For xUnit and NUnit the timeout is renewed after every test case,
+For MSTest, the timeout is used for all testcases.
+This option is currently supported only on Windows together with netcoreapp2.1 and newer. And on Linux with netcoreapp3.1 and newer. OSX and UWP are not supported.</source>
+        <target state="new">Per-test timeout, after which hang dump is triggered and the testhost process is terminated. 
+The timeout value is specified in the following format: 1.5h / 90m / 5400s / 5400000ms. When no unit is used (e.g. 5400000), the value is assumed to be in milliseconds.
+When used together with data driven tests, the timeout behavior depends on the test adapter used. For xUnit and NUnit the timeout is renewed after every test case,
+For MSTest, the timeout is used for all testcases.
+This option is currently supported only on Windows together with netcoreapp2.1 and newer. And on Linux with netcoreapp3.1 and newer. OSX and UWP are not supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdNoLogo">
@@ -199,9 +215,18 @@ RunSettings arguments:
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameDescription">
-        <source>Run the tests in blame mode. This option is helpful in isolating a problematic test causing the test host to crash.
-Outputs a 'Sequence.xml' file in the current directory that captures the order of execution of test before the crash.</source>
-        <target state="translated">Выполнение тестов в режиме обвинения. Этот параметр помогает изолировать проблемный тест, из-за которого в хосте для тестов возникает сбой.
+        <source>Runs the tests in blame mode. This option is helpful in isolating problematic tests that cause the test host to crash or hang. 
+When a crash is detected, it creates an sequence file in TestResults/guid/guid_Sequence.xml that captures the order of tests that were run before the crash.
+Based on the additional settings, hang dump or crash dump can also be collected.
+Example: 
+  Timeout the test run when test takes more than the default timeout of 1 hour, and collect crash dump when the test host exits unexpectedly. 
+  (Crash dumps require additional setup, see below.)
+  dotnet test --blame-hang --blame-crash
+Example: 
+  Timeout the test run when a test takes more than 20 minutes and collect hang dump. 
+  dotnet test --blame-hang-timeout 20min
+</source>
+        <target state="needs-review-translation">Выполнение тестов в режиме обвинения. Этот параметр помогает изолировать проблемный тест, из-за которого в хосте для тестов возникает сбой.
 В текущем каталоге создается выходной файл "Sequence.xml", в который записывается порядок выполнения теста перед сбоем.</target>
         <note />
       </trans-unit>

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.tr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.tr.xlf
@@ -12,6 +12,36 @@
         <target state="translated">.NET Platformunun Test Sürücüsü</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdBlameCrashCollectAlwaysDescription">
+        <source>TODO</source>
+        <target state="new">TODO</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdBlameCrashDescription">
+        <source>TODO</source>
+        <target state="new">TODO</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdBlameCrashDumpTypeDescription">
+        <source>TODO</source>
+        <target state="new">TODO</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdBlameHangDescription">
+        <source>TODO</source>
+        <target state="new">TODO</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdBlameHangDumpTypeDescription">
+        <source>TODO</source>
+        <target state="new">TODO</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdBlameHangTimeoutDescription">
+        <source>TODO</source>
+        <target state="new">TODO</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdNoLogo">
         <source>Run test(s), without displaying Microsoft Testplatform banner</source>
         <target state="translated">Testleri Microsoft Testplatform bandını görüntülemeden çalıştır</target>
@@ -117,6 +147,21 @@ Belirtilen dizin yoksa oluşturulur.</target>
       <trans-unit id="CmdPathToResultsDirectory">
         <source>RESULTS_DIR</source>
         <target state="translated">RESULTS_DIR</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CrashDumpTypeArgumentName">
+        <source>DUMP_TYPE</source>
+        <target state="new">DUMP_TYPE</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HangDumpTypeArgumentName">
+        <source>DUMP_TYPE</source>
+        <target state="new">DUMP_TYPE</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HangTimeoutArgumentName">
+        <source>TIMESPAN</source>
+        <target state="new">TIMESPAN</target>
         <note />
       </trans-unit>
       <trans-unit id="IgnoredArgumentsMessage">

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.tr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.tr.xlf
@@ -13,33 +13,49 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameCrashCollectAlwaysDescription">
-        <source>TODO</source>
-        <target state="new">TODO</target>
+        <source>Enables collecting crash dump on expected as well as unexpected testhost exit.</source>
+        <target state="new">Enables collecting crash dump on expected as well as unexpected testhost exit.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameCrashDescription">
-        <source>TODO</source>
-        <target state="new">TODO</target>
+        <source>Runs the tests in blame mode and enables collecting crash dump when testhost exits unexpectedly. 
+This option is currently only supported on Windows, and requires procdump.exe and procdump64.exe to be available in PATH.
+Or PROCDUMP_PATH environment variable to be set, and point to a directory that contains procdump.exe and procdump64.exe. 
+The tools can be downloaded here: https://docs.microsoft.com/en-us/sysinternals/downloads/procdump 
+Implies --blame.</source>
+        <target state="new">Runs the tests in blame mode and enables collecting crash dump when testhost exits unexpectedly. 
+This option is currently only supported on Windows, and requires procdump.exe and procdump64.exe to be available in PATH.
+Or PROCDUMP_PATH environment variable to be set, and point to a directory that contains procdump.exe and procdump64.exe. 
+The tools can be downloaded here: https://docs.microsoft.com/en-us/sysinternals/downloads/procdump 
+Implies --blame.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameCrashDumpTypeDescription">
-        <source>TODO</source>
-        <target state="new">TODO</target>
+        <source>The type of crash dump to be collected. Implies --blame-crash.</source>
+        <target state="new">The type of crash dump to be collected. Implies --blame-crash.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangDescription">
-        <source>TODO</source>
-        <target state="new">TODO</target>
+        <source>Run the tests in blame mode and enables collecting hang dump when test exceeds the given timeout. Implies --blame-hang.</source>
+        <target state="new">Run the tests in blame mode and enables collecting hang dump when test exceeds the given timeout. Implies --blame-hang.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangDumpTypeDescription">
-        <source>TODO</source>
-        <target state="new">TODO</target>
+        <source>The type of crash dump to be collected. When None, is used then test host is terminated on timeout, but no dump is collected. Implies --blame-hang.</source>
+        <target state="new">The type of crash dump to be collected. When None, is used then test host is terminated on timeout, but no dump is collected. Implies --blame-hang.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangTimeoutDescription">
-        <source>TODO</source>
-        <target state="new">TODO</target>
+        <source>Per-test timeout, after which hang dump is triggered and the testhost process is terminated. 
+The timeout value is specified in the following format: 1.5h / 90m / 5400s / 5400000ms. When no unit is used (e.g. 5400000), the value is assumed to be in milliseconds.
+When used together with data driven tests, the timeout behavior depends on the test adapter used. For xUnit and NUnit the timeout is renewed after every test case,
+For MSTest, the timeout is used for all testcases.
+This option is currently supported only on Windows together with netcoreapp2.1 and newer. And on Linux with netcoreapp3.1 and newer. OSX and UWP are not supported.</source>
+        <target state="new">Per-test timeout, after which hang dump is triggered and the testhost process is terminated. 
+The timeout value is specified in the following format: 1.5h / 90m / 5400s / 5400000ms. When no unit is used (e.g. 5400000), the value is assumed to be in milliseconds.
+When used together with data driven tests, the timeout behavior depends on the test adapter used. For xUnit and NUnit the timeout is renewed after every test case,
+For MSTest, the timeout is used for all testcases.
+This option is currently supported only on Windows together with netcoreapp2.1 and newer. And on Linux with netcoreapp3.1 and newer. OSX and UWP are not supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdNoLogo">
@@ -199,9 +215,18 @@ RunSettings bağımsız değişkenleri:
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameDescription">
-        <source>Run the tests in blame mode. This option is helpful in isolating a problematic test causing the test host to crash.
-Outputs a 'Sequence.xml' file in the current directory that captures the order of execution of test before the crash.</source>
-        <target state="translated">Testleri blame modunda çalıştırır. Bu seçenek, test konağının kilitlenmesine neden olan sorunlu testi yalıtmak için kullanışlıdır.
+        <source>Runs the tests in blame mode. This option is helpful in isolating problematic tests that cause the test host to crash or hang. 
+When a crash is detected, it creates an sequence file in TestResults/guid/guid_Sequence.xml that captures the order of tests that were run before the crash.
+Based on the additional settings, hang dump or crash dump can also be collected.
+Example: 
+  Timeout the test run when test takes more than the default timeout of 1 hour, and collect crash dump when the test host exits unexpectedly. 
+  (Crash dumps require additional setup, see below.)
+  dotnet test --blame-hang --blame-crash
+Example: 
+  Timeout the test run when a test takes more than 20 minutes and collect hang dump. 
+  dotnet test --blame-hang-timeout 20min
+</source>
+        <target state="needs-review-translation">Testleri blame modunda çalıştırır. Bu seçenek, test konağının kilitlenmesine neden olan sorunlu testi yalıtmak için kullanışlıdır.
 Geçerli dizinde testin kilitlenmeden önceki test yürütme sırasını yakalayan ‘Sequence.xml’ adlı dosyayı çıkarır.</target>
         <note />
       </trans-unit>

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.zh-Hans.xlf
@@ -13,33 +13,49 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameCrashCollectAlwaysDescription">
-        <source>TODO</source>
-        <target state="new">TODO</target>
+        <source>Enables collecting crash dump on expected as well as unexpected testhost exit.</source>
+        <target state="new">Enables collecting crash dump on expected as well as unexpected testhost exit.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameCrashDescription">
-        <source>TODO</source>
-        <target state="new">TODO</target>
+        <source>Runs the tests in blame mode and enables collecting crash dump when testhost exits unexpectedly. 
+This option is currently only supported on Windows, and requires procdump.exe and procdump64.exe to be available in PATH.
+Or PROCDUMP_PATH environment variable to be set, and point to a directory that contains procdump.exe and procdump64.exe. 
+The tools can be downloaded here: https://docs.microsoft.com/en-us/sysinternals/downloads/procdump 
+Implies --blame.</source>
+        <target state="new">Runs the tests in blame mode and enables collecting crash dump when testhost exits unexpectedly. 
+This option is currently only supported on Windows, and requires procdump.exe and procdump64.exe to be available in PATH.
+Or PROCDUMP_PATH environment variable to be set, and point to a directory that contains procdump.exe and procdump64.exe. 
+The tools can be downloaded here: https://docs.microsoft.com/en-us/sysinternals/downloads/procdump 
+Implies --blame.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameCrashDumpTypeDescription">
-        <source>TODO</source>
-        <target state="new">TODO</target>
+        <source>The type of crash dump to be collected. Implies --blame-crash.</source>
+        <target state="new">The type of crash dump to be collected. Implies --blame-crash.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangDescription">
-        <source>TODO</source>
-        <target state="new">TODO</target>
+        <source>Run the tests in blame mode and enables collecting hang dump when test exceeds the given timeout. Implies --blame-hang.</source>
+        <target state="new">Run the tests in blame mode and enables collecting hang dump when test exceeds the given timeout. Implies --blame-hang.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangDumpTypeDescription">
-        <source>TODO</source>
-        <target state="new">TODO</target>
+        <source>The type of crash dump to be collected. When None, is used then test host is terminated on timeout, but no dump is collected. Implies --blame-hang.</source>
+        <target state="new">The type of crash dump to be collected. When None, is used then test host is terminated on timeout, but no dump is collected. Implies --blame-hang.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangTimeoutDescription">
-        <source>TODO</source>
-        <target state="new">TODO</target>
+        <source>Per-test timeout, after which hang dump is triggered and the testhost process is terminated. 
+The timeout value is specified in the following format: 1.5h / 90m / 5400s / 5400000ms. When no unit is used (e.g. 5400000), the value is assumed to be in milliseconds.
+When used together with data driven tests, the timeout behavior depends on the test adapter used. For xUnit and NUnit the timeout is renewed after every test case,
+For MSTest, the timeout is used for all testcases.
+This option is currently supported only on Windows together with netcoreapp2.1 and newer. And on Linux with netcoreapp3.1 and newer. OSX and UWP are not supported.</source>
+        <target state="new">Per-test timeout, after which hang dump is triggered and the testhost process is terminated. 
+The timeout value is specified in the following format: 1.5h / 90m / 5400s / 5400000ms. When no unit is used (e.g. 5400000), the value is assumed to be in milliseconds.
+When used together with data driven tests, the timeout behavior depends on the test adapter used. For xUnit and NUnit the timeout is renewed after every test case,
+For MSTest, the timeout is used for all testcases.
+This option is currently supported only on Windows together with netcoreapp2.1 and newer. And on Linux with netcoreapp3.1 and newer. OSX and UWP are not supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdNoLogo">
@@ -199,9 +215,18 @@ RunSettings 参数:
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameDescription">
-        <source>Run the tests in blame mode. This option is helpful in isolating a problematic test causing the test host to crash.
-Outputs a 'Sequence.xml' file in the current directory that captures the order of execution of test before the crash.</source>
-        <target state="translated">在追责模式下运行测试。此选项有助于隔离有问题的测试，以免导致测试主机崩溃。
+        <source>Runs the tests in blame mode. This option is helpful in isolating problematic tests that cause the test host to crash or hang. 
+When a crash is detected, it creates an sequence file in TestResults/guid/guid_Sequence.xml that captures the order of tests that were run before the crash.
+Based on the additional settings, hang dump or crash dump can also be collected.
+Example: 
+  Timeout the test run when test takes more than the default timeout of 1 hour, and collect crash dump when the test host exits unexpectedly. 
+  (Crash dumps require additional setup, see below.)
+  dotnet test --blame-hang --blame-crash
+Example: 
+  Timeout the test run when a test takes more than 20 minutes and collect hang dump. 
+  dotnet test --blame-hang-timeout 20min
+</source>
+        <target state="needs-review-translation">在追责模式下运行测试。此选项有助于隔离有问题的测试，以免导致测试主机崩溃。
 在当前目录中输出一个 "Sequence.xml" 文件，该文件在崩溃之前捕获测试的执行顺序。</target>
         <note />
       </trans-unit>

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.zh-Hans.xlf
@@ -12,6 +12,36 @@
         <target state="translated">适用于 .NET 平台的测试驱动程序</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdBlameCrashCollectAlwaysDescription">
+        <source>TODO</source>
+        <target state="new">TODO</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdBlameCrashDescription">
+        <source>TODO</source>
+        <target state="new">TODO</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdBlameCrashDumpTypeDescription">
+        <source>TODO</source>
+        <target state="new">TODO</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdBlameHangDescription">
+        <source>TODO</source>
+        <target state="new">TODO</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdBlameHangDumpTypeDescription">
+        <source>TODO</source>
+        <target state="new">TODO</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdBlameHangTimeoutDescription">
+        <source>TODO</source>
+        <target state="new">TODO</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdNoLogo">
         <source>Run test(s), without displaying Microsoft Testplatform banner</source>
         <target state="translated">运行测试，而不显示 Microsoft Testplatform 版权标志</target>
@@ -117,6 +147,21 @@ The specified directory will be created if it does not exist.</source>
       <trans-unit id="CmdPathToResultsDirectory">
         <source>RESULTS_DIR</source>
         <target state="translated">RESULTS_DIR</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CrashDumpTypeArgumentName">
+        <source>DUMP_TYPE</source>
+        <target state="new">DUMP_TYPE</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HangDumpTypeArgumentName">
+        <source>DUMP_TYPE</source>
+        <target state="new">DUMP_TYPE</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HangTimeoutArgumentName">
+        <source>TIMESPAN</source>
+        <target state="new">TIMESPAN</target>
         <note />
       </trans-unit>
       <trans-unit id="IgnoredArgumentsMessage">

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.zh-Hant.xlf
@@ -13,33 +13,49 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameCrashCollectAlwaysDescription">
-        <source>TODO</source>
-        <target state="new">TODO</target>
+        <source>Enables collecting crash dump on expected as well as unexpected testhost exit.</source>
+        <target state="new">Enables collecting crash dump on expected as well as unexpected testhost exit.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameCrashDescription">
-        <source>TODO</source>
-        <target state="new">TODO</target>
+        <source>Runs the tests in blame mode and enables collecting crash dump when testhost exits unexpectedly. 
+This option is currently only supported on Windows, and requires procdump.exe and procdump64.exe to be available in PATH.
+Or PROCDUMP_PATH environment variable to be set, and point to a directory that contains procdump.exe and procdump64.exe. 
+The tools can be downloaded here: https://docs.microsoft.com/en-us/sysinternals/downloads/procdump 
+Implies --blame.</source>
+        <target state="new">Runs the tests in blame mode and enables collecting crash dump when testhost exits unexpectedly. 
+This option is currently only supported on Windows, and requires procdump.exe and procdump64.exe to be available in PATH.
+Or PROCDUMP_PATH environment variable to be set, and point to a directory that contains procdump.exe and procdump64.exe. 
+The tools can be downloaded here: https://docs.microsoft.com/en-us/sysinternals/downloads/procdump 
+Implies --blame.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameCrashDumpTypeDescription">
-        <source>TODO</source>
-        <target state="new">TODO</target>
+        <source>The type of crash dump to be collected. Implies --blame-crash.</source>
+        <target state="new">The type of crash dump to be collected. Implies --blame-crash.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangDescription">
-        <source>TODO</source>
-        <target state="new">TODO</target>
+        <source>Run the tests in blame mode and enables collecting hang dump when test exceeds the given timeout. Implies --blame-hang.</source>
+        <target state="new">Run the tests in blame mode and enables collecting hang dump when test exceeds the given timeout. Implies --blame-hang.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangDumpTypeDescription">
-        <source>TODO</source>
-        <target state="new">TODO</target>
+        <source>The type of crash dump to be collected. When None, is used then test host is terminated on timeout, but no dump is collected. Implies --blame-hang.</source>
+        <target state="new">The type of crash dump to be collected. When None, is used then test host is terminated on timeout, but no dump is collected. Implies --blame-hang.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangTimeoutDescription">
-        <source>TODO</source>
-        <target state="new">TODO</target>
+        <source>Per-test timeout, after which hang dump is triggered and the testhost process is terminated. 
+The timeout value is specified in the following format: 1.5h / 90m / 5400s / 5400000ms. When no unit is used (e.g. 5400000), the value is assumed to be in milliseconds.
+When used together with data driven tests, the timeout behavior depends on the test adapter used. For xUnit and NUnit the timeout is renewed after every test case,
+For MSTest, the timeout is used for all testcases.
+This option is currently supported only on Windows together with netcoreapp2.1 and newer. And on Linux with netcoreapp3.1 and newer. OSX and UWP are not supported.</source>
+        <target state="new">Per-test timeout, after which hang dump is triggered and the testhost process is terminated. 
+The timeout value is specified in the following format: 1.5h / 90m / 5400s / 5400000ms. When no unit is used (e.g. 5400000), the value is assumed to be in milliseconds.
+When used together with data driven tests, the timeout behavior depends on the test adapter used. For xUnit and NUnit the timeout is renewed after every test case,
+For MSTest, the timeout is used for all testcases.
+This option is currently supported only on Windows together with netcoreapp2.1 and newer. And on Linux with netcoreapp3.1 and newer. OSX and UWP are not supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdNoLogo">
@@ -199,9 +215,18 @@ RunSettings 引數:
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameDescription">
-        <source>Run the tests in blame mode. This option is helpful in isolating a problematic test causing the test host to crash.
-Outputs a 'Sequence.xml' file in the current directory that captures the order of execution of test before the crash.</source>
-        <target state="translated">以 Blame 模式執行測試。此選項有助於釐清造成測試主機損毀的出錯測試。
+        <source>Runs the tests in blame mode. This option is helpful in isolating problematic tests that cause the test host to crash or hang. 
+When a crash is detected, it creates an sequence file in TestResults/guid/guid_Sequence.xml that captures the order of tests that were run before the crash.
+Based on the additional settings, hang dump or crash dump can also be collected.
+Example: 
+  Timeout the test run when test takes more than the default timeout of 1 hour, and collect crash dump when the test host exits unexpectedly. 
+  (Crash dumps require additional setup, see below.)
+  dotnet test --blame-hang --blame-crash
+Example: 
+  Timeout the test run when a test takes more than 20 minutes and collect hang dump. 
+  dotnet test --blame-hang-timeout 20min
+</source>
+        <target state="needs-review-translation">以 Blame 模式執行測試。此選項有助於釐清造成測試主機損毀的出錯測試。
 其會在目前的目錄 (擷取損毀前執行測試的順序) 中輸出 'Sequence.xml' 檔案。</target>
         <note />
       </trans-unit>

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.zh-Hant.xlf
@@ -12,6 +12,36 @@
         <target state="translated">適用於 .NET 平台的測試驅動程式</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdBlameCrashCollectAlwaysDescription">
+        <source>TODO</source>
+        <target state="new">TODO</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdBlameCrashDescription">
+        <source>TODO</source>
+        <target state="new">TODO</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdBlameCrashDumpTypeDescription">
+        <source>TODO</source>
+        <target state="new">TODO</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdBlameHangDescription">
+        <source>TODO</source>
+        <target state="new">TODO</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdBlameHangDumpTypeDescription">
+        <source>TODO</source>
+        <target state="new">TODO</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdBlameHangTimeoutDescription">
+        <source>TODO</source>
+        <target state="new">TODO</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdNoLogo">
         <source>Run test(s), without displaying Microsoft Testplatform banner</source>
         <target state="translated">執行測試，但不顯示 Microsoft Testplatform 橫幅</target>
@@ -117,6 +147,21 @@ The specified directory will be created if it does not exist.</source>
       <trans-unit id="CmdPathToResultsDirectory">
         <source>RESULTS_DIR</source>
         <target state="translated">RESULTS_DIR</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CrashDumpTypeArgumentName">
+        <source>DUMP_TYPE</source>
+        <target state="new">DUMP_TYPE</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HangDumpTypeArgumentName">
+        <source>DUMP_TYPE</source>
+        <target state="new">DUMP_TYPE</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HangTimeoutArgumentName">
+        <source>TIMESPAN</source>
+        <target state="new">TIMESPAN</target>
         <note />
       </trans-unit>
       <trans-unit id="IgnoredArgumentsMessage">

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThereAreDefaultItems.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThereAreDefaultItems.cs
@@ -528,46 +528,6 @@ namespace Microsoft.NET.Build.Tests
         }
 
         [Fact]
-        public void It_gives_the_correct_error_if_duplicate_compile_items_are_included_and_default_items_are_disabled()
-        {
-            var testProject = new TestProject()
-            {
-                Name = "DuplicateCompileItems",
-                TargetFrameworks = "netstandard1.6",
-                IsSdkProject = true
-            };
-
-            var testAsset = _testAssetsManager.CreateTestProject(testProject, "DuplicateCompileItemsWithDefaultItemsDisabled")
-                .WithProjectChanges(project =>
-                {
-                    var ns = project.Root.Name.Namespace;
-
-                    project.Root.Element(ns + "PropertyGroup").Add(
-                        new XElement(ns + "EnableDefaultCompileItems", "false"));
-
-                    var itemGroup = new XElement(ns + "ItemGroup");
-                    project.Root.Add(itemGroup);
-                    itemGroup.Add(new XElement(ns + "Compile", new XAttribute("Include", @"**\*.cs")));
-                    itemGroup.Add(new XElement(ns + "Compile", new XAttribute("Include", @"DuplicateCompileItems.cs")));
-                });
-
-            var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
-
-            WriteFile(Path.Combine(buildCommand.ProjectRootPath, "Class1.cs"), "public class Class1 {}");
-
-            buildCommand
-                .Execute()
-                .Should()
-                .Fail()
-                .And.HaveStdOutContaining("DuplicateCompileItems.cs")
-                //  Class1.cs wasn't included multiple times, so it shouldn't be mentioned
-                .And.NotHaveStdOutMatching("Class1.cs")
-                //  Default items weren't enabled, so the error message should come from the C# compiler and shouldn't include the information about default compile items
-                .And.HaveStdOutContaining("MSB3105")
-                .And.NotHaveStdOutMatching("EnableDefaultCompileItems");
-        }
-
-        [Fact]
         public void Implicit_package_references_are_overridden_by_PackageReference_includes_in_the_project_file()
         {
             var testProject = new TestProject()


### PR DESCRIPTION
 Adds options to enable crash and hang dumps from dotnet test commandline without using runsettings.