### PR TITLE
Enable post-build signing

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -20,6 +20,8 @@ variables:
     value: .NETCore
   - name: _PublishToAzure
     value: false
+  - name: PostBuildSign
+    value: true
   - ${{ if ne(variables['System.TeamProject'], 'public') }}:
     - name: PB_PublishBlobFeedUrl
       value: https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json


### PR DESCRIPTION
Enables post build signing. This repo will discontinue signing in-build and instead the entire product will sign all at once in the staging pipelines.