### PR TITLE
Add mock dotnet workload update

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-workload/list/WorkloadListCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/list/WorkloadListCommand.cs
@@ -14,6 +14,7 @@ using Microsoft.DotNet.Workloads.Workload.Install;
 using Microsoft.DotNet.Workloads.Workload.Install.InstallRecord;
 using Microsoft.NET.Sdk.WorkloadManifestReader;
 using System.Linq;
+using Microsoft.DotNet.Workloads.Workload.Update;
 
 namespace Microsoft.DotNet.Workloads.Workload.List
 {
@@ -24,6 +25,7 @@ namespace Microsoft.DotNet.Workloads.Workload.List
         private readonly bool _machineReadableOption;
         private readonly IWorkloadInstallationRecordRepository _workloadRecordRepo;
         private readonly SdkFeatureBand _sdkFeatureBand;
+
 
         public WorkloadListCommand(
             ParseResult result,
@@ -40,8 +42,11 @@ namespace Microsoft.DotNet.Workloads.Workload.List
             var workloadManifestProvider = new SdkDirectoryWorkloadManifestProvider(dotnetPath, sdkVersion.ToString());
             var workloadResolver = WorkloadResolver.Create(workloadManifestProvider, dotnetPath, sdkVersion.ToString());
             _sdkFeatureBand = new SdkFeatureBand(sdkVersion);
-            _workloadRecordRepo = workloadRecordRepo ?? 
-                WorkloadInstallerFactory.GetWorkloadInstaller(_reporter, _sdkFeatureBand, workloadResolver, _verbosity).GetWorkloadInstallationRecordRepository();
+            _workloadRecordRepo = workloadRecordRepo ??
+                                  WorkloadInstallerFactory
+                                      .GetWorkloadInstaller(_reporter, _sdkFeatureBand, workloadResolver, _verbosity)
+                                      .GetWorkloadInstallationRecordRepository();
+            _sdkVersion = result.ValueForOption<string>(WorkloadUpdateCommandParser.SdkVersionOption);
         }
 
         public override int Execute()
@@ -49,14 +54,14 @@ namespace Microsoft.DotNet.Workloads.Workload.List
             var installedList = _workloadRecordRepo.GetInstalledWorkloads(_sdkFeatureBand);
             if (_machineReadableOption)
             {
-                var outputJson = new Dictionary<string, string[]>()
-                {
-                    ["installed"] = installedList.Select(id => id.ToString()).ToArray()
-                };
+                var updateAvailable = MockUpdateAvailable();
+                var listOutput = new ListOutput(Installed: installedList.Select(id => id.ToString()).ToArray(),
+                    UpdateAvailable: updateAvailable);
 
                 _reporter.WriteLine("==workloadListJsonOutputStart==");
                 _reporter.WriteLine(
-                    JsonSerializer.Serialize(outputJson));
+                    JsonSerializer.Serialize(listOutput,
+                        options: new JsonSerializerOptions {PropertyNamingPolicy = JsonNamingPolicy.CamelCase}));
                 _reporter.WriteLine("==workloadListJsonOutputEnd==");
             }
             else
@@ -71,5 +76,40 @@ namespace Microsoft.DotNet.Workloads.Workload.List
 
             return 0;
         }
+
+        private UpdateAvailableEntry[] MockUpdateAvailable()
+        {
+            var updateList = new List<UpdateAvailableEntry>();
+
+            if (!File.Exists(Path.Combine(WorkloadUpdateCommand.MockUpdateDirectory,
+                "Microsoft.NET.Workload.Android.6.0.100.nupkg")))
+            {
+                updateList.Add(new UpdateAvailableEntry("6.0.100",
+                    _mockAndroidDescription,
+                    "microsoft-android-sdk-full"));
+            }
+
+            if (!File.Exists(Path.Combine(WorkloadUpdateCommand.MockUpdateDirectory,
+                "Microsoft.iOS.Bundle.6.0.100.nupkg")))
+            {
+                updateList.Add(new UpdateAvailableEntry("6.0.100",
+                    _mockIosDescription,
+                    "microsoft-ios-sdk-full"));
+            }
+
+            return updateList.ToArray();
+        }
+
+        internal record ListOutput(string[] Installed, UpdateAvailableEntry[] UpdateAvailable);
+
+        internal record UpdateAvailableEntry(string ManifestVersion, string Description, string WorkloadId);
+
+        private readonly string _mockIosDescription =
+            $"ios-workload-description: for testing you can delete the content of {WorkloadUpdateCommand.MockUpdateDirectory} to revert the mock update";
+
+        private readonly string _mockAndroidDescription =
+            $"android-workload-description: for testing you can delete the content of {WorkloadUpdateCommand.MockUpdateDirectory} to revert the mock update";
+
+        private readonly string _sdkVersion;
     }
 }

--- a/src/Cli/dotnet/commands/dotnet-workload/list/WorkloadListCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/list/WorkloadListCommandParser.cs
@@ -9,11 +9,7 @@ namespace Microsoft.DotNet.Cli
     internal static class WorkloadListCommandParser
     {
         // arguments are a list of workload to be detected
-        public static readonly Option MachineReadableOption = new Option<bool>("--machine-readable")
-        {
-            IsHidden = true
-        };
-
+        public static readonly Option MachineReadableOption = new Option<bool>("--machine-readable") {IsHidden = true};
         public static readonly Option VerbosityOption = CommonOptions.VerbosityOption();
 
         public static Command GetCommand()
@@ -21,6 +17,7 @@ namespace Microsoft.DotNet.Cli
             var command = new Command("list", LocalizableStrings.CommandDescription);
             command.AddOption(MachineReadableOption);
             command.AddOption(VerbosityOption);
+            command.AddOption(WorkloadUpdateCommandParser.SdkVersionOption);
             return command;
         }
     }

--- a/src/Cli/dotnet/commands/dotnet-workload/update/WorkloadUpdateCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/WorkloadUpdateCommand.cs
@@ -1,25 +1,94 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
+using System.Collections.Generic;
 using System.CommandLine.Parsing;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
 using Microsoft.DotNet.Cli;
 using Microsoft.DotNet.Cli.Utils;
+using Microsoft.DotNet.Configurer;
+using Microsoft.DotNet.MSBuildSdkResolver;
+using NuGet.Protocol;
+using NuGet.Protocol.Core.Types;
+using NuGet.Versioning;
 
 namespace Microsoft.DotNet.Workloads.Workload.Update
 {
     internal class WorkloadUpdateCommand : CommandBase
     {
+        private readonly bool _printDownloadLinkOnly;
+        private readonly string _fromCacheOption;
+
+        public static readonly string MockUpdateDirectory = Path.Combine(Path.GetDirectoryName(Environment.ProcessPath),
+            "DEV_mockworkloads", "update");
+
+        private readonly string _sdkVersion;
+
         public WorkloadUpdateCommand(
-            ParseResult result)
-            : base(result)
+            ParseResult parseResult)
+            : base(parseResult)
         {
+            _printDownloadLinkOnly =
+                parseResult.ValueForOption<bool>(WorkloadInstallCommandParser.PrintDownloadLinkOnlyOption);
+            _fromCacheOption = parseResult.ValueForOption<string>(WorkloadInstallCommandParser.FromCacheOption);
+            _sdkVersion = parseResult.ValueForOption<string>(WorkloadUpdateCommandParser.SdkVersionOption);
         }
 
         public override int Execute()
         {
-            // TODO stub
-            Reporter.Output.WriteLine("WIP workload update");
+            if (_printDownloadLinkOnly || !string.IsNullOrWhiteSpace(_fromCacheOption))
+            {
+                if (string.IsNullOrWhiteSpace(_sdkVersion))
+                {
+                    throw new ArgumentException(
+                        "SDK version is require when using --print-download-link-only option. Since the update may cross version band");
+                }
+
+                SourceRepository source =
+                    Repository.Factory.GetCoreV3("https://www.myget.org/F/mockworkloadfeed/api/v3/index.json");
+                ServiceIndexResourceV3 serviceIndexResource = source.GetResourceAsync<ServiceIndexResourceV3>().Result;
+                IReadOnlyList<Uri> packageBaseAddress =
+                    serviceIndexResource?.GetServiceEntryUris(ServiceTypes.PackageBaseAddress);
+                List<string> allPackageUrl = new List<string>();
+
+                if (_printDownloadLinkOnly)
+                {
+                    allPackageUrl.Add(nupkgUrl(packageBaseAddress.First().ToString(), "Microsoft.iOS.Bundle",
+                        NuGetVersion.Parse("6.0.100")));
+
+                    allPackageUrl.Add(nupkgUrl(packageBaseAddress.First().ToString(), "Microsoft.NET.Workload.Android",
+                        NuGetVersion.Parse("6.0.100")));
+
+                    Reporter.Output.WriteLine("==allPackageLinksJsonOutputStart==");
+                    Reporter.Output.WriteLine(JsonSerializer.Serialize(allPackageUrl));
+                    Reporter.Output.WriteLine("==allPackageLinksJsonOutputEnd==");
+                }
+
+                if (!string.IsNullOrWhiteSpace(_fromCacheOption))
+                {
+                    Directory.CreateDirectory(MockUpdateDirectory);
+
+                    File.Copy(Path.Combine(_fromCacheOption, "Microsoft.NET.Workload.Android.6.0.100.nupkg"),
+                        Path.Combine(MockUpdateDirectory, "Microsoft.NET.Workload.Android.6.0.100.nupkg"));
+
+                    File.Copy(Path.Combine(_fromCacheOption, "Microsoft.iOS.Bundle.6.0.100.nupkg"),
+                        Path.Combine(MockUpdateDirectory, "Microsoft.iOS.Bundle.6.0.100.nupkg"));
+                }
+            }
+            else
+            {
+                throw new NotImplementedException("Only have mock behavior, need '--print-download-link-only'");
+            }
+
             return 0;
         }
+
+        public string nupkgUrl(string baseUri, string id, NuGetVersion version) =>
+            baseUri + id.ToLowerInvariant() + "/" + version.ToNormalizedString() + "/" + id.ToLowerInvariant() +
+            "." +
+            version.ToNormalizedString() + ".nupkg";
     }
 }

--- a/src/Cli/dotnet/commands/dotnet-workload/update/WorkloadUpdateCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/WorkloadUpdateCommandParser.cs
@@ -8,8 +8,6 @@ namespace Microsoft.DotNet.Cli
 {
     internal static class WorkloadUpdateCommandParser
     {
-        public static readonly Argument PackageIdArgument = WorkloadInstallCommandParser.WorkloadIdArgument;
-
         public static readonly Option ConfigOption = WorkloadInstallCommandParser.ConfigOption;
 
         public static readonly Option AddSourceOption = WorkloadInstallCommandParser.AddSourceOption;
@@ -18,14 +16,29 @@ namespace Microsoft.DotNet.Cli
 
         public static readonly Option VerbosityOption = WorkloadInstallCommandParser.VerbosityOption;
 
+        public static readonly Option PrintDownloadLinkOnlyOption =
+            WorkloadInstallCommandParser.PrintDownloadLinkOnlyOption;
+
+        public static readonly Option FromCacheOption =
+            WorkloadInstallCommandParser.FromCacheOption;
+
+        /// <summary>
+        /// VSMac updater could update SDK across feature band. This option is only for VSMac updater
+        /// scenario. If there are breaking change between manifests, we would fail to load the new available update
+        /// we will do best effort in that case.
+        /// </summary>
+        public static readonly Option SdkVersionOption = new Option<string>("--target-sdk-version") {IsHidden = true};
+
         public static Command GetCommand()
         {
             Command command = new("update", LocalizableStrings.CommandDescription);
 
-            command.AddArgument(PackageIdArgument);
             command.AddOption(ConfigOption);
             command.AddOption(AddSourceOption);
             command.AddOption(VersionOption);
+            command.AddOption(PrintDownloadLinkOnlyOption);
+            command.AddOption(FromCacheOption);
+            command.AddOption(SdkVersionOption);
             command.AddOption(WorkloadCommandRestorePassThroughOptions.DisableParallelOption);
             command.AddOption(WorkloadCommandRestorePassThroughOptions.IgnoreFailedSourcesOption);
             command.AddOption(WorkloadCommandRestorePassThroughOptions.NoCacheOption);

--- a/src/Tests/dotnet-workload-list.Tests/GivenDotnetWorkloadList.cs
+++ b/src/Tests/dotnet-workload-list.Tests/GivenDotnetWorkloadList.cs
@@ -49,7 +49,7 @@ namespace Microsoft.DotNet.Cli.Workload.List.Tests
             var command = new WorkloadListCommand(_machineReadableParseResult, _reporter, workloadInstaller, "6.0.100");
             command.Execute();
 
-            _reporter.Lines.Should().Contain(@"{""installed"":[]}");
+            _reporter.Lines.Should().Contain(l => l.Contains(@"""installed"":[]"));
         }
 
         [Fact]
@@ -76,7 +76,7 @@ namespace Microsoft.DotNet.Cli.Workload.List.Tests
             var command = new WorkloadListCommand(_machineReadableParseResult, _reporter, workloadInstaller, "6.0.100");
             command.Execute();
 
-            _reporter.Lines.Should().Contain(@"{""installed"":[""mock-workload-1"",""mock-workload-2"",""mock-workload-3""]}");
+            _reporter.Lines.Should().Contain(l => l.Contains("{\"installed\":[\"mock-workload-1\",\"mock-workload-2\",\"mock-workload-3\"]"));
         }
     }
 }


### PR DESCRIPTION
Workload update flow. Currently in mock.

# display available update

```shell
dotnet workload list --machine-readable --target-sdk-version 6.0.200
```

--target-sdk-version should also be set by VSMac updater. Since VSMac updater could update .NET SDK from one version band to the other, say 6.0.100 to 6.0.200. And .NET SDK need to know the version band of the targeting SDK (in this case 6.0.200). VSMac updater should always pass the .NET SDK version that it installed.

Response:

```shell
==workloadListJsonOutputStart==
{"installed":[],"updateAvailable":[{"manifestVersion":"6.0.100","description":"android-workload-description: for testing you can delete the content of C:\\work\\sdk\\artifacts\\bin\\redist\\Debug\\dotnet\\DEV_mockworkloads\\update to revert the mock update","workloadId":"microsoft-android-sdk-full"},{"manifestVersion":"6.0.100","description":"ios-workload-description: for testing you can delete the content of C:\\work\\sdk\\artifacts\\bin\\redist\\Debug\\dotnet\\DEV_mockworkloads\\update to revert the mock update","workloadId":"microsoft-ios-sdk-full"}]}
==workloadListJsonOutputEnd==
```

VSMac updater should read the updateAvailable session. _workloadId_, _description_ should also be displayed to the user. The mock implementation does not take what is installed in to consideration. The real implementation would.

# download files

Similar to VSMac installer. VSMac update would download the package itself while asking for the URLS to download. Note, if the user decide the update, all workload would be updated. VSMac updater should reflect that.

```shell
 dotnet workload update --print-download-link-only --target-sdk-version 6.0.200
```

```shell
==allPackageLinksJsonOutputStart==
["https://www.myget.org/F/mockworkloadfeed/api/v3/flatcontainer/microsoft.ios.bundle/6.0.100/microsoft.ios.bundle.6.0.100.nupkg","https://www.myget.org/F/mockworkloadfeed/api/v3/flatcontainer/microsoft.net.workload.android/6.0.100/microsoft.net.workload.android.6.0.100.nupkg"]
==allPackageLinksJsonOutputEnd==
```

# finish update

```shell
dotnet workload update --from-cache /vsmacupdater/tempfolder --target-sdk-version 6.0.200
```

return code 0 means success. This command has no output.

/vsmacupdater/tempfolder is the temp location of VSMac updater. VSMac updater should be in charge of cleaning up when update is done.

Mock uses folder `DEV_mockworkloads\update` that is sitting in the same root folder as dotnet executable. You can delete the entire folder to set the environment back. And since all operation happens in a root access location, sudo are required. This is also true for the real implementation.