### PR TITLE
Use Crossgen2 by default for R2R publishing

### DIFF
--- a/src/Layout/toolset-tasks/OverrideAndCreateBundledNETCoreAppPackageVersion.cs
+++ b/src/Layout/toolset-tasks/OverrideAndCreateBundledNETCoreAppPackageVersion.cs
@@ -108,6 +108,13 @@ namespace Microsoft.DotNet.Build.Tasks
             CheckAndReplaceAttribute(itemGroup
                 .Elements(ns + "KnownCrossgen2Pack").First().Attribute("Crossgen2PackVersion"));
 
+            // TODO: remove this once we're using an SDK that contains https://github.com/dotnet/installer/pull/10250
+            var crossgen2Rids = itemGroup.Elements(ns + "KnownCrossgen2Pack").First().Attribute("Crossgen2RuntimeIdentifiers");
+            if (!crossgen2Rids.Value.Contains("osx-x64"))
+            {
+                crossgen2Rids.Value += ";osx-x64";
+            }
+
             // TODO: remove this once we're using an SDK that contains https://github.com/dotnet/installer/pull/10206
             if (itemGroup.Elements(ns + "KnownRuntimePack").FirstOrDefault() == null)
             {

--- a/src/Tasks/Microsoft.NET.Build.Tasks/PrepareForReadyToRunCompilation.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/PrepareForReadyToRunCompilation.cs
@@ -57,7 +57,6 @@ namespace Microsoft.NET.Build.Tasks
 
         protected override void ExecuteCore()
         {
-            // Future: when crossgen2 supports generating PDBs, update this to check crossgen2 when we are using crossgen2.
             string diaSymReaderPath = CrossgenTool?.GetMetadata(MetadataKeys.DiaSymReader);
             bool hasValidDiaSymReaderLib = !string.IsNullOrEmpty(diaSymReaderPath) && File.Exists(diaSymReaderPath);
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/PrepareForReadyToRunCompilation.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/PrepareForReadyToRunCompilation.cs
@@ -57,9 +57,6 @@ namespace Microsoft.NET.Build.Tasks
 
         protected override void ExecuteCore()
         {
-            string diaSymReaderPath = CrossgenTool?.GetMetadata(MetadataKeys.DiaSymReader);
-            bool hasValidDiaSymReaderLib = !string.IsNullOrEmpty(diaSymReaderPath) && File.Exists(diaSymReaderPath);
-
             if (ReadyToRunUseCrossgen2)
             {
                 string isVersion5 = Crossgen2Tool.GetMetadata(MetadataKeys.IsVersion5);
@@ -71,6 +68,12 @@ namespace Microsoft.NET.Build.Tasks
                     return;
                 }
             }
+
+            string diaSymReaderPath = CrossgenTool?.GetMetadata(MetadataKeys.DiaSymReader);
+
+            bool hasValidDiaSymReaderLib =
+                ReadyToRunUseCrossgen2 && !_crossgen2IsVersion5 ||
+                !string.IsNullOrEmpty(diaSymReaderPath) && File.Exists(diaSymReaderPath);
 
             // Process input lists of files
             ProcessInputFileList(Assemblies, _compileList, _symbolsCompileList, _r2rFiles, _r2rReferences, hasValidDiaSymReaderLib);

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolveReadyToRunCompilers.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveReadyToRunCompilers.cs
@@ -51,6 +51,7 @@ namespace Microsoft.NET.Build.Tasks
         private CrossgenToolInfo _crossgen2Tool;
 
         private Architecture _targetArchitecture;
+        private bool _crossgen2IsVersion5;
 
         protected override void ExecuteCore()
         {
@@ -85,9 +86,8 @@ namespace Microsoft.NET.Build.Tasks
                     return;
                 }
 
-                // NOTE: Crossgen2 does not yet currently support emitting native symbols, and until this feature
-                // is implemented, we will use crossgen for it. This should go away in the future when crossgen2 supports the feature.
-                if (EmitSymbols && !ValidateCrossgenSupport())
+                // In .NET 5 Crossgen2 did not support emitting native symbols, so we use Crossgen to emit them
+                if (_crossgen2IsVersion5 && EmitSymbols && !ValidateCrossgenSupport())
                 {
                     return;
                 }
@@ -183,6 +183,7 @@ namespace Microsoft.NET.Build.Tasks
                 Crossgen2Tool.SetMetadata(MetadataKeys.DiaSymReader, _crossgen2Tool.DiaSymReaderPath);
             }
 
+            _crossgen2IsVersion5 = version5;
             return true;
         }
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolveReadyToRunCompilers.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveReadyToRunCompilers.cs
@@ -178,10 +178,6 @@ namespace Microsoft.NET.Build.Tasks
                 Crossgen2Tool.SetMetadata(MetadataKeys.TargetOS, targetOS);
                 Crossgen2Tool.SetMetadata(MetadataKeys.TargetArch, ArchitectureToString(_targetArchitecture));
             }
-            if (!String.IsNullOrEmpty(_crossgen2Tool.DiaSymReaderPath))
-            {
-                Crossgen2Tool.SetMetadata(MetadataKeys.DiaSymReader, _crossgen2Tool.DiaSymReaderPath);
-            }
 
             _crossgen2IsVersion5 = version5;
             return true;

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -14,8 +14,13 @@ Copyright (c) .NET Foundation. All rights reserved.
   <PropertyGroup>
     <DefaultCopyToPublishDirectoryMetadata Condition="'$(DefaultCopyToPublishDirectoryMetadata)' == ''">true</DefaultCopyToPublishDirectoryMetadata>
     <_GetChildProjectCopyToPublishDirectoryItems Condition="'$(_GetChildProjectCopyToPublishDirectoryItems)' == ''">true</_GetChildProjectCopyToPublishDirectoryItems>
-
     <IsPublishable Condition="'$(IsPublishable)' == ''">true</IsPublishable>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(PublishReadyToRun)' == 'true' and '$(TargetFrameworkIdentifier)' == '.NETCoreApp' and '$(_TargetFrameworkVersionWithoutV)' >= '3.0'">
+    <!-- For .NET 6 and higher, default to using Crossgen2 in non-composite mode -->
+    <PublishReadyToRunUseCrossgen2 Condition="'$(PublishReadyToRunUseCrossgen2)' == '' and '$(_TargetFrameworkVersionWithoutV)' >= '6.0'">true</PublishReadyToRunUseCrossgen2>
+    <PublishReadyToRunComposite Condition="'$(PublishReadyToRunComposite)' == '' and '$(_TargetFrameworkVersionWithoutV)' >= '6.0'">false</PublishReadyToRunComposite>
     <PublishReadyToRunComposite Condition="'$(PublishReadyToRunComposite)' == ''">true</PublishReadyToRunComposite>
     <PublishReadyToRunComposite Condition="'$(PublishReadyToRunUseCrossgen2)' != 'true' or '$(SelfContained)' != 'true'">false</PublishReadyToRunComposite>
   </PropertyGroup>


### PR DESCRIPTION
When targeting .NET 6, default to using Crossgen2 in non-composite mode.  Keep the old behavior when targeting .NET 5 and .NET Core 3.1.