### PR TITLE
Allow updating PublishUrl

### DIFF
--- a/src/WebSdk/Publish/Targets/PublishProfiles/FileSystem.pubxml
+++ b/src/WebSdk/Publish/Targets/PublishProfiles/FileSystem.pubxml
@@ -6,7 +6,7 @@ by editing this MSBuild file. In order to learn more about this please visit htt
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <WebPublishMethod>FileSystem</WebPublishMethod>
-    <publishUrl>$(OutputPath)Publish\</publishUrl>
+    <PublishUrl Condition=" '$(PublishUrl)' == '' ">$(OutputPath)Publish\</PublishUrl>
     <DeleteExistingFiles>False</DeleteExistingFiles>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Currently it's very hard to update `PublishUrl` since it is imported after `Directory.Build.targets`. Adding this condition would allow doing so.

I also found it a bit weird that web publishing (file system profile) doesn't use `PublishDir`. And there's a difference in the default letter cases:
* Web publish - `bin/.../Publish`
* Publish - `bin/.../publish`