### PR TITLE
Moving command line suggestions to delegates

### DIFF
--- a/src/Cli/dotnet/CommonOptions.cs
+++ b/src/Cli/dotnet/CommonOptions.cs
@@ -36,7 +36,7 @@ namespace Microsoft.DotNet.Cli
                 description)
             {
                 Argument = new Argument<string>(CommonLocalizableStrings.FrameworkArgumentName)
-                    .AddSuggestions(Suggest.TargetFrameworksFromProjectFile().ToArray())
+                    .AddSuggestions(Suggest.TargetFrameworksFromProjectFile())
             }.ForwardAsSingle(o => $"-property:TargetFramework={o}");
 
         public static Option RuntimeOption(string description, bool withShortOption = true) =>
@@ -45,7 +45,7 @@ namespace Microsoft.DotNet.Cli
                 description)
             {
                 Argument = new Argument<string>(CommonLocalizableStrings.RuntimeIdentifierArgumentName)
-                    .AddSuggestions(Suggest.RunTimesFromProjectFile().ToArray())
+                    .AddSuggestions(Suggest.RunTimesFromProjectFile())
             }.ForwardAsSingle(o => $"-property:RuntimeIdentifier={o}");
 
         public static Option CurrentRuntimeOption(string description) =>
@@ -58,7 +58,7 @@ namespace Microsoft.DotNet.Cli
                 description)
             {
                 Argument = new Argument<string>(CommonLocalizableStrings.ConfigurationArgumentName)
-                    .AddSuggestions(Suggest.ConfigurationsFromProjectFileOrDefaults().ToArray())
+                    .AddSuggestions(Suggest.ConfigurationsFromProjectFileOrDefaults())
             }.ForwardAsSingle(o => $"-property:Configuration={o}");
 
         public static Option VersionSuffixOption() =>

--- a/src/Cli/dotnet/OptionForwardingExtensions.cs
+++ b/src/Cli/dotnet/OptionForwardingExtensions.cs
@@ -59,10 +59,6 @@ namespace Microsoft.DotNet.Cli
                 {
                     Argument = option.Argument;
                 }
-                if (option.GetSuggestions() != null)
-                {
-                    this.AddSuggestions(option.GetSuggestions().ToArray());
-                }
             }
 
             public ForwardedOption<T> SetForwardingFunction(Func<T, IEnumerable<string>> func)

--- a/src/Cli/dotnet/commands/dotnet-add/dotnet-add-reference/AddProjectToProjectReferenceParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-add/dotnet-add-reference/AddProjectToProjectReferenceParser.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Generic;
 using System.CommandLine;
-using System.Linq;
 using LocalizableStrings = Microsoft.DotNet.Tools.Add.ProjectToProjectReference.LocalizableStrings;
 
 namespace Microsoft.DotNet.Cli
@@ -19,7 +18,7 @@ namespace Microsoft.DotNet.Cli
         public static readonly Option FrameworkOption = new Option<string>(new string[] { "-f", "--framework" }, LocalizableStrings.CmdFrameworkDescription)
         {
             Argument = new Argument<string>(Tools.Add.PackageReference.LocalizableStrings.CmdFramework)
-                    .AddSuggestions(Suggest.TargetFrameworksFromProjectFile().ToArray())
+                .AddSuggestions(Suggest.TargetFrameworksFromProjectFile())
         };
 
         public static readonly Option InteractiveOption = CommonOptions.InteractiveOption();

--- a/src/Cli/dotnet/commands/dotnet-complete/Suggest.cs
+++ b/src/Cli/dotnet/commands/dotnet-complete/Suggest.cs
@@ -1,5 +1,9 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System;
-using System.Collections.Generic;
+using System.CommandLine.Parsing;
+using System.CommandLine.Suggestions;
 using System.IO;
 using System.Linq;
 using Microsoft.Build.Evaluation;
@@ -11,56 +15,69 @@ namespace Microsoft.DotNet.Cli
 {
     internal static class Suggest
     {
-        public static IEnumerable<string> TargetFrameworksFromProjectFile()
+        public static SuggestDelegate TargetFrameworksFromProjectFile()
         {
-            try
+            return (ParseResult parseResult, string textToMatch) =>
             {
-                return GetMSBuildProject()?.GetTargetFrameworks().Select(tf => tf.GetShortFolderName()) ?? Empty<string>();
-            }
-            catch (Exception)
-            {
-                return Empty<string>();
-            }
+                try
+                {
+                    return GetMSBuildProject()?.GetTargetFrameworks().Select(tf => tf.GetShortFolderName()) ?? Empty<string>();
+                }
+                catch (Exception)
+                {
+                    return Empty<string>();
+                }
+            };
+
         }
 
         private static void Report(Exception e) =>
             Reporter.Verbose.WriteLine($"Exception occurred while getting suggestions: {e}");
 
-        public static IEnumerable<string> RunTimesFromProjectFile()
+        public static SuggestDelegate RunTimesFromProjectFile()
         {
-            try
+            return (ParseResult parseResult, string textToMatch) =>
             {
-                return GetMSBuildProject()?.GetRuntimeIdentifiers() ?? Empty<string>();
-            }
-            catch (Exception)
-            {
-                return Empty<string>();
-            }
+                try
+                {
+                    return GetMSBuildProject()?.GetRuntimeIdentifiers() ?? Empty<string>();
+                }
+                catch (Exception)
+                {
+                    return Empty<string>();
+                }
+            };
         }
             
 
-        public static IEnumerable<string> ProjectReferencesFromProjectFile()
+        public static SuggestDelegate ProjectReferencesFromProjectFile()
         {
-            try
+            return (ParseResult parseResult, string textToMatch) =>
             {
-                return GetMSBuildProject()?.GetProjectToProjectReferences().Select(r => r.Include) ?? Empty<string>();
-            }
-            catch (Exception)
-            {
-                return Empty<string>();
-            }
+                try
+                {
+                    return GetMSBuildProject()?.GetProjectToProjectReferences().Select(r => r.Include) ?? Empty<string>();
+                }
+                catch (Exception)
+                {
+                    return Empty<string>();
+                }
+            };
         }
 
-        public static IEnumerable<string> ConfigurationsFromProjectFileOrDefaults()
+        public static SuggestDelegate ConfigurationsFromProjectFileOrDefaults()
         {
-            try
+            return (ParseResult parseResult, string textToMatch) =>
             {
-                return GetMSBuildProject()?.GetConfigurations() ?? new[] { "Debug", "Release" };
-            }
-            catch (Exception)
-            {
-                return Empty<string>();
-            }
+                try
+                {
+                    return GetMSBuildProject()?.GetConfigurations() ?? new[] { "Debug", "Release" };
+                }
+                catch (Exception)
+                {
+                    return Empty<string>();
+                }
+            };
         }
 
         private static MsbuildProject GetMSBuildProject()

--- a/src/Cli/dotnet/commands/dotnet-remove/dotnet-remove-reference/RemoveProjectToProjectReferenceParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-remove/dotnet-remove-reference/RemoveProjectToProjectReferenceParser.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Generic;
 using System.CommandLine;
-using System.Linq;
 using Microsoft.DotNet.Tools;
 using LocalizableStrings = Microsoft.DotNet.Tools.Remove.ProjectToProjectReference.LocalizableStrings;
 
@@ -15,7 +14,7 @@ namespace Microsoft.DotNet.Cli
         {
             Description = LocalizableStrings.ProjectPathArgumentDescription,
             Arity = ArgumentArity.OneOrMore,
-        }.AddSuggestions(Suggest.ProjectReferencesFromProjectFile().ToArray());
+        }.AddSuggestions(Suggest.ProjectReferencesFromProjectFile());
 
         public static readonly Option FrameworkOption = new Option<string>(new string[] { "-f", "--framework" }, LocalizableStrings.CmdFrameworkDescription)
         {

--- a/src/Cli/dotnet/commands/dotnet-restore/RestoreCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-restore/RestoreCommandParser.cs
@@ -124,10 +124,10 @@ namespace Microsoft.DotNet.Cli
                         useShortOptions ? new string[] { "-r", "--runtime" } : new string[] { "--runtime" },
                         LocalizableStrings.CmdRuntimeOptionDescription)
                     {
-                        Argument = new Argument<IEnumerable<string>>(LocalizableStrings.CmdRuntimeOption) { Arity = ArgumentArity.OneOrMore },
+                        Argument = new Argument<IEnumerable<string>>(LocalizableStrings.CmdRuntimeOption) { Arity = ArgumentArity.OneOrMore }
+                            .AddSuggestions(Suggest.RunTimesFromProjectFile()),
                         IsHidden = !showHelp
                     }.ForwardAsSingle(o => $"-property:RuntimeIdentifiers={string.Join("%3B", o)}")
-                    .AddSuggestions(Suggest.RunTimesFromProjectFile().ToArray())
                     .AllowSingleArgPerToken()
                 ).ToArray();
             }


### PR DESCRIPTION
Context: I accidentally switched from using delegates to directly querying for suggestions in the main System.CommandLine PR (https://github.com/dotnet/sdk/pull/14379). This can cause significant performance impact when running commands in directories containing projects, specifically WPF projects. 

Pre-fix perf data: https://github.com/sfoslund/sdk-perf-testing/blob/SuggestDelegateCompare/NoSuggestChange.txt
Perf data with this fix: https://github.com/sfoslund/sdk-perf-testing/blob/SuggestDelegateCompare/SuggestFix.txt

One note is that since System.CommandLine includes suggestions in the generated help, we can still see perf impact in commands like `dotnet build -h`. We might want to discuss if the benefits of getting the suggestions in help output (for example `-f, --framework <net6.0-windows>`) is worth the performance impact we're seeing, or if there's a way for us to speed up how we gather those suggestions. 