### PR TITLE
[dotnet-watch] Fix dotnet-watch to account for absolute launchUrls in launchSettings.json

### DIFF
--- a/src/BuiltInTools/dotnet-watch/Filters/LaunchBrowserFilter.cs
+++ b/src/BuiltInTools/dotnet-watch/Filters/LaunchBrowserFilter.cs
@@ -130,7 +130,7 @@ namespace Microsoft.DotNet.Watcher.Tools
 
         private void LaunchBrowser(string launchUrl)
         {
-            var fileName = launchUrl + "/" + _launchPath;
+            var fileName = Uri.TryCreate(_launchPath, UriKind.Absolute, out _) ? _launchPath : launchUrl + "/" + _launchPath;
             var args = string.Empty;
             if (!string.IsNullOrEmpty(_browserPath))
             {


### PR DESCRIPTION
## Description
* dotnet-watch doesn't account for absolute URIs in launchSettings.json correctly. 
* This bug was surfaced by the changes aspnetcore did on the SPA templates.
* The new behavior is more inline with what visual studio supports.

## Customer Impact
When a customer tries out the new SPA experience in combination with dotnet watch run, dotnet watch will launch the browser with an incorrect url.

## Regression?
- [x] Yes
- [ ] No

[If yes, specify the version the behavior has regressed from]

## Risk
- [ ] High
- [ ] Medium
- [X] Low

[Justify the selection above]

## Verification
- [x] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [X] No
- [ ] N/A

Addresses #17084