### PR TITLE
Use task to get around unexpected batching behavior

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GetPublishItemsOutputGroupOutputsTests.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GetPublishItemsOutputGroupOutputsTests.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using FluentAssertions;
+using Microsoft.NET.TestFramework;
+using Xunit;
+
+namespace Microsoft.NET.Build.Tasks.UnitTests
+{
+    public class GetPublishItemsOutputGroupOutputsTests
+    {
+        private readonly MockTaskItem _apphost
+            = new MockTaskItem(@"C:\work\temp\WindowsDesktopSdkTest_without_ProjectSdk_set\obj\Debug\net5.0\apphost.exe",
+                new Dictionary<string, string>
+                {
+                    {"RelativePath", "WindowsDesktopSdkTest_without_ProjectSdk_set.exe"},
+                    {"IsKeyOutput", "True"},
+                    {"CopyToPublishDirectory", "Always"},
+                    {"TargetPath", "WindowsDesktopSdkTest_without_ProjectSdk_set.exe"},
+                });
+
+
+        private readonly MockTaskItem _dll =
+            new MockTaskItem(@"obj\Debug\net5.0\WindowsDesktopSdkTest_without_ProjectSdk_set.dll",
+                new Dictionary<string, string>
+                {
+                    {"RelativePath", "WindowsDesktopSdkTest_without_ProjectSdk_set.dll"},
+                    {"CopyToPublishDirectory", "Always"},
+                });
+
+        // The logic is cross platform but the test path examples are all in Windows
+        [WindowsOnlyFact]
+        public void It_can_expand_OutputPath()
+        {
+            var task = new GetPublishItemsOutputGroupOutputs();
+
+            task.PublishDir = @"bin\Debug\net5.0\publish\";
+            task.ResolvedFileToPublish = new[]
+            {
+                _apphost, _dll, _dll
+            };
+
+            task.Execute().Should().BeTrue();
+
+            task.PublishItemsOutputGroupOutputs.Length.Should().Be(3);
+
+            // mock itemgroup does not support well-known metadata "FullPath". So no assertion on that
+            // https://github.com/dotnet/msbuild/blob/46b723ba9ee9f4297d0c8ccbb6dc52e4bd8ea438/src/Shared/Modifiers.cs#L53-L67
+            task.PublishItemsOutputGroupOutputs[0].GetMetadata("RelativePath").Should().Be("WindowsDesktopSdkTest_without_ProjectSdk_set.exe");
+            task.PublishItemsOutputGroupOutputs[0].GetMetadata("OutputGroup").Should().Be("PublishItemsOutputGroup");
+            task.PublishItemsOutputGroupOutputs[0].GetMetadata("IsKeyOutput").Should().Be("True");
+            task.PublishItemsOutputGroupOutputs[0].GetMetadata("OutputPath").Should().Be(@"bin\Debug\net5.0\publish\WindowsDesktopSdkTest_without_ProjectSdk_set.exe");
+            task.PublishItemsOutputGroupOutputs[0].GetMetadata("CopyToPublishDirectory").Should().Be("Always", "should keep all existing metadata");
+            task.PublishItemsOutputGroupOutputs[0].GetMetadata("TargetPath").Should().Be("WindowsDesktopSdkTest_without_ProjectSdk_set.exe");
+
+            task.PublishItemsOutputGroupOutputs[1].GetMetadata("RelativePath").Should().Be("WindowsDesktopSdkTest_without_ProjectSdk_set.dll");
+            task.PublishItemsOutputGroupOutputs[1].GetMetadata("OutputGroup").Should().Be("PublishItemsOutputGroup");
+            task.PublishItemsOutputGroupOutputs[1].GetMetadata("CopyToPublishDirectory").Should().Be("Always");
+            task.PublishItemsOutputGroupOutputs[1].GetMetadata("TargetPath").Should().Be(@"WindowsDesktopSdkTest_without_ProjectSdk_set.dll");
+
+            // duplicated item should have the same info without error
+            task.PublishItemsOutputGroupOutputs[2].GetMetadata("RelativePath").Should().Be("WindowsDesktopSdkTest_without_ProjectSdk_set.dll");
+            task.PublishItemsOutputGroupOutputs[2].GetMetadata("OutputGroup").Should().Be("PublishItemsOutputGroup");
+            task.PublishItemsOutputGroupOutputs[2].GetMetadata("CopyToPublishDirectory").Should().Be("Always");
+            task.PublishItemsOutputGroupOutputs[2].GetMetadata("TargetPath").Should().Be(@"WindowsDesktopSdkTest_without_ProjectSdk_set.dll");
+        }
+    }
+}

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/Microsoft.NET.Build.Tasks.UnitTests.csproj
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/Microsoft.NET.Build.Tasks.UnitTests.csproj
@@ -24,6 +24,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\Tests\Microsoft.NET.TestFramework\Microsoft.NET.TestFramework.csproj" />
     <ProjectReference Include="..\Microsoft.NET.Build.Tasks\Microsoft.NET.Build.Tasks.csproj" />
   </ItemGroup>
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/GetPublishItemsOutputGroupOutputs.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/GetPublishItemsOutputGroupOutputs.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+namespace Microsoft.NET.Build.Tasks
+{
+    public sealed class GetPublishItemsOutputGroupOutputs : TaskBase
+    {
+        public ITaskItem[] ResolvedFileToPublish { get; set; }
+        public string PublishDir { get; set; }
+
+        [Output]
+        public ITaskItem[] PublishItemsOutputGroupOutputs { get; private set; }
+
+        protected override void ExecuteCore()
+        {
+            var list = new List<ITaskItem>();
+            if (ResolvedFileToPublish != null)
+            {
+                foreach (var r in ResolvedFileToPublish)
+                {
+                    var newItem = new TaskItem(r.GetMetadata("FullPath"));
+                    r.CopyMetadataTo(newItem);
+                    newItem.SetMetadata(metadataName: MetadataKeys.TargetPath, metadataValue: r.GetMetadata(MetadataKeys.RelativePath));
+                    newItem.SetMetadata(metadataName: "OutputPath", (PublishDir ?? "") + r.GetMetadata(MetadataKeys.RelativePath));
+                    newItem.SetMetadata(metadataName: "OutputGroup", "PublishItemsOutputGroup");
+                    list.Add(newItem);
+                }
+            }
+
+            PublishItemsOutputGroupOutputs = list.ToArray();
+        }
+    }
+}

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -1169,13 +1169,19 @@ Copyright (c) .NET Foundation. All rights reserved.
     </PublishItemsOutputGroupDependsOn>
   </PropertyGroup>
 
+  <UsingTask TaskName="Microsoft.NET.Build.Tasks.GetPublishItemsOutputGroupOutputs"
+          AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
+
   <Target Name="PublishItemsOutputGroup" DependsOnTargets="$(PublishItemsOutputGroupDependsOn)" Returns="@(PublishItemsOutputGroupOutputs)">
+    <GetPublishItemsOutputGroupOutputs
+      ResolvedFileToPublish="@(ResolvedFileToPublish)"
+      PublishDir="$(PublishDir)"
+        >
+
+      <Output TaskParameter="PublishItemsOutputGroupOutputs" ItemName="PublishItemsOutputGroupOutputs" />
+    </GetPublishItemsOutputGroupOutputs>
+
     <ItemGroup>
-      <PublishItemsOutputGroupOutputs Include="@(ResolvedFileToPublish->'%(FullPath)')"
-                                      TargetPath="%(ResolvedFileToPublish.RelativePath)"
-                                      IsKeyOutput="%(ResolvedFileToPublish.IsKeyOutput)"
-                                      OutputPath="@(ResolvedFileToPublish->'$(PublishDir)%(relativePath)')"
-                                      OutputGroup="PublishItemsOutputGroup" />
       <PublishItemsOutputGroupOutputs Include="$(PublishedSingleFilePath)"
                                       TargetPath="$(PublishedSingleFileName)"
                                       IsKeyOutput="true"


### PR DESCRIPTION
%(Identity) is not unique in this case. Would get ; if there are
duplicated relative path or identity