### PR TITLE
[release/5.0-rc2] Add Microsoft.Managed.{Before/After}.targets for F#

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FSharpTargetsShim.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FSharpTargetsShim.targets
@@ -12,6 +12,8 @@ Copyright (c) .NET Foundation. All rights reserved.
 
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
+  <Import Project="$(MSBuildToolsPath)\Microsoft.Managed.Before.targets" />
+
   <PropertyGroup Condition=" '$(UseBundledFSharpTargets)' == 'true' ">
     <AppDesignerFolder Condition="'$(AppDesignerFolder)' == ''">Properties</AppDesignerFolder>
   </PropertyGroup>
@@ -57,5 +59,5 @@ Copyright (c) .NET Foundation. All rights reserved.
      <FSharpTargetsShim Condition = " '$(FSharpTargetsShim)' == '' and Exists('$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.NetSdk.targets') ">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.NetSdk.targets</FSharpTargetsShim>
   </PropertyGroup>
   <Import Condition=" '$(UseBundledFSharpTargets)' == 'true' and  '$(IsCrossTargetingBuild)' != 'true' and Exists('$(FSharpTargetsShim)') " Project="$(FSharpTargetsShim)" />
-
+  <Import Project="$(MSBuildToolsPath)\Microsoft.Managed.After.targets" />
 </Project>

--- a/src/Tests/dotnet-restore.Tests/GivenThatIWantToRestoreApp.cs
+++ b/src/Tests/dotnet-restore.Tests/GivenThatIWantToRestoreApp.cs
@@ -53,9 +53,11 @@ namespace Microsoft.DotNet.Restore.Test
         }
 
         [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void ItRestoresLibToSpecificDirectory(bool useStaticGraphEvaluation)
+        [InlineData(true, ".csproj")]
+        [InlineData(false, ".csproj")]
+        [InlineData(true, ".fsproj")]
+        [InlineData(false, ".fsproj")]
+        public void ItRestoresLibToSpecificDirectory(bool useStaticGraphEvaluation, string extension)
         {
             var testProject = new TestProject()
             {
@@ -66,7 +68,7 @@ namespace Microsoft.DotNet.Restore.Test
 
             testProject.PackageReferences.Add(new TestPackageReference("Newtonsoft.Json", "12.0.3"));
 
-            var testAsset = _testAssetsManager.CreateTestProject(testProject, identifier: useStaticGraphEvaluation.ToString());
+            var testAsset = _testAssetsManager.CreateTestProject(testProject, identifier: useStaticGraphEvaluation.ToString(), targetExtension: extension);
 
             var rootPath = Path.Combine(testAsset.TestRoot, testProject.Name);
 


### PR DESCRIPTION
## Customer Impact
Restoring or building a cross-targeting F# project with static graph enabled (opt-in feature) is broken and results in an error during build/restore. The reason for that is that msbuild target files that are expected to be imported by language target files (VB, C#, F#) are missing for F#.

## Testing
We have coverage for this in dotnet/runtime and this PR adds an additional test in dotnet/sdk. @am11 tested the scenario manually as well.

## Risk
Low. This most likely regressed when msbuild language helper target files were refactored. The additional import doesn't cause any change in behavior besides the desired one to fix static graph build/restore.

Fixes https://github.com/NuGet/Home/issues/10005.
cc @jeffkl, @ViktorHofer - works on my machine™️.