### PR TITLE
Correctly resolve metadata reference from current assembly

### DIFF
--- a/src/RazorSdk/SourceGenerators/RazorSourceGenerator.cs
+++ b/src/RazorSdk/SourceGenerators/RazorSourceGenerator.cs
@@ -168,7 +168,7 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
             tagHelperFeature.Compilation = GeneratorExecutionContext.Compilation.AddSyntaxTrees(results.Take(files.Count));
             ArrayPool<SyntaxTree>.Shared.Return(results);
 
-            var currentMetadataReference = GeneratorExecutionContext.Compilation.GetMetadataReference(GeneratorExecutionContext.Compilation.Assembly);
+            var currentMetadataReference = GeneratorExecutionContext.Compilation.ToMetadataReference();
             tagHelperFeature.TargetReference = currentMetadataReference;
             var assemblyTagHelpers = tagHelperFeature.GetDescriptors();
 


### PR DESCRIPTION
Should address https://github.com/dotnet/aspnetcore/issues/30421.

`GeneratorExecutionContext.Compilation.GetMetadataReference` cannot actually resolve a metadata reference for an assembly that is currently being created. As a result, `currentMetadataReference` was always null. When `TargetReference` is null, we end up enumerating the entire list of `Compilation.References` for TagHelpers (without caching it).

We enumerate again when we call `GetTagHelperDescriptorsFromReferences` so we were effectively doing the work twice (once without caching at all).

Using `context.Compilation. ToMetadataReference` to compute the MetadataReference associated with the `TargetAssembly` resolves this.