### PR TITLE
Fix `dotnet sln add` creating empty solution folders

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-sln/add/Program.cs
+++ b/src/Cli/dotnet/commands/dotnet-sln/add/Program.cs
@@ -33,7 +33,7 @@ namespace Microsoft.DotNet.Tools.Sln.Add
                 throw new GracefulException(LocalizableStrings.SolutionFolderAndInRootMutuallyExclusive);
             }
 
-            _relativeRootSolutionFolders = string.IsNullOrEmpty(relativeRoot) ? null : relativeRoot.Split(Path.DirectorySeparatorChar);
+            _relativeRootSolutionFolders = string.IsNullOrEmpty(relativeRoot) ? null : relativeRoot.Split(Path.DirectorySeparatorChar, StringSplitOptions.RemoveEmptyEntries);
         }
 
         public override int Execute()

--- a/src/Cli/dotnet/commands/dotnet-sln/add/Program.cs
+++ b/src/Cli/dotnet/commands/dotnet-sln/add/Program.cs
@@ -10,7 +10,6 @@ using Microsoft.DotNet.Cli;
 using Microsoft.DotNet.Cli.Sln.Internal;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.Tools.Common;
-using LocalizableStrings = Microsoft.DotNet.Tools.Sln.LocalizableStrings;
 
 namespace Microsoft.DotNet.Tools.Sln.Add
 {
@@ -19,9 +18,6 @@ namespace Microsoft.DotNet.Tools.Sln.Add
         private readonly string _fileOrDirectory;
         private readonly bool _inRoot;
         private readonly IList<string> _relativeRootSolutionFolders;
-
-        private const string InRootOption = "in-root";
-        private const string SolutionFolderOption = "solution-folder";
 
         public AddProjectToSolutionCommand(
             ParseResult parseResult) : base(parseResult)
@@ -37,7 +33,7 @@ namespace Microsoft.DotNet.Tools.Sln.Add
                 throw new GracefulException(LocalizableStrings.SolutionFolderAndInRootMutuallyExclusive);
             }
 
-            _relativeRootSolutionFolders = string.IsNullOrEmpty(relativeRoot)? null : relativeRoot.Split(Path.DirectorySeparatorChar);
+            _relativeRootSolutionFolders = string.IsNullOrEmpty(relativeRoot) ? null : relativeRoot.Split(Path.DirectorySeparatorChar);
         }
 
         public override int Execute()

--- a/src/Cli/dotnet/commands/dotnet-sln/add/Program.cs
+++ b/src/Cli/dotnet/commands/dotnet-sln/add/Program.cs
@@ -26,14 +26,23 @@ namespace Microsoft.DotNet.Tools.Sln.Add
 
             _inRoot = parseResult.ValueForOption<bool>(SlnAddParser.InRootOption);
             string relativeRoot = parseResult.ValueForOption<string>(SlnAddParser.SolutionFolderOption);
-
-            if (_inRoot && !string.IsNullOrEmpty(relativeRoot))
+            bool hasRelativeRoot = !string.IsNullOrEmpty(relativeRoot);
+            
+            if (_inRoot && hasRelativeRoot)
             {
                 // These two options are mutually exclusive
                 throw new GracefulException(LocalizableStrings.SolutionFolderAndInRootMutuallyExclusive);
             }
 
-            _relativeRootSolutionFolders = string.IsNullOrEmpty(relativeRoot) ? null : relativeRoot.Split(Path.DirectorySeparatorChar, StringSplitOptions.RemoveEmptyEntries);
+            if (hasRelativeRoot)
+            {
+                relativeRoot = PathUtility.GetPathWithDirectorySeparator(relativeRoot);
+                _relativeRootSolutionFolders = relativeRoot.Split(Path.DirectorySeparatorChar, StringSplitOptions.RemoveEmptyEntries);
+            }
+            else
+            {
+                _relativeRootSolutionFolders = null;
+            }
         }
 
         public override int Execute()

--- a/src/Tests/dotnet-sln.Tests/GivenDotnetSlnAdd.cs
+++ b/src/Tests/dotnet-sln.Tests/GivenDotnetSlnAdd.cs
@@ -1187,6 +1187,28 @@ EndGlobal
                 .BeVisuallyEquivalentTo(contentBefore);
         }
 
+        [Theory]
+        [InlineData("/TestFolder//", "ForwardSlash")]
+        [InlineData("\\TestFolder\\\\", "BackwardSlash")]
+        public void WhenSolutionFolderIsPassedWithDirectorySeparatorFolderStructureIsCorrect(string solutionFolder, string testIdentifier)
+        {
+            var projectDirectory = _testAssetsManager
+                .CopyTestAsset("TestAppWithSlnAndCsprojInSubDir", identifier: testIdentifier)
+                .WithSource()
+                .Path;
+
+            var projectToAdd = Path.Combine("src", "Lib", "Lib.csproj");
+            var cmd = new DotnetCommand(Log)
+                .WithWorkingDirectory(projectDirectory)
+                .Execute($"sln", "App.sln", "add", "--solution-folder", solutionFolder, projectToAdd);
+            cmd.Should().Pass();
+
+            var slnPath = Path.Combine(projectDirectory, "App.sln");
+            var expectedSlnContents = GetExpectedSlnContents(slnPath, ExpectedSlnFileAfterAddingProjectWithSolutionFolderOption);
+            File.ReadAllText(slnPath)
+                .Should().BeVisuallyEquivalentTo(expectedSlnContents);
+        }
+
         private string GetExpectedSlnContents(
             string slnPath,
             string slnTemplate,


### PR DESCRIPTION
Fixes https://github.com/dotnet/sdk/issues/11793

## Change log
- Added `StringSplitOptions.RemoveEmptyEntries` when handling `SlnAddParser.SolutionFolderOption` to prevent empty solution folders.
- Normalize directory seperator in `SlnAddParser.SolutionFolderOption` so either `Path.DirectorySeparatorChar` or `Path.AltDirectorySeparatorChar` can be used.
- Added unit tests for above cases
- Removed unused private fields in `AddProjectToSolutionCommand`

## Description
When using the `dotnet sln add` command with a provided solution folder is was possible for the command to add empty solution folders if the provided path contained multiple simultaneous directory separators or had a directory separator as a prefix or suffix.

To prevent this from happening the `StringSplitOptions.RemoveEmptyEntries` was added to the `string.Split(...)` method call when getting the list of folders in the path. This prevents any empty strings in the list and so prevents empty solution folders from being created.

The command also failed to recognize the alt directory separator allowing solution folders to contain `/` characters on windows.
To solve that problem the path's directory separators are now normalized to be `Path.DirectorySeparatorChar` so the path can be correctly split.

## Testing
Unit tests for the above problems included.

To test manually setup a solution and a project with
```
dotnet new sln
dotnet new console --output src/todo-app
```

**Windows**
Run one of the following:
`dotnet sln add src/todo-app --solution-folder todo`
`dotnet sln add src/todo-app --solution-folder /todo//`
`dotnet sln add src/todo-app --solution-folder \todo\\`

**Linux**
Run one of the following:
`dotnet sln add src/todo-app --solution-folder todo`
`dotnet sln add src/todo-app --solution-folder /todo//`

All of these now add `src/todo-app` in the solution folder `todo`.
```sln
Project("{GUID}") = "todo", "todo", "{GUID}"
EndProject
Project("{GUID}") = "todo-app", "src\todo-app\todo-app.csproj", "{GUID}"
EndProject
```

<details>
 <summary>The previous functionality (main)</summary>

`dotnet sln add src/todo-app --solution-folder /todo//`
```sln
Project("{GUID}") = "/todo//", "todo\", "{GUID}"
EndProject
Project("{GUID}") = "todo-app", "src\todo-app\todo-app.csproj", "{GUID}"
EndProject
```
_Note: On linux this produces the output of the command below below._
<br/>

`dotnet sln add src/todo-app --solution-folder \todo\\`
```sln
Project("{GUID}") = "", "", "{GUID}"
EndProject
Project("{GUID}") = "todo", "todo", "{GUID}"
EndProject
Project("{GUID}") = "", "", "{GUID}"
EndProject
Project("{GUID}") = "", "", "{GUID}"
EndProject
Project("{GUID}") = "todo-app", "src\todo-app\todo-app.csproj", "{GUID}"
EndProject
```
<br/>

`dotnet sln add src/todo-app --solution-folder todo`
```sln
Project("{GUID}") = "todo", "todo", "{GUID}"
EndProject
Project("{GUID}") = "todo-app", "src\todo-app\todo-app.csproj", "{GUID}"
EndProject
```
</details>
