### PR TITLE
Add zsh compdef completion script.

### DIFF
--- a/scripts/_dotnet
+++ b/scripts/_dotnet
@@ -1,0 +1,3 @@
+#compdef dotnet
+local completions=("$(dotnet complete "$words")")
+[[ -n "$completions" ]] && compadd -- "${(ps:\n:)completions}"

--- a/scripts/_dotnet
+++ b/scripts/_dotnet
@@ -1,3 +1,0 @@
-#compdef dotnet
-local completions=("$(dotnet complete "$words")")
-[[ -n "$completions" ]] && compadd -- "${(ps:\n:)completions}"

--- a/scripts/register-completions.zsh
+++ b/scripts/register-completions.zsh
@@ -1,10 +1,9 @@
-# zsh parameter completion for the dotnet CLI
+#compdef dotnet
 
-_dotnet_zsh_complete() 
-{
-  local completions=("$(dotnet complete "$words")")
-
-  reply=( "${(ps:\n:)completions}" )
+_dotnet_completion() {
+  local -a completions=("${(@f)$(dotnet complete "${words}")}")
+  compadd -a completions
+  _files
 }
 
-compctl -K _dotnet_zsh_complete dotnet
+compdef _dotnet_completion dotnet


### PR DESCRIPTION
Taking another look at stuff mentioned in https://github.com/dotnet/cli/pull/13384/ 
I have no knowledge of zsh and completion scripts, just followed the suggestions from aforementioned PR.
Because of that there's few things left to do that come to mind:
- integrate this script with others so that it conforms to both [zsh sourcing/autoloading of completion files](zsh.sourceforge.net/Doc/Release/Completion-System.html#Autoloaded-files) (gets included into `fpath` somehow) and what is expected of script files here, in `scripts` folder
- add descriptions (when applicable) to `dotnet complete` output using zsh completion system's mechanisms of which I know exactly nothing.
