### PR TITLE
Make VSTest target depend on _ComputeTargetFrameworkItems

### DIFF
--- a/src/Layout/redist/MSBuildImports/Current/Microsoft.Common.CrossTargeting.targets/ImportAfter/Microsoft.TestPlatform.CrossTargeting.targets
+++ b/src/Layout/redist/MSBuildImports/Current/Microsoft.Common.CrossTargeting.targets/ImportAfter/Microsoft.TestPlatform.CrossTargeting.targets
@@ -64,7 +64,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                     all builds.
   =================================================================================
   -->
-  <Target Name="VSTest" >
+  <Target Name="VSTest" DependsOnTargets="_ComputeTargetFrameworkItems">
     <CallTarget Condition="'$(VSTestNoBuild)' != 'true'" Targets="BuildProject" />
     <CallTarget Targets="SetVSTestInnerTarget" />
     <CallTarget Targets="DispatchToInnerBuildsWithVSTestTarget" />

--- a/src/Tests/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestFromCsprojForMultipleTFM.cs
+++ b/src/Tests/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestFromCsprojForMultipleTFM.cs
@@ -11,6 +11,7 @@ using Microsoft.NET.TestFramework;
 using Microsoft.NET.TestFramework.Assertions;
 using Microsoft.NET.TestFramework.Commands;
 using Xunit.Abstractions;
+using Microsoft.NET.TestFramework.ProjectConstruction;
 
 namespace Microsoft.DotNet.Cli.Test.Tests
 {
@@ -142,6 +143,55 @@ namespace Microsoft.DotNet.Cli.Test.Tests
             new DotnetTestCommand(Log, ConsoleLoggerOutputNormal)
                .WithWorkingDirectory(projectDirectory)
                .Execute("--framework", "netcoreapp3.0")
+               .Should().Pass();
+        }
+
+        [Fact]
+        public void TestSlnWithMultitargetedProject()
+        {
+            var libraryProject = new TestProject()
+            {
+                Name = "LibraryProject",
+                TargetFrameworks = "netcoreapp3.1;net5.0",
+                IsSdkProject = true
+            };
+
+            var testProject = new TestProject()
+            {
+                Name = "TestProject",
+                TargetFrameworks = "net5.0",
+                IsSdkProject = true
+            };
+
+            testProject.PackageReferences.Add(new TestPackageReference("Microsoft.NET.Test.Sdk", "16.7.1"));
+            testProject.PackageReferences.Add(new TestPackageReference("xunit", "2.4.1"));
+            testProject.PackageReferences.Add(new TestPackageReference("xunit.runner.visualstudio", "2.4.3", privateAssets: "all"));
+
+            testProject.ReferencedProjects.Add(libraryProject);
+
+            var testAsset = _testAssetsManager.CreateTestProject(testProject);
+
+            new DotnetCommand(Log, "new", "sln")
+                .WithWorkingDirectory(testAsset.TestRoot)
+                .Execute()
+                .Should()
+                .Pass();
+
+            new DotnetCommand(Log, "sln", "add", libraryProject.Name)
+                .WithWorkingDirectory(testAsset.TestRoot)
+                .Execute()
+                .Should()
+                .Pass();
+
+            new DotnetCommand(Log, "sln", "add", testProject.Name)
+                .WithWorkingDirectory(testAsset.TestRoot)
+                .Execute()
+                .Should()
+                .Pass();
+
+            new DotnetTestCommand(Log, ConsoleLoggerOutputNormal)
+               .WithWorkingDirectory(testAsset.TestRoot)
+               .Execute()
                .Should().Pass();
         }
     }


### PR DESCRIPTION
Fixes microsoft/vstest#2570 by moving `_ComputeTargetFrameworkItems` outside the CallTargets used inside the VSTest target. This means that `@(_InnerBuildProjects)` is available in all CallTarget scopes.

What happened in a tiny sample project with a multitargeted library and a test assembly that @dsplaisted used was this:

1. The `VSTest` target runs in the library, creating a CallTarget scope.
1. Inside that scope, `BuildProject` runs, creating a CallTarget scope.
2. Inside that scope, `_ComputeTargetFrameworkItems` runs, populating `@(_InnerBuildProjects)`.
3. Inside that scope again, the inner builds are dispatched to and built.
5. The `VSTest` target runs in the test project, and eventually calls down to the normal build process.
6. That process calls `GetTargetFrameworks` on the library project.
7. The library project sees that `_ComputeTargetFrameworkItems` has already run and skips it.
8. The library project proceeds to `GetTargetFrameworksWithPlatformFromInnerBuilds`, but doesn't have access to `@(_InnerBuildProjects)` because it's trapped in a scope, so the dispatch fails.
9. The test project then tries to directly reference the _outer_ build of the library, which has no primary output.
9. The compiler fails because the library wasn't passed to it.

Step 8 is what's new. That was computed before dotnet/msbuild#5657 with only evaluation-time data, but now requires multitargeting dispatch.

Ideally, we'll eliminate `CallTarget` entirely. At this late time, however, this is a safer choice: ensure that `@(_InnerBuildProjects)` is populated in the biggest possible scope before any of the `VSTest` machinery runs by depending on it from `VSTest`.