### PR TITLE
Remove left over references to PlatformAbstractions

### DIFF
--- a/src/Cli/Microsoft.DotNet.Cli.Utils/WindowsRegistryEnvironmentPathEditor.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/WindowsRegistryEnvironmentPathEditor.cs
@@ -7,7 +7,6 @@ using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Security.Principal;
-using Microsoft.DotNet.PlatformAbstractions;
 using Microsoft.Win32;
 
 namespace Microsoft.DotNet.Cli.Utils

--- a/src/Layout/redist/targets/GenerateLayout.targets
+++ b/src/Layout/redist/targets/GenerateLayout.targets
@@ -61,7 +61,6 @@
     <ItemGroup>
       <!-- https://github.com/microsoft/vstest/issues/1886 -->
       <TestCliBitsToExclude Include="$(TestCliNuGetDirectory)NewtonSoft.Json.dll" />
-      <TestCliBitsToExclude Include="$(TestCliNuGetDirectory)Microsoft.DotNet.PlatformAbstractions.dll" />
       <TestCliBitsToExclude Include="$(TestCliNuGetDirectory)Microsoft.Extensions.DependencyModel.dll" />
       <TestCliBitsToExclude Include="$(TestCliNuGetDirectory)System.Memory.dll" />
       <TestCliBitsToExclude Include="$(TestCliNuGetDirectory)System.Runtime.CompilerServices.Unsafe.dll" />

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ProjectContext.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ProjectContext.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Build.Framework;
-using Microsoft.DotNet.PlatformAbstractions;
 using NuGet.Packaging.Core;
 using NuGet.ProjectModel;
 using System;


### PR DESCRIPTION
I checked, and dotnet/vstest doesn't reference/include `Microsoft.DotNet.PlatformAbstractions.dll` anymore, so the line in GenerateLayout.targets can be removed.

The reason the `using Microsoft.DotNet.PlatformAbstractions;` still works is because there is an obsolete type in the `Microsoft.Extensions.DependencyModel` library under that namespace.