### PR TITLE
Test updated to exclude of sources under Microsoft.NET.Test.Sdk

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -81,9 +81,9 @@
       <Uri>https://github.com/NuGet/NuGet.Client</Uri>
       <Sha>fc2672f9c82aa74259427aa04f43399ec90e243b</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Test.Sdk" Version="16.8.0-preview-20200917-01">
+    <Dependency Name="Microsoft.NET.Test.Sdk" Version="16.8.0-preview-20200918-06">
       <Uri>https://github.com/microsoft/vstest</Uri>
-      <Sha>f2f8d7292a0b045818d33a5edbe2eea23adabb6a</Sha>
+      <Sha>63817611638bd221e0bd8f0f953fb4619c642877</Sha>
     </Dependency>
     <Dependency Name="Microsoft.NET.ILLink.Tasks" Version="6.0.0-alpha.1.20472.1">
       <Uri>https://github.com/mono/linker</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -64,7 +64,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/Microsoft/vstest -->
-    <MicrosoftNETTestSdkPackageVersion>16.8.0-preview-20200917-01</MicrosoftNETTestSdkPackageVersion>
+    <MicrosoftNETTestSdkPackageVersion>16.8.0-preview-20200918-06</MicrosoftNETTestSdkPackageVersion>
     <MicrosoftTestPlatformCLIPackageVersion>$(MicrosoftNETTestSdkPackageVersion)</MicrosoftTestPlatformCLIPackageVersion>
     <MicrosoftTestPlatformBuildPackageVersion>$(MicrosoftNETTestSdkPackageVersion)</MicrosoftTestPlatformBuildPackageVersion>
   </PropertyGroup>

--- a/src/Assets/TestProjects/VSTestCore/VSTestCore.csproj
+++ b/src/Assets/TestProjects/VSTestCore/VSTestCore.csproj
@@ -11,4 +11,10 @@
     <PackageReference Include="MSTest.TestAdapter" Version="$(MSTestVersion)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPackageVersion)" />
   </ItemGroup>
+
+  <ItemGroup>
+    <!-- Microsoft.NET.Test.Sdk package includes source files which shouldn't be automatically included. -->
+    <!-- Excluding those -->
+    <Compile Remove="pkgs\Microsoft.NET.Test.Sdk\**" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
Fixes the build problem in https://github.com/dotnet/sdk/pull/13684.