### PR TITLE
Fixup post-build signing manifest and re-enable PostBuildSign

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -20,6 +20,8 @@ variables:
     value: .NETCore
   - name: _PublishToAzure
     value: false
+  - name: PostBuildSign
+    value: true
   - ${{ if ne(variables['System.TeamProject'], 'public') }}:
     - name: PB_PublishBlobFeedUrl
       value: https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -65,6 +65,11 @@
         <ManifestArtifactData>NonShipping=true</ManifestArtifactData>
       </ToolsetAssetsToPushToBlobFeed>
     </ItemGroup>
+    
+    <ItemGroup Condition="'$(PostBuildSign)' == 'true'">
+      <ItemsToSignPostBuild Remove="@(ItemsToSignPostBuild)" />
+      <ItemsToSignPostBuild Include="@(ToolsetAssetsToPublish->'%(Filename)%(Extension)')" />
+    </ItemGroup>
 
     <MakeDir Directories="$(TempWorkingDirectory)"/>
 

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -53,8 +53,4 @@
     <FileSignInfo Include="xunit.performance.execution.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="xunit.performance.metrics.dll" CertificateName="3PartySHA2" />
   </ItemGroup>
-  
-  <ItemGroup Condition="'$(PostBuildSign)' == 'true'">
-    <ItemsToSignPostBuild Include="$(ArtifactsNonShippingPackagesDir)*.zip" />
-  </ItemGroup>
 </Project>


### PR DESCRIPTION
The post build signing manifest was a little loose before. This fixes up some issues that arise from the fact that sdk uses both Arcade's publishing pass as well as another target implemented in Publishing.props.
- Only include file names in post build sign paths
- Move ItemsToSignPostBuild into publishing target for those items that are published separately.
- Remove existing ItemsToSignPostBuild (arcade defaults) in this target.