### PR TITLE
Encode TargetPaths before writing them to the editorconfig

### DIFF
--- a/src/Assets/TestProjects/RazorSimpleMvc/Views/Home/#F{}i+l!e.cshtml
+++ b/src/Assets/TestProjects/RazorSimpleMvc/Views/Home/#F{}i+l!e.cshtml
@@ -1,0 +1,1 @@
+<p>Just a file with a special character in the name!</p>

--- a/src/RazorSdk/SourceGenerators/RazorSourceGenerationContext.cs
+++ b/src/RazorSdk/SourceGenerators/RazorSourceGenerationContext.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using System.Text.RegularExpressions;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.CodeAnalysis;
 
@@ -149,7 +148,7 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
                     continue;
                 }
 
-                relativePath = Convert.FromBase64String(relativePath).ToString();
+                relativePath = Encoding.UTF8.GetString(Convert.FromBase64String(relativePath));
 
                 options.TryGetValue("build_metadata.AdditionalFiles.CssScope", out var cssScope);
 

--- a/src/RazorSdk/SourceGenerators/RazorSourceGenerationContext.cs
+++ b/src/RazorSdk/SourceGenerators/RazorSourceGenerationContext.cs
@@ -4,6 +4,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.CodeAnalysis;
 
@@ -146,6 +148,8 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
                         item.Path));
                     continue;
                 }
+
+                relativePath = Convert.FromBase64String(relativePath).ToString();
 
                 options.TryGetValue("build_metadata.AdditionalFiles.CssScope", out var cssScope);
 

--- a/src/RazorSdk/SourceGenerators/RazorSourceGenerator.cs
+++ b/src/RazorSdk/SourceGenerators/RazorSourceGenerator.cs
@@ -9,7 +9,6 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text;
-using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc.Razor.Extensions;
@@ -282,7 +281,7 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
                 switch (filePath[i])
                 {
                     case ':' or '\\' or '/':
-                    case char ch when !Char.IsLetterOrDigit(ch):
+                    case char ch when !char.IsLetterOrDigit(ch):
                         builder.Append('_');
                         break;
                     default:

--- a/src/RazorSdk/SourceGenerators/RazorSourceGenerator.cs
+++ b/src/RazorSdk/SourceGenerators/RazorSourceGenerator.cs
@@ -9,6 +9,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc.Razor.Extensions;
@@ -278,11 +279,16 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
 
             for (var i = 0; i < filePath.Length; i++)
             {
-                builder.Append(filePath[i] switch
+                switch (filePath[i])
                 {
-                    ':' or '\\' or '/' => '_',
-                    var @default => @default,
-                });
+                    case ':' or '\\' or '/':
+                    case char ch when !Char.IsLetterOrDigit(ch):
+                        builder.Append('_');
+                        break;
+                    default:
+                        builder.Append(filePath[i]);
+                        break;
+                }
             }
 
             return builder.ToString();

--- a/src/RazorSdk/Targets/Microsoft.NET.Sdk.Razor.SourceGenerators.targets
+++ b/src/RazorSdk/Targets/Microsoft.NET.Sdk.Razor.SourceGenerators.targets
@@ -74,8 +74,8 @@ Copyright (c) .NET Foundation. All rights reserved.
     </ItemGroup>
 
     <EncodeRazorInputItem RazorInputItems="@(_RazorAdditionalFile)">
-        <Output TaskParameter="EncodedRazorInputItems" ItemName="_RazorSpecialCharacterWorkaround" />
-      </EncodeRazorInputItem>
+      <Output TaskParameter="EncodedRazorInputItems" ItemName="_RazorSpecialCharacterWorkaround" />
+    </EncodeRazorInputItem>
 
     <ItemGroup>
       <_RazorAdditionalFile Remove="@(_RazorAdditionalFile)" />

--- a/src/RazorSdk/Targets/Microsoft.NET.Sdk.Razor.SourceGenerators.targets
+++ b/src/RazorSdk/Targets/Microsoft.NET.Sdk.Razor.SourceGenerators.targets
@@ -10,6 +10,8 @@ Copyright (c) .NET Foundation. All rights reserved.
 
 <Project ToolsVersion="14.0">
 
+  <UsingTask TaskName="Microsoft.AspNetCore.Razor.Tasks.EncodeRazorInputItem" AssemblyFile="$(RazorSdkBuildTasksAssembly)" />
+
   <Target Name="_PrepareRazorSourceGenerators"
     BeforeTargets="GenerateMSBuildEditorConfigFileShouldRun"
     DependsOnTargets="PrepareForRazorGenerate;PrepareForRazorComponentGenerate">
@@ -45,7 +47,6 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ItemGroup>
       <!-- Additional metadata and properties that we want the compiler to pass to   the compiler we want to pass additional MSBuild properties \ metadata -->
       <CompilerVisibleItemMetadata Include="AdditionalFiles" MetadataName="TargetPath" />
-      <CompilerVisibleItemMetadata Include="AdditionalFiles" MetadataName="GeneratedOutputFullPath" />
       <CompilerVisibleItemMetadata Include="AdditionalFiles" MetadataName="CssScope" />
       <CompilerVisibleProperty Include="RazorLangVersion" />
       <CompilerVisibleProperty Include="RootNamespace" />
@@ -70,6 +71,15 @@ Copyright (c) .NET Foundation. All rights reserved.
 
       <_RazorAdditionalFile Remove="@(_RazorAdditionalFile)" Condition="$([MSBuild]::IsOSPlatform(`Windows`))" />
       <_RazorAdditionalFile Include="@(_RazorOmnisharpWorkAround)" Condition="$([MSBuild]::IsOSPlatform(`Windows`))" />
+    </ItemGroup>
+
+    <EncodeRazorInputItem RazorInputItems="@(_RazorAdditionalFile)">
+        <Output TaskParameter="EncodedRazorInputItems" ItemName="_RazorSpecialCharacterWorkaround" />
+      </EncodeRazorInputItem>
+
+    <ItemGroup>
+      <_RazorAdditionalFile Remove="@(_RazorAdditionalFile)" />
+      <_RazorAdditionalFile Include="@(_RazorSpecialCharacterWorkaround)" />
 
       <AdditionalFiles Include="@(_RazorAdditionalFile)" />
 

--- a/src/RazorSdk/Tasks/EncodeRazorInputItem.cs
+++ b/src/RazorSdk/Tasks/EncodeRazorInputItem.cs
@@ -34,7 +34,7 @@ namespace Microsoft.AspNetCore.Razor.Tasks
             for (var i = 0; i < RazorInputItems.Length; i++)
             {
                 var input = RazorInputItems[i];
-                var targetPath = Convert.ToBase64String(Encoding.ASCII.GetBytes(input.GetMetadata("TargetPath")));
+                var targetPath = Convert.ToBase64String(Encoding.UTF8.GetBytes(input.GetMetadata("TargetPath")));
 
                 var outputItem = new TaskItem(input);
                 outputItem.SetMetadata("TargetPath", targetPath);

--- a/src/RazorSdk/Tasks/EncodeRazorInputItem.cs
+++ b/src/RazorSdk/Tasks/EncodeRazorInputItem.cs
@@ -1,0 +1,48 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Numerics;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.RegularExpressions;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+namespace Microsoft.AspNetCore.Razor.Tasks
+{
+    // The compiler leverages .editorconfig files to transfer information between
+    // msbuild and the compiler. However, the transfer of data from MSBuild to the
+    // .editorconfig file to the source generator, causes a lot of issues as strings
+    // are transferred from one type to another. For example, the editorconfig file
+    // interprets "#" as comments and omits them from the produced AnalyzerConfigOptions.
+    // Characters like {} in the filename cause issues with resolving the type. To work
+    // around this, we encode everything before writing it to the editorconfig then decode
+    // inside the Razor source generator.
+    public class EncodeRazorInputItem : Task
+    {
+        [Required]
+        public ITaskItem[] RazorInputItems { get; set; }
+
+        [Output]
+        public ITaskItem[] EncodedRazorInputItems { get; set; }
+
+        public override bool Execute()
+        {
+            EncodedRazorInputItems = new ITaskItem[RazorInputItems.Length];
+
+            for (var i = 0; i < RazorInputItems.Length; i++)
+            {
+                var input = RazorInputItems[i];
+                var targetPath = Convert.ToBase64String(Encoding.ASCII.GetBytes(input.GetMetadata("TargetPath")));
+
+                var outputItem = new TaskItem(input);
+                outputItem.SetMetadata("TargetPath", targetPath);
+
+                EncodedRazorInputItems[i] = outputItem;
+            }
+
+            return !Log.HasLoggedErrors;
+        }
+    }
+}

--- a/src/Tests/Microsoft.NET.Sdk.Razor.Tests/ScopedCssIntegrationTests.cs
+++ b/src/Tests/Microsoft.NET.Sdk.Razor.Tests/ScopedCssIntegrationTests.cs
@@ -102,7 +102,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             var scoped = Path.Combine(intermediateOutputPath, "scopedcss", "Styles", "Pages", "Counter.rz.scp.css");
             new FileInfo(scoped).Should().Exist();
             new FileInfo(scoped).Should().Contain("b-overriden");
-            var generated = Path.Combine(intermediateOutputPath, "generated", "Microsoft.NET.Sdk.Razor.SourceGenerators", "Microsoft.NET.Sdk.Razor.SourceGenerators.RazorSourceGenerator", "_Components_Pages_Counter.razor.cs");	
+            var generated = Path.Combine(intermediateOutputPath, "generated", "Microsoft.NET.Sdk.Razor.SourceGenerators", "Microsoft.NET.Sdk.Razor.SourceGenerators.RazorSourceGenerator", "_Components_Pages_Counter_razor.cs");	
             new FileInfo(generated).Should().Exist();	
             new FileInfo(generated).Should().Contain("b-overriden");
             new FileInfo(Path.Combine(intermediateOutputPath, "scopedcss", "Components", "Pages", "Index.razor.rz.scp.css")).Should().NotExist();
@@ -327,7 +327,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             new FileInfo(generatedBundle).Should().Exist();
             var generatedProjectBundle = Path.Combine(intermediateOutputPath, "scopedcss", "projectbundle", "ComponentApp.bundle.scp.css");
             new FileInfo(generatedProjectBundle).Should().Exist();
-            var generatedCounter = Path.Combine(intermediateOutputPath, "generated", "Microsoft.NET.Sdk.Razor.SourceGenerators", "Microsoft.NET.Sdk.Razor.SourceGenerators.RazorSourceGenerator", "_Components_Pages_Counter.razor.cs");	
+            var generatedCounter = Path.Combine(intermediateOutputPath, "generated", "Microsoft.NET.Sdk.Razor.SourceGenerators", "Microsoft.NET.Sdk.Razor.SourceGenerators.RazorSourceGenerator", "_Components_Pages_Counter_razor.cs");	
             new FileInfo(generatedCounter).Should().Exist();	
 
             var componentThumbprint = FileThumbPrint.Create(generatedCounter);


### PR DESCRIPTION
Address https://github.com/dotnet/aspnetcore/issues/28794.

Source generators and analyzers use an editor config file to transfer relevant metadata between MSBuild and the compiler. In Razor, the editor config is populated with the `TargetPaths` of the output files like so:

```
[/Users/captainsafia/Verifications/TestFilesNames/Views/#Shared/Error.cshtml]
build_metadata.AdditionalFiles.TargetPath = /Views/#Shared/Error.cshtml
build_metadata.AdditionalFiles.CssScope =
```

If there are characters in the editor config that are delineated as special characters by the editor config spec, then the string processing will be borked for the filename. For example, a "#" anywhere in the filename will cause the rest of the filename to be ignored since # is interpreted as a comment character in editorconfig.

To work around this, we base64 encode the TargetPath property before writing it to disk to ensure that only alphanumeric characters are written to the editor config.

```
[/Users/captainsafia/Verifications/TestFilesNames/Views/#Shared/Error.cshtml]
build_metadata.AdditionalFiles.TargetPath = Vmlld3MvI1NoYXJlZC9FcnJvci5jc2h0bWw=
build_metadata.AdditionalFiles.CssScope =
```

Then we decode the properties when reading them.

Note: this is a temporary workaround until a more permanent solution is in place at the compiler level.