### PR TITLE
Fix Crossgen2 extra arguments escape hatch

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/RunReadyToRunCompiler.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/RunReadyToRunCompiler.cs
@@ -213,8 +213,7 @@ namespace Microsoft.NET.Build.Tasks
             {
                 foreach (string extraArg in Crossgen2ExtraCommandLineArgs.Split(';', StringSplitOptions.RemoveEmptyEntries))
                 {
-                    if (!String.IsNullOrEmpty(extraArg))
-                        result.AppendLine(extraArg);
+                    result.AppendLine(extraArg);
                 }
             }
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/RunReadyToRunCompiler.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/RunReadyToRunCompiler.cs
@@ -209,19 +209,20 @@ namespace Microsoft.NET.Build.Tasks
 
             result.AppendLine("-O");
 
+            if (!String.IsNullOrEmpty(Crossgen2ExtraCommandLineArgs))
+            {
+                foreach (string extraArg in Crossgen2ExtraCommandLineArgs.Split(';', StringSplitOptions.RemoveEmptyEntries))
+                {
+                    if (!String.IsNullOrEmpty(extraArg))
+                        result.AppendLine(extraArg);
+                }
+            }
+
             if (Crossgen2Composite)
             {
                 result.AppendLine("--composite");
                 result.AppendLine("--inputbubble");
                 result.AppendLine($"--out:\"{_outputR2RImage}\"");
-                if (!String.IsNullOrEmpty(Crossgen2ExtraCommandLineArgs))
-                {
-                    foreach (string extraArg in Crossgen2ExtraCommandLineArgs.Split(';'))
-                    {
-                        if (!String.IsNullOrEmpty(extraArg))
-                            result.AppendLine(extraArg);
-                    }
-                }
 
                 // Note: do not add double quotes around the input assembly, even if the file path contains spaces. The command line 
                 // parsing logic will append this string to the working directory if it's a relative path, so any double quotes will result in errors.
@@ -234,14 +235,7 @@ namespace Microsoft.NET.Build.Tasks
             {
                 result.Append(GetAssemblyReferencesCommands());
                 result.AppendLine($"--out:\"{_outputR2RImage}\"");
-                if (!String.IsNullOrEmpty(Crossgen2ExtraCommandLineArgs))
-                {
-                    foreach (string extraArg in Crossgen2ExtraCommandLineArgs.Split(';'))
-                    {
-                        if (!String.IsNullOrEmpty(extraArg))
-                            result.AppendLine(extraArg);
-                    }
-                }
+
                 // Note: do not add double quotes around the input assembly, even if the file path contains spaces. The command line 
                 // parsing logic will append this string to the working directory if it's a relative path, so any double quotes will result in errors.
                 result.AppendLine($"{_inputAssembly}");

--- a/src/Tasks/Microsoft.NET.Build.Tasks/RunReadyToRunCompiler.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/RunReadyToRunCompiler.cs
@@ -211,9 +211,10 @@ namespace Microsoft.NET.Build.Tasks
 
             if (!String.IsNullOrEmpty(Crossgen2ExtraCommandLineArgs))
             {
-                foreach (string extraArg in Crossgen2ExtraCommandLineArgs.Split(';', StringSplitOptions.RemoveEmptyEntries))
+                foreach (string extraArg in Crossgen2ExtraCommandLineArgs.Split(';'))
                 {
-                    result.AppendLine(extraArg);
+                    if (!String.IsNullOrEmpty(extraArg))
+                        result.AppendLine(extraArg);
                 }
             }
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/RunReadyToRunCompiler.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/RunReadyToRunCompiler.cs
@@ -211,10 +211,9 @@ namespace Microsoft.NET.Build.Tasks
 
             if (!String.IsNullOrEmpty(Crossgen2ExtraCommandLineArgs))
             {
-                foreach (string extraArg in Crossgen2ExtraCommandLineArgs.Split(';'))
+                foreach (string extraArg in Crossgen2ExtraCommandLineArgs.Split(new char[]{';'}, StringSplitOptions.RemoveEmptyEntries))
                 {
-                    if (!String.IsNullOrEmpty(extraArg))
-                        result.AppendLine(extraArg);
+                    result.AppendLine(extraArg);
                 }
             }
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/RunReadyToRunCompiler.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/RunReadyToRunCompiler.cs
@@ -216,7 +216,11 @@ namespace Microsoft.NET.Build.Tasks
                 result.AppendLine($"--out:\"{_outputR2RImage}\"");
                 if (!String.IsNullOrEmpty(Crossgen2ExtraCommandLineArgs))
                 {
-                    result.AppendLine(Crossgen2ExtraCommandLineArgs);
+                    foreach (string extraArg in Crossgen2ExtraCommandLineArgs.Split(';'))
+                    {
+                        if (!String.IsNullOrEmpty(extraArg))
+                            result.AppendLine(extraArg);
+                    }
                 }
 
                 // Note: do not add double quotes around the input assembly, even if the file path contains spaces. The command line 
@@ -232,7 +236,11 @@ namespace Microsoft.NET.Build.Tasks
                 result.AppendLine($"--out:\"{_outputR2RImage}\"");
                 if (!String.IsNullOrEmpty(Crossgen2ExtraCommandLineArgs))
                 {
-                    result.AppendLine(Crossgen2ExtraCommandLineArgs);
+                    foreach (string extraArg in Crossgen2ExtraCommandLineArgs.Split(';'))
+                    {
+                        if (!String.IsNullOrEmpty(extraArg))
+                            result.AppendLine(extraArg);
+                    }
                 }
                 // Note: do not add double quotes around the input assembly, even if the file path contains spaces. The command line 
                 // parsing logic will append this string to the working directory if it's a relative path, so any double quotes will result in errors.


### PR DESCRIPTION
The current implementation of the extra arguments escape hatch does not allow multiple arguments to be passed to crossgen2. That is necessary for the upcoming profile guided optimization work. In the long term, we will add specific project properties/itemgroups for pgo, but for now, this will unblock the work, and be useful going forward.