### PR TITLE
Disable "MSBuild Server v1" by default

### DIFF
--- a/src/Cli/Microsoft.DotNet.Cli.Utils/MSBuildForwardingAppWithoutLogging.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/MSBuildForwardingAppWithoutLogging.cs
@@ -16,7 +16,7 @@ namespace Microsoft.DotNet.Cli.Utils
     internal class MSBuildForwardingAppWithoutLogging
     {
         private static readonly bool AlwaysExecuteMSBuildOutOfProc = Env.GetEnvironmentVariableAsBool("DOTNET_CLI_RUN_MSBUILD_OUTOFPROC");
-        private static readonly bool DoNotUseMSBUILDNOINPROCNODE = Env.GetEnvironmentVariableAsBool("DOTNET_CLI_DO_NOT_USE_MSBUILDNOINPROCNODE");
+        private static readonly bool DoNotUseMSBUILDNOINPROCNODE = Env.GetEnvironmentVariableAsBool("DOTNET_CLI_USE_MSBUILDNOINPROCNODE");
 
         private const string MSBuildExeName = "MSBuild.dll";
 
@@ -54,7 +54,7 @@ namespace Microsoft.DotNet.Cli.Utils
             _argsToForward = argsToForward;
             MSBuildPath = msbuildPath ?? defaultMSBuildPath;
 
-            if (!DoNotUseMSBUILDNOINPROCNODE)
+            if (DoNotUseMSBUILDNOINPROCNODE)
             {
                 // Force MSBuild to use external working node long living process for building projects
                 // We also refers to this as MSBuild Server V1 as entry process forwards most of the work to it.

--- a/src/Cli/Microsoft.DotNet.Cli.Utils/MSBuildForwardingAppWithoutLogging.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/MSBuildForwardingAppWithoutLogging.cs
@@ -16,7 +16,7 @@ namespace Microsoft.DotNet.Cli.Utils
     internal class MSBuildForwardingAppWithoutLogging
     {
         private static readonly bool AlwaysExecuteMSBuildOutOfProc = Env.GetEnvironmentVariableAsBool("DOTNET_CLI_RUN_MSBUILD_OUTOFPROC");
-        private static readonly bool DoNotUseMSBUILDNOINPROCNODE = Env.GetEnvironmentVariableAsBool("DOTNET_CLI_USE_MSBUILDNOINPROCNODE");
+        private static readonly bool UseMSBUILDNOINPROCNODE = Env.GetEnvironmentVariableAsBool("DOTNET_CLI_USE_MSBUILDNOINPROCNODE");
 
         private const string MSBuildExeName = "MSBuild.dll";
 

--- a/src/Cli/Microsoft.DotNet.Cli.Utils/MSBuildForwardingAppWithoutLogging.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/MSBuildForwardingAppWithoutLogging.cs
@@ -54,7 +54,7 @@ namespace Microsoft.DotNet.Cli.Utils
             _argsToForward = argsToForward;
             MSBuildPath = msbuildPath ?? defaultMSBuildPath;
 
-            if (DoNotUseMSBUILDNOINPROCNODE)
+            if (UseMSBUILDNOINPROCNODE)
             {
                 // Force MSBuild to use external working node long living process for building projects
                 // We also refers to this as MSBuild Server V1 as entry process forwards most of the work to it.


### PR DESCRIPTION
## Description
Disabling the new MS Build server feature as it's not ready yet.  Leaving the feature flag in place so we can continue to test it.

**Prior change to enable this two weeks ago**
https://github.com/dotnet/sdk/pull/18263

## Customer Impact
We've found multiple impacts from early dogfooding so far.  The primary one below is that MSBuild can get into a state where it fails to expand wildcards, failing builds. Because of how confusing that was to track down and how unsure we are on other impact, we want to revert this to be safe.

https://github.com/dotnet/msbuild/issues/6602

Another impact was we were blocked from updating stage 0 SDK in the installer repo so this could have a lot of other silent internal impact we haven't tracked down yet:
https://github.com/dotnet/installer/pull/10940

## Testing

Passed SDK tests.

## Risk
Low, this flips a feature flag back off that was enabled only two weeks ago.