### PR TITLE
Fix building projects restored with NuGet 5.7

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageAssets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageAssets.cs
@@ -663,8 +663,8 @@ namespace Microsoft.NET.Build.Tasks
                 CanWriteToCacheFile = true;
                 if (task.DesignTimeBuild)
                 {
-                    _compileTimeTarget = _lockFile.GetTarget(_targetFramework, runtimeIdentifier: null);
-                    _runtimeTarget = _lockFile.GetTarget(_targetFramework, _task.RuntimeIdentifier);
+                    _compileTimeTarget = _lockFile.GetTargetAndReturnNullIfNotFound(_targetFramework, runtimeIdentifier: null);
+                    _runtimeTarget = _lockFile.GetTargetAndReturnNullIfNotFound(_targetFramework, _task.RuntimeIdentifier);
                     if (_compileTimeTarget == null)
                     {
                         _compileTimeTarget = new LockFileTarget();
@@ -678,7 +678,7 @@ namespace Microsoft.NET.Build.Tasks
                 }
                 else
                 {
-                    _compileTimeTarget = _lockFile.GetTargetAndThrowIfNotFound(_targetFramework, runtime: null); 
+                    _compileTimeTarget = _lockFile.GetTargetAndThrowIfNotFound(_targetFramework, runtimeIdentifier: null); 
                     _runtimeTarget = _lockFile.GetTargetAndThrowIfNotFound(_targetFramework, _task.RuntimeIdentifier);
                 }
                 
@@ -1065,7 +1065,7 @@ namespace Microsoft.NET.Build.Tasks
                     LockFileTarget runtimeTarget;
                     if (_task.DesignTimeBuild)
                     {
-                        runtimeTarget = _lockFile.GetTarget(_targetFramework, runtimeIdentifier) ?? new LockFileTarget();
+                        runtimeTarget = _lockFile.GetTargetAndReturnNullIfNotFound(_targetFramework, runtimeIdentifier) ?? new LockFileTarget();
                     }
                     else
                     {
@@ -1095,7 +1095,7 @@ namespace Microsoft.NET.Build.Tasks
                 }
                 else
                 { 
-                    var targetFramework = _lockFile.GetTarget(_targetFramework, null).TargetFramework;
+                    var targetFramework = _lockFile.GetTargetAndThrowIfNotFound(_targetFramework, null).TargetFramework;
 
                     if (targetFramework.Version.Major >= 3
                         && targetFramework.Framework.Equals(".NETCoreApp", StringComparison.OrdinalIgnoreCase))

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildADesktopExeWtihNetStandardLib.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildADesktopExeWtihNetStandardLib.cs
@@ -237,7 +237,10 @@ namespace Microsoft.NET.Build.Tests
 
             if (usePackagesConfig)
             {
-                testAsset.NuGetRestore(Log, relativePath: AppName);
+                new NuGetExeRestoreCommand(Log, testAsset.TestRoot, AppName)
+                    .Execute()
+                    .Should()
+                    .Pass();
             }
             else
             {

--- a/src/Tests/Microsoft.NET.Restore.Tests/RestoreWithOlderNuGet.cs
+++ b/src/Tests/Microsoft.NET.Restore.Tests/RestoreWithOlderNuGet.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using FluentAssertions;
+using Microsoft.NET.TestFramework;
+using Microsoft.NET.TestFramework.Assertions;
+using Microsoft.NET.TestFramework.Commands;
+using Microsoft.NET.TestFramework.ProjectConstruction;
+using NuGet.Common;
+using NuGet.Packaging;
+using NuGet.Packaging.Core;
+using System.IO;
+using System.Threading;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.NET.Restore.Tests
+{
+    public class RestoreWithOlderNuGet : SdkTest
+    {
+        public RestoreWithOlderNuGet(ITestOutputHelper log) : base(log)
+        {
+        }
+
+        [WindowsOnlyFact]
+        public void ItCanBuildProjectRestoredWithNuGet5_7()
+        {
+            var testProject = new TestProject()
+            {
+                TargetFrameworks = "netcoreapp3.1",
+                IsSdkProject = true
+            };
+            testProject.PackageReferences.Add(new TestPackageReference("Humanizer.Core", "2.8.26"));
+
+            var testAsset = _testAssetsManager.CreateTestProject(testProject);
+
+            var restoreCommand = new NuGetExeRestoreCommand(Log, testAsset.Path, testProject.Name);
+            restoreCommand.NuGetExeVersion = "5.7.0";
+            restoreCommand.Execute()
+                .Should()
+                .Pass();
+
+            new BuildCommand(testAsset)
+                .ExecuteWithoutRestore()
+                .Should()
+                .Pass();
+        }
+    }
+}

--- a/src/Tests/Microsoft.NET.TestFramework/Commands/NuGetExeRestoreCommand.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/Commands/NuGetExeRestoreCommand.cs
@@ -18,6 +18,8 @@ namespace Microsoft.NET.TestFramework.Commands
 
         public string ProjectFile { get; }
 
+        public string NuGetExeVersion { get; set; }
+
         public string FullPathProjectFile => Path.Combine(ProjectRootPath, ProjectFile);
 
         public NuGetExeRestoreCommand(ITestOutputHelper log, string projectRootPath, string relativePathToProject = null) : base(log)
@@ -43,18 +45,35 @@ namespace Microsoft.NET.TestFramework.Commands
             {
                 throw new InvalidOperationException("Path to nuget.exe not set");
             }
-            else if (!File.Exists(TestContext.Current.NuGetExePath))
+
+            var nugetExePath = TestContext.Current.NuGetExePath;
+            if (!string.IsNullOrEmpty(NuGetExeVersion))
             {
-                //  https://dist.nuget.org/win-x86-commandline/latest/nuget.exe
+                nugetExePath = Path.Combine(Path.GetDirectoryName(nugetExePath), NuGetExeVersion, "nuget.exe");
+            }
+
+            if (!File.Exists(nugetExePath))
+            {
+                string directory = Path.GetDirectoryName(nugetExePath);
+                if (!Directory.Exists(directory))
+                {
+                    Directory.CreateDirectory(directory);
+                }
+
+                string url = string.IsNullOrEmpty(NuGetExeVersion) ?
+                    "https://dist.nuget.org/win-x86-commandline/latest/nuget.exe" :
+                    $"https://dist.nuget.org/win-x86-commandline/v{NuGetExeVersion}/nuget.exe";
                 var client = new System.Net.WebClient();
-                client.DownloadFile("https://dist.nuget.org/win-x86-commandline/latest/nuget.exe", TestContext.Current.NuGetExePath);
+                client.DownloadFile(url, nugetExePath);
             }
 
             var ret = new SdkCommandSpec()
             {
-                FileName = TestContext.Current.NuGetExePath,
+                FileName = nugetExePath,
                 Arguments = newArgs
             };
+
+            TestContext.Current.AddTestEnvironmentVariables(ret);
 
             return ret;
         }

--- a/src/Tests/Microsoft.NET.TestFramework/Commands/NuGetExeRestoreCommand.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/Commands/NuGetExeRestoreCommand.cs
@@ -11,10 +11,8 @@ using System;
 
 namespace Microsoft.NET.TestFramework.Commands
 {
-    public class NuGetRestoreCommand : TestCommand
+    public class NuGetExeRestoreCommand : TestCommand
     {
-        private List<string> _sources = new List<string>();
-        
         private readonly string _projectRootPath;
         public string ProjectRootPath => _projectRootPath;
 
@@ -22,29 +20,10 @@ namespace Microsoft.NET.TestFramework.Commands
 
         public string FullPathProjectFile => Path.Combine(ProjectRootPath, ProjectFile);
 
-        public NuGetRestoreCommand(ITestOutputHelper log, string projectRootPath, string relativePathToProject = null) : base(log)
+        public NuGetExeRestoreCommand(ITestOutputHelper log, string projectRootPath, string relativePathToProject = null) : base(log)
         {
             _projectRootPath = projectRootPath;
             ProjectFile = MSBuildCommand.FindProjectFile(ref _projectRootPath, relativePathToProject);
-        }
-
-        public NuGetRestoreCommand AddSource(string source)
-        {
-            _sources.Add(source);
-            return this;
-        }
-
-        public NuGetRestoreCommand AddSourcesFromCurrentConfig()
-        {
-            var settings = Settings.LoadDefaultSettings(Directory.GetCurrentDirectory(), null, null);
-            var packageSourceProvider = new PackageSourceProvider(settings);
-
-            foreach (var packageSource in packageSourceProvider.LoadPackageSources())
-            {
-                _sources.Add(packageSource.Source);
-            }
-
-            return this;
         }
 
         protected override SdkCommandSpec CreateCommand(IEnumerable<string> args)
@@ -52,12 +31,6 @@ namespace Microsoft.NET.TestFramework.Commands
             var newArgs = new List<string>();
 
             newArgs.Add("restore");
-
-            if (_sources.Any())
-            {
-                newArgs.Add("-Source");
-                newArgs.Add(string.Join(";", _sources));
-            }
 
             newArgs.Add(FullPathProjectFile);
 

--- a/src/Tests/Microsoft.NET.TestFramework/TestAsset.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/TestAsset.cs
@@ -181,25 +181,9 @@ namespace Microsoft.NET.TestFramework
             return new RestoreCommand(log, System.IO.Path.Combine(TestRoot, relativePath));
         }
 
-        public NuGetRestoreCommand GetNuGetRestoreCommand(ITestOutputHelper log, string relativePath = "")
-        {
-            return new NuGetRestoreCommand(log, System.IO.Path.Combine(TestRoot, relativePath))
-                .AddSourcesFromCurrentConfig();
-        }
-
         public TestAsset Restore(ITestOutputHelper log, string relativePath = "", params string[] args)
         {
             var commandResult = GetRestoreCommand(log, relativePath)
-                .Execute(args);
-
-            commandResult.Should().Pass();
-
-            return this;
-        }
-
-        public TestAsset NuGetRestore(ITestOutputHelper log, string relativePath = "", params string[] args)
-        {
-            var commandResult = GetNuGetRestoreCommand(log, relativePath)
                 .Execute(args);
 
             commandResult.Should().Pass();


### PR DESCRIPTION
**Description**

Fix builds when assets file was created by an earlier version of NuGet.  

Bugs:

- https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1244228
- https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1245551
- https://developercommunity2.visualstudio.com/t/NuGet-Restore-build-issues---projectass/1190427

**Customer Impact**

This will fix issues where CI builds fail because they download an older version of NuGet.exe and use this for restore.

**How found**

Azure pipelines canary testing

**Test coverage**

Automated test coverage is added with this PR

**Regression?**

Yes.

We had previously decided that we did not need to support building with assets files created by an earlier version of NuGet.  We did not realize the impact this would have on CI builds, where it is a common pattern to download NuGet.exe and use it for the restore, and the version of NuGet.exe used may not match the version of NuGet used by the build.

Because of this impact, we have reconsidered this breaking change.

**Risk**

Low risk that this would break new scenarios.

Medium-low risk that there are some scenarios we haven't found that would still be broken when restoring with a previous NuGet version.