### PR TITLE
add end to end test for package validation

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -67,4 +67,5 @@
 # Compatibility tools owned by runtime team
 # Area-Compatibility
 /src/Compatibility/ @Anipik, @safern, @ericstj
-/src/Tests/Microsoft.DotNet.ApiCompatibility/ @Anipik, @safern, @ericstj
+/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/ @Anipik, @safern, @ericstj
+/src/Tests/Microsoft.DotNet.PackageValidation.Tests/ @Anipik, @safern, @ericstj

--- a/src/Assets/TestProjects/PackageValidationTestProject/NuGet.Config
+++ b/src/Assets/TestProjects/PackageValidationTestProject/NuGet.Config
@@ -1,7 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
-    <add key="localFeed" value="../testpackages" />
     <add key="workingDirectory" value="./" />
   </packageSources>
 </configuration>

--- a/src/Assets/TestProjects/PackageValidationTestProject/NuGet.Config
+++ b/src/Assets/TestProjects/PackageValidationTestProject/NuGet.Config
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="localFeed" value="../testpackages" />
+    <add key="localFeed" value="./" />
+  </packageSources>
+</configuration>

--- a/src/Assets/TestProjects/PackageValidationTestProject/NuGet.Config
+++ b/src/Assets/TestProjects/PackageValidationTestProject/NuGet.Config
@@ -2,6 +2,6 @@
 <configuration>
   <packageSources>
     <add key="localFeed" value="../testpackages" />
-    <add key="localFeed" value="./" />
+    <add key="workingDirectory" value="./" />
   </packageSources>
 </configuration>

--- a/src/Assets/TestProjects/PackageValidationTestProject/PackageValidationTestProject.csproj
+++ b/src/Assets/TestProjects/PackageValidationTestProject/PackageValidationTestProject.csproj
@@ -3,5 +3,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+    <DefineConstants Condition="'$(ForceValidationProblem)' == 'true'">$(DefineConstants);ForceValidationProblem</DefineConstants>
   </PropertyGroup>
 </Project>

--- a/src/Assets/TestProjects/PackageValidationTestProject/PackageValidationTestProject.csproj
+++ b/src/Assets/TestProjects/PackageValidationTestProject/PackageValidationTestProject.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <Sdk Name="Microsoft.DotNet.PackageValidation" Version="1.0.0-test" />
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+  </PropertyGroup>
+</Project>

--- a/src/Assets/TestProjects/PackageValidationTestProject/PackageValidationTestProject.csproj
+++ b/src/Assets/TestProjects/PackageValidationTestProject/PackageValidationTestProject.csproj
@@ -1,8 +1,24 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Sdk Name="Microsoft.DotNet.PackageValidation" Version="1.0.0-test" />
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <DefineConstants Condition="'$(ForceValidationProblem)' == 'true'">$(DefineConstants);ForceValidationProblem</DefineConstants>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="$(MSBuildProjectDirectory)\..\..\..\..\src\Compatibility\Microsoft.DotNet.PackageValidation\Microsoft.DotNet.PackageValidation.csproj" />
+    <PackageReference Include="NuGet.Frameworks" Version="6.0.0-preview.1.66" />
+    <PackageReference Include="NuGet.Packaging" Version="6.0.0-preview.1.66" />
+    <PackageReference Include="Microsoft.Bcl.HashCode" Version="1.1.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis" Version="4.0.0-1.21277.15" />
+  </ItemGroup>
+
+  <Import Project="$(MSBuildProjectDirectory)\..\..\..\..\src\Compatibility\Microsoft.DotNet.PackageValidation\build\Microsoft.DotNet.PackageValidation.targets" />
+  
+  <PropertyGroup>
+    <DotNetPackageValidationAssembly Condition="'$(MSBuildRuntimeType)' != 'Core'">$(MSBuildThisFileDirectory)\bin\$(Configuration)\netstandard2.0\Microsoft.DotNet.PackageValidation.dll</DotNetPackageValidationAssembly>
+    <DotNetPackageValidationAssembly Condition="'$(MSBuildRuntimeType)' == 'Core'">$(MSBuildThisFileDirectory)\bin\$(Configuration)\net6.0\Microsoft.DotNet.PackageValidation.dll</DotNetPackageValidationAssembly>
+  </PropertyGroup>
+
 </Project>

--- a/src/Assets/TestProjects/PackageValidationTestProject/Program.cs
+++ b/src/Assets/TestProjects/PackageValidationTestProject/Program.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace PackageValidationTestProject
+{
+    public class Program
+    {
+    }
+}

--- a/src/Assets/TestProjects/PackageValidationTestProject/Program.cs
+++ b/src/Assets/TestProjects/PackageValidationTestProject/Program.cs
@@ -7,5 +7,12 @@ namespace PackageValidationTestProject
 {
     public class Program
     {
+#if ForceValidationProblem
+#if !NET6_0
+  public void SomeAPINotIn6_0()
+  {
+  }
+#endif
+#endif
     }
 }

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/Microsoft.DotNet.PackageValidation.csproj
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/Microsoft.DotNet.PackageValidation.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(SdkTargetFramework);net472</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net472</TargetFrameworks>
     <IsPackable>true</IsPackable>
     <IsShippingPackage>true</IsShippingPackage>
     <StrongNameKeyId>Open</StrongNameKeyId>

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/build/Microsoft.DotNet.PackageValidation.props
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/build/Microsoft.DotNet.PackageValidation.props
@@ -2,6 +2,6 @@
 <Project>
   <PropertyGroup>
     <DotNetPackageValidationAssembly Condition="'$(MSBuildRuntimeType)' != 'Core'">$(MSBuildThisFileDirectory)..\tools\net472\Microsoft.DotNet.PackageValidation.dll</DotNetPackageValidationAssembly>
-    <DotNetPackageValidationAssembly Condition="'$(MSBuildRuntimeType)' == 'Core'">$(MSBuildThisFileDirectory)..\tools\net6.0\Microsoft.DotNet.PackageValidation.dll</DotNetPackageValidationAssembly>
+    <DotNetPackageValidationAssembly Condition="'$(MSBuildRuntimeType)' == 'Core'">$(MSBuildThisFileDirectory)..\tools\netcoreapp3.1\Microsoft.DotNet.PackageValidation.dll</DotNetPackageValidationAssembly>
   </PropertyGroup>
 </Project>

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/build/Microsoft.DotNet.PackageValidation.targets
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/build/Microsoft.DotNet.PackageValidation.targets
@@ -25,7 +25,7 @@
 
     <!-- PackageTargetPath isn't exposed by NuGet: https://github.com/NuGet/Home/issues/6671. -->
     <Microsoft.DotNet.PackageValidation.ValidatePackage
-      PackageTargetPath="$([MSBuild]::ValueOrDefault('$(PackageTargetPath)', '$(PackageOutputPath)$(PackageId).$(PackageVersion).nupkg'))"
+      PackageTargetPath="$([MSBuild]::ValueOrDefault('$(PackageTargetPath)', '$([MSBuild]::NormalizePath('$(PackageOutputPath)', '$(PackageId).$(PackageVersion).nupkg'))'))"
       RuntimeGraph="$(RuntimeIdentifierGraphPath)"
       NoWarn="$(NoWarn)"
       RunApiCompat="$([MSBuild]::ValueOrDefault('$(RunApiCompat)', 'true'))"

--- a/src/Tests/Microsoft.DotNet.PackageValidation.Tests/CompatibleFrameworksInPackageTests.cs
+++ b/src/Tests/Microsoft.DotNet.PackageValidation.Tests/CompatibleFrameworksInPackageTests.cs
@@ -22,9 +22,10 @@ namespace Microsoft.DotNet.PackageValidation.Tests
         [Fact]
         public void CompatibleFrameworksInPackage()
         {
+            string name = Path.GetFileNameWithoutExtension(Path.GetTempFileName());
             TestProject testProject = new()
             {
-                Name = "TestPackage",
+                Name = name,
                 TargetFrameworks = "netstandard2.0;net5.0",
             };
 
@@ -39,7 +40,6 @@ namespace PackageValidationTests
 #endif
     }
 }";
-
             testProject.SourceFiles.Add("Hello.cs", sourceCode);
             TestAsset asset = _testAssetsManager.CreateTestProject(testProject, testProject.Name);
             PackCommand packCommand = new PackCommand(Log, Path.Combine(asset.TestRoot, testProject.Name));
@@ -55,9 +55,10 @@ namespace PackageValidationTests
         [Fact]
         public void MultipleCompatibleFrameworksInPackage()
         {
+            string name = Path.GetFileNameWithoutExtension(Path.GetTempFileName());
             TestProject testProject = new()
             {
-                Name = "TestPackageMupltiple",
+                Name = name,
                 TargetFrameworks = "netstandard2.0;netcoreapp3.1;net5.0",
             };
 

--- a/src/Tests/Microsoft.DotNet.PackageValidation.Tests/ValidatePackageTargetTests.cs
+++ b/src/Tests/Microsoft.DotNet.PackageValidation.Tests/ValidatePackageTargetTests.cs
@@ -13,15 +13,6 @@ namespace Microsoft.DotNet.PackageValidation.Tests
     {
         public ValidatePackageTargetTests(ITestOutputHelper log) : base(log)
         {
-            // clearing the cache
-            string localSdkNugetCacheValidationPath = Path.Combine(TestContext.Current.NuGetCachePath, "microsoft.dotnet.packagevalidation");
-            if (Directory.Exists(localSdkNugetCacheValidationPath))
-                Directory.Delete(localSdkNugetCacheValidationPath, recursive: true);
-
-            // Packing and copying the local version package validation
-            string packageValidationProjectPath = Path.Combine(Path.GetDirectoryName(_testAssetsManager.TestAssetsRoot), "Compatibility", "Microsoft.DotNet.PackageValidation", "Microsoft.DotNet.PackageValidation.csproj");
-            new PackCommand(Log, packageValidationProjectPath)
-                .Execute($"-p:PackageVersion=1.0.0-test;PackageOutputPath={TestContext.Current.TestPackages}");
         }
 
         [Fact]
@@ -86,7 +77,7 @@ namespace Microsoft.DotNet.PackageValidation.Tests
             Assert.Equal(0, result.ExitCode);
 
             result = new PackCommand(Log, Path.Combine(testAsset.TestRoot, "PackageValidationTestProject.csproj"))
-                .Execute($"-p:PackageVersion=2.0.0;PackageValidationBaselineVersion=1.0.0");
+                .Execute($"-p:PackageVersion=2.0.0;PackageValidationBaselineVersion=1.0.0;PackageValidationBaselineName=PackageValidationTestProject");
 
             // No failures while running the package validation on a simple assembly.
             Assert.Equal(0, result.ExitCode);

--- a/src/Tests/Microsoft.DotNet.PackageValidation.Tests/ValidatePackageTargetTests.cs
+++ b/src/Tests/Microsoft.DotNet.PackageValidation.Tests/ValidatePackageTargetTests.cs
@@ -15,7 +15,8 @@ namespace Microsoft.DotNet.PackageValidation.Tests
         {
             // clearing the cache
             string localSdkNugetCacheValidationPath = Path.Combine(TestContext.Current.NuGetCachePath, "microsoft.dotnet.packagevalidation");
-            Directory.Delete(localSdkNugetCacheValidationPath, recursive: true);
+            if (Directory.Exists(localSdkNugetCacheValidationPath))
+                Directory.Delete(localSdkNugetCacheValidationPath, recursive: true);
 
             // Packing and copying the local version package validation
             string packageValidationProjectPath = Path.Combine(Path.GetDirectoryName(_testAssetsManager.TestAssetsRoot), "Compatibility", "Microsoft.DotNet.PackageValidation", "Microsoft.DotNet.PackageValidation.csproj");
@@ -27,7 +28,7 @@ namespace Microsoft.DotNet.PackageValidation.Tests
         public void ValidatePackageTargetRunsSuccessfully()
         {
             var testAsset = _testAssetsManager
-                .CopyTestAsset("PackageValidationTestProject")
+                .CopyTestAsset("PackageValidationTestProject", allowCopyIfPresent: true)
                 .WithSource();
 
             var result = new PackCommand(Log, Path.Combine(testAsset.TestRoot, "PackageValidationTestProject.csproj"))
@@ -41,7 +42,7 @@ namespace Microsoft.DotNet.PackageValidation.Tests
         public void ValidatePackageTargetRunsSuccessfullyWithBaselineCheck()
         {
             var testAsset = _testAssetsManager
-                .CopyTestAsset("PackageValidationTestProject")
+                .CopyTestAsset("PackageValidationTestProject", allowCopyIfPresent: true)
                 .WithSource();
 
             var result = new PackCommand(Log, Path.Combine(testAsset.TestRoot, "PackageValidationTestProject.csproj"))
@@ -53,7 +54,7 @@ namespace Microsoft.DotNet.PackageValidation.Tests
             result = new PackCommand(Log, Path.Combine(testAsset.TestRoot, "PackageValidationTestProject.csproj"))
                 .Execute($"-p:PackageVersion=2.0.0;PackageValidationBaselinePath={packageValidationBaselinePath}");
 
-            // No failures while running the package validation on a simple assembly with baseline flag.
+            // No failures while running the package validation on a simple assembly.
             Assert.Equal(0, result.ExitCode);
         }
 
@@ -61,7 +62,7 @@ namespace Microsoft.DotNet.PackageValidation.Tests
         public void ValidatePackageTargetRunsSuccessfullyWithBaselineVersion()
         {
             var testAsset = _testAssetsManager
-                .CopyTestAsset("PackageValidationTestProject")
+                .CopyTestAsset("PackageValidationTestProject", allowCopyIfPresent: true)
                 .WithSource();
 
             var result = new PackCommand(Log, Path.Combine(testAsset.TestRoot, "PackageValidationTestProject.csproj"))
@@ -72,7 +73,7 @@ namespace Microsoft.DotNet.PackageValidation.Tests
             result = new PackCommand(Log, Path.Combine(testAsset.TestRoot, "PackageValidationTestProject.csproj"))
                 .Execute($"-p:PackageVersion=2.0.0;PackageValidationBaselineVersion=1.0.0");
 
-            // No failures while running the package validation on a simple assembly with PackageValidationBaselineVersion flag.
+            // No failures while running the package validation on a simple assembly.
             Assert.Equal(0, result.ExitCode);
         }
 
@@ -81,7 +82,7 @@ namespace Microsoft.DotNet.PackageValidation.Tests
         public void ValidatePackageTargetWithIncorrectBaselinePackagePath()
         {
             var testAsset = _testAssetsManager
-                .CopyTestAsset("PackageValidationTestProject")
+                .CopyTestAsset("PackageValidationTestProject", allowCopyIfPresent: true)
                 .WithSource();
 
             string nonExistentPackageBaselinePath = Path.Combine(testAsset.TestRoot, "PackageValidationTestProject.1.0.0.nupkg");

--- a/src/Tests/Microsoft.DotNet.PackageValidation.Tests/ValidatePackageTargetTests.cs
+++ b/src/Tests/Microsoft.DotNet.PackageValidation.Tests/ValidatePackageTargetTests.cs
@@ -25,6 +25,21 @@ namespace Microsoft.DotNet.PackageValidation.Tests
         }
 
         [Fact]
+        public void InvalidPackage()
+        {
+            var testAsset = _testAssetsManager
+                .CopyTestAsset("PackageValidationTestProject", allowCopyIfPresent: true)
+                .WithSource();
+
+            var result = new PackCommand(Log, Path.Combine(testAsset.TestRoot, "PackageValidationTestProject.csproj"))
+                .Execute($"-p:ForceValidationProblem=true");
+
+            // No failures while running the package validation on a simple assembly.
+            Assert.Equal(1, result.ExitCode);
+            Assert.Contains("error CP0002: Member 'PackageValidationTestProject.Program.SomeAPINotIn6_0()' exists on the left but not on the right", result.StdOut);
+        }
+
+        [Fact]
         public void ValidatePackageTargetRunsSuccessfully()
         {
             var testAsset = _testAssetsManager

--- a/src/Tests/Microsoft.DotNet.PackageValidation.Tests/ValidatePackageTargetTests.cs
+++ b/src/Tests/Microsoft.DotNet.PackageValidation.Tests/ValidatePackageTargetTests.cs
@@ -1,0 +1,95 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.IO;
+using Microsoft.NET.TestFramework;
+using Microsoft.NET.TestFramework.Commands;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.DotNet.PackageValidation.Tests
+{
+    public class ValidatePackageTargetTests : SdkTest
+    {
+        public ValidatePackageTargetTests(ITestOutputHelper log) : base(log)
+        {
+            // clearing the cache
+            string localSdkNugetCacheValidationPath = Path.Combine(TestContext.Current.NuGetCachePath, "microsoft.dotnet.packagevalidation");
+            Directory.Delete(localSdkNugetCacheValidationPath, recursive: true);
+
+            // Packing and copying the local version package validation
+            string packageValidationProjectPath = Path.Combine(Path.GetDirectoryName(_testAssetsManager.TestAssetsRoot), "Compatibility", "Microsoft.DotNet.PackageValidation", "Microsoft.DotNet.PackageValidation.csproj");
+            new PackCommand(Log, packageValidationProjectPath)
+                .Execute($"-p:PackageVersion=1.0.0-test;PackageOutputPath={TestContext.Current.TestPackages}");
+        }
+
+        [Fact]
+        public void ValidatePackageTargetRunsSuccessfully()
+        {
+            var testAsset = _testAssetsManager
+                .CopyTestAsset("PackageValidationTestProject")
+                .WithSource();
+
+            var result = new PackCommand(Log, Path.Combine(testAsset.TestRoot, "PackageValidationTestProject.csproj"))
+                .Execute();
+
+            // No failures while running the package validation on a simple assembly.
+            Assert.Equal(0, result.ExitCode);
+        }
+
+        [Fact]
+        public void ValidatePackageTargetRunsSuccessfullyWithBaselineCheck()
+        {
+            var testAsset = _testAssetsManager
+                .CopyTestAsset("PackageValidationTestProject")
+                .WithSource();
+
+            var result = new PackCommand(Log, Path.Combine(testAsset.TestRoot, "PackageValidationTestProject.csproj"))
+                .Execute($"-p:PackageOutputPath={testAsset.TestRoot}");
+
+            Assert.Equal(0, result.ExitCode);
+
+            string packageValidationBaselinePath = Path.Combine(testAsset.TestRoot, "PackageValidationTestProject.1.0.0.nupkg");
+            result = new PackCommand(Log, Path.Combine(testAsset.TestRoot, "PackageValidationTestProject.csproj"))
+                .Execute($"-p:PackageVersion=2.0.0;PackageValidationBaselinePath={packageValidationBaselinePath}");
+
+            // No failures while running the package validation on a simple assembly with baseline flag.
+            Assert.Equal(0, result.ExitCode);
+        }
+
+        [Fact]
+        public void ValidatePackageTargetRunsSuccessfullyWithBaselineVersion()
+        {
+            var testAsset = _testAssetsManager
+                .CopyTestAsset("PackageValidationTestProject")
+                .WithSource();
+
+            var result = new PackCommand(Log, Path.Combine(testAsset.TestRoot, "PackageValidationTestProject.csproj"))
+                .Execute($"-p:PackageOutputPath={testAsset.TestRoot}");
+
+            Assert.Equal(0, result.ExitCode);
+
+            result = new PackCommand(Log, Path.Combine(testAsset.TestRoot, "PackageValidationTestProject.csproj"))
+                .Execute($"-p:PackageVersion=2.0.0;PackageValidationBaselineVersion=1.0.0");
+
+            // No failures while running the package validation on a simple assembly with PackageValidationBaselineVersion flag.
+            Assert.Equal(0, result.ExitCode);
+        }
+
+
+        [Fact]
+        public void ValidatePackageTargetWithIncorrectBaselinePackagePath()
+        {
+            var testAsset = _testAssetsManager
+                .CopyTestAsset("PackageValidationTestProject")
+                .WithSource();
+
+            string nonExistentPackageBaselinePath = Path.Combine(testAsset.TestRoot, "PackageValidationTestProject.1.0.0.nupkg");
+            var result = new PackCommand(Log, Path.Combine(testAsset.TestRoot, "PackageValidationTestProject.csproj"))
+                .Execute($"-p:PackageVersion=2.0.0;PackageValidationBaselinePath={nonExistentPackageBaselinePath}");
+
+            Assert.Equal(1, result.ExitCode);
+            Assert.Contains($"{nonExistentPackageBaselinePath} does not exist. Please check the PackageValidationBaselinePath or PackageValidationBaselineVersion.", result.StdOut);
+        }
+    }
+}

--- a/src/Tests/Microsoft.NET.TestFramework/TestAssetsManager.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/TestAssetsManager.cs
@@ -38,13 +38,14 @@ namespace Microsoft.NET.TestFramework
             [CallerMemberName] string callingMethod = "",
             [CallerFilePath] string callerFilePath = null,
             string identifier = "",
-            string testAssetSubdirectory = "")
+            string testAssetSubdirectory = "",
+            bool allowCopyIfPresent = false)
         {
             var testProjectDirectory = GetAndValidateTestProjectDirectory(testProjectName, testAssetSubdirectory);
 
             var fileName = Path.GetFileNameWithoutExtension(callerFilePath);
             var testDestinationDirectory =
-                GetTestDestinationDirectoryPath(testProjectName, callingMethod + "_" + fileName, identifier);
+                GetTestDestinationDirectoryPath(testProjectName, callingMethod + "_" + fileName, identifier, allowCopyIfPresent);
             TestDestinationDirectories.Add(testDestinationDirectory);
 
             var testAsset = new TestAsset(testProjectDirectory, testDestinationDirectory, TestContext.Current.SdkVersion, Log);
@@ -112,7 +113,8 @@ namespace Microsoft.NET.TestFramework
         public static string GetTestDestinationDirectoryPath(
             string testProjectName,
             string callingMethodAndFileName,
-            string identifier)
+            string identifier,
+            bool allowCopyIfPresent = false)
         {
             string baseDirectory = TestContext.Current.TestExecutionDirectory;
             var directoryName = new StringBuilder(callingMethodAndFileName).Append(identifier);
@@ -141,7 +143,7 @@ namespace Microsoft.NET.TestFramework
 
             var directoryPath = Path.Combine(baseDirectory, directoryName.ToString());
 #if CI_BUILD
-            if (Directory.Exists(directoryPath))
+            if (!allowCopyIfPresent && Directory.Exists(directoryPath))
             {
                 throw new Exception($"Test dir {directoryPath} already exists");
             }

--- a/src/Tests/testsProjectCannotRunOnHelixList.txt
+++ b/src/Tests/testsProjectCannotRunOnHelixList.txt
@@ -9,3 +9,4 @@ dotnet.Tests
 msbuild.Integration.Tests
 dotnet-sln.Tests
 Microsoft.NET.Sdk.Publish.Tasks.Tests
+Microsoft.DotNet.PackageValidation.Tests


### PR DESCRIPTION
Fixes https://github.com/dotnet/sdk/issues/17879
Fixes https://github.com/dotnet/sdk/issues/17936

These tests protects us from breaking msbuild props and targets file

- simply running package validation with no baseline
- running baseline with baselineVersion
- running baseline with baseline package path
- throwing error when path is not valid.

Found and Fixed a bug where the PackageOutputPath is not normalized.