### PR TITLE
Handle SourceSpan.Undefined when producing diagnostics

### DIFF
--- a/src/RazorSdk/SourceGenerators/Diagnostics/RazorDiagnostics.cs
+++ b/src/RazorSdk/SourceGenerators/Diagnostics/RazorDiagnostics.cs
@@ -116,12 +116,24 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
                 isEnabledByDefault: true);
 
             var span = razorDiagnostic.Span;
-            var location = Location.Create(
-                span.FilePath,
-                span.AsTextSpan(),
-                new LinePositionSpan(
+
+            Location location;
+            if (span == SourceSpan.Undefined)
+            {
+                // TextSpan.Empty
+                location = Location.None;
+            }
+            else
+            {
+                var linePosition = new LinePositionSpan(
                     new LinePosition(span.LineIndex, span.CharacterIndex),
-                    new LinePosition(span.LineIndex, span.CharacterIndex + span.Length)));
+                    new LinePosition(span.LineIndex, span.CharacterIndex + span.Length));
+
+                location = Location.Create(
+                   span.FilePath,
+                   span.AsTextSpan(),
+                   linePosition);
+            }
 
             return Diagnostic.Create(descriptor, location);
         }

--- a/src/RazorSdk/SourceGenerators/Microsoft.NET.Sdk.Razor.SourceGenerators.csproj
+++ b/src/RazorSdk/SourceGenerators/Microsoft.NET.Sdk.Razor.SourceGenerators.csproj
@@ -12,9 +12,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(MicrosoftCodeAnalysisCSharpPackageVersion)" GeneratePathProperty="true" />
-    <PackageReference Include="Microsoft.AspNetCore.Razor.Language" Version="$(MicrosoftAspNetCoreRazorLanguageVersion)" PrivateAssets="all"/>
-    <PackageReference Include="Microsoft.CodeAnalysis.Razor" Version="$(MicrosoftCodeAnalysisRazorVersion)" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(MicrosoftCodeAnalysisCSharpPackageVersion)"/>
+    <PackageReference Include="Microsoft.CodeAnalysis.Razor" Version="$(MicrosoftCodeAnalysisRazorVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.Extensions" Version="$(MicrosoftAspNetCoreMvcRazorExtensionsPackageVersion)" GeneratePathProperty="true" />
   </ItemGroup>
 

--- a/src/Tests/Microsoft.NET.Sdk.Razor.SourceGenerators.Tests/Microsoft.NET.Sdk.Razor.SourceGenerators.Tests.csproj
+++ b/src/Tests/Microsoft.NET.Sdk.Razor.SourceGenerators.Tests/Microsoft.NET.Sdk.Razor.SourceGenerators.Tests.csproj
@@ -16,10 +16,8 @@
   <ItemGroup>
     <Compile Include="**\*.cs" Exclude="$(GlobalExclude)" />
   </ItemGroup>
-  
+
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(MicrosoftCodeAnalysisCSharpPackageVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Razor.Language" Version="$(MicrosoftAspNetCoreRazorLanguageVersion)"/>
     <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
     <PackageReference Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildFrameworkPackageVersion)" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildUtilitiesCorePackageVersion)" />

--- a/src/Tests/Microsoft.NET.Sdk.Razor.SourceGenerators.Tests/RazorDiagnosticTest.cs
+++ b/src/Tests/Microsoft.NET.Sdk.Razor.SourceGenerators.Tests/RazorDiagnosticTest.cs
@@ -1,0 +1,52 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.CodeAnalysis;
+using Xunit;
+
+namespace Microsoft.NET.Sdk.Razor.SourceGenerators
+{
+    public class RazorDiagnosticTest
+    {
+        [Fact]
+        public void AsDiagnostic_WithUndefinedSpanWorks()
+        {
+            // Arrange
+            var diagnostics = RazorDiagnostic.Create(new RazorDiagnosticDescriptor("RZC1001", () => "Some message", RazorDiagnosticSeverity.Error), SourceSpan.Undefined);
+
+            // Act
+            var csharpDiagnostic = diagnostics.AsDiagnostic();
+
+            // Assert
+            Assert.Equal("Some message", csharpDiagnostic.GetMessage());
+            Assert.Equal("RZC1001", csharpDiagnostic.Descriptor.Id);
+            Assert.Equal(DiagnosticSeverity.Error, csharpDiagnostic.Severity);
+            Assert.Equal(Location.None, csharpDiagnostic.Location);
+        }
+
+        [Fact]
+        public void AsDiagnostic_WithSpanWorks()
+        {
+            // Arrange
+            var span = new SourceSpan("some-file", 100, 1, 5, 10);
+            var diagnostics = RazorDiagnostic.Create(new RazorDiagnosticDescriptor("RZC1001", () => "Some message", RazorDiagnosticSeverity.Error), span);
+
+            // Act
+            var csharpDiagnostic = diagnostics.AsDiagnostic();
+
+            // Assert
+            Assert.Equal("Some message", csharpDiagnostic.GetMessage());
+            Assert.Equal("RZC1001", csharpDiagnostic.Descriptor.Id);
+            Assert.Equal(DiagnosticSeverity.Error, csharpDiagnostic.Severity);
+            Assert.Equal(100, csharpDiagnostic.Location.SourceSpan.Start);
+
+            var lineSpan = csharpDiagnostic.Location.GetLineSpan();
+            Assert.Equal("some-file", lineSpan.Path);
+            Assert.Equal(1, lineSpan.StartLinePosition.Line);
+            Assert.Equal(5, lineSpan.StartLinePosition.Character);
+            Assert.Equal(1, lineSpan.EndLinePosition.Line);
+            Assert.Equal(15, lineSpan.EndLinePosition.Character);
+        }
+    }
+}

--- a/src/Tests/Microsoft.NET.Sdk.Razor.SourceGenerators.Tests/SourceGeneratorProjectItemTest.cs
+++ b/src/Tests/Microsoft.NET.Sdk.Razor.SourceGenerators.Tests/SourceGeneratorProjectItemTest.cs
@@ -6,7 +6,7 @@ using Moq;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.CodeAnalysis;
 
-namespace Microsoft.NET.Sdk.Razor.SourceGenerators.Tests
+namespace Microsoft.NET.Sdk.Razor.SourceGenerators
 {
     public class SourceGeneratorProjectItemTest
     {

--- a/src/Tests/Microsoft.NET.Sdk.Razor.SourceGenerators.Tests/SourceTextSourceLineCollectionTest.cs
+++ b/src/Tests/Microsoft.NET.Sdk.Razor.SourceGenerators.Tests/SourceTextSourceLineCollectionTest.cs
@@ -8,7 +8,7 @@ using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Text;
 
-namespace Microsoft.NET.Sdk.Razor.SourceGenerators.Tests
+namespace Microsoft.NET.Sdk.Razor.SourceGenerators
 {
     public class SourceTextSourceLineCollectionTest
     {

--- a/src/Tests/Microsoft.NET.Sdk.Razor.SourceGenerators.Tests/TestAdditionalText.cs
+++ b/src/Tests/Microsoft.NET.Sdk.Razor.SourceGenerators.Tests/TestAdditionalText.cs
@@ -6,7 +6,7 @@ using System.Threading;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Text;
  
-namespace Microsoft.NET.Sdk.Razor.SourceGenerators.Tests
+namespace Microsoft.NET.Sdk.Razor.SourceGenerators
 {
     public sealed class TestAdditionalText : AdditionalText
     {


### PR DESCRIPTION
* Clean up project files a bit
* Change tests to be in a consistent namespace