### PR TITLE
Oob apphost override

### DIFF
--- a/src/Tasks/Common/Resources/Strings.resx
+++ b/src/Tasks/Common/Resources/Strings.resx
@@ -682,4 +682,8 @@ The following are names of parameters or literal values and should not be transl
     <value>NETSDK1144: Optimizing assemblies for size failed. Optimization can be disabled by setting the PublishTrimmed property to false.</value>
     <comment>{StrBegin="NETSDK1144: "}</comment>
   </data>
+  <data name="TargetingApphostPackMissingCannotRestore" xml:space="preserve">
+    <value>NETSDK1145: The {0} pack is not installed and NuGet package restore is not supported. Upgrade Visual Studio, remove global.json if it specifies a certain SDK version, and uninstall the newer SDK. For more options visit   https://aka.ms/targeting-apphost-pack-missing  Pack Type:{0}, Pack directory: {1}, targetframework: {2}, Pack PackageId: {3}, Pack Package Version: {4}</value>
+    <comment>{StrBegin="NETSDK1145: "}</comment>
+  </data>
 </root>

--- a/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
@@ -620,6 +620,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1046: Hodnota TargetFramework {0} není platná. Pokud chcete cílit na více cílů, použijte raději vlastnost TargetFrameworks.</target>
         <note>{StrBegin="NETSDK1046: "}</note>
       </trans-unit>
+      <trans-unit id="TargetingApphostPackMissingCannotRestore">
+        <source>NETSDK1145: The {0} pack is not installed and NuGet package restore is not supported. Upgrade Visual Studio, remove global.json if it specifies a certain SDK version, and uninstall the newer SDK. For more options visit   https://aka.ms/targeting-apphost-pack-missing  Pack Type:{0}, Pack directory: {1}, targetframework: {2}, Pack PackageId: {3}, Pack Package Version: {4}</source>
+        <target state="new">NETSDK1145: The {0} pack is not installed and NuGet package restore is not supported. Upgrade Visual Studio, remove global.json if it specifies a certain SDK version, and uninstall the newer SDK. For more options visit   https://aka.ms/targeting-apphost-pack-missing  Pack Type:{0}, Pack directory: {1}, targetframework: {2}, Pack PackageId: {3}, Pack Package Version: {4}</target>
+        <note>{StrBegin="NETSDK1145: "}</note>
+      </trans-unit>
       <trans-unit id="TargetingPackNeedsRestore">
         <source>NETSDK1127: The targeting pack {0} is not installed. Please restore and try again.</source>
         <target state="new">NETSDK1127: The targeting pack {0} is not installed. Please restore and try again.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.de.xlf
@@ -620,6 +620,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1046: Der TargetFramework-Wert "{0}" ist nicht gültig. Verwenden Sie für mehrere Ziele die Eigenschaft "TargetFrameworks".</target>
         <note>{StrBegin="NETSDK1046: "}</note>
       </trans-unit>
+      <trans-unit id="TargetingApphostPackMissingCannotRestore">
+        <source>NETSDK1145: The {0} pack is not installed and NuGet package restore is not supported. Upgrade Visual Studio, remove global.json if it specifies a certain SDK version, and uninstall the newer SDK. For more options visit   https://aka.ms/targeting-apphost-pack-missing  Pack Type:{0}, Pack directory: {1}, targetframework: {2}, Pack PackageId: {3}, Pack Package Version: {4}</source>
+        <target state="new">NETSDK1145: The {0} pack is not installed and NuGet package restore is not supported. Upgrade Visual Studio, remove global.json if it specifies a certain SDK version, and uninstall the newer SDK. For more options visit   https://aka.ms/targeting-apphost-pack-missing  Pack Type:{0}, Pack directory: {1}, targetframework: {2}, Pack PackageId: {3}, Pack Package Version: {4}</target>
+        <note>{StrBegin="NETSDK1145: "}</note>
+      </trans-unit>
       <trans-unit id="TargetingPackNeedsRestore">
         <source>NETSDK1127: The targeting pack {0} is not installed. Please restore and try again.</source>
         <target state="new">NETSDK1127: The targeting pack {0} is not installed. Please restore and try again.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.es.xlf
@@ -620,6 +620,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1046: El valor de TargetFramework "{0}" no es válido. Para varios destinos, use en su lugar la propiedad "TargetFrameworks".</target>
         <note>{StrBegin="NETSDK1046: "}</note>
       </trans-unit>
+      <trans-unit id="TargetingApphostPackMissingCannotRestore">
+        <source>NETSDK1145: The {0} pack is not installed and NuGet package restore is not supported. Upgrade Visual Studio, remove global.json if it specifies a certain SDK version, and uninstall the newer SDK. For more options visit   https://aka.ms/targeting-apphost-pack-missing  Pack Type:{0}, Pack directory: {1}, targetframework: {2}, Pack PackageId: {3}, Pack Package Version: {4}</source>
+        <target state="new">NETSDK1145: The {0} pack is not installed and NuGet package restore is not supported. Upgrade Visual Studio, remove global.json if it specifies a certain SDK version, and uninstall the newer SDK. For more options visit   https://aka.ms/targeting-apphost-pack-missing  Pack Type:{0}, Pack directory: {1}, targetframework: {2}, Pack PackageId: {3}, Pack Package Version: {4}</target>
+        <note>{StrBegin="NETSDK1145: "}</note>
+      </trans-unit>
       <trans-unit id="TargetingPackNeedsRestore">
         <source>NETSDK1127: The targeting pack {0} is not installed. Please restore and try again.</source>
         <target state="new">NETSDK1127: The targeting pack {0} is not installed. Please restore and try again.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
@@ -620,6 +620,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1046: La valeur TargetFramework '{0}' est non valide. Pour effectuer un multiciblage, utilisez la propriété 'TargetFrameworks' à la place.</target>
         <note>{StrBegin="NETSDK1046: "}</note>
       </trans-unit>
+      <trans-unit id="TargetingApphostPackMissingCannotRestore">
+        <source>NETSDK1145: The {0} pack is not installed and NuGet package restore is not supported. Upgrade Visual Studio, remove global.json if it specifies a certain SDK version, and uninstall the newer SDK. For more options visit   https://aka.ms/targeting-apphost-pack-missing  Pack Type:{0}, Pack directory: {1}, targetframework: {2}, Pack PackageId: {3}, Pack Package Version: {4}</source>
+        <target state="new">NETSDK1145: The {0} pack is not installed and NuGet package restore is not supported. Upgrade Visual Studio, remove global.json if it specifies a certain SDK version, and uninstall the newer SDK. For more options visit   https://aka.ms/targeting-apphost-pack-missing  Pack Type:{0}, Pack directory: {1}, targetframework: {2}, Pack PackageId: {3}, Pack Package Version: {4}</target>
+        <note>{StrBegin="NETSDK1145: "}</note>
+      </trans-unit>
       <trans-unit id="TargetingPackNeedsRestore">
         <source>NETSDK1127: The targeting pack {0} is not installed. Please restore and try again.</source>
         <target state="new">NETSDK1127: The targeting pack {0} is not installed. Please restore and try again.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.it.xlf
@@ -620,6 +620,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1046: il valore '{0}' di TargetFramework non è valido. Per impostare più destinazioni, usare la proprietà 'TargetFrameworks'.</target>
         <note>{StrBegin="NETSDK1046: "}</note>
       </trans-unit>
+      <trans-unit id="TargetingApphostPackMissingCannotRestore">
+        <source>NETSDK1145: The {0} pack is not installed and NuGet package restore is not supported. Upgrade Visual Studio, remove global.json if it specifies a certain SDK version, and uninstall the newer SDK. For more options visit   https://aka.ms/targeting-apphost-pack-missing  Pack Type:{0}, Pack directory: {1}, targetframework: {2}, Pack PackageId: {3}, Pack Package Version: {4}</source>
+        <target state="new">NETSDK1145: The {0} pack is not installed and NuGet package restore is not supported. Upgrade Visual Studio, remove global.json if it specifies a certain SDK version, and uninstall the newer SDK. For more options visit   https://aka.ms/targeting-apphost-pack-missing  Pack Type:{0}, Pack directory: {1}, targetframework: {2}, Pack PackageId: {3}, Pack Package Version: {4}</target>
+        <note>{StrBegin="NETSDK1145: "}</note>
+      </trans-unit>
       <trans-unit id="TargetingPackNeedsRestore">
         <source>NETSDK1127: The targeting pack {0} is not installed. Please restore and try again.</source>
         <target state="new">NETSDK1127: The targeting pack {0} is not installed. Please restore and try again.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
@@ -620,6 +620,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1046: TargetFramework 値 '{0}' が無効です。複数をターゲットとするには、代わりに 'TargetFrameworks' プロパティを使用してください。</target>
         <note>{StrBegin="NETSDK1046: "}</note>
       </trans-unit>
+      <trans-unit id="TargetingApphostPackMissingCannotRestore">
+        <source>NETSDK1145: The {0} pack is not installed and NuGet package restore is not supported. Upgrade Visual Studio, remove global.json if it specifies a certain SDK version, and uninstall the newer SDK. For more options visit   https://aka.ms/targeting-apphost-pack-missing  Pack Type:{0}, Pack directory: {1}, targetframework: {2}, Pack PackageId: {3}, Pack Package Version: {4}</source>
+        <target state="new">NETSDK1145: The {0} pack is not installed and NuGet package restore is not supported. Upgrade Visual Studio, remove global.json if it specifies a certain SDK version, and uninstall the newer SDK. For more options visit   https://aka.ms/targeting-apphost-pack-missing  Pack Type:{0}, Pack directory: {1}, targetframework: {2}, Pack PackageId: {3}, Pack Package Version: {4}</target>
+        <note>{StrBegin="NETSDK1145: "}</note>
+      </trans-unit>
       <trans-unit id="TargetingPackNeedsRestore">
         <source>NETSDK1127: The targeting pack {0} is not installed. Please restore and try again.</source>
         <target state="new">NETSDK1127: The targeting pack {0} is not installed. Please restore and try again.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
@@ -620,6 +620,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1046: TargetFramework 값 '{0}'이(가) 잘못되었습니다. 여러 대상을 지정하려면 'TargetFrameworks' 속성을 대신 사용하세요.</target>
         <note>{StrBegin="NETSDK1046: "}</note>
       </trans-unit>
+      <trans-unit id="TargetingApphostPackMissingCannotRestore">
+        <source>NETSDK1145: The {0} pack is not installed and NuGet package restore is not supported. Upgrade Visual Studio, remove global.json if it specifies a certain SDK version, and uninstall the newer SDK. For more options visit   https://aka.ms/targeting-apphost-pack-missing  Pack Type:{0}, Pack directory: {1}, targetframework: {2}, Pack PackageId: {3}, Pack Package Version: {4}</source>
+        <target state="new">NETSDK1145: The {0} pack is not installed and NuGet package restore is not supported. Upgrade Visual Studio, remove global.json if it specifies a certain SDK version, and uninstall the newer SDK. For more options visit   https://aka.ms/targeting-apphost-pack-missing  Pack Type:{0}, Pack directory: {1}, targetframework: {2}, Pack PackageId: {3}, Pack Package Version: {4}</target>
+        <note>{StrBegin="NETSDK1145: "}</note>
+      </trans-unit>
       <trans-unit id="TargetingPackNeedsRestore">
         <source>NETSDK1127: The targeting pack {0} is not installed. Please restore and try again.</source>
         <target state="new">NETSDK1127: The targeting pack {0} is not installed. Please restore and try again.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
@@ -620,6 +620,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1046: Wartość „{0}” elementu TargetFramework jest nieprawidłowa. Aby obsługiwać wiele środowisk docelowych, użyj zamiast tego właściwości TargetFrameworks.</target>
         <note>{StrBegin="NETSDK1046: "}</note>
       </trans-unit>
+      <trans-unit id="TargetingApphostPackMissingCannotRestore">
+        <source>NETSDK1145: The {0} pack is not installed and NuGet package restore is not supported. Upgrade Visual Studio, remove global.json if it specifies a certain SDK version, and uninstall the newer SDK. For more options visit   https://aka.ms/targeting-apphost-pack-missing  Pack Type:{0}, Pack directory: {1}, targetframework: {2}, Pack PackageId: {3}, Pack Package Version: {4}</source>
+        <target state="new">NETSDK1145: The {0} pack is not installed and NuGet package restore is not supported. Upgrade Visual Studio, remove global.json if it specifies a certain SDK version, and uninstall the newer SDK. For more options visit   https://aka.ms/targeting-apphost-pack-missing  Pack Type:{0}, Pack directory: {1}, targetframework: {2}, Pack PackageId: {3}, Pack Package Version: {4}</target>
+        <note>{StrBegin="NETSDK1145: "}</note>
+      </trans-unit>
       <trans-unit id="TargetingPackNeedsRestore">
         <source>NETSDK1127: The targeting pack {0} is not installed. Please restore and try again.</source>
         <target state="new">NETSDK1127: The targeting pack {0} is not installed. Please restore and try again.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
@@ -620,6 +620,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1046: O valor '{0}' do TargetFramework não é válido. Para vários destinos, use a propriedade 'TargetFrameworks'.</target>
         <note>{StrBegin="NETSDK1046: "}</note>
       </trans-unit>
+      <trans-unit id="TargetingApphostPackMissingCannotRestore">
+        <source>NETSDK1145: The {0} pack is not installed and NuGet package restore is not supported. Upgrade Visual Studio, remove global.json if it specifies a certain SDK version, and uninstall the newer SDK. For more options visit   https://aka.ms/targeting-apphost-pack-missing  Pack Type:{0}, Pack directory: {1}, targetframework: {2}, Pack PackageId: {3}, Pack Package Version: {4}</source>
+        <target state="new">NETSDK1145: The {0} pack is not installed and NuGet package restore is not supported. Upgrade Visual Studio, remove global.json if it specifies a certain SDK version, and uninstall the newer SDK. For more options visit   https://aka.ms/targeting-apphost-pack-missing  Pack Type:{0}, Pack directory: {1}, targetframework: {2}, Pack PackageId: {3}, Pack Package Version: {4}</target>
+        <note>{StrBegin="NETSDK1145: "}</note>
+      </trans-unit>
       <trans-unit id="TargetingPackNeedsRestore">
         <source>NETSDK1127: The targeting pack {0} is not installed. Please restore and try again.</source>
         <target state="new">NETSDK1127: The targeting pack {0} is not installed. Please restore and try again.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
@@ -620,6 +620,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1046: значение "{0}" свойства TargetFramework недопустимо. Для выбора нескольких целевых платформ используйте свойство "TargetFrameworks".</target>
         <note>{StrBegin="NETSDK1046: "}</note>
       </trans-unit>
+      <trans-unit id="TargetingApphostPackMissingCannotRestore">
+        <source>NETSDK1145: The {0} pack is not installed and NuGet package restore is not supported. Upgrade Visual Studio, remove global.json if it specifies a certain SDK version, and uninstall the newer SDK. For more options visit   https://aka.ms/targeting-apphost-pack-missing  Pack Type:{0}, Pack directory: {1}, targetframework: {2}, Pack PackageId: {3}, Pack Package Version: {4}</source>
+        <target state="new">NETSDK1145: The {0} pack is not installed and NuGet package restore is not supported. Upgrade Visual Studio, remove global.json if it specifies a certain SDK version, and uninstall the newer SDK. For more options visit   https://aka.ms/targeting-apphost-pack-missing  Pack Type:{0}, Pack directory: {1}, targetframework: {2}, Pack PackageId: {3}, Pack Package Version: {4}</target>
+        <note>{StrBegin="NETSDK1145: "}</note>
+      </trans-unit>
       <trans-unit id="TargetingPackNeedsRestore">
         <source>NETSDK1127: The targeting pack {0} is not installed. Please restore and try again.</source>
         <target state="new">NETSDK1127: The targeting pack {0} is not installed. Please restore and try again.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
@@ -620,6 +620,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1046: '{0}' TargetFramework değeri geçerli değil. Çoklu hedefleme için 'TargetFrameworks' özelliğini kullanın.</target>
         <note>{StrBegin="NETSDK1046: "}</note>
       </trans-unit>
+      <trans-unit id="TargetingApphostPackMissingCannotRestore">
+        <source>NETSDK1145: The {0} pack is not installed and NuGet package restore is not supported. Upgrade Visual Studio, remove global.json if it specifies a certain SDK version, and uninstall the newer SDK. For more options visit   https://aka.ms/targeting-apphost-pack-missing  Pack Type:{0}, Pack directory: {1}, targetframework: {2}, Pack PackageId: {3}, Pack Package Version: {4}</source>
+        <target state="new">NETSDK1145: The {0} pack is not installed and NuGet package restore is not supported. Upgrade Visual Studio, remove global.json if it specifies a certain SDK version, and uninstall the newer SDK. For more options visit   https://aka.ms/targeting-apphost-pack-missing  Pack Type:{0}, Pack directory: {1}, targetframework: {2}, Pack PackageId: {3}, Pack Package Version: {4}</target>
+        <note>{StrBegin="NETSDK1145: "}</note>
+      </trans-unit>
       <trans-unit id="TargetingPackNeedsRestore">
         <source>NETSDK1127: The targeting pack {0} is not installed. Please restore and try again.</source>
         <target state="new">NETSDK1127: The targeting pack {0} is not installed. Please restore and try again.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
@@ -620,6 +620,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1046: TargetFramework 值“{0}”无效。若要设置多个目标，请改用 "TargetFrameworks" 属性。</target>
         <note>{StrBegin="NETSDK1046: "}</note>
       </trans-unit>
+      <trans-unit id="TargetingApphostPackMissingCannotRestore">
+        <source>NETSDK1145: The {0} pack is not installed and NuGet package restore is not supported. Upgrade Visual Studio, remove global.json if it specifies a certain SDK version, and uninstall the newer SDK. For more options visit   https://aka.ms/targeting-apphost-pack-missing  Pack Type:{0}, Pack directory: {1}, targetframework: {2}, Pack PackageId: {3}, Pack Package Version: {4}</source>
+        <target state="new">NETSDK1145: The {0} pack is not installed and NuGet package restore is not supported. Upgrade Visual Studio, remove global.json if it specifies a certain SDK version, and uninstall the newer SDK. For more options visit   https://aka.ms/targeting-apphost-pack-missing  Pack Type:{0}, Pack directory: {1}, targetframework: {2}, Pack PackageId: {3}, Pack Package Version: {4}</target>
+        <note>{StrBegin="NETSDK1145: "}</note>
+      </trans-unit>
       <trans-unit id="TargetingPackNeedsRestore">
         <source>NETSDK1127: The targeting pack {0} is not installed. Please restore and try again.</source>
         <target state="new">NETSDK1127: The targeting pack {0} is not installed. Please restore and try again.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
@@ -620,6 +620,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1046: TargetFramework 值 '{0}' 無效。若要設定多重目標，請改用 'TargetFrameworks' 屬性。</target>
         <note>{StrBegin="NETSDK1046: "}</note>
       </trans-unit>
+      <trans-unit id="TargetingApphostPackMissingCannotRestore">
+        <source>NETSDK1145: The {0} pack is not installed and NuGet package restore is not supported. Upgrade Visual Studio, remove global.json if it specifies a certain SDK version, and uninstall the newer SDK. For more options visit   https://aka.ms/targeting-apphost-pack-missing  Pack Type:{0}, Pack directory: {1}, targetframework: {2}, Pack PackageId: {3}, Pack Package Version: {4}</source>
+        <target state="new">NETSDK1145: The {0} pack is not installed and NuGet package restore is not supported. Upgrade VS, remove global.json if it specifies a certain SDK version and uninstall the newer SDK. For more options visit   https://aka.ms/targeting-apphost-pack-missing  Pack Type:{0}, Pack directory: {1}, targetframework: {2}, Pack PackageId: {3}, Pack Package Version: {4}</target>
+        <note>{StrBegin="NETSDK1145: "}</note>
+      </trans-unit>
       <trans-unit id="TargetingPackNeedsRestore">
         <source>NETSDK1127: The targeting pack {0} is not installed. Please restore and try again.</source>
         <target state="new">NETSDK1127: The targeting pack {0} is not installed. Please restore and try again.</target>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolveAppHosts.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveAppHosts.cs
@@ -51,6 +51,10 @@ namespace Microsoft.NET.Build.Tasks
 
         public ITaskItem[] KnownAppHostPacks { get; set; }
 
+        public bool NuGetRestoreSupported { get; set; } = true;
+
+        public string NetCoreTargetingPackRoot { get; set; }
+
         [Output]
         public ITaskItem[] PackagesToDownload { get; set; }
 
@@ -279,6 +283,19 @@ namespace Microsoft.NET.Build.Tasks
                 }
                 else
                 {
+                    // C++/CLI does not support package download && dedup error
+                    if (!NuGetRestoreSupported && !packagesToDownload.Any(p => p.ItemSpec == hostPackName))
+                    {
+                        Log.LogError(
+                                    Strings.TargetingApphostPackMissingCannotRestore,
+                                    "Apphost",
+                                    $"{NetCoreTargetingPackRoot}\\{hostPackName}",
+                                    selectedAppHostPack.GetMetadata("TargetFramework") ?? "",
+                                    hostPackName,
+                                    appHostPackVersion
+                                    );
+                    }
+
                     //  Download apphost pack
                     TaskItem packageToDownload = new TaskItem(hostPackName);
                     packageToDownload.SetMetadata(MetadataKeys.Version, appHostPackVersion);

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolveTargetingPackAssets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveTargetingPackAssets.cs
@@ -22,6 +22,10 @@ namespace Microsoft.NET.Build.Tasks
 
         public bool GenerateErrorForMissingTargetingPacks { get; set; }
 
+        public bool NuGetRestoreSupported { get; set; } = true;
+
+        public string NetCoreTargetingPackRoot { get; set; }
+
         [Output]
         public ITaskItem[] ReferencesToAdd { get; set; }
 
@@ -67,7 +71,21 @@ namespace Microsoft.NET.Build.Tasks
                         }
                         else
                         {
-                            Log.LogError(Strings.TargetingPackNeedsRestore, frameworkReference.ItemSpec);
+                            if (NuGetRestoreSupported)
+                            {
+                                Log.LogError(Strings.TargetingPackNeedsRestore, frameworkReference.ItemSpec);
+                            }
+                            else
+                            {
+                                Log.LogError(
+                                    Strings.TargetingApphostPackMissingCannotRestore,
+                                    "Targeting",
+                                    $"{NetCoreTargetingPackRoot}\\{targetingPack.GetMetadata("NuGetPackageId") ?? ""}",
+                                    targetingPack.GetMetadata("TargetFramework") ?? "",
+                                    targetingPack.GetMetadata("NuGetPackageId") ?? "",
+                                    targetingPack.GetMetadata("NuGetPackageVersion") ?? ""
+                                    );
+                            }
                         }
                     }
                 }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets
@@ -52,6 +52,10 @@ Copyright (c) .NET Foundation. All rights reserved.
       <EnableTargetingPackDownload>true</EnableTargetingPackDownload>
     </PropertyGroup>
 
+    <PropertyGroup>
+      <_NuGetRestoreSupported Condition="'$(Language)' == 'C++'">false</_NuGetRestoreSupported>
+    </PropertyGroup>
+
     <ItemGroup>
       <_PackAsToolShimRuntimeIdentifiers Condition="@(_PackAsToolShimRuntimeIdentifiers) ==''" Include="$(PackAsToolShimRuntimeIdentifiers)"/>
     </ItemGroup>
@@ -104,7 +108,9 @@ Copyright (c) .NET Foundation. All rights reserved.
                      DotNetComHostLibraryNameWithoutExtension="$(_DotNetComHostLibraryNameWithoutExtension)"
                      DotNetIjwHostLibraryNameWithoutExtension="$(_DotNetIjwHostLibraryNameWithoutExtension)"
                      RuntimeGraphPath="$(BundledRuntimeIdentifierGraphFile)"
-                     KnownAppHostPacks="@(KnownAppHostPack)">
+                     KnownAppHostPacks="@(KnownAppHostPack)"
+                     NuGetRestoreSupported="$(_NuGetRestoreSupported)"
+                     NetCoreTargetingPackRoot="$(NetCoreTargetingPackRoot)">
 
       <Output TaskParameter="PackagesToDownload" ItemName="_PackageToDownload" />
       <Output TaskParameter="AppHost" ItemName="AppHostPack" />
@@ -318,7 +324,9 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ResolveTargetingPackAssets FrameworkReferences="@(FrameworkReference)"
                                 ResolvedTargetingPacks="@(ResolvedTargetingPack)"
                                 RuntimeFrameworks="@(RuntimeFramework)"
-                                GenerateErrorForMissingTargetingPacks="$(GenerateErrorForMissingTargetingPacks)">
+                                GenerateErrorForMissingTargetingPacks="$(GenerateErrorForMissingTargetingPacks)"
+                                NuGetRestoreSupported="$(_NuGetRestoreSupported)"
+                                NetCoreTargetingPackRoot="$(NetCoreTargetingPackRoot)">
       <Output TaskParameter="ReferencesToAdd" ItemName="Reference" />
       <Output TaskParameter="PlatformManifests" ItemName="PlatformManifestsFromTargetingPacks" />
       <Output TaskParameter="PackageConflictPreferredPackages" PropertyName="PackageConflictPreferredPackages" />


### PR DESCRIPTION
fix https://github.com/dotnet/sdk/issues/12911

Add guide when apphost and targeting pack does not exist on disk for C++/CLI
Problem: C++/CLI does not support nuget package restore yet (plan in 16.9). When apphost and targeting pack does not exist on disk, C++/CLI will fail to build. It will occur when the user install an out of band SDK that has a higher version than the one used by VS (note, if the SDK version is too high, VS will not pick it either. For example, 16.8 will only pick 5.0.1xx not 5.0.2xx). Or the user uses global.json. This change will add the following error by the end of the post.
These error messages are not a perfect solution. Uninstalling the out of band SDK should be the easiest. Adding the code to the project is not straightforward. And I expect only experts would want to do that. However, I think it is good enough considering the following:

-  C++/CLI is a VS scenario meaning, it cannot function without VS. C++/CLI users should not need to update SDK separately.
-  C++/CLI nuget package restore is coming in 16.9. And it will no longer has this issue.
-  Only a certain range of SDK will cause this error. For example, install 5.0.200 with 16.8 will not case the error since SDK version is too high.
-  The testing of this error is very hard since it depends on the disk setup and VS. So, I don’t want to make the error too smart.

Why we don’t have this issue in 3.1 time frame? In 3.1, there is only one TFM is supported in C++/CLI which is 3.1. And the out of band SDK would carry the targeting packs and apphost packs in box. However, now we have 5.0 and 3.1. And out of band SDK would only carry 5.0 targeting packs and apphost packs. If the C++/CLI targets 3.1, and if the out of band SDK has a higher version than the SDK VS carries(VS carries 3.1 targeting pack if 3.1 runtime is installed). The 3.1 packs will mismatch and cause this failure.

Error:

_error NETSDK1145: The Targeting pack is not installed and NuGet package restore is not supported. Upgrade VS, remove global.json if it specifies a certain SDK version and uninstall the newer SDK. For more options visit https://aka.ms/targeting-apphost-pack-missing Pack Type:Targeting, Pack directory: C:\work\sdk\artifacts\bin\redist\Debug\dotnet\packs\Microsoft.NETCore.App.Ref, targetframework: netcoreapp3.1, Pack PackageId: Microsoft.NETCore.App.Ref, Pack Package Version: 3.1.0_

_error NETSDK1145: The Apphost pack is not installed and NuGet package restore is not supported. Upgrade VS, remove global.json if it specifies a certain SDK version and uninstall the newer SDK. For more options visit https://aka.ms/targeting-apphost-pack-missing Pack Type:Apphost, Pack directory: C:\work\sdk\artifacts\bin\redist\Debug\dotnet\packs\Microsoft.NETCore.App.Host.win-x64, targetframework: netcoreapp3.1, Pack PackageId: Microsoft.NETCore.App.Host.win-x64, Pack Package Version: 3.1.7_

https://aka.ms/targeting-apphost-pack-missing is pointing to the PR to the doc currently. Please also review it. https://github.com/dotnet/docs/pull/20641/files

Why no unit test?

Currently no C++/CLI can run in SDK repo. And to repro this error, we need a VS installed a subsequence servicing SDK. I kept the error message simple to avoid it has bug by itself. Tested manually.