### PR TITLE
Few bug fixes for dotnet-watch hot reload

### DIFF
--- a/src/BuiltInTools/DotNetDeltaApplier/StartupHook.cs
+++ b/src/BuiltInTools/DotNetDeltaApplier/StartupHook.cs
@@ -4,7 +4,6 @@
 using System;
 using System.IO.Pipes;
 using System.Threading.Tasks;
-using Microsoft.DotNet.Watcher.Tools;
 using Microsoft.Extensions.HotReload;
 
 internal sealed class StartupHook

--- a/src/BuiltInTools/dotnet-watch/HotReload/BlazorWebAssemblyDeltaApplier.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/BlazorWebAssemblyDeltaApplier.cs
@@ -89,9 +89,10 @@ namespace Microsoft.DotNet.Watcher.Tools
                         return false;
                     }
 
-                    if (IsDeltaApplied(result.Value))
+                    if (IsDeltaReceivedMessage(result.Value))
                     {
-                        return true;
+                        // 1 indicates success.
+                        return _receiveBuffer[0] == 1;
                     }
                 }
             }
@@ -102,13 +103,12 @@ namespace Microsoft.DotNet.Watcher.Tools
 
             return false;
 
-            bool IsDeltaApplied(ValueWebSocketReceiveResult result)
+            bool IsDeltaReceivedMessage(ValueWebSocketReceiveResult result)
             {
                 _reporter.Verbose($"Received {_receiveBuffer[0]} from browser in [Count: {result.Count}, MessageType: {result.MessageType}, EndOfMessage: {result.EndOfMessage}].");
                 return result.Count == 1 // Should have received 1 byte on the socket for the acknowledgement
                     && result.MessageType is WebSocketMessageType.Binary
-                    && result.EndOfMessage
-                    && _receiveBuffer[0] == 1;
+                    && result.EndOfMessage;
             }
         }
 

--- a/src/BuiltInTools/dotnet-watch/HotReload/DefaultDeltaApplier.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/DefaultDeltaApplier.cs
@@ -11,6 +11,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.ExternalAccess.Watch.Api;
+using Microsoft.Extensions.HotReload;
 using Microsoft.Extensions.Tools.Internal;
 
 namespace Microsoft.DotNet.Watcher.Tools

--- a/src/BuiltInTools/dotnet-watch/HotReload/NamedPipeContract.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/NamedPipeContract.cs
@@ -8,7 +8,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Microsoft.DotNet.Watcher.Tools
+namespace Microsoft.Extensions.HotReload
 {
     internal readonly struct UpdatePayload
     {

--- a/src/BuiltInTools/dotnet-watch/HotReload/RudeEditPreference.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/RudeEditPreference.cs
@@ -26,6 +26,7 @@ namespace Microsoft.DotNet.Watcher.Tools
             if (_restartImmediatelySessionPreference.HasValue)
             {
                 await GetRudeEditResult(_restartImmediatelySessionPreference.Value, cancellationToken);
+                return;
             }
 
             while (true)

--- a/src/Tests/dotnet-watch.Tests/HotReload/UpdatePayloadTest.cs
+++ b/src/Tests/dotnet-watch.Tests/HotReload/UpdatePayloadTest.cs
@@ -8,7 +8,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
 
-namespace Microsoft.DotNet.Watcher.Tools
+namespace Microsoft.Extensions.HotReload
 {
     public class UpdatePayloadtest
     {


### PR DESCRIPTION
* Avoid null-refs when accessing Assembly.Modules
* Fail quickly if the browser responds with a failure status when applying a Blazor hot reload delta
* Fix an issue where selecting the "Always" or "Never" option when prompted by rude edit does not get
  re-used.
* Change the namespace of types refererenced by HotReloadAgent so it's easier to copy