### PR TITLE
Adding test coverage for prefixed options

### DIFF
--- a/src/Cli/dotnet/Program.cs
+++ b/src/Cli/dotnet/Program.cs
@@ -231,7 +231,7 @@ namespace Microsoft.DotNet.Cli
                 PerformanceLogEventSource.Log.BuiltInCommandStart();
                 var topLevelCommands = new string[] { "dotnet", parseResult.RootSubCommandResult() }.Concat(Parser.DiagOption.Aliases);
 
-                exitCode = builtIn.Command(parseResult.Tokens.Select(t => t.Value).Where(t => !topLevelCommands.Contains(t)).ToArray());
+                exitCode = builtIn.Command(args.Where(t => !topLevelCommands.Contains(t)).ToArray());
 				PerformanceLogEventSource.Log.BuiltInCommandStop();
             }
             else

--- a/src/Tests/dotnet-new.Tests/GivenThatIWantANewApp.cs
+++ b/src/Tests/dotnet-new.Tests/GivenThatIWantANewApp.cs
@@ -3,11 +3,7 @@
 
 using System;
 using System.IO;
-using System.Linq;
-using System.Xml.Linq;
 using FluentAssertions;
-using Microsoft.DotNet.Tools.Test.Utilities;
-using Microsoft.Extensions.DependencyModel;
 using Microsoft.NET.TestFramework;
 using Microsoft.NET.TestFramework.Assertions;
 using Microsoft.NET.TestFramework.Commands;
@@ -70,6 +66,20 @@ namespace Microsoft.DotNet.New.Tests
                 .Should().Pass();
 
             string expectedCsprojPath = Path.Combine(rootPath, "c1", "c1.csproj");
+            Assert.True(File.Exists(expectedCsprojPath), $"expected '{expectedCsprojPath}' but was not found");
+        }
+
+        [Fact]
+        public void Dotnet_new_can_be_invoked_with_lang_option()
+        {
+            var rootPath = _testAssetsManager.CreateTestDirectory().Path;
+
+            new DotnetCommand(Log, "new")
+                .WithWorkingDirectory(rootPath)
+                .Execute($"console", "--debug:ephemeral-hive", "--no-restore", "-n", "vb1", "-lang", "vb")
+                .Should().Pass();
+
+            string expectedCsprojPath = Path.Combine(rootPath, "vb1", "vb1.vbproj");
             Assert.True(File.Exists(expectedCsprojPath), $"expected '{expectedCsprojPath}' but was not found");
         }
 

--- a/src/Tests/dotnet-nuget.UnitTests/GivenANuGetCommand.cs
+++ b/src/Tests/dotnet-nuget.UnitTests/GivenANuGetCommand.cs
@@ -1,17 +1,16 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Collections.Generic;
 using FluentAssertions;
 using Microsoft.DotNet.Cli;
-using Microsoft.DotNet.Cli.Utils;
-using Microsoft.DotNet.Tools.Test.Utilities;
 using Microsoft.DotNet.Tools.NuGet;
 using Moq;
-using NuGet.Frameworks;
 using Xunit;
 using Microsoft.NET.TestFramework;
 using Xunit.Abstractions;
+using Microsoft.NET.TestFramework.Commands;
+
+using Microsoft.NET.TestFramework.Assertions;
 
 namespace Microsoft.DotNet.Tools.Run.Tests
 {
@@ -60,6 +59,20 @@ namespace Microsoft.DotNet.Tools.Run.Tests
             // Assert
             receivedArgs.Should().BeEquivalentTo(inputArgs);
             returned.Should().Be(result);
+        }
+
+        [Fact]
+        public void ItAcceptsPrefixedOption()
+        {
+            var rootPath = _testAssetsManager.CreateTestDirectory().Path;
+
+            new DotnetCommand(Log, "nuget")
+                .WithWorkingDirectory(rootPath)
+                .Execute($"push", "-ss")
+                .Should()
+                .Fail()
+                .And
+                .HaveStdOutContaining("Missing value for option 'symbol-source'");
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/sdk/issues/14712