### PR TITLE
Make reader public and packable for use in other repos

### DIFF
--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/Microsoft.NET.Sdk.WorkloadManifestReader.csproj
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/Microsoft.NET.Sdk.WorkloadManifestReader.csproj
@@ -10,6 +10,7 @@
 
     <LangVersion>8.0</LangVersion>
     <Nullable>Enable</Nullable>
+    <IsPackable>true</IsPackable>
 
     <UseSystemTextJson Condition="'$(TargetFramework)'!='netstandard2.0' And '$(TargetFramework)'!='net472'">True</UseSystemTextJson>
     <DefineConstants Condition="'$(UseSystemTextJson)'=='True'">$(DefineConstants);USE_SYSTEM_TEXT_JSON</DefineConstants>

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadDefinition.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadDefinition.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 
 namespace Microsoft.NET.Sdk.WorkloadManifestReader
 {
-    internal class WorkloadDefinition
+    public class WorkloadDefinition
     {
         public WorkloadDefinition(
             WorkloadDefinitionId id, bool isAbstract, string? description, WorkloadDefinitionKind kind, List<WorkloadDefinitionId>? extends,
@@ -29,7 +29,7 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
         public List<string>? Platforms { get; }
     }
 
-    internal enum WorkloadDefinitionKind
+    public enum WorkloadDefinitionKind
     {
         Dev,
         Build

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadDefinitionkId.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadDefinitionkId.cs
@@ -9,7 +9,7 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
     /// Wraps a workload definition id string to help ensure consistency of behaviour/semantics.
     /// Comparisons are case insensitive but ToString() will return the original string for display purposes.
     /// </summary>
-    internal readonly struct WorkloadDefinitionId : IComparable<WorkloadDefinitionId>, IEquatable<WorkloadDefinitionId>
+    public readonly struct WorkloadDefinitionId : IComparable<WorkloadDefinitionId>, IEquatable<WorkloadDefinitionId>
     {
         private readonly string _id;
 

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadManifest.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadManifest.cs
@@ -8,7 +8,7 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
     /// <summary>
     /// An SDK workload manifest
     /// </summary>
-    internal class WorkloadManifest
+    public class WorkloadManifest
     {
         public WorkloadManifest(long version, string? description, Dictionary<WorkloadDefinitionId, WorkloadDefinition> workloads, Dictionary<WorkloadPackId, WorkloadPack> packs)
         {

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadManifestReader.NewtonsoftJson.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadManifestReader.NewtonsoftJson.cs
@@ -12,7 +12,7 @@ using JsonTokenType = Newtonsoft.Json.JsonToken;
 
 namespace Microsoft.NET.Sdk.WorkloadManifestReader
 {
-    internal partial class WorkloadManifestReader
+    public partial class WorkloadManifestReader
     {
 
         public static WorkloadManifest ReadWorkloadManifest(Stream manifestStream)

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadManifestReader.SystemTextJson.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadManifestReader.SystemTextJson.cs
@@ -10,7 +10,7 @@ using System.Text.Json;
 
 namespace Microsoft.NET.Sdk.WorkloadManifestReader
 {
-    internal partial class WorkloadManifestReader
+    public partial class WorkloadManifestReader
     {
         public static WorkloadManifest ReadWorkloadManifest(Stream manifestStream)
         {

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadManifestReader.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadManifestReader.cs
@@ -14,7 +14,7 @@ using JsonTokenType = Newtonsoft.Json.JsonToken;
 
 namespace Microsoft.NET.Sdk.WorkloadManifestReader
 {
-    internal partial class WorkloadManifestReader
+    public partial class WorkloadManifestReader
     {
         private static void ConsumeToken(ref Utf8JsonStreamReader reader, JsonTokenType expected)
         {

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadPack.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadPack.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 
 namespace Microsoft.NET.Sdk.WorkloadManifestReader
 {
-    internal class WorkloadPack
+    public class WorkloadPack
     {
         public WorkloadPack(WorkloadPackId id, string version, WorkloadPackKind kind, Dictionary<string, WorkloadPackId>? aliasTo)
         {

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadPackId.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadPackId.cs
@@ -11,7 +11,7 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
     /// This internal struct helps preserve/annotate these semantics.
     /// </summary>
     /// <remarks>We also use this for workload definition ids for consistency</remarks>
-    internal struct WorkloadPackId : IComparable<WorkloadPackId>, IEquatable<WorkloadPackId>
+    public struct WorkloadPackId : IComparable<WorkloadPackId>, IEquatable<WorkloadPackId>
     {
         string _id;
 


### PR DESCRIPTION
Arcade tasks will need to read/process manifests and can't use the library right now as many items are marked as internal