### PR TITLE
Fix linker PDB behavior and add DebuggerSupport property

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ILLink.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ILLink.targets
@@ -41,6 +41,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ItemGroup>
       <_LinkedResolvedFileToPublish Include="@(_LinkedResolvedFileToPublishCandidate)" Condition="Exists('%(Identity)')" />
       <ResolvedFileToPublish Remove="@(ManagedAssemblyToLink)" />
+      <ResolvedFileToPublish Remove="@(_PDBToLink)" />
       <ResolvedFileToPublish Include="@(_LinkedResolvedFileToPublish)" />
     </ItemGroup>
 
@@ -87,6 +88,11 @@ Copyright (c) .NET Foundation. All rights reserved.
         <Action>%(ManagedAssemblyToLink.TrimMode)</Action>
       </ManagedAssemblyToLink>
     </ItemGroup>
+
+    <!-- Temporary: translate to the old linker options. -->
+    <PropertyGroup>
+      <_TrimmerLinkSymbols Condition="! '$(TrimSymbols)'">true</_TrimmerLinkSymbols>
+    </PropertyGroup>
 
     <Delete Files="@(_LinkedResolvedFileToPublishCandidate)" />
     <ILLink AssemblyPaths="@(ManagedAssemblyToLink)"
@@ -141,6 +147,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <PropertyGroup>
       <_ExtraTrimmerArgs>--skip-unresolved true $(_ExtraTrimmerArgs)</_ExtraTrimmerArgs>
       <TrimMode Condition=" '$(TrimMode)' == '' ">copyused</TrimMode>
+      <TrimSymbols Condition=" '$(TrimSymbols)' == '' ">true</TrimSymbols>
     </PropertyGroup>
 
     <ItemGroup>
@@ -178,10 +185,15 @@ Copyright (c) .NET Foundation. All rights reserved.
     </ComputeManagedAssemblies>
 
     <ItemGroup>
-      <_LinkedResolvedFileToPublishCandidate Include="@(ManagedAssemblyToLink->'$(IntermediateLinkDir)%(Filename)%(Extension)')" />
+      <!-- The linker implicitly picks up PDBs next to input assemblies. We will filter these out of the publish set. -->
+      <__PDBToLink Include="@(ResolvedFileToPublish)" Exclude="@(_ManagedAssembliesToLink->'%(RelativeDir)%(Filename).pdb')" />
+      <_PDBToLink Include="@(ResolvedFileToPublish)" Exclude="@(__PDBToLink)" />
     </ItemGroup>
 
+    <ItemGroup>
+      <_LinkedResolvedFileToPublishCandidate Include="@(ManagedAssemblyToLink->'$(IntermediateLinkDir)%(Filename)%(Extension)')" />
+      <_LinkedResolvedFileToPublishCandidate Include="@(_PDBToLink->'$(IntermediateLinkDir)%(Filename)%(Extension)')" />
+    <ItemGroup>
   </Target>
-
 
 </Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ILLink.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ILLink.targets
@@ -89,6 +89,12 @@ Copyright (c) .NET Foundation. All rights reserved.
       </ManagedAssemblyToLink>
     </ItemGroup>
 
+    <!-- Map public properties to the task options -->
+    <PropertyGroup>
+      <_TrimmerLinkSymbols Condition=" '$(TrimmerRemoveSymbols)' == 'true' ">false</_TrimmerLinkSymbols>
+      <_TrimmerLinkSymbols Condition=" '$(TrimmerRemoveSymbols)' != 'true' ">true</_TrimmerLinkSymbols>
+    </PropertyGroup>
+
     <Delete Files="@(_LinkedResolvedFileToPublishCandidate)" />
     <ILLink AssemblyPaths="@(ManagedAssemblyToLink)"
             ReferenceAssemblyPaths="@(ReferencePath)"
@@ -142,8 +148,13 @@ Copyright (c) .NET Foundation. All rights reserved.
     <PropertyGroup>
       <_ExtraTrimmerArgs>--skip-unresolved true $(_ExtraTrimmerArgs)</_ExtraTrimmerArgs>
       <TrimMode Condition=" '$(TrimMode)' == '' ">copyused</TrimMode>
-      <_TrimmerLinkSymbols Condition=" '$(_TrimmerLinkSymbols)' == '' ">$(DebuggerSupport)</_TrimmerLinkSymbols>
-      <_TrimmerLinkSymbols Condition=" '$(_TrimmerLinkSymbols)' == '' ">true</_TrimmerLinkSymbols>
+    </PropertyGroup>
+
+    <!-- Set a default value for TrimmerRemoveSymbols unless set explicitly. -->
+    <PropertyGroup Condition=" '$(TrimmerRemoveSymbols)' == '' ">
+      <!-- The default is to remove symbols when debugger support is disabled, and keep them otherwise. -->
+      <TrimmerRemoveSymbols Condition=" '$(DebuggerSupport)' == 'false' ">true</TrimmerRemoveSymbols>
+      <TrimmerRemoveSymbols Condition=" '$(DebuggerSupport)' != 'false' ">false</TrimmerRemoveSymbols>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ILLink.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ILLink.targets
@@ -142,7 +142,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <PropertyGroup>
       <_ExtraTrimmerArgs>--skip-unresolved true $(_ExtraTrimmerArgs)</_ExtraTrimmerArgs>
       <TrimMode Condition=" '$(TrimMode)' == '' ">copyused</TrimMode>
-      <_TrimmerLinkSymbols>$(DebuggerSupport)</_TrimmerLinkSymbols>
+      <_TrimmerLinkSymbols Condition=" '$(_TrimmerLinkSymbols)' == '' ">$(DebuggerSupport)</_TrimmerLinkSymbols>
       <_TrimmerLinkSymbols Condition=" '$(_TrimmerLinkSymbols)' == '' ">true</_TrimmerLinkSymbols>
     </PropertyGroup>
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ILLink.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ILLink.targets
@@ -89,11 +89,6 @@ Copyright (c) .NET Foundation. All rights reserved.
       </ManagedAssemblyToLink>
     </ItemGroup>
 
-    <!-- Temporary: translate to the old linker options. -->
-    <PropertyGroup>
-      <_TrimmerLinkSymbols Condition="! '$(TrimSymbols)'">true</_TrimmerLinkSymbols>
-    </PropertyGroup>
-
     <Delete Files="@(_LinkedResolvedFileToPublishCandidate)" />
     <ILLink AssemblyPaths="@(ManagedAssemblyToLink)"
             ReferenceAssemblyPaths="@(ReferencePath)"
@@ -147,7 +142,8 @@ Copyright (c) .NET Foundation. All rights reserved.
     <PropertyGroup>
       <_ExtraTrimmerArgs>--skip-unresolved true $(_ExtraTrimmerArgs)</_ExtraTrimmerArgs>
       <TrimMode Condition=" '$(TrimMode)' == '' ">copyused</TrimMode>
-      <TrimSymbols Condition=" '$(TrimSymbols)' == '' ">true</TrimSymbols>
+      <_TrimmerLinkSymbols>$(DebuggerSupport)</_TrimmerLinkSymbols>
+      <_TrimmerLinkSymbols Condition=" '$(_TrimmerLinkSymbols)' == '' ">true</_TrimmerLinkSymbols>
     </PropertyGroup>
 
     <ItemGroup>
@@ -186,14 +182,14 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <ItemGroup>
       <!-- The linker implicitly picks up PDBs next to input assemblies. We will filter these out of the publish set. -->
-      <__PDBToLink Include="@(ResolvedFileToPublish)" Exclude="@(_ManagedAssembliesToLink->'%(RelativeDir)%(Filename).pdb')" />
+      <__PDBToLink Include="@(ResolvedFileToPublish)" Exclude="@(ManagedAssemblyToLink->'%(RelativeDir)%(Filename).pdb')" />
       <_PDBToLink Include="@(ResolvedFileToPublish)" Exclude="@(__PDBToLink)" />
     </ItemGroup>
 
     <ItemGroup>
       <_LinkedResolvedFileToPublishCandidate Include="@(ManagedAssemblyToLink->'$(IntermediateLinkDir)%(Filename)%(Extension)')" />
       <_LinkedResolvedFileToPublishCandidate Include="@(_PDBToLink->'$(IntermediateLinkDir)%(Filename)%(Extension)')" />
-    <ItemGroup>
+    </ItemGroup>
   </Target>
 
 </Project>

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToRunILLink.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToRunILLink.cs
@@ -418,6 +418,67 @@ namespace Microsoft.NET.Publish.Tests
 
         [Theory]
         [InlineData("netcoreapp3.0")]
+        public void ILLink_trims_pdbs_by_default(string targetFramework)
+        {
+            var projectName = "HelloWorld";
+            var referenceProjectName = "ClassLibForILLink";
+            var rid = EnvironmentInfo.GetCompatibleRid(targetFramework);
+
+            var testProject = CreateTestProjectForILLinkTesting(targetFramework, projectName, referenceProjectName);
+            var testAsset = _testAssetsManager.CreateTestProject(testProject)
+                .WithProjectChanges(project => EnableNonFrameworkTrimming(project));
+
+            var publishCommand = new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            publishCommand.Execute($"/p:RuntimeIdentifier={rid}", $"/p:SelfContained=true", "/p:PublishTrimmed=true").Should().Pass();
+
+            var publishDirectory = publishCommand.GetOutputDirectory(targetFramework: targetFramework, runtimeIdentifier: rid).FullName;
+            var intermediateDirectory = publishCommand.GetIntermediateDirectory(targetFramework: targetFramework, runtimeIdentifier: rid).FullName;
+            var linkedDirectory = Path.Combine(intermediateDirectory, "linked");
+
+            var intermediatePdb = Path.Combine(intermediateDirectory, $"{projectName}.pdb");
+            var linkedPdb = Path.Combine(linkedDirectory, $"{projectName}.pdb");
+            var publishedPdb = Path.Combine(publishDirectory, $"{projectName}.pdb");
+
+            File.Exists(intermediatePdb).Should().BeTrue();
+            File.Exists(linkedPdb).Should().BeFalse();
+            File.Exists(publishedPdb).Should().BeFalse();
+        }
+
+        [Theory]
+        [InlineData("netcoreapp3.0")]
+        public void ILLink_accepts_option_to_link_pdbs(string targetFramework)
+        {
+            var projectName = "HelloWorld";
+            var referenceProjectName = "ClassLibForILLink";
+            var rid = EnvironmentInfo.GetCompatibleRid(targetFramework);
+
+            var testProject = CreateTestProjectForILLinkTesting(targetFramework, projectName, referenceProjectName);
+            var testAsset = _testAssetsManager.CreateTestProject(testProject)
+                .WithProjectChanges(project => EnableNonFrameworkTrimming(project));
+
+            var publishCommand = new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            publishCommand.Execute($"/p:RuntimeIdentifier={rid}", $"/p:SelfContained=true", "/p:PublishTrimmed=true", "/p:TrimSymbols=false").Should().Pass();
+
+            var publishDirectory = publishCommand.GetOutputDirectory(targetFramework: targetFramework, runtimeIdentifier: rid).FullName;
+            var intermediateDirectory = publishCommand.GetIntermediateDirectory(targetFramework: targetFramework, runtimeIdentifier: rid).FullName;
+            var linkedDirectory = Path.Combine(intermediateDirectory, "linked");
+
+            var intermediatePdb = Path.Combine(intermediateDirectory, $"{projectName}.pdb");
+            var linkedPdb = Path.Combine(linkedDirectory, $"{projectName}.pdb");
+            var publishedPdb = Path.Combine(publishDirectory, $"{projectName}.pdb");
+
+            File.Exists(linkedPdb).Should().BeTrue();
+
+            var intermediatePdbSize = new FileInfo(intermediatePdb).Length;
+            var linkedPdbSize = new FileInfo(linkedPdb).Length;
+            var publishPdbSize = new FileInfo(publishedPdb).Length;
+
+            linkedPdbSize.Should().BeLessThan(intermediatePdbSize);
+            publishPdbSize.Should().Be(linkedPdbSize);
+        }
+
+        [Theory]
+        [InlineData("netcoreapp3.0")]
         public void ILLink_error_on_portable_app(string targetFramework)
         {
             var projectName = "HelloWorld";

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToRunILLink.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToRunILLink.cs
@@ -479,6 +479,40 @@ namespace Microsoft.NET.Publish.Tests
 
         [Theory]
         [InlineData("netcoreapp3.0")]
+        public void ILLink_private_option_can_override_symbol_behavior_of_debugger_support(string targetFramework)
+        {
+            var projectName = "HelloWorld";
+            var referenceProjectName = "ClassLibForILLink";
+            var rid = EnvironmentInfo.GetCompatibleRid(targetFramework);
+
+            var testProject = CreateTestProjectForILLinkTesting(targetFramework, projectName, referenceProjectName);
+            var testAsset = _testAssetsManager.CreateTestProject(testProject)
+                .WithProjectChanges(project => EnableNonFrameworkTrimming(project));
+
+            var publishCommand = new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            publishCommand.Execute($"/p:RuntimeIdentifier={rid}", $"/p:SelfContained=true", "/p:PublishTrimmed=true",
+                                    "/p:DebuggerSupport=false", "/p:_TrimmerLinkSymbols=true").Should().Pass();
+
+            var publishDirectory = publishCommand.GetOutputDirectory(targetFramework: targetFramework, runtimeIdentifier: rid).FullName;
+            var intermediateDirectory = publishCommand.GetIntermediateDirectory(targetFramework: targetFramework, runtimeIdentifier: rid).FullName;
+            var linkedDirectory = Path.Combine(intermediateDirectory, "linked");
+
+            var intermediatePdb = Path.Combine(intermediateDirectory, $"{projectName}.pdb");
+            var linkedPdb = Path.Combine(linkedDirectory, $"{projectName}.pdb");
+            var publishedPdb = Path.Combine(publishDirectory, $"{projectName}.pdb");
+
+            File.Exists(linkedPdb).Should().BeTrue();
+
+            var intermediatePdbSize = new FileInfo(intermediatePdb).Length;
+            var linkedPdbSize = new FileInfo(linkedPdb).Length;
+            var publishPdbSize = new FileInfo(publishedPdb).Length;
+
+            linkedPdbSize.Should().BeLessThan(intermediatePdbSize);
+            publishPdbSize.Should().Be(linkedPdbSize);
+        }
+
+        [Theory]
+        [InlineData("netcoreapp3.0")]
         public void ILLink_error_on_portable_app(string targetFramework)
         {
             var projectName = "HelloWorld";


### PR DESCRIPTION
(Edited)

### Linker symbol behavior
Based on discussion with @eerhardt, @marek-safar, @vitek-karas, we have decided that there should be two properties, one to control debugger support all-up, and one to control linker symbol behavior. The latter should get defaults matching the debugger support property, but it should be possible to override the defaults by setting it explicitly. We also agreed that these settings should be independent of the compiler options (`DebugSymbols`/`DebugType`).

Ideally we would not have a linker symbol knob, and instead it would always fix up symbols in the input - and the SDK would have options to publish with or without symbols (or with symbols in a separate output directory). Lacking that ability, we expect the linker option to be useful especially for cases where the inputs contain embedded symbols that would be published otherwise.

### Implementation

This change introduces two properties, `DebuggerSupport` and `TrimmerRemoveSymbols`. `DebuggerSupport` will eventually enable `RuntimeHostConfigurationOption` to remove debugger support (see https://github.com/dotnet/runtime/pull/37288). In this change, it only influences the defaults for `TrimmerRemoveSymbols`:
- If `TrimmerRemoveSymbols` is set explicitly, this will be respected. If not set explicitly:
- When `DebuggerSupport` is empty or `true`, `TrimmerRemoveSymbols` defaults to `false`.
- When `DebuggerSupport` is `false`, `TrimmerRemoveSymbols` defaults to `true`.

`TrimmerRemoveSymbols` will cause the linker to drop symbols from all inputs. If it is not `true`, the linker will modify input symbols the same way that it modifies the corresponding IL (barring bugs).

@samsp-msft could you please review the proposed naming of the options `DebuggerSupport` and `TrimmerRemoveSymbols`? Rationale was:
- `DebuggerSupport` matches existing feature flags like `InvariantGlobalization`.
- `TrimmerRemoveSymbols` avoids the ambiguity of `TrimSymbols` (see the naming notes below).

Below are the original notes, which are out of date.

<hr />

**Outdated notes**

- Filter out pre-link PDBs from the publish output
- Introduce `TrimSymbols` public option to allow removing symbols (replaces `_LinkSymbols`)

Naming:
- `TrimSymbols` matches the "trim" terminology we've been using, but is odd in that it suggests selective trimming, but actually means complete removal. Symbols are either "trimmed" with the same granularity as the assembly (defined by the new `TrimMode` option), or not at all.
- `Remove`/`Strip`/`Drop` might make more sense for the verb, but if we want consistency with the other options, maybe it should be called `TrimmerRemoveSymbols` for example. This is descriptive, but a bit verbose.
- Another option is to go with the opposite behavior, like `_LinkSymbols`. `true` means the "trimmed" symbols are kept, and `false` means they are discarded. `Link` makes some sense in this context, but isn't accurate either - maybe a better name would be `TrimmerPreserveSymbols` if we went this route.

Defaults:
- The defaults before this change are buggy. Symbols would be removed by the linker, but the SDK would keep pre-link symbols. As a result, embedded PDBs would be stripped, while separate PDB files would be placed unmodified into the publish folder.
- With this change, the default behavior will be to remove symbols, under the assumption that people using the linker are optimizing for size over debuggability. `TrimSymbols` can be set to `false` to keep the PDBs (which are modified to match the trimmed IL).

@marek-safar @vitek-karas @eerhardt @samsp-msft I would appreciate feedback on the defaults and naming. Initially I thought `TrimSymbols` made sense, but after writing this `TrimmerRemoveSymbols` seems less confusing.
