### PR TITLE
[release/5.0.1xx] Remove extra version property

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -75,7 +75,6 @@
     <!-- Dependencies from https://github.com/dotnet/runtime -->
     <SystemCodeDomPackageVersion>5.0.0</SystemCodeDomPackageVersion>
     <SystemTextEncodingCodePagesPackageVersion>5.0.0</SystemTextEncodingCodePagesPackageVersion>
-    <SystemSecurityCryptographyProtectedDataPackageVersion>5.0.0-preview.7.20307.4</SystemSecurityCryptographyProtectedDataPackageVersion>
     <SystemResourcesExtensionsPackageVersion>5.0.0</SystemResourcesExtensionsPackageVersion>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/WebSdk/Publish/Tasks/Tasks/MsDeploy/GetPassword.cs
+++ b/src/WebSdk/Publish/Tasks/Tasks/MsDeploy/GetPassword.cs
@@ -43,7 +43,9 @@ namespace Microsoft.NET.Sdk.Publish.Tasks.MsDeploy
             string plainPWD = "";
             try
             {
+#pragma warning disable CA1416 // This functionality is only expected to work in Windows.
                 Byte[] uncrypted = System.Security.Cryptography.ProtectedData.Unprotect(encryptedData, null, System.Security.Cryptography.DataProtectionScope.CurrentUser);
+#pragma warning restore CA1416 // This functionality is only expected to work in Windows.
                 plainPWD = Encoding.Unicode.GetString(uncrypted);
             }
             catch


### PR DESCRIPTION
This was causing System.Security.Cryptography to pin at preview7