### PR TITLE
Pass architecture to bundler (#13402)

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -9,41 +9,41 @@
       <Uri>https://github.com/dotnet/templating</Uri>
       <Sha>20ea899f372ebaaa221cd8e433068d04c86c2033</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Ref" Version="6.0.0-alpha.1.20453.28">
+    <Dependency Name="Microsoft.NETCore.App.Ref" Version="6.0.0-alpha.1.20459.5">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>09c9d10db3ee63a3719870b5433191b9466fbad5</Sha>
+      <Sha>3ac170acc89adde016b1297f7c29232cda61c102</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Internal" Version="6.0.0-alpha.1.20453.28">
+    <Dependency Name="Microsoft.NETCore.App.Internal" Version="6.0.0-alpha.1.20459.5">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>09c9d10db3ee63a3719870b5433191b9466fbad5</Sha>
+      <Sha>3ac170acc89adde016b1297f7c29232cda61c102</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="6.0.0-alpha.1.20453.28">
+    <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="6.0.0-alpha.1.20459.5">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>09c9d10db3ee63a3719870b5433191b9466fbad5</Sha>
+      <Sha>3ac170acc89adde016b1297f7c29232cda61c102</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Host.win-x64" Version="6.0.0-alpha.1.20453.28">
+    <Dependency Name="Microsoft.NETCore.App.Host.win-x64" Version="6.0.0-alpha.1.20459.5">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>09c9d10db3ee63a3719870b5433191b9466fbad5</Sha>
+      <Sha>3ac170acc89adde016b1297f7c29232cda61c102</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.Platforms" Version="6.0.0-alpha.1.20453.28">
+    <Dependency Name="Microsoft.NETCore.Platforms" Version="6.0.0-alpha.1.20459.5">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>09c9d10db3ee63a3719870b5433191b9466fbad5</Sha>
+      <Sha>3ac170acc89adde016b1297f7c29232cda61c102</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="5.0.0-beta.20453.7">
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>16b71a2f216c3c5be5860977c4cb03a95ee2f0e3</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.HostModel" Version="6.0.0-alpha.1.20453.28">
+    <Dependency Name="Microsoft.NET.HostModel" Version="6.0.0-alpha.1.20459.5">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>09c9d10db3ee63a3719870b5433191b9466fbad5</Sha>
+      <Sha>3ac170acc89adde016b1297f7c29232cda61c102</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.DependencyModel" Version="6.0.0-alpha.1.20453.28">
+    <Dependency Name="Microsoft.Extensions.DependencyModel" Version="6.0.0-alpha.1.20459.5">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>09c9d10db3ee63a3719870b5433191b9466fbad5</Sha>
+      <Sha>3ac170acc89adde016b1297f7c29232cda61c102</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.DotNetHostResolver" Version="6.0.0-alpha.1.20453.28">
+    <Dependency Name="Microsoft.NETCore.DotNetHostResolver" Version="6.0.0-alpha.1.20459.5">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>09c9d10db3ee63a3719870b5433191b9466fbad5</Sha>
+      <Sha>3ac170acc89adde016b1297f7c29232cda61c102</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.Cli.CommandLine" Version="1.0.0-preview.19208.1">
       <Uri>https://github.com/dotnet/CliCommandLineParser</Uri>
@@ -89,21 +89,21 @@
       <Uri>https://github.com/mono/linker</Uri>
       <Sha>7ea69bd1a846e5ffd57ebdc4d10f9960f0644f6a</Sha>
     </Dependency>
-    <Dependency Name="System.CodeDom" Version="6.0.0-alpha.1.20453.28">
+    <Dependency Name="System.CodeDom" Version="6.0.0-alpha.1.20459.5">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>09c9d10db3ee63a3719870b5433191b9466fbad5</Sha>
+      <Sha>3ac170acc89adde016b1297f7c29232cda61c102</Sha>
     </Dependency>
-    <Dependency Name="System.Security.Cryptography.ProtectedData" Version="6.0.0-alpha.1.20453.28">
+    <Dependency Name="System.Security.Cryptography.ProtectedData" Version="6.0.0-alpha.1.20459.5">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>09c9d10db3ee63a3719870b5433191b9466fbad5</Sha>
+      <Sha>3ac170acc89adde016b1297f7c29232cda61c102</Sha>
     </Dependency>
-    <Dependency Name="System.Text.Encoding.CodePages" Version="6.0.0-alpha.1.20453.28">
+    <Dependency Name="System.Text.Encoding.CodePages" Version="6.0.0-alpha.1.20459.5">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>09c9d10db3ee63a3719870b5433191b9466fbad5</Sha>
+      <Sha>3ac170acc89adde016b1297f7c29232cda61c102</Sha>
     </Dependency>
-    <Dependency Name="System.Resources.Extensions" Version="6.0.0-alpha.1.20453.28">
+    <Dependency Name="System.Resources.Extensions" Version="6.0.0-alpha.1.20459.5">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>09c9d10db3ee63a3719870b5433191b9466fbad5</Sha>
+      <Sha>3ac170acc89adde016b1297f7c29232cda61c102</Sha>
     </Dependency>
     <Dependency Name="Microsoft.WindowsDesktop.App.Runtime.win-x64" Version="5.0.0-rc.1.20417.4">
       <Uri>https://github.com/dotnet/windowsdesktop</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -29,7 +29,7 @@
     <SystemReflectionMetadataVersion>1.8.0</SystemReflectionMetadataVersion>
     <MicrosoftDotNetSignToolVersion>5.0.0-beta.20453.7</MicrosoftDotNetSignToolVersion>
     <MicrosoftWebXdtPackageVersion>3.1.0</MicrosoftWebXdtPackageVersion>
-    <SystemSecurityCryptographyProtectedDataPackageVersion>6.0.0-alpha.1.20453.28</SystemSecurityCryptographyProtectedDataPackageVersion>
+    <SystemSecurityCryptographyProtectedDataPackageVersion>6.0.0-alpha.1.20459.5</SystemSecurityCryptographyProtectedDataPackageVersion>
     <SystemCollectionsSpecializedPackageVersion>4.3.0</SystemCollectionsSpecializedPackageVersion>
     <SystemXmlXmlDocumentPackageVersion>4.3.0</SystemXmlXmlDocumentPackageVersion>
     <WebDeploymentPackageVersion>4.0.5</WebDeploymentPackageVersion>
@@ -37,13 +37,13 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/runtime -->
-    <MicrosoftNETCoreAppRefPackageVersion>6.0.0-alpha.1.20453.28</MicrosoftNETCoreAppRefPackageVersion>
-    <MicrosoftNETCoreAppInternalPackageVersion>6.0.0-alpha.1.20453.28</MicrosoftNETCoreAppInternalPackageVersion>
-    <MicrosoftNETCoreAppRuntimewinx64PackageVersion>6.0.0-alpha.1.20453.28</MicrosoftNETCoreAppRuntimewinx64PackageVersion>
+    <MicrosoftNETCoreAppRefPackageVersion>6.0.0-alpha.1.20459.5</MicrosoftNETCoreAppRefPackageVersion>
+    <MicrosoftNETCoreAppInternalPackageVersion>6.0.0-alpha.1.20459.5</MicrosoftNETCoreAppInternalPackageVersion>
+    <MicrosoftNETCoreAppRuntimewinx64PackageVersion>6.0.0-alpha.1.20459.5</MicrosoftNETCoreAppRuntimewinx64PackageVersion>
     <MicrosoftNETCoreAppRuntimePackageVersion>$(MicrosoftNETCoreAppRuntimewinx64PackageVersion)</MicrosoftNETCoreAppRuntimePackageVersion>
-    <MicrosoftExtensionsDependencyModelPackageVersion>6.0.0-alpha.1.20453.28</MicrosoftExtensionsDependencyModelPackageVersion>
-    <MicrosoftNETCoreDotNetHostResolverPackageVersion>6.0.0-alpha.1.20453.28</MicrosoftNETCoreDotNetHostResolverPackageVersion>
-    <MicrosoftNETHostModelVersion>6.0.0-alpha.1.20453.28</MicrosoftNETHostModelVersion>
+    <MicrosoftExtensionsDependencyModelPackageVersion>6.0.0-alpha.1.20459.5</MicrosoftExtensionsDependencyModelPackageVersion>
+    <MicrosoftNETCoreDotNetHostResolverPackageVersion>6.0.0-alpha.1.20459.5</MicrosoftNETCoreDotNetHostResolverPackageVersion>
+    <MicrosoftNETHostModelVersion>6.0.0-alpha.1.20459.5</MicrosoftNETHostModelVersion>
     <MicrosoftExtensionsDependencyModelVersion>$(MicrosoftExtensionsDependencyModelPackageVersion)</MicrosoftExtensionsDependencyModelVersion>
   </PropertyGroup>
   <PropertyGroup>
@@ -74,10 +74,10 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/runtime -->
-    <SystemCodeDomPackageVersion>6.0.0-alpha.1.20453.28</SystemCodeDomPackageVersion>
-    <SystemTextEncodingCodePagesPackageVersion>6.0.0-alpha.1.20453.28</SystemTextEncodingCodePagesPackageVersion>
+    <SystemCodeDomPackageVersion>6.0.0-alpha.1.20459.5</SystemCodeDomPackageVersion>
+    <SystemTextEncodingCodePagesPackageVersion>6.0.0-alpha.1.20459.5</SystemTextEncodingCodePagesPackageVersion>
     <SystemSecurityCryptographyProtectedDataPackageVersion>5.0.0-preview.7.20307.4</SystemSecurityCryptographyProtectedDataPackageVersion>
-    <SystemResourcesExtensionsPackageVersion>6.0.0-alpha.1.20453.28</SystemResourcesExtensionsPackageVersion>
+    <SystemResourcesExtensionsPackageVersion>6.0.0-alpha.1.20459.5</SystemResourcesExtensionsPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/roslyn-analyzers -->

--- a/src/Tasks/Microsoft.NET.Build.Tasks/GenerateBundle.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/GenerateBundle.cs
@@ -39,12 +39,25 @@ namespace Microsoft.NET.Build.Tasks
             OSPlatform targetOS = RuntimeIdentifier.StartsWith("win") ? OSPlatform.Windows :
                                   RuntimeIdentifier.StartsWith("osx") ? OSPlatform.OSX : OSPlatform.Linux;
 
+            Architecture targetArch = RuntimeIdentifier.EndsWith("-x64") || RuntimeIdentifier.Contains("-x64-") ? Architecture.X64 :
+                                      RuntimeIdentifier.EndsWith("-x86") || RuntimeIdentifier.Contains("-x86-") ? Architecture.X86 :
+                                      RuntimeIdentifier.EndsWith("-arm64") || RuntimeIdentifier.Contains("-arm64-") ? Architecture.Arm64 :
+                                      RuntimeIdentifier.EndsWith("-arm") || RuntimeIdentifier.Contains("-arm-") ? Architecture.Arm :
+                                      throw new ArgumentException(nameof (RuntimeIdentifier));
+
             BundleOptions options = BundleOptions.None;
             options |= IncludeNativeLibraries ? BundleOptions.BundleNativeBinaries : BundleOptions.None;
             options |= IncludeAllContent ? BundleOptions.BundleAllContent : BundleOptions.None;
             options |= IncludeSymbols ? BundleOptions.BundleSymbolFiles : BundleOptions.None;
 
-            var bundler = new Bundler(AppHostName, OutputDir, options, targetOS, new Version(TargetFrameworkVersion), ShowDiagnosticOutput);
+            var bundler = new Bundler(
+                AppHostName,
+                OutputDir,
+                options,
+                targetOS,
+                targetArch,
+                new Version(TargetFrameworkVersion),
+                ShowDiagnosticOutput);
 
             var fileSpec = new List<FileSpec>(FilesToBundle.Length);
 


### PR DESCRIPTION
This is a port of https://github.com/dotnet/sdk/pull/13402 to master, with a manual dependency update, to fix ARM64 Linux behavior. See https://github.com/dotnet/runtime/pull/41809.

This will unblock dependency flow from runtime.