### PR TITLE
Allow inferring ARM64 PlatformTarget from RID

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets
@@ -6,54 +6,39 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
           created a backup copy.  Incorrect changes to this file will make it
           impossible to load or build your projects from the command-line or the IDE.
 
-Copyright (c) .NET Foundation. All rights reserved. 
+Copyright (c) .NET Foundation. All rights reserved.
 ***********************************************************************************************
 -->
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <!--
-    .NETFramework cannot load native package dependencies dynamically
-    based on the current architecture.  We have must have a RID to
-    resolve and copy native dependencies to the output directory.
+    .NET Framework cannot load native package dependencies dynamically
+    based on the current architecture.  We must have a RID to resolve
+    and copy native dependencies to the output directory.
 
-     When building a .NETFramework exe on Windows and not given a RID,
-     we'll pick either win7-x64 or win7-x86 (based on PlatformTarget)
-     if we're not given an explicit RID. However, if after resolving
-     NuGet assets we find no copy-local native dependencies, we will
-     emit the binary as AnyCPU.
+    When building a .NET Framework exe on Windows and not given a RID,
+    we'll pick either win7-x64 or win7-x86 (based on PlatformTarget)
+    if we're not given an explicit RID. However, if after resolving
+    NuGet assets we find no copy-local native dependencies, we will
+    emit the binary as AnyCPU.
 
-     Note that we must set the RID here early (to be seen during NuGet
-     restore) in order for the project.assets.json to include the
-     native dependencies that will let us make the final call on
-     AnyCPU or platform-specific.
+    Note that we must set the RID here early (to be seen during NuGet
+    restore) in order for the project.assets.json to include the
+    native dependencies that will let us make the final call on
+    AnyCPU or platform-specific.
 
-     This allows these common cases to work without requiring mention
-     of RuntimeIdentifier in the user project PlatformTarget:
+    This allows these common cases to work without requiring mention
+    of RuntimeIdentifier in the user project PlatformTarget:
 
-      1. Building an AnyCPU .NETFramework application on any host OS
-         with no native NuGet dependencies. (*)
+      1. Building an AnyCPU .NET Framework application on any host OS
+         with no native NuGet dependencies.
 
-      2. Building an x86 or x64 NETFramework application on and for
+      2. Building an x86 or x64 .NET Framework application on and for
          Windows with native NuGet dependencies that do not require
          greater than win7.
-
-     However, any other combination of host operating system, CPU
-     architecture, and minimum Windows version will require some
-     manual intervention in the project file to set up the right
-     RID. (**)
-
-     (*) Building NET4x from non-Windows is still not fully supported:
-         https://github.com/dotnet/sdk/issues/335) The point above is
-         that this code would not have to change to make the first
-         scenario work on non-Windows hosts.
-
-     (**) https://github.com/dotnet/sdk/issues/840 tracks improving
-          the default RID selection here to make more non-AnyCPU scenarios
-          work without user intervention. The current static evaluation
-          requirement limits us.
-   -->
-  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework' and 
-                            '$(HasRuntimeOutput)' == 'true' and 
+  -->
+  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework' and
+                            '$(HasRuntimeOutput)' == 'true' and
                             '$(OS)' == 'Windows_NT' and
                             '$(RuntimeIdentifier)' == ''">
     <_UsingDefaultRuntimeIdentifier>true</_UsingDefaultRuntimeIdentifier>
@@ -87,7 +72,12 @@ Copyright (c) .NET Foundation. All rights reserved.
       </PropertyGroup>
     </When>
 
-    <!-- NOTE: PlatformTarget=arm64 is not currently supported and therefore no inference of that here. -->
+    <When Condition="$(RuntimeIdentifier.EndsWith('-arm64')) or $(RuntimeIdentifier.Contains('-arm64-'))">
+      <PropertyGroup>
+        <PlatformTarget>arm64</PlatformTarget>
+      </PropertyGroup>
+    </When>
+
     <Otherwise>
       <PropertyGroup>
         <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildADesktopExe.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildADesktopExe.cs
@@ -243,9 +243,8 @@ namespace Microsoft.NET.Build.Tests
         [InlineData("win8-x64-aot", "x64")]
         [InlineData("win10-arm", "arm")]
         [InlineData("win10-arm-aot", "arm")]
-        //PlatformTarget=arm64 is not supported and never inferred
-        [InlineData("win10-arm64", "AnyCPU")]
-        [InlineData("win10-arm64-aot", "AnyCPU")]
+        [InlineData("win10-arm64", "arm64")]
+        [InlineData("win10-arm64-aot", "arm64")]
         // cpu architecture is never expected at the front
         [InlineData("x86-something", "AnyCPU")]
         [InlineData("x64-something", "AnyCPU")]


### PR DESCRIPTION
Inference of `PlatformTarget` from RID would not work for ARM64, falling back to `AnyCPU`.  In addition, both issues mentioned in the long comment seem resolved so I removed those paragraphs and fixed indentation.