### PR TITLE
Disable Razor source generator for design time builds

### DIFF
--- a/src/RazorSdk/Targets/Microsoft.NET.Sdk.Razor.SourceGenerators.targets
+++ b/src/RazorSdk/Targets/Microsoft.NET.Sdk.Razor.SourceGenerators.targets
@@ -9,7 +9,8 @@ Copyright (c) .NET Foundation. All rights reserved.
 -->
 
 <Project ToolsVersion="14.0">
-
+  <!-- Temporary workaround for design-time and build-time files being produced at
+        the same time. See https://github.com/dotnet/sdk/pull/16648 for more info. -->
   <Target Name="_PrepareRazorSourceGenerators"
     Condition="'$(DesignTimeBuild)'!='true'"
     BeforeTargets="GenerateMSBuildEditorConfigFileShouldRun"

--- a/src/RazorSdk/Targets/Microsoft.NET.Sdk.Razor.SourceGenerators.targets
+++ b/src/RazorSdk/Targets/Microsoft.NET.Sdk.Razor.SourceGenerators.targets
@@ -11,6 +11,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 <Project ToolsVersion="14.0">
 
   <Target Name="_PrepareRazorSourceGenerators"
+    Condition="'$(DesignTimeBuild)'!='true'"
     BeforeTargets="GenerateMSBuildEditorConfigFileShouldRun"
     DependsOnTargets="PrepareForRazorGenerate;PrepareForRazorComponentGenerate">
 


### PR DESCRIPTION
## Description

Source generators run in design-time builds in Visual Studio. In Razor, the source generator produces generated code that is optimized for runtime execution. Razor tooling produces generated code that is optimized for tooling (AKA design-time). When the two run together, it produces two different representations of the same source document in the user's current workspace.

## Customer Impact

Customers editing their Razor files in VS will see lots of errors related to conflicts between types that are repeated in both the design-time and run-time compiled files.

![image](https://user-images.githubusercontent.com/1857993/113173736-8db37080-91fe-11eb-8225-fc7b9708d7c0.png)

This change only affects projects targeting TFM net6.0.

## Regression?
- [X] Yes
- [ ] No

This is a regression from .NET 6 Preview 1. 

## Risk
- [ ] High
- [ ] Medium
- [X] Low

This strategy is one we've utilized previously when we were using the Razor compiler as a tool. This will only affect users who are using a .NET 6 Preview 2 and above SDK.

## Verification
- [x] Manual (required)
- [X] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [X] N/A
