### PR TITLE
Update ClickOnce targets for publishing deps.json

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ClickOnce.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ClickOnce.targets
@@ -59,7 +59,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <!-- Get correct deps json files based on _UseBuildDependencyFile -->
     <ItemGroup>
       <ProjectDepsFilesForClickOnce Condition="'$(_UseBuildDependencyFile)' == 'true'" Include="$(ProjectDepsFilePath)"/>
-      <ProjectDepsFilesForClickOnce Condition="'$(_UseBuildDependencyFile)' != 'true'" Include="$(PublishDepsFilePath)"/>
+      <ProjectDepsFilesForClickOnce Condition="'$(_UseBuildDependencyFile)' != 'true'" Include="$(IntermediateDepsFilePath)"/>
     </ItemGroup>
 
     <!-- Add runtimeconfig and deps json file to item group that's included in files for clickonce publishing -->


### PR DESCRIPTION
**Customer Impact**
ClickOnce publish fails for projects referencing packages marked as developer dependency because the publishing specific deps.json file that needs to be referenced is not present.

**Testing**
CTI team has tested the change for the top 50 NuGet packages plus packages specifically affected by the bug.

**Risk**
Low. Only affects packages that are marked as developer dependency.

**Code Reviewer:**
johnhart;mslukewest

**Description of fix**
ClickOnce currently uses PublishDepsFilePath to reference the Publish version of deps.json. The publishing deps.json gets copied to the PublishDepsFilePath when copy targets run at the end of publish build.

However, ClickOnce manifest generation target that references this deps.json runs before the copy targets. This causes ClickOnce target to fail when it tries to access the publishing deps.json instead of the build generate deps.json (conditioned on the _UseBuildDependencyFile property).

The fix is to change the path used to reference the Publish deps.json from PublishDepsFilePath to IntermediateDepsFilePath. The IntermediateDepsFilePath is the intermediate location where the file is generated before its final copy to PublishDepsFilePath.
