### PR TITLE
Update TargetFramework processing

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenADependencyContextBuilder.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenADependencyContextBuilder.cs
@@ -56,7 +56,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                     i => true);
 
             ProjectContext projectContext = lockFile.CreateProjectContext(
-                FrameworkConstants.CommonFrameworks.NetCoreApp10,
+                FrameworkConstants.CommonFrameworks.NetCoreApp10.GetShortFolderName(),
                 runtime,
                 Constants.DefaultPlatformLibrary,
                 runtimeFrameworks: null,
@@ -254,7 +254,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             };
 
             ProjectContext projectContext = lockFile.CreateProjectContext(
-                FrameworkConstants.CommonFrameworks.NetCoreApp10,
+                FrameworkConstants.CommonFrameworks.NetCoreApp10.GetShortFolderName(),
                 runtime: null,
                 platformLibraryName: Constants.DefaultPlatformLibrary,
                 runtimeFrameworks: null,
@@ -306,7 +306,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 new ITaskItem[] { });
 
             ProjectContext projectContext = lockFile.CreateProjectContext(
-                FrameworkConstants.CommonFrameworks.NetCoreApp10,
+                FrameworkConstants.CommonFrameworks.NetCoreApp10.GetShortFolderName(),
                 runtime: null,
                 platformLibraryName: Constants.DefaultPlatformLibrary,
                 runtimeFrameworks: null,

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAProjectContext.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAProjectContext.cs
@@ -19,7 +19,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
         {
             LockFile lockFile = TestLockFiles.GetLockFile("dependencies.withgraphs");
             ProjectContext projectContext = lockFile.CreateProjectContext(
-               FrameworkConstants.CommonFrameworks.NetStandard16,
+               FrameworkConstants.CommonFrameworks.NetStandard16.GetShortFolderName(),
                runtime: null,
                Constants.DefaultPlatformLibrary,
                runtimeFrameworks: null,

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAnAssetsFileResolver.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAnAssetsFileResolver.cs
@@ -24,7 +24,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
         {
             LockFile lockFile = TestLockFiles.GetLockFile(projectName);
             ProjectContext projectContext = lockFile.CreateProjectContext(
-                FrameworkConstants.CommonFrameworks.NetCoreApp10,
+                FrameworkConstants.CommonFrameworks.NetCoreApp10.GetShortFolderName(),
                 runtime,
                 Constants.DefaultPlatformLibrary,
                 runtimeFrameworks: null,
@@ -44,7 +44,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
         {
             LockFile lockFile = TestLockFiles.GetLockFile(projectName);
             ProjectContext projectContext = lockFile.CreateProjectContext(
-                FrameworkConstants.CommonFrameworks.NetCoreApp10,
+                FrameworkConstants.CommonFrameworks.NetCoreApp10.GetShortFolderName(),
                 runtime,
                 Constants.DefaultPlatformLibrary,
                 runtimeFrameworks: null,

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenThatWeWantToGetDependenciesViaDesignTimeBuild.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenThatWeWantToGetDependenciesViaDesignTimeBuild.cs
@@ -14,7 +14,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
         {
             var task = new PreprocessPackageDependenciesDesignTime
             {
-                TargetFrameworkMoniker = ".Net Framework,Version=v4.5",
+                TargetFramework = "net45",
                 DefaultImplicitPackages = string.Empty,
                 PackageDefinitions = new ITaskItem[]
                 {
@@ -44,13 +44,13 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                         itemSpec: "mockPackageNoType/1.0.0",
                         metadata: new Dictionary<string, string>
                         {
-                            { MetadataKeys.ParentTarget, ".Net Framework,Version=v4.5" }
+                            { MetadataKeys.ParentTarget, "net45" }
                         }),
                     new MockTaskItem(
                         itemSpec: "mockPackageUnknown/1.0.0",
                         metadata: new Dictionary<string, string>
                         {
-                            { MetadataKeys.ParentTarget, ".Net Framework,Version=v4.5" }
+                            { MetadataKeys.ParentTarget, "net45" }
                         })
                 }
             };
@@ -65,7 +65,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
         {
             var task = new PreprocessPackageDependenciesDesignTime
             {
-                TargetFrameworkMoniker = ".Net Framework,Version=v4.5",
+                TargetFramework = "net45",
                 DefaultImplicitPackages = string.Empty,
                 PackageDefinitions = new ITaskItem[]
                 {
@@ -87,7 +87,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                         itemSpec: "mockPackageUnresolved/1.0.0",
                         metadata: new Dictionary<string, string>
                         {
-                            { MetadataKeys.ParentTarget, ".Net Framework,Version=v4.5" }
+                            { MetadataKeys.ParentTarget, "net45" }
                         })
                 }
             };
@@ -111,7 +111,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
         {
             var task = new PreprocessPackageDependenciesDesignTime
             {
-                TargetFrameworkMoniker = ".Net Framework,Version=v4.5",
+                TargetFramework = "net45",
                 DefaultImplicitPackages = "DefaultImplicit",
                 PackageDefinitions = new ITaskItem[]
                 {
@@ -132,7 +132,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                         itemSpec: "DefaultImplicit/1.0.0",
                         metadata: new Dictionary<string, string>
                         {
-                            { MetadataKeys.ParentTarget, ".Net Framework,Version=v4.5" }
+                            { MetadataKeys.ParentTarget, "net45" }
                         })
                 }
             };
@@ -150,7 +150,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
         {
             var task = new PreprocessPackageDependenciesDesignTime
             {
-                TargetFrameworkMoniker = ".Net Framework,Version=v4.5",
+                TargetFramework = "net45",
                 DefaultImplicitPackages = string.Empty,
                 PackageDefinitions = new ITaskItem[] {
                     new MockTaskItem(
@@ -239,49 +239,49 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                         itemSpec: "mockPackageExternalProject/1.0.0",
                         metadata: new Dictionary<string, string>
                         {
-                            { MetadataKeys.ParentTarget, ".Net Framework,Version=v4.5" }
+                            { MetadataKeys.ParentTarget, "net45" }
                         }),
                     new MockTaskItem(
                         itemSpec: "mockPackageProject/1.0.0",
                         metadata: new Dictionary<string, string>
                         {
-                            { MetadataKeys.ParentTarget, ".Net Framework,Version=v4.5" }
+                            { MetadataKeys.ParentTarget, "net45" }
                         }),
                     new MockTaskItem(
                         itemSpec: "mockPackageContent/1.0.0",
                         metadata: new Dictionary<string, string>
                         {
-                            { MetadataKeys.ParentTarget, ".Net Framework,Version=v4.5" }
+                            { MetadataKeys.ParentTarget, "net45" }
                         }),
                     new MockTaskItem(
                         itemSpec: "mockPackageAssembly/1.0.0",
                         metadata: new Dictionary<string, string>
                         {
-                            { MetadataKeys.ParentTarget, ".Net Framework,Version=v4.5" }
+                            { MetadataKeys.ParentTarget, "net45" }
                         }),
                     new MockTaskItem(
                         itemSpec: "mockPackageFrameworkAssembly/1.0.0",
                         metadata: new Dictionary<string, string>
                         {
-                            { MetadataKeys.ParentTarget, ".Net Framework,Version=v4.5" }
+                            { MetadataKeys.ParentTarget, "net45" }
                         }),
                     new MockTaskItem(
                         itemSpec: "mockPackageDiagnostic/1.0.0",
                         metadata: new Dictionary<string, string>
                         {
-                            { MetadataKeys.ParentTarget, ".Net Framework,Version=v4.5" }
+                            { MetadataKeys.ParentTarget, "net45" }
                         }),
                     new MockTaskItem(
                         itemSpec: "mockPackageWinmd/1.0.0",
                         metadata: new Dictionary<string, string>
                         {
-                            { MetadataKeys.ParentTarget, ".Net Framework,Version=v4.5" }
+                            { MetadataKeys.ParentTarget, "net45" }
                         }),
                     new MockTaskItem(
                         itemSpec: "mockPackageReference/1.0.0",
                         metadata: new Dictionary<string, string>
                         {
-                            { MetadataKeys.ParentTarget, ".Net Framework,Version=v4.5" }
+                            { MetadataKeys.ParentTarget, "net45" }
                         })
                 }
             };
@@ -296,7 +296,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
         {
             var task = new PreprocessPackageDependenciesDesignTime
             {
-                TargetFrameworkMoniker = ".Net Framework,Version=v4.5",
+                TargetFramework = "net45",
                 DefaultImplicitPackages = string.Empty,
                 PackageDefinitions = new ITaskItem[] {
                     new MockTaskItem(
@@ -325,13 +325,13 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                         itemSpec: "Package1/1.0.0",
                         metadata: new Dictionary<string, string>
                         {
-                            { MetadataKeys.ParentTarget, ".Net Framework,Version=v4.5" }
+                            { MetadataKeys.ParentTarget, "net45" }
                         }),
                     new MockTaskItem(
                         itemSpec: "Package2/1.0.0",
                         metadata: new Dictionary<string, string>
                         {
-                            { MetadataKeys.ParentTarget, ".Net Framework,Version=v4.6" }
+                            { MetadataKeys.ParentTarget, "net46" }
                         })
                 }
             };
@@ -348,7 +348,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
         {
             var task = new PreprocessPackageDependenciesDesignTime
             {
-                TargetFrameworkMoniker = ".Net Framework,Version=v4.5",
+                TargetFramework = "net45",
                 DefaultImplicitPackages = string.Empty,
                 PackageDefinitions = new ITaskItem[] {
                     new MockTaskItem(
@@ -377,13 +377,13 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                         itemSpec: "Package1/1.0.0",
                         metadata: new Dictionary<string, string>
                         {
-                            { MetadataKeys.ParentTarget, ".Net Framework,Version=v4.5" }
+                            { MetadataKeys.ParentTarget, "net45" }
                         }),
                     new MockTaskItem(
                         itemSpec: "ChildPackage1/1.0.0",
                         metadata: new Dictionary<string, string>
                         {
-                            { MetadataKeys.ParentTarget, ".Net Framework,Version=v4.5" },
+                            { MetadataKeys.ParentTarget, "net45" },
                             { MetadataKeys.ParentPackage, "Package1/1.0.0" }
                         })
                 }

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/LockFileSnippets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/LockFileSnippets.cs
@@ -23,10 +23,56 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
               ""targets"": {{{string.Join(",", targets)}}},
               ""libraries"": {{{string.Join(",", libraries)}}},
               {GetLogsPart(logs)}
-              ""projectFileDependencyGroups"": {{{string.Join(",", projectFileDependencyGroups)}}}
-
+              ""projectFileDependencyGroups"": {{{string.Join(",", projectFileDependencyGroups)}}},
+              {LockFileProjectSection}
             }}";
         }
+
+        private static string LockFileProjectSection = @"  'project': {
+    'version': '1.0.0',
+    'restore': {
+      'projectUniqueName': 'C:\\git\\repro\\consoletest\\consoletest.csproj',
+      'projectName': 'consoletest',
+      'projectPath': 'C:\\git\\repro\\consoletest\\consoletest.csproj',
+      'packagesPath': 'C:\\Users\\username\\.nuget\\packages\\',
+      'outputPath': 'C:\\git\\repro\\consoletest\\obj\\',
+      'projectStyle': 'PackageReference',
+      'fallbackFolders': [],
+      'configFilePaths': [
+        'C:\\Users\\username\\AppData\\Roaming\\NuGet\\NuGet.Config'
+      ],
+      'originalTargetFrameworks': [
+        'netcoreapp1.0'
+      ],
+      'sources': {
+        'https://api.nuget.org/v3/index.json': {}
+      },
+      'frameworks': {
+        'netcoreapp1.0': {
+          'targetAlias': 'netcoreapp1.0',
+          'projectReferences': {}
+        }
+      },
+      'warningProperties': {
+        'warnAsError': [
+          'NU1605'
+        ]
+      }
+    },
+    'frameworks': {
+      'netcoreapp1.0': {
+        'targetAlias': 'netcoreapp1.0',
+        'dependencies': {
+          'Microsoft.NETCore.App': {
+            'target': 'Package',
+            'version': '[1.0.5, )',
+            'autoReferenced': true
+          }
+        },
+        'runtimeIdentifierGraphPath': 'C:\\git\\dotnet-sdk\\artifacts\\bin\\redist\\Debug\\dotnet\\sdk\\5.0.100-dev\\RuntimeIdentifierGraph.json'
+      }
+    }
+  }".Replace('\'', '"');
 
         private static string GetLogsPart(string[] logs)
             => logs == null ? string.Empty : $@" ""logs"": [{string.Join(",", logs)}], ";

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/LockFiles/all.asset.types.project.lock.json
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/LockFiles/all.asset.types.project.lock.json
@@ -1,5 +1,5 @@
 {
-  "version": 2,
+  "version": 3,
   "targets": {
     ".NETCoreApp,Version=v1.0": {
       "Libuv/1.9.0": {
@@ -210,9 +210,52 @@
       "System.Spatial >= 5.7.0"
     ]
   },
-  "tools": {},
-  "projectFileToolGroups": {},
   "packageFolders": {
     "C:\\.nuget\\packages\\": {}
+  },
+  "project": {
+    "version": "1.0.0",
+    "restore": {
+      "projectUniqueName": "C:\\git\\repro\\consoletest\\consoletest.csproj",
+      "projectName": "consoletest",
+      "projectPath": "C:\\git\\repro\\consoletest\\consoletest.csproj",
+      "packagesPath": "C:\\Users\\username\\.nuget\\packages\\",
+      "outputPath": "C:\\git\\repro\\consoletest\\obj\\",
+      "projectStyle": "PackageReference",
+      "fallbackFolders": [],
+      "configFilePaths": [
+        "C:\\Users\\username\\AppData\\Roaming\\NuGet\\NuGet.Config"
+      ],
+      "originalTargetFrameworks": [
+        "netcoreapp1.0"
+      ],
+      "sources": {
+        "https://api.nuget.org/v3/index.json": {}
+      },
+      "frameworks": {
+        "netcoreapp1.0": {
+          "targetAlias": "netcoreapp1.0",
+          "projectReferences": {}
+        }
+      },
+      "warningProperties": {
+        "warnAsError": [
+          "NU1605"
+        ]
+      }
+    },
+    "frameworks": {
+      "netcoreapp1.0": {
+        "targetAlias": "netcoreapp1.0",
+        "dependencies": {
+          "Microsoft.NETCore.App": {
+            "target": "Package",
+            "version": "[1.0.5, )",
+            "autoReferenced": true
+          }
+        },
+        "runtimeIdentifierGraphPath": "C:\\git\\dotnet-sdk\\artifacts\\bin\\redist\\Debug\\dotnet\\sdk\\5.0.100-dev\\RuntimeIdentifierGraph.json"
+      }
+    }
   }
 }

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/LockFiles/dependencies.withgraphs.project.lock.json
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/LockFiles/dependencies.withgraphs.project.lock.json
@@ -1,5 +1,5 @@
 {
-  "version": 2,
+  "version": 3,
   "targets": {
     ".NETStandard,Version=v1.6": {
       "Microsoft.CSharp/4.0.1": {
@@ -2824,9 +2824,52 @@
       "Newtonsoft.Json >= 9.0.1"
     ]
   },
-  "tools": {},
-  "projectFileToolGroups": {},
   "packageFolders": {
-    "C:\\Users\\eerhardt\\.nuget\\packages\\": {}
+    "C:\\.nuget\\packages\\": {}
+  },
+  "project": {
+    "version": "1.0.0",
+    "restore": {
+      "projectUniqueName": "C:\\git\\repro\\consoletest\\consoletest.csproj",
+      "projectName": "consoletest",
+      "projectPath": "C:\\git\\repro\\consoletest\\consoletest.csproj",
+      "packagesPath": "C:\\Users\\username\\.nuget\\packages\\",
+      "outputPath": "C:\\git\\repro\\consoletest\\obj\\",
+      "projectStyle": "PackageReference",
+      "fallbackFolders": [],
+      "configFilePaths": [
+        "C:\\Users\\username\\AppData\\Roaming\\NuGet\\NuGet.Config"
+      ],
+      "originalTargetFrameworks": [
+        "netstandard1.6"
+      ],
+      "sources": {
+        "https://api.nuget.org/v3/index.json": {}
+      },
+      "frameworks": {
+        "netstandard1.6": {
+          "targetAlias": "netstandard1.6",
+          "projectReferences": {}
+        }
+      },
+      "warningProperties": {
+        "warnAsError": [
+          "NU1605"
+        ]
+      }
+    },
+    "frameworks": {
+      "netstandard1.6": {
+        "targetAlias": "netstandard1.6",
+        "dependencies": {
+          "Microsoft.NETCore.App": {
+            "target": "Package",
+            "version": "[1.0.5, )",
+            "autoReferenced": true
+          }
+        },
+        "runtimeIdentifierGraphPath": "C:\\git\\dotnet-sdk\\artifacts\\bin\\redist\\Debug\\dotnet\\sdk\\5.0.100-dev\\RuntimeIdentifierGraph.json"
+      }
+    }
   }
 }

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/LockFiles/dotnet.new.project.lock.json
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/LockFiles/dotnet.new.project.lock.json
@@ -1,5 +1,5 @@
 {
-  "version": 2,
+  "version": 3,
   "targets": {
     ".NETCoreApp,Version=v1.0": {
       "Libuv/1.9.0": {
@@ -6592,9 +6592,52 @@
       "Microsoft.NETCore.App >= 1.0.0"
     ]
   },
-  "tools": {},
-  "projectFileToolGroups": {},
   "packageFolders": {
     "C:\\.nuget\\packages\\": {}
+  },
+  "project": {
+    "version": "1.0.0",
+    "restore": {
+      "projectUniqueName": "C:\\git\\repro\\consoletest\\consoletest.csproj",
+      "projectName": "consoletest",
+      "projectPath": "C:\\git\\repro\\consoletest\\consoletest.csproj",
+      "packagesPath": "C:\\Users\\username\\.nuget\\packages\\",
+      "outputPath": "C:\\git\\repro\\consoletest\\obj\\",
+      "projectStyle": "PackageReference",
+      "fallbackFolders": [],
+      "configFilePaths": [
+        "C:\\Users\\username\\AppData\\Roaming\\NuGet\\NuGet.Config"
+      ],
+      "originalTargetFrameworks": [
+        "netcoreapp1.0"
+      ],
+      "sources": {
+        "https://api.nuget.org/v3/index.json": {}
+      },
+      "frameworks": {
+        "netcoreapp1.0": {
+          "targetAlias": "netcoreapp1.0",
+          "projectReferences": {}
+        }
+      },
+      "warningProperties": {
+        "warnAsError": [
+          "NU1605"
+        ]
+      }
+    },
+    "frameworks": {
+      "netcoreapp1.0": {
+        "targetAlias": "netcoreapp1.0",
+        "dependencies": {
+          "Microsoft.NETCore.App": {
+            "target": "Package",
+            "version": "[1.0.5, )",
+            "autoReferenced": true
+          }
+        },
+        "runtimeIdentifierGraphPath": "C:\\git\\dotnet-sdk\\artifacts\\bin\\redist\\Debug\\dotnet\\sdk\\5.0.100-dev\\RuntimeIdentifierGraph.json"
+      }
+    }
   }
 }

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/LockFiles/simple.dependencies.project.lock.json
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/LockFiles/simple.dependencies.project.lock.json
@@ -1,6 +1,6 @@
 {
   "locked": false,
-  "version": 2,
+  "version": 3,
   "targets": {
     ".NETCoreApp,Version=v1.0": {
       "Libuv/1.9.0": {
@@ -6791,6 +6791,52 @@
       "System.Collections.NonGeneric >= 4.0.1"
     ]
   },
-  "tools": {},
-  "projectFileToolGroups": {}
+  "packageFolders": {
+    "C:\\.nuget\\packages\\": {}
+  },
+  "project": {
+    "version": "1.0.0",
+    "restore": {
+      "projectUniqueName": "C:\\git\\repro\\consoletest\\consoletest.csproj",
+      "projectName": "consoletest",
+      "projectPath": "C:\\git\\repro\\consoletest\\consoletest.csproj",
+      "packagesPath": "C:\\Users\\username\\.nuget\\packages\\",
+      "outputPath": "C:\\git\\repro\\consoletest\\obj\\",
+      "projectStyle": "PackageReference",
+      "fallbackFolders": [],
+      "configFilePaths": [
+        "C:\\Users\\username\\AppData\\Roaming\\NuGet\\NuGet.Config"
+      ],
+      "originalTargetFrameworks": [
+        "netcoreapp1.0"
+      ],
+      "sources": {
+        "https://api.nuget.org/v3/index.json": {}
+      },
+      "frameworks": {
+        "netcoreapp1.0": {
+          "targetAlias": "netcoreapp1.0",
+          "projectReferences": {}
+        }
+      },
+      "warningProperties": {
+        "warnAsError": [
+          "NU1605"
+        ]
+      }
+    },
+    "frameworks": {
+      "netcoreapp1.0": {
+        "targetAlias": "netcoreapp1.0",
+        "dependencies": {
+          "Microsoft.NETCore.App": {
+            "target": "Package",
+            "version": "[1.0.5, )",
+            "autoReferenced": true
+          }
+        },
+        "runtimeIdentifierGraphPath": "C:\\git\\dotnet-sdk\\artifacts\\bin\\redist\\Debug\\dotnet\\sdk\\5.0.100-dev\\RuntimeIdentifierGraph.json"
+      }
+    }
+  }
 }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/CheckForTargetInAssetsFile.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/CheckForTargetInAssetsFile.cs
@@ -14,7 +14,7 @@ namespace Microsoft.NET.Build.Tasks
         public string AssetsFilePath { get; set; }
 
         [Required]
-        public string TargetFrameworkMoniker { get; set; }
+        public string TargetFramework { get; set; }
 
         public string RuntimeIdentifier { get; set; }
 
@@ -23,9 +23,7 @@ namespace Microsoft.NET.Build.Tasks
         {
             LockFile lockFile = new LockFileCache(this).GetLockFile(AssetsFilePath);
 
-            var nugetFramework = NuGetUtils.ParseFrameworkName(TargetFrameworkMoniker);
-
-            lockFile.GetTargetAndThrowIfNotFound(nugetFramework, RuntimeIdentifier);
+            lockFile.GetTargetAndThrowIfNotFound(TargetFramework, RuntimeIdentifier);
         }
     }
 }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/FilterResolvedFiles.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/FilterResolvedFiles.cs
@@ -30,8 +30,6 @@ namespace Microsoft.NET.Build.Tasks
         [Required]
         public string TargetFramework { get; set; }
 
-        public string TargetPlatformMoniker { get; set; }
-
         public string RuntimeIdentifier { get; set; }
 
         public string PlatformLibraryName { get; set; }
@@ -58,7 +56,7 @@ namespace Microsoft.NET.Build.Tasks
             LockFile lockFile = lockFileCache.GetLockFile(AssetsFilePath);
 
             ProjectContext projectContext = lockFile.CreateProjectContext(
-                NuGetTargetFrameworkUtils.GetTargetFramework(TargetFramework, TargetPlatformMoniker),
+                TargetFramework,
                 RuntimeIdentifier,
                 PlatformLibraryName,
                 runtimeFrameworks: null,

--- a/src/Tasks/Microsoft.NET.Build.Tasks/GenerateDepsFile.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/GenerateDepsFile.cs
@@ -32,8 +32,6 @@ namespace Microsoft.NET.Build.Tasks
         [Required]
         public string TargetFramework { get; set; }
 
-        public string TargetPlatformMoniker { get; set; }
-
         public string RuntimeIdentifier { get; set; }
 
         public string PlatformLibraryName { get; set; }
@@ -136,7 +134,7 @@ namespace Microsoft.NET.Build.Tasks
             {
                 LockFile lockFile = new LockFileCache(this).GetLockFile(AssetsFilePath);
                 projectContext = lockFile.CreateProjectContext(
-                 NuGetTargetFrameworkUtils.GetTargetFramework(TargetFramework, TargetPlatformMoniker),
+                 TargetFramework,
                  RuntimeIdentifier,
                  PlatformLibraryName,
                  RuntimeFrameworks,

--- a/src/Tasks/Microsoft.NET.Build.Tasks/GenerateRuntimeConfigurationFiles.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/GenerateRuntimeConfigurationFiles.cs
@@ -24,6 +24,9 @@ namespace Microsoft.NET.Build.Tasks
         public string AssetsFilePath { get; set; }
 
         [Required]
+        public string TargetFramework { get; set; }
+
+        [Required]
         public string TargetFrameworkMoniker { get; set; }
 
         public string TargetPlatformMoniker { get; set; }
@@ -126,7 +129,7 @@ namespace Microsoft.NET.Build.Tasks
                 LockFile lockFile = new LockFileCache(this).GetLockFile(AssetsFilePath);
 
                 ProjectContext projectContext = lockFile.CreateProjectContext(
-                    NuGetTargetFrameworkUtils.GetTargetFramework(TargetFrameworkMoniker, TargetPlatformMoniker),
+                    TargetFramework,
                     RuntimeIdentifier,
                     PlatformLibraryName,
                     RuntimeFrameworks,

--- a/src/Tasks/Microsoft.NET.Build.Tasks/GenerateRuntimeConfigurationFiles.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/GenerateRuntimeConfigurationFiles.cs
@@ -29,8 +29,6 @@ namespace Microsoft.NET.Build.Tasks
         [Required]
         public string TargetFrameworkMoniker { get; set; }
 
-        public string TargetPlatformMoniker { get; set; }
-
         [Required]
         public string RuntimeConfigPath { get; set; }
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/LockFileExtensions.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/LockFileExtensions.cs
@@ -13,13 +13,13 @@ namespace Microsoft.NET.Build.Tasks
 {
     internal static class LockFileExtensions
     {
-        public static LockFileTarget GetTargetAndThrowIfNotFound(this LockFile lockFile, NuGetFramework framework, string runtime)
+        public static LockFileTarget GetTargetAndThrowIfNotFound(this LockFile lockFile, string frameworkAlias, string runtime)
         {
-            LockFileTarget lockFileTarget = lockFile.GetTarget(framework, runtime);
+            LockFileTarget lockFileTarget = lockFile.GetTarget(frameworkAlias, runtime);
 
             if (lockFileTarget == null)
             {
-                string frameworkString = framework.DotNetFrameworkName;
+                string frameworkString = frameworkAlias;
                 string targetMoniker = string.IsNullOrEmpty(runtime) ?
                     frameworkString :
                     $"{frameworkString}/{runtime}";
@@ -27,11 +27,11 @@ namespace Microsoft.NET.Build.Tasks
                 string message;
                 if (string.IsNullOrEmpty(runtime))
                 {
-                    message = string.Format(Strings.AssetsFileMissingTarget, lockFile.Path, targetMoniker, framework.GetShortFolderName());
+                    message = string.Format(Strings.AssetsFileMissingTarget, lockFile.Path, targetMoniker, frameworkString);
                 }
                 else
                 {
-                    message = string.Format(Strings.AssetsFileMissingRuntimeIdentifier, lockFile.Path, targetMoniker, framework.GetShortFolderName(), runtime);
+                    message = string.Format(Strings.AssetsFileMissingRuntimeIdentifier, lockFile.Path, targetMoniker, frameworkString, runtime);
                 }
 
                 throw new BuildErrorException(message);
@@ -42,7 +42,7 @@ namespace Microsoft.NET.Build.Tasks
 
         public static ProjectContext CreateProjectContext(
             this LockFile lockFile,
-            NuGetFramework framework,
+            string frameworkAlias,
             string runtime,
             //  Trimmed from publish output, and if there are no runtimeFrameworks, written to runtimeconfig.json
             string platformLibraryName,
@@ -54,12 +54,12 @@ namespace Microsoft.NET.Build.Tasks
             {
                 throw new ArgumentNullException(nameof(lockFile));
             }
-            if (framework == null)
+            if (frameworkAlias == null)
             {
-                throw new ArgumentNullException(nameof(framework));
+                throw new ArgumentNullException(nameof(frameworkAlias));
             }
 
-            var lockFileTarget = lockFile.GetTargetAndThrowIfNotFound(framework, runtime);
+            var lockFileTarget = lockFile.GetTargetAndThrowIfNotFound(frameworkAlias, runtime);
 
             LockFileTargetLibrary platformLibrary = lockFileTarget.GetLibrary(platformLibraryName);
             bool isFrameworkDependent = IsFrameworkDependent(runtimeFrameworks, isSelfContained, lockFileTarget.RuntimeIdentifier, platformLibrary != null);

--- a/src/Tasks/Microsoft.NET.Build.Tasks/LockFileExtensions.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/LockFileExtensions.cs
@@ -40,6 +40,16 @@ namespace Microsoft.NET.Build.Tasks
             return lockFileTarget;
         }
 
+        public static string GetLockFileTargetAlias(this LockFile lockFile, LockFileTarget lockFileTarget)
+        {
+            var frameworkAlias = lockFile.PackageSpec.TargetFrameworks.FirstOrDefault(tfi => tfi.FrameworkName == lockFileTarget.TargetFramework)?.TargetAlias;
+            if (frameworkAlias == null)
+            {
+                throw new ArgumentException("Could not find TargetFramework alias in lock file for " + lockFileTarget.TargetFramework);
+            }
+            return frameworkAlias;
+        }
+
         public static ProjectContext CreateProjectContext(
             this LockFile lockFile,
             string frameworkAlias,

--- a/src/Tasks/Microsoft.NET.Build.Tasks/PreprocessPackageDependenciesDesignTime.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/PreprocessPackageDependenciesDesignTime.cs
@@ -50,11 +50,12 @@ namespace Microsoft.NET.Build.Tasks
         public string DefaultImplicitPackages { get; set; }
 
         /// <summary>
-        /// Eg: ".NETCoreApp,Version=v5.0".
+        /// The TargetFramework, which may be an alias
+        /// Eg: "netcoreapp3.1", "net5.0-windows", etc.
         /// Only packages targeting this framework will be returned.
         /// </summary>
         [Required]
-        public string TargetFrameworkMoniker { get; set; }
+        public string TargetFramework { get; set; }
 
         [Output]
         public ITaskItem[] PackageDependenciesDesignTime { get; private set; }
@@ -82,7 +83,7 @@ namespace Microsoft.NET.Build.Tasks
 
                 var target = dependency.GetMetadata(MetadataKeys.ParentTarget);
 
-                if (!StringComparer.OrdinalIgnoreCase.Equals(target, TargetFrameworkMoniker))
+                if (!StringComparer.OrdinalIgnoreCase.Equals(target, TargetFramework))
                 {
                     // skip dependencies for other targets
                     continue;

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ProjectContext.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ProjectContext.cs
@@ -79,7 +79,12 @@ namespace Microsoft.NET.Build.Tasks
             }
             else
             {
-                CompilationLockFileTarget = lockFile.GetTargetAndThrowIfNotFound(lockFileTarget.TargetFramework, null);
+                var frameworkAlias = lockFile.PackageSpec.TargetFrameworks.FirstOrDefault(tfi => tfi.FrameworkName == lockFileTarget.TargetFramework).TargetAlias;
+                if (frameworkAlias == null)
+                {
+                    throw new ArgumentException("Could not find TargetFramework alias in lock file for " + lockFileTarget.TargetFramework);
+                }
+                CompilationLockFileTarget = lockFile.GetTargetAndThrowIfNotFound(frameworkAlias, null);
             }
 
             PlatformLibrary = platformLibrary;

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ProjectContext.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ProjectContext.cs
@@ -79,7 +79,7 @@ namespace Microsoft.NET.Build.Tasks
             }
             else
             {
-                var frameworkAlias = lockFile.PackageSpec.TargetFrameworks.FirstOrDefault(tfi => tfi.FrameworkName == lockFileTarget.TargetFramework).TargetAlias;
+                var frameworkAlias = lockFile.PackageSpec.TargetFrameworks.FirstOrDefault(tfi => tfi.FrameworkName == lockFileTarget.TargetFramework)?.TargetAlias;
                 if (frameworkAlias == null)
                 {
                     throw new ArgumentException("Could not find TargetFramework alias in lock file for " + lockFileTarget.TargetFramework);

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ProjectContext.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ProjectContext.cs
@@ -79,11 +79,7 @@ namespace Microsoft.NET.Build.Tasks
             }
             else
             {
-                var frameworkAlias = lockFile.PackageSpec.TargetFrameworks.FirstOrDefault(tfi => tfi.FrameworkName == lockFileTarget.TargetFramework)?.TargetAlias;
-                if (frameworkAlias == null)
-                {
-                    throw new ArgumentException("Could not find TargetFramework alias in lock file for " + lockFileTarget.TargetFramework);
-                }
+                var frameworkAlias = lockFile.GetLockFileTargetAlias(lockFileTarget);
                 CompilationLockFileTarget = lockFile.GetTargetAndThrowIfNotFound(frameworkAlias, null);
             }
 
@@ -194,10 +190,12 @@ namespace Microsoft.NET.Build.Tasks
             Dictionary<string, LockFileTargetLibrary> libraryLookup =
                 lockFileTarget.Libraries.ToDictionary(l => l.Name, StringComparer.OrdinalIgnoreCase);
 
+            var frameworkAlias = lockFile.GetLockFileTargetAlias(lockFileTarget);
+
             return lockFile
                 .ProjectFileDependencyGroups
                 .Where(dg => dg.FrameworkName == string.Empty ||
-                             dg.FrameworkName == lockFileTarget.TargetFramework.DotNetFrameworkName)
+                             dg.FrameworkName == frameworkAlias)
                 .SelectMany(g => g.Dependencies)
                 .Select(projectFileDependency =>
                 {

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ProjectContext.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ProjectContext.cs
@@ -190,12 +190,12 @@ namespace Microsoft.NET.Build.Tasks
             Dictionary<string, LockFileTargetLibrary> libraryLookup =
                 lockFileTarget.Libraries.ToDictionary(l => l.Name, StringComparer.OrdinalIgnoreCase);
 
-            var frameworkAlias = lockFile.GetLockFileTargetAlias(lockFileTarget);
+            string lockFileTargetFramework = lockFileTarget.Name.Split('/')[0];
 
             return lockFile
                 .ProjectFileDependencyGroups
                 .Where(dg => dg.FrameworkName == string.Empty ||
-                             dg.FrameworkName == frameworkAlias)
+                             dg.FrameworkName == lockFileTargetFramework)
                 .SelectMany(g => g.Dependencies)
                 .Select(projectFileDependency =>
                 {

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolveCopyLocalAssets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveCopyLocalAssets.cs
@@ -23,8 +23,6 @@ namespace Microsoft.NET.Build.Tasks
         [Required]
         public string TargetFramework { get; set; }
 
-        public string TargetPlatformMoniker { get; set; }
-
         public string RuntimeIdentifier { get; set; }
 
         public string PlatformLibraryName { get; set; }
@@ -60,7 +58,7 @@ namespace Microsoft.NET.Build.Tasks
             }
 
             ProjectContext projectContext = lockFile.CreateProjectContext(
-                NuGetTargetFrameworkUtils.GetTargetFramework(TargetFramework, TargetPlatformMoniker),
+                TargetFramework,
                 RuntimeIdentifier,
                 PlatformLibraryName,
                 RuntimeFrameworks,

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageDependencies.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageDependencies.cs
@@ -142,11 +142,28 @@ namespace Microsoft.NET.Build.Tasks
 
         private LockFile LockFile => _lockFile ??= new LockFileCache(this).GetLockFile(ProjectAssetsFile);
 
+        private Dictionary<string, string> _targetNameToAliasMap;
+
         /// <summary>
         /// Raise Nuget LockFile representation to MSBuild items
         /// </summary>
         protected override void ExecuteCore()
         {
+            var targetFrameworkToAliasMap = LockFile.PackageSpec.TargetFrameworks.ToDictionary(tf => tf.FrameworkName.DotNetFrameworkName, tf => tf.TargetAlias);
+
+            _targetNameToAliasMap = LockFile.Targets.ToDictionary(t => t.Name, t =>
+            {
+                var alias = targetFrameworkToAliasMap[t.TargetFramework.DotNetFrameworkName];
+                if (string.IsNullOrEmpty(t.RuntimeIdentifier))
+                {
+                    return alias;
+                }
+                else
+                {
+                    return alias + "/" + t.RuntimeIdentifier;
+                }
+            });
+
             ReadProjectFileDependencies();
             RaiseLockFileTargets();
             GetPackageAndFileDefinitions();
@@ -211,8 +228,10 @@ namespace Microsoft.NET.Build.Tasks
 
                         foreach (var target in parentTargets)
                         {
+                            string frameworkAlias = _targetNameToAliasMap[target.Name];
+
                             var fileDepsItem = new TaskItem(fileKey);
-                            fileDepsItem.SetMetadata(MetadataKeys.ParentTarget, target.Name); // Foreign Key
+                            fileDepsItem.SetMetadata(MetadataKeys.ParentTarget, frameworkAlias); // Foreign Key
                             fileDepsItem.SetMetadata(MetadataKeys.ParentPackage, packageId); // Foreign Key
 
                             _fileDependencies.Add(fileDepsItem);
@@ -286,8 +305,15 @@ namespace Microsoft.NET.Build.Tasks
 
                 if (_projectFileDependencies.Contains(package.Name))
                 {
+                    if (!_targetNameToAliasMap.ContainsKey(target.Name))
+                    {
+
+                    }
+
+                    string frameworkAlias = _targetNameToAliasMap[target.Name];
+
                     TaskItem item = new TaskItem(packageId);
-                    item.SetMetadata(MetadataKeys.ParentTarget, target.Name); // Foreign Key
+                    item.SetMetadata(MetadataKeys.ParentTarget, frameworkAlias); // Foreign Key
                     item.SetMetadata(MetadataKeys.ParentPackage, string.Empty); // Foreign Key
 
                     _packageDependencies.Add(item);
@@ -311,6 +337,7 @@ namespace Microsoft.NET.Build.Tasks
             HashSet<string> transitiveProjectRefs)
         {
             string packageId = $"{package.Name}/{package.Version.ToNormalizedString()}";
+            string frameworkAlias = _targetNameToAliasMap[targetName];
             foreach (var deps in package.Dependencies)
             {
                 if (!resolvedPackageVersions.TryGetValue(deps.Id, out string version))
@@ -321,7 +348,7 @@ namespace Microsoft.NET.Build.Tasks
                 string depsName = $"{deps.Id}/{version}";
 
                 TaskItem item = new TaskItem(depsName);
-                item.SetMetadata(MetadataKeys.ParentTarget, targetName); // Foreign Key
+                item.SetMetadata(MetadataKeys.ParentTarget, frameworkAlias); // Foreign Key
                 item.SetMetadata(MetadataKeys.ParentPackage, packageId); // Foreign Key
 
                 if (transitiveProjectRefs.Contains(deps.Id))
@@ -336,6 +363,7 @@ namespace Microsoft.NET.Build.Tasks
         private void GetFileDependencies(LockFileTargetLibrary package, string targetName)
         {
             string packageId = $"{package.Name}/{package.Version.ToNormalizedString()}";
+            string frameworkAlias = _targetNameToAliasMap[targetName];
 
             // for each type of file group
             foreach (var fileGroup in (FileGroup[])Enum.GetValues(typeof(FileGroup)))
@@ -354,7 +382,7 @@ namespace Microsoft.NET.Build.Tasks
                     var fileKey = $"{packageId}/{filePath}";
                     var item = new TaskItem(fileKey);
                     item.SetMetadata(MetadataKeys.FileGroup, fileGroup.ToString());
-                    item.SetMetadata(MetadataKeys.ParentTarget, targetName); // Foreign Key
+                    item.SetMetadata(MetadataKeys.ParentTarget, frameworkAlias); // Foreign Key
                     item.SetMetadata(MetadataKeys.ParentPackage, packageId); // Foreign Key
 
                     if (fileGroup == FileGroup.FrameworkAssembly)

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageDependencies.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageDependencies.cs
@@ -305,11 +305,6 @@ namespace Microsoft.NET.Build.Tasks
 
                 if (_projectFileDependencies.Contains(package.Name))
                 {
-                    if (!_targetNameToAliasMap.ContainsKey(target.Name))
-                    {
-
-                    }
-
                     string frameworkAlias = _targetNameToAliasMap[target.Name];
 
                     TaskItem item = new TaskItem(packageId);

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ComposeStore.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ComposeStore.targets
@@ -420,7 +420,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <FilterResolvedFiles  AssetsFilePath="$(ProjectAssetsFile)"
                           ResolvedFiles ="@(_ResolvedCopyLocalPublishAssets)"
                           PackagesToPrune="$(PackagesToPrune)"
-                          TargetFramework="$(TargetFrameworkMoniker)"
+                          TargetFramework="$(TargetFramework)"
                           RuntimeIdentifier="$(RuntimeIdentifier)"
                           IsSelfContained="$(SelfContained)" >
       <Output TaskParameter="AssembliesToPublish" ItemName="ResolvedFileToPublish" />

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ComposeStore.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ComposeStore.targets
@@ -421,7 +421,6 @@ Copyright (c) .NET Foundation. All rights reserved.
                           ResolvedFiles ="@(_ResolvedCopyLocalPublishAssets)"
                           PackagesToPrune="$(PackagesToPrune)"
                           TargetFramework="$(TargetFrameworkMoniker)"
-                          TargetPlatformMoniker="$(TargetPlatformMoniker)"
                           RuntimeIdentifier="$(RuntimeIdentifier)"
                           IsSelfContained="$(SelfContained)" >
       <Output TaskParameter="AssembliesToPublish" ItemName="ResolvedFileToPublish" />

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.CrossGen.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.CrossGen.targets
@@ -279,7 +279,6 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ResolveCopyLocalAssets Condition="'$(_TargetFrameworkVersionWithoutV)' &lt; '3.0'"
                             AssetsFilePath="$(_CrossProjAssetsFile)"
                             TargetFramework="$(_TFM)"
-                            TargetPlatformMoniker="$(TargetPlatformMoniker)"
                             RuntimeIdentifier="$(RuntimeIdentifier)"
                             PlatformLibraryName="$(MicrosoftNETPlatformLibrary)"
                             RuntimeFrameworks="@(RuntimeFramework)"

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.DesignerSupport.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.DesignerSupport.targets
@@ -66,8 +66,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       CompileReferences="@(ResolvedCompileFileDefinitions)"
       ResolvedNuGetFiles="@(NativeCopyLocalItems);@(ResourceCopyLocalItems);@(RuntimeCopyLocalItems)"
       ResolvedRuntimeTargetsFiles="@(RuntimeTargetsCopyLocalItems)"
-      TargetFramework="$(TargetFrameworkMoniker)"
-      TargetPlatformMoniker="$(TargetPlatformMoniker)"
+      TargetFramework="$(TargetFramework)"
       RuntimeGraphPath="$(BundledRuntimeIdentifierGraphFile)"
       />
 
@@ -104,6 +103,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       PlatformLibraryName="$(MicrosoftNETPlatformLibrary)"
       RuntimeConfigPath="$(_DesignerRuntimeConfigFilePath)"
       RuntimeFrameworks="@(RuntimeFramework)"
+      TargetFramework="$(TargetFramework)"
       TargetFrameworkMoniker="$(TargetFrameworkMoniker)"
       TargetPlatformMoniker="$(TargetPlatformMoniker)"
       UserRuntimeConfig="$(UserRuntimeConfig)"

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.DesignerSupport.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.DesignerSupport.targets
@@ -105,7 +105,6 @@ Copyright (c) .NET Foundation. All rights reserved.
       RuntimeFrameworks="@(RuntimeFramework)"
       TargetFramework="$(TargetFramework)"
       TargetFrameworkMoniker="$(TargetFrameworkMoniker)"
-      TargetPlatformMoniker="$(TargetPlatformMoniker)"
       UserRuntimeConfig="$(UserRuntimeConfig)"
       WriteAdditionalProbingPathsToMainConfig="true"
       />

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -609,8 +609,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       <!-- For future: Delete ResolveCopyLocalAssets task.  Need to figure out how to get correct DestinationSubPath for
            PreserveStoreLayout without this task, and how to handle RuntimeStorePackages. -->
       <ResolveCopyLocalAssets AssetsFilePath="$(ProjectAssetsFile)"
-                              TargetFramework="$(TargetFrameworkMoniker)"
-                              TargetPlatformMoniker="$(TargetPlatformMoniker)"
+                              TargetFramework="$(TargetFramework)"
                               RuntimeIdentifier="$(RuntimeIdentifier)"
                               PlatformLibraryName="$(MicrosoftNETPlatformLibrary)"
                               RuntimeFrameworks="@(RuntimeFramework)"
@@ -1071,8 +1070,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <GenerateDepsFile ProjectPath="$(MSBuildProjectFullPath)"
                       AssetsFilePath="$(ProjectAssetsFile)"
                       DepsFilePath="$(IntermediateDepsFilePath)"
-                      TargetFramework="$(TargetFrameworkMoniker)"
-                      TargetPlatformMoniker="$(TargetPlatformMoniker)"
+                      TargetFramework="$(TargetFramework)"
                       AssemblyName="$(AssemblyName)"
                       AssemblyExtension="$(TargetExt)"
                       AssemblyVersion="$(Version)"

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.BeforeCommon.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.BeforeCommon.targets
@@ -256,9 +256,4 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ProjectCapability Include="GenerateDocumentationFile" />
   </ItemGroup>
 
-  <!--Workaround for https://github.com/dotnet/sdk/issues/12856-->
-  <PropertyGroup Condition="'$(ReferringTargetFrameworkForProjectReferences)' == ''">
-    <ReferringTargetFrameworkForProjectReferences>$(TargetFramework)</ReferringTargetFrameworkForProjectReferences>
-  </PropertyGroup>
-
 </Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -195,8 +195,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <GenerateDepsFile ProjectPath="$(MSBuildProjectFullPath)"
                       AssetsFilePath="$(ProjectAssetsFile)"
                       DepsFilePath="$(ProjectDepsFilePath)"
-                      TargetFramework="$(TargetFrameworkMoniker)"
-                      TargetPlatformMoniker="$(TargetPlatformMoniker)"
+                      TargetFramework="$(TargetFramework)"
                       AssemblyName="$(AssemblyName)"
                       AssemblyExtension="$(TargetExt)"
                       AssemblyVersion="$(Version)"
@@ -289,6 +288,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     </PropertyGroup>
 
     <GenerateRuntimeConfigurationFiles AssetsFilePath="$(ProjectAssetsFile)"
+                                       TargetFramework="$(TargetFramework)"
                                        TargetFrameworkMoniker="$(TargetFrameworkMoniker)"
                                        TargetPlatformMoniker="$(TargetPlatformMoniker)"
                                        RuntimeConfigPath="$(ProjectRuntimeConfigFilePath)"

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -290,7 +290,6 @@ Copyright (c) .NET Foundation. All rights reserved.
     <GenerateRuntimeConfigurationFiles AssetsFilePath="$(ProjectAssetsFile)"
                                        TargetFramework="$(TargetFramework)"
                                        TargetFrameworkMoniker="$(TargetFrameworkMoniker)"
-                                       TargetPlatformMoniker="$(TargetPlatformMoniker)"
                                        RuntimeConfigPath="$(ProjectRuntimeConfigFilePath)"
                                        RuntimeConfigDevPath="$(ProjectRuntimeConfigDevFilePath)"
                                        RuntimeIdentifier="$(RuntimeIdentifier)"

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.PackageDependencyResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.PackageDependencyResolution.targets
@@ -179,7 +179,7 @@ Copyright (c) .NET Foundation. All rights reserved.
          compile errors. -->
     <CheckForTargetInAssetsFile
       AssetsFilePath="$(ProjectAssetsFile)"
-      TargetFrameworkMoniker="$(NuGetTargetMoniker)"
+      TargetFramework="$(TargetFramework)"
       RuntimeIdentifier="$(RuntimeIdentifier)"
       Condition=" '$(DesignTimeBuild)' != 'true'"/>
 
@@ -244,8 +244,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       ProjectPath="$(MSBuildProjectFullPath)"
       ProjectLanguage="$(Language)"
       EmitAssetsLogMessages="$(EmitAssetsLogMessages)"
-      TargetFrameworkMoniker="$(NuGetTargetMoniker)"
-      TargetPlatformMoniker="$(TargetPlatformMoniker)"
+      TargetFramework="$(TargetFramework)"
       RuntimeIdentifier="$(RuntimeIdentifier)"
       PlatformLibraryName="$(MicrosoftNETPlatformLibrary)"
       RuntimeFrameworks="@(RuntimeFramework)"
@@ -314,7 +313,7 @@ Copyright (c) .NET Foundation. All rights reserved.
           PackageDefinitions="@(PackageDefinitions)"
           PackageDependencies="@(PackageDependencies)"
           DefaultImplicitPackages="$(DefaultImplicitPackages)"
-          TargetFrameworkMoniker="$(NuGetTargetMoniker)">
+          TargetFramework="$(TargetFramework)">
 
       <Output TaskParameter="PackageDependenciesDesignTime" ItemName="_PackageDependenciesDesignTime" />
     </PreprocessPackageDependenciesDesignTime>

--- a/src/Tests/Microsoft.NET.Build.Tests/DesignTimeBuildTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/DesignTimeBuildTests.cs
@@ -135,7 +135,7 @@ namespace Microsoft.NET.Build.Tests
             //  Use a test-specific packages folder
             testProject.AdditionalProperties["RestorePackagesPath"] = @"$(MSBuildProjectDirectory)\packages";
 
-            var testAsset = _testAssetsManager.CreateTestProject(testProject)
+            var testAsset = _testAssetsManager.CreateTestProject(testProject, callingMethod: callingMethod)
                 .WithProjectChanges(p =>
                 {
                     var ns = p.Root.Name.Namespace;

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToReferenceAProject.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToReferenceAProject.cs
@@ -48,7 +48,7 @@ namespace Microsoft.NET.Build.Tests
             FailsBuild
         }
 
-        [Theory]
+        [RequiresMSBuildVersionTheory("16.8.0.42407")]
         [InlineData("net5.0-windows", "net5.0", true)]
         [InlineData("net5.0", "net5.0-windows", false)]
         [InlineData("net5.0-windows", "net5.0-windows", true)]

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToReferenceAProject.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToReferenceAProject.cs
@@ -49,6 +49,17 @@ namespace Microsoft.NET.Build.Tests
         }
 
         [Theory]
+        [InlineData("net5.0-windows", "net5.0", true)]
+        [InlineData("net5.0", "net5.0-windows", false)]
+        [InlineData("net5.0-windows", "net5.0-windows", true)]
+        [InlineData("net5.0-windows", "net5.0-windows7.0", true)]
+        [InlineData("net5.0-windows7.0", "net5.0-windows", true)]
+        public void It_checks_for_valid_platform_references(string referencerTarget, string dependencyTarget, bool succeeds)
+        {
+            It_checks_for_valid_references(referencerTarget, true, dependencyTarget, true, succeeds, succeeds);
+        }
+
+        [Theory]
         [InlineData("netstandard1.2", true, "netstandard1.5", true, false, false)]
         [InlineData("netcoreapp1.1", true, "net45;netstandard1.5", true, true, true)]
         [InlineData("netcoreapp1.1", true, "net45;net46", true, false, false)]


### PR DESCRIPTION
- Use `TargetFramework` (alias) to look up sections of the assets file, instead of `TargetFrameworkMoniker` and `TargetPlatformMoniker` @nkolev92 
- Fix design-time package resolution (PreprocessPackageDependenciesDesignTime) to match based on `TargetFramework` (alias) @drewnoakes 
- Remove workaround for P2P platform references (#12859)
- Add tests for P2P references with target platforms