### PR TITLE
Enable Importing Framework's WinFX Targets By Default While Allowing Opt-Out

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.BeforeCommon.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.BeforeCommon.targets
@@ -25,7 +25,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     Make it opt-out, just in case, if something fails or we don't want to use 'WindowsDesktop' SDK.
   -->
   <PropertyGroup>
-    <ImportFrameworkWinFXTargets Condition="'$(ImportFrameworkWinFXTargets)' == ''">false</ImportFrameworkWinFXTargets>
+    <ImportFrameworkWinFXTargets Condition="'$(ImportFrameworkWinFXTargets)' == '' and '$(TargetFrameworkIdentifier)' != '.NETFramework'">false</ImportFrameworkWinFXTargets>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.BeforeCommon.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.BeforeCommon.targets
@@ -20,12 +20,10 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <!--
     Workaround: https://github.com/microsoft/msbuild/issues/4948
-    Disable .NET Framework's inbox WinFX targets when using the SDK, since, we really don't use it's build logic
-    and is superseded by 'WindowsDesktop' SDK that provides it's own WinFX for both NETFX and CoreCLR targets.
-    Make it opt-out, just in case, if something fails or we don't want to use 'WindowsDesktop' SDK.
+    Allow opt-out of importing framework's winfx.targets.
   -->
   <PropertyGroup>
-    <ImportFrameworkWinFXTargets Condition="'$(ImportFrameworkWinFXTargets)' == '' and '$(TargetFrameworkIdentifier)' != '.NETFramework'">false</ImportFrameworkWinFXTargets>
+    <ImportFrameworkWinFXTargets Condition="'$(ImportFrameworkWinFXTargets)' == ''">true</ImportFrameworkWinFXTargets>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Should fix https://github.com/dotnet/sdk/issues/12324.

We're running into MANY cases where disabling the default-import of framework's `winfx.targets` is breaking internal partners. This PR reverses that behavior.

Now it imports framework `winfx.targets` by default (as this seems to be the normal case), while allowing for "opt-out" of this behavior by setting `ImportFrameworkWinFXTargets` to false.