### PR TITLE
Change _BlockWinMDsOnUnsupportedTFMs dependencies to fix WPF temp targets ordering

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -891,7 +891,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   ============================================================
   -->
   <Target Name="_BlockWinMDsOnUnsupportedTFMs"
-          BeforeTargets="CoreCompile"
+          AfterTargets="PreBuildEvent"
           DependsOnTargets="ResolveReferences"
           Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' and $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '5.0'))">
     <NETSdkError Condition="'%(ReferencePath.Extension)' == '.winmd'"


### PR DESCRIPTION
The introduction of _BlockWinMDsOnUnsupportedTFMs broke the WPF temp project generation, which broke PowerShell Core. This PR changes the target ordering so it doesn't destabilize the WPF targets.

I've validated that this change doesn't cause this target to be skipped on incremental builds.

Fixes #12093

cc: @rlander @AaronRobinsonMSFT @ryalanms @wli3 @dsplaisted