### PR TITLE
Implement template locator on the top of xml manifest reader

### DIFF
--- a/src/Microsoft.DotNet.TemplateLocator/Microsoft.DotNet.TemplateLocator.csproj
+++ b/src/Microsoft.DotNet.TemplateLocator/Microsoft.DotNet.TemplateLocator.csproj
@@ -11,7 +11,7 @@
     <!-- Create FileDefinitions items for ResolveHostfxrCopyLocalContent target -->
     <EmitLegacyAssetsFileItems>true</EmitLegacyAssetsFileItems>
 
-    <PackageId>Microsoft.Internal.DotNet.MockTemplateLocator</PackageId>
+    <PackageId>microsoft.dotnet.templateLocator</PackageId>
   </PropertyGroup>
 
   <Target Name="LinkVSEmbeddableAssemblies" DependsOnTargets="ResolveReferences" AfterTargets="ResolveReferences">
@@ -23,7 +23,7 @@
   </Target>
 
   <ItemGroup>
-    <PackageReference Include="NuGet.Protocol" Version="$(NuGetProjectModelVersion)" />
-    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />
+    <ProjectReference Include="..\Resolvers\Microsoft.DotNet.SdkResolver\Microsoft.DotNet.SdkResolver.csproj" />
+    <ProjectReference Include="..\Resolvers\Microsoft.DotNet.WorkloadManifestReader\Microsoft.DotNet.WorkloadManifestReader.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.DotNet.TemplateLocator/TemplateLocator.cs
+++ b/src/Microsoft.DotNet.TemplateLocator/TemplateLocator.cs
@@ -5,68 +5,122 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using NuGet.Common;
-using NuGet.Protocol;
+using Microsoft.DotNet.DotNetSdkResolver;
+using Microsoft.NET.Sdk.WorkloadManifestReader;
 
 namespace Microsoft.DotNet.TemplateLocator
 {
     public sealed class TemplateLocator
     {
-        private DirectoryInfo _dotnetSdkTemplatesLocation;
+        private readonly Lazy<NETCoreSdkResolver> _netCoreSdkResolver;
 
         public TemplateLocator()
+            : this(Environment.GetEnvironmentVariable, VSSettings.Ambient)
         {
-            string mockTemplateLocation = Environment.GetEnvironmentVariable("MOCKDOTNETSDKTEMPLATESLOCATION");
-            if (!string.IsNullOrWhiteSpace(mockTemplateLocation))
-            {
-                _dotnetSdkTemplatesLocation = new DirectoryInfo(mockTemplateLocation);
-            }
         }
 
-        public IReadOnlyCollection<IOptionalSdkTemplatePackageInfo> GetDotnetSdkTemplatePackages(string sdkVersion)
+        /// <summary>
+        /// Test constructor
+        /// </summary>
+        public TemplateLocator(Func<string, string> getEnvironmentVariable, VSSettings vsSettings)
         {
-            if (_dotnetSdkTemplatesLocation == null)
+            _netCoreSdkResolver =
+                new Lazy<NETCoreSdkResolver>(() => new NETCoreSdkResolver(getEnvironmentVariable, vsSettings));
+        }
+
+        public IReadOnlyCollection<IOptionalSdkTemplatePackageInfo> GetDotnetSdkTemplatePackages(
+            string sdkVersion,
+            string dotnetRootPath)
+        {
+            if (string.IsNullOrWhiteSpace(sdkVersion))
+            {
+                throw new ArgumentException($"'{nameof(sdkVersion)}' cannot be null or whitespace", nameof(sdkVersion));
+            }
+
+            if (string.IsNullOrWhiteSpace(dotnetRootPath))
+            {
+                throw new ArgumentException($"'{nameof(dotnetRootPath)}' cannot be null or whitespace", nameof(dotnetRootPath));
+            }
+
+            if (!Version.TryParse(sdkVersion.Split('-')[0], out var sdkVersionParsed))
+            {
+                throw new ArgumentException($"'{nameof(sdkVersion)}' should be a version, but get {sdkVersion}");
+            }
+
+            bool FindSameVersionBand(DirectoryInfo manifestDirectory)
+            {
+                var directoryVersion = Version.Parse(manifestDirectory.Name);
+                return directoryVersion.Major == sdkVersionParsed.Major &&
+                       directoryVersion.Minor == sdkVersionParsed.Minor &&
+                       (directoryVersion.Revision / 100) == (sdkVersionParsed.Revision / 100);
+            }
+
+            var bondManifestDirectory = new DirectoryInfo(Path.Combine(dotnetRootPath, "workloadmanifests")).GetDirectories().Where(FindSameVersionBand)
+                .OrderByDescending(d => Version.Parse(d.Name)).FirstOrDefault();
+
+            if (bondManifestDirectory == null)
             {
                 return Array.Empty<IOptionalSdkTemplatePackageInfo>();
             }
 
-            IEnumerable<LocalPackageInfo> packages = LocalFolderUtility
-                            .GetPackagesV2(_dotnetSdkTemplatesLocation.FullName, new NullLogger());
-
-            if (packages == null)
+            var manifestContent =
+                WorkloadManifest.LoadFromFolder(bondManifestDirectory.FullName);
+            var dotnetSdkTemplatePackages = new List<IOptionalSdkTemplatePackageInfo>();
+            foreach (var pack in manifestContent.SdkPackDetail)
             {
-                return Array.Empty<IOptionalSdkTemplatePackageInfo>();
+                if (pack.Value.kind.Equals("Template", StringComparison.OrdinalIgnoreCase))
+                {
+                    var optionalSdkTemplatePackageInfo = new OptionalSdkTemplatePackageInfo(
+                        pack.Key,
+                        pack.Value.version,
+                        Path.Combine(dotnetRootPath, "template-packs",
+                            pack.Key.ToLower() + "." + pack.Value.version.ToLower() + ".nupkg"));
+                    dotnetSdkTemplatePackages.Add(optionalSdkTemplatePackageInfo);
+                }
+            }
+
+            return dotnetSdkTemplatePackages;
+        }
+
+        public bool TryGetDotnetSdkVersionUsedInVs(string vsVersion, out string sdkVersion)
+        {
+            string dotnetExeDir = _netCoreSdkResolver.Value.GetDotnetExeDirectory();
+
+            if (!Version.TryParse(vsVersion, out var parsedVsVersion))
+            {
+                throw new ArgumentException(vsVersion + " is not a valid version");
+            }
+
+            // VS major minor version will match msbuild major minor
+            // and for resolve SDK, major minor version is enough
+            var msbuildMajorMinorVersion = new Version(parsedVsVersion.Major, parsedVsVersion.Minor, 0);
+
+            var resolverResult =
+                _netCoreSdkResolver.Value.ResolveNETCoreSdkDirectory(null, msbuildMajorMinorVersion, true, dotnetExeDir);
+
+            if (resolverResult.ResolvedSdkDirectory == null)
+            {
+                sdkVersion = null;
+                return false;
             }
             else
             {
-                return packages
-                    .Select(l => new OptionalSdkTemplatePackageInfo(l)).ToArray();
+                sdkVersion = new DirectoryInfo(resolverResult.ResolvedSdkDirectory).Name;
+                return true;
             }
-        }
-
-        public string DotnetSdkVersionUsedInVs()
-        {
-            return "5.1.100";
-        }
-
-        internal void SetDotnetSdkTemplatesLocation(DirectoryInfo directoryInfo)
-        {
-            _dotnetSdkTemplatesLocation = directoryInfo;
         }
 
         private class OptionalSdkTemplatePackageInfo : IOptionalSdkTemplatePackageInfo
         {
-            public OptionalSdkTemplatePackageInfo(LocalPackageInfo localPackageInfo)
+            public OptionalSdkTemplatePackageInfo(string templatePackageId, string templateVersion, string path)
             {
-                TemplatePackageId = localPackageInfo.Identity.Id;
-                TemplateVersion = localPackageInfo.Identity.Version.ToNormalizedString();
-                Path = localPackageInfo.Path;
+                TemplatePackageId = templatePackageId ?? throw new ArgumentNullException(nameof(templatePackageId));
+                TemplateVersion = templateVersion ?? throw new ArgumentNullException(nameof(templateVersion));
+                Path = path ?? throw new ArgumentNullException(nameof(path));
             }
 
             public string TemplatePackageId { get; }
-
             public string TemplateVersion { get; }
-
             public string Path { get; }
         }
     }

--- a/src/Tests/Microsoft.DotNet.MSBuildSdkResolver.Tests/GivenAnMSBuildSdkResolver.cs
+++ b/src/Tests/Microsoft.DotNet.MSBuildSdkResolver.Tests/GivenAnMSBuildSdkResolver.cs
@@ -424,7 +424,7 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
             Check(disallowPreviews: true, message: "file changed to disallow previews");
 
             environment.CreateVSSettingsFile(disallowPreviews: false);
-            Check(disallowPreviews: false,  message: "file changed to not disallow previews");
+            Check(disallowPreviews: false, message: "file changed to not disallow previews");
 
             environment.CreateVSSettingsFile(disallowPreviews: true);
             Check(disallowPreviews: true, message: "file changed back to disallow previews");
@@ -439,7 +439,7 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
             var environment = new TestEnvironment(_testAssetsManager);
             var rtm = environment.CreateSdkDirectory(ProgramFiles.X64, "Some.Test.Sdk", "10.0.0");
             var preview = environment.CreateSdkDirectory(ProgramFiles.X64, "Some.Test.Sdk", "11.0.0-preview1");
- 
+
             environment.CreateMuxerAndAddToPath(ProgramFiles.X64);
             environment.DisallowPrereleaseByDefault = true;
             environment.CreateGlobalJson(environment.TestDirectory, "11.0.0-preview1");
@@ -487,6 +487,21 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
             result.Errors.Should().BeNullOrEmpty();
         }
 
+        [Fact]
+        public void GivenTemplateLocatorItCanResolveSdkVersion()
+        {
+            var environment = new TestEnvironment(_testAssetsManager);
+            const string sdkVersion = "99.99.97";
+            environment.CreateSdkDirectory(ProgramFiles.X64, "Some.Test.Sdk", sdkVersion);
+            environment.CreateMuxerAndAddToPath(ProgramFiles.X64);
+
+            var resolver = new TemplateLocator.TemplateLocator(environment.GetEnvironmentVariable,
+                new VSSettings(environment.VSSettingsFile?.FullName, environment.DisallowPrereleaseByDefault));
+            resolver.TryGetDotnetSdkVersionUsedInVs("15.8", out var version).Should().BeTrue();
+
+            version.Should().Be(sdkVersion);
+        }
+
         private enum ProgramFiles
         {
             X64,
@@ -519,14 +534,14 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
 
             public SdkResolver CreateResolver(bool useAmbientSettings = false)
                 => new DotNetMSBuildSdkResolver(
-                    GetEnvironmentVariable, 
+                    GetEnvironmentVariable,
                     useAmbientSettings
                         ? VSSettings.Ambient
                         : new VSSettings(VSSettingsFile?.FullName, DisallowPrereleaseByDefault));
 
             public DirectoryInfo GetSdkDirectory(ProgramFiles programFiles, string sdkName, string sdkVersion)
                 => new DirectoryInfo(Path.Combine(
-                    TestDirectory.FullName, 
+                    TestDirectory.FullName,
                     GetProgramFilesDirectory(programFiles).FullName,
                     "dotnet",
                     "sdk",
@@ -537,7 +552,7 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
 
             public DirectoryInfo GetProgramFilesDirectory(ProgramFiles programFiles)
                 => new DirectoryInfo(Path.Combine(TestDirectory.FullName, $"ProgramFiles{programFiles}"));
-            
+
             public DirectoryInfo CreateSdkDirectory(
                 ProgramFiles programFiles,
                 string sdkName,
@@ -589,7 +604,7 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
             }
 
             public void CreateGlobalJson(DirectoryInfo directory, string version)
-                => File.WriteAllText(Path.Combine(directory.FullName, "global.json"), 
+                => File.WriteAllText(Path.Combine(directory.FullName, "global.json"),
                     $@"{{ ""sdk"": {{ ""version"":  ""{version}"" }} }}");
 
             public string GetEnvironmentVariable(string variable)
@@ -609,7 +624,7 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
             }
 
             private void DeleteMinimumVSDefinedSDKVersionFile()
-            {                
+            {
                 File.Delete(GetMinimumVSDefinedSDKVersionFilePath());
             }
 
@@ -697,7 +712,7 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
                 ItemsToAdd = itemsToAdd;
             }
 
-            public MockResult(bool success, IEnumerable<string> paths, string version, 
+            public MockResult(bool success, IEnumerable<string> paths, string version,
                 IDictionary<string, string> propertiesToAdd, IDictionary<string, SdkResultItem> itemsToAdd, IEnumerable<string> warnings)
             {
                 Success = success;

--- a/src/Tests/Microsoft.DotNet.MSBuildSdkResolver.Tests/Microsoft.DotNet.MSBuildSdkResolver.Tests.csproj
+++ b/src/Tests/Microsoft.DotNet.MSBuildSdkResolver.Tests/Microsoft.DotNet.MSBuildSdkResolver.Tests.csproj
@@ -11,6 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\Microsoft.DotNet.TemplateLocator\Microsoft.DotNet.TemplateLocator.csproj" />
     <ProjectReference Include="..\..\Resolvers\Microsoft.DotNet.MSBuildSdkResolver\Microsoft.DotNet.MSBuildSdkResolver.csproj" />
     <ProjectReference Include="..\Microsoft.NET.TestFramework\Microsoft.NET.TestFramework.csproj" />
     <!--<ProjectReference Include="..\Microsoft.DotNet.Tools.Tests.Utilities\Microsoft.DotNet.Tools.Tests.Utilities.csproj" />-->

--- a/src/Tests/Microsoft.DotNet.TemplateLocator.Tests/GivenAnMSBuildSdkResolver.cs
+++ b/src/Tests/Microsoft.DotNet.TemplateLocator.Tests/GivenAnMSBuildSdkResolver.cs
@@ -7,29 +7,89 @@ using Xunit;
 using Xunit.Abstractions;
 using Microsoft.NET.TestFramework;
 using System.Linq;
-using NuGet.Common;
-using NuGet.Protocol;
 
 namespace Microsoft.DotNet.TemplateLocator.Tests
 {
     public class GivenAnTemplateLocator : SdkTest
     {
+        private readonly TemplateLocator _resolver;
+        private readonly string _manifestDirectory;
+        private readonly string _fakeDotnetRootDirectory;
 
         public GivenAnTemplateLocator(ITestOutputHelper logger) : base(logger)
         {
+            _resolver = new TemplateLocator();
+            _fakeDotnetRootDirectory =
+                Path.Combine(TestContext.Current.TestExecutionDirectory, Path.GetRandomFileName());
+            _manifestDirectory = Path.Combine(_fakeDotnetRootDirectory, "workloadmanifests", "5.0.100");
+            Directory.CreateDirectory(_manifestDirectory);
         }
 
         [Fact]
         public void ItShouldReturnListOfTemplates()
         {
-            var resolver = new TemplateLocator();
-            var stage2Dotnet = new DirectoryInfo(TestContext.Current.ToolsetUnderTest.DotNetHostPath);
-            var stage2Templates = stage2Dotnet.Parent.GetDirectories("templates")[0].EnumerateDirectories().First();
-            resolver.SetDotnetSdkTemplatesLocation(stage2Templates);
+            File.WriteAllText(Path.Combine(_manifestDirectory, "WorkloadManifest.xml"), fakeManifest);
+            var result = _resolver.GetDotnetSdkTemplatePackages("5.0.102", _fakeDotnetRootDirectory);
 
-            var result = resolver.GetDotnetSdkTemplatePackages("any");
+            result.First().Path.Should().Be(Path.Combine(_fakeDotnetRootDirectory, "template-packs",
+                "xamarin.android.templates.2.0.1.nupkg"));
+            result.First().TemplatePackageId.Should().Be("xamarin.android.templates");
+            result.First().TemplateVersion.Should().Be("2.0.1");
 
-            result.Should().NotBeEmpty();
+            result.Skip(1).First().Path.Should().Be(Path.Combine(_fakeDotnetRootDirectory, "template-packs",
+                "xamarin.ios.templates.4.0.1.nupkg"));
+            result.Skip(1).First().TemplatePackageId.Should().Be("xamarin.ios.templates");
+            result.Skip(1).First().TemplateVersion.Should().Be("4.0.1");
         }
+
+        [Fact]
+        public void WhenPassEmptyManifestItShouldReturnListOfTemplates()
+        {
+            File.WriteAllText(Path.Combine(_manifestDirectory, "WorkloadManifest.xml"), emptyManifest);
+            var result = _resolver.GetDotnetSdkTemplatePackages("5.0.102", _fakeDotnetRootDirectory);
+            result.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void GivenNoSdkToBondItShouldReturnListOfTemplates()
+        {
+            File.WriteAllText(Path.Combine(_manifestDirectory, "WorkloadManifest.xml"), fakeManifest);
+            var result = _resolver.GetDotnetSdkTemplatePackages("5.1.102", _fakeDotnetRootDirectory);
+            result.Should().BeEmpty();
+        }
+
+        private static string fakeManifest = @"
+<WorkloadManifest>
+  <Workloads>
+    <Workload Name=""Xamarin.Android.Workload"">
+      <RequiredPack Name=""xamarin.android.workload""/>
+      <RequiredPack Name=""xamarin.android.templates""/>
+    </Workload>
+    <Workload Name=""Xamarin.iOS.Workload"">
+      <RequiredPack Name=""xamarin.ios.workload""/>
+      <RequiredPack Name=""xamarin.ios.templates""/>
+    </Workload>
+  </Workloads>
+  <WorkloadPacks>
+    <Pack Name=""xamarin.android.workload""
+          Version=""1.0.1""
+          Kind=""sdk"" />
+    <Pack Name=""xamarin.android.templates""
+          Version=""2.0.1""
+          Kind=""Template"" />
+    <Pack Name=""xamarin.ios.workload""
+          Version=""3.0.1""
+          Kind=""sdk"" />
+    <Pack Name=""xamarin.ios.templates""
+          Version=""4.0.1""
+          Kind=""template"" />
+  </WorkloadPacks>
+</WorkloadManifest>
+";
+
+        private static string emptyManifest = @"
+<WorkloadManifest>
+</WorkloadManifest>
+";
     }
 }


### PR DESCRIPTION
Folder structure as in spec https://github.com/dotnet/designs/blob/master/accepted/2020/workloads/workload-resolvers.md#sdk-behavior

```
C:\USERS\WUL\DOWNLOADS\DOTNET
│   dotnet-install.ps1
│   dotnet.exe
│   LICENSE.txt
│   ThirdPartyNotices.txt
│
├───host
├───packs
├───sdk
├───shared
├───template-packs
│       xamarin.ios.templates.4.0.1.nupkg
│
├───templates
└───workloadmanifests
    └───5.0.100
            WorkloadManifest.xml
```