### PR TITLE
Publish Installers And Checksums

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -168,6 +168,7 @@ stages:
       enableSigningValidation: false
       enableNugetValidation: false
       enableSourceLinkValidation: false
+      publishInstallersAndChecksums: true
       SDLValidationParameters:
         enable: false
         params: ' -SourceToolsList @("policheck","credscan")


### PR DESCRIPTION
Ensures that the sdk zip file goes to the appropriate places (dotnetcli).