### PR TITLE
bugfix/port namespace properties to 5.0.400

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.Analyzers.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.Analyzers.targets
@@ -71,6 +71,13 @@ Copyright (c) .NET Foundation. All rights reserved.
       IsImplicitlyDefined="true" />
   </ItemGroup>
 
+  <!-- CompilerVisibleProperties for .NET -->
+  <ItemGroup Condition="'$(Language)' == 'C#' Or '$(Language)' == 'VB'">
+    <!-- Used for analyzer to match namespace to folder structure -->
+    <CompilerVisibleProperty Include="RootNamespace" />
+    <CompilerVisibleProperty Include="ProjectDir" />
+  </ItemGroup>
+
   <!-- C# Code Style Analyzers -->
   <ItemGroup Condition="$(EnforceCodeStyleInBuild) And '$(Language)' == 'C#'">
     <Analyzer


### PR DESCRIPTION
porting fixes from 5.0.300 to 5.0.400. For some reason these branches do not flow into each other.

https://github.com/dotnet/sdk/pull/15836/commits/2ef8cfafa6e994d89b46c9c26c3e394b9fe91623