### PR TITLE
A simple composite R2R test for singlefile apps

### DIFF
--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishASingleFileApp.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishASingleFileApp.cs
@@ -28,6 +28,7 @@ namespace Microsoft.NET.Publish.Tests
         private const string ExcludeAlways = "/p:ExcludeAlways=true";
         private const string DontUseAppHost = "/p:UseAppHost=false";
         private const string ReadyToRun = "/p:PublishReadyToRun=true";
+        private const string ReadyToRunComposite = "/p:PublishReadyToRunComposite=true";
         private const string ReadyToRunWithSymbols = "/p:PublishReadyToRunEmitSymbols=true";
         private const string UseAppHost = "/p:UseAppHost=true";
         private const string IncludeDefault = "/p:IncludeSymbolsInSingleFile=false";
@@ -276,6 +277,27 @@ namespace Microsoft.NET.Publish.Tests
             GetPublishDirectory(publishCommand, "net6.0")
                 .Should()
                 .OnlyHaveFiles(expectedFiles);
+        }
+
+        [RequiresMSBuildVersionTheory("16.8.0")]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void It_supports_composite_r2r(bool extractAll)
+        {
+            var testProject = new TestProject()
+            {
+                Name = "SingleFileTest",
+                TargetFrameworks = "net6.0",
+                IsExe = true,
+            };
+
+            var testAsset = _testAssetsManager.CreateTestProject(testProject);
+            var publishCommand = new PublishCommand(testAsset);
+
+            publishCommand
+                .Execute(PublishSingleFile, ReadyToRun, ReadyToRunComposite, RuntimeIdentifier, extractAll ? IncludeAllContent: "")
+                .Should()
+                .Pass();
         }
 
         [RequiresMSBuildVersionFact("16.8.0")]

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishASingleFileApp.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishASingleFileApp.cs
@@ -285,9 +285,15 @@ namespace Microsoft.NET.Publish.Tests
         [InlineData(false)]
         public void It_supports_composite_r2r(bool extractAll)
         {
+            var projName = "SingleFileTest";
+            if (extractAll)
+            {
+                projName += "Extracted";
+            }
+
             var testProject = new TestProject()
             {
-                Name = "SingleFileTest",
+                Name = projName,
                 TargetFrameworks = "net6.0",
                 IsExe = true,
             };


### PR DESCRIPTION
NOTE: The test is expected to fail until https://github.com/dotnet/runtime/pull/53739 is merged and propagated to SDK.