### PR TITLE
Default 'AnalysisLevel' if 'AnalysisMode' has been set

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.Analyzers.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.Analyzers.targets
@@ -17,8 +17,9 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <!-- Automatically set AnalysisLevel if not specified -->
     <AnalysisLevel Condition="'$(AnalysisLevel)' == '' And
-                              '$(TargetFrameworkIdentifier)' == '.NETCoreApp' And
-                              $([MSBuild]::VersionGreaterThanOrEquals($(_TargetFrameworkVersionWithoutV), '5.0'))">latest</AnalysisLevel>
+                              (('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And
+                               $([MSBuild]::VersionGreaterThanOrEquals($(_TargetFrameworkVersionWithoutV), '5.0'))) Or
+							                 '$(AnalysisMode)' != '')">latest</AnalysisLevel>
 
     <!-- EffectiveAnalysisLevel is used to differentiate from user specified strings (such as 'none')
          and an implied numerical option (such as '4')-->


### PR DESCRIPTION
See [AnalysisMode](https://docs.microsoft.com/dotnet/core/project-sdk/msbuild-props#analysismode).

Prior to this change, the following project file does not cause `AnalysisMode` to be respected as `AnalysisLevel` and `EffectiveAnalysisLevel` were never being set:

```xml
<Project Sdk="Microsoft.NET.Sdk">
  <PropertyGroup>
    <TargetFramework>netstandard2.1</TargetFramework>
    <EnableNETAnalyzers>true</EnableNETAnalyzers>
    <AnalysisMode>AllEnabledByDefault</AnalysisMode>
  </PropertyGroup>
</Project>
```