### PR TITLE
[6.0.1xx Preview4] Backport fix for Optional Workload Template provider

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-new/OptionalWorkloadProvider.cs
+++ b/src/Cli/dotnet/commands/dotnet-new/OptionalWorkloadProvider.cs
@@ -38,8 +38,9 @@ namespace Microsoft.TemplateEngine.Utils
             var optionalWorkloadLocator = new TemplateLocator();
             var sdkDirectory = Path.GetDirectoryName(typeof(DotnetFiles).Assembly.Location);
             var sdkVersion = Path.GetFileName(sdkDirectory);
+            var dotnetRootPath = Path.GetDirectoryName(Path.GetDirectoryName(sdkDirectory));
 
-            var packages = optionalWorkloadLocator.GetDotnetSdkTemplatePackages(sdkVersion, sdkDirectory);
+            var packages = optionalWorkloadLocator.GetDotnetSdkTemplatePackages(sdkVersion, dotnetRootPath);
             var fileSystem = _environmentSettings.Host.FileSystem as IFileLastWriteTimeSource;
             foreach (IOptionalSdkTemplatePackageInfo packageInfo in packages)
             {


### PR DESCRIPTION
Without this fix `dotnet new android` won't work on Preview4 and https://github.com/xamarin/xamarin-android/pull/5866 can't be merged...

This is backport of https://github.com/dotnet/sdk/pull/17049