### PR TITLE
Correctly initialize RefreshBrowserAfterFileChange

### DIFF
--- a/src/BuiltInTools/BrowserRefresh/WebSocketScriptInjection.js
+++ b/src/BuiltInTools/BrowserRefresh/WebSocketScriptInjection.js
@@ -37,7 +37,7 @@ setTimeout(async function () {
         'UpdateStaticFile': () => updateStaticFile(payload.path),
         'BlazorHotReloadDeltav1': () => applyBlazorDeltas(payload.deltas),
         'HotReloadDiagnosticsv1': () => displayDiagnostics(payload.diagnostics),
-        'HotReloadApplied': () => notifyHotReloadApplied(),
+        'AspNetCoreHotReloadApplied': () => aspnetCoreHotReloadApplied(),
       };
 
       if (payload.type && action.hasOwnProperty(payload.type)) {
@@ -157,6 +157,15 @@ setTimeout(async function () {
     el.textContent = 'Updated the page';
     document.body.appendChild(el);
     setTimeout(() => el.remove(), 520);
+  }
+
+  function aspnetCoreHotReloadApplied() {
+    if (window.Blazor) {
+      // If this page has any Blazor, don't refresh the browser.
+      notiifyHotReloadApplied();
+    } else {
+      location.reload();
+    }
   }
 
   function sendDeltaApplied() {

--- a/src/BuiltInTools/dotnet-watch/HotReload/BlazorWebAssemblyHostedDeltaApplier.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/BlazorWebAssemblyHostedDeltaApplier.cs
@@ -18,10 +18,7 @@ namespace Microsoft.DotNet.Watcher.Tools
         public BlazorWebAssemblyHostedDeltaApplier(IReporter reporter)
         {
             _wasmApplier = new BlazorWebAssemblyDeltaApplier(reporter);
-            _hostApplier = new DefaultDeltaApplier(reporter)
-            {
-                SuppressBrowserRefreshAfterApply = true,
-            };
+            _hostApplier = new DefaultDeltaApplier(reporter);
         }
 
         public async ValueTask InitializeAsync(DotNetWatchContext context, CancellationToken cancellationToken)

--- a/src/BuiltInTools/dotnet-watch/HotReload/DefaultDeltaApplier.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/DefaultDeltaApplier.cs
@@ -28,10 +28,6 @@ namespace Microsoft.DotNet.Watcher.Tools
             _reporter = reporter;
         }
 
-        public bool SuppressBrowserRefreshAfterApply { get; init; }
-
-        internal bool RefreshBrowserAfterFileChange { get; private set; }
-
         internal bool SuppressNamedPipeForTests { get; set; }
 
         public ValueTask InitializeAsync(DotNetWatchContext context, CancellationToken cancellationToken)
@@ -50,12 +46,6 @@ namespace Microsoft.DotNet.Watcher.Tools
                 // Configure the app for EnC
                 context.ProcessSpec.EnvironmentVariables["DOTNET_MODIFIABLE_ASSEMBLIES"] = "debug";
                 context.ProcessSpec.EnvironmentVariables["DOTNET_HOTRELOAD_NAMEDPIPE_NAME"] = _namedPipeName;
-            }
-
-            // If there's any .razor file, we'll assume this is a blazor app and not cause a browser refresh.
-            if (!SuppressBrowserRefreshAfterApply)
-            {
-                RefreshBrowserAfterFileChange = !context.FileSet.Any(f => f.FilePath.EndsWith(".razor", StringComparison.Ordinal));
             }
 
             return default;
@@ -118,21 +108,7 @@ namespace Microsoft.DotNet.Watcher.Tools
                 return false;
             }
 
-            if (!SuppressBrowserRefreshAfterApply && context.BrowserRefreshServer is not null)
-            {
-                // For a Web app, we have the option of either letting the app update the UI or
-                // refresh the browser. In general, for Blazor apps, we will choose not to refresh the UI
-                // and for other apps we'll always refresh
-                if (RefreshBrowserAfterFileChange)
-                {
-                    await context.BrowserRefreshServer.ReloadAsync(cancellationToken);
-                }
-                else
-                {
-                    await context.BrowserRefreshServer.SendJsonSerlialized(new HotReloadApplied());
-                }
-            }
-
+            await context.BrowserRefreshServer.SendJsonSerlialized(new AspNetCoreHotReloadApplied(), cancellationToken);
             return true;
         }
 
@@ -161,9 +137,9 @@ namespace Microsoft.DotNet.Watcher.Tools
             public IEnumerable<string> Diagnostics { get; init; }
         }
 
-        public readonly struct HotReloadApplied
+        public readonly struct AspNetCoreHotReloadApplied
         {
-            public string Type => "HotReloadApplied";
+            public string Type => "AspNetCoreHotReloadApplied";
         }
     }
 }

--- a/src/Tests/dotnet-watch.Tests/HotReload/DefaultDeltaApplierTest.cs
+++ b/src/Tests/dotnet-watch.Tests/HotReload/DefaultDeltaApplierTest.cs
@@ -1,0 +1,77 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System.Threading.Tasks;
+using Microsoft.Extensions.Tools.Internal;
+using Moq;
+using Xunit;
+
+namespace Microsoft.DotNet.Watcher.Tools
+{
+    public class DefaultDeltaApplierTest
+    {
+        [Fact]
+        public async Task InitializeAsync_ConfiguresEnvironmentVariables()
+        {
+            // Arrange
+            var applier = new DefaultDeltaApplier(Mock.Of<IReporter>()) { SuppressNamedPipeForTests = true };
+            var process = new ProcessSpec();
+            var fileSet = new FileSet(null, new[]
+            {
+                new FileItem {  FilePath = "Test.cs" },
+            });
+            var context = new DotNetWatchContext { ProcessSpec = process, FileSet = fileSet, Iteration = 0 };
+
+            // Act
+            await applier.InitializeAsync(context, default);
+
+            // Assert
+            Assert.Equal("debug", process.EnvironmentVariables["DOTNET_MODIFIABLE_ASSEMBLIES"]);
+            Assert.NotEmpty(process.EnvironmentVariables["DOTNET_HOTRELOAD_NAMEDPIPE_NAME"]);
+            Assert.NotEmpty(process.EnvironmentVariables.DotNetStartupHooks);
+        }
+
+        [Fact]
+        public async Task InitializeAsync_ResetsRefreshBrowserAfterFileChange_ForBlazorProjects()
+        {
+            // Arrange
+            var applier = new DefaultDeltaApplier(Mock.Of<IReporter>()) { SuppressNamedPipeForTests = true };
+            var process = new ProcessSpec();
+            var fileSet = new FileSet(null, new[]
+            {
+                new FileItem {  FilePath = "Index.razor" },
+                new FileItem {  FilePath = "_Host.cshtml", }
+            });
+            var context = new DotNetWatchContext { ProcessSpec = process, FileSet = fileSet, Iteration = 0 };
+
+            // Act
+            await applier.InitializeAsync(context, default);
+
+            // Assert
+            Assert.False(applier.RefreshBrowserAfterFileChange);
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(7)]
+        public async Task InitializeAsync_SetsRefreshBrowserAfterFileChange_ForProjectsWithoutRazorFiles(int iteration)
+        {
+            // Arrange
+            var applier = new DefaultDeltaApplier(Mock.Of<IReporter>()) { SuppressNamedPipeForTests = true };
+            var process = new ProcessSpec();
+            var fileSet = new FileSet(null, new[]
+            {
+                new FileItem {  FilePath = "HomeController.cs", },
+                new FileItem {  FilePath = "Index.cshtml", }
+            });
+            var context = new DotNetWatchContext { ProcessSpec = process, FileSet = fileSet, Iteration = iteration };
+
+            // Act
+            await applier.InitializeAsync(context, default);
+
+            // Assert
+            Assert.True(applier.RefreshBrowserAfterFileChange);
+        }
+    }
+}

--- a/src/Tests/dotnet-watch.Tests/HotReload/DefaultDeltaApplierTest.cs
+++ b/src/Tests/dotnet-watch.Tests/HotReload/DefaultDeltaApplierTest.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
 
 using System.Threading.Tasks;
 using Microsoft.Extensions.Tools.Internal;
@@ -30,48 +29,6 @@ namespace Microsoft.DotNet.Watcher.Tools
             Assert.Equal("debug", process.EnvironmentVariables["DOTNET_MODIFIABLE_ASSEMBLIES"]);
             Assert.NotEmpty(process.EnvironmentVariables["DOTNET_HOTRELOAD_NAMEDPIPE_NAME"]);
             Assert.NotEmpty(process.EnvironmentVariables.DotNetStartupHooks);
-        }
-
-        [Fact]
-        public async Task InitializeAsync_ResetsRefreshBrowserAfterFileChange_ForBlazorProjects()
-        {
-            // Arrange
-            var applier = new DefaultDeltaApplier(Mock.Of<IReporter>()) { SuppressNamedPipeForTests = true };
-            var process = new ProcessSpec();
-            var fileSet = new FileSet(null, new[]
-            {
-                new FileItem {  FilePath = "Index.razor" },
-                new FileItem {  FilePath = "_Host.cshtml", }
-            });
-            var context = new DotNetWatchContext { ProcessSpec = process, FileSet = fileSet, Iteration = 0 };
-
-            // Act
-            await applier.InitializeAsync(context, default);
-
-            // Assert
-            Assert.False(applier.RefreshBrowserAfterFileChange);
-        }
-
-        [Theory]
-        [InlineData(0)]
-        [InlineData(7)]
-        public async Task InitializeAsync_SetsRefreshBrowserAfterFileChange_ForProjectsWithoutRazorFiles(int iteration)
-        {
-            // Arrange
-            var applier = new DefaultDeltaApplier(Mock.Of<IReporter>()) { SuppressNamedPipeForTests = true };
-            var process = new ProcessSpec();
-            var fileSet = new FileSet(null, new[]
-            {
-                new FileItem {  FilePath = "HomeController.cs", },
-                new FileItem {  FilePath = "Index.cshtml", }
-            });
-            var context = new DotNetWatchContext { ProcessSpec = process, FileSet = fileSet, Iteration = iteration };
-
-            // Act
-            await applier.InitializeAsync(context, default);
-
-            // Assert
-            Assert.True(applier.RefreshBrowserAfterFileChange);
         }
     }
 }


### PR DESCRIPTION
dotnet-watch uses a heuristic to determine if it should rely on the app
refreshing vs performing a browser refresh. It decides it should not refresh
the browser for any Blazor app (app with Blazor components). This heuristic
was not being correctly initialized after a rude edit.

Fixes https://github.com/dotnet/aspnetcore/issues/33655