### PR TITLE
Do not process known framework references that were not included.

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/ProcessFrameworkReferences.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ProcessFrameworkReferences.cs
@@ -103,7 +103,9 @@ namespace Microsoft.NET.Build.Tasks
             bool windowsOnlyErrorLogged = false;
             foreach (var knownFrameworkReference in knownFrameworkReferencesForTargetFramework)
             {
-                frameworkReferenceMap.TryGetValue(knownFrameworkReference.Name, out ITaskItem frameworkReference);
+                // If the framework reference is not actually requested, discard it.
+                if (!frameworkReferenceMap.TryGetValue(knownFrameworkReference.Name, out ITaskItem frameworkReference))
+                    continue;
 
                 // Handle Windows-only frameworks on non-Windows platforms
                 if (knownFrameworkReference.IsWindowsOnly &&


### PR DESCRIPTION
While investigating #4078, I stumbled upon the following findings in a build log:

![image](https://user-images.githubusercontent.com/12659251/83691810-7bc36a00-a5fb-11ea-8e25-04a745428512.png)

The output `TargetingPack` item contains WinForms, WPF, _and even ASP.NET Core_, while the input `FrameworkReference` item only asks for WinForms and .NET Core.

This PR will stop the `ProcessFrameworkReferences` task from blindly choosing all `KnownFrameworkReferences` with a matching framework version and could pave the way to an actual fix of dotnet/winforms#2426.