### PR TITLE
Use TLS to run browser refresh server when possible

### DIFF
--- a/src/BuiltInTools/dotnet-watch/Filters/BrowserRefreshServer.cs
+++ b/src/BuiltInTools/dotnet-watch/Filters/BrowserRefreshServer.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Net.WebSockets;
 using System.Text;
@@ -25,7 +26,7 @@ namespace Microsoft.DotNet.Watcher.Tools
     {
         private readonly byte[] ReloadMessage = Encoding.UTF8.GetBytes("Reload");
         private readonly byte[] WaitMessage = Encoding.UTF8.GetBytes("Wait");
-        private readonly JsonSerializerOptions _jsonSerializerOptions = new (JsonSerializerDefaults.Web);
+        private readonly JsonSerializerOptions _jsonSerializerOptions = new(JsonSerializerDefaults.Web);
         private readonly List<WebSocket> _clientSockets = new();
         private readonly IReporter _reporter;
         private readonly TaskCompletionSource _taskCompletionSource;
@@ -39,13 +40,16 @@ namespace Microsoft.DotNet.Watcher.Tools
 
         public async ValueTask<string> StartAsync(CancellationToken cancellationToken)
         {
-            var hostName = Environment.GetEnvironmentVariable("DOTNET_WATCH_AUTO_RELOAD_WS_HOSTNAME") ?? "127.0.0.1";
+            var envHostName = Environment.GetEnvironmentVariable("DOTNET_WATCH_AUTO_RELOAD_WS_HOSTNAME");
+            var hostName = envHostName ?? "127.0.0.1";
+
+            var useTls = await ShouldUseHttps();
 
             _refreshServer = new HostBuilder()
                 .ConfigureWebHost(builder =>
                 {
                     builder.UseKestrel();
-                    builder.UseUrls($"http://{hostName}:0");
+                    builder.UseUrls(useTls ? $"https://{hostName}:0" : $"http://{hostName}:0");
 
                     builder.Configure(app =>
                     {
@@ -64,7 +68,16 @@ namespace Microsoft.DotNet.Watcher.Tools
                 .Addresses
                 .First();
 
-            return serverUrl.Replace("http://", "ws://");
+            if (envHostName is null)
+            {
+                return useTls ?
+                    serverUrl.Replace("https://127.0.0.1", "wss://localhost", StringComparison.Ordinal) :
+                    serverUrl.Replace("http://127.0.0.1", "ws://localhost", StringComparison.Ordinal);
+            }
+
+            return serverUrl
+                .Replace("https://", "wss://", StringComparison.Ordinal)
+                .Replace("http://", "ws://", StringComparison.Ordinal);
         }
 
         private async Task WebSocketRequest(HttpContext context)
@@ -126,5 +139,19 @@ namespace Microsoft.DotNet.Watcher.Tools
         public ValueTask ReloadAsync(CancellationToken cancellationToken) => SendMessage(ReloadMessage, cancellationToken);
 
         public ValueTask SendWaitMessageAsync(CancellationToken cancellationToken) => SendMessage(WaitMessage, cancellationToken);
+
+        private static async Task<bool> ShouldUseHttps()
+        {
+            try
+            {
+                using var process = Process.Start(DotnetMuxer.MuxerPath, "dev-certs https -c");
+                await process.WaitForExitAsync().WaitAsync(TimeSpan.FromSeconds(10));
+                return process.ExitCode == 0;
+            }
+            catch
+            {
+                return false;
+            }
+        }
     }
 }

--- a/src/BuiltInTools/dotnet-watch/HotReload/ScopedCssFileHandler.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/ScopedCssFileHandler.cs
@@ -5,18 +5,18 @@ using System;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.Watcher.Internal;
+using Microsoft.Extensions.Tools.Internal;
 
 namespace Microsoft.DotNet.Watcher.Tools
 {
     internal sealed class ScopedCssFileHandler
     {
-        private static readonly string _muxerPath = new Muxer().MuxerPath;
+        private static readonly string _muxerPath = DotnetMuxer.MuxerPath;
         private readonly ProcessRunner _processRunner;
-        private readonly Extensions.Tools.Internal.IReporter _reporter;
+        private readonly IReporter _reporter;
 
-        public ScopedCssFileHandler(ProcessRunner processRunner, Extensions.Tools.Internal.IReporter reporter)
+        public ScopedCssFileHandler(ProcessRunner processRunner, IReporter reporter)
         {
             _processRunner = processRunner;
             _reporter = reporter;

--- a/src/BuiltInTools/dotnet-watch/HotReloadDotNetWatcher.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReloadDotNetWatcher.cs
@@ -209,7 +209,7 @@ namespace Microsoft.DotNet.Watcher
             var rootVariableName = Environment.Is64BitProcess ? "DOTNET_ROOT" : "DOTNET_ROOT(x86)";
             if (string.IsNullOrEmpty(Environment.GetEnvironmentVariable(rootVariableName)))
             {
-                processSpec.EnvironmentVariables[rootVariableName] = Path.GetDirectoryName(new Muxer().MuxerPath);
+                processSpec.EnvironmentVariables[rootVariableName] = Path.GetDirectoryName(DotnetMuxer.MuxerPath);
             }
 
             if (context.DefaultLaunchSettingsProfile.EnvironmentVariables is IDictionary<string, string> envVariables)

--- a/src/BuiltInTools/dotnet-watch/Internal/DotnetMuxer.cs
+++ b/src/BuiltInTools/dotnet-watch/Internal/DotnetMuxer.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.DotNet.Cli.Utils;
+
+namespace Microsoft.DotNet.Watcher.Tools
+{
+    internal static class DotnetMuxer
+    {
+        public static string MuxerPath { get; } = new Muxer().MuxerPath;
+    }
+}

--- a/src/BuiltInTools/dotnet-watch/Program.cs
+++ b/src/BuiltInTools/dotnet-watch/Program.cs
@@ -10,12 +10,10 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.Watcher.Internal;
 using Microsoft.DotNet.Watcher.Tools;
 using Microsoft.Extensions.Tools.Internal;
 using IConsole = Microsoft.Extensions.Tools.Internal.IConsole;
-using IReporter = Microsoft.Extensions.Tools.Internal.IReporter;
 using Resources = Microsoft.DotNet.Watcher.Tools.Resources;
 
 namespace Microsoft.DotNet.Watcher
@@ -235,7 +233,7 @@ Examples:
                 trace: false);
             var processInfo = new ProcessSpec
             {
-                Executable = new Muxer().MuxerPath,
+                Executable = DotnetMuxer.MuxerPath,
                 WorkingDirectory = Path.GetDirectoryName(projectFile),
                 Arguments = args,
                 EnvironmentVariables =


### PR DESCRIPTION
If the dev-cert is available, host the WebSocket server over TLS

Fixes https://github.com/dotnet/aspnetcore/issues/31481