### PR TITLE
Remove duplicated UsingTask declarations

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ILLink.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ILLink.targets
@@ -80,7 +80,6 @@ Copyright (c) .NET Foundation. All rights reserved.
     if the output semaphore file is out of date with respect to the inputs.
     ============================================================
     -->
-  <UsingTask TaskName="ILLink" AssemblyFile="$(ILLinkTasksAssembly)" />
   <Target Name="_RunILLink"
           DependsOnTargets="_ComputeManagedAssemblyToLink;PrepareForILLink"
           Inputs="$(MSBuildAllProjects);@(ManagedAssemblyToLink);@(TrimmerRootDescriptor);@(ReferencePath)"
@@ -227,7 +226,6 @@ Copyright (c) .NET Foundation. All rights reserved.
     Compute the set of inputs to the linker.
     ============================================================
     -->
-  <UsingTask TaskName="ComputeManagedAssemblies" AssemblyFile="$(ILLinkTasksAssembly)" />
   <Target Name="_ComputeManagedAssemblyToLink" DependsOnTargets="_ComputeAssembliesToPostprocessOnPublish">
 
     <!-- NB: There should not be non-managed assemblies in this list, but we still give the linker a chance to


### PR DESCRIPTION
These UsingTasks are already defined in the illink package: https://github.com/mono/linker/blob/17f809c257d10537a5773cbfbad87f3e741a6f2c/src/ILLink.Tasks/Sdk/Sdk.props#L22-L23