### PR TITLE
Updating System.CommandLine version

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -26,7 +26,7 @@
     <NETStandardLibraryNETFrameworkVersion>2.0.1-servicing-26011-01</NETStandardLibraryNETFrameworkVersion>
     <NewtonsoftJsonPackageVersion>11.0.1</NewtonsoftJsonPackageVersion>
     <NewtonsoftJsonVersion>$(NewtonsoftJsonPackageVersion)</NewtonsoftJsonVersion>
-    <SystemCommandLineVersion>2.0.0-beta1.21079.2</SystemCommandLineVersion>
+    <SystemCommandLineVersion>2.0.0-beta1.21118.1</SystemCommandLineVersion>
     <SystemDiagnosticsFileVersionInfoVersion>4.0.0</SystemDiagnosticsFileVersionInfoVersion>
     <SystemReflectionMetadataVersion>5.0.0</SystemReflectionMetadataVersion>
     <MicrosoftDotNetSignToolVersion>6.0.0-beta.21101.7</MicrosoftDotNetSignToolVersion>

--- a/src/BuiltInTools/dotnet-watch/Program.cs
+++ b/src/BuiltInTools/dotnet-watch/Program.cs
@@ -14,10 +14,10 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.Watcher.Internal;
-using Microsoft.DotNet.Watcher.Tools;
 using Microsoft.Extensions.Tools.Internal;
 using IConsole = Microsoft.Extensions.Tools.Internal.IConsole;
 using IReporter = Microsoft.Extensions.Tools.Internal.IReporter;
+using Resources = Microsoft.DotNet.Watcher.Tools.Resources;
 
 namespace Microsoft.DotNet.Watcher
 {

--- a/src/Cli/dotnet/CommandLineValidation/CommandLineValidationMessages.cs
+++ b/src/Cli/dotnet/CommandLineValidation/CommandLineValidationMessages.cs
@@ -10,7 +10,7 @@ using Microsoft.DotNet.Cli.CommandLineValidation;
 
 namespace Microsoft.DotNet.Cli
 {
-    internal sealed class CommandLineValidationMessages : ValidationMessages
+    internal sealed class CommandLineValidationMessages : Resources
     {
         public override string ExpectsOneArgument(SymbolResult symbolResult) =>
             symbolResult is CommandResult
@@ -61,6 +61,8 @@ namespace Microsoft.DotNet.Cli
 
         public override string ErrorReadingResponseFile(string filePath, IOException e) =>
             string.Format(LocalizableStrings.ErrorReadingResponseFile, filePath, e.Message);
+
+        public override string HelpOptionDescription() => LocalizableStrings.ShowHelpInfo;
     }
 
     internal static class SymbolResultExtensions

--- a/src/Cli/dotnet/CommonOptions.cs
+++ b/src/Cli/dotnet/CommonOptions.cs
@@ -4,7 +4,6 @@
 using System;
 using Microsoft.DotNet.Tools;
 using System.CommandLine;
-using System.Linq;
 using System.IO;
 using Microsoft.DotNet.Tools.Common;
 
@@ -13,7 +12,7 @@ namespace Microsoft.DotNet.Cli
     internal static class CommonOptions
     {
         public static Option PropertiesOption() =>
-            new Option<string[]>(new string[] { "-property", "/p" })
+            new ForwardedOption<string[]>(new string[] { "-property", "/p" })
             {
                 IsHidden = true
             }.ForwardAsProperty()
@@ -23,50 +22,51 @@ namespace Microsoft.DotNet.Cli
             VerbosityOption(o => $"-verbosity:{o}");
 
         public static Option VerbosityOption(Func<VerbosityOptions, string> format) =>
-            new Option<VerbosityOptions>(
+            new ForwardedOption<VerbosityOptions>(
                 new string[] { "-v", "--verbosity" },
                 description: CommonLocalizableStrings.VerbosityOptionDescription)
             {
-                Argument = new Argument<VerbosityOptions>(CommonLocalizableStrings.LevelArgumentName)
+                ArgumentHelpName = CommonLocalizableStrings.LevelArgumentName
             }.ForwardAsSingle(format);
 
         public static Option FrameworkOption(string description) =>
-            new Option<string>(
+            new ForwardedOption<string>(
                 new string[] { "-f", "--framework" },
                 description)
             {
-                Argument = new Argument<string>(CommonLocalizableStrings.FrameworkArgumentName)
-                    .AddSuggestions(Suggest.TargetFrameworksFromProjectFile())
-            }.ForwardAsSingle(o => $"-property:TargetFramework={o}");
+                ArgumentHelpName = CommonLocalizableStrings.FrameworkArgumentName
+                    
+            }.ForwardAsSingle(o => $"-property:TargetFramework={o}")
+            .AddSuggestions(Suggest.TargetFrameworksFromProjectFile());
 
         public static Option RuntimeOption(string description, bool withShortOption = true) =>
-            new Option<string>(
+            new ForwardedOption<string>(
                 withShortOption ? new string[] { "-r", "--runtime" } : new string[] { "--runtime" },
                 description)
             {
-                Argument = new Argument<string>(CommonLocalizableStrings.RuntimeIdentifierArgumentName)
-                    .AddSuggestions(Suggest.RunTimesFromProjectFile())
-            }.ForwardAsSingle(o => $"-property:RuntimeIdentifier={o}");
+                ArgumentHelpName = CommonLocalizableStrings.RuntimeIdentifierArgumentName
+            }.ForwardAsSingle(o => $"-property:RuntimeIdentifier={o}")
+            .AddSuggestions(Suggest.RunTimesFromProjectFile());
 
         public static Option CurrentRuntimeOption(string description) =>
-            new Option<bool>("--use-current-runtime", description)
+            new ForwardedOption<bool>("--use-current-runtime", description)
                 .ForwardAs("-property:UseCurrentRuntimeIdentifier=True");
 
         public static Option ConfigurationOption(string description) =>
-            new Option<string>(
+            new ForwardedOption<string>(
                 new string[] { "-c", "--configuration" },
                 description)
             {
-                Argument = new Argument<string>(CommonLocalizableStrings.ConfigurationArgumentName)
-                    .AddSuggestions(Suggest.ConfigurationsFromProjectFileOrDefaults())
-            }.ForwardAsSingle(o => $"-property:Configuration={o}");
+                ArgumentHelpName = CommonLocalizableStrings.ConfigurationArgumentName
+            }.ForwardAsSingle(o => $"-property:Configuration={o}")
+            .AddSuggestions(Suggest.ConfigurationsFromProjectFileOrDefaults());
 
         public static Option VersionSuffixOption() =>
-            new Option<string>(
+            new ForwardedOption<string>(
                 "--version-suffix",
                 CommonLocalizableStrings.CmdVersionSuffixDescription)
             {
-                Argument = new Argument<string>(CommonLocalizableStrings.VersionSuffixArgumentName)
+                ArgumentHelpName = CommonLocalizableStrings.VersionSuffixArgumentName
             }.ForwardAsSingle(o => $"-property:VersionSuffix={o}");
 
         public static Argument DefaultToCurrentDirectory(this Argument arg)
@@ -81,7 +81,7 @@ namespace Microsoft.DotNet.Cli
                 CommonLocalizableStrings.NoRestoreDescription);
 
         public static Option InteractiveMsBuildForwardOption() =>
-            new Option<bool>(
+            new ForwardedOption<bool>(
                 "--interactive",
                 CommonLocalizableStrings.CommandInteractiveOptionDescription)
             .ForwardAs(Utils.Constants.MsBuildInteractiveOption);

--- a/src/Cli/dotnet/ToolPackage/ToolPackageInstaller.cs
+++ b/src/Cli/dotnet/ToolPackage/ToolPackageInstaller.cs
@@ -56,7 +56,7 @@ namespace Microsoft.DotNet.ToolPackage
                         var tempProject = CreateTempProject(
                             packageId: packageId,
                             versionRange: versionRange,
-                            targetFramework: targetFramework ?? BundledTargetFramework.GetTargetFrameworkMoniker(),
+                            targetFramework: string.IsNullOrEmpty(targetFramework) ? BundledTargetFramework.GetTargetFrameworkMoniker() :  targetFramework,
                             restoreDirectory: stageDirectory,
                             assetJsonOutputDirectory: stageDirectory,
                             rootConfigDirectory: packageLocation.RootConfigDirectory,
@@ -134,7 +134,7 @@ namespace Microsoft.DotNet.ToolPackage
             var tempProject = CreateTempProject(
                 packageId: packageId,
                 versionRange: versionRange,
-                targetFramework: targetFramework ?? BundledTargetFramework.GetTargetFrameworkMoniker(),
+                targetFramework: string.IsNullOrEmpty(targetFramework) ? BundledTargetFramework.GetTargetFrameworkMoniker() : targetFramework,
                 assetJsonOutputDirectory: tempDirectoryForAssetJson,
                 restoreDirectory: null,
                 rootConfigDirectory: packageLocation.RootConfigDirectory,

--- a/src/Cli/dotnet/commands/dotnet-add/dotnet-add-package/AddPackageParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-add/dotnet-add-package/AddPackageParser.cs
@@ -20,36 +20,32 @@ namespace Microsoft.DotNet.Cli
             Description = LocalizableStrings.CmdPackageDescription
         }.AddSuggestions((parseResult, match) => QueryNuGet(match));
 
-        public static readonly Option VersionOption = new Option<string>(new string[] { "-v", "--version" },
-                              LocalizableStrings.CmdVersionDescription)
+        public static readonly Option VersionOption = new ForwardedOption<string>(new string[] { "-v", "--version" }, LocalizableStrings.CmdVersionDescription)
         {
-            Argument = new Argument<string>(LocalizableStrings.CmdVersion)
+            ArgumentHelpName = LocalizableStrings.CmdVersion
         }.ForwardAsSingle(o => $"--version {o}");
 
-        public static readonly Option FrameworkOption = new Option<string>(new string[] { "-f", "--framework" },
-                              LocalizableStrings.CmdFrameworkDescription)
+        public static readonly Option FrameworkOption = new ForwardedOption<string>(new string[] { "-f", "--framework" }, LocalizableStrings.CmdFrameworkDescription)
         {
-            Argument = new Argument<string>(LocalizableStrings.CmdFramework)
+            ArgumentHelpName = LocalizableStrings.CmdFramework
         }.ForwardAsSingle(o => $"--framework {o}");
 
         public static readonly Option NoRestoreOption = new Option<bool>(new string[] { "-n", "--no-restore" }, LocalizableStrings.CmdNoRestoreDescription);
 
-        public static readonly Option SourceOption = new Option<string>(new string[] { "-s", "--source" },
-                              LocalizableStrings.CmdSourceDescription)
+        public static readonly Option SourceOption = new ForwardedOption<string>(new string[] { "-s", "--source" }, LocalizableStrings.CmdSourceDescription)
         {
-            Argument = new Argument<string>(LocalizableStrings.CmdSource)
+            ArgumentHelpName = LocalizableStrings.CmdSource
         }.ForwardAsSingle(o => $"--source {o}");
 
-
-        public static readonly Option PackageDirOption = new Option<string>("--package-directory", LocalizableStrings.CmdPackageDirectoryDescription)
+        public static readonly Option PackageDirOption = new ForwardedOption<string>("--package-directory", LocalizableStrings.CmdPackageDirectoryDescription)
         {
-            Argument = new Argument<string>(LocalizableStrings.CmdPackageDirectory)
+            ArgumentHelpName = LocalizableStrings.CmdPackageDirectory
         }.ForwardAsSingle(o => $"--package-directory {o}");
 
-        public static readonly Option InteractiveOption = new Option<bool>("--interactive", CommonLocalizableStrings.CommandInteractiveOptionDescription)
+        public static readonly Option InteractiveOption = new ForwardedOption<bool>("--interactive", CommonLocalizableStrings.CommandInteractiveOptionDescription)
             .ForwardAs("--interactive");
 
-        public static readonly Option PrereleaseOption = new Option<bool>("--prerelease", CommonLocalizableStrings.CommandPrereleaseOptionDescription)
+        public static readonly Option PrereleaseOption = new ForwardedOption<bool>("--prerelease", CommonLocalizableStrings.CommandPrereleaseOptionDescription)
             .ForwardAs("--prerelease");
 
         public static Command GetCommand()

--- a/src/Cli/dotnet/commands/dotnet-add/dotnet-add-reference/AddProjectToProjectReferenceParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-add/dotnet-add-reference/AddProjectToProjectReferenceParser.cs
@@ -17,9 +17,9 @@ namespace Microsoft.DotNet.Cli
 
         public static readonly Option FrameworkOption = new Option<string>(new string[] { "-f", "--framework" }, LocalizableStrings.CmdFrameworkDescription)
         {
-            Argument = new Argument<string>(Tools.Add.PackageReference.LocalizableStrings.CmdFramework)
-                .AddSuggestions(Suggest.TargetFrameworksFromProjectFile())
-        };
+            ArgumentHelpName = Tools.Add.PackageReference.LocalizableStrings.CmdFramework
+                
+        }.AddSuggestions(Suggest.TargetFrameworksFromProjectFile());
 
         public static readonly Option InteractiveOption = CommonOptions.InteractiveOption();
 

--- a/src/Cli/dotnet/commands/dotnet-add/dotnet-add-reference/Program.cs
+++ b/src/Cli/dotnet/commands/dotnet-add/dotnet-add-reference/Program.cs
@@ -43,7 +43,7 @@ namespace Microsoft.DotNet.Tools.Add.ProjectToProjectReference
                     .Select((r) => MsbuildProject.FromFileOrDirectory(projects, r, interactive))
                     .ToList();
 
-            if (frameworkString == null)
+            if (string.IsNullOrEmpty(frameworkString))
             {
                 foreach (var tfm in msbuildProj.GetTargetFrameworks())
                 {

--- a/src/Cli/dotnet/commands/dotnet-build/BuildCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-build/BuildCommandParser.cs
@@ -16,17 +16,17 @@ namespace Microsoft.DotNet.Cli
             Arity = ArgumentArity.ZeroOrMore
         };
 
-        public static readonly Option OutputOption = new Option<string>(new string[] { "-o", "--output" }, LocalizableStrings.OutputOptionDescription)
+        public static readonly Option OutputOption = new ForwardedOption<string>(new string[] { "-o", "--output" }, LocalizableStrings.OutputOptionDescription)
         {
-            Argument = new Argument<string>(LocalizableStrings.OutputOptionName)
+            ArgumentHelpName = LocalizableStrings.OutputOptionName
         }.ForwardAsSingle(arg => $"-property:OutputPath={CommandDirectoryContext.GetFullPath(arg)}");
 
         public static readonly Option NoIncrementalOption = new Option<bool>("--no-incremental", LocalizableStrings.NoIncrementalOptionDescription);
 
-        public static readonly Option NoDependenciesOption = new Option<bool>("--no-dependencies", LocalizableStrings.NoDependenciesOptionDescription)
+        public static readonly Option NoDependenciesOption = new ForwardedOption<bool>("--no-dependencies", LocalizableStrings.NoDependenciesOptionDescription)
             .ForwardAs("-property:BuildProjectReferences=false");
 
-        public static readonly Option NoLogoOption = new Option<bool>("--nologo", LocalizableStrings.CmdNoLogo)
+        public static readonly Option NoLogoOption = new ForwardedOption<bool>("--nologo", LocalizableStrings.CmdNoLogo)
             .ForwardAs("-nologo");
 
         public static readonly Option NoRestoreOption = CommonOptions.NoRestoreOption();

--- a/src/Cli/dotnet/commands/dotnet-clean/CleanCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-clean/CleanCommandParser.cs
@@ -16,12 +16,12 @@ namespace Microsoft.DotNet.Cli
             Arity = ArgumentArity.ZeroOrMore
         };
 
-        public static readonly Option OutputOption = new Option<string>(new string[] { "-o", "--output" }, LocalizableStrings.CmdOutputDirDescription)
+        public static readonly Option OutputOption = new ForwardedOption<string>(new string[] { "-o", "--output" }, LocalizableStrings.CmdOutputDirDescription)
         {
-            Argument = new Argument<string>(LocalizableStrings.CmdOutputDir)
+            ArgumentHelpName = LocalizableStrings.CmdOutputDir
         }.ForwardAsSingle(o => $"-property:OutputPath={CommandDirectoryContext.GetFullPath(o)}");
 
-        public static readonly Option NoLogoOption = new Option<bool>("--nologo", LocalizableStrings.CmdNoLogo)
+        public static readonly Option NoLogoOption = new ForwardedOption<bool>("--nologo", LocalizableStrings.CmdNoLogo)
             .ForwardAs("-nologo");
 
         public static Command GetCommand()

--- a/src/Cli/dotnet/commands/dotnet-complete/CompleteCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-complete/CompleteCommandParser.cs
@@ -11,7 +11,7 @@ namespace Microsoft.DotNet.Cli
 
         public static readonly Option PositionOption = new Option<int>("--position")
         {
-            Argument = new Argument<int>("command")
+            ArgumentHelpName = "command"
         };
 
         public static Command GetCommand()

--- a/src/Cli/dotnet/commands/dotnet-help/HelpCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-help/HelpCommand.cs
@@ -29,7 +29,7 @@ namespace Microsoft.DotNet.Tools.Help
 
             result.ShowHelpOrErrorIfAppropriate();
 
-            if (result.ValueForArgument<string>(HelpCommandParser.Argument) != null)
+            if (!string.IsNullOrEmpty(result.ValueForArgument<string>(HelpCommandParser.Argument)))
             {
                 return new HelpCommand(result).Execute();
             }

--- a/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/ListPackageReferencesCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/ListPackageReferencesCommandParser.cs
@@ -10,45 +10,45 @@ namespace Microsoft.DotNet.Cli
 {
     internal static class ListPackageReferencesCommandParser
     {
-        public static readonly Option OutdatedOption = new Option<bool>("--outdated", LocalizableStrings.CmdOutdatedDescription)
+        public static readonly Option OutdatedOption = new ForwardedOption<bool>("--outdated", LocalizableStrings.CmdOutdatedDescription)
             .ForwardAs("--outdated");
 
-        public static readonly Option DepreciatedOption = new Option<bool>("--deprecated", LocalizableStrings.CmdDeprecatedDescription)
+        public static readonly Option DepreciatedOption = new ForwardedOption<bool>("--deprecated", LocalizableStrings.CmdDeprecatedDescription)
             .ForwardAs("--deprecated");
 
-        public static readonly Option VulnerableOption = new Option<bool>("--vulnerable", LocalizableStrings.CmdVulnerableDescription)
+        public static readonly Option VulnerableOption = new ForwardedOption<bool>("--vulnerable", LocalizableStrings.CmdVulnerableDescription)
             .ForwardAs("--vulnerable");
 
-        public static readonly Option FrameworkOption = new Option<IEnumerable<string>>("--framework", LocalizableStrings.CmdFrameworkDescription)
+        public static readonly Option FrameworkOption = new ForwardedOption<IEnumerable<string>>("--framework", LocalizableStrings.CmdFrameworkDescription)
         {
-            Argument = new Argument<IEnumerable<string>>(LocalizableStrings.CmdFramework) { Arity = ArgumentArity.OneOrMore }
+            ArgumentHelpName = LocalizableStrings.CmdFramework
         }.ForwardAsMany(o => ForwardedArguments("--framework", o))
         .AllowSingleArgPerToken();
 
-        public static readonly Option TransitiveOption = new Option<bool>("--include-transitive", LocalizableStrings.CmdTransitiveDescription)
+        public static readonly Option TransitiveOption = new ForwardedOption<bool>("--include-transitive", LocalizableStrings.CmdTransitiveDescription)
             .ForwardAs("--include-transitive");
 
-        public static readonly Option PrereleaseOption = new Option<bool>("--include-prerelease", LocalizableStrings.CmdPrereleaseDescription)
+        public static readonly Option PrereleaseOption = new ForwardedOption<bool>("--include-prerelease", LocalizableStrings.CmdPrereleaseDescription)
             .ForwardAs("--include-prerelease");
 
-        public static readonly Option HighestPatchOption = new Option<bool>("--highest-patch", LocalizableStrings.CmdHighestPatchDescription)
+        public static readonly Option HighestPatchOption = new ForwardedOption<bool>("--highest-patch", LocalizableStrings.CmdHighestPatchDescription)
             .ForwardAs("--highest-patch");
 
-        public static readonly Option HighestMinorOption = new Option<bool>("--highest-minor", LocalizableStrings.CmdHighestMinorDescription)
+        public static readonly Option HighestMinorOption = new ForwardedOption<bool>("--highest-minor", LocalizableStrings.CmdHighestMinorDescription)
             .ForwardAs("--highest-minor");
 
-        public static readonly Option ConfigOption = new Option<string>("--config", LocalizableStrings.CmdConfigDescription)
+        public static readonly Option ConfigOption = new ForwardedOption<string>("--config", LocalizableStrings.CmdConfigDescription)
         {
-            Argument = new Argument<string>(LocalizableStrings.CmdConfig)
+            ArgumentHelpName = LocalizableStrings.CmdConfig
         }.ForwardAsMany(o => new[] { "--config", o });
 
-        public static readonly Option SourceOption = new Option<IEnumerable<string>>("--source", LocalizableStrings.CmdSourceDescription)
+        public static readonly Option SourceOption = new ForwardedOption<IEnumerable<string>>("--source", LocalizableStrings.CmdSourceDescription)
         {
-            Argument = new Argument<IEnumerable<string>>(LocalizableStrings.CmdSource) { Arity = ArgumentArity.OneOrMore }
+            ArgumentHelpName = LocalizableStrings.CmdSource
         }.ForwardAsMany(o => ForwardedArguments("--source", o))
         .AllowSingleArgPerToken();
 
-        public static readonly Option InteractiveOption = new Option<bool>("--interactive", CommonLocalizableStrings.CommandInteractiveOptionDescription)
+        public static readonly Option InteractiveOption = new ForwardedOption<bool>("--interactive", CommonLocalizableStrings.CommandInteractiveOptionDescription)
             .ForwardAs("--interactive");
 
         public static Command GetCommand()

--- a/src/Cli/dotnet/commands/dotnet-new/NewCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-new/NewCommandParser.cs
@@ -30,10 +30,7 @@ namespace Microsoft.DotNet.Cli
         
         public static readonly Option ForceOption = new Option<bool>("--force");
         
-        public static readonly Option LanguageOption = new Option<string>(new string[] { "-lang", "--language" })
-        {
-            Argument = new Argument<string>()
-        };
+        public static readonly Option LanguageOption = new Option<string>(new string[] { "-lang", "--language" });
 
         public static readonly Option UpdateCheckOption = new Option<bool>("--update-check");
 

--- a/src/Cli/dotnet/commands/dotnet-pack/PackCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-pack/PackCommandParser.cs
@@ -16,24 +16,24 @@ namespace Microsoft.DotNet.Cli
             Arity = ArgumentArity.ZeroOrMore
         };
 
-        public static readonly Option OutputOption = new Option<string>(new string[] { "-o", "--output" }, LocalizableStrings.CmdOutputDirDescription)
+        public static readonly Option OutputOption = new ForwardedOption<string>(new string[] { "-o", "--output" }, LocalizableStrings.CmdOutputDirDescription)
         {
-            Argument = new Argument<string>(LocalizableStrings.CmdOutputDir)
+            ArgumentHelpName = LocalizableStrings.CmdOutputDir
         }.ForwardAsSingle(o => $"-property:PackageOutputPath={CommandDirectoryContext.GetFullPath(o)}");
 
-        public static readonly Option NoBuildOption = new Option<bool>("--no-build", LocalizableStrings.CmdNoBuildOptionDescription)
+        public static readonly Option NoBuildOption = new ForwardedOption<bool>("--no-build", LocalizableStrings.CmdNoBuildOptionDescription)
             .ForwardAs("-property:NoBuild=true");
 
-        public static readonly Option IncludeSymbolsOption = new Option<bool>("--include-symbols", LocalizableStrings.CmdIncludeSymbolsDescription)
+        public static readonly Option IncludeSymbolsOption = new ForwardedOption<bool>("--include-symbols", LocalizableStrings.CmdIncludeSymbolsDescription)
             .ForwardAs("-property:IncludeSymbols=true");
 
-        public static readonly Option IncludeSourceOption = new Option<bool>("--include-source", LocalizableStrings.CmdIncludeSourceDescription)
+        public static readonly Option IncludeSourceOption = new ForwardedOption<bool>("--include-source", LocalizableStrings.CmdIncludeSourceDescription)
             .ForwardAs("-property:IncludeSource=true");
 
-        public static readonly Option ServiceableOption = new Option<bool>(new string[] { "-s", "--serviceable" }, LocalizableStrings.CmdServiceableDescription)
+        public static readonly Option ServiceableOption = new ForwardedOption<bool>(new string[] { "-s", "--serviceable" }, LocalizableStrings.CmdServiceableDescription)
             .ForwardAs("-property:Serviceable=true");
 
-        public static readonly Option NoLogoOption = new Option<bool>("--nologo", LocalizableStrings.CmdNoLogo)
+        public static readonly Option NoLogoOption = new ForwardedOption<bool>("--nologo", LocalizableStrings.CmdNoLogo)
             .ForwardAs("-nologo");
 
         public static readonly Option NoRestoreOption = CommonOptions.NoRestoreOption();

--- a/src/Cli/dotnet/commands/dotnet-publish/PublishCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-publish/PublishCommandParser.cs
@@ -17,27 +17,27 @@ namespace Microsoft.DotNet.Cli
             Arity = ArgumentArity.ZeroOrMore
         };
 
-        public static readonly Option OuputOption = new Option<string>(new string[] { "-o", "--output" }, LocalizableStrings.OutputOptionDescription)
+        public static readonly Option OuputOption = new ForwardedOption<string>(new string[] { "-o", "--output" }, LocalizableStrings.OutputOptionDescription)
         {
-            Argument = new Argument<string>(LocalizableStrings.OutputOption)
+            ArgumentHelpName = LocalizableStrings.OutputOption
         }.ForwardAsSingle(o => $"-property:PublishDir={CommandDirectoryContext.GetFullPath(o)}");
 
-        public static readonly Option ManifestOption = new Option<IEnumerable<string>>("--manifest", LocalizableStrings.ManifestOptionDescription)
+        public static readonly Option ManifestOption = new ForwardedOption<IEnumerable<string>>("--manifest", LocalizableStrings.ManifestOptionDescription)
         {
-            Argument = new Argument<IEnumerable<string>>(LocalizableStrings.ManifestOption)
+            ArgumentHelpName = LocalizableStrings.ManifestOption
         }.ForwardAsSingle(o => $"-property:TargetManifestFiles={string.Join("%3B", o.Select(CommandDirectoryContext.GetFullPath))}")
         .AllowSingleArgPerToken();
 
-        public static readonly Option NoBuildOption = new Option<bool>("--no-build", LocalizableStrings.NoBuildOptionDescription)
+        public static readonly Option NoBuildOption = new ForwardedOption<bool>("--no-build", LocalizableStrings.NoBuildOptionDescription)
             .ForwardAs("-property:NoBuild=true");
 
-        public static readonly Option SelfContainedOption = new Option<bool>("--self-contained", LocalizableStrings.SelfContainedOptionDescription)
+        public static readonly Option SelfContainedOption = new ForwardedOption<bool>("--self-contained", LocalizableStrings.SelfContainedOptionDescription)
             .ForwardAsSingle(o =>  $"-property:SelfContained={o}");
 
-        public static readonly Option NoSelfContainedOption = new Option<bool>("--no-self-contained", LocalizableStrings.NoSelfContainedOptionDescription)
+        public static readonly Option NoSelfContainedOption = new ForwardedOption<bool>("--no-self-contained", LocalizableStrings.NoSelfContainedOptionDescription)
             .ForwardAs("-property:SelfContained=false");
 
-        public static readonly Option NoLogoOption = new Option<bool>("--nologo", LocalizableStrings.CmdNoLogo)
+        public static readonly Option NoLogoOption = new ForwardedOption<bool>("--nologo", LocalizableStrings.CmdNoLogo)
             .ForwardAs("-nologo");
 
         public static readonly Option NoRestoreOption = CommonOptions.NoRestoreOption();

--- a/src/Cli/dotnet/commands/dotnet-remove/dotnet-remove-package/RemovePackageParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-remove/dotnet-remove-package/RemovePackageParser.cs
@@ -16,7 +16,7 @@ namespace Microsoft.DotNet.Cli
             Arity = ArgumentArity.OneOrMore,
         };
 
-        public static readonly Option InteractiveOption = new Option<bool>("--interactive", CommonLocalizableStrings.CommandInteractiveOptionDescription)
+        public static readonly Option InteractiveOption = new ForwardedOption<bool>("--interactive", CommonLocalizableStrings.CommandInteractiveOptionDescription)
             .ForwardAs("--interactive");
 
         public static Command GetCommand()

--- a/src/Cli/dotnet/commands/dotnet-remove/dotnet-remove-reference/RemoveProjectToProjectReferenceParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-remove/dotnet-remove-reference/RemoveProjectToProjectReferenceParser.cs
@@ -18,7 +18,7 @@ namespace Microsoft.DotNet.Cli
 
         public static readonly Option FrameworkOption = new Option<string>(new string[] { "-f", "--framework" }, LocalizableStrings.CmdFrameworkDescription)
         {
-            Argument = new Argument<string>(CommonLocalizableStrings.CmdFramework)
+            ArgumentHelpName = CommonLocalizableStrings.CmdFramework
         };
 
         public static Command GetCommand()

--- a/src/Cli/dotnet/commands/dotnet-restore/RestoreCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-restore/RestoreCommandParser.cs
@@ -22,21 +22,21 @@ namespace Microsoft.DotNet.Cli
                 new Option[] {
                     CommonOptions.VerbosityOption(),
                     CommonOptions.InteractiveMsBuildForwardOption(),
-                    new Option<bool>(
+                    new ForwardedOption<bool>(
                         "--use-lock-file",
                         LocalizableStrings.CmdUseLockFileOptionDescription)
                             .ForwardAs("-property:RestorePackagesWithLockFile=true"),
-                    new Option<bool>(
+                    new ForwardedOption<bool>(
                         "--locked-mode",
                         LocalizableStrings.CmdLockedModeOptionDescription)
                             .ForwardAs("-property:RestoreLockedMode=true"),
-                    new Option<string>(
+                    new ForwardedOption<string>(
                         "--lock-file-path",
                         LocalizableStrings.CmdLockFilePathOptionDescription)
                     {
-                        Argument = new Argument<string>(LocalizableStrings.CmdLockFilePathOption)
+                        ArgumentHelpName = LocalizableStrings.CmdLockFilePathOption
                     }.ForwardAsSingle(o => $"-property:NuGetLockFilePath={o}"),
-                    new Option<bool>(
+                    new ForwardedOption<bool>(
                         "--force-evaluate",
                         LocalizableStrings.CmdReevaluateOptionDescription)
                             .ForwardAs("-property:RestoreForceEvaluate=true") })
@@ -67,48 +67,48 @@ namespace Microsoft.DotNet.Cli
         private static Option[] ImplicitRestoreOptions(bool showHelp, bool useShortOptions, bool includeRuntimeOption, bool includeNoDependenciesOption)
         {
             var options = new Option[] {
-                new Option<IEnumerable<string>>(
+                new ForwardedOption<IEnumerable<string>>(
                     useShortOptions ? new string[] {"-s", "--source" }  : new string[] { "--source" },
                     showHelp ? LocalizableStrings.CmdSourceOptionDescription : string.Empty)
                 {
-                    Argument = new Argument<IEnumerable<string>>(LocalizableStrings.CmdSourceOption) { Arity = ArgumentArity.OneOrMore },
+                    ArgumentHelpName = LocalizableStrings.CmdSourceOption,
                     IsHidden = !showHelp
                 }.ForwardAsSingle(o => $"-property:RestoreSources={string.Join("%3B", o)}")
                 .AllowSingleArgPerToken(),
-                new Option<string>(
+                new ForwardedOption<string>(
                     "--packages",
                     showHelp ? LocalizableStrings.CmdPackagesOptionDescription : string.Empty)
                 {
-                    Argument = new Argument<string>(LocalizableStrings.CmdPackagesOption),
+                    ArgumentHelpName = LocalizableStrings.CmdPackagesOption,
                     IsHidden = !showHelp
                 }.ForwardAsSingle(o => $"-property:RestorePackagesPath={CommandDirectoryContext.GetFullPath(o)}"),
 				CommonOptions.CurrentRuntimeOption(LocalizableStrings.CmdCurrentRuntimeOptionDescription),
-                new Option<bool>(
+                new ForwardedOption<bool>(
                     "--disable-parallel",
                     showHelp ? LocalizableStrings.CmdDisableParallelOptionDescription : string.Empty)
                 {
                     IsHidden = !showHelp
                 }.ForwardAs("-property:RestoreDisableParallel=true"),
-                new Option<string>(
+                new ForwardedOption<string>(
                     "--configfile",
                     showHelp ? LocalizableStrings.CmdConfigFileOptionDescription : string.Empty)
                 {
-                    Argument = new Argument<string>(LocalizableStrings.CmdConfigFileOption),
+                    ArgumentHelpName = LocalizableStrings.CmdConfigFileOption,
                     IsHidden = !showHelp
                 }.ForwardAsSingle(o => $"-property:RestoreConfigFile={CommandDirectoryContext.GetFullPath(o)}"),
-                new Option<bool>(
+                new ForwardedOption<bool>(
                     "--no-cache",
                     showHelp ? LocalizableStrings.CmdNoCacheOptionDescription : string.Empty)
                 {
                     IsHidden = !showHelp
                 }.ForwardAs("-property:RestoreNoCache=true"),
-                new Option<bool>(
+                new ForwardedOption<bool>(
                     "--ignore-failed-sources",
                     showHelp ? LocalizableStrings.CmdIgnoreFailedSourcesOptionDescription : string.Empty)
                 {
                     IsHidden = !showHelp
                 }.ForwardAs("-property:RestoreIgnoreFailedSources=true"),
-                new Option<bool>(
+                new ForwardedOption<bool>(
                     useShortOptions ? new string[] {"-f", "--force" } : new string[] {"--force" },
                     LocalizableStrings.CmdForceRestoreOptionDescription)
                 {
@@ -120,22 +120,22 @@ namespace Microsoft.DotNet.Cli
             if (includeRuntimeOption)
             {
                 options = options.Append(
-                    new Option<IEnumerable<string>>(
+                    new ForwardedOption<IEnumerable<string>>(
                         useShortOptions ? new string[] { "-r", "--runtime" } : new string[] { "--runtime" },
                         LocalizableStrings.CmdRuntimeOptionDescription)
                     {
-                        Argument = new Argument<IEnumerable<string>>(LocalizableStrings.CmdRuntimeOption) { Arity = ArgumentArity.OneOrMore }
-                            .AddSuggestions(Suggest.RunTimesFromProjectFile()),
+                        ArgumentHelpName = LocalizableStrings.CmdRuntimeOption,
                         IsHidden = !showHelp
                     }.ForwardAsSingle(o => $"-property:RuntimeIdentifiers={string.Join("%3B", o)}")
                     .AllowSingleArgPerToken()
+                    .AddSuggestions(Suggest.RunTimesFromProjectFile())
                 ).ToArray();
             }
 
             if (includeNoDependenciesOption)
             {
                 options = options.Append(
-                    new Option<bool>(
+                    new ForwardedOption<bool>(
                         "--no-dependencies",
                         LocalizableStrings.CmdNoDependenciesOptionDescription)
                     {

--- a/src/Cli/dotnet/commands/dotnet-run/LaunchSettings/LaunchSettingsManager.cs
+++ b/src/Cli/dotnet/commands/dotnet-run/LaunchSettings/LaunchSettingsManager.cs
@@ -44,7 +44,7 @@ namespace Microsoft.DotNet.Tools.Run.LaunchSettings
                     }
 
                     JsonElement profileObject;
-                    if (profileName == null)
+                    if (string.IsNullOrEmpty(profileName))
                     {
                         profileObject = profilesObject
                             .EnumerateObject()

--- a/src/Cli/dotnet/commands/dotnet-run/RunCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-run/RunCommandParser.cs
@@ -15,15 +15,9 @@ namespace Microsoft.DotNet.Cli
 
         public static readonly Option RuntimeOption = CommonOptions.RuntimeOption(LocalizableStrings.RuntimeOptionDescription);
 
-        public static readonly Option ProjectOption = new Option<string>(new string[] { "-p", "--project" }, LocalizableStrings.CommandOptionProjectDescription)
-        {
-            Argument = new Argument<string>()
-        };
+        public static readonly Option ProjectOption = new Option<string>(new string[] { "-p", "--project" }, LocalizableStrings.CommandOptionProjectDescription);
 
-        public static readonly Option LaunchProfileOption = new Option<string>("--launch-profile", LocalizableStrings.CommandOptionLaunchProfileDescription)
-        {
-            Argument = new Argument<string>()
-        };
+        public static readonly Option LaunchProfileOption = new Option<string>("--launch-profile", LocalizableStrings.CommandOptionLaunchProfileDescription);
 
         public static readonly Option NoLaunchProfileOption = new Option<bool>("--no-launch-profile", LocalizableStrings.CommandOptionNoLaunchProfileDescription);
 

--- a/src/Cli/dotnet/commands/dotnet-sln/add/Program.cs
+++ b/src/Cli/dotnet/commands/dotnet-sln/add/Program.cs
@@ -37,7 +37,7 @@ namespace Microsoft.DotNet.Tools.Sln.Add
                 throw new GracefulException(LocalizableStrings.SolutionFolderAndInRootMutuallyExclusive);
             }
 
-            _relativeRootSolutionFolders = relativeRoot?.Split(Path.DirectorySeparatorChar);
+            _relativeRootSolutionFolders = string.IsNullOrEmpty(relativeRoot)? null : relativeRoot.Split(Path.DirectorySeparatorChar);
         }
 
         public override int Execute()

--- a/src/Cli/dotnet/commands/dotnet-sln/add/SlnAddParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-sln/add/SlnAddParser.cs
@@ -17,10 +17,7 @@ namespace Microsoft.DotNet.Cli
 
         public static readonly Option InRootOption = new Option<bool>("--in-root", LocalizableStrings.InRoot);
 
-        public static readonly Option SolutionFolderOption = new Option<string>(new string[] { "-s", "--solution-folder" }, LocalizableStrings.AddProjectSolutionFolderArgumentDescription)
-        {
-            Argument = new Argument<string>()
-        };
+        public static readonly Option SolutionFolderOption = new Option<string>(new string[] { "-s", "--solution-folder" }, LocalizableStrings.AddProjectSolutionFolderArgumentDescription);
 
         public static Command GetCommand()
         {

--- a/src/Cli/dotnet/commands/dotnet-store/StoreCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-store/StoreCommandParser.cs
@@ -15,13 +15,10 @@ namespace Microsoft.DotNet.Cli
             Arity = ArgumentArity.ZeroOrMore,
         };
 
-        public static readonly Option ManifestOption = new Option<IEnumerable<string>>(new string[] { "-m", "--manifest" },
+        public static readonly Option ManifestOption = new ForwardedOption<IEnumerable<string>>(new string[] { "-m", "--manifest" },
                     LocalizableStrings.ProjectManifestDescription)
         {
-            Argument = new Argument<IEnumerable<string>>(LocalizableStrings.ProjectManifest)
-            {
-                Arity = ArgumentArity.OneOrMore
-            }
+            ArgumentHelpName = LocalizableStrings.ProjectManifest
         }.ForwardAsMany(o => {
             // the first path doesn't need to go through CommandDirectoryContext.ExpandPath
             // since it is a direct argument to MSBuild, not a property
@@ -44,25 +41,25 @@ namespace Microsoft.DotNet.Cli
             }
         }).AllowSingleArgPerToken();
 
-        public static readonly Option FrameworkVersionOption = new Option<string>("--framework-version", LocalizableStrings.FrameworkVersionOptionDescription)
+        public static readonly Option FrameworkVersionOption = new ForwardedOption<string>("--framework-version", LocalizableStrings.FrameworkVersionOptionDescription)
         {
-            Argument = new Argument<string>(LocalizableStrings.FrameworkVersionOption)
+            ArgumentHelpName = LocalizableStrings.FrameworkVersionOption
         }.ForwardAsSingle(o => $"-property:RuntimeFrameworkVersion={o}");
 
-        public static readonly Option OutputOption = new Option<string>(new string[] { "-o", "--output" }, LocalizableStrings.OutputOptionDescription)
+        public static readonly Option OutputOption = new ForwardedOption<string>(new string[] { "-o", "--output" }, LocalizableStrings.OutputOptionDescription)
         {
-            Argument = new Argument<string>(LocalizableStrings.OutputOption)
+            ArgumentHelpName = LocalizableStrings.OutputOption
         }.ForwardAsSingle(o => $"-property:ComposeDir={CommandDirectoryContext.GetFullPath(o)}");
 
-        public static readonly Option WorkingDirOption = new Option<string>(new string[] { "-w", "--working-dir" }, LocalizableStrings.IntermediateWorkingDirOptionDescription)
+        public static readonly Option WorkingDirOption = new ForwardedOption<string>(new string[] { "-w", "--working-dir" }, LocalizableStrings.IntermediateWorkingDirOptionDescription)
         {
-            Argument = new Argument<string>(LocalizableStrings.IntermediateWorkingDirOption)
+            ArgumentHelpName = LocalizableStrings.IntermediateWorkingDirOption
         }.ForwardAsSingle(o => $"-property:ComposeWorkingDir={CommandDirectoryContext.GetFullPath(o)}");
 
-        public static readonly Option SkipOptimizationOption = new Option<bool>("--skip-optimization", LocalizableStrings.SkipOptimizationOptionDescription)
+        public static readonly Option SkipOptimizationOption = new ForwardedOption<bool>("--skip-optimization", LocalizableStrings.SkipOptimizationOptionDescription)
             .ForwardAs("-property:SkipOptimization=true");
 
-        public static readonly Option SkipSymbolsOption = new Option<bool>("--skip-symbols", LocalizableStrings.SkipSymbolsOptionDescription)
+        public static readonly Option SkipSymbolsOption = new ForwardedOption<bool>("--skip-symbols", LocalizableStrings.SkipSymbolsOptionDescription)
             .ForwardAs("-property:CreateProfilingSymbols=false");
 
         public static Command GetCommand()

--- a/src/Cli/dotnet/commands/dotnet-test/TestCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/TestCommandParser.cs
@@ -17,42 +17,33 @@ namespace Microsoft.DotNet.Cli
             Arity = ArgumentArity.ZeroOrMore,
         };
 
-        public static readonly Option SettingsOption = new Option<string>(new string[] { "-s", "--settings" }, LocalizableStrings.CmdSettingsDescription)
+        public static readonly Option SettingsOption = new ForwardedOption<string>(new string[] { "-s", "--settings" }, LocalizableStrings.CmdSettingsDescription)
         {
-            Argument = new Argument<string>(LocalizableStrings.CmdSettingsFile)
+            ArgumentHelpName = LocalizableStrings.CmdSettingsFile
         }.ForwardAsSingle(o => $"-property:VSTestSetting={CommandDirectoryContext.GetFullPath(o)}");
 
-        public static readonly Option ListTestsOption = new Option<bool>(new string[] { "-t", "--list-tests" }, LocalizableStrings.CmdListTestsDescription)
+        public static readonly Option ListTestsOption = new ForwardedOption<bool>(new string[] { "-t", "--list-tests" }, LocalizableStrings.CmdListTestsDescription)
               .ForwardAs("-property:VSTestListTests=true");
 
         public static readonly Option EnvOption = new Option<IEnumerable<string>>(new string[] { "-e", "--environment" }, LocalizableStrings.CmdEnvironmentVariableDescription)
         {
-            Argument = new Argument<IEnumerable<string>>(LocalizableStrings.CmdEnvironmentVariableExpression)
-            {
-                Arity = ArgumentArity.OneOrMore
-            }
+            ArgumentHelpName = LocalizableStrings.CmdEnvironmentVariableExpression
         }.AllowSingleArgPerToken();
 
-        public static readonly Option FilterOption = new Option<string>("--filter", LocalizableStrings.CmdTestCaseFilterDescription)
+        public static readonly Option FilterOption = new ForwardedOption<string>("--filter", LocalizableStrings.CmdTestCaseFilterDescription)
         {
-            Argument = new Argument<string>(LocalizableStrings.CmdTestCaseFilterExpression)
+            ArgumentHelpName = LocalizableStrings.CmdTestCaseFilterExpression
         }.ForwardAsSingle(o => $"-property:VSTestTestCaseFilter={o}");
 
-        public static readonly Option AdapterOption = new Option<IEnumerable<string>>(new string[] { "-a", "--test-adapter-path" }, LocalizableStrings.CmdTestAdapterPathDescription)
+        public static readonly Option AdapterOption = new ForwardedOption<IEnumerable<string>>(new string[] { "-a", "--test-adapter-path" }, LocalizableStrings.CmdTestAdapterPathDescription)
         {
-            Argument = new Argument<IEnumerable<string>>(LocalizableStrings.CmdTestAdapterPath)
-            {
-                Arity = ArgumentArity.OneOrMore
-            }
+            ArgumentHelpName = LocalizableStrings.CmdTestAdapterPath
         }.ForwardAsSingle(o => $"-property:VSTestTestAdapterPath=\"{string.Join(";", o.Select(CommandDirectoryContext.GetFullPath))}\"")
         .AllowSingleArgPerToken();
 
-        public static readonly Option LoggerOption = new Option<IEnumerable<string>>(new string[] { "-l", "--logger" }, LocalizableStrings.CmdLoggerDescription)
+        public static readonly Option LoggerOption = new ForwardedOption<IEnumerable<string>>(new string[] { "-l", "--logger" }, LocalizableStrings.CmdLoggerDescription)
         {
-            Argument = new Argument<IEnumerable<string>>(LocalizableStrings.CmdLoggerOption)
-            {
-                Arity = ArgumentArity.OneOrMore
-            }
+            ArgumentHelpName = LocalizableStrings.CmdLoggerOption
         }.ForwardAsSingle(o => {
             var loggersString = string.Join(";", GetSemiColonEscapedArgs(o));
 
@@ -60,61 +51,58 @@ namespace Microsoft.DotNet.Cli
         })
         .AllowSingleArgPerToken();
 
-        public static readonly Option OutputOption = new Option<string>(new string[] { "-o", "--output" }, LocalizableStrings.CmdOutputDescription)
+        public static readonly Option OutputOption = new ForwardedOption<string>(new string[] { "-o", "--output" }, LocalizableStrings.CmdOutputDescription)
         {
-            Argument = new Argument<string>(LocalizableStrings.CmdOutputDir)
+            ArgumentHelpName = LocalizableStrings.CmdOutputDir
         }.ForwardAsSingle(o => $"-property:OutputPath={CommandDirectoryContext.GetFullPath(o)}");
 
-        public static readonly Option DiagOption = new Option<string>(new string[] { "-d", "--diag" }, LocalizableStrings.CmdPathTologFileDescription)
+        public static readonly Option DiagOption = new ForwardedOption<string>(new string[] { "-d", "--diag" }, LocalizableStrings.CmdPathTologFileDescription)
         {
-            Argument = new Argument<string>(LocalizableStrings.CmdPathToLogFile)
+            ArgumentHelpName = LocalizableStrings.CmdPathToLogFile
         }.ForwardAsSingle(o => $"-property:VSTestDiag={CommandDirectoryContext.GetFullPath(o)}");
 
-        public static readonly Option NoBuildOption = new Option<bool>("--no-build", LocalizableStrings.CmdNoBuildDescription)
+        public static readonly Option NoBuildOption = new ForwardedOption<bool>("--no-build", LocalizableStrings.CmdNoBuildDescription)
             .ForwardAs("-property:VSTestNoBuild=true");
 
-        public static readonly Option ResultsOption = new Option<string>(new string[] { "-r", "--results-directory" }, LocalizableStrings.CmdResultsDirectoryDescription)
+        public static readonly Option ResultsOption = new ForwardedOption<string>(new string[] { "-r", "--results-directory" }, LocalizableStrings.CmdResultsDirectoryDescription)
         {
-            Argument = new Argument<string>(LocalizableStrings.CmdPathToResultsDirectory)
+            ArgumentHelpName = LocalizableStrings.CmdPathToResultsDirectory
         }.ForwardAsSingle(o => $"-property:VSTestResultsDirectory={CommandDirectoryContext.GetFullPath(o)}");
 
-        public static readonly Option CollectOption = new Option<IEnumerable<string>>("--collect", LocalizableStrings.cmdCollectDescription)
+        public static readonly Option CollectOption = new ForwardedOption<IEnumerable<string>>("--collect", LocalizableStrings.cmdCollectDescription)
         {
-            Argument = new Argument<IEnumerable<string>>(LocalizableStrings.cmdCollectFriendlyName)
-            {
-                Arity = ArgumentArity.OneOrMore
-            }
+            ArgumentHelpName = LocalizableStrings.cmdCollectFriendlyName
         }.ForwardAsSingle(o => $"-property:VSTestCollect=\"{string.Join(";", o)}\"")
         .AllowSingleArgPerToken();
 
-        public static readonly Option BlameOption = new Option<bool>("--blame", LocalizableStrings.CmdBlameDescription)
+        public static readonly Option BlameOption = new ForwardedOption<bool>("--blame", LocalizableStrings.CmdBlameDescription)
             .ForwardAs("-property:VSTestBlame=true");
 
-        public static readonly Option BlameCrashOption = new Option<bool>("--blame-crash", LocalizableStrings.CmdBlameCrashDescription)
+        public static readonly Option BlameCrashOption = new ForwardedOption<bool>("--blame-crash", LocalizableStrings.CmdBlameCrashDescription)
             .ForwardAs("-property:VSTestBlameCrash=true");
 
         public static readonly Argument BlameCrashDumpArgument = new Argument<string>(LocalizableStrings.CrashDumpTypeArgumentName).FromAmong(new string[] { "full", "mini" });
 
-        public static readonly Option BlameCrashDumpOption = new Option<string>("--blame-crash-dump-type", LocalizableStrings.CmdBlameCrashDumpTypeDescription)
+        public static readonly Option BlameCrashDumpOption = new ForwardedOption<string>("--blame-crash-dump-type", LocalizableStrings.CmdBlameCrashDumpTypeDescription)
             .ForwardAsMany(o => new[] { "-property:VSTestBlameCrash=true", $"-property:VSTestBlameCrashDumpType={o}" });
 
-        public static readonly Option BlameCrashAlwaysOption = new Option<string>("--blame-crash-collect-always", LocalizableStrings.CmdBlameCrashCollectAlwaysDescription)
+        public static readonly Option BlameCrashAlwaysOption = new ForwardedOption<string>("--blame-crash-collect-always", LocalizableStrings.CmdBlameCrashCollectAlwaysDescription)
             .ForwardAsMany(o => new[] {"-property:VSTestBlameCrash=true", "-property:VSTestBlameCrashCollectAlways=true"});
 
-        public static readonly Option BlameHangOption = new Option<bool>("--blame-hang", LocalizableStrings.CmdBlameHangDescription)
+        public static readonly Option BlameHangOption = new ForwardedOption<bool>("--blame-hang", LocalizableStrings.CmdBlameHangDescription)
             .ForwardAs("-property:VSTestBlameHang=true");
 
         public static readonly Argument BlameHangDumpArgument = new Argument<string>(LocalizableStrings.HangDumpTypeArgumentName).FromAmong(new string[] { "full", "mini", "none" });
 
-        public static readonly Option BlameHangDumpOption = new Option<string>("--blame-hang-dump-type", LocalizableStrings.CmdBlameHangDumpTypeDescription)
+        public static readonly Option BlameHangDumpOption = new ForwardedOption<string>("--blame-hang-dump-type", LocalizableStrings.CmdBlameHangDumpTypeDescription)
             .ForwardAsMany(o => new[] { "-property:VSTestBlameHang=true", $"-property:VSTestBlameHangDumpType={o}" });
 
-        public static readonly Option BlameHangTimeoutOption = new Option<string>("--blame-hang-timeout", LocalizableStrings.CmdBlameHangTimeoutDescription)
+        public static readonly Option BlameHangTimeoutOption = new ForwardedOption<string>("--blame-hang-timeout", LocalizableStrings.CmdBlameHangTimeoutDescription)
         {
-            Argument = new Argument<string>(LocalizableStrings.HangTimeoutArgumentName)
+            ArgumentHelpName = LocalizableStrings.HangTimeoutArgumentName
         }.ForwardAsMany(o => new[] { "-property:VSTestBlameHang=true", $"-property:VSTestBlameHangTimeout={o}" });
 
-        public static readonly Option NoLogoOption = new Option<bool>("--nologo", LocalizableStrings.CmdNoLogo)
+        public static readonly Option NoLogoOption = new ForwardedOption<bool>("--nologo", LocalizableStrings.CmdNoLogo)
             .ForwardAs("-property:VSTestNoLogo=nologo");
 
         public static readonly Option NoRestoreOption = CommonOptions.NoRestoreOption();

--- a/src/Cli/dotnet/commands/dotnet-tool/ToolCommandRestorePassThroughOptions.cs
+++ b/src/Cli/dotnet/commands/dotnet-tool/ToolCommandRestorePassThroughOptions.cs
@@ -11,22 +11,22 @@ namespace Microsoft.DotNet.Cli
 {
     internal static class ToolCommandRestorePassThroughOptions
     {
-        public static Option DisableParallelOption = new Option<bool>(
+        public static Option DisableParallelOption = new ForwardedOption<bool>(
                 "--disable-parallel",
                 LocalizableStrings.CmdDisableParallelOptionDescription)
                 .ForwardAs("--disable-parallel");
 
-        public static Option NoCacheOption = new Option<bool>(
+        public static Option NoCacheOption = new ForwardedOption<bool>(
                 "--no-cache",
                 LocalizableStrings.CmdNoCacheOptionDescription)
                 .ForwardAs("--no-cache");
 
-        public static Option IgnoreFailedSourcesOption = new Option<bool>(
+        public static Option IgnoreFailedSourcesOption = new ForwardedOption<bool>(
                 "--ignore-failed-sources",
                 LocalizableStrings.CmdIgnoreFailedSourcesOptionDescription)
                 .ForwardAs("--ignore-failed-sources");
 
-        public static Option InteractiveRestoreOption = new Option<bool>(
+        public static Option InteractiveRestoreOption = new ForwardedOption<bool>(
                 "--interactive",
                 CommonLocalizableStrings.CommandInteractiveOptionDescription)
                 .ForwardAs(Constants.RestoreInteractiveOption);

--- a/src/Cli/dotnet/commands/dotnet-tool/common/ToolAppliedOption.cs
+++ b/src/Cli/dotnet/commands/dotnet-tool/common/ToolAppliedOption.cs
@@ -21,16 +21,13 @@ namespace Microsoft.DotNet.Tools.Tool.Common
         public static string ToolPathOptionAlias = "--tool-path";
         public static Option ToolPathOption(string description, string argumentName) => new Option<string>(ToolPathOptionAlias, description)
         {
-            Argument = new Argument<string>(argumentName)
+            ArgumentHelpName = argumentName
         };
 
         public static string ToolManifestOptionAlias = "--tool-manifest";
-        public static Option ToolManifestOption(string description, string argumentName) => new Option<string>(ToolManifestOptionAlias, description)
+        public static Option ToolManifestOption(string description, string argumentName) => new Option<string>(ToolManifestOptionAlias, description, arity: ArgumentArity.ZeroOrOne)
         {
-            Argument = new Argument<string>(argumentName)
-            {
-                Arity = ArgumentArity.ZeroOrOne
-            }
+            ArgumentHelpName = argumentName
         };
 
         internal static void EnsureNoConflictGlobalLocalToolPathOption(

--- a/src/Cli/dotnet/commands/dotnet-tool/install/ToolInstallCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-tool/install/ToolInstallCommandParser.cs
@@ -17,22 +17,22 @@ namespace Microsoft.DotNet.Cli
 
         public static readonly Option VersionOption = new Option<string>("--version", LocalizableStrings.VersionOptionDescription)
         {
-            Argument = new Argument<string>(LocalizableStrings.VersionOptionName)
+            ArgumentHelpName = LocalizableStrings.VersionOptionName
         };
 
         public static readonly Option ConfigOption = new Option<string>("--configfile", LocalizableStrings.ConfigFileOptionDescription)
         {
-            Argument = new Argument<string>(LocalizableStrings.ConfigFileOptionName)
+            ArgumentHelpName = LocalizableStrings.ConfigFileOptionName
         };
 
-        public static readonly Option AddSourceOption = new Option<IEnumerable<string>>("--add-source", LocalizableStrings.AddSourceOptionDescription)
+        public static readonly Option AddSourceOption = new Option<string[]>("--add-source", LocalizableStrings.AddSourceOptionDescription)
         {
-            Argument = new Argument<IEnumerable<string>>(LocalizableStrings.AddSourceOptionName)
+            ArgumentHelpName = LocalizableStrings.AddSourceOptionName
         }.AllowSingleArgPerToken();
 
         public static readonly Option FrameworkOption = new Option<string>("--framework", LocalizableStrings.FrameworkOptionDescription)
         {
-            Argument = new Argument<string>(LocalizableStrings.FrameworkOptionName)
+            ArgumentHelpName = LocalizableStrings.FrameworkOptionName
         };
 
         public static readonly Option VerbosityOption = CommonOptions.VerbosityOption();

--- a/src/Cli/dotnet/commands/dotnet-tool/install/ToolInstallGlobalOrToolPathCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-tool/install/ToolInstallGlobalOrToolPathCommand.cs
@@ -70,7 +70,7 @@ namespace Microsoft.DotNet.Tools.Tool.Install
 
         public override int Execute()
         {
-            if (_configFilePath != null && !File.Exists(_configFilePath))
+            if (!string.IsNullOrEmpty(_configFilePath) && !File.Exists(_configFilePath))
             {
                 throw new GracefulException(
                     string.Format(
@@ -88,7 +88,7 @@ namespace Microsoft.DotNet.Tools.Tool.Install
             }
 
             DirectoryPath? toolPath = null;
-            if (_toolPath != null)
+            if (!string.IsNullOrEmpty(_toolPath))
             {
                 toolPath = new DirectoryPath(_toolPath);
             }
@@ -105,7 +105,7 @@ namespace Microsoft.DotNet.Tools.Tool.Install
             }
 
             FilePath? configFile = null;
-            if (_configFilePath != null)
+            if (!string.IsNullOrEmpty(_configFilePath))
             {
                 configFile = new FilePath(_configFilePath);
             }

--- a/src/Cli/dotnet/commands/dotnet-tool/install/ToolInstallLocalInstaller.cs
+++ b/src/Cli/dotnet/commands/dotnet-tool/install/ToolInstallLocalInstaller.cs
@@ -52,7 +52,7 @@ namespace Microsoft.DotNet.Tools.Tool.Install
 
         public IToolPackage Install(FilePath manifestFile)
         {
-            if (_configFilePath != null && !File.Exists(_configFilePath))
+            if (!string.IsNullOrEmpty(_configFilePath) && !File.Exists(_configFilePath))
             {
                 throw new GracefulException(
                     string.Format(
@@ -70,7 +70,7 @@ namespace Microsoft.DotNet.Tools.Tool.Install
             }
 
             FilePath? configFile = null;
-            if (_configFilePath != null)
+            if (!string.IsNullOrEmpty(_configFilePath))
             {
                 configFile = new FilePath(_configFilePath);
             }

--- a/src/Cli/dotnet/commands/dotnet-tool/restore/ToolRestoreCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-tool/restore/ToolRestoreCommand.cs
@@ -71,7 +71,7 @@ namespace Microsoft.DotNet.Tools.Tool.Restore
             FilePath? customManifestFileLocation = GetCustomManifestFileLocation();
 
             FilePath? configFile = null;
-            if (_configFilePath != null)
+            if (!string.IsNullOrEmpty(_configFilePath))
             {
                 configFile = new FilePath(_configFilePath);
             }
@@ -246,7 +246,7 @@ namespace Microsoft.DotNet.Tools.Tool.Restore
         {
             string customFile = _parseResult.ValueForOption<string>(ToolRestoreCommandParser.ToolManifestOption);
             FilePath? customManifestFileLocation;
-            if (customFile != null)
+            if (!string.IsNullOrEmpty(customFile))
             {
                 customManifestFileLocation = new FilePath(customFile);
             }

--- a/src/Cli/dotnet/commands/dotnet-tool/search/ToolSearchCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-tool/search/ToolSearchCommandParser.cs
@@ -15,13 +15,14 @@ namespace Microsoft.DotNet.Cli
 
         public static readonly Option DetailOption = new Option<bool>("--detail", LocalizableStrings.DetailDescription);
 
-        public static readonly Option SkipOption = new Option<string>("--skip", LocalizableStrings.SkipDescription) {
-            Argument = new Argument<string>(LocalizableStrings.SkipArgumentName)
+        public static readonly Option SkipOption = new Option<string>("--skip", LocalizableStrings.SkipDescription)
+        {
+            ArgumentHelpName = LocalizableStrings.SkipArgumentName
         };
 
         public static readonly Option TakeOption = new Option<string>($"--take", LocalizableStrings.TakeDescription)
         {
-            Argument = new Argument<string>(LocalizableStrings.TakeArgumentName)
+            ArgumentHelpName = LocalizableStrings.TakeArgumentName
         };
 
         public static readonly Option PrereleaseOption = new Option<bool>($"--prerelease", LocalizableStrings.PrereleaseDescription);

--- a/src/Cli/dotnet/commands/dotnet-tool/update/ToolUpdateGlobalOrToolPathCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-tool/update/ToolUpdateGlobalOrToolPathCommand.cs
@@ -73,7 +73,7 @@ namespace Microsoft.DotNet.Tools.Tool.Update
             ValidateArguments();
 
             DirectoryPath? toolPath = null;
-            if (_toolPath != null)
+            if (!string.IsNullOrEmpty(_toolPath))
             {
                 toolPath = new DirectoryPath(_toolPath);
             }
@@ -155,7 +155,7 @@ namespace Microsoft.DotNet.Tools.Tool.Update
 
         private void ValidateArguments()
         {
-            if (_configFilePath != null && !File.Exists(_configFilePath))
+            if (!string.IsNullOrEmpty(_configFilePath) && !File.Exists(_configFilePath))
             {
                 throw new GracefulException(
                     string.Format(
@@ -214,7 +214,7 @@ namespace Microsoft.DotNet.Tools.Tool.Update
         private FilePath? GetConfigFile()
         {
             FilePath? configFile = null;
-            if (_configFilePath != null)
+            if (!string.IsNullOrEmpty(_configFilePath))
             {
                 configFile = new FilePath(_configFilePath);
             }


### PR DESCRIPTION
Fixes https://github.com/dotnet/sdk/issues/16001
This requires updating to a new version of System.CommandLine that has a few breaking changes, most notably, option arguments are now private and getting a string option value now returns an empty string instead of null when the option is not present.