### PR TITLE
Adding PrepareForBundle target

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -863,7 +863,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     </PropertyGroup>
   </Target>
 
-  <Target Name="BeforeBundle"
+  <Target Name="PrepareForBundle"
       DependsOnTargets="_ComputeFilesToBundle"
       Condition="'$(PublishSingleFile)' == 'true'">
 
@@ -879,8 +879,8 @@ Copyright (c) .NET Foundation. All rights reserved.
   <UsingTask TaskName="GenerateBundle" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
   <Target Name="GenerateSingleFileBundle"
           Condition="'$(PublishSingleFile)' == 'true'"
-          DependsOnTargets="_ComputeFilesToBundle;BeforeBundle"
-          Inputs="@(_FilesToBundle)"
+          DependsOnTargets="_ComputeFilesToBundle;PrepareForBundle"
+          Inputs="@(FilesToBundle)"
           Outputs="$(PublishedSingleFilePath)">
 
     <PropertyGroup>
@@ -894,7 +894,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <NETSdkError Condition="'$(IncludeAllContentForSelfExtract)' == 'true' And '$(IncludeNativeLibrariesForSelfExtract)' != 'true'"
                  ResourceName="CannotIncludeAllContentButNotNativeLibrariesInSingleFile" />
 
-    <GenerateBundle FilesToBundle="@(_FilesToBundle)"
+    <GenerateBundle FilesToBundle="@(FilesToBundle)"
                     AppHostName="$(PublishedSingleFileName)"
                     IncludeSymbols="$(IncludeSymbolsInSingleFile)"
                     EnableCompressionInSingleFile="$(EnableCompressionInSingleFile)"

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -861,13 +861,25 @@ Copyright (c) .NET Foundation. All rights reserved.
       <PublishedSingleFileName>$(AssemblyName)$(_NativeExecutableExtension)</PublishedSingleFileName>
       <PublishedSingleFilePath>$(PublishDir)$(PublishedSingleFileName)</PublishedSingleFilePath>
     </PropertyGroup>
-
   </Target>
 
+  <Target Name="BeforeBundle"
+      DependsOnTargets="_ComputeFilesToBundle"
+      Condition="'$(PublishSingleFile)' == 'true'">
+
+    <ItemGroup>
+      <FilesToBundle Include="@(_FilesToBundle)"/>
+    </ItemGroup>
+
+    <PropertyGroup>
+      <AppHostFile>$(PublishedSingleFileName)</AppHostFile>
+    </PropertyGroup>
+  </Target>
+  
   <UsingTask TaskName="GenerateBundle" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
   <Target Name="GenerateSingleFileBundle"
           Condition="'$(PublishSingleFile)' == 'true'"
-          DependsOnTargets="_ComputeFilesToBundle"
+          DependsOnTargets="_ComputeFilesToBundle;BeforeBundle"
           Inputs="@(_FilesToBundle)"
           Outputs="$(PublishedSingleFilePath)">
 

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishASingleFileApp.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishASingleFileApp.cs
@@ -911,8 +911,6 @@ class C
 
             void VerifyPrepareForBundle(XDocument project)
             {
-                System.Console.WriteLine(project.ToString());
-
                 var ns = project.Root.Name.Namespace;
                 var targetName = "CheckPrepareForBundleData";
 
@@ -939,29 +937,16 @@ class C
                 // Modify the FilesToBundle to not have SingleFileTest.dll, so that publish could pass.
                 //
                 //         <ItemGroup>
-                //             <FilesToBundle
-                //                  Include = "@(FilesToBundle)">
-                //                  Condition = "'%(FilesToBundle.RelativePath)' != 'SingleFileTest.dll'"
-                //             </FilesToBundle>
+                //              <FilesToBundle Remove="@(FilesToBundle)"
+                //              Condition="'%(FilesToBundle.RelativePath)' == 'SingleFileTest.dll'" />
                 //         </ItemGroup >
-
-                target.Add(
-                    new XElement(ns + "Message",
-                        new XAttribute("Importance", "High"),
-                        new XAttribute("Text", "BEFORE: %(FilesToBundle.Identity) %(FilesToBundle.RelativePath)")));
+                //
 
                 target.Add(
                     new XElement(ns + "ItemGroup",
                         new XElement(ns + "FilesToBundle",
-                            new XAttribute("Include", "@(FilesToBundle)"),
-                            new XAttribute("Condition", "'%(FilesToBundle.RelativePath)' != 'SingleFileTest.dll'"))));
-
-                target.Add(
-                    new XElement(ns + "Message",
-                        new XAttribute("Importance", "High"),
-                        new XAttribute("Text", "AFTER: %(FilesToBundle.Identity) %(FilesToBundle.RelativePath)")));
-
-                System.Console.WriteLine(project.ToString());
+                            new XAttribute("Remove", "@(FilesToBundle)"),
+                            new XAttribute("Condition", "'%(FilesToBundle.RelativePath)' == 'SingleFileTest.dll'"))));
             }
         }
     }

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishASingleFileApp.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishASingleFileApp.cs
@@ -938,20 +938,15 @@ class C
                 // Modify the FilesToBundle list accordingly, so that publish could pass.
                 //
                 //         <ItemGroup>
-                //             <FilesToBundle Include = "@(FilesToBundle)">
-                //                  <RelativePath>%(FilesToBundle.Identity)</RelativePath>
-                //                  <RelativePath Condition = "'%(FilesToBundle.RelativePath)' == 'SingleFileTest.dll'">@(FilesToBundle->'%(RelativePath).renamed')</RelativePath>
+                //             <FilesToBundle Condition = "'%(FilesToBundle.RelativePath)' == 'SingleFileTest.dll'">
+                //                  <RelativePath>SingleFileTest.dll.renamed</RelativePath>
                 //             </FilesToBundle>
                 //         </ItemGroup >
 
                 target.Add(
                     new XElement(ns + "ItemGroup",
-                        new XElement(ns + "FilesToBundle", new XAttribute("Include", "@(FilesToBundle)"),
-                            new XElement(ns + "RelativePath",
-                                "%(FilesToBundle.Identity)"),
-                            new XElement(ns + "RelativePath",
-                                new XAttribute("Condition", "'%(FilesToBundle.RelativePath)' == 'SingleFileTest.dll'"),
-                                "@(FilesToBundle->'%(RelativePath).renamed')"))));
+                        new XElement("FilesToBundle", new XAttribute("Condition", "'%(FilesToBundle.RelativePath)' == 'SingleFileTest.dll'"),
+                            new XElement("RelativePath", "SingleFileTest.dll.renamed"))));
             }
         }
     }

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishASingleFileApp.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishASingleFileApp.cs
@@ -831,7 +831,7 @@ class C
         }
 
         [RequiresMSBuildVersionFact("17.0.0.32901")]
-        public void User_can_intervene_before_bundling()
+        public void User_can_get_bundle_info_before_bundling()
         {
             var testProject = new TestProject()
             {
@@ -869,11 +869,20 @@ class C
                         new XAttribute("BeforeTargets", "GenerateSingleFileBundle"),
                         new XAttribute("DependsOnTargets", "PrepareForBundle"));
 
+                project.Root.Add(target);
+
+                //     <Error Condition = "'@(FilesToBundle->AnyHaveMetadataValue('RelativePath', 'System.Private.CoreLib.dll'))' != 'true'" Text="System.Private.CoreLib.dll is not in FilesToBundle list">
+                target.Add(
+                    new XElement(ns + "Error",
+                        new XAttribute("Condition", "'@(FilesToBundle->AnyHaveMetadataValue('RelativePath', 'System.Private.CoreLib.dll'))' != 'true'"),
+                        new XAttribute("Text", "System.Private.CoreLib.dll is not in FilesToBundle list")));
+
+
                 var host = $"SingleFileTest{Constants.ExeSuffix}";
 
                 //     <Error Condition="'$(AppHostFile)' != 'SingleFileTest.exe'" Text="AppHostFile expected to be: 'SingleFileTest.exe' actually: '$(AppHostFile)'" />
                 target.Add(
-                    new XElement("Error",
+                    new XElement(ns + "Error",
                         new XAttribute("Condition", $"'$(AppHostFile)' != '{host}'"),
                         new XAttribute("Text", $"AppHostFile expected to be: '{host}' actually: '$(AppHostFile)'")));
             }


### PR DESCRIPTION
As described in https://github.com/dotnet/designs/pull/228

The testing strategy:
- `User_can_get_bundle_info_before_bundling`
A synthetic target is hooked up to run where signing tool should run. 
In the target we observe that `AppHostFile` is set as expected and that among the `FilesToBundle` items we have `System.Private.CoreLib.dll`
- `User_can_move_file_before_bundling`
A synthetic target is hooked up to run where signing tool should run. 
The target renames `SingleFileTest.dll` file and removes its entry from `FilesToBundle`
If the changes to `FilesToBundle` are not propagated to Bundler, the publish step will fail. 
(NOTE: we do not expect a runnable app here, just expect that publishing succeeds, proving that `FilesToBundle` is functional)

