### PR TITLE
Clean up SDK code driving Crossgen2 compilation

### DIFF
--- a/src/Tasks/Common/MetadataKeys.cs
+++ b/src/Tasks/Common/MetadataKeys.cs
@@ -122,6 +122,5 @@ namespace Microsoft.NET.Build.Tasks
         public const string OutputPDBImage = "OutputPDBImage";
         public const string EmitSymbols = "EmitSymbols";
         public const string IsVersion5 = "IsVersion5";
-        public const string IsVersion6Preview1 = "IsVersion6Preview1";
     }
 }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/PrepareForReadyToRunCompilation.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/PrepareForReadyToRunCompilation.cs
@@ -49,7 +49,6 @@ namespace Microsoft.NET.Build.Tasks
         public ITaskItem[] ReadyToRunAssembliesToReference => _r2rReferences.ToArray();
 
         private bool _crossgen2IsVersion5;
-        private bool _crossgen2IsVersion6Preview1;
 
         private List<ITaskItem> _compileList = new List<ITaskItem>();
         private List<ITaskItem> _symbolsCompileList = new List<ITaskItem>();
@@ -72,9 +71,6 @@ namespace Microsoft.NET.Build.Tasks
                     Log.LogError(Strings.Crossgen5CannotEmitSymbolsInCompositeMode);
                     return;
                 }
-                
-                string isVersion6Preview1 = Crossgen2Tool.GetMetadata(MetadataKeys.IsVersion6Preview1);
-                _crossgen2IsVersion6Preview1 = !string.IsNullOrEmpty(isVersion6Preview1) && bool.Parse(isVersion6Preview1);
             }
 
             // Process input lists of files
@@ -137,11 +133,6 @@ namespace Microsoft.NET.Build.Tasks
                             Guid mvid = mdReader.GetGuid(mdReader.GetModuleDefinition().Mvid);
 
                             outputPDBImage = Path.ChangeExtension(outputR2RImage, "ni.{" + mvid + "}.map");
-                            if (ReadyToRunUseCrossgen2 && _crossgen2IsVersion6Preview1)
-                            {
-                                // .NET 6 Preview1 Crossgen2 sets ".perf.map" as the perfmap extension
-                                outputPDBImage = Path.ChangeExtension(outputR2RImage, ".perf.map");
-                            }
                             outputPDBImageRelativePath = Path.ChangeExtension(outputR2RImageRelativePath, "ni.{" + mvid + "}.map");
                             crossgen1CreatePDBCommand = $"/CreatePerfMap \"{Path.GetDirectoryName(outputPDBImage)}\"";
                         }
@@ -179,11 +170,6 @@ namespace Microsoft.NET.Build.Tasks
                     else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
                     {
                         compositePDBImage = Path.ChangeExtension(compositeR2RImage, ".ni.{composite}.map");
-                        if (ReadyToRunUseCrossgen2 && _crossgen2IsVersion6Preview1)
-                        {
-                            // .NET 6 Preview1 Crossgen2 sets ".perf.map" as the perfmap extension
-                            compositePDBImage = Path.ChangeExtension(compositeR2RImage, ".perf.map");
-                        }
                         compositePDBRelativePath = Path.ChangeExtension(compositeR2RImageRelativePath, ".ni.{composite}.map");
                     }
 


### PR DESCRIPTION
As Anton pointed out, after upgrading the SDK repo to Crossgen2
Preview 3 we no longer need provisions for dealing with the
Preview 1-specific perfmap filename differences.

Thanks

Tomas