### PR TITLE
Enable content copying transitive in VS.

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -701,6 +701,15 @@ Copyright (c) .NET Foundation. All rights reserved.
     See comment on GetCopyToOutputDirectoryItems, from which this logic was taken.
     ============================================================
     -->
+
+  <!--
+    Workaround for https://github.com/microsoft/msbuild/issues/4923
+    and https://github.com/dotnet/project-system/issues/4665
+  -->
+  <PropertyGroup>
+    <MSBuildCopyContentTransitively>true</MSBuildCopyContentTransitively>
+  </PropertyGroup>
+
   <Target Name="GetCopyToPublishDirectoryItems"
           Returns="@(AllPublishItemsFullPathWithTargetPath)"
           KeepDuplicateOutputs=" '$(MSBuildDisableGetCopyToPublishDirectoryItemsOptimization)' == '' "


### PR DESCRIPTION
**The problem:**
Currently Fast-up-date (FUTD) cannot resolve `CopyToOutputDirectory `transitively. 

Lets assume there is project  A and has a reference to B and B has a reference to C.
If C contains items with `CopyToOutputDirectory`, and if those items are modified, then project A will not detect those changes.
Bug https://github.com/dotnet/project-system/issues/4665

The fix for the issue 4665 is in the [pr 6046](https://github.com/dotnet/project-system/pull/6046) in dotnet ProjectSystem, but this changes will cause conflicts with dependencies of `_SplitProjectReferencesByFileExistence `. This pr 6046 in dotnet ProjectSystem executes targets that has dependencies with `AssignProjectConfiguration`. The problem is that dotnet will consume the output generated by those dependencies before `AssignProjectConfiguration `is executed. This causes `AssignProjectConfiguration` to consume no data. More details in [here](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1073852).

**What this change does:**
Set [MSBuildCopyContentTransitively ](https://github.com/microsoft/msbuild/pull/4865)to true which means transitive copying content.

**How this change help to solve the dependencies:**
`MSBuildCopyContentTransitively  `= true means transitive copying content. ProjectSystem and `AssignProjectConfiguration `will have their own copy of the content.

This change is not high priority.