### PR TITLE
FsiForwardingApp.cs

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-fsi/FsiForwardingApp.cs
+++ b/src/Cli/dotnet/commands/dotnet-fsi/FsiForwardingApp.cs
@@ -11,16 +11,45 @@ namespace Microsoft.DotNet.Cli
 {
     public class FsiForwardingApp : ForwardingApp
     {
-        private const string FsiAppName = @"FSharp/fsi.exe";
+        private const string FsiDllName = @"FSharp/fsi.dll";
+        private const string FsiExeName = @"FSharp/fsi.exe";
 
         public FsiForwardingApp(IEnumerable<string> argsToForward)
-            : base(GetFsiExePath(), argsToForward)
+            : base(GetFsiAppPath(), argsToForward)
         {
         }
 
-        private static string GetFsiExePath()
+        private static bool exists(string path)
         {
-            return Path.Combine(AppContext.BaseDirectory, FsiAppName);
+            try
+            {
+                return File.Exists(path);
+            }
+            catch
+            {
+                return false;
+            }
+            
+        }
+
+        /*
+         * FSharp switched from compiling fsi.exe to fsi.dll which will allow us to ship an AppHost version of fsi.exe
+         * The signal that fsi.exe is an apphost fs.exe is the presence of fsi.dll
+         *
+         * So here we look for fsi.dll, if it's found then we will return the path to it, otherwise we return fsi.exe
+         * the reason for using this bridging mechanism is to simplify the coordination between F#/VS and the dotnet sdk
+        */
+        private static string GetFsiAppPath()
+        {
+            var dllPath = Path.Combine(AppContext.BaseDirectory, FsiDllName);
+            if (exists(dllPath))
+            {
+                return dllPath;
+            }
+            else
+            {
+                return Path.Combine(AppContext.BaseDirectory, FsiExeName);
+            }
         }
     }
 }


### PR DESCRIPTION
@wli3 

Okay, we have taken another think about this and for sure want to go ahead.  F# currently builds the IL dll fsi.dll as fsi.exe, we want to start using an apphost fsi.exe in our repo tool chain.

To this end we are changing the probing by fsiforwardingapp for the dotnet fsi command, to first search for fsi.dll, if it doesn't find one it will fall back to using fsi.exe.  Probing for both simplifies our insertions and coordination, we just need to make our change after you have merged this.

We want the change to go out with the next rtm release of the sdk.  Please let me know if this is the right branch.

Thanks

Kevin

