### PR TITLE
Don't suppress trim warnings for web projects

### DIFF
--- a/src/WebSdk/Web/Sdk/Sdk.targets
+++ b/src/WebSdk/Web/Sdk/Sdk.targets
@@ -14,12 +14,6 @@ Copyright (c) .NET Foundation. All rights reserved.
   <!-- We can't add it here because the OutputPath and other msbuild properties are not evaluated.-->
   <!--<Import Sdk="Microsoft.NET.Sdk.Publish" Project="ImportPublishProfile.targets" />-->
 
-  <PropertyGroup>
-    <!-- Trimmer defaults that depend on user-definable settings.
-         This must be configured before it's initialized in the .NET SDK targets. -->
-    <SuppressTrimAnalysisWarnings Condition="'$(SuppressTrimAnalysisWarnings)' == '' And '$(TrimmerDefaultAction)' != 'link'">true</SuppressTrimAnalysisWarnings>
-  </PropertyGroup>
-
   <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" />
 
   <PropertyGroup>


### PR DESCRIPTION
Our strategy changed to only suppress warnings in scenarios where
trimming is enabled by default, so this undoes https://github.com/dotnet/sdk/pull/16327
for ASP.NET where we don't trim by default.