### PR TITLE
Fixing duplicate argument filtering in parser

### DIFF
--- a/src/Cli/dotnet/Program.cs
+++ b/src/Cli/dotnet/Program.cs
@@ -227,7 +227,7 @@ namespace Microsoft.DotNet.Cli
                 PerformanceLogEventSource.Log.BuiltInCommandStart();
                 var topLevelCommands = new string[] { "dotnet", parseResult.RootSubCommandResult() }.Concat(Parser.DiagOption.Aliases);
 
-                exitCode = builtIn.Command(parseResult.Tokens.Select(t => t.Value).Except(topLevelCommands).ToArray());
+                exitCode = builtIn.Command(parseResult.Tokens.Select(t => t.Value).Where(t => !topLevelCommands.Contains(t)).ToArray());
 				PerformanceLogEventSource.Log.BuiltInCommandStop();
             }
             else

--- a/src/Tests/dotnet-run.Tests/GivenDotnetRunRunsCsProj.cs
+++ b/src/Tests/dotnet-run.Tests/GivenDotnetRunRunsCsProj.cs
@@ -3,10 +3,8 @@
 
 using System;
 using System.IO;
-using System.Xml.Linq;
 using FluentAssertions;
 using Microsoft.DotNet.Cli.Utils;
-using Microsoft.DotNet.Tools.Test.Utilities;
 using Microsoft.NET.TestFramework;
 using Microsoft.NET.TestFramework.Assertions;
 using Microsoft.NET.TestFramework.Commands;
@@ -526,6 +524,21 @@ namespace Microsoft.DotNet.Cli.Run.Tests
 
             result.Should().Pass()
                 .And.HaveStdOutContaining("Important text");
+        }
+
+        [Fact]
+        public void ItPrintsDuplicateArguments()
+        {
+            var testAppName = "MSBuildTestApp";
+            var testInstance = _testAssetsManager.CopyTestAsset(testAppName)
+                .WithSource();
+
+            var result = new DotnetCommand(Log, "run")
+                .WithWorkingDirectory(testInstance.Path)
+                .Execute("a", "b", "c", "a", "c");
+
+            result.Should().Pass()
+                .And.HaveStdOutContaining("echo args:a;b;c;a;c");
         }
 
         [Fact]


### PR DESCRIPTION
Replacing a .Except call with alternate filtering, since .Except has the side effect of filtering out all duplicate values.
Fixes #14673