### PR TITLE
Add vulnerable option to dotnet list package

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/ListPackageReferencesCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/ListPackageReferencesCommandParser.cs
@@ -22,6 +22,9 @@ namespace Microsoft.DotNet.Cli
                 Create.Option("--deprecated",
                               LocalizableStrings.CmdDeprecatedDescription,
                               Accept.NoArguments().ForwardAs("--deprecated")),
+                Create.Option("--vulnerable",
+                              LocalizableStrings.CmdVulnerableDescription,
+                              Accept.NoArguments().ForwardAs("--vulnerable")),
                 Create.Option("--framework",
                               LocalizableStrings.CmdFrameworkDescription,
                               Accept.OneOrMoreArguments()

--- a/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/LocalizableStrings.resx
+++ b/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/LocalizableStrings.resx
@@ -126,9 +126,6 @@
   <data name="CmdFrameworkDescription" xml:space="preserve">
     <value>Chooses a framework to show its packages. Use the option multiple times for multiple frameworks.</value>
   </data>
-  <data name="CmdOutdatedDescription" xml:space="preserve">
-    <value>Lists packages that have newer versions.</value>
-  </data>
   <data name="CmdTransitiveDescription" xml:space="preserve">
     <value>Lists transitive and top-level packages.</value>
   </data>
@@ -139,33 +136,36 @@
     <value>CONFIG_FILE</value>
   </data>
   <data name="CmdConfigDescription" xml:space="preserve">
-    <value>The path to the NuGet config file to use. Requires the '--outdated' or '--deprecated' option.</value>
+    <value>The path to the NuGet config file to use. Requires the '--outdated', '--deprecated' or '--vulnerable' option.</value>
   </data>
   <data name="CmdHighestMinorDescription" xml:space="preserve">
-    <value>Consider only the packages with a matching major version number when searching for newer packages. Requires the '--outdated' or '--deprecated' option.</value>
+    <value>Consider only the packages with a matching major version number when searching for newer packages. Requires the '--outdated' option.</value>
   </data>
   <data name="CmdHighestPatchDescription" xml:space="preserve">
-    <value>Consider only the packages with a matching major and minor version numbers when searching for newer packages. Requires the '--outdated' or '--deprecated' option.</value>
+    <value>Consider only the packages with a matching major and minor version numbers when searching for newer packages. Requires the '--outdated' option.</value>
   </data>
   <data name="CmdPrereleaseDescription" xml:space="preserve">
-    <value>Consider packages with prerelease versions when searching for newer packages. Requires the '--outdated' or '--deprecated' option.</value>
+    <value>Consider packages with prerelease versions when searching for newer packages. Requires the '--outdated' option.</value>
   </data>
   <data name="CmdSource" xml:space="preserve">
     <value>SOURCE</value>
   </data>
   <data name="CmdSourceDescription" xml:space="preserve">
-    <value>The NuGet sources to use when searching for newer packages. Requires the '--outdated' or '--deprecated' option.</value>
+    <value>The NuGet sources to use when searching for newer packages. Requires the '--outdated', '--deprecated' or '--vulnerable' option.</value>
   </data>
   <data name="FileNotFound" xml:space="preserve">
     <value>Could not find file or directory '{0}'.</value>
   </data>
-  <data name="OutdatedAndDeprecatedOptionsCannotBeCombined" xml:space="preserve">
-    <value>Option '--outdated' and '--deprecated' cannot be combined.</value>
+  <data name="OptionsCannotBeCombined" xml:space="preserve">
+    <value>Options '--outdated', '--deprecated' and '--vulnerable' cannot be combined.</value>
+  </data>
+  <data name="CmdOutdatedDescription" xml:space="preserve">
+    <value>Lists packages that have newer versions. Cannot be combined with '--deprecated' or '--vulnerable' options.</value>
   </data>
   <data name="CmdDeprecatedDescription" xml:space="preserve">
-    <value>Lists packages that have been deprecated.</value>
+    <value>Lists packages that have been deprecated. Cannot be combined with '--vulnerable' or '--outdated' options.</value>
   </data>
-  <data name="OutdatedOrDeprecatedOptionOnly" xml:space="preserve">
-    <value>Option '{0}' requires the '--outdated' or '--deprecated' option to be specified.</value>
+  <data name="CmdVulnerableDescription" xml:space="preserve">
+    <value>Lists packages that have known vulnerabilities. Cannot be combined with '--deprecated' or '--outdated' options.</value>
   </data>
 </root>

--- a/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.cs.xlf
+++ b/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.cs.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdDeprecatedDescription">
-        <source>Lists packages that have been deprecated.</source>
-        <target state="translated">Seznam zastaralých balíčků</target>
+        <source>Lists packages that have been deprecated. Cannot be combined with '--vulnerable' or '--outdated' options.</source>
+        <target state="needs-review-translation">Seznam zastaralých balíčků</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdFramework">
@@ -23,13 +23,18 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdOutdatedDescription">
-        <source>Lists packages that have newer versions.</source>
-        <target state="translated">Zobrazí seznam balíčků, které mají novější verze.</target>
+        <source>Lists packages that have newer versions. Cannot be combined with '--deprecated' or '--vulnerable' options.</source>
+        <target state="needs-review-translation">Zobrazí seznam balíčků, které mají novější verze.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdTransitiveDescription">
         <source>Lists transitive and top-level packages.</source>
         <target state="translated">Vypíše seznam přenosných balíčků a balíčků nejvyšší úrovně.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdVulnerableDescription">
+        <source>Lists packages that have known vulnerabilities. Cannot be combined with '--deprecated' or '--outdated' options.</source>
+        <target state="new">Lists packages that have known vulnerabilities. Cannot be combined with '--deprecated' or '--outdated' options.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoProjectsOrSolutions">
@@ -43,23 +48,23 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdConfigDescription">
-        <source>The path to the NuGet config file to use. Requires the '--outdated' or '--deprecated' option.</source>
-        <target state="translated">Cesta ke konfiguračnímu souboru NuGet, který se má použít. Vyžaduje přepínač --outdated nebo --deprecated.</target>
+        <source>The path to the NuGet config file to use. Requires the '--outdated', '--deprecated' or '--vulnerable' option.</source>
+        <target state="needs-review-translation">Cesta ke konfiguračnímu souboru NuGet, který se má použít. Vyžaduje přepínač --outdated nebo --deprecated.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdHighestMinorDescription">
-        <source>Consider only the packages with a matching major version number when searching for newer packages. Requires the '--outdated' or '--deprecated' option.</source>
-        <target state="translated">Při hledání novějších balíčků se budou brát v úvahu jen balíčky s odpovídajícím číslem hlavní verze. Vyžaduje přepínač --outdated nebo --deprecated.</target>
+        <source>Consider only the packages with a matching major version number when searching for newer packages. Requires the '--outdated' option.</source>
+        <target state="needs-review-translation">Při hledání novějších balíčků se budou brát v úvahu jen balíčky s odpovídajícím číslem hlavní verze. Vyžaduje přepínač --outdated nebo --deprecated.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdHighestPatchDescription">
-        <source>Consider only the packages with a matching major and minor version numbers when searching for newer packages. Requires the '--outdated' or '--deprecated' option.</source>
-        <target state="translated">Při hledání novějších balíčků se budou brát v úvahu jen balíčky s odpovídajícími čísly hlavní verze a podverze. Vyžaduje přepínač --outdated nebo --deprecated.</target>
+        <source>Consider only the packages with a matching major and minor version numbers when searching for newer packages. Requires the '--outdated' option.</source>
+        <target state="needs-review-translation">Při hledání novějších balíčků se budou brát v úvahu jen balíčky s odpovídajícími čísly hlavní verze a podverze. Vyžaduje přepínač --outdated nebo --deprecated.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdPrereleaseDescription">
-        <source>Consider packages with prerelease versions when searching for newer packages. Requires the '--outdated' or '--deprecated' option.</source>
-        <target state="translated">Při hledání novějších balíčků se budou brát v úvahu i balíčky v předběžných verzích. Vyžaduje přepínač --outdated nebo --deprecated.</target>
+        <source>Consider packages with prerelease versions when searching for newer packages. Requires the '--outdated' option.</source>
+        <target state="needs-review-translation">Při hledání novějších balíčků se budou brát v úvahu i balíčky v předběžných verzích. Vyžaduje přepínač --outdated nebo --deprecated.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdSource">
@@ -68,13 +73,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdSourceDescription">
-        <source>The NuGet sources to use when searching for newer packages. Requires the '--outdated' or '--deprecated' option.</source>
-        <target state="translated">Zdroje NuGet, které se mají použít při hledání novějších balíčků. Vyžaduje přepínač --outdated nebo --deprecated.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="OutdatedAndDeprecatedOptionsCannotBeCombined">
-        <source>Option '--outdated' and '--deprecated' cannot be combined.</source>
-        <target state="translated">Možnosti --outdated a --deprecated se nedají kombinovat.</target>
+        <source>The NuGet sources to use when searching for newer packages. Requires the '--outdated', '--deprecated' or '--vulnerable' option.</source>
+        <target state="needs-review-translation">Zdroje NuGet, které se mají použít při hledání novějších balíčků. Vyžaduje přepínač --outdated nebo --deprecated.</target>
         <note />
       </trans-unit>
       <trans-unit id="FileNotFound">
@@ -82,9 +82,9 @@
         <target state="translated">Soubor nebo adresář {0} nešlo najít.</target>
         <note />
       </trans-unit>
-      <trans-unit id="OutdatedOrDeprecatedOptionOnly">
-        <source>Option '{0}' requires the '--outdated' or '--deprecated' option to be specified.</source>
-        <target state="translated">Přepínač {0} vyžaduje, aby se zadal přepínač --outdated nebo --deprecated.</target>
+      <trans-unit id="OptionsCannotBeCombined">
+        <source>Options '--outdated', '--deprecated' and '--vulnerable' cannot be combined.</source>
+        <target state="new">Options '--outdated', '--deprecated' and '--vulnerable' cannot be combined.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.de.xlf
+++ b/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.de.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdDeprecatedDescription">
-        <source>Lists packages that have been deprecated.</source>
-        <target state="translated">Listet Pakete auf, die veraltet sind.</target>
+        <source>Lists packages that have been deprecated. Cannot be combined with '--vulnerable' or '--outdated' options.</source>
+        <target state="needs-review-translation">Listet Pakete auf, die veraltet sind.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdFramework">
@@ -23,13 +23,18 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdOutdatedDescription">
-        <source>Lists packages that have newer versions.</source>
-        <target state="translated">Listet Pakete mit neueren Versionen auf.</target>
+        <source>Lists packages that have newer versions. Cannot be combined with '--deprecated' or '--vulnerable' options.</source>
+        <target state="needs-review-translation">Listet Pakete mit neueren Versionen auf.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdTransitiveDescription">
         <source>Lists transitive and top-level packages.</source>
         <target state="translated">Listet transitive Pakete und Pakete der obersten Ebene auf.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdVulnerableDescription">
+        <source>Lists packages that have known vulnerabilities. Cannot be combined with '--deprecated' or '--outdated' options.</source>
+        <target state="new">Lists packages that have known vulnerabilities. Cannot be combined with '--deprecated' or '--outdated' options.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoProjectsOrSolutions">
@@ -43,23 +48,23 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdConfigDescription">
-        <source>The path to the NuGet config file to use. Requires the '--outdated' or '--deprecated' option.</source>
-        <target state="translated">Der Pfad zu der NuGet-Konfigurationsdatei, die verwendet werden soll. Erfordert die Option "--outdated" oder "--deprecated".</target>
+        <source>The path to the NuGet config file to use. Requires the '--outdated', '--deprecated' or '--vulnerable' option.</source>
+        <target state="needs-review-translation">Der Pfad zu der NuGet-Konfigurationsdatei, die verwendet werden soll. Erfordert die Option "--outdated" oder "--deprecated".</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdHighestMinorDescription">
-        <source>Consider only the packages with a matching major version number when searching for newer packages. Requires the '--outdated' or '--deprecated' option.</source>
-        <target state="translated">Hiermit werden bei der Suche nach neueren Paketen nur Pakete mit übereinstimmender Hauptversionsnummer berücksichtigt. Erfordert die Option "--outdated" oder "--deprecated".</target>
+        <source>Consider only the packages with a matching major version number when searching for newer packages. Requires the '--outdated' option.</source>
+        <target state="needs-review-translation">Hiermit werden bei der Suche nach neueren Paketen nur Pakete mit übereinstimmender Hauptversionsnummer berücksichtigt. Erfordert die Option "--outdated" oder "--deprecated".</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdHighestPatchDescription">
-        <source>Consider only the packages with a matching major and minor version numbers when searching for newer packages. Requires the '--outdated' or '--deprecated' option.</source>
-        <target state="translated">Hiermit werden bei der Suche nach neueren Paketen nur Pakete mit übereinstimmender Haupt- und Nebenversionsnummer berücksichtigt. Erfordert die Option "--outdated" oder "--deprecated".</target>
+        <source>Consider only the packages with a matching major and minor version numbers when searching for newer packages. Requires the '--outdated' option.</source>
+        <target state="needs-review-translation">Hiermit werden bei der Suche nach neueren Paketen nur Pakete mit übereinstimmender Haupt- und Nebenversionsnummer berücksichtigt. Erfordert die Option "--outdated" oder "--deprecated".</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdPrereleaseDescription">
-        <source>Consider packages with prerelease versions when searching for newer packages. Requires the '--outdated' or '--deprecated' option.</source>
-        <target state="translated">Hiermit werden bei der Suche nach neueren Paketen auch Pakete mit Vorabversionen berücksichtigt. Erfordert die Option "--outdated" oder "--deprecated".</target>
+        <source>Consider packages with prerelease versions when searching for newer packages. Requires the '--outdated' option.</source>
+        <target state="needs-review-translation">Hiermit werden bei der Suche nach neueren Paketen auch Pakete mit Vorabversionen berücksichtigt. Erfordert die Option "--outdated" oder "--deprecated".</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdSource">
@@ -68,13 +73,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdSourceDescription">
-        <source>The NuGet sources to use when searching for newer packages. Requires the '--outdated' or '--deprecated' option.</source>
-        <target state="translated">Die bei der Suche nach neueren Paketen zu verwendenden NuGet-Quellen. Erfordert die Option "--outdated" oder "--deprecated".</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="OutdatedAndDeprecatedOptionsCannotBeCombined">
-        <source>Option '--outdated' and '--deprecated' cannot be combined.</source>
-        <target state="translated">Die Optionen "--outdated" und "--deprecated" können nicht kombiniert werden.</target>
+        <source>The NuGet sources to use when searching for newer packages. Requires the '--outdated', '--deprecated' or '--vulnerable' option.</source>
+        <target state="needs-review-translation">Die bei der Suche nach neueren Paketen zu verwendenden NuGet-Quellen. Erfordert die Option "--outdated" oder "--deprecated".</target>
         <note />
       </trans-unit>
       <trans-unit id="FileNotFound">
@@ -82,9 +82,9 @@
         <target state="translated">Die Datei oder das Verzeichnis "{0}" wurde nicht gefunden.</target>
         <note />
       </trans-unit>
-      <trans-unit id="OutdatedOrDeprecatedOptionOnly">
-        <source>Option '{0}' requires the '--outdated' or '--deprecated' option to be specified.</source>
-        <target state="translated">Für die Option "{0}" muss die Option "--outdated" oder "--deprecated" angegeben werden.</target>
+      <trans-unit id="OptionsCannotBeCombined">
+        <source>Options '--outdated', '--deprecated' and '--vulnerable' cannot be combined.</source>
+        <target state="new">Options '--outdated', '--deprecated' and '--vulnerable' cannot be combined.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.es.xlf
+++ b/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.es.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdDeprecatedDescription">
-        <source>Lists packages that have been deprecated.</source>
-        <target state="translated">Muestra los paquetes que han quedado en desuso.</target>
+        <source>Lists packages that have been deprecated. Cannot be combined with '--vulnerable' or '--outdated' options.</source>
+        <target state="needs-review-translation">Muestra los paquetes que han quedado en desuso.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdFramework">
@@ -23,13 +23,18 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdOutdatedDescription">
-        <source>Lists packages that have newer versions.</source>
-        <target state="translated">Muestra los paquetes que tienen versiones más recientes.</target>
+        <source>Lists packages that have newer versions. Cannot be combined with '--deprecated' or '--vulnerable' options.</source>
+        <target state="needs-review-translation">Muestra los paquetes que tienen versiones más recientes.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdTransitiveDescription">
         <source>Lists transitive and top-level packages.</source>
         <target state="translated">Contiene paquetes de transitivos y de nivel superior.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdVulnerableDescription">
+        <source>Lists packages that have known vulnerabilities. Cannot be combined with '--deprecated' or '--outdated' options.</source>
+        <target state="new">Lists packages that have known vulnerabilities. Cannot be combined with '--deprecated' or '--outdated' options.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoProjectsOrSolutions">
@@ -43,23 +48,23 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdConfigDescription">
-        <source>The path to the NuGet config file to use. Requires the '--outdated' or '--deprecated' option.</source>
-        <target state="translated">La ruta al archivo de config de NuGet que se usará. Se requiere la opción "--outdated" o "--deprecated".</target>
+        <source>The path to the NuGet config file to use. Requires the '--outdated', '--deprecated' or '--vulnerable' option.</source>
+        <target state="needs-review-translation">La ruta al archivo de config de NuGet que se usará. Se requiere la opción "--outdated" o "--deprecated".</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdHighestMinorDescription">
-        <source>Consider only the packages with a matching major version number when searching for newer packages. Requires the '--outdated' or '--deprecated' option.</source>
-        <target state="translated">Al buscar paquetes más recientes, tenga en cuenta solo los paquetes con números de versión principal que coincidan. Se requiere la opción "--outdated" o "--deprecated".</target>
+        <source>Consider only the packages with a matching major version number when searching for newer packages. Requires the '--outdated' option.</source>
+        <target state="needs-review-translation">Al buscar paquetes más recientes, tenga en cuenta solo los paquetes con números de versión principal que coincidan. Se requiere la opción "--outdated" o "--deprecated".</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdHighestPatchDescription">
-        <source>Consider only the packages with a matching major and minor version numbers when searching for newer packages. Requires the '--outdated' or '--deprecated' option.</source>
-        <target state="translated">Al buscar paquetes más recientes, tenga en cuenta solo los paquetes con números de versión principal y secundaria que coincidan. Se requiere la opción "--outdated" o "--deprecated".</target>
+        <source>Consider only the packages with a matching major and minor version numbers when searching for newer packages. Requires the '--outdated' option.</source>
+        <target state="needs-review-translation">Al buscar paquetes más recientes, tenga en cuenta solo los paquetes con números de versión principal y secundaria que coincidan. Se requiere la opción "--outdated" o "--deprecated".</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdPrereleaseDescription">
-        <source>Consider packages with prerelease versions when searching for newer packages. Requires the '--outdated' or '--deprecated' option.</source>
-        <target state="translated">Al buscar paquetes más recientes, tenga en cuenta los paquetes con versiones previas. Se requiere la opción "--outdated" o "--deprecated".</target>
+        <source>Consider packages with prerelease versions when searching for newer packages. Requires the '--outdated' option.</source>
+        <target state="needs-review-translation">Al buscar paquetes más recientes, tenga en cuenta los paquetes con versiones previas. Se requiere la opción "--outdated" o "--deprecated".</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdSource">
@@ -68,13 +73,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdSourceDescription">
-        <source>The NuGet sources to use when searching for newer packages. Requires the '--outdated' or '--deprecated' option.</source>
-        <target state="translated">Los orígenes de NuGet que se usan al buscar paquetes más recientes. Se requiere la opción "--outdated" o "--deprecated".</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="OutdatedAndDeprecatedOptionsCannotBeCombined">
-        <source>Option '--outdated' and '--deprecated' cannot be combined.</source>
-        <target state="translated">No se puede combinar la opción "--outdated" y "--deprecated".</target>
+        <source>The NuGet sources to use when searching for newer packages. Requires the '--outdated', '--deprecated' or '--vulnerable' option.</source>
+        <target state="needs-review-translation">Los orígenes de NuGet que se usan al buscar paquetes más recientes. Se requiere la opción "--outdated" o "--deprecated".</target>
         <note />
       </trans-unit>
       <trans-unit id="FileNotFound">
@@ -82,9 +82,9 @@
         <target state="translated">No se pudo encontrar el archivo o directorio "{0}".</target>
         <note />
       </trans-unit>
-      <trans-unit id="OutdatedOrDeprecatedOptionOnly">
-        <source>Option '{0}' requires the '--outdated' or '--deprecated' option to be specified.</source>
-        <target state="translated">La opción "{0}" requiere que se especifique la opción "--outdated" o "--deprecated".</target>
+      <trans-unit id="OptionsCannotBeCombined">
+        <source>Options '--outdated', '--deprecated' and '--vulnerable' cannot be combined.</source>
+        <target state="new">Options '--outdated', '--deprecated' and '--vulnerable' cannot be combined.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.fr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.fr.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdDeprecatedDescription">
-        <source>Lists packages that have been deprecated.</source>
-        <target state="translated">Liste les packages qui ont été dépréciés.</target>
+        <source>Lists packages that have been deprecated. Cannot be combined with '--vulnerable' or '--outdated' options.</source>
+        <target state="needs-review-translation">Liste les packages qui ont été dépréciés.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdFramework">
@@ -23,13 +23,18 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdOutdatedDescription">
-        <source>Lists packages that have newer versions.</source>
-        <target state="translated">Liste les packages avec des versions plus récentes.</target>
+        <source>Lists packages that have newer versions. Cannot be combined with '--deprecated' or '--vulnerable' options.</source>
+        <target state="needs-review-translation">Liste les packages avec des versions plus récentes.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdTransitiveDescription">
         <source>Lists transitive and top-level packages.</source>
         <target state="translated">Liste les packages transitifs et de niveau supérieur.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdVulnerableDescription">
+        <source>Lists packages that have known vulnerabilities. Cannot be combined with '--deprecated' or '--outdated' options.</source>
+        <target state="new">Lists packages that have known vulnerabilities. Cannot be combined with '--deprecated' or '--outdated' options.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoProjectsOrSolutions">
@@ -43,23 +48,23 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdConfigDescription">
-        <source>The path to the NuGet config file to use. Requires the '--outdated' or '--deprecated' option.</source>
-        <target state="translated">Chemin du fichier config NuGet à utiliser. Nécessite l'option '--outdated' ou '--deprecated'.</target>
+        <source>The path to the NuGet config file to use. Requires the '--outdated', '--deprecated' or '--vulnerable' option.</source>
+        <target state="needs-review-translation">Chemin du fichier config NuGet à utiliser. Nécessite l'option '--outdated' ou '--deprecated'.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdHighestMinorDescription">
-        <source>Consider only the packages with a matching major version number when searching for newer packages. Requires the '--outdated' or '--deprecated' option.</source>
-        <target state="translated">Prend en compte uniquement les packages avec le numéro de version principale correspondant durant la recherche de packages plus récents. Nécessite l'option '--outdated' ou '--deprecated'.</target>
+        <source>Consider only the packages with a matching major version number when searching for newer packages. Requires the '--outdated' option.</source>
+        <target state="needs-review-translation">Prend en compte uniquement les packages avec le numéro de version principale correspondant durant la recherche de packages plus récents. Nécessite l'option '--outdated' ou '--deprecated'.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdHighestPatchDescription">
-        <source>Consider only the packages with a matching major and minor version numbers when searching for newer packages. Requires the '--outdated' or '--deprecated' option.</source>
-        <target state="translated">Prend en compte uniquement les packages avec les numéros de version principale et mineure correspondants durant la recherche de packages plus récents. Nécessite l'option '--outdated' ou '--deprecated'.</target>
+        <source>Consider only the packages with a matching major and minor version numbers when searching for newer packages. Requires the '--outdated' option.</source>
+        <target state="needs-review-translation">Prend en compte uniquement les packages avec les numéros de version principale et mineure correspondants durant la recherche de packages plus récents. Nécessite l'option '--outdated' ou '--deprecated'.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdPrereleaseDescription">
-        <source>Consider packages with prerelease versions when searching for newer packages. Requires the '--outdated' or '--deprecated' option.</source>
-        <target state="translated">Prend en compte les packages avec des préversions durant la recherche de packages plus récents. Nécessite l'option '--outdated' ou '--deprecated'.</target>
+        <source>Consider packages with prerelease versions when searching for newer packages. Requires the '--outdated' option.</source>
+        <target state="needs-review-translation">Prend en compte les packages avec des préversions durant la recherche de packages plus récents. Nécessite l'option '--outdated' ou '--deprecated'.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdSource">
@@ -68,13 +73,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdSourceDescription">
-        <source>The NuGet sources to use when searching for newer packages. Requires the '--outdated' or '--deprecated' option.</source>
-        <target state="translated">Sources NuGet à utiliser durant la recherche de packages plus récents. Nécessite l'option '--outdated' ou '--deprecated'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="OutdatedAndDeprecatedOptionsCannotBeCombined">
-        <source>Option '--outdated' and '--deprecated' cannot be combined.</source>
-        <target state="translated">Impossible de combiner les options '--outdated' et '--deprecated'.</target>
+        <source>The NuGet sources to use when searching for newer packages. Requires the '--outdated', '--deprecated' or '--vulnerable' option.</source>
+        <target state="needs-review-translation">Sources NuGet à utiliser durant la recherche de packages plus récents. Nécessite l'option '--outdated' ou '--deprecated'.</target>
         <note />
       </trans-unit>
       <trans-unit id="FileNotFound">
@@ -82,9 +82,9 @@
         <target state="translated">Fichier ou répertoire '{0}' introuvable.</target>
         <note />
       </trans-unit>
-      <trans-unit id="OutdatedOrDeprecatedOptionOnly">
-        <source>Option '{0}' requires the '--outdated' or '--deprecated' option to be specified.</source>
-        <target state="translated">L'option '{0}' nécessite la spécification de l'option '--outdated' ou '--deprecated'.</target>
+      <trans-unit id="OptionsCannotBeCombined">
+        <source>Options '--outdated', '--deprecated' and '--vulnerable' cannot be combined.</source>
+        <target state="new">Options '--outdated', '--deprecated' and '--vulnerable' cannot be combined.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.it.xlf
+++ b/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.it.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdDeprecatedDescription">
-        <source>Lists packages that have been deprecated.</source>
-        <target state="translated">Elenca i pacchetti che sono stati deprecati.</target>
+        <source>Lists packages that have been deprecated. Cannot be combined with '--vulnerable' or '--outdated' options.</source>
+        <target state="needs-review-translation">Elenca i pacchetti che sono stati deprecati.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdFramework">
@@ -23,13 +23,18 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdOutdatedDescription">
-        <source>Lists packages that have newer versions.</source>
-        <target state="translated">Elenca i pacchetti per cui esistono versioni più recenti.</target>
+        <source>Lists packages that have newer versions. Cannot be combined with '--deprecated' or '--vulnerable' options.</source>
+        <target state="needs-review-translation">Elenca i pacchetti per cui esistono versioni più recenti.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdTransitiveDescription">
         <source>Lists transitive and top-level packages.</source>
         <target state="translated">Elenca i pacchetti transitivi e di primo livello.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdVulnerableDescription">
+        <source>Lists packages that have known vulnerabilities. Cannot be combined with '--deprecated' or '--outdated' options.</source>
+        <target state="new">Lists packages that have known vulnerabilities. Cannot be combined with '--deprecated' or '--outdated' options.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoProjectsOrSolutions">
@@ -43,23 +48,23 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdConfigDescription">
-        <source>The path to the NuGet config file to use. Requires the '--outdated' or '--deprecated' option.</source>
-        <target state="translated">Percorso del file config NuGet da usare. Richiede l'opzione '--outdated' o '--deprecated'.</target>
+        <source>The path to the NuGet config file to use. Requires the '--outdated', '--deprecated' or '--vulnerable' option.</source>
+        <target state="needs-review-translation">Percorso del file config NuGet da usare. Richiede l'opzione '--outdated' o '--deprecated'.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdHighestMinorDescription">
-        <source>Consider only the packages with a matching major version number when searching for newer packages. Requires the '--outdated' or '--deprecated' option.</source>
-        <target state="translated">Prende in considerazione solo i pacchetti con il numero di versione principale corrispondente quando si cercano i pacchetti più recenti. Richiede l'opzione '--outdated' o '--deprecated'.</target>
+        <source>Consider only the packages with a matching major version number when searching for newer packages. Requires the '--outdated' option.</source>
+        <target state="needs-review-translation">Prende in considerazione solo i pacchetti con il numero di versione principale corrispondente quando si cercano i pacchetti più recenti. Richiede l'opzione '--outdated' o '--deprecated'.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdHighestPatchDescription">
-        <source>Consider only the packages with a matching major and minor version numbers when searching for newer packages. Requires the '--outdated' or '--deprecated' option.</source>
-        <target state="translated">Prende in considerazione solo i pacchetti con i numeri di versione principale e secondaria corrispondenti quando si cercano i pacchetti più recenti. Richiede l'opzione '--outdated' o '--deprecated'.</target>
+        <source>Consider only the packages with a matching major and minor version numbers when searching for newer packages. Requires the '--outdated' option.</source>
+        <target state="needs-review-translation">Prende in considerazione solo i pacchetti con i numeri di versione principale e secondaria corrispondenti quando si cercano i pacchetti più recenti. Richiede l'opzione '--outdated' o '--deprecated'.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdPrereleaseDescription">
-        <source>Consider packages with prerelease versions when searching for newer packages. Requires the '--outdated' or '--deprecated' option.</source>
-        <target state="translated">Prende in considerazione i pacchetti con versioni preliminari quando si cercano i pacchetti più recenti. Richiede l'opzione '--outdated' o '--deprecated'.</target>
+        <source>Consider packages with prerelease versions when searching for newer packages. Requires the '--outdated' option.</source>
+        <target state="needs-review-translation">Prende in considerazione i pacchetti con versioni preliminari quando si cercano i pacchetti più recenti. Richiede l'opzione '--outdated' o '--deprecated'.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdSource">
@@ -68,13 +73,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdSourceDescription">
-        <source>The NuGet sources to use when searching for newer packages. Requires the '--outdated' or '--deprecated' option.</source>
-        <target state="translated">Origini NuGet da usare quando si cercano i pacchetti più recenti. Richiede l'opzione '--outdated' o '--deprecated'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="OutdatedAndDeprecatedOptionsCannotBeCombined">
-        <source>Option '--outdated' and '--deprecated' cannot be combined.</source>
-        <target state="translated">Non è possibile combinare le opzioni '--outdated' e '--deprecated'.</target>
+        <source>The NuGet sources to use when searching for newer packages. Requires the '--outdated', '--deprecated' or '--vulnerable' option.</source>
+        <target state="needs-review-translation">Origini NuGet da usare quando si cercano i pacchetti più recenti. Richiede l'opzione '--outdated' o '--deprecated'.</target>
         <note />
       </trans-unit>
       <trans-unit id="FileNotFound">
@@ -82,9 +82,9 @@
         <target state="translated">Non è stato possibile trovare il file o la directory '{0}'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="OutdatedOrDeprecatedOptionOnly">
-        <source>Option '{0}' requires the '--outdated' or '--deprecated' option to be specified.</source>
-        <target state="translated">Con l'opzione '{0}' è necessario specificare l'opzione '--outdated' o '--deprecated'.</target>
+      <trans-unit id="OptionsCannotBeCombined">
+        <source>Options '--outdated', '--deprecated' and '--vulnerable' cannot be combined.</source>
+        <target state="new">Options '--outdated', '--deprecated' and '--vulnerable' cannot be combined.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.ja.xlf
+++ b/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.ja.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdDeprecatedDescription">
-        <source>Lists packages that have been deprecated.</source>
-        <target state="translated">非推奨となったパッケージを一覧表示します。</target>
+        <source>Lists packages that have been deprecated. Cannot be combined with '--vulnerable' or '--outdated' options.</source>
+        <target state="needs-review-translation">非推奨となったパッケージを一覧表示します。</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdFramework">
@@ -23,13 +23,18 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdOutdatedDescription">
-        <source>Lists packages that have newer versions.</source>
-        <target state="translated">新しいバージョンが含まれるパッケージを一覧表示します。</target>
+        <source>Lists packages that have newer versions. Cannot be combined with '--deprecated' or '--vulnerable' options.</source>
+        <target state="needs-review-translation">新しいバージョンが含まれるパッケージを一覧表示します。</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdTransitiveDescription">
         <source>Lists transitive and top-level packages.</source>
         <target state="translated">推移的なパッケージと最上位レベルのパッケージを一覧表示します。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdVulnerableDescription">
+        <source>Lists packages that have known vulnerabilities. Cannot be combined with '--deprecated' or '--outdated' options.</source>
+        <target state="new">Lists packages that have known vulnerabilities. Cannot be combined with '--deprecated' or '--outdated' options.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoProjectsOrSolutions">
@@ -43,23 +48,23 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdConfigDescription">
-        <source>The path to the NuGet config file to use. Requires the '--outdated' or '--deprecated' option.</source>
-        <target state="translated">使用する NuGet config ファイルのパス。'--outdated' または '--deprecated' のオプションが必要です。</target>
+        <source>The path to the NuGet config file to use. Requires the '--outdated', '--deprecated' or '--vulnerable' option.</source>
+        <target state="needs-review-translation">使用する NuGet config ファイルのパス。'--outdated' または '--deprecated' のオプションが必要です。</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdHighestMinorDescription">
-        <source>Consider only the packages with a matching major version number when searching for newer packages. Requires the '--outdated' or '--deprecated' option.</source>
-        <target state="translated">新しいパッケージを検索するときにメジャー バージョン番号が一致するパッケージのみを検討します。'--outdated' または '--deprecated' のオプションが必要です。</target>
+        <source>Consider only the packages with a matching major version number when searching for newer packages. Requires the '--outdated' option.</source>
+        <target state="needs-review-translation">新しいパッケージを検索するときにメジャー バージョン番号が一致するパッケージのみを検討します。'--outdated' または '--deprecated' のオプションが必要です。</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdHighestPatchDescription">
-        <source>Consider only the packages with a matching major and minor version numbers when searching for newer packages. Requires the '--outdated' or '--deprecated' option.</source>
-        <target state="translated">新しいパッケージを検索するときにメジャーとマイナーのバージョン番号が一致するパッケージのみを検討します。'--outdated' または '--deprecated' のオプションが必要です。</target>
+        <source>Consider only the packages with a matching major and minor version numbers when searching for newer packages. Requires the '--outdated' option.</source>
+        <target state="needs-review-translation">新しいパッケージを検索するときにメジャーとマイナーのバージョン番号が一致するパッケージのみを検討します。'--outdated' または '--deprecated' のオプションが必要です。</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdPrereleaseDescription">
-        <source>Consider packages with prerelease versions when searching for newer packages. Requires the '--outdated' or '--deprecated' option.</source>
-        <target state="translated">新しいパッケージを検索するときにプレリリース バージョンのパッケージを検討します。'--outdated' または '--deprecated' のオプションが必要です。</target>
+        <source>Consider packages with prerelease versions when searching for newer packages. Requires the '--outdated' option.</source>
+        <target state="needs-review-translation">新しいパッケージを検索するときにプレリリース バージョンのパッケージを検討します。'--outdated' または '--deprecated' のオプションが必要です。</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdSource">
@@ -68,13 +73,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdSourceDescription">
-        <source>The NuGet sources to use when searching for newer packages. Requires the '--outdated' or '--deprecated' option.</source>
-        <target state="translated">新しいパッケージを検索するときに使用する NuGet ソース。'--outdated' または '--deprecated' オプションが必要です。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="OutdatedAndDeprecatedOptionsCannotBeCombined">
-        <source>Option '--outdated' and '--deprecated' cannot be combined.</source>
-        <target state="translated">オプション '--outdated' と '--deprecated' を組み合わせることはできません。</target>
+        <source>The NuGet sources to use when searching for newer packages. Requires the '--outdated', '--deprecated' or '--vulnerable' option.</source>
+        <target state="needs-review-translation">新しいパッケージを検索するときに使用する NuGet ソース。'--outdated' または '--deprecated' オプションが必要です。</target>
         <note />
       </trans-unit>
       <trans-unit id="FileNotFound">
@@ -82,9 +82,9 @@
         <target state="translated">ファイルまたはディレクトリ '{0}' が見つかりませんでした。</target>
         <note />
       </trans-unit>
-      <trans-unit id="OutdatedOrDeprecatedOptionOnly">
-        <source>Option '{0}' requires the '--outdated' or '--deprecated' option to be specified.</source>
-        <target state="translated">オプション '{0}' では '--outdated' または '--deprecated' オプションを指定する必要があります。</target>
+      <trans-unit id="OptionsCannotBeCombined">
+        <source>Options '--outdated', '--deprecated' and '--vulnerable' cannot be combined.</source>
+        <target state="new">Options '--outdated', '--deprecated' and '--vulnerable' cannot be combined.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.ko.xlf
+++ b/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.ko.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdDeprecatedDescription">
-        <source>Lists packages that have been deprecated.</source>
-        <target state="translated">사용되지 않는 패키지를 나열합니다.</target>
+        <source>Lists packages that have been deprecated. Cannot be combined with '--vulnerable' or '--outdated' options.</source>
+        <target state="needs-review-translation">사용되지 않는 패키지를 나열합니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdFramework">
@@ -23,13 +23,18 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdOutdatedDescription">
-        <source>Lists packages that have newer versions.</source>
-        <target state="translated">최신 버전이 있는 패키지를 나열합니다.</target>
+        <source>Lists packages that have newer versions. Cannot be combined with '--deprecated' or '--vulnerable' options.</source>
+        <target state="needs-review-translation">최신 버전이 있는 패키지를 나열합니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdTransitiveDescription">
         <source>Lists transitive and top-level packages.</source>
         <target state="translated">전이적 패키지 및 최상위 패키지를 나열합니다.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdVulnerableDescription">
+        <source>Lists packages that have known vulnerabilities. Cannot be combined with '--deprecated' or '--outdated' options.</source>
+        <target state="new">Lists packages that have known vulnerabilities. Cannot be combined with '--deprecated' or '--outdated' options.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoProjectsOrSolutions">
@@ -43,23 +48,23 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdConfigDescription">
-        <source>The path to the NuGet config file to use. Requires the '--outdated' or '--deprecated' option.</source>
-        <target state="translated">사용할 NuGet 구성 파일의 경로입니다. '--outdated' 또는 '--deprecated' 옵션이 필요합니다.</target>
+        <source>The path to the NuGet config file to use. Requires the '--outdated', '--deprecated' or '--vulnerable' option.</source>
+        <target state="needs-review-translation">사용할 NuGet 구성 파일의 경로입니다. '--outdated' 또는 '--deprecated' 옵션이 필요합니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdHighestMinorDescription">
-        <source>Consider only the packages with a matching major version number when searching for newer packages. Requires the '--outdated' or '--deprecated' option.</source>
-        <target state="translated">최신 패키지를 검색할 때 주 버전 번호가 일치하는 패키지만 고려합니다. '--outdated' 또는 '--deprecated' 옵션이 필요합니다.</target>
+        <source>Consider only the packages with a matching major version number when searching for newer packages. Requires the '--outdated' option.</source>
+        <target state="needs-review-translation">최신 패키지를 검색할 때 주 버전 번호가 일치하는 패키지만 고려합니다. '--outdated' 또는 '--deprecated' 옵션이 필요합니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdHighestPatchDescription">
-        <source>Consider only the packages with a matching major and minor version numbers when searching for newer packages. Requires the '--outdated' or '--deprecated' option.</source>
-        <target state="translated">최신 패키지를 검색할 때 주 버전 번호와 부 버전 번호가 일치하는 패키지만 고려합니다. '--outdated' 또는 '--deprecated' 옵션이 필요합니다.</target>
+        <source>Consider only the packages with a matching major and minor version numbers when searching for newer packages. Requires the '--outdated' option.</source>
+        <target state="needs-review-translation">최신 패키지를 검색할 때 주 버전 번호와 부 버전 번호가 일치하는 패키지만 고려합니다. '--outdated' 또는 '--deprecated' 옵션이 필요합니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdPrereleaseDescription">
-        <source>Consider packages with prerelease versions when searching for newer packages. Requires the '--outdated' or '--deprecated' option.</source>
-        <target state="translated">최신 패키지를 검색할 때 시험판 버전이 있는 패키지를 고려합니다. '--outdated' 또는 '--deprecated' 옵션이 필요합니다.</target>
+        <source>Consider packages with prerelease versions when searching for newer packages. Requires the '--outdated' option.</source>
+        <target state="needs-review-translation">최신 패키지를 검색할 때 시험판 버전이 있는 패키지를 고려합니다. '--outdated' 또는 '--deprecated' 옵션이 필요합니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdSource">
@@ -68,13 +73,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdSourceDescription">
-        <source>The NuGet sources to use when searching for newer packages. Requires the '--outdated' or '--deprecated' option.</source>
-        <target state="translated">최신 패키지를 검색할 때 사용하는 NuGet 소스입니다. '--outdated' 또는 '--deprecated' 옵션이 필요합니다.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="OutdatedAndDeprecatedOptionsCannotBeCombined">
-        <source>Option '--outdated' and '--deprecated' cannot be combined.</source>
-        <target state="translated">'--outdated'와 '--deprecated' 옵션은 함께 사용할 수 없습니다.</target>
+        <source>The NuGet sources to use when searching for newer packages. Requires the '--outdated', '--deprecated' or '--vulnerable' option.</source>
+        <target state="needs-review-translation">최신 패키지를 검색할 때 사용하는 NuGet 소스입니다. '--outdated' 또는 '--deprecated' 옵션이 필요합니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="FileNotFound">
@@ -82,9 +82,9 @@
         <target state="translated">'{0}' 파일 또는 디렉터리를 찾을 수 없습니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="OutdatedOrDeprecatedOptionOnly">
-        <source>Option '{0}' requires the '--outdated' or '--deprecated' option to be specified.</source>
-        <target state="translated">'{0}' 옵션을 사용하려면 '--outdated' 또는 '--deprecated' 옵션을 지정해야 합니다.</target>
+      <trans-unit id="OptionsCannotBeCombined">
+        <source>Options '--outdated', '--deprecated' and '--vulnerable' cannot be combined.</source>
+        <target state="new">Options '--outdated', '--deprecated' and '--vulnerable' cannot be combined.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.pl.xlf
+++ b/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.pl.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdDeprecatedDescription">
-        <source>Lists packages that have been deprecated.</source>
-        <target state="translated">Wyświetla pakiety, które są przestarzałe.</target>
+        <source>Lists packages that have been deprecated. Cannot be combined with '--vulnerable' or '--outdated' options.</source>
+        <target state="needs-review-translation">Wyświetla pakiety, które są przestarzałe.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdFramework">
@@ -23,13 +23,18 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdOutdatedDescription">
-        <source>Lists packages that have newer versions.</source>
-        <target state="translated">Zwraca listę pakietów, które mają nowsze wersje.</target>
+        <source>Lists packages that have newer versions. Cannot be combined with '--deprecated' or '--vulnerable' options.</source>
+        <target state="needs-review-translation">Zwraca listę pakietów, które mają nowsze wersje.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdTransitiveDescription">
         <source>Lists transitive and top-level packages.</source>
         <target state="translated">Zwraca listę pakietów przejściowych i pakietów najwyższego poziomu.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdVulnerableDescription">
+        <source>Lists packages that have known vulnerabilities. Cannot be combined with '--deprecated' or '--outdated' options.</source>
+        <target state="new">Lists packages that have known vulnerabilities. Cannot be combined with '--deprecated' or '--outdated' options.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoProjectsOrSolutions">
@@ -43,23 +48,23 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdConfigDescription">
-        <source>The path to the NuGet config file to use. Requires the '--outdated' or '--deprecated' option.</source>
-        <target state="translated">Ścieżka do pliku konfiguracji NuGet, który ma być używany. Wymaga opcji „--outdated” lub „--deprecated”.</target>
+        <source>The path to the NuGet config file to use. Requires the '--outdated', '--deprecated' or '--vulnerable' option.</source>
+        <target state="needs-review-translation">Ścieżka do pliku konfiguracji NuGet, który ma być używany. Wymaga opcji „--outdated” lub „--deprecated”.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdHighestMinorDescription">
-        <source>Consider only the packages with a matching major version number when searching for newer packages. Requires the '--outdated' or '--deprecated' option.</source>
-        <target state="translated">Podczas wyszukiwania nowszych pakietów uwzględniaj tylko pakiety ze zgodnym numerem wersji głównej. Wymaga opcji „--outdated” lub „--deprecated”.</target>
+        <source>Consider only the packages with a matching major version number when searching for newer packages. Requires the '--outdated' option.</source>
+        <target state="needs-review-translation">Podczas wyszukiwania nowszych pakietów uwzględniaj tylko pakiety ze zgodnym numerem wersji głównej. Wymaga opcji „--outdated” lub „--deprecated”.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdHighestPatchDescription">
-        <source>Consider only the packages with a matching major and minor version numbers when searching for newer packages. Requires the '--outdated' or '--deprecated' option.</source>
-        <target state="translated">Podczas wyszukiwania nowszych pakietów uwzględniaj tylko pakiety ze zgodnym numerem wersji głównej i pomocniczej. Wymaga opcji „--outdated” lub „--deprecated”.</target>
+        <source>Consider only the packages with a matching major and minor version numbers when searching for newer packages. Requires the '--outdated' option.</source>
+        <target state="needs-review-translation">Podczas wyszukiwania nowszych pakietów uwzględniaj tylko pakiety ze zgodnym numerem wersji głównej i pomocniczej. Wymaga opcji „--outdated” lub „--deprecated”.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdPrereleaseDescription">
-        <source>Consider packages with prerelease versions when searching for newer packages. Requires the '--outdated' or '--deprecated' option.</source>
-        <target state="translated">Podczas wyszukiwania nowszych pakietów uwzględniaj pakiety z wersjami wstępnymi. Wymaga opcji „--outdated” lub „--deprecated”.</target>
+        <source>Consider packages with prerelease versions when searching for newer packages. Requires the '--outdated' option.</source>
+        <target state="needs-review-translation">Podczas wyszukiwania nowszych pakietów uwzględniaj pakiety z wersjami wstępnymi. Wymaga opcji „--outdated” lub „--deprecated”.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdSource">
@@ -68,13 +73,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdSourceDescription">
-        <source>The NuGet sources to use when searching for newer packages. Requires the '--outdated' or '--deprecated' option.</source>
-        <target state="translated">Źródła NuGet do użycia podczas wyszukiwania nowszych pakietów. Wymaga opcji „--outdated” lub „--deprecated”.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="OutdatedAndDeprecatedOptionsCannotBeCombined">
-        <source>Option '--outdated' and '--deprecated' cannot be combined.</source>
-        <target state="translated">Nie można łączyć opcji „--outdated” i „--deprecated”.</target>
+        <source>The NuGet sources to use when searching for newer packages. Requires the '--outdated', '--deprecated' or '--vulnerable' option.</source>
+        <target state="needs-review-translation">Źródła NuGet do użycia podczas wyszukiwania nowszych pakietów. Wymaga opcji „--outdated” lub „--deprecated”.</target>
         <note />
       </trans-unit>
       <trans-unit id="FileNotFound">
@@ -82,9 +82,9 @@
         <target state="translated">Nie można odnaleźć pliku lub katalogu „{0}”.</target>
         <note />
       </trans-unit>
-      <trans-unit id="OutdatedOrDeprecatedOptionOnly">
-        <source>Option '{0}' requires the '--outdated' or '--deprecated' option to be specified.</source>
-        <target state="translated">Opcja „{0}” wymaga określenia opcji „--outdated” lub „--deprecated”.</target>
+      <trans-unit id="OptionsCannotBeCombined">
+        <source>Options '--outdated', '--deprecated' and '--vulnerable' cannot be combined.</source>
+        <target state="new">Options '--outdated', '--deprecated' and '--vulnerable' cannot be combined.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.pt-BR.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdDeprecatedDescription">
-        <source>Lists packages that have been deprecated.</source>
-        <target state="translated">Lista pacotes que foram preteridos.</target>
+        <source>Lists packages that have been deprecated. Cannot be combined with '--vulnerable' or '--outdated' options.</source>
+        <target state="needs-review-translation">Lista pacotes que foram preteridos.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdFramework">
@@ -23,13 +23,18 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdOutdatedDescription">
-        <source>Lists packages that have newer versions.</source>
-        <target state="translated">Lista os pacotes que têm as versões mais recentes.</target>
+        <source>Lists packages that have newer versions. Cannot be combined with '--deprecated' or '--vulnerable' options.</source>
+        <target state="needs-review-translation">Lista os pacotes que têm as versões mais recentes.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdTransitiveDescription">
         <source>Lists transitive and top-level packages.</source>
         <target state="translated">Lista os pacotes de nível superior e transitivos.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdVulnerableDescription">
+        <source>Lists packages that have known vulnerabilities. Cannot be combined with '--deprecated' or '--outdated' options.</source>
+        <target state="new">Lists packages that have known vulnerabilities. Cannot be combined with '--deprecated' or '--outdated' options.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoProjectsOrSolutions">
@@ -43,23 +48,23 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdConfigDescription">
-        <source>The path to the NuGet config file to use. Requires the '--outdated' or '--deprecated' option.</source>
-        <target state="translated">O caminho para o arquivo de configuração do NuGet a ser usado. Exige a opção '--outdated' ou '--deprecated'.</target>
+        <source>The path to the NuGet config file to use. Requires the '--outdated', '--deprecated' or '--vulnerable' option.</source>
+        <target state="needs-review-translation">O caminho para o arquivo de configuração do NuGet a ser usado. Exige a opção '--outdated' ou '--deprecated'.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdHighestMinorDescription">
-        <source>Consider only the packages with a matching major version number when searching for newer packages. Requires the '--outdated' or '--deprecated' option.</source>
-        <target state="translated">Ao procurar pacotes mais novos, considere apenas os pacotes com número de versão principal correspondente. Exige a opção '--outdated' ou '--deprecated'.</target>
+        <source>Consider only the packages with a matching major version number when searching for newer packages. Requires the '--outdated' option.</source>
+        <target state="needs-review-translation">Ao procurar pacotes mais novos, considere apenas os pacotes com número de versão principal correspondente. Exige a opção '--outdated' ou '--deprecated'.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdHighestPatchDescription">
-        <source>Consider only the packages with a matching major and minor version numbers when searching for newer packages. Requires the '--outdated' or '--deprecated' option.</source>
-        <target state="translated">Ao procurar pacotes mais novos, considere apenas os pacotes com números de versão principal e secundária correspondentes. Exige a opção '--outdated' ou '--deprecated'.</target>
+        <source>Consider only the packages with a matching major and minor version numbers when searching for newer packages. Requires the '--outdated' option.</source>
+        <target state="needs-review-translation">Ao procurar pacotes mais novos, considere apenas os pacotes com números de versão principal e secundária correspondentes. Exige a opção '--outdated' ou '--deprecated'.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdPrereleaseDescription">
-        <source>Consider packages with prerelease versions when searching for newer packages. Requires the '--outdated' or '--deprecated' option.</source>
-        <target state="translated">Ao procurar pacotes mais novos, considere pacotes com versões de pré-lançamento. Exige a opção '--outdated' ou '--deprecated'.</target>
+        <source>Consider packages with prerelease versions when searching for newer packages. Requires the '--outdated' option.</source>
+        <target state="needs-review-translation">Ao procurar pacotes mais novos, considere pacotes com versões de pré-lançamento. Exige a opção '--outdated' ou '--deprecated'.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdSource">
@@ -68,13 +73,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdSourceDescription">
-        <source>The NuGet sources to use when searching for newer packages. Requires the '--outdated' or '--deprecated' option.</source>
-        <target state="translated">As fontes do NuGet a serem usadas ao procurar pacotes mais novos. Exige a opção '--outdated' ou '--deprecated'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="OutdatedAndDeprecatedOptionsCannotBeCombined">
-        <source>Option '--outdated' and '--deprecated' cannot be combined.</source>
-        <target state="translated">As opções '--outdated' e '--deprecated' não podem ser combinadas.</target>
+        <source>The NuGet sources to use when searching for newer packages. Requires the '--outdated', '--deprecated' or '--vulnerable' option.</source>
+        <target state="needs-review-translation">As fontes do NuGet a serem usadas ao procurar pacotes mais novos. Exige a opção '--outdated' ou '--deprecated'.</target>
         <note />
       </trans-unit>
       <trans-unit id="FileNotFound">
@@ -82,9 +82,9 @@
         <target state="translated">Não foi possível encontrar o arquivo ou o diretório '{0}'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="OutdatedOrDeprecatedOptionOnly">
-        <source>Option '{0}' requires the '--outdated' or '--deprecated' option to be specified.</source>
-        <target state="translated">A opção '{0}' exige que a opção '--outdated' ou '--deprecated' seja especificada.</target>
+      <trans-unit id="OptionsCannotBeCombined">
+        <source>Options '--outdated', '--deprecated' and '--vulnerable' cannot be combined.</source>
+        <target state="new">Options '--outdated', '--deprecated' and '--vulnerable' cannot be combined.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.ru.xlf
+++ b/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.ru.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdDeprecatedDescription">
-        <source>Lists packages that have been deprecated.</source>
-        <target state="translated">Список нерекомендуемых пакетов.</target>
+        <source>Lists packages that have been deprecated. Cannot be combined with '--vulnerable' or '--outdated' options.</source>
+        <target state="needs-review-translation">Список нерекомендуемых пакетов.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdFramework">
@@ -23,13 +23,18 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdOutdatedDescription">
-        <source>Lists packages that have newer versions.</source>
-        <target state="translated">Список пакетов, для которых обнаружены более новые версии.</target>
+        <source>Lists packages that have newer versions. Cannot be combined with '--deprecated' or '--vulnerable' options.</source>
+        <target state="needs-review-translation">Список пакетов, для которых обнаружены более новые версии.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdTransitiveDescription">
         <source>Lists transitive and top-level packages.</source>
         <target state="translated">Список транзитивных пакетов и пакетов верхнего уровня.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdVulnerableDescription">
+        <source>Lists packages that have known vulnerabilities. Cannot be combined with '--deprecated' or '--outdated' options.</source>
+        <target state="new">Lists packages that have known vulnerabilities. Cannot be combined with '--deprecated' or '--outdated' options.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoProjectsOrSolutions">
@@ -43,23 +48,23 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdConfigDescription">
-        <source>The path to the NuGet config file to use. Requires the '--outdated' or '--deprecated' option.</source>
-        <target state="translated">Путь к используемому файлу конфигурации NuGet. Требуется указать параметр "--outdated" или "--deprecated".</target>
+        <source>The path to the NuGet config file to use. Requires the '--outdated', '--deprecated' or '--vulnerable' option.</source>
+        <target state="needs-review-translation">Путь к используемому файлу конфигурации NuGet. Требуется указать параметр "--outdated" или "--deprecated".</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdHighestMinorDescription">
-        <source>Consider only the packages with a matching major version number when searching for newer packages. Requires the '--outdated' or '--deprecated' option.</source>
-        <target state="translated">Учитывать только пакеты с соответствующим основным номером версии при поиске более новых версий пакетов. Требуется указать параметр "--outdated" или "--deprecated".</target>
+        <source>Consider only the packages with a matching major version number when searching for newer packages. Requires the '--outdated' option.</source>
+        <target state="needs-review-translation">Учитывать только пакеты с соответствующим основным номером версии при поиске более новых версий пакетов. Требуется указать параметр "--outdated" или "--deprecated".</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdHighestPatchDescription">
-        <source>Consider only the packages with a matching major and minor version numbers when searching for newer packages. Requires the '--outdated' or '--deprecated' option.</source>
-        <target state="translated">Учитывать только пакеты с соответствующими основным и дополнительным номерами версий при поиске более новых версий пакетов. Требуется указать параметр "--outdated" или "--deprecated".</target>
+        <source>Consider only the packages with a matching major and minor version numbers when searching for newer packages. Requires the '--outdated' option.</source>
+        <target state="needs-review-translation">Учитывать только пакеты с соответствующими основным и дополнительным номерами версий при поиске более новых версий пакетов. Требуется указать параметр "--outdated" или "--deprecated".</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdPrereleaseDescription">
-        <source>Consider packages with prerelease versions when searching for newer packages. Requires the '--outdated' or '--deprecated' option.</source>
-        <target state="translated">Учитывать пакеты с версиями предварительных выпусков при поиске более новых версий пакетов. Требуется указать параметр "--outdated" или "--deprecated".</target>
+        <source>Consider packages with prerelease versions when searching for newer packages. Requires the '--outdated' option.</source>
+        <target state="needs-review-translation">Учитывать пакеты с версиями предварительных выпусков при поиске более новых версий пакетов. Требуется указать параметр "--outdated" или "--deprecated".</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdSource">
@@ -68,13 +73,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdSourceDescription">
-        <source>The NuGet sources to use when searching for newer packages. Requires the '--outdated' or '--deprecated' option.</source>
-        <target state="translated">Источники NuGet, используемые при поиске более новых версий пакетов. Требуется указать параметр "--outdated" или "--deprecated".</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="OutdatedAndDeprecatedOptionsCannotBeCombined">
-        <source>Option '--outdated' and '--deprecated' cannot be combined.</source>
-        <target state="translated">Параметры "--outdated" и "--deprecated" не могут использоваться вместе.</target>
+        <source>The NuGet sources to use when searching for newer packages. Requires the '--outdated', '--deprecated' or '--vulnerable' option.</source>
+        <target state="needs-review-translation">Источники NuGet, используемые при поиске более новых версий пакетов. Требуется указать параметр "--outdated" или "--deprecated".</target>
         <note />
       </trans-unit>
       <trans-unit id="FileNotFound">
@@ -82,9 +82,9 @@
         <target state="translated">Не удалось найти файл или каталог "{0}".</target>
         <note />
       </trans-unit>
-      <trans-unit id="OutdatedOrDeprecatedOptionOnly">
-        <source>Option '{0}' requires the '--outdated' or '--deprecated' option to be specified.</source>
-        <target state="translated">Для параметра "{0}" необходимо указать параметр "--outdated" или "--deprecated".</target>
+      <trans-unit id="OptionsCannotBeCombined">
+        <source>Options '--outdated', '--deprecated' and '--vulnerable' cannot be combined.</source>
+        <target state="new">Options '--outdated', '--deprecated' and '--vulnerable' cannot be combined.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.tr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.tr.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdDeprecatedDescription">
-        <source>Lists packages that have been deprecated.</source>
-        <target state="translated">Kullanım dışı bırakılan paketleri listeler.</target>
+        <source>Lists packages that have been deprecated. Cannot be combined with '--vulnerable' or '--outdated' options.</source>
+        <target state="needs-review-translation">Kullanım dışı bırakılan paketleri listeler.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdFramework">
@@ -23,13 +23,18 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdOutdatedDescription">
-        <source>Lists packages that have newer versions.</source>
-        <target state="translated">Daha yeni sürümleri olan paketleri listeler.</target>
+        <source>Lists packages that have newer versions. Cannot be combined with '--deprecated' or '--vulnerable' options.</source>
+        <target state="needs-review-translation">Daha yeni sürümleri olan paketleri listeler.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdTransitiveDescription">
         <source>Lists transitive and top-level packages.</source>
         <target state="translated">Geçişli ve üst düzey paketleri listeler.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdVulnerableDescription">
+        <source>Lists packages that have known vulnerabilities. Cannot be combined with '--deprecated' or '--outdated' options.</source>
+        <target state="new">Lists packages that have known vulnerabilities. Cannot be combined with '--deprecated' or '--outdated' options.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoProjectsOrSolutions">
@@ -43,23 +48,23 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdConfigDescription">
-        <source>The path to the NuGet config file to use. Requires the '--outdated' or '--deprecated' option.</source>
-        <target state="translated">Kullanılacak NuGet yapılandırma dosyasının yolu. '--outdated' veya '--deprecated' seçeneğini gerektirir.</target>
+        <source>The path to the NuGet config file to use. Requires the '--outdated', '--deprecated' or '--vulnerable' option.</source>
+        <target state="needs-review-translation">Kullanılacak NuGet yapılandırma dosyasının yolu. '--outdated' veya '--deprecated' seçeneğini gerektirir.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdHighestMinorDescription">
-        <source>Consider only the packages with a matching major version number when searching for newer packages. Requires the '--outdated' or '--deprecated' option.</source>
-        <target state="translated">Daha yeni paketler aranırken yalnızca eşleşen birincil sürüm numarasına sahip paketleri göz önünde bulundurun. '--outdated' veya '--deprecated' seçeneğini gerektirir.</target>
+        <source>Consider only the packages with a matching major version number when searching for newer packages. Requires the '--outdated' option.</source>
+        <target state="needs-review-translation">Daha yeni paketler aranırken yalnızca eşleşen birincil sürüm numarasına sahip paketleri göz önünde bulundurun. '--outdated' veya '--deprecated' seçeneğini gerektirir.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdHighestPatchDescription">
-        <source>Consider only the packages with a matching major and minor version numbers when searching for newer packages. Requires the '--outdated' or '--deprecated' option.</source>
-        <target state="translated">Daha yeni paketler aranırken yalnızca eşleşen birincil ve ikincil sürüm numaralarına sahip paketleri değerlendirin. '--outdated' veya '--deprecated' seçeneğini gerektirir.</target>
+        <source>Consider only the packages with a matching major and minor version numbers when searching for newer packages. Requires the '--outdated' option.</source>
+        <target state="needs-review-translation">Daha yeni paketler aranırken yalnızca eşleşen birincil ve ikincil sürüm numaralarına sahip paketleri değerlendirin. '--outdated' veya '--deprecated' seçeneğini gerektirir.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdPrereleaseDescription">
-        <source>Consider packages with prerelease versions when searching for newer packages. Requires the '--outdated' or '--deprecated' option.</source>
-        <target state="translated">Daha yeni paketleri ararken yayın öncesi sürümlere sahip olan paketleri göz önünde bulundurun. '--outdated' veya '--deprecated' seçeneğini gerektirir.</target>
+        <source>Consider packages with prerelease versions when searching for newer packages. Requires the '--outdated' option.</source>
+        <target state="needs-review-translation">Daha yeni paketleri ararken yayın öncesi sürümlere sahip olan paketleri göz önünde bulundurun. '--outdated' veya '--deprecated' seçeneğini gerektirir.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdSource">
@@ -68,13 +73,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdSourceDescription">
-        <source>The NuGet sources to use when searching for newer packages. Requires the '--outdated' or '--deprecated' option.</source>
-        <target state="translated">Daha yeni paketler aranırken kullanılacak NuGet kaynakları. '--outdated' veya '--deprecated' seçeneğini gerektirir.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="OutdatedAndDeprecatedOptionsCannotBeCombined">
-        <source>Option '--outdated' and '--deprecated' cannot be combined.</source>
-        <target state="translated">'--outdated' ve '--deprecated' seçeneği birleştirilemez.</target>
+        <source>The NuGet sources to use when searching for newer packages. Requires the '--outdated', '--deprecated' or '--vulnerable' option.</source>
+        <target state="needs-review-translation">Daha yeni paketler aranırken kullanılacak NuGet kaynakları. '--outdated' veya '--deprecated' seçeneğini gerektirir.</target>
         <note />
       </trans-unit>
       <trans-unit id="FileNotFound">
@@ -82,9 +82,9 @@
         <target state="translated">'{0}' dosyası veya dizini bulunamadı.</target>
         <note />
       </trans-unit>
-      <trans-unit id="OutdatedOrDeprecatedOptionOnly">
-        <source>Option '{0}' requires the '--outdated' or '--deprecated' option to be specified.</source>
-        <target state="translated">'{0}' seçeneği '--outdated' veya '--deprecated' seçeneğinin belirtilmesini gerektirir.</target>
+      <trans-unit id="OptionsCannotBeCombined">
+        <source>Options '--outdated', '--deprecated' and '--vulnerable' cannot be combined.</source>
+        <target state="new">Options '--outdated', '--deprecated' and '--vulnerable' cannot be combined.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.zh-Hans.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdDeprecatedDescription">
-        <source>Lists packages that have been deprecated.</source>
-        <target state="translated">列出已弃用的包。</target>
+        <source>Lists packages that have been deprecated. Cannot be combined with '--vulnerable' or '--outdated' options.</source>
+        <target state="needs-review-translation">列出已弃用的包。</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdFramework">
@@ -23,13 +23,18 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdOutdatedDescription">
-        <source>Lists packages that have newer versions.</source>
-        <target state="translated">列出具有较新版本的包。</target>
+        <source>Lists packages that have newer versions. Cannot be combined with '--deprecated' or '--vulnerable' options.</source>
+        <target state="needs-review-translation">列出具有较新版本的包。</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdTransitiveDescription">
         <source>Lists transitive and top-level packages.</source>
         <target state="translated">列出可传递的包和顶级包。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdVulnerableDescription">
+        <source>Lists packages that have known vulnerabilities. Cannot be combined with '--deprecated' or '--outdated' options.</source>
+        <target state="new">Lists packages that have known vulnerabilities. Cannot be combined with '--deprecated' or '--outdated' options.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoProjectsOrSolutions">
@@ -43,23 +48,23 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdConfigDescription">
-        <source>The path to the NuGet config file to use. Requires the '--outdated' or '--deprecated' option.</source>
-        <target state="translated">要使用的 NuGet 配置文件的路径。需要 "--outdated" 或 "--deprecated" 选项。</target>
+        <source>The path to the NuGet config file to use. Requires the '--outdated', '--deprecated' or '--vulnerable' option.</source>
+        <target state="needs-review-translation">要使用的 NuGet 配置文件的路径。需要 "--outdated" 或 "--deprecated" 选项。</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdHighestMinorDescription">
-        <source>Consider only the packages with a matching major version number when searching for newer packages. Requires the '--outdated' or '--deprecated' option.</source>
-        <target state="translated">在搜索较新的包时，仅考虑具有匹配的主版本号的包。需要 "--outdated" 或 "--deprecated" 选项。</target>
+        <source>Consider only the packages with a matching major version number when searching for newer packages. Requires the '--outdated' option.</source>
+        <target state="needs-review-translation">在搜索较新的包时，仅考虑具有匹配的主版本号的包。需要 "--outdated" 或 "--deprecated" 选项。</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdHighestPatchDescription">
-        <source>Consider only the packages with a matching major and minor version numbers when searching for newer packages. Requires the '--outdated' or '--deprecated' option.</source>
-        <target state="translated">在搜索较新的包时，仅考虑具有匹配的主要和次要版本号的包。需要 "--outdated" 或 "--deprecated" 选项。</target>
+        <source>Consider only the packages with a matching major and minor version numbers when searching for newer packages. Requires the '--outdated' option.</source>
+        <target state="needs-review-translation">在搜索较新的包时，仅考虑具有匹配的主要和次要版本号的包。需要 "--outdated" 或 "--deprecated" 选项。</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdPrereleaseDescription">
-        <source>Consider packages with prerelease versions when searching for newer packages. Requires the '--outdated' or '--deprecated' option.</source>
-        <target state="translated">在搜索较新的包时，请考虑使用具有预发行版本的包。需要 "--outdated" 或 "--deprecated" 选项。</target>
+        <source>Consider packages with prerelease versions when searching for newer packages. Requires the '--outdated' option.</source>
+        <target state="needs-review-translation">在搜索较新的包时，请考虑使用具有预发行版本的包。需要 "--outdated" 或 "--deprecated" 选项。</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdSource">
@@ -68,13 +73,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdSourceDescription">
-        <source>The NuGet sources to use when searching for newer packages. Requires the '--outdated' or '--deprecated' option.</source>
-        <target state="translated">搜索较新的包时要使用的 NuGet 源。需要 "--outdated" 或 "--deprecated" 选项。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="OutdatedAndDeprecatedOptionsCannotBeCombined">
-        <source>Option '--outdated' and '--deprecated' cannot be combined.</source>
-        <target state="translated">不可结合使用 "--outdated" 或 "--deprecated"。</target>
+        <source>The NuGet sources to use when searching for newer packages. Requires the '--outdated', '--deprecated' or '--vulnerable' option.</source>
+        <target state="needs-review-translation">搜索较新的包时要使用的 NuGet 源。需要 "--outdated" 或 "--deprecated" 选项。</target>
         <note />
       </trans-unit>
       <trans-unit id="FileNotFound">
@@ -82,9 +82,9 @@
         <target state="translated">找不到文件或目录“{0}”。</target>
         <note />
       </trans-unit>
-      <trans-unit id="OutdatedOrDeprecatedOptionOnly">
-        <source>Option '{0}' requires the '--outdated' or '--deprecated' option to be specified.</source>
-        <target state="translated">选项“{0}”要求指定 "--outdated" 或 "--deprecated" 选项。</target>
+      <trans-unit id="OptionsCannotBeCombined">
+        <source>Options '--outdated', '--deprecated' and '--vulnerable' cannot be combined.</source>
+        <target state="new">Options '--outdated', '--deprecated' and '--vulnerable' cannot be combined.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.zh-Hant.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdDeprecatedDescription">
-        <source>Lists packages that have been deprecated.</source>
-        <target state="translated">列出已取代的套件。</target>
+        <source>Lists packages that have been deprecated. Cannot be combined with '--vulnerable' or '--outdated' options.</source>
+        <target state="needs-review-translation">列出已取代的套件。</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdFramework">
@@ -23,13 +23,18 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdOutdatedDescription">
-        <source>Lists packages that have newer versions.</source>
-        <target state="translated">列出有較新版本的套件。</target>
+        <source>Lists packages that have newer versions. Cannot be combined with '--deprecated' or '--vulnerable' options.</source>
+        <target state="needs-review-translation">列出有較新版本的套件。</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdTransitiveDescription">
         <source>Lists transitive and top-level packages.</source>
         <target state="translated">列出可轉移和頂層套件。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdVulnerableDescription">
+        <source>Lists packages that have known vulnerabilities. Cannot be combined with '--deprecated' or '--outdated' options.</source>
+        <target state="new">Lists packages that have known vulnerabilities. Cannot be combined with '--deprecated' or '--outdated' options.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoProjectsOrSolutions">
@@ -43,23 +48,23 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdConfigDescription">
-        <source>The path to the NuGet config file to use. Requires the '--outdated' or '--deprecated' option.</source>
-        <target state="translated">要使用的 NuGet 組態檔路徑。需要使用 '--outdated’ 或 '--deprecated' 選項。</target>
+        <source>The path to the NuGet config file to use. Requires the '--outdated', '--deprecated' or '--vulnerable' option.</source>
+        <target state="needs-review-translation">要使用的 NuGet 組態檔路徑。需要使用 '--outdated’ 或 '--deprecated' 選項。</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdHighestMinorDescription">
-        <source>Consider only the packages with a matching major version number when searching for newer packages. Requires the '--outdated' or '--deprecated' option.</source>
-        <target state="translated">在搜尋較新的套件時，建議只搜尋主要版本號碼相符的套件。需要使用 '--outdated' 或 '--deprecated' 選項。</target>
+        <source>Consider only the packages with a matching major version number when searching for newer packages. Requires the '--outdated' option.</source>
+        <target state="needs-review-translation">在搜尋較新的套件時，建議只搜尋主要版本號碼相符的套件。需要使用 '--outdated' 或 '--deprecated' 選項。</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdHighestPatchDescription">
-        <source>Consider only the packages with a matching major and minor version numbers when searching for newer packages. Requires the '--outdated' or '--deprecated' option.</source>
-        <target state="translated">在搜尋較新的套件時，建議只搜尋主要和次要版本號碼相符的套件。需要使用 '--outdated’ 或 '--deprecated' 選項。</target>
+        <source>Consider only the packages with a matching major and minor version numbers when searching for newer packages. Requires the '--outdated' option.</source>
+        <target state="needs-review-translation">在搜尋較新的套件時，建議只搜尋主要和次要版本號碼相符的套件。需要使用 '--outdated’ 或 '--deprecated' 選項。</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdPrereleaseDescription">
-        <source>Consider packages with prerelease versions when searching for newer packages. Requires the '--outdated' or '--deprecated' option.</source>
-        <target state="translated">在搜尋較新的套件時，建議搜尋具有發行前版本的套件。需要使用 '--outdated' 或 '--deprecated' 選項。</target>
+        <source>Consider packages with prerelease versions when searching for newer packages. Requires the '--outdated' option.</source>
+        <target state="needs-review-translation">在搜尋較新的套件時，建議搜尋具有發行前版本的套件。需要使用 '--outdated' 或 '--deprecated' 選項。</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdSource">
@@ -68,13 +73,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdSourceDescription">
-        <source>The NuGet sources to use when searching for newer packages. Requires the '--outdated' or '--deprecated' option.</source>
-        <target state="translated">搜尋較新套件時要使用的 NuGet 來源。需要使用 '--outdated' 或 '--deprecated' 選項。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="OutdatedAndDeprecatedOptionsCannotBeCombined">
-        <source>Option '--outdated' and '--deprecated' cannot be combined.</source>
-        <target state="translated">無法結合選項 '--outdated' 和 '--deprecated'。</target>
+        <source>The NuGet sources to use when searching for newer packages. Requires the '--outdated', '--deprecated' or '--vulnerable' option.</source>
+        <target state="needs-review-translation">搜尋較新套件時要使用的 NuGet 來源。需要使用 '--outdated' 或 '--deprecated' 選項。</target>
         <note />
       </trans-unit>
       <trans-unit id="FileNotFound">
@@ -82,9 +82,9 @@
         <target state="translated">找不到檔案或目錄 ‘{0}’。</target>
         <note />
       </trans-unit>
-      <trans-unit id="OutdatedOrDeprecatedOptionOnly">
-        <source>Option '{0}' requires the '--outdated' or '--deprecated' option to be specified.</source>
-        <target state="translated">選項 '{0}' 需要指定 '--outdated' 或 '--deprecated' 選項。</target>
+      <trans-unit id="OptionsCannotBeCombined">
+        <source>Options '--outdated', '--deprecated' and '--vulnerable' cannot be combined.</source>
+        <target state="new">Options '--outdated', '--deprecated' and '--vulnerable' cannot be combined.</target>
         <note />
       </trans-unit>
     </body>


### PR DESCRIPTION
This is a cherry-pick of the commit from https://github.com/dotnet/sdk/pull/13318 into release/5.0.2xx. Details copied below:

Added `--vulnerable` option to `dotnet list package` CLI. Also removed most of the "policing" around other option combinations:
- `--include-prerelease`, `--highest-minor`, and `highest-patch` are only supposed to be used in combination with the `--outdated` option, but they're just ignored by the NuGet Xplat CLI otherwise, and we'll do the same here.
- `--config` and `--source` are only supposed to be used in combination with `--vulnerable`, `--outdated` and `--deprecated` reports, but they're also just ignored by the NuGet Xplat CLI, so we'll ignore them here.
- `--vulnerable`, `--outdated` and `--deprecated` all must be used mutually exclusively, and combining them is nonsense--we throw in the NuGet Xplat CLI in this case, and we'll continue to throw here.