### PR TITLE
Disable COM for trimming

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ILLink.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ILLink.targets
@@ -45,6 +45,16 @@ Copyright (c) .NET Foundation. All rights reserved.
     <EnableUnsafeBinaryFormatterInDesigntimeLicenseContextSerialization>false</EnableUnsafeBinaryFormatterInDesigntimeLicenseContextSerialization>
   </PropertyGroup>
 
+  <!-- We disable in-built COM support for trimmed apps here so that the feature
+       switch can flow to the runtimeconfig.json. Built-in COM support is disabled
+       by default since they may require assemblies, types or members that
+       could be removed by the linker, causing a trimmed app to crash. -->
+  <PropertyGroup Condition="'$(BuiltInComSupport)' == '' And
+                            '$(PublishTrimmed)' == 'true' And
+                            $([MSBuild]::VersionGreaterThanOrEquals($(_TargetFrameworkVersionWithoutV), '6.0'))">
+    <BuiltInComSupport>false</BuiltInComSupport>
+  </PropertyGroup>  
+
   <PropertyGroup Condition="'$(SuppressTrimAnalysisWarnings)' == '' And ('$(EnableTrimAnalyzer)' == 'true' Or '$(PublishTrimmed)' == 'true')">
     <!-- Trim analysis warnings are suppressed for .NET < 6. -->
     <SuppressTrimAnalysisWarnings Condition="$([MSBuild]::VersionLessThan('$(TargetFrameworkVersion)', '6.0'))">true</SuppressTrimAnalysisWarnings>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -352,9 +352,9 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <ItemGroup>
     <RuntimeHostConfigurationOption Include=" System.Runtime.InteropServices.Marshal.IsBuiltInComSupported"
-                                        Condition="'$(BuiltInComSupport)' != ''"
-                                        Value="$(BuiltInComSupport)"
-                                        Trim="true" />
+                                    Condition="'$(BuiltInComSupport)' != ''"
+                                    Value="$(BuiltInComSupport)"
+                                    Trim="true" />
 
     <RuntimeHostConfigurationOption Include="System.ComponentModel.TypeConverter.EnableUnsafeBinaryFormatterInDesigntimeLicenseContextSerialization"
                                     Condition="'$(EnableUnsafeBinaryFormatterInDesigntimeLicenseContextSerialization)' != ''"

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -351,6 +351,11 @@ Copyright (c) .NET Foundation. All rights reserved.
     -->
 
   <ItemGroup>
+    <RuntimeHostConfigurationOption Include=" System.Runtime.InteropServices.Marshal.IsBuiltInComSupported"
+                                        Condition="'$(BuiltInComSupport)' != ''"
+                                        Value="$(BuiltInComSupport)"
+                                        Trim="true" />
+
     <RuntimeHostConfigurationOption Include="System.ComponentModel.TypeConverter.EnableUnsafeBinaryFormatterInDesigntimeLicenseContextSerialization"
                                     Condition="'$(EnableUnsafeBinaryFormatterInDesigntimeLicenseContextSerialization)' != ''"
                                     Value="$(EnableUnsafeBinaryFormatterInDesigntimeLicenseContextSerialization)"

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToRunILLink.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToRunILLink.cs
@@ -682,6 +682,9 @@ namespace Microsoft.NET.Publish.Tests
             {
                 JObject runtimeConfig = JObject.Parse(runtimeConfigContents);
                 runtimeConfig["runtimeOptions"]["configProperties"]
+                    ["System.Runtime.InteropServices.Marshal.IsBuiltInComSupported"].Value<bool>()
+                    .Should().Be(false);
+                runtimeConfig["runtimeOptions"]["configProperties"]
                     ["System.StartupHookProvider.IsSupported"].Value<bool>()
                     .Should().Be(false);
                 runtimeConfig["runtimeOptions"]["configProperties"]
@@ -693,6 +696,7 @@ namespace Microsoft.NET.Publish.Tests
             }
             else
             {
+                runtimeConfigContents.Should().NotContain("System.Runtime.InteropServices.Marshal.IsBuiltInComSupported");
                 runtimeConfigContents.Should().NotContain("System.StartupHookProvider.IsSupported");
                 runtimeConfigContents.Should().NotContain("System.Resources.ResourceManager.AllowCustomResourceTypes");
                 runtimeConfigContents.Should().NotContain("System.ComponentModel.TypeConverter.EnableUnsafeBinaryFormatterInDesigntimeLicenseContextSerialization");


### PR DESCRIPTION
Propagates the built-in `msbuild` property, `BuiltInComSupport`, for trimming which is set to false by default. Built-in COM is not trim-safe and will need explicit developer action if needed for their application