### PR TITLE
Reuse binaries from compiler directory to reduce SDK size

### DIFF
--- a/src/BuiltInTools/dotnet-watch/Program.cs
+++ b/src/BuiltInTools/dotnet-watch/Program.cs
@@ -79,7 +79,7 @@ Examples:
             _reporter = CreateReporter(verbose: true, quiet: false, console: _console);
 
             // Register listeners that load Roslyn-related assemblies from the `Rosyln/bincore` directory.
-            RegisterAssemblyResolutionEvents();
+            RegisterAssemblyResolutionEvents(sdkRootDirectory);
         }
 
         public static async Task<int> Main(string[] args)
@@ -383,16 +383,15 @@ Examples:
             _cts.Dispose();
         }
 
-        private static void RegisterAssemblyResolutionEvents()
+        private static void RegisterAssemblyResolutionEvents(string sdkRootDirectory)
         {
-            var roslynPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "..", "..", "..", "..", "..", "..", "Roslyn", "bincore");
+            var roslynPath = Path.Combine(sdkRootDirectory, "Roslyn", "bincore");
 
             AssemblyLoadContext.Default.Resolving += (context, assembly) =>
             {
-                var assemblyFilename = $"{assembly.Name}.dll";
-                if (assemblyFilename == "Microsoft.CodeAnalysis.CSharp.dll" || assemblyFilename == "Microsoft.CodeAnalysis.dll")
+                if (assembly.Name is "Microsoft.CodeAnalysis" or "Microsoft.CodeAnalysis.CSharp")
                 {
-                    return context.LoadFromAssemblyPath(Path.Combine(roslynPath, assemblyFilename));
+                    return context.LoadFromAssemblyPath(Path.Combine(roslynPath, assembly.Name + ".dll"));
                 }
                 return null;
             };

--- a/src/Layout/redist/targets/GenerateLayout.targets
+++ b/src/Layout/redist/targets/GenerateLayout.targets
@@ -253,6 +253,11 @@
   <Target Name="MoveRazorSdkTools" AfterTargets="PublishRazorSdkTools">
     <ItemGroup>
       <_RazorToolOutput Include="$(ArtifactsBinDir)Microsoft.NET.Sdk.Razor.Tool\$(Configuration)\$(SdkTargetFramework)\publish\*.*" />
+      <!-- To reduce the size of the SDK, we use the compiler dependencies that are located in the `Rosyln/bincore` location
+      instead of shipping our own copies in the Razor compiler. These assemblies will be resolved by path in the
+      rzc executable. -->
+      <_RazorToolOutput Remove="$(ArtifactsBinDir)Microsoft.NET.Sdk.Razor.Tool\$(Configuration)\$(SdkTargetFramework)\publish\Microsoft.CodeAnalysis.dll" />
+      <_RazorToolOutput Remove="$(ArtifactsBinDir)Microsoft.NET.Sdk.Razor.Tool\$(Configuration)\$(SdkTargetFramework)\publish\Microsoft.CodeAnalysis.CSharp.dll" />
       <_RazorSourceGeneratorsOutput Include="$(ArtifactsBinDir)Microsoft.NET.Sdk.Razor.SourceGenerators\$(Configuration)\netstandard2.0\publish\Microsoft.AspNetCore.Mvc.Razor.Extensions.dll" />
       <_RazorSourceGeneratorsOutput Include="$(ArtifactsBinDir)Microsoft.NET.Sdk.Razor.SourceGenerators\$(Configuration)\netstandard2.0\publish\Microsoft.AspNetCore.Razor.Language.dll" />
       <_RazorSourceGeneratorsOutput Include="$(ArtifactsBinDir)Microsoft.NET.Sdk.Razor.SourceGenerators\$(Configuration)\netstandard2.0\publish\Microsoft.CodeAnalysis.Razor.dll" />

--- a/src/Layout/redist/targets/OverlaySdkOnLKG.targets
+++ b/src/Layout/redist/targets/OverlaySdkOnLKG.targets
@@ -44,6 +44,11 @@
      <!-- Copy dotnet-watch files -->
     <ItemGroup>
       <DotNetWatchOverlay Include="$(ArtifactsDir)bin\dotnet-watch\$(Configuration)\$(SdkTargetFramework)\**" />
+      <!-- To reduce the size of the SDK, we use the compiler dependencies that are located in the `Rosyln/bincore` location
+      instead of shipping our own copies in the dotnet-watch tool. These assemblies will be resolved by path in the
+      dotnet-watch executable. -->
+      <DotNetWatchOverlay Remove="$(ArtifactsDir)bin\dotnet-watch\$(Configuration)\$(SdkTargetFramework)\Microsoft.CodeAnalysis.CSharp.dll" />
+      <DotNetWatchOverlay Remove="$(ArtifactsDir)bin\dotnet-watch\$(Configuration)\$(SdkTargetFramework)\Microsoft.CodeAnalysis.dll" />
       <DotNetWatchOverlay Include="$(ArtifactsDir)bin\Microsoft.AspNetCore.Watch.BrowserRefresh\$(Configuration)\netcoreapp3.1\*.dll" TargetDir="middleware" />
       <DotNetWatchOverlay Include="$(ArtifactsDir)bin\Microsoft.Extensions.DotNetDeltaApplier\$(Configuration)\net6.0\*.dll" TargetDir="hotreload" />
       <DotNetWatchOverlay Include="$(ArtifactsDir)bin\DotNetWatchTasks\$(Configuration)\netstandard2.0\DotNetWatchTasks.dll" />

--- a/src/RazorSdk/Tool/Program.cs
+++ b/src/RazorSdk/Tool/Program.cs
@@ -63,14 +63,13 @@ namespace Microsoft.NET.Sdk.Razor.Tool
 
         private static void RegisterAssemblyResolutionEvents()
         {
-            var roslynPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "..", "..", "..", "Roslyn", "bincore");
+            var roslynPath = Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "Roslyn", "bincore");
 
             AssemblyLoadContext.Default.Resolving += (context, assembly) =>
             {
-                var assemblyFilename = $"{assembly.Name}.dll";
-                if (assemblyFilename == "Microsoft.CodeAnalysis.CSharp.dll" || assemblyFilename == "Microsoft.CodeAnalysis.dll")
+                if (assembly.Name is "Microsoft.CodeAnalysis" or "Microsoft.CodeAnalysis.CSharp")
                 {
-                    return context.LoadFromAssemblyPath(Path.Combine(roslynPath, assemblyFilename));
+                    return context.LoadFromAssemblyPath(Path.Combine(roslynPath, assembly.Name + ".dll"));
                 }
                 return null;
             };

--- a/src/RazorSdk/Tool/Program.cs
+++ b/src/RazorSdk/Tool/Program.cs
@@ -11,7 +11,7 @@ namespace Microsoft.NET.Sdk.Razor.Tool
 {
     internal static class Program
     {
-        static Program()
+        public static int Main(string[] args)
         {
             // To minimize the size of the SDK, we resolve all Rosyln-related assemblies
             // from the `Roslyn/bincore` location in the SDK. The `RegisterAssemblyResolutionEvents`
@@ -20,8 +20,10 @@ namespace Microsoft.NET.Sdk.Razor.Tool
             // invoked, so we register the event listener here to ensure they are registered before
             // we `Main` is invoked.
             RegisterAssemblyResolutionEvents();
+            return RunApplication(args);
         }
-        public static int Main(string[] args)
+
+        private static int RunApplication(string[] args)
         {
             DebugMode.HandleDebugSwitch(ref args);
 


### PR DESCRIPTION
Part of https://github.com/dotnet/aspnetcore/issues/31212.

Size of `~/github.com/dotnet/sdk/artifacts/bin/redist/Debug/dotnet/sdk/6.0.100-dev ` on this branch: 176MB
Size of `~/github.com/dotnet/sdk/artifacts/bin/redist/Debug/dotnet/sdk/6.0.100-dev ` on this main: 184MB