### PR TITLE
Add the xlf resources and xliff tasks into Microsoft.NET.Publish tests

### DIFF
--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAFrameworkDependentApp.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAFrameworkDependentApp.cs
@@ -122,7 +122,7 @@ namespace Microsoft.NET.Publish.Tests
                 .Should()
                 .Fail()
                 .And
-                .HaveStdOutContaining(Strings.FrameworkDependentAppHostRequiresVersion21);
+                .HaveStdOutContaining(Strings.FrameworkDependentAppHostRequiresVersion21.Replace("“", "\"").Replace("”", "\""));
         }
     }
 }

--- a/src/Tests/Microsoft.NET.Publish.Tests/Microsoft.NET.Publish.Tests.csproj
+++ b/src/Tests/Microsoft.NET.Publish.Tests/Microsoft.NET.Publish.Tests.csproj
@@ -34,6 +34,8 @@
 
   <ItemGroup>
     <EmbeddedResource Include="..\..\Tasks\Common\Resources\Strings.resx" LinkBase="Resources" GenerateSource="True" Namespace="Microsoft.NET.Build.Tasks" />
+    <None Include="..\..\Tasks\Common\Resources\xlf\**\*" LinkBase="Resources\xlf" />
+    <PackageReference Include="XliffTasks" Version="$(XliffTasksVersion)" PrivateAssets="all" IsImplicitlyDefined="true" />
     <EmbeddedResource Include="**\*.resx" Exclude="$(GlobalExclude)" />
   </ItemGroup>
 


### PR DESCRIPTION
Modify the english quotes to universal quotes for loc strings as stdout on windows only supports universal.

https://github.com/dotnet/installer/issues/10218