### PR TITLE
Fix: dotnet-new locale is not correctly set

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-new/NewCommandShim.cs
+++ b/src/Cli/dotnet/commands/dotnet-new/NewCommandShim.cs
@@ -81,7 +81,7 @@ namespace Microsoft.DotNet.Tools.New
                 { "NetStandardImplicitPackageVersion", new FrameworkDependencyFile().GetNetStandardLibraryVersion() },
             };
 
-            return new DefaultTemplateEngineHost(HostIdentifier, "v" + Product.Version, CultureInfo.CurrentCulture.Name, preferences, builtIns);
+            return new DefaultTemplateEngineHost(HostIdentifier, "v" + Product.Version, CultureInfo.CurrentUICulture.Name, preferences, builtIns);
         }
 
         private static void FirstRun(IEngineEnvironmentSettings environmentSettings, IInstaller installer)


### PR DESCRIPTION
Currently, template engine host gets the `CultureInfo.CurrentCulture` during initialization. This respects the user's locale, but it won't be overwritten by `DOTNET_CLI_UI_LANGUAGE` environment settings which is only reflected onto `CultureInfo.CurrentUICulture`.

This PR updates the TE host constructor invocation to use `CurrentUICulture` so that template engine will run with correct locale.