### PR TITLE
Fix test projects which reference self-contained Exes

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -1060,6 +1060,13 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ShouldBeValidatedAsExecutableReference>false</ShouldBeValidatedAsExecutableReference>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(IsTestProject)' == 'true' And '$(ValidateExecutableReferencesMatchSelfContained)' == ''">
+    <!-- Don't generate an error if a test project references a self-contained Exe.  Test projects
+         use an OutputType of Exe but will usually call APIs in a referenced Exe rather than try
+         to run it. -->
+    <ValidateExecutableReferencesMatchSelfContained>false</ValidateExecutableReferencesMatchSelfContained>
+  </PropertyGroup>
+
   <UsingTask TaskName="ValidateExecutableReferences" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
 
   <Target Name="ValidateExecutableReferences"

--- a/src/Tests/Microsoft.NET.Build.Tests/ReferenceExeTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/ReferenceExeTests.cs
@@ -283,7 +283,7 @@ namespace Microsoft.NET.Build.Tests
                 .Should()
                 .Pass();
 
-            new DotnetCommand(Log, "add", "reference", $@"..\{testConsoleProject.Name}")
+            new DotnetCommand(Log, "add", "reference", ".." + Path.DirectorySeparatorChar + testConsoleProject.Name)
                 .WithWorkingDirectory(testProjectDirectory)
                 .Execute()
                 .Should()

--- a/src/Tests/Microsoft.NET.Build.Tests/ReferenceExeTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/ReferenceExeTests.cs
@@ -259,5 +259,41 @@ namespace Microsoft.NET.Build.Tests
 
             RunTest();
         }
+
+        [Theory]
+        [InlineData("xunit")]
+        [InlineData("mstest")]
+        public void TestProjectCanReferenceExe(string testTemplateName)
+        {
+            var testConsoleProject = new TestProject("ConsoleApp")
+            {
+                IsExe = true,
+                TargetFrameworks = "net5.0",
+                RuntimeIdentifier = EnvironmentInfo.GetCompatibleRid()
+            };
+
+            var testAsset = _testAssetsManager.CreateTestProject(testConsoleProject, identifier: testTemplateName);
+
+            var testProjectDirectory = Path.Combine(testAsset.TestRoot, "TestProject");
+            Directory.CreateDirectory(testProjectDirectory);
+
+            new DotnetCommand(Log, "new", testTemplateName)
+                .WithWorkingDirectory(testProjectDirectory)
+                .Execute()
+                .Should()
+                .Pass();
+
+            new DotnetCommand(Log, "add", "reference", $@"..\{testConsoleProject.Name}")
+                .WithWorkingDirectory(testProjectDirectory)
+                .Execute()
+                .Should()
+                .Pass();
+
+            new BuildCommand(Log, testProjectDirectory)
+                .Execute()
+                .Should()
+                .Pass();
+
+        }
     }
 }


### PR DESCRIPTION
Fix #17579

## Description
In #15134, we added an error when a self-contained app references a non self-contained app, or vice versa.  This is because if you are trying to get copies of both apps in the output folder, they won't both work.

However, I didn't consider that test projects are also use the `Exe` OutputType.  So with that change, test projects which reference Exe projects which were self-contained would fail to build.

## Customer Impact
Test projects referencing Exe projects (fairly common, especially for Web projects) which were self-contained (not as common, but enough that at least two projects hit this bug in the preview) would fail to build.  This could be worked around by setting the `ValidateExecutableReferencesMatchSelfContained` property to false, but developers would have to look through our MSBuild code or search for help on the internet to figure out they needed to do that.

## Regression?
- [x] Yes
- [ ] No

Regressed from 5.0.2xx and prior behavior in #15134.

## Risk
- [ ] High
- [ ] Medium
- [x] Low

[Justify the selection above]

The change is to disable the error check for unit test projects, and is a simple code change.

## Verification
- [ ] Manual (required)
- [x] Automated

Added test cases covering failing scenario

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [x] N/A


Addresses [issue number]
https://github.com/dotnet/sdk/issues/17579