### PR TITLE
Refactor how composite image creation works

### DIFF
--- a/src/Tasks/Common/MetadataKeys.cs
+++ b/src/Tasks/Common/MetadataKeys.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 namespace Microsoft.NET.Build.Tasks
 {
@@ -25,7 +25,7 @@ namespace Microsoft.NET.Build.Tasks
         public const string TargetFramework = "TargetFramework";
         public const string FrameworkName = "FrameworkName";
         public const string FrameworkVersion = "FrameworkVersion";
-        public const string IsTrimmable = "IsTrimmable"; 
+        public const string IsTrimmable = "IsTrimmable";
         public const string RuntimeFrameworkName = "RuntimeFrameworkName";
         public const string RuntimePackRuntimeIdentifiers = "RuntimePackRuntimeIdentifiers";
 
@@ -123,5 +123,6 @@ namespace Microsoft.NET.Build.Tasks
         public const string OutputPDBImage = "OutputPDBImage";
         public const string EmitSymbols = "EmitSymbols";
         public const string IsVersion5 = "IsVersion5";
+        public const string CreateCompositeImage = "CreateCompositeImage";
     }
 }

--- a/src/Tasks/Common/MetadataKeys.cs
+++ b/src/Tasks/Common/MetadataKeys.cs
@@ -1,5 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.NET.Build.Tasks
 {

--- a/src/Tasks/Microsoft.NET.Build.Tasks/PrepareForReadyToRunCompilation.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/PrepareForReadyToRunCompilation.cs
@@ -1,5 +1,5 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Tasks/Microsoft.NET.Build.Tasks/PrepareForReadyToRunCompilation.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/PrepareForReadyToRunCompilation.cs
@@ -1,5 +1,5 @@
-// Copyright (c) .NET Foundation and contributors. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;
@@ -30,6 +30,8 @@ namespace Microsoft.NET.Build.Tasks
         [Required]
         public bool IncludeSymbolsInSingleFile { get; set; }
 
+        public string[] PublishReadyToRunCompositeExclusions { get; set; }
+
         public ITaskItem CrossgenTool { get; set; }
         public ITaskItem Crossgen2Tool { get; set; }
 
@@ -48,12 +50,20 @@ namespace Microsoft.NET.Build.Tasks
         [Output]
         public ITaskItem[] ReadyToRunAssembliesToReference => _r2rReferences.ToArray();
 
+        [Output]
+        public ITaskItem[] ReadyToRunCompositeBuildReferences => _r2rCompositeReferences.ToArray();
+
+        [Output]
+        public ITaskItem[] ReadyToRunCompositeBuildInput => _r2rCompositeInput.ToArray();
+
         private bool _crossgen2IsVersion5;
 
         private List<ITaskItem> _compileList = new List<ITaskItem>();
         private List<ITaskItem> _symbolsCompileList = new List<ITaskItem>();
         private List<ITaskItem> _r2rFiles = new List<ITaskItem>();
         private List<ITaskItem> _r2rReferences = new List<ITaskItem>();
+        private List<ITaskItem> _r2rCompositeReferences = new List<ITaskItem>();
+        private List<ITaskItem> _r2rCompositeInput = new List<ITaskItem>();
 
         protected override void ExecuteCore()
         {
@@ -76,7 +86,7 @@ namespace Microsoft.NET.Build.Tasks
                 !string.IsNullOrEmpty(diaSymReaderPath) && File.Exists(diaSymReaderPath);
 
             // Process input lists of files
-            ProcessInputFileList(Assemblies, _compileList, _symbolsCompileList, _r2rFiles, _r2rReferences, hasValidDiaSymReaderLib);
+            ProcessInputFileList(Assemblies, _compileList, _symbolsCompileList, _r2rFiles, _r2rReferences, _r2rCompositeReferences, _r2rCompositeInput, hasValidDiaSymReaderLib);
         }
 
         private void ProcessInputFileList(
@@ -85,6 +95,8 @@ namespace Microsoft.NET.Build.Tasks
             List<ITaskItem> symbolsCompilationList,
             List<ITaskItem> r2rFilesPublishList,
             List<ITaskItem> r2rReferenceList,
+            List<ITaskItem> r2rCompositeReferenceList,
+            List<ITaskItem> r2rCompositeInputList,
             bool hasValidDiaSymReaderLib)
         {
             if (inputFiles == null)
@@ -92,21 +104,25 @@ namespace Microsoft.NET.Build.Tasks
                 return;
             }
 
-            // TODO: ExcludeList for composite mode
             var exclusionSet = ExcludeList == null || Crossgen2Composite ? null : new HashSet<string>(ExcludeList, StringComparer.OrdinalIgnoreCase);
+            var compositeExclusionSet = PublishReadyToRunCompositeExclusions == null || !Crossgen2Composite ? null : new HashSet<string>(PublishReadyToRunCompositeExclusions, StringComparer.OrdinalIgnoreCase);
 
             foreach (var file in inputFiles)
             {
-                var eligibility = GetInputFileEligibility(file, exclusionSet);
+                var eligibility = GetInputFileEligibility(file, Crossgen2Composite, exclusionSet, compositeExclusionSet);
 
-                if (eligibility == Eligibility.None)
+                if (eligibility.NoEligibility)
                 {
                     continue;
                 }
 
-                r2rReferenceList.Add(file);
+                if (eligibility.IsReference)
+                    r2rReferenceList.Add(file);
 
-                if (!Crossgen2Composite && (eligibility == Eligibility.ReferenceOnly))
+                if (eligibility.IsReference && !eligibility.ReferenceHiddenFromCompositeBuild && !eligibility.Compile)
+                    r2rCompositeReferenceList.Add(file);
+
+                if (!eligibility.Compile)
                 {
                     continue;
                 }
@@ -141,7 +157,7 @@ namespace Microsoft.NET.Build.Tasks
                     }
                 }
 
-                if (!Crossgen2Composite)
+                if (eligibility.CompileSeparately)
                 {
                     // This TaskItem is the IL->R2R entry, for an input assembly that needs to be compiled into a R2R image. This will be used as
                     // an input to the ReadyToRunCompiler task
@@ -150,64 +166,14 @@ namespace Microsoft.NET.Build.Tasks
                     if (outputPDBImage != null && ReadyToRunUseCrossgen2 && !_crossgen2IsVersion5)
                     {
                         r2rCompilationEntry.SetMetadata(MetadataKeys.EmitSymbols, "true");
-                        r2rCompilationEntry.SetMetadata(MetadataKeys.OutputPDBImage, Path.GetDirectoryName(outputPDBImage));
+                        r2rCompilationEntry.SetMetadata(MetadataKeys.OutputPDBImage, outputPDBImage);
                     }
                     r2rCompilationEntry.RemoveMetadata(MetadataKeys.OriginalItemSpec);
                     imageCompilationList.Add(r2rCompilationEntry);
                 }
-                else if (file.ItemSpec == MainAssembly.ItemSpec)
+                else if (eligibility.CompileIntoCompositeImage)
                 {
-                    // Create a TaskItem for <MainAssembly>.r2r.dll
-                    var compositeR2RImageRelativePath = file.GetMetadata(MetadataKeys.RelativePath);
-                    compositeR2RImageRelativePath = Path.ChangeExtension(compositeR2RImageRelativePath, "r2r" + Path.GetExtension(compositeR2RImageRelativePath));
-                    var compositeR2RImage = Path.Combine(OutputPath, compositeR2RImageRelativePath);
-
-                    TaskItem r2rCompilationEntry = new TaskItem(file);
-                    r2rCompilationEntry.SetMetadata(MetadataKeys.OutputR2RImage, compositeR2RImage);
-                    r2rCompilationEntry.RemoveMetadata(MetadataKeys.OriginalItemSpec);
-
-                    if (EmitSymbols)
-                    {
-                        string compositePDBImage = null;
-                        string compositePDBRelativePath = null;
-                        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && hasValidDiaSymReaderLib)
-                        {
-                            compositePDBImage = Path.ChangeExtension(compositeR2RImage, ".ni.pdb");
-                            compositePDBRelativePath = Path.ChangeExtension(compositeR2RImageRelativePath, ".ni.pdb");
-                        }
-                        else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-                        {
-                            compositePDBImage = Path.ChangeExtension(compositeR2RImage, ".ni.{composite}.map");
-                            compositePDBRelativePath = Path.ChangeExtension(compositeR2RImageRelativePath, ".ni.{composite}.map");
-                        }
-    
-                        if (compositePDBImage != null && ReadyToRunUseCrossgen2 && !_crossgen2IsVersion5)
-                        {
-                            r2rCompilationEntry.SetMetadata(MetadataKeys.EmitSymbols, "true");
-                            r2rCompilationEntry.SetMetadata(MetadataKeys.OutputPDBImage, Path.GetDirectoryName(compositePDBImage));
-    
-                            // Publish composite PDB file
-                            TaskItem r2rSymbolsFileToPublish = new TaskItem(file);
-                            r2rSymbolsFileToPublish.ItemSpec = compositePDBImage;
-                            r2rSymbolsFileToPublish.SetMetadata(MetadataKeys.RelativePath, compositePDBRelativePath);
-                            r2rSymbolsFileToPublish.RemoveMetadata(MetadataKeys.OriginalItemSpec);
-                            if (!IncludeSymbolsInSingleFile)
-                            {
-                                r2rSymbolsFileToPublish.SetMetadata(MetadataKeys.ExcludeFromSingleFile, "true");
-                            }
-        
-                            r2rFilesPublishList.Add(r2rSymbolsFileToPublish);
-                        }
-                    }
-
-                    imageCompilationList.Add(r2rCompilationEntry);
-
-                    // Publish it
-                    TaskItem compositeR2RFileToPublish = new TaskItem(file);
-                    compositeR2RFileToPublish.ItemSpec = compositeR2RImage;
-                    compositeR2RFileToPublish.RemoveMetadata(MetadataKeys.OriginalItemSpec);
-                    compositeR2RFileToPublish.SetMetadata(MetadataKeys.RelativePath, compositeR2RImageRelativePath);
-                    r2rFilesPublishList.Add(compositeR2RFileToPublish);
+                    r2rCompositeInputList.Add(file);
                 }
 
                 // This TaskItem corresponds to the output R2R image. It is equivalent to the input TaskItem, only the ItemSpec for it points to the new path
@@ -221,7 +187,7 @@ namespace Microsoft.NET.Build.Tasks
                 // unless an explicit PublishReadyToRunEmitSymbols flag is enabled by the app developer. There is also another way to profile that the runtime supports, which does
                 // not rely on the native PDBs/Map files, so creating them is really an opt-in option, typically used by advanced users.
                 // For debugging, only the IL PDBs are required.
-                if (!Crossgen2Composite && outputPDBImage != null)
+                if (eligibility.CompileSeparately && outputPDBImage != null)
                 {
                     if (!ReadyToRunUseCrossgen2 || _crossgen2IsVersion5)
                     {
@@ -248,16 +214,131 @@ namespace Microsoft.NET.Build.Tasks
                     r2rFilesPublishList.Add(r2rSymbolsFileToPublish);
                 }
             }
+
+            if (Crossgen2Composite)
+            {
+                MainAssembly.SetMetadata(MetadataKeys.RelativePath, Path.GetFileName(MainAssembly.ItemSpec));
+
+                var compositeR2RImageRelativePath = MainAssembly.GetMetadata(MetadataKeys.RelativePath);
+                compositeR2RImageRelativePath = Path.ChangeExtension(compositeR2RImageRelativePath, "r2r" + Path.GetExtension(compositeR2RImageRelativePath));
+                var compositeR2RImage = Path.Combine(OutputPath, compositeR2RImageRelativePath);
+
+                TaskItem r2rCompilationEntry = new TaskItem(MainAssembly);
+                r2rCompilationEntry.ItemSpec = r2rCompositeInputList[0].ItemSpec;
+                r2rCompilationEntry.SetMetadata(MetadataKeys.OutputR2RImage, compositeR2RImage);
+                r2rCompilationEntry.SetMetadata(MetadataKeys.CreateCompositeImage, "true");
+                r2rCompilationEntry.RemoveMetadata(MetadataKeys.OriginalItemSpec);
+
+                if (EmitSymbols)
+                {
+                    string compositePDBImage = null;
+                    string compositePDBRelativePath = null;
+                    if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && hasValidDiaSymReaderLib)
+                    {
+                        compositePDBImage = Path.ChangeExtension(compositeR2RImage, ".ni.pdb");
+                        compositePDBRelativePath = Path.ChangeExtension(compositeR2RImageRelativePath, ".ni.pdb");
+                    }
+                    else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                    {
+                        compositePDBImage = Path.ChangeExtension(compositeR2RImage, ".ni.{composite}.map");
+                        compositePDBRelativePath = Path.ChangeExtension(compositeR2RImageRelativePath, ".ni.{composite}.map");
+                    }
+
+                    if (compositePDBImage != null && ReadyToRunUseCrossgen2 && !_crossgen2IsVersion5)
+                    {
+                        r2rCompilationEntry.SetMetadata(MetadataKeys.EmitSymbols, "true");
+                        r2rCompilationEntry.SetMetadata(MetadataKeys.OutputPDBImage, compositePDBImage);
+
+                        // Publish composite PDB file
+                        TaskItem r2rSymbolsFileToPublish = new TaskItem(MainAssembly);
+                        r2rSymbolsFileToPublish.ItemSpec = compositePDBImage;
+                        r2rSymbolsFileToPublish.SetMetadata(MetadataKeys.RelativePath, compositePDBRelativePath);
+                        r2rSymbolsFileToPublish.RemoveMetadata(MetadataKeys.OriginalItemSpec);
+                        if (!IncludeSymbolsInSingleFile)
+                        {
+                            r2rSymbolsFileToPublish.SetMetadata(MetadataKeys.ExcludeFromSingleFile, "true");
+                        }
+
+                        r2rFilesPublishList.Add(r2rSymbolsFileToPublish);
+                    }
+                }
+
+                imageCompilationList.Add(r2rCompilationEntry);
+
+                // Publish it
+                TaskItem compositeR2RFileToPublish = new TaskItem(MainAssembly);
+                compositeR2RFileToPublish.ItemSpec = compositeR2RImage;
+                compositeR2RFileToPublish.RemoveMetadata(MetadataKeys.OriginalItemSpec);
+                compositeR2RFileToPublish.SetMetadata(MetadataKeys.RelativePath, compositeR2RImageRelativePath);
+                r2rFilesPublishList.Add(compositeR2RFileToPublish);
+            }
         }
 
-        private enum Eligibility
+        private struct Eligibility
         {
-            None,
-            ReferenceOnly,
-            CompileAndReference
+            [Flags]
+            private enum EligibilityEnum
+            {
+                None = 0,
+                Reference = 1,
+                HideReferenceFromComposite = 2,
+                CompileSeparately = 4,
+                CompileIntoCompositeImage = 8,
+            }
+
+            private readonly EligibilityEnum _flags;
+
+            public static Eligibility None => new Eligibility(EligibilityEnum.None);
+
+            public bool NoEligibility => _flags == EligibilityEnum.None;
+            public bool IsReference => (_flags & EligibilityEnum.Reference) == EligibilityEnum.Reference;
+            public bool ReferenceHiddenFromCompositeBuild => (_flags & EligibilityEnum.HideReferenceFromComposite) == EligibilityEnum.HideReferenceFromComposite;
+            public bool CompileIntoCompositeImage => (_flags & EligibilityEnum.CompileIntoCompositeImage) == EligibilityEnum.CompileIntoCompositeImage;
+            public bool CompileSeparately => (_flags & EligibilityEnum.CompileSeparately) == EligibilityEnum.CompileSeparately;
+            public bool Compile => CompileIntoCompositeImage || CompileSeparately;
+
+            private Eligibility(EligibilityEnum flags)
+            {
+                _flags = flags;
+            }
+
+            public static Eligibility CreateReferenceEligibility(bool hideFromCompositeBuilds)
+            {
+                if (hideFromCompositeBuilds)
+                    return new Eligibility(EligibilityEnum.Reference | EligibilityEnum.HideReferenceFromComposite);
+                else
+                    return new Eligibility(EligibilityEnum.Reference);
+            }
+
+            public static Eligibility CreateCompileEligibility(bool doNotBuildIntoComposite)
+            {
+                if (doNotBuildIntoComposite)
+                    return new Eligibility(EligibilityEnum.Reference | EligibilityEnum.HideReferenceFromComposite | EligibilityEnum.CompileSeparately);
+                else
+                    return new Eligibility(EligibilityEnum.Reference | EligibilityEnum.CompileIntoCompositeImage);
+            }
         };
 
-        private static Eligibility GetInputFileEligibility(ITaskItem file, HashSet<string> exclusionSet)
+        private static bool IsNonCompositeReadyToRunImage(PEReader peReader)
+        {
+            if (peReader.PEHeaders == null)
+                return false;
+
+            if (peReader.PEHeaders.CorHeader == null)
+                return false;
+
+            if ((peReader.PEHeaders.CorHeader.Flags & CorFlags.ILLibrary) == 0)
+            {
+                // This is likely a composite image, but those can't be re-r2r'd
+                return false;
+            }
+            else
+            {
+                return peReader.PEHeaders.CorHeader.ManagedNativeHeaderDirectory.Size != 0;
+            }
+        }
+
+        private static Eligibility GetInputFileEligibility(ITaskItem file, bool compositeCompile, HashSet<string> exclusionSet, HashSet<string> r2rCompositeExclusionSet)
         {
             // Check to see if this is a valid ILOnly image that we can compile
             using (FileStream fs = new FileStream(file.ItemSpec, FileMode.Open, FileAccess.Read))
@@ -276,35 +357,54 @@ namespace Microsoft.NET.Build.Tasks
                         {
                             return Eligibility.None;
                         }
-                        
+
                         if (IsReferenceAssembly(mdReader))
                         {
                             // crossgen can only take implementation assemblies, even as references
                             return Eligibility.None;
                         }
 
+                        bool excludeFromR2R = (exclusionSet != null && exclusionSet.Contains(Path.GetFileName(file.ItemSpec)));
+                        bool excludeFromComposite = (r2rCompositeExclusionSet != null && r2rCompositeExclusionSet.Contains(Path.GetFileName(file.ItemSpec))) || excludeFromR2R;
+
                         if ((pereader.PEHeaders.CorHeader.Flags & CorFlags.ILOnly) != CorFlags.ILOnly)
                         {
-                            return Eligibility.ReferenceOnly;
+                            // This can happen due to C++/CLI binaries or due to previously R2R compiled binaries.
+
+                            if (!IsNonCompositeReadyToRunImage(pereader))
+                            {
+                                // For C++/CLI always treat as only a reference
+                                return Eligibility.CreateReferenceEligibility(excludeFromComposite);
+                            }
+                            else
+                            {
+                                // If previously compiled as R2R, treat as reference if this would be compiled seperately
+                                if (!compositeCompile || excludeFromComposite)
+                                {
+                                    return Eligibility.CreateReferenceEligibility(excludeFromComposite);
+                                }
+                            }
                         }
 
                         if (file.HasMetadataValue(MetadataKeys.ReferenceOnly, "true"))
                         {
-                            return Eligibility.ReferenceOnly;
+                            return Eligibility.CreateReferenceEligibility(excludeFromComposite);
                         }
 
-                        if (exclusionSet != null && exclusionSet.Contains(Path.GetFileName(file.ItemSpec)))
+                        if (excludeFromR2R)
                         {
-                            return Eligibility.ReferenceOnly;
+                            return Eligibility.CreateReferenceEligibility(excludeFromComposite);
                         }
 
                         // save these most expensive checks for last. We don't want to scan all references for IL code
                         if (ReferencesWinMD(mdReader) || !HasILCode(pereader, mdReader))
                         {
-                            return Eligibility.ReferenceOnly;
+                            // Forwarder assemblies are not separately compiled via R2R, but when performing composite compilation, they are included in the bundle
+                            if (excludeFromComposite || !compositeCompile)
+                                return Eligibility.CreateReferenceEligibility(excludeFromComposite);
                         }
 
-                        return Eligibility.CompileAndReference;
+                        return Eligibility.CreateCompileEligibility(!compositeCompile || excludeFromComposite);
                     }
                 }
                 catch (BadImageFormatException)

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolveReadyToRunCompilers.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveReadyToRunCompilers.cs
@@ -1,5 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.ComponentModel;

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolveReadyToRunCompilers.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveReadyToRunCompilers.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.ComponentModel;
@@ -59,7 +59,7 @@ namespace Microsoft.NET.Build.Tasks
             _crossgen2Pack = Crossgen2Packs?.FirstOrDefault();
             _targetRuntimeIdentifier = _runtimePack?.GetMetadata(MetadataKeys.RuntimeIdentifier);
 
-            // Get the list of runtime identifiers that we support and can target 
+            // Get the list of runtime identifiers that we support and can target
             ITaskItem targetingPack = GetNETCoreAppTargetingPack();
             string supportedRuntimeIdentifiers = targetingPack?.GetMetadata(MetadataKeys.RuntimePackRuntimeIdentifiers);
 
@@ -122,7 +122,7 @@ namespace Microsoft.NET.Build.Tasks
             // Create tool task item
             CrossgenTool = new TaskItem(_crossgenTool.ToolPath);
             CrossgenTool.SetMetadata(MetadataKeys.JitPath, _crossgenTool.ClrJitPath);
-            if (!String.IsNullOrEmpty(_crossgenTool.DiaSymReaderPath))
+            if (!string.IsNullOrEmpty(_crossgenTool.DiaSymReaderPath))
             {
                 CrossgenTool.SetMetadata(MetadataKeys.DiaSymReader, _crossgenTool.DiaSymReaderPath);
             }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/RunReadyToRunCompiler.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/RunReadyToRunCompiler.cs
@@ -1,5 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.IO;

--- a/src/Tasks/Microsoft.NET.Build.Tasks/RunReadyToRunCompiler.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/RunReadyToRunCompiler.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.IO;
@@ -20,9 +20,10 @@ namespace Microsoft.NET.Build.Tasks
         public ITaskItem CompilationEntry { get; set; }
         [Required]
         public ITaskItem[] ImplementationAssemblyReferences { get; set; }
+        public ITaskItem[] ReadyToRunCompositeBuildReferences { get; set; }
+        public ITaskItem[] ReadyToRunCompositeBuildInput { get; set; }
         public bool ShowCompilerWarnings { get; set; }
         public bool UseCrossgen2 { get; set; }
-        public bool Crossgen2Composite { get; set; }
         public string Crossgen2ExtraCommandLineArgs { get; set; }
 
         [Output]
@@ -33,8 +34,9 @@ namespace Microsoft.NET.Build.Tasks
         private string _outputR2RImage;
         private string _outputPDBImage;
         private string _createPDBCommand;
+        private bool _createCompositeImage;
 
-        private bool IsPdbCompilation => !String.IsNullOrEmpty(_createPDBCommand);
+        private bool IsPdbCompilation => !string.IsNullOrEmpty(_createPDBCommand);
         private bool ActuallyUseCrossgen2 => UseCrossgen2 && !IsPdbCompilation;
 
         private string DotNetHostPath => Crossgen2Tool?.GetMetadata(MetadataKeys.DotNetHostPath);
@@ -79,6 +81,8 @@ namespace Microsoft.NET.Build.Tasks
             string emitSymbolsMetadata = CompilationEntry.GetMetadata(MetadataKeys.EmitSymbols);
             _emitSymbols = !string.IsNullOrEmpty(emitSymbolsMetadata) && bool.Parse(emitSymbolsMetadata);
             _createPDBCommand = CompilationEntry.GetMetadata(MetadataKeys.CreatePDBCommand);
+            string createCompositeImageMetadata = CompilationEntry.GetMetadata(MetadataKeys.CreateCompositeImage);
+            _createCompositeImage = !string.IsNullOrEmpty(createCompositeImageMetadata) && bool.Parse(createCompositeImageMetadata);
 
             if (IsPdbCompilation && CrossgenTool == null)
             {
@@ -162,14 +166,14 @@ namespace Microsoft.NET.Build.Tasks
             {
                 _outputR2RImage = CompilationEntry.ItemSpec;
 
-                if (!String.IsNullOrEmpty(DiaSymReader) && !File.Exists(DiaSymReader))
+                if (!string.IsNullOrEmpty(DiaSymReader) && !File.Exists(DiaSymReader))
                 {
                     Log.LogError(Strings.DiaSymReaderLibraryNotFound, DiaSymReader);
                     return false;
                 }
 
                 // R2R image has to be created before emitting native symbols (crossgen needs this as an input argument)
-                if (String.IsNullOrEmpty(_outputPDBImage))
+                if (string.IsNullOrEmpty(_outputPDBImage))
                 {
                     Log.LogError(Strings.MissingOutputPDBImagePath);
                 }
@@ -182,21 +186,28 @@ namespace Microsoft.NET.Build.Tasks
             }
             else
             {
-                _inputAssembly = CompilationEntry.ItemSpec;
                 _outputR2RImage = CompilationEntry.GetMetadata(MetadataKeys.OutputR2RImage);
 
-                if (!File.Exists(_inputAssembly))
+                if (!_createCompositeImage)
                 {
-                    Log.LogError(Strings.InputAssemblyNotFound, _inputAssembly);
-                    return false;
+                    _inputAssembly = CompilationEntry.ItemSpec;
+                    if (!File.Exists(_inputAssembly))
+                    {
+                        Log.LogError(Strings.InputAssemblyNotFound, _inputAssembly);
+                        return false;
+                    }
                 }
-                
+                else
+                {
+                    _inputAssembly = "CompositeImage";
+                }
+
                 if (string.IsNullOrEmpty(_outputR2RImage))
                 {
                     Log.LogError(Strings.MissingOutputR2RImageFileName);
                     return false;
                 }
-                
+
                 if (_emitSymbols && string.IsNullOrEmpty(_outputPDBImage))
                 {
                     Log.LogError(Strings.MissingOutputPDBImagePath);
@@ -210,19 +221,24 @@ namespace Microsoft.NET.Build.Tasks
         {
             StringBuilder result = new StringBuilder();
 
-            foreach (var reference in ImplementationAssemblyReferences)
-            {
-                // When generating PDBs, we must not add a reference to the IL version of the R2R image for which we're trying to generate a PDB
-                if (IsPdbCompilation && String.Equals(Path.GetFileName(reference.ItemSpec), Path.GetFileName(_outputR2RImage), StringComparison.OrdinalIgnoreCase))
-                    continue;
+            var references = _createCompositeImage ? ReadyToRunCompositeBuildReferences : ImplementationAssemblyReferences;
 
-                if (UseCrossgen2 && !IsPdbCompilation)
+            if (references != null)
+            {
+                foreach (var reference in (_createCompositeImage ? ReadyToRunCompositeBuildReferences : ImplementationAssemblyReferences))
                 {
-                    result.AppendLine($"-r:\"{reference}\"");
-                }
-                else
-                {
-                    result.AppendLine($"-r \"{reference}\"");
+                    // When generating PDBs, we must not add a reference to the IL version of the R2R image for which we're trying to generate a PDB
+                    if (IsPdbCompilation && string.Equals(Path.GetFileName(reference.ItemSpec), Path.GetFileName(_outputR2RImage), StringComparison.OrdinalIgnoreCase))
+                        continue;
+
+                    if (UseCrossgen2 && !IsPdbCompilation)
+                    {
+                        result.AppendLine($"-r:\"{reference}\"");
+                    }
+                    else
+                    {
+                        result.AppendLine($"-r \"{reference}\"");
+                    }
                 }
             }
 
@@ -261,7 +277,7 @@ namespace Microsoft.NET.Build.Tasks
             {
                 result.Append(GetAssemblyReferencesCommands());
 
-                if (!String.IsNullOrEmpty(DiaSymReader))
+                if (!string.IsNullOrEmpty(DiaSymReader))
                 {
                     result.AppendLine($"/DiasymreaderPath \"{DiaSymReader}\"");
                 }
@@ -284,7 +300,7 @@ namespace Microsoft.NET.Build.Tasks
         private string GenerateCrossgen2ResponseFile()
         {
             StringBuilder result = new StringBuilder();
-            
+
             string jitPath = Crossgen2Tool.GetMetadata(MetadataKeys.JitPath);
             if (!string.IsNullOrEmpty(jitPath))
             {
@@ -297,23 +313,23 @@ namespace Microsoft.NET.Build.Tasks
             }
 
             result.AppendLine("-O");
-            
+
             // 5.0 Crossgen2 doesn't support PDB generation.
             if (!Crossgen2IsVersion5 && _emitSymbols)
             {
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                 {
                     result.AppendLine("--pdb");
-                    result.AppendLine($"--pdb-path:{_outputPDBImage}");
+                    result.AppendLine($"--pdb-path:{Path.GetDirectoryName(_outputPDBImage)}");
                 }
                 else
                 {
                     result.AppendLine("--perfmap");
-                    result.AppendLine($"--perfmap-path:{_outputPDBImage}");
+                    result.AppendLine($"--perfmap-path:{Path.GetDirectoryName(_outputPDBImage)}");
                 }
             }
 
-            if (!String.IsNullOrEmpty(Crossgen2ExtraCommandLineArgs))
+            if (!string.IsNullOrEmpty(Crossgen2ExtraCommandLineArgs))
             {
                 foreach (string extraArg in Crossgen2ExtraCommandLineArgs.Split(new char[]{';'}, StringSplitOptions.RemoveEmptyEntries))
                 {
@@ -321,15 +337,21 @@ namespace Microsoft.NET.Build.Tasks
                 }
             }
 
-            if (Crossgen2Composite)
+            if (_createCompositeImage)
             {
                 result.AppendLine("--composite");
-                result.AppendLine("--inputbubble");
+
+                // Crossgen2 v5 only supported compilation with --inputbubble specified
+                if (Crossgen2IsVersion5)
+                    result.AppendLine("--inputbubble");
+
                 result.AppendLine($"--out:\"{_outputR2RImage}\"");
+
+                result.Append(GetAssemblyReferencesCommands());
 
                 // Note: do not add double quotes around the input assembly, even if the file path contains spaces. The command line
                 // parsing logic will append this string to the working directory if it's a relative path, so any double quotes will result in errors.
-                foreach (var reference in ImplementationAssemblyReferences)
+                foreach (var reference in ReadyToRunCompositeBuildInput)
                 {
                     result.AppendLine(reference.ItemSpec);
                 }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.CrossGen.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.CrossGen.targets
@@ -11,6 +11,14 @@ Copyright (c) .NET Foundation. All rights reserved.
 -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
+  <PropertyGroup Condition="'$(PublishReadyToRun)' == 'true' and '$(TargetFrameworkIdentifier)' == '.NETCoreApp' and '$(_TargetFrameworkVersionWithoutV)' >= '3.0'">
+    <!-- For .NET 6 and higher, default to using Crossgen2 in non-composite mode -->
+    <PublishReadyToRunUseCrossgen2 Condition="'$(PublishReadyToRunUseCrossgen2)' == '' and '$(_TargetFrameworkVersionWithoutV)' >= '6.0'">true</PublishReadyToRunUseCrossgen2>
+    <PublishReadyToRunComposite Condition="'$(PublishReadyToRunComposite)' == '' and '$(_TargetFrameworkVersionWithoutV)' >= '6.0'">false</PublishReadyToRunComposite>
+    <PublishReadyToRunComposite Condition="'$(PublishReadyToRunComposite)' == ''">true</PublishReadyToRunComposite>
+    <PublishReadyToRunComposite Condition="'$(PublishReadyToRunUseCrossgen2)' != 'true' or '$(SelfContained)' != 'true'">false</PublishReadyToRunComposite>
+  </PropertyGroup>
+
   <!--
     ============================================================
                                         PrepOptimizer
@@ -314,4 +322,187 @@ Copyright (c) .NET Foundation. All rights reserved.
     </Copy>
   </Target>
 
+  <PropertyGroup>
+    <MicrosoftNETCrossgenBuildTasksAssembly Condition="'$(MSBuildRuntimeType)' == 'Core'">$(MSBuildThisFileDirectory)..\tasks\net6.0\Microsoft.NET.Sdk.Crossgen.dll</MicrosoftNETCrossgenBuildTasksAssembly>
+    <MicrosoftNETCrossgenBuildTasksAssembly Condition="'$(MSBuildRuntimeType)' != 'Core'">$(MSBuildThisFileDirectory)..\tasks\net472\Microsoft.NET.Sdk.Crossgen.dll</MicrosoftNETCrossgenBuildTasksAssembly>
+  </PropertyGroup>
+
+  <!--
+    ============================================================
+                                        CreateReadyToRunImages
+
+    Create ReadyToRun images for managed assemblies in _ResolvedFileToPublishAlways and _ResolvedFileToPublishPreserveNewest.
+    ============================================================
+    -->
+  <Target Name="CreateReadyToRunImages"
+          Condition="'$(_TargetFrameworkVersionWithoutV)' >= '3.0' And '$(PublishReadyToRun)' == 'true' And '$(TargetFrameworkIdentifier)' == '.NETCoreApp'"
+          DependsOnTargets="_PrepareForReadyToRunCompilation;
+                            _CreateR2RImages;
+                            _CreateR2RSymbols">
+
+    <AllowEmptyTelemetry EventName="ReadyToRun" EventData="PublishReadyToRunUseCrossgen2=$(PublishReadyToRunUseCrossgen2);Crossgen2PackVersion=%(ResolvedCrossgen2Pack.NuGetPackageVersion);CompileListCount=@(_ReadyToRunCompileList->Count());FailedCount=@(_ReadyToRunCompilationFailures->Count())" />
+
+    <NETSdkError Condition="'@(_ReadyToRunCompilationFailures)' != ''" ResourceName="ReadyToRunCompilationFailed" />
+
+    <NETSdkInformation Condition="'$(_ReadyToRunCompilerHasWarnings)' != ''" ResourceName="ReadyToRunCompilationHasWarnings_Info" />
+
+    <ItemGroup>
+      <!--
+      Note: we only remove the entries for the IL images and replace them with the entries for the R2R images.
+      We do not do the same for PDBs, because the native PDBs created by the R2R compiler complement the IL PDBs
+      and do not replace them. IL PDBs are still required for debugging. Native PDBs emitted by the R2R compiler are
+      only used for profiling purposes.
+      -->
+      <ResolvedFileToPublish Remove="@(_ReadyToRunCompositeBuildInput)" />
+      <ResolvedFileToPublish Remove="@(_ReadyToRunCompileList)" />
+      <ResolvedFileToPublish Include="@(_ReadyToRunFilesToPublish)" />
+    </ItemGroup>
+
+  </Target>
+
+  <!--
+    ============================================================
+                                        _PrepareForReadyToRunCompilation
+
+    Prepare build for ReadyToRun compilations. Builds list of assemblies to compile, and computes paths to ReadyToRun compiler bits
+    ============================================================
+    -->
+  <UsingTask Condition="'$(Crossgen2TasksOverriden)' != 'true'"  TaskName="PrepareForReadyToRunCompilation" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)"/>
+  <Target Name="_PrepareForReadyToRunCompilation" DependsOnTargets="ResolveReadyToRunCompilers;_ComputeManagedRuntimePackAssemblies;_ComputeAssembliesToPostprocessOnPublish">
+
+    <PropertyGroup>
+      <_ReadyToRunOutputPath>$(IntermediateOutputPath)R2R</_ReadyToRunOutputPath>
+    </PropertyGroup>
+
+    <MakeDir Directories="$(_ReadyToRunOutputPath)" />
+
+    <ItemGroup>
+      <_ReadyToRunImplementationAssemblies Include="@(ResolvedFileToPublish->WithMetadataValue('PostprocessAssembly', 'true'))" />
+    </ItemGroup>
+
+    <!-- Even if app is not self-contained, crossgen requires closure of implementation assemblies. Resolve conflicts
+         of the runtime pack assets as though we were copying them locally, and add them to the R2R implementation
+         assembly list. -->
+    <ItemGroup Condition="'$(SelfContained)' != 'true'">
+      <_ReadyToRunImplementationAssemblies Include="@(_ManagedRuntimePackAssembly)" ReferenceOnly="true" />
+    </ItemGroup>
+
+    <ResolvePackageFileConflicts Condition="'$(SelfContained)' != 'true'"
+                                 ReferenceCopyLocalPaths="@(_ReadyToRunImplementationAssemblies)">
+      <Output TaskParameter="ReferenceCopyLocalPathsWithoutConflicts" ItemName="_ReadyToRunImplementationAssembliesWithoutConflicts" />
+    </ResolvePackageFileConflicts>
+
+    <ItemGroup Condition="'$(SelfContained)' != 'true'">
+      <_ReadyToRunImplementationAssemblies Remove="@(_ReadyToRunImplementationAssemblies)" />
+      <_ReadyToRunImplementationAssemblies Include="@(_ReadyToRunImplementationAssembliesWithoutConflicts)" />
+    </ItemGroup>
+
+    <PrepareForReadyToRunCompilation CrossgenTool="@(CrossgenTool)"
+                                     Crossgen2Tool="@(Crossgen2Tool)"
+                                     OutputPath="$(_ReadyToRunOutputPath)"
+                                     MainAssembly="@(IntermediateAssembly)"
+                                     Assemblies="@(_ReadyToRunImplementationAssemblies)"
+                                     ExcludeList="@(PublishReadyToRunExclude)"
+                                     EmitSymbols="$(PublishReadyToRunEmitSymbols)"
+                                     IncludeSymbolsInSingleFile="$(IncludeSymbolsInSingleFile)"
+                                     ReadyToRunUseCrossgen2="$(PublishReadyToRunUseCrossgen2)"
+                                     Crossgen2Composite="$(PublishReadyToRunComposite)"
+                                     PublishReadyToRunCompositeExclusions="@(PublishReadyToRunCompositeExclusions)">
+
+      <Output TaskParameter="ReadyToRunCompileList" ItemName="_ReadyToRunCompileList" />
+      <Output TaskParameter="ReadyToRunSymbolsCompileList" ItemName="_ReadyToRunSymbolsCompileList" />
+
+      <Output TaskParameter="ReadyToRunFilesToPublish" ItemName="_ReadyToRunFilesToPublish" />
+      <Output TaskParameter="ReadyToRunAssembliesToReference" ItemName="_ReadyToRunAssembliesToReference" />
+      <Output TaskParameter="ReadyToRunCompositeBuildReferences" ItemName="_ReadyToRunCompositeBuildReferences" />
+      <Output TaskParameter="ReadyToRunCompositeBuildInput" ItemName="_ReadyToRunCompositeBuildInput" />
+
+    </PrepareForReadyToRunCompilation>
+  </Target>
+
+  <UsingTask Condition="'$(Crossgen2TasksOverriden)' != 'true'" TaskName="ResolveReadyToRunCompilers" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
+  <Target Name="ResolveReadyToRunCompilers">
+    <ResolveReadyToRunCompilers RuntimePacks="@(ResolvedRuntimePack)"
+                                Crossgen2Packs="@(ResolvedCrossgen2Pack)"
+                                TargetingPacks="@(ResolvedTargetingPack)"
+                                RuntimeGraphPath="$(BundledRuntimeIdentifierGraphFile)"
+                                NETCoreSdkRuntimeIdentifier="$(NETCoreSdkRuntimeIdentifier)"
+                                EmitSymbols="$(PublishReadyToRunEmitSymbols)"
+                                ReadyToRunUseCrossgen2="$(PublishReadyToRunUseCrossgen2)">
+
+      <Output TaskParameter="CrossgenTool" ItemName="CrossgenTool" />
+      <Output TaskParameter="Crossgen2Tool" ItemName="Crossgen2Tool" />
+    </ResolveReadyToRunCompilers>
+  </Target>
+
+  <!--
+    ============================================================
+                                        _CreateR2RImages
+
+    Compiles assemblies in the _ReadyToRunCompileList list into ReadyToRun images
+    ============================================================
+    -->
+  <UsingTask Condition="'$(Crossgen2TasksOverriden)' != 'true'" TaskName="RunReadyToRunCompiler" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
+  <Target Name="_CreateR2RImages"
+          Inputs="@(_ReadyToRunCompileList);@(_ReadyToRunCompositeBuildInput)"
+          Outputs="%(_ReadyToRunCompileList.OutputR2RImage);%(_ReadyToRunCompileList.OutputPDBImage)">
+
+    <RunReadyToRunCompiler CrossgenTool="@(CrossgenTool)"
+                           Crossgen2Tool="@(Crossgen2Tool)"
+                           UseCrossgen2="$(PublishReadyToRunUseCrossgen2)"
+                           Crossgen2ExtraCommandLineArgs="$(PublishReadyToRunCrossgen2ExtraArgs)"
+                           ImplementationAssemblyReferences="@(_ReadyToRunAssembliesToReference)"
+                           ShowCompilerWarnings="$(PublishReadyToRunShowWarnings)"
+                           CompilationEntry="@(_ReadyToRunCompileList)"
+                           ContinueOnError="ErrorAndContinue"
+                           ReadyToRunCompositeBuildReferences="@(_ReadyToRunCompositeBuildReferences)"
+                           ReadyToRunCompositeBuildInput="@(_ReadyToRunCompositeBuildInput)">
+      <Output TaskParameter="ExitCode" PropertyName="_ReadyToRunCompilerExitCode" />
+      <Output TaskParameter="WarningsDetected" PropertyName="_ReadyToRunWarningsDetected" />
+    </RunReadyToRunCompiler>
+
+    <PropertyGroup>
+      <!-- Use distinct property here as any of the invocations can set it -->
+      <_ReadyToRunCompilerHasWarnings Condition="'$(_ReadyToRunWarningsDetected)' == 'true'">true</_ReadyToRunCompilerHasWarnings>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <_ReadyToRunCompilationFailures Condition="'$(_ReadyToRunCompilerExitCode)' != '' And $(_ReadyToRunCompilerExitCode) != 0"
+                                      Include="@(_ReadyToRunCompileList)" />
+    </ItemGroup>
+  </Target>
+
+  <!--
+    ============================================================
+                                        _CreateR2RSymbols
+
+    Emit native symbols for ReadyToRun images in the _ReadyToRunSymbolsCompileList list
+    ============================================================
+    -->
+  <Target Name="_CreateR2RSymbols"
+          Inputs="@(_ReadyToRunSymbolsCompileList)"
+          Outputs="%(_ReadyToRunSymbolsCompileList.OutputPDBImage)"
+          Condition="'$(PublishReadyToRunUseCrossgen2)' != 'true' or '@(Crossgen2Tool -> '%(IsVersion5)')' == 'true'">
+    <RunReadyToRunCompiler CrossgenTool="@(CrossgenTool)"
+                           Crossgen2Tool="@(Crossgen2Tool)"
+                           UseCrossgen2="$(PublishReadyToRunUseCrossgen2)"
+                           Crossgen2ExtraCommandLineArgs="$(PublishReadyToRunCrossgen2ExtraArgs)"
+                           ImplementationAssemblyReferences="@(_ReadyToRunAssembliesToReference)"
+                           ShowCompilerWarnings="$(PublishReadyToRunShowWarnings)"
+                           CompilationEntry="@(_ReadyToRunSymbolsCompileList)"
+                           ContinueOnError="ErrorAndContinue">
+      <Output TaskParameter="ExitCode" PropertyName="_ReadyToRunCompilerExitCode" />
+      <Output TaskParameter="WarningsDetected" PropertyName="_ReadyToRunWarningsDetected" />
+    </RunReadyToRunCompiler>
+
+    <PropertyGroup>
+      <!-- Use distinct property here as any of the invocations can set it -->
+      <_ReadyToRunCompilerHasWarnings Condition="'$(_ReadyToRunWarningsDetected)' == 'true'">true</_ReadyToRunCompilerHasWarnings>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <_ReadyToRunCompilationFailures Condition="'$(_ReadyToRunCompilerExitCode)' != '' And $(_ReadyToRunCompilerExitCode) != 0"
+                                      Include="@(_ReadyToRunSymbolsCompileList)" />
+    </ItemGroup>
+  </Target>
 </Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -17,14 +17,6 @@ Copyright (c) .NET Foundation. All rights reserved.
     <IsPublishable Condition="'$(IsPublishable)' == ''">true</IsPublishable>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(PublishReadyToRun)' == 'true' and '$(TargetFrameworkIdentifier)' == '.NETCoreApp' and '$(_TargetFrameworkVersionWithoutV)' >= '3.0'">
-    <!-- For .NET 6 and higher, default to using Crossgen2 in non-composite mode -->
-    <PublishReadyToRunUseCrossgen2 Condition="'$(PublishReadyToRunUseCrossgen2)' == '' and '$(_TargetFrameworkVersionWithoutV)' >= '6.0'">true</PublishReadyToRunUseCrossgen2>
-    <PublishReadyToRunComposite Condition="'$(PublishReadyToRunComposite)' == '' and '$(_TargetFrameworkVersionWithoutV)' >= '6.0'">false</PublishReadyToRunComposite>
-    <PublishReadyToRunComposite Condition="'$(PublishReadyToRunComposite)' == ''">true</PublishReadyToRunComposite>
-    <PublishReadyToRunComposite Condition="'$(PublishReadyToRunUseCrossgen2)' != 'true' or '$(SelfContained)' != 'true'">false</PublishReadyToRunComposite>
-  </PropertyGroup>
-
   <ItemDefinitionGroup>
     <ResolvedFileToPublish>
       <CopyToPublishDirectory>Always</CopyToPublishDirectory>
@@ -300,39 +292,6 @@ Copyright (c) .NET Foundation. All rights reserved.
     </Copy>
   </Target>
 
-  <!--
-    ============================================================
-                                        CreateReadyToRunImages
-
-    Create ReadyToRun images for managed assemblies in _ResolvedFileToPublishAlways and _ResolvedFileToPublishPreserveNewest.
-    ============================================================
-    -->
-  <Target Name="CreateReadyToRunImages"
-          Condition="'$(_TargetFrameworkVersionWithoutV)' >= '3.0' And '$(PublishReadyToRun)' == 'true' And '$(TargetFrameworkIdentifier)' == '.NETCoreApp'"
-          DependsOnTargets="_PrepareForReadyToRunCompilation;
-                            _CreateR2RImages;
-                            _CreateR2RSymbols">
-
-    <AllowEmptyTelemetry EventName="ReadyToRun" EventData="PublishReadyToRunUseCrossgen2=$(PublishReadyToRunUseCrossgen2);Crossgen2PackVersion=%(ResolvedCrossgen2Pack.NuGetPackageVersion);CompileListCount=@(_ReadyToRunCompileList->Count());FailedCount=@(_ReadyToRunCompilationFailures->Count())" />
-
-    <NETSdkError Condition="'@(_ReadyToRunCompilationFailures)' != ''" ResourceName="ReadyToRunCompilationFailed" />
-
-    <NETSdkInformation Condition="'$(_ReadyToRunCompilerHasWarnings)' != ''" ResourceName="ReadyToRunCompilationHasWarnings_Info" />
-
-    <ItemGroup>
-      <!--
-      Note: we only remove the entries for the IL images and replace them with the entries for the R2R images.
-      We do not do the same for PDBs, because the native PDBs created by the R2R compiler complement the IL PDBs
-      and do not replace them. IL PDBs are still required for debugging. Native PDBs emitted by the R2R compiler are
-      only used for profiling purposes.
-      -->
-      <ResolvedFileToPublish Remove="@(_ReadyToRunImplementationAssemblies)" Condition="'$(PublishReadyToRunComposite)' == 'true'"/>
-      <ResolvedFileToPublish Remove="@(_ReadyToRunCompileList)" />
-      <ResolvedFileToPublish Include="@(_ReadyToRunFilesToPublish)" />
-    </ItemGroup>
-
-  </Target>
-
   <UsingTask TaskName="ResolveReadyToRunCompilers" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
   <Target Name="ResolveReadyToRunCompilers">
     <ResolveReadyToRunCompilers RuntimePacks="@(ResolvedRuntimePack)"
@@ -346,133 +305,6 @@ Copyright (c) .NET Foundation. All rights reserved.
       <Output TaskParameter="CrossgenTool" ItemName="CrossgenTool" />
       <Output TaskParameter="Crossgen2Tool" ItemName="Crossgen2Tool" />
     </ResolveReadyToRunCompilers>
-  </Target>
-
-  <!--
-    ============================================================
-                                        _PrepareForReadyToRunCompilation
-
-    Prepare build for ReadyToRun compilations. Builds list of assemblies to compile, and computes paths to ReadyToRun compiler bits
-    ============================================================
-    -->
-  <UsingTask TaskName="PrepareForReadyToRunCompilation" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
-  <Target Name="_PrepareForReadyToRunCompilation" DependsOnTargets="ResolveReadyToRunCompilers;_ComputeManagedRuntimePackAssemblies;_ComputeAssembliesToPostprocessOnPublish">
-
-    <PropertyGroup>
-      <_ReadyToRunOutputPath>$(IntermediateOutputPath)R2R</_ReadyToRunOutputPath>
-    </PropertyGroup>
-
-    <MakeDir Directories="$(_ReadyToRunOutputPath)" />
-
-    <ItemGroup>
-      <_ReadyToRunImplementationAssemblies Include="@(ResolvedFileToPublish->WithMetadataValue('PostprocessAssembly', 'true'))" />
-    </ItemGroup>
-
-    <!-- Even if app is not self-contained, crossgen requires closure of implementation assemblies. Resolve conflicts
-         of the runtime pack assets as though we were copying them locally, and add them to the R2R implementation
-         assembly list. -->
-    <ItemGroup Condition="'$(SelfContained)' != 'true'">
-      <_ReadyToRunImplementationAssemblies Include="@(_ManagedRuntimePackAssembly)" ReferenceOnly="true" />
-    </ItemGroup>
-
-    <ResolvePackageFileConflicts Condition="'$(SelfContained)' != 'true'"
-                                 ReferenceCopyLocalPaths="@(_ReadyToRunImplementationAssemblies)">
-      <Output TaskParameter="ReferenceCopyLocalPathsWithoutConflicts" ItemName="_ReadyToRunImplementationAssembliesWithoutConflicts" />
-    </ResolvePackageFileConflicts>
-
-    <ItemGroup Condition="'$(SelfContained)' != 'true'">
-      <_ReadyToRunImplementationAssemblies Remove="@(_ReadyToRunImplementationAssemblies)" />
-      <_ReadyToRunImplementationAssemblies Include="@(_ReadyToRunImplementationAssembliesWithoutConflicts)" />
-    </ItemGroup>
-
-    <PrepareForReadyToRunCompilation CrossgenTool="@(CrossgenTool)"
-                                     Crossgen2Tool="@(Crossgen2Tool)"
-                                     OutputPath="$(_ReadyToRunOutputPath)"
-                                     MainAssembly="@(IntermediateAssembly)"
-                                     Assemblies="@(_ReadyToRunImplementationAssemblies)"
-                                     ExcludeList="@(PublishReadyToRunExclude)"
-                                     EmitSymbols="$(PublishReadyToRunEmitSymbols)"
-                                     IncludeSymbolsInSingleFile="$(IncludeSymbolsInSingleFile)"
-                                     ReadyToRunUseCrossgen2="$(PublishReadyToRunUseCrossgen2)"
-                                     Crossgen2Composite="$(PublishReadyToRunComposite)">
-
-      <Output TaskParameter="ReadyToRunCompileList" ItemName="_ReadyToRunCompileList" />
-      <Output TaskParameter="ReadyToRunSymbolsCompileList" ItemName="_ReadyToRunSymbolsCompileList" />
-
-      <Output TaskParameter="ReadyToRunFilesToPublish" ItemName="_ReadyToRunFilesToPublish" />
-      <Output TaskParameter="ReadyToRunAssembliesToReference" ItemName="_ReadyToRunAssembliesToReference" />
-
-    </PrepareForReadyToRunCompilation>
-  </Target>
-
-  <!--
-    ============================================================
-                                        _CreateR2RImages
-
-    Compiles assemblies in the _ReadyToRunCompileList list into ReadyToRun images
-    ============================================================
-    -->
-  <UsingTask TaskName="RunReadyToRunCompiler" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
-  <Target Name="_CreateR2RImages"
-          Inputs="@(_ReadyToRunCompileList)"
-          Outputs="%(_ReadyToRunCompileList.OutputR2RImage)">
-
-    <RunReadyToRunCompiler CrossgenTool="@(CrossgenTool)"
-                           Crossgen2Tool="@(Crossgen2Tool)"
-                           UseCrossgen2="$(PublishReadyToRunUseCrossgen2)"
-                           Crossgen2Composite="$(PublishReadyToRunComposite)"
-                           Crossgen2ExtraCommandLineArgs="$(PublishReadyToRunCrossgen2ExtraArgs)"
-                           ImplementationAssemblyReferences="@(_ReadyToRunAssembliesToReference)"
-                           ShowCompilerWarnings="$(PublishReadyToRunShowWarnings)"
-                           CompilationEntry="@(_ReadyToRunCompileList)"
-                           ContinueOnError="ErrorAndContinue">
-      <Output TaskParameter="ExitCode" PropertyName="_ReadyToRunCompilerExitCode" />
-      <Output TaskParameter="WarningsDetected" PropertyName="_ReadyToRunWarningsDetected" />
-    </RunReadyToRunCompiler>
-
-    <PropertyGroup>
-      <!-- Use distinct property here as any of the invocations can set it -->
-      <_ReadyToRunCompilerHasWarnings Condition="'$(_ReadyToRunWarningsDetected)' == 'true'">true</_ReadyToRunCompilerHasWarnings>
-    </PropertyGroup>
-
-    <ItemGroup>
-      <_ReadyToRunCompilationFailures Condition="'$(_ReadyToRunCompilerExitCode)' != '' And $(_ReadyToRunCompilerExitCode) != 0"
-                                      Include="@(_ReadyToRunCompileList)" />
-    </ItemGroup>
-  </Target>
-
-  <!--
-    ============================================================
-                                        _CreateR2RSymbols
-
-    Emit native symbols for ReadyToRun images in the _ReadyToRunSymbolsCompileList list
-    ============================================================
-    -->
-  <Target Name="_CreateR2RSymbols"
-          Inputs="@(_ReadyToRunSymbolsCompileList)"
-          Outputs="%(_ReadyToRunSymbolsCompileList.OutputPDBImage)"
-          Condition="'$(PublishReadyToRunUseCrossgen2)' != 'true' or '@(Crossgen2Tool -> '%(IsVersion5)')' == 'true'">
-    <RunReadyToRunCompiler CrossgenTool="@(CrossgenTool)"
-                           Crossgen2Tool="@(Crossgen2Tool)"
-                           UseCrossgen2="$(PublishReadyToRunUseCrossgen2)"
-                           Crossgen2ExtraCommandLineArgs="$(PublishReadyToRunCrossgen2ExtraArgs)"
-                           ImplementationAssemblyReferences="@(_ReadyToRunAssembliesToReference)"
-                           ShowCompilerWarnings="$(PublishReadyToRunShowWarnings)"
-                           CompilationEntry="@(_ReadyToRunSymbolsCompileList)"
-                           ContinueOnError="ErrorAndContinue">
-      <Output TaskParameter="ExitCode" PropertyName="_ReadyToRunCompilerExitCode" />
-      <Output TaskParameter="WarningsDetected" PropertyName="_ReadyToRunWarningsDetected" />
-    </RunReadyToRunCompiler>
-
-    <PropertyGroup>
-      <!-- Use distinct property here as any of the invocations can set it -->
-      <_ReadyToRunCompilerHasWarnings Condition="'$(_ReadyToRunWarningsDetected)' == 'true'">true</_ReadyToRunCompilerHasWarnings>
-    </PropertyGroup>
-
-    <ItemGroup>
-      <_ReadyToRunCompilationFailures Condition="'$(_ReadyToRunCompilerExitCode)' != '' And $(_ReadyToRunCompilerExitCode) != 0"
-                                      Include="@(_ReadyToRunSymbolsCompileList)" />
-    </ItemGroup>
   </Target>
 
   <!--


### PR DESCRIPTION
- Move it to allow mixed composite and non-composite r2r in the same build, controlled by the PublishReadyToRunCompositeExclusions list
- Enhance the accuracy of how msbuild tracks which files are input vs reference for composite images
- Implement the R2R exclusion list for composite images
- Remove the always on usage of --inputbubble when compiling a composite image

Refactor crossgen2 targets so that all targets specifically associated with Crossgen2 are located in Microsoft.NET.CrossGen.targets
- Add a Crossgen2TasksOverriden flag to indicate that the tasks are overriden and the UsingTask feature should not bring the normal ones into msbuild
- This is all done to better facilitate carrying a completely independent replacement copy in the runtime repo for use during feature development and dogfooding