### PR TITLE
Do not append rid to path when configured

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.BeforeCommon.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.BeforeCommon.targets
@@ -107,7 +107,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <PublishDirName Condition="'$(PublishDirName)' == ''">publish</PublishDirName>
     <!-- ensure the PublishDir is RID specific-->
     <PublishDir Condition="'$(PublishDir)' == '' and
-                           '$(AppendRuntimeIdentifierToOutputPath)' == 'true' and
+                           '$(AppendRuntimeIdentifierToOutputPath)' != 'false' and
                            '$(RuntimeIdentifier)' != '' and
                            '$(_UsingDefaultRuntimeIdentifier)' != 'true'">$(OutputPath)$(RuntimeIdentifier)\$(PublishDirName)\</PublishDir>
     <PublishDir Condition="'$(PublishDir)' == ''">$(OutputPath)$(PublishDirName)\</PublishDir>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.BeforeCommon.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.BeforeCommon.targets
@@ -107,7 +107,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <PublishDirName Condition="'$(PublishDirName)' == ''">publish</PublishDirName>
     <!-- ensure the PublishDir is RID specific-->
     <PublishDir Condition="'$(PublishDir)' == '' and
-                           '$(AppendRuntimeIdentifierToOutputPath)' != 'true' and
+                           '$(AppendRuntimeIdentifierToOutputPath)' == 'true' and
                            '$(RuntimeIdentifier)' != '' and
                            '$(_UsingDefaultRuntimeIdentifier)' != 'true'">$(OutputPath)$(RuntimeIdentifier)\$(PublishDirName)\</PublishDir>
     <PublishDir Condition="'$(PublishDir)' == ''">$(OutputPath)$(PublishDirName)\</PublishDir>


### PR DESCRIPTION
Fixes https://github.com/dotnet/sdk/issues/12114

Here's OutputPath accounting for the property: https://github.com/dotnet/sdk/blob/master/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets#L218-L221 