### PR TITLE
Set PackageValidationBaselineName to assemblyName when packageID is not set

### DIFF
--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/build/Microsoft.DotNet.PackageValidation.targets
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/build/Microsoft.DotNet.PackageValidation.targets
@@ -11,7 +11,7 @@
           Condition="'$(IsPackable)' == 'true'">
 
     <PropertyGroup>
-      <PackageValidationBaselineName>$([MSBuild]::ValueOrDefault('$(PackageValidationBaselineName)', '$(PackageId)'))</PackageValidationBaselineName>
+      <PackageValidationBaselineName Condition="'$(PackageValidationBaselineName)' == ''">$(PackageId)</PackageValidationBaselineName>
       <PackageValidationBaselinePath Condition="'$(PackageValidationBaselinePath)' == '' and '$(PackageValidationBaselineVersion)' != ''">$([MSBuild]::NormalizePath('$(NuGetPackageRoot)', '$(PackageValidationBaselineName.ToLower())', '$(PackageValidationBaselineVersion)', '$(PackageValidationBaselineName.ToLower()).$(PackageValidationBaselineVersion).nupkg'))</PackageValidationBaselinePath>
       <GenerateCompatibilitySuppressionFile Condition="'$(GenerateCompatibilitySuppressionFile)' == ''">false</GenerateCompatibilitySuppressionFile>
       <_compatibilitySuppressionFilePath>$([MSBuild]::NormalizePath('$(MSBuildProjectDirectory)', 'CompatibilitySuppressions.xml'))</_compatibilitySuppressionFilePath>

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/build/Microsoft.DotNet.PackageValidation.targets
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/build/Microsoft.DotNet.PackageValidation.targets
@@ -3,6 +3,7 @@
   <UsingTask TaskName="Microsoft.DotNet.PackageValidation.ValidatePackage" AssemblyFile="$(DotNetPackageValidationAssembly)" />
 
   <PropertyGroup>
+    <PackageValidationBaselineName Condition="'$(PackageId)' == ''">$(AssemblyName)</PackageValidationBaselineName>
     <PackageValidationBaselineName>$([MSBuild]::ValueOrDefault('$(PackageValidationBaselineName)', '$(PackageId)'))</PackageValidationBaselineName>
   </PropertyGroup>
 

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/build/Microsoft.DotNet.PackageValidation.targets
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/build/Microsoft.DotNet.PackageValidation.targets
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <PackageValidationBaselineName Condition="'$(PackageId)' == ''">$(AssemblyName)</PackageValidationBaselineName>
-    <PackageValidationBaselineName>$([MSBuild]::ValueOrDefault('$(PackageValidationBaselineName)', '$(PackageId)'))</PackageValidationBaselineName>
+    <PackageValidationBaselineName>$([MSBuild]::ValueOrDefault('$(PackageValidationBaselineName)', '$([MSBuild]::ValueOrDefault('$(PackageId)', '$(AssemblyName)'))'))</PackageValidationBaselineName>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(PackageValidationBaselinePath)' == '' and '$(PackageValidationBaselineVersion)' != ''">

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/build/Microsoft.DotNet.PackageValidation.targets
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/build/Microsoft.DotNet.PackageValidation.targets
@@ -3,7 +3,6 @@
   <UsingTask TaskName="Microsoft.DotNet.PackageValidation.ValidatePackage" AssemblyFile="$(DotNetPackageValidationAssembly)" />
 
   <PropertyGroup>
-    <PackageValidationBaselineName Condition="'$(PackageId)' == ''">$(AssemblyName)</PackageValidationBaselineName>
     <PackageValidationBaselineName>$([MSBuild]::ValueOrDefault('$(PackageValidationBaselineName)', '$([MSBuild]::ValueOrDefault('$(PackageId)', '$(AssemblyName)'))'))</PackageValidationBaselineName>
   </PropertyGroup>
 

--- a/src/Compatibility/Microsoft.DotNet.PackageValidation/build/Microsoft.DotNet.PackageValidation.targets
+++ b/src/Compatibility/Microsoft.DotNet.PackageValidation/build/Microsoft.DotNet.PackageValidation.targets
@@ -2,12 +2,8 @@
 <Project>
   <UsingTask TaskName="Microsoft.DotNet.PackageValidation.ValidatePackage" AssemblyFile="$(DotNetPackageValidationAssembly)" />
 
-  <PropertyGroup>
-    <PackageValidationBaselineName>$([MSBuild]::ValueOrDefault('$(PackageValidationBaselineName)', '$([MSBuild]::ValueOrDefault('$(PackageId)', '$(AssemblyName)'))'))</PackageValidationBaselineName>
-  </PropertyGroup>
-
   <ItemGroup Condition="'$(PackageValidationBaselinePath)' == '' and '$(PackageValidationBaselineVersion)' != ''">
-    <PackageDownload Include="$(PackageValidationBaselineName)" Version="[$(PackageValidationBaselineVersion)]" />
+    <PackageDownload Include="$([MSBuild]::ValueOrDefault('$(PackageValidationBaselineName)', '$(PackageId)'))" Version="[$(PackageValidationBaselineVersion)]" />
   </ItemGroup>
 
   <Target Name="RunPackageValidation"
@@ -15,6 +11,7 @@
           Condition="'$(IsPackable)' == 'true'">
 
     <PropertyGroup>
+      <PackageValidationBaselineName>$([MSBuild]::ValueOrDefault('$(PackageValidationBaselineName)', '$(PackageId)'))</PackageValidationBaselineName>
       <PackageValidationBaselinePath Condition="'$(PackageValidationBaselinePath)' == '' and '$(PackageValidationBaselineVersion)' != ''">$([MSBuild]::NormalizePath('$(NuGetPackageRoot)', '$(PackageValidationBaselineName.ToLower())', '$(PackageValidationBaselineVersion)', '$(PackageValidationBaselineName.ToLower()).$(PackageValidationBaselineVersion).nupkg'))</PackageValidationBaselinePath>
       <GenerateCompatibilitySuppressionFile Condition="'$(GenerateCompatibilitySuppressionFile)' == ''">false</GenerateCompatibilitySuppressionFile>
       <_compatibilitySuppressionFilePath>$([MSBuild]::NormalizePath('$(MSBuildProjectDirectory)', 'CompatibilitySuppressions.xml'))</_compatibilitySuppressionFilePath>


### PR DESCRIPTION
Fixes issue in https://github.com/dotnet/runtime/pull/54250

