### PR TITLE
Add support for new feature switch

### DIFF
--- a/src/Assets/TestProjects/KitchenSink/TestApp/TestApp.csproj
+++ b/src/Assets/TestProjects/KitchenSink/TestApp/TestApp.csproj
@@ -17,6 +17,7 @@
     <TieredCompilation>true</TieredCompilation>
     <TieredCompilationQuickJit>true</TieredCompilationQuickJit>
     <TieredCompilationQuickJitForLoops>true</TieredCompilationQuickJitForLoops>
+    <StartupHookSupport>false</StartupHookSupport>
     <EventSourceSupport>false</EventSourceSupport>
     <UseSystemResourceKeys>true</UseSystemResourceKeys>
     <EnableUnsafeUTF7Encoding>false</EnableUnsafeUTF7Encoding>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ILLink.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ILLink.targets
@@ -22,6 +22,15 @@ Copyright (c) .NET Foundation. All rights reserved.
     <_LinkSemaphore>$(IntermediateOutputPath)Link.semaphore</_LinkSemaphore>
   </PropertyGroup>
 
+  <!-- We disable startup hooks for trimmed apps here so that the feature
+       switch can flow to the runtimeconfig.json. Startup hooks are disabled
+       by default since they may require assemblies, types or members that
+       could be removed by the linker, causing a trimmed app to crash. -->
+  <PropertyGroup Condition="'$(EnableUnsafeBinaryFormatterSerialization)' == '' And
+                            '$(PublishTrimmed)' == 'true'">
+    <StartupHookSupport>false</StartupHookSupport>
+  </PropertyGroup>
+
   <!--
     ============================================================
                      ILLink

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ILLink.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ILLink.targets
@@ -26,7 +26,7 @@ Copyright (c) .NET Foundation. All rights reserved.
        switch can flow to the runtimeconfig.json. Startup hooks are disabled
        by default since they may require assemblies, types or members that
        could be removed by the linker, causing a trimmed app to crash. -->
-  <PropertyGroup Condition="'$(EnableUnsafeBinaryFormatterSerialization)' == '' And
+  <PropertyGroup Condition="'$(StartupHookSupport)' == '' And
                             '$(PublishTrimmed)' == 'true'">
     <StartupHookSupport>false</StartupHookSupport>
   </PropertyGroup>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ILLink.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ILLink.targets
@@ -27,7 +27,8 @@ Copyright (c) .NET Foundation. All rights reserved.
        by default since they may require assemblies, types or members that
        could be removed by the linker, causing a trimmed app to crash. -->
   <PropertyGroup Condition="'$(StartupHookSupport)' == '' And
-                            '$(PublishTrimmed)' == 'true'">
+                            '$(PublishTrimmed)' == 'true' And
+                            '$(_TargetFrameworkVersionWithoutV)' >= '6.0'">
     <StartupHookSupport>false</StartupHookSupport>
   </PropertyGroup>
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -400,6 +400,11 @@ Copyright (c) .NET Foundation. All rights reserved.
                                     Condition="'$(TieredCompilationQuickJitForLoops)' != ''"
                                     Value="$(TieredCompilationQuickJitForLoops)" />
 
+    <RuntimeHostConfigurationOption Include="System.StartupHookProvider.IsSupported"
+                                    Condition="'$(StartupHookSupport)' != ''"
+                                    Value="$(StartupHookSupport)"
+                                    Trim="true" />
+
     <RuntimeHostConfigurationOption Include="System.Text.Encoding.EnableUnsafeUTF7Encoding"
                                     Condition="'$(EnableUnsafeUTF7Encoding)' != ''"
                                     Value="$(EnableUnsafeUTF7Encoding)"
@@ -412,11 +417,6 @@ Copyright (c) .NET Foundation. All rights reserved.
     <RuntimeHostConfigurationOption Include="System.Threading.ThreadPool.MaxThreads"
                                     Condition="'$(ThreadPoolMaxThreads)' != ''"
                                     Value="$(ThreadPoolMaxThreads)" />
-
-    <RuntimeHostConfigurationOption Include="System.StartupHookProvider.IsSupported"
-                                    Condition="'$(StartupHookSupport)' != ''"
-                                    Value="$(StartupHookSupport)"
-                                    Trim="true" />
   </ItemGroup>
 
   <!--

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -413,6 +413,10 @@ Copyright (c) .NET Foundation. All rights reserved.
                                     Condition="'$(ThreadPoolMaxThreads)' != ''"
                                     Value="$(ThreadPoolMaxThreads)" />
 
+    <RuntimeHostConfigurationOption Include="System.StartupHookProvider.IsSupported"
+                                    Condition="'$(StartupHookSupport)' != ''"
+                                    Value="$(StartupHookSupport)"
+                                    Trim="true" />
   </ItemGroup>
 
   <!--

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAProjectWithAllFeatures.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAProjectWithAllFeatures.cs
@@ -77,6 +77,7 @@ namespace Microsoft.NET.Publish.Tests
             ""System.Runtime.TieredCompilation"": true,
             ""System.Runtime.TieredCompilation.QuickJit"": true,
             ""System.Runtime.TieredCompilation.QuickJitForLoops"": true,
+            ""System.StartupHookProvider.IsSupported"": false,
             ""System.Text.Encoding.EnableUnsafeUTF7Encoding"": false,
             ""System.Threading.ThreadPool.MinThreads"": 2,
             ""System.Threading.ThreadPool.MaxThreads"": 9,

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToRunILLink.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToRunILLink.cs
@@ -374,7 +374,7 @@ namespace Microsoft.NET.Publish.Tests
         }
 
         [Theory]
-        [InlineData("net5.0")]
+        [InlineData("net6.0")]
         public void StartupHookSupport_is_false_by_default_on_trimmed_apps(string targetFramework)
         {
             var projectName = "HelloWorld";

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToRunILLink.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToRunILLink.cs
@@ -18,6 +18,7 @@ using Microsoft.NET.TestFramework;
 using Microsoft.NET.TestFramework.Assertions;
 using Microsoft.NET.TestFramework.Commands;
 using Microsoft.NET.TestFramework.ProjectConstruction;
+using Newtonsoft.Json.Linq;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -370,6 +371,29 @@ namespace Microsoft.NET.Publish.Tests
                     errorMessage += "+  " + extraWarning + Environment.NewLine;
             }
             Assert.True(!missingWarnings.Any() && !extraWarnings.Any(), errorMessage);
+        }
+
+        [Theory]
+        [InlineData("net5.0")]
+        public void StartupHookSupport_is_false_by_default_on_trimmed_apps(string targetFramework)
+        {
+            var projectName = "HelloWorld";
+            var rid = EnvironmentInfo.GetCompatibleRid(targetFramework);
+
+            var testProject = CreateTestProjectForILLinkTesting(targetFramework, projectName);
+            var testAsset = _testAssetsManager.CreateTestProject(testProject, identifier: projectName);
+
+            var publishCommand = new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            publishCommand.Execute($"/p:RuntimeIdentifier={rid}", "/p:PublishTrimmed=true")
+                .Should().Pass();
+
+            string outputDirectory = publishCommand.GetOutputDirectory(targetFramework: targetFramework, runtimeIdentifier: rid).FullName;
+            string runtimeConfigFile = Path.Combine(outputDirectory, $"{projectName}.runtimeconfig.json");
+            string runtimeConfigContents = File.ReadAllText(runtimeConfigFile);
+            JObject runtimeConfig = JObject.Parse(runtimeConfigContents);
+            runtimeConfig["runtimeOptions"]["configProperties"]
+                ["System.StartupHookProvider.IsSupported"].Value<bool>()
+                .Should().Be(false);
         }
 
         [Theory]

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToRunILLink.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToRunILLink.cs
@@ -374,6 +374,7 @@ namespace Microsoft.NET.Publish.Tests
         }
 
         [Theory]
+        [InlineData("net5.0")]
         [InlineData("net6.0")]
         public void StartupHookSupport_is_false_by_default_on_trimmed_apps(string targetFramework)
         {
@@ -390,10 +391,20 @@ namespace Microsoft.NET.Publish.Tests
             string outputDirectory = publishCommand.GetOutputDirectory(targetFramework: targetFramework, runtimeIdentifier: rid).FullName;
             string runtimeConfigFile = Path.Combine(outputDirectory, $"{projectName}.runtimeconfig.json");
             string runtimeConfigContents = File.ReadAllText(runtimeConfigFile);
-            JObject runtimeConfig = JObject.Parse(runtimeConfigContents);
-            runtimeConfig["runtimeOptions"]["configProperties"]
-                ["System.StartupHookProvider.IsSupported"].Value<bool>()
-                .Should().Be(false);
+
+
+            if (Version.TryParse(targetFramework.TrimStart("net".ToCharArray()), out Version parsedVersion) &&
+                parsedVersion.Major >= 6)
+            {
+                JObject runtimeConfig = JObject.Parse(runtimeConfigContents);
+                runtimeConfig["runtimeOptions"]["configProperties"]
+                    ["System.StartupHookProvider.IsSupported"].Value<bool>()
+                    .Should().Be(false);
+            }
+            else
+            {
+                runtimeConfigContents.Should().NotContain("System.StartupHookProvider.IsSupported");
+            }
         }
 
         [Theory]


### PR DESCRIPTION
This adds SDK support for StartupHookSupport, a new feature switch that allows users to disable startup hooks.

Related to #14385.