### PR TITLE
Allow parsing of prefixed msbuild options

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -26,7 +26,7 @@
     <NETStandardLibraryNETFrameworkVersion>2.0.1-servicing-26011-01</NETStandardLibraryNETFrameworkVersion>
     <NewtonsoftJsonPackageVersion>11.0.1</NewtonsoftJsonPackageVersion>
     <NewtonsoftJsonVersion>$(NewtonsoftJsonPackageVersion)</NewtonsoftJsonVersion>
-    <SystemCommandLineVersion>2.0.0-beta1.20574.7</SystemCommandLineVersion>
+    <SystemCommandLineVersion>2.0.0-beta1.21079.2</SystemCommandLineVersion>
     <SystemDiagnosticsFileVersionInfoVersion>4.0.0</SystemDiagnosticsFileVersionInfoVersion>
     <SystemReflectionMetadataVersion>5.0.0</SystemReflectionMetadataVersion>
     <MicrosoftDotNetSignToolVersion>6.0.0-beta.21076.1</MicrosoftDotNetSignToolVersion>

--- a/src/Cli/dotnet/Parser.cs
+++ b/src/Cli/dotnet/Parser.cs
@@ -88,6 +88,12 @@ namespace Microsoft.DotNet.Cli
             return rootCommand;
         }
 
+        private static CommandLineBuilder DisablePosixBinding(this CommandLineBuilder builder)
+        {
+            builder.EnablePosixBundling = false;
+            return builder;
+        }
+
         public static System.CommandLine.Parsing.Parser Instance { get; } = new CommandLineBuilder(ConfigureCommandLine(RootCommand))
             .UseExceptionHandler(ExceptionHandler)
             .UseHelp()
@@ -95,6 +101,7 @@ namespace Microsoft.DotNet.Cli
             .UseValidationMessages(new CommandLineValidationMessages())
             .UseParseDirective()
             .UseSuggestDirective()
+            .DisablePosixBinding()
             .Build();
 
         private static void ExceptionHandler(Exception exception, InvocationContext context)
@@ -118,7 +125,7 @@ namespace Microsoft.DotNet.Cli
                 context.Console.Error.WriteLine(exception.ToString());
             }
             context.ParseResult.ShowHelp();
-            context.ResultCode = 1;
+            context.ExitCode = 1;
         }
 
         internal class CommandLineConsole : IConsole

--- a/src/Tests/dotnet.Tests/ParserTests/MSBuildArgumentCommandLineParserTests.cs
+++ b/src/Tests/dotnet.Tests/ParserTests/MSBuildArgumentCommandLineParserTests.cs
@@ -1,0 +1,39 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using FluentAssertions;
+using Microsoft.DotNet.Tools;
+using Microsoft.DotNet.Tools.Build;
+using Microsoft.DotNet.Tools.Publish;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.DotNet.Tests.CommandLineParserTests
+{
+    public class MSBuildArgumentCommandLineParserTests
+    {
+        private readonly ITestOutputHelper output;
+
+        public MSBuildArgumentCommandLineParserTests(ITestOutputHelper output)
+        {
+            this.output = output;
+        }
+
+        [Theory]
+        [InlineData(new string[] { "-property:prop1=true", "-p:prop2=false" }, true)]
+        [InlineData(new string[] { "-property:prop1=true", "-p:prop2=false" }, false)]
+        [InlineData(new string[] { "-detailedSummary" }, true)]
+        [InlineData(new string[] { "-clp:NoSummary" }, true)]
+        [InlineData(new string[] { "-orc" }, true)]
+        [InlineData(new string[] { "-orc" }, false)]
+        public void MSBuildArgumentsAreForwardedCorrectly(string[] arguments, bool buildCommand)
+        {
+            RestoringCommand command = buildCommand ? 
+                BuildCommand.FromArgs(arguments) : 
+                PublishCommand.FromArgs(arguments);
+            command.GetProcessStartInfo().Arguments.Split(' ')
+                .Should()
+                .Contain(arguments);
+        }
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/dotnet/sdk/issues/15351