### PR TITLE
Generate errors when referencing an Executable project with different SelfContained value

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the MIT license. See License.txt in the project root for full license information. -->
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup>
-    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
-  </PropertyGroup>
   <!-- Opt out of certain Arcade features -->
   <PropertyGroup>
     <UsingToolNetFrameworkReferenceAssemblies>true</UsingToolNetFrameworkReferenceAssemblies>

--- a/src/Tasks/Common/Resources/Strings.resx
+++ b/src/Tasks/Common/Resources/Strings.resx
@@ -698,4 +698,12 @@ The following are names of parameters or literal values and should not be transl
     <value>NETSDK1148: A referenced assembly was compiled using a newer version of Microsoft.Windows.SDK.NET.dll. Please update to a newer .NET SDK in order to reference this assembly.</value>
     <comment>{StrBegin="NETSDK1148: "}</comment>
   </data>
+  <data name="SelfContainedExeCannotReferenceNonSelfContained" xml:space="preserve">
+    <value>NETSDK1150: The referenced project '{0}' is a non self-contained executable.  A non self-contained executable cannot be referenced by a self-contained executable.</value>
+    <comment>{StrBegin="NETSDK1150: "}</comment>
+  </data>
+  <data name="NonSelfContainedExeCannotReferenceSelfContained" xml:space="preserve">
+    <value>NETSDK1151: The referenced project '{0}' is a self-contained executable.  A self-contained executable cannot be referenced by a non self-contained executable.</value>
+    <comment>{StrBegin="NETSDK1151: "}</comment>
+  </data>
 </root>

--- a/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
@@ -505,6 +505,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1121: Projekty C++/CLI cílené na rozhraní .NET Core nemůžou používat SelfContained=true.</target>
         <note>{StrBegin="NETSDK1121: "}</note>
       </trans-unit>
+      <trans-unit id="NonSelfContainedExeCannotReferenceSelfContained">
+        <source>NETSDK1151: The referenced project '{0}' is a self-contained executable.  A self-contained executable cannot be referenced by a non self-contained executable.</source>
+        <target state="new">NETSDK1151: The referenced project '{0}' is a self-contained executable.  A self-contained executable cannot be referenced by a non self-contained executable.</target>
+        <note>{StrBegin="NETSDK1151: "}</note>
+      </trans-unit>
       <trans-unit id="PackAsToolCannotSupportSelfContained">
         <source>NETSDK1053: Pack as tool does not support self contained.</source>
         <target state="translated">NETSDK1053: Zabalit jako nástroj nepodporuje nezávislost.</target>
@@ -609,6 +614,11 @@ The following are names of parameters or literal values and should not be transl
         <source>NETSDK1112: The runtime pack for {0} was not downloaded. Try running a NuGet restore with the RuntimeIdentifier '{1}'.</source>
         <target state="translated">NETSDK1112: Balíček modulu runtime pro {0} se nestáhl. Zkuste spustit obnovení NuGet s identifikátorem RuntimeIdentifier {1}.</target>
         <note>{StrBegin="NETSDK1112: "}</note>
+      </trans-unit>
+      <trans-unit id="SelfContainedExeCannotReferenceNonSelfContained">
+        <source>NETSDK1150: The referenced project '{0}' is a non self-contained executable.  A non self-contained executable cannot be referenced by a self-contained executable.</source>
+        <target state="new">NETSDK1150: The referenced project '{0}' is a non self-contained executable.  A non self-contained executable cannot be referenced by a self-contained executable.</target>
+        <note>{StrBegin="NETSDK1150: "}</note>
       </trans-unit>
       <trans-unit id="SkippingAdditionalProbingPaths">
         <source>NETSDK1048: 'AdditionalProbingPaths' were specified for GenerateRuntimeConfigurationFiles, but are being skipped because 'RuntimeConfigDevPath' is empty.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.de.xlf
@@ -505,6 +505,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1121: C++-/CLI-Projekte für .NET Core können "SelfContained=true" nicht verwenden.</target>
         <note>{StrBegin="NETSDK1121: "}</note>
       </trans-unit>
+      <trans-unit id="NonSelfContainedExeCannotReferenceSelfContained">
+        <source>NETSDK1151: The referenced project '{0}' is a self-contained executable.  A self-contained executable cannot be referenced by a non self-contained executable.</source>
+        <target state="new">NETSDK1151: The referenced project '{0}' is a self-contained executable.  A self-contained executable cannot be referenced by a non self-contained executable.</target>
+        <note>{StrBegin="NETSDK1151: "}</note>
+      </trans-unit>
       <trans-unit id="PackAsToolCannotSupportSelfContained">
         <source>NETSDK1053: Pack as tool does not support self contained.</source>
         <target state="translated">NETSDK1053: Die Paketierung als Tool unterstützt keine eigenständige Bereitstellung.</target>
@@ -609,6 +614,11 @@ The following are names of parameters or literal values and should not be transl
         <source>NETSDK1112: The runtime pack for {0} was not downloaded. Try running a NuGet restore with the RuntimeIdentifier '{1}'.</source>
         <target state="translated">NETSDK1112: Das Laufzeitpaket für "{0}" wurde nicht heruntergeladen. Führen Sie eine NuGet-Wiederherstellung mit RuntimeIdentifier "{1}" aus.</target>
         <note>{StrBegin="NETSDK1112: "}</note>
+      </trans-unit>
+      <trans-unit id="SelfContainedExeCannotReferenceNonSelfContained">
+        <source>NETSDK1150: The referenced project '{0}' is a non self-contained executable.  A non self-contained executable cannot be referenced by a self-contained executable.</source>
+        <target state="new">NETSDK1150: The referenced project '{0}' is a non self-contained executable.  A non self-contained executable cannot be referenced by a self-contained executable.</target>
+        <note>{StrBegin="NETSDK1150: "}</note>
       </trans-unit>
       <trans-unit id="SkippingAdditionalProbingPaths">
         <source>NETSDK1048: 'AdditionalProbingPaths' were specified for GenerateRuntimeConfigurationFiles, but are being skipped because 'RuntimeConfigDevPath' is empty.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.es.xlf
@@ -505,6 +505,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1121: Los proyectos de C++/CLI destinados a .NET Core no pueden usar SelfContained=true.</target>
         <note>{StrBegin="NETSDK1121: "}</note>
       </trans-unit>
+      <trans-unit id="NonSelfContainedExeCannotReferenceSelfContained">
+        <source>NETSDK1151: The referenced project '{0}' is a self-contained executable.  A self-contained executable cannot be referenced by a non self-contained executable.</source>
+        <target state="new">NETSDK1151: The referenced project '{0}' is a self-contained executable.  A self-contained executable cannot be referenced by a non self-contained executable.</target>
+        <note>{StrBegin="NETSDK1151: "}</note>
+      </trans-unit>
       <trans-unit id="PackAsToolCannotSupportSelfContained">
         <source>NETSDK1053: Pack as tool does not support self contained.</source>
         <target state="translated">NETSDK1053: El paquete como herramienta no admite la autocontención.</target>
@@ -609,6 +614,11 @@ The following are names of parameters or literal values and should not be transl
         <source>NETSDK1112: The runtime pack for {0} was not downloaded. Try running a NuGet restore with the RuntimeIdentifier '{1}'.</source>
         <target state="translated">NETSDK1112: no se descargó el paquete de tiempo de ejecución de {0}. Pruebe a ejecutar una restauración de NuGet con RuntimeIdentifier "{1}".</target>
         <note>{StrBegin="NETSDK1112: "}</note>
+      </trans-unit>
+      <trans-unit id="SelfContainedExeCannotReferenceNonSelfContained">
+        <source>NETSDK1150: The referenced project '{0}' is a non self-contained executable.  A non self-contained executable cannot be referenced by a self-contained executable.</source>
+        <target state="new">NETSDK1150: The referenced project '{0}' is a non self-contained executable.  A non self-contained executable cannot be referenced by a self-contained executable.</target>
+        <note>{StrBegin="NETSDK1150: "}</note>
       </trans-unit>
       <trans-unit id="SkippingAdditionalProbingPaths">
         <source>NETSDK1048: 'AdditionalProbingPaths' were specified for GenerateRuntimeConfigurationFiles, but are being skipped because 'RuntimeConfigDevPath' is empty.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
@@ -505,6 +505,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1121: les projets C++/CLI qui ciblent le .NET Core ne peuvent pas utiliser SelfContained=true.</target>
         <note>{StrBegin="NETSDK1121: "}</note>
       </trans-unit>
+      <trans-unit id="NonSelfContainedExeCannotReferenceSelfContained">
+        <source>NETSDK1151: The referenced project '{0}' is a self-contained executable.  A self-contained executable cannot be referenced by a non self-contained executable.</source>
+        <target state="new">NETSDK1151: The referenced project '{0}' is a self-contained executable.  A self-contained executable cannot be referenced by a non self-contained executable.</target>
+        <note>{StrBegin="NETSDK1151: "}</note>
+      </trans-unit>
       <trans-unit id="PackAsToolCannotSupportSelfContained">
         <source>NETSDK1053: Pack as tool does not support self contained.</source>
         <target state="translated">NETSDK1053: L'outil de compression ne prend pas en charge l'autonomie.</target>
@@ -609,6 +614,11 @@ The following are names of parameters or literal values and should not be transl
         <source>NETSDK1112: The runtime pack for {0} was not downloaded. Try running a NuGet restore with the RuntimeIdentifier '{1}'.</source>
         <target state="translated">NETSDK1112: le pack de runtime pour {0} n'a pas été téléchargé. Essayez d'exécuter une restauration NuGet avec le RuntimeIdentifier '{1}'.</target>
         <note>{StrBegin="NETSDK1112: "}</note>
+      </trans-unit>
+      <trans-unit id="SelfContainedExeCannotReferenceNonSelfContained">
+        <source>NETSDK1150: The referenced project '{0}' is a non self-contained executable.  A non self-contained executable cannot be referenced by a self-contained executable.</source>
+        <target state="new">NETSDK1150: The referenced project '{0}' is a non self-contained executable.  A non self-contained executable cannot be referenced by a self-contained executable.</target>
+        <note>{StrBegin="NETSDK1150: "}</note>
       </trans-unit>
       <trans-unit id="SkippingAdditionalProbingPaths">
         <source>NETSDK1048: 'AdditionalProbingPaths' were specified for GenerateRuntimeConfigurationFiles, but are being skipped because 'RuntimeConfigDevPath' is empty.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.it.xlf
@@ -505,6 +505,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1121: i progetti C++/CLI destinati a .NET Core non possono usare SelfContained=true.</target>
         <note>{StrBegin="NETSDK1121: "}</note>
       </trans-unit>
+      <trans-unit id="NonSelfContainedExeCannotReferenceSelfContained">
+        <source>NETSDK1151: The referenced project '{0}' is a self-contained executable.  A self-contained executable cannot be referenced by a non self-contained executable.</source>
+        <target state="new">NETSDK1151: The referenced project '{0}' is a self-contained executable.  A self-contained executable cannot be referenced by a non self-contained executable.</target>
+        <note>{StrBegin="NETSDK1151: "}</note>
+      </trans-unit>
       <trans-unit id="PackAsToolCannotSupportSelfContained">
         <source>NETSDK1053: Pack as tool does not support self contained.</source>
         <target state="translated">NETSDK1053: la creazione di pacchetti come strumenti non prevede elementi autonomi.</target>
@@ -609,6 +614,11 @@ The following are names of parameters or literal values and should not be transl
         <source>NETSDK1112: The runtime pack for {0} was not downloaded. Try running a NuGet restore with the RuntimeIdentifier '{1}'.</source>
         <target state="translated">NETSDK1112: il pacchetto di runtime per {0} non è stato scaricato. Provare a eseguire un ripristino NuGet con RuntimeIdentifier '{1}'.</target>
         <note>{StrBegin="NETSDK1112: "}</note>
+      </trans-unit>
+      <trans-unit id="SelfContainedExeCannotReferenceNonSelfContained">
+        <source>NETSDK1150: The referenced project '{0}' is a non self-contained executable.  A non self-contained executable cannot be referenced by a self-contained executable.</source>
+        <target state="new">NETSDK1150: The referenced project '{0}' is a non self-contained executable.  A non self-contained executable cannot be referenced by a self-contained executable.</target>
+        <note>{StrBegin="NETSDK1150: "}</note>
       </trans-unit>
       <trans-unit id="SkippingAdditionalProbingPaths">
         <source>NETSDK1048: 'AdditionalProbingPaths' were specified for GenerateRuntimeConfigurationFiles, but are being skipped because 'RuntimeConfigDevPath' is empty.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
@@ -505,6 +505,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1121: .NET Core をターゲットとする C++/CLI プロジェクトでは SelfContained=true を使用できません。</target>
         <note>{StrBegin="NETSDK1121: "}</note>
       </trans-unit>
+      <trans-unit id="NonSelfContainedExeCannotReferenceSelfContained">
+        <source>NETSDK1151: The referenced project '{0}' is a self-contained executable.  A self-contained executable cannot be referenced by a non self-contained executable.</source>
+        <target state="new">NETSDK1151: The referenced project '{0}' is a self-contained executable.  A self-contained executable cannot be referenced by a non self-contained executable.</target>
+        <note>{StrBegin="NETSDK1151: "}</note>
+      </trans-unit>
       <trans-unit id="PackAsToolCannotSupportSelfContained">
         <source>NETSDK1053: Pack as tool does not support self contained.</source>
         <target state="translated">NETSDK1053: Pack As ツールは自己完結型をサポートしていません。</target>
@@ -609,6 +614,11 @@ The following are names of parameters or literal values and should not be transl
         <source>NETSDK1112: The runtime pack for {0} was not downloaded. Try running a NuGet restore with the RuntimeIdentifier '{1}'.</source>
         <target state="translated">NETSDK1112: {0} のランタイム パックがダウンロードされませんでした。RuntimeIdentifier '{1}' で NuGet 復元を実行してみてください。</target>
         <note>{StrBegin="NETSDK1112: "}</note>
+      </trans-unit>
+      <trans-unit id="SelfContainedExeCannotReferenceNonSelfContained">
+        <source>NETSDK1150: The referenced project '{0}' is a non self-contained executable.  A non self-contained executable cannot be referenced by a self-contained executable.</source>
+        <target state="new">NETSDK1150: The referenced project '{0}' is a non self-contained executable.  A non self-contained executable cannot be referenced by a self-contained executable.</target>
+        <note>{StrBegin="NETSDK1150: "}</note>
       </trans-unit>
       <trans-unit id="SkippingAdditionalProbingPaths">
         <source>NETSDK1048: 'AdditionalProbingPaths' were specified for GenerateRuntimeConfigurationFiles, but are being skipped because 'RuntimeConfigDevPath' is empty.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
@@ -505,6 +505,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1121: .NET Core를 대상으로 하는 C++/CLI 프로젝트는 SelfContained=true를 사용할 수 없습니다.</target>
         <note>{StrBegin="NETSDK1121: "}</note>
       </trans-unit>
+      <trans-unit id="NonSelfContainedExeCannotReferenceSelfContained">
+        <source>NETSDK1151: The referenced project '{0}' is a self-contained executable.  A self-contained executable cannot be referenced by a non self-contained executable.</source>
+        <target state="new">NETSDK1151: The referenced project '{0}' is a self-contained executable.  A self-contained executable cannot be referenced by a non self-contained executable.</target>
+        <note>{StrBegin="NETSDK1151: "}</note>
+      </trans-unit>
       <trans-unit id="PackAsToolCannotSupportSelfContained">
         <source>NETSDK1053: Pack as tool does not support self contained.</source>
         <target state="translated">NETSDK1053: 도구로서 팩은 자체 포함을 지원하지 않습니다.</target>
@@ -609,6 +614,11 @@ The following are names of parameters or literal values and should not be transl
         <source>NETSDK1112: The runtime pack for {0} was not downloaded. Try running a NuGet restore with the RuntimeIdentifier '{1}'.</source>
         <target state="translated">NETSDK1112: {0}용 런타임 팩이 다운로드되지 않았습니다. RuntimeIdentifier '{1}'을(를) 사용하여 NuGet 복원을 실행해 보세요.</target>
         <note>{StrBegin="NETSDK1112: "}</note>
+      </trans-unit>
+      <trans-unit id="SelfContainedExeCannotReferenceNonSelfContained">
+        <source>NETSDK1150: The referenced project '{0}' is a non self-contained executable.  A non self-contained executable cannot be referenced by a self-contained executable.</source>
+        <target state="new">NETSDK1150: The referenced project '{0}' is a non self-contained executable.  A non self-contained executable cannot be referenced by a self-contained executable.</target>
+        <note>{StrBegin="NETSDK1150: "}</note>
       </trans-unit>
       <trans-unit id="SkippingAdditionalProbingPaths">
         <source>NETSDK1048: 'AdditionalProbingPaths' were specified for GenerateRuntimeConfigurationFiles, but are being skipped because 'RuntimeConfigDevPath' is empty.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
@@ -505,6 +505,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1121: Projekty C++/CLI przeznaczone dla platformy .NET Core nie mogą używać elementu SelfContained=true.</target>
         <note>{StrBegin="NETSDK1121: "}</note>
       </trans-unit>
+      <trans-unit id="NonSelfContainedExeCannotReferenceSelfContained">
+        <source>NETSDK1151: The referenced project '{0}' is a self-contained executable.  A self-contained executable cannot be referenced by a non self-contained executable.</source>
+        <target state="new">NETSDK1151: The referenced project '{0}' is a self-contained executable.  A self-contained executable cannot be referenced by a non self-contained executable.</target>
+        <note>{StrBegin="NETSDK1151: "}</note>
+      </trans-unit>
       <trans-unit id="PackAsToolCannotSupportSelfContained">
         <source>NETSDK1053: Pack as tool does not support self contained.</source>
         <target state="translated">NETSDK1053: Funkcja pakowania jako narzędzie nie obsługuje elementów autonomicznych.</target>
@@ -609,6 +614,11 @@ The following are names of parameters or literal values and should not be transl
         <source>NETSDK1112: The runtime pack for {0} was not downloaded. Try running a NuGet restore with the RuntimeIdentifier '{1}'.</source>
         <target state="translated">NETSDK1112: Nie pobrano pakietu wykonawczego dla: {0}. Spróbuj uruchomić przywracanie NuGet z użyciem wartości RuntimeIdentifier „{1}”.</target>
         <note>{StrBegin="NETSDK1112: "}</note>
+      </trans-unit>
+      <trans-unit id="SelfContainedExeCannotReferenceNonSelfContained">
+        <source>NETSDK1150: The referenced project '{0}' is a non self-contained executable.  A non self-contained executable cannot be referenced by a self-contained executable.</source>
+        <target state="new">NETSDK1150: The referenced project '{0}' is a non self-contained executable.  A non self-contained executable cannot be referenced by a self-contained executable.</target>
+        <note>{StrBegin="NETSDK1150: "}</note>
       </trans-unit>
       <trans-unit id="SkippingAdditionalProbingPaths">
         <source>NETSDK1048: 'AdditionalProbingPaths' were specified for GenerateRuntimeConfigurationFiles, but are being skipped because 'RuntimeConfigDevPath' is empty.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
@@ -505,6 +505,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1121: os projetos C++/CLI direcionados ao .NET Core não podem usar SelfContained=true.</target>
         <note>{StrBegin="NETSDK1121: "}</note>
       </trans-unit>
+      <trans-unit id="NonSelfContainedExeCannotReferenceSelfContained">
+        <source>NETSDK1151: The referenced project '{0}' is a self-contained executable.  A self-contained executable cannot be referenced by a non self-contained executable.</source>
+        <target state="new">NETSDK1151: The referenced project '{0}' is a self-contained executable.  A self-contained executable cannot be referenced by a non self-contained executable.</target>
+        <note>{StrBegin="NETSDK1151: "}</note>
+      </trans-unit>
       <trans-unit id="PackAsToolCannotSupportSelfContained">
         <source>NETSDK1053: Pack as tool does not support self contained.</source>
         <target state="translated">NETSDK1053: O pacote como ferramenta não é compatível com a opção autossuficiente.</target>
@@ -609,6 +614,11 @@ The following are names of parameters or literal values and should not be transl
         <source>NETSDK1112: The runtime pack for {0} was not downloaded. Try running a NuGet restore with the RuntimeIdentifier '{1}'.</source>
         <target state="translated">NETSDK1112: o pacote de tempo de execução para {0} não foi baixado. Tente executar uma restauração do NuGet com o RuntimeIdentifier '{1}'.</target>
         <note>{StrBegin="NETSDK1112: "}</note>
+      </trans-unit>
+      <trans-unit id="SelfContainedExeCannotReferenceNonSelfContained">
+        <source>NETSDK1150: The referenced project '{0}' is a non self-contained executable.  A non self-contained executable cannot be referenced by a self-contained executable.</source>
+        <target state="new">NETSDK1150: The referenced project '{0}' is a non self-contained executable.  A non self-contained executable cannot be referenced by a self-contained executable.</target>
+        <note>{StrBegin="NETSDK1150: "}</note>
       </trans-unit>
       <trans-unit id="SkippingAdditionalProbingPaths">
         <source>NETSDK1048: 'AdditionalProbingPaths' were specified for GenerateRuntimeConfigurationFiles, but are being skipped because 'RuntimeConfigDevPath' is empty.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
@@ -505,6 +505,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1121: проекты C++/CLI для .NET Core не могут использовать значение параметра SelfContained=true.</target>
         <note>{StrBegin="NETSDK1121: "}</note>
       </trans-unit>
+      <trans-unit id="NonSelfContainedExeCannotReferenceSelfContained">
+        <source>NETSDK1151: The referenced project '{0}' is a self-contained executable.  A self-contained executable cannot be referenced by a non self-contained executable.</source>
+        <target state="new">NETSDK1151: The referenced project '{0}' is a self-contained executable.  A self-contained executable cannot be referenced by a non self-contained executable.</target>
+        <note>{StrBegin="NETSDK1151: "}</note>
+      </trans-unit>
       <trans-unit id="PackAsToolCannotSupportSelfContained">
         <source>NETSDK1053: Pack as tool does not support self contained.</source>
         <target state="translated">NETSDK1053: упаковка в качестве инструмента не поддерживает автономное использование.</target>
@@ -609,6 +614,11 @@ The following are names of parameters or literal values and should not be transl
         <source>NETSDK1112: The runtime pack for {0} was not downloaded. Try running a NuGet restore with the RuntimeIdentifier '{1}'.</source>
         <target state="translated">NETSDK1112: пакет среды выполнения для {0} не был скачан. Попробуйте выполнить восстановление NuGet с помощью RuntimeIdentifier "{1}".</target>
         <note>{StrBegin="NETSDK1112: "}</note>
+      </trans-unit>
+      <trans-unit id="SelfContainedExeCannotReferenceNonSelfContained">
+        <source>NETSDK1150: The referenced project '{0}' is a non self-contained executable.  A non self-contained executable cannot be referenced by a self-contained executable.</source>
+        <target state="new">NETSDK1150: The referenced project '{0}' is a non self-contained executable.  A non self-contained executable cannot be referenced by a self-contained executable.</target>
+        <note>{StrBegin="NETSDK1150: "}</note>
       </trans-unit>
       <trans-unit id="SkippingAdditionalProbingPaths">
         <source>NETSDK1048: 'AdditionalProbingPaths' were specified for GenerateRuntimeConfigurationFiles, but are being skipped because 'RuntimeConfigDevPath' is empty.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
@@ -505,6 +505,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1121: .NET Core'u hedefleyen C++/CLI projelerinde SelfContained=true kullanılamaz.</target>
         <note>{StrBegin="NETSDK1121: "}</note>
       </trans-unit>
+      <trans-unit id="NonSelfContainedExeCannotReferenceSelfContained">
+        <source>NETSDK1151: The referenced project '{0}' is a self-contained executable.  A self-contained executable cannot be referenced by a non self-contained executable.</source>
+        <target state="new">NETSDK1151: The referenced project '{0}' is a self-contained executable.  A self-contained executable cannot be referenced by a non self-contained executable.</target>
+        <note>{StrBegin="NETSDK1151: "}</note>
+      </trans-unit>
       <trans-unit id="PackAsToolCannotSupportSelfContained">
         <source>NETSDK1053: Pack as tool does not support self contained.</source>
         <target state="translated">NETSDK1053: Araç olarak paketleme kendi kendini kapsamayı desteklemiyor.</target>
@@ -609,6 +614,11 @@ The following are names of parameters or literal values and should not be transl
         <source>NETSDK1112: The runtime pack for {0} was not downloaded. Try running a NuGet restore with the RuntimeIdentifier '{1}'.</source>
         <target state="translated">NETSDK1112: {0} için çalışma zamanı paketi indirilmedi. '{1}' RuntimeIdentifier ile bir NuGet geri yüklemesi çalıştırmayı deneyin.</target>
         <note>{StrBegin="NETSDK1112: "}</note>
+      </trans-unit>
+      <trans-unit id="SelfContainedExeCannotReferenceNonSelfContained">
+        <source>NETSDK1150: The referenced project '{0}' is a non self-contained executable.  A non self-contained executable cannot be referenced by a self-contained executable.</source>
+        <target state="new">NETSDK1150: The referenced project '{0}' is a non self-contained executable.  A non self-contained executable cannot be referenced by a self-contained executable.</target>
+        <note>{StrBegin="NETSDK1150: "}</note>
       </trans-unit>
       <trans-unit id="SkippingAdditionalProbingPaths">
         <source>NETSDK1048: 'AdditionalProbingPaths' were specified for GenerateRuntimeConfigurationFiles, but are being skipped because 'RuntimeConfigDevPath' is empty.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
@@ -505,6 +505,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1121: 面向 .NET Core 的 C++/CLI 项目不能使用 SelfContained=true。</target>
         <note>{StrBegin="NETSDK1121: "}</note>
       </trans-unit>
+      <trans-unit id="NonSelfContainedExeCannotReferenceSelfContained">
+        <source>NETSDK1151: The referenced project '{0}' is a self-contained executable.  A self-contained executable cannot be referenced by a non self-contained executable.</source>
+        <target state="new">NETSDK1151: The referenced project '{0}' is a self-contained executable.  A self-contained executable cannot be referenced by a non self-contained executable.</target>
+        <note>{StrBegin="NETSDK1151: "}</note>
+      </trans-unit>
       <trans-unit id="PackAsToolCannotSupportSelfContained">
         <source>NETSDK1053: Pack as tool does not support self contained.</source>
         <target state="translated">NETSDK1053: 打包为工具不支持自包含。</target>
@@ -609,6 +614,11 @@ The following are names of parameters or literal values and should not be transl
         <source>NETSDK1112: The runtime pack for {0} was not downloaded. Try running a NuGet restore with the RuntimeIdentifier '{1}'.</source>
         <target state="translated">NETSDK1112: 未下载 {0} 的运行时包。请尝试使用 RuntimeIdentifier“{1}”运行 NuGet 还原。</target>
         <note>{StrBegin="NETSDK1112: "}</note>
+      </trans-unit>
+      <trans-unit id="SelfContainedExeCannotReferenceNonSelfContained">
+        <source>NETSDK1150: The referenced project '{0}' is a non self-contained executable.  A non self-contained executable cannot be referenced by a self-contained executable.</source>
+        <target state="new">NETSDK1150: The referenced project '{0}' is a non self-contained executable.  A non self-contained executable cannot be referenced by a self-contained executable.</target>
+        <note>{StrBegin="NETSDK1150: "}</note>
       </trans-unit>
       <trans-unit id="SkippingAdditionalProbingPaths">
         <source>NETSDK1048: 'AdditionalProbingPaths' were specified for GenerateRuntimeConfigurationFiles, but are being skipped because 'RuntimeConfigDevPath' is empty.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
@@ -505,6 +505,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1121: 以 .NET Core 為目標的 C++/CLI 專案無法使用 SelfContained=true。</target>
         <note>{StrBegin="NETSDK1121: "}</note>
       </trans-unit>
+      <trans-unit id="NonSelfContainedExeCannotReferenceSelfContained">
+        <source>NETSDK1151: The referenced project '{0}' is a self-contained executable.  A self-contained executable cannot be referenced by a non self-contained executable.</source>
+        <target state="new">NETSDK1151: The referenced project '{0}' is a self-contained executable.  A self-contained executable cannot be referenced by a non self-contained executable.</target>
+        <note>{StrBegin="NETSDK1151: "}</note>
+      </trans-unit>
       <trans-unit id="PackAsToolCannotSupportSelfContained">
         <source>NETSDK1053: Pack as tool does not support self contained.</source>
         <target state="translated">NETSDK1053: 封裝為工具不支援包含本身。</target>
@@ -609,6 +614,11 @@ The following are names of parameters or literal values and should not be transl
         <source>NETSDK1112: The runtime pack for {0} was not downloaded. Try running a NuGet restore with the RuntimeIdentifier '{1}'.</source>
         <target state="translated">NETSDK1112: 未下載 {0} 的執行階段套件。請嘗試使用 RuntimeIdentifier '{1}' 執行 NuGet 還原。</target>
         <note>{StrBegin="NETSDK1112: "}</note>
+      </trans-unit>
+      <trans-unit id="SelfContainedExeCannotReferenceNonSelfContained">
+        <source>NETSDK1150: The referenced project '{0}' is a non self-contained executable.  A non self-contained executable cannot be referenced by a self-contained executable.</source>
+        <target state="new">NETSDK1150: The referenced project '{0}' is a non self-contained executable.  A non self-contained executable cannot be referenced by a self-contained executable.</target>
+        <note>{StrBegin="NETSDK1150: "}</note>
       </trans-unit>
       <trans-unit id="SkippingAdditionalProbingPaths">
         <source>NETSDK1048: 'AdditionalProbingPaths' were specified for GenerateRuntimeConfigurationFiles, but are being skipped because 'RuntimeConfigDevPath' is empty.</source>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ValidateExecutableReferences.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ValidateExecutableReferences.cs
@@ -1,0 +1,59 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Build.Framework;
+
+namespace Microsoft.NET.Build.Tasks
+{
+    public class ValidateExecutableReferences : TaskBase
+    {
+        public bool SelfContained { get; set; }
+
+        public bool IsExecutable { get; set; }
+
+        public ITaskItem[] ReferencedProjects { get; set; } = Array.Empty<ITaskItem>();
+
+        protected override void ExecuteCore()
+        {
+            if (!IsExecutable)
+            {
+                //  If current project is not executable, then we don't need to check its references
+                return;
+            }
+
+            foreach (var project in ReferencedProjects)
+            {
+                string nearestTargetFramework = project.GetMetadata("NearestTargetFramework");
+                int targetFrameworkIndex = project.GetMetadata("TargetFrameworks").Split(';').ToList().IndexOf(nearestTargetFramework);
+                string projectAdditionalPropertiesMetadata = project.GetMetadata("AdditionalPropertiesFromProject").Split(new[] { ";;" }, StringSplitOptions.None)[targetFrameworkIndex];
+                Dictionary<string, string> projectAdditionalProperties = new(StringComparer.OrdinalIgnoreCase);
+                foreach (var propAndValue in projectAdditionalPropertiesMetadata.Split(';'))
+                {
+                    var split = propAndValue.Split('=');
+                    projectAdditionalProperties[split[0]] = split[1];
+                }
+
+                var referencedProjectIsExecutable = MSBuildUtilities.ConvertStringToBool(projectAdditionalProperties["_IsExecutable"]);
+                var referencedProjectIsSelfContained = MSBuildUtilities.ConvertStringToBool(projectAdditionalProperties["SelfContained"]);
+
+                if (referencedProjectIsExecutable)
+                {
+                    if (SelfContained && !referencedProjectIsSelfContained)
+                    {
+                        Log.LogError(Strings.SelfContainedExeCannotReferenceNonSelfContained, project.ItemSpec);
+                    }
+                    else if (!SelfContained && referencedProjectIsSelfContained)
+                    {
+                        Log.LogError(Strings.NonSelfContainedExeCannotReferenceSelfContained, project.ItemSpec);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -1031,6 +1031,31 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <!--
   ============================================================
+  ValidateExecutableReferences
+  ============================================================
+  -->
+
+  <ItemGroup>
+    <AdditionalTargetFrameworkInfoProperty Include="SelfContained"/>
+    <AdditionalTargetFrameworkInfoProperty Include="_IsExecutable"/>
+  </ItemGroup>
+
+  <UsingTask TaskName="ValidateExecutableReferences" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
+
+  <Target Name="ValidateExecutableReferences"
+          AfterTargets="_GetProjectReferenceTargetFrameworkProperties"
+          Condition="'$(ValidateExecutableReferencesMatchSelfContained)' != 'false'">
+
+    <ValidateExecutableReferences
+      SelfContained="$(SelfContained)"
+      IsExecutable="$(_IsExecutable)"
+      ReferencedProjects="@(_MSBuildProjectReferenceExistent)"
+      />
+    
+  </Target>
+
+  <!--
+  ============================================================
                                          Project Capabilities
   ============================================================
   -->

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAWindowsDesktopProject.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAWindowsDesktopProject.cs
@@ -352,7 +352,7 @@ namespace Microsoft.NET.Build.Tests
             {
                 TargetFrameworks = targetFramework
             };
-            var testAsset = _testAssetsManager.CreateTestProject(testProject);
+            var testAsset = _testAssetsManager.CreateTestProject(testProject, identifier: targetFramework);
 
             var getValueCommand = new GetValuesCommand(testAsset, "SdkSupportedTargetPlatformIdentifier", GetValuesCommand.ValueType.Item);
             getValueCommand.Execute()

--- a/src/Tests/Microsoft.NET.Build.Tests/ReferenceExeTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/ReferenceExeTests.cs
@@ -76,50 +76,52 @@ namespace Microsoft.NET.Build.Tests
             MainProject.ReferencedProjects.Add(ReferencedProject);
         }
 
-        private void RunTest(bool referencedExeShouldRun, [CallerMemberName] string callingMethod = null)
+        private void RunTest(string buildFailureCode = null, [CallerMemberName] string callingMethod = null)
         {
             var testProjectInstance = _testAssetsManager.CreateTestProject(MainProject, callingMethod: callingMethod, identifier: MainSelfContained.ToString() + "_" + ReferencedSelfContained.ToString());
 
             string outputDirectory;
 
+            TestCommand buildOrPublishCommand;
+
             if (TestWithPublish)
             {
                 var publishCommand = new PublishCommand(testProjectInstance);
 
-                publishCommand.Execute()
-                    .Should()
-                    .Pass();
-
                 outputDirectory = publishCommand.GetOutputDirectory(MainProject.TargetFrameworks, runtimeIdentifier: MainProject.RuntimeIdentifier).FullName;
+
+                buildOrPublishCommand = publishCommand;
             }
             else
             {
                 var buildCommand = new BuildCommand(testProjectInstance);
 
-                buildCommand.Execute()
+                outputDirectory = buildCommand.GetOutputDirectory(MainProject.TargetFrameworks, runtimeIdentifier: MainProject.RuntimeIdentifier).FullName;
+
+                buildOrPublishCommand = buildCommand;
+            }
+
+            if (buildFailureCode == null)
+            {
+                buildOrPublishCommand.Execute()
                     .Should()
                     .Pass();
 
-                outputDirectory = buildCommand.GetOutputDirectory(MainProject.TargetFrameworks, runtimeIdentifier: MainProject.RuntimeIdentifier).FullName;
-            }
+                var mainExePath = Path.Combine(outputDirectory, MainProject.Name + Constants.ExeSuffix);
 
-            var mainExePath = Path.Combine(outputDirectory, MainProject.Name + Constants.ExeSuffix);
+                var referencedExePath = Path.Combine(outputDirectory, ReferencedProject.Name + Constants.ExeSuffix);
 
-            var referencedExePath = Path.Combine(outputDirectory, ReferencedProject.Name + Constants.ExeSuffix);
-
-            new RunExeCommand(Log, mainExePath)
-                .Execute()
-                .Should()
-                .Pass()
-                .And
-                .HaveStdOut("Main project");
+                new RunExeCommand(Log, mainExePath)
+                    .Execute()
+                    .Should()
+                    .Pass()
+                    .And
+                    .HaveStdOut("Main project");
 
 
-            var referencedExeResult = new RunExeCommand(Log, referencedExePath)
-                .Execute();
+                var referencedExeResult = new RunExeCommand(Log, referencedExePath)
+                    .Execute();
 
-            if (referencedExeShouldRun)
-            {
                 referencedExeResult
                     .Should()
                     .Pass()
@@ -128,12 +130,14 @@ namespace Microsoft.NET.Build.Tests
             }
             else
             {
-                referencedExeResult
+                //  Build should not succeed
+                buildOrPublishCommand.Execute()
                     .Should()
-                    .Fail();
-            }
+                    .Fail()
+                    .And
+                    .HaveStdOutContaining(buildFailureCode);
+            }            
         }
-
 
         [Theory]
         [InlineData(false, false)]
@@ -145,7 +149,7 @@ namespace Microsoft.NET.Build.Tests
 
             CreateProjects();
 
-            RunTest(true);
+            RunTest();
         }
 
         [Fact]
@@ -159,22 +163,64 @@ namespace Microsoft.NET.Build.Tests
             ReferencedProject.TargetFrameworks = "netcoreapp3.1";
             ReferencedProject.AdditionalProperties["LangVersion"] = "9.0";
 
-            RunTest(true);
+            RunTest();
         }
 
         //  Having a self-contained and a framework-dependent app in the same folder is not supported (due to the way the host works).
         //  The referenced app will fail to run.  See here for more details: https://github.com/dotnet/sdk/pull/14488#issuecomment-725406998
         [Theory]
-        [InlineData(true, false)]
-        [InlineData(false, true)]
-        public void ReferencedExeFailsToRun(bool mainSelfContained, bool referencedSelfContained)
+        [InlineData(true, false, "NETSDK1150")]
+        [InlineData(false, true, "NETSDK1151")]
+        public void ReferencedExeFailsToBuild(bool mainSelfContained, bool referencedSelfContained, string expectedFailureCode)
         {
             MainSelfContained = mainSelfContained;
             ReferencedSelfContained = referencedSelfContained;
 
             CreateProjects();
 
-            RunTest(referencedExeShouldRun: false);
+            RunTest(expectedFailureCode);
+        }
+
+        [Fact]
+        public void ReferencedExeCanRunWhenReferencesExeWithSelfContainedMismatchForDifferentTargetFramework()
+        {
+            MainSelfContained = true;
+            ReferencedSelfContained = false;
+
+            CreateProjects();
+
+            //  Reference project which is self-contained for net5.0, not self-contained for net5.0-windows.
+            ReferencedProject.TargetFrameworks = "net5.0;net5.0-windows";
+            ReferencedProject.ProjectChanges.Add(project =>
+            {
+                var ns = project.Root.Name.Namespace;
+
+                project.Root.Element(ns + "PropertyGroup")
+                    .Add(XElement.Parse(@"<RuntimeIdentifier Condition=""'$(TargetFramework)' == 'net5.0'"">" + EnvironmentInfo.GetCompatibleRid() + "</RuntimeIdentifier>"));
+            });
+
+            RunTest();
+        }
+
+        [Fact]
+        public void ReferencedExeFailsToBuildWhenReferencesExeWithSelfContainedMismatchForSameTargetFramework()
+        {
+            MainSelfContained = true;
+            ReferencedSelfContained = false;
+
+            CreateProjects();
+
+            //  Reference project which is self-contained for net5.0-windows, not self-contained for net5.0.
+            ReferencedProject.TargetFrameworks = "net5.0;net5.0-windows";
+            ReferencedProject.ProjectChanges.Add(project =>
+            {
+                var ns = project.Root.Name.Namespace;
+
+                project.Root.Element(ns + "PropertyGroup")
+                    .Add(XElement.Parse(@"<RuntimeIdentifier Condition=""'$(TargetFramework)' == 'net5.0-windows'"">" + EnvironmentInfo.GetCompatibleRid() + "</RuntimeIdentifier>"));
+            });
+
+            RunTest("NETSDK1150");
         }
 
         [Theory]
@@ -189,7 +235,7 @@ namespace Microsoft.NET.Build.Tests
             
             CreateProjects();
 
-            RunTest(referencedExeShouldRun: true);
+            RunTest();
         }
 
         [Fact]
@@ -211,7 +257,7 @@ namespace Microsoft.NET.Build.Tests
                 ReferencedProject.AdditionalProperties["PublishTrimmed"] = "True";
             }
 
-            RunTest(referencedExeShouldRun: true);
+            RunTest();
         }
     }
 }

--- a/src/Tests/Microsoft.NET.TestFramework/ProjectConstruction/TestProject.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/ProjectConstruction/TestProject.cs
@@ -61,6 +61,8 @@ namespace Microsoft.NET.TestFramework.ProjectConstruction
 
         public Dictionary<string, string> AdditionalItems { get; } = new Dictionary<string, string>();
 
+        public List<Action<XDocument>> ProjectChanges { get; } = new List<Action<XDocument>>();
+
         public IEnumerable<string> TargetFrameworkIdentifiers
         {
             get
@@ -309,6 +311,11 @@ namespace Microsoft.NET.TestFramework.ProjectConstruction
                     target.Add(copyElement);
                     projectXml.Root.Add(target);
                 }
+            }
+
+            foreach (var projectChange in ProjectChanges)
+            {
+                projectChange(projectXml);
             }
 
             using (var file = File.CreateText(targetProjectPath))


### PR DESCRIPTION
Fixes #15117

Requires changes to MSBuild in dotnet/msbuild#5994 before this will work.