### PR TITLE
Trim trailing white-space in leftover MSBuild files

### DIFF
--- a/src/BlazorWasmSdk/Targets/Microsoft.NET.Sdk.BlazorWebAssembly.Current.targets
+++ b/src/BlazorWasmSdk/Targets/Microsoft.NET.Sdk.BlazorWebAssembly.Current.targets
@@ -16,7 +16,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <!-- Trimmer defaults that depend on user-definable settings.
         This must be configured before it's initialized in the .NET SDK targets (which are imported by the Razor SDK). -->
-    <SuppressTrimAnalysisWarnings Condition="'$(SuppressTrimAnalysisWarnings)' == '' And '$(TrimmerDefaultAction)' != 'link'">true</SuppressTrimAnalysisWarnings> 
+    <SuppressTrimAnalysisWarnings Condition="'$(SuppressTrimAnalysisWarnings)' == '' And '$(TrimmerDefaultAction)' != 'link'">true</SuppressTrimAnalysisWarnings>
   </PropertyGroup>
 
   <Import Sdk="Microsoft.NET.Sdk.Razor" Project="Sdk.targets" />

--- a/src/RazorSdk/Targets/Microsoft.NET.Sdk.Razor.Configuration.targets
+++ b/src/RazorSdk/Targets/Microsoft.NET.Sdk.Razor.Configuration.targets
@@ -58,7 +58,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       </RazorTargetAssemblyAttribute>
     </ItemGroup>
 
-    <ItemGroup 
+    <ItemGroup
       Condition="'$(GenerateRazorAssemblyInfo)'=='true'
         AND '$(ResolvedRazorCompileToolset)'=='RazorSdk'
         AND ('$(RazorCompileOnBuild)' == 'true'

--- a/src/Tasks/Microsoft.NET.Build.Tasks/sdk/Sdk.NuGet.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/sdk/Sdk.NuGet.targets
@@ -12,16 +12,16 @@ Copyright (c) .NET Foundation. All rights reserved.
 <Project>
 
   <Import Project="..\targets\Microsoft.NET.Sdk.DefaultItems.props" />
-  
+
   <Import Project="..\targets\Microsoft.NET.Sdk.Common.targets" />
   <Import Project="..\targets\Microsoft.PackageDependencyResolution.targets" />
-  
+
   <Import Project="..\targets\Microsoft.NET.Sdk.DefaultItems.Shared.targets" />
 
   <Import Project="..\targets\Microsoft.NET.Sdk.FrameworkReferenceResolution.targets" />
   <Import Project="..\targets\Microsoft.NET.Sdk.Shared.targets" />
 
-  
+
   <Import Project="..\targets\Microsoft.NET.GenerateSupportedRuntime.targets" />
   <Import Project="..\targets\Microsoft.NET.ObsoleteReferences.targets" />
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ILLink.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ILLink.targets
@@ -203,7 +203,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       <_ExtraTrimmerArgs>--skip-unresolved true $(_ExtraTrimmerArgs)</_ExtraTrimmerArgs>
       <TrimmerSingleWarn Condition=" '$(TrimmerSingleWarn)' == '' ">true</TrimmerSingleWarn>
     </PropertyGroup>
-    
+
     <!-- Suppress warnings produced by the linker. Any warnings shared with the analyzer should be
          moved to the global PropertyGroup above. -->
     <PropertyGroup Condition="'$(SuppressTrimAnalysisWarnings)' == 'true'">
@@ -316,7 +316,7 @@ Copyright (c) .NET Foundation. All rights reserved.
         <TrimmerSingleWarn Condition=" '%(ManagedAssemblyToLink.TrimmerSingleWarn)' == '' ">false</TrimmerSingleWarn>
       </ManagedAssemblyToLink>
     </ItemGroup>
-  
+
     <ItemGroup>
       <_TrimmerFeatureSettings Include="@(RuntimeHostConfigurationOption)" Condition="'%(RuntimeHostConfigurationOption.Trim)' == 'true'" />
     </ItemGroup>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.Shared.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.Shared.targets
@@ -70,7 +70,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                       Condition="'$(DisableImplicitFrameworkReferences)' == 'true'"
                       AllowExplicitVersion="true"/>
   </ItemGroup>
-  
+
   <UsingTask TaskName="ApplyImplicitVersions" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
   <UsingTask TaskName="CheckIfPackageReferenceShouldBeFrameworkReference" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
 
@@ -140,7 +140,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       </PackageReference>
     </ItemGroup>
   </Target>
-  
+
   <UsingTask TaskName="CheckForImplicitPackageReferenceOverrides" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
 
   <!-- Remove package references with metadata IsImplicitlyDefined = true, if there are other PackageReference items with the same identity -->

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.Shared.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.Shared.targets
@@ -22,7 +22,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <GenerateResourceMSBuildArchitecture Condition=" '$(GenerateResourceMSBuildArchitecture)' == '' ">CurrentArchitecture</GenerateResourceMSBuildArchitecture>
     <GenerateResourceMSBuildRuntime Condition=" '$(GenerateResourceMSBuildRuntime)' == '' ">CurrentRuntime</GenerateResourceMSBuildRuntime>
   </PropertyGroup>
-  
+
   <PropertyGroup>
     <_NativeLibraryPrefix Condition="'$(_NativeLibraryPrefix)' == '' and !$(RuntimeIdentifier.StartsWith('win'))">lib</_NativeLibraryPrefix>
 

--- a/src/WebSdk/Publish/Targets/PublishProfiles/DefaultMSDeploy.pubxml
+++ b/src/WebSdk/Publish/Targets/PublishProfiles/DefaultMSDeploy.pubxml
@@ -8,4 +8,4 @@
     <MSDeployPublishMethod>WMSVC</MSDeployPublishMethod>
     <EnableMSDeployBackup>True</EnableMSDeployBackup>
   </PropertyGroup>
-</Project> 
+</Project>

--- a/src/WebSdk/Publish/Targets/PublishProfiles/DefaultMSDeployPackage.pubxml
+++ b/src/WebSdk/Publish/Targets/PublishProfiles/DefaultMSDeployPackage.pubxml
@@ -7,4 +7,4 @@
     <DesktopBuildPackageLocation>$(OutputPath)Publish\MSDeployPackage.zip</DesktopBuildPackageLocation>
     <DeployIisAppPath>Default Web Site</DeployIisAppPath>
   </PropertyGroup>
-</Project> 
+</Project>

--- a/src/WebSdk/Publish/Targets/PublishProfiles/DefaultZipDeploy.pubxml
+++ b/src/WebSdk/Publish/Targets/PublishProfiles/DefaultZipDeploy.pubxml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-https://go.microsoft.com/fwlink/?LinkID=208121. 
+https://go.microsoft.com/fwlink/?LinkID=208121.
 -->
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>


### PR DESCRIPTION
#### CHANGES
Trims trailing white-space in leftover MSBuild SDKs' props and targets from previous PR.
This patch makes sure that we follow the `EditorConfig` rule on `trim_trailing_whitespace`.

#### NOTES
This patch applies the same changes from #16844 as there are some files that have been added/modified since the `v5` branch. The reason I created this separately since, there are a few patches I have that touches some of these files. So, applying white-space changes early before any other PRs should make reviewing easier.