### PR TITLE
Warn users when `TargetFramework` and `RuntimeIdentifier` are not lowercase

### DIFF
--- a/src/Tasks/Common/Resources/Strings.resx
+++ b/src/Tasks/Common/Resources/Strings.resx
@@ -237,6 +237,10 @@
     <value>NETSDK1032: The RuntimeIdentifier platform '{0}' and the PlatformTarget '{1}' must be compatible.</value>
     <comment>{StrBegin="NETSDK1032: "}</comment>
   </data>
+  <data name="PropertyValueShouldBeLowercase" xml:space="preserve">
+    <value>NETSDK1033: The value of '{0}' is expected to be in lower-case but the actual casing is '{1}'. This value might be used as a part of a path which could lead into unexpected file not found errors (i.e. in case-sensitive file-systems). So, please use lower-case for '{0}' value.</value>
+    <comment>{StrBegin="NETSDK1033: "}</comment>
+  </data>
   <data name="ChoosingAssemblyVersion_Info" xml:space="preserve">
     <value>Choosing '{0}' because AssemblyVersion '{1}' is greater than '{2}'.</value>
   </data>

--- a/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
@@ -550,6 +550,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1093: Nástroje projektu (DotnetCliTool) podporují jen cílení na .NET Core 2.2 a nižší.</target>
         <note>{StrBegin="NETSDK1093: "}</note>
       </trans-unit>
+      <trans-unit id="PropertyValueShouldBeLowercase">
+        <source>NETSDK1033: The value of '{0}' is expected to be in lower-case but the actual casing is '{1}'. This value might be used as a part of a path which could lead into unexpected file not found errors (i.e. in case-sensitive file-systems). So, please use lower-case for '{0}' value.</source>
+        <target state="new">NETSDK1033: The value of '{0}' is expected to be in lower-case but the actual casing is '{1}'. This value might be used as a part of a path which could lead into unexpected file not found errors (i.e. in case-sensitive file-systems). So, please use lower-case for '{0}' value.</target>
+        <note>{StrBegin="NETSDK1033: "}</note>
+      </trans-unit>
       <trans-unit id="PublishReadyToRunRequiresVersion30">
         <source>NETSDK1122: ReadyToRun compilation will be skipped because it is only supported for .NET Core 3.0 or higher.</source>
         <target state="translated">NETSDK1122: Kompilace ReadyToRun se přeskočí, protože se podporuje jen pro architekturu .NET Core 3.0 a vyšší.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.de.xlf
@@ -550,6 +550,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1093: Projekttools (DotnetCliTool) unterstützen als Ziel nur .NET Core 2.2 und früher.</target>
         <note>{StrBegin="NETSDK1093: "}</note>
       </trans-unit>
+      <trans-unit id="PropertyValueShouldBeLowercase">
+        <source>NETSDK1033: The value of '{0}' is expected to be in lower-case but the actual casing is '{1}'. This value might be used as a part of a path which could lead into unexpected file not found errors (i.e. in case-sensitive file-systems). So, please use lower-case for '{0}' value.</source>
+        <target state="new">NETSDK1033: The value of '{0}' is expected to be in lower-case but the actual casing is '{1}'. This value might be used as a part of a path which could lead into unexpected file not found errors (i.e. in case-sensitive file-systems). So, please use lower-case for '{0}' value.</target>
+        <note>{StrBegin="NETSDK1033: "}</note>
+      </trans-unit>
       <trans-unit id="PublishReadyToRunRequiresVersion30">
         <source>NETSDK1122: ReadyToRun compilation will be skipped because it is only supported for .NET Core 3.0 or higher.</source>
         <target state="translated">NETSDK1122: Die ReadyToRun-Kompilierung wird übersprungen, weil sie nur für .NET Core 3.0 oder höher unterstützt wird.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.es.xlf
@@ -550,6 +550,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1093: Las herramientas de proyecto (DotnetCliTool) solo admiten como destino .NET Core 2.2 y versiones inferiores.</target>
         <note>{StrBegin="NETSDK1093: "}</note>
       </trans-unit>
+      <trans-unit id="PropertyValueShouldBeLowercase">
+        <source>NETSDK1033: The value of '{0}' is expected to be in lower-case but the actual casing is '{1}'. This value might be used as a part of a path which could lead into unexpected file not found errors (i.e. in case-sensitive file-systems). So, please use lower-case for '{0}' value.</source>
+        <target state="new">NETSDK1033: The value of '{0}' is expected to be in lower-case but the actual casing is '{1}'. This value might be used as a part of a path which could lead into unexpected file not found errors (i.e. in case-sensitive file-systems). So, please use lower-case for '{0}' value.</target>
+        <note>{StrBegin="NETSDK1033: "}</note>
+      </trans-unit>
       <trans-unit id="PublishReadyToRunRequiresVersion30">
         <source>NETSDK1122: ReadyToRun compilation will be skipped because it is only supported for .NET Core 3.0 or higher.</source>
         <target state="translated">NETSDK1122: Se omitirá la compilación de ReadyToRun porque solo se admite para .NET Core 3.0 o versiones posteriores.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
@@ -550,6 +550,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1093: les outils de projet (DotnetCliTool) prennent uniquement en charge le ciblage de .NET Core 2.2 et des versions antérieures.</target>
         <note>{StrBegin="NETSDK1093: "}</note>
       </trans-unit>
+      <trans-unit id="PropertyValueShouldBeLowercase">
+        <source>NETSDK1033: The value of '{0}' is expected to be in lower-case but the actual casing is '{1}'. This value might be used as a part of a path which could lead into unexpected file not found errors (i.e. in case-sensitive file-systems). So, please use lower-case for '{0}' value.</source>
+        <target state="new">NETSDK1033: The value of '{0}' is expected to be in lower-case but the actual casing is '{1}'. This value might be used as a part of a path which could lead into unexpected file not found errors (i.e. in case-sensitive file-systems). So, please use lower-case for '{0}' value.</target>
+        <note>{StrBegin="NETSDK1033: "}</note>
+      </trans-unit>
       <trans-unit id="PublishReadyToRunRequiresVersion30">
         <source>NETSDK1122: ReadyToRun compilation will be skipped because it is only supported for .NET Core 3.0 or higher.</source>
         <target state="translated">NETSDK1122: la compilation ReadyToRun va être ignorée, car elle est uniquement prise en charge pour .NET Core 3.0 ou une version ultérieure.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.it.xlf
@@ -550,6 +550,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1093: gli strumenti del progetto (DotnetCliTool) supportano come destinazione solo .NET Core 2.2 e versioni precedenti.</target>
         <note>{StrBegin="NETSDK1093: "}</note>
       </trans-unit>
+      <trans-unit id="PropertyValueShouldBeLowercase">
+        <source>NETSDK1033: The value of '{0}' is expected to be in lower-case but the actual casing is '{1}'. This value might be used as a part of a path which could lead into unexpected file not found errors (i.e. in case-sensitive file-systems). So, please use lower-case for '{0}' value.</source>
+        <target state="new">NETSDK1033: The value of '{0}' is expected to be in lower-case but the actual casing is '{1}'. This value might be used as a part of a path which could lead into unexpected file not found errors (i.e. in case-sensitive file-systems). So, please use lower-case for '{0}' value.</target>
+        <note>{StrBegin="NETSDK1033: "}</note>
+      </trans-unit>
       <trans-unit id="PublishReadyToRunRequiresVersion30">
         <source>NETSDK1122: ReadyToRun compilation will be skipped because it is only supported for .NET Core 3.0 or higher.</source>
         <target state="translated">NETSDK1122: la compilazione eseguita con ReadyToRun verrà ignorata perché è supportata solo per .NET Core 3.0 o versioni successive.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
@@ -550,6 +550,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1093: プロジェクト ツール (DotnetCliTool) は、ターゲットが .NET Core 2.2 以下の場合のみサポートされます。</target>
         <note>{StrBegin="NETSDK1093: "}</note>
       </trans-unit>
+      <trans-unit id="PropertyValueShouldBeLowercase">
+        <source>NETSDK1033: The value of '{0}' is expected to be in lower-case but the actual casing is '{1}'. This value might be used as a part of a path which could lead into unexpected file not found errors (i.e. in case-sensitive file-systems). So, please use lower-case for '{0}' value.</source>
+        <target state="new">NETSDK1033: The value of '{0}' is expected to be in lower-case but the actual casing is '{1}'. This value might be used as a part of a path which could lead into unexpected file not found errors (i.e. in case-sensitive file-systems). So, please use lower-case for '{0}' value.</target>
+        <note>{StrBegin="NETSDK1033: "}</note>
+      </trans-unit>
       <trans-unit id="PublishReadyToRunRequiresVersion30">
         <source>NETSDK1122: ReadyToRun compilation will be skipped because it is only supported for .NET Core 3.0 or higher.</source>
         <target state="translated">NETSDK1122: ReadyToRun コンパイルは、.NET Core 3.0 以降でのみサポートされているため、スキップされます。</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
@@ -550,6 +550,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1093: 프로젝트 도구(DotnetCliTool)는 .NET Core 2.2 이하를 대상으로 하는 경우만 지원합니다.</target>
         <note>{StrBegin="NETSDK1093: "}</note>
       </trans-unit>
+      <trans-unit id="PropertyValueShouldBeLowercase">
+        <source>NETSDK1033: The value of '{0}' is expected to be in lower-case but the actual casing is '{1}'. This value might be used as a part of a path which could lead into unexpected file not found errors (i.e. in case-sensitive file-systems). So, please use lower-case for '{0}' value.</source>
+        <target state="new">NETSDK1033: The value of '{0}' is expected to be in lower-case but the actual casing is '{1}'. This value might be used as a part of a path which could lead into unexpected file not found errors (i.e. in case-sensitive file-systems). So, please use lower-case for '{0}' value.</target>
+        <note>{StrBegin="NETSDK1033: "}</note>
+      </trans-unit>
       <trans-unit id="PublishReadyToRunRequiresVersion30">
         <source>NETSDK1122: ReadyToRun compilation will be skipped because it is only supported for .NET Core 3.0 or higher.</source>
         <target state="translated">NETSDK1122: ReadyToRun 컴파일은 .NET Core 3.0 이상에서만 지원되므로 건너뜁니다.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
@@ -550,6 +550,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1093: Narzędzia projektu (DotnetCliTool) obsługują tylko ukierunkowanie na program .NET Core w wersji 2.2 lub niższej.</target>
         <note>{StrBegin="NETSDK1093: "}</note>
       </trans-unit>
+      <trans-unit id="PropertyValueShouldBeLowercase">
+        <source>NETSDK1033: The value of '{0}' is expected to be in lower-case but the actual casing is '{1}'. This value might be used as a part of a path which could lead into unexpected file not found errors (i.e. in case-sensitive file-systems). So, please use lower-case for '{0}' value.</source>
+        <target state="new">NETSDK1033: The value of '{0}' is expected to be in lower-case but the actual casing is '{1}'. This value might be used as a part of a path which could lead into unexpected file not found errors (i.e. in case-sensitive file-systems). So, please use lower-case for '{0}' value.</target>
+        <note>{StrBegin="NETSDK1033: "}</note>
+      </trans-unit>
       <trans-unit id="PublishReadyToRunRequiresVersion30">
         <source>NETSDK1122: ReadyToRun compilation will be skipped because it is only supported for .NET Core 3.0 or higher.</source>
         <target state="translated">NETSDK1122: Kompilacja ReadyToRun zostanie pominięta, ponieważ jest obsługiwana tylko w przypadku platformy .NET Core 3.0 lub nowszej.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
@@ -550,6 +550,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1093: as ferramentas do projeto (DotnetCliTool) dão suporte somente para o direcionamento ao .NET Core 2.2 e inferior.</target>
         <note>{StrBegin="NETSDK1093: "}</note>
       </trans-unit>
+      <trans-unit id="PropertyValueShouldBeLowercase">
+        <source>NETSDK1033: The value of '{0}' is expected to be in lower-case but the actual casing is '{1}'. This value might be used as a part of a path which could lead into unexpected file not found errors (i.e. in case-sensitive file-systems). So, please use lower-case for '{0}' value.</source>
+        <target state="new">NETSDK1033: The value of '{0}' is expected to be in lower-case but the actual casing is '{1}'. This value might be used as a part of a path which could lead into unexpected file not found errors (i.e. in case-sensitive file-systems). So, please use lower-case for '{0}' value.</target>
+        <note>{StrBegin="NETSDK1033: "}</note>
+      </trans-unit>
       <trans-unit id="PublishReadyToRunRequiresVersion30">
         <source>NETSDK1122: ReadyToRun compilation will be skipped because it is only supported for .NET Core 3.0 or higher.</source>
         <target state="translated">NETSDK1122: a compilação de ReadyToRun será ignorada porque ela é compatível apenas com o .NET Core 3.0 ou superior.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
@@ -550,6 +550,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1093: средства проекта (DotnetCliTool) поддерживают только целевую платформу .NET Core 2.2 и более ранних версий.</target>
         <note>{StrBegin="NETSDK1093: "}</note>
       </trans-unit>
+      <trans-unit id="PropertyValueShouldBeLowercase">
+        <source>NETSDK1033: The value of '{0}' is expected to be in lower-case but the actual casing is '{1}'. This value might be used as a part of a path which could lead into unexpected file not found errors (i.e. in case-sensitive file-systems). So, please use lower-case for '{0}' value.</source>
+        <target state="new">NETSDK1033: The value of '{0}' is expected to be in lower-case but the actual casing is '{1}'. This value might be used as a part of a path which could lead into unexpected file not found errors (i.e. in case-sensitive file-systems). So, please use lower-case for '{0}' value.</target>
+        <note>{StrBegin="NETSDK1033: "}</note>
+      </trans-unit>
       <trans-unit id="PublishReadyToRunRequiresVersion30">
         <source>NETSDK1122: ReadyToRun compilation will be skipped because it is only supported for .NET Core 3.0 or higher.</source>
         <target state="translated">NETSDK1122: компиляция ReadyToRun будет пропущена, так как она поддерживается только для .NET Core 3.0 или более поздних версий.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
@@ -550,6 +550,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1093: Proje araçları (DotnetCliTool) yalnızca .NET Core 2.2 veya daha düşük sürümünü hedeflemeyi destekliyor.</target>
         <note>{StrBegin="NETSDK1093: "}</note>
       </trans-unit>
+      <trans-unit id="PropertyValueShouldBeLowercase">
+        <source>NETSDK1033: The value of '{0}' is expected to be in lower-case but the actual casing is '{1}'. This value might be used as a part of a path which could lead into unexpected file not found errors (i.e. in case-sensitive file-systems). So, please use lower-case for '{0}' value.</source>
+        <target state="new">NETSDK1033: The value of '{0}' is expected to be in lower-case but the actual casing is '{1}'. This value might be used as a part of a path which could lead into unexpected file not found errors (i.e. in case-sensitive file-systems). So, please use lower-case for '{0}' value.</target>
+        <note>{StrBegin="NETSDK1033: "}</note>
+      </trans-unit>
       <trans-unit id="PublishReadyToRunRequiresVersion30">
         <source>NETSDK1122: ReadyToRun compilation will be skipped because it is only supported for .NET Core 3.0 or higher.</source>
         <target state="translated">NETSDK1122: ReadyToRun derlemesi, yalnızca .NET Core 3.0 veya üzeri için desteklendiğinden atlanacak.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
@@ -550,6 +550,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1093: NETSDK1093: 项目工具(DotnetCliTool)仅支持面向 .NET Core 2.2 及更低版本。</target>
         <note>{StrBegin="NETSDK1093: "}</note>
       </trans-unit>
+      <trans-unit id="PropertyValueShouldBeLowercase">
+        <source>NETSDK1033: The value of '{0}' is expected to be in lower-case but the actual casing is '{1}'. This value might be used as a part of a path which could lead into unexpected file not found errors (i.e. in case-sensitive file-systems). So, please use lower-case for '{0}' value.</source>
+        <target state="new">NETSDK1033: The value of '{0}' is expected to be in lower-case but the actual casing is '{1}'. This value might be used as a part of a path which could lead into unexpected file not found errors (i.e. in case-sensitive file-systems). So, please use lower-case for '{0}' value.</target>
+        <note>{StrBegin="NETSDK1033: "}</note>
+      </trans-unit>
       <trans-unit id="PublishReadyToRunRequiresVersion30">
         <source>NETSDK1122: ReadyToRun compilation will be skipped because it is only supported for .NET Core 3.0 or higher.</source>
         <target state="translated">NETSDK1122: 将跳过 ReadyToRun 编译，因为只有 .NET Core 3.0 或更高版本才支持该编译。</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
@@ -550,6 +550,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1093: 專案工具 (DotnetCliTool) 僅支援以 .NET Core 2.2 或更低版本作為目標。</target>
         <note>{StrBegin="NETSDK1093: "}</note>
       </trans-unit>
+      <trans-unit id="PropertyValueShouldBeLowercase">
+        <source>NETSDK1033: The value of '{0}' is expected to be in lower-case but the actual casing is '{1}'. This value might be used as a part of a path which could lead into unexpected file not found errors (i.e. in case-sensitive file-systems). So, please use lower-case for '{0}' value.</source>
+        <target state="new">NETSDK1033: The value of '{0}' is expected to be in lower-case but the actual casing is '{1}'. This value might be used as a part of a path which could lead into unexpected file not found errors (i.e. in case-sensitive file-systems). So, please use lower-case for '{0}' value.</target>
+        <note>{StrBegin="NETSDK1033: "}</note>
+      </trans-unit>
       <trans-unit id="PublishReadyToRunRequiresVersion30">
         <source>NETSDK1122: ReadyToRun compilation will be skipped because it is only supported for .NET Core 3.0 or higher.</source>
         <target state="translated">NETSDK1122: 將跳過 ReadyToRun 編譯，原因是只有 .NET Core 3.0 或更高版本支援此作業。</target>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolveAppHosts.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveAppHosts.cs
@@ -268,13 +268,13 @@ namespace Microsoft.NET.Build.Tasks
                 string hostRelativePathInPackage = Path.Combine("runtimes", bestAppHostRuntimeIdentifier, "native",
                     hostNameWithoutExtension + (isExecutable ? ExecutableExtension.ForRuntimeIdentifier(bestAppHostRuntimeIdentifier) : ".dll"));
 
-
                 TaskItem appHostItem = new TaskItem(itemName);
                 string appHostPackPath = null;
                 if (!string.IsNullOrEmpty(TargetingPackRoot))
                 {
                     appHostPackPath = Path.Combine(TargetingPackRoot, hostPackName, appHostPackVersion);
                 }
+
                 if (appHostPackPath != null && Directory.Exists(appHostPackPath))
                 {
                     //  Use AppHost from packs folder

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.EolTargetFrameworks.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.EolTargetFrameworks.targets
@@ -26,6 +26,6 @@ Copyright (c) .NET Foundation. All rights reserved.
   <Target Name="_CheckForEolTargetFrameworks" AfterTargets="_CheckForUnsupportedNETCoreVersion"
           Condition="'@(_EolNetCoreTargetFrameworkVersions->AnyHaveMetadataValue('Identity', '$(_TargetFrameworkVersionWithoutV)'))' and '$(TargetFrameworkIdentifier)' == '.NETCoreApp' and '$(CheckEolTargetFramework)' == 'true'">
     <NETSdkWarning ResourceName="TargetFrameworkIsEol"
-                   FormatArguments="$(TargetFramework.ToLowerInvariant());https://aka.ms/dotnet-core-support" />
+                   FormatArguments="$(TargetFramework);https://aka.ms/dotnet-core-support" />
   </Target>
 </Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets
@@ -185,6 +185,19 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   </Target>
 
+  <!--
+    Check for improper casing of the 'RuntimeIdentifier' value.
+    For reasons such as case-sensitive file system, we prefer lower-case 'RuntimeIdentifier' value.
+  -->
+  <Target Name="_CheckForRuntimeIdentifierCasing"
+          BeforeTargets="_CheckForInvalidConfigurationAndPlatform;RunResolvePackageDependencies;GetFrameworkPaths;GetReferenceAssemblyPaths;Restore;CollectPackageReferences"
+          Condition="'$(AppendRuntimeIdentifierToOutputPath)' == 'true' and '$(RuntimeIdentifier)' != '' and '$(_UsingDefaultRuntimeIdentifier)' != 'true'">
+
+    <NETSdkWarning Condition="!$(RuntimeIdentifier.Equals('$(RuntimeIdentifier.ToLowerInvariant())'))"
+                 ResourceName="PropertyValueShouldBeLowercase"
+                 FormatArguments="RuntimeIdentifier;$([MSBuild]::Escape('$(RuntimeIdentifier)'))" />
+  </Target>
+
   <Target Name="_CheckForNETCoreSdkIsPreview"
           BeforeTargets="_CheckForInvalidConfigurationAndPlatform"
           Condition=" '$(_NETCoreSdkIsPreview)' == 'true' AND '$(SuppressNETCoreSdkPreviewMessage)' != 'true' ">

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets
@@ -199,12 +199,12 @@ Copyright (c) .NET Foundation. All rights reserved.
   </PropertyGroup>
 
   <!--
-    Append $(RuntimeIdentifier) directory to output and intermediate paths to prevent bin clashes between
-    targets.
+    Append 'RuntimeIdentifier' directory to output and intermediate paths
+    to prevent bin clashes between targets.
 
     But do not append the implicit default runtime identifier for .NET Framework apps as that would
     append a RID the user never mentioned in the path and do so even in the AnyCPU case.
-   -->
+  -->
   <PropertyGroup Condition="'$(AppendRuntimeIdentifierToOutputPath)' == 'true' and '$(RuntimeIdentifier)' != '' and '$(_UsingDefaultRuntimeIdentifier)' != 'true'">
     <IntermediateOutputPath>$(IntermediateOutputPath)$(RuntimeIdentifier)\</IntermediateOutputPath>
     <OutputPath>$(OutputPath)$(RuntimeIdentifier)\</OutputPath>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.TargetFrameworkInference.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.TargetFrameworkInference.targets
@@ -86,9 +86,9 @@ Copyright (c) .NET Foundation. All rights reserved.
           errors that are only consequences of the root cause identified here.
   -->
   <Target Name="_CheckForUnsupportedTargetFramework"
-          BeforeTargets="_CheckForInvalidConfigurationAndPlatform;RunResolvePackageDependencies;GetFrameworkPaths;GetReferenceAssemblyPaths;Restore"
-          Condition="'$(_UnsupportedTargetFrameworkError)' == 'true'"
-          >
+          BeforeTargets="_CheckForInvalidConfigurationAndPlatform;RunResolvePackageDependencies;GetFrameworkPaths;GetReferenceAssemblyPaths;Restore;CollectPackageReferences"
+          Condition="'$(_UnsupportedTargetFrameworkError)' == 'true'">
+
     <NETSdkError Condition="!$(TargetFramework.Contains(';'))"
                  ResourceName="CannotInferTargetFrameworkIdentifierAndVersion"
                  FormatArguments="$([MSBuild]::Escape('$(TargetFramework)'))" />
@@ -234,12 +234,12 @@ Copyright (c) .NET Foundation. All rights reserved.
   </PropertyGroup>
 
   <!--
-    Append $(TargetFramework) directory to output and intermediate paths to prevent bin clashes between
-    targets.
-   -->
+    Append 'TargetFramework' directory to output and intermediate paths
+    to prevent bin clashes between targets.
+  -->
   <PropertyGroup Condition="'$(AppendTargetFrameworkToOutputPath)' == 'true' and '$(TargetFramework)' != '' and '$(_UnsupportedTargetFrameworkError)' != 'true'">
-    <IntermediateOutputPath>$(IntermediateOutputPath)$(TargetFramework.ToLowerInvariant())\</IntermediateOutputPath>
-    <OutputPath>$(OutputPath)$(TargetFramework.ToLowerInvariant())\</OutputPath>
+    <IntermediateOutputPath>$(IntermediateOutputPath)$(TargetFramework)\</IntermediateOutputPath>
+    <OutputPath>$(OutputPath)$(TargetFramework)\</OutputPath>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.TargetFrameworkInference.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.TargetFrameworkInference.targets
@@ -78,6 +78,19 @@ Copyright (c) .NET Foundation. All rights reserved.
   </PropertyGroup>
 
   <!--
+    Check for improper casing of the 'TargetFramework' value.
+    For reasons such as case-sensitive file system, we prefer lower-case 'TargetFramework' value.
+  -->
+  <Target Name="_CheckForTargetFrameworkCasing"
+          BeforeTargets="_CheckForInvalidConfigurationAndPlatform;RunResolvePackageDependencies;GetFrameworkPaths;GetReferenceAssemblyPaths;Restore;CollectPackageReferences"
+          Condition="'$(AppendTargetFrameworkToOutputPath)' == 'true' and '$(TargetFramework)' != '' and '$(_UnsupportedTargetFrameworkError)' != 'true'">
+
+    <NETSdkWarning Condition="!$(TargetFramework.Equals('$(TargetFramework.ToLowerInvariant())'))"
+                 ResourceName="PropertyValueShouldBeLowercase"
+                 FormatArguments="TargetFramework;$([MSBuild]::Escape('$(TargetFramework)'))" />
+  </Target>
+
+  <!--
     NOTE: We must not validate the TFM before restore target runs as it prevents adding additional TFM
           support from being provided by a nuget package such as MSBuild.Sdk.Extras.
 

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildANetCoreApp.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildANetCoreApp.cs
@@ -551,42 +551,6 @@ public static class Program
         }
 
         [Fact]
-        public void It_uses_lowercase_form_of_the_target_framework_for_the_output_path()
-        {
-            var testProject = new TestProject()
-            {
-                Name = "OutputPathCasing",
-                TargetFrameworks = "ignored",
-                IsExe = true
-            };
-
-            string[] extraArgs = new[] { "/p:TargetFramework=NETCOREAPP1.1" };
-
-            var testAsset = _testAssetsManager.CreateTestProject(testProject, testProject.Name);
-
-            var buildCommand = new BuildCommand(testAsset);
-
-            buildCommand
-                .Execute(extraArgs)
-                .Should()
-                .Pass();
-
-            string outputFolderWithConfiguration = Path.Combine(buildCommand.ProjectRootPath, "bin", "Debug");
-
-            Directory.GetDirectories(outputFolderWithConfiguration)
-                .Select(Path.GetFileName)
-                .Should()
-                .BeEquivalentTo("netcoreapp1.1");
-
-            string intermediateFolderWithConfiguration = Path.Combine(buildCommand.GetBaseIntermediateDirectory().FullName, "Debug");
-
-            Directory.GetDirectories(intermediateFolderWithConfiguration)
-                .Select(Path.GetFileName)
-                .Should()
-                .BeEquivalentTo("netcoreapp1.1");
-        }
-
-        [Fact]
         public void BuildWithTransitiveReferenceToNetCoreAppPackage()
         {
             var testProject = new TestProject()

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildANetCoreApp.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildANetCoreApp.cs
@@ -551,6 +551,59 @@ public static class Program
         }
 
         [Fact]
+        public void It_warns_about_the_casing_of_the_target_framework()
+        {
+            var testProject = new TestProject()
+            {
+                Name = "WarnAboutCasing-TargetFramework",
+                TargetFrameworks = "ignored",
+                IsExe = true
+            };
+
+            string[] extraArgs = new[] { "/p:TargetFramework=NETCOREAPP1.1" };
+
+            var testAsset = _testAssetsManager.CreateTestProject(testProject, testProject.Name);
+
+            var buildCommand = new BuildCommand(testAsset);
+
+            var result = buildCommand
+                .Execute(extraArgs);
+
+            result
+                .Should()
+                .Pass()
+                .And
+                .HaveStdOutContaining("NETSDK1033");
+        }
+
+        [Fact]
+        public void It_warns_about_the_casing_of_the_runtime_identifier()
+        {
+            var testProject = new TestProject()
+            {
+                Name = "WarnAboutCasing-RuntimeIdentifier",
+                TargetFrameworks = "netcoreapp3.1",
+                RuntimeIdentifier = "ignored",
+                IsExe = true
+            };
+
+            string[] extraArgs = new[] { "/p:RuntimeIdentifier=WIN7-X64" };
+
+            var testAsset = _testAssetsManager.CreateTestProject(testProject, testProject.Name);
+
+            var buildCommand = new BuildCommand(testAsset);
+
+            var result = buildCommand
+                .Execute(extraArgs);
+
+            result
+                .Should()
+                .Pass()
+                .And
+                .HaveStdOutContaining("NETSDK1033");
+        }
+
+        [Fact]
         public void BuildWithTransitiveReferenceToNetCoreAppPackage()
         {
             var testProject = new TestProject()

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildANetCoreApp.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildANetCoreApp.cs
@@ -598,9 +598,11 @@ public static class Program
 
             result
                 .Should()
-                .Pass()
+                .Fail()
                 .And
-                .HaveStdOutContaining("NETSDK1033");
+                .HaveStdOutContaining("NETSDK1033")
+                .And
+                .HaveStdOutContaining("NETSDK1083");
         }
 
         [Fact]


### PR DESCRIPTION
#### CHANGES

Instead of Implicitly converting to lowercase, warn users instead. So, when possible, they can change them to lowercase right at the source.
We don't actually require lowercase but it was assumed in the design doc since there is logic when the values are used as a part of the path in case-sensitive file systems.

#### NOTES

The comments and the help text are not final, since, I'm not fluent in English.
Please do suggest alternative forms that properly convey the meaning and intent.
I'll update the tests and localizations after we land on something more concrete.