### PR TITLE
Overwrite `Prefer32Bit` when implicitly assigning `PlatformTarget`

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets
@@ -76,24 +76,28 @@ Copyright (c) .NET Foundation. All rights reserved.
     <When Condition="$(RuntimeIdentifier.EndsWith('-x86')) or $(RuntimeIdentifier.Contains('-x86-'))">
       <PropertyGroup>
         <PlatformTarget>x86</PlatformTarget>
+        <Prefer32Bit>true</Prefer32Bit>
       </PropertyGroup>
     </When>
 
     <When Condition="$(RuntimeIdentifier.EndsWith('-x64')) or $(RuntimeIdentifier.Contains('-x64-'))">
       <PropertyGroup>
         <PlatformTarget>x64</PlatformTarget>
+        <Prefer32Bit>false</Prefer32Bit>
       </PropertyGroup>
     </When>
 
     <When Condition="$(RuntimeIdentifier.EndsWith('-arm')) or $(RuntimeIdentifier.Contains('-arm-'))">
       <PropertyGroup>
         <PlatformTarget>arm</PlatformTarget>
+        <Prefer32Bit>true</Prefer32Bit>
       </PropertyGroup>
     </When>
 
     <When Condition="$(RuntimeIdentifier.EndsWith('-arm64')) or $(RuntimeIdentifier.Contains('-arm64-'))">
       <PropertyGroup>
         <PlatformTarget>arm64</PlatformTarget>
+        <Prefer32Bit>false</Prefer32Bit>
       </PropertyGroup>
     </When>
 


### PR DESCRIPTION
`Prefer32Bit` should be set according to the implicitly defined `PlatformTarget`/`RuntimeIdentifier` architecture. Otherwise, the opportunity exists for a .NET Framework application to be built as `AnyCPU (64-bit preferred)`, while only having `x86` runtime binaries copied to the output directory.

See here for more info:
https://github.com/dotnet/sdk/issues/1545#issuecomment-767801483

Fixes #1545