### PR TITLE
Stub workload list and install command

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-workload/install/LocalizableStrings.resx
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/LocalizableStrings.resx
@@ -127,7 +127,7 @@
     <value>VERSION</value>
   </data>
   <data name="VersionOptionDescription" xml:space="preserve">
-    <value>The version of the workload package to install.</value>
+    <value>The version of the SDK.</value>
   </data>
   <data name="AddSourceOptionName" xml:space="preserve">
     <value>SOURCE</value>
@@ -143,9 +143,6 @@
   </data>
   <data name="ConfigFileOptionDescription" xml:space="preserve">
     <value>The NuGet configuration file to use.</value>
-  </data>
-  <data name="FrameworkOptionName" xml:space="preserve">
-    <value>FRAMEWORK</value>
   </data>
   <data name="FrameworkOptionDescription" xml:space="preserve">
     <value>The target framework to install the workload for.</value>
@@ -177,10 +174,10 @@
   <data name="WorkloadPathOptionDescription" xml:space="preserve">
     <value>The directory where the workload will be installed. The directory will be created if it does not exist.</value>
   </data>
-  <data name="ManifestPathOptionDescription" xml:space="preserve">
-    <value>Path to the manifest file.</value>
+  <data name="PrintDownloadLinkOnlyDescription" xml:space="preserve">
+    <value>Only print the list of links to download without downloading it.</value>
   </data>
-  <data name="ManifestPathOptionName" xml:space="preserve">
-    <value>PATH</value>
+  <data name="FromCacheOptionDescription" xml:space="preserve">
+    <value>Complete the operation from cache (offline).</value>
   </data>
 </root>

--- a/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadInstallCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadInstallCommand.cs
@@ -1,32 +1,122 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Collections.Generic;
 using System.CommandLine.Parsing;
+using System.IO;
 using System.Linq;
+using System.Text.Json;
 using Microsoft.DotNet.Cli;
 using Microsoft.DotNet.Cli.Utils;
+using Microsoft.DotNet.Configurer;
+using NuGet.Protocol;
+using NuGet.Protocol.Core.Types;
+using NuGet.Versioning;
 
 namespace Microsoft.DotNet.Workloads.Workload.Install
 {
     internal class WorkloadInstallCommand : CommandBase
     {
-        private readonly string _framework;
-        private IReadOnlyCollection<string> _workloadIds;
+        private readonly string _fromCacheOption;
+        private readonly bool _printDownloadLinkOnly;
+        private readonly IReadOnlyCollection<string> _workloadIds;
+
+        public readonly string MockInstallDirectory = Path.Combine(CliFolderPathCalculator.DotnetUserProfileFolderPath,
+            "DEV_mockworkloads");
 
         public WorkloadInstallCommand(
             ParseResult parseResult)
             : base(parseResult)
         {
-            _framework = parseResult.ValueForOption<string>(WorkloadInstallCommandParser.FrameworkOption);
-            _workloadIds = parseResult.ValueForArgument<IReadOnlyCollection<string>>(WorkloadInstallCommandParser.WorkloadIdArgument);
+            _workloadIds =
+                parseResult.ValueForArgument<IReadOnlyCollection<string>>(WorkloadInstallCommandParser
+                    .WorkloadIdArgument);
+            _printDownloadLinkOnly =
+                parseResult.ValueForOption<bool>(WorkloadInstallCommandParser.PrintDownloadLinkOnlyOption);
+            _fromCacheOption = parseResult.ValueForOption<string>(WorkloadInstallCommandParser.FromCacheOption);
         }
 
         public override int Execute()
         {
             // TODO stub
-            Reporter.Output.WriteLine($"WIP workload install {string.Join("; ",_workloadIds)}");
+            Reporter.Output.WriteLine($"WIP workload install {string.Join("; ", _workloadIds)}");
+            List<string> allowedMockWorkloads = new List<string> {"mobile-ios", "mobile-android"};
+
+            if (!_printDownloadLinkOnly && string.IsNullOrWhiteSpace(_fromCacheOption))
+            {
+                Reporter.Output.WriteLine(
+                    "mock currently does not support normal install. Need --print-download-link-only or --from-cache");
+            }
+
+            if (_workloadIds.Except(allowedMockWorkloads).Any())
+            {
+                Reporter.Output.WriteLine("Only support \"mobile-ios\", \"mobile-android\" in the mock");
+            }
+
+            SourceRepository source =
+                Repository.Factory.GetCoreV3("https://www.myget.org/F/mockworkloadfeed/api/v3/index.json");
+            ServiceIndexResourceV3 serviceIndexResource = source.GetResourceAsync<ServiceIndexResourceV3>().Result;
+            IReadOnlyList<Uri> packageBaseAddress =
+                serviceIndexResource?.GetServiceEntryUris(ServiceTypes.PackageBaseAddress);
+            List<string> allPackageUrl = new List<string>();
+
+            if (_printDownloadLinkOnly)
+            {
+                if (_workloadIds.Contains("mobile-ios"))
+                {
+                    allPackageUrl.Add(nupkgUrl(packageBaseAddress.First().ToString(), "Microsoft.iOS.Bundle",
+                        NuGetVersion.Parse("6.0.100")));
+
+                    AddNewtonsoftJson(allPackageUrl);
+                }
+
+                if (_workloadIds.Contains("mobile-android"))
+                {
+                    allPackageUrl.Add(nupkgUrl(packageBaseAddress.First().ToString(), "Microsoft.NET.Workload.Android",
+                        NuGetVersion.Parse("6.0.100")));
+
+
+                    AddNewtonsoftJson(allPackageUrl);
+                }
+
+                Reporter.Output.WriteLine("==allPackageLinksJsonOutputStart==");
+                Reporter.Output.WriteLine(JsonSerializer.Serialize(allPackageUrl));
+                Reporter.Output.WriteLine("==allPackageLinksJsonOutputEnd==");
+            }
+
+            if (!string.IsNullOrWhiteSpace(_fromCacheOption))
+            {
+                Directory.CreateDirectory(MockInstallDirectory);
+                if (_workloadIds.Contains("mobile-android"))
+                {
+                    File.Copy(Path.Combine(_fromCacheOption, "Microsoft.NET.Workload.Android.6.0.100.nupkg"),
+                        Path.Combine(MockInstallDirectory, "Microsoft.NET.Workload.Android.6.0.100.nupkg"));
+                }
+
+                if (_workloadIds.Contains("mobile-ios"))
+                {
+                    File.Copy(Path.Combine(_fromCacheOption, "Microsoft.iOS.Bundle.6.0.100.nupkg"),
+                        Path.Combine(MockInstallDirectory, "Microsoft.iOS.Bundle.6.0.100.nupkg"));
+                }
+            }
+
             return 0;
         }
+
+        /// Add a Newtonsoft.Json to make sure caller can handle multiple packages
+        private static void AddNewtonsoftJson(List<string> allPackageUrl)
+        {
+            string newtonsoftJsonUrl = "https://www.nuget.org/api/v2/package/Newtonsoft.Json/13.0.1-beta2";
+            if (!allPackageUrl.Contains(newtonsoftJsonUrl))
+            {
+                allPackageUrl.Add(newtonsoftJsonUrl);
+            }
+        }
+
+        public string nupkgUrl(string baseUri, string id, NuGetVersion version) =>
+            baseUri + id.ToLowerInvariant() + "/" + version.ToNormalizedString() + "/" + id.ToLowerInvariant() +
+            "." +
+            version.ToNormalizedString() + ".nupkg";
     }
 }

--- a/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadInstallCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadInstallCommandParser.cs
@@ -9,31 +9,38 @@ namespace Microsoft.DotNet.Cli
 {
     internal static class WorkloadInstallCommandParser
     {
-        public static readonly Argument WorkloadIdArgument = new Argument<string>(LocalizableStrings.WorkloadIdArgumentName)
-        {
-            Arity = ArgumentArity.OneOrMore,
-            Description = LocalizableStrings.WorkloadIdArgumentDescription
-        };
+        public static readonly Argument WorkloadIdArgument =
+            new Argument<string>(LocalizableStrings.WorkloadIdArgumentName)
+            {
+                Arity = ArgumentArity.OneOrMore, Description = LocalizableStrings.WorkloadIdArgumentDescription
+            };
 
-        public static readonly Option VersionOption = new Option<string>("--version", LocalizableStrings.VersionOptionDescription)
-        {
-            ArgumentHelpName = LocalizableStrings.VersionOptionName
-        };
+        public static readonly Option VersionOption =
+            new Option<string>("--sdk-version", LocalizableStrings.VersionOptionDescription)
+            {
+                ArgumentHelpName = LocalizableStrings.VersionOptionName
+            };
 
-        public static readonly Option ConfigOption = new Option<string>("--configfile", LocalizableStrings.ConfigFileOptionDescription)
-        {
-            ArgumentHelpName = LocalizableStrings.ConfigFileOptionName
-        };
+        public static readonly Option ConfigOption =
+            new Option<string>("--configfile", LocalizableStrings.ConfigFileOptionDescription)
+            {
+                ArgumentHelpName = LocalizableStrings.ConfigFileOptionName
+            };
 
-        public static readonly Option AddSourceOption = new Option<string[]>("--add-source", LocalizableStrings.AddSourceOptionDescription)
-        {
-            ArgumentHelpName = LocalizableStrings.AddSourceOptionName
-        }.AllowSingleArgPerToken();
+        public static readonly Option AddSourceOption =
+            new Option<string[]>("--add-source", LocalizableStrings.AddSourceOptionDescription)
+            {
+                ArgumentHelpName = LocalizableStrings.AddSourceOptionName
+            }.AllowSingleArgPerToken();
 
-        public static readonly Option FrameworkOption = new Option<string>("--framework", LocalizableStrings.FrameworkOptionDescription)
-        {
-            ArgumentHelpName = LocalizableStrings.FrameworkOptionName
-        };
+        public static readonly Option PrintDownloadLinkOnlyOption =
+            new Option<bool>("--print-download-link-only", LocalizableStrings.PrintDownloadLinkOnlyDescription)
+            {
+                IsHidden = true
+            };
+
+        public static readonly Option FromCacheOption =
+            new Option<string>("--from-cache", LocalizableStrings.FromCacheOptionDescription) { };
 
         public static readonly Option VerbosityOption = CommonOptions.VerbosityOption();
 
@@ -45,7 +52,8 @@ namespace Microsoft.DotNet.Cli
             command.AddOption(VersionOption);
             command.AddOption(ConfigOption);
             command.AddOption(AddSourceOption);
-            command.AddOption(FrameworkOption);
+            command.AddOption(PrintDownloadLinkOnlyOption);
+            command.AddOption(FromCacheOption);
             command.AddOption(WorkloadCommandRestorePassThroughOptions.DisableParallelOption);
             command.AddOption(WorkloadCommandRestorePassThroughOptions.IgnoreFailedSourcesOption);
             command.AddOption(WorkloadCommandRestorePassThroughOptions.NoCacheOption);

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.cs.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.cs.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../LocalizableStrings.resx">
     <body>
+      <trans-unit id="FromCacheOptionDescription">
+        <source>Complete the operation from cache (offline).</source>
+        <target state="new">Complete the operation from cache (offline).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InstallationSucceeded">
         <source>Workload '{0}' (version '{1}') was successfully installed.</source>
         <target state="new">Workload '{0}' (version '{1}') was successfully installed.</target>
@@ -10,16 +15,6 @@
       <trans-unit id="InvalidWorkloadConfiguration">
         <source>The settings file in the workload's NuGet package is invalid: {0}</source>
         <target state="new">The settings file in the workload's NuGet package is invalid: {0}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ManifestPathOptionDescription">
-        <source>Path to the manifest file.</source>
-        <target state="translated">Cesta k souboru manifestu</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ManifestPathOptionName">
-        <source>PATH</source>
-        <target state="translated">PATH</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandDescription">
@@ -37,8 +32,13 @@
         <target state="needs-review-translation">Cílová architektura, pro kterou se má nástroj nainstalovat</target>
         <note />
       </trans-unit>
+      <trans-unit id="PrintDownloadLinkOnlyDescription">
+        <source>Only print the list of links to download without downloading it.</source>
+        <target state="new">Only print the list of links to download without downloading it.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="VersionOptionDescription">
-        <source>The version of the workload package to install.</source>
+        <source>The version of the SDK.</source>
         <target state="needs-review-translation">Verze balíčku nástroje, který se má nainstalovat</target>
         <note />
       </trans-unit>
@@ -75,11 +75,6 @@
       <trans-unit id="ConfigFileOptionName">
         <source>FILE</source>
         <target state="translated">FILE</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="FrameworkOptionName">
-        <source>FRAMEWORK</source>
-        <target state="translated">FRAMEWORK</target>
         <note />
       </trans-unit>
       <trans-unit id="WorkloadAlreadyInstalled">

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.de.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.de.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../LocalizableStrings.resx">
     <body>
+      <trans-unit id="FromCacheOptionDescription">
+        <source>Complete the operation from cache (offline).</source>
+        <target state="new">Complete the operation from cache (offline).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InstallationSucceeded">
         <source>Workload '{0}' (version '{1}') was successfully installed.</source>
         <target state="new">Workload '{0}' (version '{1}') was successfully installed.</target>
@@ -10,16 +15,6 @@
       <trans-unit id="InvalidWorkloadConfiguration">
         <source>The settings file in the workload's NuGet package is invalid: {0}</source>
         <target state="new">The settings file in the workload's NuGet package is invalid: {0}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ManifestPathOptionDescription">
-        <source>Path to the manifest file.</source>
-        <target state="translated">Pfad zur Manifestdatei.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ManifestPathOptionName">
-        <source>PATH</source>
-        <target state="translated">PATH</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandDescription">
@@ -37,8 +32,13 @@
         <target state="needs-review-translation">Das Zielframework, für das das Tool installiert wird.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PrintDownloadLinkOnlyDescription">
+        <source>Only print the list of links to download without downloading it.</source>
+        <target state="new">Only print the list of links to download without downloading it.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="VersionOptionDescription">
-        <source>The version of the workload package to install.</source>
+        <source>The version of the SDK.</source>
         <target state="needs-review-translation">Die Version des zu installierenden Toolpakets.</target>
         <note />
       </trans-unit>
@@ -75,11 +75,6 @@
       <trans-unit id="ConfigFileOptionName">
         <source>FILE</source>
         <target state="translated">FILE</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="FrameworkOptionName">
-        <source>FRAMEWORK</source>
-        <target state="translated">FRAMEWORK</target>
         <note />
       </trans-unit>
       <trans-unit id="WorkloadAlreadyInstalled">

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.es.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.es.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../LocalizableStrings.resx">
     <body>
+      <trans-unit id="FromCacheOptionDescription">
+        <source>Complete the operation from cache (offline).</source>
+        <target state="new">Complete the operation from cache (offline).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InstallationSucceeded">
         <source>Workload '{0}' (version '{1}') was successfully installed.</source>
         <target state="new">Workload '{0}' (version '{1}') was successfully installed.</target>
@@ -10,16 +15,6 @@
       <trans-unit id="InvalidWorkloadConfiguration">
         <source>The settings file in the workload's NuGet package is invalid: {0}</source>
         <target state="new">The settings file in the workload's NuGet package is invalid: {0}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ManifestPathOptionDescription">
-        <source>Path to the manifest file.</source>
-        <target state="translated">Ruta de acceso al archivo de manifiesto.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ManifestPathOptionName">
-        <source>PATH</source>
-        <target state="translated">PATH</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandDescription">
@@ -37,8 +32,13 @@
         <target state="needs-review-translation">La plataforma de destino para la que se instala la herramienta.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PrintDownloadLinkOnlyDescription">
+        <source>Only print the list of links to download without downloading it.</source>
+        <target state="new">Only print the list of links to download without downloading it.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="VersionOptionDescription">
-        <source>The version of the workload package to install.</source>
+        <source>The version of the SDK.</source>
         <target state="needs-review-translation">La versión del paquete de herramientas para instalar.</target>
         <note />
       </trans-unit>
@@ -75,11 +75,6 @@
       <trans-unit id="ConfigFileOptionName">
         <source>FILE</source>
         <target state="translated">FILE</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="FrameworkOptionName">
-        <source>FRAMEWORK</source>
-        <target state="translated">FRAMEWORK</target>
         <note />
       </trans-unit>
       <trans-unit id="WorkloadAlreadyInstalled">

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.fr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.fr.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../LocalizableStrings.resx">
     <body>
+      <trans-unit id="FromCacheOptionDescription">
+        <source>Complete the operation from cache (offline).</source>
+        <target state="new">Complete the operation from cache (offline).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InstallationSucceeded">
         <source>Workload '{0}' (version '{1}') was successfully installed.</source>
         <target state="new">Workload '{0}' (version '{1}') was successfully installed.</target>
@@ -10,16 +15,6 @@
       <trans-unit id="InvalidWorkloadConfiguration">
         <source>The settings file in the workload's NuGet package is invalid: {0}</source>
         <target state="new">The settings file in the workload's NuGet package is invalid: {0}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ManifestPathOptionDescription">
-        <source>Path to the manifest file.</source>
-        <target state="translated">Chemin du fichier manifeste.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ManifestPathOptionName">
-        <source>PATH</source>
-        <target state="translated">PATH</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandDescription">
@@ -37,8 +32,13 @@
         <target state="needs-review-translation">Framework cible pour lequel l'outil doit être installé.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PrintDownloadLinkOnlyDescription">
+        <source>Only print the list of links to download without downloading it.</source>
+        <target state="new">Only print the list of links to download without downloading it.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="VersionOptionDescription">
-        <source>The version of the workload package to install.</source>
+        <source>The version of the SDK.</source>
         <target state="needs-review-translation">Version du package d'outils à installer.</target>
         <note />
       </trans-unit>
@@ -75,11 +75,6 @@
       <trans-unit id="ConfigFileOptionName">
         <source>FILE</source>
         <target state="translated">FILE</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="FrameworkOptionName">
-        <source>FRAMEWORK</source>
-        <target state="translated">FRAMEWORK</target>
         <note />
       </trans-unit>
       <trans-unit id="WorkloadAlreadyInstalled">

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.it.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.it.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../LocalizableStrings.resx">
     <body>
+      <trans-unit id="FromCacheOptionDescription">
+        <source>Complete the operation from cache (offline).</source>
+        <target state="new">Complete the operation from cache (offline).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InstallationSucceeded">
         <source>Workload '{0}' (version '{1}') was successfully installed.</source>
         <target state="new">Workload '{0}' (version '{1}') was successfully installed.</target>
@@ -10,16 +15,6 @@
       <trans-unit id="InvalidWorkloadConfiguration">
         <source>The settings file in the workload's NuGet package is invalid: {0}</source>
         <target state="new">The settings file in the workload's NuGet package is invalid: {0}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ManifestPathOptionDescription">
-        <source>Path to the manifest file.</source>
-        <target state="translated">Percorso del file manifesto.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ManifestPathOptionName">
-        <source>PATH</source>
-        <target state="translated">PATH</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandDescription">
@@ -37,8 +32,13 @@
         <target state="needs-review-translation">Framework di destinazione per cui installare lo strumento.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PrintDownloadLinkOnlyDescription">
+        <source>Only print the list of links to download without downloading it.</source>
+        <target state="new">Only print the list of links to download without downloading it.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="VersionOptionDescription">
-        <source>The version of the workload package to install.</source>
+        <source>The version of the SDK.</source>
         <target state="needs-review-translation">Versione del pacchetto dello strumento da installare.</target>
         <note />
       </trans-unit>
@@ -75,11 +75,6 @@
       <trans-unit id="ConfigFileOptionName">
         <source>FILE</source>
         <target state="translated">FILE</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="FrameworkOptionName">
-        <source>FRAMEWORK</source>
-        <target state="translated">FRAMEWORK</target>
         <note />
       </trans-unit>
       <trans-unit id="WorkloadAlreadyInstalled">

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.ja.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.ja.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../LocalizableStrings.resx">
     <body>
+      <trans-unit id="FromCacheOptionDescription">
+        <source>Complete the operation from cache (offline).</source>
+        <target state="new">Complete the operation from cache (offline).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InstallationSucceeded">
         <source>Workload '{0}' (version '{1}') was successfully installed.</source>
         <target state="new">Workload '{0}' (version '{1}') was successfully installed.</target>
@@ -10,16 +15,6 @@
       <trans-unit id="InvalidWorkloadConfiguration">
         <source>The settings file in the workload's NuGet package is invalid: {0}</source>
         <target state="new">The settings file in the workload's NuGet package is invalid: {0}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ManifestPathOptionDescription">
-        <source>Path to the manifest file.</source>
-        <target state="translated">マニフェスト ファイルへのパス。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ManifestPathOptionName">
-        <source>PATH</source>
-        <target state="translated">PATH</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandDescription">
@@ -37,8 +32,13 @@
         <target state="needs-review-translation">ツールをインストールするターゲット フレームワーク。</target>
         <note />
       </trans-unit>
+      <trans-unit id="PrintDownloadLinkOnlyDescription">
+        <source>Only print the list of links to download without downloading it.</source>
+        <target state="new">Only print the list of links to download without downloading it.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="VersionOptionDescription">
-        <source>The version of the workload package to install.</source>
+        <source>The version of the SDK.</source>
         <target state="needs-review-translation">インストールするツール パッケージのバージョン。</target>
         <note />
       </trans-unit>
@@ -75,11 +75,6 @@
       <trans-unit id="ConfigFileOptionName">
         <source>FILE</source>
         <target state="translated">FILE</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="FrameworkOptionName">
-        <source>FRAMEWORK</source>
-        <target state="translated">FRAMEWORK</target>
         <note />
       </trans-unit>
       <trans-unit id="WorkloadAlreadyInstalled">

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.ko.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.ko.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../LocalizableStrings.resx">
     <body>
+      <trans-unit id="FromCacheOptionDescription">
+        <source>Complete the operation from cache (offline).</source>
+        <target state="new">Complete the operation from cache (offline).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InstallationSucceeded">
         <source>Workload '{0}' (version '{1}') was successfully installed.</source>
         <target state="new">Workload '{0}' (version '{1}') was successfully installed.</target>
@@ -10,16 +15,6 @@
       <trans-unit id="InvalidWorkloadConfiguration">
         <source>The settings file in the workload's NuGet package is invalid: {0}</source>
         <target state="new">The settings file in the workload's NuGet package is invalid: {0}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ManifestPathOptionDescription">
-        <source>Path to the manifest file.</source>
-        <target state="translated">매니페스트 파일 경로입니다.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ManifestPathOptionName">
-        <source>PATH</source>
-        <target state="translated">PATH</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandDescription">
@@ -37,8 +32,13 @@
         <target state="needs-review-translation">도구를 설치할 대상 프레임워크입니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PrintDownloadLinkOnlyDescription">
+        <source>Only print the list of links to download without downloading it.</source>
+        <target state="new">Only print the list of links to download without downloading it.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="VersionOptionDescription">
-        <source>The version of the workload package to install.</source>
+        <source>The version of the SDK.</source>
         <target state="needs-review-translation">설치할 도구 패키지 버전입니다.</target>
         <note />
       </trans-unit>
@@ -75,11 +75,6 @@
       <trans-unit id="ConfigFileOptionName">
         <source>FILE</source>
         <target state="translated">FILE</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="FrameworkOptionName">
-        <source>FRAMEWORK</source>
-        <target state="translated">FRAMEWORK</target>
         <note />
       </trans-unit>
       <trans-unit id="WorkloadAlreadyInstalled">

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.pl.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.pl.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../LocalizableStrings.resx">
     <body>
+      <trans-unit id="FromCacheOptionDescription">
+        <source>Complete the operation from cache (offline).</source>
+        <target state="new">Complete the operation from cache (offline).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InstallationSucceeded">
         <source>Workload '{0}' (version '{1}') was successfully installed.</source>
         <target state="new">Workload '{0}' (version '{1}') was successfully installed.</target>
@@ -10,16 +15,6 @@
       <trans-unit id="InvalidWorkloadConfiguration">
         <source>The settings file in the workload's NuGet package is invalid: {0}</source>
         <target state="new">The settings file in the workload's NuGet package is invalid: {0}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ManifestPathOptionDescription">
-        <source>Path to the manifest file.</source>
-        <target state="translated">Ścieżka do pliku manifestu.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ManifestPathOptionName">
-        <source>PATH</source>
-        <target state="translated">PATH</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandDescription">
@@ -37,8 +32,13 @@
         <target state="needs-review-translation">Docelowa platforma, dla której ma zostać zainstalowane narzędzie.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PrintDownloadLinkOnlyDescription">
+        <source>Only print the list of links to download without downloading it.</source>
+        <target state="new">Only print the list of links to download without downloading it.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="VersionOptionDescription">
-        <source>The version of the workload package to install.</source>
+        <source>The version of the SDK.</source>
         <target state="needs-review-translation">Wersja pakietu narzędzia do zainstalowania.</target>
         <note />
       </trans-unit>
@@ -75,11 +75,6 @@
       <trans-unit id="ConfigFileOptionName">
         <source>FILE</source>
         <target state="translated">FILE</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="FrameworkOptionName">
-        <source>FRAMEWORK</source>
-        <target state="translated">FRAMEWORK</target>
         <note />
       </trans-unit>
       <trans-unit id="WorkloadAlreadyInstalled">

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.pt-BR.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../LocalizableStrings.resx">
     <body>
+      <trans-unit id="FromCacheOptionDescription">
+        <source>Complete the operation from cache (offline).</source>
+        <target state="new">Complete the operation from cache (offline).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InstallationSucceeded">
         <source>Workload '{0}' (version '{1}') was successfully installed.</source>
         <target state="new">Workload '{0}' (version '{1}') was successfully installed.</target>
@@ -10,16 +15,6 @@
       <trans-unit id="InvalidWorkloadConfiguration">
         <source>The settings file in the workload's NuGet package is invalid: {0}</source>
         <target state="new">The settings file in the workload's NuGet package is invalid: {0}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ManifestPathOptionDescription">
-        <source>Path to the manifest file.</source>
-        <target state="translated">Caminho para o arquivo de manifesto.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ManifestPathOptionName">
-        <source>PATH</source>
-        <target state="translated">PATH</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandDescription">
@@ -37,8 +32,13 @@
         <target state="needs-review-translation">A estrutura de destino para a qual instalar a ferramenta.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PrintDownloadLinkOnlyDescription">
+        <source>Only print the list of links to download without downloading it.</source>
+        <target state="new">Only print the list of links to download without downloading it.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="VersionOptionDescription">
-        <source>The version of the workload package to install.</source>
+        <source>The version of the SDK.</source>
         <target state="needs-review-translation">A versão do pacote da ferramenta a ser instalada.</target>
         <note />
       </trans-unit>
@@ -75,11 +75,6 @@
       <trans-unit id="ConfigFileOptionName">
         <source>FILE</source>
         <target state="translated">FILE</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="FrameworkOptionName">
-        <source>FRAMEWORK</source>
-        <target state="translated">FRAMEWORK</target>
         <note />
       </trans-unit>
       <trans-unit id="WorkloadAlreadyInstalled">

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.ru.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.ru.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../LocalizableStrings.resx">
     <body>
+      <trans-unit id="FromCacheOptionDescription">
+        <source>Complete the operation from cache (offline).</source>
+        <target state="new">Complete the operation from cache (offline).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InstallationSucceeded">
         <source>Workload '{0}' (version '{1}') was successfully installed.</source>
         <target state="new">Workload '{0}' (version '{1}') was successfully installed.</target>
@@ -10,16 +15,6 @@
       <trans-unit id="InvalidWorkloadConfiguration">
         <source>The settings file in the workload's NuGet package is invalid: {0}</source>
         <target state="new">The settings file in the workload's NuGet package is invalid: {0}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ManifestPathOptionDescription">
-        <source>Path to the manifest file.</source>
-        <target state="translated">Путь к файлу манифеста.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ManifestPathOptionName">
-        <source>PATH</source>
-        <target state="translated">PATH</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandDescription">
@@ -37,8 +32,13 @@
         <target state="needs-review-translation">Целевая платформа для установки инструмента.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PrintDownloadLinkOnlyDescription">
+        <source>Only print the list of links to download without downloading it.</source>
+        <target state="new">Only print the list of links to download without downloading it.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="VersionOptionDescription">
-        <source>The version of the workload package to install.</source>
+        <source>The version of the SDK.</source>
         <target state="needs-review-translation">Версия устанавливаемого пакета инструмента.</target>
         <note />
       </trans-unit>
@@ -75,11 +75,6 @@
       <trans-unit id="ConfigFileOptionName">
         <source>FILE</source>
         <target state="translated">FILE</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="FrameworkOptionName">
-        <source>FRAMEWORK</source>
-        <target state="translated">FRAMEWORK</target>
         <note />
       </trans-unit>
       <trans-unit id="WorkloadAlreadyInstalled">

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.tr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.tr.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../LocalizableStrings.resx">
     <body>
+      <trans-unit id="FromCacheOptionDescription">
+        <source>Complete the operation from cache (offline).</source>
+        <target state="new">Complete the operation from cache (offline).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InstallationSucceeded">
         <source>Workload '{0}' (version '{1}') was successfully installed.</source>
         <target state="new">Workload '{0}' (version '{1}') was successfully installed.</target>
@@ -10,16 +15,6 @@
       <trans-unit id="InvalidWorkloadConfiguration">
         <source>The settings file in the workload's NuGet package is invalid: {0}</source>
         <target state="new">The settings file in the workload's NuGet package is invalid: {0}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ManifestPathOptionDescription">
-        <source>Path to the manifest file.</source>
-        <target state="translated">Bildirim dosyasının yolu.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ManifestPathOptionName">
-        <source>PATH</source>
-        <target state="translated">PATH</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandDescription">
@@ -37,8 +32,13 @@
         <target state="needs-review-translation">Aracın yükleneceği hedef çerçeve.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PrintDownloadLinkOnlyDescription">
+        <source>Only print the list of links to download without downloading it.</source>
+        <target state="new">Only print the list of links to download without downloading it.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="VersionOptionDescription">
-        <source>The version of the workload package to install.</source>
+        <source>The version of the SDK.</source>
         <target state="needs-review-translation">Yüklenecek araç paketinin sürümü.</target>
         <note />
       </trans-unit>
@@ -75,11 +75,6 @@
       <trans-unit id="ConfigFileOptionName">
         <source>FILE</source>
         <target state="translated">FILE</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="FrameworkOptionName">
-        <source>FRAMEWORK</source>
-        <target state="translated">FRAMEWORK</target>
         <note />
       </trans-unit>
       <trans-unit id="WorkloadAlreadyInstalled">

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.zh-Hans.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-HANS" original="../LocalizableStrings.resx">
     <body>
+      <trans-unit id="FromCacheOptionDescription">
+        <source>Complete the operation from cache (offline).</source>
+        <target state="new">Complete the operation from cache (offline).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InstallationSucceeded">
         <source>Workload '{0}' (version '{1}') was successfully installed.</source>
         <target state="new">Workload '{0}' (version '{1}') was successfully installed.</target>
@@ -10,16 +15,6 @@
       <trans-unit id="InvalidWorkloadConfiguration">
         <source>The settings file in the workload's NuGet package is invalid: {0}</source>
         <target state="new">The settings file in the workload's NuGet package is invalid: {0}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ManifestPathOptionDescription">
-        <source>Path to the manifest file.</source>
-        <target state="translated">清单文件的路径。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ManifestPathOptionName">
-        <source>PATH</source>
-        <target state="translated">PATH</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandDescription">
@@ -37,8 +32,13 @@
         <target state="needs-review-translation">要安装工具的目标框架。</target>
         <note />
       </trans-unit>
+      <trans-unit id="PrintDownloadLinkOnlyDescription">
+        <source>Only print the list of links to download without downloading it.</source>
+        <target state="new">Only print the list of links to download without downloading it.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="VersionOptionDescription">
-        <source>The version of the workload package to install.</source>
+        <source>The version of the SDK.</source>
         <target state="needs-review-translation">要安装的工具包版本。</target>
         <note />
       </trans-unit>
@@ -75,11 +75,6 @@
       <trans-unit id="ConfigFileOptionName">
         <source>FILE</source>
         <target state="translated">FILE</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="FrameworkOptionName">
-        <source>FRAMEWORK</source>
-        <target state="translated">FRAMEWORK</target>
         <note />
       </trans-unit>
       <trans-unit id="WorkloadAlreadyInstalled">

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.zh-Hant.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-HANT" original="../LocalizableStrings.resx">
     <body>
+      <trans-unit id="FromCacheOptionDescription">
+        <source>Complete the operation from cache (offline).</source>
+        <target state="new">Complete the operation from cache (offline).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InstallationSucceeded">
         <source>Workload '{0}' (version '{1}') was successfully installed.</source>
         <target state="new">Workload '{0}' (version '{1}') was successfully installed.</target>
@@ -10,16 +15,6 @@
       <trans-unit id="InvalidWorkloadConfiguration">
         <source>The settings file in the workload's NuGet package is invalid: {0}</source>
         <target state="new">The settings file in the workload's NuGet package is invalid: {0}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ManifestPathOptionDescription">
-        <source>Path to the manifest file.</source>
-        <target state="translated">資訊清單檔的路徑。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ManifestPathOptionName">
-        <source>PATH</source>
-        <target state="translated">PATH</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandDescription">
@@ -37,8 +32,13 @@
         <target state="needs-review-translation">要為工具安裝的目標 Framework。</target>
         <note />
       </trans-unit>
+      <trans-unit id="PrintDownloadLinkOnlyDescription">
+        <source>Only print the list of links to download without downloading it.</source>
+        <target state="new">Only print the list of links to download without downloading it.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="VersionOptionDescription">
-        <source>The version of the workload package to install.</source>
+        <source>The version of the SDK.</source>
         <target state="needs-review-translation">要安裝之工具套件的版本。</target>
         <note />
       </trans-unit>
@@ -75,11 +75,6 @@
       <trans-unit id="ConfigFileOptionName">
         <source>FILE</source>
         <target state="translated">FILE</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="FrameworkOptionName">
-        <source>FRAMEWORK</source>
-        <target state="translated">FRAMEWORK</target>
         <note />
       </trans-unit>
       <trans-unit id="WorkloadAlreadyInstalled">

--- a/src/Cli/dotnet/commands/dotnet-workload/list/WorkloadListCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/list/WorkloadListCommand.cs
@@ -1,26 +1,59 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Generic;
 using System.CommandLine.Parsing;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
 using Microsoft.DotNet.Cli;
 using Microsoft.DotNet.Cli.Utils;
+using Microsoft.DotNet.Configurer;
+using Microsoft.DotNet.Workloads.Workload.Install;
 
 namespace Microsoft.DotNet.Workloads.Workload.List
 {
     internal class WorkloadListCommand : CommandBase
     {
+        private readonly bool _machineReadableOption;
+
+        private readonly string _mockInstallDirectory = Path.Combine(CliFolderPathCalculator.DotnetUserProfileFolderPath,
+            "DEV_mockworkloads");
+
         public WorkloadListCommand(
             ParseResult result
         )
             : base(result)
         {
-  
+            _machineReadableOption = result.ValueForOption<bool>(WorkloadListCommandParser.MachineReadableOption);
         }
 
         public override int Execute()
         {
             // TODO stub
-            Reporter.Output.Write("WIP stub workload list");
+            var installedList = new List<string>();
+            if (_machineReadableOption)
+            {
+                if (File.Exists(Path.Combine(_mockInstallDirectory, "Microsoft.iOS.Bundle.6.0.100.nupkg")))
+                {
+                    installedList.Add("mobile-ios");
+                }
+
+                if (File.Exists(Path.Combine(_mockInstallDirectory, "Microsoft.NET.Workload.Android.6.0.100.nupkg")))
+                {
+                    installedList.Add("mobile-ios");
+                }
+            }
+
+            var outputJson = new Dictionary<string, string[]>()
+            {
+                ["installed"] = installedList.ToArray()
+            };
+
+            Reporter.Output.WriteLine("==workloadListJsonOutputStart==");
+            Reporter.Output.WriteLine(
+                JsonSerializer.Serialize(outputJson));
+            Reporter.Output.WriteLine("==workloadListJsonOutputEnd==");
             return 0;
         }
     }

--- a/src/Cli/dotnet/commands/dotnet-workload/list/WorkloadListCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/list/WorkloadListCommandParser.cs
@@ -8,9 +8,16 @@ namespace Microsoft.DotNet.Cli
 {
     internal static class WorkloadListCommandParser
     {
+        // arguments are a list of workload to be detected
+        public static readonly Option MachineReadableOption = new Option<bool>("--machine-readable")
+        {
+            IsHidden = true
+        };
+
         public static Command GetCommand()
         {
             var command = new Command("list", LocalizableStrings.CommandDescription);
+            command.AddOption(MachineReadableOption);
             return command;
         }
     }

--- a/src/Cli/dotnet/commands/dotnet-workload/update/LocalizableStrings.resx
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/LocalizableStrings.resx
@@ -141,12 +141,6 @@
   <data name="ConfigFileOptionDescription" xml:space="preserve">
     <value>The NuGet configuration file to use.</value>
   </data>
-  <data name="FrameworkOptionName" xml:space="preserve">
-    <value>FRAMEWORK</value>
-  </data>
-  <data name="FrameworkOptionDescription" xml:space="preserve">
-    <value>The target framework to update the workload for.</value>
-  </data>
   <data name="NuGetConfigurationFileDoesNotExist" xml:space="preserve">
     <value>NuGet configuration file '{0}' does not exist.</value>
   </data>

--- a/src/Cli/dotnet/commands/dotnet-workload/update/WorkloadUpdateCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/WorkloadUpdateCommandParser.cs
@@ -14,8 +14,6 @@ namespace Microsoft.DotNet.Cli
 
         public static readonly Option AddSourceOption = WorkloadInstallCommandParser.AddSourceOption;
 
-        public static readonly Option FrameworkOption = WorkloadInstallCommandParser.FrameworkOption;
-
         public static readonly Option VersionOption = WorkloadInstallCommandParser.VersionOption;
 
         public static readonly Option VerbosityOption = WorkloadInstallCommandParser.VerbosityOption;
@@ -27,7 +25,6 @@ namespace Microsoft.DotNet.Cli
             command.AddArgument(PackageIdArgument);
             command.AddOption(ConfigOption);
             command.AddOption(AddSourceOption);
-            command.AddOption(FrameworkOption);
             command.AddOption(VersionOption);
             command.AddOption(WorkloadCommandRestorePassThroughOptions.DisableParallelOption);
             command.AddOption(WorkloadCommandRestorePassThroughOptions.IgnoreFailedSourcesOption);

--- a/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.cs.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.cs.xlf
@@ -57,11 +57,6 @@
         <target state="translated">Konfigurační soubor NuGet, který se použije.</target>
         <note />
       </trans-unit>
-      <trans-unit id="FrameworkOptionDescription">
-        <source>The target framework to update the workload for.</source>
-        <target state="translated">Cílová architektura, pro kterou se má nástroj aktualizovat</target>
-        <note />
-      </trans-unit>
       <trans-unit id="NuGetConfigurationFileDoesNotExist">
         <source>NuGet configuration file '{0}' does not exist.</source>
         <target state="translated">Konfigurační soubor NuGet {0} neexistuje.</target>
@@ -100,11 +95,6 @@
       <trans-unit id="ConfigFileOptionName">
         <source>FILE</source>
         <target state="translated">FILE</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="FrameworkOptionName">
-        <source>FRAMEWORK</source>
-        <target state="translated">FRAMEWORK</target>
         <note />
       </trans-unit>
       <trans-unit id="VersionOptionName">

--- a/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.de.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.de.xlf
@@ -57,11 +57,6 @@
         <target state="translated">Die zu verwendende NuGet-Konfigurationsdatei.</target>
         <note />
       </trans-unit>
-      <trans-unit id="FrameworkOptionDescription">
-        <source>The target framework to update the workload for.</source>
-        <target state="translated">Das Zielframework, für das das Workload aktualisiert wird.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="NuGetConfigurationFileDoesNotExist">
         <source>NuGet configuration file '{0}' does not exist.</source>
         <target state="translated">Die NuGet-Konfigurationsdatei "{0}" ist nicht vorhanden.</target>
@@ -100,11 +95,6 @@
       <trans-unit id="ConfigFileOptionName">
         <source>FILE</source>
         <target state="translated">FILE</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="FrameworkOptionName">
-        <source>FRAMEWORK</source>
-        <target state="translated">FRAMEWORK</target>
         <note />
       </trans-unit>
       <trans-unit id="VersionOptionName">

--- a/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.es.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.es.xlf
@@ -57,11 +57,6 @@
         <target state="translated">Archivo de configuración de NuGet que debe usarse.</target>
         <note />
       </trans-unit>
-      <trans-unit id="FrameworkOptionDescription">
-        <source>The target framework to update the workload for.</source>
-        <target state="translated">La plataforma de destino para la que se actualiza la herramienta.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="NuGetConfigurationFileDoesNotExist">
         <source>NuGet configuration file '{0}' does not exist.</source>
         <target state="translated">El archivo de configuración de NuGet "{0}" no existe.</target>
@@ -100,11 +95,6 @@
       <trans-unit id="ConfigFileOptionName">
         <source>FILE</source>
         <target state="translated">FILE</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="FrameworkOptionName">
-        <source>FRAMEWORK</source>
-        <target state="translated">FRAMEWORK</target>
         <note />
       </trans-unit>
       <trans-unit id="VersionOptionName">

--- a/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.fr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.fr.xlf
@@ -57,11 +57,6 @@
         <target state="translated">Fichier de configuration NuGet à utiliser.</target>
         <note />
       </trans-unit>
-      <trans-unit id="FrameworkOptionDescription">
-        <source>The target framework to update the workload for.</source>
-        <target state="translated">Framework cible pour lequel l'outil doit être mis à jour.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="NuGetConfigurationFileDoesNotExist">
         <source>NuGet configuration file '{0}' does not exist.</source>
         <target state="translated">Le fichier config NuGet '{0}' n'existe pas.</target>
@@ -100,11 +95,6 @@
       <trans-unit id="ConfigFileOptionName">
         <source>FILE</source>
         <target state="translated">FILE</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="FrameworkOptionName">
-        <source>FRAMEWORK</source>
-        <target state="translated">FRAMEWORK</target>
         <note />
       </trans-unit>
       <trans-unit id="VersionOptionName">

--- a/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.it.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.it.xlf
@@ -57,11 +57,6 @@
         <target state="translated">File di configurazione NuGet da usare.</target>
         <note />
       </trans-unit>
-      <trans-unit id="FrameworkOptionDescription">
-        <source>The target framework to update the workload for.</source>
-        <target state="translated">Framework di destinazione per cui aggiornare lo strumento.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="NuGetConfigurationFileDoesNotExist">
         <source>NuGet configuration file '{0}' does not exist.</source>
         <target state="translated">Il file di configurazione NuGet '{0}' non esiste.</target>
@@ -100,11 +95,6 @@
       <trans-unit id="ConfigFileOptionName">
         <source>FILE</source>
         <target state="translated">FILE</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="FrameworkOptionName">
-        <source>FRAMEWORK</source>
-        <target state="translated">FRAMEWORK</target>
         <note />
       </trans-unit>
       <trans-unit id="VersionOptionName">

--- a/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.ja.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.ja.xlf
@@ -57,11 +57,6 @@
         <target state="translated">使用する NuGet 構成ファイル。</target>
         <note />
       </trans-unit>
-      <trans-unit id="FrameworkOptionDescription">
-        <source>The target framework to update the workload for.</source>
-        <target state="translated">ツールを更新するターゲット フレームワーク。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="NuGetConfigurationFileDoesNotExist">
         <source>NuGet configuration file '{0}' does not exist.</source>
         <target state="translated">NuGet 構成ファイル '{0}' は存在しません。</target>
@@ -100,11 +95,6 @@
       <trans-unit id="ConfigFileOptionName">
         <source>FILE</source>
         <target state="translated">FILE</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="FrameworkOptionName">
-        <source>FRAMEWORK</source>
-        <target state="translated">FRAMEWORK</target>
         <note />
       </trans-unit>
       <trans-unit id="VersionOptionName">

--- a/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.ko.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.ko.xlf
@@ -57,11 +57,6 @@
         <target state="translated">사용할 NuGet 구성 파일입니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="FrameworkOptionDescription">
-        <source>The target framework to update the workload for.</source>
-        <target state="translated">도구를 업데이트할 대상 프레임워크입니다.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="NuGetConfigurationFileDoesNotExist">
         <source>NuGet configuration file '{0}' does not exist.</source>
         <target state="translated">NuGet 구성 파일 '{0}'이(가) 없습니다.</target>
@@ -100,11 +95,6 @@
       <trans-unit id="ConfigFileOptionName">
         <source>FILE</source>
         <target state="translated">FILE</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="FrameworkOptionName">
-        <source>FRAMEWORK</source>
-        <target state="translated">FRAMEWORK</target>
         <note />
       </trans-unit>
       <trans-unit id="VersionOptionName">

--- a/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.pl.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.pl.xlf
@@ -57,11 +57,6 @@
         <target state="translated">Plik konfiguracji programu NuGet do użycia.</target>
         <note />
       </trans-unit>
-      <trans-unit id="FrameworkOptionDescription">
-        <source>The target framework to update the workload for.</source>
-        <target state="translated">Docelowa platforma, dla której ma zostać zaktualizowane narzędzie.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="NuGetConfigurationFileDoesNotExist">
         <source>NuGet configuration file '{0}' does not exist.</source>
         <target state="translated">Plik konfiguracji pakietu NuGet „{0}” nie istnieje.</target>
@@ -100,11 +95,6 @@
       <trans-unit id="ConfigFileOptionName">
         <source>FILE</source>
         <target state="translated">FILE</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="FrameworkOptionName">
-        <source>FRAMEWORK</source>
-        <target state="translated">FRAMEWORK</target>
         <note />
       </trans-unit>
       <trans-unit id="VersionOptionName">

--- a/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.pt-BR.xlf
@@ -57,11 +57,6 @@
         <target state="translated">O arquivo de configuração do NuGet a ser usado.</target>
         <note />
       </trans-unit>
-      <trans-unit id="FrameworkOptionDescription">
-        <source>The target framework to update the workload for.</source>
-        <target state="translated">A estrutura de destino para a qual atualizar a ferramenta.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="NuGetConfigurationFileDoesNotExist">
         <source>NuGet configuration file '{0}' does not exist.</source>
         <target state="translated">O arquivo de configuração '{0}' do NuGet não existe.</target>
@@ -100,11 +95,6 @@
       <trans-unit id="ConfigFileOptionName">
         <source>FILE</source>
         <target state="translated">FILE</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="FrameworkOptionName">
-        <source>FRAMEWORK</source>
-        <target state="translated">FRAMEWORK</target>
         <note />
       </trans-unit>
       <trans-unit id="VersionOptionName">

--- a/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.ru.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.ru.xlf
@@ -57,11 +57,6 @@
         <target state="translated">Используемый файл конфигурации NuGet.</target>
         <note />
       </trans-unit>
-      <trans-unit id="FrameworkOptionDescription">
-        <source>The target framework to update the workload for.</source>
-        <target state="translated">Целевая платформа для обновления инструмента.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="NuGetConfigurationFileDoesNotExist">
         <source>NuGet configuration file '{0}' does not exist.</source>
         <target state="translated">Файл конфигурации NuGet "{0}" не существует.</target>
@@ -100,11 +95,6 @@
       <trans-unit id="ConfigFileOptionName">
         <source>FILE</source>
         <target state="translated">FILE</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="FrameworkOptionName">
-        <source>FRAMEWORK</source>
-        <target state="translated">FRAMEWORK</target>
         <note />
       </trans-unit>
       <trans-unit id="VersionOptionName">

--- a/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.tr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.tr.xlf
@@ -57,11 +57,6 @@
         <target state="translated">Kullanılacak NuGet yapılandırma dosyası.</target>
         <note />
       </trans-unit>
-      <trans-unit id="FrameworkOptionDescription">
-        <source>The target framework to update the workload for.</source>
-        <target state="translated">Aracın güncelleştirileceği hedef çerçeve.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="NuGetConfigurationFileDoesNotExist">
         <source>NuGet configuration file '{0}' does not exist.</source>
         <target state="translated">NuGet yapılandırma dosyası '{0}' yok.</target>
@@ -100,11 +95,6 @@
       <trans-unit id="ConfigFileOptionName">
         <source>FILE</source>
         <target state="translated">FILE</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="FrameworkOptionName">
-        <source>FRAMEWORK</source>
-        <target state="translated">FRAMEWORK</target>
         <note />
       </trans-unit>
       <trans-unit id="VersionOptionName">

--- a/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.zh-Hans.xlf
@@ -57,11 +57,6 @@
         <target state="translated">要使用的 NuGet 配置文件。</target>
         <note />
       </trans-unit>
-      <trans-unit id="FrameworkOptionDescription">
-        <source>The target framework to update the workload for.</source>
-        <target state="translated">要更新工具的目标框架。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="NuGetConfigurationFileDoesNotExist">
         <source>NuGet configuration file '{0}' does not exist.</source>
         <target state="translated">NuGet 配置文件“{0}”不存在。</target>
@@ -100,11 +95,6 @@
       <trans-unit id="ConfigFileOptionName">
         <source>FILE</source>
         <target state="translated">FILE</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="FrameworkOptionName">
-        <source>FRAMEWORK</source>
-        <target state="translated">FRAMEWORK</target>
         <note />
       </trans-unit>
       <trans-unit id="VersionOptionName">

--- a/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.zh-Hant.xlf
@@ -57,11 +57,6 @@
         <target state="translated">要使用的 NuGet 組態檔。</target>
         <note />
       </trans-unit>
-      <trans-unit id="FrameworkOptionDescription">
-        <source>The target framework to update the workload for.</source>
-        <target state="translated">要為工具更新的目標 Framework。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="NuGetConfigurationFileDoesNotExist">
         <source>NuGet configuration file '{0}' does not exist.</source>
         <target state="translated">NuGet 組態檔 '{0}' 不存在。</target>
@@ -100,11 +95,6 @@
       <trans-unit id="ConfigFileOptionName">
         <source>FILE</source>
         <target state="translated">FILE</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="FrameworkOptionName">
-        <source>FRAMEWORK</source>
-        <target state="translated">FRAMEWORK</target>
         <note />
       </trans-unit>
       <trans-unit id="VersionOptionName">


### PR DESCRIPTION
# VS mac mock command line interaction

The mock commands are the desired **.NET SDK commandline structure**. However, it does not have a proper implementation. For example, the command `dotnet workload install mobile-ios` should be the "final" command. However what it does internally today is just copy a marker file around.

To enable it, run `export DEVENABLEWORKLOADCOMMAND=1` on the command line first.

So far, only install part is done. We can at least start to work on VS mac installer integration.

## internal only command

These "internal only" commands are intended for internal consumption only. So that we don't have to spend too much time designing the UX and maintaining the backcompat in the future. These commands will not show up in "dotnet --help". However, any user can user them. We will treat them like "underscore msbuild property" -- you can use them, however, we will not maintain backcompat, use it at your own risk.

## Workload installed/need update or not (internal only command)

input `dotnet workload list --machine-readable`

output, all installed workloads per installation record. If _mobile_ is installed, it will not show _mobile-ios_ or _mobile-android_ even if _mobile_ is composed with _mobile-ios_ and _mobile-android_.

```shell
==workloadListJsonOutputStart==
{"installed":["mobile-ios"]}
==workloadListJsonOutputEnd==
```

## Show download URL (internal only command)

input `dotnet workload install mobile-ios mobile-android --print-download-link-only`

output

```shell
==allPackageLinksJsonOutputStart==
["https://www.myget.org/F/mockworkloadfeed/api/v3/flatcontainer/microsoft.ios.bundle/6.0.100/microsoft.ios.bundle.6.0.100.nupkg","https://www.nuget.org/api/v2/package/Newtonsoft.Json/13.0.1-beta2","https://www.myget.org/F/mockworkloadfeed/api/v3/flatcontainer/microsoft.net.workload.android/6.0.100/microsoft.net.workload.android.6.0.100.nupkg"]
==allPackageLinksJsonOutputEnd==
```

An array of URL is returned for the input "mobile-ios", "mobile-android" workload ids. Once VSMac installer get the list of URL. VSMac should download these packages to a folder it maintains. Later VSMac should be in charge of deleting these temporary nupkgs.

The mock implementation will add a newtonsoft.json to the download list to show that there could be multiple nupkgs to download for a single workload.

## Install from cache

input `dotnet workload install mobile-ios --from-cache /Users/Downloads/temp-downloaddir`

/Users/Downloads/temp-downloaddir should contain all the necessary nupkgs like *microsoft.ios.bundle.6.0.100.nupkg* and newtonsoft.json.

output, nothing, return 0 if succeed.

If the workload is installed already. The command will fail.