### PR TITLE
Add FSharp.Core docs to the set of files to be published

### DIFF
--- a/src/Layout/tool_fsharp/tool_fsc.csproj
+++ b/src/Layout/tool_fsharp/tool_fsc.csproj
@@ -4,9 +4,21 @@
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.FSharp.Compiler" Version="$(MicrosoftFSharpCompilerPackageVersion)" />
+    <PackageReference Include="Microsoft.FSharp.Compiler" Version="$(MicrosoftFSharpCompilerPackageVersion)" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.Build.Framework" Version="$(FSharpBuildVersion)" />
     <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(FSharpBuildVersion)" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(FSharpBuildVersion)" />
   </ItemGroup>
+
+   <Target Name="_ResolvePublishNuGetPackagePdbsAndXml"
+        AfterTargets="_ResolveCopyLocalAssetsForPublish">
+    <ItemGroup>
+        <ResolvedFileToPublish
+          Include="$(PkgMicrosoft_FSharp_Compiler)/lib/netcoreapp3.1/FSharp.Core.xml"
+          CopyToPublishDirectory="PreserveNewest"
+          DestinationSubPath="FSharp.Core.xml"
+          RelativePath="FSharp.Core.xml"
+          TargetPath="FSharpCore.xml" />
+    </ItemGroup>
+  </Target>
 </Project>


### PR DESCRIPTION
Fixes #13590 by using the MSBuild-generated property that points to the package location of the `Microsoft.FSharp.Compiler` `PackageReference` to include the bundled xml documentation there.

This is based off of the suggestion over at [issue 1458](https://github.com/dotnet/sdk/issues/1458#issuecomment-667037150) but uncomplicated a bit because it doesn't need to be quite so generic.

After the build now, the FSharp.Core.xml file is located in the publish directory of the tool_fsc project.