### PR TITLE
Add Compiler Visible Properties

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.Analyzers.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.Analyzers.targets
@@ -103,4 +103,10 @@ Copyright (c) .NET Foundation. All rights reserved.
       Include="$(MSBuildThisFileDirectory)..\codestyle\vb\Microsoft.CodeAnalysis.VisualBasic.CodeStyle.Fixes.dll"
       IsImplicitlyDefined="true" />
   </ItemGroup>
+  
+  <!-- Build Properties Exposed to CodeStyle Analyzers -->
+  <ItemGroup Condition="$(EnforceCodeStyleInBuild)>
+    <CompilerVisibleProperty Include="RootNamespace" />
+	  <CompilerVisibleProperty Include="ProjectDir" />
+  </ItemGroup>
 </Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.Analyzers.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.Analyzers.targets
@@ -105,8 +105,8 @@ Copyright (c) .NET Foundation. All rights reserved.
   </ItemGroup>
   
   <!-- Build Properties Exposed to CodeStyle Analyzers -->
-  <ItemGroup>
+  <ItemGroup Condition="'$(Language)' == 'C#' Or '$(Language)' == 'VB'">
     <CompilerVisibleProperty Include="RootNamespace" />
-	  <CompilerVisibleProperty Include="ProjectDir" />
+    <CompilerVisibleProperty Include="ProjectDir" />
   </ItemGroup>
 </Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.Analyzers.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.Analyzers.targets
@@ -105,7 +105,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   </ItemGroup>
   
   <!-- Build Properties Exposed to CodeStyle Analyzers -->
-  <ItemGroup Condition="$(EnforceCodeStyleInBuild)>
+  <ItemGroup Condition="$(EnforceCodeStyleInBuild)">
     <CompilerVisibleProperty Include="RootNamespace" />
 	  <CompilerVisibleProperty Include="ProjectDir" />
   </ItemGroup>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.Analyzers.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.Analyzers.targets
@@ -105,7 +105,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   </ItemGroup>
   
   <!-- Build Properties Exposed to CodeStyle Analyzers -->
-  <ItemGroup Condition="$(EnforceCodeStyleInBuild)">
+  <ItemGroup>
     <CompilerVisibleProperty Include="RootNamespace" />
 	  <CompilerVisibleProperty Include="ProjectDir" />
   </ItemGroup>


### PR DESCRIPTION
The Build properties `RootNamespace` and `ProjectDir` are needed for the new Namespace Analyzer in Roslyn to work outside of VS. Adding these properties to the Dotent SDK ensures that the analyzer works in dotnet build scenarios.