### PR TITLE
Implement Text-Based Performance Log

### DIFF
--- a/src/Cli/Microsoft.DotNet.Cli.Utils/Env.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/Env.cs
@@ -36,5 +36,10 @@ namespace Microsoft.DotNet.Cli.Utils
         {
             return _environment.GetEnvironmentVariableAsBool(name, defaultValue);
         }
+
+        public static string GetEnvironmentVariable(string name)
+        {
+            return _environment.GetEnvironmentVariable(name);
+        }
     }
 }

--- a/src/Cli/Microsoft.DotNet.InternalAbstractions/DirectoryWrapper.cs
+++ b/src/Cli/Microsoft.DotNet.InternalAbstractions/DirectoryWrapper.cs
@@ -19,6 +19,11 @@ namespace Microsoft.Extensions.EnvironmentAbstractions
             return new TemporaryDirectory();
         }
 
+        public IEnumerable<string> EnumerateDirectories(string path)
+        {
+            return Directory.EnumerateDirectories(path);
+        }
+
         public IEnumerable<string> EnumerateFiles(string path)
         {
             return Directory.EnumerateFiles(path);

--- a/src/Cli/Microsoft.DotNet.InternalAbstractions/IDirectory.cs
+++ b/src/Cli/Microsoft.DotNet.InternalAbstractions/IDirectory.cs
@@ -11,6 +11,8 @@ namespace Microsoft.Extensions.EnvironmentAbstractions
 
         ITemporaryDirectory CreateTemporaryDirectory();
 
+        IEnumerable<string> EnumerateDirectories(string path);
+
         IEnumerable<string> EnumerateFiles(string path);
 
         IEnumerable<string> EnumerateFileSystemEntries(string path);

--- a/src/Cli/dotnet/PerformanceLogEventListener.cs
+++ b/src/Cli/dotnet/PerformanceLogEventListener.cs
@@ -1,0 +1,163 @@
+﻿using System;
+using System.Diagnostics;
+using System.Diagnostics.Tracing;
+using System.IO;
+using System.Text;
+using Microsoft.Extensions.EnvironmentAbstractions;
+
+namespace Microsoft.DotNet.Cli.Utils
+{
+    internal sealed class PerformanceLogEventListener : EventListener
+    {
+        internal struct ProviderConfiguration
+        {
+            internal string Name { get; set; }
+            internal EventKeywords Keywords { get; set; }
+            internal EventLevel Level { get; set; }
+        }
+
+        private static ProviderConfiguration[] s_config = new ProviderConfiguration[]
+        {
+            new ProviderConfiguration()
+            {
+                Name = "Microsoft-Dotnet-CLI-Performance",
+                Keywords = EventKeywords.All,
+                Level = EventLevel.Verbose
+            }
+        };
+
+        private const char EventDelimiter = '\n';
+        private string _processIDStr;
+        private StreamWriter _writer;
+
+        [ThreadStatic]
+        private static StringBuilder s_builder = new StringBuilder();
+
+        internal static PerformanceLogEventListener Create(IFileSystem fileSystem, string logDirectory)
+        {
+            // Only create a listener if the log directory exists.
+            if(string.IsNullOrWhiteSpace(logDirectory) || !fileSystem.Directory.Exists(logDirectory))
+            {
+                return null;
+            }
+
+            PerformanceLogEventListener eventListener = null;
+            try
+            {
+                // Initialization happens as a separate step and not in the constructor to ensure that
+                // if an exception is thrown during init, we have the opportunity to dispose of the listener,
+                // which will disable any EventSources that have been enabled.  Any EventSources that existed before
+                // this EventListener will be passed to OnEventSourceCreated before our constructor is called, so
+                // we if we do this work in the constructor, and don't get an opportunity to call Dispose, the
+                // EventSources will remain enabled even if there aren't any consuming EventListeners.
+                eventListener = new PerformanceLogEventListener();
+                eventListener.Initialize(fileSystem, logDirectory);
+            }
+            catch
+            {
+                if(eventListener != null)
+                {
+                    eventListener.Dispose();
+                }
+            }
+
+            return eventListener;
+        }
+
+        private PerformanceLogEventListener()
+        {
+        }
+
+        internal void Initialize(IFileSystem fileSystem, string logDirectory)
+        {
+            _processIDStr = Process.GetCurrentProcess().Id.ToString();
+
+            // Use a GUID disambiguator to make sure that we have a unique file name.
+            string logFilePath = Path.Combine(logDirectory, $"perf-{_processIDStr}-{Guid.NewGuid().ToString("N")}.log");
+
+            Stream outputStream = fileSystem.File.OpenFile(
+                logFilePath,
+                FileMode.Create,    // Create or overwrite.
+                FileAccess.Write,   // Open for writing.
+                FileShare.Read,     // Allow others to read.
+                4096,               // Default buffer size.
+                FileOptions.None);  // No hints about how the file will be written.
+
+            _writer = new StreamWriter(outputStream);
+        }
+
+        public override void Dispose()
+        {
+            lock (this)
+            {
+                if (_writer != null)
+                {
+                    _writer.Dispose();
+                    _writer = null;
+                }
+            }
+
+            base.Dispose();
+        }
+
+        protected override void OnEventSourceCreated(EventSource eventSource)
+        {
+            try
+            {
+                // Enable the provider if it matches a requested configuration.
+                foreach (ProviderConfiguration entry in s_config)
+                {
+                    if (entry.Name.Equals(eventSource.Name))
+                    {
+                        EnableEvents(eventSource, entry.Level, entry.Keywords);
+                    }
+                }
+            }
+            catch
+            {
+                // If we fail to enable, just skip it and continue.
+            }
+
+            base.OnEventSourceCreated(eventSource);
+        }
+
+        protected override void OnEventWritten(EventWrittenEventArgs eventData)
+        {
+            try
+            {
+                if (s_builder == null)
+                {
+                    s_builder = new StringBuilder();
+                }
+                else
+                {
+                    s_builder.Clear();
+                }
+
+                s_builder.Append($"[{DateTime.UtcNow.ToString("o")}] Event={eventData.EventSource.Name}/{eventData.EventName} ProcessID={_processIDStr} ThreadID={System.Threading.Thread.CurrentThread.ManagedThreadId}\t ");
+                for (int i = 0; i < eventData.PayloadNames.Count; i++)
+                {
+                    s_builder.Append($"{eventData.PayloadNames[i]}=\"{eventData.Payload[i]}\" ");
+                }
+
+                lock (this)
+                {
+                    if (_writer != null)
+                    {
+                        foreach (ReadOnlyMemory<char> mem in s_builder.GetChunks())
+                        {
+                            _writer.Write(mem);
+                        }
+                        _writer.Write(EventDelimiter);
+                    }
+                }
+            }
+            catch
+            {
+                // If we fail to log an event, just skip it and continue.
+            }
+
+            base.OnEventWritten(eventData);
+        }
+    }
+}

--- a/src/Cli/dotnet/PerformanceLogEventSource.cs
+++ b/src/Cli/dotnet/PerformanceLogEventSource.cs
@@ -1,0 +1,449 @@
+﻿using System;
+using System.Diagnostics;
+using System.Diagnostics.Tracing;
+using System.IO;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using Microsoft.DotNet.Cli.Utils;
+using RuntimeEnvironment = Microsoft.DotNet.Cli.Utils.RuntimeEnvironment;
+
+namespace Microsoft.DotNet.Cli
+{
+    [EventSource(Name = "Microsoft-Dotnet-CLI-Performance", Guid = "cbd57d06-3b9f-5374-ed53-cfbcc23cf44f")]
+    internal sealed class PerformanceLogEventSource : EventSource
+    {
+        internal static PerformanceLogEventSource Log = new PerformanceLogEventSource();
+
+        private PerformanceLogEventSource()
+        {
+        }
+
+        [NonEvent]
+        internal void LogStartUpInformation(PerformanceLogStartupInformation startupInfo)
+        {
+            if(!IsEnabled())
+            {
+                return;
+            }
+
+            DotnetVersionFile versionFile = DotnetFiles.VersionFileObject;
+            string commitSha = versionFile.CommitSha ?? "N/A";
+
+            LogMachineConfiguration();
+            OSInfo(RuntimeEnvironment.OperatingSystem, RuntimeEnvironment.OperatingSystemVersion, RuntimeEnvironment.OperatingSystemPlatform.ToString());
+            SDKInfo(Product.Version, commitSha, RuntimeInformation.RuntimeIdentifier, versionFile.BuildRid, AppContext.BaseDirectory);
+            EnvironmentInfo(Environment.CommandLine);
+            LogMemoryConfiguration();
+            LogDrives();
+
+            // It's possible that IsEnabled returns true if an out-of-process collector such as ETW is enabled.
+            // If the perf log hasn't been enabled, then startupInfo will be null, so protect against nullref here.
+            if (startupInfo != null)
+            {
+                if (startupInfo.TimedAssembly != null)
+                {
+                    AssemblyLoad(startupInfo.TimedAssembly.GetName().Name, startupInfo.AssemblyLoadTime.TotalMilliseconds);
+                }
+
+                Process currentProcess = Process.GetCurrentProcess();
+                TimeSpan latency = startupInfo.MainTimeStamp - currentProcess.StartTime;
+                HostLatency(latency.TotalMilliseconds);
+            }
+        }
+
+        [Event(1)]
+        internal void OSInfo(string osname, string osversion, string osplatform)
+        {
+            WriteEvent(1, osname, osversion, osplatform);
+        }
+
+        [Event(2)]
+        internal void SDKInfo(string version, string commit, string currentRid, string buildRid, string basePath)
+        {
+            WriteEvent(2, version, commit, currentRid, buildRid, basePath);
+        }
+
+        [Event(3)]
+        internal void EnvironmentInfo(string commandLine)
+        {
+            WriteEvent(3, commandLine);
+        }
+
+        [Event(4)]
+        internal void HostLatency(double timeInMs)
+        {
+            WriteEvent(4, timeInMs);
+        }
+
+        [Event(5)]
+        internal void CLIStart()
+        {
+            WriteEvent(5);
+        }
+
+        [Event(6)]
+        internal void CLIStop()
+        {
+            WriteEvent(6);
+        }
+
+        [Event(7)]
+        internal void FirstTimeConfigurationStart()
+        {
+            WriteEvent(7);
+        }
+
+        [Event(8)]
+        internal void FirstTimeConfigurationStop()
+        {
+            WriteEvent(8);
+        }
+
+        [Event(9)]
+        internal void TelemetryRegistrationStart()
+        {
+            WriteEvent(9);
+        }
+
+        [Event(10)]
+        internal void TelemetryRegistrationStop()
+        {
+            WriteEvent(10);
+        }
+
+        [Event(11)]
+        internal void TelemetrySaveIfEnabledStart()
+        {
+            WriteEvent(11);
+        }
+
+        [Event(12)]
+        internal void TelemetrySaveIfEnabledStop()
+        {
+            WriteEvent(12);
+        }
+
+        [Event(13)]
+        internal void BuiltInCommandStart()
+        {
+            WriteEvent(13);
+        }
+
+        [Event(14)]
+        internal void BuiltInCommandStop()
+        {
+            WriteEvent(14);
+        }
+
+        [Event(15)]
+        internal void BuiltInCommandParserStart()
+        {
+            WriteEvent(15);
+        }
+
+        [Event(16)]
+        internal void BuiltInCommandParserStop()
+        {
+            WriteEvent(16);
+        }
+
+        [Event(17)]
+        internal void ExtensibleCommandResolverStart()
+        {
+            WriteEvent(17);
+        }
+
+        [Event(18)]
+        internal void ExtensibleCommandResolverStop()
+        {
+            WriteEvent(18);
+        }
+
+        [Event(19)]
+        internal void ExtensibleCommandStart()
+        {
+            WriteEvent(19);
+        }
+
+        [Event(20)]
+        internal void ExtensibleCommandStop()
+        {
+            WriteEvent(20);
+        }
+
+        [Event(21)]
+        internal void TelemetryClientFlushStart()
+        {
+            WriteEvent(21);
+        }
+
+        [Event(22)]
+        internal void TelemetryClientFlushStop()
+        {
+            WriteEvent(22);
+        }
+
+        [NonEvent]
+        internal void LogMachineConfiguration()
+        {
+            if(IsEnabled())
+            {
+                MachineConfiguration(Environment.MachineName, Environment.ProcessorCount);
+            }
+        }
+
+        [Event(23)]
+        internal void MachineConfiguration(string machineName, int processorCount)
+        {
+            WriteEvent(23, machineName, processorCount);
+        }
+
+        [NonEvent]
+        internal void LogDrives()
+        {
+            if (IsEnabled())
+            {
+                foreach (DriveInfo driveInfo in DriveInfo.GetDrives())
+                {
+                    try
+                    {
+                        DriveConfiguration(driveInfo.Name, driveInfo.DriveFormat, driveInfo.DriveType.ToString(),
+                            (double)driveInfo.TotalSize/1024/1024, (double)driveInfo.AvailableFreeSpace/1024/1024);
+                    }
+                    catch
+                    {
+                        // If we fail to log a drive, skip it and continue.
+                    }
+                }
+            }
+        }
+
+        [Event(24)]
+        internal void DriveConfiguration(string name, string format, string type, double totalSizeMB, double availableFreeSpaceMB)
+        {
+            WriteEvent(24, name, format, type, totalSizeMB, availableFreeSpaceMB);
+        }
+
+        [Event(25)]
+        internal void AssemblyLoad(string assemblyName, double timeInMs)
+        {
+            WriteEvent(25, assemblyName, timeInMs);
+        }
+
+        [NonEvent]
+        internal void LogMemoryConfiguration()
+        {
+            if (IsEnabled())
+            {
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                {
+                    Interop.MEMORYSTATUSEX memoryStatusEx = new Interop.MEMORYSTATUSEX();
+                    memoryStatusEx.dwLength = (uint)Marshal.SizeOf(memoryStatusEx);
+
+                    if (Interop.GlobalMemoryStatusEx(ref memoryStatusEx))
+                    {
+                        MemoryConfiguration((int)memoryStatusEx.dwMemoryLoad, (int)(memoryStatusEx.ullAvailPhys / 1024 / 1024),
+                            (int)(memoryStatusEx.ullTotalPhys / 1024 / 1024));
+                    }
+                }
+                else if(RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                {
+                    ProcMemInfo memInfo = new ProcMemInfo();
+                    if(memInfo.Valid)
+                    {
+                        MemoryConfiguration(memInfo.MemoryLoad, memInfo.AvailableMemoryMB, memInfo.TotalMemoryMB);
+                    }
+                }
+            }
+        }
+
+        [Event(26)]
+        internal void MemoryConfiguration(int memoryLoad, int availablePhysicalMB, int totalPhysicalMB)
+        {
+            WriteEvent(26, memoryLoad, availablePhysicalMB, totalPhysicalMB);
+        }
+
+        [NonEvent]
+        internal void LogMSBuildStart(ProcessStartInfo startInfo)
+        {
+            if (IsEnabled())
+            {
+                MSBuildStart($"{startInfo.FileName} {startInfo.Arguments}");
+            }
+        }
+
+        [Event(27)]
+        internal void MSBuildStart(string cmdline)
+        {
+            WriteEvent(27, cmdline);
+        }
+
+        [Event(28)]
+        internal void MSBuildStop(int exitCode)
+        {
+            WriteEvent(28, exitCode);
+        }
+
+        [Event(29)]
+        internal void CreateBuildCommandStart()
+        {
+            WriteEvent(29);
+        }
+
+        [Event(30)]
+        internal void CreateBuildCommandStop()
+        {
+            WriteEvent(30);
+        }
+    }
+
+    internal class PerformanceLogStartupInformation
+    {
+        public PerformanceLogStartupInformation(DateTime mainTimeStamp)
+        {
+            // Save the main timestamp.
+            MainTimeStamp = mainTimeStamp;
+
+            // Attempt to load an assembly.
+            // Ideally, we've picked one that we'll already need, so we're not adding additional overhead.
+            MeasureModuleLoad();
+        }
+
+        internal DateTime MainTimeStamp { get; private set; }
+        internal Assembly TimedAssembly { get; private set; }
+        internal TimeSpan AssemblyLoadTime { get; private set; }
+
+        private void MeasureModuleLoad()
+        {
+            // Make sure the assembly hasn't been loaded yet.
+            string assemblyName = "Microsoft.DotNet.Configurer";
+            try
+            {
+                foreach (Assembly loadedAssembly in AppDomain.CurrentDomain.GetAssemblies())
+                {
+                    if (loadedAssembly.GetName().Name.Equals(assemblyName))
+                    {
+                        // If the assembly is already loaded, then bail.
+                        return;
+                    }
+                }
+            }
+            catch
+            {
+                // If we fail to enumerate, just bail.
+                return;
+            }
+
+            Stopwatch stopWatch = Stopwatch.StartNew();
+            Assembly assembly = null;
+            try
+            {
+                assembly = Assembly.Load(assemblyName);
+            }
+            catch
+            {
+                return;
+            }
+            stopWatch.Stop();
+            if (assembly != null)
+            {
+                // Save the results.
+                TimedAssembly = assembly;
+                AssemblyLoadTime = stopWatch.Elapsed;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Global memory statistics on Windows.
+    /// </summary>
+    internal static class Interop
+    {
+        [StructLayout(LayoutKind.Sequential)]
+        internal struct MEMORYSTATUSEX
+        {
+            // The length field must be set to the size of this data structure.
+            internal uint dwLength;
+            internal uint dwMemoryLoad;
+            internal ulong ullTotalPhys;
+            internal ulong ullAvailPhys;
+            internal ulong ullTotalPageFile;
+            internal ulong ullAvailPageFile;
+            internal ulong ullTotalVirtual;
+            internal ulong ullAvailVirtual;
+            internal ulong ullAvailExtendedVirtual;
+        }
+
+        [DllImport("kernel32.dll")]
+        internal static extern bool GlobalMemoryStatusEx(ref MEMORYSTATUSEX lpBuffer);
+    }
+
+    /// <summary>
+    /// Global memory statistics on Linux.
+    /// </summary>
+    internal sealed class ProcMemInfo
+    {
+        private const string MemTotal = "MemTotal:";
+        private const string MemAvailable = "MemAvailable:";
+
+        private short _matchingLineCount = 0;
+
+        internal ProcMemInfo()
+        {
+            Initialize();
+        }
+
+        /// <summary>
+        /// The data in this class is valid if we parsed the file, found, and properly parsed the two matching lines.
+        /// </summary>
+        internal bool Valid
+        {
+            get { return _matchingLineCount == 2; }
+        }
+
+        internal int MemoryLoad
+        {
+            get { return (int)((double)(TotalMemoryMB - AvailableMemoryMB) / TotalMemoryMB * 100); }
+        }
+
+        internal int AvailableMemoryMB
+        {
+            get;
+            private set;
+        }
+
+        internal int TotalMemoryMB
+        {
+            get;
+            private set;
+        }
+
+        private void Initialize()
+        {
+            using (StreamReader reader = new StreamReader(File.OpenRead("/proc/meminfo")))
+            {
+                string line;
+                while (!Valid && ((line = reader.ReadLine()) != null))
+                {
+                    if (line.StartsWith(MemTotal) || line.StartsWith(MemAvailable))
+                    {
+                        string[] tokens = line.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+                        if (tokens.Length == 3)
+                        {
+                            if (MemTotal.Equals(tokens[0]))
+                            {
+                                TotalMemoryMB = (int)Convert.ToUInt64(tokens[1]) / 1024;
+                                _matchingLineCount++;
+                            }
+                            else if (MemAvailable.Equals(tokens[0]))
+                            {
+                                AvailableMemoryMB = (int)Convert.ToUInt64(tokens[1]) / 1024;
+                                _matchingLineCount++;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/Cli/dotnet/PerformanceLogManager.cs
+++ b/src/Cli/dotnet/PerformanceLogManager.cs
@@ -1,0 +1,140 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.DotNet.Configurer;
+using Microsoft.Extensions.EnvironmentAbstractions;
+
+namespace Microsoft.DotNet.Cli.Utils
+{
+    internal sealed class PerformanceLogManager
+    {
+        internal const string PerfLogDirEnvVar = "DOTNET_PERFLOG_DIR";
+        private const string PerfLogRoot = "PerformanceLogs";
+        private const int DefaultNumLogsToKeep = 10;
+
+        private IFileSystem _fileSystem;
+        private string _perfLogRoot;
+        private string _currentLogDir;
+
+        internal static PerformanceLogManager Instance
+        {
+            get;
+            private set;
+        }
+
+        internal static void InitializeAndStartCleanup(IFileSystem fileSystem)
+        {
+            if(Instance == null)
+            {
+                Instance = new PerformanceLogManager(fileSystem);
+
+                // Check to see if this instance is part of an already running chain of processes.
+                string perfLogDir = Env.GetEnvironmentVariable(PerfLogDirEnvVar);
+                if (!string.IsNullOrEmpty(perfLogDir))
+                {
+                        // This process has been provided with a log directory, so use it.
+                        Instance.UseExistingLogDirectory(perfLogDir);
+                }
+                else
+                {
+                    // This process was not provided with a log root, so make a new one.
+                    Instance._perfLogRoot = Path.Combine(CliFolderPathCalculator.DotnetUserProfileFolderPath, PerfLogRoot);
+                    Instance.CreateLogDirectory();
+
+                    Task.Factory.StartNew(() =>
+                    {
+                        Instance.CleanupOldLogs();
+                    });
+                }
+            }
+        }
+
+        internal PerformanceLogManager(IFileSystem fileSystem)
+        {
+            _fileSystem = fileSystem;
+        }
+
+        internal string CurrentLogDirectory
+        {
+            get { return _currentLogDir; }
+        }
+
+        private void CreateLogDirectory()
+        {
+            // Ensure the log root directory exists.
+            if(!_fileSystem.Directory.Exists(_perfLogRoot))
+            {
+                _fileSystem.Directory.CreateDirectory(_perfLogRoot);
+            }
+
+            // Create a new perf log directory.
+            _currentLogDir = Path.Combine(_perfLogRoot, Guid.NewGuid().ToString("N"));
+            _fileSystem.Directory.CreateDirectory(_currentLogDir);
+        }
+
+        private void UseExistingLogDirectory(string logDirectory)
+        {
+            _currentLogDir = logDirectory;
+        }
+
+        private void CleanupOldLogs()
+        {
+            if(_fileSystem.Directory.Exists(_perfLogRoot))
+            {
+                List<DirectoryInfo> logDirectories = new List<DirectoryInfo>();
+                foreach(string directoryPath in _fileSystem.Directory.EnumerateDirectories(_perfLogRoot))
+                {
+                    logDirectories.Add(new DirectoryInfo(directoryPath));
+                }
+
+                // Sort the list.
+                logDirectories.Sort(new LogDirectoryComparer());
+
+                // Figure out how many logs to keep.
+                int numLogsToKeep;
+                string strNumLogsToKeep = Env.GetEnvironmentVariable("DOTNET_PERF_LOG_COUNT");
+                if(!int.TryParse(strNumLogsToKeep, out numLogsToKeep))
+                {
+                    numLogsToKeep = DefaultNumLogsToKeep;
+
+                    // -1 == keep all logs
+                    if(numLogsToKeep == -1)
+                    {
+                        numLogsToKeep = int.MaxValue;
+                    }
+                }
+
+                // Skip the first numLogsToKeep elements.
+                if(logDirectories.Count > numLogsToKeep)
+                {
+                    // Prune the old logs.
+                    for(int i = logDirectories.Count - numLogsToKeep - 1; i>=0; i--)
+                    {
+                        try
+                        {
+                            logDirectories[i].Delete(true);
+                        }
+                        catch
+                        {
+                            // Do nothing if a log can't be deleted.
+                            // We'll get another chance next time around.
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Used to sort log directories when deciding which ones to delete.
+    /// </summary>
+    internal sealed class LogDirectoryComparer : IComparer<DirectoryInfo>
+    {
+        int IComparer<DirectoryInfo>.Compare(DirectoryInfo x, DirectoryInfo y)
+        {
+            return x.CreationTime.CompareTo(y.CreationTime);
+        }
+    }
+}

--- a/src/Cli/dotnet/commands/dotnet-build/BuildCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-build/BuildCommand.cs
@@ -27,6 +27,8 @@ namespace Microsoft.DotNet.Tools.Build
 
         public static BuildCommand FromArgs(string[] args, string msbuildPath = null)
         {
+            PerformanceLogEventSource.Log.CreateBuildCommandStart();
+
             var msbuildArgs = new List<string>();
 
             var parser = Parser.Instance;
@@ -50,12 +52,16 @@ namespace Microsoft.DotNet.Tools.Build
 
             bool noRestore = appliedBuildOptions.HasOption("--no-restore");
 
-            return new BuildCommand(
+            BuildCommand command = new BuildCommand(
                 msbuildArgs,
                 appliedBuildOptions.OptionValuesToBeForwarded(),
                 appliedBuildOptions.Arguments,
                 noRestore,
                 msbuildPath);
+
+            PerformanceLogEventSource.Log.CreateBuildCommandStop();
+
+            return command;
         }
 
         public static int Run(string[] args)

--- a/src/Tests/Microsoft.DotNet.Configurer.UnitTests/GivenAFirstTimeUseNoticeSentinel.cs
+++ b/src/Tests/Microsoft.DotNet.Configurer.UnitTests/GivenAFirstTimeUseNoticeSentinel.cs
@@ -174,6 +174,11 @@ namespace Microsoft.DotNet.Configurer.UnitTests
                 throw new NotImplementedException();
             }
 
+            public IEnumerable<string> EnumerateDirectories(string path)
+            {
+                throw new NotImplementedException();
+            }
+
             public IEnumerable<string> EnumerateFiles(string path)
             {
                 throw new NotImplementedException();

--- a/src/Tests/Microsoft.DotNet.Configurer.UnitTests/GivenAFunctionReturnStringAndFakeFileSystem.cs
+++ b/src/Tests/Microsoft.DotNet.Configurer.UnitTests/GivenAFunctionReturnStringAndFakeFileSystem.cs
@@ -158,6 +158,11 @@ namespace Microsoft.DotNet.Configurer.UnitTests
                 throw new NotImplementedException();
             }
 
+            public IEnumerable<string> EnumerateDirectories(string path)
+            {
+                throw new NotImplementedException();
+            }
+
             public IEnumerable<string> EnumerateFiles(string path)
             {
                 throw new NotImplementedException();

--- a/src/Tests/Microsoft.NET.TestFramework/Mock/FileSystemMockBuilder.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/Mock/FileSystemMockBuilder.cs
@@ -541,6 +541,15 @@ namespace Microsoft.Extensions.DependencyModel.Tests
                 return temporaryDirectoryMock;
             }
 
+            public IEnumerable<string> EnumerateDirectories(string path)
+            {
+                if (path == null) throw new ArgumentNullException(nameof(path));
+
+                return _files.EnumerateDirectory(path,
+                    subs => subs.Where(s => s.Value is DirectoryNode)
+                        .Select(s => Path.Combine(path, s.Key)));
+            }
+
             public IEnumerable<string> EnumerateFiles(string path)
             {
                 if (path == null) throw new ArgumentNullException(nameof(path));

--- a/src/Tests/dotnet.Tests/GivenThatTheUserEnablesThePerfLog.cs
+++ b/src/Tests/dotnet.Tests/GivenThatTheUserEnablesThePerfLog.cs
@@ -1,0 +1,94 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+
+using System;
+using System.IO;
+using System.Collections.Generic;
+using Microsoft.DotNet.Cli.Utils;
+using Microsoft.DotNet.Cli;
+using Microsoft.DotNet.Configurer;
+using Xunit;
+using Xunit.Abstractions;
+using FluentAssertions;
+using Microsoft.NET.TestFramework;
+using Microsoft.NET.TestFramework.Assertions;
+using Microsoft.NET.TestFramework.Commands;
+using System.Runtime.CompilerServices;
+using System.Diagnostics.Tracing;
+
+namespace Microsoft.DotNet.Tests
+{
+    public class GivenThatTheUserEnablesThePerfLog : SdkTest
+    {
+        public GivenThatTheUserEnablesThePerfLog(ITestOutputHelper log) : base(log)
+        {
+        }
+
+        [Fact]
+        public void WhenPerfLogDisabledDotNetDoesNotWriteToThePerfLog()
+        {
+            var dir = _testAssetsManager.CreateTestDirectory();
+
+            var result = new DotnetCommand(Log, "--help")
+                .WithEnvironmentVariable("DOTNET_PERFLOG_DIR", dir.Path)
+                .Execute();
+
+            result.ExitCode.Should().Be(0);
+            Assert.Empty(new DirectoryInfo(dir.Path).GetFiles());
+        }
+
+        [Fact]
+        public void WhenPerfLogEnabledDotNetWritesToThePerfLog()
+        {
+            var dir = _testAssetsManager.CreateTestDirectory();
+
+            var result = new DotnetCommand(Log, "--help")
+                .WithEnvironmentVariable("DOTNET_CLI_PERF_LOG", "1")
+                .WithEnvironmentVariable("DOTNET_PERFLOG_DIR", dir.Path)
+                .Execute();
+
+            result.ExitCode.Should().Be(0);
+
+            DirectoryInfo logDir = new DirectoryInfo(dir.Path);
+            FileInfo[] logFiles = logDir.GetFiles();
+            Assert.NotEmpty(logFiles);
+            Assert.All(logFiles, f => Assert.StartsWith("perf-", f.Name));
+            Assert.All(logFiles, f => Assert.NotEqual(0, f.Length));
+        }
+
+        [Fact]
+        public void WhenPerfLogEnabledDotNetBuildWritesAPerfLog()
+        {
+            using (PerfLogTestEventListener listener = new PerfLogTestEventListener())
+            {
+                int exitCode = Cli.Program.Main(new string[] { "--help" });
+                Assert.Equal(0, exitCode);
+                Assert.NotEqual(0, listener.EventCount);
+            }
+        }
+    }
+
+    internal sealed class PerfLogTestEventListener : EventListener
+    {
+        private const string PerfLogEventSourceName = "Microsoft-Dotnet-CLI-Performance";
+
+        public int EventCount
+        {
+            get; private set;
+        }
+
+        protected override void OnEventSourceCreated(EventSource eventSource)
+        {
+            if(eventSource.Name.Equals(PerfLogEventSourceName))
+            {
+                EnableEvents(eventSource, EventLevel.Verbose);
+            }
+        }
+
+        protected override void OnEventWritten(EventWrittenEventArgs eventData)
+        {
+            Assert.Equal(PerfLogEventSourceName, eventData.EventSource.Name);
+            EventCount++;
+        }
+    }
+}


### PR DESCRIPTION
Implements a text-based performance log scheme that writes coarse-grained performance logs:

 - No logs are written unless the user opts-in by setting `DOTNET_CLI_PERF_LOG=1`.
 - Each log is represented on disk as a directory, containing a collection of log files.  Each process involved in an invocation of the CLI writes its own log file.  Thus, when new processes are spawned by the CLI, there can be more than one log file.
 - Logs are written by default to `<DotnetUserProfilePath>\PerformanceLogs`.  Logs for an individual invocation of the CLI can be redirected via `DOTNET_PERFLOG_DIR`.
 - By default, the most recent 10 logs are kept.  This is changeable via `DOTNET_PERF_LOG_COUNT`.  Set this variable to `-1` to keep all logs.
 - Data in the logs are emitted via `PerformanceLogEventSource` so that the events can be consumed through other profilers, such as those that use ETW.
 - Sets `DOTNET_PERFLOG_DIR` when spawning msbuild processes so that msbuild can contribute to the performance log.

cc: @marcpopMSFT, @davidfowl, @DamianEdwards, @bwadswor