### PR TITLE
Add list of properties copied between configuration

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.props
@@ -34,6 +34,12 @@ Copyright (c) .NET Foundation. All rights reserved.
     <Deterministic Condition=" '$(Deterministic)' == '' ">true</Deterministic>
   </PropertyGroup>
 
+  <!-- These are the names that we copy between configurations -->
+  <!-- Helper to fix https://github.com/dotnet/project-system/issues/2828 -->
+  <PropertyGroup>
+    <CopyingConfigurationProperties>$(CopyingConfigurationProperties);Optimize;DebugSymbols</CopyingConfigurationProperties>
+  </PropertyGroup>
+
   <!-- User-facing configuration-specific defaults -->
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">


### PR DESCRIPTION
This is part of the fix [2828 ](https://github.com/dotnet/project-system/issues/2828)Project System

There is not much support in CPS to get the list of
evaluated properties from Sdk. These values are hard coded
and need to be in sync with properties that factor on configuration.