### PR TITLE
Fix design-time build with RuntimeIdentifier specific for .NET Core 2.x

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.PackageDependencyResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.PackageDependencyResolution.targets
@@ -512,4 +512,12 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   </Target>
 
+  <!-- Override EnsureNETCoreAppRuntime target which is included in Microsoft.NETCore.App NuGet package for
+       .NET Core 2.x.  It no longer works with the .NET 5.0.100 SDK, as the ParentTarget metadata has changed format
+       but the targets in the NuGet package still expect the old format.
+       
+       So here we just override that target.  We have logic in the SDK that covers this scenario and generates
+       NETSDK1056. -->
+  <Target Name="EnsureNETCoreAppRuntime" />
+
 </Project>

--- a/src/Tests/Microsoft.NET.Build.Tests/DesignTimeBuildTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/DesignTimeBuildTests.cs
@@ -81,6 +81,29 @@ namespace Microsoft.NET.Build.Tests
             });
         }
 
+        //  Regression test for https://github.com/dotnet/sdk/issues/13513
+        [Fact]
+        public void DesignTimeBuildSucceedsWhenTargetingNetCore21WithRuntimeIdentifier()
+        {
+            var testProject = new TestProject()
+            {
+                Name = "DesignTimePackageDependencies",
+                TargetFrameworks = "netcoreapp2.1",
+                IsSdkProject = true,
+                RuntimeIdentifier = EnvironmentInfo.GetCompatibleRid()
+            };
+
+            testProject.PackageReferences.Add(new TestPackageReference("Newtonsoft.Json", "12.0.2", privateAssets: "All"));
+            testProject.PackageReferences.Add(new TestPackageReference("Humanizer", "2.6.2"));
+
+            var testAsset = _testAssetsManager.CreateTestProject(testProject);
+
+            new MSBuildCommand(testAsset, "ResolvePackageDependenciesDesignTime")
+                .Execute()
+                .Should()
+                .Pass();
+       }
+
         [Theory]
         [InlineData("netcoreapp3.0")]
         [InlineData("net5.0")]

--- a/src/Tests/Microsoft.NET.Build.Tests/DesignTimeBuildTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/DesignTimeBuildTests.cs
@@ -93,9 +93,6 @@ namespace Microsoft.NET.Build.Tests
                 RuntimeIdentifier = EnvironmentInfo.GetCompatibleRid()
             };
 
-            testProject.PackageReferences.Add(new TestPackageReference("Newtonsoft.Json", "12.0.2", privateAssets: "All"));
-            testProject.PackageReferences.Add(new TestPackageReference("Humanizer", "2.6.2"));
-
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
             new MSBuildCommand(testAsset, "ResolvePackageDependenciesDesignTime")

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildWithARuntimeIdentifier.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildWithARuntimeIdentifier.cs
@@ -5,6 +5,7 @@ using System.Xml.Linq;
 using Microsoft.NET.TestFramework;
 using Microsoft.NET.TestFramework.Assertions;
 using Microsoft.NET.TestFramework.Commands;
+using Microsoft.NET.TestFramework.ProjectConstruction;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -51,6 +52,29 @@ namespace Microsoft.NET.Build.Tests
                 .Execute()
                 .Should()
                 .Pass();
+        }
+
+        [Fact]
+        public void It_fails_with_unsupported_RID()
+        {
+            var testProject = new TestProject()
+            {
+                Name = "DesignTimePackageDependencies",
+                //  Note: The logic is different for .NET Core 3+, there is a different test that covers that (and the error is different too, it's NETSDK1083)
+                TargetFrameworks = "netcoreapp2.1",
+                IsSdkProject = true,
+                //  Note the typo in the RID
+                RuntimeIdentifier = "won-x64"
+            };
+
+            var testAsset = _testAssetsManager.CreateTestProject(testProject);
+
+            new BuildCommand(testAsset)
+                .Execute()
+                .Should()
+                .Fail()
+                .And
+                .HaveStdOutContaining("NETSDK1056");
         }
     }
 }


### PR DESCRIPTION
Fixes #13513

**Description**

Fix issue where `EnsureNETCoreAppRuntime` task would fail for .NET Core 2.x projects with a RuntimeIdentifier specified.

**Customer Impact**

This issue will cause warning icons on packages in the Solution Explorer dependency tree and an error in the error list in Visual Studio for projects which:

- Target .NET Core 2.x
- Have a RuntimeIdentifier specified in the project file

Service Fabric projects apparently need to have the RuntimeIdentifier specified, so they will typically be impacted by this.

**How found**

Customer report

**Test coverage**

Automated test coverage is added with this PR

**Regression?**

Yes, this was a regression caused by the TargetFramework changes for .NET 5.

We did not catch it earlier because it only affects design-time builds for .NET Core 2.x projects with a RuntimeIdentifier specified.  Also, there were other issues which we fixed before GA which also caused warning icons in Solution Explorer, which meant it took us longer to realize that this was a distinct issue.

**Risk**

Low.  The fix is to disable a target which is brought in by the 2.x Microsoft.NETCore.App NuGet package, but doesn't run during normal builds because the target it is scheduled after the `RunResolvePackageDependencies`, which is only run during design-time builds since .NET Core 3.0
