### PR TITLE
Insert 3.1.6 runtime

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -15,9 +15,9 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>ed69753a3ffbdaa08365252c710d57a64d17f859</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.HostModel" Version="3.1.2" Pinned="true">
-      <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>916b5cba268e1e1e803243004f4276cf40b2dda8</Sha>
+    <Dependency Name="Microsoft.NET.HostModel" Version="3.1.6">
+      <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-core-setup</Uri>
+      <Sha>3acd9b0cd16596bad450c82be08780875a73c05c</Sha>
     </Dependency>
     <Dependency Name="NuGet.Build.Tasks" Version="5.7.0-rtm.6702">
       <Uri>https://github.com/NuGet/NuGet.Client</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -15,7 +15,7 @@
     <MicrosoftBuildFrameworkVersion>15.4.8</MicrosoftBuildFrameworkVersion>
     <MicrosoftBuildUtilitiesCoreVersion>15.4.8</MicrosoftBuildUtilitiesCoreVersion>
     <MicrosoftExtensionsDependencyModelVersion>2.1.0-preview2-26306-03</MicrosoftExtensionsDependencyModelVersion>
-    <MicrosoftNETHostModelVersion>3.1.2</MicrosoftNETHostModelVersion>
+    <MicrosoftNETHostModelVersion>3.1.6</MicrosoftNETHostModelVersion>
     <NETStandardLibraryNETFrameworkVersion>2.0.1-servicing-26011-01</NETStandardLibraryNETFrameworkVersion>
     <NewtonsoftJsonVersion>9.0.1</NewtonsoftJsonVersion>
     <NuGetBuildTasksPackageVersion>5.7.0-rtm.6702</NuGetBuildTasksPackageVersion>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "3.1.400-preview-015212",
+    "dotnet": "3.1.400-preview-015217",
     "vs-opt": {
       "version": "15.9"
     }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "3.1.400-preview-015204",
+    "dotnet": "3.1.400-preview-015212",
     "vs-opt": {
       "version": "15.9"
     }


### PR DESCRIPTION
This will need a stage0 from the 3.1.6 insertion into dotnet/installer. I think installer will need to ingest CLI & Toolset with the updated 3.1.6 runtime as well before the produced SDK will unblock this PR