### PR TITLE
Fix test directory clash between two tests with the same name

### DIFF
--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishReadyToRun.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishReadyToRun.cs
@@ -158,7 +158,7 @@ namespace Microsoft.NET.Publish.Tests
         }
 
         [Fact]
-        public void It_warns_when_targetting_netcoreapp_2_x()
+        public void It_warns_when_targetting_netcoreapp_2_x_readytorun()
         {
             var testProject = new TestProject()
             {

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToRunILLink.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToRunILLink.cs
@@ -1033,7 +1033,7 @@ namespace Microsoft.NET.Publish.Tests
         }
 
         [Fact]
-        public void It_warns_when_targetting_netcoreapp_2_x()
+        public void It_warns_when_targetting_netcoreapp_2_x_illink()
         {
             var testProject = new TestProject()
             {


### PR DESCRIPTION
Since both tests were called `It_warns_when_targetting_netcoreapp_2_x()` we generated the same path to the test project: `It_warns_when---89ACFD43/ConsoleApp/ConsoleApp.csproj`

If these two tests execute at roughly the same time (which can happen randomly with xunit's parallelization) then we'd run into weird issues where files are missing since one of the two tests deleted them:

```
error MSB4019: The imported project "/datadisks/disk1/work/A11D08D5/w/B2BB092B/e/testExecutionDirectory/It_warns_when---89ACFD43/ConsoleApp/obj/ConsoleApp.csproj.*.targets" was not found
```

Making the test names unique will avoid this.

---

Note: I saw more instance of the same path/hash being used for multiple test runs but those were different runs of the same `[Theory]` and xunit doesn't parallelize those. (~~However maybe those should still be fixed since they could create wrong results if one theory run leaves behind some files that the next run sees?~~ EDIT: ah it looks like we delete the contents of the `TestDirectory` before running a test so that should be fine.)