### PR TITLE
Add StrictMode to MembersMustExist rule

### DIFF
--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/Resources.resx
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/Resources.resx
@@ -138,6 +138,9 @@
   <data name="MemberExistsOnLeft" xml:space="preserve">
     <value>Member '{0}' exists on the left but not on the right</value>
   </data>
+  <data name="MemberExistsOnRight" xml:space="preserve">
+    <value>Member '{0}' exists on the right but not on the left</value>
+  </data>
   <data name="ProvidedPathToLoadBinariesFromNotFound" xml:space="preserve">
     <value>Could not find the provided path '{0}' to load binaries from.</value>
   </data>

--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/Rules/MembersMustExist.cs
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/Rules/MembersMustExist.cs
@@ -35,11 +35,11 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
         {
             if (left != null && right == null)
             {
-                differences.Add(CreateDifference(left, DiagnosticIds.TypeMustExist, DifferenceType.Removed, "Type '{0}' exists on the left but not on the right"));
+                differences.Add(CreateDifference(left, DiagnosticIds.TypeMustExist, DifferenceType.Removed, Resources.TypeExistsOnLeft));
             }
             else if (Settings.StrictMode && left == null && right != null)
             {
-                differences.Add(CreateDifference(right, DiagnosticIds.TypeMustExist, DifferenceType.Added, "Type '{0}' exists on the right but not on the left"));
+                differences.Add(CreateDifference(right, DiagnosticIds.TypeMustExist, DifferenceType.Added, Resources.TypeExistsOnRight));
             }
         }
 
@@ -54,14 +54,14 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
             {
                 if (ShouldReportMissingMember(left))
                 {
-                    differences.Add(CreateDifference(left, DiagnosticIds.MemberMustExist, DifferenceType.Removed, "Member '{0}' exists on the left but not on the right"));
+                    differences.Add(CreateDifference(left, DiagnosticIds.MemberMustExist, DifferenceType.Removed, Resources.MemberExistsOnLeft));
                 }
             }
             else if (Settings.StrictMode && left == null && right != null)
             {
                 if (ShouldReportMissingMember(right))
                 {
-                    differences.Add(CreateDifference(right, DiagnosticIds.MemberMustExist, DifferenceType.Added, "Member '{0}' exists on the right but not on the left"));
+                    differences.Add(CreateDifference(right, DiagnosticIds.MemberMustExist, DifferenceType.Added, Resources.MemberExistsOnRight));
                 }
             }
         }

--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/Rules/MembersMustExist.cs
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/Rules/MembersMustExist.cs
@@ -35,17 +35,11 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
         {
             if (left != null && right == null)
             {
-                AddDifference(left, DifferenceType.Removed, Resources.TypeExistsOnLeft);
+                differences.Add(CreateDifference(left, DiagnosticIds.TypeMustExist, DifferenceType.Removed, "Type '{0}' exists on the left but not on the right"));
             }
             else if (Settings.StrictMode && left == null && right != null)
             {
-                AddDifference(right, DifferenceType.Added, Resources.TypeExistsOnRight);
-            }
-
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            void AddDifference(ITypeSymbol symbol, DifferenceType type, string format)
-            {
-                differences.Add(new CompatDifference(DiagnosticIds.TypeMustExist, string.Format(format, symbol.ToDisplayString()), type, symbol));
+                differences.Add(CreateDifference(right, DiagnosticIds.TypeMustExist, DifferenceType.Added, "Type '{0}' exists on the right but not on the left"));
             }
         }
 
@@ -58,23 +52,42 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
         {
             if (left != null && right == null)
             {
-                // Events and properties are handled via their accessors.
-                if (left.Kind == SymbolKind.Property || left.Kind == SymbolKind.Event)
-                    return;
-
-                if (left is IMethodSymbol method)
+                if (ShouldReportMissingMember(left))
                 {
-                    // Will be handled by a different rule
-                    if (method.MethodKind == MethodKind.ExplicitInterfaceImplementation)
-                        return;
-
-                    // If method is an override or hides a base type definition removing it from right is compatible.
-                    if (method.IsOverride || FindMatchingOnBaseType(method))
-                        return;
+                    differences.Add(CreateDifference(left, DiagnosticIds.MemberMustExist, DifferenceType.Removed, "Member '{0}' exists on the left but not on the right"));
                 }
-
-                differences.Add(new CompatDifference(DiagnosticIds.MemberMustExist, string.Format(Resources.MemberExistsOnLeft, left.ToDisplayString()), DifferenceType.Removed, left));
             }
+            else if (Settings.StrictMode && left == null && right != null)
+            {
+                if (ShouldReportMissingMember(right))
+                {
+                    differences.Add(CreateDifference(right, DiagnosticIds.MemberMustExist, DifferenceType.Added, "Member '{0}' exists on the right but not on the left"));
+                }
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private CompatDifference CreateDifference(ISymbol symbol, string id, DifferenceType type, string format) =>
+            new(id, string.Format(format, symbol.ToDisplayString()), type, symbol);
+
+        private bool ShouldReportMissingMember(ISymbol symbol)
+        {
+            // Events and properties are handled via their accessors.
+            if (symbol.Kind == SymbolKind.Property || symbol.Kind == SymbolKind.Event)
+                return false;
+
+            if (symbol is IMethodSymbol method)
+            {
+                // Will be handled by a different rule
+                if (method.MethodKind == MethodKind.ExplicitInterfaceImplementation)
+                    return false;
+
+                // If method is an override or hides a base type definition removing it from the comparing side is compatible.
+                if (method.IsOverride || FindMatchingOnBaseType(method))
+                    return false;
+            }
+
+            return true;
         }
 
         private bool FindMatchingOnBaseType(IMethodSymbol method)

--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Resources.cs.xlf
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Resources.cs.xlf
@@ -37,6 +37,11 @@
         <target state="new">Member '{0}' exists on the left but not on the right</target>
         <note />
       </trans-unit>
+      <trans-unit id="MemberExistsOnRight">
+        <source>Member '{0}' exists on the right but not on the left</source>
+        <target state="new">Member '{0}' exists on the right but not on the left</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProvidedPathToLoadBinariesFromNotFound">
         <source>Could not find the provided path '{0}' to load binaries from.</source>
         <target state="new">Could not find the provided path '{0}' to load binaries from.</target>

--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Resources.de.xlf
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Resources.de.xlf
@@ -37,6 +37,11 @@
         <target state="new">Member '{0}' exists on the left but not on the right</target>
         <note />
       </trans-unit>
+      <trans-unit id="MemberExistsOnRight">
+        <source>Member '{0}' exists on the right but not on the left</source>
+        <target state="new">Member '{0}' exists on the right but not on the left</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProvidedPathToLoadBinariesFromNotFound">
         <source>Could not find the provided path '{0}' to load binaries from.</source>
         <target state="new">Could not find the provided path '{0}' to load binaries from.</target>

--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Resources.es.xlf
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Resources.es.xlf
@@ -37,6 +37,11 @@
         <target state="new">Member '{0}' exists on the left but not on the right</target>
         <note />
       </trans-unit>
+      <trans-unit id="MemberExistsOnRight">
+        <source>Member '{0}' exists on the right but not on the left</source>
+        <target state="new">Member '{0}' exists on the right but not on the left</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProvidedPathToLoadBinariesFromNotFound">
         <source>Could not find the provided path '{0}' to load binaries from.</source>
         <target state="new">Could not find the provided path '{0}' to load binaries from.</target>

--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Resources.fr.xlf
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Resources.fr.xlf
@@ -37,6 +37,11 @@
         <target state="new">Member '{0}' exists on the left but not on the right</target>
         <note />
       </trans-unit>
+      <trans-unit id="MemberExistsOnRight">
+        <source>Member '{0}' exists on the right but not on the left</source>
+        <target state="new">Member '{0}' exists on the right but not on the left</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProvidedPathToLoadBinariesFromNotFound">
         <source>Could not find the provided path '{0}' to load binaries from.</source>
         <target state="new">Could not find the provided path '{0}' to load binaries from.</target>

--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Resources.it.xlf
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Resources.it.xlf
@@ -37,6 +37,11 @@
         <target state="new">Member '{0}' exists on the left but not on the right</target>
         <note />
       </trans-unit>
+      <trans-unit id="MemberExistsOnRight">
+        <source>Member '{0}' exists on the right but not on the left</source>
+        <target state="new">Member '{0}' exists on the right but not on the left</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProvidedPathToLoadBinariesFromNotFound">
         <source>Could not find the provided path '{0}' to load binaries from.</source>
         <target state="new">Could not find the provided path '{0}' to load binaries from.</target>

--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Resources.ja.xlf
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Resources.ja.xlf
@@ -37,6 +37,11 @@
         <target state="new">Member '{0}' exists on the left but not on the right</target>
         <note />
       </trans-unit>
+      <trans-unit id="MemberExistsOnRight">
+        <source>Member '{0}' exists on the right but not on the left</source>
+        <target state="new">Member '{0}' exists on the right but not on the left</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProvidedPathToLoadBinariesFromNotFound">
         <source>Could not find the provided path '{0}' to load binaries from.</source>
         <target state="new">Could not find the provided path '{0}' to load binaries from.</target>

--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Resources.ko.xlf
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Resources.ko.xlf
@@ -37,6 +37,11 @@
         <target state="new">Member '{0}' exists on the left but not on the right</target>
         <note />
       </trans-unit>
+      <trans-unit id="MemberExistsOnRight">
+        <source>Member '{0}' exists on the right but not on the left</source>
+        <target state="new">Member '{0}' exists on the right but not on the left</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProvidedPathToLoadBinariesFromNotFound">
         <source>Could not find the provided path '{0}' to load binaries from.</source>
         <target state="new">Could not find the provided path '{0}' to load binaries from.</target>

--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Resources.pl.xlf
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Resources.pl.xlf
@@ -37,6 +37,11 @@
         <target state="new">Member '{0}' exists on the left but not on the right</target>
         <note />
       </trans-unit>
+      <trans-unit id="MemberExistsOnRight">
+        <source>Member '{0}' exists on the right but not on the left</source>
+        <target state="new">Member '{0}' exists on the right but not on the left</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProvidedPathToLoadBinariesFromNotFound">
         <source>Could not find the provided path '{0}' to load binaries from.</source>
         <target state="new">Could not find the provided path '{0}' to load binaries from.</target>

--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Resources.pt-BR.xlf
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Resources.pt-BR.xlf
@@ -37,6 +37,11 @@
         <target state="new">Member '{0}' exists on the left but not on the right</target>
         <note />
       </trans-unit>
+      <trans-unit id="MemberExistsOnRight">
+        <source>Member '{0}' exists on the right but not on the left</source>
+        <target state="new">Member '{0}' exists on the right but not on the left</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProvidedPathToLoadBinariesFromNotFound">
         <source>Could not find the provided path '{0}' to load binaries from.</source>
         <target state="new">Could not find the provided path '{0}' to load binaries from.</target>

--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Resources.ru.xlf
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Resources.ru.xlf
@@ -37,6 +37,11 @@
         <target state="new">Member '{0}' exists on the left but not on the right</target>
         <note />
       </trans-unit>
+      <trans-unit id="MemberExistsOnRight">
+        <source>Member '{0}' exists on the right but not on the left</source>
+        <target state="new">Member '{0}' exists on the right but not on the left</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProvidedPathToLoadBinariesFromNotFound">
         <source>Could not find the provided path '{0}' to load binaries from.</source>
         <target state="new">Could not find the provided path '{0}' to load binaries from.</target>

--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Resources.tr.xlf
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Resources.tr.xlf
@@ -37,6 +37,11 @@
         <target state="new">Member '{0}' exists on the left but not on the right</target>
         <note />
       </trans-unit>
+      <trans-unit id="MemberExistsOnRight">
+        <source>Member '{0}' exists on the right but not on the left</source>
+        <target state="new">Member '{0}' exists on the right but not on the left</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProvidedPathToLoadBinariesFromNotFound">
         <source>Could not find the provided path '{0}' to load binaries from.</source>
         <target state="new">Could not find the provided path '{0}' to load binaries from.</target>

--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Resources.zh-Hans.xlf
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Resources.zh-Hans.xlf
@@ -37,6 +37,11 @@
         <target state="new">Member '{0}' exists on the left but not on the right</target>
         <note />
       </trans-unit>
+      <trans-unit id="MemberExistsOnRight">
+        <source>Member '{0}' exists on the right but not on the left</source>
+        <target state="new">Member '{0}' exists on the right but not on the left</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProvidedPathToLoadBinariesFromNotFound">
         <source>Could not find the provided path '{0}' to load binaries from.</source>
         <target state="new">Could not find the provided path '{0}' to load binaries from.</target>

--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Resources.zh-Hant.xlf
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Resources.zh-Hant.xlf
@@ -37,6 +37,11 @@
         <target state="new">Member '{0}' exists on the left but not on the right</target>
         <note />
       </trans-unit>
+      <trans-unit id="MemberExistsOnRight">
+        <source>Member '{0}' exists on the right but not on the left</source>
+        <target state="new">Member '{0}' exists on the right but not on the left</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProvidedPathToLoadBinariesFromNotFound">
         <source>Could not find the provided path '{0}' to load binaries from.</source>
         <target state="new">Could not find the provided path '{0}' to load binaries from.</target>

--- a/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/Rules/MembersMustExistTests.Strict.cs
+++ b/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/Rules/MembersMustExistTests.Strict.cs
@@ -1,0 +1,363 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.DotNet.ApiCompatibility.Abstractions;
+using Xunit;
+
+namespace Microsoft.DotNet.ApiCompatibility.Tests
+{
+    public class MembersMustExistTests_Strict
+    {
+        [Fact]
+        public static void MissingMembersOnLeftAreReported()
+        {
+            string leftSyntax = @"
+namespace CompatTests
+{
+  public class First
+  {
+    public string Parameterless() { }
+  }
+  public delegate void EventHandler(object sender EventArgs e);
+}
+";
+
+            string rightSyntax = @"
+namespace CompatTests
+{
+  public class First
+  {
+    public string Parameterless() { }
+    public void ShouldReportMethod(string a, string b) { }
+    public string ShouldReportMissingProperty { get; }
+    public string this[int index] { get; }
+    public event EventHandler ShouldReportMissingEvent;
+    public int ReportMissingField = 0;
+  }
+
+  public delegate void EventHandler(object sender EventArgs e);
+}
+";
+
+            IAssemblySymbol left = SymbolFactory.GetAssemblyFromSyntax(leftSyntax);
+            IAssemblySymbol right = SymbolFactory.GetAssemblyFromSyntax(rightSyntax);
+            ApiComparer differ = new();
+            differ.StrictMode = true;
+            IEnumerable<CompatDifference> differences = differ.GetDifferences(new[] { left }, new[] { right });
+
+            CompatDifference[] expected = new[]
+            {
+                new CompatDifference(DiagnosticIds.MemberMustExist, string.Empty, DifferenceType.Added, "M:CompatTests.First.ShouldReportMethod(System.String,System.String)"),
+                new CompatDifference(DiagnosticIds.MemberMustExist, string.Empty, DifferenceType.Added, "M:CompatTests.First.get_ShouldReportMissingProperty"),
+                new CompatDifference(DiagnosticIds.MemberMustExist, string.Empty, DifferenceType.Added, "M:CompatTests.First.get_Item(System.Int32)"),
+                new CompatDifference(DiagnosticIds.MemberMustExist, string.Empty, DifferenceType.Added, "M:CompatTests.First.add_ShouldReportMissingEvent(CompatTests.EventHandler)"),
+                new CompatDifference(DiagnosticIds.MemberMustExist, string.Empty, DifferenceType.Added, "M:CompatTests.First.remove_ShouldReportMissingEvent(CompatTests.EventHandler)"),
+                new CompatDifference(DiagnosticIds.MemberMustExist, string.Empty, DifferenceType.Added, "F:CompatTests.First.ReportMissingField"),
+            };
+
+            Assert.Equal(expected, differences, CompatDifferenceComparer.Default);
+        }
+
+        [Fact]
+        public static void HiddenMemberInRightIsNotReported()
+        {
+            string leftSyntax = @"
+namespace CompatTests
+{
+  public class FirstBase
+  {
+    public void MyMethod() { }
+    public string MyMethodWithParams(string a, int b, FirstBase c) { }
+    public T MyGenericMethod<T, T2, T3>(string name, T2 a, T3 b) { }
+    public virtual string MyVirtualMethod() { }
+  }
+  public class Second : FirstBase { }
+}
+";
+
+            string rightSyntax = @"
+namespace CompatTests
+{
+  public class FirstBase
+  {
+    public void MyMethod() { }
+    public string MyMethodWithParams(string a, int b, FirstBase c) { }
+    public T MyGenericMethod<T, T2, T3>(string name, T2 a, T3 b) { }
+    public virtual string MyVirtualMethod() { }
+  }
+  public class Second : FirstBase
+  {
+    public new void MyMethod() { }
+    public new string MyMethodWithParams(string a, int b, FirstBase c) { }
+    public new T MyGenericMethod<T, T2, T3>(string name, T2 a, T3 b) { }
+    public override string MyVirtualMethod() { }
+  }
+}
+";
+
+            IAssemblySymbol left = SymbolFactory.GetAssemblyFromSyntax(leftSyntax);
+            IAssemblySymbol right = SymbolFactory.GetAssemblyFromSyntax(rightSyntax);
+            ApiComparer differ = new();
+            differ.StrictMode = true;
+            IEnumerable<CompatDifference> differences = differ.GetDifferences(new[] { left }, new[] { right });
+            Assert.Empty(differences);
+        }
+
+        [Fact]
+        public static void MultipleOverridesMissingInLeftAreReported()
+        {
+            string rightSyntax = @"
+namespace CompatTests
+{
+  public class First
+  {
+    public string MultipleOverrides() { }
+    public string MultipleOverrides(string a) { }
+    public string MultipleOverrides(string a, string b) { }
+    public string MultipleOverrides(string a, int b, string c) { }
+    public string MultipleOverrides(string a, int b, int c) { }
+  }
+}
+";
+
+            string leftSyntax = @"
+namespace CompatTests
+{
+  public class First
+  {
+    public string MultipleOverrides() { }
+    public string MultipleOverrides(string a) { }
+    public string MultipleOverrides(string a, int b, int c) { }
+  }
+}
+";
+
+            IAssemblySymbol left = SymbolFactory.GetAssemblyFromSyntax(leftSyntax);
+            IAssemblySymbol right = SymbolFactory.GetAssemblyFromSyntax(rightSyntax);
+            ApiComparer differ = new();
+            differ.StrictMode = true;
+            IEnumerable<CompatDifference> differences = differ.GetDifferences(new[] { left }, new[] { right });
+
+            CompatDifference[] expected = new[]
+            {
+                new CompatDifference(DiagnosticIds.MemberMustExist, string.Empty, DifferenceType.Added, "M:CompatTests.First.MultipleOverrides(System.String,System.String)"),
+                new CompatDifference(DiagnosticIds.MemberMustExist, string.Empty, DifferenceType.Added, "M:CompatTests.First.MultipleOverrides(System.String,System.Int32,System.String)"),
+            };
+
+            Assert.Equal(expected, differences, CompatDifferenceComparer.Default);
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public static void IncludeInternalsIsRespectedForMembers_IndividualAssemblies(bool includeInternals)
+        {
+            string rightSyntax = @"
+namespace CompatTests
+{
+  public class First
+  {
+    public string MultipleOverrides() { }
+    public string MultipleOverrides(string a) { }
+    public string MultipleOverrides(string a, string b) { }
+    public string MultipleOverrides(string a, int b, string c) { }
+    internal string MultipleOverrides(string a, int b, int c) { }
+    internal int InternalProperty { get; set; }
+  }
+}
+";
+
+            string leftSyntax = @"
+namespace CompatTests
+{
+  public class First
+  {
+    public string MultipleOverrides() { }
+    public string MultipleOverrides(string a) { }
+    public string MultipleOverrides(string a, string b) { }
+    public string MultipleOverrides(string a, int b, string c) { }
+    internal int InternalProperty { get; }
+  }
+}
+";
+
+            IAssemblySymbol left = SymbolFactory.GetAssemblyFromSyntax(leftSyntax);
+            IAssemblySymbol right = SymbolFactory.GetAssemblyFromSyntax(rightSyntax, assemblyName: "DifferentName");
+            ApiComparer differ = new();
+            differ.IncludeInternalSymbols = includeInternals;
+            differ.StrictMode = true;
+            IEnumerable<CompatDifference> differences = differ.GetDifferences(left, right);
+
+            if (includeInternals)
+            {
+                CompatDifference[] expected = new[]
+                {
+                    new CompatDifference(DiagnosticIds.MemberMustExist, string.Empty, DifferenceType.Added, "M:CompatTests.First.MultipleOverrides(System.String,System.Int32,System.Int32)"),
+                    new CompatDifference(DiagnosticIds.MemberMustExist, string.Empty, DifferenceType.Added, "M:CompatTests.First.set_InternalProperty(System.Int32)"),
+                };
+
+                Assert.Equal(expected, differences, CompatDifferenceComparer.Default);
+            }
+            else
+            {
+                Assert.Empty(differences);
+            }
+        }
+
+        [Fact]
+        public static void MissingMembersOnBothSidesAreReported()
+        {
+            string leftSyntax = @"
+namespace CompatTests
+{
+  public class First
+  {
+    public string Parameterless() { }
+    public string MissingMethodRight() { }
+  }
+}
+";
+
+            string rightSyntax = @"
+namespace CompatTests
+{
+  public class First
+  {
+    public string Parameterless() { }
+    public void MissingMethodLeft(string a, string b) { }
+  }
+}
+";
+
+            IAssemblySymbol left = SymbolFactory.GetAssemblyFromSyntax(leftSyntax);
+            IAssemblySymbol right = SymbolFactory.GetAssemblyFromSyntax(rightSyntax);
+            ApiComparer differ = new();
+            differ.StrictMode = true;
+            IEnumerable<CompatDifference> differences = differ.GetDifferences(new[] { left }, new[] { right });
+
+            CompatDifference[] expected = new[]
+            {
+                new CompatDifference(DiagnosticIds.MemberMustExist, string.Empty, DifferenceType.Removed, "M:CompatTests.First.MissingMethodRight"),
+                new CompatDifference(DiagnosticIds.MemberMustExist, string.Empty, DifferenceType.Added, "M:CompatTests.First.MissingMethodLeft(System.String,System.String)"),
+            };
+
+            Assert.Equal(expected, differences, CompatDifferenceComparer.Default);
+        }
+
+        [Fact]
+        public static void MultipleRightsMissingMembersOnLeftAreReported()
+        {
+            string leftSyntax = @"
+namespace CompatTests
+{
+  public class First
+  {
+    public class FirstNested
+    {
+      public string MyProperty { get; }
+      public class SecondNested
+      {
+        public int MyMethod() => 0;
+        public class ThirdNested
+        {
+        }
+      }
+    }
+  }
+}
+";
+
+            string[] rightSyntaxes = new[]
+            { @"
+namespace CompatTests
+{
+  public class First
+  {
+    public class FirstNested
+    {
+      public string MyProperty { get; }
+      public class SecondNested
+      {
+        public int MyMethod() => 0;
+        public class ThirdNested
+        {
+          public string MyField;
+        }
+      }
+    }
+  }
+}
+",
+            @"
+namespace CompatTests
+{
+  public class First
+  {
+    public class FirstNested
+    {
+      public string MyProperty { get; }
+      public class SecondNested
+      {
+        public int MyMethod() => 0;
+        public class ThirdNested
+        {
+          public string MyField;
+        }
+      }
+    }
+  }
+}
+",
+            @"
+namespace CompatTests
+{
+  public class First
+  {
+    public class FirstNested
+    {
+      public string MyProperty { get; }
+      public class SecondNested
+      {
+        public int MyMethod() => 0;
+        public class ThirdNested
+        {
+        }
+      }
+    }
+  }
+}
+"};
+
+            ApiComparer differ = new();
+            differ.StrictMode = true;
+            ElementContainer<IAssemblySymbol> left =
+                new(SymbolFactory.GetAssemblyFromSyntax(leftSyntax), new MetadataInformation(string.Empty, string.Empty, "ref"));
+
+            IList<ElementContainer<IAssemblySymbol>> right = SymbolFactory.GetElementContainersFromSyntaxes(rightSyntaxes);
+
+            IEnumerable<(MetadataInformation, MetadataInformation, IEnumerable<CompatDifference>)> differences =
+                differ.GetDifferences(left, right);
+
+            CompatDifference[][] expectedDiffs =
+            {
+                new[]
+                {
+                    new CompatDifference(DiagnosticIds.MemberMustExist, string.Empty, DifferenceType.Added, "F:CompatTests.First.FirstNested.SecondNested.ThirdNested.MyField"),
+                },
+                new[]
+                {
+                    new CompatDifference(DiagnosticIds.MemberMustExist, string.Empty, DifferenceType.Added, "F:CompatTests.First.FirstNested.SecondNested.ThirdNested.MyField"),
+                },
+                Array.Empty<CompatDifference>(),
+            };
+
+            AssertExtensions.MultiRightResult(left.MetadataInformation, expectedDiffs, differences);
+        }
+    }
+}


### PR DESCRIPTION
If we are going to enable strict mode for compile asset vs runtime asset comparison on Preview 6 we might want to port this as well. 