### PR TITLE
Add ExistingManifestVersion, AvailableUpdateManifestVersion to mock

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-workload/list/WorkloadListCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/list/WorkloadListCommand.cs
@@ -85,7 +85,7 @@ namespace Microsoft.DotNet.Workloads.Workload.List
             if (!File.Exists(Path.Combine(MockUpdateDirectory,
                 "Microsoft.NET.Workload.Android.6.0.100.nupkg")))
             {
-                updateList.Add(new UpdateAvailableEntry("6.0.100",
+                updateList.Add(new UpdateAvailableEntry("6.0.100", "6.0.101",
                     _mockAndroidDescription,
                     "microsoft-android-sdk-full"));
             }
@@ -93,7 +93,7 @@ namespace Microsoft.DotNet.Workloads.Workload.List
             if (!File.Exists(Path.Combine(MockUpdateDirectory,
                 "Microsoft.iOS.Bundle.6.0.100.nupkg")))
             {
-                updateList.Add(new UpdateAvailableEntry("6.0.100",
+                updateList.Add(new UpdateAvailableEntry("6.0.100", "6.0.101",
                     _mockIosDescription,
                     "microsoft-ios-sdk-full"));
             }
@@ -103,7 +103,7 @@ namespace Microsoft.DotNet.Workloads.Workload.List
 
         internal record ListOutput(string[] Installed, UpdateAvailableEntry[] UpdateAvailable);
 
-        internal record UpdateAvailableEntry(string ManifestVersion, string Description, string WorkloadId);
+        internal record UpdateAvailableEntry(string ExistingManifestVersion, string AvailableUpdateManifestVersion, string Description, string WorkloadId);
 
         private readonly string _mockIosDescription =
             $"ios-workload-description: for testing you can delete the content of {MockUpdateDirectory} to revert the mock update";


### PR DESCRIPTION
This is more like updating "the spec". Use existingManifestVersion and availableUpdateManifestVersion to show both "before" and "after" manifest version

```
==workloadListJsonOutputStart==
{"installed":[],"updateAvailable":[{"existingManifestVersion":"6.0.100","availableUpdateManifestVersion":"6.0.101","description":"android-workload-description: for testing you can delete the content of C:\\work\\sdk\\artifacts\\bin\\redist\\Debug\\dotnet\\DEV_mockworkloads\\update to revert the mock update","workloadId":"microsoft-android-sdk-full"},{"existingManifestVersion":"6.0.100","availableUpdateManifestVersion":"6.0.101","description":"ios-workload-description: for testing you can delete the content of C:\\work\\sdk\\artifacts\\bin\\redist\\Debug\\dotnet\\DEV_mockworkloads\\update to revert the mock update","workloadId":"microsoft-ios-sdk-full"}]}
==workloadListJsonOutputEnd==
```

pretty json
```json
[
   {
      "existingManifestVersion":"6.0.100",
      "availableUpdateManifestVersion":"6.0.101",
      "description":"android-workload-description: for testing you can delete the content of C:\\work\\sdk\\artifacts\\bin\\redist\\Debug\\dotnet\\DEV_mockworkloads\\update to revert the mock update",
      "workloadId":"microsoft-android-sdk-full"
   },
   {
      "existingManifestVersion":"6.0.100",
      "availableUpdateManifestVersion":"6.0.101",
      "description":"ios-workload-description: for testing you can delete the content of C:\\work\\sdk\\artifacts\\bin\\redist\\Debug\\dotnet\\DEV_mockworkloads\\update to revert the mock update",
      "workloadId":"microsoft-ios-sdk-full"
   }
]
```