### PR TITLE
Change name to match spec

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.GenerateAssemblyInfo.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.GenerateAssemblyInfo.targets
@@ -37,7 +37,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <GenerateAssemblyMetadataAttributes Condition="'$(GenerateAssemblyMetadataAttributes)' == ''">true</GenerateAssemblyMetadataAttributes>
     <IncludeSourceRevisionInInformationalVersion Condition="'$(IncludeSourceRevisionInInformationalVersion)' == ''">true</IncludeSourceRevisionInInformationalVersion>
     <GenerateInternalsVisibleToAttributes Condition="'$(GenerateInternalsVisibleToAttributes)' == ''">true</GenerateInternalsVisibleToAttributes>
-    <GeneratePreviewFeaturesAttribute Condition="'$(GeneratePreviewFeaturesAttribute)' == ''">true</GeneratePreviewFeaturesAttribute>
+    <GenerateRequiresPreviewFeaturesAttribute Condition="'$(GenerateRequiresPreviewFeaturesAttribute)' == ''">true</GenerateRequiresPreviewFeaturesAttribute>
   </PropertyGroup>
 
   <!--
@@ -115,7 +115,7 @@ Copyright (c) .NET Foundation. All rights reserved.
         <_Parameter1>%(AssemblyMetadata.Identity)</_Parameter1>
         <_Parameter2>%(AssemblyMetadata.Value)</_Parameter2>
       </AssemblyAttribute>
-      <AssemblyAttribute Include="System.Runtime.Versioning.RequiresPreviewFeaturesAttribute" Condition="'$(EnablePreviewFeatures)' == 'true' and '$(GeneratePreviewFeaturesAttribute)' == 'true'">
+      <AssemblyAttribute Include="System.Runtime.Versioning.RequiresPreviewFeaturesAttribute" Condition="'$(EnablePreviewFeatures)' == 'true' and '$(GenerateRequiresPreviewFeaturesAttribute)' == 'true'">
       </AssemblyAttribute>
     </ItemGroup>
 

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToControlGeneratedAssemblyInfo.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToControlGeneratedAssemblyInfo.cs
@@ -371,9 +371,10 @@ namespace Microsoft.NET.Build.Tests
         }
 
         [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void TestPreviewFeatures(bool enablePreviewFeatures)
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, false)]
+        public void TestPreviewFeatures(bool enablePreviewFeatures, bool generateRequiresPreviewFeaturesAttribute)
         {
             const string targetFramework = "net6.0";
             var testAsset = _testAssetsManager
@@ -387,6 +388,13 @@ namespace Microsoft.NET.Build.Tests
                     project.Root.Add(
                         new XElement(ns + "PropertyGroup",
                             new XElement(ns + "EnablePreviewFeatures", $"{enablePreviewFeatures}")));
+
+                    if (enablePreviewFeatures && !generateRequiresPreviewFeaturesAttribute)
+                    {
+                        project.Root.Add(
+                            new XElement(ns + "PropertyGroup",
+                                new XElement(ns + "GenerateRequiresPreviewFeaturesAttribute", $"False")));
+                    }
                 });
 
             var buildCommand = new BuildCommand(testAsset);
@@ -410,13 +418,14 @@ namespace Microsoft.NET.Build.Tests
 
             var values = getValuesCommand.GetValues();
             var langVersion = values.FirstOrDefault() ?? string.Empty;
-            if (!enablePreviewFeatures)
+
+            if (generateRequiresPreviewFeaturesAttribute)
             {
-                Assert.False(contains);
+                Assert.True(contains);
             }
             else
             {
-                Assert.True(contains);
+                Assert.False(contains);
             }
         }
 

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToControlGeneratedAssemblyInfo.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToControlGeneratedAssemblyInfo.cs
@@ -378,7 +378,7 @@ namespace Microsoft.NET.Build.Tests
         {
             const string targetFramework = "net6.0";
             var testAsset = _testAssetsManager
-                .CopyTestAsset("HelloWorld", identifier: $"{enablePreviewFeatures}")
+                .CopyTestAsset("HelloWorld", identifier: $"{enablePreviewFeatures}${generateRequiresPreviewFeaturesAttribute}")
                 .WithSource()
                 .WithTargetFramework(targetFramework)
                 .WithProjectChanges((path, project) =>


### PR DESCRIPTION
Just changing `GeneratePreviewFeaturesAttribute` to `GenerateRequiresPreviewFeaturesAttribute` to match https://github.com/dotnet/designs/blob/main/accepted/2021/preview-features/preview-features.md#building-a-library-that-offers-preview-features. Also added a unit test.  Should be a straightforward review