### PR TITLE
Stop generating *.runtimeconfig.dev.json

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.props
@@ -116,9 +116,10 @@ Copyright (c) .NET Foundation. All rights reserved.
   </PropertyGroup>
 
   <PropertyGroup>
-    <!-- Stop generating *.runtimeconfig.dev.json files to reduce probing paths. -->
+    <GenerateRuntimeConfigDevFile>true</GenerateRuntimeConfigDevFile>
+    <!-- Post-net6.0, stop generating *.runtimeconfig.dev.json files to reduce probing paths. -->
     <!-- https://github.com/dotnet/sdk/issues/16818 -->
-    <GenerateRuntimeConfigDevFile>false<GenerateRuntimeConfigDevFile>
+    <GenerateRuntimeConfigDevFile Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' and $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '6.0'))">false<GenerateRuntimeConfigDevFile>
   </PropertyGroup>
 
   <!-- Default item includes (globs and implicit references) -->

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.props
@@ -115,6 +115,12 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ToolDepsJsonGeneratorProject>$(MSBuildThisFileDirectory)GenerateDeps\GenerateDeps.proj</ToolDepsJsonGeneratorProject>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <!-- Stop generating *.runtimeconfig.dev.json files to reduce probing paths. -->
+    <!-- https://github.com/dotnet/sdk/issues/16818 -->
+    <GenerateRuntimeConfigDevFile>false<GenerateRuntimeConfigDevFile>
+  </PropertyGroup>
+
   <!-- Default item includes (globs and implicit references) -->
   <Import Project="Microsoft.NET.Sdk.DefaultItems.props" />
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.props
@@ -119,7 +119,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <GenerateRuntimeConfigDevFile>true</GenerateRuntimeConfigDevFile>
     <!-- Post-net6.0, stop generating *.runtimeconfig.dev.json files to reduce probing paths. -->
     <!-- https://github.com/dotnet/sdk/issues/16818 -->
-    <GenerateRuntimeConfigDevFile Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' and $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '6.0'))">false<GenerateRuntimeConfigDevFile>
+    <GenerateRuntimeConfigDevFile Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' and $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '6.0'))">false</GenerateRuntimeConfigDevFile>
   </PropertyGroup>
 
   <!-- Default item includes (globs and implicit references) -->

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.props
@@ -115,13 +115,6 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ToolDepsJsonGeneratorProject>$(MSBuildThisFileDirectory)GenerateDeps\GenerateDeps.proj</ToolDepsJsonGeneratorProject>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <GenerateRuntimeConfigDevFile>true</GenerateRuntimeConfigDevFile>
-    <!-- Post-net6.0, stop generating *.runtimeconfig.dev.json files to reduce probing paths. -->
-    <!-- https://github.com/dotnet/sdk/issues/16818 -->
-    <GenerateRuntimeConfigDevFile Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' and $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '6.0'))">false</GenerateRuntimeConfigDevFile>
-  </PropertyGroup>
-
   <!-- Default item includes (globs and implicit references) -->
   <Import Project="Microsoft.NET.Sdk.DefaultItems.props" />
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -60,6 +60,13 @@ Copyright (c) .NET Foundation. All rights reserved.
   </ItemGroup>
 
   <PropertyGroup>
+    <GenerateRuntimeConfigDevFile>true</GenerateRuntimeConfigDevFile>
+    <!-- Post-net6.0, stop generating *.runtimeconfig.dev.json files to reduce probing paths. -->
+    <!-- https://github.com/dotnet/sdk/issues/16818 -->
+    <GenerateRuntimeConfigDevFile Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' and $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '6.0'))">false</GenerateRuntimeConfigDevFile>
+  </PropertyGroup>
+
+  <PropertyGroup>
     <ProjectDepsFileName Condition="'$(ProjectDepsFileName)' == ''">$(AssemblyName).deps.json</ProjectDepsFileName>
     <ProjectDepsFilePath Condition="'$(ProjectDepsFilePath)' == ''">$(TargetDir)$(ProjectDepsFileName)</ProjectDepsFilePath>
     <ProjectRuntimeConfigFileName Condition="'$(ProjectRuntimeConfigFileName)' == ''">$(AssemblyName).runtimeconfig.json</ProjectRuntimeConfigFileName>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -64,7 +64,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ProjectDepsFilePath Condition="'$(ProjectDepsFilePath)' == ''">$(TargetDir)$(ProjectDepsFileName)</ProjectDepsFilePath>
     <ProjectRuntimeConfigFileName Condition="'$(ProjectRuntimeConfigFileName)' == ''">$(AssemblyName).runtimeconfig.json</ProjectRuntimeConfigFileName>
     <ProjectRuntimeConfigFilePath Condition="'$(ProjectRuntimeConfigFilePath)' == ''">$(TargetDir)$(ProjectRuntimeConfigFileName)</ProjectRuntimeConfigFilePath>
-    <ProjectRuntimeConfigDevFilePath Condition="'$(ProjectRuntimeConfigDevFilePath)' == ''">$(TargetDir)$(AssemblyName).runtimeconfig.dev.json</ProjectRuntimeConfigDevFilePath>
+    <ProjectRuntimeConfigDevFilePath Condition="'$(ProjectRuntimeConfigDevFilePath)' == '' and $(GenerateRuntimeConfigDevFile) == 'true'">$(TargetDir)$(AssemblyName).runtimeconfig.dev.json</ProjectRuntimeConfigDevFilePath>
     <IncludeMainProjectInDepsFile Condition=" '$(IncludeMainProjectInDepsFile)' == '' ">true</IncludeMainProjectInDepsFile>
   </PropertyGroup>
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -59,7 +59,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <GenerateRuntimeConfigurationFilesInputs Include="$(UserRuntimeConfig)" Condition=" Exists($(UserRuntimeConfig)) " />
   </ItemGroup>
 
-  <PropertyGroup>
+  <PropertyGroup Condition="'$(GenerateRuntimeConfigDevFile)' == ''">
     <GenerateRuntimeConfigDevFile>true</GenerateRuntimeConfigDevFile>
     <!-- Post-net6.0, stop generating *.runtimeconfig.dev.json files to reduce probing paths. -->
     <!-- https://github.com/dotnet/sdk/issues/16818 -->

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildANetCoreApp.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildANetCoreApp.cs
@@ -377,11 +377,21 @@ public static class Program
         }
 
         [Theory]
-        [InlineData("netcoreapp2.0", true)]
-        [InlineData("netcoreapp3.0", true)]
-        [InlineData("net5.0", true)]
-        [InlineData("net6.0", false)]
-        public void It_stops_generating_runtimeconfig_dev_json_after_net6(string targetFramework, bool generateRuntimeConfigDevJson)
+        // Default behavior
+        [InlineData("netcoreapp2.0", "", true)]
+        [InlineData("netcoreapp3.0", "", true)]
+        [InlineData("net5.0", "", true)]
+        [InlineData("net6.0", "", false)]
+        // Allow property override
+        [InlineData("netcoreapp2.0", "true", true)]
+        [InlineData("netcoreapp2.0", "false", false)]
+        [InlineData("netcoreapp3.0", "true", true)]
+        [InlineData("netcoreapp3.0", "false", false)]
+        [InlineData("net5.0", "true", true)]
+        [InlineData("net5.0", "false", false)]
+        [InlineData("net6.0", "true", true)]
+        [InlineData("net6.0", "false", false)]
+        public void It_stops_generating_runtimeconfig_dev_json_after_net6(string targetFramework, string propertyOverride, bool generateRuntimeConfigDevJson)
         {
             TestProject proj = new TestProject()
             {
@@ -392,9 +402,12 @@ public static class Program
                 IsSdkProject = true
             };
 
+            // User-set property GenerateRuntimeConfigDevFile takes priority.
+            proj.AdditionalProperties.Add("GenerateRuntimeConfigDevFile", propertyOverride);
+
             var buildCommand = new BuildCommand(_testAssetsManager.CreateTestProject(proj, identifier: targetFramework));
 
-            buildCommand.Execute("/bl");
+            buildCommand.Execute();
 
             var runtimeconfigFile = Path.Combine(
                 buildCommand.GetOutputDirectory(targetFramework).FullName,

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildANetCoreApp.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildANetCoreApp.cs
@@ -377,6 +377,37 @@ public static class Program
         }
 
         [Theory]
+        [InlineData("netcoreapp2.0", true)]
+        [InlineData("netcoreapp3.0", true)]
+        [InlineData("net5.0", true)]
+        [InlineData("net6.0", false)]
+        public void It_stops_generating_runtimeconfig_dev_json_after_net6(string targetFramework, bool generateRuntimeConfigDevJson)
+        {
+            TestProject proj = new TestProject()
+            {
+                Name = "NetCoreApp",
+                ProjectSdk = "Microsoft.NET.Sdk",
+                IsExe = true,
+                TargetFrameworks = targetFramework,
+                IsSdkProject = true
+            };
+
+            var buildCommand = new BuildCommand(_testAssetsManager.CreateTestProject(proj, identifier: targetFramework));
+
+            buildCommand.Execute("/bl");
+
+            var runtimeconfigFile = Path.Combine(
+                buildCommand.GetOutputDirectory(targetFramework).FullName,
+                $"{proj.Name}.runtimeconfig.dev.json");
+
+            buildCommand.GetOutputDirectory(targetFramework)
+                .GetFiles()
+                .Any(x => x.Name.Contains("runtimeconfig.dev.json"))
+                .Should()
+                .Be(generateRuntimeConfigDevJson);
+        }
+
+        [Theory]
         [InlineData("netcoreapp2.0")]
         [InlineData("netcoreapp3.0")]
         public void It_trims_conflicts_from_the_deps_file(string targetFramework)


### PR DESCRIPTION
Fixes: https://github.com/dotnet/sdk/issues/16818

This prevents more probing paths being added when not necessary.

### Changes Made
The `GenerateRuntimeConfigurationFiles` class already checks to see if it should generate a .dev file. When the value is null or empty it doesn't.

The fix was adding a property and a condition to set the value of `RuntimeConfigDevPath`.

No value on RuntimeConfigDevPath means no *.runtimeconfig.dev.json file should be generated. I considered conditioning the target on the property, but that target also generates *.runtimeconfig.json, and I'm not sure if we want to keep that or not.

### Notes
Also not sure if we wanted to explicitly define the property as `false`, but I added the property along with context to Microsoft.NET.Sdk.props.