### PR TITLE
[NO MERGE] use a hacky way to run all the tests using new FileStream implementation

### DIFF
--- a/src/Tests/Common/runtimeconfig.template.json
+++ b/src/Tests/Common/runtimeconfig.template.json
@@ -1,3 +1,6 @@
 {
-    "rollForwardOnNoCandidateFx": 2
+    "rollForwardOnNoCandidateFx": 2,
+    "configProperties": {
+        "System.IO.UseNet5CompatFileStream": false
+    }
 }

--- a/src/Tests/dotnet.Tests/Net5CompatSwitchTests.cs
+++ b/src/Tests/dotnet.Tests/Net5CompatSwitchTests.cs
@@ -1,0 +1,42 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#if NET6_0
+using System.Reflection;
+using Xunit;
+
+namespace System.IO.Tests
+{
+    public class Net5CompatSwitchTests
+    {
+        [Fact]
+        public static void LegacySwitchIsHonored()
+        {
+            string filePath = Path.Combine(Path.GetTempPath(), Path.GetTempFileName());
+
+            using (FileStream fileStream = File.Create(filePath))
+            {
+                object strategy = fileStream?
+                        .GetType()?
+                        .GetField("_strategy", BindingFlags.NonPublic | BindingFlags.Instance)?
+                        .GetValue(fileStream)
+                    ?? null;
+
+                if (OperatingSystem.IsWindows())
+                {
+                    if (strategy == null)
+                    {
+                        throw new Exception("using an old build");
+                    }
+
+                    Assert.DoesNotContain("Net5Compat", strategy.GetType().FullName);
+                    Assert.DoesNotContain("Legacy", strategy.GetType().FullName);
+                }
+            }
+
+            File.Delete(filePath);
+        }
+    }
+}
+#endif


### PR DESCRIPTION
Please ignore this PR, I just want to check if the most recent changes have not broken anything in the SDK before we enable them by default.