### PR TITLE
Add macro to terminate dotnet and msbuild processes when running tests locally

### DIFF
--- a/eng/restore-toolset.ps1
+++ b/eng/restore-toolset.ps1
@@ -50,6 +50,8 @@ set DOTNET_MSBUILD_SDK_RESOLVER_CLI_DIR=$env:DOTNET_INSTALL_DIR
 
 set PATH=$env:DOTNET_INSTALL_DIR;%PATH%
 set NUGET_PACKAGES=$env:NUGET_PACKAGES
+
+DOSKEY killdotnet=taskkill /F /IM dotnet.exe /T ^& taskkill /F /IM VSTest.Console.exe /T ^& taskkill /F /IM msbuild.exe /T
 "@
 
   Out-File -FilePath $scriptPath -InputObject $scriptContents -Encoding ASCII


### PR DESCRIPTION
Adding a macro to the sdk-build-env.bat script to quickly terminate dotnet and msbuild process when running tests locally. This is useful when running tests from VS and then running build command from the commandline. If there are lingering processes, they end up locking files.