### PR TITLE
Fix target platform attribute generation

### DIFF
--- a/src/Tasks/Common/Resources/Strings.resx
+++ b/src/Tasks/Common/Resources/Strings.resx
@@ -641,8 +641,8 @@ The following are names of parameters or literal values and should not be transl
     <value>NETSDK1134: Building a solution with a specific RuntimeIdentifier is not supported. If you would like to publish for a single RID, specifiy the RID at the individual project level instead.</value>
     <comment>{StrBegin="NETSDK1134: "}</comment>
   </data>
-  <data name="CannotHaveSupportedOSPlatformHigherThanTargetPlatformVersion" xml:space="preserve">
-    <value>NETSDK1135: SupportedOSPlatform {0} cannot be higher than TargetPlatformVersion {1}.</value>
+  <data name="CannotHaveSupportedOSPlatformVersionHigherThanTargetPlatformVersion" xml:space="preserve">
+    <value>NETSDK1135: SupportedOSPlatformVersion {0} cannot be higher than TargetPlatformVersion {1}.</value>
     <comment>{StrBegin="NETSDK1135: "}</comment>
   </data>
   <data name="WindowsDesktopTargetPlatformMustBeWindows" xml:space="preserve">

--- a/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
@@ -107,11 +107,6 @@
         <target state="translated">NETSDK1007: Nelze najít informace o projektu pro {0}. Může to znamenat chybějící odkaz na projekt.</target>
         <note>{StrBegin="NETSDK1007: "}</note>
       </trans-unit>
-      <trans-unit id="CannotHaveSupportedOSPlatformHigherThanTargetPlatformVersion">
-        <source>NETSDK1135: SupportedOSPlatform {0} cannot be higher than TargetPlatformVersion {1}.</source>
-        <target state="new">NETSDK1135: SupportedOSPlatform {0} cannot be higher than TargetPlatformVersion {1}.</target>
-        <note>{StrBegin="NETSDK1135: "}</note>
-      </trans-unit>
       <trans-unit id="CannotHaveRuntimeIdentifierPlatformMismatchPlatformTarget">
         <source>NETSDK1032: The RuntimeIdentifier platform '{0}' and the PlatformTarget '{1}' must be compatible.</source>
         <target state="translated">NETSDK1032: Platforma RuntimeIdentifier {0} a PlatformTarget {1} musí být kompatibilní.</target>
@@ -141,6 +136,11 @@
         <source>NETSDK1134: Building a solution with a specific RuntimeIdentifier is not supported. If you would like to publish for a single RID, specifiy the RID at the individual project level instead.</source>
         <target state="new">NETSDK1134: Building a solution with a specific RuntimeIdentifier is not supported. If you would like to publish for a single RID, specifiy the RID at the individual project level instead.</target>
         <note>{StrBegin="NETSDK1134: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotHaveSupportedOSPlatformVersionHigherThanTargetPlatformVersion">
+        <source>NETSDK1135: SupportedOSPlatformVersion {0} cannot be higher than TargetPlatformVersion {1}.</source>
+        <target state="new">NETSDK1135: SupportedOSPlatformVersion {0} cannot be higher than TargetPlatformVersion {1}.</target>
+        <note>{StrBegin="NETSDK1135: "}</note>
       </trans-unit>
       <trans-unit id="CannotIncludeAllContentButNotNativeLibrariesInSingleFile">
         <source>NETSDK1143: Including all content in a single file bundle also includes native libraries. If IncludeAllContentForSelfExtract is true, IncludeNativeLibrariesForSelfExtract must not be false.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.de.xlf
@@ -107,11 +107,6 @@
         <target state="translated">NETSDK1007: Die Projektinformationen für "{0}" wurden nicht gefunden. Dies ist möglicherweise auf einen fehlenden Projektverweis zurückzuführen.</target>
         <note>{StrBegin="NETSDK1007: "}</note>
       </trans-unit>
-      <trans-unit id="CannotHaveSupportedOSPlatformHigherThanTargetPlatformVersion">
-        <source>NETSDK1135: SupportedOSPlatform {0} cannot be higher than TargetPlatformVersion {1}.</source>
-        <target state="new">NETSDK1135: SupportedOSPlatform {0} cannot be higher than TargetPlatformVersion {1}.</target>
-        <note>{StrBegin="NETSDK1135: "}</note>
-      </trans-unit>
       <trans-unit id="CannotHaveRuntimeIdentifierPlatformMismatchPlatformTarget">
         <source>NETSDK1032: The RuntimeIdentifier platform '{0}' and the PlatformTarget '{1}' must be compatible.</source>
         <target state="translated">NETSDK1032: Die RuntimeIdentifier-Plattform "{0}" und das PlatformTarget "{1}" müssen kompatibel sein.</target>
@@ -141,6 +136,11 @@
         <source>NETSDK1134: Building a solution with a specific RuntimeIdentifier is not supported. If you would like to publish for a single RID, specifiy the RID at the individual project level instead.</source>
         <target state="new">NETSDK1134: Building a solution with a specific RuntimeIdentifier is not supported. If you would like to publish for a single RID, specifiy the RID at the individual project level instead.</target>
         <note>{StrBegin="NETSDK1134: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotHaveSupportedOSPlatformVersionHigherThanTargetPlatformVersion">
+        <source>NETSDK1135: SupportedOSPlatformVersion {0} cannot be higher than TargetPlatformVersion {1}.</source>
+        <target state="new">NETSDK1135: SupportedOSPlatformVersion {0} cannot be higher than TargetPlatformVersion {1}.</target>
+        <note>{StrBegin="NETSDK1135: "}</note>
       </trans-unit>
       <trans-unit id="CannotIncludeAllContentButNotNativeLibrariesInSingleFile">
         <source>NETSDK1143: Including all content in a single file bundle also includes native libraries. If IncludeAllContentForSelfExtract is true, IncludeNativeLibrariesForSelfExtract must not be false.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.es.xlf
@@ -107,11 +107,6 @@
         <target state="translated">NETSDK1007: No se encuentra la información de proyecto de "{0}". Esto puede indicar que falta una referencia de proyecto.</target>
         <note>{StrBegin="NETSDK1007: "}</note>
       </trans-unit>
-      <trans-unit id="CannotHaveSupportedOSPlatformHigherThanTargetPlatformVersion">
-        <source>NETSDK1135: SupportedOSPlatform {0} cannot be higher than TargetPlatformVersion {1}.</source>
-        <target state="new">NETSDK1135: SupportedOSPlatform {0} cannot be higher than TargetPlatformVersion {1}.</target>
-        <note>{StrBegin="NETSDK1135: "}</note>
-      </trans-unit>
       <trans-unit id="CannotHaveRuntimeIdentifierPlatformMismatchPlatformTarget">
         <source>NETSDK1032: The RuntimeIdentifier platform '{0}' and the PlatformTarget '{1}' must be compatible.</source>
         <target state="translated">NETSDK1032: Las plataformas RuntimeIdentifier "{0}" y PlatformTarget "{1}" deben ser compatibles.</target>
@@ -141,6 +136,11 @@
         <source>NETSDK1134: Building a solution with a specific RuntimeIdentifier is not supported. If you would like to publish for a single RID, specifiy the RID at the individual project level instead.</source>
         <target state="new">NETSDK1134: Building a solution with a specific RuntimeIdentifier is not supported. If you would like to publish for a single RID, specifiy the RID at the individual project level instead.</target>
         <note>{StrBegin="NETSDK1134: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotHaveSupportedOSPlatformVersionHigherThanTargetPlatformVersion">
+        <source>NETSDK1135: SupportedOSPlatformVersion {0} cannot be higher than TargetPlatformVersion {1}.</source>
+        <target state="new">NETSDK1135: SupportedOSPlatformVersion {0} cannot be higher than TargetPlatformVersion {1}.</target>
+        <note>{StrBegin="NETSDK1135: "}</note>
       </trans-unit>
       <trans-unit id="CannotIncludeAllContentButNotNativeLibrariesInSingleFile">
         <source>NETSDK1143: Including all content in a single file bundle also includes native libraries. If IncludeAllContentForSelfExtract is true, IncludeNativeLibrariesForSelfExtract must not be false.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
@@ -107,11 +107,6 @@
         <target state="translated">NETSDK1007: Les informations relatives au projet sont introuvables pour '{0}'. Cela peut indiquer une référence de projet manquante.</target>
         <note>{StrBegin="NETSDK1007: "}</note>
       </trans-unit>
-      <trans-unit id="CannotHaveSupportedOSPlatformHigherThanTargetPlatformVersion">
-        <source>NETSDK1135: SupportedOSPlatform {0} cannot be higher than TargetPlatformVersion {1}.</source>
-        <target state="new">NETSDK1135: SupportedOSPlatform {0} cannot be higher than TargetPlatformVersion {1}.</target>
-        <note>{StrBegin="NETSDK1135: "}</note>
-      </trans-unit>
       <trans-unit id="CannotHaveRuntimeIdentifierPlatformMismatchPlatformTarget">
         <source>NETSDK1032: The RuntimeIdentifier platform '{0}' and the PlatformTarget '{1}' must be compatible.</source>
         <target state="translated">NETSDK1032: La plateforme de RuntimeIdentifier '{0}' et le PlatformTarget '{1}' doivent être compatibles.</target>
@@ -141,6 +136,11 @@
         <source>NETSDK1134: Building a solution with a specific RuntimeIdentifier is not supported. If you would like to publish for a single RID, specifiy the RID at the individual project level instead.</source>
         <target state="new">NETSDK1134: Building a solution with a specific RuntimeIdentifier is not supported. If you would like to publish for a single RID, specifiy the RID at the individual project level instead.</target>
         <note>{StrBegin="NETSDK1134: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotHaveSupportedOSPlatformVersionHigherThanTargetPlatformVersion">
+        <source>NETSDK1135: SupportedOSPlatformVersion {0} cannot be higher than TargetPlatformVersion {1}.</source>
+        <target state="new">NETSDK1135: SupportedOSPlatformVersion {0} cannot be higher than TargetPlatformVersion {1}.</target>
+        <note>{StrBegin="NETSDK1135: "}</note>
       </trans-unit>
       <trans-unit id="CannotIncludeAllContentButNotNativeLibrariesInSingleFile">
         <source>NETSDK1143: Including all content in a single file bundle also includes native libraries. If IncludeAllContentForSelfExtract is true, IncludeNativeLibrariesForSelfExtract must not be false.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.it.xlf
@@ -107,11 +107,6 @@
         <target state="translated">NETSDK1007: le informazioni del progetto per '{0}' non sono state trovate. Questo errore può indicare la mancanza di un riferimento al progetto.</target>
         <note>{StrBegin="NETSDK1007: "}</note>
       </trans-unit>
-      <trans-unit id="CannotHaveSupportedOSPlatformHigherThanTargetPlatformVersion">
-        <source>NETSDK1135: SupportedOSPlatform {0} cannot be higher than TargetPlatformVersion {1}.</source>
-        <target state="new">NETSDK1135: SupportedOSPlatform {0} cannot be higher than TargetPlatformVersion {1}.</target>
-        <note>{StrBegin="NETSDK1135: "}</note>
-      </trans-unit>
       <trans-unit id="CannotHaveRuntimeIdentifierPlatformMismatchPlatformTarget">
         <source>NETSDK1032: The RuntimeIdentifier platform '{0}' and the PlatformTarget '{1}' must be compatible.</source>
         <target state="translated">NETSDK1032: la piattaforma '{0}' di RuntimeIdentifier e quella '{1}' di PlatformTarget devono essere compatibili.</target>
@@ -141,6 +136,11 @@
         <source>NETSDK1134: Building a solution with a specific RuntimeIdentifier is not supported. If you would like to publish for a single RID, specifiy the RID at the individual project level instead.</source>
         <target state="new">NETSDK1134: Building a solution with a specific RuntimeIdentifier is not supported. If you would like to publish for a single RID, specifiy the RID at the individual project level instead.</target>
         <note>{StrBegin="NETSDK1134: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotHaveSupportedOSPlatformVersionHigherThanTargetPlatformVersion">
+        <source>NETSDK1135: SupportedOSPlatformVersion {0} cannot be higher than TargetPlatformVersion {1}.</source>
+        <target state="new">NETSDK1135: SupportedOSPlatformVersion {0} cannot be higher than TargetPlatformVersion {1}.</target>
+        <note>{StrBegin="NETSDK1135: "}</note>
       </trans-unit>
       <trans-unit id="CannotIncludeAllContentButNotNativeLibrariesInSingleFile">
         <source>NETSDK1143: Including all content in a single file bundle also includes native libraries. If IncludeAllContentForSelfExtract is true, IncludeNativeLibrariesForSelfExtract must not be false.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
@@ -107,11 +107,6 @@
         <target state="translated">NETSDK1007: '{0}' のプロジェクト情報が見つかりません。これは、プロジェクト参照がないことを示している可能性があります。</target>
         <note>{StrBegin="NETSDK1007: "}</note>
       </trans-unit>
-      <trans-unit id="CannotHaveSupportedOSPlatformHigherThanTargetPlatformVersion">
-        <source>NETSDK1135: SupportedOSPlatform {0} cannot be higher than TargetPlatformVersion {1}.</source>
-        <target state="new">NETSDK1135: SupportedOSPlatform {0} cannot be higher than TargetPlatformVersion {1}.</target>
-        <note>{StrBegin="NETSDK1135: "}</note>
-      </trans-unit>
       <trans-unit id="CannotHaveRuntimeIdentifierPlatformMismatchPlatformTarget">
         <source>NETSDK1032: The RuntimeIdentifier platform '{0}' and the PlatformTarget '{1}' must be compatible.</source>
         <target state="translated">NETSDK1032: RuntimeIdentifier プラットフォーム '{0}' と PlatformTarget '{1}' には互換性が必要です。</target>
@@ -141,6 +136,11 @@
         <source>NETSDK1134: Building a solution with a specific RuntimeIdentifier is not supported. If you would like to publish for a single RID, specifiy the RID at the individual project level instead.</source>
         <target state="new">NETSDK1134: Building a solution with a specific RuntimeIdentifier is not supported. If you would like to publish for a single RID, specifiy the RID at the individual project level instead.</target>
         <note>{StrBegin="NETSDK1134: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotHaveSupportedOSPlatformVersionHigherThanTargetPlatformVersion">
+        <source>NETSDK1135: SupportedOSPlatformVersion {0} cannot be higher than TargetPlatformVersion {1}.</source>
+        <target state="new">NETSDK1135: SupportedOSPlatformVersion {0} cannot be higher than TargetPlatformVersion {1}.</target>
+        <note>{StrBegin="NETSDK1135: "}</note>
       </trans-unit>
       <trans-unit id="CannotIncludeAllContentButNotNativeLibrariesInSingleFile">
         <source>NETSDK1143: Including all content in a single file bundle also includes native libraries. If IncludeAllContentForSelfExtract is true, IncludeNativeLibrariesForSelfExtract must not be false.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
@@ -107,11 +107,6 @@
         <target state="translated">NETSDK1007: '{0}'에 대한 프로젝트 정보를 찾을 수 없습니다. 프로젝트 참조가 없음을 나타낼 수 있습니다.</target>
         <note>{StrBegin="NETSDK1007: "}</note>
       </trans-unit>
-      <trans-unit id="CannotHaveSupportedOSPlatformHigherThanTargetPlatformVersion">
-        <source>NETSDK1135: SupportedOSPlatform {0} cannot be higher than TargetPlatformVersion {1}.</source>
-        <target state="new">NETSDK1135: SupportedOSPlatform {0} cannot be higher than TargetPlatformVersion {1}.</target>
-        <note>{StrBegin="NETSDK1135: "}</note>
-      </trans-unit>
       <trans-unit id="CannotHaveRuntimeIdentifierPlatformMismatchPlatformTarget">
         <source>NETSDK1032: The RuntimeIdentifier platform '{0}' and the PlatformTarget '{1}' must be compatible.</source>
         <target state="translated">NETSDK1032: RuntimeIdentifier 플랫폼 '{0}'과(와) PlatformTarget '{1}'은(는) 호환되어야 합니다.</target>
@@ -141,6 +136,11 @@
         <source>NETSDK1134: Building a solution with a specific RuntimeIdentifier is not supported. If you would like to publish for a single RID, specifiy the RID at the individual project level instead.</source>
         <target state="new">NETSDK1134: Building a solution with a specific RuntimeIdentifier is not supported. If you would like to publish for a single RID, specifiy the RID at the individual project level instead.</target>
         <note>{StrBegin="NETSDK1134: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotHaveSupportedOSPlatformVersionHigherThanTargetPlatformVersion">
+        <source>NETSDK1135: SupportedOSPlatformVersion {0} cannot be higher than TargetPlatformVersion {1}.</source>
+        <target state="new">NETSDK1135: SupportedOSPlatformVersion {0} cannot be higher than TargetPlatformVersion {1}.</target>
+        <note>{StrBegin="NETSDK1135: "}</note>
       </trans-unit>
       <trans-unit id="CannotIncludeAllContentButNotNativeLibrariesInSingleFile">
         <source>NETSDK1143: Including all content in a single file bundle also includes native libraries. If IncludeAllContentForSelfExtract is true, IncludeNativeLibrariesForSelfExtract must not be false.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
@@ -107,11 +107,6 @@
         <target state="translated">NETSDK1007: Nie odnaleziono informacji o projekcie dla elementu „{0}”. Może to wskazywać na brakujące odwołanie do projektu.</target>
         <note>{StrBegin="NETSDK1007: "}</note>
       </trans-unit>
-      <trans-unit id="CannotHaveSupportedOSPlatformHigherThanTargetPlatformVersion">
-        <source>NETSDK1135: SupportedOSPlatform {0} cannot be higher than TargetPlatformVersion {1}.</source>
-        <target state="new">NETSDK1135: SupportedOSPlatform {0} cannot be higher than TargetPlatformVersion {1}.</target>
-        <note>{StrBegin="NETSDK1135: "}</note>
-      </trans-unit>
       <trans-unit id="CannotHaveRuntimeIdentifierPlatformMismatchPlatformTarget">
         <source>NETSDK1032: The RuntimeIdentifier platform '{0}' and the PlatformTarget '{1}' must be compatible.</source>
         <target state="translated">NETSDK1032: Platforma elementu RuntimeIdentifier „{0}” i element PlatformTarget „{1}” muszą być zgodne.</target>
@@ -141,6 +136,11 @@
         <source>NETSDK1134: Building a solution with a specific RuntimeIdentifier is not supported. If you would like to publish for a single RID, specifiy the RID at the individual project level instead.</source>
         <target state="new">NETSDK1134: Building a solution with a specific RuntimeIdentifier is not supported. If you would like to publish for a single RID, specifiy the RID at the individual project level instead.</target>
         <note>{StrBegin="NETSDK1134: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotHaveSupportedOSPlatformVersionHigherThanTargetPlatformVersion">
+        <source>NETSDK1135: SupportedOSPlatformVersion {0} cannot be higher than TargetPlatformVersion {1}.</source>
+        <target state="new">NETSDK1135: SupportedOSPlatformVersion {0} cannot be higher than TargetPlatformVersion {1}.</target>
+        <note>{StrBegin="NETSDK1135: "}</note>
       </trans-unit>
       <trans-unit id="CannotIncludeAllContentButNotNativeLibrariesInSingleFile">
         <source>NETSDK1143: Including all content in a single file bundle also includes native libraries. If IncludeAllContentForSelfExtract is true, IncludeNativeLibrariesForSelfExtract must not be false.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
@@ -107,11 +107,6 @@
         <target state="translated">NETSDK1007: Não é possível localizar informações do projeto para '{0}'. Isso pode indicar a ausência de uma referência de projeto.</target>
         <note>{StrBegin="NETSDK1007: "}</note>
       </trans-unit>
-      <trans-unit id="CannotHaveSupportedOSPlatformHigherThanTargetPlatformVersion">
-        <source>NETSDK1135: SupportedOSPlatform {0} cannot be higher than TargetPlatformVersion {1}.</source>
-        <target state="new">NETSDK1135: SupportedOSPlatform {0} cannot be higher than TargetPlatformVersion {1}.</target>
-        <note>{StrBegin="NETSDK1135: "}</note>
-      </trans-unit>
       <trans-unit id="CannotHaveRuntimeIdentifierPlatformMismatchPlatformTarget">
         <source>NETSDK1032: The RuntimeIdentifier platform '{0}' and the PlatformTarget '{1}' must be compatible.</source>
         <target state="translated">NETSDK1032: A plataforma '{0}' do RuntimeIdentifier e o PlatformTarget '{1}' precisam ser compatíveis.</target>
@@ -141,6 +136,11 @@
         <source>NETSDK1134: Building a solution with a specific RuntimeIdentifier is not supported. If you would like to publish for a single RID, specifiy the RID at the individual project level instead.</source>
         <target state="new">NETSDK1134: Building a solution with a specific RuntimeIdentifier is not supported. If you would like to publish for a single RID, specifiy the RID at the individual project level instead.</target>
         <note>{StrBegin="NETSDK1134: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotHaveSupportedOSPlatformVersionHigherThanTargetPlatformVersion">
+        <source>NETSDK1135: SupportedOSPlatformVersion {0} cannot be higher than TargetPlatformVersion {1}.</source>
+        <target state="new">NETSDK1135: SupportedOSPlatformVersion {0} cannot be higher than TargetPlatformVersion {1}.</target>
+        <note>{StrBegin="NETSDK1135: "}</note>
       </trans-unit>
       <trans-unit id="CannotIncludeAllContentButNotNativeLibrariesInSingleFile">
         <source>NETSDK1143: Including all content in a single file bundle also includes native libraries. If IncludeAllContentForSelfExtract is true, IncludeNativeLibrariesForSelfExtract must not be false.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
@@ -107,11 +107,6 @@
         <target state="translated">NETSDK1007: не удается найти сведения о проекте "{0}". Возможно, отсутствует ссылка на проект.</target>
         <note>{StrBegin="NETSDK1007: "}</note>
       </trans-unit>
-      <trans-unit id="CannotHaveSupportedOSPlatformHigherThanTargetPlatformVersion">
-        <source>NETSDK1135: SupportedOSPlatform {0} cannot be higher than TargetPlatformVersion {1}.</source>
-        <target state="new">NETSDK1135: SupportedOSPlatform {0} cannot be higher than TargetPlatformVersion {1}.</target>
-        <note>{StrBegin="NETSDK1135: "}</note>
-      </trans-unit>
       <trans-unit id="CannotHaveRuntimeIdentifierPlatformMismatchPlatformTarget">
         <source>NETSDK1032: The RuntimeIdentifier platform '{0}' and the PlatformTarget '{1}' must be compatible.</source>
         <target state="translated">NETSDK1032: платформа RuntimeIdentifier "{0}" и PlatformTarget "{1}" должны быть совместимы.</target>
@@ -141,6 +136,11 @@
         <source>NETSDK1134: Building a solution with a specific RuntimeIdentifier is not supported. If you would like to publish for a single RID, specifiy the RID at the individual project level instead.</source>
         <target state="new">NETSDK1134: Building a solution with a specific RuntimeIdentifier is not supported. If you would like to publish for a single RID, specifiy the RID at the individual project level instead.</target>
         <note>{StrBegin="NETSDK1134: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotHaveSupportedOSPlatformVersionHigherThanTargetPlatformVersion">
+        <source>NETSDK1135: SupportedOSPlatformVersion {0} cannot be higher than TargetPlatformVersion {1}.</source>
+        <target state="new">NETSDK1135: SupportedOSPlatformVersion {0} cannot be higher than TargetPlatformVersion {1}.</target>
+        <note>{StrBegin="NETSDK1135: "}</note>
       </trans-unit>
       <trans-unit id="CannotIncludeAllContentButNotNativeLibrariesInSingleFile">
         <source>NETSDK1143: Including all content in a single file bundle also includes native libraries. If IncludeAllContentForSelfExtract is true, IncludeNativeLibrariesForSelfExtract must not be false.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
@@ -107,11 +107,6 @@
         <target state="translated">NETSDK1007: '{0}' için proje bilgisi bulunamıyor. Bu durum, bir proje başvurusunun eksik olduğunu gösteriyor olabilir.</target>
         <note>{StrBegin="NETSDK1007: "}</note>
       </trans-unit>
-      <trans-unit id="CannotHaveSupportedOSPlatformHigherThanTargetPlatformVersion">
-        <source>NETSDK1135: SupportedOSPlatform {0} cannot be higher than TargetPlatformVersion {1}.</source>
-        <target state="new">NETSDK1135: SupportedOSPlatform {0} cannot be higher than TargetPlatformVersion {1}.</target>
-        <note>{StrBegin="NETSDK1135: "}</note>
-      </trans-unit>
       <trans-unit id="CannotHaveRuntimeIdentifierPlatformMismatchPlatformTarget">
         <source>NETSDK1032: The RuntimeIdentifier platform '{0}' and the PlatformTarget '{1}' must be compatible.</source>
         <target state="translated">NETSDK1032: RuntimeIdentifier platformu '{0}' ile PlatformTarget '{1}' uyumlu olmalıdır.</target>
@@ -141,6 +136,11 @@
         <source>NETSDK1134: Building a solution with a specific RuntimeIdentifier is not supported. If you would like to publish for a single RID, specifiy the RID at the individual project level instead.</source>
         <target state="new">NETSDK1134: Building a solution with a specific RuntimeIdentifier is not supported. If you would like to publish for a single RID, specifiy the RID at the individual project level instead.</target>
         <note>{StrBegin="NETSDK1134: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotHaveSupportedOSPlatformVersionHigherThanTargetPlatformVersion">
+        <source>NETSDK1135: SupportedOSPlatformVersion {0} cannot be higher than TargetPlatformVersion {1}.</source>
+        <target state="new">NETSDK1135: SupportedOSPlatformVersion {0} cannot be higher than TargetPlatformVersion {1}.</target>
+        <note>{StrBegin="NETSDK1135: "}</note>
       </trans-unit>
       <trans-unit id="CannotIncludeAllContentButNotNativeLibrariesInSingleFile">
         <source>NETSDK1143: Including all content in a single file bundle also includes native libraries. If IncludeAllContentForSelfExtract is true, IncludeNativeLibrariesForSelfExtract must not be false.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
@@ -107,11 +107,6 @@
         <target state="translated">NETSDK1007: 找不到“{0}”的项目信息。这可以指示缺少一个项目引用。</target>
         <note>{StrBegin="NETSDK1007: "}</note>
       </trans-unit>
-      <trans-unit id="CannotHaveSupportedOSPlatformHigherThanTargetPlatformVersion">
-        <source>NETSDK1135: SupportedOSPlatform {0} cannot be higher than TargetPlatformVersion {1}.</source>
-        <target state="new">NETSDK1135: SupportedOSPlatform {0} cannot be higher than TargetPlatformVersion {1}.</target>
-        <note>{StrBegin="NETSDK1135: "}</note>
-      </trans-unit>
       <trans-unit id="CannotHaveRuntimeIdentifierPlatformMismatchPlatformTarget">
         <source>NETSDK1032: The RuntimeIdentifier platform '{0}' and the PlatformTarget '{1}' must be compatible.</source>
         <target state="translated">NETSDK1032: RuntimeIdentifier 平台“{0}”和 PlatformTarget“{1}”必须兼容。</target>
@@ -141,6 +136,11 @@
         <source>NETSDK1134: Building a solution with a specific RuntimeIdentifier is not supported. If you would like to publish for a single RID, specifiy the RID at the individual project level instead.</source>
         <target state="new">NETSDK1134: Building a solution with a specific RuntimeIdentifier is not supported. If you would like to publish for a single RID, specifiy the RID at the individual project level instead.</target>
         <note>{StrBegin="NETSDK1134: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotHaveSupportedOSPlatformVersionHigherThanTargetPlatformVersion">
+        <source>NETSDK1135: SupportedOSPlatformVersion {0} cannot be higher than TargetPlatformVersion {1}.</source>
+        <target state="new">NETSDK1135: SupportedOSPlatformVersion {0} cannot be higher than TargetPlatformVersion {1}.</target>
+        <note>{StrBegin="NETSDK1135: "}</note>
       </trans-unit>
       <trans-unit id="CannotIncludeAllContentButNotNativeLibrariesInSingleFile">
         <source>NETSDK1143: Including all content in a single file bundle also includes native libraries. If IncludeAllContentForSelfExtract is true, IncludeNativeLibrariesForSelfExtract must not be false.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
@@ -107,11 +107,6 @@
         <target state="translated">NETSDK1007: 找不到 '{0}' 的專案資訊。這可能表示遺漏專案參考。</target>
         <note>{StrBegin="NETSDK1007: "}</note>
       </trans-unit>
-      <trans-unit id="CannotHaveSupportedOSPlatformHigherThanTargetPlatformVersion">
-        <source>NETSDK1135: SupportedOSPlatform {0} cannot be higher than TargetPlatformVersion {1}.</source>
-        <target state="new">NETSDK1135: SupportedOSPlatform {0} cannot be higher than TargetPlatformVersion {1}.</target>
-        <note>{StrBegin="NETSDK1135: "}</note>
-      </trans-unit>
       <trans-unit id="CannotHaveRuntimeIdentifierPlatformMismatchPlatformTarget">
         <source>NETSDK1032: The RuntimeIdentifier platform '{0}' and the PlatformTarget '{1}' must be compatible.</source>
         <target state="translated">NETSDK1032: RuntimeIdentifier 平台 '{0}' 必須與 PlatformTarget '{1}' 相容。</target>
@@ -141,6 +136,11 @@
         <source>NETSDK1134: Building a solution with a specific RuntimeIdentifier is not supported. If you would like to publish for a single RID, specifiy the RID at the individual project level instead.</source>
         <target state="new">NETSDK1134: Building a solution with a specific RuntimeIdentifier is not supported. If you would like to publish for a single RID, specifiy the RID at the individual project level instead.</target>
         <note>{StrBegin="NETSDK1134: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotHaveSupportedOSPlatformVersionHigherThanTargetPlatformVersion">
+        <source>NETSDK1135: SupportedOSPlatformVersion {0} cannot be higher than TargetPlatformVersion {1}.</source>
+        <target state="new">NETSDK1135: SupportedOSPlatformVersion {0} cannot be higher than TargetPlatformVersion {1}.</target>
+        <note>{StrBegin="NETSDK1135: "}</note>
       </trans-unit>
       <trans-unit id="CannotIncludeAllContentButNotNativeLibrariesInSingleFile">
         <source>NETSDK1143: Including all content in a single file bundle also includes native libraries. If IncludeAllContentForSelfExtract is true, IncludeNativeLibrariesForSelfExtract must not be false.</source>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.GenerateAssemblyInfo.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.GenerateAssemblyInfo.targets
@@ -117,15 +117,24 @@ Copyright (c) .NET Foundation. All rights reserved.
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetPlatformIdentifier)' != ''
-                         and '$(SupportedOSPlatform)' != ''
+                         and '$(TargetPlatformVersion)' != ''
+                         and '$(TargetFrameworkIdentifier)' == '.NETCoreApp'
+                         and $([MSBuild]::VersionGreaterThanOrEquals($(_TargetFrameworkVersionWithoutV), '5.0'))">
+      <AssemblyAttribute Include="System.Runtime.Versioning.TargetPlatformAttribute">
+        <_Parameter1>$(TargetPlatformIdentifier)$(TargetPlatformVersion)</_Parameter1>
+      </AssemblyAttribute>
+    </ItemGroup>
+    
+    <ItemGroup Condition="'$(TargetPlatformIdentifier)' != ''
+                         and '$(SupportedOSPlatformVersion)' != ''
                          and '$(TargetFrameworkIdentifier)' == '.NETCoreApp'
                          and $([MSBuild]::VersionGreaterThanOrEquals($(_TargetFrameworkVersionWithoutV), '5.0'))">
       <AssemblyAttribute Include="System.Runtime.Versioning.SupportedOSPlatformAttribute"
-                         Condition="!$([MSBuild]::VersionEquals($(SupportedOSPlatform), '0.0'))" >
-        <_Parameter1>$(TargetPlatformIdentifier)$(SupportedOSPlatform)</_Parameter1>
+                         Condition="!$([MSBuild]::VersionEquals($(SupportedOSPlatformVersion), '0.0'))" >
+        <_Parameter1>$(TargetPlatformIdentifier)$(SupportedOSPlatformVersion)</_Parameter1>
       </AssemblyAttribute>
       <AssemblyAttribute Include="System.Runtime.Versioning.SupportedOSPlatformAttribute"
-                         Condition="$([MSBuild]::VersionEquals($(SupportedOSPlatform), '0.0'))" >
+                         Condition="$([MSBuild]::VersionEquals($(SupportedOSPlatformVersion), '0.0'))" >
         <_Parameter1>$(TargetPlatformIdentifier)</_Parameter1>
       </AssemblyAttribute>
     </ItemGroup>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -1009,4 +1009,16 @@ Copyright (c) .NET Foundation. All rights reserved.
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.NET.Sdk.Analyzers.targets" Condition="'$(Language)' == 'C#' or '$(Language)' == 'VB'" />
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.NET.Windows.targets" Condition="'$(TargetPlatformIdentifier)' == 'Windows'" />
   <Import Project="$(MSBuildThisFileDirectory)../../Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.targets" Condition="'$(ImportWindowsDesktopTargets)' == 'true'"/>
+
+  <!-- TargetPlatformMoniker and TargetPlatformDisplayName would normally be set in Microsoft.Common.CurrentVersion.targets.  However, the
+       TargetPlatformVersion may have been set later than that in evaluation by platform-specific targets.  So fix up those properties here -->
+  <PropertyGroup Condition="'$(TargetPlatformMoniker)' == '' and '$(TargetPlatformIdentifier)' != '' and '$(TargetPlatformVersion)' != ''">
+    <TargetPlatformMoniker>$(TargetPlatformIdentifier),Version=$(TargetPlatformVersion)</TargetPlatformMoniker>
+    <TargetPlatformDisplayName>$([Microsoft.Build.Utilities.ToolLocationHelper]::GetPlatformSDKDisplayName($(TargetPlatformIdentifier), $(TargetPlatformVersion)))</TargetPlatformDisplayName>
+  </PropertyGroup>
+
+  <!-- Default SupportedOSPlatformVersion to TargetPlatformVersion -->
+  <PropertyGroup Condition="'$(SupportedOSPlatformVersion)' == ''">
+    <SupportedOSPlatformVersion>$(TargetPlatformVersion)</SupportedOSPlatformVersion>
+  </PropertyGroup>
 </Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.TargetFrameworkInference.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.TargetFrameworkInference.targets
@@ -77,9 +77,20 @@ Copyright (c) .NET Foundation. All rights reserved.
     <_UnsupportedTargetFrameworkError>true</_UnsupportedTargetFrameworkError>
   </PropertyGroup>
 
-  <!--Default SupportedOSPlatform to TargetPlatformVersion-->
-  <PropertyGroup Condition="'$(SupportedOSPlatform)' == '' and '$(TargetPlatformVersion)' != ''">
-    <SupportedOSPlatform>$(TargetPlatformVersion)</SupportedOSPlatform>
+  <PropertyGroup Condition="'$(TargetPlatformIdentifier)' == 'Windows'">
+    <!-- When targeting Windows, sync the SupportedOSPlatformVersion and TargetPlatformMinVersion.  If either one isn't set, set it to the
+         other value. -->
+    <SupportedOSPlatformVersion Condition="'$(SupportedOSPlatformVersion)' == ''">$(TargetPlatformMinVersion)</SupportedOSPlatformVersion>
+    <TargetPlatformMinVersion Condition="'$(TargetPlatformMinVersion)' == ''">$(SupportedOSPlatformVersion)</TargetPlatformMinVersion>
+  
+    <!-- If niether were set, then use the TargetPlatformVersion value for both -->
+    <SupportedOSPlatformVersion Condition="'$(SupportedOSPlatformVersion)' == ''">$(TargetPlatformVersion)</SupportedOSPlatformVersion>
+    <TargetPlatformMinVersion Condition="'$(TargetPlatformMinVersion)' == ''">$(TargetPlatformVersion)</TargetPlatformMinVersion>    
+  </PropertyGroup>
+  
+  <!-- Default SupportedOSPlatformVersion to TargetPlatformVersion -->
+  <PropertyGroup Condition="'$(SupportedOSPlatformVersion)' == ''">
+    <SupportedOSPlatformVersion>$(TargetPlatformVersion)</SupportedOSPlatformVersion>
   </PropertyGroup>
 
   <!--
@@ -184,11 +195,11 @@ Copyright (c) .NET Foundation. All rights reserved.
                  ResourceName="NETFrameworkWithoutUsingNETSdkDefaults" />
   </Target>
 
-  <Target Name="_CheckForSupportedOSPlatformHigherThanTargetPlatformVersion" BeforeTargets="_CheckForInvalidConfigurationAndPlatform" >
+  <Target Name="_CheckForSupportedOSPlatformVersionHigherThanTargetPlatformVersion" BeforeTargets="_CheckForInvalidConfigurationAndPlatform" >
 
-    <NETSdkError Condition="'$(SupportedOSPlatform)' != '' and $(TargetPlatformVersion) != '' and $([MSBuild]::VersionGreaterThan($(SupportedOSPlatform), $(TargetPlatformVersion)))"
+    <NETSdkError Condition="'$(SupportedOSPlatformVersion)' != '' and $(TargetPlatformVersion) != '' and $([MSBuild]::VersionGreaterThan($(SupportedOSPlatformVersion), $(TargetPlatformVersion)))"
                  ResourceName="CannotHaveSupportedOSPlatformVersionHigherThanTargetPlatformVersion"
-                 FormatArguments="$(SupportedOSPlatform);$(TargetPlatformVersion)"/>
+                 FormatArguments="$(SupportedOSPlatformVersion);$(TargetPlatformVersion)"/>
   </Target>
 
   <!--C++/CLI targets rely on the patch version of the Windows SDK version as TargetPlatformVersion. Skip the normalization.-->

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.TargetFrameworkInference.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.TargetFrameworkInference.targets
@@ -179,7 +179,8 @@ Copyright (c) .NET Foundation. All rights reserved.
                  ResourceName="NETFrameworkWithoutUsingNETSdkDefaults" />
   </Target>
 
-  <Target Name="_CheckForSupportedOSPlatformVersionHigherThanTargetPlatformVersion" BeforeTargets="_CheckForInvalidConfigurationAndPlatform" >
+  <Target Name="_CheckForSupportedOSPlatformVersionHigherThanTargetPlatformVersion" BeforeTargets="_CheckForInvalidConfigurationAndPlatform"
+          Condition="'$(TargetPlatformVersion)' != '' and '$(TargetFrameworkIdentifier)' == '.NETCoreApp' and $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), 5.0))">
 
     <NETSdkError Condition="'$(SupportedOSPlatformVersion)' != '' and $(TargetPlatformVersion) != '' and $([MSBuild]::VersionGreaterThan($(SupportedOSPlatformVersion), $(TargetPlatformVersion)))"
                  ResourceName="CannotHaveSupportedOSPlatformVersionHigherThanTargetPlatformVersion"

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.TargetFrameworkInference.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.TargetFrameworkInference.targets
@@ -187,7 +187,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <Target Name="_CheckForSupportedOSPlatformHigherThanTargetPlatformVersion" BeforeTargets="_CheckForInvalidConfigurationAndPlatform" >
 
     <NETSdkError Condition="'$(SupportedOSPlatform)' != '' and $(TargetPlatformVersion) != '' and $([MSBuild]::VersionGreaterThan($(SupportedOSPlatform), $(TargetPlatformVersion)))"
-                 ResourceName="CannotHaveSupportedOSPlatformHigherThanTargetPlatformVersion"
+                 ResourceName="CannotHaveSupportedOSPlatformVersionHigherThanTargetPlatformVersion"
                  FormatArguments="$(SupportedOSPlatform);$(TargetPlatformVersion)"/>
   </Target>
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.TargetFrameworkInference.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.TargetFrameworkInference.targets
@@ -191,7 +191,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     BeforeTargets="ProcessFrameworkReferences"
     Condition="'$(TargetPlatformVersion)' != '' and '$(TargetFrameworkIdentifier)' == '.NETCoreApp' and $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), 5.0)) and '$(Language)' != 'C++'">
     <ItemGroup>
-      <_ValidTargetPlatformVersion Include="@(SdkSupportedTargetPlatform)" Condition="'@(SdkSupportedTargetPlatform)' != '' and $([MSBuild]::VersionEquals(%(Identity), $(TargetPlatformVersion)))" />
+      <_ValidTargetPlatformVersion Include="@(SdkSupportedTargetPlatformVersion)" Condition="'@(SdkSupportedTargetPlatformVersion)' != '' and $([MSBuild]::VersionEquals(%(Identity), $(TargetPlatformVersion)))" />
     </ItemGroup>
 
     <PropertyGroup>
@@ -205,8 +205,8 @@ Copyright (c) .NET Foundation. All rights reserved.
       Condition="'$(TargetPlatformVersion)' != '' and '$(TargetFrameworkIdentifier)' == '.NETCoreApp' and $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), 5.0)) and '$(Language)' != 'C++'">
     <PropertyGroup>
       <TargetPlatformVersionSupported Condition="'$(TargetPlatformVersionSupported)' == '' and '@(_ValidTargetPlatformVersion)' != ''" >true</TargetPlatformVersionSupported>
-      <_ValidTargetPlatformVersions Condition="'@(SdkSupportedTargetPlatform)' != ''" >@(SdkSupportedTargetPlatform, '%0a')</_ValidTargetPlatformVersions>
-      <_ValidTargetPlatformVersions Condition="'@(SdkSupportedTargetPlatform)' == ''" >None</_ValidTargetPlatformVersions>
+      <_ValidTargetPlatformVersions Condition="'@(SdkSupportedTargetPlatformVersion)' != ''" >@(SdkSupportedTargetPlatformVersion, '%0a')</_ValidTargetPlatformVersions>
+      <_ValidTargetPlatformVersions Condition="'@(SdkSupportedTargetPlatformVersion)' == ''" >None</_ValidTargetPlatformVersions>
     </PropertyGroup>
 
     <NetSdkError Condition="'$(TargetPlatformVersionSupported)' != 'true'"

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.TargetFrameworkInference.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.TargetFrameworkInference.targets
@@ -77,22 +77,6 @@ Copyright (c) .NET Foundation. All rights reserved.
     <_UnsupportedTargetFrameworkError>true</_UnsupportedTargetFrameworkError>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetPlatformIdentifier)' == 'Windows'">
-    <!-- When targeting Windows, sync the SupportedOSPlatformVersion and TargetPlatformMinVersion.  If either one isn't set, set it to the
-         other value. -->
-    <SupportedOSPlatformVersion Condition="'$(SupportedOSPlatformVersion)' == ''">$(TargetPlatformMinVersion)</SupportedOSPlatformVersion>
-    <TargetPlatformMinVersion Condition="'$(TargetPlatformMinVersion)' == ''">$(SupportedOSPlatformVersion)</TargetPlatformMinVersion>
-  
-    <!-- If niether were set, then use the TargetPlatformVersion value for both -->
-    <SupportedOSPlatformVersion Condition="'$(SupportedOSPlatformVersion)' == ''">$(TargetPlatformVersion)</SupportedOSPlatformVersion>
-    <TargetPlatformMinVersion Condition="'$(TargetPlatformMinVersion)' == ''">$(TargetPlatformVersion)</TargetPlatformMinVersion>    
-  </PropertyGroup>
-  
-  <!-- Default SupportedOSPlatformVersion to TargetPlatformVersion -->
-  <PropertyGroup Condition="'$(SupportedOSPlatformVersion)' == ''">
-    <SupportedOSPlatformVersion>$(TargetPlatformVersion)</SupportedOSPlatformVersion>
-  </PropertyGroup>
-
   <!--
     NOTE: We must not validate the TFM before restore target runs as it prevents adding additional TFM 
           support from being provided by a nuget package such as MSBuild.Sdk.Extras.

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Windows.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Windows.targets
@@ -26,9 +26,16 @@ Copyright (c) .NET Foundation. All rights reserved.
   <!-- Set 7.0 as the TargetPlatformVersion for windows. -->
   <PropertyGroup Condition="'$(TargetPlatformIdentifier)' == 'windows' and '$(TargetPlatformVersion)' == ''" >
     <TargetPlatformVersion>7.0</TargetPlatformVersion>
-    <!-- Automatic generation of TargetPlatformMoniker and TargetPlatformDisplayName have already been evaluated so we need to hardcode these values. -->
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetPlatformIdentifier)' == 'Windows'">
+    <!-- When targeting Windows, sync the SupportedOSPlatformVersion and TargetPlatformMinVersion.  If either one isn't set, set it to the
+         other value. -->
+    <SupportedOSPlatformVersion Condition="'$(SupportedOSPlatformVersion)' == ''">$(TargetPlatformMinVersion)</SupportedOSPlatformVersion>
+    <TargetPlatformMinVersion Condition="'$(TargetPlatformMinVersion)' == ''">$(SupportedOSPlatformVersion)</TargetPlatformMinVersion>
+  
+    <!-- If neither were set, then use the TargetPlatformVersion value for both -->
     <SupportedOSPlatformVersion Condition="'$(SupportedOSPlatformVersion)' == ''">$(TargetPlatformVersion)</SupportedOSPlatformVersion>
-    <TargetPlatformMoniker>Windows,Version=$(TargetPlatformVersion)</TargetPlatformMoniker>
-    <TargetPlatformDisplayName>Windows $(TargetPlatformVersion)</TargetPlatformDisplayName>
+    <TargetPlatformMinVersion Condition="'$(TargetPlatformMinVersion)' == ''">$(TargetPlatformVersion)</TargetPlatformMinVersion>    
   </PropertyGroup>
 </Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Windows.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Windows.targets
@@ -27,7 +27,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <PropertyGroup Condition="'$(TargetPlatformIdentifier)' == 'windows' and '$(TargetPlatformVersion)' == ''" >
     <TargetPlatformVersion>7.0</TargetPlatformVersion>
     <!-- Automatic generation of TargetPlatformMoniker and TargetPlatformDisplayName have already been evaluated so we need to hardcode these values. -->
-    <SupportedOSPlatform Condition="'$(SupportedOSPlatform)' == ''">$(TargetPlatformVersion)</SupportedOSPlatform>
+    <SupportedOSPlatformVersion Condition="'$(SupportedOSPlatformVersion)' == ''">$(TargetPlatformVersion)</SupportedOSPlatformVersion>
     <TargetPlatformMoniker>Windows,Version=$(TargetPlatformVersion)</TargetPlatformMoniker>
     <TargetPlatformDisplayName>Windows $(TargetPlatformVersion)</TargetPlatformDisplayName>
   </PropertyGroup>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.WindowsSdkSupportedTargetPlatforms.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.WindowsSdkSupportedTargetPlatforms.props
@@ -13,14 +13,14 @@ Copyright (c) .NET Foundation. All rights reserved.
 <!-- This file contains a list of the windows target platform versions that are supported by this SDK for .NET. Supported versions are processed in _NormalizeTargetPlatformVersion -->
 <Project>
     <ItemGroup>
-        <WindowsSdkSupportedTargetPlatform Include="10.0.19041.0" />
-        <WindowsSdkSupportedTargetPlatform Include="10.0.18362.0" />
-        <WindowsSdkSupportedTargetPlatform Include="10.0.17763.0" />
-        <WindowsSdkSupportedTargetPlatform Include="8.0" />
-        <WindowsSdkSupportedTargetPlatform Include="7.0" />
+        <WindowsSdkSupportedTargetPlatformVersion Include="10.0.19041.0" />
+        <WindowsSdkSupportedTargetPlatformVersion Include="10.0.18362.0" />
+        <WindowsSdkSupportedTargetPlatformVersion Include="10.0.17763.0" />
+        <WindowsSdkSupportedTargetPlatformVersion Include="8.0" />
+        <WindowsSdkSupportedTargetPlatformVersion Include="7.0" />
     </ItemGroup>
   
     <ItemGroup>
-        <SdkSupportedTargetPlatform Condition="'$(TargetPlatformIdentifier)' == 'Windows'" Include="@(WindowsSdkSupportedTargetPlatform)" />
+        <SdkSupportedTargetPlatformVersion Condition="'$(TargetPlatformIdentifier)' == 'Windows'" Include="@(WindowsSdkSupportedTargetPlatformVersion)" />
     </ItemGroup>
 </Project>

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildALibrary.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildALibrary.cs
@@ -392,7 +392,7 @@ namespace Microsoft.NET.Build.Tests
         [InlineData(new string[] { }, "windows", "10.0.19041.0", new[] { "WINDOWS" })]
         [InlineData(new[] { "1.0", "1.1" }, "ios", "1.1", new[] { "IOS" })]
         [InlineData(new[] { "11.11", "12.12", "13.13" }, "android", "12.12", new[] { "ANDROID" })]
-        public void It_implicitly_defines_compilation_constants_for_the_target_platform(string[] sdkSupportedTargetPlatform, string targetPlatformIdentifier, string targetPlatformVersion, string[] expectedDefines)
+        public void It_implicitly_defines_compilation_constants_for_the_target_platform(string[] sdkSupportedTargetPlatformVersion, string targetPlatformIdentifier, string targetPlatformVersion, string[] expectedDefines)
         {
             var targetFramework = "net5.0";
             var testAsset = _testAssetsManager
@@ -417,9 +417,9 @@ namespace Microsoft.NET.Build.Tests
 
                     var itemGroup = new XElement(ns + "ItemGroup");
                     project.Root.Add(itemGroup);
-                    foreach (var targetPlatform in sdkSupportedTargetPlatform)
+                    foreach (var targetPlatform in sdkSupportedTargetPlatformVersion)
                     {
-                        itemGroup.Add(new XElement(ns + "SdkSupportedTargetPlatform", new XAttribute("Include", targetPlatform)));
+                        itemGroup.Add(new XElement(ns + "SdkSupportedTargetPlatformVersion", new XAttribute("Include", targetPlatform)));
                     }
                 });
 

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildALibraryWithOSSupportedVersion.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildALibraryWithOSSupportedVersion.cs
@@ -212,6 +212,29 @@ namespace Microsoft.NET.Build.Tests
 
         }
 
+        [Theory]
+        [InlineData("netcoreapp3.1")]
+        [InlineData("net48")]
+        public void WhenNotTargetingNet5TargetPlatformMinVersionPropertyCanBeSet(string targetFramework)
+        {
+            TestProject testProject = new TestProject()
+            {
+                Name = "Project",
+                IsSdkProject = true,
+                IsExe = true,
+                TargetFrameworks = targetFramework,
+            };
+
+            testProject.AdditionalProperties["TargetPlatformMinVersion"] = "10.0.18362.0";
+
+            var testAsset = _testAssetsManager.CreateTestProject(testProject);
+
+            new BuildCommand(testAsset)
+                .Execute()
+                .Should()
+                .Pass();
+        }
+
         [Fact]
         public void WhenNotTargetingWindowsTargetPlatformMinVersionPropertyIsIgnored()
         {

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildALibraryWithOSSupportedVersion.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildALibraryWithOSSupportedVersion.cs
@@ -150,7 +150,7 @@ namespace Microsoft.NET.Build.Tests
                 .Fail().And.HaveStdOutContaining("NETSDK1135");
         }
 
-        [Fact]
+        [WindowsOnlyFact]
         public void WhenTargetPlatformMinVersionIsSetForWindowsItIsUsedForTheSupportedOSPlatformAttribute()
         {
             TestProject testProject = SetUpProject("net5.0-windows10.0.19041");
@@ -167,7 +167,7 @@ namespace Microsoft.NET.Build.Tests
                 .And.HaveStdOutContaining(SupportedOSPlatformAttribute("Windows10.0.18362.0"));
         }
 
-        [Fact]
+        [WindowsOnlyFact]
         public void WhenTargetingWindowsSupportedOSVersionPropertySetsTargetPlatformMinVersion()
         {
             TestProject testProject = SetUpProject("net5.0-windows10.0.19041");
@@ -193,7 +193,7 @@ namespace Microsoft.NET.Build.Tests
                 .BeEquivalentTo("10.0.18362.0");                
         }
 
-        [Fact]
+        [WindowsOnlyFact]
         public void WhenTargetingWindowsSupportedOSPlatformVersionPropertyIsPreferredOverTargetPlatformMinVersion()
         {
             TestProject testProject = SetUpProject("net5.0-windows10.0.19041");

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildALibraryWithOSSupportedVersion.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildALibraryWithOSSupportedVersion.cs
@@ -28,7 +28,9 @@ namespace Microsoft.NET.Build.Tests
             runCommand.WorkingDirectory = Path.Combine(testAsset.TestRoot, testProject.Name);
             runCommand.Execute()
                 .Should()
-                .Pass().And.HaveStdOutContaining("NO ATTRIBUTE");
+                .Pass()
+                .And.HaveStdOutContaining(TargetPlatformAttribute(null))
+                .And.HaveStdOutContaining(SupportedOSPlatformAttribute(null));
         }
 
         [Fact]
@@ -40,7 +42,7 @@ namespace Microsoft.NET.Build.Tests
             testProject.AdditionalProperties["TargetPlatformIdentifier"] = targetPlatformIdentifier;
             testProject.AdditionalProperties["TargetPlatformSupported"] = "true";
             testProject.AdditionalProperties["TargetPlatformVersionSupported"] = "true";
-            testProject.AdditionalProperties["SupportedOSPlatform"] = "13.2";
+            testProject.AdditionalProperties["SupportedOSPlatformVersion"] = "13.2";
             testProject.AdditionalProperties["TargetPlatformVersion"] = "14.0";
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
@@ -49,11 +51,13 @@ namespace Microsoft.NET.Build.Tests
             runCommand.WorkingDirectory = Path.Combine(testAsset.TestRoot, testProject.Name);
             runCommand.Execute()
                 .Should()
-                .Pass().And.HaveStdOutContaining("PlatformName:'iOS13.2'");
+                .Pass()
+                .And.HaveStdOutContaining(TargetPlatformAttribute("iOS14.0"))
+                .And.HaveStdOutContaining(SupportedOSPlatformAttribute("iOS13.2"));
         }
 
         [Fact]
-        public void WhenSupportedOSPlatformISNotSetTargetPlatformVersionIsSetItCanGenerateSupportedOSPlatformAttribute()
+        public void WhenSupportedOSPlatformVersionIsNotSetTargetPlatformVersionIsSetItCanGenerateSupportedOSPlatformAttribute()
         {
             TestProject testProject = SetUpProject();
 
@@ -69,7 +73,9 @@ namespace Microsoft.NET.Build.Tests
             runCommand.WorkingDirectory = Path.Combine(testAsset.TestRoot, testProject.Name);
             runCommand.Execute()
                 .Should()
-                .Pass().And.HaveStdOutContaining("PlatformName:'iOS13.2'");
+                .Pass()
+                .And.HaveStdOutContaining(TargetPlatformAttribute("iOS13.2"))
+                .And.HaveStdOutContaining(SupportedOSPlatformAttribute("iOS13.2"));
         }
 
         [Fact]
@@ -84,7 +90,9 @@ namespace Microsoft.NET.Build.Tests
             runCommand.WorkingDirectory = Path.Combine(testAsset.TestRoot, testProject.Name);
             runCommand.Execute()
                 .Should()
-                .Pass().And.HaveStdOutContaining("PlatformName:'Windows7.0'");
+                .Pass()
+                .And.HaveStdOutContaining(TargetPlatformAttribute("Windows7.0"))
+                .And.HaveStdOutContaining(SupportedOSPlatformAttribute("Windows7.0"));
         }
 
         [WindowsOnlyTheory]
@@ -100,14 +108,16 @@ namespace Microsoft.NET.Build.Tests
             runCommand.WorkingDirectory = Path.Combine(testAsset.TestRoot, testProject.Name);
             runCommand.Execute()
                 .Should()
-                .Pass().And.HaveStdOutContaining($"PlatformName:'{ expectedAttribute }'");
+                .Pass()
+                .And.HaveStdOutContaining(TargetPlatformAttribute(expectedAttribute))
+                .And.HaveStdOutContaining(SupportedOSPlatformAttribute(expectedAttribute));
         }
 
         [Fact]
-        public void WhenUsingZeroedSupportedOSPlatformItCanGenerateSupportedOSPlatformAttribute()
+        public void WhenUsingZeroedSupportedOSPlatformVersionItCanGenerateSupportedOSPlatformAttribute()
         {
             TestProject testProject = SetUpProject("net5.0-windows");
-            testProject.AdditionalProperties["SupportedOSPlatform"] = "0.0";
+            testProject.AdditionalProperties["SupportedOSPlatformVersion"] = "0.0";
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
@@ -116,12 +126,12 @@ namespace Microsoft.NET.Build.Tests
             runCommand.Execute()
                 .Should()
                 .Pass()
-                .And
-                .HaveStdOutContaining("PlatformName:'Windows'");
+                .And.HaveStdOutContaining(TargetPlatformAttribute("Windows7.0"))
+                .And.HaveStdOutContaining(SupportedOSPlatformAttribute("Windows"));
         }
 
         [Fact]
-        public void WhenSupportedOSPlatformIsHigherThanTargetPlatformVersionItShouldError()
+        public void WhenSupportedOSPlatformVersionIsHigherThanTargetPlatformVersionItShouldError()
         {
             TestProject testProject = SetUpProject();
 
@@ -129,7 +139,7 @@ namespace Microsoft.NET.Build.Tests
             testProject.AdditionalProperties["TargetPlatformIdentifier"] = targetPlatformIdentifier;
             testProject.AdditionalProperties["TargetPlatformVersionSupported"] = "true";
             testProject.AdditionalProperties["TargetPlatformVersion"] = "13.2";
-            testProject.AdditionalProperties["SupportedOSPlatform"] = "14.0";
+            testProject.AdditionalProperties["SupportedOSPlatformVersion"] = "14.0";
             testProject.AdditionalProperties["TargetPlatformSupported"] = "true";
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
@@ -138,6 +148,24 @@ namespace Microsoft.NET.Build.Tests
             buildCommand.Execute()
                 .Should()
                 .Fail().And.HaveStdOutContaining("NETSDK1135");
+        }
+
+        private static string TargetPlatformAttribute(string targetPlatform)
+        {
+            string expected = string.IsNullOrEmpty(targetPlatform) ?
+                "NO TargetPlatformAttribute" :
+                $"TargetPlatform:'{targetPlatform}'";
+
+            return expected;
+        }
+  
+        private static string SupportedOSPlatformAttribute(string supportedOSPlatform)
+        {
+            string expected = string.IsNullOrEmpty(supportedOSPlatform) ?
+                "NO SupportedOSPlatformAttribute" :
+                $"SupportedOSPlatform:'{supportedOSPlatform}'";
+
+            return expected;
         }
 
         private static TestProject SetUpProject(string targetFramework = "net5.0")
@@ -150,11 +178,11 @@ namespace Microsoft.NET.Build.Tests
                 TargetFrameworks = targetFramework,
             };
 
-            testProject.SourceFiles["PrintAttribute.cs"] = _printAttribute;
+            testProject.SourceFiles["PrintAttributes.cs"] = _printAttributes;
             return testProject;
         }
 
-        private static readonly string _printAttribute = @"
+        private static readonly string _printAttributes = @"
 using System;
 using System.Runtime.Versioning;
 
@@ -165,15 +193,27 @@ namespace CustomAttributesTestApp
         public static void Main()
         {
             var assembly = typeof(CustomAttributesTestApp).Assembly;
+
+            object[] targetPlatformAttributes = assembly.GetCustomAttributes(typeof(System.Runtime.Versioning.TargetPlatformAttribute), false);
+            if (targetPlatformAttributes.Length > 0)
+            {
+                var attribute = targetPlatformAttributes[0] as System.Runtime.Versioning.TargetPlatformAttribute;
+                Console.WriteLine($""TargetPlatform:'{attribute.PlatformName}'"");
+            }
+            else
+            {
+                Console.WriteLine(""NO TargetPlatformAttribute"");
+            }
+
             object[] attributes = assembly.GetCustomAttributes(typeof(System.Runtime.Versioning.SupportedOSPlatformAttribute), false);
             if (attributes.Length > 0)
             {
                 var attribute = attributes[0] as System.Runtime.Versioning.SupportedOSPlatformAttribute;
-                Console.WriteLine($""PlatformName:'{attribute.PlatformName}'"");
+                Console.WriteLine($""SupportedOSPlatform:'{attribute.PlatformName}'"");
             }
             else
             {
-                Console.WriteLine(""NO ATTRIBUTE"");
+                Console.WriteLine(""NO SupportedOSPlatformAttribute"");
             }
         }
     }


### PR DESCRIPTION
Fixes #13453

- Use SupportedOSPlatformVersion property instead of SupportedOSPlatform
- Generate TargetPlatformAttribute
- Sync SupportedOSPlatformVersion property with TargetPlatformMinVersion property on Windows
- Move setting some properties to the end of Microsoft.NET.Sdk.targets, so that platform / workload targets don't have to fix anything up after defaulting `TargetPlatformVersion`
- Rename SdkSupportedTargetPlatform to SdkSupportedTargetPlatformVersion