### PR TITLE
[release/6.0-preview6] [API Compat] Add support to specify custom names for left and right on errors

### DIFF
--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/Abstractions/Mappers/ElementMapper.cs
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/Abstractions/Mappers/ElementMapper.cs
@@ -26,7 +26,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Abstractions
         /// <summary>
         /// The <see cref="ComparingSettings"/> used to diff <see cref="Left"/> and <see cref="Right"/>.
         /// </summary>
-        public ComparingSettings Settings { get; }
+        public ComparingSettings Settings { get; internal set; }
 
         /// <summary>
         /// Instantiates an object with the provided <see cref="ComparingSettings"/>.
@@ -38,7 +38,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Abstractions
             if (rightSetSize <= 0)
                 throw new ArgumentOutOfRangeException(nameof(rightSetSize), Resources.ShouldBeGreaterThanZero);
 
-            Settings = settings;
+            Settings = settings ?? throw new ArgumentNullException(nameof(settings));
             Right = new T[rightSetSize];
         }
 

--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/Abstractions/MetadataInformation.cs
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/Abstractions/MetadataInformation.cs
@@ -13,20 +13,20 @@ namespace Microsoft.DotNet.ApiCompatibility.Abstractions
     {
         public readonly string AssemblyName;
         public readonly string TargetFramework;
-        public readonly string AssemblyType;
+        public readonly string AssemblyId;
 
-        public MetadataInformation(string name, string targetFramework, string assemblyType)
+        public MetadataInformation(string name, string targetFramework, string assemblyId)
         {
             AssemblyName = name ?? string.Empty;
             TargetFramework = targetFramework ?? string.Empty;
-            AssemblyType = assemblyType ?? string.Empty;
+            AssemblyId = assemblyId ?? string.Empty;
         }
 
         public bool Equals(MetadataInformation other) =>
             string.Equals(AssemblyName, other.AssemblyName, StringComparison.OrdinalIgnoreCase) &&
             string.Equals(TargetFramework, other.TargetFramework, StringComparison.OrdinalIgnoreCase) &&
-            string.Equals(AssemblyType, other.AssemblyType, StringComparison.Ordinal);
+            string.Equals(AssemblyId, other.AssemblyId, StringComparison.Ordinal);
 
-        public override int GetHashCode() => HashCode.Combine(AssemblyName, TargetFramework, AssemblyType);
+        public override int GetHashCode() => HashCode.Combine(AssemblyName, TargetFramework, AssemblyId);
     }
 }

--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/ApiComparer.cs
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/ApiComparer.cs
@@ -39,9 +39,11 @@ namespace Microsoft.DotNet.ApiCompatibility
 
         /// <summary>
         /// Callback function to get the <see cref="ComparingSettings"/> to be used when creating the settings to get the differences.
+        /// The callback takes a string leftName and string[] rightNames parameters to indicate API Compat via the settings what the 
+        /// name for the left and right the user specified.
         /// This callback is called at the beginning of every <see cref="GetDifferences"/> overload.
         /// </summary>
-        public Func<ComparingSettings> GetComparingSettings { get; set; }
+        public Func<string, string[], ComparingSettings> GetComparingSettings { get; set; }
 
         /// <summary>
         /// Get's the differences when comparing Left vs Right based on the settings at the moment this method is called.
@@ -50,7 +52,7 @@ namespace Microsoft.DotNet.ApiCompatibility
         /// <param name="left">Left symbols to compare against.</param>
         /// <param name="right">Right symbols to compare against.</param>
         /// <returns>List of found differences.</returns>
-        public IEnumerable<CompatDifference> GetDifferences(IEnumerable<IAssemblySymbol> left, IEnumerable<IAssemblySymbol> right)
+        public IEnumerable<CompatDifference> GetDifferences(IEnumerable<IAssemblySymbol> left, IEnumerable<IAssemblySymbol> right, string leftName = null, string rightName = null)
         {
             if (left == null)
             {
@@ -62,7 +64,7 @@ namespace Microsoft.DotNet.ApiCompatibility
                 throw new ArgumentNullException(nameof(right));
             }
 
-            AssemblySetMapper mapper = new(GetComparingSettingsCore());
+            AssemblySetMapper mapper = new(GetComparingSettingsCore(leftName, new[] { rightName }));
             mapper.AddElement(left, ElementSide.Left);
             mapper.AddElement(right, ElementSide.Right);
 
@@ -78,7 +80,7 @@ namespace Microsoft.DotNet.ApiCompatibility
         /// <param name="left">Left symbol to compare against.</param>
         /// <param name="right">Right symbol to compare against.</param>
         /// <returns>List of found differences.</returns>
-        public IEnumerable<CompatDifference> GetDifferences(IAssemblySymbol left, IAssemblySymbol right)
+        public IEnumerable<CompatDifference> GetDifferences(IAssemblySymbol left, IAssemblySymbol right, string leftName = null, string rightName = null)
         {
             if (left == null)
             {
@@ -90,7 +92,7 @@ namespace Microsoft.DotNet.ApiCompatibility
                 throw new ArgumentNullException(nameof(right));
             }
 
-            AssemblyMapper mapper = new(GetComparingSettingsCore());
+            AssemblyMapper mapper = new(GetComparingSettingsCore(leftName, new[] { rightName }));
             mapper.AddElement(left, ElementSide.Left);
             mapper.AddElement(right, ElementSide.Right);
 
@@ -120,10 +122,10 @@ namespace Microsoft.DotNet.ApiCompatibility
             }
 
             int rightCount = right.Count;
-            AssemblyMapper mapper = new(GetComparingSettingsCore(), rightSetSize: rightCount);
+            AssemblyMapper mapper = new(new ComparingSettings(), rightSetSize: rightCount);
             mapper.AddElement(left.Element, ElementSide.Left);
 
-            
+            string[] rightNames = new string[rightCount];
             for (int i = 0; i < rightCount; i++)
             {
                 if (right[i] == null)
@@ -131,8 +133,12 @@ namespace Microsoft.DotNet.ApiCompatibility
                     throw new ArgumentNullException(nameof(right), string.Format(Resources.ElementShouldNotBeNullAtIndex, i));
                 }
 
-                mapper.AddElement(right[i].Element, ElementSide.Right, i);
+                ElementContainer<IAssemblySymbol> element = right[i];
+                rightNames[i] = element.MetadataInformation.AssemblyId;
+                mapper.AddElement(element.Element, ElementSide.Right, i);
             }
+
+            mapper.Settings = GetComparingSettingsCore(left.MetadataInformation.AssemblyId, rightNames);
 
             DifferenceVisitor visitor = new(rightCount: rightCount, noWarn: NoWarn, ignoredDifferences: IgnoredDifferences);
             visitor.Visit(mapper);
@@ -149,12 +155,12 @@ namespace Microsoft.DotNet.ApiCompatibility
             return result;
         }
 
-        private ComparingSettings GetComparingSettingsCore()
+        private ComparingSettings GetComparingSettingsCore(string leftName, string[] rightNames)
         {
             if (GetComparingSettings != null)
-                return GetComparingSettings();
+                return GetComparingSettings(leftName, rightNames);
 
-            return new ComparingSettings(filter: new SymbolAccessibilityBasedFilter(IncludeInternalSymbols), strictMode: StrictMode);
+            return new ComparingSettings(filter: new SymbolAccessibilityBasedFilter(IncludeInternalSymbols), strictMode: StrictMode, leftName: leftName, rightNames: rightNames);
         }
     }
 }

--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/ComparingSettings.cs
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/ComparingSettings.cs
@@ -4,6 +4,7 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.DotNet.ApiCompatibility.Abstractions;
 using Microsoft.DotNet.ApiCompatibility.Rules;
+using System;
 using System.Collections.Generic;
 
 namespace Microsoft.DotNet.ApiCompatibility
@@ -34,9 +35,9 @@ namespace Microsoft.DotNet.ApiCompatibility
         /// <param name="ruleRunnerFactory">The factory to create a <see cref="IRuleRunner"/></param>
         /// <param name="filter">The symbol filter.</param>
         /// <param name="equalityComparer">The comparer to map metadata.</param>
-        public ComparingSettings(IRuleRunnerFactory ruleRunnerFactory = null, ISymbolFilter filter = null, IEqualityComparer<ISymbol> equalityComparer = null, bool strictMode = false)
+        public ComparingSettings(IRuleRunnerFactory ruleRunnerFactory = null, ISymbolFilter filter = null, IEqualityComparer<ISymbol> equalityComparer = null, bool strictMode = false, string leftName = null, string[] rightNames = null)
         {
-            RuleRunnerFactory = ruleRunnerFactory ?? new RuleRunnerFactory(strictMode);
+            RuleRunnerFactory = ruleRunnerFactory ?? new RuleRunnerFactory(leftName, rightNames, strictMode: strictMode);
             Filter = filter ?? new SymbolAccessibilityBasedFilter(includeInternalSymbols: false);
             EqualityComparer = equalityComparer ?? new DefaultSymbolsEqualityComparer();
         }

--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/Resources.resx
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/Resources.resx
@@ -136,13 +136,16 @@
     <value>Could not find matching assembly: '{0}' in any of the search directories.</value>
   </data>
   <data name="MemberExistsOnLeft" xml:space="preserve">
-    <value>Member '{0}' exists on the left but not on the right</value>
+    <value>Member '{0}' exists on {1} but not on {2}</value>
   </data>
   <data name="ProvidedPathToLoadBinariesFromNotFound" xml:space="preserve">
     <value>Could not find the provided path '{0}' to load binaries from.</value>
   </data>
   <data name="ProvidedStreamDoesNotHaveMetadata" xml:space="preserve">
     <value>Provided stream for assembly '{0}' doesn't have any metadata to read. from.</value>
+  </data>
+  <data name="RightNamesAtLeastOne" xml:space="preserve">
+    <value>Should at least contain one right name.</value>
   </data>
   <data name="ShouldBeGreaterThanZero" xml:space="preserve">
     <value>Value should be greater than 0.</value>
@@ -157,10 +160,10 @@
     <value>Stream position is greater than it's length, so there are no contents available to read.</value>
   </data>
   <data name="TypeExistsOnLeft" xml:space="preserve">
-    <value>Type '{0}' exists on the left but not on the right</value>
+    <value>Type '{0}' exists on {1} but not on {2}</value>
   </data>
   <data name="TypeExistsOnRight" xml:space="preserve">
-    <value>Type '{0}' exists on the right but not on the left</value>
+    <value>Type '{0}' exists on {2} but not on {1}</value>
   </data>
   <data name="VisitorRightCountShouldMatchMappersSetSize" xml:space="preserve">
     <value>The provided right count when creating the visitor should match the right set size specified for the mappers.</value>

--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/Rules/MembersMustExist.cs
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/Rules/MembersMustExist.cs
@@ -31,7 +31,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
         /// </summary>
         /// <param name="mapper">The <see cref="TypeMapper"/> to evaluate.</param>
         /// <param name="differences">The list of <see cref="CompatDifference"/> to add differences to.</param>
-        private void RunOnTypeSymbol(ITypeSymbol left, ITypeSymbol right, IList<CompatDifference> differences)
+        private void RunOnTypeSymbol(ITypeSymbol left, ITypeSymbol right, string leftName, string rightName, IList<CompatDifference> differences)
         {
             if (left != null && right == null)
             {
@@ -45,7 +45,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             void AddDifference(ITypeSymbol symbol, DifferenceType type, string format)
             {
-                differences.Add(new CompatDifference(DiagnosticIds.TypeMustExist, string.Format(format, symbol.ToDisplayString()), type, symbol));
+                differences.Add(new CompatDifference(DiagnosticIds.TypeMustExist, string.Format(format, symbol.ToDisplayString(), leftName, rightName), type, symbol));
             }
         }
 
@@ -54,7 +54,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
         /// </summary>
         /// <param name="mapper">The <see cref="MemberMapper"/> to evaluate.</param>
         /// <param name="differences">The list of <see cref="CompatDifference"/> to add differences to.</param>
-        private void RunOnMemberSymbol(ISymbol left, ISymbol right, IList<CompatDifference> differences)
+        private void RunOnMemberSymbol(ISymbol left, ISymbol right, string leftName, string rightName, IList<CompatDifference> differences)
         {
             if (left != null && right == null)
             {
@@ -73,7 +73,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
                         return;
                 }
 
-                differences.Add(new CompatDifference(DiagnosticIds.MemberMustExist, string.Format(Resources.MemberExistsOnLeft, left.ToDisplayString()), DifferenceType.Removed, left));
+                differences.Add(new CompatDifference(DiagnosticIds.MemberMustExist, string.Format(Resources.MemberExistsOnLeft, left.ToDisplayString(), leftName, rightName), DifferenceType.Removed, left));
             }
         }
 

--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/Rules/RuleRunner.cs
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/Rules/RuleRunner.cs
@@ -12,11 +12,18 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
     {
         private readonly RuleRunnerContext _context;
         private readonly RuleSettings _settings;
+        private readonly string _leftName;
+        private readonly string[] _rightNames;
 
-        internal RuleRunner(bool strictMode)
+        internal const string DEFAULT_LEFT_NAME = "left";
+        internal const string DEFAULT_RIGHT_NAME = "right";
+
+        internal RuleRunner(string leftName, string[] rightNames, bool strictMode)
         {
             _context = new RuleRunnerContext();
             _settings = new RuleSettings(strictMode);
+            _leftName = leftName;
+            _rightNames = rightNames;
             InitializeRules();
         }
 
@@ -38,21 +45,23 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
 
             void RunOnMapper(int rightIndex)
             {
+                string leftName = _leftName;
+                string rightName = rightIndex < _rightNames.Length ? _rightNames[rightIndex] : DEFAULT_RIGHT_NAME;
                 List<CompatDifference> differences = new();
                 T right = mapper.Right[rightIndex];
                 if (mapper is AssemblyMapper)
                 {
-                    _context.RunOnAssemblySymbolActions((IAssemblySymbol)mapper.Left, (IAssemblySymbol)right, differences);
+                    _context.RunOnAssemblySymbolActions((IAssemblySymbol)mapper.Left, (IAssemblySymbol)right, leftName, rightName, differences);
                 }
                 else if (mapper is TypeMapper tm)
                 {
                     if (tm.ShouldDiffElement(rightIndex))
-                        _context.RunOnTypeSymbolActions((ITypeSymbol)mapper.Left, (ITypeSymbol)right, differences);
+                        _context.RunOnTypeSymbolActions((ITypeSymbol)mapper.Left, (ITypeSymbol)right, leftName, rightName, differences);
                 }
                 else if (mapper is MemberMapper mm)
                 {
                     if (mm.ShouldDiffElement(rightIndex))
-                        _context.RunOnMemberSymbolActions((ISymbol)mapper.Left, (ISymbol)right, differences);
+                        _context.RunOnMemberSymbolActions((ISymbol)mapper.Left, (ISymbol)right, leftName, rightName, differences);
                 }
                 result.Add(differences);
             }

--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/Rules/RuleRunnerContext.cs
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/Rules/RuleRunnerContext.cs
@@ -14,15 +14,15 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
     /// </summary>
     public class RuleRunnerContext
     {
-        private readonly List<Action<IAssemblySymbol, IAssemblySymbol, IList<CompatDifference>>> _onAssemblySymbolActions = new();
-        private readonly List<Action<ITypeSymbol, ITypeSymbol, IList<CompatDifference>>> _onTypeSymbolActions = new();
-        private readonly List<Action<ISymbol, ISymbol, IList<CompatDifference>>> _onMemberSymbolActions = new();
+        private readonly List<Action<IAssemblySymbol, IAssemblySymbol, string, string, IList<CompatDifference>>> _onAssemblySymbolActions = new();
+        private readonly List<Action<ITypeSymbol, ITypeSymbol, string, string, IList<CompatDifference>>> _onTypeSymbolActions = new();
+        private readonly List<Action<ISymbol, ISymbol, string, string, IList<CompatDifference>>> _onMemberSymbolActions = new();
 
         /// <summary>
         /// Registers a callback to invoke when two <see cref="IAssemblySymbol"/> are compared.
         /// </summary>
         /// <param name="action">The action to invoke.</param>
-        public void RegisterOnAssemblySymbolAction(Action<IAssemblySymbol, IAssemblySymbol, IList<CompatDifference>> action)
+        public void RegisterOnAssemblySymbolAction(Action<IAssemblySymbol, IAssemblySymbol, string, string, IList<CompatDifference>> action)
         {
             _onAssemblySymbolActions.Add(action);
         }
@@ -31,7 +31,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
         /// Registers a callback to invoke when two <see cref="ITypeSymbol"/> are compared.
         /// </summary>
         /// <param name="action">The action to invoke.</param>
-        public void RegisterOnTypeSymbolAction(Action<ITypeSymbol, ITypeSymbol, IList<CompatDifference>> action)
+        public void RegisterOnTypeSymbolAction(Action<ITypeSymbol, ITypeSymbol, string, string, IList<CompatDifference>> action)
         {
             _onTypeSymbolActions.Add(action);
         }
@@ -40,32 +40,32 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
         /// Registers a callback to invoke when two <see cref="ISymbol"/> members of a <see cref="ITypeSymbol"/> are compared.
         /// </summary>
         /// <param name="action">The action to invoke.</param>
-        public void RegisterOnMemberSymbolAction(Action<ISymbol, ISymbol, IList<CompatDifference>> action)
+        public void RegisterOnMemberSymbolAction(Action<ISymbol, ISymbol, string, string, IList<CompatDifference>> action)
         {
             _onMemberSymbolActions.Add(action);
         }
 
-        internal void RunOnAssemblySymbolActions(IAssemblySymbol left, IAssemblySymbol right, List<CompatDifference> differences)
+        internal void RunOnAssemblySymbolActions(IAssemblySymbol left, IAssemblySymbol right, string leftName, string rightName, List<CompatDifference> differences)
         {
-            foreach (Action<IAssemblySymbol, IAssemblySymbol, IList<CompatDifference>> action in _onAssemblySymbolActions)
+            foreach (Action<IAssemblySymbol, IAssemblySymbol, string, string, IList<CompatDifference>> action in _onAssemblySymbolActions)
             {
-                action(left, right, differences);
+                action(left, right, leftName, rightName, differences);
             }
         }
 
-        internal void RunOnTypeSymbolActions(ITypeSymbol left, ITypeSymbol right, List<CompatDifference> differences)
+        internal void RunOnTypeSymbolActions(ITypeSymbol left, ITypeSymbol right, string leftName, string rightName, List<CompatDifference> differences)
         {
-            foreach (Action<ITypeSymbol, ITypeSymbol, IList<CompatDifference>> action in _onTypeSymbolActions)
+            foreach (Action<ITypeSymbol, ITypeSymbol, string, string, IList<CompatDifference>> action in _onTypeSymbolActions)
             {
-                action(left, right, differences);
+                action(left, right, leftName, rightName, differences);
             }
         }
 
-        internal void RunOnMemberSymbolActions(ISymbol left, ISymbol right, List<CompatDifference> differences)
+        internal void RunOnMemberSymbolActions(ISymbol left, ISymbol right, string leftName, string rightName, List<CompatDifference> differences)
         {
-            foreach (Action<ISymbol, ISymbol, IList<CompatDifference>> action in _onMemberSymbolActions)
+            foreach (Action<ISymbol, ISymbol, string, string, IList<CompatDifference>> action in _onMemberSymbolActions)
             {
-                action(left, right, differences);
+                action(left, right, leftName, rightName, differences);
             }
         }
     }

--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/Rules/RuleRunnerFactory.cs
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/Rules/RuleRunnerFactory.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.s
 
+using System;
 using Microsoft.DotNet.ApiCompatibility.Abstractions;
 
 namespace Microsoft.DotNet.ApiCompatibility.Rules
@@ -8,19 +9,41 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
     public class RuleRunnerFactory : IRuleRunnerFactory
     {
         private readonly bool _strictMode;
-        private RuleRunner _driver;
+        private readonly string _leftName;
+        private readonly string[] _rightNames;
+        private RuleRunner _runner;
 
-        public RuleRunnerFactory(bool strictMode = false)
+        public RuleRunnerFactory(string leftName, string[] rightNames, bool strictMode = false)
         {
             _strictMode = strictMode;
+            _leftName = string.IsNullOrEmpty(leftName) ? RuleRunner.DEFAULT_LEFT_NAME : leftName;
+            _rightNames = rightNames ?? new string[] { RuleRunner.DEFAULT_RIGHT_NAME };
+
+            if (_rightNames.Length <= 0)
+            {
+                throw new ArgumentException(nameof(rightNames), Resources.RightNamesAtLeastOne);
+            }
+
+            InitializeRightNamesIfNeeded();
+        }
+
+        private void InitializeRightNamesIfNeeded()
+        {
+            for (int i = 0; i < _rightNames.Length; i++)
+            {
+                if (string.IsNullOrEmpty(_rightNames[i]))
+                {
+                    _rightNames[i] = RuleRunner.DEFAULT_RIGHT_NAME;
+                }
+            }
         }
 
         public IRuleRunner GetRuleRunner()
         {
-            if (_driver == null)
-                _driver = new RuleRunner(_strictMode);
+            if (_runner == null)
+                _runner = new RuleRunner(_leftName, _rightNames, _strictMode);
 
-            return _driver;
+            return _runner;
         }
     }
 }

--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Resources.cs.xlf
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Resources.cs.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="MemberExistsOnLeft">
-        <source>Member '{0}' exists on the left but not on the right</source>
-        <target state="new">Member '{0}' exists on the left but not on the right</target>
+        <source>Member '{0}' exists on {1} but not on {2}</source>
+        <target state="new">Member '{0}' exists on {1} but not on {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="ProvidedPathToLoadBinariesFromNotFound">
@@ -45,6 +45,11 @@
       <trans-unit id="ProvidedStreamDoesNotHaveMetadata">
         <source>Provided stream for assembly '{0}' doesn't have any metadata to read. from.</source>
         <target state="new">Provided stream for assembly '{0}' doesn't have any metadata to read. from.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RightNamesAtLeastOne">
+        <source>Should at least contain one right name.</source>
+        <target state="new">Should at least contain one right name.</target>
         <note />
       </trans-unit>
       <trans-unit id="ShouldBeGreaterThanZero">
@@ -68,13 +73,13 @@
         <note />
       </trans-unit>
       <trans-unit id="TypeExistsOnLeft">
-        <source>Type '{0}' exists on the left but not on the right</source>
-        <target state="new">Type '{0}' exists on the left but not on the right</target>
+        <source>Type '{0}' exists on {1} but not on {2}</source>
+        <target state="new">Type '{0}' exists on {1} but not on {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="TypeExistsOnRight">
-        <source>Type '{0}' exists on the right but not on the left</source>
-        <target state="new">Type '{0}' exists on the right but not on the left</target>
+        <source>Type '{0}' exists on {2} but not on {1}</source>
+        <target state="new">Type '{0}' exists on {2} but not on {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="VisitorRightCountShouldMatchMappersSetSize">

--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Resources.de.xlf
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Resources.de.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="MemberExistsOnLeft">
-        <source>Member '{0}' exists on the left but not on the right</source>
-        <target state="new">Member '{0}' exists on the left but not on the right</target>
+        <source>Member '{0}' exists on {1} but not on {2}</source>
+        <target state="new">Member '{0}' exists on {1} but not on {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="ProvidedPathToLoadBinariesFromNotFound">
@@ -45,6 +45,11 @@
       <trans-unit id="ProvidedStreamDoesNotHaveMetadata">
         <source>Provided stream for assembly '{0}' doesn't have any metadata to read. from.</source>
         <target state="new">Provided stream for assembly '{0}' doesn't have any metadata to read. from.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RightNamesAtLeastOne">
+        <source>Should at least contain one right name.</source>
+        <target state="new">Should at least contain one right name.</target>
         <note />
       </trans-unit>
       <trans-unit id="ShouldBeGreaterThanZero">
@@ -68,13 +73,13 @@
         <note />
       </trans-unit>
       <trans-unit id="TypeExistsOnLeft">
-        <source>Type '{0}' exists on the left but not on the right</source>
-        <target state="new">Type '{0}' exists on the left but not on the right</target>
+        <source>Type '{0}' exists on {1} but not on {2}</source>
+        <target state="new">Type '{0}' exists on {1} but not on {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="TypeExistsOnRight">
-        <source>Type '{0}' exists on the right but not on the left</source>
-        <target state="new">Type '{0}' exists on the right but not on the left</target>
+        <source>Type '{0}' exists on {2} but not on {1}</source>
+        <target state="new">Type '{0}' exists on {2} but not on {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="VisitorRightCountShouldMatchMappersSetSize">

--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Resources.es.xlf
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Resources.es.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="MemberExistsOnLeft">
-        <source>Member '{0}' exists on the left but not on the right</source>
-        <target state="new">Member '{0}' exists on the left but not on the right</target>
+        <source>Member '{0}' exists on {1} but not on {2}</source>
+        <target state="new">Member '{0}' exists on {1} but not on {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="ProvidedPathToLoadBinariesFromNotFound">
@@ -45,6 +45,11 @@
       <trans-unit id="ProvidedStreamDoesNotHaveMetadata">
         <source>Provided stream for assembly '{0}' doesn't have any metadata to read. from.</source>
         <target state="new">Provided stream for assembly '{0}' doesn't have any metadata to read. from.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RightNamesAtLeastOne">
+        <source>Should at least contain one right name.</source>
+        <target state="new">Should at least contain one right name.</target>
         <note />
       </trans-unit>
       <trans-unit id="ShouldBeGreaterThanZero">
@@ -68,13 +73,13 @@
         <note />
       </trans-unit>
       <trans-unit id="TypeExistsOnLeft">
-        <source>Type '{0}' exists on the left but not on the right</source>
-        <target state="new">Type '{0}' exists on the left but not on the right</target>
+        <source>Type '{0}' exists on {1} but not on {2}</source>
+        <target state="new">Type '{0}' exists on {1} but not on {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="TypeExistsOnRight">
-        <source>Type '{0}' exists on the right but not on the left</source>
-        <target state="new">Type '{0}' exists on the right but not on the left</target>
+        <source>Type '{0}' exists on {2} but not on {1}</source>
+        <target state="new">Type '{0}' exists on {2} but not on {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="VisitorRightCountShouldMatchMappersSetSize">

--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Resources.fr.xlf
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Resources.fr.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="MemberExistsOnLeft">
-        <source>Member '{0}' exists on the left but not on the right</source>
-        <target state="new">Member '{0}' exists on the left but not on the right</target>
+        <source>Member '{0}' exists on {1} but not on {2}</source>
+        <target state="new">Member '{0}' exists on {1} but not on {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="ProvidedPathToLoadBinariesFromNotFound">
@@ -45,6 +45,11 @@
       <trans-unit id="ProvidedStreamDoesNotHaveMetadata">
         <source>Provided stream for assembly '{0}' doesn't have any metadata to read. from.</source>
         <target state="new">Provided stream for assembly '{0}' doesn't have any metadata to read. from.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RightNamesAtLeastOne">
+        <source>Should at least contain one right name.</source>
+        <target state="new">Should at least contain one right name.</target>
         <note />
       </trans-unit>
       <trans-unit id="ShouldBeGreaterThanZero">
@@ -68,13 +73,13 @@
         <note />
       </trans-unit>
       <trans-unit id="TypeExistsOnLeft">
-        <source>Type '{0}' exists on the left but not on the right</source>
-        <target state="new">Type '{0}' exists on the left but not on the right</target>
+        <source>Type '{0}' exists on {1} but not on {2}</source>
+        <target state="new">Type '{0}' exists on {1} but not on {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="TypeExistsOnRight">
-        <source>Type '{0}' exists on the right but not on the left</source>
-        <target state="new">Type '{0}' exists on the right but not on the left</target>
+        <source>Type '{0}' exists on {2} but not on {1}</source>
+        <target state="new">Type '{0}' exists on {2} but not on {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="VisitorRightCountShouldMatchMappersSetSize">

--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Resources.it.xlf
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Resources.it.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="MemberExistsOnLeft">
-        <source>Member '{0}' exists on the left but not on the right</source>
-        <target state="new">Member '{0}' exists on the left but not on the right</target>
+        <source>Member '{0}' exists on {1} but not on {2}</source>
+        <target state="new">Member '{0}' exists on {1} but not on {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="ProvidedPathToLoadBinariesFromNotFound">
@@ -45,6 +45,11 @@
       <trans-unit id="ProvidedStreamDoesNotHaveMetadata">
         <source>Provided stream for assembly '{0}' doesn't have any metadata to read. from.</source>
         <target state="new">Provided stream for assembly '{0}' doesn't have any metadata to read. from.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RightNamesAtLeastOne">
+        <source>Should at least contain one right name.</source>
+        <target state="new">Should at least contain one right name.</target>
         <note />
       </trans-unit>
       <trans-unit id="ShouldBeGreaterThanZero">
@@ -68,13 +73,13 @@
         <note />
       </trans-unit>
       <trans-unit id="TypeExistsOnLeft">
-        <source>Type '{0}' exists on the left but not on the right</source>
-        <target state="new">Type '{0}' exists on the left but not on the right</target>
+        <source>Type '{0}' exists on {1} but not on {2}</source>
+        <target state="new">Type '{0}' exists on {1} but not on {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="TypeExistsOnRight">
-        <source>Type '{0}' exists on the right but not on the left</source>
-        <target state="new">Type '{0}' exists on the right but not on the left</target>
+        <source>Type '{0}' exists on {2} but not on {1}</source>
+        <target state="new">Type '{0}' exists on {2} but not on {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="VisitorRightCountShouldMatchMappersSetSize">

--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Resources.ja.xlf
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Resources.ja.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="MemberExistsOnLeft">
-        <source>Member '{0}' exists on the left but not on the right</source>
-        <target state="new">Member '{0}' exists on the left but not on the right</target>
+        <source>Member '{0}' exists on {1} but not on {2}</source>
+        <target state="new">Member '{0}' exists on {1} but not on {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="ProvidedPathToLoadBinariesFromNotFound">
@@ -45,6 +45,11 @@
       <trans-unit id="ProvidedStreamDoesNotHaveMetadata">
         <source>Provided stream for assembly '{0}' doesn't have any metadata to read. from.</source>
         <target state="new">Provided stream for assembly '{0}' doesn't have any metadata to read. from.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RightNamesAtLeastOne">
+        <source>Should at least contain one right name.</source>
+        <target state="new">Should at least contain one right name.</target>
         <note />
       </trans-unit>
       <trans-unit id="ShouldBeGreaterThanZero">
@@ -68,13 +73,13 @@
         <note />
       </trans-unit>
       <trans-unit id="TypeExistsOnLeft">
-        <source>Type '{0}' exists on the left but not on the right</source>
-        <target state="new">Type '{0}' exists on the left but not on the right</target>
+        <source>Type '{0}' exists on {1} but not on {2}</source>
+        <target state="new">Type '{0}' exists on {1} but not on {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="TypeExistsOnRight">
-        <source>Type '{0}' exists on the right but not on the left</source>
-        <target state="new">Type '{0}' exists on the right but not on the left</target>
+        <source>Type '{0}' exists on {2} but not on {1}</source>
+        <target state="new">Type '{0}' exists on {2} but not on {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="VisitorRightCountShouldMatchMappersSetSize">

--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Resources.ko.xlf
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Resources.ko.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="MemberExistsOnLeft">
-        <source>Member '{0}' exists on the left but not on the right</source>
-        <target state="new">Member '{0}' exists on the left but not on the right</target>
+        <source>Member '{0}' exists on {1} but not on {2}</source>
+        <target state="new">Member '{0}' exists on {1} but not on {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="ProvidedPathToLoadBinariesFromNotFound">
@@ -45,6 +45,11 @@
       <trans-unit id="ProvidedStreamDoesNotHaveMetadata">
         <source>Provided stream for assembly '{0}' doesn't have any metadata to read. from.</source>
         <target state="new">Provided stream for assembly '{0}' doesn't have any metadata to read. from.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RightNamesAtLeastOne">
+        <source>Should at least contain one right name.</source>
+        <target state="new">Should at least contain one right name.</target>
         <note />
       </trans-unit>
       <trans-unit id="ShouldBeGreaterThanZero">
@@ -68,13 +73,13 @@
         <note />
       </trans-unit>
       <trans-unit id="TypeExistsOnLeft">
-        <source>Type '{0}' exists on the left but not on the right</source>
-        <target state="new">Type '{0}' exists on the left but not on the right</target>
+        <source>Type '{0}' exists on {1} but not on {2}</source>
+        <target state="new">Type '{0}' exists on {1} but not on {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="TypeExistsOnRight">
-        <source>Type '{0}' exists on the right but not on the left</source>
-        <target state="new">Type '{0}' exists on the right but not on the left</target>
+        <source>Type '{0}' exists on {2} but not on {1}</source>
+        <target state="new">Type '{0}' exists on {2} but not on {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="VisitorRightCountShouldMatchMappersSetSize">

--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Resources.pl.xlf
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Resources.pl.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="MemberExistsOnLeft">
-        <source>Member '{0}' exists on the left but not on the right</source>
-        <target state="new">Member '{0}' exists on the left but not on the right</target>
+        <source>Member '{0}' exists on {1} but not on {2}</source>
+        <target state="new">Member '{0}' exists on {1} but not on {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="ProvidedPathToLoadBinariesFromNotFound">
@@ -45,6 +45,11 @@
       <trans-unit id="ProvidedStreamDoesNotHaveMetadata">
         <source>Provided stream for assembly '{0}' doesn't have any metadata to read. from.</source>
         <target state="new">Provided stream for assembly '{0}' doesn't have any metadata to read. from.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RightNamesAtLeastOne">
+        <source>Should at least contain one right name.</source>
+        <target state="new">Should at least contain one right name.</target>
         <note />
       </trans-unit>
       <trans-unit id="ShouldBeGreaterThanZero">
@@ -68,13 +73,13 @@
         <note />
       </trans-unit>
       <trans-unit id="TypeExistsOnLeft">
-        <source>Type '{0}' exists on the left but not on the right</source>
-        <target state="new">Type '{0}' exists on the left but not on the right</target>
+        <source>Type '{0}' exists on {1} but not on {2}</source>
+        <target state="new">Type '{0}' exists on {1} but not on {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="TypeExistsOnRight">
-        <source>Type '{0}' exists on the right but not on the left</source>
-        <target state="new">Type '{0}' exists on the right but not on the left</target>
+        <source>Type '{0}' exists on {2} but not on {1}</source>
+        <target state="new">Type '{0}' exists on {2} but not on {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="VisitorRightCountShouldMatchMappersSetSize">

--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Resources.pt-BR.xlf
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Resources.pt-BR.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="MemberExistsOnLeft">
-        <source>Member '{0}' exists on the left but not on the right</source>
-        <target state="new">Member '{0}' exists on the left but not on the right</target>
+        <source>Member '{0}' exists on {1} but not on {2}</source>
+        <target state="new">Member '{0}' exists on {1} but not on {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="ProvidedPathToLoadBinariesFromNotFound">
@@ -45,6 +45,11 @@
       <trans-unit id="ProvidedStreamDoesNotHaveMetadata">
         <source>Provided stream for assembly '{0}' doesn't have any metadata to read. from.</source>
         <target state="new">Provided stream for assembly '{0}' doesn't have any metadata to read. from.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RightNamesAtLeastOne">
+        <source>Should at least contain one right name.</source>
+        <target state="new">Should at least contain one right name.</target>
         <note />
       </trans-unit>
       <trans-unit id="ShouldBeGreaterThanZero">
@@ -68,13 +73,13 @@
         <note />
       </trans-unit>
       <trans-unit id="TypeExistsOnLeft">
-        <source>Type '{0}' exists on the left but not on the right</source>
-        <target state="new">Type '{0}' exists on the left but not on the right</target>
+        <source>Type '{0}' exists on {1} but not on {2}</source>
+        <target state="new">Type '{0}' exists on {1} but not on {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="TypeExistsOnRight">
-        <source>Type '{0}' exists on the right but not on the left</source>
-        <target state="new">Type '{0}' exists on the right but not on the left</target>
+        <source>Type '{0}' exists on {2} but not on {1}</source>
+        <target state="new">Type '{0}' exists on {2} but not on {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="VisitorRightCountShouldMatchMappersSetSize">

--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Resources.ru.xlf
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Resources.ru.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="MemberExistsOnLeft">
-        <source>Member '{0}' exists on the left but not on the right</source>
-        <target state="new">Member '{0}' exists on the left but not on the right</target>
+        <source>Member '{0}' exists on {1} but not on {2}</source>
+        <target state="new">Member '{0}' exists on {1} but not on {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="ProvidedPathToLoadBinariesFromNotFound">
@@ -45,6 +45,11 @@
       <trans-unit id="ProvidedStreamDoesNotHaveMetadata">
         <source>Provided stream for assembly '{0}' doesn't have any metadata to read. from.</source>
         <target state="new">Provided stream for assembly '{0}' doesn't have any metadata to read. from.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RightNamesAtLeastOne">
+        <source>Should at least contain one right name.</source>
+        <target state="new">Should at least contain one right name.</target>
         <note />
       </trans-unit>
       <trans-unit id="ShouldBeGreaterThanZero">
@@ -68,13 +73,13 @@
         <note />
       </trans-unit>
       <trans-unit id="TypeExistsOnLeft">
-        <source>Type '{0}' exists on the left but not on the right</source>
-        <target state="new">Type '{0}' exists on the left but not on the right</target>
+        <source>Type '{0}' exists on {1} but not on {2}</source>
+        <target state="new">Type '{0}' exists on {1} but not on {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="TypeExistsOnRight">
-        <source>Type '{0}' exists on the right but not on the left</source>
-        <target state="new">Type '{0}' exists on the right but not on the left</target>
+        <source>Type '{0}' exists on {2} but not on {1}</source>
+        <target state="new">Type '{0}' exists on {2} but not on {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="VisitorRightCountShouldMatchMappersSetSize">

--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Resources.tr.xlf
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Resources.tr.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="MemberExistsOnLeft">
-        <source>Member '{0}' exists on the left but not on the right</source>
-        <target state="new">Member '{0}' exists on the left but not on the right</target>
+        <source>Member '{0}' exists on {1} but not on {2}</source>
+        <target state="new">Member '{0}' exists on {1} but not on {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="ProvidedPathToLoadBinariesFromNotFound">
@@ -45,6 +45,11 @@
       <trans-unit id="ProvidedStreamDoesNotHaveMetadata">
         <source>Provided stream for assembly '{0}' doesn't have any metadata to read. from.</source>
         <target state="new">Provided stream for assembly '{0}' doesn't have any metadata to read. from.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RightNamesAtLeastOne">
+        <source>Should at least contain one right name.</source>
+        <target state="new">Should at least contain one right name.</target>
         <note />
       </trans-unit>
       <trans-unit id="ShouldBeGreaterThanZero">
@@ -68,13 +73,13 @@
         <note />
       </trans-unit>
       <trans-unit id="TypeExistsOnLeft">
-        <source>Type '{0}' exists on the left but not on the right</source>
-        <target state="new">Type '{0}' exists on the left but not on the right</target>
+        <source>Type '{0}' exists on {1} but not on {2}</source>
+        <target state="new">Type '{0}' exists on {1} but not on {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="TypeExistsOnRight">
-        <source>Type '{0}' exists on the right but not on the left</source>
-        <target state="new">Type '{0}' exists on the right but not on the left</target>
+        <source>Type '{0}' exists on {2} but not on {1}</source>
+        <target state="new">Type '{0}' exists on {2} but not on {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="VisitorRightCountShouldMatchMappersSetSize">

--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Resources.zh-Hans.xlf
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Resources.zh-Hans.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="MemberExistsOnLeft">
-        <source>Member '{0}' exists on the left but not on the right</source>
-        <target state="new">Member '{0}' exists on the left but not on the right</target>
+        <source>Member '{0}' exists on {1} but not on {2}</source>
+        <target state="new">Member '{0}' exists on {1} but not on {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="ProvidedPathToLoadBinariesFromNotFound">
@@ -45,6 +45,11 @@
       <trans-unit id="ProvidedStreamDoesNotHaveMetadata">
         <source>Provided stream for assembly '{0}' doesn't have any metadata to read. from.</source>
         <target state="new">Provided stream for assembly '{0}' doesn't have any metadata to read. from.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RightNamesAtLeastOne">
+        <source>Should at least contain one right name.</source>
+        <target state="new">Should at least contain one right name.</target>
         <note />
       </trans-unit>
       <trans-unit id="ShouldBeGreaterThanZero">
@@ -68,13 +73,13 @@
         <note />
       </trans-unit>
       <trans-unit id="TypeExistsOnLeft">
-        <source>Type '{0}' exists on the left but not on the right</source>
-        <target state="new">Type '{0}' exists on the left but not on the right</target>
+        <source>Type '{0}' exists on {1} but not on {2}</source>
+        <target state="new">Type '{0}' exists on {1} but not on {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="TypeExistsOnRight">
-        <source>Type '{0}' exists on the right but not on the left</source>
-        <target state="new">Type '{0}' exists on the right but not on the left</target>
+        <source>Type '{0}' exists on {2} but not on {1}</source>
+        <target state="new">Type '{0}' exists on {2} but not on {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="VisitorRightCountShouldMatchMappersSetSize">

--- a/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Resources.zh-Hant.xlf
+++ b/src/Compatibility/Microsoft.DotNet.ApiCompatibility/xlf/Resources.zh-Hant.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="MemberExistsOnLeft">
-        <source>Member '{0}' exists on the left but not on the right</source>
-        <target state="new">Member '{0}' exists on the left but not on the right</target>
+        <source>Member '{0}' exists on {1} but not on {2}</source>
+        <target state="new">Member '{0}' exists on {1} but not on {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="ProvidedPathToLoadBinariesFromNotFound">
@@ -45,6 +45,11 @@
       <trans-unit id="ProvidedStreamDoesNotHaveMetadata">
         <source>Provided stream for assembly '{0}' doesn't have any metadata to read. from.</source>
         <target state="new">Provided stream for assembly '{0}' doesn't have any metadata to read. from.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RightNamesAtLeastOne">
+        <source>Should at least contain one right name.</source>
+        <target state="new">Should at least contain one right name.</target>
         <note />
       </trans-unit>
       <trans-unit id="ShouldBeGreaterThanZero">
@@ -68,13 +73,13 @@
         <note />
       </trans-unit>
       <trans-unit id="TypeExistsOnLeft">
-        <source>Type '{0}' exists on the left but not on the right</source>
-        <target state="new">Type '{0}' exists on the left but not on the right</target>
+        <source>Type '{0}' exists on {1} but not on {2}</source>
+        <target state="new">Type '{0}' exists on {1} but not on {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="TypeExistsOnRight">
-        <source>Type '{0}' exists on the right but not on the left</source>
-        <target state="new">Type '{0}' exists on the right but not on the left</target>
+        <source>Type '{0}' exists on {2} but not on {1}</source>
+        <target state="new">Type '{0}' exists on {2} but not on {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="VisitorRightCountShouldMatchMappersSetSize">

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/ApiCompatRunner.cs
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/ApiCompatRunner.cs
@@ -45,7 +45,7 @@ namespace Microsoft.DotNet.PackageValidation
 
                     _log.LogMessage(MessageImportance.Low, apicompatTuples.header);
 
-                    IEnumerable<CompatDifference> differences = _differ.GetDifferences(leftSymbols, rightSymbols);
+                    IEnumerable<CompatDifference> differences = _differ.GetDifferences(leftSymbols, rightSymbols, leftName: apicompatTuples.leftAssemblyRelativePath, rightName: apicompatTuples.rightAssemblyRelativePath);
 
                     foreach (CompatDifference difference in differences)
                     {

--- a/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/CustomSideNameTests.cs
+++ b/src/Tests/Microsoft.DotNet.ApiCompatibility.Tests/CustomSideNameTests.cs
@@ -1,0 +1,192 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.DotNet.ApiCompatibility.Abstractions;
+using Xunit;
+
+namespace Microsoft.DotNet.ApiCompatibility.Tests
+{
+    public class CustomSideNameTests
+    {
+        [Fact]
+        public void CustomSideNameAreNotSpecified()
+        {
+            string leftSyntax = @"
+
+namespace CompatTests
+{
+  public class First { }
+  public class Second { }
+}
+";
+
+            string rightSyntax = @"
+namespace CompatTests
+{
+  public class First { }
+}
+";
+
+            ApiComparer differ = new();
+            bool enableNullable = false;
+            IAssemblySymbol left = SymbolFactory.GetAssemblyFromSyntax(leftSyntax, enableNullable);
+            IAssemblySymbol right = SymbolFactory.GetAssemblyFromSyntax(rightSyntax, enableNullable);
+            string expectedLeftName = "left";
+            string expectedRightName = "right";
+            IEnumerable<CompatDifference> differences = differ.GetDifferences(new[] { left }, new[] { right });
+            Assert.Single(differences);
+            AssertNames(differences.First(), expectedLeftName, expectedRightName);
+        }
+
+        [Fact]
+        public void CustomSideNamesAreUsed()
+        {
+            string leftSyntax = @"
+
+namespace CompatTests
+{
+  public class First
+  {
+    public string Method1() { }
+  }
+}
+";
+
+            string rightSyntax = @"
+namespace CompatTests
+{
+  public class First { }
+}
+";
+
+            ApiComparer differ = new();
+            bool enableNullable = false;
+            IAssemblySymbol left = SymbolFactory.GetAssemblyFromSyntax(leftSyntax, enableNullable);
+            IAssemblySymbol right = SymbolFactory.GetAssemblyFromSyntax(rightSyntax, enableNullable);
+            string expectedLeftName = "ref/net6.0/a.dll";
+            string expectedRightName = "lib/net6.0/a.dll";
+            IEnumerable<CompatDifference> differences = differ.GetDifferences(new[] { left }, new[] { right }, leftName: expectedLeftName, rightName: expectedRightName);
+            Assert.Single(differences);
+            AssertNames(differences.First(), expectedLeftName, expectedRightName);
+
+            // Use the single assembly override
+            differences = differ.GetDifferences(left, right, leftName: expectedLeftName, rightName: expectedRightName);
+            Assert.Single(differences);
+            AssertNames(differences.First(), expectedLeftName, expectedRightName);
+        }
+
+        [Fact]
+        public void MultipleRightsMetadataInformationIsUsedAsName()
+        {
+            string leftSyntax = @"
+namespace CompatTests
+{
+  public class First
+  {
+    public class FirstNested
+    {
+      public class SecondNested
+      {
+        public class ThirdNested
+        {
+          public string MyField;
+        }
+      }
+    }
+  }
+}
+";
+
+            string[] rightSyntaxes = new[]
+            { @"
+namespace CompatTests
+{
+  public class First
+  {
+    public class FirstNested
+    {
+      public class SecondNested
+      {
+        public class ThirdNested
+        {
+        }
+      }
+    }
+  }
+}
+",
+            @"
+namespace CompatTests
+{
+  public class First
+  {
+    public class FirstNested
+    {
+      public class SecondNested
+      {
+        public class ThirdNested
+        {
+        }
+      }
+    }
+  }
+}
+",
+            @"
+namespace CompatTests
+{
+  public class First
+  {
+    public class FirstNested
+    {
+      public class SecondNested
+      {
+        public class ThirdNested
+        {
+        }
+      }
+    }
+  }
+}
+"};
+
+            ApiComparer differ = new();
+            ElementContainer<IAssemblySymbol> left =
+                new(SymbolFactory.GetAssemblyFromSyntax(leftSyntax), new MetadataInformation(string.Empty, string.Empty, "ref/net6.0/a.dll"));
+
+            IList<ElementContainer<IAssemblySymbol>> right = SymbolFactory.GetElementContainersFromSyntaxes(rightSyntaxes);
+
+            IEnumerable<(MetadataInformation, MetadataInformation, IEnumerable<CompatDifference>)> differences =
+                differ.GetDifferences(left, right);
+
+            int i = 0;
+            foreach ((MetadataInformation, MetadataInformation, IEnumerable<CompatDifference> differences) diff in differences)
+            {
+                Assert.Single(diff.differences);
+                AssertNames(diff.differences.First(), left.MetadataInformation.AssemblyId, right[i++].MetadataInformation.AssemblyId);
+            }
+        }
+
+        private void AssertNames(CompatDifference difference, string expectedLeftName, string expectedRightName, bool leftFirst = true)
+        {
+            string message = difference.Message;
+
+            // make sure it is separater by a space and it is not a substr of a word.
+            string left = " " + expectedLeftName;
+            string right = " " + expectedRightName; 
+            if (leftFirst)
+            {
+                Assert.Contains(left + " ", message);
+                Assert.EndsWith(right, message);
+            }
+            else
+            {
+                Assert.Contains(right + " ", message);
+                Assert.EndsWith(left, message);
+            }
+        }
+    }
+}

--- a/src/Tests/Microsoft.DotNet.PackageValidation.Tests/CompatibleFrameworksInPackageTests.cs
+++ b/src/Tests/Microsoft.DotNet.PackageValidation.Tests/CompatibleFrameworksInPackageTests.cs
@@ -49,7 +49,8 @@ namespace PackageValidationTests
             new CompatibleFrameworkInPackageValidator(string.Empty, null, _log).Validate(package);
             Assert.NotEmpty(_log.errors);
             // TODO: add asserts for assembly and header metadata.
-            Assert.Contains("CP0002 Member 'PackageValidationTests.First.test(string)' exists on the left but not on the right", _log.errors);
+            string assemblyName = $"{asset.TestProject.Name}.dll";
+            Assert.Contains($"CP0002 Member 'PackageValidationTests.First.test(string)' exists on lib/netstandard2.0/{assemblyName} but not on lib/net5.0/{assemblyName}", _log.errors);
         }
         
         [Fact]
@@ -84,9 +85,11 @@ namespace PackageValidationTests
             Package package = NupkgParser.CreatePackage(packCommand.GetNuGetPackage(), null);
             new CompatibleFrameworkInPackageValidator(string.Empty, null, _log).Validate(package);
             Assert.NotEmpty(_log.errors);
+
+            string assemblyName = $"{asset.TestProject.Name}.dll";
             // TODO: add asserts for assembly and header metadata.
-            Assert.Contains("CP0002 Member 'PackageValidationTests.First.test(string)' exists on the left but not on the right", _log.errors);
-            Assert.Contains("CP0002 Member 'PackageValidationTests.First.test(bool)' exists on the left but not on the right", _log.errors);
+            Assert.Contains($"CP0002 Member 'PackageValidationTests.First.test(string)' exists on lib/netstandard2.0/{assemblyName} but not on lib/netcoreapp3.1/{assemblyName}", _log.errors);
+            Assert.Contains($"CP0002 Member 'PackageValidationTests.First.test(bool)' exists on lib/netcoreapp3.1/{assemblyName} but not on lib/net5.0/{assemblyName}", _log.errors);
         }
     }
 }


### PR DESCRIPTION
Port of: https://github.com/dotnet/sdk/pull/18533

## Description
Currently with Package Validation and API Compat if there is a breaking change the error would hardcode `left` and `right` instead of the path to the assemblies being compared within the package. i.e:

```
error CP002: Member 'F:A.B.C' exists on left but not on right
```

When PackageValidation uses API Compat it compares multiple assemblies within the package depending on which runtime asset applies to a compile asset, so all errors would say there is a member missing on `right` that is present on `left` when `left` and `right` could mean different things depending on the assembly. 

With this change the errors would now be shown as:
```
error CP002: Member 'F:A.B.C' exists on lib/net6.0/a.dll but not on runtimes/win-x64/a.dll
```

## Customer Impact

This makes it easier for customers to understand where the errors are and how to fix them. Also, it aligns with the error suppression which uses the assembly paths within the package to suppress these errors. 

## Testing

Added unit tests and also manually tested with sample projects.

## Risk
Low, test coverage is good and it just changes some error strings.