### PR TITLE
Optional workloads: Utilities

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -38,6 +38,7 @@
     <SystemTextJsonVersion>4.7.2</SystemTextJsonVersion>
     <SystemReflectionMetadataLoadContextVersion>6.0.0-preview.4.21213.3</SystemReflectionMetadataLoadContextVersion>
     <DeploymentReleasesVersion>1.0.0-preview1.1.21112.1</DeploymentReleasesVersion>
+    <SystemManagementPackageVersion>4.6.0</SystemManagementPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/runtime -->

--- a/src/Cli/Microsoft.DotNet.Cli.Utils/DependencyProvider.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/DependencyProvider.cs
@@ -1,0 +1,162 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Microsoft.Win32;
+
+namespace Microsoft.DotNet.Cli.Utils
+{
+    /// <summary>
+    /// <para>
+    /// Represents an installer dependency provider used to manage reference counts against an installer (MSI). 
+    /// A dependency provider is an artificial construct introduced in WiX v3.6 to support reference counting installation
+    /// packages. MSIs that support this include a custom table, WixDependencyProvider, and a registry entry that writes the 
+    /// provider key to SOFTWARE\Classes\Installer\Dependencies\{provider key name} under HKLM or HKCU.
+    /// </para>
+    /// <para>
+    /// Installers like chainers register a reference by writing a value under the Dependents subkey of the provider key. When the
+    /// MSI is removed, a custom action is executed to determine if there are any remaining dependents and block the uninstall.
+    /// The check can be bypassed by setting IGNOREDEPENDENCIES=ALL. When a chainer removes the MSI, it first removes its
+    /// dependent entry. If there are no other dependents, it can proceed to remove the MSI, otherwise it should do nothing.
+    /// </para>
+    /// </summary>
+    public sealed class DependencyProvider
+    {
+        /// <summary>
+        /// The key name used by Visual Studio 2015 and later to register a dependency.
+        /// </summary>
+        internal const string VisualStudioDependentKeyName = "VS.{AEF703B8-D2CC-4343-915C-F54A30B90937}";
+
+        /// <summary>
+        /// The relative path from the <see cref="BaseKey"/> to the Dependencies key.
+        /// </summary>
+        internal const string DependenciesKeyRelativePath = @"SOFTWARE\Classes\Installer\Dependencies";
+
+        /// <summary>
+        /// <see langword="true"/> if the dependency provider is associated with a per-machine 
+        /// installation; <see langword="false"/> otherwise.
+        /// </summary>
+        public readonly bool AllUsers;
+
+        /// <summary>
+        /// Returns the root key to use: <see cref="Registry.LocalMachine"/> for per-machine installations or 
+        /// <see cref="Registry.CurrentUser"/> for per-user installations.
+        /// </summary>
+        public readonly RegistryKey BaseKey;
+
+        /// <summary>
+        /// Gets all dependents associated with the provider key.
+        /// </summary>
+        public IEnumerable<string> Dependents => GetDependents();
+
+        /// <summary>
+        /// The path of the key where the provider's dependents are stored, relative to the <see cref="BaseKey"/>.
+        /// </summary>
+        public readonly string DependentsKeyPath;
+
+        /// <summary>
+        /// <see langword="true"/> if Visual Studio 2015 or later is registered as a dependent. Visual Studio only
+        /// writes a single entry, regardless of how many instances have taken dependencies.
+        /// </summary>
+        public bool HasVisualStudioDependency => Dependents.Contains(VisualStudioDependentKeyName);
+
+        /// <summary>
+        /// The name of the dependency provider key used for tracking reference counts.
+        /// </summary>
+        public readonly string ProviderKeyName;
+
+        /// <summary>
+        /// The path of the provider key, relative to the <see cref="BaseKey"/>.
+        /// </summary>
+        public readonly string ProviderKeyPath;
+
+        /// <summary>
+        /// Creates a new <see cref="DependencyProvider"/> instance.
+        /// </summary>
+        /// <param name="providerKeyName">The name of the dependency provider key.</param>
+        /// <param name="allUsers"><see langword="true" /> if the provider belongs to a per-machine installation; 
+        /// <see langword="false"/> otherwise.</param>
+        public DependencyProvider(string providerKeyName, bool allUsers)
+        {
+            if (providerKeyName is null)
+            {
+                throw new ArgumentNullException(nameof(providerKeyName));
+            }
+
+            if (string.IsNullOrWhiteSpace(providerKeyName))
+            {
+                throw new ArgumentException($"{nameof(providerKeyName)} cannot be empty.");
+            }
+
+            ProviderKeyName = providerKeyName;
+            AllUsers = allUsers;
+            BaseKey = AllUsers ? Registry.LocalMachine : Registry.CurrentUser;
+            ProviderKeyPath = $@"{DependenciesKeyRelativePath}\{ProviderKeyName}";
+            DependentsKeyPath = $@"{ProviderKeyPath}\Dependents";
+        }
+
+        /// <summary>
+        /// Adds the specified dependent to the provider key. The dependent is stored as a subkey under the Dependents key of
+        /// the provider."/>
+        /// </summary>
+        /// <param name="dependent">The dependent to add.</param>
+        public void AddDependent(string dependent)
+        {
+            if (dependent is null)
+            {
+                throw new ArgumentNullException(nameof(dependent));
+            }
+
+            if (string.IsNullOrWhiteSpace(dependent))
+            {
+                throw new ArgumentException($"{nameof(dependent)} cannot be empty.");
+            }
+
+            using RegistryKey dependentsKey = BaseKey.CreateSubKey(Path.Combine(DependentsKeyPath, dependent), writable: true);
+        }
+
+        /// <summary>
+        /// Remove the specified dependent from the provider key. Optionally, if this is the final dependent,
+        /// the provider key can also be removed. This is typically done during an uninstall.
+        /// </summary>
+        /// <param name="dependent">The dependent to remove.</param>
+        /// <param name="removeProvider">When <see langword="true"/>, delete the provider key if the dependent being
+        /// removed is the last dependent.</param>
+        public void RemoveDependent(string dependent, bool removeProvider)
+        {
+            if (dependent is null)
+            {
+                throw new ArgumentNullException(nameof(dependent));
+            }
+
+            if (string.IsNullOrWhiteSpace(dependent))
+            {
+                throw new ArgumentException($"{nameof(dependent)} cannot be empty.");
+            }
+
+            using RegistryKey dependentsKey = BaseKey.OpenSubKey(DependentsKeyPath, writable: true);
+            dependentsKey?.DeleteSubKeyTree(dependent);
+
+            if ((removeProvider) && (Dependents.Count() == 0))
+            {
+                using RegistryKey providerKey = BaseKey.OpenSubKey(DependenciesKeyRelativePath, writable: true);
+                providerKey?.DeleteSubKeyTree(ProviderKeyName);
+            }
+        }
+
+        /// <summary>
+        /// Gets all the dependents associated with the provider key.
+        /// </summary>
+        /// <returns>All dependents of the provider key.</returns>
+        private IEnumerable<string> GetDependents()
+        {
+            using RegistryKey dependentsKey = BaseKey.OpenSubKey(DependentsKeyPath);
+
+            return dependentsKey?.GetSubKeyNames() ?? Enumerable.Empty<string>();
+        }
+    }
+}

--- a/src/Cli/Microsoft.DotNet.Cli.Utils/Extensions/ProcessExtensions.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/Extensions/ProcessExtensions.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Diagnostics;
+using System.Management;
+
+namespace Microsoft.DotNet.Cli.Utils
+{
+    /// <summary>
+    /// Extensions methods for <see cref="Process"/> components.
+    /// </summary>
+    public static class ProcessExtensions
+    {
+        /// <summary>
+        /// Returns the parent process of this process by querying the Win32_Process class.
+        /// </summary>
+        /// <param name="process">The process component.</param>
+        /// <returns>The parent process or <see langword="null"/> if the parent process cannot be found.</returns>
+        public static Process GetParentProcess(this Process process)
+        {
+            int ppid = process.GetParentProcessId();
+
+            return ppid != -1 ? Process.GetProcessById(ppid) : null;
+        }
+
+        /// <summary>
+        /// Returns the parent process ID of this process by querying the Win32_Process class.
+        /// </summary>
+        /// <param name="process">The process component.</param>
+        /// <returns>The process ID of the parent process, or -1 if the parent process could not be found.</returns>
+        public static int GetParentProcessId(this Process process)
+        {
+            ManagementObjectSearcher searcher = new($"SELECT ParentProcessId FROM Win32_Process WHERE ProcessId='{process.Id}'");
+            using ManagementObjectCollection result = searcher.Get();
+            ManagementObjectCollection.ManagementObjectEnumerator enumerator = result.GetEnumerator();
+
+            return enumerator.MoveNext() ? Convert.ToInt32(enumerator.Current.GetPropertyValue("ParentProcessId")) : -1;
+
+            //if (enumerator.MoveNext())
+            //{
+            //    return Convert.ToInt32(enumerator.Current.GetPropertyValue("ParentProcessId"));
+            //}
+
+            //return -1;
+        }
+    }
+}

--- a/src/Cli/Microsoft.DotNet.Cli.Utils/Extensions/ProcessExtensions.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/Extensions/ProcessExtensions.cs
@@ -36,13 +36,6 @@ namespace Microsoft.DotNet.Cli.Utils
             ManagementObjectCollection.ManagementObjectEnumerator enumerator = result.GetEnumerator();
 
             return enumerator.MoveNext() ? Convert.ToInt32(enumerator.Current.GetPropertyValue("ParentProcessId")) : -1;
-
-            //if (enumerator.MoveNext())
-            //{
-            //    return Convert.ToInt32(enumerator.Current.GetPropertyValue("ParentProcessId"));
-            //}
-
-            //return -1;
         }
     }
 }

--- a/src/Cli/Microsoft.DotNet.Cli.Utils/Interop.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/Interop.cs
@@ -72,4 +72,59 @@ namespace Microsoft.DotNet.Cli.Utils
         [MethodImpl(MethodImplOptions.InternalCall)]
         void Clone([MarshalAs(UnmanagedType.Interface)] out IEnumString ppenum);
     }
+
+    // Decompiled from WUA typelib
+    [ComImport]
+    [Guid("ADE87BF7-7B56-4275-8FAB-B9B0E591844B")]
+    [TypeLibType(4304)]
+    public interface ISystemInformation
+    {
+        [DispId(1610743809)]
+        string OemHardwareSupportLink
+        {
+            [MethodImpl(MethodImplOptions.InternalCall)]
+            [DispId(1610743809)]
+            [return: MarshalAs(UnmanagedType.BStr)]
+            get;
+        }
+
+        [DispId(1610743810)]
+        bool RebootRequired
+        {
+            [MethodImpl(MethodImplOptions.InternalCall)]
+            [DispId(1610743810)]
+            get;
+        }
+    }
+
+    [ComImport]
+    [Guid("ADE87BF7-7B56-4275-8FAB-B9B0E591844B")]
+    [CoClass(typeof(SystemInformationClass))]
+    public interface SystemInformation : ISystemInformation
+    {
+    }
+
+    [ComImport]
+    [Guid("C01B9BA0-BEA7-41BA-B604-D0A36F469133")]
+    [TypeLibType(2)]
+    [ClassInterface(ClassInterfaceType.None)]
+    public class SystemInformationClass : ISystemInformation, SystemInformation
+    {
+        [DispId(1610743809)]
+        public extern virtual string OemHardwareSupportLink
+        {
+            [MethodImpl(MethodImplOptions.InternalCall)]
+            [DispId(1610743809)]
+            [return: MarshalAs(UnmanagedType.BStr)]
+            get;
+        }
+
+        [DispId(1610743810)]
+        public extern virtual bool RebootRequired
+        {
+            [MethodImpl(MethodImplOptions.InternalCall)]
+            [DispId(1610743810)]
+            get;
+        }
+    }    
 }

--- a/src/Cli/Microsoft.DotNet.Cli.Utils/Microsoft.DotNet.Cli.Utils.csproj
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/Microsoft.DotNet.Cli.Utils.csproj
@@ -42,6 +42,6 @@
     <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildPackageVersion)" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildUtilitiesCorePackageVersion)" />
     <PackageReference Include="System.CommandLine" Version="$(SystemCommandLineVersion)" />
+    <PackageReference Include="System.Management" Version="$(SystemManagementPackageVersion)" />    
   </ItemGroup>
-
 </Project>

--- a/src/Cli/Microsoft.DotNet.Cli.Utils/Windows.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/Windows.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System.Security.Principal;
+using System.Threading;
+
+namespace Microsoft.DotNet.Cli.Utils
+{
+    /// <summary>
+    /// Utility methods, specific to Windows.
+    /// </summary>
+    public static class Windows
+    {
+        /// <summary>
+        /// Determines whether the current user has the Administrator role.
+        /// </summary>
+        /// <returns><see langword="true"/> if the user has the Administrator role.</returns>
+        public static bool IsAdministrator()
+        {
+            WindowsPrincipal principal = new(WindowsIdentity.GetCurrent());
+
+            return principal.IsInRole(WindowsBuiltInRole.Administrator);
+        }
+
+        /// <summary>
+        /// Determine if an install is running by trying to open the global _MSIExecute mutex. The mutex is
+        /// only set while processing the InstallExecuteSequence, AdminExecuteSequence or AdvtExecuteSequence tables.
+        /// </summary>
+        /// <returns><see langword="true" /> if another install is already running; <see langword="false"/> otherwise.</returns>
+        /// See the <see href="https://docs.microsoft.com/en-us/windows/win32/msi/-msiexecute-mutex">_MSIMutex</see> documentation.
+        public static bool InstallRunning()
+        {
+            return !Mutex.TryOpenExisting(@"Global\_MSIExecute", out _);
+        }
+
+        /// <summary>
+        /// Queries the Windows Update Agent API to determine if there is a pending reboot.
+        /// </summary>
+        /// <returns><see langword="true"/> if there is a pending reboot; <see langword="false"> otherwise.</see></returns>
+        /// <remarks>
+        /// See <see href="https://docs.microsoft.com/en-us/windows/win32/api/wuapi/nf-wuapi-isysteminformation-get_rebootrequired">this</see>
+        /// for more information.
+        /// </remarks>
+        public static bool RebootRequired()
+        {
+            return new SystemInformationClass().RebootRequired;
+        }
+    }
+}

--- a/src/Tests/Microsoft.DotNet.Cli.Utils.Tests/DependencyProviderTests.cs
+++ b/src/Tests/Microsoft.DotNet.Cli.Utils.Tests/DependencyProviderTests.cs
@@ -1,0 +1,99 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System.Linq;
+using Microsoft.NET.TestFramework;
+using Microsoft.Win32;
+using Xunit;
+
+namespace Microsoft.DotNet.Cli.Utils.Tests
+{
+    public class DependencyProviderTests
+    {
+        [WindowsOnlyTheory]
+        [InlineData(false, "NET.CORE.SDK,v6.0", @"SOFTWARE\Classes\Installer\Dependencies\NET.CORE.SDK,v6.0\Dependents", "HKEY_CURRENT_USER")]
+        [InlineData(true, "NET.CORE.SDK,v6.0", @"SOFTWARE\Classes\Installer\Dependencies\NET.CORE.SDK,v6.0\Dependents", "HKEY_LOCAL_MACHINE")]
+        public void ProviderProperties(bool allUsers, string providerKeyName, string expectedDependentsKeyPath, string expectedBaseKeyName)
+        {
+            DependencyProvider dep = new DependencyProvider(providerKeyName, allUsers);
+
+            Assert.Equal(expectedDependentsKeyPath, dep.DependentsKeyPath);
+            Assert.Equal(expectedBaseKeyName, dep.BaseKey.Name);
+            Assert.Equal(providerKeyName, dep.ProviderKeyName);
+        }
+
+        [WindowsOnlyFact]
+        public void ItCanAddDependents()
+        {
+            // We cannot create per-machine entries unless the tests run elevated. The results are the
+            // the same, it's only the base key that's different
+            DependencyProvider dep = new DependencyProvider(".NET_SDK_TEST_PROVIDER_KEY", allUsers: false);
+
+            try
+            {
+                // We should not have any dependents
+                Assert.Empty(dep.Dependents);
+
+                dep.AddDependent("Microsoft.NET.SDK,v6.0.100");
+
+                Assert.Single(dep.Dependents);
+                Assert.Equal("Microsoft.NET.SDK,v6.0.100", dep.Dependents.First());
+            }
+            finally
+            {
+                // Clean up and delete everything
+                using RegistryKey providerKey = dep.BaseKey.OpenSubKey(DependencyProvider.DependenciesKeyRelativePath, writable: true);
+                providerKey?.DeleteSubKeyTree(dep.ProviderKeyName);
+            }
+        }
+
+        [WindowsOnlyFact]
+        public void ItCanFindVisualStudioDependents()
+        {
+            DependencyProvider dep = new DependencyProvider(".NET_SDK_TEST_PROVIDER_KEY", allUsers: false);
+
+            try
+            {
+                // We should not have any dependents
+                Assert.Empty(dep.Dependents);
+
+                // Write the VS dependents key
+                dep.AddDependent(DependencyProvider.VisualStudioDependentKeyName);
+
+                Assert.True(dep.HasVisualStudioDependency);
+            }
+            finally
+            {
+                // Clean up and delete everything
+                using RegistryKey providerKey = dep.BaseKey.OpenSubKey(DependencyProvider.DependenciesKeyRelativePath, writable: true);
+                providerKey?.DeleteSubKeyTree(dep.ProviderKeyName);
+            }
+        }
+
+        [WindowsOnlyFact]
+        public void ItWillNotRemoveTheProviderIfOtherDependentsExist()
+        {
+            DependencyProvider dep = new DependencyProvider(".NET_SDK_TEST_PROVIDER_KEY", allUsers: false);
+
+            try
+            {
+                // Write multiple dependents
+                dep.AddDependent(DependencyProvider.VisualStudioDependentKeyName);
+                dep.AddDependent("Microsoft.NET.SDK,v6.0.100");
+
+                Assert.Equal(2, dep.Dependents.Count());
+
+                dep.RemoveDependent("Microsoft.NET.SDK,v6.0.100", removeProvider: true);
+
+                Assert.True(dep.HasVisualStudioDependency);
+            }
+            finally
+            {
+                // Clean up and delete everything
+                using RegistryKey providerKey = dep.BaseKey.OpenSubKey(DependencyProvider.DependenciesKeyRelativePath, writable: true);
+                providerKey?.DeleteSubKeyTree(dep.ProviderKeyName);
+            }
+        }
+    }
+}

--- a/src/Tests/Microsoft.DotNet.Cli.Utils.Tests/ProcessExtensionsTests.cs
+++ b/src/Tests/Microsoft.DotNet.Cli.Utils.Tests/ProcessExtensionsTests.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System.Diagnostics;
+using Microsoft.NET.TestFramework;
+using Xunit;
+
+namespace Microsoft.DotNet.Cli.Utils.Tests
+{
+    public class ProcessExtensionsTests
+    {
+        [WindowsOnlyFact]
+        public void ItReturnsTheParentProcessId()
+        {
+            int expectedParentProcessId = Process.GetCurrentProcess().Id;
+
+            using Process childProcess = new();
+            childProcess.StartInfo.CreateNoWindow = true;
+            childProcess.StartInfo.FileName = "cmd";
+            childProcess.Start();
+            Process parentProcess = childProcess.GetParentProcess();
+            int ppid = parentProcess.Id;
+            childProcess.Kill();
+
+            Assert.Equal(expectedParentProcessId, ppid);
+        }
+    }
+}


### PR DESCRIPTION
Some higher level utilities to support admin installs of workloads, including support for dependency providers to manage MSI reference counts.

The Windows utilities have 3 methods that do not lend themselves well to tests

- ```IsAdministrator``` can only be tested if a test can flip between elevated/non-elevated
- ```RebootRequired``` can only be tested if we for a machine into a reboot state, which would be bad for CI machines
- ```InstallRunning``` can only be tested by starting an install of an MSI