### PR TITLE
Suppress generating source checksum attribute

### DIFF
--- a/src/RazorSdk/SourceGenerators/RazorSourceGenerationContext.cs
+++ b/src/RazorSdk/SourceGenerators/RazorSourceGenerationContext.cs
@@ -2,10 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Diagnostics;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.CodeAnalysis;
 
@@ -23,7 +21,6 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
 
         public RazorConfiguration Configuration { get; private set; }
 
-
         /// <summary>
         /// Gets a flag that determines if the source generator waits for the debugger to attach.
         /// <para>
@@ -34,13 +31,9 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
         public bool WaitForDebugger { get; private set; }
 
         /// <summary>
-        /// Gets a flag that determine if the source generator should log verbose messages.
+        /// Gets a flag that determines if generated Razor views and Pages includes the <c>RazorSourceChecksumAttribute</c>.
         /// </summary>
-        /// <para>
-        /// To configure this using MSBuild, use the <c>_RazorSourceGeneratorLog</c> property.
-        /// For instance <c>dotnet msbuild /p:_RazorSourceGeneratorLog=true</c>
-        /// </para>
-        public bool EnableLogging { get; private set; }
+        public bool GenerateMetadataSourceChecksumAttributes { get; private set; }
 
         public RazorSourceGenerationContext(GeneratorExecutionContext context)
         {
@@ -67,7 +60,8 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
             }
 
             globalOptions.TryGetValue("build_property._RazorSourceGeneratorDebug", out var waitForDebugger);
-            globalOptions.TryGetValue("build_property._RazorSourceGeneratorLog", out var enableLogging);
+
+            globalOptions.TryGetValue("build_property.GenerateRazorMetadataSourceChecksumAttributes", out var generateMetadataSourceChecksumAttributes);
 
             var razorConfiguration = RazorConfiguration.Create(razorLanguageVersion, configurationName, Enumerable.Empty<RazorExtension>(), true);
             var (razorFiles, cshtmlFiles) = GetRazorInputs(context);
@@ -79,7 +73,7 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
             RazorFiles = razorFiles;
             CshtmlFiles = cshtmlFiles;
             WaitForDebugger = waitForDebugger == "true";
-            EnableLogging = enableLogging == "true";
+            GenerateMetadataSourceChecksumAttributes = generateMetadataSourceChecksumAttributes == "true";
         }
 
         private static VirtualRazorProjectFileSystem GetVirtualFileSystem(GeneratorExecutionContext context, IReadOnlyList<RazorInputItem> razorFiles, IReadOnlyList<RazorInputItem> cshtmlFiles)

--- a/src/RazorSdk/SourceGenerators/RazorSourceGenerator.cs
+++ b/src/RazorSdk/SourceGenerators/RazorSourceGenerator.cs
@@ -56,6 +56,11 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
                 b.Features.Add(new DefaultTypeNameFeature());
                 b.SetRootNamespace(razorContext.RootNamespace);
 
+                b.Features.Add(new ConfigureRazorCodeGenerationOptions(options =>
+                {
+                    options.SuppressMetadataSourceChecksumAttributes = !razorContext.GenerateMetadataSourceChecksumAttributes;
+                }));
+
                 b.Features.Add(new StaticTagHelperFeature { TagHelpers = tagHelpers, });
                 b.Features.Add(new DefaultTagHelperDescriptorProvider());
 

--- a/src/RazorSdk/Targets/Microsoft.NET.Sdk.Razor.SourceGenerators.targets
+++ b/src/RazorSdk/Targets/Microsoft.NET.Sdk.Razor.SourceGenerators.targets
@@ -41,6 +41,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       <CompilerVisibleItemMetadata Include="AdditionalFiles" MetadataName="CssScope" />
       <CompilerVisibleProperty Include="RazorLangVersion" />
       <CompilerVisibleProperty Include="RootNamespace" />
+      <CompilerVisibleProperty Include="GenerateRazorMetadataSourceChecksumAttributes" />
       <CompilerVisibleProperty Include="MSBuildProjectDirectory" />
       <CompilerVisibleProperty Include="_RazorSourceGeneratorDebug" />
       <CompilerVisibleProperty Include="_RazorSourceGeneratorLog" />


### PR DESCRIPTION
Follow up to https://github.com/dotnet/aspnetcore/pull/31089.

Consume the new attribute to turn off generating source checksum attributes by default.