### PR TITLE
Support preview Windows SDK Ref packs, and simplify how they're defined

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/CreateWindowsSdkKnownFrameworkReferences.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/CreateWindowsSdkKnownFrameworkReferences.cs
@@ -1,0 +1,99 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+namespace Microsoft.NET.Build.Tasks
+{
+    //  Generate KnownFrameworkReference items for the Windows SDK pack
+    //  If WindowsSdkPackageVersion is set, then use that for the package version of the Windows SDK pack
+    //  Otherwise, if UseWindowsSDKPreview is set, then construct the package version from the TargetPlatformVersion (dropping the 4th component of the component and appending "-preview")
+    //  Otherwise, create KnownFrameworkReference items based on WindowsSdkSupportedTargetPlatformVersion items, using WindowsSdkPackageVersion and MinimumNETVersion metadata
+
+    public class CreateWindowsSdkKnownFrameworkReferences : TaskBase
+    {
+        public bool UseWindowsSDKPreview { get; set; }
+
+        public string WindowsSdkPackageVersion { get; set; }
+
+        public string TargetFrameworkIdentifier { get; set; }
+
+        public string TargetFrameworkVersion { get; set; }
+
+        public string TargetPlatformIdentifier { get; set; }
+
+        public string TargetPlatformVersion { get; set; }
+
+        public ITaskItem[] WindowsSdkSupportedTargetPlatformVersions { get; set; }
+
+        [Output]
+        public ITaskItem[] KnownFrameworkReferences { get; set; }
+
+        protected override void ExecuteCore()
+        {
+            List<ITaskItem> knownFrameworkReferences = new List<ITaskItem>();
+
+            if (!string.IsNullOrEmpty(WindowsSdkPackageVersion))
+            {
+                knownFrameworkReferences.Add(CreateKnownFrameworkReference(WindowsSdkPackageVersion, TargetFrameworkVersion, TargetPlatformVersion));
+            }
+            else if (UseWindowsSDKPreview)
+            {
+                var tpv = new Version(TargetPlatformVersion);
+
+                var windowsSdkPackageVersion = $"{tpv.Major}.{tpv.Minor}.{tpv.Build}-preview";
+
+                knownFrameworkReferences.Add(CreateKnownFrameworkReference(windowsSdkPackageVersion, TargetFrameworkVersion, TargetPlatformVersion));
+            }
+            else
+            {
+                var normalizedTargetFrameworkVersion = ProcessFrameworkReferences.NormalizeVersion(new Version(TargetFrameworkVersion));
+                foreach (var supportedWindowsVersion in WindowsSdkSupportedTargetPlatformVersions)
+                {
+                    var windowsSdkPackageVersion = supportedWindowsVersion.GetMetadata("WindowsSdkPackageVersion");
+
+                    if (!string.IsNullOrEmpty(windowsSdkPackageVersion))
+                    {
+                        var minimumNETVersion = supportedWindowsVersion.GetMetadata("MinimumNETVersion");
+                        if (!string.IsNullOrEmpty(minimumNETVersion))
+                        {
+                            var normalizedMinimumVersion = ProcessFrameworkReferences.NormalizeVersion(new Version(minimumNETVersion));
+                            if (normalizedMinimumVersion > normalizedTargetFrameworkVersion)
+                            {
+                                continue;
+                            }
+                        }
+
+                        knownFrameworkReferences.Add(CreateKnownFrameworkReference(windowsSdkPackageVersion, TargetFrameworkVersion, supportedWindowsVersion.ItemSpec));
+                    }
+                }
+            }
+
+            KnownFrameworkReferences = knownFrameworkReferences.ToArray();
+        }
+
+        private static TaskItem CreateKnownFrameworkReference(string windowsSdkPackageVersion, string targetFrameworkVersion, string targetPlatformVersion)
+        {
+            var knownFrameworkReference = new TaskItem("Microsoft.Windows.SDK.NET.Ref");
+            knownFrameworkReference.SetMetadata("TargetFramework", $"net{targetFrameworkVersion}-windows{targetPlatformVersion}");
+            knownFrameworkReference.SetMetadata("RuntimeFrameworkName", "Microsoft.Windows.SDK.NET.Ref");
+            knownFrameworkReference.SetMetadata("DefaultRuntimeFrameworkVersion", windowsSdkPackageVersion);
+            knownFrameworkReference.SetMetadata("LatestRuntimeFrameworkVersion", windowsSdkPackageVersion);
+            knownFrameworkReference.SetMetadata("TargetingPackName", "Microsoft.Windows.SDK.NET.Ref");
+            knownFrameworkReference.SetMetadata("TargetingPackVersion", windowsSdkPackageVersion);
+            knownFrameworkReference.SetMetadata("RuntimePackAlwaysCopyLocal", "true");
+            knownFrameworkReference.SetMetadata("RuntimePackNamePatterns", "Microsoft.Windows.SDK.NET.Ref");
+            knownFrameworkReference.SetMetadata("RuntimePackRuntimeIdentifiers", "any");
+            knownFrameworkReference.SetMetadata("IsWindowsOnly", "true");
+
+            return knownFrameworkReference;
+        }
+    }
+}

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets
@@ -17,9 +17,34 @@ Copyright (c) .NET Foundation. All rights reserved.
     </ResolveAssemblyReferencesDependsOn>
   </PropertyGroup>
 
+  <UsingTask TaskName="CreateWindowsSdkKnownFrameworkReferences" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
   <UsingTask TaskName="CheckForDuplicateFrameworkReferences" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
   <UsingTask TaskName="ProcessFrameworkReferences" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
   <UsingTask TaskName="ResolveAppHosts" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
+
+  <Target Name="AddWindowsSdkKnownFrameworkReferences"
+          Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(TargetPlatformIdentifier)' == 'Windows'">
+
+    <!-- Remove Windows SDK KnownFrameworkReference items from BundledVersions.props (they will eventually be removed, but that is in a different repo so
+         we can't do the change atomically -->
+    <ItemGroup>
+      <KnownFrameworkReference Remove="Microsoft.Windows.SDK.NET.Ref" />
+    </ItemGroup>
+    
+    <!-- Generate KnownFrameworkReference items for the Windows SDK pack -->
+    <CreateWindowsSdkKnownFrameworkReferences
+      UseWindowsSDKPreview="$(UseWindowsSDKPreview)"
+      WindowsSdkPackageVersion="$(WindowsSdkPackageVersion)"
+      TargetFrameworkIdentifier="$(TargetFrameworkIdentifier)"
+      TargetFrameworkVersion="$(_TargetFrameworkVersionWithoutV)"
+      TargetPlatformIdentifier="$(TargetPlatformIdentifier)"
+      TargetPlatformVersion="$(TargetPlatformVersion)"
+      WindowsSdkSupportedTargetPlatformVersions="@(WindowsSdkSupportedTargetPlatformVersion)">
+
+      <Output TaskParameter="KnownFrameworkReferences" ItemName="KnownFrameworkReference" />
+      
+    </CreateWindowsSdkKnownFrameworkReferences>
+  </Target>
 
   <!--
     ============================================================
@@ -34,6 +59,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     -->
   
   <Target Name="ProcessFrameworkReferences" BeforeTargets="_CheckForInvalidConfigurationAndPlatform;CollectPackageReferences;CollectPackageDownloads"
+          DependsOnTargets="AddWindowsSdkKnownFrameworkReferences"
           Condition="'@(FrameworkReference)' != ''">
     
     <CheckForDuplicateFrameworkReferences

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Windows.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Windows.targets
@@ -24,6 +24,11 @@ Copyright (c) .NET Foundation. All rights reserved.
     <IncludeWindowsSDKRefFrameworkReferences>true</IncludeWindowsSDKRefFrameworkReferences>
   </PropertyGroup>
 
+  <!-- If UseWindowsSDKPreview is true, then allow any target platform version, not just the ones defined by the SDK -->
+  <PropertyGroup Condition="'$(UseWindowsSDKPreview)' == 'true'">
+    <TargetPlatformVersionSupported>true</TargetPlatformVersionSupported>
+  </PropertyGroup>
+
   <!-- Set 7.0 as the TargetPlatformVersion for windows. -->
   <PropertyGroup Condition="'$(TargetPlatformIdentifier)' == 'windows' and '$(TargetPlatformVersion)' == ''" >
     <TargetPlatformVersion>7.0</TargetPlatformVersion>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.WindowsSdkSupportedTargetPlatforms.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.WindowsSdkSupportedTargetPlatforms.props
@@ -12,10 +12,12 @@ Copyright (c) .NET Foundation. All rights reserved.
 
 <!-- This file contains a list of the windows target platform versions that are supported by this SDK for .NET. Supported versions are processed in _NormalizeTargetPlatformVersion -->
 <Project>
-    <ItemGroup>
-        <WindowsSdkSupportedTargetPlatformVersion Include="10.0.19041.0" />
-        <WindowsSdkSupportedTargetPlatformVersion Include="10.0.18362.0" />
-        <WindowsSdkSupportedTargetPlatformVersion Include="10.0.17763.0" />
+  
+    <!-- These will be added to the BundledVersions.props that's generated in dotnet/installer.  So only add them here if we don't have that change yet -->
+    <ItemGroup Condition="'@(WindowsSdkSupportedTargetPlatformVersion)' == ''">
+        <WindowsSdkSupportedTargetPlatformVersion Include="10.0.19041.0" WindowsSdkPackageVersion="10.0.19041.16" MinimumNETVersion="5.0" />
+        <WindowsSdkSupportedTargetPlatformVersion Include="10.0.18362.0" WindowsSdkPackageVersion="10.0.18362.16" MinimumNETVersion="5.0" />
+        <WindowsSdkSupportedTargetPlatformVersion Include="10.0.17763.0" WindowsSdkPackageVersion="10.0.17763.16" MinimumNETVersion="5.0" />
         <WindowsSdkSupportedTargetPlatformVersion Include="8.0" />
         <WindowsSdkSupportedTargetPlatformVersion Include="7.0" />
     </ItemGroup>

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildALibrary.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildALibrary.cs
@@ -957,7 +957,7 @@ namespace ProjectNameWithSpaces
             GetPropertyValue("RootNamespace").Should().Be("Project_Name_With_Spaces");
         }
 
-        [WindowsOnlyRequiresMSBuildVersionFact("16.9.0-preview-21076-28")]
+        [WindowsOnlyFact]
         public void It_errors_on_windows_sdk_assembly_version_conflicts()
         {
             var testProjectA = new TestProject()
@@ -965,6 +965,10 @@ namespace ProjectNameWithSpaces
                 Name = "ProjA",
                 TargetFrameworks = "net5.0-windows10.0.19041"
             };
+            //  Use a previous version of the Microsoft.Windows.SDK.NET.Ref package, to
+            //  simulate the scenario where a project is compiling against a library from NuGet
+            //  which was built with a more recent SDK version.
+            testProjectA.AdditionalProperties["WindowsSdkPackageVersion"] = "10.0.19041.6-preview";
             testProjectA.SourceFiles.Add("ProjA.cs", @"namespace ProjA
 {
     public class ProjAClass
@@ -987,22 +991,7 @@ namespace ProjectNameWithSpaces
 }");
             testProjectA.ReferencedProjects.Add(testProjectB);
 
-            var testAsset = _testAssetsManager.CreateTestProject(testProjectA)
-                .WithProjectChanges((path, project) =>
-                {
-                    if (Path.GetFileName(path).Equals("ProjA.csproj"))
-                    {
-                        //  Use a previous version of the Microsoft.Windows.SDK.NET.Ref package, to
-                        //  simulate the scenario where a project is compiling against a library from NuGet
-                        //  which was built with a more recent SDK version.
-                        var ns = project.Root.Name.Namespace;
-                        var itemGroup = project.Root.Elements(ns + "ItemGroup").First();
-                        var updateKnownFrameworkRef = new XElement(ns + "KnownFrameworkReference",
-                            new XAttribute("Update", "Microsoft.Windows.SDK.NET.Ref"),
-                            new XAttribute("TargetingPackVersion", "10.0.19041.6-preview"));
-                        itemGroup.Add(updateKnownFrameworkRef);
-                    }
-                });
+            var testAsset = _testAssetsManager.CreateTestProject(testProjectA);
 
             var buildCommand = new BuildCommand(testAsset);
             buildCommand

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAWindowsDesktopProject.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAWindowsDesktopProject.cs
@@ -343,7 +343,7 @@ namespace Microsoft.NET.Build.Tests
         }
 
 
-        [Theory]
+        [WindowsOnlyTheory]
         //  Basic Windows TargetFramework
         [InlineData("net5.0-windows10.0.19041.0", false, null, "10.0.19041.*")]
         //  Basic UseWindowsSdkPreview usage

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAWindowsDesktopProject.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAWindowsDesktopProject.cs
@@ -11,6 +11,7 @@ using Microsoft.NET.TestFramework.ProjectConstruction;
 using System.Xml.Linq;
 using System.IO;
 using System.Linq;
+using System;
 
 namespace Microsoft.NET.Build.Tests
 {
@@ -341,6 +342,60 @@ namespace Microsoft.NET.Build.Tests
             GetPropertyValue(testAsset, "TargetPlatformMoniker").Should().Be("Windows,Version=10.0.19041.0");
         }
 
+
+        [Theory]
+        //  Basic Windows TargetFramework
+        [InlineData("net5.0-windows10.0.19041.0", false, null, "10.0.19041.*")]
+        //  Basic UseWindowsSdkPreview usage
+        [InlineData("net5.0-windows10.0.99999.0", true, null, "10.0.99999-preview")]
+        //  Basic WindowsSdkPackageVersion usage
+        [InlineData("net5.0-windows10.0.19041.0", null, "10.0.99999-abc", "10.0.99999-abc")]
+        [InlineData("net5.0-windows10.0.19041.0", null, "10.0.99999.0", "10.0.99999.0")]
+        //  WindowsSdkPackageVersion should supercede UseWindowsSDKPreview property
+        [InlineData("net5.0-windows10.0.19041.0", true, "10.0.99999-abc", "10.0.99999-abc")]
+        public void ItUsesCorrectWindowsSdkPackVersion(string targetFramework, bool? useWindowsSDKPreview, string windowsSdkPackageVersion, string expectedWindowsSdkPackageVersion)
+        {
+            var testProject = new TestProject()
+            {
+                TargetFrameworks = targetFramework
+            };
+            if (useWindowsSDKPreview != null)
+            {
+                testProject.AdditionalProperties["UsewindowsSdkPreview"] = useWindowsSDKPreview.Value.ToString();
+            }
+            if (!string.IsNullOrEmpty(windowsSdkPackageVersion))
+            {
+                testProject.AdditionalProperties["WindowsSdkPackageVersion"] = windowsSdkPackageVersion;
+            }
+
+            var testAsset = _testAssetsManager.CreateTestProject(testProject, identifier: targetFramework + useWindowsSDKPreview + windowsSdkPackageVersion);
+
+            var getValueCommand = new GetValuesCommand(testAsset, "PackageDownload", GetValuesCommand.ValueType.Item);
+            getValueCommand.ShouldRestore = false;
+            getValueCommand.DependsOnTargets = "_CheckForInvalidConfigurationAndPlatform;CollectPackageDownloads";
+            getValueCommand.MetadataNames.Add("Version");
+            getValueCommand.Execute()
+                .Should()
+                .Pass();
+
+            var packageDownloadValues = getValueCommand.GetValuesWithMetadata().Where(kvp => kvp.value == "Microsoft.Windows.SDK.NET.Ref").ToList();
+
+            packageDownloadValues.Count.Should().Be(1);
+
+            var packageDownloadVersion = packageDownloadValues.Single().metadata["Version"];
+            packageDownloadVersion[0].Should().Be('[');
+            packageDownloadVersion.Last().Should().Be(']');
+
+            //  The patch version of the Windows SDK Ref pack will change over time, so we use a '*' in the expected version to indicate that and replace it with
+            //  the 4th part of the version number of the resolved package.
+            var trimmedPackageDownloadVersion = packageDownloadVersion.Substring(1, packageDownloadVersion.Length - 2);
+            if (expectedWindowsSdkPackageVersion.Contains('*'))
+            {
+                expectedWindowsSdkPackageVersion = expectedWindowsSdkPackageVersion.Replace("*", new Version(trimmedPackageDownloadVersion).Revision.ToString());
+            }
+
+            trimmedPackageDownloadVersion.Should().Be(expectedWindowsSdkPackageVersion);
+        }
 
         private string GetPropertyValue(TestAsset testAsset, string propertyName)
         {


### PR DESCRIPTION
- Instead of duplicating Windows SDK Reference `KnownFrameworkReference` items for each target framework, they can be defined in BundledVersions.props like the following:

```xml
<WindowsSdkSupportedTargetPlatformVersion Include="10.0.19041.0" WindowsSdkPackageVersion="10.0.19041.16" MinimumNETVersion="5.0" />
<WindowsSdkSupportedTargetPlatformVersion Include="10.0.18362.0" WindowsSdkPackageVersion="10.0.18362.16" MinimumNETVersion="5.0" />
<WindowsSdkSupportedTargetPlatformVersion Include="10.0.17763.0" WindowsSdkPackageVersion="10.0.17763.16" MinimumNETVersion="5.0" />
<WindowsSdkSupportedTargetPlatformVersion Include="8.0" />
<WindowsSdkSupportedTargetPlatformVersion Include="7.0" />
```

- Support `UseWindowsSDKPreview` property to opt in to preview Windows SDKs
- Support `WindowsSdkPackageVersion` to explicitly set the Windows SDK Ref package version