### PR TITLE
Add OutputPath metadata to PublishItemsOutputGroupOutputs

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -52,6 +52,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       PrepareForPublish;
       ComputeAndCopyFilesToPublishDirectory;
       $(PublishProtocolProviderTargets);
+      PublishItemsOutputGroup;
     </_CorePublishTargets>
 
     <_PublishNoBuildAlternativeDependsOn>$(_BeforePublishNoBuildTargets);$(_CorePublishTargets)</_PublishNoBuildAlternativeDependsOn>
@@ -1173,11 +1174,13 @@ Copyright (c) .NET Foundation. All rights reserved.
       <PublishItemsOutputGroupOutputs Include="@(ResolvedFileToPublish->'%(FullPath)')"
                                       TargetPath="%(ResolvedFileToPublish.RelativePath)"
                                       IsKeyOutput="%(ResolvedFileToPublish.IsKeyOutput)"
+                                      OutputPath="@(ResolvedFileToPublish->'$(PublishDir)%(relativePath)')"
                                       OutputGroup="PublishItemsOutputGroup" />
       <PublishItemsOutputGroupOutputs Include="$(PublishedSingleFilePath)"
                                       TargetPath="$(PublishedSingleFileName)"
                                       IsKeyOutput="true"
                                       Condition="'$(PublishSingleFile)' == 'true'"
+                                      OutputPath="$(PublishedSingleFilePath)"
                                       OutputGroup="PublishItemsOutputGroup" />
     </ItemGroup>
   </Target>

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenWeWantToRequireWindowsForDesktopApps.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenWeWantToRequireWindowsForDesktopApps.cs
@@ -225,7 +225,7 @@ namespace Microsoft.NET.Build.Tests
 
             Assert(publishCommand.GetOutputDirectory(tfm, runtimeIdentifier: runtimeIdentifier));
 
-            var command = new GetValuesCommand(
+            var filesCopiedToPublishDirCommand = new GetValuesCommand(
                 Log,
                 Path.Combine(asset.Path, testProject.Name),
                 testProject.TargetFrameworks,
@@ -236,21 +236,49 @@ namespace Microsoft.NET.Build.Tests
                 MetadataNames = { "RelativePath" },
             };
 
-            command.Execute().Should().Pass();
-            var items = from item in command.GetValuesWithMetadata()
-                        select new
-                        {
-                            Identity = item.value,
-                            RelativePath = item.metadata["RelativePath"]
-                        };
+            filesCopiedToPublishDirCommand.Execute().Should().Pass();
+            var filesCopiedToPublishDircommandItems
+                = from item in filesCopiedToPublishDirCommand.GetValuesWithMetadata()
+                  select new
+                  {
+                      Identity = item.value,
+                      RelativePath = item.metadata["RelativePath"]
+                  };
 
-            items
+            filesCopiedToPublishDircommandItems
                 .Should().Contain(i => i.RelativePath == "Microsoft.Windows.SDK.NET.dll" && Path.GetFileName(i.Identity) == "Microsoft.Windows.SDK.NET.dll",
                                   because: "wapproj should copy cswinrt dlls");
-            items
+            filesCopiedToPublishDircommandItems
                 .Should()
                 .Contain(i => i.RelativePath == "WinRT.Runtime.dll" && Path.GetFileName(i.Identity) == "WinRT.Runtime.dll",
                          because: "wapproj should copy cswinrt dlls");
+
+            var publishItemsOutputGroupOutputsCommand = new GetValuesCommand(
+                Log,
+                Path.Combine(asset.Path, testProject.Name),
+                testProject.TargetFrameworks,
+                "PublishItemsOutputGroupOutputs",
+                GetValuesCommand.ValueType.Item)
+            {
+                DependsOnTargets = "Publish",
+                MetadataNames = { "OutputPath" },
+            };
+
+            publishItemsOutputGroupOutputsCommand.Execute().Should().Pass();
+            var publishItemsOutputGroupOutputsItems =
+                from item in publishItemsOutputGroupOutputsCommand.GetValuesWithMetadata()
+                select new
+                {
+                    FullAssetPath = Path.GetFullPath(Path.Combine(asset.Path, testProject.Name, item.metadata["OutputPath"]))
+                };
+
+            publishItemsOutputGroupOutputsItems
+                .Should().Contain(i => Path.GetFileName(Path.GetFullPath(i.FullAssetPath)) == "WinRT.Runtime.dll" && File.Exists(i.FullAssetPath),
+                      because: (string)"as the replacement for FilesCopiedToPublishDir, wapproj should copy cswinrt dlls");
+            publishItemsOutputGroupOutputsItems
+                .Should()
+                .Contain(i => Path.GetFileName(Path.GetFullPath(i.FullAssetPath)) == "WinRT.Runtime.dll" && File.Exists(i.FullAssetPath),
+                         because: "as the replacement for FilesCopiedToPublishDir, wapproj should copy cswinrt dlls");
 
             // ready to run is supported
             publishCommand.Execute("-p:SelfContained=true", $"-p:RuntimeIdentifier={runtimeIdentifier}", $"-p:PublishReadyToRun=true")

--- a/src/Tests/Microsoft.NET.Publish.Tests/PublishItemsOutputGroupOutputsTests.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/PublishItemsOutputGroupOutputsTests.cs
@@ -104,7 +104,6 @@ namespace Microsoft.NET.Publish.Tests
             else
             {
                 FrameworkAssemblies.ForEach(fa => items.Should().NotContain(i => i.OutputPath.Equals(fa, StringComparison.OrdinalIgnoreCase)));
-
             }
         }
     }

--- a/src/Tests/Microsoft.NET.Publish.Tests/PublishItemsOutputGroupOutputsTests.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/PublishItemsOutputGroupOutputsTests.cs
@@ -1,0 +1,111 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using FluentAssertions;
+using Microsoft.DotNet.Cli.Utils;
+using Microsoft.NET.TestFramework;
+using Microsoft.NET.TestFramework.Assertions;
+using Microsoft.NET.TestFramework.Commands;
+using Microsoft.NET.TestFramework.ProjectConstruction;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.NET.Publish.Tests
+{
+    public class PublishItemsOutputGroupOutputsTests : SdkTest
+    {
+        public PublishItemsOutputGroupOutputsTests(ITestOutputHelper log) : base(log)
+        {
+        }
+
+        private readonly static List<string> FrameworkAssemblies = new List<string>()
+        {
+            "api-ms-win-core-console-l1-1-0.dll",
+            "System.Runtime.dll",
+            "WindowsBase.dll",
+        };
+
+        [Theory]
+        [InlineData(true, false)]
+        [InlineData(true, true)]
+        [InlineData(false, false)]
+        public void RunPublishItemsOutputGroupOutputsTest(bool specifyRid, bool singleFile)
+        {
+            var testProject = new TestProject()
+            {
+                Name = "TestPublishItemsOutputGroupOutputs",
+                TargetFrameworks = "netcoreapp3.0",
+                IsExe = true
+            };
+
+            testProject.AdditionalProperties["RuntimeIdentifiers"] = "win-x86";
+            testProject.AdditionalProperties["RestorePackagesPath"] = @"$(MSBuildProjectDirectory)\..\pkg";
+            if (specifyRid)
+            {
+                testProject.AdditionalProperties["RuntimeIdentifier"] = "win-x86";
+            }
+
+            if (singleFile)
+            {
+                testProject.AdditionalProperties["PublishSingleFile"] = "true";
+            }
+
+            var testAsset = _testAssetsManager.CreateTestProject(testProject);
+
+            var restoreCommand = new RestoreCommand(testAsset);
+            restoreCommand
+                .Execute()
+                .Should()
+                .Pass();
+
+            var command = new GetValuesCommand(
+                Log,
+                Path.Combine(testAsset.Path, testProject.Name),
+                testProject.TargetFrameworks,
+                "PublishItemsOutputGroupOutputs",
+                GetValuesCommand.ValueType.Item)
+            {
+                DependsOnTargets = "Publish",
+                MetadataNames = { "OutputPath" },
+            };
+
+            command.Execute().Should().Pass();
+            var items = from item in command.GetValuesWithMetadata()
+                        select new
+                        {
+                            Identity = item.value,
+                            OutputPath = Path.GetFileName(Path.GetFullPath(Path.Combine(testAsset.Path, testProject.Name, item.metadata["OutputPath"])))
+                        };
+
+            Log.WriteLine("PublishItemsOutputGroupOutputs contains '{0}' items:", items.Count());
+            foreach (var item in items)
+            {
+                Log.WriteLine("    '{0}': OutputPath = '{1}'", item.Identity, item.OutputPath);
+            }
+
+            // Check for the main exe
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                string exeSuffix = specifyRid ? ".exe" : Constants.ExeSuffix;
+                items.Should().ContainSingle(i => i.OutputPath.Equals($"{testProject.Name}{exeSuffix}", StringComparison.OrdinalIgnoreCase));
+            }
+
+            // Framework assemblies should be there if we specified and rid and this isn't in the single file case
+            if (specifyRid && !singleFile)
+            {
+                FrameworkAssemblies.ForEach(fa => items.Should().ContainSingle(i => i.OutputPath.Equals(fa, StringComparison.OrdinalIgnoreCase)));
+                items.Should().Contain(i => i.OutputPath.Equals($"{testProject.Name}.deps.json", StringComparison.OrdinalIgnoreCase));
+            }
+            else
+            {
+                FrameworkAssemblies.ForEach(fa => items.Should().NotContain(i => i.OutputPath.Equals(fa, StringComparison.OrdinalIgnoreCase)));
+
+            }
+        }
+    }
+}


### PR DESCRIPTION
To resolve wrapproj logic duplication, create a new metadata
“OutputPath” on  PublishItemsOutputGroupOutputs at the end of Publish
target to represent the content of PublishDir. By the time the itemgroup
is created, the files in this itemgroup should exist on disk. So that
wapproj target do not need to prob the content of PublishDir.

Wapproj targets should depend on Publish target with additional props
being set. And it should set PublishDir to desire end output directory
to avoid an extra copying.

![image](https://user-images.githubusercontent.com/6993335/101546963-69393d00-395e-11eb-8dd7-11c292d3ae7e.png)
