### PR TITLE
Implement workload suggestion API

### DIFF
--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/IWorkloadResolver.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/IWorkloadResolver.cs
@@ -9,7 +9,7 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
     {
         IEnumerable<WorkloadResolver.PackInfo> GetInstalledWorkloadPacksOfKind(WorkloadPackKind kind);
         IEnumerable<string> GetPacksInWorkload(string workloadId);
-        IList<WorkloadResolver.WorkloadInfo> GetWorkloadSuggestionForMissingPacks(IList<string> packId);
+        ISet<WorkloadResolver.WorkloadInfo> GetWorkloadSuggestionForMissingPacks(IList<string> packId);
         /// <summary>
         /// Gets information about a workload pack from the manifests, whether or not the pack is installed
         /// </summary>

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/IWorkloadResolver.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/IWorkloadResolver.cs
@@ -10,9 +10,14 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
         IEnumerable<WorkloadResolver.PackInfo> GetInstalledWorkloadPacksOfKind(WorkloadPackKind kind);
         IEnumerable<string> GetPacksInWorkload(string workloadId);
         ISet<WorkloadResolver.WorkloadInfo> GetWorkloadSuggestionForMissingPacks(IList<string> packId);
+        
         /// <summary>
-        /// Gets information about a workload pack from the manifests, whether or not the pack is installed
+        /// Resolve the pack for this resolver's SDK band.
         /// </summary>
+        /// <remarks>
+        /// Used by the MSBuild SDK resolver to look up which versions of the SDK packs to import.
+        /// NOTE: The pack path may use an aliased ID.
+        /// </remarks>
         /// <param name="packId">A workload pack ID</param>
         /// <returns>Information about the workload pack, or null if the specified pack ID isn't found in the manifests</returns>
         WorkloadResolver.PackInfo? TryGetPackInfo(string packId);

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadDefinitionkId.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadDefinitionkId.cs
@@ -15,9 +15,9 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
 
         public WorkloadDefinitionId(string id)
         {
-            if (string.IsNullOrWhiteSpace(id))
+            if (string.IsNullOrEmpty(id))
             {
-                throw new ArgumentException($"'{nameof(id)}' cannot be null or whitespace", nameof(id));
+                throw new ArgumentException($"'{nameof(id)}' cannot be null or empty", nameof(id));
             }
 
             _id = id;

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadResolver.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadResolver.cs
@@ -34,9 +34,9 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
             return new WorkloadResolver(manifestProvider, dotnetRootPath, currentRuntimeIdentifiers);
         }
 
-        public static WorkloadResolver CreateForTests(IWorkloadManifestProvider manifestProvider, string dotNetRootPath, string[] currentRuntimeIdentifiers)
+        public static WorkloadResolver CreateForTests(IWorkloadManifestProvider manifestProvider, string dotnetRootPath, string[] currentRuntimeIdentifiers)
         {
-            return new WorkloadResolver(manifestProvider, dotNetRootPath, currentRuntimeIdentifiers);
+            return new WorkloadResolver(manifestProvider, dotnetRootPath, currentRuntimeIdentifiers);
         }
 
         private WorkloadResolver(IWorkloadManifestProvider manifestProvider, string dotnetRootPath, string [] currentRuntimeIdentifiers)
@@ -85,10 +85,10 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
                     continue;
                 }
 
-                var packInfo = CreatePackInfo(pack.Value);
-                if (PackExists(packInfo))
+                var aliasedPath = GetAliasedPackPath(pack.Value);
+                if (PackExists(aliasedPath, pack.Value.Kind))
                 {
-                    yield return packInfo;
+                    yield return CreatePackInfo(pack.Value, aliasedPath);
                 }
             }
         }
@@ -99,35 +99,34 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
             _directoryExistOverride = directoryExists;
         }
 
-        private PackInfo CreatePackInfo(WorkloadPack pack)
-        {
-            var aliasedId = pack.TryGetAliasForRuntimeIdentifiers(_currentRuntimeIdentifiers) ?? pack.Id;
-            var packPath = GetPackPath(_dotnetRootPath, aliasedId, pack.Version, pack.Kind);
-
-            return new PackInfo(
+        private PackInfo CreatePackInfo(WorkloadPack pack, string aliasedPath) => new PackInfo(
                 pack.Id.ToString(),
                 pack.Version,
                 pack.Kind,
-                packPath
+                aliasedPath
             );
-        }
-        
 
-        private bool PackExists (PackInfo packInfo)
+        private bool PackExists (string packPath, WorkloadPackKind packKind)
         {
-            switch (packInfo.Kind)
+            switch (packKind)
             {
                 case WorkloadPackKind.Framework:
                 case WorkloadPackKind.Sdk:
                 case WorkloadPackKind.Tool:
                     //can we do a more robust check than directory.exists?
-                    return _directoryExistOverride?.Invoke(packInfo.Path) ?? Directory.Exists(packInfo.Path);
+                    return _directoryExistOverride?.Invoke(packPath) ?? Directory.Exists(packPath);
                 case WorkloadPackKind.Library:
                 case WorkloadPackKind.Template:
-                    return _fileExistOverride?.Invoke(packInfo.Path) ?? File.Exists(packInfo.Path);
+                    return _fileExistOverride?.Invoke(packPath) ?? File.Exists(packPath);
                 default:
-                    throw new ArgumentException($"The package kind '{packInfo.Kind}' is not known", nameof(packInfo));
+                    throw new ArgumentException($"The package kind '{packKind}' is not known", nameof(packKind));
             }
+        }
+
+        private string GetAliasedPackPath(WorkloadPack pack)
+        {
+            var aliasedId = pack.TryGetAliasForRuntimeIdentifiers(_currentRuntimeIdentifiers) ?? pack.Id;
+            return GetPackPath(_dotnetRootPath, aliasedId, pack.Version, pack.Kind);
         }
 
         private static string GetPackPath (string dotnetRootPath, WorkloadPackId packageId, string packageVersion, WorkloadPackKind kind)
@@ -156,8 +155,7 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
             var installedPacks = new HashSet<WorkloadPackId>();
             foreach (var pack in _packs)
             {
-                var aliasedId = pack.Value.TryGetAliasForPlatformIds(_platformIds) ?? pack.Value.Id;
-                var packPath = GetPackPath(_dotNetRootPath, aliasedId, pack.Value.Version, pack.Value.Kind);
+                var packPath = GetAliasedPackPath(pack.Value);
 
                 if (PackExists(packPath, pack.Value.Kind))
                 {
@@ -244,7 +242,7 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
 
             if (_packs.TryGetValue(new WorkloadPackId (packId), out var pack))
             {
-                return CreatePackInfo(pack);
+                return CreatePackInfo(pack, GetAliasedPackPath(pack));
             }
 
             return null;

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadSuggestionFinder.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadSuggestionFinder.cs
@@ -1,0 +1,183 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.NET.Sdk.WorkloadManifestReader
+{
+    internal class WorkloadSuggestionFinder
+    {
+        public WorkloadSuggestionFinder(HashSet<WorkloadPackId> installedPacks, HashSet<WorkloadPackId> requestedPacks, IEnumerable<(WorkloadDefinitionId id, HashSet<WorkloadPackId> expandedPacks)> expandedWorkloads)
+        {
+            var partialSuggestions = new List<WorkloadSuggestionCandidate>();
+            var completeSuggestions = new HashSet<WorkloadSuggestionCandidate>();
+
+            foreach (var workload in expandedWorkloads)
+            {
+                if (workload.expandedPacks.Any(e => requestedPacks.Contains(e)))
+                {
+                    var unsatisfied = new HashSet<WorkloadPackId>(requestedPacks.Where(p => !workload.expandedPacks.Contains(p)));
+                    var suggestion = new WorkloadSuggestionCandidate(new HashSet<WorkloadDefinitionId>() { workload.id }, workload.expandedPacks, unsatisfied);
+                    if (suggestion.IsComplete)
+                    {
+                        completeSuggestions.Add(suggestion);
+                    }
+                    else
+                    {
+                        partialSuggestions.Add(suggestion);
+                    }
+                }
+            }
+
+            foreach (var root in partialSuggestions)
+            {
+                GatherCompleteSuggestions(root, partialSuggestions, completeSuggestions);
+            }
+
+            UnsortedSuggestions = completeSuggestions.Select(
+                c =>
+                {
+                    var installedCount = c.Packs.Count(p => installedPacks.Contains(p));
+                    var extraPacks = c.Packs.Count - installedCount - requestedPacks.Count;
+                    return new WorkloadSuggestion(c.Workloads, extraPacks);
+                })
+                .ToList();
+        }
+
+        /// <summary>
+        /// Recursively explores a branching tree from the root, adding branches that would reduce the number of unsatisfied packs, and recording any fully satisfied solutions found.
+        /// </summary>
+        /// <param name="root">A partial suggestion candidate that is the base for this permutation</param>
+        /// <param name="branches">Partial suggestion candidates that can be added to the root to make it more complete</param>
+        /// <param name="completeSuggestions">A collection to which to add any discovered complete solutions</param>
+        private static void GatherCompleteSuggestions(WorkloadSuggestionCandidate root, List<WorkloadSuggestionCandidate> branches, HashSet<WorkloadSuggestionCandidate> completeSuggestions)
+        {
+            foreach (var branch in branches)
+            {
+                //skip branches identical to ones that have already already been taken
+                //there's probably a more efficient way to do this but this is easy to reason about
+                if (root.Workloads.IsSupersetOf(branch.Workloads))
+                {
+                    continue;
+                }
+
+                //skip branches that don't reduce the number of missing packs
+                //the branch may be a more optimal solution, but this will be handled elsewhere in the permutation space where it is treated as a root
+                if (!root.UnsatisfiedPacks.Overlaps(branch.Packs))
+                {
+                    continue;
+                }
+
+                //construct the new condidate by combining the root and the branch
+                var combinedIds = new HashSet<WorkloadDefinitionId>(root.Workloads);
+                combinedIds.UnionWith(branch.Workloads);
+                var combinedPacks = new HashSet<WorkloadPackId>(root.Packs);
+                combinedPacks.UnionWith(branch.Packs);
+                var stillMissing = new HashSet<WorkloadPackId>(root.UnsatisfiedPacks);
+                stillMissing.ExceptWith(branch.Packs);
+                var candidate = new WorkloadSuggestionCandidate(combinedIds, combinedPacks, stillMissing);
+
+                //if the candidate contains all the requested packs, it's complete. else, recurse to try adding more branches to it.
+                if (candidate.IsComplete)
+                {
+                    completeSuggestions.Add(candidate);
+                }
+                else
+                {
+                    GatherCompleteSuggestions(candidate, branches, completeSuggestions);
+                }
+            }
+        }
+
+        public ICollection<WorkloadSuggestion> UnsortedSuggestions { get; }
+
+        /// <summary>
+        /// Finds the best value from a list of values according to one or more custom comparators. The comparators are an ordered fallback list - the second comparator is only checked when values are equal according to the first comparator, and so on.
+        /// </summary>
+        private T FindBest<T>(IEnumerable<T> values, params Comparison<T>[] comparators)
+        {
+            T best = values.First();
+
+            foreach (T val in values.Skip(1))
+            {
+                foreach (Comparison<T> c in comparators)
+                {
+                    var cmp = c(val, best);
+                    if (cmp > 0)
+                    {
+                        best = val;
+                        break;
+                    }
+                    else if (cmp < 0)
+                    {
+                        break;
+                    }
+                }
+            }
+            return best;
+        }
+
+        /// <summary>
+        /// Gets the suggestion with the lowest number of extra packs and lowest number of workload IDs.
+        /// </summary>
+        public WorkloadSuggestion GetBestSuggestion() => FindBest(
+                UnsortedSuggestions,
+                (x, y) => y.ExtraPacks - x.ExtraPacks,
+                (x, y) => y.Workloads.Count - x.Workloads.Count);
+
+        /// <summary>
+        /// A partial or complete suggestion for workloads to install, annotated with which requested packs it does not satisfy
+        /// </summary>
+        class WorkloadSuggestionCandidate : IEquatable<WorkloadSuggestionCandidate>
+        {
+            public WorkloadSuggestionCandidate(HashSet<WorkloadDefinitionId> id, HashSet<WorkloadPackId> packs, HashSet<WorkloadPackId> unsatisfiedPacks)
+            {
+                Packs = packs;
+                UnsatisfiedPacks = unsatisfiedPacks;
+                Workloads = id;
+            }
+
+            public HashSet<WorkloadDefinitionId> Workloads { get; }
+            public HashSet<WorkloadPackId> Packs { get; }
+            public HashSet<WorkloadPackId> UnsatisfiedPacks { get; }
+            public bool IsComplete => UnsatisfiedPacks.Count == 0;
+
+            public bool Equals(WorkloadSuggestionCandidate? other) => other != null && Workloads.SetEquals(other.Workloads);
+
+            public override int GetHashCode()
+            {
+                int hashcode = 0;
+                foreach (var id in Workloads)
+                {
+                    hashcode ^= id.GetHashCode();
+                }
+                return hashcode;
+            }
+        }
+
+        /// <summary>
+        /// A suggestion of one or more workloads to be installed to satisfy missing packs.
+        /// </summary>
+        public class WorkloadSuggestion
+        {
+            public WorkloadSuggestion(HashSet<WorkloadDefinitionId> workloads, int extraPacks)
+            {
+                Workloads = workloads;
+                ExtraPacks = extraPacks;
+            }
+
+            /// <summary>
+            /// The workload IDs that comprise this suggestion
+            /// </summary>
+            public HashSet<WorkloadDefinitionId> Workloads { get; internal set; }
+
+            /// <summary>
+            /// How many additional (and potentionally unnecessary) packs this suggestion will result in installing
+            /// </summary>
+            public int ExtraPacks { get; internal set; }
+        }
+    }
+}

--- a/src/Tests/Microsoft.NET.Sdk.WorkloadManifestReader.Tests/ManifestTests.cs
+++ b/src/Tests/Microsoft.NET.Sdk.WorkloadManifestReader.Tests/ManifestTests.cs
@@ -2,15 +2,13 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using FluentAssertions;
+
 using Microsoft.NET.Sdk.WorkloadManifestReader;
 
-using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using Xunit;
 
-using WorkloadSuggestionCandidate = Microsoft.NET.Sdk.WorkloadManifestReader.WorkloadSuggestionFinder.WorkloadSuggestionCandidate;
+using Xunit;
 
 namespace ManifestReaderTests
 {
@@ -50,134 +48,6 @@ namespace ManifestReaderTests
             buildToolsPack.Id.Should().Be("Xamarin.Android.BuildTools");
             buildToolsPack.Version.Should().Be("8.4.7");
             buildToolsPack.Path.Should().Be(Path.Combine(fakeRootPath, "packs", "Xamarin.Android.BuildTools.Win64Host", "8.4.7"));
-        }
-
-        [Fact]
-        public void CanSuggestSimpleWorkload()
-        {
-            var manifestProvider = new FakeManifestProvider(Path.Combine("Manifests", "Sample.json"));
-            var resolver = new WorkloadResolver(manifestProvider, fakeRootPath);
-
-            FakeFileSystemChecksSoThesePackagesAppearInstalled(resolver, "Xamarin.Android.Sdk", "Xamarin.Android.BuildTools");
-
-            resolver.ReplacePlatformIdsForTest(new[] { "win-x64", "*" });
-
-            var suggestions = resolver.GetWorkloadSuggestionForMissingPacks(new[] { "Mono.Android.Sdk" });
-            suggestions.Count().Should().Be(1);
-            suggestions.First().Id.Should().Be("xamarin-android-build");
-        }
-
-        [Fact]
-        public void CanSuggestTwoWorkloadsToFulfilTwoRequirements()
-        {
-            var manifestProvider = new FakeManifestProvider(Path.Combine("Manifests", "Sample.json"));
-            var resolver = new WorkloadResolver(manifestProvider, fakeRootPath);
-
-            FakeFileSystemChecksSoThesePackagesAppearInstalled(resolver,
-                //xamarin-android-build is fully installed
-                "Xamarin.Android.Sdk",
-                "Xamarin.Android.BuildTools",
-                "Xamarin.Android.Framework",
-                "Xamarin.Android.Runtime",
-                "Mono.Android.Sdk");
-
-            resolver.ReplacePlatformIdsForTest(new[] { "win-x64", "*" });
-
-            var suggestions = resolver.GetWorkloadSuggestionForMissingPacks(new[] { "Mono.Android.Runtime.x86", "Mono.Android.Runtime.Armv7a" });
-            suggestions.Count().Should().Be(2);
-            suggestions.Should().Contain(s => s.Id == "xamarin-android-build-armv7a");
-            suggestions.Should().Contain(s => s.Id == "xamarin-android-build-x86");
-        }
-
-        [Fact]
-        public void CanSuggestWorkloadThatFulfillsTwoRequirements()
-        {
-            var manifestProvider = new FakeManifestProvider(Path.Combine("Manifests", "Sample.json"));
-            var resolver = new WorkloadResolver(manifestProvider, fakeRootPath);
-
-            FakeFileSystemChecksSoThesePackagesAppearInstalled(resolver,
-                //xamarin-android-build is fully installed
-                "Xamarin.Android.Sdk",
-                "Xamarin.Android.BuildTools",
-                "Xamarin.Android.Framework",
-                "Xamarin.Android.Runtime",
-                "Mono.Android.Sdk");
-
-            resolver.ReplacePlatformIdsForTest(new[] { "win-x64", "*" });
-
-            var suggestions = resolver.GetWorkloadSuggestionForMissingPacks(new[] { "Xamarin.Android.Templates", "Xamarin.Android.LLVM.Aot.armv7a" });
-            suggestions.Count().Should().Be(1);
-            suggestions.First().Id.Should().Be("xamarin-android-complete");
-        }
-
-        [Fact]
-        public static void WorkloadsSuggestionsArePermutedCorrectly()
-        {
-            static HashSet<WorkloadPackId> ConstructPackHash (params string[] packIds)
-                => new HashSet<WorkloadPackId> (packIds.Select(id => new WorkloadPackId(id)));
-
-            static HashSet<WorkloadDefinitionId> ConstructWorkloadHash (params string[] workloadIds)
-                => new HashSet<WorkloadDefinitionId> (workloadIds.Select(id => new WorkloadDefinitionId(id)));
-
-            static WorkloadSuggestionCandidate ConstructCandidate(string[] workloadIds, string[] packIds, string[] unsatisfiedPackIds)
-                => new WorkloadSuggestionCandidate (ConstructWorkloadHash(workloadIds), ConstructPackHash(packIds), ConstructPackHash(unsatisfiedPackIds));
-
-            //we're looking for suggestions with "pack1", "pack2", "pack3"
-            var partialSuggestions = new List<WorkloadSuggestionCandidate>
-            {
-                ConstructCandidate(new[] { "workload1" }, new[] { "pack1" }, new[] { "pack2", "pack3" }),
-                ConstructCandidate(new[] { "workload2" }, new[] { "pack1", "pack2" }, new[] { "pack3" }),
-                ConstructCandidate(new[] { "workload3" }, new[] { "pack2" }, new[] { "pack1", "pack3" }),
-                ConstructCandidate(new[] { "workload4" }, new[] { "pack3" }, new[] { "pack1", "pack2" }),
-                ConstructCandidate(new[] { "workload5" }, new[] { "pack2", "pack3" }, new[] { "pack1" })
-            };
-
-            var completeSuggestions = WorkloadSuggestionFinder.GatherCompleteSuggestions(partialSuggestions);
-
-            Assert.Equal(4, completeSuggestions.Count);
-
-            static int CountMatchingSuggestions(HashSet<WorkloadSuggestionCandidate> suggestions, params string[] workloadIds)
-            {
-                int found = 0;
-                foreach(var suggestion in suggestions)
-                {
-                    if (suggestion.Workloads.Count == workloadIds.Length)
-                    {
-                        if (workloadIds.All(id => suggestion.Workloads.Contains(new WorkloadDefinitionId(id))))
-                        {
-                            found++;
-                        }
-                    }
-                }
-                return found;
-            }
-
-            Assert.Equal(1, CountMatchingSuggestions(completeSuggestions, "workload1", "workload3", "workload4"));
-            Assert.Equal(1, CountMatchingSuggestions(completeSuggestions, "workload1", "workload5"));
-            Assert.Equal(1, CountMatchingSuggestions(completeSuggestions, "workload2", "workload4"));
-            Assert.Equal(1, CountMatchingSuggestions(completeSuggestions, "workload2", "workload5"));
-        }
-
-        private static void FakeFileSystemChecksSoThesePackagesAppearInstalled(WorkloadResolver resolver, params string[] ids)
-        {
-            var installedPacks = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-            foreach(var id in ids)
-            {
-                installedPacks.Add(id);
-            }
-
-            resolver.ReplaceFilesystemChecksForTest(
-                fileName =>
-                {
-                    var versionDir = Path.GetDirectoryName(fileName);
-                    var idDir = Path.GetDirectoryName(versionDir);
-                    return installedPacks.Contains(Path.GetFileName(idDir));
-                },
-                dirName =>
-                {
-                    var idDir = Path.GetDirectoryName(dirName);
-                    return installedPacks.Contains(Path.GetFileName(idDir));
-                });
         }
     }
 }

--- a/src/Tests/Microsoft.NET.Sdk.WorkloadManifestReader.Tests/Manifests/Sample.json
+++ b/src/Tests/Microsoft.NET.Sdk.WorkloadManifestReader.Tests/Manifests/Sample.json
@@ -70,7 +70,7 @@
                 "Xamarin.Android.LLVM.Aot.armv7a"
             ],
             "extends": [
-                "xamarin-android"
+                "xamarin-android-build"
             ]
         },
         // this is a convenience for devs who want to pre-install everything

--- a/src/Tests/Microsoft.NET.Sdk.WorkloadManifestReader.Tests/WorkloadSuggestionFinderTests.cs
+++ b/src/Tests/Microsoft.NET.Sdk.WorkloadManifestReader.Tests/WorkloadSuggestionFinderTests.cs
@@ -1,0 +1,204 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using FluentAssertions;
+
+using Microsoft.NET.Sdk.WorkloadManifestReader;
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+using Xunit;
+
+using WorkloadSuggestionCandidate = Microsoft.NET.Sdk.WorkloadManifestReader.WorkloadSuggestionFinder.WorkloadSuggestionCandidate;
+
+namespace ManifestReaderTests
+{
+    public class WorkloadSuggestionFinderTests
+    {
+        private const string fakeRootPath = "fakeRootPath";
+
+        [Fact]
+        public void CanSuggestSimpleWorkload()
+        {
+            var manifestProvider = new FakeManifestProvider(Path.Combine("Manifests", "Sample.json"));
+            var resolver = WorkloadResolver.CreateForTests(manifestProvider, fakeRootPath, ManifestTests.TEST_RUNTIME_IDENTIFIER_CHAIN);
+
+            FakeFileSystemChecksSoThesePackagesAppearInstalled(resolver, "Xamarin.Android.Sdk", "Xamarin.Android.BuildTools");
+
+            var suggestions = resolver.GetWorkloadSuggestionForMissingPacks(new[] { "Mono.Android.Sdk" });
+            suggestions.Count().Should().Be(1);
+            suggestions.First().Id.Should().Be("xamarin-android-build");
+        }
+
+        [Fact]
+        public void CanSuggestTwoWorkloadsToFulfilTwoRequirements()
+        {
+            var manifestProvider = new FakeManifestProvider(Path.Combine("Manifests", "Sample.json"));
+            var resolver = WorkloadResolver.CreateForTests(manifestProvider, fakeRootPath, ManifestTests.TEST_RUNTIME_IDENTIFIER_CHAIN);
+
+            FakeFileSystemChecksSoThesePackagesAppearInstalled(resolver,
+                //xamarin-android-build is fully installed
+                "Xamarin.Android.Sdk",
+                "Xamarin.Android.BuildTools",
+                "Xamarin.Android.Framework",
+                "Xamarin.Android.Runtime",
+                "Mono.Android.Sdk");
+
+            var suggestions = resolver.GetWorkloadSuggestionForMissingPacks(new[] { "Mono.Android.Runtime.x86", "Mono.Android.Runtime.Armv7a" });
+            suggestions.Count().Should().Be(2);
+            suggestions.Should().Contain(s => s.Id == "xamarin-android-build-armv7a");
+            suggestions.Should().Contain(s => s.Id == "xamarin-android-build-x86");
+        }
+
+        [Fact]
+        public void CanSuggestWorkloadThatFulfillsTwoRequirements()
+        {
+            var manifestProvider = new FakeManifestProvider(Path.Combine("Manifests", "Sample.json"));
+            var resolver = WorkloadResolver.CreateForTests(manifestProvider, fakeRootPath, ManifestTests.TEST_RUNTIME_IDENTIFIER_CHAIN);
+
+            FakeFileSystemChecksSoThesePackagesAppearInstalled(resolver,
+                //xamarin-android-build is fully installed
+                "Xamarin.Android.Sdk",
+                "Xamarin.Android.BuildTools",
+                "Xamarin.Android.Framework",
+                "Xamarin.Android.Runtime",
+                "Mono.Android.Sdk");
+
+            var suggestions = resolver.GetWorkloadSuggestionForMissingPacks(new[] { "Xamarin.Android.Templates", "Xamarin.Android.LLVM.Aot.armv7a" });
+            suggestions.Count().Should().Be(1);
+            suggestions.First().Id.Should().Be("xamarin-android-complete");
+        }
+
+        [Fact]
+        public static void CanFindSimpleAndPartialSuggestions()
+        {
+            var workloads = new(string workloadId, string[] packIds)[]
+            {
+                ("workload1", new[] { "pack1" }), // irrelevant
+                ("workload2", new[] { "pack1", "pack2" }), //partial
+                ("workload3", new[] { "pack1", "pack2", "pack4" }), //partial
+                ("workload4", new[] { "pack2", "pack3" }), //complete
+                ("workload5", new[] { "pack2", "pack3", "pack4" }), //complete
+                ("workload6", new[] { "pack2", "pack4" }) //partial
+            }
+            .Select (a => (new WorkloadDefinitionId(a.workloadId), a.packIds.Select(p => new WorkloadPackId(p)).ToHashSet()));
+
+            var requestedPacks = new[]
+            {
+                "pack2",
+                "pack3"
+            }
+            .Select(s => new WorkloadPackId(s)).ToHashSet();
+
+            WorkloadSuggestionFinder.FindPartialSuggestionsAndSimpleCompleteSuggestions(
+                requestedPacks, workloads,
+                out List<WorkloadSuggestionCandidate> partialSuggestions,
+                out HashSet<WorkloadSuggestionCandidate> completeSimpleSuggestions);
+
+            Assert.Equal(3, partialSuggestions.Count);
+            Assert.Contains(partialSuggestions, p => p.Workloads.Single().ToString() == "workload2");
+            Assert.Contains(partialSuggestions, p => p.Workloads.Single().ToString() == "workload3");
+            Assert.Contains(partialSuggestions, p => p.Workloads.Single().ToString() == "workload6");
+
+            Assert.Equal(2, completeSimpleSuggestions.Count);
+            Assert.Contains(completeSimpleSuggestions, p => p.Workloads.Single().ToString() == "workload4");
+            Assert.Contains(completeSimpleSuggestions, p => p.Workloads.Single().ToString() == "workload5");
+        }
+
+        [Fact]
+        public static void SuggestionsArePermutedCorrectly()
+        {
+            static HashSet<WorkloadPackId> ConstructPackHash (params string[] packIds)
+                => new HashSet<WorkloadPackId> (packIds.Select(id => new WorkloadPackId(id)));
+
+            static HashSet<WorkloadDefinitionId> ConstructWorkloadHash (params string[] workloadIds)
+                => new HashSet<WorkloadDefinitionId> (workloadIds.Select(id => new WorkloadDefinitionId(id)));
+
+            static WorkloadSuggestionCandidate ConstructCandidate(string[] workloadIds, string[] packIds, string[] unsatisfiedPackIds)
+                => new WorkloadSuggestionCandidate (ConstructWorkloadHash(workloadIds), ConstructPackHash(packIds), ConstructPackHash(unsatisfiedPackIds));
+
+            //we're looking for suggestions with "pack1", "pack2", "pack3"
+            var partialSuggestions = new List<WorkloadSuggestionCandidate>
+            {
+                ConstructCandidate(new[] { "workload1" }, new[] { "pack1" }, new[] { "pack2", "pack3" }),
+                ConstructCandidate(new[] { "workload2" }, new[] { "pack1", "pack2" }, new[] { "pack3" }),
+                ConstructCandidate(new[] { "workload3" }, new[] { "pack2" }, new[] { "pack1", "pack3" }),
+                ConstructCandidate(new[] { "workload4" }, new[] { "pack3" }, new[] { "pack1", "pack2" }),
+                ConstructCandidate(new[] { "workload5" }, new[] { "pack2", "pack3" }, new[] { "pack1" })
+            };
+
+            var completeSuggestions = WorkloadSuggestionFinder.GatherUniqueCompletePermutedSuggestions(partialSuggestions);
+
+            Assert.Equal(4, completeSuggestions.Count);
+
+            static int CountMatchingSuggestions(HashSet<WorkloadSuggestionCandidate> suggestions, params string[] workloadIds)
+            {
+                int found = 0;
+                foreach(var suggestion in suggestions)
+                {
+                    if (suggestion.Workloads.Count == workloadIds.Length)
+                    {
+                        if (workloadIds.All(id => suggestion.Workloads.Contains(new WorkloadDefinitionId(id))))
+                        {
+                            found++;
+                        }
+                    }
+                }
+                return found;
+            }
+
+            Assert.Equal(1, CountMatchingSuggestions(completeSuggestions, "workload1", "workload3", "workload4"));
+            Assert.Equal(1, CountMatchingSuggestions(completeSuggestions, "workload1", "workload5"));
+            Assert.Equal(1, CountMatchingSuggestions(completeSuggestions, "workload2", "workload4"));
+            Assert.Equal(1, CountMatchingSuggestions(completeSuggestions, "workload2", "workload5"));
+        }
+
+        [Fact]
+        public static void CanDetermineBestSuggestion()
+        {
+            static WorkloadSuggestionFinder.WorkloadSuggestion Suggestion(int extraPacks, params string[] workloadIds)
+                => new WorkloadSuggestionFinder.WorkloadSuggestion(new HashSet<WorkloadDefinitionId>(workloadIds.Select(id => new WorkloadDefinitionId(id))), extraPacks);
+
+            var suggestions = new[]
+            {
+                Suggestion(10, "ReallyBigWorkloadWithLotsOfUnnecessaryPacks"),
+                Suggestion(3, "ModerateWorkloadWithSomeUnnecessaryPacks"),
+                Suggestion(0, "CombinationOfThreeWorkloads", "That", "HasNoExtraPacks"),
+                Suggestion(0, "TheBest", "Match"), // is one of the suggestions with the fewest extra packs, and of those, the one with the fewest workloads
+                Suggestion(2, "CombinationOfTwoWorkloads", "WithACoupleExtraPacks"),
+            };
+
+            var best = WorkloadSuggestionFinder.GetBestSuggestion(suggestions);
+
+            Assert.Equal(0, best.ExtraPacks);
+            Assert.Equal(2, best.Workloads.Count);
+            Assert.Contains(new WorkloadDefinitionId("TheBest"), best.Workloads);
+            Assert.Contains(new WorkloadDefinitionId("Match"), best.Workloads);
+        }
+
+        private static void FakeFileSystemChecksSoThesePackagesAppearInstalled(WorkloadResolver resolver, params string[] ids)
+        {
+            var installedPacks = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach(var id in ids)
+            {
+                installedPacks.Add(id);
+            }
+
+            resolver.ReplaceFilesystemChecksForTest(
+                fileName =>
+                {
+                    var versionDir = Path.GetDirectoryName(fileName);
+                    var idDir = Path.GetDirectoryName(versionDir);
+                    return installedPacks.Contains(Path.GetFileName(idDir));
+                },
+                dirName =>
+                {
+                    var idDir = Path.GetDirectoryName(dirName);
+                    return installedPacks.Contains(Path.GetFileName(idDir));
+                });
+        }
+    }
+}


### PR DESCRIPTION
Adds an API to suggest which workloads should be installed to satisfy a set of missing workload packs.

Fixes the NotImplementException in the workload manifest reader library.