### PR TITLE
Import WinFX Targets Only When Targeting .NETFramework

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.BeforeCommon.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.BeforeCommon.targets
@@ -18,14 +18,6 @@ Copyright (c) .NET Foundation. All rights reserved.
     <Import Project="Microsoft.NET.SupportedTargetFrameworks.props" />
   </ImportGroup>
 
-  <!--
-    Workaround: https://github.com/microsoft/msbuild/issues/4948
-    Allow opt-out of importing framework's winfx.targets.
-  -->
-  <PropertyGroup>
-    <ImportFrameworkWinFXTargets Condition="'$(ImportFrameworkWinFXTargets)' == ''">true</ImportFrameworkWinFXTargets>
-  </PropertyGroup>
-
   <PropertyGroup>
     <_IsExecutable Condition="'$(OutputType)' == 'Exe' or '$(OutputType)'=='WinExe'">true</_IsExecutable>
     <OutputType Condition="'$(DisableWinExeOutputInference)' != 'true' and '$(OutputType)' == 'Exe' and ('$(UseWindowsForms)' == 'true' or '$(UseWPF)' == 'true')">WinExe</OutputType>
@@ -52,6 +44,15 @@ Copyright (c) .NET Foundation. All rights reserved.
     and adjust intermediate and output paths to include it.
   -->
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.NET.TargetFrameworkInference.targets" />
+
+  <!-- Related issue: https://github.com/dotnet/sdk/issues/12324-->
+  <PropertyGroup>
+    <!-- Import winfx targets when we're not on WPF and targeting .NETFramework. -->
+    <ImportFrameworkWinFXTargets Condition="'$(ImportFrameworkWinFXTargets)' == '' and '$(UseWPF)' != 'true' and '$(TargetFrameworkIdentifier)' == '.NETFramework'">true</ImportFrameworkWinFXTargets>
+
+    <!-- Otherwise, don't import. -->
+    <ImportFrameworkWinFXTargets Condition="'$(ImportFrameworkWinFXTargets)' == ''">false</ImportFrameworkWinFXTargets>
+  </PropertyGroup>
 
   <!-- For .NET Framework, reference core assemblies -->
   <PropertyGroup>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.BeforeCommon.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.BeforeCommon.targets
@@ -47,7 +47,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <!-- Related issue: https://github.com/dotnet/sdk/issues/12324-->
   <PropertyGroup>
-    <!-- Import winfx targets when we're not on WPF and targeting .NETFramework. -->
+    <!-- Import winfx targets when we're targeting .NETFramework and not importing the newer WindowsDesktop targets via `UseWPF`. -->
     <ImportFrameworkWinFXTargets Condition="'$(ImportFrameworkWinFXTargets)' == '' and '$(UseWPF)' != 'true' and '$(TargetFrameworkIdentifier)' == '.NETFramework'">true</ImportFrameworkWinFXTargets>
 
     <!-- Otherwise, don't import. -->


### PR DESCRIPTION
Fixes https://github.com/dotnet/sdk/issues/12324 by importing framework winfx.targets only when `TargetFrameworkIdentifier` is `.NETFramework` and `UseWPF` is false. Otherwise, `ImportFrameworkWinFXTargets` will be set to false and thus _not_ import.

Moved the import of winfx.targets after Microsoft.NET.TargetFrameworkInference.targets, so we know what the TargetFrameworkIdentifier is by the time we need to check it.

I wrote the same property twice with two separate conditions because of how we implemented ImportFrameworkWinFXTargets on the msbuild side. So I wrote this in a way that's easier to read, although there's an extra line.

<Import Project="$(MSBuildFrameworkToolsPath)\Microsoft.WinFx.targets" Condition="'$(ImportFrameworkWinFXTargets)' != 'false' and Exists('$(MSBuildFrameworkToolsPath)\Microsoft.WinFx.targets')" />
Note that any non false value is interpreted as "yes, import framework winfx targets".

Equivalent PR to `release/5.0.1xx-preview8`: https://github.com/dotnet/sdk/pull/12789