### PR TITLE
Fix illink test

### DIFF
--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishReadyToRun.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishReadyToRun.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
@@ -59,7 +60,7 @@ namespace Microsoft.NET.Publish.Tests
                 "ClassLib");
 
             testProject.AdditionalProperties["PublishReadyToRun"] = "True";
-            testProject.AdditionalItems["PublishReadyToRunExclude"] = "Classlib.dll";
+            testProject.AdditionalItems["PublishReadyToRunExclude"] = new Dictionary<string, string> { ["Include"] = "Classlib.dll" };
 
             var testProjectInstance = _testAssetsManager.CreateTestProject(testProject);
 

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToRunILLink.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToRunILLink.cs
@@ -493,12 +493,13 @@ namespace Microsoft.NET.Publish.Tests
             var targetFramework = "net5.0";
             var rid = EnvironmentInfo.GetCompatibleRid(targetFramework);
 
-            var testProject = CreateTestProjectForILLinkTesting(targetFramework, projectName, referenceProjectName);
-            // Set up a conditional feature substitution for the "FeatureDisabled" property
-            AddFeatureDefinition(testProject, referenceProjectName);
+            var testProject = CreateTestProjectForILLinkTesting(targetFramework, projectName, referenceProjectName,
+                // Reference the classlib to ensure its XML is processed.
+                addAssemblyReference: true,
+                // Set up a conditional feature substitution for the "FeatureDisabled" property
+                modifyReferencedProject: (referencedProject) => AddFeatureDefinition(referencedProject, referenceProjectName));
             var testAsset = _testAssetsManager.CreateTestProject(testProject)
                 .WithProjectChanges(project => EnableNonFrameworkTrimming(project))
-                .WithProjectChanges(project => EmbedSubstitutions(project))
                 // Set a matching RuntimeHostConfigurationOption, with Trim = "true"
                 .WithProjectChanges(project => AddRuntimeConfigOption(project, trim: true))
                 .WithProjectChanges(project => AddRootDescriptor(project, $"{referenceProjectName}.xml"));
@@ -525,12 +526,13 @@ namespace Microsoft.NET.Publish.Tests
             var targetFramework = "net5.0";
             var rid = EnvironmentInfo.GetCompatibleRid(targetFramework);
 
-            var testProject = CreateTestProjectForILLinkTesting(targetFramework, projectName, referenceProjectName);
-            // Set up a conditional feature substitution for the "FeatureDisabled" property
-            AddFeatureDefinition(testProject, referenceProjectName);
+            var testProject = CreateTestProjectForILLinkTesting(targetFramework, projectName, referenceProjectName,
+                // Reference the classlib to ensure its XML is processed.
+                addAssemblyReference: true,
+                // Set up a conditional feature substitution for the "FeatureDisabled" property
+                modifyReferencedProject: (referencedProject) => AddFeatureDefinition(referencedProject, referenceProjectName));
             var testAsset = _testAssetsManager.CreateTestProject(testProject)
                 .WithProjectChanges(project => EnableNonFrameworkTrimming(project))
-                .WithProjectChanges(project => EmbedSubstitutions(project))
                 // Set a matching RuntimeHostConfigurationOption, with Trim = "false"
                 .WithProjectChanges(project => AddRuntimeConfigOption(project, trim: false))
                 .WithProjectChanges(project => AddRootDescriptor(project, $"{referenceProjectName}.xml"));
@@ -1116,28 +1118,23 @@ namespace Microsoft.NET.Publish.Tests
 
         static readonly string substitutionsFilename = "ILLink.Substitutions.xml";
 
-        private void EmbedSubstitutions(XDocument project)
-        {
-            var ns = project.Root.Name.Namespace;
-
-            project.Root.Add(new XElement(ns + "ItemGroup",
-                                new XElement("EmbeddedResource",
-                                    new XAttribute("Include", substitutionsFilename),
-                                    new XElement("LogicalName", substitutionsFilename))));
-        }
-
-        private void AddFeatureDefinition(TestProject testProject, string referenceAssemblyName)
+        private void AddFeatureDefinition(TestProject testProject, string assemblyName)
         {
             // Add a feature definition that replaces the FeatureDisabled property when DisableFeature is true.
             testProject.EmbeddedResources[substitutionsFilename] = $@"
 <linker>
-  <assembly fullname=""{referenceAssemblyName}"" feature=""DisableFeature"" featurevalue=""true"">
+  <assembly fullname=""{assemblyName}"" feature=""DisableFeature"" featurevalue=""true"">
     <type fullname=""ClassLib"">
       <method signature=""System.Boolean get_FeatureDisabled()"" body=""stub"" value=""true"" />
     </type>
   </assembly>
 </linker>
 ";
+
+            testProject.AdditionalItems["EmbeddedResource"] = new Dictionary<string, string> {
+                ["Include"] = substitutionsFilename,
+                ["LogicalName"] = substitutionsFilename
+            };
         }
 
         private void AddRuntimeConfigOption(XDocument project, bool trim)
@@ -1221,7 +1218,9 @@ public class Program
             string referenceProjectName = null,
             bool usePackageReference = true,
             [CallerMemberName] string callingMethod = "",
-            string referenceProjectIdentifier = "")
+            string referenceProjectIdentifier = "",
+            Action<TestProject> modifyReferencedProject = null,
+            bool addAssemblyReference = false)
         {
             var testProject = new TestProject()
             {
@@ -1239,11 +1238,24 @@ public class Program
     {
         Console.WriteLine(""Hello world"");
     }
-}
 ";
+
+            if (addAssemblyReference)
+            {
+                testProject.SourceFiles[$"{mainProjectName}.cs"] += @"
+    public static void UseClassLib()
+    {
+        ClassLib.UsedMethod();
+    }
+}";
+            } else {
+                testProject.SourceFiles[$"{mainProjectName}.cs"] += @"}";
+            }
 
             if (referenceProjectName == null)
             {
+                if (addAssemblyReference)
+                    throw new ArgumentException("Adding an assembly reference requires a project to reference.");
                 return testProject;
             }
 
@@ -1258,8 +1270,13 @@ public class Program
             };
             referenceProject.SourceFiles[$"{referenceProjectName}.cs"] = @"
 using System;
+
 public class ClassLib
 {
+    public static void UsedMethod()
+    {
+    }
+
     public void UnusedMethod()
     {
     }
@@ -1283,6 +1300,8 @@ public class ClassLib
     }
 }
 ";
+            if (modifyReferencedProject != null)
+                modifyReferencedProject(referenceProject);
 
             if (usePackageReference)
             {

--- a/src/Tests/Microsoft.NET.TestFramework/ProjectConstruction/TestProject.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/ProjectConstruction/TestProject.cs
@@ -231,8 +231,8 @@ namespace Microsoft.NET.TestFramework.ProjectConstruction
                         projectXml.Root.Add(packageReferenceItemGroup);
                     }
                     var item = new XElement(ns + additionalItem.Key);
-                    foreach (var (attributeKey, attributeValue) in additionalItem.Value)
-                        item.Add(new XAttribute(attributeKey, attributeValue));
+                    foreach (var attribute in additionalItem.Value)
+                        item.Add(new XAttribute(attribute.Key, attribute.Value));
                     additionalItemGroup.Add(item);
                 }
             }

--- a/src/Tests/Microsoft.NET.TestFramework/ProjectConstruction/TestProject.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/ProjectConstruction/TestProject.cs
@@ -59,7 +59,7 @@ namespace Microsoft.NET.TestFramework.ProjectConstruction
 
         public Dictionary<string, string> AdditionalProperties { get; } = new Dictionary<string, string>();
 
-        public Dictionary<string, string> AdditionalItems { get; } = new Dictionary<string, string>();
+        public Dictionary<string, Dictionary<string, string>> AdditionalItems { get; } = new Dictionary<string, Dictionary<string, string>>();
 
         public IEnumerable<string> TargetFrameworkIdentifiers
         {
@@ -230,9 +230,10 @@ namespace Microsoft.NET.TestFramework.ProjectConstruction
                         additionalItemGroup = new XElement(ns + "ItemGroup");
                         projectXml.Root.Add(packageReferenceItemGroup);
                     }
-                    additionalItemGroup.Add(new XElement(
-                        ns + additionalItem.Key, 
-                        new XAttribute("Include", additionalItem.Value)));
+                    var item = new XElement(ns + additionalItem.Key);
+                    foreach (var (attributeKey, attributeValue) in additionalItem.Value)
+                        item.Add(new XAttribute(attributeKey, attributeValue));
+                    additionalItemGroup.Add(item);
                 }
             }
 


### PR DESCRIPTION
Avoids modifying other assemblies in embedded XML, in response to
https://github.com/mono/linker/pull/1675.

This will unblock dependency flow in https://github.com/dotnet/sdk/pull/14925.