### PR TITLE
Remove Windows only condition from test

### DIFF
--- a/src/Tests/Microsoft.NET.Build.Tests/AppHostTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/AppHostTests.cs
@@ -253,10 +253,10 @@ namespace Microsoft.NET.Build.Tests
 
         }
 
-        [WindowsOnlyFact] // Windows-only due to https://github.com/dotnet/corefx/issues/42455
+        [Fact]
         public void It_retries_on_failure_to_create_apphost()
         {
-            const string TFM = "netcoreapp3.0";
+            const string TFM = "net5.0";
 
             var testProject = new TestProject()
             {


### PR DESCRIPTION
When looking at https://github.com/dotnet/sdk/pull/16183 I noticed this test can now run for Unix as the original issue was fixed.

Also I see many tests using `netcoreapp3.0` TFM. That's not supported anymore. Should it be using 5.0 or later?