### PR TITLE
Preventing windows sdk warning when multitargeting below net5.0

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.targets
@@ -372,7 +372,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <Target Name="_CheckForUnnecessaryWindowsDesktopSDK"
         BeforeTargets="_CheckForInvalidConfigurationAndPlatform"
-        Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' and $([MSBuild]::VersionGreaterThanOrEquals($(_TargetFrameworkVersionWithoutV), '5.0')) and '$(_MicrosoftWindowsDesktopSdkImported)' == 'true'">
+        Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' and $([MSBuild]::VersionGreaterThanOrEquals($(_TargetFrameworkVersionWithoutV), '5.0')) and '$(_MicrosoftWindowsDesktopSdkImported)' == 'true' and '$(TargetFrameworks)' == ''">
     <NETSdkWarning ResourceName="UnnecessaryWindowsDesktopSDK" />
   </Target>
 </Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -983,7 +983,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <PropertyGroup Condition=" '$(ImportWindowsDesktopTargets)' == ''
                  and '$(TargetFrameworkIdentifier)' == '.NETCoreApp'
-                 and $([MSBuild]::VersionGreaterThanOrEquals($(_TargetFrameworkVersionWithoutV), '5.0'))
+                 and $([MSBuild]::VersionGreaterThanOrEquals($(_TargetFrameworkVersionWithoutV), '3.0'))
                  and '$(TargetPlatformIdentifier)' == 'Windows'
                  and ('$(UseWpf)' == 'true' Or '$(UseWindowsForms)' == 'true')">
     <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAWindowsDesktopProject.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAWindowsDesktopProject.cs
@@ -102,8 +102,57 @@ namespace Microsoft.NET.Build.Tests
                 .And
                 .HaveStdOutContaining("NETSDK1137");
         }
-		
-		[WindowsOnlyFact]
+
+        [WindowsOnlyFact]
+        public void It_does_not_warn_when_multitargeting()
+        {
+            var targetFramework = "net5.0;net472;netcoreapp3.1";
+            TestProject testProject = new TestProject()
+            {
+                Name = "windowsDesktopSdk",
+                IsSdkProject = true,
+                ProjectSdk = "Microsoft.NET.Sdk.WindowsDesktop",
+                TargetFrameworks = targetFramework
+            };
+            testProject.AdditionalProperties["UseWPF"] = "true";
+            testProject.AdditionalProperties["TargetPlatformIdentifier"] = "Windows";
+            var testAsset = _testAssetsManager.CreateTestProject(testProject);
+
+            var buildCommand = new BuildCommand(testAsset);
+            buildCommand.Execute()
+                .Should()
+                .Pass()
+                .And
+                .NotHaveStdOutContaining("NETSDK1137");
+        }
+
+        [WindowsOnlyFact]
+        public void It_imports_when_targeting_dotnet_3()
+        {
+            var targetFramework = "netcoreapp3.1";
+            TestProject testProject = new TestProject()
+            {
+                Name = "windowsDesktopSdk",
+                IsSdkProject = true,
+                TargetFrameworks = targetFramework
+            };
+            testProject.AdditionalProperties["UseWPF"] = "true";
+            testProject.AdditionalProperties["TargetPlatformIdentifier"] = "Windows";
+            var testAsset = _testAssetsManager.CreateTestProject(testProject);
+
+            var buildCommand = new BuildCommand(testAsset);
+            buildCommand.Execute()
+                .Should()
+                .Pass();
+
+            var getValuesCommand = new GetValuesCommand(testAsset, "ImportWindowsDesktopTargets");
+            getValuesCommand.Execute()
+                .Should()
+                .Pass();
+            getValuesCommand.GetValues().ShouldBeEquivalentTo(new[] { "true" });
+        }
+
+        [WindowsOnlyFact]
         public void It_fails_if_windows_target_platform_version_is_invalid()
         {
             var testProject = new TestProject()

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenWeWantToRequireWindowsForDesktopApps.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenWeWantToRequireWindowsForDesktopApps.cs
@@ -96,7 +96,7 @@ namespace Microsoft.NET.Build.Tests
                 .HaveStdOutContaining(Strings.WindowsDesktopFrameworkRequiresWindows);
         }
 
-        [RequiresMSBuildVersionTheory("16.8.0")]
+        [WindowsOnlyTheory]
         [InlineData("net5.0", "TargetPlatformIdentifier", "Windows", "Exe")]
         [InlineData("netcoreapp3.1", "UseWindowsForms", "true", "WinExe")]
         [InlineData("netcoreapp3.1", "UseWPF", "true", "WinExe")]


### PR DESCRIPTION
Fixes https://github.com/dotnet/sdk/issues/13427
Fixes https://github.com/dotnet/sdk/issues/13449