### PR TITLE
Add SDK support for Debugger.IsSupported and Http.EnableActivityPropagation

### DIFF
--- a/src/Assets/TestProjects/KitchenSink/TestApp/TestApp.csproj
+++ b/src/Assets/TestProjects/KitchenSink/TestApp/TestApp.csproj
@@ -20,6 +20,8 @@
     <EventSourceSupport>false</EventSourceSupport>
     <UseSystemResourceKeys>true</UseSystemResourceKeys>
     <EnableUnsafeUTF7Encoding>false</EnableUnsafeUTF7Encoding>
+    <HttpActivityPropagationSupport>false</HttpActivityPropagationSupport>
+    <DebuggerSupport>true</DebuggerSupport>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -346,6 +346,11 @@ Copyright (c) .NET Foundation. All rights reserved.
     -->
 
   <ItemGroup>
+    <RuntimeHostConfigurationOption Include="System.Diagnostics.Debugger.IsSupported"
+                                    Condition="'$(DebuggerSupport)' != ''"
+                                    Value="$(DebuggerSupport)"
+                                    Trim="true" />
+
     <RuntimeHostConfigurationOption Include="System.Diagnostics.Tracing.EventSource.IsSupported"
                                     Condition="'$(EventSourceSupport)' != ''"
                                     Value="$(EventSourceSupport)"
@@ -362,6 +367,16 @@ Copyright (c) .NET Foundation. All rights reserved.
     <RuntimeHostConfigurationOption Include="System.GC.RetainVM"
                                     Condition="'$(RetainVMGarbageCollection)' != ''"
                                     Value="$(RetainVMGarbageCollection)" />
+
+    <RuntimeHostConfigurationOption Include="System.Globalization.Invariant"
+                                    Condition="'$(InvariantGlobalization)' != ''"
+                                    Value="$(InvariantGlobalization)"
+                                    Trim="true" />
+
+    <RuntimeHostConfigurationOption Include="System.Net.Http.EnableActivityPropagation"
+                                    Condition="'$(HttpActivityPropagationSupport)' != ''"
+                                    Value="$(HttpActivityPropagationSupport)"
+                                    Trim="true" />
 
     <RuntimeHostConfigurationOption Include="System.Resources.UseSystemResourceKeys"
                                     Condition="'$(UseSystemResourceKeys)' != ''"
@@ -393,11 +408,6 @@ Copyright (c) .NET Foundation. All rights reserved.
                                     Condition="'$(ThreadPoolMaxThreads)' != ''"
                                     Value="$(ThreadPoolMaxThreads)" />
   
-    <RuntimeHostConfigurationOption Include="System.Globalization.Invariant"
-                                    Condition="'$(InvariantGlobalization)' != ''"
-                                    Value="$(InvariantGlobalization)"
-                                    Trim="true" />
-
   </ItemGroup>
 
   <!--

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAProjectWithAllFeatures.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAProjectWithAllFeatures.cs
@@ -66,10 +66,13 @@ namespace Microsoft.NET.Publish.Tests
             var baselineConfigJsonObject = JObject.Parse(@"{
     ""runtimeOptions"": {
         ""configProperties"": {
+            ""System.Diagnostics.Debugger.IsSupported"": true,
             ""System.Diagnostics.Tracing.EventSource.IsSupported"": false,
+            ""System.Globalization.Invariant"": true,
             ""System.GC.Concurrent"": false,
             ""System.GC.Server"": true,
             ""System.GC.RetainVM"": false,
+            ""System.Net.Http.EnableActivityPropagation"": false,
             ""System.Resources.UseSystemResourceKeys"": true,
             ""System.Runtime.TieredCompilation"": true,
             ""System.Runtime.TieredCompilation.QuickJit"": true,
@@ -77,7 +80,6 @@ namespace Microsoft.NET.Publish.Tests
             ""System.Text.Encoding.EnableUnsafeUTF7Encoding"": false,
             ""System.Threading.ThreadPool.MinThreads"": 2,
             ""System.Threading.ThreadPool.MaxThreads"": 9,
-            ""System.Globalization.Invariant"": true,
             ""extraProperty"": true
         },
         ""framework"": {


### PR DESCRIPTION
These feature switches were added in the runtime:
* Debugger - https://github.com/dotnet/runtime/pull/37288
* Http activity propagation - https://github.com/dotnet/runtime/pull/38765

Fix #12217