### PR TITLE
Adding workaround for parsing -clp

### DIFF
--- a/src/Cli/dotnet/CommonOptions.cs
+++ b/src/Cli/dotnet/CommonOptions.cs
@@ -59,7 +59,7 @@ namespace Microsoft.DotNet.Cli
             {
                 Argument = new Argument<string>(CommonLocalizableStrings.ConfigurationArgumentName)
                     .AddSuggestions(Suggest.ConfigurationsFromProjectFileOrDefaults().ToArray())
-            }.ForwardAsSingle(o => $"-property:Configuration={o}");
+            }.ForwardAsSingle(o => o.StartsWith("lp:") ? $"-c{o}" : $"-property:Configuration={o}");
 
         public static Option VersionSuffixOption() =>
             new Option<string>(

--- a/src/Tests/dotnet-build.Tests/GivenDotnetBuildBuildsCsproj.cs
+++ b/src/Tests/dotnet-build.Tests/GivenDotnetBuildBuildsCsproj.cs
@@ -11,6 +11,7 @@ using Microsoft.NET.TestFramework;
 using Microsoft.NET.TestFramework.Assertions;
 using Microsoft.NET.TestFramework.Commands;
 using Xunit.Abstractions;
+using System.CommandLine.Parsing;
 
 namespace Microsoft.DotNet.Cli.Build.Tests
 {
@@ -171,6 +172,20 @@ namespace Microsoft.DotNet.Cli.Build.Tests
             {
                 cmd.Should().NotHaveStdOutContaining("Copyright (C) Microsoft Corporation. All rights reserved.");
             }
+        }
+
+        [Fact]
+        public void ItCanParseClpCommandLineOption()
+        {
+            var testInstance = _testAssetsManager.CopyTestAsset("MSBuildTestApp")
+                .WithSource()
+                .Restore(Log);
+
+            new DotnetBuildCommand(Log)
+               .WithWorkingDirectory(testInstance.Path)
+               .Execute("-clp:NoSummary")
+               .Should()
+               .Pass();
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/sdk/issues/15351