### PR TITLE
Eliminate build process hop by loading MSBuild.dll into CLI process

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -98,6 +98,7 @@
     <MicrosoftBuildVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildVersion>
     <MicrosoftBuildFrameworkVersion>$(MicrosoftBuildFrameworkPackageVersion)</MicrosoftBuildFrameworkVersion>
     <MicrosoftBuildUtilitiesCoreVersion>$(MicrosoftBuildUtilitiesCorePackageVersion)</MicrosoftBuildUtilitiesCoreVersion>
+    <MicrosoftBuildTasksCoreVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildTasksCoreVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/templating -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -95,10 +95,11 @@
     <MicrosoftBuildRuntimePackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildRuntimePackageVersion>
     <MicrosoftBuildLocalizationPackageVersion>16.10.0-preview-21175-01</MicrosoftBuildLocalizationPackageVersion>
     <MicrosoftBuildUtilitiesCorePackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildUtilitiesCorePackageVersion>
+    <MicrosoftBuildTasksCorePackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildTasksCorePackageVersion>
     <MicrosoftBuildVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildVersion>
     <MicrosoftBuildFrameworkVersion>$(MicrosoftBuildFrameworkPackageVersion)</MicrosoftBuildFrameworkVersion>
     <MicrosoftBuildUtilitiesCoreVersion>$(MicrosoftBuildUtilitiesCorePackageVersion)</MicrosoftBuildUtilitiesCoreVersion>
-    <MicrosoftBuildTasksCoreVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildTasksCoreVersion>
+    <MicrosoftBuildTasksCoreVersion>$(MicrosoftBuildTasksCorePackageVersion)</MicrosoftBuildTasksCoreVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/templating -->

--- a/src/Cli/Microsoft.DotNet.Cli.Utils/MSBuildForwardingAppWithoutLogging.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/MSBuildForwardingAppWithoutLogging.cs
@@ -107,7 +107,18 @@ namespace Microsoft.DotNet.Cli.Utils
                 Assembly assembly = Assembly.LoadFrom(_msbuildPath);
                 Type type = assembly.GetType(MSBuildAppClassName);
                 MethodInfo mi = type.GetMethod("Main");
-                return (int)mi.Invoke(null, new object[] { arguments });
+
+                try
+                {
+                    return (int)mi.Invoke(null, new object[] { arguments });
+                }
+                catch (TargetInvocationException targetException)
+                {
+                    Console.Error.Write("Unhandled exception: ");
+                    Console.Error.WriteLine(targetException.InnerException.ToString());
+
+                    return unchecked((int)0xe0434352); // EXCEPTION_COMPLUS
+                }
             }
             finally
             {

--- a/src/Cli/Microsoft.DotNet.Cli.Utils/MSBuildForwardingAppWithoutLogging.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/MSBuildForwardingAppWithoutLogging.cs
@@ -54,11 +54,16 @@ namespace Microsoft.DotNet.Cli.Utils
             // If DOTNET_CLI_RUN_MSBUILD_OUTOFPROC is set or we're asked to execute a non-default binary, call MSBuild out-of-proc.
             if (AlwaysExecuteMSBuildOutOfProc || !string.Equals(MSBuildPath, defaultMSBuildPath, StringComparison.OrdinalIgnoreCase))
             {
-                _forwardingApp = new ForwardingAppImplementation(
-                    MSBuildPath,
-                    _msbuildRequiredParameters.Concat(argsToForward.Select(Escape)),
-                    environmentVariables: _msbuildRequiredEnvironmentVariables);
+                InitializeForOutOfProcForwarding();
             }
+        }
+
+        private void InitializeForOutOfProcForwarding()
+        {
+            _forwardingApp = new ForwardingAppImplementation(
+                MSBuildPath,
+                _msbuildRequiredParameters.Concat(_argsToForward.Select(Escape)),
+                environmentVariables: _msbuildRequiredEnvironmentVariables);
         }
 
         public virtual ProcessStartInfo GetProcessStartInfo()
@@ -88,10 +93,7 @@ namespace Microsoft.DotNet.Cli.Utils
                 // Unlike ProcessStartInfo.EnvironmentVariables, Environment.SetEnvironmentVariable can't set a variable
                 // to an empty value, so we just fall back to calling MSBuild out-of-proc if we encounter this case.
                 // https://github.com/dotnet/runtime/issues/50554
-                _forwardingApp = new ForwardingAppImplementation(
-                    MSBuildPath,
-                    _msbuildRequiredParameters.Concat(_argsToForward.Select(Escape)),
-                    environmentVariables: _msbuildRequiredEnvironmentVariables);
+                InitializeForOutOfProcForwarding();
             }
         }
 

--- a/src/Cli/Microsoft.DotNet.Cli.Utils/MSBuildForwardingAppWithoutLogging.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/MSBuildForwardingAppWithoutLogging.cs
@@ -65,7 +65,7 @@ namespace Microsoft.DotNet.Cli.Utils
 
         public string[] GetAllArgumentsUnescaped()
         {
-            return _msbuildRequiredParameters.Concat(_argsToForward).ToArray();
+            return _msbuildRequiredParameters.Concat(_argsToForward.Select(Escape)).ToArray();
         }
 
         public void EnvironmentVariable(string name, string value)

--- a/src/Cli/Microsoft.DotNet.Cli.Utils/MSBuildForwardingAppWithoutLogging.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/MSBuildForwardingAppWithoutLogging.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Text;
 
@@ -116,18 +115,14 @@ namespace Microsoft.DotNet.Cli.Utils
                     Environment.SetEnvironmentVariable(kvp.Key, kvp.Value);
                 }
 
-                Assembly assembly = Assembly.LoadFrom(_msbuildPath);
-                Type type = assembly.GetType(MSBuildAppClassName);
-                MethodInfo mi = type.GetMethod("Main");
-
                 try
                 {
-                    return (int)mi.Invoke(null, new object[] { arguments });
+                    return Microsoft.Build.CommandLine.MSBuildApp.Main(arguments);
                 }
-                catch (TargetInvocationException targetException)
+                catch (Exception exception)
                 {
                     Console.Error.Write("Unhandled exception: ");
-                    Console.Error.WriteLine(targetException.InnerException.ToString());
+                    Console.Error.WriteLine(exception.ToString());
 
                     return unchecked((int)0xe0434352); // EXCEPTION_COMPLUS
                 }

--- a/src/Cli/Microsoft.DotNet.Cli.Utils/MSBuildForwardingAppWithoutLogging.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/MSBuildForwardingAppWithoutLogging.cs
@@ -67,7 +67,7 @@ namespace Microsoft.DotNet.Cli.Utils
             return _forwardingApp.GetProcessStartInfo();
         }
 
-        public string[] GetAllArgumentsUnescaped()
+        public string[] GetAllArguments()
         {
             return _msbuildRequiredParameters.Concat(_argsToForward.Select(Escape)).ToArray();
         }
@@ -103,7 +103,7 @@ namespace Microsoft.DotNet.Cli.Utils
             }
             else
             {
-                return ExecuteInProc(GetAllArgumentsUnescaped());
+                return ExecuteInProc(GetAllArguments());
             }
         }
 

--- a/src/Cli/Microsoft.DotNet.Cli.Utils/MSBuildForwardingAppWithoutLogging.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/MSBuildForwardingAppWithoutLogging.cs
@@ -52,7 +52,7 @@ namespace Microsoft.DotNet.Cli.Utils
             MSBuildPath = msbuildPath ?? defaultMSBuildPath;
 
             // If DOTNET_CLI_RUN_MSBUILD_OUTOFPROC is set or we're asked to execute a non-default binary, call MSBuild out-of-proc.
-            if (AlwaysExecuteMSBuildOutOfProc || string.Compare(MSBuildPath, defaultMSBuildPath, StringComparison.OrdinalIgnoreCase) != 0)
+            if (AlwaysExecuteMSBuildOutOfProc || !string.Equals(MSBuildPath, defaultMSBuildPath, StringComparison.OrdinalIgnoreCase))
             {
                 _forwardingApp = new ForwardingAppImplementation(
                     MSBuildPath,

--- a/src/Cli/Microsoft.DotNet.Cli.Utils/MSBuildForwardingAppWithoutLogging.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/MSBuildForwardingAppWithoutLogging.cs
@@ -13,7 +13,7 @@ namespace Microsoft.DotNet.Cli.Utils
 {
     internal class MSBuildForwardingAppWithoutLogging
     {
-        private static readonly bool AlwaysExecuteMSBuildOutOfProc = Env.GetEnvironmentVariableAsBool("DOTNET_CLI_EXEC_MSBUILD");
+        private static readonly bool AlwaysExecuteMSBuildOutOfProc = Env.GetEnvironmentVariableAsBool("DOTNET_CLI_RUN_MSBUILD_OUTOFPROC");
 
         private const string MSBuildExeName = "MSBuild.dll";
 
@@ -51,7 +51,7 @@ namespace Microsoft.DotNet.Cli.Utils
             _argsToForward = argsToForward;
             MSBuildPath = msbuildPath ?? defaultMSBuildPath;
 
-            // If DOTNET_CLI_EXEC_MSBUILD is set or we're asked to execute a non-default binary, call MSBuild out-of-proc.
+            // If DOTNET_CLI_RUN_MSBUILD_OUTOFPROC is set or we're asked to execute a non-default binary, call MSBuild out-of-proc.
             if (AlwaysExecuteMSBuildOutOfProc || string.Compare(MSBuildPath, defaultMSBuildPath, StringComparison.OrdinalIgnoreCase) != 0)
             {
                 _forwardingApp = new ForwardingAppImplementation(

--- a/src/Cli/Microsoft.DotNet.Cli.Utils/MSBuildForwardingAppWithoutLogging.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/MSBuildForwardingAppWithoutLogging.cs
@@ -68,7 +68,7 @@ namespace Microsoft.DotNet.Cli.Utils
                 environmentVariables: _msbuildRequiredEnvironmentVariables);
         }
 
-        public virtual ProcessStartInfo GetProcessStartInfo()
+        public ProcessStartInfo GetProcessStartInfo()
         {
             Debug.Assert(_forwardingApp != null, "Can't get ProcessStartInfo when not executing out-of-proc");
             return _forwardingApp.GetProcessStartInfo();

--- a/src/Cli/Microsoft.DotNet.Cli.Utils/MSBuildForwardingAppWithoutLogging.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/MSBuildForwardingAppWithoutLogging.cs
@@ -14,7 +14,7 @@ namespace Microsoft.DotNet.Cli.Utils
 {
     internal class MSBuildForwardingAppWithoutLogging
     {
-        internal static readonly bool executeMSBuildOutOfProc = Env.GetEnvironmentVariableAsBool("DOTNET_CLI_EXEC_MSBUILD");
+        internal static bool executeMSBuildOutOfProc = Env.GetEnvironmentVariableAsBool("DOTNET_CLI_EXEC_MSBUILD");
 
         private const string MSBuildAppClassName = "Microsoft.Build.CommandLine.MSBuildApp";
 

--- a/src/Cli/Microsoft.DotNet.Cli.Utils/MSBuildForwardingAppWithoutLogging.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/MSBuildForwardingAppWithoutLogging.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if NET
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -189,3 +191,5 @@ namespace Microsoft.DotNet.Cli.Utils
         }
     }
 }
+
+#endif

--- a/src/Cli/Microsoft.DotNet.Cli.Utils/Microsoft.DotNet.Cli.Utils.csproj
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/Microsoft.DotNet.Cli.Utils.csproj
@@ -44,8 +44,4 @@
     <PackageReference Include="System.CommandLine" Version="$(SystemCommandLineVersion)" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Compile Remove="MSBuildForwardingAppWithoutLogging.cs" Condition="'$(TargetFramework)' != '$(SdkTargetFramework)'" />
-  </ItemGroup>
-
 </Project>

--- a/src/Cli/Microsoft.DotNet.Cli.Utils/Microsoft.DotNet.Cli.Utils.csproj
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/Microsoft.DotNet.Cli.Utils.csproj
@@ -15,6 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Build.Runtime" Version="$(MicrosoftBuildRuntimePackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="$(MicrosoftExtensionsDependencyModelPackageVersion)" />
     <PackageReference Include="NuGet.Versioning" Version="$(NuGetVersioningPackageVersion)" />
     <PackageReference Include="NuGet.Packaging" Version="$(NuGetPackagingPackageVersion)" />

--- a/src/Cli/Microsoft.DotNet.Cli.Utils/Microsoft.DotNet.Cli.Utils.csproj
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/Microsoft.DotNet.Cli.Utils.csproj
@@ -14,6 +14,16 @@
     <EmbeddedResource Update="**\*.resx" GenerateSource="true" />
   </ItemGroup>
 
+  <Target Name="VerifyMSBuildDependency" BeforeTargets="ResolveAssemblyReferences" Condition="'$(TargetFramework)' == '$(SdkTargetFramework)'">
+    <PropertyGroup>
+      <MSBuildPathInPackage>$(PkgMicrosoft_Build_Runtime)\contentFiles\any\net5.0\MSBuild.dll</MSBuildPathInPackage>
+    </PropertyGroup>
+    <Error Condition="!Exists('$(MSBuildPathInPackage)')" Text="Something moved around in Microsoft.Build.Runtime, adjust code here accordingly." />
+    <ItemGroup>
+      <Reference Include="$(MSBuildPathInPackage)" />
+    </ItemGroup>
+  </Target>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.Build.Runtime"
         ExcludeAssets="all"
@@ -32,9 +42,6 @@
     <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildPackageVersion)" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildUtilitiesCorePackageVersion)" />
     <PackageReference Include="System.CommandLine" Version="$(SystemCommandLineVersion)" />
-
-    <Reference Include="$(PkgMicrosoft_Build_Runtime)\contentFiles\any\net5.0\MSBuild.dll"
-        Condition="'$(TargetFramework)' == '$(SdkTargetFramework)'" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Cli/Microsoft.DotNet.Cli.Utils/Microsoft.DotNet.Cli.Utils.csproj
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/Microsoft.DotNet.Cli.Utils.csproj
@@ -15,7 +15,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build.Runtime" Version="$(MicrosoftBuildRuntimePackageVersion)" />
+    <PackageReference Include="Microsoft.Build.Runtime"
+        Version="$(MicrosoftBuildRuntimePackageVersion)"
+        Condition="'$(TargetFramework)' == '$(SdkTargetFramework)'"
+        GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="$(MicrosoftExtensionsDependencyModelPackageVersion)" />
     <PackageReference Include="NuGet.Versioning" Version="$(NuGetVersioningPackageVersion)" />
     <PackageReference Include="NuGet.Packaging" Version="$(NuGetPackagingPackageVersion)" />
@@ -28,6 +31,14 @@
     <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildPackageVersion)" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildUtilitiesCorePackageVersion)" />
     <PackageReference Include="System.CommandLine" Version="$(SystemCommandLineVersion)" />
+
+    <Reference Include="$(PkgMicrosoft_Build_Runtime)\contentFiles\any\net5.0\ref\MSBuild.dll"
+        Condition="'$(TargetFramework)' == '$(SdkTargetFramework)'"
+        Private="True" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="MSBuildForwardingAppWithoutLogging.cs" Condition="'$(TargetFramework)' != '$(SdkTargetFramework)'" />
   </ItemGroup>
 
 </Project>

--- a/src/Cli/Microsoft.DotNet.Cli.Utils/Microsoft.DotNet.Cli.Utils.csproj
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/Microsoft.DotNet.Cli.Utils.csproj
@@ -16,6 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Build.Runtime"
+        ExcludeAssets="all"
         Version="$(MicrosoftBuildRuntimePackageVersion)"
         Condition="'$(TargetFramework)' == '$(SdkTargetFramework)'"
         GeneratePathProperty="true" />
@@ -32,9 +33,8 @@
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildUtilitiesCorePackageVersion)" />
     <PackageReference Include="System.CommandLine" Version="$(SystemCommandLineVersion)" />
 
-    <Reference Include="$(PkgMicrosoft_Build_Runtime)\contentFiles\any\net5.0\ref\MSBuild.dll"
-        Condition="'$(TargetFramework)' == '$(SdkTargetFramework)'"
-        Private="True" />
+    <Reference Include="$(PkgMicrosoft_Build_Runtime)\contentFiles\any\net5.0\MSBuild.dll"
+        Condition="'$(TargetFramework)' == '$(SdkTargetFramework)'" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Cli/dotnet/CommandFactory/CommandResolution/ProjectToolsCommandResolver.cs
+++ b/src/Cli/dotnet/CommandFactory/CommandResolution/ProjectToolsCommandResolver.cs
@@ -404,7 +404,7 @@ namespace Microsoft.DotNet.CommandFactory
             string stdErr;
 
             var forwardingAppWithoutLogging = new MSBuildForwardingAppWithoutLogging(args, msBuildExePath);
-            if (MSBuildForwardingAppWithoutLogging.executeMSBuildOutOfProc)
+            if (forwardingAppWithoutLogging.ExecuteMSBuildOutOfProc)
             {
                 result = forwardingAppWithoutLogging
                     .GetProcessStartInfo()

--- a/src/Cli/dotnet/CommandFactory/CommandResolution/ProjectToolsCommandResolver.cs
+++ b/src/Cli/dotnet/CommandFactory/CommandResolution/ProjectToolsCommandResolver.cs
@@ -412,6 +412,7 @@ namespace Microsoft.DotNet.CommandFactory
             }
             else
             {
+                // Execute and capture output of MSBuild running in-process.
                 var outWriter = new StringWriter();
                 var errWriter = new StringWriter();
                 var savedOutWriter = Console.Out;
@@ -422,12 +423,12 @@ namespace Microsoft.DotNet.CommandFactory
                     Console.SetError(errWriter);
 
                     result = forwardingAppWithoutLogging.Execute();
+
+                    stdOut = outWriter.ToString();
+                    stdErr = errWriter.ToString();
                 }
                 finally
                 {
-                    stdOut = outWriter.ToString();
-                    stdErr = errWriter.ToString();
-
                     Console.SetOut(savedOutWriter);
                     Console.SetError(savedErrWriter);
                 }

--- a/src/Cli/dotnet/PerformanceLogEventSource.cs
+++ b/src/Cli/dotnet/PerformanceLogEventSource.cs
@@ -264,11 +264,11 @@ namespace Microsoft.DotNet.Cli
         }
 
         [NonEvent]
-        internal void LogMSBuildStart(ProcessStartInfo startInfo)
+        internal void LogMSBuildStart(string fileName, string arguments)
         {
             if (IsEnabled())
             {
-                MSBuildStart($"{startInfo.FileName} {startInfo.Arguments}");
+                MSBuildStart($"{fileName} {arguments}");
             }
         }
 

--- a/src/Cli/dotnet/commands/dotnet-msbuild/MSBuildForwardingApp.cs
+++ b/src/Cli/dotnet/commands/dotnet-msbuild/MSBuildForwardingApp.cs
@@ -69,6 +69,12 @@ namespace Microsoft.DotNet.Tools.MSBuild
             return _forwardingAppWithoutLogging.GetProcessStartInfo();
         }
 
+        public string GetConcatenatedArguments()
+        {
+            var argumentsUnescaped = _forwardingAppWithoutLogging.GetAllArgumentsUnescaped();
+            return Cli.Utils.ArgumentEscaper.EscapeAndConcatenateArgArrayForProcessStart(argumentsUnescaped);
+        }
+
         public virtual int Execute()
         {
             int exitCode;

--- a/src/Cli/dotnet/commands/dotnet-msbuild/MSBuildForwardingApp.cs
+++ b/src/Cli/dotnet/commands/dotnet-msbuild/MSBuildForwardingApp.cs
@@ -71,7 +71,7 @@ namespace Microsoft.DotNet.Tools.MSBuild
 
         public string GetConcatenatedArguments()
         {
-            var argumentsUnescaped = _forwardingAppWithoutLogging.GetAllArgumentsUnescaped();
+            var argumentsUnescaped = _forwardingAppWithoutLogging.GetAllArguments();
             return Cli.Utils.ArgumentEscaper.EscapeAndConcatenateArgArrayForProcessStart(argumentsUnescaped);
         }
 
@@ -92,7 +92,7 @@ namespace Microsoft.DotNet.Tools.MSBuild
             }
             else
             {
-                string[] arguments = _forwardingAppWithoutLogging.GetAllArgumentsUnescaped();
+                string[] arguments = _forwardingAppWithoutLogging.GetAllArguments();
                 if (PerformanceLogEventSource.Log.IsEnabled())
                 {
                     PerformanceLogEventSource.Log.LogMSBuildStart(

--- a/src/Cli/dotnet/commands/dotnet-msbuild/MSBuildForwardingApp.cs
+++ b/src/Cli/dotnet/commands/dotnet-msbuild/MSBuildForwardingApp.cs
@@ -44,11 +44,12 @@ namespace Microsoft.DotNet.Tools.MSBuild
             return argsToForward;
         }
 
-        public MSBuildForwardingApp(IEnumerable<string> argsToForward, string msbuildPath = null)
+        public MSBuildForwardingApp(IEnumerable<string> argsToForward, string msbuildPath = null, bool? executeOutOfProc = null)
         {
             _forwardingAppWithoutLogging = new MSBuildForwardingAppWithoutLogging(
                 ConcatTelemetryLogger(argsToForward),
-                msbuildPath);
+                msbuildPath,
+                executeOutOfProc);
 
             // Add the performance log location to the environment of the target process.
             if (PerformanceLogManager.Instance != null && !string.IsNullOrEmpty(PerformanceLogManager.Instance.CurrentLogDirectory))
@@ -79,7 +80,7 @@ namespace Microsoft.DotNet.Tools.MSBuild
         {
             int exitCode;
 
-            if (MSBuildForwardingAppWithoutLogging.executeMSBuildOutOfProc)
+            if (_forwardingAppWithoutLogging.ExecuteMSBuildOutOfProc)
             {
                 // Ignore Ctrl-C for the remainder of the command's execution
                 // Forwarding commands will just spawn the child process and exit

--- a/src/Cli/dotnet/commands/dotnet-msbuild/MSBuildForwardingApp.cs
+++ b/src/Cli/dotnet/commands/dotnet-msbuild/MSBuildForwardingApp.cs
@@ -69,7 +69,10 @@ namespace Microsoft.DotNet.Tools.MSBuild
             return _forwardingAppWithoutLogging.GetProcessStartInfo();
         }
 
-        public string GetConcatenatedArguments()
+        /// <summary>
+        /// Test hook returning concatenated and escaped command line arguments that would be passed to MSBuild.
+        /// </summary>
+        internal string GetArgumentsToMSBuild()
         {
             var argumentsUnescaped = _forwardingAppWithoutLogging.GetAllArguments();
             return Cli.Utils.ArgumentEscaper.EscapeAndConcatenateArgArrayForProcessStart(argumentsUnescaped);

--- a/src/Tests/Microsoft.NET.TestFramework/TestContext.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/TestContext.cs
@@ -208,8 +208,10 @@ namespace Microsoft.NET.TestFramework
                 "MSBuildSDKsPath",
                 Path.Combine(testContext.ToolsetUnderTest.SdksPath));
 
+#if NETCOREAPP
             DotNet.Cli.Utils.MSBuildForwardingAppWithoutLogging.MSBuildExtensionsPathTestHook =
                 testContext.ToolsetUnderTest.SdkFolderUnderTest;
+#endif
         }
 
         public static string GetRepoRoot()

--- a/src/Tests/dotnet.Tests/ParserTests/MSBuildArgumentCommandLineParserTests.cs
+++ b/src/Tests/dotnet.Tests/ParserTests/MSBuildArgumentCommandLineParserTests.cs
@@ -31,7 +31,7 @@ namespace Microsoft.DotNet.Tests.CommandLineParserTests
             RestoringCommand command = buildCommand ? 
                 BuildCommand.FromArgs(arguments) : 
                 PublishCommand.FromArgs(arguments);
-            command.GetConcatenatedArguments().Split(' ')
+            command.GetArgumentsToMSBuild().Split(' ')
                 .Should()
                 .Contain(arguments);
         }

--- a/src/Tests/dotnet.Tests/ParserTests/MSBuildArgumentCommandLineParserTests.cs
+++ b/src/Tests/dotnet.Tests/ParserTests/MSBuildArgumentCommandLineParserTests.cs
@@ -31,7 +31,7 @@ namespace Microsoft.DotNet.Tests.CommandLineParserTests
             RestoringCommand command = buildCommand ? 
                 BuildCommand.FromArgs(arguments) : 
                 PublishCommand.FromArgs(arguments);
-            command.GetProcessStartInfo().Arguments.Split(' ')
+            command.GetConcatenatedArguments().Split(' ')
                 .Should()
                 .Contain(arguments);
         }

--- a/src/Tests/dotnet.Tests/dotnet-msbuild/DotnetMsbuildInProcTests.cs
+++ b/src/Tests/dotnet.Tests/dotnet-msbuild/DotnetMsbuildInProcTests.cs
@@ -65,7 +65,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
                 .GetField("_forwardingAppWithoutLogging", BindingFlags.Instance | BindingFlags.NonPublic)
                 ?.GetValue(msBuildForwardingApp) as Cli.Utils.MSBuildForwardingAppWithoutLogging;
 
-            return forwardingAppWithoutLogging?.GetAllArgumentsUnescaped();
+            return forwardingAppWithoutLogging?.GetAllArguments();
         }
     }
     public sealed class MockFirstTimeUseNoticeSentinel : IFirstTimeUseNoticeSentinel

--- a/src/Tests/dotnet.Tests/dotnet-msbuild/DotnetMsbuildInProcTests.cs
+++ b/src/Tests/dotnet.Tests/dotnet-msbuild/DotnetMsbuildInProcTests.cs
@@ -60,22 +60,12 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
 
             MSBuildForwardingApp msBuildForwardingApp = new MSBuildForwardingApp(Enumerable.Empty<string>());
 
-            object forwardingAppWithoutLogging = msBuildForwardingApp
+            var forwardingAppWithoutLogging = msBuildForwardingApp
                 .GetType()
                 .GetField("_forwardingAppWithoutLogging", BindingFlags.Instance | BindingFlags.NonPublic)
-                ?.GetValue(msBuildForwardingApp);
+                ?.GetValue(msBuildForwardingApp) as Cli.Utils.MSBuildForwardingAppWithoutLogging;
 
-            FieldInfo forwardingAppFieldInfo = forwardingAppWithoutLogging
-                .GetType()
-                .GetField("_forwardingApp", BindingFlags.Instance | BindingFlags.NonPublic);
-
-            object forwardingApp = forwardingAppFieldInfo?.GetValue(forwardingAppWithoutLogging);
-
-            FieldInfo allArgsFieldinfo = forwardingApp?
-                .GetType()
-                .GetField("_allArgs", BindingFlags.Instance | BindingFlags.NonPublic);
-
-            return allArgsFieldinfo?.GetValue(forwardingApp) as string[];
+            return forwardingAppWithoutLogging?.GetAllArgumentsUnescaped();
         }
     }
     public sealed class MockFirstTimeUseNoticeSentinel : IFirstTimeUseNoticeSentinel

--- a/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetBuildInvocation.cs
+++ b/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetBuildInvocation.cs
@@ -9,7 +9,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
 {
     public class GivenDotnetBuildInvocation : IClassFixture<NullCurrentSessionIdFixture>
     {
-        const string ExpectedPrefix = "exec <msbuildpath> -maxcpucount -verbosity:m";
+        const string ExpectedPrefix = "-maxcpucount -verbosity:m";
 
         private static readonly string WorkingDirectory =
             TestPathUtilities.FormatAbsolutePath(nameof(GivenDotnetBuildInvocation));

--- a/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetBuildInvocation.cs
+++ b/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetBuildInvocation.cs
@@ -46,7 +46,8 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
 
                 command.SeparateRestoreCommand.Should().BeNull();
 
-                command.GetConcatenatedArguments().Should()
+                command.GetConcatenatedArguments()
+                    .Should()
                     .Be($"{ExpectedPrefix} -restore -consoleloggerparameters:Summary{expectedAdditionalArgs}");
             });
         }
@@ -79,8 +80,8 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
                     .Arguments.Should()
                     .Be($"{ExpectedPrefix} {expectedAdditionalArgsForRestore}");
 
-                command.GetProcessStartInfo()
-                    .Arguments.Should()
+                command.GetConcatenatedArguments()
+                    .Should()
                     .Be($"{ExpectedPrefix} -nologo -consoleloggerparameters:Summary{expectedAdditionalArgs}");
             });
 

--- a/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetBuildInvocation.cs
+++ b/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetBuildInvocation.cs
@@ -46,8 +46,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
 
                 command.SeparateRestoreCommand.Should().BeNull();
 
-                command.GetProcessStartInfo()
-                    .Arguments.Should()
+                command.GetConcatenatedArguments().Should()
                     .Be($"{ExpectedPrefix} -restore -consoleloggerparameters:Summary{expectedAdditionalArgs}");
             });
         }

--- a/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetBuildInvocation.cs
+++ b/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetBuildInvocation.cs
@@ -46,7 +46,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
 
                 command.SeparateRestoreCommand.Should().BeNull();
 
-                command.GetConcatenatedArguments()
+                command.GetArgumentsToMSBuild()
                     .Should()
                     .Be($"{ExpectedPrefix} -restore -consoleloggerparameters:Summary{expectedAdditionalArgs}");
             });
@@ -76,11 +76,11 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
                 var msbuildPath = "<msbuildpath>";
                 var command = BuildCommand.FromArgs(args, msbuildPath);
 
-                command.SeparateRestoreCommand.GetConcatenatedArguments()
+                command.SeparateRestoreCommand.GetArgumentsToMSBuild()
                     .Should()
                     .Be($"{ExpectedPrefix} {expectedAdditionalArgsForRestore}");
 
-                command.GetConcatenatedArguments()
+                command.GetArgumentsToMSBuild()
                     .Should()
                     .Be($"{ExpectedPrefix} -nologo -consoleloggerparameters:Summary{expectedAdditionalArgs}");
             });

--- a/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetBuildInvocation.cs
+++ b/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetBuildInvocation.cs
@@ -76,8 +76,8 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
                 var msbuildPath = "<msbuildpath>";
                 var command = BuildCommand.FromArgs(args, msbuildPath);
 
-                command.SeparateRestoreCommand.GetProcessStartInfo()
-                    .Arguments.Should()
+                command.SeparateRestoreCommand.GetConcatenatedArguments()
+                    .Should()
                     .Be($"{ExpectedPrefix} {expectedAdditionalArgsForRestore}");
 
                 command.GetConcatenatedArguments()

--- a/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetCleanInvocation.cs
+++ b/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetCleanInvocation.cs
@@ -45,7 +45,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
 
                 var msbuildPath = "<msbuildpath>";
                 CleanCommand.FromArgs(args, msbuildPath)
-                    .GetProcessStartInfo().Arguments.Should().Be($"{ExpectedPrefix}{expectedAdditionalArgs}");
+                    .GetConcatenatedArguments().Should().Be($"{ExpectedPrefix}{expectedAdditionalArgs}");
             });
         }
     }

--- a/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetCleanInvocation.cs
+++ b/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetCleanInvocation.cs
@@ -12,7 +12,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
 {
     public class GivenDotnetCleanInvocation : IClassFixture<NullCurrentSessionIdFixture>
     {
-        const string ExpectedPrefix = "exec <msbuildpath> -maxcpucount -verbosity:m -verbosity:normal -target:Clean";
+        const string ExpectedPrefix = "-maxcpucount -verbosity:m -verbosity:normal -target:Clean";
 
         private static readonly string WorkingDirectory = 
             TestPathUtilities.FormatAbsolutePath(nameof(GivenDotnetCleanInvocation));
@@ -22,7 +22,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
         {
             var msbuildPath = "<msbuildpath>";
             CleanCommand.FromArgs(new string[] { "<project>" }, msbuildPath)
-                .GetProcessStartInfo().Arguments.Should().Be("exec <msbuildpath> -maxcpucount -verbosity:m -verbosity:normal <project> -target:Clean");
+                .GetConcatenatedArguments().Should().Be("-maxcpucount -verbosity:m -verbosity:normal <project> -target:Clean");
         }
 
         [Theory]

--- a/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetCleanInvocation.cs
+++ b/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetCleanInvocation.cs
@@ -22,7 +22,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
         {
             var msbuildPath = "<msbuildpath>";
             CleanCommand.FromArgs(new string[] { "<project>" }, msbuildPath)
-                .GetConcatenatedArguments().Should().Be("-maxcpucount -verbosity:m -verbosity:normal <project> -target:Clean");
+                .GetArgumentsToMSBuild().Should().Be("-maxcpucount -verbosity:m -verbosity:normal <project> -target:Clean");
         }
 
         [Theory]
@@ -45,7 +45,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
 
                 var msbuildPath = "<msbuildpath>";
                 CleanCommand.FromArgs(args, msbuildPath)
-                    .GetConcatenatedArguments().Should().Be($"{ExpectedPrefix}{expectedAdditionalArgs}");
+                    .GetArgumentsToMSBuild().Should().Be($"{ExpectedPrefix}{expectedAdditionalArgs}");
             });
         }
     }

--- a/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetPackInvocation.cs
+++ b/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetPackInvocation.cs
@@ -48,7 +48,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
                 var expectedPrefix = args.FirstOrDefault() == "--no-build" ? ExpectedNoBuildPrefix : ExpectedPrefix;
 
                 command.SeparateRestoreCommand.Should().BeNull();
-                command.GetProcessStartInfo().Arguments.Should().Be($"{expectedPrefix}{expectedAdditionalArgs}");
+                command.GetConcatenatedArguments().Should().Be($"{expectedPrefix}{expectedAdditionalArgs}");
             });
         }
     }

--- a/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetPackInvocation.cs
+++ b/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetPackInvocation.cs
@@ -14,8 +14,8 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
 {
     public class GivenDotnetPackInvocation : IClassFixture<NullCurrentSessionIdFixture>
     {
-        const string ExpectedPrefix = "exec <msbuildpath> -maxcpucount -verbosity:m -restore -target:pack";
-        const string ExpectedNoBuildPrefix = "exec <msbuildpath> -maxcpucount -verbosity:m -target:pack";
+        const string ExpectedPrefix = "-maxcpucount -verbosity:m -restore -target:pack";
+        const string ExpectedNoBuildPrefix = "-maxcpucount -verbosity:m -target:pack";
 
         private static readonly string WorkingDirectory = 
             TestPathUtilities.FormatAbsolutePath(nameof(GivenDotnetPackInvocation));

--- a/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetPackInvocation.cs
+++ b/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetPackInvocation.cs
@@ -48,7 +48,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
                 var expectedPrefix = args.FirstOrDefault() == "--no-build" ? ExpectedNoBuildPrefix : ExpectedPrefix;
 
                 command.SeparateRestoreCommand.Should().BeNull();
-                command.GetConcatenatedArguments().Should().Be($"{expectedPrefix}{expectedAdditionalArgs}");
+                command.GetArgumentsToMSBuild().Should().Be($"{expectedPrefix}{expectedAdditionalArgs}");
             });
         }
     }

--- a/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetPublishInvocation.cs
+++ b/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetPublishInvocation.cs
@@ -20,7 +20,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
             this.output = output;
         }
 
-        const string ExpectedPrefix = "exec <msbuildpath> -maxcpucount -verbosity:m";
+        const string ExpectedPrefix = "-maxcpucount -verbosity:m";
 
         [Theory]
         [InlineData(new string[] { }, "")]

--- a/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetPublishInvocation.cs
+++ b/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetPublishInvocation.cs
@@ -52,8 +52,8 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
                     .Should()
                     .BeNull();
 
-                command.GetProcessStartInfo()
-                    .Arguments.Should()
+                command.GetConcatenatedArguments()
+                    .Should()
                     .Be($"{ExpectedPrefix} -restore -target:Publish{expectedAdditionalArgs}");
             });
         }
@@ -68,13 +68,12 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
             var msbuildPath = "<msbuildpath>";
             var command = PublishCommand.FromArgs(args, msbuildPath);
 
-            command.SeparateRestoreCommand
-                   .GetProcessStartInfo()
-                   .Arguments.Should()
+            command.GetConcatenatedArguments()
+                   .Should()
                    .Be($"{ExpectedPrefix} -target:Restore");
 
-            command.GetProcessStartInfo()
-                   .Arguments.Should()
+            command.GetConcatenatedArguments()
+                   .Should()
                    .Be($"{ExpectedPrefix} -nologo -target:Publish{expectedAdditionalArgs}");
         }
 
@@ -89,8 +88,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
                    .BeNull();
 
             // NOTE --no-build implies no-restore hence no -restore argument to msbuild below.
-            command.GetProcessStartInfo()
-                   .Arguments
+            command.GetConcatenatedArguments()
                    .Should()
                    .Be($"{ExpectedPrefix} -target:Publish -property:NoBuild=true");
         }

--- a/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetPublishInvocation.cs
+++ b/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetPublishInvocation.cs
@@ -68,7 +68,8 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
             var msbuildPath = "<msbuildpath>";
             var command = PublishCommand.FromArgs(args, msbuildPath);
 
-            command.GetConcatenatedArguments()
+            command.SeparateRestoreCommand
+                   .GetConcatenatedArguments()
                    .Should()
                    .Be($"{ExpectedPrefix} -target:Restore");
 

--- a/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetPublishInvocation.cs
+++ b/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetPublishInvocation.cs
@@ -101,8 +101,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
             var msbuildPath = "<msbuildpath>";
             var command = PublishCommand.FromArgs(new[] { "/p:Prop1=prop1", "/p:Prop2=prop2" }, msbuildPath);
 
-            command.GetProcessStartInfo()
-               .Arguments
+            command.GetConcatenatedArguments()
                .Should()
                .Be($"{ExpectedPrefix} -restore -target:Publish -property:Prop1=prop1 -property:Prop2=prop2");
         }

--- a/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetPublishInvocation.cs
+++ b/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetPublishInvocation.cs
@@ -52,7 +52,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
                     .Should()
                     .BeNull();
 
-                command.GetConcatenatedArguments()
+                command.GetArgumentsToMSBuild()
                     .Should()
                     .Be($"{ExpectedPrefix} -restore -target:Publish{expectedAdditionalArgs}");
             });
@@ -69,11 +69,11 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
             var command = PublishCommand.FromArgs(args, msbuildPath);
 
             command.SeparateRestoreCommand
-                   .GetConcatenatedArguments()
+                   .GetArgumentsToMSBuild()
                    .Should()
                    .Be($"{ExpectedPrefix} -target:Restore");
 
-            command.GetConcatenatedArguments()
+            command.GetArgumentsToMSBuild()
                    .Should()
                    .Be($"{ExpectedPrefix} -nologo -target:Publish{expectedAdditionalArgs}");
         }
@@ -89,7 +89,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
                    .BeNull();
 
             // NOTE --no-build implies no-restore hence no -restore argument to msbuild below.
-            command.GetConcatenatedArguments()
+            command.GetArgumentsToMSBuild()
                    .Should()
                    .Be($"{ExpectedPrefix} -target:Publish -property:NoBuild=true");
         }
@@ -100,7 +100,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
             var msbuildPath = "<msbuildpath>";
             var command = PublishCommand.FromArgs(new[] { "/p:Prop1=prop1", "/p:Prop2=prop2" }, msbuildPath);
 
-            command.GetConcatenatedArguments()
+            command.GetArgumentsToMSBuild()
                .Should()
                .Be($"{ExpectedPrefix} -restore -target:Publish -property:Prop1=prop1 -property:Prop2=prop2");
         }

--- a/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetRestoreInvocation.cs
+++ b/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetRestoreInvocation.cs
@@ -49,7 +49,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
 
                 var msbuildPath = "<msbuildpath>";
                 RestoreCommand.FromArgs(args, msbuildPath)
-                    .GetConcatenatedArguments()
+                    .GetArgumentsToMSBuild()
                     .Should().Be($"{ExpectedPrefix}{expectedAdditionalArgs}");
             });
         }

--- a/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetRestoreInvocation.cs
+++ b/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetRestoreInvocation.cs
@@ -13,7 +13,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
     public class GivenDotnetRestoreInvocation : IClassFixture<NullCurrentSessionIdFixture>
     {
         private const string ExpectedPrefix =
-            "exec <msbuildpath> -maxcpucount -verbosity:m -nologo -target:Restore";
+            "-maxcpucount -verbosity:m -nologo -target:Restore";
         private static readonly string WorkingDirectory = 
             TestPathUtilities.FormatAbsolutePath(nameof(GivenDotnetRestoreInvocation));
 

--- a/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetRestoreInvocation.cs
+++ b/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetRestoreInvocation.cs
@@ -49,7 +49,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
 
                 var msbuildPath = "<msbuildpath>";
                 RestoreCommand.FromArgs(args, msbuildPath)
-                    .GetProcessStartInfo().Arguments
+                    .GetConcatenatedArguments()
                     .Should().Be($"{ExpectedPrefix}{expectedAdditionalArgs}");
             });
         }

--- a/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetStoreInvocation.cs
+++ b/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetStoreInvocation.cs
@@ -12,7 +12,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
 {
     public class GivenDotnetStoreInvocation : IClassFixture<NullCurrentSessionIdFixture>
     {
-        const string ExpectedPrefix = "exec <msbuildpath> -maxcpucount -verbosity:m -target:ComposeStore <project>";
+        const string ExpectedPrefix = "-maxcpucount -verbosity:m -target:ComposeStore <project>";
         static readonly string[] ArgsPrefix = { "--manifest", "<project>" };
         private static readonly string WorkingDirectory =
             TestPathUtilities.FormatAbsolutePath(nameof(GivenDotnetStoreInvocation));

--- a/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetStoreInvocation.cs
+++ b/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetStoreInvocation.cs
@@ -25,7 +25,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
             var msbuildPath = "<msbuildpath>";
             string[] args = new string[] { optionName, "<project>" };
             StoreCommand.FromArgs(args, msbuildPath)
-                .GetConcatenatedArguments().Should().Be($"{ExpectedPrefix}");
+                .GetArgumentsToMSBuild().Should().Be($"{ExpectedPrefix}");
         }
 
         [Theory]
@@ -46,7 +46,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
 
                 var msbuildPath = "<msbuildpath>";
                 StoreCommand.FromArgs(args, msbuildPath)
-                    .GetConcatenatedArguments().Should().Be($"{ExpectedPrefix}{expectedAdditionalArgs}");
+                    .GetArgumentsToMSBuild().Should().Be($"{ExpectedPrefix}{expectedAdditionalArgs}");
             });
         }
 
@@ -60,7 +60,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
 
             var msbuildPath = "<msbuildpath>";
             StoreCommand.FromArgs(args, msbuildPath)
-                .GetConcatenatedArguments().Should().Be($"{ExpectedPrefix} -property:ComposeDir={Path.GetFullPath(path)}");
+                .GetArgumentsToMSBuild().Should().Be($"{ExpectedPrefix} -property:ComposeDir={Path.GetFullPath(path)}");
         }
     }
 }

--- a/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetStoreInvocation.cs
+++ b/src/Tests/dotnet.Tests/dotnet-msbuild/GivenDotnetStoreInvocation.cs
@@ -25,7 +25,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
             var msbuildPath = "<msbuildpath>";
             string[] args = new string[] { optionName, "<project>" };
             StoreCommand.FromArgs(args, msbuildPath)
-                .GetProcessStartInfo().Arguments.Should().Be($"{ExpectedPrefix}");
+                .GetConcatenatedArguments().Should().Be($"{ExpectedPrefix}");
         }
 
         [Theory]
@@ -46,7 +46,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
 
                 var msbuildPath = "<msbuildpath>";
                 StoreCommand.FromArgs(args, msbuildPath)
-                    .GetProcessStartInfo().Arguments.Should().Be($"{ExpectedPrefix}{expectedAdditionalArgs}");
+                    .GetConcatenatedArguments().Should().Be($"{ExpectedPrefix}{expectedAdditionalArgs}");
             });
         }
 
@@ -60,7 +60,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
 
             var msbuildPath = "<msbuildpath>";
             StoreCommand.FromArgs(args, msbuildPath)
-                .GetProcessStartInfo().Arguments.Should().Be($"{ExpectedPrefix} -property:ComposeDir={Path.GetFullPath(path)}");
+                .GetConcatenatedArguments().Should().Be($"{ExpectedPrefix} -property:ComposeDir={Path.GetFullPath(path)}");
         }
     }
 }

--- a/src/Tests/dotnet.Tests/dotnet-msbuild/GivenMsbuildForwardingApp.cs
+++ b/src/Tests/dotnet.Tests/dotnet-msbuild/GivenMsbuildForwardingApp.cs
@@ -14,21 +14,6 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
 {
     public class GivenMsbuildForwardingApp : SdkTest
     {
-        private struct OutOfProcMSBuildHolder : IDisposable
-        {
-            private bool _originalExecuteMSBuildOutOfProc;
-            public OutOfProcMSBuildHolder(bool executeMSBuildOutOfProc)
-            {
-                _originalExecuteMSBuildOutOfProc = Cli.Utils.MSBuildForwardingAppWithoutLogging.executeMSBuildOutOfProc;
-                Cli.Utils.MSBuildForwardingAppWithoutLogging.executeMSBuildOutOfProc = executeMSBuildOutOfProc;
-
-            }
-            public void Dispose()
-            {
-                Cli.Utils.MSBuildForwardingAppWithoutLogging.executeMSBuildOutOfProc = _originalExecuteMSBuildOutOfProc;
-            }
-        }
-
         public GivenMsbuildForwardingApp(ITestOutputHelper log) : base(log)
         {
         }
@@ -36,20 +21,16 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
         [WindowsOnlyFact]
         public void DotnetExeIsExecuted()
         {
-            using var holder = new OutOfProcMSBuildHolder(true);
-
             var msbuildPath = "<msbuildpath>";
-            new MSBuildForwardingApp(new string[0], msbuildPath)
+            new MSBuildForwardingApp(new string[0], msbuildPath, executeOutOfProc: true)
                 .GetProcessStartInfo().FileName.Should().Be("dotnet.exe");
         }
 
         [UnixOnlyFact]
         public void DotnetIsExecuted()
         {
-            using var holder = new OutOfProcMSBuildHolder(true);
-
             var msbuildPath = "<msbuildpath>";
-            new MSBuildForwardingApp(new string[0], msbuildPath)
+            new MSBuildForwardingApp(new string[0], msbuildPath, executeOutOfProc: true)
                 .GetProcessStartInfo().FileName.Should().Be("dotnet");
         }
 
@@ -59,21 +40,17 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
         [InlineData("DOTNET_CLI_TELEMETRY_SESSIONID")]
         public void ItSetsEnvironmentalVariables(string envVarName)
         {
-            using var holder = new OutOfProcMSBuildHolder(true);
-
             var msbuildPath = "<msbuildpath>";
-            var startInfo = new MSBuildForwardingApp(new string[0], msbuildPath).GetProcessStartInfo();
+            var startInfo = new MSBuildForwardingApp(new string[0], msbuildPath, executeOutOfProc: true).GetProcessStartInfo();
             startInfo.Environment.ContainsKey(envVarName).Should().BeTrue();
         }
 
         [Fact]
         public void ItSetsMSBuildExtensionPathToExistingPath()
         {
-            using var holder = new OutOfProcMSBuildHolder(true);
-
             var msbuildPath = "<msbuildpath>";
             var envVar = "MSBuildExtensionsPath";
-            new DirectoryInfo(new MSBuildForwardingApp(new string[0], msbuildPath)
+            new DirectoryInfo(new MSBuildForwardingApp(new string[0], msbuildPath, executeOutOfProc: true)
                                 .GetProcessStartInfo()
                                 .Environment[envVar])
                 .Should()
@@ -83,11 +60,9 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
         [Fact(Skip ="Test app base folder doesn't have Sdks")]
         public void ItSetsMSBuildSDKsPathToExistingPath()
         {
-            using var holder = new OutOfProcMSBuildHolder(true);
-
             var msbuildPath = "<msbuildpath>";
             var envVar = "MSBuildSDKsPath";
-            new DirectoryInfo(new MSBuildForwardingApp(new string[0], msbuildPath)
+            new DirectoryInfo(new MSBuildForwardingApp(new string[0], msbuildPath, executeOutOfProc: true)
                                 .GetProcessStartInfo()
                                 .Environment[envVar])
                 .Should()
@@ -97,11 +72,9 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
         [Fact]
         public void ItSetsOrIgnoresTelemetrySessionId()
         {
-            using var holder = new OutOfProcMSBuildHolder(true);
-
             var msbuildPath = "<msbuildpath>";
             var envVar = "DOTNET_CLI_TELEMETRY_SESSIONID";
-            var startInfo = new MSBuildForwardingApp(new string[0], msbuildPath)
+            var startInfo = new MSBuildForwardingApp(new string[0], msbuildPath, executeOutOfProc: true)
                 .GetProcessStartInfo();
 
             string sessionId = startInfo.Environment[envVar];
@@ -120,10 +93,8 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
         [Fact]
         public void ItDoesNotSetCurrentWorkingDirectory()
         {
-            using var holder = new OutOfProcMSBuildHolder(true);
-
             var msbuildPath = "<msbuildpath>";
-            var startInfo = new MSBuildForwardingApp(new string[0], msbuildPath)
+            var startInfo = new MSBuildForwardingApp(new string[0], msbuildPath, executeOutOfProc: true)
                 .GetProcessStartInfo().WorkingDirectory.Should().Be("");
         }
     }

--- a/src/Tests/dotnet.Tests/dotnet-msbuild/GivenMsbuildForwardingApp.cs
+++ b/src/Tests/dotnet.Tests/dotnet-msbuild/GivenMsbuildForwardingApp.cs
@@ -14,6 +14,21 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
 {
     public class GivenMsbuildForwardingApp : SdkTest
     {
+        private struct OutOfProcMSBuildHolder : IDisposable
+        {
+            private bool _originalExecuteMSBuildOutOfProc;
+            public OutOfProcMSBuildHolder(bool executeMSBuildOutOfProc)
+            {
+                _originalExecuteMSBuildOutOfProc = Cli.Utils.MSBuildForwardingAppWithoutLogging.executeMSBuildOutOfProc;
+                Cli.Utils.MSBuildForwardingAppWithoutLogging.executeMSBuildOutOfProc = executeMSBuildOutOfProc;
+
+            }
+            public void Dispose()
+            {
+                Cli.Utils.MSBuildForwardingAppWithoutLogging.executeMSBuildOutOfProc = _originalExecuteMSBuildOutOfProc;
+            }
+        }
+
         public GivenMsbuildForwardingApp(ITestOutputHelper log) : base(log)
         {
         }
@@ -21,6 +36,8 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
         [WindowsOnlyFact]
         public void DotnetExeIsExecuted()
         {
+            using var holder = new OutOfProcMSBuildHolder(true);
+
             var msbuildPath = "<msbuildpath>";
             new MSBuildForwardingApp(new string[0], msbuildPath)
                 .GetProcessStartInfo().FileName.Should().Be("dotnet.exe");
@@ -29,6 +46,8 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
         [UnixOnlyFact]
         public void DotnetIsExecuted()
         {
+            using var holder = new OutOfProcMSBuildHolder(true);
+
             var msbuildPath = "<msbuildpath>";
             new MSBuildForwardingApp(new string[0], msbuildPath)
                 .GetProcessStartInfo().FileName.Should().Be("dotnet");
@@ -40,6 +59,8 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
         [InlineData("DOTNET_CLI_TELEMETRY_SESSIONID")]
         public void ItSetsEnvironmentalVariables(string envVarName)
         {
+            using var holder = new OutOfProcMSBuildHolder(true);
+
             var msbuildPath = "<msbuildpath>";
             var startInfo = new MSBuildForwardingApp(new string[0], msbuildPath).GetProcessStartInfo();
             startInfo.Environment.ContainsKey(envVarName).Should().BeTrue();
@@ -48,6 +69,8 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
         [Fact]
         public void ItSetsMSBuildExtensionPathToExistingPath()
         {
+            using var holder = new OutOfProcMSBuildHolder(true);
+
             var msbuildPath = "<msbuildpath>";
             var envVar = "MSBuildExtensionsPath";
             new DirectoryInfo(new MSBuildForwardingApp(new string[0], msbuildPath)
@@ -60,6 +83,8 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
         [Fact(Skip ="Test app base folder doesn't have Sdks")]
         public void ItSetsMSBuildSDKsPathToExistingPath()
         {
+            using var holder = new OutOfProcMSBuildHolder(true);
+
             var msbuildPath = "<msbuildpath>";
             var envVar = "MSBuildSDKsPath";
             new DirectoryInfo(new MSBuildForwardingApp(new string[0], msbuildPath)
@@ -72,6 +97,8 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
         [Fact]
         public void ItSetsOrIgnoresTelemetrySessionId()
         {
+            using var holder = new OutOfProcMSBuildHolder(true);
+
             var msbuildPath = "<msbuildpath>";
             var envVar = "DOTNET_CLI_TELEMETRY_SESSIONID";
             var startInfo = new MSBuildForwardingApp(new string[0], msbuildPath)
@@ -93,6 +120,8 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
         [Fact]
         public void ItDoesNotSetCurrentWorkingDirectory()
         {
+            using var holder = new OutOfProcMSBuildHolder(true);
+
             var msbuildPath = "<msbuildpath>";
             var startInfo = new MSBuildForwardingApp(new string[0], msbuildPath)
                 .GetProcessStartInfo().WorkingDirectory.Should().Be("");

--- a/src/Tests/dotnet.Tests/dotnet-msbuild/GivenMsbuildForwardingApp.cs
+++ b/src/Tests/dotnet.Tests/dotnet-msbuild/GivenMsbuildForwardingApp.cs
@@ -22,7 +22,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
         public void DotnetExeIsExecuted()
         {
             var msbuildPath = "<msbuildpath>";
-            new MSBuildForwardingApp(new string[0], msbuildPath, executeOutOfProc: true)
+            new MSBuildForwardingApp(new string[0], msbuildPath)
                 .GetProcessStartInfo().FileName.Should().Be("dotnet.exe");
         }
 
@@ -30,7 +30,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
         public void DotnetIsExecuted()
         {
             var msbuildPath = "<msbuildpath>";
-            new MSBuildForwardingApp(new string[0], msbuildPath, executeOutOfProc: true)
+            new MSBuildForwardingApp(new string[0], msbuildPath)
                 .GetProcessStartInfo().FileName.Should().Be("dotnet");
         }
 
@@ -41,7 +41,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
         public void ItSetsEnvironmentalVariables(string envVarName)
         {
             var msbuildPath = "<msbuildpath>";
-            var startInfo = new MSBuildForwardingApp(new string[0], msbuildPath, executeOutOfProc: true).GetProcessStartInfo();
+            var startInfo = new MSBuildForwardingApp(new string[0], msbuildPath).GetProcessStartInfo();
             startInfo.Environment.ContainsKey(envVarName).Should().BeTrue();
         }
 
@@ -50,7 +50,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
         {
             var msbuildPath = "<msbuildpath>";
             var envVar = "MSBuildExtensionsPath";
-            new DirectoryInfo(new MSBuildForwardingApp(new string[0], msbuildPath, executeOutOfProc: true)
+            new DirectoryInfo(new MSBuildForwardingApp(new string[0], msbuildPath)
                                 .GetProcessStartInfo()
                                 .Environment[envVar])
                 .Should()
@@ -62,7 +62,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
         {
             var msbuildPath = "<msbuildpath>";
             var envVar = "MSBuildSDKsPath";
-            new DirectoryInfo(new MSBuildForwardingApp(new string[0], msbuildPath, executeOutOfProc: true)
+            new DirectoryInfo(new MSBuildForwardingApp(new string[0], msbuildPath)
                                 .GetProcessStartInfo()
                                 .Environment[envVar])
                 .Should()
@@ -74,7 +74,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
         {
             var msbuildPath = "<msbuildpath>";
             var envVar = "DOTNET_CLI_TELEMETRY_SESSIONID";
-            var startInfo = new MSBuildForwardingApp(new string[0], msbuildPath, executeOutOfProc: true)
+            var startInfo = new MSBuildForwardingApp(new string[0], msbuildPath)
                 .GetProcessStartInfo();
 
             string sessionId = startInfo.Environment[envVar];
@@ -94,7 +94,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
         public void ItDoesNotSetCurrentWorkingDirectory()
         {
             var msbuildPath = "<msbuildpath>";
-            var startInfo = new MSBuildForwardingApp(new string[0], msbuildPath, executeOutOfProc: true)
+            var startInfo = new MSBuildForwardingApp(new string[0], msbuildPath)
                 .GetProcessStartInfo().WorkingDirectory.Should().Be("");
         }
     }

--- a/src/Tests/dotnet.Tests/dotnet.Tests.csproj
+++ b/src/Tests/dotnet.Tests/dotnet.Tests.csproj
@@ -148,5 +148,6 @@
   <ItemGroup>
     <PackageReference Include="Moq" Version="$(MoqPackageVersion)" />
     <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildUtilitiesCorePackageVersion)" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Fixes #16362

This PR adds the possibility to load MSBuild.dll into the CLI process and directly call its entry point. This is in addition to the existing logic of launching a new dotnet process with MSBuild.dll as the startup assembly. The new behavior is enabled by default and can be disabled by setting a newly introduced `DOTNET_CLI_RUN_MSBUILD_OUTOFPROC` environment variable. The motivation for this change is performance as the extra process costs us 100 - 150 ms per MSBuild invocation, depending on platform and CPU specs.

Overall the change is straightforward but a few aspects deserve to be mentioned here:
- MSBuild.dll is distributed in the `Microsoft.Build.Runtime` package which has non-standard layout and requires the assembly reference to be provided manually (see `Microsoft.DotNet.Cli.Utils.csproj`).
- The .NET runtime currently has a feature gap and [does not expose an API to set environment variables with empty values](https://github.com/dotnet/runtime/issues/50554). This is worked around by falling back to executing MSBuild out-of-proc if such a variable is set. Hopefully this is not common.
- The change is covered by existing tests. Some tests still take the old code path, simply because they are passing a non-default MSBuild.dll file path while end-to-end tests exercise in-proc MSBuild invocation. The difference between in-proc and out-of-proc is only in the way MSBuild is ultimately called. The underlying logic of argument passing, which most tests seem to be focused on, is the same so running tests twice (in-proc and out-of-proc) doesn't look warranted.