### PR TITLE
Fix CG2 version check in ResolveReadyToRunCompilers

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolveReadyToRunCompilers.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveReadyToRunCompilers.cs
@@ -141,7 +141,7 @@ namespace Microsoft.NET.Build.Tasks
             }
 
             bool version5 = crossgen2PackVersion.Major < 6;
-            bool version6Preview1 = crossgen2PackVersion.Major == 6 && crossgen2PackVersion.Release.StartsWith("preview.1.");
+            bool version6Preview1 = crossgen2PackVersion.Major == 6 && StringComparer.OrdinalIgnoreCase.Compare(crossgen2PackVersion.Release, "preview.2.21119.3") < 0;
             bool isSupportedTarget = ExtractTargetPlatformAndArchitecture(_targetRuntimeIdentifier, out _targetPlatform, out _targetArchitecture);
             string targetOS = _targetPlatform switch
             {

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolveReadyToRunCompilers.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveReadyToRunCompilers.cs
@@ -141,7 +141,7 @@ namespace Microsoft.NET.Build.Tasks
             }
 
             bool version5 = crossgen2PackVersion.Major < 6;
-            bool version6Preview1 = crossgen2PackVersion.Major == 6 && crossgen2PackVersion.Patch <= 21117;
+            bool version6Preview1 = crossgen2PackVersion.Major == 6 && crossgen2PackVersion.Release.StartsWith("preview.1.");
             bool isSupportedTarget = ExtractTargetPlatformAndArchitecture(_targetRuntimeIdentifier, out _targetPlatform, out _targetArchitecture);
             string targetOS = _targetPlatform switch
             {


### PR DESCRIPTION
Addresses failures in: https://github.com/dotnet/sdk/pull/15978
/cc @dotnet/crossgen-contrib 
