### PR TITLE
[Preview 6] Add Package Validation suppression engine

### DIFF
--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/ErrorSuppression/Suppression.cs
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/ErrorSuppression/Suppression.cs
@@ -1,0 +1,59 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+using System;
+using System.Xml.Serialization;
+
+namespace Microsoft.DotNet.Compatibility.ErrorSuppression
+{
+    /// <summary>
+    /// Represents a Suppression for a validation error.
+    /// </summary>
+    public class Suppression : IEquatable<Suppression>
+    {
+        /// <summary>
+        /// The DiagnosticId representing the error to be suppressed.
+        /// </summary>
+        public string? DiagnosticId { get; set; }
+
+        /// <summary>
+        /// The target of where to suppress the <see cref="DiagnosticId"/>
+        /// </summary>
+        public string? Target { get; set; }
+
+        /// <summary>
+        /// Left operand of an APICompat comparison.
+        /// </summary>
+        public string? Left { get; set; }
+
+        /// <summary>
+        /// Right operand of an APICompat comparison.
+        /// </summary>
+        public string? Right { get; set; }
+
+        /// <summary>
+        /// <see langword="true"/> if the suppression is to be applied to a baseline validation. <see langword="false"/> otherwise.
+        /// </summary>
+        public bool IsBaselineSuppression { get; set; }
+
+        // It only makes sense to serialize IsBaselineSuppression when is true, if it is off, no need to have it on the file.
+        public bool ShouldSerializeIsBaselineSuppression() => IsBaselineSuppression;
+
+        /// <inheritdoc/>
+        public bool Equals(Suppression? other)
+        {
+            return other != null &&
+                   AreEqual(DiagnosticId, other.DiagnosticId) &&
+                   AreEqual(Target, other.Target) &&
+                   AreEqual(Left, other.Left) &&
+                   AreEqual(Right, other.Right) &&
+                   IsBaselineSuppression == other.IsBaselineSuppression;
+
+            static bool AreEqual(string? first, string? second)
+                => string.IsNullOrEmpty(first?.Trim()) && string.IsNullOrEmpty(second?.Trim()) || StringComparer.InvariantCultureIgnoreCase.Equals(first?.Trim(), second?.Trim());
+        }
+
+        public override int GetHashCode() => HashCode.Combine(DiagnosticId?.ToLowerInvariant(), Target?.ToLowerInvariant(), Left?.ToLowerInvariant(), Right?.ToLowerInvariant(), IsBaselineSuppression);
+    }
+}

--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/ErrorSuppression/SuppressionEngine.cs
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/ErrorSuppression/SuppressionEngine.cs
@@ -1,0 +1,200 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Xml.Serialization;
+
+namespace Microsoft.DotNet.Compatibility.ErrorSuppression
+{
+    /// <summary>
+    /// Collection of Suppressions which is able to add suppressions, check if a specific error is suppressed, and write all suppressions
+    /// down to a file. The engine is thread-safe.
+    /// </summary>
+    public class SuppressionEngine
+    {
+        protected HashSet<Suppression> _validationSuppressions;
+        private readonly ReaderWriterLockSlim _readerWriterLock = new();
+        private readonly XmlSerializer _serializer = new(typeof(Suppression[]), new XmlRootAttribute("Suppressions"));
+
+        protected SuppressionEngine(string suppressionFile)
+        {
+            _validationSuppressions = ParseSuppressionFile(suppressionFile);
+        }
+
+        protected SuppressionEngine()
+        {
+            _validationSuppressions = new HashSet<Suppression>();
+        }
+
+        /// <summary>
+        /// Checks if the passed in error is suppressed or not.
+        /// </summary>
+        /// <param name="diagnosticId">The diagnostic ID of the error to check.</param>
+        /// <param name="target">The target of where the <paramref name="diagnosticId"/> should be applied.</param>
+        /// <param name="left">Optional. The left operand in a APICompat error.</param>
+        /// <param name="right">Optional. The right operand in a APICompat error.</param>
+        /// <returns><see langword="true"/> if the error is already suppressed. <see langword="false"/> otherwise.</returns>
+        public bool IsErrorSuppressed(string? diagnosticId, string? target, string? left = null, string? right = null, bool isBaselineSuppression = false)
+        {
+            var suppressionToCheck = new Suppression()
+            {
+                DiagnosticId = diagnosticId,
+                Target = target,
+                Left = left,
+                Right = right,
+                IsBaselineSuppression = isBaselineSuppression
+            };
+            return IsErrorSuppressed(suppressionToCheck);
+        }
+
+        /// <summary>
+        /// Checks if the passed in error is suppressed or not.
+        /// </summary>
+        /// <param name="error">The <see cref="Suppression"/> error to check.</param>
+        /// <returns><see langword="true"/> if the error is already suppressed. <see langword="false"/> otherwise.</returns>
+        public bool IsErrorSuppressed(Suppression error)
+        {
+            _readerWriterLock.EnterReadLock();
+            try
+            {
+                if (_validationSuppressions.Contains(error))
+                {
+                    return true;
+                }
+                else
+                {
+                    // See if the error is globally suppressed by checking if the same diagnosticid and target are entered
+                    // without any left and right.
+                    return (error.DiagnosticId == null || error.DiagnosticId.StartsWith("cp", StringComparison.InvariantCultureIgnoreCase)) &&
+                            _validationSuppressions.Contains(new Suppression { DiagnosticId = error.DiagnosticId, Target = error.Target });
+                }
+            }
+            finally
+            {
+                _readerWriterLock.ExitReadLock();
+            }
+        }
+
+        /// <summary>
+        /// Adds a suppression to the collection.
+        /// </summary>
+        /// <param name="diagnosticId">The diagnostic ID of the error to add.</param>
+        /// <param name="target">The target of where the <paramref name="diagnosticId"/> should be applied.</param>
+        /// <param name="left">Optional. The left operand in a APICompat error.</param>
+        /// <param name="right">Optional. The right operand in a APICompat error.</param>
+        public void AddSuppression(string? diagnosticId, string? target, string? left = null, string? right = null, bool isBaselineSuppression = false)
+        {
+            var suppressionToAdd = new Suppression()
+            {
+                DiagnosticId = diagnosticId,
+                Target = target,
+                Left = left,
+                Right = right,
+                IsBaselineSuppression = isBaselineSuppression
+            };
+            AddSuppression(suppressionToAdd);
+        }
+
+        /// <summary>
+        /// Adds a suppression to the collection.
+        /// </summary>
+        /// <param name="suppression">The <see cref="Suppression"/> to be added.</param>
+        public void AddSuppression(Suppression suppression)
+        {
+            _readerWriterLock.EnterUpgradeableReadLock();
+            try
+            {
+                if (!_validationSuppressions.Contains(suppression))
+                {
+                    _readerWriterLock.EnterWriteLock();
+                    try
+                    {
+                        _validationSuppressions.Add(suppression);
+                    }
+                    finally
+                    {
+                        _readerWriterLock.ExitWriteLock();
+                    }
+                }
+            }
+            finally
+            {
+                _readerWriterLock.ExitUpgradeableReadLock();
+            }
+        }
+
+        /// <summary>
+        /// Writes all suppressions in collection down to a file.
+        /// </summary>
+        /// <param name="supressionFile">The path to the file to be written.</param>
+        public void WriteSuppressionsToFile(string supressionFile)
+        {
+            using (Stream writer = GetWritableStream(supressionFile))
+            {
+                _readerWriterLock.EnterReadLock();
+                try
+                {
+                    _serializer.Serialize(writer, _validationSuppressions.ToArray());
+                    AfterWrittingSuppressionsCallback(writer);
+                }
+                finally
+                {
+                    _readerWriterLock.ExitReadLock();
+                }
+            }
+        }
+
+        protected virtual void AfterWrittingSuppressionsCallback(Stream stream)
+        {
+            // Do nothing. Used for tests.
+        }
+
+        /// <summary>
+        /// Creates a new instance of <see cref="SuppressionEngine"/> based on the contents of a given suppression file.
+        /// </summary>
+        /// <param name="suppressionFile">The path to the suppressions file to be used for initialization.</param>
+        /// <returns>An instance of <see cref="SuppressionEngine"/>.</returns>
+        public static SuppressionEngine CreateFromFile(string suppressionFile)
+            => new SuppressionEngine(suppressionFile);
+
+        /// <summary>
+        /// Creates a new instance of <see cref="SuppressionEngine"/> which is empty.
+        /// </summary>
+        /// <returns>An instance of <see cref="SuppressionEngine"/>.</returns>
+        public static SuppressionEngine Create()
+            => new SuppressionEngine();
+
+        private HashSet<Suppression> ParseSuppressionFile(string? file)
+        {
+            if (string.IsNullOrEmpty(file?.Trim()))
+            {
+                return new HashSet<Suppression>();
+            }
+
+            HashSet<Suppression> result;
+
+            using (Stream reader = GetReadableStream(file!))
+            {
+                Suppression[]? deserializedSuppressions = _serializer.Deserialize(reader) as Suppression[];
+                if (deserializedSuppressions == null)
+                {
+                    result = new HashSet<Suppression>();
+                }
+                else
+                {
+                    result = new HashSet<Suppression>(deserializedSuppressions);
+                }
+            }
+            return result;
+        }
+
+        protected virtual Stream GetReadableStream(string supressionFile) => new FileStream(supressionFile, FileMode.Open);
+
+        protected virtual Stream GetWritableStream(string suppressionFile) => new FileStream(suppressionFile, FileMode.OpenOrCreate);
+    }
+}

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/BaselinePackageValidator.cs
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/BaselinePackageValidator.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Linq;
 using Microsoft.DotNet.ApiCompatibility;
 using Microsoft.DotNet.ApiCompatibility.Abstractions;
+using Microsoft.DotNet.Compatibility.ErrorSuppression;
 using NuGet.ContentModel;
 using NuGet.Frameworks;
 
@@ -47,7 +48,11 @@ namespace Microsoft.DotNet.PackageValidation
                 {
                     if (!_diagnosticBag.Filter(DiagnosticIds.TargetFrameworkDropped, baselineTargetFramework.ToString()))
                     {
-                        _log.LogError(DiagnosticIds.TargetFrameworkDropped, Resources.MissingTargetFramework, baselineTargetFramework.ToString());
+                        _log.LogError(
+                            new Suppression { DiagnosticId = DiagnosticIds.TargetFrameworkDropped, Target = baselineTargetFramework.ToString() },
+                            DiagnosticIds.TargetFrameworkDropped, 
+                            Resources.MissingTargetFramework, 
+                            baselineTargetFramework.ToString());
                     }
                 }
                 else if (_runApiCompat)
@@ -70,7 +75,11 @@ namespace Microsoft.DotNet.PackageValidation
                 {
                     if (!_diagnosticBag.Filter(DiagnosticIds.TargetFrameworkDropped, baselineTargetFramework.ToString()))
                     {
-                        _log.LogError(DiagnosticIds.TargetFrameworkDropped, Resources.MissingTargetFramework, baselineTargetFramework.ToString());
+                        _log.LogError(
+                            new Suppression { DiagnosticId = DiagnosticIds.TargetFrameworkDropped, Target = baselineTargetFramework.ToString() },
+                            DiagnosticIds.TargetFrameworkDropped, 
+                            Resources.MissingTargetFramework, 
+                            baselineTargetFramework.ToString());
                     }
                 }
                 else
@@ -97,7 +106,12 @@ namespace Microsoft.DotNet.PackageValidation
                 {
                     if (!_diagnosticBag.Filter(DiagnosticIds.TargetFrameworkDropped, baselineTargetFramework.ToString() + "-" + baselineRid))
                     {
-                        _log.LogError(DiagnosticIds.TargetFrameworkAndRidPairDropped, Resources.MissingTargetFrameworkAndRid, baselineTargetFramework.ToString(), baselineRid);
+                        _log.LogError(
+                            new Suppression { DiagnosticId = DiagnosticIds.TargetFrameworkAndRidPairDropped, Target = baselineTargetFramework.ToString() + "-" + baselineRid },
+                            DiagnosticIds.TargetFrameworkAndRidPairDropped, 
+                            Resources.MissingTargetFrameworkAndRid, 
+                            baselineTargetFramework.ToString(), 
+                            baselineRid);
                     }
                 }
                 else

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/CompatibleFrameworkInPackageValidator.cs
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/CompatibleFrameworkInPackageValidator.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using NuGet.Client;
 using NuGet.ContentModel;

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/CompatibleTFMValidator.cs
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/CompatibleTFMValidator.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Linq;
 using Microsoft.DotNet.ApiCompatibility;
 using Microsoft.DotNet.ApiCompatibility.Abstractions;
+using Microsoft.DotNet.Compatibility.ErrorSuppression;
 using NuGet.ContentModel;
 using NuGet.Frameworks;
 
@@ -58,7 +59,11 @@ namespace Microsoft.DotNet.PackageValidation
                 {
                     if (!_diagnosticBag.Filter(DiagnosticIds.ApplicableCompileTimeAsset, framework.ToString()))
                     {
-                        _log.LogError(DiagnosticIds.ApplicableCompileTimeAsset, Resources.NoCompatibleCompileTimeAsset, framework.ToString());
+                        _log.LogError(
+                            new Suppression { DiagnosticId = DiagnosticIds.ApplicableCompileTimeAsset, Target = framework.ToString() },
+                            DiagnosticIds.ApplicableCompileTimeAsset, 
+                            Resources.NoCompatibleCompileTimeAsset, 
+                            framework.ToString());
                     }
                     break;
                 }
@@ -68,7 +73,11 @@ namespace Microsoft.DotNet.PackageValidation
                 {
                     if (!_diagnosticBag.Filter(DiagnosticIds.CompatibleRuntimeRidLessAsset, framework.ToString()))
                     {
-                        _log.LogError(DiagnosticIds.CompatibleRuntimeRidLessAsset, Resources.NoCompatibleRuntimeAsset, framework.ToString());
+                        _log.LogError(
+                            new Suppression { DiagnosticId = DiagnosticIds.CompatibleRuntimeRidLessAsset, Target = framework.ToString() },
+                            DiagnosticIds.CompatibleRuntimeRidLessAsset, 
+                            Resources.NoCompatibleRuntimeAsset, 
+                            framework.ToString());
                     }
                 }
                 else
@@ -92,7 +101,12 @@ namespace Microsoft.DotNet.PackageValidation
                     {
                         if (!_diagnosticBag.Filter(DiagnosticIds.CompatibleRuntimeRidSpecificAsset, framework.ToString() + "-" + rid))
                         {
-                            _log.LogError(DiagnosticIds.CompatibleRuntimeRidSpecificAsset, Resources.NoCompatibleRidSpecificRuntimeAsset, framework.ToString(), rid);
+                            _log.LogError(
+                                new Suppression { DiagnosticId = DiagnosticIds.CompatibleRuntimeRidSpecificAsset, Target = framework.ToString() + "-" + rid },
+                                DiagnosticIds.CompatibleRuntimeRidSpecificAsset, 
+                                Resources.NoCompatibleRidSpecificRuntimeAsset, 
+                                framework.ToString(), 
+                                rid);
                         }
                     }
                     else

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/IPackageLogger.cs
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/IPackageLogger.cs
@@ -1,10 +1,16 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Microsoft.Build.Framework;
+using Microsoft.DotNet.ApiCompatibility.Abstractions;
+using Microsoft.DotNet.Compatibility.ErrorSuppression;
+
 namespace Microsoft.DotNet.PackageValidation
 {
     public interface IPackageLogger
     {
-        void LogError(string code, string format, params string[] args);
+        void LogError(Suppression suppression, string code, string format, params string[] args);
+        void LogErrorHeader(string message);
+        void LogMessage(MessageImportance importance, string format, params string[] args);
     }
 }

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/Resources.resx
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/Resources.resx
@@ -156,4 +156,7 @@
   <data name="NonExistentPackagePath" xml:space="preserve">
     <value>Package '{0}' not found. Please provide a valid package path.</value>
   </data>
+  <data name="WroteSuppressions" xml:space="preserve">
+    <value>Successfully wrote compatibility suppressions to '{0}'.</value>
+  </data>
 </root>

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/build/Microsoft.DotNet.PackageValidation.targets
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/build/Microsoft.DotNet.PackageValidation.targets
@@ -12,10 +12,13 @@
 
   <Target Name="RunPackageValidation"
           AfterTargets="Pack"
-          Condition="$(IsPackable) == 'true'">
+          Condition="'$(IsPackable)' == 'true'">
 
     <PropertyGroup >
       <PackageValidationBaselinePath Condition="'$(PackageValidationBaselinePath)' == '' and '$(PackageValidationBaselineVersion)' != ''">$([MSBuild]::NormalizePath('$(NuGetPackageRoot)', '$(PackageValidationBaselineName.ToLower())', '$(PackageValidationBaselineVersion)', '$(PackageValidationBaselineName.ToLower()).$(PackageValidationBaselineVersion).nupkg'))</PackageValidationBaselinePath>
+      <GenerateCompatibilitySuppressionFile Condition="'$(GenerateCompatibilitySuppressionFile)' == ''">false</GenerateCompatibilitySuppressionFile>
+      <_compatibilitySuppressionFilePath>$([MSBuild]::NormalizePath('$(MSBuildProjectDirectory)', 'CompatibilitySuppressions.xml'))</_compatibilitySuppressionFilePath>
+      <CompatibilitySuppressionFilePath Condition="'$(CompatibilitySuppressionFilePath)' == '' and (Exists($(_compatibilitySuppressionFilePath)) or '$(GenerateCompatibilitySuppressionFile)' == 'true')">$(_compatibilitySuppressionFilePath)</CompatibilitySuppressionFilePath>
     </PropertyGroup>
 
     <Error Condition="'$(PackageValidationBaselinePath)' != '' and !Exists('$(PackageValidationBaselinePath)')" Text="$(PackageValidationBaselinePath) does not exist. Please check the PackageValidationBaselinePath or PackageValidationBaselineVersion." />
@@ -26,6 +29,8 @@
       RuntimeGraph="$(RuntimeIdentifierGraphPath)"
       NoWarn="$(NoWarn)"
       RunApiCompat="$([MSBuild]::ValueOrDefault('$(RunApiCompat)', 'true'))"
+      GenerateCompatibilitySuppressionFile="$(GenerateCompatibilitySuppressionFile)"
+      CompatibilitySuppressionFilePath="$(CompatibilitySuppressionFilePath)"
       BaselinePackageTargetPath="$(PackageValidationBaselinePath)" />
   </Target>
 </Project>

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.cs.xlf
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.cs.xlf
@@ -67,6 +67,11 @@
         <target state="new">Package '{0}' not found. Please provide a valid package path.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WroteSuppressions">
+        <source>Successfully wrote compatibility suppressions to '{0}'.</source>
+        <target state="new">Successfully wrote compatibility suppressions to '{0}'.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.de.xlf
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.de.xlf
@@ -67,6 +67,11 @@
         <target state="new">Package '{0}' not found. Please provide a valid package path.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WroteSuppressions">
+        <source>Successfully wrote compatibility suppressions to '{0}'.</source>
+        <target state="new">Successfully wrote compatibility suppressions to '{0}'.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.es.xlf
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.es.xlf
@@ -67,6 +67,11 @@
         <target state="new">Package '{0}' not found. Please provide a valid package path.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WroteSuppressions">
+        <source>Successfully wrote compatibility suppressions to '{0}'.</source>
+        <target state="new">Successfully wrote compatibility suppressions to '{0}'.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.fr.xlf
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.fr.xlf
@@ -67,6 +67,11 @@
         <target state="new">Package '{0}' not found. Please provide a valid package path.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WroteSuppressions">
+        <source>Successfully wrote compatibility suppressions to '{0}'.</source>
+        <target state="new">Successfully wrote compatibility suppressions to '{0}'.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.it.xlf
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.it.xlf
@@ -67,6 +67,11 @@
         <target state="new">Package '{0}' not found. Please provide a valid package path.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WroteSuppressions">
+        <source>Successfully wrote compatibility suppressions to '{0}'.</source>
+        <target state="new">Successfully wrote compatibility suppressions to '{0}'.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.ja.xlf
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.ja.xlf
@@ -67,6 +67,11 @@
         <target state="new">Package '{0}' not found. Please provide a valid package path.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WroteSuppressions">
+        <source>Successfully wrote compatibility suppressions to '{0}'.</source>
+        <target state="new">Successfully wrote compatibility suppressions to '{0}'.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.ko.xlf
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.ko.xlf
@@ -67,6 +67,11 @@
         <target state="new">Package '{0}' not found. Please provide a valid package path.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WroteSuppressions">
+        <source>Successfully wrote compatibility suppressions to '{0}'.</source>
+        <target state="new">Successfully wrote compatibility suppressions to '{0}'.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.pl.xlf
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.pl.xlf
@@ -67,6 +67,11 @@
         <target state="new">Package '{0}' not found. Please provide a valid package path.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WroteSuppressions">
+        <source>Successfully wrote compatibility suppressions to '{0}'.</source>
+        <target state="new">Successfully wrote compatibility suppressions to '{0}'.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.pt-BR.xlf
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.pt-BR.xlf
@@ -67,6 +67,11 @@
         <target state="new">Package '{0}' not found. Please provide a valid package path.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WroteSuppressions">
+        <source>Successfully wrote compatibility suppressions to '{0}'.</source>
+        <target state="new">Successfully wrote compatibility suppressions to '{0}'.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.ru.xlf
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.ru.xlf
@@ -67,6 +67,11 @@
         <target state="new">Package '{0}' not found. Please provide a valid package path.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WroteSuppressions">
+        <source>Successfully wrote compatibility suppressions to '{0}'.</source>
+        <target state="new">Successfully wrote compatibility suppressions to '{0}'.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.tr.xlf
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.tr.xlf
@@ -67,6 +67,11 @@
         <target state="new">Package '{0}' not found. Please provide a valid package path.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WroteSuppressions">
+        <source>Successfully wrote compatibility suppressions to '{0}'.</source>
+        <target state="new">Successfully wrote compatibility suppressions to '{0}'.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.zh-Hans.xlf
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.zh-Hans.xlf
@@ -67,6 +67,11 @@
         <target state="new">Package '{0}' not found. Please provide a valid package path.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WroteSuppressions">
+        <source>Successfully wrote compatibility suppressions to '{0}'.</source>
+        <target state="new">Successfully wrote compatibility suppressions to '{0}'.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.zh-Hant.xlf
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.zh-Hant.xlf
@@ -67,6 +67,11 @@
         <target state="new">Package '{0}' not found. Please provide a valid package path.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WroteSuppressions">
+        <source>Successfully wrote compatibility suppressions to '{0}'.</source>
+        <target state="new">Successfully wrote compatibility suppressions to '{0}'.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compatibility/compatibility.slnf
+++ b/src/Compatibility/compatibility.slnf
@@ -1,0 +1,15 @@
+{
+  "solution": {
+    "path": "..\\..\\sdk.sln",
+    "projects": [
+      "src\\Cli\\Microsoft.DotNet.Cli.Utils\\Microsoft.DotNet.Cli.Utils.csproj",
+      "src\\Cli\\Microsoft.DotNet.InternalAbstractions\\Microsoft.DotNet.InternalAbstractions.csproj",
+      "src\\Compatibility\\Microsoft.DotNet.ApiCompatibility\\Microsoft.DotNet.ApiCompatibility.csproj",
+      "src\\Compatibility\\Microsoft.DotNet.PackageValidation\\Microsoft.DotNet.PackageValidation.csproj",
+      "src\\Layout\\toolset-tasks\\toolset-tasks.csproj",
+      "src\\Tests\\Microsoft.DotNet.ApiCompatibility.Tests\\Microsoft.DotNet.ApiCompatibility.Tests.csproj",
+      "src\\Tests\\Microsoft.DotNet.PackageValidation.Tests\\Microsoft.DotNet.PackageValidation.Tests.csproj",
+      "src\\Tests\\Microsoft.NET.TestFramework\\Microsoft.NET.TestFramework.csproj"
+    ]
+  }
+}

--- a/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/SuppressionTests/SuppressionEngineTests.cs
+++ b/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/SuppressionTests/SuppressionEngineTests.cs
@@ -1,0 +1,227 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.IO;
+using System.Xml.Serialization;
+using Xunit;
+
+namespace Microsoft.DotNet.Compatibility.ErrorSuppression.Tests
+{
+    public class SuppressionEngineTests
+    {
+        [Fact]
+        public void AddingASuppressionTwiceDoesntThrow()
+        {
+            var testEngine = SuppressionEngine.Create();
+            AddSuppression(testEngine);
+            AddSuppression(testEngine);
+
+            static void AddSuppression(SuppressionEngine testEngine) => testEngine.AddSuppression("PKG004", "A.B()", "ref/net6.0/mylib.dll", "lib/net6.0/mylib.dll");
+        }
+
+        [Fact]
+        public void SuppressionEngineCanParseInputSuppressionFile()
+        {
+            TestSuppressionEngine testEngine = TestSuppressionEngine.CreateTestSuppressionEngine();
+
+            // Parsed the right ammount of suppressions
+            Assert.Equal(9, testEngine.GetSuppressionCount());
+
+            // Test IsErrorSuppressed string overload.
+            Assert.True(testEngine.IsErrorSuppressed("CP0001", "T:A.B", "ref/netstandard2.0/tempValidation.dll", "lib/net6.0/tempValidation.dll"));
+            Assert.False(testEngine.IsErrorSuppressed("CP0001", "T:A.C", "ref/netstandard2.0/tempValidation.dll", "lib/net6.0/tempValidation.dll"));
+            Assert.False(testEngine.IsErrorSuppressed("CP0001", "T:A.B", "lib/netstandard2.0/tempValidation.dll", "lib/net6.0/tempValidation.dll"));
+            Assert.True(testEngine.IsErrorSuppressed("PKV004", ".netframework,Version=v4.8"));
+            Assert.False(testEngine.IsErrorSuppressed(string.Empty, string.Empty));
+            Assert.False(testEngine.IsErrorSuppressed("PKV004", ".netframework,Version=v4.8", "lib/net6.0/mylib.dll"));
+            Assert.False(testEngine.IsErrorSuppressed("PKV004", ".NETStandard,Version=v2.0"));
+            Assert.True(testEngine.IsErrorSuppressed("CP123", "T:myValidation.Class1", isBaselineSuppression: true));
+            Assert.False(testEngine.IsErrorSuppressed("CP123", "T:myValidation.Class1", isBaselineSuppression: false));
+
+            // Test IsErrorSuppressed Suppression overload.
+            Assert.True(testEngine.IsErrorSuppressed(new Suppression
+            {
+                DiagnosticId = "CP0001",
+                Target = "T:A.B",
+                Left = "ref/netstandard2.0/tempValidation.dll",
+                Right = "lib/net6.0/tempValidation.dll"
+            }));
+        }
+
+        [Fact]
+        public void SuppressionEngineThrowsIfFileDoesNotExist()
+        {
+            Assert.Throws<FileNotFoundException>(() => SuppressionEngine.CreateFromFile("AFileThatDoesNotExist.xml"));
+        }
+
+        [Fact]
+        public void SuppressionEngineDoesNotThrowOnEmptyFile()
+        {
+            SuppressionEngine _ = SuppressionEngine.CreateFromFile(string.Empty);
+            _ = SuppressionEngine.CreateFromFile("      ");
+        }
+
+        [Fact]
+        public void SuppressionEngineSuppressionsRoundTrip()
+        {
+            string output = string.Empty;
+            TestSuppressionEngine engine = TestSuppressionEngine.CreateTestSuppressionEngine(
+            (stream) =>
+            {
+                stream.Position = 0;
+                using StreamReader reader = new(stream);
+                output = reader.ReadToEnd();
+            });
+            string filePath = Path.Combine(Path.GetTempPath(), Path.GetTempFileName(), "DummyFile.xml");
+            engine.WriteSuppressionsToFile(filePath);
+
+            Assert.True(StringComparer.OrdinalIgnoreCase.Equals(engine.suppressionsFile.Trim(), output.Trim()));
+        }
+
+        [Fact]
+        public void SuppressionEngineSupportsGlobalCompare()
+        {
+            SuppressionEngine engine = SuppressionEngine.Create();
+            // Engine has a suppression with no left and no right. This should be treated global for any left and any right.
+            engine.AddSuppression("CP0001", "T:A.B");
+
+            Assert.True(engine.IsErrorSuppressed("CP0001", "T:A.B", "ref/net6.0/myLib.dll", "lib/net6.0/myLib.dll"));
+            Assert.True(engine.IsErrorSuppressed("CP0001", "T:A.B", "ref/net6.0/myLib.dll", "lib/net6.0/myLib.dll", false));
+            Assert.True(engine.IsErrorSuppressed("CP0001", "T:A.B", "ref/net6.0/myLib.dll", "lib/net6.0/myLib.dll", true));
+        }
+
+        [Fact]
+        public void BaseliningNewErrorsDoesntOverrideSuppressions()
+        {
+            using Stream stream = new MemoryStream();
+            TestSuppressionEngine engine = TestSuppressionEngine.CreateTestSuppressionEngine(
+            (s) =>
+            {
+                s.Position = 0;
+                s.CopyTo(stream);
+                stream.Position = 0;
+            });
+
+            Assert.Equal(9, engine.GetSuppressionCount());
+
+            Suppression newSuppression = new()
+            {
+                DiagnosticId = "CP0002",
+                Target = "F:MyNs.Class1.Field"
+            };
+
+            engine.AddSuppression(newSuppression);
+            string filePath = Path.Combine(Path.GetTempPath(), Path.GetTempFileName(), "DummyFile.xml");
+            engine.WriteSuppressionsToFile(filePath);
+
+            XmlSerializer xmlSerializer = new(typeof(Suppression[]), new XmlRootAttribute("Suppressions"));
+            Suppression[] deserializedSuppressions = xmlSerializer.Deserialize(stream) as Suppression[];
+            Assert.Equal(10, deserializedSuppressions.Length);
+
+            Assert.Equal(new Suppression()
+            {
+                DiagnosticId = "CP0001",
+                Target = "T:A.B",
+                Left = "ref/netstandard2.0/tempValidation.dll",
+                Right = "lib/net6.0/tempValidation.dll"
+            }, deserializedSuppressions[0]);
+
+            Assert.Equal(newSuppression, deserializedSuppressions[9]);
+        }
+    }
+
+    public class TestSuppressionEngine : SuppressionEngine
+    {
+        private MemoryStream _stream;
+        private StreamWriter _writer;
+        public readonly string suppressionsFile = @"<?xml version=""1.0""?>
+<Suppressions xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:xsd=""http://www.w3.org/2001/XMLSchema"">
+  <Suppression>
+    <DiagnosticId>CP0001</DiagnosticId>
+    <Target>T:A.B</Target>
+    <Left>ref/netstandard2.0/tempValidation.dll</Left>
+    <Right>lib/net6.0/tempValidation.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:tempValidation.Class1.Bar(System.Int32)</Target>
+    <Left>ref/netstandard2.0/tempValidation.dll</Left>
+    <Right>lib/net6.0/tempValidation.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:tempValidation.Class1.SomeOtherGenericMethod``1(``0)</Target>
+    <Left>ref/netstandard2.0/tempValidation.dll</Left>
+    <Right>lib/net6.0/tempValidation.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:tempValidation.Class1.SomeNewBreakingChange</Target>
+    <Left>ref/netstandard2.0/tempValidation.dll</Left>
+    <Right>lib/net6.0/tempValidation.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0001</DiagnosticId>
+    <Target>T:tempValidation.SomeGenericType`1</Target>
+    <Left>ref/netstandard2.0/tempValidation.dll</Left>
+    <Right>lib/net6.0/tempValidation.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0001</DiagnosticId>
+    <Target>T:A</Target>
+    <Left>lib/netstandard1.3/tempValidation.dll</Left>
+    <Right>lib/netstandard1.3/tempValidation.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0001</DiagnosticId>
+    <Target>T:tempValidation.Class1</Target>
+    <Left>lib/netstandard1.3/tempValidation.dll</Left>
+    <Right>lib/netstandard1.3/tempValidation.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>PKV004</DiagnosticId>
+    <Target>.NETFramework,Version=v4.8</Target>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP123</DiagnosticId>
+    <Target>T:myValidation.Class1</Target>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+</Suppressions>";
+
+        private MemoryStream _outputStream = new();
+        private readonly Action<Stream> _callback;
+
+        public TestSuppressionEngine(string baselineFile, Action<Stream> callback)
+            : base(baselineFile)
+        {
+            if (callback == null)
+            {
+                callback = (s) => { };
+            }
+            _callback = callback;
+        }
+
+        public static TestSuppressionEngine CreateTestSuppressionEngine(Action<Stream> callback = null)
+            => new("NonExistentFile.xml", callback);
+
+        public int GetSuppressionCount() => _validationSuppressions.Count;
+
+        protected override Stream GetReadableStream(string baselineFile)
+        {
+            // Not Disposing stream since it will be disposed by caller.
+            _stream = new MemoryStream();
+            _writer = new StreamWriter(_stream);
+            _writer.Write(suppressionsFile);
+            _writer.Flush();
+            _stream.Position = 0;
+            return _stream;
+        }
+
+        protected override Stream GetWritableStream(string validationSuppressionFile) => _outputStream;
+
+        protected override void AfterWrittingSuppressionsCallback(Stream stream) => _callback(stream);
+    }
+}

--- a/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/SuppressionTests/SuppressionTests.cs
+++ b/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/SuppressionTests/SuppressionTests.cs
@@ -1,0 +1,62 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using Xunit;
+
+namespace Microsoft.DotNet.Compatibility.ErrorSuppression.Tests
+{
+    public class SuppressionTests
+    {
+        public static IEnumerable<object[]> GetEqualData()
+        {
+            yield return new object[] { new Suppression(), new Suppression { DiagnosticId = null, Left = null, Right = null, Target = null} };
+            yield return new object[] { new Suppression(), new Suppression { DiagnosticId = string.Empty, Left = string.Empty, Right = string.Empty, Target = string.Empty} };
+            yield return new object[] { new Suppression { DiagnosticId = "PK004" }, new Suppression { DiagnosticId = "pk004" } };
+            yield return new object[] { new Suppression { DiagnosticId = "PK004" }, new Suppression { DiagnosticId = " pk004 " } };
+            yield return new object[] { new Suppression { DiagnosticId = "PK004", Target = "A.B" }, new Suppression { DiagnosticId = " pk004 ", Target = "A.b " } };
+            yield return new object[] { new Suppression { DiagnosticId = "PK004", Target = "A.B", Left = "ref/net6.0/myLib.dll" }, new Suppression { DiagnosticId = " pk004 ", Target = "A.B", Left = "ref/net6.0/mylib.dll" } };
+            yield return new object[] { new Suppression { DiagnosticId = "PK004", Target = "A.B", Left = "ref/net6.0/myLib.dll", Right = "lib/net6.0/myLib.dll" }, new Suppression { DiagnosticId = "PK004", Target = "A.B", Left = "ref/net6.0/myLib.dll", Right = "lib/net6.0/myLib.dll", IsBaselineSuppression = false } };
+            yield return new object[] { new Suppression { DiagnosticId = "PK004", Target = "A.B", Left = "ref/net6.0/myLib.dll", Right = "lib/net6.0/myLib.dll", IsBaselineSuppression = false }, new Suppression { DiagnosticId = "PK004", Target = "A.B", Left = "ref/net6.0/myLib.dll", Right = "lib/net6.0/myLib.dll", IsBaselineSuppression = false } };
+            yield return new object[] { new Suppression { DiagnosticId = "PK004", Target = "A.B", Left = "ref/net6.0/myLib.dll", Right = "lib/net6.0/myLib.dll", IsBaselineSuppression = true }, new Suppression { DiagnosticId = "PK004", Target = "A.B", Left = "ref/net6.0/myLib.dll", Right = "lib/net6.0/myLib.dll", IsBaselineSuppression = true } };
+        }
+
+        public static IEnumerable<object[]> GetDifferentData()
+        {
+            yield return new object[] { new Suppression(), new Suppression { DiagnosticId = "PK005" } };
+            yield return new object[] { new Suppression { DiagnosticId = "PK004" }, new Suppression { DiagnosticId = "PK005" } };
+            yield return new object[] { new Suppression { DiagnosticId = "PK004" }, new Suppression { DiagnosticId = "PK004", Target = "A.B()" } };
+            yield return new object[] { new Suppression { DiagnosticId = "PK004", Target = "A.B" }, new Suppression { DiagnosticId = "PK004", Target = "A.B()" } };
+            yield return new object[] { new Suppression { DiagnosticId = "PK004", Target = "A.C" }, new Suppression { DiagnosticId = "PK004", Target = "A.B()" } };
+            yield return new object[] { new Suppression { DiagnosticId = "PK004", Target = "A.B()", Left = "ref/net6.0/myLib.dll" }, new Suppression { DiagnosticId = "PK004", Target = "A.B()" } };
+            yield return new object[] { new Suppression { DiagnosticId = "PK004", Target = "A.B()", Left = "ref/net6.0/myLib.dll" }, new Suppression { DiagnosticId = "PK004", Target = "A.B()", Left = "lib/net6.0/myLib.dll" } };
+            yield return new object[] { new Suppression { DiagnosticId = "PK004", Target = "A.B()", Right = "ref/net6.0/myLib.dll" }, new Suppression { DiagnosticId = "PK004", Target = "A.B()" } };
+            yield return new object[] { new Suppression { DiagnosticId = "PK004", Target = "A.B()", Right = "ref/net6.0/myLib.dll" }, new Suppression { DiagnosticId = "PK004", Target = "A.B()", Right = "lib/net6.0/myLib.dll" } };
+            yield return new object[] { new Suppression { DiagnosticId = "PK004", Target = "A.B()", Left = "ref/net6.0/mylib.dll", Right = "lib/net6.0/myLib.dll" }, new Suppression { DiagnosticId = "PK004", Target = "A.B()", Left = "ref/netstandard2.0/mylib.dll", Right = "lib/net6.0/myLib.dll" } };
+            yield return new object[] { new Suppression { DiagnosticId = "PK004", Target = "A.B", Left = "ref/net6.0/myLib.dll", Right = "lib/net6.0/myLib.dll", IsBaselineSuppression = true }, new Suppression { DiagnosticId = "PK004", Target = "A.B", Left = "ref/net6.0/myLib.dll", Right = "lib/net6.0/myLib.dll", IsBaselineSuppression = false } };
+            yield return new object[] { new Suppression { DiagnosticId = "PK004", Target = "A.B", Left = "ref/net6.0/myLib.dll", Right = "lib/net6.0/myLib.dll" }, new Suppression { DiagnosticId = "PK004", Target = "A.B", Left = "ref/net6.0/myLib.dll", Right = "lib/net6.0/myLib.dll", IsBaselineSuppression = true } };
+        }
+
+        [Theory]
+        [MemberData(nameof(GetEqualData))]
+        public void CheckSuppressionsAreEqual(Suppression suppression, Suppression other)
+        {
+            Assert.True(suppression.Equals(other));
+            Assert.True(other.Equals(suppression));
+        }
+
+        [Theory]
+        [MemberData(nameof(GetDifferentData))]
+        public void CheckSuppressionsAreNotEqual(Suppression suppression, Suppression other)
+        {
+            Assert.False(suppression.Equals(other));
+            Assert.False(other.Equals(suppression));
+        }
+
+        [Fact]
+        public void CheckSuppressionIsNotEqualWithNull()
+        {
+            Assert.False(new Suppression().Equals(null));
+        }
+    }
+}

--- a/src/Tests/Microsoft.DotNet.PackageValidation.Tests/BaseLineVersionValidatorTests.cs
+++ b/src/Tests/Microsoft.DotNet.PackageValidation.Tests/BaseLineVersionValidatorTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.NET.TestFramework;
+using NuGet.Frameworks;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/src/Tests/Microsoft.DotNet.PackageValidation.Tests/TestLogger.cs
+++ b/src/Tests/Microsoft.DotNet.PackageValidation.Tests/TestLogger.cs
@@ -1,7 +1,10 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Collections.Generic;
+using Microsoft.Build.Framework;
+using Microsoft.DotNet.Compatibility.ErrorSuppression;
 
 namespace Microsoft.DotNet.PackageValidation.Tests
 {
@@ -9,9 +12,13 @@ namespace Microsoft.DotNet.PackageValidation.Tests
     {
         public List<string> errors = new();
 
-        public void LogError(string code, string format, params string[] args)
+        public void LogError(Suppression suppression, string code, string format, params string[] args)
         {
             errors.Add(code + " " + string.Format(format, args));
         }
+
+        public void LogErrorHeader(string message) { }
+
+        public void LogMessage(MessageImportance importance, string format, params string[] args) { }
     }
 }


### PR DESCRIPTION
## Description
Currently with Package Validation there is no way to add granular error suppressions, the only way is to add a NoWarn​ entry to the project, which disables the whole diagnostic ID. So if a customer has an intentional breaking change by removing a method named A.B but also accidentally deleted a method A.C, they would get two errors with diagnostic id CP002​, one for each member that was removed, with NoWarn, they would disable the whole CP002​ diagnostic ID, so the accidental deletion of A.C​ would also be suppressed. 

With this change they can add an XML file listing the suppressions they care to suppress, so they could now disable just CP002 for method A.B by adding this to the XML:

```xml
<Suppressions>
  <Suppression>
    <DiagnosticId>CP002</DiagnosticId>
    <Target>M:A.B</Target>
  </Suppression>
</Suppressions>
```
This is a critical feature for Preview 6 in order to get feedback on granular suppressions story. 
Direct port of: https://github.com/dotnet/sdk/pull/18185

## Customer Impact

It gives the ability to suppress errors on package validation in a granular form rather than just using `NoWarn` and suppressing all errors with the same diagnostic ID.

## Testing

Added unit tests and also manually tested with sample projects.

## Risk
Low, this just adds new functionality. 