### PR TITLE
Bypass .NET 3.5 framework install check

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets
@@ -364,7 +364,7 @@ Copyright (c) .NET Foundation. All rights reserved.
         TargetFrameworkMoniker="$(TargetFrameworkMoniker)"
         RootPath="$(TargetFrameworkRootPath)"
         TargetFrameworkFallbackSearchPaths="$(TargetFrameworkFallbackSearchPaths)"
-        BypassFrameworkInstallChecks="$(BypassFrameworkInstallChecks)"
+        BypassFrameworkInstallChecks="true"
         SuppressNotFoundError="true">
       <Output TaskParameter="FullFrameworkReferenceAssemblyPaths" PropertyName="_FullFrameworkReferenceAssemblyPaths"/>
     </GetReferenceAssemblyPaths>


### PR DESCRIPTION
Bypass .NET 3.5 framework install check when checking whether targeting pack NuGet package should be referenced.

The targeting pack NuGet package will set this property to true, but that doesn't apply during the restore operation when we run this task.