### PR TITLE
Fix restore of packages in PackageValidation

### DIFF
--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/build/Microsoft.DotNet.PackageValidation.targets
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/build/Microsoft.DotNet.PackageValidation.targets
@@ -68,7 +68,7 @@
       <_PackageValidationIntermediateBaselineFile>$(MSBuildProjectExtensionsPath)$(MSBuildProjectFile).packagevalidation.g.props</_PackageValidationIntermediateBaselineFile>
       <_PackageValidationIntermediateBaselineFileContent>
 <![CDATA[<Project>
-  <PropertyGroup Condition="'%24(EnablePackageBaselineValidation)' == 'true'">
+  <PropertyGroup>
     <_PackageValidationBaselineName>$(PackageValidationBaselineName)</_PackageValidationBaselineName>
     <_PackageValidationBaselineVersion>$(PackageValidationBaselineVersion)</_PackageValidationBaselineVersion>
   </PropertyGroup>

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/build/Microsoft.DotNet.PackageValidation.targets
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/build/Microsoft.DotNet.PackageValidation.targets
@@ -3,11 +3,13 @@
   <UsingTask TaskName="Microsoft.DotNet.PackageValidation.ValidatePackage" AssemblyFile="$(DotNetPackageValidationAssembly)" />
   <UsingTask TaskName="Microsoft.DotNet.PackageValidation.GetLastStablePackage" AssemblyFile="$(DotNetPackageValidationAssembly)" />
   
-  <PropertyGroup Condition="'$(EnablePackageBaselineValidation)' == 'true' and '$(IsCrossTargetingBuild)' == 'true'">
-    <!-- Static graph restore invokes CollectPackageDownloads from an outer build, non static graph restore doesn't.
-         To avoid multiple target invocations, hook onto an outer build extension point for non static graph restore. -->
-    <AddPackageValidationBaselinePackageAsPackageDownloadBeforeTargets Condition="'$(IsGraphBuild)' == 'true'">CollectPackageDownloads</AddPackageValidationBaselinePackageAsPackageDownloadBeforeTargets>
-    <AddPackageValidationBaselinePackageAsPackageDownloadBeforeTargets Condition="'$(IsGraphBuild)' != 'true'">_GenerateRestoreDependencies</AddPackageValidationBaselinePackageAsPackageDownloadBeforeTargets>
+  <PropertyGroup>
+    <!-- Create the intermediate file which contains the PackageDownload item before static graph restore (out-of-proc) is invoked. -->
+    <AddPackageValidationBaselinePackageAsPackageDownloadBeforeTargets Condition="'$(RestoreUseStaticGraphEvaluation)' == 'true'">Restore</AddPackageValidationBaselinePackageAsPackageDownloadBeforeTargets>
+    <!-- For a non static graph restore with a single tfm, hook onto CollectPackageDownloads which will then be invoked just once. -->
+    <AddPackageValidationBaselinePackageAsPackageDownloadBeforeTargets Condition="'$(AddPackageValidationBaselinePackageAsPackageDownloadBeforeTargets)' == '' and '$(TargetFrameworks)' == '' and '$(TargetFramework)' != ''">CollectPackageDownloads</AddPackageValidationBaselinePackageAsPackageDownloadBeforeTargets>
+    <!-- For a non static graph restore with multiple tfms, hook onto the target that fans out to the individual tfm restore graph walk operations. -->
+    <AddPackageValidationBaselinePackageAsPackageDownloadBeforeTargets Condition="'$(AddPackageValidationBaselinePackageAsPackageDownloadBeforeTargets)' == ''">_GetAllRestoreProjectPathItems</AddPackageValidationBaselinePackageAsPackageDownloadBeforeTargets>
   </PropertyGroup>
 
   <Target Name="RunPackageValidation"
@@ -15,6 +17,8 @@
           Condition="$(IsPackable) == 'true'">
     <PropertyGroup Condition="'$(EnablePackageBaselineValidation)' == 'true' and
                               '$(PackageValidationBaselinePath)' == ''">
+      <PackageValidationBaselineName Condition="'$(PackageValidationBaselineName)' == ''">$(_PackageValidationBaselineName)</PackageValidationBaselineName>
+      <PackageValidationBaselineVersion Condition="'$(PackageValidationBaselineVersion)' == ''">$(_PackageValidationBaselineVersion)</PackageValidationBaselineVersion>
       <PackageValidationBaselinePath>$([MSBuild]::NormalizePath('$(NuGetPackageRoot)', '$(PackageValidationBaselineName)', '$(PackageValidationBaselineVersion)', '$(PackageValidationBaselineName).$(PackageValidationBaselineVersion).nupkg'))</PackageValidationBaselinePath>
     </PropertyGroup>
 
@@ -41,8 +45,7 @@
           BeforeTargets="$(AddPackageValidationBaselinePackageAsPackageDownloadBeforeTargets)"
           DependsOnTargets="_GetRestoreSettings"
           Condition="'$(EnablePackageBaselineValidation)' == 'true' and
-                     '$(PackageValidationBaselinePath)' == '' and
-                     '$(IsCrossTargetingBuild)' == 'true'">
+                     '$(PackageValidationBaselinePath)' == ''">
     <PropertyGroup>
       <PackageValidationBaselineName Condition="'$(PackageValidationBaselineName)' == ''">$(PackageId)</PackageValidationBaselineName>
     </PropertyGroup>
@@ -64,11 +67,14 @@
     <PropertyGroup>
       <_PackageValidationIntermediateBaselineFile>$(MSBuildProjectExtensionsPath)$(MSBuildProjectFile).packagevalidation.g.props</_PackageValidationIntermediateBaselineFile>
       <_PackageValidationIntermediateBaselineFileContent>
-<![CDATA[<Project Condition="'%24(EnablePackageBaselineValidation)' == 'true'">
-  <PropertyGroup>
-    <PackageValidationBaselineName Condition="'%24(PackageValidationBaselineName)' == ''">$(PackageValidationBaselineName)</PackageValidationBaselineName>
-    <PackageValidationBaselineVersion Condition="'%24(PackageValidationBaselineVersion)' == ''">$(PackageValidationBaselineVersion)</PackageValidationBaselineVersion>
+<![CDATA[<Project>
+  <PropertyGroup Condition="'%24(EnablePackageBaselineValidation)' == 'true'">
+    <_PackageValidationBaselineName>$(PackageValidationBaselineName)</_PackageValidationBaselineName>
+    <_PackageValidationBaselineVersion>$(PackageValidationBaselineVersion)</_PackageValidationBaselineVersion>
   </PropertyGroup>
+  <ItemGroup Condition="'%24(EnablePackageBaselineValidation)' == 'true'">
+    <PackageDownload Include="$(PackageValidationBaselineName)" Version="[$(PackageValidationBaselineVersion)]" />
+  </ItemGroup>
 </Project>]]>
       </_PackageValidationIntermediateBaselineFileContent>
     </PropertyGroup>

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/build/Microsoft.DotNet.PackageValidation.targets
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/build/Microsoft.DotNet.PackageValidation.targets
@@ -50,7 +50,7 @@
     <!-- Relying on the private _OutputSources property to pass in the current feeds. -->
     <Microsoft.DotNet.PackageValidation.GetLastStablePackage
       PackageId="$(PackageValidationBaselineName)"
-      PackageVersion="$(Version)"
+      PackageVersion="$(PackageVersion)"
       NugetFeeds="$(_OutputSources)"
       Condition="'$(PackageValidationBaselineVersion)' == ''">
       <Output TaskParameter="LastStableVersion" PropertyName="PackageValidationBaselineVersion" />

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/build/Microsoft.DotNet.PackageValidation.targets
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/build/Microsoft.DotNet.PackageValidation.targets
@@ -38,8 +38,8 @@
        Using the private _GetRestoreSettings target which makes the restore settings (i.e. the feeds) available for
        consumption. -->
   <Target Name="AddPackageValidationBaselinePackageAsPackageDownload"
-          BeforeTargets="_GenerateRestoreGraph;CollectPackageDownloads"
-          DependsOnTargets="$(AddPackageValidationBaselinePackageAsPackageDownloadBeforeTargets)"
+          BeforeTargets="$(AddPackageValidationBaselinePackageAsPackageDownloadBeforeTargets)"
+          DependsOnTargets="_GetRestoreSettings"
           Condition="'$(EnablePackageBaselineValidation)' == 'true' and
                      '$(PackageValidationBaselinePath)' == '' and
                      '$(IsCrossTargetingBuild)' == 'true'">

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/build/Microsoft.DotNet.PackageValidation.targets
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/build/Microsoft.DotNet.PackageValidation.targets
@@ -2,6 +2,13 @@
 <Project>
   <UsingTask TaskName="Microsoft.DotNet.PackageValidation.ValidatePackage" AssemblyFile="$(DotNetPackageValidationAssembly)" />
   <UsingTask TaskName="Microsoft.DotNet.PackageValidation.GetLastStablePackage" AssemblyFile="$(DotNetPackageValidationAssembly)" />
+  
+  <PropertyGroup Condition="'$(EnablePackageBaselineValidation)' == 'true' and '$(IsCrossTargetingBuild)' == 'true'">
+    <!-- Static graph restore invokes CollectPackageDownloads from an outer build, non static graph restore doesn't.
+         To avoid multiple target invocations, hook onto an outer build extension point for non static graph restore. -->
+    <AddPackageValidationBaselinePackageAsPackageDownloadBeforeTargets Condition="'$(IsGraphBuild)' == 'true'">CollectPackageDownloads</AddPackageValidationBaselinePackageAsPackageDownloadBeforeTargets>
+    <AddPackageValidationBaselinePackageAsPackageDownloadBeforeTargets Condition="'$(IsGraphBuild)' != 'true'">_GenerateRestoreDependencies</AddPackageValidationBaselinePackageAsPackageDownloadBeforeTargets>
+  </PropertyGroup>
 
   <Target Name="RunPackageValidation"
           AfterTargets="Pack"
@@ -31,8 +38,8 @@
        Using the private _GetRestoreSettings target which makes the restore settings (i.e. the feeds) available for
        consumption. -->
   <Target Name="AddPackageValidationBaselinePackageAsPackageDownload"
-          BeforeTargets="Restore;CollectPackageDownloads"
-          DependsOnTargets="_GetRestoreSettings"
+          BeforeTargets="_GenerateRestoreGraph;CollectPackageDownloads"
+          DependsOnTargets="$(AddPackageValidationBaselinePackageAsPackageDownloadBeforeTargets)"
           Condition="'$(EnablePackageBaselineValidation)' == 'true' and
                      '$(PackageValidationBaselinePath)' == '' and
                      '$(IsCrossTargetingBuild)' == 'true'">


### PR DESCRIPTION
The target that adds the PackageDownload didn't run early enough in normal restore.