### PR TITLE
Disable SDL and other validation

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -143,8 +143,11 @@ stages:
   - template: /eng/common/templates/post-build/post-build.yml
     parameters:
       enableSymbolValidation: false
+      enableSigningValidation: false
+      enableNugetValidation: false
+      enableSourceLinkValidation: false
       SDLValidationParameters:
-        enable: true
+        enable: false
         params: ' -SourceToolsList @("policheck","credscan")
         -TsaInstanceURL $(_TsaInstanceURL)
         -TsaProjectName $(_TsaProjectName)


### PR DESCRIPTION
After onboarding to post-build/nightly SDL validation, all this validation is run once a day and so can be removed from the build, saving signficant time.