### PR TITLE
Reverting backwards compatibility for compilation constants

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.BeforeCommon.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.BeforeCommon.targets
@@ -184,6 +184,8 @@ Copyright (c) .NET Foundation. All rights reserved.
     <_FrameworkVersionForImplicitDefine Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework'">$(_FrameworkVersionForImplicitDefine.Replace('_', ''))</_FrameworkVersionForImplicitDefine>
 
     <ImplicitFrameworkDefine>$(_FrameworkIdentifierForImplicitDefine)$(_FrameworkVersionForImplicitDefine)</ImplicitFrameworkDefine>
+
+    <BackwardsCompatFrameworkDefine Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' and $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), 5.0))">$(TargetFrameworkIdentifier.Replace('.', '').ToUpperInvariant())</BackwardsCompatFrameworkDefine>
   </PropertyGroup>
 
   <!-- Add conditional compilation symbols for the target platform (for example ANDROID, IOS, WINDOWS) -->
@@ -199,31 +201,10 @@ Copyright (c) .NET Foundation. All rights reserved.
     </ItemGroup>
   </Target>
 
-  <!-- Add conditional compilation symbols for target framework backwards compatibility with .NET 5.0 and later (for example .NET 6.0 defines NET5_0 and NETCOREAPP3_1) -->
-  <Target Name="GenerateNETCompatibleDefineConstants"
-          Condition=" '$(DisableImplicitFrameworkDefines)' != 'true' and '$(TargetFrameworkIdentifier)' == '.NETCoreApp' and $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), 5.0)) " >
-    <ItemGroup>
-      <_NetCoreAppFrameworkVersions Include="@(SupportedNETCoreAppTargetFramework->'%(Identity)'->TrimStart('.NETCoreApp,Version=v'))" />
-      <_NetCoreAppCompatibleVersions Include="@(_NetCoreAppFrameworkVersions)" Condition=" $([MSBuild]::VersionGreaterThan(%(Identity), 3.1)) and $([MSBuild]::VersionLessThan(%(Identity), $(TargetFrameworkVersion))) " />
-      <_ImplicitDefineConstant Include="NETCOREAPP" />
-      <_ImplicitDefineConstant Include="NETCOREAPP3_1" />
-      <_ImplicitDefineConstant Include="@(_NetCoreAppCompatibleVersions->'NET%(Identity)'->Replace('.', '_'))" />
-    </ItemGroup>
-  </Target>
-
-  <!-- Add conditional compilation symbols for target platform backwards compatibility. -->
-  <Target Name="GeneratePlatformCompatibleDefineConstants"
-          Condition=" '$(DisableImplicitFrameworkDefines)' != 'true' and '$(TargetPlatformIdentifier)' != '' and '$(TargetFrameworkIdentifier)' == '.NETCoreApp' and $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), 5.0)) " >
-    <ItemGroup>
-      <_SupportedPlatformCompatibleVersions Include="@(SdkSupportedTargetPlatform)" Condition=" %(Identity) != '' and $([MSBuild]::VersionLessThan(%(Identity), $(TargetPlatformVersion))) " />
-      <_ImplicitDefineConstant Include="@(_SupportedPlatformCompatibleVersions->'$(TargetPlatformIdentifier.ToUpper())%(Identity)'->Replace('.', '_'))" />
-    </ItemGroup>
-  </Target>
-
   <!-- Add implicitly defined preprocessor symbols to DefineConstants -->
   <Target Name="AddImplicitDefineConstants"
           Condition=" '$(DisableImplicitFrameworkDefines)' != 'true' "
-          DependsOnTargets="GenerateTargetPlatformDefineConstants;GenerateNETCompatibleDefineConstants;GeneratePlatformCompatibleDefineConstants"
+          DependsOnTargets="GenerateTargetPlatformDefineConstants"
           BeforeTargets="CoreCompile" >
     <PropertyGroup>
       <DefineConstants Condition=" '@(_ImplicitDefineConstant)' != '' " >$(DefineConstants);@(_ImplicitDefineConstant)</DefineConstants>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.BeforeCommon.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.BeforeCommon.targets
@@ -193,11 +193,9 @@ Copyright (c) .NET Foundation. All rights reserved.
         Condition=" '$(DisableImplicitFrameworkDefines)' != 'true' and '$(TargetPlatformIdentifier)' != '' and '$(TargetFrameworkIdentifier)' == '.NETCoreApp' and $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), 5.0)) " >
     <PropertyGroup>
       <_PlatformIdentifierForImplicitDefine>$(TargetPlatformIdentifier.ToUpperInvariant())</_PlatformIdentifierForImplicitDefine>
-      <_PlatformVersionForImplicitDefine>$(TargetPlatformVersion.Replace('.', '_'))</_PlatformVersionForImplicitDefine>
     </PropertyGroup>
     <ItemGroup>
       <_ImplicitDefineConstant Include="$(_PlatformIdentifierForImplicitDefine)" />
-      <_ImplicitDefineConstant Include="$(_PlatformIdentifierForImplicitDefine)$(_PlatformVersionForImplicitDefine)" />
     </ItemGroup>
   </Target>
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.CSharp.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.CSharp.targets
@@ -31,6 +31,6 @@ Copyright (c) .NET Foundation. All rights reserved.
     <DefineConstants>$(DefineConstants);$(ImplicitConfigurationDefine)</DefineConstants>
   </PropertyGroup>
   <PropertyGroup>
-    <DefineConstants>$(DefineConstants);$(VersionlessImplicitFrameworkDefine);$(ImplicitFrameworkDefine)</DefineConstants>
+    <DefineConstants>$(DefineConstants);$(VersionlessImplicitFrameworkDefine);$(ImplicitFrameworkDefine);$(BackwardsCompatFrameworkDefine)</DefineConstants>
   </PropertyGroup>
 </Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FSharp.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FSharp.targets
@@ -25,7 +25,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <Import Condition=" '$(UseBundledFSharpTargets)' == 'true' and  '$(IsCrossTargetingBuild)' != 'true' and Exists('$(FSharpOverridesTargetsShim)') " Project="$(FSharpOverridesTargetsShim)" />
 
   <PropertyGroup>
-    <DefineConstants>$(DefineConstants);$(VersionlessImplicitFrameworkDefine);$(ImplicitFrameworkDefine)</DefineConstants>
+    <DefineConstants>$(DefineConstants);$(VersionlessImplicitFrameworkDefine);$(ImplicitFrameworkDefine);$(BackwardsCompatFrameworkDefine)</DefineConstants>
   </PropertyGroup>
 
 </Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.VisualBasic.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.VisualBasic.targets
@@ -58,6 +58,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <PropertyGroup>
     <FinalDefineConstants Condition="'$(VersionlessImplicitFrameworkDefine)' != ''">$(FinalDefineConstants),$(VersionlessImplicitFrameworkDefine)=-1</FinalDefineConstants>
     <FinalDefineConstants Condition="'$(ImplicitFrameworkDefine)' != ''">$(FinalDefineConstants),$(ImplicitFrameworkDefine)=-1</FinalDefineConstants>
+    <FinalDefineConstants Condition="'$(BackwardsCompatFrameworkDefine)' != ''">$(FinalDefineConstants),$(BackwardsCompatFrameworkDefine)=-1</FinalDefineConstants>
     <FinalDefineConstants Condition="'$(DefineDebug)' != 'true' and '$(ImplicitConfigurationDefine)' != ''">$(FinalDefineConstants),$(ImplicitConfigurationDefine)=-1</FinalDefineConstants>
   </PropertyGroup>
 

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildALibrary.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildALibrary.cs
@@ -16,10 +16,7 @@ using System;
 using System.Runtime.CompilerServices;
 using Xunit.Abstractions;
 using Microsoft.NET.TestFramework.ProjectConstruction;
-using NuGet.ProjectModel;
-using NuGet.Common;
 using Newtonsoft.Json.Linq;
-using Microsoft.NET.Build.Tasks;
 
 namespace Microsoft.NET.Build.Tests
 {
@@ -319,6 +316,7 @@ namespace Microsoft.NET.Build.Tests
         [InlineData("net461", new[] { "NETFRAMEWORK", "NET461" }, true)]
         [InlineData("netcoreapp1.0", new[] { "NETCOREAPP", "NETCOREAPP1_0" }, false)]
         [InlineData("netcoreapp3.0", new[] { "NETCOREAPP", "NETCOREAPP3_0" }, false)]
+        [InlineData("net5.0", new[] { "NETCOREAPP", "NET", "NET5_0" }, false)]
         [InlineData(".NETPortable,Version=v4.5,Profile=Profile78", new string[] { }, false)]
         [InlineData(".NETFramework,Version=v4.0,Profile=Client", new string[] { "NETFRAMEWORK", "NET40" }, false)]
         [InlineData("Xamarin.iOS,Version=v1.0", new string[] { "XAMARINIOS", "XAMARINIOS1_0" }, false)]
@@ -390,72 +388,14 @@ namespace Microsoft.NET.Build.Tests
             definedConstants.Should().BeEquivalentTo(new[] { "DEBUG", "TRACE" }.Concat(expectedDefines).ToArray());
         }
 
-        [RequiresMSBuildVersionTheory("16.7.0-preview-20310-07")]
-        [InlineData("net5.0", new[] { "NETCOREAPP3_1", "NET5_0" })]
-        [InlineData("net6.0", new[] { "NETCOREAPP3_1", "NET5_0", "NET6_0" })]
-        public void It_implicitly_defines_compilation_constants_for_the_target_framework_with_backwards_compatibility(string targetFramework, string[] expectedDefines)
-        {
-            var testAsset = _testAssetsManager
-                .CopyTestAsset("AppWithLibrary", "ImplicitFrameworkConstants", targetFramework)
-                .WithSource()
-                .WithTargetFramework(targetFramework)
-                .WithProjectChanges(project =>
-                {
-                    var ns = project.Root.Name.Namespace;
-                    var propGroup = new XElement(ns + "PropertyGroup");
-                    project.Root.Add(propGroup);
-                    var maxVersion = new XElement(ns + "NETCoreAppMaximumVersion", "6.0");
-                    propGroup.Add(maxVersion);
-                    var errorOnMissing = new XElement(ns + "GenerateErrorForMissingTargetingPacks", "false");
-                    propGroup.Add(errorOnMissing);
-
-                    var itemGroup = new XElement(ns + "ItemGroup");
-                    project.Root.Add(itemGroup);
-                    var supportedFramework = new XElement(ns + "SupportedNETCoreAppTargetFramework",
-                        new XAttribute("Include", ".NETCoreApp,Version=v6.0"),
-                        new XAttribute("DisplayName", ".NET 6.0"));
-                    itemGroup.Add(supportedFramework);
-                });
-
-            AssertDefinedConstantsOutput(testAsset, targetFramework, new[] { "NETCOREAPP", "NET"}.Concat(expectedDefines).ToArray());
-        }
-
         [Theory]
-        [InlineData("ios", "1.1", new[] { "IOS", "IOS1_1" })]
-        [InlineData("android", "2.2", new[] { "ANDROID", "ANDROID2_2" })]
-        [InlineData("windows", "7.0", new[] { "WINDOWS", "WINDOWS7_0" })]
-        public void It_implicitly_defines_compilation_constants_for_the_target_platform(string targetPlatformIdentifier, string targetPlatformVersion, string[] expectedDefines)
-        {
-            var targetFramework = "net5.0";
-            var testAsset = _testAssetsManager
-                .CopyTestAsset("AppWithLibrary", "ImplicitFrameworkConstants", targetFramework)
-                .WithSource()
-                .WithTargetFramework(targetFramework)
-                .WithProjectChanges(project =>
-                {
-                    //  Manually set target plaform properties
-                    var ns = project.Root.Name.Namespace;
-                    var propGroup = new XElement(ns + "PropertyGroup");
-                    project.Root.Add(propGroup);
-
-                    var platformIdentifier = new XElement(ns + "TargetPlatformIdentifier", targetPlatformIdentifier);
-                    propGroup.Add(platformIdentifier);
-                    var platformVersion = new XElement(ns + "TargetPlatformVersion", targetPlatformVersion);
-                    propGroup.Add(platformVersion);
-                    var platformSupported = new XElement(ns + "TargetPlatformSupported", true);
-                    propGroup.Add(platformSupported);
-                    var disableUnnecessaryImplicitFrameworkReferencesForThisTest = new XElement(ns + "DisableImplicitFrameworkReferences", "true");
-                    propGroup.Add(disableUnnecessaryImplicitFrameworkReferencesForThisTest);
-                });
-
-            AssertDefinedConstantsOutput(testAsset, targetFramework, new[] { "NETCOREAPP", "NET", "NET5_0", "NETCOREAPP3_1" }.Concat(expectedDefines).ToArray());
-        }
-
-        [Theory]
-        [InlineData(new[] { "1.0", "1.1" }, "ios", "1.1", new[] { "IOS", "IOS1_1", "IOS1_0" })]
-        [InlineData(new[] { "11.11", "12.12", "13.13" }, "android", "12.12", new[] { "ANDROID", "ANDROID11_11", "ANDROID12_12" })]
-        [InlineData(new string[] { /* Use the built in SdkSupportedTargetPlatform items */}, "windows", "10.0.19041.0", new[] { "WINDOWS", "WINDOWS7_0", "WINDOWS8_0", "WINDOWS10_0_17763_0", "WINDOWS10_0_18362_0", "WINDOWS10_0_19041_0" })]
-        public void It_implicitly_defines_compilation_constants_for_the_target_platform_with_backwards_compatibility(string[] sdkSupportedTargetPlatform, string targetPlatformIdentifier, string targetPlatformVersion, string[] expectedDefines)
+        [InlineData(new string[] { }, "ios", "1.1", new[] { "IOS", "IOS1_1" })]
+        [InlineData(new string[] { }, "android", "2.2", new[] { "ANDROID", "ANDROID2_2" })]
+        [InlineData(new string[] { }, "windows", "7.0", new[] { "WINDOWS", "WINDOWS7_0" })]
+        [InlineData(new string[] { }, "windows", "10.0.19041.0", new[] { "WINDOWS", "WINDOWS10_0_19041_0" })]
+        [InlineData(new[] { "1.0", "1.1" }, "ios", "1.1", new[] { "IOS", "IOS1_1" })]
+        [InlineData(new[] { "11.11", "12.12", "13.13" }, "android", "12.12", new[] { "ANDROID", "ANDROID12_12" })]
+        public void It_implicitly_defines_compilation_constants_for_the_target_platform(string[] sdkSupportedTargetPlatform, string targetPlatformIdentifier, string targetPlatformVersion, string[] expectedDefines)
         {
             var targetFramework = "net5.0";
             var testAsset = _testAssetsManager
@@ -486,7 +426,7 @@ namespace Microsoft.NET.Build.Tests
                     }
                 });
 
-            AssertDefinedConstantsOutput(testAsset, targetFramework, new[] { "NETCOREAPP", "NET", "NET5_0", "NETCOREAPP3_1" }.Concat(expectedDefines).ToArray());
+            AssertDefinedConstantsOutput(testAsset, targetFramework, new[] { "NETCOREAPP", "NET", "NET5_0" }.Concat(expectedDefines).ToArray());
         }
 
         private void AssertDefinedConstantsOutput(TestAsset testAsset, string targetFramework, string[] expectedDefines)
@@ -512,7 +452,7 @@ namespace Microsoft.NET.Build.Tests
 
         [WindowsOnlyTheory]
         [InlineData("netcoreapp3.1", new[] { "NETCOREAPP", "NETCOREAPP3_1" })]
-        [InlineData("net5.0", new[] { "NETCOREAPP", "NETCOREAPP3_1", "NET", "NET5_0", "WINDOWS", "WINDOWS7_0" }, "windows", "7.0")]
+        [InlineData("net5.0", new[] { "NETCOREAPP", "NET", "NET5_0", "WINDOWS", "WINDOWS7_0" }, "windows", "7.0")]
         public void It_can_use_implicitly_defined_compilation_constants(string targetFramework, string[] expectedOutput, string targetPlatformIdentifier = null, string targetPlatformVersion = null)
         {
             var testProj = new TestProject()

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildALibrary.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildALibrary.cs
@@ -389,12 +389,9 @@ namespace Microsoft.NET.Build.Tests
         }
 
         [Theory]
-        [InlineData(new string[] { }, "ios", "1.1", new[] { "IOS", "IOS1_1" })]
-        [InlineData(new string[] { }, "android", "2.2", new[] { "ANDROID", "ANDROID2_2" })]
-        [InlineData(new string[] { }, "windows", "7.0", new[] { "WINDOWS", "WINDOWS7_0" })]
-        [InlineData(new string[] { }, "windows", "10.0.19041.0", new[] { "WINDOWS", "WINDOWS10_0_19041_0" })]
-        [InlineData(new[] { "1.0", "1.1" }, "ios", "1.1", new[] { "IOS", "IOS1_1" })]
-        [InlineData(new[] { "11.11", "12.12", "13.13" }, "android", "12.12", new[] { "ANDROID", "ANDROID12_12" })]
+        [InlineData(new string[] { }, "windows", "10.0.19041.0", new[] { "WINDOWS" })]
+        [InlineData(new[] { "1.0", "1.1" }, "ios", "1.1", new[] { "IOS" })]
+        [InlineData(new[] { "11.11", "12.12", "13.13" }, "android", "12.12", new[] { "ANDROID" })]
         public void It_implicitly_defines_compilation_constants_for_the_target_platform(string[] sdkSupportedTargetPlatform, string targetPlatformIdentifier, string targetPlatformVersion, string[] expectedDefines)
         {
             var targetFramework = "net5.0";
@@ -452,7 +449,7 @@ namespace Microsoft.NET.Build.Tests
 
         [WindowsOnlyTheory]
         [InlineData("netcoreapp3.1", new[] { "NETCOREAPP", "NETCOREAPP3_1" })]
-        [InlineData("net5.0", new[] { "NETCOREAPP", "NET", "NET5_0", "WINDOWS", "WINDOWS7_0" }, "windows", "7.0")]
+        [InlineData("net5.0", new[] { "NETCOREAPP", "NET", "NET5_0", "WINDOWS" }, "windows", "7.0")]
         public void It_can_use_implicitly_defined_compilation_constants(string targetFramework, string[] expectedOutput, string targetPlatformIdentifier = null, string targetPlatformVersion = null)
         {
             var testProj = new TestProject()
@@ -492,14 +489,8 @@ class Program
         #if WINDOWS
             Console.WriteLine(""WINDOWS"");
         #endif
-        #if WINDOWS7_0
-            Console.WriteLine(""WINDOWS7_0"");
-        #endif
         #if IOS
             Console.WriteLine(""IOS"");
-        #endif
-        #if IOS7_0
-            Console.WriteLine(""IOS7_0"");
         #endif
     }
 }");

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildALibraryWithFSharp.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildALibraryWithFSharp.cs
@@ -15,10 +15,6 @@ using System.Collections.Generic;
 using System;
 using System.Runtime.CompilerServices;
 using Xunit.Abstractions;
-using Microsoft.NET.TestFramework.ProjectConstruction;
-using NuGet.ProjectModel;
-using NuGet.Common;
-using Newtonsoft.Json.Linq;
 
 namespace Microsoft.NET.Build.Tests
 {
@@ -182,6 +178,7 @@ namespace Microsoft.NET.Build.Tests
         [InlineData("net45", new[] { "NETFRAMEWORK", "NET45" }, true)]
         [InlineData("net461", new[] { "NETFRAMEWORK", "NET461" }, true)]
         [InlineData("netcoreapp2.0", new[] { "NETCOREAPP", "NETCOREAPP2_0" }, false)]
+        [InlineData("net5.0", new[] { "NETCOREAPP", "NET", "NET5_0" }, false)]
         public void It_implicitly_defines_compilation_constants_for_the_target_framework(string targetFramework, string[] expectedDefines, bool buildOnlyOnWindows)
         {
             bool shouldCompile = true;

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildALibraryWithVB.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildALibraryWithVB.cs
@@ -15,10 +15,6 @@ using System.Collections.Generic;
 using System;
 using System.Runtime.CompilerServices;
 using Xunit.Abstractions;
-using Microsoft.NET.TestFramework.ProjectConstruction;
-using NuGet.ProjectModel;
-using NuGet.Common;
-using Newtonsoft.Json.Linq;
 
 namespace Microsoft.NET.Build.Tests
 {
@@ -195,7 +191,7 @@ namespace Microsoft.NET.Build.Tests
         [InlineData("net45", new[] { "NETFRAMEWORK=-1", "NET45=-1" }, true)]
         [InlineData("net461", new[] { "NETFRAMEWORK=-1", "NET461=-1" }, true)]
         [InlineData("netcoreapp1.0", new[] { "NETCOREAPP=-1", "NETCOREAPP1_0=-1", "_MyType=\"Empty\"" }, false)]
-        [InlineData("net5.0", new[] { "NET=-1", "NET5_0=-1", "NETCOREAPP=-1", "NETCOREAPP3_1=-1", "_MyType=\"Empty\"" }, false)]
+        [InlineData("net5.0", new[] { "NET=-1", "NET5_0=-1", "NETCOREAPP=-1", "_MyType=\"Empty\"" }, false)]
         [InlineData(".NETPortable,Version=v4.5,Profile=Profile78", new string[] { "_MyType=\"Empty\"" }, false)]
         [InlineData(".NETFramework,Version=v4.0,Profile=Client", new string[] { "NETFRAMEWORK=-1", "NET40=-1" }, false)]
         [InlineData("Xamarin.iOS,Version=v1.0", new string[] { "XAMARINIOS=-1", "XAMARINIOS1_0=-1", "_MyType=\"Empty\"" }, false)]


### PR DESCRIPTION
Fixes https://github.com/dotnet/sdk/issues/13377