### PR TITLE
Enable additional ways to opt in to trimming

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -102,13 +102,13 @@
       <Uri>https://github.com/microsoft/vstest</Uri>
       <Sha>8ee2efd12c3781c5cf850f113f2252fda6a3312b</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.ILLink.Tasks" Version="6.0.100-preview.2.21124.3">
+    <Dependency Name="Microsoft.NET.ILLink.Tasks" Version="6.0.100-preview.2.21125.1">
       <Uri>https://github.com/mono/linker</Uri>
-      <Sha>6b3a3050c70577bd1b3fd7611eef56679e22a4f1</Sha>
+      <Sha>44907d98e524f65db0a0edc2cab8afe077ba812a</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.ILLink.Analyzers" Version="6.0.100-preview.2.21124.3">
+    <Dependency Name="Microsoft.NET.ILLink.Analyzers" Version="6.0.100-preview.2.21125.1">
       <Uri>https://github.com/mono/linker</Uri>
-      <Sha>6b3a3050c70577bd1b3fd7611eef56679e22a4f1</Sha>
+      <Sha>44907d98e524f65db0a0edc2cab8afe077ba812a</Sha>
     </Dependency>
     <Dependency Name="System.CodeDom" Version="6.0.0-preview.3.21123.15">
       <Uri>https://github.com/dotnet/runtime</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -73,7 +73,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/mono/linker -->
-    <MicrosoftNETILLinkTasksPackageVersion>6.0.100-preview.2.21124.3</MicrosoftNETILLinkTasksPackageVersion>
+    <MicrosoftNETILLinkTasksPackageVersion>6.0.100-preview.2.21125.1</MicrosoftNETILLinkTasksPackageVersion>
     <MicrosoftNETILLinkAnalyzerPackageVersion>$(MicrosoftNETILLinkTasksPackageVersion)</MicrosoftNETILLinkAnalyzerPackageVersion>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ILLink.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ILLink.targets
@@ -182,9 +182,6 @@ Copyright (c) .NET Foundation. All rights reserved.
       <ILLinkTreatWarningsAsErrors Condition=" '$(ILLinkTreatWarningsAsErrors)' == '' ">$(TreatWarningsAsErrors)</ILLinkTreatWarningsAsErrors>
       <_ExtraTrimmerArgs>--skip-unresolved true $(_ExtraTrimmerArgs)</_ExtraTrimmerArgs>
       <TrimMode Condition=" '$(TrimMode)' == '' ">copyused</TrimMode>
-    </PropertyGroup>
-
-    <PropertyGroup Condition=" '$(_TrimmerDefaultAction)' == '' ">
       <!-- For .NET < 6, the defaults are the same regardless of whether the assembly has an IsTrimmable attribute. (The attribute didn't exist until .NET 6.) -->
       <_TrimmerDefaultAction Condition=" $([MSBuild]::VersionLessThan('$(TargetFrameworkVersion)', '6.0')) ">$(TrimMode)</_TrimmerDefaultAction>
       <!-- For .NET 6+, assemblies without IsTrimmable attribute get the "copy" action. -->
@@ -230,25 +227,26 @@ Copyright (c) .NET Foundation. All rights reserved.
       <TrimmerRemoveSymbols Condition=" '$(DebuggerSupport)' != 'false' ">false</TrimmerRemoveSymbols>
     </PropertyGroup>
 
+    <!-- Set IsTrimmable for any assemblies that already have customized TrimMode. -->
     <ItemGroup>
-      <!-- Set IsTrimmable for any assemblies that already have customized TrimMode. -->
       <ManagedAssemblyToLink Condition=" '%(ManagedAssemblyToLink.TrimMode)' != '' ">
         <IsTrimmable>true</IsTrimmable>
       </ManagedAssemblyToLink>
+    </ItemGroup>
 
-      <!-- SetIsTrimmable for any assemblies listed in TrimmableAssembly. -->
-      <_ManagedAssemblyToLinkName Include="@(ManagedAssemblyToLink->'%(Filename)')">
-        <OriginalItemSpec>%(Identity)</OriginalItemSpec>
-      </_ManagedAssemblyToLinkName>
-      <_NonTrimmableManagedAssemblyToLinkName Include="@(_ManagedAssemblyToLinkName)" Exclude="@(TrimmableAssembly)" />
-      <_TrimmableManagedAssemblyToLinkName Include="@(_ManagedAssemblyToLinkName)" Exclude="@(_NonTrimmableManagedAssemblyToLinkName)" />
-      <_TrimmableManagedAssemblyToLink Include="@(_TrimmableManagedAssemblyToLinkName->'%(OriginalItemSpec)')" />
+    <!-- SetIsTrimmable for any assemblies listed in TrimmableAssembly. -->
+    <JoinItems Left="@(ManagedAssemblyToLink)" LeftKey="FileName" LeftMetadata="*"
+               Right="@(TrimmableAssembly)"
+               ItemSpecToUse="Left">
+      <Output TaskParameter="JoinResult" ItemName="_TrimmableManagedAssemblyToLink" />
+    </JoinItems>
+    <ItemGroup>
       <ManagedAssemblyToLink Remove="@(_TrimmableManagedAssemblyToLink)" />
-      <ManagedAssemblyToLink Include="@(_TrimmableManagedAssemblyToLink)">
-        <IsTrimmable>true</IsTrimmable>
-      </ManagedAssemblyToLink>
+      <ManagedAssemblyToLink Include="@(_TrimmableManagedAssemblyToLink)" IsTrimmable="true" />
+    </ItemGroup>
 
-      <!-- Root the main assembly, whether or not it has IsTrimmable set. -->
+    <!-- Root the main assembly, whether or not it has IsTrimmable set. -->
+    <ItemGroup>
       <TrimmerRootAssembly Include="@(IntermediateAssembly)" />
     </ItemGroup>
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ILLink.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ILLink.targets
@@ -118,6 +118,7 @@ Copyright (c) .NET Foundation. All rights reserved.
             ReferenceAssemblyPaths="@(ReferencePath)"
             RootAssemblyNames="@(TrimmerRootAssembly)"
             TrimMode="$(TrimMode)"
+            DefaultAction="$(_TrimmerDefaultAction)"
             RemoveSymbols="$(TrimmerRemoveSymbols)"
             FeatureSettings="@(_TrimmerFeatureSettings)"
             CustomData="@(_TrimmerCustomData)"
@@ -171,14 +172,23 @@ Copyright (c) .NET Foundation. All rights reserved.
          in some cases. -->
     <NETSdkError Condition="'$(SelfContained)' != 'true'" ResourceName="ILLinkNotSupportedError" />
 
-    <PropertyGroup>
-      <ILLinkWarningLevel Condition=" '$(ILLinkWarningLevel)' == '' And
-                                      '$(EffectiveAnalysisLevel)' != '' And
+    <PropertyGroup Condition=" '$(ILLinkWarningLevel)' == '' ">
+      <ILLinkWarningLevel Condition=" '$(EffectiveAnalysisLevel)' != '' And
                                        $([MSBuild]::VersionGreaterThanOrEquals($(EffectiveAnalysisLevel), '5.0')) ">5</ILLinkWarningLevel>
       <ILLinkWarningLevel Condition=" '$(ILLinkWarningLevel)' == '' ">0</ILLinkWarningLevel>
+    </PropertyGroup>
+
+    <PropertyGroup>
       <ILLinkTreatWarningsAsErrors Condition=" '$(ILLinkTreatWarningsAsErrors)' == '' ">$(TreatWarningsAsErrors)</ILLinkTreatWarningsAsErrors>
       <_ExtraTrimmerArgs>--skip-unresolved true $(_ExtraTrimmerArgs)</_ExtraTrimmerArgs>
       <TrimMode Condition=" '$(TrimMode)' == '' ">copyused</TrimMode>
+    </PropertyGroup>
+
+    <PropertyGroup Condition=" '$(_TrimmerDefaultAction)' == '' ">
+      <!-- For .NET < 6, the defaults are the same regardless of whether the assembly has an IsTrimmable attribute. (The attribute didn't exist until .NET 6.) -->
+      <_TrimmerDefaultAction Condition=" $([MSBuild]::VersionLessThan('$(TargetFrameworkVersion)', '6.0')) ">$(TrimMode)</_TrimmerDefaultAction>
+      <!-- For .NET 6+, assemblies without IsTrimmable attribute get the "copy" action. -->
+      <_TrimmerDefaultAction Condition=" '$(_TrimmerDefaultAction)' == '' ">copy</_TrimmerDefaultAction>
     </PropertyGroup>
     
     <!-- Suppress warnings produced by the linker. Any warnings shared with the analyzer should be
@@ -221,14 +231,42 @@ Copyright (c) .NET Foundation. All rights reserved.
     </PropertyGroup>
 
     <ItemGroup>
-      <!-- Treat any assemblies that already have customized TrimMode as trimmable. -->
+      <!-- Set IsTrimmable for any assemblies that already have customized TrimMode. -->
       <ManagedAssemblyToLink Condition=" '%(ManagedAssemblyToLink.TrimMode)' != '' ">
         <IsTrimmable>true</IsTrimmable>
       </ManagedAssemblyToLink>
-      <!-- Root and copy non-trimmable assemblies. -->
+
+      <!-- SetIsTrimmable for any assemblies listed in TrimmableAssembly. -->
+      <_ManagedAssemblyToLinkName Include="@(ManagedAssemblyToLink->'%(Filename)')">
+        <OriginalItemSpec>%(Identity)</OriginalItemSpec>
+      </_ManagedAssemblyToLinkName>
+      <_NonTrimmableManagedAssemblyToLinkName Include="@(_ManagedAssemblyToLinkName)" Exclude="@(TrimmableAssembly)" />
+      <_TrimmableManagedAssemblyToLinkName Include="@(_ManagedAssemblyToLinkName)" Exclude="@(_NonTrimmableManagedAssemblyToLinkName)" />
+      <_TrimmableManagedAssemblyToLink Include="@(_TrimmableManagedAssemblyToLinkName->'%(OriginalItemSpec)')" />
+      <ManagedAssemblyToLink Remove="@(_TrimmableManagedAssemblyToLink)" />
+      <ManagedAssemblyToLink Include="@(_TrimmableManagedAssemblyToLink)">
+        <IsTrimmable>true</IsTrimmable>
+      </ManagedAssemblyToLink>
+
+      <!-- Root the main assembly, whether or not it has IsTrimmable set. -->
+      <TrimmerRootAssembly Include="@(IntermediateAssembly)" />
+    </ItemGroup>
+
+    <!-- For .NET < 6, root and copy assemblies without IsTrimmable=true MSBuild metadata. -->
+    <ItemGroup Condition=" $([MSBuild]::VersionLessThan('$(TargetFrameworkVersion)', '6.0')) ">
       <TrimmerRootAssembly Include="@(ManagedAssemblyToLink)" Condition=" '%(ManagedAssemblyToLink.IsTrimmable)' != 'true' " />
       <ManagedAssemblyToLink Condition=" '%(ManagedAssemblyToLink.IsTrimmable)' != 'true' ">
         <TrimMode>copy</TrimMode>
+      </ManagedAssemblyToLink>
+    </ItemGroup>
+
+    <!-- In .NET6+, set the action explicitly for any with IsTrimmable MSBuild metadata -->
+    <ItemGroup Condition=" $([MSBuild]::VersionGreaterThanOrEquals('$(TargetFrameworkVersion)', '6.0')) ">
+      <ManagedAssemblyToLink Condition=" '%(ManagedAssemblyToLink.IsTrimmable)' == 'true' And '%(ManagedAssemblyToLink.TrimMode)' == '' ">
+        <TrimMode>$(TrimMode)</TrimMode>
+      </ManagedAssemblyToLink>
+      <ManagedAssemblyToLink Condition=" '%(ManagedAssemblyToLink.IsTrimmable)' == 'false' And '%(ManagedAssemblyToLink.TrimMode)' == '' ">
+        <TrimMode>$(_TrimmerDefaultAction)</TrimMode>
       </ManagedAssemblyToLink>
     </ItemGroup>
 


### PR DESCRIPTION
This implements the SDK side of the behavior described at https://github.com/mono/linker/blob/main/docs/design/trimmed-assemblies.md#net-6.

This includes a linker update with https://github.com/mono/linker/pull/1839.

The last step will be to remove https://github.com/dotnet/installer/blob/master/src/redist/targets/GenerateBundledVersions.targets#L253 when this flows to installer.

@pranavkm 