### PR TITLE
Fix SuppressTrimAnalysisWarnings

### DIFF
--- a/src/BlazorWasmSdk/Targets/Microsoft.NET.Sdk.BlazorWebAssembly.Current.targets
+++ b/src/BlazorWasmSdk/Targets/Microsoft.NET.Sdk.BlazorWebAssembly.Current.targets
@@ -13,6 +13,10 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <PropertyGroup>
     <EnableDefaultContentItems Condition=" '$(EnableDefaultContentItems)' == '' ">true</EnableDefaultContentItems>
+
+    <!-- Trimmer defaults that depend on user-definable settings.
+        This must be configured before it's initialized in the .NET SDK targets (which are imported by the Razor SDK). -->
+    <SuppressTrimAnalysisWarnings Condition="'$(SuppressTrimAnalysisWarnings)' == '' And '$(TrimmerDefaultAction)' != 'link'">true</SuppressTrimAnalysisWarnings> 
   </PropertyGroup>
 
   <Import Sdk="Microsoft.NET.Sdk.Razor" Project="Sdk.targets" />
@@ -60,9 +64,6 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <StaticWebAssetBasePath Condition="'$(StaticWebAssetBasePath)' == ''">/</StaticWebAssetBasePath>
     <BlazorCacheBootResources Condition="'$(BlazorCacheBootResources)' == ''">true</BlazorCacheBootResources>
-
-    <!-- Trimmer defaults that depend on user-definable settings -->
-    <SuppressTrimAnalysisWarnings Condition="'$(SuppressTrimAnalysisWarnings)' == '' And '$(TrimmerDefaultAction)' != 'link'">true</SuppressTrimAnalysisWarnings> 
 
     <!-- Turn off parts of the build that do not apply to WASM projects -->
     <GenerateDependencyFile>false</GenerateDependencyFile>

--- a/src/Tests/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/WasmPublishTest.cs
+++ b/src/Tests/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/WasmPublishTest.cs
@@ -34,7 +34,8 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
             var testInstance = CreateAspNetSdkTestAsset(testAppName);
 
             var publishCommand = new PublishCommand(Log, testInstance.TestRoot);
-            publishCommand.Execute().Should().Pass();
+            publishCommand.Execute().Should().Pass()
+                .And.NotHaveStdOutContaining("warning IL");
 
             var publishDirectory = publishCommand.GetOutputDirectory(DefaultTfm);
 

--- a/src/WebSdk/Web/Sdk/Sdk.targets
+++ b/src/WebSdk/Web/Sdk/Sdk.targets
@@ -14,6 +14,12 @@ Copyright (c) .NET Foundation. All rights reserved.
   <!-- We can't add it here because the OutputPath and other msbuild properties are not evaluated.-->
   <!--<Import Sdk="Microsoft.NET.Sdk.Publish" Project="ImportPublishProfile.targets" />-->
 
+  <PropertyGroup>
+    <!-- Trimmer defaults that depend on user-definable settings.
+         This must be configured before it's initialized in the .NET SDK targets. -->
+    <SuppressTrimAnalysisWarnings Condition="'$(SuppressTrimAnalysisWarnings)' == '' And '$(TrimmerDefaultAction)' != 'link'">true</SuppressTrimAnalysisWarnings>
+  </PropertyGroup>
+
   <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" />
 
   <PropertyGroup>
@@ -22,9 +28,6 @@ Copyright (c) .NET Foundation. All rights reserved.
       Microsoft.AspNetCore.App. This needs to happen after the .NET SDK has evaluated TFMs.
      -->
     <AddRazorSupportForMvc Condition="'$(DisableImplicitFrameworkReferences)' != 'true' And '$(AddRazorSupportForMvc)' == '' And '$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(_TargetFrameworkVersionWithoutV)' >= '3.0'">true</AddRazorSupportForMvc>
-
-    <!-- Trimmer defaults that depend on user-definable settings -->
-    <SuppressTrimAnalysisWarnings Condition="'$(SuppressTrimAnalysisWarnings)' == '' And '$(TrimmerDefaultAction)' != 'link'">true</SuppressTrimAnalysisWarnings>
   </PropertyGroup>
 
   <Import Sdk="Microsoft.NET.Sdk.Razor" Project="Sdk.targets" />


### PR DESCRIPTION
This needs to be set before the .NET SDK targets get imported, otherwise the .NET defaults win.

I was too hasty in https://github.com/dotnet/sdk/pull/16865, and regressed this when I responded to @eerhardt's [feedback](https://github.com/dotnet/sdk/pull/16865#discussion_r615895443). @pranavkm noticed that blazor was producing warnings after my change. I've now double-checked that this change doesn't produce warnings by default for blazor/web.