### PR TITLE
Ensure case-insensitive web.config file name is used

### DIFF
--- a/src/Tests/Microsoft.NET.Sdk.Publish.Tasks.Tests/Tasks/TransformWebConfigTests.cs
+++ b/src/Tests/Microsoft.NET.Sdk.Publish.Tasks.Tests/Tasks/TransformWebConfigTests.cs
@@ -1,6 +1,80 @@
-﻿namespace Microsoft.NET.Sdk.Publish.Tasks.Tests
+﻿using Xunit;
+using System.Text;
+using System.IO;
+using System;
+
+namespace Microsoft.NET.Sdk.Publish.Tasks.Tests
 {
     public class TransformWebConfigTests
     {
+
+        [Theory]
+        [InlineData("Web.config")]
+        [InlineData("web.config")]
+        [InlineData("web.Config")]
+        [InlineData("wEb.CoNfIg")]
+        [InlineData("WEB.CONFIG")]
+        public void TransformWebConfig_FindWebConfig(string webConfigToSearchFor)
+        {
+
+            string projectFolder = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            try
+            {
+                //Arrange
+                CreateDummyFile(projectFolder, webConfigToSearchFor);
+                var transformWebConfigTask = new TransformWebConfig();
+
+                var projectFile = Path.Combine(projectFolder, "Test.csproj");
+
+                //Act
+                var webConfig = transformWebConfigTask.GetWebConfigFileOrDefault(projectFile, "web.config");
+
+                //Assert
+                Assert.Equal(Path.Combine(projectFolder, webConfigToSearchFor), webConfig); 
+            }
+            finally 
+            {
+                if (File.Exists(Path.Combine(projectFolder, webConfigToSearchFor)))
+                {
+                    File.Delete(Path.Combine(projectFolder, webConfigToSearchFor));
+                }
+            }
+        }
+
+        [Fact]
+        public void TransformWebConfig_ReturnDefaultWebConfig()
+        {
+            string projectFolder = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            string fileName = "unrelated.txt";
+            try 
+            {
+                //Arrange
+                CreateDummyFile(projectFolder, fileName);
+                var transformWebConfigTask = new TransformWebConfig();
+
+                var projectFile = Path.Combine(projectFolder, "Test.csproj");
+                
+                //Act
+                var webConfig = transformWebConfigTask.GetWebConfigFileOrDefault(projectFile, "web.config");
+
+                //Assert
+                Assert.Equal(Path.Combine(projectFolder, "web.config"), webConfig);
+            } 
+            finally 
+            {
+                if (File.Exists(Path.Combine(projectFolder, fileName)))
+                {
+                    File.Delete(Path.Combine(projectFolder, fileName));
+                } 
+            }
+        }
+
+        private void CreateDummyFile(string path, string name)
+        {
+            Directory.CreateDirectory(path);
+            using var fs = File.Create(Path.Combine(path, name));
+            byte[] info = new UTF8Encoding(true).GetBytes("transformwebconfig_test");
+            fs.Write(info, 0, info.Length);
+        }
     }
 }

--- a/src/WebSdk/Publish/Tasks/Tasks/TransformWebConfig.cs
+++ b/src/WebSdk/Publish/Tasks/Tasks/TransformWebConfig.cs
@@ -155,7 +155,7 @@ namespace Microsoft.NET.Sdk.Publish.Tasks
         {
             var projectDirectory = Path.GetDirectoryName(projectPath);
             var currentWebConfigFileName = Directory.EnumerateFiles(projectDirectory)
-                .FirstOrDefault(file => string.Equals(Path.GetFileName(file), defaultWebConfigName, StringComparison.CurrentCultureIgnoreCase)); 
+                .FirstOrDefault(file => string.Equals(Path.GetFileName(file), defaultWebConfigName, StringComparison.OrdinalIgnoreCase));
             var webConfigFileName = currentWebConfigFileName == null ? defaultWebConfigName : Path.GetFileName(currentWebConfigFileName);
             var projectWebConfigPath = Path.Combine(projectDirectory, webConfigFileName); 
 

--- a/src/WebSdk/Publish/Tasks/Tasks/TransformWebConfig.cs
+++ b/src/WebSdk/Publish/Tasks/Tasks/TransformWebConfig.cs
@@ -1,6 +1,8 @@
+using System;
 using System.IO;
 using System.Xml;
 using System.Xml.Linq;
+using System.Linq;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 
@@ -75,13 +77,17 @@ namespace Microsoft.NET.Sdk.Publish.Tasks
 
             // Initialize the publish web.config file with project web.config content if present. Else, clean the existing web.config in the
             // publish folder to make sure we have a consistent web.config update experience.
+            string defaultWebConfigPath = "web.config";
             string projectWebConfigPath = null;
+            string publishWebConfigPath = Path.Combine(PublishDir, defaultWebConfigPath);
+
             if (!string.IsNullOrEmpty(ProjectFullPath))
             {
-                projectWebConfigPath = Path.Combine(Path.GetDirectoryName(ProjectFullPath), "web.config");
+                //Ensure that we load the actual web.config name (case-sensitive on Unix-like systems)
+                projectWebConfigPath = GetWebConfigFileOrDefault(ProjectFullPath, defaultWebConfigPath);
+                publishWebConfigPath = Path.Combine(PublishDir, Path.GetFileName(projectWebConfigPath));
             }
 
-            string publishWebConfigPath = Path.Combine(PublishDir, "web.config");
             publishWebConfigPath = Path.GetFullPath(publishWebConfigPath);
 
             if (File.Exists(publishWebConfigPath))
@@ -138,5 +144,23 @@ namespace Microsoft.NET.Sdk.Publish.Tasks
             Log.LogMessage(MessageImportance.Low, "Configuring project completed successfully");
             return true;
         }
+
+        /// <summary>
+        /// Searches for an existing (case-insensitive) `Web.config` file. Otherwise defaults to defaultWebConfigName
+        /// </summary>
+        /// <param name="projectPath">Full path to project file</param>
+        /// <param name="defaultWebConfigName">Web Config file name to search for i.e. `web.config`</param> 
+        /// <returns></returns>
+        public string GetWebConfigFileOrDefault(string projectPath, string defaultWebConfigName)
+        {
+            var projectDirectory = Path.GetDirectoryName(projectPath);
+            var currentWebConfigFileName = Directory.EnumerateFiles(projectDirectory)
+                .FirstOrDefault(file => string.Equals(Path.GetFileName(file), defaultWebConfigName, StringComparison.CurrentCultureIgnoreCase)); 
+            var webConfigFileName = currentWebConfigFileName == null ? defaultWebConfigName : Path.GetFileName(currentWebConfigFileName);
+            var projectWebConfigPath = Path.Combine(projectDirectory, webConfigFileName); 
+
+            return projectWebConfigPath; 
+        }
+
     }
 }


### PR DESCRIPTION
## Description

This PR attempts to resolve [issue 14853](https://github.com/dotnet/sdk/issues/14853)

Currently, linux environments will fail to retrieve a `Web.config` file if the case does not match `web.config`. This results in the users version of `Web.config` from not being loaded and passed to `WebConfigTransform`, producing an incorrect result.

This PR fixes the issue by searching for the web.config file in the project directory, before passing it to the WebConfigTransform step

## Tests

* Added a series of "integration" tests for the TransformWebConfig task ✅ 
* Test for regression on an OSX System ✅ 
* Compile and test this on a Linux system (Kernel 5.4.78-1-lts) ✅ 
* Test for regression on a Linux System ✅ 
* Test for regression on a Windows System ✅ 

