### PR TITLE
Fix https://github.com/dotnet/msbuild/issues/5941

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -16,7 +16,6 @@
   </PropertyGroup>
   <!-- Production Dependencies -->
   <PropertyGroup>
-    <FSharpBuildVersion>16.6</FSharpBuildVersion>
     <MicrosoftBuildVersion>15.4.8</MicrosoftBuildVersion>
     <MicrosoftBuildFrameworkVersion>15.4.8</MicrosoftBuildFrameworkVersion>
     <MicrosoftBuildUtilitiesCoreVersion>15.4.8</MicrosoftBuildUtilitiesCoreVersion>

--- a/src/Layout/tool_fsharp/tool_fsc.csproj
+++ b/src/Layout/tool_fsharp/tool_fsc.csproj
@@ -5,9 +5,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.FSharp.Compiler" Version="$(MicrosoftFSharpCompilerPackageVersion)" GeneratePathProperty="true" />
-    <PackageReference Include="Microsoft.Build.Framework" Version="$(FSharpBuildVersion)" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(FSharpBuildVersion)" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(FSharpBuildVersion)" />
+    <PackageReference Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildPackageVersion)" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildPackageVersion)" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildPackageVersion)" />
   </ItemGroup>
 
    <Target Name="_ResolvePublishNuGetPackagePdbsAndXml"


### PR DESCRIPTION
Fixes https://github.com/dotnet/msbuild/issues/5941

 - Bring F#'s MSBuild version up-to-date

Ensure that the F# compiler and fsi use the msbuild shipped with the dotnet sdk rather than an old one.