### PR TITLE
FsiForwardingApp.cs

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-fsi/FsiForwardingApp.cs
+++ b/src/Cli/dotnet/commands/dotnet-fsi/FsiForwardingApp.cs
@@ -11,16 +11,45 @@ namespace Microsoft.DotNet.Cli
 {
     public class FsiForwardingApp : ForwardingApp
     {
-        private const string FsiAppName = @"FSharp/fsi.exe";
+        private const string FsiDllName = @"FSharp/fsi.dll";
+        private const string FsiExeName = @"FSharp/fsi.exe";
 
         public FsiForwardingApp(IEnumerable<string> argsToForward)
-            : base(GetFsiExePath(), argsToForward)
+            : base(GetFsiAppPath(), argsToForward)
         {
         }
 
-        private static string GetFsiExePath()
+        private static bool exists(string path)
         {
-            return Path.Combine(AppContext.BaseDirectory, FsiAppName);
+            try
+            {
+                return File.Exists(path);
+            }
+            catch
+            {
+                return false;
+            }
+            
+        }
+
+        /*
+         * FSharp switched from compiling fsi.exe to fsi.dll which will allow us to ship an AppHost version of fsi.exe
+         * The signal that fsi.exe is an apphost fs.exe is the presence of fsi.dll
+         *
+         * So here we look for fsi.dll, if it's found then we will return the path to it, otherwise we return fsi.exe
+         * the reason for using this bridging mechanism is to simplify the coordination between F#/VS and the dotnet sdk
+        */
+        private static string GetFsiAppPath()
+        {
+            var dllPath = Path.Combine(AppContext.BaseDirectory, FsiDllName);
+            if (exists(dllPath))
+            {
+                return dllPath;
+            }
+            else
+            {
+                return Path.Combine(AppContext.BaseDirectory, FsiExeName);
+            }
         }
     }
 }


### PR DESCRIPTION
Hey,

I'm not sure which branch this needs to go in, however, it should end up in all branches that will recieve future FSharp insertions.

The current FSharp packaging packages fsi and fsc as IL executables named fsi.exe and fsc.exe.  We are changing our packaging so that the il executables will be named fsc.dll and fsi.dll, which will allow us to switch on Use_App_Host in our build thus fsc.exe and fsi.exe will be able to execute without requiring dotnet.exe.

In order to make that work we need to update dotnet fsi to execute fsi.dll rather than fsi.exe.

To simplify our coordination, this pr looks to see if fsi.dll exists, if that is the case then dotnet will start fsi.dll.  If fsi.dll does not exist then we fall back to trying to load fsi from fsi.exe

You will note that fsc.exe is not touched in this PR because we don't have an fsc command.

/cc @brettfo 