### PR TITLE
Add ILLink extension points (#12116)

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ILLink.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ILLink.targets
@@ -13,7 +13,9 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <Import Project="Sdk.props" Sdk="Microsoft.NET.ILLink.Tasks" />
 
-  <PropertyGroup Condition=" '$(PublishTrimmed)' == 'true' ">
+  <!-- These properties should be set even if PublishTrimmed != true, to allow SDK components to
+       set PublishTrimmed in targets which are imported after these targets. -->
+  <PropertyGroup>
     <IntermediateLinkDir Condition=" '$(IntermediateLinkDir)' == '' ">$(IntermediateOutputPath)linked\</IntermediateLinkDir>
     <IntermediateLinkDir Condition=" !HasTrailingSlash('$(IntermediateLinkDir)') ">$(IntermediateLinkDir)\</IntermediateLinkDir>
     <!-- Used to enable incremental build for the linker target. -->
@@ -37,21 +39,21 @@ Copyright (c) .NET Foundation. All rights reserved.
     <NETSdkInformation ResourceName="ILLink_Info" />
 
     <ItemGroup>
-      <_LinkedResolvedFileToPublish Include="@(_LinkedResolvedFileToPublishCandidates)" Condition="Exists('%(Identity)')" />
-      <ResolvedFileToPublish Remove="@(_ManagedAssembliesToLink)" />
+      <_LinkedResolvedFileToPublish Include="@(_LinkedResolvedFileToPublishCandidate)" Condition="Exists('%(Identity)')" />
+      <ResolvedFileToPublish Remove="@(ManagedAssemblyToLink)" />
       <ResolvedFileToPublish Include="@(_LinkedResolvedFileToPublish)" />
     </ItemGroup>
 
     <!-- Remove assemblies from inputs to GenerateDepsFile. See
          https://github.com/dotnet/sdk/pull/3086 -->
     <ItemGroup>
-      <_RemovedManagedAssemblies Include="@(_ManagedAssembliesToLink)" Condition="!Exists('$(IntermediateLinkDir)%(Filename)%(Extension)')" />
+      <_RemovedManagedAssembly Include="@(ManagedAssemblyToLink)" Condition="!Exists('$(IntermediateLinkDir)%(Filename)%(Extension)')" />
 
-      <ResolvedCompileFileDefinitions Remove="@(_RemovedManagedAssemblies)" />
-      <RuntimeCopyLocalItems Remove="@(_RemovedManagedAssemblies)" />
-      <RuntimeTargetsCopyLocalItems Remove="@(_RemovedManagedAssemblies)" />
-      <UserRuntimeAssembly Remove="@(_RemovedManagedAssemblies)" />
-      <RuntimePackAsset Remove="@(_RemovedManagedAssemblies)" />
+      <ResolvedCompileFileDefinitions Remove="@(_RemovedManagedAssembly)" />
+      <RuntimeCopyLocalItems Remove="@(_RemovedManagedAssembly)" />
+      <RuntimeTargetsCopyLocalItems Remove="@(_RemovedManagedAssembly)" />
+      <UserRuntimeAssembly Remove="@(_RemovedManagedAssembly)" />
+      <RuntimePackAsset Remove="@(_RemovedManagedAssembly)" />
     </ItemGroup>
 
   </Target>
@@ -67,8 +69,8 @@ Copyright (c) .NET Foundation. All rights reserved.
     -->
   <UsingTask TaskName="ILLink" AssemblyFile="$(ILLinkTasksAssembly)" />
   <Target Name="_RunILLink"
-          DependsOnTargets="_ComputeManagedAssembliesToLink;_SetILLinkDefaults"
-          Inputs="$(MSBuildAllProjects);@(_ManagedAssembliesToLink);@(TrimmerRootDescriptor);@(ReferencePath)"
+          DependsOnTargets="_ComputeManagedAssemblyToLink;PrepareForILLink"
+          Inputs="$(MSBuildAllProjects);@(ManagedAssemblyToLink);@(TrimmerRootDescriptor);@(ReferencePath)"
           Outputs="$(_LinkSemaphore)">
 
     <!-- When running from Desktop MSBuild, DOTNET_HOST_PATH is not set.
@@ -79,13 +81,21 @@ Copyright (c) .NET Foundation. All rights reserved.
       <_DotNetHostFileName Condition=" '$(OS)' == 'Windows_NT' ">dotnet.exe</_DotNetHostFileName>
     </PropertyGroup>
 
-    <Delete Files="@(_LinkedResolvedFileToPublishCandidates)" />
-    <ILLink AssemblyPaths="@(_ManagedAssembliesToLink)"
+    <!-- Temporary workaround until the naming is finalized. Translate from TrimMode to Action metadata. -->
+    <ItemGroup>
+      <ManagedAssemblyToLink Condition=" '%(ManagedAssemblyToLink.TrimMode)' != '' ">
+        <Action>%(ManagedAssemblyToLink.TrimMode)</Action>
+      </ManagedAssemblyToLink>
+    </ItemGroup>
+
+    <Delete Files="@(_LinkedResolvedFileToPublishCandidate)" />
+    <ILLink AssemblyPaths="@(ManagedAssemblyToLink)"
             ReferenceAssemblyPaths="@(ReferencePath)"
             RootAssemblyNames="@(TrimmerRootAssembly)"
-            DefaultAction="$(_TrimmerDefaultAction)"
+            DefaultAction="$(TrimMode)"
             LinkSymbols="$(_TrimmerLinkSymbols)"
             FeatureSettings="@(_TrimmerFeatureSettings)"
+            CustomData="@(_TrimmerCustomData)"
 
             BeforeFieldInit="$(_TrimmerBeforeFieldInit)"
             OverrideRemoval="$(_TrimmerOverrideRemoval)"
@@ -109,12 +119,18 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <!--
     ============================================================
-                     _SetILLinkDefaults
+                     PrepareForILLink
 
-    Set up the default options and inputs to ILLink.
+    Set up the default options and inputs to ILLink. Other targets are expected to hook into
+    this extension point via BeforeTargets/AfterTargets to opt assemblies into or out of trimming
+    using global ILLink options, or per-assembly IsTrimmable and TrimMode metadata.
+
+    Note that adding items to or removing items from ManagedAssemblyToLink is unsupported. To change
+    the set of inputs to the linker, instead use a different extension point to
+    set PostprocessAssembly metadata on ResolvedFileToPublish.
    -->
-   <Target Name="_SetILLinkDefaults"
-           DependsOnTargets="_ComputeManagedAssembliesToLink">
+   <Target Name="PrepareForILLink"
+           DependsOnTargets="_ComputeManagedAssemblyToLink">
 
     <!-- The defaults currently root non-framework assemblies, which
          is a no-op for portable apps. If we later support more ways
@@ -124,13 +140,19 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <PropertyGroup>
       <_ExtraTrimmerArgs>--skip-unresolved true $(_ExtraTrimmerArgs)</_ExtraTrimmerArgs>
-      <_TrimmerDefaultAction Condition=" '$(_TrimmerDefaultAction)' == '' ">copyused</_TrimmerDefaultAction>
+      <TrimMode Condition=" '$(TrimMode)' == '' ">copyused</TrimMode>
     </PropertyGroup>
+
     <ItemGroup>
-      <TrimmerRootAssembly Include="@(_ManagedAssembliesToLink)" Condition=" '%(_ManagedAssembliesToLink.IsTrimmable)' != 'true' " />
-      <_ManagedAssembliesToLink Condition=" '%(_ManagedAssembliesToLink.IsTrimmable)' != 'true' ">
-        <action>copy</action>
-      </_ManagedAssembliesToLink>
+      <!-- Treat any assemblies that already have customized TrimMode as trimmable. -->
+      <ManagedAssemblyToLink Condition=" '%(ManagedAssemblyToLink.TrimMode)' != '' ">
+        <IsTrimmable>true</IsTrimmable>
+      </ManagedAssemblyToLink>
+      <!-- Root and copy non-trimmable assemblies. -->
+      <TrimmerRootAssembly Include="@(ManagedAssemblyToLink)" Condition=" '%(ManagedAssemblyToLink.IsTrimmable)' != 'true' " />
+      <ManagedAssemblyToLink Condition=" '%(ManagedAssemblyToLink.IsTrimmable)' != 'true' ">
+        <TrimMode>copy</TrimMode>
+      </ManagedAssemblyToLink>
     </ItemGroup>
 
     <ItemGroup>
@@ -141,22 +163,22 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <!--
     ============================================================
-                     _ComputeManagedAssembliesToLink
+                     _ComputeManagedAssemblyToLink
 
     Compute the set of inputs to the linker.
     ============================================================
     -->
   <UsingTask TaskName="ComputeManagedAssemblies" AssemblyFile="$(ILLinkTasksAssembly)" />
-  <Target Name="_ComputeManagedAssembliesToLink" DependsOnTargets="_ComputeAssembliesToPostprocessOnPublish">
+  <Target Name="_ComputeManagedAssemblyToLink" DependsOnTargets="_ComputeAssembliesToPostprocessOnPublish">
 
     <!-- NB: There should not be non-managed assemblies in this list, but we still give the linker a chance to
          further refine this list. It currently drops C++/CLI assemblies in ComputeManageAssemblies. -->
     <ComputeManagedAssemblies Assemblies="@(ResolvedFileToPublish->WithMetadataValue('PostprocessAssembly', 'true'))">
-      <Output TaskParameter="ManagedAssemblies" ItemName="_ManagedAssembliesToLink" />
+      <Output TaskParameter="ManagedAssemblies" ItemName="ManagedAssemblyToLink" />
     </ComputeManagedAssemblies>
 
     <ItemGroup>
-      <_LinkedResolvedFileToPublishCandidates Include="@(_ManagedAssembliesToLink->'$(IntermediateLinkDir)%(Filename)%(Extension)')" />
+      <_LinkedResolvedFileToPublishCandidate Include="@(ManagedAssemblyToLink->'$(IntermediateLinkDir)%(Filename)%(Extension)')" />
     </ItemGroup>
 
   </Target>


### PR DESCRIPTION
Port #12116 to preview7.

### Summary
Blazor WASM applications need to be able to extend the ILLink functionality in the SDK. Without this extensibility, ILLink only performs "assembly level" trimming. It doesn't trim unused code from assemblies (like System.Private.CoreLib). This adds extensibility into the ILLinker to allow Blazor to specify which assemblies should be trimmed, and at what level.

### Customer Impact
**Medium:** Without this functionality, a Blazor application is over double from what we shipped in Blazor 3.2. Currently, it is at ~ 4 MB download size, when in Blazor 3.2 it was ~1.8 MB.

### Regression?
No, this is new functionality of the ILLinker in the SDK.

### Testing
Automated tests are added with this PR. I also tested manually that I can use this functionality to trim a Blazor application successfully.

### Risk
**Low:** This is new functionality that is already in the master branch and it doesn't change existing behavior. Getting it into preview7 and getting early feedback on it would be beneficial.

* Add ILLink extension points

See https://github.com/dotnet/sdk/issues/12035

- PrepareForILLink target
- ManagedAssemblyToLink ItemGroup
- TrimMode property and metadata
- private _TrimmerCustomData (https://github.com/mono/linker/issues/1134)
- Allow setting `PublishTrimmed` in a late import.targets

* Add tests for extension points

* Set Action in _RunILLink

* Add notes about ManagedAssemblyToLink