### PR TITLE
Add compilervisible properties needed for namespace sync

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.Analyzers.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.Analyzers.targets
@@ -91,6 +91,13 @@ Copyright (c) .NET Foundation. All rights reserved.
       IsImplicitlyDefined="true" />
   </ItemGroup>
 
+  <!-- CompilerVisibleProperties for .NET -->
+  <ItemGroup Condition="'$(Language)' == 'C#' Or '$(Language)' == 'VB'">
+    <!-- Used for analyzer to match namespace to folder structure -->
+    <CompilerVisibleProperty Include="RootNamespace" />
+    <CompilerVisibleProperty Include="ProjectDir" />
+  </ItemGroup>
+
   <!-- C# Code Style Analyzers -->
   <ItemGroup Condition="$(EnforceCodeStyleInBuild) And '$(Language)' == 'C#'">
     <Analyzer


### PR DESCRIPTION
Analyzer is being added in https://github.com/dotnet/roslyn/pull/49990 , target is 16.10. We want this to work out of the box in sdk 6+