### PR TITLE
[release/6.0-preview5] Add support for Pgo Mibc files to be used by the SDK for Preview5

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolveRuntimePackAssets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveRuntimePackAssets.cs
@@ -118,6 +118,10 @@ namespace Microsoft.NET.Build.Tasks
                 {
                     assetType = "native";
                 }
+                else if (typeAttributeValue.Equals("PgoData", StringComparison.OrdinalIgnoreCase))
+                {
+                    assetType = "pgodata";
+                }
                 else if (typeAttributeValue.Equals("Resources", StringComparison.OrdinalIgnoreCase))
                 {
                     assetType = "resources";
@@ -166,7 +170,9 @@ namespace Microsoft.NET.Build.Tasks
 
             var assetItem = new TaskItem(assetPath);
 
-            assetItem.SetMetadata(MetadataKeys.CopyLocal, "true");
+            if (assetType != "pgodata")
+                assetItem.SetMetadata(MetadataKeys.CopyLocal, "true");
+
             if (string.IsNullOrEmpty(culture))
             {
                 assetItem.SetMetadata(MetadataKeys.DestinationSubPath, Path.GetFileName(assetPath));

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolvedFile.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolvedFile.cs
@@ -13,7 +13,8 @@ namespace Microsoft.NET.Build.Tasks
         None,
         Runtime,
         Native,
-        Resources
+        Resources,
+        PgoData
     }
 
     internal class ResolvedFile

--- a/src/Tasks/Microsoft.NET.Build.Tasks/RunReadyToRunCompiler.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/RunReadyToRunCompiler.cs
@@ -25,6 +25,7 @@ namespace Microsoft.NET.Build.Tasks
         public bool ShowCompilerWarnings { get; set; }
         public bool UseCrossgen2 { get; set; }
         public string Crossgen2ExtraCommandLineArgs { get; set; }
+        public ITaskItem[] Crossgen2PgoFiles { get; set; }
 
         [Output]
         public bool WarningsDetected { get; set; }
@@ -326,6 +327,14 @@ namespace Microsoft.NET.Build.Tasks
                 {
                     result.AppendLine("--perfmap");
                     result.AppendLine($"--perfmap-path:{Path.GetDirectoryName(_outputPDBImage)}");
+                }
+            }
+
+            if (Crossgen2PgoFiles != null)
+            {
+                foreach (var mibc in Crossgen2PgoFiles)
+                {
+                    result.AppendLine($"-m:\"{mibc.ItemSpec}\"");
                 }
             }
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/RuntimePackAssetInfo.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/RuntimePackAssetInfo.cs
@@ -39,6 +39,10 @@ namespace Microsoft.NET.Build.Tasks
             {
                 assetInfo.AssetType = AssetType.Resources;
             }
+            else if (assetTypeString.Equals("pgodata", StringComparison.OrdinalIgnoreCase))
+            {
+                assetInfo.AssetType = AssetType.PgoData;
+            }
             else
             {
                 throw new InvalidOperationException("Unexpected asset type: " + item.GetMetadata(MetadataKeys.AssetType));

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.CrossGen.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.CrossGen.targets
@@ -17,6 +17,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <PublishReadyToRunComposite Condition="'$(PublishReadyToRunComposite)' == '' and '$(_TargetFrameworkVersionWithoutV)' >= '6.0'">false</PublishReadyToRunComposite>
     <PublishReadyToRunComposite Condition="'$(PublishReadyToRunComposite)' == ''">true</PublishReadyToRunComposite>
     <PublishReadyToRunComposite Condition="'$(PublishReadyToRunUseCrossgen2)' != 'true' or '$(SelfContained)' != 'true'">false</PublishReadyToRunComposite>
+    <PublishReadyToRunUseRuntimePackOptimizationData Condition="'$(PublishReadyToRunUseRuntimePackOptimizationData)' == ''">true</PublishReadyToRunUseRuntimePackOptimizationData>
   </PropertyGroup>
 
   <!--
@@ -367,7 +368,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     Prepare build for ReadyToRun compilations. Builds list of assemblies to compile, and computes paths to ReadyToRun compiler bits
     ============================================================
     -->
-  <UsingTask Condition="'$(Crossgen2TasksOverriden)' != 'true'"  TaskName="PrepareForReadyToRunCompilation" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)"/>
+  <UsingTask Condition="'$(Crossgen2TasksOverriden)' != 'true'" TaskName="PrepareForReadyToRunCompilation" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
   <Target Name="_PrepareForReadyToRunCompilation" DependsOnTargets="ResolveReadyToRunCompilers;_ComputeManagedRuntimePackAssemblies;_ComputeAssembliesToPostprocessOnPublish">
 
     <PropertyGroup>
@@ -395,6 +396,12 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ItemGroup Condition="'$(SelfContained)' != 'true'">
       <_ReadyToRunImplementationAssemblies Remove="@(_ReadyToRunImplementationAssemblies)" />
       <_ReadyToRunImplementationAssemblies Include="@(_ReadyToRunImplementationAssembliesWithoutConflicts)" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <_ReadyToRunPgoFiles Include="@(PublishReadyToRunPgoFiles)" />
+      <_ReadyToRunPgoFiles Include="@(RuntimePackAsset)"
+                           Condition="'%(RuntimePackAsset.AssetType)' == 'pgodata' and '%(RuntimePackAsset.Extension)' == '.mibc' and '$(PublishReadyToRunUseRuntimePackOptimizationData)' == 'true'" />
     </ItemGroup>
 
     <PrepareForReadyToRunCompilation CrossgenTool="@(CrossgenTool)"
@@ -444,12 +451,13 @@ Copyright (c) .NET Foundation. All rights reserved.
     -->
   <UsingTask Condition="'$(Crossgen2TasksOverriden)' != 'true'" TaskName="RunReadyToRunCompiler" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
   <Target Name="_CreateR2RImages"
-          Inputs="@(_ReadyToRunCompileList);@(_ReadyToRunCompositeBuildInput)"
+          Inputs="@(_ReadyToRunCompileList);@(_ReadyToRunCompositeBuildInput);@(_ReadyToRunPgoFiles)"
           Outputs="%(_ReadyToRunCompileList.OutputR2RImage);%(_ReadyToRunCompileList.OutputPDBImage)">
 
     <RunReadyToRunCompiler CrossgenTool="@(CrossgenTool)"
                            Crossgen2Tool="@(Crossgen2Tool)"
                            UseCrossgen2="$(PublishReadyToRunUseCrossgen2)"
+                           Crossgen2PgoFiles="@(_ReadyToRunPgoFiles)"
                            Crossgen2ExtraCommandLineArgs="$(PublishReadyToRunCrossgen2ExtraArgs)"
                            ImplementationAssemblyReferences="@(_ReadyToRunAssembliesToReference)"
                            ShowCompilerWarnings="$(PublishReadyToRunShowWarnings)"

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -499,7 +499,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
       <ItemGroup>
         <_ResolvedCopyLocalPublishAssets Include="@(RuntimePackAsset)"
-                                         Condition="'$(SelfContained)' == 'true' Or '%(RuntimePackAsset.RuntimePackAlwaysCopyLocal)' == 'true'" />
+                                         Condition="('$(SelfContained)' == 'true' Or '%(RuntimePackAsset.RuntimePackAlwaysCopyLocal)' == 'true') and '%(RuntimePackAsset.AssetType)' != 'pgodata'" />
       </ItemGroup>
 
       <ItemGroup Condition="'$(_UseBuildDependencyFile)' != 'true'">

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets
@@ -398,7 +398,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <ItemGroup>
       <ReferenceCopyLocalPaths Include="@(RuntimePackAsset)"
-                               Condition="'$(CopyLocalLockFileAssemblies)' == 'true' and ('$(SelfContained)' == 'true' or '%(RuntimePackAsset.RuntimePackAlwaysCopyLocal)' == 'true')" />
+                               Condition="'$(CopyLocalLockFileAssemblies)' == 'true' and ('$(SelfContained)' == 'true' or '%(RuntimePackAsset.RuntimePackAlwaysCopyLocal)' == 'true') and '%(RuntimePackAsset.AssetType)' != 'pgodata'" />
     </ItemGroup>
 
 


### PR DESCRIPTION
In order to upgrade the RuntimeList.xml file schema for building the RuntimeList.xml in the runtime repo, we must update the SDK to be able to consume them. (The SDK update must happen before the runtime repo can generate the new data as the runtime repo has a testbed which depends on the LKG of the SDK to be able to process existing files.)

Pgo Mibc file consumption from within a RuntimeList.xml file is necessary to enable end customers to take advantage our our static pgo system when producing trimmed, R2R'd published self-contained applications, or self-contained R2R composite images.

## Customer Impact
By adding this work to Preview5, we will be able to expose static pgo data to consumers in long-term serviceable manner in Preview7. In addition, this will enable customers in Preview5 to use their own locally generated static pgo data. However, as we do not intend to advertise that feature in Preview5, it is not expected that customers will see any impact.

## Testing
Local ad-hoc testing of runtime repo.

## Risk
Minimal. No new logic will activate until the runtime produces a RuntimeList.xml with the new content.