### PR TITLE
ClickOnce targets import

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -34,7 +34,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     ============================================================
     -->
 
-  <Import Project="Microsoft.NET.$(PublishProtocol).targets" Condition="'$(PublishProtocol)' != '' and Exists('Microsoft.NET.$(PublishProtocol).targets')" />
+  <Import Project="Microsoft.NET.ClickOnce.targets" Condition="'$(PublishProtocol)' == 'ClickOnce'" />
 
   <PropertyGroup>
     <!-- We still need to resolve references even if we are not building during publish. -->


### PR DESCRIPTION
Currently ClickOnce publishing targets file gets imported based on a generic import statement that is based on the PublishProtocol property that gets set in the pubxml file. A concern has been raised that there is a risk that we auto import targets with names that match MS.NET.$(PublishProtocol).targets. To avoid this risk, the import line is now being changed to import the ClickOnce targets file explicitly if the PublishProtocol == 'ClickOnce'