### PR TITLE
Mark source generator file as generated

### DIFF
--- a/src/RazorSdk/SourceGenerators/RazorSourceGenerator.cs
+++ b/src/RazorSdk/SourceGenerators/RazorSourceGenerator.cs
@@ -79,7 +79,7 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
 
             if (razorContext.CshtmlFiles.Count != 0)
             {
-                context.AddSource($"{context.Compilation.AssemblyName}.UnifiedAssembly.Info", ProvideApplicationPartFactoryAttributeSourceText);
+                context.AddSource($"{context.Compilation.AssemblyName}.UnifiedAssembly.Info.g", ProvideApplicationPartFactoryAttributeSourceText);
             }
 
             RazorGenerateForSourceTexts(razorContext.CshtmlFiles, context, projectEngine);

--- a/src/RazorSdk/SourceGenerators/RazorSourceGenerator.cs
+++ b/src/RazorSdk/SourceGenerators/RazorSourceGenerator.cs
@@ -79,7 +79,7 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
 
             if (razorContext.CshtmlFiles.Count != 0)
             {
-                context.AddSource($"{context.Compilation.AssemblyName}.UnifiedAssembly.Info.g", ProvideApplicationPartFactoryAttributeSourceText);
+                context.AddSource($"{context.Compilation.AssemblyName}.UnifiedAssembly.Info.g.cs", ProvideApplicationPartFactoryAttributeSourceText);
             }
 
             RazorGenerateForSourceTexts(razorContext.CshtmlFiles, context, projectEngine);


### PR DESCRIPTION
Give the output file for the `ProvideApplicationPartFactoryAttribute` a `.g` suffix so that it is treated as a generated file to prevent it being flagged by source analyzers for violations the application developer cannot fix themselves. See reactiveui/refit#1067 for a similar fix.

Otherwise an application using a package such as [StyleCop.Analyzers](https://www.nuget.org/packages/StyleCop.Analyzers) can receive warnings/errors for the code emitted by the source generator as it is not determined to have been generated by tooling and to be user code.

For example, using `6.0.100-preview.3.21202.5` of the SDK errors such as the following are emitted;

```
C:\Coding\martincostello\api\src\API\Microsoft.NET.Sdk.Razor.SourceGenerators\Microsoft.NET.Sdk.Razor.SourceGenerators.RazorSourceGenerator\API.UnifiedAssembly.Info.cs(1,221): error SA1518: File is required to end with a single newline character [C:\Coding\martincostello\api\src\API\API.csproj]
C:\Coding\martincostello\api\src\API\Microsoft.NET.Sdk.Razor.SourceGenerators\Microsoft.NET.Sdk.Razor.SourceGenerators.RazorSourceGenerator\API.UnifiedAssembly.Info.cs(1,1): error SA1633: The file header is missing or not located at the top of the file. [C:\Coding\martincostello\api\src\API\API.csproj]
```

I wasn't sure of the best way to add a unit test for this, or how to go about validating this locally.