### PR TITLE
Fix references to Exe projects

### DIFF
--- a/eng/dogfood.ps1
+++ b/eng/dogfood.ps1
@@ -44,6 +44,7 @@ try {
   $env:MicrosoftNETBuildExtensionsTargets = Join-Path $ArtifactsDir "bin\$configuration\Sdks\Microsoft.NET.Build.Extensions\msbuildExtensions\Microsoft\Microsoft.NET.Build.Extensions\Microsoft.NET.Build.Extensions.targets"
 
   $env:PATH = "$TestDotnetRoot;$env:Path"
+  $env:DOTNET_ROOT = $TestDotnetRoot
 
   if ($command -eq $null -and $env:DOTNET_SDK_DOGFOOD_SHELL -ne $null) {
     $command = , $env:DOTNET_SDK_DOGFOOD_SHELL

--- a/eng/dogfood.sh
+++ b/eng/dogfood.sh
@@ -24,3 +24,4 @@ export DOTNET_MSBUILD_SDK_RESOLVER_SDKS_DIR="$testDotnetRoot/sdk/$testDotnetVers
 export MicrosoftNETBuildExtensionsTargets="$artifacts_dir/bin/$configuration/Sdks/Microsoft.NET.Build.Extensions/msbuildExtensions/Microsoft/Microsoft.NET.Build.Extensions/Microsoft.NET.Build.Extensions.targets"
 
 export PATH=$testDotnetRoot:$PATH
+export DOTNET_ROOT=$testDotnetRoot

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -324,6 +324,54 @@ Copyright (c) .NET Foundation. All rights reserved.
     </ItemGroup>
   </Target>
 
+  <Target Name="AddDepsJsonAndRuntimeConfigToCopyItemsForReferencingProjects"
+          BeforeTargets="GetCopyToOutputDirectoryItems;_GetCopyToOutputDirectoryItemsFromThisProject"
+          Condition="'$(HasRuntimeOutput)' == 'true'">
+
+    <ItemGroup Condition="'$(GenerateDependencyFile)' == 'true'">
+      <AllItemsFullPathWithTargetPath Include="$(ProjectDepsFilePath)"
+                                      TargetPath="$([System.IO.Path]::GetFileName($(ProjectDepsFilePath)))"
+                                      CopyToOutputDirectory="PreserveNewest" />
+    </ItemGroup>
+    
+    <ItemGroup Condition=" '$(GenerateRuntimeConfigurationFiles)' == 'true'">
+      <AllItemsFullPathWithTargetPath Include="$(ProjectRuntimeConfigFilePath)"
+                                TargetPath="$([System.IO.Path]::GetFileName($(ProjectRuntimeConfigFilePath)))"
+                                CopyToOutputDirectory="PreserveNewest" />
+      <AllItemsFullPathWithTargetPath Include="$(ProjectRuntimeConfigDevFilePath)"
+                                TargetPath="$([System.IO.Path]::GetFileName($(ProjectRuntimeConfigDevFilePath)))"
+                                CopyToOutputDirectory="PreserveNewest" />
+    </ItemGroup>
+    
+  </Target>
+
+  <Target Name="AddDepsJsonAndRuntimeConfigToPublishItemsForReferencingProjects"
+          DependsOnTargets="_ComputeUseBuildDependencyFile"
+          BeforeTargets="GetCopyToPublishDirectoryItems"
+          Condition="'$(HasRuntimeOutput)' == 'true'">
+
+    <ItemGroup Condition="'$(GenerateDependencyFile)' == 'true'">
+      <AllPublishItemsFullPathWithTargetPath Include="$(ProjectDepsFilePath)"
+                                      TargetPath="$([System.IO.Path]::GetFileName($(ProjectDepsFilePath)))"
+                                      CopyToPublishDirectory="PreserveNewest" 
+                                      Condition="'$(_UseBuildDependencyFile)' == 'true'"/>
+      <AllPublishItemsFullPathWithTargetPath Include="$(PublishDepsFilePath)"
+                                      TargetPath="$([System.IO.Path]::GetFileName($(PublishDepsFilePath)))"
+                                      CopyToPublishDirectory="PreserveNewest"
+                                      Condition="'$(PublishDepsFilePath)' != '' and '$(_UseBuildDependencyFile)' != 'true'"/>
+    </ItemGroup>
+
+    <ItemGroup Condition=" '$(GenerateRuntimeConfigurationFiles)' == 'true'">
+      <AllPublishItemsFullPathWithTargetPath Include="$(ProjectRuntimeConfigFilePath)"
+                                TargetPath="$([System.IO.Path]::GetFileName($(ProjectRuntimeConfigFilePath)))"
+                                CopyToPublishDirectory="PreserveNewest" />
+    
+
+    </ItemGroup>
+    
+    
+  </Target>
+
   <Target Name="_SdkBeforeClean">
     <PropertyGroup Condition="'$(_CleaningWithoutRebuilding)' == ''">
       <_CleaningWithoutRebuilding>true</_CleaningWithoutRebuilding>

--- a/src/Tests/Microsoft.NET.Build.Tests/COMReferenceTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/COMReferenceTests.cs
@@ -130,7 +130,7 @@ namespace Microsoft.NET.Build.Tests
             Assert.True(outputDirectory.File($"Interop.{vslangProj70ComRef}").Exists);
             Assert.True(outputDirectory.File($"Interop.{vslangProj80ComRef}").Exists);
 
-            var publishCommand = new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var publishCommand = new PublishCommand(testAsset);
             publishCommand.Execute().Should().Pass();
 
             outputDirectory = publishCommand.GetOutputDirectory(targetFramework);

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildADesktopExe.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildADesktopExe.cs
@@ -194,7 +194,7 @@ namespace Microsoft.NET.Build.Tests
                     .Should()
                     .Pass();
 
-                var publishCommand = new PublishCommand(Log, testAsset.TestRoot);
+                var publishCommand = new PublishCommand(testAsset);
                 publishCommand
                     .Execute(multiTarget ? new[] { "/p:TargetFramework=net46" } : Array.Empty<string>())
                     .Should()

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildANetCoreApp.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildANetCoreApp.cs
@@ -534,7 +534,7 @@ public static class Program
                     }
                 });
 
-            var publishCommand = new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var publishCommand = new PublishCommand(testAsset);
             publishCommand
                 .Execute("/v:normal", $"/p:TargetFramework={testProject.TargetFrameworks}")
                 .Should()

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenWeWantToRequireWindowsForDesktopApps.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenWeWantToRequireWindowsForDesktopApps.cs
@@ -221,7 +221,7 @@ namespace Microsoft.NET.Build.Tests
 
             Assert(buildCommand.GetOutputDirectory(tfm));
 
-            var publishCommand = new PublishCommand(Log, Path.Combine(asset.Path, ProjectName));
+            var publishCommand = new PublishCommand(asset);
             var runtimeIdentifier = "win-x64";
             publishCommand.Execute("-p:SelfContained=true", $"-p:RuntimeIdentifier={runtimeIdentifier}")
                 .Should()

--- a/src/Tests/Microsoft.NET.Build.Tests/ReferenceExeTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/ReferenceExeTests.cs
@@ -162,16 +162,10 @@ namespace Microsoft.NET.Build.Tests
             RunTest(true);
         }
 
-        //  Test cases that are currently failing
+        //  Having a self-contained and a framework-dependent app in the same folder is not supported (due to the way the host works).
+        //  The referenced app will fail to run.  See here for more details: https://github.com/dotnet/sdk/pull/14488#issuecomment-725406998
         [Theory]
-        //  Fails because runtime pack artifacts are not transitively copied
         [InlineData(true, false)]
-        //  Fails with the following error (is the self-contained copy of hostfxr or something interfering with the framework dependent app?):
-        //  It was not possible to find any compatible framework version
-        //  The framework 'Microsoft.NETCore.App', version '5.0.0' was not found.
-        //    - No frameworks were found.
-        //
-        //  You can resolve the problem by installing the specified framework and/or SDK.
         [InlineData(false, true)]
         public void ReferencedExeFailsToRun(bool mainSelfContained, bool referencedSelfContained)
         {
@@ -184,14 +178,12 @@ namespace Microsoft.NET.Build.Tests
         }
 
         [Theory]
-        [InlineData(false, false)]
-        //[InlineData(true, false, Skip = "Currently not supported (see ReferencedExeFailsToRun)")]
-        //[InlineData(false, true, Skip = "Currently not supported (see ReferencedExeFailsToRun)")]
-        [InlineData(true, true)]
-        public void ReferencedExeCanRunWhenPublished(bool mainSelfContained, bool referencedSelfContained)
+        [InlineData(false)]
+        [InlineData(true)]
+        public void ReferencedExeCanRunWhenPublished(bool selfContained)
         {
-            MainSelfContained = mainSelfContained;
-            ReferencedSelfContained = referencedSelfContained;
+            MainSelfContained = selfContained;
+            ReferencedSelfContained = selfContained;
 
             TestWithPublish = true;
             
@@ -200,15 +192,11 @@ namespace Microsoft.NET.Build.Tests
             RunTest(referencedExeShouldRun: true);
         }
 
-        [Theory]
-        //[InlineData(true, false, Skip = "Currently not supported (see ReferencedExeFailsToRun)")]
-        //[InlineData(false, true, Skip = "Currently not supported (see ReferencedExeFailsToRun)")]
-        [InlineData(true, true)]
-
-        public void ReferencedExeCanRunWhenPublishedWithTrimming(bool mainSelfContained, bool referencedSelfContained)
+        [Fact]
+        public void ReferencedExeCanRunWhenPublishedWithTrimming()
         {
-            MainSelfContained = mainSelfContained;
-            ReferencedSelfContained = referencedSelfContained;
+            MainSelfContained = true;
+            ReferencedSelfContained = true;
 
             TestWithPublish = true;
 

--- a/src/Tests/Microsoft.NET.Build.Tests/ReferenceExeTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/ReferenceExeTests.cs
@@ -1,0 +1,229 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Xml.Linq;
+using FluentAssertions;
+using Microsoft.DotNet.Cli.Utils;
+using Microsoft.NET.TestFramework;
+using Microsoft.NET.TestFramework.Assertions;
+using Microsoft.NET.TestFramework.Commands;
+using Microsoft.NET.TestFramework.ProjectConstruction;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.NET.Build.Tests
+{
+    public class ReferenceExeTests : SdkTest
+    {
+        public ReferenceExeTests(ITestOutputHelper log) : base(log)
+        {
+        }
+
+        private bool MainSelfContained { get; set; }
+
+        private bool ReferencedSelfContained { get; set; }
+
+        private bool TestWithPublish { get; set; } = false;
+
+        private TestProject MainProject { get; set; }
+
+        private TestProject ReferencedProject { get; set; }
+
+        private void CreateProjects()
+        {
+            MainProject = new TestProject()
+            {
+                Name = "MainProject",
+                TargetFrameworks = "net5.0",
+                IsSdkProject = true,
+                IsExe = true
+            };
+
+            MainProject.PackageReferences.Add(new TestPackageReference("Humanizer", "2.8.26"));
+            MainProject.SourceFiles["Program.cs"] = @"using Humanizer; System.Console.WriteLine(""MainProject"".Humanize());";
+
+            //  By default we don't create the app host on Mac for FDD.  For these tests, we want to create it everywhere
+            MainProject.AdditionalProperties["UseAppHost"] = "true";
+
+            if (MainSelfContained)
+            {
+                MainProject.RuntimeIdentifier = EnvironmentInfo.GetCompatibleRid();
+            }
+
+            ReferencedProject = new TestProject()
+            {
+                Name = "ReferencedProject",
+                TargetFrameworks = "net5.0",
+                IsSdkProject = true,
+                IsExe = true,
+            };
+
+            ReferencedProject.AdditionalProperties["UseAppHost"] = "true";
+
+            if (ReferencedSelfContained)
+            {
+                ReferencedProject.RuntimeIdentifier = EnvironmentInfo.GetCompatibleRid();
+            }
+
+            //  Use a lower version of a library in the referenced project
+            ReferencedProject.PackageReferences.Add(new TestPackageReference("Humanizer", "2.7.9"));
+            ReferencedProject.SourceFiles["Program.cs"] = @"using Humanizer; System.Console.WriteLine(""ReferencedProject"".Humanize());";
+
+            MainProject.ReferencedProjects.Add(ReferencedProject);
+        }
+
+        private void RunTest(bool referencedExeShouldRun, [CallerMemberName] string callingMethod = null)
+        {
+            var testProjectInstance = _testAssetsManager.CreateTestProject(MainProject, callingMethod: callingMethod, identifier: MainSelfContained.ToString() + "_" + ReferencedSelfContained.ToString());
+
+            string outputDirectory;
+
+            if (TestWithPublish)
+            {
+                var publishCommand = new PublishCommand(testProjectInstance);
+
+                publishCommand.Execute()
+                    .Should()
+                    .Pass();
+
+                outputDirectory = publishCommand.GetOutputDirectory(MainProject.TargetFrameworks, runtimeIdentifier: MainProject.RuntimeIdentifier).FullName;
+            }
+            else
+            {
+                var buildCommand = new BuildCommand(testProjectInstance);
+
+                buildCommand.Execute()
+                    .Should()
+                    .Pass();
+
+                outputDirectory = buildCommand.GetOutputDirectory(MainProject.TargetFrameworks, runtimeIdentifier: MainProject.RuntimeIdentifier).FullName;
+            }
+
+            var mainExePath = Path.Combine(outputDirectory, MainProject.Name + Constants.ExeSuffix);
+
+            var referencedExePath = Path.Combine(outputDirectory, ReferencedProject.Name + Constants.ExeSuffix);
+
+            new RunExeCommand(Log, mainExePath)
+                .Execute()
+                .Should()
+                .Pass()
+                .And
+                .HaveStdOut("Main project");
+
+
+            var referencedExeResult = new RunExeCommand(Log, referencedExePath)
+                .Execute();
+
+            if (referencedExeShouldRun)
+            {
+                referencedExeResult
+                    .Should()
+                    .Pass()
+                    .And
+                    .HaveStdOut("Referenced project");
+            }
+            else
+            {
+                referencedExeResult
+                    .Should()
+                    .Fail();
+            }
+        }
+
+
+        [Theory]
+        [InlineData(false, false)]
+        [InlineData(true, true)]
+        public void ReferencedExeCanRun(bool mainSelfContained, bool referencedSelfContained)
+        {
+            MainSelfContained = mainSelfContained;
+            ReferencedSelfContained = referencedSelfContained;
+
+            CreateProjects();
+
+            RunTest(true);
+        }
+
+        [Fact]
+        public void ReferencedExeWithLowerTargetFrameworkCanRun()
+        {
+            MainSelfContained = false;
+            ReferencedSelfContained = false;
+            
+            CreateProjects();
+
+            ReferencedProject.TargetFrameworks = "netcoreapp3.1";
+            ReferencedProject.AdditionalProperties["LangVersion"] = "9.0";
+
+            RunTest(true);
+        }
+
+        //  Test cases that are currently failing
+        [Theory]
+        //  Fails because runtime pack artifacts are not transitively copied
+        [InlineData(true, false)]
+        //  Fails with the following error (is the self-contained copy of hostfxr or something interfering with the framework dependent app?):
+        //  It was not possible to find any compatible framework version
+        //  The framework 'Microsoft.NETCore.App', version '5.0.0' was not found.
+        //    - No frameworks were found.
+        //
+        //  You can resolve the problem by installing the specified framework and/or SDK.
+        [InlineData(false, true)]
+        public void ReferencedExeFailsToRun(bool mainSelfContained, bool referencedSelfContained)
+        {
+            MainSelfContained = mainSelfContained;
+            ReferencedSelfContained = referencedSelfContained;
+
+            CreateProjects();
+
+            RunTest(referencedExeShouldRun: false);
+        }
+
+        [Theory]
+        [InlineData(false, false)]
+        //[InlineData(true, false, Skip = "Currently not supported (see ReferencedExeFailsToRun)")]
+        //[InlineData(false, true, Skip = "Currently not supported (see ReferencedExeFailsToRun)")]
+        [InlineData(true, true)]
+        public void ReferencedExeCanRunWhenPublished(bool mainSelfContained, bool referencedSelfContained)
+        {
+            MainSelfContained = mainSelfContained;
+            ReferencedSelfContained = referencedSelfContained;
+
+            TestWithPublish = true;
+            
+            CreateProjects();
+
+            RunTest(referencedExeShouldRun: true);
+        }
+
+        [Theory]
+        //[InlineData(true, false, Skip = "Currently not supported (see ReferencedExeFailsToRun)")]
+        //[InlineData(false, true, Skip = "Currently not supported (see ReferencedExeFailsToRun)")]
+        [InlineData(true, true)]
+
+        public void ReferencedExeCanRunWhenPublishedWithTrimming(bool mainSelfContained, bool referencedSelfContained)
+        {
+            MainSelfContained = mainSelfContained;
+            ReferencedSelfContained = referencedSelfContained;
+
+            TestWithPublish = true;
+
+            CreateProjects();
+
+            if (MainSelfContained)
+            {
+                MainProject.AdditionalProperties["PublishTrimmed"] = "True";
+            }
+            if (ReferencedSelfContained)
+            {
+                ReferencedProject.AdditionalProperties["PublishTrimmed"] = "True";
+            }
+
+            RunTest(referencedExeShouldRun: true);
+        }
+    }
+}

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatAPublishedDepsJsonShouldContainVersionInformation.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatAPublishedDepsJsonShouldContainVersionInformation.cs
@@ -51,7 +51,7 @@ namespace Microsoft.NET.Publish.Tests
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
-            var publishCommand = new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var publishCommand = new PublishCommand(testAsset);
 
             publishCommand.Execute()
                 .Should()
@@ -122,7 +122,7 @@ namespace Microsoft.NET.Publish.Tests
             }
             else
             {
-                command = new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+                command = new PublishCommand(testAsset);
             }
 
             command.Execute()
@@ -200,7 +200,7 @@ static class Program
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject, callingMethod: callingMethod);
 
-            var publishCommand = new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var publishCommand = new PublishCommand(testAsset);
 
             publishCommand.Execute()
                 .Should()

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToCrossPublish.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToCrossPublish.cs
@@ -34,7 +34,7 @@ namespace Microsoft.NET.Publish.Tests
 
             var testProjectInstance = _testAssetsManager.CreateTestProject(testProject);
 
-            var publishCommand = new PublishCommand(Log, Path.Combine(testProjectInstance.Path, testProject.Name));
+            var publishCommand = new PublishCommand(testProjectInstance);
 
             //  Shouldn't have messages like the following:
             //  Encountered conflict between 'CopyLocal:C:\git\dotnet-sdk\artifacts\.nuget\packages\runtime.any.system.runtime\4.3.0\lib\netstandard1.5\System.Runtime.dll'

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToExcludeAPackageFromPublish.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToExcludeAPackageFromPublish.cs
@@ -43,7 +43,7 @@ namespace Microsoft.NET.Publish.Tests
                                                                         new XAttribute("PrivateAssets", "All")));
                 });
 
-            var publishCommand = new PublishCommand(Log, helloWorldAsset.TestRoot);
+            var publishCommand = new PublishCommand(helloWorldAsset);
             var publishResult = publishCommand.Execute();
 
             publishResult.Should().Pass();
@@ -88,7 +88,7 @@ namespace Microsoft.NET.Publish.Tests
                                                                         new XAttribute("Publish", "false")));
                 });
 
-            var publishCommand = new PublishCommand(Log, helloWorldAsset.TestRoot);
+            var publishCommand = new PublishCommand(helloWorldAsset);
             var publishResult = publishCommand.Execute();
 
             publishResult.Should().Pass();
@@ -134,7 +134,7 @@ namespace Microsoft.NET.Publish.Tests
                                                                         new XAttribute("Publish", "true")));
                 });
 
-            var publishCommand = new PublishCommand(Log, helloWorldAsset.TestRoot);
+            var publishCommand = new PublishCommand(helloWorldAsset);
             var publishResult = publishCommand.Execute();
 
             publishResult.Should().Pass();
@@ -189,7 +189,7 @@ namespace Microsoft.NET.Publish.Tests
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
-            var publishCommand = new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var publishCommand = new PublishCommand(testAsset);
 
             publishCommand.Execute().Should().Pass();
         }
@@ -212,7 +212,7 @@ namespace Microsoft.NET.Publish.Tests
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
-            var publishCommand = new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var publishCommand = new PublishCommand(testAsset);
             publishCommand.Execute().Should().Pass();
 
             var publishDirectory = publishCommand.GetOutputDirectory(testProject.TargetFrameworks);

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToFilterSatelliteAssemblies.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToFilterSatelliteAssemblies.cs
@@ -39,7 +39,7 @@ namespace Microsoft.NET.Publish.Tests
 
             var testProjectInstance = _testAssetsManager.CreateTestProject(testProject);
 
-            var publishCommand = new PublishCommand(Log, Path.Combine(testProjectInstance.TestRoot, testProject.Name));
+            var publishCommand = new PublishCommand(testProjectInstance);
             var publishResult = publishCommand.Execute();
 
             publishResult.Should().Pass();
@@ -78,7 +78,7 @@ namespace Microsoft.NET.Publish.Tests
 
             var testProjectInstance = _testAssetsManager.CreateTestProject(testProject);
 
-            var publishCommand = new PublishCommand(Log, Path.Combine(testProjectInstance.TestRoot, testProject.Name));
+            var publishCommand = new PublishCommand(testProjectInstance);
             var publishResult = publishCommand.Execute();
 
             publishResult.Should().Pass();

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPreserveCompilationContext.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPreserveCompilationContext.cs
@@ -67,14 +67,12 @@ namespace Microsoft.NET.Publish.Tests
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject, identifier: appTargetFramework + withoutCopyingRefs);
 
-            var appProjectDirectory = Path.Combine(testAsset.TestRoot, "TestApp");
-
-            var getValuesCommand = new GetValuesCommand(Log, appProjectDirectory, testProject.TargetFrameworks, "LangVersion");
+            var getValuesCommand = new GetValuesCommand(testAsset, "LangVersion");
             getValuesCommand.Execute().Should().Pass();
 
             var langVersion = getValuesCommand.GetValues().FirstOrDefault() ?? string.Empty;
 
-            var publishCommand = new PublishCommand(Log, appProjectDirectory);
+            var publishCommand = new PublishCommand(testAsset);
 
             publishCommand
                 .Execute()

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAComServerLibrary.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAComServerLibrary.cs
@@ -25,7 +25,7 @@ namespace Microsoft.NET.Publish.Tests
                 .CopyTestAsset("ComServer")
                 .WithSource();
 
-            var publishCommand = new PublishCommand(Log, testAsset.TestRoot);
+            var publishCommand = new PublishCommand(testAsset);
             publishCommand.Execute()
                 .Should()
                 .Pass();

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAFrameworkDependentApp.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAFrameworkDependentApp.cs
@@ -64,7 +64,7 @@ namespace Microsoft.NET.Publish.Tests
                 msbuildArgs.Add("/p:TargetLatestRuntimePatch=true");
             }
 
-            var publishCommand = new PublishCommand(Log, testAsset.TestRoot);
+            var publishCommand = new PublishCommand(testAsset);
             publishCommand
                 .Execute(msbuildArgs.ToArray())
                 .Should()
@@ -113,7 +113,7 @@ namespace Microsoft.NET.Publish.Tests
                 .WithSource()
                 .WithTargetFramework("netcoreapp2.0");
 
-            var publishCommand = new PublishCommand(Log, testAsset.TestRoot);
+            var publishCommand = new PublishCommand(testAsset);
             publishCommand
                 .Execute(
                     "/p:SelfContained=false",

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAHelloWorldProject.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAHelloWorldProject.cs
@@ -34,7 +34,7 @@ namespace Microsoft.NET.Publish.Tests
                 .WithSource()
                 .WithTargetFramework(targetFramework);
 
-            var publishCommand = new PublishCommand(Log, helloWorldAsset.TestRoot);
+            var publishCommand = new PublishCommand(helloWorldAsset);
             var publishResult = publishCommand.Execute();
 
             publishResult.Should().Pass();
@@ -78,7 +78,7 @@ namespace Microsoft.NET.Publish.Tests
                 .WithSource()
                 .WithTargetFramework(targetFramework);
 
-            var publishCommand = new PublishCommand(Log, helloWorldAsset.TestRoot);
+            var publishCommand = new PublishCommand(helloWorldAsset);
             var publishResult = publishCommand.Execute($"/p:RuntimeIdentifier={rid}", "/p:CopyLocalLockFileAssemblies=true");
 
             publishResult.Should().Pass();
@@ -149,7 +149,7 @@ public static class Program
 ";
             var testProjectInstance = _testAssetsManager.CreateTestProject(testProject);
 
-            var publishCommand = new PublishCommand(Log, Path.Combine(testProjectInstance.TestRoot, testProject.Name));
+            var publishCommand = new PublishCommand(testProjectInstance);
             publishCommand.Execute().Should().Pass();
 
             var publishDirectory = publishCommand.GetOutputDirectory(
@@ -194,7 +194,7 @@ public static class Program
 ";
             var testProjectInstance = _testAssetsManager.CreateTestProject(testProject, identifier: runtimeIdentifier);
 
-            var publishCommand = new PublishCommand(Log, Path.Combine(testProjectInstance.TestRoot, testProject.Name));
+            var publishCommand = new PublishCommand(testProjectInstance);
             var publishResult = publishCommand.Execute();
 
             publishResult.Should().Pass();
@@ -310,7 +310,7 @@ public static class Program
                     }
                 });
 
-            var publishCommand = new PublishCommand(Log, Path.Combine(testProjectInstance.TestRoot, testProject.Name));
+            var publishCommand = new PublishCommand(testProjectInstance);
             var publishResult = publishCommand.Execute();
 
             publishResult.Should().Pass();
@@ -415,7 +415,7 @@ public static class Program
                 .CopyTestAsset("HelloWorld")
                 .WithSource();
 
-            var publishCommand = new PublishCommand(Log, helloWorldAsset.TestRoot);
+            var publishCommand = new PublishCommand(helloWorldAsset);
             var publishResult = publishCommand.Execute("/p:RuntimeIdentifier=notvalid");
 
             publishResult.Should().Fail();
@@ -428,7 +428,7 @@ public static class Program
                 .CopyTestAsset("HelloWorld")
                 .WithSource();
 
-            var publishCommand = new PublishCommand(Log, helloWorldAsset.TestRoot);
+            var publishCommand = new PublishCommand(helloWorldAsset);
             var publishResult = publishCommand.Execute("/p:RuntimeIdentifier=notvalid", "/p:EnsureNETCoreAppRuntime=false");
 
             publishResult.Should().Pass();
@@ -449,7 +449,7 @@ public static class Program
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject, testProject.Name);
 
-            var publishCommand = new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var publishCommand = new PublishCommand(testAsset);
 
             publishCommand
                 .Execute("-v:n")
@@ -488,7 +488,7 @@ public static class Program
                 .Should()
                 .Pass();
 
-            new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name))
+            new PublishCommand(testAsset)
                 .Execute("/p:NoBuild=true")
                 .Should()
                 .Fail()
@@ -552,7 +552,7 @@ public static class Program
 </Target>"));
                 });
 
-            new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name))
+            new PublishCommand(testAsset)
                 .Execute()
                 .Should()
                 .Pass()
@@ -602,7 +602,7 @@ public static class Program
 </Project>
 ");
 
-            var command = new PublishCommand(Log, projectDirectory);
+            var command = new PublishCommand(testProjectInstance);
             command
                 .Execute("/p:PublishProfile=test")
                 .Should()
@@ -687,7 +687,7 @@ public static class Program
 </Project>
 ");
 
-            var command = new PublishCommand(Log, projectDirectory);
+            var command = new PublishCommand(testProjectInstance);
             command
                 .Execute(
                     $"/p:WebPublishProfileFile={publishProfilePath}",

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishANetCoreAppForTelemetry.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishANetCoreAppForTelemetry.cs
@@ -31,7 +31,7 @@ namespace Microsoft.NET.Publish.Tests
 
             var testProject = CreateTestProject(targetFramework, "PlainProject");
             var testProjectInstance = _testAssetsManager.CreateTestProject(testProject);
-            var publishCommand = new PublishCommand(Log, Path.Combine(testProjectInstance.Path, testProject.Name));
+            var publishCommand = new PublishCommand(testProjectInstance);
             publishCommand.Execute(TelemetryTestLogger).StdOut.Should().Contain(
                 "{\"EventName\":\"PublishProperties\",\"Properties\":{\"PublishReadyToRun\":\"null\",\"PublishTrimmed\":\"null\",\"PublishSingleFile\":\"null\"}");
         }
@@ -48,7 +48,7 @@ namespace Microsoft.NET.Publish.Tests
 
             var testProject = CreateTestProject(targetFramework, "TrimmedR2RSingleFileProject", true, true, true);
             var testProjectInstance = _testAssetsManager.CreateTestProject(testProject);
-            var publishCommand = new PublishCommand(Log, Path.Combine(testProjectInstance.Path, testProject.Name));
+            var publishCommand = new PublishCommand(testProjectInstance);
             string s = publishCommand.Execute(TelemetryTestLogger).StdOut;//.Should()
             s.Should().Contain(
                 "{\"EventName\":\"PublishProperties\",\"Properties\":{\"PublishReadyToRun\":\"True\",\"PublishTrimmed\":\"True\",\"PublishSingleFile\":\"True\"}");
@@ -78,7 +78,7 @@ namespace Microsoft.NET.Publish.Tests
             testProject.AdditionalProperties["PublishReadyToRunUseCrossgen2"] = "True";
 
             var testProjectInstance = _testAssetsManager.CreateTestProject(testProject);
-            var publishCommand = new PublishCommand(Log, Path.Combine(testProjectInstance.Path, testProject.Name));
+            var publishCommand = new PublishCommand(testProjectInstance);
             publishCommand.Execute(TelemetryTestLogger).StdOut.Should()
                 .Contain(
                     "{\"EventName\":\"PublishProperties\",\"Properties\":{\"PublishReadyToRun\":\"True\",\"PublishTrimmed\":\"null\",\"PublishSingleFile\":\"null\"}")

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAProjectWithDependencies.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAProjectWithDependencies.cs
@@ -31,7 +31,7 @@ namespace Microsoft.NET.Publish.Tests
                 .CopyTestAsset("SimpleDependencies")
                 .WithSource();
 
-            PublishCommand publishCommand = new PublishCommand(Log, simpleDependenciesAsset.TestRoot);
+            PublishCommand publishCommand = new PublishCommand(simpleDependenciesAsset);
             publishCommand
                 .Execute()
                 .Should()
@@ -74,7 +74,7 @@ namespace Microsoft.NET.Publish.Tests
                 .CopyTestAsset("DesktopNeedsBindingRedirects")
                 .WithSource();
 
-            PublishCommand publishCommand = new PublishCommand(Log, testAsset.TestRoot);
+            PublishCommand publishCommand = new PublishCommand(testAsset);
             publishCommand
                 .Execute()
                 .Should()
@@ -132,7 +132,7 @@ namespace Microsoft.NET.Publish.Tests
             string manifestFile1 = Path.Combine(filterProjDir, manifestFileName1);
             string manifestFile2 = Path.Combine(filterProjDir, manifestFileName2);
 
-            PublishCommand publishCommand = new PublishCommand(Log, simpleDependenciesAsset.TestRoot);
+            PublishCommand publishCommand = new PublishCommand(simpleDependenciesAsset);
             publishCommand
                 .Execute($"/p:TargetManifestFiles={manifestFile1}%3b{manifestFile2}")
                 .Should()
@@ -181,7 +181,7 @@ namespace Microsoft.NET.Publish.Tests
             // since this scenario is not supported. Running the published app doesn't work currently.
             // This test should be updated when that bug is fixed.
 
-            PublishCommand publishCommand = new PublishCommand(Log, simpleDependenciesAsset.TestRoot);
+            PublishCommand publishCommand = new PublishCommand(simpleDependenciesAsset);
             publishCommand
                 .Execute($"/p:RuntimeIdentifier={rid}", $"/p:TargetManifestFiles={manifestFile}")
                 .Should()

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishASelfContainedApp.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishASelfContainedApp.cs
@@ -31,7 +31,7 @@ namespace Microsoft.NET.Publish.Tests
                 .CopyTestAsset(TestProjectName)
                 .WithSource();
 
-            var publishCommand = new PublishCommand(Log, testAsset.TestRoot);
+            var publishCommand = new PublishCommand(testAsset);
             publishCommand
                 .Execute(
                     "/p:SelfContained=true",
@@ -51,7 +51,7 @@ namespace Microsoft.NET.Publish.Tests
                 .CopyTestAsset(TestProjectName)
                 .WithSource();
 
-            var publishCommand = new PublishCommand(Log, testAsset.TestRoot);
+            var publishCommand = new PublishCommand(testAsset);
             publishCommand
                 .Execute(
                     "/p:SelfContained=true",
@@ -82,7 +82,7 @@ namespace Microsoft.NET.Publish.Tests
 
             restoreCommand.Execute(msbuildArgs);
 
-            var publishCommand = new PublishCommand(Log, testAsset.TestRoot);
+            var publishCommand = new PublishCommand(testAsset);
             publishCommand
                 .Execute(msbuildArgs)
                 .Should().Pass();
@@ -108,7 +108,7 @@ namespace Microsoft.NET.Publish.Tests
                     doc.Root.Element("PropertyGroup").Element("TargetFramework").SetValue(TargetFramework);
                 });
 
-            var publishCommand = new PublishCommand(Log, testAsset.TestRoot);
+            var publishCommand = new PublishCommand(testAsset);
             publishCommand
                 .Execute(
                     "/p:SelfContained=true",
@@ -143,11 +143,9 @@ namespace Microsoft.NET.Publish.Tests
                 $"/p:RuntimeIdentifier={EnvironmentInfo.GetCompatibleRid("netcoreapp3.1")}"
             };
 
-            var projectRoot = Path.Combine(testAsset.TestRoot, "main");
-
             new RestoreCommand(testAsset, "main").Execute(args);
 
-            new PublishCommand(Log, projectRoot)
+            new PublishCommand(testAsset, "main")
                 .Execute(args)
                 .Should()
                 .Pass();
@@ -172,7 +170,7 @@ namespace Microsoft.NET.Publish.Tests
             var testProjectInstance = _testAssetsManager.CreateTestProject(testProject);
 
             var rid = EnvironmentInfo.GetCompatibleRid(tfm);
-            var command = new PublishCommand(Log, Path.Combine(testProjectInstance.Path, testProject.Name));
+            var command = new PublishCommand(testProjectInstance);
 
             command
                 .Execute($"/p:RuntimeIdentifier={rid}")
@@ -218,7 +216,7 @@ namespace Microsoft.NET.Publish.Tests
             var testProjectInstance = _testAssetsManager.CreateTestProject(testProject);
 
             var rid = EnvironmentInfo.GetCompatibleRid(tfm);
-            var command = new PublishCommand(Log, Path.Combine(testProjectInstance.Path, testProject.Name));
+            var command = new PublishCommand(testProjectInstance);
 
             command
                 .Execute($"/p:RuntimeIdentifier={rid}")

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishASingleFileApp.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishASingleFileApp.cs
@@ -71,7 +71,7 @@ namespace Microsoft.NET.Publish.Tests
                 writer.Write("World!");
             }
 
-            return new PublishCommand(Log, testAsset.TestRoot);
+            return new PublishCommand(testAsset);
         }
 
         private string GetNativeDll(string baseName)
@@ -99,7 +99,7 @@ namespace Microsoft.NET.Publish.Tests
             testProject.AdditionalProperties.Add("SelfContained", $"{true}");
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
-            var cmd = new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var cmd = new PublishCommand(testAsset);
 
             var singleFilePath = Path.Combine(GetPublishDirectory(cmd).FullName, $"SingleFileTest{Constants.ExeSuffix}");
             cmd.Execute(RuntimeIdentifier).Should().Pass();
@@ -155,7 +155,7 @@ namespace Microsoft.NET.Publish.Tests
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
-            var publishCommand = new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var publishCommand = new PublishCommand(testAsset);
 
             publishCommand.Execute(PublishSingleFile, RuntimeIdentifier)
                 .Should()
@@ -179,7 +179,7 @@ namespace Microsoft.NET.Publish.Tests
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
-            var publishCommand = new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var publishCommand = new PublishCommand(testAsset);
 
             publishCommand.Execute(PublishSingleFile, RuntimeIdentifier, UseAppHost)
                 .Should()
@@ -203,7 +203,7 @@ namespace Microsoft.NET.Publish.Tests
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
-            var publishCommand = new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var publishCommand = new PublishCommand(testAsset);
 
             publishCommand.Execute(PublishSingleFile, RuntimeIdentifier)
                 .Should()
@@ -332,7 +332,7 @@ namespace Microsoft.NET.Publish.Tests
             };
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
-            var publishCommand = new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var publishCommand = new PublishCommand(testAsset);
 
             publishCommand
                 .Execute(PublishSingleFile, RuntimeIdentifier, IncludeAllContent, IncludePdb)
@@ -390,7 +390,7 @@ namespace Microsoft.NET.Publish.Tests
             };
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
-            var publishCommand = new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var publishCommand = new PublishCommand(testAsset);
 
             publishCommand
                 .Execute(PublishSingleFile, RuntimeIdentifier, ReadyToRun, ReadyToRunWithSymbols, IncludeAllContent, IncludePdb)
@@ -533,7 +533,7 @@ namespace Microsoft.NET.Publish.Tests
             testProject.AdditionalProperties.Add("SelfContained", $"{selfContained}");
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
-            var publishCommand = new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var publishCommand = new PublishCommand(testAsset);
 
             publishCommand.Execute(PublishSingleFile, RuntimeIdentifier, bundleOption)
                 .Should()
@@ -565,7 +565,7 @@ namespace Microsoft.NET.Publish.Tests
             testProject.AdditionalProperties.Add("SelfContained", $"{selfContained}");
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
-            var publishCommand = new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var publishCommand = new PublishCommand(testAsset);
 
             publishCommand.Execute(PublishSingleFile, RuntimeIdentifier, IncludePdb)
                 .Should()

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAToolProjectWithPackagedShim.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAToolProjectWithPackagedShim.cs
@@ -46,7 +46,7 @@ namespace Microsoft.NET.Publish.Tests
         public void It_contains_dependencies_shims()
         {
             var testAsset = SetupTestAsset();
-            var publishCommand = new PublishCommand(Log, testAsset.TestRoot);
+            var publishCommand = new PublishCommand(testAsset);
 
             publishCommand.Execute();
 
@@ -63,7 +63,7 @@ namespace Microsoft.NET.Publish.Tests
             var buildCommand = new BuildCommand(testAsset);
             buildCommand.Execute();
 
-            var publishCommand = new PublishCommand(Log, testAsset.TestRoot);
+            var publishCommand = new PublishCommand(testAsset);
 
             publishCommand.Execute("/p:NoBuild=true");
 

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAWebApp.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAWebApp.cs
@@ -37,7 +37,7 @@ namespace Microsoft.NET.Publish.Tests
                 .Should()
                 .Pass();
 
-            var command = new PublishCommand(Log, testAsset.TestRoot);
+            var command = new PublishCommand(testAsset);
 
             command
                 .Execute(args)
@@ -79,7 +79,7 @@ namespace Microsoft.NET.Publish.Tests
 
             var testProjectInstance = _testAssetsManager.CreateTestProject(testProject);
 
-            var command = new PublishCommand(Log, Path.Combine(testProjectInstance.Path, testProject.Name));
+            var command = new PublishCommand(testProjectInstance);
 
             var rid = EnvironmentInfo.GetCompatibleRid(tfm);
             command
@@ -137,7 +137,7 @@ namespace Microsoft.NET.Publish.Tests
 
             var testProjectInstance = _testAssetsManager.CreateTestProject(testProject);
 
-            var command = new PublishCommand(Log, Path.Combine(testProjectInstance.Path, testProject.Name));
+            var command = new PublishCommand(testProjectInstance);
 
             var rid = EnvironmentInfo.GetCompatibleRid(tfm);
             command
@@ -203,7 +203,7 @@ namespace Microsoft.NET.Publish.Tests
 </Project>
 ");
 
-            var command = new PublishCommand(Log, projectDirectory);
+            var command = new PublishCommand(testProjectInstance);
             command
                 .Execute("/p:PublishProfile=test")
                 .Should()

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAnUnpublishableProject.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAnUnpublishableProject.cs
@@ -22,7 +22,7 @@ namespace Microsoft.NET.Publish.Tests
                 .CopyTestAsset("Unpublishable")
                 .WithSource();
 
-            var publishCommand = new PublishCommand(Log, helloWorldAsset.TestRoot);
+            var publishCommand = new PublishCommand(helloWorldAsset);
             var publishResult = publishCommand.Execute();
 
             publishResult.Should().Pass();

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishIncrementally.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishIncrementally.cs
@@ -39,7 +39,7 @@ namespace Microsoft.NET.Publish.Tests
             var expectedSingleExeFiles = new string[] { ".exe", ".pdb" }.Select(ending => testProject.Name + ending);
 
             // Publish normally
-            new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name))
+            new PublishCommand(testAsset)
                 .Execute()
                 .Should()
                 .Pass();
@@ -48,7 +48,7 @@ namespace Microsoft.NET.Publish.Tests
             File.WriteAllText(Path.Combine(publishDir, "UserData.txt"), string.Empty);
 
             // Publish as a single file
-            new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name))
+            new PublishCommand(testAsset)
                 .Execute(@"/p:PublishSingleFile=true")
                 .Should()
                 .Pass();
@@ -72,7 +72,7 @@ namespace Microsoft.NET.Publish.Tests
             var expectedSingleExeFileExtensions = new string[] { ".exe", ".pdb" };
 
             // Publish as a single file
-            new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name))
+            new PublishCommand(testAsset)
                 .Execute(@"/p:PublishSingleFile=true")
                 .Should()
                 .Pass();
@@ -87,7 +87,7 @@ namespace Microsoft.NET.Publish.Tests
                 Path.Combine(testAsset.TestRoot, testProject.Name, newName + ".csproj"));
 
             // Publish as a single file
-            new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name))
+            new PublishCommand(testAsset)
                 .Execute(@"/p:PublishSingleFile=true")
                 .Should()
                 .Pass();
@@ -112,7 +112,7 @@ namespace Microsoft.NET.Publish.Tests
             var expectedSingleExeFiles = new string[] { ".exe", ".pdb" }.Select(ending => testProject.Name + ending);
 
             // Publish as a single file
-            new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name))
+            new PublishCommand(testAsset)
                 .Execute(@"/p:PublishSingleFile=true")
                 .Should()
                 .Pass();
@@ -122,7 +122,7 @@ namespace Microsoft.NET.Publish.Tests
             File.WriteAllText(Path.Combine(publishDir, testProject.Name + ".dll"), string.Empty);
 
             // Publish as a single file
-            new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name))
+            new PublishCommand(testAsset)
                 .Execute(@"/p:PublishSingleFile=true")
                 .Should()
                 .Pass();
@@ -149,7 +149,7 @@ namespace Microsoft.NET.Publish.Tests
             var expectedSingleExeFiles = new string[] { ".exe", ".pdb" }.Select(ending => testProject.Name + ending);
 
             // Publish trimmed
-            new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name))
+            new PublishCommand(testAsset)
                 .Execute()
                 .Should()
                 .Pass();
@@ -158,7 +158,7 @@ namespace Microsoft.NET.Publish.Tests
             File.WriteAllText(Path.Combine(publishDir, "UserData.txt"), string.Empty);
 
             // Publish as a single file
-            new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name))
+            new PublishCommand(testAsset)
                 .Execute(@"/p:PublishSingleFile=true")
                 .Should()
                 .Pass();
@@ -221,7 +221,7 @@ namespace Microsoft.NET.Publish.Tests
             var expectedSingleExeFiles = new string[] { ".exe", ".pdb" }.Select(ending => testProject.Name + ending);
 
             // Publish normally
-            new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name))
+            new PublishCommand(testAsset)
                 .Execute("/p:PublishDir=" + publishOutputFolder)
                 .Should()
                 .Pass();
@@ -230,7 +230,7 @@ namespace Microsoft.NET.Publish.Tests
             File.WriteAllText(Path.Combine(publishDir, "UserData.txt"), string.Empty);
 
             // Publish as a single file
-            new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name))
+            new PublishCommand(testAsset)
                 .Execute(@"/p:PublishSingleFile=true", "/p:PublishDir=" + publishOutputFolder)
                 .Should()
                 .Pass();
@@ -259,14 +259,14 @@ namespace Microsoft.NET.Publish.Tests
             var expectedSingleExeFiles = new string[] { ".exe", ".pdb" }.Select(ending => testProject.Name + ending);
 
             // Publish normally in folder 1
-            new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name))
+            new PublishCommand(testAsset)
                 .Execute("/p:PublishDir=" + publishOutputFolder1)
                 .Should()
                 .Pass();
             CheckPublishOutput(publishDir1, expectedSingleExeFiles.Concat(expectedNonSingleExeFiles), null);
 
             // Publish as a single file in folder 2
-            new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name))
+            new PublishCommand(testAsset)
                 .Execute(@"/p:PublishSingleFile=true", "/p:PublishDir=" + publishOutputFolder2)
                 .Should()
                 .Pass();
@@ -278,7 +278,7 @@ namespace Microsoft.NET.Publish.Tests
             var newName = "PublishToMultipleDirs1";
             File.Move(Path.Combine(testAsset.TestRoot, testProject.Name, testProject.Name + ".csproj"),
                 Path.Combine(testAsset.TestRoot, testProject.Name, newName + ".csproj"));
-            new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name))
+            new PublishCommand(testAsset)
                 .Execute("/p:PublishDir=" + publishOutputFolder1)
                 .Should()
                 .Pass();

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishReadyToRun.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishReadyToRun.cs
@@ -33,7 +33,7 @@ namespace Microsoft.NET.Publish.Tests
 
             var testProjectInstance = _testAssetsManager.CreateTestProject(testProject);
 
-            var publishCommand = new PublishCommand(Log, Path.Combine(testProjectInstance.Path, testProject.Name));
+            var publishCommand = new PublishCommand(testProjectInstance);
             publishCommand.Execute().Should().Pass();
 
             DirectoryInfo publishDirectory = publishCommand.GetOutputDirectory(
@@ -63,7 +63,7 @@ namespace Microsoft.NET.Publish.Tests
 
             var testProjectInstance = _testAssetsManager.CreateTestProject(testProject);
 
-            var publishCommand = new PublishCommand(Log, Path.Combine(testProjectInstance.Path, testProject.Name));
+            var publishCommand = new PublishCommand(testProjectInstance);
             publishCommand.Execute().Should().Pass();
 
             DirectoryInfo publishDirectory = publishCommand.GetOutputDirectory(
@@ -149,7 +149,7 @@ namespace Microsoft.NET.Publish.Tests
 
             var testProjectInstance = _testAssetsManager.CreateTestProject(testProject);
 
-            var publishCommand = new PublishCommand(Log, Path.Combine(testProjectInstance.Path, testProject.Name));
+            var publishCommand = new PublishCommand(testProjectInstance);
 
             publishCommand.Execute()
                 .Should()
@@ -170,7 +170,7 @@ namespace Microsoft.NET.Publish.Tests
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
-            var publishCommand = new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var publishCommand = new PublishCommand(testAsset);
 
             publishCommand.Execute($"/p:PublishReadyToRun=true",
                                    $"/p:RuntimeIdentifier={RuntimeInformation.RuntimeIdentifier}")
@@ -237,7 +237,7 @@ namespace Microsoft.NET.Publish.Tests
 
             var testProjectInstance = _testAssetsManager.CreateTestProject(testProject);
 
-            var publishCommand = new PublishCommand(Log, Path.Combine(testProjectInstance.Path, testProject.Name));
+            var publishCommand = new PublishCommand(testProjectInstance);
             publishCommand.Execute()
                 .Should()
                 .Fail()
@@ -260,7 +260,7 @@ namespace Microsoft.NET.Publish.Tests
 
             var testProjectInstance = _testAssetsManager.CreateTestProject(testProject);
 
-            var publishCommand = new PublishCommand(Log, Path.Combine(testProjectInstance.Path, testProject.Name));
+            var publishCommand = new PublishCommand(testProjectInstance);
             publishCommand.Execute().Should().Pass();
 
             DirectoryInfo publishDirectory = publishCommand.GetOutputDirectory(

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishToClickOnce.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishToClickOnce.cs
@@ -66,7 +66,7 @@ namespace Microsoft.NET.Publish.Tests
 </Project>
 ");
 
-            var command = new PublishCommand(Log, projectDirectory);
+            var command = new PublishCommand(testProjectInstance);
             command
                 .Execute("/p:PublishProfile=test")
                 .Should()

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishWithGeneratePackageOnBuildAndPackAsTool.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishWithGeneratePackageOnBuildAndPackAsTool.cs
@@ -43,8 +43,7 @@ namespace Microsoft.NET.ToolPack.Tests
                     propertyGroup.Add(new XElement(ns + "PackAsTool", packAsTool.ToString()));
                 });
 
-            var appProjectDirectory = Path.Combine(testAsset.TestRoot);
-            var publishCommand = new PublishCommand(Log, appProjectDirectory);
+            var publishCommand = new PublishCommand(testAsset);
 
             CommandResult result = publishCommand.Execute();
 

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToRunILLink.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToRunILLink.cs
@@ -39,7 +39,7 @@ namespace Microsoft.NET.Publish.Tests
             var testProject = CreateTestProjectForILLinkTesting(targetFramework, projectName, referenceProjectName);
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
-            var publishCommand = new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var publishCommand = new PublishCommand(testAsset);
             publishCommand.Execute($"/p:RuntimeIdentifier={rid}", $"/p:SelfContained=true").Should().Pass();
 
             var publishDirectory = publishCommand.GetOutputDirectory(targetFramework: targetFramework, runtimeIdentifier: rid).FullName;
@@ -75,7 +75,7 @@ namespace Microsoft.NET.Publish.Tests
             var testAsset = _testAssetsManager.CreateTestProject(testProject, identifier: targetFramework + referenceClassLibAsPackage)
                 .WithProjectChanges(project => EnableNonFrameworkTrimming(project));
 
-            var publishCommand = new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var publishCommand = new PublishCommand(testAsset);
             publishCommand.Execute($"/p:RuntimeIdentifier={rid}", $"/p:SelfContained=true", "/p:PublishTrimmed=true").Should().Pass();
 
             var publishDirectory = publishCommand.GetOutputDirectory(targetFramework: targetFramework, runtimeIdentifier: rid).FullName;
@@ -113,7 +113,7 @@ namespace Microsoft.NET.Publish.Tests
             var testProject = CreateTestProjectForILLinkTesting(targetFramework, projectName);
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
-            var publishCommand = new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var publishCommand = new PublishCommand(testAsset);
             publishCommand.Execute($"/p:RuntimeIdentifier={rid}", "/p:SelfContained=true", "/p:PublishTrimmed=true", $"/p:TrimMode={trimMode}")
                 .Should().Pass()
                 .And.NotHaveStdOutContaining("warning IL2075")
@@ -139,7 +139,7 @@ namespace Microsoft.NET.Publish.Tests
             var testAsset = _testAssetsManager.CreateTestProject(testProject)
                 .WithProjectChanges(project => SetIsTrimmable(project, referenceProjectName));
 
-            var publishCommand = new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var publishCommand = new PublishCommand(testAsset);
             publishCommand.Execute($"/p:RuntimeIdentifier={rid}", $"/p:SelfContained=true", "/p:PublishTrimmed=true").Should().Pass();
 
             var publishDirectory = publishCommand.GetOutputDirectory(targetFramework: targetFramework, runtimeIdentifier: rid).FullName;
@@ -164,7 +164,7 @@ namespace Microsoft.NET.Publish.Tests
             var testAsset = _testAssetsManager.CreateTestProject(testProject)
                 .WithProjectChanges(project => SetTrimMode(project, referenceProjectName, "link"));
 
-            var publishCommand = new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var publishCommand = new PublishCommand(testAsset);
             publishCommand.Execute($"/p:RuntimeIdentifier={rid}", $"/p:SelfContained=true", "/p:PublishTrimmed=true").Should().Pass();
 
             var publishDirectory = publishCommand.GetOutputDirectory(targetFramework: targetFramework, runtimeIdentifier: rid).FullName;
@@ -191,7 +191,7 @@ namespace Microsoft.NET.Publish.Tests
                 .WithProjectChanges(project => SetIsTrimmable(project, referenceProjectName))
                 .WithProjectChanges(project => AddRootDescriptor(project, $"{referenceProjectName}.xml"));
 
-            var publishCommand = new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var publishCommand = new PublishCommand(testAsset);
             publishCommand.Execute($"/p:RuntimeIdentifier={rid}", $"/p:SelfContained=true", "/p:PublishTrimmed=true").Should().Pass();
 
             var publishDirectory = publishCommand.GetOutputDirectory(targetFramework: targetFramework, runtimeIdentifier: rid).FullName;
@@ -216,7 +216,7 @@ namespace Microsoft.NET.Publish.Tests
             var testProject = CreateTestProjectWithAnalysisWarnings(targetFramework, projectName);
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
-            var publishCommand = new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var publishCommand = new PublishCommand(testAsset);
             publishCommand.Execute($"/p:RuntimeIdentifier={rid}", $"/p:SelfContained=true", "/p:PublishTrimmed=true")
                 .Should().Pass()
                 // trim analysis warnings are disabled
@@ -237,7 +237,7 @@ namespace Microsoft.NET.Publish.Tests
             var testProject = CreateTestProjectWithAnalysisWarnings(targetFramework, projectName);
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
-            var publishCommand = new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var publishCommand = new PublishCommand(testAsset);
             publishCommand.Execute($"/p:RuntimeIdentifier={rid}", $"/p:SelfContained=true", "/p:PublishTrimmed=true", "/p:SuppressTrimAnalysisWarnings=false")
                 .Should().Pass()
                 .And.HaveStdOutMatching("warning IL2075.*Program.IL_2075")
@@ -266,7 +266,7 @@ namespace Microsoft.NET.Publish.Tests
             var testAsset = _testAssetsManager.CreateTestProject(testProject)
                 .WithProjectChanges(project => AddRootDescriptor(project, $"{projectName}.xml"));
 
-            var publishCommand = new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var publishCommand = new PublishCommand(testAsset);
             publishCommand.Execute($"/p:RuntimeIdentifier={rid}", $"/p:SelfContained=true", "/p:PublishTrimmed=true", "/p:SuppressTrimAnalysisWarnings=false")
                 .Should().Fail()
                 .And.HaveStdOutContaining("error IL1001")
@@ -295,7 +295,7 @@ namespace Microsoft.NET.Publish.Tests
                 .WithProjectChanges(project => EnableNonFrameworkTrimming(project))
                 .WithProjectChanges(project => AddRootDescriptor(project, $"{referenceProjectName}.xml"));
 
-            var publishCommand = new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var publishCommand = new PublishCommand(testAsset);
             // Inject extra arguments to prevent the linker from
             // keeping the entire referenceProject assembly. The
             // linker by default runs in a conservative mode that
@@ -333,7 +333,7 @@ namespace Microsoft.NET.Publish.Tests
             var testProject = CreateTestProjectForILLinkTesting(targetFramework, projectName);
             var testAsset = _testAssetsManager.CreateTestProject(testProject, identifier: property);
 
-            var publishCommand = new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var publishCommand = new PublishCommand(testAsset);
             publishCommand.Execute($"/p:RuntimeIdentifier={rid}", $"/p:SelfContained=true", "/p:PublishTrimmed=true", $"/p:{property}=NonBool")
                 .Should().Fail().And.HaveStdOutContaining("MSB4030");
         }
@@ -356,7 +356,7 @@ namespace Microsoft.NET.Publish.Tests
                 .WithProjectChanges(project => AddRuntimeConfigOption(project, trim: true))
                 .WithProjectChanges(project => AddRootDescriptor(project, $"{referenceProjectName}.xml"));
 
-            var publishCommand = new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var publishCommand = new PublishCommand(testAsset);
             publishCommand.Execute($"/p:RuntimeIdentifier={rid}", $"/p:SelfContained=true", "/p:PublishTrimmed=true",
                                     $"/p:_ExtraTrimmerArgs=-p link {referenceProjectName}").Should().Pass();
 
@@ -388,7 +388,7 @@ namespace Microsoft.NET.Publish.Tests
                 .WithProjectChanges(project => AddRuntimeConfigOption(project, trim: false))
                 .WithProjectChanges(project => AddRootDescriptor(project, $"{referenceProjectName}.xml"));
 
-            var publishCommand = new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var publishCommand = new PublishCommand(testAsset);
             publishCommand.Execute($"/p:RuntimeIdentifier={rid}", $"/p:SelfContained=true", "/p:PublishTrimmed=true",
                                     $"/p:_ExtraTrimmerArgs=-p link {referenceProjectName}").Should().Pass();
 
@@ -413,7 +413,7 @@ namespace Microsoft.NET.Publish.Tests
             var testProject = CreateTestProjectForILLinkTesting(targetFramework, projectName, referenceProjectName);
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
-            var publishCommand = new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var publishCommand = new PublishCommand(testAsset);
 
             var intermediateDirectory = publishCommand.GetIntermediateDirectory(targetFramework: targetFramework, runtimeIdentifier: rid).FullName;
 
@@ -441,7 +441,7 @@ namespace Microsoft.NET.Publish.Tests
             var testProject = CreateTestProjectForILLinkTesting(targetFramework, projectName, referenceProjectName);
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
-            var publishCommand = new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var publishCommand = new PublishCommand(testAsset);
             publishCommand.Execute("/v:n", $"/p:RuntimeIdentifier={rid}", $"/p:SelfContained=true", "/p:PublishTrimmed=true").Should().Pass();
 
             var publishDirectory = publishCommand.GetOutputDirectory(targetFramework: targetFramework, runtimeIdentifier: rid).FullName;
@@ -479,7 +479,7 @@ namespace Microsoft.NET.Publish.Tests
                 .WithProjectChanges(project => EnableNonFrameworkTrimming(project))
                 .WithProjectChanges(project => AddRootDescriptor(project, $"{referenceProjectName}.xml"));
 
-            var publishCommand = new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var publishCommand = new PublishCommand(testAsset);
 
             var publishDirectory = publishCommand.GetOutputDirectory(targetFramework: targetFramework, runtimeIdentifier: rid).FullName;
             var intermediateDirectory = publishCommand.GetIntermediateDirectory(targetFramework: targetFramework, runtimeIdentifier: rid).FullName;
@@ -530,7 +530,7 @@ namespace Microsoft.NET.Publish.Tests
             var testAsset = _testAssetsManager.CreateTestProject(testProject)
                 .WithProjectChanges(project => EnableNonFrameworkTrimming(project));
 
-            var publishCommand = new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var publishCommand = new PublishCommand(testAsset);
             publishCommand.Execute($"/p:RuntimeIdentifier={rid}", $"/p:SelfContained=true", "/p:PublishTrimmed=true").Should().Pass();
 
             var publishDirectory = publishCommand.GetOutputDirectory(targetFramework: targetFramework, runtimeIdentifier: rid).FullName;
@@ -563,7 +563,7 @@ namespace Microsoft.NET.Publish.Tests
             var testAsset = _testAssetsManager.CreateTestProject(testProject)
                 .WithProjectChanges(project => EnableNonFrameworkTrimming(project));
 
-            var publishCommand = new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var publishCommand = new PublishCommand(testAsset);
             publishCommand.Execute($"/p:RuntimeIdentifier={rid}", $"/p:SelfContained=true", "/p:PublishTrimmed=true", "/p:DebuggerSupport=false").Should().Pass();
 
             var publishDirectory = publishCommand.GetOutputDirectory(targetFramework: targetFramework, runtimeIdentifier: rid).FullName;
@@ -591,7 +591,7 @@ namespace Microsoft.NET.Publish.Tests
             var testAsset = _testAssetsManager.CreateTestProject(testProject)
                 .WithProjectChanges(project => EnableNonFrameworkTrimming(project));
 
-            var publishCommand = new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var publishCommand = new PublishCommand(testAsset);
             publishCommand.Execute($"/p:RuntimeIdentifier={rid}", $"/p:SelfContained=true", "/p:PublishTrimmed=true", "/p:TrimmerRemoveSymbols=true").Should().Pass();
 
             var publishDirectory = publishCommand.GetOutputDirectory(targetFramework: targetFramework, runtimeIdentifier: rid).FullName;
@@ -619,7 +619,7 @@ namespace Microsoft.NET.Publish.Tests
             var testAsset = _testAssetsManager.CreateTestProject(testProject)
                 .WithProjectChanges(project => EnableNonFrameworkTrimming(project));
 
-            var publishCommand = new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var publishCommand = new PublishCommand(testAsset);
             publishCommand.Execute($"/p:RuntimeIdentifier={rid}", $"/p:SelfContained=true", "/p:PublishTrimmed=true",
                                     "/p:DebuggerSupport=false", "/p:TrimmerRemoveSymbols=false").Should().Pass();
 
@@ -651,7 +651,7 @@ namespace Microsoft.NET.Publish.Tests
             var testProject = CreateTestProjectWithAnalysisWarnings(targetFramework, projectName);
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
-            var publishCommand = new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var publishCommand = new PublishCommand(testAsset);
             publishCommand.Execute($"/p:RuntimeIdentifier={rid}", $"/p:SelfContained=true", "/p:PublishTrimmed=true", "/p:SuppressTrimAnalysisWarnings=false",
                                     "/p:WarningsAsErrors=IL2075")
                 .Should().Fail()
@@ -669,7 +669,7 @@ namespace Microsoft.NET.Publish.Tests
             var testProject = CreateTestProjectWithAnalysisWarnings(targetFramework, projectName);
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
-            var publishCommand = new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var publishCommand = new PublishCommand(testAsset);
             publishCommand.Execute($"/p:RuntimeIdentifier={rid}", $"/p:SelfContained=true", "/p:PublishTrimmed=true", "/p:SuppressTrimAnalysisWarnings=false",
                                     "/p:TreatWarningsAsErrors=true", "/p:WarningsNotAsErrors=IL2075")
                 .Should().Fail()
@@ -687,7 +687,7 @@ namespace Microsoft.NET.Publish.Tests
             var testProject = CreateTestProjectWithAnalysisWarnings(targetFramework, projectName);
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
-            var publishCommand = new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var publishCommand = new PublishCommand(testAsset);
             publishCommand.Execute($"/p:RuntimeIdentifier={rid}", $"/p:SelfContained=true", "/p:PublishTrimmed=true", "/p:SuppressTrimAnalysisWarnings=false",
                                     "/p:NoWarn=IL2075", "/p:WarnAsError=IL2075")
                 .Should().Pass()
@@ -706,7 +706,7 @@ namespace Microsoft.NET.Publish.Tests
             var testProject = CreateTestProjectWithAnalysisWarnings(targetFramework, projectName);
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
-            var publishCommand = new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var publishCommand = new PublishCommand(testAsset);
             publishCommand.Execute($"/p:RuntimeIdentifier={rid}", $"/p:SelfContained=true", "/p:PublishTrimmed=true", "/p:SuppressTrimAnalysisWarnings=false",
                                     "/p:AnalysisLevel=0.0")
                 .Should().Pass()
@@ -723,7 +723,7 @@ namespace Microsoft.NET.Publish.Tests
             var testProject = CreateTestProjectWithAnalysisWarnings(targetFramework, projectName);
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
-            var publishCommand = new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var publishCommand = new PublishCommand(testAsset);
             publishCommand.Execute($"/p:RuntimeIdentifier={rid}", $"/p:SelfContained=true", "/p:PublishTrimmed=true", "/p:SuppressTrimAnalysisWarnings=false",
                                     "/p:ILLinkWarningLevel=0")
                 .Should().Pass()
@@ -740,7 +740,7 @@ namespace Microsoft.NET.Publish.Tests
             var testProject = CreateTestProjectWithAnalysisWarnings(targetFramework, projectName);
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
-            var publishCommand = new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var publishCommand = new PublishCommand(testAsset);
             publishCommand.Execute($"/p:RuntimeIdentifier={rid}", $"/p:SelfContained=true", "/p:PublishTrimmed=true", "/p:SuppressTrimAnalysisWarnings=false",
                                     "/p:TreatWarningsAsErrors=true", "/p:ILLinkTreatWarningsAsErrors=false")
                 .Should().Pass()
@@ -757,7 +757,7 @@ namespace Microsoft.NET.Publish.Tests
             var testProject = CreateTestProjectForILLinkTesting(targetFramework, projectName, referenceProjectName);
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
-            var publishCommand = new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var publishCommand = new PublishCommand(testAsset);
             publishCommand.Execute("/p:PublishTrimmed=true")
                 .Should().Fail()
                 .And.HaveStdOutContaining(Strings.ILLinkNotSupportedError);
@@ -774,7 +774,7 @@ namespace Microsoft.NET.Publish.Tests
             var testProject = CreateTestProjectForILLinkTesting(targetFramework, projectName, referenceProjectName);
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
-            var publishCommand = new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var publishCommand = new PublishCommand(testAsset);
             publishCommand.Execute("/p:PublishTrimmed=true", $"/p:RuntimeIdentifier={rid}", "/p:SelfContained=true", "/p:PublishTrimmed=true")
                 .Should().Pass().And.HaveStdOutContainingIgnoreCase("https://aka.ms/dotnet-illink");
         }
@@ -815,7 +815,7 @@ namespace Microsoft.NET.Publish.Tests
             };
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
-            var publishCommand = new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var publishCommand = new PublishCommand(testAsset);
             publishCommand.Execute().Should().Pass();
 
             var publishDir = publishCommand.GetOutputDirectory(targetFramework, runtimeIdentifier: rid);
@@ -897,7 +897,7 @@ namespace Microsoft.NET.Publish.Tests
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
-            var publishCommand = new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var publishCommand = new PublishCommand(testAsset);
 
             publishCommand.Execute($"/p:PublishTrimmed=true")
                 .Should()

--- a/src/Tests/Microsoft.NET.Publish.Tests/PublishWebApp.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/PublishWebApp.cs
@@ -45,7 +45,7 @@ namespace Microsoft.NET.Publish.Tests
 
                             });
 
-            var publishCommand = new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            var publishCommand = new PublishCommand(testAsset);
 
             publishCommand.Execute()
                 .Should()

--- a/src/Tests/Microsoft.NET.Publish.Tests/RuntimeIdentifiersTests.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/RuntimeIdentifiersTests.cs
@@ -128,7 +128,7 @@ namespace Microsoft.NET.Publish.Tests
                     publishArgs.Add("/p:NoBuild=true");
                 }
 
-                var publishCommand = new PublishCommand(Log, Path.Combine(testAsset.Path, testProject.Name));
+                var publishCommand = new PublishCommand(testAsset);
                 publishCommand.Execute(publishArgs.ToArray())
                     .Should()
                     .Pass();

--- a/src/Tests/Microsoft.NET.TestFramework/Commands/PublishCommand.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/Commands/PublishCommand.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.ComponentModel;
 using System.IO;
 using Xunit.Abstractions;
 
@@ -10,9 +11,17 @@ namespace Microsoft.NET.TestFramework.Commands
     {
         private const string PublishSubfolderName = "publish";
 
+        //  Encourage use of the other overload, which is generally simpler to use
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public PublishCommand(ITestOutputHelper log, string projectPath)
             : base(log, "Publish", projectPath, relativePathToProject: null)
         {
+        }
+
+        public PublishCommand(TestAsset testAsset, string relativePathToProject = null)
+            : base(testAsset, "Publish", relativePathToProject)
+        {
+
         }
 
         public override DirectoryInfo GetOutputDirectory(string targetFramework = "netcoreapp1.1", string configuration = "Debug", string runtimeIdentifier = "")


### PR DESCRIPTION
Fix #1675 

Include runtimeconfig.json and deps.json in files that are copied from a referenced Exe project.

Note that I also included a refactoring of how you can create test PublishCommands, which touched a lot of files.  So it should be easier to review this commit by commit.

Currently, it still fails if a self-contained project references a framework-dependent project, or vice versa.  When a self-contained project references a framework-dependent project, running the referenced project fails with the following error:

> It was not possible to find any compatible framework version
> The framework 'Microsoft.NETCore.App', version '5.0.0' was not found.
>  - No frameworks were found.
>
> You can resolve the problem by installing the specified framework and/or SDK.

I suspect this may be because some of the host files (hostfxr or something) are different between self-contained and framework-dependent apps, and are interfering with each other.  @vitek-karas @agocke What do you think?

When a framework-dependent project references a self-contained project, it fails because the runtime pack assets aren't copied.  However, if we were to fix that I think we might run into the same issues that we get when referencing a framework-dependent project from a self-contained project.

@jaredpar @ericstj @ViktorHofer 