### PR TITLE
Exclude javascript files in sign check

### DIFF
--- a/eng/SignCheckExclusionsFile.txt
+++ b/eng/SignCheckExclusionsFile.txt
@@ -23,3 +23,6 @@ testwpf*.dll
 ;; Possibly no longer needed
 kerneltracecontrol*.dll
 msdia140*.dll
+
+;; Javascript files aren't signed
+*.js


### PR DESCRIPTION
Javascript files are not signed in sdk, so sign check should also exclude them.