### PR TITLE
Adding default publish profiles

### DIFF
--- a/sdk.sln
+++ b/sdk.sln
@@ -211,6 +211,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "PublishProfiles", "PublishP
 		src\WebSdk\Publish\Targets\PublishProfiles\Default.pubxml = src\WebSdk\Publish\Targets\PublishProfiles\Default.pubxml
 		src\WebSdk\Publish\Targets\PublishProfiles\DefaultMSDeploy.pubxml = src\WebSdk\Publish\Targets\PublishProfiles\DefaultMSDeploy.pubxml
 		src\WebSdk\Publish\Targets\PublishProfiles\DefaultMSDeployPackage.pubxml = src\WebSdk\Publish\Targets\PublishProfiles\DefaultMSDeployPackage.pubxml
+		src\WebSdk\Publish\Targets\PublishProfiles\DefaultZipDeploy.pubxml = src\WebSdk\Publish\Targets\PublishProfiles\DefaultZipDeploy.pubxml
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "PublishTargets", "PublishTargets", "{40E6E4B1-286B-4542-B814-2A3DA29510D1}"

--- a/src/WebSdk/Publish/Targets/PublishProfiles/Default.pubxml
+++ b/src/WebSdk/Publish/Targets/PublishProfiles/Default.pubxml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+This file is used by the publish/package process of your Web project. You can customize the behavior of this process
+by editing this MSBuild file. In order to learn more about this please visit http://go.microsoft.com/fwlink/?LinkID=208121. 
+-->
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <WebPublishMethod>FileSystem</WebPublishMethod>
+    <PublishUrl Condition=" '$(PublishUrl)' == '' ">$(OutputPath)Publish\</PublishUrl>
+    <DeleteExistingFiles>False</DeleteExistingFiles>
+  </PropertyGroup>
+</Project>

--- a/src/WebSdk/Publish/Targets/PublishProfiles/DefaultMSDeploy.pubxml
+++ b/src/WebSdk/Publish/Targets/PublishProfiles/DefaultMSDeploy.pubxml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <WebPublishMethod>MSDeploy</WebPublishMethod>
+    <LastUsedBuildConfiguration>Release</LastUsedBuildConfiguration>
+    <LastUsedPlatform>Any CPU</LastUsedPlatform>
+    <SkipExtraFilesOnServer>True</SkipExtraFilesOnServer>
+    <MSDeployPublishMethod>WMSVC</MSDeployPublishMethod>
+    <EnableMSDeployBackup>True</EnableMSDeployBackup>
+  </PropertyGroup>
+</Project> 

--- a/src/WebSdk/Publish/Targets/PublishProfiles/DefaultMSDeployPackage.pubxml
+++ b/src/WebSdk/Publish/Targets/PublishProfiles/DefaultMSDeployPackage.pubxml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <WebPublishMethod>Package</WebPublishMethod>
+    <LastUsedBuildConfiguration>Release</LastUsedBuildConfiguration>
+    <LastUsedPlatform>Any CPU</LastUsedPlatform>
+    <DesktopBuildPackageLocation>$(OutputPath)Publish\MSDeployPackage.zip</DesktopBuildPackageLocation>
+    <DeployIisAppPath>Default Web Site</DeployIisAppPath>
+  </PropertyGroup>
+</Project> 

--- a/src/WebSdk/Publish/Targets/PublishProfiles/DefaultZipDeploy.pubxml
+++ b/src/WebSdk/Publish/Targets/PublishProfiles/DefaultZipDeploy.pubxml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+https://go.microsoft.com/fwlink/?LinkID=208121. 
+-->
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <WebPublishMethod>ZipDeploy</WebPublishMethod>
+    <PublishProvider>AzureWebSite</PublishProvider>
+    <LastUsedBuildConfiguration>Release</LastUsedBuildConfiguration>
+    <LastUsedPlatform>Any CPU</LastUsedPlatform>
+    <PublishUrl></PublishUrl>
+  </PropertyGroup>
+</Project>

--- a/src/WebSdk/Publish/Tasks/Tasks/ZipDeploy/CreateZipFile.cs
+++ b/src/WebSdk/Publish/Tasks/Tasks/ZipDeploy/CreateZipFile.cs
@@ -22,7 +22,7 @@ namespace Microsoft.NET.Sdk.Publish.Tasks.ZipDeploy
 
         public override bool Execute()
         {
-            string zipFileName = ProjectName + " - " + DateTime.Now.ToString("yyyyMMddHHmmssFFF") + ".zip";
+            string zipFileName = ProjectName + "-" + DateTime.Now.ToString("yyyyMMddHHmmssFFF") + ".zip";
             CreatedZipPath = Path.Combine(PublishIntermediateTempPath, zipFileName);
             ZipFile.CreateFromDirectory(FolderToZip, CreatedZipPath);
             return true;


### PR DESCRIPTION
The publish profiles folder adds sample profiles for each of the profile types: 
- Folder
- MSDeploy
- MSDeployPackage
- ZipDeploy

These profiles can be invoked by passing the default profilenames from the commandline
e.g: 
dotnet publish /p:PublishProfile=DefaultMSDeploy
dotnet publish /p:PublishProfile=DefaultZipDeploy