### PR TITLE
Pass Optimize to CoreGenerateSatelliteAssemblies

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -864,6 +864,7 @@ Copyright (c) .NET Foundation. All rights reserved.
          NoConfig="true"
          NoLogo="$(NoLogo)"
          NoStandardLib="$(NoCompilerStandardLib)"
+         Optimize="$(Optimize)"
          PublicSign="$(PublicSign)"
          DelaySign="$(DelaySign)"
          Deterministic="$(Deterministic)"


### PR DESCRIPTION
Fixes #13491 by passing standard property to the additional csc invocation used for satellite assemblies.