### PR TITLE
Add ClickOnce publishing target for Dotnet app publishing

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -24,3 +24,5 @@
 
 /src/Cli/dotnet/commands/dotnet-new @DonJoseLuis
 /src/Tests/dotnet-new.Tests @DonJoseLuis
+
+/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ClickOnce.targets @sujitnayak

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ClickOnce.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ClickOnce.targets
@@ -1,0 +1,86 @@
+<!--
+***********************************************************************************************
+Microsoft.NET.ClickOnce.targets
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+          created a backup copy.  Incorrect changes to this file will make it
+          impossible to load or build your projects from the command-line or the IDE.
+
+Copyright (c) .NET Foundation. All rights reserved. 
+***********************************************************************************************
+-->
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <PublishDirName>app.publish</PublishDirName>
+    <PublishDir>$(OutputPath)app.publish\</PublishDir>
+    <GenerateManifests>true</GenerateManifests>
+    <_DeploymentSignClickOnceManifests Condition="'$(SignManifests)' == 'true'">true</_DeploymentSignClickOnceManifests>
+    <PublishProtocolProviderTargets>ClickOncePublish</PublishProtocolProviderTargets>
+  </PropertyGroup>
+
+  <!-- 
+    For .NET Core ClickOnce publish in Single File mode, the ClickOnce manifest generation needs to run 
+    after ComputeFilesToPublish. This is so that the bundle EXE which is included in the ClickOnce manifest 
+    is generated before the manifest is created.
+  -->
+  <PropertyGroup Condition="'$(PublishSingleFile)' == 'true'">
+    <DeploymentComputeClickOnceManifestInfoDependsOn>
+      $(DeploymentComputeClickOnceManifestInfoDependsOn);
+      ComputeFilesToPublish
+    </DeploymentComputeClickOnceManifestInfoDependsOn>
+  </PropertyGroup>
+
+  <!-- Ensure runtimeconfig.json is built before clickonce manifest generation -->
+  <PropertyGroup Condition="'$(GenerateRuntimeConfigurationFiles)'=='true'">
+    <GenerateManifestsDependsOn>
+       GenerateBuildRuntimeConfigurationFiles;
+       $(GenerateManifestsDependsOn)
+    </GenerateManifestsDependsOn>
+  </PropertyGroup>
+
+  <!-- Ensure deps.json is available before clickonce manifest generation -->
+  <PropertyGroup Condition="'$(GenerateDependencyFile)' == 'true'">
+    <GenerateManifestsDependsOn>
+      _ComputeUseBuildDependencyFile;
+      GenerateBuildDependencyFile;
+      GeneratePublishDependencyFile;
+      GetNetCoreRuntimeJsonFilesForClickOnce;
+      $(GenerateManifestsDependsOn)
+    </GenerateManifestsDependsOn>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(GenerateRuntimeConfigurationFiles)'=='true'">
+    <ProjectRuntimeConfigFilesForClickOnce Include="$(ProjectRuntimeConfigFilePath)"/>
+  </ItemGroup>
+
+  <Target Name="GetNetCoreRuntimeJsonFilesForClickOnce" 
+          Condition="'$(GenerateDependencyFile)' == 'true'">
+
+    <!-- Get correct deps json files based on _UseBuildDependencyFile -->
+    <ItemGroup>
+      <ProjectDepsFilesForClickOnce Condition="'$(_UseBuildDependencyFile)' == 'true'" Include="$(ProjectDepsFilePath)"/>
+      <ProjectDepsFilesForClickOnce Condition="'$(_UseBuildDependencyFile)' != 'true'" Include="$(PublishDepsFilePath)"/>
+    </ItemGroup>
+
+    <!-- Add runtimeconfig and deps json file to item group that's included in files for clickonce publishing -->
+    <ItemGroup>
+       <NetCoreRuntimeJsonFilesForClickOnce Include="@(ProjectRuntimeConfigFilesForClickOnce);@(ProjectDepsFilesForClickOnce)"/>
+    </ItemGroup>
+  </Target>  
+
+  <!-- 
+    Add necessary clickonce targets that need to run during publish process.
+    These targets are defined in MS.Common.CurrentVersion.targets in the msbuild repo.
+  -->
+  <PropertyGroup>
+    <ClickOncePublishDependsOn>
+      $(ClickOncePublishDependsOn);
+      _CopyFilesToPublishFolder;
+      _DeploymentGenerateBootstrapper;
+      ResolveKeySource;
+      _DeploymentSignClickOnceDeployment;
+    </ClickOncePublishDependsOn>
+  </PropertyGroup>
+
+  <Target Name="ClickOncePublish" Condition="'$(PublishableProject)'=='true'" DependsOnTargets="$(ClickOncePublishDependsOn)" />
+</Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -34,6 +34,8 @@ Copyright (c) .NET Foundation. All rights reserved.
     ============================================================
     -->
 
+  <Import Project="Microsoft.NET.$(PublishProtocol).targets" Condition="'$(PublishProtocol)' != '' and Exists('Microsoft.NET.$(PublishProtocol).targets')" />
+
   <PropertyGroup>
     <!-- We still need to resolve references even if we are not building during publish. -->
     <!-- BuildOnlySettings are required for RAR to find satellites and dependencies -->
@@ -49,6 +51,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <_CorePublishTargets>
       PrepareForPublish;
       ComputeAndCopyFilesToPublishDirectory;
+      $(PublishProtocolProviderTargets);
     </_CorePublishTargets>
 
     <_PublishNoBuildAlternativeDependsOn>$(_BeforePublishNoBuildTargets);$(_CorePublishTargets)</_PublishNoBuildAlternativeDependsOn>

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishToClickOnce.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishToClickOnce.cs
@@ -1,0 +1,107 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.IO;
+using System.Runtime.InteropServices;
+using Microsoft.DotNet.Cli.Utils;
+using Microsoft.NET.TestFramework;
+using Microsoft.NET.TestFramework.Assertions;
+using Microsoft.NET.TestFramework.Commands;
+using Microsoft.NET.TestFramework.ProjectConstruction;
+using Xunit;
+using System.Xml.Linq;
+using System.Runtime.CompilerServices;
+using System;
+using Microsoft.Extensions.DependencyModel;
+using Xunit.Abstractions;
+
+namespace Microsoft.NET.Publish.Tests
+{
+    public class GivenThatWeWantToPublishAClickOnceProject : SdkTest
+    {
+        public GivenThatWeWantToPublishAClickOnceProject(ITestOutputHelper log) : base(log)
+        {
+        }
+
+        [FullMSBuildOnlyTheory(Skip = "Disabled for now")]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void It_publishes_with_a_publish_profile(bool? publishSingleFile)
+        {
+            var tfm = "netcoreapp3.1";
+            var testProject = new TestProject()
+            {
+                Name = "ConsoleWithPublishProfile",
+                TargetFrameworks = tfm,
+                IsSdkProject = true,
+                ProjectSdk = "Microsoft.NET.Sdk;Microsoft.NET.Sdk.Publish",
+                IsExe = true,
+            };
+            testProject.PackageReferences.Add(new TestPackageReference("NewtonSoft.Json", "9.0.1"));
+
+            var testProjectInstance = _testAssetsManager.CreateTestProject(testProject);
+
+            var projectDirectory = Path.Combine(testProjectInstance.Path, testProject.Name);
+            var publishProfilesDirectory = Path.Combine(projectDirectory, "Properties", "PublishProfiles");
+            Directory.CreateDirectory(publishProfilesDirectory);
+
+            File.WriteAllText(Path.Combine(publishProfilesDirectory, "test.pubxml"), $@"
+<Project>
+  <PropertyGroup>
+    <PublishUrl>publish\</PublishUrl>
+    <Install>true</Install>
+    <InstallFrom>Disk</InstallFrom>
+    <ApplicationRevision>4</ApplicationRevision>
+    <ApplicationVersion>1.2.3.*</ApplicationVersion>
+    <PublishProtocol>ClickOnce</PublishProtocol>
+    <BootstrapperEnabled>True</BootstrapperEnabled>
+    <UpdateEnabled>False</UpdateEnabled>
+    <IsWebBootstrapper>false</IsWebBootstrapper>
+    <CreateWebPageOnPublish>true</CreateWebPageOnPublish>
+    <GenerateManifests>true</GenerateManifests>
+    <PublishWizardCompleted>true</PublishWizardCompleted>
+    <SelfContained>false</SelfContained>
+    {(publishSingleFile.HasValue ? $"<PublishSingleFile>{publishSingleFile}</PublishSingleFile>" : "")}
+  </PropertyGroup>
+</Project>
+");
+
+            var command = new PublishCommand(Log, projectDirectory);
+            command
+                .Execute("/p:PublishProfile=test")
+                .Should()
+                .Pass();
+
+            var output = command.GetOutputDirectory(targetFramework: tfm);
+
+            output.Should().HaveFiles(new[] {
+                $"app.Publish\\setup.exe",
+                $"app.Publish\\{testProject.Name}.application",
+                $"app.Publish\\application files\\{testProject.Name}_1_2_3_4\\launcher{Constants.ExeSuffix}",
+            });
+
+            if (publishSingleFile ?? true)
+            {
+                output.Should().HaveFiles(new[] {
+                    $"app.Publish\\application files\\{testProject.Name}_1_2_3_4\\{testProject.Name}{Constants.ExeSuffix}",
+                    $"app.Publish\\application files\\{testProject.Name}_1_2_3_4\\{testProject.Name}{Constants.ExeSuffix}.manifest",
+                });
+                output.Should().NotHaveFiles(new[] {
+                    $"app.Publish\\application files\\{testProject.Name}_1_2_3_4\\{testProject.Name}.dll",
+                    $"app.Publish\\application files\\{testProject.Name}_1_2_3_4\\{testProject.Name}.dll.manifest",
+                });
+            }
+            else
+            {
+                output.Should().HaveFiles(new[] {
+                    $"app.Publish\\application files\\{testProject.Name}_1_2_3_4\\{testProject.Name}.dll",
+                    $"app.Publish\\application files\\{testProject.Name}_1_2_3_4\\{testProject.Name}.dll.manifest",
+                    $"app.Publish\\application files\\{testProject.Name}_1_2_3_4\\Newtonsoft.Json.dll",
+                    $"app.Publish\\application files\\{testProject.Name}_1_2_3_4\\{testProject.Name}.deps.json",
+                    $"app.Publish\\application files\\{testProject.Name}_1_2_3_4\\{testProject.Name}.runtimeconfig.json",
+                    $"app.Publish\\application files\\{testProject.Name}_1_2_3_4\\{testProject.Name}{Constants.ExeSuffix}",
+                });
+            }
+        }
+    }
+}


### PR DESCRIPTION
1. ClickOnce publishing needs to inject some of its targets into the publishing process. To do this, a extension point has been added to MS.Net,Publish.targets to import targets for any providers that need to plug into the publishing process. The extension point is based on the PublishProtocol property in the .pubxml file.
2. Adding a ClickOnce targets file that will get imported into the MS.Net.Publish.targets file and extend the publishing process by setting some custom properties and injecting its targets into the publishing target dependencies. 