### PR TITLE
Fix OptionalWorkload Template provider

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-new/OptionalWorkloadProvider.cs
+++ b/src/Cli/dotnet/commands/dotnet-new/OptionalWorkloadProvider.cs
@@ -38,8 +38,9 @@ namespace Microsoft.TemplateEngine.Utils
             var optionalWorkloadLocator = new TemplateLocator();
             var sdkDirectory = Path.GetDirectoryName(typeof(DotnetFiles).Assembly.Location);
             var sdkVersion = Path.GetFileName(sdkDirectory);
+            var dotnetRootPath = Path.GetDirectoryName(Path.GetDirectoryName(sdkDirectory));
 
-            var packages = optionalWorkloadLocator.GetDotnetSdkTemplatePackages(sdkVersion, sdkDirectory);
+            var packages = optionalWorkloadLocator.GetDotnetSdkTemplatePackages(sdkVersion, dotnetRootPath);
             var fileSystem = _environmentSettings.Host.FileSystem as IFileLastWriteTimeSource;
             foreach (IOptionalSdkTemplatePackageInfo packageInfo in packages)
             {


### PR DESCRIPTION
We were passing in `C:\Program Files\dotnet\sdk\6.0.100-preview.4.21220.4` instead of `C:\Program Files\dotnet\`