### PR TITLE
Update the conventions for discovering and invoking metadata update handlers

### DIFF
--- a/sdk.sln
+++ b/sdk.sln
@@ -363,6 +363,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DotNet.PackageVal
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DotNet.PackageValidation.Tests", "src\Tests\Microsoft.DotNet.PackageValidation.Tests\Microsoft.DotNet.PackageValidation.Tests.csproj", "{69C03400-12AC-4E4D-B970-6A880616BF68}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Extensions.DotNetDeltaApplier.Tests", "src\Tests\Microsoft.Extensions.DotNetDeltaApplier.Tests\Microsoft.Extensions.DotNetDeltaApplier.Tests.csproj", "{FAAC2E23-A460-40FE-9207-C10EEE5A6A07}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -665,6 +667,10 @@ Global
 		{69C03400-12AC-4E4D-B970-6A880616BF68}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{69C03400-12AC-4E4D-B970-6A880616BF68}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{69C03400-12AC-4E4D-B970-6A880616BF68}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FAAC2E23-A460-40FE-9207-C10EEE5A6A07}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FAAC2E23-A460-40FE-9207-C10EEE5A6A07}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FAAC2E23-A460-40FE-9207-C10EEE5A6A07}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FAAC2E23-A460-40FE-9207-C10EEE5A6A07}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -786,6 +792,7 @@ Global
 		{EEF4C7DD-CDC9-44B6-8B4F-725647D54ED8} = {580D1AE7-AA8F-4912-8B76-105594E00B3B}
 		{E56BEA9A-B52A-4781-9FF4-217439923319} = {AF683E5C-421E-4DE0-ADD7-9841E5D12BFA}
 		{69C03400-12AC-4E4D-B970-6A880616BF68} = {580D1AE7-AA8F-4912-8B76-105594E00B3B}
+		{FAAC2E23-A460-40FE-9207-C10EEE5A6A07} = {580D1AE7-AA8F-4912-8B76-105594E00B3B}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {FB8F26CE-4DE6-433F-B32A-79183020BBD6}

--- a/src/BuiltInTools/DotNetDeltaApplier/HotReloadAgent.cs
+++ b/src/BuiltInTools/DotNetDeltaApplier/HotReloadAgent.cs
@@ -1,14 +1,13 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#nullable enable
-
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Reflection.Metadata;
+using System.Runtime.InteropServices;
 using Microsoft.DotNet.Watcher.Tools;
 
 namespace Microsoft.Extensions.HotReload
@@ -19,7 +18,7 @@ namespace Microsoft.Extensions.HotReload
         private readonly AssemblyLoadEventHandler _assemblyLoad;
         private readonly ConcurrentDictionary<Guid, IReadOnlyList<UpdateDelta>> _deltas = new();
         private readonly ConcurrentDictionary<Assembly, Assembly> _appliedAssemblies = new();
-        private volatile UpdateHandlerActions? _beforeAfterUpdates;
+        private volatile UpdateHandlerActions? _handlerActions;
 
         public HotReloadAgent(Action<string> log)
         {
@@ -30,7 +29,7 @@ namespace Microsoft.Extensions.HotReload
 
         private void OnAssemblyLoad(object? _, AssemblyLoadEventArgs eventArgs)
         {
-            _beforeAfterUpdates = null;
+            _handlerActions = null;
             var loadedAssembly = eventArgs.LoadedAssembly;
             var moduleId = loadedAssembly.Modules.FirstOrDefault()?.ModuleVersionId;
             if (moduleId is null)
@@ -45,98 +44,186 @@ namespace Microsoft.Extensions.HotReload
             }
         }
 
-        private sealed class UpdateHandlerActions
+        internal sealed class UpdateHandlerActions
         {
-            public UpdateHandlerActions(List<Action<Type[]?>> before, List<Action<Type[]?>> after)
-            {
-                Before = before;
-                After = after;
-            }
-
-            public List<Action<Type[]?>> Before { get; }
-            public List<Action<Type[]?>> After { get; }
+            public List<Action<Type[]?>> Before { get; } = new();
+            public List<Action<Type[]?>> After { get; } = new();
+            public List<Action<Type[]?>> ClearCache { get; } = new();
+            public List<Action<Type[]?>> UpdateApplication { get; } = new();
         }
 
         private UpdateHandlerActions GetMetadataUpdateHandlerActions()
         {
-            var before = new List<Action<Type[]?>>();
-            var after = new List<Action<Type[]?>>();
-
-            foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
+            // In a typical app, a handful of assemblies will have metadata handler attributes. We need to discover these assemblies
+            // and ensure that they are topologically sorted so that handlers in a dependency are executed before the dependent (e.g.
+            // the reflection cache action in System.Private.CoreLib is executed before System.Text.Json clears it's own cache.)
+            // This would ensure that there is a well-defined order and that caches and updates more lower in the application stack
+            // are up to date before ones higher in the stack are recomputed.
+            var assemblies = GetAssembliesWithMetadataUpdateHandlerAttributes();
+            var sortedAssemblies = TopologicalSort(CollectionsMarshal.AsSpan(assemblies));
+            var handlerActions = new UpdateHandlerActions();
+            foreach (var assembly in CollectionsMarshal.AsSpan(sortedAssemblies))
             {
-                foreach (var attr in assembly.GetCustomAttributes<MetadataUpdateHandlerAttribute>())
+                foreach (var attribute in assembly.GetCustomAttributes<MetadataUpdateHandlerAttribute>())
                 {
-                    bool methodFound = false;
-                    var handlerType = attr.HandlerType;
-
-                    if (GetUpdateMethod(handlerType, "BeforeUpdate") is MethodInfo beforeUpdate)
-                    {
-                        before.Add(CreateAction(beforeUpdate));
-                        methodFound = true;
-                    }
-
-                    if (GetUpdateMethod(handlerType, "AfterUpdate") is MethodInfo afterUpdate)
-                    {
-                        after.Add(CreateAction(afterUpdate));
-                        methodFound = true;
-                    }
-
-                    if (!methodFound)
-                    {
-                        _log($"No BeforeUpdate or AfterUpdate method found on '{handlerType}'.");
-                    }
-
-                    Action<Type[]?> CreateAction(MethodInfo update)
-                    {
-                        Action<Type[]?> action = update.CreateDelegate<Action<Type[]?>>();
-                        return types =>
-                        {
-                            try
-                            {
-                                action(types);
-                            }
-                            catch (Exception ex)
-                            {
-                                _log($"Exception from '{action}': {ex}");
-                            }
-                        };
-                    }
-
-                    MethodInfo? GetUpdateMethod(Type handlerType, string name)
-                    {
-                        if (handlerType.GetMethod(name, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static, new[] { typeof(Type[]) }) is MethodInfo updateMethod &&
-                            updateMethod.ReturnType == typeof(void))
-                        {
-                            return updateMethod;
-                        }
-
-                        foreach (MethodInfo method in handlerType.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance))
-                        {
-                            if (method.Name == name)
-                            {
-                                _log($"Type '{handlerType}' has method '{method}' that does not match the required signature.");
-                                break;
-                            }
-                        }
-
-                        return null;
-                    }
+                    GetHandlerActions(handlerActions, attribute.HandlerType);
                 }
             }
 
-            return new UpdateHandlerActions(before, after);
+            return handlerActions;
+
+            static List<Assembly> GetAssembliesWithMetadataUpdateHandlerAttributes()
+            {
+                var assemblies = new List<Assembly>();
+                foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
+                {
+                    if (assembly.IsDefined(typeof(MetadataUpdateHandlerAttribute)))
+                    {
+                        assemblies.Add(assembly);
+                    }
+                }
+
+                return assemblies;
+            }
+        }
+
+        internal void GetHandlerActions(UpdateHandlerActions handlerActions, Type handlerType)
+        {
+            bool methodFound = false;
+
+            // Temporarily allow BeforeUpdate and AfterUpdate to be invoked until
+            // everything is updated to use the new names.
+            if (GetUpdateMethod(handlerType, "BeforeUpdate") is MethodInfo beforeUpdate)
+            {
+                handlerActions.Before.Add(CreateAction(beforeUpdate));
+                methodFound = true;
+            }
+
+            if (GetUpdateMethod(handlerType, "AfterUpdate") is MethodInfo afterUpdate)
+            {
+                handlerActions.After.Add(CreateAction(afterUpdate));
+                methodFound = true;
+            }
+
+            if (GetUpdateMethod(handlerType, "ClearCache") is MethodInfo clearCache)
+            {
+                handlerActions.ClearCache.Add(CreateAction(clearCache));
+                methodFound = true;
+            }
+
+            if (GetUpdateMethod(handlerType, "UpdateApplication") is MethodInfo updateApplication)
+            {
+                handlerActions.UpdateApplication.Add(CreateAction(updateApplication));
+                methodFound = true;
+            }
+
+            if (!methodFound)
+            {
+                _log($"No invokable methods found on metadata handler type '{handlerType}'. " +
+                    $"Allowed methods are ClearCache, UpdateApplication");
+            }
+
+            Action<Type[]?> CreateAction(MethodInfo update)
+            {
+                Action<Type[]?> action = update.CreateDelegate<Action<Type[]?>>();
+                return types =>
+                {
+                    try
+                    {
+                        action(types);
+                    }
+                    catch (Exception ex)
+                    {
+                        _log($"Exception from '{action}': {ex}");
+                    }
+                };
+            }
+
+            MethodInfo? GetUpdateMethod(Type handlerType, string name)
+            {
+                if (handlerType.GetMethod(name, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static, new[] { typeof(Type[]) }) is MethodInfo updateMethod &&
+                    updateMethod.ReturnType == typeof(void))
+                {
+                    return updateMethod;
+                }
+
+                foreach (MethodInfo method in handlerType.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance))
+                {
+                    if (method.Name == name)
+                    {
+                        _log($"Type '{handlerType}' has method '{method}' that does not match the required signature.");
+                        break;
+                    }
+                }
+
+                return null;
+            }
+        }
+
+        internal static List<Assembly> TopologicalSort(ReadOnlySpan<Assembly> assemblies)
+        {
+            var sortedAssemblies = new List<Assembly>(assemblies.Length);
+
+            var visited = new HashSet<string>(StringComparer.Ordinal);
+
+            foreach (var assembly in assemblies)
+            {
+                Visit(assemblies, assembly, sortedAssemblies, visited);
+            }
+
+            static void Visit(ReadOnlySpan<Assembly> assemblies, Assembly assembly, List<Assembly> sortedAssemblies, HashSet<string> visited)
+            {
+                var assemblyIdentifier = assembly.FullName ?? assembly.ToString();
+                if (!visited.Add(assemblyIdentifier))
+                {
+                    return;
+                }
+
+                foreach (var dependencyName in assembly.GetReferencedAssemblies())
+                {
+                    var dependency = FindDependency(assemblies, dependencyName);
+                    if (dependency is not null)
+                    {
+                        Visit(assemblies, dependency, sortedAssemblies, visited);
+                    }
+                }
+
+                sortedAssemblies.Add(assembly);
+            }
+
+            static Assembly? FindDependency(ReadOnlySpan<Assembly> assemblies, AssemblyName dependencyName)
+            {
+                foreach (var assembly in assemblies)
+                {
+                    if (assembly.FullName == dependencyName.FullName)
+                    {
+                        return assembly;
+                    }
+                }
+
+                return null;
+            }
+
+            return sortedAssemblies;
         }
 
         public void ApplyDeltas(IReadOnlyList<UpdateDelta> deltas)
         {
             try
             {
-                UpdateHandlerActions beforeAfterUpdates = _beforeAfterUpdates ??= GetMetadataUpdateHandlerActions();
+                // Defer discovering the receiving deltas until the first hot reload delta.
+                // This should give enough opportunity for AppDomain.GetAssemblies() to be sufficiently populated.
+                _handlerActions ??= GetMetadataUpdateHandlerActions();
+                var handlerActions = _handlerActions;
 
-                beforeAfterUpdates.Before.ForEach(b => b(null)); // TODO: Get types to pass in
+                // TODO: Get types to pass in
+                Type[]? updatedTypes = null;
 
-                foreach (var item in deltas)
+                InvokeActions(handlerActions.Before, updatedTypes);
+
+                for (var i = 0; i < deltas.Count; i++)
                 {
+                    var item = deltas[i];
                     var assembly = AppDomain.CurrentDomain.GetAssemblies().FirstOrDefault(a => a.Modules.FirstOrDefault() is Module m && m.ModuleVersionId == item.ModuleId);
                     if (assembly is not null)
                     {
@@ -144,16 +231,23 @@ namespace Microsoft.Extensions.HotReload
                     }
                 }
 
-                // Defer discovering the receiving deltas until the first hot reload delta.
-                // This should give enough opportunity for AppDomain.GetAssemblies() to be sufficiently populated.
-
-                beforeAfterUpdates.After.ForEach(a => a(null)); // TODO: Get types to pass in
+                InvokeActions(handlerActions.ClearCache, updatedTypes);
+                InvokeActions(handlerActions.After, updatedTypes);
+                InvokeActions(handlerActions.UpdateApplication, updatedTypes);
 
                 _log("Deltas applied.");
             }
             catch (Exception ex)
             {
                 _log(ex.ToString());
+            }
+
+            static void InvokeActions(List<Action<Type[]?>> actions, Type[]? updatedTypes)
+            {
+                foreach (var action in CollectionsMarshal.AsSpan(actions))
+                {
+                    action(updatedTypes);
+                }
             }
         }
 

--- a/src/BuiltInTools/DotNetDeltaApplier/Properties/AssemblyInfo.cs
+++ b/src/BuiltInTools/DotNetDeltaApplier/Properties/AssemblyInfo.cs
@@ -1,0 +1,6 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Microsoft.Extensions.DotNetDeltaApplier.Tests, PublicKey = 0024000004800000940000000602000000240000525341310004000001000100f33a29044fa9d740c9b3213a93e57c84b472c84e0b8a0e1ae48e67a9f8f6de9d5f7f3d52ac23e48ac51801f1dc950abe901da34d2a9e3baadb141a17c77ef3c565dd5ee5054b91cf63bb3c6ab83f72ab3aafe93d0fc3c2348b764fafb0b1c0733de51459aeab46580384bf9d74c4e28164b7cde247f891ba07891c9d872ad2bb")]

--- a/src/BuiltInTools/dotnet-watch/dotnet-watch.slnf
+++ b/src/BuiltInTools/dotnet-watch/dotnet-watch.slnf
@@ -2,12 +2,13 @@
   "solution": {
     "path": "..\\..\\..\\sdk.sln",
     "projects": [
-      "src\\BuiltInTools\\DotNetDeltaApplier\\Microsoft.Extensions.DotNetDeltaApplier.csproj",
       "src\\BuiltInTools\\BrowserRefresh\\Microsoft.AspNetCore.Watch.BrowserRefresh.csproj",
+      "src\\BuiltInTools\\DotNetDeltaApplier\\Microsoft.Extensions.DotNetDeltaApplier.csproj",
       "src\\BuiltInTools\\DotNetWatchTasks\\DotNetWatchTasks.csproj",
       "src\\BuiltInTools\\dotnet-watch\\dotnet-watch.csproj",
       "src\\Cli\\Microsoft.DotNet.Cli.Utils\\Microsoft.DotNet.Cli.Utils.csproj",
       "src\\Tests\\Microsoft.AspNetCore.Watch.BrowserRefresh.Tests\\Microsoft.AspNetCore.Watch.BrowserRefresh.Tests.csproj",
+      "src\\Tests\\Microsoft.Extensions.DotNetDeltaApplier.Tests\\Microsoft.Extensions.DotNetDeltaApplier.Tests.csproj",
       "src\\Tests\\Microsoft.NET.TestFramework\\Microsoft.NET.TestFramework.csproj",
       "src\\Tests\\dotnet-watch.Tests\\dotnet-watch.Tests.csproj"
     ]

--- a/src/Tests/Microsoft.Extensions.DotNetDeltaApplier.Tests/HotReloadAgentTest.cs
+++ b/src/Tests/Microsoft.Extensions.DotNetDeltaApplier.Tests/HotReloadAgentTest.cs
@@ -28,23 +28,6 @@ namespace Microsoft.Extensions.DotNetDeltaApplier
         }
 
         [Fact]
-        public void TopologicalSort_UsesFullName()
-        {
-            // Arrange
-            var assembly1 = GetAssembly("System.Private.CoreLib", Array.Empty<AssemblyName>());
-            var assembly2 = GetAssembly("System.Text.Json", new[] { new AssemblyName("System.Private.CoreLib"), });
-            var assembly3 = GetAssembly("System.Text.Json, Culture=fr-FR", new[] { new AssemblyName("System.Private.CoreLib"), });
-            var assembly4 = GetAssembly("Microsoft.AspNetCore.Components", new[] { new AssemblyName("System.Private.CoreLib"), });
-            var assembly5 = GetAssembly("Microsoft.AspNetCore.Components.Web", new[] { new AssemblyName("Microsoft.AspNetCore.Components"), new AssemblyName("System.Text.Json"), });
-            var assembly6 = GetAssembly("Microsoft.AspNetCore.Components.Web, Culture=fr-FR", new[] { new AssemblyName("System.Private.CoreLib"), });
-
-            var sortedList = HotReloadAgent.TopologicalSort(new[] { assembly2, assembly4, assembly1, assembly3, assembly5, assembly6 });
-
-            // Assert
-            Assert.Equal(new[] { assembly1, assembly2, assembly4, assembly3, assembly5, assembly6, }, sortedList);
-        }
-
-        [Fact]
         public void TopologicalSort_IgnoresUnknownReferencedAssemblies()
         {
             // Arrange

--- a/src/Tests/Microsoft.Extensions.DotNetDeltaApplier.Tests/HotReloadAgentTest.cs
+++ b/src/Tests/Microsoft.Extensions.DotNetDeltaApplier.Tests/HotReloadAgentTest.cs
@@ -1,0 +1,195 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using Microsoft.Extensions.HotReload;
+using Moq;
+using Xunit;
+
+namespace Microsoft.Extensions.DotNetDeltaApplier
+{
+    public class HotReloadAgentTest
+    {
+        [Fact]
+        public void TopologicalSort_Works()
+        {
+            // Arrange
+            var assembly1 = GetAssembly("System.Private.CoreLib", Array.Empty<AssemblyName>());
+            var assembly2 = GetAssembly("System.Text.Json", new[] { new AssemblyName("System.Private.CoreLib"), });
+            var assembly3 = GetAssembly("Microsoft.AspNetCore.Components", new[] { new AssemblyName("System.Private.CoreLib"), });
+            var assembly4 = GetAssembly("Microsoft.AspNetCore.Components.Web", new[] { new AssemblyName("Microsoft.AspNetCore.Components"), new AssemblyName("System.Text.Json"), });
+
+            var sortedList = HotReloadAgent.TopologicalSort(new[] { assembly2, assembly4, assembly1, assembly3 });
+
+            // Assert
+            Assert.Equal(new[] { assembly1, assembly2, assembly3, assembly4 }, sortedList);
+        }
+
+        [Fact]
+        public void TopologicalSort_UsesFullName()
+        {
+            // Arrange
+            var assembly1 = GetAssembly("System.Private.CoreLib", Array.Empty<AssemblyName>());
+            var assembly2 = GetAssembly("System.Text.Json", new[] { new AssemblyName("System.Private.CoreLib"), });
+            var assembly3 = GetAssembly("System.Text.Json, Culture=fr-FR", new[] { new AssemblyName("System.Private.CoreLib"), });
+            var assembly4 = GetAssembly("Microsoft.AspNetCore.Components", new[] { new AssemblyName("System.Private.CoreLib"), });
+            var assembly5 = GetAssembly("Microsoft.AspNetCore.Components.Web", new[] { new AssemblyName("Microsoft.AspNetCore.Components"), new AssemblyName("System.Text.Json"), });
+            var assembly6 = GetAssembly("Microsoft.AspNetCore.Components.Web, Culture=fr-FR", new[] { new AssemblyName("System.Private.CoreLib"), });
+
+            var sortedList = HotReloadAgent.TopologicalSort(new[] { assembly2, assembly4, assembly1, assembly3, assembly5, assembly6 });
+
+            // Assert
+            Assert.Equal(new[] { assembly1, assembly2, assembly4, assembly3, assembly5, assembly6, }, sortedList);
+        }
+
+        [Fact]
+        public void TopologicalSort_IgnoresUnknownReferencedAssemblies()
+        {
+            // Arrange
+            var assembly1 = GetAssembly("System.Private.CoreLib", Array.Empty<AssemblyName>());
+            var assembly2 = GetAssembly("System.Text.Json", new[] { new AssemblyName("netstandard"), new AssemblyName("System.Private.CoreLib"), });
+            var assembly3 = GetAssembly("Microsoft.AspNetCore.Components", new[] { new AssemblyName("System.Private.CoreLib"), new AssemblyName("Microsoft.Extensions.DependencyInjection"), });
+            var assembly4 = GetAssembly("Microsoft.AspNetCore.Components.Web", new[] { new AssemblyName("Microsoft.AspNetCore.Components"), new AssemblyName("System.Text.Json"), });
+
+            var sortedList = HotReloadAgent.TopologicalSort(new[] { assembly2, assembly4, assembly1, assembly3 });
+
+            // Assert
+            Assert.Equal(new[] { assembly1, assembly2, assembly3, assembly4 }, sortedList);
+        }
+
+        [Fact]
+        public void TopologicalSort_WithCycles()
+        {
+            // Arrange
+            var assembly1 = GetAssembly("System.Private.CoreLib", Array.Empty<AssemblyName>());
+            var assembly2 = GetAssembly("System.Text.Json", new[] { new AssemblyName("System.Collections.Immutable"), new AssemblyName("System.Private.CoreLib"), });
+            var assembly3 = GetAssembly("System.Collections.Immutable", new[] { new AssemblyName("System.Text.Json"), new AssemblyName("System.Private.CoreLib"), });
+            var assembly4 = GetAssembly("Microsoft.AspNetCore.Components", new[] { new AssemblyName("System.Private.CoreLib"), new AssemblyName("Microsoft.Extensions.DependencyInjection"), });
+            var assembly5 = GetAssembly("Microsoft.AspNetCore.Components.Web", new[] { new AssemblyName("Microsoft.AspNetCore.Components"), new AssemblyName("System.Text.Json"), });
+
+            var sortedList = HotReloadAgent.TopologicalSort(new[] { assembly2, assembly4, assembly1, assembly3, assembly5 });
+
+            // Assert
+            Assert.Equal(new[] { assembly1, assembly3, assembly2, assembly4, assembly5 }, sortedList);
+        }
+
+        [Fact]
+        public void GetHandlerActions_DiscoversActionsOnTypeWithClearCache()
+        {
+            // Arrange
+            var actions = new HotReloadAgent.UpdateHandlerActions();
+            var log = new List<string>();
+            var agent = new HotReloadAgent(message => log.Add(message));
+
+            agent.GetHandlerActions(actions, typeof(HandlerWithClearCache));
+
+            Assert.Empty(log);
+            Assert.Single(actions.ClearCache);
+            Assert.Empty(actions.UpdateApplication);
+        }
+
+        [Fact]
+        public void GetHandlerActions_DiscoversActionsOnTypeWithUpdateApplication()
+        {
+            // Arrange
+            var actions = new HotReloadAgent.UpdateHandlerActions();
+            var log = new List<string>();
+            var agent = new HotReloadAgent(message => log.Add(message));
+
+            agent.GetHandlerActions(actions, typeof(HandlerWithUpdateApplication));
+
+            Assert.Empty(log);
+            Assert.Empty(actions.ClearCache);
+            Assert.Single(actions.UpdateApplication);
+        }
+
+        [Fact]
+        public void GetHandlerActions_DiscoversActionsOnTypeWithBothActions()
+        {
+            // Arrange
+            var actions = new HotReloadAgent.UpdateHandlerActions();
+            var log = new List<string>();
+            var agent = new HotReloadAgent(message => log.Add(message));
+
+            agent.GetHandlerActions(actions, typeof(HandlerWithBothActions));
+
+            Assert.Empty(log);
+            Assert.Single(actions.ClearCache);
+            Assert.Single(actions.UpdateApplication);
+        }
+
+        [Fact]
+        public void GetHandlerActions_LogsMessageIfMethodHasIncorrectSignature()
+        {
+            // Arrange
+            var actions = new HotReloadAgent.UpdateHandlerActions();
+            var log = new List<string>();
+            var agent = new HotReloadAgent(message => log.Add(message));
+            var handlerType = typeof(HandlerWithIncorrectSignature);
+
+            agent.GetHandlerActions(actions, handlerType);
+
+            var message = Assert.Single(log);
+            Assert.Equal($"Type '{handlerType}' has method 'Void ClearCache()' that does not match the required signature.", message);
+            Assert.Empty(actions.ClearCache);
+            Assert.Single(actions.UpdateApplication);
+        }
+
+        [Fact]
+        public void GetHandlerActions_LogsMessageIfNoActionsAreDiscovered()
+        {
+            // Arrange
+            var actions = new HotReloadAgent.UpdateHandlerActions();
+            var log = new List<string>();
+            var agent = new HotReloadAgent(message => log.Add(message));
+            var handlerType = typeof(HandlerWithNoActions);
+
+            agent.GetHandlerActions(actions, handlerType);
+
+            var message = Assert.Single(log);
+            Assert.Equal($"No invokable methods found on metadata handler type '{handlerType}'. " +
+                    $"Allowed methods are ClearCache, UpdateApplication", message);
+            Assert.Empty(actions.ClearCache);
+            Assert.Empty(actions.UpdateApplication);
+        }
+
+        private static Assembly GetAssembly(string fullName, AssemblyName[] dependencies)
+        {
+            var assembly = new Mock<Assembly>();
+            assembly.Setup(a => a.GetName()).Returns(new AssemblyName(fullName));
+            assembly.SetupGet(a => a.FullName).Returns(fullName);
+            assembly.Setup(a => a.GetReferencedAssemblies()).Returns(dependencies);
+            assembly.Setup(a => a.ToString()).Returns(fullName);
+            return assembly.Object;
+        }
+
+        private class HandlerWithClearCache
+        {
+            internal static void ClearCache(Type[]? _) { }
+        }
+
+        private class HandlerWithUpdateApplication
+        {
+            internal static void UpdateApplication(Type[]? _) { }
+        }
+
+        private class HandlerWithBothActions
+        {
+            internal static void ClearCache(Type[]? _) { }
+            internal static void UpdateApplication(Type[]? _) { }
+        }
+
+        private class HandlerWithIncorrectSignature
+        {
+            internal static void ClearCache() { }
+            internal static void UpdateApplication(Type[]? _) { }
+        }
+
+        private class HandlerWithNoActions
+        {
+            internal static void SomeMethod() { }
+        }
+    }
+}

--- a/src/Tests/Microsoft.Extensions.DotNetDeltaApplier.Tests/Microsoft.Extensions.DotNetDeltaApplier.Tests.csproj
+++ b/src/Tests/Microsoft.Extensions.DotNetDeltaApplier.Tests/Microsoft.Extensions.DotNetDeltaApplier.Tests.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(SdkTargetFramework)</TargetFramework>
+    <RootNamespace>Microsoft.Extensions.DotNetDeltaApplier</RootNamespace>
+    <Nullable>enable</Nullable>
+    <StrongNameKeyId>MicrosoftAspNetCore</StrongNameKeyId>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\BuiltInTools\DotNetDeltaApplier\Microsoft.Extensions.DotNetDeltaApplier.csproj" />
+    <ProjectReference Include="..\Microsoft.NET.TestFramework\Microsoft.NET.TestFramework.csproj" />
+    <PackageReference Include="Moq" Version="$(MoqPackageVersion)" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
* Introduce ClearCache and UpdateApplication action names
* Invoke actions in topologically sorted order.

Contributes to https://github.com/dotnet/runtime/issues/51545