### PR TITLE
Add support for Pgo Mibc files to be used by the SDK

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolveRuntimePackAssets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveRuntimePackAssets.cs
@@ -91,13 +91,6 @@ namespace Microsoft.NET.Build.Tasks
                 {
                     throw new BuildErrorException(string.Format(Strings.RuntimeListNotFound, runtimeListPath));
                 }
-
-                foreach (var mibcFile in Directory.GetFiles(Path.Combine(runtimePackRoot, "tools"), "*.mibc")
-                {
-                    var assetItem = CreateAssetItem(mibcFile.FullPath, "pgodatafile", runtimePack, null);
-                    assetItem.SetMetadata("DropFromSingleFile", true);
-                    runtimePackAssets.Add(assetItem);
-                }
             }
 
             RuntimePackAssets = runtimePackAssets.ToArray();
@@ -124,6 +117,10 @@ namespace Microsoft.NET.Build.Tasks
                 else if (typeAttributeValue.Equals("Native", StringComparison.OrdinalIgnoreCase))
                 {
                     assetType = "native";
+                }
+                else if (typeAttributeValue.Equals("PgoData", StringComparison.OrdinalIgnoreCase))
+                {
+                    assetType = "pgodata";
                 }
                 else if (typeAttributeValue.Equals("Resources", StringComparison.OrdinalIgnoreCase))
                 {
@@ -173,7 +170,9 @@ namespace Microsoft.NET.Build.Tasks
 
             var assetItem = new TaskItem(assetPath);
 
-            assetItem.SetMetadata(MetadataKeys.CopyLocal, "true");
+            if (assetType != "pgodata")
+                assetItem.SetMetadata(MetadataKeys.CopyLocal, "true");
+
             if (string.IsNullOrEmpty(culture))
             {
                 assetItem.SetMetadata(MetadataKeys.DestinationSubPath, Path.GetFileName(assetPath));

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolveRuntimePackAssets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveRuntimePackAssets.cs
@@ -91,6 +91,13 @@ namespace Microsoft.NET.Build.Tasks
                 {
                     throw new BuildErrorException(string.Format(Strings.RuntimeListNotFound, runtimeListPath));
                 }
+
+                foreach (var mibcFile in Directory.GetFiles(Path.Combine(runtimePackRoot, "tools"), "*.mibc")
+                {
+                    var assetItem = CreateAssetItem(mibcFile.FullPath, "pgodatafile", runtimePack, null);
+                    assetItem.SetMetadata("DropFromSingleFile", true);
+                    runtimePackAssets.Add(assetItem);
+                }
             }
 
             RuntimePackAssets = runtimePackAssets.ToArray();

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolvedFile.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolvedFile.cs
@@ -13,7 +13,8 @@ namespace Microsoft.NET.Build.Tasks
         None,
         Runtime,
         Native,
-        Resources
+        Resources,
+        PgoData
     }
 
     internal class ResolvedFile

--- a/src/Tasks/Microsoft.NET.Build.Tasks/RunReadyToRunCompiler.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/RunReadyToRunCompiler.cs
@@ -330,9 +330,12 @@ namespace Microsoft.NET.Build.Tasks
                 }
             }
 
-            foreach (var mibc in Crossgen2PgoFiles)
+            if (Crossgen2PgoFiles != null)
             {
-                result.AppendLine($"-m:\"{mibc.ItemSpec}\"");
+                foreach (var mibc in Crossgen2PgoFiles)
+                {
+                    result.AppendLine($"-m:\"{mibc.ItemSpec}\"");
+                }
             }
 
             if (!string.IsNullOrEmpty(Crossgen2ExtraCommandLineArgs))

--- a/src/Tasks/Microsoft.NET.Build.Tasks/RunReadyToRunCompiler.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/RunReadyToRunCompiler.cs
@@ -25,6 +25,7 @@ namespace Microsoft.NET.Build.Tasks
         public bool ShowCompilerWarnings { get; set; }
         public bool UseCrossgen2 { get; set; }
         public string Crossgen2ExtraCommandLineArgs { get; set; }
+        public ITaskItem[] Crossgen2PgoFiles { get; set; }
 
         [Output]
         public bool WarningsDetected { get; set; }
@@ -327,6 +328,11 @@ namespace Microsoft.NET.Build.Tasks
                     result.AppendLine("--perfmap");
                     result.AppendLine($"--perfmap-path:{Path.GetDirectoryName(_outputPDBImage)}");
                 }
+            }
+
+            foreach (var mibc in Crossgen2PgoData)
+            {
+                result.AppendLine($"-m:\"{mibc.ItemSpec}\"");
             }
 
             if (!string.IsNullOrEmpty(Crossgen2ExtraCommandLineArgs))

--- a/src/Tasks/Microsoft.NET.Build.Tasks/RunReadyToRunCompiler.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/RunReadyToRunCompiler.cs
@@ -330,7 +330,7 @@ namespace Microsoft.NET.Build.Tasks
                 }
             }
 
-            foreach (var mibc in Crossgen2PgoData)
+            foreach (var mibc in Crossgen2PgoFiles)
             {
                 result.AppendLine($"-m:\"{mibc.ItemSpec}\"");
             }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/RuntimePackAssetInfo.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/RuntimePackAssetInfo.cs
@@ -39,6 +39,10 @@ namespace Microsoft.NET.Build.Tasks
             {
                 assetInfo.AssetType = AssetType.Resources;
             }
+            else if (assetTypeString.Equals("pgodata", StringComparison.OrdinalIgnoreCase))
+            {
+                assetInfo.AssetType = AssetType.PgoData;
+            }
             else
             {
                 throw new InvalidOperationException("Unexpected asset type: " + item.GetMetadata(MetadataKeys.AssetType));

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.CrossGen.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.CrossGen.targets
@@ -399,6 +399,8 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <ItemGroup>
       <_ReadyToRunPgoFiles Include="@(PublishReadyToRunPgoFiles)" />
+      <_ReadyToRunPgoFiles Include="@(RuntimePackAsset)"
+                          Condition="'%(RuntimePackAsset.AssetType)' == 'pgodata' and '%(RuntimePackAsset.Extension)' == '.mibc' and '$(PublishReadyToRunDisableRuntimePackOptimizationData)' != 'true'" />
     </ItemGroup>
 
     <PrepareForReadyToRunCompilation CrossgenTool="@(CrossgenTool)"

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.CrossGen.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.CrossGen.targets
@@ -367,7 +367,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     Prepare build for ReadyToRun compilations. Builds list of assemblies to compile, and computes paths to ReadyToRun compiler bits
     ============================================================
     -->
-  <UsingTask Condition="'$(Crossgen2TasksOverriden)' != 'true'"  TaskName="PrepareForReadyToRunCompilation" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)"/>
+  <UsingTask Condition="'$(Crossgen2TasksOverriden)' != 'true'" TaskName="PrepareForReadyToRunCompilation" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
   <Target Name="_PrepareForReadyToRunCompilation" DependsOnTargets="ResolveReadyToRunCompilers;_ComputeManagedRuntimePackAssemblies;_ComputeAssembliesToPostprocessOnPublish">
 
     <PropertyGroup>
@@ -395,6 +395,10 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ItemGroup Condition="'$(SelfContained)' != 'true'">
       <_ReadyToRunImplementationAssemblies Remove="@(_ReadyToRunImplementationAssemblies)" />
       <_ReadyToRunImplementationAssemblies Include="@(_ReadyToRunImplementationAssembliesWithoutConflicts)" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <_ReadyToRunPgoFiles Include="@(PublishReadyToRunPgoFiles)" />
     </ItemGroup>
 
     <PrepareForReadyToRunCompilation CrossgenTool="@(CrossgenTool)"
@@ -444,12 +448,13 @@ Copyright (c) .NET Foundation. All rights reserved.
     -->
   <UsingTask Condition="'$(Crossgen2TasksOverriden)' != 'true'" TaskName="RunReadyToRunCompiler" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
   <Target Name="_CreateR2RImages"
-          Inputs="@(_ReadyToRunCompileList);@(_ReadyToRunCompositeBuildInput)"
+          Inputs="@(_ReadyToRunCompileList);@(_ReadyToRunCompositeBuildInput);@(_ReadyToRunPgoFiles)"
           Outputs="%(_ReadyToRunCompileList.OutputR2RImage);%(_ReadyToRunCompileList.OutputPDBImage)">
 
     <RunReadyToRunCompiler CrossgenTool="@(CrossgenTool)"
                            Crossgen2Tool="@(Crossgen2Tool)"
                            UseCrossgen2="$(PublishReadyToRunUseCrossgen2)"
+                           Crossgen2PgoFiles="@(_ReadyToRunPgoFiles)"
                            Crossgen2ExtraCommandLineArgs="$(PublishReadyToRunCrossgen2ExtraArgs)"
                            ImplementationAssemblyReferences="@(_ReadyToRunAssembliesToReference)"
                            ShowCompilerWarnings="$(PublishReadyToRunShowWarnings)"

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.CrossGen.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.CrossGen.targets
@@ -17,6 +17,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <PublishReadyToRunComposite Condition="'$(PublishReadyToRunComposite)' == '' and '$(_TargetFrameworkVersionWithoutV)' >= '6.0'">false</PublishReadyToRunComposite>
     <PublishReadyToRunComposite Condition="'$(PublishReadyToRunComposite)' == ''">true</PublishReadyToRunComposite>
     <PublishReadyToRunComposite Condition="'$(PublishReadyToRunUseCrossgen2)' != 'true' or '$(SelfContained)' != 'true'">false</PublishReadyToRunComposite>
+    <PublishReadyToRunUseRuntimePackOptimizationData Condition="'$(PublishReadyToRunUseRuntimePackOptimizationData)' == ''>true</PublishReadyToRunUseRuntimePackOptimizationData>
   </PropertyGroup>
 
   <!--
@@ -400,7 +401,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ItemGroup>
       <_ReadyToRunPgoFiles Include="@(PublishReadyToRunPgoFiles)" />
       <_ReadyToRunPgoFiles Include="@(RuntimePackAsset)"
-                          Condition="'%(RuntimePackAsset.AssetType)' == 'pgodata' and '%(RuntimePackAsset.Extension)' == '.mibc' and ('$(PublishReadyToRunUseRuntimePackOptimizationData)' == 'true' or '$(PublishReadyToRunUseRuntimePackOptimizationData)' == '')" />
+                           Condition="'%(RuntimePackAsset.AssetType)' == 'pgodata' and '%(RuntimePackAsset.Extension)' == '.mibc' and '$(PublishReadyToRunUseRuntimePackOptimizationData)' == 'true'" />
     </ItemGroup>
 
     <PrepareForReadyToRunCompilation CrossgenTool="@(CrossgenTool)"

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.CrossGen.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.CrossGen.targets
@@ -400,7 +400,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ItemGroup>
       <_ReadyToRunPgoFiles Include="@(PublishReadyToRunPgoFiles)" />
       <_ReadyToRunPgoFiles Include="@(RuntimePackAsset)"
-                          Condition="'%(RuntimePackAsset.AssetType)' == 'pgodata' and '%(RuntimePackAsset.Extension)' == '.mibc' and '$(PublishReadyToRunDisableRuntimePackOptimizationData)' != 'true'" />
+                          Condition="'%(RuntimePackAsset.AssetType)' == 'pgodata' and '%(RuntimePackAsset.Extension)' == '.mibc' and ('$(PublishReadyToRunUseRuntimePackOptimizationData)' == 'true' or '$(PublishReadyToRunUseRuntimePackOptimizationData)' == '')" />
     </ItemGroup>
 
     <PrepareForReadyToRunCompilation CrossgenTool="@(CrossgenTool)"

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.CrossGen.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.CrossGen.targets
@@ -17,7 +17,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <PublishReadyToRunComposite Condition="'$(PublishReadyToRunComposite)' == '' and '$(_TargetFrameworkVersionWithoutV)' >= '6.0'">false</PublishReadyToRunComposite>
     <PublishReadyToRunComposite Condition="'$(PublishReadyToRunComposite)' == ''">true</PublishReadyToRunComposite>
     <PublishReadyToRunComposite Condition="'$(PublishReadyToRunUseCrossgen2)' != 'true' or '$(SelfContained)' != 'true'">false</PublishReadyToRunComposite>
-    <PublishReadyToRunUseRuntimePackOptimizationData Condition="'$(PublishReadyToRunUseRuntimePackOptimizationData)' == ''>true</PublishReadyToRunUseRuntimePackOptimizationData>
+    <PublishReadyToRunUseRuntimePackOptimizationData Condition="'$(PublishReadyToRunUseRuntimePackOptimizationData)' == ''">true</PublishReadyToRunUseRuntimePackOptimizationData>
   </PropertyGroup>
 
   <!--

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -499,7 +499,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
       <ItemGroup>
         <_ResolvedCopyLocalPublishAssets Include="@(RuntimePackAsset)"
-                                         Condition="'$(SelfContained)' == 'true' Or '%(RuntimePackAsset.RuntimePackAlwaysCopyLocal)' == 'true'" />
+                                         Condition="('$(SelfContained)' == 'true' Or '%(RuntimePackAsset.RuntimePackAlwaysCopyLocal)' == 'true') and '%(RuntimePackAsset.AssetType)' != 'pgodata'" />
       </ItemGroup>
 
       <ItemGroup Condition="'$(_UseBuildDependencyFile)' != 'true'">

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets
@@ -398,7 +398,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <ItemGroup>
       <ReferenceCopyLocalPaths Include="@(RuntimePackAsset)"
-                               Condition="'$(CopyLocalLockFileAssemblies)' == 'true' and ('$(SelfContained)' == 'true' or '%(RuntimePackAsset.RuntimePackAlwaysCopyLocal)' == 'true')" />
+                               Condition="'$(CopyLocalLockFileAssemblies)' == 'true' and ('$(SelfContained)' == 'true' or '%(RuntimePackAsset.RuntimePackAlwaysCopyLocal)' == 'true') and '%(RuntimePackAsset.AssetType)' != 'pgodata'" />
     </ItemGroup>
 
 


### PR DESCRIPTION
- A new ItemList (PublishReadyToRunPgoFiles) can be used to specify a custom list of Mibc files
- Any Mibc files defined in associated RuntimePacks via a RuntimeAsset with AssetType PgoData will also be included
  - This behavior can be disabled by setting PublishReadyToRunUseRuntimePackOptimizationData to false
