### PR TITLE
Skip installing SDK 1.0.5 and 1.1.2 on Ubuntu 18+

### DIFF
--- a/eng/restore-toolset.sh
+++ b/eng/restore-toolset.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 function InitializeCustomSDKToolset {
   if [[ "$restore" != true ]]; then
     return
@@ -9,9 +11,19 @@ function InitializeCustomSDKToolset {
     return
   fi
 
+  DISTRO=
+  MAJOR_VERSION=
+  if [ -e /etc/os-release ]; then
+      . /etc/os-release
+      DISTRO="$ID"
+      MAJOR_VERSION="${VERSION_ID:+${VERSION_ID%%.*}}"
+  fi
+
   InitializeDotNetCli true
-  InstallDotNetSharedFramework "1.0.5"
-  InstallDotNetSharedFramework "1.1.2"
+  if [[ "$DISTRO" != "ubuntu" || "$MAJOR_VERSION" -le 16 ]]; then
+    InstallDotNetSharedFramework "1.0.5"
+    InstallDotNetSharedFramework "1.1.2"
+  fi
   InstallDotNetSharedFramework "2.1.0"
   InstallDotNetSharedFramework "2.2.8"
   InstallDotNetSharedFramework "3.1.0"

--- a/src/Tests/Microsoft.NET.TestFramework/EnvironmentInfo.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/EnvironmentInfo.cs
@@ -121,6 +121,25 @@ namespace Microsoft.NET.TestFramework
                     }
                 }
             }
+            else if (ridOS.Equals("ubuntu", StringComparison.OrdinalIgnoreCase))
+            {
+                string restOfRid = currentRid.Substring(ridOS.Length + 1);
+                string ubuntuVersionString = restOfRid.Split('-')[0];
+                if (float.TryParse(ubuntuVersionString, out float ubuntuVersion))
+                {
+                    if (ubuntuVersion > 16)
+                    {
+                        if (nugetFramework.Version < new Version(2, 0, 0, 0))
+                        {
+                            return false;
+                        }
+                    }
+                }
+                else
+                {
+                    return true;
+                }
+            }
             else if (ridOS.Equals("osx", StringComparison.OrdinalIgnoreCase))
             {
                 string restOfRid = currentRid.Substring(ridOS.Length + 1);

--- a/src/Tests/Microsoft.NET.TestFramework/EnvironmentInfo.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/EnvironmentInfo.cs
@@ -127,7 +127,7 @@ namespace Microsoft.NET.TestFramework
                 string ubuntuVersionString = restOfRid.Split('-')[0];
                 if (float.TryParse(ubuntuVersionString, out float ubuntuVersion))
                 {
-                    if (ubuntuVersion > 16)
+                    if (ubuntuVersion > 16.04)
                     {
                         if (nugetFramework.Version < new Version(2, 0, 0, 0))
                         {


### PR DESCRIPTION
SDK v1.x Ubuntu package has 16.04 hardcoded as version, which breaks build on higher LTS versions (18.04, 20.04)

This patch fixes the issue by skipping SDK v1.x installation on unsupported LTS versions, and has no effect on non-Ubuntu Linux distros or other operating systems.

Tested with v16.04 and v20.04.

Fixes #3768

cc @wli3, @wfurt