### PR TITLE
Use list of current Runtime Identifiers for workload resolver

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "5.0.100",
+    "dotnet": "5.0.200-preview.20601.7",
     "runtimes": {
       "dotnet": [
         "$(MicrosoftNETCoreAppInternalPackageVersion)"

--- a/src/Layout/redist/targets/OverlaySdkOnLKG.targets
+++ b/src/Layout/redist/targets/OverlaySdkOnLKG.targets
@@ -14,6 +14,7 @@
       <OverlaySDK Include="$(_DotNetHiveRoot)/**/*" Exclude="$(_DotNetHiveRoot)sdk/**/*"/>
       <OverlaySdkFilesFromStage0 Include="$(_DotNetHiveRoot)/sdk/$(Stage0SdkVersion)/Microsoft.NETCoreSdk.BundledCliTools.props" />
       <OverlaySdkFilesFromStage0 Include="$(_DotNetHiveRoot)/sdk/$(Stage0SdkVersion)/RuntimeIdentifierGraph.json" />
+      <OverlaySdkFilesFromStage0 Include="$(_DotNetHiveRoot)/sdk/$(Stage0SdkVersion)/NETCoreSdkRuntimeIdentifierChain.txt" />
       <OverlaySdkFilesFromStage0 Include="$(_DotNetHiveRoot)/sdk/$(Stage0SdkVersion)/DotnetTools/**/*" RelativeDestination="DotnetTools"/>
       <OverlaySdkFilesFromStage0 Include="$(_DotNetHiveRoot)/sdk/$(Stage0SdkVersion)/AppHostTemplate/**/*" RelativeDestination="AppHostTemplate"/>
       <ToolsetToOverlay Include="$(OutputPath)/**/*" />

--- a/src/Microsoft.DotNet.TemplateLocator/TemplateLocator.cs
+++ b/src/Microsoft.DotNet.TemplateLocator/TemplateLocator.cs
@@ -50,11 +50,8 @@ namespace Microsoft.DotNet.TemplateLocator
                     nameof(dotnetRootPath));
             }
 
-            string runtimeIdentifierChainPath = Path.Combine(dotnetRootPath, "sdk", sdkVersion, "NETCoreSdkRuntimeIdentifierChain.txt");
-            string[] currentRuntimeIdentifiers = File.ReadAllLines(runtimeIdentifierChainPath).Where(l => !string.IsNullOrEmpty(l)).ToArray();
-
             _workloadManifestProvider ??= new SdkDirectoryWorkloadManifestProvider(dotnetRootPath, sdkVersion);
-            _workloadResolver ??= new WorkloadResolver(_workloadManifestProvider, dotnetRootPath, currentRuntimeIdentifiers);
+            _workloadResolver ??= WorkloadResolver.Create(_workloadManifestProvider, dotnetRootPath, sdkVersion);
 
             return _workloadResolver.GetInstalledWorkloadPacksOfKind(WorkloadPackKind.Template)
                 .Select(pack => new OptionalSdkTemplatePackageInfo(pack.Id, pack.Version, pack.Path)).ToList();

--- a/src/Microsoft.DotNet.TemplateLocator/TemplateLocator.cs
+++ b/src/Microsoft.DotNet.TemplateLocator/TemplateLocator.cs
@@ -50,8 +50,11 @@ namespace Microsoft.DotNet.TemplateLocator
                     nameof(dotnetRootPath));
             }
 
+            string runtimeIdentifierChainPath = Path.Combine(dotnetRootPath, "sdk", sdkVersion, "NETCoreSdkRuntimeIdentifierChain.txt");
+            string[] currentRuntimeIdentifiers = File.ReadAllLines(runtimeIdentifierChainPath).Where(l => !string.IsNullOrEmpty(l)).ToArray();
+
             _workloadManifestProvider ??= new SdkDirectoryWorkloadManifestProvider(dotnetRootPath, sdkVersion);
-            _workloadResolver ??= new WorkloadResolver(_workloadManifestProvider, dotnetRootPath);
+            _workloadResolver ??= new WorkloadResolver(_workloadManifestProvider, dotnetRootPath, currentRuntimeIdentifiers);
 
             return _workloadResolver.GetInstalledWorkloadPacksOfKind(WorkloadPackKind.Template)
                 .Select(pack => new OptionalSdkTemplatePackageInfo(pack.Id, pack.Version, pack.Path)).ToList();

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver/WorkloadSdkResolver.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver/WorkloadSdkResolver.cs
@@ -71,9 +71,12 @@ namespace Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver
             //  The SDK version is the name of the SDK directory (ie dotnet\sdk\5.0.100)
             var sdkVersion = Path.GetFileName(sdkDirectory);
 
+            string runtimeIdentifierChainPath = Path.Combine(sdkDirectory, "NETCoreSdkRuntimeIdentifierChain.txt");
+            string[] currentRuntimeIdentifiers = File.ReadAllLines(runtimeIdentifierChainPath).Where(l => !string.IsNullOrEmpty(l)).ToArray();
+
             _workloadManifestProvider ??= new SdkDirectoryWorkloadManifestProvider(dotnetRootPath, sdkVersion);
             
-            _workloadResolver ??= new WorkloadResolver(_workloadManifestProvider, dotnetRootPath);
+            _workloadResolver ??= new WorkloadResolver(_workloadManifestProvider, dotnetRootPath, currentRuntimeIdentifiers);
         }
 
         public override SdkResult Resolve(SdkReference sdkReference, SdkResolverContext resolverContext, SdkResultFactory factory)

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver/WorkloadSdkResolver.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver/WorkloadSdkResolver.cs
@@ -71,12 +71,8 @@ namespace Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver
             //  The SDK version is the name of the SDK directory (ie dotnet\sdk\5.0.100)
             var sdkVersion = Path.GetFileName(sdkDirectory);
 
-            string runtimeIdentifierChainPath = Path.Combine(sdkDirectory, "NETCoreSdkRuntimeIdentifierChain.txt");
-            string[] currentRuntimeIdentifiers = File.ReadAllLines(runtimeIdentifierChainPath).Where(l => !string.IsNullOrEmpty(l)).ToArray();
-
             _workloadManifestProvider ??= new SdkDirectoryWorkloadManifestProvider(dotnetRootPath, sdkVersion);
-            
-            _workloadResolver ??= new WorkloadResolver(_workloadManifestProvider, dotnetRootPath, currentRuntimeIdentifiers);
+            _workloadResolver ??= WorkloadResolver.Create(_workloadManifestProvider, dotnetRootPath, sdkVersion);
         }
 
         public override SdkResult Resolve(SdkReference sdkReference, SdkResolverContext resolverContext, SdkResultFactory factory)

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadPack.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadPack.cs
@@ -21,16 +21,16 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
         public bool IsAlias => AliasTo != null && AliasTo.Count > 0;
         public Dictionary<string, WorkloadPackId>? AliasTo { get; }
 
-        public WorkloadPackId? TryGetAliasForPlatformIds (IEnumerable<string> platformIds)
+        public WorkloadPackId? TryGetAliasForRuntimeIdentifiers(IEnumerable<string> runtimeIdentifiers)
         {
             if (AliasTo == null || AliasTo.Count == 0)
             {
                 return null;
             }
 
-            foreach (var platformId in platformIds)
+            foreach (var runtimeIdentifier in runtimeIdentifiers)
             {
-                if (AliasTo.TryGetValue(platformId, out WorkloadPackId alias))
+                if (AliasTo.TryGetValue(runtimeIdentifier, out WorkloadPackId alias))
                 {
                     return alias;
                 }

--- a/src/Tests/Microsoft.DotNet.TemplateLocator.Tests/GivenAnTemplateLocator.cs
+++ b/src/Tests/Microsoft.DotNet.TemplateLocator.Tests/GivenAnTemplateLocator.cs
@@ -23,8 +23,16 @@ namespace Microsoft.DotNet.TemplateLocator.Tests
             _resolver = new TemplateLocator(Environment.GetEnvironmentVariable, VSSettings.Ambient, null, null);
             _fakeDotnetRootDirectory =
                 Path.Combine(TestContext.Current.TestExecutionDirectory, Path.GetRandomFileName());
+
+            var fakeSdkDirectory = Path.Combine(_fakeDotnetRootDirectory, "sdk", "5.0.102");
+            Directory.CreateDirectory(fakeSdkDirectory);
+            var fakeRuntimeIdentifierChainPath = Path.Combine(fakeSdkDirectory, "NETCoreSdkRuntimeIdentifierChain.txt");
+            File.WriteAllLines(fakeRuntimeIdentifierChainPath,
+                               new[] { "win-x64", "win", "any", "base" });
+
             _manifestDirectory = Path.Combine(_fakeDotnetRootDirectory, "sdk-manifests", "5.0.100");
             Directory.CreateDirectory(_manifestDirectory);
+            
         }
 
         [Fact]
@@ -64,7 +72,7 @@ namespace Microsoft.DotNet.TemplateLocator.Tests
         {
             var fakeDotnetRootDirectory =
                 Path.Combine(TestContext.Current.TestExecutionDirectory, Path.GetRandomFileName());
-            var result = _resolver.GetDotnetSdkTemplatePackages("5.1.102", fakeDotnetRootDirectory);
+            var result = _resolver.GetDotnetSdkTemplatePackages("5.0.102", fakeDotnetRootDirectory);
             result.Should().BeEmpty();
         }
     }

--- a/src/Tests/Microsoft.NET.Sdk.WorkloadManifestReader.Tests/ManifestReaderFunctionalTests.cs
+++ b/src/Tests/Microsoft.NET.Sdk.WorkloadManifestReader.Tests/ManifestReaderFunctionalTests.cs
@@ -42,7 +42,7 @@ namespace ManifestReaderTests
         private static WorkloadResolver SetUp()
         {
             var workloadResolver =
-                new WorkloadResolver(new FakeManifestProvider(new[] {Path.Combine("Manifests", "Sample.json")}),
+                WorkloadResolver.CreateForTests(new FakeManifestProvider(new[] {Path.Combine("Manifests", "Sample.json")}),
                     "fakepath", ManifestTests.TEST_RUNTIME_IDENTIFIER_CHAIN);
 
             workloadResolver.ReplaceFilesystemChecksForTest(fileExists: (_) => true, directoryExists: (_) => true);
@@ -53,7 +53,7 @@ namespace ManifestReaderTests
         public void GivenTemplateNupkgDoesNotExistOnDiskItShouldReturnEmpty()
         {
             var workloadResolver =
-                new WorkloadResolver(new FakeManifestProvider(new[] {Path.Combine("Manifests", "Sample.json")}),
+                WorkloadResolver.CreateForTests(new FakeManifestProvider(new[] {Path.Combine("Manifests", "Sample.json")}),
                     "fakepath", ManifestTests.TEST_RUNTIME_IDENTIFIER_CHAIN);
             workloadResolver.ReplaceFilesystemChecksForTest(fileExists: (_) => false, directoryExists: (_) => true);
             var result = workloadResolver.GetInstalledWorkloadPacksOfKind(WorkloadPackKind.Template);
@@ -64,7 +64,7 @@ namespace ManifestReaderTests
         public void GivenWorkloadSDKsDirectoryNotExistOnDiskItShouldReturnEmpty()
         {
             var workloadResolver =
-                new WorkloadResolver(new FakeManifestProvider(new[] {Path.Combine("Manifests", "Sample.json")}),
+                WorkloadResolver.CreateForTests(new FakeManifestProvider(new[] {Path.Combine("Manifests", "Sample.json")}),
                     "fakepath", ManifestTests.TEST_RUNTIME_IDENTIFIER_CHAIN);
             workloadResolver.ReplaceFilesystemChecksForTest(fileExists: (_) => true, directoryExists: (_) => false);
             var result = workloadResolver.GetInstalledWorkloadPacksOfKind(WorkloadPackKind.Sdk);

--- a/src/Tests/Microsoft.NET.Sdk.WorkloadManifestReader.Tests/ManifestReaderFunctionalTests.cs
+++ b/src/Tests/Microsoft.NET.Sdk.WorkloadManifestReader.Tests/ManifestReaderFunctionalTests.cs
@@ -43,7 +43,7 @@ namespace ManifestReaderTests
         {
             var workloadResolver =
                 new WorkloadResolver(new FakeManifestProvider(new[] {Path.Combine("Manifests", "Sample.json")}),
-                    "fakepath");
+                    "fakepath", ManifestTests.TEST_RUNTIME_IDENTIFIER_CHAIN);
 
             workloadResolver.ReplaceFilesystemChecksForTest(fileExists: (_) => true, directoryExists: (_) => true);
             return workloadResolver;
@@ -54,7 +54,7 @@ namespace ManifestReaderTests
         {
             var workloadResolver =
                 new WorkloadResolver(new FakeManifestProvider(new[] {Path.Combine("Manifests", "Sample.json")}),
-                    "fakepath");
+                    "fakepath", ManifestTests.TEST_RUNTIME_IDENTIFIER_CHAIN);
             workloadResolver.ReplaceFilesystemChecksForTest(fileExists: (_) => false, directoryExists: (_) => true);
             var result = workloadResolver.GetInstalledWorkloadPacksOfKind(WorkloadPackKind.Template);
             result.Should().HaveCount(0);
@@ -65,7 +65,7 @@ namespace ManifestReaderTests
         {
             var workloadResolver =
                 new WorkloadResolver(new FakeManifestProvider(new[] {Path.Combine("Manifests", "Sample.json")}),
-                    "fakepath");
+                    "fakepath", ManifestTests.TEST_RUNTIME_IDENTIFIER_CHAIN);
             workloadResolver.ReplaceFilesystemChecksForTest(fileExists: (_) => true, directoryExists: (_) => false);
             var result = workloadResolver.GetInstalledWorkloadPacksOfKind(WorkloadPackKind.Sdk);
             result.Should().HaveCount(0);

--- a/src/Tests/Microsoft.NET.Sdk.WorkloadManifestReader.Tests/ManifestTests.cs
+++ b/src/Tests/Microsoft.NET.Sdk.WorkloadManifestReader.Tests/ManifestTests.cs
@@ -13,6 +13,8 @@ namespace ManifestReaderTests
     {
         private const string fakeRootPath = "fakeRootPath";
 
+        public static readonly string[] TEST_RUNTIME_IDENTIFIER_CHAIN = new[] { "win-x64", "win", "any", "base" };
+
         [Fact]
         public void ItCanDeserialize()
         {
@@ -33,10 +35,9 @@ namespace ManifestReaderTests
         public void AliasedPackPath()
         {
             var manifestProvider = new FakeManifestProvider(Path.Combine("Manifests", "Sample.json"));
-            var resolver = new WorkloadResolver(manifestProvider, fakeRootPath);
+            var resolver = new WorkloadResolver(manifestProvider, fakeRootPath, TEST_RUNTIME_IDENTIFIER_CHAIN);
 
             resolver.ReplaceFilesystemChecksForTest(_ => true, _ => true);
-            resolver.ReplacePlatformIdsForTest(new[] { "win-x64", "*" });
 
             var buildToolsPack = resolver.GetInstalledWorkloadPacksOfKind(WorkloadPackKind.Sdk).FirstOrDefault(pack => pack.Id == "Xamarin.Android.BuildTools");
 

--- a/src/Tests/Microsoft.NET.Sdk.WorkloadManifestReader.Tests/ManifestTests.cs
+++ b/src/Tests/Microsoft.NET.Sdk.WorkloadManifestReader.Tests/ManifestTests.cs
@@ -35,7 +35,7 @@ namespace ManifestReaderTests
         public void AliasedPackPath()
         {
             var manifestProvider = new FakeManifestProvider(Path.Combine("Manifests", "Sample.json"));
-            var resolver = new WorkloadResolver(manifestProvider, fakeRootPath, TEST_RUNTIME_IDENTIFIER_CHAIN);
+            var resolver = WorkloadResolver.CreateForTests(manifestProvider, fakeRootPath, TEST_RUNTIME_IDENTIFIER_CHAIN);
 
             resolver.ReplaceFilesystemChecksForTest(_ => true, _ => true);
 


### PR DESCRIPTION
Instead of hard coding one RuntimeIdentifier to use to select workloads, read the list of current RuntimeIdentifiers for the current SDK from a file that it now includes (see https://github.com/dotnet/installer/pull/9106).

FYI @Redth @jonathanpeppers