### PR TITLE
Add support for caching generated SourceTexts

### DIFF
--- a/src/RazorSdk/SourceGenerators/RazorInputItem.cs
+++ b/src/RazorSdk/SourceGenerators/RazorInputItem.cs
@@ -9,7 +9,7 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
 {
     internal readonly struct RazorInputItem
     {
-        public RazorInputItem(AdditionalText additionalText, string relativePath, string fileKind, string? generatedOutputPath, string? cssScope)
+        public RazorInputItem(AdditionalText additionalText, string relativePath, string fileKind, string? cssScope)
         {
             AdditionalText = additionalText;
             RelativePath = relativePath;
@@ -18,7 +18,6 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
                 .Replace(Path.DirectorySeparatorChar, '/')
                 .Replace("//", "/");
             FileKind = fileKind;
-            GeneratedOutputPath = generatedOutputPath;
         }
 
         public AdditionalText AdditionalText { get; }
@@ -30,7 +29,5 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
         public string FileKind { get; }
 
         public string? CssScope { get; }
-
-        public string? GeneratedOutputPath { get; }
     }
 }

--- a/src/RazorSdk/SourceGenerators/RazorSourceGenerationContext.cs
+++ b/src/RazorSdk/SourceGenerators/RazorSourceGenerationContext.cs
@@ -136,17 +136,9 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
 
                 options.TryGetValue("build_metadata.AdditionalFiles.CssScope", out var cssScope);
 
-                if (!options.TryGetValue("build_metadata.AdditionalFiles.GeneratedOutputFullPath", out var generatedOutputPath))
-                {
-                    context.ReportDiagnostic(Diagnostic.Create(
-                        RazorDiagnostics.GeneratedOutputFullPathNotProvided,
-                        Location.None,
-                        item.Path));
-                }
-
                 var fileKind = isComponent ? FileKinds.GetComponentFileKindFromFilePath(item.Path) : FileKinds.Legacy;
 
-                var inputItem = new RazorInputItem(item, relativePath, fileKind, generatedOutputPath, cssScope);
+                var inputItem = new RazorInputItem(item, relativePath, fileKind, cssScope);
 
                 if (isComponent)
                 {

--- a/src/RazorSdk/SourceGenerators/RazorSourceGenerator.cs
+++ b/src/RazorSdk/SourceGenerators/RazorSourceGenerator.cs
@@ -111,10 +111,6 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
         private static (string, SourceText?) ResolveGeneratedSourceTextFromFile(RazorInputItem file, RazorProjectEngine projectEngine, GeneratorExecutionContext context)
         {
             var hint = GetIdentifierFromPath(file.NormalizedPath);
-            if (file.FileKind == FileKinds.Legacy)
-            {
-                hint = GetIdentifierFromPath(file.GeneratedOutputPath ?? file.NormalizedPath);
-            }
 
             var entryFound = _sourceTextCache.TryGetValue(hint, out (SourceText cachedSourceText, SourceText cachedGeneratedSourceText) cachedValues);
 

--- a/src/RazorSdk/SourceGenerators/RazorSourceGenerator.cs
+++ b/src/RazorSdk/SourceGenerators/RazorSourceGenerator.cs
@@ -163,6 +163,10 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
             }
             else
             {
+                if (_sourceTextCache.Count > 200)
+                {
+                    _sourceTextCache.Clear();
+                }
                 _sourceTextCache[hint] = generatedSourceText;
                 return generatedSourceText;
             }


### PR DESCRIPTION
Add some logic to cache generated source texts to resolve https://github.com/dotnet/aspnetcore/issues/30709.

I used the code in the [CachingSourceGenerator](https://github.com/dotnet/roslyn/blob/main/src/Tools/Source/CompilerGeneratorTools/Source/CSharpSyntaxGenerator/CachingSourceGenerator.cs) as a blueprint.

This code will likely be replaced once we consume the incremental source generator.