### PR TITLE
Refactoring and adding test coverage for RootSubcommandResult extension

### DIFF
--- a/src/Cli/dotnet/ParseResultExtensions.cs
+++ b/src/Cli/dotnet/ParseResultExtensions.cs
@@ -33,11 +33,24 @@ namespace Microsoft.DotNet.Cli
         public static string RootSubCommandResult(this ParseResult parseResult)
         {
             return parseResult.RootCommandResult.Children?
-                .Select(c => c.Token() == null ?
-                    parseResult.FindResultFor(Parser.DotnetSubCommand)?.GetValueOrDefault<string>() :
-                    c.Token().Type.Equals(TokenType.Command) ? c.Symbol.Name : null)
-                .Where(subcommand => !string.IsNullOrEmpty(subcommand))
-                .FirstOrDefault() ?? string.Empty;
+                .Select(child => GetSymbolResultValue(parseResult, child))
+                .FirstOrDefault(subcommand => !string.IsNullOrEmpty(subcommand)) ?? string.Empty;
+        }
+
+        private static string GetSymbolResultValue(ParseResult parseResult, SymbolResult symbolResult)
+        {
+            if (symbolResult.Token() == null)
+            {
+                return parseResult.FindResultFor(Parser.DotnetSubCommand)?.GetValueOrDefault<string>();
+            }
+            else if (symbolResult.Token().Type.Equals(TokenType.Command))
+            {
+                return symbolResult.Symbol.Name;
+            }
+            else
+            {
+                return string.Empty;
+            }
         }
     }
 }

--- a/src/Tests/dotnet.Tests/ParserTests/ParseResultExtensionsTests.cs
+++ b/src/Tests/dotnet.Tests/ParserTests/ParseResultExtensionsTests.cs
@@ -1,0 +1,37 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.CommandLine.Parsing;
+using FluentAssertions;
+using Microsoft.DotNet.Cli;
+using Xunit;
+using Xunit.Abstractions;
+using Parser = Microsoft.DotNet.Cli.Parser;
+
+namespace Microsoft.DotNet.Tests.ParserTests
+{
+    public class ParseResultExtensionsTests
+    {
+        private readonly ITestOutputHelper output;
+
+        public ParseResultExtensionsTests(ITestOutputHelper output)
+        {
+            this.output = output;
+        }
+
+        [Theory]
+        [InlineData("build /p:prop=true", "build")]
+        [InlineData("add package", "add")]
+        [InlineData("watch run", "watch")]
+        [InlineData("watch run -h", "watch")]
+        [InlineData("ignore list", "ignore")] // Global tool
+        public void RootSubCommandResultReturnsCorrectSubCommand(string input, string expected)
+        {
+            var result = Parser.Instance.Parse(input);
+
+            result.RootSubCommandResult()
+                .Should()
+                .Be(expected);
+        }
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/dotnet/sdk/issues/15349
Fixes https://github.com/dotnet/sdk/issues/15459