### PR TITLE
Fix WebSdk packages

### DIFF
--- a/src/WebSdk/CopyPackageLayout.targets
+++ b/src/WebSdk/CopyPackageLayout.targets
@@ -2,12 +2,12 @@
 
 <Target Name="PrepareAdditionalFilesToLayout" BeforeTargets="AssignTargetPaths">
   <ItemGroup>
-    <LayoutFile Include="@(Content)" Condition="'%(Content.PackagePath)' != '' and '%(Content.PackagePath)' != 'Icon.png' and '%(Content.PackagePath)' != 'analyzers/cs'">
-      <TargetPath>%(Content.PackagePath)\%(Content.RecursiveDir)%(Content.Filename)%(Content.Extension)</TargetPath>
+    <LayoutFile Include="@(AdditionalContent)" Condition="'%(AdditionalContent.PackagePath)' != '' and '%(AdditionalContent.PackagePath)' != 'Icon.png' and '%(AdditionalContent.PackagePath)' != 'analyzers/cs'">
+      <TargetPath>%(AdditionalContent.PackagePath)\%(AdditionalContent.RecursiveDir)%(AdditionalContent.Filename)%(AdditionalContent.Extension)</TargetPath>
     </LayoutFile>
     <!-- Analyzers needs to be copied to the root -->
-    <LayoutFile Include="@(Content)" Condition="'%(Content.PackagePath)' != '' and '%(Content.PackagePath)' != 'Icon.png' and '%(Content.PackagePath)' == 'analyzers/cs'">
-      <TargetPath>%(Content.PackagePath)\%(Content.Filename)%(Content.Extension)</TargetPath>
+    <LayoutFile Include="@(AdditionalContent)" Condition="'%(AdditionalContent.PackagePath)' != '' and '%(AdditionalContent.PackagePath)' != 'Icon.png' and '%(AdditionalContent.PackagePath)' == 'analyzers/cs'">
+      <TargetPath>%(AdditionalContent.PackagePath)\%(AdditionalContent.Filename)%(AdditionalContent.Extension)</TargetPath>
     </LayoutFile>
   </ItemGroup>
 </Target>

--- a/src/WebSdk/ProjectSystem/Tasks/Microsoft.NET.Sdk.Web.ProjectSystem.Tasks.csproj
+++ b/src/WebSdk/ProjectSystem/Tasks/Microsoft.NET.Sdk.Web.ProjectSystem.Tasks.csproj
@@ -13,15 +13,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Content Include="$(ProjectSystemRoot)\Targets\**\*.*">
+    <AdditionalContent Include="$(ProjectSystemRoot)\Targets\**\*.*">
       <Pack>true</Pack>
       <PackagePath>targets</PackagePath>
-    </Content>
+    </AdditionalContent>
 
-    <Content Include="$(ProjectSystemRoot)\Sdk\**\*.*">
+    <AdditionalContent Include="$(ProjectSystemRoot)\Sdk\**\*.*">
       <Pack>true</Pack>
       <PackagePath>Sdk</PackagePath>
-    </Content>
+    </AdditionalContent>
   </ItemGroup>
 
   <Import Project="$(RepoRoot)\src\WebSdk\CopyPackageLayout.targets" />

--- a/src/WebSdk/Publish/Tasks/Microsoft.NET.Sdk.Publish.Tasks.csproj
+++ b/src/WebSdk/Publish/Tasks/Microsoft.NET.Sdk.Publish.Tasks.csproj
@@ -49,15 +49,15 @@
       <DependentUpon>Resources.resx</DependentUpon>
     </Compile>
     
-    <Content Include="$(PublishRoot)\Targets\**\*.*">
+    <AdditionalContent Update="$(PublishRoot)\Targets\**\*.*">
       <Pack>true</Pack>
       <PackagePath>targets</PackagePath>
-    </Content>
+    </AdditionalContent>
 
-    <Content Include="$(PublishRoot)\Sdk\**\*.*">
+    <AdditionalContent Update="$(PublishRoot)\Sdk\**\*.*">
       <Pack>true</Pack>
       <PackagePath>Sdk</PackagePath>
-    </Content>
+    </AdditionalContent>
 
     <EmbeddedResource Include="Properties\Resources.resx">
       <Generator>PublicResXFileCodeGenerator</Generator>

--- a/src/WebSdk/Publish/Tasks/Microsoft.NET.Sdk.Publish.Tasks.csproj
+++ b/src/WebSdk/Publish/Tasks/Microsoft.NET.Sdk.Publish.Tasks.csproj
@@ -49,12 +49,12 @@
       <DependentUpon>Resources.resx</DependentUpon>
     </Compile>
     
-    <AdditionalContent Update="$(PublishRoot)\Targets\**\*.*">
+    <AdditionalContent Include="$(PublishRoot)\Targets\**\*.*">
       <Pack>true</Pack>
       <PackagePath>targets</PackagePath>
     </AdditionalContent>
 
-    <AdditionalContent Update="$(PublishRoot)\Sdk\**\*.*">
+    <AdditionalContent Include="$(PublishRoot)\Sdk\**\*.*">
       <Pack>true</Pack>
       <PackagePath>Sdk</PackagePath>
     </AdditionalContent>

--- a/src/WebSdk/Web/Tasks/Microsoft.NET.Sdk.Web.Tasks.csproj
+++ b/src/WebSdk/Web/Tasks/Microsoft.NET.Sdk.Web.Tasks.csproj
@@ -14,18 +14,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Content Include="$(WebRoot)\Targets\**\*.*">
-      <Pack>true</Pack>
-      <PackagePath>targets</PackagePath>
-    </Content>
-
-    <Content Include="$(WebRoot)\Sdk\**\*.*">
-      <Pack>true</Pack>
-      <PackagePath>Sdk</PackagePath>
-    </Content>
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Analyzers" Version="$(MicrosoftAspNetCoreAnalyzersPackageVersion)" PrivateAssets="All" BundleAsAnalyzer="true" />
     <PackageReference Include="Microsoft.AspNetCore.Components.Analyzers" Version="$(MicrosoftAspNetCoreComponentsAnalyzersPackageVersion)" PrivateAssets="All" BundleAsAnalyzer="true" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Analyzers" Version="$(MicrosoftAspNetCoreMvcAnalyzersPackageVersion)" PrivateAssets="All" BundleAsAnalyzer="true" />
@@ -43,7 +31,7 @@
     <Error Text="No files found for analyzer for @(PackageReference) at path $(_AnalyzerPath)" Condition="'@(_AnalyzerFile-&gt;Count())' == '0'" />
 
     <ItemGroup>
-      <Content Include="@(_AnalyzerFile)" Pack="true" PackagePath="analyzers/cs" />
+      <AdditionalContent Include="@(_AnalyzerFile)" Pack="true" PackagePath="analyzers/cs" />
     </ItemGroup>
   </Target>
 

--- a/src/WebSdk/Web/Tasks/Microsoft.NET.Sdk.Web.Tasks.csproj
+++ b/src/WebSdk/Web/Tasks/Microsoft.NET.Sdk.Web.Tasks.csproj
@@ -14,6 +14,18 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <AdditionalContent Include="$(WebRoot)\Targets\**\*.*">
+      <Pack>true</Pack>
+      <PackagePath>targets</PackagePath>
+    </AdditionalContent>
+
+    <AdditionalContent Include="$(WebRoot)\Sdk\**\*.*">
+      <Pack>true</Pack>
+      <PackagePath>Sdk</PackagePath>
+    </AdditionalContent>
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Analyzers" Version="$(MicrosoftAspNetCoreAnalyzersPackageVersion)" PrivateAssets="All" BundleAsAnalyzer="true" />
     <PackageReference Include="Microsoft.AspNetCore.Components.Analyzers" Version="$(MicrosoftAspNetCoreComponentsAnalyzersPackageVersion)" PrivateAssets="All" BundleAsAnalyzer="true" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Analyzers" Version="$(MicrosoftAspNetCoreMvcAnalyzersPackageVersion)" PrivateAssets="All" BundleAsAnalyzer="true" />

--- a/src/WebSdk/Worker/Tasks/Microsoft.NET.Sdk.Worker.Tasks.csproj
+++ b/src/WebSdk/Worker/Tasks/Microsoft.NET.Sdk.Worker.Tasks.csproj
@@ -14,15 +14,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Content Include="$(WorkerRoot)\Targets\**\*.*">
+    <AdditionalContent Update="$(WorkerRoot)\Targets\**\*.*">
       <Pack>true</Pack>
       <PackagePath>targets</PackagePath>
-    </Content>
+    </AdditionalContent>
 
-    <Content Include="$(WorkerRoot)\Sdk\**\*.*">
+    <AdditionalContent Update="$(WorkerRoot)\Sdk\**\*.*">
       <Pack>true</Pack>
       <PackagePath>Sdk</PackagePath>
-    </Content>
+    </AdditionalContent>
   </ItemGroup>
 
   <Import Project="$(RepoRoot)\src\WebSdk\CopyPackageLayout.targets" />

--- a/src/WebSdk/Worker/Tasks/Microsoft.NET.Sdk.Worker.Tasks.csproj
+++ b/src/WebSdk/Worker/Tasks/Microsoft.NET.Sdk.Worker.Tasks.csproj
@@ -14,12 +14,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <AdditionalContent Update="$(WorkerRoot)\Targets\**\*.*">
+    <AdditionalContent Include="$(WorkerRoot)\Targets\**\*.*">
       <Pack>true</Pack>
       <PackagePath>targets</PackagePath>
     </AdditionalContent>
 
-    <AdditionalContent Update="$(WorkerRoot)\Sdk\**\*.*">
+    <AdditionalContent Include="$(WorkerRoot)\Sdk\**\*.*">
       <Pack>true</Pack>
       <PackagePath>Sdk</PackagePath>
     </AdditionalContent>


### PR DESCRIPTION
The packages contained multiple copies of Sdk.props and Sdk.targets, as well as some others (analyzers). This was because the Content itemgroup was being filled multiple times. Once in each project file, and once when the final layout of the package was laid out.