### PR TITLE
[AspNetCore] Fix issue with static web assets when building referenced project from Visual Studio

### DIFF
--- a/src/RazorSdk/Targets/Microsoft.NET.Sdk.Razor.StaticWebAssets.targets
+++ b/src/RazorSdk/Targets/Microsoft.NET.Sdk.Razor.StaticWebAssets.targets
@@ -210,10 +210,11 @@ Copyright (c) .NET Foundation. All rights reserved.
       WebRootFiles="@(_WebRootFiles)" />
 
     <GenerateStaticWebAssetsManifest
+      Condition="'@(_ExternalStaticWebAsset->Count())' != '0'"
       ContentRootDefinitions="@(_ExternalStaticWebAsset)"
       TargetManifestPath="$(_GeneratedStaticWebAssetsDevelopmentManifest)" />
 
-    <ItemGroup>
+    <ItemGroup Condition="'@(_ExternalStaticWebAsset->Count())' != '0'">
       <FileWrites Include="$(_GeneratedStaticWebAssetsDevelopmentManifest)" />
     </ItemGroup>
 

--- a/src/RazorSdk/Targets/Microsoft.NET.Sdk.Razor.StaticWebAssets.targets
+++ b/src/RazorSdk/Targets/Microsoft.NET.Sdk.Razor.StaticWebAssets.targets
@@ -224,7 +224,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ItemGroup>
       <ContentWithTargetPath
         Include="$(_GeneratedStaticWebAssetsDevelopmentManifest)"
-        Condition="'@(_ExternalStaticWebAsset->Count())' != '0'">
+        Condition="Exists('$(_GeneratedStaticWebAssetsDevelopmentManifest)')">
         <Pack>false</Pack>
         <TargetPath>$(TargetName).StaticWebAssets.xml</TargetPath>
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/src/Tests/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsIntegrationTest.cs
+++ b/src/Tests/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsIntegrationTest.cs
@@ -168,7 +168,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
         }
 
         [Fact]
-        public void Build_DoesNotEmbedManifestWhen_NoStaticResourcesAvailable()
+        public void Build_DoesNotGenerateManifestWhen_NoStaticResourcesAvailable()
         {
             var testAsset = "RazorSimpleMvc";
             var projectDirectory = CreateAspNetSdkTestAsset(testAsset);
@@ -179,8 +179,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             var intermediateOutputPath = build.GetIntermediateDirectory(DefaultTfm, "Debug").ToString();
             var outputPath = build.GetOutputDirectory(DefaultTfm, "Debug").ToString();
 
-            // GenerateStaticWebAssetsManifest should generate the manifest and the cache.
-            new FileInfo(Path.Combine(intermediateOutputPath, "staticwebassets", "SimpleMvc.StaticWebAssets.xml")).Should().Exist();
+            // GenerateStaticWebAssetsManifest should generate the manifest.
             new FileInfo(Path.Combine(intermediateOutputPath, "staticwebassets", "SimpleMvc.StaticWebAssets.Manifest.cache")).Should().Exist();
             new FileInfo(Path.Combine(outputPath, "SimpleMvc.StaticWebAssets.xml")).Should().NotExist();
 


### PR DESCRIPTION
The updated condition was looking for the existence of external static
web assets.

In some invocations of the build that is not true when Visual Studio invokes
the target on the project in some circumstances and as a result the manifest
was not being included in the output of the referenced project.

The update changes the condition to just check for the existence of the
file on disk to include it. Given that the file only gets generated as
part of PrepareForRun, it picks up the output from the last build, which
is what we expect.