### PR TITLE
parsing work for dotnet nuget verify command

### DIFF
--- a/src/Cli/dotnet/OptionForwardingExtensions.cs
+++ b/src/Cli/dotnet/OptionForwardingExtensions.cs
@@ -67,7 +67,7 @@ namespace Microsoft.DotNet.Cli
 
         public ForwardedOption(string[] aliases) : base(aliases) { }
 
-        public ForwardedOption(string alias, string description) : base(alias, description) { }
+        public ForwardedOption(string alias, string description = null) : base(alias, description) { }
 
         public ForwardedOption<T> SetForwardingFunction(Func<T, IEnumerable<string>> func)
         {

--- a/src/Cli/dotnet/OptionForwardingExtensions.cs
+++ b/src/Cli/dotnet/OptionForwardingExtensions.cs
@@ -22,7 +22,9 @@ namespace Microsoft.DotNet.Cli
 
         public static Option ForwardAsMany<T>(this ForwardedOption<T> option, Func<T, IEnumerable<string>> format) => option.SetForwardingFunction(format);
 
-        public static IEnumerable<string> OptionValuesToBeForwarded(this ParseResult parseResult, Command command) => 
+        public static Option ForwardAsManyArgumentsEachPrefixedByOption(this ForwardedOption<IEnumerable<string>> option, string alias) => option.ForwardAsMany(o => ForwardedArguments(alias, o));
+
+        public static IEnumerable<string> OptionValuesToBeForwarded(this ParseResult parseResult, Command command) =>
             command.Options
                 .OfType<IForwardedOption>()
                 .SelectMany(o => o.GetForwardingFunction()(parseResult)) ?? Array.Empty<string>();
@@ -40,6 +42,15 @@ namespace Microsoft.DotNet.Cli
         {
             option.AllowMultipleArgumentsPerToken = false;
             return option;
+        }
+
+        private static IEnumerable<string> ForwardedArguments(string alias, IEnumerable<string> arguments)
+        {
+            foreach (string arg in arguments)
+            {
+                yield return alias;
+                yield return arg;
+            }
         }
     }
 

--- a/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/ListPackageReferencesCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/ListPackageReferencesCommandParser.cs
@@ -22,7 +22,7 @@ namespace Microsoft.DotNet.Cli
         public static readonly Option FrameworkOption = new ForwardedOption<IEnumerable<string>>("--framework", LocalizableStrings.CmdFrameworkDescription)
         {
             ArgumentHelpName = LocalizableStrings.CmdFramework
-        }.ForwardAsMany(o => ForwardedArguments("--framework", o))
+        }.ForwardAsManyArgumentsEachPrefixedByOption("--framework")
         .AllowSingleArgPerToken();
 
         public static readonly Option TransitiveOption = new ForwardedOption<bool>("--include-transitive", LocalizableStrings.CmdTransitiveDescription)
@@ -45,7 +45,7 @@ namespace Microsoft.DotNet.Cli
         public static readonly Option SourceOption = new ForwardedOption<IEnumerable<string>>("--source", LocalizableStrings.CmdSourceDescription)
         {
             ArgumentHelpName = LocalizableStrings.CmdSource
-        }.ForwardAsMany(o => ForwardedArguments("--source", o))
+        }.ForwardAsManyArgumentsEachPrefixedByOption("--source")
         .AllowSingleArgPerToken();
 
         public static readonly Option InteractiveOption = new ForwardedOption<bool>("--interactive", CommonLocalizableStrings.CommandInteractiveOptionDescription)
@@ -69,15 +69,6 @@ namespace Microsoft.DotNet.Cli
             command.AddOption(InteractiveOption);
 
             return command;
-        }
-
-        public static IEnumerable<string> ForwardedArguments(string token, IEnumerable<string> arguments)
-        {
-            foreach (var arg in arguments)
-            {
-                yield return token;
-                yield return arg;
-            }
         }
     }
 }

--- a/src/Cli/dotnet/commands/dotnet-nuget/NuGetCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-nuget/NuGetCommandParser.cs
@@ -77,20 +77,21 @@ namespace Microsoft.DotNet.Cli
 
         private static Command GetVerifyCommand()
         {
+            const string fingerprint = "--certificate-fingerprint";
             var verifyCommand = new Command("verify");
 
             verifyCommand.AddArgument(new Argument<IEnumerable<string>>() { Arity = ArgumentArity.OneOrMore });
 
             verifyCommand.AddOption(new Option<bool>("--all"));
-            verifyCommand.AddOption(new ForwardedOption<IEnumerable<string>>("--certificate-fingerprint", "certificatefingerprint")
-                .ForwardAsMany(o => ForwardedArguments("--certificate-fingerprint", o))
+            verifyCommand.AddOption(new ForwardedOption<IEnumerable<string>>(fingerprint, "certificatefingerprint")
+                .ForwardAsMany(o => ForwardedArguments(fingerprint, o))
                 .AllowSingleArgPerToken());
             verifyCommand.AddOption(CommonOptions.VerbosityOption());
 
             return verifyCommand;
         }
 
-        public static IEnumerable<string> ForwardedArguments(string token, IEnumerable<string> arguments)
+        private static IEnumerable<string> ForwardedArguments(string token, IEnumerable<string> arguments)
         {
             foreach (string arg in arguments)
             {

--- a/src/Cli/dotnet/commands/dotnet-nuget/NuGetCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-nuget/NuGetCommandParser.cs
@@ -85,14 +85,14 @@ namespace Microsoft.DotNet.Cli
             verifyCommand.AddOption(new ForwardedOption<IEnumerable<string>>("--certificate-fingerprint", "certificatefingerprint")
                 .ForwardAsMany(o => ForwardedArguments("--certificate-fingerprint", o))
                 .AllowSingleArgPerToken());
-            verifyCommand.AddOption(CommonOptions.VerbosityOption(o => $"--verbosity:{o}"));
+            verifyCommand.AddOption(CommonOptions.VerbosityOption());
 
             return verifyCommand;
         }
 
         public static IEnumerable<string> ForwardedArguments(string token, IEnumerable<string> arguments)
         {
-            foreach (var arg in arguments)
+            foreach (string arg in arguments)
             {
                 yield return token;
                 yield return arg;

--- a/src/Cli/dotnet/commands/dotnet-nuget/NuGetCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-nuget/NuGetCommandParser.cs
@@ -21,6 +21,7 @@ namespace Microsoft.DotNet.Cli
             command.AddCommand(GetDeleteCommand());
             command.AddCommand(GetLocalsCommand());
             command.AddCommand(GetPushCommand());
+            command.AddCommand(GetVerifyCommand());
 
             return command;
         }
@@ -72,6 +73,30 @@ namespace Microsoft.DotNet.Cli
             pushCommand.AddOption(new Option<bool>("--skip-duplicate"));
 
             return pushCommand;
+        }
+
+        private static Command GetVerifyCommand()
+        {
+            var verifyCommand = new Command("verify");
+
+            verifyCommand.AddArgument(new Argument<IEnumerable<string>>() { Arity = ArgumentArity.OneOrMore });
+
+            verifyCommand.AddOption(new Option<bool>("--all"));
+            verifyCommand.AddOption(new ForwardedOption<IEnumerable<string>>("--certificate-fingerprint", "certificatefingerprint")
+                .ForwardAsMany(o => ForwardedArguments("--certificate-fingerprint", o))
+                .AllowSingleArgPerToken());
+            verifyCommand.AddOption(CommonOptions.VerbosityOption(o => $"--verbosity:{o}"));
+
+            return verifyCommand;
+        }
+
+        public static IEnumerable<string> ForwardedArguments(string token, IEnumerable<string> arguments)
+        {
+            foreach (var arg in arguments)
+            {
+                yield return token;
+                yield return arg;
+            }
         }
     }
 }

--- a/src/Cli/dotnet/commands/dotnet-nuget/NuGetCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-nuget/NuGetCommandParser.cs
@@ -84,20 +84,11 @@ namespace Microsoft.DotNet.Cli
 
             verifyCommand.AddOption(new Option<bool>("--all"));
             verifyCommand.AddOption(new ForwardedOption<IEnumerable<string>>(fingerprint, "certificatefingerprint")
-                .ForwardAsMany(o => ForwardedArguments(fingerprint, o))
+                .ForwardAsManyArgumentsEachPrefixedByOption(fingerprint)
                 .AllowSingleArgPerToken());
             verifyCommand.AddOption(CommonOptions.VerbosityOption());
 
             return verifyCommand;
-        }
-
-        private static IEnumerable<string> ForwardedArguments(string token, IEnumerable<string> arguments)
-        {
-            foreach (string arg in arguments)
-            {
-                yield return token;
-                yield return arg;
-            }
         }
     }
 }

--- a/src/Cli/dotnet/commands/dotnet-nuget/NuGetCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-nuget/NuGetCommandParser.cs
@@ -83,7 +83,7 @@ namespace Microsoft.DotNet.Cli
             verifyCommand.AddArgument(new Argument<IEnumerable<string>>() { Arity = ArgumentArity.OneOrMore });
 
             verifyCommand.AddOption(new Option<bool>("--all"));
-            verifyCommand.AddOption(new ForwardedOption<IEnumerable<string>>(fingerprint, "certificatefingerprint")
+            verifyCommand.AddOption(new ForwardedOption<IEnumerable<string>>(fingerprint)
                 .ForwardAsManyArgumentsEachPrefixedByOption(fingerprint)
                 .AllowSingleArgPerToken());
             verifyCommand.AddOption(CommonOptions.VerbosityOption());

--- a/src/Tests/dotnet-nuget.UnitTests/GivenANuGetCommand.cs
+++ b/src/Tests/dotnet-nuget.UnitTests/GivenANuGetCommand.cs
@@ -43,6 +43,11 @@ namespace Microsoft.DotNet.Tools.Run.Tests
                             "--non-interactive" }, 0)]
         [InlineData(new[] { "locals" }, 0)]
         [InlineData(new[] { "locals", "http-cache", "packages-cache", "global-packages", "temp" }, 0)]
+        [InlineData(new[] { "verify", "foo.1.0.0.nupkg" }, 0)]
+        [InlineData(new[] { "verify", "foo.1.0.0.nupkg", "--all" }, 0)]
+        [InlineData(new[] { "verify", "foo.1.0.0.nupkg",
+                            "--certificate-fingerprint", "CE40881FF5F0AD3E58965DA20A9F57",
+                            "--certificate-fingerprint", "1EF1651A56933748E1BF1C99E537C4E039" }, 0)]
         public void ItPassesCommandIfSupported(string[] inputArgs, int result)
         {
             // Arrange

--- a/src/Tests/dotnet.Tests/CommandTests/CompleteCommandTests.cs
+++ b/src/Tests/dotnet.Tests/CommandTests/CompleteCommandTests.cs
@@ -224,5 +224,25 @@ namespace Microsoft.DotNet.Tests.Commands
             CompleteCommand.RunWithReporter(new[] { "dotnet nuget push " }, reporter).Should().Be(0);
             reporter.Lines.OrderBy(c => c).Should().Equal(expected.OrderBy(c => c));
         }
+
+        [Fact]
+        public void GivenNuGetVerifyCommandItDisplaysCompletions()
+        {
+            var expected = new[] {
+                "--all",
+                "--certificate-fingerprint",
+                "--verbosity",
+                "--help",
+                "-v",
+                "-?",
+                "-h",
+                "/?",
+                "/h",
+            };
+
+            var reporter = new BufferedReporter();
+            CompleteCommand.RunWithReporter(new[] { "dotnet nuget verify " }, reporter).Should().Be(0);
+            reporter.Lines.OrderBy(c => c).Should().Equal(expected.OrderBy(c => c));
+        }
     }
 }

--- a/src/Tests/dotnet.Tests/CommandTests/CompleteCommandTests.cs
+++ b/src/Tests/dotnet.Tests/CommandTests/CompleteCommandTests.cs
@@ -133,6 +133,7 @@ namespace Microsoft.DotNet.Tests.Commands
                 "delete",
                 "locals",
                 "push",
+                "verify"
             };
 
             var reporter = new BufferedReporter();


### PR DESCRIPTION
Fixes: https://github.com/dotnet/sdk/issues/13702

### Description
I work on NuGet Client team. We added [`dotnet nuget verify`](https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-nuget-verify) command to `dotnet SDK`. Added this command to the parser for tab completion. This is my first PR in this repo. If there are better ways to develop parsing logic for the said command, please let me know.