### PR TITLE
Re-enable Crossgen2 tests

### DIFF
--- a/src/Layout/toolset-tasks/OverrideAndCreateBundledNETCoreAppPackageVersion.cs
+++ b/src/Layout/toolset-tasks/OverrideAndCreateBundledNETCoreAppPackageVersion.cs
@@ -95,6 +95,8 @@ namespace Microsoft.DotNet.Build.Tasks
                 .Elements(ns + "KnownFrameworkReference").First().Attribute("TargetingPackVersion"));
             CheckAndReplaceAttribute(itemGroup
                 .Elements(ns + "KnownAppHostPack").First().Attribute("AppHostPackVersion"));
+            CheckAndReplaceAttribute(itemGroup
+                .Elements(ns + "KnownCrossgen2Pack").First().Attribute("Crossgen2PackVersion"));
 
             return projectXml.ToString();
         }

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishANetCoreAppForTelemetry.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishANetCoreAppForTelemetry.cs
@@ -60,7 +60,7 @@ namespace Microsoft.NET.Publish.Tests
                 "\"CompileListCount\":\"[1-9]\\d?\"");  // Do not hardcode number of assemblies being compiled here, due to ILTrimmer
         }
 
-        [CoreMSBuildOnlyTheory(Skip = "https://github.com/dotnet/sdk/issues/13279")]
+        [CoreMSBuildOnlyTheory]
         [InlineData("net5.0")] 
         void It_collects_crossgen2_publishing_properties(string targetFramework)
         {
@@ -85,7 +85,7 @@ namespace Microsoft.NET.Publish.Tests
                 .And.Contain(
                     "{\"EventName\":\"ReadyToRun\",\"Properties\":{\"PublishReadyToRunUseCrossgen2\":\"True\",")
                 .And.MatchRegex(
-                    "\"Crossgen2PackVersion\":\"5.+\"")
+                    "\"Crossgen2PackVersion\":\"[5-9]\\..+\"")
                 .And.Contain(
                     "\"CompileListCount\":\"1\",\"FailedCount\":\"0\"");
         }

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishReadyToRun.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishReadyToRun.cs
@@ -194,7 +194,7 @@ namespace Microsoft.NET.Publish.Tests
             TestProjectPublishing_Internal("LibraryProject2", targetFramework, isSelfContained:true, makeExeProject: false);
         }
 
-        [RequiresMSBuildVersionTheory("16.8.0", Skip = "https://github.com/dotnet/sdk/issues/13279")]
+        [RequiresMSBuildVersionTheory("16.8.0")]
         [InlineData("net5.0")]
         void It_can_publish_readytorun_using_crossgen2(string targetFramework)
         {
@@ -205,7 +205,7 @@ namespace Microsoft.NET.Publish.Tests
             TestProjectPublishing_Internal("Crossgen2TestApp", targetFramework, isSelfContained: true, emitNativeSymbols: true, useCrossgen2: true, composite: false);
         }
 
-        [RequiresMSBuildVersionTheory("16.8.0", Skip = "https://github.com/dotnet/sdk/issues/13279")]
+        [RequiresMSBuildVersionTheory("16.8.0")]
         [InlineData("net5.0")]
         void It_can_publish_readytorun_using_crossgen2_composite_mode(string targetFramework)
         {


### PR DESCRIPTION
Use the proper version of the Crossgen2 package instead of stage 0's one (fixes #12994).  Re-enable Crossgen2 tests (fixes #13279).  Reflect the recent JIT library naming change for .NET 6.  I will make that code more resilient in a separate change.