### PR TITLE
Add support for ARM32 & ARM64 as AvailablePlatforms

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -116,18 +116,11 @@ Copyright (c) .NET Foundation. All rights reserved.
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' and $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '2.1'))">
-    <AvailablePlatforms Condition="$([MSBuild]::IsOSPlatform('linux'))">$(AvailablePlatforms),ARM32</AvailablePlatforms>
+    <AvailablePlatforms>$(AvailablePlatforms),ARM32</AvailablePlatforms>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' and $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '3.1'))">
-    <AvailablePlatforms Condition="$([MSBuild]::IsOSPlatform('Windows'))">$(AvailablePlatforms),ARM32</AvailablePlatforms>
-    <AvailablePlatforms Condition="$([MSBuild]::IsOSPlatform('linux'))">$(AvailablePlatforms),ARM32,ARM64</AvailablePlatforms>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' and $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '5.0'))">
-    <!-- TODO: Check "Windows && Console" here. -->
-    <AvailablePlatforms Condition="$([MSBuild]::IsOSPlatform('Windows'))">$(AvailablePlatforms),ARM32,ARM64</AvailablePlatforms>
-    <AvailablePlatforms Condition="$([MSBuild]::IsOSPlatform('linux'))">$(AvailablePlatforms),ARM32,ARM64</AvailablePlatforms>
+    <AvailablePlatforms>$(AvailablePlatforms),ARM64</AvailablePlatforms>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -115,6 +115,21 @@ Copyright (c) .NET Foundation. All rights reserved.
                   ('$(TargetFrameworkIdentifier)' == '.NETStandard' and '$(_TargetFrameworkVersionWithoutV)' >= '2.1'))">true</EmbeddedResourceUseDependentUponConvention>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' and '$(_TargetFrameworkVersionWithoutV)' >= '2.1'">
+    <AvailablePlatforms Condition="$([MSBuild]::IsOSPlatform('linux'))">$(AvailablePlatforms),ARM32</AvailablePlatforms>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' and '$(_TargetFrameworkVersionWithoutV)' >= '3.1'">
+    <AvailablePlatforms Condition="$([MSBuild]::IsOSPlatform('Windows'))">$(AvailablePlatforms),ARM32</AvailablePlatforms>
+    <AvailablePlatforms Condition="$([MSBuild]::IsOSPlatform('linux'))">$(AvailablePlatforms),ARM32,ARM64</AvailablePlatforms>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' and '$(_TargetFrameworkVersionWithoutV)' >= '5.0'">
+    <!-- Need to check console and windows here. -->
+    <AvailablePlatforms Condition="$([MSBuild]::IsOSPlatform('Windows'))">$(AvailablePlatforms),ARM32,ARM64</AvailablePlatforms>
+    <AvailablePlatforms Condition="$([MSBuild]::IsOSPlatform('linux'))">$(AvailablePlatforms),ARM32,ARM64</AvailablePlatforms>
+  </PropertyGroup>
+
   <PropertyGroup>
     <CoreBuildDependsOn>
       _CheckForBuildWithNoBuild;

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -115,17 +115,17 @@ Copyright (c) .NET Foundation. All rights reserved.
                   ('$(TargetFrameworkIdentifier)' == '.NETStandard' and '$(_TargetFrameworkVersionWithoutV)' >= '2.1'))">true</EmbeddedResourceUseDependentUponConvention>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' and '$(_TargetFrameworkVersionWithoutV)' >= '2.1'">
+  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' and $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '2.1'))">
     <AvailablePlatforms Condition="$([MSBuild]::IsOSPlatform('linux'))">$(AvailablePlatforms),ARM32</AvailablePlatforms>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' and '$(_TargetFrameworkVersionWithoutV)' >= '3.1'">
+  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' and $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '3.1'))">
     <AvailablePlatforms Condition="$([MSBuild]::IsOSPlatform('Windows'))">$(AvailablePlatforms),ARM32</AvailablePlatforms>
     <AvailablePlatforms Condition="$([MSBuild]::IsOSPlatform('linux'))">$(AvailablePlatforms),ARM32,ARM64</AvailablePlatforms>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' and '$(_TargetFrameworkVersionWithoutV)' >= '5.0'">
-    <!-- Need to check console and windows here. -->
+  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' and $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '5.0'))">
+    <!-- TODO: Check "Windows && Console" here. -->
     <AvailablePlatforms Condition="$([MSBuild]::IsOSPlatform('Windows'))">$(AvailablePlatforms),ARM32,ARM64</AvailablePlatforms>
     <AvailablePlatforms Condition="$([MSBuild]::IsOSPlatform('linux'))">$(AvailablePlatforms),ARM32,ARM64</AvailablePlatforms>
   </PropertyGroup>


### PR DESCRIPTION
Fixes https://github.com/dotnet/msbuild/issues/5951

### Context
.NET 5 is adding support for Windows ARM64. Visual Studio .NET Core projects should allow you target ARM64 in addition to x86/x64/arm32.

This is planned to be based off of the `AvailablePlatforms` property.

### Changes Made
In Microsoft.NET.Sdk.targets, added conditional propertygroups based on `TargetFrameworkIdentifier` and `TargetFrameworkVersion` to add ARM32/64 as a platform.

### Testing
Needs https://github.com/dotnet/project-system/issues/7081 to account for `AvailablePlatforms` so we can see it in the Platform Target dropdown under project properties.

### Notes
What we're trying to apply ARM to:
| Version | Windows | Linux | macOS
| --- | --- | --- | ---
| [.NET Core 2.1](https://github.com/dotnet/core/blob/master/release-notes/2.1/2.1-supported-os.md) | x86, x64 | x86, x64, arm32 | x64
| [.NET Core 3.1](https://github.com/dotnet/core/blob/master/release-notes/3.1/3.1-supported-os.md) | x86, x64, arm32 | x86, x64, arm32, arm64 | x64
| [.NET 5](https://github.com/dotnet/core/blob/master/release-notes/5.0/5.0-supported-os.md) | x86, x64, arm64 (console only) | x86, x64, arm32, arm64 | x64

### Todo
- [x] Find the "correct" location to place these propertygroups.