### PR TITLE
Block referencing or producing winmds when targeting .NET 5.0 or newer.

### DIFF
--- a/src/Assets/TestProjects/WinMDClassLibrary/WinMDClassLibrary.cs
+++ b/src/Assets/TestProjects/WinMDClassLibrary/WinMDClassLibrary.cs
@@ -1,0 +1,10 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace WindowsRuntimeComponent
+{
+    public class Class1
+    {
+        public int Foo() => 0;
+    }
+}

--- a/src/Assets/TestProjects/WinMDClassLibrary/WinMDClassLibrary.csproj
+++ b/src/Assets/TestProjects/WinMDClassLibrary/WinMDClassLibrary.csproj
@@ -1,0 +1,8 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Windows.Sdk.Contracts" Version="10.0.18362.2005" />
+  </ItemGroup>
+</Project>

--- a/src/Assets/TestProjects/WindowsRuntimeComponent/WindowsRuntimeComponent.cs
+++ b/src/Assets/TestProjects/WindowsRuntimeComponent/WindowsRuntimeComponent.cs
@@ -1,0 +1,10 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace WindowsRuntimeComponent
+{
+    public class Class1
+    {
+        public int Foo() => 0;
+    }
+}

--- a/src/Assets/TestProjects/WindowsRuntimeComponent/WindowsRuntimeComponent.csproj
+++ b/src/Assets/TestProjects/WindowsRuntimeComponent/WindowsRuntimeComponent.csproj
@@ -1,0 +1,6 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>winmdobj</OutputType>
+    <TargetFramework>net5.0</TargetFramework>
+  </PropertyGroup>
+</Project>

--- a/src/Tasks/Common/Resources/Strings.resx
+++ b/src/Tasks/Common/Resources/Strings.resx
@@ -620,4 +620,12 @@ The following are names of parameters or literal values and should not be transl
     <value>NETSDK1129: The 'Publish' target is not supported without specifying a target framework. The current project targets multiple frameworks, you must specify the framework for the published application.</value>
     <comment>{StrBegin="NETSDK1129: "}</comment>
   </data>
+  <data name="WinMDReferenceNotSupportedOnTargetFramework" xml:space="preserve">
+    <value>NETSDK1130: Referencing a Windows Metadata component directly when targeting {0} is not supported. Use the C#/WinRT projection tool or a provided projection for this target.</value>
+    <comment>{StrBegin="NETSDK1130: "}</comment>
+  </data>
+  <data name="WinMDObjNotSupportedOnTargetFramework" xml:space="preserve">
+    <value>NETSDK1131: Producing a managed Windows Metadata component with WinMDExp is not supportd when targeting {0}.</value>
+    <comment>{StrBegin="NETSDK1131: "}</comment>
+  </data>
 </root>

--- a/src/Tasks/Common/Resources/Strings.resx
+++ b/src/Tasks/Common/Resources/Strings.resx
@@ -621,11 +621,11 @@ The following are names of parameters or literal values and should not be transl
     <comment>{StrBegin="NETSDK1129: "}</comment>
   </data>
   <data name="WinMDReferenceNotSupportedOnTargetFramework" xml:space="preserve">
-    <value>NETSDK1130: Referencing a Windows Metadata component directly when targeting {0} is not supported. Use the C#/WinRT projection tool or a provided projection for this target.</value>
+    <value>NETSDK1130: Referencing a Windows Metadata component directly when targeting {0} is not supported. Use the C#/WinRT projection tool (https://aka.ms/cswinrt) or a provided projection for this target.</value>
     <comment>{StrBegin="NETSDK1130: "}</comment>
   </data>
   <data name="WinMDObjNotSupportedOnTargetFramework" xml:space="preserve">
-    <value>NETSDK1131: Producing a managed Windows Metadata component with WinMDExp is not supportd when targeting {0}.</value>
+    <value>NETSDK1131: Producing a managed Windows Metadata component with WinMDExp is not supported when targeting {0}.</value>
     <comment>{StrBegin="NETSDK1131: "}</comment>
   </data>
 </root>

--- a/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
@@ -632,13 +632,13 @@ The following are names of parameters or literal values and should not be transl
         <note />
       </trans-unit>
       <trans-unit id="WinMDObjNotSupportedOnTargetFramework">
-        <source>NETSDK1131: Producing a managed Windows Metadata component with WinMDExp is not supportd when targeting {0}.</source>
-        <target state="new">NETSDK1131: Producing a managed Windows Metadata component with WinMDExp is not supportd when targeting {0}.</target>
+        <source>NETSDK1131: Producing a managed Windows Metadata component with WinMDExp is not supported when targeting {0}.</source>
+        <target state="new">NETSDK1131: Producing a managed Windows Metadata component with WinMDExp is not supported when targeting {0}.</target>
         <note>{StrBegin="NETSDK1131: "}</note>
       </trans-unit>
       <trans-unit id="WinMDReferenceNotSupportedOnTargetFramework">
-        <source>NETSDK1130: Referencing a Windows Metadata component directly when targeting {0} is not supported. Use the C#/WinRT projection tool or a provided projection for this target.</source>
-        <target state="new">NETSDK1130: Referencing a Windows Metadata component directly when targeting {0} is not supported. Use the C#/WinRT projection tool or a provided projection for this target.</target>
+        <source>NETSDK1130: Referencing a Windows Metadata component directly when targeting {0} is not supported. Use the C#/WinRT projection tool (https://aka.ms/cswinrt) or a provided projection for this target.</source>
+        <target state="new">NETSDK1130: Referencing a Windows Metadata component directly when targeting {0} is not supported. Use the C#/WinRT projection tool (https://aka.ms/cswinrt) or a provided projection for this target.</target>
         <note>{StrBegin="NETSDK1130: "}</note>
       </trans-unit>
       <trans-unit id="WindowsDesktopFrameworkRequiresUseWpfOrUseWindowsForms">

--- a/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
@@ -631,6 +631,16 @@ The following are names of parameters or literal values and should not be transl
         <target state="needs-review-translation">Používáte preview verzi .NET Core. Další informace: https://aka.ms/dotnet-core-preview</target>
         <note />
       </trans-unit>
+      <trans-unit id="WinMDObjNotSupportedOnTargetFramework">
+        <source>NETSDK1131: Producing a managed Windows Metadata component with WinMDExp is not supportd when targeting {0}.</source>
+        <target state="new">NETSDK1131: Producing a managed Windows Metadata component with WinMDExp is not supportd when targeting {0}.</target>
+        <note>{StrBegin="NETSDK1131: "}</note>
+      </trans-unit>
+      <trans-unit id="WinMDReferenceNotSupportedOnTargetFramework">
+        <source>NETSDK1130: Referencing a Windows Metadata component directly when targeting {0} is not supported. Use the C#/WinRT projection tool or a provided projection for this target.</source>
+        <target state="new">NETSDK1130: Referencing a Windows Metadata component directly when targeting {0} is not supported. Use the C#/WinRT projection tool or a provided projection for this target.</target>
+        <note>{StrBegin="NETSDK1130: "}</note>
+      </trans-unit>
       <trans-unit id="WindowsDesktopFrameworkRequiresUseWpfOrUseWindowsForms">
         <source>NETSDK1106: Microsoft.NET.Sdk.WindowsDesktop requires 'UseWpf' or 'UseWindowsForms' to be set to 'true'</source>
         <target state="translated">NETSDK1106: Microsoft.NET.Sdk.WindowsDesktop vyžaduje, aby hodnota UseWpf nebo UseWindowsForms byla nastavená na true.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.de.xlf
@@ -632,13 +632,13 @@ The following are names of parameters or literal values and should not be transl
         <note />
       </trans-unit>
       <trans-unit id="WinMDObjNotSupportedOnTargetFramework">
-        <source>NETSDK1131: Producing a managed Windows Metadata component with WinMDExp is not supportd when targeting {0}.</source>
-        <target state="new">NETSDK1131: Producing a managed Windows Metadata component with WinMDExp is not supportd when targeting {0}.</target>
+        <source>NETSDK1131: Producing a managed Windows Metadata component with WinMDExp is not supported when targeting {0}.</source>
+        <target state="new">NETSDK1131: Producing a managed Windows Metadata component with WinMDExp is not supported when targeting {0}.</target>
         <note>{StrBegin="NETSDK1131: "}</note>
       </trans-unit>
       <trans-unit id="WinMDReferenceNotSupportedOnTargetFramework">
-        <source>NETSDK1130: Referencing a Windows Metadata component directly when targeting {0} is not supported. Use the C#/WinRT projection tool or a provided projection for this target.</source>
-        <target state="new">NETSDK1130: Referencing a Windows Metadata component directly when targeting {0} is not supported. Use the C#/WinRT projection tool or a provided projection for this target.</target>
+        <source>NETSDK1130: Referencing a Windows Metadata component directly when targeting {0} is not supported. Use the C#/WinRT projection tool (https://aka.ms/cswinrt) or a provided projection for this target.</source>
+        <target state="new">NETSDK1130: Referencing a Windows Metadata component directly when targeting {0} is not supported. Use the C#/WinRT projection tool (https://aka.ms/cswinrt) or a provided projection for this target.</target>
         <note>{StrBegin="NETSDK1130: "}</note>
       </trans-unit>
       <trans-unit id="WindowsDesktopFrameworkRequiresUseWpfOrUseWindowsForms">

--- a/src/Tasks/Common/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.de.xlf
@@ -631,6 +631,16 @@ The following are names of parameters or literal values and should not be transl
         <target state="needs-review-translation">Sie verwenden eine Vorschauversion von .NET Core. Weitere Informationen: https://aka.ms/dotnet-core-preview</target>
         <note />
       </trans-unit>
+      <trans-unit id="WinMDObjNotSupportedOnTargetFramework">
+        <source>NETSDK1131: Producing a managed Windows Metadata component with WinMDExp is not supportd when targeting {0}.</source>
+        <target state="new">NETSDK1131: Producing a managed Windows Metadata component with WinMDExp is not supportd when targeting {0}.</target>
+        <note>{StrBegin="NETSDK1131: "}</note>
+      </trans-unit>
+      <trans-unit id="WinMDReferenceNotSupportedOnTargetFramework">
+        <source>NETSDK1130: Referencing a Windows Metadata component directly when targeting {0} is not supported. Use the C#/WinRT projection tool or a provided projection for this target.</source>
+        <target state="new">NETSDK1130: Referencing a Windows Metadata component directly when targeting {0} is not supported. Use the C#/WinRT projection tool or a provided projection for this target.</target>
+        <note>{StrBegin="NETSDK1130: "}</note>
+      </trans-unit>
       <trans-unit id="WindowsDesktopFrameworkRequiresUseWpfOrUseWindowsForms">
         <source>NETSDK1106: Microsoft.NET.Sdk.WindowsDesktop requires 'UseWpf' or 'UseWindowsForms' to be set to 'true'</source>
         <target state="translated">NETSDK1106: Für Microsoft.NET.Sdk.WindowsDesktop muss "UseWpf" oder "UseWindowsForms" auf TRUE festgelegt werden.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.es.xlf
@@ -632,13 +632,13 @@ The following are names of parameters or literal values and should not be transl
         <note />
       </trans-unit>
       <trans-unit id="WinMDObjNotSupportedOnTargetFramework">
-        <source>NETSDK1131: Producing a managed Windows Metadata component with WinMDExp is not supportd when targeting {0}.</source>
-        <target state="new">NETSDK1131: Producing a managed Windows Metadata component with WinMDExp is not supportd when targeting {0}.</target>
+        <source>NETSDK1131: Producing a managed Windows Metadata component with WinMDExp is not supported when targeting {0}.</source>
+        <target state="new">NETSDK1131: Producing a managed Windows Metadata component with WinMDExp is not supported when targeting {0}.</target>
         <note>{StrBegin="NETSDK1131: "}</note>
       </trans-unit>
       <trans-unit id="WinMDReferenceNotSupportedOnTargetFramework">
-        <source>NETSDK1130: Referencing a Windows Metadata component directly when targeting {0} is not supported. Use the C#/WinRT projection tool or a provided projection for this target.</source>
-        <target state="new">NETSDK1130: Referencing a Windows Metadata component directly when targeting {0} is not supported. Use the C#/WinRT projection tool or a provided projection for this target.</target>
+        <source>NETSDK1130: Referencing a Windows Metadata component directly when targeting {0} is not supported. Use the C#/WinRT projection tool (https://aka.ms/cswinrt) or a provided projection for this target.</source>
+        <target state="new">NETSDK1130: Referencing a Windows Metadata component directly when targeting {0} is not supported. Use the C#/WinRT projection tool (https://aka.ms/cswinrt) or a provided projection for this target.</target>
         <note>{StrBegin="NETSDK1130: "}</note>
       </trans-unit>
       <trans-unit id="WindowsDesktopFrameworkRequiresUseWpfOrUseWindowsForms">

--- a/src/Tasks/Common/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.es.xlf
@@ -631,6 +631,16 @@ The following are names of parameters or literal values and should not be transl
         <target state="needs-review-translation">Está utilizando una versión preliminar de .NET Core. Consulte https://aka.ms/dotnet-core-preview</target>
         <note />
       </trans-unit>
+      <trans-unit id="WinMDObjNotSupportedOnTargetFramework">
+        <source>NETSDK1131: Producing a managed Windows Metadata component with WinMDExp is not supportd when targeting {0}.</source>
+        <target state="new">NETSDK1131: Producing a managed Windows Metadata component with WinMDExp is not supportd when targeting {0}.</target>
+        <note>{StrBegin="NETSDK1131: "}</note>
+      </trans-unit>
+      <trans-unit id="WinMDReferenceNotSupportedOnTargetFramework">
+        <source>NETSDK1130: Referencing a Windows Metadata component directly when targeting {0} is not supported. Use the C#/WinRT projection tool or a provided projection for this target.</source>
+        <target state="new">NETSDK1130: Referencing a Windows Metadata component directly when targeting {0} is not supported. Use the C#/WinRT projection tool or a provided projection for this target.</target>
+        <note>{StrBegin="NETSDK1130: "}</note>
+      </trans-unit>
       <trans-unit id="WindowsDesktopFrameworkRequiresUseWpfOrUseWindowsForms">
         <source>NETSDK1106: Microsoft.NET.Sdk.WindowsDesktop requires 'UseWpf' or 'UseWindowsForms' to be set to 'true'</source>
         <target state="translated">NETSDK1106: Microsoft.NET.Sdk.WindowsDesktop requiere que "UseWpf" o "UseWindowsForms" se establezca en "true"</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
@@ -632,13 +632,13 @@ The following are names of parameters or literal values and should not be transl
         <note />
       </trans-unit>
       <trans-unit id="WinMDObjNotSupportedOnTargetFramework">
-        <source>NETSDK1131: Producing a managed Windows Metadata component with WinMDExp is not supportd when targeting {0}.</source>
-        <target state="new">NETSDK1131: Producing a managed Windows Metadata component with WinMDExp is not supportd when targeting {0}.</target>
+        <source>NETSDK1131: Producing a managed Windows Metadata component with WinMDExp is not supported when targeting {0}.</source>
+        <target state="new">NETSDK1131: Producing a managed Windows Metadata component with WinMDExp is not supported when targeting {0}.</target>
         <note>{StrBegin="NETSDK1131: "}</note>
       </trans-unit>
       <trans-unit id="WinMDReferenceNotSupportedOnTargetFramework">
-        <source>NETSDK1130: Referencing a Windows Metadata component directly when targeting {0} is not supported. Use the C#/WinRT projection tool or a provided projection for this target.</source>
-        <target state="new">NETSDK1130: Referencing a Windows Metadata component directly when targeting {0} is not supported. Use the C#/WinRT projection tool or a provided projection for this target.</target>
+        <source>NETSDK1130: Referencing a Windows Metadata component directly when targeting {0} is not supported. Use the C#/WinRT projection tool (https://aka.ms/cswinrt) or a provided projection for this target.</source>
+        <target state="new">NETSDK1130: Referencing a Windows Metadata component directly when targeting {0} is not supported. Use the C#/WinRT projection tool (https://aka.ms/cswinrt) or a provided projection for this target.</target>
         <note>{StrBegin="NETSDK1130: "}</note>
       </trans-unit>
       <trans-unit id="WindowsDesktopFrameworkRequiresUseWpfOrUseWindowsForms">

--- a/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
@@ -631,6 +631,16 @@ The following are names of parameters or literal values and should not be transl
         <target state="needs-review-translation">Vous utilisez une préversion de .NET Core. Consultez https://aka.ms/dotnet-core-preview</target>
         <note />
       </trans-unit>
+      <trans-unit id="WinMDObjNotSupportedOnTargetFramework">
+        <source>NETSDK1131: Producing a managed Windows Metadata component with WinMDExp is not supportd when targeting {0}.</source>
+        <target state="new">NETSDK1131: Producing a managed Windows Metadata component with WinMDExp is not supportd when targeting {0}.</target>
+        <note>{StrBegin="NETSDK1131: "}</note>
+      </trans-unit>
+      <trans-unit id="WinMDReferenceNotSupportedOnTargetFramework">
+        <source>NETSDK1130: Referencing a Windows Metadata component directly when targeting {0} is not supported. Use the C#/WinRT projection tool or a provided projection for this target.</source>
+        <target state="new">NETSDK1130: Referencing a Windows Metadata component directly when targeting {0} is not supported. Use the C#/WinRT projection tool or a provided projection for this target.</target>
+        <note>{StrBegin="NETSDK1130: "}</note>
+      </trans-unit>
       <trans-unit id="WindowsDesktopFrameworkRequiresUseWpfOrUseWindowsForms">
         <source>NETSDK1106: Microsoft.NET.Sdk.WindowsDesktop requires 'UseWpf' or 'UseWindowsForms' to be set to 'true'</source>
         <target state="translated">NETSDK1106: vous devez affecter la valeur 'true' à 'UseWpf' ou 'UseWindowsForms' pour Microsoft.NET.Sdk.WindowsDesktop</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.it.xlf
@@ -632,13 +632,13 @@ The following are names of parameters or literal values and should not be transl
         <note />
       </trans-unit>
       <trans-unit id="WinMDObjNotSupportedOnTargetFramework">
-        <source>NETSDK1131: Producing a managed Windows Metadata component with WinMDExp is not supportd when targeting {0}.</source>
-        <target state="new">NETSDK1131: Producing a managed Windows Metadata component with WinMDExp is not supportd when targeting {0}.</target>
+        <source>NETSDK1131: Producing a managed Windows Metadata component with WinMDExp is not supported when targeting {0}.</source>
+        <target state="new">NETSDK1131: Producing a managed Windows Metadata component with WinMDExp is not supported when targeting {0}.</target>
         <note>{StrBegin="NETSDK1131: "}</note>
       </trans-unit>
       <trans-unit id="WinMDReferenceNotSupportedOnTargetFramework">
-        <source>NETSDK1130: Referencing a Windows Metadata component directly when targeting {0} is not supported. Use the C#/WinRT projection tool or a provided projection for this target.</source>
-        <target state="new">NETSDK1130: Referencing a Windows Metadata component directly when targeting {0} is not supported. Use the C#/WinRT projection tool or a provided projection for this target.</target>
+        <source>NETSDK1130: Referencing a Windows Metadata component directly when targeting {0} is not supported. Use the C#/WinRT projection tool (https://aka.ms/cswinrt) or a provided projection for this target.</source>
+        <target state="new">NETSDK1130: Referencing a Windows Metadata component directly when targeting {0} is not supported. Use the C#/WinRT projection tool (https://aka.ms/cswinrt) or a provided projection for this target.</target>
         <note>{StrBegin="NETSDK1130: "}</note>
       </trans-unit>
       <trans-unit id="WindowsDesktopFrameworkRequiresUseWpfOrUseWindowsForms">

--- a/src/Tasks/Common/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.it.xlf
@@ -631,6 +631,16 @@ The following are names of parameters or literal values and should not be transl
         <target state="needs-review-translation">Si sta usando una versione in anteprima di .NET Core. Vedere https://aka.ms/dotnet-core-preview</target>
         <note />
       </trans-unit>
+      <trans-unit id="WinMDObjNotSupportedOnTargetFramework">
+        <source>NETSDK1131: Producing a managed Windows Metadata component with WinMDExp is not supportd when targeting {0}.</source>
+        <target state="new">NETSDK1131: Producing a managed Windows Metadata component with WinMDExp is not supportd when targeting {0}.</target>
+        <note>{StrBegin="NETSDK1131: "}</note>
+      </trans-unit>
+      <trans-unit id="WinMDReferenceNotSupportedOnTargetFramework">
+        <source>NETSDK1130: Referencing a Windows Metadata component directly when targeting {0} is not supported. Use the C#/WinRT projection tool or a provided projection for this target.</source>
+        <target state="new">NETSDK1130: Referencing a Windows Metadata component directly when targeting {0} is not supported. Use the C#/WinRT projection tool or a provided projection for this target.</target>
+        <note>{StrBegin="NETSDK1130: "}</note>
+      </trans-unit>
       <trans-unit id="WindowsDesktopFrameworkRequiresUseWpfOrUseWindowsForms">
         <source>NETSDK1106: Microsoft.NET.Sdk.WindowsDesktop requires 'UseWpf' or 'UseWindowsForms' to be set to 'true'</source>
         <target state="translated">NETSDK1106: con Microsoft.NET.Sdk.WindowsDesktop 'UseWpf' o 'UseWindowsForms' deve essere impostato su 'true'</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
@@ -632,13 +632,13 @@ The following are names of parameters or literal values and should not be transl
         <note />
       </trans-unit>
       <trans-unit id="WinMDObjNotSupportedOnTargetFramework">
-        <source>NETSDK1131: Producing a managed Windows Metadata component with WinMDExp is not supportd when targeting {0}.</source>
-        <target state="new">NETSDK1131: Producing a managed Windows Metadata component with WinMDExp is not supportd when targeting {0}.</target>
+        <source>NETSDK1131: Producing a managed Windows Metadata component with WinMDExp is not supported when targeting {0}.</source>
+        <target state="new">NETSDK1131: Producing a managed Windows Metadata component with WinMDExp is not supported when targeting {0}.</target>
         <note>{StrBegin="NETSDK1131: "}</note>
       </trans-unit>
       <trans-unit id="WinMDReferenceNotSupportedOnTargetFramework">
-        <source>NETSDK1130: Referencing a Windows Metadata component directly when targeting {0} is not supported. Use the C#/WinRT projection tool or a provided projection for this target.</source>
-        <target state="new">NETSDK1130: Referencing a Windows Metadata component directly when targeting {0} is not supported. Use the C#/WinRT projection tool or a provided projection for this target.</target>
+        <source>NETSDK1130: Referencing a Windows Metadata component directly when targeting {0} is not supported. Use the C#/WinRT projection tool (https://aka.ms/cswinrt) or a provided projection for this target.</source>
+        <target state="new">NETSDK1130: Referencing a Windows Metadata component directly when targeting {0} is not supported. Use the C#/WinRT projection tool (https://aka.ms/cswinrt) or a provided projection for this target.</target>
         <note>{StrBegin="NETSDK1130: "}</note>
       </trans-unit>
       <trans-unit id="WindowsDesktopFrameworkRequiresUseWpfOrUseWindowsForms">

--- a/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
@@ -631,6 +631,16 @@ The following are names of parameters or literal values and should not be transl
         <target state="needs-review-translation">プレビュー版の .NET Core を使用しています。https://aka.ms/dotnet-core-preview をご覧ください</target>
         <note />
       </trans-unit>
+      <trans-unit id="WinMDObjNotSupportedOnTargetFramework">
+        <source>NETSDK1131: Producing a managed Windows Metadata component with WinMDExp is not supportd when targeting {0}.</source>
+        <target state="new">NETSDK1131: Producing a managed Windows Metadata component with WinMDExp is not supportd when targeting {0}.</target>
+        <note>{StrBegin="NETSDK1131: "}</note>
+      </trans-unit>
+      <trans-unit id="WinMDReferenceNotSupportedOnTargetFramework">
+        <source>NETSDK1130: Referencing a Windows Metadata component directly when targeting {0} is not supported. Use the C#/WinRT projection tool or a provided projection for this target.</source>
+        <target state="new">NETSDK1130: Referencing a Windows Metadata component directly when targeting {0} is not supported. Use the C#/WinRT projection tool or a provided projection for this target.</target>
+        <note>{StrBegin="NETSDK1130: "}</note>
+      </trans-unit>
       <trans-unit id="WindowsDesktopFrameworkRequiresUseWpfOrUseWindowsForms">
         <source>NETSDK1106: Microsoft.NET.Sdk.WindowsDesktop requires 'UseWpf' or 'UseWindowsForms' to be set to 'true'</source>
         <target state="translated">NETSDK1106: Microsoft.NET.Sdk.WindowsDesktop では、'UseWpf' または 'UseWindowsForms' を 'true' に設定する必要があります</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
@@ -632,13 +632,13 @@ The following are names of parameters or literal values and should not be transl
         <note />
       </trans-unit>
       <trans-unit id="WinMDObjNotSupportedOnTargetFramework">
-        <source>NETSDK1131: Producing a managed Windows Metadata component with WinMDExp is not supportd when targeting {0}.</source>
-        <target state="new">NETSDK1131: Producing a managed Windows Metadata component with WinMDExp is not supportd when targeting {0}.</target>
+        <source>NETSDK1131: Producing a managed Windows Metadata component with WinMDExp is not supported when targeting {0}.</source>
+        <target state="new">NETSDK1131: Producing a managed Windows Metadata component with WinMDExp is not supported when targeting {0}.</target>
         <note>{StrBegin="NETSDK1131: "}</note>
       </trans-unit>
       <trans-unit id="WinMDReferenceNotSupportedOnTargetFramework">
-        <source>NETSDK1130: Referencing a Windows Metadata component directly when targeting {0} is not supported. Use the C#/WinRT projection tool or a provided projection for this target.</source>
-        <target state="new">NETSDK1130: Referencing a Windows Metadata component directly when targeting {0} is not supported. Use the C#/WinRT projection tool or a provided projection for this target.</target>
+        <source>NETSDK1130: Referencing a Windows Metadata component directly when targeting {0} is not supported. Use the C#/WinRT projection tool (https://aka.ms/cswinrt) or a provided projection for this target.</source>
+        <target state="new">NETSDK1130: Referencing a Windows Metadata component directly when targeting {0} is not supported. Use the C#/WinRT projection tool (https://aka.ms/cswinrt) or a provided projection for this target.</target>
         <note>{StrBegin="NETSDK1130: "}</note>
       </trans-unit>
       <trans-unit id="WindowsDesktopFrameworkRequiresUseWpfOrUseWindowsForms">

--- a/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
@@ -631,6 +631,16 @@ The following are names of parameters or literal values and should not be transl
         <target state="needs-review-translation">.NET Core의 미리 보기 버전을 사용 중입니다. 참조: https://aka.ms/dotnet-core-preview</target>
         <note />
       </trans-unit>
+      <trans-unit id="WinMDObjNotSupportedOnTargetFramework">
+        <source>NETSDK1131: Producing a managed Windows Metadata component with WinMDExp is not supportd when targeting {0}.</source>
+        <target state="new">NETSDK1131: Producing a managed Windows Metadata component with WinMDExp is not supportd when targeting {0}.</target>
+        <note>{StrBegin="NETSDK1131: "}</note>
+      </trans-unit>
+      <trans-unit id="WinMDReferenceNotSupportedOnTargetFramework">
+        <source>NETSDK1130: Referencing a Windows Metadata component directly when targeting {0} is not supported. Use the C#/WinRT projection tool or a provided projection for this target.</source>
+        <target state="new">NETSDK1130: Referencing a Windows Metadata component directly when targeting {0} is not supported. Use the C#/WinRT projection tool or a provided projection for this target.</target>
+        <note>{StrBegin="NETSDK1130: "}</note>
+      </trans-unit>
       <trans-unit id="WindowsDesktopFrameworkRequiresUseWpfOrUseWindowsForms">
         <source>NETSDK1106: Microsoft.NET.Sdk.WindowsDesktop requires 'UseWpf' or 'UseWindowsForms' to be set to 'true'</source>
         <target state="translated">NETSDK1106: Microsoft.NET.Sdk.WindowsDesktop을 사용하려면 'UseWpf' 또는 'UseWindowsForms'를 'true'로 설정해야 합니다.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
@@ -632,13 +632,13 @@ The following are names of parameters or literal values and should not be transl
         <note />
       </trans-unit>
       <trans-unit id="WinMDObjNotSupportedOnTargetFramework">
-        <source>NETSDK1131: Producing a managed Windows Metadata component with WinMDExp is not supportd when targeting {0}.</source>
-        <target state="new">NETSDK1131: Producing a managed Windows Metadata component with WinMDExp is not supportd when targeting {0}.</target>
+        <source>NETSDK1131: Producing a managed Windows Metadata component with WinMDExp is not supported when targeting {0}.</source>
+        <target state="new">NETSDK1131: Producing a managed Windows Metadata component with WinMDExp is not supported when targeting {0}.</target>
         <note>{StrBegin="NETSDK1131: "}</note>
       </trans-unit>
       <trans-unit id="WinMDReferenceNotSupportedOnTargetFramework">
-        <source>NETSDK1130: Referencing a Windows Metadata component directly when targeting {0} is not supported. Use the C#/WinRT projection tool or a provided projection for this target.</source>
-        <target state="new">NETSDK1130: Referencing a Windows Metadata component directly when targeting {0} is not supported. Use the C#/WinRT projection tool or a provided projection for this target.</target>
+        <source>NETSDK1130: Referencing a Windows Metadata component directly when targeting {0} is not supported. Use the C#/WinRT projection tool (https://aka.ms/cswinrt) or a provided projection for this target.</source>
+        <target state="new">NETSDK1130: Referencing a Windows Metadata component directly when targeting {0} is not supported. Use the C#/WinRT projection tool (https://aka.ms/cswinrt) or a provided projection for this target.</target>
         <note>{StrBegin="NETSDK1130: "}</note>
       </trans-unit>
       <trans-unit id="WindowsDesktopFrameworkRequiresUseWpfOrUseWindowsForms">

--- a/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
@@ -631,6 +631,16 @@ The following are names of parameters or literal values and should not be transl
         <target state="needs-review-translation">Korzystasz z wersji zapoznawczej programu .NET Core. Zobacz: https://aka.ms/dotnet-core-preview</target>
         <note />
       </trans-unit>
+      <trans-unit id="WinMDObjNotSupportedOnTargetFramework">
+        <source>NETSDK1131: Producing a managed Windows Metadata component with WinMDExp is not supportd when targeting {0}.</source>
+        <target state="new">NETSDK1131: Producing a managed Windows Metadata component with WinMDExp is not supportd when targeting {0}.</target>
+        <note>{StrBegin="NETSDK1131: "}</note>
+      </trans-unit>
+      <trans-unit id="WinMDReferenceNotSupportedOnTargetFramework">
+        <source>NETSDK1130: Referencing a Windows Metadata component directly when targeting {0} is not supported. Use the C#/WinRT projection tool or a provided projection for this target.</source>
+        <target state="new">NETSDK1130: Referencing a Windows Metadata component directly when targeting {0} is not supported. Use the C#/WinRT projection tool or a provided projection for this target.</target>
+        <note>{StrBegin="NETSDK1130: "}</note>
+      </trans-unit>
       <trans-unit id="WindowsDesktopFrameworkRequiresUseWpfOrUseWindowsForms">
         <source>NETSDK1106: Microsoft.NET.Sdk.WindowsDesktop requires 'UseWpf' or 'UseWindowsForms' to be set to 'true'</source>
         <target state="translated">NETSDK1106: Zestaw Microsoft.NET.Sdk.WindowsDesktop wymaga ustawienia właściwości „UseWpf” lub „UseWindowsForms” na wartość „true”</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
@@ -632,13 +632,13 @@ The following are names of parameters or literal values and should not be transl
         <note />
       </trans-unit>
       <trans-unit id="WinMDObjNotSupportedOnTargetFramework">
-        <source>NETSDK1131: Producing a managed Windows Metadata component with WinMDExp is not supportd when targeting {0}.</source>
-        <target state="new">NETSDK1131: Producing a managed Windows Metadata component with WinMDExp is not supportd when targeting {0}.</target>
+        <source>NETSDK1131: Producing a managed Windows Metadata component with WinMDExp is not supported when targeting {0}.</source>
+        <target state="new">NETSDK1131: Producing a managed Windows Metadata component with WinMDExp is not supported when targeting {0}.</target>
         <note>{StrBegin="NETSDK1131: "}</note>
       </trans-unit>
       <trans-unit id="WinMDReferenceNotSupportedOnTargetFramework">
-        <source>NETSDK1130: Referencing a Windows Metadata component directly when targeting {0} is not supported. Use the C#/WinRT projection tool or a provided projection for this target.</source>
-        <target state="new">NETSDK1130: Referencing a Windows Metadata component directly when targeting {0} is not supported. Use the C#/WinRT projection tool or a provided projection for this target.</target>
+        <source>NETSDK1130: Referencing a Windows Metadata component directly when targeting {0} is not supported. Use the C#/WinRT projection tool (https://aka.ms/cswinrt) or a provided projection for this target.</source>
+        <target state="new">NETSDK1130: Referencing a Windows Metadata component directly when targeting {0} is not supported. Use the C#/WinRT projection tool (https://aka.ms/cswinrt) or a provided projection for this target.</target>
         <note>{StrBegin="NETSDK1130: "}</note>
       </trans-unit>
       <trans-unit id="WindowsDesktopFrameworkRequiresUseWpfOrUseWindowsForms">

--- a/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
@@ -631,6 +631,16 @@ The following are names of parameters or literal values and should not be transl
         <target state="needs-review-translation">Você está usando uma versão prévia do .NET Core. Confira: https://aka.ms/dotnet-core-preview</target>
         <note />
       </trans-unit>
+      <trans-unit id="WinMDObjNotSupportedOnTargetFramework">
+        <source>NETSDK1131: Producing a managed Windows Metadata component with WinMDExp is not supportd when targeting {0}.</source>
+        <target state="new">NETSDK1131: Producing a managed Windows Metadata component with WinMDExp is not supportd when targeting {0}.</target>
+        <note>{StrBegin="NETSDK1131: "}</note>
+      </trans-unit>
+      <trans-unit id="WinMDReferenceNotSupportedOnTargetFramework">
+        <source>NETSDK1130: Referencing a Windows Metadata component directly when targeting {0} is not supported. Use the C#/WinRT projection tool or a provided projection for this target.</source>
+        <target state="new">NETSDK1130: Referencing a Windows Metadata component directly when targeting {0} is not supported. Use the C#/WinRT projection tool or a provided projection for this target.</target>
+        <note>{StrBegin="NETSDK1130: "}</note>
+      </trans-unit>
       <trans-unit id="WindowsDesktopFrameworkRequiresUseWpfOrUseWindowsForms">
         <source>NETSDK1106: Microsoft.NET.Sdk.WindowsDesktop requires 'UseWpf' or 'UseWindowsForms' to be set to 'true'</source>
         <target state="translated">NETSDK1106: Microsoft.NET.Sdk.WindowsDesktop exige 'UseWpf' ou 'UseWindowsForms' para ser definido como 'true'</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
@@ -632,13 +632,13 @@ The following are names of parameters or literal values and should not be transl
         <note />
       </trans-unit>
       <trans-unit id="WinMDObjNotSupportedOnTargetFramework">
-        <source>NETSDK1131: Producing a managed Windows Metadata component with WinMDExp is not supportd when targeting {0}.</source>
-        <target state="new">NETSDK1131: Producing a managed Windows Metadata component with WinMDExp is not supportd when targeting {0}.</target>
+        <source>NETSDK1131: Producing a managed Windows Metadata component with WinMDExp is not supported when targeting {0}.</source>
+        <target state="new">NETSDK1131: Producing a managed Windows Metadata component with WinMDExp is not supported when targeting {0}.</target>
         <note>{StrBegin="NETSDK1131: "}</note>
       </trans-unit>
       <trans-unit id="WinMDReferenceNotSupportedOnTargetFramework">
-        <source>NETSDK1130: Referencing a Windows Metadata component directly when targeting {0} is not supported. Use the C#/WinRT projection tool or a provided projection for this target.</source>
-        <target state="new">NETSDK1130: Referencing a Windows Metadata component directly when targeting {0} is not supported. Use the C#/WinRT projection tool or a provided projection for this target.</target>
+        <source>NETSDK1130: Referencing a Windows Metadata component directly when targeting {0} is not supported. Use the C#/WinRT projection tool (https://aka.ms/cswinrt) or a provided projection for this target.</source>
+        <target state="new">NETSDK1130: Referencing a Windows Metadata component directly when targeting {0} is not supported. Use the C#/WinRT projection tool (https://aka.ms/cswinrt) or a provided projection for this target.</target>
         <note>{StrBegin="NETSDK1130: "}</note>
       </trans-unit>
       <trans-unit id="WindowsDesktopFrameworkRequiresUseWpfOrUseWindowsForms">

--- a/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
@@ -631,6 +631,16 @@ The following are names of parameters or literal values and should not be transl
         <target state="needs-review-translation">Вы используете предварительную версию .NET Core. Дополнительные сведения см. на странице https://aka.ms/dotnet-core-preview.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WinMDObjNotSupportedOnTargetFramework">
+        <source>NETSDK1131: Producing a managed Windows Metadata component with WinMDExp is not supportd when targeting {0}.</source>
+        <target state="new">NETSDK1131: Producing a managed Windows Metadata component with WinMDExp is not supportd when targeting {0}.</target>
+        <note>{StrBegin="NETSDK1131: "}</note>
+      </trans-unit>
+      <trans-unit id="WinMDReferenceNotSupportedOnTargetFramework">
+        <source>NETSDK1130: Referencing a Windows Metadata component directly when targeting {0} is not supported. Use the C#/WinRT projection tool or a provided projection for this target.</source>
+        <target state="new">NETSDK1130: Referencing a Windows Metadata component directly when targeting {0} is not supported. Use the C#/WinRT projection tool or a provided projection for this target.</target>
+        <note>{StrBegin="NETSDK1130: "}</note>
+      </trans-unit>
       <trans-unit id="WindowsDesktopFrameworkRequiresUseWpfOrUseWindowsForms">
         <source>NETSDK1106: Microsoft.NET.Sdk.WindowsDesktop requires 'UseWpf' or 'UseWindowsForms' to be set to 'true'</source>
         <target state="translated">NETSDK1106: для использования Microsoft.NET.Sdk.WindowsDesktop требуется установить значение "true" для свойства "UseWpf" или "UseWindowsForms"</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
@@ -632,13 +632,13 @@ The following are names of parameters or literal values and should not be transl
         <note />
       </trans-unit>
       <trans-unit id="WinMDObjNotSupportedOnTargetFramework">
-        <source>NETSDK1131: Producing a managed Windows Metadata component with WinMDExp is not supportd when targeting {0}.</source>
-        <target state="new">NETSDK1131: Producing a managed Windows Metadata component with WinMDExp is not supportd when targeting {0}.</target>
+        <source>NETSDK1131: Producing a managed Windows Metadata component with WinMDExp is not supported when targeting {0}.</source>
+        <target state="new">NETSDK1131: Producing a managed Windows Metadata component with WinMDExp is not supported when targeting {0}.</target>
         <note>{StrBegin="NETSDK1131: "}</note>
       </trans-unit>
       <trans-unit id="WinMDReferenceNotSupportedOnTargetFramework">
-        <source>NETSDK1130: Referencing a Windows Metadata component directly when targeting {0} is not supported. Use the C#/WinRT projection tool or a provided projection for this target.</source>
-        <target state="new">NETSDK1130: Referencing a Windows Metadata component directly when targeting {0} is not supported. Use the C#/WinRT projection tool or a provided projection for this target.</target>
+        <source>NETSDK1130: Referencing a Windows Metadata component directly when targeting {0} is not supported. Use the C#/WinRT projection tool (https://aka.ms/cswinrt) or a provided projection for this target.</source>
+        <target state="new">NETSDK1130: Referencing a Windows Metadata component directly when targeting {0} is not supported. Use the C#/WinRT projection tool (https://aka.ms/cswinrt) or a provided projection for this target.</target>
         <note>{StrBegin="NETSDK1130: "}</note>
       </trans-unit>
       <trans-unit id="WindowsDesktopFrameworkRequiresUseWpfOrUseWindowsForms">

--- a/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
@@ -631,6 +631,16 @@ The following are names of parameters or literal values and should not be transl
         <target state="needs-review-translation">.NET Core'un önizleme sürümünü kullanıyorsunuz. Bkz. https://aka.ms/dotnet-core-preview</target>
         <note />
       </trans-unit>
+      <trans-unit id="WinMDObjNotSupportedOnTargetFramework">
+        <source>NETSDK1131: Producing a managed Windows Metadata component with WinMDExp is not supportd when targeting {0}.</source>
+        <target state="new">NETSDK1131: Producing a managed Windows Metadata component with WinMDExp is not supportd when targeting {0}.</target>
+        <note>{StrBegin="NETSDK1131: "}</note>
+      </trans-unit>
+      <trans-unit id="WinMDReferenceNotSupportedOnTargetFramework">
+        <source>NETSDK1130: Referencing a Windows Metadata component directly when targeting {0} is not supported. Use the C#/WinRT projection tool or a provided projection for this target.</source>
+        <target state="new">NETSDK1130: Referencing a Windows Metadata component directly when targeting {0} is not supported. Use the C#/WinRT projection tool or a provided projection for this target.</target>
+        <note>{StrBegin="NETSDK1130: "}</note>
+      </trans-unit>
       <trans-unit id="WindowsDesktopFrameworkRequiresUseWpfOrUseWindowsForms">
         <source>NETSDK1106: Microsoft.NET.Sdk.WindowsDesktop requires 'UseWpf' or 'UseWindowsForms' to be set to 'true'</source>
         <target state="translated">NETSDK1106: Microsoft.NET.Sdk.WindowsDesktop için 'UseWpf' veya 'UseWindowsForms' değerinin 'true' olarak ayarlanması gerekiyor</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
@@ -632,13 +632,13 @@ The following are names of parameters or literal values and should not be transl
         <note />
       </trans-unit>
       <trans-unit id="WinMDObjNotSupportedOnTargetFramework">
-        <source>NETSDK1131: Producing a managed Windows Metadata component with WinMDExp is not supportd when targeting {0}.</source>
-        <target state="new">NETSDK1131: Producing a managed Windows Metadata component with WinMDExp is not supportd when targeting {0}.</target>
+        <source>NETSDK1131: Producing a managed Windows Metadata component with WinMDExp is not supported when targeting {0}.</source>
+        <target state="new">NETSDK1131: Producing a managed Windows Metadata component with WinMDExp is not supported when targeting {0}.</target>
         <note>{StrBegin="NETSDK1131: "}</note>
       </trans-unit>
       <trans-unit id="WinMDReferenceNotSupportedOnTargetFramework">
-        <source>NETSDK1130: Referencing a Windows Metadata component directly when targeting {0} is not supported. Use the C#/WinRT projection tool or a provided projection for this target.</source>
-        <target state="new">NETSDK1130: Referencing a Windows Metadata component directly when targeting {0} is not supported. Use the C#/WinRT projection tool or a provided projection for this target.</target>
+        <source>NETSDK1130: Referencing a Windows Metadata component directly when targeting {0} is not supported. Use the C#/WinRT projection tool (https://aka.ms/cswinrt) or a provided projection for this target.</source>
+        <target state="new">NETSDK1130: Referencing a Windows Metadata component directly when targeting {0} is not supported. Use the C#/WinRT projection tool (https://aka.ms/cswinrt) or a provided projection for this target.</target>
         <note>{StrBegin="NETSDK1130: "}</note>
       </trans-unit>
       <trans-unit id="WindowsDesktopFrameworkRequiresUseWpfOrUseWindowsForms">

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
@@ -631,6 +631,16 @@ The following are names of parameters or literal values and should not be transl
         <target state="needs-review-translation">你正在使用 .NET Core 的预览版。请查看 https://aka.ms/dotnet-core-preview</target>
         <note />
       </trans-unit>
+      <trans-unit id="WinMDObjNotSupportedOnTargetFramework">
+        <source>NETSDK1131: Producing a managed Windows Metadata component with WinMDExp is not supportd when targeting {0}.</source>
+        <target state="new">NETSDK1131: Producing a managed Windows Metadata component with WinMDExp is not supportd when targeting {0}.</target>
+        <note>{StrBegin="NETSDK1131: "}</note>
+      </trans-unit>
+      <trans-unit id="WinMDReferenceNotSupportedOnTargetFramework">
+        <source>NETSDK1130: Referencing a Windows Metadata component directly when targeting {0} is not supported. Use the C#/WinRT projection tool or a provided projection for this target.</source>
+        <target state="new">NETSDK1130: Referencing a Windows Metadata component directly when targeting {0} is not supported. Use the C#/WinRT projection tool or a provided projection for this target.</target>
+        <note>{StrBegin="NETSDK1130: "}</note>
+      </trans-unit>
       <trans-unit id="WindowsDesktopFrameworkRequiresUseWpfOrUseWindowsForms">
         <source>NETSDK1106: Microsoft.NET.Sdk.WindowsDesktop requires 'UseWpf' or 'UseWindowsForms' to be set to 'true'</source>
         <target state="translated">NETSDK1106: Microsoft.NET.Sdk.WindowsDesktop 需要将 "UseWpf" 或 "UseWindowsForms" 设置为 "true"</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
@@ -632,13 +632,13 @@ The following are names of parameters or literal values and should not be transl
         <note />
       </trans-unit>
       <trans-unit id="WinMDObjNotSupportedOnTargetFramework">
-        <source>NETSDK1131: Producing a managed Windows Metadata component with WinMDExp is not supportd when targeting {0}.</source>
-        <target state="new">NETSDK1131: Producing a managed Windows Metadata component with WinMDExp is not supportd when targeting {0}.</target>
+        <source>NETSDK1131: Producing a managed Windows Metadata component with WinMDExp is not supported when targeting {0}.</source>
+        <target state="new">NETSDK1131: Producing a managed Windows Metadata component with WinMDExp is not supported when targeting {0}.</target>
         <note>{StrBegin="NETSDK1131: "}</note>
       </trans-unit>
       <trans-unit id="WinMDReferenceNotSupportedOnTargetFramework">
-        <source>NETSDK1130: Referencing a Windows Metadata component directly when targeting {0} is not supported. Use the C#/WinRT projection tool or a provided projection for this target.</source>
-        <target state="new">NETSDK1130: Referencing a Windows Metadata component directly when targeting {0} is not supported. Use the C#/WinRT projection tool or a provided projection for this target.</target>
+        <source>NETSDK1130: Referencing a Windows Metadata component directly when targeting {0} is not supported. Use the C#/WinRT projection tool (https://aka.ms/cswinrt) or a provided projection for this target.</source>
+        <target state="new">NETSDK1130: Referencing a Windows Metadata component directly when targeting {0} is not supported. Use the C#/WinRT projection tool (https://aka.ms/cswinrt) or a provided projection for this target.</target>
         <note>{StrBegin="NETSDK1130: "}</note>
       </trans-unit>
       <trans-unit id="WindowsDesktopFrameworkRequiresUseWpfOrUseWindowsForms">

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
@@ -631,6 +631,16 @@ The following are names of parameters or literal values and should not be transl
         <target state="needs-review-translation">您目前使用 .NET Core 預覽版。請參閱: https://aka.ms/dotnet-core-preview</target>
         <note />
       </trans-unit>
+      <trans-unit id="WinMDObjNotSupportedOnTargetFramework">
+        <source>NETSDK1131: Producing a managed Windows Metadata component with WinMDExp is not supportd when targeting {0}.</source>
+        <target state="new">NETSDK1131: Producing a managed Windows Metadata component with WinMDExp is not supportd when targeting {0}.</target>
+        <note>{StrBegin="NETSDK1131: "}</note>
+      </trans-unit>
+      <trans-unit id="WinMDReferenceNotSupportedOnTargetFramework">
+        <source>NETSDK1130: Referencing a Windows Metadata component directly when targeting {0} is not supported. Use the C#/WinRT projection tool or a provided projection for this target.</source>
+        <target state="new">NETSDK1130: Referencing a Windows Metadata component directly when targeting {0} is not supported. Use the C#/WinRT projection tool or a provided projection for this target.</target>
+        <note>{StrBegin="NETSDK1130: "}</note>
+      </trans-unit>
       <trans-unit id="WindowsDesktopFrameworkRequiresUseWpfOrUseWindowsForms">
         <source>NETSDK1106: Microsoft.NET.Sdk.WindowsDesktop requires 'UseWpf' or 'UseWindowsForms' to be set to 'true'</source>
         <target state="translated">NETSDK1106: Microsoft.NET.Sdk.WindowsDesktop 需要 'UseWpf' 或 'UseWindowsForms' 設為 'true'</target>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -863,6 +863,27 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <!--
   ============================================================
+               _BlockWinMDsOnUnsupportedTFMs
+  Block referencing or producing
+  Windows Metadata files (.winmd) for target frameworks
+  that do not support loading winmds directly
+  into the runtime as assemblies
+  ============================================================
+  -->
+  <Target Name="_BlockWinMDsOnUnsupportedTFMs"
+          BeforeTargets="CoreCompile"
+          DependsOnTargets="ResolveReferences"
+          Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' and $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '5.0'))">
+    <NETSdkError Condition="'%(ReferencePath.Extension)' == '.winmd'"
+      ResourceName="WinMDReferenceNotSupportedOnTargetFramework"
+      FormatArguments="$(TargetFrameworkMoniker)" />
+    <NETSdkError Condition="'$(OutputType)' == 'winmdobj'"
+      ResourceName="WinMDObjNotSupportedOnTargetFramework"
+      FormatArguments="$(TargetFrameworkMoniker)" />
+  </Target>
+
+  <!--
+  ============================================================
                                       InjectTargetPathMetadata
 
   Update TargetPathWithTargetPlatformMoniker with target framework

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAWindowsRuntimeComponent.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAWindowsRuntimeComponent.cs
@@ -21,7 +21,7 @@ namespace Microsoft.NET.Build.Tests
         }
 
         [Fact]
-        public void It_fails_from_producing_winmds_for_net5_0()
+        public void It_fails_from_producing_winmds_for_net5_0_or_newer()
         {
             var testAsset = _testAssetsManager
                 .CopyTestAsset("WindowsRuntimeComponent")
@@ -37,12 +37,11 @@ namespace Microsoft.NET.Build.Tests
         }
 
         [Fact]
-        public void It_fails_from_referencing_winmds_for_net5_0()
+        public void It_fails_from_referencing_winmds_for_net5_0_or_newer()
         {
             var testAsset = _testAssetsManager
                 .CopyTestAsset("WinMDClasslibrary")
                 .WithSource();
-
 
             var buildCommand = new BuildCommand(Log, testAsset.TestRoot);
             buildCommand
@@ -67,7 +66,6 @@ namespace Microsoft.NET.Build.Tests
                     var propertyGroup = project.Root.Elements(ns + "PropertyGroup").First();
                     propertyGroup.Element("TargetFramework").ReplaceWith(new XElement("TargetFramework", targetFramework));
                 });
-
 
             var buildCommand = new BuildCommand(Log, testAsset.TestRoot);
             buildCommand

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAWindowsRuntimeComponent.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAWindowsRuntimeComponent.cs
@@ -21,7 +21,7 @@ namespace Microsoft.NET.Build.Tests
         }
 
         [Fact]
-        public void It_fails_from_producing_winmds_for_net5_0_or_newer()
+        public void It_fails_to_produce_winmds_for_net5_0_or_newer()
         {
             var testAsset = _testAssetsManager
                 .CopyTestAsset("WindowsRuntimeComponent")
@@ -37,7 +37,7 @@ namespace Microsoft.NET.Build.Tests
         }
 
         [Fact]
-        public void It_fails_from_referencing_winmds_for_net5_0_or_newer()
+        public void It_fails_when_referencing_winmds_for_net5_0_or_newer()
         {
             var testAsset = _testAssetsManager
                 .CopyTestAsset("WinMDClasslibrary")
@@ -60,12 +60,7 @@ namespace Microsoft.NET.Build.Tests
             var testAsset = _testAssetsManager
                 .CopyTestAsset("WinMDClasslibrary")
                 .WithSource()
-                .WithProjectChanges(project =>
-                {
-                    var ns = project.Root.Name.Namespace;
-                    var propertyGroup = project.Root.Elements(ns + "PropertyGroup").First();
-                    propertyGroup.Element("TargetFramework").ReplaceWith(new XElement("TargetFramework", targetFramework));
-                });
+                .WithTargetFramework(targetFramework);
 
             var buildCommand = new BuildCommand(Log, testAsset.TestRoot);
             buildCommand

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAWindowsRuntimeComponent.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAWindowsRuntimeComponent.cs
@@ -40,7 +40,7 @@ namespace Microsoft.NET.Build.Tests
         public void It_fails_when_referencing_winmds_for_net5_0_or_newer()
         {
             var testAsset = _testAssetsManager
-                .CopyTestAsset("WinMDClasslibrary")
+                .CopyTestAsset("WinMDClassLibrary")
                 .WithSource();
 
             var buildCommand = new BuildCommand(Log, testAsset.TestRoot);
@@ -58,7 +58,7 @@ namespace Microsoft.NET.Build.Tests
         public void It_successfully_builds_when_referencing_winmds(string targetFramework)
         {
             var testAsset = _testAssetsManager
-                .CopyTestAsset("WinMDClasslibrary")
+                .CopyTestAsset("WinMDClassLibrary")
                 .WithSource()
                 .WithTargetFramework(targetFramework);
 

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAWindowsRuntimeComponent.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAWindowsRuntimeComponent.cs
@@ -1,0 +1,79 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+using FluentAssertions;
+using Microsoft.NET.TestFramework;
+using Microsoft.NET.TestFramework.Assertions;
+using Microsoft.NET.TestFramework.Commands;
+using Newtonsoft.Json.Linq;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.NET.Build.Tests
+{
+    public class GivenThatWeWantToBuildAWindowsRuntimeComponent : SdkTest
+    {
+        public GivenThatWeWantToBuildAWindowsRuntimeComponent(ITestOutputHelper log) : base(log)
+        {
+        }
+
+        [Fact]
+        public void It_fails_from_producing_winmds_for_net5_0()
+        {
+            var testAsset = _testAssetsManager
+                .CopyTestAsset("WindowsRuntimeComponent")
+                .WithSource();
+
+            var buildCommand = new BuildCommand(Log, testAsset.TestRoot);
+            buildCommand
+                .Execute()
+                .Should()
+                .Fail()
+                .And
+                .HaveStdOutContaining("NETSDK1131: ");
+        }
+
+        [Fact]
+        public void It_fails_from_referencing_winmds_for_net5_0()
+        {
+            var testAsset = _testAssetsManager
+                .CopyTestAsset("WinMDClasslibrary")
+                .WithSource();
+
+
+            var buildCommand = new BuildCommand(Log, testAsset.TestRoot);
+            buildCommand
+                .Execute()
+                .Should()
+                .Fail()
+                .And
+                .HaveStdOutContaining("NETSDK1130: ");
+        }
+
+        [Theory]
+        [InlineData("netcoreapp3.1")]
+        [InlineData("net48")]
+        public void It_successfully_builds_when_referencing_winmds(string targetFramework)
+        {
+            var testAsset = _testAssetsManager
+                .CopyTestAsset("WinMDClasslibrary")
+                .WithSource()
+                .WithProjectChanges(project =>
+                {
+                    var ns = project.Root.Name.Namespace;
+                    var propertyGroup = project.Root.Elements(ns + "PropertyGroup").First();
+                    propertyGroup.Element("TargetFramework").ReplaceWith(new XElement("TargetFramework", targetFramework));
+                });
+
+
+            var buildCommand = new BuildCommand(Log, testAsset.TestRoot);
+            buildCommand
+                .Execute()
+                .Should()
+                .Pass();
+        }
+    }
+}


### PR DESCRIPTION
In https://github.com/dotnet/runtime/pull/36715, we are removing the ability to load WinMD metadata files and WinRT types directly into the .NET runtime. This PR adds SDK-side support to fail builds at compile time instead of at runtime when targeting .NET 5 and producing or consuming WinMD references directly.

cc: @AaronRobinsonMSFT @jeffschwMSFT @Scottj1s