### PR TITLE
Show trimmer warnings for WinForms and WPF

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -111,10 +111,6 @@ Copyright (c) .NET Foundation. All rights reserved.
                             '$(EnableCompressionInSingleFile)' == 'true' And
                             '$(SelfContained)' != 'true'"
                  ResourceName="CompressionInSingleFileRequiresSelfContained" />
-    <NetSdkWarning Condition="'$(UseWindowsForms)' == 'true' and '$(PublishTrimmed)' == 'true'"
-                 ResourceName="TrimmingWindowsFormsIsNotSupported" />
-    <NetSdkWarning Condition="'$(UseWpf)' == 'true' and '$(PublishTrimmed)' == 'true'"
-                 ResourceName="TrimmingWpfIsNotSupported" />
 
     <PropertyGroup>
       <!-- Ensure any PublishDir has a trailing slash, so it can be concatenated -->

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets
@@ -163,6 +163,12 @@ Copyright (c) .NET Foundation. All rights reserved.
     <NETSdkWarning Condition="'$(PublishTrimmed)' == 'true' and '$(_TargetFrameworkVersionWithoutV)' &lt; '3.0'"
                    ResourceName="PublishTrimmedRequiresVersion30" />
 
+    <!-- Generate Trimming warnings for WinForms and Wpf applications-->
+    <NetSdkWarning Condition="'$(UseWindowsForms)' == 'true' and '$(PublishTrimmed)' == 'true'"
+                 ResourceName="TrimmingWindowsFormsIsNotSupported" />
+    <NetSdkWarning Condition="'$(UseWpf)' == 'true' and '$(PublishTrimmed)' == 'true'"
+                 ResourceName="TrimmingWpfIsNotSupported" />
+    
   </Target>
 
   <Target Name="_CheckForUnsupportedHostingUsage"

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishTrimmedWindowsFormsAndWPFApps.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishTrimmedWindowsFormsAndWPFApps.cs
@@ -21,21 +21,70 @@ namespace Microsoft.NET.Publish.Tests
         }
 
         [WindowsOnlyFact]
+        public void It_builds_windows_Forms_app_with_warning()
+        {
+            var targetFramework = "net6.0-windows";
+            TestProject testProject = new TestProject()
+            {
+                Name = "WinformsBuildWarnPresentPassTest",
+                TargetFrameworks = targetFramework,
+                IsWinExe=true
+            };
+            testProject.AdditionalProperties["UseWindowsForms"] = "true";
+            testProject.AdditionalProperties["PublishTrimmed"] = "true";
+            var testAsset = _testAssetsManager.CreateTestProject(testProject);
+
+            var buildCommand = new BuildCommand(testAsset);
+            buildCommand.Execute()
+                .Should()
+                .Pass()
+                .And
+                .HaveStdOutContaining("NETSDK1175");
+        }
+
+        [WindowsOnlyFact]
+        public void It_builds_windows_Forms_app_with_warning_suppressed()
+        {
+            var targetFramework = "net6.0-windows";
+            TestProject testProject = new TestProject()
+            {
+                Name = "WinformsBuildWarnSuppressPassTest",
+                TargetFrameworks = targetFramework,
+                IsWinExe = true
+            };
+            testProject.AdditionalProperties["UseWindowsForms"] = "true";
+            testProject.AdditionalProperties["PublishTrimmed"] = "true";
+            testProject.AdditionalProperties["NoWarn"] = "NETSDK1175";
+            var testAsset = _testAssetsManager.CreateTestProject(testProject);
+
+            var buildCommand = new BuildCommand(testAsset);
+            buildCommand.Execute()
+                .Should()
+                .Pass()
+                .And
+                //cannot check for absence of NETSDK1175 since that is used with /nowarn: in some configurations
+                .NotHaveStdOutContaining(Strings.@TrimmingWindowsFormsIsNotSupported);
+        }
+
+
+        [WindowsOnlyFact]
         public void It_publishes_windows_Forms_app_with_warning()
         {
             var targetFramework = "net6.0-windows";
             TestProject testProject = new TestProject()
             {
                 Name = "WinformsWarnPresentPassTest",
-                TargetFrameworks = targetFramework
+                TargetFrameworks = targetFramework,
+                IsWinExe = true
             };
             testProject.AdditionalProperties["UseWindowsForms"] = "true";
             testProject.AdditionalProperties["SelfContained"] = "true";
             testProject.AdditionalProperties["RuntimeIdentifier"] = "win-x64";
+            testProject.AdditionalProperties["PublishTrimmed"] = "true";
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
-            
+
             var publishCommand = new PublishCommand(testAsset);
-            publishCommand.Execute($"/p:PublishTrimmed=true")
+            publishCommand.Execute()
                 .Should()
                 .Pass()
                 .And
@@ -48,19 +97,20 @@ namespace Microsoft.NET.Publish.Tests
             var targetFramework = "net6.0-windows";
             TestProject testProject = new TestProject()
             {
-                Name = "WinformsPassTest",
-                TargetFrameworks = targetFramework
+                Name = "WinformsWarnSuppressedPassTest",
+                TargetFrameworks = targetFramework,
+                IsWinExe = true
             };
-            testProject.IsWinExe = true;
             testProject.AdditionalProperties["UseWindowsForms"] = "true";
             testProject.AdditionalProperties["SelfContained"] = "true";
             testProject.AdditionalProperties["RuntimeIdentifier"] = "win-x64";
+            testProject.AdditionalProperties["PublishTrimmed"] = "true";
             testProject.AdditionalProperties["NoWarn"] = "NETSDK1175";
             testProject.AdditionalProperties["SuppressTrimAnalysisWarnings"] = "false";
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
             var publishCommand = new PublishCommand(testAsset);
-            publishCommand.Execute($"/p:PublishTrimmed=true")
+            publishCommand.Execute()
                 .Should()
                 .Pass()
                 .And
@@ -69,22 +119,70 @@ namespace Microsoft.NET.Publish.Tests
         }
 
         [WindowsOnlyFact]
+        public void It_builds_wpf_app_with_warning()
+        {
+            var targetFramework = "net6.0-windows";
+            TestProject testProject = new TestProject()
+            {
+                Name = "WpfWarnPresentPassTest",
+                TargetFrameworks = targetFramework,
+                IsWinExe = true
+            };
+            testProject.AdditionalProperties["UseWPF"] = "true";
+            testProject.AdditionalProperties["PublishTrimmed"] = "true";
+            var testAsset = _testAssetsManager.CreateTestProject(testProject);
+
+            var buildCommand = new BuildCommand(testAsset);
+            buildCommand.Execute()
+                .Should()
+                .Pass()
+                .And
+                .HaveStdOutContaining("NETSDK1168");
+        }
+
+        [WindowsOnlyFact]
+        public void It_builds_wpf_app_with_warning_Suppressed()
+        {
+            var targetFramework = "net6.0-windows";
+            TestProject testProject = new TestProject()
+            {
+                Name = "WpfWarnSuppressedPassTest",
+                TargetFrameworks = targetFramework,
+                IsWinExe = true
+            };
+            testProject.AdditionalProperties["UseWPF"] = "true";
+            testProject.AdditionalProperties["PublishTrimmed"] = "true";
+            testProject.AdditionalProperties["NoWarn"] = "NETSDK1168";
+            var testAsset = _testAssetsManager.CreateTestProject(testProject);
+
+            var buildCommand = new BuildCommand(testAsset);
+            buildCommand.Execute()
+                .Should()
+                .Pass()
+                .And
+                //cannot check for absence of NETSDK1168 since that is used with /nowarn: in some configurations
+                .NotHaveStdOutContaining(Strings.@TrimmingWpfIsNotSupported);
+        }
+
+
+        [WindowsOnlyFact]
         public void It_publishes_wpf_app_with_warning()
         {
             var targetFramework = "net6.0-windows";
             TestProject testProject = new TestProject()
             {
                 Name = "WpfWarnPresentPassTest",
-                TargetFrameworks = targetFramework
+                TargetFrameworks = targetFramework,
+                IsWinExe = true
             };
-            testProject.IsWinExe = true;
             testProject.AdditionalProperties["UseWPF"] = "true";
             testProject.AdditionalProperties["SelfContained"] = "true";
             testProject.AdditionalProperties["RuntimeIdentifier"] = "win-x64";
+            testProject.AdditionalProperties["PublishTrimmed"] = "true";
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
             var publishCommand = new PublishCommand(testAsset);
-            publishCommand.Execute($"/p:PublishTrimmed=true")
+            publishCommand.Execute()
                 .Should()
                 .Pass()
                 .And
@@ -98,18 +196,19 @@ namespace Microsoft.NET.Publish.Tests
             TestProject testProject = new TestProject()
             {
                 Name = "WpfPassTest",
-                TargetFrameworks = targetFramework
+                TargetFrameworks = targetFramework,
+                IsWinExe = true
             };
-            testProject.IsWinExe = true;
             testProject.AdditionalProperties["UseWPF"] = "true";
             testProject.AdditionalProperties["SelfContained"] = "true";
             testProject.AdditionalProperties["RuntimeIdentifier"] = "win-x64";
             testProject.AdditionalProperties["NoWarn"] = "NETSDK1168";
-            testProject.AdditionalProperties["SuppressTrimAnalysisWarnings"] = "false";            
+            testProject.AdditionalProperties["SuppressTrimAnalysisWarnings"] = "false";
+            testProject.AdditionalProperties["PublishTrimmed"] = "true";
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
             var publishCommand = new PublishCommand(testAsset);
-            publishCommand.Execute($"/p:PublishTrimmed=true")
+            publishCommand.Execute()
                 .Should()
                 .Pass()
                 .And


### PR DESCRIPTION
WinForms and WPF applications can have the `PublishTrimmed `property set in the project file. This will cause some feature switches to be triggered, one of which is to turn off built-in COM support, since that is not compatible with trimming. But this results in a poor developer experience since building the project will not generate any warnings but trying to run almost any WinForms or WPF applications will generate an exception indicating that built-in COM is turned off.

We have been generating warnings during the publish phase. The fix here is to move the warnings to the build phase

- We will generate separate warnings for WinForms and WPF applications to indicate trimming is not compatible
- The warnings (NETSDK1175, NETSDK1168) mention that trimming is not compatible and give aka.ms links to find out more information
- Created a doc [bug](https://github.com/dotnet/docs/issues/24903) to give more information on why trimming is not a good idea and perhaps directions for the determined (and brave) developers to set the turned off feature switches
- Updated the tests to reflect both build and publish options


Fixes #18474