### PR TITLE
Apply deltas to Blazor WebAssembly on app start

### DIFF
--- a/src/BuiltInTools/BrowserRefresh/BlazorHotReload.js
+++ b/src/BuiltInTools/BrowserRefresh/BlazorHotReload.js
@@ -1,0 +1,18 @@
+export function receiveHotReload() {
+  return BINDING.js_to_mono_obj(new Promise((resolve) => receiveHotReloadAsync().then(resolve(0))));
+}
+
+async function receiveHotReloadAsync() {
+  const cache = window.sessionStorage.getItem('blazor-webassembly-cache');
+  let headers;
+  if (cache) {
+    headers = { 'if-none-match' : cache.etag };
+  }
+  const response = await fetch('_framework/blazor-hotreload', { headers });
+  if (response.status === 200) {
+    const deltas = await response.json();
+    if (deltas) {
+      deltas.forEach(d => window.Blazor._internal.applyHotReload(d.moduleId, d.metadataDelta, d.ilDelta));
+    }
+  }
+}

--- a/src/BuiltInTools/BrowserRefresh/BlazorWasmHotReloadMiddleware.cs
+++ b/src/BuiltInTools/BrowserRefresh/BlazorWasmHotReloadMiddleware.cs
@@ -1,0 +1,140 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Net.Http.Headers;
+
+namespace Microsoft.AspNetCore.Watch.BrowserRefresh
+{
+    /// <summary>
+    /// A middleware that manages receiving and sending deltas from a BlazorWebAssembly app.
+    /// This assembly is shared between Visual Studio and dotnet-watch. By putting some of the complexity
+    /// in here, we can avoid duplicating work in watch and VS.
+    /// </summary>
+    internal sealed class BlazorWasmHotReloadMiddleware
+    {
+        private readonly object @lock = new();
+        private readonly string EtagDiscriminator = Guid.NewGuid().ToString();
+        private readonly JsonSerializerOptions _jsonSerializerOptions = new()
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        };
+
+        public BlazorWasmHotReloadMiddleware(RequestDelegate next)
+        {
+        }
+
+        internal List<UpdateDelta> Deltas { get; } = new();
+
+        public Task InvokeAsync(HttpContext context)
+        {
+            // Multiple instances of the BlazorWebAssembly app could be running (multiple tabs or multiple browsers).
+            // We want to avoid serialize reads and writes between then
+            lock (@lock)
+            {
+                if (HttpMethods.IsGet(context.Request.Method))
+                {
+                    return OnGet(context);
+                }
+                else if (HttpMethods.IsPost(context.Request.Method))
+                {
+                    return OnPost(context);
+                }
+                else
+                {
+                    context.Response.StatusCode = StatusCodes.Status405MethodNotAllowed;
+                    return Task.CompletedTask;
+                }
+            }
+
+            // Don't call next(). This middleware is terminal.
+        }
+
+        private async Task OnGet(HttpContext context)
+        {
+            if (Deltas.Count == 0)
+            {
+                context.Response.StatusCode = StatusCodes.Status204NoContent;
+                return;
+            }
+
+            if (EtagMatches(context))
+            {
+                context.Response.StatusCode = StatusCodes.Status304NotModified;
+                return;
+            }
+
+            WriteETag(context);
+            await JsonSerializer.SerializeAsync(context.Response.Body, Deltas, _jsonSerializerOptions);
+        }
+
+        private bool EtagMatches(HttpContext context)
+        {
+            if (context.Request.Headers[HeaderNames.IfNoneMatch] is not { Count: 1 } ifNoneMatch)
+            {
+                return false;
+            }
+
+            var expected = GetETag();
+            return string.Equals(expected, ifNoneMatch[0], StringComparison.Ordinal);
+        }
+
+        private async Task OnPost(HttpContext context)
+        {
+            var updateDeltas = await JsonSerializer.DeserializeAsync<UpdateDelta[]>(context.Request.Body, _jsonSerializerOptions);
+            AppendDeltas(updateDeltas);
+
+            WriteETag(context);
+        }
+
+        private void WriteETag(HttpContext context)
+        {
+            var etag = GetETag();
+            if (etag is not null)
+            {
+                context.Response.Headers[HeaderNames.ETag] = etag;
+            }
+        }
+
+        private string? GetETag()
+        {
+            if (Deltas.Count == 0)
+            {
+                return null;
+            }
+
+            return string.Format(CultureInfo.InvariantCulture, "W/\"{0}{1}\"", EtagDiscriminator, Deltas[^1].SequenceId);
+        }
+
+        private void AppendDeltas(UpdateDelta[] updateDeltas)
+        {
+            if (updateDeltas.Length == 0)
+            {
+                return;
+            }
+
+            // It's possible that multiple instances of the BlazorWasm are simultaneously executing and could be posting the same deltas
+            // We'll use the sequence id to ensure that we're not recording duplicate entries. Replaying duplicated values would cause
+            // ApplyDelta to fail.
+            // It's currently not possible to receive different ranges of sequences from different clients (for e.g client 1 sends deltas 1 - 3,
+            // and client 2 sends deltas 2 - 4, client 3 sends 1 - 5 etc), so we only need to verify that the first item in the sequence has not already been seen.
+            if (Deltas.Count == 0 || Deltas[^1].SequenceId < updateDeltas[0].SequenceId)
+            {
+                Deltas.AddRange(updateDeltas);
+            }
+        }
+
+        internal class UpdateDelta
+        {
+            public int SequenceId { get; set; }
+            public string ModuleId { get; set; } = default!;
+            public string MetadataDelta { get; set; } = default!;
+            public string ILDelta { get; set; } = default!;
+        }
+    }
+}

--- a/src/BuiltInTools/BrowserRefresh/BrowserScriptMiddleware.cs
+++ b/src/BuiltInTools/BrowserRefresh/BrowserScriptMiddleware.cs
@@ -19,14 +19,9 @@ namespace Microsoft.AspNetCore.Watch.BrowserRefresh
         private readonly byte[] _scriptBytes;
         private readonly string _contentLength;
 
-        public BrowserScriptMiddleware(RequestDelegate next)
-            : this(Environment.GetEnvironmentVariable("ASPNETCORE_AUTO_RELOAD_WS_ENDPOINT")!)
+        public BrowserScriptMiddleware(RequestDelegate next, byte[] scriptBytes)
         {
-        }
-
-        internal BrowserScriptMiddleware(string webSocketUrl)
-        {
-            _scriptBytes = GetWebSocketClientJavaScript(webSocketUrl);
+            _scriptBytes = scriptBytes;
             _contentLength = _scriptBytes.Length.ToString(CultureInfo.InvariantCulture);
         }
 
@@ -38,6 +33,19 @@ namespace Microsoft.AspNetCore.Watch.BrowserRefresh
 
             await context.Response.Body.WriteAsync(_scriptBytes.AsMemory(), context.RequestAborted);
         }
+
+        internal static byte[] GetBlazorHotReloadJS()
+        {
+            var jsFileName = "Microsoft.AspNetCore.Watch.BrowserRefresh.BlazorHotReload.js";
+            using var stream = new MemoryStream();
+            var manifestStream = typeof(WebSocketScriptInjection).Assembly.GetManifestResourceStream(jsFileName)!;
+            manifestStream.CopyTo(stream);
+
+            return stream.ToArray();
+        }
+
+        internal static byte[] GetBrowserRefreshJS()
+            => GetWebSocketClientJavaScript(Environment.GetEnvironmentVariable("ASPNETCORE_AUTO_RELOAD_WS_ENDPOINT")!);
 
         internal static byte[] GetWebSocketClientJavaScript(string hostString)
         {

--- a/src/BuiltInTools/BrowserRefresh/HostingStartup.cs
+++ b/src/BuiltInTools/BrowserRefresh/HostingStartup.cs
@@ -23,14 +23,22 @@ namespace Microsoft.AspNetCore.Watch.BrowserRefresh
         {
             return app =>
             {
-                app.Map("/_framework/clear-browser-cache", app1 => app1.Run(context =>
+                app.Map(Urls.ClearSiteData, app1 => app1.Run(context =>
                 {
                     // Scoped css files can contain links to other css files. We'll try clearing out the http caches to force the browser to re-download.
                     // See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Clear-Site-Data#directives
-                    context.Response.Headers["Clear-site-data"] = "\"cache\"";
+                    context.Response.Headers["Clear-Site-Data"] = "\"cache\"";
                     return Task.CompletedTask;
                 }));
-                app.Map(WebSocketScriptInjection.WebSocketScriptUrl, app1 => app1.UseMiddleware<BrowserScriptMiddleware>());
+
+                app.Map(Urls.BlazorHotReloadMiddleware, app1 => app1.UseMiddleware<BlazorWasmHotReloadMiddleware>());
+
+                app.Map(Urls.BrowserRefreshJS,
+                    app1 => app1.UseMiddleware<BrowserScriptMiddleware>(BrowserScriptMiddleware.GetBrowserRefreshJS()));
+
+                app.Map(Urls.BlazorHotReloadJS,
+                    app1 => app1.UseMiddleware<BrowserScriptMiddleware>(BrowserScriptMiddleware.GetBlazorHotReloadJS()));
+
                 app.UseMiddleware<BrowserRefreshMiddleware>();
                 next(app);
             };

--- a/src/BuiltInTools/BrowserRefresh/Microsoft.AspNetCore.Watch.BrowserRefresh.csproj
+++ b/src/BuiltInTools/BrowserRefresh/Microsoft.AspNetCore.Watch.BrowserRefresh.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <EmbeddedResource Include="WebSocketScriptInjection.js" />
+    <EmbeddedResource Include="BlazorHotReload.js" />
   </ItemGroup>
 
 </Project>

--- a/src/BuiltInTools/BrowserRefresh/Urls.cs
+++ b/src/BuiltInTools/BrowserRefresh/Urls.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore.Http;
+
+namespace Microsoft.AspNetCore.Watch.BrowserRefresh
+{
+    internal static class Urls
+    {
+        /// <summary>
+        /// An endpoint that responds with cache-clearing headers. See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Clear-Site-Data#directives.
+        /// </summary>
+        /// <value><c>/_framework/clear-browser-cache</c></value>
+        public static PathString ClearSiteData { get; } = "/_framework/clear-browser-cache";
+
+        /// <summary>
+        /// Returns a JS file that handles browser refresh and showing notifications.
+        /// </summary>
+        /// <value><c>/_framework/aspnetcore-browser-refresh.js</c></value>
+        public static PathString BrowserRefreshJS { get; } = "/_framework/aspnetcore-browser-refresh.js";
+
+        /// <summary>
+        /// Hosts a middleware that can cache deltas sent by dotnet-watch.
+        /// </summary>
+        /// <value><c>/_framework/blazor-hotreload</c></value>
+        public static PathString BlazorHotReloadMiddleware { get; } = "/_framework/blazor-hotreload";
+
+        /// <summary>
+        /// Returns a JS file imported by BlazorWebAssembly as part of it's initialization. Contains
+        /// scripts to apply deltas on app start.
+        /// </summary>
+        /// <value>/_framework/blazor-hotreload.js</value>
+        public static PathString BlazorHotReloadJS { get; } = "/_framework/blazor-hotreload.js";
+    }
+}

--- a/src/BuiltInTools/BrowserRefresh/WebSocketScriptInjection.cs
+++ b/src/BuiltInTools/BrowserRefresh/WebSocketScriptInjection.cs
@@ -16,11 +16,10 @@ namespace Microsoft.AspNetCore.Watch.BrowserRefresh
     public static class WebSocketScriptInjection
     {
         private const string BodyMarker = "</body>";
-        internal const string WebSocketScriptUrl = "/_framework/aspnetcore-browser-refresh.js";
 
         private static readonly byte[] _bodyBytes = Encoding.UTF8.GetBytes(BodyMarker);
 
-        internal static string InjectedScript { get; } = $"<script src=\"{WebSocketScriptUrl}\"></script>";
+        internal static string InjectedScript { get; } = $"<script src=\"{Urls.BrowserRefreshJS}\"></script>";
 
         private static readonly byte[] _injectedScriptBytes = Encoding.UTF8.GetBytes(InjectedScript);
 

--- a/src/BuiltInTools/BrowserRefresh/WebSocketScriptInjection.js
+++ b/src/BuiltInTools/BrowserRefresh/WebSocketScriptInjection.js
@@ -47,11 +47,11 @@ setTimeout(function () {
 
   function updateStaticFile(path) {
     if (path && path.endsWith('.css')) {
-        updateCssByPath(path);
+      updateCssByPath(path);
     } else {
-        console.debug(`File change detected to css file ${path}. Reloading page...`);
-        location.reload();
-        return;
+      console.debug(`File change detected to css file ${path}. Reloading page...`);
+      location.reload();
+      return;
     }
   }
 
@@ -99,6 +99,11 @@ setTimeout(function () {
 
   function applyBlazorDeltas(deltas) {
     deltas.forEach(d => window.Blazor._internal.applyHotReload(d.moduleId, d.metadataDelta, d.ilDelta));
+    fetch('_framework/blazor-hotreload', { method: 'post', headers: { 'content-type': 'application/json' }, body: JSON.stringify(deltas) })
+      .then(response => {
+        const etag = response.headers['etag'];
+        window.sessionStorage.setItem('blazor-webasssembly-cache', { etag, deltas });
+      });
     notifyHotReloadApplied();
   }
 
@@ -108,25 +113,25 @@ setTimeout(function () {
     el.id = 'dotnet-compile-error';
     el.setAttribute('style', 'z-index:1000000; position:fixed; top: 0; left: 0; right: 0; bottom: 0; background-color: rgba(0,0,0,0.5); color:black');
     diagnostics.forEach(error => {
-        const item = el.appendChild(document.createElement('div'));
-        item.setAttribute('style', 'border: 2px solid red; padding: 8px; background-color: #faa;')
-        const message = item.appendChild(document.createElement('div'));
-        message.setAttribute('style', 'font-weight: bold');
-        message.textContent = error.Message;
-        item.appendChild(document.createElement('div')).textContent = error;
+      const item = el.appendChild(document.createElement('div'));
+      item.setAttribute('style', 'border: 2px solid red; padding: 8px; background-color: #faa;')
+      const message = item.appendChild(document.createElement('div'));
+      message.setAttribute('style', 'font-weight: bold');
+      message.textContent = error.Message;
+      item.appendChild(document.createElement('div')).textContent = error;
     });
   }
 
   function notifyHotReloadApplied() {
-      document.querySelectorAll('#dotnet-compile-error').forEach(el => el.remove());
-      if (document.querySelector('#dotnet-hotreload-toast')) {
-        return;
-      }
-      const el = document.createElement('div');
-      el.id = 'dotnet-hotreload-toast';
-      el.setAttribute('style', 'z-index:1000000; width:100%; height: 30px; font-size: large; text-align:center; position:fixed; top: 0; left: 0; right: 0; bottom: 0; background-color: rgba(0,0,0,0.5); color:black; transition: 0.5s all ease-in-out;');
-      el.textContent = 'Updated the page';
-      document.body.appendChild(el);
-      setTimeout(() => el.remove(), 520);
+    document.querySelectorAll('#dotnet-compile-error').forEach(el => el.remove());
+    if (document.querySelector('#dotnet-hotreload-toast')) {
+      return;
+    }
+    const el = document.createElement('div');
+    el.id = 'dotnet-hotreload-toast';
+    el.setAttribute('style', 'z-index:1000000; width:100%; height: 30px; font-size: large; text-align:center; position:fixed; top: 0; left: 0; right: 0; bottom: 0; background-color: rgba(0,0,0,0.5); color:black; transition: 0.5s all ease-in-out;');
+    el.textContent = 'Updated the page';
+    document.body.appendChild(el);
+    setTimeout(() => el.remove(), 520);
   }
 }, 500);

--- a/src/BuiltInTools/BrowserRefresh/WebSocketScriptInjection.js
+++ b/src/BuiltInTools/BrowserRefresh/WebSocketScriptInjection.js
@@ -101,8 +101,10 @@ setTimeout(function () {
     deltas.forEach(d => window.Blazor._internal.applyHotReload(d.moduleId, d.metadataDelta, d.ilDelta));
     fetch('_framework/blazor-hotreload', { method: 'post', headers: { 'content-type': 'application/json' }, body: JSON.stringify(deltas) })
       .then(response => {
-        const etag = response.headers['etag'];
-        window.sessionStorage.setItem('blazor-webasssembly-cache', { etag, deltas });
+        if (response.status == 200) {
+          const etag = response.headers['etag'];
+          window.sessionStorage.setItem('blazor-webasssembly-cache', { etag, deltas });
+        }
       });
     notifyHotReloadApplied();
   }

--- a/src/BuiltInTools/dotnet-watch/HotReload/BlazorWebAssemblyDeltaApplier.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/BlazorWebAssemblyDeltaApplier.cs
@@ -15,6 +15,7 @@ namespace Microsoft.DotNet.Watcher.Tools
     internal class BlazorWebAssemblyDeltaApplier : IDeltaApplier
     {
         private readonly IReporter _reporter;
+        private int _sequenceId;
 
         public BlazorWebAssemblyDeltaApplier(IReporter reporter)
         {
@@ -23,6 +24,8 @@ namespace Microsoft.DotNet.Watcher.Tools
 
         public ValueTask InitializeAsync(DotNetWatchContext context, CancellationToken cancellationToken)
         {
+            // Configure the app for EnC
+            context.ProcessSpec.EnvironmentVariables["DOTNET_MODIFIABLE_ASSEMBLIES"] = "debug";
             return default;
         }
 
@@ -38,6 +41,7 @@ namespace Microsoft.DotNet.Watcher.Tools
             {
                 Deltas = solutionUpdate.Select(c => new UpdateDelta
                 {
+                    SequenceId = _sequenceId++,
                     ModuleId = c.ModuleId,
                     MetadataDelta = c.MetadataDelta.ToArray(),
                     ILDelta = c.ILDelta.ToArray(),
@@ -75,6 +79,7 @@ namespace Microsoft.DotNet.Watcher.Tools
 
         private readonly struct UpdateDelta
         {
+            public int SequenceId { get; init; }
             public Guid ModuleId { get; init; }
             public byte[] MetadataDelta { get; init; }
             public byte[] ILDelta { get; init; }

--- a/src/Tests/Microsoft.AspNetCore.Watch.BrowserRefresh.Tests/BlazorWasmHotReloadMiddlewareTest.cs
+++ b/src/Tests/Microsoft.AspNetCore.Watch.BrowserRefresh.Tests/BlazorWasmHotReloadMiddlewareTest.cs
@@ -1,0 +1,330 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Net.Http.Headers;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Watch.BrowserRefresh
+{
+    public class BlazorWasmHotReloadMiddlewareTest
+    {
+        [Fact]
+        public async Task DeltasAreSavedOnPost()
+        {
+            // Arrange
+            var context = new DefaultHttpContext();
+            context.Request.Method = "post";
+            var deltas = new[]
+            {
+                new BlazorWasmHotReloadMiddleware.UpdateDelta
+                {
+                    SequenceId = 0,
+                    ModuleId = Guid.NewGuid().ToString(),
+                    ILDelta = "ILDelta1",
+                    MetadataDelta = "MetadataDelta1",
+                },
+                new BlazorWasmHotReloadMiddleware.UpdateDelta
+                {
+                    SequenceId = 1,
+                    ModuleId = Guid.NewGuid().ToString(),
+                    ILDelta = "ILDelta2",
+                    MetadataDelta = "MetadataDelta2",
+                }
+            };
+            context.Request.Body = GetJson(deltas);
+
+            var middleware = new BlazorWasmHotReloadMiddleware(context => throw new TimeZoneNotFoundException());
+
+            // Act
+            await middleware.InvokeAsync(context);
+
+            // Assert
+            AssertDeltas(deltas, middleware.Deltas);
+            Assert.NotEmpty(context.Response.Headers["ETag"]);
+        }
+
+        [Fact]
+        public async Task DuplicateDeltasOnPostAreIgnored()
+        {
+            // Arrange
+            var deltas = new[]
+            {
+                new BlazorWasmHotReloadMiddleware.UpdateDelta
+                {
+                    SequenceId = 0,
+                    ModuleId = Guid.NewGuid().ToString(),
+                    ILDelta = "ILDelta1",
+                    MetadataDelta = "MetadataDelta1",
+                },
+                new BlazorWasmHotReloadMiddleware.UpdateDelta
+                {
+                    SequenceId = 1,
+                    ModuleId = Guid.NewGuid().ToString(),
+                    ILDelta = "ILDelta2",
+                    MetadataDelta = "MetadataDelta2",
+                }
+            };
+            var context = new DefaultHttpContext();
+            context.Request.Method = "post";
+            context.Request.Body = GetJson(deltas);
+
+            var middleware = new BlazorWasmHotReloadMiddleware(context => throw new TimeZoneNotFoundException());
+
+            // Act 1
+            await middleware.InvokeAsync(context);
+
+            // Act 2
+            context = new DefaultHttpContext();
+            context.Request.Method = "post";
+            context.Request.Body = GetJson(deltas);
+            await middleware.InvokeAsync(context);
+
+            // Assert
+            AssertDeltas(deltas, middleware.Deltas);
+            Assert.NotEmpty(context.Response.Headers["ETag"]);
+        }
+
+        [Fact]
+        public async Task MultipleDeltaPayloadsCanBeAccepted()
+        {
+            // Arrange
+            var deltas = new List<BlazorWasmHotReloadMiddleware.UpdateDelta>
+            {
+                new BlazorWasmHotReloadMiddleware.UpdateDelta
+                {
+                    SequenceId = 0,
+                    ModuleId = Guid.NewGuid().ToString(),
+                    ILDelta = "ILDelta1",
+                    MetadataDelta = "MetadataDelta1",
+                },
+                new BlazorWasmHotReloadMiddleware.UpdateDelta
+                {
+                    SequenceId = 1,
+                    ModuleId = Guid.NewGuid().ToString(),
+                    ILDelta = "ILDelta2",
+                    MetadataDelta = "MetadataDelta2",
+                }
+            };
+            var context = new DefaultHttpContext();
+            context.Request.Method = "post";
+            context.Request.Body = GetJson(deltas);
+
+            var middleware = new BlazorWasmHotReloadMiddleware(context => throw new TimeZoneNotFoundException());
+
+            // Act 1
+            await middleware.InvokeAsync(context);
+
+            // Act 2
+            var newDeltas = new[]
+            {
+                new BlazorWasmHotReloadMiddleware.UpdateDelta
+                {
+                    SequenceId = 3,
+                    ModuleId = Guid.NewGuid().ToString(),
+                    ILDelta = "ILDelta3",
+                    MetadataDelta = "MetadataDelta3",
+                },
+                new BlazorWasmHotReloadMiddleware.UpdateDelta
+                {
+                    SequenceId = 4,
+                    ModuleId = Guid.NewGuid().ToString(),
+                    ILDelta = "ILDelta4",
+                    MetadataDelta = "MetadataDelta4",
+                },
+                    new BlazorWasmHotReloadMiddleware.UpdateDelta
+                {
+                    SequenceId = 5,
+                    ModuleId = Guid.NewGuid().ToString(),
+                    ILDelta = "ILDelta5",
+                    MetadataDelta = "MetadataDelta5",
+                },
+            };
+
+            context = new DefaultHttpContext();
+            context.Request.Method = "post";
+            context.Request.Body = GetJson(newDeltas);
+            await middleware.InvokeAsync(context);
+
+            // Assert
+            deltas.AddRange(newDeltas);
+            AssertDeltas(deltas, middleware.Deltas);
+            Assert.NotEmpty(context.Response.Headers["ETag"]);
+        }
+
+        [Fact]
+        public async Task Get_Returns204_IfNoDeltasPresent()
+        {
+            // Arrange
+            var context = new DefaultHttpContext();
+            context.Request.Method = "get";
+            var middleware = new BlazorWasmHotReloadMiddleware(context => throw new TimeZoneNotFoundException());
+
+            // Act
+            await middleware.InvokeAsync(context);
+
+            // Assert
+            Assert.Equal(204, context.Response.StatusCode);
+        }
+
+        [Fact]
+        public async Task GetReturnsDeltas()
+        {
+            // Arrange
+            var context = new DefaultHttpContext();
+            context.Request.Method = "get";
+            var stream = new MemoryStream();
+            context.Response.Body = stream;
+            var middleware = new BlazorWasmHotReloadMiddleware(context => throw new TimeZoneNotFoundException());
+            var deltas = new List<BlazorWasmHotReloadMiddleware.UpdateDelta>
+            {
+                new BlazorWasmHotReloadMiddleware.UpdateDelta
+                {
+                    SequenceId = 0,
+                    ModuleId = Guid.NewGuid().ToString(),
+                    ILDelta = "ILDelta1",
+                    MetadataDelta = "MetadataDelta1",
+                },
+                new BlazorWasmHotReloadMiddleware.UpdateDelta
+                {
+                    SequenceId = 1,
+                    ModuleId = Guid.NewGuid().ToString(),
+                    ILDelta = "ILDelta2",
+                    MetadataDelta = "MetadataDelta2",
+                }
+            };
+            middleware.Deltas.AddRange(deltas);
+
+            // Act
+            await middleware.InvokeAsync(context);
+
+            // Assert
+            Assert.Equal(200, context.Response.StatusCode);
+            Assert.Equal(
+                JsonSerializer.SerializeToUtf8Bytes(deltas, new JsonSerializerOptions(JsonSerializerDefaults.Web)),
+                stream.ToArray());
+            Assert.NotEmpty(context.Response.Headers[HeaderNames.ETag]);
+        }
+
+        [Fact]
+        public async Task GetReturnsNotModified_IfNoneMatchApplies()
+        {
+            // Arrange
+            var context = new DefaultHttpContext();
+            context.Request.Method = "get";
+            var middleware = new BlazorWasmHotReloadMiddleware(context => throw new TimeZoneNotFoundException());
+            var deltas = new List<BlazorWasmHotReloadMiddleware.UpdateDelta>
+            {
+                new BlazorWasmHotReloadMiddleware.UpdateDelta
+                {
+                    SequenceId = 0,
+                    ModuleId = Guid.NewGuid().ToString(),
+                    ILDelta = "ILDelta1",
+                    MetadataDelta = "MetadataDelta1",
+                },
+                new BlazorWasmHotReloadMiddleware.UpdateDelta
+                {
+                    SequenceId = 1,
+                    ModuleId = Guid.NewGuid().ToString(),
+                    ILDelta = "ILDelta2",
+                    MetadataDelta = "MetadataDelta2",
+                }
+            };
+            middleware.Deltas.AddRange(deltas);
+
+            // Act 1
+            await middleware.InvokeAsync(context);
+            var etag = context.Response.Headers[HeaderNames.ETag];
+
+            // Act 2
+            context = new DefaultHttpContext();
+            context.Request.Method = "get";
+            context.Request.Headers[HeaderNames.IfNoneMatch] = etag;
+
+            await middleware.InvokeAsync(context);
+
+            // Assert 2
+            Assert.Equal(StatusCodes.Status304NotModified, context.Response.StatusCode);
+        }
+
+        [Fact]
+        public async Task GetReturnsUpdatedResults_IfNoneMatchFails()
+        {
+            // Arrange
+            var context = new DefaultHttpContext();
+            context.Request.Method = "get";
+            var middleware = new BlazorWasmHotReloadMiddleware(context => throw new TimeZoneNotFoundException());
+            var deltas = new List<BlazorWasmHotReloadMiddleware.UpdateDelta>
+            {
+                new BlazorWasmHotReloadMiddleware.UpdateDelta
+                {
+                    SequenceId = 0,
+                    ModuleId = Guid.NewGuid().ToString(),
+                    ILDelta = "ILDelta1",
+                    MetadataDelta = "MetadataDelta1",
+                },
+                new BlazorWasmHotReloadMiddleware.UpdateDelta
+                {
+                    SequenceId = 1,
+                    ModuleId = Guid.NewGuid().ToString(),
+                    ILDelta = "ILDelta2",
+                    MetadataDelta = "MetadataDelta2",
+                }
+            };
+            middleware.Deltas.AddRange(deltas);
+
+            // Act 1
+            await middleware.InvokeAsync(context);
+            var etag = context.Response.Headers[HeaderNames.ETag];
+
+            // Act 2
+            var update = new BlazorWasmHotReloadMiddleware.UpdateDelta
+            {
+                SequenceId = 3,
+                ModuleId = Guid.NewGuid().ToString(),
+                ILDelta = "ILDelta3",
+                MetadataDelta = "MetadataDelta3",
+            };
+            deltas.Add(update);
+            middleware.Deltas.Add(update);
+            context = new DefaultHttpContext();
+            context.Request.Method = "get";
+            context.Request.Headers[HeaderNames.IfNoneMatch] = etag;
+            var stream = new MemoryStream();
+            context.Response.Body = stream;
+
+            await middleware.InvokeAsync(context);
+
+            // Assert 2
+            Assert.Equal(StatusCodes.Status200OK, context.Response.StatusCode);
+            Assert.Equal(
+                JsonSerializer.SerializeToUtf8Bytes(deltas, new JsonSerializerOptions(JsonSerializerDefaults.Web)),
+                stream.ToArray());
+            Assert.NotEqual(etag, context.Response.Headers[HeaderNames.ETag]);
+        }
+
+        private static void AssertDeltas(IReadOnlyList<BlazorWasmHotReloadMiddleware.UpdateDelta> expected, IReadOnlyList<BlazorWasmHotReloadMiddleware.UpdateDelta> actual)
+        {
+            Assert.Equal(expected.Count, actual.Count);
+
+            for (var i = 0; i < expected.Count; i++)
+            {
+                Assert.Equal(expected[i].ILDelta, actual[i].ILDelta);
+                Assert.Equal(expected[i].MetadataDelta, actual[i].MetadataDelta);
+                Assert.Equal(expected[i].ModuleId, actual[i].ModuleId);
+                Assert.Equal(expected[i].SequenceId, actual[i].SequenceId);
+            }
+        }
+
+        private Stream GetJson(IReadOnlyList<BlazorWasmHotReloadMiddleware.UpdateDelta> deltas)
+        {
+            var bytes = JsonSerializer.SerializeToUtf8Bytes(deltas, new JsonSerializerOptions(JsonSerializerDefaults.Web));
+            return new MemoryStream(bytes);
+        }
+    }
+}

--- a/src/Tests/Microsoft.AspNetCore.Watch.BrowserRefresh.Tests/BrowserScriptMiddlewareTest.cs
+++ b/src/Tests/Microsoft.AspNetCore.Watch.BrowserRefresh.Tests/BrowserScriptMiddlewareTest.cs
@@ -12,6 +12,8 @@ namespace Microsoft.AspNetCore.Watch.BrowserRefresh
 {
     public class BrowserScriptMiddlewareTest
     {
+        private readonly RequestDelegate _next = (context) => Task.CompletedTask;
+
         [Fact]
         public async Task InvokeAsync_ReturnsScript()
         {
@@ -19,7 +21,7 @@ namespace Microsoft.AspNetCore.Watch.BrowserRefresh
             var context = new DefaultHttpContext();
             var stream = new MemoryStream();
             context.Response.Body = stream;
-            var middleware = new BrowserScriptMiddleware("some-host");
+            var middleware = new BrowserScriptMiddleware(_next, BrowserScriptMiddleware.GetWebSocketClientJavaScript("some-host"));
 
             // Act
             await middleware.InvokeAsync(context);
@@ -37,7 +39,7 @@ namespace Microsoft.AspNetCore.Watch.BrowserRefresh
             // Arrange
             var context = new DefaultHttpContext();
             context.Response.Body = new MemoryStream();
-            var middleware = new BrowserScriptMiddleware("some-host");
+            var middleware = new BrowserScriptMiddleware(_next, BrowserScriptMiddleware.GetWebSocketClientJavaScript("some-host"));
 
             // Act
             await middleware.InvokeAsync(context);

--- a/src/Tests/Microsoft.AspNetCore.Watch.BrowserRefresh.Tests/HostingStartupTest.cs
+++ b/src/Tests/Microsoft.AspNetCore.Watch.BrowserRefresh.Tests/HostingStartupTest.cs
@@ -1,0 +1,136 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Watch.BrowserRefresh
+{
+    public class HostingStartupTest
+    {
+        [Fact]
+        public async Task ClearSiteDataWorks()
+        {
+            // Arrange
+            var requestDelegate = GetRequestDelegate();
+            var context = new DefaultHttpContext();
+            context.Request.Path = "/_framework/clear-browser-cache";
+
+            // Act
+            await requestDelegate(context);
+
+            // Assert
+            Assert.Equal(StatusCodes.Status200OK, context.Response.StatusCode);
+            Assert.Equal("\"cache\"", context.Response.Headers["Clear-Site-Data"]);
+        }
+
+        [Fact]
+        public async Task GetBlazorHotReloadMiddlewareWorks()
+        {
+            // Arrange
+            var requestDelegate = GetRequestDelegate();
+            var context = new DefaultHttpContext();
+            context.Request.Method = "GET";
+            context.Request.Path = "/_framework/blazor-hotreload";
+            context.Response.Body = new MemoryStream();
+
+            // Act
+            await requestDelegate(context);
+
+            // Assert
+            Assert.Equal(StatusCodes.Status204NoContent, context.Response.StatusCode);
+        }
+
+        [Fact]
+        public async Task PostBlazorHotReloadMiddlewareWorks()
+        {
+            // Arrange
+            var requestDelegate = GetRequestDelegate();
+            var context = new DefaultHttpContext();
+            context.Request.Path = "/_framework/blazor-hotreload";
+            context.Request.Method = "POST";
+            context.Request.Body = new MemoryStream(Encoding.UTF8.GetBytes("[]"));
+
+            // Act
+            await requestDelegate(context);
+
+            // Assert
+            Assert.Equal(StatusCodes.Status200OK, context.Response.StatusCode);
+        }
+
+        [Fact]
+        public async Task GetBlazorHotReloadJsWorks()
+        {
+            // Arrange
+            var requestDelegate = GetRequestDelegate();
+            var context = new DefaultHttpContext();
+            context.Request.Path = "/_framework/blazor-hotreload.js";
+            var responseBody = new MemoryStream();
+            context.Response.Body = responseBody;
+
+            // Act
+            await requestDelegate(context);
+
+            // Assert
+            Assert.Equal(StatusCodes.Status200OK, context.Response.StatusCode);
+            Assert.NotEmpty(responseBody.ToArray());
+        }
+
+        [Fact]
+        public async Task GetAspNetCoreBrowserRefreshWorks()
+        {
+            // Arrange
+            var requestDelegate = GetRequestDelegate();
+            var context = new DefaultHttpContext();
+            context.Request.Path = "/_framework/aspnetcore-browser-refresh.js";
+            var responseBody = new MemoryStream();
+            context.Response.Body = responseBody;
+
+            // Act
+            await requestDelegate(context);
+
+            // Assert
+            Assert.Equal(StatusCodes.Status200OK, context.Response.StatusCode);
+            Assert.NotEmpty(responseBody.ToArray());
+        }
+
+        [Fact]
+        public async Task GetUnknownUrlWorks()
+        {
+            // Arrange
+            var requestDelegate = GetRequestDelegate();
+            var context = new DefaultHttpContext();
+            context.Request.Path = "/someurl";
+
+            // Act
+            await requestDelegate(context);
+
+            // Assert
+            Assert.Equal(StatusCodes.Status418ImATeapot, context.Response.StatusCode);
+        }
+
+        private static RequestDelegate GetRequestDelegate()
+        {
+            var action = new HostingStartup().Configure(builder =>
+            {
+                builder.Run(context =>
+                {
+                    context.Response.StatusCode = StatusCodes.Status418ImATeapot;
+                    return Task.CompletedTask;
+                });
+            });
+
+            var serviceProvider = new ServiceCollection()
+                .AddLogging()
+                .BuildServiceProvider();
+            var builder = new ApplicationBuilder(serviceProvider);
+            action(builder);
+            return builder.Build();
+        }
+    }
+}


### PR DESCRIPTION
In Blazor WebAssembly, refreshing the browser causes the wasm app to be restarted and go out of sync with
where dotnet-watch thinks the app is at w.r.t what deltas have been applied. This PR introduces a way for
Blazor WASM to stash away these deltas and re-apply them when the app starts.

The implementation relies on the browser refresh middleware to stash and retrieve the deltas. Doing so has a few advantages
- we no longer have to concern ourselves with cross-origin requests
- the implementation can be much more easily shared with Visual Studio.

Corresponding Blazor Wasm PR: https://github.com/dotnet/aspnetcore/pull/31670