### PR TITLE
Update vstest to 16.8.0 in 5.0.1xx-preview8

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -61,9 +61,9 @@
       <Uri>https://github.com/NuGet/NuGet.Client</Uri>
       <Sha>d428c2a79aae81ade1caa326e04f65a119025f42</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Test.Sdk" Version="16.7.0-release-20200612-02">
+    <Dependency Name="Microsoft.NET.Test.Sdk" Version="16.8.0-preview-20200728-02">
       <Uri>https://github.com/microsoft/vstest</Uri>
-      <Sha>df62aca07cacc5c018dc8e828f03a0cd79ee52da</Sha>
+      <Sha>c4c4491da41cd51039eb64139ec5f26a5a202845</Sha>
     </Dependency>
     <Dependency Name="Microsoft.NET.ILLink.Tasks" Version="5.0.0-preview.3.20361.1">
       <Uri>https://github.com/mono/linker</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -62,7 +62,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/Microsoft/vstest -->
-    <MicrosoftNETTestSdkPackageVersion>16.7.0-release-20200612-02</MicrosoftNETTestSdkPackageVersion>
+    <MicrosoftNETTestSdkPackageVersion>16.8.0-preview-20200728-02</MicrosoftNETTestSdkPackageVersion>
     <MicrosoftTestPlatformCLIPackageVersion>$(MicrosoftNETTestSdkPackageVersion)</MicrosoftTestPlatformCLIPackageVersion>
     <MicrosoftTestPlatformBuildPackageVersion>$(MicrosoftNETTestSdkPackageVersion)</MicrosoftTestPlatformBuildPackageVersion>
   </PropertyGroup>

--- a/src/Tests/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestFromCsprojForMultipleTFM.cs
+++ b/src/Tests/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestFromCsprojForMultipleTFM.cs
@@ -49,11 +49,11 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                     .Should().Contain("Total tests: 3")
                          .And.Contain("Passed: 2")
                          .And.Contain("Failed: 1")
-                         .And.Contain("\u221a VSTestPassTestDesktop", "because .NET 4.6 tests will pass")
+                         .And.Contain("Passed VSTestPassTestDesktop", "because .NET 4.6 tests will pass")
                          .And.Contain("Total tests: 3")
                          .And.Contain("Passed: 1")
                          .And.Contain("Failed: 2")
-                         .And.Contain("X VSTestFailTestNetCoreApp", "because netcoreapp2.0 tests will fail");
+                         .And.Contain("Failed VSTestFailTestNetCoreApp", "because netcoreapp2.0 tests will fail");
             }
             result.ExitCode.Should().Be(1);
         }
@@ -87,13 +87,13 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                 result.StdOut.Should().Contain("Total tests: 3");
                 result.StdOut.Should().Contain("Passed: 2");
                 result.StdOut.Should().Contain("Failed: 1");
-                result.StdOut.Should().Contain("\u221a TestNamespace.VSTestXunitTests.VSTestXunitPassTestDesktop");
+                result.StdOut.Should().Contain("Passed TestNamespace.VSTestXunitTests.VSTestXunitPassTestDesktop");
 
                 // for target framework netcoreapp1.0
                 result.StdOut.Should().Contain("Total tests: 3");
                 result.StdOut.Should().Contain("Passed: 1");
                 result.StdOut.Should().Contain("Failed: 2");
-                result.StdOut.Should().Contain("X TestNamespace.VSTestXunitTests.VSTestXunitFailTestNetCoreApp");
+                result.StdOut.Should().Contain("Failed TestNamespace.VSTestXunitTests.VSTestXunitFailTestNetCoreApp");
             }
 
             result.ExitCode.Should().Be(1);

--- a/src/Tests/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestfromCsproj.cs
+++ b/src/Tests/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestfromCsproj.cs
@@ -525,7 +525,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                 result.StdOut.Should().Contain("No code coverage data available. Code coverage is currently supported only on Windows.");
                 result.StdOut.Should().Contain("Total:     1");
                 result.StdOut.Should().Contain("Passed:     1");
-                result.StdOut.Should().Contain("Test Run Successful.");
+                result.StdOut.Should().NotContain("Failed!");
             }
 
             result.ExitCode.Should().Be(0);

--- a/src/Tests/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestfromCsproj.cs
+++ b/src/Tests/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestfromCsproj.cs
@@ -46,8 +46,8 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                 result.StdOut.Should().Contain("Total tests: 2");
                 result.StdOut.Should().Contain("Passed: 1");
                 result.StdOut.Should().Contain("Failed: 1");
-                result.StdOut.Should().Contain("\u221a VSTestPassTest");
-                result.StdOut.Should().Contain("X VSTestFailTest");
+                result.StdOut.Should().Contain("Passed VSTestPassTest");
+                result.StdOut.Should().Contain("Failed VSTestFailTest");
             }
 
             result.ExitCode.Should().Be(1);
@@ -74,8 +74,8 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                 result.StdOut.Should().Contain("Total tests: 2");
                 result.StdOut.Should().Contain("Passed: 1");
                 result.StdOut.Should().Contain("Failed: 1");
-                result.StdOut.Should().Contain("\u221a VSTestPassTest");
-                result.StdOut.Should().Contain("X VSTestFailTest");
+                result.StdOut.Should().Contain("Passed VSTestPassTest");
+                result.StdOut.Should().Contain("Failed VSTestFailTest");
             }
 
             result.ExitCode.Should().Be(1);
@@ -142,8 +142,8 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                 result.StdOut.Should().Contain("Total tests: 2");
                 result.StdOut.Should().Contain("Passed: 1");
                 result.StdOut.Should().Contain("Failed: 1");
-                result.StdOut.Should().Contain("\u221a TestNamespace.VSTestXunitTests.VSTestXunitPassTest");
-                result.StdOut.Should().Contain("X TestNamespace.VSTestXunitTests.VSTestXunitFailTest");
+                result.StdOut.Should().Contain("Passed TestNamespace.VSTestXunitTests.VSTestXunitPassTest");
+                result.StdOut.Should().Contain("Failed TestNamespace.VSTestXunitTests.VSTestXunitFailTest");
             }
 
             result.ExitCode.Should().Be(1);
@@ -164,7 +164,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
 
             if (!TestContext.IsLocalized())
             {
-                result.StdOut.Should().Contain("X TestNamespace.VSTestXunitTests.VSTestXunitFailTest");
+                result.StdOut.Should().Contain("Failed TestNamespace.VSTestXunitTests.VSTestXunitFailTest");
                 result.StdOut.Should().Contain("Total tests: 2");
                 result.StdOut.Should().Contain("Passed: 1");
                 result.StdOut.Should().Contain("Failed: 1");
@@ -197,8 +197,8 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                 // We append current date time to trx file name, hence modifying this check
                 Assert.True(Directory.EnumerateFiles(trxLoggerDirectory, trxFileNamePattern).Any());
 
-                result.StdOut.Should().Contain("\u221a VSTestPassTest");
-                result.StdOut.Should().Contain("X VSTestFailTest");
+                result.StdOut.Should().Contain("Passed VSTestPassTest");
+                result.StdOut.Should().Contain("Failed VSTestFailTest");
             }
 
             // Cleanup trxLoggerDirectory if it exist
@@ -341,8 +341,8 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                 result.StdOut.Should().Contain("Total tests: 2");
                 result.StdOut.Should().Contain("Passed: 1");
                 result.StdOut.Should().Contain("Failed: 1");
-                result.StdOut.Should().Contain("\u221a VSTestPassTest");
-                result.StdOut.Should().Contain("X VSTestFailTest");
+                result.StdOut.Should().Contain("Passed VSTestPassTest");
+                result.StdOut.Should().Contain("Failed VSTestFailTest");
             }
 
             result.ExitCode.Should().Be(1);
@@ -365,8 +365,8 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                 result.StdOut.Should().Contain("Total tests: 2");
                 result.StdOut.Should().Contain("Passed: 1");
                 result.StdOut.Should().Contain("Failed: 1");
-                result.StdOut.Should().NotContain("\u221a TestNamespace.VSTestTests.VSTestPassTest");
-                result.StdOut.Should().NotContain("X TestNamespace.VSTestTests.VSTestFailTest");
+                result.StdOut.Should().NotContain("Passed TestNamespace.VSTestTests.VSTestPassTest");
+                result.StdOut.Should().NotContain("Failed TestNamespace.VSTestTests.VSTestFailTest");
             }
 
             result.ExitCode.Should().Be(1);

--- a/src/Tests/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestfromCsproj.cs
+++ b/src/Tests/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestfromCsproj.cs
@@ -43,9 +43,9 @@ namespace Microsoft.DotNet.Cli.Test.Tests
             // Verify
             if (!TestContext.IsLocalized())
             {
-                result.StdOut.Should().Contain("Total tests: 2");
-                result.StdOut.Should().Contain("Passed: 1");
-                result.StdOut.Should().Contain("Failed: 1");
+                result.StdOut.Should().Contain("Total:     2");
+                result.StdOut.Should().Contain("Passed:     1");
+                result.StdOut.Should().Contain("Failed:     1");
                 result.StdOut.Should().Contain("Passed VSTestPassTest");
                 result.StdOut.Should().Contain("Failed VSTestFailTest");
             }
@@ -69,11 +69,11 @@ namespace Microsoft.DotNet.Cli.Test.Tests
 
             if (!TestContext.IsLocalized())
             {
-                result.StdOut.Should().Contain("Total tests: 2");
-                result.StdOut.Should().Contain("Passed: 1");
-                result.StdOut.Should().Contain("Total tests: 2");
-                result.StdOut.Should().Contain("Passed: 1");
-                result.StdOut.Should().Contain("Failed: 1");
+                result.StdOut.Should().Contain("Total:     2");
+                result.StdOut.Should().Contain("Passed:     1");
+                result.StdOut.Should().Contain("Total:     2");
+                result.StdOut.Should().Contain("Passed:     1");
+                result.StdOut.Should().Contain("Failed:     1");
                 result.StdOut.Should().Contain("Passed VSTestPassTest");
                 result.StdOut.Should().Contain("Failed VSTestFailTest");
             }
@@ -139,9 +139,9 @@ namespace Microsoft.DotNet.Cli.Test.Tests
             // Verify
             if (!TestContext.IsLocalized())
             {
-                result.StdOut.Should().Contain("Total tests: 2");
-                result.StdOut.Should().Contain("Passed: 1");
-                result.StdOut.Should().Contain("Failed: 1");
+                result.StdOut.Should().Contain("Total:     2");
+                result.StdOut.Should().Contain("Passed:     1");
+                result.StdOut.Should().Contain("Failed:     1");
                 result.StdOut.Should().Contain("Passed TestNamespace.VSTestXunitTests.VSTestXunitPassTest");
                 result.StdOut.Should().Contain("Failed TestNamespace.VSTestXunitTests.VSTestXunitFailTest");
             }
@@ -165,9 +165,9 @@ namespace Microsoft.DotNet.Cli.Test.Tests
             if (!TestContext.IsLocalized())
             {
                 result.StdOut.Should().Contain("Failed TestNamespace.VSTestXunitTests.VSTestXunitFailTest");
-                result.StdOut.Should().Contain("Total tests: 2");
-                result.StdOut.Should().Contain("Passed: 1");
-                result.StdOut.Should().Contain("Failed: 1");
+                result.StdOut.Should().Contain("Total:     2");
+                result.StdOut.Should().Contain("Passed:     1");
+                result.StdOut.Should().Contain("Failed:     1");
             }
         }
 
@@ -338,9 +338,9 @@ namespace Microsoft.DotNet.Cli.Test.Tests
 
             if (!TestContext.IsLocalized())
             {
-                result.StdOut.Should().Contain("Total tests: 2");
-                result.StdOut.Should().Contain("Passed: 1");
-                result.StdOut.Should().Contain("Failed: 1");
+                result.StdOut.Should().Contain("Total:     2");
+                result.StdOut.Should().Contain("Passed:     1");
+                result.StdOut.Should().Contain("Failed:     1");
                 result.StdOut.Should().Contain("Passed VSTestPassTest");
                 result.StdOut.Should().Contain("Failed VSTestFailTest");
             }
@@ -362,9 +362,9 @@ namespace Microsoft.DotNet.Cli.Test.Tests
             // Verify
             if (!TestContext.IsLocalized())
             {
-                result.StdOut.Should().Contain("Total tests: 2");
-                result.StdOut.Should().Contain("Passed: 1");
-                result.StdOut.Should().Contain("Failed: 1");
+                result.StdOut.Should().Contain("Total:     2");
+                result.StdOut.Should().Contain("Passed:     1");
+                result.StdOut.Should().Contain("Failed:     1");
                 result.StdOut.Should().NotContain("Passed TestNamespace.VSTestTests.VSTestPassTest");
                 result.StdOut.Should().NotContain("Failed TestNamespace.VSTestTests.VSTestFailTest");
             }
@@ -401,9 +401,9 @@ namespace Microsoft.DotNet.Cli.Test.Tests
 
             if (!TestContext.IsLocalized())
             {
-                result.StdOut.Should().Contain("Total tests: 2");
-                result.StdOut.Should().Contain("Passed: 1");
-                result.StdOut.Should().Contain("Failed: 1");
+                result.StdOut.Should().Contain("Total:     2");
+                result.StdOut.Should().Contain("Passed:     1");
+                result.StdOut.Should().Contain("Failed:     1");
             }
 
             result.ExitCode.Should().Be(1);
@@ -424,9 +424,9 @@ namespace Microsoft.DotNet.Cli.Test.Tests
             if (!TestContext.IsLocalized())
             {
                 result.StdOut.Should().NotContain("Microsoft (R) Test Execution Command Line Tool Version");
-                result.StdOut.Should().Contain("Total tests: 2");
-                result.StdOut.Should().Contain("Passed: 1");
-                result.StdOut.Should().Contain("Failed: 1");
+                result.StdOut.Should().Contain("Total:     2");
+                result.StdOut.Should().Contain("Passed:     1");
+                result.StdOut.Should().Contain("Failed:     1");
             }
         }
 
@@ -458,9 +458,9 @@ namespace Microsoft.DotNet.Cli.Test.Tests
             // Verify test results
             if (!TestContext.IsLocalized())
             {
-                result.StdOut.Should().Contain("Total tests: 2");
-                result.StdOut.Should().Contain("Passed: 1");
-                result.StdOut.Should().Contain("Failed: 1");
+                result.StdOut.Should().Contain("Total:     2");
+                result.StdOut.Should().Contain("Passed:     1");
+                result.StdOut.Should().Contain("Failed:     1");
             }
 
             // Verify coverage file.
@@ -494,9 +494,9 @@ namespace Microsoft.DotNet.Cli.Test.Tests
             // Verify test results
             if (!TestContext.IsLocalized())
             {
-                result.StdOut.Should().Contain("Total tests: 2");
-                result.StdOut.Should().Contain("Passed: 1");
-                result.StdOut.Should().Contain("Failed: 1");
+                result.StdOut.Should().Contain("Total:     2");
+                result.StdOut.Should().Contain("Passed:     1");
+                result.StdOut.Should().Contain("Failed:     1");
             }
 
             // Verify coverage file.
@@ -523,8 +523,8 @@ namespace Microsoft.DotNet.Cli.Test.Tests
             if (!TestContext.IsLocalized())
             {
                 result.StdOut.Should().Contain("No code coverage data available. Code coverage is currently supported only on Windows.");
-                result.StdOut.Should().Contain("Total tests: 1");
-                result.StdOut.Should().Contain("Passed: 1");
+                result.StdOut.Should().Contain("Total:     1");
+                result.StdOut.Should().Contain("Passed:     1");
                 result.StdOut.Should().Contain("Test Run Successful.");
             }
 

--- a/src/Tests/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestfromCsproj.cs
+++ b/src/Tests/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestfromCsproj.cs
@@ -43,9 +43,9 @@ namespace Microsoft.DotNet.Cli.Test.Tests
             // Verify
             if (!TestContext.IsLocalized())
             {
-                result.StdOut.Should().Contain("Total:     2");
-                result.StdOut.Should().Contain("Passed:     1");
-                result.StdOut.Should().Contain("Failed:     1");
+                result.StdOut.Should().Contain("Total tests: 2");
+                result.StdOut.Should().Contain("Passed: 1");
+                result.StdOut.Should().Contain("Failed: 1");
                 result.StdOut.Should().Contain("Passed VSTestPassTest");
                 result.StdOut.Should().Contain("Failed VSTestFailTest");
             }
@@ -69,11 +69,11 @@ namespace Microsoft.DotNet.Cli.Test.Tests
 
             if (!TestContext.IsLocalized())
             {
-                result.StdOut.Should().Contain("Total:     2");
-                result.StdOut.Should().Contain("Passed:     1");
-                result.StdOut.Should().Contain("Total:     2");
-                result.StdOut.Should().Contain("Passed:     1");
-                result.StdOut.Should().Contain("Failed:     1");
+                result.StdOut.Should().Contain("Total tests: 2");
+                result.StdOut.Should().Contain("Passed: 1");
+                result.StdOut.Should().Contain("Total tests: 2");
+                result.StdOut.Should().Contain("Passed: 1");
+                result.StdOut.Should().Contain("Failed: 1");
                 result.StdOut.Should().Contain("Passed VSTestPassTest");
                 result.StdOut.Should().Contain("Failed VSTestFailTest");
             }
@@ -139,9 +139,9 @@ namespace Microsoft.DotNet.Cli.Test.Tests
             // Verify
             if (!TestContext.IsLocalized())
             {
-                result.StdOut.Should().Contain("Total:     2");
-                result.StdOut.Should().Contain("Passed:     1");
-                result.StdOut.Should().Contain("Failed:     1");
+                result.StdOut.Should().Contain("Total tests: 2");
+                result.StdOut.Should().Contain("Passed: 1");
+                result.StdOut.Should().Contain("Failed: 1");
                 result.StdOut.Should().Contain("Passed TestNamespace.VSTestXunitTests.VSTestXunitPassTest");
                 result.StdOut.Should().Contain("Failed TestNamespace.VSTestXunitTests.VSTestXunitFailTest");
             }
@@ -338,9 +338,9 @@ namespace Microsoft.DotNet.Cli.Test.Tests
 
             if (!TestContext.IsLocalized())
             {
-                result.StdOut.Should().Contain("Total:     2");
-                result.StdOut.Should().Contain("Passed:     1");
-                result.StdOut.Should().Contain("Failed:     1");
+                result.StdOut.Should().Contain("Total tests: 2");
+                result.StdOut.Should().Contain("Passed: 1");
+                result.StdOut.Should().Contain("Failed: 1");
                 result.StdOut.Should().Contain("Passed VSTestPassTest");
                 result.StdOut.Should().Contain("Failed VSTestFailTest");
             }
@@ -401,9 +401,9 @@ namespace Microsoft.DotNet.Cli.Test.Tests
 
             if (!TestContext.IsLocalized())
             {
-                result.StdOut.Should().Contain("Total:     2");
-                result.StdOut.Should().Contain("Passed:     1");
-                result.StdOut.Should().Contain("Failed:     1");
+                result.StdOut.Should().Contain("Total tests: 2");
+                result.StdOut.Should().Contain("Passed: 1");
+                result.StdOut.Should().Contain("Failed: 1");
             }
 
             result.ExitCode.Should().Be(1);

--- a/src/Tests/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestfromCsprojWithCorrectTestRunParameters.cs
+++ b/src/Tests/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestfromCsprojWithCorrectTestRunParameters.cs
@@ -48,7 +48,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                 result.StdOut.Should().NotMatch("The test run parameter argument '*' is invalid.");
                 result.StdOut.Should().Contain("Total tests: 1");
                 result.StdOut.Should().Contain("Passed: 1");
-                result.StdOut.Should().Contain("\u221a VSTestTestRunParameters");
+                result.StdOut.Should().Contain("Passed VSTestTestRunParameters");
             }
 
             result.ExitCode.Should().Be(0);
@@ -86,7 +86,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                 result.StdOut.Should().NotMatch("The test run parameter argument '*' is invalid.");
                 result.StdOut.Should().Contain("Total tests: 1");
                 result.StdOut.Should().Contain("Passed: 1");
-                result.StdOut.Should().Contain("\u221a VSTestTestRunParameters");
+                result.StdOut.Should().Contain("Passed VSTestTestRunParameters");
             }
 
             result.ExitCode.Should().Be(0);

--- a/src/Tests/dotnet-vstest.Tests/VSTestTests.cs
+++ b/src/Tests/dotnet-vstest.Tests/VSTestTests.cs
@@ -48,8 +48,8 @@ namespace Microsoft.DotNet.Cli.VSTest.Tests
                     .Should().Contain("Total tests: 2")
                     .And.Contain("Passed: 1")
                     .And.Contain("Failed: 1")
-                    .And.Contain("\u221a VSTestPassTest")
-                    .And.Contain("X VSTestFailTest");
+                    .And.Contain("Passed VSTestPassTest")
+                    .And.Contain("Failed VSTestFailTest");
             }
 
             result.ExitCode.Should().Be(1);
@@ -88,7 +88,7 @@ namespace Microsoft.DotNet.Cli.VSTest.Tests
                 result.StdOut.Should().NotMatch("The test run parameter argument '*' is invalid.");
                 result.StdOut.Should().Contain("Total tests: 1");
                 result.StdOut.Should().Contain("Passed: 1");
-                result.StdOut.Should().Contain("\u221a VSTestTestRunParameters");
+                result.StdOut.Should().Contain("Passed VSTestTestRunParameters");
             }
 
             result.ExitCode.Should().Be(0);


### PR DESCRIPTION
Indicators of Passed tests changed between 16.7.0 and 16.8.0, adding those changes to the changes made by this automatic PR. https://github.com/dotnet/sdk/pull/12667