### PR TITLE
Include Razor editor config for design time builds

### DIFF
--- a/src/RazorSdk/SourceGenerators/Microsoft.NET.Sdk.Razor.SourceGenerators.csproj
+++ b/src/RazorSdk/SourceGenerators/Microsoft.NET.Sdk.Razor.SourceGenerators.csproj
@@ -18,6 +18,10 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.Extensions" Version="$(MicrosoftAspNetCoreMvcRazorExtensionsPackageVersion)" GeneratePathProperty="true" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Update="RazorSourceGenerator.razorencconfig" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
   <!-- See https://github.com/dotnet/roslyn/discussions/47517#discussioncomment-64145 -->
   <PropertyGroup>
     <GetTargetPathDependsOn>$(GetTargetPathDependsOn);GetDependencyTargetPaths</GetTargetPathDependsOn>

--- a/src/RazorSdk/SourceGenerators/RazorSourceGenerationContext.cs
+++ b/src/RazorSdk/SourceGenerators/RazorSourceGenerationContext.cs
@@ -35,6 +35,16 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
         /// </summary>
         public bool GenerateMetadataSourceChecksumAttributes { get; private set; }
 
+        /// <summary>
+        /// Gets a flag that determines if the source generator should no-op.
+        /// <para>
+        /// This flag exists to support scenarios in VS where design-time and EnC builds need
+        /// to run without invoking the source generator to avoid duplicate types being produced.
+        /// The property is set by the SDK via an editor config.
+        /// </para>
+        /// </summary>
+        public bool SuppressRazorSourceGenerator { get; private set; }
+
         public RazorSourceGenerationContext(GeneratorExecutionContext context)
         {
             var globalOptions = context.AnalyzerConfigOptions.GlobalOptions;
@@ -61,6 +71,8 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
 
             globalOptions.TryGetValue("build_property._RazorSourceGeneratorDebug", out var waitForDebugger);
 
+            globalOptions.TryGetValue("build_property.SuppressRazorSourceGenerator", out var suppressRazorSourceGenerator);
+
             globalOptions.TryGetValue("build_property.GenerateRazorMetadataSourceChecksumAttributes", out var generateMetadataSourceChecksumAttributes);
 
             var razorConfiguration = RazorConfiguration.Create(razorLanguageVersion, configurationName, Enumerable.Empty<RazorExtension>(), true);
@@ -73,6 +85,7 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
             RazorFiles = razorFiles;
             CshtmlFiles = cshtmlFiles;
             WaitForDebugger = waitForDebugger == "true";
+            SuppressRazorSourceGenerator = suppressRazorSourceGenerator == "true";
             GenerateMetadataSourceChecksumAttributes = generateMetadataSourceChecksumAttributes == "true";
         }
 

--- a/src/RazorSdk/SourceGenerators/RazorSourceGenerator.cs
+++ b/src/RazorSdk/SourceGenerators/RazorSourceGenerator.cs
@@ -49,6 +49,11 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
                 return;
             }
 
+            if (razorContext.SuppressRazorSourceGenerator)
+            {
+                return;
+            }
+
             HandleDebugSwitch(razorContext.WaitForDebugger);
 
             var tagHelpers = ResolveTagHelperDescriptors(context, razorContext);

--- a/src/RazorSdk/SourceGenerators/RazorSourceGenerator.razorencconfig
+++ b/src/RazorSdk/SourceGenerators/RazorSourceGenerator.razorencconfig
@@ -1,0 +1,2 @@
+is_global = true
+build_property.SuppressRazorSourceGenerator = true

--- a/src/RazorSdk/Targets/Microsoft.NET.Sdk.Razor.SourceGenerators.targets
+++ b/src/RazorSdk/Targets/Microsoft.NET.Sdk.Razor.SourceGenerators.targets
@@ -23,7 +23,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       <RazorEncConfigFile>$(_RazorSdkSourceGeneratorDirectoryRoot)RazorSourceGenerator.razorencconfig</RazorEncConfigFile>
     </PropertyGroup>
 
-    <EditorConfigFiles Include="$(RazorEncConfigFile)" Condition="'$(DesignTimeBuild)' == 'true'"/>
+    <EditorConfigFiles Include="$(RazorEncConfigFile)" Condition="'$(DesignTimeBuild)' == 'true' AND '$(BuildingInsideVisualStudio)' == 'true'"/>
 
     <!-- Configure analyzers -->
     <ItemGroup>

--- a/src/RazorSdk/Targets/Microsoft.NET.Sdk.Razor.SourceGenerators.targets
+++ b/src/RazorSdk/Targets/Microsoft.NET.Sdk.Razor.SourceGenerators.targets
@@ -19,6 +19,12 @@ Copyright (c) .NET Foundation. All rights reserved.
       <_RazorSdkToolsDirectoryRoot>$(RazorSdkDirectoryRoot)\tools\</_RazorSdkToolsDirectoryRoot>
     </PropertyGroup>
 
+    <PropertyGroup>
+      <RazorEncConfigFile>$(_RazorSdkSourceGeneratorDirectoryRoot)RazorSourceGenerator.razorencconfig</RazorEncConfigFile>
+    </PropertyGroup>
+
+    <EditorConfigFiles Include="$(RazorEncConfigFile)" Condition="'$(DesignTimeBuild)' == 'true'"/>
+
     <!-- Configure analyzers -->
     <ItemGroup>
       <_RazorAnalyzer Include="$(_RazorSdkToolsDirectoryRoot)Microsoft.AspNetCore.Mvc.Razor.Extensions.dll" />


### PR DESCRIPTION
Part of https://github.com/dotnet/aspnetcore/issues/31155.

Includes a `RazorSourceGenerator.razorencconfig` file with `SuppressRazorSourceGenerator=true` property in `DesignTimeBuild`-enabled builds.