### PR TITLE
Add OneLocBuild to 5.0.3xx

### DIFF
--- a/eng/build.yml
+++ b/eng/build.yml
@@ -15,6 +15,12 @@ parameters:
   timeoutInMinutes: 180
 
 jobs:
+- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+  - template: /eng/common/templates/job/onelocbuild.yml
+    parameters:
+      CreatePr: false
+      LclSource: lclFilesfromPackage
+      LclPackageId: 'LCL-JUNO-PROD-DOTNETSDK'
 - template: /eng/common/templates/job/job.yml
   parameters:
     name: ${{ parameters.agentOs }}


### PR DESCRIPTION
Turn on OneLocBuild into 5.0.3xx in preparation for 16.10 release.