### PR TITLE
Compose ASPNETCORE_HOSTINGSTARTUPASSEMBLIES if present in launchSettings.json

### DIFF
--- a/src/Assets/TestProjects/TestAppWithLaunchSettings/Program.cs
+++ b/src/Assets/TestProjects/TestAppWithLaunchSettings/Program.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace ConsoleApplication
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            Console.WriteLine("Hello world");
+            Console.WriteLine($"MyCoolEnvironmentVariableKey={Environment.GetEnvironmentVariable("MyCoolEnvironmentVariableKey")}");
+        }
+    }
+}

--- a/src/Assets/TestProjects/TestAppWithLaunchSettings/Program.cs
+++ b/src/Assets/TestProjects/TestAppWithLaunchSettings/Program.cs
@@ -11,6 +11,7 @@ namespace ConsoleApplication
         {
             Console.WriteLine("Hello world");
             Console.WriteLine($"MyCoolEnvironmentVariableKey={Environment.GetEnvironmentVariable("MyCoolEnvironmentVariableKey")}");
+            Console.WriteLine($"ASPNETCORE_HOSTINGSTARTUPASSEMBLIES={Environment.GetEnvironmentVariable("ASPNETCORE_HOSTINGSTARTUPASSEMBLIES")}");
         }
     }
 }

--- a/src/Assets/TestProjects/TestAppWithLaunchSettings/Properties/launchSettings.json
+++ b/src/Assets/TestProjects/TestAppWithLaunchSettings/Properties/launchSettings.json
@@ -1,0 +1,11 @@
+{
+  "profiles": {
+    "TestAppWithLaunchSettings": {
+      "commandName": "Project",
+      "dotnetRunMessages": "true",
+      "environmentVariables": {
+        "MyCoolEnvironmentVariableKey": "MyCoolEnvironmentVariableValue"
+      }
+    }
+  }
+}

--- a/src/Assets/TestProjects/TestAppWithLaunchSettings/Properties/launchSettings.json
+++ b/src/Assets/TestProjects/TestAppWithLaunchSettings/Properties/launchSettings.json
@@ -4,7 +4,8 @@
       "commandName": "Project",
       "dotnetRunMessages": "true",
       "environmentVariables": {
-        "MyCoolEnvironmentVariableKey": "MyCoolEnvironmentVariableValue"
+        "MyCoolEnvironmentVariableKey": "MyCoolEnvironmentVariableValue",
+        "ASPNETCORE_HOSTINGSTARTUPASSEMBLIES": "HostingStartupInLaunchSettings"
       }
     }
   }

--- a/src/Assets/TestProjects/TestAppWithLaunchSettings/TestAppWithLaunchSettings.csproj
+++ b/src/Assets/TestProjects/TestAppWithLaunchSettings/TestAppWithLaunchSettings.csproj
@@ -1,0 +1,8 @@
+﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), testAsset.props))\testAsset.props" />
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+</Project>

--- a/src/Cli/dotnet/commands/dotnet-run/LaunchSettings/ILaunchSettingsProvider.cs
+++ b/src/Cli/dotnet/commands/dotnet-run/LaunchSettings/ILaunchSettingsProvider.cs
@@ -5,9 +5,7 @@ namespace Microsoft.DotNet.Tools.Run.LaunchSettings
 {
     internal interface ILaunchSettingsProvider
     {
-        string CommandName { get; }
-
-        LaunchSettingsApplyResult TryApplySettings(JsonElement model, ref ICommand command);
+        LaunchSettingsApplyResult TryGetLaunchSettings(JsonElement model);
     }
 
 }

--- a/src/Cli/dotnet/commands/dotnet-run/LaunchSettings/LaunchSettingsApplyResult.cs
+++ b/src/Cli/dotnet/commands/dotnet-run/LaunchSettings/LaunchSettingsApplyResult.cs
@@ -1,18 +1,21 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 namespace Microsoft.DotNet.Tools.Run.LaunchSettings
 {
     public class LaunchSettingsApplyResult
     {
-        public LaunchSettingsApplyResult(bool success, string failureReason, string runAfterLaunch = null)
+        public LaunchSettingsApplyResult(bool success, string failureReason, ProjectLaunchSettingsModel launchSettings = null)
         {
             Success = success;
             FailureReason = failureReason;
-            RunAfterLaunch = runAfterLaunch;
+            LaunchSettings = launchSettings;
         }
 
         public bool Success { get; }
 
         public string FailureReason { get; }
 
-        public string RunAfterLaunch { get; }
+        public ProjectLaunchSettingsModel LaunchSettings { get; }
     }
 }

--- a/src/Cli/dotnet/commands/dotnet-run/LaunchSettings/LaunchSettingsManager.cs
+++ b/src/Cli/dotnet/commands/dotnet-run/LaunchSettings/LaunchSettingsManager.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json;
@@ -21,7 +24,7 @@ namespace Microsoft.DotNet.Tools.Run.LaunchSettings
             };
         }
 
-        public static LaunchSettingsApplyResult TryApplyLaunchSettings(string launchSettingsJsonContents, ref ICommand command, string profileName = null)
+        public static LaunchSettingsApplyResult TryApplyLaunchSettings(string launchSettingsJsonContents, string profileName = null)
         {
             try
             {
@@ -90,7 +93,7 @@ namespace Microsoft.DotNet.Tools.Run.LaunchSettings
                         return new LaunchSettingsApplyResult(false, string.Format(LocalizableStrings.LaunchProfileHandlerCannotBeLocated, commandName));
                     }
 
-                    return provider.TryApplySettings(profileObject, ref command);
+                    return provider.TryGetLaunchSettings(profileObject);
                 }
             }
             catch (JsonException ex)

--- a/src/Cli/dotnet/commands/dotnet-run/LaunchSettings/ProjectLaunchSettingsModel.cs
+++ b/src/Cli/dotnet/commands/dotnet-run/LaunchSettings/ProjectLaunchSettingsModel.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.DotNet.Tools.Run.LaunchSettings
+{
+    public class ProjectLaunchSettingsModel
+    {
+        public string CommandLineArgs { get; set; }
+
+        public bool LaunchBrowser { get; set; }
+
+        public string LaunchUrl { get; set; }
+
+        public string ApplicationUrl { get; set; }
+
+        public string DotNetRunMessages { get; set; }
+
+        public Dictionary<string, string> EnvironmentVariables { get; } = new Dictionary<string, string>(StringComparer.Ordinal);
+    }
+}

--- a/src/Cli/dotnet/commands/dotnet-run/LaunchSettings/ProjectLaunchSettingsProvider.cs
+++ b/src/Cli/dotnet/commands/dotnet-run/LaunchSettings/ProjectLaunchSettingsProvider.cs
@@ -1,7 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
 using System.Text.Json;
-using Microsoft.DotNet.Cli.Utils;
 
 namespace Microsoft.DotNet.Tools.Run.LaunchSettings
 {
@@ -11,7 +12,7 @@ namespace Microsoft.DotNet.Tools.Run.LaunchSettings
 
         public string CommandName => CommandNameValue;
 
-        public LaunchSettingsApplyResult TryApplySettings(JsonElement model, ref ICommand command)
+        public LaunchSettingsApplyResult TryGetLaunchSettings(JsonElement model)
         {
             var config = new ProjectLaunchSettingsModel();
             foreach (var property in model.EnumerateObject())
@@ -52,6 +53,15 @@ namespace Microsoft.DotNet.Tools.Run.LaunchSettings
 
                     config.ApplicationUrl = applicationUrlValue;
                 }
+                else if (string.Equals(property.Name, nameof(ProjectLaunchSettingsModel.DotNetRunMessages), StringComparison.OrdinalIgnoreCase))
+                {
+                    if (!TryGetStringValue(property.Value, out var dotNetRunMessages))
+                    {
+                        return new LaunchSettingsApplyResult(false, string.Format(LocalizableStrings.CouldNotConvertToString, property.Name));
+                    }
+
+                    config.DotNetRunMessages = dotNetRunMessages;
+                }
                 else if (string.Equals(property.Name, nameof(ProjectLaunchSettingsModel.EnvironmentVariables), StringComparison.OrdinalIgnoreCase))
                 {
                     if (property.Value.ValueKind != JsonValueKind.Object)
@@ -59,7 +69,7 @@ namespace Microsoft.DotNet.Tools.Run.LaunchSettings
                         return new LaunchSettingsApplyResult(false, string.Format(LocalizableStrings.ValueMustBeAnObject, property.Name));
                     }
 
-                    foreach(var environmentVariable in property.Value.EnumerateObject())
+                    foreach (var environmentVariable in property.Value.EnumerateObject())
                     {
                         if (TryGetStringValue(environmentVariable.Value, out var environmentVariableValue))
                         {
@@ -69,21 +79,7 @@ namespace Microsoft.DotNet.Tools.Run.LaunchSettings
                 }
             }
 
-            if (!string.IsNullOrEmpty(config.ApplicationUrl))
-            {
-                command.EnvironmentVariable("ASPNETCORE_URLS", config.ApplicationUrl);
-            }
-
-            //For now, ignore everything but the environment variables section
-
-            foreach (var entry in config.EnvironmentVariables)
-            {
-                string value = Environment.ExpandEnvironmentVariables(entry.Value);
-                //NOTE: MSBuild variables are not expanded like they are in VS
-                command.EnvironmentVariable(entry.Key, value);
-            }
-
-            return new LaunchSettingsApplyResult(true, null, config.LaunchUrl);
+            return new LaunchSettingsApplyResult(true, null, config);
         }
 
         private static bool TryGetBooleanValue(JsonElement element, out bool value)
@@ -135,24 +131,6 @@ namespace Microsoft.DotNet.Tools.Run.LaunchSettings
                     value = null;
                     return false;
             }
-        }
-
-        private class ProjectLaunchSettingsModel
-        {
-            public ProjectLaunchSettingsModel()
-            {
-                EnvironmentVariables = new Dictionary<string, string>(StringComparer.Ordinal);
-            }
-
-            public string CommandLineArgs { get; set; }
-
-            public bool LaunchBrowser { get; set; }
-
-            public string LaunchUrl { get; set; }
-
-            public string ApplicationUrl { get; set; }
-
-            public Dictionary<string, string> EnvironmentVariables { get; }
         }
     }
 }

--- a/src/Cli/dotnet/commands/dotnet-run/LocalizableStrings.resx
+++ b/src/Cli/dotnet/commands/dotnet-run/LocalizableStrings.resx
@@ -147,6 +147,9 @@
   <data name="RuntimeOptionDescription" xml:space="preserve">
     <value>The target runtime to run for.</value>
   </data>
+  <data name="RunCommandBuilding" xml:space="preserve">
+    <value>Building...</value>
+  </data>
   <data name="RunCommandException" xml:space="preserve">
     <value>The build failed. Fix the build errors and run again.</value>
   </data>

--- a/src/Cli/dotnet/commands/dotnet-run/RunCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-run/RunCommand.cs
@@ -67,6 +67,15 @@ namespace Microsoft.DotNet.Tools.Run
                     foreach (var entry in launchSettings.EnvironmentVariables)
                     {
                         string value = Environment.ExpandEnvironmentVariables(entry.Value);
+                        if (entry.Key == "ASPNETCORE_HOSTINGSTARTUPASSEMBLIES")
+                        {
+                            var existingValue = Environment.GetEnvironmentVariable("ASPNETCORE_HOSTINGSTARTUPASSEMBLIES");
+                            if (!string.IsNullOrEmpty(existingValue))
+                            {
+                                value = existingValue + ";" + value;
+                            }
+                        }
+
                         //NOTE: MSBuild variables are not expanded like they are in VS
                         targetCommand.EnvironmentVariable(entry.Key, value);
                     }

--- a/src/Cli/dotnet/commands/dotnet-run/RunCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-run/RunCommand.cs
@@ -8,8 +8,6 @@ using System.Linq;
 using Microsoft.Build.Execution;
 using Microsoft.Build.Exceptions;
 using Microsoft.DotNet.Cli.Utils;
-using Microsoft.DotNet.Tools;
-using Microsoft.DotNet.Tools.MSBuild;
 using Microsoft.DotNet.Tools.Run.LaunchSettings;
 using Microsoft.DotNet.CommandFactory;
 
@@ -41,17 +39,37 @@ namespace Microsoft.DotNet.Tools.Run
         {
             Initialize();
 
+            if (!TryGetLaunchProfileSettingsIfNeeded(out var launchSettings))
+            {
+                return 1;
+            }
+
             if (ShouldBuild)
             {
+                if (string.Equals("true", launchSettings?.DotNetRunMessages, StringComparison.OrdinalIgnoreCase))
+                {
+                    Reporter.Output.WriteLine(LocalizableStrings.RunCommandBuilding);
+                }
+
                 EnsureProjectIsBuilt();
             }
 
             try
             {
                 ICommand targetCommand = GetTargetCommand();
-                if (!ApplyLaunchProfileSettingsIfNeeded(ref targetCommand))
+                if (launchSettings != null)
                 {
-                    return 1;
+                    if (!string.IsNullOrEmpty(launchSettings.ApplicationUrl))
+                    {
+                        targetCommand.EnvironmentVariable("ASPNETCORE_URLS", launchSettings.ApplicationUrl);
+                    }
+
+                    foreach (var entry in launchSettings.EnvironmentVariables)
+                    {
+                        string value = Environment.ExpandEnvironmentVariables(entry.Value);
+                        //NOTE: MSBuild variables are not expanded like they are in VS
+                        targetCommand.EnvironmentVariable(entry.Key, value);
+                    }
                 }
 
                 // Ignore Ctrl-C for the remainder of the command's execution
@@ -92,8 +110,9 @@ namespace Microsoft.DotNet.Tools.Run
             Interactive = interactive;
         }
 
-        private bool ApplyLaunchProfileSettingsIfNeeded(ref ICommand targetCommand)
+        private bool TryGetLaunchProfileSettingsIfNeeded(out ProjectLaunchSettingsModel launchSettingsModel)
         {
+            launchSettingsModel = default;
             if (!UseLaunchProfile)
             {
                 return true;
@@ -117,7 +136,8 @@ namespace Microsoft.DotNet.Tools.Run
 
             if (File.Exists(launchSettingsPath))
             {
-                if (!HasQuietVerbosity) {
+                if (!HasQuietVerbosity)
+                {
                     Reporter.Output.WriteLine(string.Format(LocalizableStrings.UsingLaunchSettingsFromMessage, launchSettingsPath));
                 }
 
@@ -126,10 +146,14 @@ namespace Microsoft.DotNet.Tools.Run
                 try
                 {
                     var launchSettingsFileContents = File.ReadAllText(launchSettingsPath);
-                    var applyResult = LaunchSettingsManager.TryApplyLaunchSettings(launchSettingsFileContents, ref targetCommand, LaunchProfile);
+                    var applyResult = LaunchSettingsManager.TryApplyLaunchSettings(launchSettingsFileContents, LaunchProfile);
                     if (!applyResult.Success)
                     {
                         Reporter.Error.WriteLine(string.Format(LocalizableStrings.RunCommandExceptionCouldNotApplyLaunchSettings, profileName, applyResult.FailureReason).Bold().Red());
+                    }
+                    else
+                    {
+                        launchSettingsModel = applyResult.LaunchSettings;
                     }
                 }
                 catch (IOException ex)
@@ -155,7 +179,7 @@ namespace Microsoft.DotNet.Tools.Run
                 new RestoringCommand(
                     restoreArgs.Prepend(Project),
                     restoreArgs,
-                    new [] { Project },
+                    new[] { Project },
                     NoRestore
                 ).Execute();
 

--- a/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.cs.xlf
+++ b/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.cs.xlf
@@ -32,6 +32,11 @@
         <target state="translated">Hodnotu vlastnosti {0} nejde převést na řetězec.</target>
         <note />
       </trans-unit>
+      <trans-unit id="RunCommandBuilding">
+        <source>Building...</source>
+        <target state="new">Building...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RunCommandException">
         <source>The build failed. Fix the build errors and run again.</source>
         <target state="translated">Sestavení se nepovedlo. Opravte v sestavení chyby a spusťte ho znovu.</target>

--- a/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.de.xlf
+++ b/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.de.xlf
@@ -32,6 +32,11 @@
         <target state="translated">Der Wert der Eigenschaft "{0}" konnte nicht in eine Zeichenfolge konvertiert werden.</target>
         <note />
       </trans-unit>
+      <trans-unit id="RunCommandBuilding">
+        <source>Building...</source>
+        <target state="new">Building...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RunCommandException">
         <source>The build failed. Fix the build errors and run again.</source>
         <target state="translated">Fehler beim Buildvorgang. Beheben Sie die Buildfehler, und versuchen Sie es anschließend noch mal.</target>

--- a/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.es.xlf
+++ b/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.es.xlf
@@ -32,6 +32,11 @@
         <target state="translated">No se pudo convertir el valor de la propiedad "{0}" en una cadena.</target>
         <note />
       </trans-unit>
+      <trans-unit id="RunCommandBuilding">
+        <source>Building...</source>
+        <target state="new">Building...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RunCommandException">
         <source>The build failed. Fix the build errors and run again.</source>
         <target state="translated">No se pudo llevar a cabo la compilación. Corrija los errores de compilación y vuelva a ejecutar el proyecto.</target>

--- a/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.fr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.fr.xlf
@@ -32,6 +32,11 @@
         <target state="translated">Impossible de convertir la valeur de la propriété '{0}' en chaîne.</target>
         <note />
       </trans-unit>
+      <trans-unit id="RunCommandBuilding">
+        <source>Building...</source>
+        <target state="new">Building...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RunCommandException">
         <source>The build failed. Fix the build errors and run again.</source>
         <target state="translated">La build a échoué. Corrigez les erreurs de la build et réexécutez-la.</target>

--- a/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.it.xlf
+++ b/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.it.xlf
@@ -32,6 +32,11 @@
         <target state="translated">Non è stato possibile convertire il valore della proprietà '{0}' in una stringa.</target>
         <note />
       </trans-unit>
+      <trans-unit id="RunCommandBuilding">
+        <source>Building...</source>
+        <target state="new">Building...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RunCommandException">
         <source>The build failed. Fix the build errors and run again.</source>
         <target state="translated">La compilazione non è riuscita. Correggere gli errori di compilazione e ripetere l'esecuzione.</target>

--- a/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.ja.xlf
+++ b/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.ja.xlf
@@ -32,6 +32,11 @@
         <target state="translated">プロパティ '{0}' の値を文字列に変換できませんでした。</target>
         <note />
       </trans-unit>
+      <trans-unit id="RunCommandBuilding">
+        <source>Building...</source>
+        <target state="new">Building...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RunCommandException">
         <source>The build failed. Fix the build errors and run again.</source>
         <target state="translated">ビルドに失敗しました。ビルド エラーを修正して、もう一度実行してください。</target>

--- a/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.ko.xlf
+++ b/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.ko.xlf
@@ -32,6 +32,11 @@
         <target state="translated">'{0}' 속성 값을 문자열로 변환할 수 없습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="RunCommandBuilding">
+        <source>Building...</source>
+        <target state="new">Building...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RunCommandException">
         <source>The build failed. Fix the build errors and run again.</source>
         <target state="translated">빌드하지 못했습니다. 빌드 오류를 수정하고 다시 실행하세요.</target>

--- a/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.pl.xlf
+++ b/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.pl.xlf
@@ -32,6 +32,11 @@
         <target state="translated">Nie można przekonwertować wartości właściwości „{0}” na ciąg.</target>
         <note />
       </trans-unit>
+      <trans-unit id="RunCommandBuilding">
+        <source>Building...</source>
+        <target state="new">Building...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RunCommandException">
         <source>The build failed. Fix the build errors and run again.</source>
         <target state="translated">Kompilacja nie powiodła się. Napraw błędy kompilacji i uruchom ją ponownie.</target>

--- a/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.pt-BR.xlf
@@ -32,6 +32,11 @@
         <target state="translated">Não foi possível converter o valor da propriedade '{0}' em uma cadeia de caracteres.</target>
         <note />
       </trans-unit>
+      <trans-unit id="RunCommandBuilding">
+        <source>Building...</source>
+        <target state="new">Building...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RunCommandException">
         <source>The build failed. Fix the build errors and run again.</source>
         <target state="translated">Ocorreu uma falha no build. Corrija os erros de build e execute novamente.</target>

--- a/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.ru.xlf
+++ b/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.ru.xlf
@@ -32,6 +32,11 @@
         <target state="translated">Не удалось преобразовать значение свойства "{0}" в строку.</target>
         <note />
       </trans-unit>
+      <trans-unit id="RunCommandBuilding">
+        <source>Building...</source>
+        <target state="new">Building...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RunCommandException">
         <source>The build failed. Fix the build errors and run again.</source>
         <target state="translated">Ошибка сборки. Устраните ошибки сборки и повторите попытку.</target>

--- a/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.tr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.tr.xlf
@@ -32,6 +32,11 @@
         <target state="translated">'{0}' özelliğinin değeri dizeye dönüştürülemedi.</target>
         <note />
       </trans-unit>
+      <trans-unit id="RunCommandBuilding">
+        <source>Building...</source>
+        <target state="new">Building...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RunCommandException">
         <source>The build failed. Fix the build errors and run again.</source>
         <target state="translated">Derleme başarısız oldu. Derleme hatalarını düzeltip yeniden çalıştırın.</target>

--- a/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.zh-Hans.xlf
@@ -32,6 +32,11 @@
         <target state="translated">无法将属性“{0}”的值转换为字符串。</target>
         <note />
       </trans-unit>
+      <trans-unit id="RunCommandBuilding">
+        <source>Building...</source>
+        <target state="new">Building...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RunCommandException">
         <source>The build failed. Fix the build errors and run again.</source>
         <target state="translated">生成失败。请修复生成错误并重新运行。</target>

--- a/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.zh-Hant.xlf
@@ -32,6 +32,11 @@
         <target state="translated">無法將屬性 '{0}' 的值轉換為字串。</target>
         <note />
       </trans-unit>
+      <trans-unit id="RunCommandBuilding">
+        <source>Building...</source>
+        <target state="new">Building...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RunCommandException">
         <source>The build failed. Fix the build errors and run again.</source>
         <target state="translated">建置失敗。請修正建置錯誤後，再執行一次。</target>

--- a/src/Tests/dotnet-run.Tests/GivenDotnetRunRunsCsProj.cs
+++ b/src/Tests/dotnet-run.Tests/GivenDotnetRunRunsCsProj.cs
@@ -572,5 +572,56 @@ namespace Microsoft.DotNet.Cli.Run.Tests
                 .And
                 .HaveStdOutContaining($"0 = a{Environment.NewLine}1 = {Environment.NewLine}2 = c");
         }
+
+        [Fact]
+        public void ItDoesNotPrintBuildingMessageByDefault()
+        {
+            var expectedValue = "Building...";
+            var testAppName = "TestAppSimple";
+            var testInstance = _testAssetsManager.CopyTestAsset(testAppName)
+                .WithSource();
+
+            new DotnetCommand(Log, "run")
+               .WithWorkingDirectory(testInstance.Path)
+               .Execute()
+               .Should()
+               .Pass()
+               .And
+               .NotHaveStdOutContaining(expectedValue);
+        }
+
+        [Fact]
+        public void ItPrintsBuildingMessageIfLaunchSettingHasDotnetRunMessagesSet()
+        {
+            var expectedValue = "Building...";
+            var testAppName = "TestAppWithLaunchSettings";
+            var testInstance = _testAssetsManager.CopyTestAsset(testAppName)
+                .WithSource();
+
+            new DotnetCommand(Log, "run")
+               .WithWorkingDirectory(testInstance.Path)
+               .Execute()
+               .Should()
+               .Pass()
+               .And
+               .HaveStdOutContaining(expectedValue);
+        }
+
+        [Fact]
+        public void ItIncludesEnvironmentVariablesSpecifiedInLaunchSettings()
+        {
+            var expectedValue = "MyCoolEnvironmentVariableKey=MyCoolEnvironmentVariableValue";
+            var testAppName = "TestAppWithLaunchSettings";
+            var testInstance = _testAssetsManager.CopyTestAsset(testAppName)
+                .WithSource();
+
+            new DotnetCommand(Log, "run")
+               .WithWorkingDirectory(testInstance.Path)
+               .Execute()
+               .Should()
+               .Pass()
+               .And
+               .HaveStdOutContaining(expectedValue);
+        }
     }
 }

--- a/src/Tests/dotnet-run.Tests/GivenDotnetRunRunsCsProj.cs
+++ b/src/Tests/dotnet-run.Tests/GivenDotnetRunRunsCsProj.cs
@@ -608,6 +608,24 @@ namespace Microsoft.DotNet.Cli.Run.Tests
         }
 
         [Fact]
+        public void ItConcatenatesHostingStartups()
+        {
+            var expectedValue = "ASPNETCORE_HOSTINGSTARTUPASSEMBLIES=HostingStartupAmbient;HostingStartupInLaunchSettings";
+            var testAppName = "TestAppWithLaunchSettings";
+            var testInstance = _testAssetsManager.CopyTestAsset(testAppName)
+                .WithSource();
+
+            new DotnetCommand(Log, "run")
+               .WithWorkingDirectory(testInstance.Path)
+               .WithEnvironmentVariable("ASPNETCORE_HOSTINGSTARTUPASSEMBLIES", "HostingStartupAmbient")
+               .Execute()
+               .Should()
+               .Pass()
+               .And
+               .HaveStdOutContaining(expectedValue);
+        }
+
+        [Fact]
         public void ItIncludesEnvironmentVariablesSpecifiedInLaunchSettings()
         {
             var expectedValue = "MyCoolEnvironmentVariableKey=MyCoolEnvironmentVariableValue";


### PR DESCRIPTION
This is a resolution for https://github.com/dotnet/aspnetcore/issues/19303 specific to dotnet run + launchSettings.json.

As part of https://github.com/dotnet/aspnetcore/issues/23412, we're planning on injecting a hosting_startup to enable some dotnet-watch specific features. However, if a value for `ASPNETCORE_HOSTINGSTARTUPASSEMBLIES` is present in `launchSettings.json`, it'll get ignored. While `dotnet run` will expand environment variables, there isn't a way to do this in a cross plat way.