### PR TITLE
Adding check for trailing slash on publishdir

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -465,11 +465,11 @@ Copyright (c) .NET Foundation. All rights reserved.
     ============================================================
     -->
   <Target Name="ComputeFilesToPublish"
-          DependsOnTargets="ComputeResolvedFilesToPublishList;
+          DependsOnTargets="PrepareForPublish;
+                            ComputeResolvedFilesToPublishList;
                             ILLink;
                             CreateReadyToRunImages;
                             GeneratePublishDependencyFile;
-                            PrepareForPublish;
                             GenerateSingleFileBundle">
   </Target>
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -962,6 +962,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <PropertyGroup>
       <PublishedSingleFileName>$(AssemblyName)$(_NativeExecutableExtension)</PublishedSingleFileName>
+      <PublishDir Condition="!HasTrailingSlash('$(PublishDir)')">$(PublishDir)\</PublishDir>
       <PublishedSingleFilePath>$(PublishDir)$(PublishedSingleFileName)</PublishedSingleFilePath>
     </PropertyGroup>
     

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -469,6 +469,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                             ILLink;
                             CreateReadyToRunImages;
                             GeneratePublishDependencyFile;
+                            PrepareForPublish;
                             GenerateSingleFileBundle">
   </Target>
 
@@ -962,7 +963,6 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <PropertyGroup>
       <PublishedSingleFileName>$(AssemblyName)$(_NativeExecutableExtension)</PublishedSingleFileName>
-      <PublishDir Condition="!HasTrailingSlash('$(PublishDir)')">$(PublishDir)\</PublishDir>
       <PublishedSingleFilePath>$(PublishDir)$(PublishedSingleFileName)</PublishedSingleFilePath>
     </PropertyGroup>
     


### PR DESCRIPTION
Currently when packaging a windows packaging project that references a .NET Core app that sets PublishSingleFile=true directly in the project file without using a publish profile we give an error caused by the lack of a path separator.  I see that there's a similar check being done in the PrepareForPublish target, but that isn't called when building a packaging project.