### PR TITLE
Removing skip manifest update requirement for prev 4

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadInstallCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadInstallCommand.cs
@@ -144,11 +144,6 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
             _reporter.WriteLine();
             var featureBand = new SdkFeatureBand(string.Join('.', _sdkVersion.Major, _sdkVersion.Minor, _sdkVersion.SdkFeatureBand));
 
-            if (!skipManifestUpdate)
-            {
-                throw new NotImplementedException();
-            }
-
             InstallWorkloadsWithInstallRecord(workloadIds, featureBand);
 
             if (_workloadInstaller.GetInstallationUnit().Equals(InstallationUnit.Packs))


### PR DESCRIPTION
No longer require `--skip-manifest-update` flag for workload install for preview 4. I will not port this to main since https://github.com/dotnet/sdk/pull/16891 should be ready for prev 5 and will have the real implementation. 