### PR TITLE
Enable overriding IncludeWindowsSDKRefFrameworkReferences (#12641)

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Windows.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Windows.props
@@ -11,7 +11,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 -->
 
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <ItemGroup Condition=" '$(_IncludeWindowsSDKRefFrameworkReferences)' == 'true' ">
+  <ItemGroup Condition=" '$(IncludeWindowsSDKRefFrameworkReferences)' == 'true' ">
     <FrameworkReference Include="Microsoft.Windows.SDK.NET.Ref" IsImplicitlyDefined="true" Pack="false" PrivateAssets="All" />
   </ItemGroup>
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Windows.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Windows.targets
@@ -19,8 +19,9 @@ Copyright (c) .NET Foundation. All rights reserved.
                              and '$(TargetPlatformIdentifier)' == 'Windows'
                              and '$(TargetPlatformVersion)' != ''
                              and $([MSBuild]::VersionGreaterThanOrEquals($(TargetPlatformVersion), '10.0'))
-                             and '$(Language)' != 'C++'">
-    <_IncludeWindowsSDKRefFrameworkReferences>true</_IncludeWindowsSDKRefFrameworkReferences>
+                             and '$(Language)' != 'C++'
+                             and '$(IncludeWindowsSDKRefFrameworkReferences)' == ''">
+    <IncludeWindowsSDKRefFrameworkReferences>true</IncludeWindowsSDKRefFrameworkReferences>
   </PropertyGroup>
 
   <!-- Set 7.0 as the TargetPlatformVersion for windows. -->


### PR DESCRIPTION
If we're going to allow overriding the property we should drop the underscore since that usually indicates its usage is more private/internal

@wli3 I think the change is fairly contained, but if you want I can add some tests