### PR TITLE
Rebased darc bump of templating repo

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,34 +1,34 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.TemplateEngine.Cli" Version="6.0.100-preview.3.21161.1">
+    <Dependency Name="Microsoft.TemplateEngine.Cli" Version="6.0.100-preview.3.21165.1">
       <Uri>https://github.com/dotnet/templating</Uri>
-      <Sha>5067a9034f799eceb42846a62e5431a3ec8a267b</Sha>
+      <Sha>06aaf297687006acbe2c7045b2c2be9549a464ad</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.TemplateEngine.Abstractions" Version="6.0.100-preview.3.21161.1">
+    <Dependency Name="Microsoft.TemplateEngine.Abstractions" Version="6.0.100-preview.3.21165.1">
       <Uri>https://github.com/dotnet/templating</Uri>
-      <Sha>5067a9034f799eceb42846a62e5431a3ec8a267b</Sha>
+      <Sha>06aaf297687006acbe2c7045b2c2be9549a464ad</Sha>
       <Sha>31980633108a1bef00c798136fcd30a873c90fa3</Sha>
     </Dependency>
     <Dependency Name="Microsoft.TemplateEngine.Cli.Localization" Version="6.0.100-preview.3.21153.3">
       <Uri>https://github.com/dotnet/templating</Uri>
       <Sha>4bcc8cfb4753f6333a0a7e0f57ca795e02688ee0</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.TemplateEngine.Orchestrator.RunnableProjects" Version="6.0.100-preview.3.21161.1">
+    <Dependency Name="Microsoft.TemplateEngine.Orchestrator.RunnableProjects" Version="6.0.100-preview.3.21165.1">
       <Uri>https://github.com/dotnet/templating</Uri>
-      <Sha>5067a9034f799eceb42846a62e5431a3ec8a267b</Sha>
+      <Sha>06aaf297687006acbe2c7045b2c2be9549a464ad</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.TemplateEngine.Utils" Version="6.0.100-preview.3.21161.1">
+    <Dependency Name="Microsoft.TemplateEngine.Utils" Version="6.0.100-preview.3.21165.1">
       <Uri>https://github.com/dotnet/templating</Uri>
-      <Sha>5067a9034f799eceb42846a62e5431a3ec8a267b</Sha>
+      <Sha>06aaf297687006acbe2c7045b2c2be9549a464ad</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.TemplateSearch.Common" Version="6.0.100-preview.3.21161.1">
+    <Dependency Name="Microsoft.TemplateSearch.Common" Version="6.0.100-preview.3.21165.1">
       <Uri>https://github.com/dotnet/templating</Uri>
-      <Sha>5067a9034f799eceb42846a62e5431a3ec8a267b</Sha>
+      <Sha>06aaf297687006acbe2c7045b2c2be9549a464ad</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Common.ItemTemplates" Version="6.0.100-preview.3.21161.1">
+    <Dependency Name="Microsoft.DotNet.Common.ItemTemplates" Version="6.0.100-preview.3.21165.1">
       <Uri>https://github.com/dotnet/templating</Uri>
-      <Sha>5067a9034f799eceb42846a62e5431a3ec8a267b</Sha>
+      <Sha>06aaf297687006acbe2c7045b2c2be9549a464ad</Sha>
     </Dependency>
     <Dependency Name="Microsoft.NETCore.App.Ref" Version="6.0.0-preview.4.21174.3">
       <Uri>https://github.com/dotnet/runtime</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,34 +1,34 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.TemplateEngine.Cli" Version="6.0.100-preview.3.21165.1">
+    <Dependency Name="Microsoft.TemplateEngine.Cli" Version="6.0.100-preview.4.21174.1">
       <Uri>https://github.com/dotnet/templating</Uri>
-      <Sha>06aaf297687006acbe2c7045b2c2be9549a464ad</Sha>
+      <Sha>8296e24c54a48147a524ccbca0422b94508c91a2</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.TemplateEngine.Abstractions" Version="6.0.100-preview.3.21165.1">
+    <Dependency Name="Microsoft.TemplateEngine.Abstractions" Version="6.0.100-preview.4.21174.1">
       <Uri>https://github.com/dotnet/templating</Uri>
-      <Sha>06aaf297687006acbe2c7045b2c2be9549a464ad</Sha>
+      <Sha>8296e24c54a48147a524ccbca0422b94508c91a2</Sha>
       <Sha>31980633108a1bef00c798136fcd30a873c90fa3</Sha>
     </Dependency>
     <Dependency Name="Microsoft.TemplateEngine.Cli.Localization" Version="6.0.100-preview.3.21153.3">
       <Uri>https://github.com/dotnet/templating</Uri>
       <Sha>4bcc8cfb4753f6333a0a7e0f57ca795e02688ee0</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.TemplateEngine.Orchestrator.RunnableProjects" Version="6.0.100-preview.3.21165.1">
+    <Dependency Name="Microsoft.TemplateEngine.Orchestrator.RunnableProjects" Version="6.0.100-preview.4.21174.1">
       <Uri>https://github.com/dotnet/templating</Uri>
-      <Sha>06aaf297687006acbe2c7045b2c2be9549a464ad</Sha>
+      <Sha>8296e24c54a48147a524ccbca0422b94508c91a2</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.TemplateEngine.Utils" Version="6.0.100-preview.3.21165.1">
+    <Dependency Name="Microsoft.TemplateEngine.Utils" Version="6.0.100-preview.4.21174.1">
       <Uri>https://github.com/dotnet/templating</Uri>
-      <Sha>06aaf297687006acbe2c7045b2c2be9549a464ad</Sha>
+      <Sha>8296e24c54a48147a524ccbca0422b94508c91a2</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.TemplateSearch.Common" Version="6.0.100-preview.3.21165.1">
+    <Dependency Name="Microsoft.TemplateSearch.Common" Version="6.0.100-preview.4.21174.1">
       <Uri>https://github.com/dotnet/templating</Uri>
-      <Sha>06aaf297687006acbe2c7045b2c2be9549a464ad</Sha>
+      <Sha>8296e24c54a48147a524ccbca0422b94508c91a2</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Common.ItemTemplates" Version="6.0.100-preview.3.21165.1">
+    <Dependency Name="Microsoft.DotNet.Common.ItemTemplates" Version="6.0.100-preview.4.21174.1">
       <Uri>https://github.com/dotnet/templating</Uri>
-      <Sha>06aaf297687006acbe2c7045b2c2be9549a464ad</Sha>
+      <Sha>8296e24c54a48147a524ccbca0422b94508c91a2</Sha>
     </Dependency>
     <Dependency Name="Microsoft.NETCore.App.Ref" Version="6.0.0-preview.4.21174.3">
       <Uri>https://github.com/dotnet/runtime</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -101,12 +101,12 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/templating -->
-    <MicrosoftTemplateEngineCliPackageVersion>6.0.100-preview.3.21161.1</MicrosoftTemplateEngineCliPackageVersion>
-    <MicrosoftTemplateEngineAbstractionsPackageVersion>6.0.100-preview.3.21161.1</MicrosoftTemplateEngineAbstractionsPackageVersion>
+    <MicrosoftTemplateEngineCliPackageVersion>6.0.100-preview.3.21165.1</MicrosoftTemplateEngineCliPackageVersion>
+    <MicrosoftTemplateEngineAbstractionsPackageVersion>6.0.100-preview.3.21165.1</MicrosoftTemplateEngineAbstractionsPackageVersion>
     <MicrosoftTemplateEngineCliLocalizationPackageVersion>6.0.100-preview.3.21153.3</MicrosoftTemplateEngineCliLocalizationPackageVersion>
-    <MicrosoftTemplateEngineOrchestratorRunnableProjectsPackageVersion>6.0.100-preview.3.21161.1</MicrosoftTemplateEngineOrchestratorRunnableProjectsPackageVersion>
-    <MicrosoftTemplateEngineUtilsPackageVersion>6.0.100-preview.3.21161.1</MicrosoftTemplateEngineUtilsPackageVersion>
-    <MicrosoftTemplateSearchCommonPackageVersion>6.0.100-preview.3.21161.1</MicrosoftTemplateSearchCommonPackageVersion>
+    <MicrosoftTemplateEngineOrchestratorRunnableProjectsPackageVersion>6.0.100-preview.3.21165.1</MicrosoftTemplateEngineOrchestratorRunnableProjectsPackageVersion>
+    <MicrosoftTemplateEngineUtilsPackageVersion>6.0.100-preview.3.21165.1</MicrosoftTemplateEngineUtilsPackageVersion>
+    <MicrosoftTemplateSearchCommonPackageVersion>6.0.100-preview.3.21165.1</MicrosoftTemplateSearchCommonPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/Microsoft/visualfsharp -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -101,12 +101,12 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/templating -->
-    <MicrosoftTemplateEngineCliPackageVersion>6.0.100-preview.3.21165.1</MicrosoftTemplateEngineCliPackageVersion>
-    <MicrosoftTemplateEngineAbstractionsPackageVersion>6.0.100-preview.3.21165.1</MicrosoftTemplateEngineAbstractionsPackageVersion>
+    <MicrosoftTemplateEngineCliPackageVersion>6.0.100-preview.4.21174.1</MicrosoftTemplateEngineCliPackageVersion>
+    <MicrosoftTemplateEngineAbstractionsPackageVersion>6.0.100-preview.4.21174.1</MicrosoftTemplateEngineAbstractionsPackageVersion>
     <MicrosoftTemplateEngineCliLocalizationPackageVersion>6.0.100-preview.3.21153.3</MicrosoftTemplateEngineCliLocalizationPackageVersion>
-    <MicrosoftTemplateEngineOrchestratorRunnableProjectsPackageVersion>6.0.100-preview.3.21165.1</MicrosoftTemplateEngineOrchestratorRunnableProjectsPackageVersion>
-    <MicrosoftTemplateEngineUtilsPackageVersion>6.0.100-preview.3.21165.1</MicrosoftTemplateEngineUtilsPackageVersion>
-    <MicrosoftTemplateSearchCommonPackageVersion>6.0.100-preview.3.21165.1</MicrosoftTemplateSearchCommonPackageVersion>
+    <MicrosoftTemplateEngineOrchestratorRunnableProjectsPackageVersion>6.0.100-preview.4.21174.1</MicrosoftTemplateEngineOrchestratorRunnableProjectsPackageVersion>
+    <MicrosoftTemplateEngineUtilsPackageVersion>6.0.100-preview.4.21174.1</MicrosoftTemplateEngineUtilsPackageVersion>
+    <MicrosoftTemplateSearchCommonPackageVersion>6.0.100-preview.4.21174.1</MicrosoftTemplateSearchCommonPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/Microsoft/visualfsharp -->

--- a/src/Cli/dotnet/commands/dotnet-new/NewCommandShim.cs
+++ b/src/Cli/dotnet/commands/dotnet-new/NewCommandShim.cs
@@ -81,7 +81,7 @@ namespace Microsoft.DotNet.Tools.New
                 { "NetStandardImplicitPackageVersion", new FrameworkDependencyFile().GetNetStandardLibraryVersion() },
             };
 
-            return new DefaultTemplateEngineHost(HostIdentifier, "v" + Product.Version, CultureInfo.CurrentUICulture.Name, preferences, builtIns);
+            return new DefaultTemplateEngineHost(HostIdentifier, "v" + Product.Version, preferences, builtIns);
         }
 
         private static void FirstRun(IEngineEnvironmentSettings environmentSettings, IInstaller installer)


### PR DESCRIPTION
My theory is, failures on https://github.com/dotnet/sdk/pull/16441 are caused by broken main at time...