### PR TITLE
Update property name in `TargetFrameworkEval` telemetry event

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-msbuild/MSBuildLogger.cs
+++ b/src/Cli/dotnet/commands/dotnet-msbuild/MSBuildLogger.cs
@@ -14,16 +14,17 @@ namespace Microsoft.DotNet.Tools.MSBuild
 {
     public sealed class MSBuildLogger : INodeLogger
     {
-        private readonly IFirstTimeUseNoticeSentinel _sentinel =
-            new FirstTimeUseNoticeSentinel();
+        private readonly IFirstTimeUseNoticeSentinel _sentinel = new FirstTimeUseNoticeSentinel();
         private readonly ITelemetry _telemetry;
-        private const string NewEventName = "msbuild";
-        internal const string TargetFrameworkTelemetryEventName = "targetframeworkeval";
-        internal const string SdkTaskBaseCatchExceptionTelemetryEventName = "taskBaseCatchException";
+
+        private const string MSBuildEventName = "MSBuild";
+
+        internal const string TargetFrameworkTelemetryEventName = "TargetFrameworkEval";
+        internal const string SdkTaskBaseCatchExceptionTelemetryEventName = "TaskBaseCatchException";
         internal const string PublishPropertiesTelemetryEventName = "PublishProperties";
         internal const string ReadyToRunTelemetryEventName = "ReadyToRun";
 
-        internal const string TargetFrameworkVersionTelemetryPropertyKey = "TargetFrameworkVersion";
+        internal const string TargetFrameworkMonikerTelemetryPropertyKey = "TargetFrameworkMoniker";
         internal const string RuntimeIdentifierTelemetryPropertyKey = "RuntimeIdentifier";
         internal const string SelfContainedTelemetryPropertyKey = "SelfContained";
         internal const string UseApphostTelemetryPropertyKey = "UseApphost";
@@ -81,16 +82,19 @@ namespace Microsoft.DotNet.Tools.MSBuild
         {
             if (args.EventName == TargetFrameworkTelemetryEventName)
             {
-                var newEventName = $"msbuild/{TargetFrameworkTelemetryEventName}";
+                var newEventName = $"{MSBuildEventName}/{TargetFrameworkTelemetryEventName}";
                 Dictionary<string, string> maskedProperties = new Dictionary<string, string>();
 
-                foreach (var key in new[] {
-                    TargetFrameworkVersionTelemetryPropertyKey,
+                var telemetryKeys = new[]
+                {
+                    TargetFrameworkMonikerTelemetryPropertyKey,
                     RuntimeIdentifierTelemetryPropertyKey,
                     SelfContainedTelemetryPropertyKey,
                     UseApphostTelemetryPropertyKey,
                     OutputTypeTelemetryPropertyKey
-                })
+                };
+
+                foreach (var key in telemetryKeys)
                 {
                     if (args.Properties.TryGetValue(key, out string value))
                     {
@@ -101,10 +105,12 @@ namespace Microsoft.DotNet.Tools.MSBuild
                 telemetry.TrackEvent(newEventName, maskedProperties, measurements: null);
             }
 
-            var passthroughEvents = new string[] {
-                    SdkTaskBaseCatchExceptionTelemetryEventName,
-                    PublishPropertiesTelemetryEventName,
-                    ReadyToRunTelemetryEventName };
+            var passthroughEvents = new[]
+            {
+                SdkTaskBaseCatchExceptionTelemetryEventName,
+                PublishPropertiesTelemetryEventName,
+                ReadyToRunTelemetryEventName
+            };
 
             if (passthroughEvents.Contains(args.EventName))
             {

--- a/src/Tasks/Common/TaskBase.cs
+++ b/src/Tasks/Common/TaskBase.cs
@@ -43,7 +43,7 @@ namespace Microsoft.NET.Build.Tasks
             }
             catch (Exception e)
             {
-                LogErrorTelemetry("taskBaseCatchException", e);
+                LogErrorTelemetry("TaskBaseCatchException", e);
                 throw;
             }
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.TargetFrameworkInference.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.TargetFrameworkInference.targets
@@ -114,7 +114,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <UsingTask TaskName="AllowEmptyTelemetry" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
 
   <Target Name="_CollectTargetFrameworkForTelemetry" AfterTargets="_CheckForUnsupportedTargetFramework">
-    <AllowEmptyTelemetry EventName="targetframeworkeval" EventData="TargetFrameworkVersion=$([MSBuild]::Escape('$(TargetFrameworkMoniker)'));RuntimeIdentifier=$(RuntimeIdentifier);SelfContained=$(SelfContained);UseApphost=$(UseApphost);OutputType=$(OutputType)" />
+    <AllowEmptyTelemetry EventName="TargetFrameworkEval" EventData="TargetFrameworkMoniker=$([MSBuild]::Escape('$(TargetFrameworkMoniker)'));RuntimeIdentifier=$(RuntimeIdentifier);SelfContained=$(SelfContained);UseApphost=$(UseApphost);OutputType=$(OutputType)" />
   </Target>
 
   <!--

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildANetCoreAppForTelemetry.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildANetCoreAppForTelemetry.cs
@@ -18,19 +18,19 @@ namespace Microsoft.NET.Build.Tests
         }
 
         [CoreMSBuildOnlyFact]
-        public void It_collects_TargetFramework_version_and_other_properties()
+        public void It_collects_single_TargetFramework_moniker_and_other_properties()
         {
             string targetFramework = "netcoreapp1.0";
             var testProject = new TestProject()
             {
-                Name = "FrameworkTargetTelemetryTest",
+                Name = "TelemetryTest-SingleTarget",
                 TargetFrameworks = targetFramework,
             };
             Type loggerType = typeof(LogTelemetryToStdOutForTest);
             var TelemetryTestLogger = new[]
-                {
-                    $"/Logger:{loggerType.FullName},{loggerType.GetTypeInfo().Assembly.Location}"
-                };
+            {
+                $"/Logger:{loggerType.FullName},{loggerType.GetTypeInfo().Assembly.Location}"
+            };
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
             var buildCommand = new BuildCommand(testAsset);
@@ -38,24 +38,23 @@ namespace Microsoft.NET.Build.Tests
             buildCommand
                 .Execute(TelemetryTestLogger)
                 .StdOut.Should()
-                .Contain("{\"EventName\":\"targetframeworkeval\",\"Properties\":{\"TargetFrameworkVersion\":\".NETCoreApp,Version=v1.0\",\"RuntimeIdentifier\":\"null\",\"SelfContained\":\"null\",\"UseApphost\":\"null\",\"OutputType\":\"Library\"}");
+                .Contain("{\"EventName\":\"TargetFrameworkEval\",\"Properties\":{\"TargetFrameworkMoniker\":\".NETCoreApp,Version=v1.0\",\"RuntimeIdentifier\":\"null\",\"SelfContained\":\"null\",\"UseApphost\":\"null\",\"OutputType\":\"Library\"}");
         }
 
         [CoreMSBuildOnlyFact]
-        public void It_collects_multi_TargetFramework_version_and_other_properties()
+        public void It_collects_multiple_TargetFramework_monikers_and_other_properties()
         {
-            string targetFramework = "net46;netcoreapp1.1";
-
+            string targetFrameworks = "net46;netcoreapp1.1";
             var testProject = new TestProject()
             {
-                Name = "MultitargetTelemetry",
-                TargetFrameworks = targetFramework,
+                Name = "TelemetryTest-MultipleTargets",
+                TargetFrameworks = targetFrameworks,
             };
             Type loggerType = typeof(LogTelemetryToStdOutForTest);
             var TelemetryTestLogger = new[]
-                {
-                    $"/Logger:{loggerType.FullName},{loggerType.GetTypeInfo().Assembly.Location}"
-                };
+            {
+                $"/Logger:{loggerType.FullName},{loggerType.GetTypeInfo().Assembly.Location}"
+            };
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
             var buildCommand = new BuildCommand(testAsset);
@@ -64,10 +63,10 @@ namespace Microsoft.NET.Build.Tests
                 .Execute(TelemetryTestLogger)
                 .StdOut.Should()
                 .Contain(
-                    "{\"EventName\":\"targetframeworkeval\",\"Properties\":{\"TargetFrameworkVersion\":\".NETFramework,Version=v4.6\",\"RuntimeIdentifier\":\"null\",\"SelfContained\":\"null\",\"UseApphost\":\"null\",\"OutputType\":\"Library\"}")
+                    "{\"EventName\":\"TargetFrameworkEval\",\"Properties\":{\"TargetFrameworkMoniker\":\".NETFramework,Version=v4.6\",\"RuntimeIdentifier\":\"null\",\"SelfContained\":\"null\",\"UseApphost\":\"null\",\"OutputType\":\"Library\"}")
                 .And
                 .Contain(
-                    "{\"EventName\":\"targetframeworkeval\",\"Properties\":{\"TargetFrameworkVersion\":\".NETCoreApp,Version=v1.1\",\"RuntimeIdentifier\":\"null\",\"SelfContained\":\"null\",\"UseApphost\":\"null\",\"OutputType\":\"Library\"}");
+                    "{\"EventName\":\"TargetFrameworkEval\",\"Properties\":{\"TargetFrameworkMoniker\":\".NETCoreApp,Version=v1.1\",\"RuntimeIdentifier\":\"null\",\"SelfContained\":\"null\",\"UseApphost\":\"null\",\"OutputType\":\"Library\"}");
         }
     }
 }

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToCollectExceptionTelemetry.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToCollectExceptionTelemetry.cs
@@ -31,7 +31,7 @@ namespace Microsoft.NET.Build.Tests
             mSBuildCommand
                 .Execute(telemetryTestLogger, causeTaskToFail)
                 .StdOut.Should()
-                .Contain("\"EventName\":\"taskBaseCatchException\",\"Properties\":{\"exceptionType\":\"System.IO.FileNotFoundException\"")
+                .Contain("\"EventName\":\"TaskBaseCatchException\",\"Properties\":{\"exceptionType\":\"System.IO.FileNotFoundException\"")
                 .And.Contain("detail");
         }
     }

--- a/src/Tests/dotnet.Tests/dotnet-msbuild/GivenMSBuildLogger.cs
+++ b/src/Tests/dotnet.Tests/dotnet-msbuild/GivenMSBuildLogger.cs
@@ -103,10 +103,10 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
             var fakeTelemetry = new FakeTelemetry();
             var telemetryEventArgs = new TelemetryEventArgs
             {
-                EventName = "targetframeworkeval",
+                EventName = "TargetFrameworkEval",
                 Properties = new Dictionary<string, string>
                 {
-                    { "TargetFrameworkVersion", ".NETFramework,Version=v4.6"},
+                    { "TargetFrameworkMoniker", ".NETFramework,Version=v4.6"},
                     { "RuntimeIdentifier", "null"},
                     { "SelfContained", "null"},
                     { "UseApphost", "null"},
@@ -118,7 +118,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
 
             fakeTelemetry.LogEntry.Properties.ShouldBeEquivalentTo(new Dictionary<string, string>
                 {
-                    { "TargetFrameworkVersion", "9a871d7066260764d4cb5047e4b10570271d04bd1da275681a4b12bce0b27496"},
+                    { "TargetFrameworkMoniker", "9a871d7066260764d4cb5047e4b10570271d04bd1da275681a4b12bce0b27496"},
                     { "RuntimeIdentifier", "fb329000228cc5a24c264c57139de8bf854fc86fc18bf1c04ab61a2b5cb4b921"},
                     { "SelfContained", "fb329000228cc5a24c264c57139de8bf854fc86fc18bf1c04ab61a2b5cb4b921"},
                     { "UseApphost", "fb329000228cc5a24c264c57139de8bf854fc86fc18bf1c04ab61a2b5cb4b921"},


### PR DESCRIPTION
#### CHANGES

Update the property name in `TargetFrameworkEval` telemetry event to use the correct terminology.
Here, the `TargetFramerworkMoniker` is being sent but the property name used is `TargetFrameworkVersion`.

#### NOTES

These are some of the missed refactoring, case changes and incorrect names
that might've been overlooked in this section of the .NET SDK's codebase.

_Since, this involves a change in how the data is sent, server-side update with similar changes may be necessary._