### PR TITLE
Introduce option to enable trim analysis warnings

### DIFF
--- a/src/Tasks/Common/Resources/Strings.resx
+++ b/src/Tasks/Common/Resources/Strings.resx
@@ -679,7 +679,7 @@ The following are names of parameters or literal values and should not be transl
     <comment>{StrBegin="NETSDK1143: "}</comment>
   </data>
   <data name="ILLinkFailed" xml:space="preserve">
-    <value>NETSDK1144: Optimizing assemblies for size failed. You can either fix the errors, or set the PublishTrimmed property to false.</value>
+    <value>NETSDK1144: Optimizing assemblies for size failed. Optimization can be disabled by setting the PublishTrimmed property to false.</value>
     <comment>{StrBegin="NETSDK1144: "}</comment>
   </data>
 </root>

--- a/src/Tasks/Common/Resources/Strings.resx
+++ b/src/Tasks/Common/Resources/Strings.resx
@@ -678,4 +678,8 @@ The following are names of parameters or literal values and should not be transl
     <value>NETSDK1143: Including all content in a single file bundle also includes native libraries. If IncludeAllContentForSelfExtract is true, IncludeNativeLibrariesForSelfExtract must not be false.</value>
     <comment>{StrBegin="NETSDK1143: "}</comment>
   </data>
+  <data name="ILLinkFailed" xml:space="preserve">
+    <value>NETSDK1144: Optimizing assemblies for size failed. You can either fix the errors, or set the PublishTrimmed property to false.</value>
+    <comment>{StrBegin="NETSDK1144: "}</comment>
+  </data>
 </root>

--- a/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
@@ -364,6 +364,11 @@
         <target state="new">NETSDK1141: Unable to resolve the .NET SDK version as specified in the global.json located at {0}.</target>
         <note>{StrBegin="NETSDK1141: "}</note>
       </trans-unit>
+      <trans-unit id="ILLinkFailed">
+        <source>NETSDK1144: Optimizing assemblies for size failed. You can either fix the errors, or set the PublishTrimmed property to false.</source>
+        <target state="new">NETSDK1144: Optimizing assemblies for size failed. You can either fix the errors, or set the PublishTrimmed property to false.</target>
+        <note>{StrBegin="NETSDK1144: "}</note>
+      </trans-unit>
       <trans-unit id="ILLinkNotSupportedError">
         <source>NETSDK1102: Optimizing assemblies for size is not supported for the selected publish configuration. Please ensure that you are publishing a self-contained app.</source>
         <target state="translated">NETSDK1102: Pro vybranou konfiguraci publikování se optimalizace velikosti sestavení nepodporuje. Ujistěte se, že publikujete samostatnou aplikaci.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
@@ -365,8 +365,8 @@
         <note>{StrBegin="NETSDK1141: "}</note>
       </trans-unit>
       <trans-unit id="ILLinkFailed">
-        <source>NETSDK1144: Optimizing assemblies for size failed. You can either fix the errors, or set the PublishTrimmed property to false.</source>
-        <target state="new">NETSDK1144: Optimizing assemblies for size failed. You can either fix the errors, or set the PublishTrimmed property to false.</target>
+        <source>NETSDK1144: Optimizing assemblies for size failed. Optimization can be disabled by setting the PublishTrimmed property to false.</source>
+        <target state="new">NETSDK1144: Optimizing assemblies for size failed. Optimization can be disabled by setting the PublishTrimmed property to false.</target>
         <note>{StrBegin="NETSDK1144: "}</note>
       </trans-unit>
       <trans-unit id="ILLinkNotSupportedError">

--- a/src/Tasks/Common/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.de.xlf
@@ -364,6 +364,11 @@
         <target state="new">NETSDK1141: Unable to resolve the .NET SDK version as specified in the global.json located at {0}.</target>
         <note>{StrBegin="NETSDK1141: "}</note>
       </trans-unit>
+      <trans-unit id="ILLinkFailed">
+        <source>NETSDK1144: Optimizing assemblies for size failed. You can either fix the errors, or set the PublishTrimmed property to false.</source>
+        <target state="new">NETSDK1144: Optimizing assemblies for size failed. You can either fix the errors, or set the PublishTrimmed property to false.</target>
+        <note>{StrBegin="NETSDK1144: "}</note>
+      </trans-unit>
       <trans-unit id="ILLinkNotSupportedError">
         <source>NETSDK1102: Optimizing assemblies for size is not supported for the selected publish configuration. Please ensure that you are publishing a self-contained app.</source>
         <target state="translated">NETSDK1102: Die Größenoptimierung von Assemblys wird für die ausgewählte Veröffentlichungskonfiguration nicht unterstützt. Stellen Sie sicher, dass Sie eine eigenständige App veröffentlichen.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.de.xlf
@@ -365,8 +365,8 @@
         <note>{StrBegin="NETSDK1141: "}</note>
       </trans-unit>
       <trans-unit id="ILLinkFailed">
-        <source>NETSDK1144: Optimizing assemblies for size failed. You can either fix the errors, or set the PublishTrimmed property to false.</source>
-        <target state="new">NETSDK1144: Optimizing assemblies for size failed. You can either fix the errors, or set the PublishTrimmed property to false.</target>
+        <source>NETSDK1144: Optimizing assemblies for size failed. Optimization can be disabled by setting the PublishTrimmed property to false.</source>
+        <target state="new">NETSDK1144: Optimizing assemblies for size failed. Optimization can be disabled by setting the PublishTrimmed property to false.</target>
         <note>{StrBegin="NETSDK1144: "}</note>
       </trans-unit>
       <trans-unit id="ILLinkNotSupportedError">

--- a/src/Tasks/Common/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.es.xlf
@@ -364,6 +364,11 @@
         <target state="new">NETSDK1141: Unable to resolve the .NET SDK version as specified in the global.json located at {0}.</target>
         <note>{StrBegin="NETSDK1141: "}</note>
       </trans-unit>
+      <trans-unit id="ILLinkFailed">
+        <source>NETSDK1144: Optimizing assemblies for size failed. You can either fix the errors, or set the PublishTrimmed property to false.</source>
+        <target state="new">NETSDK1144: Optimizing assemblies for size failed. You can either fix the errors, or set the PublishTrimmed property to false.</target>
+        <note>{StrBegin="NETSDK1144: "}</note>
+      </trans-unit>
       <trans-unit id="ILLinkNotSupportedError">
         <source>NETSDK1102: Optimizing assemblies for size is not supported for the selected publish configuration. Please ensure that you are publishing a self-contained app.</source>
         <target state="translated">NETSDK1102: No se admite la optimización de tamaño de los ensamblados para la configuración de publicación seleccionada. Asegúrese de que está publicando una aplicación autónoma.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.es.xlf
@@ -365,8 +365,8 @@
         <note>{StrBegin="NETSDK1141: "}</note>
       </trans-unit>
       <trans-unit id="ILLinkFailed">
-        <source>NETSDK1144: Optimizing assemblies for size failed. You can either fix the errors, or set the PublishTrimmed property to false.</source>
-        <target state="new">NETSDK1144: Optimizing assemblies for size failed. You can either fix the errors, or set the PublishTrimmed property to false.</target>
+        <source>NETSDK1144: Optimizing assemblies for size failed. Optimization can be disabled by setting the PublishTrimmed property to false.</source>
+        <target state="new">NETSDK1144: Optimizing assemblies for size failed. Optimization can be disabled by setting the PublishTrimmed property to false.</target>
         <note>{StrBegin="NETSDK1144: "}</note>
       </trans-unit>
       <trans-unit id="ILLinkNotSupportedError">

--- a/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
@@ -364,6 +364,11 @@
         <target state="new">NETSDK1141: Unable to resolve the .NET SDK version as specified in the global.json located at {0}.</target>
         <note>{StrBegin="NETSDK1141: "}</note>
       </trans-unit>
+      <trans-unit id="ILLinkFailed">
+        <source>NETSDK1144: Optimizing assemblies for size failed. You can either fix the errors, or set the PublishTrimmed property to false.</source>
+        <target state="new">NETSDK1144: Optimizing assemblies for size failed. You can either fix the errors, or set the PublishTrimmed property to false.</target>
+        <note>{StrBegin="NETSDK1144: "}</note>
+      </trans-unit>
       <trans-unit id="ILLinkNotSupportedError">
         <source>NETSDK1102: Optimizing assemblies for size is not supported for the selected publish configuration. Please ensure that you are publishing a self-contained app.</source>
         <target state="translated">NETSDK1102: l'optimisation de la taille des assemblys n'est pas prise en charge pour la configuration de publication sélectionnée. Vérifiez que vous publiez une application autonome.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
@@ -365,8 +365,8 @@
         <note>{StrBegin="NETSDK1141: "}</note>
       </trans-unit>
       <trans-unit id="ILLinkFailed">
-        <source>NETSDK1144: Optimizing assemblies for size failed. You can either fix the errors, or set the PublishTrimmed property to false.</source>
-        <target state="new">NETSDK1144: Optimizing assemblies for size failed. You can either fix the errors, or set the PublishTrimmed property to false.</target>
+        <source>NETSDK1144: Optimizing assemblies for size failed. Optimization can be disabled by setting the PublishTrimmed property to false.</source>
+        <target state="new">NETSDK1144: Optimizing assemblies for size failed. Optimization can be disabled by setting the PublishTrimmed property to false.</target>
         <note>{StrBegin="NETSDK1144: "}</note>
       </trans-unit>
       <trans-unit id="ILLinkNotSupportedError">

--- a/src/Tasks/Common/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.it.xlf
@@ -365,8 +365,8 @@
         <note>{StrBegin="NETSDK1141: "}</note>
       </trans-unit>
       <trans-unit id="ILLinkFailed">
-        <source>NETSDK1144: Optimizing assemblies for size failed. You can either fix the errors, or set the PublishTrimmed property to false.</source>
-        <target state="new">NETSDK1144: Optimizing assemblies for size failed. You can either fix the errors, or set the PublishTrimmed property to false.</target>
+        <source>NETSDK1144: Optimizing assemblies for size failed. Optimization can be disabled by setting the PublishTrimmed property to false.</source>
+        <target state="new">NETSDK1144: Optimizing assemblies for size failed. Optimization can be disabled by setting the PublishTrimmed property to false.</target>
         <note>{StrBegin="NETSDK1144: "}</note>
       </trans-unit>
       <trans-unit id="ILLinkNotSupportedError">

--- a/src/Tasks/Common/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.it.xlf
@@ -364,6 +364,11 @@
         <target state="new">NETSDK1141: Unable to resolve the .NET SDK version as specified in the global.json located at {0}.</target>
         <note>{StrBegin="NETSDK1141: "}</note>
       </trans-unit>
+      <trans-unit id="ILLinkFailed">
+        <source>NETSDK1144: Optimizing assemblies for size failed. You can either fix the errors, or set the PublishTrimmed property to false.</source>
+        <target state="new">NETSDK1144: Optimizing assemblies for size failed. You can either fix the errors, or set the PublishTrimmed property to false.</target>
+        <note>{StrBegin="NETSDK1144: "}</note>
+      </trans-unit>
       <trans-unit id="ILLinkNotSupportedError">
         <source>NETSDK1102: Optimizing assemblies for size is not supported for the selected publish configuration. Please ensure that you are publishing a self-contained app.</source>
         <target state="translated">NETSDK1102: l'ottimizzazione degli assembly per le dimensioni non è supportata per la configurazione di pubblicazione selezionata. Assicurarsi di pubblicare un'app indipendente.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
@@ -364,6 +364,11 @@
         <target state="new">NETSDK1141: Unable to resolve the .NET SDK version as specified in the global.json located at {0}.</target>
         <note>{StrBegin="NETSDK1141: "}</note>
       </trans-unit>
+      <trans-unit id="ILLinkFailed">
+        <source>NETSDK1144: Optimizing assemblies for size failed. You can either fix the errors, or set the PublishTrimmed property to false.</source>
+        <target state="new">NETSDK1144: Optimizing assemblies for size failed. You can either fix the errors, or set the PublishTrimmed property to false.</target>
+        <note>{StrBegin="NETSDK1144: "}</note>
+      </trans-unit>
       <trans-unit id="ILLinkNotSupportedError">
         <source>NETSDK1102: Optimizing assemblies for size is not supported for the selected publish configuration. Please ensure that you are publishing a self-contained app.</source>
         <target state="translated">NETSDK1102: アセンブリのサイズの最適化は、選択された公開構成に対してはサポートされていません。自己完結型のアプリを公開していることをご確認ください。</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
@@ -365,8 +365,8 @@
         <note>{StrBegin="NETSDK1141: "}</note>
       </trans-unit>
       <trans-unit id="ILLinkFailed">
-        <source>NETSDK1144: Optimizing assemblies for size failed. You can either fix the errors, or set the PublishTrimmed property to false.</source>
-        <target state="new">NETSDK1144: Optimizing assemblies for size failed. You can either fix the errors, or set the PublishTrimmed property to false.</target>
+        <source>NETSDK1144: Optimizing assemblies for size failed. Optimization can be disabled by setting the PublishTrimmed property to false.</source>
+        <target state="new">NETSDK1144: Optimizing assemblies for size failed. Optimization can be disabled by setting the PublishTrimmed property to false.</target>
         <note>{StrBegin="NETSDK1144: "}</note>
       </trans-unit>
       <trans-unit id="ILLinkNotSupportedError">

--- a/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
@@ -364,6 +364,11 @@
         <target state="new">NETSDK1141: Unable to resolve the .NET SDK version as specified in the global.json located at {0}.</target>
         <note>{StrBegin="NETSDK1141: "}</note>
       </trans-unit>
+      <trans-unit id="ILLinkFailed">
+        <source>NETSDK1144: Optimizing assemblies for size failed. You can either fix the errors, or set the PublishTrimmed property to false.</source>
+        <target state="new">NETSDK1144: Optimizing assemblies for size failed. You can either fix the errors, or set the PublishTrimmed property to false.</target>
+        <note>{StrBegin="NETSDK1144: "}</note>
+      </trans-unit>
       <trans-unit id="ILLinkNotSupportedError">
         <source>NETSDK1102: Optimizing assemblies for size is not supported for the selected publish configuration. Please ensure that you are publishing a self-contained app.</source>
         <target state="translated">NETSDK1102: 선택한 게시 구성에서는 크기에 대한 어셈블리 최적화가 지원되지 않습니다. 자체 포함 앱을 게시하고 있는지 확인하세요.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
@@ -365,8 +365,8 @@
         <note>{StrBegin="NETSDK1141: "}</note>
       </trans-unit>
       <trans-unit id="ILLinkFailed">
-        <source>NETSDK1144: Optimizing assemblies for size failed. You can either fix the errors, or set the PublishTrimmed property to false.</source>
-        <target state="new">NETSDK1144: Optimizing assemblies for size failed. You can either fix the errors, or set the PublishTrimmed property to false.</target>
+        <source>NETSDK1144: Optimizing assemblies for size failed. Optimization can be disabled by setting the PublishTrimmed property to false.</source>
+        <target state="new">NETSDK1144: Optimizing assemblies for size failed. Optimization can be disabled by setting the PublishTrimmed property to false.</target>
         <note>{StrBegin="NETSDK1144: "}</note>
       </trans-unit>
       <trans-unit id="ILLinkNotSupportedError">

--- a/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
@@ -364,6 +364,11 @@
         <target state="new">NETSDK1141: Unable to resolve the .NET SDK version as specified in the global.json located at {0}.</target>
         <note>{StrBegin="NETSDK1141: "}</note>
       </trans-unit>
+      <trans-unit id="ILLinkFailed">
+        <source>NETSDK1144: Optimizing assemblies for size failed. You can either fix the errors, or set the PublishTrimmed property to false.</source>
+        <target state="new">NETSDK1144: Optimizing assemblies for size failed. You can either fix the errors, or set the PublishTrimmed property to false.</target>
+        <note>{StrBegin="NETSDK1144: "}</note>
+      </trans-unit>
       <trans-unit id="ILLinkNotSupportedError">
         <source>NETSDK1102: Optimizing assemblies for size is not supported for the selected publish configuration. Please ensure that you are publishing a self-contained app.</source>
         <target state="translated">NETSDK1102: Optymalizacja zestawów pod kątem rozmiaru nie jest obsługiwana w przypadku wybranej konfiguracji publikowania. Upewnij się, że publikujesz niezależną aplikację.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
@@ -365,8 +365,8 @@
         <note>{StrBegin="NETSDK1141: "}</note>
       </trans-unit>
       <trans-unit id="ILLinkFailed">
-        <source>NETSDK1144: Optimizing assemblies for size failed. You can either fix the errors, or set the PublishTrimmed property to false.</source>
-        <target state="new">NETSDK1144: Optimizing assemblies for size failed. You can either fix the errors, or set the PublishTrimmed property to false.</target>
+        <source>NETSDK1144: Optimizing assemblies for size failed. Optimization can be disabled by setting the PublishTrimmed property to false.</source>
+        <target state="new">NETSDK1144: Optimizing assemblies for size failed. Optimization can be disabled by setting the PublishTrimmed property to false.</target>
         <note>{StrBegin="NETSDK1144: "}</note>
       </trans-unit>
       <trans-unit id="ILLinkNotSupportedError">

--- a/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
@@ -364,6 +364,11 @@
         <target state="new">NETSDK1141: Unable to resolve the .NET SDK version as specified in the global.json located at {0}.</target>
         <note>{StrBegin="NETSDK1141: "}</note>
       </trans-unit>
+      <trans-unit id="ILLinkFailed">
+        <source>NETSDK1144: Optimizing assemblies for size failed. You can either fix the errors, or set the PublishTrimmed property to false.</source>
+        <target state="new">NETSDK1144: Optimizing assemblies for size failed. You can either fix the errors, or set the PublishTrimmed property to false.</target>
+        <note>{StrBegin="NETSDK1144: "}</note>
+      </trans-unit>
       <trans-unit id="ILLinkNotSupportedError">
         <source>NETSDK1102: Optimizing assemblies for size is not supported for the selected publish configuration. Please ensure that you are publishing a self-contained app.</source>
         <target state="translated">NETSDK1102: não há suporte para a otimização de assemblies para tamanho na configuração de publicação selecionada. Verifique se você está publicando um aplicativo independente.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
@@ -365,8 +365,8 @@
         <note>{StrBegin="NETSDK1141: "}</note>
       </trans-unit>
       <trans-unit id="ILLinkFailed">
-        <source>NETSDK1144: Optimizing assemblies for size failed. You can either fix the errors, or set the PublishTrimmed property to false.</source>
-        <target state="new">NETSDK1144: Optimizing assemblies for size failed. You can either fix the errors, or set the PublishTrimmed property to false.</target>
+        <source>NETSDK1144: Optimizing assemblies for size failed. Optimization can be disabled by setting the PublishTrimmed property to false.</source>
+        <target state="new">NETSDK1144: Optimizing assemblies for size failed. Optimization can be disabled by setting the PublishTrimmed property to false.</target>
         <note>{StrBegin="NETSDK1144: "}</note>
       </trans-unit>
       <trans-unit id="ILLinkNotSupportedError">

--- a/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
@@ -364,6 +364,11 @@
         <target state="new">NETSDK1141: Unable to resolve the .NET SDK version as specified in the global.json located at {0}.</target>
         <note>{StrBegin="NETSDK1141: "}</note>
       </trans-unit>
+      <trans-unit id="ILLinkFailed">
+        <source>NETSDK1144: Optimizing assemblies for size failed. You can either fix the errors, or set the PublishTrimmed property to false.</source>
+        <target state="new">NETSDK1144: Optimizing assemblies for size failed. You can either fix the errors, or set the PublishTrimmed property to false.</target>
+        <note>{StrBegin="NETSDK1144: "}</note>
+      </trans-unit>
       <trans-unit id="ILLinkNotSupportedError">
         <source>NETSDK1102: Optimizing assemblies for size is not supported for the selected publish configuration. Please ensure that you are publishing a self-contained app.</source>
         <target state="translated">NETSDK1102: оптимизация сборок по размеру не поддерживается для выбранной конфигурации публикации. Убедитесь, что вы публикуете автономное приложение.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
@@ -365,8 +365,8 @@
         <note>{StrBegin="NETSDK1141: "}</note>
       </trans-unit>
       <trans-unit id="ILLinkFailed">
-        <source>NETSDK1144: Optimizing assemblies for size failed. You can either fix the errors, or set the PublishTrimmed property to false.</source>
-        <target state="new">NETSDK1144: Optimizing assemblies for size failed. You can either fix the errors, or set the PublishTrimmed property to false.</target>
+        <source>NETSDK1144: Optimizing assemblies for size failed. Optimization can be disabled by setting the PublishTrimmed property to false.</source>
+        <target state="new">NETSDK1144: Optimizing assemblies for size failed. Optimization can be disabled by setting the PublishTrimmed property to false.</target>
         <note>{StrBegin="NETSDK1144: "}</note>
       </trans-unit>
       <trans-unit id="ILLinkNotSupportedError">

--- a/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
@@ -364,6 +364,11 @@
         <target state="new">NETSDK1141: Unable to resolve the .NET SDK version as specified in the global.json located at {0}.</target>
         <note>{StrBegin="NETSDK1141: "}</note>
       </trans-unit>
+      <trans-unit id="ILLinkFailed">
+        <source>NETSDK1144: Optimizing assemblies for size failed. You can either fix the errors, or set the PublishTrimmed property to false.</source>
+        <target state="new">NETSDK1144: Optimizing assemblies for size failed. You can either fix the errors, or set the PublishTrimmed property to false.</target>
+        <note>{StrBegin="NETSDK1144: "}</note>
+      </trans-unit>
       <trans-unit id="ILLinkNotSupportedError">
         <source>NETSDK1102: Optimizing assemblies for size is not supported for the selected publish configuration. Please ensure that you are publishing a self-contained app.</source>
         <target state="translated">NETSDK1102: Derlemeleri boyut için iyileştirme, seçilen yayımlama yapılandırması için desteklenmiyor. Lütfen kendi içinde bulunan bir uygulama yayımladığınızdan emin olun.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
@@ -365,8 +365,8 @@
         <note>{StrBegin="NETSDK1141: "}</note>
       </trans-unit>
       <trans-unit id="ILLinkFailed">
-        <source>NETSDK1144: Optimizing assemblies for size failed. You can either fix the errors, or set the PublishTrimmed property to false.</source>
-        <target state="new">NETSDK1144: Optimizing assemblies for size failed. You can either fix the errors, or set the PublishTrimmed property to false.</target>
+        <source>NETSDK1144: Optimizing assemblies for size failed. Optimization can be disabled by setting the PublishTrimmed property to false.</source>
+        <target state="new">NETSDK1144: Optimizing assemblies for size failed. Optimization can be disabled by setting the PublishTrimmed property to false.</target>
         <note>{StrBegin="NETSDK1144: "}</note>
       </trans-unit>
       <trans-unit id="ILLinkNotSupportedError">

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
@@ -365,8 +365,8 @@
         <note>{StrBegin="NETSDK1141: "}</note>
       </trans-unit>
       <trans-unit id="ILLinkFailed">
-        <source>NETSDK1144: Optimizing assemblies for size failed. You can either fix the errors, or set the PublishTrimmed property to false.</source>
-        <target state="new">NETSDK1144: Optimizing assemblies for size failed. You can either fix the errors, or set the PublishTrimmed property to false.</target>
+        <source>NETSDK1144: Optimizing assemblies for size failed. Optimization can be disabled by setting the PublishTrimmed property to false.</source>
+        <target state="new">NETSDK1144: Optimizing assemblies for size failed. Optimization can be disabled by setting the PublishTrimmed property to false.</target>
         <note>{StrBegin="NETSDK1144: "}</note>
       </trans-unit>
       <trans-unit id="ILLinkNotSupportedError">

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
@@ -364,6 +364,11 @@
         <target state="new">NETSDK1141: Unable to resolve the .NET SDK version as specified in the global.json located at {0}.</target>
         <note>{StrBegin="NETSDK1141: "}</note>
       </trans-unit>
+      <trans-unit id="ILLinkFailed">
+        <source>NETSDK1144: Optimizing assemblies for size failed. You can either fix the errors, or set the PublishTrimmed property to false.</source>
+        <target state="new">NETSDK1144: Optimizing assemblies for size failed. You can either fix the errors, or set the PublishTrimmed property to false.</target>
+        <note>{StrBegin="NETSDK1144: "}</note>
+      </trans-unit>
       <trans-unit id="ILLinkNotSupportedError">
         <source>NETSDK1102: Optimizing assemblies for size is not supported for the selected publish configuration. Please ensure that you are publishing a self-contained app.</source>
         <target state="translated">NETSDK1102: 所选发布配置不支持优化程序集的大小。请确保你发布的是独立应用。</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
@@ -364,6 +364,11 @@
         <target state="new">NETSDK1141: Unable to resolve the .NET SDK version as specified in the global.json located at {0}.</target>
         <note>{StrBegin="NETSDK1141: "}</note>
       </trans-unit>
+      <trans-unit id="ILLinkFailed">
+        <source>NETSDK1144: Optimizing assemblies for size failed. You can either fix the errors, or set the PublishTrimmed property to false.</source>
+        <target state="new">NETSDK1144: Optimizing assemblies for size failed. You can either fix the errors, or set the PublishTrimmed property to false.</target>
+        <note>{StrBegin="NETSDK1144: "}</note>
+      </trans-unit>
       <trans-unit id="ILLinkNotSupportedError">
         <source>NETSDK1102: Optimizing assemblies for size is not supported for the selected publish configuration. Please ensure that you are publishing a self-contained app.</source>
         <target state="translated">NETSDK1102: 選取的發佈設定不支援最佳化組件的大小。請確定您發佈的是獨立式應用程式。</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
@@ -365,8 +365,8 @@
         <note>{StrBegin="NETSDK1141: "}</note>
       </trans-unit>
       <trans-unit id="ILLinkFailed">
-        <source>NETSDK1144: Optimizing assemblies for size failed. You can either fix the errors, or set the PublishTrimmed property to false.</source>
-        <target state="new">NETSDK1144: Optimizing assemblies for size failed. You can either fix the errors, or set the PublishTrimmed property to false.</target>
+        <source>NETSDK1144: Optimizing assemblies for size failed. Optimization can be disabled by setting the PublishTrimmed property to false.</source>
+        <target state="new">NETSDK1144: Optimizing assemblies for size failed. Optimization can be disabled by setting the PublishTrimmed property to false.</target>
         <note>{StrBegin="NETSDK1144: "}</note>
       </trans-unit>
       <trans-unit id="ILLinkNotSupportedError">

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ILLink.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ILLink.targets
@@ -135,7 +135,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <PropertyGroup>
       <_ExtraTrimmerArgs>--skip-unresolved true $(_ExtraTrimmerArgs)</_ExtraTrimmerArgs>
       <TrimMode Condition=" '$(TrimMode)' == '' ">copyused</TrimMode>
-      <NoWarn Condition=" '$(TrimAnalysis)' != 'true' ">$(NoWarn);IL2006;IL2026;IL2043</NoWarn>
+      <NoWarn Condition=" '$(TrimAnalysis)' != 'true' ">$(NoWarn);IL2006;IL2026;IL2043;IL2046;IL2047</NoWarn>
     </PropertyGroup>
 
     <!-- Set a default value for TrimmerRemoveSymbols unless set explicitly. -->

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ILLink.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ILLink.targets
@@ -141,7 +141,22 @@ Copyright (c) .NET Foundation. All rights reserved.
       <_ExtraTrimmerArgs>--skip-unresolved true $(_ExtraTrimmerArgs)</_ExtraTrimmerArgs>
       <TrimMode Condition=" '$(TrimMode)' == '' ">copyused</TrimMode>
       <SuppressTrimAnalysisWarnings Condition=" '$(SuppressTrimAnalysisWarnings)' == '' ">true</SuppressTrimAnalysisWarnings>
-      <NoWarn Condition=" '$(SuppressTrimAnalysisWarnings)' == 'true' ">$(NoWarn);IL2006;IL2026;IL2043;IL2046;IL2047</NoWarn>
+    </PropertyGroup>
+    
+    <!-- These warning codes need to be updated https://github.com/mono/linker/pull/1385 is finished. -->
+    <PropertyGroup Condition=" '$(SuppressTrimAnalysisWarnings)' == 'true' ">
+      <!-- Trim analysis warnings -->
+      <NoWarn>$(NoWarn);IL2006</NoWarn> <!-- Unrecognized reflection pattern -->
+      <NoWarn>$(NoWarn);IL2026</NoWarn> <!-- RequiresUnreferencedCodeAttribute method -->
+
+      <!-- Warnings from the framework. Can be removed once https://github.com/dotnet/runtime/issues/40336 is fixed. -->
+      <!-- Framework embedded XML descriptors reference windows-only members. -->
+      <NoWarn Condition=" !$(RuntimeIdentifier.StartsWith('win')) ">$(NoWarn);IL2008</NoWarn> <!-- Unresolved type referenced in XML. -->
+      <NoWarn Condition=" !$(RuntimeIdentifier.StartsWith('win')) ">$(NoWarn);IL2009</NoWarn> <!-- Unresolved member on type referenced in XML. -->
+      <!-- Framework has DynamicDependencyAttributes that reference windows-only members. -->
+      <NoWarn Condition=" !$(RuntimeIdentifier.StartsWith('win')) ">$(NoWarn);IL2037</NoWarn> <!-- Unresolved member for DynamicDependencyAttribute -->
+      <!-- Framework embedded XML descriptors reference 32-bit-only members. -->
+      <NoWarn Condition=" '$(PlatformTarget)' != 'x64' AND '$(PlatformTarget)' != 'arm64'">$(NoWarn);IL2012</NoWarn> <!-- Unresolved field referenced in XML -->
     </PropertyGroup>
 
     <!-- Set a default value for TrimmerRemoveSymbols unless set explicitly. -->

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ILLink.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ILLink.targets
@@ -38,6 +38,8 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <NETSdkInformation ResourceName="ILLink_Info" />
 
+    <NETSdkError Condition="'$(_ILLinkExitCode)' != '' And '$(_ILLinkExitCode)' != '0'" ResourceName="ILLinkFailed" />
+
     <ItemGroup>
       <_LinkedResolvedFileToPublish Include="@(_LinkedResolvedFileToPublishCandidate)" Condition="Exists('%(Identity)')" />
       <ResolvedFileToPublish Remove="@(ManagedAssemblyToLink)" />
@@ -105,9 +107,12 @@ Copyright (c) .NET Foundation. All rights reserved.
             DumpDependencies="$(_TrimmerDumpDependencies)"
             ExtraArgs="$(_ExtraTrimmerArgs)"
             ToolExe="$(_DotNetHostFileName)"
-            ToolPath="$(_DotNetHostDirectory)" />
+            ToolPath="$(_DotNetHostDirectory)"
+            ContinueOnError="ErrorAndContinue">
+        <Output TaskParameter="ExitCode" PropertyName="_ILLinkExitCode" />
+      </ILLink>
 
-     <Touch Files="$(_LinkSemaphore)" AlwaysCreate="true" />
+     <Touch Files="$(_LinkSemaphore)" AlwaysCreate="true" Condition=" '$(_ILLinkExitCode)' == '0' " />
 
   </Target>
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ILLink.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ILLink.targets
@@ -140,7 +140,8 @@ Copyright (c) .NET Foundation. All rights reserved.
     <PropertyGroup>
       <_ExtraTrimmerArgs>--skip-unresolved true $(_ExtraTrimmerArgs)</_ExtraTrimmerArgs>
       <TrimMode Condition=" '$(TrimMode)' == '' ">copyused</TrimMode>
-      <NoWarn Condition=" '$(TrimAnalysis)' != 'true' ">$(NoWarn);IL2006;IL2026;IL2043;IL2046;IL2047</NoWarn>
+      <SuppressTrimAnalysisWarnings Condition=" '$(SuppressTrimAnalysisWarnings)' == '' ">true</SuppressTrimAnalysisWarnings>
+      <NoWarn Condition=" '$(SuppressTrimAnalysisWarnings)' == 'true' ">$(NoWarn);IL2006;IL2026;IL2043;IL2046;IL2047</NoWarn>
     </PropertyGroup>
 
     <!-- Set a default value for TrimmerRemoveSymbols unless set explicitly. -->

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ILLink.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ILLink.targets
@@ -90,6 +90,7 @@ Copyright (c) .NET Foundation. All rights reserved.
             RemoveSymbols="$(TrimmerRemoveSymbols)"
             FeatureSettings="@(_TrimmerFeatureSettings)"
             CustomData="@(_TrimmerCustomData)"
+            NoWarn="$(NoWarn)"
 
             BeforeFieldInit="$(_TrimmerBeforeFieldInit)"
             OverrideRemoval="$(_TrimmerOverrideRemoval)"
@@ -134,6 +135,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <PropertyGroup>
       <_ExtraTrimmerArgs>--skip-unresolved true $(_ExtraTrimmerArgs)</_ExtraTrimmerArgs>
       <TrimMode Condition=" '$(TrimMode)' == '' ">copyused</TrimMode>
+      <NoWarn Condition=" '$(TrimAnalysis)' != 'true' ">$(NoWarn);IL2006;IL2026;IL2043</NoWarn>
     </PropertyGroup>
 
     <!-- Set a default value for TrimmerRemoveSymbols unless set explicitly. -->

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToRunILLink.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToRunILLink.cs
@@ -235,7 +235,7 @@ namespace Microsoft.NET.Publish.Tests
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
             var publishCommand = new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
-            publishCommand.Execute($"/p:RuntimeIdentifier={rid}", $"/p:SelfContained=true", "/p:PublishTrimmed=true", "/p:TrimAnalysis=true", "/p:_ExtraTrimmerArgs=--verbose")
+            publishCommand.Execute($"/p:RuntimeIdentifier={rid}", $"/p:SelfContained=true", "/p:PublishTrimmed=true", "/p:SuppressTrimAnalysisWarnings=false", "/p:_ExtraTrimmerArgs=--verbose")
                 .Should().Pass()
                 .And.HaveStdOutMatching("IL2006.*Program.IL_2006")
                 .And.HaveStdOutMatching("IL2026.*Program.IL_2026.*Testing analysis warning IL2026")
@@ -265,7 +265,7 @@ namespace Microsoft.NET.Publish.Tests
 
             var publishCommand = new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
             publishCommand.Execute($"/p:RuntimeIdentifier={rid}", $"/p:SelfContained=true", "/p:PublishTrimmed=true",
-                "/p:TrimAnalysis=true", "/p:_ExtraTrimmerArgs=--verbose")
+                "/p:SuppressTrimAnalysisWarnings=false", "/p:_ExtraTrimmerArgs=--verbose")
                 .Should().Fail()
                 .And.HaveStdOutMatching("error IL1001")
                 .And.HaveStdOutMatching("NETSDK1136");

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToRunILLink.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToRunILLink.cs
@@ -204,7 +204,7 @@ namespace Microsoft.NET.Publish.Tests
             DoesImageHaveMethod(isTrimmableDll, "UnusedMethod").Should().BeFalse();
         }
 
-        [Theory]
+        [RequiresMSBuildVersionTheory("16.8.0")]
         [InlineData("net5.0")]
         public void ILLink_analysis_warnings_are_disabled_by_default(string targetFramework)
         {
@@ -224,7 +224,7 @@ namespace Microsoft.NET.Publish.Tests
                 .And.NotHaveStdOutContaining("IL2047");
         }
 
-        [Theory]
+        [RequiresMSBuildVersionTheory("16.8.0")]
         [InlineData("net5.0")]
         public void ILLink_accepts_option_to_enable_analysis_warnings(string targetFramework)
         {
@@ -244,7 +244,7 @@ namespace Microsoft.NET.Publish.Tests
                 .And.HaveStdOutMatching("IL2047.*Program.Derived.IL_2047");
         }
 
-        [Theory]
+        [RequiresMSBuildVersionTheory("16.8.0")]
         [InlineData("net5.0")]
         public void ILLink_errors_fail_the_build(string targetFramework)
         {

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToRunILLink.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToRunILLink.cs
@@ -116,8 +116,8 @@ namespace Microsoft.NET.Publish.Tests
             var publishCommand = new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
             publishCommand.Execute($"/p:RuntimeIdentifier={rid}", "/p:SelfContained=true", "/p:PublishTrimmed=true", $"/p:TrimMode={trimMode}")
                 .Should().Pass()
-                .And.NotHaveStdOutContaining("IL2006")
-                .And.NotHaveStdOutContaining("IL2026");
+                .And.NotHaveStdOutContaining("warning IL2006")
+                .And.NotHaveStdOutContaining("warning IL2026");
 
             var publishDirectory = publishCommand.GetOutputDirectory(targetFramework: targetFramework, runtimeIdentifier: rid);
             var exe = Path.Combine(publishDirectory.FullName, $"{testProject.Name}{Constants.ExeSuffix}");
@@ -220,12 +220,12 @@ namespace Microsoft.NET.Publish.Tests
             publishCommand.Execute($"/p:RuntimeIdentifier={rid}", $"/p:SelfContained=true", "/p:PublishTrimmed=true")
                 .Should().Pass()
                 // trim analysis warnings are disabled
-                .And.NotHaveStdOutContaining("IL2006")
-                .And.NotHaveStdOutContaining("IL2026")
+                .And.NotHaveStdOutContaining("warning IL2006")
+                .And.NotHaveStdOutContaining("warning IL2026")
                 // warnings about invalid attributes still show up
-                .And.HaveStdOutContaining("IL2043")
-                .And.HaveStdOutContaining("IL2046")
-                .And.HaveStdOutContaining("IL2047");
+                .And.HaveStdOutContaining("warning IL2043")
+                .And.HaveStdOutContaining("warning IL2046")
+                .And.HaveStdOutContaining("warning IL2047");
         }
 
         [RequiresMSBuildVersionTheory("16.8.0")]
@@ -241,11 +241,11 @@ namespace Microsoft.NET.Publish.Tests
             var publishCommand = new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
             publishCommand.Execute($"/p:RuntimeIdentifier={rid}", $"/p:SelfContained=true", "/p:PublishTrimmed=true", "/p:SuppressTrimAnalysisWarnings=false")
                 .Should().Pass()
-                .And.HaveStdOutMatching("IL2006.*Program.IL_2006")
-                .And.HaveStdOutMatching("IL2026.*Program.IL_2026.*Testing analysis warning IL2026")
-                .And.HaveStdOutMatching("IL2043.*Program.get_IL_2043")
-                .And.HaveStdOutMatching("IL2046.*Program.Derived.IL_2046")
-                .And.HaveStdOutMatching("IL2047.*Program.Derived.IL_2047");
+                .And.HaveStdOutMatching("warning IL2006.*Program.IL_2006")
+                .And.HaveStdOutMatching("warning IL2026.*Program.IL_2026.*Testing analysis warning IL2026")
+                .And.HaveStdOutMatching("warning IL2043.*Program.get_IL_2043")
+                .And.HaveStdOutMatching("warning IL2046.*Program.Derived.IL_2046")
+                .And.HaveStdOutMatching("warning IL2047.*Program.Derived.IL_2047");
         }
 
         [RequiresMSBuildVersionTheory("16.8.0")]

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToRunILLink.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToRunILLink.cs
@@ -194,7 +194,9 @@ namespace Microsoft.NET.Publish.Tests
                 .Should().Pass()
                 .And.NotHaveStdOutContaining("IL2006")
                 .And.NotHaveStdOutContaining("IL2026")
-                .And.NotHaveStdOutContaining("IL2043");
+                .And.NotHaveStdOutContaining("IL2043")
+                .And.NotHaveStdOutContaining("IL2046")
+                .And.NotHaveStdOutContaining("IL2047");
         }
 
         [Theory]
@@ -212,7 +214,9 @@ namespace Microsoft.NET.Publish.Tests
                 .Should().Pass()
                 .And.HaveStdOutContaining(stdout => new Regex("IL2006.*Program.IL_2006").IsMatch(stdout), "IL2006")
                 .And.HaveStdOutContaining(stdout => new Regex("IL2026.*Program.IL_2026.*Testing analysis warning IL2026").IsMatch(stdout), "IL2026")
-                .And.HaveStdOutContaining(stdout => new Regex("IL2043.*Program.get_IL_2043").IsMatch(stdout), "IL2043");
+                .And.HaveStdOutContaining(stdout => new Regex("IL2043.*Program.get_IL_2043").IsMatch(stdout), "IL2043")
+                .And.HaveStdOutContaining(stdout => new Regex("IL2046.*Program.Derived.IL_2046").IsMatch(stdout), "IL2046")
+                .And.HaveStdOutContaining(stdout => new Regex("IL2047.*Program.Derived.IL_2047").IsMatch(stdout), "IL2047");
         }
 
         [Theory]
@@ -850,6 +854,8 @@ public class Program
         IL_2006();
         IL_2026();
         _ = IL_2043;
+        new Derived().IL_2046();
+        new Derived().IL_2047();
     }
 
     [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)]
@@ -869,6 +875,22 @@ public class Program
     public static string IL_2043 {
         [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)]
         get => null;
+    }
+
+    public class Base
+    {
+        [RequiresUnreferencedCode(""Testing analysis warning IL2046"")]
+        public virtual void IL_2046() {}
+
+        public virtual string IL_2047() => null;
+    }
+
+    public class Derived : Base
+    {
+        public override void IL_2046() {}
+
+        [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)]
+        public override string IL_2047() => null;
     }
 }
 ";

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToRunILLink.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToRunILLink.cs
@@ -267,8 +267,8 @@ namespace Microsoft.NET.Publish.Tests
             publishCommand.Execute($"/p:RuntimeIdentifier={rid}", $"/p:SelfContained=true", "/p:PublishTrimmed=true",
                 "/p:SuppressTrimAnalysisWarnings=false", "/p:_ExtraTrimmerArgs=--verbose")
                 .Should().Fail()
-                .And.HaveStdOutMatching("error IL1001")
-                .And.HaveStdOutMatching("NETSDK1136");
+                .And.HaveStdOutContaining("error IL1001")
+                .And.HaveStdOutContaining(Strings.ILLinkFailed);
 
             var intermediateDirectory = publishCommand.GetIntermediateDirectory(targetFramework: targetFramework, runtimeIdentifier: rid).FullName;
             var publishDirectory = publishCommand.GetOutputDirectory(targetFramework: targetFramework, runtimeIdentifier: rid).FullName;
@@ -652,7 +652,7 @@ namespace Microsoft.NET.Publish.Tests
             var publishCommand = new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
             publishCommand.Execute("/p:PublishTrimmed=true")
                 .Should().Fail()
-                .And.HaveStdOutContainingIgnoreCase("NETSDK1102");
+                .And.HaveStdOutContaining(Strings.ILLinkNotSupportedError);
         }
 
         [Theory]
@@ -661,12 +661,13 @@ namespace Microsoft.NET.Publish.Tests
         {
             var projectName = "HelloWorld";
             var referenceProjectName = "ClassLibForILLink";
+            var rid = EnvironmentInfo.GetCompatibleRid(targetFramework);
 
             var testProject = CreateTestProjectForILLinkTesting(targetFramework, projectName, referenceProjectName);
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
             var publishCommand = new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
-            publishCommand.Execute("/p:PublishTrimmed=true", $"/p:SelfContained=true", "/p:PublishTrimmed=true")
+            publishCommand.Execute("/p:PublishTrimmed=true", $"/p:RuntimeIdentifier={rid}", "/p:SelfContained=true", "/p:PublishTrimmed=true")
                 .Should().Pass().And.HaveStdOutContainingIgnoreCase("https://aka.ms/dotnet-illink");
         }
 


### PR DESCRIPTION
New versions of the linker will emit warnings for code that can be broken by trimming. https://github.com/mono/linker/pull/1324 added support for `--nowarn`, which we will use to disable them (the "opinionated default") in .NET5 to prevent noise. This change turns them off and adds a new property to let developers opt into the warnings.

The new property is called `SuppressTrimAnalysisWarnings`.

See some old discussion in https://github.com/dotnet/sdk/pull/12388.