### PR TITLE
Added a Shim Target to allow imports to a Windows Application Packaging Project (WAP)

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/sdk/Sdk.NuGet.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/sdk/Sdk.NuGet.targets
@@ -1,0 +1,26 @@
+<!--
+***********************************************************************************************
+Sdk.NuGet.targets
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+          created a backup copy.  Incorrect changes to this file will make it
+          impossible to load or build your projects from the command-line or the IDE.
+
+Copyright (c) .NET Foundation. All rights reserved. 
+***********************************************************************************************
+-->
+<Project>
+  <Import Project="..\targets\Microsoft.NET.ConflictResolution.targets" />
+  <Import Project="..\targets\Microsoft.NET.DisableStandardFrameworkResolution.targets" />
+  <Import Project="..\targets\Microsoft.NET.EolTargetFrameworks.targets" />
+  <Import Project="..\targets\Microsoft.NET.GenerateAssemblyInfo.targets" />
+  <Import Project="..\targets\Microsoft.NET.GenerateSupportedRuntime.targets" />
+  <Import Project="..\targets\Microsoft.NET.ObsoleteReferences.targets" />
+  <Import Project="..\targets\Microsoft.NET.RuntimeIdentifierInference.targets" />
+  <Import Project="..\targets\Microsoft.NET.Sdk.BeforeCommon.targets" />
+  <Import Project="..\targets\Microsoft.NET.Sdk.DefaultItems.targets" />
+  <Import Project="..\targets\Microsoft.NET.Sdk.FrameworkReferenceResolution.targets" />
+  <Import Project="..\targets\Microsoft.NET.Sdk.targets" />
+  <Import Project="..\targets\Microsoft.Microsoft.NET.TargetFrameworkInference.targets" />
+  <Import Project="..\targets\Microsoft.PackageDependencyResolution.targets" />
+</Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/sdk/Sdk.NuGet.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/sdk/Sdk.NuGet.targets
@@ -10,17 +10,8 @@ Copyright (c) .NET Foundation. All rights reserved.
 ***********************************************************************************************
 -->
 <Project>
-  <Import Project="..\targets\Microsoft.NET.ConflictResolution.targets" />
-  <Import Project="..\targets\Microsoft.NET.DisableStandardFrameworkResolution.targets" />
-  <Import Project="..\targets\Microsoft.NET.EolTargetFrameworks.targets" />
-  <Import Project="..\targets\Microsoft.NET.GenerateAssemblyInfo.targets" />
-  <Import Project="..\targets\Microsoft.NET.GenerateSupportedRuntime.targets" />
-  <Import Project="..\targets\Microsoft.NET.ObsoleteReferences.targets" />
-  <Import Project="..\targets\Microsoft.NET.RuntimeIdentifierInference.targets" />
-  <Import Project="..\targets\Microsoft.NET.Sdk.BeforeCommon.targets" />
-  <Import Project="..\targets\Microsoft.NET.Sdk.DefaultItems.targets" />
+  <Import Project="..\targets\Microsoft.PackageDependencyResolution.targets" />
+  <Import Project="..\targets\Microsoft.NET.Sdk.Common.targets" />
   <Import Project="..\targets\Microsoft.NET.Sdk.FrameworkReferenceResolution.targets" />
   <Import Project="..\targets\Microsoft.NET.Sdk.targets" />
-  <Import Project="..\targets\Microsoft.Microsoft.NET.TargetFrameworkInference.targets" />
-  <Import Project="..\targets\Microsoft.PackageDependencyResolution.targets" />
 </Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/sdk/Sdk.NuGet.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/sdk/Sdk.NuGet.targets
@@ -10,8 +10,5 @@ Copyright (c) .NET Foundation. All rights reserved.
 ***********************************************************************************************
 -->
 <Project>
-  <Import Project="..\targets\Microsoft.PackageDependencyResolution.targets" />
-  <Import Project="..\targets\Microsoft.NET.Sdk.Common.targets" />
-  <Import Project="..\targets\Microsoft.NET.Sdk.FrameworkReferenceResolution.targets" />
   <Import Project="..\targets\Microsoft.NET.Sdk.targets" />
 </Project>


### PR DESCRIPTION
Visual Studio's UWP Modern Apps Team would like to display a dependencies node in the Solution Explorer of the Windows Application Packaging Project (WAP).  To enable this feature, it is necessary to access the Dependency Tree .NET Sdk targets (and common tasks) from MSBuild.

There currently is a pattern in use for C++ projects that target .NET Core.  They import the .NET Sdk into MSBuild from [Microsoft.CppCommon.targets](https://devdiv.visualstudio.com/DevDiv/_git/VS?path=%2Fsrc%2Fvc%2Fprojbld%2FCppTargets%2FMicrosoft.CppCommon.targets&version=GBmain):

  ```
<PropertyGroup>
    <MicrosoftNETSdkBeforeCommonTargets  Condition="'$(MicrosoftNETSdkBeforeCommonTargets)' == ''">Sdk.BeforeCommon.targets</MicrosoftNETSdkBeforeCommonTargets>
    <MicrosoftNETSdkAfterCommonTargets   Condition="'$(MicrosoftNETSdkAfterCommonTargets)' == ''">Sdk.AfterCommon.targets </MicrosoftNETSdkAfterCommonTargets>
    <EnableManagedIncrementalBuild Condition="'$(CLRSupport)' == 'NetCore'">false</EnableManagedIncrementalBuild>
  </PropertyGroup>

  <Import Sdk="Microsoft.NET.Sdk" Project="$(MicrosoftNETSdkBeforeCommonTargets)" Condition="'$(CLRSupport)' == 'NetCore' and '$(ImportNETCoreSdkFromVCTargets)' != 'false'"/>

  <Import Project="$(VCTargetsPath)\Microsoft.CppBuild.targets"/>

  <Import Sdk="Microsoft.NET.Sdk" Project="$(MicrosoftNETSdkAfterCommonTargets)"  Condition="'$(CLRSupport)' == 'NetCore'  and '$(ImportNETCoreSdkFromVCTargets)' != 'false'"/>
```

The Sdk.BeforeCommon.targets and Sdk.AfterCommon.targets files can be found in sdk/src/Tasks/Microsoft.NET.Build.Tasks/sdk/

We will copy this pattern and import the Sdk.NuGet.targets file from the WAP Microsoft.DesktopBridge.targets, which will import all the necessary .targets that are used to populate the Dependency tree in the Windows Application Packaging Projects.

By implementing this pattern, we will also solve a current bug where output from CPS is not being displayed in the WAP Build output.