### PR TITLE
Account for new boolean when generating runtimeconfig.dev.json

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/GenerateRuntimeConfigurationFiles.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/GenerateRuntimeConfigurationFiles.cs
@@ -54,6 +54,8 @@ namespace Microsoft.NET.Build.Tasks
 
         public bool WriteIncludedFrameworks { get; set; }
 
+        public bool GenerateRuntimeConfigDevFile { get; set; }
+
         List<ITaskItem> _filesWritten = new List<ITaskItem>();
 
         private static readonly string[] RollForwardValues = new string[]
@@ -74,11 +76,12 @@ namespace Microsoft.NET.Build.Tasks
 
         protected override void ExecuteCore()
         {
-            bool writeDevRuntimeConfig = !string.IsNullOrEmpty(RuntimeConfigDevPath);
-
             if (!WriteAdditionalProbingPathsToMainConfig)
             {
-                if (AdditionalProbingPaths?.Any() == true && !writeDevRuntimeConfig)
+                // If we want to generate the runtimeconfig.dev.json file
+                // and we have probing paths to log
+                // BUT the runtimeconfigdevpath is empty, log a warning.
+                if (GenerateRuntimeConfigDevFile && AdditionalProbingPaths?.Any() == true && string.IsNullOrEmpty(RuntimeConfigDevPath))
                 {
                     Log.LogWarning(Strings.SkippingAdditionalProbingPaths);
                 }
@@ -138,7 +141,7 @@ namespace Microsoft.NET.Build.Tasks
                     projectContext.IsFrameworkDependent,
                     projectContext.LockFile.PackageFolders);
 
-                if (writeDevRuntimeConfig)
+                if (GenerateRuntimeConfigDevFile)
                 {
                     WriteDevRuntimeConfig(projectContext.LockFile.PackageFolders);
                 }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/GenerateRuntimeConfigurationFiles.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/GenerateRuntimeConfigurationFiles.cs
@@ -79,7 +79,7 @@ namespace Microsoft.NET.Build.Tasks
             if (!WriteAdditionalProbingPathsToMainConfig)
             {
                 // If we want to generate the runtimeconfig.dev.json file
-                // and we have probing paths to log
+                // and we have additional probing paths to add to it
                 // BUT the runtimeconfigdevpath is empty, log a warning.
                 if (GenerateRuntimeConfigDevFile && AdditionalProbingPaths?.Any() == true && string.IsNullOrEmpty(RuntimeConfigDevPath))
                 {
@@ -141,7 +141,7 @@ namespace Microsoft.NET.Build.Tasks
                     projectContext.IsFrameworkDependent,
                     projectContext.LockFile.PackageFolders);
 
-                if (GenerateRuntimeConfigDevFile)
+                if (GenerateRuntimeConfigDevFile && !string.IsNullOrEmpty(RuntimeConfigDevPath))
                 {
                     WriteDevRuntimeConfig(projectContext.LockFile.PackageFolders);
                 }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -265,7 +265,8 @@ Copyright (c) .NET Foundation. All rights reserved.
                                        HostConfigurationOptions="@(RuntimeHostConfigurationOption)"
                                        AdditionalProbingPaths="@(AdditionalProbingPath)"
                                        IsSelfContained="$(SelfContained)"
-                                       WriteIncludedFrameworks="$(_WriteIncludedFrameworks)">
+                                       WriteIncludedFrameworks="$(_WriteIncludedFrameworks)"
+                                       GenerateRuntimeConfigDevFile="$(GenerateRuntimeConfigDevFile)">
 
     </GenerateRuntimeConfigurationFiles>
 

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildANetCoreApp.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildANetCoreApp.cs
@@ -393,11 +393,15 @@ public static class Program
             };
 
             var buildCommand = new BuildCommand(_testAssetsManager.CreateTestProject(proj, identifier: targetFramework));
+
             var runtimeconfigFile = Path.Combine(
                 buildCommand.GetOutputDirectory(targetFramework).FullName,
                 $"{proj.Name}.runtimeconfig.dev.json");
 
-            buildCommand.Execute();
+            buildCommand.Execute().StdOut
+                        .Should()
+                        .NotContain("NETSDK1048");
+
             File.Exists(runtimeconfigFile).Should().Be(shouldGenerateRuntimeConfigDevJson);
         }
 
@@ -423,10 +427,14 @@ public static class Program
                 $"{proj.Name}.runtimeconfig.dev.json");
 
             // GenerateRuntimeConfigDevFile overrides default behavior
-            buildCommand.Execute("/p:GenerateRuntimeConfigDevFile=true");
+            buildCommand.Execute("/p:GenerateRuntimeConfigDevFile=true").StdOut
+                        .Should()
+                        .NotContain("NETSDK1048"); ;
             File.Exists(runtimeconfigFile).Should().BeTrue();
 
-            buildCommand.Execute("/p:GenerateRuntimeConfigDevFile=false");
+            buildCommand.Execute("/p:GenerateRuntimeConfigDevFile=false").StdOut
+                        .Should()
+                        .NotContain("NETSDK1048"); ;
             File.Exists(runtimeconfigFile).Should().BeFalse();
         }
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/sdk/issues/17388

### Context
In https://github.com/dotnet/sdk/pull/17014, we introduced a new property, `GenerateRuntimeConfigDevFile`. It's a boolean that determines whether to generate *.runtimeconfig.dev.json. The task needs to be updated to account for it.

### Changes Made
The `GenerateRuntimeConfigurationFiles` task is updated to also consider the `GenerateRuntimeConfigDevFile` property before throwing a warning.