### PR TITLE
Opting into single argument per option token parser behavior

### DIFF
--- a/src/Cli/Microsoft.DotNet.Cli.Utils/Microsoft.DotNet.Cli.Utils.csproj
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/Microsoft.DotNet.Cli.Utils.csproj
@@ -26,7 +26,7 @@
     <PackageReference Include="NuGet.ProjectModel" Version="$(NuGetProjectModelPackageVersion)" />
     <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildPackageVersion)" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildUtilitiesCorePackageVersion)" />
-    <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20529.1" />
+    <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20574.7" />
   </ItemGroup>
 
 </Project>

--- a/src/Cli/dotnet/CommonOptions.cs
+++ b/src/Cli/dotnet/CommonOptions.cs
@@ -15,8 +15,9 @@ namespace Microsoft.DotNet.Cli
         public static Option PropertiesOption() =>
             new Option<string[]>(new string[] { "-property", "/p" })
             {
-                IsHidden = true,
-            }.ForwardAsProperty();
+                IsHidden = true
+            }.ForwardAsProperty()
+            .AllowSingleArgPerToken();
 
         public static Option VerbosityOption() =>
             VerbosityOption(o => $"-verbosity:{o}");

--- a/src/Cli/dotnet/OptionForwardingExtensions.cs
+++ b/src/Cli/dotnet/OptionForwardingExtensions.cs
@@ -36,6 +36,12 @@ namespace Microsoft.DotNet.Cli
                 .GetForwardingFunction()(parseResult)
             ?? Array.Empty<string>();
 
+        public static Option AllowSingleArgPerToken(this Option option)
+        {
+            option.AllowMultipleArgumentsPerToken = false;
+            return option;
+        }
+
         private interface IForwardedOption
         {
             Func<ParseResult, IEnumerable<string>> GetForwardingFunction();

--- a/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/ListPackageReferencesCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/ListPackageReferencesCommandParser.cs
@@ -22,7 +22,8 @@ namespace Microsoft.DotNet.Cli
         public static readonly Option FrameworkOption = new Option<IEnumerable<string>>("--framework", LocalizableStrings.CmdFrameworkDescription)
         {
             Argument = new Argument<IEnumerable<string>>(LocalizableStrings.CmdFramework) { Arity = ArgumentArity.OneOrMore }
-        }.ForwardAsMany(o => ForwardedArguments("--framework", o));
+        }.ForwardAsMany(o => ForwardedArguments("--framework", o))
+        .AllowSingleArgPerToken();
 
         public static readonly Option TransitiveOption = new Option<bool>("--include-transitive", LocalizableStrings.CmdTransitiveDescription)
             .ForwardAs("--include-transitive");
@@ -44,7 +45,8 @@ namespace Microsoft.DotNet.Cli
         public static readonly Option SourceOption = new Option<IEnumerable<string>>("--source", LocalizableStrings.CmdSourceDescription)
         {
             Argument = new Argument<IEnumerable<string>>(LocalizableStrings.CmdSource) { Arity = ArgumentArity.OneOrMore }
-        }.ForwardAsMany(o => ForwardedArguments("--source", o));
+        }.ForwardAsMany(o => ForwardedArguments("--source", o))
+        .AllowSingleArgPerToken();
 
         public static readonly Option InteractiveOption = new Option<bool>("--interactive", CommonLocalizableStrings.CommandInteractiveOptionDescription)
             .ForwardAs("--interactive");

--- a/src/Cli/dotnet/commands/dotnet-publish/PublishCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-publish/PublishCommandParser.cs
@@ -25,7 +25,8 @@ namespace Microsoft.DotNet.Cli
         public static readonly Option ManifestOption = new Option<IEnumerable<string>>("--manifest", LocalizableStrings.ManifestOptionDescription)
         {
             Argument = new Argument<IEnumerable<string>>(LocalizableStrings.ManifestOption)
-        }.ForwardAsSingle(o => $"-property:TargetManifestFiles={string.Join("%3B", o.Select(CommandDirectoryContext.GetFullPath))}");
+        }.ForwardAsSingle(o => $"-property:TargetManifestFiles={string.Join("%3B", o.Select(CommandDirectoryContext.GetFullPath))}")
+        .AllowSingleArgPerToken();
 
         public static readonly Option NoBuildOption = new Option<bool>("--no-build", LocalizableStrings.NoBuildOptionDescription)
             .ForwardAs("-property:NoBuild=true");

--- a/src/Cli/dotnet/commands/dotnet-restore/RestoreCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-restore/RestoreCommandParser.cs
@@ -73,7 +73,8 @@ namespace Microsoft.DotNet.Cli
                 {
                     Argument = new Argument<IEnumerable<string>>(LocalizableStrings.CmdSourceOption) { Arity = ArgumentArity.OneOrMore },
                     IsHidden = !showHelp
-                }.ForwardAsSingle(o => $"-property:RestoreSources={string.Join("%3B", o)}"),
+                }.ForwardAsSingle(o => $"-property:RestoreSources={string.Join("%3B", o)}")
+                .AllowSingleArgPerToken(),
                 new Option<string>(
                     "--packages",
                     showHelp ? LocalizableStrings.CmdPackagesOptionDescription : string.Empty)
@@ -127,6 +128,7 @@ namespace Microsoft.DotNet.Cli
                         IsHidden = !showHelp
                     }.ForwardAsSingle(o => $"-property:RuntimeIdentifiers={string.Join("%3B", o)}")
                     .AddSuggestions(Suggest.RunTimesFromProjectFile().ToArray())
+                    .AllowSingleArgPerToken()
                 ).ToArray();
             }
 

--- a/src/Cli/dotnet/commands/dotnet-store/StoreCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-store/StoreCommandParser.cs
@@ -42,7 +42,7 @@ namespace Microsoft.DotNet.Cli
                     $"-property:AdditionalProjects={string.Join("%3B", o.Skip(1).Select(CommandDirectoryContext.GetFullPath))}"
                 };
             }
-        });
+        }).AllowSingleArgPerToken();
 
         public static readonly Option FrameworkVersionOption = new Option<string>("--framework-version", LocalizableStrings.FrameworkVersionOptionDescription)
         {

--- a/src/Cli/dotnet/commands/dotnet-test/TestCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/TestCommandParser.cs
@@ -31,7 +31,7 @@ namespace Microsoft.DotNet.Cli
             {
                 Arity = ArgumentArity.OneOrMore
             }
-        };
+        }.AllowSingleArgPerToken();
 
         public static readonly Option FilterOption = new Option<string>("--filter", LocalizableStrings.CmdTestCaseFilterDescription)
         {
@@ -44,7 +44,8 @@ namespace Microsoft.DotNet.Cli
             {
                 Arity = ArgumentArity.OneOrMore
             }
-        }.ForwardAsSingle(o => $"-property:VSTestTestAdapterPath=\"{string.Join(";", o.Select(CommandDirectoryContext.GetFullPath))}\"");
+        }.ForwardAsSingle(o => $"-property:VSTestTestAdapterPath=\"{string.Join(";", o.Select(CommandDirectoryContext.GetFullPath))}\"")
+        .AllowSingleArgPerToken();
 
         public static readonly Option LoggerOption = new Option<IEnumerable<string>>(new string[] { "-l", "--logger" }, LocalizableStrings.CmdLoggerDescription)
         {
@@ -56,7 +57,8 @@ namespace Microsoft.DotNet.Cli
             var loggersString = string.Join(";", GetSemiColonEscapedArgs(o));
 
             return $"-property:VSTestLogger=\"{loggersString}\"";
-        });
+        })
+        .AllowSingleArgPerToken();
 
         public static readonly Option OutputOption = new Option<string>(new string[] { "-o", "--output" }, LocalizableStrings.CmdOutputDescription)
         {
@@ -82,7 +84,8 @@ namespace Microsoft.DotNet.Cli
             {
                 Arity = ArgumentArity.OneOrMore
             }
-        }.ForwardAsSingle(o => $"-property:VSTestCollect=\"{string.Join(";", o)}\"");
+        }.ForwardAsSingle(o => $"-property:VSTestCollect=\"{string.Join(";", o)}\"")
+        .AllowSingleArgPerToken();
 
         public static readonly Option BlameOption = new Option<bool>("--blame", LocalizableStrings.CmdBlameDescription)
             .ForwardAs("-property:VSTestBlame=true");

--- a/src/Cli/dotnet/commands/dotnet-tool/install/ToolInstallCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-tool/install/ToolInstallCommandParser.cs
@@ -28,7 +28,7 @@ namespace Microsoft.DotNet.Cli
         public static readonly Option AddSourceOption = new Option<IEnumerable<string>>("--add-source", LocalizableStrings.AddSourceOptionDescription)
         {
             Argument = new Argument<IEnumerable<string>>(LocalizableStrings.AddSourceOptionName)
-        };
+        }.AllowSingleArgPerToken();
 
         public static readonly Option FrameworkOption = new Option<string>("--framework", LocalizableStrings.FrameworkOptionDescription)
         {

--- a/src/Cli/dotnet/dotnet.csproj
+++ b/src/Cli/dotnet/dotnet.csproj
@@ -74,7 +74,7 @@
     <PackageReference Include="Microsoft.TemplateEngine.Utils" Version="$(MicrosoftTemplateEngineUtilsPackageVersion)" />
     <PackageReference Include="Microsoft.TemplateSearch.Common" Version="$(MicrosoftTemplateSearchCommonPackageVersion)" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="4.6.0" />
-    <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20529.1" />
+    <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20574.7" />
   </ItemGroup>
   <ItemGroup Condition=" '$(IncludeAspNetCoreRuntime)' != 'false' ">
     <PackageReference Include="Microsoft.AspNetCore.DeveloperCertificates.XPlat" Version="$(MicrosoftAspNetCoreDeveloperCertificatesXPlatPackageVersion)" />

--- a/src/Tests/dotnet-restore.Tests/GivenThatIWantToRestoreApp.cs
+++ b/src/Tests/dotnet-restore.Tests/GivenThatIWantToRestoreApp.cs
@@ -155,6 +155,26 @@ namespace Microsoft.DotNet.Restore.Test
                  .And.NotHaveStdOut();
         }
 
+        [Fact]
+        public void ItAcceptsArgumentsAfterProperties()
+        {
+            var rootPath = _testAssetsManager.CreateTestDirectory().Path;
+
+            string[] newArgs = new[] { "console", "-o", rootPath, "--no-restore" };
+            new DotnetCommand(Log, "new")
+                .WithWorkingDirectory(rootPath)
+                .Execute(newArgs)
+                .Should()
+                .Pass();
+
+            string[] args = new[] { "/p:prop1=true", "/m:1" };
+            new DotnetRestoreCommand(Log)
+                 .WithWorkingDirectory(rootPath)
+                 .Execute(args)
+                 .Should()
+                 .Pass();
+        }
+
         private static string[] HandleStaticGraphEvaluation(bool useStaticGraphEvaluation, string[] args) =>
             useStaticGraphEvaluation ? 
                 args.Append("/p:RestoreUseStaticGraphEvaluation=true").ToArray() :

--- a/src/Tests/dotnet-test.Tests/GivenDotnetTestContainsEnvironmentVariables.cs
+++ b/src/Tests/dotnet-test.Tests/GivenDotnetTestContainsEnvironmentVariables.cs
@@ -64,7 +64,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
             result.ExitCode.Should().Be(0);
         }
 
-        [Fact(Skip = "https://github.com/dotnet/command-line-api/issues/1077")]
+        [Fact]
         public void ItPassesEnvironmentVariablesFromCommandLineParametersWhenRunningViaDll()
         {
             var testAsset = _testAssetsManager.CopyTestAsset(TestAppName)

--- a/src/Tests/dotnet.Tests/ParserTests/RestoreParserTests.cs
+++ b/src/Tests/dotnet.Tests/ParserTests/RestoreParserTests.cs
@@ -39,7 +39,7 @@ namespace Microsoft.DotNet.Tests.CommandLineParserTests
             result.OptionValuesToBeForwarded(RestoreCommandParser.GetCommand()).Should().Contain(@"-property:SkipInvalidConfigurations=true");
         }
 
-        [Fact(Skip = "https://github.com/dotnet/command-line-api/issues/1077")]
+        [Fact]
         public void RestoreDistinguishesRepeatSourceArgsFromCommandArgs()
         {
             var restore =
@@ -47,7 +47,7 @@ namespace Microsoft.DotNet.Tests.CommandLineParserTests
                       .Parse(
                           @"dotnet restore --no-cache --packages ""D:\OSS\corefx\packages"" --source https://dotnet.myget.org/F/dotnet-buildtools/api/v3/index.json --source https://dotnet.myget.org/F/dotnet-core/api/v3/index.json --source https://api.nuget.org/v3/index.json D:\OSS\corefx\external\runtime\runtime.depproj");
 
-            restore.ValueForArgument<string>(RestoreCommandParser.SlnOrProjectArgument);
+            restore.ValueForArgument<string[]>(RestoreCommandParser.SlnOrProjectArgument);
 
             restore.ValueForOption<string[]>("--source")
                 .Should()


### PR DESCRIPTION
Fixes https://github.com/dotnet/sdk/issues/14461
Fixes https://github.com/dotnet/sdk/issues/14691

Opting into new System.CommandLine functionality which allows us to return to the old parser's behavior such that `-option optionVal arg` is parsed as optionVal as the option value and arg as an argument, instead of both being option values
