### PR TITLE
Fix C++/CLI

### DIFF
--- a/src/Assets/TestProjects/NETCoreCppClApp/NETCoreCppCliTest/NETCoreCppCliTest.vcxproj
+++ b/src/Assets/TestProjects/NETCoreCppClApp/NETCoreCppCliTest/NETCoreCppCliTest.vcxproj
@@ -13,7 +13,7 @@
   <PropertyGroup Label="Globals">
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{CF5DA8D7-1FDF-4E8F-AFE6-450BE16E906A}</ProjectGuid>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <Keyword>ManagedCProj</Keyword>
     <RootNamespace>NETCoreCppCliTest</RootNamespace>
     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>

--- a/src/Assets/TestProjects/NetCoreCsharpAppReferenceCppCliLib/CSConsoleApp/CSConsoleApp.csproj
+++ b/src/Assets/TestProjects/NetCoreCsharpAppReferenceCppCliLib/CSConsoleApp/CSConsoleApp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <Platforms>x64</Platforms>
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.TargetFrameworkInference.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.TargetFrameworkInference.targets
@@ -161,7 +161,8 @@ Copyright (c) .NET Foundation. All rights reserved.
       />
   </Target>
 
-  <PropertyGroup  Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' and $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), 5.0))">
+  <!--C++/CLI has its own logic of determine TargetPlatformIdentifier and TargetPlatformVersion-->
+  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' and $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), 5.0)) and '$(Language)' != 'C++'">
     <_EnableDefaultWindowsPlatform>false</_EnableDefaultWindowsPlatform>
     <UseOSWinMdReferences>false</UseOSWinMdReferences>
   </PropertyGroup>
@@ -198,9 +199,10 @@ Copyright (c) .NET Foundation. All rights reserved.
                  FormatArguments="$(SupportedOSPlatform);$(TargetPlatformVersion)"/>
   </Target>
 
+  <!--C++/CLI targets rely on the patch version of the Windows SDK version as TargetPlatformVersion. Skip the normalization.-->
   <Target Name="_NormalizeTargetPlatformVersion"
     BeforeTargets="ProcessFrameworkReferences"
-    Condition="'$(TargetPlatformVersion)' != '' and '$(TargetFrameworkIdentifier)' == '.NETCoreApp' and $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), 5.0))">
+    Condition="'$(TargetPlatformVersion)' != '' and '$(TargetFrameworkIdentifier)' == '.NETCoreApp' and $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), 5.0)) and '$(Language)' != 'C++'">
     <ItemGroup>
       <_ValidTargetPlatformVersion Include="@(SupportedTargetPlatform)" Condition="'@(SupportedTargetPlatform)' != '' and $([MSBuild]::VersionEquals(%(Identity), $(TargetPlatformVersion)))" />
     </ItemGroup>
@@ -213,7 +215,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <Target Name="_CheckForInvalidTargetPlatformVersion"
       BeforeTargets="_CheckForInvalidConfigurationAndPlatform"
       DependsOnTargets="_NormalizeTargetPlatformVersion"
-      Condition="'$(TargetPlatformVersion)' != '' and '$(TargetFrameworkIdentifier)' == '.NETCoreApp' and $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), 5.0))">
+      Condition="'$(TargetPlatformVersion)' != '' and '$(TargetFrameworkIdentifier)' == '.NETCoreApp' and $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), 5.0)) and '$(Language)' != 'C++'">
     <PropertyGroup>
       <TargetPlatformVersionSupported Condition="'$(TargetPlatformVersionSupported)' == '' and '@(_ValidTargetPlatformVersion)' != ''" >true</TargetPlatformVersionSupported>
       <_ValidTargetPlatformVersions Condition="'@(SupportedTargetPlatform)' != ''" >@(SupportedTargetPlatform, '%0a')</_ValidTargetPlatformVersions>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Windows.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Windows.targets
@@ -11,12 +11,15 @@ Copyright (c) .NET Foundation. All rights reserved.
 -->
 
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <!--C++/CLI does not support nuget restore which is required for Windows SDK Ref. Also these are C# projections.-->
   <PropertyGroup Condition=" '$(DisableImplicitFrameworkReferences)' != 'true'
                              and '$(TargetFrameworkIdentifier)' == '.NETCoreApp'
                              and $([MSBuild]::VersionGreaterThanOrEquals($(_TargetFrameworkVersionWithoutV), '5.0'))
                              and '$(TargetPlatformIdentifier)' == 'Windows'
                              and '$(TargetPlatformVersion)' != ''
-                             and $([MSBuild]::VersionGreaterThanOrEquals($(TargetPlatformVersion), '10.0')) ">
+                             and $([MSBuild]::VersionGreaterThanOrEquals($(TargetPlatformVersion), '10.0'))
+                             and '$(Language)' != 'C++'">
     <_IncludeWindowsSDKRefFrameworkReferences>true</_IncludeWindowsSDKRefFrameworkReferences>
   </PropertyGroup>
 


### PR DESCRIPTION
1.Keep setting default TargetPlatformIdentifier and
  TargetPlatformVersion. C++/CLI has its own logic on deciding
  TargetPlatformVersion. Without the default TargetPlatformIdentifier to
  windows, it will fail the check on common target.

2.Disable CSWinRT pack auto reference when TargetPlatformIdentifier is
  windows 7 and above. C++/CLI does not support nuget restore which is
  required for Windows SDK Ref. Also, these are C# projections.

3.Do no normalize TargetPlatformVersion for C++/CLI as well as checking
  the support. The full version of Windows SDK is something like
  10.0.18362.0. The last digit is Windows SDK build number, and digits
     before that (10.0.18362) is Windows API version. C++ targets and
     SDK has different interpretation of TargetPlatformVersion. C++
     targets use the full version while SDK use Windows API version.
     Since the normalization and the check is for the issue 2. I
     disabled them all together.

4.Testing for C++/CLI. I fixed bug that in dotnet/sdk, the targeting
  pack is still the stage0(the older SDK that is used to build this SDK)
  version instead of what is in dotnet/sdk. However, that breaks all
  C++/CLI testing in dotnet/sdk due to these targeting pack need to
  download from the internet and C++/CLI does not support nuget restore.
  I will only add few test in dotnet/installer instead. Since C++ nuget
  restore support will be added later. And before that, there will be no
  big new feature in C++/CLI. I will also update the manual tests for
  net5.0 https://github.com/dotnet/sdk/issues/3785

fix https://github.com/dotnet/sdk/issues/12916