### PR TITLE
Update Microsoft.CodeAnalysis.NetAnalyzers.props

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.Analyzers.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.Analyzers.targets
@@ -51,8 +51,8 @@ Copyright (c) .NET Foundation. All rights reserved.
                              '$(AnalysisLevel)' == 'preview'">9999</WarningLevel>
 
   </PropertyGroup>
-  <Import Project="$(MSBuildThisFileDirectory)..\analyzers\build\Microsoft.CodeAnalysis.NetAnalyzers.props"
-          Condition="$(EnableNETAnalyzers)" />
+  <!-- Unconditionally import 'Microsoft.CodeAnalysis.NetAnalyzers.props' for supporting https://github.com/dotnet/roslyn-analyzers/issues/3977 -->
+  <Import Project="$(MSBuildThisFileDirectory)..\analyzers\build\Microsoft.CodeAnalysis.NetAnalyzers.props"/>
   <Import Project="$(MSBuildThisFileDirectory)..\analyzers\build\Microsoft.CodeAnalysis.NetAnalyzers.targets"
           Condition="$(EnableNETAnalyzers)" />
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.Analyzers.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.Analyzers.targets
@@ -51,8 +51,9 @@ Copyright (c) .NET Foundation. All rights reserved.
                              '$(AnalysisLevel)' == 'preview'">9999</WarningLevel>
 
   </PropertyGroup>
-  <!-- Unconditionally import 'Microsoft.CodeAnalysis.NetAnalyzers.props' for supporting https://github.com/dotnet/roslyn-analyzers/issues/3977 -->
-  <Import Project="$(MSBuildThisFileDirectory)..\analyzers\build\Microsoft.CodeAnalysis.NetAnalyzers.props"/>
+  <!-- Unconditionally import 'Microsoft.CodeAnalysis.NetAnalyzers.props' for all C# and VB projects for supporting https://github.com/dotnet/roslyn-analyzers/issues/3977 -->
+  <Import Project="$(MSBuildThisFileDirectory)..\analyzers\build\Microsoft.CodeAnalysis.NetAnalyzers.props"
+          Condition="'$(Language)' == 'C#' Or '$(Language)' == 'VB'" />
   <Import Project="$(MSBuildThisFileDirectory)..\analyzers\build\Microsoft.CodeAnalysis.NetAnalyzers.targets"
           Condition="$(EnableNETAnalyzers)" />
 


### PR DESCRIPTION
Unconditionally import `Microsoft.CodeAnalysis.NetAnalyzers.props` for supporting dotnet/roslyn-analyzers#3977
See dotnet/roslyn-analyzers#4092 for details