### PR TITLE
Add mock template locator

### DIFF
--- a/sdk.sln
+++ b/sdk.sln
@@ -246,6 +246,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tasks", "Tasks", "{27302615
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tasks", "Tasks", "{EBEF2950-E27B-4EB8-8F1C-2001984B4D41}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DotNet.TemplateLocator", "src\Microsoft.DotNet.TemplateLocator\Microsoft.DotNet.TemplateLocator.csproj", "{89F798D9-A8BA-4556-B2A2-39CEF3587093}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DotNet.TemplateLocator.Tests", "src\Tests\Microsoft.DotNet.TemplateLocator.Tests\Microsoft.DotNet.TemplateLocator.Tests.csproj", "{360F049F-D501-478A-98BD-A2BA4DB000B9}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -432,6 +436,14 @@ Global
 		{1F26FAE6-2654-4E83-8936-146134638C59}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1F26FAE6-2654-4E83-8936-146134638C59}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1F26FAE6-2654-4E83-8936-146134638C59}.Release|Any CPU.Build.0 = Release|Any CPU
+		{89F798D9-A8BA-4556-B2A2-39CEF3587093}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{89F798D9-A8BA-4556-B2A2-39CEF3587093}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{89F798D9-A8BA-4556-B2A2-39CEF3587093}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{89F798D9-A8BA-4556-B2A2-39CEF3587093}.Release|Any CPU.Build.0 = Release|Any CPU
+		{360F049F-D501-478A-98BD-A2BA4DB000B9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{360F049F-D501-478A-98BD-A2BA4DB000B9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{360F049F-D501-478A-98BD-A2BA4DB000B9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{360F049F-D501-478A-98BD-A2BA4DB000B9}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -512,6 +524,8 @@ Global
 		{5F8809DE-414C-42CB-A1BC-CF95267E6F49} = {409D6E91-ACFD-4801-A879-B166668EE256}
 		{27302615-7D46-499E-AC84-D3E193F9A62D} = {029BC558-D2FA-413F-83D0-A67216BA9DB1}
 		{EBEF2950-E27B-4EB8-8F1C-2001984B4D41} = {60D66F66-3B2B-4418-9BE3-AD9270012703}
+		{89F798D9-A8BA-4556-B2A2-39CEF3587093} = {22AB674F-ED91-4FBC-BFEE-8A1E82F9F05E}
+		{360F049F-D501-478A-98BD-A2BA4DB000B9} = {580D1AE7-AA8F-4912-8B76-105594E00B3B}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {FB8F26CE-4DE6-433F-B32A-79183020BBD6}

--- a/src/Microsoft.DotNet.TemplateLocator/IOptionalSdkTemplatePackageInfo.cs
+++ b/src/Microsoft.DotNet.TemplateLocator/IOptionalSdkTemplatePackageInfo.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.DotNet.TemplateLocator
+{
+    public interface IOptionalSdkTemplatePackageInfo
+    {
+        string TemplatePackageId { get; }
+        string TemplateVersion { get; }
+        string Path { get; }
+    }
+}

--- a/src/Microsoft.DotNet.TemplateLocator/Microsoft.DotNet.TemplateLocator.csproj
+++ b/src/Microsoft.DotNet.TemplateLocator/Microsoft.DotNet.TemplateLocator.csproj
@@ -1,0 +1,29 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0;net472</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netstandard2.0</TargetFrameworks>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <RuntimeIdentifiers Condition="'$(OS)' == 'Windows_NT'">win-x86;win-x64</RuntimeIdentifiers>
+    <WarningsAsErrors>true</WarningsAsErrors>
+    <StrongNameKeyId>MicrosoftAspNetCore</StrongNameKeyId>
+    <IsPackable>true</IsPackable>
+    <!-- Create FileDefinitions items for ResolveHostfxrCopyLocalContent target -->
+    <EmitLegacyAssetsFileItems>true</EmitLegacyAssetsFileItems>
+
+    <PackageId>Microsoft.Internal.DotNet.MockTemplateLocator</PackageId>
+  </PropertyGroup>
+
+  <Target Name="LinkVSEmbeddableAssemblies" DependsOnTargets="ResolveReferences" AfterTargets="ResolveReferences">
+    <ItemGroup>
+      <ReferencePath Condition="'%(ReferencePath.FileName)' == 'Microsoft.VisualStudio.Setup.Configuration.Interop'">
+        <EmbedInteropTypes>true</EmbedInteropTypes>
+      </ReferencePath>
+    </ItemGroup>
+  </Target>
+
+  <ItemGroup>
+    <PackageReference Include="NuGet.Protocol" Version="$(NuGetProjectModelVersion)" />
+    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />
+  </ItemGroup>
+</Project>

--- a/src/Microsoft.DotNet.TemplateLocator/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.DotNet.TemplateLocator/Properties/AssemblyInfo.cs
@@ -1,0 +1,8 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Reflection;
+using System.Runtime.CompilerServices;
+
+[assembly: AssemblyMetadataAttribute("Serviceable", "True")]
+[assembly: InternalsVisibleTo("Microsoft.DotNet.TemplateLocator.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100f33a29044fa9d740c9b3213a93e57c84b472c84e0b8a0e1ae48e67a9f8f6de9d5f7f3d52ac23e48ac51801f1dc950abe901da34d2a9e3baadb141a17c77ef3c565dd5ee5054b91cf63bb3c6ab83f72ab3aafe93d0fc3c2348b764fafb0b1c0733de51459aeab46580384bf9d74c4e28164b7cde247f891ba07891c9d872ad2bb")]

--- a/src/Microsoft.DotNet.TemplateLocator/TemplateLocator.cs
+++ b/src/Microsoft.DotNet.TemplateLocator/TemplateLocator.cs
@@ -1,0 +1,73 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using NuGet.Common;
+using NuGet.Protocol;
+
+namespace Microsoft.DotNet.TemplateLocator
+{
+    public sealed class TemplateLocator
+    {
+        private DirectoryInfo _dotnetSdkTemplatesLocation;
+
+        public TemplateLocator()
+        {
+            string mockTemplateLocation = Environment.GetEnvironmentVariable("MOCKDOTNETSDKTEMPLATESLOCATION");
+            if (!string.IsNullOrWhiteSpace(mockTemplateLocation))
+            {
+                _dotnetSdkTemplatesLocation = new DirectoryInfo(mockTemplateLocation);
+            }
+        }
+
+        public IReadOnlyCollection<IOptionalSdkTemplatePackageInfo> GetDotnetSdkTemplatePackages(string sdkVersion)
+        {
+            if (_dotnetSdkTemplatesLocation == null)
+            {
+                return Array.Empty<IOptionalSdkTemplatePackageInfo>();
+            }
+
+            IEnumerable<LocalPackageInfo> packages = LocalFolderUtility
+                            .GetPackagesV2(_dotnetSdkTemplatesLocation.FullName, new NullLogger());
+
+            if (packages == null)
+            {
+                return Array.Empty<IOptionalSdkTemplatePackageInfo>();
+            }
+            else
+            {
+                return packages
+                    .Select(l => new OptionalSdkTemplatePackageInfo(l)).ToArray();
+            }
+        }
+
+        public string DotnetSdkVersionUsedInVs()
+        {
+            return "5.1.100";
+        }
+
+        internal void SetDotnetSdkTemplatesLocation(DirectoryInfo directoryInfo)
+        {
+            _dotnetSdkTemplatesLocation = directoryInfo;
+        }
+
+        private class OptionalSdkTemplatePackageInfo : IOptionalSdkTemplatePackageInfo
+        {
+            public OptionalSdkTemplatePackageInfo(LocalPackageInfo localPackageInfo)
+            {
+                TemplatePackageId = localPackageInfo.Identity.Id;
+                TemplateVersion = localPackageInfo.Identity.Version.ToNormalizedString();
+                Path = localPackageInfo.Path;
+            }
+
+            public string TemplatePackageId { get; }
+
+            public string TemplateVersion { get; }
+
+            public string Path { get; }
+        }
+    }
+}

--- a/src/Tests/Microsoft.DotNet.TemplateLocator.Tests/GivenAnMSBuildSdkResolver.cs
+++ b/src/Tests/Microsoft.DotNet.TemplateLocator.Tests/GivenAnMSBuildSdkResolver.cs
@@ -1,0 +1,35 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using FluentAssertions;
+using System.IO;
+using Xunit;
+using Xunit.Abstractions;
+using Microsoft.NET.TestFramework;
+using System.Linq;
+using NuGet.Common;
+using NuGet.Protocol;
+
+namespace Microsoft.DotNet.TemplateLocator.Tests
+{
+    public class GivenAnTemplateLocator : SdkTest
+    {
+
+        public GivenAnTemplateLocator(ITestOutputHelper logger) : base(logger)
+        {
+        }
+
+        [Fact]
+        public void ItShouldReturnListOfTemplates()
+        {
+            var resolver = new TemplateLocator();
+            var stage2Dotnet = new DirectoryInfo(TestContext.Current.ToolsetUnderTest.DotNetHostPath);
+            var stage2Templates = stage2Dotnet.Parent.GetDirectories("templates")[0].EnumerateDirectories().First();
+            resolver.SetDotnetSdkTemplatesLocation(stage2Templates);
+
+            var result = resolver.GetDotnetSdkTemplatePackages("any");
+
+            result.Should().NotBeEmpty();
+        }
+    }
+}

--- a/src/Tests/Microsoft.DotNet.TemplateLocator.Tests/Microsoft.DotNet.TemplateLocator.Tests.csproj
+++ b/src/Tests/Microsoft.DotNet.TemplateLocator.Tests/Microsoft.DotNet.TemplateLocator.Tests.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <TargetFrameworks>net472;$(ToolsetTargetFramework)</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">$(ToolsetTargetFramework)</TargetFrameworks>
+    <OutputType Condition="'$(TargetFramework)' == '$(ToolsetTargetFramework)'">Exe</OutputType>
+    <StrongNameKeyId>MicrosoftAspNetCore</StrongNameKeyId>
+
+    <!-- By default test projects don't append TargetFramework to output path, but for multi-targeted tests
+         we need to -->
+    <AppendTargetFrameworkToOutputPath>true</AppendTargetFrameworkToOutputPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Microsoft.DotNet.TemplateLocator\Microsoft.DotNet.TemplateLocator.csproj" />
+    <ProjectReference Include="..\Microsoft.NET.TestFramework\Microsoft.NET.TestFramework.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Check in the code, so it will be published to the feed.
dotnet/templating can start to consume it. Once the actual
implementation is done, we can rename the package. The only thing
dotnet/templating need to do is to change the package reference name
then.