### PR TITLE
Restore package to a different folder

### DIFF
--- a/src/Tests/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestfromCsproj.cs
+++ b/src/Tests/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestfromCsproj.cs
@@ -308,7 +308,6 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                 .WithVersionVariables()
                 .Path;
 
-
             string pkgDir;
             //if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             //{
@@ -317,7 +316,8 @@ namespace Microsoft.DotNet.Cli.Test.Tests
             //}
             //else
             {
-                pkgDir = Path.Combine(rootPath, "pkgs");
+                pkgDir = _testAssetsManager.CreateTestDirectory(identifier: "pkgs").Path;
+                Log.WriteLine("pkgDir, package restored path is: " + pkgDir);
             }
 
             new DotnetRestoreCommand(Log)


### PR DESCRIPTION
So that it won't be globbed by the project and cause package files to be included.

/ref: https://github.com/dotnet/sdk/pull/14764