### PR TITLE
Handle exceptions when delta applied and send acknowledgement (#17008)

### DIFF
--- a/src/BuiltInTools/BrowserRefresh/BlazorHotReload.js
+++ b/src/BuiltInTools/BrowserRefresh/BlazorHotReload.js
@@ -12,7 +12,12 @@ async function receiveHotReloadAsync() {
   if (response.status === 200) {
     const deltas = await response.json();
     if (deltas) {
-      deltas.forEach(d => window.Blazor._internal.applyHotReload(d.moduleId, d.metadataDelta, d.ilDelta));
+      try {
+        deltas.forEach(d => window.Blazor._internal.applyHotReload(d.moduleId, d.metadataDelta, d.ilDelta));
+      } catch (error) {
+        console.warn(error);
+        return;
+      } 
     }
   }
 }


### PR DESCRIPTION
## Description

Due to some pending issues, there are some scenarios where edits the compiler classifies as supported edits are not actually supported by the Mono implementation of EnC.

When this would occur, Blazor WASM customers would receive a confusing unhandled exception user interface in their app.

The dotnet watch server would not be able to recover from this scenario forcing the user into an unexpected state that required them to restart their dotnet watch setting.

This PR adds error handling to this codepath and adds a system for acknowledging whether a delta was successfully applied or not. If it was not successfully applied, the watch server will automatically trigger a build or reload.

## Customer Impact

The changes in this PR prevents users from landing into a pit-of-failure if they make edits unsupported by the Mono implementation of EnC and allows the watch server to recover from these issues.

## Regression?
- [ ] Yes
- [X] No

## Risk
- [ ] High
- [ ] Medium
- [X] Low

Change was manually validated and is limited to Blazor WASM applications.

## Verification
- [X] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [X] No
- [ ] N/A


Addresses https://github.com/dotnet/aspnetcore/issues/31776