### PR TITLE
Fix up delta apply acknowledgement and add logging

### DIFF
--- a/src/BuiltInTools/BrowserRefresh/WebSocketScriptInjection.js
+++ b/src/BuiltInTools/BrowserRefresh/WebSocketScriptInjection.js
@@ -153,14 +153,10 @@ setTimeout(function () {
   }
 
   function sendDeltaApplied() {
-    const webAssemblyHotReloadSuccessPayload = new ArrayBuffer(1);
-    webAssemblyHotReloadSuccessPayload[0] = 1;
-    connection.send(webAssemblyHotReloadSuccessPayload);
+    connection.send(new Uint8Array([1]).buffer);
   }
 
   function sendDeltaNotApplied() {
-    const webAssemblyHotReloadFailurePayload = new ArrayBuffer(1);
-    webAssemblyHotReloadFailurePayload[0] = 0;
-    connection.send(webAssemblyHotReloadFailurePayload);
+    connection.send(new Uint8Array([0]).buffer);
   }
 }, 500);

--- a/src/BuiltInTools/dotnet-watch/Filters/BrowserRefreshServer.cs
+++ b/src/BuiltInTools/dotnet-watch/Filters/BrowserRefreshServer.cs
@@ -32,8 +32,6 @@ namespace Microsoft.DotNet.Watcher.Tools
         private readonly TaskCompletionSource _taskCompletionSource;
         private IHost _refreshServer;
 
-        private const int MESSAGE_TIMEOUT = 5000;
-
         public BrowserRefreshServer(IReporter reporter)
         {
             _reporter = reporter;
@@ -143,9 +141,6 @@ namespace Microsoft.DotNet.Watcher.Tools
 
         public async ValueTask<ValueWebSocketReceiveResult?> ReceiveAsync(Memory<byte> buffer, CancellationToken cancellationToken)
         {
-            var linkedCancellationToken = CancellationTokenSource.CreateLinkedTokenSource(
-                cancellationToken,
-                new CancellationTokenSource(MESSAGE_TIMEOUT).Token);
             for (int i = 0; i < _clientSockets.Count; i++)
             {
                 var clientSocket = _clientSockets[i];
@@ -157,7 +152,7 @@ namespace Microsoft.DotNet.Watcher.Tools
 
                 try
                 {
-                    return await clientSocket.ReceiveAsync(buffer, linkedCancellationToken.Token);
+                    return await clientSocket.ReceiveAsync(buffer, cancellationToken);
                 }
                 catch (Exception ex)
                 {

--- a/src/BuiltInTools/dotnet-watch/HotReload/CompilationHandler.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/CompilationHandler.cs
@@ -115,10 +115,12 @@ namespace Microsoft.DotNet.Watcher.Tools
                 var diagnostics = GetDiagnostics(updatedSolution, cancellationToken);
                 if (diagnostics.IsDefaultOrEmpty)
                 {
+                    _reporter.Verbose("No deltas modified. Applying changes to clear diagnostics.");
                     await _deltaApplier.Apply(context, file.FilePath, updates, cancellationToken);
                 }
                 else
                 {
+                    _reporter.Verbose("Found compilation errors during hot reload. Reporting it in application UI.");
                     await _deltaApplier.ReportDiagnosticsAsync(context, diagnostics, cancellationToken);
                 }
 
@@ -143,6 +145,7 @@ namespace Microsoft.DotNet.Watcher.Tools
             _currentSolution = updatedSolution;
 
             var applyState = await _deltaApplier.Apply(context, file.FilePath, updates, cancellationToken);
+            _reporter.Verbose($"Received {(applyState ? "successful" : "failed")} apply from delta applier.");
             HotReloadEventSource.Log.HotReloadEnd(HotReloadEventSource.StartType.CompilationHandler);
             return applyState;
         }

--- a/src/BuiltInTools/dotnet-watch/HotReloadDotNetWatcher.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReloadDotNetWatcher.cs
@@ -139,7 +139,7 @@ namespace Microsoft.DotNet.Watcher
                         }
                     }
 
-                    // Regardless of the which task finished first, make sure everything is cancelled
+                    // Regardless of the which task finished firsft, make sure everything is cancelled
                     // and wait for dotnet to exit. We don't want orphan processes
                     currentRunCancellationSource.Cancel();
 
@@ -170,8 +170,9 @@ namespace Microsoft.DotNet.Watcher
                         context.ChangedFile = changedFile;
                     }
                 }
-                catch
+                catch (Exception e)
                 {
+                    _reporter.Verbose($"{e}");
                     if (!currentRunCancellationSource.IsCancellationRequested)
                     {
                         currentRunCancellationSource.Cancel();

--- a/src/BuiltInTools/dotnet-watch/HotReloadDotNetWatcher.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReloadDotNetWatcher.cs
@@ -139,7 +139,7 @@ namespace Microsoft.DotNet.Watcher
                         }
                     }
 
-                    // Regardless of the which task finished firsft, make sure everything is cancelled
+                    // Regardless of the which task finished first, make sure everything is cancelled
                     // and wait for dotnet to exit. We don't want orphan processes
                     currentRunCancellationSource.Cancel();
 
@@ -172,7 +172,7 @@ namespace Microsoft.DotNet.Watcher
                 }
                 catch (Exception e)
                 {
-                    _reporter.Verbose($"{e}");
+                    _reporter.Verbose($"Caught top-level exception from hot reload: {e}");
                     if (!currentRunCancellationSource.IsCancellationRequested)
                     {
                         currentRunCancellationSource.Cancel();


### PR DESCRIPTION
## Description

This PR adds additional logging to the hot reload area to make it easier to diagnose customer issues. This PR resolves a bug where the hot reload server would always restarted even if a delta was applied.

## Customer Impact

This PR prevents the app from reloading even if hot reload was successful. It also adds logging to improve the diagnosing customer issues.

## Regression?
- [ ] Yes
- [X] No

## Risk
- [ ] High
- [X] Medium
- [ ] Low

Change was manually validated and verified with additional logging.

## Verification
- [X] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [X] No
- [ ] N/A
