### PR TITLE
Asynchronously Call SendMessageTimeoutW When Setting PATH

### DIFF
--- a/src/Cli/Microsoft.DotNet.Cli.Utils/WindowsRegistryEnvironmentPathEditor.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/WindowsRegistryEnvironmentPathEditor.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Security.Principal;
+using System.Threading.Tasks;
 using Microsoft.Win32;
 
 namespace Microsoft.DotNet.Cli.Utils
@@ -29,14 +30,17 @@ namespace Microsoft.DotNet.Cli.Utils
                 environmentKey?.SetValue(Path, value, RegistryValueKind.ExpandString);
             }
 
-            unsafe
+            Task.Factory.StartNew(() =>
             {
-                // send a WM_SETTINGCHANGE message to all windows
-                fixed (char* lParam = "Environment")
+                unsafe
                 {
-                    IntPtr r = SendMessageTimeout(new IntPtr(HWND_BROADCAST), WM_SETTINGCHANGE, IntPtr.Zero, (IntPtr)lParam, 0, 1000, out IntPtr _);
+                    // send a WM_SETTINGCHANGE message to all windows
+                    fixed (char* lParam = "Environment")
+                    {
+                        IntPtr r = SendMessageTimeout(new IntPtr(HWND_BROADCAST), WM_SETTINGCHANGE, IntPtr.Zero, (IntPtr)lParam, 0, 1000, out IntPtr _);
+                    }
                 }
-            }
+            });
         }
 
         private static RegistryKey OpenEnvironmentKeyIfExists(bool writable, SdkEnvironmentVariableTarget sdkEnvironmentVariableTarget)


### PR DESCRIPTION
The goal of this issue is to help address a Windows-specific performance issue that occurs on first-run of the CLI.  This is interesting because this first-run behavior is experienced on a regular basis in CI runs, GitHub actions, containers, and clean environments.

The first run of the CLI results in some setup actions occurring.  One of them is to add the global tools directory to the current user's PATH.  This is a two part operation:

 - Update the PATH environment variable via registry APIs.
 - Broadcast the change to all top-level windows by calling `SendMessageTimeoutW`.

The call to `SendMessageTimeoutW` results in significant user-perceived blocking of the main thread while the top-level windows handle the message.  By moving the call to `SendMessageTimeoutW` to a background task, the CLI can move on to executing the user's requested command, and make the blocked time spent in `SendMessageTimeoutW` imperceptible to the user.

With this change, the time to update the PATH variable can be broken up in the following way.  These numbers come from my test environment which is a 4 Core / 4GB RAM VM:
 - Foreground time spent setting the PATH via Registry APIs: 36ms
 - Background time spent calling `SendMessageTimeoutW` and not blocking user execution: 1.2 sec

In my measurements, there is a delay between updating the registry and calling `SendMessageTimeoutW` of ~0.5ms which is induced by the thread hop associated with calling `SendMessageTimeoutW` from the threadpool instead of directly on the main thread.

Prior to this change, the full 1.236 seconds would be on the critical path / main thread and would be perceived by the user.

Addresses part of #12281.

cc: @marcpopMSFT, @timheuer, @bwadswor, @jkotas