### PR TITLE
Enable BinaryFormatter killbit by default in aspnet applications; introduce feature switch

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -398,6 +398,10 @@ Copyright (c) .NET Foundation. All rights reserved.
                                     Value="$(InvariantGlobalization)"
                                     Trim="true" />
 
+    <RuntimeHostConfigurationOption Include="System.Runtime.Serialization.EnableUnsafeBinaryFormatterSerialization"
+                                    Condition="'$(EnableUnsafeBinaryFormatterSerialization)' != ''"
+                                    Value="$(EnableUnsafeBinaryFormatterSerialization)"
+                                    Trim="true" />
   </ItemGroup>
 
   <!--

--- a/src/WebSdk/ProjectSystem/Targets/Microsoft.NET.Sdk.Web.ProjectSystem.targets
+++ b/src/WebSdk/ProjectSystem/Targets/Microsoft.NET.Sdk.Web.ProjectSystem.targets
@@ -35,6 +35,17 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ProjectCapability Include="AspNetCoreInProcessHosting" />
   </ItemGroup>
 
+  <PropertyGroup>
+    <!--
+      Unless the project explicitly set the property value to 'true' (case-insensitive),
+      default it to 'false'. Not specifying a value at all (or specifying an empty value)
+      will also default to 'false'. In .NET 5.0 this functionality is explicitly disabled
+      by default for web project types, and in future .NET releases the "disable by default"
+      logic will roll out to other project types.
+    -->
+    <EnableUnsafeBinaryFormatterSerialization Condition="'$(EnableUnsafeBinaryFormatterSerialization)' != 'true'">false</EnableUnsafeBinaryFormatterSerialization>
+  </PropertyGroup>
+
   <!--
     Newer versions of Visual Studio ship the designtime related properties in a targets file and all future design time only elements should be added there. If that file does not
     exist, it falls back to the default set of values defined here.

--- a/src/WebSdk/ProjectSystem/Targets/Microsoft.NET.Sdk.Web.ProjectSystem.targets
+++ b/src/WebSdk/ProjectSystem/Targets/Microsoft.NET.Sdk.Web.ProjectSystem.targets
@@ -37,13 +37,13 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <PropertyGroup>
     <!--
-      Unless the project explicitly set the property value to 'true' (case-insensitive),
-      default it to 'false'. Not specifying a value at all (or specifying an empty value)
-      will also default to 'false'. In .NET 5.0 this functionality is explicitly disabled
-      by default for web project types, and in future .NET releases the "disable by default"
-      logic will roll out to other project types.
+      ASP.NET 5.0 explicitly disables this functionality by default, requiring the app author
+      to opt-in to re-enabling the feature. The way to opt back in is to specify the below
+      element with the value "true". It is anticipated that future releases of .NET will
+      disable this functionality by default across all project types, at which point this logic
+      can be removed from the ASP.NET-specific SDK.
     -->
-    <EnableUnsafeBinaryFormatterSerialization Condition="'$(EnableUnsafeBinaryFormatterSerialization)' != 'true'">false</EnableUnsafeBinaryFormatterSerialization>
+    <EnableUnsafeBinaryFormatterSerialization Condition="'$(EnableUnsafeBinaryFormatterSerialization)' == ''">false</EnableUnsafeBinaryFormatterSerialization>
   </PropertyGroup>
 
   <!--


### PR DESCRIPTION
Contributes to https://github.com/dotnet/sdk/issues/12217

This is the "feature switch" companion PR to https://github.com/dotnet/runtime/pull/38963. It also triggers the `BinaryFormatter` killbit by default for aspnet applications. Unlike wasm applications, the project file can still opt-in to allowing `BinaryFormatter` payloads to run.

Open questions and notes for reviewers:

- It'd be good to get clarification on the open question at https://github.com/dotnet/sdk/issues/12217#issuecomment-657151788.

- Is using the .targets file the right way to perform the check "the developer must have defined this element, and the value must be equal to _true_"? What I'm trying to avoid is having somebody write `<Enable>I like puppies!</Enable>" and having that re-enable the feature. In aspnet project types, the default behavior should be _killbit on_ unless somebody explicitly specifies _killbit off_.

/cc @davidfowl 

__This is a breaking change and should be documented in the Preview 8 release notes.__

This change should only affect .NET 5.0+ applications. Setting the switch has no effect in .NET Framework or .NET Core 2.x - 3.x.

Further documentation will be available at https://aka.ms/binaryformatter.