### PR TITLE
[preview5] Remove linker warnings for native host and COM

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ILLink.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ILLink.targets
@@ -52,15 +52,37 @@ Copyright (c) .NET Foundation. All rights reserved.
     <EnableUnsafeBinaryFormatterInDesigntimeLicenseContextSerialization>false</EnableUnsafeBinaryFormatterInDesigntimeLicenseContextSerialization>
   </PropertyGroup>
 
-  <!-- We disable in-built COM support for trimmed apps here so that the feature
-       switch can flow to the runtimeconfig.json. Built-in COM support is disabled
+  <!-- We disable in-built COM Interop support for trimmed apps here so that the feature
+       switch can flow to the runtimeconfig.json. Built-in COM Interop support is disabled
        by default since they may require assemblies, types or members that
        could be removed by the linker, causing a trimmed app to crash. -->
-  <PropertyGroup Condition="'$(BuiltInComSupport)' == '' And
+  <PropertyGroup Condition="'$(BuiltInComInteropSupport)' == '' And
                             '$(PublishTrimmed)' == 'true' And
                             $([MSBuild]::VersionGreaterThanOrEquals($(_TargetFrameworkVersionWithoutV), '6.0'))">
-    <BuiltInComSupport>false</BuiltInComSupport>
-  </PropertyGroup>  
+    <BuiltInComInteropSupport>false</BuiltInComInteropSupport>
+  </PropertyGroup>
+
+  <!-- We disable Native Host entry point support for IJW (C++/CLI Assemblies) for trimmed
+       apps here so that the feature switch can flow to the runtimeconfig.json. 
+       Native Host entry point support is disabled
+       by default since they may require assemblies, types or members that
+       could be removed by the linker, causing a trimmed app to crash. -->
+  <PropertyGroup Condition="'$(EnableCPlusPlusCLIHostActivation)' == '' And
+                            '$(PublishTrimmed)' == 'true' And
+                            $([MSBuild]::VersionGreaterThanOrEquals($(_TargetFrameworkVersionWithoutV), '6.0'))">
+    <EnableCPlusPlusCLIHostActivation>false</EnableCPlusPlusCLIHostActivation>
+  </PropertyGroup>
+
+  <!-- We disable Native Host entry point support for loading managed components for trimmed
+       apps here so that the feature switch can flow to the runtimeconfig.json. 
+       Native Host entry point support is disabled
+       by default since they may require assemblies, types or members that
+       could be removed by the linker, causing a trimmed app to crash. -->
+  <PropertyGroup Condition="'$(_EnableCallingManagedFunctionFromNativeHosting)' == '' And
+                            '$(PublishTrimmed)' == 'true' And
+                            $([MSBuild]::VersionGreaterThanOrEquals($(_TargetFrameworkVersionWithoutV), '6.0'))">
+    <_EnableCallingManagedFunctionFromNativeHosting>false</_EnableCallingManagedFunctionFromNativeHosting>
+  </PropertyGroup>
 
   <PropertyGroup Condition="'$(SuppressTrimAnalysisWarnings)' == '' And ('$(EnableTrimAnalyzer)' == 'true' Or '$(PublishTrimmed)' == 'true')">
     <!-- Trim analysis warnings are suppressed for .NET < 6. -->

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ILLink.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ILLink.targets
@@ -27,61 +27,19 @@ Copyright (c) .NET Foundation. All rights reserved.
     </AssemblyAttribute>
   </ItemGroup>
 
-  <!-- We disable startup hooks for trimmed apps here so that the feature
-       switch can flow to the runtimeconfig.json. Startup hooks are disabled
-       by default since they may require assemblies, types or members that
-       could be removed by the linker, causing a trimmed app to crash. -->
-  <PropertyGroup Condition="'$(StartupHookSupport)' == '' And
-                            '$(PublishTrimmed)' == 'true' And
-                            $([MSBuild]::VersionGreaterThanOrEquals($(_TargetFrameworkVersionWithoutV), '6.0'))">
-    <StartupHookSupport>false</StartupHookSupport>
-  </PropertyGroup>
 
-  <!-- We disable custom resource types for trimmed apps here so that the feature
-       switch can flow to the runtimeconfig.json. Custom resource types are disabled
-       by default since they may require assemblies, types or members that
-       could be removed by the linker, causing a trimmed app to crash. -->
-  <PropertyGroup Condition="'$(CustomResourceTypesSupport)' == '' And
-                            '$(PublishTrimmed)' == 'true' And
+  <!-- We disable features for trimmed apps here so that the feature
+      switches can flow to the runtimeconfig.json. Features are disabled
+      by default since they may require assemblies, types or members that
+      could be removed by the linker, causing a trimmed app to crash. -->
+  <PropertyGroup Condition="'$(PublishTrimmed)' == 'true' And
                             $([MSBuild]::VersionGreaterThanOrEquals($(_TargetFrameworkVersionWithoutV), '6.0'))">
-    <CustomResourceTypesSupport>false</CustomResourceTypesSupport>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(EnableUnsafeBinaryFormatterInDesigntimeLicenseContextSerialization)' == '' And
-                            '$(PublishTrimmed)' == 'true' And
-                            $([MSBuild]::VersionGreaterThanOrEquals($(_TargetFrameworkVersionWithoutV), '6.0'))">
-    <EnableUnsafeBinaryFormatterInDesigntimeLicenseContextSerialization>false</EnableUnsafeBinaryFormatterInDesigntimeLicenseContextSerialization>
-  </PropertyGroup>
-
-  <!-- We disable in-built COM Interop support for trimmed apps here so that the feature
-       switch can flow to the runtimeconfig.json. Built-in COM Interop support is disabled
-       by default since they may require assemblies, types or members that
-       could be removed by the linker, causing a trimmed app to crash. -->
-  <PropertyGroup Condition="'$(BuiltInComInteropSupport)' == '' And
-                            '$(PublishTrimmed)' == 'true' And
-                            $([MSBuild]::VersionGreaterThanOrEquals($(_TargetFrameworkVersionWithoutV), '6.0'))">
-    <BuiltInComInteropSupport>false</BuiltInComInteropSupport>
-  </PropertyGroup>
-
-  <!-- We disable Native Host entry point support for IJW (C++/CLI Assemblies) for trimmed
-       apps here so that the feature switch can flow to the runtimeconfig.json. 
-       Native Host entry point support is disabled
-       by default since they may require assemblies, types or members that
-       could be removed by the linker, causing a trimmed app to crash. -->
-  <PropertyGroup Condition="'$(EnableCPlusPlusCLIHostActivation)' == '' And
-                            '$(PublishTrimmed)' == 'true' And
-                            $([MSBuild]::VersionGreaterThanOrEquals($(_TargetFrameworkVersionWithoutV), '6.0'))">
-    <EnableCPlusPlusCLIHostActivation>false</EnableCPlusPlusCLIHostActivation>
-  </PropertyGroup>
-
-  <!-- We disable Native Host entry point support for loading managed components for trimmed
-       apps here so that the feature switch can flow to the runtimeconfig.json. 
-       Native Host entry point support is disabled
-       by default since they may require assemblies, types or members that
-       could be removed by the linker, causing a trimmed app to crash. -->
-  <PropertyGroup Condition="'$(_EnableCallingManagedFunctionFromNativeHosting)' == '' And
-                            '$(PublishTrimmed)' == 'true' And
-                            $([MSBuild]::VersionGreaterThanOrEquals($(_TargetFrameworkVersionWithoutV), '6.0'))">
-    <_EnableCallingManagedFunctionFromNativeHosting>false</_EnableCallingManagedFunctionFromNativeHosting>
+    <StartupHookSupport Condition="'$(StartupHookSupport)' == ''">false</StartupHookSupport>
+    <CustomResourceTypesSupport Condition="'$(CustomResourceTypesSupport)' == ''">false</CustomResourceTypesSupport>
+    <EnableUnsafeBinaryFormatterInDesigntimeLicenseContextSerialization Condition="'$(EnableUnsafeBinaryFormatterInDesigntimeLicenseContextSerialization)' == ''">false</EnableUnsafeBinaryFormatterInDesigntimeLicenseContextSerialization>
+    <BuiltInComInteropSupport Condition="'$(BuiltInComInteropSupport)' == ''">false</BuiltInComInteropSupport>
+    <EnableCPlusPlusCLIHostActivation Condition="'$(EnableCPlusPlusCLIHostActivation)' == ''">false</EnableCPlusPlusCLIHostActivation>
+    <_EnableCallingManagedFunctionFromNativeHosting Condition="'$(_EnableCallingManagedFunctionFromNativeHosting)' == ''">false</_EnableCallingManagedFunctionFromNativeHosting>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(SuppressTrimAnalysisWarnings)' == '' And ('$(EnableTrimAnalyzer)' == 'true' Or '$(PublishTrimmed)' == 'true')">

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -359,9 +359,14 @@ Copyright (c) .NET Foundation. All rights reserved.
     -->
 
   <ItemGroup>
-    <RuntimeHostConfigurationOption Include=" System.Runtime.InteropServices.Marshal.IsBuiltInComSupported"
-                                    Condition="'$(BuiltInComSupport)' != ''"
-                                    Value="$(BuiltInComSupport)"
+    <RuntimeHostConfigurationOption Include="Internal.Runtime.InteropServices.ComponentActivator.IsSupported"
+                                    Condition="'$(_EnableCallingManagedFunctionFromNativeHosting)' != ''"
+                                    Value="$(_EnableCallingManagedFunctionFromNativeHosting)"
+                                    Trim="true" />
+
+    <RuntimeHostConfigurationOption Include="Internal.Runtime.InteropServices.InMemoryAssemblyLoader.IsSupported"
+                                    Condition="'$(EnableCPlusPlusCLIHostActivation)' != ''"
+                                    Value="$(EnableCPlusPlusCLIHostActivation)"
                                     Trim="true" />
 
     <RuntimeHostConfigurationOption Include="System.ComponentModel.TypeConverter.EnableUnsafeBinaryFormatterInDesigntimeLicenseContextSerialization"
@@ -414,6 +419,11 @@ Copyright (c) .NET Foundation. All rights reserved.
     <RuntimeHostConfigurationOption Include="System.Resources.UseSystemResourceKeys"
                                     Condition="'$(UseSystemResourceKeys)' != ''"
                                     Value="$(UseSystemResourceKeys)"
+                                    Trim="true" />
+
+    <RuntimeHostConfigurationOption Include="System.Runtime.InteropServices.BuiltInComInterop.IsSupported"
+                                    Condition="'$(BuiltInComInteropSupport)' != ''"
+                                    Value="$(BuiltInComInteropSupport)"
                                     Trim="true" />
 
     <RuntimeHostConfigurationOption Include="System.Runtime.Serialization.EnableUnsafeBinaryFormatterSerialization"

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToRunILLink.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToRunILLink.cs
@@ -682,24 +682,32 @@ namespace Microsoft.NET.Publish.Tests
             {
                 JObject runtimeConfig = JObject.Parse(runtimeConfigContents);
                 runtimeConfig["runtimeOptions"]["configProperties"]
-                    ["System.Runtime.InteropServices.Marshal.IsBuiltInComSupported"].Value<bool>()
+                    ["Internal.Runtime.InteropServices.ComponentActivator.IsSupported"].Value<bool>()
                     .Should().BeFalse();
                 runtimeConfig["runtimeOptions"]["configProperties"]
-                    ["System.StartupHookProvider.IsSupported"].Value<bool>()
+                    ["Internal.Runtime.InteropServices.InMemoryAssemblyLoader.IsSupported"].Value<bool>()
+                    .Should().BeFalse();
+                runtimeConfig["runtimeOptions"]["configProperties"]
+                    ["System.ComponentModel.TypeConverter.EnableUnsafeBinaryFormatterInDesigntimeLicenseContextSerialization"].Value<bool>()
                     .Should().BeFalse();
                 runtimeConfig["runtimeOptions"]["configProperties"]
                     ["System.Resources.ResourceManager.AllowCustomResourceTypes"].Value<bool>()
                     .Should().BeFalse();
                 runtimeConfig["runtimeOptions"]["configProperties"]
-                    ["System.ComponentModel.TypeConverter.EnableUnsafeBinaryFormatterInDesigntimeLicenseContextSerialization"].Value<bool>()
+                    ["System.Runtime.InteropServices.BuiltInComInterop.IsSupported"].Value<bool>()
+                    .Should().BeFalse();
+                runtimeConfig["runtimeOptions"]["configProperties"]
+                    ["System.StartupHookProvider.IsSupported"].Value<bool>()
                     .Should().BeFalse();
             }
             else
             {
-                runtimeConfigContents.Should().NotContain("System.Runtime.InteropServices.Marshal.IsBuiltInComSupported");
-                runtimeConfigContents.Should().NotContain("System.StartupHookProvider.IsSupported");
-                runtimeConfigContents.Should().NotContain("System.Resources.ResourceManager.AllowCustomResourceTypes");
+                runtimeConfigContents.Should().NotContain("Internal.Runtime.InteropServices.ComponentActivator.IsSupported");
+                runtimeConfigContents.Should().NotContain("Internal.Runtime.InteropServices.InMemoryAssemblyLoader.IsSupported");
                 runtimeConfigContents.Should().NotContain("System.ComponentModel.TypeConverter.EnableUnsafeBinaryFormatterInDesigntimeLicenseContextSerialization");
+                runtimeConfigContents.Should().NotContain("System.Resources.ResourceManager.AllowCustomResourceTypes");
+                runtimeConfigContents.Should().NotContain("System.Runtime.InteropServices.BuiltInComInterop.IsSupported");
+                runtimeConfigContents.Should().NotContain("System.StartupHookProvider.IsSupported");
             }
         }
 

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToRunILLink.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToRunILLink.cs
@@ -387,11 +387,7 @@ namespace Microsoft.NET.Publish.Tests
             publishCommand.Execute($"/p:RuntimeIdentifier={rid}")
                 .Should().Pass()
                 // trim analysis warnings are disabled
-                .And.NotHaveStdOutContaining("warning IL2075")
-                .And.NotHaveStdOutContaining("warning IL2026")
-                .And.NotHaveStdOutContaining("warning IL2043")
-                .And.NotHaveStdOutContaining("warning IL2046")
-                .And.NotHaveStdOutContaining("warning IL2093");
+                .And.NotHaveStdOutMatching(@"warning IL\d\d\d\d");
         }
 
         [RequiresMSBuildVersionTheory("16.8.0")]
@@ -453,11 +449,7 @@ namespace Microsoft.NET.Publish.Tests
             var publishCommand = new PublishCommand(testAsset);
             publishCommand.Execute($"/p:RuntimeIdentifier={rid}")
                 .Should().Pass()
-                .And.NotHaveStdOutContaining("warning IL2075")
-                .And.NotHaveStdOutContaining("warning IL2026")
-                .And.NotHaveStdOutContaining("warning IL2043")
-                .And.NotHaveStdOutContaining("warning IL2046")
-                .And.NotHaveStdOutContaining("warning IL2093");
+                .And.NotHaveStdOutMatching(@"warning IL\d\d\d\d");
         }
 
         [RequiresMSBuildVersionTheory("16.8.0")]
@@ -603,7 +595,7 @@ namespace Microsoft.NET.Publish.Tests
             var testAsset = _testAssetsManager.CreateTestProject(testProject, identifier: targetFramework);
 
             var publishCommand = new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
-            var result = publishCommand.Execute($"/p:RuntimeIdentifier={rid}", "/p:PublishTrimmed=true", "/p:TrimMode=copyused");
+            var result = publishCommand.Execute($"/p:RuntimeIdentifier={rid}", "/p:PublishTrimmed=true", "/p:TrimMode=copyused", "/p:TrimmerSingleWarn=false");
             result.Should().Pass();
             ValidateWarningsOnHelloWorldApp(publishCommand, result, expectedOutput, targetFramework, rid);
         }
@@ -619,7 +611,7 @@ namespace Microsoft.NET.Publish.Tests
             var testAsset = _testAssetsManager.CreateTestProject(testProject, identifier: targetFramework);
 
             var publishCommand = new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
-            var result = publishCommand.Execute($"/p:RuntimeIdentifier={rid}", "/p:PublishTrimmed=true");
+            var result = publishCommand.Execute($"/p:RuntimeIdentifier={rid}", "/p:PublishTrimmed=true", "/p:TrimmerSingleWarn=false");
             result.Should().Pass();
             ValidateWarningsOnHelloWorldApp(publishCommand, result, Array.Empty<string>(), targetFramework, rid);
         }
@@ -627,7 +619,7 @@ namespace Microsoft.NET.Publish.Tests
         private void ValidateWarningsOnHelloWorldApp (PublishCommand publishCommand, CommandResult result, string[] expectedOutput, string targetFramework, string rid)
         {
             // This checks that there are no unexpected warnings, but does not cause failures for missing expected warnings.
-            var warnings = result.StdOut.Split('\n', '\r', ')').Where(line => line.StartsWith("ILLink :"));
+            var warnings = result.StdOut.Split('\n', '\r', ')').Where(line => line.StartsWith("warning IL"));
             var extraWarnings = warnings.Except(expectedOutput);
 
             StringBuilder errorMessage = new StringBuilder();


### PR DESCRIPTION
This includes @LakshanF 's changes from https://github.com/dotnet/sdk/pull/17657, except for the renamed properties, so that the feature switches get set using the existing names. This gets rid of the following warnings which were not caught by the test infra:
```
ILLink : Trim analysis warning IL2026: Internal.Runtime.InteropServices.ComponentActivator.GetFunctionPointer(IntPtr,IntPtr,IntPtr,IntPtr,IntPtr,IntPtr
ILLink : Trim analysis warning IL2026: Internal.Runtime.InteropServices.InMemoryAssemblyLoader.LoadInMemoryAssembly(IntPtr,IntPtr
```

The warning checks in the tests have been made more strict. The issue was that the collapsed warnings weren't caught by the "ILLink :" check (they look like this):
```
System.Private.CoreLib.dll : warning IL2104: Assembly 'System.Private.CoreLib' produced trim warnings. For more information see https://aka.ms/dotnet-illink/libraries
```

To fix this I'm checking for "warning IL" instead, and also not collapsing the warnings for the baseline test cases to produce detailed warnings if the test fails.