### PR TITLE
Don't omit Microsoft.NETCore.App from list of frameworks in runtimeconfig

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/GenerateRuntimeConfigurationFiles.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/GenerateRuntimeConfigurationFiles.cs
@@ -56,6 +56,8 @@ namespace Microsoft.NET.Build.Tasks
 
         public bool GenerateRuntimeConfigDevFile { get; set; }
 
+        public bool AlwaysIncludeCoreFramework { get; set; }
+
         List<ITaskItem> _filesWritten = new List<ITaskItem>();
 
         private static readonly string[] RollForwardValues = new string[]
@@ -206,14 +208,15 @@ namespace Microsoft.NET.Build.Tasks
                 HashSet<string> usedFrameworkNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
                 foreach (var platformLibrary in runtimeFrameworks)
                 {
-                    if (runtimeFrameworks.Length > 1 &&
+                    //  In earlier versions of the SDK, we would exclude Microsoft.NETCore.App from the frameworks listed in the runtimeconfig file.
+                    //  This was originally a workaround for a bug: https://github.com/dotnet/core-setup/issues/4947
+                    //  We would only do this for framework-dependent apps, as the full list was required for self-contained apps.
+                    //  As the bug is fixed, we now always include the Microsoft.NETCore.App framework by default for .NET Core 6 and higher
+                    if (!AlwaysIncludeCoreFramework &&
+                        runtimeFrameworks.Length > 1 &&
                         platformLibrary.Name.Equals("Microsoft.NETCore.App", StringComparison.OrdinalIgnoreCase) &&
                         isFrameworkDependent)
                     {
-                        //  If there are multiple runtime frameworks, then exclude Microsoft.NETCore.App,
-                        //  as a workaround for https://github.com/dotnet/core-setup/issues/4947
-                        //  The workaround only applies to normal framework references, included frameworks
-                        //  (in self-contained apps) must list all frameworks.
                         continue;
                     }
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.DesignerSupport.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.DesignerSupport.targets
@@ -107,6 +107,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       TargetFrameworkMoniker="$(TargetFrameworkMoniker)"
       UserRuntimeConfig="$(UserRuntimeConfig)"
       WriteAdditionalProbingPathsToMainConfig="true"
+      AlwaysIncludeCoreFramework="$(AlwaysIncludeCoreFrameworkInRuntimeConfig)"
       />
 
     <ItemGroup>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -32,6 +32,8 @@ Copyright (c) .NET Foundation. All rights reserved.
   <PropertyGroup>
     <EnableDynamicLoading Condition="'$(EnableDynamicLoading)' == '' and '$(EnableComHosting)' == 'true'">true</EnableDynamicLoading>
     <GenerateRuntimeConfigurationFiles Condition=" '$(GenerateRuntimeConfigurationFiles)' == '' and '$(TargetFrameworkIdentifier)' == '.NETCoreApp' and ('$(HasRuntimeOutput)' == 'true' or '$(EnableComHosting)' == 'true' or '$(EnableDynamicLoading)' == 'true') ">true</GenerateRuntimeConfigurationFiles>
+    <AlwaysIncludeCoreFrameworkInRuntimeConfig Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' and $([MSBuild]::VersionLessThan('$(TargetFrameworkVersion)', '6.0'))">false</AlwaysIncludeCoreFrameworkInRuntimeConfig>
+    <AlwaysIncludeCoreFrameworkInRuntimeConfig Condition="'$(AlwaysIncludeCoreFrameworkInRuntimeConfig)' == ''">true</AlwaysIncludeCoreFrameworkInRuntimeConfig>
     <UserRuntimeConfig Condition=" '$(UserRuntimeConfig)' == '' ">$(MSBuildProjectDirectory)/runtimeconfig.template.json</UserRuntimeConfig>
     <GenerateSatelliteAssembliesForCore Condition=" '$(GenerateSatelliteAssembliesForCore)' == '' and '$(MSBuildRuntimeType)' == 'Core' ">true</GenerateSatelliteAssembliesForCore>
     <ComputeNETCoreBuildOutputFiles Condition=" '$(ComputeNETCoreBuildOutputFiles)' == '' and '$(TargetFrameworkIdentifier)' == '.NETCoreApp'">true</ComputeNETCoreBuildOutputFiles>
@@ -266,7 +268,8 @@ Copyright (c) .NET Foundation. All rights reserved.
                                        AdditionalProbingPaths="@(AdditionalProbingPath)"
                                        IsSelfContained="$(SelfContained)"
                                        WriteIncludedFrameworks="$(_WriteIncludedFrameworks)"
-                                       GenerateRuntimeConfigDevFile="$(GenerateRuntimeConfigDevFile)">
+                                       GenerateRuntimeConfigDevFile="$(GenerateRuntimeConfigDevFile)"
+                                       AlwaysIncludeCoreFramework="$(AlwaysIncludeCoreFrameworkInRuntimeConfig)">
 
     </GenerateRuntimeConfigurationFiles>
 

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenFrameworkReferences.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenFrameworkReferences.cs
@@ -40,7 +40,7 @@ namespace FrameworkReferenceTest
             var testProject = new TestProject()
             {
                 Name = "MultipleFrameworkReferenceTest",
-                TargetFrameworks = "netcoreapp3.0",
+                TargetFrameworks = "net6.0",
                 IsExe = true
             };
 
@@ -63,9 +63,7 @@ namespace FrameworkReferenceTest
             string runtimeConfigFile = Path.Combine(outputDirectory.FullName, testProject.Name + ".runtimeconfig.json");
             var runtimeFrameworkNames = GetRuntimeFrameworks(runtimeConfigFile);
 
-            //  When we remove the workaround for https://github.com/dotnet/core-setup/issues/4947 in GenerateRuntimeConfigurationFiles,
-            //  Microsoft.NETCore.App will need to be added to this list
-            runtimeFrameworkNames.Should().BeEquivalentTo("Microsoft.AspNetCore.App", "Microsoft.WindowsDesktop.App");
+            runtimeFrameworkNames.Should().BeEquivalentTo("Microsoft.AspNetCore.App", "Microsoft.WindowsDesktop.App", "Microsoft.NETCore.App");
         }
 
         [Theory]
@@ -148,7 +146,7 @@ namespace FrameworkReferenceTest
             var testProject = new TestProject()
             {
                 Name = "MultipleProfileFrameworkReferenceTest",
-                TargetFrameworks = "netcoreapp3.0",
+                TargetFrameworks = "net6.0",
                 IsExe = true
             };
 
@@ -171,9 +169,7 @@ namespace FrameworkReferenceTest
             string runtimeConfigFile = Path.Combine(outputDirectory.FullName, testProject.Name + ".runtimeconfig.json");
             var runtimeFrameworkNames = GetRuntimeFrameworks(runtimeConfigFile);
 
-            //  When we remove the workaround for https://github.com/dotnet/core-setup/issues/4947 in GenerateRuntimeConfigurationFiles,
-            //  Microsoft.NETCore.App will need to be added to this list
-            runtimeFrameworkNames.Should().BeEquivalentTo("Microsoft.WindowsDesktop.App");
+            runtimeFrameworkNames.Should().BeEquivalentTo("Microsoft.WindowsDesktop.App", "Microsoft.NETCore.App");
         }
 
         [Fact]
@@ -677,14 +673,14 @@ namespace FrameworkReferenceTest
             var testProject = new TestProject()
             {
                 Name = "TransitiveFrameworkReference",
-                TargetFrameworks = "netcoreapp3.0",
+                TargetFrameworks = "net6.0",
                 IsExe = true
             };
 
             var referencedProject = new TestProject()
             {
                 Name = "ReferencedProject",
-                TargetFrameworks = "netcoreapp3.0",
+                TargetFrameworks = "net6.0",
             };
 
             referencedProject.FrameworkReferences.Add("Microsoft.ASPNETCORE.App");
@@ -707,7 +703,7 @@ namespace FrameworkReferenceTest
 
             //  When we remove the workaround for https://github.com/dotnet/core-setup/issues/4947 in GenerateRuntimeConfigurationFiles,
             //  Microsoft.NETCore.App will need to be added to this list
-            runtimeFrameworkNames.Should().BeEquivalentTo("Microsoft.AspNetCore.App");
+            runtimeFrameworkNames.Should().BeEquivalentTo("Microsoft.AspNetCore.App", "Microsoft.NETCore.App");
         }
 
         [Fact]

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenFrameworkReferences.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenFrameworkReferences.cs
@@ -34,13 +34,15 @@ namespace FrameworkReferenceTest
     }
 }";
 
-        [WindowsOnlyFact]
-        public void Multiple_frameworks_are_written_to_runtimeconfig_when_there_are_multiple_FrameworkReferences()
+        [WindowsOnlyTheory]
+        [InlineData("net6.0", true)]
+        [InlineData("netcoreapp3.1", false)]
+        public void Multiple_frameworks_are_written_to_runtimeconfig_when_there_are_multiple_FrameworkReferences(string targetFramework, bool shouldIncludeBaseFramework)
         {
             var testProject = new TestProject()
             {
                 Name = "MultipleFrameworkReferenceTest",
-                TargetFrameworks = "net6.0",
+                TargetFrameworks = targetFramework,
                 IsExe = true
             };
 
@@ -49,7 +51,7 @@ namespace FrameworkReferenceTest
 
             testProject.SourceFiles.Add("Program.cs", FrameworkReferenceEmptyProgramSource);
 
-            var testAsset = _testAssetsManager.CreateTestProject(testProject);
+            var testAsset = _testAssetsManager.CreateTestProject(testProject, identifier: targetFramework);
 
             var buildCommand = new BuildCommand(testAsset);
 
@@ -63,7 +65,14 @@ namespace FrameworkReferenceTest
             string runtimeConfigFile = Path.Combine(outputDirectory.FullName, testProject.Name + ".runtimeconfig.json");
             var runtimeFrameworkNames = GetRuntimeFrameworks(runtimeConfigFile);
 
-            runtimeFrameworkNames.Should().BeEquivalentTo("Microsoft.AspNetCore.App", "Microsoft.WindowsDesktop.App", "Microsoft.NETCore.App");
+            if (shouldIncludeBaseFramework)
+            {
+                runtimeFrameworkNames.Should().BeEquivalentTo("Microsoft.AspNetCore.App", "Microsoft.WindowsDesktop.App", "Microsoft.NETCore.App");
+            }
+            else
+            {
+                runtimeFrameworkNames.Should().BeEquivalentTo("Microsoft.AspNetCore.App", "Microsoft.WindowsDesktop.App");
+            }
         }
 
         [Theory]


### PR DESCRIPTION
In .NET Core 3.0, we added the ability to have multiple shared frameworks, which are listed in the runtimeconfig.json file.  However, due to [issues in the host](https://github.com/dotnet/runtime/issues/3402), we omitted the base Microsoft.NETCore.App framework from the list in the runtimeconfig if there were any other frameworks.

The bugs in the host have long since been fixed (as far as I know).  However, omitting the Microsoft.NETCore.App entry from the frameworks was causing issues in dotnet/sdk, where we override the version of the base framework.  Projects that used a higher-level framework such as Microsoft.AspNetCore.App were loading the wrong version of Microsoft.NETCore.App, as the version compiled against wasn't listed in the runtimeconfig.

PR where we hit this: #17948
Commit with workaround: 150c6fa0aae7347be7e3a452492faad5ddb34f7e

This PR currently changes the logic so that Microsoft.NETCore.App will by default always be listed in the runtimeconfig when targeting .NET 6 or higher.  In any case the `AlwaysIncludeCoreFrameworkInRuntimeConfig` property can be used to override the default behavior.

I think the issues were fixed before .NET Core 3.0 released, so we might be able to always make the default to list all frameworks if the breaking change risk is low.