### PR TITLE
Add the $(VSTestUseConsole) property to the `dotnet test` command

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-test/Program.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/Program.cs
@@ -34,7 +34,8 @@ namespace Microsoft.DotNet.Tools.Test
             {
                 "-target:VSTest",
                 "-nodereuse:false", // workaround for https://github.com/Microsoft/vstest/issues/1503
-                "-nologo"
+                "-nologo",
+                "-property:VSTestUseConsole=True" // will colorize console output, but lose the MSBuild logs
             };
 
             msbuildArgs.AddRange(result.OptionValuesToBeForwarded(TestCommandParser.GetCommand()));


### PR DESCRIPTION
This PR is a prerequisite for microsoft/vstest#2702. It adds the `$(VSTestUseConsole)` property to the MSBuild process launched by `dotnet test`. As a result this command will behave like it does today (cf. microsoft/vstest#680): colorized output, no MSBuild logs.

microsoft/vstest#2702 adds the ability to use MSBuild directly if logs (or node reuse) are more important than colorization.