### PR TITLE
Fix condition for setting RelatedAssemblyAttribute

### DIFF
--- a/src/RazorSdk/Targets/Microsoft.NET.Sdk.Razor.Configuration.targets
+++ b/src/RazorSdk/Targets/Microsoft.NET.Sdk.Razor.Configuration.targets
@@ -63,7 +63,7 @@ Copyright (c) .NET Foundation. All rights reserved.
         AND '$(ResolvedRazorCompileToolset)'=='RazorSdk'
         AND ('$(RazorCompileOnBuild)' == 'true'
         OR '$(RazorCompileOnPublish)' == 'true')
-        AND '$(_UseRazorSourceGenerator)' == ''">
+        AND '$(_UseRazorSourceGenerator)' != 'true'">
       <_RazorAssemblyAttribute Include="Microsoft.AspNetCore.Mvc.ApplicationParts.RelatedAssemblyAttribute">
         <_Parameter1>$(RazorTargetName)</_Parameter1>
       </_RazorAssemblyAttribute>


### PR DESCRIPTION
`_UseRazorSourceGenerator` gets set to `false` for non-.NET 6 projects so this condition was always failing and resulting in the RelatedAssemblyAttribute not being set.