### PR TITLE
[NO-MERGE] SDK dependency update with fix

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -30,41 +30,41 @@
       <Uri>https://github.com/dotnet/templating</Uri>
       <Sha>e9be440fd5a04e167c622715b7a920f5cf73aa78</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Ref" Version="6.0.0-preview.2.21118.6">
+    <Dependency Name="Microsoft.NETCore.App.Ref" Version="6.0.0-preview.2.21119.11">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>3e85099234a06ff36915b0c11289bcfe6787fc66</Sha>
+      <Sha>064a4a3dc37d39f9761b9750c98c8f09cbbf62a1</Sha>
     </Dependency>
-    <Dependency Name="VS.Redist.Common.NetCore.SharedFramework.x64.6.0" Version="6.0.0-preview.2.21118.6">
+    <Dependency Name="VS.Redist.Common.NetCore.SharedFramework.x64.6.0" Version="6.0.0-preview.2.21119.11">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>3e85099234a06ff36915b0c11289bcfe6787fc66</Sha>
+      <Sha>064a4a3dc37d39f9761b9750c98c8f09cbbf62a1</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="6.0.0-preview.2.21118.6">
+    <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="6.0.0-preview.2.21119.11">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>3e85099234a06ff36915b0c11289bcfe6787fc66</Sha>
+      <Sha>064a4a3dc37d39f9761b9750c98c8f09cbbf62a1</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Host.win-x64" Version="6.0.0-preview.2.21118.6">
+    <Dependency Name="Microsoft.NETCore.App.Host.win-x64" Version="6.0.0-preview.2.21119.11">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>3e85099234a06ff36915b0c11289bcfe6787fc66</Sha>
+      <Sha>064a4a3dc37d39f9761b9750c98c8f09cbbf62a1</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.Platforms" Version="6.0.0-preview.2.21118.6">
+    <Dependency Name="Microsoft.NETCore.Platforms" Version="6.0.0-preview.2.21119.11">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>3e85099234a06ff36915b0c11289bcfe6787fc66</Sha>
+      <Sha>064a4a3dc37d39f9761b9750c98c8f09cbbf62a1</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="6.0.0-beta.21081.1">
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>f6ed3308865528c56ed26b85004121fce56bf4f4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.HostModel" Version="6.0.0-preview.2.21118.6">
+    <Dependency Name="Microsoft.NET.HostModel" Version="6.0.0-preview.2.21119.11">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>3e85099234a06ff36915b0c11289bcfe6787fc66</Sha>
+      <Sha>064a4a3dc37d39f9761b9750c98c8f09cbbf62a1</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.DependencyModel" Version="6.0.0-preview.2.21118.6">
+    <Dependency Name="Microsoft.Extensions.DependencyModel" Version="6.0.0-preview.2.21119.11">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>3e85099234a06ff36915b0c11289bcfe6787fc66</Sha>
+      <Sha>064a4a3dc37d39f9761b9750c98c8f09cbbf62a1</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.DotNetHostResolver" Version="6.0.0-preview.2.21118.6">
+    <Dependency Name="Microsoft.NETCore.DotNetHostResolver" Version="6.0.0-preview.2.21119.11">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>3e85099234a06ff36915b0c11289bcfe6787fc66</Sha>
+      <Sha>064a4a3dc37d39f9761b9750c98c8f09cbbf62a1</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.Cli.CommandLine" Version="1.0.0-preview.19208.1">
       <Uri>https://github.com/dotnet/CliCommandLineParser</Uri>
@@ -110,21 +110,21 @@
       <Uri>https://github.com/mono/linker</Uri>
       <Sha>422f2f710707c1cf95dd513022c8fbef19f177dc</Sha>
     </Dependency>
-    <Dependency Name="System.CodeDom" Version="6.0.0-preview.2.21118.6">
+    <Dependency Name="System.CodeDom" Version="6.0.0-preview.2.21119.11">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>3e85099234a06ff36915b0c11289bcfe6787fc66</Sha>
+      <Sha>064a4a3dc37d39f9761b9750c98c8f09cbbf62a1</Sha>
     </Dependency>
-    <Dependency Name="System.Security.Cryptography.ProtectedData" Version="6.0.0-preview.2.21118.6">
+    <Dependency Name="System.Security.Cryptography.ProtectedData" Version="6.0.0-preview.2.21119.11">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>3e85099234a06ff36915b0c11289bcfe6787fc66</Sha>
+      <Sha>064a4a3dc37d39f9761b9750c98c8f09cbbf62a1</Sha>
     </Dependency>
-    <Dependency Name="System.Text.Encoding.CodePages" Version="6.0.0-preview.2.21118.6">
+    <Dependency Name="System.Text.Encoding.CodePages" Version="6.0.0-preview.2.21119.11">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>3e85099234a06ff36915b0c11289bcfe6787fc66</Sha>
+      <Sha>064a4a3dc37d39f9761b9750c98c8f09cbbf62a1</Sha>
     </Dependency>
-    <Dependency Name="System.Resources.Extensions" Version="6.0.0-preview.2.21118.6">
+    <Dependency Name="System.Resources.Extensions" Version="6.0.0-preview.2.21119.11">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>3e85099234a06ff36915b0c11289bcfe6787fc66</Sha>
+      <Sha>064a4a3dc37d39f9761b9750c98c8f09cbbf62a1</Sha>
     </Dependency>
     <Dependency Name="Microsoft.WindowsDesktop.App.Runtime.win-x64" Version="6.0.0-preview.3.21122.9">
       <Uri>https://github.com/dotnet/windowsdesktop</Uri>
@@ -224,9 +224,9 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>2b430e5bbfaec37a6cead2f0cf79157f01f1a623</Sha>
     </Dependency>
-    <Dependency Name="System.Reflection.MetadataLoadContext" Version="6.0.0-preview.2.21118.6">
+    <Dependency Name="System.Reflection.MetadataLoadContext" Version="6.0.0-preview.2.21119.11">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>3e85099234a06ff36915b0c11289bcfe6787fc66</Sha>
+      <Sha>064a4a3dc37d39f9761b9750c98c8f09cbbf62a1</Sha>
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -30,41 +30,41 @@
       <Uri>https://github.com/dotnet/templating</Uri>
       <Sha>e9be440fd5a04e167c622715b7a920f5cf73aa78</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Ref" Version="6.0.0-preview.2.21119.11">
+    <Dependency Name="Microsoft.NETCore.App.Ref" Version="6.0.0-preview.2.21120.6">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>064a4a3dc37d39f9761b9750c98c8f09cbbf62a1</Sha>
+      <Sha>a350bc6e0896d2869e4028fdafb94588e3fe0867</Sha>
     </Dependency>
-    <Dependency Name="VS.Redist.Common.NetCore.SharedFramework.x64.6.0" Version="6.0.0-preview.2.21119.11">
+    <Dependency Name="VS.Redist.Common.NetCore.SharedFramework.x64.6.0" Version="6.0.0-preview.2.21120.6">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>064a4a3dc37d39f9761b9750c98c8f09cbbf62a1</Sha>
+      <Sha>a350bc6e0896d2869e4028fdafb94588e3fe0867</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="6.0.0-preview.2.21119.11">
+    <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="6.0.0-preview.2.21120.6">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>064a4a3dc37d39f9761b9750c98c8f09cbbf62a1</Sha>
+      <Sha>a350bc6e0896d2869e4028fdafb94588e3fe0867</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Host.win-x64" Version="6.0.0-preview.2.21119.11">
+    <Dependency Name="Microsoft.NETCore.App.Host.win-x64" Version="6.0.0-preview.2.21120.6">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>064a4a3dc37d39f9761b9750c98c8f09cbbf62a1</Sha>
+      <Sha>a350bc6e0896d2869e4028fdafb94588e3fe0867</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.Platforms" Version="6.0.0-preview.2.21119.11">
+    <Dependency Name="Microsoft.NETCore.Platforms" Version="6.0.0-preview.2.21120.6">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>064a4a3dc37d39f9761b9750c98c8f09cbbf62a1</Sha>
+      <Sha>a350bc6e0896d2869e4028fdafb94588e3fe0867</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="6.0.0-beta.21081.1">
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>f6ed3308865528c56ed26b85004121fce56bf4f4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.HostModel" Version="6.0.0-preview.2.21119.11">
+    <Dependency Name="Microsoft.NET.HostModel" Version="6.0.0-preview.2.21120.6">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>064a4a3dc37d39f9761b9750c98c8f09cbbf62a1</Sha>
+      <Sha>a350bc6e0896d2869e4028fdafb94588e3fe0867</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.DependencyModel" Version="6.0.0-preview.2.21119.11">
+    <Dependency Name="Microsoft.Extensions.DependencyModel" Version="6.0.0-preview.2.21120.6">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>064a4a3dc37d39f9761b9750c98c8f09cbbf62a1</Sha>
+      <Sha>a350bc6e0896d2869e4028fdafb94588e3fe0867</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.DotNetHostResolver" Version="6.0.0-preview.2.21119.11">
+    <Dependency Name="Microsoft.NETCore.DotNetHostResolver" Version="6.0.0-preview.2.21120.6">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>064a4a3dc37d39f9761b9750c98c8f09cbbf62a1</Sha>
+      <Sha>a350bc6e0896d2869e4028fdafb94588e3fe0867</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.Cli.CommandLine" Version="1.0.0-preview.19208.1">
       <Uri>https://github.com/dotnet/CliCommandLineParser</Uri>
@@ -110,21 +110,21 @@
       <Uri>https://github.com/mono/linker</Uri>
       <Sha>422f2f710707c1cf95dd513022c8fbef19f177dc</Sha>
     </Dependency>
-    <Dependency Name="System.CodeDom" Version="6.0.0-preview.2.21119.11">
+    <Dependency Name="System.CodeDom" Version="6.0.0-preview.2.21120.6">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>064a4a3dc37d39f9761b9750c98c8f09cbbf62a1</Sha>
+      <Sha>a350bc6e0896d2869e4028fdafb94588e3fe0867</Sha>
     </Dependency>
-    <Dependency Name="System.Security.Cryptography.ProtectedData" Version="6.0.0-preview.2.21119.11">
+    <Dependency Name="System.Security.Cryptography.ProtectedData" Version="6.0.0-preview.2.21120.6">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>064a4a3dc37d39f9761b9750c98c8f09cbbf62a1</Sha>
+      <Sha>a350bc6e0896d2869e4028fdafb94588e3fe0867</Sha>
     </Dependency>
-    <Dependency Name="System.Text.Encoding.CodePages" Version="6.0.0-preview.2.21119.11">
+    <Dependency Name="System.Text.Encoding.CodePages" Version="6.0.0-preview.2.21120.6">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>064a4a3dc37d39f9761b9750c98c8f09cbbf62a1</Sha>
+      <Sha>a350bc6e0896d2869e4028fdafb94588e3fe0867</Sha>
     </Dependency>
-    <Dependency Name="System.Resources.Extensions" Version="6.0.0-preview.2.21119.11">
+    <Dependency Name="System.Resources.Extensions" Version="6.0.0-preview.2.21120.6">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>064a4a3dc37d39f9761b9750c98c8f09cbbf62a1</Sha>
+      <Sha>a350bc6e0896d2869e4028fdafb94588e3fe0867</Sha>
     </Dependency>
     <Dependency Name="Microsoft.WindowsDesktop.App.Runtime.win-x64" Version="6.0.0-preview.3.21122.9">
       <Uri>https://github.com/dotnet/windowsdesktop</Uri>
@@ -224,9 +224,9 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>2b430e5bbfaec37a6cead2f0cf79157f01f1a623</Sha>
     </Dependency>
-    <Dependency Name="System.Reflection.MetadataLoadContext" Version="6.0.0-preview.2.21119.11">
+    <Dependency Name="System.Reflection.MetadataLoadContext" Version="6.0.0-preview.2.21120.6">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>064a4a3dc37d39f9761b9750c98c8f09cbbf62a1</Sha>
+      <Sha>a350bc6e0896d2869e4028fdafb94588e3fe0867</Sha>
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -30,41 +30,41 @@
       <Uri>https://github.com/dotnet/templating</Uri>
       <Sha>e9be440fd5a04e167c622715b7a920f5cf73aa78</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Ref" Version="6.0.0-preview.3.21121.7">
+    <Dependency Name="Microsoft.NETCore.App.Ref" Version="6.0.0-preview.3.21123.2">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>49cfb3507c586b539d0652814defbbc9e3073f16</Sha>
+      <Sha>b121bcacec60f10b316b25eb9d0b7113599bc508</Sha>
     </Dependency>
-    <Dependency Name="VS.Redist.Common.NetCore.SharedFramework.x64.6.0" Version="6.0.0-preview.3.21121.7">
+    <Dependency Name="VS.Redist.Common.NetCore.SharedFramework.x64.6.0" Version="6.0.0-preview.3.21123.2">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>49cfb3507c586b539d0652814defbbc9e3073f16</Sha>
+      <Sha>b121bcacec60f10b316b25eb9d0b7113599bc508</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="6.0.0-preview.3.21121.7">
+    <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="6.0.0-preview.3.21123.2">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>49cfb3507c586b539d0652814defbbc9e3073f16</Sha>
+      <Sha>b121bcacec60f10b316b25eb9d0b7113599bc508</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Host.win-x64" Version="6.0.0-preview.3.21121.7">
+    <Dependency Name="Microsoft.NETCore.App.Host.win-x64" Version="6.0.0-preview.3.21123.2">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>49cfb3507c586b539d0652814defbbc9e3073f16</Sha>
+      <Sha>b121bcacec60f10b316b25eb9d0b7113599bc508</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.Platforms" Version="6.0.0-preview.3.21121.7">
+    <Dependency Name="Microsoft.NETCore.Platforms" Version="6.0.0-preview.3.21123.2">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>49cfb3507c586b539d0652814defbbc9e3073f16</Sha>
+      <Sha>b121bcacec60f10b316b25eb9d0b7113599bc508</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="6.0.0-beta.21081.1">
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>f6ed3308865528c56ed26b85004121fce56bf4f4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.HostModel" Version="6.0.0-preview.3.21121.7">
+    <Dependency Name="Microsoft.NET.HostModel" Version="6.0.0-preview.3.21123.2">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>49cfb3507c586b539d0652814defbbc9e3073f16</Sha>
+      <Sha>b121bcacec60f10b316b25eb9d0b7113599bc508</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.DependencyModel" Version="6.0.0-preview.3.21121.7">
+    <Dependency Name="Microsoft.Extensions.DependencyModel" Version="6.0.0-preview.3.21123.2">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>49cfb3507c586b539d0652814defbbc9e3073f16</Sha>
+      <Sha>b121bcacec60f10b316b25eb9d0b7113599bc508</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.DotNetHostResolver" Version="6.0.0-preview.3.21121.7">
+    <Dependency Name="Microsoft.NETCore.DotNetHostResolver" Version="6.0.0-preview.3.21123.2">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>49cfb3507c586b539d0652814defbbc9e3073f16</Sha>
+      <Sha>b121bcacec60f10b316b25eb9d0b7113599bc508</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.Cli.CommandLine" Version="1.0.0-preview.19208.1">
       <Uri>https://github.com/dotnet/CliCommandLineParser</Uri>
@@ -110,21 +110,21 @@
       <Uri>https://github.com/mono/linker</Uri>
       <Sha>422f2f710707c1cf95dd513022c8fbef19f177dc</Sha>
     </Dependency>
-    <Dependency Name="System.CodeDom" Version="6.0.0-preview.3.21121.7">
+    <Dependency Name="System.CodeDom" Version="6.0.0-preview.3.21123.2">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>49cfb3507c586b539d0652814defbbc9e3073f16</Sha>
+      <Sha>b121bcacec60f10b316b25eb9d0b7113599bc508</Sha>
     </Dependency>
-    <Dependency Name="System.Security.Cryptography.ProtectedData" Version="6.0.0-preview.3.21121.7">
+    <Dependency Name="System.Security.Cryptography.ProtectedData" Version="6.0.0-preview.3.21123.2">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>49cfb3507c586b539d0652814defbbc9e3073f16</Sha>
+      <Sha>b121bcacec60f10b316b25eb9d0b7113599bc508</Sha>
     </Dependency>
-    <Dependency Name="System.Text.Encoding.CodePages" Version="6.0.0-preview.3.21121.7">
+    <Dependency Name="System.Text.Encoding.CodePages" Version="6.0.0-preview.3.21123.2">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>49cfb3507c586b539d0652814defbbc9e3073f16</Sha>
+      <Sha>b121bcacec60f10b316b25eb9d0b7113599bc508</Sha>
     </Dependency>
-    <Dependency Name="System.Resources.Extensions" Version="6.0.0-preview.3.21121.7">
+    <Dependency Name="System.Resources.Extensions" Version="6.0.0-preview.3.21123.2">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>49cfb3507c586b539d0652814defbbc9e3073f16</Sha>
+      <Sha>b121bcacec60f10b316b25eb9d0b7113599bc508</Sha>
     </Dependency>
     <Dependency Name="Microsoft.WindowsDesktop.App.Runtime.win-x64" Version="6.0.0-preview.3.21122.9">
       <Uri>https://github.com/dotnet/windowsdesktop</Uri>
@@ -224,9 +224,9 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>2b430e5bbfaec37a6cead2f0cf79157f01f1a623</Sha>
     </Dependency>
-    <Dependency Name="System.Reflection.MetadataLoadContext" Version="6.0.0-preview.3.21121.7">
+    <Dependency Name="System.Reflection.MetadataLoadContext" Version="6.0.0-preview.3.21123.2">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>49cfb3507c586b539d0652814defbbc9e3073f16</Sha>
+      <Sha>b121bcacec60f10b316b25eb9d0b7113599bc508</Sha>
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -30,41 +30,41 @@
       <Uri>https://github.com/dotnet/templating</Uri>
       <Sha>e9be440fd5a04e167c622715b7a920f5cf73aa78</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Ref" Version="6.0.0-preview.2.21120.6">
+    <Dependency Name="Microsoft.NETCore.App.Ref" Version="6.0.0-preview.3.21121.7">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>a350bc6e0896d2869e4028fdafb94588e3fe0867</Sha>
+      <Sha>49cfb3507c586b539d0652814defbbc9e3073f16</Sha>
     </Dependency>
-    <Dependency Name="VS.Redist.Common.NetCore.SharedFramework.x64.6.0" Version="6.0.0-preview.2.21120.6">
+    <Dependency Name="VS.Redist.Common.NetCore.SharedFramework.x64.6.0" Version="6.0.0-preview.3.21121.7">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>a350bc6e0896d2869e4028fdafb94588e3fe0867</Sha>
+      <Sha>49cfb3507c586b539d0652814defbbc9e3073f16</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="6.0.0-preview.2.21120.6">
+    <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="6.0.0-preview.3.21121.7">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>a350bc6e0896d2869e4028fdafb94588e3fe0867</Sha>
+      <Sha>49cfb3507c586b539d0652814defbbc9e3073f16</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Host.win-x64" Version="6.0.0-preview.2.21120.6">
+    <Dependency Name="Microsoft.NETCore.App.Host.win-x64" Version="6.0.0-preview.3.21121.7">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>a350bc6e0896d2869e4028fdafb94588e3fe0867</Sha>
+      <Sha>49cfb3507c586b539d0652814defbbc9e3073f16</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.Platforms" Version="6.0.0-preview.2.21120.6">
+    <Dependency Name="Microsoft.NETCore.Platforms" Version="6.0.0-preview.3.21121.7">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>a350bc6e0896d2869e4028fdafb94588e3fe0867</Sha>
+      <Sha>49cfb3507c586b539d0652814defbbc9e3073f16</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="6.0.0-beta.21081.1">
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>f6ed3308865528c56ed26b85004121fce56bf4f4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.HostModel" Version="6.0.0-preview.2.21120.6">
+    <Dependency Name="Microsoft.NET.HostModel" Version="6.0.0-preview.3.21121.7">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>a350bc6e0896d2869e4028fdafb94588e3fe0867</Sha>
+      <Sha>49cfb3507c586b539d0652814defbbc9e3073f16</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.DependencyModel" Version="6.0.0-preview.2.21120.6">
+    <Dependency Name="Microsoft.Extensions.DependencyModel" Version="6.0.0-preview.3.21121.7">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>a350bc6e0896d2869e4028fdafb94588e3fe0867</Sha>
+      <Sha>49cfb3507c586b539d0652814defbbc9e3073f16</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.DotNetHostResolver" Version="6.0.0-preview.2.21120.6">
+    <Dependency Name="Microsoft.NETCore.DotNetHostResolver" Version="6.0.0-preview.3.21121.7">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>a350bc6e0896d2869e4028fdafb94588e3fe0867</Sha>
+      <Sha>49cfb3507c586b539d0652814defbbc9e3073f16</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.Cli.CommandLine" Version="1.0.0-preview.19208.1">
       <Uri>https://github.com/dotnet/CliCommandLineParser</Uri>
@@ -110,21 +110,21 @@
       <Uri>https://github.com/mono/linker</Uri>
       <Sha>422f2f710707c1cf95dd513022c8fbef19f177dc</Sha>
     </Dependency>
-    <Dependency Name="System.CodeDom" Version="6.0.0-preview.2.21120.6">
+    <Dependency Name="System.CodeDom" Version="6.0.0-preview.3.21121.7">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>a350bc6e0896d2869e4028fdafb94588e3fe0867</Sha>
+      <Sha>49cfb3507c586b539d0652814defbbc9e3073f16</Sha>
     </Dependency>
-    <Dependency Name="System.Security.Cryptography.ProtectedData" Version="6.0.0-preview.2.21120.6">
+    <Dependency Name="System.Security.Cryptography.ProtectedData" Version="6.0.0-preview.3.21121.7">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>a350bc6e0896d2869e4028fdafb94588e3fe0867</Sha>
+      <Sha>49cfb3507c586b539d0652814defbbc9e3073f16</Sha>
     </Dependency>
-    <Dependency Name="System.Text.Encoding.CodePages" Version="6.0.0-preview.2.21120.6">
+    <Dependency Name="System.Text.Encoding.CodePages" Version="6.0.0-preview.3.21121.7">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>a350bc6e0896d2869e4028fdafb94588e3fe0867</Sha>
+      <Sha>49cfb3507c586b539d0652814defbbc9e3073f16</Sha>
     </Dependency>
-    <Dependency Name="System.Resources.Extensions" Version="6.0.0-preview.2.21120.6">
+    <Dependency Name="System.Resources.Extensions" Version="6.0.0-preview.3.21121.7">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>a350bc6e0896d2869e4028fdafb94588e3fe0867</Sha>
+      <Sha>49cfb3507c586b539d0652814defbbc9e3073f16</Sha>
     </Dependency>
     <Dependency Name="Microsoft.WindowsDesktop.App.Runtime.win-x64" Version="6.0.0-preview.3.21122.9">
       <Uri>https://github.com/dotnet/windowsdesktop</Uri>
@@ -224,9 +224,9 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>2b430e5bbfaec37a6cead2f0cf79157f01f1a623</Sha>
     </Dependency>
-    <Dependency Name="System.Reflection.MetadataLoadContext" Version="6.0.0-preview.2.21120.6">
+    <Dependency Name="System.Reflection.MetadataLoadContext" Version="6.0.0-preview.3.21121.7">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>a350bc6e0896d2869e4028fdafb94588e3fe0867</Sha>
+      <Sha>49cfb3507c586b539d0652814defbbc9e3073f16</Sha>
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -31,22 +31,22 @@
     <SystemReflectionMetadataVersion>5.0.0</SystemReflectionMetadataVersion>
     <MicrosoftDotNetSignToolVersion>6.0.0-beta.21101.7</MicrosoftDotNetSignToolVersion>
     <MicrosoftWebXdtPackageVersion>3.1.0</MicrosoftWebXdtPackageVersion>
-    <SystemSecurityCryptographyProtectedDataPackageVersion>6.0.0-preview.2.21119.11</SystemSecurityCryptographyProtectedDataPackageVersion>
+    <SystemSecurityCryptographyProtectedDataPackageVersion>6.0.0-preview.2.21120.6</SystemSecurityCryptographyProtectedDataPackageVersion>
     <SystemCollectionsSpecializedPackageVersion>4.3.0</SystemCollectionsSpecializedPackageVersion>
     <SystemXmlXmlDocumentPackageVersion>4.3.0</SystemXmlXmlDocumentPackageVersion>
     <WebDeploymentPackageVersion>4.0.5</WebDeploymentPackageVersion>
     <SystemTextJsonVersion>4.7.2</SystemTextJsonVersion>
-    <SystemReflectionMetadataLoadContextVersion>6.0.0-preview.2.21119.11</SystemReflectionMetadataLoadContextVersion>
+    <SystemReflectionMetadataLoadContextVersion>6.0.0-preview.2.21120.6</SystemReflectionMetadataLoadContextVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/runtime -->
-    <MicrosoftNETCoreAppRefPackageVersion>6.0.0-preview.2.21119.11</MicrosoftNETCoreAppRefPackageVersion>
-    <VSRedistCommonNetCoreSharedFrameworkx6460PackageVersion>6.0.0-preview.2.21119.11</VSRedistCommonNetCoreSharedFrameworkx6460PackageVersion>
-    <MicrosoftNETCoreAppRuntimewinx64PackageVersion>6.0.0-preview.2.21119.11</MicrosoftNETCoreAppRuntimewinx64PackageVersion>
+    <MicrosoftNETCoreAppRefPackageVersion>6.0.0-preview.2.21120.6</MicrosoftNETCoreAppRefPackageVersion>
+    <VSRedistCommonNetCoreSharedFrameworkx6460PackageVersion>6.0.0-preview.2.21120.6</VSRedistCommonNetCoreSharedFrameworkx6460PackageVersion>
+    <MicrosoftNETCoreAppRuntimewinx64PackageVersion>6.0.0-preview.2.21120.6</MicrosoftNETCoreAppRuntimewinx64PackageVersion>
     <MicrosoftNETCoreAppRuntimePackageVersion>$(MicrosoftNETCoreAppRuntimewinx64PackageVersion)</MicrosoftNETCoreAppRuntimePackageVersion>
-    <MicrosoftExtensionsDependencyModelPackageVersion>6.0.0-preview.2.21119.11</MicrosoftExtensionsDependencyModelPackageVersion>
-    <MicrosoftNETCoreDotNetHostResolverPackageVersion>6.0.0-preview.2.21119.11</MicrosoftNETCoreDotNetHostResolverPackageVersion>
-    <MicrosoftNETHostModelVersion>6.0.0-preview.2.21119.11</MicrosoftNETHostModelVersion>
+    <MicrosoftExtensionsDependencyModelPackageVersion>6.0.0-preview.2.21120.6</MicrosoftExtensionsDependencyModelPackageVersion>
+    <MicrosoftNETCoreDotNetHostResolverPackageVersion>6.0.0-preview.2.21120.6</MicrosoftNETCoreDotNetHostResolverPackageVersion>
+    <MicrosoftNETHostModelVersion>6.0.0-preview.2.21120.6</MicrosoftNETHostModelVersion>
     <MicrosoftExtensionsDependencyModelVersion>$(MicrosoftExtensionsDependencyModelPackageVersion)</MicrosoftExtensionsDependencyModelVersion>
   </PropertyGroup>
   <PropertyGroup>
@@ -78,10 +78,10 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/runtime -->
-    <SystemCodeDomPackageVersion>6.0.0-preview.2.21119.11</SystemCodeDomPackageVersion>
-    <SystemTextEncodingCodePagesPackageVersion>6.0.0-preview.2.21119.11</SystemTextEncodingCodePagesPackageVersion>
+    <SystemCodeDomPackageVersion>6.0.0-preview.2.21120.6</SystemCodeDomPackageVersion>
+    <SystemTextEncodingCodePagesPackageVersion>6.0.0-preview.2.21120.6</SystemTextEncodingCodePagesPackageVersion>
     <SystemSecurityCryptographyProtectedDataPackageVersion>5.0.0-preview.7.20307.4</SystemSecurityCryptographyProtectedDataPackageVersion>
-    <SystemResourcesExtensionsPackageVersion>6.0.0-preview.2.21119.11</SystemResourcesExtensionsPackageVersion>
+    <SystemResourcesExtensionsPackageVersion>6.0.0-preview.2.21120.6</SystemResourcesExtensionsPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/roslyn-analyzers -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -31,22 +31,22 @@
     <SystemReflectionMetadataVersion>5.0.0</SystemReflectionMetadataVersion>
     <MicrosoftDotNetSignToolVersion>6.0.0-beta.21101.7</MicrosoftDotNetSignToolVersion>
     <MicrosoftWebXdtPackageVersion>3.1.0</MicrosoftWebXdtPackageVersion>
-    <SystemSecurityCryptographyProtectedDataPackageVersion>6.0.0-preview.2.21120.6</SystemSecurityCryptographyProtectedDataPackageVersion>
+    <SystemSecurityCryptographyProtectedDataPackageVersion>6.0.0-preview.3.21121.7</SystemSecurityCryptographyProtectedDataPackageVersion>
     <SystemCollectionsSpecializedPackageVersion>4.3.0</SystemCollectionsSpecializedPackageVersion>
     <SystemXmlXmlDocumentPackageVersion>4.3.0</SystemXmlXmlDocumentPackageVersion>
     <WebDeploymentPackageVersion>4.0.5</WebDeploymentPackageVersion>
     <SystemTextJsonVersion>4.7.2</SystemTextJsonVersion>
-    <SystemReflectionMetadataLoadContextVersion>6.0.0-preview.2.21120.6</SystemReflectionMetadataLoadContextVersion>
+    <SystemReflectionMetadataLoadContextVersion>6.0.0-preview.3.21121.7</SystemReflectionMetadataLoadContextVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/runtime -->
-    <MicrosoftNETCoreAppRefPackageVersion>6.0.0-preview.2.21120.6</MicrosoftNETCoreAppRefPackageVersion>
-    <VSRedistCommonNetCoreSharedFrameworkx6460PackageVersion>6.0.0-preview.2.21120.6</VSRedistCommonNetCoreSharedFrameworkx6460PackageVersion>
-    <MicrosoftNETCoreAppRuntimewinx64PackageVersion>6.0.0-preview.2.21120.6</MicrosoftNETCoreAppRuntimewinx64PackageVersion>
+    <MicrosoftNETCoreAppRefPackageVersion>6.0.0-preview.3.21121.7</MicrosoftNETCoreAppRefPackageVersion>
+    <VSRedistCommonNetCoreSharedFrameworkx6460PackageVersion>6.0.0-preview.3.21121.7</VSRedistCommonNetCoreSharedFrameworkx6460PackageVersion>
+    <MicrosoftNETCoreAppRuntimewinx64PackageVersion>6.0.0-preview.3.21121.7</MicrosoftNETCoreAppRuntimewinx64PackageVersion>
     <MicrosoftNETCoreAppRuntimePackageVersion>$(MicrosoftNETCoreAppRuntimewinx64PackageVersion)</MicrosoftNETCoreAppRuntimePackageVersion>
-    <MicrosoftExtensionsDependencyModelPackageVersion>6.0.0-preview.2.21120.6</MicrosoftExtensionsDependencyModelPackageVersion>
-    <MicrosoftNETCoreDotNetHostResolverPackageVersion>6.0.0-preview.2.21120.6</MicrosoftNETCoreDotNetHostResolverPackageVersion>
-    <MicrosoftNETHostModelVersion>6.0.0-preview.2.21120.6</MicrosoftNETHostModelVersion>
+    <MicrosoftExtensionsDependencyModelPackageVersion>6.0.0-preview.3.21121.7</MicrosoftExtensionsDependencyModelPackageVersion>
+    <MicrosoftNETCoreDotNetHostResolverPackageVersion>6.0.0-preview.3.21121.7</MicrosoftNETCoreDotNetHostResolverPackageVersion>
+    <MicrosoftNETHostModelVersion>6.0.0-preview.3.21121.7</MicrosoftNETHostModelVersion>
     <MicrosoftExtensionsDependencyModelVersion>$(MicrosoftExtensionsDependencyModelPackageVersion)</MicrosoftExtensionsDependencyModelVersion>
   </PropertyGroup>
   <PropertyGroup>
@@ -78,10 +78,10 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/runtime -->
-    <SystemCodeDomPackageVersion>6.0.0-preview.2.21120.6</SystemCodeDomPackageVersion>
-    <SystemTextEncodingCodePagesPackageVersion>6.0.0-preview.2.21120.6</SystemTextEncodingCodePagesPackageVersion>
+    <SystemCodeDomPackageVersion>6.0.0-preview.3.21121.7</SystemCodeDomPackageVersion>
+    <SystemTextEncodingCodePagesPackageVersion>6.0.0-preview.3.21121.7</SystemTextEncodingCodePagesPackageVersion>
     <SystemSecurityCryptographyProtectedDataPackageVersion>5.0.0-preview.7.20307.4</SystemSecurityCryptographyProtectedDataPackageVersion>
-    <SystemResourcesExtensionsPackageVersion>6.0.0-preview.2.21120.6</SystemResourcesExtensionsPackageVersion>
+    <SystemResourcesExtensionsPackageVersion>6.0.0-preview.3.21121.7</SystemResourcesExtensionsPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/roslyn-analyzers -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -31,22 +31,22 @@
     <SystemReflectionMetadataVersion>5.0.0</SystemReflectionMetadataVersion>
     <MicrosoftDotNetSignToolVersion>6.0.0-beta.21101.7</MicrosoftDotNetSignToolVersion>
     <MicrosoftWebXdtPackageVersion>3.1.0</MicrosoftWebXdtPackageVersion>
-    <SystemSecurityCryptographyProtectedDataPackageVersion>6.0.0-preview.2.21118.6</SystemSecurityCryptographyProtectedDataPackageVersion>
+    <SystemSecurityCryptographyProtectedDataPackageVersion>6.0.0-preview.2.21119.11</SystemSecurityCryptographyProtectedDataPackageVersion>
     <SystemCollectionsSpecializedPackageVersion>4.3.0</SystemCollectionsSpecializedPackageVersion>
     <SystemXmlXmlDocumentPackageVersion>4.3.0</SystemXmlXmlDocumentPackageVersion>
     <WebDeploymentPackageVersion>4.0.5</WebDeploymentPackageVersion>
     <SystemTextJsonVersion>4.7.2</SystemTextJsonVersion>
-    <SystemReflectionMetadataLoadContextVersion>6.0.0-preview.2.21118.6</SystemReflectionMetadataLoadContextVersion>
+    <SystemReflectionMetadataLoadContextVersion>6.0.0-preview.2.21119.11</SystemReflectionMetadataLoadContextVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/runtime -->
-    <MicrosoftNETCoreAppRefPackageVersion>6.0.0-preview.2.21118.6</MicrosoftNETCoreAppRefPackageVersion>
-    <VSRedistCommonNetCoreSharedFrameworkx6460PackageVersion>6.0.0-preview.2.21118.6</VSRedistCommonNetCoreSharedFrameworkx6460PackageVersion>
-    <MicrosoftNETCoreAppRuntimewinx64PackageVersion>6.0.0-preview.2.21118.6</MicrosoftNETCoreAppRuntimewinx64PackageVersion>
+    <MicrosoftNETCoreAppRefPackageVersion>6.0.0-preview.2.21119.11</MicrosoftNETCoreAppRefPackageVersion>
+    <VSRedistCommonNetCoreSharedFrameworkx6460PackageVersion>6.0.0-preview.2.21119.11</VSRedistCommonNetCoreSharedFrameworkx6460PackageVersion>
+    <MicrosoftNETCoreAppRuntimewinx64PackageVersion>6.0.0-preview.2.21119.11</MicrosoftNETCoreAppRuntimewinx64PackageVersion>
     <MicrosoftNETCoreAppRuntimePackageVersion>$(MicrosoftNETCoreAppRuntimewinx64PackageVersion)</MicrosoftNETCoreAppRuntimePackageVersion>
-    <MicrosoftExtensionsDependencyModelPackageVersion>6.0.0-preview.2.21118.6</MicrosoftExtensionsDependencyModelPackageVersion>
-    <MicrosoftNETCoreDotNetHostResolverPackageVersion>6.0.0-preview.2.21118.6</MicrosoftNETCoreDotNetHostResolverPackageVersion>
-    <MicrosoftNETHostModelVersion>6.0.0-preview.2.21118.6</MicrosoftNETHostModelVersion>
+    <MicrosoftExtensionsDependencyModelPackageVersion>6.0.0-preview.2.21119.11</MicrosoftExtensionsDependencyModelPackageVersion>
+    <MicrosoftNETCoreDotNetHostResolverPackageVersion>6.0.0-preview.2.21119.11</MicrosoftNETCoreDotNetHostResolverPackageVersion>
+    <MicrosoftNETHostModelVersion>6.0.0-preview.2.21119.11</MicrosoftNETHostModelVersion>
     <MicrosoftExtensionsDependencyModelVersion>$(MicrosoftExtensionsDependencyModelPackageVersion)</MicrosoftExtensionsDependencyModelVersion>
   </PropertyGroup>
   <PropertyGroup>
@@ -78,9 +78,10 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/runtime -->
-    <SystemCodeDomPackageVersion>6.0.0-preview.2.21118.6</SystemCodeDomPackageVersion>
-    <SystemTextEncodingCodePagesPackageVersion>6.0.0-preview.2.21118.6</SystemTextEncodingCodePagesPackageVersion>
-    <SystemResourcesExtensionsPackageVersion>6.0.0-preview.2.21118.6</SystemResourcesExtensionsPackageVersion>
+    <SystemCodeDomPackageVersion>6.0.0-preview.2.21119.11</SystemCodeDomPackageVersion>
+    <SystemTextEncodingCodePagesPackageVersion>6.0.0-preview.2.21119.11</SystemTextEncodingCodePagesPackageVersion>
+    <SystemSecurityCryptographyProtectedDataPackageVersion>5.0.0-preview.7.20307.4</SystemSecurityCryptographyProtectedDataPackageVersion>
+    <SystemResourcesExtensionsPackageVersion>6.0.0-preview.2.21119.11</SystemResourcesExtensionsPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/roslyn-analyzers -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -31,22 +31,22 @@
     <SystemReflectionMetadataVersion>5.0.0</SystemReflectionMetadataVersion>
     <MicrosoftDotNetSignToolVersion>6.0.0-beta.21101.7</MicrosoftDotNetSignToolVersion>
     <MicrosoftWebXdtPackageVersion>3.1.0</MicrosoftWebXdtPackageVersion>
-    <SystemSecurityCryptographyProtectedDataPackageVersion>6.0.0-preview.3.21121.7</SystemSecurityCryptographyProtectedDataPackageVersion>
+    <SystemSecurityCryptographyProtectedDataPackageVersion>6.0.0-preview.3.21123.2</SystemSecurityCryptographyProtectedDataPackageVersion>
     <SystemCollectionsSpecializedPackageVersion>4.3.0</SystemCollectionsSpecializedPackageVersion>
     <SystemXmlXmlDocumentPackageVersion>4.3.0</SystemXmlXmlDocumentPackageVersion>
     <WebDeploymentPackageVersion>4.0.5</WebDeploymentPackageVersion>
     <SystemTextJsonVersion>4.7.2</SystemTextJsonVersion>
-    <SystemReflectionMetadataLoadContextVersion>6.0.0-preview.3.21121.7</SystemReflectionMetadataLoadContextVersion>
+    <SystemReflectionMetadataLoadContextVersion>6.0.0-preview.3.21123.2</SystemReflectionMetadataLoadContextVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/runtime -->
-    <MicrosoftNETCoreAppRefPackageVersion>6.0.0-preview.3.21121.7</MicrosoftNETCoreAppRefPackageVersion>
-    <VSRedistCommonNetCoreSharedFrameworkx6460PackageVersion>6.0.0-preview.3.21121.7</VSRedistCommonNetCoreSharedFrameworkx6460PackageVersion>
-    <MicrosoftNETCoreAppRuntimewinx64PackageVersion>6.0.0-preview.3.21121.7</MicrosoftNETCoreAppRuntimewinx64PackageVersion>
+    <MicrosoftNETCoreAppRefPackageVersion>6.0.0-preview.3.21123.2</MicrosoftNETCoreAppRefPackageVersion>
+    <VSRedistCommonNetCoreSharedFrameworkx6460PackageVersion>6.0.0-preview.3.21123.2</VSRedistCommonNetCoreSharedFrameworkx6460PackageVersion>
+    <MicrosoftNETCoreAppRuntimewinx64PackageVersion>6.0.0-preview.3.21123.2</MicrosoftNETCoreAppRuntimewinx64PackageVersion>
     <MicrosoftNETCoreAppRuntimePackageVersion>$(MicrosoftNETCoreAppRuntimewinx64PackageVersion)</MicrosoftNETCoreAppRuntimePackageVersion>
-    <MicrosoftExtensionsDependencyModelPackageVersion>6.0.0-preview.3.21121.7</MicrosoftExtensionsDependencyModelPackageVersion>
-    <MicrosoftNETCoreDotNetHostResolverPackageVersion>6.0.0-preview.3.21121.7</MicrosoftNETCoreDotNetHostResolverPackageVersion>
-    <MicrosoftNETHostModelVersion>6.0.0-preview.3.21121.7</MicrosoftNETHostModelVersion>
+    <MicrosoftExtensionsDependencyModelPackageVersion>6.0.0-preview.3.21123.2</MicrosoftExtensionsDependencyModelPackageVersion>
+    <MicrosoftNETCoreDotNetHostResolverPackageVersion>6.0.0-preview.3.21123.2</MicrosoftNETCoreDotNetHostResolverPackageVersion>
+    <MicrosoftNETHostModelVersion>6.0.0-preview.3.21123.2</MicrosoftNETHostModelVersion>
     <MicrosoftExtensionsDependencyModelVersion>$(MicrosoftExtensionsDependencyModelPackageVersion)</MicrosoftExtensionsDependencyModelVersion>
   </PropertyGroup>
   <PropertyGroup>
@@ -78,10 +78,10 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/runtime -->
-    <SystemCodeDomPackageVersion>6.0.0-preview.3.21121.7</SystemCodeDomPackageVersion>
-    <SystemTextEncodingCodePagesPackageVersion>6.0.0-preview.3.21121.7</SystemTextEncodingCodePagesPackageVersion>
+    <SystemCodeDomPackageVersion>6.0.0-preview.3.21123.2</SystemCodeDomPackageVersion>
+    <SystemTextEncodingCodePagesPackageVersion>6.0.0-preview.3.21123.2</SystemTextEncodingCodePagesPackageVersion>
     <SystemSecurityCryptographyProtectedDataPackageVersion>5.0.0-preview.7.20307.4</SystemSecurityCryptographyProtectedDataPackageVersion>
-    <SystemResourcesExtensionsPackageVersion>6.0.0-preview.3.21121.7</SystemResourcesExtensionsPackageVersion>
+    <SystemResourcesExtensionsPackageVersion>6.0.0-preview.3.21123.2</SystemResourcesExtensionsPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/roslyn-analyzers -->

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolveReadyToRunCompilers.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveReadyToRunCompilers.cs
@@ -141,7 +141,7 @@ namespace Microsoft.NET.Build.Tasks
             }
 
             bool version5 = crossgen2PackVersion.Major < 6;
-            bool version6Preview1 = crossgen2PackVersion.Major == 6 && crossgen2PackVersion.Patch <= 21117;
+            bool version6Preview1 = crossgen2PackVersion.Major == 6 && StringComparer.OrdinalIgnoreCase.Compare(crossgen2PackVersion.Release, "preview.2.21119.3") < 0;
             bool isSupportedTarget = ExtractTargetPlatformAndArchitecture(_targetRuntimeIdentifier, out _targetPlatform, out _targetArchitecture);
             string targetOS = _targetPlatform switch
             {


### PR DESCRIPTION
This change (not for merge) tests my SDK Crossgen2 version check fix. I'll publish another PR with the separate fix (without the dependency update) in parallel.

/cc: @dotnet/crossgen-contrib 
Should fix PR: https://github.com/dotnet/sdk/pull/15978