### PR TITLE
Strict coherency + runtime version fix

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -5,11 +5,27 @@
       <Uri>https://github.com/dotnet/templating</Uri>
       <Sha>6a10ce799f42102bee8f8bec9a52c42cca6ed272</Sha>
     </Dependency>
+    <Dependency Name="Microsoft.DotNet.Common.ItemTemplates" Version="5.0.0-rc.1.20419.1">
+      <Uri>https://github.com/dotnet/templating</Uri>
+      <Sha>6a10ce799f42102bee8f8bec9a52c42cca6ed272</Sha>
+    </Dependency>
     <Dependency Name="Microsoft.NETCore.App.Ref" Version="5.0.0-rc.1.20417.14">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>907f7da59b40c80941b02ac2a46650adf3f606bc</Sha>
     </Dependency>
+    <Dependency Name="Microsoft.NETCore.App.Internal" Version="5.0.0-rc.1.20417.14">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>907f7da59b40c80941b02ac2a46650adf3f606bc</Sha>
+    </Dependency>
     <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="5.0.0-rc.1.20417.14">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>907f7da59b40c80941b02ac2a46650adf3f606bc</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.NETCore.App.Host.win-x64" Version="5.0.0-rc.1.20417.14">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>907f7da59b40c80941b02ac2a46650adf3f606bc</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.NETCore.Platforms" Version="5.0.0-rc.1.20417.14">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>907f7da59b40c80941b02ac2a46650adf3f606bc</Sha>
     </Dependency>
@@ -89,13 +105,41 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>907f7da59b40c80941b02ac2a46650adf3f606bc</Sha>
     </Dependency>
+    <Dependency Name="Microsoft.WindowsDesktop.App.Runtime.win-x64" Version="5.0.0-rc.1.20417.4">
+      <Uri>https://github.com/dotnet/windowsdesktop</Uri>
+      <Sha>85186023c8de8237268033cadc41d738b7f2005e</Sha>
+    </Dependency>
     <Dependency Name="Microsoft.WindowsDesktop.App" Version="5.0.0-rc.1.20417.4">
+      <Uri>https://github.com/dotnet/windowsdesktop</Uri>
+      <Sha>85186023c8de8237268033cadc41d738b7f2005e</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.WindowsDesktop.App.Ref" Version="5.0.0-rc.1.20417.4">
       <Uri>https://github.com/dotnet/windowsdesktop</Uri>
       <Sha>85186023c8de8237268033cadc41d738b7f2005e</Sha>
     </Dependency>
     <Dependency Name="Microsoft.NET.Sdk.WindowsDesktop" Version="5.0.0-rc.1.20417.3" CoherentParentDependency="Microsoft.WindowsDesktop.App">
       <Uri>https://github.com/dotnet/wpf</Uri>
       <Sha>b91ba697c48bc7825580e3c7fa09c5c3781c3788</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="5.0.0-rc.1.20419.22">
+      <Uri>https://github.com/dotnet/aspnetcore</Uri>
+      <Sha>f490dd24c924e32acb46d0dee6b838237172d5e8</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.AspNetCore.App.Runtime.win-x64" Version="5.0.0-rc.1.20419.22">
+      <Uri>https://github.com/dotnet/aspnetcore</Uri>
+      <Sha>f490dd24c924e32acb46d0dee6b838237172d5e8</Sha>
+    </Dependency>
+    <Dependency Name="dotnet-dev-certs" Version="5.0.0-rc.1.20419.22">
+      <Uri>https://github.com/dotnet/aspnetcore</Uri>
+      <Sha>f490dd24c924e32acb46d0dee6b838237172d5e8</Sha>
+    </Dependency>
+    <Dependency Name="dotnet-user-secrets" Version="5.0.0-rc.1.20419.22">
+      <Uri>https://github.com/dotnet/aspnetcore</Uri>
+      <Sha>f490dd24c924e32acb46d0dee6b838237172d5e8</Sha>
+    </Dependency>
+    <Dependency Name="dotnet-watch" Version="5.0.0-rc.1.20419.22">
+      <Uri>https://github.com/dotnet/aspnetcore</Uri>
+      <Sha>f490dd24c924e32acb46d0dee6b838237172d5e8</Sha>
     </Dependency>
     <Dependency Name="Microsoft.AspNetCore.Analyzers" Version="5.0.0-rc.1.20419.22">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -36,8 +36,9 @@
     <SystemTextJsonVersion>4.7.2</SystemTextJsonVersion>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Dependencies from https://github.com/dotnet/core-setup -->
+    <!-- Dependencies from https://github.com/dotnet/runtime -->
     <MicrosoftNETCoreAppRefPackageVersion>5.0.0-rc.1.20417.14</MicrosoftNETCoreAppRefPackageVersion>
+    <MicrosoftNETCoreAppInternalPackageVersion>5.0.0-rc.1.20417.14</MicrosoftNETCoreAppInternalPackageVersion>
     <MicrosoftNETCoreAppRuntimewinx64PackageVersion>5.0.0-rc.1.20417.14</MicrosoftNETCoreAppRuntimewinx64PackageVersion>
     <MicrosoftNETCoreAppRuntimePackageVersion>$(MicrosoftNETCoreAppRuntimewinx64PackageVersion)</MicrosoftNETCoreAppRuntimePackageVersion>
     <MicrosoftExtensionsDependencyModelPackageVersion>5.0.0-rc.1.20417.14</MicrosoftExtensionsDependencyModelPackageVersion>

--- a/global.json
+++ b/global.json
@@ -3,7 +3,7 @@
     "dotnet": "5.0.100-rc.1.20376.1",
     "runtimes": {
       "dotnet": [
-        "$(MicrosoftNETCoreAppRuntimePackageVersion)"
+        "$(MicrosoftNETCoreAppInternalPackageVersion)"
       ]
     },
     "vs-opt": {


### PR DESCRIPTION
- Add dependencies for strict coherency compatibility in dotnet/installer
- Change the runtime version in global.json to point to the non-stabilized version, so that it will always vary build-to-build.