### PR TITLE
Tweak how dotnet-watch decides how browser refresh happens

### DIFF
--- a/src/BuiltInTools/BrowserRefresh/WebSocketScriptInjection.js
+++ b/src/BuiltInTools/BrowserRefresh/WebSocketScriptInjection.js
@@ -37,7 +37,7 @@ setTimeout(async function () {
         'UpdateStaticFile': () => updateStaticFile(payload.path),
         'BlazorHotReloadDeltav1': () => applyBlazorDeltas(payload.deltas),
         'HotReloadDiagnosticsv1': () => displayDiagnostics(payload.diagnostics),
-        'HotReloadApplied': () => notifyHotReloadApplied(),
+        'AspNetCoreHotReloadApplied': () => aspnetCoreHotReloadApplied(),
       };
 
       if (payload.type && action.hasOwnProperty(payload.type)) {
@@ -157,6 +157,15 @@ setTimeout(async function () {
     el.textContent = 'Updated the page';
     document.body.appendChild(el);
     setTimeout(() => el.remove(), 520);
+  }
+
+  function aspnetCoreHotReloadApplied() {
+    if (window.Blazor) {
+      // If this page has any Blazor, don't refresh the browser.
+      notiifyHotReloadApplied();
+    } else {
+      location.reload();
+    }
   }
 
   function sendDeltaApplied() {

--- a/src/BuiltInTools/dotnet-watch/HotReload/BlazorWebAssemblyHostedDeltaApplier.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/BlazorWebAssemblyHostedDeltaApplier.cs
@@ -18,10 +18,7 @@ namespace Microsoft.DotNet.Watcher.Tools
         public BlazorWebAssemblyHostedDeltaApplier(IReporter reporter)
         {
             _wasmApplier = new BlazorWebAssemblyDeltaApplier(reporter);
-            _hostApplier = new DefaultDeltaApplier(reporter)
-            {
-                SuppressBrowserRefreshAfterApply = true,
-            };
+            _hostApplier = new DefaultDeltaApplier(reporter);
         }
 
         public async ValueTask InitializeAsync(DotNetWatchContext context, CancellationToken cancellationToken)

--- a/src/BuiltInTools/dotnet-watch/HotReload/DefaultDeltaApplier.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/DefaultDeltaApplier.cs
@@ -22,19 +22,21 @@ namespace Microsoft.DotNet.Watcher.Tools
         private readonly IReporter _reporter;
         private Task _task;
         private NamedPipeServerStream _pipe;
-        private bool _refreshBrowserAfterFileChange;
 
         public DefaultDeltaApplier(IReporter reporter)
         {
             _reporter = reporter;
         }
 
-        public bool SuppressBrowserRefreshAfterApply { get; init; }
+        internal bool SuppressNamedPipeForTests { get; set; }
 
         public ValueTask InitializeAsync(DotNetWatchContext context, CancellationToken cancellationToken)
         {
-            _pipe = new NamedPipeServerStream(_namedPipeName, PipeDirection.InOut, 1, PipeTransmissionMode.Byte, PipeOptions.Asynchronous | PipeOptions.CurrentUserOnly);
-            _task = _pipe.WaitForConnectionAsync(cancellationToken);
+            if (!SuppressNamedPipeForTests)
+            {
+                _pipe = new NamedPipeServerStream(_namedPipeName, PipeDirection.InOut, 1, PipeTransmissionMode.Byte, PipeOptions.Asynchronous | PipeOptions.CurrentUserOnly);
+                _task = _pipe.WaitForConnectionAsync(cancellationToken);
+            }
 
             if (context.Iteration == 0)
             {
@@ -44,12 +46,6 @@ namespace Microsoft.DotNet.Watcher.Tools
                 // Configure the app for EnC
                 context.ProcessSpec.EnvironmentVariables["DOTNET_MODIFIABLE_ASSEMBLIES"] = "debug";
                 context.ProcessSpec.EnvironmentVariables["DOTNET_HOTRELOAD_NAMEDPIPE_NAME"] = _namedPipeName;
-
-                // If there's any .razor file, we'll assume this is a blazor app and not cause a browser refresh.
-                if (!SuppressBrowserRefreshAfterApply)
-                {
-                    _refreshBrowserAfterFileChange = !context.FileSet.Any(f => f.FilePath.EndsWith(".razor", StringComparison.Ordinal));
-                }
             }
 
             return default;
@@ -112,21 +108,7 @@ namespace Microsoft.DotNet.Watcher.Tools
                 return false;
             }
 
-            if (!SuppressBrowserRefreshAfterApply && context.BrowserRefreshServer is not null)
-            {
-                // For a Web app, we have the option of either letting the app update the UI or
-                // refresh the browser. In general, for Blazor apps, we will choose not to refresh the UI
-                // and for other apps we'll always refresh
-                if (_refreshBrowserAfterFileChange)
-                {
-                    await context.BrowserRefreshServer.ReloadAsync(cancellationToken);
-                }
-                else
-                {
-                    await context.BrowserRefreshServer.SendJsonSerlialized(new HotReloadApplied());
-                }
-            }
-
+            await context.BrowserRefreshServer.SendJsonSerlialized(new AspNetCoreHotReloadApplied(), cancellationToken);
             return true;
         }
 
@@ -155,9 +137,9 @@ namespace Microsoft.DotNet.Watcher.Tools
             public IEnumerable<string> Diagnostics { get; init; }
         }
 
-        public readonly struct HotReloadApplied
+        public readonly struct AspNetCoreHotReloadApplied
         {
-            public string Type => "HotReloadApplied";
+            public string Type => "AspNetCoreHotReloadApplied";
         }
     }
 }

--- a/src/Tests/dotnet-watch.Tests/HotReload/DefaultDeltaApplierTest.cs
+++ b/src/Tests/dotnet-watch.Tests/HotReload/DefaultDeltaApplierTest.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Threading.Tasks;
+using Microsoft.Extensions.Tools.Internal;
+using Moq;
+using Xunit;
+
+namespace Microsoft.DotNet.Watcher.Tools
+{
+    public class DefaultDeltaApplierTest
+    {
+        [Fact]
+        public async Task InitializeAsync_ConfiguresEnvironmentVariables()
+        {
+            // Arrange
+            var applier = new DefaultDeltaApplier(Mock.Of<IReporter>()) { SuppressNamedPipeForTests = true };
+            var process = new ProcessSpec();
+            var fileSet = new FileSet(null, new[]
+            {
+                new FileItem {  FilePath = "Test.cs" },
+            });
+            var context = new DotNetWatchContext { ProcessSpec = process, FileSet = fileSet, Iteration = 0 };
+
+            // Act
+            await applier.InitializeAsync(context, default);
+
+            // Assert
+            Assert.Equal("debug", process.EnvironmentVariables["DOTNET_MODIFIABLE_ASSEMBLIES"]);
+            Assert.NotEmpty(process.EnvironmentVariables["DOTNET_HOTRELOAD_NAMEDPIPE_NAME"]);
+            Assert.NotEmpty(process.EnvironmentVariables.DotNetStartupHooks);
+        }
+    }
+}


### PR DESCRIPTION
dotnet-watch uses a heuristic to determine if it should rely on the app
refreshing vs performing a browser refresh. This change updates it to rely on
testing the presence of the Blazor object in the DOM to determine if it needs to refresh the browser vs passively let the app
UI to re-render.

Fixes https://github.com/dotnet/aspnetcore/issues/33655

## Description
dotnet-watch has a bug where it stops refreshing the browser after a rude edit is produced which requires an app restart. Prior to this change, dotnet-watch used a heuristic that it would suppress browser refreshes if any .razor files were present in the project (assumed a Blazor project). This was being incorrectly initialized after a rude edit causing the bug. This change updates watch to rely on the presence of Blazor in the browser to detect if it’s currently rendering any Blazor, and performs a reload in the absence of it. This fixes the issue, while also improves the experience for mixed mode Blazor and MVC apps.

## Customer Impact
dotnet-watch experience is degraded. Users have to restart dotnet-watch to get browser refreshes after it encounters a rude edit.

## Regression?
- [ ] Yes
- [x] No

## Risk
- [ ] High
- [ ] Medium
- [x] Low

The change is limited to the browser refreshes and was manually tested.

## Verification
- [x] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [x] No
- [ ] N/A
