### PR TITLE
Resolve target framework for Blazor test assets for SdkTargetFramework

### DIFF
--- a/src/Assets/TestProjects/BlazorHosted/blazorhosted/blazorhosted.csproj
+++ b/src/Assets/TestProjects/BlazorHosted/blazorhosted/blazorhosted.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>$(DefaultBlazorTestTfm)</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Assets/TestProjects/BlazorHosted/blazorwasm/blazorwasm.csproj
+++ b/src/Assets/TestProjects/BlazorHosted/blazorwasm/blazorwasm.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>$(DefaultBlazorTestTfm)</TargetFramework>
     <ServiceWorkerAssetsManifest>custom-service-worker-assets.js</ServiceWorkerAssetsManifest>
   </PropertyGroup>
 

--- a/src/Assets/TestProjects/BlazorHostedRID/blazorhosted/blazorhosted-rid.csproj
+++ b/src/Assets/TestProjects/BlazorHostedRID/blazorhosted/blazorhosted-rid.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>$(DefaultBlazorTestTfm)</TargetFramework>
     <RuntimeIdentifier>linux-x64</RuntimeIdentifier>
   </PropertyGroup>
 

--- a/src/Assets/TestProjects/BlazorHostedRID/blazorwasm/blazorwasm.csproj
+++ b/src/Assets/TestProjects/BlazorHostedRID/blazorwasm/blazorwasm.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>$(DefaultBlazorTestTfm)</TargetFramework>
     <ServiceWorkerAssetsManifest>custom-service-worker-assets.js</ServiceWorkerAssetsManifest>
   </PropertyGroup>
 

--- a/src/Assets/TestProjects/BlazorMultiApp/BlazorMultipleApps.FirstClient/BlazorMultipleApps.FirstClient.csproj
+++ b/src/Assets/TestProjects/BlazorMultiApp/BlazorMultipleApps.FirstClient/BlazorMultipleApps.FirstClient.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>$(DefaultBlazorTestTfm)</TargetFramework>
     <StaticWebAssetBasePath>FirstApp</StaticWebAssetBasePath>
   </PropertyGroup>
 

--- a/src/Assets/TestProjects/BlazorMultiApp/BlazorMultipleApps.SecondClient/BlazorMultipleApps.SecondClient.csproj
+++ b/src/Assets/TestProjects/BlazorMultiApp/BlazorMultipleApps.SecondClient/BlazorMultipleApps.SecondClient.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>$(DefaultBlazorTestTfm)</TargetFramework>
     <StaticWebAssetBasePath>SecondApp</StaticWebAssetBasePath>
   </PropertyGroup>
 

--- a/src/Assets/TestProjects/BlazorMultiApp/BlazorMultipleApps.Server/BlazorMultipleApps.Server.csproj
+++ b/src/Assets/TestProjects/BlazorMultiApp/BlazorMultipleApps.Server/BlazorMultipleApps.Server.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>$(DefaultBlazorTestTfm)</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Assets/TestProjects/BlazorWasmMinimal/blazorwasm-minimal.csproj
+++ b/src/Assets/TestProjects/BlazorWasmMinimal/blazorwasm-minimal.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>$(DefaultBlazorTestTfm)</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Assets/TestProjects/BlazorWasmWithLibrary/blazorwasm/blazorwasm.csproj
+++ b/src/Assets/TestProjects/BlazorWasmWithLibrary/blazorwasm/blazorwasm.csproj
@@ -1,14 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>$(DefaultBlazorTestTfm)</TargetFramework>
     <ServiceWorkerAssetsManifest>custom-service-worker-assets.js</ServiceWorkerAssetsManifest>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="5.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="5.0.0" PrivateAssets="all" />
-    <PackageReference Include="System.Net.Http.Json" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Tests/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/BlazorWasmSdkTest.cs
+++ b/src/Tests/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/BlazorWasmSdkTest.cs
@@ -1,0 +1,44 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Xml.Linq;
+using Microsoft.NET.TestFramework;
+using Xunit.Abstractions;
+
+namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
+{
+    public abstract class BlazorWasmSdkTest : SdkTest
+    {
+        private static readonly IEnumerable<System.Reflection.AssemblyMetadataAttribute> TestAssemblyMetadata = Assembly.GetExecutingAssembly().GetCustomAttributes<AssemblyMetadataAttribute>();
+        public readonly string DefaultTfm = TestAssemblyMetadata.SingleOrDefault(a => a.Key == "DefaultBlazorTestTfm").Value;
+
+        protected BlazorWasmSdkTest(ITestOutputHelper log) : base(log) {}
+
+        public TestAsset CreateBlazorWasmSdkTestAsset(
+            string testAsset,
+            [CallerMemberName] string callerName = "",
+            string subdirectory = "",
+            string overrideTfm = null) 
+        {
+            var projectDirectory = _testAssetsManager
+                .CopyTestAsset(testAsset, callingMethod: callerName, testAssetSubdirectory: subdirectory)
+                .WithSource()
+                .WithProjectChanges(project => 
+                {
+                    var ns = project.Root.Name.Namespace;
+                    var targetFramework = project.Descendants()
+                       .Single(e => e.Name.LocalName == "TargetFramework");
+                    if (targetFramework.Value == "$(DefaultBlazorTestTfm)")
+                    {
+                        targetFramework.Value = overrideTfm ?? DefaultTfm;
+                    }
+                });
+            return projectDirectory;
+        }
+    }
+}

--- a/src/Tests/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/Microsoft.NET.Sdk.BlazorWebAssembly.Tests.csproj
+++ b/src/Tests/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/Microsoft.NET.Sdk.BlazorWebAssembly.Tests.csproj
@@ -16,6 +16,14 @@
   <ItemGroup>
     <Compile Include="**\*.cs" Exclude="$(GlobalExclude)" />
   </ItemGroup>
+
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute">
+      <_Parameter1>DefaultBlazorTestTfm</_Parameter1>
+      <_Parameter2>$(SdkTargetFramework)</_Parameter2>
+    </AssemblyAttribute>
+  </ItemGroup>
+  
   
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />

--- a/src/Tests/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/WasmBuildIncrementalismTest.cs
+++ b/src/Tests/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/WasmBuildIncrementalismTest.cs
@@ -16,7 +16,7 @@ using Xunit.Abstractions;
 
 namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
 {
-    public class WasmBuildIncrementalismTest : SdkTest
+    public class WasmBuildIncrementalismTest : BlazorWasmSdkTest
     {
         public WasmBuildIncrementalismTest(ITestOutputHelper log) : base(log) {}
 
@@ -25,16 +25,14 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
         {
             // Arrange
             var testAsset = "BlazorWasmWithLibrary";
-            var projectDirectory = _testAssetsManager
-                .CopyTestAsset(testAsset)
-                .WithSource();
+            var projectDirectory = CreateBlazorWasmSdkTestAsset(testAsset);
 
             var build = new BuildCommand(projectDirectory, "blazorwasm");
             build.Execute()
                 .Should()
                 .Pass();
 
-            var buildOutputDirectory = build.GetOutputDirectory("net5.0").ToString();
+            var buildOutputDirectory = build.GetOutputDirectory(DefaultTfm).ToString();
 
             // Act
             var thumbPrint = FileThumbPrint.CreateFolderThumbprint(projectDirectory, buildOutputDirectory);
@@ -59,16 +57,14 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
         {
             // Arrange
             var testAsset = "BlazorWasmWithLibrary";
-            var projectDirectory = _testAssetsManager
-                .CopyTestAsset(testAsset)
-                .WithSource();
+            var projectDirectory = CreateBlazorWasmSdkTestAsset(testAsset);
 
             var build = new BuildCommand(projectDirectory, "blazorwasm");
             build.Execute()
                 .Should()
                 .Pass();
 
-            var gzipCompressionDirectory = Path.Combine(projectDirectory.TestRoot, "blazorwasm", "obj", "Debug", "net5.0", "build-gz");
+            var gzipCompressionDirectory = Path.Combine(projectDirectory.TestRoot, "blazorwasm", "obj", "Debug", DefaultTfm, "build-gz");
             new DirectoryInfo(gzipCompressionDirectory).Should().Exist();
 
             // Act
@@ -96,9 +92,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
         {
             // Arrange
             var testAsset = "BlazorWasmWithLibrary";
-            var projectDirectory = _testAssetsManager
-                .CopyTestAsset(testAsset)
-                .WithSource();
+            var projectDirectory = CreateBlazorWasmSdkTestAsset(testAsset);
             File.Move(Path.Combine(projectDirectory.TestRoot, "blazorwasm", "Resources.ja.resx.txt"), Path.Combine(projectDirectory.TestRoot, "blazorwasm", "Resource.ja.resx"));
             
             var build = new BuildCommand(projectDirectory, "blazorwasm");
@@ -106,9 +100,9 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
                 .Should()
                 .Pass();
 
-            var satelliteAssemblyCacheFile = Path.Combine(projectDirectory.TestRoot, "blazorwasm", "obj", "Debug", "net5.0", "blazor.satelliteasm.props");
-            var satelliteAssemblyFile = Path.Combine(build.GetOutputDirectory("net5.0").ToString(), "wwwroot", "_framework", "ja", "blazorwasm.resources.dll");
-            var bootJson = Path.Combine(build.GetOutputDirectory("net5.0").ToString(), "wwwroot", "_framework", "blazor.boot.json");
+            var satelliteAssemblyCacheFile = Path.Combine(projectDirectory.TestRoot, "blazorwasm", "obj", "Debug", DefaultTfm, "blazor.satelliteasm.props");
+            var satelliteAssemblyFile = Path.Combine(build.GetOutputDirectory(DefaultTfm).ToString(), "wwwroot", "_framework", "ja", "blazorwasm.resources.dll");
+            var bootJson = Path.Combine(build.GetOutputDirectory(DefaultTfm).ToString(), "wwwroot", "_framework", "blazor.boot.json");
 
             // Assert
             for (var i = 0; i < 3; i++)
@@ -155,18 +149,16 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
         {
             // Arrange
             var testAsset = "BlazorWasmWithLibrary";
-            var projectDirectory = _testAssetsManager
-                .CopyTestAsset(testAsset)
-                .WithSource();
+            var projectDirectory = CreateBlazorWasmSdkTestAsset(testAsset);
             
             var build = new BuildCommand(projectDirectory, "blazorwasm");
             build.Execute()
                 .Should()
                 .Pass();
 
-            var satelliteAssemblyCacheFile = Path.Combine(projectDirectory.TestRoot, "blazorwasm", "obj", "Debug", "net5.0", "blazor.satelliteasm.props");
-            var satelliteAssemblyFile = Path.Combine(build.GetOutputDirectory("net5.0").ToString(), "wwwroot", "_framework", "ja", "blazorwasm.resources.dll");
-            var bootJson = Path.Combine(build.GetOutputDirectory("net5.0").ToString(), "wwwroot", "_framework", "blazor.boot.json");
+            var satelliteAssemblyCacheFile = Path.Combine(projectDirectory.TestRoot, "blazorwasm", "obj", "Debug", DefaultTfm, "blazor.satelliteasm.props");
+            var satelliteAssemblyFile = Path.Combine(build.GetOutputDirectory(DefaultTfm).ToString(), "wwwroot", "_framework", "ja", "blazorwasm.resources.dll");
+            var bootJson = Path.Combine(build.GetOutputDirectory(DefaultTfm).ToString(), "wwwroot", "_framework", "blazor.boot.json");
 
             build = new BuildCommand(projectDirectory, "blazorwasm");
             build.Execute()
@@ -203,9 +195,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
         {
             // Arrange
             var testAsset = "BlazorWasmWithLibrary";
-            var projectDirectory = _testAssetsManager
-                .CopyTestAsset(testAsset)
-                .WithSource();
+            var projectDirectory = CreateBlazorWasmSdkTestAsset(testAsset);
             File.Move(Path.Combine(projectDirectory.TestRoot, "blazorwasm", "Resources.ja.resx.txt"), Path.Combine(projectDirectory.TestRoot, "blazorwasm", "Resource.ja.resx"));
             
             var build = new BuildCommand(projectDirectory, "blazorwasm");
@@ -213,9 +203,9 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
                 .Should()
                 .Pass();
 
-            var satelliteAssemblyCacheFile = Path.Combine(projectDirectory.TestRoot, "blazorwasm", "obj", "Debug", "net5.0", "blazor.satelliteasm.props");
-            var satelliteAssemblyFile = Path.Combine(build.GetOutputDirectory("net5.0").ToString(), "wwwroot", "_framework", "ja", "blazorwasm.resources.dll");
-            var bootJson = Path.Combine(build.GetOutputDirectory("net5.0").ToString(), "wwwroot", "_framework", "blazor.boot.json");
+            var satelliteAssemblyCacheFile = Path.Combine(projectDirectory.TestRoot, "blazorwasm", "obj", "Debug", DefaultTfm, "blazor.satelliteasm.props");
+            var satelliteAssemblyFile = Path.Combine(build.GetOutputDirectory(DefaultTfm).ToString(), "wwwroot", "_framework", "ja", "blazorwasm.resources.dll");
+            var bootJson = Path.Combine(build.GetOutputDirectory(DefaultTfm).ToString(), "wwwroot", "_framework", "blazor.boot.json");
             
             build = new BuildCommand(projectDirectory, "blazorwasm");
             build.Execute()

--- a/src/Tests/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/WasmBuildIntegrationTest.cs
+++ b/src/Tests/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/WasmBuildIntegrationTest.cs
@@ -16,7 +16,7 @@ using Xunit.Abstractions;
 
 namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
 {
-    public class WasmBuildIntegrationTest : SdkTest
+    public class WasmBuildIntegrationTest : BlazorWasmSdkTest
     {
         public WasmBuildIntegrationTest(ITestOutputHelper log) : base(log) {}
 
@@ -26,9 +26,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
             // Arrange
             // Minimal has no project references, service worker etc. This is pretty close to the project template.
             var testAsset = "BlazorWasmMinimal";
-            var testInstance = _testAssetsManager
-                .CopyTestAsset(testAsset)
-                .WithSource();
+            var testInstance = CreateBlazorWasmSdkTestAsset(testAsset);
             File.WriteAllText(Path.Combine(testInstance.TestRoot, "App.razor.css"), "h1 { font-size: 16px; }");
 
             var build = new BuildCommand(testInstance);
@@ -36,7 +34,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
                 .Should()
                 .Pass();
 
-            var buildOutputDirectory = build.GetOutputDirectory("net5.0").ToString();
+            var buildOutputDirectory = build.GetOutputDirectory(DefaultTfm).ToString();
 
             new FileInfo(Path.Combine(buildOutputDirectory, "wwwroot", "_framework", "blazor.boot.json")).Should().Exist();
             new FileInfo(Path.Combine(buildOutputDirectory, "wwwroot", "_framework", "blazor.webassembly.js")).Should().Exist();
@@ -47,8 +45,8 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
 
             var staticWebAssets = new FileInfo(Path.Combine(buildOutputDirectory, "blazorwasm-minimal.StaticWebAssets.xml"));
             staticWebAssets.Should().Exist();
-            staticWebAssets.Should().Contain(Path.Combine("net5.0", "wwwroot"));
-            staticWebAssets.Should().Contain(Path.Combine("net5.0", "scopedcss"));
+            staticWebAssets.Should().Contain(Path.Combine(DefaultTfm, "wwwroot"));
+            staticWebAssets.Should().Contain(Path.Combine(DefaultTfm, "scopedcss"));
         }
 
         [Fact]
@@ -56,14 +54,13 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
         {
             // Arrange
             var testAppName = "BlazorWasmWithLibrary";
-            var testInstance = _testAssetsManager.CopyTestAsset(testAppName)
-                            .WithSource();
+            var testInstance = CreateBlazorWasmSdkTestAsset(testAppName);
 
             var buildCommand = new BuildCommand(testInstance, "blazorwasm");
             buildCommand.Execute()
                 .Should().Pass();
 
-            var buildOutputDirectory = buildCommand.GetOutputDirectory("net5.0").ToString();
+            var buildOutputDirectory = buildCommand.GetOutputDirectory(DefaultTfm).ToString();
 
             new FileInfo(Path.Combine(buildOutputDirectory, "wwwroot", "_framework", "blazor.boot.json")).Should().Exist();
             new FileInfo(Path.Combine(buildOutputDirectory, "wwwroot", "_framework", "blazor.webassembly.js")).Should().Exist();
@@ -81,7 +78,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
 
             var staticWebAssets = new FileInfo(Path.Combine(buildOutputDirectory, "blazorwasm.StaticWebAssets.xml"));
             staticWebAssets.Should().Exist();
-            staticWebAssets.Should().Contain(Path.Combine("net5.0", "wwwroot"));
+            staticWebAssets.Should().Contain(Path.Combine(DefaultTfm, "wwwroot"));
             staticWebAssets.Should().Contain(Path.Combine(testInstance.TestRoot, "razorclasslibrary", "wwwroot"));
         }
 
@@ -90,14 +87,13 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
         {
             // Arrange
             var testAppName = "BlazorWasmWithLibrary";
-            var testInstance = _testAssetsManager.CopyTestAsset(testAppName)
-                            .WithSource();
+            var testInstance = CreateBlazorWasmSdkTestAsset(testAppName);
 
             var buildCommand = new BuildCommand(testInstance, "blazorwasm");
             buildCommand.Execute("/p:Configuration=Release")
                 .Should().Pass();
 
-            var buildOutputDirectory = buildCommand.GetOutputDirectory("net5.0", "Release").ToString();
+            var buildOutputDirectory = buildCommand.GetOutputDirectory(DefaultTfm, "Release").ToString();
 
             new FileInfo(Path.Combine(buildOutputDirectory, "wwwroot", "_framework", "blazor.boot.json")).Should().Exist();
             new FileInfo(Path.Combine(buildOutputDirectory, "wwwroot", "_framework", "blazor.webassembly.js")).Should().Exist();
@@ -115,7 +111,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
 
             var staticWebAssets = new FileInfo(Path.Combine(buildOutputDirectory, "blazorwasm.StaticWebAssets.xml"));
             staticWebAssets.Should().Exist();
-            staticWebAssets.Should().Contain(Path.Combine("net5.0", "wwwroot"));
+            staticWebAssets.Should().Contain(Path.Combine(DefaultTfm, "wwwroot"));
             staticWebAssets.Should().Contain(Path.Combine(testInstance.TestRoot, "razorclasslibrary", "wwwroot"));
         }
 
@@ -124,8 +120,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
         {
             // Arrange
             var testAppName = "BlazorWasmWithLibrary";
-            var testInstance = _testAssetsManager.CopyTestAsset(testAppName)
-                            .WithSource();
+            var testInstance = CreateBlazorWasmSdkTestAsset(testAppName);
 
             var wwwroot = Path.Combine(testInstance.TestRoot, "blazorwasm", "wwwroot");
             File.WriteAllText(Path.Combine(wwwroot, "appsettings.json"), "Default settings");
@@ -135,7 +130,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
             buildCommand.Execute()
                 .Should().Pass();
 
-            var buildOutputDirectory = buildCommand.GetOutputDirectory("net5.0").ToString();
+            var buildOutputDirectory = buildCommand.GetOutputDirectory(DefaultTfm).ToString();
 
             var bootJsonPath = Path.Combine(buildOutputDirectory, "wwwroot", "_framework", "blazor.boot.json");
             var bootJsonData = ReadBootJsonData(bootJsonPath);
@@ -163,8 +158,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
         {
             // Arrange
             var testAppName = "BlazorWasmWithLibrary";
-            var testInstance = _testAssetsManager.CopyTestAsset(testAppName)
-                            .WithSource();
+            var testInstance = CreateBlazorWasmSdkTestAsset(testAppName);
 
             var wwwroot = Path.Combine(testInstance.TestRoot, "blazorwasm", "wwwroot");
             File.WriteAllText(Path.Combine(wwwroot, "appsettings.json"), "Default settings");
@@ -174,7 +168,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
             buildCommand.Execute("/p:Configuration=Release")
                 .Should().Pass();
 
-            var buildOutputDirectory = buildCommand.GetOutputDirectory("net5.0", "Release").ToString();
+            var buildOutputDirectory = buildCommand.GetOutputDirectory(DefaultTfm, "Release").ToString();
 
             var bootJsonPath = Path.Combine(buildOutputDirectory, "wwwroot", "_framework", "blazor.boot.json");
             var bootJsonData = ReadBootJsonData(bootJsonPath);
@@ -199,8 +193,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
         {
             // Arrange
             var testAppName = "BlazorWasmWithLibrary";
-            var testInstance = _testAssetsManager.CopyTestAsset(testAppName)
-                            .WithSource();
+            var testInstance = CreateBlazorWasmSdkTestAsset(testAppName);
 
             testInstance.WithProjectChanges((project) =>
             {
@@ -215,7 +208,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
             buildCommand.Execute()
                 .Should().Pass();
 
-            var buildOutputDirectory = buildCommand.GetOutputDirectory("net5.0").ToString();
+            var buildOutputDirectory = buildCommand.GetOutputDirectory(DefaultTfm).ToString();
 
             var bootJsonPath = Path.Combine(buildOutputDirectory, "wwwroot", "_framework", "blazor.boot.json");
             var bootJsonData = ReadBootJsonData(bootJsonPath);
@@ -233,8 +226,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
         {
             // Arrange
             var testAppName = "BlazorWasmMinimal";
-            var testInstance = _testAssetsManager.CopyTestAsset(testAppName)
-                            .WithSource();
+            var testInstance = CreateBlazorWasmSdkTestAsset(testAppName);
 
             testInstance.WithProjectChanges((project) =>
             {
@@ -248,7 +240,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
             buildCommand.Execute()
                 .Should().Pass();
 
-            var buildOutputDirectory = buildCommand.GetOutputDirectory("net5.0").ToString();
+            var buildOutputDirectory = buildCommand.GetOutputDirectory(DefaultTfm).ToString();
 
             var bootJsonPath = Path.Combine(buildOutputDirectory, "wwwroot", "_framework", "blazor.boot.json");
             var bootJsonData = ReadBootJsonData(bootJsonPath);
@@ -273,8 +265,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
         {
             // Arrange
             var testAppName = "BlazorWasmMinimal";
-            var testInstance = _testAssetsManager.CopyTestAsset(testAppName)
-                            .WithSource();
+            var testInstance = CreateBlazorWasmSdkTestAsset(testAppName);
 
             testInstance.WithProjectChanges((project) =>
             {
@@ -288,7 +279,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
             buildCommand.Execute()
                 .Should().Pass();
 
-            var buildOutputDirectory = buildCommand.GetOutputDirectory("net5.0").ToString();
+            var buildOutputDirectory = buildCommand.GetOutputDirectory(DefaultTfm).ToString();
 
             var bootJsonPath = Path.Combine(buildOutputDirectory, "wwwroot", "_framework", "blazor.boot.json");
             var bootJsonData = ReadBootJsonData(bootJsonPath);
@@ -313,19 +304,18 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
         {
             // Arrange
             var testAppName = "BlazorHosted";
-            var testInstance = _testAssetsManager.CopyTestAsset(testAppName)
-                            .WithSource();
+            var testInstance = CreateBlazorWasmSdkTestAsset(testAppName);
             
             var buildCommand = new BuildCommand(testInstance, "blazorhosted");
             buildCommand.Execute().Should().Pass();
 
-            var buildOutputDirectory = buildCommand.GetOutputDirectory("net5.0").ToString();
+            var buildOutputDirectory = buildCommand.GetOutputDirectory(DefaultTfm).ToString();
 
             new FileInfo(Path.Combine(buildOutputDirectory, "wwwroot", "_framework", "_bin", "blazorwasm.dll")).Should().NotExist();
 
             var staticWebAssets = new FileInfo(Path.Combine(buildOutputDirectory, "blazorhosted.StaticWebAssets.xml"));
             staticWebAssets.Should().Exist();
-            staticWebAssets.Should().Contain(Path.Combine("net5.0", "wwwroot"));
+            staticWebAssets.Should().Contain(Path.Combine(DefaultTfm, "wwwroot"));
             staticWebAssets.Should().Contain(Path.Combine("razorclasslibrary", "wwwroot"));
             staticWebAssets.Should().Contain(Path.Combine("blazorwasm", "wwwroot"));
         }
@@ -335,7 +325,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
         {
             // Arrange
             var testAppName = "BlazorWasmWithLibrary";
-            var testInstance = _testAssetsManager.CopyTestAsset(testAppName).WithSource();
+            var testInstance = CreateBlazorWasmSdkTestAsset(testAppName);
 
             testInstance.WithProjectChanges((path, project) =>
             {
@@ -356,7 +346,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
             var buildCommand = new BuildCommand(testInstance, "blazorwasm");
             buildCommand.Execute().Should().Pass();
 
-            var buildOutputDirectory = buildCommand.GetOutputDirectory("net5.0").ToString();
+            var buildOutputDirectory = buildCommand.GetOutputDirectory(DefaultTfm).ToString();
 
             new FileInfo(Path.Combine(buildOutputDirectory, "wwwroot", "_framework", "blazorwasm.dll")).Should().Exist();
             new FileInfo(Path.Combine(buildOutputDirectory, "wwwroot", "_framework", "classlibrarywithsatelliteassemblies.dll")).Should().Exist();
@@ -372,8 +362,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
         public void Build_WithCustomOutputPath_Works()
         {
             var testAppName = "BlazorWasmWithLibrary";
-            var testInstance = _testAssetsManager.CopyTestAsset(testAppName)
-                            .WithSource();
+            var testInstance = CreateBlazorWasmSdkTestAsset(testAppName);
 
             testInstance.WithProjectChanges((path, project) =>
             {

--- a/src/Tests/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/WasmBuildLazyLoadTest.cs
+++ b/src/Tests/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/WasmBuildLazyLoadTest.cs
@@ -17,7 +17,7 @@ using Xunit.Abstractions;
 
 namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
 {
-    public class WasmBuildLazyLoadTest : SdkTest
+    public class WasmBuildLazyLoadTest : BlazorWasmSdkTest
     {
         public WasmBuildLazyLoadTest(ITestOutputHelper log) : base(log) {}
 
@@ -26,8 +26,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
         {
             // Arrange
             var testAppName = "BlazorWasmWithLibrary";
-            var testInstance = _testAssetsManager.CopyTestAsset(testAppName)
-                            .WithSource();
+            var testInstance = CreateBlazorWasmSdkTestAsset(testAppName);
 
             testInstance.WithProjectChanges((project) =>
             {
@@ -43,7 +42,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
             buildCommand.Execute()
                 .Should().Pass();
 
-            var outputDirectory = buildCommand.GetOutputDirectory("net5.0");
+            var outputDirectory = buildCommand.GetOutputDirectory(DefaultTfm);
 
             // Assert
             var expectedFiles = new[]
@@ -75,8 +74,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
         {
             // Arrange
             var testAppName = "BlazorWasmWithLibrary";
-            var testInstance = _testAssetsManager.CopyTestAsset(testAppName)
-                            .WithSource();
+            var testInstance = CreateBlazorWasmSdkTestAsset(testAppName);
 
             testInstance.WithProjectChanges((project) =>
             {
@@ -92,7 +90,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
             buildCommand.Execute("/p:Configuration=Release")
                 .Should().Pass();
 
-            var outputDirectory = buildCommand.GetOutputDirectory("net5.0", "Release");
+            var outputDirectory = buildCommand.GetOutputDirectory(DefaultTfm, "Release");
 
             // Assert
             var expectedFiles = new[]
@@ -124,8 +122,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
         {
             // Arrange
             var testAppName = "BlazorWasmWithLibrary";
-            var testInstance = _testAssetsManager.CopyTestAsset(testAppName)
-                            .WithSource();
+            var testInstance = CreateBlazorWasmSdkTestAsset(testAppName);
 
             testInstance.WithProjectChanges((project) =>
             {
@@ -141,7 +138,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
             publishCommand.Execute()
                 .Should().Pass();
 
-            var outputDirectory = publishCommand.GetOutputDirectory("net5.0");
+            var outputDirectory = publishCommand.GetOutputDirectory(DefaultTfm);
 
             // Assert
             var expectedFiles = new[]
@@ -173,8 +170,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
         {
             // Arrange
             var testAppName = "BlazorWasmWithLibrary";
-            var testInstance = _testAssetsManager.CopyTestAsset(testAppName)
-                            .WithSource();
+            var testInstance = CreateBlazorWasmSdkTestAsset(testAppName);
 
             testInstance.WithProjectChanges((project) =>
             {
@@ -190,7 +186,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
             publishCommand.Execute("/p:Configuration=Release")
                 .Should().Pass();
 
-            var outputDirectory = publishCommand.GetOutputDirectory("net5.0", "Release");
+            var outputDirectory = publishCommand.GetOutputDirectory(DefaultTfm, "Release");
 
             // Assert
             var expectedFiles = new[]
@@ -222,8 +218,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
         {
             // Arrange
             var testAppName = "BlazorWasmWithLibrary";
-            var testInstance = _testAssetsManager.CopyTestAsset(testAppName)
-                            .WithSource();
+            var testInstance = CreateBlazorWasmSdkTestAsset(testAppName);
 
             testInstance.WithProjectChanges((project) =>
             {
@@ -244,8 +239,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
         {
             // Arrange
             var testAppName = "BlazorWasmWithLibrary";
-            var testInstance = _testAssetsManager.CopyTestAsset(testAppName)
-                            .WithSource();
+            var testInstance = CreateBlazorWasmSdkTestAsset(testAppName);
 
             testInstance.WithProjectChanges((project) =>
             {

--- a/src/Tests/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/WasmCompressionTests.cs
+++ b/src/Tests/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/WasmCompressionTests.cs
@@ -12,7 +12,7 @@ using Xunit.Abstractions;
 
 namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
 {
-    public class WasmCompressionTests : SdkTest
+    public class WasmCompressionTests : BlazorWasmSdkTest
     {
         public WasmCompressionTests(ITestOutputHelper log) : base(log) {}
 
@@ -21,21 +21,20 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
         {
             // Arrange
             var testAppName = "BlazorHosted";
-            var testInstance = _testAssetsManager.CopyTestAsset(testAppName)
-                            .WithSource();
+            var testInstance = CreateBlazorWasmSdkTestAsset(testAppName);
             
             var publishCommand = new PublishCommand(Log, Path.Combine(testInstance.TestRoot, "blazorhosted"));
             publishCommand.Execute().Should().Pass();
 
             // Act
-            var mainAppDll = Path.Combine(testInstance.TestRoot, "blazorhosted", "bin", "Debug", "net5.0", "publish", "wwwroot", "_framework", "blazorwasm.dll");
+            var mainAppDll = Path.Combine(testInstance.TestRoot, "blazorhosted", "bin", "Debug", DefaultTfm, "publish", "wwwroot", "_framework", "blazorwasm.dll");
             var mainAppDllThumbPrint = FileThumbPrint.Create(mainAppDll);
-            var mainAppCompressedDll = Path.Combine(testInstance.TestRoot, "blazorhosted", "bin", "Debug", "net5.0", "publish", "wwwroot", "_framework", "blazorwasm.dll.br");
+            var mainAppCompressedDll = Path.Combine(testInstance.TestRoot, "blazorhosted", "bin", "Debug", DefaultTfm, "publish", "wwwroot", "_framework", "blazorwasm.dll.br");
             var mainAppCompressedDllThumbPrint = FileThumbPrint.Create(mainAppCompressedDll);
 
-            var blazorBootJson = Path.Combine(testInstance.TestRoot, publishCommand.GetOutputDirectory("net5.0").ToString(), "wwwroot", "_framework", "blazor.boot.json");
+            var blazorBootJson = Path.Combine(testInstance.TestRoot, publishCommand.GetOutputDirectory(DefaultTfm).ToString(), "wwwroot", "_framework", "blazor.boot.json");
             var blazorBootJsonThumbPrint = FileThumbPrint.Create(blazorBootJson);
-            var blazorBootJsonCompressed = Path.Combine(testInstance.TestRoot, publishCommand.GetOutputDirectory("net5.0").ToString(), "wwwroot", "_framework", "blazor.boot.json.br");
+            var blazorBootJsonCompressed = Path.Combine(testInstance.TestRoot, publishCommand.GetOutputDirectory(DefaultTfm).ToString(), "wwwroot", "_framework", "blazor.boot.json.br");
             var blazorBootJsonCompressedThumbPrint = FileThumbPrint.Create(blazorBootJsonCompressed);
 
             var programFile = Path.Combine(testInstance.TestRoot, "blazorwasm", "Program.cs");
@@ -63,18 +62,17 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
         {
             // Arrange
             var testAppName = "BlazorHosted";
-            var testInstance = _testAssetsManager.CopyTestAsset(testAppName)
-                            .WithSource();
+            var testInstance = CreateBlazorWasmSdkTestAsset(testAppName);
             
             var publishCommand = new PublishCommand(Log, Path.Combine(testInstance.TestRoot, "blazorhosted"));
             publishCommand.Execute("/p:BlazorWebAssemblyEnableLinking=false").Should().Pass();
 
             // Act
-            var buildOutputDirectory = publishCommand.GetOutputDirectory("net5.0").ToString();
-            var mainAppDll = Path.Combine(testInstance.TestRoot, "blazorhosted", "bin", "Debug", "net5.0", "publish", "wwwroot", "_framework", "blazorwasm.dll");
+            var buildOutputDirectory = publishCommand.GetOutputDirectory(DefaultTfm).ToString();
+            var mainAppDll = Path.Combine(testInstance.TestRoot, "blazorhosted", "bin", "Debug", DefaultTfm, "publish", "wwwroot", "_framework", "blazorwasm.dll");
             var mainAppDllThumbPrint = FileThumbPrint.Create(mainAppDll);
 
-            var mainAppCompressedDll = Path.Combine(testInstance.TestRoot, "blazorhosted", "bin", "Debug", "net5.0", "publish", "wwwroot", "_framework", "blazorwasm.dll.br");
+            var mainAppCompressedDll = Path.Combine(testInstance.TestRoot, "blazorhosted", "bin", "Debug", DefaultTfm, "publish", "wwwroot", "_framework", "blazorwasm.dll.br");
             var mainAppCompressedDllThumbPrint = FileThumbPrint.Create(mainAppCompressedDll);
 
             var programFile = Path.Combine(testInstance.TestRoot, "blazorwasm", "Program.cs");
@@ -97,16 +95,15 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
         {
             // Arrange
             var testAppName = "BlazorHosted";
-            var testInstance = _testAssetsManager.CopyTestAsset(testAppName)
-                            .WithSource();
+            var testInstance = CreateBlazorWasmSdkTestAsset(testAppName);
             
             var publishCommand = new PublishCommand(Log, Path.Combine(testInstance.TestRoot, "blazorhosted"));
             publishCommand.Execute().Should().Pass();
 
-            var buildOutputDirectory = publishCommand.GetOutputDirectory("net5.0");
+            var buildOutputDirectory = publishCommand.GetOutputDirectory(DefaultTfm);
 
             // Act
-            var compressedFilesFolder = Path.Combine(testInstance.TestRoot, "blazorwasm", "obj", "Debug", "net5.0", "compress");
+            var compressedFilesFolder = Path.Combine(testInstance.TestRoot, "blazorwasm", "obj", "Debug", DefaultTfm, "compress");
             var thumbPrint = FileThumbPrint.CreateFolderThumbprint(testInstance, compressedFilesFolder);
 
             // Assert
@@ -129,17 +126,16 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
         {
             // Arrange
             var testAppName = "BlazorHosted";
-            var testInstance = _testAssetsManager.CopyTestAsset(testAppName)
-                            .WithSource();
+            var testInstance = CreateBlazorWasmSdkTestAsset(testAppName);
 
             var publishCommand = new PublishCommand(Log, Path.Combine(testInstance.TestRoot, "blazorhosted"));
             publishCommand.Execute("/p:BlazorWebAssemblyEnableLinking=false")
                 .Should().Pass();
 
-            var buildOutputDirectory = publishCommand.GetOutputDirectory("net5.0");
+            var buildOutputDirectory = publishCommand.GetOutputDirectory(DefaultTfm);
 
             // Act
-            var compressedFilesFolder = Path.Combine(testInstance.TestRoot, "blazorwasm", "obj", "Debug", "net5.0", "compress");
+            var compressedFilesFolder = Path.Combine(testInstance.TestRoot, "blazorwasm", "obj", "Debug", DefaultTfm, "compress");
             var thumbPrint = FileThumbPrint.CreateFolderThumbprint(testInstance, compressedFilesFolder);
 
             // Assert
@@ -162,8 +158,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
         {
             // Arrange
             var testAppName = "BlazorWasmWithLibrary";
-            var testInstance = _testAssetsManager.CopyTestAsset(testAppName)
-                            .WithSource();
+            var testInstance = CreateBlazorWasmSdkTestAsset(testAppName);
             
             var publishCommand = new PublishCommand(Log, Path.Combine(testInstance.TestRoot, "blazorwasm"));
             publishCommand.Execute().Should().Pass();
@@ -171,7 +166,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
             var extensions = new[] { ".dll", ".js", ".pdb", ".wasm", ".map", ".json", ".dat" };
 
             // Act
-            var publishOutputDirectory = publishCommand.GetOutputDirectory("net5.0").ToString();
+            var publishOutputDirectory = publishCommand.GetOutputDirectory(DefaultTfm).ToString();
             var frameworkFilesPath = Path.Combine(Path.Combine(testInstance.TestRoot, "blazorwasm"), publishOutputDirectory, "wwwroot", "_framework");
 
             // Assert

--- a/src/Tests/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/WasmPublishTest.cs
+++ b/src/Tests/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/WasmPublishTest.cs
@@ -22,7 +22,7 @@ using ResourceHashesByNameDictionary = System.Collections.Generic.Dictionary<str
 
 namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
 {
-    public class WasmPublishIntegrationTest : SdkTest
+    public class WasmPublishIntegrationTest : BlazorWasmSdkTest
     {
         public WasmPublishIntegrationTest(ITestOutputHelper log) : base(log) { }
 
@@ -31,13 +31,12 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
         {
             // Arrange
             var testAppName = "BlazorWasmMinimal";
-            var testInstance = _testAssetsManager.CopyTestAsset(testAppName)
-                            .WithSource();
+            var testInstance = CreateBlazorWasmSdkTestAsset(testAppName);
 
             var publishCommand = new PublishCommand(Log, testInstance.TestRoot);
             publishCommand.Execute().Should().Pass();
 
-            var publishDirectory = publishCommand.GetOutputDirectory("net5.0");
+            var publishDirectory = publishCommand.GetOutputDirectory(DefaultTfm);
 
             var expectedFiles = new[]
             {
@@ -63,13 +62,12 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
         {
             // Arrange
             var testAppName = "BlazorWasmWithLibrary";
-            var testInstance = _testAssetsManager.CopyTestAsset(testAppName)
-                            .WithSource();
+            var testInstance = CreateBlazorWasmSdkTestAsset(testAppName);
 
             var publishCommand = new PublishCommand(Log, Path.Combine(testInstance.TestRoot, "blazorwasm"));
             publishCommand.Execute().Should().Pass();
 
-            var publishDirectory = publishCommand.GetOutputDirectory("net5.0");
+            var publishDirectory = publishCommand.GetOutputDirectory(DefaultTfm);
 
             var expectedFiles = new[]
             {
@@ -109,14 +107,13 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
         {
             // Arrange
             var testAppName = "BlazorWasmWithLibrary";
-            var testInstance = _testAssetsManager.CopyTestAsset(testAppName)
-                            .WithSource();
+            var testInstance = CreateBlazorWasmSdkTestAsset(testAppName);
             File.WriteAllText(Path.Combine(testInstance.TestRoot, "blazorwasm", "App.razor.css"), "h1 { font-size: 16px; }");
 
             var publishCommand = new PublishCommand(Log, Path.Combine(testInstance.TestRoot, "blazorwasm"));
             publishCommand.Execute().Should().Pass();
 
-            var publishDirectory = publishCommand.GetOutputDirectory("net5.0");
+            var publishDirectory = publishCommand.GetOutputDirectory(DefaultTfm);
 
             var blazorPublishDirectory = Path.Combine(publishDirectory.ToString(), "wwwroot");
 
@@ -152,14 +149,13 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
         {
             // Arrange
             var testAppName = "BlazorWasmWithLibrary";
-            var testInstance = _testAssetsManager.CopyTestAsset(testAppName)
-                            .WithSource();
+            var testInstance = CreateBlazorWasmSdkTestAsset(testAppName);
             File.WriteAllText(Path.Combine(testInstance.TestRoot, "blazorwasm", "App.razor.css"), "h1 { font-size: 16px; }");
 
             var publishCommand = new PublishCommand(Log, Path.Combine(testInstance.TestRoot, "blazorwasm"));
             publishCommand.Execute("/p:Configuration=Release").Should().Pass();
 
-            var publishDirectory = publishCommand.GetOutputDirectory("net5.0", "Release");
+            var publishDirectory = publishCommand.GetOutputDirectory(DefaultTfm, "Release");
 
             var blazorPublishDirectory = Path.Combine(publishDirectory.ToString(), "wwwroot");
 
@@ -189,8 +185,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
         {
             // Arrange
             var testAppName = "BlazorWasmWithLibrary";
-            var testInstance = _testAssetsManager.CopyTestAsset(testAppName)
-                            .WithSource();
+            var testInstance = CreateBlazorWasmSdkTestAsset(testAppName);
 
             var webConfigContents = "test webconfig contents";
             File.WriteAllText(Path.Combine(testInstance.TestRoot, "blazorwasm", "web.config"), webConfigContents);
@@ -198,7 +193,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
             var publishCommand = new PublishCommand(Log, Path.Combine(testInstance.TestRoot, "blazorwasm"));
             publishCommand.Execute("/p:Configuration=Release").Should().Pass();
 
-            var publishDirectory = publishCommand.GetOutputDirectory("net5.0", "Release");
+            var publishDirectory = publishCommand.GetOutputDirectory(DefaultTfm, "Release");
 
             // Verify web.config
             new FileInfo(Path.Combine(publishDirectory.ToString(), "..", "web.config")).Should().Exist();
@@ -210,8 +205,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
         {
             // Arrange
             var testAppName = "BlazorWasmWithLibrary";
-            var testInstance = _testAssetsManager.CopyTestAsset(testAppName)
-                            .WithSource();
+            var testInstance = CreateBlazorWasmSdkTestAsset(testAppName);
 
             var buildCommand = new BuildCommand(testInstance, "blazorwasm");
             buildCommand.Execute()
@@ -220,7 +214,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
             var publishCommand = new PublishCommand(Log, Path.Combine(testInstance.TestRoot, "blazorwasm"));
             publishCommand.Execute("/p:NoBuild=true").Should().Pass();
 
-            var publishDirectory = publishCommand.GetOutputDirectory("net5.0");
+            var publishDirectory = publishCommand.GetOutputDirectory(DefaultTfm);
             var blazorPublishDirectory = Path.Combine(publishDirectory.ToString(), "wwwroot");
 
             var expectedFiles = new[]
@@ -256,8 +250,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
         {
             // Arrange
             var testAppName = "BlazorWasmWithLibrary";
-            var testInstance = _testAssetsManager.CopyTestAsset(testAppName)
-                            .WithSource();
+            var testInstance = CreateBlazorWasmSdkTestAsset(testAppName);
 
             testInstance.WithProjectChanges((path, project) =>
             {
@@ -274,7 +267,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
             var publishCommand = new PublishCommand(Log, Path.Combine(testInstance.TestRoot, "blazorwasm"));
             publishCommand.Execute().Should().Pass();
 
-            var publishDirectory = publishCommand.GetOutputDirectory("net5.0");
+            var publishDirectory = publishCommand.GetOutputDirectory(DefaultTfm);
 
             var expectedFiles = new[]
             {
@@ -318,8 +311,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
         public void Publish_Hosted_WithStaticWebBasePathWorks(string basePath)
         {
             var testAppName = "BlazorHosted";
-            var testInstance = _testAssetsManager.CopyTestAsset(testAppName)
-                            .WithSource();;
+            var testInstance = CreateBlazorWasmSdkTestAsset(testAppName);
 
             testInstance.WithProjectChanges((path, project) =>
             {
@@ -336,7 +328,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
             var publishCommand = new PublishCommand(Log, Path.Combine(testInstance.TestRoot, "blazorhosted"));
             publishCommand.Execute().Should().Pass();
 
-            var publishDirectory = publishCommand.GetOutputDirectory("net5.0");
+            var publishDirectory = publishCommand.GetOutputDirectory(DefaultTfm);
 
             var expectedFiles = new[]
             {
@@ -385,8 +377,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
         {
             // Arrange
             var testAppName = "BlazorWasmWithLibrary";
-            var testInstance = _testAssetsManager.CopyTestAsset(testAppName)
-                            .WithSource();
+            var testInstance = CreateBlazorWasmSdkTestAsset(testAppName);
 
             testInstance.WithProjectChanges((path, project) =>
             {
@@ -403,7 +394,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
             var publishCommand = new PublishCommand(Log, Path.Combine(testInstance.TestRoot, "blazorwasm"));
             publishCommand.Execute().Should().Pass();
 
-            var publishDirectory = publishCommand.GetOutputDirectory("net5.0");
+            var publishDirectory = publishCommand.GetOutputDirectory(DefaultTfm);
             var blazorPublishDirectory = Path.Combine(publishDirectory.ToString(), "wwwroot");
 
             publishDirectory.Should().HaveFiles(new[]
@@ -456,8 +447,8 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
         public void Publish_SatelliteAssemblies_AreCopiedToBuildOutput()
         {
             // Arrange
-            var testAppName = "BlazorWasmWithLibrary";
-            var testInstance = _testAssetsManager.CopyTestAsset(testAppName).WithSource();
+            var testAppName = "BlazorHosted";
+            var testInstance = CreateBlazorWasmSdkTestAsset(testAppName);
 
             testInstance.WithProjectChanges((path, project) =>
             {
@@ -476,7 +467,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
             var publishCommand = new PublishCommand(Log, Path.Combine(testInstance.TestRoot, "blazorwasm"));
             publishCommand.Execute().Should().Pass();
 
-            var publishDirectory = publishCommand.GetOutputDirectory("net5.0");
+            var publishDirectory = publishCommand.GetOutputDirectory(DefaultTfm);
             var blazorPublishDirectory = Path.Combine(publishDirectory.ToString(), "wwwroot");
 
             publishDirectory.Should().HaveFiles(new[]
@@ -497,26 +488,23 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
         {
             // Arrange
             var testAppName = "BlazorHosted";
-            var testInstance = _testAssetsManager.CopyTestAsset(testAppName)
-                            .WithSource();
+            var testInstance = CreateBlazorWasmSdkTestAsset(testAppName);
 
             var publishCommand = new PublishCommand(Log, Path.Combine(testInstance.TestRoot, "blazorhosted"));
             publishCommand.Execute().Should().Pass();
 
-            var publishDirectory = publishCommand.GetOutputDirectory("net5.0");
-            // Make sure the main project exists
-            new FileInfo(Path.Combine(publishDirectory.ToString(), "blazorhosted.dll")).Should().Exist();
+            var publishOutputDirectory = publishCommand.GetOutputDirectory(DefaultTfm);
 
             // Verification for https://github.com/dotnet/aspnetcore/issues/19926. Verify binaries for projects
             // referenced by the Hosted project appear in the publish directory
-            publishDirectory.Should().HaveFiles(new[]
+            publishOutputDirectory.Should().HaveFiles(new[]
             {
                 "RazorClassLibrary.dll",
                 "blazorwasm.dll"
             });
 
-            var blazorPublishDirectory = Path.Combine(publishDirectory.ToString(), "wwwroot");
-            publishDirectory.Should().HaveFiles(new[]
+            var blazorPublishDirectory = Path.Combine(publishOutputDirectory.ToString(), "wwwroot");
+            publishOutputDirectory.Should().HaveFiles(new[]
             {
                 "wwwroot/_framework/blazor.boot.json",
                 "wwwroot/_framework/blazor.webassembly.js",
@@ -526,27 +514,27 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
             });
 
             // Verify project references appear as static web assets
-            publishDirectory.Should().HaveFiles(new[]
+            publishOutputDirectory.Should().HaveFiles(new[]
             {
                 "wwwroot/_framework/RazorClassLibrary.dll",
                 "RazorClassLibrary.dll"
             });
 
             // Verify static assets are in the publish directory
-            publishDirectory.Should().HaveFiles(new[]
+            publishOutputDirectory.Should().HaveFiles(new[]
             {
                 "wwwroot/index.html"
             });
 
             // Verify static web assets from referenced projects are copied.
-            publishDirectory.Should().HaveFiles(new[]
+            publishOutputDirectory.Should().HaveFiles(new[]
             {
                 "wwwroot/_content/RazorClassLibrary/wwwroot/exampleJsInterop.js",
                 "wwwroot/_content/RazorClassLibrary/styles.css",
             });
 
             // Verify web.config
-            publishDirectory.Should().HaveFiles(new[]
+            publishOutputDirectory.Should().HaveFiles(new[]
             {
                 "web.config"
             });
@@ -554,7 +542,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
             VerifyBootManifestHashes(testInstance, blazorPublishDirectory);
 
             // Verify compression works
-            publishDirectory.Should().HaveFiles(new[]
+            publishOutputDirectory.Should().HaveFiles(new[]
             {
                 "wwwroot/_framework/dotnet.wasm.br",
                 "wwwroot/_framework/blazorwasm.dll.br",
@@ -562,7 +550,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
                 "wwwroot/_framework/System.Text.Json.dll.br"
             });
 
-            publishDirectory.Should().HaveFiles(new[]
+            publishOutputDirectory.Should().HaveFiles(new[]
             {
                 "wwwroot/_framework/dotnet.wasm.gz",
                 "wwwroot/_framework/blazorwasm.dll.gz",
@@ -583,8 +571,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
         {
             // Arrange
             var testAppName = "BlazorHosted";
-            var testInstance = _testAssetsManager.CopyTestAsset(testAppName)
-                            .WithSource();
+            var testInstance = CreateBlazorWasmSdkTestAsset(testAppName);
 
             var wwwroot = Path.Combine(testInstance.TestRoot, "blazorwasm", "wwwroot");
             File.WriteAllText(Path.Combine(wwwroot, "appsettings.json"), "Default settings");
@@ -593,7 +580,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
             var publishCommand = new PublishCommand(Log, Path.Combine(testInstance.TestRoot, "blazorhosted"));
             publishCommand.Execute().Should().Pass();
 
-            var buildOutputDirectory = publishCommand.GetOutputDirectory("net5.0").ToString();
+            var buildOutputDirectory = publishCommand.GetOutputDirectory(DefaultTfm).ToString();
 
             var bootJsonPath = Path.Combine(buildOutputDirectory, "wwwroot", "_framework", "blazor.boot.json");
             var bootJsonData = ReadBootJsonData(bootJsonPath);
@@ -617,8 +604,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
         {
             // Arrange
             var testAppName = "BlazorHosted";
-            var testInstance = _testAssetsManager.CopyTestAsset(testAppName)
-                            .WithSource();
+            var testInstance = CreateBlazorWasmSdkTestAsset(testAppName);
 
             testInstance.WithProjectChanges((path, project) =>
             {
@@ -644,7 +630,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
             var publishCommand = new PublishCommand(Log, Path.Combine(testInstance.TestRoot, "blazorhosted"));
             publishCommand.Execute().Should().Pass();
 
-            var publishOutputDirectory = publishCommand.GetOutputDirectory("net5.0");
+            var publishOutputDirectory = publishCommand.GetOutputDirectory(DefaultTfm);
 
             var bootJsonData = new FileInfo(Path.Combine(publishOutputDirectory.ToString(), "wwwroot", "_framework", "blazor.boot.json"));
 
@@ -666,8 +652,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
         {
             // Arrange
             var testAppName = "BlazorHosted";
-            var testInstance = _testAssetsManager.CopyTestAsset(testAppName)
-                            .WithSource();
+            var testInstance = CreateBlazorWasmSdkTestAsset(testAppName);
 
             testInstance.WithProjectChanges((path, project) =>
             {
@@ -689,7 +674,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
             var publishCommand = new PublishCommand(Log, Path.Combine(testInstance.TestRoot, "blazorhosted"));
             publishCommand.Execute("/p:BuildDependencies=false /bl").Should().Pass();
 
-            var publishDirectory = publishCommand.GetOutputDirectory("net5.0");
+            var publishDirectory = publishCommand.GetOutputDirectory(DefaultTfm);
             // Make sure the main project exists
             new FileInfo(Path.Combine(publishDirectory.ToString(), "blazorhosted.dll")).Should().Exist();
 
@@ -767,8 +752,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
         {
             // Arrange
             var testAppName = "BlazorHosted";
-            var testInstance = _testAssetsManager.CopyTestAsset(testAppName)
-                            .WithSource();
+            var testInstance = CreateBlazorWasmSdkTestAsset(testAppName);
 
             var buildCommand = new BuildCommand(testInstance, "blazorhosted");
             buildCommand.Execute().Should().Pass();
@@ -776,7 +760,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
             var publishCommand = new PublishCommand(Log, Path.Combine(testInstance.TestRoot, "blazorhosted"));
             publishCommand.Execute("/p:NoBuild=true").Should().Pass();
 
-            var publishDirectory = publishCommand.GetOutputDirectory("net5.0");
+            var publishDirectory = publishCommand.GetOutputDirectory(DefaultTfm);
             // Make sure the main project exists
             new FileInfo(Path.Combine(publishDirectory.ToString(), "blazorhosted.dll")).Should().Exist();
 
@@ -821,8 +805,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
             // Simulates publishing the same way VS does by setting BuildProjectReferences=false.
             // Arrange
             var testAppName = "BlazorHosted";
-            var testInstance = _testAssetsManager.CopyTestAsset(testAppName)
-                            .WithSource();
+            var testInstance = CreateBlazorWasmSdkTestAsset(testAppName);
 
             // VS builds projects individually and then a publish with BuildDependencies=false, but building the main project is a close enough approximation for this test.
             var buildCommand = new BuildCommand(testInstance, "blazorwasm");
@@ -832,7 +815,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
             var publishCommand = new PublishCommand(Log, Path.Combine(testInstance.TestRoot, "blazorhosted"));
             publishCommand.Execute("/p:BuildProjectReferences=false /p:BuildInsideVisualStudio=true").Should().Pass();
 
-            var publishDirectory = publishCommand.GetOutputDirectory("net5.0");
+            var publishDirectory = publishCommand.GetOutputDirectory(DefaultTfm);
             // Make sure the main project exists
             new FileInfo(Path.Combine(publishDirectory.ToString(), "blazorhosted.dll")).Should().Exist();
 
@@ -905,8 +888,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
         {
             // Simulates publishing the same way VS does by setting BuildProjectReferences=false.
             var testAppName = "BlazorHosted";
-            var testInstance = _testAssetsManager.CopyTestAsset(testAppName)
-                            .WithSource();
+            var testInstance = CreateBlazorWasmSdkTestAsset(testAppName);
             File.WriteAllText(Path.Combine(testInstance.TestRoot, "blazorwasm", "App.razor.css"), "h1 { font-size: 16px; }");
 
             // VS builds projects individually and then a publish with BuildDependencies=false, but building the main project is a close enough approximation for this test.
@@ -917,7 +899,9 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
             var publishCommand = new PublishCommand(Log, Path.Combine(testInstance.TestRoot, "blazorhosted"));
             publishCommand.Execute("/p:BuildProjectReferences=false /p:BuildInsideVisualStudio=true").Should().Pass();
 
-            var publishDirectory = publishCommand.GetOutputDirectory("net5.0");
+            var publishDirectory = publishCommand.GetOutputDirectory(DefaultTfm);
+            var blazorPublishDirectory = Path.Combine(publishDirectory.ToString(), "wwwroot");
+
             // Make sure the main project exists
             new FileInfo(Path.Combine(publishDirectory.ToString(), "blazorhosted.dll")).Should().Exist();
 
@@ -982,8 +966,6 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
                 "wwwroot/_framework/System.Text.Json.dll.br"
             });
 
-            var blazorPublishDirectory = Path.Combine(publishDirectory.ToString(), "wwwroot");
-
             VerifyBootManifestHashes(testInstance, blazorPublishDirectory);
             VerifyServiceWorkerFiles(testInstance, blazorPublishDirectory,
                 serviceWorkerPath: Path.Combine("serviceworkers", "my-service-worker.js"),
@@ -997,7 +979,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
         public void Publish_HostedApp_VisualStudio_WithSatelliteAssemblies()
         {
             var testAppName = "BlazorWasmWithLibrary";
-            var testInstance = _testAssetsManager.CopyTestAsset(testAppName).WithSource();
+            var testInstance = CreateBlazorWasmSdkTestAsset(testAppName);
 
             testInstance.WithProjectChanges((path, project) =>
             {
@@ -1022,7 +1004,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
             var publishCommand = new PublishCommand(Log, Path.Combine(testInstance.TestRoot, "blazorwasm"));
             publishCommand.Execute("/p:BuildProjectReferences=false").Should().Pass();
 
-            var publishDirectory = publishCommand.GetOutputDirectory("net5.0");
+            var publishDirectory = publishCommand.GetOutputDirectory(DefaultTfm);
             var blazorPublishDirectory = Path.Combine(publishDirectory.ToString(), "wwwroot");
 
             publishDirectory.Should().HaveFiles(new[]
@@ -1045,8 +1027,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
         {
             // Arrange
             var testAppName = "BlazorHostedRID";
-            var testInstance = _testAssetsManager.CopyTestAsset(testAppName)
-                            .WithSource();
+            var testInstance = CreateBlazorWasmSdkTestAsset(testAppName);
 
             var publishCommand = new PublishCommand(Log, Path.Combine(testInstance.TestRoot, "blazorhosted"));
             publishCommand.Execute("/p:RuntimeIdentifier=linux-x64").Should().Pass();
@@ -1059,7 +1040,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
         {
             // Arrange
             var testAppName = "BlazorHostedRID";
-            var testInstance = _testAssetsManager.CopyTestAsset(testAppName).WithSource();
+            var testInstance = CreateBlazorWasmSdkTestAsset(testAppName);
 
             var publishCommand = new PublishCommand(Log, Path.Combine(testInstance.TestRoot, "blazorhosted"));
             publishCommand.Execute().Should().Pass();
@@ -1067,9 +1048,9 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
             AssertRIDPublishOuput(publishCommand, testInstance);
         }
 
-        private static void AssertRIDPublishOuput(PublishCommand command, TestAsset testInstance)
+        private void AssertRIDPublishOuput(PublishCommand command, TestAsset testInstance)
         {
-            var publishDirectory = command.GetOutputDirectory("net5.0", "Debug", "linux-x64");
+            var publishDirectory = command.GetOutputDirectory(DefaultTfm, "Debug", "linux-x64");
 
             // Make sure the main project exists
             publishDirectory.Should().HaveFiles(new[]
@@ -1148,8 +1129,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
         {
             // Arrange
             var testAppName = "BlazorWasmMinimal";
-            var testInstance = _testAssetsManager.CopyTestAsset(testAppName)
-                            .WithSource();
+            var testInstance = CreateBlazorWasmSdkTestAsset(testAppName);
 
             testInstance.WithProjectChanges((project) =>
             {
@@ -1162,7 +1142,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
             var publishCommand = new PublishCommand(Log, testInstance.TestRoot);
             publishCommand.Execute().Should().Pass();
 
-            var publishOutputDirectory = publishCommand.GetOutputDirectory("net5.0").ToString();
+            var publishOutputDirectory = publishCommand.GetOutputDirectory(DefaultTfm).ToString();
 
             var bootJsonPath = Path.Combine(publishOutputDirectory.ToString(), "wwwroot", "_framework", "blazor.boot.json");
             var bootJsonData = ReadBootJsonData(bootJsonPath);
@@ -1188,13 +1168,12 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
             // Regression test for https://github.com/dotnet/aspnetcore/issues/29264
             // Arrange
             var testAppName = "BlazorMultiApp";
-            var testInstance = _testAssetsManager.CopyTestAsset(testAppName)
-                            .WithSource();
+            var testInstance = CreateBlazorWasmSdkTestAsset(testAppName);
 
             var publishCommand = new PublishCommand(Log, Path.Combine(testInstance.TestRoot, "BlazorMultipleApps.Server"));
             publishCommand.Execute().Should().Pass();
 
-            var publishOutputDirectory = publishCommand.GetOutputDirectory("net5.0").ToString();
+            var publishOutputDirectory = publishCommand.GetOutputDirectory(DefaultTfm).ToString();
 
             new FileInfo(Path.Combine(publishOutputDirectory, "BlazorMultipleApps.Server.dll")).Should().Exist();
             new FileInfo(Path.Combine(publishOutputDirectory, "BlazorMultipleApps.FirstClient.dll")).Should().Exist();

--- a/src/Tests/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/WasmPwaManifestTests.cs
+++ b/src/Tests/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/WasmPwaManifestTests.cs
@@ -18,7 +18,7 @@ using static Microsoft.NET.Sdk.BlazorWebAssembly.Tests.ServiceWorkerAssert;
 
 namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
 {
-    public class WasmPwaManifestTests : SdkTest
+    public class WasmPwaManifestTests : BlazorWasmSdkTest
     {
         public WasmPwaManifestTests(ITestOutputHelper log) : base(log) {}
 
@@ -28,21 +28,20 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
             // Arrange
             var expectedExtensions = new[] { ".dll", ".pdb", ".js", ".wasm" };
             var testAppName = "BlazorWasmWithLibrary";
-            var testInstance = _testAssetsManager.CopyTestAsset(testAppName)
-                            .WithSource();
+            var testInstance = CreateBlazorWasmSdkTestAsset(testAppName);
 
             var buildCommand = new BuildCommand(testInstance, "blazorwasm");
             buildCommand.Execute("/p:ServiceWorkerAssetsManifest=service-worker-assets.js")
                 .Should().Pass();
 
-            var buildOutputDirectory = buildCommand.GetOutputDirectory("net5.0").ToString();
+            var buildOutputDirectory = buildCommand.GetOutputDirectory(DefaultTfm).ToString();
 
             new FileInfo(Path.Combine(buildOutputDirectory, "wwwroot", "_framework", "blazor.boot.json")).Should().Exist();
             new FileInfo(Path.Combine(buildOutputDirectory, "wwwroot", "_framework", "dotnet.wasm")).Should().Exist();
             new FileInfo(Path.Combine(buildOutputDirectory, "wwwroot", "_framework", "blazorwasm.dll")).Should().Exist();
 
             var staticWebAssets = Path.Combine(buildOutputDirectory, "blazorwasm.StaticWebAssets.xml");
-            new FileInfo(staticWebAssets).Should().Contain(Path.Combine("net5.0", "wwwroot"));
+            new FileInfo(staticWebAssets).Should().Contain(Path.Combine(DefaultTfm, "wwwroot"));
 
             var serviceWorkerAssetsManifest = Path.Combine(buildOutputDirectory, "wwwroot", "service-worker-assets.js");
             // Trim prefix 'self.assetsManifest = ' and suffix ';'
@@ -68,17 +67,16 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
             // Arrange
             var expectedExtensions = new[] { ".dll", ".pdb", ".js", ".wasm" };
             var testAppName = "BlazorHosted";
-            var testInstance = _testAssetsManager.CopyTestAsset(testAppName)
-                            .WithSource();
+            var testInstance = CreateBlazorWasmSdkTestAsset(testAppName);
 
             var buildCommand = new BuildCommand(testInstance, "blazorhosted");
             buildCommand.Execute()
                 .Should().Pass();
 
-            var buildOutputDirectory = Path.Combine(testInstance.TestRoot, "blazorwasm", "bin", "Debug", "net5.0");
+            var buildOutputDirectory = Path.Combine(testInstance.TestRoot, "blazorwasm", "bin", "Debug", DefaultTfm);
 
             var staticWebAssets = Path.Combine(buildOutputDirectory, "blazorwasm.StaticWebAssets.xml");
-            new FileInfo(staticWebAssets).Should().Contain(Path.Combine("net5.0", "wwwroot"));
+            new FileInfo(staticWebAssets).Should().Contain(Path.Combine(DefaultTfm, "wwwroot"));
 
             var serviceWorkerAssetsManifest = Path.Combine(buildOutputDirectory, "wwwroot", "custom-service-worker-assets.js");
             // Trim prefix 'self.assetsManifest = ' and suffix ';'
@@ -98,13 +96,12 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
             // Arrange
             var expectedExtensions = new[] { ".dll", ".pdb", ".js", ".wasm" };
             var testAppName = "BlazorWasmWithLibrary";
-            var testInstance = _testAssetsManager.CopyTestAsset(testAppName)
-                            .WithSource();
+            var testInstance = CreateBlazorWasmSdkTestAsset(testAppName);
 
             var publishCommand = new PublishCommand(Log, Path.Combine(testInstance.TestRoot, "blazorwasm"));
             publishCommand.Execute().Should().Pass();
 
-            var publishOutputDirectory = publishCommand.GetOutputDirectory("net5.0").ToString();
+            var publishOutputDirectory = publishCommand.GetOutputDirectory(DefaultTfm).ToString();
 
             var serviceWorkerAssetsManifest = Path.Combine(publishOutputDirectory, "wwwroot", "custom-service-worker-assets.js");
             // Trim prefix 'self.assetsManifest = ' and suffix ';'
@@ -127,13 +124,12 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
             // Arrange
             var expectedExtensions = new[] { ".dll", ".pdb", ".js", ".wasm" };
             var testAppName = "BlazorHosted";
-            var testInstance = _testAssetsManager.CopyTestAsset(testAppName)
-                            .WithSource();
+            var testInstance = CreateBlazorWasmSdkTestAsset(testAppName);
 
             var publishCommand = new PublishCommand(Log, Path.Combine(testInstance.TestRoot, "blazorhosted"));
             publishCommand.Execute().Should().Pass();
 
-            var publishOutputDirectory = publishCommand.GetOutputDirectory("net5.0").ToString();
+            var publishOutputDirectory = publishCommand.GetOutputDirectory(DefaultTfm).ToString();
 
             var serviceWorkerAssetsManifest = Path.Combine(publishOutputDirectory, "wwwroot", "custom-service-worker-assets.js");
             // Trim prefix 'self.assetsManifest = ' and suffix ';'
@@ -155,13 +151,12 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
         {
             // Arrange
             var testAppName = "BlazorWasmWithLibrary";
-            var testInstance = _testAssetsManager.CopyTestAsset(testAppName)
-                            .WithSource();
+            var testInstance = CreateBlazorWasmSdkTestAsset(testAppName);
 
             var publishCommand = new PublishCommand(Log, Path.Combine(testInstance.TestRoot, "blazorwasm"));
             publishCommand.Execute("/p:ServiceWorkerAssetsManifest=service-worker-assets.js").Should().Pass();
 
-            var publishOutputDirectory = publishCommand.GetOutputDirectory("net5.0").ToString();
+            var publishOutputDirectory = publishCommand.GetOutputDirectory(DefaultTfm).ToString();
 
             var serviceWorkerFile = Path.Combine(publishOutputDirectory, "wwwroot", "serviceworkers", "my-service-worker.js");
             var version = File.ReadAllLines(serviceWorkerFile).Last();
@@ -197,13 +192,12 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
         {
             // Arrange
             var testAppName = "BlazorWasmWithLibrary";
-            var testInstance = _testAssetsManager.CopyTestAsset(testAppName)
-                            .WithSource();
+            var testInstance = CreateBlazorWasmSdkTestAsset(testAppName);
 
             var publishCommand = new PublishCommand(Log, Path.Combine(testInstance.TestRoot, "blazorwasm"));
             publishCommand.Execute("/p:ServiceWorkerAssetsManifest=service-worker-assets.js").Should().Pass();
 
-            var publishOutputDirectory = publishCommand.GetOutputDirectory("net5.0").ToString();
+            var publishOutputDirectory = publishCommand.GetOutputDirectory(DefaultTfm).ToString();
 
             var serviceWorkerFile = Path.Combine(publishOutputDirectory, "wwwroot", "serviceworkers", "my-service-worker.js");
             var version = File.ReadAllLines(serviceWorkerFile).Last();


### PR DESCRIPTION
Applies the technique we used for the Razor SDK tests to the Blazor WASM SDK tests.