### PR TITLE
Filtering SupportedTargetFrameworkAlias based on target framework moniker

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenThatWeWantToGenerateSupportedTargetFrameworkAlias.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenThatWeWantToGenerateSupportedTargetFrameworkAlias.cs
@@ -25,24 +25,40 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 ( ".NETFramework,Version=v4.8", ".NET Framework 4.8"),
             };
 
+        [Fact]
+        public void It_generates_supported_net_standard_target_framework_alias_items()
+        {
+            var targetFrameworkMoniker = ".NETStandard,Version=v2.1";
+            RunTask(targetFrameworkMoniker, targetPlatformMoniker: string.Empty, UseWpf: false, UseWindowsForms: false, expectedResult: new List<(string, string)>
+                {
+                    ("netstandard2.0", ".NET Standard 2.0"),
+                    ("netstandard2.1", ".NET Standard 2.1"),
+                });
+        }
+
+        [Fact]
+        public void It_generates_supported_net_framework_target_framework_alias_items()
+        {
+            var targetFrameworkMoniker = ".NETFramework,Version=v4.8";
+            RunTask(targetFrameworkMoniker, targetPlatformMoniker: string.Empty, UseWpf: false, UseWindowsForms: false, expectedResult: new List<(string, string)>
+                {
+                    ("net471", ".NET Framework 4.7.1"),
+                    ("net48", ".NET Framework 4.8")
+                });
+        }
+
         [Theory]
         [InlineData(".NETCoreApp,Version=v3.1")]
         [InlineData(".NETCoreApp,Version=v5.0")]
         [InlineData(".NETCoreApp,Version=v6.0")]
-        [InlineData(".NETStandard,Version=v2.1")]
-        [InlineData(".NETFramework,Version=v4.8")]
-        public void It_generates_supported_target_framework_alias_items(string targetFrameworkMoniker)
+        public void It_generates_supported_net_core_target_framework_alias_items(string targetFrameworkMoniker)
         {
             RunTask(targetFrameworkMoniker, targetPlatformMoniker: string.Empty, UseWpf: false, UseWindowsForms: false, expectedResult: new List<(string, string)>
                 {
                     ("netcoreapp3.0", ".NET Core 3.0"),
                     ("netcoreapp3.1", ".NET Core 3.1"),
                     ("net5.0", ".NET 5"),
-                    ("net6.0", ".NET 6"),
-                    ("netstandard2.0", ".NET Standard 2.0"),
-                    ("netstandard2.1", ".NET Standard 2.1"),
-                    ("net471", ".NET Framework 4.7.1"),
-                    ("net48", ".NET Framework 4.8")
+                    ("net6.0", ".NET 6")
                 });
         }
 
@@ -56,11 +72,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                     ("netcoreapp3.0", ".NET Core 3.0"),
                     ("netcoreapp3.1", ".NET Core 3.1"),
                     ("net5.0-windows7.0", ".NET 5"),
-                    ("net6.0-windows7.0", ".NET 6"),
-                    ("netstandard2.0", ".NET Standard 2.0"),
-                    ("netstandard2.1", ".NET Standard 2.1"),
-                    ("net471", ".NET Framework 4.7.1"),
-                    ("net48", ".NET Framework 4.8")
+                    ("net6.0-windows7.0", ".NET 6")
                 });
         }
 
@@ -78,11 +90,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                     ("netcoreapp3.0", ".NET Core 3.0"),
                     ("netcoreapp3.1", ".NET Core 3.1"),
                     ("net5.0-windows", ".NET 5"),
-                    ("net6.0-windows", ".NET 6"),
-                    ("netstandard2.0", ".NET Standard 2.0"),
-                    ("netstandard2.1", ".NET Standard 2.1"),
-                    ("net471", ".NET Framework 4.7.1"),
-                    ("net48", ".NET Framework 4.8")
+                    ("net6.0-windows", ".NET 6")
                 });
         }
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenThatWeWantToGenerateSupportedTargetFrameworkAlias.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenThatWeWantToGenerateSupportedTargetFrameworkAlias.cs
@@ -64,6 +64,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
 
         [Theory]
         [InlineData(".NETCoreApp,Version=v5.0", "Windows,Version=7.0")]
+        [InlineData(".netcoreapp,version=v5.0", "windows,version=7.0")]
         [InlineData(".NETCoreApp,Version=v6.0", "Windows,Version=7.0")]
         public void It_generates_supported_target_framework_alias_items_when_targeting_windows(string targetFrameworkMoniker, string targetPlatformMoniker)
         {

--- a/src/Tasks/Microsoft.NET.Build.Tasks/GenerateSupportedTargetFrameworkAlias.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/GenerateSupportedTargetFrameworkAlias.cs
@@ -40,16 +40,20 @@ namespace Microsoft.NET.Build.Tasks
             foreach (var tfm in SupportedTargetFramework)
             {
                 var currentTargetFramework = NuGetFramework.ParseComponents(tfm.ItemSpec, TargetPlatformMoniker);
-                var targetFrameworkAlias = currentTargetFramework.GetShortFolderName();
-                if ((UseWindowsForms || UseWpf) && currentTargetFramework.Framework.Equals(".NETCoreApp") && currentTargetFramework.Version >= new Version(5, 0))
+                if (currentTargetFramework.Framework.Equals(targetFramework.Framework))
                 {
-                    // Set versionless windows as target platform for wpf and windows forms
-                    targetFrameworkAlias = $"{targetFrameworkAlias}-windows";
-                }
+                    var targetFrameworkAlias = currentTargetFramework.GetShortFolderName();
+                    if ((UseWindowsForms || UseWpf) && currentTargetFramework.Framework.Equals(".NETCoreApp") && currentTargetFramework.Version >= new Version(5, 0))
+                    {
+                        // Set versionless windows as target platform for wpf and windows forms
+                        targetFrameworkAlias = $"{targetFrameworkAlias}-windows";
+                    }
 
-                var displayName = string.IsNullOrWhiteSpace(tfm.GetMetadata("DisplayName"))? targetFrameworkAlias : tfm.GetMetadata("DisplayName");
-                convertedTfms.Add(new TaskItem(targetFrameworkAlias, new Dictionary<string, string>() { { "DisplayName", displayName } }));
+                    var displayName = string.IsNullOrWhiteSpace(tfm.GetMetadata("DisplayName")) ? targetFrameworkAlias : tfm.GetMetadata("DisplayName");
+                    convertedTfms.Add(new TaskItem(targetFrameworkAlias, new Dictionary<string, string>() { { "DisplayName", displayName } }));
+                }
             }
+
             SupportedTargetFrameworkAlias = convertedTfms.ToArray();
         }
     }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.targets
@@ -375,20 +375,4 @@ Copyright (c) .NET Foundation. All rights reserved.
         Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' and $([MSBuild]::VersionGreaterThanOrEquals($(_TargetFrameworkVersionWithoutV), '5.0')) and '$(_MicrosoftWindowsDesktopSdkImported)' == 'true' and '$(TargetFrameworks)' == ''">
     <NETSdkWarning ResourceName="UnnecessaryWindowsDesktopSDK" />
   </Target>
-  
-  <UsingTask TaskName="GenerateSupportedTargetFrameworkAlias" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
-
-  <!--
-    Generate a list of valid TargetFramework aliases for the project system to consume for the target framework properties page drop down
-  -->
-  <Target Name="GenerateSupportedTargetFrameworkAlias"
-          Returns="@(SupportedTargetFrameworkAlias)">
-    <GenerateSupportedTargetFrameworkAlias SupportedTargetFramework="@(SupportedTargetFramework)"
-                                           TargetFrameworkMoniker="$(TargetFrameworkMoniker)"
-                                           TargetPlatformMoniker="$(TargetPlatformMoniker)"
-                                           UseWpf="$(UseWpf)"
-                                           UseWindowsForms="$(UseWindowsForms)">
-      <Output TaskParameter="SupportedTargetFrameworkAlias" ItemName="SupportedTargetFrameworkAlias" />
-    </GenerateSupportedTargetFrameworkAlias>
-  </Target>
 </Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.targets
@@ -375,4 +375,20 @@ Copyright (c) .NET Foundation. All rights reserved.
         Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' and $([MSBuild]::VersionGreaterThanOrEquals($(_TargetFrameworkVersionWithoutV), '5.0')) and '$(_MicrosoftWindowsDesktopSdkImported)' == 'true' and '$(TargetFrameworks)' == ''">
     <NETSdkWarning ResourceName="UnnecessaryWindowsDesktopSDK" />
   </Target>
+  
+  <UsingTask TaskName="GenerateSupportedTargetFrameworkAlias" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
+
+  <!--
+    Generate a list of valid TargetFramework aliases for the project system to consume for the target framework properties page drop down
+  -->
+  <Target Name="GenerateSupportedTargetFrameworkAlias"
+          Returns="@(SupportedTargetFrameworkAlias)">
+    <GenerateSupportedTargetFrameworkAlias SupportedTargetFramework="@(SupportedTargetFramework)"
+                                           TargetFrameworkMoniker="$(TargetFrameworkMoniker)"
+                                           TargetPlatformMoniker="$(TargetPlatformMoniker)"
+                                           UseWpf="$(UseWpf)"
+                                           UseWindowsForms="$(UseWindowsForms)">
+      <Output TaskParameter="SupportedTargetFrameworkAlias" ItemName="SupportedTargetFrameworkAlias" />
+    </GenerateSupportedTargetFrameworkAlias>
+  </Target>
 </Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -961,6 +961,26 @@ Copyright (c) .NET Foundation. All rights reserved.
   </ItemDefinitionGroup>
 
   <!--
+    ============================================================
+                            GenerateSupportedTargetFrameworkAlias
+    Generate a list of valid TargetFramework aliases for the project 
+    system to consume for the target framework properties page drop down
+    ============================================================
+  -->
+  <UsingTask TaskName="GenerateSupportedTargetFrameworkAlias" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
+
+  <Target Name="GenerateSupportedTargetFrameworkAlias"
+          Returns="@(SupportedTargetFrameworkAlias)">
+    <GenerateSupportedTargetFrameworkAlias SupportedTargetFramework="@(SupportedTargetFramework)"
+                                           TargetFrameworkMoniker="$(TargetFrameworkMoniker)"
+                                           TargetPlatformMoniker="$(TargetPlatformMoniker)"
+                                           UseWpf="$(UseWpf)"
+                                           UseWindowsForms="$(UseWindowsForms)">
+      <Output TaskParameter="SupportedTargetFrameworkAlias" ItemName="SupportedTargetFrameworkAlias" />
+    </GenerateSupportedTargetFrameworkAlias>
+  </Target>
+
+  <!--
   ============================================================
                                          Project Capabilities
   ============================================================

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.TargetFrameworkInference.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.TargetFrameworkInference.targets
@@ -246,20 +246,4 @@ Copyright (c) .NET Foundation. All rights reserved.
     <OutputPath>$(OutputPath)$(TargetFramework.ToLowerInvariant())\</OutputPath>
   </PropertyGroup>
 
-  <UsingTask TaskName="GenerateSupportedTargetFrameworkAlias" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
-
-  <!--
-    Generate a list of valid TargetFramework aliases for the project system to consume for the target framework properties page drop down
-  -->
-  <Target Name="GenerateSupportedTargetFrameworkAlias"
-          Returns="@(SupportedTargetFrameworkAlias)">
-    <GenerateSupportedTargetFrameworkAlias SupportedTargetFramework="@(SupportedTargetFramework)"
-                                           TargetFrameworkMoniker="$(TargetFrameworkMoniker)"
-                                           TargetPlatformMoniker="$(TargetPlatformMoniker)"
-                                           UseWpf="$(UseWpf)"
-                                           UseWindowsForms="$(UseWindowsForms)">
-      <Output TaskParameter="SupportedTargetFrameworkAlias" ItemName="SupportedTargetFrameworkAlias" />
-    </GenerateSupportedTargetFrameworkAlias>
-  </Target>
-
 </Project>


### PR DESCRIPTION
- Adding filtering based on matching TargetFrameworkIdentifiers
- Moving the GenerateSupportedTargetFrameworkAlias target to be later in evaluation (See also https://github.com/dotnet/msbuild/pull/5753)