### PR TITLE
Use SingleFileHost

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "5.0.100-preview.6.20266.3",
+    "dotnet": "5.0.100-preview.6.20278.11",
     "runtimes": {
       "dotnet": [
         "$(MicrosoftNETCoreAppRuntimePackageVersion)"

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "5.0.100-preview.6.20278.11",
+    "dotnet": "5.0.100-preview.6.20280.6",
     "runtimes": {
       "dotnet": [
         "$(MicrosoftNETCoreAppRuntimePackageVersion)"

--- a/src/Assets/TestProjects/HelloWorldWithSubDirs/HelloWorldWithSubDirs.csproj
+++ b/src/Assets/TestProjects/HelloWorldWithSubDirs/HelloWorldWithSubDirs.csproj
@@ -2,18 +2,18 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
     <Content Include="$(MSBuildThisFileDirectory)\SmallNameDir\**\*.*" >
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
     </Content>
-    <Content Include="$(MSBuildThisFileDirectory)\Signature.Newest.Stamp" >
+    <Content Include="$(MSBuildThisFileDirectory)\Signature.Newest.Stamp" Condition="'$(PlaceStamp)' == 'true'">
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
       <ExcludeFromSingleFile>$(ExcludeNewest)</ExcludeFromSingleFile>
     </Content>
-    <Content Include="$(MSBuildThisFileDirectory)\Signature.Always.Stamp" >
+    <Content Include="$(MSBuildThisFileDirectory)\Signature.Always.Stamp" Condition="'$(PlaceStamp)' == 'true'">
       <CopyToPublishDirectory>Always</CopyToPublishDirectory>
       <ExcludeFromSingleFile>$(ExcludeAlways)</ExcludeFromSingleFile>
     </Content>

--- a/src/Assets/TestProjects/HelloWorldWithSubDirs/HelloWorldWithSubDirs.csproj
+++ b/src/Assets/TestProjects/HelloWorldWithSubDirs/HelloWorldWithSubDirs.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp5.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Tasks/Common/MetadataKeys.cs
+++ b/src/Tasks/Common/MetadataKeys.cs
@@ -80,6 +80,9 @@ namespace Microsoft.NET.Build.Tasks
         //  Targeting packs
         public const string PackageConflictPreferredPackages = "PackageConflictPreferredPackages";
 
+        //  Runtime packs
+        public const string DropFromSingleFile = "DropFromSingleFile";
+
         // Content files
         public const string PPOutputPath = "PPOutputPath";
         public const string CodeLanguage = "CodeLanguage";

--- a/src/Tasks/Microsoft.NET.Build.Tasks/GenerateBundle.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/GenerateBundle.cs
@@ -19,6 +19,10 @@ namespace Microsoft.NET.Build.Tasks
         [Required]
         public bool IncludeSymbols { get; set; }
         [Required]
+        public bool IncludeNativeLibraries { get; set; }
+        [Required]
+        public bool IncludeAllContent { get; set; }
+        [Required]
         public string TargetFrameworkVersion { get; set; }
         [Required]
         public string RuntimeIdentifier { get; set; }
@@ -35,7 +39,9 @@ namespace Microsoft.NET.Build.Tasks
             OSPlatform targetOS = RuntimeIdentifier.StartsWith("win") ? OSPlatform.Windows :
                                   RuntimeIdentifier.StartsWith("osx") ? OSPlatform.OSX : OSPlatform.Linux;
 
-            BundleOptions options = BundleOptions.BundleAllContent;
+            BundleOptions options = BundleOptions.None;
+            options |= IncludeNativeLibraries ? BundleOptions.BundleNativeBinaries : BundleOptions.None;
+            options |= IncludeAllContent ? BundleOptions.BundleAllContent : BundleOptions.None;
             options |= IncludeSymbols ? BundleOptions.BundleSymbolFiles : BundleOptions.None;
 
             var bundler = new Bundler(AppHostName, OutputDir, options, targetOS, new Version(TargetFrameworkVersion), ShowDiagnosticOutput);

--- a/src/Tasks/Microsoft.NET.Build.Tasks/GenerateDepsFile.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/GenerateDepsFile.cs
@@ -172,9 +172,8 @@ namespace Microsoft.NET.Build.Tasks
 
             IEnumerable<RuntimePackAssetInfo> runtimePackAssets =
                 IsSelfContained ? 
-                    IsSingleFile ? RuntimePackAssets.Where(item => !item.GetMetadata(MetadataKeys.DropFromSingleFile).Equals("true"))
-                                                    .Select(item => RuntimePackAssetInfo.FromItem(item)) :
-                                   RuntimePackAssets.Select(item => RuntimePackAssetInfo.FromItem(item)) : 
+                    RuntimePackAssets.Where(item => !IsSingleFile || !item.GetMetadata(MetadataKeys.DropFromSingleFile).Equals("true"))
+                                     .Select(item => RuntimePackAssetInfo.FromItem(item)) :
                     Enumerable.Empty<RuntimePackAssetInfo>();
 
             DependencyContextBuilder builder;

--- a/src/Tasks/Microsoft.NET.Build.Tasks/GenerateDepsFile.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/GenerateDepsFile.cs
@@ -90,6 +90,8 @@ namespace Microsoft.NET.Build.Tasks
 
         public bool IsSelfContained { get; set; }
 
+        public bool IsSingleFile { get; set; }
+
         public bool IncludeRuntimeFileVersions { get; set; }
 
         [Required]
@@ -169,7 +171,11 @@ namespace Microsoft.NET.Build.Tasks
                 SingleProjectInfo.CreateProjectReferenceInfos(ReferencePaths, ReferenceSatellitePaths, isUserRuntimeAssembly);
 
             IEnumerable<RuntimePackAssetInfo> runtimePackAssets =
-                IsSelfContained ? RuntimePackAssets.Select(item => RuntimePackAssetInfo.FromItem(item)) : Enumerable.Empty<RuntimePackAssetInfo>();
+                IsSelfContained ? 
+                    IsSingleFile ? RuntimePackAssets.Where(item => !item.GetMetadata(MetadataKeys.DropFromSingleFile).Equals("true"))
+                                                    .Select(item => RuntimePackAssetInfo.FromItem(item)) :
+                                   RuntimePackAssets.Select(item => RuntimePackAssetInfo.FromItem(item)) : 
+                    Enumerable.Empty<RuntimePackAssetInfo>();
 
             DependencyContextBuilder builder;
             if (projectContext != null)

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolveAppHosts.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveAppHosts.cs
@@ -31,6 +31,9 @@ namespace Microsoft.NET.Build.Tasks
         [Required]
         public string DotNetAppHostExecutableNameWithoutExtension { get; set; }
 
+        [Required]
+        public string DotNetSingleFileHostExecutableNameWithoutExtension { get; set; }
+
         /// <summary>
         /// The file name of comhost asset.
         /// </summary>
@@ -56,6 +59,9 @@ namespace Microsoft.NET.Build.Tasks
         //  we can resolve the full path later)
         [Output]
         public ITaskItem[] AppHost { get; set; }
+
+        [Output]
+        public ITaskItem[] SingleFileHost { get; set; }
 
         [Output]
         public ITaskItem[] ComHost { get; set; }
@@ -105,6 +111,20 @@ namespace Microsoft.NET.Build.Tasks
                 if (appHostItem != null)
                 {
                     AppHost = new ITaskItem[] { appHostItem };
+                }
+
+                var singlefileHostItem = GetHostItem(
+                    AppHostRuntimeIdentifier,
+                    knownAppHostPacksForTargetFramework,
+                    packagesToDownload,
+                    DotNetSingleFileHostExecutableNameWithoutExtension,
+                    "SingleFileHost",
+                    isExecutable: true,
+                    errorIfNotFound: true);
+
+                if (singlefileHostItem != null)
+                {
+                    SingleFileHost = new ITaskItem[] { singlefileHostItem };
                 }
 
                 var comHostItem = GetHostItem(

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolveRuntimePackAssets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveRuntimePackAssets.cs
@@ -143,6 +143,7 @@ namespace Microsoft.NET.Build.Tasks
                 assetItem.SetMetadata("AssemblyVersion", fileElement.Attribute("AssemblyVersion")?.Value);
                 assetItem.SetMetadata("FileVersion", fileElement.Attribute("FileVersion")?.Value);
                 assetItem.SetMetadata("PublicKeyToken", fileElement.Attribute("PublicKeyToken")?.Value);
+                assetItem.SetMetadata("DropFromSingleFile", fileElement.Attribute("DropFromSingleFile")?.Value);
 
                 runtimePackAssets.Add(assetItem);
             }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -547,6 +547,12 @@ Copyright (c) .NET Foundation. All rights reserved.
         <RelativePath>shims/%(_EmbeddedApphostPaths.ShimRuntimeIdentifier)/%(_EmbeddedApphostPaths.Filename)%(_EmbeddedApphostPaths.Extension)</RelativePath>
         <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
       </ResolvedFileToPublish>
+
+      <!-- Filter files for PublishSingleFiles scenario -->
+      <_FilesToDrop Include="@(ResolvedFileToPublish)"
+                    Condition="'$(PublishSingleFile)' == 'true' and
+                               '%(ResolvedFileToPublish.DropFromSingleFile)' == 'true'"/>
+      <ResolvedFileToPublish Remove="@(_FilesToDrop)"/>
     </ItemGroup>
 
   </Target>
@@ -917,10 +923,12 @@ Copyright (c) .NET Foundation. All rights reserved.
     <!-- Check to see whether we can re-use the .deps.json file from the build for publish, or whether we have to
          generate a different one. -->
     <PropertyGroup>
+      <_TrimRuntimeAssets Condition="'$(PublishSingleFile)' == 'true' and '$(SelfContained)' == 'true'">true</_TrimRuntimeAssets>
       <_UseBuildDependencyFile Condition="'@(_ExcludeFromPublishPackageReference)' == '' and
                                           '@(RuntimeStorePackages)' == '' and
                                           '$(PreserveStoreLayout)' != 'true' and
-                                          '$(PublishTrimmed)' != 'true'">true</_UseBuildDependencyFile>
+                                          '$(PublishTrimmed)' != 'true' and 
+                                          '$(_TrimRuntimeAssets)' != 'true'">true</_UseBuildDependencyFile>
     </PropertyGroup>
 
   </Target>
@@ -937,17 +945,17 @@ Copyright (c) .NET Foundation. All rights reserved.
         Condition="'$(PublishSingleFile)' == 'true'">
 
     <ItemGroup>
-      <_FilesToBundle Include="@(ResolvedFileToPublish)" Condition="'%(ResolvedFileToPublish.ExcludeFromSingleFile)' != 'true'"/>
+      <_FilesToBundle Include="@(ResolvedFileToPublish)" 
+                      Condition="'%(ResolvedFileToPublish.ExcludeFromSingleFile)' != 'true'"/>
+      
+      <ResolvedFileToPublish Remove="@(_FilesToBundle)"/>
     </ItemGroup>
 
     <PropertyGroup>
       <PublishedSingleFileName>$(AssemblyName)$(_NativeExecutableExtension)</PublishedSingleFileName>
       <PublishedSingleFilePath>$(PublishDir)$(PublishedSingleFileName)</PublishedSingleFilePath>
     </PropertyGroup>
-
-    <ItemGroup>
-      <ResolvedFileToPublish Remove="@(_FilesToBundle)"/>
-    </ItemGroup>
+    
   </Target>
 
   <UsingTask TaskName="GenerateBundle" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
@@ -960,11 +968,15 @@ Copyright (c) .NET Foundation. All rights reserved.
     <PropertyGroup>
       <TraceSingleFileBundler Condition="'$(TraceSingleFileBundler)' == ''">false</TraceSingleFileBundler>
       <IncludeSymbolsInSingleFile Condition="'$(IncludeSymbolsInSingleFile)' == ''">false</IncludeSymbolsInSingleFile>
+      <IncludeNativeLibrariesInSingleFile Condition="'$(IncludeNativeLibrariesInSingleFile)' == ''">false</IncludeNativeLibrariesInSingleFile>
+      <IncludeAllContentInSingleFile Condition="'$(IncludeAllContentInSingleFile)' == ''">false</IncludeAllContentInSingleFile>
     </PropertyGroup>    
 
     <GenerateBundle FilesToBundle="@(_FilesToBundle)"
                     AppHostName="$(PublishedSingleFileName)"
                     IncludeSymbols="$(IncludeSymbolsInSingleFile)"
+                    IncludeNativeLibraries="$(IncludeNativeLibrariesInSingleFile)"
+                    IncludeAllContent="$(IncludeAllContentInSingleFile)"                    
                     TargetFrameworkVersion="$(_TargetFrameworkVersionWithoutV)"
                     RuntimeIdentifier="$(RuntimeIdentifier)"
                     OutputDir="$(PublishDir)"
@@ -1002,7 +1014,9 @@ Copyright (c) .NET Foundation. All rights reserved.
            PublishDepsFilePath is empty (by default) for PublishSingleFile, since the deps.json file is embedde within the single-file bundle -->      
       <IntermediateDepsFilePath Condition=" '$(PublishDepsFilePath)' != ''">$(PublishDepsFilePath)</IntermediateDepsFilePath >
       <IntermediateDepsFilePath Condition=" '$(PublishDepsFilePath)' == ''">$(IntermediateOutputPath)$(ProjectDepsFileName)</IntermediateDepsFilePath >
-      <PublishDepsFilePath Condition=" '$(PublishDepsFilePath)' == '' And '$(PublishSingleFile)' != 'true'">$(PublishDir)$(ProjectDepsFileName)</PublishDepsFilePath>      
+      <PublishDepsFilePath Condition=" '$(PublishDepsFilePath)' == '' And '$(PublishSingleFile)' != 'true'">$(PublishDir)$(ProjectDepsFileName)</PublishDepsFilePath>
+      <_IsSingleFilePublish Condition="'$(PublishSingleFile)' == ''">false</_IsSingleFilePublish>
+      <_IsSingleFilePublish Condition="'$(PublishSingleFile)' != ''">$(PublishSingleFile)</_IsSingleFilePublish>
     </PropertyGroup>
     <ItemGroup>
       <ResolvedCompileFileDefinitions Remove="@(_PublishConflictPackageFiles)" Condition="'%(_PublishConflictPackageFiles.ConflictItemType)' == 'Reference'" />
@@ -1013,6 +1027,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       <_ResolvedNuGetFilesForPublish Include="@(ResourceCopyLocalItems)" Condition="'%(ResourceCopyLocalItems.CopyToPublishDirectory)' != 'false'" />
       <_ResolvedNuGetFilesForPublish Include="@(RuntimeCopyLocalItems)" Condition="'%(RuntimeCopyLocalItems.CopyToPublishDirectory)' != 'false'" />
       <_ResolvedNuGetFilesForPublish Remove="@(_PublishConflictPackageFiles)" Condition="'%(_PublishConflictPackageFiles.ConflictItemType)' != 'Reference'" />
+     
     </ItemGroup>
 
     <GenerateDepsFile ProjectPath="$(MSBuildProjectFullPath)"
@@ -1039,6 +1054,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                       ResolvedRuntimeTargetsFiles="@(RuntimeTargetsCopyLocalItems)"
                       UserRuntimeAssemblies="@(UserRuntimeAssembly)"
                       IsSelfContained="$(SelfContained)"
+                      IsSingleFile="$(_IsSingleFilePublish)"
                       IncludeRuntimeFileVersions="$(IncludeFileVersionsInDependencyFile)"
                       RuntimeGraphPath="$(BundledRuntimeIdentifierGraphFile)"/>
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets
@@ -97,6 +97,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                      RuntimeFrameworkVersion="$(RuntimeFrameworkVersion)"
                      PackAsToolShimRuntimeIdentifiers="@(_PackAsToolShimRuntimeIdentifiers)"
                      DotNetAppHostExecutableNameWithoutExtension="$(_DotNetAppHostExecutableNameWithoutExtension)"
+                     DotNetSingleFileHostExecutableNameWithoutExtension="$(_DotNetSingleFileHostExecutableNameWithoutExtension)"
                      DotNetComHostLibraryNameWithoutExtension="$(_DotNetComHostLibraryNameWithoutExtension)"
                      DotNetIjwHostLibraryNameWithoutExtension="$(_DotNetIjwHostLibraryNameWithoutExtension)"
                      RuntimeGraphPath="$(BundledRuntimeIdentifierGraphFile)"
@@ -104,6 +105,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
       <Output TaskParameter="PackagesToDownload" ItemName="_PackageToDownload" />
       <Output TaskParameter="AppHost" ItemName="AppHostPack" />
+      <Output TaskParameter="SingleFileHost" ItemName="SingleFileHostPack" />
       <Output TaskParameter="ComHost" ItemName="ComHostPack" />
       <Output TaskParameter="IjwHost" ItemName="IjwHostPack" />
       <Output TaskParameter="PackAsToolShimAppHostPacks" ItemName="PackAsToolShimAppHostPack" />
@@ -188,6 +190,14 @@ Copyright (c) .NET Foundation. All rights reserved.
     </GetPackageDirectory>
 
     <GetPackageDirectory
+      Items="@(SingleFileHostPack)"
+      PackageFolders="@(AssetsFilePackageFolder)">
+
+      <Output TaskParameter="Output" ItemName="ResolvedSingleFileHostPack" />
+
+    </GetPackageDirectory>
+
+    <GetPackageDirectory
       Items="@(Crossgen2Pack)"
       PackageFolders="@(AssetsFilePackageFolder)">
 
@@ -232,6 +242,16 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <PropertyGroup Condition="'@(ResolvedAppHostPack)' != '' And '$(AppHostSourcePath)' == ''">
       <AppHostSourcePath>@(ResolvedAppHostPack->'%(Path)')</AppHostSourcePath>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <ResolvedSingleFileHostPack Condition="'%(ResolvedSingleFileHostPack.Path)' == '' and '%(ResolvedSingleFileHostPack.PackageDirectory)' != ''">
+        <Path>%(ResolvedSingleFileHostPack.PackageDirectory)\%(ResolvedSingleFileHostPack.PathInPackage)</Path>
+      </ResolvedSingleFileHostPack>
+    </ItemGroup>
+
+    <PropertyGroup Condition="'@(ResolvedSingleFileHostPack)' != '' And '$(SingleFileHostSourcePath)' == ''">
+      <SingleFileHostSourcePath>@(ResolvedSingleFileHostPack->'%(Path)')</SingleFileHostSourcePath>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -83,6 +83,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <_DotNetAppHostExecutableNameWithoutExtension>apphost</_DotNetAppHostExecutableNameWithoutExtension>
     <_DotNetAppHostExecutableName>$(_DotNetAppHostExecutableNameWithoutExtension)$(_NativeExecutableExtension)</_DotNetAppHostExecutableName>
 
+    <_DotNetSingleFileHostExecutableNameWithoutExtension>singlefilehost</_DotNetSingleFileHostExecutableNameWithoutExtension>
     <_DotNetComHostLibraryNameWithoutExtension>comhost</_DotNetComHostLibraryNameWithoutExtension>
     <_DotNetComHostLibraryName>$(_DotNetComHostLibraryNameWithoutExtension)$(_ComHostLibraryExtension)</_DotNetComHostLibraryName>
     <_DotNetIjwHostLibraryNameWithoutExtension>Ijwhost</_DotNetIjwHostLibraryNameWithoutExtension>
@@ -415,7 +416,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <Target Name="_CreateAppHost"
           Inputs="@(IntermediateAssembly);$(AppHostSourcePath)"
           Outputs="$(AppHostIntermediatePath)"
-          DependsOnTargets="_GetAppHostPaths;CoreCompile"
+          DependsOnTargets="_ChooseAppHost;CoreCompile"
           Condition="'$(ComputeNETCoreBuildOutputFiles)' == 'true' and
                      '$(AppHostSourcePath)' != '' and
                      Exists('@(IntermediateAssembly)') and
@@ -432,6 +433,25 @@ Copyright (c) .NET Foundation. All rights reserved.
                    Retries="$(CopyRetryCount)"
                    RetryDelayMilliseconds="$(CopyRetryDelayMilliseconds)"
                    />
+  </Target>
+
+  <!--
+    ============================================================
+                                        _ChooseAppHost
+      Choose the correct app-host for the build scenario:
+      * SingleFileHost if an app being published as a self-contained single-file .net5+ app 
+      * AppHost otherwise
+    ============================================================
+     -->
+  <Target Name="_ChooseAppHost"
+          DependsOnTargets="_GetAppHostPaths"
+          Condition="'$(UseAppHost)' == 'true' and '$(_IsExecutable)' == 'true'">
+    <PropertyGroup>
+      <AppHostSourcePath Condition="'$(PublishSingleFile)' == 'true' and 
+                                  '$(SelfContained)' == 'true' and
+                                  '$(_TargetFrameworkVersionWithoutV)' >= '5.0' and
+                                  '$(SingleFileHostSourcePath)' != ''">$(SingleFileHostSourcePath)</AppHostSourcePath>
+    </PropertyGroup>
   </Target>
 
   <!--

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishANetCoreAppForTelemetry.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishANetCoreAppForTelemetry.cs
@@ -60,9 +60,9 @@ namespace Microsoft.NET.Publish.Tests
                 "\"CompileListCount\":\"[1-9]\\d?\"");  // Do not hardcode number of assemblies being compiled here, due to ILTrimmer
         }
 
-        [CoreMSBuildOnlyTheory]
-        [InlineData("net5.0")]
-        public void It_collects_crossgen2_publishing_properties(string targetFramework)
+        [CoreMSBuildOnlyTheory(Skip = "https://github.com/dotnet/runtime/issues/37196")]
+        [InlineData("net5.0")] 
+        void It_collects_crossgen2_publishing_properties(string targetFramework)
         {
             // Crossgen2 only supported for Linux/Windows x64 scenarios for now
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX) || RuntimeInformation.OSArchitecture != Architecture.X64)

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishASingleFileApp.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishASingleFileApp.cs
@@ -23,13 +23,17 @@ namespace Microsoft.NET.Publish.Tests
 
         private const string PublishSingleFile = "/p:PublishSingleFile=true";
         private const string FrameworkDependent = "/p:SelfContained=false";
-        private const string IncludePdb = "/p:IncludeSymbolsInSingleFile=true";
+        private const string PlaceStamp = "/p:PlaceStamp=true";
         private const string ExcludeNewest = "/p:ExcludeNewest=true";
         private const string ExcludeAlways = "/p:ExcludeAlways=true";
         private const string DontUseAppHost = "/p:UseAppHost=false";
         private const string ReadyToRun = "/p:PublishReadyToRun=true";
         private const string ReadyToRunWithSymbols = "/p:PublishReadyToRunEmitSymbols=true";
         private const string UseAppHost = "/p:UseAppHost=true";
+        private const string IncludeDefault = "/p:IncludeSymbolsInSingleFile=false";
+        private const string IncludePdb = "/p:IncludeSymbolsInSingleFile=true";
+        private const string IncludeNative = "/p:IncludeNativeLibrariesInSingleFile=true";
+        private const string IncludeAllContent = "/p:IncludeAllContentInSingleFile=true";
 
         private readonly string RuntimeIdentifier = $"/p:RuntimeIdentifier={RuntimeInformation.RuntimeIdentifier}";
         private readonly string SingleFile = $"{TestProjectName}{Constants.ExeSuffix}";
@@ -37,6 +41,11 @@ namespace Microsoft.NET.Publish.Tests
         private readonly string NiPdbFile = $"{TestProjectName}.ni.pdb";
         private const string NewestContent = "Signature.Newest.Stamp";
         private const string AlwaysContent = "Signature.Always.Stamp";
+
+        private const string SmallNameDir = "SmallNameDir";
+        private const string LargeNameDir = "This is a directory with a really long name for one that only contains a small file";
+        private readonly string SmallNameDirWord = Path.Combine(SmallNameDir, "word").Replace('\\', '/'); // DirectoryInfoAssertions normalizes Path-Separator.
+        private readonly string LargeNameDirWord = Path.Combine(SmallNameDir, LargeNameDir, ".word").Replace('\\', '/');
 
         public GivenThatWeWantToPublishASingleFileApp(ITestOutputHelper log) : base(log)
         {
@@ -55,9 +64,7 @@ namespace Microsoft.NET.Publish.Tests
             // in order to circumvent certain issues like: 
             // Git Clone: Cannot clone files with long names on Windows if long file name support is not enabled
             // Nuget Pack: By default ignores files starting with "."
-            string longDirPath = Path.Combine(testAsset.TestRoot,
-                                              "SmallNameDir",
-                                              "This is a directory with a really long name for one that only contains a small file");
+            string longDirPath = Path.Combine(testAsset.TestRoot, SmallNameDir, LargeNameDir);
             Directory.CreateDirectory(longDirPath);
             using (var writer = File.CreateText(Path.Combine(longDirPath, ".word")))
             {
@@ -67,7 +74,13 @@ namespace Microsoft.NET.Publish.Tests
             return new PublishCommand(Log, testAsset.TestRoot);
         }
 
-        private DirectoryInfo GetPublishDirectory(PublishCommand publishCommand, string targetFramework = "netcoreapp3.0")
+        private string GetNativeDll(string baseName)
+        {
+            return RuntimeInformation.RuntimeIdentifier.StartsWith("win") ? baseName + ".dll" :
+                   RuntimeInformation.RuntimeIdentifier.StartsWith("osx") ? "lib" + baseName + ".dylib" :  "lib" + baseName + ".so";
+        }
+
+        private DirectoryInfo GetPublishDirectory(PublishCommand publishCommand, string targetFramework = "netcoreapp5.0")
         {
             return publishCommand.GetOutputDirectory(targetFramework: targetFramework,
                                                      runtimeIdentifier: RuntimeInformation.RuntimeIdentifier);
@@ -174,7 +187,7 @@ namespace Microsoft.NET.Publish.Tests
                 .Should()
                 .Pass();
 
-            string[] expectedFiles = { SingleFile, PdbFile };
+            string[] expectedFiles = { SingleFile, PdbFile, SmallNameDirWord, LargeNameDirWord };
             GetPublishDirectory(publishCommand)
                 .Should()
                 .OnlyHaveFiles(expectedFiles);
@@ -189,6 +202,70 @@ namespace Microsoft.NET.Publish.Tests
                 .Should()
                 .Pass();
 
+            string[] expectedFiles = { SingleFile, PdbFile, SmallNameDirWord, LargeNameDirWord, GetNativeDll("coreclr"), GetNativeDll("clrjit") };
+            string[] unexpectedFiles = { GetNativeDll("hostfxr"), GetNativeDll("hostpolicy") };
+
+            GetPublishDirectory(publishCommand)
+                .Should()
+                .HaveFiles(expectedFiles)
+                .And
+                .NotHaveFiles(unexpectedFiles);
+        }
+
+        [Fact]
+        public void It_generates_a_single_file_with_native_binaries_for_framework_dependent_apps()
+        {
+            var publishCommand = GetPublishCommand();
+            publishCommand
+                .Execute(PublishSingleFile, RuntimeIdentifier, FrameworkDependent, IncludeNative)
+                .Should()
+                .Pass();
+
+            string[] expectedFiles = { SingleFile, PdbFile, SmallNameDirWord, LargeNameDirWord };
+            GetPublishDirectory(publishCommand)
+                .Should()
+                .OnlyHaveFiles(expectedFiles);
+        }
+
+        [Fact]
+        public void It_generates_a_single_file_with_native_binaries_for_self_contained_apps()
+        {
+            var publishCommand = GetPublishCommand();
+            publishCommand
+                .Execute(PublishSingleFile, RuntimeIdentifier, IncludeNative)
+                .Should()
+                .Pass();
+
+            string[] expectedFiles = { SingleFile, PdbFile, SmallNameDirWord, LargeNameDirWord };
+            GetPublishDirectory(publishCommand)
+                .Should()
+                .OnlyHaveFiles(expectedFiles);
+        }
+
+        [Fact]
+        public void It_generates_a_single_file_with_all_content_for_framework_dependent_apps()
+        {
+            var publishCommand = GetPublishCommand();
+            publishCommand
+                .Execute(PublishSingleFile, RuntimeIdentifier, FrameworkDependent, IncludeAllContent)
+                .Should()
+                .Pass();
+
+            string[] expectedFiles = { SingleFile, PdbFile };
+            GetPublishDirectory(publishCommand)
+                .Should()
+                .OnlyHaveFiles(expectedFiles);
+        }
+
+        [Fact]
+        public void It_generates_a_single_file_with_all_content_for_self_contained_apps()
+        {
+            var publishCommand = GetPublishCommand();
+            publishCommand
+                .Execute(PublishSingleFile, RuntimeIdentifier, IncludeAllContent)
+                .Should()
+                .Pass();
+
             string[] expectedFiles = { SingleFile, PdbFile };
             GetPublishDirectory(publishCommand)
                 .Should()
@@ -200,7 +277,7 @@ namespace Microsoft.NET.Publish.Tests
         {
             var publishCommand = GetPublishCommand();
             publishCommand
-                .Execute(PublishSingleFile, RuntimeIdentifier, IncludePdb)
+                .Execute(PublishSingleFile, RuntimeIdentifier, IncludeAllContent, IncludePdb)
                 .Should()
                 .Pass();
 
@@ -215,15 +292,14 @@ namespace Microsoft.NET.Publish.Tests
         {
             var publishCommand = GetPublishCommand();
             publishCommand
-                .Execute(PublishSingleFile, RuntimeIdentifier, ReadyToRun, ReadyToRunWithSymbols)
+                .Execute(PublishSingleFile, RuntimeIdentifier, IncludeAllContent, ReadyToRun, ReadyToRunWithSymbols)
                 .Should()
                 .Pass();
 
             string[] expectedFiles = { SingleFile, PdbFile, NiPdbFile };
             GetPublishDirectory(publishCommand)
                 .Should()
-                //  TODO: Change HaveFiles to OnlyHaveFiles, once https://github.com/dotnet/coreclr/issues/25522 is fixed
-                .HaveFiles(expectedFiles);
+                .OnlyHaveFiles(expectedFiles);
         }
 
         [WindowsOnlyFact]
@@ -231,7 +307,7 @@ namespace Microsoft.NET.Publish.Tests
         {
             var publishCommand = GetPublishCommand();
             publishCommand
-                .Execute(PublishSingleFile, RuntimeIdentifier, ReadyToRun, ReadyToRunWithSymbols, IncludePdb)
+                .Execute(PublishSingleFile, RuntimeIdentifier, ReadyToRun, ReadyToRunWithSymbols, IncludeAllContent, IncludePdb)
                 .Should()
                 .Pass();
 
@@ -248,7 +324,7 @@ namespace Microsoft.NET.Publish.Tests
         {
             var publishCommand = GetPublishCommand();
             publishCommand
-                .Execute(PublishSingleFile, RuntimeIdentifier, exclusion)
+                .Execute(PublishSingleFile, RuntimeIdentifier, IncludeAllContent, PlaceStamp, exclusion)
                 .Should()
                 .Pass();
 
@@ -263,7 +339,7 @@ namespace Microsoft.NET.Publish.Tests
         {
             var publishCommand = GetPublishCommand();
             publishCommand
-                .Execute(PublishSingleFile, RuntimeIdentifier, ReadyToRun)
+                .Execute(PublishSingleFile, RuntimeIdentifier, IncludeAllContent, ReadyToRun)
                 .Should()
                 .Pass();
 
@@ -344,51 +420,20 @@ namespace Microsoft.NET.Publish.Tests
             appHostSize.Should().BeLessThan(singleFileSize);
         }
 
-        [Fact]
-        public void It_leaves_host_components_unbundled_when_necessary()
-        {
-            // In.net 5, Single-file bundles are processed in the framework.
-            // Therefore, in self-contained builds, hostpolicy and hostfxr DLLs cannot themselves be in the bundle.
-            // This check is temporary until until statically linked singlefilehost is supported: 
-            // * https://github.com/dotnet/runtime/issues/32823
-            // * https://github.com/dotnet/sdk/issues/11567
-
-            var testProject = new TestProject()
-            {
-                Name = "SingleFileTest",
-                TargetFrameworks = "netcoreapp5.0",
-                IsSdkProject = true,
-                IsExe = true
-            };
-
-            var testAsset = _testAssetsManager.CreateTestProject(testProject);
-            var publishCommand = new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
-
-            publishCommand.Execute(PublishSingleFile, RuntimeIdentifier)
-                .Should()
-                .Pass();
-
-            string hostfxr = RuntimeInformation.RuntimeIdentifier.StartsWith("win") ? "hostfxr.dll" :
-                             RuntimeInformation.RuntimeIdentifier.StartsWith("osx") ? "libhostfxr.dylib" : "libhostfxr.so";
-
-            string hostpolicy = RuntimeInformation.RuntimeIdentifier.StartsWith("win") ? "hostpolicy.dll" :
-                                RuntimeInformation.RuntimeIdentifier.StartsWith("osx") ? "libhostpolicy.dylib" : "libhostpolicy.so";
-
-            string[] expectedFiles = { $"{testProject.Name}{Constants.ExeSuffix}", $"{testProject.Name}.pdb", hostfxr, hostpolicy };
-
-            GetPublishDirectory(publishCommand, "netcoreapp5.0")
-                .Should()
-                .OnlyHaveFiles(expectedFiles);
-        }
-
         [Theory]
-        [InlineData("netcoreapp3.0", false)]
-        [InlineData("netcoreapp3.0", true)]
-        [InlineData("netcoreapp3.1", false)]
-        [InlineData("netcoreapp3.1", true)]
-        [InlineData("netcoreapp5.0", false)]
-        [InlineData("netcoreapp5.0", true)]
-        public void It_runs_single_file_apps(string targetFramework, bool selfContained)
+        [InlineData("netcoreapp3.0", false, IncludeDefault)]
+        [InlineData("netcoreapp3.0", true, IncludeDefault)]
+        [InlineData("netcoreapp3.1", false, IncludeDefault)]
+        [InlineData("netcoreapp3.1", true, IncludeDefault)]
+        [InlineData("netcoreapp5.0", false, IncludeDefault)]
+        [InlineData("netcoreapp5.0", false, IncludeNative)]
+        [InlineData("netcoreapp5.0", false, IncludeAllContent)]
+        [InlineData("netcoreapp5.0", false, IncludePdb)]
+        [InlineData("netcoreapp5.0", true, IncludeDefault)]
+        [InlineData("netcoreapp5.0", true, IncludeNative)]
+        [InlineData("netcoreapp5.0", true, IncludeAllContent)]
+        [InlineData("netcoreapp5.0", true, IncludePdb)]
+        public void It_runs_single_file_apps(string targetFramework, bool selfContained, string bundleOption)
         {
             var testProject = new TestProject()
             {
@@ -402,7 +447,7 @@ namespace Microsoft.NET.Publish.Tests
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
             var publishCommand = new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
 
-            publishCommand.Execute(PublishSingleFile, RuntimeIdentifier)
+            publishCommand.Execute(PublishSingleFile, RuntimeIdentifier, bundleOption)
                 .Should()
                 .Pass();
 

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishASingleFileApp.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishASingleFileApp.cs
@@ -80,7 +80,7 @@ namespace Microsoft.NET.Publish.Tests
                    RuntimeInformation.RuntimeIdentifier.StartsWith("osx") ? "lib" + baseName + ".dylib" :  "lib" + baseName + ".so";
         }
 
-        private DirectoryInfo GetPublishDirectory(PublishCommand publishCommand, string targetFramework = "netcoreapp5.0")
+        private DirectoryInfo GetPublishDirectory(PublishCommand publishCommand, string targetFramework = "net5.0")
         {
             return publishCommand.GetOutputDirectory(targetFramework: targetFramework,
                                                      runtimeIdentifier: RuntimeInformation.RuntimeIdentifier);
@@ -425,14 +425,14 @@ namespace Microsoft.NET.Publish.Tests
         [InlineData("netcoreapp3.0", true, IncludeDefault)]
         [InlineData("netcoreapp3.1", false, IncludeDefault)]
         [InlineData("netcoreapp3.1", true, IncludeDefault)]
-        [InlineData("netcoreapp5.0", false, IncludeDefault)]
-        [InlineData("netcoreapp5.0", false, IncludeNative)]
-        [InlineData("netcoreapp5.0", false, IncludeAllContent)]
-        [InlineData("netcoreapp5.0", false, IncludePdb)]
-        [InlineData("netcoreapp5.0", true, IncludeDefault)]
-        [InlineData("netcoreapp5.0", true, IncludeNative)]
-        [InlineData("netcoreapp5.0", true, IncludeAllContent)]
-        [InlineData("netcoreapp5.0", true, IncludePdb)]
+        [InlineData("net5.0", false, IncludeDefault)]
+        [InlineData("net5.0", false, IncludeNative)]
+        [InlineData("net5.0", false, IncludeAllContent)]
+        [InlineData("net5.0", false, IncludePdb)]
+        [InlineData("net5.0", true, IncludeDefault)]
+        [InlineData("net5.0", true, IncludeNative)]
+        [InlineData("net5.0", true, IncludeAllContent)]
+        [InlineData("net5.0", true, IncludePdb)]
         public void It_runs_single_file_apps(string targetFramework, bool selfContained, string bundleOption)
         {
             var testProject = new TestProject()

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishIncrementally.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishIncrementally.cs
@@ -179,7 +179,7 @@ namespace Microsoft.NET.Publish.Tests
             var expectedRegularFiles = new string[] { ".dll", ".deps.json", ".runtimeconfig.json", ".Views.dll"}
                 .Select(ending => assetName + ending);
             var expectedSingleFiles = new string[] { ".Views.pdb", ".pdb", ".exe" }.Select(ending => assetName + ending)
-                .Concat(new string[] { "hostfxr.dll", "hostpolicy.dll", "appsettings.json", "appsettings.Development.json", "web.config" });
+                .Concat(new string[] { "appsettings.json", "appsettings.Development.json", "web.config" });
 
             // Publish normally
             new PublishCommand(Log, Path.Combine(testDir.Path, assetName))

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishReadyToRun.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishReadyToRun.cs
@@ -194,9 +194,9 @@ namespace Microsoft.NET.Publish.Tests
             TestProjectPublishing_Internal("LibraryProject2", targetFramework, isSelfContained:true, makeExeProject: false);
         }
 
-        [Theory]
+        [Theory(Skip = "https://github.com/dotnet/runtime/issues/37196")]
         [InlineData("net5.0")]
-        public void It_can_publish_readytorun_using_crossgen2(string targetFramework)
+        void It_can_publish_readytorun_using_crossgen2(string targetFramework)
         {
             // Crossgen2 only supported for Linux/Windows x64 scenarios for now
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX) || RuntimeInformation.OSArchitecture != Architecture.X64)


### PR DESCRIPTION
This commit implements the following changes for single-file apps:
* When publishing self-contained single-file apps:
  * Use `SingleFileHost` instead of `apphost`
  * Trim the native components of the runtime published for the app.
   * Fixes #11567.
* Implements the [optional additional settings](https://github.com/dotnet/designs/blob/master/accepted/2020/single-file/design.md#optional-settings) for .net 5 `PublishSingleFile`.
