### PR TITLE
Remove delay in dotnet-watch before reading files

### DIFF
--- a/src/BuiltInTools/dotnet-watch/HotReload/CompilationHandler.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/CompilationHandler.cs
@@ -201,10 +201,6 @@ namespace Microsoft.DotNet.Watcher.Tools
 
         private async ValueTask<SourceText> GetSourceTextAsync(string filePath)
         {
-            // FSW events sometimes appear before the file has been completely written to disk. Provide a small delay before we read the file contents
-            // to ensure we are not contending with partial writes or write locks.
-            await Task.Delay(20);
-
             for (var attemptIndex = 0; attemptIndex < 10; attemptIndex++)
             {
                 try


### PR DESCRIPTION
This delay was previously required because we would update the MSBuildWorkspace
which would then write to the disk in the background causing weird race conditions.
The workspace is now never updated and consequently we do not need to worry about
reading the file immediately after the file change event is triggered.