### PR TITLE
Allow workloads to override property defaults

### DIFF
--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadResolver.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadResolver.cs
@@ -82,7 +82,7 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
             {
                 if (RuntimeInformation.OSArchitecture == Architecture.X64)
                 {
-                    return "windows-x64";
+                    return "win-x64";
                 }
             }
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.BeforeCommon.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.BeforeCommon.targets
@@ -56,7 +56,6 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ImportFrameworkWinFXTargets Condition="'$(ImportFrameworkWinFXTargets)' == ''">false</ImportFrameworkWinFXTargets>
   </PropertyGroup>
 
-  <!-- For .NET Framework, reference core assemblies -->
   <PropertyGroup>
     <_TargetFrameworkVersionWithoutV>$(TargetFrameworkVersion.TrimStart('vV'))</_TargetFrameworkVersionWithoutV>
   </PropertyGroup>
@@ -67,6 +66,35 @@ Copyright (c) .NET Foundation. All rights reserved.
   -->
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.NET.RuntimeIdentifierInference.targets" />
   
+  
+  <!-- Import workload targets -->
+  <Import Project="Microsoft.NET.Sdk.ImportWorkloads.targets" Condition="'$(MSBuildEnableWorkloadResolver)' == 'true'" />
+
+  <Import Project="$(MSBuildThisFileDirectory)Microsoft.NET.Windows.targets" Condition="'$(TargetPlatformIdentifier)' == 'Windows'" />
+  
+  <!-- Import WindowsDesktop targets if necessary -->
+  <PropertyGroup Condition=" '$(ImportWindowsDesktopTargets)' == ''
+                 and '$(TargetFrameworkIdentifier)' == '.NETCoreApp'
+                 and $([MSBuild]::VersionGreaterThanOrEquals($(_TargetFrameworkVersionWithoutV), '3.0'))
+                 and '$(TargetPlatformIdentifier)' == 'Windows'
+                 and ('$(UseWpf)' == 'true' Or '$(UseWindowsForms)' == 'true')">
+    <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(ImportWindowsDesktopTargets)' == 'true'">
+    <AfterMicrosoftNETSdkTargets>$(AfterMicrosoftNETSdkTargets);$(MSBuildThisFileDirectory)../../Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.targets</AfterMicrosoftNETSdkTargets>
+  </PropertyGroup>
+  
+  <PropertyGroup Condition="'$(TargetPlatformIdentifier)' != ''">
+    <!-- Set TargetPlatformVersion if it isn't set.  This is so that we have a valid TargetPlatformMoniker for Restore.
+         This avoids an issue where projects with multitargeted unknown platforms would fail to restore because the platforms
+         weren't included in the TargetPlatformMoniker for restore, obscuring the errors about unknown platforms or missing
+         workloads. -->
+    <TargetPlatformVersion Condition="'$(TargetPlatformVersion)' == ''">0.0</TargetPlatformVersion>
+    
+    <!-- Default SupportedOSPlatformVersion to TargetPlatformVersion -->
+    <SupportedOSPlatformVersion Condition="'$(SupportedOSPlatformVersion)' == ''">$(TargetPlatformVersion)</SupportedOSPlatformVersion>
+  </PropertyGroup>
+
   <!-- Checks for EOL frameworks -->
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.NET.EolTargetFrameworks.targets" />
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -995,20 +995,6 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ProjectCapability Remove="ReferenceManagerAssemblies" />
   </ItemGroup>
 
-  <!--
-  ============================================================
-                            Set ImportWindowsDesktopTargets
-  ============================================================
-  -->
-
-  <PropertyGroup Condition=" '$(ImportWindowsDesktopTargets)' == ''
-                 and '$(TargetFrameworkIdentifier)' == '.NETCoreApp'
-                 and $([MSBuild]::VersionGreaterThanOrEquals($(_TargetFrameworkVersionWithoutV), '3.0'))
-                 and '$(TargetPlatformIdentifier)' == 'Windows'
-                 and ('$(UseWpf)' == 'true' Or '$(UseWindowsForms)' == 'true')">
-    <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
-  </PropertyGroup>
-
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.NET.DisableStandardFrameworkResolution.targets" Condition="'$(DisableStandardFrameworkResolution)' == 'true'" />
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.NET.DesignerSupport.targets" />
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.NET.GenerateAssemblyInfo.targets" Condition="'$(UsingNETSdkDefaults)' == 'true'"/>
@@ -1027,26 +1013,6 @@ Copyright (c) .NET Foundation. All rights reserved.
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.NET.Sdk.FSharp.targets" Condition="'$(Language)' == 'F#'" />
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.NET.ILLink.targets" />
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.NET.Sdk.Analyzers.targets" Condition="'$(Language)' == 'C#' or '$(Language)' == 'VB'" />
-  <Import Project="$(MSBuildThisFileDirectory)Microsoft.NET.Windows.targets" Condition="'$(TargetPlatformIdentifier)' == 'Windows'" />
-  <Import Project="$(MSBuildThisFileDirectory)../../Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.targets" Condition="'$(ImportWindowsDesktopTargets)' == 'true'"/>
 
-  <!-- Import workload targets -->
-  <Import Project="Microsoft.NET.Sdk.ImportWorkloads.targets" Condition="'$(MSBuildEnableWorkloadResolver)' == 'true'" />
-
-  <!-- TargetPlatformMoniker and TargetPlatformDisplayName would normally be set in Microsoft.Common.CurrentVersion.targets.  However, the
-       TargetPlatformVersion may have been set later than that in evaluation by platform-specific targets.  So fix up those properties here -->
-  <PropertyGroup Condition="'$(TargetPlatformMoniker)' == '' and '$(TargetPlatformIdentifier)' != ''">
-    <!-- Set TargetPlatformVersion if it isn't set.  This is so that we have a valid TargetPlatformMoniker for Restore.
-         This avoids an issue where projects with multitargeted unknown platforms would fail to restore because the platforms
-         weren't included in the TargetPlatformMoniker for restore, obscuring the errors about unknown platforms or missing
-         workloads. -->
-    <TargetPlatformVersion Condition="'$(TargetPlatformVersion)' == ''">0.0</TargetPlatformVersion>
-    <TargetPlatformMoniker>$(TargetPlatformIdentifier),Version=$(TargetPlatformVersion)</TargetPlatformMoniker>
-    <TargetPlatformDisplayName>$([Microsoft.Build.Utilities.ToolLocationHelper]::GetPlatformSDKDisplayName($(TargetPlatformIdentifier), $(TargetPlatformVersion)))</TargetPlatformDisplayName>
-  </PropertyGroup>
-
-  <!-- Default SupportedOSPlatformVersion to TargetPlatformVersion -->
-  <PropertyGroup Condition="'$(SupportedOSPlatformVersion)' == ''">
-    <SupportedOSPlatformVersion>$(TargetPlatformVersion)</SupportedOSPlatformVersion>
-  </PropertyGroup>
+  <Import Project="$(AfterMicrosoftNETSdkTargets)" Condition="'$(AfterMicrosoftNETSdkTargets)' != ''"/>
 </Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.TargetFrameworkInference.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.TargetFrameworkInference.targets
@@ -217,11 +217,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <!-- Exclude files from OutputPath and IntermediateOutputPath from default item globs.  Use the value
        of these properties before the TargetFramework is appended, so that if these values are specified
-       in the project file, the specified value will be used for the exclude.
-       
-       We may be able to move this to Microsoft.NET.Sdk.DefaultItems.targets (where the other DefaultItemExcludes
-       are defined) if we fix https://github.com/dotnet/sdk/issues/550
-       -->
+       in the project file, the specified value will be used for the exclude. -->
   <PropertyGroup>
     <DefaultItemExcludes>$(DefaultItemExcludes);$(OutputPath)/**</DefaultItemExcludes>
     <DefaultItemExcludes>$(DefaultItemExcludes);$(IntermediateOutputPath)/**</DefaultItemExcludes>

--- a/src/Tests/Microsoft.NET.Build.Tests/WorkloadTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/WorkloadTests.cs
@@ -90,7 +90,7 @@ namespace Microsoft.NET.Build.Tests
         }
 
         [CoreMSBuildOnlyFact]
-        public void It_should_fail_without_when_multitargeted_to_unknown_platforms()
+        public void It_should_fail_when_multitargeted_to_unknown_platforms()
         {
             var testProject = new TestProject()
             {


### PR DESCRIPTION
Workload targets imports now go soon after target framework inference, allowing them to override property defaults from the .NET SDK