### PR TITLE
Added '-e, --environment' option to 'dotnet test'.

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-test/LocalizableStrings.resx
+++ b/src/Cli/dotnet/commands/dotnet-test/LocalizableStrings.resx
@@ -261,4 +261,18 @@ This option is currently supported only on Windows together with netcoreapp2.1 a
   <data name="HangTimeoutArgumentName" xml:space="preserve">
     <value>TIMESPAN</value>
   </data>
+  <data name="CmdEnvironmentVariableDescription" xml:space="preserve">
+    <value>Sets the value of an environment variable. 
+Creates the variable if it does not exist, overrides if it does. 
+This will force the tests to be run in an isolated process. 
+This argument can be specified multiple times to provide multiple variables.
+
+Examples:
+-e VARIABLE1=VALUE1
+-e ANOTHER_VARIABLE="VALUE WITH SPACES"
+-e ANOTHER_VARIABLE="VALUE;seperated with;semicolons"</value>
+  </data>
+  <data name="CmdEnvironmentVariableExpression" xml:space="preserve">
+    <value>NAME="VALUE"</value>
+  </data>
 </root>

--- a/src/Cli/dotnet/commands/dotnet-test/LocalizableStrings.resx
+++ b/src/Cli/dotnet/commands/dotnet-test/LocalizableStrings.resx
@@ -268,9 +268,11 @@ This will force the tests to be run in an isolated process.
 This argument can be specified multiple times to provide multiple variables.
 
 Examples:
--e VARIABLE1=VALUE1
--e ANOTHER_VARIABLE="VALUE WITH SPACES"
--e ANOTHER_VARIABLE="VALUE;seperated with;semicolons"</value>
+-e VARIABLE=abc
+-e VARIABLE="value with spaces"
+-e VARIABLE="value;seperated with;semicolons"
+-e VAR1=abc -e VAR2=def -e VAR3=ghi
+</value>
   </data>
   <data name="CmdEnvironmentVariableExpression" xml:space="preserve">
     <value>NAME="VALUE"</value>

--- a/src/Cli/dotnet/commands/dotnet-test/TestCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/TestCommandParser.cs
@@ -32,6 +32,11 @@ namespace Microsoft.DotNet.Cli
                         Accept.NoArguments()
                               .ForwardAsSingle(o => "-property:VSTestListTests=true")),
                   Create.Option(
+                        "-e|--environment",
+                        LocalizableStrings.CmdEnvironmentVariableDescription,
+                        Accept.OneOrMoreArguments()
+                              .With(name: LocalizableStrings.CmdEnvironmentVariableExpression)),
+                  Create.Option(
                         "--filter",
                         LocalizableStrings.CmdTestCaseFilterDescription,
                         Accept.ExactlyOneArgument()

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.cs.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.cs.xlf
@@ -65,18 +65,22 @@ This will force the tests to be run in an isolated process.
 This argument can be specified multiple times to provide multiple variables.
 
 Examples:
--e VARIABLE1=VALUE1
--e ANOTHER_VARIABLE="VALUE WITH SPACES"
--e ANOTHER_VARIABLE="VALUE;seperated with;semicolons"</source>
+-e VARIABLE=abc
+-e VARIABLE="value with spaces"
+-e VARIABLE="value;seperated with;semicolons"
+-e VAR1=abc -e VAR2=def -e VAR3=ghi
+</source>
         <target state="new">Sets the value of an environment variable. 
 Creates the variable if it does not exist, overrides if it does. 
 This will force the tests to be run in an isolated process. 
 This argument can be specified multiple times to provide multiple variables.
 
 Examples:
--e VARIABLE1=VALUE1
--e ANOTHER_VARIABLE="VALUE WITH SPACES"
--e ANOTHER_VARIABLE="VALUE;seperated with;semicolons"</target>
+-e VARIABLE=abc
+-e VARIABLE="value with spaces"
+-e VARIABLE="value;seperated with;semicolons"
+-e VAR1=abc -e VAR2=def -e VAR3=ghi
+</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdEnvironmentVariableExpression">

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.cs.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.cs.xlf
@@ -58,6 +58,32 @@ For MSTest, the timeout is used for all testcases.
 This option is currently supported only on Windows together with netcoreapp2.1 and newer. And on Linux with netcoreapp3.1 and newer. OSX and UWP are not supported.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdEnvironmentVariableDescription">
+        <source>Sets the value of an environment variable. 
+Creates the variable if it does not exist, overrides if it does. 
+This will force the tests to be run in an isolated process. 
+This argument can be specified multiple times to provide multiple variables.
+
+Examples:
+-e VARIABLE1=VALUE1
+-e ANOTHER_VARIABLE="VALUE WITH SPACES"
+-e ANOTHER_VARIABLE="VALUE;seperated with;semicolons"</source>
+        <target state="new">Sets the value of an environment variable. 
+Creates the variable if it does not exist, overrides if it does. 
+This will force the tests to be run in an isolated process. 
+This argument can be specified multiple times to provide multiple variables.
+
+Examples:
+-e VARIABLE1=VALUE1
+-e ANOTHER_VARIABLE="VALUE WITH SPACES"
+-e ANOTHER_VARIABLE="VALUE;seperated with;semicolons"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdEnvironmentVariableExpression">
+        <source>NAME="VALUE"</source>
+        <target state="new">NAME="VALUE"</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdNoLogo">
         <source>Run test(s), without displaying Microsoft Testplatform banner</source>
         <target state="translated">Spustit testy bez zobrazení nápisu Microsoft Testplatform</target>

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.de.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.de.xlf
@@ -65,18 +65,22 @@ This will force the tests to be run in an isolated process.
 This argument can be specified multiple times to provide multiple variables.
 
 Examples:
--e VARIABLE1=VALUE1
--e ANOTHER_VARIABLE="VALUE WITH SPACES"
--e ANOTHER_VARIABLE="VALUE;seperated with;semicolons"</source>
+-e VARIABLE=abc
+-e VARIABLE="value with spaces"
+-e VARIABLE="value;seperated with;semicolons"
+-e VAR1=abc -e VAR2=def -e VAR3=ghi
+</source>
         <target state="new">Sets the value of an environment variable. 
 Creates the variable if it does not exist, overrides if it does. 
 This will force the tests to be run in an isolated process. 
 This argument can be specified multiple times to provide multiple variables.
 
 Examples:
--e VARIABLE1=VALUE1
--e ANOTHER_VARIABLE="VALUE WITH SPACES"
--e ANOTHER_VARIABLE="VALUE;seperated with;semicolons"</target>
+-e VARIABLE=abc
+-e VARIABLE="value with spaces"
+-e VARIABLE="value;seperated with;semicolons"
+-e VAR1=abc -e VAR2=def -e VAR3=ghi
+</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdEnvironmentVariableExpression">

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.de.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.de.xlf
@@ -58,6 +58,32 @@ For MSTest, the timeout is used for all testcases.
 This option is currently supported only on Windows together with netcoreapp2.1 and newer. And on Linux with netcoreapp3.1 and newer. OSX and UWP are not supported.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdEnvironmentVariableDescription">
+        <source>Sets the value of an environment variable. 
+Creates the variable if it does not exist, overrides if it does. 
+This will force the tests to be run in an isolated process. 
+This argument can be specified multiple times to provide multiple variables.
+
+Examples:
+-e VARIABLE1=VALUE1
+-e ANOTHER_VARIABLE="VALUE WITH SPACES"
+-e ANOTHER_VARIABLE="VALUE;seperated with;semicolons"</source>
+        <target state="new">Sets the value of an environment variable. 
+Creates the variable if it does not exist, overrides if it does. 
+This will force the tests to be run in an isolated process. 
+This argument can be specified multiple times to provide multiple variables.
+
+Examples:
+-e VARIABLE1=VALUE1
+-e ANOTHER_VARIABLE="VALUE WITH SPACES"
+-e ANOTHER_VARIABLE="VALUE;seperated with;semicolons"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdEnvironmentVariableExpression">
+        <source>NAME="VALUE"</source>
+        <target state="new">NAME="VALUE"</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdNoLogo">
         <source>Run test(s), without displaying Microsoft Testplatform banner</source>
         <target state="translated">Test(s) ohne Anzeige des Microsoft-Testplattformbanners ausführen</target>

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.es.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.es.xlf
@@ -65,18 +65,22 @@ This will force the tests to be run in an isolated process.
 This argument can be specified multiple times to provide multiple variables.
 
 Examples:
--e VARIABLE1=VALUE1
--e ANOTHER_VARIABLE="VALUE WITH SPACES"
--e ANOTHER_VARIABLE="VALUE;seperated with;semicolons"</source>
+-e VARIABLE=abc
+-e VARIABLE="value with spaces"
+-e VARIABLE="value;seperated with;semicolons"
+-e VAR1=abc -e VAR2=def -e VAR3=ghi
+</source>
         <target state="new">Sets the value of an environment variable. 
 Creates the variable if it does not exist, overrides if it does. 
 This will force the tests to be run in an isolated process. 
 This argument can be specified multiple times to provide multiple variables.
 
 Examples:
--e VARIABLE1=VALUE1
--e ANOTHER_VARIABLE="VALUE WITH SPACES"
--e ANOTHER_VARIABLE="VALUE;seperated with;semicolons"</target>
+-e VARIABLE=abc
+-e VARIABLE="value with spaces"
+-e VARIABLE="value;seperated with;semicolons"
+-e VAR1=abc -e VAR2=def -e VAR3=ghi
+</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdEnvironmentVariableExpression">

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.es.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.es.xlf
@@ -58,6 +58,32 @@ For MSTest, the timeout is used for all testcases.
 This option is currently supported only on Windows together with netcoreapp2.1 and newer. And on Linux with netcoreapp3.1 and newer. OSX and UWP are not supported.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdEnvironmentVariableDescription">
+        <source>Sets the value of an environment variable. 
+Creates the variable if it does not exist, overrides if it does. 
+This will force the tests to be run in an isolated process. 
+This argument can be specified multiple times to provide multiple variables.
+
+Examples:
+-e VARIABLE1=VALUE1
+-e ANOTHER_VARIABLE="VALUE WITH SPACES"
+-e ANOTHER_VARIABLE="VALUE;seperated with;semicolons"</source>
+        <target state="new">Sets the value of an environment variable. 
+Creates the variable if it does not exist, overrides if it does. 
+This will force the tests to be run in an isolated process. 
+This argument can be specified multiple times to provide multiple variables.
+
+Examples:
+-e VARIABLE1=VALUE1
+-e ANOTHER_VARIABLE="VALUE WITH SPACES"
+-e ANOTHER_VARIABLE="VALUE;seperated with;semicolons"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdEnvironmentVariableExpression">
+        <source>NAME="VALUE"</source>
+        <target state="new">NAME="VALUE"</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdNoLogo">
         <source>Run test(s), without displaying Microsoft Testplatform banner</source>
         <target state="translated">Ejecutar pruebas, sin mostrar la pancarta de Microsoft Testplatform</target>

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.fr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.fr.xlf
@@ -58,6 +58,32 @@ For MSTest, the timeout is used for all testcases.
 This option is currently supported only on Windows together with netcoreapp2.1 and newer. And on Linux with netcoreapp3.1 and newer. OSX and UWP are not supported.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdEnvironmentVariableDescription">
+        <source>Sets the value of an environment variable. 
+Creates the variable if it does not exist, overrides if it does. 
+This will force the tests to be run in an isolated process. 
+This argument can be specified multiple times to provide multiple variables.
+
+Examples:
+-e VARIABLE1=VALUE1
+-e ANOTHER_VARIABLE="VALUE WITH SPACES"
+-e ANOTHER_VARIABLE="VALUE;seperated with;semicolons"</source>
+        <target state="new">Sets the value of an environment variable. 
+Creates the variable if it does not exist, overrides if it does. 
+This will force the tests to be run in an isolated process. 
+This argument can be specified multiple times to provide multiple variables.
+
+Examples:
+-e VARIABLE1=VALUE1
+-e ANOTHER_VARIABLE="VALUE WITH SPACES"
+-e ANOTHER_VARIABLE="VALUE;seperated with;semicolons"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdEnvironmentVariableExpression">
+        <source>NAME="VALUE"</source>
+        <target state="new">NAME="VALUE"</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdNoLogo">
         <source>Run test(s), without displaying Microsoft Testplatform banner</source>
         <target state="translated">Exécute le ou les tests, sans afficher la bannière Microsoft Testplatform</target>

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.fr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.fr.xlf
@@ -65,18 +65,22 @@ This will force the tests to be run in an isolated process.
 This argument can be specified multiple times to provide multiple variables.
 
 Examples:
--e VARIABLE1=VALUE1
--e ANOTHER_VARIABLE="VALUE WITH SPACES"
--e ANOTHER_VARIABLE="VALUE;seperated with;semicolons"</source>
+-e VARIABLE=abc
+-e VARIABLE="value with spaces"
+-e VARIABLE="value;seperated with;semicolons"
+-e VAR1=abc -e VAR2=def -e VAR3=ghi
+</source>
         <target state="new">Sets the value of an environment variable. 
 Creates the variable if it does not exist, overrides if it does. 
 This will force the tests to be run in an isolated process. 
 This argument can be specified multiple times to provide multiple variables.
 
 Examples:
--e VARIABLE1=VALUE1
--e ANOTHER_VARIABLE="VALUE WITH SPACES"
--e ANOTHER_VARIABLE="VALUE;seperated with;semicolons"</target>
+-e VARIABLE=abc
+-e VARIABLE="value with spaces"
+-e VARIABLE="value;seperated with;semicolons"
+-e VAR1=abc -e VAR2=def -e VAR3=ghi
+</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdEnvironmentVariableExpression">

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.it.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.it.xlf
@@ -58,6 +58,32 @@ For MSTest, the timeout is used for all testcases.
 This option is currently supported only on Windows together with netcoreapp2.1 and newer. And on Linux with netcoreapp3.1 and newer. OSX and UWP are not supported.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdEnvironmentVariableDescription">
+        <source>Sets the value of an environment variable. 
+Creates the variable if it does not exist, overrides if it does. 
+This will force the tests to be run in an isolated process. 
+This argument can be specified multiple times to provide multiple variables.
+
+Examples:
+-e VARIABLE1=VALUE1
+-e ANOTHER_VARIABLE="VALUE WITH SPACES"
+-e ANOTHER_VARIABLE="VALUE;seperated with;semicolons"</source>
+        <target state="new">Sets the value of an environment variable. 
+Creates the variable if it does not exist, overrides if it does. 
+This will force the tests to be run in an isolated process. 
+This argument can be specified multiple times to provide multiple variables.
+
+Examples:
+-e VARIABLE1=VALUE1
+-e ANOTHER_VARIABLE="VALUE WITH SPACES"
+-e ANOTHER_VARIABLE="VALUE;seperated with;semicolons"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdEnvironmentVariableExpression">
+        <source>NAME="VALUE"</source>
+        <target state="new">NAME="VALUE"</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdNoLogo">
         <source>Run test(s), without displaying Microsoft Testplatform banner</source>
         <target state="translated">Esegui test senza visualizzare il banner di Microsoft Testplatform</target>

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.it.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.it.xlf
@@ -65,18 +65,22 @@ This will force the tests to be run in an isolated process.
 This argument can be specified multiple times to provide multiple variables.
 
 Examples:
--e VARIABLE1=VALUE1
--e ANOTHER_VARIABLE="VALUE WITH SPACES"
--e ANOTHER_VARIABLE="VALUE;seperated with;semicolons"</source>
+-e VARIABLE=abc
+-e VARIABLE="value with spaces"
+-e VARIABLE="value;seperated with;semicolons"
+-e VAR1=abc -e VAR2=def -e VAR3=ghi
+</source>
         <target state="new">Sets the value of an environment variable. 
 Creates the variable if it does not exist, overrides if it does. 
 This will force the tests to be run in an isolated process. 
 This argument can be specified multiple times to provide multiple variables.
 
 Examples:
--e VARIABLE1=VALUE1
--e ANOTHER_VARIABLE="VALUE WITH SPACES"
--e ANOTHER_VARIABLE="VALUE;seperated with;semicolons"</target>
+-e VARIABLE=abc
+-e VARIABLE="value with spaces"
+-e VARIABLE="value;seperated with;semicolons"
+-e VAR1=abc -e VAR2=def -e VAR3=ghi
+</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdEnvironmentVariableExpression">

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.ja.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.ja.xlf
@@ -58,6 +58,32 @@ For MSTest, the timeout is used for all testcases.
 This option is currently supported only on Windows together with netcoreapp2.1 and newer. And on Linux with netcoreapp3.1 and newer. OSX and UWP are not supported.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdEnvironmentVariableDescription">
+        <source>Sets the value of an environment variable. 
+Creates the variable if it does not exist, overrides if it does. 
+This will force the tests to be run in an isolated process. 
+This argument can be specified multiple times to provide multiple variables.
+
+Examples:
+-e VARIABLE1=VALUE1
+-e ANOTHER_VARIABLE="VALUE WITH SPACES"
+-e ANOTHER_VARIABLE="VALUE;seperated with;semicolons"</source>
+        <target state="new">Sets the value of an environment variable. 
+Creates the variable if it does not exist, overrides if it does. 
+This will force the tests to be run in an isolated process. 
+This argument can be specified multiple times to provide multiple variables.
+
+Examples:
+-e VARIABLE1=VALUE1
+-e ANOTHER_VARIABLE="VALUE WITH SPACES"
+-e ANOTHER_VARIABLE="VALUE;seperated with;semicolons"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdEnvironmentVariableExpression">
+        <source>NAME="VALUE"</source>
+        <target state="new">NAME="VALUE"</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdNoLogo">
         <source>Run test(s), without displaying Microsoft Testplatform banner</source>
         <target state="translated">Microsoft Testplatform バナーを表示せずにテストを実行する</target>

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.ja.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.ja.xlf
@@ -65,18 +65,22 @@ This will force the tests to be run in an isolated process.
 This argument can be specified multiple times to provide multiple variables.
 
 Examples:
--e VARIABLE1=VALUE1
--e ANOTHER_VARIABLE="VALUE WITH SPACES"
--e ANOTHER_VARIABLE="VALUE;seperated with;semicolons"</source>
+-e VARIABLE=abc
+-e VARIABLE="value with spaces"
+-e VARIABLE="value;seperated with;semicolons"
+-e VAR1=abc -e VAR2=def -e VAR3=ghi
+</source>
         <target state="new">Sets the value of an environment variable. 
 Creates the variable if it does not exist, overrides if it does. 
 This will force the tests to be run in an isolated process. 
 This argument can be specified multiple times to provide multiple variables.
 
 Examples:
--e VARIABLE1=VALUE1
--e ANOTHER_VARIABLE="VALUE WITH SPACES"
--e ANOTHER_VARIABLE="VALUE;seperated with;semicolons"</target>
+-e VARIABLE=abc
+-e VARIABLE="value with spaces"
+-e VARIABLE="value;seperated with;semicolons"
+-e VAR1=abc -e VAR2=def -e VAR3=ghi
+</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdEnvironmentVariableExpression">

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.ko.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.ko.xlf
@@ -65,18 +65,22 @@ This will force the tests to be run in an isolated process.
 This argument can be specified multiple times to provide multiple variables.
 
 Examples:
--e VARIABLE1=VALUE1
--e ANOTHER_VARIABLE="VALUE WITH SPACES"
--e ANOTHER_VARIABLE="VALUE;seperated with;semicolons"</source>
+-e VARIABLE=abc
+-e VARIABLE="value with spaces"
+-e VARIABLE="value;seperated with;semicolons"
+-e VAR1=abc -e VAR2=def -e VAR3=ghi
+</source>
         <target state="new">Sets the value of an environment variable. 
 Creates the variable if it does not exist, overrides if it does. 
 This will force the tests to be run in an isolated process. 
 This argument can be specified multiple times to provide multiple variables.
 
 Examples:
--e VARIABLE1=VALUE1
--e ANOTHER_VARIABLE="VALUE WITH SPACES"
--e ANOTHER_VARIABLE="VALUE;seperated with;semicolons"</target>
+-e VARIABLE=abc
+-e VARIABLE="value with spaces"
+-e VARIABLE="value;seperated with;semicolons"
+-e VAR1=abc -e VAR2=def -e VAR3=ghi
+</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdEnvironmentVariableExpression">

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.ko.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.ko.xlf
@@ -58,6 +58,32 @@ For MSTest, the timeout is used for all testcases.
 This option is currently supported only on Windows together with netcoreapp2.1 and newer. And on Linux with netcoreapp3.1 and newer. OSX and UWP are not supported.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdEnvironmentVariableDescription">
+        <source>Sets the value of an environment variable. 
+Creates the variable if it does not exist, overrides if it does. 
+This will force the tests to be run in an isolated process. 
+This argument can be specified multiple times to provide multiple variables.
+
+Examples:
+-e VARIABLE1=VALUE1
+-e ANOTHER_VARIABLE="VALUE WITH SPACES"
+-e ANOTHER_VARIABLE="VALUE;seperated with;semicolons"</source>
+        <target state="new">Sets the value of an environment variable. 
+Creates the variable if it does not exist, overrides if it does. 
+This will force the tests to be run in an isolated process. 
+This argument can be specified multiple times to provide multiple variables.
+
+Examples:
+-e VARIABLE1=VALUE1
+-e ANOTHER_VARIABLE="VALUE WITH SPACES"
+-e ANOTHER_VARIABLE="VALUE;seperated with;semicolons"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdEnvironmentVariableExpression">
+        <source>NAME="VALUE"</source>
+        <target state="new">NAME="VALUE"</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdNoLogo">
         <source>Run test(s), without displaying Microsoft Testplatform banner</source>
         <target state="translated">Microsoft Testplatform 배너를 표시하지 않고 테스트 실행</target>

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.pl.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.pl.xlf
@@ -58,6 +58,32 @@ For MSTest, the timeout is used for all testcases.
 This option is currently supported only on Windows together with netcoreapp2.1 and newer. And on Linux with netcoreapp3.1 and newer. OSX and UWP are not supported.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdEnvironmentVariableDescription">
+        <source>Sets the value of an environment variable. 
+Creates the variable if it does not exist, overrides if it does. 
+This will force the tests to be run in an isolated process. 
+This argument can be specified multiple times to provide multiple variables.
+
+Examples:
+-e VARIABLE1=VALUE1
+-e ANOTHER_VARIABLE="VALUE WITH SPACES"
+-e ANOTHER_VARIABLE="VALUE;seperated with;semicolons"</source>
+        <target state="new">Sets the value of an environment variable. 
+Creates the variable if it does not exist, overrides if it does. 
+This will force the tests to be run in an isolated process. 
+This argument can be specified multiple times to provide multiple variables.
+
+Examples:
+-e VARIABLE1=VALUE1
+-e ANOTHER_VARIABLE="VALUE WITH SPACES"
+-e ANOTHER_VARIABLE="VALUE;seperated with;semicolons"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdEnvironmentVariableExpression">
+        <source>NAME="VALUE"</source>
+        <target state="new">NAME="VALUE"</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdNoLogo">
         <source>Run test(s), without displaying Microsoft Testplatform banner</source>
         <target state="translated">Uruchom testy bez wyświetlania baneru platformy testowej firmy Microsoft</target>

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.pl.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.pl.xlf
@@ -65,18 +65,22 @@ This will force the tests to be run in an isolated process.
 This argument can be specified multiple times to provide multiple variables.
 
 Examples:
--e VARIABLE1=VALUE1
--e ANOTHER_VARIABLE="VALUE WITH SPACES"
--e ANOTHER_VARIABLE="VALUE;seperated with;semicolons"</source>
+-e VARIABLE=abc
+-e VARIABLE="value with spaces"
+-e VARIABLE="value;seperated with;semicolons"
+-e VAR1=abc -e VAR2=def -e VAR3=ghi
+</source>
         <target state="new">Sets the value of an environment variable. 
 Creates the variable if it does not exist, overrides if it does. 
 This will force the tests to be run in an isolated process. 
 This argument can be specified multiple times to provide multiple variables.
 
 Examples:
--e VARIABLE1=VALUE1
--e ANOTHER_VARIABLE="VALUE WITH SPACES"
--e ANOTHER_VARIABLE="VALUE;seperated with;semicolons"</target>
+-e VARIABLE=abc
+-e VARIABLE="value with spaces"
+-e VARIABLE="value;seperated with;semicolons"
+-e VAR1=abc -e VAR2=def -e VAR3=ghi
+</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdEnvironmentVariableExpression">

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.pt-BR.xlf
@@ -65,18 +65,22 @@ This will force the tests to be run in an isolated process.
 This argument can be specified multiple times to provide multiple variables.
 
 Examples:
--e VARIABLE1=VALUE1
--e ANOTHER_VARIABLE="VALUE WITH SPACES"
--e ANOTHER_VARIABLE="VALUE;seperated with;semicolons"</source>
+-e VARIABLE=abc
+-e VARIABLE="value with spaces"
+-e VARIABLE="value;seperated with;semicolons"
+-e VAR1=abc -e VAR2=def -e VAR3=ghi
+</source>
         <target state="new">Sets the value of an environment variable. 
 Creates the variable if it does not exist, overrides if it does. 
 This will force the tests to be run in an isolated process. 
 This argument can be specified multiple times to provide multiple variables.
 
 Examples:
--e VARIABLE1=VALUE1
--e ANOTHER_VARIABLE="VALUE WITH SPACES"
--e ANOTHER_VARIABLE="VALUE;seperated with;semicolons"</target>
+-e VARIABLE=abc
+-e VARIABLE="value with spaces"
+-e VARIABLE="value;seperated with;semicolons"
+-e VAR1=abc -e VAR2=def -e VAR3=ghi
+</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdEnvironmentVariableExpression">

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.pt-BR.xlf
@@ -58,6 +58,32 @@ For MSTest, the timeout is used for all testcases.
 This option is currently supported only on Windows together with netcoreapp2.1 and newer. And on Linux with netcoreapp3.1 and newer. OSX and UWP are not supported.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdEnvironmentVariableDescription">
+        <source>Sets the value of an environment variable. 
+Creates the variable if it does not exist, overrides if it does. 
+This will force the tests to be run in an isolated process. 
+This argument can be specified multiple times to provide multiple variables.
+
+Examples:
+-e VARIABLE1=VALUE1
+-e ANOTHER_VARIABLE="VALUE WITH SPACES"
+-e ANOTHER_VARIABLE="VALUE;seperated with;semicolons"</source>
+        <target state="new">Sets the value of an environment variable. 
+Creates the variable if it does not exist, overrides if it does. 
+This will force the tests to be run in an isolated process. 
+This argument can be specified multiple times to provide multiple variables.
+
+Examples:
+-e VARIABLE1=VALUE1
+-e ANOTHER_VARIABLE="VALUE WITH SPACES"
+-e ANOTHER_VARIABLE="VALUE;seperated with;semicolons"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdEnvironmentVariableExpression">
+        <source>NAME="VALUE"</source>
+        <target state="new">NAME="VALUE"</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdNoLogo">
         <source>Run test(s), without displaying Microsoft Testplatform banner</source>
         <target state="translated">Executar testes, sem exibir a faixa do Microsoft Testplatform</target>

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.ru.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.ru.xlf
@@ -58,6 +58,32 @@ For MSTest, the timeout is used for all testcases.
 This option is currently supported only on Windows together with netcoreapp2.1 and newer. And on Linux with netcoreapp3.1 and newer. OSX and UWP are not supported.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdEnvironmentVariableDescription">
+        <source>Sets the value of an environment variable. 
+Creates the variable if it does not exist, overrides if it does. 
+This will force the tests to be run in an isolated process. 
+This argument can be specified multiple times to provide multiple variables.
+
+Examples:
+-e VARIABLE1=VALUE1
+-e ANOTHER_VARIABLE="VALUE WITH SPACES"
+-e ANOTHER_VARIABLE="VALUE;seperated with;semicolons"</source>
+        <target state="new">Sets the value of an environment variable. 
+Creates the variable if it does not exist, overrides if it does. 
+This will force the tests to be run in an isolated process. 
+This argument can be specified multiple times to provide multiple variables.
+
+Examples:
+-e VARIABLE1=VALUE1
+-e ANOTHER_VARIABLE="VALUE WITH SPACES"
+-e ANOTHER_VARIABLE="VALUE;seperated with;semicolons"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdEnvironmentVariableExpression">
+        <source>NAME="VALUE"</source>
+        <target state="new">NAME="VALUE"</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdNoLogo">
         <source>Run test(s), without displaying Microsoft Testplatform banner</source>
         <target state="translated">Запуск тестов без отображения баннера Testplatform Майкрософт</target>

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.ru.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.ru.xlf
@@ -65,18 +65,22 @@ This will force the tests to be run in an isolated process.
 This argument can be specified multiple times to provide multiple variables.
 
 Examples:
--e VARIABLE1=VALUE1
--e ANOTHER_VARIABLE="VALUE WITH SPACES"
--e ANOTHER_VARIABLE="VALUE;seperated with;semicolons"</source>
+-e VARIABLE=abc
+-e VARIABLE="value with spaces"
+-e VARIABLE="value;seperated with;semicolons"
+-e VAR1=abc -e VAR2=def -e VAR3=ghi
+</source>
         <target state="new">Sets the value of an environment variable. 
 Creates the variable if it does not exist, overrides if it does. 
 This will force the tests to be run in an isolated process. 
 This argument can be specified multiple times to provide multiple variables.
 
 Examples:
--e VARIABLE1=VALUE1
--e ANOTHER_VARIABLE="VALUE WITH SPACES"
--e ANOTHER_VARIABLE="VALUE;seperated with;semicolons"</target>
+-e VARIABLE=abc
+-e VARIABLE="value with spaces"
+-e VARIABLE="value;seperated with;semicolons"
+-e VAR1=abc -e VAR2=def -e VAR3=ghi
+</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdEnvironmentVariableExpression">

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.tr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.tr.xlf
@@ -58,6 +58,32 @@ For MSTest, the timeout is used for all testcases.
 This option is currently supported only on Windows together with netcoreapp2.1 and newer. And on Linux with netcoreapp3.1 and newer. OSX and UWP are not supported.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdEnvironmentVariableDescription">
+        <source>Sets the value of an environment variable. 
+Creates the variable if it does not exist, overrides if it does. 
+This will force the tests to be run in an isolated process. 
+This argument can be specified multiple times to provide multiple variables.
+
+Examples:
+-e VARIABLE1=VALUE1
+-e ANOTHER_VARIABLE="VALUE WITH SPACES"
+-e ANOTHER_VARIABLE="VALUE;seperated with;semicolons"</source>
+        <target state="new">Sets the value of an environment variable. 
+Creates the variable if it does not exist, overrides if it does. 
+This will force the tests to be run in an isolated process. 
+This argument can be specified multiple times to provide multiple variables.
+
+Examples:
+-e VARIABLE1=VALUE1
+-e ANOTHER_VARIABLE="VALUE WITH SPACES"
+-e ANOTHER_VARIABLE="VALUE;seperated with;semicolons"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdEnvironmentVariableExpression">
+        <source>NAME="VALUE"</source>
+        <target state="new">NAME="VALUE"</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdNoLogo">
         <source>Run test(s), without displaying Microsoft Testplatform banner</source>
         <target state="translated">Testleri Microsoft Testplatform bandını görüntülemeden çalıştır</target>

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.tr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.tr.xlf
@@ -65,18 +65,22 @@ This will force the tests to be run in an isolated process.
 This argument can be specified multiple times to provide multiple variables.
 
 Examples:
--e VARIABLE1=VALUE1
--e ANOTHER_VARIABLE="VALUE WITH SPACES"
--e ANOTHER_VARIABLE="VALUE;seperated with;semicolons"</source>
+-e VARIABLE=abc
+-e VARIABLE="value with spaces"
+-e VARIABLE="value;seperated with;semicolons"
+-e VAR1=abc -e VAR2=def -e VAR3=ghi
+</source>
         <target state="new">Sets the value of an environment variable. 
 Creates the variable if it does not exist, overrides if it does. 
 This will force the tests to be run in an isolated process. 
 This argument can be specified multiple times to provide multiple variables.
 
 Examples:
--e VARIABLE1=VALUE1
--e ANOTHER_VARIABLE="VALUE WITH SPACES"
--e ANOTHER_VARIABLE="VALUE;seperated with;semicolons"</target>
+-e VARIABLE=abc
+-e VARIABLE="value with spaces"
+-e VARIABLE="value;seperated with;semicolons"
+-e VAR1=abc -e VAR2=def -e VAR3=ghi
+</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdEnvironmentVariableExpression">

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.zh-Hans.xlf
@@ -58,6 +58,32 @@ For MSTest, the timeout is used for all testcases.
 This option is currently supported only on Windows together with netcoreapp2.1 and newer. And on Linux with netcoreapp3.1 and newer. OSX and UWP are not supported.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdEnvironmentVariableDescription">
+        <source>Sets the value of an environment variable. 
+Creates the variable if it does not exist, overrides if it does. 
+This will force the tests to be run in an isolated process. 
+This argument can be specified multiple times to provide multiple variables.
+
+Examples:
+-e VARIABLE1=VALUE1
+-e ANOTHER_VARIABLE="VALUE WITH SPACES"
+-e ANOTHER_VARIABLE="VALUE;seperated with;semicolons"</source>
+        <target state="new">Sets the value of an environment variable. 
+Creates the variable if it does not exist, overrides if it does. 
+This will force the tests to be run in an isolated process. 
+This argument can be specified multiple times to provide multiple variables.
+
+Examples:
+-e VARIABLE1=VALUE1
+-e ANOTHER_VARIABLE="VALUE WITH SPACES"
+-e ANOTHER_VARIABLE="VALUE;seperated with;semicolons"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdEnvironmentVariableExpression">
+        <source>NAME="VALUE"</source>
+        <target state="new">NAME="VALUE"</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdNoLogo">
         <source>Run test(s), without displaying Microsoft Testplatform banner</source>
         <target state="translated">运行测试，而不显示 Microsoft Testplatform 版权标志</target>

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.zh-Hans.xlf
@@ -65,18 +65,22 @@ This will force the tests to be run in an isolated process.
 This argument can be specified multiple times to provide multiple variables.
 
 Examples:
--e VARIABLE1=VALUE1
--e ANOTHER_VARIABLE="VALUE WITH SPACES"
--e ANOTHER_VARIABLE="VALUE;seperated with;semicolons"</source>
+-e VARIABLE=abc
+-e VARIABLE="value with spaces"
+-e VARIABLE="value;seperated with;semicolons"
+-e VAR1=abc -e VAR2=def -e VAR3=ghi
+</source>
         <target state="new">Sets the value of an environment variable. 
 Creates the variable if it does not exist, overrides if it does. 
 This will force the tests to be run in an isolated process. 
 This argument can be specified multiple times to provide multiple variables.
 
 Examples:
--e VARIABLE1=VALUE1
--e ANOTHER_VARIABLE="VALUE WITH SPACES"
--e ANOTHER_VARIABLE="VALUE;seperated with;semicolons"</target>
+-e VARIABLE=abc
+-e VARIABLE="value with spaces"
+-e VARIABLE="value;seperated with;semicolons"
+-e VAR1=abc -e VAR2=def -e VAR3=ghi
+</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdEnvironmentVariableExpression">

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.zh-Hant.xlf
@@ -58,6 +58,32 @@ For MSTest, the timeout is used for all testcases.
 This option is currently supported only on Windows together with netcoreapp2.1 and newer. And on Linux with netcoreapp3.1 and newer. OSX and UWP are not supported.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdEnvironmentVariableDescription">
+        <source>Sets the value of an environment variable. 
+Creates the variable if it does not exist, overrides if it does. 
+This will force the tests to be run in an isolated process. 
+This argument can be specified multiple times to provide multiple variables.
+
+Examples:
+-e VARIABLE1=VALUE1
+-e ANOTHER_VARIABLE="VALUE WITH SPACES"
+-e ANOTHER_VARIABLE="VALUE;seperated with;semicolons"</source>
+        <target state="new">Sets the value of an environment variable. 
+Creates the variable if it does not exist, overrides if it does. 
+This will force the tests to be run in an isolated process. 
+This argument can be specified multiple times to provide multiple variables.
+
+Examples:
+-e VARIABLE1=VALUE1
+-e ANOTHER_VARIABLE="VALUE WITH SPACES"
+-e ANOTHER_VARIABLE="VALUE;seperated with;semicolons"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdEnvironmentVariableExpression">
+        <source>NAME="VALUE"</source>
+        <target state="new">NAME="VALUE"</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdNoLogo">
         <source>Run test(s), without displaying Microsoft Testplatform banner</source>
         <target state="translated">執行測試，但不顯示 Microsoft Testplatform 橫幅</target>

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.zh-Hant.xlf
@@ -65,18 +65,22 @@ This will force the tests to be run in an isolated process.
 This argument can be specified multiple times to provide multiple variables.
 
 Examples:
--e VARIABLE1=VALUE1
--e ANOTHER_VARIABLE="VALUE WITH SPACES"
--e ANOTHER_VARIABLE="VALUE;seperated with;semicolons"</source>
+-e VARIABLE=abc
+-e VARIABLE="value with spaces"
+-e VARIABLE="value;seperated with;semicolons"
+-e VAR1=abc -e VAR2=def -e VAR3=ghi
+</source>
         <target state="new">Sets the value of an environment variable. 
 Creates the variable if it does not exist, overrides if it does. 
 This will force the tests to be run in an isolated process. 
 This argument can be specified multiple times to provide multiple variables.
 
 Examples:
--e VARIABLE1=VALUE1
--e ANOTHER_VARIABLE="VALUE WITH SPACES"
--e ANOTHER_VARIABLE="VALUE;seperated with;semicolons"</target>
+-e VARIABLE=abc
+-e VARIABLE="value with spaces"
+-e VARIABLE="value;seperated with;semicolons"
+-e VAR1=abc -e VAR2=def -e VAR3=ghi
+</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdEnvironmentVariableExpression">


### PR DESCRIPTION
Added help string for `-e, --environment` option to `dotnet test` command.

(Part of ongoing work on https://github.com/microsoft/vstest/issues/669)