### PR TITLE
Remove iOS, Android, and macCatalyst from the default SupportedPlatform item

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.SupportedPlatforms.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.SupportedPlatforms.props
@@ -6,18 +6,15 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
           created a backup copy.  Incorrect changes to this file will make it
           impossible to load or build your projects from the command-line or the IDE.
 
-Copyright (c) .NET Foundation. All rights reserved. 
+Copyright (c) .NET Foundation. All rights reserved.
 ***********************************************************************************************
 -->
 
 <Project>
   <ItemGroup>
     <!-- Platforms supported by this SDK for analyzer warnings. Spec: https://github.com/dotnet/designs/blob/master/accepted/2020/platform-exclusion/platform-exclusion.md  -->
-    <SupportedPlatform Include="Android" />
-    <SupportedPlatform Include="iOS" />
     <SupportedPlatform Include="Linux" />
     <SupportedPlatform Include="macOS" />
-    <SupportedPlatform Include="macCatalyst" />
     <SupportedPlatform Include="Windows" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Both [aspnetcore](https://github.com/dotnet/aspnetcore/pull/31020#issuecomment-802275643) and the [SDK](https://github.com/dotnet/sdk/pull/16425#issuecomment-802752584) itself were affected by the addition of new `SupportedOSPlatform` attributes for `iOS`, and that surfaced that we needed to reconsider the default set of platforms the SDK respects for the Platform Compatibility Analyzer.

We will need this change included in Preview 3 so that the addition of those annotations isn't a breaking change. #16488 was filed to find a way to reintroduce those platforms in a scoped manner.