### PR TITLE
Embed project.assets.json in binlog

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.PackageDependencyResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.PackageDependencyResolution.targets
@@ -60,6 +60,11 @@ Copyright (c) .NET Foundation. All rights reserved.
     <_NugetTargetMonikerAndRID Condition="'$(RuntimeIdentifier)' != ''">$(NuGetTargetMoniker)/$(RuntimeIdentifier)</_NugetTargetMonikerAndRID>
   </PropertyGroup>
 
+  <!-- Embed all project.assets.json files into the binary log when building with /bl -->
+  <ItemGroup>
+    <EmbedInBinlog Include="$(ProjectAssetsFile)" Condition="Exists('$(ProjectAssetsFile)') AND $(EmbedProjectAssetsFile) != false" />
+  </ItemGroup>
+
   <!--
     *************************************
     2. EXTERNAL PROPERTIES and ITEMS


### PR DESCRIPTION
We're thinking of adding a way to embed arbitrary files in the binlog.
See https://github.com/dotnet/msbuild/pull/6339

project.assets.json is commonly requested to be embedded. This would fix https://github.com/dotnet/msbuild/issues/3529

Binlog size does increase from 3.5 MB -> 5 MB, so we'll need to think perhaps about making it off by default.