### PR TITLE
Replace spaces when RootNamespace defaults to project name (#11792)

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.props
@@ -30,7 +30,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <FileAlignment Condition=" '$(FileAlignment)' == '' ">512</FileAlignment>
     <ErrorReport Condition=" '$(ErrorReport)' == '' ">prompt</ErrorReport>
     <AssemblyName Condition=" '$(AssemblyName)' == '' ">$(MSBuildProjectName)</AssemblyName>
-    <RootNamespace Condition=" '$(RootNamespace)' == '' ">$(MSBuildProjectName)</RootNamespace>
+    <RootNamespace Condition=" '$(RootNamespace)' == '' ">$(MSBuildProjectName.Replace(" ", "_"))</RootNamespace>
     <Deterministic Condition=" '$(Deterministic)' == '' ">true</Deterministic>
   </PropertyGroup>
 

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildALibrary.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildALibrary.cs
@@ -955,5 +955,63 @@ class Program
 
 
         }
+
+        [Theory]
+        [InlineData("netcoreapp3.1")]
+        [InlineData("netcoreapp5.0")]
+        public void It_makes_RootNamespace_safe_when_project_name_has_spaces(string targetFramework)
+        {
+            var testProject = new TestProject()
+            {
+                Name = "Project Name With Spaces",
+                TargetFrameworks = targetFramework,
+                IsSdkProject = true
+            };
+
+            var testAsset = _testAssetsManager.CreateTestProject(testProject);
+
+            // Overwrite the default file. CreateTestProject uses the defined project name for the namespace.
+            // We need a buildable project to extract the property to verify it
+            // since this issue only surfaces in VS when adding a new class through an item template.
+            File.WriteAllText(Path.Combine(testAsset.Path, testProject.Name, $"{testProject.Name}.cs"), @"
+using System;
+using System.Collections.Generic;
+
+namespace ProjectNameWithSpaces
+{
+    public class ProjectNameWithSpacesClass
+    {
+        public static string Name { get { return ""Project Name With Spaces""; } }
+        public static List<string> List { get { return null; } }
+    }
+}");
+            string projectFolder = Path.Combine(testAsset.Path, testProject.Name);
+
+            var buildCommand = new BuildCommand(testAsset, $"{ testProject.Name}");
+            buildCommand
+                .Execute()
+                .Should()
+                .Pass();
+
+            string GetPropertyValue(string propertyName)
+            {
+                var getValuesCommand = new GetValuesCommand(Log, projectFolder,
+                    testProject.TargetFrameworks, propertyName, GetValuesCommand.ValueType.Property)
+                {
+                    Configuration = "Debug"
+                };
+
+                getValuesCommand
+                    .Execute()
+                    .Should()
+                    .Pass();
+
+                var values = getValuesCommand.GetValues();
+                values.Count.Should().Be(1);
+                return values[0];
+            }
+
+            GetPropertyValue("RootNamespace").Should().Be("Project_Name_With_Spaces");
+        }
     }
 }


### PR DESCRIPTION
Given a project name, e.g "My Project.csproj" that does not define the RootNamespace property, adding a class through an item template in Visual Studio will use the default value from the SDK, which is the project name.

