### PR TITLE
Ensure Razor design time targets are correctly wired up

### DIFF
--- a/src/Assets/TestProjects/RazorComponentApp/ComponentApp.csproj
+++ b/src/Assets/TestProjects/RazorComponentApp/ComponentApp.csproj
@@ -17,4 +17,8 @@
     <Message Text="Watch: %(Watch.FileName)%(Watch.Extension)" Importance="High" />
   </Target>
 
+  <Target Name="_IntrospectRazorGenerateComponentDesignTime" DependsOnTargets="RazorGenerateComponentDesignTime">
+    <Message Text="RazorComponentWithTargetPath: %(RazorComponentWithTargetPath.FileName) %(RazorComponentWithTargetPath.TargetPath)" Importance="High" />
+  </Target>
+
 </Project>

--- a/src/RazorSdk/Targets/Microsoft.NET.Sdk.Razor.Component.targets
+++ b/src/RazorSdk/Targets/Microsoft.NET.Sdk.Razor.Component.targets
@@ -22,7 +22,6 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <PropertyGroup>
     <_RazorGenerateComponentDeclarationDesignTimeDependsOn>ResolveRazorConfiguration;ResolveRazorComponentInputs;AssignRazorComponentTargetPaths;RazorGenerateComponentDeclaration</_RazorGenerateComponentDeclarationDesignTimeDependsOn>
-    <_RazorGenerateComponentDesignTimeDependsOn>ResolveRazorComponentInputs;AssignRazorComponentTargetPaths</_RazorGenerateComponentDesignTimeDependsOn>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/RazorSdk/Targets/Sdk.Razor.CurrentVersion.targets
+++ b/src/RazorSdk/Targets/Sdk.Razor.CurrentVersion.targets
@@ -70,7 +70,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     </When>
   </Choose>
 
-  
+
   <PropertyGroup>
     <!--
       In 3.0, we expect RazorLangVersion to either be specified in the template or inferred via TFM. In 2.x, RazorLangVersion is
@@ -201,6 +201,10 @@ Copyright (c) .NET Foundation. All rights reserved.
       $(GetCopyToOutputDirectoryItemsDependsOn)
     </GetCopyToOutputDirectoryItemsDependsOn>
 
+    <_RazorGenerateComponentDesignTimeDependsOn>
+      ResolveRazorComponentInputs;
+      AssignRazorComponentTargetPaths
+    </_RazorGenerateComponentDesignTimeDependsOn>
   </PropertyGroup>
 
   <!--

--- a/src/Tests/Microsoft.NET.Sdk.Razor.Tests/BuildIntrospectionTest.cs
+++ b/src/Tests/Microsoft.NET.Sdk.Razor.Tests/BuildIntrospectionTest.cs
@@ -120,6 +120,8 @@ namespace Microsoft.NET.Sdk.Razor.Tests
         [Fact]
         public void IntrospectRazorDesignTimeTargets()
         {
+            var expected1 = Path.Combine("Components", "App.razor");
+            var expected2 = Path.Combine("Components", "Shared", "MainLayout.razor");
             var testAsset = "RazorComponentApp";
             var projectDirectory = CreateAspNetSdkTestAsset(testAsset);
 
@@ -127,8 +129,8 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             build.Execute()
                 .Should()
                 .Pass()
-                .And.HaveStdOutContaining("RazorComponentWithTargetPath: App Components\\App.razor")
-                .And.HaveStdOutContaining("RazorComponentWithTargetPath: MainLayout Components\\Shared\\MainLayout.razor");
+                .And.HaveStdOutContaining($"RazorComponentWithTargetPath: App {expected1}")
+                .And.HaveStdOutContaining($"RazorComponentWithTargetPath: MainLayout {expected2}");
         }
     }
 }

--- a/src/Tests/Microsoft.NET.Sdk.Razor.Tests/BuildIntrospectionTest.cs
+++ b/src/Tests/Microsoft.NET.Sdk.Razor.Tests/BuildIntrospectionTest.cs
@@ -116,5 +116,19 @@ namespace Microsoft.NET.Sdk.Razor.Tests
                 .And.HaveStdOutContaining("Watch: Index.razor")
                 .And.HaveStdOutContaining("Watch: Index.razor.css");
         }
+
+        [Fact]
+        public void IntrospectRazorDesignTimeTargets()
+        {
+            var testAsset = "RazorComponentApp";
+            var projectDirectory = CreateAspNetSdkTestAsset(testAsset);
+
+            var build = new MSBuildCommand(Log, "_IntrospectRazorGenerateComponentDesignTime", projectDirectory.Path);
+            build.Execute()
+                .Should()
+                .Pass()
+                .And.HaveStdOutContaining("RazorComponentWithTargetPath: App Components\\App.razor")
+                .And.HaveStdOutContaining("RazorComponentWithTargetPath: MainLayout Components\\Shared\\MainLayout.razor");
+        }
     }
 }


### PR DESCRIPTION
## Description

As part of updating Razor SDK to use source generators, we no longer certain target files that relied on using Razor's compiler server for code generation. When doing so, we moved some certain targets to the common targets file,
but missed carrying over properties that wired it up for design time tooling. We'd tested that things build in VS, but missed verifying if intellisense was broken.

## Customer Impact

Colorisation and intellisense for razor components is lost for 6.0 projects.

## Regression?
- [x] Yes
- [ ] No

[If yes, specify the version the behavior has regressed from] 
6.0-preview1 SDK

## Risk
- [ ] High
- [ ] Medium
- [x] Low

This particular change ensures an MSBuild property that is private to the SDK is initialized at a different location. We do not expect any other SDKs relying on this property (or when it gets initialized) which makes it a fairly safe move.

[Justify the selection above]

## Verification
- [X] Manual (required) - Verified the change fixes this issue in VS
- [X] Automated - We wrote a automated test to ensure this scenario does not regress.

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [X] N/A


Addresses [issue number]