### PR TITLE
SDK support for runtime native host and COM changes

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ILLink.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ILLink.targets
@@ -52,15 +52,37 @@ Copyright (c) .NET Foundation. All rights reserved.
     <EnableUnsafeBinaryFormatterInDesigntimeLicenseContextSerialization>false</EnableUnsafeBinaryFormatterInDesigntimeLicenseContextSerialization>
   </PropertyGroup>
 
-  <!-- We disable in-built COM support for trimmed apps here so that the feature
-       switch can flow to the runtimeconfig.json. Built-in COM support is disabled
+  <!-- We disable in-built COM Interop support for trimmed apps here so that the feature
+       switch can flow to the runtimeconfig.json. Built-in COM Interop support is disabled
        by default since they may require assemblies, types or members that
        could be removed by the linker, causing a trimmed app to crash. -->
-  <PropertyGroup Condition="'$(BuiltInComSupport)' == '' And
+  <PropertyGroup Condition="'$(BuiltInComInteropSupport)' == '' And
                             '$(PublishTrimmed)' == 'true' And
                             $([MSBuild]::VersionGreaterThanOrEquals($(_TargetFrameworkVersionWithoutV), '6.0'))">
-    <BuiltInComSupport>false</BuiltInComSupport>
-  </PropertyGroup>  
+    <BuiltInComInteropSupport>false</BuiltInComInteropSupport>
+  </PropertyGroup>
+
+  <!-- We disable Native Host entry point support for IJW (C++/CLI Assemblies) for trimmed
+       apps here so that the feature switch can flow to the runtimeconfig.json. 
+       Native Host entry point support is disabled
+       by default since they may require assemblies, types or members that
+       could be removed by the linker, causing a trimmed app to crash. -->
+  <PropertyGroup Condition="'$(EnableCPlusPlusCLIHostActivation)' == '' And
+                            '$(PublishTrimmed)' == 'true' And
+                            $([MSBuild]::VersionGreaterThanOrEquals($(_TargetFrameworkVersionWithoutV), '6.0'))">
+    <EnableCPlusPlusCLIHostActivation>false</EnableCPlusPlusCLIHostActivation>
+  </PropertyGroup>
+
+  <!-- We disable Native Host entry point support for loading managed components for trimmed
+       apps here so that the feature switch can flow to the runtimeconfig.json. 
+       Native Host entry point support is disabled
+       by default since they may require assemblies, types or members that
+       could be removed by the linker, causing a trimmed app to crash. -->
+  <PropertyGroup Condition="'$(_EnableCallingManagedFunctionFromNativeHosting)' == '' And
+                            '$(PublishTrimmed)' == 'true' And
+                            $([MSBuild]::VersionGreaterThanOrEquals($(_TargetFrameworkVersionWithoutV), '6.0'))">
+    <_EnableCallingManagedFunctionFromNativeHosting>false</_EnableCallingManagedFunctionFromNativeHosting>
+  </PropertyGroup>
 
   <PropertyGroup Condition="'$(SuppressTrimAnalysisWarnings)' == '' And ('$(EnableTrimAnalyzer)' == 'true' Or '$(PublishTrimmed)' == 'true')">
     <!-- Trim analysis warnings are suppressed for .NET < 6. -->

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ILLink.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ILLink.targets
@@ -27,61 +27,19 @@ Copyright (c) .NET Foundation. All rights reserved.
     </AssemblyAttribute>
   </ItemGroup>
 
-  <!-- We disable startup hooks for trimmed apps here so that the feature
-       switch can flow to the runtimeconfig.json. Startup hooks are disabled
-       by default since they may require assemblies, types or members that
-       could be removed by the linker, causing a trimmed app to crash. -->
-  <PropertyGroup Condition="'$(StartupHookSupport)' == '' And
-                            '$(PublishTrimmed)' == 'true' And
-                            $([MSBuild]::VersionGreaterThanOrEquals($(_TargetFrameworkVersionWithoutV), '6.0'))">
-    <StartupHookSupport>false</StartupHookSupport>
-  </PropertyGroup>
 
-  <!-- We disable custom resource types for trimmed apps here so that the feature
-       switch can flow to the runtimeconfig.json. Custom resource types are disabled
-       by default since they may require assemblies, types or members that
-       could be removed by the linker, causing a trimmed app to crash. -->
-  <PropertyGroup Condition="'$(CustomResourceTypesSupport)' == '' And
-                            '$(PublishTrimmed)' == 'true' And
+  <!-- We disable features for trimmed apps here so that the feature
+      switches can flow to the runtimeconfig.json. Features are disabled
+      by default since they may require assemblies, types or members that
+      could be removed by the linker, causing a trimmed app to crash. -->
+  <PropertyGroup Condition="'$(PublishTrimmed)' == 'true' And
                             $([MSBuild]::VersionGreaterThanOrEquals($(_TargetFrameworkVersionWithoutV), '6.0'))">
-    <CustomResourceTypesSupport>false</CustomResourceTypesSupport>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(EnableUnsafeBinaryFormatterInDesigntimeLicenseContextSerialization)' == '' And
-                            '$(PublishTrimmed)' == 'true' And
-                            $([MSBuild]::VersionGreaterThanOrEquals($(_TargetFrameworkVersionWithoutV), '6.0'))">
-    <EnableUnsafeBinaryFormatterInDesigntimeLicenseContextSerialization>false</EnableUnsafeBinaryFormatterInDesigntimeLicenseContextSerialization>
-  </PropertyGroup>
-
-  <!-- We disable in-built COM Interop support for trimmed apps here so that the feature
-       switch can flow to the runtimeconfig.json. Built-in COM Interop support is disabled
-       by default since they may require assemblies, types or members that
-       could be removed by the linker, causing a trimmed app to crash. -->
-  <PropertyGroup Condition="'$(BuiltInComInteropSupport)' == '' And
-                            '$(PublishTrimmed)' == 'true' And
-                            $([MSBuild]::VersionGreaterThanOrEquals($(_TargetFrameworkVersionWithoutV), '6.0'))">
-    <BuiltInComInteropSupport>false</BuiltInComInteropSupport>
-  </PropertyGroup>
-
-  <!-- We disable Native Host entry point support for IJW (C++/CLI Assemblies) for trimmed
-       apps here so that the feature switch can flow to the runtimeconfig.json. 
-       Native Host entry point support is disabled
-       by default since they may require assemblies, types or members that
-       could be removed by the linker, causing a trimmed app to crash. -->
-  <PropertyGroup Condition="'$(EnableCPlusPlusCLIHostActivation)' == '' And
-                            '$(PublishTrimmed)' == 'true' And
-                            $([MSBuild]::VersionGreaterThanOrEquals($(_TargetFrameworkVersionWithoutV), '6.0'))">
-    <EnableCPlusPlusCLIHostActivation>false</EnableCPlusPlusCLIHostActivation>
-  </PropertyGroup>
-
-  <!-- We disable Native Host entry point support for loading managed components for trimmed
-       apps here so that the feature switch can flow to the runtimeconfig.json. 
-       Native Host entry point support is disabled
-       by default since they may require assemblies, types or members that
-       could be removed by the linker, causing a trimmed app to crash. -->
-  <PropertyGroup Condition="'$(_EnableCallingManagedFunctionFromNativeHosting)' == '' And
-                            '$(PublishTrimmed)' == 'true' And
-                            $([MSBuild]::VersionGreaterThanOrEquals($(_TargetFrameworkVersionWithoutV), '6.0'))">
-    <_EnableCallingManagedFunctionFromNativeHosting>false</_EnableCallingManagedFunctionFromNativeHosting>
+    <StartupHookSupport Condition="'$(StartupHookSupport)' == ''">false</StartupHookSupport>
+    <CustomResourceTypesSupport Condition="'$(CustomResourceTypesSupport)' == ''">false</CustomResourceTypesSupport>
+    <EnableUnsafeBinaryFormatterInDesigntimeLicenseContextSerialization Condition="'$(EnableUnsafeBinaryFormatterInDesigntimeLicenseContextSerialization)' == ''">false</EnableUnsafeBinaryFormatterInDesigntimeLicenseContextSerialization>
+    <BuiltInComInteropSupport Condition="'$(BuiltInComInteropSupport)' == ''">false</BuiltInComInteropSupport>
+    <EnableCPlusPlusCLIHostActivation Condition="'$(EnableCPlusPlusCLIHostActivation)' == ''">false</EnableCPlusPlusCLIHostActivation>
+    <_EnableCallingManagedFunctionFromNativeHosting Condition="'$(_EnableCallingManagedFunctionFromNativeHosting)' == ''">false</_EnableCallingManagedFunctionFromNativeHosting>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(SuppressTrimAnalysisWarnings)' == '' And ('$(EnableTrimAnalyzer)' == 'true' Or '$(PublishTrimmed)' == 'true')">

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ILLink.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ILLink.targets
@@ -38,8 +38,8 @@ Copyright (c) .NET Foundation. All rights reserved.
     <CustomResourceTypesSupport Condition="'$(CustomResourceTypesSupport)' == ''">false</CustomResourceTypesSupport>
     <EnableUnsafeBinaryFormatterInDesigntimeLicenseContextSerialization Condition="'$(EnableUnsafeBinaryFormatterInDesigntimeLicenseContextSerialization)' == ''">false</EnableUnsafeBinaryFormatterInDesigntimeLicenseContextSerialization>
     <BuiltInComInteropSupport Condition="'$(BuiltInComInteropSupport)' == ''">false</BuiltInComInteropSupport>
-    <EnableCPlusPlusCLIHostActivation Condition="'$(EnableCPlusPlusCLIHostActivation)' == ''">false</EnableCPlusPlusCLIHostActivation>
-    <_EnableCallingManagedFunctionFromNativeHosting Condition="'$(_EnableCallingManagedFunctionFromNativeHosting)' == ''">false</_EnableCallingManagedFunctionFromNativeHosting>
+    <EnableCppCLIHostActivation Condition="'$(EnableCppCLIHostActivation)' == ''">false</EnableCppCLIHostActivation>
+    <_EnableConsumingManagedCodeFromNativeHosting Condition="'$(_EnableConsumingManagedCodeFromNativeHosting)' == ''">false</_EnableConsumingManagedCodeFromNativeHosting>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(SuppressTrimAnalysisWarnings)' == '' And ('$(EnableTrimAnalyzer)' == 'true' Or '$(PublishTrimmed)' == 'true')">

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -416,14 +416,14 @@ Copyright (c) .NET Foundation. All rights reserved.
                                     Value="$(BuiltInComInteropSupport)"
                                     Trim="true" />
 
-    <RuntimeHostConfigurationOption Include="System.Runtime.InteropServices.CallingManagedFunctionFromNativeHosting.IsSupported"
-                                    Condition="'$(_EnableCallingManagedFunctionFromNativeHosting)' != ''"
-                                    Value="$(_EnableCallingManagedFunctionFromNativeHosting)"
+    <RuntimeHostConfigurationOption Include="System.Runtime.InteropServices.EnableConsumingManagedCodeFromNativeHosting"
+                                    Condition="'$(_EnableConsumingManagedCodeFromNativeHosting)' != ''"
+                                    Value="$(_EnableConsumingManagedCodeFromNativeHosting)"
                                     Trim="true" />
 
-    <RuntimeHostConfigurationOption Include="System.Runtime.InteropServices.CPlusPlusCLIHostActivation.IsSupported"
-                                    Condition="'$(EnableCPlusPlusCLIHostActivation)' != ''"
-                                    Value="$(EnableCPlusPlusCLIHostActivation)"
+    <RuntimeHostConfigurationOption Include="System.Runtime.InteropServices.EnableCppCLIHostActivation"
+                                    Condition="'$(EnableCppCLIHostActivation)' != ''"
+                                    Value="$(EnableCppCLIHostActivation)"
                                     Trim="true" />
 
     <RuntimeHostConfigurationOption Include="System.Runtime.Serialization.EnableUnsafeBinaryFormatterSerialization"

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -359,9 +359,14 @@ Copyright (c) .NET Foundation. All rights reserved.
     -->
 
   <ItemGroup>
-    <RuntimeHostConfigurationOption Include=" System.Runtime.InteropServices.Marshal.IsBuiltInComSupported"
-                                    Condition="'$(BuiltInComSupport)' != ''"
-                                    Value="$(BuiltInComSupport)"
+    <RuntimeHostConfigurationOption Include="Internal.Runtime.InteropServices.ComponentActivator.IsSupported"
+                                    Condition="'$(_EnableCallingManagedFunctionFromNativeHosting)' != ''"
+                                    Value="$(_EnableCallingManagedFunctionFromNativeHosting)"
+                                    Trim="true" />
+
+    <RuntimeHostConfigurationOption Include="Internal.Runtime.InteropServices.InMemoryAssemblyLoader.IsSupported"
+                                    Condition="'$(EnableCPlusPlusCLIHostActivation)' != ''"
+                                    Value="$(EnableCPlusPlusCLIHostActivation)"
                                     Trim="true" />
 
     <RuntimeHostConfigurationOption Include="System.ComponentModel.TypeConverter.EnableUnsafeBinaryFormatterInDesigntimeLicenseContextSerialization"
@@ -414,6 +419,11 @@ Copyright (c) .NET Foundation. All rights reserved.
     <RuntimeHostConfigurationOption Include="System.Resources.UseSystemResourceKeys"
                                     Condition="'$(UseSystemResourceKeys)' != ''"
                                     Value="$(UseSystemResourceKeys)"
+                                    Trim="true" />
+
+    <RuntimeHostConfigurationOption Include="System.Runtime.InteropServices.BuiltInComInterop.IsSupported"
+                                    Condition="'$(BuiltInComInteropSupport)' != ''"
+                                    Value="$(BuiltInComInteropSupport)"
                                     Trim="true" />
 
     <RuntimeHostConfigurationOption Include="System.Runtime.Serialization.EnableUnsafeBinaryFormatterSerialization"

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -359,16 +359,6 @@ Copyright (c) .NET Foundation. All rights reserved.
     -->
 
   <ItemGroup>
-    <RuntimeHostConfigurationOption Include="Internal.Runtime.InteropServices.ComponentActivator.IsSupported"
-                                    Condition="'$(_EnableCallingManagedFunctionFromNativeHosting)' != ''"
-                                    Value="$(_EnableCallingManagedFunctionFromNativeHosting)"
-                                    Trim="true" />
-
-    <RuntimeHostConfigurationOption Include="Internal.Runtime.InteropServices.InMemoryAssemblyLoader.IsSupported"
-                                    Condition="'$(EnableCPlusPlusCLIHostActivation)' != ''"
-                                    Value="$(EnableCPlusPlusCLIHostActivation)"
-                                    Trim="true" />
-
     <RuntimeHostConfigurationOption Include="System.ComponentModel.TypeConverter.EnableUnsafeBinaryFormatterInDesigntimeLicenseContextSerialization"
                                     Condition="'$(EnableUnsafeBinaryFormatterInDesigntimeLicenseContextSerialization)' != ''"
                                     Value="$(EnableUnsafeBinaryFormatterInDesigntimeLicenseContextSerialization)"
@@ -424,6 +414,16 @@ Copyright (c) .NET Foundation. All rights reserved.
     <RuntimeHostConfigurationOption Include="System.Runtime.InteropServices.BuiltInComInterop.IsSupported"
                                     Condition="'$(BuiltInComInteropSupport)' != ''"
                                     Value="$(BuiltInComInteropSupport)"
+                                    Trim="true" />
+
+    <RuntimeHostConfigurationOption Include="System.Runtime.InteropServices.CallingManagedFunctionFromNativeHosting.IsSupported"
+                                    Condition="'$(_EnableCallingManagedFunctionFromNativeHosting)' != ''"
+                                    Value="$(_EnableCallingManagedFunctionFromNativeHosting)"
+                                    Trim="true" />
+
+    <RuntimeHostConfigurationOption Include="System.Runtime.InteropServices.CPlusPlusCLIHostActivation.IsSupported"
+                                    Condition="'$(EnableCPlusPlusCLIHostActivation)' != ''"
+                                    Value="$(EnableCPlusPlusCLIHostActivation)"
                                     Trim="true" />
 
     <RuntimeHostConfigurationOption Include="System.Runtime.Serialization.EnableUnsafeBinaryFormatterSerialization"

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToRunILLink.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToRunILLink.cs
@@ -682,24 +682,32 @@ namespace Microsoft.NET.Publish.Tests
             {
                 JObject runtimeConfig = JObject.Parse(runtimeConfigContents);
                 runtimeConfig["runtimeOptions"]["configProperties"]
-                    ["System.Runtime.InteropServices.Marshal.IsBuiltInComSupported"].Value<bool>()
+                    ["Internal.Runtime.InteropServices.ComponentActivator.IsSupported"].Value<bool>()
                     .Should().BeFalse();
                 runtimeConfig["runtimeOptions"]["configProperties"]
-                    ["System.StartupHookProvider.IsSupported"].Value<bool>()
+                    ["Internal.Runtime.InteropServices.InMemoryAssemblyLoader.IsSupported"].Value<bool>()
+                    .Should().BeFalse();
+                runtimeConfig["runtimeOptions"]["configProperties"]
+                    ["System.ComponentModel.TypeConverter.EnableUnsafeBinaryFormatterInDesigntimeLicenseContextSerialization"].Value<bool>()
                     .Should().BeFalse();
                 runtimeConfig["runtimeOptions"]["configProperties"]
                     ["System.Resources.ResourceManager.AllowCustomResourceTypes"].Value<bool>()
                     .Should().BeFalse();
                 runtimeConfig["runtimeOptions"]["configProperties"]
-                    ["System.ComponentModel.TypeConverter.EnableUnsafeBinaryFormatterInDesigntimeLicenseContextSerialization"].Value<bool>()
+                    ["System.Runtime.InteropServices.BuiltInComInterop.IsSupported"].Value<bool>()
+                    .Should().BeFalse();
+                runtimeConfig["runtimeOptions"]["configProperties"]
+                    ["System.StartupHookProvider.IsSupported"].Value<bool>()
                     .Should().BeFalse();
             }
             else
             {
-                runtimeConfigContents.Should().NotContain("System.Runtime.InteropServices.Marshal.IsBuiltInComSupported");
-                runtimeConfigContents.Should().NotContain("System.StartupHookProvider.IsSupported");
-                runtimeConfigContents.Should().NotContain("System.Resources.ResourceManager.AllowCustomResourceTypes");
+                runtimeConfigContents.Should().NotContain("Internal.Runtime.InteropServices.ComponentActivator.IsSupported");
+                runtimeConfigContents.Should().NotContain("Internal.Runtime.InteropServices.InMemoryAssemblyLoader.IsSupported");
                 runtimeConfigContents.Should().NotContain("System.ComponentModel.TypeConverter.EnableUnsafeBinaryFormatterInDesigntimeLicenseContextSerialization");
+                runtimeConfigContents.Should().NotContain("System.Resources.ResourceManager.AllowCustomResourceTypes");
+                runtimeConfigContents.Should().NotContain("System.Runtime.InteropServices.BuiltInComInterop.IsSupported");
+                runtimeConfigContents.Should().NotContain("System.StartupHookProvider.IsSupported");
             }
         }
 

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToRunILLink.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToRunILLink.cs
@@ -682,12 +682,6 @@ namespace Microsoft.NET.Publish.Tests
             {
                 JObject runtimeConfig = JObject.Parse(runtimeConfigContents);
                 runtimeConfig["runtimeOptions"]["configProperties"]
-                    ["Internal.Runtime.InteropServices.ComponentActivator.IsSupported"].Value<bool>()
-                    .Should().BeFalse();
-                runtimeConfig["runtimeOptions"]["configProperties"]
-                    ["Internal.Runtime.InteropServices.InMemoryAssemblyLoader.IsSupported"].Value<bool>()
-                    .Should().BeFalse();
-                runtimeConfig["runtimeOptions"]["configProperties"]
                     ["System.ComponentModel.TypeConverter.EnableUnsafeBinaryFormatterInDesigntimeLicenseContextSerialization"].Value<bool>()
                     .Should().BeFalse();
                 runtimeConfig["runtimeOptions"]["configProperties"]
@@ -697,16 +691,22 @@ namespace Microsoft.NET.Publish.Tests
                     ["System.Runtime.InteropServices.BuiltInComInterop.IsSupported"].Value<bool>()
                     .Should().BeFalse();
                 runtimeConfig["runtimeOptions"]["configProperties"]
+                    ["System.Runtime.InteropServices.CallingManagedFunctionFromNativeHosting.IsSupported"].Value<bool>()
+                    .Should().BeFalse();
+                runtimeConfig["runtimeOptions"]["configProperties"]
+                    ["System.Runtime.InteropServices.CPlusPlusCLIHostActivation.IsSupported"].Value<bool>()
+                    .Should().BeFalse();
+                runtimeConfig["runtimeOptions"]["configProperties"]
                     ["System.StartupHookProvider.IsSupported"].Value<bool>()
                     .Should().BeFalse();
             }
             else
             {
-                runtimeConfigContents.Should().NotContain("Internal.Runtime.InteropServices.ComponentActivator.IsSupported");
-                runtimeConfigContents.Should().NotContain("Internal.Runtime.InteropServices.InMemoryAssemblyLoader.IsSupported");
                 runtimeConfigContents.Should().NotContain("System.ComponentModel.TypeConverter.EnableUnsafeBinaryFormatterInDesigntimeLicenseContextSerialization");
                 runtimeConfigContents.Should().NotContain("System.Resources.ResourceManager.AllowCustomResourceTypes");
                 runtimeConfigContents.Should().NotContain("System.Runtime.InteropServices.BuiltInComInterop.IsSupported");
+                runtimeConfigContents.Should().NotContain("System.Runtime.InteropServices.CallingManagedFunctionFromNativeHosting.IsSupported");
+                runtimeConfigContents.Should().NotContain("System.Runtime.InteropServices.CPlusPlusCLIHostActivation.IsSupported");
                 runtimeConfigContents.Should().NotContain("System.StartupHookProvider.IsSupported");
             }
         }

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToRunILLink.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToRunILLink.cs
@@ -691,10 +691,10 @@ namespace Microsoft.NET.Publish.Tests
                     ["System.Runtime.InteropServices.BuiltInComInterop.IsSupported"].Value<bool>()
                     .Should().BeFalse();
                 runtimeConfig["runtimeOptions"]["configProperties"]
-                    ["System.Runtime.InteropServices.CallingManagedFunctionFromNativeHosting.IsSupported"].Value<bool>()
+                    ["System.Runtime.InteropServices.EnableConsumingManagedCodeFromNativeHosting"].Value<bool>()
                     .Should().BeFalse();
                 runtimeConfig["runtimeOptions"]["configProperties"]
-                    ["System.Runtime.InteropServices.CPlusPlusCLIHostActivation.IsSupported"].Value<bool>()
+                    ["System.Runtime.InteropServices.EnableCppCLIHostActivation"].Value<bool>()
                     .Should().BeFalse();
                 runtimeConfig["runtimeOptions"]["configProperties"]
                     ["System.StartupHookProvider.IsSupported"].Value<bool>()
@@ -705,8 +705,8 @@ namespace Microsoft.NET.Publish.Tests
                 runtimeConfigContents.Should().NotContain("System.ComponentModel.TypeConverter.EnableUnsafeBinaryFormatterInDesigntimeLicenseContextSerialization");
                 runtimeConfigContents.Should().NotContain("System.Resources.ResourceManager.AllowCustomResourceTypes");
                 runtimeConfigContents.Should().NotContain("System.Runtime.InteropServices.BuiltInComInterop.IsSupported");
-                runtimeConfigContents.Should().NotContain("System.Runtime.InteropServices.CallingManagedFunctionFromNativeHosting.IsSupported");
-                runtimeConfigContents.Should().NotContain("System.Runtime.InteropServices.CPlusPlusCLIHostActivation.IsSupported");
+                runtimeConfigContents.Should().NotContain("System.Runtime.InteropServices.EnableConsumingManagedCodeFromNativeHosting");
+                runtimeConfigContents.Should().NotContain("System.Runtime.InteropServices.EnableCppCLIHostActivation");
                 runtimeConfigContents.Should().NotContain("System.StartupHookProvider.IsSupported");
             }
         }


### PR DESCRIPTION
SDK property support for the native host (IJW & Managed Component) feature switches. Also fixed name changes for the COM feature switch