### PR TITLE
Allow opting out of self-contained exe reference errors

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/ValidateExecutableReferences.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ValidateExecutableReferences.cs
@@ -47,10 +47,11 @@ namespace Microsoft.NET.Build.Tasks
                     projectAdditionalProperties[propertyElement.Name.LocalName] = propertyElement.Value;
                 }
 
+                var shouldBeValidatedAsExecutableReference = MSBuildUtilities.ConvertStringToBool(projectAdditionalProperties["ShouldBeValidatedAsExecutableReference"], true);
                 var referencedProjectIsExecutable = MSBuildUtilities.ConvertStringToBool(projectAdditionalProperties["_IsExecutable"]);
                 var referencedProjectIsSelfContained = MSBuildUtilities.ConvertStringToBool(projectAdditionalProperties["SelfContained"]);
 
-                if (referencedProjectIsExecutable)
+                if (referencedProjectIsExecutable && shouldBeValidatedAsExecutableReference)
                 {
                     if (SelfContained && !referencedProjectIsSelfContained)
                     {

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -1044,6 +1044,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <ItemGroup>
     <AdditionalTargetFrameworkInfoProperty Include="SelfContained"/>
     <AdditionalTargetFrameworkInfoProperty Include="_IsExecutable"/>
+    <AdditionalTargetFrameworkInfoProperty Include="ShouldBeValidatedAsExecutableReference"/>
   </ItemGroup>
 
   <UsingTask TaskName="ValidateExecutableReferences" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -1047,6 +1047,11 @@ Copyright (c) .NET Foundation. All rights reserved.
     <AdditionalTargetFrameworkInfoProperty Include="ShouldBeValidatedAsExecutableReference"/>
   </ItemGroup>
 
+  <PropertyGroup Condition="'$(RuntimeIdentifier)' == 'browser-wasm'">
+    <!-- Don't generate a NETSDK1151 error if a non self-contained Exe references a Blazor wasm Exe -->
+    <ShouldBeValidatedAsExecutableReference>false</ShouldBeValidatedAsExecutableReference>
+  </PropertyGroup>
+
   <UsingTask TaskName="ValidateExecutableReferences" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
 
   <Target Name="ValidateExecutableReferences"


### PR DESCRIPTION
This happens in Blazor "hosted" scenarios.  Blazor should set ShouldBeValidatedAsExecutableReference to false for Blazor Wasm projects