### PR TITLE
Simplify the path that dotnet-watch is installed to

### DIFF
--- a/src/Cli/dotnet/CommandFactory/CommandResolution/DotnetToolsCommandResolver.cs
+++ b/src/Cli/dotnet/CommandFactory/CommandResolution/DotnetToolsCommandResolver.cs
@@ -30,7 +30,19 @@ namespace Microsoft.DotNet.CommandFactory
                 return null;
             }
 
-            var packageId = new DirectoryInfo(Path.Combine(_dotnetToolPath, arguments.CommandName));
+            var packagePath = Path.Combine(_dotnetToolPath, arguments.CommandName);
+            if (string.Equals(arguments.CommandName, "dotnet-watch", StringComparison.Ordinal))
+            {
+                var toolAtRootPath = Path.Combine(packagePath, arguments.CommandName + ".dll");
+                if (File.Exists(toolAtRootPath))
+                {
+                    return MuxerCommandSpecMaker.CreatePackageCommandSpecUsingMuxer(
+                        toolAtRootPath,
+                        arguments.CommandArguments);
+                }
+            }
+
+            var packageId = new DirectoryInfo(packagePath);
             if (!packageId.Exists)
             {
                 return null;

--- a/src/Cli/dotnet/CommandFactory/CommandResolution/DotnetToolsCommandResolver.cs
+++ b/src/Cli/dotnet/CommandFactory/CommandResolution/DotnetToolsCommandResolver.cs
@@ -6,6 +6,10 @@ using System.IO;
 
 namespace Microsoft.DotNet.CommandFactory
 {
+    /// <summary>
+    /// A <see cref="ICommandResolver" /> for tools built-in with the .NET SDK.
+    /// This includes <c>dotnet-watch</c>, <c>dotnet-dev-certs<c>, <c>dotnet-sql-cache<c>, and <c>dotnet-user-secrets</c>.
+    /// </summary>
     public class DotnetToolsCommandResolver : ICommandResolver
     {
         private string _dotnetToolPath;
@@ -31,32 +35,15 @@ namespace Microsoft.DotNet.CommandFactory
             }
 
             var packagePath = Path.Combine(_dotnetToolPath, arguments.CommandName);
-            if (string.Equals(arguments.CommandName, "dotnet-watch", StringComparison.Ordinal))
+            var toolAtRootPath = Path.Combine(packagePath, arguments.CommandName + ".dll");
+            if (File.Exists(toolAtRootPath))
             {
-                var toolAtRootPath = Path.Combine(packagePath, arguments.CommandName + ".dll");
-                if (File.Exists(toolAtRootPath))
-                {
-                    return MuxerCommandSpecMaker.CreatePackageCommandSpecUsingMuxer(
-                        toolAtRootPath,
-                        arguments.CommandArguments);
-                }
-            }
-
-            var packageId = new DirectoryInfo(packagePath);
-            if (!packageId.Exists)
-            {
-                return null;
-            }
-
-            var version = packageId.GetDirectories()[0];
-            var dll = version.GetDirectories("tools")[0]
-                .GetDirectories()[0] // TFM
-                .GetDirectories()[0] // RID
-                .GetFiles($"{arguments.CommandName}.dll")[0];
-
-            return MuxerCommandSpecMaker.CreatePackageCommandSpecUsingMuxer(
-                    dll.FullName,
+                return MuxerCommandSpecMaker.CreatePackageCommandSpecUsingMuxer(
+                    toolAtRootPath,
                     arguments.CommandArguments);
+            }
+
+            return null;
         }
     }
 }

--- a/src/Layout/redist/targets/GenerateLayout.targets
+++ b/src/Layout/redist/targets/GenerateLayout.targets
@@ -135,7 +135,7 @@
           BeforeTargets="Build">
 
     <PropertyGroup>
-      <DotnetWatchOutputDirectory>$(OutputPath)\DotnetTools\dotnet-watch\$(Version)\tools\$(SdkTargetFramework)\any\</DotnetWatchOutputDirectory>
+      <DotnetWatchOutputDirectory>$(OutputPath)\DotnetTools\dotnet-watch\</DotnetWatchOutputDirectory>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Layout/redist/targets/OverlaySdkOnLKG.targets
+++ b/src/Layout/redist/targets/OverlaySdkOnLKG.targets
@@ -27,7 +27,7 @@
 
     <PropertyGroup>
       <SdkOutputDirectory>$(RedistLayoutPath)/sdk/$(Version)</SdkOutputDirectory>
-      <DotnetWatchOutputDirectory>$(SdkOutputDirectory)\DotnetTools\dotnet-watch\$(Version)\tools\$(SdkTargetFramework)\any\</DotnetWatchOutputDirectory>
+      <DotnetWatchOutputDirectory>$(SdkOutputDirectory)\DotnetTools\dotnet-watch\</DotnetWatchOutputDirectory>
     </PropertyGroup>
 
     <Copy SourceFiles="@(OverlaySdkFilesFromStage0)"


### PR DESCRIPTION
VS attempts to load a couple of binaries carried by dotnet-watch. Currently this involves
digging around a bunch of directories. This simplifies the process a bit for them.

Fixes https://github.com/dotnet/aspnetcore/issues/30860