### PR TITLE
Add DisablePackageBaselineValidation flag to override the packagebaselineVersion and packageBaselinePath

### DIFF
--- a/src/Assets/TestProjects/PackageValidationTestProject/PackageValidationTestProject.csproj
+++ b/src/Assets/TestProjects/PackageValidationTestProject/PackageValidationTestProject.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <DefineConstants Condition="'$(ForceValidationProblem)' == 'true'">$(DefineConstants);ForceValidationProblem</DefineConstants>
+    <DefineConstants Condition="'$(AddBreakingChange)' == 'true'">$(DefineConstants);AddBreakingChange</DefineConstants>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 

--- a/src/Assets/TestProjects/PackageValidationTestProject/Program.cs
+++ b/src/Assets/TestProjects/PackageValidationTestProject/Program.cs
@@ -14,5 +14,10 @@ namespace PackageValidationTestProject
   }
 #endif
 #endif
+#if !AddBreakingChange
+  public void SomeApiNotInLatestVersion()
+  {
+  }
+#endif
     }
 }

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/ApiCompatRunner.cs
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/ApiCompatRunner.cs
@@ -45,17 +45,18 @@ namespace Microsoft.DotNet.PackageValidation
 
                     _log.LogMessage(MessageImportance.Low, apicompatTuples.header);
 
-                    IEnumerable<CompatDifference> differences = _differ.GetDifferences(leftSymbols, rightSymbols, leftName: apicompatTuples.leftAssemblyRelativePath, rightName: apicompatTuples.rightAssemblyRelativePath);
+                    string leftName = apicompatTuples.leftAssemblyRelativePath;
+                    bool isBaselineSuppression = false;
+                    if (!apicompatTuples.leftAssemblyPackagePath.Equals(apicompatTuples.rightAssemblyPackagePath, System.StringComparison.InvariantCultureIgnoreCase))
+                    {
+                        isBaselineSuppression = true;
+                        leftName = Resources.Baseline + " " + leftName;
+                    }
+
+                    IEnumerable<CompatDifference> differences = _differ.GetDifferences(leftSymbols, rightSymbols, leftName: leftName, rightName: apicompatTuples.rightAssemblyRelativePath);
 
                     foreach (CompatDifference difference in differences)
                     {
-                        // Only include package version when comparing assets from different packages.
-                        bool isBaselineSuppression = false;
-                        if (!apicompatTuples.leftAssemblyPackagePath.Equals(apicompatTuples.rightAssemblyPackagePath, System.StringComparison.InvariantCultureIgnoreCase))
-                        {
-                            isBaselineSuppression = true;
-                        }
-
                         _log.LogError(
                             new Suppression
                             {

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/Resources.resx
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/Resources.resx
@@ -159,4 +159,7 @@
   <data name="WroteSuppressions" xml:space="preserve">
     <value>Successfully wrote compatibility suppressions to '{0}'.</value>
   </data>
+  <data name="Baseline" xml:space="preserve">
+    <value>[Baseline]</value>
+  </data>
 </root>

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/ValidatePackage.cs
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/ValidatePackage.cs
@@ -23,6 +23,8 @@ namespace Microsoft.DotNet.PackageValidation
 
         public string BaselinePackageTargetPath { get; set; }
 
+        public bool DisablePackageBaselineValidation { get; set; }
+
         public bool GenerateCompatibilitySuppressionFile { get; set; }
 
         public string CompatibilitySuppressionFilePath { get; set; }
@@ -40,7 +42,8 @@ namespace Microsoft.DotNet.PackageValidation
 
             new CompatibleTfmValidator(NoWarn, null, RunApiCompat, logger).Validate(package);
             new CompatibleFrameworkInPackageValidator(NoWarn, null, logger).Validate(package);
-            if (!string.IsNullOrEmpty(BaselinePackageTargetPath))
+
+            if (!DisablePackageBaselineValidation && !string.IsNullOrEmpty(BaselinePackageTargetPath))
             {
                 Package baselinePackage = NupkgParser.CreatePackage(BaselinePackageTargetPath, runtimeGraph);
                 new BaselinePackageValidator(baselinePackage, NoWarn, null, RunApiCompat, logger).Validate(package);

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/ValidatePackage.cs
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/ValidatePackage.cs
@@ -1,10 +1,7 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Collections.Generic;
-using System.Diagnostics;
 using Microsoft.Build.Framework;
-using Microsoft.DotNet.Compatibility.ErrorSuppression;
 using Microsoft.NET.Build.Tasks;
 using NuGet.RuntimeModel;
 

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/build/Microsoft.DotNet.PackageValidation.targets
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/build/Microsoft.DotNet.PackageValidation.targets
@@ -16,13 +16,12 @@
 
     <PropertyGroup>
       <PackageValidationBaselinePath Condition="'$(PackageValidationBaselinePath)' == '' and '$(PackageValidationBaselineVersion)' != ''">$([MSBuild]::NormalizePath('$(NuGetPackageRoot)', '$(PackageValidationBaselineName.ToLower())', '$(PackageValidationBaselineVersion)', '$(PackageValidationBaselineName.ToLower()).$(PackageValidationBaselineVersion).nupkg'))</PackageValidationBaselinePath>
-      <PackageValidationBaselinePath Condition="'$(DisablePackageBaselineValidation)' == 'true'"></PackageValidationBaselinePath>
       <GenerateCompatibilitySuppressionFile Condition="'$(GenerateCompatibilitySuppressionFile)' == ''">false</GenerateCompatibilitySuppressionFile>
       <_compatibilitySuppressionFilePath>$([MSBuild]::NormalizePath('$(MSBuildProjectDirectory)', 'CompatibilitySuppressions.xml'))</_compatibilitySuppressionFilePath>
       <CompatibilitySuppressionFilePath Condition="'$(CompatibilitySuppressionFilePath)' == '' and (Exists($(_compatibilitySuppressionFilePath)) or '$(GenerateCompatibilitySuppressionFile)' == 'true')">$(_compatibilitySuppressionFilePath)</CompatibilitySuppressionFilePath>
     </PropertyGroup>
 
-    <Error Condition="'$(PackageValidationBaselinePath)' != '' and !Exists('$(PackageValidationBaselinePath)')" Text="$(PackageValidationBaselinePath) does not exist. Please check the PackageValidationBaselinePath or PackageValidationBaselineVersion." />
+    <Error Condition="'$(DisablePackageBaselineValidation)' != 'true' and '$(PackageValidationBaselinePath)' != '' and !Exists('$(PackageValidationBaselinePath)')" Text="$(PackageValidationBaselinePath) does not exist. Please check the PackageValidationBaselinePath or PackageValidationBaselineVersion." />
 
     <!-- PackageTargetPath isn't exposed by NuGet: https://github.com/NuGet/Home/issues/6671. -->
     <Microsoft.DotNet.PackageValidation.ValidatePackage
@@ -32,6 +31,7 @@
       RunApiCompat="$([MSBuild]::ValueOrDefault('$(RunApiCompat)', 'true'))"
       GenerateCompatibilitySuppressionFile="$(GenerateCompatibilitySuppressionFile)"
       CompatibilitySuppressionFilePath="$(CompatibilitySuppressionFilePath)"
-      BaselinePackageTargetPath="$(PackageValidationBaselinePath)" />
+      BaselinePackageTargetPath="$(PackageValidationBaselinePath)"
+      DisablePackageBaselineValidation="$(DisablePackageBaselineValidation)"/>
   </Target>
 </Project>

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/build/Microsoft.DotNet.PackageValidation.targets
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/build/Microsoft.DotNet.PackageValidation.targets
@@ -14,8 +14,9 @@
           AfterTargets="Pack"
           Condition="'$(IsPackable)' == 'true'">
 
-    <PropertyGroup >
+    <PropertyGroup>
       <PackageValidationBaselinePath Condition="'$(PackageValidationBaselinePath)' == '' and '$(PackageValidationBaselineVersion)' != ''">$([MSBuild]::NormalizePath('$(NuGetPackageRoot)', '$(PackageValidationBaselineName.ToLower())', '$(PackageValidationBaselineVersion)', '$(PackageValidationBaselineName.ToLower()).$(PackageValidationBaselineVersion).nupkg'))</PackageValidationBaselinePath>
+      <PackageValidationBaselinePath Condition="'$(DisablePackageBaselineValidation)' == 'true'"></PackageValidationBaselinePath>
       <GenerateCompatibilitySuppressionFile Condition="'$(GenerateCompatibilitySuppressionFile)' == ''">false</GenerateCompatibilitySuppressionFile>
       <_compatibilitySuppressionFilePath>$([MSBuild]::NormalizePath('$(MSBuildProjectDirectory)', 'CompatibilitySuppressions.xml'))</_compatibilitySuppressionFilePath>
       <CompatibilitySuppressionFilePath Condition="'$(CompatibilitySuppressionFilePath)' == '' and (Exists($(_compatibilitySuppressionFilePath)) or '$(GenerateCompatibilitySuppressionFile)' == 'true')">$(_compatibilitySuppressionFilePath)</CompatibilitySuppressionFilePath>

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/build/Microsoft.DotNet.PackageValidation.targets
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/build/Microsoft.DotNet.PackageValidation.targets
@@ -21,8 +21,6 @@
       <CompatibilitySuppressionFilePath Condition="'$(CompatibilitySuppressionFilePath)' == '' and (Exists($(_compatibilitySuppressionFilePath)) or '$(GenerateCompatibilitySuppressionFile)' == 'true')">$(_compatibilitySuppressionFilePath)</CompatibilitySuppressionFilePath>
     </PropertyGroup>
 
-    <Error Condition="'$(DisablePackageBaselineValidation)' != 'true' and '$(PackageValidationBaselinePath)' != '' and !Exists('$(PackageValidationBaselinePath)')" Text="$(PackageValidationBaselinePath) does not exist. Please check the PackageValidationBaselinePath or PackageValidationBaselineVersion." />
-
     <!-- PackageTargetPath isn't exposed by NuGet: https://github.com/NuGet/Home/issues/6671. -->
     <Microsoft.DotNet.PackageValidation.ValidatePackage
       PackageTargetPath="$([MSBuild]::ValueOrDefault('$(PackageTargetPath)', '$([MSBuild]::NormalizePath('$(PackageOutputPath)', '$(PackageId).$(PackageVersion).nupkg'))'))"

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.cs.xlf
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.cs.xlf
@@ -12,6 +12,11 @@
         <target state="new">API compatibility errors between '{0}' (left) and '{1}' (right):</target>
         <note />
       </trans-unit>
+      <trans-unit id="Baseline">
+        <source>[Baseline]</source>
+        <target state="new">[Baseline]</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CompatibleFrameworkInPackageValidatorHeader">
         <source>Assembly API surface area of {0} should be compatible with assembly surface area of {1}. This ensures that it is possible to compile against {0} and then run on the {1} framework.</source>
         <target state="new">Assembly API surface area of {0} should be compatible with assembly surface area of {1}. This ensures that it is possible to compile against {0} and then run on the {1} framework.</target>

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.de.xlf
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.de.xlf
@@ -12,6 +12,11 @@
         <target state="new">API compatibility errors between '{0}' (left) and '{1}' (right):</target>
         <note />
       </trans-unit>
+      <trans-unit id="Baseline">
+        <source>[Baseline]</source>
+        <target state="new">[Baseline]</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CompatibleFrameworkInPackageValidatorHeader">
         <source>Assembly API surface area of {0} should be compatible with assembly surface area of {1}. This ensures that it is possible to compile against {0} and then run on the {1} framework.</source>
         <target state="new">Assembly API surface area of {0} should be compatible with assembly surface area of {1}. This ensures that it is possible to compile against {0} and then run on the {1} framework.</target>

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.es.xlf
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.es.xlf
@@ -12,6 +12,11 @@
         <target state="new">API compatibility errors between '{0}' (left) and '{1}' (right):</target>
         <note />
       </trans-unit>
+      <trans-unit id="Baseline">
+        <source>[Baseline]</source>
+        <target state="new">[Baseline]</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CompatibleFrameworkInPackageValidatorHeader">
         <source>Assembly API surface area of {0} should be compatible with assembly surface area of {1}. This ensures that it is possible to compile against {0} and then run on the {1} framework.</source>
         <target state="new">Assembly API surface area of {0} should be compatible with assembly surface area of {1}. This ensures that it is possible to compile against {0} and then run on the {1} framework.</target>

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.fr.xlf
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.fr.xlf
@@ -12,6 +12,11 @@
         <target state="new">API compatibility errors between '{0}' (left) and '{1}' (right):</target>
         <note />
       </trans-unit>
+      <trans-unit id="Baseline">
+        <source>[Baseline]</source>
+        <target state="new">[Baseline]</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CompatibleFrameworkInPackageValidatorHeader">
         <source>Assembly API surface area of {0} should be compatible with assembly surface area of {1}. This ensures that it is possible to compile against {0} and then run on the {1} framework.</source>
         <target state="new">Assembly API surface area of {0} should be compatible with assembly surface area of {1}. This ensures that it is possible to compile against {0} and then run on the {1} framework.</target>

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.it.xlf
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.it.xlf
@@ -12,6 +12,11 @@
         <target state="new">API compatibility errors between '{0}' (left) and '{1}' (right):</target>
         <note />
       </trans-unit>
+      <trans-unit id="Baseline">
+        <source>[Baseline]</source>
+        <target state="new">[Baseline]</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CompatibleFrameworkInPackageValidatorHeader">
         <source>Assembly API surface area of {0} should be compatible with assembly surface area of {1}. This ensures that it is possible to compile against {0} and then run on the {1} framework.</source>
         <target state="new">Assembly API surface area of {0} should be compatible with assembly surface area of {1}. This ensures that it is possible to compile against {0} and then run on the {1} framework.</target>

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.ja.xlf
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.ja.xlf
@@ -12,6 +12,11 @@
         <target state="new">API compatibility errors between '{0}' (left) and '{1}' (right):</target>
         <note />
       </trans-unit>
+      <trans-unit id="Baseline">
+        <source>[Baseline]</source>
+        <target state="new">[Baseline]</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CompatibleFrameworkInPackageValidatorHeader">
         <source>Assembly API surface area of {0} should be compatible with assembly surface area of {1}. This ensures that it is possible to compile against {0} and then run on the {1} framework.</source>
         <target state="new">Assembly API surface area of {0} should be compatible with assembly surface area of {1}. This ensures that it is possible to compile against {0} and then run on the {1} framework.</target>

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.ko.xlf
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.ko.xlf
@@ -12,6 +12,11 @@
         <target state="new">API compatibility errors between '{0}' (left) and '{1}' (right):</target>
         <note />
       </trans-unit>
+      <trans-unit id="Baseline">
+        <source>[Baseline]</source>
+        <target state="new">[Baseline]</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CompatibleFrameworkInPackageValidatorHeader">
         <source>Assembly API surface area of {0} should be compatible with assembly surface area of {1}. This ensures that it is possible to compile against {0} and then run on the {1} framework.</source>
         <target state="new">Assembly API surface area of {0} should be compatible with assembly surface area of {1}. This ensures that it is possible to compile against {0} and then run on the {1} framework.</target>

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.pl.xlf
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.pl.xlf
@@ -12,6 +12,11 @@
         <target state="new">API compatibility errors between '{0}' (left) and '{1}' (right):</target>
         <note />
       </trans-unit>
+      <trans-unit id="Baseline">
+        <source>[Baseline]</source>
+        <target state="new">[Baseline]</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CompatibleFrameworkInPackageValidatorHeader">
         <source>Assembly API surface area of {0} should be compatible with assembly surface area of {1}. This ensures that it is possible to compile against {0} and then run on the {1} framework.</source>
         <target state="new">Assembly API surface area of {0} should be compatible with assembly surface area of {1}. This ensures that it is possible to compile against {0} and then run on the {1} framework.</target>

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.pt-BR.xlf
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.pt-BR.xlf
@@ -12,6 +12,11 @@
         <target state="new">API compatibility errors between '{0}' (left) and '{1}' (right):</target>
         <note />
       </trans-unit>
+      <trans-unit id="Baseline">
+        <source>[Baseline]</source>
+        <target state="new">[Baseline]</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CompatibleFrameworkInPackageValidatorHeader">
         <source>Assembly API surface area of {0} should be compatible with assembly surface area of {1}. This ensures that it is possible to compile against {0} and then run on the {1} framework.</source>
         <target state="new">Assembly API surface area of {0} should be compatible with assembly surface area of {1}. This ensures that it is possible to compile against {0} and then run on the {1} framework.</target>

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.ru.xlf
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.ru.xlf
@@ -12,6 +12,11 @@
         <target state="new">API compatibility errors between '{0}' (left) and '{1}' (right):</target>
         <note />
       </trans-unit>
+      <trans-unit id="Baseline">
+        <source>[Baseline]</source>
+        <target state="new">[Baseline]</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CompatibleFrameworkInPackageValidatorHeader">
         <source>Assembly API surface area of {0} should be compatible with assembly surface area of {1}. This ensures that it is possible to compile against {0} and then run on the {1} framework.</source>
         <target state="new">Assembly API surface area of {0} should be compatible with assembly surface area of {1}. This ensures that it is possible to compile against {0} and then run on the {1} framework.</target>

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.tr.xlf
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.tr.xlf
@@ -12,6 +12,11 @@
         <target state="new">API compatibility errors between '{0}' (left) and '{1}' (right):</target>
         <note />
       </trans-unit>
+      <trans-unit id="Baseline">
+        <source>[Baseline]</source>
+        <target state="new">[Baseline]</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CompatibleFrameworkInPackageValidatorHeader">
         <source>Assembly API surface area of {0} should be compatible with assembly surface area of {1}. This ensures that it is possible to compile against {0} and then run on the {1} framework.</source>
         <target state="new">Assembly API surface area of {0} should be compatible with assembly surface area of {1}. This ensures that it is possible to compile against {0} and then run on the {1} framework.</target>

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.zh-Hans.xlf
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.zh-Hans.xlf
@@ -12,6 +12,11 @@
         <target state="new">API compatibility errors between '{0}' (left) and '{1}' (right):</target>
         <note />
       </trans-unit>
+      <trans-unit id="Baseline">
+        <source>[Baseline]</source>
+        <target state="new">[Baseline]</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CompatibleFrameworkInPackageValidatorHeader">
         <source>Assembly API surface area of {0} should be compatible with assembly surface area of {1}. This ensures that it is possible to compile against {0} and then run on the {1} framework.</source>
         <target state="new">Assembly API surface area of {0} should be compatible with assembly surface area of {1}. This ensures that it is possible to compile against {0} and then run on the {1} framework.</target>

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.zh-Hant.xlf
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/xlf/Resources.zh-Hant.xlf
@@ -12,6 +12,11 @@
         <target state="new">API compatibility errors between '{0}' (left) and '{1}' (right):</target>
         <note />
       </trans-unit>
+      <trans-unit id="Baseline">
+        <source>[Baseline]</source>
+        <target state="new">[Baseline]</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CompatibleFrameworkInPackageValidatorHeader">
         <source>Assembly API surface area of {0} should be compatible with assembly surface area of {1}. This ensures that it is possible to compile against {0} and then run on the {1} framework.</source>
         <target state="new">Assembly API surface area of {0} should be compatible with assembly surface area of {1}. This ensures that it is possible to compile against {0} and then run on the {1} framework.</target>

--- a/src/Tests/Microsoft.DotNet.PackageValidation.Tests/ValidatePackageTargetTests.cs
+++ b/src/Tests/Microsoft.DotNet.PackageValidation.Tests/ValidatePackageTargetTests.cs
@@ -116,7 +116,7 @@ namespace Microsoft.DotNet.PackageValidation.Tests
                 .Execute($"-p:PackageVersion=2.0.0;PackageValidationBaselinePath={nonExistentPackageBaselinePath}");
 
             Assert.Equal(1, result.ExitCode);
-            Assert.Contains($"{nonExistentPackageBaselinePath} does not exist. Please check the PackageValidationBaselinePath or PackageValidationBaselineVersion.", result.StdOut);
+            Assert.Contains($"Could not find file '{nonExistentPackageBaselinePath}'. ", result.StdOut);
 
             // Disables package baseline validation.
             result = new PackCommand(Log, Path.Combine(testAsset.TestRoot, "PackageValidationTestProject.csproj"))

--- a/src/Tests/Microsoft.DotNet.PackageValidation.Tests/ValidatePackageTargetTests.cs
+++ b/src/Tests/Microsoft.DotNet.PackageValidation.Tests/ValidatePackageTargetTests.cs
@@ -100,8 +100,8 @@ namespace Microsoft.DotNet.PackageValidation.Tests
                 .Execute($"-p:PackageVersion=2.0.0;AddBreakingChange=true;PackageValidationBaselinePath={packageValidationBaselinePath}");
 
             Assert.Equal(1, result.ExitCode);
-            Assert.Contains("error CP0002: Member 'PackageValidationTestProject.Program.SomeApiNotInLatestVersion()' exists on lib/net6.0/PackageValidationTestProject.dll but not on lib/net6.0/PackageValidationTestProject.dll", result.StdOut);
-            Assert.Contains("error CP0002: Member 'PackageValidationTestProject.Program.SomeApiNotInLatestVersion()' exists on lib/netstandard2.0/PackageValidationTestProject.dll but not on lib/netstandard2.0/PackageValidationTestProject.dll", result.StdOut);
+            Assert.Contains("error CP0002: Member 'PackageValidationTestProject.Program.SomeApiNotInLatestVersion()' exists on [Baseline] lib/net6.0/PackageValidationTestProject.dll but not on lib/net6.0/PackageValidationTestProject.dll", result.StdOut);
+            Assert.Contains("error CP0002: Member 'PackageValidationTestProject.Program.SomeApiNotInLatestVersion()' exists on [Baseline] lib/netstandard2.0/PackageValidationTestProject.dll but not on lib/netstandard2.0/PackageValidationTestProject.dll", result.StdOut);
         }
 
         [Fact]

--- a/src/Tests/Microsoft.DotNet.PackageValidation.Tests/ValidatePackageTargetTests.cs
+++ b/src/Tests/Microsoft.DotNet.PackageValidation.Tests/ValidatePackageTargetTests.cs
@@ -120,7 +120,7 @@ namespace Microsoft.DotNet.PackageValidation.Tests
 
             // Disables package baseline validation.
             result = new PackCommand(Log, Path.Combine(testAsset.TestRoot, "PackageValidationTestProject.csproj"))
-                .Execute($"-p:PackageVersion=2.0.0;DisablePackageBaselineValidation=true;EnablePackageBaselineValidation=true;PackageValidationBaselinePath={nonExistentPackageBaselinePath}");
+                .Execute($"-p:PackageVersion=2.0.0;DisablePackageBaselineValidation=true;PackageValidationBaselinePath={nonExistentPackageBaselinePath}");
             Assert.Equal(0, result.ExitCode);
         }
     }


### PR DESCRIPTION
Imagine a case where we want to run baseline validation for multiple projects except few. we can set packagebaselineVersion in ```directory.build.props``` file but we will have to unset it for all projects where we don`t want to run the baseline validation.
having ```DisablePackageBaselineValidation``` provide a better user experience.

