### PR TITLE
use display string instead of name for namespaces

### DIFF
--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/DefaultSymbolsEqualityComparer.cs
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/DefaultSymbolsEqualityComparer.cs
@@ -16,16 +16,6 @@ namespace Microsoft.DotNet.ApiCompatibility
         public int GetHashCode(ISymbol obj) =>
             GetKey(obj).GetHashCode();
 
-        private static string GetKey(ISymbol symbol) =>
-            symbol switch
-            {
-                IMethodSymbol => symbol.ToComparisonDisplayString(),
-                IFieldSymbol => symbol.ToComparisonDisplayString(),
-                IPropertySymbol => symbol.ToComparisonDisplayString(),
-                IEventSymbol => symbol.ToComparisonDisplayString(),
-                ITypeSymbol => symbol.ToComparisonDisplayString(),
-                INamespaceSymbol => symbol.ToComparisonDisplayString(),
-                _ => symbol.ToComparisonDisplayString(),
-            };
+        private static string GetKey(ISymbol symbol) => symbol.ToComparisonDisplayString();
     }
 }

--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/DefaultSymbolsEqualityComparer.cs
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/DefaultSymbolsEqualityComparer.cs
@@ -24,7 +24,8 @@ namespace Microsoft.DotNet.ApiCompatibility
                 IPropertySymbol => symbol.ToComparisonDisplayString(),
                 IEventSymbol => symbol.ToComparisonDisplayString(),
                 ITypeSymbol => symbol.ToComparisonDisplayString(),
-                _ => symbol.Name,
+                INamespaceSymbol => symbol.ToComparisonDisplayString(),
+                _ => symbol.ToComparisonDisplayString(),
             };
     }
 }

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/BaselinePackageValidator.cs
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/BaselinePackageValidator.cs
@@ -56,7 +56,7 @@ namespace Microsoft.DotNet.PackageValidation
                         baselineCompileTimeAsset.Path,
                         package.PackagePath,
                         latestCompileTimeAsset.Path,
-                        Path.GetFileName(package.PackagePath),
+                        package.PackageId,
                         Resources.BaselineVersionValidatorHeader,
                         string.Format(Resources.ApiCompatibilityBaselineHeader, baselineCompileTimeAsset.Path, latestCompileTimeAsset.Path, _baselinePackage.Version, package.Version));
                 }
@@ -81,7 +81,7 @@ namespace Microsoft.DotNet.PackageValidation
                             baselineRuntimeAsset.Path,
                             package.PackagePath, 
                             latestRuntimeAsset.Path,
-                            Path.GetFileName(package.PackagePath),
+                            package.PackageId,
                             Resources.BaselineVersionValidatorHeader,
                             string.Format(Resources.ApiCompatibilityBaselineHeader, baselineRuntimeAsset.Path, latestRuntimeAsset.Path, _baselinePackage.Version, package.Version));
                     }
@@ -108,7 +108,7 @@ namespace Microsoft.DotNet.PackageValidation
                             baselineRuntimeSpecificAsset.Path,
                             package.PackagePath, 
                             latestRuntimeSpecificAsset.Path,
-                            Path.GetFileName(package.PackagePath),
+                            package.PackageId,
                             Resources.BaselineVersionValidatorHeader,
                             string.Format(Resources.BaselineVersionValidatorHeader, baselineRuntimeSpecificAsset.Path, latestRuntimeSpecificAsset.Path, _baselinePackage.Version, package.Version));
                     }

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/CompatibleFrameworkInPackageValidator.cs
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/CompatibleFrameworkInPackageValidator.cs
@@ -57,7 +57,7 @@ namespace Microsoft.DotNet.PackageValidation
                         compatibleFrameworkAsset.Path,
                         package.PackagePath,
                         compileTimeAsset.Path,
-                        Path.GetFileName(package.PackagePath),
+                        package.PackageId,
                         string.Format(Resources.CompatibleFrameworkInPackageValidatorHeader, ((NuGetFramework)compatibleFrameworkAsset.Properties["tfm"]).ToString(), framework.ToString()),
                         string.Format(Resources.ApiCompatibilityHeader, compatibleFrameworkAsset.Path, compileTimeAsset.Path));
                 }

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/CompatibleTFMValidator.cs
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/CompatibleTFMValidator.cs
@@ -79,7 +79,7 @@ namespace Microsoft.DotNet.PackageValidation
                             compileTimeAsset.Path,
                             package.PackagePath,
                             runtimeAsset.Path,
-                            Path.GetFileName(package.PackagePath),
+                            package.PackageId,
                             Resources.CompatibleTfmValidatorHeader,
                             string.Format(Resources.ApiCompatibilityHeader, compileTimeAsset.Path, runtimeAsset.Path));
                     }
@@ -103,7 +103,7 @@ namespace Microsoft.DotNet.PackageValidation
                                 compileTimeAsset.Path,
                                 package.PackagePath, 
                                 runtimeAsset.Path,
-                                Path.GetFileName(package.PackagePath),
+                                package.PackageId,
                                 Resources.CompatibleTfmValidatorHeader,
                                 string.Format(Resources.ApiCompatibilityHeader, compileTimeAsset.Path, runtimeAsset.Path));
                         }

--- a/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/Rules/TypeMustExistTests.cs
+++ b/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/Rules/TypeMustExistTests.cs
@@ -75,7 +75,7 @@ namespace B.B
             bool enableNullable = false;
             IAssemblySymbol left = SymbolFactory.GetAssemblyFromSyntax(leftSyntax, enableNullable);
             IAssemblySymbol right = SymbolFactory.GetAssemblyFromSyntax(rightSyntax, enableNullable);
-            IEnumerable<CompatDifference> differences = differ.GetDifferences(new[] { left }, new[] { right });
+            IEnumerable<CompatDifference> differences = differ.GetDifferences(left , right);
 
             CompatDifference[] expected = new[]
             {
@@ -141,7 +141,7 @@ namespace CompatTests
             IAssemblySymbol left = SymbolFactory.GetAssemblyFromSyntaxWithReferences(leftSyntax, new[] { forwardedTypeSyntax }, includeDefaultReferences: true);
             IAssemblySymbol right = SymbolFactory.GetAssemblyFromSyntax(rightSyntax);
             ApiComparer differ = new();
-            IEnumerable<CompatDifference> differences = differ.GetDifferences(new[] { left }, new[] { right });
+            IEnumerable<CompatDifference> differences = differ.GetDifferences(left, right);
 
             CompatDifference[] expected = new[]
             {

--- a/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/Rules/TypeMustExistTests.cs
+++ b/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/Rules/TypeMustExistTests.cs
@@ -56,6 +56,66 @@ namespace CompatTests
         }
 
         [Fact]
+        public void TypeInDifferentNamespaces()
+        {
+
+            string leftSyntax = @"
+namespace A.B
+{
+  public class C { }
+}
+";
+            string rightSyntax = @"
+namespace B.B
+{
+  public class C { }
+}
+";
+            ApiComparer differ = new();
+            bool enableNullable = false;
+            IAssemblySymbol left = SymbolFactory.GetAssemblyFromSyntax(leftSyntax, enableNullable);
+            IAssemblySymbol right = SymbolFactory.GetAssemblyFromSyntax(rightSyntax, enableNullable);
+            IEnumerable<CompatDifference> differences = differ.GetDifferences(new[] { left }, new[] { right });
+
+            CompatDifference[] expected = new[]
+            {
+                new CompatDifference(DiagnosticIds.TypeMustExist, string.Empty, DifferenceType.Removed, "T:A.B.C"),
+            };
+
+            Assert.Equal(expected, differences, CompatDifferenceComparer.Default);
+        }
+
+        [Fact]
+        public void NestedTypeVsNamespaces()
+        {
+
+            string leftSyntax = @"
+namespace A
+{
+  public class B { }
+}
+";
+            string rightSyntax = @"
+public class A
+{
+  public class B { }
+}
+";
+            ApiComparer differ = new();
+            bool enableNullable = false;
+            IAssemblySymbol left = SymbolFactory.GetAssemblyFromSyntax(leftSyntax, enableNullable);
+            IAssemblySymbol right = SymbolFactory.GetAssemblyFromSyntax(rightSyntax, enableNullable);
+            IEnumerable<CompatDifference> differences = differ.GetDifferences(new[] { left }, new[] { right });
+
+            CompatDifference[] expected = new[]
+            {
+                new CompatDifference(DiagnosticIds.TypeMustExist, string.Empty, DifferenceType.Removed, "T:A.B"),
+            };
+
+            Assert.Equal(expected, differences, CompatDifferenceComparer.Default);
+        }
+
+        [Fact]
         public void MissingTypeFromTypeForwardIsReported()
         {
             string forwardedTypeSyntax = @"


### PR DESCRIPTION
Symbol.name was returning the same output for fxResources.Microsoft.Extensions.FileGlobbing and Microsoft.Extensions.FileGlobbing., due to which we were getting false positives here https://github.com/dotnet/runtime/pull/52741

Display string fixes this issue. 

The assembly name was being passed with .version.nupkg, passing the package id. (No known effect of this but correcting it as required by apicompat)