### PR TITLE
Use NonShipping=true as part of the ManifestArtifactData

### DIFF
--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -30,9 +30,9 @@
        a relative path inside the blob storage. -->
   <Target Name="PublishToolsetAssets" DependsOnTargets="ReadToolsetVersion" BeforeTargets="Publish" Condition="'$(PublishToAzure)' == 'true'">
     <ItemGroup>
-      <ToolsetAssetsToPushToBlobFeed Include="@(ToolsetAssetsToPublish)" IsShipping="false" >
+      <ToolsetAssetsToPushToBlobFeed Include="@(ToolsetAssetsToPublish)">
         <RelativeBlobPath>$(BlobStoragePartialRelativePath)/$(ToolsetVersionValue)/$([System.String]::Copy('%(Filename)%(Extension)').Replace('\' ,'/'))</RelativeBlobPath>
-        <ManifestArtifactData>ShipInstaller=dotnetcli</ManifestArtifactData>
+        <ManifestArtifactData>NonShipping=true</ManifestArtifactData>
       </ToolsetAssetsToPushToBlobFeed>
     </ItemGroup>
 

--- a/src/Layout/redist/targets/GetRuntimeInformation.targets
+++ b/src/Layout/redist/targets/GetRuntimeInformation.targets
@@ -1,6 +1,5 @@
 <Project>
   <Target Name="GetCurrentRuntimeInformation"
-          DependsOnTargets="GetCoreSdkGitCommitInfo"
           BeforeTargets="Build">
 
     <PropertyGroup>

--- a/src/Layout/redist/targets/GetRuntimeInformation.targets
+++ b/src/Layout/redist/targets/GetRuntimeInformation.targets
@@ -1,5 +1,6 @@
 <Project>
   <Target Name="GetCurrentRuntimeInformation"
+          DependsOnTargets="GetCoreSdkGitCommitInfo"
           BeforeTargets="Build">
 
     <PropertyGroup>

--- a/src/Layout/redist/targets/Version.targets
+++ b/src/Layout/redist/targets/Version.targets
@@ -1,22 +1,4 @@
 <Project>
-  <Target Name="GetCoreSdkGitCommitInfo">
-    <Exec Command="git rev-list --count HEAD"
-          ConsoleToMSBuild="true"
-          Condition=" '$(GitCommitCount)' == '' ">
-      <Output TaskParameter="ConsoleOutput" PropertyName="GitCommitCount" />
-    </Exec>
-
-    <Exec Command="git rev-parse HEAD"
-          ConsoleToMSBuild="true"
-          Condition=" '$(GitCommitHash)' == '' ">
-      <Output TaskParameter="ConsoleOutput" PropertyName="GitCommitHash" />
-    </Exec>
-
-    <PropertyGroup>
-      <GitCommitCount>$(GitCommitCount.PadLeft(6,'0'))</GitCommitCount>
-    </PropertyGroup>
-  </Target>
-
   <PropertyGroup>
     <ArtifactNameSdk>dotnet-toolset-internal</ArtifactNameSdk>
     <ArtifactNameSdkLanguagePack>dotnet-toolset-langpack</ArtifactNameSdkLanguagePack>

--- a/src/Layout/redist/targets/Version.targets
+++ b/src/Layout/redist/targets/Version.targets
@@ -1,4 +1,12 @@
 <Project>
+  <Target Name="GetCoreSdkGitCommitInfo">
+    <Exec Command="git rev-parse HEAD"
+          ConsoleToMSBuild="true"
+          Condition=" '$(GitCommitHash)' == '' ">
+      <Output TaskParameter="ConsoleOutput" PropertyName="GitCommitHash" />
+    </Exec>
+  </Target>
+
   <PropertyGroup>
     <ArtifactNameSdk>dotnet-toolset-internal</ArtifactNameSdk>
     <ArtifactNameSdkLanguagePack>dotnet-toolset-langpack</ArtifactNameSdkLanguagePack>


### PR DESCRIPTION
- Remove ShipInstaller (unused)
- Cleanup the git commit depth code