### PR TITLE
improve workflow for no baseline packages.

### DIFF
--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/DiagnosticIds.cs
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/DiagnosticIds.cs
@@ -15,5 +15,6 @@ namespace Microsoft.DotNet.PackageValidation
         public const string CompatibleRuntimeRidSpecificAsset = "PKV005";
         public const string TargetFrameworkDropped = "PKV006";
         public const string TargetFrameworkAndRidPairDropped = "PKV007";
+        public const string NoBaselinePackageFound = "PKV008";
     }
 }

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/GetLastStablePackage.cs
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/GetLastStablePackage.cs
@@ -50,7 +50,7 @@ namespace Microsoft.DotNet.PackageValidation
             
             if (version == null)
             {
-                Log.LogNonSdkWarning(DiagnosticIds.NoBaselinePackageFound, string.Format(Resources.BaselinePackageNotFound, PackageId, Environment.NewLine + string.Join(Environment.NewLine + " - ", NugetFeeds), PackageVersion));
+                Log.LogNonSdkWarning(DiagnosticIds.NoBaselinePackageFound, string.Format(Resources.BaselinePackageNotFound, PackageId, string.Join(" ;", NugetFeeds), PackageVersion));
                 return;
             }
 

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/GetLastStablePackage.cs
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/GetLastStablePackage.cs
@@ -50,7 +50,8 @@ namespace Microsoft.DotNet.PackageValidation
             
             if (version == null)
             {
-                throw new Exception(string.Format(Resources.BaselinePackageNotFound, PackageId, Environment.NewLine + string.Join(Environment.NewLine + " - ", NugetFeeds)));
+                Log.LogNonSdkWarning(DiagnosticIds.NoBaselinePackageFound, string.Format(Resources.BaselinePackageNotFound, PackageId, Environment.NewLine + string.Join(Environment.NewLine + " - ", NugetFeeds)));
+                return;
             }
 
             LastStableVersion = version?.ToNormalizedString();

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/GetLastStablePackage.cs
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/GetLastStablePackage.cs
@@ -50,7 +50,7 @@ namespace Microsoft.DotNet.PackageValidation
             
             if (version == null)
             {
-                Log.LogNonSdkWarning(DiagnosticIds.NoBaselinePackageFound, string.Format(Resources.BaselinePackageNotFound, PackageId, Environment.NewLine + string.Join(Environment.NewLine + " - ", NugetFeeds)));
+                Log.LogNonSdkWarning(DiagnosticIds.NoBaselinePackageFound, string.Format(Resources.BaselinePackageNotFound, PackageId, Environment.NewLine + string.Join(Environment.NewLine + " - ", NugetFeeds), PackageVersion));
                 return;
             }
 

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/Resources.resx
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/Resources.resx
@@ -151,7 +151,7 @@
     <value>API compatibility errors in between {0} (left) and {1} (right) for versions {2} and {3} respectively:</value>
   </data>
   <data name="BaselinePackageNotFound" xml:space="preserve">
-    <value>No baseline package with id {0} found in feeds: {1}.</value>
+    <value>Baseline package with id {0} and version less than {2} not found in feeds: {1}.</value>
   </data>
   <data name="EmptyPackagePath" xml:space="preserve">
     <value>{0} is empty or null.  Please provide a valid package path.</value>

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/Resources.resx
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/Resources.resx
@@ -151,7 +151,7 @@
     <value>API compatibility errors in between {0} (left) and {1} (right) for versions {2} and {3} respectively:</value>
   </data>
   <data name="BaselinePackageNotFound" xml:space="preserve">
-    <value>Baseline package with id {0} and version less than {2} not found in feeds: {1}.</value>
+    <value>Baseline package with id {0} and version less than {2} not found in feeds: ({1}).</value>
   </data>
   <data name="EmptyPackagePath" xml:space="preserve">
     <value>{0} is empty or null.  Please provide a valid package path.</value>

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/build/Microsoft.DotNet.PackageValidation.targets
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/build/Microsoft.DotNet.PackageValidation.targets
@@ -20,7 +20,8 @@
                               '$(PackageValidationBaselinePath)' == ''">
       <PackageValidationBaselineName Condition="'$(PackageValidationBaselineName)' == ''">$(_PackageValidationBaselineName)</PackageValidationBaselineName>
       <PackageValidationBaselineVersion Condition="'$(PackageValidationBaselineVersion)' == ''">$(_PackageValidationBaselineVersion)</PackageValidationBaselineVersion>
-      <PackageValidationBaselinePath>$([MSBuild]::NormalizePath('$(NuGetPackageRoot)', '$(PackageValidationBaselineName)', '$(PackageValidationBaselineVersion)', '$(PackageValidationBaselineName).$(PackageValidationBaselineVersion).nupkg'))</PackageValidationBaselinePath>
+      <PackageValidationBaselinePath Condition="'$(PackageValidationBaselineVersion)' != ''">$([MSBuild]::NormalizePath('$(NuGetPackageRoot)', '$(PackageValidationBaselineName)', '$(PackageValidationBaselineVersion)', '$(PackageValidationBaselineName).$(PackageValidationBaselineVersion).nupkg'))</PackageValidationBaselinePath>
+      <EnablePackageBaselineValidation Condition="'$(PackageValidationBaselinePath)' == ''">false</EnablePackageBaselineValidation>
     </PropertyGroup>
 
     <!-- PackageTargetPath isn't exposed by NuGet: https://github.com/NuGet/Home/issues/6671. -->
@@ -65,7 +66,7 @@
                        Version="[$(PackageValidationBaselineVersion)]" />
     </ItemGroup>
 
-    <PropertyGroup Condition="'$(PackageValidationBaselineVersion)' != ''">
+    <PropertyGroup>
       <_PackageValidationIntermediateBaselineFile>$(MSBuildProjectExtensionsPath)$(MSBuildProjectFile).packagevalidation.g.props</_PackageValidationIntermediateBaselineFile>
       <_PackageValidationIntermediateBaselineFileContent>
 <![CDATA[<Project>
@@ -73,19 +74,6 @@
     <_PackageValidationBaselineName>$(PackageValidationBaselineName)</_PackageValidationBaselineName>
     <_PackageValidationBaselineVersion>$(PackageValidationBaselineVersion)</_PackageValidationBaselineVersion>
   </PropertyGroup>
-</Project>]]>
-      </_PackageValidationIntermediateBaselineFileContent>
-    </PropertyGroup>
-
-    <PropertyGroup Condition="'$(PackageValidationBaselineVersion)' == ''">
-      <_PackageValidationIntermediateBaselineFile>$(MSBuildProjectExtensionsPath)$(MSBuildProjectFile).packagevalidation.g.targets</_PackageValidationIntermediateBaselineFile>
-      <_PackageValidationIntermediateBaselineFileContent>
-<![CDATA[<Project>
-  <Target Name="ResetEnablePackageValidation" BeforeTargets="RunPackageValidation">
-    <PropertyGroup>
-     <EnablePackageBaselineValidation>false</EnablePackageBaselineValidation>
-    </PropertyGroup>
-  </Target>
 </Project>]]>
       </_PackageValidationIntermediateBaselineFileContent>
     </PropertyGroup>

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/build/Microsoft.DotNet.PackageValidation.targets
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/build/Microsoft.DotNet.PackageValidation.targets
@@ -81,9 +81,11 @@
       <_PackageValidationIntermediateBaselineFile>$(MSBuildProjectExtensionsPath)$(MSBuildProjectFile).packagevalidation.g.targets</_PackageValidationIntermediateBaselineFile>
       <_PackageValidationIntermediateBaselineFileContent>
 <![CDATA[<Project>
-  <PropertyGroup>
-    <EnablePackageBaselineValidation>false</EnablePackageBaselineValidation>
-  </PropertyGroup>
+  <Target Name="ResetEnablePackageValidation" BeforeTargets="RunPackageValidation">
+    <PropertyGroup>
+     <EnablePackageBaselineValidation>false</EnablePackageBaselineValidation>
+    </PropertyGroup>
+  </Target>
 </Project>]]>
       </_PackageValidationIntermediateBaselineFileContent>
     </PropertyGroup>

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/build/Microsoft.DotNet.PackageValidation.targets
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/build/Microsoft.DotNet.PackageValidation.targets
@@ -2,7 +2,7 @@
 <Project>
   <UsingTask TaskName="Microsoft.DotNet.PackageValidation.ValidatePackage" AssemblyFile="$(DotNetPackageValidationAssembly)" />
   <UsingTask TaskName="Microsoft.DotNet.PackageValidation.GetLastStablePackage" AssemblyFile="$(DotNetPackageValidationAssembly)" />
-  
+
   <PropertyGroup>
     <!-- On static graph build, the CollectPackageDownloads target is invoked per target and there is no other way to run logic only once for all tfms.
          Hence the GetLastStablePackage feature should not be used when using static graph build as it results in a remote call per tfm. -->
@@ -60,18 +60,29 @@
       <Output TaskParameter="LastStableVersion" PropertyName="PackageValidationBaselineVersion" />
     </Microsoft.DotNet.PackageValidation.GetLastStablePackage>
 
-    <ItemGroup>
+    <ItemGroup Condition="'$(PackageValidationBaselineVersion)' != ''">
       <PackageDownload Include="$(PackageValidationBaselineName)"
                        Version="[$(PackageValidationBaselineVersion)]" />
     </ItemGroup>
 
-    <PropertyGroup>
+    <PropertyGroup Condition="'$(PackageValidationBaselineVersion)' != ''">
       <_PackageValidationIntermediateBaselineFile>$(MSBuildProjectExtensionsPath)$(MSBuildProjectFile).packagevalidation.g.props</_PackageValidationIntermediateBaselineFile>
       <_PackageValidationIntermediateBaselineFileContent>
 <![CDATA[<Project>
   <PropertyGroup>
     <_PackageValidationBaselineName>$(PackageValidationBaselineName)</_PackageValidationBaselineName>
     <_PackageValidationBaselineVersion>$(PackageValidationBaselineVersion)</_PackageValidationBaselineVersion>
+  </PropertyGroup>
+</Project>]]>
+      </_PackageValidationIntermediateBaselineFileContent>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(PackageValidationBaselineVersion)' == ''">
+      <_PackageValidationIntermediateBaselineFile>$(MSBuildProjectExtensionsPath)$(MSBuildProjectFile).packagevalidation.g.targets</_PackageValidationIntermediateBaselineFile>
+      <_PackageValidationIntermediateBaselineFileContent>
+<![CDATA[<Project>
+  <PropertyGroup>
+    <EnablePackageBaselineValidation>false</EnablePackageBaselineValidation>
   </PropertyGroup>
 </Project>]]>
       </_PackageValidationIntermediateBaselineFileContent>

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.cs.xlf
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.cs.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BaselinePackageNotFound">
-        <source>Baseline package with id {0} and version less than {2} not found in feeds: {1}.</source>
-        <target state="new">Baseline package with id {0} and version less than {2} not found in feeds: {1}.</target>
+        <source>Baseline package with id {0} and version less than {2} not found in feeds: ({1}).</source>
+        <target state="new">Baseline package with id {0} and version less than {2} not found in feeds: ({1}).</target>
         <note />
       </trans-unit>
       <trans-unit id="CompatibleFrameworkInPackageValidatorHeader">

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.cs.xlf
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.cs.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BaselinePackageNotFound">
-        <source>No baseline package with id {0} found in feeds: {1}.</source>
-        <target state="new">No baseline package with id {0} found in feeds: {1}.</target>
+        <source>Baseline package with id {0} and version less than {2} not found in feeds: {1}.</source>
+        <target state="new">Baseline package with id {0} and version less than {2} not found in feeds: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="CompatibleFrameworkInPackageValidatorHeader">

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.de.xlf
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.de.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BaselinePackageNotFound">
-        <source>Baseline package with id {0} and version less than {2} not found in feeds: {1}.</source>
-        <target state="new">Baseline package with id {0} and version less than {2} not found in feeds: {1}.</target>
+        <source>Baseline package with id {0} and version less than {2} not found in feeds: ({1}).</source>
+        <target state="new">Baseline package with id {0} and version less than {2} not found in feeds: ({1}).</target>
         <note />
       </trans-unit>
       <trans-unit id="CompatibleFrameworkInPackageValidatorHeader">

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.de.xlf
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.de.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BaselinePackageNotFound">
-        <source>No baseline package with id {0} found in feeds: {1}.</source>
-        <target state="new">No baseline package with id {0} found in feeds: {1}.</target>
+        <source>Baseline package with id {0} and version less than {2} not found in feeds: {1}.</source>
+        <target state="new">Baseline package with id {0} and version less than {2} not found in feeds: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="CompatibleFrameworkInPackageValidatorHeader">

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.es.xlf
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.es.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BaselinePackageNotFound">
-        <source>Baseline package with id {0} and version less than {2} not found in feeds: {1}.</source>
-        <target state="new">Baseline package with id {0} and version less than {2} not found in feeds: {1}.</target>
+        <source>Baseline package with id {0} and version less than {2} not found in feeds: ({1}).</source>
+        <target state="new">Baseline package with id {0} and version less than {2} not found in feeds: ({1}).</target>
         <note />
       </trans-unit>
       <trans-unit id="CompatibleFrameworkInPackageValidatorHeader">

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.es.xlf
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.es.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BaselinePackageNotFound">
-        <source>No baseline package with id {0} found in feeds: {1}.</source>
-        <target state="new">No baseline package with id {0} found in feeds: {1}.</target>
+        <source>Baseline package with id {0} and version less than {2} not found in feeds: {1}.</source>
+        <target state="new">Baseline package with id {0} and version less than {2} not found in feeds: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="CompatibleFrameworkInPackageValidatorHeader">

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.fr.xlf
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.fr.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BaselinePackageNotFound">
-        <source>Baseline package with id {0} and version less than {2} not found in feeds: {1}.</source>
-        <target state="new">Baseline package with id {0} and version less than {2} not found in feeds: {1}.</target>
+        <source>Baseline package with id {0} and version less than {2} not found in feeds: ({1}).</source>
+        <target state="new">Baseline package with id {0} and version less than {2} not found in feeds: ({1}).</target>
         <note />
       </trans-unit>
       <trans-unit id="CompatibleFrameworkInPackageValidatorHeader">

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.fr.xlf
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.fr.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BaselinePackageNotFound">
-        <source>No baseline package with id {0} found in feeds: {1}.</source>
-        <target state="new">No baseline package with id {0} found in feeds: {1}.</target>
+        <source>Baseline package with id {0} and version less than {2} not found in feeds: {1}.</source>
+        <target state="new">Baseline package with id {0} and version less than {2} not found in feeds: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="CompatibleFrameworkInPackageValidatorHeader">

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.it.xlf
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.it.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BaselinePackageNotFound">
-        <source>Baseline package with id {0} and version less than {2} not found in feeds: {1}.</source>
-        <target state="new">Baseline package with id {0} and version less than {2} not found in feeds: {1}.</target>
+        <source>Baseline package with id {0} and version less than {2} not found in feeds: ({1}).</source>
+        <target state="new">Baseline package with id {0} and version less than {2} not found in feeds: ({1}).</target>
         <note />
       </trans-unit>
       <trans-unit id="CompatibleFrameworkInPackageValidatorHeader">

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.it.xlf
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.it.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BaselinePackageNotFound">
-        <source>No baseline package with id {0} found in feeds: {1}.</source>
-        <target state="new">No baseline package with id {0} found in feeds: {1}.</target>
+        <source>Baseline package with id {0} and version less than {2} not found in feeds: {1}.</source>
+        <target state="new">Baseline package with id {0} and version less than {2} not found in feeds: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="CompatibleFrameworkInPackageValidatorHeader">

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.ja.xlf
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.ja.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BaselinePackageNotFound">
-        <source>Baseline package with id {0} and version less than {2} not found in feeds: {1}.</source>
-        <target state="new">Baseline package with id {0} and version less than {2} not found in feeds: {1}.</target>
+        <source>Baseline package with id {0} and version less than {2} not found in feeds: ({1}).</source>
+        <target state="new">Baseline package with id {0} and version less than {2} not found in feeds: ({1}).</target>
         <note />
       </trans-unit>
       <trans-unit id="CompatibleFrameworkInPackageValidatorHeader">

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.ja.xlf
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.ja.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BaselinePackageNotFound">
-        <source>No baseline package with id {0} found in feeds: {1}.</source>
-        <target state="new">No baseline package with id {0} found in feeds: {1}.</target>
+        <source>Baseline package with id {0} and version less than {2} not found in feeds: {1}.</source>
+        <target state="new">Baseline package with id {0} and version less than {2} not found in feeds: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="CompatibleFrameworkInPackageValidatorHeader">

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.ko.xlf
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.ko.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BaselinePackageNotFound">
-        <source>Baseline package with id {0} and version less than {2} not found in feeds: {1}.</source>
-        <target state="new">Baseline package with id {0} and version less than {2} not found in feeds: {1}.</target>
+        <source>Baseline package with id {0} and version less than {2} not found in feeds: ({1}).</source>
+        <target state="new">Baseline package with id {0} and version less than {2} not found in feeds: ({1}).</target>
         <note />
       </trans-unit>
       <trans-unit id="CompatibleFrameworkInPackageValidatorHeader">

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.ko.xlf
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.ko.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BaselinePackageNotFound">
-        <source>No baseline package with id {0} found in feeds: {1}.</source>
-        <target state="new">No baseline package with id {0} found in feeds: {1}.</target>
+        <source>Baseline package with id {0} and version less than {2} not found in feeds: {1}.</source>
+        <target state="new">Baseline package with id {0} and version less than {2} not found in feeds: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="CompatibleFrameworkInPackageValidatorHeader">

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.pl.xlf
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.pl.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BaselinePackageNotFound">
-        <source>Baseline package with id {0} and version less than {2} not found in feeds: {1}.</source>
-        <target state="new">Baseline package with id {0} and version less than {2} not found in feeds: {1}.</target>
+        <source>Baseline package with id {0} and version less than {2} not found in feeds: ({1}).</source>
+        <target state="new">Baseline package with id {0} and version less than {2} not found in feeds: ({1}).</target>
         <note />
       </trans-unit>
       <trans-unit id="CompatibleFrameworkInPackageValidatorHeader">

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.pl.xlf
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.pl.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BaselinePackageNotFound">
-        <source>No baseline package with id {0} found in feeds: {1}.</source>
-        <target state="new">No baseline package with id {0} found in feeds: {1}.</target>
+        <source>Baseline package with id {0} and version less than {2} not found in feeds: {1}.</source>
+        <target state="new">Baseline package with id {0} and version less than {2} not found in feeds: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="CompatibleFrameworkInPackageValidatorHeader">

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.pt-BR.xlf
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.pt-BR.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BaselinePackageNotFound">
-        <source>Baseline package with id {0} and version less than {2} not found in feeds: {1}.</source>
-        <target state="new">Baseline package with id {0} and version less than {2} not found in feeds: {1}.</target>
+        <source>Baseline package with id {0} and version less than {2} not found in feeds: ({1}).</source>
+        <target state="new">Baseline package with id {0} and version less than {2} not found in feeds: ({1}).</target>
         <note />
       </trans-unit>
       <trans-unit id="CompatibleFrameworkInPackageValidatorHeader">

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.pt-BR.xlf
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.pt-BR.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BaselinePackageNotFound">
-        <source>No baseline package with id {0} found in feeds: {1}.</source>
-        <target state="new">No baseline package with id {0} found in feeds: {1}.</target>
+        <source>Baseline package with id {0} and version less than {2} not found in feeds: {1}.</source>
+        <target state="new">Baseline package with id {0} and version less than {2} not found in feeds: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="CompatibleFrameworkInPackageValidatorHeader">

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.ru.xlf
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.ru.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BaselinePackageNotFound">
-        <source>Baseline package with id {0} and version less than {2} not found in feeds: {1}.</source>
-        <target state="new">Baseline package with id {0} and version less than {2} not found in feeds: {1}.</target>
+        <source>Baseline package with id {0} and version less than {2} not found in feeds: ({1}).</source>
+        <target state="new">Baseline package with id {0} and version less than {2} not found in feeds: ({1}).</target>
         <note />
       </trans-unit>
       <trans-unit id="CompatibleFrameworkInPackageValidatorHeader">

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.ru.xlf
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.ru.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BaselinePackageNotFound">
-        <source>No baseline package with id {0} found in feeds: {1}.</source>
-        <target state="new">No baseline package with id {0} found in feeds: {1}.</target>
+        <source>Baseline package with id {0} and version less than {2} not found in feeds: {1}.</source>
+        <target state="new">Baseline package with id {0} and version less than {2} not found in feeds: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="CompatibleFrameworkInPackageValidatorHeader">

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.tr.xlf
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.tr.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BaselinePackageNotFound">
-        <source>Baseline package with id {0} and version less than {2} not found in feeds: {1}.</source>
-        <target state="new">Baseline package with id {0} and version less than {2} not found in feeds: {1}.</target>
+        <source>Baseline package with id {0} and version less than {2} not found in feeds: ({1}).</source>
+        <target state="new">Baseline package with id {0} and version less than {2} not found in feeds: ({1}).</target>
         <note />
       </trans-unit>
       <trans-unit id="CompatibleFrameworkInPackageValidatorHeader">

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.tr.xlf
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.tr.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BaselinePackageNotFound">
-        <source>No baseline package with id {0} found in feeds: {1}.</source>
-        <target state="new">No baseline package with id {0} found in feeds: {1}.</target>
+        <source>Baseline package with id {0} and version less than {2} not found in feeds: {1}.</source>
+        <target state="new">Baseline package with id {0} and version less than {2} not found in feeds: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="CompatibleFrameworkInPackageValidatorHeader">

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.zh-Hans.xlf
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.zh-Hans.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BaselinePackageNotFound">
-        <source>Baseline package with id {0} and version less than {2} not found in feeds: {1}.</source>
-        <target state="new">Baseline package with id {0} and version less than {2} not found in feeds: {1}.</target>
+        <source>Baseline package with id {0} and version less than {2} not found in feeds: ({1}).</source>
+        <target state="new">Baseline package with id {0} and version less than {2} not found in feeds: ({1}).</target>
         <note />
       </trans-unit>
       <trans-unit id="CompatibleFrameworkInPackageValidatorHeader">

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.zh-Hans.xlf
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.zh-Hans.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BaselinePackageNotFound">
-        <source>No baseline package with id {0} found in feeds: {1}.</source>
-        <target state="new">No baseline package with id {0} found in feeds: {1}.</target>
+        <source>Baseline package with id {0} and version less than {2} not found in feeds: {1}.</source>
+        <target state="new">Baseline package with id {0} and version less than {2} not found in feeds: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="CompatibleFrameworkInPackageValidatorHeader">

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.zh-Hant.xlf
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.zh-Hant.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BaselinePackageNotFound">
-        <source>Baseline package with id {0} and version less than {2} not found in feeds: {1}.</source>
-        <target state="new">Baseline package with id {0} and version less than {2} not found in feeds: {1}.</target>
+        <source>Baseline package with id {0} and version less than {2} not found in feeds: ({1}).</source>
+        <target state="new">Baseline package with id {0} and version less than {2} not found in feeds: ({1}).</target>
         <note />
       </trans-unit>
       <trans-unit id="CompatibleFrameworkInPackageValidatorHeader">

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.zh-Hant.xlf
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.zh-Hant.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BaselinePackageNotFound">
-        <source>No baseline package with id {0} found in feeds: {1}.</source>
-        <target state="new">No baseline package with id {0} found in feeds: {1}.</target>
+        <source>Baseline package with id {0} and version less than {2} not found in feeds: {1}.</source>
+        <target state="new">Baseline package with id {0} and version less than {2} not found in feeds: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="CompatibleFrameworkInPackageValidatorHeader">

--- a/src/Tasks/Common/Logger.cs
+++ b/src/Tasks/Common/Logger.cs
@@ -62,6 +62,9 @@ namespace Microsoft.NET.Build.Tasks
         public void LogWarning(string format, params string[] args)
             => Log(CreateMessage(MessageLevel.Warning, format, args));
 
+        public void LogNonSdkWarning(string code, string format, params string[] args)
+            => Log(new Message(MessageLevel.Warning, string.Format(format, args), code));
+
         public void LogError(string format, params string[] args)
             => Log(CreateMessage(MessageLevel.Error, format, args));
 


### PR DESCRIPTION
Fixes: https://github.com/dotnet/sdk/issues/17721

- Log Warning if no baseline package is found in feeds
- Set EnablePackageValidation to false in generated targets file
- Continue with the rest of validation

```
C:\Program Files\dotnet\sdk\6.0.100-preview.3.21202.5\MSBuild.dll -distributedlogger:Microsoft.DotNet.Tools.MSBuild.MSBuildLogger,C:\Program Files\dotnet\sdk\6.0.100-preview.3.21202.5\dotnet.dll*Microsoft.DotNet.Tools.MSBuild.MSBuildForwardingLogger,C:\Program Files\dotnet\sdk\6.0.100-preview.3.21202.5\dotnet.dll -maxcpucount -restore -target:pack -verbosity:m /bl .\CheckIfZero.csproj
  Determining projects to restore...
C:\Users\anagniho\.nuget\packages\microsoft.dotnet.packagevalidation\1.0.0-dev\build\Microsoft.DotNet.PackageValidation.targets(55,5): warning   : No baseline package with id CheckIfZero found in feeds:  [E:\AllHands\CheckIfZero\CheckIfZero.csproj]
C:\Users\anagniho\.nuget\packages\microsoft.dotnet.packagevalidation\1.0.0-dev\build\Microsoft.DotNet.PackageValidation.targets(55,5): warning  : E:\LocalFeed [E:\AllHands\CheckIfZero\CheckIfZero.csproj]
C:\Users\anagniho\.nuget\packages\microsoft.dotnet.packagevalidation\1.0.0-dev\build\Microsoft.DotNet.PackageValidation.targets(55,5): warning  :  - https://api.nuget.org/v3/index.json. [E:\AllHands\CheckIfZero\CheckIfZero.csproj]
  All projects are up-to-date for restore.
  You are using a preview version of .NET. See: https://aka.ms/dotnet-core-preview
  You are using a preview version of .NET. See: https://aka.ms/dotnet-core-preview
  CheckIfZero -> E:\AllHands\CheckIfZero\bin\Debug\net6.0\CheckIfZero.dll
  CheckIfZero -> E:\AllHands\CheckIfZero\bin\Debug\netstandard2.0\CheckIfZero.dll
  Successfully created package 'E:\AllHands\CheckIfZero\bin\Debug\CheckIfZero.1.0.0.nupkg'.

```

i added the warning code as well.