### PR TITLE
blazor-wasm: Fix dest path when copying versioned dotnet.js

### DIFF
--- a/src/BlazorWasmSdk/Targets/Microsoft.NET.Sdk.BlazorWebAssembly.Current.targets
+++ b/src/BlazorWasmSdk/Targets/Microsoft.NET.Sdk.BlazorWebAssembly.Current.targets
@@ -567,7 +567,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       But first, mangle the AOTed dotnet.js file to include the runtime version.
     -->
 
-    <Copy SourceFiles="@(WasmNativeAsset)" DestinationFiles="%(WasmNativeAsset.Directory)\dotnet.$(_DotNetJsVersion).js" Condition="%(FileName) == 'dotnet' AND %(Extension) == '.js'">
+    <Copy SourceFiles="@(WasmNativeAsset)" DestinationFiles="%(RootDir)%(Directory)\dotnet.$(_DotNetJsVersion).js" Condition="%(FileName) == 'dotnet' AND %(Extension) == '.js'">
       <Output TaskParameter="CopiedFiles" ItemName="_PublishAotDotnetJsFile" />
     </Copy>
 


### PR DESCRIPTION
Without this, instead of the path being `/Users/foo/..`, it is
`Users/foo/..`, which then creates that directory tree under the project
directory, and copies the file there.