### PR TITLE
Change manifest root hook to work across SDK versions

### DIFF
--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/SdkDirectoryWorkloadManifestProvider.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/SdkDirectoryWorkloadManifestProvider.cs
@@ -56,7 +56,11 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
             var manifestDirectoryEnvironmentVariable = getEnvironmentVariable("DOTNETSDK_WORKLOAD_MANIFEST_ROOTS");
             if (manifestDirectoryEnvironmentVariable != null)
             {
-                _manifestDirectories = manifestDirectoryEnvironmentVariable.Split(Path.PathSeparator).Append(manifestDirectory).ToArray();
+                //  Append the SDK version band to each manifest root specified via the environment variable.  This allows the same
+                //  environment variable settings to be shared by multiple SDKs.
+                _manifestDirectories = manifestDirectoryEnvironmentVariable.Split(Path.PathSeparator)
+                    .Select(p => Path.Combine(p, _sdkVersionBand))
+                    .Append(manifestDirectory).ToArray();
             }
             else
             {

--- a/src/Tests/Microsoft.NET.Sdk.WorkloadManifestReader.Tests/SdkDirectoryWorkloadManifestProviderTests.cs
+++ b/src/Tests/Microsoft.NET.Sdk.WorkloadManifestReader.Tests/SdkDirectoryWorkloadManifestProviderTests.cs
@@ -99,6 +99,8 @@ namespace ManifestReaderTests
         {
             Initialize();
 
+            string sdkVersion = "5.0.100";
+
             var additionalManifestDirectory = Path.Combine(_testDirectory, "AdditionalManifests");
             Directory.CreateDirectory(additionalManifestDirectory);
 
@@ -106,8 +108,8 @@ namespace ManifestReaderTests
             environmentMock.Add("DOTNETSDK_WORKLOAD_MANIFEST_ROOTS", additionalManifestDirectory);
 
             //  Manifest in test hook directory
-            Directory.CreateDirectory(Path.Combine(additionalManifestDirectory, "Android"));
-            File.WriteAllText(Path.Combine(additionalManifestDirectory, "Android", "WorkloadManifest.json"), "AndroidContent");
+            Directory.CreateDirectory(Path.Combine(additionalManifestDirectory, sdkVersion, "Android"));
+            File.WriteAllText(Path.Combine(additionalManifestDirectory, sdkVersion, "Android", "WorkloadManifest.json"), "AndroidContent");
 
             //  Manifest in default directory
             Directory.CreateDirectory(Path.Combine(_manifestDirectory, "iOS"));
@@ -115,7 +117,7 @@ namespace ManifestReaderTests
 
 
             var sdkDirectoryWorkloadManifestProvider
-                = new SdkDirectoryWorkloadManifestProvider(sdkRootPath: _fakeDotnetRootDirectory, sdkVersion: "5.0.100", environmentMock.GetEnvironmentVariable);
+                = new SdkDirectoryWorkloadManifestProvider(sdkRootPath: _fakeDotnetRootDirectory, sdkVersion: sdkVersion, environmentMock.GetEnvironmentVariable);
 
             GetManifestContents(sdkDirectoryWorkloadManifestProvider)
                 .Should()
@@ -127,6 +129,8 @@ namespace ManifestReaderTests
         {
             Initialize();
 
+            string sdkVersion = "5.0.100";
+
             var additionalManifestDirectory = Path.Combine(_testDirectory, "AdditionalManifests");
             Directory.CreateDirectory(additionalManifestDirectory);
 
@@ -134,15 +138,15 @@ namespace ManifestReaderTests
             environmentMock.Add("DOTNETSDK_WORKLOAD_MANIFEST_ROOTS", additionalManifestDirectory);
 
             //  Manifest in test hook directory
-            Directory.CreateDirectory(Path.Combine(additionalManifestDirectory, "Android"));
-            File.WriteAllText(Path.Combine(additionalManifestDirectory, "Android", "WorkloadManifest.json"), "OverridingAndroidContent");
+            Directory.CreateDirectory(Path.Combine(additionalManifestDirectory, sdkVersion, "Android"));
+            File.WriteAllText(Path.Combine(additionalManifestDirectory, sdkVersion, "Android", "WorkloadManifest.json"), "OverridingAndroidContent");
 
             //  Manifest in default directory
             Directory.CreateDirectory(Path.Combine(_manifestDirectory, "Android"));
             File.WriteAllText(Path.Combine(_manifestDirectory, "Android", "WorkloadManifest.json"), "OverriddenAndroidContent");
 
             var sdkDirectoryWorkloadManifestProvider
-                = new SdkDirectoryWorkloadManifestProvider(sdkRootPath: _fakeDotnetRootDirectory, sdkVersion: "5.0.100", environmentMock.GetEnvironmentVariable);
+                = new SdkDirectoryWorkloadManifestProvider(sdkRootPath: _fakeDotnetRootDirectory, sdkVersion: sdkVersion, environmentMock.GetEnvironmentVariable);
 
             GetManifestContents(sdkDirectoryWorkloadManifestProvider)
                 .Should()
@@ -154,6 +158,8 @@ namespace ManifestReaderTests
         public void ItSupportsMultipleTestHookFolders()
         {
             Initialize();
+
+            string sdkVersion = "5.0.100";
 
             var additionalManifestDirectory1 = Path.Combine(_testDirectory, "AdditionalManifests1");
             Directory.CreateDirectory(additionalManifestDirectory1);
@@ -172,18 +178,18 @@ namespace ManifestReaderTests
             File.WriteAllText(Path.Combine(_manifestDirectory, "Android", "WorkloadManifest.json"), "DefaultAndroidContent");
 
             //  Manifests in first additional directory
-            Directory.CreateDirectory(Path.Combine(additionalManifestDirectory1, "Android"));
-            File.WriteAllText(Path.Combine(additionalManifestDirectory1, "Android", "WorkloadManifest.json"), "AndroidContent1");
+            Directory.CreateDirectory(Path.Combine(additionalManifestDirectory1, sdkVersion, "Android"));
+            File.WriteAllText(Path.Combine(additionalManifestDirectory1, sdkVersion, "Android", "WorkloadManifest.json"), "AndroidContent1");
 
             //  Manifests in second additional directory
-            Directory.CreateDirectory(Path.Combine(additionalManifestDirectory2, "Android"));
-            File.WriteAllText(Path.Combine(additionalManifestDirectory2, "Android", "WorkloadManifest.json"), "AndroidContent2");
+            Directory.CreateDirectory(Path.Combine(additionalManifestDirectory2, sdkVersion, "Android"));
+            File.WriteAllText(Path.Combine(additionalManifestDirectory2, sdkVersion, "Android", "WorkloadManifest.json"), "AndroidContent2");
 
-            Directory.CreateDirectory(Path.Combine(additionalManifestDirectory2, "Test"));
-            File.WriteAllText(Path.Combine(additionalManifestDirectory2, "Test", "WorkloadManifest.json"), "TestContent2");
+            Directory.CreateDirectory(Path.Combine(additionalManifestDirectory2, sdkVersion, "Test"));
+            File.WriteAllText(Path.Combine(additionalManifestDirectory2, sdkVersion, "Test", "WorkloadManifest.json"), "TestContent2");
 
             var sdkDirectoryWorkloadManifestProvider
-                = new SdkDirectoryWorkloadManifestProvider(sdkRootPath: _fakeDotnetRootDirectory, sdkVersion: "5.0.100", environmentMock.GetEnvironmentVariable);
+                = new SdkDirectoryWorkloadManifestProvider(sdkRootPath: _fakeDotnetRootDirectory, sdkVersion: sdkVersion, environmentMock.GetEnvironmentVariable);
 
             GetManifestContents(sdkDirectoryWorkloadManifestProvider)
                 .Should()


### PR DESCRIPTION
This changes the workload resolver so that it will append the SDK feature band to the paths defined in `DOTNETSDK_WORKLOAD_MANIFEST_ROOTS`.  This means that setting this environment variable for one SDK feature band won't pollute other bands with workload manifests for the wrong band.

This is a change in behavior for this environment variable.  The only usage of it that I could find so far was [in xamarin-macios](https://github.com/xamarin/xamarin-macios/blob/3b6f059863e2435422769cbe2fa11c41cd095ff8/dotnet/Makefile#L347), which would need to be updated if we make this change.

@rolfbjarne @jonathanpeppers @Redth Does this sound OK?  Are you aware of any other uses of this environment variable?