### PR TITLE
Add RuntimePackAlwaysCopyLocal run time asset

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -700,8 +700,13 @@ Copyright (c) .NET Foundation. All rights reserved.
                                        Condition="'$(PublishReferencesDocumentationFiles)' == 'true' or '%(ReferenceCopyLocalPaths.Extension)' != '.xml'">
         <DestinationSubPath>%(ReferenceCopyLocalPaths.DestinationSubDirectory)%(ReferenceCopyLocalPaths.Filename)%(ReferenceCopyLocalPaths.Extension)</DestinationSubPath>
       </_ResolvedCopyLocalPublishAssets>
-    </ItemGroup>
 
+      <!-- Include RuntimePackAsset where RuntimePackAlwaysCopyLocal is true -->
+      <_ResolvedCopyLocalPublishAssets Include="@(RuntimePackAsset)"
+                              Condition="'%(RuntimePackAsset.RuntimePackAlwaysCopyLocal)' == 'true'">
+        <DestinationSubPath>%(ReferenceCopyLocalPaths.DestinationSubDirectory)%(ReferenceCopyLocalPaths.Filename)%(ReferenceCopyLocalPaths.Extension)</DestinationSubPath>
+      </_ResolvedCopyLocalPublishAssets>
+    </ItemGroup>
   </Target>
 
   <!--


### PR DESCRIPTION
So that wapproj can copy these files out

wapproj is a scenario originally missed.

wapproj decide what to copy by look into ResolvedFileToPublish. We added _RuntimePackAlwaysCopyLocal=true_ to _ReferenceCopyLocalPaths_. However, we excluded all runtime asset from _ResolvedCopyLocalPublishAssets (which includes all _ReferenceCopyLocalPaths_). This change is to add _RuntimePackAsset.RuntimePackAlwaysCopyLocal = true_ . _ResolvedCopyLocalPublishAssets_  end up in ResolvedFileToPublish eventually.

_RuntimePackAlwaysCopyLocal_ is a flag to tell Microsoft.Windows.SDK.NET apart from other runtime assets that installed on client machine, therefor need to copylocal