### PR TITLE
Spruce up Razor source generator

### DIFF
--- a/src/RazorSdk/SourceGenerators/RazorSourceGenerationContext.cs
+++ b/src/RazorSdk/SourceGenerators/RazorSourceGenerationContext.cs
@@ -46,6 +46,12 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
         /// </summary>
         public bool SuppressRazorSourceGenerator { get; private set; }
 
+        /// <summary>
+        /// Gets a flag that determines if the source generator should produce
+        /// heap dumps from failing assertions.
+        /// </summary>
+        public bool ProduceHeapDumps { get; private set; }
+
         public RazorSourceGenerationContext(GeneratorExecutionContext context)
         {
             var globalOptions = context.AnalyzerConfigOptions.GlobalOptions;
@@ -71,10 +77,9 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
             }
 
             globalOptions.TryGetValue("build_property._RazorSourceGeneratorDebug", out var waitForDebugger);
-
             globalOptions.TryGetValue("build_property.SuppressRazorSourceGenerator", out var suppressRazorSourceGenerator);
-
             globalOptions.TryGetValue("build_property.GenerateRazorMetadataSourceChecksumAttributes", out var generateMetadataSourceChecksumAttributes);
+            globalOptions.TryGetValue("build_property._RazorSourceGeneratorHeapDumps", out var produceHeapDumps);
 
             var razorConfiguration = RazorConfiguration.Create(razorLanguageVersion, configurationName, Enumerable.Empty<RazorExtension>(), true);
             var (razorFiles, cshtmlFiles) = GetRazorInputs(context);
@@ -88,6 +93,7 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
             WaitForDebugger = waitForDebugger == "true";
             SuppressRazorSourceGenerator = suppressRazorSourceGenerator == "true";
             GenerateMetadataSourceChecksumAttributes = generateMetadataSourceChecksumAttributes == "true";
+            ProduceHeapDumps = produceHeapDumps == "true";
         }
 
         private static VirtualRazorProjectFileSystem GetVirtualFileSystem(GeneratorExecutionContext context, IReadOnlyList<RazorInputItem> razorFiles, IReadOnlyList<RazorInputItem> cshtmlFiles)

--- a/src/RazorSdk/SourceGenerators/RazorSourceGenerator.Helpers.cs
+++ b/src/RazorSdk/SourceGenerators/RazorSourceGenerator.Helpers.cs
@@ -88,10 +88,6 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
                 {
                     Environment.FailFast(message);
                 }
-                else
-                {
-                    Debug.Assert(condition, message);
-                }
             }
             else
             {

--- a/src/RazorSdk/SourceGenerators/RazorSourceGenerator.Helpers.cs
+++ b/src/RazorSdk/SourceGenerators/RazorSourceGenerator.Helpers.cs
@@ -75,9 +75,6 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
         [System.Diagnostics.Conditional("DEBUG")]
         private static void AssertOrFailFast(bool condition, string message)
         {
-#if NET20 || NETSTANDARD1_3
-            Debug.Assert(condition, message);
-#else
             if (!condition)
             {
                 message ??= $"{nameof(AssertOrFailFast)} failed";
@@ -100,7 +97,6 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
             {
                 Debug.Assert(false, message);
             }
-#endif
         }
     }
 }

--- a/src/RazorSdk/SourceGenerators/RazorSourceGenerator.Helpers.cs
+++ b/src/RazorSdk/SourceGenerators/RazorSourceGenerator.Helpers.cs
@@ -1,0 +1,106 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Buffers;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.Razor.Extensions;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Razor;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.NET.Sdk.Razor.SourceGenerators
+{
+    public partial class RazorSourceGenerator
+    {
+        private static SourceText GetProvideApplicationPartFactorySourceText()
+        {
+            var typeInfo = "Microsoft.AspNetCore.Mvc.ApplicationParts.ConsolidatedAssemblyApplicationPartFactory, Microsoft.AspNetCore.Mvc.Razor";
+            var assemblyInfo = $@"[assembly: global::Microsoft.AspNetCore.Mvc.ApplicationParts.ProvideApplicationPartFactoryAttribute(""{typeInfo}"")]";
+            return SourceText.From(assemblyInfo, Encoding.UTF8);
+        }
+
+        private static string GetIdentifierFromPath(string filePath)
+        {
+            var builder = new StringBuilder(filePath.Length);
+
+            for (var i = 0; i < filePath.Length; i++)
+            {
+                switch (filePath[i])
+                {
+                    case ':' or '\\' or '/':
+                    case char ch when !char.IsLetterOrDigit(ch):
+                        builder.Append('_');
+                        break;
+                    default:
+                        builder.Append(filePath[i]);
+                        break;
+                }
+            }
+
+            return builder.ToString();
+        }
+
+        private static ParallelOptions GetParallelOptions(GeneratorExecutionContext generatorExecutionContext)
+        {
+            var options = new ParallelOptions { CancellationToken = generatorExecutionContext.CancellationToken };
+            var isConcurrentBuild = generatorExecutionContext.Compilation.Options.ConcurrentBuild;
+            if (Debugger.IsAttached || !isConcurrentBuild)
+            {
+                options.MaxDegreeOfParallelism = 1;
+            }
+            return options;
+        }
+
+        private static void HandleDebugSwitch(bool waitForDebugger)
+        {
+            if (waitForDebugger)
+            {
+                while (!Debugger.IsAttached)
+                {
+                    Thread.Sleep(3000);
+                }
+            }
+        }
+
+        [System.Diagnostics.Conditional("DEBUG")]
+        private static void AssertOrFailFast(bool condition, string message)
+        {
+#if NET20 || NETSTANDARD1_3
+            Debug.Assert(condition, message);
+#else
+            if (!condition)
+            {
+                message ??= $"{nameof(AssertOrFailFast)} failed";
+                var stackTrace = new StackTrace();
+                Console.WriteLine(message);
+                Console.WriteLine(stackTrace);
+
+                // Use FailFast so that the process fails rudely and goes through 
+                // windows error reporting (on Windows at least) for further analysis.
+                if (_razorContext is not null && _razorContext.ProduceHeapDumps)
+                {
+                    Environment.FailFast(message);
+                }
+                else
+                {
+                    Debug.Assert(condition, message);
+                }
+            }
+            else
+            {
+                Debug.Assert(false, message);
+            }
+#endif
+        }
+    }
+}

--- a/src/RazorSdk/SourceGenerators/RazorSourceGenerator.SourceTexts.cs
+++ b/src/RazorSdk/SourceGenerators/RazorSourceGenerator.SourceTexts.cs
@@ -44,15 +44,7 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
                 var (hint, sourceText) = outputs[i];
                 if (sourceText != null)
                 {
-                    try
-                    {
-                        context.AddSource(hint, sourceText);
-                    }
-                    catch
-                    {
-                        // Call AssertOrFailFast so that we can get error dumps.
-                        AssertOrFailFast(true, "Unexpected error when adding sources.");
-                    }
+                    context.AddSource(hint, sourceText);
                 }
             }
 

--- a/src/RazorSdk/SourceGenerators/RazorSourceGenerator.SourceTexts.cs
+++ b/src/RazorSdk/SourceGenerators/RazorSourceGenerator.SourceTexts.cs
@@ -1,0 +1,106 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Buffers;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.Razor.Extensions;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Razor;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.NET.Sdk.Razor.SourceGenerators
+{
+    public partial class RazorSourceGenerator
+    {
+        private static readonly ConcurrentDictionary<string, (SourceText, SourceText)> _sourceTextCache = new();
+
+        private void RazorGenerateForSourceTexts(IReadOnlyList<RazorInputItem> files, GeneratorExecutionContext context, RazorProjectEngine projectEngine)
+        {
+            if (files.Count == 0)
+            {
+                return;
+            }
+
+            var arraypool = ArrayPool<(string, SourceText?)>.Shared;
+            var outputs = arraypool.Rent(files.Count);
+
+            Parallel.For(0, files.Count, GetParallelOptions(context), i =>
+            {
+                outputs[i] = ResolveGeneratedSourceTextFromFile(files[i], projectEngine, context);
+            });
+
+            for (var i = 0; i < files.Count; i++)
+            {
+                var (hint, sourceText) = outputs[i];
+                if (sourceText != null)
+                {
+                    try
+                    {
+                        context.AddSource(hint, sourceText);
+                    }
+                    catch
+                    {
+                        // Call AssertOrFailFast so that we can get error dumps.
+                        AssertOrFailFast(true, "Unexpected error when adding sources.");
+                    }
+                }
+            }
+
+            arraypool.Return(outputs);
+        }
+
+        private static (string, SourceText?) ResolveGeneratedSourceTextFromFile(RazorInputItem file, RazorProjectEngine projectEngine, GeneratorExecutionContext context)
+        {
+            var hint = GetIdentifierFromPath(file.NormalizedPath);
+
+            var entryFound = _sourceTextCache.TryGetValue(hint, out (SourceText cachedSourceText, SourceText cachedGeneratedSourceText) cachedValues);
+
+            var sourceText = file.AdditionalText.GetText();
+
+            if (sourceText is null)
+            {
+                context.ReportDiagnostic(Diagnostic.Create(RazorDiagnostics.SourceTextNotFoundDescriptor, Location.None, hint));
+                return (hint, null);
+            }
+
+            var checksum = sourceText.GetChecksum();
+            var cachedSourceText = cachedValues.cachedSourceText;
+            if (entryFound && cachedSourceText.GetChecksum().Equals(checksum))
+            {
+                return (hint, cachedValues.cachedGeneratedSourceText);
+            }
+
+            var projectItem = projectEngine.FileSystem.GetItem(file.NormalizedPath, file.FileKind);
+            var codeDocument = projectEngine.Process(projectItem);
+            var csharpDocument = codeDocument.GetCSharpDocument();
+
+            for (var j = 0; j < csharpDocument.Diagnostics.Count; j++)
+            {
+                var razorDiagnostic = csharpDocument.Diagnostics[j];
+                var csharpDiagnostic = razorDiagnostic.AsDiagnostic();
+                context.ReportDiagnostic(csharpDiagnostic);
+            }
+
+            var generatedCode = csharpDocument.GeneratedCode;
+            var generatedSourceText = SourceText.From(generatedCode, Encoding.UTF8);
+
+            if (_sourceTextCache.Count > 200)
+            {
+                _sourceTextCache.Clear();
+            }
+                    
+            _sourceTextCache[hint] = (sourceText, generatedSourceText);
+            return (hint, generatedSourceText);
+        }
+    }
+}

--- a/src/RazorSdk/SourceGenerators/RazorSourceGenerator.TagHelperDiscovery.cs
+++ b/src/RazorSdk/SourceGenerators/RazorSourceGenerator.TagHelperDiscovery.cs
@@ -1,0 +1,136 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Buffers;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.Razor.Extensions;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Razor;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.NET.Sdk.Razor.SourceGenerators
+{
+    public partial class RazorSourceGenerator
+    {
+        // Until the compiler supports granular caching for generators, we roll out our own simple caching implementation.
+        // https://github.com/dotnet/roslyn/issues/51257 track the long-term resolution for this.
+        private static readonly ConcurrentDictionary<Guid, IReadOnlyList<TagHelperDescriptor>> _tagHelperCache = new();
+        private static IReadOnlyList<TagHelperDescriptor> ResolveTagHelperDescriptors(GeneratorExecutionContext GeneratorExecutionContext, RazorSourceGenerationContext razorContext)
+        {
+            var tagHelperFeature = new StaticCompilationTagHelperFeature(GeneratorExecutionContext);
+
+            var parseOptions = (CSharpParseOptions)GeneratorExecutionContext.ParseOptions;
+            var langVersion = parseOptions.LanguageVersion;
+
+            var discoveryProjectEngine = RazorProjectEngine.Create(razorContext.Configuration, razorContext.FileSystem, b =>
+            {
+                b.Features.Add(new DefaultTypeNameFeature());
+                b.Features.Add(new ConfigureRazorCodeGenerationOptions(options =>
+                {
+                    options.SuppressPrimaryMethodBody = true;
+                    options.SuppressChecksum = true;
+                }));
+
+                b.SetRootNamespace(razorContext.RootNamespace);
+
+                var metadataReferences = new List<MetadataReference>(GeneratorExecutionContext.Compilation.References);
+                b.Features.Add(new DefaultMetadataReferenceFeature { References = metadataReferences });
+
+                b.Features.Add(tagHelperFeature);
+                b.Features.Add(new DefaultTagHelperDescriptorProvider());
+
+                CompilerFeatures.Register(b);
+                RazorExtensions.Register(b);
+
+                b.SetCSharpLanguageVersion(langVersion);
+            });
+
+            var files = razorContext.RazorFiles;
+
+            var results = ArrayPool<SyntaxTree>.Shared.Rent(files.Count);
+
+            Parallel.For(0, files.Count, GetParallelOptions(GeneratorExecutionContext), i =>
+            {
+                var file = files[i];
+                var codeGen = discoveryProjectEngine.Process(discoveryProjectEngine.FileSystem.GetItem(file.NormalizedPath, FileKinds.Component));
+                var generatedCode = codeGen.GetCSharpDocument().GeneratedCode;
+
+                results[i] = CSharpSyntaxTree.ParseText(
+                    generatedCode,
+                    options: parseOptions);
+            });
+
+            // Add declaration codegen to the compilation so we can perform discovery on it.
+            var compilationWithDeclarationCodeGen = GeneratorExecutionContext.Compilation.AddSyntaxTrees(results.Take(files.Count));
+            ArrayPool<SyntaxTree>.Shared.Return(results);
+
+            tagHelperFeature.Compilation = compilationWithDeclarationCodeGen;
+
+            tagHelperFeature.TargetAssembly = compilationWithDeclarationCodeGen.Assembly;
+            var assemblyTagHelpers = tagHelperFeature.GetDescriptors();
+
+            var refTagHelpers = GetTagHelperDescriptorsFromReferences(GeneratorExecutionContext, tagHelperFeature);
+
+            var result = new List<TagHelperDescriptor>(refTagHelpers.Count + assemblyTagHelpers.Count);
+            result.AddRange(assemblyTagHelpers);
+            result.AddRange(refTagHelpers);
+
+            return result;
+        }
+
+        private static IReadOnlyList<TagHelperDescriptor> GetTagHelperDescriptorsFromReferences(GeneratorExecutionContext context, StaticCompilationTagHelperFeature tagHelperFeature)
+        {
+            List<TagHelperDescriptor> tagHelperDescriptors = new();
+            var compilation = context.Compilation;
+
+            foreach (var reference in compilation.References)
+            {
+                if (compilation.GetAssemblyOrModuleSymbol(reference) is IAssemblySymbol assembly)
+                {
+                    var guid = reference.GetModuleVersionId(compilation);
+                    IReadOnlyList<TagHelperDescriptor> descriptors = new List<TagHelperDescriptor>();
+
+                    if (guid is Guid _guid)
+                    {
+                        if (!_tagHelperCache.TryGetValue(_guid, out descriptors))
+                        {
+                            tagHelperFeature.TargetAssembly = assembly;
+                            descriptors = tagHelperFeature.GetDescriptors();
+                            // Clear out the cache if it is growing too large. A
+                            // simple compilation can include around ~300 references
+                            // so give a little bit of buffer beyond this.
+                            if (_tagHelperCache.Count > 400)
+                            {
+                                _tagHelperCache.Clear();
+                            }
+                            _tagHelperCache[_guid] = descriptors;
+                        }
+                    }
+                    else
+                    {
+                        tagHelperFeature.TargetAssembly = assembly;
+                        descriptors = tagHelperFeature.GetDescriptors();
+                        context.ReportDiagnostic(Diagnostic.Create(
+                            RazorDiagnostics.ReComputingTagHelpersDescriptor,
+                            Location.None,
+                            reference.Display));
+                    }
+
+                    tagHelperDescriptors.AddRange(descriptors);
+                }
+            }
+
+            return tagHelperDescriptors;
+        }
+    }
+}

--- a/src/RazorSdk/SourceGenerators/RazorSourceGenerator.cs
+++ b/src/RazorSdk/SourceGenerators/RazorSourceGenerator.cs
@@ -23,12 +23,7 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
     [Generator]
     public partial class RazorSourceGenerator : ISourceGenerator
     {
-        // Until the compiler supports granular caching for generators, we roll out our own simple caching implementation.
-        // https://github.com/dotnet/roslyn/issues/51257 track the long-term resolution for this.
-        private static readonly ConcurrentDictionary<Guid, IReadOnlyList<TagHelperDescriptor>> _tagHelperCache = new();
-
-        private static readonly ConcurrentDictionary<string, (SourceText, SourceText)> _sourceTextCache = new();
-
+        private static RazorSourceGenerationContext? _razorContext { get; set; }
         private static readonly SourceText ProvideApplicationPartFactoryAttributeSourceText = GetProvideApplicationPartFactorySourceText();
 
         public void Initialize(GeneratorInitializationContext context)
@@ -37,35 +32,37 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
 
         public void Execute(GeneratorExecutionContext context)
         {
-            var razorContext = new RazorSourceGenerationContext(context);
-            if (razorContext is null)
+            var _razorContext = new RazorSourceGenerationContext(context);
+            if (_razorContext is null)
             {
                 context.ReportDiagnostic(Diagnostic.Create(RazorDiagnostics.InvalidRazorContextComputedDescriptor, Location.None));
                 return;
             }
 
-            if (razorContext.RazorFiles.Count == 0 && razorContext.CshtmlFiles.Count == 0)
+            if (_razorContext.RazorFiles.Count == 0 && _razorContext.CshtmlFiles.Count == 0)
             {
                 return;
             }
 
-            if (razorContext.SuppressRazorSourceGenerator)
+            if (_razorContext.SuppressRazorSourceGenerator)
             {
                 return;
             }
 
-            HandleDebugSwitch(razorContext.WaitForDebugger);
+            HandleDebugSwitch(_razorContext.WaitForDebugger);
 
-            var tagHelpers = ResolveTagHelperDescriptors(context, razorContext);
+            var tagHelpers = ResolveTagHelperDescriptors(context, _razorContext);
 
-            var projectEngine = RazorProjectEngine.Create(razorContext.Configuration, razorContext.FileSystem, b =>
+            AssertOrFailFast(tagHelpers.Count == 0, "No tag helpers resolved.");
+
+            var projectEngine = RazorProjectEngine.Create(_razorContext.Configuration, _razorContext.FileSystem, b =>
             {
                 b.Features.Add(new DefaultTypeNameFeature());
-                b.SetRootNamespace(razorContext.RootNamespace);
+                b.SetRootNamespace(_razorContext.RootNamespace);
 
                 b.Features.Add(new ConfigureRazorCodeGenerationOptions(options =>
                 {
-                    options.SuppressMetadataSourceChecksumAttributes = !razorContext.GenerateMetadataSourceChecksumAttributes;
+                    options.SuppressMetadataSourceChecksumAttributes = !_razorContext.GenerateMetadataSourceChecksumAttributes;
                 }));
 
                 b.Features.Add(new StaticTagHelperFeature { TagHelpers = tagHelpers, });
@@ -77,242 +74,13 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
                 b.SetCSharpLanguageVersion(((CSharpParseOptions)context.ParseOptions).LanguageVersion);
             });
 
-            if (razorContext.CshtmlFiles.Count != 0)
+            if (_razorContext.CshtmlFiles.Count != 0)
             {
                 context.AddSource($"{context.Compilation.AssemblyName}.UnifiedAssembly.Info.g.cs", ProvideApplicationPartFactoryAttributeSourceText);
             }
 
-            RazorGenerateForSourceTexts(razorContext.CshtmlFiles, context, projectEngine);
-            RazorGenerateForSourceTexts(razorContext.RazorFiles, context, projectEngine);
-        }
-
-        private void RazorGenerateForSourceTexts(IReadOnlyList<RazorInputItem> files, GeneratorExecutionContext context, RazorProjectEngine projectEngine)
-        {
-            if (files.Count == 0)
-            {
-                return;
-            }
-
-            var arraypool = ArrayPool<(string, SourceText?)>.Shared;
-            var outputs = arraypool.Rent(files.Count);
-
-            Parallel.For(0, files.Count, GetParallelOptions(context), i =>
-            {
-                outputs[i] = ResolveGeneratedSourceTextFromFile(files[i], projectEngine, context);
-            });
-
-            for (var i = 0; i < files.Count; i++)
-            {
-                var (hint, sourceText) = outputs[i];
-                if (sourceText != null)
-                {
-                    context.AddSource(hint, sourceText);
-                }
-            }
-
-            arraypool.Return(outputs);
-        }
-
-        private static (string, SourceText?) ResolveGeneratedSourceTextFromFile(RazorInputItem file, RazorProjectEngine projectEngine, GeneratorExecutionContext context)
-        {
-            var hint = GetIdentifierFromPath(file.NormalizedPath);
-
-            var entryFound = _sourceTextCache.TryGetValue(hint, out (SourceText cachedSourceText, SourceText cachedGeneratedSourceText) cachedValues);
-
-            var sourceText = file.AdditionalText.GetText();
-
-            if (sourceText is null)
-            {
-                context.ReportDiagnostic(Diagnostic.Create(RazorDiagnostics.SourceTextNotFoundDescriptor, Location.None, hint));
-                return (hint, null);
-            }
-
-            var checksum = sourceText.GetChecksum();
-            var cachedSourceText = cachedValues.cachedSourceText;
-            if (entryFound && cachedSourceText.GetChecksum().Equals(checksum))
-            {
-                return (hint, cachedValues.cachedGeneratedSourceText);
-            }
-
-            var projectItem = projectEngine.FileSystem.GetItem(file.NormalizedPath, file.FileKind);
-            var codeDocument = projectEngine.Process(projectItem);
-            var csharpDocument = codeDocument.GetCSharpDocument();
-
-            for (var j = 0; j < csharpDocument.Diagnostics.Count; j++)
-            {
-                var razorDiagnostic = csharpDocument.Diagnostics[j];
-                var csharpDiagnostic = razorDiagnostic.AsDiagnostic();
-                context.ReportDiagnostic(csharpDiagnostic);
-            }
-
-            var generatedCode = csharpDocument.GeneratedCode;
-            var generatedSourceText = SourceText.From(generatedCode, Encoding.UTF8);
-
-            if (_sourceTextCache.Count > 200)
-            {
-                _sourceTextCache.Clear();
-            }
-                    
-            _sourceTextCache[hint] = (sourceText, generatedSourceText);
-            return (hint, generatedSourceText);
-        }
-
-        private static IReadOnlyList<TagHelperDescriptor> ResolveTagHelperDescriptors(GeneratorExecutionContext GeneratorExecutionContext, RazorSourceGenerationContext razorContext)
-        {
-            var tagHelperFeature = new StaticCompilationTagHelperFeature(GeneratorExecutionContext);
-
-            var parseOptions = (CSharpParseOptions)GeneratorExecutionContext.ParseOptions;
-            var langVersion = parseOptions.LanguageVersion;
-
-            var discoveryProjectEngine = RazorProjectEngine.Create(razorContext.Configuration, razorContext.FileSystem, b =>
-            {
-                b.Features.Add(new DefaultTypeNameFeature());
-                b.Features.Add(new ConfigureRazorCodeGenerationOptions(options =>
-                {
-                    options.SuppressPrimaryMethodBody = true;
-                    options.SuppressChecksum = true;
-                }));
-
-                b.SetRootNamespace(razorContext.RootNamespace);
-
-                var metadataReferences = new List<MetadataReference>(GeneratorExecutionContext.Compilation.References);
-                b.Features.Add(new DefaultMetadataReferenceFeature { References = metadataReferences });
-
-                b.Features.Add(tagHelperFeature);
-                b.Features.Add(new DefaultTagHelperDescriptorProvider());
-
-                CompilerFeatures.Register(b);
-                RazorExtensions.Register(b);
-
-                b.SetCSharpLanguageVersion(langVersion);
-            });
-
-            var files = razorContext.RazorFiles;
-
-            var results = ArrayPool<SyntaxTree>.Shared.Rent(files.Count);
-
-            Parallel.For(0, files.Count, GetParallelOptions(GeneratorExecutionContext), i =>
-            {
-                var file = files[i];
-                var codeGen = discoveryProjectEngine.Process(discoveryProjectEngine.FileSystem.GetItem(file.NormalizedPath, FileKinds.Component));
-                var generatedCode = codeGen.GetCSharpDocument().GeneratedCode;
-
-                results[i] = CSharpSyntaxTree.ParseText(
-                    generatedCode,
-                    options: parseOptions);
-            });
-
-            // Add declaration codegen to the compilation so we can perform discovery on it.
-            var compilationWithDeclarationCodeGen = GeneratorExecutionContext.Compilation.AddSyntaxTrees(results.Take(files.Count));
-            ArrayPool<SyntaxTree>.Shared.Return(results);
-
-            tagHelperFeature.Compilation = compilationWithDeclarationCodeGen;
-
-            tagHelperFeature.TargetAssembly = compilationWithDeclarationCodeGen.Assembly;
-            var assemblyTagHelpers = tagHelperFeature.GetDescriptors();
-
-            var refTagHelpers = GetTagHelperDescriptorsFromReferences(GeneratorExecutionContext, tagHelperFeature);
-
-            var result = new List<TagHelperDescriptor>(refTagHelpers.Count + assemblyTagHelpers.Count);
-            result.AddRange(assemblyTagHelpers);
-            result.AddRange(refTagHelpers);
-
-            return result;
-        }
-
-        private static IReadOnlyList<TagHelperDescriptor> GetTagHelperDescriptorsFromReferences(GeneratorExecutionContext context, StaticCompilationTagHelperFeature tagHelperFeature)
-        {
-            List<TagHelperDescriptor> tagHelperDescriptors = new();
-            var compilation = context.Compilation;
-
-            foreach (var reference in compilation.References)
-            {
-                if (compilation.GetAssemblyOrModuleSymbol(reference) is IAssemblySymbol assembly)
-                {
-                    var guid = reference.GetModuleVersionId(compilation);
-                    IReadOnlyList<TagHelperDescriptor> descriptors = new List<TagHelperDescriptor>();
-
-                    if (guid is Guid _guid)
-                    {
-                        if (!_tagHelperCache.TryGetValue(_guid, out descriptors))
-                        {
-                            tagHelperFeature.TargetAssembly = assembly;
-                            descriptors = tagHelperFeature.GetDescriptors();
-                            // Clear out the cache if it is growing too large. A
-                            // simple compilation can include around ~300 references
-                            // so give a little bit of buffer beyond this.
-                            if (_tagHelperCache.Count > 400)
-                            {
-                                _tagHelperCache.Clear();
-                            }
-                            _tagHelperCache[_guid] = descriptors;
-                        }
-                    }
-                    else
-                    {
-                        tagHelperFeature.TargetAssembly = assembly;
-                        descriptors = tagHelperFeature.GetDescriptors();
-                        context.ReportDiagnostic(Diagnostic.Create(
-                            RazorDiagnostics.ReComputingTagHelpersDescriptor,
-                            Location.None,
-                            reference.Display));
-                    }
-
-                    tagHelperDescriptors.AddRange(descriptors);
-                }
-            }
-
-            return tagHelperDescriptors;
-        }
-
-        private static SourceText GetProvideApplicationPartFactorySourceText()
-        {
-            var typeInfo = "Microsoft.AspNetCore.Mvc.ApplicationParts.ConsolidatedAssemblyApplicationPartFactory, Microsoft.AspNetCore.Mvc.Razor";
-            var assemblyInfo = $@"[assembly: global::Microsoft.AspNetCore.Mvc.ApplicationParts.ProvideApplicationPartFactoryAttribute(""{typeInfo}"")]";
-            return SourceText.From(assemblyInfo, Encoding.UTF8);
-        }
-
-        private static string GetIdentifierFromPath(string filePath)
-        {
-            var builder = new StringBuilder(filePath.Length);
-
-            for (var i = 0; i < filePath.Length; i++)
-            {
-                switch (filePath[i])
-                {
-                    case ':' or '\\' or '/':
-                    case char ch when !char.IsLetterOrDigit(ch):
-                        builder.Append('_');
-                        break;
-                    default:
-                        builder.Append(filePath[i]);
-                        break;
-                }
-            }
-
-            return builder.ToString();
-        }
-
-        private static ParallelOptions GetParallelOptions(GeneratorExecutionContext generatorExecutionContext)
-        {
-            var options = new ParallelOptions { CancellationToken = generatorExecutionContext.CancellationToken };
-            var isConcurrentBuild = generatorExecutionContext.Compilation.Options.ConcurrentBuild;
-            if (Debugger.IsAttached || !isConcurrentBuild)
-            {
-                options.MaxDegreeOfParallelism = 1;
-            }
-            return options;
-        }
-
-        private static void HandleDebugSwitch(bool waitForDebugger)
-        {
-            if (waitForDebugger)
-            {
-                while (!Debugger.IsAttached)
-                {
-                    Thread.Sleep(3000);
-                }
-            }
+            RazorGenerateForSourceTexts(_razorContext.CshtmlFiles, context, projectEngine);
+            RazorGenerateForSourceTexts(_razorContext.RazorFiles, context, projectEngine);
         }
     }
 }

--- a/src/RazorSdk/Targets/Microsoft.NET.Sdk.Razor.SourceGenerators.targets
+++ b/src/RazorSdk/Targets/Microsoft.NET.Sdk.Razor.SourceGenerators.targets
@@ -66,7 +66,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       <CompilerVisibleProperty Include="GenerateRazorMetadataSourceChecksumAttributes" />
       <CompilerVisibleProperty Include="MSBuildProjectDirectory" />
       <CompilerVisibleProperty Include="_RazorSourceGeneratorDebug" />
-      <CompilerVisibleProperty Include="_RazorSourceGeneratorLog" />
+      <CompilerVisibleProperty Include="_RazorSourceGeneratorHeapDumps" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/RazorSdk/Targets/Sdk.Razor.CurrentVersion.targets
+++ b/src/RazorSdk/Targets/Sdk.Razor.CurrentVersion.targets
@@ -49,7 +49,7 @@ Copyright (c) .NET Foundation. All rights reserved.
         <_TargetingNETCoreApp30OrLater>true</_TargetingNETCoreApp30OrLater>
         <_TargetingNET50OrLater>true</_TargetingNET50OrLater>
         <_TargetingNET60OrLater>true</_TargetingNET60OrLater>
-        <_UseRazorSourceGenerator>true</_UseRazorSourceGenerator>
+        <_UseRazorSourceGenerator Condition="'$(_UseRazorSourceGenerator)' == '' ">true</_UseRazorSourceGenerator>
         <RazorLangVersion Condition="'$(RazorLangVersion)' == '' ">5.0</RazorLangVersion>
       </PropertyGroup>
     </When>


### PR DESCRIPTION
Resolves https://github.com/dotnet/aspnetcore/issues/32255

* Create separate partial classes for different parts of the RSG
* Allow the `_UseRazorSourceGenerator` property to be override by consumer for .NET 6 apps
* Add support for `_RazorSourceGeneratorHeapDumps` and generate heap dumps from certain scenarios