### PR TITLE
Pull language version from compilation parse options

### DIFF
--- a/src/RazorSdk/SourceGenerators/RazorSourceGenerationOptions.cs
+++ b/src/RazorSdk/SourceGenerators/RazorSourceGenerationOptions.cs
@@ -3,6 +3,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.CodeAnalysis.CSharp;
 
 namespace Microsoft.NET.Sdk.Razor.SourceGenerators
 {
@@ -35,5 +36,10 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
         /// </para>
         /// </summary>
         public bool SuppressRazorSourceGenerator { get; set; } = false;
+
+        /// <summary>
+        /// Gets the CSharp language version currently used by the compilation.
+        /// </summary>
+        public LanguageVersion CSharpLanguageVersion { get; set; } = LanguageVersion.Preview;
     }
 }

--- a/src/RazorSdk/SourceGenerators/RazorSourceGenerator.Helpers.cs
+++ b/src/RazorSdk/SourceGenerators/RazorSourceGenerator.Helpers.cs
@@ -48,17 +48,15 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
             }
         }
 
-        private static RazorProjectEngine GetDiscoveryProjectEngine(StaticCompilationTagHelperFeature tagHelperFeature, IEnumerable<MetadataReference> references, IEnumerable<SourceGeneratorProjectItem> items, string rootNamespace)
+        private static RazorProjectEngine GetDiscoveryProjectEngine(StaticCompilationTagHelperFeature tagHelperFeature, IEnumerable<MetadataReference> references, IEnumerable<SourceGeneratorProjectItem> items, RazorSourceGenerationOptions razorSourceGeneratorOptions)
         {
-            var config = RazorConfiguration.Create(RazorLanguageVersion.Latest, "default", Enumerable.Empty<RazorExtension>(), true);
-
             var fileSystem = new VirtualRazorProjectFileSystem();
             foreach (var item in items)
             {
                 fileSystem.Add(item);
             }
 
-            var discoveryProjectEngine = RazorProjectEngine.Create(config, fileSystem, b =>
+            var discoveryProjectEngine = RazorProjectEngine.Create(razorSourceGeneratorOptions.Configuration, fileSystem, b =>
             {
                 b.Features.Add(new DefaultTypeNameFeature());
                 b.Features.Add(new ConfigureRazorCodeGenerationOptions(options =>
@@ -67,7 +65,7 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
                     options.SuppressChecksum = true;
                 }));
 
-                b.SetRootNamespace(rootNamespace);
+                b.SetRootNamespace(razorSourceGeneratorOptions.RootNamespace);
 
                 b.Features.Add(new DefaultMetadataReferenceFeature { References = references.ToList() });
 
@@ -77,7 +75,7 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
                 CompilerFeatures.Register(b);
                 RazorExtensions.Register(b);
 
-                b.SetCSharpLanguageVersion(LanguageVersion.Preview);
+                b.SetCSharpLanguageVersion(razorSourceGeneratorOptions.CSharpLanguageVersion);
             });
 
             return discoveryProjectEngine;
@@ -107,7 +105,7 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
                 CompilerFeatures.Register(b);
                 RazorExtensions.Register(b);
 
-                b.SetCSharpLanguageVersion(LanguageVersion.Preview);
+                b.SetCSharpLanguageVersion(razorSourceGeneratorOptions.CSharpLanguageVersion);
             });
 
             return projectEngine;

--- a/src/RazorSdk/SourceGenerators/RazorSourceGenerator.RazorProviders.cs
+++ b/src/RazorSdk/SourceGenerators/RazorSourceGenerator.RazorProviders.cs
@@ -7,14 +7,16 @@ using System.Text;
 using System.Threading;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace Microsoft.NET.Sdk.Razor.SourceGenerators
 {
     public partial class RazorSourceGenerator
     {
-        private static (RazorSourceGenerationOptions?, Diagnostic?) ComputeRazorSourceGeneratorOptions(AnalyzerConfigOptionsProvider options, CancellationToken ct)
+        private static (RazorSourceGenerationOptions?, Diagnostic?) ComputeRazorSourceGeneratorOptions((AnalyzerConfigOptionsProvider, ParseOptions) pair, CancellationToken ct)
         {
+            var (options, parseOptions) = pair;
             var globalOptions = options.GlobalOptions;
 
             globalOptions.TryGetValue("build_property.RazorConfiguration", out var configurationName);
@@ -42,7 +44,8 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
                 SuppressRazorSourceGenerator = suppressRazorSourceGenerator == "true",
                 GenerateMetadataSourceChecksumAttributes = generateMetadataSourceChecksumAttributes == "true",
                 RootNamespace = rootNamespace ?? "ASP",
-                Configuration = razorConfiguration
+                Configuration = razorConfiguration,
+                CSharpLanguageVersion = ((CSharpParseOptions)parseOptions).LanguageVersion,
             };
 
             return (razorSourceGenerationOptions, diagnostic);


### PR DESCRIPTION
Since we set the lang version in the SDK, we don't need to reconstruct it here.

Follow-up to undo all this later: https://github.com/dotnet/aspnetcore/issues/33848