### PR TITLE
Fixing the parsing to handle the zip deploy status

### DIFF
--- a/src/WebSdk/Publish/Tasks/Tasks/ZipDeploy/CreateZipFile.cs
+++ b/src/WebSdk/Publish/Tasks/Tasks/ZipDeploy/CreateZipFile.cs
@@ -22,7 +22,7 @@ namespace Microsoft.NET.Sdk.Publish.Tasks.ZipDeploy
 
         public override bool Execute()
         {
-            string zipFileName = ProjectName + " - " + DateTime.Now.ToString("yyyyMMddHHmmssFFF") + ".zip";
+            string zipFileName = ProjectName + "-" + DateTime.Now.ToString("yyyyMMddHHmmssFFF") + ".zip";
             CreatedZipPath = Path.Combine(PublishIntermediateTempPath, zipFileName);
             ZipFile.CreateFromDirectory(FolderToZip, CreatedZipPath);
             return true;

--- a/src/WebSdk/Publish/Tasks/Tasks/ZipDeploy/ZipDeploymentStatus.cs
+++ b/src/WebSdk/Publish/Tasks/Tasks/ZipDeploy/ZipDeploymentStatus.cs
@@ -64,14 +64,14 @@ namespace Microsoft.NET.Sdk.Publish.Tasks.ZipDeploy
 
         private async Task<DeployStatus> GetDeploymentStatusAsync(string deploymentUrl, string userName, string password, int retryCount, TimeSpan retryDelay, CancellationTokenSource cts)
         {
-            Dictionary<string, string> json = await InvokeGetRequestWithRetryAsync<Dictionary<string, string>>(deploymentUrl, userName, password, retryCount, retryDelay, cts);
-            string statusString = null;
-            if (json!= null && !json.TryGetValue("status", out statusString))
+            Dictionary<string, object> json = await InvokeGetRequestWithRetryAsync<Dictionary<string, object>>(deploymentUrl, userName, password, retryCount, retryDelay, cts);
+            object status = null;
+            if (json!= null && !json.TryGetValue("status", out status))
             {
                 return DeployStatus.Unknown;
             }
 
-            if (Enum.TryParse(statusString, out DeployStatus result))
+            if (status != null && Enum.TryParse(status.ToString(), out DeployStatus result))
             {
                 return result;
             }


### PR DESCRIPTION
- Currently Azure returns the status as a number instead of a string which causes the system text json parse to fail.
- Changing the return type to object to fix the issue. 