### PR TITLE
Support labels for runtime packs

### DIFF
--- a/src/Tasks/Common/MetadataKeys.cs
+++ b/src/Tasks/Common/MetadataKeys.cs
@@ -83,6 +83,7 @@ namespace Microsoft.NET.Build.Tasks
         //  Runtime packs
 		public const string DropFromSingleFile = "DropFromSingleFile";
         public const string RuntimePackLabels = "RuntimePackLabels";
+        public const string AdditionalFrameworkReferences = "AdditionalFrameworkReferences";
 
         // Content files
         public const string PPOutputPath = "PPOutputPath";

--- a/src/Tasks/Common/MetadataKeys.cs
+++ b/src/Tasks/Common/MetadataKeys.cs
@@ -81,7 +81,8 @@ namespace Microsoft.NET.Build.Tasks
         public const string PackageConflictPreferredPackages = "PackageConflictPreferredPackages";
 
         //  Runtime packs
-        public const string DropFromSingleFile = "DropFromSingleFile";
+		public const string DropFromSingleFile = "DropFromSingleFile";
+        public const string RuntimePackLabels = "RuntimePackLabels";
 
         // Content files
         public const string PPOutputPath = "PPOutputPath";

--- a/src/Tasks/Common/Resources/Strings.resx
+++ b/src/Tasks/Common/Resources/Strings.resx
@@ -628,4 +628,13 @@ The following are names of parameters or literal values and should not be transl
     <value>NETSDK1131: Producing a managed Windows Metadata component with WinMDExp is not supported when targeting {0}.</value>
     <comment>{StrBegin="NETSDK1131: "}</comment>
   </data>
+  <data name="NoRuntimePackInformation" xml:space="preserve">
+    <value>NETSDK1132: No runtime pack information was available for {0}.</value>
+    <comment>{StrBegin="NETSDK1132: "}</comment>
+  </data>
+  <data name="ConflictingRuntimePackInformation" xml:space="preserve">
+    <value>NETSDK1133: There was conflicting information about runtime packs available for {0}:
+{1}</value>
+    <comment>{StrBegin="NETSDK1133: "}</comment>
+  </data>
 </root>

--- a/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
@@ -192,6 +192,13 @@
         <note>{StrBegin="NETSDK1090: "}
 {0} - The path to the invalid assembly.</note>
       </trans-unit>
+      <trans-unit id="ConflictingRuntimePackInformation">
+        <source>NETSDK1133: There was conflicting information about runtime packs available for {0}:
+{1}</source>
+        <target state="new">NETSDK1133: There was conflicting information about runtime packs available for {0}:
+{1}</target>
+        <note>{StrBegin="NETSDK1133: "}</note>
+      </trans-unit>
       <trans-unit id="ContentItemDoesNotProvideOutputPath">
         <source>NETSDK1014: Content item for '{0}' sets '{1}', but does not provide  '{2}' or '{3}'.</source>
         <target state="translated">NETSDK1014: Položka obsahu pro {0} nastaví {1}, ale neposkytuje {2} ani {3}.</target>
@@ -425,6 +432,11 @@ The following are names of parameters or literal values and should not be transl
         <source>NETSDK1082: There was no runtime pack for {0} available for the specified RuntimeIdentifier '{1}'.</source>
         <target state="translated">NETSDK1082: Pro zadaný identifikátor RuntimeIdentifier {1} nebyl k dispozici žádný balíček modulu runtime {0}.</target>
         <note>{StrBegin="NETSDK1082: "}</note>
+      </trans-unit>
+      <trans-unit id="NoRuntimePackInformation">
+        <source>NETSDK1132: No runtime pack information was available for {0}.</source>
+        <target state="new">NETSDK1132: No runtime pack information was available for {0}.</target>
+        <note>{StrBegin="NETSDK1132: "}</note>
       </trans-unit>
       <trans-unit id="NoSupportComSelfContained">
         <source>NETSDK1128: COM hosting does not support self-contained deployments.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.de.xlf
@@ -192,6 +192,13 @@
         <note>{StrBegin="NETSDK1090: "}
 {0} - The path to the invalid assembly.</note>
       </trans-unit>
+      <trans-unit id="ConflictingRuntimePackInformation">
+        <source>NETSDK1133: There was conflicting information about runtime packs available for {0}:
+{1}</source>
+        <target state="new">NETSDK1133: There was conflicting information about runtime packs available for {0}:
+{1}</target>
+        <note>{StrBegin="NETSDK1133: "}</note>
+      </trans-unit>
       <trans-unit id="ContentItemDoesNotProvideOutputPath">
         <source>NETSDK1014: Content item for '{0}' sets '{1}', but does not provide  '{2}' or '{3}'.</source>
         <target state="translated">NETSDK1014: Das Inhaltselement für "{0}" legt "{1}" fest, gibt aber "{2}" oder "{3}" nicht an.</target>
@@ -425,6 +432,11 @@ The following are names of parameters or literal values and should not be transl
         <source>NETSDK1082: There was no runtime pack for {0} available for the specified RuntimeIdentifier '{1}'.</source>
         <target state="translated">NETSDK1082: Für "{0}" stand für den angegebenen RuntimeIdentifier "{1}" kein Runtimepaket zur Verfügung.</target>
         <note>{StrBegin="NETSDK1082: "}</note>
+      </trans-unit>
+      <trans-unit id="NoRuntimePackInformation">
+        <source>NETSDK1132: No runtime pack information was available for {0}.</source>
+        <target state="new">NETSDK1132: No runtime pack information was available for {0}.</target>
+        <note>{StrBegin="NETSDK1132: "}</note>
       </trans-unit>
       <trans-unit id="NoSupportComSelfContained">
         <source>NETSDK1128: COM hosting does not support self-contained deployments.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.es.xlf
@@ -192,6 +192,13 @@
         <note>{StrBegin="NETSDK1090: "}
 {0} - The path to the invalid assembly.</note>
       </trans-unit>
+      <trans-unit id="ConflictingRuntimePackInformation">
+        <source>NETSDK1133: There was conflicting information about runtime packs available for {0}:
+{1}</source>
+        <target state="new">NETSDK1133: There was conflicting information about runtime packs available for {0}:
+{1}</target>
+        <note>{StrBegin="NETSDK1133: "}</note>
+      </trans-unit>
       <trans-unit id="ContentItemDoesNotProvideOutputPath">
         <source>NETSDK1014: Content item for '{0}' sets '{1}', but does not provide  '{2}' or '{3}'.</source>
         <target state="translated">NETSDK1014: El elemento de contenido de "{0}" establece "{1}", pero no proporciona "{2}" ni "{3}".</target>
@@ -425,6 +432,11 @@ The following are names of parameters or literal values and should not be transl
         <source>NETSDK1082: There was no runtime pack for {0} available for the specified RuntimeIdentifier '{1}'.</source>
         <target state="translated">NETSDK1082: No había ningún paquete de tiempo de ejecución para {0} disponible para el valor de RuntimeIdentifier especificado "{1}".</target>
         <note>{StrBegin="NETSDK1082: "}</note>
+      </trans-unit>
+      <trans-unit id="NoRuntimePackInformation">
+        <source>NETSDK1132: No runtime pack information was available for {0}.</source>
+        <target state="new">NETSDK1132: No runtime pack information was available for {0}.</target>
+        <note>{StrBegin="NETSDK1132: "}</note>
       </trans-unit>
       <trans-unit id="NoSupportComSelfContained">
         <source>NETSDK1128: COM hosting does not support self-contained deployments.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
@@ -192,6 +192,13 @@
         <note>{StrBegin="NETSDK1090: "}
 {0} - The path to the invalid assembly.</note>
       </trans-unit>
+      <trans-unit id="ConflictingRuntimePackInformation">
+        <source>NETSDK1133: There was conflicting information about runtime packs available for {0}:
+{1}</source>
+        <target state="new">NETSDK1133: There was conflicting information about runtime packs available for {0}:
+{1}</target>
+        <note>{StrBegin="NETSDK1133: "}</note>
+      </trans-unit>
       <trans-unit id="ContentItemDoesNotProvideOutputPath">
         <source>NETSDK1014: Content item for '{0}' sets '{1}', but does not provide  '{2}' or '{3}'.</source>
         <target state="translated">NETSDK1014: L'élément de contenu pour '{0}' définit '{1}', mais ne fournit ni '{2}' ni '{3}'.</target>
@@ -425,6 +432,11 @@ The following are names of parameters or literal values and should not be transl
         <source>NETSDK1082: There was no runtime pack for {0} available for the specified RuntimeIdentifier '{1}'.</source>
         <target state="translated">NETSDK1082: aucun pack d'exécution lié à {0} n'est disponible pour le RuntimeIdentifier spécifié '{1}'.</target>
         <note>{StrBegin="NETSDK1082: "}</note>
+      </trans-unit>
+      <trans-unit id="NoRuntimePackInformation">
+        <source>NETSDK1132: No runtime pack information was available for {0}.</source>
+        <target state="new">NETSDK1132: No runtime pack information was available for {0}.</target>
+        <note>{StrBegin="NETSDK1132: "}</note>
       </trans-unit>
       <trans-unit id="NoSupportComSelfContained">
         <source>NETSDK1128: COM hosting does not support self-contained deployments.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.it.xlf
@@ -192,6 +192,13 @@
         <note>{StrBegin="NETSDK1090: "}
 {0} - The path to the invalid assembly.</note>
       </trans-unit>
+      <trans-unit id="ConflictingRuntimePackInformation">
+        <source>NETSDK1133: There was conflicting information about runtime packs available for {0}:
+{1}</source>
+        <target state="new">NETSDK1133: There was conflicting information about runtime packs available for {0}:
+{1}</target>
+        <note>{StrBegin="NETSDK1133: "}</note>
+      </trans-unit>
       <trans-unit id="ContentItemDoesNotProvideOutputPath">
         <source>NETSDK1014: Content item for '{0}' sets '{1}', but does not provide  '{2}' or '{3}'.</source>
         <target state="translated">NETSDK1014: l'elemento di contenuto per '{0}' imposta '{1}', ma non fornisce '{2}' o '{3}'.</target>
@@ -425,6 +432,11 @@ The following are names of parameters or literal values and should not be transl
         <source>NETSDK1082: There was no runtime pack for {0} available for the specified RuntimeIdentifier '{1}'.</source>
         <target state="translated">NETSDK1082: non è disponibile alcun pacchetto di runtime per {0} per l'elemento RuntimeIdentifier specificato '{1}'.</target>
         <note>{StrBegin="NETSDK1082: "}</note>
+      </trans-unit>
+      <trans-unit id="NoRuntimePackInformation">
+        <source>NETSDK1132: No runtime pack information was available for {0}.</source>
+        <target state="new">NETSDK1132: No runtime pack information was available for {0}.</target>
+        <note>{StrBegin="NETSDK1132: "}</note>
       </trans-unit>
       <trans-unit id="NoSupportComSelfContained">
         <source>NETSDK1128: COM hosting does not support self-contained deployments.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
@@ -192,6 +192,13 @@
         <note>{StrBegin="NETSDK1090: "}
 {0} - The path to the invalid assembly.</note>
       </trans-unit>
+      <trans-unit id="ConflictingRuntimePackInformation">
+        <source>NETSDK1133: There was conflicting information about runtime packs available for {0}:
+{1}</source>
+        <target state="new">NETSDK1133: There was conflicting information about runtime packs available for {0}:
+{1}</target>
+        <note>{StrBegin="NETSDK1133: "}</note>
+      </trans-unit>
       <trans-unit id="ContentItemDoesNotProvideOutputPath">
         <source>NETSDK1014: Content item for '{0}' sets '{1}', but does not provide  '{2}' or '{3}'.</source>
         <target state="translated">NETSDK1014: '{0}' のコンテンツ項目で '{1}' が設定されていますが、'{2}' または '{3}' は指定されていません。</target>
@@ -425,6 +432,11 @@ The following are names of parameters or literal values and should not be transl
         <source>NETSDK1082: There was no runtime pack for {0} available for the specified RuntimeIdentifier '{1}'.</source>
         <target state="translated">NETSDK1082: 指定された RuntimeIdentifier '{1}' で利用できる {0} のランタイム パックがありませんでした。</target>
         <note>{StrBegin="NETSDK1082: "}</note>
+      </trans-unit>
+      <trans-unit id="NoRuntimePackInformation">
+        <source>NETSDK1132: No runtime pack information was available for {0}.</source>
+        <target state="new">NETSDK1132: No runtime pack information was available for {0}.</target>
+        <note>{StrBegin="NETSDK1132: "}</note>
       </trans-unit>
       <trans-unit id="NoSupportComSelfContained">
         <source>NETSDK1128: COM hosting does not support self-contained deployments.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
@@ -192,6 +192,13 @@
         <note>{StrBegin="NETSDK1090: "}
 {0} - The path to the invalid assembly.</note>
       </trans-unit>
+      <trans-unit id="ConflictingRuntimePackInformation">
+        <source>NETSDK1133: There was conflicting information about runtime packs available for {0}:
+{1}</source>
+        <target state="new">NETSDK1133: There was conflicting information about runtime packs available for {0}:
+{1}</target>
+        <note>{StrBegin="NETSDK1133: "}</note>
+      </trans-unit>
       <trans-unit id="ContentItemDoesNotProvideOutputPath">
         <source>NETSDK1014: Content item for '{0}' sets '{1}', but does not provide  '{2}' or '{3}'.</source>
         <target state="translated">NETSDK1014: '{0}'의 콘텐츠 항목이 '{1}'을(를) 설정하지만, '{2}' 또는 '{3}'을(를) 제공하지 않습니다.</target>
@@ -425,6 +432,11 @@ The following are names of parameters or literal values and should not be transl
         <source>NETSDK1082: There was no runtime pack for {0} available for the specified RuntimeIdentifier '{1}'.</source>
         <target state="translated">NETSDK1082: 지정된 RuntimeIdentifier '{1}'에 사용할 수 있는 {0}용 런타임 팩이 없습니다.</target>
         <note>{StrBegin="NETSDK1082: "}</note>
+      </trans-unit>
+      <trans-unit id="NoRuntimePackInformation">
+        <source>NETSDK1132: No runtime pack information was available for {0}.</source>
+        <target state="new">NETSDK1132: No runtime pack information was available for {0}.</target>
+        <note>{StrBegin="NETSDK1132: "}</note>
       </trans-unit>
       <trans-unit id="NoSupportComSelfContained">
         <source>NETSDK1128: COM hosting does not support self-contained deployments.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
@@ -192,6 +192,13 @@
         <note>{StrBegin="NETSDK1090: "}
 {0} - The path to the invalid assembly.</note>
       </trans-unit>
+      <trans-unit id="ConflictingRuntimePackInformation">
+        <source>NETSDK1133: There was conflicting information about runtime packs available for {0}:
+{1}</source>
+        <target state="new">NETSDK1133: There was conflicting information about runtime packs available for {0}:
+{1}</target>
+        <note>{StrBegin="NETSDK1133: "}</note>
+      </trans-unit>
       <trans-unit id="ContentItemDoesNotProvideOutputPath">
         <source>NETSDK1014: Content item for '{0}' sets '{1}', but does not provide  '{2}' or '{3}'.</source>
         <target state="translated">NETSDK1014: Element zawartości dla elementu „{0}” ustawia wartość „{1}”, ale nie zapewnia wartości „{2}” ani „{3}”.</target>
@@ -425,6 +432,11 @@ The following are names of parameters or literal values and should not be transl
         <source>NETSDK1082: There was no runtime pack for {0} available for the specified RuntimeIdentifier '{1}'.</source>
         <target state="translated">NETSDK1082: Brak dostępnego pakietu środowiska uruchomieniowego {0} dla określonego elementu RuntimeIdentifier „{1}”.</target>
         <note>{StrBegin="NETSDK1082: "}</note>
+      </trans-unit>
+      <trans-unit id="NoRuntimePackInformation">
+        <source>NETSDK1132: No runtime pack information was available for {0}.</source>
+        <target state="new">NETSDK1132: No runtime pack information was available for {0}.</target>
+        <note>{StrBegin="NETSDK1132: "}</note>
       </trans-unit>
       <trans-unit id="NoSupportComSelfContained">
         <source>NETSDK1128: COM hosting does not support self-contained deployments.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
@@ -192,6 +192,13 @@
         <note>{StrBegin="NETSDK1090: "}
 {0} - The path to the invalid assembly.</note>
       </trans-unit>
+      <trans-unit id="ConflictingRuntimePackInformation">
+        <source>NETSDK1133: There was conflicting information about runtime packs available for {0}:
+{1}</source>
+        <target state="new">NETSDK1133: There was conflicting information about runtime packs available for {0}:
+{1}</target>
+        <note>{StrBegin="NETSDK1133: "}</note>
+      </trans-unit>
       <trans-unit id="ContentItemDoesNotProvideOutputPath">
         <source>NETSDK1014: Content item for '{0}' sets '{1}', but does not provide  '{2}' or '{3}'.</source>
         <target state="translated">NETSDK1014: O item de conteúdo para '{0}' define '{1}', mas não fornece '{2}' ou '{3}'.</target>
@@ -425,6 +432,11 @@ The following are names of parameters or literal values and should not be transl
         <source>NETSDK1082: There was no runtime pack for {0} available for the specified RuntimeIdentifier '{1}'.</source>
         <target state="translated">NETSDK1082: não havia nenhum pacote de tempo de execução de {0} disponível para o RuntimeIdentifier especificado '{1}'.</target>
         <note>{StrBegin="NETSDK1082: "}</note>
+      </trans-unit>
+      <trans-unit id="NoRuntimePackInformation">
+        <source>NETSDK1132: No runtime pack information was available for {0}.</source>
+        <target state="new">NETSDK1132: No runtime pack information was available for {0}.</target>
+        <note>{StrBegin="NETSDK1132: "}</note>
       </trans-unit>
       <trans-unit id="NoSupportComSelfContained">
         <source>NETSDK1128: COM hosting does not support self-contained deployments.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
@@ -192,6 +192,13 @@
         <note>{StrBegin="NETSDK1090: "}
 {0} - The path to the invalid assembly.</note>
       </trans-unit>
+      <trans-unit id="ConflictingRuntimePackInformation">
+        <source>NETSDK1133: There was conflicting information about runtime packs available for {0}:
+{1}</source>
+        <target state="new">NETSDK1133: There was conflicting information about runtime packs available for {0}:
+{1}</target>
+        <note>{StrBegin="NETSDK1133: "}</note>
+      </trans-unit>
       <trans-unit id="ContentItemDoesNotProvideOutputPath">
         <source>NETSDK1014: Content item for '{0}' sets '{1}', but does not provide  '{2}' or '{3}'.</source>
         <target state="translated">NETSDK1014: элемент содержимого для "{0}" задает "{1}", но не предоставляет "{2}" или "{3}".</target>
@@ -425,6 +432,11 @@ The following are names of parameters or literal values and should not be transl
         <source>NETSDK1082: There was no runtime pack for {0} available for the specified RuntimeIdentifier '{1}'.</source>
         <target state="translated">NETSDK1082: не было доступного пакета среды выполнения для {0} для указанного RuntimeIdentifier "{1}".</target>
         <note>{StrBegin="NETSDK1082: "}</note>
+      </trans-unit>
+      <trans-unit id="NoRuntimePackInformation">
+        <source>NETSDK1132: No runtime pack information was available for {0}.</source>
+        <target state="new">NETSDK1132: No runtime pack information was available for {0}.</target>
+        <note>{StrBegin="NETSDK1132: "}</note>
       </trans-unit>
       <trans-unit id="NoSupportComSelfContained">
         <source>NETSDK1128: COM hosting does not support self-contained deployments.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
@@ -192,6 +192,13 @@
         <note>{StrBegin="NETSDK1090: "}
 {0} - The path to the invalid assembly.</note>
       </trans-unit>
+      <trans-unit id="ConflictingRuntimePackInformation">
+        <source>NETSDK1133: There was conflicting information about runtime packs available for {0}:
+{1}</source>
+        <target state="new">NETSDK1133: There was conflicting information about runtime packs available for {0}:
+{1}</target>
+        <note>{StrBegin="NETSDK1133: "}</note>
+      </trans-unit>
       <trans-unit id="ContentItemDoesNotProvideOutputPath">
         <source>NETSDK1014: Content item for '{0}' sets '{1}', but does not provide  '{2}' or '{3}'.</source>
         <target state="translated">NETSDK1014: '{0}' için içerik öğesi, '{1}' değerini ayarlıyor ancak '{2}' veya '{3}' sağlamıyor.</target>
@@ -425,6 +432,11 @@ The following are names of parameters or literal values and should not be transl
         <source>NETSDK1082: There was no runtime pack for {0} available for the specified RuntimeIdentifier '{1}'.</source>
         <target state="translated">NETSDK1082: {0} için, belirtilen RuntimeIdentifier '{1}' için kullanılabilecek bir çalışma zamanı paketi yoktu.</target>
         <note>{StrBegin="NETSDK1082: "}</note>
+      </trans-unit>
+      <trans-unit id="NoRuntimePackInformation">
+        <source>NETSDK1132: No runtime pack information was available for {0}.</source>
+        <target state="new">NETSDK1132: No runtime pack information was available for {0}.</target>
+        <note>{StrBegin="NETSDK1132: "}</note>
       </trans-unit>
       <trans-unit id="NoSupportComSelfContained">
         <source>NETSDK1128: COM hosting does not support self-contained deployments.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
@@ -192,6 +192,13 @@
         <note>{StrBegin="NETSDK1090: "}
 {0} - The path to the invalid assembly.</note>
       </trans-unit>
+      <trans-unit id="ConflictingRuntimePackInformation">
+        <source>NETSDK1133: There was conflicting information about runtime packs available for {0}:
+{1}</source>
+        <target state="new">NETSDK1133: There was conflicting information about runtime packs available for {0}:
+{1}</target>
+        <note>{StrBegin="NETSDK1133: "}</note>
+      </trans-unit>
       <trans-unit id="ContentItemDoesNotProvideOutputPath">
         <source>NETSDK1014: Content item for '{0}' sets '{1}', but does not provide  '{2}' or '{3}'.</source>
         <target state="translated">NETSDK1014: “{0}”的内容项设置为“{1}”，但不提供“{2}”或“{3}”。</target>
@@ -425,6 +432,11 @@ The following are names of parameters or literal values and should not be transl
         <source>NETSDK1082: There was no runtime pack for {0} available for the specified RuntimeIdentifier '{1}'.</source>
         <target state="translated">NETSDK1082: {0} 没有运行时包可用于指定的 RuntimeIdentifier“{1}”。</target>
         <note>{StrBegin="NETSDK1082: "}</note>
+      </trans-unit>
+      <trans-unit id="NoRuntimePackInformation">
+        <source>NETSDK1132: No runtime pack information was available for {0}.</source>
+        <target state="new">NETSDK1132: No runtime pack information was available for {0}.</target>
+        <note>{StrBegin="NETSDK1132: "}</note>
       </trans-unit>
       <trans-unit id="NoSupportComSelfContained">
         <source>NETSDK1128: COM hosting does not support self-contained deployments.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
@@ -192,6 +192,13 @@
         <note>{StrBegin="NETSDK1090: "}
 {0} - The path to the invalid assembly.</note>
       </trans-unit>
+      <trans-unit id="ConflictingRuntimePackInformation">
+        <source>NETSDK1133: There was conflicting information about runtime packs available for {0}:
+{1}</source>
+        <target state="new">NETSDK1133: There was conflicting information about runtime packs available for {0}:
+{1}</target>
+        <note>{StrBegin="NETSDK1133: "}</note>
+      </trans-unit>
       <trans-unit id="ContentItemDoesNotProvideOutputPath">
         <source>NETSDK1014: Content item for '{0}' sets '{1}', but does not provide  '{2}' or '{3}'.</source>
         <target state="translated">NETSDK1014: '{0}' 的內容項目設定了 '{1}'，但未提供 '{2}' 或 '{3}'。</target>
@@ -425,6 +432,11 @@ The following are names of parameters or literal values and should not be transl
         <source>NETSDK1082: There was no runtime pack for {0} available for the specified RuntimeIdentifier '{1}'.</source>
         <target state="translated">NETSDK1082: 對指定的 RuntimeIdentifier '{1}'，無法使用任何 {0} 的執行階段套件。</target>
         <note>{StrBegin="NETSDK1082: "}</note>
+      </trans-unit>
+      <trans-unit id="NoRuntimePackInformation">
+        <source>NETSDK1132: No runtime pack information was available for {0}.</source>
+        <target state="new">NETSDK1132: No runtime pack information was available for {0}.</target>
+        <note>{StrBegin="NETSDK1132: "}</note>
       </trans-unit>
       <trans-unit id="NoSupportComSelfContained">
         <source>NETSDK1128: COM hosting does not support self-contained deployments.</source>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ProcessFrameworkReferences.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ProcessFrameworkReferences.cs
@@ -6,8 +6,10 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Text.RegularExpressions;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
+using Newtonsoft.Json;
 using NuGet.Frameworks;
 
 namespace Microsoft.NET.Build.Tasks
@@ -50,6 +52,8 @@ namespace Microsoft.NET.Build.Tasks
 
         public ITaskItem[] KnownFrameworkReferences { get; set; } = Array.Empty<ITaskItem>();
 
+        public ITaskItem[] KnownRuntimePacks { get; set; } = Array.Empty<ITaskItem>();
+
         public ITaskItem[] KnownCrossgen2Packs { get; set; } = Array.Empty<ITaskItem>();
 
         [Required]
@@ -90,6 +94,21 @@ namespace Microsoft.NET.Build.Tasks
                               NormalizeVersion(kfr.TargetFramework.Version) == normalizedTargetFrameworkVersion)
                 .ToList();
 
+            //  Get known runtime packs from known framework references.
+            //  Only use items where the framework reference name matches the RuntimeFrameworkName.
+            //  This will filter out known framework references for "profiles", ie WindowsForms and WPF
+            var knownRuntimePacksForTargetFramework = 
+                knownFrameworkReferencesForTargetFramework
+                    .Where(kfr => kfr.Name == kfr.RuntimeFrameworkName)
+                    .Select(kfr => kfr.ToKnownRuntimePack())
+                    .ToList();
+
+            //  Add additional known runtime packs
+            knownRuntimePacksForTargetFramework.AddRange(
+                KnownRuntimePacks.Select(item => new KnownRuntimePack(item))
+                                 .Where(krp => krp.TargetFramework.Framework.Equals(TargetFrameworkIdentifier, StringComparison.OrdinalIgnoreCase) &&
+                                               NormalizeVersion(krp.TargetFramework.Version) == normalizedTargetFrameworkVersion));
+
             var frameworkReferenceMap = FrameworkReferences.ToDictionary(fr => fr.ItemSpec, StringComparer.OrdinalIgnoreCase);
 
             List<ITaskItem> packagesToDownload = new List<ITaskItem>();
@@ -120,20 +139,23 @@ namespace Microsoft.NET.Build.Tasks
                     continue;
                 }
 
+                KnownRuntimePack selectedRuntimePack = SelectRuntimePack(frameworkReference, knownFrameworkReference, knownRuntimePacksForTargetFramework);
+
+                //  Add targeting pack and all known runtime packs to "preferred packages" list.
+                //  These are packages that will win in conflict resolution for assets that have identical assembly and file versions
                 List<string> preferredPackages = new List<string>();
                 preferredPackages.Add(knownFrameworkReference.TargetingPackName);
 
-                var knownFrameworkReferenceRuntimePackRuntimeIdentifiers = knownFrameworkReference.RuntimePackRuntimeIdentifiers.Split(';');
+                var knownFrameworkReferenceRuntimePackRuntimeIdentifiers = selectedRuntimePack.RuntimePackRuntimeIdentifiers.Split(';');
                 foreach (var runtimeIdentifier in knownFrameworkReferenceRuntimePackRuntimeIdentifiers)
                 {
-                    foreach (var runtimePackNamePattern in knownFrameworkReference.RuntimePackNamePatterns.Split(';'))
+                    foreach (var runtimePackNamePattern in selectedRuntimePack.RuntimePackNamePatterns.Split(';'))
                     {
                         string runtimePackName = runtimePackNamePattern.Replace("**RID**", runtimeIdentifier);
                         preferredPackages.Add(runtimePackName);
                     }
                 }
-
-                //  Get the path of the targeting pack in the targeting pack root (e.g. dotnet/ref)
+                
                 TaskItem targetingPack = new TaskItem(knownFrameworkReference.Name);
                 targetingPack.SetMetadata(MetadataKeys.NuGetPackageId, knownFrameworkReference.TargetingPackName);
                 targetingPack.SetMetadata(MetadataKeys.PackageConflictPreferredPackages, string.Join(";", preferredPackages));
@@ -152,13 +174,14 @@ namespace Microsoft.NET.Build.Tasks
                 targetingPack.SetMetadata("TargetingPackFormat", knownFrameworkReference.TargetingPackFormat);
                 targetingPack.SetMetadata("TargetFramework", knownFrameworkReference.TargetFramework.GetShortFolderName());
                 targetingPack.SetMetadata(MetadataKeys.RuntimeFrameworkName, knownFrameworkReference.RuntimeFrameworkName);
-                targetingPack.SetMetadata(MetadataKeys.RuntimePackRuntimeIdentifiers, knownFrameworkReference.RuntimePackRuntimeIdentifiers);
+                targetingPack.SetMetadata(MetadataKeys.RuntimePackRuntimeIdentifiers, selectedRuntimePack.RuntimePackRuntimeIdentifiers);
 
                 if (!string.IsNullOrEmpty(knownFrameworkReference.Profile))
                 {
                     targetingPack.SetMetadata("Profile", knownFrameworkReference.Profile);
                 }
 
+                //  Get the path of the targeting pack in the targeting pack root (e.g. dotnet/packs)
                 string targetingPackPath = null;
                 if (!string.IsNullOrEmpty(TargetingPackRoot))
                 {
@@ -186,7 +209,8 @@ namespace Microsoft.NET.Build.Tasks
 
                 var runtimeFrameworkVersion = GetRuntimeFrameworkVersion(
                     frameworkReference, 
-                    knownFrameworkReference, 
+                    knownFrameworkReference,
+                    selectedRuntimePack,
                     out string runtimePackVersion);
 
                 string isTrimmable = null;
@@ -197,16 +221,16 @@ namespace Microsoft.NET.Build.Tasks
                 }
                 if (string.IsNullOrEmpty(isTrimmable))
                 {
-                    isTrimmable = knownFrameworkReference.IsTrimmable;
+                    isTrimmable = selectedRuntimePack.IsTrimmable;
                 }
 
                 bool processedPrimaryRuntimeIdentifier = false;
 
                 if ((SelfContained || ReadyToRunEnabled) &&
                     !string.IsNullOrEmpty(RuntimeIdentifier) &&
-                    !string.IsNullOrEmpty(knownFrameworkReference.RuntimePackNamePatterns))
+                    !string.IsNullOrEmpty(selectedRuntimePack.RuntimePackNamePatterns))
                 {
-                    ProcessRuntimeIdentifier(RuntimeIdentifier, knownFrameworkReference, runtimePackVersion,
+                    ProcessRuntimeIdentifier(RuntimeIdentifier, selectedRuntimePack, runtimePackVersion,
                         unrecognizedRuntimeIdentifiers, unavailableRuntimePacks, runtimePacks, packagesToDownload, isTrimmable);
 
                     processedPrimaryRuntimeIdentifier = true;
@@ -224,7 +248,7 @@ namespace Microsoft.NET.Build.Tasks
 
                         //  Pass in null for the runtimePacks list, as for these runtime identifiers we only want to
                         //  download the runtime packs, but not use the assets from them
-                        ProcessRuntimeIdentifier(runtimeIdentifier, knownFrameworkReference, runtimePackVersion,
+                        ProcessRuntimeIdentifier(runtimeIdentifier, selectedRuntimePack, runtimePackVersion,
                             unrecognizedRuntimeIdentifiers, unavailableRuntimePacks, runtimePacks: null, packagesToDownload, isTrimmable);
                     }
                 }
@@ -280,9 +304,57 @@ namespace Microsoft.NET.Build.Tasks
             }
         }
 
+        private KnownRuntimePack SelectRuntimePack(ITaskItem frameworkReference, KnownFrameworkReference knownFrameworkReference, List<KnownRuntimePack> knownRuntimePacks)
+        {
+            var requiredLabelsMetadata = frameworkReference?.GetMetadata(MetadataKeys.RuntimePackLabels) ?? "";
+
+            HashSet<string> requiredRuntimePackLabels = null;
+            if (frameworkReference != null)
+            {
+                requiredRuntimePackLabels = new HashSet<string>(requiredLabelsMetadata.Split(new [] { ';' }, StringSplitOptions.RemoveEmptyEntries), StringComparer.OrdinalIgnoreCase);
+            }
+
+            //  The runtime pack name matches the RuntimeFrameworkName on the KnownFrameworkReference
+            var matchingRuntimePacks = knownRuntimePacks.Where(krp => krp.Name.Equals(knownFrameworkReference.RuntimeFrameworkName, StringComparison.OrdinalIgnoreCase))
+                .Where(krp =>
+                {
+                    if (requiredRuntimePackLabels == null)
+                    {
+                        return krp.RuntimePackLabels.Length == 0;
+                    }
+                    else
+                    {
+                        return requiredRuntimePackLabels.SetEquals(krp.RuntimePackLabels);
+                    }
+                })
+                .ToList();
+
+            if (matchingRuntimePacks.Count == 1)
+            {
+                return matchingRuntimePacks[0];
+            }
+            else
+            {
+                string runtimePackDescriptionForErrorMessage = knownFrameworkReference.RuntimeFrameworkName +
+                    (requiredLabelsMetadata == string.Empty ? string.Empty : ":" + requiredLabelsMetadata);
+
+                if (matchingRuntimePacks.Count == 0)
+                {
+                    Log.LogError(Strings.NoRuntimePackInformation, runtimePackDescriptionForErrorMessage);
+                }
+                else
+                {
+                    Log.LogError(Strings.ConflictingRuntimePackInformation, runtimePackDescriptionForErrorMessage,
+                        string.Join(Environment.NewLine, matchingRuntimePacks.Select(rp => rp.RuntimePackNamePatterns)));
+                }
+
+                return knownFrameworkReference.ToKnownRuntimePack();
+            }
+        }
+
         private void ProcessRuntimeIdentifier(
             string runtimeIdentifier,
-            KnownFrameworkReference knownFrameworkReference,
+            KnownRuntimePack selectedRuntimePack,
             string runtimePackVersion,
             HashSet<string> unrecognizedRuntimeIdentifiers,
             List<ITaskItem> unavailableRuntimePacks,
@@ -291,7 +363,7 @@ namespace Microsoft.NET.Build.Tasks
             string isTrimmable)
         {
             var runtimeGraph = new RuntimeGraphCache(this).GetRuntimeGraph(RuntimeGraphPath);
-            var knownFrameworkReferenceRuntimePackRuntimeIdentifiers = knownFrameworkReference.RuntimePackRuntimeIdentifiers.Split(';');
+            var knownFrameworkReferenceRuntimePackRuntimeIdentifiers = selectedRuntimePack.RuntimePackRuntimeIdentifiers.Split(';');
 
             string runtimePackRuntimeIdentifier = NuGetUtils.GetBestMatchingRid(
                     runtimeGraph,
@@ -308,7 +380,7 @@ namespace Microsoft.NET.Build.Tasks
                     //  framework we don't directly reference.  But we don't want to immediately error out
                     //  here if a runtime pack that we might not need to reference isn't available for the
                     //  targeted RID (e.g. Microsoft.WindowsDesktop.App for a linux RID).
-                    var unavailableRuntimePack = new TaskItem(knownFrameworkReference.Name);
+                    var unavailableRuntimePack = new TaskItem(selectedRuntimePack.Name);
                     unavailableRuntimePack.SetMetadata(MetadataKeys.RuntimeIdentifier, runtimeIdentifier);
                     unavailableRuntimePacks.Add(unavailableRuntimePack);
                 }
@@ -321,7 +393,7 @@ namespace Microsoft.NET.Build.Tasks
             }
             else
             {
-                foreach (var runtimePackNamePattern in knownFrameworkReference.RuntimePackNamePatterns.Split(';'))
+                foreach (var runtimePackNamePattern in selectedRuntimePack.RuntimePackNamePatterns.Split(';'))
                 {
                     string runtimePackName = runtimePackNamePattern.Replace("**RID**", runtimePackRuntimeIdentifier);
 
@@ -330,7 +402,7 @@ namespace Microsoft.NET.Build.Tasks
                         TaskItem runtimePackItem = new TaskItem(runtimePackName);
                         runtimePackItem.SetMetadata(MetadataKeys.NuGetPackageId, runtimePackName);
                         runtimePackItem.SetMetadata(MetadataKeys.NuGetPackageVersion, runtimePackVersion);
-                        runtimePackItem.SetMetadata(MetadataKeys.FrameworkName, knownFrameworkReference.Name);
+                        runtimePackItem.SetMetadata(MetadataKeys.FrameworkName, selectedRuntimePack.Name);
                         runtimePackItem.SetMetadata(MetadataKeys.RuntimeIdentifier, runtimePackRuntimeIdentifier);
                         runtimePackItem.SetMetadata(MetadataKeys.IsTrimmable, isTrimmable);
 
@@ -392,6 +464,7 @@ namespace Microsoft.NET.Build.Tasks
         private string GetRuntimeFrameworkVersion(
             ITaskItem frameworkReference, 
             KnownFrameworkReference knownFrameworkReference,
+            KnownRuntimePack knownRuntimePack,
             out string runtimePackVersion)
         {
             //  Precedence order for selecting runtime framework version
@@ -417,11 +490,11 @@ namespace Microsoft.NET.Build.Tasks
                     return knownFrameworkReference.DefaultRuntimeFrameworkVersion;
 
                 case RuntimePatchRequest.UseLatestVersion:
-                    runtimePackVersion = knownFrameworkReference.LatestRuntimeFrameworkVersion;
-                    return knownFrameworkReference.LatestRuntimeFrameworkVersion;
+                    runtimePackVersion = knownRuntimePack.LatestRuntimeFrameworkVersion;
+                    return knownRuntimePack.LatestRuntimeFrameworkVersion;
 
                 case RuntimePatchRequest.UseDefaultVersionWithLatestRuntimePack:
-                    runtimePackVersion = knownFrameworkReference.LatestRuntimeFrameworkVersion;
+                    runtimePackVersion = knownRuntimePack.LatestRuntimeFrameworkVersion;
                     return knownFrameworkReference.DefaultRuntimeFrameworkVersion;
 
                 default:
@@ -501,12 +574,57 @@ namespace Microsoft.NET.Build.Tasks
             //  The framework name to write to the runtimeconfig file (and the name of the folder under dotnet/shared)
             public string RuntimeFrameworkName => _item.GetMetadata(MetadataKeys.RuntimeFrameworkName);
             public string DefaultRuntimeFrameworkVersion => _item.GetMetadata("DefaultRuntimeFrameworkVersion");
-            public string LatestRuntimeFrameworkVersion => _item.GetMetadata("LatestRuntimeFrameworkVersion");
+            //public string LatestRuntimeFrameworkVersion => _item.GetMetadata("LatestRuntimeFrameworkVersion");
 
             //  The ID of the targeting pack NuGet package to reference
             public string TargetingPackName => _item.GetMetadata("TargetingPackName");
             public string TargetingPackVersion => _item.GetMetadata("TargetingPackVersion");
             public string TargetingPackFormat => _item.GetMetadata("TargetingPackFormat");
+
+            //public string RuntimePackNamePatterns => _item.GetMetadata("RuntimePackNamePatterns");
+
+            //public string RuntimePackRuntimeIdentifiers => _item.GetMetadata(MetadataKeys.RuntimePackRuntimeIdentifiers);
+
+            //public string IsTrimmable => _item.GetMetadata(MetadataKeys.IsTrimmable);
+
+            public bool IsWindowsOnly => _item.HasMetadataValue("IsWindowsOnly", "true");
+
+            public string Profile => _item.GetMetadata("Profile");
+
+            public NuGetFramework TargetFramework { get; }
+
+            public KnownRuntimePack ToKnownRuntimePack()
+            {
+                return new KnownRuntimePack(_item);
+            }
+        }
+
+        private struct KnownRuntimePack
+        {
+            ITaskItem _item;
+
+            public KnownRuntimePack(ITaskItem item)
+            {
+                _item = item;
+                TargetFramework = NuGetFramework.Parse(item.GetMetadata("TargetFramework"));
+                string runtimePackLabels = item.GetMetadata(MetadataKeys.RuntimePackLabels);
+                if (string.IsNullOrEmpty(runtimePackLabels))
+                {
+                    RuntimePackLabels = Array.Empty<string>();
+                }
+                else
+                {
+                    RuntimePackLabels = runtimePackLabels.Split(';');
+                }
+            }
+
+            //  The name / itemspec of the FrameworkReference used in the project
+            public string Name => _item.ItemSpec;
+
+            ////  The framework name to write to the runtimeconfig file (and the name of the folder under dotnet/shared)
+            //public string RuntimeFrameworkName => _item.GetMetadata(MetadataKeys.RuntimeFrameworkName);
+            //public string DefaultRuntimeFrameworkVersion => _item.GetMetadata("DefaultRuntimeFrameworkVersion");
+            public string LatestRuntimeFrameworkVersion => _item.GetMetadata("LatestRuntimeFrameworkVersion");
 
             public string RuntimePackNamePatterns => _item.GetMetadata("RuntimePackNamePatterns");
 
@@ -516,7 +634,7 @@ namespace Microsoft.NET.Build.Tasks
 
             public bool IsWindowsOnly => _item.HasMetadataValue("IsWindowsOnly", "true");
 
-            public string Profile => _item.GetMetadata("Profile");
+            public string [] RuntimePackLabels { get; }
 
             public NuGetFramework TargetFramework { get; }
         }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolveRuntimePackAssets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveRuntimePackAssets.cs
@@ -48,8 +48,13 @@ namespace Microsoft.NET.Build.Tasks
             {
                 if (!frameworkReferenceNames.Contains(runtimePack.GetMetadata(MetadataKeys.FrameworkName)))
                 {
-                    //  This is a runtime pack for a shared framework that ultimately wasn't referenced, so don't include its assets
-                    continue;
+                    var additionalFrameworkReferences = runtimePack.GetMetadata(MetadataKeys.AdditionalFrameworkReferences);
+                    if (additionalFrameworkReferences == null ||
+                        !additionalFrameworkReferences.Split(';').Any(afr => frameworkReferenceNames.Contains(afr)))
+                    {
+                        //  This is a runtime pack for a shared framework that ultimately wasn't referenced, so don't include its assets
+                        continue;
+                    }
                 }
 
                 string runtimePackRoot = runtimePack.GetMetadata(MetadataKeys.PackageDirectory);

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets
@@ -58,6 +58,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <ProcessFrameworkReferences FrameworkReferences="@(FrameworkReference)"
                                 KnownFrameworkReferences="@(KnownFrameworkReference)"
+                                KnownRuntimePacks="@(KnownRuntimePack)"
                                 TargetFrameworkIdentifier="$(TargetFrameworkIdentifier)"
                                 TargetFrameworkVersion="$(_TargetFrameworkVersionWithoutV)"
                                 TargetingPackRoot="$(NetCoreTargetingPackRoot)"

--- a/src/Tests/EndToEnd.Tests/GivenDotNetUsesMSBuild.cs
+++ b/src/Tests/EndToEnd.Tests/GivenDotNetUsesMSBuild.cs
@@ -71,7 +71,7 @@ namespace Microsoft.DotNet.Tests.EndToEnd
 
             NuGetConfigWriter.Write(testInstance.Path, TestContext.Current.TestPackages);
 
-            new RestoreCommand(Log, testInstance.Path)
+            new RestoreCommand(testInstance)
                 .Execute()
                 .Should()
                 .Pass();
@@ -107,7 +107,7 @@ namespace Microsoft.DotNet.Tests.EndToEnd
 
             NuGetConfigWriter.Write(testInstance.Path, TestContext.Current.TestPackages);
 
-            new RestoreCommand(Log, testInstance.Path)
+            new RestoreCommand(testInstance)
                 .Execute()
                 .Should()
                 .Pass();

--- a/src/Tests/Microsoft.DotNet.CommandFactory.Tests/GivenAProjectDependencyCommandResolver.cs
+++ b/src/Tests/Microsoft.DotNet.CommandFactory.Tests/GivenAProjectDependencyCommandResolver.cs
@@ -103,7 +103,7 @@ namespace Microsoft.DotNet.Tests
 
             NuGetConfigWriter.Write(testAsset.Path, TestContext.Current.TestPackages);
 
-            new RestoreCommand(Log, testAsset.TestRoot)
+            new RestoreCommand(testAsset)
                 .Execute()
                 .Should()
                 .Pass();
@@ -133,7 +133,7 @@ namespace Microsoft.DotNet.Tests
 
             NuGetConfigWriter.Write(testAsset.Path, TestContext.Current.TestPackages);
 
-            new RestoreCommand(Log, testAsset.TestRoot)
+            new RestoreCommand(testAsset)
                 .Execute()
                 .Should()
                 .Pass();

--- a/src/Tests/Microsoft.DotNet.ShellShim.Tests/ShellShimRepositoryTests.cs
+++ b/src/Tests/Microsoft.DotNet.ShellShim.Tests/ShellShimRepositoryTests.cs
@@ -485,7 +485,7 @@ namespace Microsoft.DotNet.ShellShim.Tests
             var testInstance = _testAssetsManager.CopyTestAsset(testAppName, callingMethod: instanceName)
                 .WithSource();
 
-            new BuildCommand(Log, testInstance.TestRoot)
+            new BuildCommand(testInstance)
                 .Execute()
                 .Should()
                 .Pass();

--- a/src/Tests/Microsoft.NET.Build.Tests/AppHostTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/AppHostTests.cs
@@ -34,7 +34,7 @@ namespace Microsoft.NET.Build.Tests
                 .WithSource()
                 .WithTargetFramework(targetFramework);
 
-            var buildCommand = new BuildCommand(Log, testAsset.TestRoot);
+            var buildCommand = new BuildCommand(testAsset);
             buildCommand
                 .Execute()
                 .Should()
@@ -73,7 +73,7 @@ namespace Microsoft.NET.Build.Tests
                 .WithSource()
                 .WithTargetFramework(targetFramework);
 
-            var buildCommand = new BuildCommand(Log, testAsset.TestRoot);
+            var buildCommand = new BuildCommand(testAsset);
             buildCommand
                 .Execute(new string[] {
                     "/restore", "/p:UseAppHost=true",
@@ -110,7 +110,7 @@ namespace Microsoft.NET.Build.Tests
                 .WithSource()
                 .WithTargetFramework(targetFramework);
 
-            var buildCommand = new BuildCommand(Log, testAsset.TestRoot);
+            var buildCommand = new BuildCommand(testAsset);
             buildCommand
                 .Execute()
                 .Should()
@@ -140,7 +140,7 @@ namespace Microsoft.NET.Build.Tests
                 .CopyTestAsset("HelloWorld")
                 .WithSource();
 
-            var buildCommand = new BuildCommand(Log, testAsset.TestRoot);
+            var buildCommand = new BuildCommand(testAsset);
             buildCommand
                 .Execute(new string[] {
                     $"/p:TargetFramework={targetFramework}",
@@ -184,7 +184,7 @@ namespace Microsoft.NET.Build.Tests
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
-            var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var buildCommand = new BuildCommand(testAsset);
 
             buildCommand.Execute()
                 .Should()
@@ -212,7 +212,7 @@ namespace Microsoft.NET.Build.Tests
                     propertyGroup.Element(ns + "TargetFramework").SetValue(targetFramework);
                 });
 
-            var buildCommand = new BuildCommand(Log, testAsset.TestRoot);
+            var buildCommand = new BuildCommand(testAsset);
             buildCommand
                 .Execute("/p:CopyLocalLockFileAssemblies=false")
                 .Should()
@@ -247,7 +247,7 @@ namespace Microsoft.NET.Build.Tests
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
-            var buildCommand = new BuildCommand(Log, testAsset.TestRoot, testProject.Name);
+            var buildCommand = new BuildCommand(testAsset);
 
             buildCommand.Execute()
                 .Should()
@@ -273,9 +273,7 @@ namespace Microsoft.NET.Build.Tests
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
-            var projectDirectory = Path.Combine(testAsset.TestRoot, testProject.Name);
-
-            var buildCommand = new BuildCommand(Log, projectDirectory);
+            var buildCommand = new BuildCommand(testAsset);
 
             buildCommand.Execute()
                 .Should()

--- a/src/Tests/Microsoft.NET.Build.Tests/AspNetCoreOnFullFramework.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/AspNetCoreOnFullFramework.cs
@@ -83,7 +83,7 @@ class Class1
             var testProjectInstance = _testAssetsManager
                 .CreateTestProject(testProject, identifier: aspnetVersion);
 
-            var buildCommand = new BuildCommand(Log, testProjectInstance.TestRoot, testProject.Name);
+            var buildCommand = new BuildCommand(testProjectInstance);
 
             buildCommand.Execute()
                 .Should()

--- a/src/Tests/Microsoft.NET.Build.Tests/COMReferenceTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/COMReferenceTests.cs
@@ -77,7 +77,7 @@ namespace Microsoft.NET.Build.Tests
                 .CreateTestProject(testProject, identifier: embedInteropTypes.ToString())
                 .WithProjectChanges(doc => doc.Root.Add(reference));
 
-            var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var buildCommand = new BuildCommand(testAsset);
             buildCommand.Execute().Should().Pass();
             
             var outputDirectory = buildCommand.GetOutputDirectory(targetFramework);

--- a/src/Tests/Microsoft.NET.Build.Tests/DepsFileSkipTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/DepsFileSkipTests.cs
@@ -137,7 +137,7 @@ namespace Microsoft.NET.Build.Tests
             var testAsset = _testAssetsManager.CreateTestProject(testProject, testProject.Name)
                .WithProjectChanges(project => AddSkipTarget(project, filenameToSkip));
 
-            var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var buildCommand = new BuildCommand(testAsset);
 
             buildCommand
                .Execute()
@@ -177,7 +177,7 @@ namespace Microsoft.NET.Build.Tests
             var testAsset = _testAssetsManager.CreateTestProject(testProject, testProject.Name)
                 .WithProjectChanges(project => AddSkipTarget(project, filenameToSkip));
 
-            var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var buildCommand = new BuildCommand(testAsset);
 
             buildCommand
                .Execute()

--- a/src/Tests/Microsoft.NET.Build.Tests/GenerateResourceTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GenerateResourceTests.cs
@@ -61,9 +61,7 @@ namespace Microsoft.NET.Build.Tests
             var testAsset = _testAssetsManager
                 .CreateTestProject(testProject, identifier: targetFramework + isExe);
 
-            var buildCommand = new BuildCommand(
-                Log,
-                Path.Combine(testAsset.TestRoot, testProject.Name));
+            var buildCommand = new BuildCommand(testAsset);
 
             buildCommand
                 .Execute()

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenFrameworkReferences.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenFrameworkReferences.cs
@@ -52,7 +52,7 @@ namespace FrameworkReferenceTest
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
-            var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var buildCommand = new BuildCommand(testAsset);
 
             buildCommand
                 .Execute()
@@ -95,7 +95,7 @@ namespace FrameworkReferenceTest
             TestAsset testAsset = _testAssetsManager.CreateTestProject(testProject)
                 .Restore(Log, testProject.Name);
 
-            var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var buildCommand = new BuildCommand(testAsset);
 
             buildCommand
                 .Execute()
@@ -133,7 +133,7 @@ namespace FrameworkReferenceTest
             TestAsset testAsset = _testAssetsManager.CreateTestProject(testProject)
                 .Restore(Log, testProject.Name);
 
-            var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var buildCommand = new BuildCommand(testAsset);
 
             buildCommand
                 .Execute()
@@ -163,7 +163,7 @@ namespace FrameworkReferenceTest
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
-            var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var buildCommand = new BuildCommand(testAsset);
 
             buildCommand
                 .Execute()
@@ -206,7 +206,7 @@ namespace FrameworkReferenceTest
 
                 });
 
-            var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var buildCommand = new BuildCommand(testAsset);
 
             buildCommand
                 .Execute()
@@ -243,7 +243,7 @@ namespace FrameworkReferenceTest
                                                new XAttribute("Include", "Microsoft.ASPNETCORE.App")));
                 });
 
-            var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var buildCommand = new BuildCommand(testAsset);
 
             var result = buildCommand.Execute();
 
@@ -287,7 +287,7 @@ namespace FrameworkReferenceTest
             restoreCommand.Execute().Should().Pass();
 
 
-            var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name))
+            var buildCommand = new BuildCommand(testAsset)
                 .WithEnvironmentVariable("NUGET_PACKAGES", nugetPackagesFolder);
 
             buildCommand
@@ -317,7 +317,7 @@ namespace FrameworkReferenceTest
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
-            var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var buildCommand = new BuildCommand(testAsset);
 
             if (valid)
             {
@@ -367,7 +367,7 @@ namespace FrameworkReferenceTest
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
-            var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var buildCommand = new BuildCommand(testAsset);
 
             var result = buildCommand.Execute();
 
@@ -412,7 +412,7 @@ namespace FrameworkReferenceTest
                     itemGroup.Add(frameworkReference);
                 });
 
-            var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var buildCommand = new BuildCommand(testAsset);
 
             buildCommand
                 //  Pass "/clp:summary" so that we can check output for string "1 Error(s)"
@@ -477,7 +477,7 @@ namespace FrameworkReferenceTest
                 .Should()
                 .Pass();
 
-            var buildCommand = new BuildCommand(Log, testAsset.TestRoot, testProject.Name);
+            var buildCommand = new BuildCommand(testAsset);
 
             //  If we do the work in https://github.com/dotnet/cli/issues/10528,
             //  then we should add a new error message here indicating that the runtime pack hasn't
@@ -668,7 +668,7 @@ namespace FrameworkReferenceTest
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
-            var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var buildCommand = new BuildCommand(testAsset);
 
             buildCommand
                 .Execute()
@@ -722,7 +722,7 @@ namespace FrameworkReferenceTest
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
             string nugetPackagesFolder = Path.Combine(testAsset.TestRoot, "packages");
 
-            var buildCommand = (BuildCommand) new BuildCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name))
+            var buildCommand = (BuildCommand) new BuildCommand(testAsset)
                 .WithEnvironmentVariable("NUGET_PACKAGES", nugetPackagesFolder);
 
             buildCommand
@@ -804,7 +804,7 @@ namespace FrameworkReferenceTest
 
             var projectFolder = Path.Combine(testAsset.TestRoot, testProject.Name);
 
-            var buildCommand = new BuildCommand(Log, projectFolder);
+            var buildCommand = new BuildCommand(testAsset);
 
             var expectedMetadata = new[]
             {
@@ -930,7 +930,7 @@ namespace FrameworkReferenceTest
 
             string projectFolder = Path.Combine(testAsset.TestRoot, testProject.Name);
 
-            var buildCommand = new BuildCommand(Log, projectFolder);
+            var buildCommand = new BuildCommand(testAsset);
 
             buildCommand
                 .Execute()

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenFrameworkReferences.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenFrameworkReferences.cs
@@ -282,7 +282,7 @@ namespace FrameworkReferenceTest
             string nugetPackagesFolder = Path.Combine(testAsset.TestRoot, "packages");
 
 
-            var restoreCommand = new RestoreCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name))
+            var restoreCommand = new RestoreCommand(testAsset)
                 .WithEnvironmentVariable("NUGET_PACKAGES", nugetPackagesFolder);
             restoreCommand.Execute().Should().Pass();
 
@@ -439,7 +439,7 @@ namespace FrameworkReferenceTest
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
-            var restoreCommand = new RestoreCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var restoreCommand = new RestoreCommand(testAsset);
 
             restoreCommand
                 //  Pass "/clp:summary" so that we can check output for string "1 Error(s)"
@@ -470,7 +470,7 @@ namespace FrameworkReferenceTest
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
-            var restoreCommand = new RestoreCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var restoreCommand = new RestoreCommand(testAsset);
 
             restoreCommand
                 .Execute()

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatAProjectHasntBeenRestored.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatAProjectHasntBeenRestored.cs
@@ -65,7 +65,7 @@ namespace Microsoft.NET.Build.Tests
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
-            var buildCommand = new BuildCommand(Log, testAsset.TestRoot, testProject.Name);
+            var buildCommand = new BuildCommand(testAsset);
 
             var result = buildCommand
                 .Execute();

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeHaveAPackageReferenceWithAliases.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeHaveAPackageReferenceWithAliases.cs
@@ -53,7 +53,7 @@ namespace Microsoft.NET.Build.Tests
             testProject.SourceFiles[$"{testProject.Name}.cs"] = ConflictingClassLibUsage;
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
-            var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var buildCommand = new BuildCommand(testAsset);
             buildCommand.Execute()
                 .Should()
                 .Pass();
@@ -98,7 +98,7 @@ namespace Microsoft.NET.Build.Tests
             testProject.SourceFiles[$"{testProject.Name}.cs"] = ClassLibAandBUsage;
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
-            var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var buildCommand = new BuildCommand(testAsset);
             buildCommand.Execute()
                 .Should()
                 .Pass();
@@ -135,7 +135,7 @@ namespace Microsoft.NET.Build.Tests
             testProject.SourceFiles[$"{testProject.Name}.cs"] = ClassLibAandBUsage;
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
-            var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var buildCommand = new BuildCommand(testAsset);
             buildCommand.Execute()
                 .Should()
                 .Pass();

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantAMessageWhenBuildingWithAPreviewSdk.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantAMessageWhenBuildingWithAPreviewSdk.cs
@@ -27,7 +27,7 @@ namespace Microsoft.NET.Build.Tests
                 .CopyTestAsset("HelloWorld")
                 .WithSource();
 
-            var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot));
+            var buildCommand = new BuildCommand(testAsset);
 
             buildCommand
                 .Execute("/p:_NETCoreSdkIsPreview=true")
@@ -43,7 +43,7 @@ namespace Microsoft.NET.Build.Tests
                 .CopyTestAsset("HelloWorld")
                 .WithSource();
 
-            var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot));
+            var buildCommand = new BuildCommand(testAsset);
 
             buildCommand
                 .Execute("/p:_NETCoreSdkIsPreview=")

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantAllResourcesInSatellite.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantAllResourcesInSatellite.cs
@@ -44,7 +44,7 @@ namespace Microsoft.NET.Build.Tests
                 testAsset = testAsset.WithProjectChanges(projectChanges);
             }
 
-            var buildCommand = new BuildCommand(log, testAsset.TestRoot);
+            var buildCommand = new BuildCommand(testAsset);
 
             if (setup != null)
             {

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantBuildsToBeIncremental.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantBuildsToBeIncremental.cs
@@ -29,7 +29,7 @@ namespace Microsoft.NET.Build.Tests
                 .WithSource()
                 .WithTargetFramework(targetFramework);
 
-            var buildCommand = new BuildCommand(Log, testAsset.TestRoot);
+            var buildCommand = new BuildCommand(testAsset);
             var outputDirectory = buildCommand.GetOutputDirectory(targetFramework).FullName;
             var runtimeConfigDevJsonPath = Path.Combine(outputDirectory, "HelloWorld.runtimeconfig.dev.json");
 
@@ -52,7 +52,7 @@ namespace Microsoft.NET.Build.Tests
                 .WithSource()
                 .WithTargetFramework(targetFramework);
 
-            var buildCommand = new BuildCommand(Log, testAsset.TestRoot);
+            var buildCommand = new BuildCommand(testAsset);
             var outputDirectory = buildCommand.GetOutputDirectory(targetFramework).FullName;
             var baseIntermediateOutputDirectory = buildCommand.GetBaseIntermediateDirectory().FullName;
             var intermediateDirectory = buildCommand.GetIntermediateDirectory(targetFramework).FullName;

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantDiagnosticsWhenAssetsFileCannotBeRead.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantDiagnosticsWhenAssetsFileCannotBeRead.cs
@@ -23,7 +23,7 @@ namespace Microsoft.NET.Build.Tests
         public void It_reports_inaccessible_file()
         {
             var testAsset = _testAssetsManager.CopyTestAsset("HelloWorld").WithSource().Restore(Log);
-            var build = new BuildCommand(Log, testAsset.TestRoot);
+            var build = new BuildCommand(testAsset);
             var assetsFile = Path.Combine(build.GetBaseIntermediateDirectory().FullName, "project.assets.json");
 
             using (var exclusive = File.Open(assetsFile, FileMode.Open, FileAccess.ReadWrite, FileShare.None))
@@ -36,7 +36,7 @@ namespace Microsoft.NET.Build.Tests
         public void It_reports_missing_file()
         {
             var testAsset = _testAssetsManager.CopyTestAsset("HelloWorld").WithSource();
-            var build = new BuildCommand(Log, testAsset.TestRoot);
+            var build = new BuildCommand(testAsset);
             var assetsFile = Path.Combine(build.GetBaseIntermediateDirectory().FullName, "project.assets.json");
 
             build.ExecuteWithoutRestore().Should().Fail().And.HaveStdOutContaining(assetsFile);
@@ -46,7 +46,7 @@ namespace Microsoft.NET.Build.Tests
         public void It_reports_corrupt_file()
         {
             var testAsset = _testAssetsManager.CopyTestAsset("HelloWorld").WithSource().Restore(Log);
-            var build = new BuildCommand(Log, testAsset.TestRoot);
+            var build = new BuildCommand(testAsset);
             var assetsFile = Path.Combine(build.GetBaseIntermediateDirectory().FullName, "project.assets.json");
 
             File.WriteAllText(assetsFile, "{ corrupt_file: ");

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantDiagnosticsWhenPackageCannotBeFound.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantDiagnosticsWhenPackageCannotBeFound.cs
@@ -43,9 +43,7 @@ namespace Microsoft.NET.Build.Tests
 
             RemovePackageFromCache(package);
 
-            var build = new BuildCommand(
-                Log,
-                Path.Combine(asset.TestRoot, project.Name));
+            var build = new BuildCommand(asset);
 
             build.ExecuteWithoutRestore()
                  .Should()

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantImplicitNamespaceImportsDisabled.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantImplicitNamespaceImportsDisabled.cs
@@ -24,7 +24,7 @@ namespace Microsoft.NET.Build.Tests
                 .CopyTestAsset("InferredTypeVariableName")
                 .WithSource();
 
-            var buildCommand = new BuildCommand(Log, Path.Combine(asset.TestRoot));
+            var buildCommand = new BuildCommand(asset);
 
             buildCommand
                 .Execute()

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantRuntimeConfigInBuiltProjectOutputGroup.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantRuntimeConfigInBuiltProjectOutputGroup.cs
@@ -66,7 +66,7 @@ namespace Microsoft.NET.Build.Tests
             };
             var testAsset = _testAssetsManager.CreateTestProject(testProject, testProject.Name);
 
-            new BuildCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name))
+            new BuildCommand(testAsset)
                 .Execute("/property:Configuration=Release")
                 .Should()
                 .Pass();
@@ -88,7 +88,7 @@ namespace Microsoft.NET.Build.Tests
                 propertyGroup.Add(new XElement(ns + "ThreadPoolMinThreads", "2"));
             });
 
-            new BuildCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name))
+            new BuildCommand(testAsset)
                 .Execute("/property:Configuration=Release")
                 .Should()
                 .Pass();
@@ -122,7 +122,7 @@ namespace Microsoft.NET.Build.Tests
                 propertyGroup.Add(new XElement(ns + "ThreadPoolMinThreads", "3"));
             });
 
-            new BuildCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name))
+            new BuildCommand(testAsset)
                 .Execute("/property:Configuration=Release")
                 .Should()
                 .Pass();
@@ -144,7 +144,7 @@ namespace Microsoft.NET.Build.Tests
                 propertyGroup.Add(new XElement(ns + "ThreadPoolMinThreads", "2"));
             });
 
-            new BuildCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name))
+            new BuildCommand(testAsset)
                 .Execute("/property:Configuration=Release")
                 .Should()
                 .Pass();

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantSatelliteAssembliesHaveassemblyVersion.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantSatelliteAssembliesHaveassemblyVersion.cs
@@ -27,7 +27,7 @@ namespace Microsoft.NET.Build.Tests
               .CopyTestAsset("AllResourcesInSatelliteDisableVersionGenerate")
               .WithSource();
 
-            var buildCommand = new BuildCommand(Log, testAsset.TestRoot);
+            var buildCommand = new BuildCommand(testAsset);
             buildCommand
                 .Execute()
                 .Should()

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAComServerLibrary.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAComServerLibrary.cs
@@ -27,7 +27,7 @@ namespace Microsoft.NET.Build.Tests
                 .CopyTestAsset("ComServer")
                 .WithSource();
 
-            var buildCommand = new BuildCommand(Log, testAsset.TestRoot);
+            var buildCommand = new BuildCommand(testAsset);
             buildCommand
                 .Execute()
                 .Should()
@@ -64,7 +64,7 @@ namespace Microsoft.NET.Build.Tests
                     propertyGroup.Add(new XElement("EnableRegFreeCom", true));
                 });
 
-            var buildCommand = new BuildCommand(Log, testAsset.TestRoot);
+            var buildCommand = new BuildCommand(testAsset);
             buildCommand
                 .Execute()
                 .Should()
@@ -98,7 +98,7 @@ namespace Microsoft.NET.Build.Tests
                     propertyGroup.Add(new XElement("RuntimeIdentifier", rid));
                 });
 
-            var buildCommand = new BuildCommand(Log, testAsset.TestRoot);
+            var buildCommand = new BuildCommand(testAsset);
             buildCommand
                 .Execute()
                 .Should()
@@ -129,7 +129,7 @@ namespace Microsoft.NET.Build.Tests
                     propertyGroup.Add(new XElement("SelfContained", true));
                 });
 
-            var buildCommand = new BuildCommand(Log, testAsset.TestRoot);
+            var buildCommand = new BuildCommand(testAsset);
             buildCommand
                 .Execute()
                 .Should()
@@ -150,7 +150,7 @@ namespace Microsoft.NET.Build.Tests
                     var propertyGroup = project.Root.Elements(ns + "PropertyGroup").First();
                 });
 
-            var buildCommand = new BuildCommand(Log, testAsset.TestRoot);
+            var buildCommand = new BuildCommand(testAsset);
             buildCommand
                 .Execute()
                 .Should()
@@ -174,7 +174,7 @@ namespace Microsoft.NET.Build.Tests
                     propertyGroup.Add(new XElement("RuntimeIdentifier", rid));
                 });
 
-            var buildCommand = new BuildCommand(Log, testAsset.TestRoot);
+            var buildCommand = new BuildCommand(testAsset);
             buildCommand
                 .Execute()
                 .Should()

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildACppCliNonLibraryProject.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildACppCliNonLibraryProject.cs
@@ -27,7 +27,7 @@ namespace Microsoft.NET.Build.Tests
                 .CopyTestAsset("NETCoreCppClApp")
                 .WithSource();
 
-            new BuildCommand(Log, Path.Combine(testAsset.TestRoot, "NETCoreCppCliTest.sln"))
+            new BuildCommand(testAsset, "NETCoreCppCliTest.sln")
                 .Execute()
                 .Should()
                 .Fail()
@@ -53,7 +53,7 @@ namespace Microsoft.NET.Build.Tests
                     }
                 });
 
-            new BuildCommand(Log, Path.Combine(testAsset.TestRoot, "NETCoreCppCliTest.sln"))
+            new BuildCommand(testAsset, "NETCoreCppCliTest.sln")
                 .Execute()
                 .Should()
                 .Fail()

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildACppCliProject.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildACppCliProject.cs
@@ -27,12 +27,12 @@ namespace Microsoft.NET.Build.Tests
                 .WithSource();
 
             // build projects separately with BuildProjectReferences=false to simulate VS build behavior
-            new BuildCommand(Log, Path.Combine(testAsset.TestRoot, "NETCoreCppCliTest"))
+            new BuildCommand(testAsset, "NETCoreCppCliTest")
                 .Execute("-p:Platform=x64")
                 .Should()
                 .Pass();
 
-            new BuildCommand(Log, Path.Combine(testAsset.TestRoot, "CSConsoleApp"))
+            new BuildCommand(testAsset, "CSConsoleApp")
                 .Execute(new string[] { "-p:Platform=x64", "-p:BuildProjectReferences=false" })
                 .Should()
                 .Pass();
@@ -59,7 +59,7 @@ namespace Microsoft.NET.Build.Tests
                 .CopyTestAsset("NetCoreCsharpAppReferenceCppCliLib")
                 .WithSource();
 
-            new BuildCommand(Log, Path.Combine(testAsset.TestRoot, "NETCoreCppCliTest"))
+            new BuildCommand(testAsset, "NETCoreCppCliTest")
                 .Execute("-p:Platform=x64")
                 .Should()
                 .Pass();
@@ -72,7 +72,7 @@ namespace Microsoft.NET.Build.Tests
                 .CopyTestAsset("CppCliLibWithWpfFrameworkReference")
                 .WithSource();
 
-            new BuildCommand(Log, testAsset.TestRoot)
+            new BuildCommand(testAsset)
                 .Execute("-p:Platform=x64")
                 .Should()
                 .Pass();
@@ -98,7 +98,7 @@ namespace Microsoft.NET.Build.Tests
                     }
                 });
 
-            new BuildCommand(Log, Path.Combine(testAsset.TestRoot, "NETCoreCppCliTest"))
+            new BuildCommand(testAsset, "NETCoreCppCliTest")
                 .Execute("-p:Platform=x64")
                 .Should()
                 .Fail()
@@ -115,7 +115,7 @@ namespace Microsoft.NET.Build.Tests
                 .WithProjectChanges((projectPath, project) =>
                     ChangeTargetFramework(projectPath, project, "net472"));
 
-            new BuildCommand(Log, Path.Combine(testAsset.TestRoot, "NETCoreCppCliTest"))
+            new BuildCommand(testAsset, "NETCoreCppCliTest")
                 .Execute("-p:Platform=x64")
                 .Should()
                 .Fail()
@@ -132,7 +132,7 @@ namespace Microsoft.NET.Build.Tests
                 .WithProjectChanges((projectPath, project) =>
                     ChangeTargetFramework(projectPath, project, "netcoreapp3.0"));
 
-            new BuildCommand(Log, Path.Combine(testAsset.TestRoot, "NETCoreCppCliTest"))
+            new BuildCommand(testAsset, "NETCoreCppCliTest")
                 .Execute("-p:Platform=x64")
                 .Should()
                 .Fail()
@@ -147,7 +147,7 @@ namespace Microsoft.NET.Build.Tests
                 .CopyTestAsset("NetCoreCsharpAppReferenceCppCliLib")
                 .WithSource();
 
-            new BuildCommand(Log, Path.Combine(testAsset.TestRoot, "NETCoreCppCliTest"))
+            new BuildCommand(testAsset, "NETCoreCppCliTest")
                 .Execute("-p:Platform=x64", "-p:selfcontained=true", "-p:RuntimeIdentifier=win-x64")
                 .Should()
                 .Fail()

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildACppCliProjectWithTransitiveDeps.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildACppCliProjectWithTransitiveDeps.cs
@@ -61,7 +61,7 @@ namespace Microsoft.NET.Build.Tests
                 .WithSource();
 
             // build projects separately with BuildProjectReferences=false to simulate VS build behavior
-            new BuildCommand(Log, Path.Combine(testAsset.TestRoot, "NETCoreCppCliTest"))
+            new BuildCommand(testAsset, "NETCoreCppCliTest")
                 .Execute("-p:Platform=win32")
                 .Should()
                 .Pass();

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildACrossTargetedLibrary.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildACrossTargetedLibrary.cs
@@ -27,9 +27,7 @@ namespace Microsoft.NET.Build.Tests
                 .CopyTestAsset("CrossTargeting")
                 .WithSource();
 
-            var libraryProjectDirectory = Path.Combine(testAsset.TestRoot, "NetStandardAndNetCoreApp");
-
-            var buildCommand = new BuildCommand(Log, libraryProjectDirectory);
+            var buildCommand = new BuildCommand(testAsset, "NetStandardAndNetCoreApp");
             buildCommand
                 .Execute()
                 .Should()
@@ -55,9 +53,7 @@ namespace Microsoft.NET.Build.Tests
                 .CopyTestAsset("CrossTargeting")
                 .WithSource();
 
-            var libraryProjectDirectory = Path.Combine(testAsset.TestRoot, "DesktopAndNetStandard");
-
-            var buildCommand = new BuildCommand(Log, libraryProjectDirectory);
+            var buildCommand = new BuildCommand(testAsset, "DesktopAndNetStandard");
             buildCommand
                 .Execute()
                 .Should()

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildADesktopExe.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildADesktopExe.cs
@@ -37,7 +37,7 @@ namespace Microsoft.NET.Build.Tests
                 .WithSource()
                 .WithTargetFramework(targetFramework);
 
-            var buildCommand = new BuildCommand(Log, testAsset.TestRoot);
+            var buildCommand = new BuildCommand(testAsset);
             buildCommand
                 .Execute()
                 .Should()
@@ -81,7 +81,7 @@ namespace Microsoft.NET.Build.Tests
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject, identifier: packageName + "_" + referencePlatformPackage.ToString());
 
-            var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var buildCommand = new BuildCommand(testAsset);
 
             buildCommand.Execute()
                 .Should()
@@ -140,7 +140,7 @@ namespace Microsoft.NET.Build.Tests
                        }
                    });
 
-                var buildCommand = new BuildCommand(Log, testAsset.TestRoot);
+                var buildCommand = new BuildCommand(testAsset);
                 buildCommand
                     .Execute()
                     .Should()
@@ -188,7 +188,7 @@ namespace Microsoft.NET.Build.Tests
                         }
                     });
 
-                var buildCommand = new BuildCommand(Log, testAsset.TestRoot);
+                var buildCommand = new BuildCommand(testAsset);
                 buildCommand
                     .Execute()
                     .Should()
@@ -322,7 +322,7 @@ namespace DefaultReferences
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
-            var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot, "DefaultReferences"));
+            var buildCommand = new BuildCommand(testAsset, "DefaultReferences");
 
             buildCommand
                 .Execute()
@@ -347,7 +347,7 @@ namespace DefaultReferences
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject, testProject.Name);
 
-            var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var buildCommand = new BuildCommand(testAsset);
 
             //  Pass "/clp:summary" so that we can check output for string "1 Error(s)"
             var result = buildCommand.Execute("/clp:summary");
@@ -386,7 +386,7 @@ namespace DefaultReferences
                     itemGroup.Add(new XElement(ns + "Reference", new XAttribute("Include", "System")));
                 });
 
-            var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var buildCommand = new BuildCommand(testAsset);
 
             buildCommand
                 .Execute("/v:normal")
@@ -420,7 +420,7 @@ namespace DefaultReferences
                                     new XAttribute("Version", "9.0.1")));
                 });
 
-            var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var buildCommand = new BuildCommand(testAsset);
 
             buildCommand
                 .Execute("/v:normal")
@@ -450,7 +450,7 @@ namespace DefaultReferences
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject, testProject.Name);
 
-            var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var buildCommand = new BuildCommand(testAsset);
 
             //  Verify that ResolveAssemblyReference doesn't generate any conflicts
             buildCommand
@@ -486,7 +486,7 @@ namespace DefaultReferences
                                     new XAttribute("Version", "4.3.0")));
                 });
 
-            var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var buildCommand = new BuildCommand(testAsset);
 
             var buildResult = buildCommand
                 .Execute("/v:normal");
@@ -578,7 +578,7 @@ class Program
                     itemGroup.Add(httpReference);
                 });
 
-            var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var buildCommand = new BuildCommand(testAsset);
 
             buildCommand
                 .Execute("/v:normal")
@@ -645,7 +645,7 @@ class Program
                 });
 
 
-            var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var buildCommand = new BuildCommand(testAsset);
 
             buildCommand
                 .Execute()
@@ -660,7 +660,7 @@ class Program
                 .CopyTestAsset("DesktopNeedsBindingRedirects")
                 .WithSource();
 
-            var buildCommand = new BuildCommand(Log, testAsset.TestRoot);
+            var buildCommand = new BuildCommand(testAsset);
 
             buildCommand
                 .Execute()
@@ -696,7 +696,7 @@ class Program
                 .CopyTestAsset("DesktopNeedsBindingRedirects")
                 .WithSource();
 
-            var buildCommand = new BuildCommand(Log, testAsset.TestRoot);
+            var buildCommand = new BuildCommand(testAsset);
 
             buildCommand
                 .Execute()
@@ -785,7 +785,7 @@ class Program
 
         private XElement BuildTestAssetGetAppConfig(TestAsset testAsset)
         {
-            var buildCommand = new BuildCommand(Log, testAsset.TestRoot);
+            var buildCommand = new BuildCommand(testAsset);
 
             buildCommand
                 .Execute()
@@ -828,7 +828,7 @@ class Program
                     }
                 });
 
-            var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var buildCommand = new BuildCommand(testAsset);
             buildCommand
                 .Execute("/v:normal")
                 .Should()
@@ -854,7 +854,7 @@ class Program
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
-            var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var buildCommand = new BuildCommand(testAsset);
 
             buildCommand
                 .Execute()

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildADesktopExeWithFSharp.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildADesktopExeWithFSharp.cs
@@ -41,7 +41,7 @@ namespace Microsoft.NET.Build.Tests
                     propertyGroup.Element(ns + "TargetFramework").SetValue(targetFramework);
                 });
 
-            var buildCommand = new BuildCommand(Log, testAsset.TestRoot);
+            var buildCommand = new BuildCommand(testAsset);
             buildCommand
                 .Execute()
                 .Should()

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildADesktopExeWtihNetStandardLib.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildADesktopExeWtihNetStandardLib.cs
@@ -111,14 +111,14 @@ namespace Microsoft.NET.Build.Tests
             if (scenario != ReferenceScenario.ProjectReference)
             {
 
-                var libBuildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot, LibraryName));
+                var libBuildCommand = new BuildCommand(testAsset, LibraryName);
                 libBuildCommand
                     .Execute()
                     .Should()
                     .Pass();
             }
 
-            var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot, AppName));
+            var buildCommand = new BuildCommand(testAsset, AppName);
             buildCommand
                 .Execute()
                 .Should()
@@ -244,7 +244,7 @@ namespace Microsoft.NET.Build.Tests
             }
 
             // build should succeed without duplicates
-            var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot, AppName));
+            var buildCommand = new BuildCommand(testAsset, AppName);
             buildCommand
                 .Execute()
                 .Should()
@@ -294,7 +294,7 @@ namespace Microsoft.NET.Build.Tests
                     }
                 });
 
-            var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot, AppName));
+            var buildCommand = new BuildCommand(testAsset, AppName);
             buildCommand
                 .Execute()
                 .Should()
@@ -355,7 +355,7 @@ namespace Microsoft.NET.Build.Tests
                     }
                 });
 
-            var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot, AppName));
+            var buildCommand = new BuildCommand(testAsset, AppName);
             buildCommand
                 .Execute()
                 .Should()
@@ -393,7 +393,7 @@ namespace Microsoft.NET.Build.Tests
                     }
                 });
 
-            var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot, AppName));
+            var buildCommand = new BuildCommand(testAsset, AppName);
             buildCommand
                 .Execute()
                 .Should()

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildADesktopLibrary.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildADesktopLibrary.cs
@@ -55,7 +55,7 @@ namespace Microsoft.NET.Build.Tests
                 }";
 
             var testAsset = _testAssetsManager.CreateTestProject(netFrameworkLibrary, "FacadesFromTargetFramework");
-            var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot, netFrameworkLibrary.Name));
+            var buildCommand = new BuildCommand(testAsset);
             buildCommand.Execute().Should().Pass();
         }
 
@@ -114,7 +114,7 @@ public class NETFramework
                     }
                 });
 
-            var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot, netFrameworkLibrary.Name));
+            var buildCommand = new BuildCommand(testAsset);
 
             buildCommand
                 .Execute()
@@ -162,7 +162,7 @@ public class NETFramework
 ";
             var testAsset = _testAssetsManager.CreateTestProject(netFrameworkLibrary, "ExchangeNETStandard2");
 
-            var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot, netFrameworkLibrary.Name));
+            var buildCommand = new BuildCommand(testAsset);
 
             buildCommand
                 .Execute()
@@ -220,7 +220,7 @@ public class NETFramework
 ";
             var testAsset = _testAssetsManager.CreateTestProject(netFrameworkLibrary, "ExchangeValueTuple");
 
-            var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot, netFrameworkLibrary.Name));
+            var buildCommand = new BuildCommand(testAsset);
 
             buildCommand
                 .Execute()
@@ -235,7 +235,7 @@ public class NETFramework
                 .CopyTestAsset("DesktopReferencingNetStandardLibrary")
                 .WithSource();
 
-            var buildCommand = new BuildCommand(Log, testAsset.TestRoot);
+            var buildCommand = new BuildCommand(testAsset);
             buildCommand
                 .Execute()
                 .Should().Pass();
@@ -285,9 +285,7 @@ public static class {project.Name}
 
                 });
 
-            string projectFolder = Path.Combine(testAsset.Path, project.Name);
-
-            var buildCommand = new BuildCommand(Log, projectFolder);
+            var buildCommand = new BuildCommand(testAsset);
 
             buildCommand
                 .Execute()
@@ -407,7 +405,7 @@ public static class {project.Name}
                             new XElement("HintPath", $"   {Environment.NewLine}{hintPath}   {Environment.NewLine}")));
                 });
 
-            var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot, project.Name));
+            var buildCommand = new BuildCommand(testAsset);
             var msbuildBuildCommand = new MSBuildCommand(Log, "Build", buildCommand.FullPathProjectFile);
             msbuildBuildCommand.Execute().Should().Pass()
                 .And.NotHaveStdOutContaining("System.ArgumentException");
@@ -426,7 +424,7 @@ public static class {project.Name}
                 .CreateTestProject(referencedProject, "SimpleNamesWithHintPathsWithNewLinesReferenced");
 
             var referencedbuildCommand =
-                new BuildCommand(Log, Path.Combine(referencedTestAsset.TestRoot, referencedProject.Name));
+                new BuildCommand(referencedTestAsset);
 
             referencedbuildCommand.Execute();
 
@@ -458,7 +456,7 @@ public static class {project.Name}
                         new XAttribute("BeforeTargets", "BeforeBuild")));
                 });
 
-            var buildCommand = new BuildCommand(Log, testInstance.TestRoot, testProject.Name);
+            var buildCommand = new BuildCommand(testInstance);
 
             buildCommand.Execute()
                 .Should()

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildALibrary.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildALibrary.cs
@@ -40,9 +40,7 @@ namespace Microsoft.NET.Build.Tests
                 .WithSource()
                 .WithTargetFramework(targetFramework, "TestLibrary");
 
-            var libraryProjectDirectory = Path.Combine(testAsset.TestRoot, "TestLibrary");
-
-            var buildCommand = new BuildCommand(Log, libraryProjectDirectory);
+            var buildCommand = new BuildCommand(testAsset, "TestLibrary");
             buildCommand
                 .Execute()
                 .Should()
@@ -64,9 +62,7 @@ namespace Microsoft.NET.Build.Tests
                 .CopyTestAsset("AppWithLibrary")
                 .WithSource();
 
-            var libraryProjectDirectory = Path.Combine(testAsset.TestRoot, "TestLibrary");
-
-            var buildCommand = new BuildCommand(Log, libraryProjectDirectory);
+            var buildCommand = new BuildCommand(testAsset, "TestLibrary");
             buildCommand
                 .Execute()
                 .Should()
@@ -164,7 +160,7 @@ namespace Microsoft.NET.Build.Tests
 
             var libraryProjectDirectory = Path.Combine(testAsset.TestRoot, "TestLibrary");
 
-            var buildCommand = new BuildCommand(Log, libraryProjectDirectory);
+            var buildCommand = new BuildCommand(testAsset, "TestLibrary");
 
             buildCommand
                 .Execute()
@@ -198,7 +194,7 @@ namespace Microsoft.NET.Build.Tests
 
             var libraryProjectDirectory = Path.Combine(testAsset.TestRoot, "TestLibrary");
 
-            var buildCommand = new BuildCommand(Log, libraryProjectDirectory);
+            var buildCommand = new BuildCommand(testAsset, "TestLibrary");
 
             buildCommand
                 .Execute()
@@ -241,7 +237,7 @@ namespace Microsoft.NET.Build.Tests
 
             var libraryProjectDirectory = Path.Combine(testAsset.TestRoot, "TestLibrary");
 
-            var buildCommand = new BuildCommand(Log, libraryProjectDirectory);
+            var buildCommand = new BuildCommand(testAsset, "TestLibrary");
 
             buildCommand
                 .Execute()
@@ -473,12 +469,12 @@ namespace Microsoft.NET.Build.Tests
                 var relativePathToSln = Path.GetFileName(testAsset.Path) + ".sln";
 
                 restoreCommand = testAsset.GetRestoreCommand(Log, relativePathToSln);
-                buildCommand = new BuildCommand(Log, testAsset.TestRoot, relativePathToSln);
+                buildCommand = new BuildCommand(testAsset, relativePathToSln);
             }
             else
             {
                 restoreCommand = testAsset.GetRestoreCommand(Log, testProject.Name);
-                buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+                buildCommand = new BuildCommand(testAsset);
             }
 
             //  Set RestoreContinueOnError=ErrorAndContinue to force failure on error
@@ -529,7 +525,7 @@ namespace Microsoft.NET.Build.Tests
                 .Fail()
                 .And.HaveStdOutContaining("The current .NET SDK does not support targeting");
 
-            var buildCommand = new BuildCommand(Log, testAsset.TestRoot, testProject.Name);
+            var buildCommand = new BuildCommand(testAsset);
 
             buildCommand
                 .Execute()
@@ -562,7 +558,7 @@ namespace Microsoft.NET.Build.Tests
                 })
                 .Restore(Log, testProject.Name);
 
-            var buildCommand = new BuildCommand(Log, testAsset.TestRoot, testProject.Name);
+            var buildCommand = new BuildCommand(testAsset);
 
             //  Test that compilation doesn't depend on any rid-specific assets by removing them from the assets file after it's been restored
             var assetsFilePath = Path.Combine(buildCommand.GetBaseIntermediateDirectory().FullName, "project.assets.json");
@@ -592,7 +588,7 @@ namespace Microsoft.NET.Build.Tests
                 .CopyTestAsset("UwpUsingSdkExtras")
                 .WithSource();
 
-            var buildCommand = new BuildCommand(Log, testAsset.TestRoot);
+            var buildCommand = new BuildCommand(testAsset);
             buildCommand
                 .Execute()
                 .Should()
@@ -678,7 +674,7 @@ namespace Microsoft.NET.Build.Tests
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
-            var buildCommand = new BuildCommand(Log, testAsset.TestRoot, testProject.Name);
+            var buildCommand = new BuildCommand(testAsset);
 
             buildCommand
                 .Execute()

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildALibraryWithFSharp.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildALibraryWithFSharp.cs
@@ -35,9 +35,7 @@ namespace Microsoft.NET.Build.Tests
                 .CopyTestAsset("AppWithLibraryFS")
                 .WithSource();
 
-            var libraryProjectDirectory = Path.Combine(testAsset.TestRoot, "TestLibrary");
-
-            var buildCommand = new BuildCommand(Log, libraryProjectDirectory);
+            var buildCommand = new BuildCommand(testAsset, "TestLibrary");
             buildCommand
                 .Execute()
                 .Should()
@@ -59,9 +57,7 @@ namespace Microsoft.NET.Build.Tests
                 .CopyTestAsset("AppWithLibraryFS")
                 .WithSource();
 
-            var libraryProjectDirectory = Path.Combine(testAsset.TestRoot, "TestLibrary");
-
-            var buildCommand = new BuildCommand(Log, libraryProjectDirectory);
+            var buildCommand = new BuildCommand(testAsset, "TestLibrary");
             buildCommand
                 .Execute()
                 .Should()
@@ -123,9 +119,7 @@ namespace Microsoft.NET.Build.Tests
                 .CopyTestAsset("AppWithLibraryFS")
                 .WithSource();
 
-            var libraryProjectDirectory = Path.Combine(testAsset.TestRoot, "TestLibrary");
-
-            var buildCommand = new BuildCommand(Log, libraryProjectDirectory);
+            var buildCommand = new BuildCommand(testAsset, "TestLibrary");
             buildCommand
                 .ExecuteWithoutRestore()
                 .Should()

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildALibraryWithVB.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildALibraryWithVB.cs
@@ -35,9 +35,7 @@ namespace Microsoft.NET.Build.Tests
                 .CopyTestAsset("AppWithLibraryVB")
                 .WithSource();
 
-            var libraryProjectDirectory = Path.Combine(testAsset.TestRoot, "TestLibrary");
-
-            var buildCommand = new BuildCommand(Log, libraryProjectDirectory);
+            var buildCommand = new BuildCommand(testAsset, "TestLibrary");
             buildCommand
                 .Execute()
                 .Should()
@@ -59,9 +57,7 @@ namespace Microsoft.NET.Build.Tests
                 .CopyTestAsset("AppWithLibraryVB")
                 .WithSource();
 
-            var libraryProjectDirectory = Path.Combine(testAsset.TestRoot, "TestLibrary");
-
-            var buildCommand = new BuildCommand(Log, libraryProjectDirectory);
+            var buildCommand = new BuildCommand(testAsset, "TestLibrary");
             buildCommand
                 .Execute()
                 .Should()
@@ -134,9 +130,7 @@ namespace Microsoft.NET.Build.Tests
                 .CopyTestAsset("AppWithLibraryVB")
                 .WithSource();
 
-            var libraryProjectDirectory = Path.Combine(testAsset.TestRoot, "TestLibrary");
-
-            var buildCommand = new BuildCommand(Log, libraryProjectDirectory);
+            var buildCommand = new BuildCommand(testAsset, "TestLibrary");
             buildCommand
                 .ExecuteWithoutRestore()
                 .Should()

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildANetCoreApp.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildANetCoreApp.cs
@@ -90,7 +90,7 @@ namespace Microsoft.NET.Build.Tests
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
-            var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var buildCommand = new BuildCommand(testAsset);
 
             buildCommand
                 .Execute()
@@ -143,7 +143,7 @@ namespace Microsoft.NET.Build.Tests
 
             NuGetConfigWriter.Write(testAsset.TestRoot, NuGetConfigWriter.DotnetCoreBlobFeed);
 
-            var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var buildCommand = new BuildCommand(testAsset);
 
             buildCommand
                 .Execute(extraArgs)
@@ -214,7 +214,7 @@ namespace Microsoft.NET.Build.Tests
             var testAsset = _testAssetsManager.CreateTestProject(testProject)
                 .Restore(Log, testProject.Name);
 
-            var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var buildCommand = new BuildCommand(testAsset);
 
             var result = buildCommand.ExecuteWithoutRestore($"/p:RuntimeIdentifier={runtimeIdentifier}");
 
@@ -351,9 +351,7 @@ public static class Program
                     }
                 });
 
-            string projectFolder = Path.Combine(testAsset.Path, project.Name);
-
-            var buildCommand = new BuildCommand(Log, projectFolder);
+            var buildCommand = new BuildCommand(testAsset);
 
             buildCommand
                 .Execute()
@@ -414,9 +412,7 @@ public static class Program
 
                 });
 
-            string projectFolder = Path.Combine(testAsset.Path, project.Name);
-
-            var buildCommand = new BuildCommand(Log, projectFolder);
+            var buildCommand = new BuildCommand(testAsset);
 
             buildCommand
                 .Execute()
@@ -455,9 +451,8 @@ public static class Program
             };
 
             var testAsset = _testAssetsManager.CreateTestProject(project);
-            string projectFolder = Path.Combine(testAsset.Path, project.Name);
 
-            var buildCommand = new BuildCommand(Log, projectFolder);
+            var buildCommand = new BuildCommand(testAsset);
 
             buildCommand
                 .Execute($"/p:SelfContained={isSelfContained}")
@@ -496,7 +491,7 @@ public static class Program
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject, testProject.Name);
 
-            var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var buildCommand = new BuildCommand(testAsset);
 
             buildCommand
                 .Execute("/v:normal")
@@ -567,7 +562,7 @@ public static class Program
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject, testProject.Name);
 
-            var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var buildCommand = new BuildCommand(testAsset);
 
             buildCommand
                 .Execute(extraArgs)
@@ -615,7 +610,7 @@ public static class Program
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject, testProject.Name);
 
-            var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var buildCommand = new BuildCommand(testAsset);
 
             buildCommand
                 .Execute()
@@ -665,7 +660,7 @@ class Program
             var testAsset = _testAssetsManager
                 .CreateTestProject(testProject);
 
-            var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var buildCommand = new BuildCommand(testAsset);
 
             buildCommand
                 .Execute()
@@ -693,7 +688,7 @@ class Program
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject, testProject.Name);
 
-            var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var buildCommand = new BuildCommand(testAsset);
 
             buildCommand
                 .Execute()
@@ -746,7 +741,7 @@ class Program
             var testAsset = _testAssetsManager
                 .CreateTestProject(testProject);
 
-            var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var buildCommand = new BuildCommand(testAsset);
 
             buildCommand
                 .Execute()
@@ -773,7 +768,7 @@ class Program
             var testAsset = _testAssetsManager
                 .CreateTestProject(testProject);
 
-            var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var buildCommand = new BuildCommand(testAsset);
 
             buildCommand
                 .Execute()

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildANetCoreAppForTelemetry.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildANetCoreAppForTelemetry.cs
@@ -34,7 +34,7 @@ namespace Microsoft.NET.Build.Tests
                 };
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
-            var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var buildCommand = new BuildCommand(testAsset);
 
             buildCommand
                 .Execute(TelemetryTestLogger)
@@ -60,7 +60,7 @@ namespace Microsoft.NET.Build.Tests
                 };
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
-            var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var buildCommand = new BuildCommand(testAsset);
 
             buildCommand
                 .Execute(TelemetryTestLogger)

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildANetStandard2Library.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildANetStandard2Library.cs
@@ -38,9 +38,7 @@ namespace Microsoft.NET.Build.Tests
 
             var testAsset = _testAssetsManager.CreateTestProject(project, identifier: targetFramework);
 
-            string projectFolder = Path.Combine(testAsset.Path, project.Name);
-
-            var buildCommand = new BuildCommand(Log, projectFolder);
+            var buildCommand = new BuildCommand(testAsset);
 
             buildCommand
                 .Execute()
@@ -83,9 +81,7 @@ public static class {project.Name}
 
                 });
 
-            string projectFolder = Path.Combine(testAsset.Path, project.Name);
-
-            var buildCommand = new BuildCommand(Log, projectFolder);
+            var buildCommand = new BuildCommand(testAsset);
 
             buildCommand
                 .Execute()

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildASelfContainedApp.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildASelfContainedApp.cs
@@ -44,7 +44,7 @@ namespace Microsoft.NET.Build.Tests
                     propertyGroup.Add(new XElement(ns + "RuntimeIdentifier", runtimeIdentifier));
                 });
 
-            var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot));
+            var buildCommand = new BuildCommand(testAsset);
 
             buildCommand
                 .Execute()
@@ -105,7 +105,7 @@ namespace Microsoft.NET.Build.Tests
                     propertyGroup.Add(new XElement(ns + "PlatformTarget", PlatformTarget));
 				});
 
-			var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot));
+			var buildCommand = new BuildCommand(testAsset);
 
 			buildCommand
 				.Execute()
@@ -133,7 +133,7 @@ namespace Microsoft.NET.Build.Tests
 					propertyGroup.Add(new XElement(ns + "PlatformTarget", "AnyCPU"));
 				});
 
-			var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot));
+			var buildCommand = new BuildCommand(testAsset);
 
 			buildCommand
 				.Execute()

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildASolutionWithNonAnyCPUPlatform.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildASolutionWithNonAnyCPUPlatform.cs
@@ -24,7 +24,7 @@ namespace Microsoft.NET.Build.Tests
                 .CopyTestAsset("x64SolutionBuild")
                 .WithSource();
 
-            var buildCommand = new BuildCommand(Log, testAsset.TestRoot, "x64SolutionBuild.sln");
+            var buildCommand = new BuildCommand(testAsset, "x64SolutionBuild.sln");
             buildCommand
                 .Execute()
                 .Should()

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildASolutionWithNonDefaultConfiguration.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildASolutionWithNonDefaultConfiguration.cs
@@ -38,7 +38,7 @@ namespace Microsoft.NET.Build.Tests
                     propertyGroup.SetElementValue(ns + "Configurations", configuration);
                 });
 
-            var buildCommand = new BuildCommand(Log, testAsset.TestRoot);
+            var buildCommand = new BuildCommand(testAsset);
             buildCommand
                 .Execute(new[] { "/v:d", $"/p:Configuration={configuration}" })
                 .Should().HaveStdOutContaining($"$(ImplicitConfigurationDefine)=\"{expected}\"");

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildASolutionWithNonDefaultConfigurationVB.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildASolutionWithNonDefaultConfigurationVB.cs
@@ -38,7 +38,7 @@ namespace Microsoft.NET.Build.Tests
                 });
 
 
-            var buildCommand = new BuildCommand(Log, testAsset.TestRoot);
+            var buildCommand = new BuildCommand(testAsset);
             buildCommand
                 .Execute(new[] { "/v:d", $"/p:Configuration={configuration}" })
                 .Should().HaveStdOutContaining($"$(ImplicitConfigurationDefine)=\"{expected}\"");

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildASolutionWithProjRefDiffCase.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildASolutionWithProjRefDiffCase.cs
@@ -26,7 +26,7 @@ namespace Microsoft.NET.Build.Tests
                 .CopyTestAsset("AppWithProjRefCaseDiff")
                 .WithSource();
 
-            var command = new BuildCommand(Log, Path.Combine(asset.TestRoot, solutionFile));
+            var command = new BuildCommand(asset, solutionFile);
             command.Execute().Should().Pass();
         }
     }

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAUnitTestProject.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAUnitTestProject.cs
@@ -23,7 +23,7 @@ namespace Microsoft.NET.Build.Tests
                 .CopyTestAsset("XUnitTestProject")
                 .WithSource();
 
-            var buildCommand = new BuildCommand(Log, testAsset.TestRoot);
+            var buildCommand = new BuildCommand(testAsset);
             buildCommand
                 .Execute()
                 .Should()
@@ -42,7 +42,7 @@ namespace Microsoft.NET.Build.Tests
                 .CopyTestAsset("XUnitTestProject")
                 .WithSource();
 
-            var buildCommand = new BuildCommand(Log, testAsset.TestRoot);
+            var buildCommand = new BuildCommand(testAsset);
             buildCommand
                 .Execute(new string[] {
                     "/restore",

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAWindowsRuntimeComponent.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAWindowsRuntimeComponent.cs
@@ -27,7 +27,7 @@ namespace Microsoft.NET.Build.Tests
                 .CopyTestAsset("WindowsRuntimeComponent")
                 .WithSource();
 
-            var buildCommand = new BuildCommand(Log, testAsset.TestRoot);
+            var buildCommand = new BuildCommand(testAsset);
             buildCommand
                 .Execute()
                 .Should()
@@ -43,7 +43,7 @@ namespace Microsoft.NET.Build.Tests
                 .CopyTestAsset("WinMDClassLibrary")
                 .WithSource();
 
-            var buildCommand = new BuildCommand(Log, testAsset.TestRoot);
+            var buildCommand = new BuildCommand(testAsset);
             buildCommand
                 .Execute()
                 .Should()
@@ -62,7 +62,7 @@ namespace Microsoft.NET.Build.Tests
                 .WithSource()
                 .WithTargetFramework(targetFramework);
 
-            var buildCommand = new BuildCommand(Log, testAsset.TestRoot);
+            var buildCommand = new BuildCommand(testAsset);
             buildCommand
                 .Execute()
                 .Should()

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAnAppWithLibrariesAndRid.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAnAppWithLibrariesAndRid.cs
@@ -43,7 +43,7 @@ namespace Microsoft.NET.Build.Tests
                 .Should()
                 .Pass();
 
-            var buildCommand = new BuildCommand(Log, projectPath);
+            var buildCommand = new BuildCommand(testAsset, "App");
 
             buildCommand
                 .Execute(msbuildArgs)
@@ -92,7 +92,7 @@ namespace Microsoft.NET.Build.Tests
                 .Should()
                 .Pass();
 
-            var buildCommand = new BuildCommand(Log, projectPath);
+            var buildCommand = new BuildCommand(testAsset, "App");
 
             buildCommand
                 .Execute($"/p:RuntimeIdentifier={runtimeIdentifier}", $"/p:TestRuntimeIdentifier={runtimeIdentifier}", "/p:SelfContained=false")

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAnAppWithLibrariesAndRid.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAnAppWithLibrariesAndRid.cs
@@ -35,9 +35,7 @@ namespace Microsoft.NET.Build.Tests
                 .CopyTestAsset("AppWithLibraryAndRid")
                 .WithSource();
 
-            var projectPath = Path.Combine(testAsset.TestRoot, "App");
-
-            var restoreCommand = new RestoreCommand(Log, projectPath, "App.csproj");
+            var restoreCommand = new RestoreCommand(testAsset, "App");
             restoreCommand
                 .Execute(msbuildArgs)
                 .Should()
@@ -84,9 +82,7 @@ namespace Microsoft.NET.Build.Tests
                 });
             }
 
-            var projectPath = Path.Combine(testAsset.TestRoot, "App");
-
-            var restoreCommand = new RestoreCommand(Log, projectPath, "App.csproj");
+            var restoreCommand = new RestoreCommand(testAsset, "App");
             restoreCommand
                 .Execute($"/p:TestRuntimeIdentifier={runtimeIdentifier}")
                 .Should()

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAnAppWithLibrary.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAnAppWithLibrary.cs
@@ -49,9 +49,7 @@ namespace Microsoft.NET.Build.Tests
 
         void VerifyAppBuilds(TestAsset testAsset)
         {
-            var appProjectDirectory = Path.Combine(testAsset.TestRoot, "TestApp");
-
-            var buildCommand = new BuildCommand(Log, appProjectDirectory);
+            var buildCommand = new BuildCommand(testAsset, "TestApp");
             var outputDirectory = buildCommand.GetOutputDirectory("netcoreapp1.1");
 
             buildCommand
@@ -100,9 +98,7 @@ namespace Microsoft.NET.Build.Tests
                 .CopyTestAsset("KitchenSink")
                 .WithSource();
 
-            var appProjectDirectory = Path.Combine(testAsset.TestRoot, "TestApp");
-
-            var buildCommand = new BuildCommand(Log, appProjectDirectory);
+            var buildCommand = new BuildCommand(testAsset, "TestApp");
             buildCommand
                 .Execute()
                 .Should()
@@ -147,9 +143,7 @@ namespace Microsoft.NET.Build.Tests
                 .CopyTestAsset("AppWithLibrary")
                 .WithSource();
 
-            var appProjectDirectory = Path.Combine(testAsset.TestRoot, "TestApp");
-
-            var buildCommand = new BuildCommand(Log, appProjectDirectory);
+            var buildCommand = new BuildCommand(testAsset, "TestApp");
 
             buildCommand
                 .Execute()
@@ -185,7 +179,7 @@ namespace Microsoft.NET.Build.Tests
                 .CopyTestAsset("AppxReferencingCrossTargeting")
                 .WithSource();
 
-            var buildCommand = new BuildCommand(Log, Path.Combine(asset.TestRoot, "Appx"));
+            var buildCommand = new BuildCommand(asset, "Appx");
 
             buildCommand
                 .Execute()

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAnAppWithSharedProject.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAnAppWithSharedProject.cs
@@ -63,7 +63,7 @@ namespace Microsoft.NET.Build.Tests
                 .CopyTestAsset("AppWithSharedProject")
                 .WithSource();
 
-            var buildCommand = new BuildCommand(Log, testAsset.TestRoot, "TestApp");
+            var buildCommand = new BuildCommand(testAsset, "TestApp");
 
             buildCommand.Execute()
                 .Should()

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAnAppWithTransitiveProjectRefs.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAnAppWithTransitiveProjectRefs.cs
@@ -40,9 +40,7 @@ namespace Microsoft.NET.Build.Tests
 
         void VerifyAppBuilds(TestAsset testAsset)
         {
-            var appProjectDirectory = Path.Combine(testAsset.TestRoot, "TestApp");
-
-            var buildCommand = new BuildCommand(Log, appProjectDirectory);
+            var buildCommand = new BuildCommand(testAsset, "TestApp");
             var outputDirectory = buildCommand.GetOutputDirectory("netcoreapp1.1");
 
             buildCommand
@@ -79,9 +77,7 @@ namespace Microsoft.NET.Build.Tests
                 .CopyTestAsset("AppWithTransitiveProjectRefs")
                 .WithSource();
 
-            var appProjectDirectory = Path.Combine(testAsset.TestRoot, "TestApp");
-
-            var buildCommand = new BuildCommand(Log, appProjectDirectory);
+            var buildCommand = new BuildCommand(testAsset, "TestApp");
 
             buildCommand
                 .Execute()
@@ -123,8 +119,7 @@ namespace Microsoft.NET.Build.Tests
                 .CopyTestAsset("AppWithTransitiveProjectRefs", "BuildAppWithTransitiveProjectRefDisabled")
                 .WithSource();
 
-            var appProjectDirectory = Path.Combine(testAsset.TestRoot, "TestApp");
-            var buildCommand = new BuildCommand(Log, appProjectDirectory);
+            var buildCommand = new BuildCommand(testAsset, "TestApp");
             buildCommand
                 .Execute("/p:DisableTransitiveProjectReferences=true")
                 .Should()

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAnAppWithoutTransitiveProjectRefs.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAnAppWithoutTransitiveProjectRefs.cs
@@ -190,9 +190,7 @@ namespace Microsoft.NET.Build.Tests
             string[] msbuildArguments
             )
         {
-            var appProjectDirectory = Path.Combine(testAsset.TestRoot, "1");
-
-            var buildCommand = new BuildCommand(Log, appProjectDirectory);
+            var buildCommand = new BuildCommand(testAsset, "1");
             var buildResult = buildCommand.ExecuteWithoutRestore(msbuildArguments);
 
             var outputDirectories = targetFrameworks.ToImmutableDictionary(tf => tf, tf => buildCommand.GetOutputDirectory(tf));

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAppsWithFrameworkRefs.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAppsWithFrameworkRefs.cs
@@ -51,8 +51,7 @@ namespace Microsoft.NET.Build.Tests
                 "EntityFrameworkApp.pdb");
 
             // Try running EntityFrameworkApp.exe
-            var appProjectDirectory = Path.Combine(testAsset.TestRoot, "EntityFrameworkApp");
-            var buildCommand = new BuildCommand(Log, appProjectDirectory);
+            var buildCommand = new BuildCommand(testAsset, "EntityFrameworkApp");
             var outputDirectory = buildCommand.GetOutputDirectory("net451", runtimeIdentifier: "win7-x86");
 
             new RunExeCommand(Log, Path.Combine(outputDirectory.FullName, "EntityFrameworkApp.exe"))
@@ -67,9 +66,7 @@ namespace Microsoft.NET.Build.Tests
             string [] buildArgs,
             params string [] expectedFiles)
         {
-            var appProjectDirectory = Path.Combine(testAsset.TestRoot, project);
-
-            var buildCommand = new BuildCommand(Log, appProjectDirectory);
+            var buildCommand = new BuildCommand(testAsset, project);
             var outputDirectory = buildCommand.GetOutputDirectory(targetFramework, runtimeIdentifier: runtimeIdentifier);
 
             buildCommand
@@ -98,9 +95,7 @@ namespace Microsoft.NET.Build.Tests
         private void VerifyClean(TestAsset testAsset, string project, string targetFramework, string runtimeIdentifier,
             params string[] expectedFiles)
         {
-            var appProjectDirectory = Path.Combine(testAsset.TestRoot, project);
-
-            var buildCommand = new BuildCommand(Log, appProjectDirectory);
+            var buildCommand = new BuildCommand(testAsset, project);
             var outputDirectory = buildCommand.GetOutputDirectory(targetFramework, runtimeIdentifier: runtimeIdentifier);
 
             buildCommand

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToControlGeneratedAssemblyInfo.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToControlGeneratedAssemblyInfo.cs
@@ -40,7 +40,7 @@ namespace Microsoft.NET.Build.Tests
                 .CopyTestAsset("HelloWorld", identifier: Path.DirectorySeparatorChar + attributeToOptOut)
                 .WithSource();
 
-            var buildCommand = new BuildCommand(Log, testAsset.TestRoot);
+            var buildCommand = new BuildCommand(testAsset);
             buildCommand
                 .Execute(
                     "/p:Version=1.2.3-beta",
@@ -263,7 +263,7 @@ namespace Microsoft.NET.Build.Tests
                 .CopyTestAsset("HelloWorld", identifier: targetFramework)
                 .WithSource();
 
-            var buildCommand = new BuildCommand(Log, testAsset.TestRoot);
+            var buildCommand = new BuildCommand(testAsset);
             buildCommand
                 .Execute($"/p:OutputType=Library", $"/p:TargetFramework={targetFramework}", $"/p:VersionPrefix=1.2.3")
                 .Should()
@@ -303,7 +303,7 @@ namespace Microsoft.NET.Build.Tests
 
             BuildCommand BuildProject(string versionPrefix)
             {
-                var command = new BuildCommand(Log, testAsset.TestRoot);
+                var command = new BuildCommand(testAsset);
                 command.Execute($"/p:OutputType=Library", $"/p:TargetFramework={targetFramework}", $"/p:VersionPrefix={versionPrefix}")
                        .Should()
                        .Pass();
@@ -342,7 +342,7 @@ namespace Microsoft.NET.Build.Tests
 
             BuildCommand BuildProject(string buildNumber)
             {
-                var command = new BuildCommand(Log, Path.Combine(testAsset.TestRoot, "TestLibrary"));
+                var command = new BuildCommand(testAsset, "TestLibrary");
                 command.Execute($"/p:BuildNumber={buildNumber}")
                        .Should()
                        .Pass();
@@ -367,7 +367,7 @@ namespace Microsoft.NET.Build.Tests
                                 new XAttribute("Include", "Tests"))));
                 });
 
-            var buildCommand = new BuildCommand(Log, testAsset.TestRoot);
+            var buildCommand = new BuildCommand(testAsset);
             buildCommand.Execute().Should().Pass();
 
             var assemblyPath = Path.Combine(buildCommand.GetOutputDirectory("netstandard2.0").FullName, "HelloWorld.dll");
@@ -394,7 +394,7 @@ namespace Microsoft.NET.Build.Tests
                                 new XAttribute("Include", "Tests"))));
                 });
 
-            var buildCommand = new BuildCommand(Log, testAsset.TestRoot);
+            var buildCommand = new BuildCommand(testAsset);
             buildCommand.Execute().Should().Pass();
 
             var assemblyPath = Path.Combine(buildCommand.GetOutputDirectory("netstandard2.0").FullName, "HelloWorld.dll");
@@ -420,7 +420,7 @@ namespace Microsoft.NET.Build.Tests
                                 new XAttribute("Key", "00240000048000009400000006020000002400005253413100040000010001001d3e6bbb36e11ea61ceff6e1022b23dd779fc6230838db2d25a2c7c8433b3fcf86b16c25b281fc3db1027c0675395e7d0548e6add88b6a811962bf958101fa9e243b1618313bee11f5e3b3fefda7b1d1226311b6cc2d07e87ff893ba6890b20082df34a0aac14b605b8be055e81081a626f8c69e9ed4bbaa4eae9f94a35accd2"))));
                 });
 
-            var buildCommand = new BuildCommand(Log, testAsset.TestRoot);
+            var buildCommand = new BuildCommand(testAsset);
             buildCommand.Execute().Should().Pass();
 
             var assemblyPath = Path.Combine(buildCommand.GetOutputDirectory("netstandard2.0").FullName, "HelloWorld.dll");
@@ -447,7 +447,7 @@ namespace Microsoft.NET.Build.Tests
                                 new XAttribute("Include", "Tests"))));
                 });
 
-            var buildCommand = new BuildCommand(Log, testAsset.TestRoot);
+            var buildCommand = new BuildCommand(testAsset);
             buildCommand.Execute().Should().Pass();
 
             var assemblyPath = Path.Combine(buildCommand.GetOutputDirectory("netstandard2.0").FullName, "HelloWorld.dll");
@@ -473,7 +473,7 @@ namespace Microsoft.NET.Build.Tests
                                 new XAttribute("Value", "MetadataValue"))));
                 });
 
-            var buildCommand = new BuildCommand(Log, testAsset.TestRoot);
+            var buildCommand = new BuildCommand(testAsset);
             buildCommand.Execute().Should().Pass();
 
             var assemblyPath = Path.Combine(buildCommand.GetOutputDirectory("netstandard2.0").FullName, "HelloWorld.dll");
@@ -501,7 +501,7 @@ namespace Microsoft.NET.Build.Tests
                                 new XAttribute("Value", "MetadataValue"))));
                 });
 
-            var buildCommand = new BuildCommand(Log, testAsset.TestRoot);
+            var buildCommand = new BuildCommand(testAsset);
             buildCommand.Execute().Should().Pass();
 
             var assemblyPath = Path.Combine(buildCommand.GetOutputDirectory("netstandard2.0").FullName, "HelloWorld.dll");
@@ -537,7 +537,7 @@ namespace Microsoft.NET.Build.Tests
             var testAsset = _testAssetsManager.CreateTestProject(testProject, identifier: referenceAspNetCore.ToString() + referenceExtensionsUserSecrets.ToString())
                 .Restore(Log, testProject.Name);
 
-            var buildCommand = new BuildCommand(Log, testAsset.TestRoot, testProject.Name);
+            var buildCommand = new BuildCommand(testAsset);
 
             buildCommand.Execute()
                 .Should()
@@ -585,7 +585,7 @@ namespace Microsoft.NET.Build.Tests
 
 </Project>
 ");
-            var buildCommand = new BuildCommand(Log, testAsset.TestRoot, testTestProject.Name);
+            var buildCommand = new BuildCommand(testAsset);
 
             buildCommand.Execute("/restore")
                 .Should()
@@ -621,7 +621,7 @@ namespace Microsoft.NET.Build.Tests
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
-            var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var buildCommand = new BuildCommand(testAsset);
             buildCommand.Execute().Should().Pass();
 
             var assemblyPath = Path.Combine(buildCommand.GetOutputDirectory("netcoreapp3.1").FullName, testProject.Name + ".dll");

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToCopyLocalDependencies.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToCopyLocalDependencies.cs
@@ -46,7 +46,7 @@ namespace Microsoft.NET.Build.Tests
              var testProjectInstance = _testAssetsManager
                 .CreateTestProject(testProject);
 
-            var buildCommand = new BuildCommand(Log, testProjectInstance.TestRoot, ProjectName);
+            var buildCommand = new BuildCommand(testProjectInstance);
 
             buildCommand.Execute()
                 .Should()
@@ -91,7 +91,7 @@ namespace Microsoft.NET.Build.Tests
              var testProjectInstance = _testAssetsManager
                 .CreateTestProject(testProject);
 
-            var buildCommand = new BuildCommand(Log, testProjectInstance.TestRoot, ProjectName);
+            var buildCommand = new BuildCommand(testProjectInstance);
 
             buildCommand.Execute().Should().Pass();
 
@@ -128,7 +128,7 @@ namespace Microsoft.NET.Build.Tests
              var testProjectInstance = _testAssetsManager
                 .CreateTestProject(testProject);
 
-            var buildCommand = new BuildCommand(Log, testProjectInstance.TestRoot, ProjectName);
+            var buildCommand = new BuildCommand(testProjectInstance);
 
             buildCommand.Execute()
                 .Should()
@@ -168,7 +168,7 @@ namespace Microsoft.NET.Build.Tests
              var testProjectInstance = _testAssetsManager
                 .CreateTestProject(testProject);
 
-            var buildCommand = new BuildCommand(Log, testProjectInstance.TestRoot, ProjectName);
+            var buildCommand = new BuildCommand(testProjectInstance);
 
             buildCommand.Execute()
                 .Should()
@@ -202,7 +202,7 @@ namespace Microsoft.NET.Build.Tests
              var testProjectInstance = _testAssetsManager
                 .CreateTestProject(testProject);
 
-            var buildCommand = new BuildCommand(Log, testProjectInstance.TestRoot, ProjectName);
+            var buildCommand = new BuildCommand(testProjectInstance);
 
             buildCommand.Execute()
                 .Should()
@@ -239,7 +239,7 @@ namespace Microsoft.NET.Build.Tests
              var testProjectInstance = _testAssetsManager
                 .CreateTestProject(testProject);
 
-            var buildCommand = new BuildCommand(Log, testProjectInstance.TestRoot, ProjectName);
+            var buildCommand = new BuildCommand(testProjectInstance);
 
             buildCommand.Execute()
                 .Should()
@@ -273,7 +273,7 @@ namespace Microsoft.NET.Build.Tests
              var testProjectInstance = _testAssetsManager
                 .CreateTestProject(testProject);
 
-            var buildCommand = new BuildCommand(Log, testProjectInstance.TestRoot, ProjectName);
+            var buildCommand = new BuildCommand(testProjectInstance);
 
             buildCommand.Execute()
                 .Should()
@@ -310,7 +310,7 @@ namespace Microsoft.NET.Build.Tests
              var testProjectInstance = _testAssetsManager
                 .CreateTestProject(testProject);
 
-            var buildCommand = new BuildCommand(Log, testProjectInstance.TestRoot, ProjectName);
+            var buildCommand = new BuildCommand(testProjectInstance);
 
             buildCommand.Execute()
                 .Should()
@@ -346,7 +346,7 @@ namespace Microsoft.NET.Build.Tests
              var testProjectInstance = _testAssetsManager
                 .CreateTestProject(testProject);
 
-            var buildCommand = new BuildCommand(Log, testProjectInstance.TestRoot, ProjectName);
+            var buildCommand = new BuildCommand(testProjectInstance);
 
             buildCommand.Execute()
                 .Should()

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToCopyPPFileToOutput.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToCopyPPFileToOutput.cs
@@ -37,7 +37,7 @@ namespace Microsoft.NET.Build.Tests
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
-            var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var buildCommand = new BuildCommand(testAsset);
             buildCommand.Execute()
                 .Should()
                 .Pass();

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToExcludeTheMainProjectFromTheDepsFile.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToExcludeTheMainProjectFromTheDepsFile.cs
@@ -58,7 +58,7 @@ namespace Microsoft.NET.Build.Tests
                     }
                 });
 
-            var buildCommand = new BuildCommand(Log, testProjectInstance.TestRoot, testProject.Name);
+            var buildCommand = new BuildCommand(testProjectInstance);
 
             buildCommand.Execute()
                 .Should()

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToFilterSatelliteAssemblies.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToFilterSatelliteAssemblies.cs
@@ -51,7 +51,7 @@ namespace Microsoft.NET.Build.Tests
 
             var testProjectInstance = _testAssetsManager.CreateTestProject(testProject, identifier: targetFramework);
 
-            var buildCommand = new BuildCommand(Log, Path.Combine(testProjectInstance.TestRoot, testProject.Name));
+            var buildCommand = new BuildCommand(testProjectInstance);
             var buildResult = buildCommand.Execute();
 
             buildResult.Should().Pass();
@@ -116,7 +116,7 @@ namespace Microsoft.NET.Build.Tests
 
             var testProjectInstance = _testAssetsManager.CreateTestProject(testProject, identifier: targetFramework);
 
-            var buildCommand = new BuildCommand(Log, Path.Combine(testProjectInstance.TestRoot, testProject.Name));
+            var buildCommand = new BuildCommand(testProjectInstance);
             var buildResult = buildCommand.Execute();
 
             buildResult.Should().Pass();

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToPreserveCompilationContextForBuild.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToPreserveCompilationContextForBuild.cs
@@ -55,7 +55,7 @@ namespace Microsoft.NET.Build.Tests
                 testProject,
                 identifier: withoutCopyingRefs.ToString());
 
-            var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var buildCommand = new BuildCommand(testAsset);
 
             buildCommand
                 .Execute()
@@ -101,7 +101,7 @@ namespace Microsoft.NET.Build.Tests
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
-            var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var buildCommand = new BuildCommand(testAsset);
             buildCommand
                 .Execute()
                 .Should()

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToPublishWithGeneratePackageOnBuildAndPackAsTool.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToPublishWithGeneratePackageOnBuildAndPackAsTool.cs
@@ -41,8 +41,7 @@ namespace Microsoft.NET.ToolPack.Tests
                     propertyGroup.Add(new XElement(ns + "PackAsTool", packAsTool.ToString()));
                 });
 
-            var appProjectDirectory = Path.Combine(testAsset.TestRoot);
-            var buildCommand = new BuildCommand(Log, appProjectDirectory);
+            var buildCommand = new BuildCommand(testAsset);
 
             CommandResult result = buildCommand.Execute();
 

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToReferenceAProject.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToReferenceAProject.cs
@@ -115,8 +115,7 @@ namespace Microsoft.NET.Build.Tests
                     .Pass();
             }
 
-            var appProjectDirectory = Path.Combine(testAsset.TestRoot, "Referencer");
-            var buildCommand = new BuildCommand(Log, appProjectDirectory);
+            var buildCommand = new BuildCommand(testAsset, "Referencer");
             var result = buildCommand.Execute();
 
             if (buildSucceeds)
@@ -186,7 +185,7 @@ namespace Microsoft.NET.Build.Tests
                 .WithProjectChanges(project => AddProjectChanges(project, Path.Combine(childAsset.Path, childProject.Name, childProject.Name + ".csproj")));
             File.WriteAllText(Path.Combine(parentAsset.Path, parentProject.Name, contentName), parentProject.Name);
 
-            var buildCommand = new BuildCommand(Log, Path.Combine(parentAsset.Path, parentProject.Name));
+            var buildCommand = new BuildCommand(parentAsset);
             buildCommand.Execute().Should().Pass();
 
             var getValuesCommand = new GetValuesCommand(Log, Path.Combine(parentAsset.Path, parentProject.Name), tfm, "ResultOutput");

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToReferenceAnAssembly.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToReferenceAnAssembly.cs
@@ -944,7 +944,7 @@ public static class Program
 
         private string RestoreAndBuild(TestAsset testAsset, TestProject testProject)
         {
-            var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var buildCommand = new BuildCommand(testAsset);
 
             buildCommand.Execute()
                 .Should()

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToResolveConflicts.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToResolveConflicts.cs
@@ -120,9 +120,7 @@ namespace Microsoft.NET.Build.Tests
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
-            string projectFolder = Path.Combine(testAsset.Path, testProject.Name);
-
-            var buildCommand = new BuildCommand(Log, projectFolder);
+            var buildCommand = new BuildCommand(testAsset);
 
             buildCommand
                 .Execute()
@@ -166,9 +164,7 @@ namespace Microsoft.NET.Build.Tests
                         new XAttribute("Private", "true")));
                 });
 
-            string projectFolder = Path.Combine(testAsset.Path, testProject.Name);
-
-            var buildCommand = new BuildCommand(Log, projectFolder);
+            var buildCommand = new BuildCommand(testAsset);
 
             buildCommand
                 .Execute()
@@ -192,9 +188,7 @@ namespace Microsoft.NET.Build.Tests
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
-            string projectFolder = Path.Combine(testAsset.Path, testProject.Name);
-
-            var buildCommand = new BuildCommand(Log, projectFolder);
+            var buildCommand = new BuildCommand(testAsset);
 
             buildCommand
                 .Execute()
@@ -225,7 +219,7 @@ namespace Microsoft.NET.Build.Tests
                                     new XAttribute("Include", "Microsoft.AspNetCore.App")));
                 });
 
-            var buildCommand = new BuildCommand(Log, testAsset.TestRoot, testProject.Name);
+            var buildCommand = new BuildCommand(testAsset);
 
             buildCommand
                 .Execute()

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToRunFromMSBuildTarget.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToRunFromMSBuildTarget.cs
@@ -31,7 +31,7 @@ namespace Microsoft.NET.Build.Tests
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
-            var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var buildCommand = new BuildCommand(testAsset);
             buildCommand
                 .Execute()
                 .Should()

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToSetPropertiesInDirectoryBuildProps.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToSetPropertiesInDirectoryBuildProps.cs
@@ -55,7 +55,7 @@ namespace Microsoft.NET.Build.Tests
 
             string projectFolder = Path.Combine(testAsset.Path, project.Name);
 
-            var buildCommand = new BuildCommand(Log, projectFolder);
+            var buildCommand = new BuildCommand(testAsset);
 
             buildCommand
                 .Execute()

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToTargetNet471.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToTargetNet471.cs
@@ -57,7 +57,7 @@ namespace Microsoft.NET.Build.Tests
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
-            var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var buildCommand = new BuildCommand(testAsset);
 
             buildCommand
                 .Execute("/v:normal")
@@ -98,7 +98,7 @@ namespace Microsoft.NET.Build.Tests
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject, "net471_ref_ns20");
 
-            var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var buildCommand = new BuildCommand(testAsset);
 
             buildCommand
                 .Execute("/v:normal")
@@ -134,7 +134,7 @@ namespace Microsoft.NET.Build.Tests
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject, testProject.Name);
 
-            var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var buildCommand = new BuildCommand(testAsset);
 
             buildCommand
                 .Execute("/v:normal")
@@ -182,7 +182,7 @@ namespace Microsoft.NET.Build.Tests
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject, "net471_ref_ns16");
 
-            var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var buildCommand = new BuildCommand(testAsset);
 
             buildCommand
                 .Execute("/v:normal")
@@ -234,7 +234,7 @@ namespace Microsoft.NET.Build.Tests
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject, "net471_ref_net471_net461");
 
-            var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var buildCommand = new BuildCommand(testAsset);
 
             buildCommand
                 .Execute("/v:normal")
@@ -272,7 +272,7 @@ namespace Microsoft.NET.Build.Tests
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject, "net471_with_override_property");
 
-            var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var buildCommand = new BuildCommand(testAsset);
 
             buildCommand
                 .Execute("/v:normal")
@@ -341,7 +341,7 @@ public static class Program
                     }
                 });
 
-            var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var buildCommand = new BuildCommand(testAsset);
 
             buildCommand
                 .Execute()
@@ -490,7 +490,7 @@ public static class NS16LibClass
                                 }
                             });
 
-            var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var buildCommand = new BuildCommand(testAsset);
 
             buildCommand
                 .Execute("/v:m")
@@ -597,7 +597,7 @@ public class Startup
                     }
                 });
 
-            var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var buildCommand = new BuildCommand(testAsset);
 
             buildCommand.Execute().Should().Pass();
         }

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToUseContentFiles.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToUseContentFiles.cs
@@ -55,7 +55,7 @@ namespace {project.Name}
             var asset = _testAssetsManager
                 .CreateTestProject(project);
 
-            var cmd = new BuildCommand(Log, Path.Combine(asset.Path, project.Name));
+            var cmd = new BuildCommand(asset);
             cmd.Execute().Should().Pass();
 
             cmd.GetOutputDirectory(targetFramework)

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToVerifyNuGetReferenceCompat.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToVerifyNuGetReferenceCompat.cs
@@ -121,7 +121,7 @@ namespace Microsoft.NET.Build.Tests
                 referencerRestoreCommand.Execute().Should().Fail();
             }
 
-            var referencerBuildCommand = new BuildCommand(Log, Path.Combine(referencerTestAsset.TestRoot, referencerProject.Name));
+            var referencerBuildCommand = new BuildCommand(referencerTestAsset);
             var referencerBuildResult = referencerBuildCommand.Execute();
 
             if (buildSucceeds)
@@ -150,9 +150,7 @@ namespace Microsoft.NET.Build.Tests
 
             restoreCommand.Execute().Should().Pass();
 
-            var buildCommand = new BuildCommand(
-                Log,
-                Path.Combine(testProjectTestAsset.TestRoot, testProjectName));
+            var buildCommand = new BuildCommand(testProjectTestAsset);
             buildCommand.Execute().Should().Pass();
         }
 
@@ -204,7 +202,7 @@ namespace Microsoft.NET.Build.Tests
             var restoreCommand = testProjectTestAsset.GetRestoreCommand(Log, relativePath: testProjectName);
             restoreCommand.Execute().Should().Pass();
 
-            var buildCommand = new BuildCommand(Log, Path.Combine(testProjectTestAsset.TestRoot, testProjectName));
+            var buildCommand = new BuildCommand(testProjectTestAsset);
             buildCommand.Execute().Should().Pass();
 
             var referencedDll = buildCommand.GetOutputDirectory("netcoreapp3.0").File("net462_net472_pkg.dll").FullName;

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToVerifyProjectReferenceCompat.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToVerifyProjectReferenceCompat.cs
@@ -79,9 +79,7 @@ namespace Microsoft.NET.Build.Tests
                 restoreCommand.Execute().Should().Fail();
             }
 
-            var appProjectDirectory = Path.Combine(testAsset.TestRoot, referencerProject.Name);
-
-            var buildCommand = new BuildCommand(Log, appProjectDirectory);
+            var buildCommand = new BuildCommand(testAsset);
 
             var result = buildCommand.Execute();
 

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThereAreDefaultItems.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThereAreDefaultItems.cs
@@ -442,9 +442,7 @@ namespace Microsoft.NET.Build.Tests
                 .WithSource()
                 .WithProjectChanges(projectChanges);
 
-            var libraryProjectDirectory = Path.Combine(testAsset.TestRoot, "TestLibrary");
-
-            var buildCommand = new BuildCommand(Log, libraryProjectDirectory);
+            var buildCommand = new BuildCommand(testAsset, "TestLibrary");
 
             WriteFile(Path.Combine(buildCommand.ProjectRootPath, "ProjectRoot.txt"), "ProjectRoot");
             WriteFile(Path.Combine(buildCommand.ProjectRootPath, "Subfolder", "ProjectSubfolder.txt"), "ProjectSubfolder");
@@ -512,7 +510,7 @@ namespace Microsoft.NET.Build.Tests
                     itemGroup.Add(new XElement(ns + "Compile", new XAttribute("Include", @"**\*.cs")));
                 });
 
-            var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var buildCommand = new BuildCommand(testAsset);
 
             WriteFile(Path.Combine(buildCommand.ProjectRootPath, "Class1.cs"), "public class Class1 {}");
 
@@ -554,7 +552,7 @@ namespace Microsoft.NET.Build.Tests
                         new XAttribute("Include", "netstandard.Library"), new XAttribute("Version", "1.6.1")));
                 });
 
-            var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var buildCommand = new BuildCommand(testAsset);
 
             buildCommand
                 .Execute()
@@ -594,7 +592,7 @@ namespace Microsoft.NET.Build.Tests
                 .Pass()
                 .And.HaveStdOutContaining("NETSDK1086");
 
-            var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var buildCommand = new BuildCommand(testAsset);
 
             buildCommand
                 .Execute()
@@ -663,7 +661,7 @@ namespace Microsoft.NET.Build.Tests
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject, identifier: disableImplicitFrameworkReferences.ToString());
 
-            var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var buildCommand = new BuildCommand(testAsset);
 
             buildCommand
                 .Execute()
@@ -704,7 +702,7 @@ public class Class1
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
-            var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var buildCommand = new BuildCommand(testAsset);
 
             buildCommand
                 .Execute()

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThereAreDefaultItems.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThereAreDefaultItems.cs
@@ -584,7 +584,7 @@ namespace Microsoft.NET.Build.Tests
                         new XAttribute("Include", "Microsoft.NETCore.App")));
                 });
 
-            var restoreCommand = new RestoreCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var restoreCommand = new RestoreCommand(testAsset);
 
             restoreCommand
                 .Execute()
@@ -629,7 +629,7 @@ namespace Microsoft.NET.Build.Tests
                         new XAttribute("Include", "Microsoft.NETCore.App")));
                 });
 
-            var restoreCommand = new RestoreCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var restoreCommand = new RestoreCommand(testAsset);
 
             restoreCommand
                 .Execute()

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenWeWantToRequireWindowsForDesktopApps.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenWeWantToRequireWindowsForDesktopApps.cs
@@ -30,7 +30,7 @@ namespace Microsoft.NET.Build.Tests
 
             var asset = CreateWindowsDesktopSdkTestAsset(ProjectName, uiFrameworkProperty);
 
-            var command = new BuildCommand(Log, Path.Combine(asset.Path, ProjectName));
+            var command = new BuildCommand(asset);
 
             command
                 .Execute()
@@ -47,7 +47,7 @@ namespace Microsoft.NET.Build.Tests
 
             var asset = CreateWindowsDesktopSdkTestAsset(ProjectName, uiFrameworkProperty);
 
-            var command = new BuildCommand(Log, Path.Combine(asset.Path, ProjectName));
+            var command = new BuildCommand(asset);
 
             command
                 .Execute()
@@ -67,7 +67,7 @@ namespace Microsoft.NET.Build.Tests
 
             var asset = CreateWindowsDesktopReferenceTestAsset(ProjectName, desktopFramework);
 
-            var command = new BuildCommand(Log, Path.Combine(asset.Path, ProjectName));
+            var command = new BuildCommand(asset);
 
             command
                 .Execute()
@@ -85,7 +85,7 @@ namespace Microsoft.NET.Build.Tests
 
             var asset = CreateWindowsDesktopReferenceTestAsset(ProjectName, desktopFramework);
 
-            var command = new BuildCommand(Log, Path.Combine(asset.Path, ProjectName));
+            var command = new BuildCommand(asset);
 
             command
                 .Execute()
@@ -112,7 +112,7 @@ namespace Microsoft.NET.Build.Tests
 
             var asset = _testAssetsManager.CreateTestProject(testProject);
 
-            var command = new BuildCommand(Log, Path.Combine(asset.Path, ProjectName));
+            var command = new BuildCommand(asset);
 
             command
                 .Execute()

--- a/src/Tests/Microsoft.NET.Build.Tests/ImplicitAspNetVersions.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/ImplicitAspNetVersions.cs
@@ -41,7 +41,7 @@ namespace Microsoft.NET.Build.Tests
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject, identifier: aspnetPackageName);
 
-            var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var buildCommand = new BuildCommand(testAsset);
 
             buildCommand
                 .Execute()
@@ -75,7 +75,7 @@ namespace Microsoft.NET.Build.Tests
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject, identifier: aspnetPackageName);
 
-            var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var buildCommand = new BuildCommand(testAsset);
 
             buildCommand
                 .Execute()
@@ -107,7 +107,7 @@ namespace Microsoft.NET.Build.Tests
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject, identifier: aspnetPackageName);
 
-            var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var buildCommand = new BuildCommand(testAsset);
 
             buildCommand
                 .Execute()
@@ -138,7 +138,7 @@ namespace Microsoft.NET.Build.Tests
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject, identifier: targetFramework);
 
-            var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var buildCommand = new BuildCommand(testAsset);
 
             buildCommand
                 .Execute()
@@ -175,9 +175,9 @@ namespace Microsoft.NET.Build.Tests
                 .Pass()
                 .And
                 .NotHaveStdOutContaining("NETSDK1071");
-                
 
-            var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+
+            var buildCommand = new BuildCommand(testAsset);
 
             buildCommand
                 .Execute()
@@ -216,7 +216,7 @@ namespace Microsoft.NET.Build.Tests
                 .And
                 .HaveStdOutContaining("NETSDK1079");
 
-            var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var buildCommand = new BuildCommand(testAsset);
 
             buildCommand.Execute()
                 .Should()
@@ -252,7 +252,7 @@ namespace Microsoft.NET.Build.Tests
                 .And
                 .HaveStdOutContaining("NETSDK1080");
 
-            var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var buildCommand = new BuildCommand(testAsset);
 
             buildCommand.Execute()
                 .Should()

--- a/src/Tests/Microsoft.NET.Build.Tests/ImplicitAspNetVersions.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/ImplicitAspNetVersions.cs
@@ -168,7 +168,7 @@ namespace Microsoft.NET.Build.Tests
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
-            var restoreCommand = new RestoreCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var restoreCommand = new RestoreCommand(testAsset);
             restoreCommand
                 .Execute()
                 .Should()
@@ -209,7 +209,7 @@ namespace Microsoft.NET.Build.Tests
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject, identifier: $"{useWebSdk}_{packageVersion}");
 
-            var restoreCommand = new RestoreCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var restoreCommand = new RestoreCommand(testAsset);
             restoreCommand.Execute()
                 .Should()
                 .Fail()
@@ -245,7 +245,7 @@ namespace Microsoft.NET.Build.Tests
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject, identifier: $"{useWebSdk}_{packageVersion}");
 
-            var restoreCommand = new RestoreCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var restoreCommand = new RestoreCommand(testAsset);
             restoreCommand.Execute()
                 .Should()
                 .Pass()

--- a/src/Tests/Microsoft.NET.Build.Tests/KnownRuntimePackTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/KnownRuntimePackTests.cs
@@ -1,0 +1,143 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+using FluentAssertions;
+using Microsoft.NET.TestFramework;
+using Microsoft.NET.TestFramework.Assertions;
+using Microsoft.NET.TestFramework.Commands;
+using Microsoft.NET.TestFramework.ProjectConstruction;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.NET.Build.Tests
+{
+    public class KnownRuntimePackTests : SdkTest
+    {
+        public KnownRuntimePackTests(ITestOutputHelper log) : base(log)
+        {
+        }
+
+        [Fact]
+        public void BuildSucceedsWithRuntimePackWithDifferentLabel()
+        {
+            var testProject = new TestProject()
+            {
+                TargetFrameworks = "net5.0",
+                IsSdkProject = true,
+                IsExe = true,
+                RuntimeIdentifier = EnvironmentInfo.GetCompatibleRid()
+            };
+
+            var testAsset = _testAssetsManager.CreateTestProject(testProject);
+
+            var knownRuntimePack = CreateTestKnownRuntimePack();
+
+            AddItem(testAsset, knownRuntimePack);
+
+            var buildCommand = new BuildCommand(testAsset);
+
+            buildCommand
+                .Execute()
+                .Should()
+                .Pass();
+        }
+
+        [Fact]
+        public void DuplicateRuntimePackCausesFailure()
+        {
+            var testProject = new TestProject()
+            {
+                TargetFrameworks = "net5.0",
+                IsSdkProject = true,
+                IsExe = true,
+                RuntimeIdentifier = EnvironmentInfo.GetCompatibleRid()
+            };
+
+            var testAsset = _testAssetsManager.CreateTestProject(testProject);
+
+            var knownRuntimePack = CreateTestKnownRuntimePack();
+            knownRuntimePack.Attribute("RuntimePackLabels").Value = "";
+
+            AddItem(testAsset, knownRuntimePack);
+
+            var buildCommand = new BuildCommand(testAsset);
+
+            buildCommand
+                .Execute()
+                .Should()
+                .Fail()
+                .And
+                .HaveStdOutContaining("NETSDK1133");
+        }
+
+        [Fact]
+        public void RuntimePackWithLabelIsSelected()
+        {
+            var testProject = new TestProject()
+            {
+                TargetFrameworks = "net5.0",
+                IsSdkProject = true,
+                IsExe = true,
+                RuntimeIdentifier = EnvironmentInfo.GetCompatibleRid()
+            };
+
+            var testAsset = _testAssetsManager.CreateTestProject(testProject);
+
+            var knownRuntimePack = CreateTestKnownRuntimePack();
+
+            AddItem(testAsset, knownRuntimePack);
+
+            var frameworkReferenceUpdate = new XElement("FrameworkReference",
+                new XAttribute("Update", "Microsoft.NETCore.App"),
+                new XAttribute("RuntimePackLabels", "Mono"));
+
+            AddItem(testAsset, frameworkReferenceUpdate);
+
+            var getValuesCommand = new GetValuesCommand(testAsset, "RuntimePack", GetValuesCommand.ValueType.Item)
+            {
+                DependsOnTargets = "ProcessFrameworkReferences",
+                ShouldRestore = false
+            };
+
+            getValuesCommand
+                .Execute()
+                .Should()
+                .Pass();
+
+            //  StartsWith instead of exact match because current RID is likely to be more specific than the runtime pack RID
+            getValuesCommand.GetValues().Should().Contain(rp => rp.StartsWith("Microsoft.NETCore.App.Runtime.Mono."));
+
+        }
+
+        private XElement CreateTestKnownRuntimePack()
+        {
+            var knownRuntimePack = new XElement("KnownRuntimePack",
+                        new XAttribute("Include", "Microsoft.NETCore.App"),
+                        new XAttribute("TargetFramework", "net5.0"),
+                        new XAttribute("RuntimeFrameworkName", "Microsoft.NETCore.App"),
+                        new XAttribute("DefaultRuntimeFrameworkVersion", "5.0.0-preview1"),
+                        new XAttribute("LatestRuntimeFrameworkVersion", "5.0.0-preview1.1"),
+                        new XAttribute("RuntimePackNamePatterns", "Microsoft.NETCore.App.Runtime.Mono.**RID**"),
+                        new XAttribute("RuntimePackRuntimeIdentifiers", "linux-arm;linux-arm64;linux-musl-arm64;linux-musl-x64;linux-x64;osx-x64;rhel.6-x64;tizen.4.0.0-armel;tizen.5.0.0-armel;win-arm;win-arm64;win-x64;win-x86;ios-arm64;ios-arm;ios-x64;ios-x86;tvos-arm64;tvos-x64;android-arm64;android-arm;android-x64;android-x86;browser-wasm"),
+                        new XAttribute("IsTrimmable", "true"),
+                        new XAttribute("RuntimePackLabels", "Mono"));
+
+            return knownRuntimePack;
+        }
+
+        private void AddItem(TestAsset testAsset, XElement item)
+        {
+            testAsset.WithProjectChanges(project =>
+            {
+                var ns = project.Root.Name.Namespace;
+
+                var itemGroup = new XElement(ns + "ItemGroup");
+                project.Root.Add(itemGroup);
+                itemGroup.Add(item);
+            });
+        }
+    }
+}

--- a/src/Tests/Microsoft.NET.Build.Tests/Net50Targeting.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/Net50Targeting.cs
@@ -32,7 +32,7 @@ namespace Microsoft.NET.Build.Tests
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject, testProject.Name);
 
-            var buildCommand = new BuildCommand(Log, testAsset.TestRoot, testProject.Name);
+            var buildCommand = new BuildCommand(testAsset);
 
             buildCommand.Execute()
                 .Should()

--- a/src/Tests/Microsoft.NET.Build.Tests/NonCopyLocalProjectReferenceTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/NonCopyLocalProjectReferenceTests.cs
@@ -53,7 +53,7 @@ namespace Microsoft.NET.Build.Tests
                        .SingleOrDefault()
                        ?.Add(new XAttribute("Private", "False")));
 
-            var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var buildCommand = new BuildCommand(testAsset);
             buildCommand.Execute().Should().Pass();
 
             var outputDirectory = buildCommand.GetOutputDirectory(targetFramework);

--- a/src/Tests/Microsoft.NET.Pack.Tests/GivenThatWeWantToPackAHelloWorldProject.cs
+++ b/src/Tests/Microsoft.NET.Pack.Tests/GivenThatWeWantToPackAHelloWorldProject.cs
@@ -73,7 +73,7 @@ namespace Microsoft.NET.Pack.Tests
                     project.Root.Add(XElement.Parse(@"<Target Name=""InvokeBuild"" DependsOnTargets=""Build"" BeforeTargets=""Pack"" />"));
                 });
 
-            new BuildCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name))
+            new BuildCommand(testAsset)
                 .Execute()
                 .Should()
                 .Pass();

--- a/src/Tests/Microsoft.NET.Publish.Tests/FilesCopiedToPublishDirTests.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/FilesCopiedToPublishDirTests.cs
@@ -58,7 +58,7 @@ namespace Microsoft.NET.Publish.Tests
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
-            var restoreCommand = new RestoreCommand(Log, testAsset.Path, testProject.Name);
+            var restoreCommand = new RestoreCommand(testAsset);
             restoreCommand
                 .Execute()
                 .Should()

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatAPublishedDepsJsonShouldContainVersionInformation.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatAPublishedDepsJsonShouldContainVersionInformation.cs
@@ -118,7 +118,7 @@ namespace Microsoft.NET.Publish.Tests
             MSBuildCommand command;
             if (build)
             {
-                command = new BuildCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+                command = new BuildCommand(testAsset);
             }
             else
             {

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAHelloWorldProject.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAHelloWorldProject.cs
@@ -400,7 +400,7 @@ public static class Program
                 .CopyTestAsset("DeployProjectReferencingSdkProject")
                 .WithSource();
 
-            var buildCommand = new BuildCommand(Log, helloWorldAsset.TestRoot, Path.Combine("DeployProj", "Deploy.proj"));
+            var buildCommand = new BuildCommand(helloWorldAsset, Path.Combine("DeployProj", "Deploy.proj"));
 
             buildCommand
                 .Execute()
@@ -483,7 +483,7 @@ public static class Program
                     project.Root.Add(XElement.Parse(@"<Target Name=""InvokeBuild"" DependsOnTargets=""Build"" BeforeTargets=""Publish"" />"));
                 });
 
-            new BuildCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name))
+            new BuildCommand(testAsset)
                 .Execute()
                 .Should()
                 .Pass();

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAProjectWithDependencies.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAProjectWithDependencies.cs
@@ -274,7 +274,7 @@ namespace Microsoft.NET.Publish.Tests
             var appAsset = _testAssetsManager.CreateTestProject(appProject, identifier: identifier);
             var appSourcePath  = Path.Combine(appAsset.TestRoot, "TestApp");
 
-            new RestoreCommand(Log, appSourcePath).Execute().Should().Pass();
+            new RestoreCommand(appAsset, "TestApp").Execute().Should().Pass();
             var appPublishCommand = new PublishCommand(Log, appSourcePath);
             var appPublishResult = appPublishCommand.Execute("/p:" + property);
             appPublishResult.Should().Pass();

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishASelfContainedApp.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishASelfContainedApp.cs
@@ -78,7 +78,7 @@ namespace Microsoft.NET.Publish.Tests
                     $"/p:TargetFramework={TargetFramework}",
                     $"/p:RuntimeIdentifier={runtimeIdentifier}"};
 
-            var restoreCommand = new RestoreCommand(Log, testAsset.TestRoot);
+            var restoreCommand = new RestoreCommand(testAsset);
 
             restoreCommand.Execute(msbuildArgs);
 
@@ -145,7 +145,7 @@ namespace Microsoft.NET.Publish.Tests
 
             var projectRoot = Path.Combine(testAsset.TestRoot, "main");
 
-            new RestoreCommand(Log, projectRoot).Execute(args);
+            new RestoreCommand(testAsset, "main").Execute(args);
 
             new PublishCommand(Log, projectRoot)
                 .Execute(args)

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAToolProjectWithPackagedShim.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAToolProjectWithPackagedShim.cs
@@ -60,7 +60,7 @@ namespace Microsoft.NET.Publish.Tests
         public void It_contains_dependencies_shims_with_no_build()
         {
             var testAsset = SetupTestAsset();
-            var buildCommand = new BuildCommand(Log, testAsset.TestRoot);
+            var buildCommand = new BuildCommand(testAsset);
             buildCommand.Execute();
 
             var publishCommand = new PublishCommand(Log, testAsset.TestRoot);

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAWebApp.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAWebApp.cs
@@ -31,7 +31,7 @@ namespace Microsoft.NET.Publish.Tests
                 "-p:Configuration=Release"
             };
 
-            var restoreCommand = new RestoreCommand(Log, testAsset.TestRoot);
+            var restoreCommand = new RestoreCommand(testAsset);
             restoreCommand
                 .Execute(args)
                 .Should()

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAnAppWithLibrariesAndRid.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAnAppWithLibrariesAndRid.cs
@@ -110,7 +110,7 @@ namespace Microsoft.NET.Publish.Tests
                 msbuildArgs.Add("/p:TargetLatestRuntimePatch=true");
             }
 
-            var restoreCommand = new RestoreCommand(Log, projectPath, "App.csproj");
+            var restoreCommand = new RestoreCommand(testAsset, "App");
             restoreCommand
                 .Execute(msbuildArgs.ToArray())
                 .Should()

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishWithGeneratePackageOnBuildAndPackAsTool.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishWithGeneratePackageOnBuildAndPackAsTool.cs
@@ -70,8 +70,7 @@ namespace Microsoft.NET.ToolPack.Tests
                     propertyGroup.Add(new XElement(ns + "PackAsTool", packAsTool.ToString()));
                 });
 
-            var appProjectDirectory = Path.Combine(testAsset.TestRoot);
-            var buildCommand = new BuildCommand(Log, appProjectDirectory);
+            var buildCommand = new BuildCommand(testAsset);
 
             CommandResult result = buildCommand.Execute();
 

--- a/src/Tests/Microsoft.NET.Publish.Tests/PublishDepsFilePathTests.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/PublishDepsFilePathTests.cs
@@ -45,7 +45,7 @@ namespace Microsoft.NET.Publish.Tests
         {
             var testProject = SetupProject(singleFile: true);
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
-            var restoreCommand = new RestoreCommand(Log, testAsset.Path, testProject.Name);
+            var restoreCommand = new RestoreCommand(testAsset);
             restoreCommand
                 .Execute()
                 .Should()

--- a/src/Tests/Microsoft.NET.Publish.Tests/PublishItemsOutputGroupTests.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/PublishItemsOutputGroupTests.cs
@@ -39,7 +39,7 @@ namespace Microsoft.NET.Publish.Tests
             var testProject = this.SetupProject(specifyRid, singleFile);
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
-            var restoreCommand = new RestoreCommand(Log, testAsset.Path, testProject.Name);
+            var restoreCommand = new RestoreCommand(testAsset);
             restoreCommand
                 .Execute()
                 .Should()
@@ -104,7 +104,7 @@ namespace Microsoft.NET.Publish.Tests
             var testProject = this.SetupProject();
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
-            var restoreCommand = new RestoreCommand(Log, testAsset.Path, testProject.Name);
+            var restoreCommand = new RestoreCommand(testAsset);
             restoreCommand
                 .Execute()
                 .Should()

--- a/src/Tests/Microsoft.NET.Publish.Tests/PublishItemsOutputGroupTests.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/PublishItemsOutputGroupTests.cs
@@ -110,7 +110,7 @@ namespace Microsoft.NET.Publish.Tests
                 .Should()
                 .Pass();
 
-            var buildCommand = new BuildCommand(Log, testAsset.Path, testProject.Name);
+            var buildCommand = new BuildCommand(testAsset);
             buildCommand
                 .Execute("/p:RuntimeIdentifier=win-x86;DesignTimeBuild=true", "/t:PublishItemsOutputGroup")
                 .Should()

--- a/src/Tests/Microsoft.NET.Publish.Tests/RuntimeIdentifiersTests.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/RuntimeIdentifiersTests.cs
@@ -56,7 +56,7 @@ namespace Microsoft.NET.Publish.Tests
 
             foreach (var runtimeIdentifier in runtimeIdentifiers)
             {
-                var buildCommand = new BuildCommand(Log, testAsset.Path, testProject.Name);
+                var buildCommand = new BuildCommand(testAsset);
 
                 buildCommand
                     .ExecuteWithoutRestore($"/p:RuntimeIdentifier={runtimeIdentifier}")
@@ -110,7 +110,7 @@ namespace Microsoft.NET.Publish.Tests
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject, identifier: publishNoBuild ? "nobuild" : string.Empty);
 
-            var buildCommand = new BuildCommand(Log, testAsset.Path, testProject.Name);
+            var buildCommand = new BuildCommand(testAsset);
 
             buildCommand
                 .Execute()
@@ -168,15 +168,12 @@ namespace Microsoft.NET.Publish.Tests
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
-            var buildCommand = new BuildCommand(Log, testAsset.Path, testProject.Name);
+            var buildCommand = new BuildCommand(testAsset);
 
             buildCommand
                 .Execute()
                 .Should()
                 .Pass();
-
-
-
 
         }
     }

--- a/src/Tests/Microsoft.NET.Publish.Tests/RuntimeIdentifiersTests.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/RuntimeIdentifiersTests.cs
@@ -47,7 +47,7 @@ namespace Microsoft.NET.Publish.Tests
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
-            var restoreCommand = new RestoreCommand(Log, testAsset.Path, testProject.Name);
+            var restoreCommand = new RestoreCommand(testAsset);
 
             restoreCommand
                 .Execute()

--- a/src/Tests/Microsoft.NET.Restore.Tests/GivenThatWeWantAutomaticTargetingPackReferences.cs
+++ b/src/Tests/Microsoft.NET.Restore.Tests/GivenThatWeWantAutomaticTargetingPackReferences.cs
@@ -197,7 +197,7 @@ namespace Microsoft.NET.Restore.Tests
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
-            var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var buildCommand = new BuildCommand(testAsset);
             if (TestProject.ReferenceAssembliesAreInstalled(TargetDotNetFrameworkVersion.Version472))
             {
                 buildCommand.Execute()

--- a/src/Tests/Microsoft.NET.Restore.Tests/GivenThatWeWantToRestoreProjectsWithPackageDowngrades.cs
+++ b/src/Tests/Microsoft.NET.Restore.Tests/GivenThatWeWantToRestoreProjectsWithPackageDowngrades.cs
@@ -46,7 +46,7 @@ namespace Microsoft.NET.Restore.Tests
                 .Should().Fail()
                 .And.HaveStdOutContaining("NU1605");
 
-            var buildCommand = new BuildCommand(Log, Path.Combine(testAsset.Path, testProjectName));
+            var buildCommand = new BuildCommand(testAsset);
             buildCommand
                 .Execute()
                 .Should().Fail()

--- a/src/Tests/Microsoft.NET.TestFramework/Commands/BuildCommand.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/Commands/BuildCommand.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.ComponentModel;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
@@ -12,8 +13,15 @@ namespace Microsoft.NET.TestFramework.Commands
 {
     public sealed class BuildCommand : MSBuildCommand
     {
+        //  Encourage use of the other overload, which is generally simpler to use
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public BuildCommand(ITestOutputHelper log, string projectRootPath, string relativePathToProject = null)
             : base(log, "Build", projectRootPath, relativePathToProject)
+        {
+        }
+
+        public BuildCommand(TestAsset testAsset, string relativePathToProject = null)
+            : base(testAsset, "Build", relativePathToProject)
         {
         }
     }

--- a/src/Tests/Microsoft.NET.TestFramework/Commands/GetValuesCommand.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/Commands/GetValuesCommand.cs
@@ -31,11 +31,26 @@ namespace Microsoft.NET.TestFramework.Commands
 
         public List<string> MetadataNames { get; set; } = new List<string>();
 
+        public bool ShouldRestore { get; set; } = true;
+
+        protected override bool ExecuteWithRestoreByDefault => ShouldRestore;
+
         public GetValuesCommand(ITestOutputHelper log, string projectPath, string targetFramework,
             string valueName, ValueType valueType = ValueType.Property)
             : base(log, "WriteValuesToFile", projectPath, relativePathToProject: null)
         {
             _targetFramework = targetFramework;
+
+            _valueName = valueName;
+            _valueType = valueType;
+        }
+
+        public GetValuesCommand(TestAsset testAsset,
+            string valueName, ValueType valueType = ValueType.Property,
+            string targetFramework = null)
+            : base(testAsset, "WriteValuesToFile", relativePathToProject: null)
+        {
+            _targetFramework = targetFramework ?? testAsset.TestProject?.TargetFrameworks;
 
             _valueName = valueName;
             _valueType = valueType;

--- a/src/Tests/Microsoft.NET.TestFramework/Commands/MSBuildCommand.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/Commands/MSBuildCommand.cs
@@ -7,6 +7,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using Xunit.Abstractions;
 
 namespace Microsoft.NET.TestFramework.Commands
@@ -31,6 +32,11 @@ namespace Microsoft.NET.TestFramework.Commands
             _projectRootPath = projectRootPath;
 
             ProjectFile = FindProjectFile(ref _projectRootPath, relativePathToProject);
+        }
+
+        public MSBuildCommand(TestAsset testAsset, string target, string relativePathToProject = null)
+            : this(testAsset.Log, target, testAsset.TestRoot, relativePathToProject ?? testAsset.TestProject?.Name)
+        {
         }
 
         internal static string FindProjectFile(ref string projectRootPath, string relativePathToProject)

--- a/src/Tests/Microsoft.NET.TestFramework/Commands/RestoreCommand.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/Commands/RestoreCommand.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.IO;
 using System.Linq;
 using Microsoft.DotNet.Cli.Utils;
@@ -12,8 +13,15 @@ namespace Microsoft.NET.TestFramework.Commands
 {
     public sealed class RestoreCommand : MSBuildCommand
     {
+        //  Encourage use of the other overload, which is generally simpler to use
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public RestoreCommand(ITestOutputHelper log, string projectPath, string relativePathToProject = null)
             : base(log, "Restore", projectPath, relativePathToProject)
+        {
+        }
+
+        public RestoreCommand(TestAsset testAsset, string relativePathToProject = null)
+            : base(testAsset, "Restore", relativePathToProject)
         {
         }
 

--- a/src/Tests/Microsoft.NET.TestFramework/ProjectConstruction/TestProject.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/ProjectConstruction/TestProject.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Xml.Linq;
 using Microsoft.Build.Utilities;
 using NuGet.Frameworks;
@@ -10,6 +11,14 @@ namespace Microsoft.NET.TestFramework.ProjectConstruction
 {
     public class TestProject
     {
+        public TestProject([CallerMemberName] string name = null)
+        {
+            if (name != null)
+            {
+                Name = name;
+            }
+        }
+
         public string Name { get; set; }
 
         public bool IsSdkProject { get; set; }

--- a/src/Tests/Microsoft.NET.TestFramework/SdkTest.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/SdkTest.cs
@@ -11,7 +11,7 @@ namespace Microsoft.NET.TestFramework
 {
     public abstract class SdkTest
     {
-        protected TestAssetsManager _testAssetsManager = new TestAssetsManager();
+        protected TestAssetsManager _testAssetsManager;
 
         protected bool UsingFullFrameworkMSBuild => TestContext.Current.ToolsetUnderTest.ShouldUseFullFrameworkMSBuild;
 
@@ -20,6 +20,7 @@ namespace Microsoft.NET.TestFramework
         protected SdkTest(ITestOutputHelper log)
         {
             Log = log;
+            _testAssetsManager = new TestAssetsManager(log);
         }
 
         protected static void WaitForUtcNowToAdvance()

--- a/src/Tests/Microsoft.NET.TestFramework/TestAsset.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/TestAsset.cs
@@ -9,6 +9,7 @@ using Microsoft.NET.TestFramework.Assertions;
 using Microsoft.NET.TestFramework.Commands;
 using System.Collections.Generic;
 using Xunit.Abstractions;
+using Microsoft.NET.TestFramework.ProjectConstruction;
 
 namespace Microsoft.NET.TestFramework
 {
@@ -20,17 +21,24 @@ namespace Microsoft.NET.TestFramework
 
         public string TestRoot => Path;
 
-        internal TestAsset(string testDestination, string sdkVersion) : base(testDestination, sdkVersion)
+        public ITestOutputHelper Log { get; }
+
+        //  The TestProject from which this asset was created, if any
+        public TestProject TestProject { get; set; }
+
+        internal TestAsset(string testDestination, string sdkVersion, ITestOutputHelper log) : base(testDestination, sdkVersion)
         {
+            Log = log;
         }
 
-        internal TestAsset(string testAssetRoot, string testDestination, string sdkVersion) : base(testDestination, sdkVersion)
+        internal TestAsset(string testAssetRoot, string testDestination, string sdkVersion, ITestOutputHelper log) : base(testDestination, sdkVersion)
         {
             if (string.IsNullOrEmpty(testAssetRoot))
             {
                 throw new ArgumentException("testAssetRoot");
             }
 
+            Log = log;
             _testAssetRoot = testAssetRoot;
         }
 

--- a/src/Tests/Microsoft.NET.TestFramework/TestAssetsManager.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/TestAssetsManager.cs
@@ -8,6 +8,7 @@ using System.IO;
 using System.Runtime.CompilerServices;
 using System.Security.Cryptography;
 using System.Text;
+using Xunit.Abstractions;
 
 namespace Microsoft.NET.TestFramework
 {
@@ -17,9 +18,12 @@ namespace Microsoft.NET.TestFramework
 
         private List<String> TestDestinationDirectories { get; } = new List<string>();
 
-        public TestAssetsManager()
+        protected ITestOutputHelper Log { get; }
+
+        public TestAssetsManager(ITestOutputHelper log)
         {
             var testAssetsDirectory = TestContext.Current.TestAssetsDirectory;
+            Log = log;
 
             if (!Directory.Exists(testAssetsDirectory))
             {
@@ -41,7 +45,7 @@ namespace Microsoft.NET.TestFramework
                 GetTestDestinationDirectoryPath(testProjectName, callingMethod, identifier);
             TestDestinationDirectories.Add(testDestinationDirectory);
 
-            var testAsset = new TestAsset(testProjectDirectory, testDestinationDirectory, TestContext.Current.SdkVersion);
+            var testAsset = new TestAsset(testProjectDirectory, testDestinationDirectory, TestContext.Current.SdkVersion, Log);
             return testAsset;
         }
 
@@ -55,7 +59,8 @@ namespace Microsoft.NET.TestFramework
                 GetTestDestinationDirectoryPath(testProject.Name, callingMethod, identifier);
             TestDestinationDirectories.Add(testDestinationDirectory);
 
-            var testAsset = new TestAsset(testDestinationDirectory, TestContext.Current.SdkVersion);
+            var testAsset = new TestAsset(testDestinationDirectory, TestContext.Current.SdkVersion, Log);
+            testAsset.TestProject = testProject;
 
             Stack<TestProject> projectStack = new Stack<TestProject>();
             projectStack.Push(testProject);

--- a/src/Tests/Microsoft.NET.ToolPack.Tests/GivenThatWeWantToPackAToolProjectWithGeneratePackageOnBuild.cs
+++ b/src/Tests/Microsoft.NET.ToolPack.Tests/GivenThatWeWantToPackAToolProjectWithGeneratePackageOnBuild.cs
@@ -48,8 +48,7 @@ namespace Microsoft.NET.ToolPack.Tests
         public void It_builds_successfully()
         {
             TestAsset testAsset = SetupAndRestoreTestAsset();
-            var appProjectDirectory = Path.Combine(testAsset.TestRoot, "App");
-            var buildCommand = new BuildCommand(Log, appProjectDirectory);
+            var buildCommand = new BuildCommand(testAsset, "App");
 
             CommandResult result = buildCommand.Execute();
 
@@ -64,7 +63,7 @@ namespace Microsoft.NET.ToolPack.Tests
         {
             TestAsset testAsset = SetupAndRestoreTestAsset();
             var appProjectDirectory = Path.Combine(testAsset.TestRoot, "App");
-            var buildCommand = new BuildCommand(Log, appProjectDirectory);
+            var buildCommand = new BuildCommand(testAsset, "App");
             buildCommand.Execute();
 
             var packCommand = new PackCommand(Log, appProjectDirectory);

--- a/src/Tests/Microsoft.NET.ToolPack.Tests/GivenThatWeWantToPackAToolProjectWithPackagedShim.cs
+++ b/src/Tests/Microsoft.NET.ToolPack.Tests/GivenThatWeWantToPackAToolProjectWithPackagedShim.cs
@@ -246,7 +246,7 @@ namespace Microsoft.NET.ToolPack.Tests
 
             _testRoot = helloWorldAsset.TestRoot;
 
-            var buildCommand = new BuildCommand(Log, helloWorldAsset.TestRoot);
+            var buildCommand = new BuildCommand(helloWorldAsset);
             buildCommand.Execute().Should().Pass();
 
             var outputDirectory = buildCommand.GetOutputDirectory(targetFramework);
@@ -270,7 +270,7 @@ namespace Microsoft.NET.ToolPack.Tests
         {
             var testAsset = CreateTestAsset(multiTarget, nameof(It_contains_shim_with_no_build) + multiTarget + targetFramework, targetFramework);
 
-            var buildCommand = new BuildCommand(Log, testAsset.TestRoot);
+            var buildCommand = new BuildCommand(testAsset);
             buildCommand.Execute().Should().Pass();
 
             var packCommand = new PackCommand(Log, testAsset.TestRoot);
@@ -333,7 +333,7 @@ namespace Microsoft.NET.ToolPack.Tests
 
             var testRoot = helloWorldAsset.TestRoot;
 
-            var buildCommand = new BuildCommand(Log, helloWorldAsset.TestRoot);
+            var buildCommand = new BuildCommand(helloWorldAsset);
             buildCommand.Execute("/p:PackageId=wrongpackagefirstbuild");
 
             var packCommand = new PackCommand(Log, helloWorldAsset.TestRoot);

--- a/src/Tests/Microsoft.NET.ToolPack.Tests/GivenThatWeWantToPackAToolSelfContainedProject.cs
+++ b/src/Tests/Microsoft.NET.ToolPack.Tests/GivenThatWeWantToPackAToolSelfContainedProject.cs
@@ -41,7 +41,7 @@ namespace Microsoft.NET.ToolPack.Tests
         {
             TestAsset helloWorldAsset = CreateAsset();
 
-            var packCommand = new BuildCommand(Log, helloWorldAsset.TestRoot);
+            var packCommand = new BuildCommand(helloWorldAsset);
 
             CommandResult result = packCommand.Execute();
             result.ExitCode.Should().Be(0);

--- a/src/Tests/dotnet-back-compat.Tests/GivenThatWeWantToBeBackwardsCompatibleWith1xProjects.cs
+++ b/src/Tests/dotnet-back-compat.Tests/GivenThatWeWantToBeBackwardsCompatibleWith1xProjects.cs
@@ -33,7 +33,7 @@ namespace Microsoft.DotNet.Cli.Build.Tests
             //   Replace the 'TargetFramework'
             ChangeProjectTargetFramework(Path.Combine(testInstance.Path, $"{testAppName}.csproj"), target);
 
-            var buildCommand = new BuildCommand(Log, testInstance.Path);
+            var buildCommand = new BuildCommand(testInstance);
 
             buildCommand
                 .Execute()
@@ -62,7 +62,7 @@ namespace Microsoft.DotNet.Cli.Build.Tests
             //   Replace the 'TargetFramework'
             ChangeProjectTargetFramework(Path.Combine(testInstance.Path, $"{testAppName}.csproj"), target);
 
-            new BuildCommand(Log, testInstance.Path)
+            new BuildCommand(testInstance)
                 .Execute()
                 .Should().Pass();
 
@@ -80,7 +80,7 @@ namespace Microsoft.DotNet.Cli.Build.Tests
 
             NuGetConfigWriter.Write(testInstance.Path, TestContext.Current.TestPackages);
 
-            new RestoreCommand(Log, testInstance.Path)
+            new RestoreCommand(testInstance)
                 .Execute()
                 .Should()
                 .Pass();

--- a/src/Tests/dotnet-list-package.Tests/GivenDotnetListPackage.cs
+++ b/src/Tests/dotnet-list-package.Tests/GivenDotnetListPackage.cs
@@ -24,11 +24,12 @@ namespace Microsoft.DotNet.Cli.List.Package.Tests
         [Fact]
         public void RequestedAndResolvedVersionsMatch()
         {
-            var testAsset = "TestAppSimple";
-            var projectDirectory = _testAssetsManager
-                .CopyTestAsset(testAsset)
-                .WithSource()
-                .Path;
+            var testAssetName = "TestAppSimple";
+            var testAsset = _testAssetsManager
+                .CopyTestAsset(testAssetName)
+                .WithSource();
+
+            var projectDirectory = testAsset.Path;
 
             var packageName = "Newtonsoft.Json";
             var packageVersion = "9.0.1";
@@ -37,7 +38,7 @@ namespace Microsoft.DotNet.Cli.List.Package.Tests
                 .Execute("add", "package", packageName, "--version", packageVersion);
             cmd.Should().Pass();
 
-            new RestoreCommand(Log, projectDirectory)
+            new RestoreCommand(testAsset)
                 .Execute()
                 .Should()
                 .Pass()
@@ -55,14 +56,14 @@ namespace Microsoft.DotNet.Cli.List.Package.Tests
         [Fact]
         public void ItListsAutoReferencedPackages()
         {
-            var testAsset = "TestAppSimple";
-            var projectDirectory = _testAssetsManager
-                .CopyTestAsset(testAsset)
+            var testAssetName = "TestAppSimple";
+            var testAsset = _testAssetsManager
+                .CopyTestAsset(testAssetName)
                 .WithSource()
-                .WithProjectChanges(ChangeTargetFrameworkTo2_1)
-                .Path;
+                .WithProjectChanges(ChangeTargetFrameworkTo2_1);
+            var projectDirectory = testAsset.Path;
 
-            new RestoreCommand(Log, projectDirectory)
+            new RestoreCommand(testAsset)
                 .Execute()
                 .Should()
                 .Pass()
@@ -89,12 +90,12 @@ namespace Microsoft.DotNet.Cli.List.Package.Tests
         public void ItRunOnSolution()
         {
             var sln = "TestAppWithSlnAndSolutionFolders";
-            var projectDirectory = _testAssetsManager
+            var testAsset = _testAssetsManager
                 .CopyTestAsset(sln)
-                .WithSource()
-                .Path;
+                .WithSource();
+            var projectDirectory = testAsset.Path;
 
-            new RestoreCommand(Log, Path.Combine(projectDirectory, "App.sln"))
+            new RestoreCommand(testAsset, "App.sln")
                 .Execute()
                 .Should()
                 .Pass()
@@ -129,13 +130,13 @@ namespace Microsoft.DotNet.Cli.List.Package.Tests
         [Fact]
         public void ItListsTransitivePackage()
         {
-            var testAsset = "NewtonSoftDependentProject";
-            var projectDirectory = _testAssetsManager
-                .CopyTestAsset(testAsset)
-                .WithSource()
-                .Path;
+            var testAssetName = "NewtonSoftDependentProject";
+            var testAsset = _testAssetsManager
+                .CopyTestAsset(testAssetName)
+                .WithSource();
+            var projectDirectory = testAsset.Path;
 
-            new RestoreCommand(Log, projectDirectory)
+            new RestoreCommand(testAsset)
                 .Execute()
                 .Should()
                 .Pass()
@@ -167,13 +168,13 @@ namespace Microsoft.DotNet.Cli.List.Package.Tests
         [InlineData("--framework net451", "[net451]", "[netcoreapp3.0]")]
         public void ItListsValidFrameworks(string args, string shouldInclude, string shouldntInclude)
         {
-            var testAsset = "MSBuildAppWithMultipleFrameworks";
-            var projectDirectory = _testAssetsManager
-                .CopyTestAsset(testAsset)
-                .WithSource()
-                .Path;
+            var testAssetName = "MSBuildAppWithMultipleFrameworks";
+            var testAsset = _testAssetsManager
+                .CopyTestAsset(testAssetName)
+                .WithSource();
+            var projectDirectory = testAsset.Path;
 
-            new RestoreCommand(Log, projectDirectory)
+            new RestoreCommand(testAsset)
                 .Execute()
                 .Should()
                 .Pass()
@@ -206,13 +207,13 @@ namespace Microsoft.DotNet.Cli.List.Package.Tests
         [Fact]
         public void ItDoesNotAcceptInvalidFramework()
         {
-            var testAsset = "MSBuildAppWithMultipleFrameworks";
-            var projectDirectory = _testAssetsManager
-                .CopyTestAsset(testAsset)
-                .WithSource()
-                .Path;
+            var testAssetName = "MSBuildAppWithMultipleFrameworks";
+            var testAsset = _testAssetsManager
+                .CopyTestAsset(testAssetName)
+                .WithSource();
+            var projectDirectory = testAsset.Path;
 
-            new RestoreCommand(Log, projectDirectory)
+            new RestoreCommand(testAsset)
                 .Execute()
                 .Should()
                 .Pass();
@@ -227,13 +228,13 @@ namespace Microsoft.DotNet.Cli.List.Package.Tests
         [Fact]
         public void ItListsFSharpProject()
         {
-            var testAsset = "FSharpTestAppSimple";
-            var projectDirectory = _testAssetsManager
-                .CopyTestAsset(testAsset)
-                .WithSource()
-                .Path;
+            var testAssetName = "FSharpTestAppSimple";
+            var testAsset = _testAssetsManager
+                .CopyTestAsset(testAssetName)
+                .WithSource();
+            var projectDirectory = testAsset.Path;
 
-            new RestoreCommand(Log, projectDirectory)
+            new RestoreCommand(testAsset)
                 .Execute()
                 .Should()
                 .Pass()

--- a/src/Tests/dotnet-publish.Tests/GivenDotnetPublishPublishesProjects.cs
+++ b/src/Tests/dotnet-publish.Tests/GivenDotnetPublishPublishesProjects.cs
@@ -30,7 +30,7 @@ namespace Microsoft.DotNet.Cli.Publish.Tests
 
             var testProjectDirectory = testInstance.Path;
 
-            new RestoreCommand(Log, testProjectDirectory)
+            new RestoreCommand(testInstance)
                 .Execute()
                 .Should().Pass();
 

--- a/src/Tests/dotnet-publish.Tests/GivenDotnetPublishPublishesProjects.cs
+++ b/src/Tests/dotnet-publish.Tests/GivenDotnetPublishPublishesProjects.cs
@@ -287,7 +287,7 @@ namespace Microsoft.DotNet.Cli.Publish.Tests
 
             var rootPath = testInstance.Path;
 
-            new BuildCommand(Log, rootPath)
+            new BuildCommand(testInstance)
                 .Execute()
                 .Should()
                 .Pass();

--- a/src/Tests/dotnet-run.Tests/GivenDotnetRootEnv.cs
+++ b/src/Tests/dotnet-run.Tests/GivenDotnetRootEnv.cs
@@ -72,7 +72,7 @@ namespace Microsoft.DotNet.Cli.Run.Tests
                 .WithSource()
                 .Restore(Log);
 
-            new BuildCommand(Log, testAsset.TestRoot)
+            new BuildCommand(testAsset)
                 .Execute()
                 .Should()
                 .Pass();

--- a/src/Tests/dotnet-run.Tests/GivenDotnetRunRunsCsProj.cs
+++ b/src/Tests/dotnet-run.Tests/GivenDotnetRunRunsCsProj.cs
@@ -32,7 +32,7 @@ namespace Microsoft.DotNet.Cli.Run.Tests
 
             var testProjectDirectory = testInstance.Path;
 
-            new BuildCommand(Log, testProjectDirectory)
+            new BuildCommand(testInstance)
                 .Execute()
                 .Should().Pass();
 
@@ -148,7 +148,7 @@ namespace Microsoft.DotNet.Cli.Run.Tests
             var testInstance = _testAssetsManager.CopyTestAsset("MSBuildTestApp")
                 .WithSource();
 
-            new BuildCommand(Log, testInstance.Path)
+            new BuildCommand(testInstance)
                 .Execute()
                 .Should().Pass();
 

--- a/src/Tests/dotnet-store.Tests/GivenDotnetStoresAndPublishesProjects.cs
+++ b/src/Tests/dotnet-store.Tests/GivenDotnetStoresAndPublishesProjects.cs
@@ -38,7 +38,7 @@ namespace Microsoft.DotNet.Cli.Publish.Tests
             var profileProjectPath = _testAssetsManager.CopyTestAsset(profileProjectName).WithSource().Path;
             var profileProject = Path.Combine(profileProjectPath, $"{profileProjectName}.xml");
 
-            new RestoreCommand(Log, testProjectDirectory)
+            new RestoreCommand(testInstance)
                 .Execute()
                 .Should().Pass();
 
@@ -133,7 +133,7 @@ namespace Microsoft.DotNet.Cli.Publish.Tests
             var profileProject1 = Path.Combine(profileProjectPath1, $"{profileProjectName1}.xml");
             var profileFilter1 = Path.Combine(profileProjectPath1, "FluentFilterProfile.xml");
 
-            new RestoreCommand(Log, testProjectDirectory)
+            new RestoreCommand(testInstance)
                 .Execute()
                 .Should().Pass();
 

--- a/src/Tests/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestFromCsprojForMultipleTFM.cs
+++ b/src/Tests/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestFromCsprojForMultipleTFM.cs
@@ -70,7 +70,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
             var testProjectDirectory = testInstance.Path;
 
             // Restore project XunitMulti
-            new RestoreCommand(Log, testProjectDirectory)
+            new RestoreCommand(testInstance)
                 .Execute()
                 .Should()
                 .Pass();

--- a/src/Tests/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestfromCsproj.cs
+++ b/src/Tests/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestfromCsproj.cs
@@ -126,7 +126,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
             var testProjectDirectory = testInstance.Path;
 
             // Restore project XunitCore
-            new RestoreCommand(Log, testProjectDirectory)
+            new RestoreCommand(testInstance)
                 .Execute()
                 .Should()
                 .Pass();
@@ -568,7 +568,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
             var testProjectDirectory = testInstance.Path;
 
             // Restore project VSTestCore
-            new RestoreCommand(Log, testProjectDirectory)
+            new RestoreCommand(testInstance)
                 .Execute()
                 .Should()
                 .Pass();

--- a/src/Tests/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestfromCsprojWithCorrectTestRunParameters.cs
+++ b/src/Tests/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestfromCsprojWithCorrectTestRunParameters.cs
@@ -104,7 +104,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
             var testProjectDirectory = testInstance.Path;
 
             // Restore project VSTestCore
-            new RestoreCommand(Log, testProjectDirectory)
+            new RestoreCommand(testInstance)
                 .Execute()
                 .Should()
                 .Pass();

--- a/src/Tests/dotnet-vstest.Tests/VSTestTests.cs
+++ b/src/Tests/dotnet-vstest.Tests/VSTestTests.cs
@@ -106,7 +106,7 @@ namespace Microsoft.DotNet.Cli.VSTest.Tests
             var testProjectDirectory = testInstance.Path;
 
             // Restore project VSTestCore
-            new RestoreCommand(Log, testProjectDirectory)
+            new RestoreCommand(testInstance)
                 .Execute()
                 .Should()
                 .Pass();

--- a/src/Tests/dotnet-vstest.Tests/VSTestTests.cs
+++ b/src/Tests/dotnet-vstest.Tests/VSTestTests.cs
@@ -25,14 +25,15 @@ namespace Microsoft.DotNet.Cli.VSTest.Tests
         public void TestsFromAGivenContainerShouldRunWithExpectedOutput()
         {
             var testAppName = "VSTestCore";
-            var testRoot = _testAssetsManager.CopyTestAsset(testAppName)
+            var testAsset = _testAssetsManager.CopyTestAsset(testAppName)
                 .WithSource()
-                .WithVersionVariables()
-                .Path;
+                .WithVersionVariables();
+
+            var testRoot = testAsset.Path;
 
             var configuration = Environment.GetEnvironmentVariable("CONFIGURATION") ?? "Debug";
 
-            new BuildCommand(Log, testRoot)
+            new BuildCommand(testAsset)
                 .Execute()
                 .Should().Pass();
 

--- a/src/Tests/dotnet.Tests/CommandTests/BuildServerShutdownCommandTests.cs
+++ b/src/Tests/dotnet.Tests/CommandTests/BuildServerShutdownCommandTests.cs
@@ -176,7 +176,7 @@ namespace Microsoft.DotNet.Tests.Commands
                 .CopyTestAsset("TestRazorApp")
                 .WithSource();
 
-            new BuildCommand(Log, testInstance.TestRoot)
+            new BuildCommand(testInstance)
                 .WithEnvironmentVariable(BuildServerProvider.PidFileDirectoryVariableName, pidDirectory)
                 .Execute($"/p:_RazorBuildServerPipeName={pipeName}")
                 .Should()

--- a/src/Tests/dotnet.Tests/GivenThatDotNetRunsCommands.cs
+++ b/src/Tests/dotnet.Tests/GivenThatDotNetRunsCommands.cs
@@ -28,7 +28,7 @@ namespace Microsoft.DotNet.Tests
             var testInstance = _testAssetsManager.CopyTestAsset("TestProjectWithUnresolvedPlatformDependency", testAssetSubdirectory: "NonRestoredTestProjects")
                             .WithSource();
 
-            new RestoreCommand(Log, testInstance.Path)
+            new RestoreCommand(testInstance)
                 .Execute("/p:SkipInvalidConfigurations=true")
                 .Should()
                 .Fail();

--- a/src/Tests/dotnet.Tests/GivenThatICareAboutVBApps.cs
+++ b/src/Tests/dotnet.Tests/GivenThatICareAboutVBApps.cs
@@ -26,7 +26,7 @@ namespace Microsoft.DotNet.Tests
             var testInstance = _testAssetsManager.CopyTestAsset("VBTestApp")
                 .WithSource();
 
-            new BuildCommand(Log, testInstance.Path)
+            new BuildCommand(testInstance)
                 .Execute()
                 .Should().Pass();
         }

--- a/src/Tests/dotnet.Tests/PackagedCommandTests.cs
+++ b/src/Tests/dotnet.Tests/PackagedCommandTests.cs
@@ -38,7 +38,7 @@ namespace Microsoft.DotNet.Tests
 
             NuGetConfigWriter.Write(testInstance.Path, TestContext.Current.TestPackages);
 
-            new BuildCommand(Log, testInstance.Path)
+            new BuildCommand(testInstance)
                 .Execute()
                 .Should().Pass();
 
@@ -72,7 +72,7 @@ namespace Microsoft.DotNet.Tests
                     toolPrefersCLIRuntime ? "dotnet-portable-v1-prefercli" : "dotnet-portable-v1";
             });
 
-            new BuildCommand(Log, testInstance.Path)
+            new BuildCommand(testInstance)
                 .Execute()
                 .Should().Pass();
 
@@ -150,7 +150,7 @@ namespace Microsoft.DotNet.Tests
 
             NuGetConfigWriter.Write(testInstance.Path, TestContext.Current.TestPackages);
 
-            new BuildCommand(Log, testInstance.Path)
+            new BuildCommand(testInstance)
                 .Execute()
                 .Should().Pass();
 
@@ -236,7 +236,7 @@ namespace Microsoft.DotNet.Tests
 
             NuGetConfigWriter.Write(testInstance.Path, TestContext.Current.TestPackages);
 
-            new BuildCommand(Log, testInstance.Path)
+            new BuildCommand(testInstance)
                 .Execute()
                 .Should().Pass();
 

--- a/src/Tests/dotnet.Tests/PackagedCommandTests.cs
+++ b/src/Tests/dotnet.Tests/PackagedCommandTests.cs
@@ -129,7 +129,7 @@ namespace Microsoft.DotNet.Tests
                                           toolName);
 
 
-            new RestoreCommand(Log, testInstance.Path)
+            new RestoreCommand(testInstance)
                 .Execute()
                 .Should()
                 .Pass();


### PR DESCRIPTION
This PR will:

- Allow available runtime packs to be specified in `KnownRuntimePack` items, separately from `KnownFrameworkReference` items
- Allow a set of runtime labels to be specified on a `FrameworkReference` via `RuntimePackLabels` metadata
- Require that the resolved runtime pack has the same set of labels specified in the `FrameworkReference`
- In the test framework, refactor `BuildCommand` and `RestoreCommand` so they can be used with less boilerplate code

This will allow separate runtime packs to be specified for Mono, and for projects to opt in to using the Mono runtime packs.  It could also be used for other options, such as AOT policy.  See dotnet/runtime#34193.

A `KnownRuntimePack` item has much of the same information as a `KnownFrameworkReference`.  It can look like this:

```xml
    <KnownRuntimePack Include="Microsoft.NETCore.App"
                      TargetFramework="net5.0"
                      RuntimeFrameworkName="Microsoft.NETCore.App"
                      DefaultRuntimeFrameworkVersion="5.0.0-preview1"
                      LatestRuntimeFrameworkVersion="5.0.0-preview1.1"
                      RuntimePackNamePatterns="Microsoft.NETCore.App.Runtime.Mono.**RID**"
                      RuntimePackRuntimeIdentifiers="linux-arm;linux-arm64;linux-musl-arm64;linux-musl-x64;linux-x64;osx-x64;rhel.6-x64;tizen.4.0.0-armel;tizen.5.0.0-armel;win-arm;win-arm64;win-x64;win-x86;ios-arm64;ios-arm;ios-x64;ios-x86;tvos-arm64;tvos-x64;android-arm64;android-arm;android-x64;android-x86;browser-wasm"
                      IsTrimmable="true"
                      RuntimePackLabels="Mono"
                      />
```

This would be selected when the `FrameworkReference` has metadata that specifies `RuntimePackLabels="Mono"`.  This can be done with the following:

```xml
<FrameworkReference Update="Microsoft.NETCore.App"
                     RuntimePackLabels="Mono" />
```

Note that this isn't the primary method by which end-users should opt into a specific runtime pack, but rather the underlying mechanism we would use to implement user-facing properties such as `UseMonoRuntime`.