### PR TITLE
Support cross-platform and cross-architecture compilation for Crossgen2

### DIFF
--- a/src/Tasks/Common/MetadataKeys.cs
+++ b/src/Tasks/Common/MetadataKeys.cs
@@ -80,11 +80,11 @@ namespace Microsoft.NET.Build.Tasks
         public const string TargetPath = "TargetPath";
         public const string CopyLocal = "CopyLocal";
 
-        //  Targeting packs
+        // Targeting packs
         public const string PackageConflictPreferredPackages = "PackageConflictPreferredPackages";
 
-        //  Runtime packs
-		public const string DropFromSingleFile = "DropFromSingleFile";
+        // Runtime packs
+        public const string DropFromSingleFile = "DropFromSingleFile";
         public const string RuntimePackLabels = "RuntimePackLabels";
         public const string AdditionalFrameworkReferences = "AdditionalFrameworkReferences";
 
@@ -110,5 +110,14 @@ namespace Microsoft.NET.Build.Tasks
         public const string ReferenceOnly = "ReferenceOnly";
 
         public const string Aliases = "Aliases";
+
+        // ReadyToRun
+        public const string JitPath = "JitPath";
+        public const string TargetOS = "TargetOS";
+        public const string TargetArch = "TargetArch";
+        public const string DiaSymReader = "DiaSymReader";
+        public const string CreatePDBCommand = "CreatePDBCommand";
+        public const string OutputR2RImage = "OutputR2RImage";
+        public const string OutputPDBImage = "OutputPDBImage";
     }
 }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/PrepareForReadyToRunCompilation.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/PrepareForReadyToRunCompilation.cs
@@ -56,7 +56,7 @@ namespace Microsoft.NET.Build.Tasks
         protected override void ExecuteCore()
         {
             // Future: when crossgen2 supports generating PDBs, update this to check crossgen2 when we are using crossgen2.
-            string diaSymReaderPath = CrossgenTool?.GetMetadata("DiaSymReader");
+            string diaSymReaderPath = CrossgenTool?.GetMetadata(MetadataKeys.DiaSymReader);
             bool hasValidDiaSymReaderLib = !string.IsNullOrEmpty(diaSymReaderPath) && File.Exists(diaSymReaderPath);
 
             // Process input lists of files
@@ -103,7 +103,7 @@ namespace Microsoft.NET.Build.Tasks
                     // This TaskItem is the IL->R2R entry, for an input assembly that needs to be compiled into a R2R image. This will be used as
                     // an input to the ReadyToRunCompiler task
                     TaskItem r2rCompilationEntry = new TaskItem(file);
-                    r2rCompilationEntry.SetMetadata("OutputR2RImage", outputR2RImage);
+                    r2rCompilationEntry.SetMetadata(MetadataKeys.OutputR2RImage, outputR2RImage);
                     r2rCompilationEntry.RemoveMetadata(MetadataKeys.OriginalItemSpec);
                     imageCompilationList.Add(r2rCompilationEntry);
                 }
@@ -115,7 +115,7 @@ namespace Microsoft.NET.Build.Tasks
                     var compositeR2RImage = Path.Combine(OutputPath, compositeR2RImageRelativePath);
 
                     TaskItem r2rCompilationEntry = new TaskItem(file);
-                    r2rCompilationEntry.SetMetadata("OutputR2RImage", compositeR2RImage);
+                    r2rCompilationEntry.SetMetadata(MetadataKeys.OutputR2RImage, compositeR2RImage);
                     r2rCompilationEntry.RemoveMetadata(MetadataKeys.OriginalItemSpec);
                     imageCompilationList.Add(r2rCompilationEntry);
 
@@ -168,8 +168,8 @@ namespace Microsoft.NET.Build.Tasks
                         // an input to the ReadyToRunCompiler task
                         TaskItem pdbCompilationEntry = new TaskItem(file);
                         pdbCompilationEntry.ItemSpec = outputR2RImage;
-                        pdbCompilationEntry.SetMetadata("OutputPDBImage", outputPDBImage);
-                        pdbCompilationEntry.SetMetadata("CreatePDBCommand", createPDBCommand);
+                        pdbCompilationEntry.SetMetadata(MetadataKeys.OutputPDBImage, outputPDBImage);
+                        pdbCompilationEntry.SetMetadata(MetadataKeys.CreatePDBCommand, createPDBCommand);
                         symbolsCompilationList.Add(pdbCompilationEntry);
 
                         // This TaskItem corresponds to the output PDB image. It is equivalent to the input TaskItem, only the ItemSpec for it points to the new path

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolveReadyToRunCompilers.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveReadyToRunCompilers.cs
@@ -2,16 +2,14 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
+using System.ComponentModel;
 using System.IO;
+using System.Linq;
 using System.Runtime.InteropServices;
-using System.Reflection.PortableExecutable;
+
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
-using System.Reflection.Metadata;
-using System.Reflection;
+using NuGet.Versioning;
 
 namespace Microsoft.NET.Build.Tasks
 {
@@ -123,10 +121,10 @@ namespace Microsoft.NET.Build.Tasks
 
             // Create tool task item
             CrossgenTool = new TaskItem(_crossgenTool.ToolPath);
-            CrossgenTool.SetMetadata("JitPath", _crossgenTool.ClrJitPath);
+            CrossgenTool.SetMetadata(MetadataKeys.JitPath, _crossgenTool.ClrJitPath);
             if (!String.IsNullOrEmpty(_crossgenTool.DiaSymReaderPath))
             {
-                CrossgenTool.SetMetadata("DiaSymReader", _crossgenTool.DiaSymReaderPath);
+                CrossgenTool.SetMetadata(MetadataKeys.DiaSymReader, _crossgenTool.DiaSymReaderPath);
             }
 
             return true;
@@ -135,21 +133,34 @@ namespace Microsoft.NET.Build.Tasks
         private bool ValidateCrossgen2Support()
         {
             _crossgen2Tool.PackagePath = _crossgen2Pack?.GetMetadata(MetadataKeys.PackageDirectory);
-            if (_crossgen2Tool.PackagePath == null)
+            if (_crossgen2Tool.PackagePath == null ||
+                !NuGetVersion.TryParse(_crossgen2Pack.GetMetadata(MetadataKeys.NuGetPackageVersion), out NuGetVersion crossgen2PackVersion))
             {
                 Log.LogError(Strings.ReadyToRunNoValidRuntimePackageError);
                 return false;
             }
 
-            // Crossgen2 only supports the following host->target compilation scenarios in net5.0:
+            bool version5 = crossgen2PackVersion.Major < 6;
+            bool isSupportedTarget = ExtractTargetPlatformAndArchitecture(_targetRuntimeIdentifier, out _targetPlatform, out _targetArchitecture);
+            string targetOS = _targetPlatform switch
+            {
+                "linux" => "linux",
+                "linux-musl" => "linux",
+                "osx" => "osx",
+                "win" => "windows",
+                _ => null
+            };
+
+            // In .NET 5 Crossgen2 supported only the following host->target compilation scenarios:
             //      win-x64 -> win-x64
             //      linux-x64 -> linux-x64
             //      linux-musl-x64 -> linux-musl-x64
-            if (!ExtractTargetPlatformAndArchitecture(_targetRuntimeIdentifier, out _targetPlatform, out _targetArchitecture) ||
-                !ExtractTargetPlatformAndArchitecture(_hostRuntimeIdentifier, out string hostPlatform, out Architecture hostArchitecture) ||
-                !GetTargetSpec(hostArchitecture, out string targetSpec) ||
-                _targetRuntimeIdentifier != _hostRuntimeIdentifier ||
-                !GetCrossgen2ComponentsPaths(targetSpec))
+            isSupportedTarget = isSupportedTarget &&
+                targetOS != null &&
+                (!version5 || _targetRuntimeIdentifier == _hostRuntimeIdentifier) &&
+                GetCrossgen2ComponentsPaths(version5);
+
+            if (!isSupportedTarget)
             {
                 Log.LogError(Strings.ReadyToRunTargetNotSupportedError);
                 return false;
@@ -157,10 +168,18 @@ namespace Microsoft.NET.Build.Tasks
 
             // Create tool task item
             Crossgen2Tool = new TaskItem(_crossgen2Tool.ToolPath);
-            Crossgen2Tool.SetMetadata("JitPath", _crossgen2Tool.ClrJitPath);
+            if (version5)
+            {
+                Crossgen2Tool.SetMetadata(MetadataKeys.JitPath, _crossgen2Tool.ClrJitPath);
+            }
+            else
+            {
+                Crossgen2Tool.SetMetadata(MetadataKeys.TargetOS, targetOS);
+                Crossgen2Tool.SetMetadata(MetadataKeys.TargetArch, ArchitectureToString(_targetArchitecture));
+            }
             if (!String.IsNullOrEmpty(_crossgen2Tool.DiaSymReaderPath))
             {
-                Crossgen2Tool.SetMetadata("DiaSymReader", _crossgen2Tool.DiaSymReaderPath);
+                Crossgen2Tool.SetMetadata(MetadataKeys.DiaSymReader, _crossgen2Tool.DiaSymReaderPath);
             }
 
             return true;
@@ -188,13 +207,13 @@ namespace Microsoft.NET.Build.Tasks
             platform = null;
             architecture = default;
 
+            // This will split RID like "linux-musl-arm64" into "linux-musl" and "arm64" components
             int separator = runtimeIdentifier.LastIndexOf('-');
             if (separator < 0)
             {
                 return false;
             }
 
-            platform = runtimeIdentifier.Substring(0, separator).ToLowerInvariant();
             string architectureStr = runtimeIdentifier.Substring(separator + 1).ToLowerInvariant();
 
             switch (architectureStr)
@@ -215,6 +234,7 @@ namespace Microsoft.NET.Build.Tasks
                     return false;
             }
 
+            platform = runtimeIdentifier.Substring(0, separator).ToLowerInvariant();
             return true;
         }
 
@@ -320,22 +340,24 @@ namespace Microsoft.NET.Build.Tasks
             return File.Exists(_crossgenTool.ToolPath) && File.Exists(_crossgenTool.ClrJitPath);
         }
 
-        private bool GetCrossgen2ComponentsPaths(string targetSpec)
+        private bool GetCrossgen2ComponentsPaths(bool version5)
         {
+            string toolFileName, v5_clrJitFileNamePattern;
+
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                _crossgen2Tool.ToolPath = Path.Combine(_crossgen2Tool.PackagePath, "tools", "crossgen2.exe");
-                _crossgen2Tool.ClrJitPath = Path.Combine(_crossgen2Tool.PackagePath, "tools", $"clrjit_{targetSpec}.dll");
+                toolFileName = "crossgen2.exe";
+                v5_clrJitFileNamePattern = "clrjit-{0}.dll";
             }
             else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
-                _crossgen2Tool.ToolPath = Path.Combine(_crossgen2Tool.PackagePath, "tools", "crossgen2");
-                _crossgen2Tool.ClrJitPath = Path.Combine(_crossgen2Tool.PackagePath, "tools", $"libclrjit_{targetSpec}.so");
+                toolFileName = "crossgen2";
+                v5_clrJitFileNamePattern = "libclrjit-{0}.so";
             }
             else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
-                _crossgen2Tool.ToolPath = Path.Combine(_crossgen2Tool.PackagePath, "tools", "crossgen2");
-                _crossgen2Tool.ClrJitPath = Path.Combine(_crossgen2Tool.PackagePath, "tools", $"libclrjit_{targetSpec}.dylib");
+                toolFileName = "crossgen2";
+                v5_clrJitFileNamePattern = "libclrjit-{0}.dylib";
             }
             else
             {
@@ -343,7 +365,26 @@ namespace Microsoft.NET.Build.Tasks
                 return false;
             }
 
-            return File.Exists(_crossgen2Tool.ToolPath) && File.Exists(_crossgen2Tool.ClrJitPath);
+            if (version5)
+            {
+                string clrJitFileName = string.Format(v5_clrJitFileNamePattern, GetTargetSpecForVersion5());
+                _crossgen2Tool.ClrJitPath = Path.Combine(_crossgen2Tool.PackagePath, "tools", clrJitFileName);
+                if (!File.Exists(_crossgen2Tool.ClrJitPath))
+                {
+                    return false;
+                }
+            }
+
+            _crossgen2Tool.ToolPath = Path.Combine(_crossgen2Tool.PackagePath, "tools", toolFileName);
+            return File.Exists(_crossgen2Tool.ToolPath);
+        }
+
+        // Keep in sync with JitConfigProvider.GetTargetSpec in .NET 5
+        private string GetTargetSpecForVersion5()
+        {
+            string targetOSComponent = (_targetPlatform == "win" ? "win" : "unix");
+            string targetArchComponent = ArchitectureToString(_targetArchitecture);
+            return targetOSComponent + '-' + targetArchComponent;
         }
 
         private static string ArchitectureToString(Architecture architecture)
@@ -356,23 +397,6 @@ namespace Microsoft.NET.Build.Tasks
                 Architecture.Arm64 => "arm64",
                 _ => null
             };
-        }
-
-        // Keep in sync with JitConfigProvider.GetTargetSpec
-        private bool GetTargetSpec(Architecture hostArchitecture, out string targetSpec)
-        {
-            string targetOSComponent = (_targetPlatform == "win" ? "win" : "unix");
-            string targetArchComponent = ArchitectureToString(_targetArchitecture);
-            string hostArchComponent = ArchitectureToString(hostArchitecture);
-
-            if (targetArchComponent == null || hostArchComponent == null)
-            {
-                targetSpec = null;
-                return false;
-            }
-
-            targetSpec = targetOSComponent + '_' + targetArchComponent + '_' + hostArchComponent;
-            return true;
         }
     }
 }


### PR DESCRIPTION
In .NET 5 SDK passed the JIT library name to Crossgen2 via the `--jitpath` command-line option.  In .NET 6 Crossgen2 packages started to contain multiple JIT libraries for cross-platform and cross-architecture compilation.  Instead of duplicating the logic for constructing the JIT library name in both Crossgen2 and the SDK, this PR passes `--targetos` and `--targetarch` options and leaves JIT library name resolution to Crossgen2.  I decided to keep the ability to use version 5 of Crossgen2 packages under `if (version5)`, so I reverted some changes made in #14194.