### PR TITLE
Remove default values

### DIFF
--- a/src/Cli/dotnet/Properties/launchSettings.json
+++ b/src/Cli/dotnet/Properties/launchSettings.json
@@ -1,8 +1,7 @@
 {
   "profiles": {
     "dotnet": {
-      "commandName": "Project",
-      "commandLineArgs": "test C:\\temp\\VSTestTestRunParameters  -- TestRunParameters.Parameter(name=\\\"myParam\\\", value=\\\"value\\\") TestRunParameters.Parameter(name=\\\"myParam2\\\", value=\\\"value with space\\\")"
+      "commandName": "Project"
     }
   }
 }

--- a/src/Cli/dotnet/commands/dotnet-test/TestCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/TestCommandParser.cs
@@ -125,12 +125,6 @@ namespace Microsoft.DotNet.Cli
 
             command.AddArgument(SlnOrProjectArgument);
 
-            BlameCrashDumpArgument.SetDefaultValue("full");
-            BlameCrashDumpOption.Argument = BlameCrashDumpArgument;
-
-            BlameHangDumpArgument.SetDefaultValue("full");
-            BlameHangDumpOption.Argument = BlameHangDumpArgument;
-
             command.AddOption(SettingsOption);
             command.AddOption(ListTestsOption);
             command.AddOption(EnvOption);


### PR DESCRIPTION
Command parsing was moved to a different parser and default values there are forcing the blame collector to always collect dumps and check hangs. Removing those default values.

Fixes https://github.com/dotnet/sdk/pull/15228