### PR TITLE
[release/6.0.1xx-preview2] Update ILLink analyzer with suppressions

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -100,11 +100,11 @@
     </Dependency>
     <Dependency Name="Microsoft.NET.ILLink.Tasks" Version="6.0.100-preview.2.21118.1">
       <Uri>https://github.com/mono/linker</Uri>
-      <Sha>422f2f710707c1cf95dd513022c8fbef19f177dc</Sha>
+      <Sha>ed016c44d716a4179ba6d0f532af0af5ebb04541</Sha>
     </Dependency>
     <Dependency Name="Microsoft.NET.ILLink.Analyzers" Version="6.0.100-preview.2.21118.1">
       <Uri>https://github.com/mono/linker</Uri>
-      <Sha>422f2f710707c1cf95dd513022c8fbef19f177dc</Sha>
+      <Sha>ed016c44d716a4179ba6d0f532af0af5ebb04541</Sha>
     </Dependency>
     <Dependency Name="System.CodeDom" Version="6.0.0-preview.2.21123.7">
       <Uri>https://github.com/dotnet/runtime</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -98,13 +98,13 @@
       <Uri>https://github.com/microsoft/vstest</Uri>
       <Sha>34fa5b59661c3d87c849e81fa5be68e3dec90b76</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.ILLink.Tasks" Version="6.0.100-preview.2.21118.1">
+    <Dependency Name="Microsoft.NET.ILLink.Tasks" Version="6.0.100-preview.2.21124.3">
       <Uri>https://github.com/mono/linker</Uri>
-      <Sha>ed016c44d716a4179ba6d0f532af0af5ebb04541</Sha>
+      <Sha>6b3a3050c70577bd1b3fd7611eef56679e22a4f1</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.ILLink.Analyzers" Version="6.0.100-preview.2.21118.1">
+    <Dependency Name="Microsoft.NET.ILLink.Analyzers" Version="6.0.100-preview.2.21124.3">
       <Uri>https://github.com/mono/linker</Uri>
-      <Sha>ed016c44d716a4179ba6d0f532af0af5ebb04541</Sha>
+      <Sha>6b3a3050c70577bd1b3fd7611eef56679e22a4f1</Sha>
     </Dependency>
     <Dependency Name="System.CodeDom" Version="6.0.0-preview.2.21123.7">
       <Uri>https://github.com/dotnet/runtime</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -73,7 +73,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/mono/linker -->
-    <MicrosoftNETILLinkTasksPackageVersion>6.0.100-preview.2.21118.1</MicrosoftNETILLinkTasksPackageVersion>
+    <MicrosoftNETILLinkTasksPackageVersion>6.0.100-preview.2.21122.1</MicrosoftNETILLinkTasksPackageVersion>
     <MicrosoftNETILLinkAnalyzerPackageVersion>$(MicrosoftNETILLinkTasksPackageVersion)</MicrosoftNETILLinkAnalyzerPackageVersion>
   </PropertyGroup>
   <PropertyGroup>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -73,7 +73,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/mono/linker -->
-    <MicrosoftNETILLinkTasksPackageVersion>6.0.100-preview.2.21122.1</MicrosoftNETILLinkTasksPackageVersion>
+    <MicrosoftNETILLinkTasksPackageVersion>6.0.100-preview.2.21124.3</MicrosoftNETILLinkTasksPackageVersion>
     <MicrosoftNETILLinkAnalyzerPackageVersion>$(MicrosoftNETILLinkTasksPackageVersion)</MicrosoftNETILLinkAnalyzerPackageVersion>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ILLink.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ILLink.targets
@@ -40,6 +40,17 @@ Copyright (c) .NET Foundation. All rights reserved.
     <CustomResourceTypesSupport>false</CustomResourceTypesSupport>
   </PropertyGroup>
 
+  <PropertyGroup Condition=" '$(PublishTrimmed)' == 'true' ">
+    <SuppressTrimAnalysisWarnings Condition=" '$(SuppressTrimAnalysisWarnings)' == '' ">true</SuppressTrimAnalysisWarnings>
+  </PropertyGroup>
+
+  <!-- Suppress warnings produced by the linker or by the ILLink Roslyn analyzer. Warnings produced
+       exclusively by the linker should be set in PrepareForILLink, to avoid polluting the global NoWarn list. -->
+  <PropertyGroup Condition=" '$(PublishTrimmed)' == 'true' and '$(SuppressTrimAnalysisWarnings)' == 'true' ">
+    <!-- RequiresUnreferenceCodeAttribute method called -->
+    <NoWarn>$(NoWarn);IL2026</NoWarn>
+  </PropertyGroup>
+
   <!--
     ============================================================
                      ILLink
@@ -166,14 +177,13 @@ Copyright (c) .NET Foundation. All rights reserved.
                                        $([MSBuild]::VersionGreaterThanOrEquals($(EffectiveAnalysisLevel), '5.0')) ">5</ILLinkWarningLevel>
       <ILLinkWarningLevel Condition=" '$(ILLinkWarningLevel)' == '' ">0</ILLinkWarningLevel>
       <ILLinkTreatWarningsAsErrors Condition=" '$(ILLinkTreatWarningsAsErrors)' == '' ">$(TreatWarningsAsErrors)</ILLinkTreatWarningsAsErrors>
-      <SuppressTrimAnalysisWarnings Condition=" '$(SuppressTrimAnalysisWarnings)' == '' ">true</SuppressTrimAnalysisWarnings>
       <_ExtraTrimmerArgs>--skip-unresolved true $(_ExtraTrimmerArgs)</_ExtraTrimmerArgs>
       <TrimMode Condition=" '$(TrimMode)' == '' ">copyused</TrimMode>
     </PropertyGroup>
     
+    <!-- Suppress warnings produced by the linker. Any warnings shared with the analyzer should be
+         moved to the global PropertyGroup above. -->
     <PropertyGroup Condition=" '$(SuppressTrimAnalysisWarnings)' == 'true' ">
-      <!-- RequiresUnreferenceCodeAttribute method called -->
-      <NoWarn>$(NoWarn);IL2026</NoWarn>
       <!-- Invalid use of DynamicallyAccessedMembersAttribute -->
       <NoWarn>$(NoWarn);IL2041;IL2042;IL2043;IL2056</NoWarn>
       <!-- Reference to removed attribute type -->

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToRunILLink.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToRunILLink.cs
@@ -812,11 +812,12 @@ namespace Microsoft.NET.Publish.Tests
             var rid = EnvironmentInfo.GetCompatibleRid(targetFramework);
 
             var testProject = CreateTestProjectWithAnalysisWarnings(targetFramework, projectName);
+            testProject.AdditionalProperties["WarningsNotAsErrors"] = "IL2075;IL2026";
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
             var publishCommand = new PublishCommand(testAsset);
             publishCommand.Execute($"/p:RuntimeIdentifier={rid}", $"/p:SelfContained=true", "/p:PublishTrimmed=true", "/p:SuppressTrimAnalysisWarnings=false",
-                                    "/p:TreatWarningsAsErrors=true", "/p:WarningsNotAsErrors=\"IL2075;IL2026\"")
+                                    "/p:TreatWarningsAsErrors=true")
                 .Should().Fail()
                 // This warning is produced by both the analyzer and the linker. Don't make it an error for the test.
                 .And.HaveStdOutContaining("warning IL2026")
@@ -892,7 +893,8 @@ namespace Microsoft.NET.Publish.Tests
                                     "/p:TreatWarningsAsErrors=true", "/p:ILLinkTreatWarningsAsErrors=false", "/p:NoWarn=IL2026")
                 .Should().Pass()
                 // This warning is produced by both the analyzer and the linker. Ignore it for this test.
-                .And.NotHaveStdOutContaining("IL2026")
+                .And.NotHaveStdOutContaining("warning IL2026")
+                .And.NotHaveStdOutContaining("error IL2026")
                 .And.HaveStdOutContaining("warning IL2075");
         }
 


### PR DESCRIPTION
This is a port of https://github.com/dotnet/sdk/pull/16021 to P2, so that we can get a linker update including https://github.com/mono/linker/pull/1844 - which is necessary for the illink analyzer to light up. @agocke 