### PR TITLE
[Preview4] revert the default for `EnableCompressionInSingleFile` to be "false"

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -1048,8 +1048,6 @@ Copyright (c) .NET Foundation. All rights reserved.
       <IncludeSymbolsInSingleFile Condition="'$(IncludeSymbolsInSingleFile)' == ''">false</IncludeSymbolsInSingleFile>
       <IncludeAllContentForSelfExtract Condition="'$(IncludeAllContentForSelfExtract)' == ''">false</IncludeAllContentForSelfExtract>
       <IncludeNativeLibrariesForSelfExtract Condition="'$(IncludeNativeLibrariesForSelfExtract)' == ''">$(IncludeAllContentForSelfExtract)</IncludeNativeLibrariesForSelfExtract>
-      <EnableCompressionInSingleFile Condition="'$(EnableCompressionInSingleFile)' == '' And
-                                   '$(_TargetFrameworkVersionWithoutV)' >= '6.0' And '$(SelfContained)' == 'true' ">true</EnableCompressionInSingleFile>
       <EnableCompressionInSingleFile Condition="'$(EnableCompressionInSingleFile)' == ''">false</EnableCompressionInSingleFile>
     </PropertyGroup>
 

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishASingleFileApp.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishASingleFileApp.cs
@@ -731,10 +731,6 @@ class C
                 IsExe = true,
             };
 
-            // NOTE: this can be removed when we support compressing managed assemblies
-            //       we only have this to add some native library to the bundle
-            testProject.PackageReferences.Add(new TestPackageReference("sqlite", "3.13.0"));
-
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
             var publishCommand = new PublishCommand(testAsset);
             var singleFilePath = Path.Combine(GetPublishDirectory(publishCommand, "net6.0").FullName, $"SingleFileTest{Constants.ExeSuffix}");
@@ -757,7 +753,7 @@ class C
         }
 
         [RequiresMSBuildVersionFact("16.8.0")]
-        public void It_compresses_single_file_by_default()
+        public void It_does_not_compress_single_file_by_default()
         {
             var testProject = new TestProject()
             {
@@ -765,10 +761,6 @@ class C
                 TargetFrameworks = "net6.0",
                 IsExe = true,
             };
-
-            // NOTE: this can be removed when we support compressing managed assemblies
-            //       we only have this to add some native library to the bundle
-            testProject.PackageReferences.Add(new TestPackageReference("sqlite", "3.13.0"));
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
             var publishCommand = new PublishCommand(testAsset);
@@ -788,7 +780,7 @@ class C
                 .Pass();
             var compressedSize = new FileInfo(singleFilePath).Length;
 
-            uncompressedSize.Should().BeGreaterThan(compressedSize);
+            uncompressedSize.Should().Be(compressedSize);
         }
     }
 }


### PR DESCRIPTION
cherry-pick port from main to preview4 for https://github.com/dotnet/sdk/pull/17054

---
There is a nontrivial penalty to the startup, so the default should be "false".

Also adjusting the test that validates the default behavior.