### PR TITLE
Remove the default code owner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,7 +5,6 @@
 # the repo. Unless a later match takes precedence,
 # @dotnet/dotnet-cli  will be requested for
 # review when someone opens a pull request.
-*       @dotnet/dotnet-cli
 
 /src/WebSdk/ @vijayrkn
 /src/Tests/Microsoft.NET.Sdk.Publish.Tasks.Tests/ @vijayrkn


### PR DESCRIPTION
Since SDK team will look in to the PRs anyway. However we don't want the automated bot to keep pinging this github tag.