### PR TITLE
Change to remove the resources node from the deps file for dotnet deps

### DIFF
--- a/src/Layout/redist/targets/GenerateLayout.targets
+++ b/src/Layout/redist/targets/GenerateLayout.targets
@@ -171,6 +171,13 @@
           NewName="%(BundledTools.Identity).deps.json" />
   </Target>
 
+  <Target Name="RemoveResourcesFromDotnetDeps"
+        AfterTargets="Build">
+    <RemoveAssetFromDepsPackages DepsFile="$(OutputPath)/dotnet.deps.json"
+               SectionName="resources"
+               AssetPath="*" />
+  </Target>
+
   <Target Name="MakeFscRunnableAndMoveToPublishDir"
           AfterTargets="Build"
           BeforeTargets="RemoveFilesAfterPublish">

--- a/src/Layout/toolset-tasks/RemoveAssetFromDepsPackages.cs
+++ b/src/Layout/toolset-tasks/RemoveAssetFromDepsPackages.cs
@@ -51,6 +51,10 @@ namespace Microsoft.DotNet.Cli.Build
                                 break;
                             }
                         }
+                        if (assetPath.Equals("*"))
+                        {
+                            section.Parent.Remove();
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Fixes 16196.  @wli3 , I manually confirmed that different languages still worked.  Do we have test coverage for that?  Anything else I should worry about with this change or do you have a preferred way of modifying that task to work for this scenario?

Per Brian, this will save ~20ms.  Not much but it'll add up eventually.
https://github.com/dotnet/sdk/issues/16196#issuecomment-803003247