### PR TITLE
Reincorporating add package suggestions

### DIFF
--- a/src/Cli/dotnet/Parser.cs
+++ b/src/Cli/dotnet/Parser.cs
@@ -170,6 +170,11 @@ namespace Microsoft.DotNet.Cli
                         ListCommandParser.SlnOrProjectArgument.Name = CommonLocalizableStrings.ProjectArgumentName;
                         ListCommandParser.SlnOrProjectArgument.Description = CommonLocalizableStrings.ProjectArgumentDescription;
                     }
+                    else if (command.Name.Equals(AddPackageParser.GetCommand().Name))
+                    {
+                        // Don't show package suggestions in help
+                        AddPackageParser.CmdPackageArgument.Suggestions.Clear();
+                    }
 
                     base.Write(command);
                 }

--- a/src/Cli/dotnet/commands/dotnet-add/dotnet-add-package/AddPackageParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-add/dotnet-add-package/AddPackageParser.cs
@@ -18,7 +18,7 @@ namespace Microsoft.DotNet.Cli
         public static readonly Argument CmdPackageArgument = new Argument<string>(LocalizableStrings.CmdPackage)
         {
             Description = LocalizableStrings.CmdPackageDescription
-        };
+        }.AddSuggestions((parseResult, match) => QueryNuGet(match));
 
         public static readonly Option VersionOption = new Option<string>(new string[] { "-v", "--version" },
                               LocalizableStrings.CmdVersionDescription)

--- a/src/Tests/dotnet.Tests/ParserTests/AddReferenceParserTests.cs
+++ b/src/Tests/dotnet.Tests/ParserTests/AddReferenceParserTests.cs
@@ -66,6 +66,15 @@ namespace Microsoft.DotNet.Tests.ParserTests
         }
 
         [Fact]
+        public void NuGetProvidesSuggestionsForAddPackages()
+        {
+            var parseResult = Parser.Instance.Parse("dotnet add package Micr");
+            parseResult.GetSuggestions()
+                .Should()
+                .NotBeEmpty();
+        }
+
+        [Fact]
         public void EnumerablePackageIdFromQueryResponseResultsPackageIds()
         {
             using (var stream = new MemoryStream())

--- a/src/Tests/dotnet.Tests/ParserTests/AddReferenceParserTests.cs
+++ b/src/Tests/dotnet.Tests/ParserTests/AddReferenceParserTests.cs
@@ -66,15 +66,6 @@ namespace Microsoft.DotNet.Tests.ParserTests
         }
 
         [Fact]
-        public void NuGetProvidesSuggestionsForAddPackages()
-        {
-            var parseResult = Parser.Instance.Parse("dotnet add package Micr");
-            parseResult.GetSuggestions()
-                .Should()
-                .NotBeEmpty();
-        }
-
-        [Fact]
         public void EnumerablePackageIdFromQueryResponseResultsPackageIds()
         {
             using (var stream = new MemoryStream())


### PR DESCRIPTION
Fixes https://github.com/dotnet/sdk/issues/15013

This is not a new addition, suggestions were lost when I switched to using system.command line in #14379 and I'm adding them back here. I added a test in this PR to ensure suggestions are not empty. 