### PR TITLE
Escaping the ConnectionString values for EF Migrations

### DIFF
--- a/sdk.sln
+++ b/sdk.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29417.175
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31422.225
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build", "build", "{50A89C27-BA35-44B2-AC57-E54551791C64}"
 	ProjectSection(SolutionItems) = preProject
@@ -160,31 +160,31 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.NET.Sdk.Worker.Ta
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.NET.Sdk.Publish.Tasks.Tests", "src\Tests\Microsoft.NET.Sdk.Publish.Tasks.Tests\Microsoft.NET.Sdk.Publish.Tasks.Tests.csproj", "{1F26FAE6-2654-4E83-8936-146134638C59}"
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Sdk (2)", "Sdk (2)", "{F717D467-EF88-49B9-AD67-55FC6350A9DE}"
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Sdk", "Sdk", "{F717D467-EF88-49B9-AD67-55FC6350A9DE}"
 	ProjectSection(SolutionItems) = preProject
 		src\WebSdk\Publish\Sdk\Sdk.props = src\WebSdk\Publish\Sdk\Sdk.props
 		src\WebSdk\Publish\Sdk\Sdk.targets = src\WebSdk\Publish\Sdk\Sdk.targets
 	EndProjectSection
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Targets (2)", "Targets (2)", "{2F565AE9-3DBC-4EFF-A3C4-4B65C7262282}"
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Targets", "Targets", "{2F565AE9-3DBC-4EFF-A3C4-4B65C7262282}"
 	ProjectSection(SolutionItems) = preProject
 		src\WebSdk\Publish\Targets\Microsoft.NET.Sdk.Publish.props = src\WebSdk\Publish\Targets\Microsoft.NET.Sdk.Publish.props
 		src\WebSdk\Publish\Targets\Microsoft.NET.Sdk.Publish.targets = src\WebSdk\Publish\Targets\Microsoft.NET.Sdk.Publish.targets
 	EndProjectSection
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Sdk (2)", "Sdk (2)", "{63DA18A8-D24A-4CD1-A7E7-2B181AB2DF9A}"
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Sdk", "Sdk", "{63DA18A8-D24A-4CD1-A7E7-2B181AB2DF9A}"
 	ProjectSection(SolutionItems) = preProject
 		src\WebSdk\Web\Sdk\Sdk.props = src\WebSdk\Web\Sdk\Sdk.props
 		src\WebSdk\Web\Sdk\Sdk.targets = src\WebSdk\Web\Sdk\Sdk.targets
 	EndProjectSection
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Sdk (2)", "Sdk (2)", "{2869912E-BD63-40CF-A17F-7195B6FE9630}"
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Sdk", "Sdk", "{2869912E-BD63-40CF-A17F-7195B6FE9630}"
 	ProjectSection(SolutionItems) = preProject
 		src\WebSdk\Worker\Sdk\Sdk.props = src\WebSdk\Worker\Sdk\Sdk.props
 		src\WebSdk\Worker\Sdk\Sdk.targets = src\WebSdk\Worker\Sdk\Sdk.targets
 	EndProjectSection
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Targets (2)", "Targets (2)", "{EE6A0097-62A5-40B7-8E6C-F8FD009B5C33}"
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Targets", "Targets", "{EE6A0097-62A5-40B7-8E6C-F8FD009B5C33}"
 	ProjectSection(SolutionItems) = preProject
 		src\WebSdk\Worker\Targets\Microsoft.NET.Sdk.Worker.props = src\WebSdk\Worker\Targets\Microsoft.NET.Sdk.Worker.props
 		src\WebSdk\Worker\Targets\Microsoft.NET.Sdk.Worker.targets = src\WebSdk\Worker\Targets\Microsoft.NET.Sdk.Worker.targets
@@ -235,15 +235,15 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Transforms", "Transforms", 
 		src\WebSdk\Publish\Targets\TransformTargets\Transforms\EnvironmentWithLocation.transform = src\WebSdk\Publish\Targets\TransformTargets\Transforms\EnvironmentWithLocation.transform
 	EndProjectSection
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Targets (2)", "Targets (2)", "{6FBE1C01-77B7-41B9-ADD6-84B072526DCA}"
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Targets", "Targets", "{6FBE1C01-77B7-41B9-ADD6-84B072526DCA}"
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tasks (2)", "Tasks (2)", "{02EA412D-60F9-41E2-A1D9-D1569BB8FC79}"
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tasks", "Tasks", "{02EA412D-60F9-41E2-A1D9-D1569BB8FC79}"
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tasks (2)", "Tasks (2)", "{5F8809DE-414C-42CB-A1BC-CF95267E6F49}"
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tasks", "Tasks", "{5F8809DE-414C-42CB-A1BC-CF95267E6F49}"
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tasks (2)", "Tasks (2)", "{27302615-7D46-499E-AC84-D3E193F9A62D}"
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tasks", "Tasks", "{27302615-7D46-499E-AC84-D3E193F9A62D}"
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tasks (2)", "Tasks (2)", "{EBEF2950-E27B-4EB8-8F1C-2001984B4D41}"
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tasks", "Tasks", "{EBEF2950-E27B-4EB8-8F1C-2001984B4D41}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DotNet.TemplateLocator", "src\Microsoft.DotNet.TemplateLocator\Microsoft.DotNet.TemplateLocator.csproj", "{89F798D9-A8BA-4556-B2A2-39CEF3587093}"
 EndProject

--- a/src/WebSdk/Publish/Tasks/Tasks/GenerateEFSQLScripts.cs
+++ b/src/WebSdk/Publish/Tasks/Tasks/GenerateEFSQLScripts.cs
@@ -2,6 +2,7 @@
 using System.Diagnostics;
 using System.IO;
 using System.Text;
+using Microsoft.Build.Evaluation;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using Microsoft.NET.Sdk.Publish.Tasks.Properties;
@@ -44,15 +45,16 @@ namespace Microsoft.NET.Sdk.Publish.Tasks
             foreach (ITaskItem dbContext in EFMigrations)
             {
                 string outputFileFullPath = Path.Combine(EFPublishDirectory, EFSQLScriptsFolderName, dbContext.ItemSpec + ".sql");
-                bool isScriptGeneratioNSuccessful = GenerateSQLScript(outputFileFullPath, dbContext.ItemSpec, isLoggingEnabled);
-                if (!isScriptGeneratioNSuccessful)
+                bool isScriptGenerationSuccessful = GenerateSQLScript(outputFileFullPath, dbContext.ItemSpec, isLoggingEnabled);
+                if (!isScriptGenerationSuccessful)
                 {
                     return false;
                 }
 
                 ITaskItem sqlScriptItem = new TaskItem(outputFileFullPath);
                 sqlScriptItem.SetMetadata("DBContext", dbContext.ItemSpec);
-                sqlScriptItem.SetMetadata("ConnectionString", dbContext.GetMetadata("Value"));
+                string connectionStringEscaped = ProjectCollection.Escape(dbContext.GetMetadata("Value"));
+                sqlScriptItem.SetMetadata("ConnectionString", connectionStringEscaped);
                 EFSQLScripts[index] = sqlScriptItem;
 
                 index++;


### PR DESCRIPTION
- The entity framework connection strings are defined in the publish user files. These values needs to be escaped after reading and before adding it to the new Itemgroup.