### PR TITLE
Add CPD for mono/linker

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -85,7 +85,7 @@
       <Uri>https://github.com/microsoft/vstest</Uri>
       <Sha>81d3148c7cd588c84a9e6cadbd7e04189127d4c9</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.ILLink.Tasks" Version="6.0.0-alpha.1.20527.2">
+    <Dependency Name="Microsoft.NET.ILLink.Tasks" Version="6.0.0-alpha.1.20527.2" CoherentParentDependency="Microsoft.NETCore.App.Internal">
       <Uri>https://github.com/mono/linker</Uri>
       <Sha>57974c1f5790e6fb33f5fce161707be5cd86c4d3</Sha>
     </Dependency>


### PR DESCRIPTION
This is also used in runtime so no need to let them diverge