### PR TITLE
Add OptionalWorkloadsProvider

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-new/NewCommandShim.cs
+++ b/src/Cli/dotnet/commands/dotnet-new/NewCommandShim.cs
@@ -66,6 +66,7 @@ namespace Microsoft.DotNet.Tools.New
             if (!disableSdkTemplates)
             {
                 builtIns.Add(new KeyValuePair<Guid, Func<Type>>(BuiltInTemplatePackageProviderFactory.FactoryId, () => typeof(BuiltInTemplatePackageProviderFactory)));
+                builtIns.Add(new KeyValuePair<Guid, Func<Type>>(OptionalWorkloadProviderFactory.FactoryId, () => typeof(OptionalWorkloadProviderFactory)));
             }
 
             string preferredLangEnvVar = Environment.GetEnvironmentVariable("DOTNET_NEW_PREFERRED_LANG");

--- a/src/Cli/dotnet/commands/dotnet-new/OptionalWorkloadProvider.cs
+++ b/src/Cli/dotnet/commands/dotnet-new/OptionalWorkloadProvider.cs
@@ -1,0 +1,51 @@
+﻿using Microsoft.DotNet.Cli;
+using Microsoft.DotNet.Cli.Utils;
+using Microsoft.DotNet.TemplateLocator;
+using Microsoft.TemplateEngine.Abstractions;
+using Microsoft.TemplateEngine.Abstractions.PhysicalFileSystem;
+using Microsoft.TemplateEngine.Abstractions.TemplatePackage;
+using Microsoft.TemplateEngine.Edge;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.TemplateEngine.Utils
+{
+    internal class OptionalWorkloadProvider : ITemplatePackageProvider
+    {
+        private readonly IEngineEnvironmentSettings _environmentSettings;
+
+        internal OptionalWorkloadProvider(ITemplatePackageProviderFactory factory, IEngineEnvironmentSettings settings)
+        {
+            this.Factory = factory;
+            this._environmentSettings = settings;
+        }
+
+        public ITemplatePackageProviderFactory Factory { get; }
+
+        // To avoid warnings about unused, its implemented via add/remove
+        event Action ITemplatePackageProvider.TemplatePackagesChanged
+        {
+            add { }
+            remove { }
+        }
+
+        public Task<IReadOnlyList<ITemplatePackage>> GetAllTemplatePackagesAsync(CancellationToken cancellationToken)
+        {
+            var list = new List<TemplatePackage>();
+            var optionalWorkloadLocator = new TemplateLocator();
+            var sdkDirectory = Path.GetDirectoryName(typeof(DotnetFiles).Assembly.Location);
+            var sdkVersion = Path.GetFileName(sdkDirectory);
+
+            var packages = optionalWorkloadLocator.GetDotnetSdkTemplatePackages(sdkVersion, sdkDirectory);
+            var fileSystem = _environmentSettings.Host.FileSystem as IFileLastWriteTimeSource;
+            foreach (IOptionalSdkTemplatePackageInfo packageInfo in packages)
+            {
+                list.Add(new TemplatePackage(this, packageInfo.Path, fileSystem?.GetLastWriteTimeUtc(packageInfo.Path) ?? File.GetLastWriteTime(packageInfo.Path)));
+            }
+            return Task.FromResult<IReadOnlyList<ITemplatePackage>>(list);
+        }
+    }
+}

--- a/src/Cli/dotnet/commands/dotnet-new/OptionalWorkloadProviderFactory.cs
+++ b/src/Cli/dotnet/commands/dotnet-new/OptionalWorkloadProviderFactory.cs
@@ -1,0 +1,25 @@
+using Microsoft.DotNet.TemplateLocator;
+using Microsoft.TemplateEngine.Abstractions;
+using Microsoft.TemplateEngine.Abstractions.TemplatePackage;
+using System;
+
+namespace Microsoft.TemplateEngine.Utils
+{
+    /// <summary>
+    /// TemplateEngine calls this when it wants to gather list of installed template packages.
+    /// This provider is responsible for gathering option workload packages via <see cref="TemplateLocator"/>.
+    /// </summary>
+    internal class OptionalWorkloadProviderFactory : ITemplatePackageProviderFactory
+    {
+        public static readonly Guid FactoryId = new Guid("{FAE2BB7C-054D-481B-B75C-E9F524193D56}");
+
+        public Guid Id => FactoryId;
+
+        public string DisplayName => "OptionalWorkloads";
+
+        public ITemplatePackageProvider CreateProvider(IEngineEnvironmentSettings settings)
+        {
+            return new OptionalWorkloadProvider(this, settings);
+        }
+    }
+}


### PR DESCRIPTION
This is second part of fixing https://github.com/dotnet/templating/issues/2651

This functionality was removed from templating repo in https://github.com/dotnet/templating/pull/3052
Main difference from there to here is how SDK version passed to `TemplateLocator.GetDotnetSdkTemplatePackages` is "calculated" before it was relying on `Microsoft.DotNet.Cli.Utils.Product.Version` via Host.Version, but now its using same approach as https://github.com/dotnet/sdk/blob/main/src/Resolvers/Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver/WorkloadSdkResolver.cs#L70-L72

This will restore optional workloads templates.