### PR TITLE
Import RuntimeIdentifierInference targets after workloads

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.BeforeCommon.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.BeforeCommon.targets
@@ -60,12 +60,6 @@ Copyright (c) .NET Foundation. All rights reserved.
   </PropertyGroup>
 
   <!--
-    Use RuntimeIdentifier to determine PlatformTarget.
-    Also, enforce that RuntimeIdentifier is always specified for .NETFramework executables.
-  -->
-  <Import Project="$(MSBuildThisFileDirectory)Microsoft.NET.RuntimeIdentifierInference.targets" />
-
-  <!--
     Import targets from RazorSDK if referenced
     Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.Sdk.BeforeCommon.targets
     Sdks\Microsoft.NET.Sdk.Razor\build\netstandard2.0\Microsoft.NET.Sdk.Razor.BeforeCommon.targets
@@ -74,6 +68,12 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <!-- Import workload targets -->
   <Import Project="Microsoft.NET.Sdk.ImportWorkloads.targets" Condition="'$(MSBuildEnableWorkloadResolver)' == 'true'" />
+
+  <!--
+    Use RuntimeIdentifier to determine PlatformTarget.
+    Also, enforce that RuntimeIdentifier is always specified for .NETFramework executables.
+  -->
+  <Import Project="$(MSBuildThisFileDirectory)Microsoft.NET.RuntimeIdentifierInference.targets" />
 
   <!-- Checks for EOL frameworks -->
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.NET.EolTargetFrameworks.targets" />


### PR DESCRIPTION
Reorder RuntimeIdentifier inference to go after workload imports, to allow workloads to set a default RuntimeIdentifier.  Fixes #18354

@rolfbjarne @jonathanpeppers @akoeplinger This *looks* like a simple change, let's see if it breaks anything.

@pranavkm this reorders the import of Microsoft.NET.RuntimeIdentifierInference.targets to happen after the import for Microsoft.NET.Sdk.Razor.BeforeCommon.targets.  Do you think this is likely to break the Razor SDK?
