### PR TITLE
Fix get dotnet root error on appended path separator

### DIFF
--- a/src/Resolvers/Microsoft.DotNet.NativeWrapper/EnvironmentProvider.cs
+++ b/src/Resolvers/Microsoft.DotNet.NativeWrapper/EnvironmentProvider.cs
@@ -41,7 +41,8 @@ namespace Microsoft.DotNet.NativeWrapper
                     searchPaths.AddRange(
                         _getEnvironmentVariable("PATH")
                         .Split(Path.PathSeparator)
-                        .Select(p => p.Trim('"')));
+                        .Select(p => p.Trim('"'))
+                        .Where(p => !string.IsNullOrWhiteSpace(p)));
 
                     _searchPaths = searchPaths;
                 }
@@ -78,7 +79,7 @@ namespace Microsoft.DotNet.NativeWrapper
                 dotnetExe = Interop.Unix.realpath(dotnetExe) ?? dotnetExe;
             }
 
-            if (dotnetExe == null)
+            if (string.IsNullOrWhiteSpace(dotnetExe))
             {
                 dotnetExe = Process.GetCurrentProcess().MainModule.FileName;
             }

--- a/src/Resolvers/Microsoft.DotNet.NativeWrapper/EnvironmentProvider.cs
+++ b/src/Resolvers/Microsoft.DotNet.NativeWrapper/EnvironmentProvider.cs
@@ -40,9 +40,8 @@ namespace Microsoft.DotNet.NativeWrapper
 
                     searchPaths.AddRange(
                         _getEnvironmentVariable("PATH")
-                        .Split(Path.PathSeparator)
-                        .Select(p => p.Trim('"'))
-                        .Where(p => !string.IsNullOrWhiteSpace(p)));
+                        .Split(new char[] { Path.PathSeparator }, options: StringSplitOptions.RemoveEmptyEntries)
+                        .Select(p => p.Trim('"')));
 
                     _searchPaths = searchPaths;
                 }

--- a/src/Tests/Microsoft.DotNet.MSBuildSdkResolver.Tests/GivenAnEnvironmentForResolution.cs
+++ b/src/Tests/Microsoft.DotNet.MSBuildSdkResolver.Tests/GivenAnEnvironmentForResolution.cs
@@ -19,5 +19,14 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
             var pathResult = environmentProvider.GetCommandPath("nonexistantCommand");
             pathResult.Should().BeNull();
         }
+
+        [Fact]
+        public void ItDoesNotReturnNullDotnetRootOnExtraPathSeparator()
+        {
+            File.Create(Path.Combine(Directory.GetCurrentDirectory(), "dotnet.exe"));
+            Func<string, string> getPathEnvVarFunc = (input) => input.Equals("PATH") ? $"fake{Path.PathSeparator}" : string.Empty;
+            var result = NativeWrapper.EnvironmentProvider.GetDotnetExeDirectory(getPathEnvVarFunc);
+            result.Should().NotBeNullOrWhiteSpace();
+        }
     }
 }


### PR DESCRIPTION
Fixing an edge case issue: when there's an extra path separator on the end of the path it uses the empty string at a search path and returns an empty string as the root if a dotnet.exe file exists in this dir