### PR TITLE
Import WinFX Targets Only When Targeting .NETFramework

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.BeforeCommon.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.BeforeCommon.targets
@@ -48,7 +48,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <!-- Related issue: https://github.com/dotnet/sdk/issues/12324-->
   <PropertyGroup>
-    <!-- Import winfx targets when we're not on WPF and targeting .NETFramework. -->
+    <!-- Import winfx targets when we're targeting .NETFramework and not importing the newer WindowsDesktop targets via `UseWPF`. -->
     <ImportFrameworkWinFXTargets Condition="'$(ImportFrameworkWinFXTargets)' == '' and '$(UseWPF)' != 'true' and '$(TargetFrameworkIdentifier)' == '.NETFramework'">true</ImportFrameworkWinFXTargets>
 
     <!-- Otherwise, don't import. -->

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.BeforeCommon.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.BeforeCommon.targets
@@ -19,16 +19,6 @@ Copyright (c) .NET Foundation. All rights reserved.
     <Import Project="Microsoft.NET.WindowsSupportedTargetPlatforms.props" />
   </ImportGroup>
 
-  <!--
-    Workaround: https://github.com/microsoft/msbuild/issues/4948
-    Disable .NET Framework's inbox WinFX targets when using the SDK, since, we really don't use it's build logic
-    and is superseded by 'WindowsDesktop' SDK that provides it's own WinFX for both NETFX and CoreCLR targets.
-    Make it opt-out, just in case, if something fails or we don't want to use 'WindowsDesktop' SDK.
-  -->
-  <PropertyGroup>
-    <ImportFrameworkWinFXTargets Condition="'$(ImportFrameworkWinFXTargets)' == ''">false</ImportFrameworkWinFXTargets>
-  </PropertyGroup>
-
   <PropertyGroup>
     <_IsExecutable Condition="'$(OutputType)' == 'Exe' or '$(OutputType)'=='WinExe'">true</_IsExecutable>
     <OutputType Condition="'$(DisableWinExeOutputInference)' != 'true' and '$(OutputType)' == 'Exe' and ('$(UseWindowsForms)' == 'true' or '$(UseWPF)' == 'true')">WinExe</OutputType>
@@ -55,6 +45,15 @@ Copyright (c) .NET Foundation. All rights reserved.
     and adjust intermediate and output paths to include it.
   -->
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.NET.TargetFrameworkInference.targets" />
+
+  <!-- Related issue: https://github.com/dotnet/sdk/issues/12324-->
+  <PropertyGroup>
+    <!-- Import winfx targets when we're not on WPF and targeting .NETFramework. -->
+    <ImportFrameworkWinFXTargets Condition="'$(ImportFrameworkWinFXTargets)' == '' and '$(UseWPF)' != 'true' and '$(TargetFrameworkIdentifier)' == '.NETFramework'">true</ImportFrameworkWinFXTargets>
+
+    <!-- Otherwise, don't import. -->
+    <ImportFrameworkWinFXTargets Condition="'$(ImportFrameworkWinFXTargets)' == ''">false</ImportFrameworkWinFXTargets>
+  </PropertyGroup>
 
   <!-- For .NET Framework, reference core assemblies -->
   <PropertyGroup>


### PR DESCRIPTION
### Description
[MSBuild was seeing](https://github.com/dotnet/msbuild/issues/4948) different behavior between `msbuild` and `dotnet` builds with sdk style projects, so we [stopped importing](https://github.com/dotnet/msbuild/pull/5200) these targets for [sdk style projects](https://github.com/dotnet/sdk/pull/10998). The mistake we made when we implemented this fix was that we should have continued to import them for sdk style WPF projects that targeted `.NETFramework` specifically.


### Customer Impact

This impacts all customers using SDK style WPF projects that target `.NETFramework`. They will import the incorrect `Microsoft.WinFx.targets` file and see failed builds unless they set the `ImportFrameworkWinFXTargets` property to any non `false` value.  A couple of internal teams already have reported not being able to compile their projects using the 5.0 sdk including VSTest and project system.

### Regression?

Yes, by https://github.com/dotnet/sdk/pull/10998

### Risk

Low risk.

### Test changes in this PR

No test changes.

#### Additional Notes
Fixes https://github.com/dotnet/sdk/issues/12324 by importing framework winfx.targets only when `TargetFrameworkIdentifier` is `.NETFramework` and `UseWPF` is false. Otherwise, `ImportFrameworkWinFXTargets` will be set to false and thus _not_ import.

Moved the import of winfx.targets after Microsoft.NET.TargetFrameworkInference.targets, so we know what the TargetFrameworkIdentifier is by the time we need to check it.

I wrote the same property twice with two separate conditions because of how we implemented ImportFrameworkWinFXTargets on the msbuild side. So I wrote this in a way that'seasier easier to read, although there's an extra line.

<Import Project="$(MSBuildFrameworkToolsPath)\Microsoft.WinFx.targets" Condition="'$(ImportFrameworkWinFXTargets)' != 'false' and Exists('$(MSBuildFrameworkToolsPath)\Microsoft.WinFx.targets')" />
Note that any non false value is interpreted as "yes, import framework winfx targets".

Side note, if TargetFrameworkIdentifier is netstandard, what should happen here?

Equivalent PR to master: https://github.com/dotnet/sdk/pull/12786