### PR TITLE
Hide RazorExtension rule file properties

### DIFF
--- a/src/RazorSdk/Targets/Rules/RazorExtension.xaml
+++ b/src/RazorSdk/Targets/Rules/RazorExtension.xaml
@@ -24,7 +24,7 @@
     DisplayName="Razor Extension Assembly Name"
     Name="AssemblyName"
     ReadOnly="True"
-    Visible="True" />
+    Visible="False" />
 
   <StringProperty
     Category="General"
@@ -32,6 +32,6 @@
     DisplayName="Razor Extension Assembly File Path"
     Name="AssemblyFilePath"
     ReadOnly="True"
-    Visible="True" />
+    Visible="False" />
 
 </Rule>


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/31150

These properties are only intended for programmatic access, and not for display to the user.

The current configuration of these rules means they appear in the updated Project Properties UI for ASP.NET projects.

Making these properties non-visible fixes the issue.