### PR TITLE
Prompt when a rude edit is encountered.

### DIFF
--- a/src/BuiltInTools/HotRestart/Program.cs
+++ b/src/BuiltInTools/HotRestart/Program.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.Loader;
 
-namespace Microsoft.Extensions.DotNetDeltaApplier
+namespace Microsoft.Extensions.HotReload
 {
     internal static class Program
     {
@@ -25,9 +25,16 @@ namespace Microsoft.Extensions.DotNetDeltaApplier
             // We need to differentiate between the emulated Control-C and a Control-C performed by the user on the terminal.
             // We use a DiagnosticListener to signal any time the StartupHook emulates Control-C, so that we know
             // when it is not-signaled, it must be a real Control-C.
+
+            var first = true;
             while (observer.EmulatedControlC)
             {
                 observer.EmulatedControlC = false;
+                if (!first)
+                {
+                    Console.WriteLine("[watch] Application restarting because changes were detected to the app's initialization code.");
+                }
+                first = false;
 
                 var currentLoadContext = new HotRestartLoadContext();
                 var mainAssembly = currentLoadContext.LoadFromAssemblyPath(appAssemblyPath);

--- a/src/BuiltInTools/dotnet-watch/HotReload/RudeEditPreference.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/RudeEditPreference.cs
@@ -1,0 +1,86 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Tools.Internal;
+
+namespace Microsoft.DotNet.Watcher.Tools
+{
+    public class RudeEditDialog
+    {
+        private readonly IReporter _reporter;
+        private readonly IConsole _console;
+        private bool? _restartImmediatelySessionPreference; // Session preference
+
+        public RudeEditDialog(IReporter reporter, IConsole console)
+        {
+            _reporter = reporter;
+            _console = console;
+        }
+
+        public async Task EvaluateAsync(CancellationToken cancellationToken)
+        {
+            if (_restartImmediatelySessionPreference.HasValue)
+            {
+                await GetRudeEditResult(_restartImmediatelySessionPreference.Value, cancellationToken);
+            }
+
+            while (true)
+            {
+                _reporter.Output("Do you want to restart your app - Yes (y) / No (n) / Always (a) / Never (v)?");
+                var tcs = new TaskCompletionSource<ConsoleKeyInfo>(TaskCreationOptions.RunContinuationsAsynchronously);
+                _console.KeyPressed += KeyPressed;
+                ConsoleKeyInfo key;
+                try
+                {
+                    key = await tcs.Task.WaitAsync(cancellationToken);
+                }
+                finally
+                {
+                    _console.KeyPressed -= KeyPressed;
+                }
+
+                switch (key.Key)
+                {
+                    case ConsoleKey.Y:
+                        await GetRudeEditResult(restartImmediately: true, cancellationToken);
+                        return;
+                    case ConsoleKey.N:
+                        await GetRudeEditResult(restartImmediately: false, cancellationToken);
+                        return;
+                    case ConsoleKey.A:
+                        _restartImmediatelySessionPreference = true;
+                        await GetRudeEditResult(restartImmediately: true, cancellationToken);
+                        return;
+                    case ConsoleKey.V:
+                        _restartImmediatelySessionPreference = false;
+                        await GetRudeEditResult(restartImmediately: false, cancellationToken);
+                        return;
+                }
+
+                void KeyPressed(ConsoleKeyInfo key)
+                {
+                    if (key.Key is ConsoleKey.Y or ConsoleKey.N or ConsoleKey.A or ConsoleKey.V)
+                    {
+                        tcs.TrySetResult(key);
+                    }
+                }
+            }
+        }
+
+        private Task GetRudeEditResult(bool restartImmediately, CancellationToken cancellationToken)
+        {
+            if (restartImmediately)
+            {
+                return Task.CompletedTask;
+            }
+
+            _reporter.Output("Hot reload suspended. To continue hot reload, press \"Ctrl + R\".");
+
+            return Task.Delay(-1, cancellationToken);
+        }
+    }
+}

--- a/src/BuiltInTools/dotnet-watch/HotReloadDotNetWatcher.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReloadDotNetWatcher.cs
@@ -66,9 +66,7 @@ namespace Microsoft.DotNet.Watcher
                 if (key.Modifiers == ConsoleModifiers.Control && key.Key == ConsoleKey.R)
                 {
                     var cancellationTokenSource = Interlocked.Exchange(ref forceReload, new CancellationTokenSource());
-
                     cancellationTokenSource.Cancel();
-                    cancellationTokenSource.Dispose();
                 }
             };
 

--- a/src/BuiltInTools/dotnet-watch/HotReloadDotNetWatcher.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReloadDotNetWatcher.cs
@@ -9,7 +9,6 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Build.Execution;
 using Microsoft.Build.Graph;
 using Microsoft.DotNet.Watcher.Internal;
 using Microsoft.DotNet.Watcher.Tools;
@@ -25,6 +24,7 @@ namespace Microsoft.DotNet.Watcher
         private readonly ProcessRunner _processRunner;
         private readonly DotNetWatchOptions _dotNetWatchOptions;
         private readonly IWatchFilter[] _filters;
+        private readonly RudeEditDialog _rudeEditDialog;
 
         public bool SuppressHotRestart { get; init; }
         public ProjectGraph ProjectGraph { get; init; }
@@ -44,6 +44,7 @@ namespace Microsoft.DotNet.Watcher
                 new DotNetBuildFilter(_processRunner, _reporter),
                 new LaunchBrowserFilter(_dotNetWatchOptions),
             };
+            _rudeEditDialog = new(reporter, _console);
         }
 
         public async Task WatchAsync(DotNetWatchContext context, CancellationToken cancellationToken)
@@ -57,6 +58,19 @@ namespace Microsoft.DotNet.Watcher
 
             _reporter.Output("Hot reload enabled. For a list of supported edits, see https://aka.ms/dotnet/hot-reload. " +
                 "Press \"Ctrl + R\" to restart.");
+
+            var forceReload = new CancellationTokenSource();
+
+            _console.KeyPressed += (key) =>
+            {
+                if (key.Modifiers == ConsoleModifiers.Control && key.Key == ConsoleKey.R)
+                {
+                    var cancellationTokenSource = Interlocked.Exchange(ref forceReload, new CancellationTokenSource());
+
+                    cancellationTokenSource.Cancel();
+                    cancellationTokenSource.Dispose();
+                }
+            };
 
             while (true)
             {
@@ -96,12 +110,12 @@ namespace Microsoft.DotNet.Watcher
                 }
 
                 using var currentRunCancellationSource = new CancellationTokenSource();
-                var forceReload = _console.ListenForForceReloadRequest();
                 using var combinedCancellationSource = CancellationTokenSource.CreateLinkedTokenSource(
                     cancellationToken,
                     currentRunCancellationSource.Token,
-                    forceReload);
+                    forceReload.Token);
                 using var fileSetWatcher = new FileSetWatcher(fileSet, _reporter) { WatchForNewFiles = true };
+
                 try
                 {
                     using var hotReload = new HotReload(_processRunner, _reporter);
@@ -150,7 +164,9 @@ namespace Microsoft.DotNet.Watcher
                             }
                             else
                             {
-                                _reporter.Verbose($"Unable to handle changes to {fileItem.FilePath}. Rebuilding the app.");
+                                _reporter.Output($"Unable to handle changes to {fileItem.FilePath}.");
+                                await _rudeEditDialog.EvaluateAsync(combinedCancellationSource.Token);
+
                                 break;
                             }
                         }

--- a/src/BuiltInTools/dotnet-watch/Internal/IConsole.cs
+++ b/src/BuiltInTools/dotnet-watch/Internal/IConsole.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.IO;
-using System.Threading;
 
 namespace Microsoft.Extensions.Tools.Internal
 {
@@ -13,8 +12,8 @@ namespace Microsoft.Extensions.Tools.Internal
     /// </summary>
     public interface IConsole
     {
-        CancellationToken ListenForForceReloadRequest();
         event ConsoleCancelEventHandler CancelKeyPress;
+        event Action<ConsoleKeyInfo> KeyPressed;
         TextWriter Out { get; }
         TextWriter Error { get; }
         TextReader In { get; }

--- a/src/BuiltInTools/dotnet-watch/Internal/PhysicalConsole.cs
+++ b/src/BuiltInTools/dotnet-watch/Internal/PhysicalConsole.cs
@@ -2,8 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
-using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Extensions.Tools.Internal
@@ -14,7 +14,7 @@ namespace Microsoft.Extensions.Tools.Internal
     /// </summary>
     public class PhysicalConsole : IConsole
     {
-        private CancellationTokenSource _cancellationTokenSource;
+        private readonly List<Action<ConsoleKeyInfo>> _keyPressedListeners = new();
 
         private PhysicalConsole()
         {
@@ -24,23 +24,30 @@ namespace Microsoft.Extensions.Tools.Internal
             };
         }
 
-        public CancellationToken ListenForForceReloadRequest()
+        public event Action<ConsoleKeyInfo> KeyPressed
         {
-            _cancellationTokenSource ??= new CancellationTokenSource();
+            add
+            {
+                _keyPressedListeners.Add(value);
+                ListenToConsoleKeyPress();
+            }
 
+            remove => _keyPressedListeners.Remove(value);
+        }
+
+        private void ListenToConsoleKeyPress()
+        {
             Task.Run(() =>
             {
-                var key = Console.ReadKey(intercept: true);
-                if (key.Modifiers == ConsoleModifiers.Control && key.Key == ConsoleKey.R)
+                while (true)
                 {
-                    var cancellationTokenSource = Interlocked.Exchange(ref _cancellationTokenSource, new CancellationTokenSource());
-
-                    cancellationTokenSource.Cancel();
-                    cancellationTokenSource.Dispose();
+                    var key = Console.ReadKey(intercept: true);
+                    for (var i = 0; i < _keyPressedListeners.Count; i++)
+                    {
+                        _keyPressedListeners[i](key);
+                    }
                 }
             });
-
-            return _cancellationTokenSource.Token;
         }
 
         public static IConsole Singleton { get; } = new PhysicalConsole();

--- a/src/BuiltInTools/dotnet-watch/Internal/PhysicalConsole.cs
+++ b/src/BuiltInTools/dotnet-watch/Internal/PhysicalConsole.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Extensions.Tools.Internal
 
         private void ListenToConsoleKeyPress()
         {
-            Task.Run(() =>
+            Task.Factory.StartNew(() =>
             {
                 while (true)
                 {
@@ -47,7 +47,7 @@ namespace Microsoft.Extensions.Tools.Internal
                         _keyPressedListeners[i](key);
                     }
                 }
-            });
+            }, TaskCreationOptions.LongRunning);
         }
 
         public static IConsole Singleton { get; } = new PhysicalConsole();

--- a/src/Tests/dotnet-watch.Tests/ConsoleReporterTests.cs
+++ b/src/Tests/dotnet-watch.Tests/ConsoleReporterTests.cs
@@ -4,7 +4,6 @@
 using System;
 using System.IO;
 using System.Text;
-using System.Threading;
 using Xunit;
 
 namespace Microsoft.Extensions.Tools.Internal
@@ -43,6 +42,12 @@ namespace Microsoft.Extensions.Tools.Internal
             private readonly StringBuilder _out;
             private readonly StringBuilder _error;
 
+            event Action<ConsoleKeyInfo> IConsole.KeyPressed
+            {
+                add { }
+                remove { }
+            }
+
             public TestConsole()
             {
                 _out = new StringBuilder();
@@ -70,8 +75,6 @@ namespace Microsoft.Extensions.Tools.Internal
             {
                 ForegroundColor = default(ConsoleColor);
             }
-
-            public CancellationToken ListenForForceReloadRequest() => default;
 
             public TextWriter Out { get; }
             public TextWriter Error { get; }

--- a/src/Tests/dotnet-watch.Tests/Utilities/TestConsole.cs
+++ b/src/Tests/dotnet-watch.Tests/Utilities/TestConsole.cs
@@ -6,7 +6,6 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
 using Xunit.Abstractions;
 
@@ -15,6 +14,7 @@ namespace Microsoft.Extensions.Tools.Internal
     internal class TestConsole : IConsole
     {
         private event ConsoleCancelEventHandler _cancelKeyPress = default!;
+
         private readonly TaskCompletionSource<bool> _cancelKeySubscribed = new TaskCompletionSource<bool>();
         private readonly TestOutputWriter _testWriter;
 
@@ -37,6 +37,7 @@ namespace Microsoft.Extensions.Tools.Internal
 
         public Task CancelKeyPressSubscribed => _cancelKeySubscribed.Task;
 
+        event Action<ConsoleKeyInfo> IConsole.KeyPressed { add { } remove { } }
         public TextWriter Error { get; }
         public TextWriter Out { get; }
         public TextReader In { get; set; } = new StringReader(string.Empty);
@@ -70,8 +71,6 @@ namespace Microsoft.Extensions.Tools.Internal
         {
             _testWriter.ClearOutput();
         }
-
-        public CancellationToken ListenForForceReloadRequest() => default;
 
         private class TestOutputWriter : TextWriter
         {


### PR DESCRIPTION
* Instead of forcing an app reload any time a rude edit is encountered,
prompt the user for their preference.
* Print a nifty message when watch hot restarts the app.