### PR TITLE
Adding buildMultiTargeting package folder in order to add support for PackageReference import for multitargeting projects.

### DIFF
--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/Microsoft.DotNet.PackageValidation.csproj
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/Microsoft.DotNet.PackageValidation.csproj
@@ -34,6 +34,15 @@
     <None Include="**/*.props;**/*.targets" Pack="true">
       <PackagePath>%(RecursiveDir)%(Filename)%(Extension)</PackagePath>
     </None>
+    
+    <!-- 
+      Additionally also copy the props and targets from the build folder into buildMultiTargeting so that
+      NuGet will also have these files automatically imported for consuming projects which multitarget
+      (use TargetFrameworks instead of TargetFramework) 
+    -->
+    <None Include="build/*.props;build/*.targets" Pack="true">
+      <PackagePath>buildMultiTargeting/%(Filename)%(Extension)</PackagePath>
+    </None>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/Microsoft.DotNet.PackageValidation.csproj
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/Microsoft.DotNet.PackageValidation.csproj
@@ -34,15 +34,6 @@
     <None Include="**/*.props;**/*.targets" Pack="true">
       <PackagePath>%(RecursiveDir)%(Filename)%(Extension)</PackagePath>
     </None>
-    
-    <!-- 
-      Additionally also copy the props and targets from the build folder into buildMultiTargeting so that
-      NuGet will also have these files automatically imported for consuming projects which multitarget
-      (use TargetFrameworks instead of TargetFramework) 
-    -->
-    <None Include="build/*.props;build/*.targets" Pack="true">
-      <PackagePath>buildMultiTargeting/%(Filename)%(Extension)</PackagePath>
-    </None>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/buildMultiTargeting/Microsoft.DotNet.PackageValidation.props
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/buildMultiTargeting/Microsoft.DotNet.PackageValidation.props
@@ -1,0 +1,4 @@
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
+<Project>
+  <Import Project="$(MSBuildThisFileDirectory)..\build\$(MSBuildThisFile)" />
+</Project>

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/buildMultiTargeting/Microsoft.DotNet.PackageValidation.targets
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/buildMultiTargeting/Microsoft.DotNet.PackageValidation.targets
@@ -1,0 +1,4 @@
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
+<Project>
+  <Import Project="$(MSBuildThisFileDirectory)..\build\$(MSBuildThisFile)" />
+</Project>


### PR DESCRIPTION
cc: @ericstj @Anipik @safern 

**Context:**
Currently the PackageValidation package is setup in a way that it runs Validation after the Pack target. Additionally, when using PackageReference this gets hooked by importing the props and targets located in the build\*props and build\*targets files. Finally, when a project multitargets, there are two types of builds that happen internally when build is invoked: the outer build (main build) and the inner builds (called  by outer, and will be individual builds which represent each supported target framework).

**Problem Definition:**
The problem is that when a consuming project is multitargeting, the Pack target gets called from the outer build but the build\*props and build\*targets files get imported only by the inner builds which means that today, using PackageReference for a project that is multitargeting is not supported.

**Proposed solution:**
This PR  is also copying the build\*props and targets into the buildMultiTargeting\ folder in the package, which will make it so that the targets also get imported by the outer build, so that validation will also run with projects that are multitargeting.

**Out of scope:**
One additional issue with using PackageReference when adding the validation infrastructure is that if the consuming project opted into validation against a baseline, we cannot add PackageDownload early enough in order to not require an additional project evaluation. This may be something that is fixed after this fix is in, but we will need to explore to make sure this can make that work.