### PR TITLE
Parsing work for dotnet nuget trust command

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-nuget/NuGetCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-nuget/NuGetCommandParser.cs
@@ -96,8 +96,8 @@ namespace Microsoft.DotNet.Cli
         {
             var trustCommand = new Command("trust");
 
-            trustCommand.AddArgument(new Argument<string>()
-                .FromAmong(new string[] { "list", "author", "repository", "source", "certificate", "remove", "sync" }));
+            trustCommand.AddArgument(new Argument<string>() { Arity = ArgumentArity.ZeroOrOne }
+                         .FromAmong(new string[] { "list", "author", "repository", "source", "certificate", "remove", "sync" }));
 
             trustCommand.AddOption(new Option<string>("--algorithm"));
             trustCommand.AddOption(new Option<bool>("--allow-untrusted-root"));

--- a/src/Cli/dotnet/commands/dotnet-nuget/NuGetCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-nuget/NuGetCommandParser.cs
@@ -22,6 +22,7 @@ namespace Microsoft.DotNet.Cli
             command.AddCommand(GetLocalsCommand());
             command.AddCommand(GetPushCommand());
             command.AddCommand(GetVerifyCommand());
+            command.AddCommand(GetTrustCommand());
 
             return command;
         }
@@ -90,5 +91,21 @@ namespace Microsoft.DotNet.Cli
 
             return verifyCommand;
         }
+
+        private static Command GetTrustCommand()
+        {
+            var trustCommand = new Command("trust");
+
+            trustCommand.AddArgument(new Argument<string>()
+                .FromAmong(new string[] { "list", "author", "repository", "source", "certificate", "remove", "sync" }));
+
+            trustCommand.AddOption(new Option<string>("--algorithm"));
+            trustCommand.AddOption(new Option<bool>("--allow-untrusted-root"));
+            trustCommand.AddOption(new Option<string>("--owners"));
+            trustCommand.AddOption(new Option<string>("--configfile"));
+            trustCommand.AddOption(CommonOptions.VerbosityOption());
+
+            return trustCommand;
+        }        
     }
 }

--- a/src/Tests/dotnet-nuget.UnitTests/GivenANuGetCommand.cs
+++ b/src/Tests/dotnet-nuget.UnitTests/GivenANuGetCommand.cs
@@ -48,6 +48,10 @@ namespace Microsoft.DotNet.Tools.Run.Tests
         [InlineData(new[] { "verify", "foo.1.0.0.nupkg",
                             "--certificate-fingerprint", "CE40881FF5F0AD3E58965DA20A9F57",
                             "--certificate-fingerprint", "1EF1651A56933748E1BF1C99E537C4E039" }, 0)]
+        [InlineData(new[] { "trust", "-v d" }, 0)]
+        [InlineData(new[] { "trust", "certificate MyCompanyCert  CE40881FF5F0AD3E58965DA20A9F571EF1651A56933748E1BF1C99E537C4E039 --algorithm SHA256" }, 0)]
+        [InlineData(new[] { "trust", "source NuGet --configfile ..\nuget.config" }, 0)]
+        [InlineData(new[] { "trust", "remove Nuget" }, 0)]
         public void ItPassesCommandIfSupported(string[] inputArgs, int result)
         {
             // Arrange

--- a/src/Tests/dotnet.Tests/CommandTests/CompleteCommandTests.cs
+++ b/src/Tests/dotnet.Tests/CommandTests/CompleteCommandTests.cs
@@ -134,7 +134,8 @@ namespace Microsoft.DotNet.Tests.Commands
                 "delete",
                 "locals",
                 "push",
-                "verify"
+                "verify",
+                "trust"
             };
 
             var reporter = new BufferedReporter();
@@ -243,6 +244,35 @@ namespace Microsoft.DotNet.Tests.Commands
 
             var reporter = new BufferedReporter();
             CompleteCommand.RunWithReporter(new[] { "dotnet nuget verify " }, reporter).Should().Be(0);
+            reporter.Lines.OrderBy(c => c).Should().Equal(expected.OrderBy(c => c));
+        }
+
+        [Fact]
+        public void GivenNuGetTrustCommandItDisplaysCompletions()
+        {
+            var expected = new[] {
+                "--algorithm",
+                "--allow-untrusted-root",
+                "--configfile",
+                "--owners",
+                "--verbosity",
+                "--help",
+                "-v",
+                "-?",
+                "-h",
+                "/?",
+                "/h",
+                "author",
+                "certificate",
+                "list",
+                "remove",
+                "repository",
+                "source",
+                "sync"
+            };
+
+            var reporter = new BufferedReporter();
+            CompleteCommand.RunWithReporter(new[] { "dotnet nuget trust " }, reporter).Should().Be(0);
             reporter.Lines.OrderBy(c => c).Should().Equal(expected.OrderBy(c => c));
         }
     }


### PR DESCRIPTION
Fixes: https://github.com/dotnet/sdk/issues/17200

**Description**

I work on NuGet Client team. We added [dotnet nuget trust](https://github.com/NuGet/Home/pull/10628/files) command to dotnet sdk. Added this command to the parser for tab completion. This is my first PR in this repo.  If there are better ways to develop parsing logic for the said command, please let me know. NuGet.Client completed issue is https://github.com/NuGet/Home/issues/8053