### PR TITLE
Append hosting startup variable to existing variable if set

### DIFF
--- a/src/BuiltInTools/dotnet-watch/LaunchBrowserFilter.cs
+++ b/src/BuiltInTools/dotnet-watch/LaunchBrowserFilter.cs
@@ -72,7 +72,7 @@ namespace Microsoft.DotNet.Watcher.Tools
 
                         const string hostingStartupAssembliesName = "ASPNETCORE_HOSTINGSTARTUPASSEMBLIES";
                         var existingHostingStartupAssemblies = Environment.GetEnvironmentVariable(hostingStartupAssembliesName);
-                        if (string.IsNullOrEmpty(existingHostingStartupAssemblies))
+                        if (!string.IsNullOrEmpty(existingHostingStartupAssemblies))
                         {
                             context.ProcessSpec.EnvironmentVariables[hostingStartupAssembliesName] = $"{existingHostingStartupAssemblies};Microsoft.AspNetCore.Watch.BrowserRefresh";
                         }

--- a/src/BuiltInTools/dotnet-watch/LaunchBrowserFilter.cs
+++ b/src/BuiltInTools/dotnet-watch/LaunchBrowserFilter.cs
@@ -69,7 +69,17 @@ namespace Microsoft.DotNet.Watcher.Tools
 
                         var pathToMiddleware = Path.Combine(AppContext.BaseDirectory, "middleware", "Microsoft.AspNetCore.Watch.BrowserRefresh.dll");
                         context.ProcessSpec.EnvironmentVariables["DOTNET_STARTUP_HOOKS"] = pathToMiddleware;
-                        context.ProcessSpec.EnvironmentVariables["ASPNETCORE_HOSTINGSTARTUPASSEMBLIES"] = "Microsoft.AspNetCore.Watch.BrowserRefresh";
+
+                        const string hostingStartupAssembliesName = "ASPNETCORE_HOSTINGSTARTUPASSEMBLIES";
+                        var existingHostingStartupAssemblies = Environment.GetEnvironmentVariable(hostingStartupAssembliesName);
+                        if (existingHostingStartupAssemblies != null)
+                        {
+                            context.ProcessSpec.EnvironmentVariables[hostingStartupAssembliesName] = $"{existingHostingStartupAssemblies};Microsoft.AspNetCore.Watch.BrowserRefresh";
+                        }
+                        else
+                        {
+                            context.ProcessSpec.EnvironmentVariables[hostingStartupAssembliesName] = "Microsoft.AspNetCore.Watch.BrowserRefresh";
+                        }
                     }
                 }
             }

--- a/src/BuiltInTools/dotnet-watch/LaunchBrowserFilter.cs
+++ b/src/BuiltInTools/dotnet-watch/LaunchBrowserFilter.cs
@@ -72,7 +72,7 @@ namespace Microsoft.DotNet.Watcher.Tools
 
                         const string hostingStartupAssembliesName = "ASPNETCORE_HOSTINGSTARTUPASSEMBLIES";
                         var existingHostingStartupAssemblies = Environment.GetEnvironmentVariable(hostingStartupAssembliesName);
-                        if (existingHostingStartupAssemblies != null)
+                        if (string.IsNullOrEmpty(existingHostingStartupAssemblies))
                         {
                             context.ProcessSpec.EnvironmentVariables[hostingStartupAssembliesName] = $"{existingHostingStartupAssemblies};Microsoft.AspNetCore.Watch.BrowserRefresh";
                         }

--- a/src/BuiltInTools/dotnet-watch/LaunchBrowserFilter.cs
+++ b/src/BuiltInTools/dotnet-watch/LaunchBrowserFilter.cs
@@ -69,7 +69,7 @@ namespace Microsoft.DotNet.Watcher.Tools
 
                         const string dotnetStartHooksName = "DOTNET_STARTUP_HOOKS";
                         var pathToMiddleware = Path.Combine(AppContext.BaseDirectory, "middleware", "Microsoft.AspNetCore.Watch.BrowserRefresh.dll");
-                        context.ProcessSpec.EnvironmentVariables["DOTNET_STARTUP_HOOKS"] = AddOrAppend(dotnetStartHooksName, pathToMiddleware);
+                        context.ProcessSpec.EnvironmentVariables[dotnetStartHooksName] = AddOrAppend(dotnetStartHooksName, pathToMiddleware);
 
                         const string hostingStartupAssembliesName = "ASPNETCORE_HOSTINGSTARTUPASSEMBLIES";
                         context.ProcessSpec.EnvironmentVariables[hostingStartupAssembliesName] = AddOrAppend(hostingStartupAssembliesName, "Microsoft.AspNetCore.Watch.BrowserRefresh");


### PR DESCRIPTION
Working on a prototype for new ways to start dotnet watch, and I found an issue when trying to set a hosting startup assembly in a process that launches dotnet watch. This fixes it to first read the environment variable and then set an appended version on the process.

I currently don't have a test for this change; I was thinking of starting a web app and have an endpoint which returns the environment variable value after setting ASPNETCORE_HOSTINGSTARTUPASSEMBLIES to a value. @pranavkm could you help me with that?