### PR TITLE
add support for dotnet-watch to reload when server listening log is on a single line

### DIFF
--- a/src/BuiltInTools/dotnet-watch/LaunchBrowserFilter.cs
+++ b/src/BuiltInTools/dotnet-watch/LaunchBrowserFilter.cs
@@ -15,7 +15,7 @@ namespace Microsoft.DotNet.Watcher.Tools
 {
     public sealed class LaunchBrowserFilter : IWatchFilter, IAsyncDisposable
     {
-        private static readonly Regex NowListeningRegex = new Regex(@"^\s*Now listening on: (?<url>.*)$", RegexOptions.None | RegexOptions.Compiled, TimeSpan.FromSeconds(10));
+        private static readonly Regex NowListeningRegex = new Regex(@"\s*Now listening on: (?<url>.*)$", RegexOptions.None | RegexOptions.Compiled, TimeSpan.FromSeconds(10));
         private readonly bool _runningInTest;
         private readonly bool _suppressLaunchBrowser;
         private readonly bool _suppressBrowserRefresh;

--- a/src/BuiltInTools/dotnet-watch/LaunchBrowserFilter.cs
+++ b/src/BuiltInTools/dotnet-watch/LaunchBrowserFilter.cs
@@ -15,7 +15,7 @@ namespace Microsoft.DotNet.Watcher.Tools
 {
     public sealed class LaunchBrowserFilter : IWatchFilter, IAsyncDisposable
     {
-        private static readonly Regex NowListeningRegex = new Regex(@"\s*Now listening on: (?<url>.*)$", RegexOptions.None | RegexOptions.Compiled, TimeSpan.FromSeconds(10));
+        private static readonly Regex NowListeningRegex = new Regex(@"Now listening on: (?<url>.*)\s*$", RegexOptions.None | RegexOptions.Compiled, TimeSpan.FromSeconds(10));
         private readonly bool _runningInTest;
         private readonly bool _suppressLaunchBrowser;
         private readonly bool _suppressBrowserRefresh;


### PR DESCRIPTION
Fixes #15864 so `dotnet watch run`'s browser features works with Serilog OOB.

I was unable to figure out how to get a built version of `dotnet watch` running locally and I didn't see any tests for this file specifically.  However I verified using [RegEx101](https://regex101.com/) that it should work:

Before for Serilog:
![image](https://user-images.githubusercontent.com/10823939/107868474-3d4ca300-6e4a-11eb-94ed-7b39559101dd.png)

After for Serilog:
![image](https://user-images.githubusercontent.com/10823939/107868488-4ccbec00-6e4a-11eb-928a-5ff4fd215fdc.png)

And still works using the baked in logging...

Before for Microsoft.Extensions.Logging:
![image](https://user-images.githubusercontent.com/10823939/107868518-7f75e480-6e4a-11eb-9ce9-fb21a81e9da2.png)

After for M.E.L:
![image](https://user-images.githubusercontent.com/10823939/107868510-75ec7c80-6e4a-11eb-8317-ef8af697553b.png)
