### PR TITLE
Support runtimecopylocal to enable cswinrt

### DIFF
--- a/eng/restore-toolset.sh
+++ b/eng/restore-toolset.sh
@@ -15,6 +15,8 @@ function InitializeCustomSDKToolset {
   InstallDotNetSharedFramework "2.1.0"
   InstallDotNetSharedFramework "2.2.8"
   InstallDotNetSharedFramework "3.1.0"
+
+  CreateBuildEnvScript
 }
 
 # Installs additional shared frameworks for testing purposes
@@ -35,6 +37,24 @@ function InstallDotNetSharedFramework {
       ExitWithExitCode $lastexitcode
     fi
   fi
+}
+
+function CreateBuildEnvScript {
+  mkdir -p $artifacts_dir
+  scriptPath="$artifacts_dir/sdk-build-env.sh"
+  scriptContents="
+#!/bin/bash
+export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
+export DOTNET_MULTILEVEL_LOOKUP=0
+
+export DOTNET_ROOT=$DOTNET_INSTALL_DIR
+export DOTNET_MSBUILD_SDK_RESOLVER_CLI_DIR=$DOTNET_INSTALL_DIR
+
+export PATH=$DOTNET_INSTALL_DIR:\$PATH
+export NUGET_PACKAGES=$NUGET_PACKAGES
+"
+
+  echo "$scriptContents" > ${scriptPath}
 }
 
 InitializeCustomSDKToolset

--- a/src/Tasks/Common/MetadataKeys.cs
+++ b/src/Tasks/Common/MetadataKeys.cs
@@ -32,6 +32,7 @@ namespace Microsoft.NET.Build.Tasks
         public const string OriginalItemSpec = "OriginalItemSpec";
         public const string SDKRootFolder = "SDKRootFolder";
         public const string ShimRuntimeIdentifier = "ShimRuntimeIdentifier";
+        public const string RuntimePackAlwaysCopyLocal = "RuntimePackAlwaysCopyLocal";
 
         // Foreign Keys
         public const string ParentTarget = "ParentTarget";

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAGenerateRuntimeConfigurationFiles.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAGenerateRuntimeConfigurationFiles.cs
@@ -2,11 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using FluentAssertions;
-using Microsoft.Build.Framework;
 using Xunit;
 
 namespace Microsoft.NET.Build.Tasks.UnitTests
@@ -40,7 +38,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
         {
             var task = new TestableGenerateRuntimeConfigurationFiles
             {
-                BuildEngine = new MockBuildEngine4(),
+                BuildEngine = new MockNeverCacheBuildEngine4(),
                 TargetFrameworkMoniker = ".NETCoreApp,Version=v3.0",
                 TargetFramework = "netcoreapp3.0",
                 RuntimeConfigPath = _runtimeConfigPath,
@@ -82,7 +80,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
         {
             var task = new TestableGenerateRuntimeConfigurationFiles
             {
-                BuildEngine = new MockBuildEngine4(),
+                BuildEngine = new MockNeverCacheBuildEngine4(),
                 TargetFrameworkMoniker = ".NETCoreApp,Version=v3.0",
                 TargetFramework = "netcoreapp3.0",
                 RuntimeConfigPath = _runtimeConfigPath,
@@ -143,7 +141,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
         {
             var task = new TestableGenerateRuntimeConfigurationFiles
             {
-                BuildEngine = new MockBuildEngine4(),
+                BuildEngine = new MockNeverCacheBuildEngine4(),
                 TargetFrameworkMoniker = ".NETCoreApp,Version=v3.0",
                 TargetFramework = "netcoreapp3.0",
                 RuntimeConfigPath = _runtimeConfigPath,
@@ -192,56 +190,6 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             public void PublicExecuteCore()
             {
                 base.ExecuteCore();
-            }
-        }
-
-        private class MockBuildEngine4 : MockBuildEngine, IBuildEngine4
-        {
-            public bool IsRunningMultipleNodes => throw new NotImplementedException();
-
-            public bool BuildProjectFile(string projectFileName, string[] targetNames, IDictionary globalProperties,
-                IDictionary targetOutputs, string toolsVersion)
-            {
-                throw new NotImplementedException();
-            }
-
-            public BuildEngineResult BuildProjectFilesInParallel(string[] projectFileNames, string[] targetNames,
-                IDictionary[] globalProperties, IList<string>[] removeGlobalProperties, string[] toolsVersion,
-                bool returnTargetOutputs)
-            {
-                throw new NotImplementedException();
-            }
-
-            public bool BuildProjectFilesInParallel(string[] projectFileNames, string[] targetNames,
-                IDictionary[] globalProperties, IDictionary[] targetOutputsPerProject, string[] toolsVersion,
-                bool useResultsCache, bool unloadProjectsOnCompletion)
-            {
-                throw new NotImplementedException();
-            }
-
-            public object GetRegisteredTaskObject(object key, RegisteredTaskObjectLifetime lifetime)
-            {
-                return null;
-            }
-
-            public void Reacquire()
-            {
-                throw new NotImplementedException();
-            }
-
-            public void RegisterTaskObject(object key, object obj, RegisteredTaskObjectLifetime lifetime,
-                bool allowEarlyCollection)
-            {
-            }
-
-            public object UnregisterTaskObject(object key, RegisteredTaskObjectLifetime lifetime)
-            {
-                throw new NotImplementedException();
-            }
-
-            public void Yield()
-            {
-                throw new NotImplementedException();
             }
         }
     }

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/MockNeverCacheBuildEngine4.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/MockNeverCacheBuildEngine4.cs
@@ -1,0 +1,60 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using Microsoft.Build.Framework;
+
+namespace Microsoft.NET.Build.Tasks.UnitTests
+{
+    internal class MockNeverCacheBuildEngine4 : MockBuildEngine, IBuildEngine4
+    {
+        public bool IsRunningMultipleNodes => throw new NotImplementedException();
+
+        public bool BuildProjectFile(string projectFileName, string[] targetNames, IDictionary globalProperties,
+            IDictionary targetOutputs, string toolsVersion)
+        {
+            throw new NotImplementedException();
+        }
+
+        public BuildEngineResult BuildProjectFilesInParallel(string[] projectFileNames, string[] targetNames,
+            IDictionary[] globalProperties, IList<string>[] removeGlobalProperties, string[] toolsVersion,
+            bool returnTargetOutputs)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool BuildProjectFilesInParallel(string[] projectFileNames, string[] targetNames,
+            IDictionary[] globalProperties, IDictionary[] targetOutputsPerProject, string[] toolsVersion,
+            bool useResultsCache, bool unloadProjectsOnCompletion)
+        {
+            throw new NotImplementedException();
+        }
+
+        public object GetRegisteredTaskObject(object key, RegisteredTaskObjectLifetime lifetime)
+        {
+            return null;
+        }
+
+        public void Reacquire()
+        {
+            throw new NotImplementedException();
+        }
+
+        public void RegisterTaskObject(object key, object obj, RegisteredTaskObjectLifetime lifetime,
+            bool allowEarlyCollection)
+        {
+        }
+
+        public object UnregisterTaskObject(object key, RegisteredTaskObjectLifetime lifetime)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Yield()
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/Mocks/MockTaskItem.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/Mocks/MockTaskItem.cs
@@ -50,7 +50,10 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
 
         public void CopyMetadataTo(ITaskItem destinationItem)
         {
-            throw new NotImplementedException();
+            foreach (var kv in _metadata)
+            {
+                destinationItem.SetMetadata(kv.Key, kv.Value);
+            }
         }
 
         public string GetMetadata(string metadataName)

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/ProcessFrameworkReferencesTests.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/ProcessFrameworkReferencesTests.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Text;
+using System.Linq;
 using FluentAssertions;
 using Xunit;
 
@@ -9,6 +9,37 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
 {
     public class ProcessFrameworkReferencesTests
     {
+        private MockTaskItem _validWindowsSDKKnownFrameworkReference
+            = new MockTaskItem("Microsoft.Windows.SDK.NET.Ref",
+                new Dictionary<string, string>
+                {
+                    {"TargetFramework", "net5.0-windows10.0.18362"},
+                    {"RuntimeFrameworkName", "Microsoft.Windows.SDK.NET.Ref"},
+                    {"DefaultRuntimeFrameworkVersion", "10.0.18362.1-preview"},
+                    {"LatestRuntimeFrameworkVersion", "10.0.18362.1-preview"},
+                    {"TargetingPackName", "Microsoft.Windows.SDK.NET.Ref"},
+                    {"TargetingPackVersion", "10.0.18362.1-preview"},
+                    {"RuntimePackNamePatterns", "Microsoft.Windows.SDK.NET.Ref"},
+                    {"RuntimePackRuntimeIdentifiers", "any"},
+                    {MetadataKeys.RuntimePackAlwaysCopyLocal, "true"},
+                    {"IsWindowsOnly", "true"},
+                });
+
+
+        private MockTaskItem _netcoreAppKnownFrameworkReference =
+            new MockTaskItem("Microsoft.NETCore.App",
+                new Dictionary<string, string>
+                {
+                    {"TargetFramework", "net5.0"},
+                    {"RuntimeFrameworkName", "Microsoft.NETCore.App"},
+                    {"DefaultRuntimeFrameworkVersion", "5.0.0-preview.4.20251.6"},
+                    {"LatestRuntimeFrameworkVersion", "5.0.0-preview.4.20251.6"},
+                    {"TargetingPackName", "Microsoft.NETCore.App.Ref"},
+                    {"TargetingPackVersion", "5.0.0-preview.4.20251.6"},
+                    {"RuntimePackNamePatterns", "Microsoft.NETCore.App.Runtime.**RID**"},
+                    {"RuntimePackRuntimeIdentifiers", "win-x64"},
+                });
+
         [Fact]
         public void It_resolves_FrameworkReferences()
         {
@@ -27,12 +58,50 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 new MockTaskItem("Microsoft.AspNetCore.App",
                     new Dictionary<string, string>()
                     {
-                        { "TargetFramework", "netcoreapp3.0" },
-                        { "RuntimeFrameworkName", "Microsoft.AspNetCore.App" },
-                        { "DefaultRuntimeFrameworkVersion", "1.9.5" },
-                        { "LatestRuntimeFrameworkVersion", "1.9.6" },
-                        { "TargetingPackName", "Microsoft.AspNetCore.App" },
-                        { "TargetingPackVersion", "1.9.0" }
+                        {"TargetFramework", "netcoreapp3.0"},
+                        {"RuntimeFrameworkName", "Microsoft.AspNetCore.App"},
+                        {"DefaultRuntimeFrameworkVersion", "1.9.5"},
+                        {"LatestRuntimeFrameworkVersion", "1.9.6"},
+                        {"TargetingPackName", "Microsoft.AspNetCore.App"},
+                        {"TargetingPackVersion", "1.9.0"}
+                    })
+            };
+
+            task.Execute().Should().BeTrue();
+
+            task.PackagesToDownload.Length.Should().Be(1);
+
+            task.RuntimeFrameworks.Length.Should().Be(1);
+            task.RuntimeFrameworks[0].ItemSpec.Should().Be("Microsoft.AspNetCore.App");
+            task.RuntimeFrameworks[0].GetMetadata(MetadataKeys.Version).Should().Be("1.9.5");
+        }
+
+        [Fact]
+        public void Given_targetPlatform_and_targetPlatform_version_It_resolves_FrameworkReferences_()
+        {
+            var task = new ProcessFrameworkReferences();
+
+            task.EnableTargetingPackDownload = true;
+            task.TargetFrameworkIdentifier = ".NETCoreApp";
+            task.TargetFrameworkVersion = "3.0";
+            task.TargetPlatformIdentifier = "Windows";
+            task.TargetPlatformVersion = "10.0.18362";
+            task.FrameworkReferences = new[]
+            {
+                new MockTaskItem("Microsoft.AspNetCore.App", new Dictionary<string, string>())
+            };
+
+            task.KnownFrameworkReferences = new[]
+            {
+                new MockTaskItem("Microsoft.AspNetCore.App",
+                    new Dictionary<string, string>()
+                    {
+                        {"TargetFramework", "netcoreapp3.0"},
+                        {"RuntimeFrameworkName", "Microsoft.AspNetCore.App"},
+                        {"DefaultRuntimeFrameworkVersion", "1.9.5"},
+                        {"LatestRuntimeFrameworkVersion", "1.9.6"},
+                        {"TargetingPackName", "Microsoft.AspNetCore.App"},
+                        {"TargetingPackVersion", "1.9.0"}
                     })
             };
 
@@ -62,12 +131,12 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 new MockTaskItem("Microsoft.AspNetCore.App",
                     new Dictionary<string, string>()
                     {
-                        { "TargetFramework", "netcoreapp3.0" },
-                        { "RuntimeFrameworkName", "Microsoft.AspNetCore.App" },
-                        { "DefaultRuntimeFrameworkVersion", "1.9.5" },
-                        { "LatestRuntimeFrameworkVersion", "1.9.6" },
-                        { "TargetingPackName", "Microsoft.AspNetCore.App" },
-                        { "TargetingPackVersion", "1.9.0" }
+                        {"TargetFramework", "netcoreapp3.0"},
+                        {"RuntimeFrameworkName", "Microsoft.AspNetCore.App"},
+                        {"DefaultRuntimeFrameworkVersion", "1.9.5"},
+                        {"LatestRuntimeFrameworkVersion", "1.9.6"},
+                        {"TargetingPackName", "Microsoft.AspNetCore.App"},
+                        {"TargetingPackVersion", "1.9.0"}
                     })
             };
 
@@ -75,6 +144,178 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
 
             task.PackagesToDownload.Should().BeNull();
             task.RuntimeFrameworks.Should().BeNull();
+        }
+
+        [Fact]
+        public void Given_KnownFrameworkReferences_with_RuntimePackAlwaysCopyLocal_It_resolves_FrameworkReferences()
+        {
+            const string minimalRuntimeGraphPathContent =
+                "{\"runtimes\":{\"any\":{\"#import\":[\"base\"]},\"base\":{\"#import\":[]}}}";
+            var runtimeGraphPathPath = Path.GetTempFileName();
+            File.WriteAllText(runtimeGraphPathPath, minimalRuntimeGraphPathContent);
+
+            var task = new ProcessFrameworkReferences
+            {
+                BuildEngine = new MockNeverCacheBuildEngine4(),
+                EnableTargetingPackDownload = true,
+                TargetFrameworkIdentifier = ".NETCoreApp",
+                TargetFrameworkVersion = "5.0",
+                TargetPlatformIdentifier = "Windows",
+                TargetPlatformVersion = "10.0.18362",
+                RuntimeGraphPath =
+                    runtimeGraphPathPath,
+                FrameworkReferences =
+                    new[] {new MockTaskItem("Microsoft.Windows.SDK.NET.Ref", new Dictionary<string, string>())},
+                KnownFrameworkReferences = new[]
+                {
+                    new MockTaskItem("Microsoft.Windows.SDK.NET.Ref",
+                        new Dictionary<string, string>
+                        {
+                            {"TargetFramework", "net5.0-windows10.0.17760"},
+                            {"RuntimeFrameworkName", "Microsoft.Windows.SDK.NET.Ref"},
+                            {"DefaultRuntimeFrameworkVersion", "10.0.17760.1-preview"},
+                            {"LatestRuntimeFrameworkVersion", "10.0.17760.1-preview"},
+                            {"TargetingPackName", "Microsoft.Windows.SDK.NET.Ref"},
+                            {"TargetingPackVersion", "10.0.17760.1-preview"},
+                            {"RuntimePackNamePatterns", "Microsoft.Windows.SDK.NET.Ref"},
+                            {"RuntimePackRuntimeIdentifiers", "any"},
+                            {MetadataKeys.RuntimePackAlwaysCopyLocal, "true"},
+                            {"IsWindowsOnly", "true"},
+                        }),
+                    _validWindowsSDKKnownFrameworkReference,
+                }
+            };
+
+            if (Environment.OSVersion.Platform != PlatformID.Win32NT)
+            {
+                task.Execute().Should().BeFalse("IsWindowsOnly=true");
+                return;
+            }
+
+            task.Execute().Should().BeTrue();
+
+            task.PackagesToDownload.Length.Should().Be(1);
+
+            task.RuntimeFrameworks.Should().BeNullOrEmpty(
+                "Should not contain RuntimePackAlwaysCopyLocal framework, or it will be put into runtimeconfig.json");
+
+            task.TargetingPacks.Length.Should().Be(1);
+            task.TargetingPacks[0].ItemSpec.Should().Be("Microsoft.Windows.SDK.NET.Ref");
+            task.TargetingPacks[0].GetMetadata(MetadataKeys.NuGetPackageId).Should()
+                .Be("Microsoft.Windows.SDK.NET.Ref");
+            task.TargetingPacks[0].GetMetadata(MetadataKeys.NuGetPackageVersion).Should().Be("10.0.18362.1-preview");
+            task.TargetingPacks[0].GetMetadata(MetadataKeys.PackageConflictPreferredPackages).Should()
+                .Be("Microsoft.Windows.SDK.NET.Ref");
+            task.TargetingPacks[0].GetMetadata(MetadataKeys.RuntimeFrameworkName).Should()
+                .Be("Microsoft.Windows.SDK.NET.Ref");
+            task.TargetingPacks[0].GetMetadata(MetadataKeys.RuntimeIdentifier).Should().Be("");
+
+            task.RuntimePacks.Length.Should().Be(1);
+            task.RuntimePacks[0].ItemSpec.Should().Be("Microsoft.Windows.SDK.NET.Ref");
+            task.RuntimePacks[0].GetMetadata(MetadataKeys.FrameworkName).Should().Be("Microsoft.Windows.SDK.NET.Ref");
+            task.RuntimePacks[0].GetMetadata(MetadataKeys.NuGetPackageVersion).Should().Be("10.0.18362.1-preview");
+            task.RuntimePacks[0].GetMetadata(MetadataKeys.RuntimePackAlwaysCopyLocal).Should().Be("true");
+        }
+
+        [Fact]
+        public void It_resolves_self_contained_FrameworkReferences_to_download()
+        {
+            const string minimalRuntimeGraphPathContent =
+                "{\"runtimes\":{\"any\":{\"#import\":[\"base\"]},\"base\":{\"#import\":[]},\"win\":{\"#import\":[\"any\"]},\"win-x64\":{\"#import\":[\"win\"]}}}";
+            var runtimeGraphPathPath = Path.GetTempFileName();
+            File.WriteAllText(runtimeGraphPathPath, minimalRuntimeGraphPathContent);
+
+            var task = new ProcessFrameworkReferences
+            {
+                BuildEngine = new MockNeverCacheBuildEngine4(),
+                EnableTargetingPackDownload = true,
+                TargetFrameworkIdentifier = ".NETCoreApp",
+                TargetFrameworkVersion = "5.0",
+                TargetPlatformIdentifier = "Windows",
+                TargetPlatformVersion = "10.0.18362",
+                NETCoreSdkRuntimeIdentifier = "win-x64",
+                RuntimeIdentifier = "win-x64",
+                RuntimeGraphPath =
+                    runtimeGraphPathPath,
+                SelfContained = true,
+                TargetLatestRuntimePatch = true,
+                TargetLatestRuntimePatchIsDefault = true,
+                FrameworkReferences =
+                    new[]
+                    {
+                        new MockTaskItem("Microsoft.NETCore.App", new Dictionary<string, string>()),
+                        new MockTaskItem("Microsoft.Windows.SDK.NET.Ref", new Dictionary<string, string>())
+                    },
+                KnownFrameworkReferences = new[]
+                {
+                    _netcoreAppKnownFrameworkReference, _validWindowsSDKKnownFrameworkReference,
+                }
+            };
+            if (Environment.OSVersion.Platform == PlatformID.Win32NT)
+            {
+                task.Execute().Should().BeTrue();
+
+                task.PackagesToDownload.Length.Should().Be(3);
+                task.PackagesToDownload.Should().Contain(p => p.ItemSpec == "Microsoft.Windows.SDK.NET.Ref");
+                task.PackagesToDownload.Should().Contain(p => p.ItemSpec == "Microsoft.NETCore.App.Ref");
+                task.PackagesToDownload.Should().Contain(p => p.ItemSpec == "Microsoft.NETCore.App.Runtime.win-x64");
+            }
+            else
+            {
+                task.Execute().Should().BeFalse("IsWindowsOnly=true");
+            }
+        }
+
+        [Fact]
+        public void Given_reference_to_NETCoreApp_It_should_not_resolve_runtime_pack()
+        {
+            const string minimalRuntimeGraphPathContent =
+                "{\"runtimes\":{\"any\":{\"#import\":[\"base\"]},\"base\":{\"#import\":[]},\"win\":{\"#import\":[\"any\"]},\"win-x64\":{\"#import\":[\"win\"]}}}";
+            var runtimeGraphPathPath = Path.GetTempFileName();
+            File.WriteAllText(runtimeGraphPathPath, minimalRuntimeGraphPathContent);
+
+            var task = new ProcessFrameworkReferences
+            {
+                BuildEngine = new MockNeverCacheBuildEngine4(),
+                EnableTargetingPackDownload = true,
+                TargetFrameworkIdentifier = ".NETCoreApp",
+                TargetFrameworkVersion = "5.0",
+                TargetPlatformIdentifier = "Windows",
+                TargetPlatformVersion = "10.0.18362",
+                NETCoreSdkRuntimeIdentifier = "win-x64",
+                RuntimeGraphPath =
+                    runtimeGraphPathPath,
+                TargetLatestRuntimePatch = true,
+                TargetLatestRuntimePatchIsDefault = true,
+                FrameworkReferences =
+                    new[]
+                    {
+                        new MockTaskItem("Microsoft.NETCore.App", new Dictionary<string, string>()),
+                        new MockTaskItem("Microsoft.Windows.SDK.NET.Ref", new Dictionary<string, string>())
+                    },
+                KnownFrameworkReferences = new[]
+                {
+                    _netcoreAppKnownFrameworkReference, _validWindowsSDKKnownFrameworkReference,
+                }
+            };
+
+            if (Environment.OSVersion.Platform != PlatformID.Win32NT)
+            {
+                task.Execute().Should().BeFalse("IsWindowsOnly=true");
+                return;
+            }
+
+            task.Execute().Should().BeTrue();
+
+            task.TargetingPacks.Length.Should().Be(2);
+            task.TargetingPacks.Should().Contain(p =>
+                p.GetMetadata(MetadataKeys.NuGetPackageId) == "Microsoft.Windows.SDK.NET.Ref");
+            task.TargetingPacks.Should()
+                .Contain(p => p.GetMetadata(MetadataKeys.NuGetPackageId) == "Microsoft.NETCore.App.Ref");
+
+            task.RuntimePacks.Length.Should().Be(1);
+            task.RuntimePacks[0].ItemSpec.Should().Be("Microsoft.Windows.SDK.NET.Ref",
+                "it should not resolve runtime pack for Microsoft.NETCore.App");
         }
     }
 }

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/ResolveTargetingPackAssetsTests.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/ResolveTargetingPackAssetsTests.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using FluentAssertions;
+using Xunit;
+
+namespace Microsoft.NET.Build.Tasks.UnitTests
+{
+    public class ResolveTargetingPackAssetsTests
+    {
+        [Fact]
+        public void Given_ResolvedTargetingPacks_with_valid_PATH_in_PlatformManifest_It_resolves_TargetingPack()
+        {
+            string mockPackageDirectory = Path.Combine(Path.GetTempPath(), "dotnetSdkTests", Path.GetRandomFileName());
+
+            string dataDir = Path.Combine(mockPackageDirectory, "data");
+            Directory.CreateDirectory(dataDir);
+
+            File.WriteAllText(Path.Combine(dataDir, "FrameworkList.xml"), _frameworkList);
+            File.WriteAllText(Path.Combine(dataDir, "PlatformManifest.txt"), "");
+
+            var task = new ResolveTargetingPackAssets();
+
+            task.FrameworkReferences = new[]
+            {
+                new MockTaskItem("Microsoft.Windows.SDK.NET.Ref", new Dictionary<string, string>())
+            };
+
+            task.ResolvedTargetingPacks = new[]
+            {
+                new MockTaskItem("Microsoft.Windows.SDK.NET.Ref",
+                    new Dictionary<string, string>()
+                    {
+                        {MetadataKeys.NuGetPackageId, "Microsoft.Windows.SDK.NET.Ref"},
+                        {MetadataKeys.NuGetPackageVersion, "5.0.0-preview1"},
+                        {MetadataKeys.PackageConflictPreferredPackages, "Microsoft.Windows.SDK.NET.Ref;"},
+                        {MetadataKeys.PackageDirectory, mockPackageDirectory},
+                        {MetadataKeys.Path, mockPackageDirectory},
+                        {"TargetFramework", "net5.0"}
+                    })
+            };
+
+            task.Execute().Should().BeTrue();
+
+            task.ReferencesToAdd[0].ItemSpec.Should().Be(Path.Combine(mockPackageDirectory, "lib/Microsoft.Windows.SDK.NET.dll"));
+            task.PlatformManifests[0].ItemSpec.Should().Be(Path.Combine(mockPackageDirectory, $"data{Path.DirectorySeparatorChar}PlatformManifest.txt"));
+        }
+
+        private readonly string _frameworkList =
+            "<FileList Name=\"cswinrt .NET Core 5.0\">	<File Type=\"Managed\" Path=\"lib/Microsoft.Windows.SDK.NET.dll\" PublicKeyToken=\"null\" AssemblyName=\"Microsoft.Windows.SDK.NET\" AssemblyVersion=\"10.0.18362.3\" FileVersion=\"10.0.18362.3\" /></FileList>";
+    }
+}

--- a/src/Tasks/Microsoft.NET.Build.Tasks/GenerateDepsFile.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/GenerateDepsFile.cs
@@ -168,13 +168,28 @@ namespace Microsoft.NET.Build.Tasks
                 ReferenceInfo.CreateDependencyReferenceInfos(ReferenceDependencyPaths, ReferenceSatellitePaths, isUserRuntimeAssembly);
 
             Dictionary<string, SingleProjectInfo> referenceProjects =
-                SingleProjectInfo.CreateProjectReferenceInfos(ReferencePaths, ReferenceSatellitePaths, isUserRuntimeAssembly);
+                SingleProjectInfo.CreateProjectReferenceInfos(ReferencePaths, ReferenceSatellitePaths,
+                    isUserRuntimeAssembly);
+
+            bool ShouldIncludeRuntimeAsset(ITaskItem item)
+            {
+                if (IsSelfContained)
+                {
+                    if (!IsSingleFile || !item.GetMetadata(MetadataKeys.DropFromSingleFile).Equals("true"))
+                    {
+                        return true;
+                    }
+                }
+                else if (item.HasMetadataValue(MetadataKeys.RuntimePackAlwaysCopyLocal, "true"))
+                {
+                    return true;
+                }
+
+                return false;
+            }
 
             IEnumerable<RuntimePackAssetInfo> runtimePackAssets =
-                IsSelfContained ? 
-                    RuntimePackAssets.Where(item => !IsSingleFile || !item.GetMetadata(MetadataKeys.DropFromSingleFile).Equals("true"))
-                                     .Select(item => RuntimePackAssetInfo.FromItem(item)) :
-                    Enumerable.Empty<RuntimePackAssetInfo>();
+                RuntimePackAssets.Where(ShouldIncludeRuntimeAsset).Select(RuntimePackAssetInfo.FromItem);
 
             DependencyContextBuilder builder;
             if (projectContext != null)

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolveRuntimePackAssets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveRuntimePackAssets.cs
@@ -83,7 +83,9 @@ namespace Microsoft.NET.Build.Tasks
 
                 if (File.Exists(runtimeListPath))
                 {
-                    AddRuntimePackAssetsFromManifest(runtimePackAssets, runtimePackRoot, runtimeListPath, runtimePack);
+                    var runtimePackAlwaysCopyLocal = runtimePack.HasMetadataValue(MetadataKeys.RuntimePackAlwaysCopyLocal, "true");
+
+                    AddRuntimePackAssetsFromManifest(runtimePackAssets, runtimePackRoot, runtimeListPath, runtimePack, runtimePackAlwaysCopyLocal);
                 }
                 else
                 {
@@ -95,7 +97,7 @@ namespace Microsoft.NET.Build.Tasks
         }
 
         private void AddRuntimePackAssetsFromManifest(List<ITaskItem> runtimePackAssets, string runtimePackRoot,
-            string runtimeListPath, ITaskItem runtimePack)
+            string runtimeListPath, ITaskItem runtimePack, bool runtimePackAlwaysCopyLocal)
         {
             var assetSubPaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
@@ -149,6 +151,10 @@ namespace Microsoft.NET.Build.Tasks
                 assetItem.SetMetadata("FileVersion", fileElement.Attribute("FileVersion")?.Value);
                 assetItem.SetMetadata("PublicKeyToken", fileElement.Attribute("PublicKeyToken")?.Value);
                 assetItem.SetMetadata("DropFromSingleFile", fileElement.Attribute("DropFromSingleFile")?.Value);
+                if (runtimePackAlwaysCopyLocal)
+                {
+                    assetItem.SetMetadata(MetadataKeys.RuntimePackAlwaysCopyLocal, "true");
+                }
 
                 runtimePackAssets.Add(assetItem);
             }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets
@@ -61,6 +61,8 @@ Copyright (c) .NET Foundation. All rights reserved.
                                 KnownRuntimePacks="@(KnownRuntimePack)"
                                 TargetFrameworkIdentifier="$(TargetFrameworkIdentifier)"
                                 TargetFrameworkVersion="$(_TargetFrameworkVersionWithoutV)"
+                                TargetPlatformIdentifier="$(TargetPlatformIdentifier)"
+                                TargetPlatformVersion="$(TargetPlatformVersion)"
                                 TargetingPackRoot="$(NetCoreTargetingPackRoot)"
                                 RuntimeGraphPath="$(BundledRuntimeIdentifierGraphFile)"
                                 SelfContained="$(SelfContained)"
@@ -384,7 +386,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     
     <ItemGroup>
       <ReferenceCopyLocalPaths Include="@(RuntimePackAsset)"
-                               Condition="'$(CopyLocalLockFileAssemblies)' == 'true' and '$(SelfContained)' == 'true'" />
+                               Condition="'$(CopyLocalLockFileAssemblies)' == 'true' and ('$(SelfContained)' == 'true' or '%(RuntimePackAsset.RuntimePackAlwaysCopyLocal)' == 'true')" />
     </ItemGroup>
   
   

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.props
@@ -126,4 +126,5 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.NET.PackTool.props" />
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.NET.PackProjectTool.props" />
+  <Import Project="$(MSBuildThisFileDirectory)Microsoft.NET.Windows.props" />
 </Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -960,4 +960,5 @@ Copyright (c) .NET Foundation. All rights reserved.
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.NET.Sdk.FSharp.targets" Condition="'$(Language)' == 'F#'" />
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.NET.ILLink.targets" />
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.NET.Sdk.Analyzers.targets" Condition="'$(Language)' == 'C#' or '$(Language)' == 'VB'" />
+  <Import Project="$(MSBuildThisFileDirectory)Microsoft.NET.Windows.targets" Condition="'$(TargetPlatformIdentifier)' == 'Windows'" />
 </Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Windows.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Windows.props
@@ -1,0 +1,17 @@
+<!--
+***********************************************************************************************
+Microsoft.NET.Windows.props
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+          created a backup copy.  Incorrect changes to this file will make it
+          impossible to load or build your projects from the command-line or the IDE.
+
+Copyright (c) .NET Foundation. All rights reserved.
+***********************************************************************************************
+-->
+
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Condition=" '$(_IncludeWindowsSDKRefFrameworkReferences)' == 'true' ">
+    <FrameworkReference Include="Microsoft.Windows.SDK.NET.Ref" IsImplicitlyDefined="true" Pack="false" PrivateAssets="All" />
+  </ItemGroup>
+</Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Windows.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Windows.targets
@@ -1,0 +1,17 @@
+<!--
+***********************************************************************************************
+Microsoft.NET.Windows.targets
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+          created a backup copy.  Incorrect changes to this file will make it
+          impossible to load or build your projects from the command-line or the IDE.
+
+Copyright (c) .NET Foundation. All rights reserved.
+***********************************************************************************************
+-->
+
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Condition=" '$(DisableImplicitFrameworkReferences)' != 'true' and '$(TargetFrameworkIdentifier)' == '.NETCoreApp' and $([MSBuild]::VersionGreaterThanOrEquals($(_TargetFrameworkVersionWithoutV), '5.0')) and '$(TargetPlatformIdentifier)' == 'Windows' and $([MSBuild]::VersionGreaterThanOrEquals($(TargetPlatformVersion), '10.0')) ">
+    <_IncludeWindowsSDKRefFrameworkReferences>true</_IncludeWindowsSDKRefFrameworkReferences>
+  </PropertyGroup>
+</Project>

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildALibrary.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildALibrary.cs
@@ -442,6 +442,8 @@ namespace Microsoft.NET.Build.Tests
                     propGroup.Add(platformIdentifier);
                     var platformVersion = new XElement(ns + "TargetPlatformVersion", targetPlatformVersion);
                     propGroup.Add(platformVersion);
+                    var disableUnnecessaryImplicitFrameworkReferencesForThisTest = new XElement(ns + "DisableImplicitFrameworkReferences", "true");
+                    propGroup.Add(disableUnnecessaryImplicitFrameworkReferencesForThisTest);
                 });
 
             AssertDefinedConstantsOutput(testAsset, targetFramework, new[] { "NETCOREAPP", "NET", "NET5_0", "NETCOREAPP3_1" }.Concat(expectedDefines).ToArray());


### PR DESCRIPTION
fix https://github.com/dotnet/sdk/issues/11556


Pending https://github.com/NuGet/NuGet.Client/pull/3479 . Currently use a temp implementation.
Pending https://github.com/dotnet/sdk/pull/12202 , so we can remove explicit definition in for TargetPlatformIdentifier and TargetPlatformVersion
Pending an edit in KnownFrameworkReference, when Microsoft.Windows.SDK.NET.Ref is ready

test project (Cannot make an automated test now since the windows package is not pushed to a feed):
```xml
<Project Sdk="Microsoft.NET.Sdk">

	<ItemGroup>
    	<KnownFrameworkReference Include="Microsoft.Windows.SDK.NET.Ref"
                              TargetFramework="net5.0-windows10.0.18362"
                              RuntimeFrameworkName="Microsoft.Windows.SDK.NET.Ref"
                              DefaultRuntimeFrameworkVersion="10.0.18362.1-preview"
                              LatestRuntimeFrameworkVersion="10.0.18362.1-preview"
                              TargetingPackName="Microsoft.Windows.SDK.NET.Ref"
                              TargetingPackVersion="10.0.18362.1-preview"
                              RuntimePackNamePatterns="Microsoft.Windows.SDK.NET.Ref"
							  RuntimePackRuntimeIdentifiers="any"
							  RuntimeCopylocal="true"
							  IsWindowsOnly="true"
                              />
	</ItemGroup>

	<PropertyGroup>
		<OutputType>Exe</OutputType>
		<TargetFramework>net5.0</TargetFramework>
		<TargetPlatformIdentifier>Windows</TargetPlatformIdentifier>
		<TargetPlatformVersion>10.0.18362</TargetPlatformVersion>
	</PropertyGroup>

</Project>
```