### PR TITLE
Add a workaround for file contention and empty file reads

### DIFF
--- a/src/BuiltInTools/dotnet-watch/HotReload/CompilationHandler.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/CompilationHandler.cs
@@ -213,12 +213,35 @@ namespace Microsoft.DotNet.Watcher.Tools
 
         private async ValueTask<SourceText> GetSourceTextAsync(string filePath)
         {
+            var zeroLengthRetryPerformed = false;
             for (var attemptIndex = 0; attemptIndex < 6; attemptIndex++)
             {
                 try
                 {
-                    using var stream = File.OpenRead(filePath);
-                    return SourceText.From(stream, Encoding.UTF8);
+                    // File.OpenRead opens the file with FileShare.Read. This may prevent IDEs from saving file
+                    // contents to disk
+                    SourceText sourceText;
+                    using (var stream = File.Open(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
+                    {
+                        sourceText = SourceText.From(stream, Encoding.UTF8);
+                    }
+
+                    if (!zeroLengthRetryPerformed && sourceText.Length == 0)
+                    {
+                        zeroLengthRetryPerformed = true;
+
+                        // VSCode (on Windows) will sometimes perform two separate writes when updating a file on disk.
+                        // In the first update, it clears the file contents, and in the second, it writes the intended
+                        // content.
+                        // It's atypical that a file being watched for hot reload would be empty. We'll use this as a
+                        // hueristic to identify this case and perform an additional retry reading the file after a delay.
+                        await Task.Delay(20);
+
+                        using var stream = File.Open(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+                        sourceText = SourceText.From(stream, Encoding.UTF8);
+                    }
+
+                    return sourceText;
                 }
                 catch (IOException) when (attemptIndex < 5)
                 {


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/31999
Fixes https://github.com/dotnet/aspnetcore/issues/32000

## Description

dotnet-watch's hot reload will sometimes interfere with VS Code's file writing and fail to apply to an update because it reads the file in an intermediate state.

a) VS Code sometimes performs two separate writes when saving a file - one to clear the file contents and one to write the updated content. If watch reads the file content between the two events, hot reload will fail since removing everything usually ends up being a rude edit.

b) Another occurrence is that watch will prevent the file from being written since it has a read-exclusive lock on the file. The result is that not only does the hot reload fail, you occasionally end up with an empty file with VS Code prompting a dialog. We can be less intrusive in this case, it's much more important to ensure users are able to save their work.

Both of these scenarios appear fairly frequently if you have the Auto Save option in VS Code enabled.

## Customer Impact

Less than ideal dotnet-watch hot reload experience.

## Regression?
- [ ] Yes
- [x] No

[If yes, specify the version the behavior has regressed from]

## Risk
- [ ] High
- [ ] Medium
- [x] Low

[Justify the selection above]

We have some retries in our file reading. This adds a special case in the event the contents we read are 0-length

## Verification
- [x] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [x] N/A


Addresses [issue number]
https://github.com/dotnet/aspnetcore/issues/31999
https://github.com/dotnet/aspnetcore/issues/32000