### PR TITLE
Use ProjectCapability to determine hot reloadibility

### DIFF
--- a/src/BuiltInTools/dotnet-watch/DotNetWatchContext.cs
+++ b/src/BuiltInTools/dotnet-watch/DotNetWatchContext.cs
@@ -1,6 +1,9 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+#nullable enable
+
+using Microsoft.Build.Graph;
 using Microsoft.Extensions.Tools.Internal;
 
 namespace Microsoft.DotNet.Watcher.Tools
@@ -9,9 +12,9 @@ namespace Microsoft.DotNet.Watcher.Tools
     {
         public IReporter Reporter { get; init; } = NullReporter.Singleton;
 
-        public ProcessSpec ProcessSpec { get; set; }
+        public ProcessSpec ProcessSpec { get; init; } = default!;
 
-        public FileSet FileSet { get; set; }
+        public FileSet FileSet { get; set; } = default!;
 
         public int Iteration { get; set; } = -1;
 
@@ -21,8 +24,10 @@ namespace Microsoft.DotNet.Watcher.Tools
 
         public bool SuppressMSBuildIncrementalism { get; set; }
 
-        public BrowserRefreshServer BrowserRefreshServer { get; set; }
+        public BrowserRefreshServer? BrowserRefreshServer { get; set; }
 
-        public LaunchSettingsProfile DefaultLaunchSettingsProfile { get; set; }
+        public LaunchSettingsProfile DefaultLaunchSettingsProfile { get; init; } = default!;
+
+        public ProjectGraph? ProjectGraph { get; set; }
     }
 }

--- a/src/BuiltInTools/dotnet-watch/HotReload/BlazorWebAssemblyHostedDeltaApplier.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/BlazorWebAssemblyHostedDeltaApplier.cs
@@ -13,12 +13,12 @@ namespace Microsoft.DotNet.Watcher.Tools
     internal class BlazorWebAssemblyHostedDeltaApplier : IDeltaApplier
     {
         private readonly BlazorWebAssemblyDeltaApplier _wasmApplier;
-        private readonly AspNetCoreDeltaApplier _hostApplier;
+        private readonly DefaultDeltaApplier _hostApplier;
 
         public BlazorWebAssemblyHostedDeltaApplier(IReporter reporter)
         {
             _wasmApplier = new BlazorWebAssemblyDeltaApplier(reporter);
-            _hostApplier = new AspNetCoreDeltaApplier(reporter)
+            _hostApplier = new DefaultDeltaApplier(reporter)
             {
                 SuppressBrowserRefreshAfterApply = true,
             };

--- a/src/BuiltInTools/dotnet-watch/HotReload/CompilationHandler.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/CompilationHandler.cs
@@ -11,7 +11,6 @@ using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Build.Locator;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.ExternalAccess.Watch.Api;
@@ -35,26 +34,22 @@ namespace Microsoft.DotNet.Watcher.Tools
 
         public async ValueTask InitializeAsync(DotNetWatchContext context, CancellationToken cancellationToken)
         {
+            Debug.Assert(context.ProjectGraph is not null);
+
             if (_deltaApplier is null)
             {
-                _deltaApplier = context.DefaultLaunchSettingsProfile.HotReloadProfile switch
+                var hotReloadProfile = HotReloadProfileReader.InferHotReloadProfile(context.ProjectGraph, _reporter);
+                _deltaApplier = hotReloadProfile switch
                 {
-                    "blazorwasm" => new BlazorWebAssemblyDeltaApplier(_reporter),
-                    "blazorwasmhosted" => new BlazorWebAssemblyHostedDeltaApplier(_reporter),
-                    _ => new AspNetCoreDeltaApplier(_reporter),
+                    HotReloadProfile.BlazorWebAssembly => new BlazorWebAssemblyDeltaApplier(_reporter),
+                    HotReloadProfile.BlazorHosted => new BlazorWebAssemblyHostedDeltaApplier(_reporter),
+                    _ => new DefaultDeltaApplier(_reporter),
                 };
             }
 
             await _deltaApplier.InitializeAsync(context, cancellationToken);
 
-            if (context.Iteration == 0)
-            {
-                var instance = MSBuildLocator.QueryVisualStudioInstances().First();
-
-                _reporter.Verbose($"Using MSBuild at '{instance.MSBuildPath}' to load projects.");
-                MSBuildLocator.RegisterInstance(instance);
-            }
-            else if (_currentSolution is not null)
+            if (_currentSolution is not null)
             {
                 _currentSolution.Workspace.Dispose();
                 _currentSolution = null;
@@ -243,5 +238,7 @@ namespace Microsoft.DotNet.Watcher.Tools
                 _currentSolution.Workspace.Dispose();
             }
         }
+
+        
     }
 }

--- a/src/BuiltInTools/dotnet-watch/HotReload/DefaultDeltaApplier.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/DefaultDeltaApplier.cs
@@ -15,13 +15,13 @@ using Microsoft.Extensions.Tools.Internal;
 
 namespace Microsoft.DotNet.Watcher.Tools
 {
-    internal class AspNetCoreDeltaApplier : IDeltaApplier
+    internal class DefaultDeltaApplier : IDeltaApplier
     {
         private readonly IReporter _reporter;
         private Task _task;
         private NamedPipeServerStream _pipe;
 
-        public AspNetCoreDeltaApplier(IReporter reporter)
+        public DefaultDeltaApplier(IReporter reporter)
         {
             _reporter = reporter;
         }

--- a/src/BuiltInTools/dotnet-watch/HotReload/HotReloadProfile.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/HotReloadProfile.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.DotNet.Watcher.Tools
+{
+    public enum HotReloadProfile
+    {
+        Default,
+
+        /// <summary>
+        /// Blazor WebAssembly app
+        /// </summary>
+        BlazorWebAssembly,
+
+        /// <summary>
+        /// Blazor WebAssembly app hosted by an ASP.NET Core app.
+        /// </summary>
+        BlazorHosted,
+    }
+}

--- a/src/BuiltInTools/dotnet-watch/HotReload/HotReloadProfileReader.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/HotReloadProfileReader.cs
@@ -1,0 +1,52 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using Microsoft.Build.Graph;
+using Microsoft.Extensions.Tools.Internal;
+
+namespace Microsoft.DotNet.Watcher.Tools
+{
+    public static class HotReloadProfileReader
+    {
+        public static HotReloadProfile InferHotReloadProfile(ProjectGraph projectGraph, IReporter reporter)
+        {
+            var queue = new Queue<ProjectGraphNode>(projectGraph.EntryPointNodes);
+
+            var seenAspNetCoreProject = false;
+
+            while (queue.Count > 0)
+            {
+                var next = queue.Dequeue();
+                var projectCapability = next.ProjectInstance.GetItems("ProjectCapability");
+
+                foreach (var item in projectCapability)
+                {
+                    if (item.EvaluatedInclude == "AspNetCore")
+                    {
+                        seenAspNetCoreProject = true;
+                    }
+                    else if (item.EvaluatedInclude == "WebAssembly")
+                    {
+                        if (seenAspNetCoreProject)
+                        {
+                            reporter.Verbose("HotReloadProfile: BlazorHosted.");
+                            return HotReloadProfile.BlazorHosted;
+                        }
+
+                        reporter.Verbose("HotReloadProfile: BlazorWebAssembly.");
+                        return HotReloadProfile.BlazorWebAssembly;
+                    }
+                }
+
+                foreach (var project in next.ProjectReferences)
+                {
+                    queue.Enqueue(project);
+                }
+            }
+
+            reporter.Verbose("HotReloadProfile: Default.");
+            return HotReloadProfile.Default;
+        }
+    }
+}

--- a/src/BuiltInTools/dotnet-watch/LaunchSettingsProfile.cs
+++ b/src/BuiltInTools/dotnet-watch/LaunchSettingsProfile.cs
@@ -22,8 +22,6 @@ namespace Microsoft.DotNet.Watcher.Tools
 
         public string? LaunchUrl { get; set; }
 
-        public string? HotReloadProfile { get; set; }
-
         public IDictionary<string, string>? EnvironmentVariables { get; set; }
 
         internal static LaunchSettingsProfile? ReadDefaultProfile(string projectDirectory, IReporter reporter)

--- a/src/BuiltInTools/dotnet-watch/dotnet-watch.csproj
+++ b/src/BuiltInTools/dotnet-watch/dotnet-watch.csproj
@@ -18,6 +18,8 @@
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="System.CommandLine" Version="$(SystemCommandLineVersion)" />
+    <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildPackageVersion)" ExcludeAssets="runtime" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildPackageVersion)" ExcludeAssets="runtime" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Build.Locator" Version="$(MicrosoftBuildLocatorPackageVersion)" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" Version="$(MicrosoftCodeAnalysisCSharpFeaturesPackageVersion)" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="$(MicrosoftCodeAnalysisWorkspacesMSBuildPackageVersion)" />

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -1000,6 +1000,11 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ProjectCapability Remove="ReferenceManagerAssemblies" />
   </ItemGroup>
 
+  <!-- Enable hot reload in 6.0 and newer apps by default -->
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '6.0'))">
+    <ProjectCapability Include="SupportsHotReload" />
+  </ItemGroup>
+
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.NET.DisableStandardFrameworkResolution.targets" Condition="'$(DisableStandardFrameworkResolution)' == 'true'" />
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.NET.DesignerSupport.targets" />
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.NET.GenerateAssemblyInfo.targets" Condition="'$(UsingNETSdkDefaults)' == 'true'"/>


### PR DESCRIPTION
dotnet-watch currently relies on the presence of a value in the launchSettings.json to
determine if a project supports hot reload. This is problematic for workloads other than
ASP.NET Core that do not contain a launchSettings.

This change introduces a ProjectCapability in the SDK that is configured for projects targeting 6.0 or newer
and updates dotnet-watch to start using this capability. In addition, for the "esoteric" cases of BlazorWasm
and BlazorWasm-hosted, we'll rely on the presence of additional capabilities rather than the profile.