### PR TITLE
Deprecate -p option (in short form) to dotnet run

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-run/LocalizableStrings.resx
+++ b/src/Cli/dotnet/commands/dotnet-run/LocalizableStrings.resx
@@ -218,6 +218,6 @@ The current {1} is '{2}'.</value>
     <value>The property '{0}' must be an object if it is specified.</value>
   </data>
   <data name="RunCommandProjectAbbreviationDeprecated" xml:space="preserve">
-    <value>WARNING: The abbreviation of -p for --project is deprecated. Please use --project.</value>
+    <value>Warning NETSDK1174: The abbreviation of -p for --project is deprecated. Please use --project.</value>
   </data>
 </root>

--- a/src/Cli/dotnet/commands/dotnet-run/LocalizableStrings.resx
+++ b/src/Cli/dotnet/commands/dotnet-run/LocalizableStrings.resx
@@ -217,4 +217,7 @@ The current {1} is '{2}'.</value>
   <data name="ValueMustBeAnObject" xml:space="preserve">
     <value>The property '{0}' must be an object if it is specified.</value>
   </data>
+  <data name="RunCommandProjectAbbreviationDeprecated" xml:space="preserve">
+    <value>WARNING: The abbreviation of -p for --project is deprecated. Please use --project.</value>
+  </data>
 </root>

--- a/src/Cli/dotnet/commands/dotnet-run/Program.cs
+++ b/src/Cli/dotnet/commands/dotnet-run/Program.cs
@@ -22,12 +22,22 @@ namespace Microsoft.DotNet.Tools.Run
                 throw new HelpException(string.Empty);
             }
 
+            string project = parseResult.ValueForOption<string>(RunCommandParser.ProjectOptionShort);
+            if (!string.IsNullOrEmpty(project))
+            {
+                Console.WriteLine(LocalizableStrings.RunCommandProjectAbbreviationDeprecated.Yellow());
+            }
+            else
+            {
+                project = parseResult.ValueForOption<string>(RunCommandParser.ProjectOption);
+            }
+
             var command = new RunCommand(
                 configuration: parseResult.ValueForOption<string>(RunCommandParser.ConfigurationOption),
                 framework: parseResult.ValueForOption<string>(RunCommandParser.FrameworkOption),
                 runtime: parseResult.ValueForOption<string>(RunCommandParser.RuntimeOption),
                 noBuild: parseResult.HasOption(RunCommandParser.NoBuildOption),
-                project: parseResult.ValueForOption<string>(RunCommandParser.ProjectOption),
+                project: project,
                 launchProfile: parseResult.ValueForOption<string>(RunCommandParser.LaunchProfileOption),
                 noLaunchProfile: parseResult.HasOption(RunCommandParser.NoLaunchProfileOption),
                 noRestore: parseResult.HasOption(RunCommandParser.NoRestoreOption) || parseResult.HasOption(RunCommandParser.NoBuildOption),

--- a/src/Cli/dotnet/commands/dotnet-run/RunCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-run/RunCommandParser.cs
@@ -15,7 +15,12 @@ namespace Microsoft.DotNet.Cli
 
         public static readonly Option RuntimeOption = CommonOptions.RuntimeOption(LocalizableStrings.RuntimeOptionDescription);
 
-        public static readonly Option ProjectOption = new Option<string>(new string[] { "-p", "--project" }, LocalizableStrings.CommandOptionProjectDescription);
+        public static readonly Option ProjectOption = new Option<string>("--project", LocalizableStrings.CommandOptionProjectDescription);
+
+        public static readonly Option ProjectOptionShort = new Option<string>("-p", LocalizableStrings.CommandOptionProjectDescription)
+        {
+            IsHidden = true
+        };
 
         public static readonly Option LaunchProfileOption = new Option<string>("--launch-profile", LocalizableStrings.CommandOptionLaunchProfileDescription);
 
@@ -35,6 +40,7 @@ namespace Microsoft.DotNet.Cli
             command.AddOption(FrameworkOption);
             command.AddOption(RuntimeOption);
             command.AddOption(ProjectOption);
+            command.AddOption(ProjectOptionShort);
             command.AddOption(LaunchProfileOption);
             command.AddOption(NoLaunchProfileOption);
             command.AddOption(NoBuildOption);

--- a/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.cs.xlf
+++ b/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.cs.xlf
@@ -107,6 +107,11 @@ Aktuální {1} je {2}.</target>
         <target state="translated">(výchozí)</target>
         <note />
       </trans-unit>
+      <trans-unit id="RunCommandProjectAbbreviationDeprecated">
+        <source>WARNING: The abbreviation of -p for --project is deprecated. Please use --project.</source>
+        <target state="new">WARNING: The abbreviation of -p for --project is deprecated. Please use --project.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UsingLaunchSettingsFromMessage">
         <source>Using launch settings from {0}...</source>
         <target state="translated">Použití nastavení spuštění z {0}...</target>

--- a/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.cs.xlf
+++ b/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.cs.xlf
@@ -108,8 +108,8 @@ Aktuální {1} je {2}.</target>
         <note />
       </trans-unit>
       <trans-unit id="RunCommandProjectAbbreviationDeprecated">
-        <source>WARNING: The abbreviation of -p for --project is deprecated. Please use --project.</source>
-        <target state="new">WARNING: The abbreviation of -p for --project is deprecated. Please use --project.</target>
+        <source>Warning NETSDK1174: The abbreviation of -p for --project is deprecated. Please use --project.</source>
+        <target state="new">Warning NETSDK1174: The abbreviation of -p for --project is deprecated. Please use --project.</target>
         <note />
       </trans-unit>
       <trans-unit id="UsingLaunchSettingsFromMessage">

--- a/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.de.xlf
+++ b/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.de.xlf
@@ -108,8 +108,8 @@ Ein ausführbares Projekt muss ein ausführbares TFM (z. B. net5.0) und den Outp
         <note />
       </trans-unit>
       <trans-unit id="RunCommandProjectAbbreviationDeprecated">
-        <source>WARNING: The abbreviation of -p for --project is deprecated. Please use --project.</source>
-        <target state="new">WARNING: The abbreviation of -p for --project is deprecated. Please use --project.</target>
+        <source>Warning NETSDK1174: The abbreviation of -p for --project is deprecated. Please use --project.</source>
+        <target state="new">Warning NETSDK1174: The abbreviation of -p for --project is deprecated. Please use --project.</target>
         <note />
       </trans-unit>
       <trans-unit id="UsingLaunchSettingsFromMessage">

--- a/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.de.xlf
+++ b/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.de.xlf
@@ -107,6 +107,11 @@ Ein ausführbares Projekt muss ein ausführbares TFM (z. B. net5.0) und den Outp
         <target state="translated">(Standard)</target>
         <note />
       </trans-unit>
+      <trans-unit id="RunCommandProjectAbbreviationDeprecated">
+        <source>WARNING: The abbreviation of -p for --project is deprecated. Please use --project.</source>
+        <target state="new">WARNING: The abbreviation of -p for --project is deprecated. Please use --project.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UsingLaunchSettingsFromMessage">
         <source>Using launch settings from {0}...</source>
         <target state="translated">Die Starteinstellungen von {0} werden verwendet…</target>

--- a/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.es.xlf
+++ b/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.es.xlf
@@ -108,8 +108,8 @@ El valor actual de {1} es "{2}".</target>
         <note />
       </trans-unit>
       <trans-unit id="RunCommandProjectAbbreviationDeprecated">
-        <source>WARNING: The abbreviation of -p for --project is deprecated. Please use --project.</source>
-        <target state="new">WARNING: The abbreviation of -p for --project is deprecated. Please use --project.</target>
+        <source>Warning NETSDK1174: The abbreviation of -p for --project is deprecated. Please use --project.</source>
+        <target state="new">Warning NETSDK1174: The abbreviation of -p for --project is deprecated. Please use --project.</target>
         <note />
       </trans-unit>
       <trans-unit id="UsingLaunchSettingsFromMessage">

--- a/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.es.xlf
+++ b/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.es.xlf
@@ -107,6 +107,11 @@ El valor actual de {1} es "{2}".</target>
         <target state="translated">(Predeterminada)</target>
         <note />
       </trans-unit>
+      <trans-unit id="RunCommandProjectAbbreviationDeprecated">
+        <source>WARNING: The abbreviation of -p for --project is deprecated. Please use --project.</source>
+        <target state="new">WARNING: The abbreviation of -p for --project is deprecated. Please use --project.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UsingLaunchSettingsFromMessage">
         <source>Using launch settings from {0}...</source>
         <target state="translated">Usando la configuración de inicio de {0}...</target>

--- a/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.fr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.fr.xlf
@@ -107,6 +107,11 @@ Le {1} actuel est '{2}'.</target>
         <target state="translated">(Par défaut)</target>
         <note />
       </trans-unit>
+      <trans-unit id="RunCommandProjectAbbreviationDeprecated">
+        <source>WARNING: The abbreviation of -p for --project is deprecated. Please use --project.</source>
+        <target state="new">WARNING: The abbreviation of -p for --project is deprecated. Please use --project.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UsingLaunchSettingsFromMessage">
         <source>Using launch settings from {0}...</source>
         <target state="translated">Utilisation des paramètres de lancement à partir de {0}...</target>

--- a/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.fr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.fr.xlf
@@ -108,8 +108,8 @@ Le {1} actuel est '{2}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="RunCommandProjectAbbreviationDeprecated">
-        <source>WARNING: The abbreviation of -p for --project is deprecated. Please use --project.</source>
-        <target state="new">WARNING: The abbreviation of -p for --project is deprecated. Please use --project.</target>
+        <source>Warning NETSDK1174: The abbreviation of -p for --project is deprecated. Please use --project.</source>
+        <target state="new">Warning NETSDK1174: The abbreviation of -p for --project is deprecated. Please use --project.</target>
         <note />
       </trans-unit>
       <trans-unit id="UsingLaunchSettingsFromMessage">

--- a/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.it.xlf
+++ b/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.it.xlf
@@ -107,6 +107,11 @@ Il valore corrente di {1} è '{2}'.</target>
         <target state="translated">(Predefinita)</target>
         <note />
       </trans-unit>
+      <trans-unit id="RunCommandProjectAbbreviationDeprecated">
+        <source>WARNING: The abbreviation of -p for --project is deprecated. Please use --project.</source>
+        <target state="new">WARNING: The abbreviation of -p for --project is deprecated. Please use --project.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UsingLaunchSettingsFromMessage">
         <source>Using launch settings from {0}...</source>
         <target state="translated">Uso delle impostazioni di avvio di {0}...</target>

--- a/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.it.xlf
+++ b/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.it.xlf
@@ -108,8 +108,8 @@ Il valore corrente di {1} è '{2}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="RunCommandProjectAbbreviationDeprecated">
-        <source>WARNING: The abbreviation of -p for --project is deprecated. Please use --project.</source>
-        <target state="new">WARNING: The abbreviation of -p for --project is deprecated. Please use --project.</target>
+        <source>Warning NETSDK1174: The abbreviation of -p for --project is deprecated. Please use --project.</source>
+        <target state="new">Warning NETSDK1174: The abbreviation of -p for --project is deprecated. Please use --project.</target>
         <note />
       </trans-unit>
       <trans-unit id="UsingLaunchSettingsFromMessage">

--- a/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.ja.xlf
+++ b/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.ja.xlf
@@ -108,8 +108,8 @@ The current {1} is '{2}'.</source>
         <note />
       </trans-unit>
       <trans-unit id="RunCommandProjectAbbreviationDeprecated">
-        <source>WARNING: The abbreviation of -p for --project is deprecated. Please use --project.</source>
-        <target state="new">WARNING: The abbreviation of -p for --project is deprecated. Please use --project.</target>
+        <source>Warning NETSDK1174: The abbreviation of -p for --project is deprecated. Please use --project.</source>
+        <target state="new">Warning NETSDK1174: The abbreviation of -p for --project is deprecated. Please use --project.</target>
         <note />
       </trans-unit>
       <trans-unit id="UsingLaunchSettingsFromMessage">

--- a/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.ja.xlf
+++ b/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.ja.xlf
@@ -107,6 +107,11 @@ The current {1} is '{2}'.</source>
         <target state="translated">(既定)</target>
         <note />
       </trans-unit>
+      <trans-unit id="RunCommandProjectAbbreviationDeprecated">
+        <source>WARNING: The abbreviation of -p for --project is deprecated. Please use --project.</source>
+        <target state="new">WARNING: The abbreviation of -p for --project is deprecated. Please use --project.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UsingLaunchSettingsFromMessage">
         <source>Using launch settings from {0}...</source>
         <target state="translated">{0} からの起動設定を使用中...</target>

--- a/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.ko.xlf
+++ b/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.ko.xlf
@@ -107,6 +107,11 @@ The current {1} is '{2}'.</source>
         <target state="translated">(기본값)</target>
         <note />
       </trans-unit>
+      <trans-unit id="RunCommandProjectAbbreviationDeprecated">
+        <source>WARNING: The abbreviation of -p for --project is deprecated. Please use --project.</source>
+        <target state="new">WARNING: The abbreviation of -p for --project is deprecated. Please use --project.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UsingLaunchSettingsFromMessage">
         <source>Using launch settings from {0}...</source>
         <target state="translated">{0}의 시작 설정을 사용하는 중...</target>

--- a/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.ko.xlf
+++ b/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.ko.xlf
@@ -108,8 +108,8 @@ The current {1} is '{2}'.</source>
         <note />
       </trans-unit>
       <trans-unit id="RunCommandProjectAbbreviationDeprecated">
-        <source>WARNING: The abbreviation of -p for --project is deprecated. Please use --project.</source>
-        <target state="new">WARNING: The abbreviation of -p for --project is deprecated. Please use --project.</target>
+        <source>Warning NETSDK1174: The abbreviation of -p for --project is deprecated. Please use --project.</source>
+        <target state="new">Warning NETSDK1174: The abbreviation of -p for --project is deprecated. Please use --project.</target>
         <note />
       </trans-unit>
       <trans-unit id="UsingLaunchSettingsFromMessage">

--- a/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.pl.xlf
+++ b/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.pl.xlf
@@ -107,6 +107,11 @@ Bieżący element {1}: „{2}”.</target>
         <target state="translated">(Domyślne)</target>
         <note />
       </trans-unit>
+      <trans-unit id="RunCommandProjectAbbreviationDeprecated">
+        <source>WARNING: The abbreviation of -p for --project is deprecated. Please use --project.</source>
+        <target state="new">WARNING: The abbreviation of -p for --project is deprecated. Please use --project.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UsingLaunchSettingsFromMessage">
         <source>Using launch settings from {0}...</source>
         <target state="translated">Używanie ustawień uruchamiania z profilu {0}...</target>

--- a/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.pl.xlf
+++ b/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.pl.xlf
@@ -108,8 +108,8 @@ Bieżący element {1}: „{2}”.</target>
         <note />
       </trans-unit>
       <trans-unit id="RunCommandProjectAbbreviationDeprecated">
-        <source>WARNING: The abbreviation of -p for --project is deprecated. Please use --project.</source>
-        <target state="new">WARNING: The abbreviation of -p for --project is deprecated. Please use --project.</target>
+        <source>Warning NETSDK1174: The abbreviation of -p for --project is deprecated. Please use --project.</source>
+        <target state="new">Warning NETSDK1174: The abbreviation of -p for --project is deprecated. Please use --project.</target>
         <note />
       </trans-unit>
       <trans-unit id="UsingLaunchSettingsFromMessage">

--- a/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.pt-BR.xlf
@@ -108,8 +108,8 @@ O {1} atual é '{2}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="RunCommandProjectAbbreviationDeprecated">
-        <source>WARNING: The abbreviation of -p for --project is deprecated. Please use --project.</source>
-        <target state="new">WARNING: The abbreviation of -p for --project is deprecated. Please use --project.</target>
+        <source>Warning NETSDK1174: The abbreviation of -p for --project is deprecated. Please use --project.</source>
+        <target state="new">Warning NETSDK1174: The abbreviation of -p for --project is deprecated. Please use --project.</target>
         <note />
       </trans-unit>
       <trans-unit id="UsingLaunchSettingsFromMessage">

--- a/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.pt-BR.xlf
@@ -107,6 +107,11 @@ O {1} atual é '{2}'.</target>
         <target state="translated">(Padrão)</target>
         <note />
       </trans-unit>
+      <trans-unit id="RunCommandProjectAbbreviationDeprecated">
+        <source>WARNING: The abbreviation of -p for --project is deprecated. Please use --project.</source>
+        <target state="new">WARNING: The abbreviation of -p for --project is deprecated. Please use --project.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UsingLaunchSettingsFromMessage">
         <source>Using launch settings from {0}...</source>
         <target state="translated">Usando as configurações de inicialização de {0}...</target>

--- a/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.ru.xlf
+++ b/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.ru.xlf
@@ -108,8 +108,8 @@ The current {1} is '{2}'.</source>
         <note />
       </trans-unit>
       <trans-unit id="RunCommandProjectAbbreviationDeprecated">
-        <source>WARNING: The abbreviation of -p for --project is deprecated. Please use --project.</source>
-        <target state="new">WARNING: The abbreviation of -p for --project is deprecated. Please use --project.</target>
+        <source>Warning NETSDK1174: The abbreviation of -p for --project is deprecated. Please use --project.</source>
+        <target state="new">Warning NETSDK1174: The abbreviation of -p for --project is deprecated. Please use --project.</target>
         <note />
       </trans-unit>
       <trans-unit id="UsingLaunchSettingsFromMessage">

--- a/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.ru.xlf
+++ b/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.ru.xlf
@@ -107,6 +107,11 @@ The current {1} is '{2}'.</source>
         <target state="translated">(По умолчанию)</target>
         <note />
       </trans-unit>
+      <trans-unit id="RunCommandProjectAbbreviationDeprecated">
+        <source>WARNING: The abbreviation of -p for --project is deprecated. Please use --project.</source>
+        <target state="new">WARNING: The abbreviation of -p for --project is deprecated. Please use --project.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UsingLaunchSettingsFromMessage">
         <source>Using launch settings from {0}...</source>
         <target state="translated">Используются параметры запуска из {0}...</target>

--- a/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.tr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.tr.xlf
@@ -108,8 +108,8 @@ Geçerli {1}: '{2}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="RunCommandProjectAbbreviationDeprecated">
-        <source>WARNING: The abbreviation of -p for --project is deprecated. Please use --project.</source>
-        <target state="new">WARNING: The abbreviation of -p for --project is deprecated. Please use --project.</target>
+        <source>Warning NETSDK1174: The abbreviation of -p for --project is deprecated. Please use --project.</source>
+        <target state="new">Warning NETSDK1174: The abbreviation of -p for --project is deprecated. Please use --project.</target>
         <note />
       </trans-unit>
       <trans-unit id="UsingLaunchSettingsFromMessage">

--- a/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.tr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.tr.xlf
@@ -107,6 +107,11 @@ Geçerli {1}: '{2}'.</target>
         <target state="translated">(Varsayılan)</target>
         <note />
       </trans-unit>
+      <trans-unit id="RunCommandProjectAbbreviationDeprecated">
+        <source>WARNING: The abbreviation of -p for --project is deprecated. Please use --project.</source>
+        <target state="new">WARNING: The abbreviation of -p for --project is deprecated. Please use --project.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UsingLaunchSettingsFromMessage">
         <source>Using launch settings from {0}...</source>
         <target state="translated">{0} içindeki başlatma ayarları kullanılıyor...</target>

--- a/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.zh-Hans.xlf
@@ -107,6 +107,11 @@ The current {1} is '{2}'.</source>
         <target state="translated">(默认值)</target>
         <note />
       </trans-unit>
+      <trans-unit id="RunCommandProjectAbbreviationDeprecated">
+        <source>WARNING: The abbreviation of -p for --project is deprecated. Please use --project.</source>
+        <target state="new">WARNING: The abbreviation of -p for --project is deprecated. Please use --project.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UsingLaunchSettingsFromMessage">
         <source>Using launch settings from {0}...</source>
         <target state="translated">从 {0} 使用启动设置...</target>

--- a/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.zh-Hans.xlf
@@ -108,8 +108,8 @@ The current {1} is '{2}'.</source>
         <note />
       </trans-unit>
       <trans-unit id="RunCommandProjectAbbreviationDeprecated">
-        <source>WARNING: The abbreviation of -p for --project is deprecated. Please use --project.</source>
-        <target state="new">WARNING: The abbreviation of -p for --project is deprecated. Please use --project.</target>
+        <source>Warning NETSDK1174: The abbreviation of -p for --project is deprecated. Please use --project.</source>
+        <target state="new">Warning NETSDK1174: The abbreviation of -p for --project is deprecated. Please use --project.</target>
         <note />
       </trans-unit>
       <trans-unit id="UsingLaunchSettingsFromMessage">

--- a/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.zh-Hant.xlf
@@ -107,6 +107,11 @@ The current {1} is '{2}'.</source>
         <target state="translated">(預設)</target>
         <note />
       </trans-unit>
+      <trans-unit id="RunCommandProjectAbbreviationDeprecated">
+        <source>WARNING: The abbreviation of -p for --project is deprecated. Please use --project.</source>
+        <target state="new">WARNING: The abbreviation of -p for --project is deprecated. Please use --project.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UsingLaunchSettingsFromMessage">
         <source>Using launch settings from {0}...</source>
         <target state="translated">使用來自 {0} 的啟動設定...</target>

--- a/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.zh-Hant.xlf
@@ -108,8 +108,8 @@ The current {1} is '{2}'.</source>
         <note />
       </trans-unit>
       <trans-unit id="RunCommandProjectAbbreviationDeprecated">
-        <source>WARNING: The abbreviation of -p for --project is deprecated. Please use --project.</source>
-        <target state="new">WARNING: The abbreviation of -p for --project is deprecated. Please use --project.</target>
+        <source>Warning NETSDK1174: The abbreviation of -p for --project is deprecated. Please use --project.</source>
+        <target state="new">Warning NETSDK1174: The abbreviation of -p for --project is deprecated. Please use --project.</target>
         <note />
       </trans-unit>
       <trans-unit id="UsingLaunchSettingsFromMessage">

--- a/src/Tasks/Common/Resources/Strings.resx
+++ b/src/Tasks/Common/Resources/Strings.resx
@@ -807,4 +807,8 @@ To install these workloads, run the following command: {1}</value>
     <value>NETSDK1173: The provided type library '{0}' is in an invalid format.</value>
     <comment>{StrBegin="NETSDK1173: "}</comment>
   </data>
+  <data name="PlaceholderRunCommandProjectAbbreviationDeprecated" xml:space="preserve">
+    <value>NETSDK1174: Placeholder</value>
+    <comment>{StrBegin="NETSDK1174: "} - This string is not used here, but is a placeholder for the error code, which is used by the "dotnet run" command.</comment>
+  </data>
 </root>

--- a/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
@@ -640,6 +640,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1071: PackageReference na balíček {0} určuje verzi {1}. Určení verze tohoto balíčku se nedoporučuje. Další informace najdete na adrese https://aka.ms/sdkimplicitrefs.</target>
         <note>{StrBegin="NETSDK1071: "}</note>
       </trans-unit>
+      <trans-unit id="PlaceholderRunCommandProjectAbbreviationDeprecated">
+        <source>NETSDK1174: Placeholder</source>
+        <target state="new">NETSDK1174: Placeholder</target>
+        <note>{StrBegin="NETSDK1174: "} - This string is not used here, but is a placeholder for the error code, which is used by the "dotnet run" command.</note>
+      </trans-unit>
       <trans-unit id="ProjectAssetsConsumedWithoutMSBuildProjectPath">
         <source>NETSDK1011: Assets are consumed from project '{0}', but no corresponding MSBuild project path was  found in '{1}'.</source>
         <target state="translated">NETSDK1011: Prostředky se používají z projektu {0}, ale v {1} se nenašla odpovídající cesta k projektu MSBuild.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.de.xlf
@@ -640,6 +640,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1071: Ein PackageReference-Verweis auf "{0}" hat die Version "{1}" angegeben. Die Angabe der Version dieses Pakets wird nicht empfohlen. Weitere Informationen finden Sie unter https://aka.ms/sdkimplicitrefs.</target>
         <note>{StrBegin="NETSDK1071: "}</note>
       </trans-unit>
+      <trans-unit id="PlaceholderRunCommandProjectAbbreviationDeprecated">
+        <source>NETSDK1174: Placeholder</source>
+        <target state="new">NETSDK1174: Placeholder</target>
+        <note>{StrBegin="NETSDK1174: "} - This string is not used here, but is a placeholder for the error code, which is used by the "dotnet run" command.</note>
+      </trans-unit>
       <trans-unit id="ProjectAssetsConsumedWithoutMSBuildProjectPath">
         <source>NETSDK1011: Assets are consumed from project '{0}', but no corresponding MSBuild project path was  found in '{1}'.</source>
         <target state="translated">NETSDK1011: Es werden Ressourcen aus dem Projekt "{0}" genutzt, in "{1}" wurde jedoch kein entsprechender MSBuild-Projektpfad gefunden.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.es.xlf
@@ -640,6 +640,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="new">NETSDK1071: A PackageReference to '{0}' specified a Version of `{1}`. Specifying the version of this package is not recommended. For more information, see https://aka.ms/sdkimplicitrefs</target>
         <note>{StrBegin="NETSDK1071: "}</note>
       </trans-unit>
+      <trans-unit id="PlaceholderRunCommandProjectAbbreviationDeprecated">
+        <source>NETSDK1174: Placeholder</source>
+        <target state="new">NETSDK1174: Placeholder</target>
+        <note>{StrBegin="NETSDK1174: "} - This string is not used here, but is a placeholder for the error code, which is used by the "dotnet run" command.</note>
+      </trans-unit>
       <trans-unit id="ProjectAssetsConsumedWithoutMSBuildProjectPath">
         <source>NETSDK1011: Assets are consumed from project '{0}', but no corresponding MSBuild project path was  found in '{1}'.</source>
         <target state="new">NETSDK1011: Assets are consumed from project '{0}', but no corresponding MSBuild project path was  found in '{1}'.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
@@ -640,6 +640,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1071: Une référence de package vers '{0}' a spécifié une version '{1}'. Nous ne vous recommandons pas de spécifier la version de ce package. Pour plus d'informations, consultez https://aka.ms/sdkimplicitrefs</target>
         <note>{StrBegin="NETSDK1071: "}</note>
       </trans-unit>
+      <trans-unit id="PlaceholderRunCommandProjectAbbreviationDeprecated">
+        <source>NETSDK1174: Placeholder</source>
+        <target state="new">NETSDK1174: Placeholder</target>
+        <note>{StrBegin="NETSDK1174: "} - This string is not used here, but is a placeholder for the error code, which is used by the "dotnet run" command.</note>
+      </trans-unit>
       <trans-unit id="ProjectAssetsConsumedWithoutMSBuildProjectPath">
         <source>NETSDK1011: Assets are consumed from project '{0}', but no corresponding MSBuild project path was  found in '{1}'.</source>
         <target state="translated">NETSDK1011: Les composants sont consommés à partir du projet '{0}', mais il n'existe aucun chemin de projet MSBuild correspondant dans '{1}'.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.it.xlf
@@ -640,6 +640,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1071: in un elemento PackageReference che fa riferimento a '{0}' è specificata la versione di `{1}`. È consigliabile non specificare la versione di questo pacchetto. Per altre informazioni, vedere https://aka.ms/sdkimplicitrefs</target>
         <note>{StrBegin="NETSDK1071: "}</note>
       </trans-unit>
+      <trans-unit id="PlaceholderRunCommandProjectAbbreviationDeprecated">
+        <source>NETSDK1174: Placeholder</source>
+        <target state="new">NETSDK1174: Placeholder</target>
+        <note>{StrBegin="NETSDK1174: "} - This string is not used here, but is a placeholder for the error code, which is used by the "dotnet run" command.</note>
+      </trans-unit>
       <trans-unit id="ProjectAssetsConsumedWithoutMSBuildProjectPath">
         <source>NETSDK1011: Assets are consumed from project '{0}', but no corresponding MSBuild project path was  found in '{1}'.</source>
         <target state="translated">NETSDK1011: le risorse vengono utilizzate dal progetto '{0}', ma non è stato trovato alcun percorso di progetto MSBuild corrispondente in '{1}'.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
@@ -640,6 +640,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1071: '{0}' への PackageReference は '{1}' のバージョンを指定しました。このパッケージのバージョンを指定することは推奨されません。詳細については、https://aka.ms/sdkimplicitrefs を参照してください</target>
         <note>{StrBegin="NETSDK1071: "}</note>
       </trans-unit>
+      <trans-unit id="PlaceholderRunCommandProjectAbbreviationDeprecated">
+        <source>NETSDK1174: Placeholder</source>
+        <target state="new">NETSDK1174: Placeholder</target>
+        <note>{StrBegin="NETSDK1174: "} - This string is not used here, but is a placeholder for the error code, which is used by the "dotnet run" command.</note>
+      </trans-unit>
       <trans-unit id="ProjectAssetsConsumedWithoutMSBuildProjectPath">
         <source>NETSDK1011: Assets are consumed from project '{0}', but no corresponding MSBuild project path was  found in '{1}'.</source>
         <target state="translated">NETSDK1011: プロジェクト '{0}' の資産が使用されますが、対応する MSBuild プロジェクト パスが '{1}' で見つかりませんでした。</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
@@ -640,6 +640,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1071: '{0}'에 대한 PackageReference에서 `{1}`의 버전을 지정했습니다. 이 패키지의 버전을 지정하지 않는 것이 좋습니다. 자세한 내용은 https://aka.ms/sdkimplicitrefs를 참조하세요.</target>
         <note>{StrBegin="NETSDK1071: "}</note>
       </trans-unit>
+      <trans-unit id="PlaceholderRunCommandProjectAbbreviationDeprecated">
+        <source>NETSDK1174: Placeholder</source>
+        <target state="new">NETSDK1174: Placeholder</target>
+        <note>{StrBegin="NETSDK1174: "} - This string is not used here, but is a placeholder for the error code, which is used by the "dotnet run" command.</note>
+      </trans-unit>
       <trans-unit id="ProjectAssetsConsumedWithoutMSBuildProjectPath">
         <source>NETSDK1011: Assets are consumed from project '{0}', but no corresponding MSBuild project path was  found in '{1}'.</source>
         <target state="translated">NETSDK1011: '{0}' 프로젝트의 자산이 사용되었지만, '{1}'에서 해당 MSBuild 프로젝트 경로를 찾을 수 없습니다.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
@@ -640,6 +640,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1071: Odwołanie PackageReference do pakietu „{0}” określiło wersję „{1}”. Określanie wersji tego pakietu nie jest zalecane. Aby uzyskać więcej informacji, zobacz https://aka.ms/sdkimplicitrefs</target>
         <note>{StrBegin="NETSDK1071: "}</note>
       </trans-unit>
+      <trans-unit id="PlaceholderRunCommandProjectAbbreviationDeprecated">
+        <source>NETSDK1174: Placeholder</source>
+        <target state="new">NETSDK1174: Placeholder</target>
+        <note>{StrBegin="NETSDK1174: "} - This string is not used here, but is a placeholder for the error code, which is used by the "dotnet run" command.</note>
+      </trans-unit>
       <trans-unit id="ProjectAssetsConsumedWithoutMSBuildProjectPath">
         <source>NETSDK1011: Assets are consumed from project '{0}', but no corresponding MSBuild project path was  found in '{1}'.</source>
         <target state="translated">NETSDK1011: Zasoby są używane z projektu „{0}”, ale w elemencie „{1}” nie odnaleziono odpowiadającej ścieżki projektu MSBuild.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
@@ -640,6 +640,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1071: uma PackageReference para '{0}' especificou uma Versão de '{1}'. Não é recomendado especificar a versão deste pacote. Para obter mais informações, consulte https://aka.ms/sdkimplicitrefs</target>
         <note>{StrBegin="NETSDK1071: "}</note>
       </trans-unit>
+      <trans-unit id="PlaceholderRunCommandProjectAbbreviationDeprecated">
+        <source>NETSDK1174: Placeholder</source>
+        <target state="new">NETSDK1174: Placeholder</target>
+        <note>{StrBegin="NETSDK1174: "} - This string is not used here, but is a placeholder for the error code, which is used by the "dotnet run" command.</note>
+      </trans-unit>
       <trans-unit id="ProjectAssetsConsumedWithoutMSBuildProjectPath">
         <source>NETSDK1011: Assets are consumed from project '{0}', but no corresponding MSBuild project path was  found in '{1}'.</source>
         <target state="translated">NETSDK1011: Os ativos são consumidos de um projeto '{0}', mas não foi encontrado nenhum caminho de projeto do MSBuild correspondente em '{1}'.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
@@ -640,6 +640,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1071: В ссылке PackageReference на '{0}' указана версия {1}. Указывать версию этого пакета не рекомендуется. Дополнительные сведения см. на странице https://aka.ms/sdkimplicitrefs</target>
         <note>{StrBegin="NETSDK1071: "}</note>
       </trans-unit>
+      <trans-unit id="PlaceholderRunCommandProjectAbbreviationDeprecated">
+        <source>NETSDK1174: Placeholder</source>
+        <target state="new">NETSDK1174: Placeholder</target>
+        <note>{StrBegin="NETSDK1174: "} - This string is not used here, but is a placeholder for the error code, which is used by the "dotnet run" command.</note>
+      </trans-unit>
       <trans-unit id="ProjectAssetsConsumedWithoutMSBuildProjectPath">
         <source>NETSDK1011: Assets are consumed from project '{0}', but no corresponding MSBuild project path was  found in '{1}'.</source>
         <target state="translated">NETSDK1011: используются ресурсы из проекта "{0}", но соответствующий путь к проекту MSBuild не найден в "{1}".</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
@@ -640,6 +640,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1071: '{0}' öğesine yönelik bir PackageReference, bir `{1}` Sürümünü belirtti. Bu paketin sürümünün belirtilmesi önerilmez. Daha fazla bilgi edinmek için bkz. https://aka.ms/sdkimplicitrefs</target>
         <note>{StrBegin="NETSDK1071: "}</note>
       </trans-unit>
+      <trans-unit id="PlaceholderRunCommandProjectAbbreviationDeprecated">
+        <source>NETSDK1174: Placeholder</source>
+        <target state="new">NETSDK1174: Placeholder</target>
+        <note>{StrBegin="NETSDK1174: "} - This string is not used here, but is a placeholder for the error code, which is used by the "dotnet run" command.</note>
+      </trans-unit>
       <trans-unit id="ProjectAssetsConsumedWithoutMSBuildProjectPath">
         <source>NETSDK1011: Assets are consumed from project '{0}', but no corresponding MSBuild project path was  found in '{1}'.</source>
         <target state="translated">NETSDK1011: '{0}' projesindeki varlıklar kullanılıyor, ancak '{1}' içinde karşılık gelen bir MSBuild proje yolu bulunamadı.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
@@ -640,6 +640,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1071: “{0}”的 PackageReference 指定了版本“{1}”。不建议指定此包的版本。有关详细信息，请查看 https://aka.ms/sdkimplicitrefs</target>
         <note>{StrBegin="NETSDK1071: "}</note>
       </trans-unit>
+      <trans-unit id="PlaceholderRunCommandProjectAbbreviationDeprecated">
+        <source>NETSDK1174: Placeholder</source>
+        <target state="new">NETSDK1174: Placeholder</target>
+        <note>{StrBegin="NETSDK1174: "} - This string is not used here, but is a placeholder for the error code, which is used by the "dotnet run" command.</note>
+      </trans-unit>
       <trans-unit id="ProjectAssetsConsumedWithoutMSBuildProjectPath">
         <source>NETSDK1011: Assets are consumed from project '{0}', but no corresponding MSBuild project path was  found in '{1}'.</source>
         <target state="translated">NETSDK1011: 从项目“{0}”消耗资产，但在“{1}”中找不到相应的 MSBuild 项目路径。</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
@@ -640,6 +640,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1071: '{0}' 的 PackageReference 指定了 `{1}` 版本。不建議指定這個套件版本。如需詳細資訊，請參閱 https://aka.ms/sdkimplicitrefs</target>
         <note>{StrBegin="NETSDK1071: "}</note>
       </trans-unit>
+      <trans-unit id="PlaceholderRunCommandProjectAbbreviationDeprecated">
+        <source>NETSDK1174: Placeholder</source>
+        <target state="new">NETSDK1174: Placeholder</target>
+        <note>{StrBegin="NETSDK1174: "} - This string is not used here, but is a placeholder for the error code, which is used by the "dotnet run" command.</note>
+      </trans-unit>
       <trans-unit id="ProjectAssetsConsumedWithoutMSBuildProjectPath">
         <source>NETSDK1011: Assets are consumed from project '{0}', but no corresponding MSBuild project path was  found in '{1}'.</source>
         <target state="translated">NETSDK1011: 已從專案 '{0}' 取用資產，但在 '{1}' 中找不到相對應的 MSBuild 專案路徑。</target>

--- a/src/Tests/dotnet-run.Tests/GivenDotnetRunRunsCsProj.cs
+++ b/src/Tests/dotnet-run.Tests/GivenDotnetRunRunsCsProj.cs
@@ -170,7 +170,8 @@ namespace Microsoft.DotNet.Cli.Run.Tests
                 .WithWorkingDirectory(Directory.GetParent(testInstance.Path).FullName)
                 .Execute($"--project", projectFile)
                 .Should().Pass()
-                         .And.HaveStdOutContaining("Hello World!");
+                         .And.HaveStdOutContaining("Hello World!")
+                         .And.NotHaveStdOutContaining(LocalizableStrings.RunCommandProjectAbbreviationDeprecated);
         }
 
         [Fact]
@@ -186,7 +187,25 @@ namespace Microsoft.DotNet.Cli.Run.Tests
                 .WithWorkingDirectory(Directory.GetParent(testInstance.Path).FullName)
                 .Execute("--project", testProjectDirectory)
                 .Should().Pass()
-                         .And.HaveStdOutContaining("Hello World!");
+                         .And.HaveStdOutContaining("Hello World!")
+                         .And.NotHaveStdOutContaining(LocalizableStrings.RunCommandProjectAbbreviationDeprecated);
+        }
+
+        [Fact]
+        public void ItWarnsWhenShortFormOfProjectArgumentIsUsed()
+        {
+            var testAppName = "MSBuildTestApp";
+            var testInstance = _testAssetsManager.CopyTestAsset(testAppName)
+                .WithSource();
+
+            var projectFile = Path.Combine(testInstance.Path, testAppName + ".csproj");
+
+            new DotnetCommand(Log, "run")
+                .WithWorkingDirectory(Directory.GetParent(testInstance.Path).FullName)
+                .Execute($"-p", projectFile)
+                .Should().Pass()
+                         .And.HaveStdOutContaining("Hello World!")
+                         .And.HaveStdOutContaining(LocalizableStrings.RunCommandProjectAbbreviationDeprecated);
         }
 
         [Fact]


### PR DESCRIPTION
See https://github.com/dotnet/designs/pull/229 and https://github.com/dotnet/docs/issues/24727

This PR implements the deprecation of the `-p` option.  Supporting `-p` to set properties will come in a later preview or release.

