### PR TITLE
Add support for updating scoped css files

### DIFF
--- a/src/BuiltInTools/BrowserRefresh/HostingFilter.cs
+++ b/src/BuiltInTools/BrowserRefresh/HostingFilter.cs
@@ -25,6 +25,7 @@ namespace Microsoft.AspNetCore.Watch.BrowserRefresh
             {
                 app.Map("/_framework/clear-browser-cache", app1 => app1.Run(context =>
                 {
+                    // Scoped css files can contain links to other css files. We'll try clearing out the http caches to force the browser to re-download.
                     // See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Clear-Site-Data#directives
                     context.Response.Headers["Clear-site-data"] = "\"cache\"";
                     return Task.CompletedTask;

--- a/src/BuiltInTools/BrowserRefresh/HostingFilter.cs
+++ b/src/BuiltInTools/BrowserRefresh/HostingFilter.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Globalization;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
@@ -23,6 +23,12 @@ namespace Microsoft.AspNetCore.Watch.BrowserRefresh
         {
             return app =>
             {
+                app.Map("/_framework/clear-browser-cache", app1 => app1.Run(context =>
+                {
+                    // See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Clear-Site-Data#directives
+                    context.Response.Headers["Clear-site-data"] = "\"cache\"";
+                    return Task.CompletedTask;
+                }));
                 app.Map(WebSocketScriptInjection.WebSocketScriptUrl, app1 => app1.UseMiddleware<BrowserScriptMiddleware>());
                 app.UseMiddleware<BrowserRefreshMiddleware>();
                 next(app);

--- a/src/BuiltInTools/BrowserRefresh/WebSocketScriptInjection.js
+++ b/src/BuiltInTools/BrowserRefresh/WebSocketScriptInjection.js
@@ -55,12 +55,15 @@ setTimeout(function () {
     }
   }
 
-  function updateCssByPath(path) {
+  async function updateCssByPath(path) {
     const styleElement = document.querySelector(`link[href^="${path}"]`) ||
       document.querySelector(`link[href^="${document.baseURI}${path}"]`);
 
+    // Receive a Clear-site-data header.
+    await fetch('/_framework/clear-browser-cache');
+
     if (!styleElement || !styleElement.parentNode) {
-      console.debug('Unable to find a stylesheet to update. Updating all css.');
+      console.debug('Unable to find a stylesheet to update. Updating all local css files.');
       updateAllLocalCss();
     }
 
@@ -74,7 +77,7 @@ setTimeout(function () {
   }
 
   function updateCssElement(styleElement) {
-    if (styleElement.loading) {
+    if (!styleElement || styleElement.loading) {
       // A file change notification may be triggered for the same file before the browser
       // finishes processing a previous update. In this case, it's easiest to ignore later updates
       return;
@@ -92,12 +95,6 @@ setTimeout(function () {
     });
 
     styleElement.parentNode.insertBefore(newElement, styleElement.nextSibling);
-  }
-
-  function updateScopedCss() {
-    [...document.querySelectorAll('link')]
-      .filter(l => l.baseURI === document.baseURI && l.href && l.href.indexOf('.styles.css') !== -1)
-      .forEach(e => updateCssElement(e));
   }
 
   function applyBlazorDeltas(deltas) {

--- a/src/BuiltInTools/dotnet-watch/HotReload/ScopedCssFileHandler.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/ScopedCssFileHandler.cs
@@ -1,0 +1,73 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.DotNet.Cli.Utils;
+using Microsoft.DotNet.Watcher.Internal;
+
+namespace Microsoft.DotNet.Watcher.Tools
+{
+    internal sealed class ScopedCssFileHandler
+    {
+        private static readonly string _muxerPath = new Muxer().MuxerPath;
+        private readonly ProcessRunner _processRunner;
+        private readonly Extensions.Tools.Internal.IReporter _reporter;
+
+        public ScopedCssFileHandler(ProcessRunner processRunner, Extensions.Tools.Internal.IReporter reporter)
+        {
+            _processRunner = processRunner;
+            _reporter = reporter;
+        }
+
+        public async ValueTask<bool> TryHandleFileChange(DotNetWatchContext context, FileItem file, CancellationToken cancellationToken)
+        {
+            if (!file.FilePath.EndsWith(".razor.css", StringComparison.Ordinal) &&
+                !file.FilePath.EndsWith(".cshtml.css", StringComparison.Ordinal))
+            {
+                return default;
+            }
+
+            _reporter.Verbose($"Handling file change event for scoped css file {file.FilePath}.");
+            if (!await RebuildScopedCss(file.ProjectPath, cancellationToken))
+            {
+                return false;
+            }
+            await HandleBrowserRefresh(context.BrowserRefreshServer, file, cancellationToken);
+            return true;
+        }
+
+        private async ValueTask<bool> RebuildScopedCss(string projectPath, CancellationToken cancellationToken)
+        {
+            var build = new ProcessSpec
+            {
+                Executable = _muxerPath,
+                Arguments = new[] { "msbuild", "/nologo", "/t:_PrepareForScopedCss", projectPath, }
+            };
+
+            var result = await _processRunner.RunAsync(build, cancellationToken);
+            return result == 0;
+        }
+
+        private static async Task HandleBrowserRefresh(BrowserRefreshServer browserRefreshServer, FileItem fileItem, CancellationToken cancellationToken)
+        {
+            // We'd like an accurate scoped css path, but this needs a lot of work to wire-up now.
+            // We'll handle this as part of https://github.com/dotnet/aspnetcore/issues/31217.
+            // For now, we'll make it look like some css file which would cause JS to update a
+            // single file if it's from the current project, or all locally hosted css files if it's a file from
+            // referenced project.
+            var cssFilePath = Path.GetFileNameWithoutExtension(fileItem.ProjectPath) + ".css";
+            var message = new UpdateStaticFileMessage { Path = cssFilePath };
+            await browserRefreshServer.SendJsonSerlialized(message, cancellationToken);
+        }
+
+        private readonly struct UpdateStaticFileMessage
+        {
+            public string Type => "UpdateStaticFile";
+
+            public string Path { get; init; }
+        }
+    }
+}

--- a/src/BuiltInTools/dotnet-watch/HotReloadDotNetWatcher.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReloadDotNetWatcher.cs
@@ -93,7 +93,7 @@ namespace Microsoft.DotNet.Watcher
                 using var fileSetWatcher = new FileSetWatcher(fileSet, _reporter);
                 try
                 {
-                    using var hotReload = new HotReload(_reporter);
+                    using var hotReload = new HotReload(_processRunner, _reporter);
                     await hotReload.InitializeAsync(context, cancellationToken);
 
                     var processTask = _processRunner.RunAsync(processSpec, combinedCancellationSource.Token);


### PR DESCRIPTION
This change adds supports for updating .razor.css and .cshtml.css files. It operates by shelling out to MSBuild and invokes targets that regens scoped css files. This is currently a lot (9x) slower compared to emitting deltas. We'll eventually be able to move creating this file in to the compiler and that should improve things there.

A second issue is that we're not correctly calculating the path of the project's bundled scoped css files. While this isn't hard, it's just a lot of work that would get thrown away once we move to hosting MSBuild in-process (https://github.com/dotnet/aspnetcore/issues/31217). In the meanwhile, updating a scoped css file causes every local css file to be updated. At least in the templates, this doesn't look very poor and should suffice for an early preview.