### PR TITLE
Correctly handle `$(InvariantGlobalization)='false'`

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -417,7 +417,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                                     Value="$(RetainVMGarbageCollection)" />
 
     <RuntimeHostConfigurationOption Include="System.Globalization.Invariant"
-                                    Condition="'$(InvariantGlobalization)' != ''"
+                                    Condition="'$(InvariantGlobalization)' == 'true'"
                                     Value="$(InvariantGlobalization)"
                                     Trim="true" />
 


### PR DESCRIPTION
In `Microsoft.NET.Sdk.targets`:

```xml
     <RuntimeHostConfigurationOption Include="System.Globalization.Invariant"
                                    Condition="'$(InvariantGlobalization)' != ''"
                                     Value="$(InvariantGlobalization)"
                                     Trim="true" />
```

The above is intended to include `System.Globalization.Invariant`, if
`$(InvariantGlobalization)` is false. The default value should be false,
and is treated as such in it's usage. But the condition here will cause
this to be included as long as the property is non-empty, so, same
behavior for `'true'` or `'false'`.

The change here fixes the empty value to behave the same as `'false'`.

For background:
This manifested in blazorwasm workload testing, because blazorwasm
explicitly sets the property to `'false'`, which (correctly) caused the icu
bits to be linked out. And due to a bug[1] the icu detection code got linked
out too, causing:

```
blazor.webassembly.js:1 Assertion failed: Cannot call unknown function mono_wasm_load_icu_data, make sure it is exported
....
blazor.webassembly.js:1 Uncaught (in promise) RuntimeError: abort(Assertion failed: Cannot call unknown function mono_wasm_load_icu_data, make sure it is exported). Build with -s ASSERTIONS=1 for more inf
```

--
1. Fix for the bug: https://github.com/dotnet/runtime/pull/48550
