### PR TITLE
Prevent infinite loops in wasm hot reload

### DIFF
--- a/src/BuiltInTools/BrowserRefresh/WebSocketScriptInjection.js
+++ b/src/BuiltInTools/BrowserRefresh/WebSocketScriptInjection.js
@@ -1,10 +1,17 @@
-setTimeout(function () {
+setTimeout(async function () {
   // dotnet-watch browser reload script
+  const webSocketUrls = '{{hostString}}'.split(',');
   let connection;
-  try {
-    connection = new WebSocket('{{hostString}}');
-  } catch (ex) {
-    console.debug(ex);
+  for (const url of webSocketUrls) {
+    try {
+      connection = await getWebSocket(url);
+      break;
+    } catch (ex) {
+      console.debug(ex);
+    }
+  }
+  if (!connection) {
+    console.debug('Unable to establish a conection to the browser refresh server.');
     return;
   }
 
@@ -105,9 +112,9 @@ setTimeout(function () {
       } catch (error) {
         console.warn(error);
         applyFailed = true;
-      } 
+      }
     });
-    
+
     fetch('_framework/blazor-hotreload', { method: 'post', headers: { 'content-type': 'application/json' }, body: JSON.stringify(deltas) })
       .then(response => {
         if (response.status == 200) {
@@ -115,7 +122,7 @@ setTimeout(function () {
           window.sessionStorage.setItem('blazor-webasssembly-cache', { etag, deltas });
         }
       });
-    
+
     if (applyFailed) {
       sendDeltaNotApplied();
     } else {
@@ -158,5 +165,28 @@ setTimeout(function () {
 
   function sendDeltaNotApplied() {
     connection.send(new Uint8Array([0]).buffer);
+  }
+
+  function getWebSocket(url) {
+    return new Promise((resolve, reject) => {
+      const webSocket = new WebSocket(url);
+      function onOpen() {
+        clearEventListeners();
+        resolve(webSocket);
+      }
+
+      function onError(error) {
+        clearEventListeners();
+        reject(error);
+      }
+
+      function clearEventListeners() {
+        webSocket.removeEventListener('open', onOpen);
+        webSocket.removeEventListener('error', onError);
+      }
+
+      webSocket.addEventListener('open', onOpen);
+      webSocket.addEventListener('error', onError);
+    });
   }
 }, 500);

--- a/src/BuiltInTools/dotnet-watch/Filters/LaunchBrowserFilter.cs
+++ b/src/BuiltInTools/dotnet-watch/Filters/LaunchBrowserFilter.cs
@@ -61,10 +61,9 @@ namespace Microsoft.DotNet.Watcher.Tools
                     {
                         _refreshServer = new BrowserRefreshServer(context.Reporter);
                         context.BrowserRefreshServer = _refreshServer;
-                        var serverUrl = await _refreshServer.StartAsync(cancellationToken);
-
-                        context.Reporter.Verbose($"Refresh server running at {serverUrl}.");
-                        context.ProcessSpec.EnvironmentVariables["ASPNETCORE_AUTO_RELOAD_WS_ENDPOINT"] = serverUrl;
+                        var serverUrls = string.Join(',', await _refreshServer.StartAsync(cancellationToken));
+                        context.Reporter.Verbose($"Refresh server running at {serverUrls}.");
+                        context.ProcessSpec.EnvironmentVariables["ASPNETCORE_AUTO_RELOAD_WS_ENDPOINT"] = serverUrls;
 
                         var pathToMiddleware = Path.Combine(AppContext.BaseDirectory, "middleware", "Microsoft.AspNetCore.Watch.BrowserRefresh.dll");
                         context.ProcessSpec.EnvironmentVariables.DotNetStartupHooks.Add(pathToMiddleware);

--- a/src/BuiltInTools/dotnet-watch/HotReload/BlazorWebAssemblyDeltaApplier.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/BlazorWebAssemblyDeltaApplier.cs
@@ -18,7 +18,7 @@ namespace Microsoft.DotNet.Watcher.Tools
         private readonly IReporter _reporter;
         private int _sequenceId;
 
-        private static readonly TimeSpan MESSAGE_TIMEOUT = TimeSpan.FromSeconds(5);
+        private static readonly TimeSpan VerifyDeltaTimeout = TimeSpan.FromSeconds(5);
 
         public BlazorWebAssemblyDeltaApplier(IReporter reporter)
         {
@@ -53,7 +53,7 @@ namespace Microsoft.DotNet.Watcher.Tools
 
             await context.BrowserRefreshServer.SendJsonSerlialized(payload, cancellationToken);
 
-            return await VerifyDeltaApplied(context, cancellationToken).WaitAsync(MESSAGE_TIMEOUT);
+            return await VerifyDeltaApplied(context, cancellationToken).WaitAsync(VerifyDeltaTimeout, cancellationToken);
         }
 
         public async ValueTask ReportDiagnosticsAsync(DotNetWatchContext context, IEnumerable<string> diagnostics, CancellationToken cancellationToken)
@@ -72,43 +72,43 @@ namespace Microsoft.DotNet.Watcher.Tools
         private async Task<bool> VerifyDeltaApplied(DotNetWatchContext context, CancellationToken cancellationToken)
         {
             var _receiveBuffer = new byte[1];
-            try 
+            try
             {
-                ValueWebSocketReceiveResult? result;
-                // Sometimes we can received a Close message from the WebSocket before the
-                // browser has transmitted the acknowledgement. To address this, we wait until
-                // a result has been received and it has the expected message type (binary).
-                // There is a `WaitAsync` at the invocation site of `VerifyDeltaApplied` so this
-                // will time out if we have received an appropriate message within 5 seconds.
-                do
+                // We want to give the client some time to ACK the deltas being applied. VerifyDeltaApplied is limited by a
+                // 5 second wait timeout enforced using a WaitAsync. However, WaitAsync only works reliably if the calling
+                // function is async. If BrowserRefreshServer.ReceiveAsync finishes synchronously, the WaitAsync would
+                // never have an opportunity to execute. Consequently, we'll give it some reasonable number of opportunities
+                // to loop before we decide that applying deltas failed.
+                for (var i = 0; i < 100; i++)
                 {
-                    result = await context.BrowserRefreshServer.ReceiveAsync(_receiveBuffer, cancellationToken);
-                } while (!result.HasValue || result?.MessageType is not WebSocketMessageType.Binary);
-                return IsDeltaApplied(result);
+                    var result = await context.BrowserRefreshServer.ReceiveAsync(_receiveBuffer, cancellationToken);
+                    if (result is null)
+                    {
+                        // A null result indicates no clients are connected. No deltas could have been applied in this state.
+                        _reporter.Verbose("No client is connected to ack deltas");
+                        return false;
+                    }
+
+                    if (IsDeltaApplied(result.Value))
+                    {
+                        return true;
+                    }
+                }
             }
             catch (TaskCanceledException)
             {
                 _reporter.Verbose("Timed out while waiting to verify delta was applied.");
-                return false;
-            }
-            
-            bool IsDeltaApplied(ValueWebSocketReceiveResult? result)
-            {
-                _reporter.Verbose($"Received {_receiveBuffer[0]} from browser in {Stringify(result)}.");
-                return result.HasValue
-                    && result.Value.Count == 1 // Should have received 1 byte on the socket for the acknowledgement
-                    && result.Value.MessageType is WebSocketMessageType.Binary 
-                    && result.Value.EndOfMessage
-                    && _receiveBuffer[0] == 1;
             }
 
-            static string Stringify(ValueWebSocketReceiveResult? result)
+            return false;
+
+            bool IsDeltaApplied(ValueWebSocketReceiveResult result)
             {
-                if (result is ValueWebSocketReceiveResult r)
-                {
-                    return $"Count: {r.Count}, MessageType: {r.MessageType}, EndOfMessage: {r.EndOfMessage}";
-                }
-                return "no result received.";
+                _reporter.Verbose($"Received {_receiveBuffer[0]} from browser in [Count: {result.Count}, MessageType: {result.MessageType}, EndOfMessage: {result.EndOfMessage}].");
+                return result.Count == 1 // Should have received 1 byte on the socket for the acknowledgement
+                    && result.MessageType is WebSocketMessageType.Binary
+                    && result.EndOfMessage
+                    && _receiveBuffer[0] == 1;
             }
         }
 


### PR DESCRIPTION
* If the WebSocket connection to the browser failed to be established,
dotnet-watch will loop indefinitely as WaitAsync never gets scheduled. This change
adds a limit to how long the app waits, and also terminates early if no client is currently connected

* In addition, it's possible for the TLS connection to fail to be established even though the dev-certs is installed.
This is particularly apparent when developing in WSL. In such an event, attempt to fallback to the non-tls WS endpoint.

Fixes https://github.com/dotnet/aspnetcore/issues/33209