### PR TITLE
[dotnet new] Make it possible to disable sdk installed templates

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-new/BuiltInTemplatePackageProviderFactory.cs
+++ b/src/Cli/dotnet/commands/dotnet-new/BuiltInTemplatePackageProviderFactory.cs
@@ -13,9 +13,11 @@ namespace Microsoft.DotNet.Tools.New
     /// </summary>
     internal class BuiltInTemplatePackageProviderFactory : ITemplatePackageProviderFactory
     {
+        public static readonly Guid FactoryId = new Guid("{4B11226E-4594-43A4-B843-EB97447B6455}");
+
         public string DisplayName => "BuiltIn SDK packages";
 
-        public Guid Id { get; } = new Guid("{4B11226E-4594-43A4-B843-EB97447B6455}");
+        public Guid Id { get => FactoryId; }
 
         public ITemplatePackageProvider CreateProvider(IEngineEnvironmentSettings settings)
             => new BuiltInTemplatePackageProvider(this, settings);

--- a/src/Cli/dotnet/commands/dotnet-new/NewCommandShim.cs
+++ b/src/Cli/dotnet/commands/dotnet-new/NewCommandShim.cs
@@ -12,7 +12,7 @@ using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Cli;
 using Microsoft.TemplateEngine.Edge;
 using Microsoft.TemplateEngine.Utils;
-using Microsoft.TemplateSearch.Common;
+using System.Linq;
 
 namespace Microsoft.DotNet.Tools.New
 {
@@ -51,17 +51,22 @@ namespace Microsoft.DotNet.Tools.New
                 RestoreProject = RestoreProject
             };
 
-            return New3Command.Run(CommandName, CreateHost(), logger, callbacks, args, null);
+            var disableSdkTemplates = args.Contains("--debug:disable-sdk-templates");
+
+            return New3Command.Run(CommandName, CreateHost(disableSdkTemplates), logger, callbacks, args, null);
         }
 
-        private static ITemplateEngineHost CreateHost()
+        private static ITemplateEngineHost CreateHost(bool disableSdkTemplates)
         {
-            var builtIns = new AssemblyComponentCatalog(new[]
+            var builtIns = new List<KeyValuePair<Guid, Func<Type>>>(new AssemblyComponentCatalog(new[]
             {
-                typeof(Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Abstractions.IMacro).Assembly,
-                typeof(BuiltInTemplatePackageProviderFactory).Assembly,
-                typeof(FileMetadataSearchSource).Assembly
-            });
+                typeof(Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Abstractions.IMacro).Assembly
+            }));
+
+            if (!disableSdkTemplates)
+            {
+                builtIns.Add(new KeyValuePair<Guid, Func<Type>>(BuiltInTemplatePackageProviderFactory.FactoryId, () => typeof(BuiltInTemplatePackageProviderFactory)));
+            }
 
             string preferredLangEnvVar = Environment.GetEnvironmentVariable("DOTNET_NEW_PREFERRED_LANG");
             string preferredLang = string.IsNullOrWhiteSpace(preferredLangEnvVar)? "C#" : preferredLangEnvVar;


### PR DESCRIPTION
aspnetcore team wants to install their locally templates when executing tests, this gives them ability to disable SDK installed templates, because we don't allow uninstalling SDK templates anymore