### PR TITLE
Add --use-current-runtime option

### DIFF
--- a/src/Cli/dotnet/CommonOptions.cs
+++ b/src/Cli/dotnet/CommonOptions.cs
@@ -1,6 +1,10 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 using Microsoft.DotNet.Cli.CommandLine;
 using Microsoft.DotNet.Tools.Common;
 using Microsoft.DotNet.Tools;
@@ -30,7 +34,7 @@ namespace Microsoft.DotNet.Cli
                           "diag", "diagnostic")
                       .With(name: CommonLocalizableStrings.LevelArgumentName)
                       .ForwardAsSingle(format));
-        
+
         public static Option FrameworkOption(string description) =>
             Create.Option(
                 "-f|--framework",
@@ -39,7 +43,7 @@ namespace Microsoft.DotNet.Cli
                     .WithSuggestionsFrom(_ => Suggest.TargetFrameworksFromProjectFile())
                     .With(name: CommonLocalizableStrings.FrameworkArgumentName)
                     .ForwardAsSingle(o => $"-property:TargetFramework={o.Arguments.Single()}"));
-        
+
         public static Option RuntimeOption(string description, bool withShortOption = true) =>
             Create.Option(
                 withShortOption ? "-r|--runtime" : "--runtime",
@@ -48,7 +52,14 @@ namespace Microsoft.DotNet.Cli
                     .WithSuggestionsFrom(_ => Suggest.RunTimesFromProjectFile())
                     .With(name: CommonLocalizableStrings.RuntimeIdentifierArgumentName)
                     .ForwardAsSingle(o => $"-property:RuntimeIdentifier={o.Arguments.Single()}"));
-                
+
+        public static Option CurrentRuntimeOption(string description, bool withShortOption = true) =>
+            Create.Option(
+                "--use-current-runtime",
+                description,
+                Accept.NoArguments()
+                    .ForwardAs("-property:UseCurrentRuntimeIdentifier=True"));
+
         public static Option ConfigurationOption(string description) =>
             Create.Option(
                 "-c|--configuration",

--- a/src/Cli/dotnet/CommonOptions.cs
+++ b/src/Cli/dotnet/CommonOptions.cs
@@ -4,7 +4,6 @@
 using System;
 using System.IO;
 using System.Linq;
-using System.Runtime.InteropServices;
 using Microsoft.DotNet.Cli.CommandLine;
 using Microsoft.DotNet.Tools.Common;
 using Microsoft.DotNet.Tools;

--- a/src/Cli/dotnet/commands/dotnet-restore/LocalizableStrings.resx
+++ b/src/Cli/dotnet/commands/dotnet-restore/LocalizableStrings.resx
@@ -142,7 +142,7 @@
     <value>The target runtime to restore packages for.</value>
   </data>
   <data name="CmdCurrentRuntimeOptionDescription" xml:space="preserve">
-    <value>Use host runtime to build the target.</value>
+    <value>Use current runtime as the target runtime.</value>
   </data>
   <data name="CmdPackagesOption" xml:space="preserve">
     <value>PACKAGES_DIR</value>

--- a/src/Cli/dotnet/commands/dotnet-restore/LocalizableStrings.resx
+++ b/src/Cli/dotnet/commands/dotnet-restore/LocalizableStrings.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -140,6 +140,9 @@
   </data>
   <data name="CmdRuntimeOptionDescription" xml:space="preserve">
     <value>The target runtime to restore packages for.</value>
+  </data>
+  <data name="CmdCurrentRuntimeOptionDescription" xml:space="preserve">
+    <value>Use host runtime to build the target.</value>
   </data>
   <data name="CmdPackagesOption" xml:space="preserve">
     <value>PACKAGES_DIR</value>

--- a/src/Cli/dotnet/commands/dotnet-restore/RestoreCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-restore/RestoreCommandParser.cs
@@ -84,11 +84,7 @@ namespace Microsoft.DotNet.Cli
                           .WithSuggestionsFrom(_ => Suggest.RunTimesFromProjectFile())
                           .With(name: LocalizableStrings.CmdRuntimeOption)
                           .ForwardAsSingle(o => $"-property:RuntimeIdentifiers={string.Join("%3B", o.Arguments)}")),
-                Create.Option(
-                    "--use-current-runtime",
-                    LocalizableStrings.CmdCurrentRuntimeOptionDescription,
-                    Accept.NoArguments()
-                          .ForwardAs("-property:UseCurrentRuntimeIdentifier=True")),
+                CommonOptions.CurrentRuntimeOption(LocalizableStrings.CmdCurrentRuntimeOptionDescription),
                 Create.Option(
                     "--packages",
                     showHelp ? LocalizableStrings.CmdPackagesOptionDescription : string.Empty,

--- a/src/Cli/dotnet/commands/dotnet-restore/RestoreCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-restore/RestoreCommandParser.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection.Metadata;
+using System.Runtime.InteropServices;
 using Microsoft.DotNet.Cli.CommandLine;
 using Microsoft.DotNet.Tools;
 using LocalizableStrings = Microsoft.DotNet.Tools.Restore.LocalizableStrings;
@@ -83,6 +84,11 @@ namespace Microsoft.DotNet.Cli
                           .WithSuggestionsFrom(_ => Suggest.RunTimesFromProjectFile())
                           .With(name: LocalizableStrings.CmdRuntimeOption)
                           .ForwardAsSingle(o => $"-property:RuntimeIdentifiers={string.Join("%3B", o.Arguments)}")),
+                Create.Option(
+                    "--use-current-runtime",
+                    LocalizableStrings.CmdCurrentRuntimeOptionDescription,
+                    Accept.NoArguments()
+                          .ForwardAs("-property:UseCurrentRuntimeIdentifier=True")),
                 Create.Option(
                     "--packages",
                     showHelp ? LocalizableStrings.CmdPackagesOptionDescription : string.Empty,

--- a/src/Cli/dotnet/commands/dotnet-restore/RestoreCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-restore/RestoreCommandParser.cs
@@ -4,7 +4,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection.Metadata;
-using System.Runtime.InteropServices;
 using Microsoft.DotNet.Cli.CommandLine;
 using Microsoft.DotNet.Tools;
 using LocalizableStrings = Microsoft.DotNet.Tools.Restore.LocalizableStrings;

--- a/src/Cli/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.cs.xlf
+++ b/src/Cli/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.cs.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdCurrentRuntimeOptionDescription">
-        <source>Use host runtime to build the target.</source>
-        <target state="new">Use host runtime to build the target.</target>
+        <source>Use current runtime as the target runtime.</source>
+        <target state="new">Use current runtime as the target runtime.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdSourceOption">

--- a/src/Cli/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.cs.xlf
+++ b/src/Cli/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.cs.xlf
@@ -22,6 +22,11 @@
         <target state="translated">Volitelná cesta k souboru projektu nebo k argumentům MSBuildu</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdCurrentRuntimeOptionDescription">
+        <source>Use host runtime to build the target.</source>
+        <target state="new">Use host runtime to build the target.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdSourceOption">
         <source>SOURCE</source>
         <target state="translated">SOURCE</target>

--- a/src/Cli/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.de.xlf
+++ b/src/Cli/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.de.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdCurrentRuntimeOptionDescription">
-        <source>Use host runtime to build the target.</source>
-        <target state="new">Use host runtime to build the target.</target>
+        <source>Use current runtime as the target runtime.</source>
+        <target state="new">Use current runtime as the target runtime.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdSourceOption">

--- a/src/Cli/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.de.xlf
+++ b/src/Cli/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.de.xlf
@@ -22,6 +22,11 @@
         <target state="translated">Optionaler Pfad zu einer Projektdatei oder MSBuild-Argumente.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdCurrentRuntimeOptionDescription">
+        <source>Use host runtime to build the target.</source>
+        <target state="new">Use host runtime to build the target.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdSourceOption">
         <source>SOURCE</source>
         <target state="translated">SOURCE</target>

--- a/src/Cli/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.es.xlf
+++ b/src/Cli/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.es.xlf
@@ -22,6 +22,11 @@
         <target state="translated">Ruta de acceso opcional a un archivo de proyecto o argumentos de MSBuild.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdCurrentRuntimeOptionDescription">
+        <source>Use host runtime to build the target.</source>
+        <target state="new">Use host runtime to build the target.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdSourceOption">
         <source>SOURCE</source>
         <target state="translated">ORIGEN</target>

--- a/src/Cli/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.es.xlf
+++ b/src/Cli/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.es.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdCurrentRuntimeOptionDescription">
-        <source>Use host runtime to build the target.</source>
-        <target state="new">Use host runtime to build the target.</target>
+        <source>Use current runtime as the target runtime.</source>
+        <target state="new">Use current runtime as the target runtime.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdSourceOption">

--- a/src/Cli/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.fr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.fr.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdCurrentRuntimeOptionDescription">
-        <source>Use host runtime to build the target.</source>
-        <target state="new">Use host runtime to build the target.</target>
+        <source>Use current runtime as the target runtime.</source>
+        <target state="new">Use current runtime as the target runtime.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdSourceOption">

--- a/src/Cli/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.fr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.fr.xlf
@@ -22,6 +22,11 @@
         <target state="translated">Chemin facultatif vers un fichier projet ou des arguments MSBuild.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdCurrentRuntimeOptionDescription">
+        <source>Use host runtime to build the target.</source>
+        <target state="new">Use host runtime to build the target.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdSourceOption">
         <source>SOURCE</source>
         <target state="translated">SOURCE</target>

--- a/src/Cli/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.it.xlf
+++ b/src/Cli/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.it.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdCurrentRuntimeOptionDescription">
-        <source>Use host runtime to build the target.</source>
-        <target state="new">Use host runtime to build the target.</target>
+        <source>Use current runtime as the target runtime.</source>
+        <target state="new">Use current runtime as the target runtime.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdSourceOption">

--- a/src/Cli/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.it.xlf
+++ b/src/Cli/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.it.xlf
@@ -22,6 +22,11 @@
         <target state="translated">Percorso facoltativo di un file di progetto o di argomenti di MSBuild.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdCurrentRuntimeOptionDescription">
+        <source>Use host runtime to build the target.</source>
+        <target state="new">Use host runtime to build the target.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdSourceOption">
         <source>SOURCE</source>
         <target state="translated">ORIGINE</target>

--- a/src/Cli/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.ja.xlf
+++ b/src/Cli/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.ja.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdCurrentRuntimeOptionDescription">
-        <source>Use host runtime to build the target.</source>
-        <target state="new">Use host runtime to build the target.</target>
+        <source>Use current runtime as the target runtime.</source>
+        <target state="new">Use current runtime as the target runtime.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdSourceOption">

--- a/src/Cli/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.ja.xlf
+++ b/src/Cli/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.ja.xlf
@@ -22,6 +22,11 @@
         <target state="translated">プロジェクト ファイルまたは MSBuild 引数へのオプションのパス。</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdCurrentRuntimeOptionDescription">
+        <source>Use host runtime to build the target.</source>
+        <target state="new">Use host runtime to build the target.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdSourceOption">
         <source>SOURCE</source>
         <target state="translated">SOURCE</target>

--- a/src/Cli/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.ko.xlf
+++ b/src/Cli/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.ko.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdCurrentRuntimeOptionDescription">
-        <source>Use host runtime to build the target.</source>
-        <target state="new">Use host runtime to build the target.</target>
+        <source>Use current runtime as the target runtime.</source>
+        <target state="new">Use current runtime as the target runtime.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdSourceOption">

--- a/src/Cli/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.ko.xlf
+++ b/src/Cli/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.ko.xlf
@@ -22,6 +22,11 @@
         <target state="translated">프로젝트 파일의 선택적 경로 또는 MSBuild 인수입니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdCurrentRuntimeOptionDescription">
+        <source>Use host runtime to build the target.</source>
+        <target state="new">Use host runtime to build the target.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdSourceOption">
         <source>SOURCE</source>
         <target state="translated">SOURCE</target>

--- a/src/Cli/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.pl.xlf
+++ b/src/Cli/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.pl.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdCurrentRuntimeOptionDescription">
-        <source>Use host runtime to build the target.</source>
-        <target state="new">Use host runtime to build the target.</target>
+        <source>Use current runtime as the target runtime.</source>
+        <target state="new">Use current runtime as the target runtime.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdSourceOption">

--- a/src/Cli/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.pl.xlf
+++ b/src/Cli/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.pl.xlf
@@ -22,6 +22,11 @@
         <target state="translated">Opcjonalna ścieżka do pliku projektu lub argumentów programu MSBuild.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdCurrentRuntimeOptionDescription">
+        <source>Use host runtime to build the target.</source>
+        <target state="new">Use host runtime to build the target.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdSourceOption">
         <source>SOURCE</source>
         <target state="translated">ŹRÓDŁO</target>

--- a/src/Cli/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.pt-BR.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdCurrentRuntimeOptionDescription">
-        <source>Use host runtime to build the target.</source>
-        <target state="new">Use host runtime to build the target.</target>
+        <source>Use current runtime as the target runtime.</source>
+        <target state="new">Use current runtime as the target runtime.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdSourceOption">

--- a/src/Cli/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.pt-BR.xlf
@@ -22,6 +22,11 @@
         <target state="translated">Caminho opcional para um arquivo de projeto ou argumentos do MSBuild.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdCurrentRuntimeOptionDescription">
+        <source>Use host runtime to build the target.</source>
+        <target state="new">Use host runtime to build the target.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdSourceOption">
         <source>SOURCE</source>
         <target state="translated">ORIGEM</target>

--- a/src/Cli/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.ru.xlf
+++ b/src/Cli/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.ru.xlf
@@ -22,6 +22,11 @@
         <target state="translated">Дополнительный путь к файлу проекта или аргументам MSBuild.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdCurrentRuntimeOptionDescription">
+        <source>Use host runtime to build the target.</source>
+        <target state="new">Use host runtime to build the target.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdSourceOption">
         <source>SOURCE</source>
         <target state="translated">SOURCE</target>

--- a/src/Cli/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.ru.xlf
+++ b/src/Cli/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.ru.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdCurrentRuntimeOptionDescription">
-        <source>Use host runtime to build the target.</source>
-        <target state="new">Use host runtime to build the target.</target>
+        <source>Use current runtime as the target runtime.</source>
+        <target state="new">Use current runtime as the target runtime.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdSourceOption">

--- a/src/Cli/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.tr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.tr.xlf
@@ -22,6 +22,11 @@
         <target state="translated">Proje dosyasının veya MSBuild bağımsız değişkenlerinin isteğe bağlı yolu.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdCurrentRuntimeOptionDescription">
+        <source>Use host runtime to build the target.</source>
+        <target state="new">Use host runtime to build the target.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdSourceOption">
         <source>SOURCE</source>
         <target state="translated">SOURCE</target>

--- a/src/Cli/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.tr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.tr.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdCurrentRuntimeOptionDescription">
-        <source>Use host runtime to build the target.</source>
-        <target state="new">Use host runtime to build the target.</target>
+        <source>Use current runtime as the target runtime.</source>
+        <target state="new">Use current runtime as the target runtime.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdSourceOption">

--- a/src/Cli/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.zh-Hans.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdCurrentRuntimeOptionDescription">
-        <source>Use host runtime to build the target.</source>
-        <target state="new">Use host runtime to build the target.</target>
+        <source>Use current runtime as the target runtime.</source>
+        <target state="new">Use current runtime as the target runtime.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdSourceOption">

--- a/src/Cli/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.zh-Hans.xlf
@@ -22,6 +22,11 @@
         <target state="translated">项目文件或 MSBuild 参数的可选路径。</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdCurrentRuntimeOptionDescription">
+        <source>Use host runtime to build the target.</source>
+        <target state="new">Use host runtime to build the target.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdSourceOption">
         <source>SOURCE</source>
         <target state="translated">SOURCE</target>

--- a/src/Cli/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.zh-Hant.xlf
@@ -22,6 +22,11 @@
         <target state="translated">專案檔或 MSBuild 引數的選擇性路徑。</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdCurrentRuntimeOptionDescription">
+        <source>Use host runtime to build the target.</source>
+        <target state="new">Use host runtime to build the target.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdSourceOption">
         <source>SOURCE</source>
         <target state="translated">SOURCE</target>

--- a/src/Cli/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.zh-Hant.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdCurrentRuntimeOptionDescription">
-        <source>Use host runtime to build the target.</source>
-        <target state="new">Use host runtime to build the target.</target>
+        <source>Use current runtime as the target runtime.</source>
+        <target state="new">Use current runtime as the target runtime.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdSourceOption">

--- a/src/Cli/dotnet/commands/dotnet-store/LocalizableStrings.resx
+++ b/src/Cli/dotnet/commands/dotnet-store/LocalizableStrings.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -161,5 +161,8 @@
   </data>
   <data name="RuntimeOptionDescription" xml:space="preserve">
     <value>The target runtime to store packages for.</value>
+  </data>
+  <data name="CurrentRuntimeOptionDescription" xml:space="preserve">
+    <value>Use host runtime to build the target.</value>
   </data>
 </root>

--- a/src/Cli/dotnet/commands/dotnet-store/LocalizableStrings.resx
+++ b/src/Cli/dotnet/commands/dotnet-store/LocalizableStrings.resx
@@ -163,6 +163,6 @@
     <value>The target runtime to store packages for.</value>
   </data>
   <data name="CurrentRuntimeOptionDescription" xml:space="preserve">
-    <value>Use host runtime to build the target.</value>
+    <value>Use current runtime as the target runtime.</value>
   </data>
 </root>

--- a/src/Cli/dotnet/commands/dotnet-store/StoreCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-store/StoreCommandParser.cs
@@ -50,6 +50,7 @@ namespace Microsoft.DotNet.Cli
                         .With(name: LocalizableStrings.FrameworkVersionOption)
                         .ForwardAsSingle(o => $"-property:RuntimeFrameworkVersion={o.Arguments.Single()}")),
                 CommonOptions.RuntimeOption(LocalizableStrings.RuntimeOptionDescription),
+                CommonOptions.CurrentRuntimeOption(LocalizableStrings.CurrentRuntimeOptionDescription),
                 Create.Option(
                     "-o|--output",
                     LocalizableStrings.OutputOptionDescription,

--- a/src/Cli/dotnet/commands/dotnet-store/xlf/LocalizableStrings.cs.xlf
+++ b/src/Cli/dotnet/commands/dotnet-store/xlf/LocalizableStrings.cs.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CurrentRuntimeOptionDescription">
-        <source>Use host runtime to build the target.</source>
-        <target state="new">Use host runtime to build the target.</target>
+        <source>Use current runtime as the target runtime.</source>
+        <target state="new">Use current runtime as the target runtime.</target>
         <note />
       </trans-unit>
       <trans-unit id="OutputOption">

--- a/src/Cli/dotnet/commands/dotnet-store/xlf/LocalizableStrings.cs.xlf
+++ b/src/Cli/dotnet/commands/dotnet-store/xlf/LocalizableStrings.cs.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Uloží určená sestavení pro platformu .NET. Standardně se optimalizují pro cílový modul runtime a architekturu.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CurrentRuntimeOptionDescription">
+        <source>Use host runtime to build the target.</source>
+        <target state="new">Use host runtime to build the target.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OutputOption">
         <source>OUTPUT_DIR</source>
         <target state="translated">OUTPUT_DIR</target>

--- a/src/Cli/dotnet/commands/dotnet-store/xlf/LocalizableStrings.de.xlf
+++ b/src/Cli/dotnet/commands/dotnet-store/xlf/LocalizableStrings.de.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CurrentRuntimeOptionDescription">
-        <source>Use host runtime to build the target.</source>
-        <target state="new">Use host runtime to build the target.</target>
+        <source>Use current runtime as the target runtime.</source>
+        <target state="new">Use current runtime as the target runtime.</target>
         <note />
       </trans-unit>
       <trans-unit id="OutputOption">

--- a/src/Cli/dotnet/commands/dotnet-store/xlf/LocalizableStrings.de.xlf
+++ b/src/Cli/dotnet/commands/dotnet-store/xlf/LocalizableStrings.de.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Speichert die angegebenen Assemblys für die .NET-Plattform. Standardmäßig werden diese für die Zielruntime und das Framework optimiert.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CurrentRuntimeOptionDescription">
+        <source>Use host runtime to build the target.</source>
+        <target state="new">Use host runtime to build the target.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OutputOption">
         <source>OUTPUT_DIR</source>
         <target state="translated">OUTPUT_DIR</target>

--- a/src/Cli/dotnet/commands/dotnet-store/xlf/LocalizableStrings.es.xlf
+++ b/src/Cli/dotnet/commands/dotnet-store/xlf/LocalizableStrings.es.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CurrentRuntimeOptionDescription">
-        <source>Use host runtime to build the target.</source>
-        <target state="new">Use host runtime to build the target.</target>
+        <source>Use current runtime as the target runtime.</source>
+        <target state="new">Use current runtime as the target runtime.</target>
         <note />
       </trans-unit>
       <trans-unit id="OutputOption">

--- a/src/Cli/dotnet/commands/dotnet-store/xlf/LocalizableStrings.es.xlf
+++ b/src/Cli/dotnet/commands/dotnet-store/xlf/LocalizableStrings.es.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Almacena los ensamblados especificados para la plataforma .NET. De forma predeterminada, estos se optimizarán para el tiempo de ejecución y la plataforma de destino.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CurrentRuntimeOptionDescription">
+        <source>Use host runtime to build the target.</source>
+        <target state="new">Use host runtime to build the target.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OutputOption">
         <source>OUTPUT_DIR</source>
         <target state="translated">DIRECTORIO_DE_SALIDA</target>

--- a/src/Cli/dotnet/commands/dotnet-store/xlf/LocalizableStrings.fr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-store/xlf/LocalizableStrings.fr.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Stocke les assemblys spécifiés pour la plateforme .NET. Par défaut, ceux-ci sont optimisés pour le runtime et le framework cible.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CurrentRuntimeOptionDescription">
+        <source>Use host runtime to build the target.</source>
+        <target state="new">Use host runtime to build the target.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OutputOption">
         <source>OUTPUT_DIR</source>
         <target state="translated">OUTPUT_DIR</target>

--- a/src/Cli/dotnet/commands/dotnet-store/xlf/LocalizableStrings.fr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-store/xlf/LocalizableStrings.fr.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CurrentRuntimeOptionDescription">
-        <source>Use host runtime to build the target.</source>
-        <target state="new">Use host runtime to build the target.</target>
+        <source>Use current runtime as the target runtime.</source>
+        <target state="new">Use current runtime as the target runtime.</target>
         <note />
       </trans-unit>
       <trans-unit id="OutputOption">

--- a/src/Cli/dotnet/commands/dotnet-store/xlf/LocalizableStrings.it.xlf
+++ b/src/Cli/dotnet/commands/dotnet-store/xlf/LocalizableStrings.it.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Consente di archiviare gli assembly specificati per la piattaforma .NET. Per impostazione predefinita, gli assembly verranno ottimizzati per il framework e il runtime di destinazione.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CurrentRuntimeOptionDescription">
+        <source>Use host runtime to build the target.</source>
+        <target state="new">Use host runtime to build the target.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OutputOption">
         <source>OUTPUT_DIR</source>
         <target state="translated">DIR_OUTPUT</target>

--- a/src/Cli/dotnet/commands/dotnet-store/xlf/LocalizableStrings.it.xlf
+++ b/src/Cli/dotnet/commands/dotnet-store/xlf/LocalizableStrings.it.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CurrentRuntimeOptionDescription">
-        <source>Use host runtime to build the target.</source>
-        <target state="new">Use host runtime to build the target.</target>
+        <source>Use current runtime as the target runtime.</source>
+        <target state="new">Use current runtime as the target runtime.</target>
         <note />
       </trans-unit>
       <trans-unit id="OutputOption">

--- a/src/Cli/dotnet/commands/dotnet-store/xlf/LocalizableStrings.ja.xlf
+++ b/src/Cli/dotnet/commands/dotnet-store/xlf/LocalizableStrings.ja.xlf
@@ -7,6 +7,11 @@
         <target state="translated">.NET Platform の指定されたアセンブリを格納します。既定では、これらはターゲットのランタイムとフレームワーク用に最適化されます。</target>
         <note />
       </trans-unit>
+      <trans-unit id="CurrentRuntimeOptionDescription">
+        <source>Use host runtime to build the target.</source>
+        <target state="new">Use host runtime to build the target.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OutputOption">
         <source>OUTPUT_DIR</source>
         <target state="translated">OUTPUT_DIR</target>

--- a/src/Cli/dotnet/commands/dotnet-store/xlf/LocalizableStrings.ja.xlf
+++ b/src/Cli/dotnet/commands/dotnet-store/xlf/LocalizableStrings.ja.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CurrentRuntimeOptionDescription">
-        <source>Use host runtime to build the target.</source>
-        <target state="new">Use host runtime to build the target.</target>
+        <source>Use current runtime as the target runtime.</source>
+        <target state="new">Use current runtime as the target runtime.</target>
         <note />
       </trans-unit>
       <trans-unit id="OutputOption">

--- a/src/Cli/dotnet/commands/dotnet-store/xlf/LocalizableStrings.ko.xlf
+++ b/src/Cli/dotnet/commands/dotnet-store/xlf/LocalizableStrings.ko.xlf
@@ -7,6 +7,11 @@
         <target state="translated">.NET 플랫폼에 대해 지정된 어셈블리를 저장합니다. 기본적으로 대상 런타임 및 프레임워크에 대해 최적화됩니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CurrentRuntimeOptionDescription">
+        <source>Use host runtime to build the target.</source>
+        <target state="new">Use host runtime to build the target.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OutputOption">
         <source>OUTPUT_DIR</source>
         <target state="translated">OUTPUT_DIR</target>

--- a/src/Cli/dotnet/commands/dotnet-store/xlf/LocalizableStrings.ko.xlf
+++ b/src/Cli/dotnet/commands/dotnet-store/xlf/LocalizableStrings.ko.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CurrentRuntimeOptionDescription">
-        <source>Use host runtime to build the target.</source>
-        <target state="new">Use host runtime to build the target.</target>
+        <source>Use current runtime as the target runtime.</source>
+        <target state="new">Use current runtime as the target runtime.</target>
         <note />
       </trans-unit>
       <trans-unit id="OutputOption">

--- a/src/Cli/dotnet/commands/dotnet-store/xlf/LocalizableStrings.pl.xlf
+++ b/src/Cli/dotnet/commands/dotnet-store/xlf/LocalizableStrings.pl.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CurrentRuntimeOptionDescription">
-        <source>Use host runtime to build the target.</source>
-        <target state="new">Use host runtime to build the target.</target>
+        <source>Use current runtime as the target runtime.</source>
+        <target state="new">Use current runtime as the target runtime.</target>
         <note />
       </trans-unit>
       <trans-unit id="OutputOption">

--- a/src/Cli/dotnet/commands/dotnet-store/xlf/LocalizableStrings.pl.xlf
+++ b/src/Cli/dotnet/commands/dotnet-store/xlf/LocalizableStrings.pl.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Przechowuje określone zestawy platformy .NET. Domyślnie są one optymalizowane pod kątem docelowego środowiska uruchomieniowego i platformy docelowej.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CurrentRuntimeOptionDescription">
+        <source>Use host runtime to build the target.</source>
+        <target state="new">Use host runtime to build the target.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OutputOption">
         <source>OUTPUT_DIR</source>
         <target state="translated">KATALOG_WYJŚCIOWY</target>

--- a/src/Cli/dotnet/commands/dotnet-store/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/commands/dotnet-store/xlf/LocalizableStrings.pt-BR.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Armazena os assemblies especificados para a Plataforma .NET. Por padrão, serão otimizados para o runtime e a estrutura de destino.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CurrentRuntimeOptionDescription">
+        <source>Use host runtime to build the target.</source>
+        <target state="new">Use host runtime to build the target.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OutputOption">
         <source>OUTPUT_DIR</source>
         <target state="translated">OUTPUT_DIR</target>

--- a/src/Cli/dotnet/commands/dotnet-store/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/commands/dotnet-store/xlf/LocalizableStrings.pt-BR.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CurrentRuntimeOptionDescription">
-        <source>Use host runtime to build the target.</source>
-        <target state="new">Use host runtime to build the target.</target>
+        <source>Use current runtime as the target runtime.</source>
+        <target state="new">Use current runtime as the target runtime.</target>
         <note />
       </trans-unit>
       <trans-unit id="OutputOption">

--- a/src/Cli/dotnet/commands/dotnet-store/xlf/LocalizableStrings.ru.xlf
+++ b/src/Cli/dotnet/commands/dotnet-store/xlf/LocalizableStrings.ru.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Хранит указанные сборки для платформы .NET. По умолчанию они оптимизируются для целевой среды выполнения и платформы.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CurrentRuntimeOptionDescription">
+        <source>Use host runtime to build the target.</source>
+        <target state="new">Use host runtime to build the target.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OutputOption">
         <source>OUTPUT_DIR</source>
         <target state="translated">OUTPUT_DIR</target>

--- a/src/Cli/dotnet/commands/dotnet-store/xlf/LocalizableStrings.ru.xlf
+++ b/src/Cli/dotnet/commands/dotnet-store/xlf/LocalizableStrings.ru.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CurrentRuntimeOptionDescription">
-        <source>Use host runtime to build the target.</source>
-        <target state="new">Use host runtime to build the target.</target>
+        <source>Use current runtime as the target runtime.</source>
+        <target state="new">Use current runtime as the target runtime.</target>
         <note />
       </trans-unit>
       <trans-unit id="OutputOption">

--- a/src/Cli/dotnet/commands/dotnet-store/xlf/LocalizableStrings.tr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-store/xlf/LocalizableStrings.tr.xlf
@@ -7,6 +7,11 @@
         <target state="translated">.NET Platformu için belirtilen bütünleştirilmiş kodları depolar. Varsayılan olarak, bunlar hedef çalışma zamanı ve çerçeve için iyileştirilir.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CurrentRuntimeOptionDescription">
+        <source>Use host runtime to build the target.</source>
+        <target state="new">Use host runtime to build the target.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OutputOption">
         <source>OUTPUT_DIR</source>
         <target state="translated">ÇIKIŞ_DİZİNİ</target>

--- a/src/Cli/dotnet/commands/dotnet-store/xlf/LocalizableStrings.tr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-store/xlf/LocalizableStrings.tr.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CurrentRuntimeOptionDescription">
-        <source>Use host runtime to build the target.</source>
-        <target state="new">Use host runtime to build the target.</target>
+        <source>Use current runtime as the target runtime.</source>
+        <target state="new">Use current runtime as the target runtime.</target>
         <note />
       </trans-unit>
       <trans-unit id="OutputOption">

--- a/src/Cli/dotnet/commands/dotnet-store/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/commands/dotnet-store/xlf/LocalizableStrings.zh-Hans.xlf
@@ -7,6 +7,11 @@
         <target state="translated">存储为 .NET 平台指定的程序集。默认情况下，这些程序集将针对目标运行时和框架进行优化。</target>
         <note />
       </trans-unit>
+      <trans-unit id="CurrentRuntimeOptionDescription">
+        <source>Use host runtime to build the target.</source>
+        <target state="new">Use host runtime to build the target.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OutputOption">
         <source>OUTPUT_DIR</source>
         <target state="translated">OUTPUT_DIR</target>

--- a/src/Cli/dotnet/commands/dotnet-store/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/commands/dotnet-store/xlf/LocalizableStrings.zh-Hans.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CurrentRuntimeOptionDescription">
-        <source>Use host runtime to build the target.</source>
-        <target state="new">Use host runtime to build the target.</target>
+        <source>Use current runtime as the target runtime.</source>
+        <target state="new">Use current runtime as the target runtime.</target>
         <note />
       </trans-unit>
       <trans-unit id="OutputOption">

--- a/src/Cli/dotnet/commands/dotnet-store/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/commands/dotnet-store/xlf/LocalizableStrings.zh-Hant.xlf
@@ -7,6 +7,11 @@
         <target state="translated">儲存為 .NET 平台所指定的組件。根據預設，會為目標執行階段與架構，最佳化這些組件。</target>
         <note />
       </trans-unit>
+      <trans-unit id="CurrentRuntimeOptionDescription">
+        <source>Use host runtime to build the target.</source>
+        <target state="new">Use host runtime to build the target.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OutputOption">
         <source>OUTPUT_DIR</source>
         <target state="translated">OUTPUT_DIR</target>

--- a/src/Cli/dotnet/commands/dotnet-store/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/commands/dotnet-store/xlf/LocalizableStrings.zh-Hant.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CurrentRuntimeOptionDescription">
-        <source>Use host runtime to build the target.</source>
-        <target state="new">Use host runtime to build the target.</target>
+        <source>Use current runtime as the target runtime.</source>
+        <target state="new">Use current runtime as the target runtime.</target>
         <note />
       </trans-unit>
       <trans-unit id="OutputOption">

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets
@@ -6,7 +6,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
           created a backup copy.  Incorrect changes to this file will make it
           impossible to load or build your projects from the command-line or the IDE.
 
-Copyright (c) .NET Foundation. All rights reserved. 
+Copyright (c) .NET Foundation. All rights reserved.
 ***********************************************************************************************
 -->
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
@@ -52,13 +52,17 @@ Copyright (c) .NET Foundation. All rights reserved.
           work without user intervention. The current static evaluation
           requirement limits us.
    -->
-  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework' and 
-                            '$(HasRuntimeOutput)' == 'true' and 
+  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework' and
+                            '$(HasRuntimeOutput)' == 'true' and
                             '$(OS)' == 'Windows_NT' and
                             '$(RuntimeIdentifier)' == ''">
     <_UsingDefaultRuntimeIdentifier>true</_UsingDefaultRuntimeIdentifier>
     <RuntimeIdentifier Condition="'$(PlatformTarget)' == 'x64'">win7-x64</RuntimeIdentifier>
     <RuntimeIdentifier Condition="'$(PlatformTarget)' == 'x86' or '$(PlatformTarget)' == ''">win7-x86</RuntimeIdentifier>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(UseCurrentRuntimeIdentifier)' == 'true'">
+    <RuntimeIdentifier>$(NETCoreSdkRuntimeIdentifier)</RuntimeIdentifier>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(PlatformTarget)' == ''">
@@ -96,7 +100,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   </Choose>
 
   <!--
-    SelfContained was not an option in .NET Core SDK 1.0. 
+    SelfContained was not an option in .NET Core SDK 1.0.
     Default SelfContained based on the RuntimeIdentifier, so projects don't have to explicitly set SelfContained.
     This avoids a breaking change from 1.0 behavior.
 
@@ -210,9 +214,9 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <!--
     Append $(RuntimeIdentifier) directory to output and intermediate paths to prevent bin clashes between
-    targets. 
+    targets.
 
-    But do not append the implicit default runtime identifier for .NET Framework apps as that would 
+    But do not append the implicit default runtime identifier for .NET Framework apps as that would
     append a RID the user never mentioned in the path and do so even in the AnyCPU case.
    -->
   <PropertyGroup Condition="'$(AppendRuntimeIdentifierToOutputPath)' == 'true' and '$(RuntimeIdentifier)' != '' and '$(_UsingDefaultRuntimeIdentifier)' != 'true'">
@@ -224,9 +228,9 @@ Copyright (c) .NET Foundation. All rights reserved.
            AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
 
 
-  <!-- 
-    Switch our default .NETFramework CPU architecture choice back to AnyCPU before 
-    compiling the exe if no copy-local native dependencies were resolved from NuGet 
+  <!--
+    Switch our default .NETFramework CPU architecture choice back to AnyCPU before
+    compiling the exe if no copy-local native dependencies were resolved from NuGet
   -->
   <Target Name="AdjustDefaultPlatformTargetForNetFrameworkExeWithNoNativeCopyLocalItems"
           AfterTargets="ResolvePackageAssets"
@@ -238,7 +242,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                                              NativeCopyLocalItems="@(NativeCopyLocalItems)">
 
       <Output TaskParameter="DefaultPlatformTarget" PropertyName="PlatformTarget" />
-      
+
     </GetDefaultPlatformTargetForNetFramework>
   </Target>
 

--- a/src/Tests/Microsoft.NET.Publish.Tests/RuntimeIdentifiersTests.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/RuntimeIdentifiersTests.cs
@@ -1,6 +1,10 @@
-﻿using System;
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text;
 using FluentAssertions;
 using Microsoft.DotNet.Cli.Utils;
@@ -77,6 +81,55 @@ namespace Microsoft.NET.Publish.Tests
                         .HaveStdOutContaining("Hello World!");
                 }
             }
+        }
+
+        //  Run on core MSBuild only as using a local packages folder hits long path issues on full MSBuild
+        [CoreMSBuildOnlyFact]
+        public void BuildWithUseCurrentRuntimeIdentifier()
+        {
+            var testProject = new TestProject()
+            {
+                Name = "BuildWithUseCurrentRuntimeIdentifier",
+                TargetFrameworks = "netcoreapp3.0",
+                IsSdkProject = true,
+                IsExe = true
+            };
+
+            var compatibleRid = EnvironmentInfo.GetCompatibleRid(testProject.TargetFrameworks);
+
+            testProject.AdditionalProperties["UseCurrentRuntimeIdentifier"] = "True";
+
+            //  Use a test-specific packages folder
+            testProject.AdditionalProperties["RestorePackagesPath"] = @"$(MSBuildProjectDirectory)\..\pkg";
+
+            var testAsset = _testAssetsManager.CreateTestProject(testProject);
+            var restoreCommand = new RestoreCommand(testAsset);
+
+            restoreCommand
+                .Execute()
+                .Should()
+                .Pass();
+
+            var buildCommand = new BuildCommand(testAsset);
+
+            buildCommand
+                .ExecuteWithoutRestore()
+                .Should()
+                .Pass();
+
+            string sdkDirectory = Path.Combine(buildCommand.GetNonSDKOutputDirectory().FullName, testProject.TargetFrameworks);
+            string outputDirectoryFullName = Directory.EnumerateDirectories(sdkDirectory, "*", SearchOption.AllDirectories).FirstOrDefault();
+            outputDirectoryFullName.Should().NotBeNullOrWhiteSpace();
+
+            var selfContainedExecutable = $"{testProject.Name}{Constants.ExeSuffix}";
+            string selfContainedExecutableFullPath = Path.Combine(outputDirectoryFullName, selfContainedExecutable);
+
+            new RunExeCommand(Log, selfContainedExecutableFullPath)
+                .Execute()
+                .Should()
+                .Pass()
+                .And
+                .HaveStdOutContaining("Hello World!");
         }
 
         //  Run on core MSBuild only as using a local packages folder hits long path issues on full MSBuild

--- a/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetBuildInvocation.cs
+++ b/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetBuildInvocation.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.IO;
@@ -13,7 +13,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
     {
         const string ExpectedPrefix = "exec <msbuildpath> -maxcpucount -verbosity:m";
 
-        private static readonly string WorkingDirectory = 
+        private static readonly string WorkingDirectory =
             TestPathUtilities.FormatAbsolutePath(nameof(GivenDotnetBuildInvocation));
 
         [Theory]
@@ -25,6 +25,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
         [InlineData(new string[] { "--no-incremental" }, "-target:Rebuild")]
         [InlineData(new string[] { "-r", "rid" }, "-property:RuntimeIdentifier=rid")]
         [InlineData(new string[] { "--runtime", "rid" }, "-property:RuntimeIdentifier=rid")]
+        [InlineData(new string[] { "--use-current-runtime" }, "-property:UseCurrentRuntimeIdentifier=True")]
         [InlineData(new string[] { "-c", "config" }, "-property:Configuration=config")]
         [InlineData(new string[] { "--configuration", "config" }, "-property:Configuration=config")]
         [InlineData(new string[] { "--version-suffix", "mysuffix" }, "-property:VersionSuffix=mysuffix")]
@@ -59,8 +60,8 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
                                   "-target:Restore -property:OutputPath=<cwd>myoutput -verbosity:diag /ArbitrarySwitchForMSBuild",
                                   "-property:OutputPath=<cwd>myoutput -property:TargetFramework=tfm -verbosity:diag /ArbitrarySwitchForMSBuild")]
         public void MsbuildInvocationIsCorrectForSeparateRestore(
-            string[] args, 
-            string expectedAdditionalArgsForRestore, 
+            string[] args,
+            string expectedAdditionalArgsForRestore,
             string expectedAdditionalArgs)
         {
             CommandDirectoryContext.PerformActionWithBasePath(WorkingDirectory, () =>

--- a/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetPublishInvocation.cs
+++ b/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetPublishInvocation.cs
@@ -1,10 +1,11 @@
-﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.IO;
-using FluentAssertions;
 using System.Linq;
+using System.Runtime.InteropServices;
+using FluentAssertions;
 using Microsoft.DotNet.Cli.CommandLine;
 using Microsoft.DotNet.Tools.Publish;
 using Xunit;
@@ -14,7 +15,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
 {
     public class GivenDotnetPublishInvocation : IClassFixture<NullCurrentSessionIdFixture>
     {
-        private static readonly string WorkingDirectory = 
+        private static readonly string WorkingDirectory =
             TestPathUtilities.FormatAbsolutePath(nameof(GivenDotnetPublishInvocation));
         private readonly ITestOutputHelper output;
 
@@ -29,6 +30,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
         [InlineData(new string[] { }, "")]
         [InlineData(new string[] { "-r", "<rid>" }, "-property:RuntimeIdentifier=<rid>")]
         [InlineData(new string[] { "--runtime", "<rid>" }, "-property:RuntimeIdentifier=<rid>")]
+        [InlineData(new string[] { "--use-current-runtime" }, "-property:UseCurrentRuntimeIdentifier=True")]
         [InlineData(new string[] { "-o", "<publishdir>" }, "-property:PublishDir=<cwd><publishdir>")]
         [InlineData(new string[] { "--output", "<publishdir>" }, "-property:PublishDir=<cwd><publishdir>")]
         [InlineData(new string[] { "-c", "<config>" }, "-property:Configuration=<config>")]
@@ -103,6 +105,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
         [InlineData(new string[] { "--framework", "<tfm>" }, "-property:TargetFramework=<tfm>")]
         [InlineData(new string[] { "-r", "<rid>" }, "-property:RuntimeIdentifier=<rid>")]
         [InlineData(new string[] { "--runtime", "<rid>" }, "-property:RuntimeIdentifier=<rid>")]
+        [InlineData(new string[] { "--use-current-runtime" }, "-property:UseCurrentRuntimeIdentifier=True")]
         [InlineData(new string[] { "-o", "<publishdir>" }, "-property:PublishDir=<cwd><publishdir>")]
         [InlineData(new string[] { "--output", "<publishdir>" }, "-property:PublishDir=<cwd><publishdir>")]
         [InlineData(new string[] { "-c", "<config>" }, "-property:Configuration=<config>")]

--- a/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetPublishInvocation.cs
+++ b/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetPublishInvocation.cs
@@ -4,7 +4,6 @@
 using System;
 using System.IO;
 using System.Linq;
-using System.Runtime.InteropServices;
 using FluentAssertions;
 using Microsoft.DotNet.Cli.CommandLine;
 using Microsoft.DotNet.Tools.Publish;

--- a/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetStoreInvocation.cs
+++ b/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetStoreInvocation.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using FluentAssertions;
@@ -14,7 +14,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
     {
         const string ExpectedPrefix = "exec <msbuildpath> -maxcpucount -verbosity:m -target:ComposeStore <project>";
         static readonly string[] ArgsPrefix = { "--manifest", "<project>" };
-        private static readonly string WorkingDirectory = 
+        private static readonly string WorkingDirectory =
             TestPathUtilities.FormatAbsolutePath(nameof(GivenDotnetStoreInvocation));
 
         [Theory]
@@ -33,6 +33,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
         [InlineData(new string[] { "--framework", "<tfm>" }, @"-property:TargetFramework=<tfm>")]
         [InlineData(new string[] { "-r", "<rid>" }, @"-property:RuntimeIdentifier=<rid>")]
         [InlineData(new string[] { "--runtime", "<rid>" }, @"-property:RuntimeIdentifier=<rid>")]
+        [InlineData(new string[] { "--use-current-runtime" }, "-property:UseCurrentRuntimeIdentifier=True")]
         [InlineData(new string[] { "--manifest", "one.xml", "--manifest", "two.xml", "--manifest", "three.xml" }, @"-property:AdditionalProjects=<cwd>one.xml%3B<cwd>two.xml%3B<cwd>three.xml")]
         public void MsbuildInvocationIsCorrect(string[] args, string expectedAdditionalArgs)
         {


### PR DESCRIPTION
It is a common use-case to use the same runtime during the build and publish. During the development of .NET apps, it is painful to remember the entire - ever growing - `--runtime <baseos>-<arch>` matrix.

`--use-current-runtime`, backed by MSBuild property `UseCurrentRuntimeIdentifier=True/False`, will allow users to keep things neutral in their documentation and deployment scripts.

Fixes #10449
cc @eerhardt @tmds, @dagood