### PR TITLE
Include diagnostic level metadata on ResolvedPackageReference

### DIFF
--- a/src/Tasks/Common/MetadataKeys.cs
+++ b/src/Tasks/Common/MetadataKeys.cs
@@ -18,6 +18,7 @@ namespace Microsoft.NET.Build.Tasks
         public const string IsTopLevelDependency = "IsTopLevelDependency";
         public const string AllowExplicitVersion = "AllowExplicitVersion";
         public const string RelativePath = "RelativePath";
+        public const string DiagnosticLevel = "DiagnosticLevel";
 
         // Target Metadata
         public const string RuntimeIdentifier = "RuntimeIdentifier";

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenThatWeWantToGetDependenciesViaDesignTimeBuild.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenThatWeWantToGetDependenciesViaDesignTimeBuild.cs
@@ -77,7 +77,8 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                             { MetadataKeys.Version, "1.0.0" },
                             { MetadataKeys.Path, "some path" },
                             { MetadataKeys.ResolvedPath, "" },
-                            { MetadataKeys.Type, "Unresolved" }
+                            { MetadataKeys.Type, "Unresolved" },
+                            { MetadataKeys.DiagnosticLevel, "Warning" }
                         })
                 },
                 PackageDependencies = new ITaskItem[]
@@ -100,6 +101,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             Assert.Equal("1.0.0", item.GetMetadata(MetadataKeys.Version));
             Assert.Equal("some path", item.GetMetadata(MetadataKeys.Path));
             Assert.Equal("", item.GetMetadata(MetadataKeys.ResolvedPath));
+            Assert.Equal("Warning", item.GetMetadata(MetadataKeys.DiagnosticLevel));
             Assert.False(item.GetBooleanMetadata(MetadataKeys.IsImplicitlyDefined));
             Assert.False(item.GetBooleanMetadata(PreprocessPackageDependenciesDesignTime.ResolvedMetadata));
         }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/PreprocessPackageDependenciesDesignTime.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/PreprocessPackageDependenciesDesignTime.cs
@@ -32,6 +32,7 @@ namespace Microsoft.NET.Build.Tasks
         /// - ResolvedPath = "C:\Users\drnoakes\.nuget\packages\metadataextractor\1.0.0"
         /// - Type = "package"
         /// - Version = "2.3.0"
+        /// - DiagnosticLevel = ""
         /// </summary>
         [Required]
         public ITaskItem[] PackageDefinitions { get; set; }
@@ -122,12 +123,14 @@ namespace Microsoft.NET.Build.Tasks
                         ? resolvedPath
                         : packageDef.GetMetadata(MetadataKeys.Path)) ?? string.Empty;
                     var isImplicitlyDefined = implicitPackageReferences.Contains(name);
+                    var diagnosticLevel = packageDef.GetMetadata(MetadataKeys.DiagnosticLevel) ?? string.Empty;
 
                     var outputItem = new TaskItem(packageDef.ItemSpec);
                     outputItem.SetMetadata(MetadataKeys.Name, name);
                     outputItem.SetMetadata(MetadataKeys.Version, version);
                     outputItem.SetMetadata(MetadataKeys.Path, path);
                     outputItem.SetMetadata(MetadataKeys.IsImplicitlyDefined, isImplicitlyDefined.ToString());
+                    outputItem.SetMetadata(MetadataKeys.DiagnosticLevel, diagnosticLevel);
                     outputItem.SetMetadata(ResolvedMetadata, resolved.ToString());
 
                     outputItems.Add(outputItem);

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageDependencies.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageDependencies.cs
@@ -173,6 +173,8 @@ namespace Microsoft.NET.Build.Tasks
                 string resolvedPackagePath = ResolvePackagePath(package);
                 item.SetMetadata(MetadataKeys.ResolvedPath, resolvedPackagePath ?? string.Empty);
 
+                item.SetMetadata(MetadataKeys.DiagnosticLevel, GetPackageDiagnosticLevel(package));
+
                 _packageDefinitions.Add(item);
 
                 if (!EmitLegacyAssetsFileItems)
@@ -226,6 +228,18 @@ namespace Microsoft.NET.Build.Tasks
 
                     _fileDefinitions.Add(fileItem);
                 }
+            }
+
+            string GetPackageDiagnosticLevel(LockFileLibrary package)
+            {
+                var messages = LockFile.LogMessages.Where(log => log.LibraryId == package.Name);
+
+                if (!messages.Any())
+                {
+                    return string.Empty;
+                }
+
+                return messages.Max(log => log.Level).ToString();
             }
         }
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageDependencies.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageDependencies.cs
@@ -119,6 +119,8 @@ namespace Microsoft.NET.Build.Tasks
         /// </summary>
         public bool EmitLegacyAssetsFileItems { get; set; } = false;
 
+        public string TargetFrameworkMoniker { get; set; }
+
         #endregion
 
         public ResolvePackageDependencies()
@@ -232,7 +234,9 @@ namespace Microsoft.NET.Build.Tasks
 
             string GetPackageDiagnosticLevel(LockFileLibrary package)
             {
-                var messages = LockFile.LogMessages.Where(log => log.LibraryId == package.Name);
+                string target = TargetFrameworkMoniker ?? "";
+
+                var messages = LockFile.LogMessages.Where(log => log.LibraryId == package.Name && log.TargetGraphs.Contains(target));
 
                 if (!messages.Any())
                 {

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.PackageDependencyResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.PackageDependencyResolution.targets
@@ -188,6 +188,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       ProjectAssetsFile="$(ProjectAssetsFile)"
       ProjectLanguage="$(Language)"
       EmitLegacyAssetsFileItems="$(EmitLegacyAssetsFileItems)"
+      TargetFrameworkMoniker="$(NuGetTargetMoniker)"
       ContinueOnError="ErrorAndContinue">
 
       <Output TaskParameter="PackageDefinitions" ItemName="PackageDefinitions" />


### PR DESCRIPTION
Contributes to dotnet/project-system#6275.

This information is needed by the Project System to correctly indicate when a package in the tree has an associated warning or error state.
