### PR TITLE
fixing when we dont want to run baseline validation 

### DIFF
--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/build/Microsoft.DotNet.PackageValidation.targets
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/build/Microsoft.DotNet.PackageValidation.targets
@@ -18,7 +18,7 @@
       <PackageValidationBaselinePath Condition="'$(PackageValidationBaselinePath)' == '' and '$(PackageValidationBaselineVersion)' != ''">$([MSBuild]::NormalizePath('$(NuGetPackageRoot)', '$(PackageValidationBaselineName.ToLower())', '$(PackageValidationBaselineVersion)', '$(PackageValidationBaselineName.ToLower()).$(PackageValidationBaselineVersion).nupkg'))</PackageValidationBaselinePath>
     </PropertyGroup>
 
-    <Error Condition="!Exists('$(PackageValidationBaselinePath)')" Text="$(PackageValidationBaselinePath) does not exist. Please check the PackageValidationBaselinePath or PackageValidationBaselineVersion." />
+    <Error Condition="'$(PackageValidationBaselinePath)' != '' and !Exists('$(PackageValidationBaselinePath)')" Text="$(PackageValidationBaselinePath) does not exist. Please check the PackageValidationBaselinePath or PackageValidationBaselineVersion." />
 
     <!-- PackageTargetPath isn't exposed by NuGet: https://github.com/NuGet/Home/issues/6671. -->
     <Microsoft.DotNet.PackageValidation.ValidatePackage


### PR DESCRIPTION
Without Baseline 
```
C:\Program Files\dotnet\sdk\6.0.100-preview.3.21202.5\MSBuild.dll -distributedlogger:Microsoft.DotNet.Tools.MSBuild.MSBuildLogger,C:\Program Files\dotnet\sdk\6.0.100-preview.3.21202.5\dotnet.dll*Microsoft.DotNet.Tools.MSBuild.MSBuildForwardingLogger,C:\Program Files\dotnet\sdk\6.0.100-preview.3.21202.5\dotnet.dll -maxcpucount -restore -target:pack -verbosity:m /bl .\CheckIfZero.csproj
  Determining projects to restore...
  Restored E:\AllHands\CheckIfZero\CheckIfZero.csproj (in 136 ms).
  You are using a preview version of .NET. See: https://aka.ms/dotnet-core-preview
  You are using a preview version of .NET. See: https://aka.ms/dotnet-core-preview
  CheckIfZero -> E:\AllHands\CheckIfZero\bin\Debug\netstandard2.0\CheckIfZero.dll
  CheckIfZero -> E:\AllHands\CheckIfZero\bin\Debug\net6.0\CheckIfZero.dll
  Successfully created package 'E:\AllHands\CheckIfZero\bin\Debug\CheckIfZero.1.0.0.nupkg'.
C:\Users\anagniho\.nuget\packages\microsoft.dotnet.packagevalidation\1.0.0-dev\build\Microsoft.DotNet.PackageValidation.targets(24,5): error : .NETStandard,Version=v2.0 assembly api surface area should be compatible with net6.0 assembly surface area so we can compile against .NETStandard,Version=v2.0 and run on net6.0 .framework. [E:\AllHands\CheckIfZero\CheckIfZero.csproj]
C:\Users\anagniho\.nuget\packages\microsoft.dotnet.packagevalidation\1.0.0-dev\build\Microsoft.DotNet.PackageValidation.targets(24,5): error : API Compatibility errors between lib/netstandard2.0/CheckIfZero.dll (left) and lib/net6.0/CheckIfZero.dll (right): [E:\AllHands\CheckIfZero\CheckIfZero.csproj]
C:\Users\anagniho\.nuget\packages\microsoft.dotnet.packagevalidation\1.0.0-dev\build\Microsoft.DotNet.PackageValidation.targets(24,5): error CP0002: Member 'CheckIfZero.Class1.DoStringManipulation(string)' exists on the left but not on the right [E:\AllHands\CheckIfZero\CheckIfZero.csproj]

```

with baseline
```
C:\Program Files\dotnet\sdk\6.0.100-preview.3.21202.5\MSBuild.dll -distributedlogger:Microsoft.DotNet.Tools.MSBuild.MSBuildLogger,C:\Program Files\dotnet\sdk\6.0.100-preview.3.21202.5\dotnet.dll*Microsoft.DotNet.Tools.MSBuild.MSBuildForwardingLogger,C:\Program Files\dotnet\sdk\6.0.100-preview.3.21202.5\dotnet.dll -maxcpucount -restore -target:pack -verbosity:m /bl .\CheckIfZero.csproj
  Determining projects to restore...
  Restored E:\AllHands\CheckIfZero\CheckIfZero.csproj (in 143 ms).
  You are using a preview version of .NET. See: https://aka.ms/dotnet-core-preview
  You are using a preview version of .NET. See: https://aka.ms/dotnet-core-preview
  CheckIfZero -> E:\AllHands\CheckIfZero\bin\Debug\netstandard2.0\CheckIfZero.dll
  CheckIfZero -> E:\AllHands\CheckIfZero\bin\Debug\net6.0\CheckIfZero.dll
  Successfully created package 'E:\AllHands\CheckIfZero\bin\Debug\CheckIfZero.2.0.0.nupkg'.
C:\Users\anagniho\.nuget\packages\microsoft.dotnet.packagevalidation\1.0.0-dev\build\Microsoft.DotNet.PackageValidation.targets(24,5): error : There are breaking changes between the versions. Please add or modify the apis in the recent version or suppress the intentional breaking changes. [E:\AllHands\CheckIfZero\CheckIfZero.csproj]
C:\Users\anagniho\.nuget\packages\microsoft.dotnet.packagevalidation\1.0.0-dev\build\Microsoft.DotNet.PackageValidation.targets(24,5): error : API compatibility errors in between lib/net6.0/CheckIfZero.dll (left) and lib/net6.0/CheckIfZero.dll (right) for versions 1.0.0 and 2.0.0 respectively: [E:\AllHands\CheckIfZero\CheckIfZero.csproj]
C:\Users\anagniho\.nuget\packages\microsoft.dotnet.packagevalidation\1.0.0-dev\build\Microsoft.DotNet.PackageValidation.targets(24,5): error CP0002: Member 'CheckIfZero.Class1.Connect(string)' exists on the left but not on the right [E:\AllHands\CheckIfZero\CheckIfZero.csproj]
```