### PR TITLE
Pass architecture to bundler

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -9,41 +9,41 @@
       <Uri>https://github.com/dotnet/templating</Uri>
       <Sha>da62f3656cac0ac4bfb6b012bc072b3499f78e6c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Ref" Version="5.0.0-rc.2.20454.25">
+    <Dependency Name="Microsoft.NETCore.App.Ref" Version="5.0.0-rc.2.20458.8">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>a916def25585f474712c7e2cbd763977c3c37ff6</Sha>
+      <Sha>98dd0970541944e149783bf8c1782472cded18fc</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Internal" Version="5.0.0-rc.2.20454.25">
+    <Dependency Name="Microsoft.NETCore.App.Internal" Version="5.0.0-rc.2.20458.8">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>a916def25585f474712c7e2cbd763977c3c37ff6</Sha>
+      <Sha>98dd0970541944e149783bf8c1782472cded18fc</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="5.0.0-rc.2.20454.25">
+    <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="5.0.0-rc.2.20458.8">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>a916def25585f474712c7e2cbd763977c3c37ff6</Sha>
+      <Sha>98dd0970541944e149783bf8c1782472cded18fc</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Host.win-x64" Version="5.0.0-rc.2.20454.25">
+    <Dependency Name="Microsoft.NETCore.App.Host.win-x64" Version="5.0.0-rc.2.20458.8">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>a916def25585f474712c7e2cbd763977c3c37ff6</Sha>
+      <Sha>98dd0970541944e149783bf8c1782472cded18fc</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.Platforms" Version="5.0.0-rc.2.20454.25">
+    <Dependency Name="Microsoft.NETCore.Platforms" Version="5.0.0-rc.2.20458.8">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>a916def25585f474712c7e2cbd763977c3c37ff6</Sha>
+      <Sha>98dd0970541944e149783bf8c1782472cded18fc</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="5.0.0-beta.20431.1">
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>4be47e467013f8a07a1ed7b6e49e39c8150bde54</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.HostModel" Version="5.0.0-rc.2.20454.25">
+    <Dependency Name="Microsoft.NET.HostModel" Version="5.0.0-rc.2.20458.8">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>a916def25585f474712c7e2cbd763977c3c37ff6</Sha>
+      <Sha>98dd0970541944e149783bf8c1782472cded18fc</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.DependencyModel" Version="5.0.0-rc.2.20454.25">
+    <Dependency Name="Microsoft.Extensions.DependencyModel" Version="5.0.0-rc.2.20458.8">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>a916def25585f474712c7e2cbd763977c3c37ff6</Sha>
+      <Sha>98dd0970541944e149783bf8c1782472cded18fc</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.DotNetHostResolver" Version="5.0.0-rc.2.20454.25">
+    <Dependency Name="Microsoft.NETCore.DotNetHostResolver" Version="5.0.0-rc.2.20458.8">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>a916def25585f474712c7e2cbd763977c3c37ff6</Sha>
+      <Sha>98dd0970541944e149783bf8c1782472cded18fc</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.Cli.CommandLine" Version="1.0.0-preview.19208.1">
       <Uri>https://github.com/dotnet/CliCommandLineParser</Uri>
@@ -89,21 +89,21 @@
       <Uri>https://github.com/mono/linker</Uri>
       <Sha>863b5502cc43b1c75b5a93ac395899f8d8b5f0a4</Sha>
     </Dependency>
-    <Dependency Name="System.CodeDom" Version="5.0.0-rc.2.20454.25">
+    <Dependency Name="System.CodeDom" Version="5.0.0-rc.2.20458.8">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>a916def25585f474712c7e2cbd763977c3c37ff6</Sha>
+      <Sha>98dd0970541944e149783bf8c1782472cded18fc</Sha>
     </Dependency>
-    <Dependency Name="System.Security.Cryptography.ProtectedData" Version="5.0.0-rc.2.20454.25">
+    <Dependency Name="System.Security.Cryptography.ProtectedData" Version="5.0.0-rc.2.20458.8">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>a916def25585f474712c7e2cbd763977c3c37ff6</Sha>
+      <Sha>98dd0970541944e149783bf8c1782472cded18fc</Sha>
     </Dependency>
-    <Dependency Name="System.Text.Encoding.CodePages" Version="5.0.0-rc.2.20454.25">
+    <Dependency Name="System.Text.Encoding.CodePages" Version="5.0.0-rc.2.20458.8">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>a916def25585f474712c7e2cbd763977c3c37ff6</Sha>
+      <Sha>98dd0970541944e149783bf8c1782472cded18fc</Sha>
     </Dependency>
-    <Dependency Name="System.Resources.Extensions" Version="5.0.0-rc.2.20454.25">
+    <Dependency Name="System.Resources.Extensions" Version="5.0.0-rc.2.20458.8">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>a916def25585f474712c7e2cbd763977c3c37ff6</Sha>
+      <Sha>98dd0970541944e149783bf8c1782472cded18fc</Sha>
     </Dependency>
     <Dependency Name="Microsoft.WindowsDesktop.App.Runtime.win-x64" Version="5.0.0-rc.2.20454.1">
       <Uri>https://github.com/dotnet/windowsdesktop</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -29,7 +29,7 @@
     <SystemReflectionMetadataVersion>1.8.0</SystemReflectionMetadataVersion>
     <MicrosoftDotNetSignToolVersion>5.0.0-beta.20431.1</MicrosoftDotNetSignToolVersion>
     <MicrosoftWebXdtPackageVersion>3.1.0</MicrosoftWebXdtPackageVersion>
-    <SystemSecurityCryptographyProtectedDataPackageVersion>5.0.0-rc.2.20454.25</SystemSecurityCryptographyProtectedDataPackageVersion>
+    <SystemSecurityCryptographyProtectedDataPackageVersion>5.0.0-rc.2.20458.8</SystemSecurityCryptographyProtectedDataPackageVersion>
     <SystemCollectionsSpecializedPackageVersion>4.3.0</SystemCollectionsSpecializedPackageVersion>
     <SystemXmlXmlDocumentPackageVersion>4.3.0</SystemXmlXmlDocumentPackageVersion>
     <WebDeploymentPackageVersion>4.0.5</WebDeploymentPackageVersion>
@@ -37,13 +37,13 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/runtime -->
-    <MicrosoftNETCoreAppRefPackageVersion>5.0.0-rc.2.20454.25</MicrosoftNETCoreAppRefPackageVersion>
-    <MicrosoftNETCoreAppInternalPackageVersion>5.0.0-rc.2.20454.25</MicrosoftNETCoreAppInternalPackageVersion>
-    <MicrosoftNETCoreAppRuntimewinx64PackageVersion>5.0.0-rc.2.20454.25</MicrosoftNETCoreAppRuntimewinx64PackageVersion>
+    <MicrosoftNETCoreAppRefPackageVersion>5.0.0-rc.2.20458.8</MicrosoftNETCoreAppRefPackageVersion>
+    <MicrosoftNETCoreAppInternalPackageVersion>5.0.0-rc.2.20458.8</MicrosoftNETCoreAppInternalPackageVersion>
+    <MicrosoftNETCoreAppRuntimewinx64PackageVersion>5.0.0-rc.2.20458.8</MicrosoftNETCoreAppRuntimewinx64PackageVersion>
     <MicrosoftNETCoreAppRuntimePackageVersion>$(MicrosoftNETCoreAppRuntimewinx64PackageVersion)</MicrosoftNETCoreAppRuntimePackageVersion>
-    <MicrosoftExtensionsDependencyModelPackageVersion>5.0.0-rc.2.20454.25</MicrosoftExtensionsDependencyModelPackageVersion>
-    <MicrosoftNETCoreDotNetHostResolverPackageVersion>5.0.0-rc.2.20454.25</MicrosoftNETCoreDotNetHostResolverPackageVersion>
-    <MicrosoftNETHostModelVersion>5.0.0-rc.2.20454.25</MicrosoftNETHostModelVersion>
+    <MicrosoftExtensionsDependencyModelPackageVersion>5.0.0-rc.2.20458.8</MicrosoftExtensionsDependencyModelPackageVersion>
+    <MicrosoftNETCoreDotNetHostResolverPackageVersion>5.0.0-rc.2.20458.8</MicrosoftNETCoreDotNetHostResolverPackageVersion>
+    <MicrosoftNETHostModelVersion>5.0.0-rc.2.20458.8</MicrosoftNETHostModelVersion>
     <MicrosoftExtensionsDependencyModelVersion>$(MicrosoftExtensionsDependencyModelPackageVersion)</MicrosoftExtensionsDependencyModelVersion>
   </PropertyGroup>
   <PropertyGroup>
@@ -74,10 +74,10 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/runtime -->
-    <SystemCodeDomPackageVersion>5.0.0-rc.2.20454.25</SystemCodeDomPackageVersion>
-    <SystemTextEncodingCodePagesPackageVersion>5.0.0-rc.2.20454.25</SystemTextEncodingCodePagesPackageVersion>
+    <SystemCodeDomPackageVersion>5.0.0-rc.2.20458.8</SystemCodeDomPackageVersion>
+    <SystemTextEncodingCodePagesPackageVersion>5.0.0-rc.2.20458.8</SystemTextEncodingCodePagesPackageVersion>
     <SystemSecurityCryptographyProtectedDataPackageVersion>5.0.0-preview.7.20307.4</SystemSecurityCryptographyProtectedDataPackageVersion>
-    <SystemResourcesExtensionsPackageVersion>5.0.0-rc.2.20454.25</SystemResourcesExtensionsPackageVersion>
+    <SystemResourcesExtensionsPackageVersion>5.0.0-rc.2.20458.8</SystemResourcesExtensionsPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/roslyn-analyzers -->

--- a/src/Tasks/Microsoft.NET.Build.Tasks/GenerateBundle.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/GenerateBundle.cs
@@ -37,9 +37,7 @@ namespace Microsoft.NET.Build.Tasks
         protected override void ExecuteCore()
         {
             OSPlatform targetOS = RuntimeIdentifier.StartsWith("win") ? OSPlatform.Windows :
-                                  RuntimeIdentifier.StartsWith("osx") ? OSPlatform.OSX :
-                                  RuntimeIdentifier.StartsWith("linux") ? OSPlatform.Linux :
-                                  throw new ArgumentException(nameof (RuntimeIdentifier));
+                                  RuntimeIdentifier.StartsWith("osx") ? OSPlatform.OSX : OSPlatform.Linux;
 
             Architecture targetArch = RuntimeIdentifier.EndsWith("-x64") || RuntimeIdentifier.Contains("-x64-") ? Architecture.X64 :
                                       RuntimeIdentifier.EndsWith("-x86") || RuntimeIdentifier.Contains("-x86-") ? Architecture.X86 :

--- a/src/Tasks/Microsoft.NET.Build.Tasks/GenerateBundle.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/GenerateBundle.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Build.Framework;
@@ -37,14 +37,29 @@ namespace Microsoft.NET.Build.Tasks
         protected override void ExecuteCore()
         {
             OSPlatform targetOS = RuntimeIdentifier.StartsWith("win") ? OSPlatform.Windows :
-                                  RuntimeIdentifier.StartsWith("osx") ? OSPlatform.OSX : OSPlatform.Linux;
+                                  RuntimeIdentifier.StartsWith("osx") ? OSPlatform.OSX :
+                                  RuntimeIdentifier.StartsWith("linux") ? OSPlatform.Linux :
+                                  throw new ArgumentException(nameof (RuntimeIdentifier));
+
+            Architecture targetArch = RuntimeIdentifier.EndsWith("x64") ? Architecture.X64 :
+                                      RuntimeIdentifier.EndsWith("x86") ? Architecture.X86 :
+                                      RuntimeIdentifier.EndsWith("arm64") ? Architecture.Arm64 :
+                                      RuntimeIdentifier.EndsWith("arm") ? Architecture.Arm :
+                                      throw new ArgumentException(nameof (RuntimeIdentifier));
 
             BundleOptions options = BundleOptions.None;
             options |= IncludeNativeLibraries ? BundleOptions.BundleNativeBinaries : BundleOptions.None;
             options |= IncludeAllContent ? BundleOptions.BundleAllContent : BundleOptions.None;
             options |= IncludeSymbols ? BundleOptions.BundleSymbolFiles : BundleOptions.None;
 
-            var bundler = new Bundler(AppHostName, OutputDir, options, targetOS, new Version(TargetFrameworkVersion), ShowDiagnosticOutput);
+            var bundler = new Bundler(
+                AppHostName,
+                OutputDir,
+                options,
+                targetOS,
+                targetArch,
+                new Version(TargetFrameworkVersion),
+                ShowDiagnosticOutput);
 
             var fileSpec = new List<FileSpec>(FilesToBundle.Length);
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/GenerateBundle.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/GenerateBundle.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation and contributors. All rights reserved.
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Build.Framework;
@@ -41,10 +41,10 @@ namespace Microsoft.NET.Build.Tasks
                                   RuntimeIdentifier.StartsWith("linux") ? OSPlatform.Linux :
                                   throw new ArgumentException(nameof (RuntimeIdentifier));
 
-            Architecture targetArch = RuntimeIdentifier.EndsWith("x64") ? Architecture.X64 :
-                                      RuntimeIdentifier.EndsWith("x86") ? Architecture.X86 :
-                                      RuntimeIdentifier.EndsWith("arm64") ? Architecture.Arm64 :
-                                      RuntimeIdentifier.EndsWith("arm") ? Architecture.Arm :
+            Architecture targetArch = RuntimeIdentifier.EndsWith("-x64") || RuntimeIdentifier.Contains("-x64-") ? Architecture.X64 :
+                                      RuntimeIdentifier.EndsWith("-x86") || RuntimeIdentifier.Contains("-x86-") ? Architecture.X86 :
+                                      RuntimeIdentifier.EndsWith("-arm64") || RuntimeIdentifier.Contains("-arm64-") ? Architecture.Arm64 :
+                                      RuntimeIdentifier.EndsWith("-arm") || RuntimeIdentifier.Contains("-arm-") ? Architecture.Arm :
                                       throw new ArgumentException(nameof (RuntimeIdentifier));
 
             BundleOptions options = BundleOptions.None;


### PR DESCRIPTION
To fix ARM64 Linux behavior. See https://github.com/dotnet/runtime/pull/41809.
This depends on the runtime change, but I wanted to get feedback before that change flows.