### PR TITLE
Allow runtime packs to not be downloaded

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/ProcessFrameworkReferences.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ProcessFrameworkReferences.cs
@@ -52,6 +52,8 @@ namespace Microsoft.NET.Build.Tasks
 
         public bool EnableTargetingPackDownload { get; set; }
 
+        public bool EnableRuntimePackDownload { get; set; }
+
         public ITaskItem[] FrameworkReferences { get; set; } = Array.Empty<ITaskItem>();
 
         public ITaskItem[] KnownFrameworkReferences { get; set; } = Array.Empty<ITaskItem>();
@@ -286,7 +288,7 @@ namespace Microsoft.NET.Build.Tasks
                     }
 
                     ProcessRuntimeIdentifier(hasRuntimePackAlwaysCopyLocal ? "any" : RuntimeIdentifier, runtimePackForRuntimeIDProcessing, runtimePackVersion, additionalFrameworkReferencesForRuntimePack,
-                        unrecognizedRuntimeIdentifiers, unavailableRuntimePacks, runtimePacks, packagesToDownload, isTrimmable, includeInPackageDownload);
+                        unrecognizedRuntimeIdentifiers, unavailableRuntimePacks, runtimePacks, packagesToDownload, isTrimmable, EnableRuntimePackDownload && includeInPackageDownload);
 
                     processedPrimaryRuntimeIdentifier = true;
                 }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets
@@ -48,8 +48,9 @@ Copyright (c) .NET Foundation. All rights reserved.
       <FrameworkReference Include="@(_FrameworkReferenceToAdd)" />
     </ItemGroup>
 
-    <PropertyGroup Condition="'$(EnableTargetingPackDownload)' == ''">
-      <EnableTargetingPackDownload>true</EnableTargetingPackDownload>
+    <PropertyGroup>
+      <EnableTargetingPackDownload Condition="'$(EnableTargetingPackDownload)' == ''">true</EnableTargetingPackDownload>
+      <EnableRuntimePackDownload Condition="'$(EnableRuntimePackDownload)' == ''">true</EnableRuntimePackDownload>
     </PropertyGroup>
 
     <PropertyGroup>
@@ -78,6 +79,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                                 TargetLatestRuntimePatch="$(TargetLatestRuntimePatch)"
                                 TargetLatestRuntimePatchIsDefault="$(_TargetLatestRuntimePatchIsDefault)"
                                 EnableTargetingPackDownload="$(EnableTargetingPackDownload)"
+                                EnableRuntimePackDownload="$(EnableRuntimePackDownload)"
                                 KnownCrossgen2Packs="@(KnownCrossgen2Pack)"
                                 NETCoreSdkRuntimeIdentifier="$(NETCoreSdkRuntimeIdentifier)">
 


### PR DESCRIPTION
Simliar to the EnableTargetingPackDownload property,
EnableRuntimePackDownload controls if a runtime pack is downloaded (i.e.
when a RuntimeIdentifier is specified.)

Fixes https://github.com/dotnet/sdk/issues/14926