### PR TITLE
Fix a couple of issues with dotnet-watch

### DIFF
--- a/src/BuiltInTools/DotNetDeltaApplier/StartupHook.cs
+++ b/src/BuiltInTools/DotNetDeltaApplier/StartupHook.cs
@@ -53,11 +53,6 @@ internal sealed class StartupHook
             Log("Attempting to apply deltas.");
 
             hotReloadAgent.ApplyDeltas(update.Deltas);
-
-            // We want to base this off of mvids, but we'll figure that out eventually.
-            var applyResult = update.ChangedFile is string changedFile && changedFile.EndsWith(".razor", StringComparison.Ordinal) ?
-                ApplyResult.Success :
-                ApplyResult.Success_RefreshBrowser;
             pipeClient.WriteByte((byte)ApplyResult.Success);
 
         }

--- a/src/BuiltInTools/dotnet-watch/HotReload/NamedPipeContract.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/NamedPipeContract.cs
@@ -98,6 +98,5 @@ namespace Microsoft.DotNet.Watcher.Tools
     {
         Failed = -1,
         Success = 0,
-        Success_RefreshBrowser = 1,
     }
 }

--- a/src/BuiltInTools/dotnet-watch/HotReload/ScopedCssFileHandler.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/ScopedCssFileHandler.cs
@@ -39,6 +39,7 @@ namespace Microsoft.DotNet.Watcher.Tools
                 return false;
             }
             await HandleBrowserRefresh(context.BrowserRefreshServer, file, cancellationToken);
+            _reporter.Output("Hot reload of scoped css succeeded.");
             HotReloadEventSource.Log.HotReloadEnd(HotReloadEventSource.StartType.ScopedCssHandler);
             return true;
         }

--- a/src/BuiltInTools/dotnet-watch/HotReload/StaticFileHandler.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/StaticFileHandler.cs
@@ -33,6 +33,7 @@ namespace Microsoft.DotNet.Watcher.Tools
             _reporter.Verbose($"Handling file change event for static content {file.FilePath}.");
             await HandleBrowserRefresh(context.BrowserRefreshServer, file, cancellationToken);
             HotReloadEventSource.Log.HotReloadEnd(HotReloadEventSource.StartType.StaticHandler);
+            _reporter.Output("Hot reload of static file succeeded.");
             return true;
         }
 

--- a/src/BuiltInTools/dotnet-watch/HotReloadDotNetWatcher.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReloadDotNetWatcher.cs
@@ -128,8 +128,7 @@ namespace Microsoft.DotNet.Watcher
                             if (await hotReload.TryHandleFileChange(context, fileItem, combinedCancellationSource.Token))
                             {
                                 var totalTime = TimeSpan.FromTicks(Stopwatch.GetTimestamp() - start);
-                                _reporter.Output($"Hot reload of changes succeeded.");
-                                _reporter.Verbose($"Hot reload applied in {totalTime.TotalMilliseconds}ms.");
+                                _reporter.Verbose($"Hot reload change handled in {totalTime.TotalMilliseconds}ms.");
                             }
                             else
                             {

--- a/src/BuiltInTools/dotnet-watch/Program.cs
+++ b/src/BuiltInTools/dotnet-watch/Program.cs
@@ -67,7 +67,13 @@ Examples:
             // AppContext.BaseDirectory = $sdkRoot\$sdkVersion\DotnetTools\dotnet-watch\$version\tools\net6.0\any\
             // MSBuild.dll is located at $sdkRoot\$sdkVersion\MSBuild.dll
             var sdkRootDirectory = Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "..", "..");
+#if DEBUG
+            // In the usual case, use the SDK that contains the dotnet-watch. However during local testing, it's
+            // much more common to run dotnet-watch from a different SDK. Use the ambient SDK in that case.
+            MSBuildLocator.RegisterDefaults();
+#else
             MSBuildLocator.RegisterMSBuildPath(sdkRootDirectory);
+#endif
 
             Ensure.NotNull(console, nameof(console));
             Ensure.NotNullOrEmpty(workingDirectory, nameof(workingDirectory));


### PR DESCRIPTION
* Print compilation errors in red and don't say hot reload succeeded when there's errors
* Fix an issue where the browser does not refresh after changes
* Fix an issue where deltas are not applied on assemblies loaded after the fact.
* Fix an issue where hot reload no longer works after an app restart.
* Fix a local dev issue to avoid using the local SDK when running dotnet-watch as an executable