### PR TITLE
Trim trailing white-space in all MSBuild SDKs' props/targets

### DIFF
--- a/src/Layout/redist/MSBuildImports/Current/Microsoft.Common.CrossTargeting.targets/ImportAfter/Microsoft.TestPlatform.CrossTargeting.targets
+++ b/src/Layout/redist/MSBuildImports/Current/Microsoft.Common.CrossTargeting.targets/ImportAfter/Microsoft.TestPlatform.CrossTargeting.targets
@@ -6,7 +6,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
           created a backup copy.  Incorrect changes to this file will make it
           impossible to load or build your projects from the command-line or the IDE.
 
-Copyright (c) .NET Foundation. All rights reserved. 
+Copyright (c) .NET Foundation. All rights reserved.
 ***********************************************************************************************
 -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
@@ -18,7 +18,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <!--
   ===================================================================================
                DispatchToInnerBuildsWithVSTestTarget
-                                       
+
      Builds this project with /t:$(InnerVSTestTargets) /p:TargetFramework=X for each
      value X in $(TargetFrameworks)
 

--- a/src/Layout/redist/MSBuildImports/Current/Microsoft.Common.targets/ImportAfter/Microsoft.TestPlatform.ImportAfter.targets
+++ b/src/Layout/redist/MSBuildImports/Current/Microsoft.Common.targets/ImportAfter/Microsoft.TestPlatform.ImportAfter.targets
@@ -6,7 +6,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
           created a backup copy.  Incorrect changes to this file will make it
           impossible to load or build your projects from the command-line or the IDE.
 
-Copyright (c) .NET Foundation. All rights reserved. 
+Copyright (c) .NET Foundation. All rights reserved.
 ***********************************************************************************************
 -->
 

--- a/src/Layout/redist/MSBuildImports/Current/SolutionFile/ImportAfter/Microsoft.NuGet.ImportAfter.targets
+++ b/src/Layout/redist/MSBuildImports/Current/SolutionFile/ImportAfter/Microsoft.NuGet.ImportAfter.targets
@@ -6,7 +6,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
           created a backup copy.  Incorrect changes to this file will make it
           impossible to load or build your projects from the command-line or the IDE.
 
-Copyright (c) .NET Foundation. All rights reserved. 
+Copyright (c) .NET Foundation. All rights reserved.
 ***********************************************************************************************
 -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">

--- a/src/Tasks/Common/targets/Microsoft.NET.DefaultPackageConflictOverrides.targets
+++ b/src/Tasks/Common/targets/Microsoft.NET.DefaultPackageConflictOverrides.targets
@@ -6,7 +6,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
           created a backup copy.  Incorrect changes to this file will make it
           impossible to load or build your projects from the command-line or the IDE.
 
-Copyright (c) .NET Foundation. All rights reserved. 
+Copyright (c) .NET Foundation. All rights reserved.
 ***********************************************************************************************
 -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">

--- a/src/Tasks/Microsoft.NET.Build.Extensions.Tasks/msbuildExtensions-ver/Microsoft.Common.targets/ImportAfter/Microsoft.NET.Build.Extensions.targets
+++ b/src/Tasks/Microsoft.NET.Build.Extensions.Tasks/msbuildExtensions-ver/Microsoft.Common.targets/ImportAfter/Microsoft.NET.Build.Extensions.targets
@@ -6,7 +6,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
           created a backup copy.  Incorrect changes to this file will make it
           impossible to load or build your projects from the command-line or the IDE.
 
-Copyright (c) .NET Foundation. All rights reserved. 
+Copyright (c) .NET Foundation. All rights reserved.
 ***********************************************************************************************
 -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">

--- a/src/Tasks/Microsoft.NET.Build.Extensions.Tasks/msbuildExtensions-ver/SolutionFile/ImportAfter/Microsoft.NET.Sdk.Solution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Extensions.Tasks/msbuildExtensions-ver/SolutionFile/ImportAfter/Microsoft.NET.Sdk.Solution.targets
@@ -12,7 +12,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <Import Project="$(MSBuildSDKsPath)\Microsoft.NET.Sdk\targets\Microsoft.NET.Sdk.Common.targets" />
-  
+
   <!--
   ============================================================
                               _CheckForSolutionLevelRuntimeIdentifier

--- a/src/Tasks/Microsoft.NET.Build.Extensions.Tasks/msbuildExtensions/Microsoft/Microsoft.NET.Build.Extensions/Microsoft.NET.Build.Extensions.ConflictResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Extensions.Tasks/msbuildExtensions/Microsoft/Microsoft.NET.Build.Extensions/Microsoft.NET.Build.Extensions.ConflictResolution.targets
@@ -6,7 +6,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
           created a backup copy.  Incorrect changes to this file will make it
           impossible to load or build your projects from the command-line or the IDE.
 
-Copyright (c) .NET Foundation. All rights reserved. 
+Copyright (c) .NET Foundation. All rights reserved.
 ***********************************************************************************************
 -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
@@ -14,13 +14,13 @@ Copyright (c) .NET Foundation. All rights reserved.
   <PropertyGroup Condition="'$(DisableHandlePackageFileConflicts)' != 'true'">
     <!-- Non-SDK using project.json or PackageReference, run after references are read from the lock/assets file -->
     <_HandlePackageFileConflictsAfter>ResolveNuGetPackageAssets</_HandlePackageFileConflictsAfter>
-    
+
     <!-- In case ResolveNuGetPackageAssets is not run (eg: packages.config), ensure we run before targets that consume references -->
     <_HandlePackageFileConflictsBefore>ResolveAssemblyReferences</_HandlePackageFileConflictsBefore>
   </PropertyGroup>
 
   <Import Project="Microsoft.NET.DefaultPackageConflictOverrides.targets" />
-  
+
   <UsingTask TaskName="ResolvePackageFileConflicts" AssemblyFile="$(MicrosoftNETBuildExtensionsTasksAssembly)" />
   <Target Name="_HandlePackageFileConflicts"
           BeforeTargets="$(_HandlePackageFileConflictsBefore)"
@@ -40,7 +40,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <!-- Replace Reference / ReferenceCopyLocalPaths with the filtered lists.
          We must remove all and include rather than just remove since removal is based
-         only on ItemSpec and duplicate ItemSpecs may exist with different metadata 
+         only on ItemSpec and duplicate ItemSpecs may exist with different metadata
          (eg: HintPath) -->
     <ItemGroup>
       <Reference Remove="@(Reference)" />

--- a/src/Tasks/Microsoft.NET.Build.Extensions.Tasks/msbuildExtensions/Microsoft/Microsoft.NET.Build.Extensions/Microsoft.NET.Build.Extensions.NETFramework.targets
+++ b/src/Tasks/Microsoft.NET.Build.Extensions.Tasks/msbuildExtensions/Microsoft/Microsoft.NET.Build.Extensions/Microsoft.NET.Build.Extensions.NETFramework.targets
@@ -110,7 +110,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
       <_UpdatedReference Remove="@(_UpdatedReference)" />
     </ItemGroup>
-    
+
     <!-- Facade assemblies should override simple name references.  However, we want to preserve custom metadata
          on those simple name references (for example for aliases).  That's what this task does. -->
     <AddFacadesToReferences References="@(Reference)"
@@ -131,7 +131,7 @@ Copyright (c) .NET Foundation. All rights reserved.
        4.0.0.0.  However, with the fix to dotnet/sdk#2221, ResolveAssemblyReference now sees a conflicting version for
        the assembly, and suggests a redirect to 4.0.3.0.  With automatic binding redirection, this overrides the redirect
        to 4.0.0.0, which causes a runtime failure.
-       
+
        So here we disable any suggested binding redirect for System.IO.Compression.ZipFile.  Assemblies in the unification
        table generally should not need binding redirects, so it should be OK to do this for 4.7.2 and forward, and on 4.7.1
        the assembly isn't in the unification table so this allows the original workaround redirect to be preserved. -->
@@ -142,7 +142,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ItemGroup>
       <SuggestedBindingRedirects Remove="System.IO.Compression.ZipFile, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
     </ItemGroup>
-    
+
   </Target>
-  
+
 </Project>

--- a/src/Tasks/Microsoft.NET.Build.Extensions.Tasks/msbuildExtensions/Microsoft/Microsoft.NET.Build.Extensions/Microsoft.NET.Build.Extensions.targets
+++ b/src/Tasks/Microsoft.NET.Build.Extensions.Tasks/msbuildExtensions/Microsoft/Microsoft.NET.Build.Extensions/Microsoft.NET.Build.Extensions.targets
@@ -6,7 +6,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
           created a backup copy.  Incorrect changes to this file will make it
           impossible to load or build your projects from the command-line or the IDE.
 
-Copyright (c) .NET Foundation. All rights reserved. 
+Copyright (c) .NET Foundation. All rights reserved.
 ***********************************************************************************************
 -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">

--- a/src/Tasks/Microsoft.NET.Build.Tasks/sdk/Sdk.AfterCommon.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/sdk/Sdk.AfterCommon.targets
@@ -6,7 +6,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
           created a backup copy.  Incorrect changes to this file will make it
           impossible to load or build your projects from the command-line or the IDE.
 
-Copyright (c) .NET Foundation. All rights reserved. 
+Copyright (c) .NET Foundation. All rights reserved.
 ***********************************************************************************************
 -->
 <Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/sdk/Sdk.BeforeCommon.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/sdk/Sdk.BeforeCommon.targets
@@ -6,7 +6,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
           created a backup copy.  Incorrect changes to this file will make it
           impossible to load or build your projects from the command-line or the IDE.
 
-Copyright (c) .NET Foundation. All rights reserved. 
+Copyright (c) .NET Foundation. All rights reserved.
 ***********************************************************************************************
 -->
 <Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/sdk/Sdk.NuGet.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/sdk/Sdk.NuGet.targets
@@ -6,7 +6,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
           created a backup copy.  Incorrect changes to this file will make it
           impossible to load or build your projects from the command-line or the IDE.
 
-Copyright (c) .NET Foundation. All rights reserved. 
+Copyright (c) .NET Foundation. All rights reserved.
 ***********************************************************************************************
 -->
 <Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/sdk/Sdk.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/sdk/Sdk.props
@@ -6,7 +6,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
           created a backup copy.  Incorrect changes to this file will make it
           impossible to load or build your projects from the command-line or the IDE.
 
-Copyright (c) .NET Foundation. All rights reserved. 
+Copyright (c) .NET Foundation. All rights reserved.
 ***********************************************************************************************
 -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
@@ -38,5 +38,5 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <Import Project="$(AlternateCommonProps)" Condition="'$(AlternateCommonProps)' != ''" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="'$(AlternateCommonProps)' == ''"/>
-  <Import Project="$(MSBuildThisFileDirectory)..\targets\Microsoft.NET.Sdk.props"  />  
+  <Import Project="$(MSBuildThisFileDirectory)..\targets\Microsoft.NET.Sdk.props"  />
 </Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/sdk/Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/sdk/Sdk.targets
@@ -6,7 +6,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
           created a backup copy.  Incorrect changes to this file will make it
           impossible to load or build your projects from the command-line or the IDE.
 
-Copyright (c) .NET Foundation. All rights reserved. 
+Copyright (c) .NET Foundation. All rights reserved.
 ***********************************************************************************************
 -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
@@ -15,7 +15,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <PropertyGroup Condition="'$(TargetFrameworks)' != '' and '$(TargetFramework)' == ''">
     <IsCrossTargetingBuild>true</IsCrossTargetingBuild>
   </PropertyGroup>
-  
+
   <Import Project="$(MSBuildThisFileDirectory)..\targets\Microsoft.NET.Sdk.BeforeCommonCrossTargeting.targets"
           Condition="'$(IsCrossTargetingBuild)' == 'true'"/>
   <Import Project="$(MSBuildThisFileDirectory)..\targets\Microsoft.NET.Sdk.BeforeCommon.targets"
@@ -32,22 +32,22 @@ Copyright (c) .NET Foundation. All rights reserved.
     <LanguageTargets Condition="'$(LanguageTargets)' == ''">$(MSBuildToolsPath)\Microsoft.Common.targets</LanguageTargets>
   </PropertyGroup>
 
-  <!-- REMARK: Dont remove/rename, the LanguageTargets property is used by F# to hook inside the project's sdk 
+  <!-- REMARK: Dont remove/rename, the LanguageTargets property is used by F# to hook inside the project's sdk
                using Sdk attribute (from .NET Core Sdk 1.0.0-preview4) -->
   <Import Project="$(LanguageTargets)"/>
-  
+
   <Import Project="$(MSBuildThisFileDirectory)..\targets\Microsoft.NET.Sdk.CrossTargeting.targets"
           Condition="'$(IsCrossTargetingBuild)' == 'true'"/>
   <Import Project="$(MSBuildThisFileDirectory)..\targets\Microsoft.NET.Sdk.targets"
           Condition="'$(IsCrossTargetingBuild)' != 'true'"/>
-  
+
   <!-- Import targets from NuGet.Build.Tasks.Pack package/Sdk -->
   <PropertyGroup Condition="'$(NuGetBuildTasksPackTargets)' == '' AND '$(ImportNuGetBuildTasksPackTargetsFromSdk)' != 'false'">
     <NuGetBuildTasksPackTargets Condition="'$(IsCrossTargetingBuild)' == 'true'">$(MSBuildThisFileDirectory)..\..\NuGet.Build.Tasks.Pack\buildCrossTargeting\NuGet.Build.Tasks.Pack.targets</NuGetBuildTasksPackTargets>
     <NuGetBuildTasksPackTargets Condition="'$(IsCrossTargetingBuild)' != 'true'">$(MSBuildThisFileDirectory)..\..\NuGet.Build.Tasks.Pack\build\NuGet.Build.Tasks.Pack.targets</NuGetBuildTasksPackTargets>
     <ImportNuGetBuildTasksPackTargetsFromSdk>true</ImportNuGetBuildTasksPackTargetsFromSdk>
   </PropertyGroup>
-  
+
   <Import Project="$(NuGetBuildTasksPackTargets)"
-          Condition="Exists('$(NuGetBuildTasksPackTargets)') AND '$(ImportNuGetBuildTasksPackTargetsFromSdk)' == 'true'"/>  
+          Condition="Exists('$(NuGetBuildTasksPackTargets)') AND '$(ImportNuGetBuildTasksPackTargetsFromSdk)' == 'true'"/>
 </Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/GenerateDeps/GenerateDeps.proj
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/GenerateDeps/GenerateDeps.proj
@@ -7,21 +7,21 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
           created a backup copy.  Incorrect changes to this file will make it
           impossible to load or build your projects from the command-line or the IDE.
 
-Copyright (c) .NET Foundation. All rights reserved. 
+Copyright (c) .NET Foundation. All rights reserved.
 ***********************************************************************************************
 -->
-  
+
   <!--
     This project is built by the .NET CLI in order to create .deps.json files for .NET CLI tools.
     Properties to be passed in by the .NET CLI:
       - ProjectAssetsFile: Full path to the project.assets.json file for the tool under the NuGet .tools folder
       - ToolName: The simple name of the tool DLL, for example, "dotnet-mytool"
       - AdditionalImport: The full path to the .props file from the platform package which will be imported, which
-        should include the PackageConflictPlatformManifests file.      
+        should include the PackageConflictPlatformManifests file.
         This is a workaround until NuGet can generate .props and .targets files for imports from packages referenced
         by tools, which is tracked by https://github.com/NuGet/Home/issues/5037.
   -->
-  
+
   <PropertyGroup>
     <ImportDirectoryBuildProps>false</ImportDirectoryBuildProps>
     <ImportDirectoryBuildTargets>false</ImportDirectoryBuildTargets>
@@ -31,7 +31,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <Import Project="$(AdditionalImport)"
           Condition=" '$(AdditionalImport)' != '' And Exists($(AdditionalImport))" />
-  
+
   <PropertyGroup>
     <ToolFolder>$([System.IO.Path]::GetDirectoryName($(ProjectAssetsFile)))</ToolFolder>
     <ProjectDepsFilePath Condition="'$(ProjectDepsFilePath)' == ''">$(ToolFolder)\$(ToolName).deps.json</ProjectDepsFilePath>
@@ -46,7 +46,7 @@ Copyright (c) .NET Foundation. All rights reserved.
          the version of that package will be determined by the version the tool package references.  However, when building
          GenerateDeps.proj, the CLI sets the TargetFramework to match the target it finds in the assets file, which is
          based on what the project with the DotNetCliToolReference was targeting, not what the tool itself was targeting.
-         
+
          So we need to disable the logic which checks that the version of Microsoft.NETCore.App from the assets file
          matches the one that would be resolved based on the TargetFramework that was passed in. -->
     <VerifyMatchingImplicitPackageVersion>false</VerifyMatchingImplicitPackageVersion>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ClickOnce.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ClickOnce.targets
@@ -6,7 +6,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
           created a backup copy.  Incorrect changes to this file will make it
           impossible to load or build your projects from the command-line or the IDE.
 
-Copyright (c) .NET Foundation. All rights reserved. 
+Copyright (c) .NET Foundation. All rights reserved.
 ***********************************************************************************************
 -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
@@ -18,8 +18,8 @@ Copyright (c) .NET Foundation. All rights reserved.
     <PublishProtocolProviderTargets>ClickOncePublish</PublishProtocolProviderTargets>
   </PropertyGroup>
 
-  <!-- 
-    .NET Core ClickOnce manifest generation needs to run after this list of targets so that all 
+  <!--
+    .NET Core ClickOnce manifest generation needs to run after this list of targets so that all
     json files are generated and files to publish are computed.
   -->
   <PropertyGroup>
@@ -33,7 +33,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     </DeploymentComputeClickOnceManifestInfoDependsOn>
   </PropertyGroup>
 
-  <Target Name="GetNetCoreRuntimeJsonFilesForClickOnce" 
+  <Target Name="GetNetCoreRuntimeJsonFilesForClickOnce"
           Condition="'$(GenerateDependencyFile)' == 'true'">
 
     <!-- Get correct deps json files based on _UseBuildDependencyFile -->
@@ -50,9 +50,9 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ItemGroup>
        <NetCoreRuntimeJsonFilesForClickOnce Include="@(ProjectRuntimeConfigFilesForClickOnce);@(ProjectDepsFilesForClickOnce)"/>
     </ItemGroup>
-  </Target>  
+  </Target>
 
-  <!-- 
+  <!--
     Add necessary clickonce targets that need to run during publish process.
     These targets are defined in MS.Common.CurrentVersion.targets in the msbuild repo.
   -->

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ComposeStore.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ComposeStore.targets
@@ -6,7 +6,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
           created a backup copy.  Incorrect changes to this file will make it
           impossible to load or build your projects from the command-line or the IDE.
 
-Copyright (c) .NET Foundation. All rights reserved. 
+Copyright (c) .NET Foundation. All rights reserved.
 ***********************************************************************************************
 -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
@@ -14,7 +14,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <!--
     ============================================================
                                         ComposeStore
- 
+
     The main store entry point.
     ============================================================
     -->
@@ -32,9 +32,9 @@ Copyright (c) .NET Foundation. All rights reserved.
    Processes the store project files
     ============================================================
     -->
-  
+
   <Target Name="StoreWorkerMain">
-    
+
     <ItemGroup>
       <_AllProjects Include="$(AdditionalProjects.Split('%3B'))"/>
       <_AllProjects Include ="$(MSBuildProjectFullPath)"/>
@@ -96,8 +96,8 @@ Copyright (c) .NET Foundation. All rights reserved.
                  Targets="RestoreForComposeStore"
                  BuildInParallel="$(BuildInParallel)">
     </MSBuild>
-    
-    
+
+
 <!-- Resolve phase-->
     <MSBuild Projects="@(PackageReferencesToStore)"
                  Targets="StoreResolver"
@@ -111,7 +111,7 @@ Copyright (c) .NET Foundation. All rights reserved.
           Returns="@(ResolvedPackagesPublished)"
           DependsOnTargets="PrepforRestoreForComposeStore;
                             StoreWorkerPerformWork"/>
-  
+
   <Target Name="StoreWorkerPerformWork"
           DependsOnTargets="ComputeAndCopyFilesToStoreDirectory;"
           Condition="Exists($(StoreWorkerWorkingDir))" />
@@ -132,7 +132,7 @@ Copyright (c) .NET Foundation. All rights reserved.
          InputPackageReferences="@(AllResolvedPackagesPublished)">
       <Output TaskParameter="UniquePackageReferences"  ItemName="AllResolvedPackagesPublishedAfterFilter"/>
     </RemoveDuplicatePackageReferences>
-    
+
     <ItemGroup>
       <ListOfPackageReference Include="@(AllResolvedPackagesPublishedAfterFilter -> '%20%20&lt;Package Id=&quot;%(Identity)&quot; Version=&quot;%(Version)&quot; /&gt;')"/>
     </ItemGroup>
@@ -196,7 +196,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       <Output TaskParameter="DestinationFiles" ItemName="FileWrites"/>
     </Copy>
   </Target>
-  
+
   <!--
     ============================================================
                                         PrepareForComposeStore
@@ -204,7 +204,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     Prepare the prerequisites for ComposeStore.
     ============================================================
     -->
-  
+
   <Target Name="PrepareForComposeStore">
 
     <PropertyGroup>
@@ -223,7 +223,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <NETSdkError Condition="'$(_TFM)' ==''"
                  ResourceName="AtLeastOneTargetFrameworkMustBeSpecified"/>
-      
+
     <PropertyGroup>
       <DefaultComposeDir>$(UserProfileRuntimeStorePath)</DefaultComposeDir>
 
@@ -249,7 +249,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       <!-- Ensure any PublishDir has a trailing slash, so it can be concatenated -->
       <PublishDir Condition="!HasTrailingSlash('$(PublishDir)')">$(PublishDir)\</PublishDir>
     </PropertyGroup>
-    
+
     <PropertyGroup Condition="'$(CreateProfilingSymbols)' == ''">
       <!-- There is no support for profiling symbols on OSX -->
       <CreateProfilingSymbols Condition="$(RuntimeIdentifier.StartsWith('osx'))">false</CreateProfilingSymbols>
@@ -275,13 +275,13 @@ Copyright (c) .NET Foundation. All rights reserved.
       <BaseIntermediateOutputPath>$(StoreWorkerWorkingDir)\</BaseIntermediateOutputPath>
       <ProjectAssetsFile>$(BaseIntermediateOutputPath)\project.assets.json</ProjectAssetsFile>
     </PropertyGroup>
-    
+
     <PropertyGroup>
       <PackagesToPrune>$(MicrosoftNETPlatformLibrary)</PackagesToPrune>
       <SelfContained Condition="'$(SelfContained)' == ''">true</SelfContained>
     </PropertyGroup>
   </Target>
-  
+
   <!--
     ============================================================
                                         RestoreForComposeStore
@@ -289,13 +289,13 @@ Copyright (c) .NET Foundation. All rights reserved.
     Restores the package
     ============================================================
     -->
-  
+
   <Target Name="RestoreForComposeStore"
           DependsOnTargets="PrepforRestoreForComposeStore;"
           Condition="!Exists($(StoreWorkerWorkingDir))">
-    
+
     <MakeDir Directories="$(StoreWorkerWorkingDir)" />
-    
+
     <MSBuild Projects="$(MSBuildProjectFullPath)"
                  Targets="Restore"
                  Properties="RestoreGraphProjectInput=$(MSBuildProjectFullPath);
@@ -313,7 +313,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     Computes the list of all files to copy to the publish directory and then publishes them.
     ============================================================
     -->
-  
+
   <Target Name="ComputeAndCopyFilesToStoreDirectory"
           DependsOnTargets="ComputeFilesToStore;
                             CopyFilesToStoreDirectory" />
@@ -325,11 +325,11 @@ Copyright (c) .NET Foundation. All rights reserved.
     Copy all build outputs, satellites and other necessary files to the publish directory.
     ============================================================
     -->
-  
+
   <Target Name="CopyFilesToStoreDirectory"
           DependsOnTargets="_CopyResolvedUnOptimizedFiles"/>
-  
-  
+
+
   <!--
     ============================================================
                                         _CopyResolvedUnOptimizedFiles
@@ -337,7 +337,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     Copy _UnOptimizedResolvedFileToPublish items to the publish directory.
     ============================================================
     -->
-  
+
   <Target Name="_CopyResolvedUnOptimizedFiles"
           DependsOnTargets="_ComputeResolvedFilesToStoreTypes;
                             _RunOptimizer">
@@ -359,7 +359,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                                         _ComputeResolvedFilesToStoreTypes
     ============================================================
     -->
-  
+
   <Target Name="_ComputeResolvedFilesToStoreTypes"
            DependsOnTargets="_GetResolvedFilesToStore;_SplitResolvedFiles;" />
 
@@ -370,7 +370,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     Splits ResolvedFileToPublish items into 'managed' and 'unmanaged' buckets.
     ============================================================
     -->
-  
+
   <Target Name="_SplitResolvedFiles"
            Condition="$(SkipOptimization) !='true' "
            DependsOnTargets="_GetResolvedFilesToStore">
@@ -392,7 +392,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                                         _GetResolvedFilesToStore
     ============================================================
     -->
-  
+
   <Target Name="_GetResolvedFilesToStore"
            Condition="$(SkipOptimization) == 'true' ">
     <ItemGroup>
@@ -431,12 +431,12 @@ Copyright (c) .NET Foundation. All rights reserved.
       <ResolvedPackagesPublished Include="@(PackagesThatWereResolved)"
                                  Condition="$(DoNotTrackPackageAsResolved) !='true'"/>
     </ItemGroup>
-    
+
   </Target>
 
   <!--
     ============================================================
-                                       PrepRestoreForStoreProjects 
+                                       PrepRestoreForStoreProjects
 
     Removes specified PackageReference for store and inserts the specified StorePackageName
     ============================================================
@@ -444,7 +444,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <Target Name="PrepRestoreForStoreProjects"
           BeforeTargets="_GenerateProjectRestoreGraphPerFramework;"
           Condition="'$(StorePackageName)' != ''" >
-    
+
     <ItemGroup>
       <PackageReference Remove="@(PackageReference)" Condition="'%(PackageReference.IsImplicitlyDefined)' != 'true'"/>
       <PackageReference Include="$(StorePackageName)" Version="$(StorePackageVersion)"/>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ConflictResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ConflictResolution.targets
@@ -6,7 +6,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
           created a backup copy.  Incorrect changes to this file will make it
           impossible to load or build your projects from the command-line or the IDE.
 
-Copyright (c) .NET Foundation. All rights reserved. 
+Copyright (c) .NET Foundation. All rights reserved.
 ***********************************************************************************************
 -->
 
@@ -50,7 +50,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <!-- Replace Reference / ReferenceCopyLocalPaths with the filtered lists.
          We must remove all and include rather than just remove since removal is based
-         only on ItemSpec and duplicate ItemSpecs may exist with different metadata 
+         only on ItemSpec and duplicate ItemSpecs may exist with different metadata
          (eg: HintPath) -->
     <ItemGroup>
       <Reference Remove="@(Reference)" />

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.CrossGen.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.CrossGen.targets
@@ -6,7 +6,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
           created a backup copy.  Incorrect changes to this file will make it
           impossible to load or build your projects from the command-line or the IDE.
 
-Copyright (c) .NET Foundation. All rights reserved. 
+Copyright (c) .NET Foundation. All rights reserved.
 ***********************************************************************************************
 -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
@@ -21,7 +21,7 @@ Copyright (c) .NET Foundation. All rights reserved.
         Crossgen
     ============================================================
     -->
-  
+
   <Target Name="PrepOptimizer"
           DependsOnTargets="_RestoreCrossgen;"
           Condition="$(SkipOptimization) != 'true' ">
@@ -79,12 +79,12 @@ Copyright (c) .NET Foundation. All rights reserved.
           UseSymboliclinksIfPossible="$(CreateSymbolicLinksForPublishFilesIfPossible)">
       <Output TaskParameter="DestinationFiles" ItemName="FileWrites"/>
     </Copy>
-    
+
     <PropertyGroup>
       <Crossgen>$([System.IO.Path]::GetFullPath($([System.IO.Path]::Combine($(_NetCoreRefDir), $([System.IO.Path]::GetFileName($(Crossgen)))))))</Crossgen>
     </PropertyGroup>
   </Target>
-  
+
   <!--
     ============================================================
                                         _RunOptimizer
@@ -92,7 +92,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     Start the optimization phase
     ============================================================
     -->
-  
+
   <Target Name="_RunOptimizer"
           DependsOnTargets="_InitializeBasicProps;
                             _ComputeResolvedFilesToStoreTypes;
@@ -115,7 +115,7 @@ Copyright (c) .NET Foundation. All rights reserved.
         </Properties>
       </AssembliestoCrossgen>
     </ItemGroup>
-    
+
     <!-- CrossGen the assemblies  -->
     <MSBuild Projects="@(AssembliestoCrossgen)"
                  Targets="RunCrossGen"
@@ -127,7 +127,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <!--
     ============================================================
                                         RunCrossGen
-    Target Encapsulating the crossgen command  
+    Target Encapsulating the crossgen command
     ============================================================
     -->
 
@@ -164,14 +164,14 @@ Copyright (c) .NET Foundation. All rights reserved.
     <MakeDir Directories="$(CrossgenProfilingSymbolsOutputDirectory)"
              Condition="'$(CreateProfilingSymbols)' == 'true' and Exists($(CrossgenOutputAssembly))" />
     <Exec Command="$(CrossgenExe) -nologo -readytorun -platform_assemblies_paths $(CrossgenPlatformAssembliesPath) -$(CreateProfilingSymbolsOptionName) $(CrossgenProfilingSymbolsOutputDirectory) $(CrossgenOutputAssembly)"
-          Condition="'$(CreateProfilingSymbols)' == 'true' and Exists($(CrossgenOutputAssembly))" 
+          Condition="'$(CreateProfilingSymbols)' == 'true' and Exists($(CrossgenOutputAssembly))"
           IgnoreStandardErrorWarningFormat="true" />
 
     <ItemGroup>
       <_ProfilingSymbols Include="$(CrossgenProfilingSymbolsOutputDirectory)\*"
                          Condition="'$(CreateProfilingSymbols)' == 'true'" />
     </ItemGroup>
-    
+
     <Copy SourceFiles="@(_ProfilingSymbols)"
           DestinationFolder="$(CrossgenSymbolsStagingDirectory)"
           Condition="'$(CreateProfilingSymbols)' == 'true'"
@@ -188,14 +188,14 @@ Copyright (c) .NET Foundation. All rights reserved.
       <DirectorySeparatorChar>$([System.IO.Path]::DirectorySeparatorChar)</DirectorySeparatorChar>
     </PropertyGroup>
   </Target>
-  
+
   <!--
     ============================================================
                                        _GetCrossgenProps
     Generates props used by Crossgen
     ============================================================
     -->
-  
+
   <Target Name="_GetCrossgenProps"
     Condition="$(SkipOptimization) != 'true' ">
 
@@ -208,7 +208,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       <_CrossProjAssetsFile>$([System.IO.Path]::Combine($(_CrossProjFileDir),  project.assets.json))</_CrossProjAssetsFile>
     </PropertyGroup>
 
-    
+
   </Target>
 
   <!--
@@ -216,7 +216,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                                         _SetupStageForCrossgen
     ============================================================
     -->
-  
+
   <Target Name="_SetupStageForCrossgen"
           DependsOnTargets="_GetCrossgenProps;">
     <PropertyGroup>
@@ -224,15 +224,15 @@ Copyright (c) .NET Foundation. All rights reserved.
       <_RuntimeOptimizedDir>$([System.IO.Path]::Combine($(StoreWorkerWorkingDir), "runtimopt"))</_RuntimeOptimizedDir>      <!-- optimized app managed assemblies in nuget cache layout -->
       <_RuntimeSymbolsDir>$([System.IO.Path]::Combine($(StoreWorkerWorkingDir), "runtimesymbols"))</_RuntimeSymbolsDir>
     </PropertyGroup>
-    
+
     <ItemGroup>
       <_ManagedResolvedFilesToOptimize Include="@(_ManagedResolvedFileToPublishCandidates)" />
     </ItemGroup>
-    
+
     <MakeDir Directories="$(_RuntimeOptimizedDir)"/>
     <MakeDir Directories="$(_RuntimeSymbolsDir)"
              Condition="'$(CreateProfilingSymbols)' == 'true'" />
-    
+
     <!-- Copy managed files to  a flat temp directory for passing it as ref -->
     <Copy SourceFiles = "@(_ManagedResolvedFilesToOptimize)"
           DestinationFolder="$(_RuntimeRefDir)"
@@ -253,7 +253,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     Restores netcoreapp and publishes it to a temp directory
     ============================================================
     -->
-  
+
   <Target Name="_RestoreCrossgen"
           DependsOnTargets="PrepforRestoreForComposeStore;
                            _SetupStageForCrossgen;
@@ -313,5 +313,5 @@ Copyright (c) .NET Foundation. All rights reserved.
       <Output TaskParameter="DestinationFiles" ItemName="FileWrites"/>
     </Copy>
   </Target>
- 
+
 </Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.DefaultAssemblyInfo.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.DefaultAssemblyInfo.targets
@@ -6,7 +6,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
           created a backup copy.  Incorrect changes to this file will make it
           impossible to load or build your projects from the command-line or the IDE.
 
-Copyright (c) .NET Foundation. All rights reserved. 
+Copyright (c) .NET Foundation. All rights reserved.
 ***********************************************************************************************
 -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.DefaultOutputPaths.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.DefaultOutputPaths.targets
@@ -6,7 +6,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
           created a backup copy.  Incorrect changes to this file will make it
           impossible to load or build your projects from the command-line or the IDE.
 
-Copyright (c) .NET Foundation. All rights reserved. 
+Copyright (c) .NET Foundation. All rights reserved.
 ***********************************************************************************************
 -->
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
@@ -15,19 +15,19 @@ Copyright (c) .NET Foundation. All rights reserved.
     Apply the same default output paths as Microsoft.Common.targets now since we're running before them,
     but need to adjust them and/or make decisions in terms of them.
 
-    Also note that common targets only set a default OutputPath if neither configuration nor 
-    platform were set by the user. This was used to validate that a valid configuration is passed, 
-    assuming the convention maintained by VS that every Configuration|Platform combination had 
-    an explicit OutputPath. Since we now want to support leaner project files with less 
+    Also note that common targets only set a default OutputPath if neither configuration nor
+    platform were set by the user. This was used to validate that a valid configuration is passed,
+    assuming the convention maintained by VS that every Configuration|Platform combination had
+    an explicit OutputPath. Since we now want to support leaner project files with less
     duplication and more automatic defaults, we always set a default OutputPath and can no
-    longer depend on that convention for validation. Getting validation re-enabled with a 
+    longer depend on that convention for validation. Getting validation re-enabled with a
     different mechanism is tracked by https://github.com/dotnet/sdk/issues/350
    -->
   <PropertyGroup>
     <Configuration Condition="'$(Configuration)'==''">Debug</Configuration>
     <Platform Condition="'$(Platform)'==''">AnyCPU</Platform>
     <PlatformName Condition="'$(PlatformName)' == ''">$(Platform)</PlatformName>
-    
+
     <BaseOutputPath Condition="'$(BaseOutputPath)' == ''">bin\</BaseOutputPath>
     <BaseOutputPath Condition="!HasTrailingSlash('$(BaseOutputPath)')">$(BaseOutputPath)\</BaseOutputPath>
     <OutputPath Condition="'$(OutputPath)' == '' and '$(PlatformName)' == 'AnyCPU'">$(BaseOutputPath)$(Configuration)\</OutputPath>
@@ -40,10 +40,10 @@ Copyright (c) .NET Foundation. All rights reserved.
     <IntermediateOutputPath Condition=" $(IntermediateOutputPath) == '' and '$(PlatformName)' != 'AnyCPU' ">$(BaseIntermediateOutputPath)$(PlatformName)\$(Configuration)\</IntermediateOutputPath>
     <IntermediateOutputPath Condition="!HasTrailingSlash('$(IntermediateOutputPath)')">$(IntermediateOutputPath)\</IntermediateOutputPath>
   </PropertyGroup>
-  
+
   <!-- Set the package output path (for nuget pack target) now, before the TargetFramework is appended -->
   <PropertyGroup>
     <PackageOutputPath Condition="'$(PackageOutputPath)' == ''">$(OutputPath)</PackageOutputPath>
   </PropertyGroup>
-  
+
 </Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.DesignerSupport.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.DesignerSupport.targets
@@ -6,7 +6,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
           created a backup copy.  Incorrect changes to this file will make it
           impossible to load or build your projects from the command-line or the IDE.
 
-Copyright (c) .NET Foundation. All rights reserved. 
+Copyright (c) .NET Foundation. All rights reserved.
 ***********************************************************************************************
 -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
@@ -44,14 +44,14 @@ Copyright (c) .NET Foundation. All rights reserved.
     Outputs="$(_DesignerDepsFilePath)"
     Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'"
     >
-    <!-- 
+    <!--
       NOTE: We do not include the main assembly info or non-NuGet dependencies
       in designer deps file as these files may not be built yet at design time.
       Instead, we rely on SetAppPaths in runtimeconfig to allow loading of
       non-NuGet assets from shadow copied app base directory. This further
-      allows loading of designer dll(s) that are not seen by the build. 
+      allows loading of designer dll(s) that are not seen by the build.
     -->
-    <GenerateDepsFile 
+    <GenerateDepsFile
       AssemblyName="_"
       AssemblyExtension="_"
       AssemblyVersion="_"
@@ -72,7 +72,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <ItemGroup>
       <!-- Designer will rename to <surface process name>.deps.json -->
-      <DesignerRuntimeImplementationProjectOutputGroupOutput 
+      <DesignerRuntimeImplementationProjectOutputGroupOutput
         Include="$([MSBuild]::NormalizePath($(_DesignerDepsFilePath)))"
         TargetPath="$(_DesignerDepsFileName)"
         />
@@ -91,11 +91,11 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ItemGroup>
       <_DesignerHostConfigurationOption
         Include="Microsoft.NETCore.DotNetHostPolicy.SetAppPaths"
-        Value="true" 
+        Value="true"
         />
     </ItemGroup>
 
-    <GenerateRuntimeConfigurationFiles 
+    <GenerateRuntimeConfigurationFiles
       AdditionalProbingPaths="@(AdditionalProbingPath)"
       AssetsFilePath="$(ProjectAssetsFile)"
       HostConfigurationOptions="@(RuntimeHostConfigurationOption);@(_DesignerHostConfigurationOption)"
@@ -111,7 +111,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <ItemGroup>
       <!-- Designer will rename to <surface process name>.runtimeconfig.json -->
-      <DesignerRuntimeImplementationProjectOutputGroupOutput 
+      <DesignerRuntimeImplementationProjectOutputGroupOutput
         Include="$([MSBuild]::NormalizePath($(_DesignerRuntimeConfigFilePath)))"
         TargetPath="$(_DesignerRuntimeConfigFileName)"
         />
@@ -134,7 +134,7 @@ Copyright (c) .NET Foundation. All rights reserved.
         Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'"
         />
 
-      <DesignerRuntimeImplementationProjectOutputGroupOutput 
+      <DesignerRuntimeImplementationProjectOutputGroupOutput
         Include="@(_DesignerShadowCopy->'%(FullPath)')"
         TargetPath="%(_DesignerShadowCopy.DestinationSubDirectory)%(_DesignerShadowCopy.Filename)%(_DesignerShadowCopy.Extension)"
         />

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.DisableStandardFrameworkResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.DisableStandardFrameworkResolution.targets
@@ -6,7 +6,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
           created a backup copy.  Incorrect changes to this file will make it
           impossible to load or build your projects from the command-line or the IDE.
 
-Copyright (c) .NET Foundation. All rights reserved. 
+Copyright (c) .NET Foundation. All rights reserved.
 ***********************************************************************************************
 -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.GenerateAssemblyInfo.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.GenerateAssemblyInfo.targets
@@ -6,7 +6,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
           created a backup copy.  Incorrect changes to this file will make it
           impossible to load or build your projects from the command-line or the IDE.
 
-Copyright (c) .NET Foundation. All rights reserved. 
+Copyright (c) .NET Foundation. All rights reserved.
 ***********************************************************************************************
 -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
@@ -39,11 +39,11 @@ Copyright (c) .NET Foundation. All rights reserved.
     <GenerateInternalsVisibleToAttributes Condition="'$(GenerateInternalsVisibleToAttributes)' == ''">true</GenerateInternalsVisibleToAttributes>
   </PropertyGroup>
 
-  <!-- 
+  <!--
     Note that this must run before every invocation of CoreCompile to ensure that all compiler
-    runs see the generated assembly info. There is at least one scenario involving Xaml 
+    runs see the generated assembly info. There is at least one scenario involving Xaml
     where CoreCompile is invoked without other potential hooks such as Compile or CoreBuild,
-    etc., so we hook directly on to CoreCompile. Furthermore, we  must run *after* 
+    etc., so we hook directly on to CoreCompile. Furthermore, we  must run *after*
     PrepareForBuild to ensure that the intermediate directory has been created.
 
     Targets that generate Compile items are also expected to run before
@@ -124,7 +124,7 @@ Copyright (c) .NET Foundation. All rights reserved.
         <_Parameter1>$(TargetPlatformIdentifier)$(TargetPlatformVersion)</_Parameter1>
       </AssemblyAttribute>
     </ItemGroup>
-    
+
     <ItemGroup Condition="'$(TargetPlatformIdentifier)' != ''
                          and '$(SupportedOSPlatformVersion)' != ''
                          and '$(TargetFrameworkIdentifier)' == '.NETCoreApp'
@@ -140,7 +140,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     </ItemGroup>
   </Target>
 
-  <!-- 
+  <!--
     To allow version changes to be respected on incremental builds (e.g. through CLI parameters),
     create a hash of all assembly attributes so that the cache file will change with the calculated
     assembly attribute values and msbuild will then execute CoreGenerateAssembly to generate a new file.
@@ -157,7 +157,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     </Hash>
 
     <WriteLinesToFile Lines="$(_AssemblyAttributesHash)" File="$(GeneratedAssemblyInfoInputsCacheFile)" Overwrite="True" WriteOnlyWhenDifferent="True" />
-    
+
     <ItemGroup>
       <FileWrites Include="$(GeneratedAssemblyInfoInputsCacheFile)" />
     </ItemGroup>
@@ -203,7 +203,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <GetAssemblyVersion Condition="'$(AssemblyVersion)' == ''" NuGetVersion="$(Version)">
       <Output TaskParameter="AssemblyVersion" PropertyName="AssemblyVersion" />
     </GetAssemblyVersion>
-    
+
     <PropertyGroup>
       <FileVersion Condition="'$(FileVersion)' == ''">$(AssemblyVersion)</FileVersion>
       <InformationalVersion Condition="'$(InformationalVersion)' == ''">$(Version)</InformationalVersion>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ILLink.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ILLink.targets
@@ -152,7 +152,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       <_ExtraTrimmerArgs>--skip-unresolved true $(_ExtraTrimmerArgs)</_ExtraTrimmerArgs>
       <TrimMode Condition=" '$(TrimMode)' == '' ">copyused</TrimMode>
     </PropertyGroup>
-    
+
     <PropertyGroup Condition=" '$(SuppressTrimAnalysisWarnings)' == 'true' ">
       <!-- RequiresUnreferenceCodeAttribute method called -->
       <NoWarn>$(NoWarn);IL2026</NoWarn>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.PackProjectTool.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.PackProjectTool.props
@@ -6,7 +6,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
           created a backup copy.  Incorrect changes to this file will make it
           impossible to load or build your projects from the command-line or the IDE.
 
-Copyright (c) .NET Foundation. All rights reserved. 
+Copyright (c) .NET Foundation. All rights reserved.
 ***********************************************************************************************
 -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.PackStubs.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.PackStubs.targets
@@ -6,7 +6,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
           created a backup copy.  Incorrect changes to this file will make it
           impossible to load or build your projects from the command-line or the IDE.
 
-Copyright (c) .NET Foundation. All rights reserved. 
+Copyright (c) .NET Foundation. All rights reserved.
 ***********************************************************************************************
 -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
@@ -14,7 +14,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <!--
     ============================================================
                                         Pack
- 
+
     Stub Pack target to surface better error message when not supported.
     ============================================================
     -->

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.PackTool.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.PackTool.props
@@ -6,7 +6,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
           created a backup copy.  Incorrect changes to this file will make it
           impossible to load or build your projects from the command-line or the IDE.
 
-Copyright (c) .NET Foundation. All rights reserved. 
+Copyright (c) .NET Foundation. All rights reserved.
 ***********************************************************************************************
 -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.PreserveCompilationContext.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.PreserveCompilationContext.targets
@@ -6,14 +6,14 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
           created a backup copy.  Incorrect changes to this file will make it
           impossible to load or build your projects from the command-line or the IDE.
 
-Copyright (c) .NET Foundation. All rights reserved. 
+Copyright (c) .NET Foundation. All rights reserved.
 ***********************************************************************************************
 -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
     <RefAssembliesFolderName Condition="'$(RefAssembliesFolderName)' == ''">refs</RefAssembliesFolderName>
-    
+
     <PreserveCompilationReferences Condition=" '$(PreserveCompilationReferences)' == ''">$(PreserveCompilationContext)</PreserveCompilationReferences>
   </PropertyGroup>
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -6,7 +6,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
           created a backup copy.  Incorrect changes to this file will make it
           impossible to load or build your projects from the command-line or the IDE.
 
-Copyright (c) .NET Foundation. All rights reserved. 
+Copyright (c) .NET Foundation. All rights reserved.
 ***********************************************************************************************
 -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
@@ -29,7 +29,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <!--
     ============================================================
                                         Publish
- 
+
     The main publish entry point.
     ============================================================
     -->
@@ -136,7 +136,7 @@ Copyright (c) .NET Foundation. All rights reserved.
           DependsOnTargets="_IncrementalCleanPublishDirectory;
                             _CopyResolvedFilesToPublishPreserveNewest;
                             _CopyResolvedFilesToPublishAlways" />
-  
+
   <!--
     ============================================================
                                         _IncrementalCleanPublishDirectory
@@ -158,12 +158,12 @@ Copyright (c) .NET Foundation. All rights reserved.
         TreatErrorsAsWarnings="true">
       <Output TaskParameter="DeletedFiles" ItemName="_OrphanFilesDeleted"/>
     </Delete>
-    
+
     <!-- Write new list of current files back to clean file. -->
     <WriteLinesToFile
         File="$(IntermediateOutputPath)$(_PublishCleanFile)"
-        Lines="@(_CurrentPublishFileWrites)" 
-        Overwrite="true"/>  
+        Lines="@(_CurrentPublishFileWrites)"
+        Overwrite="true"/>
   </Target>
 
   <!--
@@ -176,14 +176,14 @@ Copyright (c) .NET Foundation. All rights reserved.
     <PropertyGroup>
       <_NormalizedPublishDir>$([MSBuild]::NormalizeDirectory($(PublishDir)))</_NormalizedPublishDir>
     </PropertyGroup>
-    
+
     <Hash ItemstoHash="$(_NormalizedPublishDir)">
       <Output TaskParameter="HashResult" PropertyName="_NormalizedPublishDirHash" />
     </Hash>
     <PropertyGroup>
       <_PublishCleanFile Condition="'$(PublishCleanFile)'==''">PublishOutputs.$(_NormalizedPublishDirHash.Substring(0, 10)).txt</_PublishCleanFile>
     </PropertyGroup>
-    
+
     <!-- Read in writes made by prior publish. -->
     <ReadLinesFromFile File="$(IntermediateOutputPath)$(_PublishCleanFile)">
       <Output TaskParameter="Lines" ItemName="_UnfilteredPriorPublishFileWrites"/>
@@ -192,12 +192,12 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ConvertToAbsolutePath Paths="@(_UnfilteredPriorPublishFileWrites)">
       <Output TaskParameter="AbsolutePaths" ItemName="_UnfilteredAbsolutePriorPublishFileWrites"/>
     </ConvertToAbsolutePath>
-  
+
     <!-- Find all files in the final output directory. -->
     <FindUnderPath Path="$(_NormalizedPublishDir)" Files="@(_UnfilteredAbsolutePriorPublishFileWrites)" UpdateToAbsolutePaths="true">
       <Output TaskParameter="InPath" ItemName="_PriorPublishFileWritesInOuput"/>
     </FindUnderPath>
-    
+
     <!-- Remove duplicates from files produced in the previous publish. -->
     <RemoveDuplicates Inputs="@(_PriorPublishFileWritesInOuput)" >
       <Output TaskParameter="Filtered" ItemName="_PriorPublishFileWrites"/>
@@ -222,7 +222,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     ============================================================
                                         _CopyResolvedFilesToPublishPreserveNewest
 
-    Copy _ResolvedFileToPublishPreserveNewest items to the publish directory 
+    Copy _ResolvedFileToPublishPreserveNewest items to the publish directory
     ============================================================
     -->
   <Target Name="_CopyResolvedFilesToPublishPreserveNewest"
@@ -298,7 +298,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <NETSdkInformation Condition="'$(_ReadyToRunCompilerHasWarnings)' != ''" ResourceName="ReadyToRunCompilationHasWarnings_Info" />
 
     <ItemGroup>
-      <!-- 
+      <!--
       Note: we only remove the entries for the IL images and replace them with the entries for the R2R images.
       We do not do the same for PDBs, because the native PDBs created by the R2R compiler complement the IL PDBs
       and do not replace them. IL PDBs are still required for debugging. Native PDBs emitted by the R2R compiler are
@@ -363,7 +363,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       <_ReadyToRunImplementationAssemblies Include="@(_ReadyToRunImplementationAssembliesWithoutConflicts)" />
     </ItemGroup>
 
-    <PrepareForReadyToRunCompilation CrossgenTool="@(CrossgenTool)" 
+    <PrepareForReadyToRunCompilation CrossgenTool="@(CrossgenTool)"
                                      Crossgen2Tool="@(Crossgen2Tool)"
                                      OutputPath="$(_ReadyToRunOutputPath)"
                                      MainAssembly="@(IntermediateAssembly)"
@@ -475,12 +475,12 @@ Copyright (c) .NET Foundation. All rights reserved.
 
       <_ResolvedUnbundledFileToPublishPreserveNewest
                     Include="@(_ResolvedFileToPublishPreserveNewest)"
-                    Condition="'$(PublishSingleFile)' != 'true' or 
+                    Condition="'$(PublishSingleFile)' != 'true' or
                                '%(_ResolvedFileToPublishPreserveNewest.ExcludeFromSingleFile)'=='true'" />
 
       <_ResolvedUnbundledFileToPublishAlways
               Include="@(_ResolvedFileToPublishAlways)"
-              Condition="'$(PublishSingleFile)' != 'true' or 
+              Condition="'$(PublishSingleFile)' != 'true' or
                          '%(_ResolvedFileToPublishAlways.ExcludeFromSingleFile)'=='true'" />
     </ItemGroup>
   </Target>
@@ -539,7 +539,7 @@ Copyright (c) .NET Foundation. All rights reserved.
         <RelativePath>$(ProjectRuntimeConfigFileName)</RelativePath>
         <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
       </ResolvedFileToPublish>
-      
+
       <!-- Copy the app.config (if any) -->
       <ResolvedFileToPublish Include="@(AppConfigWithTargetPath)"
                              Condition="'$(CopyBuildOutputToPublishDirectory)' == 'true'">
@@ -625,8 +625,8 @@ Copyright (c) .NET Foundation. All rights reserved.
                               Condition="'$(PreserveStoreLayout)' == 'true' Or '@(RuntimeStorePackages)' != ''">
         <Output TaskParameter="ResolvedAssets" ItemName="_ResolvedCopyLocalPublishAssets" />
       </ResolveCopyLocalAssets>
-    
-    
+
+
       <ItemGroup>
         <_ResolvedCopyLocalPublishAssets Include="@(RuntimePackAsset)"
                                          Condition="'$(SelfContained)' == 'true' Or '%(RuntimePackAsset.RuntimePackAlwaysCopyLocal)' == 'true'" />
@@ -638,7 +638,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       </ItemGroup>
 
       <ItemGroup Condition="'$(PreserveStoreLayout)' != 'true' And '@(RuntimeStorePackages)' == ''">
-        <_ResolvedCopyLocalPublishAssets Include="@(_ResolvedCopyLocalBuildAssets)" 
+        <_ResolvedCopyLocalPublishAssets Include="@(_ResolvedCopyLocalBuildAssets)"
                                          Condition="'%(_ResolvedCopyLocalBuildAssets.CopyToPublishDirectory)' != 'false' "/>
       </ItemGroup>
 
@@ -741,8 +741,8 @@ Copyright (c) .NET Foundation. All rights reserved.
     This includes baggage items from transitively referenced projects. It would appear
     that this target computes full transitive closure of content items for all referenced
     projects; however that is not the case. It only collects the content items from its
-    immediate children and not children of children. 
-    
+    immediate children and not children of children.
+
     See comment on GetCopyToOutputDirectoryItems, from which this logic was taken.
     ============================================================
     -->
@@ -897,24 +897,24 @@ Copyright (c) .NET Foundation. All rights reserved.
   </PropertyGroup>
 
   <!-- Determine the managed assembly subset of ResolvedFileToPublish that should be post-processed by linker, and ready to run compilation -->
-  <Target Name="_ComputeAssembliesToPostprocessOnPublish" 
+  <Target Name="_ComputeAssembliesToPostprocessOnPublish"
           DependsOnTargets="_ComputeUserRuntimeAssemblies;$(_ComputeManagedRuntimePackAssembliesIfSelfContained)">
-    
-    <!-- 
+
+    <!--
       Default set of files to post-process correspond to the items that would be designated
       as managed runtime assemblies in .deps.json, and published to root of the application.
       RuntimeTargets and satellite assemblies are excluded. Currently, both linker and ready
-      to run require a RID, so there will not be RuntimeTargets. Linker could conceptually 
+      to run require a RID, so there will not be RuntimeTargets. Linker could conceptually
       operate without a RID, but would not know how to handle multiple assemblies with same
       identity.
     -->
     <ItemGroup>
       <!-- Assemblies from packages -->
       <_ManagedRuntimeAssembly Include="@(RuntimeCopyLocalItems)" />
-      
+
       <!-- Assemblies from other references -->
       <_ManagedRuntimeAssembly Include="@(UserRuntimeAssembly)" />
-      
+
       <!-- Assembly produced by this project -->
       <_ManagedRuntimeAssembly Include="@(IntermediateAssembly)" />
     </ItemGroup>
@@ -923,8 +923,8 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ItemGroup Condition="'$(SelfContained)' == 'true'">
       <_ManagedRuntimeAssembly Include="@(_ManagedRuntimePackAssembly)" />
     </ItemGroup>
-    
-    <!-- 
+
+    <!--
       Match above with ResolvedFileToPublish. Some of above would have been excluded from publish in
       various ways and should be excluded from the list of files to postprocess as well. Furthermore,
       the metadata must match ResolvedFileToPublish as the tools modify or remove these items in that
@@ -937,7 +937,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <!--
       Set PostprocessAssembly=true metadata on ResolvedFileToPublish, which will be honored by linker
       and crossgen.
-      
+
       Assemblies injected into ResolvedFileToPublish outside the set above (such as razor views) are
       responsible for setting this metadata to opt in to post-processing.
     -->
@@ -951,7 +951,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ItemGroup>
       <!-- Special case for System.Private.Corelib due to https://github.com/dotnet/core-setup/issues/7728 -->
       <_ManagedRuntimePackAssembly Include="@(RuntimePackAsset)"
-                                   Condition="'%(RuntimePackAsset.AssetType)' == 'runtime' 
+                                   Condition="'%(RuntimePackAsset.AssetType)' == 'runtime'
                                                 or '%(RuntimePackAsset.Filename)' == 'System.Private.Corelib'" />
     </ItemGroup>
   </Target>
@@ -966,7 +966,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       <_UseBuildDependencyFile Condition="'@(_ExcludeFromPublishPackageReference)' == '' and
                                           '@(RuntimeStorePackages)' == '' and
                                           '$(PreserveStoreLayout)' != 'true' and
-                                          '$(PublishTrimmed)' != 'true' and 
+                                          '$(PublishTrimmed)' != 'true' and
                                           '$(_TrimRuntimeAssets)' != 'true'">true</_UseBuildDependencyFile>
     </PropertyGroup>
 
@@ -977,16 +977,16 @@ Copyright (c) .NET Foundation. All rights reserved.
                                         GenerateSingleFileBundle
 
     Bundle the ResolvedFileToPublish items into one file in PublishDir
-    (except those marked ExcludeFromSingleFile) 
+    (except those marked ExcludeFromSingleFile)
     ============================================================
     -->
   <Target Name="_ComputeFilesToBundle"
         Condition="'$(PublishSingleFile)' == 'true'">
 
     <ItemGroup>
-      <_FilesToBundle Include="@(ResolvedFileToPublish)" 
+      <_FilesToBundle Include="@(ResolvedFileToPublish)"
                       Condition="'%(ResolvedFileToPublish.ExcludeFromSingleFile)' != 'true'"/>
-      
+
       <ResolvedFileToPublish Remove="@(_FilesToBundle)"/>
     </ItemGroup>
 
@@ -994,13 +994,13 @@ Copyright (c) .NET Foundation. All rights reserved.
       <PublishedSingleFileName>$(AssemblyName)$(_NativeExecutableExtension)</PublishedSingleFileName>
       <PublishedSingleFilePath>$(PublishDir)$(PublishedSingleFileName)</PublishedSingleFilePath>
     </PropertyGroup>
-    
+
   </Target>
 
   <UsingTask TaskName="GenerateBundle" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
-  <Target Name="GenerateSingleFileBundle" 
+  <Target Name="GenerateSingleFileBundle"
           Condition="'$(PublishSingleFile)' == 'true'"
-          DependsOnTargets="_ComputeFilesToBundle" 
+          DependsOnTargets="_ComputeFilesToBundle"
           Inputs="@(_FilesToBundle)"
           Outputs="$(PublishedSingleFilePath)">
 
@@ -1029,8 +1029,8 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ItemGroup>
       <ResolvedFileToPublish Include="@(_FilesExcludedFromBundle)"/>
       <!-- ResolvedFileToPublish shouldn't include PublishedSingleFilePath, since the single-file bundle is written directly to the publish directory -->
-    </ItemGroup>  
-  
+    </ItemGroup>
+
   </Target>
 
   <!--
@@ -1052,8 +1052,8 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <PropertyGroup>
       <!-- IntermediateDepsFilePath is the location where the deps.json file is originally created
-           PublishDepsFilePath is the location where the deps.json resides when published 
-           PublishDepsFilePath is empty (by default) for PublishSingleFile, since the deps.json file is embedde within the single-file bundle -->      
+           PublishDepsFilePath is the location where the deps.json resides when published
+           PublishDepsFilePath is empty (by default) for PublishSingleFile, since the deps.json file is embedde within the single-file bundle -->
       <IntermediateDepsFilePath Condition=" '$(PublishDepsFilePath)' != ''">$(PublishDepsFilePath)</IntermediateDepsFilePath >
       <IntermediateDepsFilePath Condition=" '$(PublishDepsFilePath)' == ''">$(IntermediateOutputPath)$(ProjectDepsFileName)</IntermediateDepsFilePath >
       <PublishDepsFilePath Condition=" '$(PublishDepsFilePath)' == '' And '$(PublishSingleFile)' != 'true'">$(PublishDir)$(ProjectDepsFileName)</PublishDepsFilePath>
@@ -1069,7 +1069,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       <_ResolvedNuGetFilesForPublish Include="@(ResourceCopyLocalItems)" Condition="'%(ResourceCopyLocalItems.CopyToPublishDirectory)' != 'false'" />
       <_ResolvedNuGetFilesForPublish Include="@(RuntimeCopyLocalItems)" Condition="'%(RuntimeCopyLocalItems.CopyToPublishDirectory)' != 'false'" />
       <_ResolvedNuGetFilesForPublish Remove="@(_PublishConflictPackageFiles)" Condition="'%(_PublishConflictPackageFiles.ConflictItemType)' != 'Reference'" />
-     
+
     </ItemGroup>
 
     <GenerateDepsFile ProjectPath="$(MSBuildProjectFullPath)"
@@ -1105,7 +1105,7 @@ Copyright (c) .NET Foundation. All rights reserved.
         <RelativePath>$(ProjectDepsFileName)</RelativePath>
       </ResolvedFileToPublish>
     </ItemGroup>
-    
+
   </Target>
 
   <!--
@@ -1133,7 +1133,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     </GetEmbeddedApphostPaths>
 
   </Target>
-  
+
   <!--
     ============================================================
                                             ComputeFilesCopiedToPublishDir
@@ -1196,7 +1196,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <!--
     ============================================================
     _CheckForLanguageAndPublishFeatureCombinationSupport
-    
+
     Block unsupported language and feature combination.
     ============================================================
     -->

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets
@@ -86,7 +86,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   </Choose>
 
   <!--
-    SelfContained was not an option in .NET Core SDK 1.0. 
+    SelfContained was not an option in .NET Core SDK 1.0.
     Default SelfContained based on the RuntimeIdentifier, so projects don't have to explicitly set SelfContained.
     This avoids a breaking change from 1.0 behavior.
 
@@ -200,9 +200,9 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <!--
     Append $(RuntimeIdentifier) directory to output and intermediate paths to prevent bin clashes between
-    targets. 
+    targets.
 
-    But do not append the implicit default runtime identifier for .NET Framework apps as that would 
+    But do not append the implicit default runtime identifier for .NET Framework apps as that would
     append a RID the user never mentioned in the path and do so even in the AnyCPU case.
    -->
   <PropertyGroup Condition="'$(AppendRuntimeIdentifierToOutputPath)' == 'true' and '$(RuntimeIdentifier)' != '' and '$(_UsingDefaultRuntimeIdentifier)' != 'true'">
@@ -213,10 +213,9 @@ Copyright (c) .NET Foundation. All rights reserved.
   <UsingTask TaskName="Microsoft.NET.Build.Tasks.GetDefaultPlatformTargetForNetFramework"
            AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
 
-
-  <!-- 
-    Switch our default .NETFramework CPU architecture choice back to AnyCPU before 
-    compiling the exe if no copy-local native dependencies were resolved from NuGet 
+  <!--
+    Switch our default .NETFramework CPU architecture choice back to AnyCPU before
+    compiling the exe if no copy-local native dependencies were resolved from NuGet
   -->
   <Target Name="AdjustDefaultPlatformTargetForNetFrameworkExeWithNoNativeCopyLocalItems"
           AfterTargets="ResolvePackageAssets"
@@ -228,7 +227,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                                              NativeCopyLocalItems="@(NativeCopyLocalItems)">
 
       <Output TaskParameter="DefaultPlatformTarget" PropertyName="PlatformTarget" />
-      
+
     </GetDefaultPlatformTargetForNetFramework>
   </Target>
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.Analyzers.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.Analyzers.targets
@@ -6,7 +6,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
           created a backup copy.  Incorrect changes to this file will make it
           impossible to load or build your projects from the command-line or the IDE.
 
-Copyright (c) .NET Foundation. All rights reserved. 
+Copyright (c) .NET Foundation. All rights reserved.
 ***********************************************************************************************
 -->
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
@@ -28,18 +28,18 @@ Copyright (c) .NET Foundation. All rights reserved.
     <EffectiveAnalysisLevel Condition="'$(AnalysisLevel)' == 'preview'">6.0</EffectiveAnalysisLevel>
 
     <!-- Set EffectiveAnalysisLevel to the value of AnalysisLevel if it is a version number -->
-    <EffectiveAnalysisLevel Condition="'$(EffectiveAnalysisLevel)' == '' And 
+    <EffectiveAnalysisLevel Condition="'$(EffectiveAnalysisLevel)' == '' And
                                        '$(AnalysisLevel)' != ''">$(AnalysisLevel)</EffectiveAnalysisLevel>
 
     <!-- EnableNETAnalyzers Allows analyzers to be disabled in bulk via msbuild if the user wants to -->
-    <EnableNETAnalyzers Condition="'$(EnableNETAnalyzers)' == '' And 
+    <EnableNETAnalyzers Condition="'$(EnableNETAnalyzers)' == '' And
                                    '$(EffectiveAnalysisLevel)' != '' And
                                     $([MSBuild]::VersionGreaterThanOrEquals($(EffectiveAnalysisLevel), '5.0'))">true</EnableNETAnalyzers>
     <EnableNETAnalyzers Condition="'$(EnableNETAnalyzers)' == ''">false</EnableNETAnalyzers>
 
     <!-- EnforceCodeStyleInBuild Allows code style analyzers to be disabled in bulk via msbuild if the user wants to -->
     <EnforceCodeStyleInBuild Condition="'$(EnforceCodeStyleInBuild)' == ''">false</EnforceCodeStyleInBuild>
-    
+
     <!-- Compiler warning level, defaulted to 4. We promote it to 5 if the user has set analysis level to 5 or higher
          NOTE: at this time only the C# compiler supports warning waves -->
     <WarningLevel Condition="'$(Language)' == 'C#' And

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.BeforeCommon.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.BeforeCommon.targets
@@ -64,8 +64,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     Also, enforce that RuntimeIdentifier is always specified for .NETFramework executables.
   -->
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.NET.RuntimeIdentifierInference.targets" />
-  
-  
+
   <!-- Import workload targets -->
   <Import Project="Microsoft.NET.Sdk.ImportWorkloads.targets" Condition="'$(MSBuildEnableWorkloadResolver)' == 'true'" />
 
@@ -180,9 +179,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <_FrameworkIdentifierForImplicitDefine Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework'">NET</_FrameworkIdentifierForImplicitDefine>
 
     <_FrameworkVersionForImplicitDefine>$(TargetFrameworkVersion.TrimStart('vV'))</_FrameworkVersionForImplicitDefine>
-    
     <_FrameworkVersionForImplicitDefine>$(_FrameworkVersionForImplicitDefine.Replace('.', '_'))</_FrameworkVersionForImplicitDefine>
-
     <_FrameworkVersionForImplicitDefine Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework'">$(_FrameworkVersionForImplicitDefine.Replace('_', ''))</_FrameworkVersionForImplicitDefine>
 
     <ImplicitFrameworkDefine>$(_FrameworkIdentifierForImplicitDefine)$(_FrameworkVersionForImplicitDefine)</ImplicitFrameworkDefine>
@@ -213,9 +210,9 @@ Copyright (c) .NET Foundation. All rights reserved.
       <_CompatibleFrameworkVersions Include="@(_SupportedFrameworkVersions)" Condition=" $([MSBuild]::VersionLessThanOrEquals(%(Identity), $(TargetFrameworkVersion))) " />
       <_FormattedCompatibleFrameworkVersions Include="@(_CompatibleFrameworkVersions)" Condition=" '$(TargetFrameworkIdentifier)' == '.NETCoreApp' or '$(TargetFrameworkIdentifier)' == '.NETStandard' " />
       <_FormattedCompatibleFrameworkVersions Include="@(_CompatibleFrameworkVersions->'%(Identity)'->Replace('.', ''))" Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' " />
-      <_ImplicitDefineConstant Include="@(_FormattedCompatibleFrameworkVersions->'$(_FrameworkIdentifierForImplicitDefine)%(Identity)_OR_GREATER'->Replace('.', '_'))" 
+      <_ImplicitDefineConstant Include="@(_FormattedCompatibleFrameworkVersions->'$(_FrameworkIdentifierForImplicitDefine)%(Identity)_OR_GREATER'->Replace('.', '_'))"
                                Condition=" '$(TargetFrameworkIdentifier)' != '.NETCoreApp' or $([MSBuild]::VersionGreaterThanOrEquals(%(_FormattedCompatibleFrameworkVersions.Identity), 5.0)) " />
-      <_ImplicitDefineConstant Include="@(_FormattedCompatibleFrameworkVersions->'NETCOREAPP%(Identity)_OR_GREATER'->Replace('.', '_'))" 
+      <_ImplicitDefineConstant Include="@(_FormattedCompatibleFrameworkVersions->'NETCOREAPP%(Identity)_OR_GREATER'->Replace('.', '_'))"
                                Condition=" '$(TargetFrameworkIdentifier)' == '.NETCoreApp' and $([MSBuild]::VersionLessThan(%(_FormattedCompatibleFrameworkVersions.Identity), 5.0)) " />
     </ItemGroup>
   </Target>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.BeforeCommonCrossTargeting.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.BeforeCommonCrossTargeting.targets
@@ -6,12 +6,12 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
           created a backup copy.  Incorrect changes to this file will make it
           impossible to load or build your projects from the command-line or the IDE.
 
-Copyright (c) .NET Foundation. All rights reserved. 
+Copyright (c) .NET Foundation. All rights reserved.
 ***********************************************************************************************
 -->
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.NET.DefaultAssemblyInfo.targets" />
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.NET.DefaultOutputPaths.targets" />
-  
+
 </Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.CSharp.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.CSharp.props
@@ -6,7 +6,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
           created a backup copy.  Incorrect changes to this file will make it
           impossible to load or build your projects from the command-line or the IDE.
 
-Copyright (c) .NET Foundation. All rights reserved. 
+Copyright (c) .NET Foundation. All rights reserved.
 ***********************************************************************************************
 -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
@@ -16,7 +16,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <NoWarn Condition=" '$(NoWarn)' == '' ">1701;1702</NoWarn>
 
     <!-- Remove the line below once https://github.com/Microsoft/visualfsharp/issues/3207 gets fixed -->
-    <WarningsAsErrors>$(WarningsAsErrors);NU1605</WarningsAsErrors> 
+    <WarningsAsErrors>$(WarningsAsErrors);NU1605</WarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup>
     <DefineConstants Condition=" '$(DefineConstants)' != '' ">$(DefineConstants);</DefineConstants>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.CSharp.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.CSharp.targets
@@ -6,7 +6,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
           created a backup copy.  Incorrect changes to this file will make it
           impossible to load or build your projects from the command-line or the IDE.
 
-Copyright (c) .NET Foundation. All rights reserved. 
+Copyright (c) .NET Foundation. All rights reserved.
 ***********************************************************************************************
 -->
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
@@ -15,7 +15,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   </PropertyGroup>
   <PropertyGroup Condition="'$(DisableImplicitConfigurationDefines)' != 'true'">
     <ImplicitConfigurationDefine>$(Configuration.ToUpperInvariant())</ImplicitConfigurationDefine>
-    
+
     <!-- Replace dashes and periods in the configuration with underscores.  This makes it more likely that
          the resulting compilation constant will be a valid C# conditional compilation symbol.  As the set
          of characters that aren't allowed is essentially open-ended, there's probably not a good way to
@@ -24,7 +24,7 @@ Copyright (c) .NET Foundation. All rights reserved.
          the define will be ignored:
             warning MSB3052: The parameter to the compiler is invalid, '/define:0BAD_DEFINE' will be ignored.
          -->
-    
+
     <ImplicitConfigurationDefine>$(ImplicitConfigurationDefine.Replace('-', '_'))</ImplicitConfigurationDefine>
     <ImplicitConfigurationDefine>$(ImplicitConfigurationDefine.Replace('.', '_'))</ImplicitConfigurationDefine>
     <ImplicitConfigurationDefine>$(ImplicitConfigurationDefine.Replace(' ', '_'))</ImplicitConfigurationDefine>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.Common.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.Common.targets
@@ -26,7 +26,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     -->
     <DefaultImplicitPackages>Microsoft.NETCore.App;NETStandard.Library</DefaultImplicitPackages>
   </PropertyGroup>
-  
+
   <!--
      Some versions of Microsoft.NET.Test.Sdk.targets change the OutputType after we've set _IsExecutable and
      HasRuntimeOutput default in Microsoft.NET.Sdk.BeforeCommon.targets. Refresh these value here for backwards

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.CrossTargeting.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.CrossTargeting.targets
@@ -73,8 +73,8 @@ Copyright (c) .NET Foundation. All rights reserved.
   ============================================================
                        GetPackagingOutputs
 
-  Stub cross-targeting implementation of GetPackagingOutputs 
-  to allow project references from from projects that pull in 
+  Stub cross-targeting implementation of GetPackagingOutputs
+  to allow project references from from projects that pull in
   Microsoft.AppxPackage.targets (UWP, PCL) to cross-targeted
   projects.
 
@@ -88,12 +88,12 @@ Copyright (c) .NET Foundation. All rights reserved.
   An empty GetPackagingOutputs is sufficient for the common
   case of a library with no special assets to contribute to
   the appx and is also equivalent to what is present in the
-  single-targeted case unless WindowsAppContainer is not set 
+  single-targeted case unless WindowsAppContainer is not set
   to true.
 
   Furthermore, the appx targets currently use continue-on-error
-  such that even without this, clean builds succeed but log an 
-  error and incremental builds silently succeed. As such, this 
+  such that even without this, clean builds succeed but log an
+  error and incremental builds silently succeed. As such, this
   simply removes a confounding error from successful clean
   builds.
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.props
@@ -6,7 +6,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
           created a backup copy.  Incorrect changes to this file will make it
           impossible to load or build your projects from the command-line or the IDE.
 
-Copyright (c) .NET Foundation. All rights reserved. 
+Copyright (c) .NET Foundation. All rights reserved.
 ***********************************************************************************************
 -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
@@ -22,7 +22,7 @@ Copyright (c) .NET Foundation. All rights reserved.
          BundledRuntimeIdentifierGraphFile is set. -->
     <RuntimeIdentifierGraphPath Condition="'$(RuntimeIdentifierGraphPath)' == ''">$(BundledRuntimeIdentifierGraphFile)</RuntimeIdentifierGraphPath>
   </PropertyGroup>
-  
+
   <PropertyGroup>
     <!-- Disable web SDK implicit package versions for ASP.NET packages, since the .NET SDK now handles that -->
     <EnableWebSdkImplicitPackageVersions>false</EnableWebSdkImplicitPackageVersions>
@@ -48,7 +48,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <!-- If targeting .NET Standard 2.0 or higher, then don't include a dependency on NETStandard.Library in the package produced by pack -->
     <PackageReference Update="NETStandard.Library"
                       Condition=" ('$(_TargetFrameworkVersionWithoutV)' != '') And ('$(_TargetFrameworkVersionWithoutV)' >= '2.0') "
-                      PrivateAssets="All" 
+                      PrivateAssets="All"
                       Publish="true" />
   </ItemGroup>
   <ItemGroup Condition=" '$(DisableImplicitFrameworkReferences)' != 'true' and '$(TargetFrameworkIdentifier)' == '.NETStandard' And '$(_TargetFrameworkVersionWithoutV)' >= '2.1'">
@@ -56,11 +56,11 @@ Copyright (c) .NET Foundation. All rights reserved.
   </ItemGroup>
 
   <ItemGroup Condition=" '$(DisableImplicitFrameworkReferences)' != 'true' and '$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
-    
+
     <!-- Use implicit PackageReference for Microsoft.NETCore.App on versions prior to 3.0.  For 3.0 or higher, use
          an implicit FrameworkReference -->
-    
-    <PackageReference Include="Microsoft.NETCore.App" IsImplicitlyDefined="true" 
+
+    <PackageReference Include="Microsoft.NETCore.App" IsImplicitlyDefined="true"
                       Condition="('$(_TargetFrameworkVersionWithoutV)' != '') And ('$(_TargetFrameworkVersionWithoutV)' &lt; '3.0')"/>
 
     <!-- For targeting .NET Core 2.0 or higher, don't include a dependency on Microsoft.NETCore.App in the package produced by pack.

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.targets
@@ -6,23 +6,23 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
           created a backup copy.  Incorrect changes to this file will make it
           impossible to load or build your projects from the command-line or the IDE.
 
-Copyright (c) .NET Foundation. All rights reserved. 
+Copyright (c) .NET Foundation. All rights reserved.
 ***********************************************************************************************
 -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <!-- Don't get the default item globs by default when the flag is not set. -->
   <PropertyGroup Condition="'$(UsingNETSdkDefaults)' == 'true'">
-   <EnableDefaultItems Condition=" '$(EnableDefaultItems)' == '' ">true</EnableDefaultItems>
-   <EnableDefaultCompileItems Condition=" '$(EnableDefaultCompileItems)' == '' ">true</EnableDefaultCompileItems>
+    <EnableDefaultItems Condition=" '$(EnableDefaultItems)' == '' ">true</EnableDefaultItems>
+    <EnableDefaultCompileItems Condition=" '$(EnableDefaultCompileItems)' == '' ">true</EnableDefaultCompileItems>
     <EnableDefaultEmbeddedResourceItems Condition=" '$(EnableDefaultEmbeddedResourceItems)' == '' ">true</EnableDefaultEmbeddedResourceItems>
     <EnableDefaultNoneItems Condition=" '$(EnableDefaultNoneItems)' == '' ">true</EnableDefaultNoneItems>
   </PropertyGroup>
 
-  <PropertyGroup>    
+  <PropertyGroup>
     <!-- Set DefaultItemExcludes property for items that should be excluded from the default Compile, etc items.
          This is in the .targets because it needs to come after the final BaseOutputPath has been evaluated. -->
-    
+
     <!-- bin folder, by default -->
     <DefaultItemExcludes>$(DefaultItemExcludes);$(BaseOutputPath)/**</DefaultItemExcludes>
     <!-- obj folder, by default -->
@@ -33,12 +33,12 @@ Copyright (c) .NET Foundation. All rights reserved.
     <DefaultItemExcludes>$(DefaultItemExcludes);**/*.*proj</DefaultItemExcludes>
     <DefaultItemExcludes>$(DefaultItemExcludes);**/*.sln</DefaultItemExcludes>
     <DefaultItemExcludes>$(DefaultItemExcludes);**/*.vssscc</DefaultItemExcludes>
-    
+
     <!-- WARNING: This pattern is there to ignore folders such as .git and .vs, but it will also match items included with a
          relative path outside the project folder (for example "..\Shared\Shared.cs").  So be sure only to apply it to items
          that are in the project folder. -->
     <DefaultExcludesInProjectFolder>$(DefaultItemExcludesInProjectFolder);**/.*/**</DefaultExcludesInProjectFolder>
-   
+
   </PropertyGroup>
 
   <!-- Set the default versions of the NETStandard.Library or Microsoft.NETCore.App packages to reference.
@@ -49,34 +49,34 @@ Copyright (c) .NET Foundation. All rights reserved.
          updating to the 2.0 or higher SDK.  When targeting .NET Standard 2.0 or higher, the NETStandard.Library reference won't show up as a dependency of the package
          produced, so we will roll forward to the latest version. -->
     <NETStandardImplicitPackageVersion Condition="'$(NETStandardImplicitPackageVersion)' =='' And '$(_TargetFrameworkVersionWithoutV)' &lt; '2.0'">1.6.1</NETStandardImplicitPackageVersion>
-    
+
     <!-- Default to use the latest stable 2.0.x release. -->
     <NETStandardImplicitPackageVersion Condition="'$(NETStandardImplicitPackageVersion)' ==''">2.0.3</NETStandardImplicitPackageVersion>
   </PropertyGroup>
 
   <!--
     Determine the version (including patch) of .NET Core to target.
-    
+
     When targeting .NET Core, the TargetFramework is used to specify the major and minor version of the runtime to use.  By default,
     the patch version is inferred.  The general logic is that self-contained apps will target the latest patch that the SDK
     knows about, while framework-dependent apps will target the ".0" patch (and roll forward to the latest patch installed at
     runtime).
-    
+
     When targeting .NET Core 1.0 and 1.1, framework-dependent apps use 1.0.5 and 1.1.2, respectively.  This is done for compatibility
     with previous releases that bumped the self-contained and framework-dependent versions together.
-    
+
     The TargetLatestRuntimePatch property can be set to true or false to explicitly opt in or out of the logic to roll forward
     to the latest patch, regardless of whether the app is self-contained or framework-dependent.
-    
+
     The RuntimeFrameworkVersion is where the actual version of the .NET Core runtime to target can be set.  If set, it will be
-    used in the implicit PackageReference to Microsoft.NETCore.App.  
-    
+    used in the implicit PackageReference to Microsoft.NETCore.App.
+
     The framework version that is written to the runtimeconfig.json file is based on the actual resolved package version
     of Microsoft.NETCore.App.  This is to allow floating the verion number (ie the RuntimeFrameworkVersion could be set to
     "2.0-*".
-  
+
   -->
-  
+
   <PropertyGroup Condition="'$(TargetLatestRuntimePatch)' == ''">
     <TargetLatestRuntimePatch Condition="'$(SelfContained)' == 'true' ">true</TargetLatestRuntimePatch>
     <TargetLatestRuntimePatch Condition="'$(SelfContained)' != 'true' ">false</TargetLatestRuntimePatch>
@@ -93,18 +93,18 @@ Copyright (c) .NET Foundation. All rights reserved.
       <PrivateAssets Condition="'%(PackageReference.Version)' == ''">all</PrivateAssets>
       <Publish Condition="'%(PackageReference.Version)' == ''">true</Publish>
     </PackageReference>
-  
+
     <PackageReference Update="Microsoft.AspNetCore.All">
       <PrivateAssets Condition="'%(PackageReference.Version)' == ''">all</PrivateAssets>
       <Publish Condition="'%(PackageReference.Version)' == ''">true</Publish>
     </PackageReference>
-  
+
     <!-- Allow RuntimeFrameworkVersion to be used to explicitly specify the version of Microsoft.NETCore.App -->
     <PackageReference Update="Microsoft.NETCore.App"
                       Version="$(RuntimeFrameworkVersion)"
-                      Condition="'$(RuntimeFrameworkVersion)' != ''" 
+                      Condition="'$(RuntimeFrameworkVersion)' != ''"
                       AllowExplicitVersion="true"/>
-    
+
     <!-- If implicit PackageReferences are disabled, then don't warn about explicit versions at all -->
     <PackageReference Update="@(PackageReference)"
                       Condition="'$(DisableImplicitFrameworkReferences)' == 'true'"
@@ -143,21 +143,21 @@ Copyright (c) .NET Foundation. All rights reserved.
       <PackageReference Remove="Microsoft.AspNetCore.App" Condition="'$(_ShouldRemoveAspNetCoreApp)' == 'true'" />
       <FrameworkReference Include="Microsoft.AspNetCore.App" Condition="'$(_ShouldAddAspNetCoreAppFrameworkReference)' == 'true'" />
     </ItemGroup>
-    
+
     <!-- NETSDK1080: A PackageReference to Microsoft.AspNetCore.App is not necessary when targeting .NET Core 3.0 or higher.
          If Microsoft.NET.Sdk.Web is used, the shared framework will be referenced automatically. Otherwise, the PackageReference
          should be replaced with a FrameworkReference. -->
 
     <NETSdkWarning Condition="'$(_ShouldRemoveAspNetCoreApp)' == 'true'"
                    ResourceName="AspNetCoreUsesFrameworkReference" />
-    
+
   </Target>
 
-  <Target Name="ApplyImplicitVersions" 
+  <Target Name="ApplyImplicitVersions"
           BeforeTargets="_CheckForInvalidConfigurationAndPlatform;CollectPackageReferences;ProcessFrameworkReferences"
           DependsOnTargets="UpdateAspNetToFrameworkReference;CheckForImplicitPackageReferenceOverrides"
           Condition="'@(PackageReference)' != ''">
-    
+
     <ApplyImplicitVersions TargetFrameworkVersion="$(_TargetFrameworkVersionWithoutV)"
                            TargetLatestRuntimePatch="$(TargetLatestRuntimePatch)"
                            PackageReferences="@(PackageReference)"
@@ -180,7 +180,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       </PackageReference>
     </ItemGroup>
   </Target>
-  
+
   <!-- This target runs before build but not before restore, to avoid duplicating these warnings
        if building with an implicit restore. -->
   <Target Name="WarnForExplicitVersions" BeforeTargets="_CheckForInvalidConfigurationAndPlatform"
@@ -197,12 +197,12 @@ Copyright (c) .NET Foundation. All rights reserved.
   <ItemGroup Condition="'$(SetLinkMetadataAutomatically)' != 'false'">
     <Compile Update="@(Compile)">
       <!-- First, add a trailing slash to the LinkBase metadata if necessary.  This allows us to use the same value
-           for the Link metadata whether or not LinkBase metadata is set: %(LinkBase)%(RecursiveDir)%(Filename)%(Extension) 
-           
+           for the Link metadata whether or not LinkBase metadata is set: %(LinkBase)%(RecursiveDir)%(Filename)%(Extension)
+
            Note that RecursiveDir already includes the trailing slash.
       -->
       <LinkBase Condition="'%(LinkBase)' != ''">$([MSBuild]::EnsureTrailingSlash(%(LinkBase)))</LinkBase>
-    
+
       <!-- Set the Link metadata if it's not already set, if the item wasn't defined in a shared project,  and the item is outside of the project directory.
            Check whether the item was defined in a shared project by checking whether the extension of the defining project was .projitems.
            Check whether an item is inside the project directory by seeing if the FullPath starts with EnsureTrailingSlash(MSBuildProjectDirectory)
@@ -211,7 +211,7 @@ Copyright (c) .NET Foundation. All rights reserved.
            not possible to call a string method on a metadata item directly.  The intrinsic ValueOrDefault() will be more
            performant than calling String.Copy(), which has been used for this in other contexts, but actually makes a copy
            of the string data.
-      -->    
+      -->
       <Link Condition="'%(Link)' == '' And '%(DefiningProjectExtension)' != '.projitems' And !$([MSBuild]::ValueOrDefault('%(FullPath)', '').StartsWith($([MSBuild]::EnsureTrailingSlash($(MSBuildProjectDirectory)))))">%(LinkBase)%(RecursiveDir)%(Filename)%(Extension)</Link>
     </Compile>
 
@@ -219,7 +219,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       <LinkBase Condition="'%(LinkBase)' != ''">$([MSBuild]::EnsureTrailingSlash(%(LinkBase)))</LinkBase>
       <Link Condition="'%(Link)' == '' And '%(DefiningProjectExtension)' != '.projitems' And !$([MSBuild]::ValueOrDefault('%(FullPath)', '').StartsWith($([MSBuild]::EnsureTrailingSlash($(MSBuildProjectDirectory)))))">%(LinkBase)%(RecursiveDir)%(Filename)%(Extension)</Link>
     </AdditionalFiles>
-    
+
     <None Update="@(None)">
       <LinkBase Condition="'%(LinkBase)' != ''">$([MSBuild]::EnsureTrailingSlash(%(LinkBase)))</LinkBase>
       <Link Condition="'%(Link)' == '' And '%(DefiningProjectExtension)' != '.projitems' And !$([MSBuild]::ValueOrDefault('%(FullPath)', '').StartsWith($([MSBuild]::EnsureTrailingSlash($(MSBuildProjectDirectory)))))">%(LinkBase)%(RecursiveDir)%(Filename)%(Extension)</Link>
@@ -271,7 +271,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       <_PackageReferenceToAdd Remove="@(_PackageReferenceToAdd)" />
 
     </ItemGroup>
-    
+
     <!-- If any implicit package references were overridden, then don't check that RuntimeFrameworkVersion matches the package version -->
     <PropertyGroup Condition="'@(_PackageReferenceToRemove)' != ''">
       <VerifyMatchingImplicitPackageVersion>false</VerifyMatchingImplicitPackageVersion>
@@ -313,7 +313,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       ContinueOnError="$(ContinueOnError)">
       <Output TaskParameter="DeduplicatedItems" ItemName="DeduplicatedEmbeddedResourceItems" />
     </CheckForDuplicateItems>
-    
+
     <!-- Default content items are enabled by the Web SDK, not the .NET SDK, but we check it here for simplicity -->
     <CheckForDuplicateItems
       Items="@(Content)"
@@ -340,7 +340,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       <Content Remove="@(Content)" />
       <Content Include="@(DeduplicatedContentItems)" />
     </ItemGroup>
-    
+
   </Target>
 
   <Target Name="_CheckForFailedSDKResolution"
@@ -375,4 +375,5 @@ Copyright (c) .NET Foundation. All rights reserved.
         Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' and $([MSBuild]::VersionGreaterThanOrEquals($(_TargetFrameworkVersionWithoutV), '5.0')) and '$(_MicrosoftWindowsDesktopSdkImported)' == 'true' and '$(TargetFrameworks)' == ''">
     <NETSdkWarning ResourceName="UnnecessaryWindowsDesktopSDK" />
   </Target>
+
 </Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FSharp.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FSharp.props
@@ -6,7 +6,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
           created a backup copy.  Incorrect changes to this file will make it
           impossible to load or build your projects from the command-line or the IDE.
 
-Copyright (c) .NET Foundation. All rights reserved. 
+Copyright (c) .NET Foundation. All rights reserved.
 ***********************************************************************************************
 -->
 
@@ -19,8 +19,8 @@ Copyright (c) .NET Foundation. All rights reserved.
     <UseBundledFSharpTargets Condition = "'$(UseBundledFSharpTargets)' == '' ">true</UseBundledFSharpTargets>
   </PropertyGroup>
 
-  <!-- Shim to select the correct Microsoft.NET.Sdk.FSharp.props file.   
-       If running under desktop select Microsoft.NET.Sdk.FSharp.props file from VS deployment, 
+  <!-- Shim to select the correct Microsoft.NET.Sdk.FSharp.props file.
+       If running under desktop select Microsoft.NET.Sdk.FSharp.props file from VS deployment,
        if running core msbuild select Microsoft.NET.Sdk.FSharp.props from dotnet cli deployment -->
   <PropertyGroup>
      <FSharpPropsShim Condition = " '$(FSharpPropsShim)' == '' and Exists('$(MSBuildToolsPath)\FSharp\Microsoft.FSharp.NetSdk.props') ">$(MSBuildToolsPath)\FSharp\Microsoft.FSharp.NetSdk.props</FSharpPropsShim>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FSharp.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FSharp.targets
@@ -6,16 +6,16 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
           created a backup copy.  Incorrect changes to this file will make it
           impossible to load or build your projects from the command-line or the IDE.
 
-Copyright (c) .NET Foundation. All rights reserved. 
+Copyright (c) .NET Foundation. All rights reserved.
 ***********************************************************************************************
 -->
 
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <!-- ***************************************************************************************************************
-       Shim to select the correct Microsoft.FSharp.Overrides.NetSdk.targets file when not running 
+       Shim to select the correct Microsoft.FSharp.Overrides.NetSdk.targets file when not running
        under Cross-targeting build and not under FSharp.Sdk
-       If running under desktop select Microsoft.FSharp.targets file from VS deployment, 
+       If running under desktop select Microsoft.FSharp.targets file from VS deployment,
        if running core msbuild select Microsoft.FSharp.targets from dotnet cli deployment
        *************************************************************************************************************** -->
   <PropertyGroup Condition=" '$(IsCrossTargetingBuild)' != 'true' " >

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FSharpTargetsShim.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FSharpTargetsShim.targets
@@ -6,7 +6,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
           created a backup copy.  Incorrect changes to this file will make it
           impossible to load or build your projects from the command-line or the IDE.
 
-Copyright (c) .NET Foundation. All rights reserved. 
+Copyright (c) .NET Foundation. All rights reserved.
 ***********************************************************************************************
 -->
 
@@ -29,7 +29,7 @@ Copyright (c) .NET Foundation. All rights reserved.
          the define will be ignored:
             warning MSB3052: The parameter to the compiler is invalid, '/define:0BAD_DEFINE' will be ignored.
          -->
-    
+
     <ImplicitConfigurationDefine>$(ImplicitConfigurationDefine.Replace('-', '_'))</ImplicitConfigurationDefine>
     <ImplicitConfigurationDefine>$(ImplicitConfigurationDefine.Replace('.', '_'))</ImplicitConfigurationDefine>
     <DefineConstants>$(DefineConstants);$(ImplicitConfigurationDefine)</DefineConstants>
@@ -43,15 +43,15 @@ Copyright (c) .NET Foundation. All rights reserved.
   <PropertyGroup>
      <FSharpDesignTimeTargetsPath Condition="'$(FSharpDesignTimeTargetsPath)' == ''">$(MSBuildExtensionsPath)\Microsoft\VisualStudio\Managed\Microsoft.FSharp.DesignTime.targets</FSharpDesignTimeTargetsPath>
   </PropertyGroup>
-  <Import Project="$(FSharpDesignTimeTargetsPath)" 
+  <Import Project="$(FSharpDesignTimeTargetsPath)"
           Condition=" '$(UseBundledFSharpTargets)' == 'true' and '$(FSharpDesignTimeTargetsPath)' != '' and Exists('$(FSharpDesignTimeTargetsPath)') " />
   <Import Project="$(MSBuildToolsPath)\Microsoft.Common.CrossTargeting.targets"
           Condition=" '$(UseBundledFSharpTargets)' == 'true' and '$(IsCrossTargetingBuild)' == 'true' "/>
 
   <!-- ***************************************************************************************************************
-       Shim to select the correct Microsoft.NET.Sdk.FSharp.targets file when not running 
+       Shim to select the correct Microsoft.NET.Sdk.FSharp.targets file when not running
        under Cross-targeting build and not under FSharp.Sdk
-       If running under desktop select Microsoft.FSharp.targets file from VS deployment, 
+       If running under desktop select Microsoft.FSharp.targets file from VS deployment,
        if running core msbuild select Microsoft.FSharp.targets from dotnet cli deployment
        *************************************************************************************************************** -->
   <PropertyGroup Condition=" '$(IsCrossTargetingBuild)' != 'true' " >

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets
@@ -6,7 +6,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
           created a backup copy.  Incorrect changes to this file will make it
           impossible to load or build your projects from the command-line or the IDE.
 
-Copyright (c) .NET Foundation. All rights reserved. 
+Copyright (c) .NET Foundation. All rights reserved.
 ***********************************************************************************************
 -->
 <Project>
@@ -28,21 +28,21 @@ Copyright (c) .NET Foundation. All rights reserved.
     Matches FrameworkReference items with KnownFrameworkReference items to determine the corresponding
     targeting pack and if necessary the runtime pack.  If the packs aren't available in the NetCoreTargetingPackRoot
     folder, then generate PackageDownload items in order to download the packs during restore.
-    
+
     Also resolves app host packs in a similar fashion, and checks for duplicate FrameworkReference items.
     ============================================================
     -->
-  
+
   <Target Name="ProcessFrameworkReferences" BeforeTargets="_CheckForInvalidConfigurationAndPlatform;CollectPackageReferences;CollectPackageDownloads"
           Condition="'@(FrameworkReference)' != ''">
-    
+
     <CheckForDuplicateFrameworkReferences
         FrameworkReferences="@(FrameworkReference)"
         MoreInformationLink="https://aka.ms/sdkimplicitrefs">
       <Output TaskParameter="ItemsToRemove" ItemName="_FrameworkReferenceToRemove" />
       <Output TaskParameter="ItemsToAdd" ItemName="_FrameworkReferenceToAdd" />
     </CheckForDuplicateFrameworkReferences>
-    
+
     <ItemGroup>
       <FrameworkReference Remove="@(_FrameworkReferenceToRemove)" />
       <FrameworkReference Include="@(_FrameworkReferenceToAdd)" />
@@ -118,7 +118,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       <Output TaskParameter="ComHost" ItemName="ComHostPack" />
       <Output TaskParameter="IjwHost" ItemName="IjwHostPack" />
       <Output TaskParameter="PackAsToolShimAppHostPacks" ItemName="PackAsToolShimAppHostPack" />
-      
+
     </ResolveAppHosts>
 
     <PropertyGroup Condition="'$(UsePackageDownload)' == ''">
@@ -126,7 +126,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       <UsePackageDownload Condition="'$(PackageDownloadSupported)' == 'true'">true</UsePackageDownload>
       <UsePackageDownload Condition="'$(UsePackageDownload)' == ''">false</UsePackageDownload>
     </PropertyGroup>
-    
+
     <ItemGroup Condition="'$(UsePackageDownload)' == 'true'">
       <PackageDownload Include="@(_PackageToDownload)">
         <Version>[%(_PackageToDownload.Version)]</Version>
@@ -159,11 +159,11 @@ Copyright (c) .NET Foundation. All rights reserved.
       <FrameworkReference Include="@(TransitiveFrameworkReference)" Exclude="@(FrameworkReference)"
                           IsTransitiveFrameworkReference="true" />
     </ItemGroup>
-    
+
   </Target>
 
   <UsingTask TaskName="ResolveFrameworkReferences" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
-  
+
   <!--
     ============================================================
                                         ResolveFrameworkReferences
@@ -299,7 +299,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       ResolvedRuntimePacks="@(ResolvedRuntimePack)">
 
       <Output TaskParameter="ResolvedFrameworkReferences" ItemName="ResolvedFrameworkReference" />
-      
+
     </ResolveFrameworkReferences>
 
   </Target>
@@ -334,9 +334,9 @@ Copyright (c) .NET Foundation. All rights reserved.
       <Output TaskParameter="PackageConflictPreferredPackages" PropertyName="PackageConflictPreferredPackages" />
       <Output TaskParameter="PackageConflictOverrides" ItemName="PackageConflictOverrides" />
       <Output TaskParameter="UsedRuntimeFrameworks" ItemName="_UsedRuntimeFramework" />
-      
+
     </ResolveTargetingPackAssets>
-    
+
     <ItemGroup Condition="'$(RuntimeIdentifier)' == '' or '$(SelfContained)' != 'true'">
       <PackageConflictPlatformManifests Include="@(PlatformManifestsFromTargetingPacks)" />
     </ItemGroup>
@@ -346,7 +346,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       <RuntimeFramework Include="@(_UsedRuntimeFramework)" />
     </ItemGroup>
   </Target>
-  
+
   <UsingTask TaskName="ResolveRuntimePackAssets" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
 
   <!--
@@ -366,8 +366,8 @@ Copyright (c) .NET Foundation. All rights reserved.
         SuppressNotFoundError="true">
       <Output TaskParameter="FullFrameworkReferenceAssemblyPaths" PropertyName="_FullFrameworkReferenceAssemblyPaths"/>
     </GetReferenceAssemblyPaths>
-    
-    
+
+
     <ItemGroup>
       <_ExistingReferenceAssembliesPackageReference Include="@(PackageReference)" Condition="'%(PackageReference.Identity)' == 'Microsoft.NETFramework.ReferenceAssemblies'"/>
 
@@ -375,7 +375,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                         Condition="'$(_FullFrameworkReferenceAssemblyPaths)' == '' and '@(_ExistingReferenceAssembliesPackageReference)' == ''"/>
     </ItemGroup>
   </Target>
-  
+
   <!--
     ============================================================
                                         ResolveRuntimePackAssets
@@ -385,7 +385,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     -->
   <Target Name="ResolveRuntimePackAssets" DependsOnTargets="ResolveFrameworkReferences"
           Condition="'@(RuntimePack)' != ''">
-        
+
     <ResolveRuntimePackAssets FrameworkReferences="@(FrameworkReference)"
                               ResolvedRuntimePacks="@(ResolvedRuntimePack)"
                               UnavailableRuntimePacks="@(UnavailableRuntimePack)"
@@ -393,18 +393,18 @@ Copyright (c) .NET Foundation. All rights reserved.
                               DesignTimeBuild="$(DesignTimeBuild)">
       <Output TaskParameter="RuntimePackAssets" ItemName="RuntimePackAsset" />
     </ResolveRuntimePackAssets>
-    
+
     <ItemGroup>
       <ReferenceCopyLocalPaths Include="@(RuntimePackAsset)"
                                Condition="'$(CopyLocalLockFileAssemblies)' == 'true' and ('$(SelfContained)' == 'true' or '%(RuntimePackAsset.RuntimePackAlwaysCopyLocal)' == 'true')" />
     </ItemGroup>
-  
-  
+
+
   </Target>
 
   <!--
     Adds metadata so the SDK will generate the UserSecretsIdAttribute.
-    
+
     This is associated with ASP.NET Core, but may be used in projects that don't use the Web SDK (especially test projects).
     So it is in the base .NET SDK.  (It used to be in the Microsoft.AspNetCore.App package, but now that that's a targeting
     pack we don't support importing build logic from it directly).
@@ -421,12 +421,12 @@ Copyright (c) .NET Foundation. All rights reserved.
       If the Microsoft.Extensions.Configuration.UserSecrets package 2.2 or higher is referenced directly,
       it will also add an AssemblyAttribute item. Since this attribute only allows one per assembly, do not
       duplicate the item.
-      
+
       Also don't add the attribute if there is neither a Microsoft.AspNetCore.App FrameworkReference nor a
       Microsoft.Extensions.Configuration.UserSecrets PackageReference, in order to preserve 2.x SDK behavior
       where projects would successfully build if they define the UserSecretsId property but don't reference
       the corresponding API.
-      
+
     -->
      <ItemGroup Condition=" @(AssemblyAttribute->WithMetadataValue('Identity', 'Microsoft.Extensions.Configuration.UserSecrets.UserSecretsIdAttribute')->Count()) == 0 And
                             (@(FrameworkReference->WithMetadataValue('Identity', 'Microsoft.AspNetCore.App')->Count()) != 0 Or

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.ImportWorkloads.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.ImportWorkloads.props
@@ -6,7 +6,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
           created a backup copy.  Incorrect changes to this file will make it
           impossible to load or build your projects from the command-line or the IDE.
 
-Copyright (c) .NET Foundation. All rights reserved. 
+Copyright (c) .NET Foundation. All rights reserved.
 ***********************************************************************************************
 -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.ImportWorkloads.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.ImportWorkloads.targets
@@ -6,7 +6,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
           created a backup copy.  Incorrect changes to this file will make it
           impossible to load or build your projects from the command-line or the IDE.
 
-Copyright (c) .NET Foundation. All rights reserved. 
+Copyright (c) .NET Foundation. All rights reserved.
 ***********************************************************************************************
 -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
@@ -14,7 +14,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <!-- Import workload manifests -->
   <Import Project="WorkloadManifest.targets" Sdk="Microsoft.NET.SDK.WorkloadManifestTargetsLocator"/>
-  
+
   <UsingTask TaskName="ShowMissingWorkloads" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
 
   <Target Name="_CheckForMissingWorkload"

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.VisualBasic.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.VisualBasic.props
@@ -6,7 +6,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
           created a backup copy.  Incorrect changes to this file will make it
           impossible to load or build your projects from the command-line or the IDE.
 
-Copyright (c) .NET Foundation. All rights reserved. 
+Copyright (c) .NET Foundation. All rights reserved.
 ***********************************************************************************************
 -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.VisualBasic.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.VisualBasic.targets
@@ -6,7 +6,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
           created a backup copy.  Incorrect changes to this file will make it
           impossible to load or build your projects from the command-line or the IDE.
 
-Copyright (c) .NET Foundation. All rights reserved. 
+Copyright (c) .NET Foundation. All rights reserved.
 ***********************************************************************************************
 -->
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
@@ -48,7 +48,7 @@ Copyright (c) .NET Foundation. All rights reserved.
          the define will be ignored:
             warning MSB3052: The parameter to the compiler is invalid, '/define:0BAD_DEFINE' will be ignored.
          -->
-    
+
     <ImplicitConfigurationDefine>$(ImplicitConfigurationDefine.Replace('-', '_'))</ImplicitConfigurationDefine>
     <ImplicitConfigurationDefine>$(ImplicitConfigurationDefine.Replace('.', '_'))</ImplicitConfigurationDefine>
     <ImplicitConfigurationDefine>$(ImplicitConfigurationDefine.Replace(' ', '_'))</ImplicitConfigurationDefine>
@@ -114,7 +114,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <!--
       VB Runtime does not yet have enough support for My.* outside .NET Framework,
       so default MyType=Empty for non .NET Framework. Project templates will be
-      responsible for setting MyType to non-Empty (Console, Windows, etc.) when 
+      responsible for setting MyType to non-Empty (Console, Windows, etc.) when
       the VB Runtime can allow it and as appropriate for the project type.
      -->
     <FinalDefineConstants Condition="'$(MyType)' == ''">$(FinalDefineConstants),_MyType=&quot;Empty&quot;</FinalDefineConstants>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.props
@@ -6,7 +6,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
           created a backup copy.  Incorrect changes to this file will make it
           impossible to load or build your projects from the command-line or the IDE.
 
-Copyright (c) .NET Foundation. All rights reserved. 
+Copyright (c) .NET Foundation. All rights reserved.
 ***********************************************************************************************
 -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
@@ -16,7 +16,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <DisableHandlePackageFileConflicts>true</DisableHandlePackageFileConflicts>
   </PropertyGroup>
 
-  <!-- Default configuration and platform to Debug|AnyCPU--> 
+  <!-- Default configuration and platform to Debug|AnyCPU-->
   <PropertyGroup>
     <Configurations Condition=" '$(Configurations)' == '' ">Debug;Release</Configurations>
     <Platforms Condition=" '$(Platforms)' == '' ">AnyCPU</Platforms>
@@ -46,10 +46,10 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <!-- User-facing platform-specific defaults -->
 
-  <!-- 
+  <!--
     NOTE:
-    
-     * We cannot compare against $(Platform) directly as that will give VS cause to instantiate extra 
+
+     * We cannot compare against $(Platform) directly as that will give VS cause to instantiate extra
        configurations, for each combination, which leads to performance problems and clutter in the sln
        in the common AnyCPU-only case.
 
@@ -60,7 +60,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   -->
   <PropertyGroup>
     <_PlatformWithoutConfigurationInference>$(Platform)</_PlatformWithoutConfigurationInference>
-  </PropertyGroup>  
+  </PropertyGroup>
   <PropertyGroup Condition=" '$(_PlatformWithoutConfigurationInference)' == 'x64' ">
     <PlatformTarget Condition=" '$(PlatformTarget)' == '' ">x64</PlatformTarget>
   </PropertyGroup>
@@ -81,12 +81,12 @@ Copyright (c) .NET Foundation. All rights reserved.
     <!-- Skip import of Microsoft.NuGet.props and Microsoft.NuGet.targets -->
     <SkipImportNuGetProps>true</SkipImportNuGetProps>
     <SkipImportNuGetBuildTargets>true</SkipImportNuGetBuildTargets>
-    
+
     <!-- NuGet should always restore .NET SDK projects with "PackageReference" style restore.  Setting this property will
          cause the right thing to happen even if there aren't any PackageReference items in the project, such as when
          a project targets .NET Framework and doesn't have any direct package dependencies. -->
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
-    
+
     <!-- Exclude GAC, registry, output directory from search paths. -->
     <AssemblySearchPaths Condition=" '$(AssemblySearchPaths)' == '' ">{CandidateAssemblyFiles};{HintPathFromItem};{TargetFrameworkDirectory};{RawFileName}</AssemblySearchPaths>
     <DesignTimeAssemblySearchPaths Condition=" '$(DesignTimeAssemblySearchPaths)' == '' ">$(AssemblySearchPaths)</DesignTimeAssemblySearchPaths>
@@ -114,7 +114,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <!-- Path to project that the .NET CLI will build in order to generate deps.json files for .NET CLI tools -->
     <ToolDepsJsonGeneratorProject>$(MSBuildThisFileDirectory)GenerateDeps\GenerateDeps.proj</ToolDepsJsonGeneratorProject>
   </PropertyGroup>
-  
+
   <!-- Default item includes (globs and implicit references) -->
   <Import Project="Microsoft.NET.Sdk.DefaultItems.props" />
 
@@ -128,13 +128,13 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <!-- Import workload props -->
   <Import Project="Microsoft.NET.Sdk.ImportWorkloads.props" Condition="'$(MSBuildEnableWorkloadResolver)' == 'true'" />
-  
+
   <!-- List of supported .NET Core and .NET Standard TFMs -->
   <Import Project="Microsoft.NET.SupportedTargetFrameworks.props" />
 
   <!-- List of supported target platforms -->
   <Import Project="Microsoft.NET.SupportedPlatforms.props" />
-  
+
   <!-- List of supported .NET windows target platform versions -->
   <Import Project="Microsoft.NET.WindowsSdkSupportedTargetPlatforms.props" />
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -333,7 +333,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                                       TargetPath="$([System.IO.Path]::GetFileName($(ProjectDepsFilePath)))"
                                       CopyToOutputDirectory="PreserveNewest" />
     </ItemGroup>
-    
+
     <ItemGroup Condition=" '$(GenerateRuntimeConfigurationFiles)' == 'true'">
       <AllItemsFullPathWithTargetPath Include="$(ProjectRuntimeConfigFilePath)"
                                 TargetPath="$([System.IO.Path]::GetFileName($(ProjectRuntimeConfigFilePath)))"
@@ -342,7 +342,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                                 TargetPath="$([System.IO.Path]::GetFileName($(ProjectRuntimeConfigDevFilePath)))"
                                 CopyToOutputDirectory="PreserveNewest" />
     </ItemGroup>
-    
+
   </Target>
 
   <Target Name="AddDepsJsonAndRuntimeConfigToPublishItemsForReferencingProjects"
@@ -353,7 +353,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ItemGroup Condition="'$(GenerateDependencyFile)' == 'true'">
       <AllPublishItemsFullPathWithTargetPath Include="$(ProjectDepsFilePath)"
                                       TargetPath="$([System.IO.Path]::GetFileName($(ProjectDepsFilePath)))"
-                                      CopyToPublishDirectory="PreserveNewest" 
+                                      CopyToPublishDirectory="PreserveNewest"
                                       Condition="'$(_UseBuildDependencyFile)' == 'true'"/>
       <AllPublishItemsFullPathWithTargetPath Include="$(PublishDepsFilePath)"
                                       TargetPath="$([System.IO.Path]::GetFileName($(PublishDepsFilePath)))"
@@ -365,11 +365,11 @@ Copyright (c) .NET Foundation. All rights reserved.
       <AllPublishItemsFullPathWithTargetPath Include="$(ProjectRuntimeConfigFilePath)"
                                 TargetPath="$([System.IO.Path]::GetFileName($(ProjectRuntimeConfigFilePath)))"
                                 CopyToPublishDirectory="PreserveNewest" />
-    
+
 
     </ItemGroup>
-    
-    
+
+
   </Target>
 
   <Target Name="_SdkBeforeClean">
@@ -1012,7 +1012,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <!--
     ============================================================
                             GenerateSupportedTargetFrameworkAlias
-    Generate a list of valid TargetFramework aliases for the project 
+    Generate a list of valid TargetFramework aliases for the project
     system to consume for the target framework properties page drop down
     ============================================================
   -->
@@ -1076,7 +1076,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   </PropertyGroup>
 
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.NET.Windows.targets" Condition="'$(TargetPlatformIdentifier)' == 'Windows'" />
-  
+
   <!-- TargetPlatformMoniker and TargetPlatformDisplayName would normally be set in Microsoft.Common.CurrentVersion.targets.  However, the
        TargetPlatformVersion may have been set later than that in evaluation by platform-specific targets or Directory.Build.targets.  So fix up those properties here -->
   <PropertyGroup Condition="'$(TargetPlatformMoniker)' == '' and '$(TargetPlatformIdentifier)' != ''">
@@ -1093,6 +1093,6 @@ Copyright (c) .NET Foundation. All rights reserved.
   <PropertyGroup Condition="'$(SupportedOSPlatformVersion)' == ''">
     <SupportedOSPlatformVersion>$(TargetPlatformVersion)</SupportedOSPlatformVersion>
   </PropertyGroup>
-  
+
   <Import Project="$(AfterMicrosoftNETSdkTargets)" Condition="'$(AfterMicrosoftNETSdkTargets)' != ''"/>
 </Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.SupportedPlatforms.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.SupportedPlatforms.props
@@ -6,7 +6,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
           created a backup copy.  Incorrect changes to this file will make it
           impossible to load or build your projects from the command-line or the IDE.
 
-Copyright (c) .NET Foundation. All rights reserved. 
+Copyright (c) .NET Foundation. All rights reserved.
 ***********************************************************************************************
 -->
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.SupportedTargetFrameworks.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.SupportedTargetFrameworks.props
@@ -6,7 +6,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
           created a backup copy.  Incorrect changes to this file will make it
           impossible to load or build your projects from the command-line or the IDE.
 
-Copyright (c) .NET Foundation. All rights reserved. 
+Copyright (c) .NET Foundation. All rights reserved.
 ***********************************************************************************************
 -->
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.TargetFrameworkInference.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.TargetFrameworkInference.targets
@@ -6,12 +6,12 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
           created a backup copy.  Incorrect changes to this file will make it
           impossible to load or build your projects from the command-line or the IDE.
 
-Copyright (c) .NET Foundation. All rights reserved. 
+Copyright (c) .NET Foundation. All rights reserved.
 ***********************************************************************************************
 -->
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <!-- 
+  <!--
     Note that this file is only included when $(TargetFramework) is set and so we do not need to check that here.
 
     Common targets require that $(TargetFrameworkIdentifier) and $(TargetFrameworkVersion) are set by static evaluation
@@ -54,7 +54,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <TargetFrameworkIdentifier>$([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)'))</TargetFrameworkIdentifier>
     <TargetFrameworkVersion>v$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)', 2))</TargetFrameworkVersion>
   </PropertyGroup>
-    
+
   <!--
     Parse TargetPlatform properties.
   -->
@@ -62,13 +62,13 @@ Copyright (c) .NET Foundation. All rights reserved.
     <TargetPlatformIdentifier Condition="'$(TargetPlatformIdentifier)' == ''">$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)'))</TargetPlatformIdentifier>
     <TargetPlatformVersion Condition="'$(TargetPlatformIdentifier)' == 'Windows'" >$([MSBuild]::GetTargetPlatformVersion('$(TargetFramework)', 4))</TargetPlatformVersion>
     <TargetPlatformVersion Condition="'$(TargetPlatformVersion)' == '' or ('$(TargetPlatformIdentifier)' == 'Windows' and !$([MSBuild]::VersionGreaterThanOrEquals($(TargetPlatformVersion), 10.0)))" >$([MSBuild]::GetTargetPlatformVersion('$(TargetFramework)', 2))</TargetPlatformVersion>
-    <TargetPlatformVersion Condition="$([MSBuild]::VersionEquals($(TargetPlatformVersion), 0.0))" ></TargetPlatformVersion> 
+    <TargetPlatformVersion Condition="$([MSBuild]::VersionEquals($(TargetPlatformVersion), 0.0))" ></TargetPlatformVersion>
     <!-- Normalize casing of windows to Windows -->
     <TargetPlatformIdentifier Condition="'$(TargetPlatformIdentifier)' == 'Windows'">Windows</TargetPlatformIdentifier>
   </PropertyGroup>
 
-  <!-- 
-    Trigger an error if we're unable to infer the framework identifier and version. 
+  <!--
+    Trigger an error if we're unable to infer the framework identifier and version.
 
     We have to evaluate this here and not in the target because by the time the target runs,
     Microsoft.Common.targets will have defaulted to .NETFramework,Version=v4.0
@@ -78,11 +78,11 @@ Copyright (c) .NET Foundation. All rights reserved.
   </PropertyGroup>
 
   <!--
-    NOTE: We must not validate the TFM before restore target runs as it prevents adding additional TFM 
+    NOTE: We must not validate the TFM before restore target runs as it prevents adding additional TFM
           support from being provided by a nuget package such as MSBuild.Sdk.Extras.
 
           We run before RunResolvePackageDependencies and GetReferenceAssemblyPaths so that design-time builds
-          which do not currently invoke _CheckForInvalidConfigurationAndPlatform, will not trigger spurious 
+          which do not currently invoke _CheckForInvalidConfigurationAndPlatform, will not trigger spurious
           errors that are only consequences of the root cause identified here.
   -->
   <Target Name="_CheckForUnsupportedTargetFramework"
@@ -131,7 +131,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == ''">
     <TargetFrameworkIdentifier>_</TargetFrameworkIdentifier>
   </PropertyGroup>
-  
+
   <!--
     Trigger an error if targeting a higher version of .NET Core or .NET Standard than is supported by the current SDK.
   -->
@@ -158,7 +158,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <_EnableDefaultWindowsPlatform>false</_EnableDefaultWindowsPlatform>
     <UseOSWinMdReferences>false</UseOSWinMdReferences>
   </PropertyGroup>
-    
+
   <PropertyGroup  Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard' And '$(NETStandardMaximumVersion)' == ''">
     <NETStandardMaximumVersion>2.1</NETStandardMaximumVersion>
   </PropertyGroup>
@@ -169,7 +169,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <NETSdkError Condition="'$(_TargetFrameworkVersionWithoutV)' > '$(NETStandardMaximumVersion)'"
                  ResourceName="UnsupportedTargetFrameworkVersion"
                  FormatArguments=".NET Standard;$(_TargetFrameworkVersionWithoutV);$(NETStandardMaximumVersion)"
-      />    
+      />
   </Target>
 
   <Target Name="_CheckForUnsupportedTargetFrameworkAndFeatureCombination" BeforeTargets="_CheckForInvalidConfigurationAndPlatform;Restore;CollectPackageReferences"

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Windows.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Windows.targets
@@ -34,10 +34,10 @@ Copyright (c) .NET Foundation. All rights reserved.
          other value. -->
     <SupportedOSPlatformVersion Condition="'$(SupportedOSPlatformVersion)' == ''">$(TargetPlatformMinVersion)</SupportedOSPlatformVersion>
     <TargetPlatformMinVersion Condition="'$(TargetPlatformMinVersion)' == ''">$(SupportedOSPlatformVersion)</TargetPlatformMinVersion>
-  
+
     <!-- If neither were set, then use the TargetPlatformVersion value for both -->
     <SupportedOSPlatformVersion Condition="'$(SupportedOSPlatformVersion)' == ''">$(TargetPlatformVersion)</SupportedOSPlatformVersion>
-    <TargetPlatformMinVersion Condition="'$(TargetPlatformMinVersion)' == ''">$(TargetPlatformVersion)</TargetPlatformMinVersion>    
+    <TargetPlatformMinVersion Condition="'$(TargetPlatformMinVersion)' == ''">$(TargetPlatformVersion)</TargetPlatformMinVersion>
   </PropertyGroup>
 
   <Target Name="_ErrorOnUnresolvedWindowsSDKAssemblyConflict"
@@ -46,7 +46,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ItemGroup>
       <_WindowsSDKUnresolvedRef Include="@(ResolveAssemblyReferenceUnresolvedAssemblyConflicts)" Condition="'%(Identity)' == 'Microsoft.Windows.SDK.NET' " />
     </ItemGroup>
-    
+
     <NETSdkError ResourceName="WindowsSDKVersionConflicts"
                  Condition="@(_WindowsSDKUnresolvedRef) != ''"/>
   </Target>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.WindowsSdkSupportedTargetPlatforms.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.WindowsSdkSupportedTargetPlatforms.props
@@ -6,7 +6,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
           created a backup copy.  Incorrect changes to this file will make it
           impossible to load or build your projects from the command-line or the IDE.
 
-Copyright (c) .NET Foundation. All rights reserved. 
+Copyright (c) .NET Foundation. All rights reserved.
 ***********************************************************************************************
 -->
 
@@ -19,7 +19,7 @@ Copyright (c) .NET Foundation. All rights reserved.
         <WindowsSdkSupportedTargetPlatformVersion Include="8.0" />
         <WindowsSdkSupportedTargetPlatformVersion Include="7.0" />
     </ItemGroup>
-  
+
     <ItemGroup>
         <SdkSupportedTargetPlatformVersion Condition="'$(TargetPlatformIdentifier)' == 'Windows'" Include="@(WindowsSdkSupportedTargetPlatformVersion)" />
     </ItemGroup>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.PackageDependencyResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.PackageDependencyResolution.targets
@@ -6,7 +6,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
           created a backup copy.  Incorrect changes to this file will make it
           impossible to load or build your projects from the command-line or the IDE.
 
-Copyright (c) .NET Foundation. All rights reserved. 
+Copyright (c) .NET Foundation. All rights reserved.
 ***********************************************************************************************
 -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
@@ -22,7 +22,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <PropertyGroup>
     <ProjectAssetsFile Condition="'$(ProjectAssetsFile)' == ''">$(MSBuildProjectExtensionsPath)/project.assets.json</ProjectAssetsFile>
     <ProjectAssetsFile>$([MSBuild]::NormalizePath($(MSBuildProjectDirectory), $(ProjectAssetsFile)))</ProjectAssetsFile>
-    
+
     <!-- Note that the assets.cache file has contents that are unique to the current TFM and configuration and therefore cannot
          be stored in a shared directory next to the assets.json file -->
     <ProjectAssetsCacheFile Condition="'$(ProjectAssetsCacheFile)' == ''">$(IntermediateOutputPath)$(MSBuildProjectName).assets.cache</ProjectAssetsCacheFile>
@@ -122,7 +122,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     ============================================================
                      ResolvePackageDependenciesForBuild
 
-    Populate items for build. This is triggered before target 
+    Populate items for build. This is triggered before target
     "AssignProjectConfiguration" to ensure ProjectReference items
     are populated before ResolveProjectReferences is run.
     ============================================================
@@ -164,7 +164,7 @@ Copyright (c) .NET Foundation. All rights reserved.
            AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
   <UsingTask TaskName="Microsoft.NET.Build.Tasks.JoinItems"
            AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
-  <UsingTask TaskName="Microsoft.NET.Build.Tasks.ResolvePackageAssets" 
+  <UsingTask TaskName="Microsoft.NET.Build.Tasks.ResolvePackageAssets"
             AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
 
   <!-- The condition on this target causes it to be skipped during design-time builds if
@@ -202,7 +202,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   </Target>
 
-  <Target Name="ResolvePackageAssets" 
+  <Target Name="ResolvePackageAssets"
           Condition=" '$(DesignTimeBuild)' != 'true' Or Exists('$(ProjectAssetsFile)')"
           DependsOnTargets="ProcessFrameworkReferences;_DefaultMicrosoftNETPlatformLibrary;_ComputePackageReferencePublish">
 
@@ -215,7 +215,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <PropertyGroup Condition="'$(UseAppHostFromAssetsFile)' == ''">
       <UseAppHostFromAssetsFile>true</UseAppHostFromAssetsFile>
     </PropertyGroup>
-    
+
     <PropertyGroup Condition="'$(EnsureRuntimePackageDependencies)' == ''
                           and '$(TargetFrameworkIdentifier)' == '.NETCoreApp'
                           and '$(_TargetFrameworkVersionWithoutV)' &lt; '3.0'
@@ -238,7 +238,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       <ExpectedPlatformPackages Include="@(PackageReference)" Condition="'%(Identity)' == 'Microsoft.AspNetCore.All'" />
     </ItemGroup>
 
-    <ResolvePackageAssets 
+    <ResolvePackageAssets
       ProjectAssetsFile="$(ProjectAssetsFile)"
       ProjectAssetsCacheFile="$(ProjectAssetsCacheFile)"
       ProjectPath="$(MSBuildProjectFullPath)"
@@ -304,7 +304,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <UsingTask TaskName="Microsoft.NET.Build.Tasks.PreprocessPackageDependenciesDesignTime"
              AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
-  
+
   <Target Name="ResolvePackageDependenciesDesignTime"
           Returns="@(_PackageDependenciesDesignTime)"
           DependsOnTargets="RunResolvePackageDependencies;ResolveAssemblyReferencesDesignTime">
@@ -319,7 +319,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     </PreprocessPackageDependenciesDesignTime>
 
   </Target>
-    
+
   <!--
     ============================================================
                      CollectSDKReferencesDesignTime
@@ -371,7 +371,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     ============================================================
                      RunProduceContentAssets
 
-    Process content assets by handling preprocessing tokens where necessary, and 
+    Process content assets by handling preprocessing tokens where necessary, and
     produce copy local items, content items grouped by "build action" and file writes
     ============================================================
     -->
@@ -395,7 +395,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       <Output TaskParameter="FileWrites" ItemName="FileWrites" />
     </ProduceContentAssets>
 
-    <!-- The items in _ProcessedContentItems need to go into the appropriately-named item group, 
+    <!-- The items in _ProcessedContentItems need to go into the appropriately-named item group,
          but the names depend upon the items themselves. Split it apart. -->
     <CreateItem Include="@(_ProcessedContentItems)" Condition="'@(_ProcessedContentItems)' != ''">
       <Output TaskParameter="Include" ItemName="%(_ProcessedContentItems.ProcessedItemType)" />
@@ -410,7 +410,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     ============================================================
     -->
 
-  <Target Name="ResolveLockFileReferences" 
+  <Target Name="ResolveLockFileReferences"
           DependsOnTargets="ResolvePackageAssets">
 
     <ItemGroup Condition="'$(MarkPackageReferencesAsExternallyResolved)' == 'true'">
@@ -426,11 +426,11 @@ Copyright (c) .NET Foundation. All rights reserved.
       <!-- Add framework references from NuGet packages here, so that if there is also a matching reference from a NuGet package,
            it will be treated the same as a reference from the project file.  If there is already an explicit Reference from the
            project, use that, in order to preserve metadata (such as aliases). -->
-      <Reference Include="@(ResolvedFrameworkAssemblies)" 
+      <Reference Include="@(ResolvedFrameworkAssemblies)"
                  Exclude="@(Reference)" />
-      
+
     </ItemGroup>
-    
+
     <!-- If there are any references from a NuGet package that match a simple reference which
          would resolve to a framework assembly, then update the NuGet references to use the
          simple name as the ItemSpec.  This will prevent the VS project system from marking
@@ -444,7 +444,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       <Reference Remove="@(_JoinedResolvedCompileFileDefinitions)" />
       <Reference Include="@(_JoinedResolvedCompileFileDefinitions)" />
     </ItemGroup>
-    
+
     <ItemGroup>
       <ResolvedCompileFileDefinitionsToAdd Include="@(ResolvedCompileFileDefinitions)" />
       <ResolvedCompileFileDefinitionsToAdd Remove="%(_JoinedResolvedCompileFileDefinitions.HintPath)" />
@@ -457,20 +457,20 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <!--
     ============================================================
-    ProjectReference Targets: Include transitive project references before 
+    ProjectReference Targets: Include transitive project references before
                               ResolveProjectReferences is called
     - IncludeTransitiveProjectReferences
     ============================================================
     -->
 
-  <Target Name="IncludeTransitiveProjectReferences" 
+  <Target Name="IncludeTransitiveProjectReferences"
           DependsOnTargets="ResolvePackageAssets"
           Condition="'$(DisableTransitiveProjectReferences)' != 'true'">
     <ItemGroup>
       <ProjectReference Include="@(_TransitiveProjectReferences)" />
     </ItemGroup>
   </Target>
-  
+
   <!--
     ============================================================
     Analyzer Targets: For populating Analyzers based on lock file
@@ -515,7 +515,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <!-- Override EnsureNETCoreAppRuntime target which is included in Microsoft.NETCore.App NuGet package for
        .NET Core 2.x.  It no longer works with the .NET 5.0.100 SDK, as the ParentTarget metadata has changed format
        but the targets in the NuGet package still expect the old format.
-       
+
        So here we just override that target.  We have logic in the SDK that covers this scenario and generates
        NETSDK1056. -->
   <Target Name="EnsureNETCoreAppRuntime" />

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.PackageDependencyResolutionStubs.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.PackageDependencyResolutionStubs.targets
@@ -6,7 +6,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
           created a backup copy.  Incorrect changes to this file will make it
           impossible to load or build your projects from the command-line or the IDE.
 
-Copyright (c) .NET Foundation. All rights reserved. 
+Copyright (c) .NET Foundation. All rights reserved.
 ***********************************************************************************************
 -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">

--- a/src/WebSdk/ProjectSystem/Sdk/Sdk.props
+++ b/src/WebSdk/ProjectSystem/Sdk/Sdk.props
@@ -6,12 +6,12 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
           created a backup copy.  Incorrect changes to this file will make it
           impossible to load or build your projects from the command-line or the IDE.
 
-Copyright (c) .NET Foundation. All rights reserved. 
+Copyright (c) .NET Foundation. All rights reserved.
 ***********************************************************************************************
 -->
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <Import Project="$(MSBuildThisFileDirectory)..\targets\Microsoft.NET.Sdk.Web.ProjectSystem.props" 
+  <Import Project="$(MSBuildThisFileDirectory)..\targets\Microsoft.NET.Sdk.Web.ProjectSystem.props"
 		Condition="Exists('$(MSBuildThisFileDirectory)..\targets\Microsoft.NET.Sdk.Web.ProjectSystem.props')" />
 
 </Project>

--- a/src/WebSdk/ProjectSystem/Sdk/Sdk.targets
+++ b/src/WebSdk/ProjectSystem/Sdk/Sdk.targets
@@ -6,12 +6,12 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
           created a backup copy.  Incorrect changes to this file will make it
           impossible to load or build your projects from the command-line or the IDE.
 
-Copyright (c) .NET Foundation. All rights reserved. 
+Copyright (c) .NET Foundation. All rights reserved.
 ***********************************************************************************************
 -->
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <Import Project="$(MSBuildThisFileDirectory)..\targets\Microsoft.NET.Sdk.Web.ProjectSystem.targets" 
+  <Import Project="$(MSBuildThisFileDirectory)..\targets\Microsoft.NET.Sdk.Web.ProjectSystem.targets"
 		Condition="Exists('$(MSBuildThisFileDirectory)..\targets\Microsoft.NET.Sdk.Web.ProjectSystem.targets')" />
 
 </Project>

--- a/src/WebSdk/ProjectSystem/Targets/Microsoft.NET.Sdk.Web.DefaultItems.props
+++ b/src/WebSdk/ProjectSystem/Targets/Microsoft.NET.Sdk.Web.DefaultItems.props
@@ -11,8 +11,8 @@ Copyright (c) .NET Foundation. All rights reserved.
 -->
 <Project ToolsVersion="14.0">
 
-  <ItemGroup Condition="'$(EnableDefaultItems)' == 'true' 
-             And '$(EnableDefaultContentItems)' == 'true' 
+  <ItemGroup Condition="'$(EnableDefaultItems)' == 'true'
+             And '$(EnableDefaultContentItems)' == 'true'
              And '$(EnableDefaultNoneItems)' == 'true'
              And '$(AppDesignerFolder)' != ''">
 
@@ -23,7 +23,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                           $(AppDesignerFolder)\PublishProfiles\**"
                           Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)"/>
 
-    <!-- Removing the tooling artifacts from all other globs and adding it to the none glob. This ensures that the 
+    <!-- Removing the tooling artifacts from all other globs and adding it to the none glob. This ensures that the
          up-to-date check is unimpacted by the changes to the tooling artifacts -->
     <None Remove="@(_WebToolingArtifacts)" />
     <None Include="@(_WebToolingArtifacts)"
@@ -38,7 +38,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <!-- Keep track of the default content items for later to distinguish them from newly generated content items -->
     <_ContentIncludedByDefault Remove="@(_ContentIncludedByDefault)" />
     <_ContentIncludedByDefault Include="@(Content)" />
-    
+
   </ItemGroup>
 
 </Project>

--- a/src/WebSdk/ProjectSystem/Targets/Microsoft.NET.Sdk.Web.ProjectSystem.props
+++ b/src/WebSdk/ProjectSystem/Targets/Microsoft.NET.Sdk.Web.ProjectSystem.props
@@ -29,4 +29,3 @@ Copyright (c) .NET Foundation. All rights reserved.
     Condition="Exists('$(MSBuildThisFileDirectory)Microsoft.NET.Sdk.Web.DefaultItems.props')"/>
 
 </Project>
-

--- a/src/WebSdk/Publish/Sdk/Sdk.props
+++ b/src/WebSdk/Publish/Sdk/Sdk.props
@@ -6,7 +6,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
           created a backup copy.  Incorrect changes to this file will make it
           impossible to load or build your projects from the command-line or the IDE.
 
-Copyright (c) .NET Foundation. All rights reserved. 
+Copyright (c) .NET Foundation. All rights reserved.
 ***********************************************************************************************
 -->
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">

--- a/src/WebSdk/Publish/Sdk/Sdk.targets
+++ b/src/WebSdk/Publish/Sdk/Sdk.targets
@@ -6,7 +6,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
           created a backup copy.  Incorrect changes to this file will make it
           impossible to load or build your projects from the command-line or the IDE.
 
-Copyright (c) .NET Foundation. All rights reserved. 
+Copyright (c) .NET Foundation. All rights reserved.
 ***********************************************************************************************
 -->
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">

--- a/src/WebSdk/Publish/Targets/ComputeTargets/Microsoft.NET.Sdk.Publish.ComputeFiles.targets
+++ b/src/WebSdk/Publish/Targets/ComputeTargets/Microsoft.NET.Sdk.Publish.ComputeFiles.targets
@@ -48,7 +48,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   <!--***************************************************************-->
   <!-- Target _IncludePrePublishGeneratedContent                     -->
   <!--***************************************************************-->
-  
+
   <Target Name="_IncludePrePublishGeneratedContent" BeforeTargets="GetCopyToPublishDirectoryItems" Condition=" '$(EnableDefaultItems)' == 'true' And '$(EnableDefaultContentItems)' == 'true' ">
     <ItemGroup>
       <!-- First, clean up previously generated content that may have been removed. -->
@@ -58,5 +58,5 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       <ContentWithTargetPath Include="@(_WebProjectGeneratedContent)" TargetPath="%(Identity)" CopyToPublishDirectory="PreserveNewest" />
     </ItemGroup>
   </Target>
-  
+
 </Project>

--- a/src/WebSdk/Publish/Targets/CopyTargets/Microsoft.NET.Sdk.Publish.CopyFiles.targets
+++ b/src/WebSdk/Publish/Targets/CopyTargets/Microsoft.NET.Sdk.Publish.CopyFiles.targets
@@ -28,11 +28,11 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   <!-- Target _RemoveExcludeFiles -->
   <!--********************************************************************-->
   <Target Name="_RemoveExcludeFiles" >
-    
+
     <ItemGroup>
       <DotNetPublishFiles Remove="@(DotNetPublishFiles)"  Condition="'%(Exclude)' == 'true'" />
     </ItemGroup>
-    
+
   </Target>
 
   <!--********************************************************************-->
@@ -51,19 +51,19 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <MakeDir Directories="$(PublishIntermediateOutputPath)" Condition="!Exists('$(PublishIntermediateOutputPath)')"/>
 
   </Target>
-         
-  
+
+
   <!--********************************************************************-->
   <!-- Target _CopyAllFilesToPublishIntermediateOutputPath -->
   <!--********************************************************************-->
   <Target Name="_CopyFilesToPublishIntermediateOutputPath">
-    
+
     <Copy
     SourceFiles="@(DotNetPublishFiles)"
     DestinationFiles="@(DotNetPublishFiles ->'$(PublishIntermediateOutputPath)%(DestinationRelativePath)')"  />
-    
+
   </Target>
-  
+
   <!--********************************************************************-->
   <!-- Target _CopyAspNetCoreFilesToIntermediateOutputPath -->
   <!--********************************************************************-->
@@ -74,8 +74,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       Publish;
     </_CopyAspNetCoreFilesToIntermediateOutputPathDependsOn>
   </PropertyGroup>
-  
-  <Target Name="_CopyAspNetCoreFilesToIntermediateOutputPath" 
+
+  <Target Name="_CopyAspNetCoreFilesToIntermediateOutputPath"
     Condition="'$(_PublishProjectType)' == 'AspNetCore'"
     DependsOnTargets="$(_CopyAspNetCoreFilesToIntermediateOutputPathDependsOn)">
   </Target>
@@ -89,7 +89,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       <Configuration>$(PublishConfiguration)</Configuration>
     </PropertyGroup>
   </Target>
-  
+
    <!--********************************************************************-->
   <!-- Target _CopyWebJobFilesToIntermediateOutputPath -->
   <!--********************************************************************-->

--- a/src/WebSdk/Publish/Targets/CopyTargets/Microsoft.NET.Sdk.Publish.FilterFiles.targets
+++ b/src/WebSdk/Publish/Targets/CopyTargets/Microsoft.NET.Sdk.Publish.FilterFiles.targets
@@ -26,12 +26,12 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       Condition="'%(Filename)%(Extension)' == 'aspnetcorev2_inprocess.dll'">
         <CopyToPublishDirectory>Never</CopyToPublishDirectory>
       </ResolvedFileToPublish>
-      
+
       <ResolvedFileToPublish Update="@(ResolvedFileToPublish)"
         Condition="'%(Filename)%(Extension)' == 'web.config'">
         <CopyToPublishDirectory>Never</CopyToPublishDirectory>
       </ResolvedFileToPublish>
     </ItemGroup>
-    
+
   </Target>
 </Project>

--- a/src/WebSdk/Publish/Targets/DotNetCLIToolTargets/Microsoft.NET.Sdk.DotNetCLITool.targets
+++ b/src/WebSdk/Publish/Targets/DotNetCLIToolTargets/Microsoft.NET.Sdk.DotNetCLITool.targets
@@ -88,7 +88,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <ConvertToAbsolutePath Paths="$(PublishDir)">
       <Output TaskParameter="AbsolutePaths" PropertyName="PublishDirFullPath"/>
     </ConvertToAbsolutePath>
-    
+
     <PropertyGroup>
       <PublishIntermediateOutputPath>$(PublishDirFullPath)</PublishIntermediateOutputPath>
     </PropertyGroup>
@@ -100,9 +100,9 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     </_PublishFilesDependsOn>
   </PropertyGroup>
 
-  <Target Name="_PublishFiles" 
+  <Target Name="_PublishFiles"
           DependsOnTargets="$(_PublishFilesDependsOn)"
-          Condition="'$(PublishProtocol)' != 'FileSystem' And '$(PublishProtocol)' != ''"> 
+          Condition="'$(PublishProtocol)' != 'FileSystem' And '$(PublishProtocol)' != ''">
   </Target>
-  
+
 </Project>

--- a/src/WebSdk/Publish/Targets/Microsoft.NET.Sdk.Publish.props
+++ b/src/WebSdk/Publish/Targets/Microsoft.NET.Sdk.Publish.props
@@ -6,7 +6,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
           created a backup copy.  Incorrect changes to this file will make it
           impossible to load or build your projects from the command-line or the IDE.
 
-Copyright (c) .NET Foundation. All rights reserved. 
+Copyright (c) .NET Foundation. All rights reserved.
 ***********************************************************************************************
 -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">

--- a/src/WebSdk/Publish/Targets/Microsoft.NET.Sdk.Publish.targets
+++ b/src/WebSdk/Publish/Targets/Microsoft.NET.Sdk.Publish.targets
@@ -1,6 +1,6 @@
 <!--
 ***********************************************************************************************
-Microsoft.NET.Sdk.Publish.targets  
+Microsoft.NET.Sdk.Publish.targets
 
 WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
           created a backup copy.  Incorrect changes to this file will make it
@@ -15,7 +15,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <!-- Properties corresponding to the tasks and targets path-->
-  
+
   <PropertyGroup>
     <!-- We want to force this property to be true, hence not adding a condition check -->
     <SupportsDeployOnBuild>true</SupportsDeployOnBuild>
@@ -30,8 +30,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <_DotNetCLIToolTargetsDir Condition=" '$(_DotNetCLIToolTargetsDir)'=='' ">$(MSBuildThisFileDirectory)DotNetCLIToolTargets\</_DotNetCLIToolTargetsDir>
     <_PublishProfilesDir Condition=" '$(_PublishProfilesDir)'=='' ">$(MSBuildThisFileDirectory)PublishProfiles\</_PublishProfilesDir>
 
-    <PublishIISAssets Condition=" '$(TargetFrameworkIdentifier)' == '.NETCoreApp' 
-             And '$(_TargetFrameworkVersionWithoutV)' != '' 
+    <PublishIISAssets Condition=" '$(TargetFrameworkIdentifier)' == '.NETCoreApp'
+             And '$(_TargetFrameworkVersionWithoutV)' != ''
              AND $([MSBuild]::VersionGreaterThanOrEquals($(_TargetFrameworkVersionWithoutV), '5.0'))
              And '$(RuntimeIdentifier)' != ''
              And !$(RuntimeIdentifier.StartsWith('win'))
@@ -51,7 +51,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <PublishProfile Condition="'$(PublishProfile)' ==''">FileSystem</PublishProfile>
     <PublishProfileName Condition="'$(PublishProfileName)' == ''">$([System.IO.Path]::GetFileNameWithoutExtension($(PublishProfile)))</PublishProfileName>
   </PropertyGroup>
-  
+
   <Import Project="$(_PublishProfilesDir)$(PublishProfileName).pubxml" Condition="Exists('$(_PublishProfilesDir)$(PublishProfileName).pubxml') And '$(PublishProfileImported)' != 'true'" />
 
   <!--
@@ -65,10 +65,10 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <PublishProtocol Condition="'$(PublishProtocol)' == ''">$(WebPublishMethod)</PublishProtocol>
     <!-- For backward compat -->
     <PublishProtocol Condition="'$(PublishProtocol)' == 'Package'">MSDeployPackage</PublishProtocol>
-    
+
     <!-- For Docker Support -->
     <PublishProtocol Condition="'$(DockerPublish)' == 'true'">Docker</PublishProtocol>
-    
+
     <!-- Properties setting the publish intermediate paths -->
     <PublishConfiguration Condition ="'$(PublishConfiguration)' == ''">$(LastUsedBuildConfiguration)</PublishConfiguration>
     <PublishConfiguration Condition="'$(PublishConfiguration)' == ''">$(Configuration)</PublishConfiguration>
@@ -83,7 +83,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <PublishIntermediateTempPath Condition="'$(PublishIntermediateTempPath)' == ''">$([System.IO.Path]::GetFullPath($(BaseIntermediateOutputPath)$(_PublishConfigurationPath)$(_TargetFrameworkPath)$(_RuntimeIdentifierPath)PubTmp\))</PublishIntermediateTempPath>
     <PublishIntermediateOutputPath Condition="'$(PublishIntermediateOutputPath)' == ''">$(PublishIntermediateTempPath)Out\</PublishIntermediateOutputPath>
     <PublishIntermediateOutputPath Condition="'$(DockerPublish)' == 'true'">obj/Docker/publish/</PublishIntermediateOutputPath>
-    
+
     <EFSQLScriptsFolderName Condition="$(EFSQLScriptsFolderName) == ''">EFSQLScripts</EFSQLScriptsFolderName>
   </PropertyGroup>
 
@@ -103,13 +103,13 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
   <Import Project="$(_CopyTargetsDir)Microsoft.NET.Sdk.Publish.FilterFiles.targets" Condition="Exists('$(_CopyTargetsDir)Microsoft.NET.Sdk.Publish.FilterFiles.targets')"/>
 
- 
+
   <!--
   ***********************************************************************************************
   Import the Copy target
   ***********************************************************************************************
  -->
-  
+
   <Import Project="$(_CopyTargetsDir)Microsoft.NET.Sdk.Publish.CopyFiles.targets" Condition="Exists('$(_CopyTargetsDir)Microsoft.NET.Sdk.Publish.CopyFiles.targets')"/>
 
 
@@ -126,7 +126,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   Import the Protocol target
   ***********************************************************************************************
  -->
-  
+
   <Import Project="$(_PublishTargetsDir)Microsoft.NET.Sdk.Publish.$(PublishProtocol).targets" Condition="Exists('$(_PublishTargetsDir)Microsoft.NET.Sdk.Publish.$(PublishProtocol).targets')"/>
 
   <!--
@@ -170,7 +170,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   <!--
   ***********************************************************************************************
   NOTE: We have to add WebPublishProfileFile to GlobalPropertiesToRemove to prevent it to flow to
-  other web apps that are referenced by current web app. If we don't do that, their output paths 
+  other web apps that are referenced by current web app. If we don't do that, their output paths
   will be messed up with RuntimeIdentifier we pass in pubxml file.
   ***********************************************************************************************
   -->
@@ -180,7 +180,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     </ProjectReference>
   </ItemDefinitionGroup>
 
-  <Target Name="CorePublish" 
+  <Target Name="CorePublish"
           DependsOnTargets="$(CorePublishDependsOn)"/>
-  
+
 </Project>

--- a/src/WebSdk/Publish/Targets/PublishProfiles/FileSystem.pubxml
+++ b/src/WebSdk/Publish/Targets/PublishProfiles/FileSystem.pubxml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
 This file is used by the publish/package process of your Web project. You can customize the behavior of this process
-by editing this MSBuild file. In order to learn more about this please visit http://go.microsoft.com/fwlink/?LinkID=208121. 
+by editing this MSBuild file. In order to learn more about this please visit http://go.microsoft.com/fwlink/?LinkID=208121.
 -->
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>

--- a/src/WebSdk/Publish/Targets/PublishTargets/Microsoft.NET.Sdk.Publish.FileSystem.targets
+++ b/src/WebSdk/Publish/Targets/PublishTargets/Microsoft.NET.Sdk.Publish.FileSystem.targets
@@ -13,7 +13,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 -->
 
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  
+
   <PropertyGroup>
     <_DotNetPublishFiles>
       FileSystemPublish;
@@ -34,7 +34,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     </FileSystemPublishDependsOn>
   </PropertyGroup>
 
-  <Target Name="FileSystemPublish" 
+  <Target Name="FileSystemPublish"
           DependsOnTargets="$(FileSystemPublishDependsOn)"
           Inputs="@(_PublishIntermediateOutputPathFiles)"
           Outputs="@(_PublishIntermediateOutputPathFiles ->'$(PublishUrl)%(RecursiveDir)%(Filename)%(Extension)')">
@@ -42,7 +42,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <Copy
         SourceFiles="@(_PublishIntermediateOutputPathFiles)"
         DestinationFiles="@(_PublishIntermediateOutputPathFiles ->'$(PublishUrl)%(RecursiveDir)%(Filename)%(Extension)')" />
-    
+
   </Target>
 
   <!--
@@ -94,8 +94,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <Copy
     Condition="@(_EFSQLScripts) != ''"
     SourceFiles="@(_EFSQLScripts)"
-    DestinationFiles="@(_EFSQLScripts ->'$(PublishIntermediateOutputPath)$(EFSQLScriptsFolderName)\%(Filename)%(Extension)')" 
+    DestinationFiles="@(_EFSQLScripts ->'$(PublishIntermediateOutputPath)$(EFSQLScriptsFolderName)\%(Filename)%(Extension)')"
     ContinueOnError="true"/>
   </Target>
-  
+
 </Project>

--- a/src/WebSdk/Publish/Targets/PublishTargets/Microsoft.NET.Sdk.Publish.Kudu.targets
+++ b/src/WebSdk/Publish/Targets/PublishTargets/Microsoft.NET.Sdk.Publish.Kudu.targets
@@ -43,7 +43,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <ValidateParameter
     ParameterName="UserName"
     ParameterValue="$(UserName)"/>
-    
+
     <PropertyGroup>
       <PublishUrl Condition=" '$(PublishUrl)'=='' ">https://{0}.scm.azurewebsites.net/api/{1}</PublishUrl>
       <DeployIndividualFiles Condition=" '$(DeployIndividualFiles)' != 'true'">false</DeployIndividualFiles>

--- a/src/WebSdk/Publish/Targets/PublishTargets/Microsoft.NET.Sdk.Publish.MSDeploy.targets
+++ b/src/WebSdk/Publish/Targets/PublishTargets/Microsoft.NET.Sdk.Publish.MSDeploy.targets
@@ -95,10 +95,10 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     </CreateProperty>
 
     <!-- Normalize service url such as convert a server name to format like https://<server>:8172/msdeploy.axd-->
-    <NormalizeServiceUrl 
-      ServiceUrl="$(MsDeployServiceUrl)" 
-      UseWMSVC="$(_UseWMSVC)" 
-      UseRemoteAgent="$(_UseRemoteAgent)" 
+    <NormalizeServiceUrl
+      ServiceUrl="$(MsDeployServiceUrl)"
+      UseWMSVC="$(_UseWMSVC)"
+      UseRemoteAgent="$(_UseRemoteAgent)"
       SiteName="$(DeployIisAppPath)"
       Condition="$(NormalizePublishSettings) == 'true'" >
       <Output TaskParameter="ResultUrl" PropertyName="MsDeployServiceUrl" />
@@ -109,7 +109,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       Condition="'$(Password)' == '' And '$(IsGetPasswordEnabled)' == 'true'">
       <Output TaskParameter="ClearPassword" PropertyName="Password"/>
     </GetPassword>
-    
+
     <!--  Data Passed to MSDeploy -->
     <ItemGroup>
       <MsDeploySourceProviderSetting Remove="@(MsDeploySourceProviderSetting)" />
@@ -167,7 +167,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <PropertyGroup>
       <_EnableRuleList>@(_EnableRuleListItems)</_EnableRuleList>
     </PropertyGroup>
-    
+
     <MSdeploy
           Condition="'$(UseMsdeployExe)' == 'true'"
           Verb="sync"
@@ -225,7 +225,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         <Path>$(PublishIntermediateOutputPath)</Path>
       </MsDeploySourceManifest>
     </ItemGroup>
-    
+
     <ItemGroup Condition="'@(_EFSQLScripts)' != ''">
       <MsDeploySourceManifest Include="dbfullsql" >
         <Path>%(_EFSQLScripts.Identity)</Path>
@@ -260,7 +260,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         <ExcludeFromSetParameter>false</ExcludeFromSetParameter>
       </MsDeployDeclareParameters>
     </ItemGroup>
-    
+
     <ItemGroup Condition="'@(_EFSQLScripts)' != ''">
       <MsDeployDeclareParameters Include="%(_EFSQLScripts.DBContext)">
         <Kind>ProviderPath</Kind>
@@ -276,13 +276,13 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     </ItemGroup>
 
     <ItemGroup>
-      <ParametersXMLFiles Include="$(MSBuildProjectDirectory)\Parameters.xml" 
+      <ParametersXMLFiles Include="$(MSBuildProjectDirectory)\Parameters.xml"
                           Condition="Exists('$(MSBuildProjectDirectory)\Parameters.xml')"/>
     </ItemGroup>
 
-    <ImportParameterFile Condition="'@(ParametersXMLFiles)' != ''" 
+    <ImportParameterFile Condition="'@(ParametersXMLFiles)' != ''"
                          Files="@(ParametersXMLFiles)">
-      <Output TaskParameter="Result" 
+      <Output TaskParameter="Result"
               ItemName="_ImportedMSDeployDeclareParameters" />
     </ImportParameterFile>
 

--- a/src/WebSdk/Publish/Targets/PublishTargets/Microsoft.NET.Sdk.Publish.MSDeployPackage.targets
+++ b/src/WebSdk/Publish/Targets/PublishTargets/Microsoft.NET.Sdk.Publish.MSDeployPackage.targets
@@ -115,7 +115,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
  -->
 
   <Target Name="_InitMSDeployPackageProperties">
-   
+
     <PropertyGroup>
       <DefaultPackageFileName Condition="'$(DefaultPackageFileName)'==''">$(MSBuildProjectName).zip</DefaultPackageFileName>
       <PackageLocation Condition="'$(PackageLocation)' == ''">$(DesktopBuildPackageLocation)</PackageLocation>
@@ -131,7 +131,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     </ConvertToAbsolutePath>
 
   </Target>
-  
+
   <!--
   ***********************************************************************************************
   TARGET : _PrepareForMsDeployPackagePublish
@@ -152,7 +152,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <ItemGroup>
       <_PublishConfigFiles Include="$(_MsDeploySourceManifestPath);$(_MSDeployParametersFilePath);$(_MSDeploySetParametersFilePath);$(_MSDeployScriptFilePath);$(_MSDeployReadMeFilePath)" />
     </ItemGroup>
-    
+
     <MakeDir Directories="$(_destinationFolder)" Condition="!Exists('$(_destinationFolder)')" ContinueOnError="true"/>
     <Delete Files="@(_PublishConfigFiles)" ContinueOnError="true" />
     <Touch AlwaysCreate="true" Files="@(_PublishConfigFiles)" ContinueOnError="true" />
@@ -184,7 +184,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       Manifests="@(MsDeploySourceManifest)"
       ManifestFile="$(_MsDeploySourceManifestPath)" />
   </Target>
-  
+
     <!--
   ***********************************************************************************************
   TARGET : _CreateMSDeployScript
@@ -196,9 +196,9 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <CreateMsDeployScript
       Condition="'$(IsCreateMSDeployScriptDisabled)' != 'true'"
       ProjectName="$(MSBuildProjectName)"
-      ScriptFullPath="$(_MSDeployScriptFilePath)" 
+      ScriptFullPath="$(_MSDeployScriptFilePath)"
       ReadMeFullPath="$(_MSDeployReadMeFilePath)"/>
-      
+
   </Target>
 
   <!--
@@ -240,11 +240,11 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     </ItemGroup>
 
     <ItemGroup>
-      <ParametersXMLFiles Include="$(MSBuildProjectDirectory)\Parameters.xml" 
+      <ParametersXMLFiles Include="$(MSBuildProjectDirectory)\Parameters.xml"
                           Condition="Exists('$(MSBuildProjectDirectory)\Parameters.xml')"/>
     </ItemGroup>
 
-    <ImportParameterFile Condition="'@(ParametersXMLFiles)' != ''" 
+    <ImportParameterFile Condition="'@(ParametersXMLFiles)' != ''"
                          Files="@(ParametersXMLFiles)">
       <Output TaskParameter="Result"
               ItemName="_ImportedMSDeployDeclareParameters" />
@@ -257,7 +257,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         <Priority></Priority>
       </MsDeployDeclareParameters>
     </ItemGroup>
-    
+
     <CreateParameterFile
       Parameters="@(MsDeployDeclareParameters)"
       DeclareSetParameterFile="$(_MSDeployParametersFilePath)"
@@ -286,7 +286,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       <prefetchPayload></prefetchPayload>
     </MsDeploySourceProviderSetting>
   </ItemDefinitionGroup>
-  
+
   <ItemDefinitionGroup>
     <MsDeployDestinationProviderSetting>
       <Path></Path>
@@ -300,7 +300,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       <prefetchPayload></prefetchPayload>
     </MsDeployDestinationProviderSetting>
   </ItemDefinitionGroup>
-  
+
   <!--
   DeploymentSkipRule(string skipAction, string objectName, string absolutePath, string XPath);-->
   <ItemDefinitionGroup>

--- a/src/WebSdk/Publish/Targets/PublishTargets/Microsoft.NET.Sdk.Publish.ZipDeploy.targets
+++ b/src/WebSdk/Publish/Targets/PublishTargets/Microsoft.NET.Sdk.Publish.ZipDeploy.targets
@@ -12,7 +12,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
   <UsingTask TaskName="ZipDeploy" AssemblyFile="$(_PublishTaskAssemblyFullPath)" />
   <UsingTask TaskName="CreateZipFile" AssemblyFile="$(_PublishTaskAssemblyFullPath)" />
   <UsingTask TaskName="GetPassword" AssemblyFile="$(_PublishTaskAssemblyFullPath)" />
-  
+
   <PropertyGroup>
     <_DotNetPublishFiles>
       ZipDeploy;
@@ -26,7 +26,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
  -->
 
   <Target Name="CreateZipFile">
-    <CreateZipFile 
+    <CreateZipFile
       FolderToZip="$(PublishIntermediateOutputPath)"
       ProjectName="$(MSBuildProjectName)"
       PublishIntermediateTempPath="$(PublishIntermediateTempPath)">
@@ -51,7 +51,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
        Condition="'$(Password)' == '' And '$(IsGetPasswordEnabled)' == 'true'">
       <Output TaskParameter="ClearPassword" PropertyName="Password"/>
     </GetPassword>
-    
+
     <ZipDeploy
       ZipToPublishPath="$(ZippedPublishContentsPath)"
       SiteName="$(DeployIisAppPath)"
@@ -60,5 +60,5 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
       DestinationPassword="$(Password)"
       UserAgentVersion="$(ZipDeployUserAgent)"/>
   </Target>
-  
+
 </Project>

--- a/src/WebSdk/Publish/Targets/TransformTargets/Microsoft.NET.Sdk.Publish.TransformFiles.targets
+++ b/src/WebSdk/Publish/Targets/TransformTargets/Microsoft.NET.Sdk.Publish.TransformFiles.targets
@@ -45,11 +45,11 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       <_ExecutableExtension Condition=" '$(_ExecutableExtension)' == '' And $(RuntimeIdentifier.StartsWith('win')) ">.exe</_ExecutableExtension>
       <_TransformWebConfigForAzure Condition=" '$(PublishProvider)' == 'AzureWebSite' Or '$(WEBSITE_SITE_NAME)' != '' Or '$(DOTNET_CONFIGURE_AZURE)' == 'true' Or '$(DOTNET_CONFIGURE_AZURE)' == '1' ">true</_TransformWebConfigForAzure>
     </PropertyGroup>
-    
+
 
     <TransformWebConfig
-        Condition="'$(_IsAspNetCoreProject)' == 'true' 
-        And '$(IsTransformWebConfigDisabled)' != 'true' 
+        Condition="'$(_IsAspNetCoreProject)' == 'true'
+        And '$(IsTransformWebConfigDisabled)' != 'true'
         And '$(IsWebConfigTransformDisabled)' != 'true'
         And '$(PublishIISAssets)' != 'false'"
         TargetPath="$(TargetPath)"
@@ -58,12 +58,12 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         ExecutableExtension="$(_ExecutableExtension)"
         IsAzure="$(_TransformWebConfigForAzure)"
         ProjectGuid="$(ProjectGuid)"
-        IgnoreProjectGuid="$(IgnoreProjectGuid)" 
-        ProjectFullPath="$(MSBuildProjectFullPath)" 
+        IgnoreProjectGuid="$(IgnoreProjectGuid)"
+        ProjectFullPath="$(MSBuildProjectFullPath)"
         SolutionPath="$(SolutionPath)"
         AspNetCoreModuleName="$(AspNetCoreModuleName)"
         AspNetCoreHostingModel="$(AspNetCoreHostingModel)"
-        EnvironmentName="$(EnvironmentName)"/> 
+        EnvironmentName="$(EnvironmentName)"/>
   </Target>
 
 
@@ -79,21 +79,21 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       <TransformXmlStackTraceEnabled Condition="'$(TransformXmlStackTraceEnabled)' == ''">true</TransformXmlStackTraceEnabled>
       <!-- Forcing the property value to be boolean -->
       <TransformXmlStackTraceEnabled Condition="'$(TransformXmlStackTraceEnabled)' != 'true'">false</TransformXmlStackTraceEnabled>
-      <_WebConfigTransformCompleted Condition="'$(_IsAspNetCoreProject)' == 'true' 
-                                    And '$(IsTransformWebConfigDisabled)' != 'true' 
-                                    And '$(IsWebConfigTransformDisabled)' != 'true' 
+      <_WebConfigTransformCompleted Condition="'$(_IsAspNetCoreProject)' == 'true'
+                                    And '$(IsTransformWebConfigDisabled)' != 'true'
+                                    And '$(IsWebConfigTransformDisabled)' != 'true'
                                     And '$(PublishIISAssets)' != 'false'">true</_WebConfigTransformCompleted>
       <_WebConfigTransformCompleted Condition="'$(_WebConfigTransformCompleted)' == ''">false</_WebConfigTransformCompleted>
       <RunXdt Condition="'$(RunXdt)' == ''">$(_WebConfigTransformCompleted)</RunXdt>
     </PropertyGroup>
-    
+
   <PropertyGroup Condition="'$(WebPublishProfileFile)' !=''">
     <PublishProfileName>$([System.IO.Path]::GetFileNameWithoutExtension($(WebPublishProfileFile)))</PublishProfileName>
     <PublishProfileDirectory>$([System.IO.Path]::GetDirectoryName($(WebPublishProfileFile)))</PublishProfileDirectory>
   </PropertyGroup>
 
 <!-- PROJECT LEVEL TRANSFORMS -->
-    
+
     <!-- Run the Project transforms first i.e $(MSBuildProjectDirectory)\web.<transform>.config -->
     <ItemGroup>
       <!-- Run the transform at the config level e.g: web.Release.config if the configuration is Release-->
@@ -116,7 +116,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
                   TransformRootPath="$(MSBuildProjectDirectory)"/>
 
     <!-- PROFILE LEVEL TRANSFORMS -->
-    
+
     <!-- Run the Profile transforms next i.e $(PublishProfileDirectory)\$(PublishProfileName).transform -->
     <ItemGroup>
       <!-- Run the transform at the profile level e.g: Properties\PublishProfiles\FolderProfile.transform when the profile name is FolderProfile -->
@@ -135,7 +135,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
                   TransformRootPath="$(MSBuildProjectDirectory)"/>
 
     <!-- CUSTOM TRANSFORMS -->
-    
+
     <!-- Run the Custom transforms next i.e $(CustomTransformFileName) in the project directory first and then run $(CustomTransformFilePath)\$(CustomTransformFileName) -->
     <ItemGroup>
       <!-- Run the custom transform file e.g: MyTransformFile.xml if the $(CustomTransformFileName) passed to msbuild is MyTransformFile.xml-->
@@ -163,7 +163,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <ItemGroup>
       <EnvironmentTransforms Include="$(MSBuildThisFileDirectory)Transforms\EnvironmentWithLocation.transform;$(MSBuildThisFileDirectory)Transforms\EnvironmentNoLocation.transform" />
     </ItemGroup>
-    
+
     <GenerateEnvTransform Condition=" '$(WebConfigEnvironmentVariables)' != '' "
                           WebConfigEnvironmentVariables = "$(WebConfigEnvironmentVariables)"
                           EnvTransformTemplatePaths="@(EnvironmentTransforms)"
@@ -189,7 +189,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   TARGET : _TransformAppSettings
   ***********************************************************************************************
  -->
-  
+
   <Target Name="_TransformAppSettings">
     <PropertyGroup>
       <_IsAspNetCoreProject Condition="%(ProjectCapability.Identity) == 'AspNetCore'">true</_IsAspNetCoreProject>

--- a/src/WebSdk/Worker/Targets/Microsoft.NET.Sdk.Worker.props
+++ b/src/WebSdk/Worker/Targets/Microsoft.NET.Sdk.Worker.props
@@ -27,7 +27,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <!-- When ExcludeConfigFilesFromBuildOutput is set, do not copy .,config, .json files to the build output directory. -->
     <Content Include="**\*.config" ExcludeFromSingleFile="true" CopyToPublishDirectory="PreserveNewest" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" Condition="'$(ExcludeConfigFilesFromBuildOutput)'=='true'" />
     <Content Include="**\*.json" ExcludeFromSingleFile="true" CopyToPublishDirectory="PreserveNewest" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" Condition="'$(ExcludeConfigFilesFromBuildOutput)'=='true'" />
-    
+
     <!-- Set CopyToOutputDirectory and CopyToPublishDirectory to Never for items under AppDesignerFolder ("Properties", by default) to avoid publishing launchSettings.json -->
     <Content Update="$(AppDesignerFolder)\**" CopyToOutputDirectory="Never" CopyToPublishDirectory="Never" Condition="'$(AppDesignerFolder)' != ''"/>
 
@@ -41,4 +41,3 @@ Copyright (c) .NET Foundation. All rights reserved.
   <Import Sdk="Microsoft.NET.Sdk.Web.ProjectSystem" Project="../targets/Microsoft.NET.Sdk.Web.DefaultItems.props" />
 
 </Project>
-


### PR DESCRIPTION
#### CHANGES
Trims trailing white-space in all of the MSBuild SDKs' props and targets.
This patch makes sure that we follow the `EditorConfig` rule on `trim_trailing_whitespace`.

#### NOTES
This PR targets `v5` branch instead of `main` now. I'll also create a PR targeting `main` branch too. The reason I created this separately since, there are a few patches I have that touches some of these files. So, applying white-space changes early before any other PRs should make reviewing easier.