### PR TITLE
Use correct column number for Razor

### DIFF
--- a/src/RazorSdk/SourceGenerators/SourceTextSourceLineCollection.cs
+++ b/src/RazorSdk/SourceGenerators/SourceTextSourceLineCollection.cs
@@ -30,7 +30,7 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
         internal override SourceLocation GetLocation(int position)
         {
             var line = _textLines.GetLineFromPosition(position);
-            return new SourceLocation(_filePath, position, line.LineNumber, position);
+            return new SourceLocation(_filePath, position, line.LineNumber, position - line.Start);
         }
     }
 }

--- a/src/Tests/Microsoft.NET.Sdk.Razor.SourceGenerators.Tests/SourceTextSourceLineCollectionTest.cs
+++ b/src/Tests/Microsoft.NET.Sdk.Razor.SourceGenerators.Tests/SourceTextSourceLineCollectionTest.cs
@@ -69,9 +69,7 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
             var location = collection.GetLocation(length);
 
             // Assert
-            // Conditional check to account for line endings on Windows
-            var lineLength = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? 39 : 38;
-            var expected = new SourceLocation("dummy", length, 1, lineLength);
+            var expected = new SourceLocation("dummy", length, 1, 15);
             Assert.Equal(expected, location);
         }
 


### PR DESCRIPTION
Resolves Razor compile errors that are dependant on column position (e.g. "directive must be at start of line")

Fixes https://github.com/dotnet/aspnetcore/issues/32154
Fixes https://github.com/dotnet/aspnetcore/issues/31783

/cc @captainsafia