### PR TITLE
Add env variable for custom vstest.console path

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-test/VSTestForwardingApp.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/VSTestForwardingApp.cs
@@ -23,6 +23,15 @@ namespace Microsoft.DotNet.Cli
 
         private static string GetVSTestExePath()
         {
+            // Provide custom path to vstest.console.dll or exe to be able to test it against any version of 
+            // vstest.console. This is useful especially for our integration tests.
+            // This is equivalent to specifying -p:VSTestConsolePath when using dotnet test with csproj.
+            string vsTestConsolePath = Environment.GetEnvironmentVariable("VSTEST_CONSOLE_PATH");
+            if (!string.IsNullOrWhiteSpace(vsTestConsolePath))
+            {
+                return vsTestConsolePath;
+            }
+
             return Path.Combine(AppContext.BaseDirectory, VstestAppName);
         }
 

--- a/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetVsTestForwardingApp.cs
+++ b/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetVsTestForwardingApp.cs
@@ -5,6 +5,7 @@ using Microsoft.DotNet.Tools.VSTest;
 using FluentAssertions;
 using Xunit;
 using System;
+using System.IO;
 
 namespace Microsoft.DotNet.Cli.MSBuild.Tests
 {
@@ -15,6 +16,24 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
         {
             new VSTestForwardingApp(new string[0])
                 .GetProcessStartInfo().Arguments.Should().EndWith("vstest.console.dll");
+        }
+
+        [Fact]
+        public void ItCanUseEnvironmentVariableToForceCustomPathToVsTestApp()
+        {
+            string vsTestConsolePath = "VSTEST_CONSOLE_PATH";
+            string dummyPath = Path.Join(Path.GetTempPath(), "vstest.custom.console.dll");
+
+            try
+            {
+                Environment.SetEnvironmentVariable(vsTestConsolePath, dummyPath);
+                new VSTestForwardingApp(new string[0])
+                    .GetProcessStartInfo().Arguments.Should().EndWith("vstest.custom.console.dll");
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable(vsTestConsolePath, null);
+            }
         }
     }
 }


### PR DESCRIPTION
Enable vstest.console.dll path to be overriden by environment variable. This allows vstest developers to point `dotnet test + dll` to our version of vstest.console when developing new features. 