### PR TITLE
Add ETW start and stop events for file changes

### DIFF
--- a/src/BuiltInTools/dotnet-watch/HotReload/CompilationHandler.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/CompilationHandler.cs
@@ -64,18 +64,18 @@ namespace Microsoft.DotNet.Watcher.Tools
 
         public async ValueTask<bool> TryHandleFileChange(DotNetWatchContext context, FileItem file, CancellationToken cancellationToken)
         {
-            HotReladEventSource.Log.HotReloadStart(HotReladEventSource.StartType.CompilationHandler);
+            HotReloadEventSource.Log.HotReloadStart(HotReloadEventSource.StartType.CompilationHandler);
             if (!file.FilePath.EndsWith(".cs", StringComparison.Ordinal) &&
                 !file.FilePath.EndsWith(".razor", StringComparison.Ordinal) &&
                 !file.FilePath.EndsWith(".cshtml", StringComparison.Ordinal))
             {
-                HotReladEventSource.Log.HotReloadEnd(HotReladEventSource.StartType.CompilationHandler);
+                HotReloadEventSource.Log.HotReloadEnd(HotReloadEventSource.StartType.CompilationHandler);
                 return false;
             }
 
             if (!await EnsureSolutionInitializedAsync())
             {
-                HotReladEventSource.Log.HotReloadEnd(HotReladEventSource.StartType.CompilationHandler);
+                HotReloadEventSource.Log.HotReloadEnd(HotReloadEventSource.StartType.CompilationHandler);
                 return false;
             }
             Debug.Assert(_editAndContinue != null);
@@ -101,7 +101,7 @@ namespace Microsoft.DotNet.Watcher.Tools
             else
             {
                 _reporter.Verbose($"Could not find document with path {file.FilePath} in the workspace.");
-                HotReladEventSource.Log.HotReloadEnd(HotReladEventSource.StartType.CompilationHandler);
+                HotReloadEventSource.Log.HotReloadEnd(HotReloadEventSource.StartType.CompilationHandler);
                 return false;
             }
 
@@ -113,7 +113,7 @@ namespace Microsoft.DotNet.Watcher.Tools
                 _editAndContinue.EndEditSession();
 
                 await _deltaApplier.Apply(context, file.FilePath, default, cancellationToken);
-                HotReladEventSource.Log.HotReloadEnd(HotReladEventSource.StartType.CompilationHandler);
+                HotReloadEventSource.Log.HotReloadEnd(HotReloadEventSource.StartType.CompilationHandler);
                 return true;
             }
             else if (updates.Status == DotNetWatchManagedModuleUpdateStatus.Blocked)
@@ -139,13 +139,13 @@ namespace Microsoft.DotNet.Watcher.Tools
                     // We'll instead simply keep track of the updated solution.
                     _currentSolution = updatedSolution;
 
-                    HotReladEventSource.Log.HotReloadEnd(HotReladEventSource.StartType.CompilationHandler);
+                    HotReloadEventSource.Log.HotReloadEnd(HotReloadEventSource.StartType.CompilationHandler);
                     // Figure out how to recover from errors. Currently it seems unrecoverable.
                     return false;
                 }
 
                 _reporter.Verbose("Unable to apply update.");
-                HotReladEventSource.Log.HotReloadEnd(HotReladEventSource.StartType.CompilationHandler);
+                HotReloadEventSource.Log.HotReloadEnd(HotReloadEventSource.StartType.CompilationHandler);
                 return false;
             }
 
@@ -157,7 +157,7 @@ namespace Microsoft.DotNet.Watcher.Tools
             _currentSolution = updatedSolution;
 
             var applyState = await _deltaApplier.Apply(context, file.FilePath, updates, cancellationToken);
-            HotReladEventSource.Log.HotReloadEnd(HotReladEventSource.StartType.CompilationHandler);
+            HotReloadEventSource.Log.HotReloadEnd(HotReloadEventSource.StartType.CompilationHandler);
             return applyState;
         }
 

--- a/src/BuiltInTools/dotnet-watch/HotReload/CompilationHandler.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/CompilationHandler.cs
@@ -75,7 +75,7 @@ namespace Microsoft.DotNet.Watcher.Tools
             {
                 return false;
             }
-
+            
             Debug.Assert(_editAndContinue != null);
             Debug.Assert(_currentSolution != null);
             Debug.Assert(_deltaApplier != null);

--- a/src/BuiltInTools/dotnet-watch/HotReload/CompilationHandler.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/CompilationHandler.cs
@@ -64,18 +64,20 @@ namespace Microsoft.DotNet.Watcher.Tools
 
         public async ValueTask<bool> TryHandleFileChange(DotNetWatchContext context, FileItem file, CancellationToken cancellationToken)
         {
+            HotReladEventSource.Log.HotReloadStart(HotReladEventSource.StartType.CompilationHandler);
             if (!file.FilePath.EndsWith(".cs", StringComparison.Ordinal) &&
                 !file.FilePath.EndsWith(".razor", StringComparison.Ordinal) &&
                 !file.FilePath.EndsWith(".cshtml", StringComparison.Ordinal))
             {
+                HotReladEventSource.Log.HotReloadEnd(HotReladEventSource.StartType.CompilationHandler);
                 return false;
             }
 
             if (!await EnsureSolutionInitializedAsync())
             {
+                HotReladEventSource.Log.HotReloadEnd(HotReladEventSource.StartType.CompilationHandler);
                 return false;
             }
-            HotReladEventSource.Log.HotReloadStart(HotReladEventSource.StartType.CompilationHandler);
             Debug.Assert(_editAndContinue != null);
             Debug.Assert(_currentSolution != null);
             Debug.Assert(_deltaApplier != null);

--- a/src/BuiltInTools/dotnet-watch/HotReload/HotReload.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/HotReload.cs
@@ -29,10 +29,32 @@ namespace Microsoft.DotNet.Watcher.Tools
 
         public async ValueTask<bool> TryHandleFileChange(DotNetWatchContext context, FileItem file, CancellationToken cancellationToken)
         {
+<<<<<<< HEAD
             return
                 await _staticFileHandler.TryHandleFileChange(context, file, cancellationToken) ||
                 await _scopedCssFileHandler.TryHandleFileChange(context, file, cancellationToken) ||
                 await _compilationHandler.TryHandleFileChange(context, file, cancellationToken);
+=======
+            HotReladEventSource.Log.HotReloadStaticFileStart(file.FilePath);
+            bool staticFileHandlerSuccess = await _staticFileHandler.TryHandleFileChange(context, file, cancellationToken);
+            HotReladEventSource.Log.HotReloadStaticFileEnd(file.FilePath);
+
+            if (staticFileHandlerSuccess)
+            {
+                return true;
+            }
+
+            HotReladEventSource.Log.HotReloadCompilationStart(file.FilePath);
+            bool compilationFileHandlerSuccess = await _compilationHandler.TryHandleFileChange(context, file, cancellationToken);
+            HotReladEventSource.Log.HotReloadCompilationEnd(file.FilePath);
+
+            if (compilationFileHandlerSuccess) // This needs to be 6.0
+            {
+                return true;
+            }
+
+            return false;
+>>>>>>> 0b3df74f1... Add ETW start and stop events for file changes
         }
 
         public void Dispose()

--- a/src/BuiltInTools/dotnet-watch/HotReload/HotReload.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/HotReload.cs
@@ -29,11 +29,11 @@ namespace Microsoft.DotNet.Watcher.Tools
 
         public async ValueTask<bool> TryHandleFileChange(DotNetWatchContext context, FileItem file, CancellationToken cancellationToken)
         {
-            HotReladEventSource.Log.HotReloadStart(HotReladEventSource.StartType.Main);
+            HotReloadEventSource.Log.HotReloadStart(HotReloadEventSource.StartType.Main);
             var fileHandlerResult = await _staticFileHandler.TryHandleFileChange(context, file, cancellationToken) ||
                 await _scopedCssFileHandler.TryHandleFileChange(context, file, cancellationToken) ||
                 await _compilationHandler.TryHandleFileChange(context, file, cancellationToken);
-            HotReladEventSource.Log.HotReloadEnd(HotReladEventSource.StartType.Main);
+            HotReloadEventSource.Log.HotReloadEnd(HotReloadEventSource.StartType.Main);
             return fileHandlerResult;
         }
 

--- a/src/BuiltInTools/dotnet-watch/HotReload/HotReload.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/HotReload.cs
@@ -29,32 +29,12 @@ namespace Microsoft.DotNet.Watcher.Tools
 
         public async ValueTask<bool> TryHandleFileChange(DotNetWatchContext context, FileItem file, CancellationToken cancellationToken)
         {
-<<<<<<< HEAD
-            return
-                await _staticFileHandler.TryHandleFileChange(context, file, cancellationToken) ||
+            HotReladEventSource.Log.HotReloadStart(HotReladEventSource.StartType.Main);
+            var fileHandlerResult = await _staticFileHandler.TryHandleFileChange(context, file, cancellationToken) ||
                 await _scopedCssFileHandler.TryHandleFileChange(context, file, cancellationToken) ||
                 await _compilationHandler.TryHandleFileChange(context, file, cancellationToken);
-=======
-            HotReladEventSource.Log.HotReloadStaticFileStart(file.FilePath);
-            bool staticFileHandlerSuccess = await _staticFileHandler.TryHandleFileChange(context, file, cancellationToken);
-            HotReladEventSource.Log.HotReloadStaticFileEnd(file.FilePath);
-
-            if (staticFileHandlerSuccess)
-            {
-                return true;
-            }
-
-            HotReladEventSource.Log.HotReloadCompilationStart(file.FilePath);
-            bool compilationFileHandlerSuccess = await _compilationHandler.TryHandleFileChange(context, file, cancellationToken);
-            HotReladEventSource.Log.HotReloadCompilationEnd(file.FilePath);
-
-            if (compilationFileHandlerSuccess) // This needs to be 6.0
-            {
-                return true;
-            }
-
-            return false;
->>>>>>> 0b3df74f1... Add ETW start and stop events for file changes
+            HotReladEventSource.Log.HotReloadEnd(HotReladEventSource.StartType.Main);
+            return fileHandlerResult;
         }
 
         public void Dispose()

--- a/src/BuiltInTools/dotnet-watch/HotReload/HotReloadEventSource.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/HotReloadEventSource.cs
@@ -6,22 +6,25 @@ namespace Microsoft.DotNet.Watcher.Tools
     [EventSource(Name = "HotReload")]
     class HotReladEventSource : EventSource
     {
+
+        public static enum StartType
+        {
+            Main,
+            StaticHandler,
+            CompilationHandler,
+            ScopedCssHandler
+        }
+
         public class Keywords
         {
             public const EventKeywords Perf = (EventKeywords)1;
         }
 
         [Event(1, Message = "Hot reload started for {0}", Level = EventLevel.Informational, Keywords = Keywords.Perf)]
-        public void HotReloadStaticFileStart(string fileChanged) { WriteEvent(1, fileChanged); }
+        public void HotReloadStart(StartType s) { WriteEvent(1, s); }
 
         [Event(2, Message = "Hot reload finished for {0}", Level = EventLevel.Informational, Keywords = Keywords.Perf)]
-        public void HotReloadStaticFileEnd(string fileChanged) { WriteEvent(2, fileChanged); }
-
-        [Event(3, Message = "Hot reload started for {0}", Level = EventLevel.Informational, Keywords = Keywords.Perf)]
-        public void HotReloadCompilationStart(string fileChanged) { WriteEvent(3, fileChanged); }
-
-        [Event(4, Message = "Hot reload finished for {0}", Level = EventLevel.Informational, Keywords = Keywords.Perf)]
-        public void HotReloadCompilationEnd(string fileChanged) { WriteEvent(4, fileChanged); }
+        public void HotReloadEnd(StartType s) { WriteEvent(2, s); }
 
         public static HotReladEventSource Log = new HotReladEventSource();
     }

--- a/src/BuiltInTools/dotnet-watch/HotReload/HotReloadEventSource.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/HotReloadEventSource.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Diagnostics.Tracing;
+
+namespace Microsoft.DotNet.Watcher.Tools
+{
+    [EventSource(Name = "HotReload")]
+    class HotReladEventSource : EventSource
+    {
+        public class Keywords
+        {
+            public const EventKeywords Perf = (EventKeywords)1;
+        }
+
+        [Event(1, Message = "Hot reload started for {0}", Level = EventLevel.Informational, Keywords = Keywords.Perf)]
+        public void HotReloadStaticFileStart(string fileChanged) { WriteEvent(1, fileChanged); }
+
+        [Event(2, Message = "Hot reload finished for {0}", Level = EventLevel.Informational, Keywords = Keywords.Perf)]
+        public void HotReloadStaticFileEnd(string fileChanged) { WriteEvent(2, fileChanged); }
+
+        [Event(3, Message = "Hot reload started for {0}", Level = EventLevel.Informational, Keywords = Keywords.Perf)]
+        public void HotReloadCompilationStart(string fileChanged) { WriteEvent(3, fileChanged); }
+
+        [Event(4, Message = "Hot reload finished for {0}", Level = EventLevel.Informational, Keywords = Keywords.Perf)]
+        public void HotReloadCompilationEnd(string fileChanged) { WriteEvent(4, fileChanged); }
+
+        public static HotReladEventSource Log = new HotReladEventSource();
+    }
+}

--- a/src/BuiltInTools/dotnet-watch/HotReload/HotReloadEventSource.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/HotReloadEventSource.cs
@@ -24,10 +24,10 @@ namespace Microsoft.DotNet.Watcher.Tools
         }
 
         [Event(1, Message = "Hot reload started for {0}", Level = EventLevel.Informational, Keywords = Keywords.Perf)]
-        public void HotReloadStart(StartType s) { WriteEvent(1, s); }
+        public void HotReloadStart(StartType handlerType) { WriteEvent(1, handlerType); }
 
         [Event(2, Message = "Hot reload finished for {0}", Level = EventLevel.Informational, Keywords = Keywords.Perf)]
-        public void HotReloadEnd(StartType s) { WriteEvent(2, s); }
+        public void HotReloadEnd(StartType handlerType) { WriteEvent(2, handlerType); }
 
         public static readonly HotReloadEventSource Log = new HotReloadEventSource();
     }

--- a/src/BuiltInTools/dotnet-watch/HotReload/HotReloadEventSource.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/HotReloadEventSource.cs
@@ -4,7 +4,7 @@ using System.Diagnostics.Tracing;
 namespace Microsoft.DotNet.Watcher.Tools
 {
     [EventSource(Name = "HotReload")]
-    class HotReladEventSource : EventSource
+    class HotReloadEventSource : EventSource
     {
 
         public static enum StartType
@@ -26,6 +26,6 @@ namespace Microsoft.DotNet.Watcher.Tools
         [Event(2, Message = "Hot reload finished for {0}", Level = EventLevel.Informational, Keywords = Keywords.Perf)]
         public void HotReloadEnd(StartType s) { WriteEvent(2, s); }
 
-        public static HotReladEventSource Log = new HotReladEventSource();
+        public static HotReloadEventSource Log = new HotReloadEventSource();
     }
 }

--- a/src/BuiltInTools/dotnet-watch/HotReload/HotReloadEventSource.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/HotReloadEventSource.cs
@@ -7,7 +7,7 @@ namespace Microsoft.DotNet.Watcher.Tools
     class HotReloadEventSource : EventSource
     {
 
-        public static enum StartType
+        public enum StartType
         {
             Main,
             StaticHandler,

--- a/src/BuiltInTools/dotnet-watch/HotReload/HotReloadEventSource.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/HotReloadEventSource.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Diagnostics.Tracing;
 
@@ -26,6 +29,6 @@ namespace Microsoft.DotNet.Watcher.Tools
         [Event(2, Message = "Hot reload finished for {0}", Level = EventLevel.Informational, Keywords = Keywords.Perf)]
         public void HotReloadEnd(StartType s) { WriteEvent(2, s); }
 
-        public static HotReloadEventSource Log = new HotReloadEventSource();
+        public static readonly HotReloadEventSource Log = new HotReloadEventSource();
     }
 }

--- a/src/BuiltInTools/dotnet-watch/HotReload/ScopedCssFileHandler.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/ScopedCssFileHandler.cs
@@ -24,18 +24,22 @@ namespace Microsoft.DotNet.Watcher.Tools
 
         public async ValueTask<bool> TryHandleFileChange(DotNetWatchContext context, FileItem file, CancellationToken cancellationToken)
         {
+            HotReladEventSource.Log.HotReloadStart(HotReladEventSource.StartType.ScopedCssHandler);
             if (!file.FilePath.EndsWith(".razor.css", StringComparison.Ordinal) &&
                 !file.FilePath.EndsWith(".cshtml.css", StringComparison.Ordinal))
             {
+                HotReladEventSource.Log.HotReloadEnd(HotReladEventSource.StartType.ScopedCssHandler);
                 return default;
             }
 
             _reporter.Verbose($"Handling file change event for scoped css file {file.FilePath}.");
             if (!await RebuildScopedCss(file.ProjectPath, cancellationToken))
             {
+                HotReladEventSource.Log.HotReloadEnd(HotReladEventSource.StartType.ScopedCssHandler);
                 return false;
             }
             await HandleBrowserRefresh(context.BrowserRefreshServer, file, cancellationToken);
+            HotReladEventSource.Log.HotReloadEnd(HotReladEventSource.StartType.ScopedCssHandler);
             return true;
         }
 

--- a/src/BuiltInTools/dotnet-watch/HotReload/ScopedCssFileHandler.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/ScopedCssFileHandler.cs
@@ -24,22 +24,22 @@ namespace Microsoft.DotNet.Watcher.Tools
 
         public async ValueTask<bool> TryHandleFileChange(DotNetWatchContext context, FileItem file, CancellationToken cancellationToken)
         {
-            HotReladEventSource.Log.HotReloadStart(HotReladEventSource.StartType.ScopedCssHandler);
+            HotReloadEventSource.Log.HotReloadStart(HotReloadEventSource.StartType.ScopedCssHandler);
             if (!file.FilePath.EndsWith(".razor.css", StringComparison.Ordinal) &&
                 !file.FilePath.EndsWith(".cshtml.css", StringComparison.Ordinal))
             {
-                HotReladEventSource.Log.HotReloadEnd(HotReladEventSource.StartType.ScopedCssHandler);
+                HotReloadEventSource.Log.HotReloadEnd(HotReloadEventSource.StartType.ScopedCssHandler);
                 return default;
             }
 
             _reporter.Verbose($"Handling file change event for scoped css file {file.FilePath}.");
             if (!await RebuildScopedCss(file.ProjectPath, cancellationToken))
             {
-                HotReladEventSource.Log.HotReloadEnd(HotReladEventSource.StartType.ScopedCssHandler);
+                HotReloadEventSource.Log.HotReloadEnd(HotReloadEventSource.StartType.ScopedCssHandler);
                 return false;
             }
             await HandleBrowserRefresh(context.BrowserRefreshServer, file, cancellationToken);
-            HotReladEventSource.Log.HotReloadEnd(HotReladEventSource.StartType.ScopedCssHandler);
+            HotReloadEventSource.Log.HotReloadEnd(HotReloadEventSource.StartType.ScopedCssHandler);
             return true;
         }
 

--- a/src/BuiltInTools/dotnet-watch/HotReload/StaticFileHandler.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/StaticFileHandler.cs
@@ -24,11 +24,12 @@ namespace Microsoft.DotNet.Watcher.Tools
 
         public async ValueTask<bool> TryHandleFileChange(DotNetWatchContext context, FileItem file, CancellationToken cancellationToken)
         {
+            HotReladEventSource.Log.HotReloadStart(HotReladEventSource.StartType.StaticHandler);
             if (!file.IsStaticFile || context.BrowserRefreshServer is null)
             {
+                HotReladEventSource.Log.HotReloadEnd(HotReladEventSource.StartType.StaticHandler);
                 return false;
             }
-            HotReladEventSource.Log.HotReloadStart(HotReladEventSource.StartType.StaticHandler);
             _reporter.Verbose($"Handling file change event for static content {file.FilePath}.");
             await HandleBrowserRefresh(context.BrowserRefreshServer, file, cancellationToken);
             HotReladEventSource.Log.HotReloadEnd(HotReladEventSource.StartType.StaticHandler);

--- a/src/BuiltInTools/dotnet-watch/HotReload/StaticFileHandler.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/StaticFileHandler.cs
@@ -28,10 +28,10 @@ namespace Microsoft.DotNet.Watcher.Tools
             {
                 return false;
             }
-            // Event for start to handle static file change
+            HotReladEventSource.Log.HotReloadStart(HotReladEventSource.StartType.StaticHandler);
             _reporter.Verbose($"Handling file change event for static content {file.FilePath}.");
             await HandleBrowserRefresh(context.BrowserRefreshServer, file, cancellationToken);
-            // Event for stop to handle static file change
+            HotReladEventSource.Log.HotReloadEnd(HotReladEventSource.StartType.StaticHandler);
             return true;
         }
 

--- a/src/BuiltInTools/dotnet-watch/HotReload/StaticFileHandler.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/StaticFileHandler.cs
@@ -24,15 +24,15 @@ namespace Microsoft.DotNet.Watcher.Tools
 
         public async ValueTask<bool> TryHandleFileChange(DotNetWatchContext context, FileItem file, CancellationToken cancellationToken)
         {
-            HotReladEventSource.Log.HotReloadStart(HotReladEventSource.StartType.StaticHandler);
+            HotReloadEventSource.Log.HotReloadStart(HotReloadEventSource.StartType.StaticHandler);
             if (!file.IsStaticFile || context.BrowserRefreshServer is null)
             {
-                HotReladEventSource.Log.HotReloadEnd(HotReladEventSource.StartType.StaticHandler);
+                HotReloadEventSource.Log.HotReloadEnd(HotReloadEventSource.StartType.StaticHandler);
                 return false;
             }
             _reporter.Verbose($"Handling file change event for static content {file.FilePath}.");
             await HandleBrowserRefresh(context.BrowserRefreshServer, file, cancellationToken);
-            HotReladEventSource.Log.HotReloadEnd(HotReladEventSource.StartType.StaticHandler);
+            HotReloadEventSource.Log.HotReloadEnd(HotReloadEventSource.StartType.StaticHandler);
             return true;
         }
 

--- a/src/BuiltInTools/dotnet-watch/HotReload/StaticFileHandler.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/StaticFileHandler.cs
@@ -28,9 +28,10 @@ namespace Microsoft.DotNet.Watcher.Tools
             {
                 return false;
             }
-
+            // Event for start to handle static file change
             _reporter.Verbose($"Handling file change event for static content {file.FilePath}.");
             await HandleBrowserRefresh(context.BrowserRefreshServer, file, cancellationToken);
+            // Event for stop to handle static file change
             return true;
         }
 


### PR DESCRIPTION
This adds etw events for start and end on the TryChange methods. This is for both static and compilation changes.