### PR TITLE
Use forward slash as dir separator inside RelativePath

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/GenerateBundle.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/GenerateBundle.cs
@@ -51,7 +51,7 @@ namespace Microsoft.NET.Build.Tasks
             foreach (var item in FilesToBundle)
             {
                 fileSpec.Add(new FileSpec(sourcePath: item.ItemSpec, 
-                                          bundleRelativePath:item.GetMetadata(MetadataKeys.RelativePath)));
+                                          bundleRelativePath: NormalizePathDirectorySeparator(item.GetMetadata(MetadataKeys.RelativePath))));
             }
 
             bundler.GenerateBundle(fileSpec);
@@ -63,6 +63,11 @@ namespace Microsoft.NET.Build.Tasks
             // Return the set of excluded files in ExcludedFiles, so that they can be placed in the publish directory.
 
             ExcludedFiles = FilesToBundle.Zip(fileSpec, (item, spec) => (spec.Excluded) ? item : null).Where(x => x != null).ToArray();
+        }
+
+        private static string NormalizePathDirectorySeparator(string path)
+        {
+            return path.Replace('\\', '/');
         }
     }
 }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -549,7 +549,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
       <!-- Copy satellite assemblies. -->
       <ResolvedFileToPublish Include="@(IntermediateSatelliteAssembliesWithTargetPath)">
-        <RelativePath>%(IntermediateSatelliteAssembliesWithTargetPath.Culture)\%(Filename)%(Extension)</RelativePath>
+        <RelativePath>%(IntermediateSatelliteAssembliesWithTargetPath.Culture)/%(Filename)%(Extension)</RelativePath>
         <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
       </ResolvedFileToPublish>
 


### PR DESCRIPTION
Related to https://github.com/dotnet/runtime/issues/37208. Using a backslash as a directory separator for copied satellite assemblies is causing errors when generating bundles for single file apps, since it's completely valid to use `\` in a filename. Changing this line seemed like the easiest way to solve this.