### PR TITLE
[release/5.0] Fix pack as tool does not work with nuget tfm alias

### DIFF
--- a/src/Tasks/Common/Resources/Strings.resx
+++ b/src/Tasks/Common/Resources/Strings.resx
@@ -687,7 +687,7 @@ The following are names of parameters or literal values and should not be transl
     <comment>{StrBegin="NETSDK1145: "}</comment>
   </data>
   <data name="PackAsToolCannotSupportTargetPlatformIdentifier" xml:space="preserve">
-    <value>NETSDK1146: Pack as tool does not support TargetPlatformIdentifier being set. For example, targetframework cannot be net5.0-windows, only net5.0. And Pack as tool .NET5 or higher does not support UseWPF and UseWinform.</value>
+    <value>NETSDK1146: PackAsTool does not support TargetPlatformIdentifier being set. For example, TargetFramework cannot be net5.0-windows, only net5.0. PackAsTool also does not support UseWPF or UseWindowsForms when targeting .NET 5 and higher.</value>
     <comment>{StrBegin="NETSDK1146: "}</comment>
   </data>
 </root>

--- a/src/Tasks/Common/Resources/Strings.resx
+++ b/src/Tasks/Common/Resources/Strings.resx
@@ -686,4 +686,8 @@ The following are names of parameters or literal values and should not be transl
     <value>NETSDK1145: The {0} pack is not installed and NuGet package restore is not supported. Upgrade Visual Studio, remove global.json if it specifies a certain SDK version, and uninstall the newer SDK. For more options visit   https://aka.ms/targeting-apphost-pack-missing  Pack Type:{0}, Pack directory: {1}, targetframework: {2}, Pack PackageId: {3}, Pack Package Version: {4}</value>
     <comment>{StrBegin="NETSDK1145: "}</comment>
   </data>
+  <data name="PackAsToolCannotSupportTargetPlatformIdentifier" xml:space="preserve">
+    <value>NETSDK1146: Pack as tool does not support TargetPlatformIdentifier being set. For example, targetframework cannot be net5.0-windows, only net5.0. And Pack as tool .NET5 or higher does not support UseWPF and UseWinform.</value>
+    <comment>{StrBegin="NETSDK1146: "}</comment>
+  </data>
 </root>

--- a/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
@@ -510,6 +510,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1053: Zabalit jako nástroj nepodporuje nezávislost.</target>
         <note>{StrBegin="NETSDK1053: "}</note>
       </trans-unit>
+      <trans-unit id="PackAsToolCannotSupportTargetPlatformIdentifier">
+        <source>NETSDK1146: Pack as tool does not support TargetPlatformIdentifier being set. For example, targetframework cannot be net5.0-windows, only net5.0. And Pack as tool .NET5 or higher does not support UseWPF and UseWinform.</source>
+        <target state="new">NETSDK1146: Pack as tool does not support TargetPlatformIdentifier being set. For example, targetframework cannot be net5.0-windows, only net5.0. And Pack as tool .NET5 or higher does not support UseWPF and UseWinform.</target>
+        <note>{StrBegin="NETSDK1146: "}</note>
+      </trans-unit>
       <trans-unit id="PackageNotFound">
         <source>NETSDK1064: Package {0}, version {1} was not found. It might have been deleted since NuGet restore. Otherwise, NuGet restore might have only partially completed, which might have been due to maximum path length restrictions.</source>
         <target state="translated">NETSDK1064: Balíček {0} verze {1} se nenašel. Je možné, že se od obnovení NuGet odstranil. Jinak je možné, že obnovení NuGet se provedlo jenom částečně, důvodem mohla být omezení pro maximální délku cesty.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
@@ -511,8 +511,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1053: "}</note>
       </trans-unit>
       <trans-unit id="PackAsToolCannotSupportTargetPlatformIdentifier">
-        <source>NETSDK1146: Pack as tool does not support TargetPlatformIdentifier being set. For example, targetframework cannot be net5.0-windows, only net5.0. And Pack as tool .NET5 or higher does not support UseWPF and UseWinform.</source>
-        <target state="new">NETSDK1146: Pack as tool does not support TargetPlatformIdentifier being set. For example, targetframework cannot be net5.0-windows, only net5.0. And Pack as tool .NET5 or higher does not support UseWPF and UseWinform.</target>
+        <source>NETSDK1146: PackAsTool does not support TargetPlatformIdentifier being set. For example, TargetFramework cannot be net5.0-windows, only net5.0. PackAsTool also does not support UseWPF or UseWindowsForms when targeting .NET 5 and higher.</source>
+        <target state="new">NETSDK1146: PackAsTool does not support TargetPlatformIdentifier being set. For example, TargetFramework cannot be net5.0-windows, only net5.0. PackAsTool also does not support UseWPF or UseWindowsForms when targeting .NET 5 and higher.</target>
         <note>{StrBegin="NETSDK1146: "}</note>
       </trans-unit>
       <trans-unit id="PackageNotFound">

--- a/src/Tasks/Common/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.de.xlf
@@ -510,6 +510,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1053: Die Paketierung als Tool unterstützt keine eigenständige Bereitstellung.</target>
         <note>{StrBegin="NETSDK1053: "}</note>
       </trans-unit>
+      <trans-unit id="PackAsToolCannotSupportTargetPlatformIdentifier">
+        <source>NETSDK1146: Pack as tool does not support TargetPlatformIdentifier being set. For example, targetframework cannot be net5.0-windows, only net5.0. And Pack as tool .NET5 or higher does not support UseWPF and UseWinform.</source>
+        <target state="new">NETSDK1146: Pack as tool does not support TargetPlatformIdentifier being set. For example, targetframework cannot be net5.0-windows, only net5.0. And Pack as tool .NET5 or higher does not support UseWPF and UseWinform.</target>
+        <note>{StrBegin="NETSDK1146: "}</note>
+      </trans-unit>
       <trans-unit id="PackageNotFound">
         <source>NETSDK1064: Package {0}, version {1} was not found. It might have been deleted since NuGet restore. Otherwise, NuGet restore might have only partially completed, which might have been due to maximum path length restrictions.</source>
         <target state="translated">NETSDK1064: Das Paket "{0}", Version {1}, wurde nicht gefunden. Möglicherweise wurde es nach der NuGet-Wiederherstellung gelöscht. Andernfalls wurde die NuGet-Wiederherstellung aufgrund von Beschränkungen der maximalen Pfadlänge eventuell nur teilweise abgeschlossen.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.de.xlf
@@ -511,8 +511,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1053: "}</note>
       </trans-unit>
       <trans-unit id="PackAsToolCannotSupportTargetPlatformIdentifier">
-        <source>NETSDK1146: Pack as tool does not support TargetPlatformIdentifier being set. For example, targetframework cannot be net5.0-windows, only net5.0. And Pack as tool .NET5 or higher does not support UseWPF and UseWinform.</source>
-        <target state="new">NETSDK1146: Pack as tool does not support TargetPlatformIdentifier being set. For example, targetframework cannot be net5.0-windows, only net5.0. And Pack as tool .NET5 or higher does not support UseWPF and UseWinform.</target>
+        <source>NETSDK1146: PackAsTool does not support TargetPlatformIdentifier being set. For example, TargetFramework cannot be net5.0-windows, only net5.0. PackAsTool also does not support UseWPF or UseWindowsForms when targeting .NET 5 and higher.</source>
+        <target state="new">NETSDK1146: PackAsTool does not support TargetPlatformIdentifier being set. For example, TargetFramework cannot be net5.0-windows, only net5.0. PackAsTool also does not support UseWPF or UseWindowsForms when targeting .NET 5 and higher.</target>
         <note>{StrBegin="NETSDK1146: "}</note>
       </trans-unit>
       <trans-unit id="PackageNotFound">

--- a/src/Tasks/Common/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.es.xlf
@@ -510,6 +510,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1053: El paquete como herramienta no admite la autocontención.</target>
         <note>{StrBegin="NETSDK1053: "}</note>
       </trans-unit>
+      <trans-unit id="PackAsToolCannotSupportTargetPlatformIdentifier">
+        <source>NETSDK1146: Pack as tool does not support TargetPlatformIdentifier being set. For example, targetframework cannot be net5.0-windows, only net5.0. And Pack as tool .NET5 or higher does not support UseWPF and UseWinform.</source>
+        <target state="new">NETSDK1146: Pack as tool does not support TargetPlatformIdentifier being set. For example, targetframework cannot be net5.0-windows, only net5.0. And Pack as tool .NET5 or higher does not support UseWPF and UseWinform.</target>
+        <note>{StrBegin="NETSDK1146: "}</note>
+      </trans-unit>
       <trans-unit id="PackageNotFound">
         <source>NETSDK1064: Package {0}, version {1} was not found. It might have been deleted since NuGet restore. Otherwise, NuGet restore might have only partially completed, which might have been due to maximum path length restrictions.</source>
         <target state="translated">NETSDK1064: No se encontró el paquete {0}, versión {1}. Es posible que se haya eliminado desde la restauración de NuGet. De lo contrario, la restauración de NuGet podría haberse completado solo parcialmente, lo que puede deberse a las restricciones de longitud de ruta máxima.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.es.xlf
@@ -511,8 +511,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1053: "}</note>
       </trans-unit>
       <trans-unit id="PackAsToolCannotSupportTargetPlatformIdentifier">
-        <source>NETSDK1146: Pack as tool does not support TargetPlatformIdentifier being set. For example, targetframework cannot be net5.0-windows, only net5.0. And Pack as tool .NET5 or higher does not support UseWPF and UseWinform.</source>
-        <target state="new">NETSDK1146: Pack as tool does not support TargetPlatformIdentifier being set. For example, targetframework cannot be net5.0-windows, only net5.0. And Pack as tool .NET5 or higher does not support UseWPF and UseWinform.</target>
+        <source>NETSDK1146: PackAsTool does not support TargetPlatformIdentifier being set. For example, TargetFramework cannot be net5.0-windows, only net5.0. PackAsTool also does not support UseWPF or UseWindowsForms when targeting .NET 5 and higher.</source>
+        <target state="new">NETSDK1146: PackAsTool does not support TargetPlatformIdentifier being set. For example, TargetFramework cannot be net5.0-windows, only net5.0. PackAsTool also does not support UseWPF or UseWindowsForms when targeting .NET 5 and higher.</target>
         <note>{StrBegin="NETSDK1146: "}</note>
       </trans-unit>
       <trans-unit id="PackageNotFound">

--- a/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
@@ -510,6 +510,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1053: L'outil de compression ne prend pas en charge l'autonomie.</target>
         <note>{StrBegin="NETSDK1053: "}</note>
       </trans-unit>
+      <trans-unit id="PackAsToolCannotSupportTargetPlatformIdentifier">
+        <source>NETSDK1146: Pack as tool does not support TargetPlatformIdentifier being set. For example, targetframework cannot be net5.0-windows, only net5.0. And Pack as tool .NET5 or higher does not support UseWPF and UseWinform.</source>
+        <target state="new">NETSDK1146: Pack as tool does not support TargetPlatformIdentifier being set. For example, targetframework cannot be net5.0-windows, only net5.0. And Pack as tool .NET5 or higher does not support UseWPF and UseWinform.</target>
+        <note>{StrBegin="NETSDK1146: "}</note>
+      </trans-unit>
       <trans-unit id="PackageNotFound">
         <source>NETSDK1064: Package {0}, version {1} was not found. It might have been deleted since NuGet restore. Otherwise, NuGet restore might have only partially completed, which might have been due to maximum path length restrictions.</source>
         <target state="translated">NETSDK1064: Le package {0}, version {1}, est introuvable. Il a peut-être été supprimé depuis la restauration NuGet. Sinon, la restauration NuGet a peut-être été partiellement effectuée en raison de restrictions appliquées à la longueur maximale du chemin.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
@@ -511,8 +511,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1053: "}</note>
       </trans-unit>
       <trans-unit id="PackAsToolCannotSupportTargetPlatformIdentifier">
-        <source>NETSDK1146: Pack as tool does not support TargetPlatformIdentifier being set. For example, targetframework cannot be net5.0-windows, only net5.0. And Pack as tool .NET5 or higher does not support UseWPF and UseWinform.</source>
-        <target state="new">NETSDK1146: Pack as tool does not support TargetPlatformIdentifier being set. For example, targetframework cannot be net5.0-windows, only net5.0. And Pack as tool .NET5 or higher does not support UseWPF and UseWinform.</target>
+        <source>NETSDK1146: PackAsTool does not support TargetPlatformIdentifier being set. For example, TargetFramework cannot be net5.0-windows, only net5.0. PackAsTool also does not support UseWPF or UseWindowsForms when targeting .NET 5 and higher.</source>
+        <target state="new">NETSDK1146: PackAsTool does not support TargetPlatformIdentifier being set. For example, TargetFramework cannot be net5.0-windows, only net5.0. PackAsTool also does not support UseWPF or UseWindowsForms when targeting .NET 5 and higher.</target>
         <note>{StrBegin="NETSDK1146: "}</note>
       </trans-unit>
       <trans-unit id="PackageNotFound">

--- a/src/Tasks/Common/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.it.xlf
@@ -510,6 +510,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1053: la creazione di pacchetti come strumenti non prevede elementi autonomi.</target>
         <note>{StrBegin="NETSDK1053: "}</note>
       </trans-unit>
+      <trans-unit id="PackAsToolCannotSupportTargetPlatformIdentifier">
+        <source>NETSDK1146: Pack as tool does not support TargetPlatformIdentifier being set. For example, targetframework cannot be net5.0-windows, only net5.0. And Pack as tool .NET5 or higher does not support UseWPF and UseWinform.</source>
+        <target state="new">NETSDK1146: Pack as tool does not support TargetPlatformIdentifier being set. For example, targetframework cannot be net5.0-windows, only net5.0. And Pack as tool .NET5 or higher does not support UseWPF and UseWinform.</target>
+        <note>{StrBegin="NETSDK1146: "}</note>
+      </trans-unit>
       <trans-unit id="PackageNotFound">
         <source>NETSDK1064: Package {0}, version {1} was not found. It might have been deleted since NuGet restore. Otherwise, NuGet restore might have only partially completed, which might have been due to maximum path length restrictions.</source>
         <target state="translated">NETSDK1064: il pacchetto {0} versione {1} non è stato trovato. Potrebbe essere stato eliminato dopo il ripristino di NuGet. In caso contrario, il ripristino di NuGet potrebbe essere stato completato solo parzialmente, a causa delle restrizioni relative alla lunghezza massima del percorso.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.it.xlf
@@ -511,8 +511,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1053: "}</note>
       </trans-unit>
       <trans-unit id="PackAsToolCannotSupportTargetPlatformIdentifier">
-        <source>NETSDK1146: Pack as tool does not support TargetPlatformIdentifier being set. For example, targetframework cannot be net5.0-windows, only net5.0. And Pack as tool .NET5 or higher does not support UseWPF and UseWinform.</source>
-        <target state="new">NETSDK1146: Pack as tool does not support TargetPlatformIdentifier being set. For example, targetframework cannot be net5.0-windows, only net5.0. And Pack as tool .NET5 or higher does not support UseWPF and UseWinform.</target>
+        <source>NETSDK1146: PackAsTool does not support TargetPlatformIdentifier being set. For example, TargetFramework cannot be net5.0-windows, only net5.0. PackAsTool also does not support UseWPF or UseWindowsForms when targeting .NET 5 and higher.</source>
+        <target state="new">NETSDK1146: PackAsTool does not support TargetPlatformIdentifier being set. For example, TargetFramework cannot be net5.0-windows, only net5.0. PackAsTool also does not support UseWPF or UseWindowsForms when targeting .NET 5 and higher.</target>
         <note>{StrBegin="NETSDK1146: "}</note>
       </trans-unit>
       <trans-unit id="PackageNotFound">

--- a/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
@@ -510,6 +510,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1053: Pack As ツールは自己完結型をサポートしていません。</target>
         <note>{StrBegin="NETSDK1053: "}</note>
       </trans-unit>
+      <trans-unit id="PackAsToolCannotSupportTargetPlatformIdentifier">
+        <source>NETSDK1146: Pack as tool does not support TargetPlatformIdentifier being set. For example, targetframework cannot be net5.0-windows, only net5.0. And Pack as tool .NET5 or higher does not support UseWPF and UseWinform.</source>
+        <target state="new">NETSDK1146: Pack as tool does not support TargetPlatformIdentifier being set. For example, targetframework cannot be net5.0-windows, only net5.0. And Pack as tool .NET5 or higher does not support UseWPF and UseWinform.</target>
+        <note>{StrBegin="NETSDK1146: "}</note>
+      </trans-unit>
       <trans-unit id="PackageNotFound">
         <source>NETSDK1064: Package {0}, version {1} was not found. It might have been deleted since NuGet restore. Otherwise, NuGet restore might have only partially completed, which might have been due to maximum path length restrictions.</source>
         <target state="translated">NETSDK1064: パッケージ {0}、バージョン {1} が見つかりませんでした。NuGet の復元により、削除された可能性があります。それ以外の場合、NuGet の復元が最大パス長の制限のために一部分しか完了していない可能性があります。</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
@@ -511,8 +511,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1053: "}</note>
       </trans-unit>
       <trans-unit id="PackAsToolCannotSupportTargetPlatformIdentifier">
-        <source>NETSDK1146: Pack as tool does not support TargetPlatformIdentifier being set. For example, targetframework cannot be net5.0-windows, only net5.0. And Pack as tool .NET5 or higher does not support UseWPF and UseWinform.</source>
-        <target state="new">NETSDK1146: Pack as tool does not support TargetPlatformIdentifier being set. For example, targetframework cannot be net5.0-windows, only net5.0. And Pack as tool .NET5 or higher does not support UseWPF and UseWinform.</target>
+        <source>NETSDK1146: PackAsTool does not support TargetPlatformIdentifier being set. For example, TargetFramework cannot be net5.0-windows, only net5.0. PackAsTool also does not support UseWPF or UseWindowsForms when targeting .NET 5 and higher.</source>
+        <target state="new">NETSDK1146: PackAsTool does not support TargetPlatformIdentifier being set. For example, TargetFramework cannot be net5.0-windows, only net5.0. PackAsTool also does not support UseWPF or UseWindowsForms when targeting .NET 5 and higher.</target>
         <note>{StrBegin="NETSDK1146: "}</note>
       </trans-unit>
       <trans-unit id="PackageNotFound">

--- a/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
@@ -510,6 +510,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1053: 도구로서 팩은 자체 포함을 지원하지 않습니다.</target>
         <note>{StrBegin="NETSDK1053: "}</note>
       </trans-unit>
+      <trans-unit id="PackAsToolCannotSupportTargetPlatformIdentifier">
+        <source>NETSDK1146: Pack as tool does not support TargetPlatformIdentifier being set. For example, targetframework cannot be net5.0-windows, only net5.0. And Pack as tool .NET5 or higher does not support UseWPF and UseWinform.</source>
+        <target state="new">NETSDK1146: Pack as tool does not support TargetPlatformIdentifier being set. For example, targetframework cannot be net5.0-windows, only net5.0. And Pack as tool .NET5 or higher does not support UseWPF and UseWinform.</target>
+        <note>{StrBegin="NETSDK1146: "}</note>
+      </trans-unit>
       <trans-unit id="PackageNotFound">
         <source>NETSDK1064: Package {0}, version {1} was not found. It might have been deleted since NuGet restore. Otherwise, NuGet restore might have only partially completed, which might have been due to maximum path length restrictions.</source>
         <target state="translated">NETSDK1064: 패키지 {0}, 버전 {1}을(를) 찾을 수 없습니다. NuGet 복원 이후 삭제되었을 수 있습니다. 아니면, 최대 경로 길이 제한으로 인해 NuGet 복원이 부분적으로만 완료되었을 수 있습니다.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
@@ -511,8 +511,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1053: "}</note>
       </trans-unit>
       <trans-unit id="PackAsToolCannotSupportTargetPlatformIdentifier">
-        <source>NETSDK1146: Pack as tool does not support TargetPlatformIdentifier being set. For example, targetframework cannot be net5.0-windows, only net5.0. And Pack as tool .NET5 or higher does not support UseWPF and UseWinform.</source>
-        <target state="new">NETSDK1146: Pack as tool does not support TargetPlatformIdentifier being set. For example, targetframework cannot be net5.0-windows, only net5.0. And Pack as tool .NET5 or higher does not support UseWPF and UseWinform.</target>
+        <source>NETSDK1146: PackAsTool does not support TargetPlatformIdentifier being set. For example, TargetFramework cannot be net5.0-windows, only net5.0. PackAsTool also does not support UseWPF or UseWindowsForms when targeting .NET 5 and higher.</source>
+        <target state="new">NETSDK1146: PackAsTool does not support TargetPlatformIdentifier being set. For example, TargetFramework cannot be net5.0-windows, only net5.0. PackAsTool also does not support UseWPF or UseWindowsForms when targeting .NET 5 and higher.</target>
         <note>{StrBegin="NETSDK1146: "}</note>
       </trans-unit>
       <trans-unit id="PackageNotFound">

--- a/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
@@ -510,6 +510,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1053: Funkcja pakowania jako narzędzie nie obsługuje elementów autonomicznych.</target>
         <note>{StrBegin="NETSDK1053: "}</note>
       </trans-unit>
+      <trans-unit id="PackAsToolCannotSupportTargetPlatformIdentifier">
+        <source>NETSDK1146: Pack as tool does not support TargetPlatformIdentifier being set. For example, targetframework cannot be net5.0-windows, only net5.0. And Pack as tool .NET5 or higher does not support UseWPF and UseWinform.</source>
+        <target state="new">NETSDK1146: Pack as tool does not support TargetPlatformIdentifier being set. For example, targetframework cannot be net5.0-windows, only net5.0. And Pack as tool .NET5 or higher does not support UseWPF and UseWinform.</target>
+        <note>{StrBegin="NETSDK1146: "}</note>
+      </trans-unit>
       <trans-unit id="PackageNotFound">
         <source>NETSDK1064: Package {0}, version {1} was not found. It might have been deleted since NuGet restore. Otherwise, NuGet restore might have only partially completed, which might have been due to maximum path length restrictions.</source>
         <target state="translated">NETSDK1064: Nie odnaleziono pakietu {0} w wersji {1}. Mógł on zostać usunięty po przywróceniu pakietu NuGet. W innym przypadku przywrócenie pakietu NuGet mogło zostać ukończone tylko częściowo, co mogło być spowodowane ograniczeniami wynikającymi z maksymalnej długości ścieżki.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
@@ -511,8 +511,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1053: "}</note>
       </trans-unit>
       <trans-unit id="PackAsToolCannotSupportTargetPlatformIdentifier">
-        <source>NETSDK1146: Pack as tool does not support TargetPlatformIdentifier being set. For example, targetframework cannot be net5.0-windows, only net5.0. And Pack as tool .NET5 or higher does not support UseWPF and UseWinform.</source>
-        <target state="new">NETSDK1146: Pack as tool does not support TargetPlatformIdentifier being set. For example, targetframework cannot be net5.0-windows, only net5.0. And Pack as tool .NET5 or higher does not support UseWPF and UseWinform.</target>
+        <source>NETSDK1146: PackAsTool does not support TargetPlatformIdentifier being set. For example, TargetFramework cannot be net5.0-windows, only net5.0. PackAsTool also does not support UseWPF or UseWindowsForms when targeting .NET 5 and higher.</source>
+        <target state="new">NETSDK1146: PackAsTool does not support TargetPlatformIdentifier being set. For example, TargetFramework cannot be net5.0-windows, only net5.0. PackAsTool also does not support UseWPF or UseWindowsForms when targeting .NET 5 and higher.</target>
         <note>{StrBegin="NETSDK1146: "}</note>
       </trans-unit>
       <trans-unit id="PackageNotFound">

--- a/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
@@ -510,6 +510,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1053: O pacote como ferramenta não é compatível com a opção autossuficiente.</target>
         <note>{StrBegin="NETSDK1053: "}</note>
       </trans-unit>
+      <trans-unit id="PackAsToolCannotSupportTargetPlatformIdentifier">
+        <source>NETSDK1146: Pack as tool does not support TargetPlatformIdentifier being set. For example, targetframework cannot be net5.0-windows, only net5.0. And Pack as tool .NET5 or higher does not support UseWPF and UseWinform.</source>
+        <target state="new">NETSDK1146: Pack as tool does not support TargetPlatformIdentifier being set. For example, targetframework cannot be net5.0-windows, only net5.0. And Pack as tool .NET5 or higher does not support UseWPF and UseWinform.</target>
+        <note>{StrBegin="NETSDK1146: "}</note>
+      </trans-unit>
       <trans-unit id="PackageNotFound">
         <source>NETSDK1064: Package {0}, version {1} was not found. It might have been deleted since NuGet restore. Otherwise, NuGet restore might have only partially completed, which might have been due to maximum path length restrictions.</source>
         <target state="translated">NETSDK1064: O pacote {0}, versão {1}, não foi encontrado. Ele pode ter sido excluído desde a restauração do NuGet. Caso contrário, a restauração do NuGet pode ter sido concluída apenas parcialmente, o que pode ter ocorrido devido a restrições de comprimento máximo do caminho.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
@@ -511,8 +511,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1053: "}</note>
       </trans-unit>
       <trans-unit id="PackAsToolCannotSupportTargetPlatformIdentifier">
-        <source>NETSDK1146: Pack as tool does not support TargetPlatformIdentifier being set. For example, targetframework cannot be net5.0-windows, only net5.0. And Pack as tool .NET5 or higher does not support UseWPF and UseWinform.</source>
-        <target state="new">NETSDK1146: Pack as tool does not support TargetPlatformIdentifier being set. For example, targetframework cannot be net5.0-windows, only net5.0. And Pack as tool .NET5 or higher does not support UseWPF and UseWinform.</target>
+        <source>NETSDK1146: PackAsTool does not support TargetPlatformIdentifier being set. For example, TargetFramework cannot be net5.0-windows, only net5.0. PackAsTool also does not support UseWPF or UseWindowsForms when targeting .NET 5 and higher.</source>
+        <target state="new">NETSDK1146: PackAsTool does not support TargetPlatformIdentifier being set. For example, TargetFramework cannot be net5.0-windows, only net5.0. PackAsTool also does not support UseWPF or UseWindowsForms when targeting .NET 5 and higher.</target>
         <note>{StrBegin="NETSDK1146: "}</note>
       </trans-unit>
       <trans-unit id="PackageNotFound">

--- a/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
@@ -510,6 +510,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1053: упаковка в качестве инструмента не поддерживает автономное использование.</target>
         <note>{StrBegin="NETSDK1053: "}</note>
       </trans-unit>
+      <trans-unit id="PackAsToolCannotSupportTargetPlatformIdentifier">
+        <source>NETSDK1146: Pack as tool does not support TargetPlatformIdentifier being set. For example, targetframework cannot be net5.0-windows, only net5.0. And Pack as tool .NET5 or higher does not support UseWPF and UseWinform.</source>
+        <target state="new">NETSDK1146: Pack as tool does not support TargetPlatformIdentifier being set. For example, targetframework cannot be net5.0-windows, only net5.0. And Pack as tool .NET5 or higher does not support UseWPF and UseWinform.</target>
+        <note>{StrBegin="NETSDK1146: "}</note>
+      </trans-unit>
       <trans-unit id="PackageNotFound">
         <source>NETSDK1064: Package {0}, version {1} was not found. It might have been deleted since NuGet restore. Otherwise, NuGet restore might have only partially completed, which might have been due to maximum path length restrictions.</source>
         <target state="translated">NETSDK1064: пакет {0} версии {1} не найден. Возможно, с момента восстановления NuGet он был удален или восстановление NuGet было выполнено лишь частично из-за ограничений на максимальную длину пути.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
@@ -511,8 +511,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1053: "}</note>
       </trans-unit>
       <trans-unit id="PackAsToolCannotSupportTargetPlatformIdentifier">
-        <source>NETSDK1146: Pack as tool does not support TargetPlatformIdentifier being set. For example, targetframework cannot be net5.0-windows, only net5.0. And Pack as tool .NET5 or higher does not support UseWPF and UseWinform.</source>
-        <target state="new">NETSDK1146: Pack as tool does not support TargetPlatformIdentifier being set. For example, targetframework cannot be net5.0-windows, only net5.0. And Pack as tool .NET5 or higher does not support UseWPF and UseWinform.</target>
+        <source>NETSDK1146: PackAsTool does not support TargetPlatformIdentifier being set. For example, TargetFramework cannot be net5.0-windows, only net5.0. PackAsTool also does not support UseWPF or UseWindowsForms when targeting .NET 5 and higher.</source>
+        <target state="new">NETSDK1146: PackAsTool does not support TargetPlatformIdentifier being set. For example, TargetFramework cannot be net5.0-windows, only net5.0. PackAsTool also does not support UseWPF or UseWindowsForms when targeting .NET 5 and higher.</target>
         <note>{StrBegin="NETSDK1146: "}</note>
       </trans-unit>
       <trans-unit id="PackageNotFound">

--- a/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
@@ -510,6 +510,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1053: Araç olarak paketleme kendi kendini kapsamayı desteklemiyor.</target>
         <note>{StrBegin="NETSDK1053: "}</note>
       </trans-unit>
+      <trans-unit id="PackAsToolCannotSupportTargetPlatformIdentifier">
+        <source>NETSDK1146: Pack as tool does not support TargetPlatformIdentifier being set. For example, targetframework cannot be net5.0-windows, only net5.0. And Pack as tool .NET5 or higher does not support UseWPF and UseWinform.</source>
+        <target state="new">NETSDK1146: Pack as tool does not support TargetPlatformIdentifier being set. For example, targetframework cannot be net5.0-windows, only net5.0. And Pack as tool .NET5 or higher does not support UseWPF and UseWinform.</target>
+        <note>{StrBegin="NETSDK1146: "}</note>
+      </trans-unit>
       <trans-unit id="PackageNotFound">
         <source>NETSDK1064: Package {0}, version {1} was not found. It might have been deleted since NuGet restore. Otherwise, NuGet restore might have only partially completed, which might have been due to maximum path length restrictions.</source>
         <target state="translated">NETSDK1064: {0} paketinin {1} sürümü bulunamadı. NuGet geri yükleme işleminden sonra silinmiş olabilir. Silinmediyse, NuGet geri yükleme işlemi muhtemelen en fazla yol uzunluğu kısıtlamaları nedeniyle yalnızca kısmen başarılı olmuş olabilir.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
@@ -511,8 +511,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1053: "}</note>
       </trans-unit>
       <trans-unit id="PackAsToolCannotSupportTargetPlatformIdentifier">
-        <source>NETSDK1146: Pack as tool does not support TargetPlatformIdentifier being set. For example, targetframework cannot be net5.0-windows, only net5.0. And Pack as tool .NET5 or higher does not support UseWPF and UseWinform.</source>
-        <target state="new">NETSDK1146: Pack as tool does not support TargetPlatformIdentifier being set. For example, targetframework cannot be net5.0-windows, only net5.0. And Pack as tool .NET5 or higher does not support UseWPF and UseWinform.</target>
+        <source>NETSDK1146: PackAsTool does not support TargetPlatformIdentifier being set. For example, TargetFramework cannot be net5.0-windows, only net5.0. PackAsTool also does not support UseWPF or UseWindowsForms when targeting .NET 5 and higher.</source>
+        <target state="new">NETSDK1146: PackAsTool does not support TargetPlatformIdentifier being set. For example, TargetFramework cannot be net5.0-windows, only net5.0. PackAsTool also does not support UseWPF or UseWindowsForms when targeting .NET 5 and higher.</target>
         <note>{StrBegin="NETSDK1146: "}</note>
       </trans-unit>
       <trans-unit id="PackageNotFound">

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
@@ -510,6 +510,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1053: 打包为工具不支持自包含。</target>
         <note>{StrBegin="NETSDK1053: "}</note>
       </trans-unit>
+      <trans-unit id="PackAsToolCannotSupportTargetPlatformIdentifier">
+        <source>NETSDK1146: Pack as tool does not support TargetPlatformIdentifier being set. For example, targetframework cannot be net5.0-windows, only net5.0. And Pack as tool .NET5 or higher does not support UseWPF and UseWinform.</source>
+        <target state="new">NETSDK1146: Pack as tool does not support TargetPlatformIdentifier being set. For example, targetframework cannot be net5.0-windows, only net5.0. And Pack as tool .NET5 or higher does not support UseWPF and UseWinform.</target>
+        <note>{StrBegin="NETSDK1146: "}</note>
+      </trans-unit>
       <trans-unit id="PackageNotFound">
         <source>NETSDK1064: Package {0}, version {1} was not found. It might have been deleted since NuGet restore. Otherwise, NuGet restore might have only partially completed, which might have been due to maximum path length restrictions.</source>
         <target state="translated">NETSDK1064: 未找到版本为 {1} 的包 {0}。它可能已在 NuGet 还原后删除。否则，NuGet 还原可能只是部分完成，这种情况可能是最大路径长度限制所导致。</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
@@ -511,8 +511,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1053: "}</note>
       </trans-unit>
       <trans-unit id="PackAsToolCannotSupportTargetPlatformIdentifier">
-        <source>NETSDK1146: Pack as tool does not support TargetPlatformIdentifier being set. For example, targetframework cannot be net5.0-windows, only net5.0. And Pack as tool .NET5 or higher does not support UseWPF and UseWinform.</source>
-        <target state="new">NETSDK1146: Pack as tool does not support TargetPlatformIdentifier being set. For example, targetframework cannot be net5.0-windows, only net5.0. And Pack as tool .NET5 or higher does not support UseWPF and UseWinform.</target>
+        <source>NETSDK1146: PackAsTool does not support TargetPlatformIdentifier being set. For example, TargetFramework cannot be net5.0-windows, only net5.0. PackAsTool also does not support UseWPF or UseWindowsForms when targeting .NET 5 and higher.</source>
+        <target state="new">NETSDK1146: PackAsTool does not support TargetPlatformIdentifier being set. For example, TargetFramework cannot be net5.0-windows, only net5.0. PackAsTool also does not support UseWPF or UseWindowsForms when targeting .NET 5 and higher.</target>
         <note>{StrBegin="NETSDK1146: "}</note>
       </trans-unit>
       <trans-unit id="PackageNotFound">

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
@@ -510,6 +510,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1053: 封裝為工具不支援包含本身。</target>
         <note>{StrBegin="NETSDK1053: "}</note>
       </trans-unit>
+      <trans-unit id="PackAsToolCannotSupportTargetPlatformIdentifier">
+        <source>NETSDK1146: Pack as tool does not support TargetPlatformIdentifier being set. For example, targetframework cannot be net5.0-windows, only net5.0. And Pack as tool .NET5 or higher does not support UseWPF and UseWinform.</source>
+        <target state="new">NETSDK1146: Pack as tool does not support TargetPlatformIdentifier being set. For example, targetframework cannot be net5.0-windows, only net5.0. And Pack as tool .NET5 or higher does not support UseWPF and UseWinform.</target>
+        <note>{StrBegin="NETSDK1146: "}</note>
+      </trans-unit>
       <trans-unit id="PackageNotFound">
         <source>NETSDK1064: Package {0}, version {1} was not found. It might have been deleted since NuGet restore. Otherwise, NuGet restore might have only partially completed, which might have been due to maximum path length restrictions.</source>
         <target state="translated">NETSDK1064: 找不到套件 {0}，版本 {1}。該套件可能因 NuGet restore 還原而刪除，或是可能因為路徑長度上限的限制，而讓 NuGet restore 可能只有部分完成所致。</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
@@ -511,8 +511,8 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1053: "}</note>
       </trans-unit>
       <trans-unit id="PackAsToolCannotSupportTargetPlatformIdentifier">
-        <source>NETSDK1146: Pack as tool does not support TargetPlatformIdentifier being set. For example, targetframework cannot be net5.0-windows, only net5.0. And Pack as tool .NET5 or higher does not support UseWPF and UseWinform.</source>
-        <target state="new">NETSDK1146: Pack as tool does not support TargetPlatformIdentifier being set. For example, targetframework cannot be net5.0-windows, only net5.0. And Pack as tool .NET5 or higher does not support UseWPF and UseWinform.</target>
+        <source>NETSDK1146: PackAsTool does not support TargetPlatformIdentifier being set. For example, TargetFramework cannot be net5.0-windows, only net5.0. PackAsTool also does not support UseWPF or UseWindowsForms when targeting .NET 5 and higher.</source>
+        <target state="new">NETSDK1146: PackAsTool does not support TargetPlatformIdentifier being set. For example, TargetFramework cannot be net5.0-windows, only net5.0. PackAsTool also does not support UseWPF or UseWindowsForms when targeting .NET 5 and higher.</target>
         <note>{StrBegin="NETSDK1146: "}</note>
       </trans-unit>
       <trans-unit id="PackageNotFound">

--- a/src/Tasks/Microsoft.NET.Build.Tasks/GetNuGetShortFolderName.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/GetNuGetShortFolderName.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Build.Framework;
+using NuGet.Frameworks;
+
+namespace Microsoft.NET.Build.Tasks
+{
+    public sealed class GetNuGetShortFolderName : TaskBase
+    {
+        [Required]
+        public string TargetFrameworkMoniker { get; set; }
+        
+        public string TargetPlatformMoniker { get; set; }
+
+
+        [Output]
+        public string NuGetShortFolderName { get; set; }
+
+        protected override void ExecuteCore()
+        {
+            NuGetShortFolderName = NuGetFramework
+                .ParseComponents(TargetFrameworkMoniker, TargetPlatformMoniker)
+                .GetShortFolderName();
+        }
+    }
+}

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolveToolPackagePaths.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveToolPackagePaths.cs
@@ -30,6 +30,8 @@ namespace Microsoft.NET.Build.Tasks
         [Required]
         public string TargetFrameworkMoniker { get; set; }
 
+        public string TargetPlatformMoniker { get; set; }
+
         [Output]
         public ITaskItem[] ResolvedFileToPublishWithPackagePath { get; private set; }
 
@@ -53,7 +55,9 @@ namespace Microsoft.NET.Build.Tasks
                     relativePath));
                 var i = new TaskItem(fullpath);
 
-                var shortFrameworkName = NuGetFramework.Parse(TargetFrameworkMoniker).GetShortFolderName();
+                var shortFrameworkName = NuGetFramework
+                    .ParseComponents(TargetFrameworkMoniker, TargetPlatformMoniker)
+                    .GetShortFolderName();
 
                 i.SetMetadata("PackagePath", $"tools/{shortFrameworkName}/any/{GetDirectoryPathInRelativePath(relativePath)}");
                 result.Add(i);

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.PackTool.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.PackTool.targets
@@ -19,6 +19,8 @@ Copyright (c) .NET Foundation. All rights reserved.
             AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
   <UsingTask TaskName="Microsoft.NET.Build.Tasks.GetEmbeddedApphostPaths"
       AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
+  <UsingTask TaskName="Microsoft.NET.Build.Tasks.GetNuGetShortFolderName"
+             AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
 
   <!--
     Mark all dependency as private assets. But keep them as Publish. So dependency DLLs will be included in NuGet package, while
@@ -42,14 +44,15 @@ Copyright (c) .NET Foundation. All rights reserved.
       AppHostIntermediatePath="$(AppHostIntermediatePath)"
       ResolvedFileToPublish="@(ResolvedFileToPublish)"
       PublishDir="$(PublishDir)"
-      TargetFrameworkMoniker="$(TargetFrameworkMoniker)">
+      TargetFrameworkMoniker="$(TargetFrameworkMoniker)"
+      TargetPlatformMoniker="$(TargetPlatformMoniker)">
 
       <Output TaskParameter="ResolvedFileToPublishWithPackagePath" ItemName="_ResolvedFileToPublishWithPackagePath" />
     </ResolveToolPackagePaths>
 
     <ItemGroup>
       <TfmSpecificPackageFile Include="@(_GeneratedFiles)">
-        <PackagePath>tools/$(TargetFramework)/any/%(_GeneratedFiles.RecursiveDir)%(_GeneratedFiles.Filename)%(_GeneratedFiles.Extension)</PackagePath>
+        <PackagePath>tools/$(_NuGetShortFolderName)/any/%(_GeneratedFiles.RecursiveDir)%(_GeneratedFiles.Filename)%(_GeneratedFiles.Extension)</PackagePath>
       </TfmSpecificPackageFile>
 
       <TfmSpecificPackageFile Include="@(_ResolvedFileToPublishWithPackagePath)">
@@ -71,6 +74,15 @@ Copyright (c) .NET Foundation. All rights reserved.
   </Target>
 
   <Target Name="_PackToolValidation" Condition=" '$(PackAsTool)' == 'true' ">
+
+    <GetNuGetShortFolderName
+      TargetFrameworkMoniker="$(TargetFrameworkMoniker)"
+      TargetPlatformMoniker="$(TargetPlatformMoniker)">
+
+      <Output TaskParameter="NuGetShortFolderName" PropertyName="_NuGetShortFolderName" />
+
+    </GetNuGetShortFolderName>
+
     <NETSdkError Condition=" '$(SelfContained)' == 'true' "
              ResourceName="PackAsToolCannotSupportSelfContained" />
 
@@ -79,6 +91,9 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <NETSdkError Condition=" '$(_TargetFrameworkVersionWithoutV)' &lt; '2.1' "
                  ResourceName="DotnetToolDoesNotSupportTFMLowerThanNetcoreapp21" />
+
+    <NETSdkError Condition=" '$(TargetPlatformIdentifier)' != '' and '$(TargetFrameworkIdentifier)' == '.NETCoreApp' and $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), 5.0))"
+             ResourceName="PackAsToolCannotSupportTargetPlatformIdentifier" />
   </Target>
 
   <!--
@@ -108,7 +123,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       ApphostsForShimRuntimeIdentifiers="@(_ApphostsForShimRuntimeIdentifiers)"
       IntermediateAssembly="@(IntermediateAssembly->'%(FullPath)')"
       OutputType="$(OutputType)"
-      PackagedShimOutputDirectory="$(PackagedShimOutputRootDirectory)/shims/$(TargetFramework)"
+      PackagedShimOutputDirectory="$(PackagedShimOutputRootDirectory)/shims/$(_NuGetShortFolderName)"
       PackageId="$(PackageId)"
       PackageVersion="$(PackageVersion)"
       ShimRuntimeIdentifiers="@(_PackAsToolShimRuntimeIdentifiers)"
@@ -137,7 +152,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <Target Name="_ComputeExpectedEmbeddedApphostPaths">
     <GetEmbeddedApphostPaths
-      PackagedShimOutputDirectory="$(PackagedShimOutputRootDirectory)/shims/$(TargetFramework)"
+      PackagedShimOutputDirectory="$(PackagedShimOutputRootDirectory)/shims/$(_NuGetShortFolderName)"
       ShimRuntimeIdentifiers="@(_PackAsToolShimRuntimeIdentifiers)"
       ToolCommandName="$(ToolCommandName)">
 

--- a/src/Tests/Microsoft.NET.ToolPack.Tests/GivenThatWeWantToPackAToolProject.cs
+++ b/src/Tests/Microsoft.NET.ToolPack.Tests/GivenThatWeWantToPackAToolProject.cs
@@ -70,11 +70,50 @@ namespace Microsoft.NET.ToolPack.Tests
         public void It_finds_the_entry_point_dll_and_command_name_and_put_in_setting_file(bool multiTarget)
         {
             var nugetPackage = SetupNuGetPackage(multiTarget);
+            AssertFiles(nugetPackage);
+        }
+
+        [Fact]
+        public void Given_nuget_alias_It_finds_the_entry_point_dll_and_command_name_and_put_in_setting_file()
+        {
+            TestAsset helloWorldAsset = _testAssetsManager
+                .CopyTestAsset("PortableTool")
+                .WithSource()
+                .WithProjectChanges(project =>
+                {
+                    XNamespace ns = project.Root.Name.Namespace;
+                    XElement propertyGroup = project.Root.Elements(ns + "PropertyGroup").First();
+                    propertyGroup.Elements("TargetFramework").First().SetValue("targetframeworkAlias");
+                    XElement conditionPropertyGroup = new XElement("PropertyGroup");
+                    project.Root.Add(conditionPropertyGroup);
+                    conditionPropertyGroup.SetAttributeValue("Condition", "'$(TargetFramework)' == 'targetframeworkAlias'");
+                    conditionPropertyGroup.SetElementValue("TargetFrameworkIdentifier", ".NETCoreApp");
+                    conditionPropertyGroup.SetElementValue("TargetFrameworkVersion", "v3.1");
+                    conditionPropertyGroup.SetElementValue("TargetFrameworkMoniker", ".NETCoreApp,Version=v3.1");
+                });
+
+            _testRoot = helloWorldAsset.TestRoot;
+
+            var packCommand = new PackCommand(Log, helloWorldAsset.TestRoot);
+
+            var result = packCommand.Execute();
+            result.Should().Pass();
+
+            var nugetPackage = packCommand.GetNuGetPackage();
+            AssertFiles(nugetPackage);
+        }
+
+        private void AssertFiles(string nugetPackage)
+        {
             using (var nupkgReader = new PackageArchiveReader(nugetPackage))
             {
                 var anyTfm = nupkgReader.GetSupportedFrameworks().First().GetShortFolderName();
                 var tmpfilePath = Path.Combine(_testRoot, "temp", Path.GetRandomFileName());
                 string copiedFile = nupkgReader.ExtractFile($"tools/{anyTfm}/any/DotnetToolSettings.xml", tmpfilePath, null);
+
+                var allItems = nupkgReader.GetToolItems().SelectMany(i => i.Items).ToList();
+                allItems.Should().Contain($"tools/{anyTfm}/any/consoledemo.runtimeconfig.json");
+
                 XElement command = XDocument.Load(copiedFile)
                                       .Element("DotNetCliTool")
                                       .Element("Commands")
@@ -240,6 +279,28 @@ namespace Microsoft.NET.ToolPack.Tests
                     allItems.Should().Contain($"tools/{framework.GetShortFolderName()}/any/Newtonsoft.Json.dll");
                 }
             }
+        }
+
+        [Fact]
+        public void Given_targetplatform_set_It_should_error()
+        {
+            TestAsset helloWorldAsset = _testAssetsManager
+                .CopyTestAsset("PortableTool")
+                .WithSource()
+                .WithProjectChanges(project =>
+                {
+                    XNamespace ns = project.Root.Name.Namespace;
+                    XElement propertyGroup = project.Root.Elements(ns + "PropertyGroup").First();
+                    propertyGroup.Elements("TargetFramework").First().SetValue("net5.0-windows");
+                });
+
+            _testRoot = helloWorldAsset.TestRoot;
+
+            var packCommand = new PackCommand(Log, helloWorldAsset.TestRoot);
+
+            var result = packCommand.Execute();
+            result.Should().Fail().And.HaveStdOutContaining("NETSDK1146");
+
         }
     }
 }


### PR DESCRIPTION
### Description

Fix pack dotnet tools (PacKAsTool=true) does not support nuget TargetFramework alias. And block net5.0-windows (instead of net5.0) to use PackAsTool since the result package cannot be installed using `dotnet tool install`. net5.0-windows support is an explicit cut from earlier due to not enough time. 

These 2 issues have the same root cause of .net5 target framework change.

### Customer Impact

The dotnet tool producer cannot produce dotnet tools with TargetFramework alias.
The dotnet tool producer cannot get early feedback of produced net5.0-windows package cannot be installed.

### Regression?

No

### Risk

Low

### Test changes in this PR

Unit test and manual test