### PR TITLE
[API Compat] Add StrictMode and support it in type must exist rule

### DIFF
--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/Abstractions/Mappers/AssemblyMapper.cs
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/Abstractions/Mappers/AssemblyMapper.cs
@@ -70,16 +70,21 @@ namespace Microsoft.DotNet.ApiCompatibility.Abstractions
                     Dictionary<INamespaceSymbol, List<INamedTypeSymbol>> typeForwards = ResolveTypeForwards(symbol, Settings.EqualityComparer);
                     foreach (KeyValuePair<INamespaceSymbol, List<INamedTypeSymbol>> kvp in typeForwards)
                     {
-                        NamespaceMapper mapper = AddMapper(kvp.Key);
+                        NamespaceMapper mapper = AddMapper(kvp.Key, checkIfExists: true);
                         mapper.AddForwardedTypes(kvp.Value, side, setIndex);
                     }
 
-                    NamespaceMapper AddMapper(INamespaceSymbol ns)
+                    NamespaceMapper AddMapper(INamespaceSymbol ns, bool checkIfExists = false)
                     {
                         if (!_namespaces.TryGetValue(ns, out NamespaceMapper mapper))
                         {
                             mapper = new NamespaceMapper(Settings, Right.Length);
                             _namespaces.Add(ns, mapper);
+                        }
+
+                        if (checkIfExists && mapper.GetElement(side, setIndex) != null)
+                        {
+                            return mapper;
                         }
 
                         mapper.AddElement(ns, side, setIndex);

--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/Abstractions/Mappers/ElementMapper.cs
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/Abstractions/Mappers/ElementMapper.cs
@@ -80,5 +80,15 @@ namespace Microsoft.DotNet.ApiCompatibility.Abstractions
         {
             return _differences ??= Settings.RuleRunnerFactory.GetRuleRunner().Run(this);
         }
+
+        internal T GetElement(ElementSide side, int setIndex)
+        {
+            if (side == ElementSide.Left)
+            {
+                return Left;
+            }
+
+            return Right[setIndex];
+        }
     }
 }

--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/Abstractions/Rule.cs
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/Abstractions/Rule.cs
@@ -16,5 +16,10 @@ namespace Microsoft.DotNet.ApiCompatibility.Abstractions
         /// </summary>
         /// <param name="context">The context that the <see cref="IRuleRunner"/> creates holding callbacks to get the differences.</param>
         public abstract void Initialize(RuleRunnerContext context);
+
+        /// <summary>
+        /// Flag that rules should use to determine which mode the differences should be calculated.
+        /// </summary>
+        public bool StrictMode { get; set; }
     }
 }

--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/Abstractions/Rule.cs
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/Abstractions/Rule.cs
@@ -11,6 +11,19 @@ namespace Microsoft.DotNet.ApiCompatibility.Abstractions
     public abstract class Rule
     {
         /// <summary>
+        //// Method that is called when the rules are created by the <see cref="IRuleRunner"/> in
+        /// order to do the initial setup for the rule. This method stores the rule settings and calls
+        /// <see cref="Initialize(RuleRunnerContext)"/>.
+        /// </summary>
+        /// <param name="context">The context containing callbacks and settings for the rule to use.</param>
+        /// <param name="settings">The settings for the rule.</param>
+        public void Setup(RuleRunnerContext context, RuleSettings settings)
+        {
+            Settings = settings;
+            Initialize(context);
+        }
+
+        /// <summary>
         /// Method that is called when the rules are created by the <see cref="IRuleRunner"/> in
         /// order to do the initial setup for the rule.
         /// </summary>
@@ -18,8 +31,8 @@ namespace Microsoft.DotNet.ApiCompatibility.Abstractions
         public abstract void Initialize(RuleRunnerContext context);
 
         /// <summary>
-        /// Flag that rules should use to determine which mode the differences should be calculated.
+        /// Settings use by the rules to determine how they should calculate differences.
         /// </summary>
-        public bool StrictMode { get; set; }
+        public RuleSettings Settings { get; private set; }
     }
 }

--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/ApiComparer.cs
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/ApiComparer.cs
@@ -30,6 +30,14 @@ namespace Microsoft.DotNet.ApiCompatibility
         public (string diagnosticId, string memberId)[] IgnoredDifferences { get; set; }
 
         /// <summary>
+        /// Flag indicating whether we should run on strict mode or not.
+        /// If StrictMode is set, the behavior of some rules will change and some other rules will be
+        /// executed when getting the differences. This is useful when you want both sides we are comparing
+        /// to be strictly the same on their surface area.
+        /// </summary>
+        public bool StrictMode { get; set; }
+
+        /// <summary>
         /// Callback function to get the <see cref="ComparingSettings"/> to be used when creating the settings to get the differences.
         /// This callback is called at the beginning of every <see cref="GetDifferences"/> overload.
         /// </summary>
@@ -146,7 +154,7 @@ namespace Microsoft.DotNet.ApiCompatibility
             if (GetComparingSettings != null)
                 return GetComparingSettings();
 
-            return new ComparingSettings(filter: new SymbolAccessibilityBasedFilter(IncludeInternalSymbols));
+            return new ComparingSettings(filter: new SymbolAccessibilityBasedFilter(IncludeInternalSymbols), strictMode: StrictMode);
         }
     }
 }

--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/ComparingSettings.cs
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/ComparingSettings.cs
@@ -34,9 +34,9 @@ namespace Microsoft.DotNet.ApiCompatibility
         /// <param name="ruleRunnerFactory">The factory to create a <see cref="IRuleRunner"/></param>
         /// <param name="filter">The symbol filter.</param>
         /// <param name="equalityComparer">The comparer to map metadata.</param>
-        public ComparingSettings(IRuleRunnerFactory ruleRunnerFactory = null, ISymbolFilter filter = null, IEqualityComparer<ISymbol> equalityComparer = null)
+        public ComparingSettings(IRuleRunnerFactory ruleRunnerFactory = null, ISymbolFilter filter = null, IEqualityComparer<ISymbol> equalityComparer = null, bool strictMode = false)
         {
-            RuleRunnerFactory = ruleRunnerFactory ?? new RuleRunnerFactory();
+            RuleRunnerFactory = ruleRunnerFactory ?? new RuleRunnerFactory(strictMode);
             Filter = filter ?? new SymbolAccessibilityBasedFilter(includeInternalSymbols: false);
             EqualityComparer = equalityComparer ?? new DefaultSymbolsEqualityComparer();
         }

--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/Rules/MembersMustExist.cs
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/Rules/MembersMustExist.cs
@@ -37,7 +37,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
             {
                 AddDifference(left, DifferenceType.Removed, "Type '{0}' exists on the left but not on the right");
             }
-            else if (StrictMode && left == null && right != null)
+            else if (Settings.StrictMode && left == null && right != null)
             {
                 AddDifference(right, DifferenceType.Added, "Type '{0}' exists on the right but not on the left");
             }

--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/Rules/MembersMustExist.cs
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/Rules/MembersMustExist.cs
@@ -5,6 +5,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.DotNet.ApiCompatibility.Abstractions;
 using Microsoft.DotNet.ApiCompatibility.Extensions;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 
 namespace Microsoft.DotNet.ApiCompatibility.Rules
 {
@@ -33,7 +34,19 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
         private void RunOnTypeSymbol(ITypeSymbol left, ITypeSymbol right, IList<CompatDifference> differences)
         {
             if (left != null && right == null)
-                differences.Add(new CompatDifference(DiagnosticIds.TypeMustExist, $"Type '{left.ToDisplayString()}' exists on the left but not on the right", DifferenceType.Removed, left));
+            {
+                AddDifference(left, DifferenceType.Removed, "Type '{0}' exists on the left but not on the right");
+            }
+            else if (StrictMode && left == null && right != null)
+            {
+                AddDifference(right, DifferenceType.Added, "Type '{0}' exists on the right but not on the left");
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            void AddDifference(ITypeSymbol symbol, DifferenceType type, string format)
+            {
+                differences.Add(new CompatDifference(DiagnosticIds.TypeMustExist, string.Format(format, symbol.ToDisplayString()), type, symbol));
+            }
         }
 
         /// <summary>
@@ -93,7 +106,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
         }
 
         private bool ReturnTypesMatch(IMethodSymbol method, IMethodSymbol candidate) =>
-            method.ReturnType.ToDisplayString() == candidate.ReturnType.ToDisplayString();
+            method.ReturnType.ToComparisonDisplayString() == candidate.ReturnType.ToComparisonDisplayString();
 
         private bool ParametersMatch(IMethodSymbol method, IMethodSymbol candidate)
         {
@@ -102,7 +115,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
 
             for (int i = 0; i < method.Parameters.Length; i++)
             {
-                if (method.Parameters[i].Type.ToDisplayString() != method.Parameters[i].Type.ToDisplayString())
+                if (method.Parameters[i].Type.ToComparisonDisplayString() != method.Parameters[i].Type.ToComparisonDisplayString())
                     return false;
             }
 

--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/Rules/RuleRunner.cs
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/Rules/RuleRunner.cs
@@ -11,12 +11,12 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
     internal class RuleRunner : IRuleRunner
     {
         private readonly RuleRunnerContext _context;
-        private readonly bool _strictMode;
+        private readonly RuleSettings _settings;
 
         internal RuleRunner(bool strictMode)
         {
             _context = new RuleRunnerContext();
-            _strictMode = strictMode;
+            _settings = new RuleSettings(strictMode);
             InitializeRules();
         }
 
@@ -66,9 +66,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
             {
                 if (!type.IsAbstract && typeof(Rule).IsAssignableFrom(type))
                 {
-                    var rule = (Rule)Activator.CreateInstance(type);
-                    rule.StrictMode = _strictMode;
-                    rule.Initialize(_context);
+                    ((Rule)Activator.CreateInstance(type)).Setup(_context, _settings);
                 }
             }
 

--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/Rules/RuleRunner.cs
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/Rules/RuleRunner.cs
@@ -11,10 +11,12 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
     internal class RuleRunner : IRuleRunner
     {
         private readonly RuleRunnerContext _context;
+        private readonly bool _strictMode;
 
-        internal RuleRunner()
+        internal RuleRunner(bool strictMode)
         {
             _context = new RuleRunnerContext();
+            _strictMode = strictMode;
             InitializeRules();
         }
 
@@ -63,7 +65,11 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
             foreach (Type type in GetType().Assembly.GetTypes())
             {
                 if (!type.IsAbstract && typeof(Rule).IsAssignableFrom(type))
-                    ((Rule)Activator.CreateInstance(type)).Initialize(_context);
+                {
+                    var rule = (Rule)Activator.CreateInstance(type);
+                    rule.StrictMode = _strictMode;
+                    rule.Initialize(_context);
+                }
             }
 
         }

--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/Rules/RuleRunnerFactory.cs
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/Rules/RuleRunnerFactory.cs
@@ -7,11 +7,18 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
 {
     public class RuleRunnerFactory : IRuleRunnerFactory
     {
+        private readonly bool _strictMode;
         private RuleRunner _driver;
+
+        public RuleRunnerFactory(bool strictMode = false)
+        {
+            _strictMode = strictMode;
+        }
+
         public IRuleRunner GetRuleRunner()
         {
             if (_driver == null)
-                _driver = new RuleRunner();
+                _driver = new RuleRunner(_strictMode);
 
             return _driver;
         }

--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/Rules/RuleSettings.cs
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/Rules/RuleSettings.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.DotNet.ApiCompatibility.Rules
+{
+    public class RuleSettings
+    {
+        public RuleSettings(bool strictMode)
+        {
+            StrictMode = strictMode;
+        }
+
+        public bool StrictMode { get; }
+    }
+}

--- a/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/Rules/TypeMustExistTests.Strict.cs
+++ b/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/Rules/TypeMustExistTests.Strict.cs
@@ -1,0 +1,440 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.DotNet.ApiCompatibility.Abstractions;
+using Xunit;
+
+namespace Microsoft.DotNet.ApiCompatibility.Tests
+{
+    public class TypeMustExistTests_Strict
+    {
+        [Theory]
+        [InlineData("")]
+        [InlineData("CP002")]
+        public void MissingPublicTypesInLeftAreReported(string noWarn)
+        {
+            string leftSyntax = @"
+
+namespace CompatTests
+{
+  public class First { }
+}
+";
+
+            string rightSyntax = @"
+namespace CompatTests
+{
+  public class First { }
+  public class Second { }
+  public record MyRecord(string a, string b);
+  public struct MyStruct { }
+}
+";
+
+            ApiComparer differ = new();
+            differ.NoWarn = noWarn;
+            differ.StrictMode = true;
+            bool enableNullable = false;
+            IAssemblySymbol left = SymbolFactory.GetAssemblyFromSyntax(leftSyntax, enableNullable);
+            IAssemblySymbol right = SymbolFactory.GetAssemblyFromSyntax(rightSyntax, enableNullable);
+            IEnumerable<CompatDifference> differences = differ.GetDifferences(left, right);
+
+            CompatDifference[] expected = new[]
+            {
+                new CompatDifference(DiagnosticIds.TypeMustExist, $"Type 'CompatTests.Second' exists on the right but not on the left", DifferenceType.Added, "T:CompatTests.Second"),
+                new CompatDifference(DiagnosticIds.TypeMustExist, $"Type 'CompatTests.MyRecord' exists on the right but not on the left", DifferenceType.Added, "T:CompatTests.MyRecord"),
+                new CompatDifference(DiagnosticIds.TypeMustExist, $"Type 'CompatTests.MyStruct' exists on the right but not on the left", DifferenceType.Added, "T:CompatTests.MyStruct"),
+            };
+
+            Assert.Equal(expected, differences);
+        }
+
+        [Fact]
+        public void MissingTypeFromTypeForwardOnLeftIsReported()
+        {
+            string forwardedTypeSyntax = @"
+namespace CompatTests
+{
+  public class ForwardedTestType { }
+}
+";
+            string leftSyntax = @"
+namespace CompatTests
+{
+  public class First { }
+}
+";
+
+            string rightSyntax = @"
+[assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(CompatTests.ForwardedTestType))];
+namespace CompatTests
+{
+  public class First { }
+}
+";
+            IAssemblySymbol left = SymbolFactory.GetAssemblyFromSyntax(leftSyntax);
+            IAssemblySymbol right = SymbolFactory.GetAssemblyFromSyntaxWithReferences(rightSyntax, new[] { forwardedTypeSyntax }, includeDefaultReferences: true);
+            ApiComparer differ = new();
+            differ.StrictMode = true;
+            IEnumerable<CompatDifference> differences = differ.GetDifferences(left, right);
+
+            CompatDifference[] expected = new[]
+            {
+                new CompatDifference(DiagnosticIds.TypeMustExist, $"Type 'CompatTests.ForwardedTestType' exists on the right but not on the left", DifferenceType.Added, "T:CompatTests.ForwardedTestType")
+            };
+
+            Assert.Equal(expected, differences);
+        }
+
+        [Fact]
+        public void TypeForwardExistsOnBothNoWarn()
+        {
+            string forwardedTypeSyntax = @"
+namespace CompatTests
+{
+  public class ForwardedTestType { }
+}
+";
+            string syntax = @"
+[assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(CompatTests.ForwardedTestType))]
+namespace CompatTests
+{
+  public class First { }
+}
+";
+            IEnumerable<string> references = new[] { forwardedTypeSyntax };
+            IAssemblySymbol left = SymbolFactory.GetAssemblyFromSyntaxWithReferences(syntax, references, includeDefaultReferences: true);
+            IAssemblySymbol right = SymbolFactory.GetAssemblyFromSyntaxWithReferences(syntax, references, includeDefaultReferences: true);
+            ApiComparer differ = new();
+            differ.StrictMode = true;
+            Assert.Empty(differ.GetDifferences(new[] { left }, new[] { right }));
+        }
+
+        [Fact]
+        public void NoDifferencesReportedWithNoWarn()
+        {
+            
+            string leftSyntax = @"
+namespace CompatTests
+{
+  public class First { }
+}
+";
+
+            string rightSyntax = @"
+
+namespace CompatTests
+{
+  public class First { }
+  public class Second { }
+}
+";
+
+            ApiComparer differ = new();
+            differ.StrictMode = true;
+            differ.NoWarn = DiagnosticIds.TypeMustExist;
+            IAssemblySymbol left = SymbolFactory.GetAssemblyFromSyntax(leftSyntax);
+            IAssemblySymbol right = SymbolFactory.GetAssemblyFromSyntax(rightSyntax);
+            Assert.Empty(differ.GetDifferences(new[] { left }, new[] { right }));
+        }
+
+        [Fact]
+        public void DifferenceIsIgnoredForMemberOnRight()
+        {
+            string leftSyntax = @"
+namespace CompatTests
+{
+  public record First(string a, string b);
+}
+";
+
+            string rightSyntax = @"
+
+namespace CompatTests
+{
+  public record First(string a, string b);
+  public class Second { }
+  public class Third { }
+  public class Fourth { }
+  public enum MyEnum { }
+}
+";
+
+            (string, string)[] ignoredDifferences = new[]
+            {
+                (DiagnosticIds.TypeMustExist, "T:CompatTests.Second"),
+                (DiagnosticIds.TypeMustExist, "T:CompatTests.MyEnum"),
+            };
+
+            ApiComparer differ = new();
+            differ.IgnoredDifferences = ignoredDifferences;
+            differ.StrictMode = true;
+
+            IAssemblySymbol left = SymbolFactory.GetAssemblyFromSyntax(leftSyntax);
+            IAssemblySymbol right = SymbolFactory.GetAssemblyFromSyntax(rightSyntax);
+            IEnumerable<CompatDifference> differences = differ.GetDifferences(new[] { left }, new[] { right });
+
+            CompatDifference[] expected = new[]
+            {
+                new CompatDifference(DiagnosticIds.TypeMustExist, $"Type 'CompatTests.Third' exists on the right but not on the left", DifferenceType.Added, "T:CompatTests.Third"),
+                new CompatDifference(DiagnosticIds.TypeMustExist, $"Type 'CompatTests.Fourth' exists on the right but not on the left", DifferenceType.Added, "T:CompatTests.Fourth")
+            };
+
+            Assert.Equal(expected, differences);
+        }
+
+        [Fact]
+        public static void MissingNestedTypeOnLeftIsReported()
+        {
+            string leftSyntax = @"
+namespace CompatTests
+{
+  public class First
+  {
+  }
+}
+";
+
+            string rightSyntax = @"
+
+namespace CompatTests
+{
+  public class First
+  {
+    public class FirstNested
+    {
+      public class SecondNested { }
+    }
+  }
+}
+";
+
+            ApiComparer differ = new();
+            differ.StrictMode = true;
+            IAssemblySymbol left = SymbolFactory.GetAssemblyFromSyntax(leftSyntax);
+            IAssemblySymbol right = SymbolFactory.GetAssemblyFromSyntax(rightSyntax);
+            IEnumerable<CompatDifference> differences = differ.GetDifferences(new[] { left }, new[] { right });
+
+            List<CompatDifference> expected = new()
+            {
+                new CompatDifference(DiagnosticIds.TypeMustExist, $"Type 'CompatTests.First.FirstNested' exists on the right but not on the left", DifferenceType.Added, "T:CompatTests.First.FirstNested"),
+            };
+
+            Assert.Equal(expected, differences);
+        }
+
+        [Fact]
+        public static void TypesMissingOnBothSidesAreReported()
+        {
+            string leftSyntax = @"
+namespace CompatTests
+{
+  public class LeftType { }
+}
+";
+            string rightSyntax = @"
+namespace CompatTests
+{
+  public class RightType { }
+}
+";
+            ApiComparer differ = new();
+            differ.StrictMode = true;
+            IAssemblySymbol left = SymbolFactory.GetAssemblyFromSyntax(leftSyntax);
+            IAssemblySymbol right = SymbolFactory.GetAssemblyFromSyntax(rightSyntax);
+            IEnumerable<CompatDifference> differences = differ.GetDifferences(left, right);
+
+            List<CompatDifference> expected = new()
+            {
+                new CompatDifference(DiagnosticIds.TypeMustExist, $"Type 'CompatTests.LeftType' exists on the left but not on the right", DifferenceType.Removed, "T:CompatTests.LeftType"),
+                new CompatDifference(DiagnosticIds.TypeMustExist, $"Type 'CompatTests.RightType' exists on the right but not on the left", DifferenceType.Added, "T:CompatTests.RightType"),
+            };
+
+            Assert.Equal(expected, differences);
+        }
+
+        [Fact]
+        public static void MultipleRightsMissingTypesOnLeftAreReported()
+        {
+            string leftSyntax = @"
+
+namespace CompatTests
+{
+  public class First { }
+}
+";
+
+            string[] rightSyntaxes = new[]
+            { @"
+namespace CompatTests
+{
+  public class First { }
+}
+",
+            @"
+namespace CompatTests
+{
+  public class First { }
+  public class Second { }
+}
+",
+            @"
+namespace CompatTests
+{
+  public class First { }
+  public class Third { }
+}
+"};
+
+            ApiComparer differ = new();
+            differ.StrictMode = true;
+            ElementContainer<IAssemblySymbol> left =
+                new(SymbolFactory.GetAssemblyFromSyntax(leftSyntax), new MetadataInformation(string.Empty, string.Empty, "ref"));
+
+            IList<ElementContainer<IAssemblySymbol>> right = SymbolFactory.GetElementContainersFromSyntaxes(rightSyntaxes);
+
+            IEnumerable<(MetadataInformation, MetadataInformation, IEnumerable<CompatDifference>)> differences =
+                differ.GetDifferences(left, right);
+
+            List<(MetadataInformation, MetadataInformation, IEnumerable<CompatDifference>)> expected = new()
+            {
+                (left.MetadataInformation, new MetadataInformation(string.Empty, string.Empty, "runtime-0"), Array.Empty<CompatDifference>()),
+                (left.MetadataInformation, new MetadataInformation(string.Empty, string.Empty, "runtime-1"), new CompatDifference[]
+                {
+                    new CompatDifference(DiagnosticIds.TypeMustExist, $"Type 'CompatTests.Second' exists on the right but not on the left", DifferenceType.Added, "T:CompatTests.Second"),
+                }),
+                (left.MetadataInformation, new MetadataInformation(string.Empty, string.Empty, "runtime-2"), new CompatDifference[]
+                {
+                    new CompatDifference(DiagnosticIds.TypeMustExist, $"Type 'CompatTests.Third' exists on the right but not on the left", DifferenceType.Added, "T:CompatTests.Third"),
+                }),
+            };
+
+            Assert.Equal(expected, differences);
+        }
+
+        [Fact]
+        public static void MultipleRightsMissingNestedTypesOnLeftAreReported()
+        {
+            string leftSyntax = @"
+namespace CompatTests
+{
+  public class First
+  {
+    public class FirstNested
+    {
+      public class SecondNested
+      {
+      }
+    }
+  }
+}
+";
+
+            string[] rightSyntaxes = new[]
+            { @"
+namespace CompatTests
+{
+  public class First
+  {
+    public class FirstNested
+    {
+      public class SecondNested
+      {
+        public class ThirdNested
+        {
+          public string MyField;
+        }
+      }
+    }
+  }
+}
+",
+            @"
+namespace CompatTests
+{
+  public class First
+  {
+    public class FirstNested
+    {
+      public class SecondNested
+      {
+      }
+    }
+  }
+}
+"};
+
+            ApiComparer differ = new();
+            differ.StrictMode = true;
+            ElementContainer<IAssemblySymbol> left =
+                new(SymbolFactory.GetAssemblyFromSyntax(leftSyntax), new MetadataInformation(string.Empty, string.Empty, "ref"));
+
+            IList<ElementContainer<IAssemblySymbol>> right = SymbolFactory.GetElementContainersFromSyntaxes(rightSyntaxes);
+
+            IEnumerable<(MetadataInformation, MetadataInformation, IEnumerable<CompatDifference>)> differences =
+                differ.GetDifferences(left, right);
+
+            List<(MetadataInformation, MetadataInformation, IEnumerable<CompatDifference>)> expected = new()
+            {
+                (left.MetadataInformation, new MetadataInformation(string.Empty, string.Empty, "runtime-0"), new CompatDifference[]
+                {
+                    new CompatDifference(DiagnosticIds.TypeMustExist, $"Type 'CompatTests.First.FirstNested.SecondNested.ThirdNested' exists on the right but not on the left", DifferenceType.Added, "T:CompatTests.First.FirstNested.SecondNested.ThirdNested"),
+                }),
+                (left.MetadataInformation, new MetadataInformation(string.Empty, string.Empty, "runtime-1"), Array.Empty<CompatDifference>()),
+            };
+
+            Assert.Equal(expected, differences);
+        }
+
+        [Fact]
+        public void MultipleRightsMissingTypeForwardInLeftIsReported()
+        {
+            string forwardedTypeSyntax = @"
+namespace CompatTests
+{
+  public class ForwardedTestType { }
+}
+";
+            string leftSyntax = @"
+namespace CompatTests
+{
+}";
+
+            string rightWithForward = @"
+[assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(CompatTests.ForwardedTestType))]
+";
+            string[] rightSyntaxes = new[] { rightWithForward, "namespace CompatTests { internal class Foo { } }", rightWithForward };
+            IEnumerable<string> references = new[] { forwardedTypeSyntax };
+            ElementContainer<IAssemblySymbol> left =
+                new(SymbolFactory.GetAssemblyFromSyntax(leftSyntax), new MetadataInformation(string.Empty, string.Empty, "ref"));
+            IList<ElementContainer<IAssemblySymbol>> right = SymbolFactory.GetElementContainersFromSyntaxes(rightSyntaxes, references, includeDefaultReferences: true);
+
+            ApiComparer differ = new();
+            differ.StrictMode = true;
+            IEnumerable<(MetadataInformation, MetadataInformation, IEnumerable<CompatDifference>)> differences =
+                differ.GetDifferences(left, right);
+
+            List<(MetadataInformation, MetadataInformation, IEnumerable<CompatDifference>)> expected = new()
+            {
+                (left.MetadataInformation, new MetadataInformation(string.Empty, string.Empty, "runtime-0"), new CompatDifference[]
+                {
+                    new CompatDifference(DiagnosticIds.TypeMustExist, $"Type 'CompatTests.ForwardedTestType' exists on the right but not on the left", DifferenceType.Added, "T:CompatTests.ForwardedTestType"),
+                }),
+                (left.MetadataInformation, new MetadataInformation(string.Empty, string.Empty, "runtime-1"), Array.Empty<CompatDifference>()),
+                (left.MetadataInformation, new MetadataInformation(string.Empty, string.Empty, "runtime-2"), new CompatDifference[]
+                {
+                    new CompatDifference(DiagnosticIds.TypeMustExist, $"Type 'CompatTests.ForwardedTestType' exists on the right but not on the left", DifferenceType.Added, "T:CompatTests.ForwardedTestType"),
+                }),
+            };
+
+            Assert.Equal(expected, differences);
+        }
+    }
+}


### PR DESCRIPTION
This allows us to run on StrictMode when running APICompat on compile asset vs implementation or runtime asset.

Also, this implements strict mode support for `TypeMustExist` rule. I will implement it for `MembersMustExist` diagnostic in a separate PR to keep the PR smaller.

Also I fixed a bug that I found while adding tests for the strict mode.