### PR TITLE
Workaround duplicate manifest errors

### DIFF
--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/SdkDirectoryWorkloadManifestProvider.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/SdkDirectoryWorkloadManifestProvider.cs
@@ -13,6 +13,8 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
         private readonly string _sdkRootPath;
         private readonly string _sdkVersionBand;
         private readonly string [] _manifestDirectories;
+        private static string[] _preview4ManifestIds = new string[] { "Microsoft.NET.Workload.Android", "Microsoft.NET.Workload.BlazorWebAssembly", "Microsoft.NET.Workload.iOS",
+            "Microsoft.NET.Workload.MacCatalyst", "Microsoft.NET.Workload.macOS", "Microsoft.NET.Workload.tvOS" };
 
         public SdkDirectoryWorkloadManifestProvider(string sdkRootPath, string sdkVersion)
             : this(sdkRootPath, sdkVersion, Environment.GetEnvironmentVariable)
@@ -81,7 +83,10 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
                 {
                     foreach (var workloadManifestDirectory in Directory.EnumerateDirectories(_manifestDirectories[0]))
                     {
-                        yield return workloadManifestDirectory;
+                        if (!_preview4ManifestIds.Any(prev4Manifest => workloadManifestDirectory.ToLowerInvariant().Contains(prev4Manifest.ToLowerInvariant())))
+                        {
+                            yield return workloadManifestDirectory;
+                        }
                     }
                 }
             }
@@ -102,7 +107,10 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
 
                 foreach (var workloadManifestDirectory in directoriesWithManifests.Values)
                 {
-                    yield return workloadManifestDirectory;
+                    if (!_preview4ManifestIds.Any(prev4Manifest => workloadManifestDirectory.ToLowerInvariant().Contains(prev4Manifest.ToLowerInvariant())))
+                    {
+                        yield return workloadManifestDirectory;
+                    }
                 }
             }
         }

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/SdkDirectoryWorkloadManifestProvider.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/SdkDirectoryWorkloadManifestProvider.cs
@@ -13,8 +13,8 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
         private readonly string _sdkRootPath;
         private readonly string _sdkVersionBand;
         private readonly string [] _manifestDirectories;
-        private static string[] _preview4ManifestIds = new string[] { "Microsoft.NET.Workload.Android", "Microsoft.NET.Workload.BlazorWebAssembly", "Microsoft.NET.Workload.iOS",
-            "Microsoft.NET.Workload.MacCatalyst", "Microsoft.NET.Workload.macOS", "Microsoft.NET.Workload.tvOS" };
+        private static HashSet<string> _outdatedManifestIds = new HashSet<string>() { "microsoft.net.workload.android", "microsoft.net.workload.blazorwebassembly", "microsoft.net.workload.ios",
+            "microsoft.net.workload.maccatalyst", "microsoft.net.workload.macos", "microsoft.net.workload.tvos" };
 
         public SdkDirectoryWorkloadManifestProvider(string sdkRootPath, string sdkVersion)
             : this(sdkRootPath, sdkVersion, Environment.GetEnvironmentVariable)
@@ -83,7 +83,7 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
                 {
                     foreach (var workloadManifestDirectory in Directory.EnumerateDirectories(_manifestDirectories[0]))
                     {
-                        if (!_preview4ManifestIds.Any(prev4Manifest => workloadManifestDirectory.ToLowerInvariant().Contains(prev4Manifest.ToLowerInvariant())))
+                        if (!IsManifestIdOutdated(workloadManifestDirectory))
                         {
                             yield return workloadManifestDirectory;
                         }
@@ -107,12 +107,18 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
 
                 foreach (var workloadManifestDirectory in directoriesWithManifests.Values)
                 {
-                    if (!_preview4ManifestIds.Any(prev4Manifest => workloadManifestDirectory.ToLowerInvariant().Contains(prev4Manifest.ToLowerInvariant())))
+                    if (!IsManifestIdOutdated(workloadManifestDirectory))
                     {
                         yield return workloadManifestDirectory;
                     }
                 }
             }
+        }
+
+        private bool IsManifestIdOutdated(string workloadManifestDir)
+        {
+            var manifestId = Path.GetFileName(workloadManifestDir).ToLowerInvariant();
+            return _outdatedManifestIds.Contains(manifestId);
         }
 
         public string GetSdkFeatureBand()

--- a/src/Tests/Microsoft.NET.Sdk.WorkloadManifestReader.Tests/SdkDirectoryWorkloadManifestProviderTests.cs
+++ b/src/Tests/Microsoft.NET.Sdk.WorkloadManifestReader.Tests/SdkDirectoryWorkloadManifestProviderTests.cs
@@ -214,6 +214,24 @@ namespace ManifestReaderTests
          
         }
 
+        [Fact]
+        public void ItShouldIgnoreOutdatedManifestIds()
+        {
+            Initialize();
+
+            Directory.CreateDirectory(Path.Combine(_manifestDirectory, "iOS"));
+            File.WriteAllText(Path.Combine(_manifestDirectory, "iOS", "WorkloadManifest.json"), "iOSContent");
+            Directory.CreateDirectory(Path.Combine(_manifestDirectory, "Microsoft.NET.Workload.Android"));
+            File.WriteAllText(Path.Combine(_manifestDirectory, "Microsoft.NET.Workload.Android", "WorkloadManifest.json"), "iOSContent");
+
+            var sdkDirectoryWorkloadManifestProvider
+                = new SdkDirectoryWorkloadManifestProvider(sdkRootPath: _fakeDotnetRootDirectory, sdkVersion: "5.0.100");
+
+            GetManifestContents(sdkDirectoryWorkloadManifestProvider)
+                .Should()
+                .BeEquivalentTo("iOSContent");
+        }
+
         private IEnumerable<string> GetManifestContents(SdkDirectoryWorkloadManifestProvider manifestProvider)
         {
             return manifestProvider.GetManifests().Select(manifest => new StreamReader(manifest.manifestStream).ReadToEnd());


### PR DESCRIPTION
First commit taken from https://github.com/dotnet/sdk/pull/17833- fixes dup manifest error caused by manifests with different casing left behind by old previews
Second commit works around manifest id naming change between previews 4 and 5, which also causes a dup manifest error. Verified manually by installing prev 4 manifests on top of this build and ensuing workload install succeeds. 