### PR TITLE
Change default DebugType from 'pdbonly' to 'full'

### DIFF
--- a/src/WebSdk/ProjectSystem/Targets/Microsoft.NET.Sdk.Web.ProjectSystem.props
+++ b/src/WebSdk/ProjectSystem/Targets/Microsoft.NET.Sdk.Web.ProjectSystem.props
@@ -15,7 +15,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <OutputType>Exe</OutputType>
     <DebugSymbols Condition="'$(DebugSymbols)' == ''">true</DebugSymbols>
-    <DebugType Condition="'$(DebugType)' == ''">pdbonly</DebugType>
+    <DebugType Condition="'$(DebugType)' == ''">full</DebugType>
     <GenerateDependencyFile Condition="'$(GenerateDependencyFile)' == ''">true</GenerateDependencyFile>
     <ServerGarbageCollection>true</ServerGarbageCollection>
     <IsPackable Condition="'$(IsPackable)' == ''">false</IsPackable>


### PR DESCRIPTION
Per [this documentation](https://github.com/dotnet/roslyn/blob/main/docs/compilers/CSharp/CommandLine.md):

> `/debug:pdbonly` &mdash; Same as `/debug:full`. For backward compatibility.

In the new Project Properties UI that will ship with Dev17 we want to hide "pdbonly" from the list of options presented to the user. It would be better if the web SDK did not use it as a default.