### PR TITLE
Upgrade mac pool and ubuntu pool

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -10,7 +10,7 @@ jobs:
 - job: debug_osx
   displayName: OSX Debug
   pool:
-    vmImage: macOS-10.13
+    vmImage: macOS-10.15
   variables:
     DOTNET_RUNTIME_ID: osx.10.12-x64
   steps:
@@ -40,6 +40,12 @@ jobs:
 - job: debug_ubuntu1604
   displayName: Ubuntu16.04 Debug
   pool:
+    ${{ if eq(variables['System.TeamProject'], 'public') }}:
+      name: NetCorePublic-Pool
+      queue: BuildPool.Ubuntu.1604.Amd64.Open
+    ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+      name: NetCoreInternal-Pool
+      queue: BuildPool.Ubuntu.1604.Amd64
     vmImage: ubuntu-16.04
   steps:
   - checkout: self
@@ -126,7 +132,7 @@ jobs:
 - job: release_osx
   displayName: OSX Release
   pool:
-    vmImage: macOS-10.13
+    vmImage: macOS-10.15
   variables:
     DOTNET_RUNTIME_ID: osx.10.12-x64
   steps:
@@ -156,6 +162,12 @@ jobs:
 - job: release_ubuntu1604
   displayName: Ubuntu16.04 Release
   pool:
+    ${{ if eq(variables['System.TeamProject'], 'public') }}:
+      name: NetCorePublic-Pool
+      queue: BuildPool.Ubuntu.1604.Amd64.Open
+    ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+      name: NetCoreInternal-Pool
+      queue: BuildPool.Ubuntu.1604.Amd64
     vmImage: ubuntu-16.04
   steps:
   - checkout: self


### PR DESCRIPTION
SDK only use mac to test. So it is safe to upgrade to an higher version.

Use a different ubuntu pool to avoid disk out of space