### PR TITLE
Fix package downgrade errors

### DIFF
--- a/src/Resolvers/Microsoft.DotNet.MSBuildSdkResolver/Microsoft.DotNet.MSBuildSdkResolver.csproj
+++ b/src/Resolvers/Microsoft.DotNet.MSBuildSdkResolver/Microsoft.DotNet.MSBuildSdkResolver.csproj
@@ -76,6 +76,9 @@
   <ItemGroup>
     <PackageReference Include="System.Text.Json" Version="4.7.2" Condition="'$(UseSystemTextJson)'=='True'"/>
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" Condition="'$(UseSystemTextJson)'!='True'"/>
+    
+    <!-- Reference this package to avoid package downgrade errors.  See https://github.com/dotnet/sdk/issues/3044 for details -->
+    <PackageReference Include="Microsoft.NETCore.Targets" Version="2.1.0" ExcludeAssets="all" PrivateAssets="all" />
   </ItemGroup>
 
   <Target Name="ResolveHostfxrCopyLocalContent" Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'" DependsOnTargets="RunResolvePackageDependencies" BeforeTargets="AssignTargetPaths">


### PR DESCRIPTION
Fix errors such as the following:

> C:\git\dotnet-sdk\src\Resolvers\Microsoft.DotNet.MSBuildSdkResolver\Microsoft.DotNet.MSBuildSdkResolver.csproj error NU1605: Detected package downgrade: System.Diagnostics.Debug from 4.3.0 to 4.0.11. Reference the package directly from the project to select a different version. 
 Microsoft.DotNet.MSBuildSdkResolver -> Microsoft.DotNet.Cli.Utils -> NuGet.Packaging 5.8.0-rc.6860 -> Newtonsoft.Json 9.0.1 -> System.Xml.ReaderWriter 4.0.11 -> System.IO.FileSystem 4.0.1 -> runtime.win.System.IO.FileSystem 4.3.0 -> System.Diagnostics.Debug (>= 4.3.0) 
 Microsoft.DotNet.MSBuildSdkResolver -> Microsoft.DotNet.Cli.Utils -> NuGet.Packaging 5.8.0-rc.6860 -> Newtonsoft.Json 9.0.1 -> System.Diagnostics.Debug (>= 4.0.11) [C:\git\dotnet-sdk\sdk.sln]

This is caused by this issue: https://github.com/dotnet/sdk/issues/3044

@sfoslund thinks this may have been introduced with #14133.  I'm not sure exactly how that would trigger this issue, or why it wouldn't have been caught in CI.