### PR TITLE
Enable Crossgen2 tests

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolveReadyToRunCompilers.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveReadyToRunCompilers.cs
@@ -46,6 +46,7 @@ namespace Microsoft.NET.Build.Tasks
         private ITaskItem _runtimePack;
         private ITaskItem _crossgen2Pack;
         private string _targetRuntimeIdentifier;
+        private string _targetPlatform;
         private string _hostRuntimeIdentifier;
 
         private CrossgenToolInfo _crossgenTool;
@@ -111,9 +112,9 @@ namespace Microsoft.NET.Build.Tasks
                 return false;
             }
 
-            if (!ExtractTargetPlatformAndArchitecture(_targetRuntimeIdentifier, out string targetPlatform, out _targetArchitecture) ||
+            if (!ExtractTargetPlatformAndArchitecture(_targetRuntimeIdentifier, out _targetPlatform, out _targetArchitecture) ||
                 !ExtractTargetPlatformAndArchitecture(_hostRuntimeIdentifier, out string hostPlatform, out Architecture hostArchitecture) ||
-                targetPlatform != hostPlatform)
+                _targetPlatform != hostPlatform)
             {
                 Log.LogError(Strings.ReadyToRunTargetNotSupportedError);
                 return false;
@@ -149,13 +150,15 @@ namespace Microsoft.NET.Build.Tasks
             //      win-x64 -> win-x64
             //      linux-x64 -> linux-x64
             //      linux-musl-x64 -> linux-musl-x64
-            if (_targetRuntimeIdentifier != _hostRuntimeIdentifier)
+            if (!ExtractTargetPlatformAndArchitecture(_targetRuntimeIdentifier, out _targetPlatform, out _targetArchitecture) ||
+                !GetTargetSpec(out string targetSpec) ||
+                _targetRuntimeIdentifier != _hostRuntimeIdentifier)
             {
                 Log.LogError(Strings.ReadyToRunTargetNotSupportedError);
                 return false;
             }
 
-            if (!GetCrossgen2ComponentsPaths())
+            if (!GetCrossgen2ComponentsPaths(targetSpec))
             {
                 Log.LogError(Strings.ReadyToRunTargetNotSupportedError);
                 return false;
@@ -326,20 +329,53 @@ namespace Microsoft.NET.Build.Tasks
             return File.Exists(_crossgenTool.ToolPath) && File.Exists(_crossgenTool.ClrJitPath);
         }
 
-        private bool GetCrossgen2ComponentsPaths()
+        private bool GetCrossgen2ComponentsPaths(string targetSpec)
         {
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 _crossgen2Tool.ToolPath = Path.Combine(_crossgen2Tool.PackagePath, "tools", "crossgen2.exe");
-                _crossgen2Tool.ClrJitPath = Path.Combine(_crossgen2Tool.PackagePath, "tools", $"clrjit-{_targetRuntimeIdentifier}.dll");
+                _crossgen2Tool.ClrJitPath = Path.Combine(_crossgen2Tool.PackagePath, "tools", $"clrjit-{targetSpec}.dll");
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                _crossgen2Tool.ToolPath = Path.Combine(_crossgen2Tool.PackagePath, "tools", "crossgen2");
+                _crossgen2Tool.ClrJitPath = Path.Combine(_crossgen2Tool.PackagePath, "tools", $"libclrjit-{targetSpec}.so");
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                _crossgen2Tool.ToolPath = Path.Combine(_crossgen2Tool.PackagePath, "tools", "crossgen2");
+                _crossgen2Tool.ClrJitPath = Path.Combine(_crossgen2Tool.PackagePath, "tools", $"libclrjit-{targetSpec}.dylib");
             }
             else
             {
-                _crossgen2Tool.ToolPath = Path.Combine(_crossgen2Tool.PackagePath, "tools", "crossgen2");
-                _crossgen2Tool.ClrJitPath = Path.Combine(_crossgen2Tool.PackagePath, "tools", $"libclrjit-{_targetRuntimeIdentifier}.so");
+                // Unknown platform
+                return false;
             }
 
             return File.Exists(_crossgen2Tool.ToolPath) && File.Exists(_crossgen2Tool.ClrJitPath);
+        }
+
+        // Keep in sync with JitConfigProvider.GetTargetSpec
+        private bool GetTargetSpec(out string targetSpec)
+        {
+            string targetOSComponent = (_targetPlatform == "win" ? "win" : "unix");
+            string targetArchComponent = _targetArchitecture switch
+            {
+                Architecture.X86 => "x86",
+                Architecture.X64 => "x64",
+                Architecture.Arm => "arm",
+                Architecture.Arm64 => "arm64",
+                _ => null
+            };
+
+            if (targetArchComponent == null)
+            {
+                targetSpec = null;
+                return false;
+            }
+
+            targetSpec = targetOSComponent + '-' + targetArchComponent;
+            return true;
         }
     }
 }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolveReadyToRunCompilers.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveReadyToRunCompilers.cs
@@ -331,12 +331,12 @@ namespace Microsoft.NET.Build.Tasks
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 _crossgen2Tool.ToolPath = Path.Combine(_crossgen2Tool.PackagePath, "tools", "crossgen2.exe");
-                _crossgen2Tool.ClrJitPath = Path.Combine(_crossgen2Tool.PackagePath, "tools", "clrjitilc.dll");
+                _crossgen2Tool.ClrJitPath = Path.Combine(_crossgen2Tool.PackagePath, "tools", $"clrjit-{_targetRuntimeIdentifier}.dll");
             }
             else
             {
                 _crossgen2Tool.ToolPath = Path.Combine(_crossgen2Tool.PackagePath, "tools", "crossgen2");
-                _crossgen2Tool.ClrJitPath = Path.Combine(_crossgen2Tool.PackagePath, "tools", "libclrjitilc.so");
+                _crossgen2Tool.ClrJitPath = Path.Combine(_crossgen2Tool.PackagePath, "tools", $"libclrjit-{_targetRuntimeIdentifier}.so");
             }
 
             return File.Exists(_crossgen2Tool.ToolPath) && File.Exists(_crossgen2Tool.ClrJitPath);

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishANetCoreAppForTelemetry.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishANetCoreAppForTelemetry.cs
@@ -60,7 +60,7 @@ namespace Microsoft.NET.Publish.Tests
                 "\"CompileListCount\":\"[1-9]\\d?\"");  // Do not hardcode number of assemblies being compiled here, due to ILTrimmer
         }
 
-        [CoreMSBuildOnlyTheory(Skip = "https://github.com/dotnet/runtime/issues/37196")]
+        [CoreMSBuildOnlyTheory]
         [InlineData("net5.0")] 
         void It_collects_crossgen2_publishing_properties(string targetFramework)
         {

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishReadyToRun.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishReadyToRun.cs
@@ -194,7 +194,7 @@ namespace Microsoft.NET.Publish.Tests
             TestProjectPublishing_Internal("LibraryProject2", targetFramework, isSelfContained:true, makeExeProject: false);
         }
 
-        [Theory(Skip = "https://github.com/dotnet/runtime/issues/37196")]
+        [Theory]
         [InlineData("net5.0")]
         void It_can_publish_readytorun_using_crossgen2(string targetFramework)
         {
@@ -202,7 +202,18 @@ namespace Microsoft.NET.Publish.Tests
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX) || RuntimeInformation.OSArchitecture != Architecture.X64)
                 return;
 
-            TestProjectPublishing_Internal("Crossgen2TestApp", targetFramework, isSelfContained: true, emitNativeSymbols: true, useCrossgen2: true);
+            TestProjectPublishing_Internal("Crossgen2TestApp", targetFramework, isSelfContained: true, emitNativeSymbols: true, useCrossgen2: true, composite: false);
+        }
+
+        [Theory]
+        [InlineData("net5.0")]
+        void It_can_publish_readytorun_using_crossgen2_composite_mode(string targetFramework)
+        {
+            // Crossgen2 only supported for Linux/Windows x64 scenarios for now
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX) || RuntimeInformation.OSArchitecture != Architecture.X64)
+                return;
+
+            TestProjectPublishing_Internal("Crossgen2TestApp", targetFramework, isSelfContained: true, emitNativeSymbols: false, useCrossgen2: true, composite: true);
         }
 
         [Theory]
@@ -233,7 +244,7 @@ namespace Microsoft.NET.Publish.Tests
                 .And.HaveStdOutContainingIgnoreCase("NETSDK1126");
         }
 
-        private void TestProjectPublishing_Internal(string projectName, string targetFramework, bool makeExeProject = true, bool isSelfContained = true, bool emitNativeSymbols = false, bool useCrossgen2 = false)
+        private void TestProjectPublishing_Internal(string projectName, string targetFramework, bool makeExeProject = true, bool isSelfContained = true, bool emitNativeSymbols = false, bool useCrossgen2 = false, bool composite = true)
         {
             var testProject = CreateTestProjectForR2RTesting(
                 targetFramework,
@@ -244,6 +255,7 @@ namespace Microsoft.NET.Publish.Tests
             testProject.AdditionalProperties["PublishReadyToRun"] = "True";
             testProject.AdditionalProperties["PublishReadyToRunEmitSymbols"] = emitNativeSymbols ? "True" : "False";
             testProject.AdditionalProperties["PublishReadyToRunUseCrossgen2"] = useCrossgen2 ? "True" : "False";
+            testProject.AdditionalProperties["PublishReadyToRunComposite"] = composite ? "True" : "False";
             testProject.AdditionalProperties["SelfContained"] = isSelfContained ? "True" : "False";
 
             var testProjectInstance = _testAssetsManager.CreateTestProject(testProject);


### PR DESCRIPTION
Reflect JIT library name change and add a test for the composite mode. Fixes #11845.
@dotnet/crossgen-contrib