### PR TITLE
Trying to reduce the number of different packages we download 

### DIFF
--- a/src/Assets/TestProjects/KitchenSink/TestApp/TestApp.csproj
+++ b/src/Assets/TestProjects/KitchenSink/TestApp/TestApp.csproj
@@ -73,6 +73,6 @@
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="1.0.0" PrivateAssets="All" />
 
     <!-- Has satellite assembly -->
-    <PackageReference Include="Humanizer" Version="2.2.0" />
+    <PackageReference Include="Humanizer" Version="2.8.26" />
   </ItemGroup>
 </Project>

--- a/src/Assets/TestProjects/RazorAppWithP2PReference/ClassLibraryMvc21/ClassLibraryMvc21.csproj
+++ b/src/Assets/TestProjects/RazorAppWithP2PReference/ClassLibraryMvc21/ClassLibraryMvc21.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.1.2">
+    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.1.0">
       <!-- Avoid exporting types from real MVC that will conflict with the test shim -->
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAResolvePackageAssetsTask.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAResolvePackageAssetsTask.cs
@@ -88,14 +88,14 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
         public void It_does_not_error_on_duplicate_package_names()
         {
             string projectAssetsJsonPath = Path.GetTempFileName();
-            var assetsContent =  @"{
+            var assetsContent = @"{
   `version`: 3,
   `targets`: {
     `net5.0`: {
-      `Humanizer.Core/2.2.0`: {
+      `Humanizer.Core/2.8.25`: {
         `type`: `package`
       },
-      `Humanizer.Core/2.2.1`: {
+      `Humanizer.Core/2.8.26`: {
         `type`: `package`
       }
     }

--- a/src/Tests/Microsoft.NET.Build.Tests/DepsFileSkipTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/DepsFileSkipTests.cs
@@ -122,7 +122,7 @@ namespace Microsoft.NET.Build.Tests
                 IsExe = true
             };
 
-            testProject.PackageReferences.Add(new TestPackageReference("Humanizer", "2.2.0"));
+            testProject.PackageReferences.Add(new TestPackageReference("Humanizer", "2.8.26"));
 
             string filenameToSkip = "de/Humanizer.resources.dll";
             string filenameNotToSkip = "es/Humanizer.resources.dll";

--- a/src/Tests/Microsoft.NET.Build.Tests/DesignTimeBuildTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/DesignTimeBuildTests.cs
@@ -115,7 +115,7 @@ namespace Microsoft.NET.Build.Tests
             };
 
             testProject.PackageReferences.Add(new TestPackageReference("Newtonsoft.Json", "12.0.2", privateAssets: "All"));
-            testProject.PackageReferences.Add(new TestPackageReference("Humanizer", "2.6.2"));
+            testProject.PackageReferences.Add(new TestPackageReference("Humanizer", "2.8.26"));
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject, identifier: targetFramework);
 
@@ -128,7 +128,7 @@ namespace Microsoft.NET.Build.Tests
 
             getValuesCommand.GetValues()
                 .Should()
-                .BeEquivalentTo("Newtonsoft.Json/12.0.2", "Humanizer/2.6.2");
+                .BeEquivalentTo("Newtonsoft.Json/12.0.2", "Humanizer/2.8.26");
         }
 
         [Theory]
@@ -199,7 +199,7 @@ namespace Microsoft.NET.Build.Tests
 
             //  Add some package references to test more code paths (such as in ResolvePackageAssets)
             testProject.PackageReferences.Add(new TestPackageReference("Newtonsoft.Json", "12.0.2", privateAssets: "All"));
-            testProject.PackageReferences.Add(new TestPackageReference("Humanizer", "2.6.2"));
+            testProject.PackageReferences.Add(new TestPackageReference("Humanizer", "2.8.26"));
 
             //  Use a test-specific packages folder
             testProject.AdditionalProperties["RestorePackagesPath"] = @"$(MSBuildProjectDirectory)\packages";

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToResolveConflicts.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToResolveConflicts.cs
@@ -113,7 +113,7 @@ namespace Microsoft.NET.Build.Tests
                 RuntimeIdentifier = string.Empty
             };
 
-            testProject.PackageReferences.Add(new TestPackageReference("Microsoft.AspNetCore.Mvc.Razor", "2.0.1"));
+            testProject.PackageReferences.Add(new TestPackageReference("Microsoft.AspNetCore.Mvc.Razor", "2.1.0"));
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
 

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAProjectWithAllFeatures.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAProjectWithAllFeatures.cs
@@ -55,8 +55,8 @@ namespace Microsoft.NET.Publish.Tests
 
                 // Verify package reference with satellites gets created correctly in the .deps.json file
                 VerifyDependency(dependencyContext, "Humanizer.Core", "lib/netstandard1.0/", "Humanizer",
-                    "af", "ar", "bg", "bn-BD", "cs", "da", "de", "el", "es", "fa", "fi-FI", "fr", "fr-BE", "he", "hr",
-                    "hu", "id", "it", "ja", "lv", "nb", "nb-NO", "nl", "pl", "pt", "ro", "ru", "sk", "sl", "sr",
+                    "af", "ar", "az", "bg", "bn-BD", "cs", "da", "de", "el", "es", "fa", "fi-FI", "fr", "fr-BE", "he", "hr",
+                    "hu", "hy", "id", "it", "ja", "lv", "ms-MY", "mt", "nb", "nb-NO", "nl", "pl", "pt", "ro", "ru", "sk", "sl", "sr",
                     "sr-Latn", "sv", "tr", "uk", "uz-Cyrl-UZ", "uz-Latn-UZ", "vi", "zh-CN", "zh-Hans", "zh-Hant");
             }
 
@@ -317,6 +317,10 @@ namespace Microsoft.NET.Publish.Tests
                         "bg/Humanizer.resources.dll",
                         "ar/Humanizer.resources.dll",
                         "af/Humanizer.resources.dll",
+                        "az/Humanizer.resources.dll",
+                        "hy/Humanizer.resources.dll",
+                        "ms-MY/Humanizer.resources.dll",
+                        "mt/Humanizer.resources.dll",
                         "runtimes/debian.8-x64/native/System.Security.Cryptography.Native.OpenSsl.so",
                         "runtimes/fedora.23-x64/native/System.Security.Cryptography.Native.OpenSsl.so",
                         "runtimes/fedora.24-x64/native/System.Security.Cryptography.Native.OpenSsl.so",
@@ -416,7 +420,11 @@ namespace Microsoft.NET.Publish.Tests
                         "bn-BD/Humanizer.resources.dll",
                         "bg/Humanizer.resources.dll",
                         "ar/Humanizer.resources.dll",
-                        "af/Humanizer.resources.dll"
+                        "af/Humanizer.resources.dll",
+                        "az/Humanizer.resources.dll",
+                        "hy/Humanizer.resources.dll",
+                        "ms-MY/Humanizer.resources.dll",
+                        "mt/Humanizer.resources.dll",
                     }
                 };
             }


### PR DESCRIPTION
Remove the two older versions of humanizer, 2.1.1 version of Mvc, 2.0.4 version of aspnet, and 2.0.1 version of Razor. No idea if this will help with our reliability or runtime. There are a lot of one-off versions that make this hard to track down as we have 1.7k unique packages downloaded during tests.