### PR TITLE
[master] Implemented option to preserve the destination folder for File System publishes when Delete existing files option is selected

### DIFF
--- a/src/WebSdk/Publish/Targets/PublishTargets/Microsoft.NET.Sdk.Publish.FileSystem.targets
+++ b/src/WebSdk/Publish/Targets/PublishTargets/Microsoft.NET.Sdk.Publish.FileSystem.targets
@@ -66,11 +66,11 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
     <RemoveDir
       Directories="$(PublishUrl)"
-      Condition="'$(DeleteExistingFiles)' == 'true' And Exists('$(PublishUrl)')" />
+      Condition="'$(DeleteExistingFiles)' == 'true' And '$(PreserveDestinationFolder)' == 'false' And Exists('$(PublishUrl)')" />
 
     <MakeDir
       Directories="$(PublishUrl)"
-      Condition="'$(DeleteExistingFiles)' == 'true' And !Exists('$(PublishUrl)')"/>
+      Condition="'$(DeleteExistingFiles)' == 'true' And '$(PreserveDestinationFolder)' == 'false' And !Exists('$(PublishUrl)')"/>
   </Target>
 
   <!--


### PR DESCRIPTION
Currently when the File System publish goes to delete the existing files, it also deletes and recreates the target folder. This can have unwarranted side effects, one such being that ACL's on the target folder are removed, and reset based on how the new folder is created (typically just inheriting permissions from the next parent folder). When publishing directly to a web server in this way, any folder permissions that were directly on the folder are lost, and can cause issues for developers who are unaware of this behavior and are attempting to configure permissions for IIS and the web server (an already tricky task). I'm sure there are other scenarios where deleting the target folder is not desired.

By providing an opt-in option to preserve the destination folder, this issue can be bypassed, yet users can still take advantage of the cleanup to remove older website files that may be outdated or defunct inside of the destination.

This option should not affect older publish profiles if they do not have this setting, as I'm hopeful it would default to false in such cases.

For the UI in Visual Studio for configuration, a new checkbox option could be introduced below the "Delete existing files" checkbox. This new option could say "Preserve destination folder" and would be unchecked and disabled until "Delete existing files" is checked, then giving users the option to check it.