### PR TITLE
Revert "Enable post-build signing"

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -20,8 +20,6 @@ variables:
     value: .NETCore
   - name: _PublishToAzure
     value: false
-  - name: PostBuildSign
-    value: true
   - ${{ if ne(variables['System.TeamProject'], 'public') }}:
     - name: PB_PublishBlobFeedUrl
       value: https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json


### PR DESCRIPTION
Reverts dotnet/sdk#14662

Hi folks,

We noticed that builds on master are failing after this PR was merged and taking an Arcade update, so we're going to revert it.

Build in which failures were first seen: https://dnceng.visualstudio.com/internal/_build/results?buildId=898447&view=results

Tracking issue: dotnet/core-eng#11514

Thanks,
Missy