### PR TITLE
Test merging MSBuild after we updated to arcade 5 and net5.0

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -15,6 +15,7 @@
     <add key="dotnet-tools-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools-transport/nuget/v3/index.json" />
     <add key="container-tools" value="https://www.myget.org/F/container-tools-for-visual-studio/api/v3/index.json" />
     <add key="dotnet-core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
+    <add key="general-testing" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/general-testing/nuget/v3/index.json" />
   </packageSources>
   <disabledPackageSources />
 </configuration>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -65,9 +65,9 @@
       <Uri>https://github.com/dotnet/CliCommandLineParser</Uri>
       <Sha>0e89c2116ad28e404ba56c14d1c3f938caa25a01</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Build" Version="16.9.0-preview-21057-03">
+    <Dependency Name="Microsoft.Build" Version="16.9.0-preview-21055-01">
       <Uri>https://github.com/dotnet/msbuild</Uri>
-      <Sha>56b853f9fdfd9c8614522b44603ae43b2698b81e</Sha>
+      <Sha>77daa881ff6adfffe9d62f54282420e5474c34da</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Build.Localization" Version="16.9.0-preview-21057-03">
       <Uri>https://github.com/dotnet/msbuild</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -84,7 +84,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/Microsoft/msbuild -->
-    <MicrosoftBuildPackageVersion>16.9.0-preview-21057-03</MicrosoftBuildPackageVersion>
+    <MicrosoftBuildPackageVersion>16.9.0-preview-21055-01</MicrosoftBuildPackageVersion>
     <MicrosoftBuildFrameworkPackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildFrameworkPackageVersion>
     <MicrosoftBuildRuntimePackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildRuntimePackageVersion>
     <MicrosoftBuildLocalizationPackageVersion>16.9.0-preview-21057-03</MicrosoftBuildLocalizationPackageVersion>


### PR DESCRIPTION
### Context
MSBuild recently updated to arcade 5 and net5.0, we'd like to make sure this plays well with the sdk before merging it in our repo.

#### This PR will likely fail CI
I'm not sure how to get this to find msbuild packages located at a specific feed, when the feed hasn't been published yet. I'd like to point it to the nupkg's located here (under PackageArtifacts): https://dev.azure.com/devdiv/DevDiv/_build/results?buildId=4343025&view=artifacts&pathAsName=false&type=publishedArtifacts

#### It builds locally
1. run `darc update-dependencies -c "General Testing" -n "Microsoft.Build"`
1. [Download and extract the PackageArtifacts folder from this build.](https://dev.azure.com/devdiv/DevDiv/_build/results?buildId=4343025&view=artifacts&pathAsName=false&type=publishedArtifacts)
1. Add `<add key="msbuild" value="path/to/packageartifacts" />` to NuGet.config
1. Run build.cmd