### PR TITLE
Update migrated SDKs and fix Razor server

### DIFF
--- a/src/Assets/TestProjects/BlazorMultiApp/BlazorMultipleApps.FirstClient/App.razor
+++ b/src/Assets/TestProjects/BlazorMultiApp/BlazorMultipleApps.FirstClient/App.razor
@@ -1,0 +1,1 @@
+<h1>@typeof(BlazorMultipleApps.FirstClient.Program)</h1>

--- a/src/Assets/TestProjects/BlazorMultiApp/BlazorMultipleApps.FirstClient/BlazorMultipleApps.FirstClient.csproj
+++ b/src/Assets/TestProjects/BlazorMultiApp/BlazorMultipleApps.FirstClient/BlazorMultipleApps.FirstClient.csproj
@@ -6,13 +6,18 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="5.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="5.0.0" PrivateAssets="all" />
-    <PackageReference Include="System.Net.Http.Json" Version="5.0.0" />
+    <ProjectReference Include="..\BlazorMultipleApps.Shared\BlazorMultipleApps.Shared.csproj" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\BlazorMultipleApps.Shared\BlazorMultipleApps.Shared.csproj" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="5.0.0"/>
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
+
+  <!-- Enabling compression increases build time. We want to avoid this for tests so we
+  disable it here. This doesn't affect any test assertions. -->
+  <PropertyGroup>
+    <_BlazorBrotliCompressionLevel>NoCompression</_BlazorBrotliCompressionLevel>
+  </PropertyGroup>
 
 </Project>

--- a/src/Assets/TestProjects/BlazorMultiApp/BlazorMultipleApps.FirstClient/BlazorMultipleApps.FirstClient.csproj
+++ b/src/Assets/TestProjects/BlazorMultiApp/BlazorMultipleApps.FirstClient/BlazorMultipleApps.FirstClient.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+    <StaticWebAssetBasePath>FirstApp</StaticWebAssetBasePath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="5.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="5.0.0" PrivateAssets="all" />
+    <PackageReference Include="System.Net.Http.Json" Version="5.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\BlazorMultipleApps.Shared\BlazorMultipleApps.Shared.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Assets/TestProjects/BlazorMultiApp/BlazorMultipleApps.FirstClient/Program.cs
+++ b/src/Assets/TestProjects/BlazorMultiApp/BlazorMultipleApps.FirstClient/Program.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using System.Text;
+
+namespace BlazorMultipleApps.FirstClient
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            GC.KeepAlive(typeof(System.Text.Json.JsonSerializer));
+        }
+    }
+}

--- a/src/Assets/TestProjects/BlazorMultiApp/BlazorMultipleApps.FirstClient/Program.cs
+++ b/src/Assets/TestProjects/BlazorMultiApp/BlazorMultipleApps.FirstClient/Program.cs
@@ -9,7 +9,7 @@ namespace BlazorMultipleApps.FirstClient
     {
         public static void Main(string[] args)
         {
-            GC.KeepAlive(typeof(System.Text.Json.JsonSerializer));
+            GC.KeepAlive(typeof(Newtonsoft.Json.JsonConvert));
         }
     }
 }

--- a/src/Assets/TestProjects/BlazorMultiApp/BlazorMultipleApps.FirstClient/wwwroot/css/app.css
+++ b/src/Assets/TestProjects/BlazorMultiApp/BlazorMultipleApps.FirstClient/wwwroot/css/app.css
@@ -1,0 +1,1 @@
+﻿/* First app.css */

--- a/src/Assets/TestProjects/BlazorMultiApp/BlazorMultipleApps.FirstClient/wwwroot/index.html
+++ b/src/Assets/TestProjects/BlazorMultiApp/BlazorMultipleApps.FirstClient/wwwroot/index.html
@@ -1,0 +1,14 @@
+﻿<!DOCTYPE html>
+<html>
+
+<head>
+    <title>BlazorMultipleApps</title>
+    <base href="/FirstApp/" />
+    <link href="css/app.css" rel="stylesheet" />
+</head>
+
+<body>
+    <script src="_framework/blazor.webassembly.js"></script>
+</body>
+
+</html>

--- a/src/Assets/TestProjects/BlazorMultiApp/BlazorMultipleApps.SecondClient/App.razor
+++ b/src/Assets/TestProjects/BlazorMultiApp/BlazorMultipleApps.SecondClient/App.razor
@@ -1,0 +1,1 @@
+<h1>@typeof(BlazorMultipleApps.SecondClient.Program)</h1>

--- a/src/Assets/TestProjects/BlazorMultiApp/BlazorMultipleApps.SecondClient/BlazorMultipleApps.SecondClient.csproj
+++ b/src/Assets/TestProjects/BlazorMultiApp/BlazorMultipleApps.SecondClient/BlazorMultipleApps.SecondClient.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+    <StaticWebAssetBasePath>SecondApp</StaticWebAssetBasePath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="5.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="5.0.0" PrivateAssets="all" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\BlazorMultipleApps.Shared\BlazorMultipleApps.Shared.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Assets/TestProjects/BlazorMultiApp/BlazorMultipleApps.SecondClient/BlazorMultipleApps.SecondClient.csproj
+++ b/src/Assets/TestProjects/BlazorMultiApp/BlazorMultipleApps.SecondClient/BlazorMultipleApps.SecondClient.csproj
@@ -6,12 +6,17 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="5.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="5.0.0" PrivateAssets="all" />
+    <ProjectReference Include="..\BlazorMultipleApps.Shared\BlazorMultipleApps.Shared.csproj" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\BlazorMultipleApps.Shared\BlazorMultipleApps.Shared.csproj" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="5.0.0"/>
   </ItemGroup>
+
+  <!-- Enabling compression increases build time. We want to avoid this for tests so we
+  disable it here. This doesn't affect any test assertions. -->
+  <PropertyGroup>
+    <_BlazorBrotliCompressionLevel>NoCompression</_BlazorBrotliCompressionLevel>
+  </PropertyGroup>
 
 </Project>

--- a/src/Assets/TestProjects/BlazorMultiApp/BlazorMultipleApps.SecondClient/Program.cs
+++ b/src/Assets/TestProjects/BlazorMultiApp/BlazorMultipleApps.SecondClient/Program.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Collections.Generic;
+
+namespace BlazorMultipleApps.SecondClient
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+        }
+    }
+}

--- a/src/Assets/TestProjects/BlazorMultiApp/BlazorMultipleApps.SecondClient/wwwroot/css/app.css
+++ b/src/Assets/TestProjects/BlazorMultiApp/BlazorMultipleApps.SecondClient/wwwroot/css/app.css
@@ -1,0 +1,1 @@
+﻿/* Second app.css */

--- a/src/Assets/TestProjects/BlazorMultiApp/BlazorMultipleApps.SecondClient/wwwroot/index.html
+++ b/src/Assets/TestProjects/BlazorMultiApp/BlazorMultipleApps.SecondClient/wwwroot/index.html
@@ -1,0 +1,14 @@
+﻿<!DOCTYPE html>
+<html>
+
+<head>
+    <title>SecondBlazorApp</title>
+    <base href="/SecondApp/" />
+    <link href="css/app.css" rel="stylesheet" />
+</head>
+
+<body>
+    <script src="_framework/blazor.webassembly.js"></script>
+</body>
+
+</html>

--- a/src/Assets/TestProjects/BlazorMultiApp/BlazorMultipleApps.Server/BlazorMultipleApps.Server.csproj
+++ b/src/Assets/TestProjects/BlazorMultiApp/BlazorMultipleApps.Server/BlazorMultipleApps.Server.csproj
@@ -16,5 +16,4 @@
     <_BlazorBrotliCompressionLevel>NoCompression</_BlazorBrotliCompressionLevel>
   </PropertyGroup>
 
-
 </Project>

--- a/src/Assets/TestProjects/BlazorMultiApp/BlazorMultipleApps.Server/BlazorMultipleApps.Server.csproj
+++ b/src/Assets/TestProjects/BlazorMultiApp/BlazorMultipleApps.Server/BlazorMultipleApps.Server.csproj
@@ -1,0 +1,20 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\BlazorMultipleApps.SecondClient\BlazorMultipleApps.SecondClient.csproj" />
+    <ProjectReference Include="..\BlazorMultipleApps.FirstClient\BlazorMultipleApps.FirstClient.csproj" />
+    <ProjectReference Include="..\BlazorMultipleApps.Shared\BlazorMultipleApps.Shared.csproj" />
+  </ItemGroup>
+
+  <!-- Enabling compression increases build time. We want to avoid this for tests so we
+  disable it here. This doesn't affect any test assertions. -->
+  <PropertyGroup>
+    <_BlazorBrotliCompressionLevel>NoCompression</_BlazorBrotliCompressionLevel>
+  </PropertyGroup>
+
+
+</Project>

--- a/src/Assets/TestProjects/BlazorMultiApp/BlazorMultipleApps.Server/Program.cs
+++ b/src/Assets/TestProjects/BlazorMultiApp/BlazorMultipleApps.Server/Program.cs
@@ -1,0 +1,10 @@
+﻿namespace BlazorMultipleApps.Server
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            
+        }
+    }
+}

--- a/src/Assets/TestProjects/BlazorMultiApp/BlazorMultipleApps.Shared/BlazorMultipleApps.Shared.csproj
+++ b/src/Assets/TestProjects/BlazorMultiApp/BlazorMultipleApps.Shared/BlazorMultipleApps.Shared.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.1</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/src/Assets/TestProjects/BlazorMultiApp/BlazorMultipleApps.Shared/WeatherForecast.cs
+++ b/src/Assets/TestProjects/BlazorMultiApp/BlazorMultipleApps.Shared/WeatherForecast.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace BlazorMultipleApps.Shared
+{
+    public class WeatherForecast
+    {
+        public DateTime Date { get; set; }
+
+        public int TemperatureC { get; set; }
+
+        public string Summary { get; set; }
+
+        public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
+    }
+}

--- a/src/BlazorWasmSdk/Sdk/Sdk.targets
+++ b/src/BlazorWasmSdk/Sdk/Sdk.targets
@@ -15,6 +15,10 @@ Copyright (c) .NET Foundation. All rights reserved.
     <_BlazorWebAssemblyTargetsFile Condition="'$(_BlazorWebAssemblyTargetsFile)' == ''">$(MSBuildThisFileDirectory)..\targets\Microsoft.NET.Sdk.BlazorWebAssembly.Current.targets</_BlazorWebAssemblyTargetsFile>
   </PropertyGroup>
 
+  <ItemGroup>
+    <ProjectCapability Include="WebAssembly" />
+  </ItemGroup>
+
   <Import Project="$(_BlazorWebAssemblyTargetsFile)" />
 
 </Project>

--- a/src/BlazorWasmSdk/Targets/Microsoft.NET.Sdk.BlazorWebAssembly.Current.targets
+++ b/src/BlazorWasmSdk/Targets/Microsoft.NET.Sdk.BlazorWebAssembly.Current.targets
@@ -515,7 +515,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ItemGroup>
       <_BlazorPublishBootResource
         Include="@(ResolvedFileToPublish)"
-        Condition="$([System.String]::Copy('%(RelativePath)').Replace('\','/').StartsWith('wwwroot/_framework')) AND '%(Extension)' != '.a'" />
+        Condition="$([System.String]::Copy('%(RelativePath)').Replace('\','/').StartsWith($(_BlazorFrameworkPublishPath.Replace('\', '/')))) AND '%(Extension)' != '.a'" />
     </ItemGroup>
 
     <GetFileHash Files="@(_BlazorPublishBootResource)" Algorithm="SHA256" HashEncoding="base64">

--- a/src/RazorSdk/Sdk/Sdk.targets
+++ b/src/RazorSdk/Sdk/Sdk.targets
@@ -14,7 +14,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" Condition="'$(_RazorSdkImportsMicrosoftNetSdk)' == 'true'" />
 
   <PropertyGroup Condition="'$(RazorSdkCurrentVersionTargets)' == ''">
-    <RazorSdkCurrentVersionTargets Condition="'$(IsCrossTargetingBuild)' != 'true'">$(MSBuildThisFileDirectory)..\build\netstandard2.0\Sdk.Razor.CurrentVersion.targets</RazorSdkCurrentVersionTargets>
+    <RazorSdkCurrentVersionTargets>$(MSBuildThisFileDirectory)..\build\netstandard2.0\Sdk.Razor.CurrentVersion.targets</RazorSdkCurrentVersionTargets>
   </PropertyGroup>
 
   <Import Project="$(RazorSdkCurrentVersionTargets)" />

--- a/src/RazorSdk/Tasks/Microsoft.NET.Sdk.Razor.Tasks.csproj
+++ b/src/RazorSdk/Tasks/Microsoft.NET.Sdk.Razor.Tasks.csproj
@@ -71,7 +71,7 @@
 
   <ItemGroup>
     <Compile Include="**\*.cs" />
-    <Compile Include="..\Tool\CommandLine\*.cs">
+    <Compile Include="..\Tool\CommandLine\ArgumentEscaper.cs">
       <Link>Shared\CommandLine\%(FileName)</Link>
     </Compile>
     <Compile Include="..\Tool\ServerProtocol\*.cs">

--- a/src/RazorSdk/Tasks/Microsoft.NET.Sdk.Razor.Tasks.csproj
+++ b/src/RazorSdk/Tasks/Microsoft.NET.Sdk.Razor.Tasks.csproj
@@ -71,6 +71,9 @@
 
   <ItemGroup>
     <Compile Include="**\*.cs" />
+    <Compile Include="..\Tool\CommandLine\*.cs">
+      <Link>Shared\CommandLine\%(FileName)</Link>
+    </Compile>
     <Compile Include="..\Tool\ServerProtocol\*.cs">
       <Link>Shared\ServerProtocol\%(FileName)</Link>
     </Compile>

--- a/src/RazorSdk/Tool/Application.cs
+++ b/src/RazorSdk/Tool/Application.cs
@@ -88,7 +88,7 @@ namespace Microsoft.NET.Sdk.Razor.Tool
 
         private string GetInformationalVersion()
         {
-            var assembly = typeof(Application).GetTypeInfo().Assembly;
+            var assembly = typeof(Application).Assembly;
             var attribute = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>();
             return attribute.InformationalVersion;
         }

--- a/src/RazorSdk/Tool/CommandLine/ArgumentEscaper.cs
+++ b/src/RazorSdk/Tool/CommandLine/ArgumentEscaper.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 
-namespace Microsoft.NET.Sdk.Razor.Tool
+namespace Microsoft.NET.Sdk.Razor.Tool.CommandLineUtils
 {
     /// <summary>
     /// A utility for escaping arguments for new processes.

--- a/src/RazorSdk/Tool/ServerProtocol/ServerConnection.cs
+++ b/src/RazorSdk/Tool/ServerProtocol/ServerConnection.cs
@@ -9,6 +9,7 @@ using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.NET.Sdk.Razor.Tool.CommandLineUtils;
 
 namespace Microsoft.NET.Sdk.Razor.Tool
 {
@@ -296,8 +297,7 @@ namespace Microsoft.NET.Sdk.Razor.Tool
                 "-p",
                 pipeName
             };
-            // var processArguments = ArgumentEscaper.EscapeAndConcatenate(argumentList);
-            var processArguments = argumentList.ToString();
+            var processArguments = ArgumentEscaper.EscapeAndConcatenate(argumentList);
 
             if (!File.Exists(expectedCompilerPath))
             {

--- a/src/Tests/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/WasmPublishTest.cs
+++ b/src/Tests/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/WasmPublishTest.cs
@@ -1217,7 +1217,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
             // Verify compression works
             new FileInfo(Path.Combine(firstAppPublishDirectory, "_framework", "dotnet.wasm.br")).Should().Exist();
             new FileInfo(Path.Combine(firstAppPublishDirectory, "_framework", "BlazorMultipleApps.FirstClient.dll.br")).Should().Exist();
-            new FileInfo(Path.Combine(firstAppPublishDirectory, "_framework", "System.Text.Json.dll.br")).Should().Exist();
+            new FileInfo(Path.Combine(firstAppPublishDirectory, "_framework", "Newtonsoft.Json.dll.br")).Should().Exist();
 
             var secondAppPublishDirectory = Path.Combine(publishOutputDirectory, "wwwroot", "SecondApp");
 
@@ -1237,6 +1237,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
             new FileInfo(Path.Combine(secondAppPublishDirectory, "_framework", "dotnet.wasm.br")).Should().Exist();
             new FileInfo(Path.Combine(secondAppPublishDirectory, "_framework", "BlazorMultipleApps.SecondClient.dll.br")).Should().Exist();
             new FileInfo(Path.Combine(secondAppPublishDirectory, "_framework", "System.Private.CoreLib.dll.br")).Should().Exist();
+            new FileInfo(Path.Combine(secondAppPublishDirectory, "_framework", "Newtonsoft.Json.dll.br")).Should().NotExist();
         }
 
         private static void VerifyBootManifestHashes(TestAsset testAsset, string blazorPublishDirectory)

--- a/src/Tests/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/WasmPublishTest.cs
+++ b/src/Tests/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/WasmPublishTest.cs
@@ -27,6 +27,38 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
         public WasmPublishIntegrationTest(ITestOutputHelper log) : base(log) { }
 
         [Fact]
+        public void Publish_MinimalApp_Works()
+        {
+            // Arrange
+            var testAppName = "BlazorWasmMinimal";
+            var testInstance = _testAssetsManager.CopyTestAsset(testAppName)
+                            .WithSource();
+
+            var publishCommand = new PublishCommand(Log, testInstance.TestRoot);
+            publishCommand.Execute().Should().Pass();
+
+            var publishDirectory = publishCommand.GetOutputDirectory("net5.0");
+
+            var expectedFiles = new[]
+            {
+                "wwwroot/_framework/blazor.boot.json",
+                "wwwroot/_framework/blazor.webassembly.js",
+                "wwwroot/_framework/dotnet.wasm",
+                "wwwroot/_framework/blazorwasm-minimal.dll",
+                "wwwroot/index.html",
+                "web.config"
+            };
+
+            publishDirectory.Should().HaveFiles(expectedFiles);
+
+            // Verify web.config
+            var content = File.ReadAllText(Path.Combine(publishDirectory.ToString(), "web.config"));
+            content.Should().Contain("<remove fileExtension=\".blat\" />");
+
+            VerifyBootManifestHashes(testInstance, Path.Combine(publishDirectory.ToString(), "wwwroot"));
+        }
+
+        [Fact]
         public void Publish_WithDefaultSettings_Works()
         {
             // Arrange
@@ -54,10 +86,6 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
                 "web.config"
             };
 
-            // Verify web.config
-            var content = File.ReadAllText(Path.Combine(publishDirectory.ToString(), "web.config"));
-            content.Should().Contain("<remove fileExtension=\".blat\" />");
-
             publishDirectory.Should().HaveFiles(expectedFiles);
 
             var blazorPublishDirectory = Path.Combine(publishDirectory.ToString(), "wwwroot");
@@ -74,6 +102,86 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
                 assetsManifestPath: "custom-service-worker-assets.js");
 
             VerifyTypeGranularTrimming(blazorPublishDirectory);
+        }
+
+        [Fact]
+        public void Publish_WithScopedCss_Works()
+        {
+            // Arrange
+            var testAppName = "BlazorWasmWithLibrary";
+            var testInstance = _testAssetsManager.CopyTestAsset(testAppName)
+                            .WithSource();
+            File.WriteAllText(Path.Combine(testInstance.TestRoot, "blazorwasm", "App.razor.css"), "h1 { font-size: 16px; }");
+
+            var publishCommand = new PublishCommand(Log, Path.Combine(testInstance.TestRoot, "blazorwasm"));
+            publishCommand.Execute().Should().Pass();
+
+            var publishDirectory = publishCommand.GetOutputDirectory("net5.0");
+
+            var blazorPublishDirectory = Path.Combine(publishDirectory.ToString(), "wwwroot");
+
+            var expectedFiles = new[]
+            {
+                "wwwroot/_framework/blazor.boot.json",
+                "wwwroot/_framework/blazor.webassembly.js",
+                "wwwroot/_framework/dotnet.wasm",
+                "wwwroot/_framework/blazorwasm.dll",
+                "wwwroot/_framework/System.Text.Json.dll",
+                "wwwroot/_content/RazorClassLibrary/wwwroot/exampleJsInterop.js",
+                "wwwroot/_content/RazorClassLibrary/styles.css",
+                "wwwroot/index.html",
+                "wwwroot/js/LinkedScript.js",
+                "wwwroot/blazorwasm.styles.css",
+                "wwwroot/css/app.css",
+                "web.config"
+            };
+
+            publishDirectory.Should().HaveFiles(expectedFiles);
+
+            new FileInfo(Path.Combine(blazorPublishDirectory, "css", "app.css")).Should().Contain(".publish");
+
+            VerifyBootManifestHashes(testInstance, blazorPublishDirectory);
+            VerifyServiceWorkerFiles(testInstance, blazorPublishDirectory,
+                serviceWorkerPath: Path.Combine("serviceworkers", "my-service-worker.js"),
+                serviceWorkerContent: "// This is the production service worker",
+                assetsManifestPath: "custom-service-worker-assets.js");
+        }
+
+        [Fact]
+        public void Publish_InRelease_Works()
+        {
+            // Arrange
+            var testAppName = "BlazorWasmWithLibrary";
+            var testInstance = _testAssetsManager.CopyTestAsset(testAppName)
+                            .WithSource();
+            File.WriteAllText(Path.Combine(testInstance.TestRoot, "blazorwasm", "App.razor.css"), "h1 { font-size: 16px; }");
+
+            var publishCommand = new PublishCommand(Log, Path.Combine(testInstance.TestRoot, "blazorwasm"));
+            publishCommand.Execute("/p:Configuration=Release").Should().Pass();
+
+            var publishDirectory = publishCommand.GetOutputDirectory("net5.0", "Release");
+
+            var blazorPublishDirectory = Path.Combine(publishDirectory.ToString(), "wwwroot");
+
+            var expectedFiles = new[]
+            {
+                "wwwroot/_framework/blazor.boot.json",
+                "wwwroot/_framework/blazor.webassembly.js",
+                "wwwroot/_framework/dotnet.wasm",
+                "wwwroot/_framework/blazorwasm.dll",
+                "wwwroot/_framework/System.Text.Json.dll",
+                "wwwroot/_content/RazorClassLibrary/wwwroot/exampleJsInterop.js",
+                "wwwroot/_content/RazorClassLibrary/styles.css",
+                "wwwroot/index.html",
+                "wwwroot/js/LinkedScript.js",
+                "wwwroot/blazorwasm.styles.css",
+                "wwwroot/css/app.css",
+                "web.config"
+            };
+
+            publishDirectory.Should().HaveFiles(expectedFiles);
+            
+            new FileInfo(Path.Combine(blazorPublishDirectory, "css", "app.css")).Should().Contain(".publish");
         }
 
         [Fact]
@@ -142,8 +250,8 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
         }
 
         [Theory]
-        [InlineData("different-path/")]
-        [InlineData("/different-path/")]
+        [InlineData("different-path")]
+        [InlineData("/different-path")]
         public void Publish_WithStaticWebBasePathWorks(string basePath)
         {
             // Arrange
@@ -160,6 +268,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
                     itemGroup.Add(new XElement("StaticWebAssetBasePath", basePath));
                     project.Root.Add(itemGroup);
                 }
+
             });
 
             var publishCommand = new PublishCommand(Log, Path.Combine(testInstance.TestRoot, "blazorwasm"));
@@ -204,13 +313,13 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
         }
 
         [Theory]
-        [InlineData("different-path")]
-        [InlineData("/different-path")]
+        [InlineData("different-path/")]
+        [InlineData("/different-path/")]
         public void Publish_Hosted_WithStaticWebBasePathWorks(string basePath)
         {
             var testAppName = "BlazorHosted";
             var testInstance = _testAssetsManager.CopyTestAsset(testAppName)
-                            .WithSource();
+                            .WithSource();;
 
             testInstance.WithProjectChanges((path, project) =>
             {
@@ -221,6 +330,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
                     itemGroup.Add(new XElement("StaticWebAssetBasePath", basePath));
                     project.Root.Add(itemGroup);
                 }
+
             });
 
             var publishCommand = new PublishCommand(Log, Path.Combine(testInstance.TestRoot, "blazorhosted"));
@@ -271,6 +381,78 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
         }
 
         [Fact]
+        public void Publish_WithTrimmingdDisabled_Works()
+        {
+            // Arrange
+            var testAppName = "BlazorWasmWithLibrary";
+            var testInstance = _testAssetsManager.CopyTestAsset(testAppName)
+                            .WithSource();
+
+            testInstance.WithProjectChanges((path, project) =>
+            {
+                if (path.Contains("blazorwasm"))
+                {
+                    var ns = project.Root.Name.Namespace;
+                    var itemGroup = new XElement(ns + "PropertyGroup");
+                    itemGroup.Add(new XElement("PublishTrimmed", false));
+                    project.Root.Add(itemGroup);
+                }
+
+            });
+
+            var publishCommand = new PublishCommand(Log, Path.Combine(testInstance.TestRoot, "blazorwasm"));
+            publishCommand.Execute().Should().Pass();
+
+            var publishDirectory = publishCommand.GetOutputDirectory("net5.0");
+            var blazorPublishDirectory = Path.Combine(publishDirectory.ToString(), "wwwroot");
+
+            publishDirectory.Should().HaveFiles(new[]
+            {
+                "wwwroot/_framework/blazor.boot.json",
+                "wwwroot/_framework/blazor.webassembly.js",
+                "wwwroot/_framework/dotnet.wasm",
+                "wwwroot/_framework/blazorwasm.dll",
+                "wwwroot/_framework/System.Text.Json.dll"
+            });
+
+            // Verify compression works
+            publishDirectory.Should().HaveFiles(new[]
+            {
+                "wwwroot/_framework/dotnet.wasm.br",
+                "wwwroot/_framework/System.Text.Json.dll.br"
+            });
+
+            // Verify static assets are in the publish directory
+            publishDirectory.Should().HaveFiles(new[]
+            {
+                "wwwroot/index.html"
+            });
+
+            // Verify referenced static web assets
+            publishDirectory.Should().HaveFiles(new[]
+            {
+                "wwwroot/_content/RazorClassLibrary/wwwroot/exampleJsInterop.js",
+                "wwwroot/_content/RazorClassLibrary/styles.css",
+            });
+
+            // Verify web.config
+            publishDirectory.Should().HaveFiles(new[]
+            {
+                "web.config"
+            });
+
+            VerifyBootManifestHashes(testInstance, blazorPublishDirectory);
+            VerifyServiceWorkerFiles(testInstance, blazorPublishDirectory,
+                serviceWorkerPath: Path.Combine("serviceworkers", "my-service-worker.js"),
+                serviceWorkerContent: "// This is the production service worker",
+                assetsManifestPath: "custom-service-worker-assets.js");
+
+            // Verify assemblies are not trimmed
+            var loggingAssemblyPath = Path.Combine(blazorPublishDirectory, "_framework", "Microsoft.Extensions.Logging.Abstractions.dll");
+            VerifyAssemblyHasTypes(loggingAssemblyPath, new[] { "Microsoft.Extensions.Logging.Abstractions.NullLogger" });
+        }
+
+        [Fact]
         public void Publish_SatelliteAssemblies_AreCopiedToBuildOutput()
         {
             // Arrange
@@ -311,6 +493,126 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
         }
 
         [Fact]
+        public void Publish_HostedApp_DefaultSettings_Works()
+        {
+            // Arrange
+            var testAppName = "BlazorHosted";
+            var testInstance = _testAssetsManager.CopyTestAsset(testAppName)
+                            .WithSource();
+
+            var publishCommand = new PublishCommand(Log, Path.Combine(testInstance.TestRoot, "blazorhosted"));
+            publishCommand.Execute().Should().Pass();
+
+            var publishDirectory = publishCommand.GetOutputDirectory("net5.0");
+            // Make sure the main project exists
+            new FileInfo(Path.Combine(publishDirectory.ToString(), "blazorhosted.dll")).Should().Exist();
+
+            // Verification for https://github.com/dotnet/aspnetcore/issues/19926. Verify binaries for projects
+            // referenced by the Hosted project appear in the publish directory
+            publishDirectory.Should().HaveFiles(new[]
+            {
+                "RazorClassLibrary.dll",
+                "blazorwasm.dll"
+            });
+
+            var blazorPublishDirectory = Path.Combine(publishDirectory.ToString(), "wwwroot");
+            publishDirectory.Should().HaveFiles(new[]
+            {
+                "wwwroot/_framework/blazor.boot.json",
+                "wwwroot/_framework/blazor.webassembly.js",
+                "wwwroot/_framework/dotnet.wasm",
+                "wwwroot/_framework/blazorwasm.dll",
+                "wwwroot/_framework/System.Text.Json.dll"
+            });
+
+            // Verify project references appear as static web assets
+            publishDirectory.Should().HaveFiles(new[]
+            {
+                "wwwroot/_framework/RazorClassLibrary.dll",
+                "RazorClassLibrary.dll"
+            });
+
+            // Verify static assets are in the publish directory
+            publishDirectory.Should().HaveFiles(new[]
+            {
+                "wwwroot/index.html"
+            });
+
+            // Verify static web assets from referenced projects are copied.
+            publishDirectory.Should().HaveFiles(new[]
+            {
+                "wwwroot/_content/RazorClassLibrary/wwwroot/exampleJsInterop.js",
+                "wwwroot/_content/RazorClassLibrary/styles.css",
+            });
+
+            // Verify web.config
+            publishDirectory.Should().HaveFiles(new[]
+            {
+                "web.config"
+            });
+
+            VerifyBootManifestHashes(testInstance, blazorPublishDirectory);
+
+            // Verify compression works
+            publishDirectory.Should().HaveFiles(new[]
+            {
+                "wwwroot/_framework/dotnet.wasm.br",
+                "wwwroot/_framework/blazorwasm.dll.br",
+                "wwwroot/_framework/RazorClassLibrary.dll.br",
+                "wwwroot/_framework/System.Text.Json.dll.br"
+            });
+
+            publishDirectory.Should().HaveFiles(new[]
+            {
+                "wwwroot/_framework/dotnet.wasm.gz",
+                "wwwroot/_framework/blazorwasm.dll.gz",
+                "wwwroot/_framework/RazorClassLibrary.dll.gz",
+                "wwwroot/_framework/System.Text.Json.dll.gz"
+            });
+
+            VerifyServiceWorkerFiles(testInstance, blazorPublishDirectory,
+                serviceWorkerPath: Path.Combine("serviceworkers", "my-service-worker.js"),
+                serviceWorkerContent: "// This is the production service worker",
+                assetsManifestPath: "custom-service-worker-assets.js");
+
+            VerifyTypeGranularTrimming(blazorPublishDirectory);
+        }
+
+        [Fact]
+        public void Publish_HostedApp_ProducesBootJsonDataWithExpectedContent()
+        {
+            // Arrange
+            var testAppName = "BlazorHosted";
+            var testInstance = _testAssetsManager.CopyTestAsset(testAppName)
+                            .WithSource();
+
+            var wwwroot = Path.Combine(testInstance.TestRoot, "blazorwasm", "wwwroot");
+            File.WriteAllText(Path.Combine(wwwroot, "appsettings.json"), "Default settings");
+            File.WriteAllText(Path.Combine(wwwroot, "appsettings.development.json"), "Development settings");
+
+            var publishCommand = new PublishCommand(Log, Path.Combine(testInstance.TestRoot, "blazorhosted"));
+            publishCommand.Execute().Should().Pass();
+
+            var buildOutputDirectory = publishCommand.GetOutputDirectory("net5.0").ToString();
+
+            var bootJsonPath = Path.Combine(buildOutputDirectory, "wwwroot", "_framework", "blazor.boot.json");
+            var bootJsonData = ReadBootJsonData(bootJsonPath);
+
+            var runtime = bootJsonData.resources.runtime;
+            runtime.Should().ContainKey("dotnet.wasm");
+
+            var assemblies = bootJsonData.resources.assembly;
+            assemblies.Should().ContainKey("blazorwasm.dll");
+            assemblies.Should().ContainKey("RazorClassLibrary.dll");
+            assemblies.Should().ContainKey("System.Text.Json.dll");
+
+            bootJsonData.resources.satelliteResources.Should().BeNull();
+
+            bootJsonData.config.Should().Contain("appsettings.json");
+            bootJsonData.config.Should().Contain("appsettings.development.json");
+        }
+
+        [Fact]
         public void Publish_HostedApp_WithSatelliteAssemblies()
         {
             // Arrange
@@ -344,87 +646,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
 
             var publishOutputDirectory = publishCommand.GetOutputDirectory("net5.0");
 
-            // Verification for https://github.com/dotnet/aspnetcore/issues/19926. Verify binaries for projects
-            // referenced by the Hosted project appear in the publish directory
-            publishOutputDirectory.Should().HaveFiles(new[]
-            {
-                "RazorClassLibrary.dll",
-                "blazorwasm.dll"
-            });
-
-            var blazorPublishDirectory = Path.Combine(publishOutputDirectory.ToString(), "wwwroot");
-            publishOutputDirectory.Should().HaveFiles(new[]
-            {
-                "wwwroot/_framework/blazor.boot.json",
-                "wwwroot/_framework/blazor.webassembly.js",
-                "wwwroot/_framework/dotnet.wasm",
-                "wwwroot/_framework/blazorwasm.dll",
-                "wwwroot/_framework/System.Text.Json.dll"
-            });
-
-            // Verify project references appear as static web assets
-            publishOutputDirectory.Should().HaveFiles(new[]
-            {
-                "wwwroot/_framework/RazorClassLibrary.dll",
-                "RazorClassLibrary.dll"
-            });
-
-            // Verify static assets are in the publish directory
-            publishOutputDirectory.Should().HaveFiles(new[]
-            {
-                "wwwroot/index.html"
-            });
-
-            // Verify static web assets from referenced projects are copied.
-            publishOutputDirectory.Should().HaveFiles(new[]
-            {
-                "wwwroot/_content/RazorClassLibrary/wwwroot/exampleJsInterop.js",
-                "wwwroot/_content/RazorClassLibrary/styles.css",
-            });
-
-            // Verify web.config
-            publishOutputDirectory.Should().HaveFiles(new[]
-            {
-                "web.config"
-            });
-
-            VerifyBootManifestHashes(testInstance, blazorPublishDirectory);
-
-            // Verify compression works
-            publishOutputDirectory.Should().HaveFiles(new[]
-            {
-                "wwwroot/_framework/dotnet.wasm.br",
-                "wwwroot/_framework/blazorwasm.dll.br",
-                "wwwroot/_framework/RazorClassLibrary.dll.br",
-                "wwwroot/_framework/System.Text.Json.dll.br"
-            });
-
-            publishOutputDirectory.Should().HaveFiles(new[]
-            {
-                "wwwroot/_framework/dotnet.wasm.gz",
-                "wwwroot/_framework/blazorwasm.dll.gz",
-                "wwwroot/_framework/RazorClassLibrary.dll.gz",
-                "wwwroot/_framework/System.Text.Json.dll.gz"
-            });
-
-            // Verify that Blazor bootJSON contains the right contents
-            var bootJsonPath = Path.Combine(blazorPublishDirectory, "_framework", "blazor.boot.json");
-            var bootJsonData = ReadBootJsonData(bootJsonPath);
-
-            var runtime = bootJsonData.resources.runtime;
-            runtime.Should().ContainKey("dotnet.wasm");
-
-            var assemblies = bootJsonData.resources.assembly;
-            assemblies.Should().ContainKey("blazorwasm.dll");
-            assemblies.Should().ContainKey("RazorClassLibrary.dll");
-            assemblies.Should().ContainKey("System.Text.Json.dll");
-
-            VerifyServiceWorkerFiles(testInstance, blazorPublishDirectory,
-                serviceWorkerPath: Path.Combine("serviceworkers", "my-service-worker.js"),
-                serviceWorkerContent: "// This is the production service worker",
-                assetsManifestPath: "custom-service-worker-assets.js");
-
-            VerifyTypeGranularTrimming(blazorPublishDirectory);
+            var bootJsonData = new FileInfo(Path.Combine(publishOutputDirectory.ToString(), "wwwroot", "_framework", "blazor.boot.json"));
 
             publishOutputDirectory.Should().HaveFiles(new[]
             {
@@ -434,9 +656,8 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
                 "wwwroot/_framework/fr/Microsoft.CodeAnalysis.CSharp.resources.dll",
             });
 
-            var bootJsonFile = new FileInfo(Path.Combine(blazorPublishDirectory, "_framework", "blazor.boot.json"));
-            bootJsonFile.Should().Contain("\"Microsoft.CodeAnalysis.CSharp.dll\"");
-            bootJsonFile.Should().Contain("\"fr\\/Microsoft.CodeAnalysis.CSharp.resources.dll\"");
+            bootJsonData.Should().Contain("\"Microsoft.CodeAnalysis.CSharp.dll\"");
+            bootJsonData.Should().Contain("\"fr\\/Microsoft.CodeAnalysis.CSharp.resources.dll\"");
         }
 
         [Fact]
@@ -466,7 +687,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
 
             // Publish
             var publishCommand = new PublishCommand(Log, Path.Combine(testInstance.TestRoot, "blazorhosted"));
-            publishCommand.Execute("/p:BuildDependencies=false").Should().Pass();
+            publishCommand.Execute("/p:BuildDependencies=false /bl").Should().Pass();
 
             var publishDirectory = publishCommand.GetOutputDirectory("net5.0");
             // Make sure the main project exists
@@ -595,30 +816,97 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
         }
 
         [Fact]
-        public void Publish_HostedAppWithScopedCssAndSatelliteAssemblies_VisualStudio()
+        public void Publish_HostedApp_VisualStudio()
+        {
+            // Simulates publishing the same way VS does by setting BuildProjectReferences=false.
+            // Arrange
+            var testAppName = "BlazorHosted";
+            var testInstance = _testAssetsManager.CopyTestAsset(testAppName)
+                            .WithSource();
+
+            // VS builds projects individually and then a publish with BuildDependencies=false, but building the main project is a close enough approximation for this test.
+            var buildCommand = new BuildCommand(testInstance, "blazorwasm");
+            buildCommand.Execute("/p:BuildInsideVisualStudio=true").Should().Pass();
+
+            // Publish
+            var publishCommand = new PublishCommand(Log, Path.Combine(testInstance.TestRoot, "blazorhosted"));
+            publishCommand.Execute("/p:BuildProjectReferences=false /p:BuildInsideVisualStudio=true").Should().Pass();
+
+            var publishDirectory = publishCommand.GetOutputDirectory("net5.0");
+            // Make sure the main project exists
+            new FileInfo(Path.Combine(publishDirectory.ToString(), "blazorhosted.dll")).Should().Exist();
+
+            // Verification for https://github.com/dotnet/aspnetcore/issues/19926. Verify binaries for projects
+            // referenced by the Hosted project appear in the publish directory
+            publishDirectory.Should().HaveFiles(new[]
+            {
+                "RazorClassLibrary.dll",
+                "blazorwasm.dll"
+            });
+
+            publishDirectory.Should().HaveFiles(new[]
+            {
+                "wwwroot/_framework/blazor.boot.json",
+                "wwwroot/_framework/blazor.webassembly.js",
+                "wwwroot/_framework/dotnet.wasm",
+                "wwwroot/_framework/blazorwasm.dll",
+                "wwwroot/_framework/System.Text.Json.dll"
+            });
+
+            // Verify project references appear as static web assets
+            // Also verify project references to the server project appear in the publish output
+            publishDirectory.Should().HaveFiles(new[]
+            {
+                "wwwroot/_framework/RazorClassLibrary.dll",
+                "RazorClassLibrary.dll"
+            });
+
+            // Verify static assets are in the publish directory
+            publishDirectory.Should().HaveFiles(new[]
+            {
+                "wwwroot/index.html"
+            });
+
+            // Verify static web assets from referenced projects are copied.
+            publishDirectory.Should().HaveFiles(new[]
+            {
+                "wwwroot/_content/RazorClassLibrary/wwwroot/exampleJsInterop.js",
+                "wwwroot/_content/RazorClassLibrary/styles.css",
+            });
+
+            // Verify web.config
+            publishDirectory.Should().HaveFiles(new[]
+            {
+                "web.config"
+            });
+
+            VerifyBootManifestHashes(testInstance, Path.Combine(publishDirectory.ToString(), "wwwroot"));
+
+            // Verify compression works
+            publishDirectory.Should().HaveFiles(new[]
+            {
+                "wwwroot/_framework/dotnet.wasm.br",
+                "wwwroot/_framework/blazorwasm.dll.br",
+                "wwwroot/_framework/RazorClassLibrary.dll.br",
+                "wwwroot/_framework/System.Text.Json.dll.br"
+            });
+
+            var blazorPublishDirectory = Path.Combine(publishDirectory.ToString(), "wwwroot");
+
+            VerifyBootManifestHashes(testInstance, blazorPublishDirectory);
+            VerifyServiceWorkerFiles(testInstance, blazorPublishDirectory,
+                serviceWorkerPath: Path.Combine("serviceworkers", "my-service-worker.js"),
+                serviceWorkerContent: "// This is the production service worker",
+                assetsManifestPath: "custom-service-worker-assets.js");
+        }
+
+        [Fact]
+        public void Publish_HostedAppWithScopedCss_VisualStudio()
         {
             // Simulates publishing the same way VS does by setting BuildProjectReferences=false.
             var testAppName = "BlazorHosted";
             var testInstance = _testAssetsManager.CopyTestAsset(testAppName)
                             .WithSource();
-
-            testInstance.WithProjectChanges((path, project) =>
-            {
-                if (path.Contains("blazorwasm"))
-                {
-                    var ns = project.Root.Name.Namespace;
-                    var propertyGroup = new XElement(ns + "PropertyGroup");
-                    propertyGroup.Add(new XElement("DefineConstants", @"$(DefineConstants);REFERENCE_classlibrarywithsatelliteassemblies"));
-                    var itemGroup = new XElement(ns + "ItemGroup");
-                    itemGroup.Add(new XElement("ProjectReference", new XAttribute("Include", @"..\classlibrarywithsatelliteassemblies\classlibrarywithsatelliteassemblies.csproj")));
-                    project.Root.Add(propertyGroup);
-                    project.Root.Add(itemGroup);
-                }
-            });
-
-            var resxfileInProject = Path.Combine(testInstance.TestRoot, "blazorwasm", "Resources.ja.resx.txt");
-            File.Move(resxfileInProject, Path.Combine(testInstance.TestRoot, "blazorwasm", "Resource.ja.resx"));
-
             File.WriteAllText(Path.Combine(testInstance.TestRoot, "blazorwasm", "App.razor.css"), "h1 { font-size: 16px; }");
 
             // VS builds projects individually and then a publish with BuildDependencies=false, but building the main project is a close enough approximation for this test.
@@ -630,23 +918,8 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
             publishCommand.Execute("/p:BuildProjectReferences=false /p:BuildInsideVisualStudio=true").Should().Pass();
 
             var publishDirectory = publishCommand.GetOutputDirectory("net5.0");
-            var blazorPublishDirectory = Path.Combine(publishDirectory.ToString(), "wwwroot");
-
             // Make sure the main project exists
             new FileInfo(Path.Combine(publishDirectory.ToString(), "blazorhosted.dll")).Should().Exist();
-
-            // Verification for satelitte assemblies
-            publishDirectory.Should().HaveFiles(new[]
-            {
-                "wwwroot/_framework/blazor.boot.json",
-                "wwwroot/_framework/ja/blazorwasm.resources.dll",
-                "wwwroot/_framework/fr/Microsoft.CodeAnalysis.CSharp.resources.dll"
-            });
-
-            var bootJsonData = new FileInfo(Path.Combine(blazorPublishDirectory, "_framework", "blazor.boot.json"));
-            bootJsonData.Should().Contain("\"es-ES\\/classlibrarywithsatelliteassemblies.resources.dll\"");
-            bootJsonData.Should().Contain("\"ja\\/blazorwasm.resources.dll\"");
-            bootJsonData.Should().Contain("\"fr\\/Microsoft.CodeAnalysis.CSharp.resources.dll\"");
 
             // Verification for https://github.com/dotnet/aspnetcore/issues/19926. Verify binaries for projects
             // referenced by the Hosted project appear in the publish directory
@@ -709,11 +982,62 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
                 "wwwroot/_framework/System.Text.Json.dll.br"
             });
 
+            var blazorPublishDirectory = Path.Combine(publishDirectory.ToString(), "wwwroot");
+
             VerifyBootManifestHashes(testInstance, blazorPublishDirectory);
             VerifyServiceWorkerFiles(testInstance, blazorPublishDirectory,
                 serviceWorkerPath: Path.Combine("serviceworkers", "my-service-worker.js"),
                 serviceWorkerContent: "// This is the production service worker",
                 assetsManifestPath: "custom-service-worker-assets.js");
+        }
+
+        // Regression test to verify satellite assemblies from the blazor app are copied to the published app's wwwroot output directory as
+        // part of publishing in VS
+        [Fact]
+        public void Publish_HostedApp_VisualStudio_WithSatelliteAssemblies()
+        {
+            var testAppName = "BlazorWasmWithLibrary";
+            var testInstance = _testAssetsManager.CopyTestAsset(testAppName).WithSource();
+
+            testInstance.WithProjectChanges((path, project) =>
+            {
+                if (path.Contains("blazorwasm"))
+                {
+                    var ns = project.Root.Name.Namespace;
+                    var propertyGroup = new XElement(ns + "PropertyGroup");
+                    propertyGroup.Add(new XElement("DefineConstants", @"$(DefineConstants);REFERENCE_classlibrarywithsatelliteassemblies"));
+                    var itemGroup = new XElement(ns + "ItemGroup");
+                    itemGroup.Add(new XElement("ProjectReference", new XAttribute("Include", @"..\classlibrarywithsatelliteassemblies\classlibrarywithsatelliteassemblies.csproj")));
+                    project.Root.Add(propertyGroup);
+                    project.Root.Add(itemGroup);
+                }
+            });
+
+            var resxfileInProject = Path.Combine(testInstance.TestRoot, "blazorwasm", "Resources.ja.resx.txt");
+            File.Move(resxfileInProject, Path.Combine(testInstance.TestRoot, "blazorwasm", "Resource.ja.resx"));
+
+            var buildCommand = new BuildCommand(testInstance, "blazorwasm");
+            buildCommand.Execute().Should().Pass();
+
+            var publishCommand = new PublishCommand(Log, Path.Combine(testInstance.TestRoot, "blazorwasm"));
+            publishCommand.Execute("/p:BuildProjectReferences=false").Should().Pass();
+
+            var publishDirectory = publishCommand.GetOutputDirectory("net5.0");
+            var blazorPublishDirectory = Path.Combine(publishDirectory.ToString(), "wwwroot");
+
+            publishDirectory.Should().HaveFiles(new[]
+            {
+                "wwwroot/_framework/blazor.boot.json",
+                "wwwroot/_framework/ja/blazorwasm.resources.dll",
+                "wwwroot/_framework/fr/Microsoft.CodeAnalysis.CSharp.resources.dll"
+            });
+
+            var bootJsonData = new FileInfo(Path.Combine(blazorPublishDirectory, "_framework", "blazor.boot.json"));
+            bootJsonData.Should().Contain("\"es-ES\\/classlibrarywithsatelliteassemblies.resources.dll\"");
+            bootJsonData.Should().Contain("\"ja\\/blazorwasm.resources.dll\"");
+            bootJsonData.Should().Contain("\"fr\\/Microsoft.CodeAnalysis.CSharp.resources.dll\"");
+
+            VerifyBootManifestHashes(testInstance, blazorPublishDirectory);
         }
 
         [Fact]
@@ -726,6 +1050,19 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
 
             var publishCommand = new PublishCommand(Log, Path.Combine(testInstance.TestRoot, "blazorhosted"));
             publishCommand.Execute("/p:RuntimeIdentifier=linux-x64").Should().Pass();
+
+            AssertRIDPublishOuput(publishCommand, testInstance);
+        }
+
+        [Fact]
+        public void Publish_HostedApp_WithRid_Works()
+        {
+            // Arrange
+            var testAppName = "BlazorHostedRID";
+            var testInstance = _testAssetsManager.CopyTestAsset(testAppName).WithSource();
+
+            var publishCommand = new PublishCommand(Log, Path.Combine(testInstance.TestRoot, "blazorhosted"));
+            publishCommand.Execute().Should().Pass();
 
             AssertRIDPublishOuput(publishCommand, testInstance);
         }
@@ -837,11 +1174,69 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
             runtime.Should().NotContainKey("icudt.dat");
             runtime.Should().NotContainKey("icudt_EFIGS.dat");
 
+
             new FileInfo(Path.Combine(publishOutputDirectory, "wwwroot", "_framework", "dotnet.wasm")).Should().Exist();
             new FileInfo(Path.Combine(publishOutputDirectory, "wwwroot", "_framework", "icudt.dat")).Should().NotExist();
             new FileInfo(Path.Combine(publishOutputDirectory, "wwwroot", "_framework", "icudt_CJK.dat")).Should().NotExist();
             new FileInfo(Path.Combine(publishOutputDirectory, "wwwroot", "_framework", "icudt_EFIGS.dat")).Should().NotExist();
             new FileInfo(Path.Combine(publishOutputDirectory, "wwwroot", "_framework", "icudt_no_CJK.dat")).Should().NotExist();
+        }
+
+        [Fact]
+        public void Publish_HostingMultipleBlazorWebApps_Works()
+        {
+            // Regression test for https://github.com/dotnet/aspnetcore/issues/29264
+            // Arrange
+            var testAppName = "BlazorMultiApp";
+            var testInstance = _testAssetsManager.CopyTestAsset(testAppName)
+                            .WithSource();
+
+            var publishCommand = new PublishCommand(Log, Path.Combine(testInstance.TestRoot, "BlazorMultipleApps.Server"));
+            publishCommand.Execute().Should().Pass();
+
+            var publishOutputDirectory = publishCommand.GetOutputDirectory("net5.0").ToString();
+
+            new FileInfo(Path.Combine(publishOutputDirectory, "BlazorMultipleApps.Server.dll")).Should().Exist();
+            new FileInfo(Path.Combine(publishOutputDirectory, "BlazorMultipleApps.FirstClient.dll")).Should().Exist();
+            new FileInfo(Path.Combine(publishOutputDirectory, "BlazorMultipleApps.SecondClient.dll")).Should().Exist();
+
+            var firstAppPublishDirectory = Path.Combine(publishOutputDirectory, "wwwroot", "FirstApp");
+
+            var firstCss = Path.Combine(firstAppPublishDirectory, "css", "app.css");
+            new FileInfo(firstCss).Should().Exist();
+            new FileInfo(firstCss).Should().Exist("/* First app.css */");
+
+            var firstBootJsonPath = Path.Combine(firstAppPublishDirectory, "_framework", "blazor.boot.json");
+            var firstBootJson = ReadBootJsonData(firstBootJsonPath);
+
+            // Do a sanity check that the boot json has files.
+            firstBootJson.resources.assembly.Keys.Should().Contain("System.Text.Json.dll");
+
+            VerifyBootManifestHashes(testInstance, firstAppPublishDirectory);
+
+            // Verify compression works
+            new FileInfo(Path.Combine(firstAppPublishDirectory, "_framework", "dotnet.wasm.br")).Should().Exist();
+            new FileInfo(Path.Combine(firstAppPublishDirectory, "_framework", "BlazorMultipleApps.FirstClient.dll.br")).Should().Exist();
+            new FileInfo(Path.Combine(firstAppPublishDirectory, "_framework", "System.Text.Json.dll.br")).Should().Exist();
+
+            var secondAppPublishDirectory = Path.Combine(publishOutputDirectory, "wwwroot", "SecondApp");
+
+            var secondCss = Path.Combine(secondAppPublishDirectory, "css", "app.css");
+            new FileInfo(secondCss).Should().Exist();
+            new FileInfo(secondCss).Should().Exist("/* Second app.css */");
+
+            var secondBootJsonPath = Path.Combine(secondAppPublishDirectory, "_framework", "blazor.boot.json");
+            var secondBootJson = ReadBootJsonData(secondBootJsonPath);
+
+            // Do a sanity check that the boot json has files.
+            secondBootJson.resources.assembly.Keys.Should().Contain("System.Private.CoreLib.dll");
+
+            VerifyBootManifestHashes(testInstance, secondAppPublishDirectory);
+
+            // Verify compression works
+            new FileInfo(Path.Combine(secondAppPublishDirectory, "_framework", "dotnet.wasm.br")).Should().Exist();
+            new FileInfo(Path.Combine(secondAppPublishDirectory, "_framework", "BlazorMultipleApps.SecondClient.dll.br")).Should().Exist();
+            new FileInfo(Path.Combine(secondAppPublishDirectory, "_framework", "System.Private.CoreLib.dll.br")).Should().Exist();
         }
 
         private static void VerifyBootManifestHashes(TestAsset testAsset, string blazorPublishDirectory)


### PR DESCRIPTION
- Migrate https://github.com/dotnet/aspnetcore/pull/29293 and https://github.com/dotnet/aspnetcore/pull/28714 into Blazor WASM SDK
- Fix ArgumentEscaper in ServerConnection to improve perf
- Remove unneeded `Condition="'$(IsCrossTargetingBuild)' != 'true'"` check in Razor SDK targets
- Bring back all the Blazor WASM tests now that the underlying perf issue is fixed
- Bring in changes from https://github.com/dotnet/aspnetcore/pull/27974