### PR TITLE
Added slashes to folders

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -49,7 +49,7 @@
 /src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets clrappmodel@microsoft.com @AntonLapounov @dotnet/dotnet-cli
 /src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ClickOnce.targets @sujitnayak
 
-/src/Assets/TestProjects/Watch*     @captainsafia, @pranavkm, @mkArtakMSFT
+/src/Assets/TestProjects/Watch*/     @captainsafia, @pranavkm, @mkArtakMSFT
 /src/Tests/dotnet-watch.Tests/       @captainsafia, @pranavkm, @mkArtakMSFT
 /src/Tests/Microsoft.AspNetCore.Watch.BrowserRefresh.Tests/       @captainsafia, @pranavkm, @mkArtakMSFT
 /src/BuiltInTools/   @captainsafia, @pranavkm, @mkArtakMSFT

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -9,18 +9,18 @@
 /src/WebSdk/ @vijayrkn
 /src/Tests/Microsoft.NET.Sdk.Publish.Tasks.Tests/ @vijayrkn
 
-/src/BlazorWasmSdk @captainsafia, @pranavkm, @mkArtakMSFT
-/src/Tests/Microsoft.NET.Sdk.BlazorWebAssembly.Tests @captainsafia, @pranavkm, @mkArtakMSFT
-/src/Assets/TestProjects/BlazorHosted @captainsafia, @pranavkm, @mkArtakMSFT
-/src/Assets/TestProjects/BlazorHostedRID @captainsafia, @pranavkm, @mkArtakMSFT
-/src/Assets/TestProjects/BlazorWasmMinimal @captainsafia, @pranavkm, @mkArtakMSFT
-/src/Assets/TestProjects/BlazorWasmWithLibrary @captainsafia, @pranavkm, @mkArtakMSFT
+/src/BlazorWasmSdk/ @captainsafia, @pranavkm, @mkArtakMSFT
+/src/Tests/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/ @captainsafia, @pranavkm, @mkArtakMSFT
+/src/Assets/TestProjects/BlazorHosted/ @captainsafia, @pranavkm, @mkArtakMSFT
+/src/Assets/TestProjects/BlazorHostedRID/ @captainsafia, @pranavkm, @mkArtakMSFT
+/src/Assets/TestProjects/BlazorWasmMinimal/ @captainsafia, @pranavkm, @mkArtakMSFT
+/src/Assets/TestProjects/BlazorWasmWithLibrary/ @captainsafia, @pranavkm, @mkArtakMSFT
 
-/src/RazorSdk @captainsafia, @pranavkm, @mkArtakMSFT
-/src/Tests/Microsoft.NET.Sdk.Razor.Tests @captainsafia, @pranavkm, @mkArtakMSFT
-/src/Tests/Microsoft.NET.Sdk.Razor.Tool.Tests @captainsafia, @pranavkm, @mkArtakMSFT
-/src/Assets/TestPackages/PackageLibraryDirectDependency @captainsafia, @pranavkm, @mkArtakMSFT
-/src/Assets/TestPackages/PackageLibraryTransitiveDependency @captainsafia, @pranavkm, @mkArtakMSFT
+/src/RazorSdk/ @captainsafia, @pranavkm, @mkArtakMSFT
+/src/Tests/Microsoft.NET.Sdk.Razor.Tests/ @captainsafia, @pranavkm, @mkArtakMSFT
+/src/Tests/Microsoft.NET.Sdk.Razor.Tool.Tests/ @captainsafia, @pranavkm, @mkArtakMSFT
+/src/Assets/TestPackages/PackageLibraryDirectDependency/ @captainsafia, @pranavkm, @mkArtakMSFT
+/src/Assets/TestPackages/PackageLibraryTransitiveDependency/ @captainsafia, @pranavkm, @mkArtakMSFT
 /src/src/Assets/TestProjects/Razor* @captainsafia, @pranavkm, @mkArtakMSFT
 
 /src/Cli/dotnet/commands/dotnet-add/dotnet-add-package @dotnet/nuget-team
@@ -50,6 +50,6 @@
 /src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ClickOnce.targets @sujitnayak
 
 /src/Assets/TestProjects/Watch*     @captainsafia, @pranavkm, @mkArtakMSFT
-/src/Tests/dotnet-watch.Tests       @captainsafia, @pranavkm, @mkArtakMSFT
-/src/Tests/Microsoft.AspNetCore.Watch.BrowserRefresh.Tests       @captainsafia, @pranavkm, mkArtakMSFT
-/src/BuiltInTools/   @captainsafia, @pranavkm, mkArtakMSFT
+/src/Tests/dotnet-watch.Tests/       @captainsafia, @pranavkm, @mkArtakMSFT
+/src/Tests/Microsoft.AspNetCore.Watch.BrowserRefresh.Tests/       @captainsafia, @pranavkm, @mkArtakMSFT
+/src/BuiltInTools/   @captainsafia, @pranavkm, @mkArtakMSFT

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -21,7 +21,7 @@
 /src/Tests/Microsoft.NET.Sdk.Razor.Tool.Tests/ @captainsafia, @pranavkm, @mkArtakMSFT
 /src/Assets/TestPackages/PackageLibraryDirectDependency/ @captainsafia, @pranavkm, @mkArtakMSFT
 /src/Assets/TestPackages/PackageLibraryTransitiveDependency/ @captainsafia, @pranavkm, @mkArtakMSFT
-/src/src/Assets/TestProjects/Razor* @captainsafia, @pranavkm, @mkArtakMSFT
+/src/src/Assets/TestProjects/Razor*/ @captainsafia, @pranavkm, @mkArtakMSFT
 
 /src/Cli/dotnet/commands/dotnet-add/dotnet-add-package @dotnet/nuget-team
 /src/Tests/dotnet-add-package.Tests @dotnet/nuget-team


### PR DESCRIPTION
According to the [documentation](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#example-of-a-codeowners-file) slashes at the end of folder paths are required.

Also fixed my alias in mappings for dotnet watch folders